### PR TITLE
Security: add gateway token auth + fix theme toggle icons

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1520,9 +1520,9 @@ function clawmetryLogout(){
 <div class="zoom-wrapper" id="zoom-wrapper">
 <div class="nav">
   <h1><span>🦞</span> ClawMetry</h1>
-  <div class="theme-toggle" onclick="document.getElementById('gw-setup-overlay').style.display='flex'" title="Gateway settings" style="cursor:pointer;">⚙️</div>
-  <div class="theme-toggle" id="theme-toggle-btn" onclick="toggleTheme()" title="Toggle theme">🌙</div>
-  <div class="theme-toggle" id="logout-btn" onclick="clawmetryLogout()" title="Logout" style="display:none;cursor:pointer;">🚪</div>
+  <div class="theme-toggle" onclick="document.getElementById('gw-setup-overlay').style.display='flex'" title="Gateway settings" style="cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></div>
+  <div class="theme-toggle" id="theme-toggle-btn" onclick="toggleTheme()" title="Toggle theme"><svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></div>
+  <div class="theme-toggle" id="logout-btn" onclick="clawmetryLogout()" title="Logout" style="display:none;cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg></div>
   <div class="zoom-controls">
     <button class="zoom-btn" onclick="zoomOut()" title="Zoom out (Ctrl/Cmd + -)">−</button>
     <span class="zoom-level" id="zoom-level" title="Current zoom level. Ctrl/Cmd + 0 to reset">100%</span>
@@ -1957,6 +1957,9 @@ function exportUsageData() {
   window.location.href = '/api/usage/export';
 }
 
+var _sunSVG = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>';
+var _moonSVG = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+
 function toggleTheme() {
   const body = document.body;
   const toggle = document.getElementById('theme-toggle-btn');
@@ -1964,12 +1967,12 @@ function toggleTheme() {
   
   if (isLight) {
     body.setAttribute('data-theme', 'dark');
-    toggle.textContent = '☀️';
+    toggle.innerHTML = _sunSVG;
     toggle.title = 'Switch to light theme';
     localStorage.setItem('openclaw-theme', 'dark');
   } else {
     body.removeAttribute('data-theme');
-    toggle.textContent = '🌙';
+    toggle.innerHTML = _moonSVG;
     toggle.title = 'Switch to dark theme';
     localStorage.setItem('openclaw-theme', 'light');
   }
@@ -1982,10 +1985,10 @@ function initTheme() {
   
   if (savedTheme === 'dark') {
     body.setAttribute('data-theme', 'dark');
-    if (toggle) { toggle.textContent = '☀️'; toggle.title = 'Switch to light theme'; }
+    if (toggle) { toggle.innerHTML = _sunSVG; toggle.title = 'Switch to light theme'; }
   } else {
     body.removeAttribute('data-theme');
-    if (toggle) { toggle.textContent = '🌙'; toggle.title = 'Switch to dark theme'; }
+    if (toggle) { toggle.innerHTML = _moonSVG; toggle.title = 'Switch to dark theme'; }
   }
 }
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="clawmetry",
-    version="0.7.3",
+    version="0.8.0",
     description="ClawMetry - Real-time observability dashboard for OpenClaw AI agents",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Changes

**Gateway Token Authentication (v0.8.0)**
- Login screen shown when `GATEWAY_TOKEN` is detected server-side
- All `/api/*` routes protected via `before_request` hook (returns 401)
- Token stored in localStorage, auto-injected into fetch + EventSource calls
- Logout button (🚪) in header
- Standalone mode (no token) = no auth required

**Theme Toggle Fix**
- Root cause: two elements shared `.theme-toggle` class; `querySelector` grabbed the wrong one (⚙️ settings btn instead of 🌙 theme btn)
- Fixed with `id="theme-toggle-btn"` + `getElementById`
- Now correctly toggles ☀️/🌙

Bumps version 0.7.3 → 0.8.0