### PR TITLE
feat: full CLI with daemon support (clawmetry start/stop/status/connect)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -14216,18 +14216,16 @@ BANNER = r"""
 ARCHITECTURE_OVERVIEW = """\
 🦞 ClawMetry {version} — See your agent think.
 
-How it works:
+  ┌─────────────────────┐              ┌─────────────────────┐              ┌─────────────────────┐
+  │  🤖                 │  READS FILES │  🦞                 │  SHOWS YOU  │  📊                 │
+  │  Your OpenClaw      │ ──────────→  │  ClawMetry          │ ──────────→  │  Your browser       │
+  │  agents             │              │  Parses logs +      │              │  localhost:{port}   │
+  │                     │              │  sessions.          │              │  Live dashboard     │
+  │  Running normally.  │              │  Serves dashboard.  │              │                     │
+  │  Nothing changes.   │              │                     │              │                     │
+  └─────────────────────┘              └─────────────────────┘              └─────────────────────┘
 
-  💬 Telegram  ╮
-  💬 iMessage  ├─→  🤖 OpenClaw  →  📁 logs / sessions / workspace
-  💬 WhatsApp  ╯                            ↑
-                                      reads silently
-                                            ↓
-                                      🦞 ClawMetry
-                                            ↓
-                                      📊 localhost:{port}
-
-  No proxy. No code changes. Your data never leaves your machine.
+  Runs locally on the same machine as OpenClaw. Your data never leaves your box.
   Docs: https://clawmetry.com/how-it-works
 """
 


### PR DESCRIPTION
## What's new

Adds a proper subcommand CLI mirroring the `openclaw gateway` pattern.

### Commands
| Command | What it does |
|---------|-------------|
| `clawmetry` | Foreground server (unchanged behaviour) |
| `clawmetry start` | Install & start as background daemon (launchd / systemd) |
| `clawmetry stop` | Stop the daemon |
| `clawmetry restart` | Restart the daemon |
| `clawmetry status` | Show service type, PID, uptime, port, cloud status |
| `clawmetry connect` | Prompt for `cm_` API key, save to openclaw.json |
| `clawmetry uninstall` | Stop daemon + remove service file |
| `clawmetry help` | Show help |

### Architecture overview
Printed on every foreground start and `clawmetry start`:
```
🦞 ClawMetry 0.10.1 — See your agent think.

How it works:

  💬 Telegram  ╮
  💬 iMessage  ├─→  🤖 OpenClaw  →  📁 logs / sessions / workspace
  💬 WhatsApp  ╯                            ↑
                                      reads silently
                                            ↓
                                      🦞 ClawMetry
                                            ↓
                                      📊 localhost:8900

  No proxy. No code changes. Your data never leaves your machine.
  Docs: https://clawmetry.com/how-it-works
```

### Daemon backends
- **macOS**: `~/Library/LaunchAgents/com.clawmetry.plist` (launchctl)
- **Linux**: `~/.config/systemd/user/clawmetry.service` (systemctl --user)
- **Other**: falls back to foreground with a warning

### Notes
- Fully backward compatible — no subcommand = foreground as before
- Uses `sys.executable` for Python path, `shutil.which('clawmetry')` for script path
- Cloud token stored under `clawmetry.cloudToken` in `~/.openclaw/openclaw.json`
- Syntax checked ✅