### PR TITLE
feat: Waitress prod server + background tip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "flask>=2.0",
+        "waitress>=2.0",
     ],
     extras_require={
         "otel": ["opentelemetry-proto>=1.20.0", "protobuf>=4.21.0"],


### PR DESCRIPTION
- Uses Waitress (production WSGI) instead of Flask dev server when not in debug mode — eliminates the 'do not use in production' warning
- Falls back to Flask with warning suppressed if Waitress not installed
- Shows 'Tip: run as background service with: clawmetry start' in foreground mode
- Adds waitress>=2.0 to install_requires