### PR TITLE
feat: collapsible reasoning traces + stuck session alerts (#29, #30)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -8141,6 +8141,16 @@ function finishBootOverlay() {
 }
 
 async function bootDashboard() {
+  // Hard 10s timeout guard — forces boot completion if any step hangs
+  var _bootDone = false;
+  var _bootGuard = setTimeout(function() {
+    if (!_bootDone) {
+      console.warn('[ClawMetry] Boot guard triggered — forcing completion');
+      ['overview','tasks','health','streams'].forEach(function(s) { setBootStep(s, 'done', s + ' ready'); });
+      finishBootOverlay();
+    }
+  }, 10000);
+  try {
   // Check auth first — if not valid, show login and abort boot
   try {
     var stored = localStorage.getItem('clawmetry-token');
@@ -8191,6 +8201,10 @@ async function bootDashboard() {
   var sub = document.getElementById('boot-sub');
   if (sub) sub.textContent = 'Dashboard ready';
   setTimeout(finishBootOverlay, 180);
+  } finally {
+    _bootDone = true;
+    clearTimeout(_bootGuard);
+  }
 }
 
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## What changed

### Problems
**#30:** Thinking blocks from extended reasoning models were already parsed and displayed, but shown inline with no visual hierarchy, no way to collapse them, and no token count.

**#29:** `session.stuck` events from OpenClaw were streaming through the log SSE but nothing in the UI responded to them.

### Changes
**dashboard.py:**

**Reasoning traces (#30):**
- Changed `.evt-item.type-thinking` CSS: purple left border (`#a855f7`), subtle purple background, replaced gray styling
- Added `.reasoning-hidden` CSS class — hides thinking blocks when toggle is off
- Added token count badge (`~N tokens`) estimated from text length
- Added `💭 Show reasoning` toggle button in transcript modal tab bar
- Added `_showReasoning` state variable + `toggleReasoning()` function
- Thinking blocks hidden by default, revealed on toggle

**Stuck session alerts (#29):**
- Added `<div id="stuck-banner">` HTML just after the nav bar (hidden by default)
- Added `showStuckBanner(sessionId, duration)`, `dismissStuckBanner()`, `hideStuckBanner()` JS functions
- Extended `startLogStream()` onmessage to parse each log line for `session.stuck` — calls `showStuckBanner()` when found
- Auto-clears banner on terminal `session.state` events (done/finished/idle/error)
- Orange banner with ⚠️ icon + dismiss button

### What was NOT changed
- `api_transcript_events()` backend — untouched
- `/api/logs-stream` SSE endpoint — untouched
- No new API endpoints

Closes #29, Closes #30