### PR TITLE
fix: force dark mode — initTheme was overriding body dark with localStorage light default

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3411,7 +3411,7 @@ function toggleTheme() {
 }
 
 function initTheme() {
-  const savedTheme = localStorage.getItem('openclaw-theme') || 'light';
+  const savedTheme = 'dark'; localStorage.setItem('openclaw-theme', 'dark');
   const body = document.body;
   const toggle = document.getElementById('theme-toggle-btn');
   


### PR DESCRIPTION
PR #37 removed the theme toggle and set `<body data-theme="dark">` but `initTheme()` still ran on load with `|| 'light'` fallback — overriding dark mode for any user whose localStorage had 'light' saved (or no saved value at all).\n\nFix: `initTheme()` now always sets dark and writes it to localStorage.\n\nAffects all users who had previously visited the dashboard.