### PR TITLE
feat: support ?token=XXX URL parameter for gateway auto-config

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -13566,6 +13566,27 @@ def _check_auth():
     return jsonify({'error': 'Unauthorized', 'authRequired': True}), 401
 
 
+@bp_auth.route('/auth')
+def auth_token():
+    """Accept ?token=XXX, store in localStorage via JS, redirect to /.
+    Works for both OSS gateway tokens and cloud cm_ keys.
+    URL: /auth?token=YOUR_TOKEN
+    """
+    token = request.args.get('token', '').strip()
+    if not token:
+        return '<html><body style="background:#0b0f1a;color:#e2e8f0;font-family:sans-serif;padding:40px;">' \
+               '<h2>Missing token</h2><p>Usage: <code>/auth?token=YOUR_TOKEN</code></p></body></html>', 400
+    return f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head>
+<body style="background:#0b0f1a;color:#e2e8f0;font-family:sans-serif;padding:40px;min-height:100vh;">
+<p>Authenticating...</p>
+<script>
+  localStorage.setItem('clawmetry-token', '{token}');
+  localStorage.setItem('clawmetry-gw-token', '{token}');
+  window.location.href = '/';
+</script>
+</body></html>"""
+
+
 @bp_auth.route('/')
 def index():
     resp = make_response(render_template_string(DASHBOARD_HTML))


### PR DESCRIPTION
## What

Adds URL-based token parameter support to the dashboard. Visit `http://localhost:8900/?token=YOUR_GATEWAY_TOKEN` and it auto-configures the gateway connection.

## How it works

1. On page load, `checkGwConfig()` checks for `?token=` in the URL
2. If found: stores in localStorage, POSTs to `/api/gw/config` to configure
3. Strips token from URL bar via `history.replaceState` (keeps it out of browser history)
4. Reloads the page with a clean URL

## Use cases

- **Bookmarkable setup URLs**: `http://localhost:8900/?token=abc123`
- **Cloud redirect flow**: `app.clawmetry.com/auth?token=cm_xxx` works seamlessly
- **Install scripts**: can open browser with token pre-filled
- **Sharing**: send someone a one-click setup link (on trusted networks)

## Security

- Token is stripped from URL immediately via `replaceState` (never stays in address bar or history)
- Token stored in localStorage (same as manual paste)

Bumps to v0.11.12