### PR TITLE
feat: sync memory files to cloud (MEMORY.md + memory/*.md)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.11.12"
+__version__ = "0.11.13"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## What
Adds memory file syncing to the `clawmetry connect` sync daemon. Memory files (MEMORY.md + memory/*.md) are now automatically pushed to the cloud on every sync cycle.

## How
- `sync_memory()` reads workspace memory files, hashes them (MD5), and only pushes changed files
- Pushes two event types to `/api/ingest`:
  - `memory_state`: file list (names, sizes, timestamps) — powers the Memory tab file list
  - `memory_content`: full file contents (up to 100KB each) — powers the Memory tab file viewer
- `detect_paths()` now also discovers the workspace directory
- State tracked in `sync-state.json` via `memory_hashes` dict

## Why
Without this, the cloud Memory tab shows "No memory files" because the sync daemon only pushed sessions + logs. Now all three data types sync automatically.

Bumps to v0.11.13