### PR TITLE
feat: real-time log streaming to cloud

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.11.13"
+__version__ = "0.11.14"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## What
Adds real-time log streaming from the sync daemon to the cloud dashboard, powering the live Flow tab and Logs tab remotely.

## How
- `start_log_streamer()` runs a daemon thread that `tail -f`s the local OpenClaw log file
- POSTs batches of log lines to `/ingest/stream` every 2 seconds (or when 50 lines accumulate)
- Auto-rotates to the latest log file at midnight
- Cloud receives lines into an in-memory ring buffer and fans out via SSE to connected browsers

## Why
The Flow tab (ClawMetry's signature feature) was dead in cloud mode because there was no real-time data. The cloud dashboard showed a static SVG with no animations. Now it's live - you can watch your AI agent work in real-time from anywhere in the world.

## Architecture
```
[Local Machine]                    [Cloud]              [Browser]
 tail -f openclaw.log              Ring Buffer           SSE
 -> POST /ingest/stream  ------>  deque(2000)  ------> EventSource
    every 2s                       per node             /api/logs-stream
```

Bumps to v0.11.14