### PR TITLE
fix: Full Logs expanded items persist across auto-refresh

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.11.14"
+__version__ = "0.11.15"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
When you expand a log entry in the task modal's Full Logs tab, the auto-refresh (every 4s) was replacing innerHTML and collapsing it. Now expanded items stay open.

Uses `_expandedEvts` dict to track open/closed state by index, applied on re-render.