### PR TITLE
fix: send X-Node-Id header in sync daemon API calls

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -117,9 +117,12 @@ def save_state(state: dict) -> None:
 def _post(path: str, payload: dict, api_key: str, timeout: int = 15) -> dict:
     url  = INGEST_URL.rstrip("/") + path
     body = json.dumps(payload).encode()
+    headers = {"Content-Type": "application/json", "X-Api-Key": api_key}
+    if payload.get("node_id"):
+        headers["X-Node-Id"] = payload["node_id"]
     req  = urllib.request.Request(
         url, data=body,
-        headers={"Content-Type": "application/json", "X-Api-Key": api_key},
+        headers=headers,
         method="POST",
     )
     try:

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.11.15"
+__version__ = "0.11.16"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Fixes 400 errors on cron/memory sync to cloud. The `/api/ingest` endpoint requires `X-Node-Id` header which `_post()` wasn't sending. Now auto-extracts from payload. Bumps to v0.11.16.