### PR TITLE
fix: clawmetry --version always shows 0.9.20 (bare import leak)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import sys
 import os
 
-_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _root not in sys.path:
-    sys.path.insert(0, _root)
+
 
 
 
@@ -476,7 +474,12 @@ def _cmd_status(args) -> None:
 
 def main() -> None:
     import argparse
-    from dashboard import main as dashboard_main
+    import importlib.util as _ilu, pathlib as _pl
+    _dp = _pl.Path(__file__).parent.parent / "dashboard.py"
+    _spec = _ilu.spec_from_file_location("_clawmetry_dashboard", str(_dp))
+    _mod = _ilu.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+    dashboard_main = _mod.main
 
     parser = argparse.ArgumentParser(prog="clawmetry", add_help=False)
     sub = parser.add_subparsers(dest="cmd")

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.11.97"
+__version__ = "0.12.0"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Problem
`clawmetry --version` always reported `0.9.20` regardless of what version was installed.

## Root cause
`cli.py` had two issues:
1. `_root` inserted into `sys.path` at position 0 — on macOS, user site-packages (`~/Library/Python/3.9/`) is already in the venv's path, so a bare `from dashboard import main` could resolve to the system-installed `dashboard.py` (0.9.20) instead of the venv's copy
2. `from dashboard import main` — bare module import, not path-anchored

## Fix
Load `dashboard.py` explicitly via `importlib.util.spec_from_file_location` using its path relative to `cli.py`. This is unambiguous and immune to sys.path ordering.

## Version bump
0.11.97 → 0.12.0