### PR TITLE
[RELEASE] test: verify auto-publish workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -68,3 +68,4 @@ jobs:
           title: "chore: bump to v${{ steps.bump.outputs.new }}"
           body: "Auto-generated after PyPI release of v${{ steps.bump.outputs.new }}."
           labels: "automated"
+# test trigger


### PR DESCRIPTION
Testing the auto-release workflow. Merge this to confirm:
- PyPI publish fires ✓
- Version bumps to 0.12.5 ✓  
- Version bump PR auto-opens ✓