### PR TITLE
fix: move _build_gateway_data before __main__ block (NameError crash fix)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1585,20 +1585,6 @@ def run_daemon() -> None:
         time.sleep(POLL_INTERVAL)
 
 
-if __name__ == "__main__":
-    while True:
-        try:
-            run_daemon()
-            break  # clean exit
-        except KeyboardInterrupt:
-            break
-        except Exception as e:
-            import traceback
-            log.error(f"Daemon crashed: {e}")
-            log.error(traceback.format_exc())
-            log.info("Restarting in 15 seconds...")
-            time.sleep(15)
-
 
 def _build_gateway_data(paths: dict = None) -> dict:
     """Parse gateway.log (plain text) for routing events."""
@@ -1660,3 +1646,19 @@ def _build_gateway_data(paths: dict = None) -> dict:
         return {"stats": {"today_messages": 0, "today_heartbeats": 0, "today_crons": 0,
                           "today_errors": 0, "active_sessions": 0},
                 "routes": [], "total": 0, "status": "running", "port": 18789}
+
+
+if __name__ == "__main__":
+    while True:
+        try:
+            run_daemon()
+            break  # clean exit
+        except KeyboardInterrupt:
+            break
+        except Exception as e:
+            import traceback
+            log.error(f"Daemon crashed: {e}")
+            log.error(traceback.format_exc())
+            log.info("Restarting in 15 seconds...")
+            time.sleep(15)
+


### PR DESCRIPTION
When sync.py is run as a script via systemd/launchd (ExecStart=python3 sync.py), Python executes the if __name__=="__main__" block at line 1588 **before** processing line 1603 where _build_gateway_data is defined.

This causes every sync daemon install to crash with:
NameError: name _build_gateway_data is not defined

The function is called by sync_system_snapshot() which is called by run_daemon().

**Fix:** Move _build_gateway_data to before the __main__ block.

**Affected:** All users on clawmetry ≥0.12.4 running the systemd or launchd service. System snapshots (cron jobs, disk stats, memory files) never synced.