### PR TITLE
[RELEASE] fix: clawmetry connect --key crash (validate_key args mismatch)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -159,7 +159,7 @@ def _post(path: str, payload: dict, api_key: str, timeout: int = 45) -> dict:
 def validate_key(api_key: str, hostname: str = "", existing_node_id: str = "", **kwargs) -> dict:
     payload = {"api_key": api_key}
     if hostname: payload["hostname"] = hostname
-    if existing_node_id: payload["existing_node_id"] = existing_node_id
+    if existing_node_id: payload["node_id"] = existing_node_id
     return _post("/auth", payload, api_key)
 
 


### PR DESCRIPTION
**Bug:** `clawmetry connect --key` crashes with `validate_key() got an unexpected keyword argument 'hostname'`

**Root cause:** `cli.py` passes `hostname` and `existing_node_id` to `validate_key()`, but `sync.py` only accepts `api_key`.

**Fix:** Add the missing params to `validate_key()` signature and forward them in the auth payload.