### PR TITLE
fix: validate_key() accepts hostname and existing_node_id kwargs

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -156,8 +156,11 @@ def _post(path: str, payload: dict, api_key: str, timeout: int = 45) -> dict:
         raise RuntimeError(f"HTTP {e.code} from {url}: {e.read().decode()[:200]}")
 
 
-def validate_key(api_key: str) -> dict:
-    return _post("/auth", {"api_key": api_key}, api_key)
+def validate_key(api_key: str, hostname: str = "", existing_node_id: str = "", **kwargs) -> dict:
+    payload = {"api_key": api_key}
+    if hostname: payload["hostname"] = hostname
+    if existing_node_id: payload["existing_node_id"] = existing_node_id
+    return _post("/auth", payload, api_key)
 
 
 # ── Path detection ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Running clawmetry connect crashes immediately with:
  
      validate_key() got an unexpected keyword argument hostname

Root cause: cli.py line 135 calls validate_key(api_key, hostname=machine_hostname, existing_node_id=_existing_node_id) but sync.py validate_key() only accepted api_key: str.

Fix: add hostname and existing_node_id as optional keyword args, include them in the /auth POST payload when provided.