### PR TITLE
chore: bump to v0.12.7 [RELEASE]

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.6"
+__version__ = "0.12.7"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Version bump to publish fix for clawmetry connect crash:

- validate_key() accepts hostname and existing_node_id kwargs (#92)
- clawmetry connect --key <token> was broken with: unexpected keyword argument hostname