### PR TITLE
[RELEASE] fix: flow SSE 400 spam in cloud dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -10205,6 +10205,7 @@ function hideUnconfiguredChannels(svgRoot) {
 var _flowSse = null;
 var _flowSseDebounce = {};
 function _startFlowSse() {
+  if (window.CLOUD_MODE) return;
   if (_flowSse && _flowSse.readyState !== EventSource.CLOSED) return;
   var _fTok = localStorage.getItem('clawmetry-token') || '';
   _flowSse = new EventSource('/api/flow-events' + (_fTok ? '?token=' + encodeURIComponent(_fTok) : ''));


### PR DESCRIPTION
The `_startFlowSse()` function added in PR #83 was missing the `if(window.CLOUD_MODE) return` guard. Cloud dashboard inherits OSS code, so this fired on app.clawmetry.com hitting `/api/flow-events` which returns 400 in cloud mode.