### PR TITLE
fix: ValueError on Windows Python 3.14 (argparse color detection)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -558,6 +558,12 @@ def main() -> None:
     _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
     dashboard_main = _mod.main
 
+    # Python 3.14 on Windows: argparse's color detection calls file.fileno()
+    # on a closed file, raising ValueError. NO_COLOR disables this code path.
+    # https://github.com/python/cpython/issues/127321
+    if sys.platform == "win32":
+        os.environ.setdefault("NO_COLOR", "1")
+
     parser = argparse.ArgumentParser(prog="clawmetry", add_help=False)
     sub = parser.add_subparsers(dest="cmd")
 


### PR DESCRIPTION
## Problem

On Windows with Python 3.14, running `clawmetry` crashes immediately:

```
File clawmetry/cli.py, line 562, in main
  sub = parser.add_subparsers(dest="cmd")
ValueError: I/O operation on closed file
```

Python 3.14 added color support to argparse (via `can_colorize()`), which calls `file.fileno()` on a file that can be closed in some Windows terminal environments (PowerShell, CMD).

## Fix

Set `NO_COLOR=1` on `win32` before argparse initializes. This disables the colorize detection code path entirely.

```python
if sys.platform == "win32":
    os.environ.setdefault("NO_COLOR", "1")
```

Using `setdefault` so users who explicitly want color (unlikely on Windows) can still set `NO_COLOR=0`.

## References
- https://github.com/python/cpython/issues/127321
- Reported by user on Windows (Python 3.14.0a7, PowerShell)