### PR TITLE
chore: bump to 0.12.13 [RELEASE]

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.12"
+__version__ = "0.12.13"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Publishes v0.12.13 with Enable Cloud Sync CTA in nav — OTP signup modal, blue sync button, redirects to app.clawmetry.com on success.