### PR TITLE
chore: bump to v0.12.15 [RELEASE]

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.14"
+__version__ = "0.12.15"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Bumps version to 0.12.15.

Includes fix from #105: cloud CTA OTP proxy now correctly targets app.clawmetry.com/api/otp/* (previously proxied to landing site, causing 502 BAD GATEWAY and "Could not reach ClawMetry server" error in the Enable Cloud Sync modal).