### PR TITLE
fix: onboard prompt defaults Y (Enter = yes)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -89,12 +89,12 @@ def _cmd_onboard(args) -> None:
     print(f"      {DIM('Decrypted in the dashboard on demand.')}")
     print(f"      {DIM('Nothing reaches the cloud in plaintext. Ever.')}")
     print()
-    print(f"      {BOLD('[y]')} Connect to ClawMetry Cloud  {DIM('(free 7-day trial · $5/node/month after)')}")
+    print(f"      {BOLD('[Y]')} Connect to ClawMetry Cloud  {DIM('(free 7-day trial · $5/node/month after)')}")
     print(f"      {BOLD('[n]')} I\'ll start the server locally for now")
     print()
 
     try:
-        choice = input("  → [y/n]: ").strip().lower()
+        choice = input("  → [Y/n]: ").strip().lower() or 'y'
     except (EOFError, KeyboardInterrupt):
         choice = "n"
 


### PR DESCRIPTION
Two small UX fixes to the onboard prompt:
- Show [Y/n] instead of [y/n] to signal Y is default
- Pressing Enter without typing anything defaults to y (connect to cloud)

Before: user had to type y. After: just press Enter.