### PR TITLE
chore: bump to v0.12.17 [RELEASE]

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.15"
+__version__ = "0.12.17"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Release v0.12.17

Batches two fixes since v0.12.16:
1. Fix cloud CTA OTP proxy to app.clawmetry.com (#105) — was causing 502 BAD GATEWAY / "Could not reach ClawMetry server"
2. Fix onboard prompt: Enter defaults to Y, shows [Y/n] (#108)