### PR TITLE
chore: bump to v0.12.19 [RELEASE]

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.17"
+__version__ = "0.12.19"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Release v0.12.19

Fixes since v0.12.18:
- OTP proxy uses stdlib urllib (was NameError on _requests_mod, caused 502)
- Removed duplicate separator in onboard output  
- Modal centering fix (margin:auto on inner div)