### PR TITLE
fix: use sys.executable for systemd/launchd daemon python path

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -367,9 +367,8 @@ def _register_launchd(config: dict) -> None:
     from clawmetry.sync import CONFIG_DIR, LOG_FILE
     label = "com.clawmetry.sync"
     plist_path = __import__("pathlib").Path.home() / "Library" / "LaunchAgents" / f"{label}.plist"
-    # Resolve python3 at registration time, but use -m so pip upgrades take effect
-    import shutil
-    python = shutil.which("python3") or sys.executable
+    # Always use the running Python (venv-aware), not system python3
+    python = sys.executable
     plist = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -410,8 +409,8 @@ def _register_systemd(config: dict) -> None:
     service_dir = __import__("pathlib").Path.home() / ".config" / "systemd" / "user"
     service_dir.mkdir(parents=True, exist_ok=True)
     service_path = service_dir / f"{label}.service"
-    import shutil
-    python = shutil.which("python3") or sys.executable
+    # Always use the running Python (venv-aware), not system python3
+    python = sys.executable
 
     unit = f"""[Unit]
 Description=ClawMetry Cloud Sync Daemon


### PR DESCRIPTION
Closes #127

## What

On Ubuntu 24.04+ (PEP 668 distros), `clawmetry connect` creates a systemd service that uses the wrong Python path. `shutil.which("python3")` resolves to `/usr/bin/python3` (system Python), not the venv Python where ClawMetry is installed, causing `ModuleNotFoundError`.

Same issue affects `_register_launchd()` on macOS.

## How

Replace `shutil.which("python3") or sys.executable` with just `sys.executable` in both `_register_systemd()` and `_register_launchd()`. `sys.executable` always points to the Python that is currently running the CLI, which is the correct venv Python.

## Testing

- Verified no other references to `shutil.which("python3")` remain in cli.py
- `_start_subprocess()` already correctly uses `sys.executable` (line 324)