### PR TITLE
feat: detect and warn when OpenClaw is not installed (closes #128)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -475,6 +475,44 @@ def _cmd_disconnect(args) -> None:
     print("Disconnected from ClawMetry Cloud.")
 
 
+def _detect_openclaw() -> bool:
+    """Check if OpenClaw is installed on this machine."""
+    import shutil
+    from pathlib import Path
+
+    # Check if openclaw binary exists in PATH
+    if shutil.which("openclaw") or shutil.which("openclaw-gateway"):
+        return True
+
+    # Check common session directory locations
+    home = Path.home()
+    candidates = [
+        home / ".openclaw" / "agents" / "main" / "sessions",
+        Path("/data/agents/main/sessions"),
+        Path("/app/agents/main/sessions"),
+        Path("/opt/openclaw/agents/main/sessions"),
+    ]
+    oc_home = os.environ.get("OPENCLAW_HOME", "")
+    if oc_home:
+        candidates.insert(0, Path(oc_home) / "agents" / "main" / "sessions")
+
+    if any(p.exists() for p in candidates):
+        return True
+
+    # Check if openclaw npm package is installed globally
+    if shutil.which("npm"):
+        import subprocess
+        try:
+            r = subprocess.run(["npm", "list", "-g", "openclaw", "--depth=0"],
+                               capture_output=True, text=True, timeout=5)
+            if "openclaw" in r.stdout and "empty" not in r.stdout:
+                return True
+        except Exception:
+            pass
+
+    return False
+
+
 def _cmd_status(args) -> None:
     """clawmetry status — show local + cloud sync status."""
     import platform
@@ -533,6 +571,24 @@ def _cmd_status(args) -> None:
         r = subprocess.run(["systemctl", "--user", "is-active", "clawmetry-sync"], capture_output=True, text=True)
         running = r.stdout.strip() == "active"
         print(f"  Daemon:      {'✅  Running (systemd)' if running else '○  Not running'}")
+
+    # OpenClaw detection (closes #128)
+    if not _detect_openclaw():
+        YELLOW = '\033[0;33m'
+        CYAN = '\033[0;36m'
+        NC = '\033[0m'
+        print(f"\n  {YELLOW}⚠️  OpenClaw not detected on this machine{NC}")
+        print()
+        print("  ClawMetry needs OpenClaw to monitor. Install it:")
+        print()
+        print(f"    {CYAN}npm install -g openclaw{NC}          # via npm")
+        print()
+        print("  Then start OpenClaw:")
+        print(f"    {CYAN}openclaw{NC}                         # interactive setup")
+        print(f"    {CYAN}openclaw gateway start{NC}           # start the agent")
+        print()
+        print(f"  Docs: https://openclaw.ai/docs")
+        print(f"  Set {CYAN}OPENCLAW_HOME{NC} if installed in a custom location.")
 
     if LOG_FILE.exists():
         print(f"  Log:         {LOG_FILE}")


### PR DESCRIPTION
When `clawmetry status` runs on a machine without OpenClaw, it now shows a clear warning with install instructions instead of silently showing '0 files seen'.

**Detection checks (in order):**
1. `openclaw` or `openclaw-gateway` binary in PATH
2. Common session directory locations (~/.openclaw, /data, /app, /opt)
3. OPENCLAW_HOME environment variable
4. npm global package check

**Output on machine without OpenClaw:**
```
  ⚠️  OpenClaw not detected on this machine

  ClawMetry needs OpenClaw to monitor. Install it:

    npm install -g openclaw          # via npm

  Then start OpenClaw:
    openclaw                         # interactive setup
    openclaw gateway start           # start the agent

  Docs: https://openclaw.ai/docs
  Set OPENCLAW_HOME if installed in a custom location.
```

Tested on AWS EC2 Ubuntu 24.04 (no OpenClaw installed).