### PR TITLE
fix: use sys.executable for daemon Python path (closes #127)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -367,9 +367,8 @@ def _register_launchd(config: dict) -> None:
     from clawmetry.sync import CONFIG_DIR, LOG_FILE
     label = "com.clawmetry.sync"
     plist_path = __import__("pathlib").Path.home() / "Library" / "LaunchAgents" / f"{label}.plist"
-    # Resolve python3 at registration time, but use -m so pip upgrades take effect
-    import shutil
-    python = shutil.which("python3") or sys.executable
+    # Always use the Python running the CLI (correct venv). Fixes #127.
+    python = sys.executable
     plist = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -410,8 +409,8 @@ def _register_systemd(config: dict) -> None:
     service_dir = __import__("pathlib").Path.home() / ".config" / "systemd" / "user"
     service_dir.mkdir(parents=True, exist_ok=True)
     service_path = service_dir / f"{label}.service"
-    import shutil
-    python = shutil.which("python3") or sys.executable
+    # Always use the Python running the CLI (correct venv). Fixes #127.
+    python = sys.executable
 
     unit = f"""[Unit]
 Description=ClawMetry Cloud Sync Daemon


### PR DESCRIPTION
On Ubuntu 24.04+ (PEP 668), `shutil.which('python3')` resolves to `/usr/bin/python3` (system Python) which doesn't have clawmetry installed when using the `/opt/clawmetry` venv.

`sys.executable` is the Python currently running the CLI, which is always the correct venv.

Fix applied to both systemd (Linux) and launchd (macOS) registration.

Tested on AWS EC2 Ubuntu 24.04 with ClawMetry 0.12.25.