### PR TITLE
feat: warn when OpenClaw is not installed (closes #128)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -476,6 +476,44 @@ def _cmd_disconnect(args) -> None:
     print("Disconnected from ClawMetry Cloud.")
 
 
+def _detect_openclaw() -> bool:
+    """Check if OpenClaw is installed on this machine."""
+    import shutil
+    from pathlib import Path
+
+    # 1. Check if openclaw binary exists in PATH
+    if shutil.which("openclaw") or shutil.which("openclaw-gateway"):
+        return True
+
+    # 2. Check common session directory locations
+    home = Path.home()
+    candidates = [
+        home / ".openclaw" / "agents" / "main" / "sessions",
+        Path("/data/agents/main/sessions"),
+        Path("/app/agents/main/sessions"),
+        Path("/opt/openclaw/agents/main/sessions"),
+    ]
+    oc_home = os.environ.get("OPENCLAW_HOME", "")
+    if oc_home:
+        candidates.insert(0, Path(oc_home) / "agents" / "main" / "sessions")
+
+    if any(p.exists() for p in candidates):
+        return True
+
+    # 3. Check npm global list (best-effort)
+    if shutil.which("npm"):
+        import subprocess
+        try:
+            r = subprocess.run(["npm", "list", "-g", "openclaw", "--depth=0"],
+                               capture_output=True, text=True, timeout=5)
+            if "openclaw" in r.stdout and "empty" not in r.stdout:
+                return True
+        except Exception:
+            pass
+
+    return False
+
+
 def _cmd_status(args) -> None:
     """clawmetry status — show local + cloud sync status."""
     import platform
@@ -534,6 +572,24 @@ def _cmd_status(args) -> None:
         r = subprocess.run(["systemctl", "--user", "is-active", "clawmetry-sync"], capture_output=True, text=True)
         running = r.stdout.strip() == "active"
         print(f"  Daemon:      {'✅  Running (systemd)' if running else '○  Not running'}")
+
+    # OpenClaw detection — warn with install guide if not found (closes #128)
+    if not _detect_openclaw():
+        Y = '\033[0;33m'  # yellow
+        C = '\033[0;36m'  # cyan
+        N = '\033[0m'     # reset
+        print(f"\n  {Y}⚠️  OpenClaw not detected on this machine{N}")
+        print()
+        print("  ClawMetry needs OpenClaw to monitor. Install it:")
+        print()
+        print(f"    {C}npm install -g openclaw{N}          # via npm")
+        print()
+        print("  Then start OpenClaw:")
+        print(f"    {C}openclaw{N}                         # interactive setup")
+        print(f"    {C}openclaw gateway start{N}           # start the agent")
+        print()
+        print(f"  Docs: {C}https://openclaw.ai/docs{N}")
+        print(f"  Set {C}OPENCLAW_HOME{N} if installed in a custom location.")
 
     if LOG_FILE.exists():
         print(f"  Log:         {LOG_FILE}")

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -304,8 +304,13 @@ def detect_paths() -> dict:
     oc_home = os.environ.get("OPENCLAW_HOME", "")
     if oc_home:
         sessions_candidates.insert(0, Path(oc_home) / "agents" / "main" / "sessions")
-    sessions_dir = docker_paths.get("sessions_dir") or next((str(p) for p in sessions_candidates if p.exists()),
-                        str(sessions_candidates[0]))
+    found_sessions = docker_paths.get("sessions_dir") or next((str(p) for p in sessions_candidates if p.exists()), None)
+    sessions_dir = found_sessions or str(sessions_candidates[0])
+
+    if not found_sessions:
+        log.warning("OpenClaw not detected — no session directories found.")
+        log.warning("  Install: npm install -g openclaw  (https://openclaw.ai/docs)")
+        log.warning("  Daemon will keep retrying every 60s.")
 
     log_candidates = [Path("/tmp/openclaw"), home / ".openclaw" / "logs", Path("/data/logs")]
     log_dir = docker_paths.get("log_dir") or next((str(p) for p in log_candidates if p.exists()), "/tmp/openclaw")


### PR DESCRIPTION
When ClawMetry is installed on a machine without OpenClaw, it now shows a clear warning with install instructions instead of silently failing.

**`clawmetry status` output:**
```
  ⚠️  OpenClaw not detected on this machine

  ClawMetry needs OpenClaw to monitor. Install it:

    npm install -g openclaw          # via npm

  Then start OpenClaw:
    openclaw                         # interactive setup
    openclaw gateway start           # start the agent

  Docs: https://openclaw.ai/docs
  Set OPENCLAW_HOME if installed in a custom location.
```

**Sync daemon log:**
```
[clawmetry-sync] WARNING OpenClaw not detected — no session directories found.
  Install: npm install -g openclaw  (https://openclaw.ai/docs)
  Daemon will keep retrying every 60s.
```

Detection checks (in order): openclaw binary in PATH, session directory existence, npm global list.