### PR TITLE
[RELEASE] bump version to 0.12.26

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.24"
+__version__ = "0.12.26"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Version bump for PyPI release.

**Changes since 0.12.24:**
- fix: use sys.executable for daemon Python path (closes #127, PR #132)
- feat: warn when OpenClaw is not installed (closes #128, PR #133)

After merge, publish to PyPI:
```bash
cd /path/to/clawmetry
python3 -m build
python3 -m twine upload dist/*
```