### PR TITLE
fix: Windows CI — wrap startup prints for closed stdout

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -20563,63 +20563,69 @@ def _run_server(args):
     _start_fleet_maintenance_thread()
     _start_budget_monitor_thread()
 
-    print(BANNER.format(version=__version__))
-    print(f"  Workspace:  {WORKSPACE}")
-    print(f"  Sessions:   {SESSIONS_DIR}")
-    print(f"  Logs:       {LOG_DIR}")
-    print(f"  Metrics:    {_metrics_file_path()}")
-    if _HAS_OTEL_PROTO:
-        print(f"  OTLP:       [ok] Ready (opentelemetry-proto installed)")
-    print(f"  User:       {USER_NAME}")
-    print(f"  Mode:       {'[dev]  Dev (auto-reload ON)' if args.debug else '[prod] Prod (auto-reload OFF)'}")
-    print(f"  SSE Limits: {SSE_MAX_SECONDS}s max duration - logs {MAX_LOG_STREAM_CLIENTS} clients - health {MAX_HEALTH_STREAM_CLIENTS} clients")
-    print(f"  Fleet DB:   {_fleet_db_path()}")
-    print(f"  Fleet Auth: {'Enabled (key set)' if FLEET_API_KEY else 'Open (no key - set --fleet-api-key for production)'}")
-    if _HAS_HISTORY and _history_db:
-        print(f"  History DB: {_history_db.db_path}")
-    else:
-        print(f"  History:    Disabled (history.py not found)")
-    print()
-
-    warnings, tips = validate_configuration()
-    if warnings or tips:
-        print("[check] Configuration Check:")
-        for warning in warnings:
-            print(f"  {warning}")
-        for tip in tips:
-            print(f"  {tip}")
+    try:
+        print(BANNER.format(version=__version__))
+        print(f"  Workspace:  {WORKSPACE}")
+        print(f"  Sessions:   {SESSIONS_DIR}")
+        print(f"  Logs:       {LOG_DIR}")
+        print(f"  Metrics:    {_metrics_file_path()}")
+        if _HAS_OTEL_PROTO:
+            print(f"  OTLP:       [ok] Ready (opentelemetry-proto installed)")
+        print(f"  User:       {USER_NAME}")
+        print(f"  Mode:       {'[dev]  Dev (auto-reload ON)' if args.debug else '[prod] Prod (auto-reload OFF)'}")
+        print(f"  SSE Limits: {SSE_MAX_SECONDS}s max duration - logs {MAX_LOG_STREAM_CLIENTS} clients - health {MAX_HEALTH_STREAM_CLIENTS} clients")
+        print(f"  Fleet DB:   {_fleet_db_path()}")
+        print(f"  Fleet Auth: {'Enabled (key set)' if FLEET_API_KEY else 'Open (no key - set --fleet-api-key for production)'}")
+        if _HAS_HISTORY and _history_db:
+            print(f"  History DB: {_history_db.db_path}")
+        else:
+            print(f"  History:    Disabled (history.py not found)")
         print()
-        if warnings:
-            print("[tip] The dashboard will work with limited functionality. See tips above for full experience.")
+    except (ValueError, OSError):
+        pass  # stdout may be closed on Windows when launched via Start-Process
+
+    try:
+        warnings, tips = validate_configuration()
+        if warnings or tips:
+            print("[check] Configuration Check:")
+            for warning in warnings:
+                print(f"  {warning}")
+            for tip in tips:
+                print(f"  {tip}")
+            print()
+            if warnings:
+                print("[tip] The dashboard will work with limited functionality. See tips above for full experience.")
+                print()
+
+        local_ip = get_local_ip()
+        public_ip = get_public_ip()
+        print(f"  -> http://localhost:{args.port}")
+        if local_ip != '127.0.0.1':
+            print(f"  -> http://{local_ip}:{args.port}  (LAN)")
+        if public_ip and public_ip != local_ip:
+            print(f"  -> http://{public_ip}:{args.port}  (Public - ensure port is open)")
+        if _HAS_OTEL_PROTO:
+            print(f"  -> OTLP endpoint: http://{local_ip}:{args.port}/v1/metrics")
+        print()
+        # Cloud nudge — only if not already connected
+        import os as _os_nudge
+        _already_connected = bool(_os_nudge.environ.get('CLAWMETRY_API_KEY') or _os_nudge.environ.get('CLAWMETRY_NODE_ID'))
+        if not _already_connected:
+            _sep = "  -" if sys.platform == "win32" else "  \u2500"
+            print(_sep * 25)
+            print()
+            _globe = "[web]" if sys.platform == "win32" else "🌐 "
+            _lock  = "[enc]" if sys.platform == "win32" else "🔒 "
+            print(f"  {_globe}  Run clawmetry connect to access your dashboard from app.clawmetry.com")
+            print(f"      {_lock}  E2E encrypted with your local key — decrypted in the dashboard on demand.")
+            print("      Free 7-day trial · no credit card required.")
             print()
 
-    local_ip = get_local_ip()
-    public_ip = get_public_ip()
-    print(f"  -> http://localhost:{args.port}")
-    if local_ip != '127.0.0.1':
-        print(f"  -> http://{local_ip}:{args.port}  (LAN)")
-    if public_ip and public_ip != local_ip:
-        print(f"  -> http://{public_ip}:{args.port}  (Public - ensure port is open)")
-    if _HAS_OTEL_PROTO:
-        print(f"  -> OTLP endpoint: http://{local_ip}:{args.port}/v1/metrics")
-    print()
-    # Cloud nudge — only if not already connected
-    import os as _os_nudge
-    _already_connected = bool(_os_nudge.environ.get('CLAWMETRY_API_KEY') or _os_nudge.environ.get('CLAWMETRY_NODE_ID'))
-    if not _already_connected:
-        _sep = "  -" if sys.platform == "win32" else "  \u2500"
-        print(_sep * 25)
-        print()
-        _globe = "[web]" if sys.platform == "win32" else "🌐 "
-        _lock  = "[enc]" if sys.platform == "win32" else "🔒 "
-        print(f"  {_globe}  Run clawmetry connect to access your dashboard from app.clawmetry.com")
-        print(f"      {_lock}  E2E encrypted with your local key — decrypted in the dashboard on demand.")
-        print("      Free 7-day trial · no credit card required.")
-        print()
-
-    if not args.debug:
-        print(f"  Tip: run as background service with: clawmetry start")
-        print()
+        if not args.debug:
+            print(f"  Tip: run as background service with: clawmetry start")
+            print()
+    except (ValueError, OSError):
+        pass  # stdout may be closed on Windows when launched via Start-Process
 
     if args.debug:
         # Dev mode -- use Flask's reloader


### PR DESCRIPTION
**Root cause of ALL Windows CI failures:** On Windows, `Start-Process -RedirectStandardOutput` closes Python's stdout handle. The startup banner `print(BANNER.format(...))` throws `ValueError: I/O operation on closed file`, crashing the server before it starts.

**Fix:** Wrap all startup print blocks in `try/except (ValueError, OSError)`. The server starts fine without printing the banner.

This fixes the `API Tests (windows-latest)` failure across PRs #117-#140.