### PR TITLE
feat: machine fingerprint dedup + preserve encryption key

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -152,6 +152,18 @@ def _get_api_key_interactive() -> str:
 
 def _cmd_connect(args) -> None:
     """clawmetry connect — validate key, save config, start daemon."""
+    # Read existing config BEFORE stopping daemon (preserve node_id + encryption_key)
+    _saved_node_id = ''
+    _saved_enc_key = ''
+    try:
+        import json as _jcfg_pre
+        _cfgpath_pre = os.path.expanduser('~/.clawmetry/config.json')
+        _cfg_pre = _jcfg_pre.load(open(_cfgpath_pre))
+        _saved_node_id = _cfg_pre.get('node_id', '')
+        _saved_enc_key = _cfg_pre.get('encryption_key', '')
+    except Exception:
+        pass
+
     _stop_existing_daemon()
     import getpass
     from clawmetry.sync import validate_key, save_config, CONFIG_FILE, CONFIG_DIR
@@ -167,14 +179,7 @@ def _cmd_connect(args) -> None:
 
     custom_name = getattr(args, 'custom_node_id', None) or ''
     machine_hostname = custom_name or socket.gethostname()
-    # Read existing node_id from config so reconnect on same machine keeps same node
-    _existing_node_id = ''
-    try:
-        import json as _jcfg
-        _cfgpath = os.path.expanduser('~/.clawmetry/config.json')
-        _existing_node_id = _jcfg.load(open(_cfgpath)).get('node_id', '')
-    except Exception:
-        pass
+    _existing_node_id = _saved_node_id
     print("Connecting to ClawMetry Cloud… ", end="", flush=True)
     try:
         result = validate_key(api_key, hostname=machine_hostname, existing_node_id=_existing_node_id)
@@ -191,15 +196,8 @@ def _cmd_connect(args) -> None:
             sys.exit(1)
 
     from clawmetry.sync import generate_encryption_key
-    # Preserve existing key on reconnect — only generate new key on first connect
-    _existing_key = ''
-    try:
-        import json as _jx, os as _ox
-        _cfg = _jx.load(open(_ox.path.expanduser('~/.clawmetry/config.json')))
-        _existing_key = _cfg.get('encryption_key', '')
-    except Exception:
-        pass
-    enc_key = _existing_key or generate_encryption_key()
+    # Reuse existing encryption key on reconnect (only generate new on first connect)
+    enc_key = _saved_enc_key or generate_encryption_key()
 
     config = {
         "api_key": api_key,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -156,10 +156,59 @@ def _post(path: str, payload: dict, api_key: str, timeout: int = 45) -> dict:
         raise RuntimeError(f"HTTP {e.code} from {url}: {e.read().decode()[:200]}")
 
 
+def get_machine_id() -> str:
+    """Generate a stable hardware fingerprint for this machine."""
+    import hashlib, platform
+    mid = ""
+    # macOS: IOPlatformUUID (stable across reboots/reinstalls)
+    if platform.system() == "Darwin":
+        try:
+            import subprocess
+            out = subprocess.check_output(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                timeout=5, stderr=subprocess.DEVNULL
+            ).decode()
+            for line in out.splitlines():
+                if "IOPlatformUUID" in line:
+                    mid = line.split('"')[-2]
+                    break
+        except Exception:
+            pass
+    # Linux: /etc/machine-id
+    if not mid:
+        for path in ["/etc/machine-id", "/var/lib/dbus/machine-id"]:
+            try:
+                with open(path) as f:
+                    mid = f.read().strip()
+                    if mid:
+                        break
+            except Exception:
+                pass
+    # Windows: WMIC
+    if not mid and platform.system() == "Windows":
+        try:
+            import subprocess
+            out = subprocess.check_output(
+                ["wmic", "csproduct", "get", "uuid"],
+                timeout=5, stderr=subprocess.DEVNULL
+            ).decode()
+            lines = [l.strip() for l in out.splitlines() if l.strip() and l.strip() != "UUID"]
+            if lines:
+                mid = lines[0]
+        except Exception:
+            pass
+    # Fallback: MAC address (less stable but better than nothing)
+    if not mid:
+        import uuid as _uuid_mod
+        mid = str(_uuid_mod.getnode())
+    return hashlib.sha256(mid.encode()).hexdigest()[:32]
+
+
 def validate_key(api_key: str, hostname: str = "", existing_node_id: str = "", **kwargs) -> dict:
     payload = {"api_key": api_key}
     if hostname: payload["hostname"] = hostname
     if existing_node_id: payload["existing_node_id"] = existing_node_id
+    payload["machine_id"] = get_machine_id()
     return _post("/auth", payload, api_key)
 
 


### PR DESCRIPTION
## Problem
Running `clawmetry connect` twice on the same machine creates duplicate nodes (e.g. `my-node+Macbook-Pro-local` and `my-node+Macbook-Pro-local-2`). Encryption key is also regenerated on reconnect, requiring users to re-enter it in the dashboard.

## Fix

### `sync.py` - Machine fingerprint
Added `get_machine_id()` that generates a stable hardware fingerprint:
- **macOS**: `IOPlatformUUID` via `ioreg` (survives reboots/reinstalls)
- **Linux**: `/etc/machine-id`
- **Windows**: WMIC `csproduct UUID`
- **Fallback**: MAC address hash

`validate_key()` now sends `machine_id` to the server. Server-side `node_registry` table already uses `mid_hash` for dedup - it just wasn't receiving it from clients.

### `cli.py` - Preserve config across reconnects
- Read existing config **before** stopping daemon (avoids race condition)
- Reuse existing `encryption_key` on reconnect (only generate new on first connect)
- Reuse existing `node_id` via server-side dedup

## Result
Same physical machine + same account = same node. No duplicates. Encryption key persists unless explicitly changed.