### PR TITLE
[RELEASE] v0.12.28 - Machine fingerprint dedup

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.26"
+__version__ = "0.12.28"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Release 0.12.28

- **Machine fingerprint dedup**: `clawmetry connect` reuses existing node for same physical machine + account
- **Preserve encryption key**: Reconnecting no longer regenerates the secret key
- **Race condition fix**: Config read before daemon stop

### Details
- `get_machine_id()`: IOPlatformUUID (macOS) / /etc/machine-id (Linux) / WMIC (Windows) / MAC fallback
- Server-side `node_registry` already handles `mid_hash` dedup - clients now send it