### PR TITLE
[RELEASE] v0.12.30 - Fix Python 3.9 SyntaxError

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -512,7 +512,8 @@ def _cmd_proxy(args) -> None:
                 start_new_session=True,
             )
             print(f"  {GREEN('✓')} Proxy started in background (pid {proc.pid})")
-            print(f"  {DIM(f'Log: {PROXY_CONFIG_FILE.parent / \"proxy.log\"}')} ")
+            _log_path = PROXY_CONFIG_FILE.parent / "proxy.log"
+            print(f"  {DIM(f'Log: {_log_path}')} ")
             print()
         else:
             print(f"  Running in foreground (Ctrl+C to stop)")

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.28"
+__version__ = "0.12.30"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Fixes `SyntaxError: f-string expression part cannot include a backslash` on Python 3.9.

`cli.py:515` had a backslash inside an f-string expression which is only supported in Python 3.12+. Extracted to a variable.

All `.py` files validated against Python 3.9 `ast.parse()`.