### PR TITLE
[RELEASE] chore: sync version to 0.12.35 (match PyPI)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.34"
+__version__ = "0.12.35"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Main branch had version 0.12.26 but PyPI already has 0.12.35. This syncs main to match, so the next release workflow will correctly bump to 0.12.36.

Without this, the release workflow would publish 0.12.27 which pip would treat as a downgrade.