### PR TITLE
[RELEASE] v0.12.37 — optional cloud onboard + install.sh fix

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.35"
+__version__ = "0.12.37"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Publishes v0.12.37 to PyPI with:

- **[Y/n] cloud choice during onboard** (was forced into cloud connect)
- install.sh now calls `clawmetry onboard` (reads from /dev/tty for piped installs)
- Version sync (0.12.36 on PyPI had old onboard code)

Merge to trigger auto-publish via release-on-merge workflow.