### PR TITLE
fix: sync_crons sends full schedule, state, and task data

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -593,10 +593,21 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
             expr = sched.get("interval", "") if kind == "interval" else (
                    f"at {sched.get('at', '')}" if kind == "at" else
                    sched.get("cron", "") if kind == "cron" else "")
+            state = j.get("state", {})
             events.append({
                 "type": "cron_state", "session_id": "",
                 "data": {"job_id": j.get("id",""), "name": j.get("name",""),
-                         "enabled": j.get("enabled", True), "expr": expr}
+                         "enabled": j.get("enabled", True), "expr": expr,
+                         "schedule": sched,
+                         "task": (j.get("task") or "")[:200],
+                         "state": {
+                             "lastStatus": state.get("lastStatus"),
+                             "lastRunAtMs": state.get("lastRunAtMs"),
+                             "nextRunAtMs": state.get("nextRunAtMs"),
+                             "lastDurationMs": state.get("lastDurationMs"),
+                             "lastError": state.get("lastError"),
+                             "consecutiveFailures": state.get("consecutiveFailures"),
+                         }}
             })
 
         if events:


### PR DESCRIPTION
## Problem

`sync_crons()` only sent minimal fields: `job_id`, `name`, `enabled`, `expr`. The cloud dashboard's crons tab showed job names but no schedules, no last run times, no durations.

## Fix

Now sends the full `schedule` object, `state` (lastStatus, lastRunAtMs, nextRunAtMs, lastDurationMs, lastError, consecutiveFailures/Errors), and `task` description. Matches what `_build_cron_jobs` already sends in the system snapshot.

## Impact

After upgrading, `pip install --upgrade clawmetry`, nodes will push enriched cron data to the cloud. Requires corresponding cloud PR (clawmetry-cloud #158) to read the new fields.