### PR TITLE
release: v0.12.44 — cold-start retry resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.12.44] — 2026-03-15
+
+### Fixed
+- Sync daemon `_post()` retries once on 401/503 responses (cloud cold-start resilience)
+- Prevents sync daemon from permanently skipping sessions when Cloud Run returns transient auth errors
+
+---
+
 ## [0.12.43] — 2026-03-15
 
 ### Fixed

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.43"
+__version__ = "0.12.44"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Release 0.12.44

### Fixed
- `_post()` retries once on 401/503 with 2s delay (cloud cold-start resilience)
- Prevents sync daemon from permanently skipping sessions when Cloud Run returns transient auth errors during cold starts

### Upgrade
```bash
pip install --upgrade clawmetry
```

### Companion
- clawmetry-cloud #162 — server-side cold-start fixes (DB retry + smart token cache)