### PR TITLE
feat: skip onboard env var in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -99,8 +99,10 @@ echo ""
 
 # ── Onboarding ───────────────────────────────────────────────────────────────
 
+if [ "${CLAWMETRY_SKIP_ONBOARD:-}" = "1" ]; then
+  echo -e "  ${DIM}Skipping onboard (CLAWMETRY_SKIP_ONBOARD=1)${NC}"
 # shellcheck disable=SC2217
-if [ -r /dev/tty ] 2>/dev/null; then
+elif [ -r /dev/tty ] 2>/dev/null; then
   "$CLAWMETRY_BIN" onboard < /dev/tty || true
 else
   "$CLAWMETRY_BIN" onboard || true


### PR DESCRIPTION
Adds `CLAWMETRY_SKIP_ONBOARD=1` support for automated/CI installs.