### PR TITLE
fix: use sys.executable for daemon Python path (fixes venv installs)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -313,9 +313,8 @@ def _register_launchd(config: dict) -> None:
     from clawmetry.sync import CONFIG_DIR, LOG_FILE
     label = "com.clawmetry.sync"
     plist_path = __import__("pathlib").Path.home() / "Library" / "LaunchAgents" / f"{label}.plist"
-    # Resolve python3 at registration time, but use -m so pip upgrades take effect
-    import shutil
-    python = shutil.which("python3") or sys.executable
+    # Use the current interpreter (venv-aware) so the daemon finds clawmetry
+    python = sys.executable
     plist = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -356,8 +355,8 @@ def _register_systemd(config: dict) -> None:
     service_dir = __import__("pathlib").Path.home() / ".config" / "systemd" / "user"
     service_dir.mkdir(parents=True, exist_ok=True)
     service_path = service_dir / f"{label}.service"
-    import shutil
-    python = shutil.which("python3") or sys.executable
+    # Use the current interpreter (venv-aware) so the daemon finds clawmetry
+    python = sys.executable
 
     unit = f"""[Unit]
 Description=ClawMetry Cloud Sync Daemon


### PR DESCRIPTION
## Problem

On fresh installs where clawmetry is installed via `pip`/`pipx` into a venv (e.g. `/opt/clawmetry/`), the sync daemon fails with:

```
/usr/bin/python3: Error while finding module specification for 'clawmetry.sync' (ModuleNotFoundError: No module named 'clawmetry')
```

## Root Cause

Both `_register_launchd()` and `_register_systemd()` resolve the Python path with:

```python
python = shutil.which('python3') or sys.executable
```

`shutil.which('python3')` finds `/usr/bin/python3` (system Python), which doesn't have clawmetry installed. The fallback to `sys.executable` (the venv Python) never triggers because system Python always exists.

## Fix

Use `sys.executable` directly. This is the interpreter that's currently running the CLI, so it's always the correct venv-aware Python that has clawmetry installed.

## Tested

- Reproduced on fresh Ubuntu 24.04 VPS (Hostinger) with clawmetry installed in `/opt/clawmetry/` venv
- After fix: daemon starts correctly using venv Python