### PR TITLE
feat: prompt for custom encryption key during onboard

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -262,7 +262,16 @@ def _cmd_connect(args) -> None:
 
     from clawmetry.sync import generate_encryption_key
     # Reuse existing encryption key on reconnect (only generate new on first connect)
-    enc_key = _saved_enc_key or generate_encryption_key()
+    if _saved_enc_key:
+        enc_key = _saved_enc_key
+    else:
+        print()
+        print("🔐 Encryption key protects your data end-to-end.")
+        custom_key = _input("  Enter a custom secret key (or press Enter to auto-generate): ").strip()
+        if custom_key:
+            enc_key = custom_key
+        else:
+            enc_key = generate_encryption_key()
 
     config = {
         "api_key": api_key,


### PR DESCRIPTION
During first `clawmetry connect`, the user is now prompted:

```
🔐 Encryption key protects your data end-to-end.
  Enter a custom secret key (or press Enter to auto-generate):
```

- Enter a custom key: uses it as-is
- Press Enter: auto-generates one (current behavior)
- On reconnect: existing key is reused silently (no prompt)