### PR TITLE
fix: NameError crash on encryption key prompt

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -213,6 +213,21 @@ def _verify_key_ownership(api_key: str) -> None:
 
 def _cmd_connect(args) -> None:
     """clawmetry connect — validate key, save config, start daemon."""
+    # Support piped stdin (curl | bash) — read from /dev/tty if needed
+    _tty = None
+    if not sys.stdin.isatty():
+        try:
+            _tty = open('/dev/tty', 'r')
+        except OSError:
+            pass
+
+    def _input(prompt):
+        if _tty is not None:
+            sys.stdout.write(prompt)
+            sys.stdout.flush()
+            return _tty.readline().rstrip('\n')
+        return input(prompt)
+
     # Read existing config BEFORE stopping daemon (preserve node_id + encryption_key)
     _saved_node_id = ''
     _saved_enc_key = ''


### PR DESCRIPTION
**Bug:** `_cmd_connect` calls `_input()` for the encryption key prompt but never defines it. `_input` is a local helper in `_cmd_onboard` that doesn't carry over.

**Result:** `NameError: name '_input' is not defined` crash after OTP verification.

**Fix:** Define `_input` in `_cmd_connect` (same pattern as other commands, with /dev/tty fallback for piped stdin).