### PR TITLE
[RELEASE] v0.12.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.12.53] — 2026-03-17
+
+### Fixed
+- NameError crash on encryption key prompt (`_input` not defined in `_cmd_connect`)
+
 ## [0.12.52] — 2026-03-17
 
 ### Improved

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.52"
+__version__ = "0.12.53"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
### Fixed
- NameError crash on encryption key prompt (`_input` not defined in `_cmd_connect`)