### PR TITLE
fix: support arbitrary passphrases as encryption keys

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -276,6 +276,21 @@ def _cmd_connect(args) -> None:
             sys.exit(1)
 
     from clawmetry.sync import generate_encryption_key
+    import hashlib as _hl_key, base64 as _b64_key
+
+    def _normalize_key(raw_key):
+        """If key is already a valid base64 AES key (16/24/32 bytes), use as-is.
+        Otherwise treat it as a passphrase and derive a 256-bit key via SHA-256."""
+        try:
+            decoded = _b64_key.urlsafe_b64decode(raw_key + "==")
+            if len(decoded) in (16, 24, 32):
+                return raw_key  # already valid
+        except Exception:
+            pass
+        # Derive 256-bit key from passphrase
+        derived = _hl_key.sha256(raw_key.encode()).digest()
+        return _b64_key.urlsafe_b64encode(derived).decode().rstrip('=')
+
     # Always prompt for encryption key — be transparent
     print()
     print("🔐 Encryption key protects your data end-to-end.")
@@ -283,10 +298,10 @@ def _cmd_connect(args) -> None:
         masked = _saved_enc_key[:6] + '…' + _saved_enc_key[-4:]
         print(f"  Existing key: {masked}")
         custom_key = _input("  Press Enter to keep it, or type a new one: ").strip()
-        enc_key = custom_key if custom_key else _saved_enc_key
+        enc_key = _normalize_key(custom_key) if custom_key else _normalize_key(_saved_enc_key)
     else:
         custom_key = _input("  Enter a custom secret key (or press Enter to auto-generate): ").strip()
-        enc_key = custom_key if custom_key else generate_encryption_key()
+        enc_key = _normalize_key(custom_key) if custom_key else generate_encryption_key()
 
     config = {
         "api_key": api_key,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -74,10 +74,24 @@ def generate_encryption_key() -> str:
     return base64.urlsafe_b64encode(secrets.token_bytes(32)).decode()
 
 
+def _normalize_encryption_key(key_str: str) -> str:
+    """Ensure key is a valid base64url AES key. If not, derive one via SHA-256."""
+    import hashlib as _hl_norm
+    try:
+        raw = base64.urlsafe_b64decode(key_str + "==")
+        if len(raw) in (16, 24, 32):
+            return key_str
+    except Exception:
+        pass
+    derived = _hl_norm.sha256(key_str.encode()).digest()
+    return base64.urlsafe_b64encode(derived).decode().rstrip('=')
+
+
 def _get_aesgcm(key_b64: str):
-    """Return an AESGCM cipher from a base64url key."""
+    """Return an AESGCM cipher from a base64url key (auto-derives if passphrase)."""
     try:
         from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        key_b64 = _normalize_encryption_key(key_b64)
         raw = base64.urlsafe_b64decode(key_b64 + "==")
         return AESGCM(raw)
     except ImportError:


### PR DESCRIPTION
**Bug:** Entering a custom key like `testabc` gets saved raw to config. AES-GCM needs 16/24/32-byte keys, so the sync daemon crashes with `AESGCM key must be 128, 192, or 256 bits`.

**Fix:** Auto-derive a valid 256-bit AES key from any passphrase using SHA-256.

- **cli.py**: `_normalize_key()` converts passphrases to proper AES keys at input time
- **sync.py**: `_get_aesgcm()` also normalizes, so existing configs with raw passphrases self-heal on next sync

Auto-generated keys (already valid base64) pass through unchanged.