### PR TITLE
fix: add /api/memory and /api/flow route aliases (E2E test failures)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -16208,6 +16208,7 @@ def api_brain_stream():
 
 
 @bp_logs.route('/api/flow-events')
+@bp_logs.route('/api/flow')
 def api_flow_events():
     """SSE endpoint — emits typed flow events (msg_in, msg_out, tool_call, tool_result).
     No auth required. Tails gateway.log + active session JSONL on disk.
@@ -16399,6 +16400,7 @@ def api_logs_stream():
 
 
 @bp_memory.route('/api/memory-files')
+@bp_memory.route('/api/memory')
 def api_memory_files():
     return jsonify(_get_memory_files())
 


### PR DESCRIPTION
## Problem

The E2E health check cron tests `/api/memory` and `/api/flow` expecting 200, but these routes don't exist:

- `/api/memory` → 404 (real route: `/api/memory-files`)
- `/api/flow` → 404 (real route: `/api/flow-events`)

## Fix

Add short-form route aliases so both paths work:

```python
@bp_memory.route('/api/memory-files')
@bp_memory.route('/api/memory')   # new alias
def api_memory_files(): ...

@bp_logs.route('/api/flow-events')
@bp_logs.route('/api/flow')       # new alias
def api_flow_events(): ...
```

## Testing
E2E test now returns 200 for both endpoints.