### PR TITLE
release: v0.12.59

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.57"
+__version__ = "0.12.59"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## v0.12.59

### What's new

- **Recent-first sync for Brain feed** (#243) - On daemon startup, syncs only events from the last 60 minutes first, then backfills older events in the background. The Brain feed now shows current activity immediately instead of being stuck on stale entries while catching up on a large backlog.

### Upgrade

```bash
pip install --upgrade clawmetry
```

Restart the sync daemon after upgrading.