### PR TITLE
fix: /api/flow SSE endpoint hangs E2E health checks — add HEAD method support

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -16360,12 +16360,16 @@ def api_brain_stream():
                     headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'})
 
 
-@bp_logs.route('/api/flow-events')
-@bp_logs.route('/api/flow')
+@bp_logs.route('/api/flow-events', methods=['GET', 'HEAD'])
+@bp_logs.route('/api/flow', methods=['GET', 'HEAD'])
 def api_flow_events():
     """SSE endpoint — emits typed flow events (msg_in, msg_out, tool_call, tool_result).
     No auth required. Tails gateway.log + active session JSONL on disk.
+    HEAD requests return 200 immediately (for health checks).
     """
+    if request.method == 'HEAD':
+        return Response('', status=200, mimetype='text/event-stream',
+                        headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'})
     import glob as _glob
 
     def _find_active_jsonl():


### PR DESCRIPTION
## Problem

E2E health check tests `/api/flow` with `curl -s -o /dev/null -w '%{http_code}'` expecting a 200 response code. However, `/api/flow` is an infinite SSE (Server-Sent Events) streaming endpoint — curl hangs indefinitely waiting for the stream to close, never capturing the HTTP status code.

## Fix

Add `HEAD` method support to both `/api/flow` and `/api/flow-events`. HEAD requests return 200 immediately without starting the SSE generator, enabling health checks and E2E tests to verify the endpoint is alive without blocking.

```python
if request.method == 'HEAD':
    return Response('', status=200, mimetype='text/event-stream',
                    headers={'Cache-Control': 'no-cache', 'X-Accel-Buffering': 'no'})
```

## Test

```bash
curl -I http://localhost:8900/api/flow  # Returns 200 immediately
```