### PR TITLE
fix: send initial SSE keepalive in /api/flow to flush response headers

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -16444,6 +16444,9 @@ def api_flow_events():
                 f.seek(0, 2)
                 jsonl_pos = f.tell()
 
+        # Send initial keepalive so SSE response headers are flushed immediately
+        yield ': keepalive\n\n'
+
         try:
             while True:
                 if time.time() - started > SSE_MAX_SECONDS:


### PR DESCRIPTION
## Problem

The `/api/flow` SSE endpoint hangs on initial HTTP connection — `curl -w '%{http_code}'` returns `000` (timeout) instead of `200`, causing E2E health checks to fail.

**Root cause:** Flask/waitress buffers the streaming response until actual data is yielded. Since `/api/flow` only yields events when new log activity occurs, a quiet dashboard causes HTTP headers to never flush, leaving clients stuck indefinitely.

## Fix

Add SSE comment (`: keepalive`) as the very first yield in `generate()`. SSE comments are spec-valid and silently ignored by EventSource clients but force headers to flush immediately.

## Impact
- E2E health check returns HTTP 200 immediately
- EventSource clients get connection confirmation without waiting
- No behavior change for existing dashboard users