### PR TITLE
fix: sync __version__ to 0.12.61 to match PyPI

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.60"
+__version__ = "0.12.61"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Problem\n\nE2E health check detected a VERSION_MISMATCH:\n- PyPI latest: `0.12.61`\n- `dashboard.py __version__`: `0.12.60`\n\nThe release commit `d6b9be2` ([RELEASE] fix: onboard copy) published 0.12.61 to PyPI but did not bump the version in `dashboard.py`.\n\n## Fix\n\nBump `__version__` in `dashboard.py` from `0.12.60` → `0.12.61` to keep the source in sync with the published package.\n\n## Detected by\n\nClawMetry E2E health cron — 2026-03-20