### PR TITLE
fix: guard closed stdout/stderr on Windows before Flask/click banner (#264)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -814,11 +814,35 @@ def main() -> None:
     import argparse
     from dashboard import main as dashboard_main
 
-    # Python 3.14 on Windows: argparse's color detection calls file.fileno()
-    # on a closed file, raising ValueError. NO_COLOR disables this code path.
-    # https://github.com/python/cpython/issues/127321
+    # Windows: protect against closed/detached stdout/stderr before any library
+    # (argparse colour detection, click._winconsole) calls fileno() on them.
+    #
+    # Scenarios that close standard handles:
+    #   - pythonw.exe: GUI launcher; no console attached at all
+    #   - Start-Process / Task Scheduler: CreateProcess with no console
+    #   - Any launcher that closes handles before exec
+    #
+    # click._winconsole._is_console() calls f.fileno() → ValueError when closed.
+    # NO_COLOR suppresses argparse / click colour paths (Python 3.14+).
+    # We *also* replace closed handles with devnull sinks so later code is safe.
     if sys.platform == "win32":
+        import io as _io
         os.environ.setdefault("NO_COLOR", "1")
+        for _attr in ("stdout", "stderr"):
+            _stream = getattr(sys, _attr, None)
+            if _stream is None:
+                try:
+                    setattr(sys, _attr, open(os.devnull, "w", encoding="utf-8"))
+                except OSError:
+                    setattr(sys, _attr, _io.StringIO())
+                continue
+            try:
+                _stream.fileno()
+            except (AttributeError, ValueError, OSError):
+                try:
+                    setattr(sys, _attr, open(os.devnull, "w", encoding="utf-8"))
+                except OSError:
+                    setattr(sys, _attr, _io.StringIO())
 
     parser = argparse.ArgumentParser(prog="clawmetry", add_help=False)
     sub = parser.add_subparsers(dest="cmd")

--- a/dashboard.py
+++ b/dashboard.py
@@ -22815,17 +22815,48 @@ def cmd_uninstall(args):
 
 def _run_server(args):
     import sys as _sys
-    # Windows: reconfigure stdout/stderr to UTF-8 so box-drawing chars and
-    # emoji don't crash with UnicodeEncodeError on CP1252 terminals.
-    # reconfigure() is Python 3.7+ and handles the buffer layer correctly.
+    # Windows: guard against closed/detached stdout/stderr before Flask or
+    # click try to use them.  Two scenarios cause problems:
+    #
+    #   1. pythonw.exe / Start-Process / GUI launchers close the standard
+    #      handles at startup.  click._winconsole._is_console() calls
+    #      f.fileno() on sys.stdout, which raises:
+    #        ValueError: I/O operation on closed file
+    #      (reported in GH#264, reproduced on Python 3.11 Windows 10/11)
+    #
+    #   2. Normal CMD terminal with CP1252 encoding: box-drawing chars and
+    #      emoji crash with UnicodeEncodeError.
+    #
+    # Strategy:
+    #   a) Try fileno() first — if it raises, the stream is closed/detached;
+    #      replace with a devnull sink so click/Flask banners never crash.
+    #   b) If the stream is open, reconfigure() to UTF-8 (Python 3.7+).
     if _sys.platform == 'win32':
+        import io as _io
         for _attr in ('stdout', 'stderr'):
             _stream = getattr(_sys, _attr, None)
-            if _stream is not None:
+            if _stream is None:
+                # Completely absent — attach a null sink
                 try:
-                    _stream.reconfigure(encoding='utf-8', errors='replace')
-                except (AttributeError, Exception):
-                    pass
+                    setattr(_sys, _attr, open(os.devnull, 'w', encoding='utf-8'))
+                except OSError:
+                    setattr(_sys, _attr, _io.StringIO())
+                continue
+            try:
+                _stream.fileno()  # raises ValueError/OSError when closed
+            except (AttributeError, ValueError, OSError):
+                # Stream is closed or has no real file descriptor.
+                # Replace with devnull so click._winconsole never calls fileno().
+                try:
+                    setattr(_sys, _attr, open(os.devnull, 'w', encoding='utf-8'))
+                except OSError:
+                    setattr(_sys, _attr, _io.StringIO())
+                continue
+            # Stream is open — reconfigure to UTF-8 to avoid CP1252 issues.
+            try:
+                _stream.reconfigure(encoding='utf-8', errors='replace')
+            except (AttributeError, Exception):
+                pass
     """Start the Flask server (foreground). Called by foreground mode and cmd_start on unsupported OS."""
     detect_config(args)
     _load_gw_config()


### PR DESCRIPTION
Closes #264

## What

On Windows, when `clawmetry` is launched via `pythonw.exe`, Start-Process, Task Scheduler, or any launcher that closes standard handles before exec, the process crashes immediately with:

```
ValueError: I/O operation on closed file
```

The crash originates in `click._winconsole._is_console()`, which calls `f.fileno()` on `sys.stdout`. Reproduced on two independent Python 3.11 Windows 10/11 machines.

## How

Both `dashboard.py _run_server()` and `clawmetry/cli.py main()` now run a Windows guard that:

1. Checks whether `sys.stdout`/`sys.stderr` are `None` (no handle) or closed by calling `fileno()` — the exact call that was crashing.
2. If the stream is closed or absent, replaces it with `open(os.devnull, 'w')` (falls back to `io.StringIO` if even that fails) before Flask or click can touch it.
3. If the stream is open, keeps the existing `reconfigure(encoding='utf-8')` path to prevent CP1252 emoji/box-drawing crashes.
4. Sets `NO_COLOR=1` (already present in cli.py) to suppress Python 3.14 argparse colour detection, which has the same `fileno()` issue.

The fix is applied as early as possible in both entry points so no library code runs before standard handles are safe.

## Testing

- `python3 -c "import ast; ast.parse(open('dashboard.py').read())")` — syntax clean
- `python3 -c "import ast; ast.parse(open('clawmetry/cli.py').read())")` — syntax clean
- The guard is a no-op on Linux/macOS (skipped entirely under `sys.platform != 'win32'`)