### PR TITLE
fix: remove stale 'clawmetry connect' comment from install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,7 +98,7 @@ echo -e "  $(printf '%.0s─' {1..50})"
 echo ""
 
 # ── Onboarding ───────────────────────────────────────────────────────────────
-# Runs: clawmetry onboard  (or clawmetry connect for existing installs)
+# Runs: clawmetry onboard
 
 if [ "${CLAWMETRY_SKIP_ONBOARD:-}" = "1" ]; then
   echo -e "  ${DIM}Skipping onboard (CLAWMETRY_SKIP_ONBOARD=1)${NC}"


### PR DESCRIPTION
## Summary

Removes an outdated comment on line 101 of `install.sh` that referenced `clawmetry connect`.

The installer now exclusively runs `clawmetry onboard`. The old comment was a leftover from an earlier command name and was causing the E2E test to fail (the test asserts `install.sh` must NOT contain the string `clawmetry connect`).

### Change
```diff
-# Runs: clawmetry onboard  (or clawmetry connect for existing installs)
+# Runs: clawmetry onboard
```

Fixes: vivekchand/clawmetry-landing#93

_PR opened automatically by ClawMetry E2E cron — 2026-03-21 12:02 CET_