### PR TITLE
fix: bump to 0.12.62 — publish localhost auth bypass to PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.12.62] — 2026-03-21
+
+### Fixed
+- **PyPI release sync**: Re-release 0.12.62 to include localhost auth bypass (committed in 0.12.61 source but not published); API endpoints now accessible without token for localhost requests
+
 ## [0.12.60] — 2026-03-19
 
 ### Added

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.61"
+__version__ = "0.12.62"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Problem

PyPI package `clawmetry==0.12.61` was published on 2026-03-20 09:34, **before** the localhost auth bypass was committed (2026-03-21 06:26 in commit `766d997`).

This caused all E2E health checks to fail with `401 Unauthorized` when hitting `/api/overview`, `/api/sessions`, `/api/crons`, `/api/memory`, and `/api/flow` endpoints — even from localhost.

## Root Cause

The `_check_auth()` `before_request` handler in the INSTALLED PyPI package was missing:

```python
# Trust localhost — the dashboard is a local tool; auth protects remote access only
remote = request.remote_addr or ''
if remote in ('127.0.0.1', '::1', 'localhost'):
    return
```

This bypass exists in `public/main`'s `dashboard.py` but the PyPI wheel was cut before it landed.

## Fix

Bump version to `0.12.62` so a new PyPI release can be cut that includes the localhost bypass.

## Test

After publishing:
```bash
pip install clawmetry --upgrade
clawmetry --port 9901 &
sleep 3
curl -s -o /dev/null -w '%{http_code}' http://localhost:9901/api/overview  # Should return 200
```