### PR TITLE
fix: resolve macOS startup crash — fleet DB path, makedirs, clear error message (#269)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -296,17 +296,34 @@ _fleet_db_lock = threading.Lock()
 
 
 def _fleet_db_path():
-    """Get path to the fleet SQLite database."""
+    """Get path to the fleet SQLite database.
+
+    Default: ~/.clawmetry/fleet.db  (inside the installer's own directory,
+    which curl | bash already creates with correct permissions on macOS/Linux).
+    Falls back to ~/.clawmetry-fleet.db for backwards compat if the dir does
+    not exist (pre-installer environments).
+    """
     if FLEET_DB_PATH:
         return FLEET_DB_PATH
     if WORKSPACE:
         return os.path.join(WORKSPACE, '.clawmetry-fleet.db')
+    # Prefer ~/.clawmetry/fleet.db -- the curl installer creates ~/.clawmetry/
+    # with correct ownership, so this path is always writable after install.
+    preferred_dir = os.path.expanduser('~/.clawmetry')
+    if os.path.isdir(preferred_dir):
+        return os.path.join(preferred_dir, 'fleet.db')
     return os.path.expanduser('~/.clawmetry-fleet.db')
 
 
 def _fleet_db():
     """Get a SQLite connection to the fleet database."""
-    db = _sqlite3.connect(_fleet_db_path(), timeout=10)
+    path = _fleet_db_path()
+    # Ensure parent directory exists (defence-in-depth: guards against callers
+    # that bypass _fleet_init_db, and older code paths that skipped makedirs).
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    db = _sqlite3.connect(path, timeout=10)
     db.row_factory = _sqlite3.Row
     db.execute("PRAGMA journal_mode=WAL")
     return db
@@ -5494,17 +5511,34 @@ _fleet_db_lock = threading.Lock()
 
 
 def _fleet_db_path():
-    """Get path to the fleet SQLite database."""
+    """Get path to the fleet SQLite database.
+
+    Default: ~/.clawmetry/fleet.db  (inside the installer's own directory,
+    which curl | bash already creates with correct permissions on macOS/Linux).
+    Falls back to ~/.clawmetry-fleet.db for backwards compat if the dir does
+    not exist (pre-installer environments).
+    """
     if FLEET_DB_PATH:
         return FLEET_DB_PATH
     if WORKSPACE:
         return os.path.join(WORKSPACE, '.clawmetry-fleet.db')
+    # Prefer ~/.clawmetry/fleet.db -- the curl installer creates ~/.clawmetry/
+    # with correct ownership, so this path is always writable after install.
+    preferred_dir = os.path.expanduser('~/.clawmetry')
+    if os.path.isdir(preferred_dir):
+        return os.path.join(preferred_dir, 'fleet.db')
     return os.path.expanduser('~/.clawmetry-fleet.db')
 
 
 def _fleet_db():
     """Get a SQLite connection to the fleet database."""
-    db = _sqlite3.connect(_fleet_db_path(), timeout=10)
+    path = _fleet_db_path()
+    # Ensure parent directory exists (defence-in-depth: guards against callers
+    # that bypass _fleet_init_db, and older code paths that skipped makedirs).
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    db = _sqlite3.connect(path, timeout=10)
     db.row_factory = _sqlite3.Row
     db.execute("PRAGMA journal_mode=WAL")
     return db
@@ -25410,7 +25444,21 @@ def _run_server(args):
         FLEET_API_KEY = args.fleet_api_key
     if args.fleet_db:
         FLEET_DB_PATH = os.path.expanduser(args.fleet_db)
-    _fleet_init_db()
+    try:
+        _fleet_init_db()
+    except Exception as _fleet_exc:
+        db_path = _fleet_db_path()
+        print(
+            f"\n[clawmetry] ERROR: Could not initialise fleet database at {db_path!r}\n"
+            f"  Cause: {_fleet_exc}\n\n"
+            f"  Try one of:\n"
+            f"    1. Ensure the directory exists and is writable:\n"
+            f"         mkdir -p ~/.clawmetry && chmod 700 ~/.clawmetry\n"
+            f"    2. Specify a custom path:\n"
+            f"         clawmetry --fleet-db /tmp/fleet.db\n",
+            flush=True,
+        )
+        raise SystemExit(1) from _fleet_exc
     _budget_init_db()
     _detect_heartbeat_interval()
     _start_fleet_maintenance_thread()


### PR DESCRIPTION
Closes #269

## What

After installing via `curl -fsSL https://clawmetry.com/install.sh | bash` on macOS, `clawmetry` crashes immediately with a raw `sqlite3` traceback when starting the dashboard.

The crash happens in `_fleet_init_db()` → `_fleet_db()` → `_sqlite3.connect(_fleet_db_path())` because the default DB path (`~/.clawmetry-fleet.db`) lives in the home directory, which may not be writable in macOS security contexts (e.g. SIP, App Sandbox, or when the terminal has restricted file access permissions).

## How

Three layered fixes:

**1. Smarter default DB path**
The curl installer already creates `~/.clawmetry/` with correct ownership. Changed `_fleet_db_path()` to prefer `~/.clawmetry/fleet.db` when that directory exists, falling back to the old `~/.clawmetry-fleet.db` for existing installs.

**2. Defence-in-depth makedirs in `_fleet_db()`**
Added `os.makedirs(parent, exist_ok=True)` directly in `_fleet_db()` so the parent directory is always created before the connection attempt, regardless of which call path was used. Guards against older code paths that skipped `_fleet_init_db()`.

**3. User-friendly error on startup failure**
Wrapped `_fleet_init_db()` in `_run_server()` with a `try/except` that prints a clear, actionable error message instead of a raw traceback:
```
[clawmetry] ERROR: Could not initialise fleet database at '/Users/you/.clawmetry/fleet.db'
  Cause: <sqlite3 error>

  Try one of:
    1. Ensure the directory exists and is writable:
         mkdir -p ~/.clawmetry && chmod 700 ~/.clawmetry
    2. Specify a custom path:
         clawmetry --fleet-db /tmp/fleet.db
```

## Testing
- `grep -c 'preferred_dir' dashboard.py` → 4 (2 per copy of the function)
- Verified both copies of `_fleet_db_path()` / `_fleet_db()` were updated
