### PR TITLE
fix: bump to 0.12.62 — ship localhost auth bypass to PyPI

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.61"
+__version__ = "0.12.62"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Problem

E2E test step 3 (API endpoints) fails with **401** on all `/api/*` routes even when called from localhost.

```
overview: 401
sessions: 401
crons: 401
memory: 401
flow: 401
```

## Root Cause

The localhost auth bypass (`_check_auth` trusting `127.0.0.1/::1`) was merged to `main` in commit `c7d67e7` **after** PyPI 0.12.61 was published. So the fix exists in the source but not in the pip-installable package.

## Fix

Bump version to **0.12.62** so the existing fix (already in `public/main` since `766d997`) ships to users via `pip install clawmetry --upgrade`.

The actual auth bypass code (already present on main):
```python
# Trust localhost — the dashboard is a local tool; auth protects remote access only
remote = request.remote_addr or ''
if remote in ('127.0.0.1', '::1', 'localhost'):
    return
```

## Testing

After reinstalling from this branch, all API endpoints return 200 from localhost:
```
overview: 200 ✅
sessions: 200 ✅
crons: 200 ✅  
memory: 200 ✅
flow: 200 ✅
```

Detected by E2E health cron.