### PR TITLE
fix: robust Ollama detection (PATH fallback + HTTP ping)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -685,6 +685,49 @@ def _flush_log_batch(entries: list, fname: str, api_key: str,
 
 # ── Heartbeat ─────────────────────────────────────────────────────────────────
 
+def _detect_ollama_for_heartbeat():
+    """Detect Ollama status for heartbeat reporting."""
+    import shutil
+    result = {"installed": False, "running": False, "models": []}
+
+    # Check if binary exists
+    ollama_bin = shutil.which('ollama')
+    if not ollama_bin:
+        common_paths = [
+            '/opt/homebrew/bin/ollama',
+            '/usr/local/bin/ollama',
+            '/usr/bin/ollama',
+            os.path.expanduser('~/.ollama/ollama'),
+        ]
+        if os.name == 'nt':
+            common_paths.extend([
+                os.path.expandvars(r'%LOCALAPPDATA%\Programs\Ollama\ollama.exe'),
+                os.path.expandvars(r'%LOCALAPPDATA%\Ollama\ollama.exe'),
+            ])
+        for p in common_paths:
+            if os.path.isfile(p):
+                ollama_bin = p
+                break
+
+    if ollama_bin:
+        result["installed"] = True
+
+    # Check if running + get models
+    try:
+        import json as _json
+        req = urllib.request.Request('http://localhost:11434/api/tags', method='GET')
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            if resp.status == 200:
+                result["running"] = True
+                data = _json.loads(resp.read())
+                result["models"] = [m.get("name", "") for m in data.get("models", [])[:10]]
+                result["installed"] = True  # If running, definitely installed
+    except Exception:
+        pass
+
+    return result
+
+
 def send_heartbeat(config: dict) -> bool:
     """Send heartbeat to cloud. Returns True on success, False on failure."""
     payload = {
@@ -693,6 +736,7 @@ def send_heartbeat(config: dict) -> bool:
         "platform": platform.system(),
         "version": _get_version(),
         "e2e": bool(config.get("encryption_key")),
+        "ollama": _detect_ollama_for_heartbeat(),
     }
     last_err = None
     for attempt in range(3):

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.61"
+__version__ = "0.12.62"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:
@@ -23442,7 +23442,7 @@ def api_cost_optimizer():
         # Cost data from existing helpers
         costs = _get_cost_summary()
         expensive_ops = _get_expensive_operations()
-        ollama_installed = shutil.which('ollama') is not None
+        ollama_installed = _detect_ollama()
 
         # Run llmfit
         llmfit_raw = {}
@@ -23594,8 +23594,7 @@ def api_cost_optimization():
         llmfit_data = _get_llmfit_recommendations()
         
         # Check if ollama binary is installed
-        import shutil
-        ollama_installed = shutil.which('ollama') is not None
+        ollama_installed = _detect_ollama()
         
         # Build savings opportunities
         savings = _generate_savings_opportunities()
@@ -24331,6 +24330,40 @@ def _get_cost_summary():
     return costs
 
 
+def _detect_ollama():
+    """Detect Ollama installation using multiple strategies."""
+    import shutil
+    # Strategy 1: shutil.which (respects PATH)
+    if shutil.which('ollama'):
+        return True
+    # Strategy 2: Check common installation paths
+    common_paths = [
+        '/opt/homebrew/bin/ollama',      # macOS Homebrew (Apple Silicon)
+        '/usr/local/bin/ollama',          # macOS Homebrew (Intel) / Linux manual
+        '/usr/bin/ollama',               # Linux package manager
+        os.path.expanduser('~/.ollama/ollama'),  # Custom install
+    ]
+    # Windows paths
+    if os.name == 'nt':
+        common_paths.extend([
+            os.path.expandvars(r'%LOCALAPPDATA%\Programs\Ollama\ollama.exe'),
+            os.path.expandvars(r'%LOCALAPPDATA%\Ollama\ollama.exe'),
+        ])
+    for p in common_paths:
+        if os.path.isfile(p):
+            return True
+    # Strategy 3: Try HTTP ping (ollama might be running even if binary not in PATH)
+    try:
+        import urllib.request
+        req = urllib.request.Request('http://localhost:11434/api/version', method='GET')
+        with urllib.request.urlopen(req, timeout=2) as resp:
+            if resp.status == 200:
+                return True
+    except Exception:
+        pass
+    return False
+
+
 def _check_ollama_availability():
     """Check if Ollama is running and what models are available."""
     try:
@@ -24355,7 +24388,11 @@ def _check_ollama_availability():
             }
     except Exception:
         pass
-    
+
+    # Fallback: use robust detection (binary found or HTTP reachable)
+    if _detect_ollama():
+        return {'available': True, 'count': 0, 'models': []}
+
     return {'available': False, 'count': 0, 'models': []}
 
 


### PR DESCRIPTION
## Problem

The Cost Optimizer panel shows "Ollama not installed" even when Ollama IS installed and running.

**Root cause:** `shutil.which('ollama')` depends on the PATH of the Python process, which often excludes non-standard locations like `/opt/homebrew/bin` on macOS (Homebrew / Apple Silicon). On the cloud dashboard (Cloud Run), it always fails since Ollama runs on the user's machine, not the server.

## Changes

### `dashboard.py`
- Add `_detect_ollama()` helper using **3 strategies**:
  1. `shutil.which` — respects current PATH (fast, existing behavior)
  2. Common install path check — `/opt/homebrew/bin/ollama`, `/usr/local/bin/ollama`, `/usr/bin/ollama`, `~/.ollama/ollama`, Windows `%LOCALAPPDATA%` paths
  3. HTTP ping to `localhost:11434/api/version` — catches the case where Ollama is running but binary isn't in PATH at all
- Replace both `shutil.which('ollama') is not None` calls in `api_cost_optimizer()` and `api_cost_optimization()` with `_detect_ollama()`
- Update `_check_ollama_availability()` to use `_detect_ollama()` as a fallback when the `requests` HTTP call fails
- Bump version `0.12.61` → `0.12.62`

### `clawmetry/sync.py`
- Add `_detect_ollama_for_heartbeat()` — same binary-path detection + HTTP check, also returns `running` status and list of installed models
- Include `ollama` field in the heartbeat payload so the cloud dashboard can use client-reported Ollama status instead of trying to detect it server-side

## Backward Compatibility
- Cloud dashboard: ignores unknown heartbeat fields — old cloud handles new heartbeats fine
- Old sync daemon: heartbeats without `ollama` field still accepted by cloud
- Uses only stdlib (`urllib.request`) for HTTP checks — no new dependencies

## Testing
```bash
python3 -c "import py_compile; py_compile.compile('dashboard.py', doraise=True)"
python3 -c "import py_compile; py_compile.compile('clawmetry/sync.py', doraise=True)"
```
Both pass.