### PR TITLE
fix: sync __version__ to 0.12.63 to match PyPI

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.62"
+__version__ = "0.12.63"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Problem\n\nE2E test detected a version mismatch:\n- PyPI: `0.12.63`\n- `public/main` dashboard.py: `0.12.62`\n\nThe version bump commit (`fca2484` on branch `chore/bump-to-0.12.63`) was never merged into `main`. The release commit `20ed7ea` was tagged but the version string in `dashboard.py` was not updated in the main branch.\n\n## Fix\n\nBump `__version__` in `dashboard.py` from `0.12.62` → `0.12.63` to match what was published to PyPI.\n\n## Test\n\nAfter merge:\n```bash\nPYPI=$(pip index versions clawmetry 2>/dev/null | head -1 | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1)\nGH=$(git show origin/main:dashboard.py | grep '__version__' | grep -oP '[0-9]+\.[0-9]+\.[0-9]+')\n[ "$PYPI" = "$GH" ] && echo VERSION_MATCH\n```\n\n_Auto-fixed by E2E health check cron_