### PR TITLE
release: v0.12.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 - fix: robust Ollama detection -- PATH fallback + HTTP ping to localhost:11434
 - feat: sync daemon heartbeat includes ollama status (installed, running, models)
 
+## [0.12.64] — 2026-03-22
+
+### Removed
+- **Agents tab** — removed sub-agent gantt/timeline view (confusing, stale sessions with no active/idle filter)
+- **Context tab** — removed workspace context inspector (not actionable for most users)
+- **Channels tab** — removed per-channel OTLP metrics tab (requires OTLP setup, shows empty state for most)
+- Corresponding backend API routes: `/api/subagents`, `/api/subagent/<id>/activity`, `/api/context-inspector`, `/api/channel-metrics`
+- OTLP queue lane depth metrics storage (channels-only feature)
+
+Simplifies OSS dashboard to 7 core tabs: **Flow, Brain, Overview, Crons, Tokens, Memory, Security**
+
 ## [0.12.60] — 2026-03-19
 
 ### Added

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.63"
+__version__ = "0.12.64"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## v0.12.64

### Removed
- **Agents tab** — sub-agent gantt/timeline view (confusing stale sessions, no active/idle filter)
- **Context tab** — workspace context inspector (not actionable for most users)
- **Channels tab** — per-channel OTLP metrics (requires OTLP, empty state for most users)
- Backend routes: `/api/subagents`, `/api/subagent/<id>/activity`, `/api/context-inspector`, `/api/channel-metrics`
- OTLP queue lane depth metrics storage

OSS dashboard now has 7 focused tabs: **Flow, Brain, Overview, Crons, Tokens, Memory, Security**

Follows #280.