### PR TITLE
[RELEASE] v0.12.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 - fix: robust Ollama detection -- PATH fallback + HTTP ping to localhost:11434
 - feat: sync daemon heartbeat includes ollama status (installed, running, models)
 
+## [0.12.66] — 2026-03-22
+
+### Removed
+- Agents, Context, and Channels tabs from OSS dashboard (simplifies to 7 core tabs)
+- Backend routes: `/api/subagents`, `/api/context-inspector`, `/api/channel-metrics`
+
+### Fixed
+- CI: removed stale tests for deleted routes
+
 ## [0.12.65] — 2026-03-22
 
 ### Fixed

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.65"
+__version__ = "0.12.66"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## v0.12.66

### Removed
- Agents, Context, and Channels tabs from OSS dashboard
- Simplifies to 7 core tabs: Flow, Brain, Overview, Crons, Tokens, Memory, Security
- Backend routes: `/api/subagents`, `/api/context-inspector`, `/api/channel-metrics`

### Fixed
- CI: removed stale tests for deleted routes

---
Merging this PR will trigger auto-publish to PyPI.