### PR TITLE
[RELEASE] v0.12.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 - fix: robust Ollama detection -- PATH fallback + HTTP ping to localhost:11434
 - feat: sync daemon heartbeat includes ollama status (installed, running, models)
 
+## [0.12.68] — 2026-03-22
+
+### Fixed
+- Remove duplicate type filter pills in Brain tab — type chips now use a dedicated container with `innerHTML =` instead of `+=`
+- Remove non-working Graph view toggle from Brain tab — live list feed is now the default with no toggle
+
 ## [0.12.66] — 2026-03-22
 
 ### Removed

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.66"
+__version__ = "0.12.68"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## v0.12.68

### Fixed
- Duplicate type filter pills in Brain tab — pills now use a dedicated `#brain-type-chips` container with `innerHTML =` (was `+=`, causing pills to stack on every refresh)
- Remove non-working Graph view toggle — Brain tab defaults to live list feed, no toggle pill

Merging triggers PyPI auto-publish.