### PR TITLE
fix: sync main branch version to 0.12.72 (PyPI/main mismatch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.12.72] — 2026-03-23
+
+### Changed
+- Bump version to 0.12.72 — sync main branch with PyPI release
+
 ## v0.12.63 (2026-03-22)
 - fix: robust Ollama detection -- PATH fallback + HTTP ping to localhost:11434
 - feat: sync daemon heartbeat includes ollama status (installed, running, models)

--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.71"
+__version__ = "0.12.72"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Problem

E2E health check detected a version mismatch:
- PyPI latest: `0.12.72`  
- `public/main` branch: `__version__ = '0.12.71'`

The release bump commit (`9017d65`) landed on branch `chore/bump-to-0.12.72` but was **never merged back to main**. Anyone cloning the repo sees 0.12.71 while the installed package is 0.12.72.

## Fix

- Bump `__version__` in `dashboard.py`: 0.12.71 → 0.12.72
- Add CHANGELOG entry for 0.12.72

_Auto-detected and fixed by ClawMetry E2E health check_