### PR TITLE
fix: merge version bump v0.12.72 into main

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.71"
+__version__ = "0.12.72"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Problem
E2E test detected version mismatch:
- PyPI latest: `0.12.72`
- `public/main` branch: `0.12.71`

The bump commit (`9017d65`) existed on `chore/bump-to-0.12.72` but was never merged into `main`.

## Fix
Cherry-picked the version bump commit to bring `main` in sync with the published PyPI package.

## E2E Test
`VERSION_MISMATCH` → `VERSION_MATCH` after this merge.