### PR TITLE
[RELEASE] security: fix token staleness + Docker config bleed (#321, #322)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 import sys
 import os
 
+
+def _get_openclaw_dir():
+    """Return the OpenClaw config directory, respecting CLAWMETRY_OPENCLAW_DIR env var."""
+    import os
+    return os.environ.get('CLAWMETRY_OPENCLAW_DIR', os.path.expanduser('~/.openclaw'))
+
+
+
 _root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _root not in sys.path:
     sys.path.insert(0, _root)
@@ -845,6 +853,7 @@ def main() -> None:
                     setattr(sys, _attr, _io.StringIO())
 
     parser = argparse.ArgumentParser(prog="clawmetry", add_help=False)
+    parser.add_argument('--openclaw-dir', type=str, help='OpenClaw config directory (default: ~/.openclaw). Env: CLAWMETRY_OPENCLAW_DIR')
     sub = parser.add_subparsers(dest="cmd")
 
     # onboard — first-time setup wizard (called by install.sh)
@@ -897,6 +906,10 @@ def main() -> None:
     _subcmds = ("onboard", "connect", "disconnect", "status", "proxy", "update")
     if len(sys.argv) > 1 and sys.argv[1] in _subcmds:
         args = parser.parse_args()
+        # Issue #322: Set OpenClaw config directory from CLI flag
+        if getattr(args, 'openclaw_dir', None):
+            os.environ['CLAWMETRY_OPENCLAW_DIR'] = os.path.expanduser(args.openclaw_dir)
+
         if args.cmd == "onboard":
             _cmd_onboard(args)
         elif args.cmd == "connect":

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -22,6 +22,13 @@ import urllib.error
 from pathlib import Path
 from datetime import datetime, timezone
 
+
+def _get_openclaw_dir():
+    """Return the OpenClaw config directory, respecting CLAWMETRY_OPENCLAW_DIR env var."""
+    return os.environ.get('CLAWMETRY_OPENCLAW_DIR', os.path.expanduser('~/.openclaw'))
+
+
+
 INGEST_URL = os.environ.get("CLAWMETRY_INGEST_URL", "https://ingest.clawmetry.com")
 CONFIG_DIR  = Path.home() / ".clawmetry"
 CONFIG_FILE = CONFIG_DIR / "config.json"
@@ -369,7 +376,7 @@ def detect_paths() -> dict:
         log.info(f"Using Docker-detected paths: {docker_paths}")
 
     sessions_candidates = [
-        home / ".openclaw" / "agents" / "main" / "sessions",
+        Path(_get_openclaw_dir()) / "agents" / "main" / "sessions",
         Path("/data/agents/main/sessions"),
         Path("/app/agents/main/sessions"),
         Path("/root/.openclaw/agents/main/sessions"),
@@ -386,11 +393,11 @@ def detect_paths() -> dict:
         log.warning("  Install: npm install -g openclaw  (https://openclaw.ai/docs)")
         log.warning("  Daemon will keep retrying every 60s.")
 
-    log_candidates = [Path("/tmp/openclaw"), home / ".openclaw" / "logs", Path("/data/logs")]
+    log_candidates = [Path("/tmp/openclaw"), Path(_get_openclaw_dir()) / "logs", Path("/data/logs")]
     log_dir = docker_paths.get("log_dir") or next((str(p) for p in log_candidates if p.exists()), "/tmp/openclaw")
 
     workspace_candidates = [
-        home / ".openclaw" / "workspace",
+        Path(_get_openclaw_dir()) / "workspace",
         Path("/data/workspace"),
         Path("/app/workspace"),
     ]
@@ -774,8 +781,8 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
     # Find cron jobs.json
     home = Path.home()
     cron_candidates = [
-        home / ".openclaw" / "cron" / "jobs.json",
-        home / ".openclaw" / "agents" / "main" / "cron" / "jobs.json",
+        Path(_get_openclaw_dir()) / "cron" / "jobs.json",
+        Path(_get_openclaw_dir()) / "agents" / "main" / "cron" / "jobs.json",
     ]
     cron_file = next((str(p) for p in cron_candidates if p.exists()), None)
     if not cron_file:
@@ -838,7 +845,7 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
     try:
         home = Path.home()
         sessions_candidates = [
-            home / ".openclaw" / "agents" / "main" / "sessions",
+            Path(_get_openclaw_dir()) / "agents" / "main" / "sessions",
             Path("/data/agents/main/sessions"),
         ]
         sessions_dir = next((p for p in sessions_candidates if p.exists()), None)
@@ -1135,7 +1142,7 @@ def _build_brain_data():
     try:
         import collections
         home = str(Path.home())
-        session_dir = os.path.join(home, ".openclaw", "agents", "main", "sessions")
+        session_dir = os.path.join(_get_openclaw_dir(), "agents", "main", "sessions")
         if not os.path.isdir(session_dir):
             return {"stats": {}, "calls": []}
 
@@ -1282,7 +1289,7 @@ def _build_tool_stats():
     try:
         import collections, glob
         home = str(Path.home())
-        session_dir = os.path.join(home, ".openclaw", "agents", "main", "sessions")
+        session_dir = os.path.join(_get_openclaw_dir(), "agents", "main", "sessions")
         if not os.path.isdir(session_dir):
             return {}
         
@@ -1386,7 +1393,7 @@ def _build_channel_list(config):
     """Build list of configured channels."""
     try:
         home = str(Path.home())
-        oc_config = os.path.join(home, ".openclaw", "openclaw.json")
+        oc_config = os.path.join(_get_openclaw_dir(), "openclaw.json")
         if not os.path.isfile(oc_config):
             return []
         data = json.load(open(oc_config))
@@ -1413,8 +1420,8 @@ def _build_channel_data(config):
     try:
         home = str(Path.home())
         today = datetime.now().strftime("%Y-%m-%d")
-        gw_log = os.path.join(home, ".openclaw", "logs", "gateway.log")
-        session_dir = os.path.join(home, ".openclaw", "agents", "main", "sessions")
+        gw_log = os.path.join(_get_openclaw_dir(), "logs", "gateway.log")
+        session_dir = os.path.join(_get_openclaw_dir(), "agents", "main", "sessions")
         channels = {}
 
         known_channels = {"telegram", "imessage", "whatsapp", "signal", "discord",
@@ -1510,8 +1517,8 @@ def _build_cron_jobs(paths):
     import json as _j2
     home = str(Path.home())
     cron_candidates = [
-        os.path.join(home, ".openclaw", "cron", "jobs.json"),
-        os.path.join(home, ".openclaw", "agents", "main", "cron", "jobs.json"),
+        os.path.join(_get_openclaw_dir(), "cron", "jobs.json"),
+        os.path.join(_get_openclaw_dir(), "agents", "main", "cron", "jobs.json"),
     ]
     cron_file = next((p for p in cron_candidates if os.path.isfile(p)), None)
     if not cron_file:
@@ -1663,8 +1670,8 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     try:
         home = os.path.expanduser("~")
         cron_candidates = [
-            os.path.join(home, ".openclaw", "cron", "jobs.json"),
-            os.path.join(home, ".openclaw", "agents", "main", "cron", "jobs.json"),
+            os.path.join(_get_openclaw_dir(), "cron", "jobs.json"),
+            os.path.join(_get_openclaw_dir(), "agents", "main", "cron", "jobs.json"),
             os.path.join(paths.get("workspace", ""), "..", "crons.json"),
         ]
         cron_path = next((p for p in cron_candidates if os.path.isfile(p)), None)
@@ -1950,7 +1957,7 @@ def _build_gateway_data(paths: dict = None) -> dict:
     try:
         from datetime import datetime as _dt
         today = _dt.now().strftime("%Y-%m-%d")
-        gw_log = os.path.expanduser("~/.openclaw/logs/gateway.log")
+        gw_log = os.path.join(_get_openclaw_dir(), "logs", "gateway.log")
 
         routes = []
         stats = {"today_messages": 0, "today_heartbeats": 0, "today_crons": 0,

--- a/dashboard.py
+++ b/dashboard.py
@@ -1388,6 +1388,10 @@ def detect_config(args=None):
     """Auto-detect OpenClaw/Moltbot paths, with CLI and env overrides."""
     global WORKSPACE, MEMORY_DIR, LOG_DIR, SESSIONS_DIR, USER_NAME
 
+    # 0a. --openclaw-dir: set OpenClaw config directory (Issue #322 - Docker config bleed)
+    if args and getattr(args, 'openclaw_dir', None):
+        os.environ['CLAWMETRY_OPENCLAW_DIR'] = os.path.expanduser(args.openclaw_dir)
+
     # 0. --data-dir: set defaults from OpenClaw data directory (e.g. /path/.openclaw)
     data_dir = None
     if args and getattr(args, 'data_dir', None):
@@ -1515,10 +1519,11 @@ def _detect_gateway_port():
             pass
     # Try reading from gateway config
     # Try JSON configs first (openclaw.json / moltbot.json / clawdbot.json)
+    _oc_dir = _get_openclaw_dir()
     json_paths = [
-        os.path.expanduser('~/.openclaw/openclaw.json'),
-        os.path.expanduser('~/.openclaw/moltbot.json'),
-        os.path.expanduser('~/.openclaw/clawdbot.json'),
+        os.path.join(_oc_dir, 'openclaw.json'),
+        os.path.join(_oc_dir, 'moltbot.json'),
+        os.path.join(_oc_dir, 'clawdbot.json'),
         os.path.expanduser('~/.clawdbot/clawdbot.json'),
     ]
     for jp in json_paths:
@@ -1575,10 +1580,11 @@ def _detect_gateway_token():
     except Exception:
         pass
     # 3. Config files
+    _oc_dir = _get_openclaw_dir()
     json_paths = [
-        os.path.expanduser('~/.openclaw/openclaw.json'),
-        os.path.expanduser('~/.openclaw/moltbot.json'),
-        os.path.expanduser('~/.openclaw/clawdbot.json'),
+        os.path.join(_oc_dir, 'openclaw.json'),
+        os.path.join(_oc_dir, 'moltbot.json'),
+        os.path.join(_oc_dir, 'clawdbot.json'),
         os.path.expanduser('~/.clawdbot/clawdbot.json'),
     ]
     for jp in json_paths:
@@ -6480,6 +6486,10 @@ def detect_config(args=None):
     """Auto-detect OpenClaw/Moltbot paths, with CLI and env overrides."""
     global WORKSPACE, MEMORY_DIR, LOG_DIR, SESSIONS_DIR, USER_NAME
 
+    # 0a. --openclaw-dir: set OpenClaw config directory (Issue #322 - Docker config bleed)
+    if args and getattr(args, 'openclaw_dir', None):
+        os.environ['CLAWMETRY_OPENCLAW_DIR'] = os.path.expanduser(args.openclaw_dir)
+
     # 0. --data-dir: set defaults from OpenClaw data directory (e.g. /path/.openclaw)
     data_dir = None
     if args and getattr(args, 'data_dir', None):
@@ -6625,10 +6635,11 @@ def _detect_gateway_port():
             pass
     # Try reading from gateway config
     # Try JSON configs first (openclaw.json / moltbot.json / clawdbot.json)
+    _oc_dir = _get_openclaw_dir()
     json_paths = [
-        os.path.expanduser('~/.openclaw/openclaw.json'),
-        os.path.expanduser('~/.openclaw/moltbot.json'),
-        os.path.expanduser('~/.openclaw/clawdbot.json'),
+        os.path.join(_oc_dir, 'openclaw.json'),
+        os.path.join(_oc_dir, 'moltbot.json'),
+        os.path.join(_oc_dir, 'clawdbot.json'),
         os.path.expanduser('~/.clawdbot/clawdbot.json'),
     ]
     for jp in json_paths:
@@ -6685,10 +6696,11 @@ def _detect_gateway_token():
     except Exception:
         pass
     # 3. Config files
+    _oc_dir = _get_openclaw_dir()
     json_paths = [
-        os.path.expanduser('~/.openclaw/openclaw.json'),
-        os.path.expanduser('~/.openclaw/moltbot.json'),
-        os.path.expanduser('~/.openclaw/clawdbot.json'),
+        os.path.join(_oc_dir, 'openclaw.json'),
+        os.path.join(_oc_dir, 'moltbot.json'),
+        os.path.join(_oc_dir, 'clawdbot.json'),
         os.path.expanduser('~/.clawdbot/clawdbot.json'),
     ]
     for jp in json_paths:
@@ -15390,6 +15402,11 @@ import uuid as _uuid
 
 _GW_CONFIG_FILE = os.path.expanduser('~/.clawmetry-gateway.json')
 
+
+def _get_openclaw_dir():
+    """Return the OpenClaw config directory, respecting CLAWMETRY_OPENCLAW_DIR env var and --openclaw-dir CLI flag."""
+    return os.environ.get('CLAWMETRY_OPENCLAW_DIR', os.path.expanduser('~/.openclaw'))
+
 # ── WebSocket RPC Client ────────────────────────────────────────────────
 _ws_client = None
 _ws_lock = threading.Lock()
@@ -15474,16 +15491,24 @@ def _gw_ws_rpc(method, params=None):
 
 
 def _load_gw_config():
-    """Load gateway config from globals, env, or file."""
+    """Load gateway config from globals, env, or file.
+
+    Token resolution order (Issue #321 - avoid stale cached tokens):
+      1. Environment variable (OPENCLAW_GATEWAY_TOKEN)
+      2. Live OpenClaw config (openclaw.json -> gateway.auth.token)
+      3. Running gateway process /proc env
+      4. CLI/env globals already set
+      5. Cached ~/.clawmetry-gateway.json (backward compat fallback)
+    """
     global GATEWAY_URL, GATEWAY_TOKEN
-    # 1. Auto-detect from live gateway config (most authoritative)
+    # 1. Auto-detect from live OpenClaw config (most authoritative - reads directly)
     token = _detect_gateway_token()
     port = _detect_gateway_port()
     if token:
         GATEWAY_TOKEN = token
         if not GATEWAY_URL:
             GATEWAY_URL = f'http://127.0.0.1:{port}'
-        # Update cache file with fresh token
+        # Update cache file with fresh token (backward compat, not used for reads)
         try:
             cache = {}
             try:
@@ -15502,7 +15527,7 @@ def _load_gw_config():
     # 2. Already set via CLI/env
     if GATEWAY_URL and GATEWAY_TOKEN:
         return {'url': GATEWAY_URL, 'token': GATEWAY_TOKEN}
-    # 3. Fallback to cache file
+    # 3. Fallback to cache file (only if live config unavailable)
     try:
         with open(_GW_CONFIG_FILE) as f:
             cfg = json.load(f)
@@ -24591,6 +24616,7 @@ def main():
     shared.add_argument('--host', '-H', type=str, default='127.0.0.1', help='Host (default: 127.0.0.1)')
     shared.add_argument('--workspace', '-w', type=str, help='Agent workspace directory')
     shared.add_argument('--data-dir', '-d', type=str, help='OpenClaw data directory (e.g. ~/.openclaw).')
+    shared.add_argument('--openclaw-dir', type=str, help='OpenClaw config directory (default: ~/.openclaw). Env: CLAWMETRY_OPENCLAW_DIR')
     shared.add_argument('--log-dir', '-l', type=str, help='Log directory')
     shared.add_argument('--sessions-dir', '-s', type=str, help='Sessions directory (transcript .jsonl files)')
     shared.add_argument('--metrics-file', '-m', type=str, help='Path to metrics persistence JSON file')


### PR DESCRIPTION
## Security Fixes

### Issue #321: Gateway token staleness risk
Previously, ClawMetry cached the gateway token from `~/.openclaw/openclaw.json` into `~/.clawmetry-gateway.json`. If OpenClaw rotated the token, the cached copy went stale and sync broke silently.

**Fix:** `_load_gw_config()` now reads directly from the live OpenClaw config first. The cached file is only used as a backward-compat fallback when the live config is unavailable. Token resolution order:
1. Environment variable (`OPENCLAW_GATEWAY_TOKEN`)
2. Live OpenClaw config (`openclaw.json` → `gateway.auth.token`)
3. Running gateway process `/proc` env
4. CLI/env globals already set
5. Cached `~/.clawmetry-gateway.json` (backward compat)

### Issue #322: Docker config bleed
When running inside Docker, ClawMetry could pick up a container's `.openclaw` directory instead of the host's.

**Fix:** Added `CLAWMETRY_OPENCLAW_DIR` environment variable and `--openclaw-dir` CLI flag to explicitly set the OpenClaw config directory. Applied to `dashboard.py`, `clawmetry/sync.py`, and `clawmetry/cli.py`.

### Testing
- `TESTING=1 SKIP_INTEGRATION=1 pytest tests/test_api.py`: 71 passed, 6 skipped

Closes #321, closes #322