### PR TITLE
fix: merge version bump v0.12.72 to main (PyPI/GitHub mismatch)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.71"
+__version__ = "0.12.72"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Bug

E2E test detected a version mismatch:
- **PyPI**: `0.12.72`
- **GitHub main**: `0.12.71`

The `chore/bump-to-0.12.72` commit (`fb11dcd`) was pushed to a branch but never merged into `main`.

## Fix

Cherry-picked the version bump commit to bring `main` in sync with the published PyPI package.

## Verification

After merge: `git show main:dashboard.py | grep __version__` should return `0.12.72`.