### PR TITLE
docs: make one-liner the recommended install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ Opens at **http://localhost:8900** and you're done.
 
 ## Install
 
-**pip (recommended):**
+**One-liner (recommended):**
+```bash
+curl -sSL https://raw.githubusercontent.com/vivekchand/clawmetry/main/install.sh | bash
+```
+
+**pip:**
 ```bash
 pip install clawmetry
 clawmetry
-```
-
-**One-liner:**
-```bash
-curl -sSL https://raw.githubusercontent.com/vivekchand/clawmetry/main/install.sh | bash
 ```
 
 **From source:**


### PR DESCRIPTION
Moves the curl one-liner above pip and marks it as (recommended), per Vivek's request.