### PR TITLE
[RELEASE] fix: validate log offsets on daemon startup (prevents silent sync gaps)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -52,6 +52,39 @@ def _release_pid_lock() -> None:
         pass
 
 
+def _validate_log_offsets(state: dict, paths: dict) -> None:
+    """Validate stored log offsets on startup.
+
+    Prevents silent data gaps caused by log rotation or file truncation:
+    after a restart the stored offset may be beyond the current file end, or
+    the file may have shrunk and grown back past the offset (so offset < size
+    but the bytes there are new content, not what was originally at that
+    position).  We reset any offset >= current file size to 0 so the daemon
+    re-reads from the start and catches up on missed events.
+    """
+    offsets = state.get("last_log_offsets", {})
+    if not offsets:
+        return
+    log_dir = paths.get("log_dir", "")
+    if not log_dir:
+        return
+    for fname in list(offsets.keys()):
+        fpath = os.path.join(log_dir, fname)
+        try:
+            size = os.path.getsize(fpath)
+            if offsets[fname] > size:
+                log.warning(
+                    f"Stale log offset for {fname}: stored={offsets[fname]}, "
+                    f"file size={size}. Resetting to 0 to catch up on missed events."
+                )
+                offsets[fname] = 0
+        except FileNotFoundError:
+            log.warning(f"Log file {fname} gone — removing stale offset entry.")
+            del offsets[fname]
+        except Exception as e:
+            log.warning(f"Could not validate offset for {fname}: {e}")
+
+
 
 INGEST_URL = os.environ.get("CLAWMETRY_INGEST_URL", "https://ingest.clawmetry.com")
 CONFIG_DIR  = Path.home() / ".clawmetry"
@@ -1923,6 +1956,11 @@ def run_daemon() -> None:
         state["last_sync"] = datetime.now(timezone.utc).isoformat()
         save_state(state)
         log.info("Initial backfill complete")
+
+    # Validate stored log offsets on startup — prevents silent gaps
+    # after log rotation, file truncation, or daemon restarts
+    _validate_log_offsets(state, paths)
+    save_state(state)
 
     # Start real-time log streamer in background
     start_log_streamer(config, paths)


### PR DESCRIPTION
Fixes a 9-hour Brain tab blackout observed on Mac-Diya after daemon restart.

## Root cause

After log rotation or file truncation, the stored offset in `sync-state.json` can exceed the current file size. The per-cycle check (`offset > size → reset to 0`) exists but misses a subtler case:

1. File at 1,300,000 bytes → offset saved as 1,288,375
2. File truncated to 1,287,477 (OpenClaw log rotation)
3. File grows back to 1,295,000 → `offset < size` again ✓
4. Daemon seeks to 1,288,375 in the regrown file — reads mid-file, finds no parseable content
5. Reports 0 log lines every cycle for hours

## Fix

`_validate_log_offsets(state, paths)` runs once at daemon startup:
- Checks every stored offset against current file size
- Resets any offset >= file size to 0
- Removes entries for files that no longer exist
- Logs a warning when it corrects something

Called before the main sync loop and before starting the log streamer.