### PR TITLE
fix: include ollamaInfo in system snapshot

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1782,6 +1782,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "runtimeInfo": _build_runtime_info(),
         "machineInfo": _build_machine_info(),
         "channelList": _build_channel_list(config),
+        "ollamaInfo": _detect_ollama_for_heartbeat(),
     }
 
     log.info(f"System snapshot: {len(subagents_list)} subagents ({active_count} active)")


### PR DESCRIPTION
Adds  (installed, running, models) to the system snapshot payload. The cloud Cost Optimizer was showing Ollama not installed for all cloud nodes because it was checking  on Cloud Run instead of the actual user machine.