### PR TITLE
fix: bump __version__ to 0.12.77 to match PyPI release

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.75"
+__version__ = "0.12.77"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Problem

E2E health check detected a version mismatch:
- PyPI: `0.12.77`
- `dashboard.py __version__`: `0.12.75`

The v0.12.77 release commit (bf34a80) updated CHANGELOG.md but did not bump `__version__` in `dashboard.py`.

## Fix

Update `__version__ = "0.12.75"` → `"0.12.77"` in dashboard.py.

## Impact

Users who run `clawmetry --version` after upgrading will see the correct version. Also prevents version-check warnings in the auto-update flow.