### PR TITLE
fix: bump __version__ to 0.12.77 to match PyPI release

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.75"
+__version__ = "0.12.77"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Problem

The RELEASE commit `bf34a80` published v0.12.77 to PyPI but forgot to update `__version__` in `dashboard.py`, which still reads `0.12.75`. This causes VERSION_MISMATCH in E2E health checks.

## Fix

One-line change: bump `__version__` from `0.12.75` to `0.12.77`.

_Detected by E2E health cron — 2026-03-25_