### PR TITLE
fix: skip OTP verification on Docker/container reconnects

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,30 @@
+# Fix: Skip OTP verification on Docker/container reconnects
+
+## Problem
+
+When running `clawmetry connect --key cm_xxx --foreground` in a Docker container, the daemon requires OTP email verification **every time** it starts. This makes it impossible to auto-restart the sync daemon in Docker/headless environments because:
+
+1. `_verify_key_ownership()` is called whenever `--key` is passed
+2. In containers without a TTY, OTP input fails immediately
+3. Even with a PTY, a new OTP email is sent on every restart
+
+## Fix
+
+### 1. Skip OTP for already-verified keys
+
+In `_cmd_connect()`, before calling `_verify_key_ownership()`, check if the config already has the same API key saved. If so, this is a reconnect/restart — not a new connection — and OTP can be safely skipped.
+
+- **First connect** → full OTP verification (secure)
+- **Restart with same key** → skip OTP (already verified)
+- **Different key** → require OTP (new connection)
+
+### 2. Graceful systemd fallback in containers
+
+`_register_systemd()` now checks if `systemctl` is available before calling it. In Docker containers without systemd, it falls back to `_start_subprocess()` instead of failing.
+
+## Testing
+
+- `clawmetry connect --key cm_xxx` — first time: OTP prompt as before ✅
+- `clawmetry connect --key cm_xxx --foreground` (restart in Docker) — skips OTP ✅
+- `clawmetry connect --key cm_NEW_KEY` — requires OTP ✅
+- Linux container without systemd — falls back to subprocess ✅

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -245,8 +245,9 @@ def _cmd_connect(args) -> None:
         _cfg_pre = _jcfg_pre.load(open(_cfgpath_pre))
         _saved_node_id = _cfg_pre.get('node_id', '')
         _saved_enc_key = _cfg_pre.get('encryption_key', '')
+        _saved_api_key = _cfg_pre.get('api_key', '')
     except Exception:
-        pass
+        _saved_api_key = ''
 
     _stop_existing_daemon()
     import getpass
@@ -262,8 +263,12 @@ def _cmd_connect(args) -> None:
         sys.exit(1)
 
     # Verify ownership via OTP when key is passed directly (not from interactive flow)
+    # Skip if this key is already verified (saved in config) — enables Docker restarts
     if args.key:
-        _verify_key_ownership(api_key)
+        if _saved_api_key and api_key == _saved_api_key:
+            pass  # Already verified — reconnecting with same key
+        else:
+            _verify_key_ownership(api_key)
 
     custom_name = getattr(args, 'custom_node_id', None) or ''
     machine_hostname = custom_name or socket.gethostname()
@@ -407,10 +412,17 @@ StandardError=append:{LOG_FILE}
 WantedBy=default.target
 """
     service_path.write_text(unit)
-    subprocess.run(["systemctl", "--user", "daemon-reload"], check=False)
-    subprocess.run(["systemctl", "--user", "enable", "--now", label], check=False)
-    print("  Running in the background. Your data is syncing to the cloud.")
-    print('  To stop: clawmetry disconnect')
+    # Check if systemctl is available (not in Docker/containers without systemd)
+    import shutil
+    if shutil.which("systemctl"):
+        subprocess.run(["systemctl", "--user", "daemon-reload"], check=False)
+        subprocess.run(["systemctl", "--user", "enable", "--now", label], check=False)
+        print("  Running in the background. Your data is syncing to the cloud.")
+        print('  To stop: clawmetry disconnect')
+    else:
+        print("  ⚠️  systemctl not available (container/Docker?).")
+        print("  Falling back to background subprocess…")
+        _start_subprocess()
 
 
 def _start_subprocess() -> None:


### PR DESCRIPTION
# Fix: Skip OTP verification on Docker/container reconnects

## Problem

When running `clawmetry connect --key cm_xxx --foreground` in a Docker container, the daemon requires OTP email verification **every time** it starts. This makes it impossible to auto-restart the sync daemon in Docker/headless environments because:

1. `_verify_key_ownership()` is called whenever `--key` is passed
2. In containers without a TTY, OTP input fails immediately
3. Even with a PTY, a new OTP email is sent on every restart

## Fix

### 1. Skip OTP for already-verified keys

In `_cmd_connect()`, before calling `_verify_key_ownership()`, check if the config already has the same API key saved. If so, this is a reconnect/restart — not a new connection — and OTP can be safely skipped.

- **First connect** → full OTP verification (secure)
- **Restart with same key** → skip OTP (already verified)
- **Different key** → require OTP (new connection)

### 2. Graceful systemd fallback in containers

`_register_systemd()` now checks if `systemctl` is available before calling it. In Docker containers without systemd, it falls back to `_start_subprocess()` instead of failing.

## Testing

- `clawmetry connect --key cm_xxx` — first time: OTP prompt as before ✅
- `clawmetry connect --key cm_xxx --foreground` (restart in Docker) — skips OTP ✅
- `clawmetry connect --key cm_NEW_KEY` — requires OTP ✅
- Linux container without systemd — falls back to subprocess ✅