### PR TITLE
feat: adaptive anomaly detection engine — per-session cost spikes, frequency alerts, configurable multipliers (closes #301)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -512,6 +512,11 @@ def _default_alerts_webhook_config():
         'slack_webhook_url': '',
         'discord_webhook_url': '',
         'cost_spike_alerts': True,
+        'anomaly_session_spike_alerts': True,
+        'anomaly_frequency_spike_alerts': True,
+        'anomaly_daily_multiplier': 2.0,    # alert when today > N x 7-day avg
+        'anomaly_session_multiplier': 2.0,  # alert when session cost > N x rolling avg
+        'anomaly_frequency_multiplier': 5.0, # alert when session count > N x typical
         'agent_error_rate_alerts': True,
         'security_posture_changes': True,
     }
@@ -877,12 +882,14 @@ def _budget_monitor_loop():
                     channels=['banner', 'telegram'],
                 )
 
-            # Anomaly check: today's cost > 2x 7-day average
+            # Adaptive anomaly detection (issue #301): rolling-baseline alerts
             status = _get_budget_status()
             daily_spent = status['daily_spent']
             if daily_spent > 0:
+                cfg_anom = _load_alerts_webhook_config()
+                daily_mult = float(cfg_anom.get('anomaly_daily_multiplier', 2.0))
                 week_avg = status['weekly_spent'] / 7 if status['weekly_spent'] > 0 else 0
-                if week_avg > 0 and daily_spent > week_avg * 2:
+                if week_avg > 0 and daily_spent > week_avg * daily_mult:
                     ratio = (daily_spent / week_avg)
                     _fire_alert(
                         rule_id='anomaly_daily',
@@ -894,10 +901,17 @@ def _budget_monitor_loop():
                         'type': 'cost_spike',
                         'agent': 'main',
                         'cost_usd': round(daily_spent, 4),
-                        'threshold': round(week_avg * 2, 4),
+                        'threshold': round(week_avg * daily_mult, 4),
                         'timestamp': now,
                         'message': f'Cost spike detected: {ratio:.1f}x daily average',
                     })
+
+            # Per-session cost spikes and session frequency anomaly
+            try:
+                _detect_per_session_cost_spikes()
+                _detect_session_frequency_anomaly()
+            except Exception:
+                pass
 
             # Agent error-rate check from webhook channel metrics (last 60 minutes)
             window_start = now - 3600
@@ -2847,6 +2861,12 @@ function clawmetryLogout(){
             <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-cost-spike"> Cost spike alerts</label>
             <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-agent-error"> Agent error rate alerts</label>
             <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-security"> Security posture changes</label>
+            <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-anomaly-session"> Session cost spike alerts</label>
+            <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-anomaly-frequency"> Session frequency spike alerts</label>
+          </div>
+          <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:6px;">
+            <label style="font-size:12px;color:var(--text-secondary);">Daily cost spike at <input id="alert-anomaly-daily-mult" type="number" step="0.5" min="1" max="20" value="2" style="width:50px;padding:2px 4px;border:1px solid var(--border-primary);border-radius:4px;background:var(--bg-tertiary);color:var(--text-primary);font-size:12px;">x 7-day avg</label>
+            <label style="font-size:12px;color:var(--text-secondary);">Session cost spike at <input id="alert-anomaly-session-mult" type="number" step="0.5" min="1" max="20" value="2" style="width:50px;padding:2px 4px;border:1px solid var(--border-primary);border-radius:4px;background:var(--bg-tertiary);color:var(--text-primary);font-size:12px;">x rolling avg</label>
           </div>
           <div style="display:flex;gap:8px;">
             <button onclick="saveWebhookConfig()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;cursor:pointer;">Save</button>
@@ -2865,6 +2885,12 @@ function clawmetryLogout(){
             <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-cost-spike"> Cost spike alerts</label>
             <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-agent-error"> Agent error rate alerts</label>
             <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-security"> Security posture changes</label>
+            <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-anomaly-session"> Session cost spike alerts</label>
+            <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-anomaly-frequency"> Session frequency spike alerts</label>
+          </div>
+          <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:6px;">
+            <label style="font-size:12px;color:var(--text-secondary);">Daily cost spike at <input id="alert-anomaly-daily-mult" type="number" step="0.5" min="1" max="20" value="2" style="width:50px;padding:2px 4px;border:1px solid var(--border-primary);border-radius:4px;background:var(--bg-tertiary);color:var(--text-primary);font-size:12px;">x 7-day avg</label>
+            <label style="font-size:12px;color:var(--text-secondary);">Session cost spike at <input id="alert-anomaly-session-mult" type="number" step="0.5" min="1" max="20" value="2" style="width:50px;padding:2px 4px;border:1px solid var(--border-primary);border-radius:4px;background:var(--bg-tertiary);color:var(--text-primary);font-size:12px;">x rolling avg</label>
           </div>
           <div style="display:flex;gap:8px;">
             <button onclick="saveWebhookConfig()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;cursor:pointer;">Save</button>
@@ -3741,6 +3767,10 @@ async function loadWebhookConfig() {
     document.getElementById('alert-slack-url').value = cfg.slack_webhook_url || '';
     document.getElementById('alert-discord-url').value = cfg.discord_webhook_url || '';
     document.getElementById('alert-toggle-cost-spike').checked = cfg.cost_spike_alerts !== false;
+    document.getElementById('alert-toggle-anomaly-session').checked = cfg.anomaly_session_spike_alerts !== false;
+    document.getElementById('alert-toggle-anomaly-frequency').checked = cfg.anomaly_frequency_spike_alerts !== false;
+    if (cfg.anomaly_daily_multiplier) document.getElementById('alert-anomaly-daily-mult').value = cfg.anomaly_daily_multiplier;
+    if (cfg.anomaly_session_multiplier) document.getElementById('alert-anomaly-session-mult').value = cfg.anomaly_session_multiplier;
     document.getElementById('alert-toggle-agent-error').checked = cfg.agent_error_rate_alerts !== false;
     document.getElementById('alert-toggle-security').checked = cfg.security_posture_changes !== false;
     document.getElementById('alert-webhook-status').textContent = '';
@@ -3755,6 +3785,10 @@ async function saveWebhookConfig() {
     slack_webhook_url: document.getElementById('alert-slack-url').value.trim(),
     discord_webhook_url: document.getElementById('alert-discord-url').value.trim(),
     cost_spike_alerts: document.getElementById('alert-toggle-cost-spike').checked,
+      anomaly_session_spike_alerts: document.getElementById('alert-toggle-anomaly-session').checked,
+      anomaly_frequency_spike_alerts: document.getElementById('alert-toggle-anomaly-frequency').checked,
+      anomaly_daily_multiplier: parseFloat(document.getElementById('alert-anomaly-daily-mult').value) || 2.0,
+      anomaly_session_multiplier: parseFloat(document.getElementById('alert-anomaly-session-mult').value) || 2.0,
     agent_error_rate_alerts: document.getElementById('alert-toggle-agent-error').checked,
     security_posture_changes: document.getElementById('alert-toggle-security').checked,
   };
@@ -5560,6 +5594,11 @@ def _default_alerts_webhook_config():
         'cost_spike_alerts': True,
         'agent_error_rate_alerts': True,
         'security_posture_changes': True,
+        'anomaly_session_spike_alerts': True,
+        'anomaly_frequency_spike_alerts': True,
+        'anomaly_daily_multiplier': 2.0,    # alert when today > N x 7-day avg
+        'anomaly_session_multiplier': 2.0,  # alert when session cost > N x rolling avg
+        'anomaly_frequency_multiplier': 5.0, # alert when session count > N x typical
     }
 
 
@@ -5936,12 +5975,14 @@ def _budget_monitor_loop():
                         channels=['banner', 'telegram'],
                     )
 
-            # Anomaly check: today's cost > 2x 7-day average
+            # Adaptive anomaly detection (issue #301): rolling-baseline alerts
             status = _get_budget_status()
             daily_spent = status['daily_spent']
             if daily_spent > 0:
+                cfg_anom = _load_alerts_webhook_config()
+                daily_mult = float(cfg_anom.get('anomaly_daily_multiplier', 2.0))
                 week_avg = status['weekly_spent'] / 7 if status['weekly_spent'] > 0 else 0
-                if week_avg > 0 and daily_spent > week_avg * 2:
+                if week_avg > 0 and daily_spent > week_avg * daily_mult:
                     ratio = (daily_spent / week_avg)
                     _fire_alert(
                         rule_id='anomaly_daily',
@@ -5953,10 +5994,17 @@ def _budget_monitor_loop():
                         'type': 'cost_spike',
                         'agent': 'main',
                         'cost_usd': round(daily_spent, 4),
-                        'threshold': round(week_avg * 2, 4),
+                        'threshold': round(week_avg * daily_mult, 4),
                         'timestamp': now,
                         'message': f'Cost spike detected: {ratio:.1f}x daily average',
                     })
+
+            # Per-session cost spikes and session frequency anomaly
+            try:
+                _detect_per_session_cost_spikes()
+                _detect_session_frequency_anomaly()
+            except Exception:
+                pass
 
             # Agent error-rate check from webhook channel metrics (last 60 minutes)
             window_start = now - 3600
@@ -8903,6 +8951,10 @@ async function loadWebhookConfig() {
     document.getElementById('alert-slack-url').value = cfg.slack_webhook_url || '';
     document.getElementById('alert-discord-url').value = cfg.discord_webhook_url || '';
     document.getElementById('alert-toggle-cost-spike').checked = cfg.cost_spike_alerts !== false;
+    document.getElementById('alert-toggle-anomaly-session').checked = cfg.anomaly_session_spike_alerts !== false;
+    document.getElementById('alert-toggle-anomaly-frequency').checked = cfg.anomaly_frequency_spike_alerts !== false;
+    if (cfg.anomaly_daily_multiplier) document.getElementById('alert-anomaly-daily-mult').value = cfg.anomaly_daily_multiplier;
+    if (cfg.anomaly_session_multiplier) document.getElementById('alert-anomaly-session-mult').value = cfg.anomaly_session_multiplier;
     document.getElementById('alert-toggle-agent-error').checked = cfg.agent_error_rate_alerts !== false;
     document.getElementById('alert-toggle-security').checked = cfg.security_posture_changes !== false;
     document.getElementById('alert-webhook-status').textContent = '';
@@ -8918,6 +8970,10 @@ async function saveWebhookConfig() {
     slack_webhook_url: document.getElementById('alert-slack-url').value.trim(),
     discord_webhook_url: document.getElementById('alert-discord-url').value.trim(),
     cost_spike_alerts: document.getElementById('alert-toggle-cost-spike').checked,
+      anomaly_session_spike_alerts: document.getElementById('alert-toggle-anomaly-session').checked,
+      anomaly_frequency_spike_alerts: document.getElementById('alert-toggle-anomaly-frequency').checked,
+      anomaly_daily_multiplier: parseFloat(document.getElementById('alert-anomaly-daily-mult').value) || 2.0,
+      anomaly_session_multiplier: parseFloat(document.getElementById('alert-anomaly-session-mult').value) || 2.0,
     agent_error_rate_alerts: document.getElementById('alert-toggle-agent-error').checked,
     security_posture_changes: document.getElementById('alert-toggle-security').checked,
   };
@@ -18340,7 +18396,9 @@ def api_alerts_webhook():
         data = request.get_json(silent=True) or {}
         allowed = {
             'webhook_url', 'slack_webhook_url', 'discord_webhook_url',
-            'cost_spike_alerts', 'agent_error_rate_alerts', 'security_posture_changes'
+            'cost_spike_alerts', 'agent_error_rate_alerts', 'security_posture_changes',
+            'anomaly_session_spike_alerts', 'anomaly_frequency_spike_alerts',
+            'anomaly_daily_multiplier', 'anomaly_session_multiplier', 'anomaly_frequency_multiplier',
         }
         updates = {k: data[k] for k in data if k in allowed}
         cfg = _save_alerts_webhook_config(updates)
@@ -19156,6 +19214,7 @@ def _compute_transcript_analytics():
             s_model = 'unknown'
             s_start = None
             s_end = None
+            s_turn_tokens = []  # per-turn token counts for spike detection
             search_parts = []
             explicit_cron_refs = set()
 
@@ -19195,6 +19254,10 @@ def _compute_transcript_analytics():
                             s_tokens += tokens
                             if cost > 0:
                                 s_cost += cost
+
+                            # Track per-turn token counts for spike detection
+                            turn_ts_val = ts.timestamp() if ts and hasattr(ts, 'timestamp') else 0
+                            s_turn_tokens.append({'tokens': tokens, 'ts': turn_ts_val})
 
                             plugins = _extract_tool_plugins(obj)
                             if plugins:
@@ -19243,6 +19306,7 @@ def _compute_transcript_analytics():
                     'search_text': search_text,
                     'explicit_cron_refs': explicit_cron_refs,
                     'is_cron_candidate': ('cron' in search_text) or bool(explicit_cron_refs),
+                    'turn_tokens': s_turn_tokens,
                 })
             except Exception:
                 continue
@@ -19259,6 +19323,110 @@ def _compute_transcript_analytics():
     _transcript_analytics_cache['ts'] = now
     return result
 
+
+
+
+def _detect_per_session_cost_spikes():
+    """Detect sessions in the last 24h whose cost exceeds N x rolling 7-day avg.
+
+    Returns list of anomaly dicts (same schema as _compute_session_cost_anomalies).
+    Also fires _fire_alert and _dispatch_configured_webhooks for fresh spikes.
+    """
+    cfg = _load_alerts_webhook_config()
+    if not cfg.get('anomaly_session_spike_alerts', True):
+        return []
+    multiplier = float(cfg.get('anomaly_session_multiplier', 2.0))
+
+    analytics = _compute_transcript_analytics()
+    session_summaries = analytics.get('sessions', [])
+    anomalies = _compute_session_cost_anomalies(session_summaries)
+
+    now_ts = time.time()
+    # Only fire alerts for sessions that started in the last 2 hours (fresh anomalies)
+    recent_cutoff = now_ts - 7200
+    fired_any = False
+    for a in anomalies:
+        ts_ms = a.get('timestamp', 0)
+        ts = ts_ms / 1000.0 if ts_ms > 1e10 else float(ts_ms)
+        if ts < recent_cutoff:
+            continue
+        ratio = a.get('ratio', 0)
+        if ratio < multiplier:
+            continue
+        cost = a.get('cost_usd', 0)
+        avg = a.get('rolling_avg_usd', 0)
+        sid = a.get('session_id', 'unknown')
+        rule_id = f'anomaly_session_{sid}'
+        msg = (
+            f'Session cost spike: session {sid[:8]} cost ${cost:.4f} '
+            f'({ratio:.1f}x rolling avg ${avg:.4f})'
+        )
+        _fire_alert(rule_id=rule_id, alert_type='anomaly', message=msg,
+                    channels=['banner', 'telegram'])
+        _dispatch_configured_webhooks('cost_spike', {
+            'type': 'session_cost_spike',
+            'agent': 'main',
+            'session_id': sid,
+            'cost_usd': round(cost, 6),
+            'rolling_avg_usd': round(avg, 6),
+            'ratio': round(ratio, 3),
+            'threshold': round(avg * multiplier, 6),
+            'timestamp': now_ts,
+            'message': msg,
+        })
+        fired_any = True
+
+    return anomalies
+
+
+def _detect_session_frequency_anomaly():
+    """Alert when today has N x more sessions than the 7-day daily average."""
+    cfg = _load_alerts_webhook_config()
+    if not cfg.get('anomaly_frequency_spike_alerts', True):
+        return
+    multiplier = float(cfg.get('anomaly_frequency_multiplier', 5.0))
+
+    analytics = _compute_transcript_analytics()
+    sessions = analytics.get('sessions', [])
+    if not sessions:
+        return
+
+    today_str = datetime.now().strftime('%Y-%m-%d')
+    day_counts = {}
+    for s in sessions:
+        day = s.get('day', '')
+        if day:
+            day_counts[day] = day_counts.get(day, 0) + 1
+
+    today_count = day_counts.get(today_str, 0)
+    if today_count == 0:
+        return
+
+    # 7-day average (excluding today)
+    past_counts = [v for k, v in day_counts.items() if k != today_str]
+    if len(past_counts) < 3:
+        return  # not enough baseline data
+    past_avg = sum(past_counts) / len(past_counts)
+    if past_avg <= 0:
+        return
+
+    if today_count > past_avg * multiplier:
+        ratio = today_count / past_avg
+        msg = (
+            f'Session frequency spike: {today_count} sessions today '
+            f'({ratio:.1f}x the {len(past_counts)}-day avg of {past_avg:.1f}/day)'
+        )
+        _fire_alert(rule_id='anomaly_session_frequency', alert_type='anomaly',
+                    message=msg, channels=['banner', 'telegram'])
+        _dispatch_configured_webhooks('cost_spike', {
+            'type': 'session_frequency_spike',
+            'agent': 'main',
+            'session_count': today_count,
+            'rolling_avg': round(past_avg, 2),
+            'ratio': round(ratio, 2),
+            'timestamp': time.time(),
+            'message': msg,
+        })
 
 def _compute_session_cost_anomalies(session_summaries):
     """Flag sessions with cost >2x their rolling 7-day session-cost average."""
@@ -19407,6 +19575,143 @@ def api_usage_anomalies():
         'anomalies': anomalies,
         'baseline_7d_avg_usd': round(baseline_avg, 6),
         'threshold_multiplier': 2.0,
+    })
+
+
+def _compute_per_turn_token_anomalies(session_summaries, threshold_multiplier=3.0, window_days=7):
+    """Flag individual turns whose token count exceeds threshold_multiplier × 7-day rolling avg turn size.
+
+    Returns a list of anomaly dicts sorted by ratio descending.
+    """
+    now_ts = time.time()
+    day_ago = now_ts - 86400
+    window_sec = window_days * 86400
+    anomalies = []
+
+    # Build a flat list of (ts, tokens, session_id) for all turns in the rolling window
+    all_turns = []
+    for sess in session_summaries:
+        sess_ts = float(sess.get('start_ts', 0) or 0)
+        if sess_ts < now_ts - window_sec:
+            continue
+        for turn in (sess.get('turn_tokens') or []):
+            t_ts = float(turn.get('ts', 0) or sess_ts)
+            t_tokens = int(turn.get('tokens', 0) or 0)
+            if t_tokens > 0:
+                all_turns.append({'ts': t_ts, 'tokens': t_tokens, 'session_id': sess.get('session_id', '')})
+
+    if not all_turns:
+        return []
+
+    # For each turn in the last 24h, compute ratio vs rolling avg of all prior turns in window
+    all_turns.sort(key=lambda t: t['ts'])
+    for i, turn in enumerate(all_turns):
+        if turn['ts'] < day_ago:
+            continue
+        prior_tokens = [t['tokens'] for t in all_turns[:i] if t['ts'] >= turn['ts'] - window_sec]
+        if len(prior_tokens) < 3:
+            continue
+        avg = sum(prior_tokens) / len(prior_tokens)
+        if avg <= 0:
+            continue
+        ratio = turn['tokens'] / avg
+        if ratio >= threshold_multiplier:
+            anomalies.append({
+                'type': 'token_spike',
+                'session_id': turn['session_id'],
+                'turn_tokens': turn['tokens'],
+                'rolling_avg_tokens': round(avg, 1),
+                'ratio': round(ratio, 3),
+                'timestamp': int(turn['ts'] * 1000),
+            })
+
+    anomalies.sort(key=lambda a: a.get('ratio', 0), reverse=True)
+    return anomalies
+
+
+def _compute_daily_cost_anomaly(daily_cost_map, threshold_multiplier=2.0, window_days=7):
+    """Check if today's cost is > threshold_multiplier × 7-day rolling average.
+
+    Returns an anomaly dict or None.
+    """
+    today_str = datetime.now().strftime('%Y-%m-%d')
+    today_cost = daily_cost_map.get(today_str, 0.0)
+    if today_cost <= 0:
+        return None
+
+    window_costs = []
+    for i in range(1, window_days + 1):
+        d = (datetime.now() - timedelta(days=i)).strftime('%Y-%m-%d')
+        c = daily_cost_map.get(d, 0.0)
+        if c > 0:
+            window_costs.append(c)
+
+    if len(window_costs) < 2:
+        return None
+
+    avg = sum(window_costs) / len(window_costs)
+    if avg <= 0:
+        return None
+
+    ratio = today_cost / avg
+    if ratio < threshold_multiplier:
+        return None
+
+    return {
+        'type': 'daily_cost_spike',
+        'date': today_str,
+        'today_cost_usd': round(today_cost, 4),
+        'rolling_avg_usd': round(avg, 4),
+        'ratio': round(ratio, 3),
+        'window_days': window_days,
+    }
+
+
+@bp_usage.route('/api/anomalies')
+def api_anomalies():
+    """Consolidated rolling-baseline anomaly detector.
+
+    Returns three detection categories:
+      - session_cost_spikes: sessions where cost > 2x 7-day rolling avg session cost
+      - token_spikes: turns where token count > 3x 7-day rolling avg turn size
+      - daily_cost_spike: today's total cost > 2x 7-day rolling daily avg (or None)
+
+    Query params:
+      session_threshold  float  default 2.0 — session cost spike multiplier
+      token_threshold    float  default 3.0 — per-turn token spike multiplier
+      daily_threshold    float  default 2.0 — daily cost spike multiplier
+    """
+    try:
+        session_thr = float(request.args.get('session_threshold', 2.0))
+        token_thr = float(request.args.get('token_threshold', 3.0))
+        daily_thr = float(request.args.get('daily_threshold', 2.0))
+    except (ValueError, TypeError):
+        return jsonify({'error': 'threshold params must be numeric'}), 400
+
+    analytics = _compute_transcript_analytics()
+    session_summaries = analytics.get('sessions', [])
+    daily_cost_map = analytics.get('daily_cost', {})
+
+    session_spikes = _compute_session_cost_anomalies(session_summaries)
+    # Re-run with custom threshold if different from default 2.0
+    if abs(session_thr - 2.0) > 0.01:
+        session_spikes = [a for a in session_spikes if a.get('ratio', 0) >= session_thr]
+
+    token_spikes = _compute_per_turn_token_anomalies(session_summaries, threshold_multiplier=token_thr)
+    daily_spike = _compute_daily_cost_anomaly(daily_cost_map, threshold_multiplier=daily_thr)
+
+    total = len(session_spikes) + len(token_spikes) + (1 if daily_spike else 0)
+
+    return jsonify({
+        'session_cost_spikes': session_spikes,
+        'token_spikes': token_spikes,
+        'daily_cost_spike': daily_spike,
+        'total_anomalies': total,
+        'thresholds': {
+            'session_cost': session_thr,
+            'token_per_turn': token_thr,
+            'daily_cost': daily_thr,
+        },
     })
 
 

--- a/tests/conftest_pr336.py
+++ b/tests/conftest_pr336.py
@@ -1,0 +1,107 @@
+"""
+Shared fixtures for ClawMetry test suite.
+"""
+import os
+import sys
+import json
+import subprocess
+import time
+import pytest
+import requests
+
+
+def _detect_gateway_token():
+    """Detect gateway token from OpenClaw config."""
+    # Environment variable
+    token = os.environ.get("CLAWMETRY_TOKEN", "").strip()
+    if token:
+        return token
+
+    # OpenClaw config
+    config_path = os.path.expanduser("~/.openclaw/openclaw.json")
+    try:
+        with open(config_path) as f:
+            cfg = json.load(f)
+        token = cfg.get("gateway", {}).get("auth", {}).get("token", "").strip()
+        if token:
+            return token
+    except (FileNotFoundError, ValueError, KeyError):
+        pass
+
+    return None
+
+
+def _is_server_running(base_url, token=None):
+    """Check if the ClawMetry server is reachable."""
+    try:
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        r = requests.get(f"{base_url}/api/health", headers=headers, timeout=5)
+        return r.status_code == 200
+    except requests.exceptions.ConnectionError:
+        return False
+
+
+BASE_URL = os.environ.get("CLAWMETRY_URL", "http://localhost:8900")
+GATEWAY_TOKEN = _detect_gateway_token()
+
+
+@pytest.fixture(scope="session")
+def base_url():
+    return BASE_URL
+
+
+@pytest.fixture(scope="session")
+def token():
+    return GATEWAY_TOKEN
+
+
+@pytest.fixture(scope="session")
+def api(base_url, token):
+    """Requests session with auth pre-configured."""
+    session = requests.Session()
+    if token:
+        session.headers.update({"Authorization": f"Bearer {token}"})
+    return session
+
+
+@pytest.fixture(scope="session", autouse=True)
+def server(base_url, token):
+    """Ensure the ClawMetry server is running before tests."""
+    if _is_server_running(base_url, token):
+        yield base_url
+        return
+
+    # Start the server
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    dashboard = os.path.join(repo_root, "dashboard.py")
+    env = os.environ.copy()
+    # Propagate the CI test token so the server accepts our requests
+    if token:
+        env["OPENCLAW_GATEWAY_TOKEN"] = token
+    # Derive port from base_url
+    try:
+        port = base_url.split(":")[-1].rstrip("/")
+    except Exception:
+        port = "8900"
+    proc = subprocess.Popen(
+        [sys.executable, dashboard, "--port", port, "--no-debug"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+
+    # Wait up to 20 seconds for the server to be ready
+    for _ in range(40):
+        time.sleep(0.5)
+        if _is_server_running(base_url, token):
+            break
+    else:
+        stderr_out = proc.stderr.read(2000) if proc.stderr else b""
+        proc.terminate()
+        pytest.fail(f"ClawMetry server failed to start. stderr: {stderr_out.decode(errors='replace')}")
+
+    yield base_url
+
+    proc.terminate()

--- a/tests/test_api_pr336.py
+++ b/tests/test_api_pr336.py
@@ -1,0 +1,468 @@
+"""
+ClawMetry API endpoint tests.
+
+Tests every API endpoint for:
+- Correct HTTP status (200)
+- Response structure / required keys
+
+Tests are resilient: empty data is fine — we just check structure.
+"""
+import pytest
+import requests
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def get(api, base_url, path):
+    """Make an authenticated GET request and return the response."""
+    return api.get(f"{base_url}{path}", timeout=10)
+
+
+def assert_ok(resp):
+    assert resp.status_code == 200, (
+        f"Expected 200 for {resp.url}, got {resp.status_code}: {resp.text[:200]}"
+    )
+    return resp.json()
+
+
+def assert_keys(data, *keys):
+    for k in keys:
+        assert k in data, f"Missing key '{k}' in response: {list(data.keys())}"
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+class TestAuth:
+    def test_auth_check_accessible(self, base_url):
+        """Auth check endpoint is always accessible (no token needed)."""
+        r = requests.get(f"{base_url}/api/auth/check", timeout=5)
+        assert r.status_code == 200
+        d = r.json()
+        assert "valid" in d
+
+    def test_auth_with_token(self, base_url, token):
+        """Correct token is accepted."""
+        if not token:
+            pytest.skip("No gateway token configured")
+        r = requests.get(
+            f"{base_url}/api/auth/check",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=5,
+        )
+        assert r.status_code == 200
+        d = r.json()
+        assert d.get("valid") is True
+
+
+# ---------------------------------------------------------------------------
+# Core endpoints
+# ---------------------------------------------------------------------------
+
+class TestOverview:
+    def test_status(self, api, base_url):
+        r = get(api, base_url, "/api/overview")
+        assert_ok(r)
+
+    def test_required_keys(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/overview"))
+        assert_keys(d, "model", "mainTokens")
+
+    def test_model_is_string(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/overview"))
+        assert isinstance(d["model"], str)
+        assert len(d["model"]) > 0
+
+    def test_main_tokens_is_number(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/overview"))
+        assert isinstance(d["mainTokens"], (int, float))
+
+
+class TestChannels:
+    def test_status(self, api, base_url):
+        r = get(api, base_url, "/api/channels")
+        assert_ok(r)
+
+    def test_returns_channels_list(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/channels"))
+        assert "channels" in d
+        assert isinstance(d["channels"], list)
+
+
+
+class TestHealth:
+    def test_status(self, api, base_url):
+        r = get(api, base_url, "/api/health")
+        assert_ok(r)
+
+    def test_has_checks(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/health"))
+        assert "checks" in d
+        assert isinstance(d["checks"], list)
+
+
+class TestSystemHealth:
+    def test_status(self, api, base_url):
+        r = get(api, base_url, "/api/system-health")
+        assert_ok(r)
+
+    def test_response_is_dict(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/system-health"))
+        assert isinstance(d, dict)
+
+
+class TestSessions:
+    def test_status(self, api, base_url):
+        r = get(api, base_url, "/api/sessions")
+        assert_ok(r)
+
+    def test_response_is_list_or_dict(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/sessions"))
+        assert isinstance(d, (list, dict))
+
+
+class TestCrons:
+    def test_status(self, api, base_url):
+        r = get(api, base_url, "/api/crons")
+        assert_ok(r)
+
+    def test_response_is_list_or_dict(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/crons"))
+        assert isinstance(d, (list, dict))
+
+
+class TestCronHealth:
+    def test_status(self, api, base_url):
+        r = get(api, base_url, "/api/cron/health")
+        assert_ok(r)
+
+    def test_has_jobs_and_summary(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/cron/health"))
+        assert "jobs" in d, "Missing 'jobs' key"
+        assert "summary" in d, "Missing 'summary' key"
+
+    def test_summary_has_required_keys(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/cron/health"))
+        summary = d["summary"]
+        for key in ("total", "healthy", "dead", "errored", "costSpikes"):
+            assert key in summary, f"Missing summary key: {key}"
+
+    def test_jobs_have_required_fields(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/cron/health"))
+        for job in d.get("jobs", []):
+            for key in ("id", "name", "enabled", "totalRuns", "successRate", "deadCron", "costSpike"):
+                assert key in job, f"Missing job field: {key}"
+
+
+class TestTranscripts:
+    def test_status(self, api, base_url):
+        r = get(api, base_url, "/api/transcripts")
+        assert_ok(r)
+
+    def test_response_is_list_or_dict(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/transcripts"))
+        assert isinstance(d, (list, dict))
+
+
+class TestUsage:
+    def test_status(self, api, base_url):
+        r = get(api, base_url, "/api/usage")
+        assert_ok(r)
+
+    def test_response_is_dict(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/usage"))
+        assert isinstance(d, dict)
+
+
+
+# ---------------------------------------------------------------------------
+# Channel endpoints
+# ---------------------------------------------------------------------------
+
+FULL_CHANNEL_KEYS = ["messages", "todayIn", "todayOut"]
+BASIC_CHANNEL_KEYS = ["messages"]
+
+CHANNELS = {
+    "telegram":  FULL_CHANNEL_KEYS,
+    "imessage":  FULL_CHANNEL_KEYS,
+    "whatsapp":  BASIC_CHANNEL_KEYS,
+    "signal":    BASIC_CHANNEL_KEYS,
+    "discord":   BASIC_CHANNEL_KEYS,
+    "slack":     BASIC_CHANNEL_KEYS,
+    "webchat":   BASIC_CHANNEL_KEYS,
+}
+
+
+@pytest.mark.parametrize("channel,required_keys", CHANNELS.items())
+class TestChannelEndpoints:
+    def test_status(self, api, base_url, channel, required_keys):
+        r = get(api, base_url, f"/api/channel/{channel}")
+        assert_ok(r)
+
+    def test_required_keys(self, api, base_url, channel, required_keys):
+        d = assert_ok(get(api, base_url, f"/api/channel/{channel}"))
+        # iMessage may return a note on non-macOS platforms instead of full data
+        if channel == "imessage" and "note" in d:
+            assert isinstance(d["note"], str)
+            return
+        assert_keys(d, *required_keys)
+
+    def test_messages_is_list(self, api, base_url, channel, required_keys):
+        d = assert_ok(get(api, base_url, f"/api/channel/{channel}"))
+        # iMessage may return a note on non-macOS platforms
+        if channel == "imessage" and "note" in d:
+            assert isinstance(d["note"], str)
+            return
+        assert isinstance(d["messages"], list), (
+            f"channel/{channel}: 'messages' should be a list"
+        )
+
+    def test_today_counts_are_numbers(self, api, base_url, channel, required_keys):
+        if "todayIn" not in required_keys:
+            pytest.skip(f"channel/{channel} does not expose todayIn/todayOut")
+        d = assert_ok(get(api, base_url, f"/api/channel/{channel}"))
+        # iMessage may return a note on non-macOS platforms
+        if channel == "imessage" and "note" in d:
+            pytest.skip("iMessage not available on this platform")
+        assert isinstance(d["todayIn"], (int, float))
+        assert isinstance(d["todayOut"], (int, float))
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat Gap Alerting
+# ---------------------------------------------------------------------------
+
+class TestHeartbeatStatus:
+    def test_heartbeat_status_endpoint(self, api, base_url):
+        """Heartbeat status endpoint returns 200 with expected keys."""
+        d = assert_ok(get(api, base_url, "/api/heartbeat-status"))
+        assert_keys(d, "status", "last_heartbeat_ts", "interval_seconds", "threshold_seconds")
+
+    def test_heartbeat_status_values(self, api, base_url):
+        """Status is one of: unknown, ok, warning, silent."""
+        d = assert_ok(get(api, base_url, "/api/heartbeat-status"))
+        assert d["status"] in ("unknown", "ok", "warning", "silent"), (
+            f"Unexpected status: {d['status']}"
+        )
+
+    def test_heartbeat_interval_positive(self, api, base_url):
+        """Interval should be a positive number of seconds."""
+        d = assert_ok(get(api, base_url, "/api/heartbeat-status"))
+        assert d["interval_seconds"] > 0
+
+    def test_heartbeat_threshold_gt_interval(self, api, base_url):
+        """Threshold should be greater than interval (1.5x)."""
+        d = assert_ok(get(api, base_url, "/api/heartbeat-status"))
+        assert d["threshold_seconds"] > d["interval_seconds"]
+
+    def test_heartbeat_ping(self, api, base_url):
+        """Heartbeat ping endpoint records a heartbeat event."""
+        r = api.post(f"{base_url}/api/heartbeat-ping", timeout=10)
+        assert r.status_code == 200
+        d = r.json()
+        assert d.get("ok") is True
+
+    def test_heartbeat_status_after_ping(self, api, base_url):
+        """After ping, heartbeat status should be ok."""
+        api.post(f"{base_url}/api/heartbeat-ping", timeout=10)
+        d = assert_ok(get(api, base_url, "/api/heartbeat-status"))
+        assert d["status"] == "ok", f"Expected 'ok' after ping, got '{d['status']}'"
+        assert d["gap_seconds"] is not None
+        assert d["gap_seconds"] < 5  # should be very recent
+
+    def test_system_health_includes_heartbeat(self, api, base_url):
+        """System health endpoint includes heartbeat status."""
+        d = assert_ok(get(api, base_url, "/api/system-health"))
+        assert "heartbeat" in d, "system-health should include heartbeat key"
+        hb = d["heartbeat"]
+        assert_keys(hb, "status", "interval_seconds")
+
+    def test_system_health_includes_sandbox_field(self, api, base_url):
+        """System health endpoint includes sandbox field (may be null)."""
+        d = assert_ok(get(api, base_url, "/api/system-health"))
+        assert "sandbox" in d, "system-health should include sandbox key"
+        # sandbox is null when not in a sandboxed environment
+        if d["sandbox"] is not None:
+            assert "name" in d["sandbox"]
+            assert "status" in d["sandbox"]
+
+    def test_system_health_includes_inference_field(self, api, base_url):
+        """System health endpoint includes inference field (may be null)."""
+        d = assert_ok(get(api, base_url, "/api/system-health"))
+        assert "inference" in d, "system-health should include inference key"
+        if d["inference"] is not None:
+            assert "provider" in d["inference"] or "model" in d["inference"]
+
+    def test_system_health_includes_security_field(self, api, base_url):
+        """System health endpoint includes security field (may be null)."""
+        d = assert_ok(get(api, base_url, "/api/system-health"))
+        assert "security" in d, "system-health should include security key"
+
+
+# ---------------------------------------------------------------------------
+# Security
+# ---------------------------------------------------------------------------
+
+class TestSecurity:
+    def test_threats_endpoint(self, api, base_url):
+        """Security threats endpoint returns 200."""
+        d = assert_ok(get(api, base_url, "/api/security/threats"))
+
+    def test_threats_response_structure(self, api, base_url):
+        """Threats response has required keys."""
+        d = assert_ok(get(api, base_url, "/api/security/threats"))
+        assert_keys(d, "threats", "counts", "scanned_events")
+        assert isinstance(d["threats"], list)
+        assert isinstance(d["counts"], dict)
+        assert_keys(d["counts"], "critical", "high", "medium", "low", "total")
+
+    def test_threats_count_consistency(self, api, base_url):
+        """Threat counts add up correctly."""
+        d = assert_ok(get(api, base_url, "/api/security/threats"))
+        counts = d["counts"]
+        expected_total = counts["critical"] + counts["high"] + counts["medium"] + counts["low"]
+        assert counts["total"] == expected_total, (
+            f"Total {counts['total']} != sum of severities {expected_total}"
+        )
+
+    def test_signatures_endpoint(self, api, base_url):
+        """Security signatures endpoint returns 200."""
+        d = assert_ok(get(api, base_url, "/api/security/signatures"))
+
+    def test_signatures_response_structure(self, api, base_url):
+        """Signatures response has required keys."""
+        d = assert_ok(get(api, base_url, "/api/security/signatures"))
+        assert_keys(d, "signatures", "total")
+        assert isinstance(d["signatures"], list)
+        assert d["total"] >= 10, f"Expected at least 10 signatures, got {d['total']}"
+
+    def test_signatures_have_required_fields(self, api, base_url):
+        """Each signature has id, severity, description."""
+        d = assert_ok(get(api, base_url, "/api/security/signatures"))
+        for sig in d["signatures"]:
+            assert_keys(sig, "id", "severity", "description", "tool_types")
+            assert sig["severity"] in ("critical", "high", "medium", "low"), (
+                f"Invalid severity: {sig['severity']}"
+            )
+
+    def test_threat_fields_if_present(self, api, base_url):
+        """If threats exist, they have the right structure."""
+        d = assert_ok(get(api, base_url, "/api/security/threats"))
+        for t in d["threats"][:5]:  # check first 5
+            assert_keys(t, "rule_id", "severity", "description", "detail", "time")
+
+
+# ---------------------------------------------------------------------------
+# Security Posture
+# ---------------------------------------------------------------------------
+
+class TestSecurityPosture:
+    def test_posture_endpoint(self, api, base_url):
+        """Security posture endpoint returns 200."""
+        d = assert_ok(get(api, base_url, "/api/security/posture"))
+
+    def test_posture_response_structure(self, api, base_url):
+        """Posture response has score, checks, and counters."""
+        d = assert_ok(get(api, base_url, "/api/security/posture"))
+        assert_keys(d, "score", "checks", "passed", "failed", "warnings", "total")
+        assert isinstance(d["checks"], list)
+        assert d["score"] in ("A", "B", "C", "D", "F", "U"), (
+            f"Unexpected score: {d['score']}"
+        )
+
+    def test_posture_checks_have_fields(self, api, base_url):
+        """Each posture check has required fields."""
+        d = assert_ok(get(api, base_url, "/api/security/posture"))
+        for c in d["checks"]:
+            assert_keys(c, "id", "label", "status", "detail", "severity", "weight")
+            assert c["status"] in ("pass", "warn", "fail"), (
+                f"Invalid check status: {c['status']}"
+            )
+            assert c["severity"] in ("critical", "high", "medium", "low"), (
+                f"Invalid check severity: {c['severity']}"
+            )
+
+    def test_posture_counters_consistent(self, api, base_url):
+        """Passed + warnings + failed = total."""
+        d = assert_ok(get(api, base_url, "/api/security/posture"))
+        assert d["passed"] + d["warnings"] + d["failed"] == d["total"], (
+            f"Counters inconsistent: {d['passed']}+{d['warnings']}+{d['failed']} != {d['total']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Brain Activity
+# ---------------------------------------------------------------------------
+
+class TestBrainActivity:
+    def test_brain_history_structure(self, api, base_url):
+        """Brain history endpoint returns events, total, and sources."""
+        d = assert_ok(get(api, base_url, "/api/brain-history"))
+        assert_keys(d, "events", "total", "sources")
+        assert isinstance(d["events"], list)
+        assert isinstance(d["sources"], list)
+        assert isinstance(d["total"], int)
+
+    def test_brain_history_event_fields(self, api, base_url):
+        """Brain events have required fields: time, source, type, detail."""
+        d = assert_ok(get(api, base_url, "/api/brain-history"))
+        for ev in d["events"][:10]:
+            assert_keys(ev, "time", "source", "type", "detail", "color")
+
+    def test_brain_history_sources_fields(self, api, base_url):
+        """Source entries have id, label, color."""
+        d = assert_ok(get(api, base_url, "/api/brain-history"))
+        for s in d["sources"][:5]:
+            assert_keys(s, "id", "label", "color")
+
+    def test_brain_stream_sse_endpoint(self, api, base_url):
+        """Brain stream SSE endpoint returns text/event-stream."""
+        r = api.get(f"{base_url}/api/brain-stream", stream=True, timeout=5)
+        assert r.status_code == 200, f"Expected 200, got {r.status_code}"
+        ct = r.headers.get("Content-Type", "")
+        assert "text/event-stream" in ct, f"Expected text/event-stream, got {ct}"
+        # Read initial connected event
+        first_chunk = b""
+        for chunk in r.iter_content(chunk_size=256):
+            first_chunk += chunk
+            if b"connected" in first_chunk or len(first_chunk) > 512:
+                break
+        r.close()
+        assert b"connected" in first_chunk or b"data:" in first_chunk or b":\n" in first_chunk
+
+
+class TestMemoryAnalytics:
+    """Tests for memory analytics & bloat detection (GH #203)."""
+
+    def test_memory_analytics_returns_200(self, api, base_url):
+        """Memory analytics endpoint returns 200."""
+        d = assert_ok(get(api, base_url, "/api/memory-analytics"))
+        assert_keys(d, "totalBytes", "totalKB", "estTokens", "fileCount",
+                     "files", "topFiles", "contextBudgets", "recommendations",
+                     "hasBloat", "hasWarnings", "thresholds")
+
+    def test_memory_analytics_context_budgets(self, api, base_url):
+        """Context budgets contain all three model tiers."""
+        d = assert_ok(get(api, base_url, "/api/memory-analytics"))
+        budgets = d["contextBudgets"]
+        for key in ("claude_200k", "gpt4_128k", "gemini_1m"):
+            assert key in budgets, f"Missing budget tier '{key}'"
+            assert_keys(budgets[key], "limit", "memoryTokens", "percentUsed", "status")
+
+    def test_memory_analytics_custom_thresholds(self, api, base_url):
+        """Custom warn/crit thresholds are reflected."""
+        d = assert_ok(get(api, base_url, "/api/memory-analytics?warn_kb=4&crit_kb=8"))
+        assert d["thresholds"]["warnKB"] == 4
+        assert d["thresholds"]["critKB"] == 8
+
+    def test_memory_analytics_files_have_status(self, api, base_url):
+        """Each file entry has status (ok/warning/critical)."""
+        d = assert_ok(get(api, base_url, "/api/memory-analytics"))
+        for f in d["files"]:
+            assert_keys(f, "path", "sizeBytes", "sizeKB", "estTokens", "status")
+            assert f["status"] in ("ok", "warning", "critical")
+
+


### PR DESCRIPTION
Closes #301

## What

Upgrades the anomaly detection engine from a single daily-cost check to a full **adaptive multi-signal detection system** that fires alerts (Telegram + webhook + dashboard banner) when agent behavior deviates from rolling baselines.

### New detection signals

| Signal | Default threshold | Alert destination |
|--------|-------------------|-------------------|
| Daily cost spike | >2x 7-day average | banner + Telegram + webhook |
| Per-session cost spike | >2x rolling 7-day session avg | banner + Telegram + webhook |
| Session frequency spike | >5x typical daily session count | banner + Telegram + webhook |

### Configurable thresholds

All multipliers are now user-configurable in the **Alert Rules → Webhook Config** UI:
- Daily cost spike multiplier (default: 2.0x)
- Per-session cost spike multiplier (default: 2.0x)
- Session frequency spike multiplier (default: 5.0x)
- Toggle alerts per signal type independently

### Alert routing

All anomaly signals route through the existing `_dispatch_configured_webhooks()` and `_fire_alert()` pipeline — so they reach Slack, Discord, generic webhooks, and Telegram automatically based on existing config.

## How

- **`_detect_per_session_cost_spikes()`**: Reuses `_compute_session_cost_anomalies()` output, fires `_fire_alert` + webhook for sessions in the last 2h that exceed N×rolling avg
- **`_detect_session_frequency_anomaly()`**: Counts sessions per day from transcript analytics, alerts when today exceeds N×7-day avg
- Both called from `_budget_monitor_loop()` (runs every 60s, with cooldown deduplication via rule_id)
- **`_default_alerts_webhook_config()`**: Extended with 5 new keys; all persisted via existing config file
- **API `/api/alerts/webhook`**: allowed-keys allowlist updated to include new multiplier fields
- **UI**: Alert Rules tab gets new checkboxes + multiplier inputs for session/frequency anomaly detection