### PR TITLE
feat: Add Docker support for easy deployment 🐳

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+ENV/
+env/
+.venv
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Documentation builds
+docs/_build/
+
+# Screenshots (not needed in container)
+screenshots/
+
+# Backup files
+*.bak

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Dockerfile for ClawMetry
+# Quick start: docker build -t clawmetry . && docker run -p 8900:8900 clawmetry
+
+FROM python:3.11-slim
+
+LABEL maintainer="ClawMetry Contributors"
+LABEL description="Real-time observability dashboard for OpenClaw AI agents"
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY dashboard.py .
+COPY setup.py .
+COPY clawmetry/ ./clawmetry/
+
+# Install clawmetry
+RUN pip install --no-cache-dir -e .
+
+# Create directories for OpenClaw integration
+RUN mkdir -p /root/.openclaw /tmp/moltbot
+
+# Expose port
+EXPOSE 8900
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8900/api/health')" || exit 1
+
+# Default command
+CMD ["clawmetry", "--host", "0.0.0.0", "--port", "8900"]

--- a/README.md
+++ b/README.md
@@ -114,11 +114,48 @@ Click any channel node in the Flow to see a live chat bubble view with incoming/
 
 > **Auto-detection:** ClawMetry reads your `~/.openclaw/openclaw.json` and only renders the channels you've actually configured. No manual setup required.
 
+## Docker Deployment
+
+Want to run ClawMetry in a container? No problem! 🐳
+
+**Quick start with Docker:**
+
+```bash
+# Build the image
+docker build -t clawmetry .
+
+# Run with default settings
+docker run -p 8900:8900 clawmetry
+
+# Or with your OpenClaw workspace mounted
+docker run -p 8900:8900 \
+  -v ~/.openclaw:/root/.openclaw \
+  -v /tmp/moltbot:/tmp/moltbot \
+  clawmetry
+```
+
+**Docker Compose example:**
+
+```yaml
+version: '3.8'
+services:
+  clawmetry:
+    build: .
+    ports:
+      - "8900:8900"
+    volumes:
+      - ~/.openclaw:/root/.openclaw:ro
+      - /tmp/moltbot:/tmp/moltbot:ro
+    restart: unless-stopped
+```
+
+> **Note:** When running in Docker, make sure to mount your OpenClaw workspace and log directories so ClawMetry can auto-detect your setup.
+
 ## Requirements
 
 - Python 3.8+
 - Flask (installed automatically via pip)
-- OpenClaw running on the same machine
+- OpenClaw running on the same machine (or mounted volumes for Docker)
 - Linux or macOS
 
 ## Cloud Deployment


### PR DESCRIPTION
Hey there! 👋

First off, thanks for building ClawMetry - it's been super helpful for monitoring my OpenClaw agents. The "see your agent think" philosophy really resonates with me.

**What this PR does:**

I've been wanting to run ClawMetry in a containerized environment (my homelab setup is all Docker-based), so I figured I'd contribute the setup back upstream.

This PR adds:
- 🐳 **Dockerfile** - based on python:3.11-slim, keeps things lightweight
- 🙈 **.dockerignore** - excludes unnecessary stuff to keep image size down
- 📖 **README updates** - Docker deployment instructions with docker-compose example

**Why this is useful:**

- Makes it easier for folks who prefer containerized deployments
- No need to worry about Python version conflicts on the host
- Easy to spin up multiple instances for different environments

**Testing I did:**

Built and tested locally:

docker build -t clawmetry .
docker run -p 8900:8900 -v ~/.openclaw:/root/.openclaw clawmetry

Works great! Dashboard loads fine and auto-detects my OpenClaw workspace.

**One small note:** 

I'm not 100% sure about the healthcheck command - went with a simple HTTP check to /api/health. Let me know if there's a better endpoint to use.

Also, I kept the Dockerfile pretty minimal following the project's philosophy. Happy to adjust if you prefer a different approach.

Cheers! 🦞

---

*P.S. This is my first contribution to ClawMetry - hope I followed the conventions correctly. Feedback welcome!*