### PR TITLE
docs: add star history chart to README

### DIFF
--- a/packages/clawmetry/README.md
+++ b/packages/clawmetry/README.md
@@ -15,3 +15,13 @@ clawmetry
 ```
 
 This package depends on `openclaw-dashboard` and exposes the same dashboard runtime.
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=vivekchand%2Fclawmetry&type=date&legend=top-left">
+ <picture>
+ <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=vivekchand/clawmetry&type=date&theme=dark&legend=top-left" />
+ <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=vivekchand/clawmetry&type=date&legend=top-left" />
+ <img alt="Star History Chart" src="https://api.star-history.com/image?repos=vivekchand/clawmetry&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
Adds Star History chart at the bottom of the README.