### PR TITLE
[RELEASE] v0.12.80 - systemctl fallback for containers, mobile Brain Feed UX

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.78"
+__version__ = "0.12.80"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Changes since v0.12.78

- **fix:** graceful fallback when `systemctl` not available — NemoClaw, Docker, any Linux container (#382). Fixes `FileNotFoundError` on `clawmetry connect/disconnect/status`.
- **fix:** mobile Brain Feed UX — stacked rows, scrollable tabs/filter chips, badge-only agent IDs, 2-line content clamp (#379)
- **feat:** update installation scripts with new ipm-based installer (#355)
- **docs:** star history chart in README (#363-#367)

## Version bump
`0.12.78` → `0.12.80`

> Supersedes #380 (v0.12.79) — close that one after merging this.