### PR TITLE
[RELEASE] v0.12.81 - pure Python process management (no pkill/pgrep)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.80"
+__version__ = "0.12.81"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Changes since v0.12.80

- **fix:** replace `pkill`/`pgrep` with pure Python process management (#384). Fixes `clawmetry connect` / `clawmetry onboard` crashing in NemoClaw and any locked-down Linux sandbox.

## Version bump
`0.12.80` → `0.12.81`