### PR TITLE
[RELEASE] v0.12.82 - NemoClaw policy preset

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.81"
+__version__ = "0.12.82"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Changes since v0.12.81

- **feat:** NemoClaw policy preset — shell script to add ClawMetry as a preset policy to all NemoClaw sandbox profiles on the user's machine (#386)

## Version bump
`0.12.81` → `0.12.82`