### PR TITLE
fix: add NemoClaw detection and preset setup to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,46 +121,13 @@ except Exception:
     echo ""
   fi
 
-  # Step 2: Prompt to install ClawMetry inside a NemoClaw OpenClaw sandbox
-  echo -e "  ${BOLD}Install ClawMetry inside your NemoClaw OpenClaw sandbox?${NC}"
-  echo -e "  ${DIM}This will open the NemoClaw TUI and run:${NC}"
+  echo -e "  ${BOLD}Next: set up ClawMetry inside your NemoClaw OpenClaw sandbox${NC}"
+  echo -e "  ${DIM}Open a NemoClaw sandbox shell and run:${NC}"
+  echo ""
   echo -e "    ${GREEN}python3 -m venv .venv${NC}"
   echo -e "    ${GREEN}.venv/bin/pip install clawmetry${NC}"
   echo -e "    ${GREEN}.venv/bin/clawmetry onboard${NC}"
   echo -e "    ${GREEN}.venv/bin/clawmetry --host 0.0.0.0 --port 8900 &${NC}"
-  echo ""
-
-  if (exec </dev/tty) 2>/dev/null; then
-    printf "  Open NemoClaw + run ClawMetry setup? [Y/n]: " > /dev/tty
-    read -r NEMO_SANDBOX_CHOICE </dev/tty || NEMO_SANDBOX_CHOICE="y"
-  else
-    NEMO_SANDBOX_CHOICE="y"
-  fi
-
-  NEMO_SANDBOX_CHOICE="${NEMO_SANDBOX_CHOICE:-y}"
-  if [[ "$NEMO_SANDBOX_CHOICE" =~ ^[Yy]$ ]] || [ -z "$NEMO_SANDBOX_CHOICE" ]; then
-    echo ""
-    echo -e "  → Opening NemoClaw OpenClaw TUI..."
-    # Run the setup commands inside a nemoclaw shell session
-    nemoclaw exec -- bash -c '
-      set -e
-      echo "  → Creating venv..."
-      python3 -m venv .venv
-      echo "  → Installing ClawMetry..."
-      .venv/bin/pip install clawmetry --quiet
-      echo "  → Running onboard (local mode)..."
-      CLAWMETRY_SKIP_ONBOARD=0 .venv/bin/clawmetry onboard
-      echo "  → Starting ClawMetry dashboard..."
-      .venv/bin/clawmetry --host 0.0.0.0 --port 8900 &
-      echo "  ✓ ClawMetry running at http://localhost:8900"
-    ' || echo -e "  ${DIM}⚠  Setup incomplete. Open NemoClaw manually and run the commands above.${NC}"
-  else
-    echo -e "  ${DIM}Skipped. To set up later, open a NemoClaw sandbox and run:${NC}"
-    echo -e "    python3 -m venv .venv"
-    echo -e "    .venv/bin/pip install clawmetry"
-    echo -e "    .venv/bin/clawmetry onboard"
-    echo -e "    .venv/bin/clawmetry --host 0.0.0.0 --port 8900 &"
-  fi
   echo ""
 fi
 


### PR DESCRIPTION
Adds NemoClaw detection to the one-liner installer.

Flow:
1. Install ClawMetry (unchanged)
2. NEW: Detect if nemoclaw is on PATH — if yes, prompt to apply the ClawMetry preset so sandboxes can reach ClawMetry Cloud
3. Run clawmetry onboard (unchanged)

Previously the NemoClaw preset detection only happened inside clawmetry onboard. This moves it to the installer so users get the full setup in one step.