### PR TITLE
[RELEASE] v0.12.83 - NemoClaw install.sh improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.12.83] — 2026-03-28
+
+### Fixed
+- NemoClaw detection and preset setup in install.sh
+- Show nemoclaw connect + sandbox setup instructions in install.sh
+
 ## v0.12.63 (2026-03-22)
 - fix: robust Ollama detection -- PATH fallback + HTTP ping to localhost:11434
 - feat: sync daemon heartbeat includes ollama status (installed, running, models)


### PR DESCRIPTION
## Problem\n\nE2E health check detected a VERSION_MISMATCH:\n- PyPI: 0.12.82\n- GitHub main: 0.12.83\n\nThe version bump PR (#391) was merged but no `v0.12.83` git tag was created, so the PyPI publish workflow was never triggered.\n\n## Fix\n\nAdds the `[RELEASE]` CHANGELOG entry for v0.12.83. After merging, push the `v0.12.83` tag to trigger PyPI publish:\n\n```bash\ngit tag v0.12.83 $(git rev-parse HEAD)\ngit push origin v0.12.83\n```\n\n## Changes in v0.12.83\n- NemoClaw detection and preset setup in install.sh (#392)\n- Show nemoclaw connect + sandbox setup instructions in install.sh (#393)