### PR TITLE
feat: anomaly alerts panel in Tokens tab — surface cost spikes vs 7-day baseline

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -9257,6 +9257,10 @@ function clawmetryLogout(){
   </div>
   <div class="section-title">💰 Cost Breakdown <span id="usage-cost-info-icon" class="tooltip-info-icon" style="display:none;">i</span></div>
   <div class="card"><table class="usage-table" id="usage-cost-table"><tbody><tr><td colspan="3" style="color:#666;">Loading...</td></tr></tbody></table></div>
+  <div id="usage-anomaly-section" style="display:none;">
+    <div class="section-title">⚠️ Anomaly Alerts <span id="usage-anomaly-badge" style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:10px;background:#7f1d1d;color:#fca5a5;margin-left:8px;"></span></div>
+    <div class="card" id="usage-anomaly-list" style="font-size:13px;"></div>
+  </div>
   <div class="section-title">🧩 Cost By Plugin / Skill</div>
   <div class="card">
     <div style="display:flex;gap:16px;align-items:flex-start;flex-wrap:wrap;">


### PR DESCRIPTION
Closes #304

## What
Adds a dedicated **⚠️ Anomaly Alerts** panel to the Tokens tab that surfaces sessions with cost >2x their rolling 7-day average.

## How
- Panel is hidden when no anomalies exist (no visual noise)
- When anomalies are detected, a section appears with a badge count
- Table shows: session ID, actual cost, rolling avg, spike ratio (color-coded), timestamp
- Ratio colors: amber (2–3x), orange (3–5x), red (5x+)
- Fetches from the existing `/api/usage/anomalies` endpoint — **no backend changes needed**
- Silent fail: if the endpoint is unavailable, panel stays hidden

## Why now
The anomaly detection backend already existed (`_compute_session_cost_anomalies`, `anomaly_daily` budget alert) but there was no dedicated UI surface in the Tokens tab. Users could only see anomaly warnings as small ⚠️ icons on the Sessions tab. This panel makes the signal prominent and actionable.

## Screenshot
The panel appears below the Cost Breakdown table when anomalies are detected, above the Plugin Cost chart.