### PR TITLE
fix: rebase before push in release workflow to avoid race condition

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -69,4 +69,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add dashboard.py
           git commit -m "chore: bump to v${{ steps.bump.outputs.new }} [skip ci]"
+          # Rebase on top of any commits that landed while we were building/publishing
+          git pull --rebase origin main
           git push origin main


### PR DESCRIPTION
## Problem

The E2E test caught a VERSION_MISMATCH: PyPI is on v0.12.82 but `dashboard.py` on `main` reads v0.12.83.

Root cause: the `release-on-merge.yml` workflow's "Commit version bump directly to main" step fails consistently (exit code 1). When the workflow builds and publishes to PyPI, other fix PRs land on `main` in parallel, causing the final `git push` to be rejected as non-fast-forward. The version bump commit never reaches `main`, but PyPI already has the new version.

Run evidence: #388 and #391 both show ✓ Publish to PyPI → ✗ Commit version bump directly to main.

## Fix

Add `git pull --rebase origin main` before the push so the version bump commit is always rebased on top of any concurrent commits before pushing.

## Test

This prevents the workflow from failing due to race conditions between parallel PR merges during release cycles.