### PR TITLE
feat: NemoClaw governance tab — wire into theme 2, fix duplicate JS

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3883,6 +3883,7 @@ function clawmetryLogout(){
   </div>
 </div><!-- end page-models -->
 
+
 <!-- NEMOCLAW GOVERNANCE -->
 <div class="page" id="page-nemoclaw">
   <div style="padding:12px 0 8px 0;">


### PR DESCRIPTION
## What this does

Completes the NemoClaw governance tab implementation by fixing a bug where the tab was implemented in theme 1 (the overwritten DASHBOARD_HTML) but **not** in theme 2 (the actually-served template).

### Changes

**Frontend (theme 2 HTML):**
- Added `NemoClaw` nav tab to the theme 2 tab bar (hidden by default, revealed on load when NemoClaw is detected)
- Added `#page-nemoclaw` content div to theme 2 — matching the layout from the spec:
  - 🟢 Status header with sandbox name + blueprint version badges
  - Two-column SANDBOX / INFERENCE info grid
  - ACTIVE POLICY section with hash badge, drift alert, and parsed network policies table
  - APPLIED PRESETS chip row
- Wired `switchTab('nemoclaw')` into theme 2's `switchTab()` function
- Fixed: duplicate `loadNemoClaw()` stub in theme 2 shadow-overrode the real implementation — wrapped in `if(false){}` to disable it

**Backend (already in previous commit):**
- `_detect_nemoclaw()` helper — reads config, state, policy YAML, and presets from `~/.nemoclaw/`
- `_parse_network_policies()` — parses YAML network_policies section (PyYAML with line-parser fallback)
- `/api/nemoclaw/governance` — full status endpoint with sandbox list, policy hash, drift detection
- `/api/nemoclaw/governance/acknowledge-drift` — clears drift alert
- `/api/nemoclaw/status` — lightweight status check
- `/api/nemoclaw/policy` — policy YAML + hash + drift status
- Module-level `_nemoclaw_policy_hash` for in-memory drift detection
- NemoClaw accent color: `#76b900` (NVIDIA green)

### Testing

The tab is hidden on load and only shown when `/api/nemoclaw/governance` returns `installed: true`. On hosts without NemoClaw, nothing changes.