### PR TITLE
[RELEASE] v0.12.84 - clawmetry uninstall, NemoClaw install.sh detection

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -61,7 +61,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.83"
+__version__ = "0.12.84"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Changes since v0.12.83

- **feat:** `clawmetry uninstall` command — interactive component chooser (daemon, config, logs, venv) with y/N confirmation, matching OpenClaw's uninstall UX (#402)
- **fix:** NemoClaw detection in install.sh — auto-applies ClawMetry preset, shows sandbox connect instructions (#392, #393)
- **fix:** NemoClaw onboarding preset integration (#390)

## Version bump
`0.12.83` → `0.12.84`