### PR TITLE
fix(security): mask encryption key in CLI output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Thumbs.db
 
 # Logs
 *.log
+.clawmetry-fleet.db

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -507,14 +507,14 @@ def _cmd_connect(args) -> None:
     # --key-only: just save config, don't start daemon (for host-side NemoClaw OTP flow)
     if getattr(args, "key_only", False):
         print(f"  API key:      {api_key}")
-        print(f"  Enc key:      {enc_key}")
+        print(f"  Enc key:      {enc_key[:6] + '…' + enc_key[-4:]}")
         print()
         return
 
     # Skip enc key reminder when --enc-key was passed (automated/sandbox use)
     if not _enc_key_arg:
         print("  Keep this secret key safe (like a password):")
-        print(f"  {enc_key}")
+        print(f"  {enc_key[:6] + '…' + enc_key[-4:]}")
         print()
 
     # --no-daemon: skip daemon start (managed by supervisord externally)
@@ -1670,8 +1670,18 @@ def _cmd_update() -> None:
     print("Checking for updates...")
     try:
         result = subprocess.run(
-            [sys.executable, "-m", "pip", "install", "--upgrade", "--break-system-packages", "clawmetry"],
-            capture_output=True, text=True, timeout=120,
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "--break-system-packages",
+                "clawmetry",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
         if result.returncode == 0:
             # Check new version

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
+import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import clawmetry.cli as cli
 
@@ -26,11 +28,44 @@ def test_get_nemoclaw_preset_script_returns_local_helper(monkeypatch, tmp_path):
     assert cli._get_nemoclaw_preset_script() == str(helper)
 
 
+def test_enc_key_masked_in_key_only_output(monkeypatch, capsys):
+    import clawmetry.sync as sync_module
+
+    test_key = "abcd1234efgh5678"
+    masked_key = test_key[:6] + "…" + test_key[-4:]
+    monkeypatch.setattr(cli, "_stop_existing_daemon", lambda: None)
+    monkeypatch.setattr(
+        sync_module, "validate_key", lambda *a, **kw: {"node_id": "test-node"}
+    )
+    monkeypatch.setattr(sync_module, "save_config", lambda *a, **kw: None)
+    monkeypatch.setattr(cli, "_get_api_key_interactive", lambda: "cm_test12345")
+    monkeypatch.setattr(cli, "_verify_key_ownership", lambda *a, **kw: None)
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("socket.gethostname", lambda: "test-host")
+    monkeypatch.setattr(os.path, "exists", lambda p: False)
+
+    class FakeArgs:
+        key = "cm_test12345"
+        enc_key = test_key
+        key_only = True
+        no_daemon = True
+        custom_node_id = None
+        foreground = False
+
+    cli._cmd_connect(FakeArgs())
+
+    out = capsys.readouterr().out
+    assert test_key not in out, "enc_key should not appear unmasked in output"
+    assert masked_key in out, f"enc_key should be masked like api_key, got: {out}"
+
+
 def test_print_nemoclaw_preset_hint_emits_command(monkeypatch, capsys):
     helper = "/tmp/add-nemoclaw-clawmetry-preset.sh"
     monkeypatch.setattr(cli, "_get_nemoclaw_preset_script", lambda: helper)
 
-    cli._print_nemoclaw_preset_hint(lambda text: text, lambda text: text, lambda text: text)
+    cli._print_nemoclaw_preset_hint(
+        lambda text: text, lambda text: text, lambda text: text
+    )
 
     out = capsys.readouterr().out
     assert "NemoClaw detected" in out


### PR DESCRIPTION
## Summary

Mask encryption key when printed to stdout in CLI output to prevent accidental exposure.

## Changes

- Updated CLI print statements to mask encryption key values
- Added proper masking when displaying configuration

## Testing

tests/test_cli.py - verifies encryption key is properly masked in output