### PR TITLE
fix: Add README.md COPY to Dockerfile to fix build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
+COPY README.md .
 COPY dashboard.py .
 COPY setup.py .
 COPY clawmetry/ ./clawmetry/


### PR DESCRIPTION
Closes #594

## What
Fixed a docker build failure where `pip install --no-cache-dir -e .` failed with `FileNotFoundError: [Errno 2] No such file or directory: 'README.md'`.

## Why
The `setup.py` reads `README.md` to set the `long_description` for the package. However, the Dockerfile was copying `setup.py` without copying `README.md` first, causing the build to fail.

## Changes
- Added `COPY README.md .` to the Dockerfile before the `pip install` step

## Testing
- Docker build should now complete successfully
- The fix ensures all files required by `setup.py` are present before installation