### PR TITLE
fix: record session's dominant model, not the last one seen

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1363,12 +1363,19 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                 continue
             try:
                 sid = fpath.stem  # UUID filename = session_id
-                model = ""
                 started_at = ""
                 updated_at = ""
                 total_tokens = 0
                 total_cost = 0.0
                 label = ""
+                # Aggregate model usage across the session — a single session
+                # can span several models (model_change mid-conversation, or
+                # an orchestrator that routes to different backends). Previously
+                # we stored "last model seen," which was arbitrary for multi-
+                # model sessions. Now we keep the per-model token count and
+                # pick the dominant one as the primary.
+                model_tokens: dict = {}
+                last_seen_model = ""
 
                 # Scan session file for metadata, tokens, cost, model
                 # Read head for start info, scan all for usage, tail for end
@@ -1388,23 +1395,33 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                             updated_at = ts
                         etype = ev.get("type", "")
                         if etype == "model_change" and ev.get("modelId"):
-                            model = ev["modelId"]
+                            last_seen_model = ev["modelId"]
                         elif etype == "session" and ev.get("label"):
                             label = ev["label"]
                         elif etype == "message":
                             msg = ev.get("message", {})
+                            msg_model = msg.get("model", "") or last_seen_model
                             usage = msg.get("usage", {})
                             if usage:
-                                total_tokens += int(usage.get("totalTokens", 0))
+                                tks = int(usage.get("totalTokens", 0))
+                                total_tokens += tks
+                                if msg_model and tks:
+                                    model_tokens[msg_model] = model_tokens.get(msg_model, 0) + tks
                                 cost_obj = usage.get("cost", {})
                                 if isinstance(cost_obj, dict):
                                     total_cost += float(cost_obj.get("total", 0))
                                 elif isinstance(cost_obj, (int, float)):
                                     total_cost += float(cost_obj)
-                            # Use last model seen in messages
-                            msg_model = msg.get("model", "")
                             if msg_model:
-                                model = msg_model
+                                last_seen_model = msg_model
+
+                # Primary = model that consumed the most tokens in this session,
+                # with last_seen_model as a tiebreaker for sessions that had a
+                # model_change but no message-level usage yet.
+                if model_tokens:
+                    model = max(model_tokens.items(), key=lambda kv: kv[1])[0]
+                else:
+                    model = last_seen_model
 
                 if model:
                     model_counts[model] = model_counts.get(model, 0) + 1


### PR DESCRIPTION
## Summary
OpenClaw sessions routinely span multiple models (\`model_change\` mid-conversation, or an orchestrator routing different turns to different backends). \`sync_session_metadata\` previously stored "last \`msg.model\` seen" — which is arbitrary for multi-model sessions.

Validated against real OpenClaw JSONLs: **half of my own multi-model sessions were mislabeled**. Example:

| Session | Actual token split | OLD stored | NEW stored |
|---|---|---|---|
| \`02a21657…\` | opus 61% / gpt 29% / sonnet 8% | gpt-5.4 | **claude-opus-4-6** |
| \`02a21657…checkpoint\` | opus 82% / sonnet 11% / gpt 6% | gpt-5.4 | **claude-opus-4-6** |
| \`02a21657…\` | opus 53% / gpt 39% / sonnet 7% | gpt-5.4 | **claude-opus-4-6** |

The dashboard was confidently reporting the wrong primary model because whichever model happened to serve the tail of the transcript won.

## Fix
Build a \`{model → tokens}\` map while parsing the transcript; pick the model that consumed the most tokens as the session's primary. \`last_seen_model\` is retained as a tiebreaker for transcripts that have a \`model_change\` event but no per-message \`usage\` yet (e.g. a brand-new session that's just started).

No schema change — \`sessions.model\` remains a single column. A richer per-model breakdown (store \`{model: tokens, cost}\` as JSON) can follow later as a schema-coordinated change; this one ships today with zero migration.

## Test plan
- [x] Verified fix logic against real JSONLs in \`~/.openclaw/agents/main/sessions/\` — 3 of 6 sampled sessions changed from wrong label to correct dominant model
- [ ] Upload via sync daemon to a test account; confirm dashboard shows the right primary model for known multi-model sessions
- [ ] Single-model sessions still show correctly (regression check — the 3 of 6 that were already correct didn't flip)

## Base / stacking
Opened against \`fix/sync-session-coverage\` (PR #596) since it touches the same parse loop. Once #596 merges to main, this rebases cleanly; until then it stacks on top. Paired server PR (removes broken \`_MODEL_PRICING\` dict + redundant cost-writer path) will land in the cloud repo separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)