### PR TITLE
fix: Overview MODEL badge = dominant model by tokens

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -19889,7 +19889,22 @@ def api_overview():
     except Exception:
         infra["storage"] = "Disk"
 
-    model_name = main.get("model") or "unknown"
+    # Primary model = model that consumed the most tokens across sessions.
+    # "First session's model" is misleading for multi-model users: a tiny
+    # recent glm-5:cloud check-in could eclipse 143M tokens of Opus from
+    # earlier on the same node. Mirror of clawmetry-cloud#313.
+    _mt: dict = {}
+    for _s in sessions:
+        _m = (_s.get("model") or "").strip()
+        if not _m or _m == "—":
+            continue
+        _t = int(_s.get("totalTokens", 0) or 0)
+        if _t > 0:
+            _mt[_m] = _mt.get(_m, 0) + _t
+    if _mt:
+        model_name = max(_mt.items(), key=lambda kv: kv[1])[0]
+    else:
+        model_name = main.get("model") or "unknown"
     return jsonify(
         {
             "model": model_name,


### PR DESCRIPTION
Mirror of vivekchand/clawmetry-cloud#313 for the OSS dashboard.

Same bug as cloud: \`/api/overview\` was picking the \"primary model\" by first-session-after-sort-by-recency. Any small recent session would eclipse the user's dominant model. Observed in prod: account with 143M tokens of Opus (5 sessions) was showing MODEL: glm-5:cloud because 3 tiny glm check-ins happened to be the most recently touched.

Fix: aggregate \`totalTokens\` per model across all sessions, pick max. Fall back to previous logic when no session has token counts yet.

Co-locates with fleet-of-fixes shipped this week:
- clawmetry-cloud#309 started_at + daily bucketing (merged)
- clawmetry-cloud#313 cloud-side MODEL fix (open)
- clawmetry#597 per-session dominant-model attribution (merged)
- clawmetry#607 gateway operator.read scope (agent, open)
- clawmetry#600 cron_state store-on-change (agent, open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)