### PR TITLE
feat: /api/session-timeline — model + thinking annotations (#606)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -25239,6 +25239,11 @@ def api_session_timeline():
     current_level = None
     model_entered_ms = 0
     level_entered_ms = 0
+    # Track the max event timestamp seen — we need it to close out the final
+    # journey segment. Previously we used the last annotation's ts_ms, which
+    # equals model_entered_ms for sessions with exactly one model_change and
+    # gave duration_ms = 0 (surfaced during E2E).
+    last_event_ms = 0
     model_turns: dict = {}  # model -> (turns, tokens)
     model_journey: list = []
     thinking_journey: list = []
@@ -25256,6 +25261,8 @@ def api_session_timeline():
                 t = ev.get('type', '')
                 ts = ev.get('timestamp', '')
                 ts_ms = _parse_ts(ts)
+                if ts_ms and ts_ms > last_event_ms:
+                    last_event_ms = ts_ms
 
                 # Session header (first line) has type='session'
                 if t == 'session' and not started_at:
@@ -25330,8 +25337,10 @@ def api_session_timeline():
     except Exception as e:
         return jsonify({'error': 'parse error: ' + str(e)}), 500
 
-    # Close out final journey segments using the last-seen timestamp
-    last_ts_ms = annotations[-1]['ts_ms'] if annotations else started_at_ms
+    # Close out final journey segments using the session's last event timestamp
+    # (not the last annotation's ts_ms — that's the same as the enter time for
+    # single-segment journeys and gives duration_ms = 0).
+    last_ts_ms = last_event_ms or (annotations[-1]['ts_ms'] if annotations else started_at_ms)
     if current_model and model_entered_ms:
         tr, tk = model_turns.get(current_model, (0, 0))
         model_journey.append({

--- a/dashboard.py
+++ b/dashboard.py
@@ -25175,6 +25175,192 @@ def api_model_attribution():
     })
 
 
+@bp_usage.route('/api/session-timeline')
+def api_session_timeline():
+    """Per-session annotations timeline: model changes + thinking-level changes.
+
+    Powers the "model journey" + thinking-depth overlay on session detail.
+    Query: ?session_id=<sid>
+
+    Response:
+      {
+        "session_id": "...",
+        "started_at": "2026-04-04T19:07:43.297Z",
+        "started_at_ms": ...,
+        "annotations": [
+          {"type": "model_change", "timestamp": "...", "ts_ms": ...,
+           "from_model": "prev", "to_model": "next", "provider": "anthropic"},
+          {"type": "thinking_level_change", "timestamp": "...", "ts_ms": ...,
+           "from_level": "low", "to_level": "medium"},
+          ...
+        ],
+        "model_journey": [
+          {"model": "...", "provider": "...", "entered_ms": ..., "exited_ms": ..., "duration_ms": ..., "turns": N, "tokens": N},
+          ...
+        ],
+        "thinking_journey": [
+          {"level": "medium", "entered_ms": ..., "exited_ms": ..., "duration_ms": ...},
+          ...
+        ]
+      }
+    """
+    sid = (request.args.get('session_id', '') or '').strip()
+    if not sid:
+        return jsonify({'error': 'session_id required'}), 400
+    sessions_dir = SESSIONS_DIR or os.path.expanduser('~/.openclaw/agents/main/sessions')
+    if not os.path.isdir(sessions_dir):
+        return jsonify({'error': 'sessions dir not found'}), 404
+
+    # Find file; accept exact match or prefix (checkpoint files extend the UUID)
+    matches = [
+        f for f in os.listdir(sessions_dir)
+        if f.startswith(sid) and f.endswith('.jsonl')
+        and '.deleted.' not in f and '.reset.' not in f
+    ]
+    if not matches:
+        return jsonify({'error': 'session not found'}), 404
+    fname = sorted(matches)[0]
+    fpath = os.path.join(sessions_dir, fname)
+
+    def _parse_ts(ts):
+        if not ts or not isinstance(ts, str):
+            return 0
+        try:
+            from datetime import datetime as _dt
+            return int(_dt.fromisoformat(ts.replace('Z', '+00:00')).timestamp() * 1000)
+        except Exception:
+            return 0
+
+    annotations: list = []
+    started_at = ''
+    started_at_ms = 0
+    current_model = None
+    current_provider = ''
+    current_level = None
+    model_entered_ms = 0
+    level_entered_ms = 0
+    model_turns: dict = {}  # model -> (turns, tokens)
+    model_journey: list = []
+    thinking_journey: list = []
+
+    try:
+        with open(fpath, 'r', errors='replace') as fh:
+            for raw in fh:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    ev = json.loads(raw)
+                except Exception:
+                    continue
+                t = ev.get('type', '')
+                ts = ev.get('timestamp', '')
+                ts_ms = _parse_ts(ts)
+
+                # Session header (first line) has type='session'
+                if t == 'session' and not started_at:
+                    started_at = ts
+                    started_at_ms = ts_ms
+
+                elif t == 'model_change':
+                    new_model = ev.get('modelId') or ev.get('model') or ''
+                    new_provider = ev.get('provider') or _provider_from_model(new_model)
+                    if new_model:
+                        annotations.append({
+                            'type': 'model_change',
+                            'timestamp': ts,
+                            'ts_ms': ts_ms,
+                            'from_model': current_model or '',
+                            'to_model': new_model,
+                            'provider': new_provider,
+                        })
+                        if current_model and current_model != new_model:
+                            tr, tk = model_turns.get(current_model, (0, 0))
+                            model_journey.append({
+                                'model': current_model,
+                                'provider': current_provider,
+                                'entered_ms': model_entered_ms,
+                                'exited_ms': ts_ms,
+                                'duration_ms': max(0, ts_ms - model_entered_ms),
+                                'turns': tr,
+                                'tokens': tk,
+                            })
+                        current_model = new_model
+                        current_provider = new_provider
+                        model_entered_ms = ts_ms
+
+                elif t == 'thinking_level_change':
+                    new_level = ev.get('thinkingLevel') or ev.get('level') or ''
+                    if new_level != current_level:
+                        annotations.append({
+                            'type': 'thinking_level_change',
+                            'timestamp': ts,
+                            'ts_ms': ts_ms,
+                            'from_level': current_level or '',
+                            'to_level': new_level,
+                        })
+                        if current_level is not None:
+                            thinking_journey.append({
+                                'level': current_level,
+                                'entered_ms': level_entered_ms,
+                                'exited_ms': ts_ms,
+                                'duration_ms': max(0, ts_ms - level_entered_ms),
+                            })
+                        current_level = new_level
+                        level_entered_ms = ts_ms
+
+                elif t == 'custom' and ev.get('customType') == 'model-snapshot':
+                    d = ev.get('data', {}) or {}
+                    m = d.get('modelId') or d.get('model') or ''
+                    if m and current_model is None:
+                        current_model = m
+                        current_provider = d.get('provider') or _provider_from_model(m)
+                        model_entered_ms = ts_ms
+
+                # Assistant turn counting per current model
+                msg = ev.get('message', {}) or {}
+                if isinstance(msg, dict) and msg.get('role') == 'assistant':
+                    m = msg.get('model') or current_model or ''
+                    if m:
+                        tr, tk = model_turns.get(m, (0, 0))
+                        u = msg.get('usage', {}) or {}
+                        tk += int(u.get('totalTokens', 0) or 0)
+                        tr += 1
+                        model_turns[m] = (tr, tk)
+    except Exception as e:
+        return jsonify({'error': 'parse error: ' + str(e)}), 500
+
+    # Close out final journey segments using the last-seen timestamp
+    last_ts_ms = annotations[-1]['ts_ms'] if annotations else started_at_ms
+    if current_model and model_entered_ms:
+        tr, tk = model_turns.get(current_model, (0, 0))
+        model_journey.append({
+            'model': current_model,
+            'provider': current_provider,
+            'entered_ms': model_entered_ms,
+            'exited_ms': last_ts_ms,
+            'duration_ms': max(0, last_ts_ms - model_entered_ms),
+            'turns': tr,
+            'tokens': tk,
+        })
+    if current_level is not None and level_entered_ms:
+        thinking_journey.append({
+            'level': current_level,
+            'entered_ms': level_entered_ms,
+            'exited_ms': last_ts_ms,
+            'duration_ms': max(0, last_ts_ms - level_entered_ms),
+        })
+
+    return jsonify({
+        'session_id': sid,
+        'started_at': started_at,
+        'started_at_ms': started_at_ms,
+        'annotations': annotations,
+        'model_journey': model_journey,
+        'thinking_journey': thinking_journey,
+    })
+
+
 @bp_usage.route('/api/skill-attribution')
 def api_skill_attribution():
     """Per-skill cost attribution with ClawHub integration hooks (GH #308).


### PR DESCRIPTION
OSS-first implementation of vivekchand/clawmetry#606 (mirror of vivekchand/clawmetry-cloud#320).

## What's missing today
Sessions can switch models mid-conversation (\`model_change\` event) and change thinking depth (\`thinking_level_change\`). ClawMetry already aggregates \`model_change\` globally in \`/api/model-attribution\`, but nothing is per-session-timestamped — so there's no way to annotate a session's transcript with *"the agent flipped from Opus to Sonnet at 14:03."* And \`thinking_level_change\` had zero coverage anywhere.

## New endpoint

\`\`\`
GET /api/session-timeline?session_id=<sid>
\`\`\`

Three shapes in one response, each drop-in for a specific UI:

1. **\`annotations[]\`** — flat ordered list of \`model_change\` + \`thinking_level_change\` events with \`timestamp\`, \`ts_ms\`, and from/to values. Plug into a timeline marker renderer.

2. **\`model_journey[]\`** — derived segments: \`[{model, provider, entered_ms, exited_ms, duration_ms, turns, tokens}, …]\`. Plug into a stacked "time in each model" bar. Turns + tokens computed by counting assistant messages between \`model_change\` events, using \`message.usage.totalTokens\` per message.

3. **\`thinking_journey[]\`** — same segment shape for thinking levels.

## Implementation notes
- Handles session-header (\`type: session\`) + \`custom/model-snapshot\` events to infer the initial model before the first explicit \`model_change\`.
- Supports session-id **prefix match** so checkpoint files (\`<uuid>.checkpoint.<uuid>.jsonl\`) resolve correctly.
- Closes out the final \`model_journey\` / \`thinking_journey\` segment at the last-seen annotation time.

## Test plan
- [ ] \`GET /api/session-timeline?session_id=<real_sid>\` returns non-empty \`annotations\` for sessions with model_change events
- [ ] \`model_journey\` durations sum to ≤ session duration
- [ ] \`thinking_journey\` populated for sessions that toggled thinking depth
- [ ] Missing session_id → 404; missing param → 400

## Scope
API only. UI (timeline stripes, stacked journey bar) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)