### PR TITLE
fix: _get_sessions_from_files reports real tokens + most-recent model

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -31593,32 +31593,56 @@ def _get_sessions():
     return _get_sessions_from_files()
 
 
+def _scan_session_aggregates(file_path):
+    """Walk a session JSONL once and return (recent_model, total_tokens).
+
+    Replaces the "file size as totalTokens" heuristic with an actual sum of
+    `message.usage.totalTokens`. `recent_model` = the LAST model actually used
+    in the session (from model_change / model-snapshot / message.model in
+    file order), which is what the MODEL badge on Overview / Flow / Brain
+    should display — those are live-activity surfaces that should reflect
+    "what's running right now," not a historical aggregate.
+    """
+    total_tokens = 0
+    last_seen_model = ""
+    try:
+        with open(file_path, "r", errors="replace") as fh:
+            for raw in fh:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except Exception:
+                    continue
+                t = obj.get("type", "")
+                if t == "model_change":
+                    m = obj.get("modelId") or obj.get("model") or ""
+                    if m:
+                        last_seen_model = m
+                elif t == "custom" and obj.get("customType") == "model-snapshot":
+                    d = obj.get("data", {}) or {}
+                    m = d.get("modelId") or d.get("model") or ""
+                    if m:
+                        last_seen_model = m
+                elif t == "message":
+                    msg = obj.get("message", {}) or {}
+                    if not isinstance(msg, dict):
+                        continue
+                    usage = msg.get("usage", {}) or {}
+                    if isinstance(usage, dict):
+                        total_tokens += int(usage.get("totalTokens", 0) or 0)
+                    msg_model = msg.get("model") or ""
+                    if msg_model:
+                        last_seen_model = msg_model
+    except Exception:
+        pass
+    return (last_seen_model or "unknown", total_tokens)
+
+
 def _get_sessions_from_files():
     """Read active sessions from the session directory (file-based fallback)."""
     now = time.time()
-
-    def _read_session_model_fast(file_path):
-        """Best-effort model extraction from the tail of a session file."""
-        try:
-            lines = []
-            with open(file_path, "r") as f:
-                lines = list(deque(f, maxlen=400))
-                for line in reversed(lines):
-                    try:
-                        obj = json.loads(line.strip())
-                    except Exception:
-                        continue
-                    if obj.get("type") != "message":
-                        continue
-                    msg = obj.get("message", {})
-                    if not isinstance(msg, dict):
-                        continue
-                    model = msg.get("model")
-                    if model:
-                        return model
-        except Exception:
-            pass
-        return "unknown"
 
     sessions = []
     try:
@@ -31638,19 +31662,23 @@ def _get_sessions_from_files():
             fpath = os.path.join(base, fname)
             try:
                 mtime = os.path.getmtime(fpath)
-                size = os.path.getsize(fpath)
                 with open(fpath) as f:
                     first = json.loads(f.readline())
                 sid = fname.replace(".jsonl", "")
+                # Single walk gets the session's most recent model + the real
+                # token count. Previous code used file size as totalTokens,
+                # which gave a bogus number proportional to JSONL bytes not
+                # actual usage.
+                model, total_tokens = _scan_session_aggregates(fpath)
                 sessions.append(
                     {
                         "sessionId": sid,
                         "key": sid[:12] + "...",
                         "displayName": sid[:20],
                         "updatedAt": int(mtime * 1000),
-                        "model": _read_session_model_fast(fpath),
+                        "model": model,
                         "channel": "unknown",
-                        "totalTokens": size,
+                        "totalTokens": total_tokens,
                         "contextTokens": 200000,
                     }
                 )


### PR DESCRIPTION
## Problem
\`_get_sessions_from_files\` was returning garbage for the token count field:

\`\`\`python
"totalTokens": size              # os.path.getsize() in bytes — NOT tokens
\`\`\`

A 6.2 MB JSONL reported \"6,189,959 tokens\" when its real total was ~56 M. This corrupted every downstream consumer of \`sessions[].totalTokens\` — including the Tokens tab aggregate and the Overview TOKENS badge.

The model field was also wrong for multi-model sessions (tail-scan 400 lines → whichever model happened to be in that window).

## Fix
Replace file-size-as-tokens with a single JSONL walk that:
- Sums real \`message.usage.totalTokens\` into \`total_tokens\`
- Tracks the LAST model actually used (\`model_change\` / \`model-snapshot\` / \`message.model\` in file order) → that's "most recent active model," which is the right semantic for the MODEL badge on Overview / Flow / Brain (live-activity surfaces).

Per-session **dominant-by-tokens** model (which was my earlier approach in the now-closed #612 / cloud-#313) is a different concern that belongs on the Tokens tab's byModel breakdown, not on the live MODEL badge.

## Before / after

**Before (garbage):**
\`\`\`
totalTokens values were file sizes (15M "tokens" total vs real 143M)
\`\`\`

**After (real):**
\`\`\`
model=@oi/beta         totalTokens=     160,048   ← most recent
model=gpt-5.4          totalTokens=  56,639,192
model=gpt-5.4          totalTokens=  49,306,486
...
total: 142,995,433 — matches JSONL ground truth exactly
\`\`\`

Overview MODEL badge now shows \`@oi/beta\` (the most recent session's most recent model) — matches "what am I running right now" UX on live surfaces.

## Performance
One JSONL walk per session in the 30-most-recent window (~0.5s for 12×5MB files). Cached in \`_sessions_cache\`, subsequent requests instant.

## Test plan
- [x] Live-tested against local workspace — per-session tokens match JSONL \`message.usage.totalTokens\` sums
- [x] Live-tested Overview MODEL badge — shows most-recent session's most-recent model
- [ ] Regression: session with no usage data returns totalTokens=0 without erroring

## Related
- Supersedes / scope-shrinks the earlier dominant-model-on-Overview approach (closed: #612, clawmetry-cloud#313)
- Per-session dominant-model attribution stays on the sync side (#597, merged) for data-pipeline purposes

🤖 Generated with [Claude Code](https://claude.com/claude-code)