### PR TITLE
feat: Add recent_model to session sync payload

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1472,6 +1472,7 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                         "display_name": label or sid[:8],
                         "status": "completed",
                         "model": model,
+                        "recent_model": last_seen_model or model,
                         "total_tokens": total_tokens,
                         "total_cost": total_cost,
                         "started_at": started_at,


### PR DESCRIPTION
Closes #621

## What
Adds a `recent_model` field to the session sync payload sent to the cloud ingest endpoint.

The cloud MODEL badge on Overview/Flow/Brain is a **live-activity surface** that should show "what is running right now" (most recent active model), not "what consumed the most tokens historically" (dominant model).

## How
- `recent_model`: Most recent active model seen in JSONL file order (model_change / message.model events)
- `model`: Dominant-by-tokens model (for Tokens tab attribution)

This follows the pattern established in #617 for OSS-side session display, extending it to the sync pipeline.

## Cloud Side Required
This PR sends the field. The cloud side needs to:
1. Add `recent_model TEXT` column to sessions table
2. Update `/ingest/sessions` to accept and store `recent_model`
3. Update `/api/cloud/sessions` to return `recent_model`
4. Update dashboard Overview to use `recent_model` for MODEL badge

## Testing
- Field is sent in sync payload
- Falls back to dominant model if no recent model detected
- Backward compatible (cloud ignores unknown fields today)