### PR TITLE
fix: AI Model panel falls back to clawmetry pricing when OpenClaw says $0

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -28684,6 +28684,24 @@ def api_component_brain():
                             if isinstance(cost_data, dict)
                             else 0.0
                         )
+                        # Fallback: if OpenClaw recorded $0 for this turn but
+                        # tokens are non-zero (model not in OpenClaw's pricing
+                        # table, e.g. @oi/beta or local providers), estimate
+                        # from clawmetry's per-provider pricing so the panel
+                        # doesn't lie that the call was free.
+                        if call_cost == 0 and (tokens_in + tokens_out) > 0:
+                            try:
+                                from clawmetry.providers_pricing import estimate_cost_usd
+                                provider = (msg.get("provider")
+                                            or _provider_from_model(model)
+                                            or "anthropic")
+                                est = estimate_cost_usd(
+                                    provider, tokens_in, tokens_out, model
+                                )
+                                if est > 0:
+                                    call_cost = est
+                            except Exception:
+                                pass
 
                         total_input += usage.get("input", 0)
                         total_output += tokens_out


### PR DESCRIPTION
Bug 1 of 4 from user-reported Flow-tab issues. AI Model side panel was showing **COST: \$0.00** against **TOKENS: 9.9K** for a call that clearly consumed tokens.

## Root cause (not really ClawMetry's fault)
OpenClaw doesn't have pricing data for every model. \`@oi/beta\` and several local / community models record \`message.usage.cost.total = 0\` even when the call consumed real tokens. ClawMetry's \`api_component_brain\` faithfully sums whatever's there, so it inherits the lie.

Verified by reading the actual JSONL message:
\`\`\`
2026-04-15T07:25:03  model=@oi/beta
usage={input:9904, output:34, totalTokens:9938,
       cost:{total:0}}
\`\`\`

## Fix
When \`call_cost == 0\` but \`tokens > 0\`, fall back to the per-provider pricing table at \`clawmetry/providers_pricing.py\` (the same one the cloud sync uses). Provider inference: prefer \`message.provider\`, then \`_provider_from_model(model)\`, then default to \`anthropic\` baseline. Bracketed in try/except so a missing module never breaks the panel.

## Live test
The 9904 in + 34 out @oi/beta turn from this morning's E2E:
- Before: \`COST: \$0.00\`
- After: \`COST: \$0.01\`

## Test plan
- [x] @oi/beta turn — fallback fires, returns ~\$0.01
- [ ] Known-model turn (e.g. claude-opus-4-6) with non-zero cost — fallback skipped, original cost preserved
- [ ] Local Ollama model — fallback fires, returns small estimate

Bug #1 of 4 in the user-reported Flow-tab UX series. Companions: #624 (gateway log), #625 (real hardware). Coming: #2 (dynamic channels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)