### PR TITLE
fix: sync daemon NameError on every session file scan

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -883,9 +883,14 @@ def sync_sessions(config: dict, state: dict, paths: dict) -> int:
                 )
                 total += len(batch)
 
-            last_ids[fname] = (
-                len(all_lines) if total < MAX_EVENTS_PER_CYCLE else line_cursor
-            )
+            # line_cursor tracks our furthest position in the file (inclusive
+            # of lines we skipped as blank/malformed), so it is always the
+            # correct "next start offset". The previous `len(all_lines)` ref
+            # was stale from a pre-islice implementation that read the whole
+            # file — it raised NameError on every call, spamming warnings
+            # and preventing the cursor from advancing past the last BATCH_SIZE
+            # flush.
+            last_ids[fname] = line_cursor
 
         except Exception as e:
             log.warning(f"Session sync error ({fname}): {e}")


### PR DESCRIPTION
## Summary

`sync_sessions()` referenced `all_lines` at line 887 but the variable was never defined in the function's current scope — the body was refactored in 091bb8fc to use `islice(f, last_line, None)` producing only `new_lines`. Every call raised `NameError`, was caught by the outer try/except, and logged:

```
WARNING Session sync error (<fname>): name 'all_lines' is not defined
```

## Impact

Pre-fix: ~100-200 warnings/minute polluted sync.log. The cursor never advanced past the last BATCH_SIZE flush, so the trailing lines of every session re-uploaded every cycle. UPSERT absorbed the duplicates server-side, so no data corruption — just wasted bandwidth + CPU + operator noise.

## Fix

Use `line_cursor` — which tracks the furthest scanned position (inclusive of skipped blank/malformed lines). Equivalent to the original `len(all_lines)` intent for a fully-scanned file.

## How this surfaced

E2E cloud-sync verification after the dashboard.py routes/ refactor completed. Noticed thousands of warnings in `~/.clawmetry/sync.log`.

## Test plan

- [x] Kill old daemon, start fresh: `python3 -m clawmetry.sync > /tmp/sync.log 2>&1 &`
- [x] Wait 3 cycles
- [x] `grep -c all_lines /tmp/sync.log` → 0
- [x] `Synced N events, 0 log lines, 0 memory files, 0 crons, 0 session rows` lines appear
- [x] Cloud dashboard still shows fresh data (last sync <60s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)