### PR TITLE
refactor: extract helpers/pricing.py (Phase 6.1 — first helper)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -67,6 +67,15 @@ from flask import (
 # truth for module-level helpers — see routes/sessions.py for the pattern.
 from routes.sessions import bp_sessions
 from routes.brain import bp_brain
+
+# Module-level helpers extracted to helpers/*.py (Phase 6 modularisation).
+# Re-exported here so existing `_d.<name>` references in routes/*.py keep
+# working without code changes. Over time, route modules will import from
+# helpers/ directly and these re-exports will be retired.
+from helpers.pricing import (  # noqa: F401 — re-export for routes/
+    _provider_from_model,
+    _infer_provider_from_model,
+)
 from routes.usage import bp_usage
 from routes.crons import bp_crons
 from routes.health import bp_health
@@ -19646,22 +19655,7 @@ def _find_log_file(ds):
     return None
 
 
-def _infer_provider_from_model(model_name):
-    """Best-effort provider inference for display only."""
-    m = (model_name or "").lower()
-    if not m:
-        return "unknown"
-    if "claude" in m:
-        return "anthropic"
-    if "grok" in m or "x-ai" in m or m.startswith("xai"):
-        return "xai"
-    if "gpt" in m or "o1" in m or "o3" in m or "o4" in m:
-        return "openai"
-    if "gemini" in m:
-        return "google"
-    if "llama" in m or "mistral" in m or "qwen" in m or "deepseek" in m:
-        return "local/other"
-    return "unknown"
+# _infer_provider_from_model moved to helpers/pricing.py (re-exported above)
 
 
 # (4 route handlers moved to routes/overview.py: /api/timeline,
@@ -19877,19 +19871,7 @@ def _load_openclaw_config_cached():
     return _openclaw_cfg_cache
 
 
-def _provider_from_model(model_name):
-    m = str(model_name or "").lower()
-    if m.startswith("openai/") or "gpt" in m or "codex" in m or m.startswith("o1"):
-        return "openai"
-    if m.startswith("anthropic/") or "claude" in m:
-        return "anthropic"
-    if m.startswith("google/") or "gemini" in m:
-        return "google"
-    if m.startswith("openrouter/"):
-        return "openrouter"
-    if m.startswith("xai/") or "grok" in m:
-        return "xai"
-    return "unknown"
+# _provider_from_model moved to helpers/pricing.py (re-exported above)
 
 
 def _provider_has_api_key(provider):

--- a/helpers/pricing.py
+++ b/helpers/pricing.py
@@ -1,0 +1,55 @@
+"""
+helpers/pricing.py — Pure helpers for mapping model names to providers.
+
+Extracted from dashboard.py as Phase 6.1 of the incremental modularisation
+(first move out of the module-level helper bag). These functions have no
+module-level state and no cross-module dependencies — trivially safe to move.
+
+Re-exported from dashboard.py so existing `_d._provider_from_model(...)`
+calls in `routes/*.py` keep working without code changes there.
+"""
+
+
+def _provider_from_model(model_name):
+    """Strict provider mapping — used for pricing table lookups.
+
+    Prefix and substring match: `openai/`, `anthropic/`, `google/`,
+    `openrouter/`, `xai/`; substring fallbacks for `gpt`, `codex`, `o1`,
+    `claude`, `gemini`, `grok`.
+    """
+    m = str(model_name or "").lower()
+    if m.startswith("openai/") or "gpt" in m or "codex" in m or m.startswith("o1"):
+        return "openai"
+    if m.startswith("anthropic/") or "claude" in m:
+        return "anthropic"
+    if m.startswith("google/") or "gemini" in m:
+        return "google"
+    if m.startswith("openrouter/"):
+        return "openrouter"
+    if m.startswith("xai/") or "grok" in m:
+        return "xai"
+    return "unknown"
+
+
+def _infer_provider_from_model(model_name):
+    """Best-effort provider inference for display only.
+
+    Looser than `_provider_from_model` — matches substrings so
+    `claude-3-5-sonnet` → anthropic without needing a prefix. Also
+    recognises `local/other` for open-weights families (llama, mistral,
+    qwen, deepseek).
+    """
+    m = (model_name or "").lower()
+    if not m:
+        return "unknown"
+    if "claude" in m:
+        return "anthropic"
+    if "grok" in m or "x-ai" in m or m.startswith("xai"):
+        return "xai"
+    if "gpt" in m or "o1" in m or "o3" in m or "o4" in m:
+        return "openai"
+    if "gemini" in m:
+        return "google"
+    if "llama" in m or "mistral" in m or "qwen" in m or "deepseek" in m:
+        return "local/other"
+    return "unknown"


### PR DESCRIPTION
## Summary
Start of the helpers/ migration flagged in CLAUDE.md ("Helpers will migrate to helpers/ over time"). Moves two pure provider-classification helpers out of dashboard.py's module-level bag into helpers/pricing.py. Re-exported from dashboard.py so `_d.<name>` references in routes/*.py keep working without code changes.

## What moved
- `_provider_from_model(model_name)` — strict prefix/substring match (pricing lookups)
- `_infer_provider_from_model(model_name)` — looser display-only inference

## Why these first
Both are pure functions with zero module-level dependencies (no state, no I/O). Safest possible first move — establishes the re-export pattern for future helper extractions.

## E2E
- 6 unit assertions on `helpers/pricing.py` (openai/anthropic/xai/google/unknown/local-other)
- 35/35 API endpoints return 200 across every tab + all 13 route modules
- Zero tracebacks in server log

## Test plan
- [ ] CI green across 3 OS matrix
- [ ] Endpoints using the helpers (overview.provider, usage.modelBreakdown, component/tool) populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)