### PR TITLE
refactor: extract helpers/hardware.py (Phase 6.4)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -87,6 +87,7 @@ from helpers.streams import (  # noqa: F401 — re-export for routes/
     _acquire_stream_slot,
     _release_stream_slot,
 )
+from helpers.hardware import _detect_host_hardware  # noqa: F401 — re-export for routes/
 from routes.usage import bp_usage
 from routes.crons import bp_crons
 from routes.health import bp_health
@@ -148,88 +149,7 @@ import platform as _platform
 # _grep_log_file, _tail_lines, _get_log_dirs moved to helpers/logs.py (re-exported above)
 
 
-def _detect_host_hardware():
-    """Return real CPU / cores / RAM / backend for the current host.
-
-    Used by the Cost Optimizer panel as a fallback when llmfit isn't
-    installed or doesn't return a `system` block. Replaces the previous
-    "Apple M2 Pro / 12 cores / 32 GB" hardcoded fallback that misrepresented
-    Linux x86 boxes.
-    """
-    cpu = "Unknown CPU"
-    cores = os.cpu_count() or 0
-    ram_gb = 0
-    backend = "CPU"
-    try:
-        import subprocess as _sp
-        if sys.platform == "darwin":
-            try:
-                cpu = _sp.run(
-                    ["sysctl", "-n", "machdep.cpu.brand_string"],
-                    capture_output=True, text=True, timeout=2,
-                ).stdout.strip() or cpu
-            except Exception:
-                pass
-            try:
-                memb = _sp.run(
-                    ["sysctl", "-n", "hw.memsize"],
-                    capture_output=True, text=True, timeout=2,
-                ).stdout.strip()
-                if memb.isdigit():
-                    ram_gb = round(int(memb) / (1024 ** 3))
-            except Exception:
-                pass
-            if any(s in cpu for s in ("M1", "M2", "M3", "M4", "Apple")):
-                backend = "Apple Metal (unified)"
-        elif sys.platform.startswith("linux"):
-            try:
-                with open("/proc/cpuinfo") as _f:
-                    for line in _f:
-                        if line.lower().startswith("model name"):
-                            cpu = line.split(":", 1)[1].strip()
-                            break
-            except Exception:
-                pass
-            try:
-                with open("/proc/meminfo") as _f:
-                    for line in _f:
-                        if line.startswith("MemTotal:"):
-                            kb = int(line.split()[1])
-                            ram_gb = round(kb / (1024 ** 2))
-                            break
-            except Exception:
-                pass
-            try:
-                if _sp.run(["which", "nvidia-smi"], capture_output=True, timeout=1).returncode == 0:
-                    backend = "NVIDIA CUDA"
-            except Exception:
-                pass
-        elif sys.platform == "win32":
-            try:
-                cpu_out = _sp.run(
-                    ["wmic", "cpu", "get", "name", "/value"],
-                    capture_output=True, text=True, timeout=3,
-                ).stdout
-                for line in cpu_out.splitlines():
-                    if line.startswith("Name="):
-                        cpu = line.split("=", 1)[1].strip()
-                        break
-            except Exception:
-                pass
-            try:
-                mem = _sp.run(
-                    ["wmic", "computersystem", "get", "TotalPhysicalMemory", "/value"],
-                    capture_output=True, text=True, timeout=3,
-                ).stdout
-                for line in mem.splitlines():
-                    if line.startswith("TotalPhysicalMemory="):
-                        ram_gb = round(int(line.split("=", 1)[1].strip()) / (1024 ** 3))
-                        break
-            except Exception:
-                pass
-    except Exception:
-        pass
-    return {"cpu": cpu, "cores": cores, "ram_gb": ram_gb, "backend": backend}
+# _detect_host_hardware moved to helpers/hardware.py (re-exported above)
 
 
 _CURRENT_PLATFORM = _platform.system().lower()
@@ -6014,88 +5934,7 @@ import platform as _platform
 # _grep_log_file, _tail_lines, _get_log_dirs moved to helpers/logs.py (re-exported above)
 
 
-def _detect_host_hardware():
-    """Return real CPU / cores / RAM / backend for the current host.
-
-    Used by the Cost Optimizer panel as a fallback when llmfit isn't
-    installed or doesn't return a `system` block. Replaces the previous
-    "Apple M2 Pro / 12 cores / 32 GB" hardcoded fallback that misrepresented
-    Linux x86 boxes.
-    """
-    cpu = "Unknown CPU"
-    cores = os.cpu_count() or 0
-    ram_gb = 0
-    backend = "CPU"
-    try:
-        import subprocess as _sp
-        if sys.platform == "darwin":
-            try:
-                cpu = _sp.run(
-                    ["sysctl", "-n", "machdep.cpu.brand_string"],
-                    capture_output=True, text=True, timeout=2,
-                ).stdout.strip() or cpu
-            except Exception:
-                pass
-            try:
-                memb = _sp.run(
-                    ["sysctl", "-n", "hw.memsize"],
-                    capture_output=True, text=True, timeout=2,
-                ).stdout.strip()
-                if memb.isdigit():
-                    ram_gb = round(int(memb) / (1024 ** 3))
-            except Exception:
-                pass
-            if any(s in cpu for s in ("M1", "M2", "M3", "M4", "Apple")):
-                backend = "Apple Metal (unified)"
-        elif sys.platform.startswith("linux"):
-            try:
-                with open("/proc/cpuinfo") as _f:
-                    for line in _f:
-                        if line.lower().startswith("model name"):
-                            cpu = line.split(":", 1)[1].strip()
-                            break
-            except Exception:
-                pass
-            try:
-                with open("/proc/meminfo") as _f:
-                    for line in _f:
-                        if line.startswith("MemTotal:"):
-                            kb = int(line.split()[1])
-                            ram_gb = round(kb / (1024 ** 2))
-                            break
-            except Exception:
-                pass
-            try:
-                if _sp.run(["which", "nvidia-smi"], capture_output=True, timeout=1).returncode == 0:
-                    backend = "NVIDIA CUDA"
-            except Exception:
-                pass
-        elif sys.platform == "win32":
-            try:
-                cpu_out = _sp.run(
-                    ["wmic", "cpu", "get", "name", "/value"],
-                    capture_output=True, text=True, timeout=3,
-                ).stdout
-                for line in cpu_out.splitlines():
-                    if line.startswith("Name="):
-                        cpu = line.split("=", 1)[1].strip()
-                        break
-            except Exception:
-                pass
-            try:
-                mem = _sp.run(
-                    ["wmic", "computersystem", "get", "TotalPhysicalMemory", "/value"],
-                    capture_output=True, text=True, timeout=3,
-                ).stdout
-                for line in mem.splitlines():
-                    if line.startswith("TotalPhysicalMemory="):
-                        ram_gb = round(int(line.split("=", 1)[1].strip()) / (1024 ** 3))
-                        break
-            except Exception:
-                pass
-    except Exception:
-        pass
-    return {"cpu": cpu, "cores": cores, "ram_gb": ram_gb, "backend": backend}
+# _detect_host_hardware moved to helpers/hardware.py (re-exported above)
 
 
 _CURRENT_PLATFORM = _platform.system().lower()

--- a/helpers/hardware.py
+++ b/helpers/hardware.py
@@ -1,0 +1,96 @@
+"""
+helpers/hardware.py — Real host hardware detection (CPU / cores / RAM / backend).
+
+Extracted from dashboard.py as Phase 6.4. Used by routes/infra.py as the
+Cost Optimizer panel's fallback when llmfit isn't installed or doesn't
+return a `system` block. Replaced the previous hardcoded "Apple M2 Pro /
+12 cores / 32 GB" that misrepresented Linux x86 boxes (PR #625).
+
+No module-level state. Pure cross-platform detection via sysctl (macOS),
+/proc (Linux), wmic (Windows).
+"""
+
+import os
+import sys
+
+
+def _detect_host_hardware():
+    """Return real CPU / cores / RAM / backend for the current host.
+
+    Returns dict: {cpu, cores, ram_gb, backend}. Falls back gracefully to
+    defaults on any tool failure — never raises.
+    """
+    cpu = "Unknown CPU"
+    cores = os.cpu_count() or 0
+    ram_gb = 0
+    backend = "CPU"
+    try:
+        import subprocess as _sp
+        if sys.platform == "darwin":
+            try:
+                cpu = _sp.run(
+                    ["sysctl", "-n", "machdep.cpu.brand_string"],
+                    capture_output=True, text=True, timeout=2,
+                ).stdout.strip() or cpu
+            except Exception:
+                pass
+            try:
+                memb = _sp.run(
+                    ["sysctl", "-n", "hw.memsize"],
+                    capture_output=True, text=True, timeout=2,
+                ).stdout.strip()
+                if memb.isdigit():
+                    ram_gb = round(int(memb) / (1024 ** 3))
+            except Exception:
+                pass
+            if any(s in cpu for s in ("M1", "M2", "M3", "M4", "Apple")):
+                backend = "Apple Metal (unified)"
+        elif sys.platform.startswith("linux"):
+            try:
+                with open("/proc/cpuinfo") as _f:
+                    for line in _f:
+                        if line.lower().startswith("model name"):
+                            cpu = line.split(":", 1)[1].strip()
+                            break
+            except Exception:
+                pass
+            try:
+                with open("/proc/meminfo") as _f:
+                    for line in _f:
+                        if line.startswith("MemTotal:"):
+                            kb = int(line.split()[1])
+                            ram_gb = round(kb / (1024 ** 2))
+                            break
+            except Exception:
+                pass
+            try:
+                if _sp.run(["which", "nvidia-smi"], capture_output=True, timeout=1).returncode == 0:
+                    backend = "NVIDIA CUDA"
+            except Exception:
+                pass
+        elif sys.platform == "win32":
+            try:
+                cpu_out = _sp.run(
+                    ["wmic", "cpu", "get", "name", "/value"],
+                    capture_output=True, text=True, timeout=3,
+                ).stdout
+                for line in cpu_out.splitlines():
+                    if line.startswith("Name="):
+                        cpu = line.split("=", 1)[1].strip()
+                        break
+            except Exception:
+                pass
+            try:
+                mem = _sp.run(
+                    ["wmic", "computersystem", "get", "TotalPhysicalMemory", "/value"],
+                    capture_output=True, text=True, timeout=3,
+                ).stdout
+                for line in mem.splitlines():
+                    if line.startswith("TotalPhysicalMemory="):
+                        ram_gb = round(int(line.split("=", 1)[1].strip()) / (1024 ** 3))
+                        break
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return {"cpu": cpu, "cores": cores, "ram_gb": ram_gb, "backend": backend}


### PR DESCRIPTION
## Summary
Phase 6.4 — move `_detect_host_hardware()` out of dashboard.py. Pure cross-platform detection via sysctl (macOS), /proc (Linux), wmic (Windows). Returns `{cpu, cores, ram_gb, backend}`.

Call sites:
- `routes/infra.py:548` — cost-optimizer panel fallback
- `routes/infra.py:689` — automation-analysis system block

Re-exported from dashboard.py; no route changes needed.

## Context
This function replaced a hardcoded `Apple M2 Pro / 12 / 32 GB` fallback in PR #625 after user caught it ("is anything hardcoded here? like apple m2?"). It happened to match the reporter's MacBook so nobody noticed locally, but misrepresented every Linux/Windows install.

## E2E
- Unit call: live detection on this Mac returns `Apple M2 Pro, 12, 32, Apple Metal (unified)` (real sysctl output, not the old hardcoded values)
- `/api/cost-optimizer` returns `system.cpu=Apple M2 Pro, cores=12, ram_gb=32.0, backend=Apple Metal (unified)`
- `/api/component/machine` returns real Hostname/IP/CPU/Cores
- 39/39 endpoints 200
- Zero tracebacks

## Sizes
- dashboard.py: **−164 lines** (two identical ~80-line duplicates removed + 1-line re-export)
- helpers/hardware.py: new (96 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)