### PR TITLE
refactor: templates/ plumbing + delete dup page-logs div (Phase 7.3A)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include static *
 recursive-include helpers *.py
 recursive-include routes *.py
+recursive-include templates *.html
 include CLAUDE.md
 include ARCHITECTURE.md
 include CHANGELOG.md

--- a/dashboard.py
+++ b/dashboard.py
@@ -9173,34 +9173,6 @@ DASHBOARD_HTML = r"""
   </div>
 </div>
 
-<div class="page" id="page-logs">
-  <div class="refresh-bar" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
-    <button class="refresh-btn" onclick="loadLogs()">&#8635; Refresh</button>
-    <label style="font-size:12px;color:var(--text-secondary);">Lines:
-      <input id="log-lines" type="number" value="200" min="10" max="2000" step="10"
-        style="width:60px;margin-left:4px;padding:3px 6px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:12px;">
-    </label>
-    <input id="log-filter" type="text" placeholder="Filter logs…" oninput="filterLogLines()"
-      style="padding:5px 10px;border-radius:7px;border:1px solid var(--border-primary);background:var(--bg-secondary);color:var(--text-primary);font-size:12px;width:180px;">
-    <div style="display:flex;gap:4px;flex-wrap:wrap;">
-      <button class="time-btn active" id="log-filter-all"   onclick="setLogLevel('all',this)">All</button>
-      <button class="time-btn"        id="log-filter-info"  onclick="setLogLevel('info',this)">Info</button>
-      <button class="time-btn"        id="log-filter-warn"  onclick="setLogLevel('warn',this)">Warn</button>
-      <button class="time-btn"        id="log-filter-error" onclick="setLogLevel('error',this)">Error</button>
-    </div>
-    <label style="display:flex;align-items:center;gap:6px;font-size:12px;color:var(--text-secondary);cursor:pointer;margin-left:auto;">
-      <input type="checkbox" id="log-autoscroll" checked> Auto-scroll
-    </label>
-    <span id="log-stream-status" style="font-size:11px;color:var(--text-muted);">&#9679; Connecting…</span>
-  </div>
-  <div class="card" style="padding:0;overflow:hidden;margin-top:8px;">
-    <div id="logs-full"
-      style="font-family:monospace;font-size:12px;padding:12px 16px;max-height:calc(100vh - 180px);overflow-y:auto;background:var(--bg-secondary);border-radius:8px;">
-      <div style="color:var(--text-muted);text-align:center;padding:24px;">Loading logs…</div>
-    </div>
-  </div>
-</div>
-
 <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 </div> <!-- end zoom-wrapper -->
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,10 @@
+# templates/
+
+Jinja2 HTML templates loaded by Flask via the auto-configured `template_folder`.
+Currently empty — the full dashboard is still rendered from the embedded
+`DASHBOARD_HTML` string in `dashboard.py` via `render_template_string`.
+
+Phase 7.3 scaffolding for the per-tab HTML split:
+- `tabs/*.html`      — per-tab containers (overview, flow, brain, …)
+- `partials/*.html`  — shared UI (modals, onboarding, footer, secret-key)
+- `dashboard.html`   — top-level layout once we pivot from string to file


### PR DESCRIPTION
## Summary
Preparatory plumbing for the per-tab HTML split (Phase 7.3). Two small, orthogonal changes in one PR:

### 1. `templates/` scaffolding
- New `templates/` directory with a README documenting intent (tabs/, partials/, dashboard.html once the layout pivots off the embedded string)
- `MANIFEST.in` gets `recursive-include templates *.html` so pip sdist ships the tree
- Flask's `Flask(__name__)` already auto-configures `template_folder='templates'` — no wiring needed

Currently empty. Subsequent PRs (7.3B+) populate this with extracted per-tab templates.

### 2. Delete duplicate `<div id="page-logs">`
Found during scouting — two byte-identical 28-line `page-logs` blocks at lines 9148 + 9176. `#log-lines`, `#log-filter`, `#logs-full`, `#log-stream-status`, `#log-autoscroll` all appeared twice in the rendered DOM, breaking `getElementById` for every copy after the first.

Verified byte-identical via `diff`, removed the second copy.

## E2E — all green
- Rendered HTML: `page-logs` count **2 → 1**; all duplicated ids **2 → 1** each
- `/api/logs`: 200, 3 lines returned
- `/static/js/app.js`: 200, 449 KB (unaffected)
- 35/35 API endpoints + main page still 200
- Zero tracebacks

## Sizes
- dashboard.py: 15,529 → **15,501 (-28)**
- templates/: new (README only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)