### PR TITLE
refactor: format templates for human readability (Phase 8.2)

### DIFF
--- a/templates/partials/banners.html
+++ b/templates/partials/banners.html
@@ -1,36 +1,150 @@
 <!-- Alert Banner -->
-<div id="alert-banner" style="display:none;padding:10px 16px;background:var(--bg-error);border-bottom:2px solid var(--text-error);color:var(--text-error);font-size:13px;font-weight:600;display:none;align-items:center;gap:10px;">
+<div id="alert-banner" style="
+  display:none;
+  padding:10px 16px;
+  background:var(--bg-error);
+  border-bottom:2px solid var(--text-error);
+  color:var(--text-error);
+  font-size:13px;
+  font-weight:600;
+  display:none;
+  align-items:center;
+  gap:10px;
+  ">
   <span style="font-size:18px;">&#9888;&#65039;</span>
   <span id="alert-banner-msg" style="flex:1;"></span>
-  <button onclick="ackAllAlerts()" style="background:var(--text-error);color:#fff;border:none;border-radius:6px;padding:4px 12px;font-size:12px;cursor:pointer;font-weight:600;">Dismiss</button>
-  <button id="alert-resume-btn" onclick="resumeGateway()" style="display:none;background:#16a34a;color:#fff;border:none;border-radius:6px;padding:4px 12px;font-size:12px;cursor:pointer;font-weight:600;">Resume Gateway</button>
+  <button onclick="ackAllAlerts()" style="
+    background:var(--text-error);
+    color:#fff;
+    border:none;
+    border-radius:6px;
+    padding:4px 12px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    ">Dismiss</button>
+  <button id="alert-resume-btn" onclick="resumeGateway()" style="
+    display:none;
+    background:#16a34a;
+    color:#fff;
+    border:none;
+    border-radius:6px;
+    padding:4px 12px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    ">Resume Gateway</button>
 </div>
 
 <!-- Auto-Pause Banner -->
-<div id="paused-banner" style="display:none;padding:10px 16px;background:#7f1d1d;border-bottom:2px solid #ef4444;color:#fecaca;font-size:13px;font-weight:700;align-items:center;gap:10px;">
+<div id="paused-banner" style="
+  display:none;
+  padding:10px 16px;
+  background:#7f1d1d;
+  border-bottom:2px solid #ef4444;
+  color:#fecaca;
+  font-size:13px;
+  font-weight:700;
+  align-items:center;
+  gap:10px;
+  ">
   <span style="font-size:18px;">⏸</span>
   <span id="paused-banner-msg" style="flex:1;"></span>
-  <button onclick="dismissPausedBanner()" style="background:#991b1b;color:#fff;border:none;border-radius:6px;padding:4px 12px;font-size:12px;cursor:pointer;font-weight:600;">Dismiss</button>
+  <button onclick="dismissPausedBanner()" style="
+    background:#991b1b;
+    color:#fff;
+    border:none;
+    border-radius:6px;
+    padding:4px 12px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    ">Dismiss</button>
 </div>
 
 <!-- Upgrade Impact Banner -->
-<div id="upgrade-banner" style="display:none;padding:10px 16px;background:linear-gradient(90deg,#1e3a5f 0%,#1a1a2e 100%);border-bottom:2px solid #3b82f6;color:#93c5fd;font-size:13px;font-weight:500;align-items:center;gap:10px;">
+<div id="upgrade-banner" style="
+  display:none;
+  padding:10px 16px;
+  background:linear-gradient(90deg,#1e3a5f 0%,#1a1a2e 100%);
+  border-bottom:2px solid #3b82f6;
+  color:#93c5fd;
+  font-size:13px;
+  font-weight:500;
+  align-items:center;
+  gap:10px;
+  ">
   <span style="font-size:16px;">&#128640;</span>
   <span id="upgrade-banner-msg" style="flex:1;"></span>
-  <button onclick="switchTab('version-impact')" style="background:#3b82f6;color:#fff;border:none;border-radius:6px;padding:4px 12px;font-size:12px;cursor:pointer;font-weight:600;">View Details</button>
-  <button onclick="dismissUpgradeBanner()" style="background:transparent;color:#93c5fd;border:1px solid #3b82f680;border-radius:6px;padding:4px 10px;font-size:11px;cursor:pointer;">Dismiss</button>
+  <button onclick="switchTab('version-impact')" style="
+    background:#3b82f6;
+    color:#fff;
+    border:none;
+    border-radius:6px;
+    padding:4px 12px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    ">View Details</button>
+  <button onclick="dismissUpgradeBanner()" style="
+    background:transparent;
+    color:#93c5fd;
+    border:1px solid #3b82f680;
+    border-radius:6px;
+    padding:4px 10px;
+    font-size:11px;
+    cursor:pointer;
+    ">Dismiss</button>
 </div>
 
 <!-- Heartbeat Gap Banner -->
-<div id="heartbeat-banner" style="display:none;padding:10px 16px;border-bottom:2px solid #f59e0b;font-size:13px;font-weight:600;align-items:center;gap:10px;background:#451a03;color:#fbbf24;">
+<div id="heartbeat-banner" style="
+  display:none;
+  padding:10px 16px;
+  border-bottom:2px solid #f59e0b;
+  font-size:13px;
+  font-weight:600;
+  align-items:center;
+  gap:10px;
+  background:#451a03;
+  color:#fbbf24;
+  ">
   <span style="font-size:18px;">&#x1F494;</span>
   <span id="heartbeat-banner-msg" style="flex:1;"></span>
-  <button onclick="document.getElementById('heartbeat-banner').style.display='none'" style="background:#92400e;color:#fef3c7;border:none;border-radius:6px;padding:4px 12px;font-size:12px;cursor:pointer;font-weight:600;">Dismiss</button>
+  <button onclick="document.getElementById('heartbeat-banner').style.display='none'" style="
+    background:#92400e;
+    color:#fef3c7;
+    border:none;
+    border-radius:6px;
+    padding:4px 12px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    ">Dismiss</button>
 </div>
 
 <!-- Budget Cap Banner -->
-<div id="budget-cap-banner" style="display:none;padding:10px 16px;border-bottom:2px solid #f59e0b;font-size:13px;font-weight:600;align-items:center;gap:10px;background:#3f2a06;color:#fbbf24;">
+<div id="budget-cap-banner" style="
+  display:none;
+  padding:10px 16px;
+  border-bottom:2px solid #f59e0b;
+  font-size:13px;
+  font-weight:600;
+  align-items:center;
+  gap:10px;
+  background:#3f2a06;
+  color:#fbbf24;
+  ">
   <span style="font-size:18px;">&#9888;&#65039;</span>
   <span id="budget-cap-banner-msg" style="flex:1;"></span>
-  <button onclick="document.getElementById('budget-cap-banner').style.display='none'" style="background:#92400e;color:#fef3c7;border:none;border-radius:6px;padding:4px 12px;font-size:12px;cursor:pointer;font-weight:600;">Dismiss</button>
+  <button onclick="document.getElementById('budget-cap-banner').style.display='none'" style="
+    background:#92400e;
+    color:#fef3c7;
+    border:none;
+    border-radius:6px;
+    padding:4px 12px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    ">Dismiss</button>
 </div>

--- a/templates/partials/budget-modal.html
+++ b/templates/partials/budget-modal.html
@@ -1,11 +1,41 @@
 <!-- Budget Settings Modal -->
-<div id="budget-modal" style="display:none;position:fixed;inset:0;z-index:1200;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;">
-  <div style="background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:16px;width:90%;max-width:560px;padding:24px;box-shadow:0 25px 50px rgba(0,0,0,0.25);">
+<div id="budget-modal" style="
+  display:none;
+  position:fixed;
+  inset:0;
+  z-index:1200;
+  background:rgba(0,0,0,0.5);
+  align-items:center;
+  justify-content:center;
+  ">
+  <div style="
+    background:var(--bg-primary);
+    border:1px solid var(--border-primary);
+    border-radius:16px;
+    width:90%;
+    max-width:560px;
+    padding:24px;
+    box-shadow:0 25px 50px rgba(0,0,0,0.25);
+    ">
     <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;">
       <h3 style="font-size:18px;font-weight:700;color:var(--text-primary);">&#128176; Budget & Alerts</h3>
-      <button onclick="document.getElementById('budget-modal').style.display='none'" style="background:var(--button-bg);border:1px solid var(--border-primary);border-radius:8px;width:32px;height:32px;cursor:pointer;font-size:18px;color:var(--text-tertiary);">&times;</button>
+      <button onclick="document.getElementById('budget-modal').style.display='none'" style="
+        background:var(--button-bg);
+        border:1px solid var(--border-primary);
+        border-radius:8px;
+        width:32px;
+        height:32px;
+        cursor:pointer;
+        font-size:18px;
+        color:var(--text-tertiary);
+        ">&times;</button>
     </div>
-    <div id="budget-modal-tabs" style="display:flex;gap:0;border-bottom:1px solid var(--border-primary);margin-bottom:16px;">
+    <div id="budget-modal-tabs" style="
+      display:flex;
+      gap:0;
+      border-bottom:1px solid var(--border-primary);
+      margin-bottom:16px;
+      ">
       <div class="modal-tab active" onclick="switchBudgetTab('limits',this)">Budget Limits</div>
       <div class="modal-tab" onclick="switchBudgetTab('alerts',this)">Alert Rules</div>
       <div class="modal-tab" onclick="switchBudgetTab('telegram',this)">Telegram</div>
@@ -15,28 +45,94 @@
     <div id="budget-tab-limits">
       <div style="display:grid;gap:12px;">
         <div>
-          <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px;">Daily Limit (USD, 0 = no limit)</label>
-          <input id="budget-daily" type="number" step="0.01" min="0" style="width:100%;padding:8px 12px;border:1px solid var(--border-primary);border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;">
+          <label style="
+            font-size:12px;
+            color:var(--text-muted);
+            display:block;
+            margin-bottom:4px;
+            ">Daily Limit (USD, 0 = no limit)</label>
+          <input id="budget-daily" type="number" step="0.01" min="0" style="
+            width:100%;
+            padding:8px 12px;
+            border:1px solid var(--border-primary);
+            border-radius:8px;
+            background:var(--bg-secondary);
+            color:var(--text-primary);
+            font-size:14px;
+            ">
         </div>
         <div>
-          <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px;">Weekly Limit (USD)</label>
-          <input id="budget-weekly" type="number" step="0.01" min="0" style="width:100%;padding:8px 12px;border:1px solid var(--border-primary);border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;">
+          <label style="
+            font-size:12px;
+            color:var(--text-muted);
+            display:block;
+            margin-bottom:4px;
+            ">Weekly Limit (USD)</label>
+          <input id="budget-weekly" type="number" step="0.01" min="0" style="
+            width:100%;
+            padding:8px 12px;
+            border:1px solid var(--border-primary);
+            border-radius:8px;
+            background:var(--bg-secondary);
+            color:var(--text-primary);
+            font-size:14px;
+            ">
         </div>
         <div>
-          <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px;">Monthly Limit (USD)</label>
-          <input id="budget-monthly" type="number" step="0.01" min="0" style="width:100%;padding:8px 12px;border:1px solid var(--border-primary);border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;">
+          <label style="
+            font-size:12px;
+            color:var(--text-muted);
+            display:block;
+            margin-bottom:4px;
+            ">Monthly Limit (USD)</label>
+          <input id="budget-monthly" type="number" step="0.01" min="0" style="
+            width:100%;
+            padding:8px 12px;
+            border:1px solid var(--border-primary);
+            border-radius:8px;
+            background:var(--bg-secondary);
+            color:var(--text-primary);
+            font-size:14px;
+            ">
         </div>
         <div>
           <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px;">Warning at (%)</label>
-          <input id="budget-warn-pct" type="number" step="1" min="1" max="100" value="80" style="width:100%;padding:8px 12px;border:1px solid var(--border-primary);border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;">
+          <input id="budget-warn-pct" type="number" step="1" min="1" max="100" value="80" style="
+            width:100%;
+            padding:8px 12px;
+            border:1px solid var(--border-primary);
+            border-radius:8px;
+            background:var(--bg-secondary);
+            color:var(--text-primary);
+            font-size:14px;
+            ">
         </div>
         <div style="display:flex;align-items:center;gap:8px;">
           <input id="budget-autopause" type="checkbox" style="cursor:pointer;">
-          <label for="budget-autopause" style="font-size:13px;color:var(--text-secondary);cursor:pointer;">Auto-pause gateway when budget exceeded</label>
+          <label for="budget-autopause" style="
+            font-size:13px;
+            color:var(--text-secondary);
+            cursor:pointer;
+            ">Auto-pause gateway when budget exceeded</label>
         </div>
-        <button onclick="saveBudgetConfig()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:8px;padding:10px;font-size:14px;font-weight:600;cursor:pointer;">Save Budget Settings</button>
+        <button onclick="saveBudgetConfig()" style="
+          background:var(--bg-accent);
+          color:#fff;
+          border:none;
+          border-radius:8px;
+          padding:10px;
+          font-size:14px;
+          font-weight:600;
+          cursor:pointer;
+          ">Save Budget Settings</button>
       </div>
-      <div id="budget-status-display" style="margin-top:16px;padding:12px;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:8px;">
+      <div id="budget-status-display" style="
+        margin-top:16px;
+        padding:12px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-primary);
+        border-radius:8px;
+        ">
         <div style="font-size:12px;color:var(--text-muted);margin-bottom:8px;">Current Spending</div>
         <div id="budget-status-content" style="font-size:13px;color:var(--text-secondary);">Loading...</div>
       </div>
@@ -44,23 +140,83 @@
     <!-- Alert Rules Tab -->
     <div id="budget-tab-alerts" style="display:none;">
       <div style="margin-bottom:12px;">
-        <button onclick="showAddAlertForm()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:8px;padding:8px 16px;font-size:13px;font-weight:600;cursor:pointer;">+ Add Alert Rule</button>
+        <button onclick="showAddAlertForm()" style="
+          background:var(--bg-accent);
+          color:#fff;
+          border:none;
+          border-radius:8px;
+          padding:8px 16px;
+          font-size:13px;
+          font-weight:600;
+          cursor:pointer;
+          ">+ Add Alert Rule</button>
       </div>
-      <div id="add-alert-form" style="display:none;padding:12px;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:8px;margin-bottom:12px;">
+      <div id="add-alert-form" style="
+        display:none;
+        padding:12px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-primary);
+        border-radius:8px;
+        margin-bottom:12px;
+        ">
         <div style="display:grid;gap:8px;">
-          <select id="alert-type" style="padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
+          <select id="alert-type" style="
+            padding:8px;
+            border:1px solid var(--border-primary);
+            border-radius:6px;
+            background:var(--bg-tertiary);
+            color:var(--text-primary);
+            ">
             <option value="threshold">Threshold (daily $ amount)</option>
             <option value="spike">Spike (hourly rate multiplier)</option>
           </select>
-          <input id="alert-threshold" type="number" step="0.01" min="0" placeholder="Threshold value" style="padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
+          <input id="alert-threshold" type="number" step="0.01" min="0" placeholder="Threshold value" style="
+            padding:8px;
+            border:1px solid var(--border-primary);
+            border-radius:6px;
+            background:var(--bg-tertiary);
+            color:var(--text-primary);
+            ">
           <div style="display:flex;gap:8px;flex-wrap:wrap;">
-            <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-ch-banner" checked> Banner</label>
-            <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-ch-telegram"> Telegram</label>
+            <label style="
+              font-size:12px;
+              display:flex;
+              align-items:center;
+              gap:4px;
+              "><input type="checkbox" id="alert-ch-banner" checked> Banner</label>
+            <label style="
+              font-size:12px;
+              display:flex;
+              align-items:center;
+              gap:4px;
+              "><input type="checkbox" id="alert-ch-telegram"> Telegram</label>
           </div>
-          <input id="alert-cooldown" type="number" value="30" min="1" placeholder="Cooldown (min)" style="padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
+          <input id="alert-cooldown" type="number" value="30" min="1" placeholder="Cooldown (min)" style="
+            padding:8px;
+            border:1px solid var(--border-primary);
+            border-radius:6px;
+            background:var(--bg-tertiary);
+            color:var(--text-primary);
+            ">
           <div style="display:flex;gap:8px;">
-            <button onclick="createAlertRule()" style="background:#16a34a;color:#fff;border:none;border-radius:6px;padding:6px 16px;font-size:13px;cursor:pointer;">Create</button>
-            <button onclick="document.getElementById('add-alert-form').style.display='none'" style="background:var(--button-bg);color:var(--text-secondary);border:none;border-radius:6px;padding:6px 16px;font-size:13px;cursor:pointer;">Cancel</button>
+            <button onclick="createAlertRule()" style="
+              background:#16a34a;
+              color:#fff;
+              border:none;
+              border-radius:6px;
+              padding:6px 16px;
+              font-size:13px;
+              cursor:pointer;
+              ">Create</button>
+            <button onclick="document.getElementById('add-alert-form').style.display='none'" style="
+              background:var(--button-bg);
+              color:var(--text-secondary);
+              border:none;
+              border-radius:6px;
+              padding:6px 16px;
+              font-size:13px;
+              cursor:pointer;
+              ">Cancel</button>
           </div>
         </div>
       </div>
@@ -74,22 +230,61 @@
         </div>
         <div>
           <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px;">Bot Token</label>
-          <input id="tg-bot-token" type="password" placeholder="123456:ABC-DEF..." style="width:100%;padding:8px 12px;border:1px solid var(--border-primary);border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;">
+          <input id="tg-bot-token" type="password" placeholder="123456:ABC-DEF..." style="
+            width:100%;
+            padding:8px 12px;
+            border:1px solid var(--border-primary);
+            border-radius:8px;
+            background:var(--bg-secondary);
+            color:var(--text-primary);
+            font-size:14px;
+            ">
         </div>
         <div>
           <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px;">Chat ID</label>
-          <input id="tg-chat-id" type="text" placeholder="-100123456789" style="width:100%;padding:8px 12px;border:1px solid var(--border-primary);border-radius:8px;background:var(--bg-secondary);color:var(--text-primary);font-size:14px;">
+          <input id="tg-chat-id" type="text" placeholder="-100123456789" style="
+            width:100%;
+            padding:8px 12px;
+            border:1px solid var(--border-primary);
+            border-radius:8px;
+            background:var(--bg-secondary);
+            color:var(--text-primary);
+            font-size:14px;
+            ">
         </div>
         <div style="display:flex;gap:8px;">
-          <button onclick="saveTelegramConfig()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:8px;padding:10px 16px;font-size:14px;font-weight:600;cursor:pointer;">Save</button>
-          <button onclick="testTelegram()" style="background:#16a34a;color:#fff;border:none;border-radius:8px;padding:10px 16px;font-size:14px;font-weight:600;cursor:pointer;">Send Test</button>
+          <button onclick="saveTelegramConfig()" style="
+            background:var(--bg-accent);
+            color:#fff;
+            border:none;
+            border-radius:8px;
+            padding:10px 16px;
+            font-size:14px;
+            font-weight:600;
+            cursor:pointer;
+            ">Save</button>
+          <button onclick="testTelegram()" style="
+            background:#16a34a;
+            color:#fff;
+            border:none;
+            border-radius:8px;
+            padding:10px 16px;
+            font-size:14px;
+            font-weight:600;
+            cursor:pointer;
+            ">Send Test</button>
         </div>
         <div id="tg-status" style="font-size:12px;color:var(--text-muted);"></div>
       </div>
     </div>
     <!-- History Tab -->
     <div id="budget-tab-history" style="display:none;">
-      <div id="alert-history-list" style="font-size:13px;color:var(--text-secondary);max-height:400px;overflow-y:auto;">Loading...</div>
+      <div id="alert-history-list" style="
+        font-size:13px;
+        color:var(--text-secondary);
+        max-height:400px;
+        overflow-y:auto;
+        ">Loading...</div>
     </div>
   </div>
 </div>

--- a/templates/partials/cloud-modal.html
+++ b/templates/partials/cloud-modal.html
@@ -1,17 +1,72 @@
 <!-- ClawMetry Cloud CTA Modal -->
-<div id="cloud-modal-overlay" onclick="if(event.target===this)closeCloudModal()" style="display:none;position:fixed;inset:0;z-index:2000;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center;">
-  <div style="background:#0f1623;border:1px solid rgba(229,68,58,0.2);border-radius:16px;width:90%;max-width:440px;padding:32px;box-shadow:0 25px 60px rgba(0,0,0,0.5);position:relative;margin:auto;">
-    <button onclick="closeCloudModal()" style="position:absolute;top:16px;right:16px;background:rgba(255,255,255,0.05);border:none;border-radius:8px;width:32px;height:32px;cursor:pointer;font-size:18px;color:#888;">&times;</button>
+<div id="cloud-modal-overlay" onclick="if(event.target===this)closeCloudModal()" style="
+  display:none;
+  position:fixed;
+  inset:0;
+  z-index:2000;
+  background:rgba(0,0,0,0.6);
+  backdrop-filter:blur(4px);
+  align-items:center;
+  justify-content:center;
+  ">
+  <div style="
+    background:#0f1623;
+    border:1px solid rgba(229,68,58,0.2);
+    border-radius:16px;
+    width:90%;
+    max-width:440px;
+    padding:32px;
+    box-shadow:0 25px 60px rgba(0,0,0,0.5);
+    position:relative;
+    margin:auto;
+    ">
+    <button onclick="closeCloudModal()" style="
+      position:absolute;
+      top:16px;
+      right:16px;
+      background:rgba(255,255,255,0.05);
+      border:none;
+      border-radius:8px;
+      width:32px;
+      height:32px;
+      cursor:pointer;
+      font-size:18px;
+      color:#888;
+      ">&times;</button>
     <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;">
       <img src="/static/img/logo.svg" width="28" height="28" style="border-radius:6px;">
       <span style="font-size:18px;font-weight:700;color:#fff;">ClawMetry Cloud</span>
     </div>
-    <p style="color:#94a3b8;font-size:14px;margin:0 0 24px;line-height:1.5;">Monitor your agents from anywhere. Encrypted, real-time, accessible from any browser or as a Mac app.</p>
+    <p style="
+      color:#94a3b8;
+      font-size:14px;
+      margin:0 0 24px;
+      line-height:1.5;
+      ">Monitor your agents from anywhere. Encrypted, real-time, accessible from any browser or as a Mac app.</p>
     <div id="cloud-step-email">
       <label style="font-size:12px;font-weight:600;color:#94a3b8;display:block;margin-bottom:6px;">YOUR EMAIL</label>
       <div style="display:flex;gap:8px;">
-        <input id="cloud-email-input" type="email" placeholder="you@example.com" style="flex:1;padding:10px 14px;background:#1a2235;border:1px solid rgba(255,255,255,0.1);border-radius:8px;color:#fff;font-size:14px;outline:none;" onkeydown="if(event.key==='Enter')cloudSendOtp()">
-        <button onclick="cloudSendOtp()" style="padding:10px 18px;background:#E5443A;color:#fff;border:none;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;white-space:nowrap;">Get Started</button>
+        <input id="cloud-email-input" type="email" placeholder="you@example.com" style="
+          flex:1;
+          padding:10px 14px;
+          background:#1a2235;
+          border:1px solid rgba(255,255,255,0.1);
+          border-radius:8px;
+          color:#fff;
+          font-size:14px;
+          outline:none;
+          " onkeydown="if(event.key==='Enter')cloudSendOtp()">
+        <button onclick="cloudSendOtp()" style="
+          padding:10px 18px;
+          background:#E5443A;
+          color:#fff;
+          border:none;
+          border-radius:8px;
+          font-size:14px;
+          font-weight:600;
+          cursor:pointer;
+          white-space:nowrap;
+          ">Get Started</button>
       </div>
       <p id="cloud-email-error" style="color:#E5443A;font-size:12px;margin:6px 0 0;display:none;"></p>
       <div style="margin-top:20px;padding-top:20px;border-top:1px solid rgba(255,255,255,0.06);text-align:center;">
@@ -21,11 +76,37 @@
     <div id="cloud-step-otp" style="display:none;">
       <p style="color:#94a3b8;font-size:13px;margin:0 0 16px;">Check your email for a 6-digit code</p>
       <div style="display:flex;gap:8px;">
-        <input id="cloud-otp-input" type="text" maxlength="6" placeholder="_ _ _ _ _ _" style="flex:1;padding:10px 14px;background:#1a2235;border:1px solid rgba(255,255,255,0.1);border-radius:8px;color:#fff;font-size:18px;letter-spacing:6px;text-align:center;outline:none;" onkeydown="if(event.key==='Enter')cloudVerifyOtp()">
-        <button onclick="cloudVerifyOtp()" style="padding:10px 18px;background:#E5443A;color:#fff;border:none;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;">Verify</button>
+        <input id="cloud-otp-input" type="text" maxlength="6" placeholder="_ _ _ _ _ _" style="
+          flex:1;
+          padding:10px 14px;
+          background:#1a2235;
+          border:1px solid rgba(255,255,255,0.1);
+          border-radius:8px;
+          color:#fff;
+          font-size:18px;
+          letter-spacing:6px;
+          text-align:center;
+          outline:none;
+          " onkeydown="if(event.key==='Enter')cloudVerifyOtp()">
+        <button onclick="cloudVerifyOtp()" style="
+          padding:10px 18px;
+          background:#E5443A;
+          color:#fff;
+          border:none;
+          border-radius:8px;
+          font-size:14px;
+          font-weight:600;
+          cursor:pointer;
+          ">Verify</button>
       </div>
       <p id="cloud-otp-error" style="color:#E5443A;font-size:12px;margin:6px 0 0;display:none;"></p>
-      <p style="color:#64748b;font-size:12px;margin:10px 0 0;text-align:center;cursor:pointer;" onclick="cloudResendOtp()">Resend code</p>
+      <p style="
+        color:#64748b;
+        font-size:12px;
+        margin:10px 0 0;
+        text-align:center;
+        cursor:pointer;
+        " onclick="cloudResendOtp()">Resend code</p>
     </div>
     <div id="cloud-step-done" style="display:none;text-align:center;padding:16px 0;">
       <div style="font-size:36px;margin-bottom:12px;">&#10003;</div>

--- a/templates/partials/overlays.html
+++ b/templates/partials/overlays.html
@@ -1,11 +1,56 @@
 <!-- Login overlay -->
-<div id="login-overlay" style="display:none;position:fixed;inset:0;z-index:99999;background:var(--bg-primary,#0f172a);align-items:center;justify-content:center;flex-direction:column;">
-  <div style="background:var(--card-bg,#1e293b);border-radius:16px;padding:40px;max-width:400px;width:90%;box-shadow:0 8px 32px rgba(0,0,0,0.4);text-align:center;">
-    <img src="/static/img/logo.svg" style="width:64px;height:64px;margin-bottom:16px;display:block;margin-left:auto;margin-right:auto;" alt="ClawMetry">
+<div id="login-overlay" style="
+  display:none;
+  position:fixed;
+  inset:0;
+  z-index:99999;
+  background:var(--bg-primary,#0f172a);
+  align-items:center;
+  justify-content:center;
+  flex-direction:column;
+  ">
+  <div style="
+    background:var(--card-bg,#1e293b);
+    border-radius:16px;
+    padding:40px;
+    max-width:400px;
+    width:90%;
+    box-shadow:0 8px 32px rgba(0,0,0,0.4);
+    text-align:center;
+    ">
+    <img src="/static/img/logo.svg" style="
+      width:64px;
+      height:64px;
+      margin-bottom:16px;
+      display:block;
+      margin-left:auto;
+      margin-right:auto;
+      " alt="ClawMetry">
     <h2 style="color:#e2e8f0;margin:0 0 8px;">ClawMetry</h2>
     <p style="color:#94a3b8;margin:0 0 24px;font-size:14px;">Enter your OpenClaw Gateway Token</p>
-    <input id="login-token" type="password" placeholder="Gateway token..." style="width:100%;box-sizing:border-box;padding:12px 16px;border-radius:8px;border:1px solid #334155;background:#0f172a;color:#e2e8f0;font-size:15px;margin-bottom:16px;outline:none;" onkeydown="if(event.key==='Enter')clawmetryLogin()">
-    <button onclick="clawmetryLogin()" style="width:100%;padding:12px;border-radius:8px;border:none;background:#3b82f6;color:#fff;font-size:15px;font-weight:600;cursor:pointer;">Login</button>
+    <input id="login-token" type="password" placeholder="Gateway token..." style="
+      width:100%;
+      box-sizing:border-box;
+      padding:12px 16px;
+      border-radius:8px;
+      border:1px solid #334155;
+      background:#0f172a;
+      color:#e2e8f0;
+      font-size:15px;
+      margin-bottom:16px;
+      outline:none;
+      " onkeydown="if(event.key==='Enter')clawmetryLogin()">
+    <button onclick="clawmetryLogin()" style="
+      width:100%;
+      padding:12px;
+      border-radius:8px;
+      border:none;
+      background:#3b82f6;
+      color:#fff;
+      font-size:15px;
+      font-weight:600;
+      cursor:pointer;
+      ">Login</button>
     <p id="login-error" style="color:#f87171;margin:12px 0 0;font-size:13px;display:none;">Invalid token</p>
   </div>
 </div>

--- a/templates/tabs/brain.html
+++ b/templates/tabs/brain.html
@@ -2,11 +2,25 @@
   <div style="padding:12px 0 8px 0;">
     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;">
       <span style="font-size:14px;font-weight:700;color:var(--text-primary);">🧠 Brain -- Unified Activity Stream</span>
-      <div style="display:flex;align-items:center;gap:8px;"><span id="brain-live-indicator"></span><button class="refresh-btn" onclick="loadBrainPage()">↻ Refresh</button></div>
+      <div style="
+        display:flex;
+        align-items:center;
+        gap:8px;
+        "><span id="brain-live-indicator"></span><button class="refresh-btn" onclick="loadBrainPage()">↻ Refresh</button></div>
     </div>
     <!-- Activity density chart -->
-    <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;margin-bottom:12px;">
-      <div style="font-size:11px;color:var(--text-muted);margin-bottom:6px;">Activity density -- last 60 min (30s buckets)</div>
+    <div style="
+      background:var(--bg-secondary);
+      border:1px solid var(--border);
+      border-radius:8px;
+      padding:10px 14px;
+      margin-bottom:12px;
+      ">
+      <div style="
+        font-size:11px;
+        color:var(--text-muted);
+        margin-bottom:6px;
+        ">Activity density -- last 60 min (30s buckets)</div>
       <canvas id="brain-density-chart" height="60" style="width:100%;display:block;"></canvas>
     </div>
     <div class="brain-view-toggle">
@@ -14,15 +28,38 @@
     </div>
     <!-- Source filter chips -->
     <div id="brain-filter-chips" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:6px;">
-      <button class="brain-chip active" data-source="all" onclick="setBrainFilter('all',this)" style="padding:3px 10px;border-radius:12px;border:1px solid #a855f7;background:rgba(168,85,247,0.2);color:#a855f7;font-size:11px;cursor:pointer;font-weight:600;">All</button>
+      <button class="brain-chip active" data-source="all" onclick="setBrainFilter('all',this)" style="
+        padding:3px 10px;
+        border-radius:12px;
+        border:1px solid #a855f7;
+        background:rgba(168,85,247,0.2);
+        color:#a855f7;
+        font-size:11px;
+        cursor:pointer;
+        font-weight:600;
+        ">All</button>
     </div>
     <!-- Type filter chips (separate container to prevent duplication) -->
     <div id="brain-type-chips" style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:10px;"></div>
     <!-- Event stream -->
-    <div id="brain-feed" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;">
+    <div id="brain-feed" style="
+      background:var(--bg-secondary);
+      border:1px solid var(--border);
+      border-radius:8px;
+      padding:10px 14px;
+      ">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;">
         <span style="font-size:11px;color:var(--text-muted);">Live event stream (newest first)</span>
-        <span id="brain-new-pill" style="display:none;background:#a855f7;color:#fff;border-radius:10px;padding:1px 8px;font-size:10px;font-weight:700;cursor:pointer;" onclick="scrollBrainToTop()">↑ new events</span>
+        <span id="brain-new-pill" style="
+          display:none;
+          background:#a855f7;
+          color:#fff;
+          border-radius:10px;
+          padding:1px 8px;
+          font-size:10px;
+          font-weight:700;
+          cursor:pointer;
+          " onclick="scrollBrainToTop()">↑ new events</span>
       </div>
       <div id="brain-stream" style="max-height:calc(100vh - 320px);overflow-y:auto;">
         <div style="color:var(--text-muted);padding:20px">Loading...</div>

--- a/templates/tabs/clusters.html
+++ b/templates/tabs/clusters.html
@@ -1,6 +1,12 @@
 <div class="page" id="page-clusters">
   <div class="refresh-bar">
-    <h2 style="font-size:16px;font-weight:700;color:var(--text-primary);margin:0;flex:1;">&#129492; Session Clusters</h2>
+    <h2 style="
+      font-size:16px;
+      font-weight:700;
+      color:var(--text-primary);
+      margin:0;
+      flex:1;
+      ">&#129492; Session Clusters</h2>
     <button class="refresh-btn" onclick="loadClusters()">&#8635; Refresh</button>
   </div>
   <div id="clusters-content" style="padding:8px 0;">

--- a/templates/tabs/crons.html
+++ b/templates/tabs/crons.html
@@ -1,8 +1,18 @@
 <div class="page" id="page-crons">
   <div class="refresh-bar" style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
     <button class="refresh-btn" onclick="loadCrons()">&#x21bb; Refresh</button>
-    <button class="refresh-btn cron-action-btn" onclick="cronCreateNew()" style="background:#6366f1;color:#fff;border-color:#6366f1;display:none;">+ New Job</button>
-    <button class="refresh-btn cron-action-btn" id="cron-kill-all-btn" onclick="cronKillAll()" style="background:#dc2626;color:#fff;border-color:#dc2626;display:none;">&#x1F6D1; Emergency Stop All</button>
+    <button class="refresh-btn cron-action-btn" onclick="cronCreateNew()" style="
+      background:#6366f1;
+      color:#fff;
+      border-color:#6366f1;
+      display:none;
+      ">+ New Job</button>
+    <button class="refresh-btn cron-action-btn" id="cron-kill-all-btn" onclick="cronKillAll()" style="
+      background:#dc2626;
+      color:#fff;
+      border-color:#dc2626;
+      display:none;
+      ">&#x1F6D1; Emergency Stop All</button>
     <label class="modal-auto-refresh" style="margin-left:auto;">
       <input type="checkbox" id="cron-auto-refresh" onchange="toggleCronAutoRefresh()" checked> Auto-refresh (30s)
     </label>
@@ -11,7 +21,17 @@
   <div id="crons-multi-node" style="display:none;margin-bottom:12px;"></div>
   <div class="card" id="crons-list">Loading...</div>
   <!-- Cron Health Monitor (GH #302) -->
-  <div id="cron-health-anomaly-banner" style="display:none;margin-top:14px;padding:10px 14px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.4);border-radius:8px;color:#ef4444;font-size:13px;font-weight:600;">&#x26A0;&#xFE0F; Anomalies detected in cron jobs — review health table below</div>
+  <div id="cron-health-anomaly-banner" style="
+    display:none;
+    margin-top:14px;
+    padding:10px 14px;
+    background:rgba(239,68,68,0.1);
+    border:1px solid rgba(239,68,68,0.4);
+    border-radius:8px;
+    color:#ef4444;
+    font-size:13px;
+    font-weight:600;
+    ">&#x26A0;&#xFE0F; Anomalies detected in cron jobs — review health table below</div>
   <div style="margin-top:16px;">
     <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;">
       <span style="font-size:14px;font-weight:700;color:var(--text-primary);">&#x1F4CA; Cron Health Monitor</span>
@@ -24,42 +44,147 @@
 </div>
 
 <!-- Cron Edit/Create Modal -->
-<div id="cron-edit-modal" style="display:none;position:fixed;inset:0;z-index:1500;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;backdrop-filter:blur(4px);">
-  <div style="background:var(--bg-tertiary);border:1px solid var(--border-primary);border-radius:12px;padding:24px;width:480px;max-width:90vw;box-shadow:0 8px 30px rgba(0,0,0,0.4);max-height:80vh;overflow-y:auto;margin:auto;">
+<div id="cron-edit-modal" style="
+  display:none;
+  position:fixed;
+  inset:0;
+  z-index:1500;
+  background:rgba(0,0,0,0.5);
+  align-items:center;
+  justify-content:center;
+  backdrop-filter:blur(4px);
+  ">
+  <div style="
+    background:var(--bg-tertiary);
+    border:1px solid var(--border-primary);
+    border-radius:12px;
+    padding:24px;
+    width:480px;
+    max-width:90vw;
+    box-shadow:0 8px 30px rgba(0,0,0,0.4);
+    max-height:80vh;
+    overflow-y:auto;
+    margin:auto;
+    ">
     <h3 id="cron-modal-title" style="margin:0 0 16px;color:var(--text-primary);font-size:16px;">Edit Cron Job</h3>
     <input type="hidden" id="cron-edit-id">
     <input type="hidden" id="cron-edit-mode" value="edit">
     <div style="margin-bottom:12px;">
       <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">Name</label>
-      <input id="cron-edit-name" style="width:100%;padding:8px 12px;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:8px;color:var(--text-primary);font-size:13px;box-sizing:border-box;" placeholder="my-health-check">
+      <input id="cron-edit-name" style="
+        width:100%;
+        padding:8px 12px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-secondary);
+        border-radius:8px;
+        color:var(--text-primary);
+        font-size:13px;
+        box-sizing:border-box;
+        " placeholder="my-health-check">
     </div>
     <div style="margin-bottom:12px;">
-      <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">Schedule (cron expression or interval like "every 30min")</label>
-      <input id="cron-edit-schedule" style="width:100%;padding:8px 12px;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:8px;color:var(--text-primary);font-size:13px;font-family:'SF Mono','Fira Code',monospace;box-sizing:border-box;" placeholder="*/30 * * * *  or  every 30min">
+      <label style="
+        display:block;
+        font-size:12px;
+        color:var(--text-muted);
+        margin-bottom:4px;
+        ">Schedule (cron expression or interval like "every 30min")</label>
+      <input id="cron-edit-schedule" style="
+        width:100%;
+        padding:8px 12px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-secondary);
+        border-radius:8px;
+        color:var(--text-primary);
+        font-size:13px;
+        font-family:'SF Mono','Fira Code',monospace;
+        box-sizing:border-box;
+        " placeholder="*/30 * * * *  or  every 30min">
     </div>
     <div style="margin-bottom:12px;">
-      <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">Timezone (for cron expressions)</label>
-      <input id="cron-edit-tz" style="width:100%;padding:8px 12px;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:8px;color:var(--text-primary);font-size:13px;box-sizing:border-box;" placeholder="e.g. Europe/Amsterdam">
+      <label style="
+        display:block;
+        font-size:12px;
+        color:var(--text-muted);
+        margin-bottom:4px;
+        ">Timezone (for cron expressions)</label>
+      <input id="cron-edit-tz" style="
+        width:100%;
+        padding:8px 12px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-secondary);
+        border-radius:8px;
+        color:var(--text-primary);
+        font-size:13px;
+        box-sizing:border-box;
+        " placeholder="e.g. Europe/Amsterdam">
     </div>
     <div id="cron-edit-prompt-section" style="margin-bottom:12px;">
       <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">Prompt / Message</label>
-      <textarea id="cron-edit-prompt" rows="3" style="width:100%;padding:8px 12px;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:8px;color:var(--text-primary);font-size:13px;box-sizing:border-box;resize:vertical;font-family:inherit;" placeholder="What should the agent do when this cron fires?"></textarea>
+      <textarea id="cron-edit-prompt" rows="3" style="
+        width:100%;
+        padding:8px 12px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-secondary);
+        border-radius:8px;
+        color:var(--text-primary);
+        font-size:13px;
+        box-sizing:border-box;
+        resize:vertical;
+        font-family:inherit;
+        " placeholder="What should the agent do when this cron fires?"></textarea>
     </div>
     <div id="cron-edit-channel-section" style="margin-bottom:12px;">
       <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">Channel (optional)</label>
-      <input id="cron-edit-channel" style="width:100%;padding:8px 12px;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:8px;color:var(--text-primary);font-size:13px;box-sizing:border-box;" placeholder="e.g. discord, telegram">
+      <input id="cron-edit-channel" style="
+        width:100%;
+        padding:8px 12px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-secondary);
+        border-radius:8px;
+        color:var(--text-primary);
+        font-size:13px;
+        box-sizing:border-box;
+        " placeholder="e.g. discord, telegram">
     </div>
     <div id="cron-edit-model-section" style="margin-bottom:12px;">
       <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">Model (optional)</label>
-      <input id="cron-edit-model" style="width:100%;padding:8px 12px;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:8px;color:var(--text-primary);font-size:13px;box-sizing:border-box;" placeholder="e.g. anthropic/claude-sonnet-4-20250514">
+      <input id="cron-edit-model" style="
+        width:100%;
+        padding:8px 12px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-secondary);
+        border-radius:8px;
+        color:var(--text-primary);
+        font-size:13px;
+        box-sizing:border-box;
+        " placeholder="e.g. anthropic/claude-sonnet-4-20250514">
     </div>
     <div style="margin-bottom:16px;display:flex;align-items:center;gap:8px;">
       <input type="checkbox" id="cron-edit-enabled" style="accent-color:#6366f1;" checked>
       <label for="cron-edit-enabled" style="font-size:13px;color:var(--text-primary);">Enabled</label>
     </div>
     <div style="display:flex;gap:8px;justify-content:flex-end;">
-      <button onclick="closeCronEditModal()" style="padding:8px 20px;border-radius:8px;border:none;font-size:13px;font-weight:600;cursor:pointer;background:var(--button-bg);color:var(--text-secondary);">Cancel</button>
-      <button onclick="saveCronEdit()" id="cron-save-btn" style="padding:8px 20px;border-radius:8px;border:none;font-size:13px;font-weight:600;cursor:pointer;background:#6366f1;color:#fff;">Save</button>
+      <button onclick="closeCronEditModal()" style="
+        padding:8px 20px;
+        border-radius:8px;
+        border:none;
+        font-size:13px;
+        font-weight:600;
+        cursor:pointer;
+        background:var(--button-bg);
+        color:var(--text-secondary);
+        ">Cancel</button>
+      <button onclick="saveCronEdit()" id="cron-save-btn" style="
+        padding:8px 20px;
+        border-radius:8px;
+        border:none;
+        font-size:13px;
+        font-weight:600;
+        cursor:pointer;
+        background:#6366f1;
+        color:#fff;
+        ">Save</button>
     </div>
   </div>
 </div>

--- a/templates/tabs/flow.html
+++ b/templates/tabs/flow.html
@@ -54,7 +54,12 @@
         <circle cx="60" cy="30" r="22" fill="#7c3aed" stroke="#6a2ec0" stroke-width="2" filter="url(#dropShadow)"/>
         <circle cx="60" cy="24" r="5" fill="#ffffff" opacity="0.6"/>
         <path d="M 50 38 Q 50 45 60 45 Q 70 45 70 38" fill="#ffffff" opacity="0.4"/>
-        <text x="60" y="68" style="font-size:13px;fill:#7c3aed;font-weight:800;text-anchor:middle;" id="flow-human-name">You</text>
+        <text x="60" y="68" style="
+          font-size:13px;
+          fill:#7c3aed;
+          font-weight:800;
+          text-anchor:middle;
+          " id="flow-human-name">You</text>
       </g>
 
       <!-- Channel Nodes -->
@@ -145,9 +150,22 @@
       <g class="flow-node flow-node-brain brain-group" id="node-brain">
         <rect x="330" y="130" width="180" height="90" rx="12" ry="12" fill="#C62828" stroke="#B71C1C" stroke-width="3" filter="url(#dropShadow)"/>
         <text x="420" y="162" style="font-size:24px;text-anchor:middle;">&#x1F9E0;</text>
-        <text x="420" y="186" style="font-size:18px;font-weight:800;fill:#FFD54F;text-anchor:middle;" id="brain-model-label">AI Model</text>
-        <text x="420" y="203" style="font-size:10px;fill:#ffccbc;text-anchor:middle;" id="brain-model-text">unknown</text>
-        <text x="420" y="214" style="font-size:8px;fill:#a7f3d0;text-anchor:middle;" id="brain-billing-text">Auth: unknown</text>
+        <text x="420" y="186" style="
+          font-size:18px;
+          font-weight:800;
+          fill:#FFD54F;
+          text-anchor:middle;
+          " id="brain-model-label">AI Model</text>
+        <text x="420" y="203" style="
+          font-size:10px;
+          fill:#ffccbc;
+          text-anchor:middle;
+          " id="brain-model-text">unknown</text>
+        <text x="420" y="214" style="
+          font-size:8px;
+          fill:#a7f3d0;
+          text-anchor:middle;
+          " id="brain-billing-text">Auth: unknown</text>
         <circle cx="420" cy="225" r="4" fill="#FF8A65">
           <animate attributeName="r" values="3;5;3" dur="1.1s" repeatCount="indefinite"/>
           <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
@@ -172,7 +190,12 @@
       </g>
       <g class="flow-node flow-node-tool" id="node-search">
         <rect x="560" y="220" width="110" height="38" rx="10" ry="10" fill="#00695C" stroke="#004D40" stroke-width="2" filter="url(#dropShadow)"/>
-        <text x="615" y="244" style="font-size:13px;font-weight:700;fill:#ffffff;text-anchor:middle;">&#x1F50D; Search</text>
+        <text x="615" y="244" style="
+          font-size:13px;
+          font-weight:700;
+          fill:#ffffff;
+          text-anchor:middle;
+          ">&#x1F50D; Search</text>
         <circle class="tool-indicator" id="ind-search" cx="665" cy="228" r="5" fill="#4DB6AC"/>
       </g>
       <g class="flow-node flow-node-tool" id="node-cron">
@@ -182,12 +205,22 @@
       </g>
       <g class="flow-node flow-node-tool" id="node-tts">
         <rect x="560" y="320" width="110" height="38" rx="10" ry="10" fill="#F9A825" stroke="#F57F17" stroke-width="2" filter="url(#dropShadow)"/>
-        <text x="615" y="344" style="font-size:13px;font-weight:700;fill:#ffffff;text-anchor:middle;">&#x1F5E3;&#xFE0F; TTS</text>
+        <text x="615" y="344" style="
+          font-size:13px;
+          font-weight:700;
+          fill:#ffffff;
+          text-anchor:middle;
+          ">&#x1F5E3;&#xFE0F; TTS</text>
         <circle class="tool-indicator" id="ind-tts" cx="665" cy="328" r="5" fill="#FFF176"/>
       </g>
       <g class="flow-node flow-node-tool" id="node-memory">
         <rect x="560" y="370" width="110" height="38" rx="10" ry="10" fill="#283593" stroke="#1A237E" stroke-width="2" filter="url(#dropShadow)"/>
-        <text x="615" y="394" style="font-size:13px;font-weight:700;fill:#ffffff;text-anchor:middle;">&#x1F4BE; Memory</text>
+        <text x="615" y="394" style="
+          font-size:13px;
+          font-weight:700;
+          fill:#ffffff;
+          text-anchor:middle;
+          ">&#x1F4BE; Memory</text>
         <circle class="tool-indicator" id="ind-memory" cx="665" cy="378" r="5" fill="#7986CB"/>
       </g>
 
@@ -217,29 +250,71 @@
 
       <g class="flow-node flow-node-infra flow-node-runtime" id="node-runtime">
         <rect x="30" y="450" width="130" height="40" rx="8" ry="8" fill="#455A64" stroke="#37474F" filter="url(#dropShadowLight)"/>
-        <text x="95" y="466" style="font-size:13px;fill:#ffffff;font-weight:700;text-anchor:middle;">&#x2699;&#xFE0F; Runtime</text>
-        <text class="infra-sub" x="95" y="480" style="fill:#B0BEC5;font-size:8px;text-anchor:middle;" id="infra-runtime-text">Node.js - Linux</text>
+        <text x="95" y="466" style="
+          font-size:13px;
+          fill:#ffffff;
+          font-weight:700;
+          text-anchor:middle;
+          ">&#x2699;&#xFE0F; Runtime</text>
+        <text class="infra-sub" x="95" y="480" style="
+          fill:#B0BEC5;
+          font-size:8px;
+          text-anchor:middle;
+          " id="infra-runtime-text">Node.js - Linux</text>
       </g>
       <g class="flow-node flow-node-infra flow-node-machine" id="node-machine">
         <rect x="195" y="450" width="130" height="40" rx="8" ry="8" fill="#4E342E" stroke="#3E2723" filter="url(#dropShadowLight)"/>
-        <text x="260" y="466" style="font-size:13px;fill:#ffffff;font-weight:700;text-anchor:middle;">&#x1F5A5;&#xFE0F; Machine</text>
-        <text class="infra-sub" x="260" y="480" style="fill:#BCAAA4;font-size:8px;text-anchor:middle;" id="infra-machine-text">Host</text>
+        <text x="260" y="466" style="
+          font-size:13px;
+          fill:#ffffff;
+          font-weight:700;
+          text-anchor:middle;
+          ">&#x1F5A5;&#xFE0F; Machine</text>
+        <text class="infra-sub" x="260" y="480" style="
+          fill:#BCAAA4;
+          font-size:8px;
+          text-anchor:middle;
+          " id="infra-machine-text">Host</text>
       </g>
       <g class="flow-node flow-node-infra flow-node-storage" id="node-storage">
         <rect x="360" y="450" width="130" height="40" rx="8" ry="8" fill="#5D4037" stroke="#4E342E" filter="url(#dropShadowLight)"/>
-        <text x="425" y="466" style="font-size:13px;fill:#ffffff;font-weight:700;text-anchor:middle;">&#x1F4BF; Storage</text>
-        <text class="infra-sub" x="425" y="480" style="fill:#BCAAA4;font-size:8px;text-anchor:middle;" id="infra-storage-text">Disk</text>
+        <text x="425" y="466" style="
+          font-size:13px;
+          fill:#ffffff;
+          font-weight:700;
+          text-anchor:middle;
+          ">&#x1F4BF; Storage</text>
+        <text class="infra-sub" x="425" y="480" style="
+          fill:#BCAAA4;
+          font-size:8px;
+          text-anchor:middle;
+          " id="infra-storage-text">Disk</text>
       </g>
       <g class="flow-node flow-node-infra flow-node-network" id="node-network">
         <rect x="525" y="450" width="130" height="40" rx="8" ry="8" fill="#004D40" stroke="#00332E" filter="url(#dropShadowLight)"/>
-        <text x="590" y="466" style="font-size:13px;fill:#ffffff;font-weight:700;text-anchor:middle;">&#x1F310; Network</text>
-        <text class="infra-sub" x="590" y="480" style="fill:#80CBC4;font-size:8px;text-anchor:middle;" id="infra-network-text">LAN</text>
+        <text x="590" y="466" style="
+          font-size:13px;
+          fill:#ffffff;
+          font-weight:700;
+          text-anchor:middle;
+          ">&#x1F310; Network</text>
+        <text class="infra-sub" x="590" y="480" style="
+          fill:#80CBC4;
+          font-size:8px;
+          text-anchor:middle;
+          " id="infra-network-text">LAN</text>
       </g>
 
       <!-- Legend -->
       <g transform="translate(140, 510)">
         <rect x="0" y="0" width="700" height="28" rx="14" ry="14" fill="var(--bg-tertiary)" stroke="var(--border-primary)" stroke-width="1" opacity="0.9"/>
-        <text x="350" y="18" style="font-size:12px;font-weight:600;fill:var(--text-secondary);letter-spacing:1px;text-anchor:middle;">&#x1F4E8; Channels  &#x27A1;&#xFE0F;  🔀 Gateway  &#x27A1;&#xFE0F;  &#x1F9E0; AI Brain  &#x27A1;&#xFE0F;  &#x1F6E0;&#xFE0F; Tools</text>
+        <text x="350" y="18" style="
+          font-size:12px;
+          font-weight:600;
+          fill:var(--text-secondary);
+          letter-spacing:1px;
+          text-anchor:middle;
+          ">&#x1F4E8; Channels  &#x27A1;&#xFE0F;  🔀 Gateway  &#x27A1;&#xFE0F;  &#x1F9E0; AI Brain  &#x27A1;&#xFE0F;  &#x1F6E0;&#xFE0F; Tools</text>
       </g>
 
       <!-- Flow direction labels -->
@@ -250,17 +325,62 @@
   </div>
 
   <!-- Live Tool Call Stream -->
-  <div style="margin-top:12px;background:var(--bg-secondary,#111128);border:1px solid var(--border-secondary,#2a2a4a);border-radius:10px;padding:12px 16px;">
-    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;flex-wrap:wrap;gap:8px;">
+  <div style="
+    margin-top:12px;
+    background:var(--bg-secondary,#111128);
+    border:1px solid var(--border-secondary,#2a2a4a);
+    border-radius:10px;
+    padding:12px 16px;
+    ">
+    <div style="
+      display:flex;
+      justify-content:space-between;
+      align-items:center;
+      margin-bottom:8px;
+      flex-wrap:wrap;
+      gap:8px;
+      ">
       <span style="font-size:13px;font-weight:600;color:#aaa;">&#128295; Live Tool Call Stream</span>
       <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
-        <input id="tool-stream-filter" type="text" placeholder="Filter by tool&hellip;" oninput="applyToolStreamFilter()" style="font-size:11px;padding:3px 8px;border:1px solid var(--border-secondary,#2a2a4a);border-radius:6px;background:var(--bg-primary,#0a0a1a);color:#aaa;width:130px;outline:none;">
-        <button id="tool-stream-pause-btn" onclick="toggleToolStreamPause()" style="font-size:11px;padding:3px 10px;border:1px solid var(--border-secondary,#2a2a4a);border-radius:6px;background:var(--bg-primary,#0a0a1a);color:#aaa;cursor:pointer;">&#9646;&#9646; Pause</button>
-        <button onclick="clearToolStream()" style="font-size:11px;padding:3px 10px;border:1px solid var(--border-secondary,#2a2a4a);border-radius:6px;background:var(--bg-primary,#0a0a1a);color:#aaa;cursor:pointer;">&#10005; Clear</button>
+        <input id="tool-stream-filter" type="text" placeholder="Filter by tool&hellip;" oninput="applyToolStreamFilter()" style="
+          font-size:11px;
+          padding:3px 8px;
+          border:1px solid var(--border-secondary,#2a2a4a);
+          border-radius:6px;
+          background:var(--bg-primary,#0a0a1a);
+          color:#aaa;
+          width:130px;
+          outline:none;
+          ">
+        <button id="tool-stream-pause-btn" onclick="toggleToolStreamPause()" style="
+          font-size:11px;
+          padding:3px 10px;
+          border:1px solid var(--border-secondary,#2a2a4a);
+          border-radius:6px;
+          background:var(--bg-primary,#0a0a1a);
+          color:#aaa;
+          cursor:pointer;
+          ">&#9646;&#9646; Pause</button>
+        <button onclick="clearToolStream()" style="
+          font-size:11px;
+          padding:3px 10px;
+          border:1px solid var(--border-secondary,#2a2a4a);
+          border-radius:6px;
+          background:var(--bg-primary,#0a0a1a);
+          color:#aaa;
+          cursor:pointer;
+          ">&#10005; Clear</button>
         <span style="font-size:10px;color:#555;" id="flow-feed-count">0 events</span>
       </div>
     </div>
-    <div id="flow-live-feed" style="max-height:350px;overflow-y:auto;font-family:'SF Mono',monospace;font-size:11px;line-height:1.6;color:#777;">
+    <div id="flow-live-feed" style="
+      max-height:350px;
+      overflow-y:auto;
+      font-family:'SF Mono',monospace;
+      font-size:11px;
+      line-height:1.6;
+      color:#777;
+      ">
       <div style="color:#555;">Waiting for activity...</div>
     </div>
   </div>

--- a/templates/tabs/history.html
+++ b/templates/tabs/history.html
@@ -10,9 +10,23 @@
       <button class="time-btn" onclick="showCustomRange()">Custom</button>
     </div>
     <div id="custom-range-picker" style="display:none;gap:8px;align-items:center;">
-      <input type="datetime-local" id="history-from" style="padding:4px 8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:12px;">
+      <input type="datetime-local" id="history-from" style="
+        padding:4px 8px;
+        border:1px solid var(--border-primary);
+        border-radius:6px;
+        background:var(--bg-secondary);
+        color:var(--text-primary);
+        font-size:12px;
+        ">
       <span style="color:var(--text-muted);">to</span>
-      <input type="datetime-local" id="history-to" style="padding:4px 8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:12px;">
+      <input type="datetime-local" id="history-to" style="
+        padding:4px 8px;
+        border:1px solid var(--border-primary);
+        border-radius:6px;
+        background:var(--bg-secondary);
+        color:var(--text-primary);
+        font-size:12px;
+        ">
       <button class="time-btn" onclick="applyCustomRange()">Apply</button>
     </div>
     <div id="history-status" style="font-size:12px;color:var(--text-muted);margin-left:auto;"></div>
@@ -38,18 +52,60 @@
     </div>
     <div class="card" style="padding:16px;">
       <h3 style="font-size:14px;font-weight:600;color:var(--text-primary);margin:0 0 12px 0;">Cron Runs</h3>
-      <div id="history-cron-table" style="max-height:300px;overflow-y:auto;font-size:13px;color:var(--text-secondary);">Loading...</div>
+      <div id="history-cron-table" style="
+        max-height:300px;
+        overflow-y:auto;
+        font-size:13px;
+        color:var(--text-secondary);
+        ">Loading...</div>
     </div>
   </div>
 
   <!-- Snapshot drilldown modal -->
-  <div id="snapshot-modal" style="display:none;position:fixed;inset:0;z-index:1200;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;">
-    <div style="background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:16px;width:90%;max-width:800px;max-height:80vh;padding:24px;overflow-y:auto;box-shadow:0 25px 50px rgba(0,0,0,0.25);">
+  <div id="snapshot-modal" style="
+    display:none;
+    position:fixed;
+    inset:0;
+    z-index:1200;
+    background:rgba(0,0,0,0.5);
+    align-items:center;
+    justify-content:center;
+    ">
+    <div style="
+      background:var(--bg-primary);
+      border:1px solid var(--border-primary);
+      border-radius:16px;
+      width:90%;
+      max-width:800px;
+      max-height:80vh;
+      padding:24px;
+      overflow-y:auto;
+      box-shadow:0 25px 50px rgba(0,0,0,0.25);
+      ">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;">
         <h3 style="font-size:16px;font-weight:700;color:var(--text-primary);margin:0;" id="snapshot-title">Snapshot</h3>
-        <button onclick="document.getElementById('snapshot-modal').style.display='none'" style="background:var(--button-bg);border:1px solid var(--border-primary);border-radius:8px;width:32px;height:32px;cursor:pointer;font-size:18px;color:var(--text-tertiary);">&times;</button>
+        <button onclick="document.getElementById('snapshot-modal').style.display='none'" style="
+          background:var(--button-bg);
+          border:1px solid var(--border-primary);
+          border-radius:8px;
+          width:32px;
+          height:32px;
+          cursor:pointer;
+          font-size:18px;
+          color:var(--text-tertiary);
+          ">&times;</button>
       </div>
-      <pre id="snapshot-content" style="font-size:12px;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:8px;padding:16px;overflow-x:auto;white-space:pre-wrap;color:var(--text-secondary);max-height:60vh;"></pre>
+      <pre id="snapshot-content" style="
+        font-size:12px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-primary);
+        border-radius:8px;
+        padding:16px;
+        overflow-x:auto;
+        white-space:pre-wrap;
+        color:var(--text-secondary);
+        max-height:60vh;
+        "></pre>
     </div>
   </div>
 </div>

--- a/templates/tabs/limits.html
+++ b/templates/tabs/limits.html
@@ -1,9 +1,19 @@
 <div class="page" id="page-limits">
   <div class="refresh-bar">
-    <h2 style="font-size:16px;font-weight:700;color:var(--text-primary);margin:0;flex:1;">&#9889; API Rate Limit Monitor</h2>
+    <h2 style="
+      font-size:16px;
+      font-weight:700;
+      color:var(--text-primary);
+      margin:0;
+      flex:1;
+      ">&#9889; API Rate Limit Monitor</h2>
     <button class="refresh-btn" onclick="loadRateLimits()">&#8635; Refresh</button>
   </div>
-  <p style="font-size:12px;color:var(--text-muted);margin:0 0 14px 0;">Rolling 1-minute window utilisation per provider. Red = &ge;90%, amber = &ge;70%. Data sourced from OTLP metrics.</p>
+  <p style="
+    font-size:12px;
+    color:var(--text-muted);
+    margin:0 0 14px 0;
+    ">Rolling 1-minute window utilisation per provider. Red = &ge;90%, amber = &ge;70%. Data sourced from OTLP metrics.</p>
   <div id="rate-limits-content">
     <div class="card" style="padding:24px;text-align:center;color:var(--text-muted);">Loading rate limit data...</div>
   </div>

--- a/templates/tabs/logs.html
+++ b/templates/tabs/logs.html
@@ -3,24 +3,57 @@
     <button class="refresh-btn" onclick="loadLogs()">&#8635; Refresh</button>
     <label style="font-size:12px;color:var(--text-secondary);">Lines:
       <input id="log-lines" type="number" value="200" min="10" max="2000" step="10"
-        style="width:60px;margin-left:4px;padding:3px 6px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-secondary);color:var(--text-primary);font-size:12px;">
+        style="
+          width:60px;
+          margin-left:4px;
+          padding:3px 6px;
+          border:1px solid var(--border-primary);
+          border-radius:6px;
+          background:var(--bg-secondary);
+          color:var(--text-primary);
+          font-size:12px;
+          ">
     </label>
     <input id="log-filter" type="text" placeholder="Filter logs…" oninput="filterLogLines()"
-      style="padding:5px 10px;border-radius:7px;border:1px solid var(--border-primary);background:var(--bg-secondary);color:var(--text-primary);font-size:12px;width:180px;">
+      style="
+        padding:5px 10px;
+        border-radius:7px;
+        border:1px solid var(--border-primary);
+        background:var(--bg-secondary);
+        color:var(--text-primary);
+        font-size:12px;
+        width:180px;
+        ">
     <div style="display:flex;gap:4px;flex-wrap:wrap;">
       <button class="time-btn active" id="log-filter-all"   onclick="setLogLevel('all',this)">All</button>
       <button class="time-btn"        id="log-filter-info"  onclick="setLogLevel('info',this)">Info</button>
       <button class="time-btn"        id="log-filter-warn"  onclick="setLogLevel('warn',this)">Warn</button>
       <button class="time-btn"        id="log-filter-error" onclick="setLogLevel('error',this)">Error</button>
     </div>
-    <label style="display:flex;align-items:center;gap:6px;font-size:12px;color:var(--text-secondary);cursor:pointer;margin-left:auto;">
+    <label style="
+      display:flex;
+      align-items:center;
+      gap:6px;
+      font-size:12px;
+      color:var(--text-secondary);
+      cursor:pointer;
+      margin-left:auto;
+      ">
       <input type="checkbox" id="log-autoscroll" checked> Auto-scroll
     </label>
     <span id="log-stream-status" style="font-size:11px;color:var(--text-muted);">&#9679; Connecting…</span>
   </div>
   <div class="card" style="padding:0;overflow:hidden;margin-top:8px;">
     <div id="logs-full"
-      style="font-family:monospace;font-size:12px;padding:12px 16px;max-height:calc(100vh - 180px);overflow-y:auto;background:var(--bg-secondary);border-radius:8px;">
+      style="
+        font-family:monospace;
+        font-size:12px;
+        padding:12px 16px;
+        max-height:calc(100vh - 180px);
+        overflow-y:auto;
+        background:var(--bg-secondary);
+        border-radius:8px;
+        ">
       <div style="color:var(--text-muted);text-align:center;padding:24px;">Loading logs…</div>
     </div>
   </div>

--- a/templates/tabs/models.html
+++ b/templates/tabs/models.html
@@ -41,7 +41,11 @@
     </table>
   </div>
   <div id="model-switches-section" style="display:none;">
-    <div class="section-title">&#x1F500; Model Switches <span id="model-switches-count" style="font-size:13px;color:var(--text-muted);font-weight:400;"></span></div>
+    <div class="section-title">&#x1F500; Model Switches <span id="model-switches-count" style="
+      font-size:13px;
+      color:var(--text-muted);
+      font-weight:400;
+      "></span></div>
     <div class="card">
       <table class="usage-table" id="model-switches-table" style="width:100%;">
         <thead><tr>

--- a/templates/tabs/nemoclaw.html
+++ b/templates/tabs/nemoclaw.html
@@ -5,8 +5,23 @@
       <div style="display:flex;align-items:center;gap:10px;">
         <span id="nc-status-dot" style="font-size:18px;">🟢</span>
         <span style="font-size:14px;font-weight:700;color:#76b900;">NemoClaw</span>
-        <span id="nc-sandbox-name" style="font-size:12px;background:rgba(118,185,0,0.15);color:#76b900;border:1px solid rgba(118,185,0,0.3);border-radius:12px;padding:2px 10px;font-weight:600;"></span>
-        <span id="nc-blueprint-ver" style="font-size:12px;background:var(--bg-secondary);color:var(--text-muted);border:1px solid var(--border);border-radius:12px;padding:2px 10px;"></span>
+        <span id="nc-sandbox-name" style="
+          font-size:12px;
+          background:rgba(118,185,0,0.15);
+          color:#76b900;
+          border:1px solid rgba(118,185,0,0.3);
+          border-radius:12px;
+          padding:2px 10px;
+          font-weight:600;
+          "></span>
+        <span id="nc-blueprint-ver" style="
+          font-size:12px;
+          background:var(--bg-secondary);
+          color:var(--text-muted);
+          border:1px solid var(--border);
+          border-radius:12px;
+          padding:2px 10px;
+          "></span>
       </div>
       <button class="refresh-btn" onclick="loadNemoClaw()">&#8635; Refresh</button>
     </div>
@@ -16,7 +31,11 @@
       <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:14px;">
         <div style="font-size:11px;font-weight:700;color:#76b900;letter-spacing:1px;margin-bottom:10px;">SANDBOX</div>
         <table style="width:100%;border-collapse:collapse;font-size:12px;">
-          <tr><td style="color:var(--text-muted);padding:3px 0;width:45%;">Status</td><td id="nc-sandbox-status" style="color:var(--text-primary);font-family:\'JetBrains Mono\',monospace;">&#8212;</td></tr>
+          <tr><td style="
+            color:var(--text-muted);
+            padding:3px 0;
+            width:45%;
+            ">Status</td><td id="nc-sandbox-status" style="color:var(--text-primary);font-family:\'JetBrains Mono\',monospace;">&#8212;</td></tr>
           <tr><td style="color:var(--text-muted);padding:3px 0;">Blueprint</td><td id="nc-blueprint-ver2" style="color:var(--text-primary);font-family:\'JetBrains Mono\',monospace;">&#8212;</td></tr>
           <tr><td style="color:var(--text-muted);padding:3px 0;">Last action</td><td id="nc-last-action" style="color:var(--text-primary);font-family:\'JetBrains Mono\',monospace;max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">&#8212;</td></tr>
           <tr><td style="color:var(--text-muted);padding:3px 0;">Run ID</td><td id="nc-run-id" style="color:var(--text-tertiary);font-family:\'JetBrains Mono\',monospace;font-size:11px;">&#8212;</td></tr>
@@ -26,7 +45,11 @@
       <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:14px;">
         <div style="font-size:11px;font-weight:700;color:#76b900;letter-spacing:1px;margin-bottom:10px;">INFERENCE</div>
         <table style="width:100%;border-collapse:collapse;font-size:12px;">
-          <tr><td style="color:var(--text-muted);padding:3px 0;width:45%;">Provider</td><td id="nc-provider" style="color:var(--text-primary);font-family:\'JetBrains Mono\',monospace;">&#8212;</td></tr>
+          <tr><td style="
+            color:var(--text-muted);
+            padding:3px 0;
+            width:45%;
+            ">Provider</td><td id="nc-provider" style="color:var(--text-primary);font-family:\'JetBrains Mono\',monospace;">&#8212;</td></tr>
           <tr><td style="color:var(--text-muted);padding:3px 0;">Model</td><td id="nc-model" style="color:var(--text-primary);font-family:\'JetBrains Mono\',monospace;max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">&#8212;</td></tr>
           <tr><td style="color:var(--text-muted);padding:3px 0;">Endpoint</td><td id="nc-endpoint" style="color:var(--text-tertiary);font-family:\'JetBrains Mono\',monospace;font-size:11px;max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">&#8212;</td></tr>
           <tr><td style="color:var(--text-muted);padding:3px 0;">Onboarded</td><td id="nc-onboarded" style="color:var(--text-tertiary);font-family:\'JetBrains Mono\',monospace;font-size:11px;">&#8212;</td></tr>
@@ -34,35 +57,91 @@
       </div>
     </div>
     <!-- Active Policy -->
-    <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:14px;margin-bottom:12px;">
+    <div style="
+      background:var(--bg-secondary);
+      border:1px solid var(--border);
+      border-radius:8px;
+      padding:14px;
+      margin-bottom:12px;
+      ">
       <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;">
         <span style="font-size:11px;font-weight:700;color:#76b900;letter-spacing:1px;">ACTIVE POLICY</span>
-        <span id="nc-policy-hash" style="font-size:11px;color:var(--text-muted);font-family:\'JetBrains Mono\',monospace;background:var(--bg-primary);border:1px solid var(--border-secondary);border-radius:4px;padding:1px 6px;"></span>
+        <span id="nc-policy-hash" style="
+          font-size:11px;
+          color:var(--text-muted);
+          font-family:\'JetBrains Mono\',monospace;
+          background:var(--bg-primary);
+          border:1px solid var(--border-secondary);
+          border-radius:4px;
+          padding:1px 6px;
+          "></span>
         <span id="nc-drift-badge" style="font-size:11px;font-weight:600;"></span>
       </div>
       <!-- Drift alert -->
-      <div id="nc-drift-alert" style="display:none;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.3);border-radius:6px;padding:10px;margin-bottom:10px;">
+      <div id="nc-drift-alert" style="
+        display:none;
+        background:rgba(239,68,68,0.1);
+        border:1px solid rgba(239,68,68,0.3);
+        border-radius:6px;
+        padding:10px;
+        margin-bottom:10px;
+        ">
         <div style="font-size:12px;font-weight:700;color:#ef4444;">&#9888;&#65039; Policy drift detected</div>
-        <div id="nc-drift-detail" style="font-size:11px;color:var(--text-muted);margin-top:4px;font-family:\'JetBrains Mono\',monospace;"></div>
+        <div id="nc-drift-detail" style="
+          font-size:11px;
+          color:var(--text-muted);
+          margin-top:4px;
+          font-family:\'JetBrains Mono\',monospace;
+          "></div>
       </div>
       <!-- Network policies table -->
-      <div id="nc-policy-table" style="font-family:\'JetBrains Mono\',\'SF Mono\',monospace;font-size:12px;line-height:1.8;">
+      <div id="nc-policy-table" style="
+        font-family:\'JetBrains Mono\',\'SF Mono\',monospace;
+        font-size:12px;
+        line-height:1.8;
+        ">
         <div style="color:var(--text-muted);padding:8px 0;">Loading policy...</div>
       </div>
     </div>
     <!-- Applied Presets -->
-    <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:14px;margin-bottom:12px;">
-      <div style="font-size:11px;font-weight:700;color:#76b900;letter-spacing:1px;margin-bottom:10px;">APPLIED PRESETS</div>
+    <div style="
+      background:var(--bg-secondary);
+      border:1px solid var(--border);
+      border-radius:8px;
+      padding:14px;
+      margin-bottom:12px;
+      ">
+      <div style="
+        font-size:11px;
+        font-weight:700;
+        color:#76b900;
+        letter-spacing:1px;
+        margin-bottom:10px;
+        ">APPLIED PRESETS</div>
       <div id="nc-presets" style="display:flex;flex-wrap:wrap;gap:6px;">
         <span style="color:var(--text-muted);font-size:12px;">None detected</span>
       </div>
     </div>
     <!-- Egress Approvals Panel -->
-    <div style="background:var(--bg-secondary);border:1px solid rgba(118,185,0,0.35);border-radius:8px;padding:14px;" id="nc-approvals-panel">
+    <div style="
+      background:var(--bg-secondary);
+      border:1px solid rgba(118,185,0,0.35);
+      border-radius:8px;
+      padding:14px;
+      " id="nc-approvals-panel">
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">
         <div style="display:flex;align-items:center;gap:8px;">
           <span style="font-size:11px;font-weight:700;color:#76b900;letter-spacing:1px;">PENDING EGRESS APPROVALS</span>
-          <span id="nc-approvals-count" style="display:none;font-size:11px;font-weight:700;background:rgba(239,68,68,0.15);color:#ef4444;border:1px solid rgba(239,68,68,0.3);border-radius:10px;padding:1px 8px;"></span>
+          <span id="nc-approvals-count" style="
+            display:none;
+            font-size:11px;
+            font-weight:700;
+            background:rgba(239,68,68,0.15);
+            color:#ef4444;
+            border:1px solid rgba(239,68,68,0.3);
+            border-radius:10px;
+            padding:1px 8px;
+            "></span>
         </div>
         <button class="refresh-btn" onclick="loadNemoClawApprovals()" style="font-size:11px;">&#8635; Refresh</button>
       </div>

--- a/templates/tabs/overview.html
+++ b/templates/tabs/overview.html
@@ -7,7 +7,14 @@
   </div>
 
   <!-- Token Velocity Alert Banner (GH #313) -->
-  <div id="velocity-alert-banner" style="display:none;margin-bottom:8px;border-radius:8px;padding:10px 16px;font-size:13px;font-weight:600;">
+  <div id="velocity-alert-banner" style="
+    display:none;
+    margin-bottom:8px;
+    border-radius:8px;
+    padding:10px 16px;
+    font-size:13px;
+    font-weight:600;
+    ">
     <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px;">
       <span id="velocity-alert-msg"></span>
       <span style="font-size:11px;font-weight:400;color:inherit;opacity:0.8;">auto-refreshes every 30s</span>
@@ -77,45 +84,161 @@
         <div class="scanline-overlay"></div>
         <div class="flow-container" id="overview-flow-container">
           <!-- Flow SVG cloned here by JS -->
-          <div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:13px;">Loading flow...</div>
+          <div style="
+            display:flex;
+            align-items:center;
+            justify-content:center;
+            height:100%;
+            color:var(--text-muted);
+            font-size:13px;
+            ">Loading flow...</div>
         </div>
       </div>
 
       <!-- System Health Panel (below flow SVG) -->
-      <div id="system-health-panel" style="background:var(--bg-secondary);border:1px solid var(--border-primary);border-top:none;padding:16px;box-shadow:var(--card-shadow);">
+      <div id="system-health-panel" style="
+        background:var(--bg-secondary);
+        border:1px solid var(--border-primary);
+        border-top:none;
+        padding:16px;
+        box-shadow:var(--card-shadow);
+        ">
         <div style="font-size:14px;font-weight:700;color:var(--text-primary);margin-bottom:12px;">🏥 System Health</div>
-        <div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">Services</div>
+        <div style="
+          font-size:11px;
+          text-transform:uppercase;
+          letter-spacing:1.5px;
+          color:var(--text-muted);
+          font-weight:600;
+          margin-bottom:6px;
+          ">Services</div>
         <div id="sh-services" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:14px;"></div>
-        <div id="sh-channels-wrap"><div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">Channels</div>
+        <div id="sh-channels-wrap">
+          <div style="
+            font-size:11px;
+            text-transform:uppercase;
+            letter-spacing:1.5px;
+            color:var(--text-muted);
+            font-weight:600;
+            margin-bottom:6px;
+            ">Channels</div>
         <div id="sh-channels" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:14px;"></div></div>
-        <div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">Disk Usage</div>
+        <div style="
+          font-size:11px;
+          text-transform:uppercase;
+          letter-spacing:1.5px;
+          color:var(--text-muted);
+          font-weight:600;
+          margin-bottom:6px;
+          ">Disk Usage</div>
         <div id="sh-disks" style="margin-bottom:14px;"></div>
-        <div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">Cron Jobs</div>
+        <div style="
+          font-size:11px;
+          text-transform:uppercase;
+          letter-spacing:1.5px;
+          color:var(--text-muted);
+          font-weight:600;
+          margin-bottom:6px;
+          ">Cron Jobs</div>
         <div id="sh-crons" style="margin-bottom:14px;"></div>
-        <div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">Sub-Agents (24h)</div>
+        <div style="
+          font-size:11px;
+          text-transform:uppercase;
+          letter-spacing:1.5px;
+          color:var(--text-muted);
+          font-weight:600;
+          margin-bottom:6px;
+          ">Sub-Agents (24h)</div>
         <div id="sh-subagents" style="margin-bottom:14px;"></div>
         <div id="delegation-chains-panel" style="margin-bottom:14px;"></div>
-        <div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">Heartbeat</div>
+        <div style="
+          font-size:11px;
+          text-transform:uppercase;
+          letter-spacing:1.5px;
+          color:var(--text-muted);
+          font-weight:600;
+          margin-bottom:6px;
+          ">Heartbeat</div>
         <div id="sh-heartbeat" style="margin-bottom:14px;"></div>
-        <div id="sh-sandbox-wrap" style="display:none;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">🔒 Sandbox</div>
+        <div id="sh-sandbox-wrap" style="display:none;">
+          <div style="
+            font-size:11px;
+            text-transform:uppercase;
+            letter-spacing:1.5px;
+            color:var(--text-muted);
+            font-weight:600;
+            margin-bottom:6px;
+            ">🔒 Sandbox</div>
         <div id="sh-sandbox" style="margin-bottom:14px;"></div></div>
-        <div id="sh-inference-wrap" style="display:none;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">🤖 Inference Provider</div>
+        <div id="sh-inference-wrap" style="display:none;">
+          <div style="
+            font-size:11px;
+            text-transform:uppercase;
+            letter-spacing:1.5px;
+            color:var(--text-muted);
+            font-weight:600;
+            margin-bottom:6px;
+            ">🤖 Inference Provider</div>
         <div id="sh-inference" style="margin-bottom:14px;"></div></div>
-        <div id="sh-security-wrap" style="display:none;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">🛡️ Security Posture</div>
+        <div id="sh-security-wrap" style="display:none;">
+          <div style="
+            font-size:11px;
+            text-transform:uppercase;
+            letter-spacing:1.5px;
+            color:var(--text-muted);
+            font-weight:600;
+            margin-bottom:6px;
+            ">🛡️ Security Posture</div>
         <div id="sh-security" style="margin-bottom:14px;"></div></div>
-        <div id="sh-reliability-wrap" style="display:none;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">📊 Agent Reliability</div>
+        <div id="sh-reliability-wrap" style="display:none;">
+          <div style="
+            font-size:11px;
+            text-transform:uppercase;
+            letter-spacing:1.5px;
+            color:var(--text-muted);
+            font-weight:600;
+            margin-bottom:6px;
+            ">📊 Agent Reliability</div>
         <div id="sh-reliability" style="margin-bottom:14px;"></div></div>
         <!-- 🔍 Diagnostics Panel (GH#28) -->
         <div id="sh-diagnostics-wrap">
-          <div style="display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:4px 0;" onclick="var b=document.getElementById(\'sh-diagnostics-body\');b.style.display=b.style.display===\'none\'?\'block\':\'none\';this.querySelector(\'.diag-chevron\').textContent=b.style.display===\'none\'?\'▶\':\'▼\';">
-            <div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;">🔍 Configuration Diagnostics</div>
+          <div style="
+            display:flex;
+            align-items:center;
+            justify-content:space-between;
+            cursor:pointer;
+            padding:4px 0;
+            " onclick="var b=document.getElementById(\'sh-diagnostics-body\');b.style.display=b.style.display===\'none\'?\'block\':\'none\';this.querySelector(\'.diag-chevron\').textContent=b.style.display===\'none\'?\'▶\':\'▼\';">
+            <div style="
+              font-size:11px;
+              text-transform:uppercase;
+              letter-spacing:1.5px;
+              color:var(--text-muted);
+              font-weight:600;
+              ">🔍 Configuration Diagnostics</div>
             <div style="display:flex;align-items:center;gap:8px;">
-              <button id="sh-diagnostics-copy" onclick="event.stopPropagation();copyDiagnostics();" style="font-size:10px;padding:2px 8px;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:4px;color:var(--text-muted);cursor:pointer;">📋 Copy</button>
+              <button id="sh-diagnostics-copy" onclick="event.stopPropagation();copyDiagnostics();" style="
+                font-size:10px;
+                padding:2px 8px;
+                background:var(--bg-secondary);
+                border:1px solid var(--border-secondary);
+                border-radius:4px;
+                color:var(--text-muted);
+                cursor:pointer;
+                ">📋 Copy</button>
               <span class="diag-chevron" style="font-size:10px;color:var(--text-muted);">▼</span>
             </div>
           </div>
           <div id="sh-diagnostics-body" style="margin-bottom:14px;">
-            <div id="sh-diagnostics" style="font-family:\'JetBrains Mono\',monospace;font-size:12px;background:var(--bg-primary);border:1px solid var(--border-secondary);border-radius:6px;padding:10px 12px;line-height:1.9;">
+            <div id="sh-diagnostics" style="
+              font-family:\'JetBrains Mono\',monospace;
+              font-size:12px;
+              background:var(--bg-primary);
+              border:1px solid var(--border-secondary);
+              border-radius:6px;
+              padding:10px 12px;
+              line-height:1.9;
+              ">
               <div style="color:var(--text-muted);">Loading diagnostics...</div>
             </div>
           </div>
@@ -142,18 +265,49 @@
         </div>
       </div>
       <!-- 🧠 Brain Panel: Main Agent Activity (below Active Tasks) -->
-      <div id="main-activity-panel" style="background:linear-gradient(180deg, var(--bg-secondary) 0%, #12121a 100%);border:1px solid var(--border-primary);border-radius:12px;padding:10px 14px 8px;min-height:80px;margin-top:14px;display:flex;flex-direction:column;overflow:hidden;">
+      <div id="main-activity-panel" style="
+        background:linear-gradient(180deg, var(--bg-secondary) 0%, #12121a 100%);
+        border:1px solid var(--border-primary);
+        border-radius:12px;
+        padding:10px 14px 8px;
+        min-height:80px;
+        margin-top:14px;
+        display:flex;
+        flex-direction:column;
+        overflow:hidden;
+        ">
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;">
           <div style="display:flex;align-items:center;gap:6px;">
-            <span id="main-activity-dot" style="width:8px;height:8px;border-radius:50%;background:#888;display:inline-block;"></span>
-            <span style="font-size:13px;font-weight:700;color:var(--text-primary);">🧠 <span id="main-activity-model">Claude Opus</span></span>
+            <span id="main-activity-dot" style="
+              width:8px;
+              height:8px;
+              border-radius:50%;
+              background:#888;
+              display:inline-block;
+              "></span>
+            <span style="
+              font-size:13px;
+              font-weight:700;
+              color:var(--text-primary);
+              ">🧠 <span id="main-activity-model">Claude Opus</span></span>
             <span id="main-activity-status" style="font-size:10px;color:var(--text-muted);">
               <span id="main-activity-label">...</span>
             </span>
           </div>
         </div>
-        <div id="main-activity-list" style="overflow-y:auto;flex:1;font-size:11px;font-family:'JetBrains Mono','Fira Code',monospace;line-height:1.6;">
-          <div style="text-align:center;padding:8px;color:var(--text-muted);font-size:11px;">Waiting for activity...</div>
+        <div id="main-activity-list" style="
+          overflow-y:auto;
+          flex:1;
+          font-size:11px;
+          font-family:'JetBrains Mono','Fira Code',monospace;
+          line-height:1.6;
+          ">
+          <div style="
+            text-align:center;
+            padding:8px;
+            color:var(--text-muted);
+            font-size:11px;
+            ">Waiting for activity...</div>
         </div>
       </div>
     </div>
@@ -167,7 +321,10 @@
     <span id="subagents-preview"></span>
     <span id="tools-active">--</span>
     <span id="tools-recent">--</span>
-    <div id="tools-sparklines"><div class="tool-spark"><span>--</span></div><div class="tool-spark"><span>--</span></div><div class="tool-spark"><span>--</span></div></div>
+    <div id="tools-sparklines">
+      <div class="tool-spark"><span>--</span></div>
+      <div class="tool-spark"><span>--</span></div>
+      <div class="tool-spark"><span>--</span></div></div>
     <div id="active-tasks-grid"></div>
     <div id="activity-stream"></div>
   </div>

--- a/templates/tabs/security.html
+++ b/templates/tabs/security.html
@@ -8,50 +8,158 @@
       </div>
     </div>
     <!-- Security Posture Score -->
-    <div id="security-posture-panel" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:16px;margin-bottom:14px;">
+    <div id="security-posture-panel" style="
+      background:var(--bg-secondary);
+      border:1px solid var(--border);
+      border-radius:8px;
+      padding:16px;
+      margin-bottom:14px;
+      ">
       <div style="display:flex;align-items:center;gap:16px;margin-bottom:12px;">
-        <div id="posture-score-badge" style="width:64px;height:64px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:800;color:#fff;background:#64748b;flex-shrink:0;">?</div>
+        <div id="posture-score-badge" style="
+          width:64px;
+          height:64px;
+          border-radius:50%;
+          display:flex;
+          align-items:center;
+          justify-content:center;
+          font-size:28px;
+          font-weight:800;
+          color:#fff;
+          background:#64748b;
+          flex-shrink:0;
+          ">?</div>
         <div style="flex:1;">
           <div style="font-size:13px;font-weight:700;color:var(--text-primary);">Security Posture</div>
-          <div id="posture-score-label" style="font-size:11px;color:var(--text-muted);margin-top:2px;">Scanning configuration...</div>
+          <div id="posture-score-label" style="
+            font-size:11px;
+            color:var(--text-muted);
+            margin-top:2px;
+            ">Scanning configuration...</div>
           <div style="margin-top:6px;background:var(--bg-primary);border-radius:4px;height:6px;overflow:hidden;">
-            <div id="posture-score-bar" style="height:100%;width:0%;background:#64748b;border-radius:4px;transition:width 0.5s ease;"></div>
+            <div id="posture-score-bar" style="
+              height:100%;
+              width:0%;
+              background:#64748b;
+              border-radius:4px;
+              transition:width 0.5s ease;
+              "></div>
           </div>
         </div>
         <div style="display:flex;gap:12px;flex-shrink:0;">
-          <div style="text-align:center;"><div id="posture-passed" style="font-size:18px;font-weight:700;color:#22c55e;">-</div><div style="font-size:10px;color:var(--text-muted);">Passed</div></div>
-          <div style="text-align:center;"><div id="posture-warnings" style="font-size:18px;font-weight:700;color:#f59e0b;">-</div><div style="font-size:10px;color:var(--text-muted);">Warnings</div></div>
-          <div style="text-align:center;"><div id="posture-failed" style="font-size:18px;font-weight:700;color:#ef4444;">-</div><div style="font-size:10px;color:var(--text-muted);">Failed</div></div>
+          <div style="text-align:center;">
+            <div id="posture-passed" style="font-size:18px;font-weight:700;color:#22c55e;">-</div>
+            <div style="font-size:10px;color:var(--text-muted);">Passed</div></div>
+          <div style="text-align:center;">
+            <div id="posture-warnings" style="font-size:18px;font-weight:700;color:#f59e0b;">-</div>
+            <div style="font-size:10px;color:var(--text-muted);">Warnings</div></div>
+          <div style="text-align:center;">
+            <div id="posture-failed" style="font-size:18px;font-weight:700;color:#ef4444;">-</div>
+            <div style="font-size:10px;color:var(--text-muted);">Failed</div></div>
         </div>
       </div>
       <div id="posture-checks-list" style="display:grid;gap:6px;"></div>
     </div>
     <!-- Threat Detection -->
-    <div style="font-size:13px;font-weight:700;color:var(--text-primary);margin-bottom:10px;">Threat Detection &amp; Anomaly Alerts</div>
+    <div style="
+      font-size:13px;
+      font-weight:700;
+      color:var(--text-primary);
+      margin-bottom:10px;
+      ">Threat Detection &amp; Anomaly Alerts</div>
     <div id="security-summary" style="display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-bottom:14px;">
-      <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:12px;text-align:center;">
+      <div style="
+        background:var(--bg-secondary);
+        border:1px solid var(--border);
+        border-radius:8px;
+        padding:12px;
+        text-align:center;
+        ">
         <div style="font-size:24px;font-weight:700;color:#ef4444;" id="sec-critical-count">0</div>
         <div style="font-size:11px;color:var(--text-muted);">Critical</div>
       </div>
-      <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:12px;text-align:center;">
+      <div style="
+        background:var(--bg-secondary);
+        border:1px solid var(--border);
+        border-radius:8px;
+        padding:12px;
+        text-align:center;
+        ">
         <div style="font-size:24px;font-weight:700;color:#f59e0b;" id="sec-high-count">0</div>
         <div style="font-size:11px;color:var(--text-muted);">High</div>
       </div>
-      <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:12px;text-align:center;">
+      <div style="
+        background:var(--bg-secondary);
+        border:1px solid var(--border);
+        border-radius:8px;
+        padding:12px;
+        text-align:center;
+        ">
         <div style="font-size:24px;font-weight:700;color:#3b82f6;" id="sec-medium-count">0</div>
         <div style="font-size:11px;color:var(--text-muted);">Medium</div>
       </div>
-      <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:12px;text-align:center;">
+      <div style="
+        background:var(--bg-secondary);
+        border:1px solid var(--border);
+        border-radius:8px;
+        padding:12px;
+        text-align:center;
+        ">
         <div style="font-size:24px;font-weight:700;color:#22c55e;" id="sec-clean-count">0</div>
         <div style="font-size:11px;color:var(--text-muted);">Clean Sessions</div>
       </div>
     </div>
     <div id="security-filter-pills" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px;">
-      <button class="brain-chip active" data-severity="all" onclick="setSecurityFilter('all',this)" style="padding:3px 10px;border-radius:12px;border:1px solid #a855f7;background:rgba(168,85,247,0.2);color:#a855f7;font-size:11px;cursor:pointer;font-weight:600;">All</button>
-      <button class="brain-chip" data-severity="critical" onclick="setSecurityFilter('critical',this)" style="padding:3px 10px;border-radius:12px;border:1px solid #ef4444;background:transparent;color:#ef4444;font-size:11px;cursor:pointer;font-weight:600;">Critical</button>
-      <button class="brain-chip" data-severity="high" onclick="setSecurityFilter('high',this)" style="padding:3px 10px;border-radius:12px;border:1px solid #f59e0b;background:transparent;color:#f59e0b;font-size:11px;cursor:pointer;font-weight:600;">High</button>
-      <button class="brain-chip" data-severity="medium" onclick="setSecurityFilter('medium',this)" style="padding:3px 10px;border-radius:12px;border:1px solid #3b82f6;background:transparent;color:#3b82f6;font-size:11px;cursor:pointer;font-weight:600;">Medium</button>
-      <button class="brain-chip" data-severity="low" onclick="setSecurityFilter('low',this)" style="padding:3px 10px;border-radius:12px;border:1px solid #64748b;background:transparent;color:#64748b;font-size:11px;cursor:pointer;font-weight:600;">Low</button>
+      <button class="brain-chip active" data-severity="all" onclick="setSecurityFilter('all',this)" style="
+        padding:3px 10px;
+        border-radius:12px;
+        border:1px solid #a855f7;
+        background:rgba(168,85,247,0.2);
+        color:#a855f7;
+        font-size:11px;
+        cursor:pointer;
+        font-weight:600;
+        ">All</button>
+      <button class="brain-chip" data-severity="critical" onclick="setSecurityFilter('critical',this)" style="
+        padding:3px 10px;
+        border-radius:12px;
+        border:1px solid #ef4444;
+        background:transparent;
+        color:#ef4444;
+        font-size:11px;
+        cursor:pointer;
+        font-weight:600;
+        ">Critical</button>
+      <button class="brain-chip" data-severity="high" onclick="setSecurityFilter('high',this)" style="
+        padding:3px 10px;
+        border-radius:12px;
+        border:1px solid #f59e0b;
+        background:transparent;
+        color:#f59e0b;
+        font-size:11px;
+        cursor:pointer;
+        font-weight:600;
+        ">High</button>
+      <button class="brain-chip" data-severity="medium" onclick="setSecurityFilter('medium',this)" style="
+        padding:3px 10px;
+        border-radius:12px;
+        border:1px solid #3b82f6;
+        background:transparent;
+        color:#3b82f6;
+        font-size:11px;
+        cursor:pointer;
+        font-weight:600;
+        ">Medium</button>
+      <button class="brain-chip" data-severity="low" onclick="setSecurityFilter('low',this)" style="
+        padding:3px 10px;
+        border-radius:12px;
+        border:1px solid #64748b;
+        background:transparent;
+        color:#64748b;
+        font-size:11px;
+        cursor:pointer;
+        font-weight:600;
+        ">Low</button>
     </div>
     <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;">
       <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;">
@@ -62,8 +170,20 @@
         <div style="color:var(--text-muted);padding:20px">Scanning...</div>
       </div>
     </div>
-    <div style="margin-top:14px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;">
-      <div style="font-size:12px;font-weight:700;color:var(--text-primary);margin-bottom:8px;cursor:pointer;" onclick="toggleSecCatalog()">&#128203; Signature Catalog <span id="sec-catalog-arrow" style="font-size:10px;">&#9654;</span></div>
+    <div style="
+      margin-top:14px;
+      background:var(--bg-secondary);
+      border:1px solid var(--border);
+      border-radius:8px;
+      padding:10px 14px;
+      ">
+      <div style="
+        font-size:12px;
+        font-weight:700;
+        color:var(--text-primary);
+        margin-bottom:8px;
+        cursor:pointer;
+        " onclick="toggleSecCatalog()">&#128203; Signature Catalog <span id="sec-catalog-arrow" style="font-size:10px;">&#9654;</span></div>
       <div id="sec-catalog" style="display:none;"></div>
     </div>
   </div>

--- a/templates/tabs/subagents.html
+++ b/templates/tabs/subagents.html
@@ -3,5 +3,6 @@
     <h2 style="font-size:16px;font-weight:700;color:var(--text-primary);margin:0;flex:1;">&#129313; Sub-Agent Tree</h2>
     <button class="refresh-btn" onclick="loadSubagents()">&#8635; Refresh</button>
   </div>
-  <div id="subagents-list"><div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading...</div></div>
+  <div id="subagents-list">
+    <div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading...</div></div>
 </div><!-- end page-subagents (theme 2) -->

--- a/templates/tabs/transcripts.html
+++ b/templates/tabs/transcripts.html
@@ -7,19 +7,91 @@
   <div id="transcript-viewer" style="display:none">
     <div class="transcript-viewer-meta" id="transcript-meta"></div>
     <!-- Session Replay Controls -->
-    <div id="replay-controls" style="display:none;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:10px;padding:12px 14px;margin-bottom:10px;">
+    <div id="replay-controls" style="
+      display:none;
+      background:var(--bg-secondary);
+      border:1px solid var(--border-secondary);
+      border-radius:10px;
+      padding:12px 14px;
+      margin-bottom:10px;
+      ">
       <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;flex-wrap:wrap;">
-        <button id="replay-prev" onclick="replayPrev()" style="padding:5px 12px;border-radius:6px;border:none;background:var(--button-bg);color:var(--text-primary);cursor:pointer;font-size:14px;">&#9664;</button>
-        <span id="replay-pos" style="font-size:13px;color:var(--text-muted);min-width:60px;text-align:center;">0/0</span>
-        <button id="replay-next" onclick="replayNext()" style="padding:5px 12px;border-radius:6px;border:none;background:var(--button-bg);color:var(--text-primary);cursor:pointer;font-size:14px;">&#9654;</button>
-        <input type="range" id="replay-scrubber" min="0" max="0" value="0" oninput="replayJumpTo(parseInt(this.value))" style="flex:1;min-width:120px;accent-color:#6366f1;">
+        <button id="replay-prev" onclick="replayPrev()" style="
+          padding:5px 12px;
+          border-radius:6px;
+          border:none;
+          background:var(--button-bg);
+          color:var(--text-primary);
+          cursor:pointer;
+          font-size:14px;
+          ">&#9664;</button>
+        <span id="replay-pos" style="
+          font-size:13px;
+          color:var(--text-muted);
+          min-width:60px;
+          text-align:center;
+          ">0/0</span>
+        <button id="replay-next" onclick="replayNext()" style="
+          padding:5px 12px;
+          border-radius:6px;
+          border:none;
+          background:var(--button-bg);
+          color:var(--text-primary);
+          cursor:pointer;
+          font-size:14px;
+          ">&#9654;</button>
+        <input type="range" id="replay-scrubber" min="0" max="0" value="0" oninput="replayJumpTo(parseInt(this.value))" style="
+          flex:1;
+          min-width:120px;
+          accent-color:#6366f1;
+          ">
       </div>
       <div style="display:flex;gap:6px;flex-wrap:wrap;">
-        <button class="replay-filter active-filter" data-type="all" onclick="replayFilter('all')" style="padding:4px 10px;border-radius:20px;border:1px solid var(--border-secondary);background:#6366f1;color:#fff;font-size:12px;cursor:pointer;">All</button>
-        <button class="replay-filter" data-type="tool_use" onclick="replayFilter('tool_use')" style="padding:4px 10px;border-radius:20px;border:1px solid var(--border-secondary);background:var(--button-bg);color:var(--text-secondary);font-size:12px;cursor:pointer;">&#128295; Tools</button>
-        <button class="replay-filter" data-type="thinking" onclick="replayFilter('thinking')" style="padding:4px 10px;border-radius:20px;border:1px solid var(--border-secondary);background:var(--button-bg);color:var(--text-secondary);font-size:12px;cursor:pointer;">&#129504; Thinking</button>
-        <button class="replay-filter" data-type="assistant" onclick="replayFilter('assistant')" style="padding:4px 10px;border-radius:20px;border:1px solid var(--border-secondary);background:var(--button-bg);color:var(--text-secondary);font-size:12px;cursor:pointer;">&#129776; AI</button>
-        <button class="replay-filter" data-type="user" onclick="replayFilter('user')" style="padding:4px 10px;border-radius:20px;border:1px solid var(--border-secondary);background:var(--button-bg);color:var(--text-secondary);font-size:12px;cursor:pointer;">&#128100; User</button>
+        <button class="replay-filter active-filter" data-type="all" onclick="replayFilter('all')" style="
+          padding:4px 10px;
+          border-radius:20px;
+          border:1px solid var(--border-secondary);
+          background:#6366f1;
+          color:#fff;
+          font-size:12px;
+          cursor:pointer;
+          ">All</button>
+        <button class="replay-filter" data-type="tool_use" onclick="replayFilter('tool_use')" style="
+          padding:4px 10px;
+          border-radius:20px;
+          border:1px solid var(--border-secondary);
+          background:var(--button-bg);
+          color:var(--text-secondary);
+          font-size:12px;
+          cursor:pointer;
+          ">&#128295; Tools</button>
+        <button class="replay-filter" data-type="thinking" onclick="replayFilter('thinking')" style="
+          padding:4px 10px;
+          border-radius:20px;
+          border:1px solid var(--border-secondary);
+          background:var(--button-bg);
+          color:var(--text-secondary);
+          font-size:12px;
+          cursor:pointer;
+          ">&#129504; Thinking</button>
+        <button class="replay-filter" data-type="assistant" onclick="replayFilter('assistant')" style="
+          padding:4px 10px;
+          border-radius:20px;
+          border:1px solid var(--border-secondary);
+          background:var(--button-bg);
+          color:var(--text-secondary);
+          font-size:12px;
+          cursor:pointer;
+          ">&#129776; AI</button>
+        <button class="replay-filter" data-type="user" onclick="replayFilter('user')" style="
+          padding:4px 10px;
+          border-radius:20px;
+          border:1px solid var(--border-secondary);
+          background:var(--button-bg);
+          color:var(--text-secondary);
+          font-size:12px;
+          cursor:pointer;
+          ">&#128100; User</button>
       </div>
     </div>
     <div class="chat-messages" id="transcript-messages"></div>

--- a/templates/tabs/usage.html
+++ b/templates/tabs/usage.html
@@ -37,19 +37,40 @@
   <div class="section-title">💰 Cost Breakdown <span id="usage-cost-info-icon" class="tooltip-info-icon" style="display:none;">i</span></div>
   <div class="card"><table class="usage-table" id="usage-cost-table"><tbody><tr><td colspan="3" style="color:#666;">Loading...</td></tr></tbody></table></div>
   <div id="usage-anomaly-section" style="display:none;">
-    <div class="section-title">⚠️ Anomaly Alerts <span id="usage-anomaly-badge" style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:10px;background:#7f1d1d;color:#fca5a5;margin-left:8px;"></span></div>
+    <div class="section-title">⚠️ Anomaly Alerts <span id="usage-anomaly-badge" style="
+      font-size:11px;
+      font-weight:600;
+      padding:2px 8px;
+      border-radius:10px;
+      background:#7f1d1d;
+      color:#fca5a5;
+      margin-left:8px;
+      "></span></div>
     <div class="card" id="usage-anomaly-list" style="font-size:13px;"></div>
   </div>
   <div class="section-title">🧩 Cost By Plugin / Skill</div>
   <div class="card">
     <div style="display:flex;gap:16px;align-items:flex-start;flex-wrap:wrap;">
       <canvas id="usage-plugin-pie" width="280" height="280" style="max-width:280px;max-height:280px;"></canvas>
-      <div id="usage-plugin-legend" style="flex:1;min-width:220px;font-size:12px;color:var(--text-secondary);">Loading...</div>
+      <div id="usage-plugin-legend" style="
+        flex:1;
+        min-width:220px;
+        font-size:12px;
+        color:var(--text-secondary);
+        ">Loading...</div>
     </div>
   </div>
   <div class="section-title">💸 Top Sessions by Cost
     <span style="float:right;font-size:12px;font-weight:400;color:var(--text-muted);">Alert threshold:
-      $<input id="session-cost-threshold" type="number" min="0" step="0.01" value="0.50" style="width:60px;padding:2px 6px;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:4px;color:var(--text-primary);font-size:12px;" onchange="renderSessionCostChart()">
+      $<input id="session-cost-threshold" type="number" min="0" step="0.01" value="0.50" style="
+        width:60px;
+        padding:2px 6px;
+        background:var(--bg-secondary);
+        border:1px solid var(--border-secondary);
+        border-radius:4px;
+        color:var(--text-primary);
+        font-size:12px;
+        " onchange="renderSessionCostChart()">
       per session</span>
   </div>
   <div class="card">
@@ -71,14 +92,27 @@
     </div>
     <div class="section-title">🤖 Model Breakdown</div>
     <div class="card"><table class="usage-table" id="usage-model-table"><tbody><tr><td colspan="2" style="color:#666;">No model data</td></tr></tbody></table></div>
-    <div style="margin-top:12px;padding:8px 12px;background:#1a3a2a;border:1px solid #2a5a3a;border-radius:8px;font-size:12px;color:#60ff80;">📡 Data source: OpenTelemetry OTLP - real-time metrics from OpenClaw</div>
+    <div style="
+      margin-top:12px;
+      padding:8px 12px;
+      background:#1a3a2a;
+      border:1px solid #2a5a3a;
+      border-radius:8px;
+      font-size:12px;
+      color:#60ff80;
+      ">📡 Data source: OpenTelemetry OTLP - real-time metrics from OpenClaw</div>
   </div>
   <!-- Cost Comparison Panel (GH#554) -->
   <div class="section-title" id="cost-comparison-section" style="display:flex;align-items:center;">💱 Cost Comparison <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">what same workload costs elsewhere · 30 days</span></div>
   <div class="card" id="cost-comparison-card" style="display:none;">
     <div id="cost-comparison-content" style="min-height:60px;color:var(--text-muted);">Loading...</div>
   </div>
-    <div class="section-title">🔮 Trace Clusters <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">auto-group sessions by behavior pattern</span></div>
+    <div class="section-title">🔮 Trace Clusters <span style="
+      font-size:11px;
+      font-weight:400;
+      color:var(--text-muted);
+      margin-left:8px;
+      ">auto-group sessions by behavior pattern</span></div>
   <div class="card">
     <div id="trace-clusters-content" style="min-height:60px;color:var(--text-muted);">Loading...</div>
   </div>
@@ -89,10 +123,16 @@
     </span>
   </div>
   <div class="card">
-    <div class="heatmap-wrap"><div id="heatmap-grid" class="heatmap-grid">Loading...</div></div>
+    <div class="heatmap-wrap">
+      <div id="heatmap-grid" class="heatmap-grid">Loading...</div></div>
     <div id="heatmap-legend" class="heatmap-legend"></div>
   </div>
-  <div class="section-title">🎯 Skill Cost Leaderboard <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">heuristic attribution — 30s window</span></div>
+  <div class="section-title">🎯 Skill Cost Leaderboard <span style="
+    font-size:11px;
+    font-weight:400;
+    color:var(--text-muted);
+    margin-left:8px;
+    ">heuristic attribution — 30s window</span></div>
   <div class="card" id="skill-leaderboard-card">
     <div id="skill-leaderboard-content" style="min-height:60px;color:var(--text-muted);">Loading...</div>
   </div>


### PR DESCRIPTION
## Summary
Two-pass surgical reformatter applied to all 20 template files:
1. **Split sibling tags onto separate lines** — `<div ...><div ...>` becomes two indented lines instead of one wide one
2. **Break overlong inline `style="..."`** onto multiple lines when CSS has 3+ declarations and total line >120 chars

Out of scope (left untouched): `onclick=`, `oninput=`, SVG `d=`, JS with escaped quotes inside attrs.

Output is byte-equivalent to a browser since CSS+HTML both ignore intra-attr newlines.

## Readability impact
- **>120-char lines: 252 → 75 (-70%)** across all templates
- 12/20 files now have **zero** lines over 120 chars
- biggest wins: `crons.html` 345→119 chars, `cloud-modal.html` 326→202

## E2E — all green
- 16/16 extracted tabs render
- 25/25 sampled DOM ids count ≥1 in rendered output
- 35/35 API endpoints + main page 200
- Zero tracebacks
- HTML payload: 105 KB → 117 KB (added newlines, gzips identically)

## Remaining long lines
Most are intentional — JS in `onclick=` with escaped quotes (`flow.html` and others), or single-attribute super-long `style=` from upstream. Could be split further with manual surgery later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)