### PR TITLE
fix: TUI Flow node is now clickable (missed in PR #627)

### DIFF
--- a/routes/channels.py
+++ b/routes/channels.py
@@ -1442,6 +1442,17 @@ def api_channel_msteams():
     return jsonify(data)
 
 
+@bp_channels.route("/api/channel/tui")
+def api_channel_tui():
+    """TUI channel: surfaces messages tagged `messageChannel=tui` in the
+    OpenClaw gateway log. The TUI is the OpenClaw terminal interface —
+    same Flow-node behaviour as Telegram/Signal/etc but its messages live
+    in gateway.log rather than a dedicated adapter directory.
+    """
+    import dashboard as _d
+    return _d._generic_channel_data("tui")
+
+
 @bp_channels.route("/api/channel/matrix")
 def api_channel_matrix():
     import dashboard as _d

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -5677,6 +5677,7 @@ var _modalEvents = [];
 
 /* === Component Modal === */
 var COMP_MAP = {
+  'node-tui':         {type:'channel', name:'TUI',            icon:'⌨️', chKey:'tui'},
   'node-telegram':    {type:'channel', name:'Telegram',       icon:'📱', chKey:'telegram'},
   'node-signal':      {type:'channel', name:'Signal',         icon:'🔒', chKey:'signal'},
   'node-whatsapp':    {type:'channel', name:'WhatsApp',       icon:'📲', chKey:'whatsapp'},
@@ -5894,7 +5895,7 @@ function openCompModal(nodeId) {
   }
 
   // Generic channel handler for all other channel types
-  var GENERIC_CHANNELS = ['node-googlechat',
+  var GENERIC_CHANNELS = ['node-tui','node-googlechat',
     'node-msteams','node-matrix','node-mattermost','node-line',
     'node-nostr','node-twitch','node-feishu','node-zalo'];
   if (GENERIC_CHANNELS.indexOf(nodeId) !== -1 && c.chKey) {


### PR DESCRIPTION
## Summary
PR #627 added the ⌨️ TUI node to the Flow SVG + dynamic channel detection but missed the click-handler wiring. Clicking the TUI box did nothing because:
- `COMP_MAP` (iterated by the click-binding loop) had no `'node-tui'` entry
- No `/api/channel/tui` route existed

Reported by user via screenshot.

## Fix (3 small changes)
1. **static/js/app.js**: add `'node-tui'` to `COMP_MAP`
2. **static/js/app.js**: add `'node-tui'` to `GENERIC_CHANNELS` so `openCompModal` routes to the generic loader
3. **routes/channels.py**: register `/api/channel/tui` → `_d._generic_channel_data("tui")` (same one-line pattern as matrix/line/nostr)

The endpoint scans gateway.log for `messageChannel=tui` events. On nodes without TUI message activity yet, modal shows "no messages found" (same UX as an empty Telegram/Signal channel). Click works either way.

## E2E
- `/api/channel/tui` → 200, valid JSON
- Reloaded `/static/js/app.js` contains the new COMP_MAP entry
- Main page still 200
- Zero tracebacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)