### PR TITLE
[RELEASE] fix: drop CLOUD_MODE guard from loadSecurityPosture

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1826,7 +1826,11 @@ async function ncReject(sandbox, chunkId, btn) {
 }
 
 async function loadSecurityPosture() {
-  if (window.CLOUD_MODE) return;
+  // Cloud mode no longer short-circuits this — the daemon now collects
+  // posture locally and pushes on its heartbeat, cloud stores it per node,
+  // and `/api/security/posture` returns the synced snapshot. The cloud-
+  // mode fetch shim auto-injects ?node_id=<current> + &token=<cm_> so the
+  // call works against either OSS-local OR cloud-served handler.
   try {
     var data = await fetchJsonWithTimeout('/api/security/posture', 25000);
     var badge = document.getElementById('posture-score-badge');


### PR DESCRIPTION
## Summary

The daemon-collects → cloud-stores → cloud-serves loop for Security is fully wired (OSS PR #664 + cloud PR #332 + #333) — `/api/security/posture?node_id=<n>` returns the daemon-pushed snapshot from Cloud SQL on `app.clawmetry.com`. **But** the frontend's `loadSecurityPosture()` still has a hard `if (window.CLOUD_MODE) return;` early-exit from before the data was synced.

Result: in the cloud iframe, the page renders the chrome (loading state) but never paints the score/checks because the renderer never runs.

This PR removes that guard. Cloud's iframe fetch shim already auto-injects `?node_id=<current>&token=<cm_>` so the call resolves to either OSS-local or cloud-served handler — same response shape, same renderer.

## Test plan
- [x] `curl https://app.clawmetry.com/api/security/posture?node_id=…` returns score=A + 10 checks (already verified)
- [ ] After release + cloud Docker pin bump: Security tab in cloud iframe shows score badge + checks list

🤖 Generated with [Claude Code](https://claude.com/claude-code)