### PR TITLE
chore: bump version 0.12.99 → 0.12.102 (auto-release blocked)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -130,7 +130,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.99"
+__version__ = "0.12.102"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Auto-release-on-merge can no longer push to main directly (branch protection requires PRs). Last 3 [RELEASE] PRs (#663/#664/#665) merged but their version-bump pushes were rejected — PyPI stuck at 0.12.101.

Manual bump so publish.yml's tag-driven path can take over.