### PR TITLE
chore: bump 0.12.102 → 0.12.103 (cloud-mediated approvals)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -131,7 +131,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.102"
+__version__ = "0.12.103"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Auto-release-on-merge bot can't push to main (branch protection). Manual bump so publish.yml tag trigger can publish #668 to PyPI.