### PR TITLE
[RELEASE] fix: end-to-end approvals (auth header + watermark + log wiring)

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -214,10 +214,34 @@ def match_policy(policies: list[dict], tool_name: str, args: dict):
 
 
 def _post_approval_request(api_key: str, payload: dict) -> Optional[dict]:
-    """POST to cloud's /api/approvals/request. Returns dict or None on failure."""
+    """POST to cloud's /api/approvals/request. Returns dict or None on failure.
+
+    We don't reuse `clawmetry.sync._post` because that ships X-Api-Key, but
+    the cloud auth shim only honors `Authorization: Bearer` for /api/* paths.
+    """
+    import urllib.request, urllib.error
+    from clawmetry.sync import INGEST_URL
     try:
-        from clawmetry.sync import _post
-        return _post("/api/approvals/request", payload, api_key, timeout=10)
+        body = json.dumps(payload).encode()
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        }
+        if payload.get("node_id"):
+            headers["X-Node-Id"] = payload["node_id"]
+        req = urllib.request.Request(
+            f"{INGEST_URL.rstrip('/')}/api/approvals/request",
+            data=body, headers=headers, method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        try:
+            err_body = e.read().decode("utf-8", errors="replace")[:200]
+        except Exception:
+            err_body = ""
+        log.warning(f"approval request POST failed: HTTP {e.code} — {err_body}")
+        return None
     except Exception as e:
         log.warning(f"approval request POST failed: {e}")
         return None

--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -410,7 +410,14 @@ def watch_iteration(api_key: str, node_id: str,
             continue
         try:
             size = os.path.getsize(fpath)
-            offset = _file_offsets.get(fpath, size)  # default: start at EOF
+            # First time we see this file: anchor to current EOF *and persist
+            # the watermark*, so subsequent appends are visible. The previous
+            # version re-defaulted to `size` every iteration, which silently
+            # absorbed any new bytes.
+            if fpath not in _file_offsets:
+                _file_offsets[fpath] = size
+                continue
+            offset = _file_offsets[fpath]
             if offset > size:
                 offset = 0  # log rotated
             if offset == size:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2937,6 +2937,18 @@ def run_daemon() -> None:
     try:
         from clawmetry import approvals as _approvals
         _approvals_stop = threading.Event()
+        # Route the approvals logger through the same handlers as our sync
+        # logger so watcher activity (policy fires, decisions, kills) shows
+        # up in ~/.clawmetry/sync.log alongside the sync line items.
+        try:
+            _ap_log = logging.getLogger("clawmetry-approvals")
+            _ap_log.setLevel(logging.INFO)
+            _ap_log.propagate = False
+            for _h in list(log.handlers):
+                if _h not in _ap_log.handlers:
+                    _ap_log.addHandler(_h)
+        except Exception:
+            pass
 
         def _approvals_worker():
             try:


### PR DESCRIPTION
## Summary

End-to-end debugging of the cloud-mediated approvals flow surfaced three blocking bugs in 0.12.103. This [RELEASE] PR fixes all three so the demo path works clean from policy match → Slack/UI Deny → daemon kills session.

### 1. `_post_approval_request` was using `X-Api-Key`, cloud only honors `Authorization: Bearer`

The OSS sync daemon's generic `_post()` ships `X-Api-Key`. The cloud's `_check_auth` shim only honors `Authorization: Bearer` for `/api/*` paths (it bypasses `/ingest/*` for X-Api-Key). Result: every approval request POST got `401 Unauthorized. Cloud mode requires a cm_ API key.` despite a perfectly valid cm_ token.

Replaced the call with a small inline `urllib.request.Request` that sends the right header. Also surfaces the actual HTTP error body on failure so future bugs aren't masked.

### 2. Watermark default re-evaluated to current EOF every iteration

`_file_offsets.get(fpath, size)` defaulted to the *current* file size every time it was called. So:

- Iteration 1: file is X bytes → offset defaults to X → `offset == size`, `continue` (and never persist X).
- I append a toolCall → file is now X+N.
- Iteration 2: still no entry in `_file_offsets` → default is *new* size X+N → skip again. Forever.

Fixed by persisting the first-seen watermark before `continue`. Subsequent iterations see growth.

### 3. `clawmetry-approvals` logger had no handlers

Watcher activity (policy fires, decisions, kills) was silent in `~/.clawmetry/sync.log`. Looked like the watcher was dead when it was working — just shouting into the void. Wired the approvals logger through the sync logger's handlers in `sync.py`.

## Live E2E run from this branch

```
21:26:17 [approval] policy='Block rm -rf' tool=exec cmd='rm -rf /tmp/...' session=e153ec20...
       ↓ POST /api/approvals/request → 200 OK, id=241617358adb45fb...
       ↓ human clicks Deny in cloud UI (POST /api/cloud/approvals/<id>/decide {action:'deny'})
21:26:51 [approval] 241617358adb45fbb1571d55fd70dc41 → denied, killed=False
```

(`killed=False` only because the test session_id was a synthetic ID with no live gateway — real sessions get `sessions_kill`'d.)

## Test plan

- [x] OSS daemon's POST round-trips against live `https://app.clawmetry.com` cloud
- [x] Pending row visible via `GET /api/cloud/approvals?status=pending`
- [x] Programmatic Deny flips status to `denied`
- [x] Daemon picks up the decision within one poll cycle
- [x] Watcher log lines now visible in `~/.clawmetry/sync.log`
- [ ] After merge: bump `clawmetry-cloud` Dockerfile pin to the new version, redeploy
- [ ] Browser walkthrough: paste cm_ key → Approvals tab → click Deny → see daemon log

Ships with `[RELEASE]` so release-on-merge.yml cuts the next patch (0.12.104).