### PR TITLE
chore: bump 0.12.103 → 0.12.104

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -131,7 +131,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.103"
+__version__ = "0.12.104"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Manual bump (release-on-merge bot blocked by branch protection again). Picks up PR #670: end-to-end approvals fix (Authorization: Bearer, watermark persistence, log handler wiring).