### PR TITLE
[RELEASE] fix: Approvals nav-tab missing from active DASHBOARD_HTML block

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -7948,6 +7948,7 @@ DASHBOARD_HTML = r"""
     <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')" style="display:none;">Crons</div>
     <div class="nav-tab" onclick="switchTab('memory')">Memory</div>
     <div class="nav-tab" onclick="switchTab('security')">Security</div>
+    <div class="nav-tab" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">Approvals <span id="nav-approvals-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
     <div class="nav-tab" id="nemoclaw-tab" onclick="switchTab('nemoclaw')" style="display:none;">NemoClaw</div>
     <div class="nav-tab nav-tab-more" onclick="toggleAdvancedTabs(event)" title="Advanced tabs">More &#9662;
       <div class="advanced-tabs-dropdown" id="advanced-tabs-dropdown" style="display:none;">


### PR DESCRIPTION
PR #667 added the Approvals nav-tab inside the *first* of two DASHBOARD_HTML literals (line ~3265), but a second `DASHBOARD_HTML = r"""..."""` at line 7910 overrides it. Net effect: the page-approvals div and its JS shipped, but there was no clickable tab. Cloud iframe nav showed Flow / Brain / Overview / Tokens / Crons / Memory / Security / NemoClaw / More — no Approvals.

Adding the same line to the active block (after Security, before NemoClaw).