### PR TITLE
chore: bump 0.12.104 → 0.12.105

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -131,7 +131,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.104"
+__version__ = "0.12.105"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Manual bump (release-on-merge bot blocked by branch protection again). Picks up PR #672: missing Approvals nav-tab in active DASHBOARD_HTML block.