### PR TITLE
chore: bump 0.12.107 → 0.12.108

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -131,7 +131,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.107"
+__version__ = "0.12.108"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
$5 price fix was on main but 0.12.107 wheel was built before merge. This bump ships the correct price.