### PR TITLE
fix(skills): dead skills were sorting to bottom instead of top

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1346,9 +1346,15 @@ async function loadSkills() {
       return;
     }
 
-    // Sort: problematic first (dead, stuck), then unused, then healthy
+    // Sort: problematic first (dead, stuck), then unused, then healthy.
+    // Use `in` not `||` — `order['dead']` is 0 which is falsy, the `||`
+    // variant accidentally sent 'dead' to the end of the list.
     var order = { dead: 0, stuck: 1, unused: 2, healthy: 3 };
-    skills.sort(function(a, b) { return (order[a.status] || 9) - (order[b.status] || 9); });
+    skills.sort(function(a, b) {
+      var oa = a.status in order ? order[a.status] : 99;
+      var ob = b.status in order ? order[b.status] : 99;
+      return oa - ob;
+    });
 
     var toggleBtn = '<div style="text-align:right;margin-bottom:8px;">'
       + '<button onclick="_skillsShowDetails=!_skillsShowDetails;loadSkills();" style="background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:6px;padding:4px 10px;font-size:11px;cursor:pointer;color:var(--text-secondary);">'


### PR DESCRIPTION
## Summary
Caught during full-E2E testing with seeded real skills. A JS falsy-coercion bug was silently burying the most important rows.

## The bug
```js
var order = { dead: 0, stuck: 1, unused: 2, healthy: 3 };
skills.sort(function(a, b) { return (order[a.status] || 9) - (order[b.status] || 9); });
```

For `status === 'dead'`, `order['dead']` is `0`. `0 || 9` evaluates to `9` (0 is falsy). So dead skills ended up sorted to the **end** of the table, defeating the "surface problems first" intent.

## Fix
Use `in` to test membership before lookup. Fallback to 99 for unknown statuses so they still land at the end.

```js
skills.sort(function(a, b) {
  var oa = a.status in order ? order[a.status] : 99;
  var ob = b.status in order ? order[b.status] : 99;
  return oa - ob;
});
```

## E2E verification
Seeded 4 real skills in `~/.openclaw/skills`:
- `roll-dice` (healthy, has a Read event in a session transcript)
- `email-html` (stuck — body fetched, references/ never read)
- `git-triage` (healthy — fresh, no events)
- `weather` (dead — aged 60 days via `touch -t`, no events)

Plus a fake session JSONL with `Read` tool_use blocks pointing at `roll-dice/SKILL.md` and `email-html/SKILL.md`. The skills-fidelity classifier correctly produced `{dead, stuck, healthy, healthy}` — the sorting was the only thing broken.

**Before**: email-html, git-triage, roll-dice, weather
**After**: **weather** (Safe to remove), email-html (Not working), git-triage, roll-dice

Sorting by `(status_priority, name)` matches the server-side sort in `routes/skills.py` so the two agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)