### PR TITLE
[RELEASE] feat: cloud autonomy trending + skills sort fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Added
+- **Cloud autonomy trending** (pairs with clawmetry-cloud#360). The sync daemon now computes a daily autonomy aggregate (median nudge gap, autonomy ratio, 7-day trend slope) locally from session transcripts and pushes only the aggregate — not raw content — to `ingest.clawmetry.com/ingest/autonomy`. Raw memory stays E2E-encrypted; cloud displays the trend on `app.clawmetry.com/fleet`. Throttled to one push per UTC day. Respects `cloud_autonomy_sync: false` opt-out.
+
+### Fixed
+- **Skills tab sort order** — dead skills were sorting to the *bottom* of the list instead of the top (`order['dead']` is 0, and `0 || 9` evaluates to 9, so "dead" slipped to the end). Uses `in` membership check now so "Safe to remove" rows surface where they should.
+
 ### Fixed
 - **`pip install clawmetry` now actually works end-to-end.** Since the routes/ helpers/ templates/ extractions (0.12.90-series), the published wheels silently omitted the non-Python asset directories — installed users' dashboards 404'd on `/static/js/app.js` and failed at import because `from routes.sessions import bp_sessions` had no target. `static/` and `templates/` now ship under the `clawmetry/` package; `routes/` and `helpers/` are declared top-level packages. A new `wheel-install` CI job verifies every release by installing the wheel in a fresh venv and requesting `/static/js/app.js`.
 - **Structural move**: `static/*` → `clawmetry/static/*`, `templates/*` → `clawmetry/templates/*`. `app = Flask(...)` now passes `static_folder` / `template_folder` pointed at the package-relative paths. URL surface (`/static/...`) unchanged; users see no behavioural difference.


### PR DESCRIPTION
## Summary
Cuts a patch release bundling two items that merged earlier today but haven't shipped to PyPI yet:

- **#696** — OSS sync daemon now computes a daily autonomy aggregate locally and pushes it to `/ingest/autonomy` (pairs with clawmetry-cloud#360, shipped together). E2E encryption preserved: only the aggregate leaves the machine.
- **#701** — Skills tab sort fix; "dead" skills now surface at the top of the list as intended.

## What changes for existing users after this release
- Dashboard UI: Skills tab reorders problem rows to the top (previously landed at the bottom due to falsy-coercion bug).
- Sync daemon: one new write per UTC day (~300 bytes per node) to `ingest.clawmetry.com/ingest/autonomy`. Opt-out: `cloud_autonomy_sync: false` in config.
- Trend card on `app.clawmetry.com/fleet` lights up for users with an active node on the next UTC day roll.

## Version
`__version__` auto-bumps on merge — should land on **0.12.113**.

## Pre-flight
- [x] PR #696 merged (autonomy sync)
- [x] PR #701 merged (sort fix)
- [x] Cloud PR #367 merged + auto-deployed to app.clawmetry.com
- [x] Full local E2E verified (real OpenClaw sessions → 'Mostly independent' on /fleet)
- [x] XSS defense tested (ingest validator + frontend escape)
- [x] 40/40 OSS API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)