### PR TITLE
chore: bump 0.12.112 → 0.12.113

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -135,7 +135,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.112"
+__version__ = "0.12.113"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Ships v1_only OpenAPI filter so cloud Swagger shows only /api/v1/* endpoints.