### PR TITLE
chore: sync __version__ to 0.12.114 (catches up with PyPI) [skip ci]

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -135,7 +135,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.113"
+__version__ = "0.12.114"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
## Why
PyPI's latest is `clawmetry==0.12.114` (released 19:48 UTC today) but `dashboard.py` on main still says `__version__ = "0.12.113"`. The old release workflow's "push directly to main" step failed for the 0.12.113 → 0.12.114 release because branch protection blocked it, but the wheel was already on PyPI by that point.

The fixed workflow from PR #704 handles this correctly for future releases. This PR is a one-shot catch-up so the next `[RELEASE]` isn't confused.

## Change
Single-line edit: `dashboard.py` — `0.12.113` → `0.12.114`.

## No impact
- Wheel already on PyPI
- Users running from PyPI are on 0.12.114 and fine
- Only fixes what `clawmetry --version` reports when run from source, and what the next `[RELEASE]` workflow reads as its "current" (though it always bumps from PyPI's latest anyway, so this is cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)