### PR TITLE
feat: real-time event streamer — brain feed in 1-2s

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2818,6 +2818,122 @@ def start_log_streamer(config: dict, paths: dict) -> threading.Thread:
     return t
 
 
+def start_event_streamer(config: dict, state: dict, paths: dict) -> threading.Thread:
+    """Real-time session event streamer — watches JSONL files for changes
+    and pushes new events immediately (like Dropbox file sync).
+
+    Only makes API calls when new data appears. Tracks file sizes locally
+    to detect changes without polling the server.
+    """
+    api_key = config["api_key"]
+    enc_key = config.get("encryption_key")
+    node_id = config["node_id"]
+    sessions_dir = paths["sessions_dir"]
+
+    # Track file sizes to detect changes
+    _file_sizes: dict[str, int] = {}
+    _file_offsets: dict[str, int] = {}  # line offsets per file
+
+    def _scan_and_push():
+        """Check all JSONL files for new content. Push immediately if found."""
+        if not os.path.isdir(sessions_dir):
+            return 0
+        total_pushed = 0
+        jsonl_files = glob.glob(os.path.join(sessions_dir, "*.jsonl"))
+        # Only check recently modified files (last 2 hours) to avoid scanning stale ones
+        cutoff = time.time() - 7200
+        active = [f for f in jsonl_files if os.path.getmtime(f) > cutoff]
+
+        # Build subagent map (reuse sync_sessions logic)
+        file_to_subagent: dict[str, str] = {}
+        idx_path = os.path.join(sessions_dir, "sessions.json")
+        if os.path.isfile(idx_path):
+            try:
+                with open(idx_path) as _fi:
+                    _idx = json.load(_fi)
+                for _k, _meta in _idx.items():
+                    if ":subagent:" in _k and isinstance(_meta, dict):
+                        _sf = _meta.get("sessionFile", "")
+                        if _sf:
+                            file_to_subagent[os.path.basename(_sf)] = _k.split(":")[-1]
+            except Exception:
+                pass
+
+        for fpath in active:
+            fname = os.path.basename(fpath)
+            try:
+                cur_size = os.path.getsize(fpath)
+            except OSError:
+                continue
+            prev_size = _file_sizes.get(fname, 0)
+            if cur_size <= prev_size:
+                # No change — skip (no API call)
+                _file_sizes[fname] = cur_size
+                continue
+
+            # File grew — read only the new lines
+            _file_sizes[fname] = cur_size
+            offset = _file_offsets.get(fname, state.get("last_event_ids", {}).get(fname, 0))
+            batch: list[dict] = []
+            new_offset = offset
+            try:
+                with open(fpath, "r", errors="replace") as f:
+                    for i, raw in enumerate(f):
+                        if i < offset:
+                            continue
+                        raw = raw.strip()
+                        new_offset = i + 1
+                        if not raw:
+                            continue
+                        try:
+                            batch.append(json.loads(raw))
+                        except Exception:
+                            continue
+            except Exception as e:
+                log.debug(f"Event streamer read error ({fname}): {e}")
+                continue
+
+            if batch:
+                subagent_id = file_to_subagent.get(fname)
+                try:
+                    _flush_session_batch(batch, fname, api_key, enc_key, node_id, subagent_id)
+                    total_pushed += len(batch)
+                    _file_offsets[fname] = new_offset
+                    # Update shared state so main loop doesn't re-push
+                    state.setdefault("last_event_ids", {})[fname] = new_offset
+                except Exception as e:
+                    log.debug(f"Event streamer push error ({fname}): {e}")
+            else:
+                _file_offsets[fname] = new_offset
+
+        return total_pushed
+
+    def _streamer_loop():
+        log.info(f"Event streamer started — watching {sessions_dir}")
+        # Initialize sizes so we don't re-push old data
+        if os.path.isdir(sessions_dir):
+            for f in glob.glob(os.path.join(sessions_dir, "*.jsonl")):
+                fname = os.path.basename(f)
+                _file_sizes[fname] = os.path.getsize(f)
+                _file_offsets[fname] = state.get("last_event_ids", {}).get(fname, 0)
+
+        while True:
+            try:
+                pushed = _scan_and_push()
+                if pushed:
+                    log.debug(f"Event streamer pushed {pushed} events")
+                    # Save state after each push so main loop stays in sync
+                    save_state(state)
+            except Exception as e:
+                log.debug(f"Event streamer error: {e}")
+            # Fast check — only sleeps 1s between scans (stat() is cheap)
+            time.sleep(1)
+
+    t = threading.Thread(target=_streamer_loop, daemon=True, name="event-streamer")
+    t.start()
+    return t
+
+
 def run_daemon() -> None:
     if not _acquire_pid_lock():
         print(
@@ -2892,8 +3008,9 @@ def run_daemon() -> None:
     _validate_log_offsets(state, paths)
     save_state(state)
 
-    # Start real-time log streamer in background
+    # Start real-time streamers in background
     start_log_streamer(config, paths)
+    start_event_streamer(config, state, paths)
 
     # Backfill older sessions in a background thread so the main loop
     # (and Brain tab) shows current activity immediately. The backfill


### PR DESCRIPTION
## Summary
Adds a background event streamer thread that watches session JSONL files and pushes new events to cloud immediately — like Dropbox file sync.

**Before:** brain events synced every 15s (POLL_INTERVAL)
**After:** brain events pushed within 1-2s of being written

### How it works
- Scans active session files every 1s (`stat()` is cheap — no API calls)
- Only reads + pushes when file size increases (diff-based, like Dropbox)
- Tracks line offsets per file to avoid re-pushing
- Shares state with main sync loop so no duplicates
- Only watches files modified in the last 2 hours (skip stale)
- Main sync loop still runs every 15s as catch-all

## Test plan
- [ ] Start sync daemon, verify "Event streamer started" in sync.log
- [ ] Send a message to agent, verify brain event appears in cloud within 2s
- [ ] Verify no duplicate events (main loop + streamer don't double-push)
- [ ] Restart daemon, verify no re-push of old events

🤖 Generated with [Claude Code](https://claude.com/claude-code)