### PR TITLE
feat: channel session badges + filter chips in Brain tab

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2059,7 +2059,19 @@ function renderBrainDetail(detail) {
 
 var _brainFilter = 'all';
 var _brainTypeFilter = 'all';
+var _brainChannelFilter = 'all';
 var _brainAllEvents = [];
+
+var _channelIcons = {
+  'telegram': '📱', 'whatsapp': '💬', 'discord': '🎮', 'slack': '📢',
+  'signal': '📡', 'irc': '💻', 'imessage': '🍎', 'webchat': '🌐',
+  'googlechat': '📧', 'cli': '🖥️', 'cron': '⏰'
+};
+var _channelColors = {
+  'telegram': '#2f9ef4', 'whatsapp': '#25d366', 'discord': '#5865F2', 'slack': '#4A154B',
+  'signal': '#3a76f0', 'irc': '#6B7280', 'imessage': '#34C759', 'webchat': '#0EA5E9',
+  'googlechat': '#1A73E8', 'cli': '#94a3b8', 'cron': '#6B7280'
+};
 
 var _brainTypeIcons = {
   'EXEC': '⚙️', 'SHELL': '⚙️', 'READ': '📖', 'WRITE': '✏️',
@@ -2129,13 +2141,36 @@ function renderBrainTypeChips(events) {
   container.innerHTML = html;
 }
 
+function renderBrainChannelChips(channels) {
+  var container = document.getElementById('brain-channel-chips');
+  if (!container) return;
+  if (!channels || Object.keys(channels).length < 2) { container.innerHTML = ''; return; }
+  var html = '<button class="brain-ch-chip" onclick="setBrainChannelFilter(\'all\',this)" style="padding:2px 9px;border-radius:10px;border:1px solid #666;background:' + (_brainChannelFilter === 'all' ? 'rgba(100,100,200,0.15)' : 'transparent') + ';color:#888;font-size:10px;cursor:pointer;font-weight:' + (_brainChannelFilter === 'all' ? '600' : '400') + ';">All channels</button>';
+  Object.keys(channels).sort().forEach(function(ch) {
+    var ico = _channelIcons[ch] || '📨';
+    var col = _channelColors[ch] || '#888';
+    var isActive = _brainChannelFilter === ch;
+    html += '<button class="brain-ch-chip" onclick="setBrainChannelFilter(\'' + ch + '\',this)" style="padding:2px 9px;border-radius:10px;border:1px solid ' + col + ';background:' + (isActive ? col + '22' : 'transparent') + ';color:' + col + ';font-size:10px;cursor:pointer;font-weight:' + (isActive ? '600' : '400') + ';">' + ico + ' ' + ch + ' (' + channels[ch] + ')</button>';
+  });
+  container.innerHTML = html;
+}
+
+function setBrainChannelFilter(ch, btn) {
+  _brainChannelFilter = ch;
+  renderBrainChannelChips(window._brainChannelCounts || {});
+  renderBrainStream(_brainAllEvents);
+}
+
 function renderBrainStream(events) {
   var el = document.getElementById('brain-stream');
   if (!el) return;
   var filtered = _brainFilter === 'all' ? events : events.filter(function(ev) { return ev.source === _brainFilter; });
-    if (_brainTypeFilter !== 'all') {
-      filtered = filtered.filter(function(ev) { return ev.type === _brainTypeFilter; });
-    }
+  if (_brainTypeFilter !== 'all') {
+    filtered = filtered.filter(function(ev) { return ev.type === _brainTypeFilter; });
+  }
+  if (_brainChannelFilter !== 'all') {
+    filtered = filtered.filter(function(ev) { return (ev.channel || '') === _brainChannelFilter; });
+  }
   filtered = filtered.slice().sort(function(a,b){
     var ta = a.time ? new Date(a.time).getTime() : 0;
     var tb = b.time ? new Date(b.time).getTime() : 0;
@@ -2151,16 +2186,26 @@ function renderBrainStream(events) {
     var evType = ev.type || 'TOOL';
     var icon = _brainTypeIcons[evType] || '🔧';
     var fullSrc = ev.sourceLabel || ev.source || 'main';
-    /* Short agent ID: show role/last segment only; full ID in title attribute */
     var srcParts = fullSrc.split(':');
     var shortSrc = srcParts[srcParts.length - 1] || fullSrc;
     if (shortSrc.length > 12) shortSrc = shortSrc.slice(0, 8) + '\u2026';
     var roleIcon = fullSrc.indexOf('subagent') >= 0 ? '\uD83E\uDD16' : '\uD83E\uDDE0';
+    // Channel badge
+    var chBadge = '';
+    var ch = ev.channel || '';
+    if (ch) {
+      var chIco = _channelIcons[ch] || '📨';
+      var chCol = _channelColors[ch] || '#667';
+      var chLabel = ch.charAt(0).toUpperCase() + ch.slice(1);
+      if (ev.channelSubject) chLabel += ':' + (ev.channelSubject.length > 14 ? ev.channelSubject.slice(0, 12) + '\u2026' : ev.channelSubject);
+      chBadge = '<span class="brain-channel" style="color:' + chCol + ';font-size:10px;flex-shrink:0;opacity:0.8;white-space:nowrap;" title="' + escHtml(ch + (ev.channelSubject ? ': ' + ev.channelSubject : '')) + '">' + chIco + ' ' + escHtml(chLabel) + '</span>';
+    }
     html += '<div class="brain-event" onclick="this.classList.toggle(\'expanded\')">';
     html += '<div class="brain-meta">';
     html += '<span class="brain-time">' + formatBrainTime(ev.time) + '</span>';
     html += '<span class="brain-type" style="background:rgba(100,100,100,0.15);color:' + color + ';padding:1px 6px;border-radius:3px;font-size:10px;font-weight:700;min-width:70px;text-align:center;display:inline-block;white-space:nowrap;">' + icon + ' ' + escHtml(evType) + '</span>';
     html += '<span class="brain-source" style="color:' + color + ';flex-shrink:0;" title="' + escHtml(fullSrc) + '">' + roleIcon + ' ' + escHtml(shortSrc) + '</span>';
+    html += chBadge;
     html += '</div>';
     html += '<span class="brain-detail">' + renderBrainDetail(ev.detail || '') + '</span>';
     html += '</div>';
@@ -2331,6 +2376,13 @@ async function loadBrainPage(silent) {
     _brainAllEvents = events;
     renderBrainFilterChips(data.sources || []);
     renderBrainTypeChips(events);
+    // Channel filter chips
+    window._brainChannelCounts = data.channels || {};
+    if (!Object.keys(window._brainChannelCounts).length) {
+      // Build from events if API didn't provide
+      events.forEach(function(ev) { if (ev.channel) window._brainChannelCounts[ev.channel] = (window._brainChannelCounts[ev.channel]||0) + 1; });
+    }
+    renderBrainChannelChips(window._brainChannelCounts);
     renderBrainChart(events);
     if (typeof syncBrainGraph === 'function') syncBrainGraph(events);
     var streamEl = document.getElementById('brain-stream');

--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -40,7 +40,9 @@
         ">All</button>
     </div>
     <!-- Type filter chips (separate container to prevent duplication) -->
-    <div id="brain-type-chips" style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:10px;"></div>
+    <div id="brain-type-chips" style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:6px;"></div>
+    <!-- Channel filter chips -->
+    <div id="brain-channel-chips" style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:10px;"></div>
     <!-- Event stream -->
     <div id="brain-feed" style="
       background:var(--bg-secondary);

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -30,10 +30,11 @@ def api_brain_history():
     # Return unified event stream - v2 no truncation
     events = []
 
-    # Build sessionId to displayName map
+    # Build sessionId to displayName + channel map
     session_dir = _d.SESSIONS_DIR or os.path.expanduser("~/.openclaw/agents/main/sessions")
     index_path = os.path.join(session_dir, "sessions.json")
     sid_to_label = {}
+    sid_to_channel = {}  # sessionId → {channel, chatType, subject}
     try:
         with open(index_path, "r") as f:
             index = json.load(f)
@@ -42,6 +43,21 @@ def api_brain_history():
             label = meta.get("displayName") or meta.get("label") or ""
             if sid and label:
                 sid_to_label[sid] = label
+            if sid:
+                # Parse channel from session key: agent:<id>:<channel>:group|channel:<chatId>
+                # or from metadata fields
+                channel = meta.get("provider", "")
+                chat_type = meta.get("chatType", "")
+                subject = meta.get("subject") or meta.get("displayName") or ""
+                if not channel:
+                    # Parse from key: agent:main:telegram:group:-100...
+                    parts = key.split(":")
+                    if len(parts) >= 3 and parts[2] not in ("main", "subagent"):
+                        channel = parts[2]
+                    elif len(parts) == 3 and parts[2] == "main":
+                        channel = "cli"
+                if channel:
+                    sid_to_channel[sid] = {"channel": channel, "chatType": chat_type, "subject": subject}
     except Exception:
         pass
 
@@ -198,6 +214,7 @@ def api_brain_history():
             fname = os.path.basename(sf).replace(".jsonl", "")
             label = sid_to_label.get(fname, "")
             source_id = fname
+            ch_info = sid_to_channel.get(fname, {})
             import re as _re
 
             source_label = (
@@ -460,11 +477,28 @@ def api_brain_history():
                     "color": ev.get("color", "#888"),
                 }
             )
+    # Enrich events with channel info from session index
+    for ev in events:
+        src = ev.get("source", "")
+        if src in sid_to_channel:
+            ev["channel"] = sid_to_channel[src].get("channel", "")
+            ev["channelSubject"] = sid_to_channel[src].get("subject", "")
+            ev["chatType"] = sid_to_channel[src].get("chatType", "")
+        elif src == "main":
+            ev["channel"] = "cli"
+
+    # Build channel summary for filter chips
+    channel_counts = {}
+    for ev in events:
+        ch = ev.get("channel", "")
+        if ch:
+            channel_counts[ch] = channel_counts.get(ch, 0) + 1
+
     try:
         _d._ext_emit("brain.event", {"count": len(events)})
     except Exception:
         pass
-    return jsonify({"events": events, "total": len(events), "sources": sources_seen})
+    return jsonify({"events": events, "total": len(events), "sources": sources_seen, "channels": channel_counts})
 
 
 @bp_brain.route("/api/brain-stream")


### PR DESCRIPTION
Closes #720 | Part of #719 (Agent Observability)

## Summary
- Each brain event now shows which channel it came from (📱 Telegram, 💬 WhatsApp, 🎮 Discord, 🖥️ CLI, etc.)
- New channel filter chip row lets you filter to a specific channel
- Channel info parsed from session keys in sessions.json

## Screenshots
Brain events now show: `18:12:50  💬 USER  🧠 main  📱 Telegram  [cron:health-check]...`

Filter chips: `[All channels] [📱 telegram (5)] [💬 whatsapp (3)] [🖥️ cli (12)]`

## Test plan
- [ ] Brain tab shows channel badges on each event
- [ ] Clicking a channel chip filters to that channel only
- [ ] Works with multi-channel agents (TG + WA + Discord)
- [ ] No regression on single-channel agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)