### PR TITLE
[RELEASE] feat: agent observability suite — brain channels, context inspector, runtime timeline, skills browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 ## [Unreleased]
 
-### Added
+---
+
+## v0.12.118
+
+### Agent Observability Suite
+- **Real-time event streamer** — Dropbox-style file-size diffing pushes brain events instantly instead of 15s polling (#718)
+- **Channel session badges** — Telegram/WhatsApp/Discord/Slack/IRC/iMessage badges in Brain tab with filter chips (#725)
+- **Channel metadata sync** — session_key, channel, chat_type synced to cloud for multi-channel visibility (#726)
+- **Skill badges + file browser** — skill usage badges on brain events + IDE-like skill file browser (#728)
+- **Flow tab architecture upgrade** — provider stack with fallback slots, skills column, Brain→Skills path (#729)
+- **LLM Context Inspector** — token breakdown bars, system prompt viewer, compaction history (#730)
+- **Agent Runtime Timeline** — per-turn drill-down with tool/LLM/user phase bars (#731)
+- **ACP sub-agent visibility** — nested sub-agent events in runtime timeline (#732)
+- **E2E key from URL fragment** — encryption key passed via `#hash`, never touches the server (#734)
+
+### Fixed
+- Heartbeat interval NaN when `interval_seconds` is missing (#717)
+
+### Docs
+- Comprehensive agent observability guide with architecture diagrams (OBSERVABILITY.md) (#733)
+
+### Added (prior unreleased)
 - **Cloud autonomy trending** (pairs with clawmetry-cloud#360). The sync daemon now computes a daily autonomy aggregate (median nudge gap, autonomy ratio, 7-day trend slope) locally from session transcripts and pushes only the aggregate — not raw content — to `ingest.clawmetry.com/ingest/autonomy`. Raw memory stays E2E-encrypted; cloud displays the trend on `app.clawmetry.com/fleet`. Throttled to one push per UTC day. Respects `cloud_autonomy_sync: false` opt-out.
 
 ### Fixed


### PR DESCRIPTION
## Summary

Ships all the agent observability features built since 0.12.117:

- **Real-time event streamer** — Dropbox-style file-size diffing for instant brain feed updates (#718)
- **Channel session badges** — Telegram/WhatsApp/Discord/etc badges + filter chips in Brain tab (#725)
- **Channel metadata sync** — session_key + channel + chat_type synced to cloud (#726)
- **Skill badges + file browser** — skill usage in Brain events + IDE-like file browser (#728)
- **Flow tab architecture** — provider stack with fallback slots + skills column (#729)
- **LLM Context Inspector** — see token breakdown, system prompt, compaction history (#730)
- **Agent Runtime Timeline** — per-turn drill-down with tool/LLM/user phases (#731)
- **ACP sub-agent visibility** — nested sub-agent events in runtime timeline (#732)
- **E2E key from URL fragment** — encryption key never touches the server (#734)

### Bug fixes
- Fix heartbeat interval NaN when `interval_seconds` is missing (#717)

### Docs
- Comprehensive agent observability guide with architecture diagrams (#733)

## Test plan
- [x] Wheel builds and ships all runtime assets (static/js/app.js, templates, routes, helpers)
- [x] Wheel install smoke test: all checks pass in clean venv
- [ ] CI passes on merge
- [ ] `pip install clawmetry==<new>` in clean venv works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)