### PR TITLE
ux: display E2E secret key during install

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1544,6 +1544,13 @@ def _cmd_onboard(args) -> None:
         print()
         print(f"     Bookmark this URL -- it's your private dashboard.")
         print(f"     Data is E2E encrypted. Only you can read it.")
+        print()
+        print(f"  {BOLD('Your secret key')} (paste this when opening the dashboard):")
+        print()
+        print(f"     {CYAN(enc_key)}")
+        print()
+        print(f"     {DIM('Keep this safe -- you need it to view your data.')}")
+        print(f"     {DIM('Run')} {CYAN('clawmetry status --show-key')} {DIM('to see it again.')}")
 
         # Auto-open the dashboard in browser
         try:


### PR DESCRIPTION
## Summary
After `curl | bash` install, the dashboard asks for the secret key but the install script never showed it. Now displays it prominently:

```
  Dashboard ready!

     https://app.clawmetry.com/d/xxx-xxx

  Your secret key (paste this when opening the dashboard):

     0cg4LMwe2lb6lJC-kea8mypZgQzkESO0-FxtD-7RbJc=

     Keep this safe -- you need it to view your data.
     Run clawmetry status --show-key to see it again.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)