### PR TITLE
[RELEASE] ux: display E2E secret key during install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ---
 
+## v0.12.119
+
+### Improved
+- **E2E secret key shown during install** — `curl | bash` now displays the encryption key so users can paste it when opening the dashboard (#738)
+
 ## v0.12.118
 
 ### Agent Observability Suite


### PR DESCRIPTION
## Summary
- Install script now shows the E2E encryption key so users can paste it when opening the dashboard
- No more confusion about where the key is after fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)