### PR TITLE
[RELEASE] feat: uninstall purges server-side registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## v0.12.120
+
+### Improved
+- **Uninstall purges server-side registration** — `clawmetry uninstall` now calls `/api/unregister` to delete the node_registry entry, preventing stale account re-linking on reinstall (#741)
+
+---
+
 ## v0.12.119
 
 ### Improved


### PR DESCRIPTION
Uninstall now deletes node_registry entry from cloud, preventing re-linking on reinstall.