### PR TITLE
[RELEASE] fix: Overview flow palette + trim nav (drop Skills + More)

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -351,43 +351,43 @@
   .flow-node-optimizer text { fill: #ffffff !important; }
   .flow-node-infra > text { fill: #ffffff !important; }
   /* Refined palette: lower saturation, clearer hierarchy */
-  #node-human circle:first-child { fill: #6d5ce8 !important; stroke: #5b4bd4 !important; }
-  #node-human text { fill: #6d5ce8 !important; }
-  #node-telegram rect { fill: #2f6feb !important; stroke: #1f4fb8 !important; }
-  #node-signal rect { fill: #0f766e !important; stroke: #115e59 !important; }
-  #node-whatsapp rect { fill: #2f9e44 !important; stroke: #237738 !important; }
-  #node-imessage rect { fill: #34C759 !important; stroke: #248A3D !important; }
-  #node-discord rect { fill: #5865F2 !important; stroke: #4752C4 !important; }
-  #node-slack rect { fill: #4A154B !important; stroke: #350e36 !important; }
-  #node-irc rect { fill: #6B7280 !important; stroke: #4B5563 !important; }
-  #node-webchat rect { fill: #0EA5E9 !important; stroke: #0369A1 !important; }
-  #node-googlechat rect { fill: #1A73E8 !important; stroke: #1557B0 !important; }
-  #node-bluebubbles rect { fill: #1C6EF3 !important; stroke: #1558C0 !important; }
-  #node-msteams rect { fill: #6264A7 !important; stroke: #464775 !important; }
-  #node-matrix rect { fill: #0DBD8B !important; stroke: #0A9E74 !important; }
-  #node-mattermost rect { fill: #0058CC !important; stroke: #0047A3 !important; }
-  #node-line rect { fill: #00B900 !important; stroke: #009900 !important; }
-  #node-nostr rect { fill: #8B5CF6 !important; stroke: #6D28D9 !important; }
-  #node-twitch rect { fill: #9146FF !important; stroke: #772CE8 !important; }
-  #node-feishu rect { fill: #3370FF !important; stroke: #2050CC !important; }
-  #node-zalo rect { fill: #0068FF !important; stroke: #0050CC !important; }
-  #node-gateway rect { fill: #334155 !important; stroke: #1f2937 !important; }
-  #node-brain rect { fill: #a63a16 !important; stroke: #7c2d12 !important; }
-  #brain-model-label { fill: #fde68a !important; }
-  #brain-model-text { fill: #fed7aa !important; }
-  #node-session rect { fill: #3158d4 !important; stroke: #2648b6 !important; }
-  #node-exec rect { fill: #d97706 !important; stroke: #b45309 !important; }
-  #node-browser rect { fill: #5b39c6 !important; stroke: #4629a1 !important; }
-  #node-search rect { fill: #0f766e !important; stroke: #115e59 !important; }
-  #node-cron rect { fill: #4b5563 !important; stroke: #374151 !important; }
-  #node-tts rect { fill: #a16207 !important; stroke: #854d0e !important; }
-  #node-memory rect { fill: #1e3a8a !important; stroke: #172554 !important; }
-  #node-cost-optimizer rect { fill: #166534 !important; stroke: #14532d !important; }
-  #node-automation-advisor rect { fill: #4338ca !important; stroke: #3730a3 !important; }
-  #node-runtime rect { fill: #334155 !important; stroke: #475569 !important; }
-  #node-machine rect { fill: #424b57 !important; stroke: #2f3945 !important; }
-  #node-storage rect { fill: #52525b !important; stroke: #3f3f46 !important; }
-  #node-network rect { fill: #0f766e !important; stroke: #115e59 !important; }
+  [id$="node-human"] circle:first-child { fill: #6d5ce8 !important; stroke: #5b4bd4 !important; }
+  [id$="node-human"] text { fill: #6d5ce8 !important; }
+  [id$="node-telegram"] rect { fill: #2f6feb !important; stroke: #1f4fb8 !important; }
+  [id$="node-signal"] rect { fill: #0f766e !important; stroke: #115e59 !important; }
+  [id$="node-whatsapp"] rect { fill: #2f9e44 !important; stroke: #237738 !important; }
+  [id$="node-imessage"] rect { fill: #34C759 !important; stroke: #248A3D !important; }
+  [id$="node-discord"] rect { fill: #5865F2 !important; stroke: #4752C4 !important; }
+  [id$="node-slack"] rect { fill: #4A154B !important; stroke: #350e36 !important; }
+  [id$="node-irc"] rect { fill: #6B7280 !important; stroke: #4B5563 !important; }
+  [id$="node-webchat"] rect { fill: #0EA5E9 !important; stroke: #0369A1 !important; }
+  [id$="node-googlechat"] rect { fill: #1A73E8 !important; stroke: #1557B0 !important; }
+  [id$="node-bluebubbles"] rect { fill: #1C6EF3 !important; stroke: #1558C0 !important; }
+  [id$="node-msteams"] rect { fill: #6264A7 !important; stroke: #464775 !important; }
+  [id$="node-matrix"] rect { fill: #0DBD8B !important; stroke: #0A9E74 !important; }
+  [id$="node-mattermost"] rect { fill: #0058CC !important; stroke: #0047A3 !important; }
+  [id$="node-line"] rect { fill: #00B900 !important; stroke: #009900 !important; }
+  [id$="node-nostr"] rect { fill: #8B5CF6 !important; stroke: #6D28D9 !important; }
+  [id$="node-twitch"] rect { fill: #9146FF !important; stroke: #772CE8 !important; }
+  [id$="node-feishu"] rect { fill: #3370FF !important; stroke: #2050CC !important; }
+  [id$="node-zalo"] rect { fill: #0068FF !important; stroke: #0050CC !important; }
+  [id$="node-gateway"] rect { fill: #334155 !important; stroke: #1f2937 !important; }
+  [id$="node-brain"] rect { fill: #a63a16 !important; stroke: #7c2d12 !important; }
+  [id$="brain-model-label"] { fill: #fde68a !important; }
+  [id$="brain-model-text"] { fill: #fed7aa !important; }
+  [id$="node-session"] rect { fill: #3158d4 !important; stroke: #2648b6 !important; }
+  [id$="node-exec"] rect { fill: #d97706 !important; stroke: #b45309 !important; }
+  [id$="node-browser"] rect { fill: #5b39c6 !important; stroke: #4629a1 !important; }
+  [id$="node-search"] rect { fill: #0f766e !important; stroke: #115e59 !important; }
+  [id$="node-cron"] rect { fill: #4b5563 !important; stroke: #374151 !important; }
+  [id$="node-tts"] rect { fill: #a16207 !important; stroke: #854d0e !important; }
+  [id$="node-memory"] rect { fill: #1e3a8a !important; stroke: #172554 !important; }
+  [id$="node-cost-optimizer"] rect { fill: #166534 !important; stroke: #14532d !important; }
+  [id$="node-automation-advisor"] rect { fill: #4338ca !important; stroke: #3730a3 !important; }
+  [id$="node-runtime"] rect { fill: #334155 !important; stroke: #475569 !important; }
+  [id$="node-machine"] rect { fill: #424b57 !important; stroke: #2f3945 !important; }
+  [id$="node-storage"] rect { fill: #52525b !important; stroke: #3f3f46 !important; }
+  [id$="node-network"] rect { fill: #0f766e !important; stroke: #115e59 !important; }
   .flow-node-clickable { cursor: pointer; }
   .flow-node-clickable:hover rect, .flow-node-clickable:hover circle { filter: brightness(1.08); }
   .flow-node rect { rx: 12; ry: 12; stroke-width: 1.6; transition: all 0.25s ease; }

--- a/dashboard.py
+++ b/dashboard.py
@@ -2489,43 +2489,43 @@ DASHBOARD_HTML = r"""
   .flow-node-optimizer text { fill: #ffffff !important; }
   .flow-node-infra > text { fill: #ffffff !important; }
   /* Refined palette: lower saturation, clearer hierarchy */
-  #node-human circle:first-child { fill: #6d5ce8 !important; stroke: #5b4bd4 !important; }
-  #node-human text { fill: #6d5ce8 !important; }
-  #node-telegram rect { fill: #2f6feb !important; stroke: #1f4fb8 !important; }
-  #node-signal rect { fill: #0f766e !important; stroke: #115e59 !important; }
-  #node-whatsapp rect { fill: #2f9e44 !important; stroke: #237738 !important; }
-  #node-imessage rect { fill: #34C759 !important; stroke: #248A3D !important; }
-  #node-discord rect { fill: #5865F2 !important; stroke: #4752C4 !important; }
-  #node-slack rect { fill: #4A154B !important; stroke: #350e36 !important; }
-  #node-irc rect { fill: #6B7280 !important; stroke: #4B5563 !important; }
-  #node-webchat rect { fill: #0EA5E9 !important; stroke: #0369A1 !important; }
-  #node-googlechat rect { fill: #1A73E8 !important; stroke: #1557B0 !important; }
-  #node-bluebubbles rect { fill: #1C6EF3 !important; stroke: #1558C0 !important; }
-  #node-msteams rect { fill: #6264A7 !important; stroke: #464775 !important; }
-  #node-matrix rect { fill: #0DBD8B !important; stroke: #0A9E74 !important; }
-  #node-mattermost rect { fill: #0058CC !important; stroke: #0047A3 !important; }
-  #node-line rect { fill: #00B900 !important; stroke: #009900 !important; }
-  #node-nostr rect { fill: #8B5CF6 !important; stroke: #6D28D9 !important; }
-  #node-twitch rect { fill: #9146FF !important; stroke: #772CE8 !important; }
-  #node-feishu rect { fill: #3370FF !important; stroke: #2050CC !important; }
-  #node-zalo rect { fill: #0068FF !important; stroke: #0050CC !important; }
-  #node-gateway rect { fill: #334155 !important; stroke: #1f2937 !important; }
-  #node-brain rect { fill: #a63a16 !important; stroke: #7c2d12 !important; }
-  #brain-model-label { fill: #fde68a !important; }
-  #brain-model-text { fill: #fed7aa !important; }
-  #node-session rect { fill: #3158d4 !important; stroke: #2648b6 !important; }
-  #node-exec rect { fill: #d97706 !important; stroke: #b45309 !important; }
-  #node-browser rect { fill: #5b39c6 !important; stroke: #4629a1 !important; }
-  #node-search rect { fill: #0f766e !important; stroke: #115e59 !important; }
-  #node-cron rect { fill: #4b5563 !important; stroke: #374151 !important; }
-  #node-tts rect { fill: #a16207 !important; stroke: #854d0e !important; }
-  #node-memory rect { fill: #1e3a8a !important; stroke: #172554 !important; }
-  #node-cost-optimizer rect { fill: #166534 !important; stroke: #14532d !important; }
-  #node-automation-advisor rect { fill: #4338ca !important; stroke: #3730a3 !important; }
-  #node-runtime rect { fill: #334155 !important; stroke: #475569 !important; }
-  #node-machine rect { fill: #424b57 !important; stroke: #2f3945 !important; }
-  #node-storage rect { fill: #52525b !important; stroke: #3f3f46 !important; }
-  #node-network rect { fill: #0f766e !important; stroke: #115e59 !important; }
+  [id$="node-human"] circle:first-child { fill: #6d5ce8 !important; stroke: #5b4bd4 !important; }
+  [id$="node-human"] text { fill: #6d5ce8 !important; }
+  [id$="node-telegram"] rect { fill: #2f6feb !important; stroke: #1f4fb8 !important; }
+  [id$="node-signal"] rect { fill: #0f766e !important; stroke: #115e59 !important; }
+  [id$="node-whatsapp"] rect { fill: #2f9e44 !important; stroke: #237738 !important; }
+  [id$="node-imessage"] rect { fill: #34C759 !important; stroke: #248A3D !important; }
+  [id$="node-discord"] rect { fill: #5865F2 !important; stroke: #4752C4 !important; }
+  [id$="node-slack"] rect { fill: #4A154B !important; stroke: #350e36 !important; }
+  [id$="node-irc"] rect { fill: #6B7280 !important; stroke: #4B5563 !important; }
+  [id$="node-webchat"] rect { fill: #0EA5E9 !important; stroke: #0369A1 !important; }
+  [id$="node-googlechat"] rect { fill: #1A73E8 !important; stroke: #1557B0 !important; }
+  [id$="node-bluebubbles"] rect { fill: #1C6EF3 !important; stroke: #1558C0 !important; }
+  [id$="node-msteams"] rect { fill: #6264A7 !important; stroke: #464775 !important; }
+  [id$="node-matrix"] rect { fill: #0DBD8B !important; stroke: #0A9E74 !important; }
+  [id$="node-mattermost"] rect { fill: #0058CC !important; stroke: #0047A3 !important; }
+  [id$="node-line"] rect { fill: #00B900 !important; stroke: #009900 !important; }
+  [id$="node-nostr"] rect { fill: #8B5CF6 !important; stroke: #6D28D9 !important; }
+  [id$="node-twitch"] rect { fill: #9146FF !important; stroke: #772CE8 !important; }
+  [id$="node-feishu"] rect { fill: #3370FF !important; stroke: #2050CC !important; }
+  [id$="node-zalo"] rect { fill: #0068FF !important; stroke: #0050CC !important; }
+  [id$="node-gateway"] rect { fill: #334155 !important; stroke: #1f2937 !important; }
+  [id$="node-brain"] rect { fill: #a63a16 !important; stroke: #7c2d12 !important; }
+  [id$="brain-model-label"] { fill: #fde68a !important; }
+  [id$="brain-model-text"] { fill: #fed7aa !important; }
+  [id$="node-session"] rect { fill: #3158d4 !important; stroke: #2648b6 !important; }
+  [id$="node-exec"] rect { fill: #d97706 !important; stroke: #b45309 !important; }
+  [id$="node-browser"] rect { fill: #5b39c6 !important; stroke: #4629a1 !important; }
+  [id$="node-search"] rect { fill: #0f766e !important; stroke: #115e59 !important; }
+  [id$="node-cron"] rect { fill: #4b5563 !important; stroke: #374151 !important; }
+  [id$="node-tts"] rect { fill: #a16207 !important; stroke: #854d0e !important; }
+  [id$="node-memory"] rect { fill: #1e3a8a !important; stroke: #172554 !important; }
+  [id$="node-cost-optimizer"] rect { fill: #166534 !important; stroke: #14532d !important; }
+  [id$="node-automation-advisor"] rect { fill: #4338ca !important; stroke: #3730a3 !important; }
+  [id$="node-runtime"] rect { fill: #334155 !important; stroke: #475569 !important; }
+  [id$="node-machine"] rect { fill: #424b57 !important; stroke: #2f3945 !important; }
+  [id$="node-storage"] rect { fill: #52525b !important; stroke: #3f3f46 !important; }
+  [id$="node-network"] rect { fill: #0f766e !important; stroke: #115e59 !important; }
   .flow-node-clickable { cursor: pointer; }
   .flow-node-clickable:hover rect, .flow-node-clickable:hover circle { filter: brightness(1.08); }
   .flow-node rect { rx: 12; ry: 12; stroke-width: 1.6; transition: all 0.25s ease; }
@@ -3263,22 +3263,12 @@ function clawmetryLogout(){
     <div class="nav-tab" onclick="switchTab('brain')">Brain</div>
     <div class="nav-tab active" onclick="switchTab('overview')">Overview</div>
     <div class="nav-tab" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">Approvals <span id="nav-approvals-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
-    <div class="nav-tab" onclick="switchTab('skills')">Skills</div>
     <div class="nav-tab" onclick="switchTab('context')" title="See what context the LLM receives each turn">Context</div>
     <div class="nav-tab" onclick="switchTab('usage')">Tokens</div>
     <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')" style="display:none;">Crons</div>
     <div class="nav-tab" onclick="switchTab('memory')">Memory</div>
     <div class="nav-tab" onclick="switchTab('security')">Security</div>
     <div class="nav-tab" id="nemoclaw-tab" onclick="switchTab('nemoclaw')" style="display:none;">NemoClaw</div>
-    <div class="nav-tab nav-tab-more" onclick="toggleAdvancedTabs(event)" title="Advanced tabs">More &#9662;
-      <div class="advanced-tabs-dropdown" id="advanced-tabs-dropdown" style="display:none;">
-        <div class="nav-tab" onclick="switchTab('models');hideAdvDropdown()">Models</div>
-        <div class="nav-tab" onclick="switchTab('subagents');hideAdvDropdown()">Agents</div>
-        <div class="nav-tab" onclick="switchTab('limits');hideAdvDropdown()">Limits</div>
-        <div class="nav-tab" onclick="switchTab('version-impact');hideAdvDropdown()">Upgrades</div>
-        <div class="nav-tab" onclick="switchTab('clusters');hideAdvDropdown()">Clusters</div>
-      </div>
-    </div>
     <!-- History tab hidden until mature -->
     <!-- <div class="nav-tab" onclick="switchTab('history')">History</div> -->
   </div>
@@ -8531,22 +8521,12 @@ DASHBOARD_HTML = r"""
     <div class="nav-tab" onclick="switchTab('brain')">Brain</div>
     <div class="nav-tab active" onclick="switchTab('overview')">Overview</div>
     <div class="nav-tab" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">Approvals <span id="nav-approvals-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
-    <div class="nav-tab" onclick="switchTab('skills')">Skills</div>
     <div class="nav-tab" onclick="switchTab('context')" title="See what context the LLM receives each turn">Context</div>
     <div class="nav-tab" onclick="switchTab('usage')">Tokens</div>
     <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')" style="display:none;">Crons</div>
     <div class="nav-tab" onclick="switchTab('memory')">Memory</div>
     <div class="nav-tab" onclick="switchTab('security')">Security</div>
     <div class="nav-tab" id="nemoclaw-tab" onclick="switchTab('nemoclaw')" style="display:none;">NemoClaw</div>
-    <div class="nav-tab nav-tab-more" onclick="toggleAdvancedTabs(event)" title="Advanced tabs">More &#9662;
-      <div class="advanced-tabs-dropdown" id="advanced-tabs-dropdown" style="display:none;">
-        <div class="nav-tab" onclick="switchTab('models');hideAdvDropdown()">Models</div>
-        <div class="nav-tab" onclick="switchTab('subagents');hideAdvDropdown()">Agents</div>
-        <div class="nav-tab" onclick="switchTab('limits');hideAdvDropdown()">Limits</div>
-        <div class="nav-tab" onclick="switchTab('version-impact');hideAdvDropdown()">Upgrades</div>
-        <div class="nav-tab" onclick="switchTab('clusters');hideAdvDropdown()">Clusters</div>
-      </div>
-    </div>
     <!-- History tab hidden until mature -->
     <!-- <div class="nav-tab" onclick="switchTab('history')">History</div> -->
   <div id="cloud-cta-btn" onclick="openCloudModal()" style="display:none;margin-left:8px;cursor:pointer;padding:6px 12px;border:1px solid rgba(96,165,250,0.5);border-radius:8px;font-size:12px;font-weight:600;color:#60a5fa;white-space:nowrap;transition:all 0.2s;user-select:none;" onmouseover="this.style.background='rgba(96,165,250,0.1)'" onmouseout="this.style.background='transparent'"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="display:inline;vertical-align:middle;margin-right:4px"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>Enable Cloud Sync</div>


### PR DESCRIPTION
## Summary

Two small user-visible fixes bundled as a single release.

### 1. Overview Agent Runtime renders bright red (visual bug)

`initOverviewFlow()` clones the Flow SVG and prefixes every id with `ov-` to avoid DOM-id collisions. The palette CSS used `#node-brain rect` / `#node-telegram rect` / etc. — those only matched the originals, so the Overview clone fell through to the garish inline defaults baked into the template (`fill="#C62828"` bright red for the brain box, wrong colors for all 30+ nodes).

**Fix:** rewrote all 37 palette selectors from `#node-X rect` → `[id$="node-X"] rect` (CSS "ends-with" attribute selector) in both `clawmetry/static/css/dashboard.css` and the embedded `<style>` block in `dashboard.py`. The attribute selector matches both `node-X` (original) and `ov-node-X` (clone), so the Overview now inherits the same muted rust/slate/navy palette as the Flow tab.

### 2. Drop "Skills" and "More ▾" from nav

User feedback: "none of them are useful — same for Skills."

| Before | After |
|---|---|
| Flow · Brain · Overview · Approvals · **Skills** · Context · Tokens · Memory · Security · **More** (Models / Agents / Limits / Upgrades / Clusters) | Flow · Brain · Overview · Approvals · Context · Tokens · Memory · Security |

Underlying `page-skills` / `page-models` / `page-subagents` / `page-limits` / `page-version-impact` / `page-clusters` templates are intact — they're just unreachable via nav. Nothing URL-level breaks. `.advanced-tabs-dropdown` CSS and `toggleAdvancedTabs()` JS helpers are left as harmless dead code (easy to strip in a cleanup pass later).

## Files changed

- `clawmetry/static/css/dashboard.css` — 37 palette selectors rewritten
- `dashboard.py` — 37 embedded-CSS palette selectors rewritten, 2 Skills nav-tabs removed, 2 More dropdown blocks removed

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — syntax clean
- [x] Hard-refresh localhost:8901 — Overview brain box now renders muted rust, matches Flow tab
- [ ] After merge: `clawmetry` CLI restart picks up the nav trim
- [ ] Verify Overview flow diagram and Flow tab flow diagram look identical (same muted palette)

🤖 Generated with [Claude Code](https://claude.com/claude-code)