### PR TITLE
[RELEASE] fix: tone down Brain box from rust-red to indigo

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -372,9 +372,9 @@
   [id$="node-feishu"] rect { fill: #3370FF !important; stroke: #2050CC !important; }
   [id$="node-zalo"] rect { fill: #0068FF !important; stroke: #0050CC !important; }
   [id$="node-gateway"] rect { fill: #334155 !important; stroke: #1f2937 !important; }
-  [id$="node-brain"] rect { fill: #a63a16 !important; stroke: #7c2d12 !important; }
-  [id$="brain-model-label"] { fill: #fde68a !important; }
-  [id$="brain-model-text"] { fill: #fed7aa !important; }
+  [id$="node-brain"] rect { fill: #312e81 !important; stroke: #1e1b4b !important; }
+  [id$="brain-model-label"] { fill: #e0e7ff !important; }
+  [id$="brain-model-text"] { fill: #c7d2fe !important; }
   [id$="node-session"] rect { fill: #3158d4 !important; stroke: #2648b6 !important; }
   [id$="node-exec"] rect { fill: #d97706 !important; stroke: #b45309 !important; }
   [id$="node-browser"] rect { fill: #5b39c6 !important; stroke: #4629a1 !important; }
@@ -406,7 +406,7 @@
   .flow-path.glow-yellow { stroke: #f0c040; filter: drop-shadow(0 0 6px rgba(240,192,64,0.6)); }
   .flow-path.glow-green { stroke: #50e080; filter: drop-shadow(0 0 6px rgba(80,224,128,0.6)); }
   .flow-path.glow-red { stroke: #e04040; filter: drop-shadow(0 0 6px rgba(224,64,64,0.6)); }
-  @keyframes brainPulse { 0%,100% { filter: drop-shadow(0 0 6px rgba(240,192,64,0.25)); } 50% { filter: drop-shadow(0 0 22px rgba(240,192,64,0.7)); } }
+  @keyframes brainPulse { 0%,100% { filter: drop-shadow(0 0 6px rgba(129,140,248,0.18)); } 50% { filter: drop-shadow(0 0 18px rgba(129,140,248,0.45)); } }
   .brain-group { animation: brainPulse 2.2s ease-in-out infinite; }
   @keyframes livePulse { 0%,100% { opacity:1; } 50% { opacity:0.4; } }
   .tool-indicator { opacity: 0.2; transition: opacity 0.3s ease; }

--- a/clawmetry/templates/tabs/flow.html
+++ b/clawmetry/templates/tabs/flow.html
@@ -156,16 +156,16 @@
       <!-- Brain (Agent Runtime) -->
       <g class="flow-node flow-node-brain brain-group" id="node-brain">
         <rect x="330" y="115" width="180" height="120" rx="12" ry="12" fill="#C62828" stroke="#B71C1C" stroke-width="3" filter="url(#dropShadow)"/>
-        <text x="345" y="133" style="font-size:8px;fill:#ffccbc;text-transform:uppercase;letter-spacing:1px;">Agent Runtime</text>
+        <text x="345" y="133" style="font-size:8px;fill:#a5b4fc;text-transform:uppercase;letter-spacing:1px;">Agent Runtime</text>
         <text x="420" y="155" style="font-size:20px;text-anchor:middle;">&#x1F9E0;</text>
         <!-- Primary provider (active) -->
         <circle cx="348" cy="172" r="4" fill="#4ade80" id="brain-provider-dot"/>
         <text x="356" y="176" style="font-size:12px;font-weight:700;fill:#FFD54F;" id="brain-model-label">AI Model</text>
-        <text x="356" y="189" style="font-size:9px;fill:#ffccbc;" id="brain-model-text">unknown</text>
+        <text x="356" y="189" style="font-size:9px;fill:#c7d2fe;" id="brain-model-text">unknown</text>
         <!-- Fallback providers (shown dynamically) -->
         <text x="356" y="202" style="font-size:8px;fill:#888;opacity:0.6;" id="brain-fallback-1"></text>
         <text x="356" y="213" style="font-size:8px;fill:#888;opacity:0.6;" id="brain-fallback-2"></text>
-        <text x="356" y="226" style="font-size:8px;fill:#a7f3d0;" id="brain-billing-text">Auth: unknown</text>
+        <text x="356" y="226" style="font-size:8px;fill:#a5b4fc;" id="brain-billing-text">Auth: unknown</text>
         <circle cx="420" cy="240" r="4" fill="#FF8A65">
           <animate attributeName="r" values="3;5;3" dur="1.1s" repeatCount="indefinite"/>
           <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>

--- a/dashboard.py
+++ b/dashboard.py
@@ -2510,9 +2510,9 @@ DASHBOARD_HTML = r"""
   [id$="node-feishu"] rect { fill: #3370FF !important; stroke: #2050CC !important; }
   [id$="node-zalo"] rect { fill: #0068FF !important; stroke: #0050CC !important; }
   [id$="node-gateway"] rect { fill: #334155 !important; stroke: #1f2937 !important; }
-  [id$="node-brain"] rect { fill: #a63a16 !important; stroke: #7c2d12 !important; }
-  [id$="brain-model-label"] { fill: #fde68a !important; }
-  [id$="brain-model-text"] { fill: #fed7aa !important; }
+  [id$="node-brain"] rect { fill: #312e81 !important; stroke: #1e1b4b !important; }
+  [id$="brain-model-label"] { fill: #e0e7ff !important; }
+  [id$="brain-model-text"] { fill: #c7d2fe !important; }
   [id$="node-session"] rect { fill: #3158d4 !important; stroke: #2648b6 !important; }
   [id$="node-exec"] rect { fill: #d97706 !important; stroke: #b45309 !important; }
   [id$="node-browser"] rect { fill: #5b39c6 !important; stroke: #4629a1 !important; }
@@ -2544,7 +2544,7 @@ DASHBOARD_HTML = r"""
   .flow-path.glow-yellow { stroke: #f0c040; filter: drop-shadow(0 0 6px rgba(240,192,64,0.6)); }
   .flow-path.glow-green { stroke: #50e080; filter: drop-shadow(0 0 6px rgba(80,224,128,0.6)); }
   .flow-path.glow-red { stroke: #e04040; filter: drop-shadow(0 0 6px rgba(224,64,64,0.6)); }
-  @keyframes brainPulse { 0%,100% { filter: drop-shadow(0 0 6px rgba(240,192,64,0.25)); } 50% { filter: drop-shadow(0 0 22px rgba(240,192,64,0.7)); } }
+  @keyframes brainPulse { 0%,100% { filter: drop-shadow(0 0 6px rgba(129,140,248,0.18)); } 50% { filter: drop-shadow(0 0 18px rgba(129,140,248,0.45)); } }
   .brain-group { animation: brainPulse 2.2s ease-in-out infinite; }
   .tool-indicator { opacity: 0.2; transition: opacity 0.3s ease; }
   .tool-indicator.active { opacity: 1; }
@@ -4081,8 +4081,8 @@ function clawmetryLogout(){
         <rect x="330" y="130" width="180" height="90" rx="12" ry="12" fill="#C62828" stroke="#B71C1C" stroke-width="3" filter="url(#dropShadow)"/>
         <text x="420" y="162" style="font-size:24px;text-anchor:middle;">&#x1F9E0;</text>
         <text x="420" y="186" style="font-size:18px;font-weight:800;fill:#FFD54F;text-anchor:middle;" id="brain-model-label">AI Model</text>
-        <text x="420" y="203" style="font-size:10px;fill:#ffccbc;text-anchor:middle;" id="brain-model-text">unknown</text>
-        <text x="420" y="214" style="font-size:8px;fill:#a7f3d0;text-anchor:middle;" id="brain-billing-text">Auth: unknown</text>
+        <text x="420" y="203" style="font-size:10px;fill:#c7d2fe;text-anchor:middle;" id="brain-model-text">unknown</text>
+        <text x="420" y="214" style="font-size:8px;fill:#a5b4fc;text-anchor:middle;" id="brain-billing-text">Auth: unknown</text>
         <circle cx="420" cy="225" r="4" fill="#FF8A65">
           <animate attributeName="r" values="3;5;3" dur="1.1s" repeatCount="indefinite"/>
           <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>


### PR DESCRIPTION
## Summary

User feedback after #757 landed: *"still brain looks weird"*. The Overview clone was now correctly inheriting the same color as Flow — but both still rendered the Agent Runtime box in rust/orange (\`#a63a16\`) on a screen of cool-toned nodes, which read as alarming/error. Salmon and amber accent text inside the box made it worse.

This PR recolors the Brain node to a calm dark indigo so it reads as **the AI centerpiece** rather than \"this dashboard is on fire.\"

## Visual change

| | Before | After |
|---|---|---|
| Box fill | \`#a63a16\` rust | \`#312e81\` indigo-800 |
| Box stroke | \`#7c2d12\` rust-dark | \`#1e1b4b\` indigo-950 |
| Model label | \`#fde68a\` pale amber | \`#e0e7ff\` indigo-100 |
| Model text | \`#fed7aa\` pale salmon | \`#c7d2fe\` indigo-200 |
| Pulse glow | amber (peak 22px / 0.7) | indigo (peak 18px / 0.45) |
| \"Agent Runtime\" label | salmon \`#ffccbc\` | \`#a5b4fc\` indigo-300 |
| \"Auth: …\" text | green \`#a7f3d0\` | \`#a5b4fc\` indigo-300 |

The Brain now sits in the same cool family as Memory (navy) and Browser (purple).

## Files

- \`clawmetry/static/css/dashboard.css\` — palette + brainPulse animation
- \`clawmetry/templates/tabs/flow.html\` — inline SVG fill attributes (which the CSS couldn't override without \`!important\`-on-inline-style trickery)
- \`dashboard.py\` — embedded CSS block + Overview-clone inline SVG fills

## Test plan

- [x] Verified live at localhost:8901 in both Flow tab and Overview tab — both show the new indigo coherently
- [x] Computed-style check: \`getComputedStyle\` returns the new fill values for both \`#node-brain rect\` and \`#ov-node-brain rect\`
- [x] Pulse animation breathes subtly rather than demanding attention

🤖 Generated with [Claude Code](https://claude.com/claude-code)