### PR TITLE
feat: wire openclaw:prompt-error events into alerts stream

### DIFF
--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -400,3 +400,83 @@ def api_alert_channels_test():
     if not sent:
         return jsonify({"ok": False, "error": "No configured webhook URL for selected target"}), 400
     return jsonify({"ok": True, "sent": sent})
+
+
+# ── Prompt Error Tracking Routes ──────────────────────────────────────────
+
+
+@bp_alerts.route("/api/prompt-errors")
+def api_prompt_errors():
+    """Scan recent session JSONLs for openclaw:prompt-error events.
+
+    Returns a list of prompt errors found in the last N sessions,
+    useful for catching failing model invocations before they cascade.
+    """
+    import dashboard as _d
+    import os
+    import glob
+    from datetime import datetime, timezone
+
+    session_dir = _d.SESSIONS_DIR or os.path.expanduser(
+        "~/.openclaw/agents/main/sessions"
+    )
+    errors = []
+    limit = request.args.get("limit", 10, type=int)
+
+    if not os.path.isdir(session_dir):
+        return jsonify({"errors": [], "count": 0, "banner": None})
+
+    # Get most recent JSONL files
+    session_files = sorted(
+        glob.glob(os.path.join(session_dir, "*.jsonl")),
+        key=os.path.getmtime,
+        reverse=True,
+    )[:20]  # Check last 20 sessions
+
+    for sf in session_files:
+        try:
+            with open(sf, "r", errors="replace") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except Exception:
+                        continue
+                    # Check for openclaw:prompt-error custom events
+                    if (
+                        obj.get("type") == "custom"
+                        and obj.get("customType") == "openclaw:prompt-error"
+                    ):
+                        data = obj.get("data", {}) or {}
+                        timestamp = obj.get("timestamp", "")
+                        error_info = {
+                            "timestamp": timestamp,
+                            "session_id": os.path.basename(sf).replace(".jsonl", ""),
+                            "error": data.get("error", "Unknown error"),
+                            "model": data.get("model", "unknown"),
+                            "provider": data.get("provider", "unknown"),
+                            "retries": data.get("retries", 0),
+                        }
+                        errors.append(error_info)
+                        if len(errors) >= limit:
+                            break
+        except Exception:
+            continue
+        if len(errors) >= limit:
+            break
+
+    # Build banner message for most recent error
+    banner = None
+    if errors:
+        latest = errors[0]
+        banner = {
+            "type": "prompt_error",
+            "severity": "warning",
+            "message": f"Prompt error: {latest['error'][:60]}... (model: {latest['model']})",
+            "count": len(errors),
+            "latest_at": latest["timestamp"],
+        }
+
+    return jsonify({"errors": errors[:limit], "count": len(errors), "banner": banner})

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -318,6 +318,50 @@ def api_overview():
         infra["storage"] = "Disk"
 
     model_name = main.get("model") or "unknown"
+
+    # Scan for recent prompt errors (openclaw:prompt-error events)
+    prompt_error_banner = None
+    try:
+        import glob
+
+        session_dir = _d.SESSIONS_DIR or os.path.expanduser(
+            "~/.openclaw/agents/main/sessions"
+        )
+        if os.path.isdir(session_dir):
+            session_files = sorted(
+                glob.glob(os.path.join(session_dir, "*.jsonl")),
+                key=os.path.getmtime,
+                reverse=True,
+            )[:10]  # Check last 10 sessions
+            for sf in session_files:
+                with open(sf, "r", errors="replace") as fh:
+                    for line in fh:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            obj = json.loads(line)
+                        except Exception:
+                            continue
+                        if (
+                            obj.get("type") == "custom"
+                            and obj.get("customType") == "openclaw:prompt-error"
+                        ):
+                            data = obj.get("data", {}) or {}
+                            prompt_error_banner = {
+                                "type": "prompt_error",
+                                "severity": "warning",
+                                "message": f"Prompt error: {data.get('error', 'Unknown error')[:50]}...",
+                                "model": data.get("model", "unknown"),
+                                "provider": data.get("provider", "unknown"),
+                                "retries": data.get("retries", 0),
+                            }
+                            break
+                if prompt_error_banner:
+                    break
+    except Exception:
+        pass
+
     return jsonify(
         {
             "model": model_name,
@@ -335,6 +379,7 @@ def api_overview():
             "memorySize": total_size,
             "system": system,
             "infra": infra,
+            "banner": prompt_error_banner,
         }
     )
 


### PR DESCRIPTION
Closes #601

## What
Adds endpoint /api/prompt-errors to scan session JSONLs for openclaw:prompt-error custom events. Returns error details including model, provider, retries, and error message.

Includes a banner field in /api/overview response for the UI to display a warning when prompt errors are detected in recent sessions.

## How
- New route /api/prompt-errors in routes/alerts.py scans the last 20 session JSONL files for openclaw:prompt-error events
- Returns structured error info: timestamp, session_id, error, model, provider, retries
- Builds a banner object for the most recent error to enable UI warnings
- Updated /api/overview in routes/overview.py to scan for prompt errors and include a banner field when errors are found