### PR TITLE
[RELEASE] fix: dedupe Brain feed events (overlapping JSONL slices)

### DIFF
--- a/routes/brain.py
+++ b/routes/brain.py
@@ -230,9 +230,15 @@ def api_brain_history():
 
             with open(sf, "r", errors="replace") as fh:
                 all_lines = fh.readlines()
-                raw_lines = (
-                    all_lines[:20] + all_lines[-600:]
-                )  # first 20 (system context) + last 600
+                # Want: first 20 (system context) + last 600 (recent activity).
+                # For files <= 620 lines the two slices overlap and we end up
+                # parsing the same JSONL line twice -> duplicate events in the
+                # Brain feed (same timestamp, same source, same payload).
+                total = len(all_lines)
+                if total <= 620:
+                    raw_lines = all_lines
+                else:
+                    raw_lines = all_lines[:20] + all_lines[-600:]
 
             for raw in raw_lines:
                 raw = raw.strip()
@@ -456,6 +462,26 @@ def api_brain_history():
                     )
                 except Exception:
                     pass
+
+    # Belt-and-suspenders dedupe: identical (time, source, type, detail) tuples
+    # can sneak in from (a) overlapping file slices, (b) the same session being
+    # recorded in two log paths, or (c) the synthetic CONTEXT pass replaying an
+    # event already parsed from JSONL. Drop the second-and-later occurrence
+    # rather than letting them double-render in the feed.
+    seen_keys = set()
+    deduped = []
+    for ev in events:
+        key = (
+            ev.get("time", ""),
+            ev.get("source", ""),
+            ev.get("type", ""),
+            (ev.get("detail") or "")[:200],
+        )
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        deduped.append(ev)
+    events = deduped
 
     events.sort(
         key=lambda ev: ev.get("time", "") or "", reverse=True


### PR DESCRIPTION
## Summary

User report (with screenshot): Brain tab shows duplicate `AGENT` and `USER` events at the same timestamp with identical content. Filter chips read `AGENT (4)` / `USER (4)` when there were really only 2 of each.

## Root cause

`routes/brain.py` builds the unified event feed by reading session JSONL files. To capture both the system-context preamble *and* recent activity in one pass it takes:

```python
raw_lines = all_lines[:20] + all_lines[-600:]
```

For any session file with **≤ 620 lines** those two slices **overlap** — every line in the overlap region gets parsed twice and emitted as two identical events.

Most local-dev session files are well under 620 lines, so almost everyone running the dev daemon was hitting this.

## Fix

1. **Avoid the overlap**: only concatenate when the file is actually large enough that the slices don't overlap (`total > 620`). For shorter files just use `all_lines`.
2. **Belt-and-suspenders dedupe**: add a final dedupe pass keyed on `(time, source, type, detail prefix)` right before sort/truncation. Defends against future regression sources — e.g. the same session being recorded under two log paths, or the synthetic CONTEXT pass replaying an event already parsed from JSONL.

## Verification

- `/api/brain-history` returns **0 duplicate** `(time, source, type, detail-prefix)` tuples (was returning multiple).
- Brain tab in browser: filter chips halve from `AGENT (4) → AGENT (2)` and `USER (4) → USER (2)` for the affected session.

## File

- `routes/brain.py` — 29 insertions, 3 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)