### PR TITLE
[RELEASE] feat(alerts): Cloud-Pro Alerts tab + soft paywall + OSS evaluator hook

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -988,3 +988,186 @@
 .mem-prose hr { border: 0; border-top: 1px solid var(--border-primary); margin: 18px 0; }
 .mem-prose a { color: #a5b4fc; text-decoration: none; border-bottom: 1px solid rgba(165,180,252,0.3); }
 .mem-prose a:hover { border-bottom-color: #a5b4fc; }
+
+/* ── Alerts tab (Cloud-Pro feature) ─────────────────────────────────── */
+.pro-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+  color: #fff; font-size: 9px; font-weight: 800; letter-spacing: .4px;
+  padding: 1px 6px; border-radius: 999px; text-transform: uppercase;
+  vertical-align: middle; margin-left: 5px; line-height: 1.4;
+}
+#page-alerts { padding: 8px 0 60px; }
+.alerts-head { display: flex; align-items: flex-end; justify-content: space-between; margin-bottom: 14px; gap: 16px; }
+.alerts-title { font-size: 22px; font-weight: 700; letter-spacing: -0.3px; color: var(--text-primary); margin: 0; }
+.alerts-sub   { font-size: 13px; color: var(--text-muted); margin-top: 2px; }
+.alerts-section-h { font-size: 13px; font-weight: 700; color: var(--text-secondary); margin: 24px 0 10px; }
+
+.alerts-btn-primary {
+  background: var(--bg-accent); color: #fff; border: 1px solid var(--bg-accent);
+  padding: 8px 14px; border-radius: 8px; font-size: 13px; font-weight: 600;
+  cursor: pointer; white-space: nowrap; transition: filter .15s;
+}
+.alerts-btn-primary:hover { filter: brightness(1.08); }
+.alerts-btn-ghost {
+  background: transparent; color: var(--text-secondary);
+  border: 1px solid var(--border-primary); padding: 6px 12px; border-radius: 8px;
+  font-size: 12px; font-weight: 600; cursor: pointer;
+}
+.alerts-btn-ghost:hover { background: var(--bg-hover); }
+.alerts-btn-pro {
+  background: linear-gradient(135deg, #f59e0b, #ef4444);
+  border: 0; color: #fff; font-weight: 700; font-size: 13px;
+  padding: 9px 16px; border-radius: 8px; cursor: pointer;
+}
+.alerts-btn-pro:hover { filter: brightness(1.05); }
+
+.alerts-trial-banner {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 16px; padding: 12px 16px; border-radius: 12px;
+  background: linear-gradient(135deg, rgba(245,158,11,.10), rgba(59,130,246,.12));
+  border: 1px solid rgba(245,158,11,.30); margin-bottom: 14px;
+}
+.alerts-trial-banner .msg { font-size: 13px; color: var(--text-secondary); }
+.alerts-trial-banner .msg b { color: var(--text-primary); }
+
+.alerts-list {
+  background: var(--bg-tertiary); border: 1px solid var(--border-primary);
+  border-radius: 12px; overflow: hidden;
+}
+.alerts-loading { padding: 18px; color: var(--text-muted); font-size: 13px; text-align: center; }
+.alerts-rule-row {
+  display: grid; grid-template-columns: 24px 1fr auto auto;
+  gap: 16px; align-items: center; padding: 13px 18px;
+  border-bottom: 1px solid var(--border-secondary);
+}
+.alerts-rule-row:last-child { border-bottom: 0; }
+.alerts-rule-row:hover { background: var(--bg-hover); }
+.alerts-rule-row.alerts-rule-example { cursor: pointer; opacity: 0.92; }
+.alerts-rule-dot { width: 10px; height: 10px; border-radius: 50%; cursor: pointer; }
+.alerts-rule-dot.on  { background: #22c55e; box-shadow: 0 0 0 3px rgba(34,197,94,0.15); }
+.alerts-rule-dot.off { background: var(--text-faint); }
+.alerts-rule-main { min-width: 0; }
+.alerts-rule-title { font-weight: 600; color: var(--text-primary); font-size: 14px; }
+.alerts-rule-meta  { color: var(--text-muted); font-size: 12px; margin-top: 2px; }
+.alerts-rule-example-badge {
+  font-size: 10px; color: var(--text-muted); font-weight: 500;
+  background: var(--bg-hover); padding: 1px 6px; border-radius: 999px;
+  margin-left: 6px;
+}
+.alerts-rule-chan { display: flex; gap: 6px; flex-wrap: wrap; }
+.alerts-chan-pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 8px; border-radius: 999px; font-size: 11px; font-weight: 600;
+  background: var(--bg-hover); border: 1px solid var(--border-secondary);
+  color: var(--text-secondary);
+}
+.alerts-chan-pill.off { opacity: 0.5; }
+
+.alerts-history {
+  background: var(--bg-tertiary); border: 1px solid var(--border-primary);
+  border-radius: 12px; overflow: hidden;
+}
+.alerts-hist-row {
+  display: grid; grid-template-columns: 16px 100px 1fr;
+  gap: 12px; padding: 9px 16px;
+  border-bottom: 1px solid var(--border-secondary); font-size: 13px;
+}
+.alerts-hist-row:last-child { border-bottom: 0; }
+.alerts-hist-time { color: var(--text-muted); font-size: 12px; }
+.sev-red   { color: var(--text-error); }
+.sev-amber { color: var(--text-warning); }
+.sev-green { color: var(--text-success); }
+
+.alerts-shared-note {
+  margin-top: 18px; padding: 12px 14px; border-radius: 10px;
+  background: var(--bg-secondary); border: 1px solid var(--border-secondary);
+  display: flex; justify-content: space-between; align-items: center; font-size: 13px;
+  gap: 16px;
+}
+.alerts-shared-note .l { color: var(--text-tertiary); }
+.alerts-shared-note .l b { color: var(--text-primary); }
+
+/* ── Modals (paywall + editor) ────────────────────────────────────── */
+.alerts-modal-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,.6);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 1000; padding: 20px;
+}
+.alerts-modal-card, .alerts-editor-card {
+  background: var(--bg-tertiary); border: 1px solid var(--border-primary);
+  border-radius: 16px; padding: 28px; max-width: 460px; width: 100%;
+  box-shadow: 0 25px 60px rgba(0,0,0,.45);
+}
+.alerts-editor-card { max-width: 560px; padding: 0; }
+.alerts-modal-icon { font-size: 38px; text-align: center; margin-bottom: 8px; }
+.alerts-modal-title { font-size: 19px; font-weight: 700; text-align: center; margin: 0 0 8px; color: var(--text-primary); }
+.alerts-modal-body  { color: var(--text-muted); font-size: 14px; text-align: center; margin: 0 0 18px; line-height: 1.5; }
+.alerts-modal-actions { display: flex; flex-direction: column; gap: 8px; }
+.alerts-modal-actions .alerts-btn-pro,
+.alerts-modal-actions .alerts-btn-ghost { width: 100%; padding: 11px; }
+.alerts-modal-footnote { font-size: 11px; color: var(--text-faint); text-align: center; margin-top: 12px; }
+
+.alerts-editor-head {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 18px 22px; border-bottom: 1px solid var(--border-secondary);
+}
+.alerts-editor-head h3 { font-size: 17px; font-weight: 700; margin: 0; color: var(--text-primary); }
+.alerts-modal-close {
+  background: transparent; border: 0; color: var(--text-muted);
+  font-size: 22px; cursor: pointer; line-height: 1; padding: 0 4px;
+}
+.alerts-modal-close:hover { color: var(--text-primary); }
+
+.alerts-editor-section { padding: 16px 22px; border-bottom: 1px solid var(--border-secondary); }
+.alerts-editor-section:last-of-type { border-bottom: 0; }
+.alerts-editor-step { font-size: 12px; font-weight: 700; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 10px; }
+
+.alerts-seg {
+  display: inline-flex; background: var(--bg-hover); padding: 3px;
+  border-radius: 10px; gap: 2px; border: 1px solid var(--border-secondary);
+  flex-wrap: wrap;
+}
+.alerts-seg button {
+  background: transparent; border: 0; color: var(--text-tertiary);
+  padding: 6px 12px; border-radius: 8px; font-size: 12px; font-weight: 600;
+  cursor: pointer; white-space: nowrap;
+}
+.alerts-seg button.active {
+  background: var(--bg-secondary); color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+}
+
+.alerts-editor-form { margin-top: 14px; }
+.alerts-form-row {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 10px; font-size: 13px; color: var(--text-secondary); flex-wrap: wrap;
+}
+.alerts-form-row label {
+  font-weight: 600; color: var(--text-secondary); min-width: 60px;
+}
+.alerts-form-row input {
+  background: var(--bg-primary); border: 1px solid var(--border-primary);
+  color: var(--text-primary); padding: 7px 10px; border-radius: 8px;
+  font-size: 13px; flex: 1; min-width: 140px;
+}
+.alerts-form-unit { color: var(--text-muted); font-size: 12px; }
+
+.alerts-chan-check {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px; border: 1px solid var(--border-secondary); border-radius: 10px;
+  margin-bottom: 6px; background: var(--bg-secondary); cursor: pointer;
+}
+.alerts-chan-check input { transform: scale(1.05); cursor: pointer; }
+.alerts-chan-check .name { font-weight: 600; font-size: 13px; color: var(--text-primary); flex: 1; }
+.alerts-chan-check .dest { font-size: 12px; color: var(--text-muted); font-family: ui-monospace, monospace; }
+
+.alerts-radio {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 13px; color: var(--text-secondary); margin-bottom: 6px; cursor: pointer;
+}
+
+.alerts-editor-actions {
+  display: flex; justify-content: flex-end; gap: 8px;
+  padding: 16px 22px; border-top: 1px solid var(--border-secondary);
+}

--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -1,0 +1,443 @@
+// Alerts tab — Cloud-Pro feature with soft paywall.
+//
+// Tier states (resolved via /api/cloud-cta/status + /api/cloud-proxy/account):
+//   - none:    no cloud token             → "Sign up for Cloud" CTA
+//   - free:    cloud, plan=free           → "Upgrade to Pro" CTA
+//   - trial:   cloud, plan=trial          → trial banner + full UI
+//   - pro:     cloud, plan=cloud_pro/pro  → full UI
+//
+// All cloud calls go through /api/cloud-proxy/<path> which the OSS Flask
+// dashboard forwards to https://app.clawmetry.com with the user's cm_ token
+// injected from ~/.openclaw/openclaw.json.
+
+(function () {
+  'use strict';
+
+  let alertsState = {
+    tier: 'unknown',         // 'none' | 'free' | 'trial' | 'pro' | 'unknown'
+    trialDaysLeft: null,
+    rules: [],
+    channels: [],
+    history: [],
+    editorRule: null,        // currently-being-edited rule, or null for new
+    editorType: 'node_offline',
+  };
+
+  // ── Tier resolution ───────────────────────────────────────────────────────
+
+  async function resolveTier() {
+    try {
+      const status = await fetch('/api/cloud-cta/status').then(r => r.json());
+      if (!status.connected) return { tier: 'none' };
+      const acct = await fetch('/api/cloud-proxy/api/cloud/account').then(r => r.json());
+      const plan = (acct.plan || 'free').toLowerCase();
+      if (plan === 'cloud_pro' || plan === 'pro') return { tier: 'pro' };
+      if (plan === 'trial') {
+        const days = parseInt(acct.trial_days_left || 0, 10);
+        return { tier: days > 0 ? 'trial' : 'free', trialDaysLeft: days };
+      }
+      return { tier: 'free' };
+    } catch (e) {
+      console.warn('[alerts] tier resolution failed', e);
+      return { tier: 'none' };
+    }
+  }
+
+  // ── Page entry point ──────────────────────────────────────────────────────
+
+  window.loadAlertsPage = async function () {
+    document.getElementById('alerts-rules-list').innerHTML =
+      '<div class="alerts-loading">Loading alerts…</div>';
+
+    const t = await resolveTier();
+    alertsState.tier = t.tier;
+    alertsState.trialDaysLeft = t.trialDaysLeft || null;
+
+    if (t.tier === 'trial' && t.trialDaysLeft != null) {
+      const banner = document.getElementById('alerts-trial-banner');
+      banner.style.display = '';
+      document.getElementById('alerts-trial-days-left').textContent =
+        ' · ' + t.trialDaysLeft + ' day' + (t.trialDaysLeft === 1 ? '' : 's') + ' left';
+    } else {
+      document.getElementById('alerts-trial-banner').style.display = 'none';
+    }
+
+    // For all tiers: try to load rules. If unauthenticated, fall back to
+    // canned examples so the user still sees the value.
+    if (t.tier === 'none') {
+      renderCannedExamples();
+      renderHistoryEmpty('Sign up for Cloud to start collecting alert history.');
+      return;
+    }
+
+    try {
+      const data = await fetch('/api/cloud-proxy/api/alerts').then(r => r.json());
+      alertsState.rules = data.alerts || [];
+    } catch {
+      alertsState.rules = [];
+    }
+    renderRules();
+
+    try {
+      const hist = await fetch('/api/cloud-proxy/api/alerts/history?limit=10')
+        .then(r => r.json());
+      alertsState.history = hist.history || [];
+    } catch {
+      alertsState.history = [];
+    }
+    renderHistory();
+
+    try {
+      const ch = await fetch('/api/cloud-proxy/api/channels').then(r => r.json());
+      alertsState.channels = ch.channels || [];
+      renderChannelsSummary();
+    } catch {
+      alertsState.channels = [];
+    }
+  };
+
+  // ── Renderers ─────────────────────────────────────────────────────────────
+
+  const RULE_TYPE_LABELS = {
+    daily_spend:      { icon: '💰', verb: 'Daily spend exceeds' },
+    session_cost:     { icon: '🧵', verb: 'Session cost exceeds' },
+    node_offline:     { icon: '🤖', verb: 'Agent offline >' },
+    session_duration: { icon: '⏱',  verb: 'Session duration >' },
+    token_velocity:   { icon: '⚡', verb: 'Tokens/min >' },
+    subagent_depth:   { icon: '🌳', verb: 'Sub-agent depth >' },
+    cron_failure:     { icon: '⏰', verb: 'Cron failed >' },
+    error_rate:       { icon: '🛠', verb: 'Tool error rate >' },
+  };
+
+  function renderRules() {
+    const wrap = document.getElementById('alerts-rules-list');
+    if (!alertsState.rules.length) {
+      renderCannedExamples();
+      return;
+    }
+    wrap.innerHTML = alertsState.rules.map(rule => {
+      const meta = RULE_TYPE_LABELS[rule.alert_type] || { icon: '🔔', verb: rule.alert_type };
+      const channelPills = (rule.channel_ids || []).map(id => {
+        const ch = alertsState.channels.find(c => c.id === id);
+        if (!ch) return '';
+        return `<span class="alerts-chan-pill">${chTypeIcon(ch.channel_type)} ${escape(ch.name)}</span>`;
+      }).join('');
+      const dotCls = rule.enabled ? 'on' : 'off';
+      const ts = rule.last_triggered_at
+        ? `Last: ${formatTimeAgo(rule.last_triggered_at)} · ${rule.trigger_count}× total`
+        : `Never triggered`;
+      return `
+        <div class="alerts-rule-row" data-rule-id="${rule.id}">
+          <div class="alerts-rule-dot ${dotCls}" title="${rule.enabled ? 'Enabled' : 'Disabled'}"
+               onclick="alertsToggleRule('${rule.id}', ${!rule.enabled})"></div>
+          <div class="alerts-rule-main">
+            <div class="alerts-rule-title">${meta.icon} ${escape(rule.name)}</div>
+            <div class="alerts-rule-meta">${meta.verb} ${rule.threshold_value}${rule.threshold_unit ? ' ' + escape(rule.threshold_unit) : ''} · ${ts}</div>
+          </div>
+          <div class="alerts-rule-chan">${channelPills || '<span class="alerts-chan-pill off">no channels</span>'}</div>
+          <button class="alerts-btn-ghost" onclick="alertsHandleEdit('${rule.id}')">Edit</button>
+        </div>
+      `;
+    }).join('');
+  }
+
+  function renderCannedExamples() {
+    const examples = [
+      { type: 'daily_spend', name: 'Daily spend > $50', threshold: 50, unit: 'USD', channels: '💬 Slack · ✉️ Email' },
+      { type: 'node_offline', name: 'Agent offline > 10 min', threshold: 10, unit: 'min', channels: '📟 PagerDuty' },
+      { type: 'session_cost', name: 'Session tokens > 1M', threshold: 1000000, unit: 'tokens', channels: '✉️ Email' },
+      { type: 'cron_failure', name: 'Cron failed 3× in a row', threshold: 3, unit: 'fails', channels: '💬 Slack · ✈️ Telegram' },
+      { type: 'error_rate', name: 'Tool failures > 5/hr', threshold: 5, unit: '/hr', channels: '✉️ Email' },
+    ];
+    const wrap = document.getElementById('alerts-rules-list');
+    wrap.innerHTML = examples.map(ex => {
+      const meta = RULE_TYPE_LABELS[ex.type];
+      return `
+        <div class="alerts-rule-row alerts-rule-example" onclick="alertsHandleNewRule()">
+          <div class="alerts-rule-dot off"></div>
+          <div class="alerts-rule-main">
+            <div class="alerts-rule-title">${meta.icon} ${escape(ex.name)}
+              <span class="alerts-rule-example-badge">example</span>
+            </div>
+            <div class="alerts-rule-meta">Tap to enable — requires Cloud Pro</div>
+          </div>
+          <div class="alerts-rule-chan"><span class="alerts-chan-pill off">${ex.channels}</span></div>
+          <button class="alerts-btn-ghost" onclick="event.stopPropagation();alertsHandleNewRule()">Enable</button>
+        </div>
+      `;
+    }).join('');
+  }
+
+  function renderHistory() {
+    const wrap = document.getElementById('alerts-history-list');
+    if (!alertsState.history.length) {
+      return renderHistoryEmpty('No alerts have fired yet.');
+    }
+    wrap.innerHTML = alertsState.history.map(h => {
+      const sev = h.resolved_at ? 'sev-green' : 'sev-red';
+      const dot = h.resolved_at ? '●' : '●';
+      const payload = h.payload || {};
+      return `
+        <div class="alerts-hist-row">
+          <span class="${sev}">${dot}</span>
+          <span class="alerts-hist-time">${formatTimeAgo(h.fired_at)}</span>
+          <span class="alerts-hist-text"><b>${escape(payload.name || h.alert_id)}</b>
+            → ${escape(String(payload.actual_value ?? ''))} ${escape(payload.threshold_unit || '')}</span>
+        </div>
+      `;
+    }).join('');
+  }
+
+  function renderHistoryEmpty(msg) {
+    document.getElementById('alerts-history-list').innerHTML =
+      `<div class="alerts-loading">${escape(msg)}</div>`;
+  }
+
+  function renderChannelsSummary() {
+    const wrap = document.getElementById('alerts-channels-summary');
+    if (!alertsState.channels.length) {
+      wrap.textContent = 'No channels configured yet';
+      return;
+    }
+    const types = [...new Set(alertsState.channels.map(c => chTypeLabel(c.channel_type)))];
+    wrap.textContent = types.join(' · ');
+  }
+
+  // ── Action handlers (paywall-aware) ───────────────────────────────────────
+
+  window.alertsHandleNewRule = function () {
+    if (alertsState.tier === 'pro' || alertsState.tier === 'trial') {
+      alertsState.editorRule = null;
+      alertsState.editorType = 'node_offline';
+      openEditor();
+    } else {
+      openPaywall();
+    }
+  };
+
+  window.alertsHandleEdit = function (ruleId) {
+    if (alertsState.tier === 'pro' || alertsState.tier === 'trial') {
+      const rule = alertsState.rules.find(r => r.id === ruleId);
+      if (!rule) return;
+      alertsState.editorRule = rule;
+      alertsState.editorType = rule.alert_type;
+      openEditor();
+    } else {
+      openPaywall();
+    }
+  };
+
+  window.alertsHandleManageChannels = function () {
+    if (alertsState.tier === 'pro' || alertsState.tier === 'trial') {
+      // Channels management is a separate page — for now point to Cloud
+      window.open('https://app.clawmetry.com/cloud#channels', '_blank');
+    } else {
+      openPaywall();
+    }
+  };
+
+  window.alertsHandleUpgrade = function () {
+    window.open('https://app.clawmetry.com/pricing', '_blank');
+  };
+
+  window.alertsToggleRule = async function (ruleId, newEnabled) {
+    if (alertsState.tier !== 'pro' && alertsState.tier !== 'trial') {
+      return openPaywall();
+    }
+    try {
+      const resp = await fetch('/api/cloud-proxy/api/alerts/' + ruleId, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: newEnabled }),
+      });
+      if (resp.status === 402) {
+        // Hit the Free-tier cap server-side
+        return openPaywall();
+      }
+      if (!resp.ok) throw new Error('toggle failed: HTTP ' + resp.status);
+      window.loadAlertsPage();
+    } catch (e) {
+      console.warn(e);
+    }
+  };
+
+  // ── Paywall modal ─────────────────────────────────────────────────────────
+
+  function openPaywall() {
+    const modal = document.getElementById('alerts-paywall-modal');
+    const title = document.getElementById('alerts-paywall-title');
+    const body  = document.getElementById('alerts-paywall-body');
+    const cta   = document.getElementById('alerts-paywall-cta');
+    if (alertsState.tier === 'none') {
+      title.textContent = 'Sign up for ClawMetry Cloud';
+      body.textContent  = 'Alerts need the cloud to deliver Slack / PagerDuty / Telegram / Email messages. Sign up — your data stays encrypted, Pro features include a 7-day free trial.';
+      cta.textContent   = 'Sign up for Cloud';
+      cta.dataset.action = 'signup';
+    } else {
+      title.textContent = 'Upgrade to ClawMetry Pro';
+      body.textContent  = 'Free plan allows 1 enabled alert. Upgrade to Pro for unlimited alerts, multi-channel delivery to Slack / PagerDuty / Telegram / Email, and 90-day alert history.';
+      cta.textContent   = 'Start 7-day free trial';
+      cta.dataset.action = 'upgrade';
+    }
+    modal.style.display = 'flex';
+  }
+
+  window.alertsClosePaywall = function (e) {
+    if (e && e.target.id !== 'alerts-paywall-modal') return;
+    document.getElementById('alerts-paywall-modal').style.display = 'none';
+  };
+
+  window.alertsCtaClick = function () {
+    const cta = document.getElementById('alerts-paywall-cta');
+    if (cta.dataset.action === 'signup' && typeof openCloudModal === 'function') {
+      window.alertsClosePaywall();
+      openCloudModal();
+    } else {
+      window.open('https://app.clawmetry.com/pricing', '_blank');
+    }
+  };
+
+  // ── Editor modal (Pro tier) ───────────────────────────────────────────────
+
+  function openEditor() {
+    document.getElementById('alerts-editor-modal').style.display = 'flex';
+    document.getElementById('alerts-editor-title').textContent =
+      alertsState.editorRule ? 'Edit alert rule' : 'New alert rule';
+    setActiveType(alertsState.editorType);
+    renderEditorForm();
+    renderEditorChannels();
+    setEditorReAlert(alertsState.editorRule?.re_alert_policy || 'once');
+  }
+
+  window.alertsCloseEditor = function (e) {
+    if (e && e.target.id !== 'alerts-editor-modal') return;
+    document.getElementById('alerts-editor-modal').style.display = 'none';
+  };
+
+  window.alertsPickType = function (type) {
+    alertsState.editorType = type;
+    setActiveType(type);
+    renderEditorForm();
+  };
+
+  function setActiveType(type) {
+    document.querySelectorAll('#alerts-type-seg button').forEach(b => {
+      b.classList.toggle('active', b.dataset.type === type);
+    });
+  }
+
+  function renderEditorForm() {
+    const t = alertsState.editorType;
+    const r = alertsState.editorRule || {};
+    const presets = {
+      daily_spend:  { unit: 'USD',    placeholder: 50, label: 'Daily spend exceeds', name: 'Daily spend cap' },
+      session_cost: { unit: 'USD',    placeholder: 5,  label: 'Single session cost exceeds', name: 'Session cost cap' },
+      node_offline: { unit: 'min',    placeholder: 10, label: 'Agent has been offline for more than', name: 'Agent offline' },
+      cron_failure: { unit: 'fails',  placeholder: 3,  label: 'Cron has failed in a row at least', name: 'Cron failure streak' },
+      error_rate:   { unit: '%',      placeholder: 20, label: 'Tool failure rate exceeds', name: 'Tool failures' },
+    };
+    const p = presets[t] || { unit: '', placeholder: 0, label: 'Threshold', name: 'Custom alert' };
+    const val = r.threshold_value ?? p.placeholder;
+    document.getElementById('alerts-editor-form').innerHTML = `
+      <div class="alerts-form-row">
+        <label>Name</label>
+        <input type="text" id="alerts-rule-name" value="${escape(r.name || p.name)}" />
+      </div>
+      <div class="alerts-form-row">
+        <label>${p.label}</label>
+        <input type="number" id="alerts-rule-threshold" value="${val}" step="any" style="width:120px;" />
+        <span class="alerts-form-unit">${p.unit}</span>
+      </div>
+    `;
+  }
+
+  function renderEditorChannels() {
+    const wrap = document.getElementById('alerts-editor-channels');
+    if (!alertsState.channels.length) {
+      wrap.innerHTML = '<div class="alerts-loading">No channels yet — add one below.</div>';
+      return;
+    }
+    const selected = new Set(alertsState.editorRule?.channel_ids || []);
+    wrap.innerHTML = alertsState.channels.map(ch => `
+      <label class="alerts-chan-check">
+        <input type="checkbox" data-channel-id="${ch.id}" ${selected.has(ch.id) ? 'checked' : ''} />
+        <span class="name">${chTypeIcon(ch.channel_type)} ${chTypeLabel(ch.channel_type)}</span>
+        <span class="dest">${escape(ch.name)}</span>
+      </label>
+    `).join('');
+  }
+
+  function setEditorReAlert(policy) {
+    document.querySelectorAll('input[name="alerts-re"]').forEach(r => {
+      r.checked = (r.value === policy);
+    });
+  }
+
+  window.alertsSaveRule = async function () {
+    const name = document.getElementById('alerts-rule-name').value.trim();
+    const threshold = parseFloat(document.getElementById('alerts-rule-threshold').value);
+    if (!name || isNaN(threshold)) return;
+    const channelIds = [...document.querySelectorAll('#alerts-editor-channels input:checked')]
+      .map(i => i.dataset.channelId);
+    const policy = document.querySelector('input[name="alerts-re"]:checked')?.value || 'once';
+
+    const body = {
+      alert_type: alertsState.editorType,
+      name,
+      threshold_value: threshold,
+      enabled: true,
+      channel_ids: channelIds,
+      re_alert_policy: policy,
+    };
+
+    const isEdit = !!alertsState.editorRule;
+    const url = isEdit
+      ? '/api/cloud-proxy/api/alerts/' + alertsState.editorRule.id
+      : '/api/cloud-proxy/api/alerts';
+    const method = isEdit ? 'PUT' : 'POST';
+
+    const resp = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (resp.status === 402) {
+      window.alertsCloseEditor();
+      return openPaywall();
+    }
+    if (!resp.ok) {
+      console.warn('save failed', resp.status, await resp.text());
+      return;
+    }
+    window.alertsCloseEditor();
+    window.loadAlertsPage();
+  };
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  function chTypeIcon(type) {
+    return ({ slack: '💬', email: '✉️', pagerduty: '📟', telegram: '✈️', phone: '📞' })[type] || '🔔';
+  }
+  function chTypeLabel(type) {
+    return ({ slack: 'Slack', email: 'Email', pagerduty: 'PagerDuty', telegram: 'Telegram', phone: 'Phone' })[type] || type;
+  }
+  function escape(s) {
+    if (s == null) return '';
+    return String(s).replace(/[&<>"']/g, c =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]
+    );
+  }
+  function formatTimeAgo(iso) {
+    if (!iso) return '';
+    try {
+      const ts = new Date(iso);
+      const sec = Math.floor((Date.now() - ts.getTime()) / 1000);
+      if (sec < 60) return 'just now';
+      if (sec < 3600) return Math.floor(sec / 60) + 'm ago';
+      if (sec < 86400) return Math.floor(sec / 3600) + 'h ago';
+      return Math.floor(sec / 86400) + 'd ago';
+    } catch {
+      return iso;
+    }
+  }
+})();

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -529,6 +529,7 @@ function switchTab(name) {
   if (name === 'brain') loadBrainPage();
   if (name === 'security') { loadSecurityPage(); loadSecurityPosture(); }
   if (name === 'approvals') { if (typeof loadApprovalsTab === 'function') loadApprovalsTab(); }
+  if (name === 'alerts') { if (typeof loadAlertsPage === 'function') loadAlertsPage(); }
   if (name === 'actions') loadQAHistory();
   if (name === 'logs') { if (!logStream || logStream.readyState === EventSource.CLOSED) startLogStream(); loadLogs(); }
   if (name === 'models') loadModelAttribution();

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3486,6 +3486,62 @@ def sync_autonomy(config, state, paths):
         return 0
 
 
+ALERTS_EVAL_INTERVAL_SEC = 300  # Re-evaluate alerts every 5 minutes
+
+
+def evaluate_alerts(config: dict, state: dict) -> int:
+    """Trigger cloud-side alert evaluation for this node.
+
+    The cloud holds the rules and runs the actual threshold checks against the
+    sessions/events tables it already syncs from this daemon. We just poke the
+    `/api/internal/evaluate-alerts` endpoint on a schedule.
+
+    Throttled to ALERTS_EVAL_INTERVAL_SEC because:
+      - The 60s sync tick is unnecessarily aggressive for cost / heartbeat /
+        cron-failure rules
+      - Cloud also enforces a 1-hour debounce per alert (`_debounce_ok`), so
+        more frequent calls would waste cycles, not catch more incidents
+
+    Skips silently if the user has no cloud account configured -- alerts is a
+    Cloud-Pro-only feature (see project_alerts_pro_feature memory).
+    """
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not api_key or not api_key.startswith("cm_"):
+        return 0  # No cloud account: nothing to evaluate
+    if not node_id:
+        return 0
+
+    last = state.get("alerts_last_eval_ts", 0)
+    now = time.time()
+    if (now - last) < ALERTS_EVAL_INTERVAL_SEC:
+        return 0
+
+    try:
+        result = _post(
+            "/api/internal/evaluate-alerts",
+            {"node_id": node_id},
+            api_key,
+            timeout=20,
+        )
+        state["alerts_last_eval_ts"] = now
+        triggered = result.get("triggered") if isinstance(result, dict) else None
+        if triggered:
+            log.info(
+                "[alerts] evaluated %s rules, %s triggered",
+                result.get("evaluated", "?"),
+                len(triggered),
+            )
+        return len(triggered or [])
+    except Exception as e:
+        # Cloud may return 402 if user is on Free tier and alerts are gated;
+        # log once and don't keep retrying every cycle.
+        log.warning(f"alerts evaluation skipped: {e}")
+        # Still record the timestamp so we back off rather than retry on every tick
+        state["alerts_last_eval_ts"] = now
+        return 0
+
+
 def run_daemon() -> None:
     """Run the sync daemon - main loop for continuous synchronization."""
     config = load_config()
@@ -3503,6 +3559,7 @@ def run_daemon() -> None:
             sync_memory(config, state, paths)
             sync_system_snapshot(config, state, paths)
             sync_autonomy(config, state, paths)
+            evaluate_alerts(config, state)
             save_state(state)
         except Exception as e:
             log.error(f"Sync error: {e}")

--- a/clawmetry/templates/tabs/alerts.html
+++ b/clawmetry/templates/tabs/alerts.html
@@ -1,0 +1,120 @@
+<!--
+  Alerts tab — Cloud-Pro feature.
+
+  Three states (resolved at runtime by alerts.js):
+    1. OSS-only (no cloud account)  → "Sign up for ClawMetry Cloud" modal
+    2. Cloud Free / trial_expired   → "Upgrade to Pro" modal (1 teaser rule visible)
+    3. Cloud Pro / active trial     → fully wired
+
+  Whichever state, the *full* tab shell renders so users see the value before
+  the soft paywall fires (per project_free_plan_upsell memory).
+-->
+<div class="page" id="page-alerts">
+  <div class="alerts-head">
+    <div>
+      <h2 class="alerts-title">
+        Alerts
+        <span class="pro-chip" title="Pro feature">Pro</span>
+      </h2>
+      <div class="alerts-sub">Get notified when something goes wrong with your agents.</div>
+    </div>
+    <button class="alerts-btn-primary" onclick="alertsHandleNewRule()">+ New alert rule</button>
+  </div>
+
+  <div id="alerts-trial-banner" class="alerts-trial-banner" style="display:none;">
+    <div class="msg">
+      <b>You're on a 7-day Pro trial</b> — unlock multi-channel delivery to
+      Slack, PagerDuty, Telegram, and Email.
+      <span id="alerts-trial-days-left" style="color:var(--text-muted);"></span>
+    </div>
+    <button class="alerts-btn-pro" onclick="alertsHandleUpgrade()">Upgrade to Pro</button>
+  </div>
+
+  <div id="alerts-rules-list" class="alerts-list">
+    <div class="alerts-loading">Loading alerts…</div>
+  </div>
+
+  <h4 class="alerts-section-h">Recent alert history</h4>
+  <div id="alerts-history-list" class="alerts-history">
+    <div class="alerts-loading">Loading history…</div>
+  </div>
+
+  <div class="alerts-shared-note">
+    <div class="l">
+      Delivery channels: <b id="alerts-channels-summary">Slack · Email · PagerDuty · Telegram</b>
+      <span style="color:var(--text-muted);font-style:italic;"> shared with Approvals</span>
+    </div>
+    <button class="alerts-btn-ghost" onclick="alertsHandleManageChannels()">Manage channels →</button>
+  </div>
+</div>
+
+<!-- ── Paywall modal (used for all three Free/no-account states) ────────── -->
+<div class="alerts-modal-overlay" id="alerts-paywall-modal" style="display:none;" onclick="alertsClosePaywall(event)">
+  <div class="alerts-modal-card" onclick="event.stopPropagation()">
+    <div class="alerts-modal-icon">🔔</div>
+    <h3 class="alerts-modal-title" id="alerts-paywall-title">Sign up for ClawMetry Cloud</h3>
+    <p class="alerts-modal-body" id="alerts-paywall-body">
+      Alerts need the cloud to deliver Slack / PagerDuty / Telegram / Email
+      messages. Sign up — your data stays encrypted, Pro features include a
+      7-day free trial.
+    </p>
+    <div class="alerts-modal-actions">
+      <button class="alerts-btn-pro" id="alerts-paywall-cta" onclick="alertsCtaClick()">Sign up for Cloud</button>
+      <button class="alerts-btn-ghost" onclick="alertsClosePaywall()">Maybe later</button>
+    </div>
+    <div class="alerts-modal-footnote">No credit card · free tier available · 7-day Pro trial</div>
+  </div>
+</div>
+
+<!-- ── Rule editor modal (Pro-tier only) ────────────────────────────────── -->
+<div class="alerts-modal-overlay" id="alerts-editor-modal" style="display:none;" onclick="alertsCloseEditor(event)">
+  <div class="alerts-editor-card" onclick="event.stopPropagation()">
+    <div class="alerts-editor-head">
+      <h3 id="alerts-editor-title">New alert rule</h3>
+      <button class="alerts-modal-close" onclick="alertsCloseEditor()">×</button>
+    </div>
+
+    <div class="alerts-editor-section">
+      <div class="alerts-editor-step">1. What should trigger this alert?</div>
+      <div class="alerts-seg" id="alerts-type-seg">
+        <button data-type="daily_spend" onclick="alertsPickType('daily_spend')">💰 Cost</button>
+        <button data-type="node_offline" class="active" onclick="alertsPickType('node_offline')">🤖 Agent</button>
+        <button data-type="session_cost" onclick="alertsPickType('session_cost')">🧵 Session</button>
+        <button data-type="cron_failure" onclick="alertsPickType('cron_failure')">⏱ Cron</button>
+        <button data-type="error_rate" onclick="alertsPickType('error_rate')">🛠 Tool fails</button>
+      </div>
+      <div class="alerts-editor-form" id="alerts-editor-form">
+        <!-- populated by alertsRenderTypeForm() -->
+      </div>
+    </div>
+
+    <div class="alerts-editor-section">
+      <div class="alerts-editor-step">2. Where should we notify you?</div>
+      <div id="alerts-editor-channels">
+        <div class="alerts-loading">Loading your channels…</div>
+      </div>
+      <button class="alerts-btn-ghost" onclick="alertsHandleManageChannels()" style="margin-top:6px;">+ Add channel</button>
+    </div>
+
+    <div class="alerts-editor-section">
+      <div class="alerts-editor-step">3. When should we re-alert?</div>
+      <label class="alerts-radio">
+        <input type="radio" name="alerts-re" value="once" checked />
+        Once per incident (auto-resolve after 30 min)
+      </label>
+      <label class="alerts-radio">
+        <input type="radio" name="alerts-re" value="every_15m" />
+        Every 15 minutes while active
+      </label>
+      <label class="alerts-radio">
+        <input type="radio" name="alerts-re" value="every_1h" />
+        Every hour while active
+      </label>
+    </div>
+
+    <div class="alerts-editor-actions">
+      <button class="alerts-btn-ghost" onclick="alertsCloseEditor()">Cancel</button>
+      <button class="alerts-btn-primary" onclick="alertsSaveRule()">Save &amp; enable</button>
+    </div>
+  </div>
+</div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -3263,6 +3263,7 @@ function clawmetryLogout(){
     <div class="nav-tab" onclick="switchTab('brain')">Brain</div>
     <div class="nav-tab active" onclick="switchTab('overview')">Overview</div>
     <div class="nav-tab" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">Approvals <span id="nav-approvals-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
+    <div class="nav-tab" onclick="switchTab('alerts')" title="Get notified when something goes wrong (Pro)">Alerts <span class="pro-chip">Pro</span></div>
     <div class="nav-tab" onclick="switchTab('context')" title="See what context the LLM receives each turn">Context</div>
     <div class="nav-tab" onclick="switchTab('usage')">Tokens</div>
     <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')" style="display:none;">Crons</div>
@@ -8496,6 +8497,7 @@ DASHBOARD_HTML = r"""
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
 <script src="{{ url_for('static', filename='js/nav-dropdown.js') }}"></script>
+<script src="{{ url_for('static', filename='js/alerts.js') }}" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
@@ -8521,6 +8523,7 @@ DASHBOARD_HTML = r"""
     <div class="nav-tab" onclick="switchTab('brain')">Brain</div>
     <div class="nav-tab active" onclick="switchTab('overview')">Overview</div>
     <div class="nav-tab" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">Approvals <span id="nav-approvals-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
+    <div class="nav-tab" onclick="switchTab('alerts')" title="Get notified when something goes wrong (Pro)">Alerts <span class="pro-chip">Pro</span></div>
     <div class="nav-tab" onclick="switchTab('context')" title="See what context the LLM receives each turn">Context</div>
     <div class="nav-tab" onclick="switchTab('usage')">Tokens</div>
     <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')" style="display:none;">Crons</div>
@@ -8542,6 +8545,9 @@ DASHBOARD_HTML = r"""
 
 <!-- OVERVIEW (Split-Screen Hacker Dashboard) -->
 {% include 'tabs/overview.html' %}
+
+<!-- ALERTS (Cloud-Pro feature) -->
+{% include 'tabs/alerts.html' %}
 
 <!-- USAGE -->
 {% include 'tabs/usage.html' %}

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -527,6 +527,56 @@ def cloud_cta_status():
     return jsonify({"connected": bool(token)})
 
 
+@bp_overview.route(
+    "/api/cloud-proxy/<path:cloud_path>",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+)
+def cloud_proxy(cloud_path):
+    """Forward an authenticated request to https://app.clawmetry.com/<path>.
+
+    Used by the Alerts tab (and anything else that needs cloud-side data) so
+    the cm_ token never has to leave the OSS dashboard. The token is read from
+    ~/.openclaw/openclaw.json.cloudToken and injected as Bearer.
+
+    Returns 401 if no cloud token is configured (UI shows the "Sign up for
+    Cloud" CTA in that case).
+    """
+    import dashboard as _d
+    import urllib.error
+    import urllib.request
+
+    token = _d._read_cloud_token()
+    if not token:
+        return jsonify({"error": "cloud_not_connected"}), 401
+
+    url = "https://app.clawmetry.com/" + cloud_path
+    if request.query_string:
+        url += "?" + request.query_string.decode("utf-8", errors="replace")
+
+    body = None
+    if request.method in ("POST", "PUT", "PATCH"):
+        body = request.get_data() or b""
+
+    headers = {
+        "Authorization": "Bearer " + token,
+        "Content-Type": request.headers.get("Content-Type", "application/json"),
+        "Accept": "application/json",
+    }
+
+    req = urllib.request.Request(url, data=body, headers=headers, method=request.method)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            payload = resp.read()
+            ct = resp.headers.get("Content-Type", "application/json")
+            return (payload, resp.status, {"Content-Type": ct})
+    except urllib.error.HTTPError as e:
+        # Pass through 4xx/5xx with body so the UI can read 402 upgrade_required etc.
+        return (e.read() or b"{}", e.code,
+                {"Content-Type": e.headers.get("Content-Type", "application/json")})
+    except Exception as e:
+        return jsonify({"error": "proxy_failed", "detail": str(e)[:200]}), 502
+
+
 @bp_overview.route("/api/cloud-cta/send-otp", methods=["POST"])
 def cloud_cta_send_otp():
     import urllib.request as _ur


### PR DESCRIPTION
## Summary

Bundles **PR #3 (OSS evaluator hook)** + **PR #4 (OSS Alerts tab UI)** from the 5-PR Alerts feature plan. Backend (cloud-side `notification_channels` + `alert_rules` + Pro-tier gate) was already shipped in clawmetry-cloud #517/#518/#519.

User-visible: a new **Alerts** tab in the OSS dashboard, between Approvals and Context, with a **Pro chip** in the nav.

## Three runtime states (soft paywall)

The full UI renders in **all three** states so users always see the value before the paywall fires (per the existing `feedback_free_plan_upsell` convention — every click is a conversion opportunity, never silently fail):

| User state | What they see |
|---|---|
| OSS-only (no cloud token) | Full tab + 5 canned example rules. Any click → "Sign up for ClawMetry Cloud" modal. |
| Cloud Free / `trial_expired` | Same shell + their existing rules. Any click that violates the Free cap → "Upgrade to Pro" modal (also fires server-side via 402 `upgrade_required`). |
| Cloud Pro / active trial | Wired to cloud APIs end-to-end — CRUD, channel multi-select, history, toggle, re-alert policy. Trial banner shows days remaining. |

## What's in this PR

### PR #3 — OSS evaluator hook (`clawmetry/sync.py`)
- New `evaluate_alerts(config, state)` called from the daemon loop
- Throttled to 5 min (`ALERTS_EVAL_INTERVAL_SEC`) — the 60s sync tick is too aggressive given cloud's 1-hour `_debounce_ok` per rule
- POSTs to cloud's existing `/api/internal/evaluate-alerts` with `X-Api-Key` + `X-Node-Id` (re-uses the established `_post` helper)
- Skips silently for users without a `cm_` token
- Records `last-eval` timestamp on Free/402 too, so we don't hammer the upgrade gate every tick

### PR #4 — OSS Alerts UI (multiple files)

| File | Lines | Purpose |
|---|---|---|
| `clawmetry/templates/tabs/alerts.html` | +120 | Tab shell: title, Pro chip, trial banner, rules list, history, channels footer, paywall modal, editor modal |
| `clawmetry/static/js/alerts.js` | +443 | Tier resolution, paywall-aware action handlers (any click on non-Pro tier opens correct modal; server-side 402 also opens it as fallback), full editor with 5 canned rule types, channel multi-select, re-alert policy radios, optimistic toggle/save |
| `clawmetry/static/css/dashboard.css` | +183 | `.pro-chip`, alert rule rows, channel pills, paywall + editor modals — all using existing `var(--bg-*)` / `var(--text-*)` tokens so the page inherits theme |
| `clawmetry/static/js/app.js` | +1 | `switchTab('alerts') → loadAlertsPage()` dispatcher line |
| `dashboard.py` | +6 | Nav tab in both blocks + alerts.html include + alerts.js script tag |
| `routes/overview.py` | +50 | `/api/cloud-proxy/<path>` route — forwards to `app.clawmetry.com/<path>` with cm_ token injected. Pass-through for body and 4xx/5xx so UI can read 402 payloads. Returns 401 `cloud_not_connected` if no token. |

**Total: 860 insertions across 7 files (5 modified + 2 new).**

## Verified live in the chrome-devtools harness

- Nav shows "Alerts" between Approvals and Context with the gradient Pro chip
- Clicking Alerts renders full page with 5 canned example rules (Daily spend / Agent offline / Session tokens / Cron failed / Tool failures), each showing icon + threshold + which channels *would* deliver
- Clicking "+ New alert rule" or any "Enable" button opens centered "Sign up for ClawMetry Cloud" modal with CTAs + "No credit card · free tier available · 7-day Pro trial" footnote
- Recent alert history shows "Sign up for Cloud to start collecting alert history."
- Footer: "Delivery channels: Slack · Email · PagerDuty · Telegram *shared with Approvals*" + "Manage channels →" link

## Backend dependencies (already merged on cloud main)

- clawmetry-cloud #518: notification_channels infra
- clawmetry-cloud #519: alert_rules + history + Pro-tier 402 gate

## What's left in the 5-PR plan after this

- **PR #5: refactor Approvals to use shared notification_channels** (cloud-side, cleanup)
- Cloud deploy + run `scripts/backfill_notification_channels.py` to migrate existing approval integrations into the new shared table

🤖 Generated with [Claude Code](https://claude.com/claude-code)