### PR TITLE
[RELEASE] fix: token chart includes .reset archives + Alerts Enable button

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -1037,7 +1037,7 @@
 }
 .alerts-loading { padding: 18px; color: var(--text-muted); font-size: 13px; text-align: center; }
 .alerts-rule-row {
-  display: grid; grid-template-columns: 24px 1fr auto auto;
+  display: grid; grid-template-columns: 24px 1fr auto auto auto;
   gap: 16px; align-items: center; padding: 13px 18px;
   border-bottom: 1px solid var(--border-secondary);
 }

--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -147,6 +147,8 @@
       const ts = rule.last_triggered_at
         ? `Last: ${formatTimeAgo(rule.last_triggered_at)} · ${rule.trigger_count}× total`
         : `Never triggered`;
+      const toggleLabel = rule.enabled ? 'Disable' : 'Enable';
+      const toggleCls = rule.enabled ? 'alerts-btn-ghost' : 'alerts-btn-primary';
       return `
         <div class="alerts-rule-row" data-rule-id="${rule.id}">
           <div class="alerts-rule-dot ${dotCls}" title="${rule.enabled ? 'Enabled' : 'Disabled'}"
@@ -156,6 +158,7 @@
             <div class="alerts-rule-meta">${meta.verb} ${rule.threshold_value}${rule.threshold_unit ? ' ' + escape(rule.threshold_unit) : ''} · ${ts}</div>
           </div>
           <div class="alerts-rule-chan">${channelPills || '<span class="alerts-chan-pill off">no channels</span>'}</div>
+          <button class="${toggleCls}" onclick="alertsToggleRule('${rule.id}', ${!rule.enabled})">${toggleLabel}</button>
           <button class="alerts-btn-ghost" onclick="alertsHandleEdit('${rule.id}')">Edit</button>
         </div>
       `;
@@ -176,6 +179,7 @@
             <div class="alerts-rule-meta">Tap to customize — saves require Cloud Pro</div>
           </div>
           <div class="alerts-rule-chan"><span class="alerts-chan-pill off">${ex._exampleChannels}</span></div>
+          <button class="alerts-btn-primary" onclick="event.stopPropagation();alertsToggleRule('${ex.id}', true)">Enable</button>
           <button class="alerts-btn-ghost" onclick="event.stopPropagation();alertsHandleEdit('${ex.id}')">Edit</button>
         </div>
       `;

--- a/dashboard.py
+++ b/dashboard.py
@@ -9836,9 +9836,10 @@ def _compute_transcript_analytics():
 
     if os.path.isdir(sessions_dir):
         for fname in os.listdir(sessions_dir):
-            if not fname.endswith(".jsonl"):
+            # Accept both live `.jsonl` and archived `.jsonl.reset.<ts>` files.
+            if not (fname.endswith(".jsonl") or ".jsonl.reset." in fname):
                 continue
-            sid = fname.replace(".jsonl", "")
+            sid = fname.split(".jsonl", 1)[0]
             fpath = os.path.join(sessions_dir, fname)
             fallback_dt = datetime.fromtimestamp(os.path.getmtime(fpath))
 
@@ -10164,9 +10165,13 @@ def _compute_transcript_analytics():
 
     if os.path.isdir(sessions_dir):
         for fname in os.listdir(sessions_dir):
-            if not fname.endswith(".jsonl"):
+            # Accept both live `.jsonl` and archived `.jsonl.reset.<ts>` files.
+            # Reset archives carry real historical token usage from earlier
+            # days; skipping them was making the 14-day chart pile every
+            # past-day total onto today.
+            if not (fname.endswith(".jsonl") or ".jsonl.reset." in fname):
                 continue
-            sid = fname.replace(".jsonl", "")
+            sid = fname.split(".jsonl", 1)[0]
             fpath = os.path.join(sessions_dir, fname)
             fallback_dt = datetime.fromtimestamp(os.path.getmtime(fpath))
 
@@ -10240,8 +10245,9 @@ def _compute_transcript_analytics():
                                     else 0.0
                                 )
                                 # Track daily breakdown for trend analysis (GH#201)
-                                # day is resolved when s_start is known; use fallback_dt day here
-                                _ev_day = fallback_dt.strftime("%Y-%m-%d")
+                                # use the event's actual day so trend lines
+                                # match the headline 14-day chart.
+                                _ev_day = (ts or fallback_dt).strftime("%Y-%m-%d")
                                 for p in plugins:
                                     plugin_stats[p]["tokens"] += share_tokens
                                     plugin_stats[p]["cost"] += share_cost


### PR DESCRIPTION
## Summary

Two small UX fixes bundled for one release.

### 1. Token Usage chart: include `.jsonl.reset.*` archives

`_compute_transcript_analytics()` filtered files by `endswith('.jsonl')`,
silently skipping archived sessions named `<sid>.jsonl.reset.<ts>`. Those
archives still carry real per-event token usage from earlier days, so the
14-day bar chart was only showing today's data — every prior day looked
empty even when sessions had run.

Fix accepts both live and archived files and splits the session id from
the first `.jsonl` segment. Per-plugin daily trend buckets now use the
event's actual day instead of the file's mtime, so per-plugin trend lines
match the headline chart for archived sessions.

**Before** (single live session today): today=26K, week=26K, month=26K, 13 empty bars.
**After** (one live + two archived): today=26K, week=39K, month=65K, bars on 04-19/04-20/04-22.

### 2. Alerts tab: explicit Enable / Disable button next to Edit

The status dot was clickable but easy to miss. Each rule (and each canned
example) now renders a primary "Enable" button alongside "Edit" so users
can toggle a rule on/off without opening the editor. For non-Pro tiers
the existing paywall path fires unchanged; for a configured Pro rule the
button label flips to "Disable" (ghost variant) when currently enabled.

CSS grid template grew from four columns to five so the buttons stay inline.

## Test plan

- [x] `curl /api/usage` returns three populated days (04-19, 04-20, 04-22) plus 11 empty
- [x] Browser /Tokens tab: chart shows three distinct bars; cards read 26K / 39K / 65K
- [x] Browser /Alerts tab: each canned example row shows Enable + Edit inline (no wrap)
- [x] Em-dash preserved in JS string (only routes/alerts.py bans em-dash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)