### PR TITLE
[RELEASE] fix(brain): unwrap claude-cli type=user/assistant in renderer

### DIFF
--- a/routes/brain.py
+++ b/routes/brain.py
@@ -252,10 +252,14 @@ def api_brain_history():
                 role = obj.get("role", "")
                 content_obj = obj.get("content", "")
 
-                if obj.get("type") == "message":
+                # OpenClaw uses type=message; claude-cli uses type=user/assistant
+                # with the same {role,content} nested under obj.message.
+                if obj.get("type") in ("message", "user", "assistant") and isinstance(
+                    obj.get("message"), dict
+                ):
                     inner = obj.get("message", {})
-                    role = inner.get("role", "")
-                    content_obj = inner.get("content", [])
+                    role = inner.get("role", role) or obj.get("type", "")
+                    content_obj = inner.get("content", content_obj)
 
                 # System context (injected files, workspace context)
                 if role == "system" and ts:
@@ -621,10 +625,14 @@ def api_brain_stream():
             return None
         role = obj.get("role", "")
         content_obj = obj.get("content", "")
-        if obj.get("type") == "message":
+        # OpenClaw wraps via type=message; claude-cli uses type=user/assistant
+        # with the same {role,content} nested under obj.message. Unwrap both.
+        if obj.get("type") in ("message", "user", "assistant") and isinstance(
+            obj.get("message"), dict
+        ):
             inner = obj.get("message", {})
-            role = inner.get("role", "")
-            content_obj = inner.get("content", [])
+            role = inner.get("role", role) or obj.get("type", "")
+            content_obj = inner.get("content", content_obj)
 
         if role == "assistant" and isinstance(content_obj, list):
             for block in content_obj:


### PR DESCRIPTION
## Summary

OpenClaw uses \`type=message\` with role+content nested in \`obj.message\`.
Claude-cli uses \`type=user\` / \`type=assistant\` with the **same**
\`{role, content}\` nested under \`obj.message\`. The OSS brain renderer
in \`routes/brain.py\` only unwrapped the OpenClaw shape, so any
claude-cli event flowing through it would render with \`role=""\` and
miss the user / assistant / tool text-extraction branches entirely.

## Why this matters now

The OSS brain reader currently only walks
\`~/.openclaw/agents/main/sessions/*.jsonl\`, which contains OpenClaw-shape
events, so this code path doesn't hit claude-cli events today.
However the new \`sync_claude_cli_sessions()\` adapter shipped in v0.12.131
opens the door for the OSS dashboard to also surface claude-cli events
in a follow-up. Patching both unwraps now keeps the renderer ready.

Pairs with the cloud-side rendering fix in clawmetry-cloud#531.

## Test plan

- [x] Syntax check
- [ ] Existing OpenClaw type=message events still render (regression)
- [ ] If we later teach the OSS reader to ingest claude-cli files, no rerelease needed for renderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)