### PR TITLE
feat: Per-message cost attribution with cache-hit breakdown

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -10126,7 +10126,13 @@ def _extract_usage_metrics(obj):
     if not isinstance(usage, dict):
         usage = obj.get("tokens_used")
     if not isinstance(usage, dict):
-        return {"tokens": 0, "cost": 0.0}
+        return {
+            "tokens": 0, "cost": 0.0,
+            "input_tokens": 0, "output_tokens": 0,
+            "cache_read_tokens": 0, "cache_write_tokens": 0,
+            "input_cost": 0.0, "output_cost": 0.0,
+            "cache_read_cost": 0.0, "cache_write_cost": 0.0,
+        }
 
     in_toks = usage.get("input", usage.get("input_tokens", 0)) or 0
     out_toks = usage.get("output", usage.get("output_tokens", 0)) or 0
@@ -10137,6 +10143,10 @@ def _extract_usage_metrics(obj):
         total = in_toks + out_toks + cache_read + cache_write
 
     cost = 0.0
+    cost_input = 0.0
+    cost_output = 0.0
+    cost_cache_read = 0.0
+    cost_cache_write = 0.0
     cost_data = usage.get("cost", {})
     if isinstance(cost_data, dict):
         raw = cost_data.get("total", cost_data.get("usd", 0))
@@ -10144,12 +10154,25 @@ def _extract_usage_metrics(obj):
             cost = float(raw or 0)
         except Exception:
             cost = 0.0
+        # Extract granular cost breakdown if available
+        cost_input = float(cost_data.get("input", 0) or 0)
+        cost_output = float(cost_data.get("output", 0) or 0)
+        cost_cache_read = float(cost_data.get("cacheRead", 0) or 0)
+        cost_cache_write = float(cost_data.get("cacheWrite", 0) or 0)
     elif isinstance(cost_data, (int, float)):
         cost = float(cost_data)
 
     return {
         "tokens": int(total or 0),
         "cost": float(cost or 0.0),
+        "input_tokens": int(in_toks or 0),
+        "output_tokens": int(out_toks or 0),
+        "cache_read_tokens": int(cache_read or 0),
+        "cache_write_tokens": int(cache_write or 0),
+        "input_cost": float(cost_input),
+        "output_cost": float(cost_output),
+        "cache_read_cost": float(cost_cache_read),
+        "cache_write_cost": float(cost_cache_write),
     }
 
 
@@ -10275,6 +10298,10 @@ def _compute_transcript_analytics():
     plugin_stats = defaultdict(lambda: {"tokens": 0.0, "cost": 0.0, "calls": 0})
     daily_tokens = {}
     daily_cost = {}
+    daily_input_tokens = {}
+    daily_output_tokens = {}
+    daily_cache_read_tokens = {}
+    daily_cache_write_tokens = {}
     model_usage = {}
 
     if os.path.isdir(sessions_dir):
@@ -10339,6 +10366,10 @@ def _compute_transcript_analytics():
                         usage_metrics = _extract_usage_metrics(obj)
                         tokens = usage_metrics["tokens"]
                         cost = usage_metrics["cost"]
+                        input_tokens = usage_metrics.get("input_tokens", 0)
+                        output_tokens = usage_metrics.get("output_tokens", 0)
+                        cache_read_tokens = usage_metrics.get("cache_read_tokens", 0)
+                        cache_write_tokens = usage_metrics.get("cache_write_tokens", 0)
 
                         if tokens > 0:
                             s_tokens += tokens
@@ -10352,6 +10383,10 @@ def _compute_transcript_analytics():
                             _ev_date = (ts or fallback_dt).strftime("%Y-%m-%d")
                             daily_tokens[_ev_date] = daily_tokens.get(_ev_date, 0) + tokens
                             daily_cost[_ev_date] = daily_cost.get(_ev_date, 0.0) + cost
+                            daily_input_tokens[_ev_date] = daily_input_tokens.get(_ev_date, 0) + input_tokens
+                            daily_output_tokens[_ev_date] = daily_output_tokens.get(_ev_date, 0) + output_tokens
+                            daily_cache_read_tokens[_ev_date] = daily_cache_read_tokens.get(_ev_date, 0) + cache_read_tokens
+                            daily_cache_write_tokens[_ev_date] = daily_cache_write_tokens.get(_ev_date, 0) + cache_write_tokens
 
                             plugins = _extract_tool_plugins(obj)
                             if plugins:
@@ -10419,6 +10454,10 @@ def _compute_transcript_analytics():
         "plugin_stats": plugin_stats,
         "daily_tokens": daily_tokens,
         "daily_cost": daily_cost,
+        "daily_input_tokens": daily_input_tokens,
+        "daily_output_tokens": daily_output_tokens,
+        "daily_cache_read_tokens": daily_cache_read_tokens,
+        "daily_cache_write_tokens": daily_cache_write_tokens,
         "model_usage": model_usage,
     }
     _transcript_analytics_cache["data"] = result
@@ -10460,7 +10499,13 @@ def _extract_usage_metrics(obj):
     if not isinstance(usage, dict):
         usage = obj.get("tokens_used")
     if not isinstance(usage, dict):
-        return {"tokens": 0, "cost": 0.0}
+        return {
+            "tokens": 0, "cost": 0.0,
+            "input_tokens": 0, "output_tokens": 0,
+            "cache_read_tokens": 0, "cache_write_tokens": 0,
+            "input_cost": 0.0, "output_cost": 0.0,
+            "cache_read_cost": 0.0, "cache_write_cost": 0.0,
+        }
 
     in_toks = usage.get("input", usage.get("input_tokens", 0)) or 0
     out_toks = usage.get("output", usage.get("output_tokens", 0)) or 0
@@ -10471,6 +10516,10 @@ def _extract_usage_metrics(obj):
         total = in_toks + out_toks + cache_read + cache_write
 
     cost = 0.0
+    cost_input = 0.0
+    cost_output = 0.0
+    cost_cache_read = 0.0
+    cost_cache_write = 0.0
     cost_data = usage.get("cost", {})
     if isinstance(cost_data, dict):
         raw = cost_data.get("total", cost_data.get("usd", 0))
@@ -10478,12 +10527,25 @@ def _extract_usage_metrics(obj):
             cost = float(raw or 0)
         except Exception:
             cost = 0.0
+        # Extract granular cost breakdown if available
+        cost_input = float(cost_data.get("input", 0) or 0)
+        cost_output = float(cost_data.get("output", 0) or 0)
+        cost_cache_read = float(cost_data.get("cacheRead", 0) or 0)
+        cost_cache_write = float(cost_data.get("cacheWrite", 0) or 0)
     elif isinstance(cost_data, (int, float)):
         cost = float(cost_data)
 
     return {
         "tokens": int(total or 0),
         "cost": float(cost or 0.0),
+        "input_tokens": int(in_toks or 0),
+        "output_tokens": int(out_toks or 0),
+        "cache_read_tokens": int(cache_read or 0),
+        "cache_write_tokens": int(cache_write or 0),
+        "input_cost": float(cost_input),
+        "output_cost": float(cost_output),
+        "cache_read_cost": float(cost_cache_read),
+        "cache_write_cost": float(cost_cache_write),
     }
 
 

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -66,6 +66,10 @@ def api_usage():
     analytics = _d._compute_transcript_analytics()
     daily_tokens = analytics.get("daily_tokens", {})
     daily_cost = analytics.get("daily_cost", {})
+    daily_input_tokens = analytics.get("daily_input_tokens", {})
+    daily_output_tokens = analytics.get("daily_output_tokens", {})
+    daily_cache_read_tokens = analytics.get("daily_cache_read_tokens", {})
+    daily_cache_write_tokens = analytics.get("daily_cache_write_tokens", {})
     model_usage = analytics.get("model_usage", {})
     session_summaries = analytics.get("sessions", [])
     session_costs = {
@@ -74,7 +78,7 @@ def api_usage():
     }
     anomalies = _d._compute_session_cost_anomalies(session_summaries)
 
-    # Build response data
+    # Build response data with cache token breakdown
     today = datetime.now()
     days = []
     for i in range(13, -1, -1):
@@ -85,6 +89,10 @@ def api_usage():
                 "date": ds,
                 "tokens": daily_tokens.get(ds, 0),
                 "cost": daily_cost.get(ds, 0),
+                "inputTokens": daily_input_tokens.get(ds, 0),
+                "outputTokens": daily_output_tokens.get(ds, 0),
+                "cacheReadTokens": daily_cache_read_tokens.get(ds, 0),
+                "cacheWriteTokens": daily_cache_write_tokens.get(ds, 0),
             }
         )
 
@@ -1515,3 +1523,157 @@ def api_skills_fidelity():
             'Orphan: body-fetched in sessions but not installed (skill removed?).'
         ),
     })
+
+
+@bp_usage.route('/api/token-attribution')
+def api_token_attribution():
+    """Per-message cost attribution with cache token breakdown.
+
+    Returns granular token/cost breakdown per message type (input, output, cache-read, cache-write)
+    for the specified session or across recent sessions.
+    """
+    import dashboard as _d
+
+    wanted_sid = request.args.get('session_id', '').strip()
+    try:
+        limit = max(1, min(int(request.args.get('limit', '100')), 1000))
+    except ValueError:
+        limit = 100
+
+    sessions_dir = _d._get_sessions_dir()
+    if not os.path.isdir(sessions_dir):
+        return jsonify({"messages": [], "totals": {}, "note": "sessions dir not found"})
+
+    try:
+        all_files = [
+            f for f in os.listdir(sessions_dir)
+            if f.endswith('.jsonl') and '.deleted.' not in f and '.reset.' not in f
+        ]
+    except OSError:
+        all_files = []
+
+    if wanted_sid:
+        files = [f for f in all_files if f.startswith(wanted_sid)]
+    else:
+        files = sorted(
+            all_files,
+            key=lambda f: os.path.getmtime(os.path.join(sessions_dir, f)),
+            reverse=True
+        )[:50]
+
+    messages = []
+    totals = {
+        'input_tokens': 0,
+        'output_tokens': 0,
+        'cache_read_tokens': 0,
+        'cache_write_tokens': 0,
+        'total_tokens': 0,
+        'input_cost': 0.0,
+        'output_cost': 0.0,
+        'cache_read_cost': 0.0,
+        'cache_write_cost': 0.0,
+        'total_cost': 0.0,
+    }
+
+    for fname in files:
+        fpath = os.path.join(sessions_dir, fname)
+        sid = fname[:-6] if fname.endswith('.jsonl') else fname
+
+        try:
+            with open(fpath, 'r', errors='replace') as fh:
+                for raw in fh:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        ev = json.loads(raw)
+                    except Exception:
+                        continue
+
+                    if ev.get('type') != 'message':
+                        continue
+
+                    msg = ev.get('message', {}) or {}
+                    if not isinstance(msg, dict):
+                        continue
+
+                    usage = msg.get('usage', {}) or {}
+                    if not isinstance(usage, dict) or not usage:
+                        continue
+
+                    # Get token breakdown
+                    input_tok = int(usage.get('input', usage.get('input_tokens', 0)) or 0)
+                    output_tok = int(usage.get('output', usage.get('output_tokens', 0)) or 0)
+                    cache_read = int(usage.get('cacheRead', usage.get('cache_read_tokens', 0)) or 0)
+                    cache_write = int(usage.get('cacheWrite', usage.get('cache_write_tokens', 0)) or 0)
+
+                    # Get cost breakdown
+                    cost_obj = usage.get('cost', {}) or {}
+                    if isinstance(cost_obj, dict):
+                        input_cost = float(cost_obj.get('input', 0) or 0)
+                        output_cost = float(cost_obj.get('output', 0) or 0)
+                        cache_read_cost = float(cost_obj.get('cacheRead', 0) or 0)
+                        cache_write_cost = float(cost_obj.get('cacheWrite', 0) or 0)
+                        total_cost = float(cost_obj.get('total', cost_obj.get('usd', 0)) or 0)
+                    else:
+                        input_cost = output_cost = cache_read_cost = cache_write_cost = total_cost = 0.0
+
+                    total_tok = input_tok + output_tok + cache_read + cache_write
+
+                    if total_tok == 0:
+                        continue
+
+                    msg_data = {
+                        'session_id': sid,
+                        'timestamp': ev.get('timestamp') or ev.get('time') or ev.get('created_at'),
+                        'model': msg.get('model', 'unknown'),
+                        'role': msg.get('role', 'unknown'),
+                        'tokens': {
+                            'input': input_tok,
+                            'output': output_tok,
+                            'cache_read': cache_read,
+                            'cache_write': cache_write,
+                            'total': total_tok,
+                        },
+                        'cost': {
+                            'input': round(input_cost, 8),
+                            'output': round(output_cost, 8),
+                            'cache_read': round(cache_read_cost, 8),
+                            'cache_write': round(cache_write_cost, 8),
+                            'total': round(total_cost, 8),
+                        },
+                        'cache_hit_ratio': round(cache_read / (input_tok + cache_read) * 100, 1) if (input_tok + cache_read) > 0 else 0.0,
+                    }
+
+                    messages.append(msg_data)
+
+                    # Update totals
+                    totals['input_tokens'] += input_tok
+                    totals['output_tokens'] += output_tok
+                    totals['cache_read_tokens'] += cache_read
+                    totals['cache_write_tokens'] += cache_write
+                    totals['total_tokens'] += total_tok
+                    totals['input_cost'] += input_cost
+                    totals['output_cost'] += output_cost
+                    totals['cache_read_cost'] += cache_read_cost
+                    totals['cache_write_cost'] += cache_write_cost
+                    totals['total_cost'] += total_cost
+        except Exception:
+            continue
+
+    # Round totals
+    for k in ['input_cost', 'output_cost', 'cache_read_cost', 'cache_write_cost', 'total_cost']:
+        totals[k] = round(totals[k], 6)
+
+    # Sort by timestamp descending and apply limit
+    messages.sort(key=lambda m: m.get('timestamp', ''), reverse=True)
+    messages = messages[:limit]
+
+    # Calculate cache hit ratio
+    input_plus_cache = totals['input_tokens'] + totals['cache_read_tokens']
+    totals['cache_hit_ratio_pct'] = round(totals['cache_read_tokens'] / input_plus_cache * 100, 1) if input_plus_cache else 0.0
+
+    return jsonify({
+        'messages': messages,
+        'totals': totals,
+        'session_id': wanted_sid if wanted_sid else None,    })


### PR DESCRIPTION
Closes vivekchand/clawmetry-cloud#318

## What
Adds granular cache token tracking to the usage analytics:
- Extended _extract_usage_metrics() to return 4-token-type + 4-cost-type breakdown
- Updated _compute_transcript_analytics() to aggregate daily cache tokens
- Enhanced /api/usage response with input/output/cache-read/cache-write token counts
- New endpoint /api/token-attribution for per-message granular cost breakdown

## How
- Reads message.usage.cost {input, output, cacheRead, cacheWrite, total}
- Tracks daily aggregate of each token type separately
- Returns structured breakdown in API responses
- Calculates cache hit ratio for visibility into cache efficiency

## API Changes
- /api/usage: Each day object now includes inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens
- /api/token-attribution: New endpoint returning per-message token/cost breakdown with cache stats