### PR TITLE
[RELEASE] feat(advisor): natural-language Q&A over your agent's activity

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2662,8 +2662,51 @@ function _fmtTokens(n) {
   return String(n);
 }
 
+// ── Advisor: natural-language Q&A over the agent's recent activity ─────────
+async function advisorProbe() {
+  try {
+    var s = await fetchJsonWithTimeout('/api/advisor/status', 3000);
+    if (s && s.available) {
+      var card = document.getElementById('advisor-card');
+      if (card) card.style.display = '';
+    }
+  } catch (e) { /* keep hidden */ }
+}
+window.advisorPrefill = function (q) {
+  var el = document.getElementById('advisor-q');
+  if (el) { el.value = q; el.focus(); }
+};
+window.advisorAsk = async function () {
+  var input = document.getElementById('advisor-q');
+  var out = document.getElementById('advisor-answer');
+  var q = (input && input.value || '').trim();
+  if (!q || !out) return;
+  out.style.display = '';
+  out.textContent = 'Thinking…';
+  try {
+    var resp = await fetch('/api/advisor/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question: q }),
+    });
+    var d = await resp.json();
+    if (!resp.ok) {
+      out.textContent = (d && d.message) || (d && d.detail) || ('Error ' + resp.status);
+      return;
+    }
+    var meta = d.input_tokens + d.output_tokens
+      ? '\n\n— ' + d.model + ' · ' + (d.input_tokens + d.output_tokens) + ' tokens · '
+        + d.events_in_context + ' events in context'
+      : '';
+    out.textContent = (d.answer || '(empty answer)') + meta;
+  } catch (e) {
+    out.textContent = 'Network error: ' + e.message;
+  }
+};
+
 async function loadBrainPage(silent) {
   if (window.CLOUD_MODE) return;
+  if (!silent) advisorProbe();
   try {
     var data = await fetchJsonWithTimeout('/api/brain-history', 8000);
     var events = (data.events || []).slice().sort(function(a,b){

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2676,13 +2676,39 @@ window.advisorPrefill = function (q) {
   var el = document.getElementById('advisor-q');
   if (el) { el.value = q; el.focus(); }
 };
+// Minimal markdown renderer — bold, italic, inline code, paragraph breaks.
+// Escapes HTML first so LLM output can't inject tags.
+function advisorRenderMarkdown(text) {
+  var esc = String(text || '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  // Inline code `x` — process FIRST so asterisks inside code aren't misread
+  esc = esc.replace(/`([^`\n]+)`/g, '<code style="background:rgba(168,85,247,0.18);padding:2px 6px;border-radius:4px;font-family:ui-monospace,Menlo,monospace;font-size:12.5px;color:#ddd6fe;">$1</code>');
+  // Bold **x** and __x__
+  esc = esc.replace(/\*\*([^\*\n]+)\*\*/g, '<strong style="color:#fff;font-weight:600;">$1</strong>');
+  esc = esc.replace(/__([^_\n]+)__/g, '<strong style="color:#fff;font-weight:600;">$1</strong>');
+  // Italic *x* and _x_ — require non-space boundary to avoid matching snake_case
+  esc = esc.replace(/(^|[\s\(])\*([^\*\n]+)\*/g, '$1<em>$2</em>');
+  esc = esc.replace(/(^|[\s\(])_([^_\n]+)_(?=$|[\s\.,\)])/g, '$1<em>$2</em>');
+  // Paragraph breaks on blank line; single newlines become <br>
+  var paras = esc.split(/\n{2,}/).map(function (p) {
+    return '<p style="margin:0 0 10px 0;">' + p.replace(/\n/g, '<br>') + '</p>';
+  });
+  // Drop trailing empty paragraph
+  return paras.join('').replace(/<p[^>]*>\s*<\/p>/g, '');
+}
+
 window.advisorAsk = async function () {
   var input = document.getElementById('advisor-q');
+  var wrap = document.getElementById('advisor-answer-wrap');
+  var qEl = document.getElementById('advisor-answer-q');
   var out = document.getElementById('advisor-answer');
+  var metaEl = document.getElementById('advisor-answer-meta');
   var q = (input && input.value || '').trim();
-  if (!q || !out) return;
-  out.style.display = '';
-  out.textContent = 'Thinking…';
+  if (!q || !wrap || !out) return;
+  wrap.style.display = '';
+  if (qEl) qEl.textContent = '› ' + q;
+  out.innerHTML = '<span style="color:#a855f7;">Thinking…</span>';
+  if (metaEl) metaEl.textContent = '';
   try {
     var resp = await fetch('/api/advisor/ask', {
       method: 'POST',
@@ -2694,11 +2720,15 @@ window.advisorAsk = async function () {
       out.textContent = (d && d.message) || (d && d.detail) || ('Error ' + resp.status);
       return;
     }
-    var meta = d.input_tokens + d.output_tokens
-      ? '\n\n— ' + d.model + ' · ' + (d.input_tokens + d.output_tokens) + ' tokens · '
-        + d.events_in_context + ' events in context'
-      : '';
-    out.textContent = (d.answer || '(empty answer)') + meta;
+    out.innerHTML = advisorRenderMarkdown(d.answer || '(empty answer)');
+    if (metaEl) {
+      var parts = [];
+      if (d.model) parts.push(d.model);
+      var totalTokens = (d.input_tokens || 0) + (d.output_tokens || 0);
+      if (totalTokens) parts.push(totalTokens + ' tokens');
+      if (typeof d.events_in_context === 'number') parts.push(d.events_in_context + ' events in context');
+      metaEl.textContent = parts.length ? parts.join(' · ') : '';
+    }
   } catch (e) {
     out.textContent = 'Network error: ' + e.message;
   }

--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -13,42 +13,54 @@
       background:var(--bg-secondary);
       border:1px solid var(--border);
       border-radius:8px;
-      padding:10px 14px;
+      padding:14px 16px;
       margin-bottom:12px;
       display:none;
       ">
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-        <span style="font-size:13px;font-weight:600;color:var(--text-primary);">✨ Advisor</span>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;">
+        <span style="font-size:14px;font-weight:700;color:#c4b5fd;">✨ Advisor</span>
         <span style="font-size:11px;color:var(--text-muted);">ask anything about this agent's activity</span>
       </div>
-      <div style="display:flex;gap:6px;">
+      <div style="display:flex;gap:8px;">
         <input id="advisor-q" type="text"
           placeholder="e.g. why did my last run cost so much?"
           onkeydown="if(event.key==='Enter')advisorAsk()"
-          style="flex:1;padding:8px 10px;background:var(--bg-primary);border:1px solid var(--border);
-                 border-radius:6px;color:var(--text-primary);font-size:13px;" />
+          style="flex:1;padding:10px 12px;background:var(--bg-primary);border:1px solid var(--border);
+                 border-radius:8px;color:var(--text-primary);font-size:13px;outline:none;" />
         <button onclick="advisorAsk()"
-          style="padding:8px 14px;background:#a855f7;color:#fff;border:none;border-radius:6px;
-                 font-size:12px;font-weight:600;cursor:pointer;">Ask</button>
+          style="padding:10px 18px;background:#a855f7;color:#fff;border:none;border-radius:8px;
+                 font-size:13px;font-weight:600;cursor:pointer;box-shadow:0 2px 8px rgba(168,85,247,0.3);">Ask</button>
       </div>
-      <div id="advisor-suggestions" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:8px;">
+      <div id="advisor-suggestions" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;">
         <button class="advisor-sugg" onclick="advisorPrefill('Why did my last run cost so much?')"
-          style="font-size:11px;padding:3px 8px;border-radius:10px;background:var(--bg-hover);
-                 border:1px solid var(--border-secondary);color:var(--text-secondary);cursor:pointer;">
+          style="font-size:11px;padding:4px 10px;border-radius:12px;background:rgba(168,85,247,0.1);
+                 border:1px solid rgba(168,85,247,0.2);color:#c4b5fd;cursor:pointer;">
           Why did my last run cost so much?</button>
         <button class="advisor-sugg" onclick="advisorPrefill('Which tool is failing most often?')"
-          style="font-size:11px;padding:3px 8px;border-radius:10px;background:var(--bg-hover);
-                 border:1px solid var(--border-secondary);color:var(--text-secondary);cursor:pointer;">
+          style="font-size:11px;padding:4px 10px;border-radius:12px;background:rgba(168,85,247,0.1);
+                 border:1px solid rgba(168,85,247,0.2);color:#c4b5fd;cursor:pointer;">
           Which tool is failing most often?</button>
         <button class="advisor-sugg" onclick="advisorPrefill('Is my agent looping?')"
-          style="font-size:11px;padding:3px 8px;border-radius:10px;background:var(--bg-hover);
-                 border:1px solid var(--border-secondary);color:var(--text-secondary);cursor:pointer;">
+          style="font-size:11px;padding:4px 10px;border-radius:12px;background:rgba(168,85,247,0.1);
+                 border:1px solid rgba(168,85,247,0.2);color:#c4b5fd;cursor:pointer;">
           Is my agent looping?</button>
       </div>
-      <div id="advisor-answer" style="
-        display:none;margin-top:10px;padding:10px 12px;background:var(--bg-primary);
-        border-left:3px solid #a855f7;border-radius:4px;font-size:13px;line-height:1.5;
-        color:var(--text-primary);white-space:pre-wrap;"></div>
+      <div id="advisor-answer-wrap" style="display:none;margin-top:12px;">
+        <div id="advisor-answer-q" style="
+          font-size:12px;color:var(--text-muted);margin-bottom:6px;font-style:italic;"></div>
+        <div id="advisor-answer" style="
+          padding:14px 16px;
+          background:var(--bg-primary);
+          border:1px solid var(--border);
+          border-left:3px solid #a855f7;
+          border-radius:8px;
+          font-size:14px;line-height:1.65;
+          color:var(--text-primary);
+          max-width:880px;
+          "></div>
+        <div id="advisor-answer-meta" style="
+          font-size:11px;color:var(--text-muted);margin-top:6px;font-family:monospace;"></div>
+      </div>
     </div>
 
     <!-- Activity density chart -->

--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -8,6 +8,49 @@
         gap:8px;
         "><span id="brain-live-indicator"></span><button class="refresh-btn" onclick="loadBrainPage()">↻ Refresh</button></div>
     </div>
+    <!-- Advisor: ask questions about your agent's activity -->
+    <div id="advisor-card" style="
+      background:var(--bg-secondary);
+      border:1px solid var(--border);
+      border-radius:8px;
+      padding:10px 14px;
+      margin-bottom:12px;
+      display:none;
+      ">
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+        <span style="font-size:13px;font-weight:600;color:var(--text-primary);">✨ Advisor</span>
+        <span style="font-size:11px;color:var(--text-muted);">ask anything about this agent's activity</span>
+      </div>
+      <div style="display:flex;gap:6px;">
+        <input id="advisor-q" type="text"
+          placeholder="e.g. why did my last run cost so much?"
+          onkeydown="if(event.key==='Enter')advisorAsk()"
+          style="flex:1;padding:8px 10px;background:var(--bg-primary);border:1px solid var(--border);
+                 border-radius:6px;color:var(--text-primary);font-size:13px;" />
+        <button onclick="advisorAsk()"
+          style="padding:8px 14px;background:#a855f7;color:#fff;border:none;border-radius:6px;
+                 font-size:12px;font-weight:600;cursor:pointer;">Ask</button>
+      </div>
+      <div id="advisor-suggestions" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:8px;">
+        <button class="advisor-sugg" onclick="advisorPrefill('Why did my last run cost so much?')"
+          style="font-size:11px;padding:3px 8px;border-radius:10px;background:var(--bg-hover);
+                 border:1px solid var(--border-secondary);color:var(--text-secondary);cursor:pointer;">
+          Why did my last run cost so much?</button>
+        <button class="advisor-sugg" onclick="advisorPrefill('Which tool is failing most often?')"
+          style="font-size:11px;padding:3px 8px;border-radius:10px;background:var(--bg-hover);
+                 border:1px solid var(--border-secondary);color:var(--text-secondary);cursor:pointer;">
+          Which tool is failing most often?</button>
+        <button class="advisor-sugg" onclick="advisorPrefill('Is my agent looping?')"
+          style="font-size:11px;padding:3px 8px;border-radius:10px;background:var(--bg-hover);
+                 border:1px solid var(--border-secondary);color:var(--text-secondary);cursor:pointer;">
+          Is my agent looping?</button>
+      </div>
+      <div id="advisor-answer" style="
+        display:none;margin-top:10px;padding:10px 12px;background:var(--bg-primary);
+        border-left:3px solid #a855f7;border-radius:4px;font-size:13px;line-height:1.5;
+        color:var(--text-primary);white-space:pre-wrap;"></div>
+    </div>
+
     <!-- Activity density chart -->
     <div style="
       background:var(--bg-secondary);

--- a/dashboard.py
+++ b/dashboard.py
@@ -67,6 +67,7 @@ from flask import (
 # truth for module-level helpers — see routes/sessions.py for the pattern.
 from routes.sessions import bp_sessions
 from routes.brain import bp_brain
+from routes.advisor import bp_advisor
 
 # Module-level helpers extracted to helpers/*.py (Phase 6 modularisation).
 # Re-exported here so existing `_d.<name>` references in routes/*.py keep
@@ -8267,6 +8268,7 @@ def detect_config(args=None):
         USER_NAME = "You"
 
     # ── Register blueprints (Phase 4) ───────────────────────────────────────
+    app.register_blueprint(bp_advisor)
     app.register_blueprint(bp_alerts)
     app.register_blueprint(bp_autonomy)
     app.register_blueprint(bp_auth)

--- a/routes/advisor.py
+++ b/routes/advisor.py
@@ -1,0 +1,338 @@
+"""
+routes/advisor.py -- ClawMetry Advisor: natural-language Q&A over your agent.
+
+A conversational layer on top of the data the dashboard already collects.
+Users ask questions like "why did my last run cost so much?" or "which tool
+is failing most often?" and get an answer with the relevant events cited.
+
+Auth strategy (zero-config preferred, env-var fallback):
+  1. Re-use OpenClaw's existing anthropic OAuth profile from
+     `~/.openclaw/agents/main/agent/auth-profiles.json`. Most users already
+     have this set up via `claude` CLI -- nothing new to configure.
+  2. Fall back to `ANTHROPIC_API_KEY` env var for users who skipped that.
+  3. If neither is present, return a structured 412 with setup instructions.
+
+This is OSS-side only. The cloud counterpart can later proxy through a
+managed key for Pro users -- not required for the local experience.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+from flask import Blueprint, jsonify, request
+
+bp_advisor = Blueprint("advisor", __name__)
+
+ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+DEFAULT_MODEL = "claude-opus-4-5-20250929"
+FALLBACK_MODEL = "claude-haiku-4-5-20251001"
+MAX_CONTEXT_EVENTS = 40
+MAX_ANSWER_TOKENS = 800
+REQUEST_TIMEOUT_SEC = 30
+
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+
+
+def _load_anthropic_auth() -> tuple[str | None, str | None]:
+    """Return (mode, credential).
+
+    mode is one of:
+      - "api_key"     : direct /v1/messages call with ANTHROPIC_API_KEY
+      - "claude_cli"  : shell out to `claude -p`; uses whatever OpenClaw's
+                        claude-cli profile is already authenticated with
+                        (works for OAuth users with no extra config)
+      - None          : nothing configured; UI stays hidden
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if api_key:
+        return "api_key", api_key
+
+    # `claude` CLI usually bundles an OAuth token after the user runs
+    # `/login` once. Detect the binary presence -- actual auth is
+    # validated at call time and we surface any error to the UI.
+    claude_bin = shutil.which("claude")
+    if claude_bin:
+        profile_path = os.path.expanduser(
+            "~/.openclaw/agents/main/agent/auth-profiles.json"
+        )
+        has_profile = False
+        if os.path.isfile(profile_path):
+            try:
+                with open(profile_path) as f:
+                    data = json.load(f)
+                has_profile = bool(
+                    (data.get("profiles") or {}).get("anthropic:claude-cli", {}).get("access")
+                )
+            except Exception:
+                pass
+        # Only return claude_cli if the binary AND an OAuth profile exist.
+        # Without the profile `claude -p` would prompt interactively, which
+        # hangs the HTTP request.
+        if has_profile:
+            return "claude_cli", claude_bin
+
+    return None, None
+
+
+# ── Context assembly ──────────────────────────────────────────────────────────
+
+
+def _summarise_event(ev: dict) -> str:
+    """Compress a brain event into a single readable line for LLM context."""
+    t = (ev.get("time") or ev.get("timestamp") or "")[:19]
+    typ = ev.get("type") or "?"
+    src = ev.get("source") or ev.get("sourceLabel") or "main"
+    detail = ev.get("detail") or ""
+    if isinstance(detail, (dict, list)):
+        detail = json.dumps(detail)[:160]
+    detail = str(detail).replace("\n", " ")[:200]
+    return f"[{t}] {src} {typ}: {detail}"
+
+
+def _gather_context(limit_events: int = MAX_CONTEXT_EVENTS) -> dict:
+    """Pull a compact snapshot of the user's current agent state.
+
+    Reuses the same primitives the Brain and Tokens tabs already render --
+    nothing new computed, just packaged for the LLM.
+    """
+    import dashboard as _d
+
+    out: dict = {"events": [], "usage": {}, "errors": []}
+
+    # Recent brain events via the existing analytics
+    try:
+        analytics = _d._compute_transcript_analytics()
+        sessions = analytics.get("sessions") or []
+        # Most-recently-updated sessions, summarised
+        sessions.sort(key=lambda s: s.get("updated_ts") or 0, reverse=True)
+        out["recent_sessions"] = [
+            {
+                "session_id": s.get("session_id", "")[:8],
+                "model": s.get("model", ""),
+                "tokens": s.get("tokens", 0),
+                "cost_usd": round(float(s.get("cost_usd", 0) or 0), 4),
+                "started_at": s.get("start_iso", ""),
+            }
+            for s in sessions[:8]
+        ]
+        out["usage"] = {
+            "today_tokens": sum(
+                s.get("tokens", 0)
+                for s in sessions
+                if (s.get("start_iso") or "")[:10] == time.strftime("%Y-%m-%d")
+            ),
+            "total_sessions": len(sessions),
+        }
+    except Exception as e:
+        out["analytics_error"] = str(e)[:200]
+
+    # Tail the unified Brain feed for last few events
+    try:
+        from routes.brain import api_brain_history
+        # Call the route function directly -- it returns a Flask Response
+        with _d.app.test_request_context(
+            "/api/brain-history?limit=" + str(limit_events)
+        ):
+            resp = api_brain_history()
+            payload = resp.get_json() if hasattr(resp, "get_json") else None
+        if payload and isinstance(payload.get("events"), list):
+            out["events"] = [
+                _summarise_event(ev)
+                for ev in payload["events"][-limit_events:]
+            ]
+    except Exception as e:
+        out["brain_error"] = str(e)[:200]
+
+    return out
+
+
+def _build_prompt(question: str, ctx: dict) -> str:
+    """Compose the user-facing question with assembled context."""
+    parts: list[str] = []
+    parts.append("Recent agent activity (most recent last):")
+    for line in ctx.get("events", []):
+        parts.append("  " + line)
+    if ctx.get("recent_sessions"):
+        parts.append("")
+        parts.append("Recent sessions:")
+        for s in ctx["recent_sessions"]:
+            parts.append(
+                f"  - {s['session_id']} model={s['model']} "
+                f"tokens={s['tokens']} cost=${s['cost_usd']} "
+                f"started={s['started_at']}"
+            )
+    if ctx.get("usage"):
+        u = ctx["usage"]
+        parts.append("")
+        parts.append(
+            f"Usage today: {u.get('today_tokens', 0)} tokens across "
+            f"{u.get('total_sessions', 0)} sessions"
+        )
+    parts.append("")
+    parts.append("Question: " + question)
+    return "\n".join(parts)
+
+
+SYSTEM_PROMPT = (
+    "You are ClawMetry Advisor. You help operators of OpenClaw AI agents "
+    "understand what their agents are doing, why a run cost what it did, "
+    "which tools are failing, and what to fix next. "
+    "You are reading the operator's own dashboard data. "
+    "Answer in 2-4 short paragraphs. Cite specific events or sessions by id. "
+    "If the data is insufficient to answer, say so explicitly and suggest "
+    "what the operator should look at next."
+)
+
+
+# ── LLM call ──────────────────────────────────────────────────────────────────
+
+
+def _call_anthropic_api(api_key: str, prompt: str) -> dict:
+    """Direct call to /v1/messages with a real ANTHROPIC_API_KEY."""
+    body = {
+        "model": DEFAULT_MODEL,
+        "max_tokens": MAX_ANSWER_TOKENS,
+        "system": SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "anthropic-version": ANTHROPIC_VERSION,
+        "x-api-key": api_key,
+    }
+    req = urllib.request.Request(
+        ANTHROPIC_URL,
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SEC) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", errors="replace")
+        return {"_error": True, "status": e.code, "body": raw[:500]}
+    except Exception as e:
+        return {"_error": True, "status": 0, "body": str(e)[:500]}
+
+
+def _call_via_claude_cli(claude_bin: str, prompt: str) -> dict:
+    """Shell out to `claude -p` so OAuth-only users still work.
+
+    Normalise the response into the same shape `_call_anthropic_api`
+    returns (content blocks + usage) so the endpoint stays uniform.
+    """
+    full_prompt = SYSTEM_PROMPT + "\n\n---\n\n" + prompt
+    try:
+        proc = subprocess.run(
+            [claude_bin, "-p"],
+            input=full_prompt,
+            capture_output=True,
+            text=True,
+            timeout=REQUEST_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return {"_error": True, "status": 504, "body": "claude CLI timed out"}
+    except Exception as e:
+        return {"_error": True, "status": 0, "body": str(e)[:500]}
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip()
+        return {"_error": True, "status": proc.returncode, "body": err[:500]}
+
+    answer_text = (proc.stdout or "").strip()
+    return {
+        "model": "claude-cli",
+        "content": [{"type": "text", "text": answer_text}],
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+
+
+def _extract_answer(api_response: dict) -> str:
+    if api_response.get("_error"):
+        return ""
+    blocks = api_response.get("content") or []
+    parts = [b.get("text", "") for b in blocks if isinstance(b, dict)]
+    return "".join(parts).strip()
+
+
+# ── Endpoint ──────────────────────────────────────────────────────────────────
+
+
+@bp_advisor.route("/api/advisor/ask", methods=["POST"])
+def api_advisor_ask():
+    payload = request.get_json(silent=True) or {}
+    question = (payload.get("question") or "").strip()
+    if not question:
+        return jsonify({"error": "Provide a non-empty 'question' field."}), 400
+    if len(question) > 1000:
+        return jsonify({"error": "Question too long (1000 char limit)."}), 400
+
+    mode, credential = _load_anthropic_auth()
+    if not credential:
+        return (
+            jsonify(
+                {
+                    "error": "no_auth",
+                    "message": (
+                        "Advisor needs an Anthropic credential. "
+                        "Either run `claude` CLI to set up OAuth, "
+                        "or export ANTHROPIC_API_KEY in your shell."
+                    ),
+                }
+            ),
+            412,
+        )
+
+    ctx = _gather_context()
+    prompt = _build_prompt(question, ctx)
+    if mode == "claude_cli":
+        resp = _call_via_claude_cli(credential, prompt)
+    else:
+        resp = _call_anthropic_api(credential, prompt)
+
+    if resp.get("_error"):
+        return (
+            jsonify(
+                {
+                    "error": "upstream_error",
+                    "status": resp.get("status"),
+                    "detail": resp.get("body", "")[:300],
+                }
+            ),
+            502,
+        )
+
+    answer = _extract_answer(resp)
+    usage = resp.get("usage") or {}
+    return jsonify(
+        {
+            "answer": answer or "(no answer returned)",
+            "model": resp.get("model", DEFAULT_MODEL),
+            "input_tokens": usage.get("input_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0),
+            "events_in_context": len(ctx.get("events", [])),
+        }
+    )
+
+
+@bp_advisor.route("/api/advisor/status")
+def api_advisor_status():
+    """Cheap probe so the UI can decide whether to show the input."""
+    mode, credential = _load_anthropic_auth()
+    return jsonify(
+        {
+            "available": bool(credential),
+            "auth_mode": mode or "none",
+            "model": DEFAULT_MODEL,
+        }
+    )


### PR DESCRIPTION
## Summary

A conversational layer on top of the data the dashboard already collects. Users ask things like *"why did my last run cost so much?"* or *"which tool is failing most often?"* and get an answer that cites the specific events and sessions from their own feed.

Part of the **agent observability visualization plan** -- the dashboard has always had the data, but operators had to cross-reference three tabs to answer even simple questions. Advisor reads all of them on the operator's behalf.

## Architecture

**Backend** (\`routes/advisor.py\`):
- \`POST /api/advisor/ask\` -> \`{answer, model, input_tokens, output_tokens, events_in_context}\`
- \`GET /api/advisor/status\` -- cheap probe so the UI can decide whether to show the input
- Context is assembled from the same primitives the Brain and Tokens tabs already use -- zero new computation
- **Zero-config auth:** re-uses the \`claude\` CLI subprocess (OAuth profile from \`claude /login\`). Falls back to \`ANTHROPIC_API_KEY\` env var. If neither is present the UI stays hidden

**Frontend** (\`brain.html\` + \`app.js\`):
- Card above the activity density chart: text input, three suggestion chips, inline answer pane
- \`advisorProbe()\` runs on Brain page load; card only appears when backend auth is available
- Single \`POST\` to \`/api/advisor/ask\`; answer renders in-place with a small metadata footer

## Verified locally

Question: *"which tool is failing most often?"*

Answer (verbatim from Advisor running against live data):

> *Based on the recent activity feed, the only failures I can see are gateway timeouts on the \`main\` agent -- nine \`EXEC execution failed: Error: gateway timeout after 10000ms\` events between 02:56:53 and 03:17:56. They're not attributed to a specific tool name in the events shown; they're failing at the gateway call layer (10s timeout) before a tool is identified...*

Real analysis, cites real events.

## Out of scope

- Streaming responses (short answers, fine for v1)
- Cloud Pro counterpart (follow-up: proxy through managed key)
- Self-evolving loop where the agent queries its own trajectories (follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)