### PR TITLE
[RELEASE] fix(selfevolve): fold into Advisor card; drop standalone block

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2794,12 +2794,15 @@ async function selfevolveProbe() {
   try {
     var s = await fetchJsonWithTimeout('/api/selfevolve/status', 3000);
     if (!s || !s.available) return;
-    var card = document.getElementById('selfevolve-card');
-    if (card) card.style.display = '';
+    var btn = document.getElementById('selfevolve-run-btn');
+    if (btn) btn.style.display = '';
     if (s.has_cached) {
       try {
         var cached = await fetchJsonWithTimeout('/api/selfevolve/latest', 3000);
-        if (cached && (cached.findings || []).length) selfevolveRenderFindings(cached);
+        if (cached && (cached.findings || []).length) {
+          selfevolveRenderFindings(cached);
+          if (btn) btn.textContent = '🔄 Re-analyze';
+        }
       } catch (e) { /* ignore */ }
     }
   } catch (e) { /* keep hidden */ }
@@ -2807,6 +2810,7 @@ async function selfevolveProbe() {
 window.selfevolveRun = async function () {
   var btn = document.getElementById('selfevolve-run-btn');
   var status = document.getElementById('selfevolve-status');
+  var origText = btn ? btn.textContent : '';
   if (btn) { btn.disabled = true; btn.textContent = 'Analyzing…'; btn.style.opacity = '0.6'; }
   if (status) status.textContent = 'Reviewing recent activity — this takes ~15 seconds…';
   try {
@@ -2820,7 +2824,7 @@ window.selfevolveRun = async function () {
   } catch (e) {
     if (status) status.textContent = 'Network error: ' + e.message;
   } finally {
-    if (btn) { btn.disabled = false; btn.textContent = 'Re-analyze'; btn.style.opacity = ''; }
+    if (btn) { btn.disabled = false; btn.textContent = '🔄 Re-analyze'; btn.style.opacity = ''; }
   }
 };
 

--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -44,7 +44,14 @@
           style="font-size:11px;padding:4px 10px;border-radius:12px;background:rgba(168,85,247,0.1);
                  border:1px solid rgba(168,85,247,0.2);color:#c4b5fd;cursor:pointer;">
           Is my agent looping?</button>
+        <button id="selfevolve-run-btn" onclick="selfevolveRun()"
+          title="Run a structured review of recent activity"
+          style="font-size:11px;padding:4px 10px;border-radius:12px;background:rgba(96,165,250,0.1);
+                 border:1px solid rgba(96,165,250,0.3);color:#93c5fd;cursor:pointer;display:none;">
+          🔄 Self-Evolve →</button>
       </div>
+      <div id="selfevolve-status" style="font-size:11px;color:var(--text-muted);margin-top:8px;"></div>
+      <div id="selfevolve-findings" style="display:flex;flex-direction:column;gap:8px;margin-top:8px;"></div>
       <div id="advisor-answer-wrap" style="display:none;margin-top:12px;">
         <div id="advisor-answer-q" style="
           font-size:12px;color:var(--text-muted);margin-bottom:6px;font-style:italic;"></div>
@@ -61,28 +68,6 @@
         <div id="advisor-answer-meta" style="
           font-size:11px;color:var(--text-muted);margin-top:6px;font-family:monospace;"></div>
       </div>
-    </div>
-
-    <!-- Self-Evolve: standing review of agent trajectory -->
-    <div id="selfevolve-card" style="
-      background:var(--bg-secondary);
-      border:1px solid var(--border);
-      border-radius:8px;
-      padding:14px 16px;
-      margin-bottom:12px;
-      display:none;
-      ">
-      <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:10px;">
-        <div style="display:flex;align-items:center;gap:8px;">
-          <span style="font-size:14px;font-weight:700;color:#60a5fa;">🔄 Self-Evolve</span>
-          <span style="font-size:11px;color:var(--text-muted);">how this agent could improve</span>
-        </div>
-        <button id="selfevolve-run-btn" onclick="selfevolveRun()"
-          style="padding:6px 14px;background:#2563eb;color:#fff;border:none;border-radius:8px;
-                 font-size:12px;font-weight:600;cursor:pointer;">Analyze</button>
-      </div>
-      <div id="selfevolve-status" style="font-size:11px;color:var(--text-muted);margin-bottom:8px;"></div>
-      <div id="selfevolve-findings" style="display:flex;flex-direction:column;gap:8px;"></div>
     </div>
 
     <!-- Activity density chart -->


### PR DESCRIPTION
## Summary

Self-Evolve was its own card on the Brain tab — visually it read like a second prompt surface and pushed the actual brain feed below the fold. Folded it into the Advisor card as a chip-style trigger ("🔄 Self-Evolve →") sitting alongside the existing suggestion chips. Findings render in-place inside the same card.

One unified prompt surface, two ways to interact:
- Free-text question → Advisor (text answer)
- One-click trigger → Self-Evolve (structured findings)

## Changes

- `brain.html`: removed standalone `#selfevolve-card`. Added `#selfevolve-run-btn` as a chip inside the Advisor `#advisor-suggestions` row. Moved `#selfevolve-status` and `#selfevolve-findings` containers inside the Advisor card.
- `app.js`: `selfevolveProbe()` now toggles the chip button instead of a card.

No backend changes. Endpoints, cache, payload shape all unchanged.

## Test plan

- [x] Served HTML confirms standalone `#selfevolve-card` is removed and chip button + findings container are inside the Advisor card
- [x] `selfevolveProbe()` reveals the chip when auth is available
- [x] Cached findings render inside Advisor card on page load (button shows "🔄 Re-analyze")

🤖 Generated with [Claude Code](https://claude.com/claude-code)