### PR TITLE
[RELEASE] feat(selfevolve): standalone page + contextual link (no top-nav slot)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -527,6 +527,7 @@ function switchTab(name) {
   if (name === 'context') loadContextInspector();
   if (name === 'history') loadHistory();
   if (name === 'brain') loadBrainPage();
+  if (name === 'selfevolve') loadSelfEvolvePage();
   if (name === 'security') { loadSecurityPage(); loadSecurityPosture(); }
   if (name === 'approvals') { if (typeof loadApprovalsTab === 'function') loadApprovalsTab(); }
   if (name === 'alerts') { if (typeof loadAlertsPage === 'function') loadAlertsPage(); }
@@ -2790,22 +2791,41 @@ function selfevolveRenderFindings(payload) {
     status.textContent = meta.join(' · ');
   }
 }
+// Self-Evolve is intentionally NOT in the top nav (option C: discoverable via
+// a contextual link on the Brain tab + deep-link). The probe's job here is
+// twofold: (1) reveal the contextual link inside the Advisor card when auth
+// is available, and (2) on direct visits to #selfevolve, render the cached
+// payload or show the appropriate empty/no-auth state.
 async function selfevolveProbe() {
   try {
     var s = await fetchJsonWithTimeout('/api/selfevolve/status', 3000);
-    if (!s || !s.available) return;
-    var btn = document.getElementById('selfevolve-run-btn');
-    if (btn) btn.style.display = '';
+    var hint = document.getElementById('advisor-selfevolve-hint');
+    var noauth = document.getElementById('selfevolve-noauth');
+    var empty = document.getElementById('selfevolve-empty');
+    var runBtn = document.getElementById('selfevolve-run-btn');
+    if (!s || !s.available) {
+      if (hint) hint.style.display = 'none';
+      if (noauth) noauth.style.display = '';
+      if (runBtn) runBtn.disabled = true;
+      return;
+    }
+    if (hint) hint.style.display = '';
+    if (noauth) noauth.style.display = 'none';
     if (s.has_cached) {
       try {
         var cached = await fetchJsonWithTimeout('/api/selfevolve/latest', 3000);
         if (cached && (cached.findings || []).length) {
           selfevolveRenderFindings(cached);
-          if (btn) btn.textContent = '🔄 Re-analyze';
+          if (runBtn) runBtn.textContent = 'Re-analyze';
+          return;
         }
-      } catch (e) { /* ignore */ }
+      } catch (e) { /* fall through to empty state */ }
     }
-  } catch (e) { /* keep hidden */ }
+    if (empty) empty.style.display = '';
+  } catch (e) { /* silent */ }
+}
+async function loadSelfEvolvePage() {
+  return selfevolveProbe();
 }
 window.selfevolveRun = async function () {
   var btn = document.getElementById('selfevolve-run-btn');

--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -44,14 +44,17 @@
           style="font-size:11px;padding:4px 10px;border-radius:12px;background:rgba(168,85,247,0.1);
                  border:1px solid rgba(168,85,247,0.2);color:#c4b5fd;cursor:pointer;">
           Is my agent looping?</button>
-        <button id="selfevolve-run-btn" onclick="selfevolveRun()"
-          title="Run a structured review of recent activity"
-          style="font-size:11px;padding:4px 10px;border-radius:12px;background:rgba(96,165,250,0.1);
-                 border:1px solid rgba(96,165,250,0.3);color:#93c5fd;cursor:pointer;display:none;">
-          🔄 Self-Evolve →</button>
       </div>
-      <div id="selfevolve-status" style="font-size:11px;color:var(--text-muted);margin-top:8px;"></div>
-      <div id="selfevolve-findings" style="display:flex;flex-direction:column;gap:8px;margin-top:8px;"></div>
+      <!-- Contextual link to the standalone Self-Evolve page. Hidden until
+           the probe confirms auth, so users without Anthropic creds don't
+           see a dead-end link. -->
+      <div id="advisor-selfevolve-hint" style="display:none;margin-top:8px;font-size:11px;color:var(--text-muted);">
+        Want a structured review with severity-ranked findings instead?
+        <a href="#selfevolve" onclick="switchTab('selfevolve');return false;"
+           style="color:#60a5fa;text-decoration:none;font-weight:600;cursor:pointer;">
+          Run Self-Evolve →
+        </a>
+      </div>
       <div id="advisor-answer-wrap" style="display:none;margin-top:12px;">
         <div id="advisor-answer-q" style="
           font-size:12px;color:var(--text-muted);margin-bottom:6px;font-style:italic;"></div>

--- a/clawmetry/templates/tabs/selfevolve.html
+++ b/clawmetry/templates/tabs/selfevolve.html
@@ -1,0 +1,75 @@
+<!--
+  Self-Evolve tab — standing review of agent trajectory.
+
+  Where the Brain tab's Advisor answers ad-hoc questions in prose, this tab
+  surfaces structured findings (cost hotspots, failing tools, looping paths,
+  over-eager models) that the operator can act on. Same LLM auth as Advisor:
+  uses claude CLI OAuth or ANTHROPIC_API_KEY transparently.
+
+  Empty-state guidance lives here too — when no Anthropic credential is
+  configured the user sees a single instruction line, not a broken card.
+-->
+
+<div class="page" id="page-selfevolve">
+  <div style="padding:12px 0 8px 0;">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;">
+      <div>
+        <div style="font-size:14px;font-weight:700;color:var(--text-primary);">🔄 Self-Evolve -- How your agent could improve</div>
+        <div style="font-size:12px;color:var(--text-muted);margin-top:2px;">
+          Structured review of recent activity. Each finding has evidence and a concrete action.
+        </div>
+      </div>
+      <button id="selfevolve-run-btn" onclick="selfevolveRun()"
+        style="padding:8px 16px;background:#2563eb;color:#fff;border:none;border-radius:8px;
+               font-size:13px;font-weight:600;cursor:pointer;box-shadow:0 2px 8px rgba(37,99,235,0.3);">
+        Analyze
+      </button>
+    </div>
+
+    <!-- Empty / no-auth state -->
+    <div id="selfevolve-noauth" style="
+      display:none;
+      background:var(--bg-secondary);
+      border:1px solid var(--border);
+      border-radius:8px;
+      padding:24px;
+      text-align:center;
+      color:var(--text-muted);
+      font-size:13px;
+      ">
+      <div style="font-size:24px;margin-bottom:8px;">🔒</div>
+      <div style="margin-bottom:6px;">Self-Evolve needs an Anthropic credential to call the analysis LLM.</div>
+      <div style="font-size:12px;">
+        Either run <code style="background:var(--bg-primary);padding:2px 6px;border-radius:4px;">claude</code>
+        once to set up OAuth, or export <code style="background:var(--bg-primary);padding:2px 6px;border-radius:4px;">ANTHROPIC_API_KEY</code>
+        in your shell.
+      </div>
+    </div>
+
+    <!-- Status line (analyzed at, model, event count) -->
+    <div id="selfevolve-status" style="
+      font-size:11px;
+      color:var(--text-muted);
+      margin-bottom:12px;
+      font-family:ui-monospace,Menlo,monospace;
+      "></div>
+
+    <!-- Findings list -->
+    <div id="selfevolve-findings" style="display:flex;flex-direction:column;gap:10px;">
+      <div id="selfevolve-empty" style="
+        background:var(--bg-secondary);
+        border:1px solid var(--border);
+        border-radius:8px;
+        padding:32px 24px;
+        text-align:center;
+        color:var(--text-muted);
+        font-size:13px;
+        display:none;
+        ">
+        <div style="font-size:24px;margin-bottom:8px;">🪶</div>
+        <div>No analysis yet. Click <strong>Analyze</strong> to review recent activity.</div>
+        <div style="font-size:11px;margin-top:8px;">Takes about 15 seconds.</div>
+      </div>
+    </div>
+  </div>
+</div><!-- end page-selfevolve -->

--- a/dashboard.py
+++ b/dashboard.py
@@ -8585,6 +8585,9 @@ DASHBOARD_HTML = r"""
 <!-- BRAIN -->
 {% include 'tabs/brain.html' %}
 
+<!-- SELF-EVOLVE -->
+{% include 'tabs/selfevolve.html' %}
+
 <!-- CONTEXT INSPECTOR -->
 {% include 'tabs/context.html' %}
 


### PR DESCRIPTION
## Summary

Self-Evolve gets its own page (`#selfevolve`), but **does not** get a slot in the top nav. Discovery happens through a contextual hint inside the Advisor card on the Brain tab:

> Want a structured review with severity-ranked findings instead? **Run Self-Evolve →**

Click the link or use the deep link — the page mounts, cached findings render instantly, "Analyze" re-runs the LLM review.

## Why no top-nav slot

Self-Evolve is reactive ("something feels off, let me review") not routine. Burning a precious top-nav slot for it would clutter the main UI for casual users while only helping power users on rare visits. The contextual link surfaces it exactly when the user is already in "what's happening with my agent?" mode.

This aligns with the simple-UI principle in our memory — checkboxes over config, target user can barely `pip install`.

## Changes

- `templates/tabs/selfevolve.html` (new): full page with heading, Analyze button, status line, findings list, and a no-auth empty state.
- `templates/tabs/brain.html`: contextual hint added below Advisor's suggestion chips (hidden until probe confirms auth).
- `dashboard.py`: include the new template; no nav button added.
- `app.js`: `switchTab('selfevolve')` handler; `selfevolveProbe` toggles the Brain hint and populates the page's empty/no-auth/findings states.

## Test plan

- [x] Deep link `/#selfevolve` mounts the page, renders cached findings if any
- [x] Brain tab shows the contextual hint when probe confirms auth; hidden otherwise
- [x] Self-Evolve does not appear in the top nav (verified: 11 nav items, none are Self-Evolve)
- [x] No-auth state renders inside the page when no Anthropic credential is available
- [x] Analyze button runs `/api/selfevolve/analyze` and re-renders findings in-place

🤖 Generated with [Claude Code](https://claude.com/claude-code)