### PR TITLE
feat: Wire openclaw:prompt-error events into alerts stream

### DIFF
--- a/routes/brain.py
+++ b/routes/brain.py
@@ -19,7 +19,7 @@ import json
 import os
 import time
 
-from flask import Blueprint, Response, jsonify
+from flask import Blueprint, Response, jsonify, request
 
 bp_brain = Blueprint('brain', __name__)
 
@@ -537,7 +537,42 @@ def api_brain_history():
         _d._ext_emit("brain.event", {"count": len(events)})
     except Exception:
         pass
-    return jsonify({"events": events, "total": len(events), "sources": sources_seen, "channels": channel_counts})
+    # Collect prompt errors as an alerts stream
+    prompt_errors = []
+    try:
+        session_files = sorted(glob.glob(os.path.join(session_dir, "*.jsonl")))
+        for sf in session_files:
+            try:
+                with open(sf, "r", errors="replace") as fh:
+                    for raw in fh:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            obj = json.loads(raw)
+                        except Exception:
+                            continue
+                        if obj.get("type") == "custom" and obj.get("customType") == "openclaw:prompt-error":
+                            data = obj.get("data", {})
+                            ts = data.get("timestamp") or obj.get("timestamp")
+                            if ts:
+                                prompt_errors.append({
+                                    "time": ts,
+                                    "provider": data.get("provider", ""),
+                                    "model": data.get("model", ""),
+                                    "error": data.get("error", ""),
+                                    "sessionId": data.get("sessionId", ""),
+                                })
+            except Exception:
+                pass
+        # Sort by time descending
+        prompt_errors.sort(key=lambda e: e.get("time", "") or "", reverse=True)
+        # Keep only last 50
+        prompt_errors = prompt_errors[:50]
+    except Exception:
+        pass
+
+    return jsonify({"events": events, "total": len(events), "sources": sources_seen, "channels": channel_counts, "promptErrors": prompt_errors})
 
 
 @bp_brain.route("/api/brain-stream")
@@ -802,7 +837,7 @@ def api_brain_stream():
                     except Exception:
                         pass
 
-                # Tail session JSONL files for sub-agent events
+                # Tail session JSONL files for sub-agent events + prompt errors
                 for jf in list(jsonl_positions.keys()):
                     try:
                         with open(jf, "rb") as f:
@@ -832,6 +867,21 @@ def api_brain_stream():
                                 ev = _parse_jsonl_event(obj, fname, source_label, color)
                                 if ev:
                                     events.append(ev)
+                                # Also detect prompt errors in streaming
+                                if obj.get("type") == "custom" and obj.get("customType") == "openclaw:prompt-error":
+                                    data_err = obj.get("data", {})
+                                    ts = data_err.get("timestamp") or obj.get("timestamp")
+                                    if ts:
+                                        events.append({
+                                            "time": ts,
+                                            "source": fname,
+                                            "sourceLabel": source_label,
+                                            "type": "PROMPT_ERROR",
+                                            "detail": data_err.get("error", "")[:200],
+                                            "color": "#ef4444",
+                                            "provider": data_err.get("provider", ""),
+                                            "model": data_err.get("model", ""),
+                                        })
                             except Exception:
                                 pass
                     except Exception:
@@ -874,3 +924,69 @@ def api_brain_stream():
         mimetype="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
+
+
+@bp_brain.route("/api/prompt-errors")
+def api_prompt_errors():
+    """Return recent openclaw:prompt-error events for the alerts stream.
+    
+    Reads from session JSONL files to find custom events with customType
+    'openclaw:prompt-error'. Returns errors from last 24h by default.
+    
+    Query param: ?since=ISO8601 — return errors since this timestamp
+    """
+    import dashboard as _d
+    since = request.args.get("since")
+    since_ms = 0
+    if since:
+        try:
+            from datetime import datetime
+            dt = datetime.fromisoformat(since.replace('Z', '+00:00'))
+            since_ms = int(dt.timestamp() * 1000)
+        except Exception:
+            pass
+    
+    session_dir = _d.SESSIONS_DIR or os.path.expanduser("~/.openclaw/agents/main/sessions")
+    prompt_errors = []
+    
+    try:
+        session_files = sorted(glob.glob(os.path.join(session_dir, "*.jsonl")))
+        for sf in session_files[-20:]:  # Check last 20 session files
+            try:
+                with open(sf, "r", errors="replace") as fh:
+                    for raw in fh:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            obj = json.loads(raw)
+                        except Exception:
+                            continue
+                        if obj.get("type") == "custom" and obj.get("customType") == "openclaw:prompt-error":
+                            data = obj.get("data", {})
+                            ts = data.get("timestamp")
+                            if ts and ts >= since_ms:
+                                prompt_errors.append({
+                                    "time": ts,
+                                    "provider": data.get("provider", ""),
+                                    "model": data.get("model", ""),
+                                    "error": data.get("error", ""),
+                                    "sessionId": data.get("sessionId", ""),
+                                    "runId": data.get("runId", ""),
+                                    "api": data.get("api", ""),
+                                })
+            except Exception:
+                pass
+        
+        # Sort by time descending
+        prompt_errors.sort(key=lambda e: e.get("time", 0), reverse=True)
+        # Keep only last 100
+        prompt_errors = prompt_errors[:100]
+    except Exception:
+        pass
+    
+    return jsonify({
+        "errors": prompt_errors,
+        "count": len(prompt_errors),
+        "since": since
+    })

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -317,7 +317,6 @@ def api_overview():
     except Exception:
         infra["storage"] = "Disk"
 
-    model_name = main.get("model") or "unknown"
     return jsonify(
         {
             "model": model_name,
@@ -335,8 +334,54 @@ def api_overview():
             "memorySize": total_size,
             "system": system,
             "infra": infra,
+            "promptErrorsLast24h": _count_recent_prompt_errors(),
         }
     )
+
+
+def _count_recent_prompt_errors():
+    """Count prompt errors from last 24h in session JSONL files."""
+    import glob
+    from datetime import datetime, timedelta
+    
+    session_dir = os.path.expanduser("~/.openclaw/agents/main/sessions")
+    cutoff_ms = int((datetime.now() - timedelta(hours=24)).timestamp() * 1000)
+    error_count = 0
+    recent_errors = []
+    
+    try:
+        session_files = sorted(glob.glob(os.path.join(session_dir, "*.jsonl")))
+        for sf in session_files[-30:]:  # Check last 30 sessions
+            try:
+                with open(sf, "r", errors="replace") as fh:
+                    for raw in fh:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            obj = json.loads(raw)
+                        except Exception:
+                            continue
+                        if obj.get("type") == "custom" and obj.get("customType") == "openclaw:prompt-error":
+                            data = obj.get("data", {})
+                            ts = data.get("timestamp", 0)
+                            if ts >= cutoff_ms:
+                                error_count += 1
+                                recent_errors.append({
+                                    "time": ts,
+                                    "provider": data.get("provider", ""),
+                                    "model": data.get("model", ""),
+                                    "error": data.get("error", "")[:100],
+                                })
+            except Exception:
+                pass
+    except Exception:
+        pass
+    
+    return {
+        "count": error_count,
+        "recent": recent_errors[:5]  # Keep only 5 most recent
+    }
 
 
 @bp_overview.route("/api/main-activity")
@@ -639,3 +684,59 @@ def cloud_cta_verify_otp():
         except Exception:
             _eb = {}
         return jsonify({"ok": False, "error": _eb.get("error", "Invalid code")}), 502
+
+
+@bp_overview.route("/api/prompt-errors/alert")
+def prompt_errors_alert():
+    """Return prompt errors summary for banner display.
+    
+    Returns:
+        - count: number of errors in last 24h
+        - recent: list of recent error summaries
+        - hasErrors: boolean for quick check
+    """
+    import glob
+    from datetime import datetime, timedelta
+    
+    session_dir = os.path.expanduser("~/.openclaw/agents/main/sessions")
+    cutoff_ms = int((datetime.now() - timedelta(hours=24)).timestamp() * 1000)
+    error_count = 0
+    recent_errors = []
+    
+    try:
+        session_files = sorted(glob.glob(os.path.join(session_dir, "*.jsonl")))
+        for sf in session_files[-50:]:  # Check last 50 sessions
+            try:
+                with open(sf, "r", errors="replace") as fh:
+                    for raw in fh:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            obj = json.loads(raw)
+                        except Exception:
+                            continue
+                        if obj.get("type") == "custom" and obj.get("customType") == "openclaw:prompt-error":
+                            data = obj.get("data", {})
+                            ts = data.get("timestamp", 0)
+                            if ts >= cutoff_ms:
+                                error_count += 1
+                                if len(recent_errors) < 3:
+                                    recent_errors.append({
+                                        "time": ts,
+                                        "provider": data.get("provider", ""),
+                                        "model": data.get("model", ""),
+                                        "error": data.get("error", "")[:150],
+                                        "sessionId": data.get("sessionId", "")[:8],
+                                    })
+            except Exception:
+                pass
+    except Exception:
+        pass
+    
+    return jsonify({
+        "hasErrors": error_count > 0,
+        "count": error_count,
+        "recent": recent_errors,
+        "cutoff": cutoff_ms,
+    })


### PR DESCRIPTION
Closes #601

## What
Add support for detecting and displaying openclaw:prompt-error events throughout ClawMetry:
- New /api/prompt-errors endpoint for querying prompt errors
- /api/prompt-errors/alert endpoint for banner display on overview
- promptErrorsLast24h field in /api/overview response
- PROMPT_ERROR events now emitted in brain-stream SSE for real-time monitoring
- promptErrors field in brain-history response

## How
- Scan session JSONL files for custom events with customType: openclaw:prompt-error
- Extract error details: provider, model, error message, timestamp, sessionId
- Sort by time descending, limit to recent 50-100 events
- Add red (#ef4444) color coding for PROMPT_ERROR events in stream

These are real provider failures: rate limits, auth issues, context overflow, model-not-found — now visible in the dashboard instead of ignored.