### PR TITLE
[RELEASE] fix(ui): tighten Notifications layout; drop duplicate Pro chip + Alerts trial banner

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -73,15 +73,9 @@
     const t = await resolveTier();
     alertsState.tier = t.tier;
     alertsState.trialDaysLeft = t.trialDaysLeft || null;
-
-    if (t.tier === 'trial' && t.trialDaysLeft != null) {
-      const banner = document.getElementById('alerts-trial-banner');
-      banner.style.display = '';
-      document.getElementById('alerts-trial-days-left').textContent =
-        ' · ' + t.trialDaysLeft + ' day' + (t.trialDaysLeft === 1 ? '' : 's') + ' left';
-    } else {
-      document.getElementById('alerts-trial-banner').style.display = 'none';
-    }
+    // Trial banner removed in PR #791 — paywall fires on action (click
+    // + New alert rule / Enable) for Free users instead. Trial/Pro users
+    // have full access and see no upgrade prompt unless they hit a cap.
 
     // For all tiers: try to load rules. If unauthenticated, fall back to
     // canned examples so the user still sees the value.
@@ -224,8 +218,13 @@
   // ── Action handlers (paywall-aware) ───────────────────────────────────────
 
   window.alertsHandleNewRule = function () {
-    // Open editor for everyone -- Free/OSS users can configure first; the
-    // paywall fires on Save (better conversion than gating at click time).
+    // Gate on click (not on Save): the banner that used to explain the trial
+    // is gone, so Free / no-cloud users need an explicit prompt that this is
+    // a Pro feature before they start filling out a form they can't save.
+    // Trial + Pro users skip the paywall and get the editor directly.
+    if (alertsState.tier !== 'pro' && alertsState.tier !== 'trial') {
+      return openPaywall();
+    }
     alertsState.editorRule = null;
     alertsState.editorType = 'node_offline';
     openEditor();

--- a/clawmetry/templates/tabs/alerts.html
+++ b/clawmetry/templates/tabs/alerts.html
@@ -21,14 +21,10 @@
     <button class="alerts-btn-primary" onclick="alertsHandleNewRule()">+ New alert rule</button>
   </div>
 
-  <div id="alerts-trial-banner" class="alerts-trial-banner" style="display:none;">
-    <div class="msg">
-      <b>You're on a 7-day Pro trial</b> — unlock multi-channel delivery to
-      Slack, PagerDuty, Telegram, and Email.
-      <span id="alerts-trial-days-left" style="color:var(--text-muted);"></span>
-    </div>
-    <button class="alerts-btn-pro" onclick="alertsHandleUpgrade()">Upgrade to Pro</button>
-  </div>
+  <!-- Trial banner removed — trial users have full access, so the "Upgrade
+       to Pro" banner was just clutter. Free users still hit the
+       openPaywall() modal when they try to enable a second rule or click
+       + New alert rule (see alerts.js alertsCreateRule / alertsToggleRule). -->
 
   <div id="alerts-rules-list" class="alerts-list">
     <div class="alerts-loading">Loading alerts…</div>

--- a/clawmetry/templates/tabs/notifications.html
+++ b/clawmetry/templates/tabs/notifications.html
@@ -52,8 +52,10 @@
     <!-- Status line -->
     <div id="notifications-status" style="font-size:11px;color:var(--text-muted);margin-bottom:8px;font-family:ui-monospace,Menlo,monospace;"></div>
 
-    <!-- Channel grid -->
-    <div id="notifications-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;"></div>
+    <!-- Channel grid — align-items:start stops the grid from stretching cards
+         to match the tallest neighbour, which otherwise creates the empty
+         vertical gaps visible in the screenshot. -->
+    <div id="notifications-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:10px;align-items:start;"></div>
 
     <!-- Setup modal (rendered into this overlay on Connect click) -->
     <div id="notifications-setup-overlay" style="display:none;position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center;"></div>
@@ -125,13 +127,13 @@
       var existing = (byType[ch.key] || [])[0];   // show the first connected of this type
       var connected = !!(existing && existing.enabled);
       return ''
-        + '<div style="background:var(--bg-secondary);border:1px solid ' + (connected ? ch.color + '55' : 'var(--border)') + ';border-radius:10px;padding:16px;text-align:center;transition:border-color 0.2s;">'
-        + '  <div style="font-size:24px;margin-bottom:8px;">' + ch.icon + '</div>'
-        + '  <div style="font-size:14px;font-weight:700;color:var(--text-primary);margin-bottom:4px;">' + ch.name + '</div>'
-        + '  <div style="font-size:11px;color:var(--text-muted);margin-bottom:12px;line-height:1.5;min-height:30px;">' + _esc(ch.desc) + '</div>'
+        + '<div style="background:var(--bg-secondary);border:1px solid ' + (connected ? ch.color + '55' : 'var(--border)') + ';border-radius:10px;padding:14px;text-align:center;transition:border-color 0.2s;">'
+        + '  <div style="font-size:20px;margin-bottom:6px;">' + ch.icon + '</div>'
+        + '  <div style="font-size:12px;font-weight:700;color:var(--text-primary);margin-bottom:4px;">' + ch.name + '</div>'
+        + '  <div style="font-size:11px;color:var(--text-muted);margin-bottom:10px;line-height:1.4;">' + _esc(ch.desc) + '</div>'
         + (connected
-            ? '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + (existing ? existing.id : '') + '\')" style="width:100%;padding:9px;border:1px solid ' + ch.color + '55;background:' + ch.color + '20;color:' + ch.color + ';border-radius:6px;font-size:12px;font-weight:700;cursor:pointer;">✓ Connected — Edit</button>'
-            : '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'\')" style="width:100%;padding:9px;border:0;background:' + ch.color + ';color:#fff;border-radius:6px;font-size:12px;font-weight:700;cursor:pointer;">Connect</button>')
+            ? '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + (existing ? existing.id : '') + '\')" style="width:100%;padding:8px;border:1px solid ' + ch.color + '55;background:' + ch.color + '20;color:' + ch.color + ';border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">✓ Connected — Edit</button>'
+            : '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'\')" style="width:100%;padding:8px;border:0;background:' + ch.color + ';color:#fff;border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">Connect</button>')
         + '</div>';
     }).join('');
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -3266,7 +3266,7 @@ function clawmetryLogout(){
     <div class="nav-tab active" onclick="switchTab('overview')">Overview</div>
     <div class="nav-tab" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">Approvals <span id="nav-approvals-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
     <div class="nav-tab" onclick="switchTab('alerts')" title="Get notified when something goes wrong (Pro)">Alerts <span class="pro-chip">Pro</span></div>
-    <div class="nav-tab" onclick="switchTab('notifications')" title="Slack / Email / PagerDuty / Telegram channels (Pro)">Notifications <span class="pro-chip">Pro</span></div>
+    <div class="nav-tab" onclick="switchTab('notifications')" title="Slack / Email / PagerDuty / Telegram channels">Notifications</div>
     <div class="nav-tab" onclick="switchTab('context')" title="See what context the LLM receives each turn">Context</div>
     <div class="nav-tab" onclick="switchTab('usage')">Tokens</div>
     <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')" style="display:none;">Crons</div>
@@ -8529,7 +8529,7 @@ DASHBOARD_HTML = r"""
     <div class="nav-tab active" onclick="switchTab('overview')">Overview</div>
     <div class="nav-tab" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">Approvals <span id="nav-approvals-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
     <div class="nav-tab" onclick="switchTab('alerts')" title="Get notified when something goes wrong (Pro)">Alerts <span class="pro-chip">Pro</span></div>
-    <div class="nav-tab" onclick="switchTab('notifications')" title="Slack / Email / PagerDuty / Telegram channels (Pro)">Notifications <span class="pro-chip">Pro</span></div>
+    <div class="nav-tab" onclick="switchTab('notifications')" title="Slack / Email / PagerDuty / Telegram channels">Notifications</div>
     <div class="nav-tab" onclick="switchTab('context')" title="See what context the LLM receives each turn">Context</div>
     <div class="nav-tab" onclick="switchTab('usage')">Tokens</div>
     <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')" style="display:none;">Crons</div>


### PR DESCRIPTION
## Three UX polish fixes from back-to-back feedback on the Notifications tab shipped in 0.12.138

1. **Notifications cards stretched vertically** → grid `align-items: start`, icon 24→20px, padding 16→14px, font-size 14→12px (mirrors the clean 5-across layout these same cards use in Approvals).
2. **Duplicate Pro chips in nav** (Alerts \[Pro\] + Notifications \[Pro\]) → dropped Notifications' chip. Paywall behaviour unchanged; purely nav cosmetics.
3. **7-day Pro trial banner on Alerts tab removed** → was clutter for users already on trial, who can't act on the info. Replaced with gating on *action*: clicking "+ New alert rule" now opens the Upgrade-to-Pro modal for Free users (previously the editor opened and gated on Save). Trial/Pro users are unaffected — no banner, no popup, just work.

### Why gate on click vs on save

The banner used to prime users for the paywall-on-save. Without the banner, letting a Free user fill out a form they can't save would be bait-and-switch. Gate on click → clearer signal: this is a Pro feature, here's the trial pitch, decide before you start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)