### PR TITLE
[RELEASE] fix(ui): compact Notifications tiles — 3 per row

### DIFF
--- a/clawmetry/templates/tabs/notifications.html
+++ b/clawmetry/templates/tabs/notifications.html
@@ -52,10 +52,10 @@
     <!-- Status line -->
     <div id="notifications-status" style="font-size:11px;color:var(--text-muted);margin-bottom:8px;font-family:ui-monospace,Menlo,monospace;"></div>
 
-    <!-- Channel grid — align-items:start stops the grid from stretching cards
-         to match the tallest neighbour, which otherwise creates the empty
-         vertical gaps visible in the screenshot. -->
-    <div id="notifications-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:10px;align-items:start;"></div>
+    <!-- Channel grid — 3 compact tiles per row, click-anywhere to connect/edit.
+         max-width keeps tiles small on wide monitors instead of stretching to
+         fill the whole viewport. -->
+    <div id="notifications-grid" style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;max-width:560px;"></div>
 
     <!-- Setup modal (rendered into this overlay on Connect click) -->
     <div id="notifications-setup-overlay" style="display:none;position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center;"></div>
@@ -126,14 +126,19 @@
     grid.innerHTML = CHANNELS.map(function(ch) {
       var existing = (byType[ch.key] || [])[0];   // show the first connected of this type
       var connected = !!(existing && existing.enabled);
+      var id = existing ? existing.id : '';
+      // Whole tile is the click target — removes the visual weight of a
+      // full-width button and keeps each card to ~icon + label + status dot.
       return ''
-        + '<div style="background:var(--bg-secondary);border:1px solid ' + (connected ? ch.color + '55' : 'var(--border)') + ';border-radius:10px;padding:14px;text-align:center;transition:border-color 0.2s;">'
-        + '  <div style="font-size:20px;margin-bottom:6px;">' + ch.icon + '</div>'
-        + '  <div style="font-size:12px;font-weight:700;color:var(--text-primary);margin-bottom:4px;">' + ch.name + '</div>'
-        + '  <div style="font-size:11px;color:var(--text-muted);margin-bottom:10px;line-height:1.4;">' + _esc(ch.desc) + '</div>'
-        + (connected
-            ? '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + (existing ? existing.id : '') + '\')" style="width:100%;padding:8px;border:1px solid ' + ch.color + '55;background:' + ch.color + '20;color:' + ch.color + ';border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">✓ Connected — Edit</button>'
-            : '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'\')" style="width:100%;padding:8px;border:0;background:' + ch.color + ';color:#fff;border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">Connect</button>')
+        + '<div role="button" tabindex="0"'
+        + '     onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + id + '\')"'
+        + '     onkeydown="if(event.key===\'Enter\'||event.key===\' \'){notifyOpenSetup(\'' + ch.key + '\',\'' + id + '\')}"'
+        + '     style="position:relative;background:var(--bg-secondary);border:1px solid ' + (connected ? ch.color + '66' : 'var(--border)') + ';border-radius:10px;padding:10px 8px;text-align:center;cursor:pointer;transition:transform .12s ease,border-color .12s ease;"'
+        + '     onmouseover="this.style.transform=\'translateY(-1px)\';this.style.borderColor=\'' + ch.color + '\'"'
+        + '     onmouseout="this.style.transform=\'\';this.style.borderColor=\'' + (connected ? ch.color + '66' : 'var(--border)') + '\'">'
+        + (connected ? '<span title="Connected" style="position:absolute;top:6px;right:6px;width:6px;height:6px;border-radius:50%;background:' + ch.color + ';box-shadow:0 0 0 2px ' + ch.color + '33;"></span>' : '')
+        + '  <div style="font-size:18px;line-height:1;margin-bottom:4px;">' + ch.icon + '</div>'
+        + '  <div style="font-size:11px;font-weight:600;color:var(--text-primary);">' + ch.name + '</div>'
         + '</div>';
     }).join('');
 


### PR DESCRIPTION
## Summary
- Hard 3-column grid (max-width 560px) replaces the stretchy `auto-fill, minmax(200px, 1fr)` layout — tiles stay ~170px wide no matter the viewport.
- Tile content reduced to icon + name. Per-channel descriptions move into the setup modal where they're actually useful.
- Whole tile is the click target (role=button, keyboard-accessible). A small colored dot in the top-right indicates "connected"; hover lifts the tile + brightens the border. No more full-width action button.
- Padding 14px -> 10/8px, icon 20px -> 18px, label 12px -> 11px.

Result: tiles take ~1/3 the vertical space. The Notifications page now feels like the lightweight "manage delivery destinations" shortcut it was meant to be, rather than a dashboard in its own right.

## Test plan
- [ ] Open Cloud dashboard, Notifications tab -> 5 tiles render in one row of 3 + a second row of 2.
- [ ] Click a tile (not just the old button spot) -> Connect modal opens.
- [ ] Connect Email -> tile gets colored border + dot in top-right.
- [ ] Hover a connected tile -> still hover-lifts; clicking opens Edit modal.
- [ ] Tab-focus a tile, press Enter -> Connect modal opens (keyboard access).