### PR TITLE
[RELEASE] fix(ui): channel pills (notifications + approvals get-notified)

### DIFF
--- a/clawmetry/templates/tabs/approvals.html
+++ b/clawmetry/templates/tabs/approvals.html
@@ -85,7 +85,7 @@
   <!-- ═══ SECTION 3: Notification Channels ═══ -->
   <div style="margin-bottom:16px;">
     <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:700;margin-bottom:8px;">Get Notified</div>
-    <div id="approvals-integrations" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:10px;">
+    <div id="approvals-integrations" style="display:flex;flex-wrap:wrap;gap:8px;">
     </div>
   </div>
 
@@ -277,18 +277,30 @@
     if (!el) return;
     _savedIntegrations = {};
     (savedIntegrations || []).forEach(function(i) { _savedIntegrations[i.channel] = i; });
+    // Compact pills, same design as the Notifications tab. Channels are
+    // shared between Approvals and Alerts, so the visual treatment should
+    // match — and a horizontal flex row stays compact even on narrow
+    // sidebars where the previous grid card layout dominated the page.
     el.innerHTML = CHANNELS.map(function(ch) {
-      var s = _savedIntegrations[ch.key];
+      var s  = _savedIntegrations[ch.key];
       var on = s && s.enabled;
-      return '<div style="background:var(--bg-secondary);border:1px solid ' + (on ? ch.color + '44' : 'var(--border)') + ';border-radius:10px;padding:14px;text-align:center;">'
-        + '<div style="font-size:20px;margin-bottom:6px;">' + ch.icon + '</div>'
-        + '<div style="font-size:12px;font-weight:700;color:var(--text-primary);margin-bottom:4px;">' + ch.name + '</div>'
-        + '<div style="font-size:11px;color:var(--text-muted);margin-bottom:10px;">' + escHtml(ch.desc) + '</div>'
-        + (on
-          ? '<button onclick="openIntegrationSetup(\'' + ch.key + '\')" style="width:100%;padding:8px;border:1px solid ' + ch.color + '44;background:' + ch.color + '15;color:' + ch.color + ';border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">Connected</button>'
-          : '<button onclick="openIntegrationSetup(\'' + ch.key + '\')" style="width:100%;padding:8px;border:0;background:' + ch.color + ';color:#fff;border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">Connect</button>'
-        )
-        + '</div>';
+      var bg     = on ? ch.color + '22' : 'rgba(255,255,255,0.04)';
+      var border = on ? ch.color + '88' : 'rgba(255,255,255,0.10)';
+      var fg     = on ? ch.color         : '#cbd5e1';
+      return ''
+        + '<button type="button"'
+        + '  onclick="openIntegrationSetup(\'' + ch.key + '\')"'
+        + '  title="' + (on ? 'Edit ' : 'Connect ') + escHtml(ch.name) + '"'
+        + '  style="display:inline-flex;align-items:center;gap:8px;padding:8px 14px;'
+        + '         background:' + bg + ';border:1px solid ' + border + ';color:' + fg + ';'
+        + '         border-radius:999px;font:inherit;font-size:12px;font-weight:600;'
+        + '         cursor:pointer;transition:transform .1s ease,background .15s ease;"'
+        + '  onmouseover="this.style.transform=\'translateY(-1px)\'"'
+        + '  onmouseout="this.style.transform=\'\'">'
+        + '<span style="font-size:14px;line-height:1;">' + ch.icon + '</span>'
+        + '<span>' + ch.name + '</span>'
+        + (on ? '<span style="width:6px;height:6px;border-radius:50%;background:' + ch.color + ';"></span>' : '')
+        + '</button>';
     }).join('');
   }
 

--- a/clawmetry/templates/tabs/notifications.html
+++ b/clawmetry/templates/tabs/notifications.html
@@ -52,10 +52,10 @@
     <!-- Status line -->
     <div id="notifications-status" style="font-size:11px;color:var(--text-muted);margin-bottom:8px;font-family:ui-monospace,Menlo,monospace;"></div>
 
-    <!-- Channel grid — 3 compact tiles per row, click-anywhere to connect/edit.
-         max-width keeps tiles small on wide monitors instead of stretching to
-         fill the whole viewport. -->
-    <div id="notifications-grid" style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;max-width:560px;"></div>
+    <!-- Channel pills — horizontal flex row that wraps. Using flexbox (not
+         grid) because something in the iframe parent CSS was collapsing the
+         grid to a single column; flex+wrap is rock-solid. -->
+    <div id="notifications-grid" style="display:flex;flex-wrap:wrap;gap:8px;"></div>
 
     <!-- Setup modal (rendered into this overlay on Connect click) -->
     <div id="notifications-setup-overlay" style="display:none;position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center;"></div>
@@ -124,22 +124,29 @@
     state.rows.forEach(function(c) { (byType[c.channel_type] = byType[c.channel_type] || []).push(c); });
 
     grid.innerHTML = CHANNELS.map(function(ch) {
-      var existing = (byType[ch.key] || [])[0];   // show the first connected of this type
+      var existing = (byType[ch.key] || [])[0];
       var connected = !!(existing && existing.enabled);
       var id = existing ? existing.id : '';
-      // Whole tile is the click target — removes the visual weight of a
-      // full-width button and keeps each card to ~icon + label + status dot.
+      // Compact pill: icon + name + (dot if connected). inline-flex with a
+      // hard-coded background colour so it can't disappear if a parent
+      // stylesheet steamrolls the CSS variables.
+      var bg     = connected ? ch.color + '22' : 'rgba(255,255,255,0.04)';
+      var border = connected ? ch.color + '88' : 'rgba(255,255,255,0.10)';
+      var fg     = connected ? ch.color         : '#cbd5e1';
       return ''
-        + '<div role="button" tabindex="0"'
-        + '     onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + id + '\')"'
-        + '     onkeydown="if(event.key===\'Enter\'||event.key===\' \'){notifyOpenSetup(\'' + ch.key + '\',\'' + id + '\')}"'
-        + '     style="position:relative;background:var(--bg-secondary);border:1px solid ' + (connected ? ch.color + '66' : 'var(--border)') + ';border-radius:10px;padding:10px 8px;text-align:center;cursor:pointer;transition:transform .12s ease,border-color .12s ease;"'
-        + '     onmouseover="this.style.transform=\'translateY(-1px)\';this.style.borderColor=\'' + ch.color + '\'"'
-        + '     onmouseout="this.style.transform=\'\';this.style.borderColor=\'' + (connected ? ch.color + '66' : 'var(--border)') + '\'">'
-        + (connected ? '<span title="Connected" style="position:absolute;top:6px;right:6px;width:6px;height:6px;border-radius:50%;background:' + ch.color + ';box-shadow:0 0 0 2px ' + ch.color + '33;"></span>' : '')
-        + '  <div style="font-size:18px;line-height:1;margin-bottom:4px;">' + ch.icon + '</div>'
-        + '  <div style="font-size:11px;font-weight:600;color:var(--text-primary);">' + ch.name + '</div>'
-        + '</div>';
+        + '<button type="button"'
+        + '  onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + id + '\')"'
+        + '  title="' + (connected ? 'Edit ' : 'Connect ') + _esc(ch.name) + '"'
+        + '  style="display:inline-flex;align-items:center;gap:8px;padding:8px 14px;'
+        + '         background:' + bg + ';border:1px solid ' + border + ';color:' + fg + ';'
+        + '         border-radius:999px;font:inherit;font-size:12px;font-weight:600;'
+        + '         cursor:pointer;transition:transform .1s ease,background .15s ease;"'
+        + '  onmouseover="this.style.transform=\'translateY(-1px)\'"'
+        + '  onmouseout="this.style.transform=\'\'">'
+        + '<span style="font-size:14px;line-height:1;">' + ch.icon + '</span>'
+        + '<span>' + ch.name + '</span>'
+        + (connected ? '<span style="width:6px;height:6px;border-radius:50%;background:' + ch.color + ';"></span>' : '')
+        + '</button>';
     }).join('');
 
     // Free-tier reminder banner (shown only when user is on Free)


### PR DESCRIPTION
## Summary
Two issues with the previous compact-tiles design:

1. The 3-column grid collapsed to a single stretched column inside the Cloud iframe — something in the parent CSS was overriding inline \`display:grid\` (or the implicit min-content sizing forced one tile per row). The Email tile filled ~1000px while the rest stacked below it.
2. The Approvals tab's "Get Notified" section still used the old big-card design (icon + name + description + full-width Connect button), which doesn't match the dashboard's information density.

Switch both surfaces to the same horizontal pill row:

\`[✉️ Email ●]  [📞 Phone Call]  [💬 Slack]  [📟 PagerDuty]  [✈️ Telegram]\`

- \`display:flex + flex-wrap\` — bulletproof against parent CSS. No parent rule will rearrange flex children into a column.
- Each pill is icon + name + small dot when connected. Hard-coded rgba colours rather than CSS variables so a missing/overridden \`--bg-secondary\` can't make the pill invisible.
- Click anywhere on the pill → setup modal (same flow; only the visual treatment changed). Hover lifts 1px.

Same renderer in \`notifications.html\` and \`approvals.html\` so channel UI is identical wherever it appears.

## Test plan
- [ ] Notifications tab inside Cloud iframe — 5 pills in a single row.
- [ ] Approvals tab inside Cloud iframe — same 5-pill row under "Get Notified".
- [ ] Connect a channel — pill gets coloured background + dot.
- [ ] Click a pill — setup modal opens.
- [ ] Narrow viewport — pills wrap to a second row instead of stretching.