### PR TITLE
[RELEASE] revert(ui): channel cards (back out pill + compact-tile churn)

### DIFF
--- a/clawmetry/templates/tabs/approvals.html
+++ b/clawmetry/templates/tabs/approvals.html
@@ -85,7 +85,7 @@
   <!-- ═══ SECTION 3: Notification Channels ═══ -->
   <div style="margin-bottom:16px;">
     <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:700;margin-bottom:8px;">Get Notified</div>
-    <div id="approvals-integrations" style="display:flex;flex-wrap:wrap;gap:8px;">
+    <div id="approvals-integrations" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:10px;">
     </div>
   </div>
 
@@ -277,30 +277,18 @@
     if (!el) return;
     _savedIntegrations = {};
     (savedIntegrations || []).forEach(function(i) { _savedIntegrations[i.channel] = i; });
-    // Compact pills, same design as the Notifications tab. Channels are
-    // shared between Approvals and Alerts, so the visual treatment should
-    // match — and a horizontal flex row stays compact even on narrow
-    // sidebars where the previous grid card layout dominated the page.
     el.innerHTML = CHANNELS.map(function(ch) {
-      var s  = _savedIntegrations[ch.key];
+      var s = _savedIntegrations[ch.key];
       var on = s && s.enabled;
-      var bg     = on ? ch.color + '22' : 'rgba(255,255,255,0.04)';
-      var border = on ? ch.color + '88' : 'rgba(255,255,255,0.10)';
-      var fg     = on ? ch.color         : '#cbd5e1';
-      return ''
-        + '<button type="button"'
-        + '  onclick="openIntegrationSetup(\'' + ch.key + '\')"'
-        + '  title="' + (on ? 'Edit ' : 'Connect ') + escHtml(ch.name) + '"'
-        + '  style="display:inline-flex;align-items:center;gap:8px;padding:8px 14px;'
-        + '         background:' + bg + ';border:1px solid ' + border + ';color:' + fg + ';'
-        + '         border-radius:999px;font:inherit;font-size:12px;font-weight:600;'
-        + '         cursor:pointer;transition:transform .1s ease,background .15s ease;"'
-        + '  onmouseover="this.style.transform=\'translateY(-1px)\'"'
-        + '  onmouseout="this.style.transform=\'\'">'
-        + '<span style="font-size:14px;line-height:1;">' + ch.icon + '</span>'
-        + '<span>' + ch.name + '</span>'
-        + (on ? '<span style="width:6px;height:6px;border-radius:50%;background:' + ch.color + ';"></span>' : '')
-        + '</button>';
+      return '<div style="background:var(--bg-secondary);border:1px solid ' + (on ? ch.color + '44' : 'var(--border)') + ';border-radius:10px;padding:14px;text-align:center;">'
+        + '<div style="font-size:20px;margin-bottom:6px;">' + ch.icon + '</div>'
+        + '<div style="font-size:12px;font-weight:700;color:var(--text-primary);margin-bottom:4px;">' + ch.name + '</div>'
+        + '<div style="font-size:11px;color:var(--text-muted);margin-bottom:10px;">' + escHtml(ch.desc) + '</div>'
+        + (on
+          ? '<button onclick="openIntegrationSetup(\'' + ch.key + '\')" style="width:100%;padding:8px;border:1px solid ' + ch.color + '44;background:' + ch.color + '15;color:' + ch.color + ';border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">Connected</button>'
+          : '<button onclick="openIntegrationSetup(\'' + ch.key + '\')" style="width:100%;padding:8px;border:0;background:' + ch.color + ';color:#fff;border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">Connect</button>'
+        )
+        + '</div>';
     }).join('');
   }
 

--- a/clawmetry/templates/tabs/notifications.html
+++ b/clawmetry/templates/tabs/notifications.html
@@ -52,10 +52,8 @@
     <!-- Status line -->
     <div id="notifications-status" style="font-size:11px;color:var(--text-muted);margin-bottom:8px;font-family:ui-monospace,Menlo,monospace;"></div>
 
-    <!-- Channel pills — horizontal flex row that wraps. Using flexbox (not
-         grid) because something in the iframe parent CSS was collapsing the
-         grid to a single column; flex+wrap is rock-solid. -->
-    <div id="notifications-grid" style="display:flex;flex-wrap:wrap;gap:8px;"></div>
+    <!-- Channel grid -->
+    <div id="notifications-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;"></div>
 
     <!-- Setup modal (rendered into this overlay on Connect click) -->
     <div id="notifications-setup-overlay" style="display:none;position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center;"></div>
@@ -124,29 +122,17 @@
     state.rows.forEach(function(c) { (byType[c.channel_type] = byType[c.channel_type] || []).push(c); });
 
     grid.innerHTML = CHANNELS.map(function(ch) {
-      var existing = (byType[ch.key] || [])[0];
+      var existing = (byType[ch.key] || [])[0];   // show the first connected of this type
       var connected = !!(existing && existing.enabled);
-      var id = existing ? existing.id : '';
-      // Compact pill: icon + name + (dot if connected). inline-flex with a
-      // hard-coded background colour so it can't disappear if a parent
-      // stylesheet steamrolls the CSS variables.
-      var bg     = connected ? ch.color + '22' : 'rgba(255,255,255,0.04)';
-      var border = connected ? ch.color + '88' : 'rgba(255,255,255,0.10)';
-      var fg     = connected ? ch.color         : '#cbd5e1';
       return ''
-        + '<button type="button"'
-        + '  onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + id + '\')"'
-        + '  title="' + (connected ? 'Edit ' : 'Connect ') + _esc(ch.name) + '"'
-        + '  style="display:inline-flex;align-items:center;gap:8px;padding:8px 14px;'
-        + '         background:' + bg + ';border:1px solid ' + border + ';color:' + fg + ';'
-        + '         border-radius:999px;font:inherit;font-size:12px;font-weight:600;'
-        + '         cursor:pointer;transition:transform .1s ease,background .15s ease;"'
-        + '  onmouseover="this.style.transform=\'translateY(-1px)\'"'
-        + '  onmouseout="this.style.transform=\'\'">'
-        + '<span style="font-size:14px;line-height:1;">' + ch.icon + '</span>'
-        + '<span>' + ch.name + '</span>'
-        + (connected ? '<span style="width:6px;height:6px;border-radius:50%;background:' + ch.color + ';"></span>' : '')
-        + '</button>';
+        + '<div style="background:var(--bg-secondary);border:1px solid ' + (connected ? ch.color + '55' : 'var(--border)') + ';border-radius:10px;padding:16px;text-align:center;transition:border-color 0.2s;">'
+        + '  <div style="font-size:24px;margin-bottom:8px;">' + ch.icon + '</div>'
+        + '  <div style="font-size:14px;font-weight:700;color:var(--text-primary);margin-bottom:4px;">' + ch.name + '</div>'
+        + '  <div style="font-size:11px;color:var(--text-muted);margin-bottom:12px;line-height:1.5;min-height:30px;">' + _esc(ch.desc) + '</div>'
+        + (connected
+            ? '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + (existing ? existing.id : '') + '\')" style="width:100%;padding:9px;border:1px solid ' + ch.color + '55;background:' + ch.color + '20;color:' + ch.color + ';border-radius:6px;font-size:12px;font-weight:700;cursor:pointer;">✓ Connected — Edit</button>'
+            : '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'\')" style="width:100%;padding:9px;border:0;background:' + ch.color + ';color:#fff;border-radius:6px;font-size:12px;font-weight:700;cursor:pointer;">Connect</button>')
+        + '</div>';
     }).join('');
 
     // Free-tier reminder banner (shown only when user is on Free)

--- a/clawmetry/templates/tabs/notifications.html
+++ b/clawmetry/templates/tabs/notifications.html
@@ -168,8 +168,8 @@
       + '<div style="background:var(--bg-secondary,#131929);border:1px solid ' + ch.color + '44;border-radius:14px;padding:24px 28px;max-width:440px;width:90%;box-shadow:0 20px 60px rgba(0,0,0,0.5);">'
       + '  <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px;">'
       + '    <span style="font-size:22px;">' + ch.icon + '</span>'
-      + '    <span style="font-size:15px;font-weight:700;color:var(--text-primary);">'+(existing ? 'Edit' : 'Connect')+' ' + ch.name + '</span>'
-      + '    <span style="margin-left:auto;cursor:pointer;color:var(--text-muted);font-size:20px;line-height:1;" onclick="notifyCloseSetup()">×</span>'
+      + '    <span style="font-size:15px;font-weight:700;color:var(--text-primary,#e2e8f0);">'+(existing ? 'Edit' : 'Connect')+' ' + ch.name + '</span>'
+      + '    <span style="margin-left:auto;cursor:pointer;color:var(--text-muted,#94a3b8);font-size:20px;line-height:1;" onclick="notifyCloseSetup()">×</span>'
       + '  </div>';
     if (ch.howTo) {
       html += '<div style="background:rgba(96,165,250,0.06);border:1px solid rgba(96,165,250,0.15);border-radius:8px;padding:12px 14px;margin-bottom:14px;font-size:12px;color:var(--text-secondary);line-height:1.7;">'


### PR DESCRIPTION
Restores the original card design (icon + name + description + Connect button) for both the Notifications tab and Approvals 'Get Notified' section. The two intermediate redesigns (PRs #798 + #800) created more problems than they solved.