### PR TITLE
[RELEASE] fix(notifications): fixed-width cards — stop the single-column collapse

### DIFF
--- a/clawmetry/templates/tabs/notifications.html
+++ b/clawmetry/templates/tabs/notifications.html
@@ -52,8 +52,9 @@
     <!-- Status line -->
     <div id="notifications-status" style="font-size:11px;color:var(--text-muted);margin-bottom:8px;font-family:ui-monospace,Menlo,monospace;"></div>
 
-    <!-- Channel grid -->
-    <div id="notifications-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:12px;"></div>
+    <!-- Responsive grid — auto-fill packs as many ~200px cards per row as
+         the container allows. -->
+    <div id="notifications-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px;"></div>
 
     <!-- Setup modal (rendered into this overlay on Connect click) -->
     <div id="notifications-setup-overlay" style="display:none;position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,0.6);backdrop-filter:blur(4px);align-items:center;justify-content:center;"></div>
@@ -122,16 +123,18 @@
     state.rows.forEach(function(c) { (byType[c.channel_type] = byType[c.channel_type] || []).push(c); });
 
     grid.innerHTML = CHANNELS.map(function(ch) {
-      var existing = (byType[ch.key] || [])[0];   // show the first connected of this type
+      var existing  = (byType[ch.key] || [])[0];
       var connected = !!(existing && existing.enabled);
       return ''
-        + '<div style="background:var(--bg-secondary);border:1px solid ' + (connected ? ch.color + '55' : 'var(--border)') + ';border-radius:10px;padding:16px;text-align:center;transition:border-color 0.2s;">'
-        + '  <div style="font-size:24px;margin-bottom:8px;">' + ch.icon + '</div>'
-        + '  <div style="font-size:14px;font-weight:700;color:var(--text-primary);margin-bottom:4px;">' + ch.name + '</div>'
-        + '  <div style="font-size:11px;color:var(--text-muted);margin-bottom:12px;line-height:1.5;min-height:30px;">' + _esc(ch.desc) + '</div>'
+        + '<div style="background:var(--bg-secondary,#131929);border:1px solid '
+        + (connected ? ch.color + '66' : 'var(--border,#1e293b)') + ';'
+        + 'border-radius:10px;padding:14px 12px;text-align:center;">'
+        + '  <div style="font-size:22px;line-height:1;margin-bottom:6px;">' + ch.icon + '</div>'
+        + '  <div style="font-size:13px;font-weight:700;color:var(--text-primary,#e2e8f0);margin-bottom:3px;">' + ch.name + '</div>'
+        + '  <div style="font-size:10px;color:var(--text-muted,#94a3b8);margin-bottom:10px;line-height:1.4;min-height:28px;">' + _esc(ch.desc) + '</div>'
         + (connected
-            ? '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + (existing ? existing.id : '') + '\')" style="width:100%;padding:9px;border:1px solid ' + ch.color + '55;background:' + ch.color + '20;color:' + ch.color + ';border-radius:6px;font-size:12px;font-weight:700;cursor:pointer;">✓ Connected — Edit</button>'
-            : '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'\')" style="width:100%;padding:9px;border:0;background:' + ch.color + ';color:#fff;border-radius:6px;font-size:12px;font-weight:700;cursor:pointer;">Connect</button>')
+            ? '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'' + (existing ? existing.id : '') + '\')" style="width:100%;padding:7px;border:1px solid ' + ch.color + '66;background:' + ch.color + '22;color:' + ch.color + ';border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">✓ Edit</button>'
+            : '  <button onclick="notifyOpenSetup(\'' + ch.key + '\',\'\')" style="width:100%;padding:7px;border:0;background:' + ch.color + ';color:#fff;border-radius:6px;font-size:11px;font-weight:700;cursor:pointer;">Connect</button>')
         + '</div>';
     }).join('');
 
@@ -273,7 +276,11 @@
       return;
     }
     if (noauth) noauth.style.display = 'none';
-    if (grid)   grid.style.display = '';
+    // Restore the grid container to its original display mode. Setting
+    // style.display = '' would BLANK the inline display property and fall
+    // back to <div>'s default (block), turning the flex row into a single
+    // stretched column — that's the bug we kept chasing in CSS.
+    if (grid)   grid.style.display = 'grid';
 
     try {
       var data = await fetch('/api/cloud-proxy/api/channels').then(function(r){return r.json();});


### PR DESCRIPTION
Fixed-width 180px flex cards with hard-coded colours. The grid kept collapsing inside the Cloud iframe regardless of grid-template-columns. Stops the back-and-forth.