### PR TITLE
feat: OpenClaw native plugin + ClawHub skill

### DIFF
--- a/clawhub-plugin/README.md
+++ b/clawhub-plugin/README.md
@@ -1,49 +1,116 @@
 # ClawMetry — OpenClaw Observability Plugin
 
-**ClawMetry** is a real-time observability dashboard for OpenClaw AI agents. Install it as a ClawHub plugin to get instant visibility into your agent's token usage, API costs, memory consumption, tool calls, and session timelines — all in a beautiful local dashboard at `http://localhost:8900`. Zero configuration required: ClawMetry auto-detects your OpenClaw setup and starts streaming live data from your `~/.openclaw/` session files the moment it starts.
+**ClawMetry** is the observability dashboard for OpenClaw AI agents. It gives you real-time visibility into token usage, API costs, tool calls, session timelines, memory, and cron jobs — all in a local dashboard at `http://localhost:8900`.
 
-## Install via ClawHub
+Zero configuration required. ClawMetry auto-detects your OpenClaw setup and starts streaming live telemetry the moment it starts.
 
-```
+## Install
+
+### Via ClawHub (recommended)
+
+```bash
 openclaw plugins install clawmetry
 ```
 
-## Manual Install
+### Via curl
 
 ```bash
 curl -fsSL https://clawmetry.com/install.sh | bash
 ```
 
+### Via pip (standalone)
+
+```bash
+pip install clawmetry && clawmetry
+```
+
+## How it works
+
+When installed as an OpenClaw plugin, ClawMetry:
+
+1. **Subscribes to diagnostic events** — model usage, tool calls, session lifecycle, message flow
+2. **Manages the dashboard process** — auto-starts with OpenClaw, auto-stops on shutdown
+3. **Buffers and forwards telemetry** — batched HTTP delivery to the local dashboard
+4. **Ships a bundled skill** — teaches agents to be cost-aware and reference the dashboard
+
+### Plugin hooks used
+
+| Hook | Purpose |
+|---|---|
+| `onDiagnosticEvent` | Token usage, costs, session state, heartbeats |
+| `registerLogTransport` | Gateway log forwarding to dashboard log viewer |
+
+### Dashboard features
+
+- **Overview** — active sessions, total costs, token usage, system health
+- **Sessions** — per-session breakdown with transcript viewer
+- **Brain** — live feed of every LLM call (model, tokens, latency)
+- **Flow** — animated architecture diagram showing real-time data flow
+- **Memory** — workspace memory file viewer
+- **Crons** — scheduled job status and history
+- **Usage** — per-model cost tracking over time
+- **Alerts** — budget alerts and anomaly detection
+
 ## Configuration
 
-In your OpenClaw config, you can optionally set:
+In your OpenClaw config (`~/.openclaw/openclaw.json`):
 
-```json5
+```json
 {
   "plugins": {
+    "allow": ["clawmetry"],
     "entries": {
       "clawmetry": {
+        "enabled": true,
         "port": 8900,
         "host": "127.0.0.1",
-        "autoStart": true
+        "autoStart": true,
+        "cloudSync": false,
+        "apiKey": "cm-..."
       }
     }
   }
 }
 ```
 
-## Zero-Config HTTP Interceptor
+### Options
 
-To auto-track LLM costs without any code changes, add one line to your project:
+| Option | Default | Description |
+|---|---|---|
+| `port` | `8900` | Dashboard port |
+| `host` | `127.0.0.1` | Bind address (`0.0.0.0` for LAN access) |
+| `autoStart` | `true` | Start dashboard with OpenClaw |
+| `cloudSync` | `false` | Enable encrypted sync to clawmetry.com |
+| `apiKey` | — | ClawMetry Cloud API key (optional) |
 
-```python
-import clawmetry.interceptor  # patches httpx + requests automatically
+## Cloud Sync
+
+Optional E2E encrypted sync to [clawmetry.com](https://clawmetry.com) for remote monitoring:
+
+```bash
+clawmetry connect
 ```
 
-Or set `CLAWMETRY_INTERCEPT=1` in your environment to activate globally.
+Your encryption key never leaves your machine. Data is AES-256-GCM encrypted before transmission.
+
+## Standalone usage
+
+ClawMetry also works without the plugin — as a standalone `pip install`:
+
+```bash
+pip install clawmetry
+clawmetry
+```
+
+In standalone mode, it reads OpenClaw's JSONL session files and logs directly from the filesystem. The plugin mode adds real-time diagnostic event streaming for richer telemetry.
 
 ## Links
 
-- **Homepage:** https://clawmetry.com
-- **GitHub:** https://github.com/vivekchand/clawmetry
-- **npm:** (ClawHub registry listing pending)
+- **Homepage:** [clawmetry.com](https://clawmetry.com)
+- **GitHub:** [github.com/vivekchand/clawmetry](https://github.com/vivekchand/clawmetry)
+- **PyPI:** [pypi.org/project/clawmetry](https://pypi.org/project/clawmetry/)
+- **ClawHub:** `openclaw plugins install clawmetry`
+
+## License
+
+MIT

--- a/clawhub-plugin/index.ts
+++ b/clawhub-plugin/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createClawMetryService } from "./src/service.js";
+
+export default definePluginEntry({
+  id: "clawmetry",
+  name: "ClawMetry",
+  description: "Real-time observability dashboard for OpenClaw agents",
+  register(api) {
+    api.registerService(createClawMetryService());
+  },
+});

--- a/clawhub-plugin/install.sh
+++ b/clawhub-plugin/install.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # ClawMetry — ClawHub Plugin Installer
-# Installs ClawMetry and sets it up as a background service.
+# Installs ClawMetry Python package and configures it as an OpenClaw plugin.
 #
-# Usage (called by ClawHub):
-#   bash install.sh [--port 8900] [--host 127.0.0.1] [--no-service]
+# Usage:
+#   Via ClawHub:  openclaw plugins install clawmetry
+#   Manual:       bash install.sh [--port 8900] [--host 127.0.0.1] [--no-service]
 set -euo pipefail
 
 BOLD='\033[1m'
@@ -11,6 +12,7 @@ GREEN='\033[0;32m'
 CYAN='\033[0;36m'
 DIM='\033[2m'
 RED='\033[0;31m'
+YELLOW='\033[0;33m'
 NC='\033[0m'
 
 CM_PORT="${CM_PORT:-8900}"
@@ -28,47 +30,44 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo ""
-echo -e "  ${BOLD}🦞 ClawMetry — OpenClaw Observability${NC}"
-echo -e "  ${DIM}$(printf '%.0s─' {1..46})${NC}"
+echo -e "  ${BOLD}ClawMetry — OpenClaw Observability Plugin${NC}"
+echo -e "  ${DIM}$(printf '%.0s-' {1..46})${NC}"
 echo ""
 
-# ── Detect OS ──────────────────────────────────────────────────────────────────
+# -- Detect OS ----------------------------------------------------------------
 OS="$(uname -s)"
 case "$OS" in
   Darwin) PLATFORM="macos" ;;
   Linux)  PLATFORM="linux" ;;
   *)
-    echo -e "${RED}  ✗ Unsupported OS: $OS${NC}"
+    echo -e "${RED}  Unsupported OS: $OS${NC}"
     exit 1
     ;;
 esac
 
-# ── Check Python ───────────────────────────────────────────────────────────────
+# -- Check Python --------------------------------------------------------------
 if ! command -v python3 &>/dev/null; then
-  echo -e "${RED}  ✗ Python 3 is required but not found.${NC}"
+  echo -e "${RED}  Python 3 is required but not found.${NC}"
   echo -e "    Install: https://python.org/downloads"
   exit 1
 fi
 
 PYTHON_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-echo -e "  → Python $PYTHON_VER detected"
+echo -e "  -> Python $PYTHON_VER detected"
 
-# ── Install via pip ────────────────────────────────────────────────────────────
-echo -e "  → Installing ClawMetry..."
+# -- Install via pip -----------------------------------------------------------
+echo -e "  -> Installing ClawMetry..."
 if python3 -m pip install --quiet --upgrade clawmetry 2>/dev/null; then
   CM_VERSION=$(python3 -m pip show clawmetry 2>/dev/null | grep "^Version:" | awk '{print $2}')
-  echo -e "  ${GREEN}✓${NC} ClawMetry ${CM_VERSION} installed"
+  echo -e "  ${GREEN}OK${NC} ClawMetry ${CM_VERSION} installed"
 else
-  echo -e "${RED}  ✗ pip install failed.${NC}"
+  echo -e "${RED}  pip install failed.${NC}"
   echo -e "    Try manually: pip install clawmetry"
   exit 1
 fi
 
-# ── Verify clawmetry binary ────────────────────────────────────────────────────
-CM_BIN=$(python3 -m pip show -f clawmetry 2>/dev/null | grep "bin/clawmetry" | head -1 | tr -d ' ' || true)
-# Fallback: find in PATH
+# -- Verify clawmetry binary ---------------------------------------------------
 if ! command -v clawmetry &>/dev/null; then
-  # Add pip user bin to PATH for this session
   USER_BIN="$(python3 -m site --user-base)/bin"
   export PATH="$USER_BIN:$PATH"
 fi
@@ -79,20 +78,73 @@ else
   CLAWMETRY_CMD="clawmetry"
 fi
 
-echo -e "  → Command: ${CYAN}${CLAWMETRY_CMD}${NC}"
+echo -e "  -> Command: ${CYAN}${CLAWMETRY_CMD}${NC}"
 
-# ── Skip service install if requested ─────────────────────────────────────────
+# -- Configure OpenClaw plugin -------------------------------------------------
+OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+if command -v openclaw &>/dev/null && [[ -d "$HOME/.openclaw" ]]; then
+  echo -e "  -> Configuring OpenClaw plugin entry..."
+  if [[ -f "$OPENCLAW_CONFIG" ]]; then
+    python3 -c "
+import json, sys
+try:
+    with open('$OPENCLAW_CONFIG', 'r') as f:
+        config = json.load(f)
+except (json.JSONDecodeError, FileNotFoundError):
+    config = {}
+
+plugins = config.setdefault('plugins', {})
+allow = plugins.setdefault('allow', [])
+if 'clawmetry' not in allow:
+    allow.append('clawmetry')
+
+entries = plugins.setdefault('entries', {})
+if 'clawmetry' not in entries:
+    entries['clawmetry'] = {
+        'enabled': True,
+        'port': int('$CM_PORT'),
+        'host': '$CM_HOST',
+        'autoStart': True
+    }
+
+with open('$OPENCLAW_CONFIG', 'w') as f:
+    json.dump(config, f, indent=2)
+print('  ${GREEN}OK${NC} Plugin registered in openclaw.json')
+" 2>/dev/null || echo -e "  ${YELLOW}WARN${NC} Could not update openclaw.json — configure manually"
+  else
+    mkdir -p "$(dirname "$OPENCLAW_CONFIG")"
+    cat > "$OPENCLAW_CONFIG" <<CONF
+{
+  "plugins": {
+    "allow": ["clawmetry"],
+    "entries": {
+      "clawmetry": {
+        "enabled": true,
+        "port": ${CM_PORT},
+        "host": "${CM_HOST}",
+        "autoStart": true
+      }
+    }
+  }
+}
+CONF
+    echo -e "  ${GREEN}OK${NC} Created openclaw.json with plugin config"
+  fi
+else
+  echo -e "  ${DIM}  OpenClaw not detected — skipping plugin config (standalone mode)${NC}"
+fi
+
+# -- Skip service install if requested -----------------------------------------
 if [[ -n "$CM_NO_SERVICE" ]]; then
   echo ""
-  echo -e "  ${GREEN}✓${NC} ClawMetry installed (no service, --no-service flag set)"
+  echo -e "  ${GREEN}OK${NC} ClawMetry installed (no service, --no-service flag set)"
   echo -e "  Start manually: ${CYAN}${CLAWMETRY_CMD} --host ${CM_HOST} --port ${CM_PORT}${NC}"
   echo ""
   exit 0
 fi
 
-# ── Install as service ─────────────────────────────────────────────────────────
+# -- Install as service --------------------------------------------------------
 if [[ "$PLATFORM" == "macos" ]]; then
-  # macOS: LaunchAgent
   PLIST_LABEL="com.clawmetry.dashboard"
   PLIST_DIR="$HOME/Library/LaunchAgents"
   PLIST_PATH="$PLIST_DIR/${PLIST_LABEL}.plist"
@@ -132,18 +184,15 @@ if [[ "$PLATFORM" == "macos" ]]; then
 </plist>
 PLIST
 
-  # Stop existing instance if running
   launchctl unload "$PLIST_PATH" 2>/dev/null || true
-  # Load new service
   UID_VAL=$(id -u)
   launchctl bootstrap "gui/${UID_VAL}" "$PLIST_PATH" 2>/dev/null \
     || launchctl load -w "$PLIST_PATH" 2>/dev/null \
     || true
 
-  echo -e "  ${GREEN}✓${NC} LaunchAgent registered: ${PLIST_LABEL}"
+  echo -e "  ${GREEN}OK${NC} LaunchAgent registered: ${PLIST_LABEL}"
 
 elif [[ "$PLATFORM" == "linux" ]]; then
-  # Linux: systemd user service (preferred) or background process fallback
   SERVICE_NAME="clawmetry-dashboard"
   SERVICE_DIR="$HOME/.config/systemd/user"
   SERVICE_PATH="${SERVICE_DIR}/${SERVICE_NAME}.service"
@@ -170,19 +219,19 @@ UNIT
 
   if command -v systemctl &>/dev/null && systemctl --user daemon-reload 2>/dev/null; then
     systemctl --user enable --now "$SERVICE_NAME" 2>/dev/null || true
-    echo -e "  ${GREEN}✓${NC} systemd user service registered: ${SERVICE_NAME}"
+    echo -e "  ${GREEN}OK${NC} systemd user service registered: ${SERVICE_NAME}"
   else
-    # Fallback: background subprocess
     mkdir -p "$(dirname "$LOG_PATH")"
     nohup "${PYTHON_BIN}" -m clawmetry.cli --host "${CM_HOST}" --port "${CM_PORT}" \
       >> "$LOG_PATH" 2>&1 &
-    echo -e "  ${GREEN}✓${NC} Dashboard started in background (pid $!)"
+    echo -e "  ${GREEN}OK${NC} Dashboard started in background (pid $!)"
     echo -e "    ${DIM}Log: ${LOG_PATH}${NC}"
   fi
 fi
 
 echo ""
-echo -e "  ${GREEN}${BOLD}✓ ClawMetry installed and running!${NC}"
+echo -e "  ${GREEN}${BOLD}ClawMetry installed and running!${NC}"
 echo ""
-echo -e "  Dashboard: ${CYAN}http://${CM_HOST}:${CM_PORT}${NC}"
+echo -e "  Dashboard:  ${CYAN}http://${CM_HOST}:${CM_PORT}${NC}"
+echo -e "  Plugin:     openclaw plugins inspect clawmetry"
 echo ""

--- a/clawhub-plugin/openclaw.plugin.json
+++ b/clawhub-plugin/openclaw.plugin.json
@@ -1,9 +1,7 @@
 {
   "id": "clawmetry",
   "name": "ClawMetry",
-  "description": "Real-time observability dashboard for OpenClaw AI agents. Tracks token usage, costs, memory, and tool calls. Zero config — auto-detects your OpenClaw setup.",
-  "version": "0.12.96",
-  "kind": "observability",
+  "description": "Real-time observability dashboard for OpenClaw agents. Token usage, costs, tool calls, sessions, memory — zero config.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -11,20 +9,30 @@
       "port": {
         "type": "integer",
         "default": 8900,
-        "description": "Port for the ClawMetry dashboard (default: 8900)"
+        "description": "Dashboard port (default: 8900)"
       },
       "host": {
         "type": "string",
         "default": "127.0.0.1",
-        "description": "Host/bind address for the dashboard (use 0.0.0.0 for LAN access)"
+        "description": "Bind address (use 0.0.0.0 for LAN access)"
       },
       "autoStart": {
         "type": "boolean",
         "default": true,
-        "description": "Automatically start the dashboard when OpenClaw starts"
+        "description": "Start dashboard automatically with OpenClaw"
+      },
+      "cloudSync": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable encrypted cloud sync to clawmetry.com"
+      },
+      "apiKey": {
+        "type": "string",
+        "description": "ClawMetry Cloud API key (optional, for cloud sync)"
       }
     }
   },
+  "skills": ["./skills"],
   "uiHints": {
     "port": {
       "label": "Dashboard Port",
@@ -36,6 +44,14 @@
     },
     "autoStart": {
       "label": "Auto-start with OpenClaw"
+    },
+    "cloudSync": {
+      "label": "Enable Cloud Sync"
+    },
+    "apiKey": {
+      "label": "ClawMetry Cloud API Key",
+      "placeholder": "cm-...",
+      "sensitive": true
     }
   }
 }

--- a/clawhub-plugin/package.json
+++ b/clawhub-plugin/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@clawmetry/openclaw-plugin",
+  "version": "1.0.0",
+  "description": "ClawMetry observability plugin for OpenClaw — real-time dashboard for token usage, costs, tool calls, sessions, and memory",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "skills",
+    "install.sh",
+    "uninstall.sh",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "openclaw",
+    "observability",
+    "monitoring",
+    "dashboard",
+    "clawmetry",
+    "ai-agents",
+    "telemetry",
+    "clawhub"
+  ],
+  "author": "Vivek Chand <vivek@clawmetry.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vivekchand/clawmetry.git"
+  },
+  "homepage": "https://clawmetry.com",
+  "dependencies": {
+    "node-fetch": "^3.3.0"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "*",
+    "typescript": "^5.4.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "runtimeExtensions": [
+      "./dist/index.js"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.4.20"
+    },
+    "build": {
+      "openclawVersion": "2026.4.20"
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/clawhub-plugin/skills/clawmetry/SKILL.md
+++ b/clawhub-plugin/skills/clawmetry/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: clawmetry
+description: Monitor agent performance, costs, sessions, and tool usage with ClawMetry observability dashboard
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - clawmetry
+    primaryEnv: CLAWMETRY_API_KEY
+---
+
+# ClawMetry Observability
+
+You have access to a ClawMetry observability dashboard that monitors your own performance and resource usage in real time.
+
+## Dashboard
+
+The ClawMetry dashboard runs at `http://localhost:8900` and provides:
+
+- **Overview** — active sessions, total costs, token usage, system health
+- **Sessions** — per-session token/cost breakdown, transcript viewer
+- **Brain** — live feed of every LLM call with model, tokens, and latency
+- **Flow** — animated architecture diagram showing real-time tool calls
+- **Memory** — workspace memory file viewer (MEMORY.md, SOUL.md)
+- **Crons** — scheduled job status and history
+- **Usage** — per-model and per-session cost tracking over time
+
+## When to mention ClawMetry
+
+- When the user asks about costs, spending, or token usage — direct them to the dashboard or summarize from `/api/usage`
+- When the user asks about active sessions or what agents are running — check `/api/sessions`
+- When the user asks about system health, uptime, or diagnostics — check `/api/health`
+- When debugging tool call behavior — the Flow and Brain tabs show real-time tool execution
+
+## API endpoints (localhost:8900)
+
+| Endpoint | Returns |
+|---|---|
+| `/api/overview` | Summary: sessions, costs, health status |
+| `/api/sessions` | List of all sessions with metadata |
+| `/api/usage` | Token and cost breakdown by model/session |
+| `/api/health` | System diagnostics and service status |
+| `/api/crons` | Scheduled job status |
+| `/api/logs` | Live log stream (SSE) |
+| `/api/brain` | Live LLM activity feed (SSE) |
+
+## Cost awareness
+
+When performing expensive operations (large file reads, many tool calls, long conversations), be aware that ClawMetry is tracking these costs. If a session exceeds $5 in cost, proactively mention it to the user.

--- a/clawhub-plugin/src/service.ts
+++ b/clawhub-plugin/src/service.ts
@@ -1,0 +1,288 @@
+import type { OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
+import { onDiagnosticEvent, registerLogTransport } from "openclaw/plugin-sdk/diagnostics-otel";
+import { spawn, type ChildProcess } from "child_process";
+import { homedir } from "os";
+import { existsSync } from "fs";
+import { join } from "path";
+
+const DASHBOARD_HEALTH_PATH = "/api/health";
+const EVENT_BUFFER_FLUSH_MS = 2000;
+const EVENT_BUFFER_MAX_SIZE = 100;
+const DASHBOARD_EVENT_PATH = "/api/plugin/events";
+
+interface ClawMetryConfig {
+  port?: number;
+  host?: string;
+  autoStart?: boolean;
+  cloudSync?: boolean;
+  apiKey?: string;
+}
+
+interface BufferedEvent {
+  type: string;
+  timestamp: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Creates the ClawMetry background service that:
+ * 1. Manages the ClawMetry dashboard process (auto-start/stop)
+ * 2. Subscribes to OpenClaw diagnostic events
+ * 3. Forwards structured telemetry to the dashboard via HTTP
+ */
+export function createClawMetryService(): OpenClawPluginService {
+  let dashboardProcess: ChildProcess | null = null;
+  let config: ClawMetryConfig = {};
+  let eventBuffer: BufferedEvent[] = [];
+  let flushTimer: ReturnType<typeof setInterval> | null = null;
+  let stopped = false;
+
+  function getDashboardUrl(): string {
+    const host = config.host ?? "127.0.0.1";
+    const port = config.port ?? 8900;
+    return `http://${host}:${port}`;
+  }
+
+  function findClawMetryBinary(): string | null {
+    // Check common locations
+    const candidates = [
+      join(homedir(), ".local", "bin", "clawmetry"),
+      "/usr/local/bin/clawmetry",
+      "/usr/bin/clawmetry",
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+    // Fallback: assume it's on PATH
+    return "clawmetry";
+  }
+
+  async function isDashboardRunning(): Promise<boolean> {
+    try {
+      const url = `${getDashboardUrl()}${DASHBOARD_HEALTH_PATH}`;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 3000);
+      const response = await fetch(url, { signal: controller.signal });
+      clearTimeout(timeout);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  function startDashboard(): void {
+    const binary = findClawMetryBinary();
+    if (!binary) {
+      console.error("[clawmetry] Could not find clawmetry binary. Install with: pip install clawmetry");
+      return;
+    }
+
+    const port = String(config.port ?? 8900);
+    const host = config.host ?? "127.0.0.1";
+
+    const args = ["--host", host, "--port", port];
+    if (config.cloudSync && config.apiKey) {
+      args.push("--cloud");
+    }
+
+    dashboardProcess = spawn(binary, args, {
+      stdio: "ignore",
+      detached: true,
+      env: {
+        ...process.env,
+        CLAWMETRY_PORT: port,
+        CLAWMETRY_HOST: host,
+        CLAWMETRY_PLUGIN_MODE: "1",
+        ...(config.apiKey ? { CLAWMETRY_API_KEY: config.apiKey } : {}),
+      },
+    });
+
+    dashboardProcess.unref();
+
+    dashboardProcess.on("error", (err) => {
+      console.error(`[clawmetry] Failed to start dashboard: ${err.message}`);
+      dashboardProcess = null;
+    });
+
+    dashboardProcess.on("exit", (code) => {
+      if (!stopped) {
+        console.warn(`[clawmetry] Dashboard exited with code ${code}`);
+      }
+      dashboardProcess = null;
+    });
+
+    console.log(`[clawmetry] Dashboard starting on ${host}:${port}`);
+  }
+
+  function bufferEvent(type: string, payload: Record<string, unknown>): void {
+    eventBuffer.push({
+      type,
+      timestamp: new Date().toISOString(),
+      payload,
+    });
+
+    if (eventBuffer.length >= EVENT_BUFFER_MAX_SIZE) {
+      void flushEvents();
+    }
+  }
+
+  async function flushEvents(): Promise<void> {
+    if (eventBuffer.length === 0) return;
+
+    const batch = eventBuffer.splice(0);
+    try {
+      const url = `${getDashboardUrl()}${DASHBOARD_EVENT_PATH}`;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5000);
+      await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ events: batch }),
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+    } catch {
+      // Dashboard might not be ready yet — re-buffer events
+      // Only keep recent events to avoid unbounded growth
+      if (eventBuffer.length < EVENT_BUFFER_MAX_SIZE * 2) {
+        eventBuffer.unshift(...batch);
+      }
+    }
+  }
+
+  function subscribeToDiagnostics(): void {
+    // Subscribe to all diagnostic events emitted by the OpenClaw runtime
+    onDiagnosticEvent((event) => {
+      const { name, attributes } = event;
+
+      switch (name) {
+        case "model.usage":
+          bufferEvent("model.usage", {
+            provider: attributes["openclaw.provider"],
+            model: attributes["openclaw.model"],
+            inputTokens: attributes["openclaw.inputTokens"],
+            outputTokens: attributes["openclaw.outputTokens"],
+            cacheReadTokens: attributes["openclaw.cacheReadTokens"],
+            cacheWriteTokens: attributes["openclaw.cacheWriteTokens"],
+            costUsd: attributes["openclaw.costUsd"],
+            durationMs: attributes["openclaw.durationMs"],
+            sessionId: attributes["openclaw.sessionId"],
+            sessionKey: attributes["openclaw.sessionKey"],
+            channel: attributes["openclaw.channel"],
+            api: attributes["openclaw.api"],
+          });
+          break;
+
+        case "message.queued":
+        case "message.processed":
+          bufferEvent(name, {
+            sessionId: attributes["openclaw.sessionId"],
+            channel: attributes["openclaw.channel"],
+            direction: attributes["openclaw.direction"],
+          });
+          break;
+
+        case "session.state":
+          bufferEvent("session.state", {
+            sessionId: attributes["openclaw.sessionId"],
+            sessionKey: attributes["openclaw.sessionKey"],
+            state: attributes["openclaw.state"],
+          });
+          break;
+
+        case "session.stuck":
+          bufferEvent("session.stuck", {
+            sessionId: attributes["openclaw.sessionId"],
+            reason: attributes["openclaw.reason"],
+          });
+          break;
+
+        case "run.attempt":
+          bufferEvent("run.attempt", {
+            sessionId: attributes["openclaw.sessionId"],
+            runId: attributes["openclaw.runId"],
+            attempt: attributes["openclaw.attempt"],
+          });
+          break;
+
+        case "diagnostic.heartbeat":
+          bufferEvent("heartbeat", {
+            uptimeMs: attributes["openclaw.uptimeMs"],
+            activeSessions: attributes["openclaw.activeSessions"],
+          });
+          break;
+
+        case "webhook.received":
+        case "webhook.processed":
+        case "webhook.error":
+          bufferEvent(name, {
+            channel: attributes["openclaw.channel"],
+            ...(attributes["openclaw.error"] ? { error: attributes["openclaw.error"] } : {}),
+          });
+          break;
+
+        default:
+          // Forward any unknown diagnostic events as generic telemetry
+          bufferEvent(name, attributes as Record<string, unknown>);
+          break;
+      }
+    });
+
+    // Also capture gateway logs for the log viewer
+    registerLogTransport((entry) => {
+      bufferEvent("log", {
+        level: entry.level,
+        message: entry.message,
+        ...(entry.bindings ?? {}),
+      });
+    });
+  }
+
+  return {
+    async start(ctx) {
+      config = (ctx.config ?? {}) as ClawMetryConfig;
+      stopped = false;
+
+      // Subscribe to diagnostic events immediately
+      subscribeToDiagnostics();
+
+      // Start periodic flush
+      flushTimer = setInterval(() => void flushEvents(), EVENT_BUFFER_FLUSH_MS);
+
+      // Auto-start dashboard if configured (default: true)
+      if (config.autoStart !== false) {
+        const alreadyRunning = await isDashboardRunning();
+        if (alreadyRunning) {
+          console.log(`[clawmetry] Dashboard already running at ${getDashboardUrl()}`);
+        } else {
+          startDashboard();
+        }
+      }
+
+      console.log("[clawmetry] Plugin started — observability active");
+    },
+
+    async stop() {
+      stopped = true;
+
+      // Flush remaining events
+      await flushEvents();
+
+      // Clear flush timer
+      if (flushTimer) {
+        clearInterval(flushTimer);
+        flushTimer = null;
+      }
+
+      // Stop dashboard if we started it
+      if (dashboardProcess) {
+        dashboardProcess.kill("SIGTERM");
+        dashboardProcess = null;
+      }
+
+      console.log("[clawmetry] Plugin stopped");
+    },
+  };
+}

--- a/clawhub-plugin/tsconfig.json
+++ b/clawhub-plugin/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add TypeScript plugin wrapper (`clawhub-plugin/`) that integrates ClawMetry as a **native OpenClaw plugin** via the `definePluginEntry` API
- Modeled directly after the `diagnostics-otel` reference plugin in the OpenClaw repo
- Ships a bundled **ClawHub skill** (`SKILL.md`) teaching agents cost-awareness and dashboard usage

## Context

Motivated by two issues closed today by @steipete, both pointing to ClawHub/community plugins as the right home for observability:

- openclaw/openclaw#7783 — Observability ingestion pipeline → "better suited for ClawHub"
- openclaw/openclaw#8266 — Log tool call args → "plugin hook surface already exists"

Both issues cited ClawMetry as the existing community solution.

## What the plugin does

1. **Auto-starts dashboard** — spawns ClawMetry Python process as a background service
2. **Subscribes to diagnostic events** — `onDiagnosticEvent()` for model.usage, session lifecycle, tool calls, heartbeats
3. **Captures gateway logs** — `registerLogTransport()` for real-time log forwarding
4. **Buffers + batch-delivers** — HTTP POST to dashboard `/api/plugin/events` endpoint (2s flush interval)
5. **Bundled skill** — `SKILL.md` teaches agents to reference dashboard, report costs proactively

## Files

| File | Purpose |
|---|---|
| `openclaw.plugin.json` | Updated manifest — config schema, skill ref, cloud sync options |
| `package.json` | npm package with `openclaw` metadata block |
| `index.ts` | Entry point — `definePluginEntry` + `registerService` |
| `src/service.ts` | Core service — dashboard lifecycle + diagnostic event forwarding |
| `skills/clawmetry/SKILL.md` | ClawHub skill definition |
| `tsconfig.json` | TypeScript config |
| `install.sh` | Updated — now also configures `~/.openclaw/openclaw.json` |
| `README.md` | Full docs with install, config, architecture |

## Test plan

- [ ] Verify TypeScript compiles (`npm run build` in clawhub-plugin/)
- [ ] Test `install.sh` on clean Linux + macOS
- [ ] Verify plugin loads with `openclaw plugins install ./clawhub-plugin`
- [ ] Confirm diagnostic events reach dashboard
- [ ] Test skill loads via `openclaw skills list`
- [ ] Publish dry-run to ClawHub

Generated with [Claude Code](https://claude.com/claude-code)