### PR TITLE
fix: rename plugin package to clawmetry-plugin for ClawHub

### DIFF
--- a/clawhub-plugin/package.json
+++ b/clawhub-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@clawmetry/openclaw-plugin",
+  "name": "clawmetry-plugin",
   "version": "1.0.0",
   "description": "ClawMetry observability plugin for OpenClaw — real-time dashboard for token usage, costs, tool calls, sessions, and memory",
   "type": "module",


### PR DESCRIPTION
## Summary

- Rename `@clawmetry/openclaw-plugin` to `clawmetry-plugin` in package.json
- ClawHub rejects package names that collide with existing skill slugs — the skill is `clawmetry`, so the plugin package must be `clawmetry-plugin`

Already published to ClawHub as `clawmetry-plugin@1.0.0`.

Generated with [Claude Code](https://claude.com/claude-code)