### PR TITLE
fix(skills): don't show note twice on empty state

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7750,7 +7750,9 @@ function openCompModal(nodeId) {
         });
         html += '</div>';
       }
-      if (data.note) {
+      // Only show the trailing note when we DO have skills — empty-state
+      // already renders the note inline above. Otherwise we'd show it twice.
+      if (data.note && skills.length > 0) {
         html += '<div style="margin-top:12px;font-size:10px;color:var(--text-muted);font-style:italic;text-align:center;">' + escapeHtml(data.note) + '</div>';
       }
       sBody.innerHTML = html;


### PR DESCRIPTION
Trailing note block at the bottom of the Skills modal renderer was unconditional, causing 'No skill invocations detected.' to appear twice when skills array was empty. Now only renders when there ARE skills.