### PR TITLE
[RELEASE] fix: 3 user-reported UI bugs (Brain stream layout, Cost Optimizer button, subagent brain events)

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -79,9 +79,16 @@
   .zoom-level { font-size: 11px; color: var(--text-muted); font-weight: 600; min-width: 36px; text-align: center; }
   .nav-tabs { display: flex; gap: 4px; margin-left: auto; position: relative; }
   /* Brain tab */
-  .brain-event { display:flex; align-items:flex-start; gap:10px; padding:5px 0; border-bottom:1px solid var(--border); font-size:12px; font-family:monospace; flex-wrap:nowrap; cursor:pointer; transition:background 0.15s; }
+  /* Always allow the row to wrap so the turn-summary badges go BELOW the
+     detail text instead of competing with it for horizontal space — the
+     detail was getting compressed to ~40% of viewport with massive
+     whitespace to the right. */
+  .brain-event { display:flex; align-items:flex-start; gap:10px; padding:5px 0; border-bottom:1px solid var(--border); font-size:12px; font-family:monospace; flex-wrap:wrap; cursor:pointer; transition:background 0.15s; }
   .brain-event:hover { background:rgba(255,255,255,0.02); }
   .brain-event.expanded { flex-wrap:wrap; }
+  /* Force the per-turn summary onto its own row, full-width, indented past
+     the time column so it visually attaches to the event above. */
+  .brain-event > .brain-turn-summary { flex-basis: 100%; width: 100%; margin-left: 80px; margin-top: 4px; }
   .brain-event.expanded .brain-detail { white-space:pre-wrap; overflow:visible; text-overflow:unset; }
   .brain-meta { display:contents; } /* Desktop: render children directly in brain-event flex row */
   .brain-time { color:var(--text-muted); min-width:70px; }

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8685,7 +8685,13 @@ function loadCostOptimizerData(isRefresh) {
       html += '<div class="co-ollama-prompt">';
       html += '<div style="font-size:13px;color:#a78bfa;font-weight:600;">⚠️ Ollama not installed -- install to run models locally (free!)</div>';
       html += '<div class="co-ollama-cmd">' + escapeHtml(_ollamaInstall) + '</div>';
-      html += '<button class="co-action-btn" onclick="navigator.clipboard.writeText(' + JSON.stringify(_ollamaInstall) + ');this.textContent=\'✅ Copied!\';setTimeout(()=>this.textContent=\'📋 Copy Install Command\',2000);">📋 Copy Install Command</button>';
+      // JSON.stringify(_ollamaInstall) produces "..." with literal " which
+      // collides with the onclick="..." double-quoted attribute and breaks
+      // out of the attribute scope (rendering raw JS inside the button).
+      // Encode " as &quot; so the HTML parser treats it as a literal quote
+      // inside the attribute, then the JS still sees a proper string.
+      var _esc1 = JSON.stringify(_ollamaInstall).replace(/"/g, '&quot;');
+      html += '<button class="co-action-btn" onclick="navigator.clipboard.writeText(' + _esc1 + ');this.textContent=\'✅ Copied!\';setTimeout(()=>this.textContent=\'📋 Copy Install Command\',2000);">📋 Copy Install Command</button>';
       html += '</div>';
     }
 
@@ -8744,7 +8750,8 @@ function loadCostOptimizerData(isRefresh) {
     html += '<div class="co-section">';
     html += '<h3>⚙️ Quick Actions</h3>';
     html += '<div style="display:flex;gap:8px;flex-wrap:wrap;">';
-    html += '<button class="co-action-btn" style="width:auto;padding:6px 14px;" onclick="navigator.clipboard.writeText(' + JSON.stringify(_ollamaInstall) + ');this.textContent=\'✅ Copied!\';setTimeout(()=>this.textContent=\'📋 Install Ollama\',2000);">📋 Install Ollama</button>';
+    var _esc2 = JSON.stringify(_ollamaInstall).replace(/"/g, '&quot;');
+    html += '<button class="co-action-btn" style="width:auto;padding:6px 14px;" onclick="navigator.clipboard.writeText(' + _esc2 + ');this.textContent=\'✅ Copied!\';setTimeout(()=>this.textContent=\'📋 Install Ollama\',2000);">📋 Install Ollama</button>';
     html += '<button class="co-action-btn secondary" style="width:auto;padding:6px 14px;" onclick="navigator.clipboard.writeText(\'ollama serve\');this.textContent=\'✅ Copied!\';setTimeout(()=>this.textContent=\'📋 ollama serve\',2000);">📋 ollama serve</button>';
     html += '<a class="co-action-btn secondary" style="width:auto;padding:6px 14px;text-decoration:none;display:inline-block;" href="https://ollama.com/search" target="_blank">🔍 Browse Models</a>';
     html += '</div>';
@@ -9750,7 +9757,13 @@ async function _renderModalBrainEvents(match) {
   try {
     var parentUuid = (match.parent || '').split(':').pop() || '';
     var childUuid  = (match.key || '').split(':').pop() || '';
-    var candidates = [parentUuid, childUuid, match.sessionId].filter(Boolean);
+    // Brain events emit `source` as the on-disk session-file UUID, NOT the
+    // subagent_id. They differ for sub-agents (sessionId + sessionFile are
+    // distinct fields). Without including the file-UUID variant the
+    // spawn-detail "Brain Events" tab said "No Brain events found in window"
+    // even when the sub-agent was actively running.
+    var fileUuid = (match.sessionFile || '').replace(/\.jsonl$/i, '');
+    var candidates = [parentUuid, childUuid, match.sessionId, fileUuid].filter(Boolean);
     if (!candidates.length) return;
 
     var startedMs = match.startedAt || Date.now();

--- a/dashboard.py
+++ b/dashboard.py
@@ -2218,10 +2218,14 @@ DASHBOARD_HTML = r"""
   .zoom-level { font-size: 11px; color: var(--text-muted); font-weight: 600; min-width: 36px; text-align: center; }
   .nav-tabs { display: flex; gap: 4px; margin-left: auto; position: relative; }
   /* Brain tab */
-  .brain-event { display:flex; align-items:flex-start; gap:10px; padding:5px 0; border-bottom:1px solid var(--border); font-size:12px; font-family:monospace; flex-wrap:nowrap; cursor:pointer; transition:background 0.15s; }
+  /* Wrap by default so the turn-summary badges (steps/LLM/tools/duration)
+     live on their own row below the detail, instead of squeezing the
+     detail to ~40% of viewport. */
+  .brain-event { display:flex; align-items:flex-start; gap:10px; padding:5px 0; border-bottom:1px solid var(--border); font-size:12px; font-family:monospace; flex-wrap:wrap; cursor:pointer; transition:background 0.15s; }
   .brain-event:hover { background:rgba(255,255,255,0.02); }
   .brain-event.expanded { flex-wrap:wrap; }
   .brain-event.expanded .brain-detail { white-space:pre-wrap; overflow:visible; text-overflow:unset; }
+  .brain-event > .brain-turn-summary { flex-basis: 100%; width: 100%; margin-left: 80px; margin-top: 4px; }
   .brain-meta { display:contents; } /* Desktop: render children directly in brain-event flex row */
   .brain-time { color:var(--text-muted); min-width:70px; }
   .brain-source { min-width:120px; max-width:200px; font-weight:600; word-break:break-all; flex-shrink:0; }


### PR DESCRIPTION
Three independent user reports, one PR:

1. **Brain stream wraps detail at ~40% viewport** — turn-summary badges competed with .brain-detail for horizontal space. Now: `.brain-event` always wraps, badges go on their own row.
2. **`this.textContent=''` exposed in Cost Optimizer button** — JSON.stringify quotes broke out of the onclick attribute. Now HTML-encodes the embedded " so the parser treats it as literal.
3. **Subagent Brain events not found** — filter only checked subagent_id, but brain events use file-UUID. Now also includes `match.sessionFile`.

All OSS-only.