### PR TITLE
[RELEASE] feat(crons): tabbed Active/Paused views + Calendar agenda + honest 'no data' status

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -195,6 +195,27 @@
   .cron-status.ok { background: var(--bg-success); color: var(--text-success); }
   .cron-status.error { background: var(--bg-error); color: var(--text-error); }
   .cron-status.pending { background: var(--bg-warning); color: var(--text-warning); }
+  .cron-status.no-data { background: rgba(107,114,128,0.18); color: #9ca3af; cursor: help; }
+  .cron-status.stale { background: rgba(245,158,11,0.18); color: #f59e0b; cursor: help; }
+
+  /* Cron view tabs (Active / Paused / Calendar) */
+  .cron-view-tabs { display: flex; gap: 4px; margin-bottom: 10px; padding: 4px; background: var(--bg-secondary); border-radius: 10px; width: fit-content; }
+  .cron-view-tab { background: transparent; border: none; color: var(--text-muted); padding: 6px 14px; border-radius: 7px; font-size: 13px; font-weight: 600; cursor: pointer; transition: background 0.15s, color 0.15s; }
+  .cron-view-tab:hover { color: var(--text-primary); }
+  .cron-view-tab.active { background: var(--bg-tertiary); color: var(--text-primary); box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+  .cron-view-count { font-weight: 500; color: var(--text-muted); margin-left: 4px; font-size: 11px; }
+  .cron-view-tab.active .cron-view-count { color: var(--text-secondary); }
+
+  /* Calendar agenda */
+  .cron-cal-section { font-size: 13px; font-weight: 700; color: var(--text-primary); margin: 8px 0 8px; display: flex; align-items: center; gap: 6px; }
+  .cron-cal-day { background: var(--bg-secondary); border-radius: 8px; margin-bottom: 8px; padding: 8px 12px; }
+  .cron-cal-daylabel { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; font-weight: 600; }
+  .cron-cal-row { display: flex; align-items: center; gap: 12px; padding: 6px 0; border-top: 1px solid rgba(255,255,255,0.04); font-size: 13px; }
+  .cron-cal-row:nth-child(2) { border-top: none; }
+  .cron-cal-time { font-family: 'SF Mono','Fira Code',monospace; color: var(--text-accent); font-size: 12px; min-width: 56px; }
+  .cron-cal-status { width: 18px; text-align: center; }
+  .cron-cal-name { color: var(--text-primary); font-weight: 600; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .cron-cal-sched { font-size: 11px; color: var(--text-muted); font-family: 'SF Mono','Fira Code',monospace; max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   /* Cron error info & fix */
   .cron-error-actions { display: inline-flex; align-items: center; gap: 6px; margin-left: 8px; vertical-align: middle; }

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3720,6 +3720,25 @@ var _cronJobs = [];
 var _cronExpanded = {};
 var _cronAutoRefreshTimer = null;
 var _cronActionsAvailable = false;
+var _cronView = 'active'; // 'active' | 'paused' | 'calendar'
+
+function setCronView(view) {
+  _cronView = view;
+  document.querySelectorAll('.cron-view-tab').forEach(function(b) {
+    if (b.dataset.view === view) b.classList.add('active'); else b.classList.remove('active');
+  });
+  renderCrons();
+}
+
+function _cronStatus(j) {
+  // Honest status: distinguish 'no run history yet' from 'pending'.
+  var s = (j.state && j.state.lastStatus) || j.lastStatus || '';
+  if (s) return s;
+  var lastMs = (j.state && j.state.lastRunAtMs) || (j.lastRun ? Date.parse(j.lastRun) : 0);
+  if (!lastMs) return 'no-data';
+  if (Date.now() - lastMs > 6 * 3600 * 1000) return 'stale';
+  return 'ok';
+}
 
 function toggleCronAutoRefresh() {
   var cb = document.getElementById('cron-auto-refresh');
@@ -3879,21 +3898,52 @@ async function loadCronsMultiNode() {
 }
 
 function renderCrons() {
+  var active = _cronJobs.filter(function(j){ return j.enabled !== false; });
+  var paused = _cronJobs.filter(function(j){ return j.enabled === false; });
+  var ca = document.getElementById('crons-count-active');
+  var cp = document.getElementById('crons-count-paused');
+  if (ca) ca.textContent = active.length ? '(' + active.length + ')' : '';
+  if (cp) cp.textContent = paused.length ? '(' + paused.length + ')' : '';
+
+  var listEl = document.getElementById('crons-list');
+  if (!listEl) return;
+
+  if (_cronView === 'calendar') {
+    renderCronCalendar(active);
+    return;
+  }
+
+  var jobs = _cronView === 'paused' ? paused : active;
+  if (jobs.length === 0) {
+    var msg = _cronView === 'paused'
+      ? 'No paused jobs. Disable any active job to see it here.'
+      : 'No active cron jobs yet. Click "+ New Job" to create one.';
+    listEl.innerHTML = '<div style="color:var(--text-muted);padding:24px;text-align:center;font-size:13px;">' + msg + '</div>';
+    return;
+  }
+
+  renderCronList(jobs);
+}
+
+function renderCronList(jobs) {
   var html = '';
-  _cronJobs.forEach(function(j) {
-    var status = j.state && j.state.lastStatus ? j.state.lastStatus : 'pending';
+  jobs.forEach(function(j) {
+    var status = _cronStatus(j);
     var isEnabled = j.enabled !== false;
     var disabledClass = isEnabled ? '' : ' cron-disabled';
     var expanded = _cronExpanded[j.id];
 
-    // Status badge -- show disabled if not enabled
-    var badgeLabel = isEnabled ? status : 'disabled';
+    var labelMap = {'no-data':'no data','stale':'stale','ok':'ok','error':'error','pending':'pending'};
+    var badgeLabel = isEnabled ? (labelMap[status] || status) : 'disabled';
     var badgeClass = isEnabled ? status : 'pending';
+    var badgeTitle = '';
+    if (status === 'no-data') badgeTitle = 'No run history yet — ClawMetry has not received any runs from your agent for this job. The schedule may still be firing on the agent side.';
+    else if (status === 'stale') badgeTitle = 'Last run was over 6h ago — job may have stopped firing.';
 
     html += '<div class="cron-item' + disabledClass + '" onclick="toggleCronExpand(\'' + escHtml(j.id) + '\')">';
     html += '<div style="display:flex;justify-content:space-between;align-items:center;">';
     html += '<div class="cron-name">' + escHtml(j.name || j.id) + '</div>';
-    html += '<span class="cron-status ' + badgeClass + '">' + badgeLabel + '</span>';
+    html += '<span class="cron-status ' + badgeClass + '" title="' + escHtml(badgeTitle) + '">' + badgeLabel + '</span>';
     if (status === 'error') {
       var errMsg = (j.state && j.state.lastError) ? escHtml(j.state.lastError) : 'Unknown error';
       var errTime = (j.state && j.state.lastRunAtMs) ? new Date(j.state.lastRunAtMs).toLocaleString() : 'Unknown';
@@ -3953,12 +4003,125 @@ function renderCrons() {
 
     html += '</div>';
   });
-  document.getElementById('crons-list').innerHTML = html || 'No cron jobs';
+  document.getElementById('crons-list').innerHTML = html;
 
   // Load run history for expanded items
   Object.keys(_cronExpanded).forEach(function(id) {
     if (_cronExpanded[id]) loadCronRuns(id);
   });
+}
+
+function _cronDayLabel(key) {
+  var dayMs = 86400000;
+  var today = new Date(); today.setHours(0,0,0,0);
+  var d = new Date(key + 'T00:00:00');
+  var diff = Math.round((d - today) / dayMs);
+  var dayName = d.toLocaleDateString('en-US', {weekday:'long', month:'short', day:'numeric'});
+  if (diff === 0) return 'Today &middot; ' + dayName;
+  if (diff === 1) return 'Tomorrow &middot; ' + dayName;
+  if (diff === -1) return 'Yesterday &middot; ' + dayName;
+  if (diff > 0) return 'In ' + diff + ' days &middot; ' + dayName;
+  return Math.abs(diff) + ' days ago &middot; ' + dayName;
+}
+function _cronTimeStr(ts) {
+  return new Date(ts).toLocaleTimeString('en-US', {hour:'2-digit',minute:'2-digit',hour12:false});
+}
+function _cronGroupByDay(items) {
+  var groups = {};
+  items.forEach(function(it) {
+    var key = new Date(it.ts).toISOString().slice(0,10);
+    (groups[key] = groups[key] || []).push(it);
+  });
+  return groups;
+}
+
+function renderCronCalendar(jobs) {
+  var listEl = document.getElementById('crons-list');
+  if (!listEl) return;
+  var now = Date.now();
+  var dayMs = 86400000;
+  var future = now + 7 * dayMs;
+  var past = now - 7 * dayMs;
+
+  var upcoming = [];
+  var recent = [];
+  jobs.forEach(function(j) {
+    var nextMs = j.state && j.state.nextRunAtMs;
+    if (nextMs && nextMs >= now && nextMs <= future) upcoming.push({ts: nextMs, job: j});
+    var lastMs = j.state && j.state.lastRunAtMs;
+    if (lastMs && lastMs >= past && lastMs <= now) {
+      recent.push({ts: lastMs, job: j, status: j.state.lastStatus || 'unknown'});
+    }
+  });
+  upcoming.sort(function(a,b){return a.ts - b.ts;});
+  recent.sort(function(a,b){return b.ts - a.ts;});
+
+  var html = '<div style="padding:12px;">';
+
+  // Summary tiles
+  html += '<div style="display:flex;gap:10px;margin-bottom:14px;flex-wrap:wrap;">';
+  [
+    {label:'Coming up (7d)', val: upcoming.length},
+    {label:'Ran (last 7d)',   val: recent.length},
+    {label:'Active jobs',     val: jobs.length},
+  ].forEach(function(t) {
+    html += '<div style="background:var(--bg-secondary);border-radius:8px;padding:10px 16px;flex:1;min-width:130px;">';
+    html += '<div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">' + t.label + '</div>';
+    html += '<div style="font-size:22px;font-weight:700;color:var(--text-primary);margin-top:2px;">' + t.val + '</div>';
+    html += '</div>';
+  });
+  html += '</div>';
+
+  if (upcoming.length === 0 && recent.length === 0) {
+    html += '<div style="background:var(--bg-secondary);border-radius:8px;padding:24px;text-align:center;color:var(--text-muted);font-size:13px;line-height:1.6;">';
+    html += '<div style="font-size:30px;margin-bottom:8px;">&#x1F4C5;</div>';
+    html += '<div><strong style="color:var(--text-primary);">No schedule data available yet.</strong></div>';
+    html += '<div style="margin-top:6px;max-width:480px;margin-left:auto;margin-right:auto;">ClawMetry shows runs once your agent reports them. If your jobs are scheduled but not running here, check the agent’s gateway connection or wait for the next scheduled fire.</div>';
+    html += '</div></div>';
+    listEl.innerHTML = html;
+    return;
+  }
+
+  if (upcoming.length > 0) {
+    html += '<div class="cron-cal-section">&#x1F552; Coming up</div>';
+    var upGroups = _cronGroupByDay(upcoming);
+    Object.keys(upGroups).sort().forEach(function(k) {
+      html += '<div class="cron-cal-day">';
+      html += '<div class="cron-cal-daylabel">' + _cronDayLabel(k) + '</div>';
+      upGroups[k].forEach(function(it) {
+        html += '<div class="cron-cal-row">';
+        html += '<div class="cron-cal-time">' + _cronTimeStr(it.ts) + '</div>';
+        html += '<div class="cron-cal-status" style="color:var(--text-muted);">&#x231B;</div>';
+        html += '<div class="cron-cal-name">' + escHtml(it.job.name || it.job.id) + '</div>';
+        html += '<div class="cron-cal-sched">' + escHtml(formatSchedule(it.job.schedule)) + '</div>';
+        html += '</div>';
+      });
+      html += '</div>';
+    });
+  }
+
+  if (recent.length > 0) {
+    html += '<div class="cron-cal-section" style="margin-top:18px;">&#x2714;&#xFE0F; Recently ran</div>';
+    var pastGroups = _cronGroupByDay(recent);
+    Object.keys(pastGroups).sort().reverse().forEach(function(k) {
+      html += '<div class="cron-cal-day">';
+      html += '<div class="cron-cal-daylabel">' + _cronDayLabel(k) + '</div>';
+      pastGroups[k].forEach(function(it) {
+        var color = it.status === 'error' ? '#ef4444' : (it.status === 'ok' ? '#22c55e' : '#9ca3af');
+        var icon  = it.status === 'error' ? '&#x274C;' : (it.status === 'ok' ? '&#x2705;' : '&#x25CF;');
+        html += '<div class="cron-cal-row">';
+        html += '<div class="cron-cal-time">' + _cronTimeStr(it.ts) + '</div>';
+        html += '<div class="cron-cal-status" style="color:' + color + ';">' + icon + '</div>';
+        html += '<div class="cron-cal-name">' + escHtml(it.job.name || it.job.id) + '</div>';
+        html += '<div class="cron-cal-sched">' + escHtml(formatSchedule(it.job.schedule)) + '</div>';
+        html += '</div>';
+      });
+      html += '</div>';
+    });
+  }
+
+  html += '</div>';
+  listEl.innerHTML = html;
 }
 
 function toggleCronExpand(jobId) {

--- a/clawmetry/templates/tabs/crons.html
+++ b/clawmetry/templates/tabs/crons.html
@@ -19,6 +19,11 @@
   </div>
   <div id="cron-health-panel" style="margin-bottom:12px;"></div>
   <div id="crons-multi-node" style="display:none;margin-bottom:12px;"></div>
+  <div class="cron-view-tabs" role="tablist">
+    <button class="cron-view-tab active" data-view="active" onclick="setCronView('active')">Active <span class="cron-view-count" id="crons-count-active"></span></button>
+    <button class="cron-view-tab" data-view="paused" onclick="setCronView('paused')">Paused <span class="cron-view-count" id="crons-count-paused"></span></button>
+    <button class="cron-view-tab" data-view="calendar" onclick="setCronView('calendar')">&#x1F4C5; Calendar</button>
+  </div>
   <div class="card" id="crons-list">Loading...</div>
   <!-- Cron Health Monitor (GH #302) -->
   <div id="cron-health-anomaly-banner" style="

--- a/dashboard.py
+++ b/dashboard.py
@@ -2332,6 +2332,25 @@ DASHBOARD_HTML = r"""
   .cron-status.ok { background: var(--bg-success); color: var(--text-success); }
   .cron-status.error { background: var(--bg-error); color: var(--text-error); }
   .cron-status.pending { background: var(--bg-warning); color: var(--text-warning); }
+  .cron-status.no-data { background: rgba(107,114,128,0.18); color: #9ca3af; cursor: help; }
+  .cron-status.stale { background: rgba(245,158,11,0.18); color: #f59e0b; cursor: help; }
+
+  /* Cron view tabs (Active / Paused / Calendar) */
+  .cron-view-tabs { display: flex; gap: 4px; margin-bottom: 10px; padding: 4px; background: var(--bg-secondary); border-radius: 10px; width: fit-content; }
+  .cron-view-tab { background: transparent; border: none; color: var(--text-muted); padding: 6px 14px; border-radius: 7px; font-size: 13px; font-weight: 600; cursor: pointer; transition: background 0.15s, color 0.15s; }
+  .cron-view-tab:hover { color: var(--text-primary); }
+  .cron-view-tab.active { background: var(--bg-tertiary); color: var(--text-primary); box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+  .cron-view-count { font-weight: 500; color: var(--text-muted); margin-left: 4px; font-size: 11px; }
+  .cron-view-tab.active .cron-view-count { color: var(--text-secondary); }
+  .cron-cal-section { font-size: 13px; font-weight: 700; color: var(--text-primary); margin: 8px 0 8px; display: flex; align-items: center; gap: 6px; }
+  .cron-cal-day { background: var(--bg-secondary); border-radius: 8px; margin-bottom: 8px; padding: 8px 12px; }
+  .cron-cal-daylabel { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; font-weight: 600; }
+  .cron-cal-row { display: flex; align-items: center; gap: 12px; padding: 6px 0; border-top: 1px solid rgba(255,255,255,0.04); font-size: 13px; }
+  .cron-cal-row:nth-child(2) { border-top: none; }
+  .cron-cal-time { font-family: 'SF Mono','Fira Code',monospace; color: var(--text-accent); font-size: 12px; min-width: 56px; }
+  .cron-cal-status { width: 18px; text-align: center; }
+  .cron-cal-name { color: var(--text-primary); font-weight: 600; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .cron-cal-sched { font-size: 11px; color: var(--text-muted); font-family: 'SF Mono','Fira Code',monospace; max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   /* Cron error info & fix */
   .cron-error-actions { display: inline-flex; align-items: center; gap: 6px; margin-left: 8px; vertical-align: middle; }
@@ -3762,6 +3781,11 @@ function clawmetryLogout(){
   </div>
   <div id="cron-health-panel" style="margin-bottom:12px;"></div>
   <div id="crons-multi-node" style="display:none;margin-bottom:12px;"></div>
+  <div class="cron-view-tabs" role="tablist">
+    <button class="cron-view-tab active" data-view="active" onclick="setCronView('active')">Active <span class="cron-view-count" id="crons-count-active"></span></button>
+    <button class="cron-view-tab" data-view="paused" onclick="setCronView('paused')">Paused <span class="cron-view-count" id="crons-count-paused"></span></button>
+    <button class="cron-view-tab" data-view="calendar" onclick="setCronView('calendar')">&#x1F4C5; Calendar</button>
+  </div>
   <div class="card" id="crons-list">Loading...</div>
   <!-- Cron Health Monitor (GH #302) -->
   <div id="cron-health-anomaly-banner" style="display:none;margin-top:14px;padding:10px 14px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.4);border-radius:8px;color:#ef4444;font-size:13px;font-weight:600;">&#x26A0;&#xFE0F; Anomalies detected in cron jobs — review health table below</div>


### PR DESCRIPTION
## Summary
The Crons page used to be a flat list where every job without a `state.lastStatus` showed a misleading **"pending"** badge — even when the agent had simply not uploaded any run history yet. There was also no way to see at a glance what was scheduled to run next.

This PR addresses the user feedback: *"why are all crons in pending state?"* and *"we can tabs within cron page for active / paused ones — also a calendar view of which all cron ran, what is about to run next day"*.

## What changed
- **Active / Paused tabs** — Active and paused jobs now live in separate tabs with live counts in the tab labels. Empty states are honest, not "Loading…".
- **📅 Calendar tab** — agenda-style view grouped by day:
  - **🕒 Coming up** — jobs with `nextRunAtMs` in the next 7 days, grouped Today / Tomorrow / Day-X
  - **✔️ Recently ran** — jobs with `lastRunAtMs` in the last 7 days, with green/red status icons
  - Three summary tiles at the top: Coming up (7d), Ran (last 7d), Active jobs
  - Clean empty state when the agent has not uploaded run data yet
- **Honest status badges**:
  - `no data` (gray) replaces the misleading `pending` for jobs with no run history (with hover tooltip explaining the agent hasn't uploaded yet)
  - `stale` (amber) for jobs whose last run was >6h ago
  - Existing `ok` / `error` / `disabled` unchanged

CSS classes added to both `static/css/dashboard.css` and the embedded `dashboard.py` copy to keep source-vs-installed renders in sync.

## Verification
Verified locally on `localhost:8903` with mock data covering all three views:
- Active tab: ok / error / **no-data** (honest!) / weekly badges all render correctly
- Paused tab: shows the disabled job with `disabled` badge
- Calendar tab: groups upcoming runs by Today / Tomorrow + recent runs by Today / N days ago, with proper status icons

## Test plan
- [ ] Open Crons tab on a node with no run history → see `no data` badges instead of `pending`
- [ ] Click `Paused` tab → see only disabled jobs
- [ ] Click `📅 Calendar` tab → see agenda layout with upcoming/recent runs
- [ ] Calendar with no data → see honest "No schedule data available yet" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)