### PR TITLE
[RELEASE] fix: Crons nav tab discoverability + AI Model 'API Calls Today' label clarity

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4131,12 +4131,14 @@ function toggleCronExpand(jobId) {
 
 async function loadCronRuns(jobId) {
   try {
-    var data = await fetch('/api/cron/' + encodeURIComponent(jobId) + '/runs').then(r => r.json());
+    var resp = await fetch('/api/cron/' + encodeURIComponent(jobId) + '/runs');
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    var data = await resp.json();
     var el = document.getElementById('cron-runs-' + jobId);
     if (!el) return;
-    var runs = data.runs || [];
+    var runs = (data && data.runs) || [];
     if (runs.length === 0) {
-      el.innerHTML = '<div style="color:var(--text-muted);">No run history available</div>';
+      el.innerHTML = '<div style="color:var(--text-muted);">No run history yet — your agent has not reported any runs for this job.</div>';
       return;
     }
     // Build calendar heatmap (last 30 days)
@@ -4178,7 +4180,7 @@ async function loadCronRuns(jobId) {
     el.innerHTML = h;
   } catch(e) {
     var el = document.getElementById('cron-runs-' + jobId);
-    if (el) el.innerHTML = '<div style="color:var(--text-error);">Failed to load runs</div>';
+    if (el) el.innerHTML = '<div style="color:var(--text-error);">Could not load run history (' + escHtml(String(e.message||e)) + '). The endpoint may be unreachable or your gateway is offline.</div>';
   }
 }
 
@@ -10282,16 +10284,6 @@ async function bootDashboard() {
   (async function backgroundPrefetch() {
     try { await _withTimeout(loadCrons(), 5000, 'crons'); } catch (e) {}
     try { await _withTimeout(loadMemory(), 5000, 'memory'); } catch (e) {}
-    try {
-      var cronData = await _withTimeout(
-        fetch('/api/crons').then(function(r){return r.json();}),
-        3000,
-        'crons-tab-check'
-      );
-      if (cronData && cronData.jobs && cronData.jobs.length > 0) {
-        document.querySelectorAll('#crons-tab').forEach(function(t){ t.style.display = ''; });
-      }
-    } catch(e) {}
   })();
 
   startSystemHealthRefresh();

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8697,8 +8697,14 @@ function loadBrainData(isRefresh) {
     html += '<div style="text-align:center;margin-bottom:14px;"><span style="background:linear-gradient(135deg,#FFD54F,#FF9800);color:#1a1a2e;padding:4px 14px;border-radius:20px;font-size:12px;font-weight:700;letter-spacing:0.5px;">' + escapeHtml(s.model||'unknown') + '</span></div>';
 
     // Stats cards 2x2
+    // Honest count + per-call avg so users can sanity-check the ratio. A "low"
+    // call count with high tokens is normal (cached context + long output);
+    // showing tokens-per-call inline avoids the "only 3 calls?" trust panic.
+    var avgTokPerCall = (s.today_calls||0) > 0 ? Math.round(totalTok / s.today_calls) : 0;
+    var avgTokFmt = avgTokPerCall >= 1e6 ? (avgTokPerCall/1e6).toFixed(1)+'M' : avgTokPerCall >= 1e3 ? (avgTokPerCall/1e3).toFixed(1)+'K' : avgTokPerCall;
+    var callsTooltip = 'API round-trips today (one HTTP request to the LLM provider per call). Cached context tokens are reused across calls and counted as cache_read, not as separate calls. Counts only what your agent has uploaded — sessions still open or pending sync may not be reflected yet.';
     html += '<div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:16px;">';
-    html += '<div style="background:var(--bg-secondary);border-radius:10px;padding:12px 14px;text-align:center;"><div style="font-size:24px;font-weight:700;color:var(--text-primary);">' + (s.today_calls||0) + '</div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;margin-top:2px;">Today\'s Calls</div></div>';
+    html += '<div style="background:var(--bg-secondary);border-radius:10px;padding:12px 14px;text-align:center;cursor:help;" title="' + callsTooltip + '"><div style="font-size:24px;font-weight:700;color:var(--text-primary);">' + (s.today_calls||0) + '</div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;margin-top:2px;">API Calls Today</div>' + (avgTokPerCall ? '<div style="font-size:10px;color:var(--text-tertiary);margin-top:2px;">~' + avgTokFmt + ' tok/call avg</div>' : '') + '</div>';
     html += '<div style="background:var(--bg-secondary);border-radius:10px;padding:12px 14px;text-align:center;"><div style="font-size:24px;font-weight:700;color:var(--text-primary);">' + fmtTok + '</div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;margin-top:2px;">Tokens</div></div>';
     var costColor = parseFloat((s.today_cost||'$0').replace('$','')) > 50 ? '#f59e0b' : parseFloat((s.today_cost||'$0').replace('$','')) > 100 ? '#ef4444' : '#22c55e';
     html += '<div style="background:var(--bg-secondary);border-radius:10px;padding:12px 14px;text-align:center;"><div style="font-size:24px;font-weight:700;color:' + costColor + ';">' + (s.today_cost||'$0.00') + '</div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;margin-top:2px;">Cost</div></div>';
@@ -8770,7 +8776,7 @@ function loadBrainData(isRefresh) {
     }
 
     body.innerHTML = html;
-    document.getElementById('comp-modal-footer').textContent = 'Auto-refreshing - Last updated: ' + new Date().toLocaleTimeString() + ' - ' + (data.total||0) + ' LLM calls today';
+    document.getElementById('comp-modal-footer').textContent = 'Auto-refreshing - Last updated: ' + new Date().toLocaleTimeString() + ' - ' + (data.total||0) + ' API call' + ((data.total||0) === 1 ? '' : 's') + ' synced today (each = one HTTP round-trip to the LLM provider)';
   }).catch(function(e) {
     if (!isCompModalActive(expectedNodeId)) return;
     var msg = String((e && e.message) || 'Unknown error');

--- a/dashboard.py
+++ b/dashboard.py
@@ -3292,7 +3292,7 @@ function clawmetryLogout(){
     <div class="nav-tab" onclick="switchTab('notifications')" title="Slack / Email / PagerDuty / Telegram channels">Notifications</div>
     <div class="nav-tab" onclick="switchTab('context')" title="See what context the LLM receives each turn">Context</div>
     <div class="nav-tab" onclick="switchTab('usage')">Tokens</div>
-    <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')" style="display:none;">Crons</div>
+    <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')">Crons</div>
     <div class="nav-tab" onclick="switchTab('memory')">Memory</div>
     <div class="nav-tab" onclick="switchTab('security')">Security</div>
     <div class="nav-tab" id="nemoclaw-tab" onclick="switchTab('nemoclaw')" style="display:none;">NemoClaw</div>
@@ -8560,7 +8560,7 @@ DASHBOARD_HTML = r"""
     <div class="nav-tab" onclick="switchTab('notifications')" title="Slack / Email / PagerDuty / Telegram channels">Notifications</div>
     <div class="nav-tab" onclick="switchTab('context')" title="See what context the LLM receives each turn">Context</div>
     <div class="nav-tab" onclick="switchTab('usage')">Tokens</div>
-    <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')" style="display:none;">Crons</div>
+    <div class="nav-tab" id="crons-tab" onclick="switchTab('crons')">Crons</div>
     <div class="nav-tab" onclick="switchTab('memory')">Memory</div>
     <div class="nav-tab" onclick="switchTab('security')">Security</div>
     <div class="nav-tab" id="nemoclaw-tab" onclick="switchTab('nemoclaw')" style="display:none;">NemoClaw</div>

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -136,12 +136,8 @@ class TestTabsLoad:
         assert overview.count() > 0, "#page-overview should be active"
 
     def test_crons_tab_loads(self, page: Page):
-        """Clicking Crons tab shows crons page (skipped when tab is hidden)."""
+        """Clicking Crons tab shows crons page (always visible for discoverability)."""
         load_dashboard(page)
-        # Crons tab is hidden by default, shown only when cron data exists
-        crons_tab = page.locator("#crons-tab")
-        if crons_tab.count() == 0 or not crons_tab.is_visible():
-            pytest.skip("Crons tab is hidden (no cron data available)")
         click_tab(page, "Crons")
         crons_page = page.locator("#page-crons")
         assert crons_page.count() > 0, "#page-crons element not found"


### PR DESCRIPTION
## Summary
Two trust-building UX fixes from user testing of v0.12.157:

### 1. Crons nav tab is now always visible
The Crons nav button was hardcoded `display:none` until `/api/crons` returned ≥1 job. New users couldn't discover the page, couldn't see the "+ New Job" button, couldn't browse the new Calendar view. Now it's always visible — the page itself has a clean empty state ("No active cron jobs yet. Click '+ New Job' to create one.").

Also dropped the redundant `crons-tab-check` background fetch in `app.js` and updated the e2e test which previously skipped on empty data.

### 2. "Failed to load runs" → honest error message
Generic catch-all message replaced with the actual reason (e.g. `HTTP 502`, network error). Empty-but-200 responses now read: *"No run history yet — your agent has not reported any runs for this job."*

### 3. AI Model modal — "Today's Calls" trust fix
User panicked at "Today's Calls: 3" while their agent had clearly used 2.3M tokens. The number is technically correct — 3 actual API round-trips, each carrying a 1M+ token cached context — but the label was a trust-killer.

- Label: "Today's Calls" → **"API Calls Today"** (unambiguous: HTTP round-trips, not turns/sessions/messages)
- Sub-text: when calls > 0, show **"~768K tok/call avg"** beneath the count (so a small number with massive avg-tokens self-explains as heavy caching)
- Tooltip on hover: explains "API round-trips today (one HTTP request to the LLM provider per call). Cached context tokens are reused across calls and counted as cache_read, not as separate calls."
- Footer: *"3 LLM calls today"* → *"3 API calls synced today (each = one HTTP round-trip to the LLM provider)"* + plural-aware

## Test plan
- [ ] OSS dashboard → Crons tab visible in nav even with zero jobs
- [ ] Clicking Crons → empty state with "+ New Job" CTA
- [ ] Cloud → Flow → AI Model modal → "API Calls Today" label, hover shows tooltip, sub-line shows "~Xk tok/call avg" when calls > 0
- [ ] Footer reads "X API calls synced today"

🤖 Generated with [Claude Code](https://claude.com/claude-code)