### PR TITLE
feat(alerts): custom token_spike rule type — user-configurable runaway-agent thresholds

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1297,6 +1297,21 @@ def _budget_monitor_loop():
                     if avg_hourly > 0 and hour_cost > avg_hourly * threshold:
                         msg = f"Spending spike: ${hour_cost:.2f} in last hour ({(hour_cost / avg_hourly):.1f}x average)"
                         fired = True
+                elif rtype == "token_spike":
+                    try:
+                        vel = _compute_velocity_status()
+                    except Exception:
+                        vel = None
+                    if vel:
+                        tokens_per_min = vel.get("tokensIn2Min", 0) / 2.0
+                        if tokens_per_min >= threshold:
+                            sid = vel.get("triggeringSession") or ""
+                            sid_hint = f" (session: {sid[:12]}...)" if sid else ""
+                            msg = (
+                                f"Token spike: {int(tokens_per_min):,} tokens/min "
+                                f"(threshold: {int(threshold):,}/min){sid_hint}"
+                            )
+                            fired = True
 
                 if fired:
                     _budget_alert_cooldowns[rule_id] = now
@@ -3371,6 +3386,7 @@ function clawmetryLogout(){
           <select id="alert-type" style="padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
             <option value="threshold">Threshold (daily $ amount)</option>
             <option value="spike">Spike (hourly rate multiplier)</option>
+            <option value="token_spike">Token spike (tokens/min)</option>
           </select>
           <input id="alert-threshold" type="number" step="0.01" min="0" placeholder="Threshold value" style="padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
           <div style="display:flex;gap:8px;flex-wrap:wrap;">
@@ -4741,7 +4757,7 @@ async function loadAlertRules() {
       try { channels = JSON.parse(r.channels); } catch(e) { channels = [r.channels]; }
       html += '<div style="padding:10px;border-bottom:1px solid var(--border-secondary);display:flex;align-items:center;gap:8px;">';
       html += '<span style="font-weight:600;">' + escHtml(r.type) + '</span>';
-      html += '<span style="color:var(--text-accent);">' + (r.type==='spike' ? r.threshold+'x' : '$'+r.threshold) + '</span>';
+      html += '<span style="color:var(--text-accent);">' + (r.type==='spike' ? r.threshold+'x' : (r.type==='token_spike' ? r.threshold.toLocaleString()+' tok/min' : '$'+r.threshold)) + '</span>';
       html += '<span style="color:var(--text-muted);font-size:11px;">' + channels.join(', ') + '</span>';
       html += '<span style="color:var(--text-muted);font-size:11px;">' + r.cooldown_min + 'min cooldown</span>';
       html += '<span style="margin-left:auto;cursor:pointer;color:var(--text-error);font-size:16px;" data-rule-id="'+r.id+'" onclick="deleteAlertRule(this.dataset.ruleId)" title="Delete">&#x1f5d1;</span>';
@@ -7705,6 +7721,21 @@ def _budget_monitor_loop():
                     if avg_hourly > 0 and hour_cost > avg_hourly * threshold:
                         msg = f"Spending spike: ${hour_cost:.2f} in last hour ({(hour_cost / avg_hourly):.1f}x average)"
                         fired = True
+                elif rtype == "token_spike":
+                    try:
+                        vel = _compute_velocity_status()
+                    except Exception:
+                        vel = None
+                    if vel:
+                        tokens_per_min = vel.get("tokensIn2Min", 0) / 2.0
+                        if tokens_per_min >= threshold:
+                            sid = vel.get("triggeringSession") or ""
+                            sid_hint = f" (session: {sid[:12]}...)" if sid else ""
+                            msg = (
+                                f"Token spike: {int(tokens_per_min):,} tokens/min "
+                                f"(threshold: {int(threshold):,}/min){sid_hint}"
+                            )
+                            fired = True
 
                 if fired:
                     _budget_alert_cooldowns[rule_id] = now

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -166,7 +166,7 @@ def api_alert_rules():
         channels = data.get("channels", ["banner"])
         cooldown = data.get("cooldown_min", 30)
         enabled = data.get("enabled", True)
-        if rtype not in ("threshold", "spike", "anomaly", "agent_down"):
+        if rtype not in ("threshold", "spike", "token_spike", "anomaly", "agent_down"):
             return jsonify({"error": "Invalid alert type"}), 400
         if not isinstance(threshold, (int, float)) or threshold <= 0:
             return jsonify({"error": "Threshold must be a positive number"}), 400

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1076,3 +1076,49 @@ class TestSelfConfig:
         assert isinstance(d["summary"], str)
         assert "added_lines" in d
         assert "removed_lines" in d
+
+
+class TestAlertRulesTokenSpike:
+    """Tests for token_spike custom alert rule type."""
+
+    def test_token_spike_rule_accepted(self, api, base_url):
+        """POST /api/alerts/rules accepts a token_spike rule."""
+        body = {
+            "type": "token_spike",
+            "threshold": 25000,
+            "channels": ["banner"],
+            "cooldown_min": 30,
+            "enabled": True,
+        }
+        r = api.post(f"{base_url}/api/alerts/rules", json=body, timeout=10)
+        if r.status_code in (401, 403):
+            return  # auth not available in this env
+        assert r.status_code == 200, (
+            f"Expected 200 for token_spike rule create, got {r.status_code}: {r.text[:200]}"
+        )
+        d = r.json()
+        assert d.get("ok") is True
+        rule_id = d.get("id")
+        assert rule_id, "Response must include rule id"
+
+        try:
+            list_r = api.get(f"{base_url}/api/alerts/rules", timeout=10)
+            assert list_r.status_code == 200
+            rules = list_r.json().get("rules", [])
+            ours = [r for r in rules if r.get("id") == rule_id]
+            assert ours, f"Created rule {rule_id} should appear in list"
+            assert ours[0]["type"] == "token_spike"
+            assert ours[0]["threshold"] == 25000
+        finally:
+            api.delete(f"{base_url}/api/alerts/rules/{rule_id}", timeout=10)
+
+    def test_invalid_rule_type_rejected(self, api, base_url):
+        """POST /api/alerts/rules rejects an unknown rule type."""
+        body = {"type": "definitely_not_a_real_type", "threshold": 1.0}
+        r = api.post(f"{base_url}/api/alerts/rules", json=body, timeout=10)
+        if r.status_code in (401, 403):
+            return
+        assert r.status_code == 400, (
+            f"Expected 400 for invalid rule type, got {r.status_code}: {r.text[:200]}"
+        )
+


### PR DESCRIPTION
## Summary

Adds a new `token_spike` alert rule type so users can configure custom thresholds for runaway-agent detection by sustained token rate (tokens/min over a 2-minute rolling window).

This is the "Token spike alerts — Custom rules for detecting runaway agents" item from the public roadmap (`Planned` column on https://clawmetry.com/roadmap).

## What changes

- `routes/alerts.py`: validator now accepts `"token_spike"` as a valid rule type.
- `dashboard.py`:
  - Custom-rule eval loop: new `elif rtype == "token_spike":` branch that uses the existing `_compute_velocity_status()` infrastructure. Fires when sustained tokens/min ≥ rule threshold. Includes the offending session ID in the alert message when available. Both copies of the eval loop in `dashboard.py` (live + duplicated post-refactor block) were updated.
  - Alert-rule editor dropdown: new `Token spike (tokens/min)` option.
  - Rule list rendering: now formats token_spike rules as `25,000 tok/min` instead of `$25000`.
- `tests/test_api.py`: adds `TestAlertRulesTokenSpike` with two tests: (1) a `token_spike` rule round-trips through POST → list → DELETE, (2) an unknown rule type is rejected with 400.

## Why this design

There is already a global hard-coded `token_velocity` alert (GH#313) that uses the same velocity primitive. This PR exposes that signal as a per-rule, per-user-configurable threshold — closing the "custom rules" gap on the roadmap card. No schema migration required: the existing `alert_rules.threshold` column (REAL) already fits "tokens/min" cleanly.

## Out of scope

- Configurable window size (currently hardcoded at 2 min — matches the existing velocity infrastructure). Easy follow-up if requested.
- Per-session vs fleet-wide threshold. Currently fleet-wide aggregate; per-session would need a separate rule shape.

## Test plan

- [x] `TESTING=1 SKIP_INTEGRATION=1 python3 -m pytest tests/test_api.py::TestAlertRulesTokenSpike -q` — passes locally
- [ ] Manual: open Alerts tab → "Add rule" → select **Token spike (tokens/min)** → set threshold (e.g. 25000) → save → confirm appears in rule list as `25,000 tok/min`
- [ ] Manual: trigger a synthetic burst (e.g. tight tool-call loop) and confirm the alert fires with cooldown respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
