### PR TITLE
feat: prompt cache hit rate analytics panel (closes #851)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -709,6 +709,97 @@ async function loadAutonomy() {
   }
 }
 
+// ── Cache Analytics (#851) ──────────────────────────────────────────────────
+async function loadCacheAnalytics() {
+  var rateEl = document.getElementById('cache-hit-rate');
+  var badgeEl = document.getElementById('cache-savings-badge');
+  var summaryEl = document.getElementById('cache-summary-text');
+  var svgEl = document.getElementById('cache-sparkline');
+  var tokensEl = document.getElementById('cache-total-tokens');
+  if (!rateEl) return;
+
+  try {
+    var d = await (typeof fetchJsonWithTimeout === 'function'
+      ? fetchJsonWithTimeout('/api/cache-analytics', 5000)
+      : fetch('/api/cache-analytics').then(function(r){return r.json();}));
+
+    if (d.cache_hit_ratio == null) {
+      rateEl.textContent = 'No cache data yet';
+      rateEl.style.color = 'var(--text-muted)';
+      rateEl.style.fontSize = '16px';
+      if (summaryEl) summaryEl.textContent = 'Run some sessions and cache stats will appear here.';
+      if (badgeEl) { badgeEl.textContent = ''; badgeEl.style.background = ''; badgeEl.style.border = ''; }
+      if (tokensEl) tokensEl.textContent = '';
+      return;
+    }
+
+    var pct = Math.round(d.cache_hit_ratio * 100);
+    rateEl.textContent = pct + '%';
+    rateEl.style.color = pct >= 60 ? '#22c55e' : pct >= 30 ? '#f59e0b' : '#94a3b8';
+
+    if (badgeEl && d.estimated_savings_usd != null) {
+      var savings = d.estimated_savings_usd.toFixed(2);
+      badgeEl.textContent = 'saved ~$' + savings;
+      badgeEl.style.background = 'rgba(34,197,94,0.15)';
+      badgeEl.style.color = '#22c55e';
+      badgeEl.style.border = '1px solid rgba(34,197,94,0.4)';
+    }
+
+    if (summaryEl) {
+      summaryEl.textContent = pct + '% of LLM calls used prompt caching, saving ~$' + d.estimated_savings_usd.toFixed(2);
+    }
+
+    if (tokensEl) {
+      var readM = (d.total_cache_read_tokens / 1e6).toFixed(1);
+      tokensEl.textContent = readM + 'M cached tokens read';
+    }
+
+    // Sparkline
+    if (svgEl && d.series_daily && d.series_daily.length > 0) {
+      var ratios = d.series_daily.map(function(e){ return e.hit_ratio; });
+      var valid = ratios.filter(function(v){ return v != null; });
+      if (valid.length >= 2) {
+        var W = 160, H = 48, pad = 4;
+        var n = ratios.length;
+        var step = (W - pad * 2) / Math.max(n - 1, 1);
+        var pts = ratios.map(function(v, i) {
+          var x = pad + i * step;
+          var y = v == null ? null : H - pad - v * (H - pad * 2);
+          return {x: x, y: y};
+        });
+        var pathD = '';
+        pts.forEach(function(p, i) {
+          if (p.y == null) return;
+          if (!pathD || pts.slice(0, i).every(function(q){ return q.y == null; })) {
+            pathD += 'M' + p.x.toFixed(1) + ',' + p.y.toFixed(1);
+          } else {
+            pathD += ' L' + p.x.toFixed(1) + ',' + p.y.toFixed(1);
+          }
+        });
+        var svgContent = '';
+        var firstP = pts.find(function(p){ return p.y != null; });
+        var lastP = null; pts.forEach(function(p){ if(p.y != null) lastP = p; });
+        if (firstP && lastP && pathD) {
+          var fillD = pathD + ' L' + lastP.x.toFixed(1) + ',' + (H - pad) + ' L' + firstP.x.toFixed(1) + ',' + (H - pad) + ' Z';
+          svgContent += '<path d="' + fillD + '" fill="rgba(16,185,129,0.15)" stroke="none"/>';
+          svgContent += '<path d="' + pathD + '" fill="none" stroke="#10b981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>';
+        }
+        pts.forEach(function(p) {
+          if (p.y == null) return;
+          svgContent += '<circle cx="' + p.x.toFixed(1) + '" cy="' + p.y.toFixed(1) + '" r="2.5" fill="#10b981"/>';
+        });
+        svgEl.innerHTML = svgContent;
+      } else {
+        svgEl.innerHTML = '<text x="80" y="28" text-anchor="middle" fill="var(--text-muted)" font-size="10">Not enough data yet</text>';
+      }
+    }
+  } catch(e) {
+    console.warn('cache analytics load failed', e);
+    if (rateEl) rateEl.textContent = '\u2014';
+    if (summaryEl) summaryEl.textContent = 'Couldn\u2019t load right now.';
+  }
+}
+
 // ── Heartbeat: is your agent alive? ──────────────────────────────────────────
 async function loadHeartbeat() {
   try {
@@ -1668,6 +1759,7 @@ async function loadAll() {
     if (typeof loadReliabilityCard === 'function') setTimeout(function(){ loadReliabilityCard().catch(function(e){console.warn('reliability card failed',e)}); }, 1200);
     if (typeof loadTokenVelocity === 'function') setTimeout(function(){ loadTokenVelocity().catch(function(e){console.warn('velocity check failed',e)}); }, 1600);
     if (typeof loadDiagnostics === 'function') loadDiagnostics().catch(function(e){console.warn('diagnostics failed',e)});
+    if (typeof loadCacheAnalytics === 'function') loadCacheAnalytics().catch(function(e){console.warn('cache analytics failed',e)});
     if (typeof loadHeartbeat === 'function') loadHeartbeat().catch(function(e){console.warn('heartbeat panel failed',e)});
     if (typeof loadAutonomy === 'function') setTimeout(function(){ loadAutonomy().catch(function(e){console.warn('autonomy failed',e)}); }, 2600);
     if (typeof loadAnomalyPanel === 'function') setTimeout(function(){ loadAnomalyPanel().catch(function(e){console.warn('anomaly panel failed',e)}); }, 3600);

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -19,6 +19,25 @@
     </div>
   </div>
 
+  <!-- Prompt Cache Hit Rate Analytics (#851) -->
+  <div id="cache-analytics-card" style="background:var(--bg-secondary);border:2px solid var(--border-primary);border-radius:12px;padding:18px 22px;margin-bottom:14px;box-shadow:var(--card-shadow);display:grid;grid-template-columns:1fr 1fr;gap:16px;align-items:start;" title="Prompt cache hit rate and estimated savings.">
+    <div>
+      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:6px;">&#128230; Prompt Cache Analytics</div>
+      <div style="display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;">
+        <span id="cache-hit-rate" style="font-size:26px;font-weight:800;line-height:1.1;color:var(--text-primary);">--</span>
+        <span id="cache-savings-badge" style="font-size:12px;font-weight:600;padding:3px 8px;border-radius:20px;"></span>
+      </div>
+      <div id="cache-summary-text" style="font-size:13px;color:var(--text-muted);margin-top:8px;">--</div>
+    </div>
+    <div style="display:flex;flex-direction:column;align-items:flex-end;justify-content:center;">
+      <div style="font-size:11px;color:var(--text-muted);margin-bottom:6px;text-align:right;">Last 7 days</div>
+      <svg id="cache-sparkline" width="160" height="48" viewBox="0 0 160 48" style="overflow:visible;">
+        <text x="80" y="28" text-anchor="middle" fill="var(--text-muted)" font-size="10">No data yet</text>
+      </svg>
+      <div id="cache-total-tokens" style="font-size:10px;color:var(--text-muted);margin-top:4px;text-align:right;"></div>
+    </div>
+  </div>
+
   <div class="refresh-bar" style="margin-bottom:6px;">
     <button class="refresh-btn" onclick="loadAll()" style="padding:4px 12px;font-size:12px;">↻</button>
     <span class="pulse"></span>

--- a/dashboard.py
+++ b/dashboard.py
@@ -109,6 +109,7 @@ from routes.nemoclaw import bp_nemoclaw
 from routes.skills import bp_skills
 from routes.heartbeat import bp_heartbeat
 from routes.autonomy import bp_autonomy
+from routes.cache_analytics import bp_cache_analytics
 from routes.selfconfig import bp_selfconfig
 from routes.reasoning import bp_reasoning
 from helpers.openapi import bp_openapi
@@ -8335,6 +8336,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_selfevolve)
     app.register_blueprint(bp_alerts)
     app.register_blueprint(bp_autonomy)
+    app.register_blueprint(bp_cache_analytics)
     app.register_blueprint(bp_auth)
     app.register_blueprint(bp_brain)
     app.register_blueprint(bp_budget)

--- a/routes/cache_analytics.py
+++ b/routes/cache_analytics.py
@@ -1,0 +1,292 @@
+"""
+routes/cache_analytics.py — Prompt Cache Hit Rate Analytics.
+
+Shows how effectively prompt caching is being used across sessions,
+including hit ratios, token breakdowns, estimated cost savings, and
+per-model / per-session drill-downs.
+
+Blueprint: bp_cache_analytics
+Endpoint:  GET /api/cache-analytics
+"""
+
+import json
+import os
+import time
+from collections import defaultdict
+from datetime import datetime, timezone, timedelta
+
+from flask import Blueprint, jsonify
+
+bp_cache_analytics = Blueprint("cache_analytics", __name__)
+
+# ---------------------------------------------------------------------------
+# Cost constants (Anthropic pricing)
+# ---------------------------------------------------------------------------
+
+_NORMAL_INPUT_PER_TOKEN = 3.00 / 1_000_000   # $3.00 per 1M tokens
+_CACHED_INPUT_PER_TOKEN = 0.30 / 1_000_000   # $0.30 per 1M tokens
+_SAVINGS_PER_CACHED_TOKEN = _NORMAL_INPUT_PER_TOKEN - _CACHED_INPUT_PER_TOKEN  # $2.70 per 1M
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+_CACHE_TTL = 30  # seconds
+_cache_result = None
+_cache_ts = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_ts(msg, file_mtime):
+    """Return a unix timestamp for *msg*."""
+    for key in ("timestamp", "ts", "created_at", "time"):
+        val = msg.get(key)
+        if val is None:
+            continue
+        if isinstance(val, (int, float)):
+            v = float(val)
+            return v / 1000.0 if v > 1e12 else v
+        if isinstance(val, str) and val:
+            try:
+                return datetime.fromisoformat(
+                    val.replace("Z", "+00:00")
+                ).timestamp()
+            except ValueError:
+                pass
+    return file_mtime
+
+
+def _compute_cache_analytics(sessions_dir):
+    """Scan session JSONL files and compute cache analytics for the last 7 days."""
+    now_utc = datetime.now(timezone.utc)
+    cutoff_ts = (now_utc - timedelta(days=7)).timestamp()
+
+    # Accumulators
+    total_calls = 0
+    calls_with_cache = 0
+    total_cache_read = 0
+    total_cache_write = 0
+    total_input_tokens = 0
+
+    daily = defaultdict(lambda: {
+        "calls": 0, "cache_hits": 0,
+        "cache_read": 0, "cache_write": 0,
+    })
+    per_model = defaultdict(lambda: {
+        "calls": 0, "cache_hits": 0, "cache_read": 0,
+    })
+    per_session = {}  # session_id -> {calls, cache_hits, cache_read}
+
+    if not sessions_dir or not os.path.isdir(sessions_dir):
+        return _empty_response()
+
+    try:
+        files = [
+            f for f in os.listdir(sessions_dir)
+            if f.endswith(".jsonl") and ".deleted." not in f and ".reset." not in f
+        ]
+    except OSError:
+        return _empty_response()
+
+    for fname in files:
+        fpath = os.path.join(sessions_dir, fname)
+        try:
+            file_mtime = os.path.getmtime(fpath)
+        except OSError:
+            file_mtime = now_utc.timestamp()
+
+        if file_mtime < cutoff_ts:
+            continue
+
+        session_id = fname.replace(".jsonl", "")
+        sess_calls = 0
+        sess_cache_hits = 0
+        sess_cache_read = 0
+
+        try:
+            with open(fpath, "r", errors="replace") as fh:
+                for raw in fh:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        ev = json.loads(raw)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+
+                    if not isinstance(ev, dict):
+                        continue
+
+                    # Support both bare messages and wrapped
+                    if ev.get("type") == "message":
+                        msg = ev.get("message") or {}
+                    else:
+                        msg = ev
+
+                    # Only count assistant messages with usage (LLM calls)
+                    if msg.get("role") != "assistant":
+                        continue
+                    usage = msg.get("usage")
+                    if not isinstance(usage, dict):
+                        continue
+
+                    ts = _parse_ts(msg, file_mtime)
+                    if ts == file_mtime and isinstance(ev, dict) and ev.get("type") == "message":
+                        ts = _parse_ts(ev, file_mtime)
+                    if ts < cutoff_ts:
+                        continue
+
+                    cache_read = usage.get("cacheRead", 0) or 0
+                    cache_write = usage.get("cacheWrite", 0) or 0
+                    input_tokens = usage.get("input", 0) or 0
+                    model = msg.get("model", "unknown") or "unknown"
+
+                    total_calls += 1
+                    sess_calls += 1
+                    total_input_tokens += input_tokens
+                    total_cache_read += cache_read
+                    total_cache_write += cache_write
+
+                    has_cache = cache_read > 0
+                    if has_cache:
+                        calls_with_cache += 1
+                        sess_cache_hits += 1
+                    sess_cache_read += cache_read
+
+                    # Daily bucket
+                    day_key = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+                    daily[day_key]["calls"] += 1
+                    daily[day_key]["cache_read"] += cache_read
+                    daily[day_key]["cache_write"] += cache_write
+                    if has_cache:
+                        daily[day_key]["cache_hits"] += 1
+
+                    # Per-model
+                    per_model[model]["calls"] += 1
+                    per_model[model]["cache_read"] += cache_read
+                    if has_cache:
+                        per_model[model]["cache_hits"] += 1
+
+        except OSError:
+            continue
+
+        if sess_calls > 0:
+            per_session[session_id] = {
+                "calls": sess_calls,
+                "cache_hits": sess_cache_hits,
+                "cache_read": sess_cache_read,
+            }
+
+    if total_calls == 0:
+        return _empty_response()
+
+    cache_hit_ratio = calls_with_cache / total_calls
+    estimated_savings = total_cache_read * _SAVINGS_PER_CACHED_TOKEN
+
+    # Build 7-day series
+    series_daily = []
+    for offset in range(6, -1, -1):
+        day_dt = now_utc - timedelta(days=offset)
+        day_str = day_dt.strftime("%Y-%m-%d")
+        bucket = daily.get(day_str)
+        if bucket and bucket["calls"] > 0:
+            series_daily.append({
+                "day": day_str,
+                "hit_ratio": round(bucket["cache_hits"] / bucket["calls"], 4),
+                "cache_read": bucket["cache_read"],
+                "cache_write": bucket["cache_write"],
+                "total_calls": bucket["calls"],
+                "savings_usd": round(bucket["cache_read"] * _SAVINGS_PER_CACHED_TOKEN, 4),
+            })
+        else:
+            series_daily.append({
+                "day": day_str,
+                "hit_ratio": None,
+                "cache_read": 0,
+                "cache_write": 0,
+                "total_calls": 0,
+                "savings_usd": 0.0,
+            })
+
+    # Per-model list
+    per_model_list = sorted(
+        [
+            {
+                "model": m,
+                "hit_ratio": round(d["cache_hits"] / d["calls"], 4) if d["calls"] else 0,
+                "cache_read": d["cache_read"],
+                "total_calls": d["calls"],
+            }
+            for m, d in per_model.items()
+        ],
+        key=lambda x: x["cache_read"],
+        reverse=True,
+    )
+
+    # Per-session top 10 by cache_read
+    per_session_list = sorted(
+        [
+            {
+                "session_id": sid,
+                "hit_ratio": round(d["cache_hits"] / d["calls"], 4) if d["calls"] else 0,
+                "cache_read": d["cache_read"],
+                "total_calls": d["calls"],
+            }
+            for sid, d in per_session.items()
+        ],
+        key=lambda x: x["cache_read"],
+        reverse=True,
+    )[:10]
+
+    return {
+        "cache_hit_ratio": round(cache_hit_ratio, 4),
+        "total_cache_read_tokens": total_cache_read,
+        "total_cache_write_tokens": total_cache_write,
+        "total_input_tokens": total_input_tokens,
+        "estimated_savings_usd": round(estimated_savings, 4),
+        "series_daily": series_daily,
+        "per_model": per_model_list,
+        "per_session": per_session_list,
+    }
+
+
+def _empty_response():
+    return {
+        "cache_hit_ratio": None,
+        "total_cache_read_tokens": 0,
+        "total_cache_write_tokens": 0,
+        "total_input_tokens": 0,
+        "estimated_savings_usd": 0.0,
+        "series_daily": [],
+        "per_model": [],
+        "per_session": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+@bp_cache_analytics.route("/api/cache-analytics")
+def api_cache_analytics():
+    global _cache_result, _cache_ts
+
+    now = time.time()
+    if _cache_result is not None and (now - _cache_ts) < _CACHE_TTL:
+        return jsonify(_cache_result)
+
+    import dashboard as _d
+    sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
+        "~/.openclaw/agents/main/sessions"
+    )
+    try:
+        result = _compute_cache_analytics(sessions_dir)
+    except Exception:
+        result = _empty_response()
+
+    _cache_result = result
+    _cache_ts = now
+    return jsonify(result)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -986,6 +986,65 @@ class TestAutonomy:
 
 
 # ---------------------------------------------------------------------------
+# Cache Analytics (#851)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheAnalytics:
+    def test_cache_analytics_endpoint_ok(self, api, base_url):
+        r = api.get(f"{base_url}/api/cache-analytics")
+        assert r.status_code == 200
+        d = r.json()
+        assert "cache_hit_ratio" in d
+        assert "estimated_savings_usd" in d
+
+    def test_cache_analytics_structure(self, api, base_url):
+        """Response always has all expected keys."""
+        d = assert_ok(get(api, base_url, "/api/cache-analytics"))
+        assert_keys(
+            d,
+            "cache_hit_ratio",
+            "total_cache_read_tokens",
+            "total_cache_write_tokens",
+            "total_input_tokens",
+            "estimated_savings_usd",
+            "series_daily",
+            "per_model",
+            "per_session",
+        )
+
+    def test_cache_analytics_series_daily_is_list(self, api, base_url):
+        """series_daily is always a list."""
+        d = assert_ok(get(api, base_url, "/api/cache-analytics"))
+        assert isinstance(d["series_daily"], list), "series_daily must be a list"
+
+    def test_cache_analytics_per_model_is_list(self, api, base_url):
+        """per_model is always a list."""
+        d = assert_ok(get(api, base_url, "/api/cache-analytics"))
+        assert isinstance(d["per_model"], list), "per_model must be a list"
+
+    def test_cache_analytics_per_session_is_list(self, api, base_url):
+        """per_session is always a list."""
+        d = assert_ok(get(api, base_url, "/api/cache-analytics"))
+        assert isinstance(d["per_session"], list), "per_session must be a list"
+
+    def test_cache_analytics_hit_ratio_range(self, api, base_url):
+        """If cache_hit_ratio is not null it must be in [0, 1]."""
+        d = assert_ok(get(api, base_url, "/api/cache-analytics"))
+        if d["cache_hit_ratio"] is not None:
+            assert 0.0 <= d["cache_hit_ratio"] <= 1.0, (
+                f"cache_hit_ratio out of range: {d['cache_hit_ratio']}"
+            )
+
+    def test_cache_analytics_savings_non_negative(self, api, base_url):
+        """estimated_savings_usd must be >= 0."""
+        d = assert_ok(get(api, base_url, "/api/cache-analytics"))
+        assert d["estimated_savings_usd"] >= 0, (
+            f"savings should be non-negative: {d['estimated_savings_usd']}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Self-Configuration Diff Viewer (#689)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #851

## What
Dedicated prompt cache analytics panel showing how effectively Anthropic prompt caching is being used across sessions.

## How
- **New endpoint** `GET /api/cache-analytics` in `routes/cache_analytics.py` — scans 7 days of session JSONL files for `cacheRead`/`cacheWrite` usage data
- **Overview card** in the overview tab showing cache hit rate %, estimated savings, and a 7-day sparkline
- **Frontend JS** `loadCacheAnalytics()` in `app.js` following the `loadAutonomy()` pattern

### Response shape
```json
{
  "cache_hit_ratio": 0.73,
  "total_cache_read_tokens": 1234567,
  "total_cache_write_tokens": 456789,
  "total_input_tokens": 2345678,
  "estimated_savings_usd": 3.33,
  "series_daily": [...],
  "per_model": [...],
  "per_session": [...]
}
```

### Cost savings estimation
Uses Anthropic pricing: cached tokens cost $0.30/1M vs $3.00/1M for normal input, so each cached token saves $2.70/1M.

## Tests
7 test cases in `TestCacheAnalytics` covering endpoint availability, response structure, types, and value ranges.