### PR TITLE
[RELEASE] feat(sync): client-side trial gating + clear upgrade-to-resume log

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -256,7 +256,15 @@ def _post(path: str, payload: dict, api_key: str, timeout: int = 45) -> dict:
     for attempt in range(2):
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                return json.loads(resp.read())
+                resp_body = json.loads(resp.read())
+            # Cloud heartbeat (and any other endpoint) may attach the user's
+            # plan / sync_allowed / trial_days_left / upgrade_url. We mirror
+            # those into _TRIAL_STATE so subsequent uploads can self-throttle
+            # before paying the network round-trip. Best-effort: missing
+            # fields leave the cache untouched.
+            if isinstance(resp_body, dict) and "sync_allowed" in resp_body:
+                _update_trial_state(resp_body)
+            return resp_body
         except urllib.error.HTTPError as e:
             code = e.code
             msg = e.read().decode()[:200]
@@ -265,8 +273,74 @@ def _post(path: str, payload: dict, api_key: str, timeout: int = 45) -> dict:
             if code in (401, 503) and attempt == 0:
                 time.sleep(2)
                 continue
+            # Server-side throttle — surface a friendly "upgrade to resume"
+            # message and remember we're paused so next call short-circuits.
+            if code == 429:
+                try:
+                    plan = json.loads(msg).get("plan", "")
+                except Exception:
+                    plan = ""
+                _update_trial_state({
+                    "sync_allowed": False,
+                    "plan": plan or "trial_expired",
+                    "upgrade_url": "https://app.clawmetry.com/cloud",
+                })
             raise last_err
     raise last_err
+
+
+# ── Client-side trial gating ────────────────────────────────────────────────
+# Cloud /ingest/heartbeat returns {plan, sync_allowed, trial_days_left,
+# upgrade_url} on every beat. We cache it here so:
+#   - Large blob uploads (events / snapshots / memory / sessions / logs /
+#     autonomy) skip themselves when sync_allowed=False, saving bandwidth.
+#   - Heartbeats and approvals/alerts polls KEEP firing so the daemon
+#     detects the moment the user upgrades (sync_allowed flips True →
+#     uploads resume automatically, no daemon restart needed).
+#   - A clear "upgrade to resume" log line prints once per UTC day so the
+#     user knows why their dashboard stopped updating.
+
+_TRIAL_STATE = {
+    "sync_allowed": True,    # default: assume allowed until cloud says otherwise
+    "plan": None,
+    "trial_days_left": None,
+    "upgrade_url": "https://app.clawmetry.com/cloud",
+    "last_log_day": "",     # YYYY-MM-DD of the last "sync paused" log
+}
+
+
+def _update_trial_state(resp: dict) -> None:
+    """Mirror plan info from a cloud response into the local cache + log
+    a one-line "upgrade to resume" message once per UTC day on transition."""
+    prev_allowed = _TRIAL_STATE["sync_allowed"]
+    new_allowed = bool(resp.get("sync_allowed", True))
+    _TRIAL_STATE["sync_allowed"] = new_allowed
+    if "plan" in resp:
+        _TRIAL_STATE["plan"] = resp.get("plan")
+    if "trial_days_left" in resp:
+        _TRIAL_STATE["trial_days_left"] = resp.get("trial_days_left")
+    if resp.get("upgrade_url"):
+        _TRIAL_STATE["upgrade_url"] = resp["upgrade_url"]
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if not new_allowed and _TRIAL_STATE["last_log_day"] != today:
+        _TRIAL_STATE["last_log_day"] = today
+        log.warning(
+            "⚠ Trial expired (plan=%s). Cloud sync paused — heartbeats "
+            "continue so we detect the moment you upgrade. Upgrade to Pro at "
+            "%s to resume event/session/memory sync.",
+            _TRIAL_STATE["plan"], _TRIAL_STATE["upgrade_url"],
+        )
+    elif new_allowed and not prev_allowed:
+        log.info(
+            "✓ Pro plan detected (plan=%s). Cloud sync resumed.",
+            _TRIAL_STATE["plan"],
+        )
+
+
+def _sync_allowed() -> bool:
+    """Gate for large blob uploads. Heartbeats + approvals/alerts polls
+    bypass this — they MUST keep firing so we detect the upgrade."""
+    return _TRIAL_STATE.get("sync_allowed", True)
 
 
 def get_machine_id() -> str:
@@ -840,6 +914,11 @@ def _canonical_session_file(name: str) -> str:
 
 
 def sync_sessions(config: dict, state: dict, paths: dict) -> int:
+    # Skipped when sync is paused (expired trial). The state dict still
+    # tracks last_event_ids so when the user upgrades, we resume from
+    # exactly where we paused -- no event loss, no double-send.
+    if not _sync_allowed():
+        return 0
     sessions_dir = paths["sessions_dir"]
     api_key = config["api_key"]
     enc_key = config.get("encryption_key")
@@ -1256,6 +1335,10 @@ def sync_claude_cli_sessions(config: dict, state: dict, paths: dict) -> int:
 
 
 def sync_logs(config: dict, state: dict, paths: dict) -> int:
+    # Skipped when sync is paused (expired trial). Offsets persist so
+    # nothing is lost on resume.
+    if not _sync_allowed():
+        return 0
     log_dir = paths["log_dir"]
     api_key = config["api_key"]
     enc_key = config.get("encryption_key")
@@ -1479,12 +1562,17 @@ CRON_STATE_HEARTBEAT_SEC = 300  # 5 minutes
 def sync_crons(config: dict, state: dict, paths: dict) -> int:
     """Sync cron job definitions to cloud.
 
+    Skipped when the cloud has flagged this account's sync as paused (e.g.
+    expired trial). Heartbeats keep firing so we detect upgrade.
+
     Dedup strategy (issue #599): emit a cron_state event per job only when the
     per-job state hash differs from the last emission, OR when the heartbeat
     interval (CRON_STATE_HEARTBEAT_SEC) has elapsed since the last emission
     for that job. Dedup tracking is persisted in the sync state dict so it
     survives daemon restarts.
     """
+    if not _sync_allowed():
+        return 0
     api_key = config["api_key"]
     node_id = config["node_id"]
     last_hash = state.get("cron_hash", "")
@@ -1589,10 +1677,15 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
 def sync_session_metadata(config: dict, state: dict = None) -> int:
     """Sync OpenClaw session metadata rows to cloud sessions table.
 
+    Skipped when the cloud has flagged sync as paused (expired trial).
+    Heartbeats continue so the daemon detects the moment the user upgrades.
+
     Uses mtime tracking to only re-parse files that changed since last sync.
     Reads JSONL session files directly (HTTP API returns HTML, not JSON).
     Extracts session_id, model, timestamps from the event stream.
     """
+    if not _sync_allowed():
+        return 0
     api_key = config["api_key"]
     node_id = config["node_id"]
     if state is None:
@@ -1777,7 +1870,11 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
 
 
 def sync_memory(config: dict, state: dict, paths: dict) -> int:
-    """Sync memory files (MEMORY.md + memory/*.md) to cloud."""
+    """Sync memory files (MEMORY.md + memory/*.md) to cloud.
+
+    Skipped when sync is paused (expired trial)."""
+    if not _sync_allowed():
+        return 0
     workspace = paths.get("workspace", "")
     api_key = config["api_key"]
     enc_key = config.get("encryption_key")
@@ -2631,7 +2728,11 @@ def _build_cron_jobs(paths):
 
 
 def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
-    """Push system info + subagent data as encrypted snapshot."""
+    """Push system info + subagent data as encrypted snapshot.
+
+    Skipped when sync is paused (expired trial)."""
+    if not _sync_allowed():
+        return 0
     import subprocess, platform, json as _json
 
     api_key = config["api_key"]
@@ -3650,7 +3751,11 @@ def sync_autonomy(config, state, paths):
     ``state['autonomy_last_day']`` and skip until that rolls over. On first
     run, pushes up to 90 days of history. Each subsequent run pushes
     whatever has changed.
+
+    Skipped when sync is paused (expired trial).
     """
+    if not _sync_allowed():
+        return 0
     api_key = config.get("api_key") or ""
     if not api_key:
         return 0

--- a/tests/test_sync_trial_gating.py
+++ b/tests/test_sync_trial_gating.py
@@ -1,0 +1,194 @@
+"""Test client-side trial gating in clawmetry/sync.py.
+
+Covers:
+  - _update_trial_state caches plan + sync_allowed correctly
+  - _sync_allowed() default True until cloud says otherwise
+  - "Trial expired -> Sync paused" log fires once per UTC day, not every call
+  - "Pro plan detected -> Sync resumed" log fires on transition back
+  - 429 from _post toggles sync_allowed=False (server confirms throttle)
+  - sync_*() entry points bail early when sync_allowed=False
+
+Hermetic: never makes real HTTP. Reuses each test's monkeypatch to neuter
+network / time / log side-effects.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import io
+import json
+import logging
+import os
+import sys
+import urllib.error
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# We import the module fresh per test to reset the in-memory _TRIAL_STATE.
+
+@pytest.fixture
+def sync(monkeypatch):
+    sys.modules.pop('clawmetry.sync', None)
+    import clawmetry.sync as s
+    # Default: pretend sync is allowed (matches module default).
+    s._TRIAL_STATE['sync_allowed'] = True
+    s._TRIAL_STATE['plan'] = None
+    s._TRIAL_STATE['trial_days_left'] = None
+    s._TRIAL_STATE['last_log_day'] = ''
+    # The clawmetry-sync logger has propagate=False so caplog (which hooks
+    # the root logger) won't see records. Flip it on for the test scope.
+    _prev = s.log.propagate
+    s.log.propagate = True
+    yield s
+    s.log.propagate = _prev
+
+
+# ── _update_trial_state ────────────────────────────────────────────────────
+
+def test_update_caches_plan_and_sync_flag(sync):
+    sync._update_trial_state({
+        'sync_allowed': False, 'plan': 'trial_expired',
+        'trial_days_left': 0, 'upgrade_url': 'https://app.clawmetry.com/cloud',
+    })
+    assert sync._TRIAL_STATE['sync_allowed'] is False
+    assert sync._TRIAL_STATE['plan'] == 'trial_expired'
+    assert sync._TRIAL_STATE['trial_days_left'] == 0
+    assert sync._TRIAL_STATE['upgrade_url'] == 'https://app.clawmetry.com/cloud'
+
+def test_default_sync_allowed_true(sync):
+    """Until cloud responds, the daemon optimistically syncs."""
+    assert sync._sync_allowed() is True
+
+def test_pause_log_fires_once_per_day(sync, caplog):
+    caplog.set_level(logging.WARNING, logger=sync.log.name)
+    sync._update_trial_state({'sync_allowed': False, 'plan': 'trial_expired'})
+    # Same UTC day → second call should NOT add another warning.
+    sync._update_trial_state({'sync_allowed': False, 'plan': 'trial_expired'})
+    sync._update_trial_state({'sync_allowed': False, 'plan': 'trial_expired'})
+    pause_logs = [r for r in caplog.records if 'Trial expired' in r.getMessage()]
+    assert len(pause_logs) == 1, \
+        f'Expected 1 pause log per day; got {len(pause_logs)}'
+
+def test_pause_log_includes_upgrade_url(sync, caplog):
+    caplog.set_level(logging.WARNING, logger=sync.log.name)
+    sync._update_trial_state({
+        'sync_allowed': False, 'plan': 'trial_expired',
+        'upgrade_url': 'https://app.clawmetry.com/cloud',
+    })
+    pause_logs = [r for r in caplog.records if 'Trial expired' in r.getMessage()]
+    assert pause_logs
+    msg = pause_logs[0].getMessage()
+    assert 'https://app.clawmetry.com/cloud' in msg
+    assert 'Upgrade to Pro' in msg
+
+def test_resume_log_fires_on_pro_transition(sync, caplog):
+    caplog.set_level(logging.INFO, logger=sync.log.name)
+    sync._update_trial_state({'sync_allowed': False, 'plan': 'trial_expired'})
+    # Now upgrade detected.
+    sync._update_trial_state({'sync_allowed': True, 'plan': 'pro'})
+    resume_logs = [r for r in caplog.records if 'sync resumed' in r.getMessage()]
+    assert len(resume_logs) == 1
+    assert sync._TRIAL_STATE['plan'] == 'pro'
+    assert sync._sync_allowed() is True
+
+def test_no_resume_log_when_already_pro(sync, caplog):
+    """Don't log 'resumed' on every Pro heartbeat — only on transition."""
+    caplog.set_level(logging.INFO, logger=sync.log.name)
+    sync._update_trial_state({'sync_allowed': True, 'plan': 'pro'})
+    sync._update_trial_state({'sync_allowed': True, 'plan': 'pro'})
+    sync._update_trial_state({'sync_allowed': True, 'plan': 'pro'})
+    resume_logs = [r for r in caplog.records if 'sync resumed' in r.getMessage()]
+    assert len(resume_logs) == 0
+
+
+# ── 429 handling: server-side throttle confirms client cache ──────────────
+
+def test_post_429_marks_sync_paused(sync, monkeypatch):
+    """When server returns 429, the client should immediately update its
+    cache so subsequent uploads short-circuit before the network round-trip."""
+    err = urllib.error.HTTPError(
+        url='https://app.clawmetry.com/api/ingest/events', code=429,
+        msg='Too Many', hdrs={},
+        fp=io.BytesIO(json.dumps({
+            'error': 'rate_limit_exceeded', 'plan': 'trial_expired',
+            'retry_after': 30,
+        }).encode()),
+    )
+    fake_urlopen_calls = []
+    def fake_urlopen(req, timeout=None):
+        fake_urlopen_calls.append(req.full_url)
+        raise err
+    monkeypatch.setattr(sync.urllib.request, 'urlopen', fake_urlopen)
+    monkeypatch.setattr(sync.time, 'sleep', lambda *a, **kw: None)
+    with pytest.raises(RuntimeError, match='HTTP 429'):
+        sync._post('/ingest/events', {'node_id': 'n'}, 'cm_x')
+    assert sync._TRIAL_STATE['sync_allowed'] is False
+    assert sync._TRIAL_STATE['plan'] == 'trial_expired'
+
+
+# ── Sync entry points bail early ──────────────────────────────────────────
+
+def test_sync_sessions_bails_when_paused(sync, monkeypatch):
+    sync._update_trial_state({'sync_allowed': False, 'plan': 'trial_expired'})
+    spy = []
+    monkeypatch.setattr(sync, '_post', lambda *a, **kw: spy.append(a) or {})
+    n = sync.sync_sessions(
+        {'api_key': 'cm_x', 'node_id': 'n'},
+        {},
+        {'sessions_dir': '/tmp/nope'},
+    )
+    assert n == 0
+    assert spy == [], 'sync_sessions must NOT make any POSTs when paused'
+
+def test_sync_logs_bails_when_paused(sync, monkeypatch):
+    sync._update_trial_state({'sync_allowed': False})
+    spy = []
+    monkeypatch.setattr(sync, '_post', lambda *a, **kw: spy.append(a) or {})
+    n = sync.sync_logs(
+        {'api_key': 'cm_x', 'node_id': 'n'},
+        {}, {'log_dir': '/tmp/nope'},
+    )
+    assert n == 0 and spy == []
+
+def test_sync_memory_bails_when_paused(sync, monkeypatch):
+    sync._update_trial_state({'sync_allowed': False})
+    spy = []
+    monkeypatch.setattr(sync, '_post', lambda *a, **kw: spy.append(a) or {})
+    n = sync.sync_memory(
+        {'api_key': 'cm_x', 'node_id': 'n'},
+        {}, {'workspace': '/tmp/nope'},
+    )
+    assert n == 0 and spy == []
+
+def test_sync_crons_bails_when_paused(sync, monkeypatch):
+    sync._update_trial_state({'sync_allowed': False})
+    spy = []
+    monkeypatch.setattr(sync, '_post', lambda *a, **kw: spy.append(a) or {})
+    n = sync.sync_crons(
+        {'api_key': 'cm_x', 'node_id': 'n'},
+        {}, {},
+    )
+    assert n == 0 and spy == []
+
+def test_sync_system_snapshot_bails_when_paused(sync, monkeypatch):
+    sync._update_trial_state({'sync_allowed': False})
+    spy = []
+    monkeypatch.setattr(sync, '_post', lambda *a, **kw: spy.append(a) or {})
+    n = sync.sync_system_snapshot(
+        {'api_key': 'cm_x', 'node_id': 'n'},
+        {}, {},
+    )
+    assert n == 0 and spy == []
+
+
+# ── Sync resumes on flip to pro ──────────────────────────────────────────
+
+def test_sync_resumes_when_plan_flips_back(sync, monkeypatch):
+    sync._update_trial_state({'sync_allowed': False, 'plan': 'trial_expired'})
+    assert sync._sync_allowed() is False
+    # Heartbeat returns pro on next beat -> _update_trial_state flips it.
+    sync._update_trial_state({'sync_allowed': True, 'plan': 'pro'})
+    assert sync._sync_allowed() is True


### PR DESCRIPTION
## Summary
User asked: *"can the client side be aware of the fact if in trial period so that after trial expiry it can better not make api calls to backend to sync data — it can periodically check if upgraded to pro etc & also in logs print that upgrade to pro to continue syncing events"*

Defense in depth — server-side rate limit (#622) catches abuse on the cloud edge; this PR adds the **client-side gate** so the daemon short-circuits BEFORE paying the network round-trip.

## How it works

1. **Cloud `/ingest/heartbeat` returns plan info** (shipped in companion cloud PR): `{plan, sync_allowed, trial_days_left, upgrade_url}` on every beat.

2. **Daemon caches it** in a module-level `_TRIAL_STATE` and also auto-flips to `sync_allowed=False` if the cloud returns `429` (belt-and-braces).

3. **Gate at every large-blob entry point** — `sync_sessions`, `sync_logs`, `sync_crons`, `sync_session_metadata`, `sync_memory`, `sync_system_snapshot`, `sync_autonomy` all bail early when paused. State dicts (offsets, last-event-ids) are untouched so on resume the daemon continues from EXACTLY where it paused — no event loss, no double-send.

4. **Heartbeats + approvals/alerts polls keep firing** (small payloads, under the 60/min free cap). They're how the daemon detects the upgrade — the moment cloud reports `sync_allowed=True`, gates flip open automatically. No daemon restart needed.

5. **Honest log message**, once per UTC day on transition:
   ```
   ⚠ Trial expired (plan=trial_expired). Cloud sync paused —
     heartbeats continue so we detect the moment you upgrade.
     Upgrade to Pro at https://app.clawmetry.com/cloud to resume
     event/session/memory sync.
   ```
   And on flip back:
   ```
   ✓ Pro plan detected (plan=pro). Cloud sync resumed.
   ```

## Tests
13 cases in `tests/test_sync_trial_gating.py`. All pass in <0.1s.

```
13 passed, 1 warning in 0.05s
```

## Test plan
- [ ] Existing Pro user: no behaviour change (sync continues normally)
- [ ] Trial-expired user: events stop uploading, heartbeats continue, log shows "Trial expired" once per day
- [ ] User upgrades mid-session: next heartbeat detects pro, sync resumes within 60s, "Cloud sync resumed" log fires once

🤖 Generated with [Claude Code](https://claude.com/claude-code)