### PR TITLE
feat: reasoning chain viewer — structured thinking visualization (closes #565)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2221,12 +2221,17 @@ window.toggleBrainFilterExpanded = function() {
 function _brainChipHtml(s) {
   var isActive = _brainFilter === s.id;
   var icon = s.icon || (s.id === 'main' ? '🧠' : '🤖');
+  // Add 🧠 badge if this source has any THINK events (reasoning sessions)
+  var hasReasoning = (_brainAllEvents || []).some(function(ev) {
+    return ev.source === s.id && ev.type === 'THINK';
+  });
+  var reasoningBadge = hasReasoning ? ' <span title="Has reasoning chains" style="font-size:9px;">&#129504;</span>' : '';
   return '<button class="brain-chip' + (isActive ? ' active' : '') + '" data-source="' +
     escHtml(s.id) + '" title="' + escHtml(s.id) +
     '" onclick="setBrainFilter(this.dataset.source,this)" style="padding:3px 10px;border-radius:12px;border:1px solid ' +
     s.color + ';background:' + (isActive ? 'rgba(100,100,100,0.2)' : 'transparent') +
     ';color:' + s.color + ';font-size:11px;cursor:pointer;font-weight:' +
-    (isActive ? '600' : '400') + ';">' + icon + ' ' + escHtml(s.label || s.id) + '</button>';
+    (isActive ? '600' : '400') + ';">' + icon + ' ' + escHtml(s.label || s.id) + reasoningBadge + '</button>';
 }
 
 function renderBrainFilterChips(sources) {
@@ -2450,7 +2455,15 @@ function renderBrainStream(events) {
           turnTimeline += '<span style="color:var(--text-faint);min-width:50px;flex-shrink:0;">' + teTime + '</span>';
           turnTimeline += '<span style="color:' + teCol + ';min-width:55px;font-weight:600;flex-shrink:0;">' + teIcon + ' ' + te.type + '</span>';
           turnTimeline += '<span style="color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(teDetail) + '</span>';
-          turnTimeline += '</div>';
+          if (te.type === 'THINK') {
+            var _rcSid = te.source || 'main';
+            var _rcContainerId = 'rc-' + _rcSid.slice(0, 8) + '-' + (te.time || '').replace(/[^0-9]/g, '').slice(-6);
+            turnTimeline += '<button onclick="event.stopPropagation();loadReasoningChain(\'' + escHtml(_rcSid) + '\',\'' + escHtml(_rcContainerId) + '\')" style="flex-shrink:0;padding:1px 7px;border-radius:10px;border:1px solid #6366f1;background:transparent;color:#818cf8;font-size:10px;cursor:pointer;white-space:nowrap;">&#129504; View chain</button>';
+            turnTimeline += '</div>';
+            turnTimeline += '<div id="' + escHtml(_rcContainerId) + '" style="margin:2px 0 4px 56px;"></div>';
+          } else {
+            turnTimeline += '</div>';
+          }
         });
         if (currentSubagent) turnTimeline += '</div>'; // close last sub-agent group
         turnTimeline += '</div>';
@@ -2471,6 +2484,78 @@ function renderBrainStream(events) {
     html += '</div>';
   });
   el.innerHTML = html;
+}
+
+// Reasoning Chain Viewer (GH #565)
+// Step type → badge color
+var _rcStepColors = {
+  premise: '#3b82f6',
+  hypothesis: '#f59e0b',
+  constraint: '#f97316',
+  conclusion: '#10b981',
+  analysis: '#6b7280'
+};
+
+function loadReasoningChain(sessionId, containerId) {
+  var container = document.getElementById(containerId);
+  if (!container) return;
+  // Toggle: if already loaded, clear it
+  if (container.dataset.loaded === '1') {
+    container.innerHTML = '';
+    container.dataset.loaded = '0';
+    return;
+  }
+  container.innerHTML = '<span style="color:var(--text-muted);font-size:10px;">Loading\u2026</span>';
+  fetch('/api/reasoning?session=' + encodeURIComponent(sessionId))
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      container.dataset.loaded = '1';
+      var chains = data.chains || [];
+      var summary = data.summary || {};
+      if (!chains.length) {
+        container.innerHTML = '<span style="color:var(--text-muted);font-size:10px;">No reasoning chains found.</span>';
+        return;
+      }
+      var html = '';
+      // Summary bar
+      html += '<div style="display:flex;gap:8px;flex-wrap:wrap;padding:4px 8px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;font-size:10px;color:var(--text-muted);margin-bottom:4px;">';
+      html += '<span style="color:#818cf8;">&#129504; ' + summary.total_thinking_tokens + ' thinking tokens</span>';
+      var totalSteps = chains.reduce(function(acc, c) { return acc + (c.steps || []).length; }, 0);
+      html += '<span>&#128295; ' + totalSteps + ' steps</span>';
+      if (summary.avg_efficiency > 0) {
+        html += '<span>&#9889; Efficiency: ' + summary.avg_efficiency + ':1</span>';
+      }
+      html += '<span>' + chains.length + ' chain' + (chains.length > 1 ? 's' : '') + '</span>';
+      html += '</div>';
+      // Render each chain
+      chains.forEach(function(chain, ci) {
+        html += '<div style="padding:4px 8px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;margin-bottom:4px;">';
+        if (chains.length > 1) {
+          html += '<div style="font-size:10px;color:var(--text-muted);margin-bottom:3px;">Chain ' + (ci + 1) + ' &mdash; ' + chain.thinking_tokens + ' tokens</div>';
+        }
+        (chain.steps || []).forEach(function(step) {
+          var col = _rcStepColors[step.type] || '#6b7280';
+          var preview = (step.content || '').slice(0, 80);
+          var hasMore = (step.content || '').length > 80;
+          var stepId = 'rcs-' + containerId + '-' + ci + '-' + Math.random().toString(36).slice(2,7);
+          html += '<div style="display:flex;gap:6px;align-items:flex-start;padding:2px 0;font-size:10px;">';
+          html += '<span style="flex-shrink:0;padding:0 5px;border-radius:8px;background:' + col + '22;color:' + col + ';font-weight:700;font-size:9px;line-height:16px;">' + escHtml(step.type) + '</span>';
+          html += '<span id="' + stepId + '" style="color:var(--text-secondary);flex:1;">' + escHtml(preview);
+          if (hasMore) {
+            html += '<span id="' + stepId + '-more" style="display:none;">' + escHtml((step.content || '').slice(80)) + '</span>';
+            html += '<span onclick="(function(el){var m=document.getElementById(\'' + stepId + '-more\');if(m){m.style.display=m.style.display===\'none\'?\'inline\':\'none\';el.textContent=m.style.display===\'none\'?\' \u2026more\':\'  \u2212less\';};})(this)" style="color:var(--text-muted);cursor:pointer;"> \u2026more</span>';
+          }
+          html += '</span>';
+          html += '<span style="flex-shrink:0;color:var(--text-faint);font-size:9px;">' + step.word_count + 'w</span>';
+          html += '</div>';
+        });
+        html += '</div>';
+      });
+      container.innerHTML = html;
+    })
+    .catch(function(err) {
+      container.innerHTML = '<span style="color:#ef4444;font-size:10px;">Error loading reasoning chain.</span>';
+    });
 }
 
 function renderBrainChart(events) {

--- a/dashboard.py
+++ b/dashboard.py
@@ -110,6 +110,7 @@ from routes.skills import bp_skills
 from routes.heartbeat import bp_heartbeat
 from routes.autonomy import bp_autonomy
 from routes.selfconfig import bp_selfconfig
+from routes.reasoning import bp_reasoning
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -8328,6 +8329,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_skills)
     app.register_blueprint(bp_heartbeat)
     app.register_blueprint(bp_selfconfig)
+    app.register_blueprint(bp_reasoning)
     app.register_blueprint(bp_openapi)
 
     # Local-OSS shims for cloud-only endpoints. Return empty arrays so the

--- a/routes/reasoning.py
+++ b/routes/reasoning.py
@@ -1,0 +1,200 @@
+"""
+routes/reasoning.py — Reasoning chain viewer endpoint.
+
+Implements GH #565: structured visualization of LLM thinking/reasoning content.
+
+  GET /api/reasoning?session=SESSION_ID
+
+Returns a structured breakdown of thinking blocks parsed from session JSONL:
+- Chains: each thinking block segmented into typed logical steps
+- Summary: aggregate token/efficiency stats across all chains
+"""
+
+import glob
+import json
+import os
+import re
+
+from flask import Blueprint, jsonify, request
+
+bp_reasoning = Blueprint("reasoning", __name__)
+
+# Keyword heuristics for step classification
+_PREMISE_RE = re.compile(
+    r"\b(user wants|the question|looking at|need to|understand|analyz|request)\b",
+    re.IGNORECASE,
+)
+_HYPOTHESIS_RE = re.compile(
+    r"\b(if I|could use|one approach|let me try|maybe|perhaps|what if)\b",
+    re.IGNORECASE,
+)
+_CONSTRAINT_RE = re.compile(
+    r"\b(but|however|constraint|can't|won't work|problem is|issue is|limitation)\b",
+    re.IGNORECASE,
+)
+_CONCLUSION_RE = re.compile(
+    r"\b(so I should|therefore|I'll|the solution|final answer|in conclusion|thus)\b",
+    re.IGNORECASE,
+)
+
+
+def _classify_step(text):
+    """Classify a thinking step using keyword heuristics."""
+    if _PREMISE_RE.search(text):
+        return "premise"
+    if _HYPOTHESIS_RE.search(text):
+        return "hypothesis"
+    if _CONSTRAINT_RE.search(text):
+        return "constraint"
+    if _CONCLUSION_RE.search(text):
+        return "conclusion"
+    return "analysis"
+
+
+def _segment_thinking(text):
+    """Split thinking text into logical steps and classify each."""
+    # Split on double newlines first, then fallback to sentence boundaries
+    raw_segments = re.split(r"\n\s*\n", text.strip())
+    steps = []
+    for seg in raw_segments:
+        seg = seg.strip()
+        if not seg:
+            continue
+        # Further split very long segments at sentence boundaries (. ! ?)
+        # but only if the segment is longer than ~200 chars
+        if len(seg) > 200:
+            sentences = re.split(r"(?<=[.!?])\s+(?=[A-Z])", seg)
+            for s in sentences:
+                s = s.strip()
+                if s:
+                    word_count = len(s.split())
+                    steps.append(
+                        {
+                            "type": _classify_step(s),
+                            "content": s,
+                            "word_count": word_count,
+                        }
+                    )
+        else:
+            word_count = len(seg.split())
+            steps.append(
+                {
+                    "type": _classify_step(seg),
+                    "content": seg,
+                    "word_count": word_count,
+                }
+            )
+    return steps
+
+
+def _parse_session_reasoning(session_id):
+    """Parse thinking blocks from a session JSONL file and build reasoning chains."""
+    import dashboard as _d
+
+    session_dir = _d.SESSIONS_DIR or os.path.expanduser(
+        "~/.openclaw/agents/main/sessions"
+    )
+    jsonl_path = os.path.join(session_dir, f"{session_id}.jsonl")
+
+    chains = []
+
+    if not os.path.isfile(jsonl_path):
+        return chains
+
+    try:
+        with open(jsonl_path, "r", errors="replace") as fh:
+            lines = fh.readlines()
+    except Exception:
+        return chains
+
+    for raw in lines:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw)
+        except Exception:
+            continue
+
+        ts = obj.get("timestamp") or obj.get("time")
+        role = obj.get("role", "")
+        content_obj = obj.get("content", "")
+
+        # Unwrap OpenClaw / claude-cli message wrappers
+        if obj.get("type") in ("message", "user", "assistant") and isinstance(
+            obj.get("message"), dict
+        ):
+            inner = obj["message"]
+            role = inner.get("role", role) or obj.get("type", "")
+            content_obj = inner.get("content", content_obj)
+
+        if role != "assistant" or not isinstance(content_obj, list):
+            continue
+
+        # Collect thinking + answer blocks from this assistant turn
+        thinking_blocks = []
+        answer_word_count = 0
+
+        for block in content_obj:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "thinking":
+                thinking_text = block.get("thinking", "")
+                if thinking_text:
+                    thinking_blocks.append(thinking_text)
+            elif btype == "text":
+                text = block.get("text", "") or ""
+                answer_word_count += len(text.split())
+
+        for thinking_text in thinking_blocks:
+            steps = _segment_thinking(thinking_text)
+            thinking_word_count = sum(s["word_count"] for s in steps)
+            thinking_tokens = int(thinking_word_count * 1.3)
+            answer_tokens = int(answer_word_count * 1.3)
+            efficiency_ratio = (
+                round(thinking_tokens / answer_tokens, 1) if answer_tokens > 0 else 0.0
+            )
+            chains.append(
+                {
+                    "timestamp": ts or "",
+                    "thinking_tokens": thinking_tokens,
+                    "answer_tokens": answer_tokens,
+                    "efficiency_ratio": efficiency_ratio,
+                    "steps": steps,
+                    "raw_thinking": thinking_text,
+                }
+            )
+
+    return chains
+
+
+@bp_reasoning.route("/api/reasoning")
+def api_reasoning():
+    """Return structured reasoning chains for a session."""
+    session_id = request.args.get("session", "").strip()
+    if not session_id:
+        return jsonify({"error": "session parameter required"}), 400
+
+    chains = _parse_session_reasoning(session_id)
+
+    total_thinking_tokens = sum(c["thinking_tokens"] for c in chains)
+    total_answer_tokens = sum(c["answer_tokens"] for c in chains)
+    avg_efficiency = (
+        round(total_thinking_tokens / total_answer_tokens, 1)
+        if total_answer_tokens > 0
+        else 0.0
+    )
+
+    return jsonify(
+        {
+            "session_id": session_id,
+            "chains": chains,
+            "summary": {
+                "total_thinking_tokens": total_thinking_tokens,
+                "total_answer_tokens": total_answer_tokens,
+                "avg_efficiency": avg_efficiency,
+                "chain_count": len(chains),
+            },
+        }
+    )


### PR DESCRIPTION
## Summary

- **New backend** `routes/reasoning.py`: `GET /api/reasoning?session=SESSION_ID` parses session JSONL for assistant messages with thinking blocks, segments each into typed logical steps, and returns structured chains with token estimates and efficiency ratios
- **Blueprint registered** in `dashboard.py` alongside all other route modules
- **Frontend viewer** in `app.js`: `loadReasoningChain()` fetches the API and renders a collapsible panel with summary bar (thinking tokens | steps | efficiency ratio) and a vertical step flow with color-coded type badges (premise=blue, hypothesis=yellow, constraint=orange, conclusion=green, analysis=gray)
- **"View chain" button** appears next to THINK events in the expanded brain turn timeline — toggles the panel on/off
- **🧠 badge** added to session filter chips that contain THINK events, making reasoning-heavy sessions visually identifiable

## Implementation details

- Step classification uses keyword heuristics (no ML): premise/hypothesis/constraint/conclusion/analysis
- Token estimate: word_count x 1.3 (rough approximation consistent with spec)
- Late import dashboard as _d pattern for SESSIONS_DIR, consistent with all other route modules
- Frontend uses existing CSS variables (var(--bg-secondary), var(--border), var(--text-muted)) for consistent Brain tab styling

## Test plan

- [x] tests/test_circular_import.py passes (no circular import introduced)
- [x] tests/test_cli.py passes (dashboard starts cleanly with new blueprint)
- [ ] Manually: open Brain tab, expand a turn with a THINK event, click "View chain" to see panel with step breakdown
- [ ] Manually: session chips for reasoning-capable sessions show the reasoning badge
- [ ] GET /api/reasoning?session=<valid-session-id> returns {session_id, chains, summary} JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)