### PR TITLE
fix(dashboard): bound transcript scans and stagger widgets - optimize data loading time in widgets

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1659,17 +1659,18 @@ async function loadAll() {
     // Render overview quickly; do not block on heavy usage aggregation.
     var overview = await fetchJsonWithTimeout('/api/overview', 3000);
 
-    // Start secondary panels immediately.
-    startActiveTasksRefresh();
+    // Start only critical secondary panels immediately. Expensive/non-critical
+    // cards are staggered below so the initial widget load does not stampede
+    // the backend and queue behind transcript analytics.
     loadActivityStream().catch(function(e){console.warn('activity stream failed',e)});
     loadHealth().catch(function(e){console.warn('health failed',e)});
     loadMCTasks().catch(function(e){console.warn('mctasks failed',e)});
-    if (typeof loadReliabilityCard === 'function') loadReliabilityCard().catch(function(e){console.warn('reliability card failed',e)});
-    if (typeof loadAnomalyPanel === 'function') loadAnomalyPanel().catch(function(e){console.warn('anomaly panel failed',e)});
-    if (typeof loadTokenVelocity === 'function') loadTokenVelocity().catch(function(e){console.warn('velocity check failed',e)});
+    if (typeof loadReliabilityCard === 'function') setTimeout(function(){ loadReliabilityCard().catch(function(e){console.warn('reliability card failed',e)}); }, 1200);
+    if (typeof loadTokenVelocity === 'function') setTimeout(function(){ loadTokenVelocity().catch(function(e){console.warn('velocity check failed',e)}); }, 1600);
     if (typeof loadDiagnostics === 'function') loadDiagnostics().catch(function(e){console.warn('diagnostics failed',e)});
-    if (typeof loadAutonomy === 'function') loadAutonomy().catch(function(e){console.warn('autonomy failed',e)});
     if (typeof loadHeartbeat === 'function') loadHeartbeat().catch(function(e){console.warn('heartbeat panel failed',e)});
+    if (typeof loadAutonomy === 'function') setTimeout(function(){ loadAutonomy().catch(function(e){console.warn('autonomy failed',e)}); }, 2600);
+    if (typeof loadAnomalyPanel === 'function') setTimeout(function(){ loadAnomalyPanel().catch(function(e){console.warn('anomaly panel failed',e)}); }, 3600);
     document.getElementById('refresh-time').textContent = 'Updated ' + new Date().toLocaleTimeString();
 
     if (overview.infra) {
@@ -2544,7 +2545,10 @@ function _startBrainSSE() {
 
   try {
     var url = '/api/brain-stream';
-    var token = localStorage.getItem('gw_token');
+    var token =
+      localStorage.getItem('clawmetry-token') ||
+      localStorage.getItem('gw_token') ||
+      localStorage.getItem('cm-token');
     if (token) url += '?token=' + encodeURIComponent(token);
     var es = new EventSource(url);
     _brainSSE = es;
@@ -2630,7 +2634,7 @@ async function loadContextInspector() {
     // Fetch overview for model + token info
     var ov = await fetch('/api/overview').then(function(r){return r.json();}).catch(function(){return {};});
     // Fetch brain history for compaction events + turn count
-    var brain = await fetch('/api/brain-history').then(function(r){return r.json();}).catch(function(){return {events:[]};});
+    var brain = await fetch('/api/brain-history?limit=300').then(function(r){return r.json();}).catch(function(){return {events:[]};});
     // Fetch skills for header token count
     var skills = await fetch('/api/skills').then(function(r){return r.json();}).catch(function(){return {skills:[],summary:{}};});
 
@@ -2939,7 +2943,7 @@ async function loadBrainPage(silent) {
   if (window.CLOUD_MODE) return;
   if (!silent) { advisorProbe(); selfevolveProbe(); }
   try {
-    var data = await fetchJsonWithTimeout('/api/brain-history', 8000);
+    var data = await fetchJsonWithTimeout('/api/brain-history?limit=300', 20000);
     var events = (data.events || []).slice().sort(function(a,b){
       var ta = a.time ? new Date(a.time).getTime() : 0;
       var tb = b.time ? new Date(b.time).getTime() : 0;
@@ -5027,7 +5031,7 @@ function startHealthStream() {
 // ===== System Health Panel =====
 async function loadSystemHealth() {
   try {
-    var d = await fetchJsonWithTimeout('/api/system-health', 4000);
+    var d = await fetchJsonWithTimeout('/api/system-health', 18000);
     var services = Array.isArray(d.services) ? d.services : [];
     var channels = Array.isArray(d.channels) ? d.channels : [];
     var disks = Array.isArray(d.disks) ? d.disks : [];
@@ -5117,7 +5121,7 @@ async function loadSystemHealth() {
 
     // Delegation chain panel (AgentWeave-inspired provenance view)
     try {
-      var chainData = await fetch('/api/delegation-tree').then(function(r){return r.json();}).catch(function(){return {chains:[]};});
+      var chainData = await fetchJsonWithTimeout('/api/delegation-tree', 4000).catch(function(){return {chains:[]};});
       var chains = (chainData && chainData.chains) || [];
       var chainsEl = document.getElementById('delegation-chains-panel');
       if (chainsEl) {
@@ -5167,7 +5171,7 @@ async function loadSystemHealth() {
 
     // Heartbeat status in system health
     try {
-      var hbData = await fetch('/api/heartbeat-status').then(function(r){return r.json();});
+      var hbData = await fetchJsonWithTimeout('/api/heartbeat-status', 3000);
       var hbEl = document.getElementById('sh-heartbeat');
       if (hbEl) {
         var hbStatus = hbData.status || 'unknown';
@@ -5249,7 +5253,7 @@ async function _loadReliabilityWidget() {
   var el = document.getElementById('sh-reliability');
   if (!wrap || !el) return;
   try {
-    var r = await fetch('/api/reliability').then(function(r) { return r.json(); });
+    var r = await fetchJsonWithTimeout('/api/reliability', 4000);
     if (r.direction === 'insufficient_data' || r.error) {
       wrap.style.display = 'none';
       return;
@@ -5293,6 +5297,67 @@ function startSystemHealthRefresh() {
   loadSystemHealth();
   if (window._sysHealthTimer) clearInterval(window._sysHealthTimer);
   window._sysHealthTimer = setInterval(loadSystemHealth, 30000);
+}
+
+async function loadDiagnostics() {
+  var el = document.getElementById('sh-diagnostics');
+  if (!el) return false;
+  try {
+    var d = await fetchJsonWithTimeout('/api/diagnostics', 6000).catch(function() {
+      return fetchJsonWithTimeout('/api/config-diagnostics', 6000);
+    });
+    var warnings = Array.isArray(d.warnings) ? d.warnings : [];
+    var flags = d.openclaw_flags && typeof d.openclaw_flags === 'object' ? d.openclaw_flags : {};
+    var flagKeys = Object.keys(flags);
+    var html = '';
+    function row(label, value, color) {
+      html += '<div><span style="color:var(--text-muted);">' + escHtml(label) + ':</span> '
+        + '<span style="color:' + (color || 'var(--text-primary)') + ';">' + escHtml(value == null || value === '' ? '—' : value) + '</span></div>';
+    }
+    row('Gateway', d.gateway_url || ('port ' + (d.gateway_port || '—')));
+    row('Workspace', d.workspace_path || '—');
+    row('Auth token', d.auth_token_status || 'unknown', d.auth_token_status === 'present' ? 'var(--text-success,#22c55e)' : 'var(--text-error,#dc2626)');
+    if (flagKeys.length) {
+      row('OpenClaw flags', flagKeys.map(function(k){ return k + '=' + flags[k]; }).join(', '));
+    }
+    if (warnings.length) {
+      html += '<div style="margin-top:6px;color:#f59e0b;">' + warnings.map(function(w){return '⚠️ ' + escHtml(w);}).join('<br>') + '</div>';
+    } else {
+      html += '<div style="margin-top:6px;color:var(--text-success,#22c55e);">✅ No diagnostics warnings</div>';
+    }
+    el.innerHTML = html;
+    return true;
+  } catch (e) {
+    console.warn('diagnostics load failed', e);
+    el.innerHTML = '<div style="color:var(--text-muted);">Unable to load diagnostics right now</div>';
+    return false;
+  }
+}
+
+function copyDiagnostics() {
+  var el = document.getElementById('sh-diagnostics');
+  var btn = document.getElementById('sh-diagnostics-copy');
+  var text = el ? (el.innerText || el.textContent || '') : '';
+  if (!text) return;
+  function done() {
+    if (!btn) return;
+    var old = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function(){ btn.textContent = old || '📋 Copy'; }, 1200);
+  }
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(done).catch(function(){});
+  } else {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      done();
+    } catch(e) {}
+  }
 }
 
 // ===== Sandbox Status (dedicated endpoint) =====
@@ -6652,7 +6717,7 @@ function startOverviewRefresh() {
 // instead of the previous "last tool call only" summary.
 async function loadMainActivity() {
   try {
-    var data = await fetchJsonWithTimeout('/api/brain-history?limit=40', 6000);
+    var data = await fetchJsonWithTimeout('/api/brain-history?limit=40', 12000);
     var el = document.getElementById('main-activity-list');
     var dot = document.getElementById('main-activity-dot');
     var label = document.getElementById('main-activity-label');
@@ -7728,9 +7793,6 @@ async function loadOverviewTasks() {
     var countBadge = document.getElementById('overview-tasks-count-badge');
     if (!el) return true;
     var agents = data.subagents || [];
-
-    // Also load into hidden active-tasks-grid for compatibility
-    loadActiveTasks();
 
     if (agents.length === 0) {
       if (countBadge) countBadge.textContent = '';
@@ -10504,7 +10566,7 @@ async function bootDashboard() {
   var results = await Promise.allSettled([
     _withTimeout(Promise.resolve().then(loadAll), 5000, 'overview'),
     _withTimeout(Promise.resolve().then(loadOverviewTasks), 5000, 'tasks'),
-    _withTimeout(Promise.resolve().then(loadSystemHealth), 5000, 'health'),
+    _withTimeout(Promise.resolve().then(loadSystemHealth), 12000, 'health'),
   ]);
   var okOverview = results[0].status === 'fulfilled' && results[0].value !== false;
   var okTasks    = results[1].status === 'fulfilled' && results[1].value !== false;
@@ -10531,7 +10593,6 @@ async function bootDashboard() {
   startSystemHealthRefresh();
   startOverviewRefresh();
   startOverviewTasksRefresh();
-  startActiveTasksRefresh();
 
   var sub = document.getElementById('boot-sub');
   if (sub) sub.textContent = 'Dashboard ready';

--- a/dashboard.py
+++ b/dashboard.py
@@ -9880,6 +9880,12 @@ def _compute_transcript_analytics():
             # Accept both live `.jsonl` and archived `.jsonl.reset.<ts>` files.
             if not (fname.endswith(".jsonl") or ".jsonl.reset." in fname):
                 continue
+            # Runtime trajectory/checkpoint files duplicate session content and
+            # can dwarf real transcripts (hundreds of MB). They make usage
+            # widgets crawl on first load, so keep analytics on canonical
+            # session/reset transcripts only.
+            if ".trajectory." in fname or ".checkpoint." in fname or ".deleted." in fname:
+                continue
             sid = fname.split(".jsonl", 1)[0]
             fpath = os.path.join(sessions_dir, fname)
             fallback_dt = datetime.fromtimestamp(os.path.getmtime(fpath))
@@ -10211,6 +10217,12 @@ def _compute_transcript_analytics():
             # days; skipping them was making the 14-day chart pile every
             # past-day total onto today.
             if not (fname.endswith(".jsonl") or ".jsonl.reset." in fname):
+                continue
+            # Runtime trajectory/checkpoint files duplicate session content and
+            # can dwarf real transcripts (hundreds of MB). They make usage
+            # widgets crawl on first load, so keep analytics on canonical
+            # session/reset transcripts only.
+            if ".trajectory." in fname or ".checkpoint." in fname or ".deleted." in fname:
                 continue
             sid = fname.split(".jsonl", 1)[0]
             fpath = os.path.join(sessions_dir, fname)

--- a/routes/autonomy.py
+++ b/routes/autonomy.py
@@ -20,6 +20,9 @@ from flask import Blueprint, jsonify
 
 bp_autonomy = Blueprint("autonomy", __name__)
 
+_AUTONOMY_CACHE = {"ts": 0.0, "data": None}
+_AUTONOMY_CACHE_TTL_SECONDS = 60
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -90,7 +93,11 @@ def _compute_autonomy(sessions_dir: str) -> dict:
     try:
         files = [
             f for f in os.listdir(sessions_dir)
-            if f.endswith(".jsonl") and ".deleted." not in f and ".reset." not in f
+            if f.endswith(".jsonl")
+            and ".deleted." not in f
+            and ".reset." not in f
+            and ".trajectory." not in f
+            and ".checkpoint." not in f
         ]
     except OSError:
         return _empty_response()
@@ -272,6 +279,10 @@ def _empty_response() -> dict:
 @bp_autonomy.route("/api/autonomy")
 def api_autonomy():
     import dashboard as _d
+    now = datetime.now(tz=timezone.utc).timestamp()
+    cached = _AUTONOMY_CACHE.get("data")
+    if cached is not None and (now - float(_AUTONOMY_CACHE.get("ts") or 0)) < _AUTONOMY_CACHE_TTL_SECONDS:
+        return jsonify(cached)
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )
@@ -279,4 +290,6 @@ def api_autonomy():
         result = _compute_autonomy(sessions_dir)
     except Exception:
         result = _empty_response()
+    _AUTONOMY_CACHE["data"] = result
+    _AUTONOMY_CACHE["ts"] = now
     return jsonify(result)

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -19,15 +19,70 @@ import json
 import os
 import time
 
-from flask import Blueprint, Response, jsonify
+from flask import Blueprint, Response, jsonify, request
 
 bp_brain = Blueprint('brain', __name__)
+
+
+_BRAIN_HISTORY_CACHE = {}
+_BRAIN_HISTORY_CACHE_TTL_SECONDS = 3.0
+_BRAIN_HISTORY_TAIL_BYTES = 512 * 1024
+
+
+def _brain_history_bool_arg(value):
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on", "all"}
+
+
+def _brain_history_is_artifact(path):
+    name = os.path.basename(path)
+    return name.endswith(".trajectory.jsonl") or ".checkpoint." in name
+
+
+def _brain_history_read_head_tail(path, head_lines=20, tail_bytes=_BRAIN_HISTORY_TAIL_BYTES):
+    """Read a tiny context head plus byte-tail from a JSONL file.
+
+    The old implementation used readlines() on every session file. On large
+    installs that can mean hundreds of MB for every Brain refresh. This keeps
+    context rows while bounding I/O per file.
+    """
+    try:
+        with open(path, "rb") as fh:
+            size = os.fstat(fh.fileno()).st_size
+            if size <= tail_bytes:
+                return fh.read().decode("utf-8", "replace").splitlines()
+
+            head = []
+            for _ in range(head_lines):
+                line = fh.readline()
+                if not line:
+                    break
+                head.append(line.decode("utf-8", "replace").rstrip("\r\n"))
+
+            fh.seek(max(0, size - tail_bytes))
+            fh.readline()  # drop a possibly partial JSONL row
+            tail = fh.read().decode("utf-8", "replace").splitlines()
+            return head + tail[-900:]
+    except Exception:
+        return []
 
 
 @bp_brain.route("/api/brain-history")
 def api_brain_history():
     import dashboard as _d
-    # Return unified event stream - v2 no truncation
+    try:
+        limit = max(1, min(500, int(request.args.get("limit", 300))))
+    except (TypeError, ValueError):
+        limit = 300
+    include_artifacts = _brain_history_bool_arg(
+        request.args.get("include_artifacts") or request.args.get("artifacts")
+    )
+    cache_key = (limit, include_artifacts)
+    cached = _BRAIN_HISTORY_CACHE.get(cache_key)
+    now_cache = time.time()
+    if cached and now_cache - cached[0] < _BRAIN_HISTORY_CACHE_TTL_SECONDS:
+        return jsonify(cached[1])
+
+    # Return unified event stream - v2 bounded by limit + tail reads
     events = []
 
     # Build sessionId to displayName + channel map
@@ -288,7 +343,19 @@ def api_brain_history():
             pass
 
     # Source 2: Session JSONL files (sub-agent activity)
-    session_files = sorted(glob.glob(os.path.join(session_dir, "*.jsonl")))
+    session_files_all = glob.glob(os.path.join(session_dir, "*.jsonl"))
+    if not include_artifacts:
+        session_files_all = [sf for sf in session_files_all if not _brain_history_is_artifact(sf)]
+
+    def _session_file_mtime(sf):
+        try:
+            return os.path.getmtime(sf)
+        except OSError:
+            return 0
+
+    session_files = sorted(session_files_all, key=_session_file_mtime, reverse=True)
+    max_files = 250 if include_artifacts else max(50, min(250, limit * 2))
+    session_files = session_files[:max_files]
 
     for sf in session_files:
         try:
@@ -309,17 +376,7 @@ def api_brain_history():
             )
             color = get_agent_color(source_id)
 
-            with open(sf, "r", errors="replace") as fh:
-                all_lines = fh.readlines()
-                # Want: first 20 (system context) + last 600 (recent activity).
-                # For files <= 620 lines the two slices overlap and we end up
-                # parsing the same JSONL line twice -> duplicate events in the
-                # Brain feed (same timestamp, same source, same payload).
-                total = len(all_lines)
-                if total <= 620:
-                    raw_lines = all_lines
-                else:
-                    raw_lines = all_lines[:20] + all_lines[-600:]
+            raw_lines = _brain_history_read_head_tail(sf)
 
             for raw in raw_lines:
                 raw = raw.strip()
@@ -573,7 +630,7 @@ def api_brain_history():
     )  # ISO string sort - correct across days
     # Keep CONTEXT events + most recent 300
     context_evts = [e for e in events if e.get("type") == "CONTEXT"]
-    other_evts = [e for e in events if e.get("type") != "CONTEXT"][:300]
+    other_evts = [e for e in events if e.get("type") != "CONTEXT"][:limit]
     events = context_evts + other_evts
     sources_seen = []
     seen_set = set()
@@ -626,7 +683,12 @@ def api_brain_history():
         _d._ext_emit("brain.event", {"count": len(events)})
     except Exception:
         pass
-    return jsonify({"events": events, "total": len(events), "sources": sources_seen, "channels": channel_counts})
+    payload = {"events": events, "total": len(events), "sources": sources_seen, "channels": channel_counts}
+    _BRAIN_HISTORY_CACHE[cache_key] = (time.time(), payload)
+    if len(_BRAIN_HISTORY_CACHE) > 8:
+        oldest_key = min(_BRAIN_HISTORY_CACHE, key=lambda k: _BRAIN_HISTORY_CACHE[k][0])
+        _BRAIN_HISTORY_CACHE.pop(oldest_key, None)
+    return jsonify(payload)
 
 
 @bp_brain.route("/api/brain-stream")

--- a/routes/health.py
+++ b/routes/health.py
@@ -557,6 +557,7 @@ def api_health():
     return jsonify({"checks": checks})
 
 
+@bp_health.route("/api/config-diagnostics")
 @bp_health.route("/api/diagnostics")
 def api_diagnostics():
     """Surface detected configuration for the Diagnostics panel (GH#28).

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -207,7 +207,7 @@ def api_overview():
     import dashboard as _d
 
     # Try gateway API for sessions
-    gw_sessions = _d._gw_invoke("sessions_list", {"limit": 50, "messageLimit": 0})
+    gw_sessions = _d._gw_invoke("sessions_list", {"limit": 20, "messageLimit": 0})
     if gw_sessions and "sessions" in gw_sessions:
         sessions = gw_sessions["sessions"]
     else:

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -26,11 +26,16 @@ from flask import Blueprint, jsonify, request
 
 bp_sessions = Blueprint('sessions', __name__)
 
+_SUBAGENTS_CACHE = {"ts": 0.0, "data": None}
+_SUBAGENTS_CACHE_TTL_SECONDS = 10
+_SUBAGENTS_SCAN_MAX_FILES = int(os.environ.get("CLAWMETRY_SUBAGENTS_SCAN_MAX_FILES", "120"))
+_SUBAGENTS_SCAN_TAIL_BYTES = int(os.environ.get("CLAWMETRY_SUBAGENTS_SCAN_TAIL_BYTES", str(512 * 1024)))
+
 
 @bp_sessions.route("/api/sessions")
 def api_sessions():
     import dashboard as _d
-    gw_data = _d._gw_invoke("sessions_list", {"limit": 50, "messageLimit": 0})
+    gw_data = _d._gw_invoke("sessions_list", {"limit": 20, "messageLimit": 0})
     if gw_data and "sessions" in gw_data:
         return jsonify({"sessions": _d._augment_sessions_with_burn(gw_data["sessions"])})
     return jsonify({"sessions": _d._augment_sessions_with_burn(_d._get_sessions())})
@@ -523,7 +528,7 @@ def api_task_runs():
     })
 
 
-def _scan_spawn_events_from_jsonl(sessions_dir):
+def _scan_spawn_events_from_jsonl(sessions_dir, max_files=None, tail_bytes=None):
     """Walk every session JSONL and pair SPAWN toolCall/toolResult rows.
 
     OpenClaw's subagent lifecycle is:
@@ -558,7 +563,15 @@ def _scan_spawn_events_from_jsonl(sessions_dir):
     _task_name_re = _re.compile(r"^task:\s*(.+)$", _re.MULTILINE)
     _status_re = _re.compile(r"^status:\s*(.+)$", _re.MULTILINE)
 
-    for fpath in _glob.glob(os.path.join(sessions_dir, "*.jsonl")):
+    files = _glob.glob(os.path.join(sessions_dir, "*.jsonl"))
+    try:
+        files.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    except Exception:
+        pass
+    if max_files and max_files > 0:
+        files = files[:max_files]
+
+    for fpath in files:
         if ".deleted." in fpath:
             continue
         # Skip checkpoints - their content is duplicated into the main file
@@ -571,6 +584,14 @@ def _scan_spawn_events_from_jsonl(sessions_dir):
         completions = {} # childSessionKey → {task, status, result, stats, ts}
         try:
             with open(fpath, "r", errors="replace") as fh:
+                if tail_bytes and tail_bytes > 0:
+                    try:
+                        size = os.path.getsize(fpath)
+                        if size > tail_bytes:
+                            fh.seek(max(0, size - tail_bytes))
+                            fh.readline()  # drop partial line after seek
+                    except Exception:
+                        pass
                 for raw in fh:
                     raw = raw.strip()
                     if not raw:
@@ -722,6 +743,11 @@ def api_subagents():
     """
     import dashboard as _d
     now_ms = time.time() * 1000
+    full_scan = request.args.get("full", "").strip().lower() in ("1", "true", "yes")
+    if not full_scan:
+        cached = _SUBAGENTS_CACHE.get("data")
+        if cached is not None and (time.time() - float(_SUBAGENTS_CACHE.get("ts") or 0)) < _SUBAGENTS_CACHE_TTL_SECONDS:
+            return jsonify(cached)
 
     # Source 1: canonical subagent registry
     reg_active = []
@@ -740,7 +766,7 @@ def api_subagents():
     # value would append registry + spawn entries to the cache itself, so
     # every subsequent /api/subagents call inherits the previous call's
     # appends — subagents get duplicated exponentially (6x, 8x, 10x...).
-    gw_data = _d._gw_invoke("sessions_list", {"limit": 100, "messageLimit": 0})
+    gw_data = _d._gw_invoke("sessions_list", {"limit": 20, "messageLimit": 0})
     if gw_data and "sessions" in gw_data:
         all_sessions = list(gw_data["sessions"])
     else:
@@ -779,7 +805,11 @@ def api_subagents():
         "~/.openclaw/agents/main/sessions"
     )
     try:
-        spawn_events = _scan_spawn_events_from_jsonl(sessions_dir)
+        spawn_events = _scan_spawn_events_from_jsonl(
+            sessions_dir,
+            max_files=None if full_scan else _SUBAGENTS_SCAN_MAX_FILES,
+            tail_bytes=None if full_scan else _SUBAGENTS_SCAN_TAIL_BYTES,
+        )
     except Exception:
         spawn_events = []
     # Build a lookup by childKey so we can enrich entries from sources 1/2
@@ -913,7 +943,11 @@ def api_subagents():
 
     _status_rank = {"active": 0, "idle": 1, "stale": 2, "failed": 3}
     subagents.sort(key=lambda x: (_status_rank.get(x["status"], 9), x["depth"]))
-    return jsonify({"subagents": subagents, "counts": counts})
+    payload = {"subagents": subagents, "counts": counts}
+    if not full_scan:
+        _SUBAGENTS_CACHE["data"] = payload
+        _SUBAGENTS_CACHE["ts"] = time.time()
+    return jsonify(payload)
 
 
 @bp_sessions.route("/api/delegation-tree")

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -33,6 +33,9 @@ from flask import Blueprint, jsonify, make_response, request
 
 bp_usage = Blueprint('usage', __name__)
 
+_CLUSTER_CACHE = {"ts": 0.0, "key": None, "data": None}
+_CLUSTER_CACHE_TTL_SECONDS = 120
+
 
 @bp_usage.route("/api/usage")
 def api_usage():
@@ -342,6 +345,10 @@ def api_sessions_clusters():
         days = int(request.args.get("days", 30))
     except (ValueError, TypeError):
         days = 30
+    cache_key = f"days:{days}"
+    cached = _CLUSTER_CACHE.get("data")
+    if cached is not None and _CLUSTER_CACHE.get("key") == cache_key and (now_ts - float(_CLUSTER_CACHE.get("ts") or 0)) < _CLUSTER_CACHE_TTL_SECONDS:
+        return jsonify(cached)
     cutoff_ts = now_ts - (days * 86400)
 
     sessions_dir = _d._get_sessions_dir()
@@ -360,6 +367,8 @@ def api_sessions_clusters():
 
     for fname in os.listdir(sessions_dir):
         if not fname.endswith(".jsonl"):
+            continue
+        if ".trajectory." in fname or ".checkpoint." in fname or ".deleted." in fname:
             continue
         fpath = os.path.join(sessions_dir, fname)
         try:
@@ -579,14 +588,16 @@ def api_sessions_clusters():
 
     clusters_out.sort(key=lambda x: x["session_count"], reverse=True)
 
-    return jsonify(
-        {
-            "clusters": clusters_out,
-            "total_sessions": len(session_profiles),
-            "days": days,
-            "generated_at": int(now_ts * 1000),
-        }
-    )
+    payload = {
+        "clusters": clusters_out,
+        "total_sessions": len(session_profiles),
+        "days": days,
+        "generated_at": int(now_ts * 1000),
+    }
+    _CLUSTER_CACHE["data"] = payload
+    _CLUSTER_CACHE["key"] = cache_key
+    _CLUSTER_CACHE["ts"] = time.time()
+    return jsonify(payload)
 
 
 @bp_usage.route("/api/usage/cost-comparison")

--- a/tests/test_dashboard_perf_hotfix.py
+++ b/tests/test_dashboard_perf_hotfix.py
@@ -1,0 +1,103 @@
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from routes import autonomy, brain, sessions
+
+
+def _write_jsonl(path: Path, rows):
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+
+def _user_message(ts=None):
+    return {
+        "type": "message",
+        "timestamp": ts or datetime.now(tz=timezone.utc).isoformat(),
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": "hello"}],
+        },
+    }
+
+
+def _spawn_rows(call_id="call-1", child_key="agent:main:subagent:child-1"):
+    return [
+        {
+            "type": "message",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "toolCall",
+                        "id": call_id,
+                        "name": "subagents",
+                        "arguments": {"action": "spawn", "label": "worker", "task": "do work"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "message",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "message": {
+                "role": "toolResult",
+                "toolName": "subagents",
+                "toolCallId": call_id,
+                "details": {"childSessionKey": child_key, "runId": "run-1"},
+                "content": [{"type": "text", "text": "accepted"}],
+            },
+        },
+    ]
+
+
+def test_autonomy_ignores_runtime_artifact_jsonl(tmp_path):
+    _write_jsonl(tmp_path / "main-session.jsonl", [_user_message()])
+    _write_jsonl(
+        tmp_path / "main-session.trajectory.jsonl",
+        [_user_message(), _user_message()],
+    )
+    _write_jsonl(
+        tmp_path / "main-session.checkpoint.abc.jsonl",
+        [_user_message(), _user_message()],
+    )
+
+    data = autonomy._compute_autonomy(str(tmp_path))
+
+    assert data["samples_7d"] == 1
+    assert data["autonomy_ratio_7d"] == 1.0
+
+
+def test_brain_history_bounds_large_file_reads_and_detects_artifacts(tmp_path):
+    assert brain._brain_history_is_artifact(str(tmp_path / "a.trajectory.jsonl"))
+    assert brain._brain_history_is_artifact(str(tmp_path / "a.checkpoint.abc.jsonl"))
+    assert not brain._brain_history_is_artifact(str(tmp_path / "a.jsonl"))
+
+    rows = [json.dumps({"line": i}) for i in range(200)]
+    fpath = tmp_path / "large.jsonl"
+    fpath.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    read_rows = brain._brain_history_read_head_tail(str(fpath), head_lines=3, tail_bytes=120)
+
+    assert json.loads(read_rows[0])["line"] == 0
+    assert json.loads(read_rows[1])["line"] == 1
+    assert json.loads(read_rows[2])["line"] == 2
+    assert json.loads(read_rows[-1])["line"] == 199
+    assert len(read_rows) < len(rows)
+
+
+def test_subagent_jsonl_scan_can_be_bounded_by_recent_files(tmp_path):
+    older = tmp_path / "older.jsonl"
+    newer = tmp_path / "newer.jsonl"
+    _write_jsonl(older, _spawn_rows())
+    _write_jsonl(newer, [_user_message()])
+
+    old_ts = time.time() - 100
+    new_ts = time.time()
+    os.utime(older, (old_ts, old_ts))
+    os.utime(newer, (new_ts, new_ts))
+
+    assert len(sessions._scan_spawn_events_from_jsonl(str(tmp_path), max_files=None)) == 1
+    assert sessions._scan_spawn_events_from_jsonl(str(tmp_path), max_files=1) == []


### PR DESCRIPTION
## Summary

Fixes slow dashboard widget loads on installs with large OpenClaw runtime artifacts. The dashboard was scanning `.trajectory.jsonl` and `.checkpoint.*.jsonl` files for analytics paths where those files duplicate canonical session transcripts, causing first-load widgets to queue behind hundreds of MB of JSONL reads.

This PR keeps analytics on canonical session/reset transcripts, bounds expensive history scans, and staggers non-critical widgets so the overview becomes usable quickly instead of stampeding the backend.

## How it works

1. **Skip duplicate runtime artifacts in transcript analytics** — usage and dashboard analytics ignore `.trajectory`, `.checkpoint`, and `.deleted` JSONL files so `/api/usage` stays focused on canonical transcripts.

2. **Bound Brain history reads** — `/api/brain-history` now supports `limit`, skips artifact files by default, sorts sessions newest-first, reads head + bounded tail instead of `readlines()` on every file, and keeps a tiny short-lived cache.

3. **Cache heavy overview cards** — `/api/autonomy` and `/api/sessions/clusters` get small TTL caches, and both avoid duplicated runtime artifacts where applicable.

4. **Reduce hot-path session fanout** — overview/session/subagent gateway lookups use smaller limits on dashboard hot paths, while `/api/subagents?full=1` still allows a complete scan when needed.

5. **Avoid frontend boot stampedes** — the overview starts critical widgets immediately and staggers expensive/non-critical cards; duplicate active-task refreshes are removed.

6. **Unstick diagnostics/health panels** — diagnostics now renders in the System Health panel, `/api/config-diagnostics` aliases `/api/diagnostics`, and nested health-card fetches have bounded timeouts.

## Tests

### Test plan

1. Open dashboard on an install with many .trajectory.jsonl / .checkpoint.*.jsonl files — overview widgets should populate without a long 30s+ wait
2. Brain tab still loads recent events and supports SSE with the stored auth token
3. System Health shows Diagnostics instead of staying on Loading diagnostics...
4. /api/subagents returns quickly by default; /api/subagents?full=1 can still do the complete historical scan

```bash
15 passed in 2.36s
```