### PR TITLE
feat(alerts): add token_velocity as configurable alert metric (closes #868)

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -36,6 +36,9 @@
     { id: 'example_session', alert_type: 'session_cost', name: 'Session cost > $5',
       threshold_value: 5, threshold_unit: 'USD',
       _exampleChannels: '✉️ Email' },
+    { id: 'example_velocity', alert_type: 'token_velocity', name: 'Token velocity > 10k/min',
+      threshold_value: 10000, threshold_unit: 'tokens/min',
+      _exampleChannels: '✈️ Telegram · ✉️ Email' },
     { id: 'example_cron', alert_type: 'cron_failure', name: 'Cron failed 3× in a row',
       threshold_value: 3, threshold_unit: 'fails',
       _exampleChannels: '💬 Slack · ✈️ Telegram' },
@@ -345,11 +348,12 @@
     const t = alertsState.editorType;
     const r = alertsState.editorRule || {};
     const presets = {
-      daily_spend:  { unit: 'USD',    placeholder: 50, label: 'Daily spend exceeds', name: 'Daily spend cap' },
-      session_cost: { unit: 'USD',    placeholder: 5,  label: 'Single session cost exceeds', name: 'Session cost cap' },
-      node_offline: { unit: 'min',    placeholder: 10, label: 'Agent has been offline for more than', name: 'Agent offline' },
-      cron_failure: { unit: 'fails',  placeholder: 3,  label: 'Cron has failed in a row at least', name: 'Cron failure streak' },
-      error_rate:   { unit: '%',      placeholder: 20, label: 'Tool failure rate exceeds', name: 'Tool failures' },
+      daily_spend:    { unit: 'USD',         placeholder: 50,    label: 'Daily spend exceeds', name: 'Daily spend cap' },
+      session_cost:   { unit: 'USD',         placeholder: 5,     label: 'Single session cost exceeds', name: 'Session cost cap' },
+      node_offline:   { unit: 'min',         placeholder: 10,    label: 'Agent has been offline for more than', name: 'Agent offline' },
+      token_velocity: { unit: 'tokens/min',  placeholder: 10000, label: 'Token velocity exceeds', name: 'Runaway session' },
+      cron_failure:   { unit: 'fails',       placeholder: 3,     label: 'Cron has failed in a row at least', name: 'Cron failure streak' },
+      error_rate:     { unit: '%',           placeholder: 20,    label: 'Tool failure rate exceeds', name: 'Tool failures' },
     };
     const p = presets[t] || { unit: '', placeholder: 0, label: 'Threshold', name: 'Custom alert' };
     const val = r.threshold_value ?? p.placeholder;

--- a/clawmetry/templates/tabs/alerts.html
+++ b/clawmetry/templates/tabs/alerts.html
@@ -76,6 +76,7 @@
         <button data-type="daily_spend" onclick="alertsPickType('daily_spend')">💰 Cost</button>
         <button data-type="node_offline" class="active" onclick="alertsPickType('node_offline')">🤖 Agent</button>
         <button data-type="session_cost" onclick="alertsPickType('session_cost')">🧵 Session</button>
+        <button data-type="token_velocity" onclick="alertsPickType('token_velocity')">⚡ Velocity</button>
         <button data-type="cron_failure" onclick="alertsPickType('cron_failure')">⏱ Cron</button>
         <button data-type="error_rate" onclick="alertsPickType('error_rate')">🛠 Tool fails</button>
       </div>


### PR DESCRIPTION
Closes #868

## What
The Alerts editor advertised a token_velocity metric in `RULE_TYPE_LABELS` (icon ⚡, verb "Tokens/min >") but did not actually expose it as a creatable rule type — the segment buttons in the editor only offered Cost / Agent / Session / Cron / Tool fails. As a result, users could not configure a tokens/minute threshold even though the icon hinted that they could.

## How
- **`clawmetry/templates/tabs/alerts.html`** — added a new `⚡ Velocity` segment button between Session and Cron, wired to `alertsPickType('token_velocity')`.
- **`clawmetry/static/js/alerts.js`** —
  - added a `token_velocity` preset to `renderEditorForm()` with unit `tokens/min`, default `10000`, label "Token velocity exceeds". Without this, picking the new button fell through to the generic "Threshold" form.
  - added an `example_velocity` canned rule so Free-tier / unauth users see Velocity surfaced alongside the existing cost / agent / session / cron / tool-fail examples.

The cloud backend already accepted `alert_type=token_velocity` (it's in `RULE_TYPE_LABELS` and the existing fleet-side velocity detector fires under the same name), so no backend change is required.

## Test plan
- Open Alerts tab → "+ New alert rule"
- Verify the new `⚡ Velocity` button appears between Session and Cron
- Click it → verify form shows "Token velocity exceeds" label, `tokens/min` unit, `10000` default
- Verify the new canned `Token velocity > 10k/min` example shows up for Free users in the rules list

🤖 Generated with [Claude Code](https://claude.com/claude-code)