### PR TITLE
docs: fix stale line counts, version, endpoint name, and architecture narrative (#872)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -208,14 +208,14 @@ Secured with `CLAWMETRY_FLEET_KEY` — nodes must provide the API key to registe
 
 ## Technical Details
 
-### Single-File Architecture
-ClawMetry is intentionally a **single Python file** (`dashboard.py`, ~11,600 lines). This makes it:
+### Per-Feature Blueprint Architecture
+ClawMetry organises HTTP endpoints into per-feature Blueprint modules under `routes/` (sessions, health, usage, brain, crons, …). Each module owns one or more Flask Blueprints that are registered on the central `dashboard.py` app. Shared helpers and app state stay in `dashboard.py` and are reached via late `import dashboard as _d`. This makes it:
 - Easy to install (`pip install clawmetry`)
-- Easy to audit (one file to read)
+- Easy to audit (each feature lives in its own `routes/<feature>.py` module)
 - Easy to deploy (no build step)
 - Portable (runs on a Raspberry Pi)
 
-The HTML/CSS/JS dashboard is embedded as template strings inside the Python file.
+The HTML/CSS/JS dashboard is still embedded as template strings inside `dashboard.py`. No build step, no npm.
 
 ### Dependencies
 Minimal by design:
@@ -226,7 +226,7 @@ Minimal by design:
 
 ### History Module (`history.py`)
 An optional companion that adds persistent time-series:
-- Stores snapshots every 5 minutes in SQLite
+- Stores snapshots every 60 seconds in SQLite
 - Enables historical charts (token usage over days/weeks)
 - Session history with cost trends
 - Cron execution history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ See `ARCHITECTURE.md` for the full deep dive. TL;DR:
 
 ### Core
 | File | Lines | Purpose |
-|------|-------|---------|
-| `dashboard.py` | ~25,400 | Flask app, blueprint registration, embedded HTML/CSS/JS, shared helpers |
+|------|-------|----------|
+| `dashboard.py` | ~15,013 | Flask app, blueprint registration, embedded HTML/CSS/JS, shared helpers |
 | `dashboard_claudecode.py` | ~1,350 | Claude Code session dashboard variant (standalone or Blueprint) |
 | `history.py` | ~555 | Optional time-series collector (SQLite, polls gateway every 60s) |
 
@@ -27,12 +27,12 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 
 | File | Lines | Blueprints / Purpose |
 |------|-------|----------------------|
-| `routes/sessions.py` | ~1,190 | `bp_sessions` — sessions list, transcripts, compactions, tool timeline, cost split, subagents, exports |
+| `routes/sessions.py` | ~1,556 | `bp_sessions` — sessions list, transcripts, compactions, tool timeline, cost split, subagents, exports |
 | `routes/channels.py` | ~1,500 | `bp_channels` — 21 chat-channel adapters (Telegram, Signal, WhatsApp, Discord, Slack, IRC, iMessage, WebChat, …) |
 | `routes/components.py` | ~1,040 | `bp_components` — Flow-panel detail endpoints (tool / runtime / machine / gateway / brain) |
 | `routes/usage.py` | ~1,070 | `bp_usage` — token/cost analytics, anomaly detection, model + skill attribution |
 | `routes/health.py` | ~920 | `bp_health` — system-health, reliability, diagnostics, rate-limits, sandbox-status, health-stream (SSE) |
-| `routes/brain.py` | ~800 | `bp_brain` — `/api/brain-history` + `/api/brain-stream` (SSE) |
+| `routes/brain.py` | ~1,027 | `bp_brain` — `/api/brain-history` + `/api/brain-stream` (SSE) |
 | `routes/infra.py` | ~785 | `bp_logs` + `bp_memory` + `bp_security` + `bp_config` — logs stream, memory files, security posture, cost-optimizer |
 | `routes/overview.py` | ~585 | `bp_overview` — main dashboard endpoint, channels list, timeline, cloud-CTA OTP |
 | `routes/crons.py` | ~530 | `bp_crons` — cron CRUD + run log + health summary |
@@ -44,20 +44,20 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 
 ### Package (`clawmetry/`)
 | File | Lines | Purpose |
-|------|-------|---------|
+|------|-------|----------|
 | `cli.py` | ~1,900 | CLI entry point — `clawmetry`, `clawmetry connect`, `clawmetry sync`, `clawmetry status` |
-| `sync.py` | ~3,000 | Cloud sync daemon — E2E encrypted (AES-256-GCM) session streaming to `ingest.clawmetry.com` |
+| `sync.py` | ~3,876 | Cloud sync daemon — E2E encrypted (AES-256-GCM) session streaming to `ingest.clawmetry.com` |
 | `proxy.py` | ~1,290 | Enforcement proxy — budget limits, loop detection, model routing (port 4100) |
 | `interceptor.py` | ~465 | Zero-config HTTP monkey-patching for LLM cost tracking (patches httpx/requests) |
 | `providers_pricing.py` | ~134 | Multi-provider pricing table (Anthropic, OpenAI, Google, OpenRouter, etc.) |
-| `config.py` | ~58 | Configuration dataclass |
+| `config.py` | ~79 | Configuration dataclass |
 | `extensions.py` | ~109 | Plugin/hook system |
 | `track.py` | ~39 | Zero-config interceptor shorthand |
 | `providers/` | — | Pluggable data provider layer (LocalDataProvider, TursoDataProvider) |
 
 ### Config & Build
 | File | Purpose |
-|------|---------|
+|------|----------|
 | `setup.py` | PyPI package definition (entry point: `clawmetry` CLI) |
 | `requirements.txt` | pip dependencies |
 | `Dockerfile` | Docker image (Python 3.11-slim base) |
@@ -66,7 +66,7 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 
 ### Documentation
 | File | Purpose |
-|------|---------|
+|------|----------|
 | `ARCHITECTURE.md` | Detailed architecture guide with diagrams |
 | `CHANGELOG.md` | Version history (~11,600 lines) |
 | `CONTRIBUTING.md` | Contribution guidelines |
@@ -86,7 +86,8 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 - `/api/transcript/<id>` — Full session transcript
 - `/api/usage` — Token and cost analytics
 - `/api/flow` — Message flow visualization (channels -> gateway -> models -> tools)
-- `/api/brain` — Live event stream
+- `/api/brain-history` — Brain event history
+- `/api/brain-stream` — Live event stream (SSE)
 - `/api/crons` — Cron job management (full CRUD via gateway RPC)
 - `/api/system-health` — Disk, memory, uptime, GPU
 - `/api/nodes` — Multi-node fleet view
@@ -133,7 +134,7 @@ Tests use `CLAWMETRY_URL` and `CLAWMETRY_TOKEN` env vars. Test matrix in CI: 3 O
 ## Deploy
 - **PyPI**: `pip install clawmetry && clawmetry`
 - **Docker**: `docker build -t clawmetry . && docker run -p 8900:8900 -v ~/.openclaw:/root/.openclaw:ro clawmetry`
-- **Current version**: `0.12.99` (in `dashboard.py` `__version__`)
+- **Current version**: `0.12.162` (in `dashboard.py` `__version__`)
 
 ## CI/CD (GitHub Actions)
 - `ci.yml` — Lint + test matrix on push/PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ clawmetry --help
 ```
 
 ### 4. **Make Changes & Test**
-- Edit `dashboard.py` (single file architecture)
+- Edit `dashboard.py` or the relevant `routes/<feature>.py` Blueprint module
 - Restart dashboard to see changes
 - Test auto-detection: `cd /tmp && python3 /path/to/dashboard.py`
 
@@ -38,7 +38,9 @@ clawmetry --help
 
 ```
 clawmetry/
-├── dashboard.py          # 🎯 Main application (single file)
+├── dashboard.py          # 🎯 Main app — blueprint registration, shared helpers, embedded HTML/JS
+├── routes/               # 📡 Per-feature Blueprint modules (sessions, health, usage, brain, …)
+├── clawmetry/            # 📦 CLI, sync daemon, interceptor, proxy
 ├── README.md             # 📖 Documentation
 ├── setup.py              # 📦 Package configuration
 ├── requirements.txt      # 🔧 Dependencies
@@ -47,7 +49,7 @@ clawmetry/
 └── CONTRIBUTING.md       # 📝 This file
 ```
 
-**Philosophy**: Keep it simple. The entire dashboard is one Python file (`dashboard.py`) with minimal dependencies. This makes it easy to understand, modify, and deploy.
+**Philosophy**: Keep it simple. HTTP endpoints live in per-feature Blueprint modules under `routes/`; shared helpers and the embedded frontend stay in `dashboard.py`. Minimal dependencies throughout.
 
 ---
 
@@ -62,7 +64,7 @@ clawmetry/
 
 ### **What to Avoid**
 - ❌ **Complex dependencies** - no heavy frameworks, ML libraries, or databases
-- ❌ **Breaking the single-file architecture** - keep everything in `dashboard.py`
+- ❌ **Dumping new endpoints into `dashboard.py`** — new routes belong in the relevant `routes/<feature>.py` Blueprint module
 - ❌ **Enterprise features** - this is for personal AI agents, not teams
 - ❌ **Major architectural changes** - discuss large changes in Issues first
 
@@ -109,8 +111,8 @@ Before submitting, test these scenarios:
 If you want to add a new tab or major feature:
 
 1. **Open an Issue first** - describe what you want to build and why
-2. **Keep it lightweight** - remember this is a single-file app
-3. **Follow the existing pattern** - look at how other tabs are implemented
+2. **Keep it lightweight** - minimal dependencies, no heavy frameworks
+3. **Follow the existing pattern** - look at how other tabs are implemented in `routes/`
 4. **Update the README** - document your new feature in the features table
 
 ---


### PR DESCRIPTION
## Summary

Fixes all items flagged in the weekly docs-drift sweep (#872). All three doc files still described the old single-file monolith; this PR brings them in sync with the current per-feature Blueprint layout and actual file sizes.

## Changes

**`CLAUDE.md`**
- Update five stale line-count figures: `dashboard.py` 25,400→15,013; `routes/sessions.py` 1,190→1,556; `routes/brain.py` 800→1,027; `clawmetry/sync.py` 3,000→3,876; `clawmetry/config.py` 58→79
- Replace `/api/brain` endpoint entry with the two actual routes: `/api/brain-history` + `/api/brain-stream`
- Bump `__version__` reference from `0.12.99` → `0.12.162`

**`ARCHITECTURE.md`**
- Rewrite the "Single-File Architecture" section to describe the per-feature Blueprint layout (the single-file claim has been architecturally false since `routes/` was introduced)
- Fix `history.py` snapshot cadence: "5 minutes" → "60 seconds" (matches `POLL_INTERVAL = 60` in the code)

**`CONTRIBUTING.md`**
- Update "Make Changes & Test" step to mention `routes/<feature>.py` alongside `dashboard.py`
- Expand project-structure tree to include `routes/` and `clawmetry/` directories
- Replace the "Breaking the single-file architecture" avoid-bullet with the accurate equivalent
- Update Philosophy paragraph to match the current layout

## Test plan

- [ ] `make lint` — no Python files changed, syntax check passes unchanged
- [ ] Read each updated section and confirm numbers match `wc -l` output on the actual files
- [ ] Confirm `routes/brain.py` has no `/api/brain` route (only `/api/brain-history` and `/api/brain-stream`)
- [ ] Confirm `dashboard.py` `__version__` is `0.12.162`

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #872. Marked draft for human review — mark Ready for Review once happy.

Closes #872

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBmgosEeZpFyCxPsJEvyAK)_