### PR TITLE
fix(health): register /healthz liveness probe route (#870)

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -2,8 +2,9 @@
 routes/health.py — Health / reliability / diagnostics / rate-limits endpoints.
 
 Extracted from dashboard.py as Phase 5.5 of the incremental modularisation.
-Owns the 11 routes registered on bp_health:
+Owns the 12 routes registered on bp_health:
 
+  GET  /healthz                   — liveness probe (Cloud Run / Kubernetes)
   GET  /api/reliability           — cross-session behavioral reliability trend
   GET  /api/heatmap               — activity heatmap (events per hour, N days)
   GET  /api/system-health         — comprehensive system health (services, disks, crons)
@@ -916,3 +917,10 @@ def api_sandbox_status():
             security = sec_fields
 
     return jsonify({"sandbox": sandbox, "inference": inference, "security": security})
+
+
+@bp_health.route("/healthz")
+def healthz():
+    """Liveness probe for Cloud Run / Kubernetes health checks."""
+    import dashboard as _d
+    return jsonify({"status": "ok", "version": _d.__version__})


### PR DESCRIPTION
## Summary

`GET /healthz` was returning 404 because the route was never registered in `bp_health`. Cloud Run (and Kubernetes) use this path as a liveness probe, so a missing route means the health check silently fails. This PR adds a minimal, non-blocking handler that returns `{"status": "ok", "version": "..."}`.

## Changes

- `routes/health.py`: add `GET /healthz` handler at the end of `bp_health`; update module docstring route count from 11 → 12

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("routes/health.py").read())'` — syntax clean
- [ ] Start the server locally (`make dev`) and run `curl -si http://localhost:8900/healthz` — expect `HTTP/1.1 200 OK` with `{"status":"ok","version":"..."}`
- [ ] Confirm existing `/api/health` endpoint still returns its full JSON payload unaffected

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #870. Marked draft for human review — mark Ready for Review once happy.

Closes #870

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb38UEUvRp9SC6JkmED7A5)_