### PR TITLE
feat(overview): add /api/autonomy-score endpoint (#688)

### DIFF
--- a/routes/overview.py
+++ b/routes/overview.py
@@ -519,6 +519,171 @@ def api_timeline():
     return jsonify({"days": days, "today": now.strftime("%Y-%m-%d")})
 
 
+def _compute_autonomy_data(sessions_dir, cutoff_ts=None):
+    """Scan JSONL session files and compute autonomy metrics.
+
+    Autonomy is measured by how far apart human nudges are (user-role messages
+    after the opening turn) and whether that interval is growing over time.
+
+    Args:
+        sessions_dir: path to the sessions directory containing *.jsonl files.
+        cutoff_ts: unix timestamp before which files are ignored (default: 7 days ago).
+
+    Returns dict with keys:
+        median_seconds_between_nudges  — overall median inter-nudge gap (seconds)
+        zero_nudge_ratio               — fraction of sessions with ≤1 user message
+        trend_slope_7d                 — linear slope of daily median gaps (positive = improving)
+        sessions_analyzed              — total sessions included
+        zero_nudge_sessions            — count of zero-nudge sessions
+        daily_medians                  — list of {day_offset, median_gap_seconds} for sparklines
+    """
+    import statistics
+
+    if cutoff_ts is None:
+        cutoff_ts = time.time() - 7 * 86400
+
+    empty = {
+        "median_seconds_between_nudges": 0,
+        "zero_nudge_ratio": 0.0,
+        "trend_slope_7d": 0.0,
+        "sessions_analyzed": 0,
+        "zero_nudge_sessions": 0,
+        "daily_medians": [],
+    }
+
+    if not os.path.isdir(sessions_dir):
+        return empty
+
+    try:
+        all_files = [
+            f for f in os.listdir(sessions_dir)
+            if f.endswith(".jsonl") and ".deleted." not in f and ".reset." not in f
+        ]
+    except OSError:
+        return empty
+
+    now_ts = time.time()
+    per_session_medians = []   # median gap per session (seconds)
+    zero_nudge_count = 0
+    total_sessions = 0
+    daily_buckets = {}  # day_offset (0=today … 6=six days ago) -> list[float]
+
+    for fname in all_files:
+        fpath = os.path.join(sessions_dir, fname)
+        try:
+            mtime = os.path.getmtime(fpath)
+        except OSError:
+            continue
+        if mtime < cutoff_ts:
+            continue
+
+        user_ts_list = []
+        try:
+            with open(fpath, errors="replace") as fh:
+                for raw in fh:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        ev = json.loads(raw)
+                    except Exception:
+                        continue
+                    role = ev.get("role") or ev.get("type", "")
+                    if role != "user":
+                        continue
+                    ts_raw = ev.get("timestamp") or ev.get("time") or ev.get("created_at")
+                    if not ts_raw:
+                        continue
+                    if isinstance(ts_raw, (int, float)):
+                        ts_sec = float(ts_raw) if ts_raw < 1e10 else float(ts_raw) / 1000.0
+                    else:
+                        try:
+                            ts_sec = datetime.fromisoformat(
+                                str(ts_raw).replace("Z", "+00:00")
+                            ).timestamp()
+                        except Exception:
+                            continue
+                    if ts_sec >= cutoff_ts:
+                        user_ts_list.append(ts_sec)
+        except Exception:
+            continue
+
+        if not user_ts_list:
+            continue
+
+        total_sessions += 1
+        user_ts_list.sort()
+
+        if len(user_ts_list) <= 1:
+            zero_nudge_count += 1
+            continue
+
+        gaps = [
+            user_ts_list[i + 1] - user_ts_list[i]
+            for i in range(len(user_ts_list) - 1)
+        ]
+        median_gap = statistics.median(gaps)
+        per_session_medians.append(median_gap)
+
+        day_offset = min(int((now_ts - mtime) / 86400), 6)
+        daily_buckets.setdefault(day_offset, []).append(median_gap)
+
+    overall_median = statistics.median(per_session_medians) if per_session_medians else 0.0
+    zero_nudge_ratio = round(zero_nudge_count / total_sessions, 3) if total_sessions else 0.0
+
+    # Linear trend: x = chronological day index (0 = 6 days ago, 6 = today)
+    # Positive slope means nudge interval is growing → agent is becoming more autonomous.
+    trend_slope_7d = 0.0
+    if len(daily_buckets) >= 2:
+        pts = [(6 - day, statistics.median(vals)) for day, vals in daily_buckets.items()]
+        xs = [p[0] for p in pts]
+        ys = [p[1] for p in pts]
+        n = len(xs)
+        x_mean = sum(xs) / n
+        y_mean = sum(ys) / n
+        num = sum((xs[i] - x_mean) * (ys[i] - y_mean) for i in range(n))
+        den = sum((xs[i] - x_mean) ** 2 for i in range(n))
+        if den:
+            trend_slope_7d = round(num / den, 2)
+
+    daily_medians = sorted(
+        [
+            {
+                "day_offset": day,
+                "median_gap_seconds": round(statistics.median(vals), 1),
+            }
+            for day, vals in daily_buckets.items()
+        ],
+        key=lambda r: r["day_offset"],
+        reverse=True,
+    )
+
+    return {
+        "median_seconds_between_nudges": round(overall_median, 1),
+        "zero_nudge_ratio": zero_nudge_ratio,
+        "trend_slope_7d": trend_slope_7d,
+        "sessions_analyzed": total_sessions,
+        "zero_nudge_sessions": zero_nudge_count,
+        "daily_medians": daily_medians,
+    }
+
+
+@bp_overview.route("/api/autonomy-score")
+def api_autonomy_score():
+    """Autonomy score — human-nudge spacing as north-star metric (closes #688).
+
+    Computes how far apart human interventions are across recent sessions and
+    whether that interval is growing. A rising trend means the agent is handling
+    more work between human check-ins — the primary signal of improving autonomy.
+    """
+    import dashboard as _d
+
+    sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
+        "~/.openclaw/agents/main/sessions"
+    )
+    return jsonify(_compute_autonomy_data(sessions_dir))
+
+
 @bp_overview.route("/api/cloud-cta/status")
 def cloud_cta_status():
     import dashboard as _d

--- a/tests/test_autonomy_score.py
+++ b/tests/test_autonomy_score.py
@@ -1,0 +1,218 @@
+"""Unit tests for routes/overview._compute_autonomy_data.
+
+Tests run without a live server by importing the helper directly.
+"""
+
+import json
+import os
+import time
+import pytest
+
+from routes.overview import _compute_autonomy_data
+
+
+def _write_jsonl(path, events):
+    with open(path, "w") as fh:
+        for ev in events:
+            fh.write(json.dumps(ev) + "\n")
+
+
+def _user(ts_sec):
+    return {"role": "user", "content": "hello", "timestamp": ts_sec}
+
+
+def _assistant(ts_sec):
+    return {"role": "assistant", "content": "ok", "timestamp": ts_sec}
+
+
+class TestMissingOrEmpty:
+    def test_nonexistent_dir(self, tmp_path):
+        result = _compute_autonomy_data(str(tmp_path / "no_such_dir"))
+        assert result["sessions_analyzed"] == 0
+        assert result["median_seconds_between_nudges"] == 0
+        assert result["zero_nudge_ratio"] == 0.0
+        assert result["trend_slope_7d"] == 0.0
+        assert result["daily_medians"] == []
+
+    def test_empty_dir(self, tmp_path):
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 0
+
+    def test_non_jsonl_files_ignored(self, tmp_path):
+        (tmp_path / "notes.txt").write_text("hello\n")
+        (tmp_path / "data.json").write_text("{}\n")
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 0
+
+    def test_deleted_files_skipped(self, tmp_path):
+        _write_jsonl(
+            tmp_path / "abc.deleted.jsonl",
+            [_user(time.time() - 10), _user(time.time() - 5)],
+        )
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 0
+
+    def test_reset_files_skipped(self, tmp_path):
+        _write_jsonl(
+            tmp_path / "abc.reset.jsonl",
+            [_user(time.time() - 10), _user(time.time() - 5)],
+        )
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 0
+
+
+class TestZeroNudgeSessions:
+    def test_single_user_message_counts_as_zero_nudge(self, tmp_path):
+        now = time.time()
+        _write_jsonl(tmp_path / "s1.jsonl", [_user(now - 100), _assistant(now - 50)])
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 1
+        assert result["zero_nudge_sessions"] == 1
+        assert result["zero_nudge_ratio"] == 1.0
+
+    def test_no_user_messages_not_counted_at_all(self, tmp_path):
+        now = time.time()
+        _write_jsonl(tmp_path / "s1.jsonl", [_assistant(now - 50)])
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 0
+
+
+class TestNudgeGapComputation:
+    def test_two_nudges_gap(self, tmp_path):
+        now = time.time()
+        _write_jsonl(
+            tmp_path / "s1.jsonl",
+            [_user(now - 200), _assistant(now - 180), _user(now - 100)],
+        )
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 1
+        assert result["zero_nudge_sessions"] == 0
+        assert abs(result["median_seconds_between_nudges"] - 100.0) < 1.0
+
+    def test_three_nudges_median(self, tmp_path):
+        now = time.time()
+        _write_jsonl(
+            tmp_path / "s1.jsonl",
+            [
+                _user(now - 300),
+                _user(now - 200),   # gap 100s
+                _user(now - 160),   # gap 40s  → median 70s
+            ],
+        )
+        result = _compute_autonomy_data(str(tmp_path))
+        assert abs(result["median_seconds_between_nudges"] - 70.0) < 1.0
+
+    def test_malformed_json_skipped(self, tmp_path):
+        now = time.time()
+        path = tmp_path / "s1.jsonl"
+        with open(path, "w") as fh:
+            fh.write("not json at all\n")
+            fh.write(json.dumps(_user(now - 200)) + "\n")
+            fh.write("{broken\n")
+            fh.write(json.dumps(_user(now - 100)) + "\n")
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 1
+        assert abs(result["median_seconds_between_nudges"] - 100.0) < 1.0
+
+    def test_missing_timestamp_skipped(self, tmp_path):
+        now = time.time()
+        _write_jsonl(
+            tmp_path / "s1.jsonl",
+            [
+                {"role": "user", "content": "hi"},          # no timestamp
+                _user(now - 200),
+                _user(now - 100),
+            ],
+        )
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 1
+        assert abs(result["median_seconds_between_nudges"] - 100.0) < 1.0
+
+
+class TestCutoffWindow:
+    def test_old_files_excluded(self, tmp_path):
+        now = time.time()
+        old_path = tmp_path / "old.jsonl"
+        _write_jsonl(old_path, [_user(now - 9 * 86400), _user(now - 8 * 86400)])
+        # back-date mtime to 8 days ago
+        old_ts = now - 8 * 86400
+        os.utime(old_path, (old_ts, old_ts))
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 0
+
+    def test_recent_files_included(self, tmp_path):
+        now = time.time()
+        _write_jsonl(
+            tmp_path / "recent.jsonl",
+            [_user(now - 3600), _user(now - 1800)],
+        )
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 1
+
+
+class TestMixedSessions:
+    def test_zero_nudge_ratio_mixed(self, tmp_path):
+        now = time.time()
+        # Session 1: 2 user messages → has nudge
+        _write_jsonl(
+            tmp_path / "s1.jsonl",
+            [_user(now - 300), _user(now - 100)],
+        )
+        # Session 2: 1 user message → zero nudge
+        _write_jsonl(
+            tmp_path / "s2.jsonl",
+            [_user(now - 200)],
+        )
+        result = _compute_autonomy_data(str(tmp_path))
+        assert result["sessions_analyzed"] == 2
+        assert result["zero_nudge_sessions"] == 1
+        assert abs(result["zero_nudge_ratio"] - 0.5) < 0.01
+
+    def test_custom_cutoff(self, tmp_path):
+        now = time.time()
+        cutoff = now - 3600  # 1 hour window
+        _write_jsonl(tmp_path / "inside.jsonl", [_user(now - 300), _user(now - 100)])
+        old = tmp_path / "outside.jsonl"
+        _write_jsonl(old, [_user(now - 7200), _user(now - 6000)])
+        os.utime(old, (now - 7200, now - 7200))
+        result = _compute_autonomy_data(str(tmp_path), cutoff_ts=cutoff)
+        assert result["sessions_analyzed"] == 1
+
+
+class TestReturnShape:
+    def test_all_keys_present_when_empty(self, tmp_path):
+        result = _compute_autonomy_data(str(tmp_path))
+        for key in (
+            "median_seconds_between_nudges",
+            "zero_nudge_ratio",
+            "trend_slope_7d",
+            "sessions_analyzed",
+            "zero_nudge_sessions",
+            "daily_medians",
+        ):
+            assert key in result, f"missing key: {key}"
+
+    def test_all_keys_present_with_data(self, tmp_path):
+        now = time.time()
+        _write_jsonl(tmp_path / "s1.jsonl", [_user(now - 300), _user(now - 100)])
+        result = _compute_autonomy_data(str(tmp_path))
+        for key in (
+            "median_seconds_between_nudges",
+            "zero_nudge_ratio",
+            "trend_slope_7d",
+            "sessions_analyzed",
+            "zero_nudge_sessions",
+            "daily_medians",
+        ):
+            assert key in result, f"missing key: {key}"
+        assert isinstance(result["daily_medians"], list)
+        if result["daily_medians"]:
+            dm = result["daily_medians"][0]
+            assert "day_offset" in dm
+            assert "median_gap_seconds" in dm
+
+    def test_ratio_bounded_0_to_1(self, tmp_path):
+        now = time.time()
+        _write_jsonl(tmp_path / "s1.jsonl", [_user(now - 200)])
+        result = _compute_autonomy_data(str(tmp_path))
+        assert 0.0 <= result["zero_nudge_ratio"] <= 1.0


### PR DESCRIPTION
## Summary

Adds `GET /api/autonomy-score` — the north-star autonomy metric from issue #688. The endpoint scans the last 7 days of session JSONL files (already on disk) and computes how far apart human nudges are, what fraction of sessions ran without any follow-up intervention, and whether autonomy is trending in the right direction. No new dependencies, no schema changes, no UI touched.

## Changes

- **`routes/overview.py`** — new `_compute_autonomy_data(sessions_dir, cutoff_ts)` helper (pure function, testable without a server) + `GET /api/autonomy-score` endpoint that calls it, following the same pattern as `api_main_activity()` and `api_timeline()`.
- **`tests/test_autonomy_score.py`** — 18 unit tests covering: missing/empty dirs, `.deleted.`/`.reset.` file exclusion, zero-nudge sessions, gap computation, median correctness, 7-day cutoff window, malformed JSON resilience, custom cutoff, and full return-shape invariants. All pass without a live server.

## Response shape

```json
{
  "median_seconds_between_nudges": 1843.5,
  "zero_nudge_ratio": 0.4,
  "trend_slope_7d": 120.3,
  "sessions_analyzed": 10,
  "zero_nudge_sessions": 4,
  "daily_medians": [
    {"day_offset": 0, "median_gap_seconds": 2100.0},
    {"day_offset": 1, "median_gap_seconds": 1800.0}
  ]
}
```

`trend_slope_7d` is the OLS slope of daily median nudge gaps over 7 days — positive means the agent is handling more work between human check-ins.

## Test plan

- [ ] `python3 -m pytest tests/test_autonomy_score.py -v` → 18/18 pass (no server needed)
- [ ] `python3 -c 'import ast; ast.parse(open("routes/overview.py").read())'` → clean
- [ ] `curl http://localhost:8900/api/autonomy-score` returns the expected shape

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #688. Marked draft for human review — mark Ready for Review once happy.

Closes #688

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3EotDXwDWsH3btPo6B4Aq)_