### PR TITLE
docs: refresh CLAUDE.md/ARCHITECTURE.md/CONTRIBUTING.md drift (#872)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -208,14 +208,16 @@ Secured with `CLAWMETRY_FLEET_KEY` — nodes must provide the API key to registe
 
 ## Technical Details
 
-### Single-File Architecture
-ClawMetry is intentionally a **single Python file** (`dashboard.py`, ~11,600 lines). This makes it:
+### Modular Blueprint Architecture
+ClawMetry is a Flask app organised as a small core (`dashboard.py`, ~15,000 lines) plus a `routes/` package of feature-scoped Blueprints (sessions, channels, components, usage, health, brain, infra, overview, crons, meta, alerts, fleet_history, nemoclaw). Shared helpers and the embedded HTML/CSS/JS templates still live in `dashboard.py`; route handlers reach them via a late `import dashboard as _d`.
+
+This layout keeps the install story simple while letting each feature evolve in its own module:
 - Easy to install (`pip install clawmetry`)
-- Easy to audit (one file to read)
-- Easy to deploy (no build step)
+- Easy to audit (one Blueprint per feature, see `CLAUDE.md` for the full table)
+- Easy to deploy (pure-Python, no build step)
 - Portable (runs on a Raspberry Pi)
 
-The HTML/CSS/JS dashboard is embedded as template strings inside the Python file.
+The HTML/CSS/JS dashboard is embedded as template strings inside `dashboard.py`.
 
 ### Dependencies
 Minimal by design:
@@ -226,7 +228,7 @@ Minimal by design:
 
 ### History Module (`history.py`)
 An optional companion that adds persistent time-series:
-- Stores snapshots every 5 minutes in SQLite
+- Stores snapshots every 60 seconds in SQLite
 - Enables historical charts (token usage over days/weeks)
 - Session history with cost trends
 - Cron execution history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ See `ARCHITECTURE.md` for the full deep dive. TL;DR:
 ### Core
 | File | Lines | Purpose |
 |------|-------|---------|
-| `dashboard.py` | ~25,400 | Flask app, blueprint registration, embedded HTML/CSS/JS, shared helpers |
+| `dashboard.py` | ~15,000 | Flask app, blueprint registration, embedded HTML/CSS/JS, shared helpers |
 | `dashboard_claudecode.py` | ~1,350 | Claude Code session dashboard variant (standalone or Blueprint) |
 | `history.py` | ~555 | Optional time-series collector (SQLite, polls gateway every 60s) |
 
@@ -27,12 +27,12 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 
 | File | Lines | Blueprints / Purpose |
 |------|-------|----------------------|
-| `routes/sessions.py` | ~1,190 | `bp_sessions` — sessions list, transcripts, compactions, tool timeline, cost split, subagents, exports |
+| `routes/sessions.py` | ~1,560 | `bp_sessions` — sessions list, transcripts, compactions, tool timeline, cost split, subagents, exports |
 | `routes/channels.py` | ~1,500 | `bp_channels` — 21 chat-channel adapters (Telegram, Signal, WhatsApp, Discord, Slack, IRC, iMessage, WebChat, …) |
 | `routes/components.py` | ~1,040 | `bp_components` — Flow-panel detail endpoints (tool / runtime / machine / gateway / brain) |
 | `routes/usage.py` | ~1,070 | `bp_usage` — token/cost analytics, anomaly detection, model + skill attribution |
 | `routes/health.py` | ~920 | `bp_health` — system-health, reliability, diagnostics, rate-limits, sandbox-status, health-stream (SSE) |
-| `routes/brain.py` | ~800 | `bp_brain` — `/api/brain-history` + `/api/brain-stream` (SSE) |
+| `routes/brain.py` | ~1,030 | `bp_brain` — `/api/brain-history` + `/api/brain-stream` (SSE) |
 | `routes/infra.py` | ~785 | `bp_logs` + `bp_memory` + `bp_security` + `bp_config` — logs stream, memory files, security posture, cost-optimizer |
 | `routes/overview.py` | ~585 | `bp_overview` — main dashboard endpoint, channels list, timeline, cloud-CTA OTP |
 | `routes/crons.py` | ~530 | `bp_crons` — cron CRUD + run log + health summary |
@@ -46,11 +46,11 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 | File | Lines | Purpose |
 |------|-------|---------|
 | `cli.py` | ~1,900 | CLI entry point — `clawmetry`, `clawmetry connect`, `clawmetry sync`, `clawmetry status` |
-| `sync.py` | ~3,000 | Cloud sync daemon — E2E encrypted (AES-256-GCM) session streaming to `ingest.clawmetry.com` |
+| `sync.py` | ~3,880 | Cloud sync daemon — E2E encrypted (AES-256-GCM) session streaming to `ingest.clawmetry.com` |
 | `proxy.py` | ~1,290 | Enforcement proxy — budget limits, loop detection, model routing (port 4100) |
 | `interceptor.py` | ~465 | Zero-config HTTP monkey-patching for LLM cost tracking (patches httpx/requests) |
 | `providers_pricing.py` | ~134 | Multi-provider pricing table (Anthropic, OpenAI, Google, OpenRouter, etc.) |
-| `config.py` | ~58 | Configuration dataclass |
+| `config.py` | ~80 | Configuration dataclass |
 | `extensions.py` | ~109 | Plugin/hook system |
 | `track.py` | ~39 | Zero-config interceptor shorthand |
 | `providers/` | — | Pluggable data provider layer (LocalDataProvider, TursoDataProvider) |
@@ -86,7 +86,8 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 - `/api/transcript/<id>` — Full session transcript
 - `/api/usage` — Token and cost analytics
 - `/api/flow` — Message flow visualization (channels -> gateway -> models -> tools)
-- `/api/brain` — Live event stream
+- `/api/brain-history` — Recent reasoning/tool events (paginated)
+- `/api/brain-stream` — Live event stream (SSE)
 - `/api/crons` — Cron job management (full CRUD via gateway RPC)
 - `/api/system-health` — Disk, memory, uptime, GPU
 - `/api/nodes` — Multi-node fleet view
@@ -133,7 +134,7 @@ Tests use `CLAWMETRY_URL` and `CLAWMETRY_TOKEN` env vars. Test matrix in CI: 3 O
 ## Deploy
 - **PyPI**: `pip install clawmetry && clawmetry`
 - **Docker**: `docker build -t clawmetry . && docker run -p 8900:8900 -v ~/.openclaw:/root/.openclaw:ro clawmetry`
-- **Current version**: `0.12.99` (in `dashboard.py` `__version__`)
+- **Current version**: `0.12.162` (in `dashboard.py` `__version__`)
 
 ## CI/CD (GitHub Actions)
 - `ci.yml` — Lint + test matrix on push/PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ clawmetry --help
 ```
 
 ### 4. **Make Changes & Test**
-- Edit `dashboard.py` (single file architecture)
+- Edit the relevant Blueprint in `routes/` (or `dashboard.py` for shared helpers / embedded templates — see `CLAUDE.md` for the file map)
 - Restart dashboard to see changes
 - Test auto-detection: `cd /tmp && python3 /path/to/dashboard.py`
 
@@ -38,7 +38,11 @@ clawmetry --help
 
 ```
 clawmetry/
-├── dashboard.py          # 🎯 Main application (single file)
+├── dashboard.py          # 🎯 Flask app, blueprint registration, embedded HTML/CSS/JS, shared helpers
+├── routes/               # 🧩 Per-feature Blueprints (sessions, channels, brain, usage, health, …)
+├── clawmetry/            # 📦 Installable package — CLI, sync daemon, proxy, interceptor, providers
+├── history.py            # 📈 Optional time-series collector (SQLite)
+├── dashboard_claudecode.py  # 🪶 Claude Code dashboard variant
 ├── README.md             # 📖 Documentation
 ├── setup.py              # 📦 Package configuration
 ├── requirements.txt      # 🔧 Dependencies
@@ -47,7 +51,9 @@ clawmetry/
 └── CONTRIBUTING.md       # 📝 This file
 ```
 
-**Philosophy**: Keep it simple. The entire dashboard is one Python file (`dashboard.py`) with minimal dependencies. This makes it easy to understand, modify, and deploy.
+See `CLAUDE.md` (`Key Files`) for the full per-module breakdown including line counts and Blueprint names.
+
+**Philosophy**: Keep it simple. The dashboard core is a Flask app in `dashboard.py` (with embedded HTML/CSS/JS) and a small `routes/` package of feature Blueprints — minimal dependencies, easy to understand, modify, and deploy.
 
 ---
 
@@ -62,7 +68,7 @@ clawmetry/
 
 ### **What to Avoid**
 - ❌ **Complex dependencies** - no heavy frameworks, ML libraries, or databases
-- ❌ **Breaking the single-file architecture** - keep everything in `dashboard.py`
+- ❌ **Sprawling new top-level modules** - prefer adding to an existing `routes/` Blueprint, or extending `dashboard.py`'s shared helpers, before introducing a new package
 - ❌ **Enterprise features** - this is for personal AI agents, not teams
 - ❌ **Major architectural changes** - discuss large changes in Issues first
 


### PR DESCRIPTION
Closes #872

## What

Weekly docs-vs-code sweep (#872) flagged stale claims across the three top-level docs. This PR fixes every flagged item in one batch — pure docs, no code/logic changes.

## How

**`CLAUDE.md`** — Key Files table + endpoints + version
- Line counts refreshed against `wc -l`:
  - `dashboard.py` 25.4k → 15k
  - `routes/sessions.py` 1,190 → 1,560
  - `routes/brain.py` 800 → 1,030
  - `clawmetry/sync.py` 3,000 → 3,880
  - `clawmetry/config.py` 58 → 80
- Endpoint list: replaced the non-existent `/api/brain` with the real `/api/brain-history` + `/api/brain-stream` (per `routes/brain.py`).
- "Current version" bumped `0.12.99` → `0.12.162` to match `dashboard.py:__version__`.

**`ARCHITECTURE.md`** — single-file claim + history cadence
- Rewrote the *Single-File Architecture* section to describe the real modular Blueprint layout (the `routes/` package). The project has not been a single-file repo for some time; CLAUDE.md already documents this correctly.
- Fixed `history.py` snapshot cadence: "every 5 minutes" → "every 60 seconds" (the actual `POLL_INTERVAL = 60` in `history.py`).

**`CONTRIBUTING.md`** — three contradictory single-file lines + project structure
- Dropped the three "single-file architecture" instructions (lines 31, 41, 65) and replaced them with guidance to extend existing Blueprints before adding new top-level modules.
- Updated the project-structure diagram to include `routes/`, `clawmetry/`, `history.py`, and the Claude Code dashboard variant.

## Verification

- `wc -l` matches the refreshed numbers (within rounding to the nearest 10).
- `grep -n "__version__" dashboard.py` shows `0.12.162`.
- `grep -n "/api/brain" routes/brain.py` confirms the two real endpoints.
- `grep -n "POLL_INTERVAL" history.py` shows `60`.
- No code changes, so existing tests / lint should be unaffected.

## Bot meta

Addresses every cluster in the `bot-docs-drift` sweep (version + line counts, endpoint rename, single-file narrative). The next Tuesday sweep should produce a clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)