### PR TITLE
fix: copy necessary files and folders for setup in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,14 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy application code
+# Copy application code and necessary files for setup
 COPY dashboard.py .
+COPY history.py .
 COPY setup.py .
+COPY README.md . 
 COPY clawmetry/ ./clawmetry/
+COPY helpers/ ./helpers/
+COPY routes/ ./routes/
 
 # Install clawmetry
 RUN pip install --no-cache-dir -e .


### PR DESCRIPTION
## What
Fixes Docker build failures caused by setup.py requiring README.md, ./helpers/, and ./routers/.

## Errors
1. FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
```plaintext
STEP 11/15: RUN pip install --no-cache-dir -e .

Obtaining file:///app
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/app/setup.py", line 4, in <module>
          with open("README.md", "r", encoding="utf-8") as f:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
      [end of output]
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

[notice] A new release of pip is available: 24.0 -> 26.1.1
[notice] To update, run: pip install --upgrade pip
Error: building at STEP "RUN pip install --no-cache-dir -e .": while running runtime: exit status 1
```

2. error: package directory 'routes' does not exist
```plaintext
STEP 12/16: RUN pip install --no-cache-dir -e .

Obtaining file:///app
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [22 lines of output]

      /usr/local/lib/python3.11/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: MIT License

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      !!

        self._finalize_license_expression()
      running egg_info
      creating /tmp/pip-pip-egg-info-sjzdx6_2/clawmetry.egg-info
      writing /tmp/pip-pip-egg-info-sjzdx6_2/clawmetry.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-pip-egg-info-sjzdx6_2/clawmetry.egg-info/dependency_links.txt
      writing entry points to /tmp/pip-pip-egg-info-sjzdx6_2/clawmetry.egg-info/entry_points.txt
      writing requirements to /tmp/pip-pip-egg-info-sjzdx6_2/clawmetry.egg-info/requires.txt
      writing top-level names to /tmp/pip-pip-egg-info-sjzdx6_2/clawmetry.egg-info/top_level.txt
      writing manifest file '/tmp/pip-pip-egg-info-sjzdx6_2/clawmetry.egg-info/SOURCES.txt'
      error: package directory 'routes' does not exist
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
× Encountered error while generating package metadata.
╰─> See above for output.
note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

[notice] A new release of pip is available: 24.0 -> 26.1.1
[notice] To update, run: pip install --upgrade pip

Error: building at STEP "RUN pip install --no-cache-dir -e .": while running runtime: exit status 1
```

3. error: package directory 'helpers' does not exist
```plaintext
STEP 13/17: RUN pip install --no-cache-dir -e .
Obtaining file:///app
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [22 lines of output]
      /usr/local/lib/python3.11/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: MIT License

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
       !!

        self._finalize_license_expression()
      running egg_info
      creating /tmp/pip-pip-egg-info-eniuoo9f/clawmetry.egg-info
      writing /tmp/pip-pip-egg-info-eniuoo9f/clawmetry.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-pip-egg-info-eniuoo9f/clawmetry.egg-info/dependency_links.txt
      writing entry points to /tmp/pip-pip-egg-info-eniuoo9f/clawmetry.egg-info/entry_points.txt
      writing requirements to /tmp/pip-pip-egg-info-eniuoo9f/clawmetry.egg-info/requires.txt
      writing top-level names to /tmp/pip-pip-egg-info-eniuoo9f/clawmetry.egg-info/top_level.txt
      writing manifest file '/tmp/pip-pip-egg-info-eniuoo9f/clawmetry.egg-info/SOURCES.txt'
      error: package directory 'helpers' does not exist
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

[notice] A new release of pip is available: 24.0 -> 26.1.1
[notice] To update, run: pip install --upgrade pip
Error: building at STEP "RUN pip install --no-cache-dir -e .": while running runtime: exit status 1
```

## Fix

* Add COPY README.md . to the Dockerfile before pip install -e . runs.
* Add COPY helpers/ ./helpers/ to the Dockerfile before pip install -e . runs.
* Add COPY routes/ ./routes/ to the Dockerfile before pip install -e . runs.

## Verification

* Docker build now completes successfully
* No functional changes to the application

## Test plan & review notes

### What changed

* Adds `COPY README.md .` to the Dockerfile immediately before `pip install -e .`, so `setup.py` can open `README.md` for long_description without a `FileNotFoundError`.
* Adds `Add COPY helpers/ ./helpers/` to the Dockerfile immediately before `pip install -e .`, so `setup.py` can complete without a `error: package directory 'routes' does not exist`.
* Adds `Add COPY scripts/ ./scripts/` to the Dockerfile immediately before `pip install -e .`, so `setup.py` can complete without a `error: package directory 'helpers' does not exist`.

### Smoke commands

* `docker build -t clawmetry-test .` — verify build succeeds without errors
* `docker run --rm clawmetry-test python -c "import clawmetry"` — verify package imports cleanly