### PR TITLE
feat(sessions): surface per-session cost and tokens in transcript list (#68)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6164,6 +6164,8 @@ async function loadTranscripts() {
       html += '<div class="transcript-meta-row">';
       html += '<span>' + t.messages + ' messages</span>';
       html += '<span>' + (t.size > 1024 ? (t.size/1024).toFixed(1) + ' KB' : t.size + ' B') + '</span>';
+      if (t.total_tokens > 0) html += '<span>' + (t.total_tokens >= 1000 ? (t.total_tokens/1000).toFixed(1) + 'K' : t.total_tokens) + ' tok</span>';
+      if (t.total_cost_usd > 0) html += '<span style="color:var(--accent-green,#22c55e);font-weight:600;">$' + t.total_cost_usd.toFixed(4) + '</span>';
       html += '<span>' + timeAgo(t.modified) + '</span>';
       html += '</div></div>';
       html += '<span style="color:#444;font-size:18px;">▸</span>';

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -1239,9 +1239,31 @@ def api_transcripts():
             fpath = os.path.join(sessions_dir, fname)
             try:
                 msg_count = 0
-                with open(fpath) as f:
-                    for _ in f:
+                total_cost_usd = 0.0
+                tok = {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0}
+                with open(fpath, errors="replace") as f:
+                    for raw in f:
                         msg_count += 1
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            ev = json.loads(raw)
+                        except Exception:
+                            continue
+                        if ev.get("type") != "message":
+                            continue
+                        msg = ev.get("message", {}) or {}
+                        if not isinstance(msg, dict):
+                            continue
+                        usage = msg.get("usage", {}) or {}
+                        if not isinstance(usage, dict):
+                            continue
+                        for k in tok:
+                            tok[k] += int(usage.get(k, 0) or 0)
+                        cost_obj = usage.get("cost", {}) or {}
+                        if isinstance(cost_obj, dict):
+                            total_cost_usd += float(cost_obj.get("total", 0) or 0)
                 transcripts.append(
                     {
                         "id": fname.replace(".jsonl", ""),
@@ -1249,6 +1271,12 @@ def api_transcripts():
                         "messages": msg_count,
                         "size": os.path.getsize(fpath),
                         "modified": int(os.path.getmtime(fpath) * 1000),
+                        "total_cost_usd": round(total_cost_usd, 6),
+                        "input_tokens": tok["input"],
+                        "output_tokens": tok["output"],
+                        "cache_read_tokens": tok["cacheRead"],
+                        "cache_write_tokens": tok["cacheWrite"],
+                        "total_tokens": sum(tok.values()),
                     }
                 )
             except Exception:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -245,6 +245,31 @@ class TestTranscripts:
         d = assert_ok(get(api, base_url, "/api/transcripts"))
         assert isinstance(d, (list, dict))
 
+    def test_transcript_entries_have_cost_fields(self, api, base_url):
+        """Every transcript entry carries cost + token fields (GH #68)."""
+        d = assert_ok(get(api, base_url, "/api/transcripts"))
+        transcripts = d.get("transcripts", d) if isinstance(d, dict) else d
+        if not isinstance(transcripts, list) or len(transcripts) == 0:
+            return  # empty workspace — nothing to assert
+        for t in transcripts:
+            assert "total_cost_usd" in t, f"missing total_cost_usd in {t}"
+            assert "total_tokens" in t, f"missing total_tokens in {t}"
+            assert isinstance(t["total_cost_usd"], float), "total_cost_usd must be float"
+            assert isinstance(t["total_tokens"], int), "total_tokens must be int"
+            assert t["total_cost_usd"] >= 0, "total_cost_usd must be non-negative"
+            assert t["total_tokens"] >= 0, "total_tokens must be non-negative"
+
+    def test_transcript_token_breakdown_fields(self, api, base_url):
+        """Transcript entries include the four-way token split (GH #68)."""
+        d = assert_ok(get(api, base_url, "/api/transcripts"))
+        transcripts = d.get("transcripts", d) if isinstance(d, dict) else d
+        if not isinstance(transcripts, list) or len(transcripts) == 0:
+            return
+        for t in transcripts:
+            for field in ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens"):
+                assert field in t, f"missing {field} in transcript entry"
+                assert isinstance(t[field], int) and t[field] >= 0
+
 
 class TestSkills:
     """Tests for /api/skills — skills fidelity telemetry (GH #687)."""


### PR DESCRIPTION
## Summary

The Sessions/Transcripts tab showed message count, file size, and timestamp but no cost or token data. This PR extends `/api/transcripts` to scan each session JSONL for cost and token usage, then surfaces a token-count pill and a green `$0.0043` cost badge in the session list.

## Changes

- **`routes/sessions.py`** — `api_transcripts()`: replaced the bare line-counter with a JSON-parsing walk (same pattern as the existing `_compute_for_file()` helper) that accumulates `total_cost_usd` and the four-way token split (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `total_tokens`). All new fields are additive; no existing keys changed.
- **`clawmetry/static/js/app.js`** — `loadTranscripts()`: adds a `N tok` pill and a green `$X.XXXX` cost badge to the `.transcript-meta-row` for any session with non-zero values.
- **`tests/test_api.py`** — `TestTranscripts`: two new test methods assert that every transcript entry carries `total_cost_usd` (non-negative float) and the full token breakdown (non-negative ints).

## Test plan

- [ ] `python3 -m pytest tests/test_api.py -k Transcripts -q` — all assertions pass
- [ ] Open the Transcripts tab in the browser; sessions with API usage show a token count and `$X.XXXX` badge
- [ ] Fresh workspace with no JSONL files still shows "No transcript files found" (no crash)
- [ ] Sessions with no cost data (e.g. local-only tool calls) show `0 tok` / no badge — no divide-by-zero

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #68. Marked draft for human review — mark Ready for Review once happy.

Closes #68

---
_Generated by [Claude Code](https://claude.ai/code/session_012NgjCnGouHeRJHHm5uzU47)_