### PR TITLE
fix(crons): wire JSONL run logs + fix startedAt/sessionFile fields (#605)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -9192,10 +9192,19 @@ def _cron_runs_from_transcripts(job_id):
         start_ts = sess.get("start_ts", 0)
         end_ts = sess.get("end_ts", 0)
         dur_ms = int((end_ts - start_ts) * 1000) if end_ts > start_ts else 0
+        session_id = sess.get("session_id", "")
+        started_at = (
+            datetime.utcfromtimestamp(start_ts).strftime("%Y-%m-%dT%H:%M:%SZ")
+            if start_ts
+            else None
+        )
         runs.append(
             {
-                "sessionId": sess.get("session_id", ""),
+                "sessionId": session_id,
+                "sessionFile": session_id + ".jsonl" if session_id else "",
                 "timestamp": int(start_ts * 1000) if start_ts else 0,
+                "startedAt": started_at,
+                "ts": started_at,
                 "status": "ok",
                 "durationMs": dur_ms,
                 "costUsd": round(float(sess.get("cost_usd", 0.0) or 0.0), 6),
@@ -9205,6 +9214,40 @@ def _cron_runs_from_transcripts(job_id):
 
     # Most-recent first
     runs.sort(key=lambda r: r.get("timestamp", 0), reverse=True)
+    return runs[:50]
+
+
+def _cron_runs_from_jsonl(job_id):
+    """Read per-run cron logs from ~/.openclaw/cron/runs/{jobId}.jsonl.
+
+    Returns a list of run dicts (newest-first, capped at 50) with the fields
+    that loadCronRuns() in app.js expects: startedAt, ts, status, durationMs,
+    costUsd, tokens, sessionFile, error.  Returns [] when the file is absent.
+    """
+    import json as _json
+
+    safe_id = os.path.basename(job_id)  # prevent path traversal
+    path = os.path.join(_get_openclaw_dir(), "cron", "runs", safe_id + ".jsonl")
+    if not os.path.exists(path):
+        return []
+    runs = []
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    runs.append(_json.loads(line))
+                except _json.JSONDecodeError:
+                    continue
+    except OSError:
+        return []
+
+    def _sort_key(r):
+        return r.get("startedAt") or r.get("ts") or r.get("timestamp") or ""
+
+    runs.sort(key=_sort_key, reverse=True)
     return runs[:50]
 
 

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -210,19 +210,26 @@ def api_cron_create():
 def api_cron_runs(job_id):
     """Return run history for a specific cron job.
 
-    Tries gateway RPC first; falls back to parsing JSONL session transcripts
-    for cron candidate sessions attributed to this job.
+    Priority order:
+      1. Gateway RPC (authoritative, live data)
+      2. ~/.openclaw/cron/runs/{jobId}.jsonl (rich on-disk run logs)
+      3. Session transcript analytics (synthetic, always available)
     Returns enriched list with p50/p95 duration stats.
     """
     import dashboard as _d
-    # Try gateway API first
+    # 1. Try gateway API first
     result = _d._gw_invoke("cron", {"action": "runs", "jobId": job_id, "limit": 50})
     if result is not None:
         runs = result.get("runs", result) if isinstance(result, dict) else result
         if isinstance(runs, list) and runs:
             return jsonify(_d._enrich_cron_runs(job_id, runs))
 
-    # Fallback: derive runs from transcript analytics
+    # 2. Fallback: read dedicated JSONL run logs from disk
+    runs = _d._cron_runs_from_jsonl(job_id)
+    if runs:
+        return jsonify(_d._enrich_cron_runs(job_id, runs))
+
+    # 3. Final fallback: derive runs from transcript analytics
     runs = _d._cron_runs_from_transcripts(job_id)
     return jsonify(_d._enrich_cron_runs(job_id, runs))
 


### PR DESCRIPTION
## Summary

The cron expand panel was stuck on "Loading run history…" forever because the backend returned `timestamp` (epoch ms) and `sessionId`, but `loadCronRuns()` in `app.js` expects `startedAt` / `ts` (ISO-8601 string) and `sessionFile` — so every run was silently dropped by the date renderer. Additionally, the rich per-run JSONL files at `~/.openclaw/cron/runs/{jobId}.jsonl` were never consulted; the fallback was deriving synthetic records from session transcripts instead.

## Changes

- **`dashboard.py`** — patch `_cron_runs_from_transcripts()` to emit `startedAt`, `ts`, and `sessionFile` alongside the existing `timestamp`/`sessionId` so the 30-day calendar heatmap and run table render correctly.
- **`dashboard.py`** — add `_cron_runs_from_jsonl(job_id)`: reads the dedicated on-disk run logs at `~/.openclaw/cron/runs/{jobId}.jsonl` (path-traversal-safe via `os.path.basename`, graceful on missing file), sorts newest-first, returns up to 50 records with the real `status`, `error`, `durationMs`, `costUsd`, and `deliveryStatus` fields from the agent.
- **`routes/crons.py`** — update `api_cron_runs()` fallback chain to three tiers: gateway RPC → JSONL file → transcript analytics.

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("dashboard.py").read())'` — no syntax errors
- [ ] `python3 -c 'import ast; ast.parse(open("routes/crons.py").read())'` — no syntax errors
- [ ] Expand any cron job in the Crons tab → 30-day calendar heatmap + run table should appear instead of "No run history yet"
- [ ] With a live `~/.openclaw/cron/runs/{jobId}.jsonl` file, verify the panel shows actual run data
- [ ] With gateway offline and no JSONL file, verify transcript-derived fallback still populates (with correct fields)

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #605. Marked draft for human review — mark Ready for Review once happy.

Closes #605

---
_Generated by [Claude Code](https://claude.ai/code/session_018qnmwnrN2dptn4QaWGa3qm)_