### PR TITLE
[RELEASE] docs(sync): clarify deferred-sync docstring (publishes #906 to PyPI)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -355,7 +355,9 @@ def _update_trial_state(resp: dict) -> None:
 
 def _sync_allowed() -> bool:
     """Gate for large blob uploads. Heartbeats + approvals/alerts polls
-    bypass this — they MUST keep firing so we detect the upgrade."""
+    bypass this — they MUST keep firing so we detect the upgrade (or, for
+    KiloClaw-provisioned accounts, the moment the user clicks "View
+    Observability" and the cloud flips reason='intent_pending' off)."""
     return _TRIAL_STATE.get("sync_allowed", True)
 
 


### PR DESCRIPTION
Cuts a 0.12.163 release that carries #906's deferred-sync mode change to PyPI. The auto-release on #906 itself was skipped (likely a title-edit / merge race in the GitHub Actions trigger), so this no-op docstring tweak is the cleanest way to bump the patch and publish.

Diff: 3 lines, just clarifies that `_sync_allowed` covers KiloClaw deferred-sync as well as trial-expired.

After this merges:
- 0.12.163 lands on PyPI
- `curl https://clawmetry.com/install.sh | bash` picks it up
- KiloClaw boxes get the friendlier deferred-sync log copy and the airtight gating on `sync_sessions_recent` / `sync_claude_cli_sessions`