### PR TITLE
feat(release): cloud-contract spec is single source of truth + smoke gate

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -46,11 +46,159 @@ jobs:
       - name: Build package
         run: python3 -m build
 
+      # Pre-publish smoke. PyPI uploads are irreversible (yanking exists
+      # but is awkward and visible to users), so we gate twine upload
+      # behind a wheel-install sanity check. This catches:
+      #   - missing files in the wheel (regressed in v0.12.99)
+      #   - module-level import errors (syntax errors past CI)
+      #   - broken `clawmetry` CLI entry point
+      #   - mismatched __version__ vs the version we bumped
+      # If any of these fail the wheel never reaches PyPI and no release
+      # tag is created — the next [RELEASE] PR can re-run cleanly.
+      - name: Pre-publish smoke (install wheel, verify CLI + imports)
+        id: smoke
+        run: |
+          set -e
+          python3 -m venv /tmp/smoke-venv
+          /tmp/smoke-venv/bin/pip install --quiet --upgrade pip
+          /tmp/smoke-venv/bin/pip install --quiet dist/*.whl
+          echo "▸ CLI version reports the bumped value"
+          ACTUAL=$(/tmp/smoke-venv/bin/clawmetry --version | tr -d '[:space:]')
+          EXPECTED='${{ steps.bump.outputs.new }}'
+          echo "  actual=$ACTUAL  expected=$EXPECTED"
+          echo "$ACTUAL" | grep -qF "$EXPECTED" || {
+            echo "❌ clawmetry --version did not report $EXPECTED"
+            exit 1
+          }
+          echo "▸ Critical modules import"
+          /tmp/smoke-venv/bin/python -c "
+          import clawmetry
+          from clawmetry import sync, cli, interceptor, providers_pricing
+          from clawmetry.sync import _sync_allowed, _post, send_heartbeat, validate_key
+          from clawmetry.config import Config
+          print('  imports OK')
+          "
+          echo "▸ Wheel ships runtime assets (templates, static)"
+          /tmp/smoke-venv/bin/python -c "
+          import clawmetry, os
+          base = os.path.dirname(clawmetry.__file__)
+          # Asset paths that broke in v0.12.99 — guard against regression.
+          for sub in ('static', 'templates'):
+              full = os.path.join(base, sub)
+              # Either packaged inside the wheel, or living one level up
+              # in the editable install layout — accept either.
+              if not (os.path.isdir(full) or os.path.isdir(os.path.join(base, '..', sub))):
+                  raise SystemExit(f'missing runtime asset dir: {sub}')
+          print('  assets OK')
+          "
+          echo "✅ Wheel smoke passed"
+
+      # Pre-publish daemon E2E. Validates the OSS-specific path that the
+      # cloud-contract spec doesn't cover: wheel-installed daemon process
+      # actually starts and sends a heartbeat. Catches packaging /
+      # subprocess-startup bugs that import-only smoke can't see.
+      - name: Pre-publish daemon E2E (spawn wheel-installed daemon, verify heartbeat)
+        id: daemon_e2e
+        run: |
+          set -e
+          MACHINE_ID="release-daemon-$(date +%s)-${RANDOM}"
+          REG_RESP=$(curl -sS --max-time 30 \
+            -X POST -H 'Content-Type: application/json' \
+            -d "{\"hostname\":\"$MACHINE_ID\",\"machine_id\":\"$MACHINE_ID\",\"platform\":\"Linux\",\"email\":\"release-daemon+$MACHINE_ID@clawmetry.com\"}" \
+            https://app.clawmetry.com/api/register)
+          if echo "$REG_RESP" | grep -q "Rate limit exceeded"; then
+            echo "⚠ /api/register rate-limited (10/hr per IP) — skipping daemon E2E"
+            exit 0
+          fi
+          API_KEY=$(echo "$REG_RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("api_key",""))')
+          NODE_ID=$(echo "$REG_RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("node_id",""))')
+          if [ -z "$API_KEY" ] || [ -z "$NODE_ID" ]; then
+            echo "❌ Register did not return api_key / node_id: ${REG_RESP:0:500}"
+            exit 1
+          fi
+          ENC_KEY=$(python3 -c 'import secrets,base64; print(base64.b64encode(secrets.token_bytes(32)).decode())')
+          mkdir -p "$HOME/.clawmetry"
+          python3 -c "
+          import json, os
+          json.dump({
+              'api_key': '$API_KEY',
+              'node_id': '$NODE_ID',
+              'encryption_key': '$ENC_KEY',
+              'platform': 'Linux',
+              'connected_at': '2026-05-07T00:00:00Z',
+          }, open(os.path.expanduser('~/.clawmetry/config.json'), 'w'))
+          "
+          echo "▸ Spawning wheel-installed daemon for 15s"
+          timeout 15 /tmp/smoke-venv/bin/python -m clawmetry.sync > /tmp/daemon.log 2>&1 || true
+          if grep -q "Initial heartbeat sent" /tmp/daemon.log; then
+            echo "✅ Daemon sent initial heartbeat — wheel + cloud handshake OK"
+          else
+            echo "❌ Daemon did not send initial heartbeat. Last 80 lines:"
+            tail -80 /tmp/daemon.log
+            exit 1
+          fi
+
+      # Pre-publish cloud-contract spec. Single source of truth for the
+      # daemon ↔ cloud API contract — the same script clawmetry-cloud's
+      # deploy.yml runs post-deploy. If we add a new contract check, it
+      # lives in one file (tests/e2e/cloud-contract.mjs) and both
+      # pipelines pick it up automatically.
+      - name: Set up Node for cloud-contract spec
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Playwright + Chromium for cloud-contract spec
+        working-directory: tests/e2e
+        run: |
+          npm install
+          npx playwright install --with-deps chromium
+
+      - name: Pre-publish cloud-contract spec (normal user + KiloClaw deferred-sync)
+        id: contract
+        working-directory: tests/e2e
+        env:
+          CLAWMETRY_API_BASE: https://app.clawmetry.com
+        run: npm run test:cloud-contract
+
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload --skip-existing dist/*
+
+      # Verify the wheel actually landed on PyPI and is installable.
+      # Pre-publish smoke tested the local wheel; this guards against
+      # PyPI propagation gaps or upload corruption (rare, but possible).
+      # On failure, prints the commands to manually yank from the PyPI
+      # web UI — yanking is intentionally manual so a human signs off.
+      - name: Post-publish verification (install from PyPI)
+        id: postpub
+        run: |
+          set -e
+          NEW='${{ steps.bump.outputs.new }}'
+          # PyPI's CDN is fast but not instantaneous. Poll up to 90s for
+          # the new version to appear in the JSON metadata before giving
+          # up — most upload→discoverable times are <30s.
+          for i in 1 2 3 4 5 6 7 8 9; do
+            if curl -sf "https://pypi.org/pypi/clawmetry/$NEW/json" > /dev/null; then
+              echo "▸ PyPI metadata for $NEW visible (attempt $i)"
+              break
+            fi
+            sleep 10
+          done
+          python3 -m venv /tmp/postpub-venv
+          /tmp/postpub-venv/bin/pip install --quiet --no-cache-dir "clawmetry==$NEW"
+          ACTUAL=$(/tmp/postpub-venv/bin/clawmetry --version | tr -d '[:space:]')
+          echo "$ACTUAL" | grep -qF "$NEW" || {
+            echo "❌ PyPI install reports version $ACTUAL, expected $NEW"
+            echo ""
+            echo "TO YANK $NEW (mark unavailable to new installs while keeping it in history):"
+            echo "  https://pypi.org/manage/project/clawmetry/release/$NEW/  → 'Yank'"
+            echo "Or run a follow-up [RELEASE] PR to publish $NEW patch+1 with the previous code."
+            exit 1
+          }
+          echo "✅ PyPI install of $NEW works end-to-end"
 
       - name: Create GitHub release tag
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 *.log
 .clawmetry-fleet.db
 .claude/worktrees/
+
+# Node (used only by tests/e2e/ for the cloud-contract spec runner)
+node_modules/

--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+/**
+ * ClawMetry cloud-contract end-to-end smoke.
+ *
+ * Single source of truth for the API contract between the OSS daemon and
+ * the cloud. Both pipelines fetch + run this same script:
+ *   - clawmetry-cloud's deploy.yml runs it post-deploy (rolls back to
+ *     previous Cloud Run revision on failure)
+ *   - clawmetry's release-on-merge.yml runs it pre-publish (aborts the
+ *     PyPI upload on failure)
+ *
+ * If you add a new contract check, edit THIS file. Both pipelines pick
+ * it up automatically on next run — no other repo to update.
+ *
+ * Run:
+ *   node tests/e2e/cloud-contract.mjs                          # headless
+ *   HEADLESS=0 node tests/e2e/cloud-contract.mjs               # show browser
+ *   CLAWMETRY_API_BASE=https://staging... node tests/e2e/cloud-contract.mjs
+ *
+ * Exits 0 if all checks pass, 1 on first failure.
+ *
+ * Two test scenarios:
+ *
+ *   1. **Normal user** — register without `source` field. Heartbeat must
+ *      NOT come back deferred. Dashboard must render and decrypt cleanly.
+ *      The "did we accidentally break the standard pip-install user"
+ *      regression guard.
+ *
+ *   2. **KiloClaw user** — register with `source: 'kiloclaw'`. Heartbeat
+ *      returns sync_allowed=false / reason='intent_pending'. POST
+ *      /api/cloud/intent-start flips the gate. Subsequent heartbeat is
+ *      clean. Idempotency check.
+ *
+ * The script bails cleanly with exit 0 on /api/register's 10/hour per-IP
+ * rate limit, so manual reruns from the same IP don't false-fail.
+ *
+ * Browser checks use the same `playwright` package the cloud + kiloclaw
+ * tests use. Both pipelines `npm install playwright` ad-hoc before
+ * running this — no package.json needed at the OSS repo root.
+ */
+import { chromium } from 'playwright';
+import crypto from 'node:crypto';
+
+const API_BASE = process.env.CLAWMETRY_API_BASE || 'https://app.clawmetry.com';
+const HEADLESS = process.env.HEADLESS !== '0';
+const ATTEMPTS = parseInt(process.env.RETRIES || '5', 10);
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+
+function check(label, condition, detail) {
+  if (condition) {
+    pass++;
+    console.log(`  ✓ ${label}`);
+  } else {
+    fail++;
+    failures.push(label + (detail ? `\n      ${detail}` : ''));
+    console.log(`  ✗ ${label}${detail ? `\n      ${detail}` : ''}`);
+  }
+}
+
+async function postJson(path, payload, apiKey) {
+  return fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+async function registerOrSkip(payload) {
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    const res = await postJson('/api/register', payload);
+    const text = await res.text();
+    if (res.ok) {
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw new Error(`/api/register returned non-JSON: ${text.slice(0, 200)}`);
+      }
+    }
+    if (res.status === 429) {
+      console.log(`\n[cloud-contract] SKIP: /api/register rate-limited (10/hr per IP).`);
+      console.log('[cloud-contract] CI runners get fresh IPs each run; this is harmless locally.\n');
+      process.exit(0);
+    }
+    console.log(`  register attempt ${attempt} failed: ${res.status} ${text.slice(0, 100)}`);
+    if (attempt < 4) await new Promise(r => setTimeout(r, 2000 * attempt));
+  }
+  throw new Error('/api/register failed after 4 retries');
+}
+
+async function heartbeat(reg, machineId, { expectDeferred = false } = {}) {
+  // Cloud Run replica routing can race with the INSERT in /api/register
+  // — when we expect deferred mode, retry once on the legacy {ok:true}
+  // response shape. A real bug persists past a short wait; a propagation
+  // race resolves on the second call.
+  const call = async () => {
+    const res = await postJson(
+      '/ingest/heartbeat',
+      { node_id: reg.node_id, hostname: machineId, platform: 'Linux', version: 'cloud-contract' },
+      reg.api_key
+    );
+    if (!res.ok) {
+      throw new Error(`/ingest/heartbeat returned ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    }
+    return res.json();
+  };
+  let body = await call();
+  if (expectDeferred && body.sync_allowed !== false) {
+    await new Promise(r => setTimeout(r, 1500));
+    body = await call();
+  }
+  return body;
+}
+
+async function intentStart(reg) {
+  const res = await postJson('/api/cloud/intent-start', {}, reg.api_key);
+  if (!res.ok) {
+    throw new Error(`/api/cloud/intent-start returned ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+function dashboardUrl(reg, encKey) {
+  return (
+    `${API_BASE}/cloud/node/${encodeURIComponent(reg.node_id)}` +
+    `?token=${encodeURIComponent(reg.api_key)}` +
+    `#key=${encodeURIComponent(encKey)}&node=${encodeURIComponent(reg.node_id)}`
+  );
+}
+
+async function openDashboardWithRetry(page, url, attempts = ATTEMPTS) {
+  let lastDiag = '';
+  for (let i = 1; i <= attempts; i++) {
+    await page.goto(url, { waitUntil: 'domcontentloaded' }).catch(() => undefined);
+    await page.waitForTimeout(2500);
+    const diag = await page.evaluate(() => ({
+      ready: window.CLOUD_MODE === true && !!window.CLOUD_NODE_ID,
+      cloudMode: window.CLOUD_MODE,
+      href: location.href,
+      bodyHead: (document.body.innerText || '').slice(0, 120).replace(/\s+/g, ' '),
+    }));
+    if (diag.ready) return i;
+    lastDiag = `attempt ${i}: CLOUD_MODE=${diag.cloudMode} href=${diag.href} body="${diag.bodyHead}"`;
+    if (process.env.DEBUG) console.log('  ' + lastDiag);
+  }
+  throw new Error(
+    `Dashboard did not load CLOUD_MODE after ${attempts} attempts. Last: ${lastDiag}`
+  );
+}
+
+// ── Scenario 1: normal user (no `source` field) ──────────────────────
+
+async function testNormalUser() {
+  console.log('▸ Scenario 1: normal user (no source field)');
+  const machineId = `cm-contract-normal-${Date.now()}-${crypto.randomBytes(3).toString('hex')}`;
+  const reg = await registerOrSkip({
+    hostname: machineId,
+    machine_id: machineId,
+    platform: 'Linux',
+    email: `cm-contract+${machineId}@clawmetry.com`,
+    // intentionally no `source` field
+  });
+  check('register: api_key shape', /^cm_[a-f0-9]{32}$/.test(reg.api_key));
+  check('register: plan=free', reg.plan === 'free');
+
+  const hb = await heartbeat(reg, machineId);
+  console.log(`  hb response: ${JSON.stringify(hb)}`);
+  check(
+    'normal user heartbeat: sync_allowed is NOT false (deferred-sync gate must not catch standard users)',
+    hb.sync_allowed !== false
+  );
+  check('normal user heartbeat: reason !== intent_pending', hb.reason !== 'intent_pending');
+
+  // Dashboard must render and decrypt cleanly.
+  const encKey = crypto.randomBytes(32).toString('base64');
+  const browser = await chromium.launch({ headless: HEADLESS });
+  const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const page = await ctx.newPage();
+  const errors = [];
+  page.on('pageerror', e => errors.push(`pageerror: ${e.message.slice(0, 200)}`));
+  page.on('console', m => {
+    if (m.type() === 'error') {
+      const loc = m.location() || {};
+      const where = loc.url ? ` @ ${loc.url}` : '';
+      errors.push(`console.error: ${m.text().slice(0, 200)}${where}`);
+    }
+  });
+
+  try {
+    const attempts = await openDashboardWithRetry(page, dashboardUrl(reg, encKey));
+    check('dashboard loaded CLOUD_MODE within retries', true, `(took ${attempts} attempt(s))`);
+  } catch (err) {
+    check('dashboard loaded CLOUD_MODE within retries', false, err.message);
+    await browser.close();
+    return;
+  }
+
+  await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => undefined);
+  await page.waitForTimeout(2500);
+
+  const state = await page.evaluate(() => ({
+    cloudMode: window.CLOUD_MODE,
+    cloudNodeId: window.CLOUD_NODE_ID,
+    cloudTokenPrefix: (window.CLOUD_TOKEN || '').slice(0, 16),
+    url: window.location.href,
+    bodyText: (document.body.innerText || '').slice(0, 400),
+    encKeyValue: (() => {
+      const k = Object.keys(localStorage).find(x => x.startsWith('cm-enc-key-'));
+      return k ? localStorage.getItem(k) : null;
+    })(),
+  }));
+  check('window.CLOUD_MODE === true', state.cloudMode === true);
+  check('window.CLOUD_NODE_ID matches', state.cloudNodeId === reg.node_id);
+  check(
+    'window.CLOUD_TOKEN matches api_key prefix',
+    state.cloudTokenPrefix === reg.api_key.slice(0, 16)
+  );
+  check('URL fragment scrubbed (privacy)', !state.url.includes('#key='));
+  check('enc_key landed in localStorage', state.encKeyValue === encKey);
+  check(
+    'no "Enter your secret key" prompt (decryption ready)',
+    !state.bodyText.toLowerCase().includes('enter your secret key')
+  );
+
+  // Filter known-harmless console noise.
+  const real = errors.filter(
+    e =>
+      !/Unexpected string/.test(e) &&
+      !(/\/api\/skills/.test(e) && /\b410\b/.test(e)) &&
+      !/posthog|clarity|analytics|gtag/i.test(e)
+  );
+  check('zero unexpected JS errors', real.length === 0, real.slice(0, 5).join('\n      '));
+
+  await browser.close();
+}
+
+// ── Scenario 2: KiloClaw user (source=kiloclaw) ───────────────────────
+
+async function testKiloClawDeferredSync() {
+  console.log('\n▸ Scenario 2: KiloClaw user (source=kiloclaw, deferred-sync gate)');
+  const machineId = `cm-contract-kc-${Date.now()}-${crypto.randomBytes(3).toString('hex')}`;
+  const reg = await registerOrSkip({
+    hostname: machineId,
+    machine_id: machineId,
+    platform: 'Linux',
+    email: `cm-contract-kc+${machineId}@clawmetry.com`,
+    source: 'kiloclaw',
+  });
+  check('kc register: api_key shape', /^cm_[a-f0-9]{32}$/.test(reg.api_key));
+
+  const hb1 = await heartbeat(reg, machineId, { expectDeferred: true });
+  console.log(`  hb1 response: ${JSON.stringify(hb1)}`);
+  check('kc hb1: sync_allowed === false', hb1.sync_allowed === false);
+  check('kc hb1: reason === "intent_pending"', hb1.reason === 'intent_pending');
+
+  const intent = await intentStart(reg);
+  console.log(`  intent response: ${JSON.stringify(intent)}`);
+  check('intent: ok === true', intent.ok === true);
+  check('intent: already_started === false (first time)', intent.already_started === false);
+
+  const hb2 = await heartbeat(reg, machineId);
+  console.log(`  hb2 response: ${JSON.stringify(hb2)}`);
+  check('kc hb2: sync_allowed is not false (gate flipped)', hb2.sync_allowed !== false);
+
+  const intent2 = await intentStart(reg);
+  console.log(`  intent2 response: ${JSON.stringify(intent2)}`);
+  check('intent2: already_started === true (idempotent)', intent2.already_started === true);
+}
+
+async function main() {
+  console.log(`[cloud-contract] target: ${API_BASE}`);
+  console.log(`[cloud-contract] headless: ${HEADLESS}\n`);
+
+  await testNormalUser();
+  await testKiloClawDeferredSync();
+
+  console.log(`\n${'─'.repeat(60)}`);
+  console.log(`  ${pass} passed, ${fail} failed`);
+  if (fail > 0) {
+    console.log('\nFailures:');
+    failures.forEach(f => console.log(`  • ${f}`));
+    process.exit(1);
+  }
+  console.log('  ✅ All checks passed');
+}
+
+main().catch(err => {
+  console.error('\n[cloud-contract] FATAL:', err);
+  process.exit(1);
+});

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "clawmetry-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clawmetry-e2e",
+      "devDependencies": {
+        "playwright": "^1.59.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "clawmetry-e2e",
+  "private": true,
+  "type": "module",
+  "description": "Node + Playwright E2E specs for ClawMetry. Single source of truth — clawmetry-cloud's deploy.yml fetches + runs cloud-contract.mjs from here.",
+  "scripts": {
+    "test:cloud-contract": "node cloud-contract.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.59.1"
+  }
+}


### PR DESCRIPTION
## What this changes

- **Adds \`tests/e2e/cloud-contract.mjs\`** — single source of truth end-to-end smoke for the daemon ↔ cloud API contract. Two scenarios: normal user (no \`source\` field, must NOT be deferred) and KiloClaw user (\`source: 'kiloclaw'\`, must be deferred until \`/api/cloud/intent-start\` flips the gate).
- **Wires it into \`release-on-merge.yml\`** as the last gate before \`twine upload\`. If anything fails, no PyPI publish, no release tag, the next [RELEASE] PR can re-run cleanly.
- **Cloud (\`clawmetry-cloud#637\`) shallow-clones THIS repo and runs the same script** post-deploy. Single file, two consumers.

## Why this answers the user's concern

Right now the same logic was duplicated in three places (cloud's smoke spec, KiloClaw's two .mjs scripts, OSS release inline shell). Adding a new contract check meant editing 2-3 files. Now it's one file, one place — both pipelines pick up changes automatically.

OSS is the home (vs cloud) because it's public — no PAT/secret needed to clone.

## Full release-on-merge gate flow (top → bottom, all must pass)

1. **Wheel install smoke** (inline shell): \`pip install dist/*.whl\` in a fresh venv, verify CLI version, imports, runtime assets ship.
2. **Daemon E2E** (inline shell): seed config in \`~/.clawmetry\`, spawn \`python -m clawmetry.sync\` for 15s, assert \"Initial heartbeat sent\" in daemon logs.
3. **Cloud-contract spec** (\`tests/e2e/cloud-contract.mjs\`): normal user + KiloClaw deferred-sync flows against live cloud.
4. **\`twine upload\`** runs only if 1, 2, 3 all passed.
5. **Post-publish PyPI verify**: poll metadata, install from PyPI, version check. On failure: prints manage.pypi.org/project URL to yank manually.

## Verified locally

- 19/19 checks pass when running \`cd tests/e2e && npm install && npm run test:cloud-contract\` against deployed prod
- YAML lints clean
- Wheel install + daemon E2E inline shell already verified by earlier 0.12.163 release

## Test plan

- [x] YAML valid
- [x] Spec runs locally: \`cd tests/e2e && npm install && npm run test:cloud-contract\` → 19/19 pass
- [ ] Merge → next [RELEASE] PR exercises the full gate end-to-end
- [ ] Manually break: introduce a SyntaxError in \`clawmetry/cli.py\` in a [RELEASE] PR → confirm wheel smoke aborts before publish