### PR TITLE
fix: add operator.read scope to gateway connect messages

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -9008,7 +9008,7 @@ def _auto_discover_gateway(token):
                         "instanceId": "clawmetry-discover",
                     },
                     "role": "operator",
-                    "scopes": ["operator.admin"],
+                    "scopes": ["operator.admin", "operator.read"],
                     "auth": {"token": token},
                 },
             }

--- a/helpers/gateway.py
+++ b/helpers/gateway.py
@@ -80,7 +80,7 @@ def _gw_ws_connect(url=None, token=None):
                     "instanceId": f"clawmetry-{_d._uuid.uuid4().hex[:8]}",
                 },
                 "role": "operator",
-                "scopes": ["operator.admin"],
+                "scopes": ["operator.admin", "operator.read"],
                 "auth": {"token": tok},
             },
         }

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -182,7 +182,7 @@ def api_gw_config():
                             "instanceId": "clawmetry-validate",
                         },
                         "role": "operator",
-                        "scopes": ["operator.admin"],
+                        "scopes": ["operator.admin", "operator.read"],
                         "auth": {"token": token},
                     },
                 }


### PR DESCRIPTION
Closes #598

## Summary
- Every gateway `connect` message requested only `["operator.admin"]`, omitting `operator.read`
- This caused `cron.list`, `sessions.list`, and all other read RPCs to be rejected with `missing scope: operator.read`, flooding `gateway.log`
- Fix adds `operator.read` alongside `operator.admin` in the three `scopes` arrays across `helpers/gateway.py`, `routes/meta.py`, and `dashboard.py`

## Test plan
- [ ] Run `clawmetry connect` against a live OpenClaw gateway and confirm no `INVALID_REQUEST errorCode=missing scope: operator.read` entries in `gateway.log`
- [ ] Confirm the Sessions tab loads cron list and session list without errors
- [ ] Confirm cron CRUD (which needs `operator.admin`) still works

---
_Generated by [Claude Code](https://claude.ai/code/session_01Peyv3ZgVXdDwL1VMAZuevG)_