### PR TITLE
feat(diagnostics): Anthropic OAuth migration warning banner (#556)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5411,6 +5411,15 @@ async function loadDiagnostics() {
       html += '<div style="margin-top:6px;color:var(--text-success,#22c55e);">✅ No diagnostics warnings</div>';
     }
     el.innerHTML = html;
+    // Show OAuth migration banner if Anthropic is configured without an API key
+    var oauthBanner = document.getElementById('oauth-migration-banner');
+    if (oauthBanner) {
+      var dismissed = false;
+      try { dismissed = !!localStorage.getItem('cm_oauth_migration_dismissed'); } catch(e){}
+      if (d.anthropic_oauth_warning && !dismissed) {
+        oauthBanner.style.display = 'flex';
+      }
+    }
     return true;
   } catch (e) {
     console.warn('diagnostics load failed', e);
@@ -6439,6 +6448,31 @@ function toggleMsg(idx) {
   }
 }
 
+
+// ── Anthropic OAuth Migration Banner (GH#556) ──────────────────────────────
+function dismissOauthMigrationBanner() {
+  var el = document.getElementById('oauth-migration-banner');
+  if (el) el.style.display = 'none';
+  try { localStorage.setItem('cm_oauth_migration_dismissed', '1'); } catch(e){}
+}
+function copyOauthMigrationCmd(btn) {
+  var cmd = 'openclaw onboard --anthropic-api-key';
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(cmd).then(function() {
+      if (btn) { var t = btn.textContent; btn.textContent = 'Copied!'; setTimeout(function(){ btn.textContent = t; }, 1400); }
+    }).catch(function(){});
+  } else {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = cmd;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      if (btn) { var t2 = btn.textContent; btn.textContent = 'Copied!'; setTimeout(function(){ btn.textContent = t2; }, 1400); }
+    } catch(e) {}
+  }
+}
 
 // ── Upgrade Banner (on overview page) ──────────────────────────────────────
 function dismissUpgradeBanner() {

--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -123,6 +123,47 @@
     ">Dismiss</button>
 </div>
 
+<!-- Anthropic OAuth Migration Banner (GH#556) -->
+<div id="oauth-migration-banner" style="
+  display:none;
+  padding:10px 16px;
+  border-bottom:2px solid #f59e0b;
+  font-size:13px;
+  font-weight:600;
+  align-items:center;
+  gap:10px;
+  background:#451a03;
+  color:#fbbf24;
+  ">
+  <span style="font-size:18px;">&#9888;&#65039;</span>
+  <span style="flex:1;">
+    Your Anthropic OAuth token no longer covers usage via OpenClaw (billing change Apr&nbsp;4&nbsp;2026).
+    Switch to an API key:
+    <button onclick="copyOauthMigrationCmd(this)" style="
+      margin-left:6px;
+      background:#92400e;
+      color:#fef3c7;
+      border:none;
+      border-radius:4px;
+      padding:2px 8px;
+      font-size:12px;
+      cursor:pointer;
+      font-family:monospace;
+      font-weight:700;
+      ">openclaw onboard --anthropic-api-key</button>
+  </span>
+  <button onclick="dismissOauthMigrationBanner()" style="
+    background:#92400e;
+    color:#fef3c7;
+    border:none;
+    border-radius:6px;
+    padding:4px 12px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    ">Dismiss</button>
+</div>
+
 <!-- Budget Cap Banner -->
 <div id="budget-cap-banner" style="
   display:none;

--- a/routes/health.py
+++ b/routes/health.py
@@ -614,6 +614,20 @@ def api_diagnostics():
     except Exception:
         warnings_list = []
 
+    # Detect Anthropic OAuth (legacy token) vs API key — warn users after Apr 4 billing change
+    anthropic_oauth_warning = False
+    try:
+        if not _d._provider_has_api_key("anthropic"):
+            cfg = _d._load_openclaw_config_cached()
+            auth_section = cfg.get("auth", {}) if isinstance(cfg, dict) else {}
+            profiles = auth_section.get("profiles", {}) if isinstance(auth_section, dict) else {}
+            for p in (profiles.values() if isinstance(profiles, dict) else []):
+                if isinstance(p, dict) and str(p.get("provider", "")).lower() == "anthropic":
+                    anthropic_oauth_warning = True
+                    break
+    except Exception:
+        pass
+
     return jsonify(
         {
             "gateway_url": gw_url,
@@ -623,6 +637,7 @@ def api_diagnostics():
             "openclaw_flags": openclaw_flags,
             "warnings": warnings_list,
             "auto_detected": auto_detected,
+            "anthropic_oauth_warning": anthropic_oauth_warning,
         }
     )
 


### PR DESCRIPTION
## Summary

After Anthropic's April 4 2026 billing change, users who configured OpenClaw with an OAuth/legacy token (instead of an API key) will silently fail. ClawMetry already reads the OpenClaw config to detect billing mode; this PR wires that signal into a dismissible top-of-page warning banner so affected users see a clear, actionable message the next time they open the dashboard.

## Changes

- **`routes/health.py`**: extend `/api/diagnostics` with `anthropic_oauth_warning: bool` — `True` when an Anthropic auth profile exists in `~/.openclaw/openclaw.json` but no API key is configured (uses existing `_provider_has_api_key` + `_load_openclaw_config_cached` helpers, no new logic)
- **`clawmetry/templates/partials/banners.html`**: new `#oauth-migration-banner` div — amber warning palette, matching the heartbeat/budget banner style; includes a one-click copy button for `openclaw onboard --anthropic-api-key`
- **`clawmetry/static/js/app.js`**: `loadDiagnostics()` shows the banner when the flag is set and the user hasn't dismissed it; `dismissOauthMigrationBanner()` hides and persists dismissal via `localStorage`; `copyOauthMigrationCmd()` handles clipboard copy with fallback

## Test plan

- [ ] Set `ANTHROPIC_API_KEY=""` and add an Anthropic auth profile (with `mode != "token"`) to `~/.openclaw/openclaw.json` → banner appears on dashboard load
- [ ] Set `ANTHROPIC_API_KEY=sk-ant-...` → no banner shown
- [ ] Click **Dismiss** → banner hides; survives page refresh (localStorage key persists)
- [ ] Click the command button → `openclaw onboard --anthropic-api-key` is copied to clipboard
- [ ] `GET /api/diagnostics` returns `anthropic_oauth_warning: true/false` correctly
- [ ] `python3 -c 'import ast; ast.parse(open("routes/health.py").read())'` passes

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #556. Marked draft for human review — mark Ready for Review once happy.

Closes #556

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKQyNkrNxWSJmiUJZnGUgy)_