### PR TITLE
fix: surface openclaw:prompt-error events in overview banner

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3521,6 +3521,15 @@ function clawmetryLogout(){
     <div id="velocity-flagged-list" style="margin-top:8px;display:flex;flex-wrap:wrap;gap:8px;"></div>
   </div>
 
+  <!-- Prompt-Error Banner (GH #601) -->
+  <div id="prompt-error-banner" style="display:none;margin-bottom:8px;border-radius:8px;padding:10px 16px;font-size:13px;font-weight:600;background:rgba(220,38,38,0.15);border:1px solid rgba(239,68,68,0.4);color:#fca5a5;">
+    <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px;">
+      <span id="prompt-error-msg"></span>
+      <button onclick="document.getElementById('prompt-error-banner').style.display='none'" style="background:none;border:none;color:inherit;opacity:0.7;cursor:pointer;font-size:18px;line-height:1;padding:0;">&times;</button>
+    </div>
+    <div id="prompt-error-list" style="margin-top:8px;display:flex;flex-direction:column;gap:4px;font-weight:400;font-size:12px;"></div>
+  </div>
+
   <!-- Stats Bar (top) -->
   <div class="stats-footer">
     <div class="stats-footer-item">
@@ -5424,6 +5433,34 @@ async function loadTokenVelocity() {
   }
 }
 
+async function loadPromptErrors() {
+  try {
+    var d = await fetchJsonWithTimeout('/api/prompt-errors', 5000);
+    var banner = document.getElementById('prompt-error-banner');
+    var msgEl  = document.getElementById('prompt-error-msg');
+    var listEl = document.getElementById('prompt-error-list');
+    if (!banner) return;
+    if (!d.errors || d.errors.length === 0) { banner.style.display = 'none'; return; }
+
+    msgEl.textContent = '⚠️ ' + d.count + ' prompt error' + (d.count === 1 ? '' : 's') + ' detected';
+
+    if (listEl) {
+      listEl.innerHTML = d.errors.slice(0, 5).map(function(e) {
+        var when = e.ts ? new Date(e.ts).toLocaleTimeString() : '';
+        var who = [e.provider, e.model].filter(Boolean).join('/') || 'unknown provider';
+        var msg = e.error ? String(e.error).slice(0, 120) : 'unknown error';
+        return '<div style="background:rgba(0,0,0,0.25);border-radius:5px;padding:4px 8px;">'
+          + (when ? '<span style="opacity:0.6;">' + when + '</span> ' : '')
+          + '<span style="opacity:0.8;">' + who + '</span>'
+          + ' — ' + msg
+          + '</div>';
+      }).join('');
+    }
+
+    banner.style.display = 'block';
+  } catch(e) { /* non-critical */ }
+}
+
 async function killSession(sessionId) {
   if (!confirm('Stop session ' + sessionId + '?')) return;
   try {
@@ -5571,6 +5608,7 @@ async function loadAll() {
     if (typeof loadReliabilityCard === 'function') loadReliabilityCard().catch(function(e){console.warn('reliability card failed',e)});
     if (typeof loadAnomalyPanel === 'function') loadAnomalyPanel().catch(function(e){console.warn('anomaly panel failed',e)});
     if (typeof loadTokenVelocity === 'function') loadTokenVelocity().catch(function(e){console.warn('velocity check failed',e)});
+    if (typeof loadPromptErrors === 'function') loadPromptErrors().catch(function(e){console.warn('prompt errors failed',e)});
     if (typeof loadDiagnostics === 'function') loadDiagnostics().catch(function(e){console.warn('diagnostics failed',e)});
     if (typeof loadHeartbeat === 'function') loadHeartbeat().catch(function(e){console.warn('heartbeat panel failed',e)});
     document.getElementById('refresh-time').textContent = 'Updated ' + new Date().toLocaleTimeString();

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -519,6 +519,92 @@ def api_timeline():
     return jsonify({"days": days, "today": now.strftime("%Y-%m-%d")})
 
 
+@bp_overview.route("/api/prompt-errors")
+def api_prompt_errors():
+    """Return recent openclaw:prompt-error events from session JSONL files.
+
+    Scans the 20 most-recently-modified session files so the response stays
+    fast regardless of how many sessions exist.  Supports ?since=<ISO8601>
+    for incremental polling by the client.
+    """
+    import dashboard as _d
+
+    since_raw = request.args.get("since")
+    since_ts = None
+    if since_raw:
+        try:
+            since_ts = datetime.fromisoformat(since_raw.replace("Z", "+00:00"))
+        except Exception:
+            pass
+
+    session_dir = _d.SESSIONS_DIR or os.path.expanduser(
+        "~/.openclaw/agents/main/sessions"
+    )
+    if not os.path.isdir(session_dir):
+        return jsonify({"errors": [], "count": 0})
+
+    try:
+        all_files = [
+            f for f in os.listdir(session_dir) if f.endswith(".jsonl")
+        ]
+        # Scan most-recently-modified first so we surface fresh errors quickly.
+        all_files.sort(
+            key=lambda f: os.path.getmtime(os.path.join(session_dir, f)),
+            reverse=True,
+        )
+        files = all_files[:20]
+    except Exception:
+        return jsonify({"errors": [], "count": 0})
+
+    errors = []
+    for fname in files:
+        fpath = os.path.join(session_dir, fname)
+        try:
+            with open(fpath, "r") as f:
+                for line in f:
+                    try:
+                        obj = json.loads(line.strip())
+                    except Exception:
+                        continue
+                    if obj.get("customType") != "openclaw:prompt-error":
+                        continue
+
+                    ts_raw = (
+                        obj.get("timestamp")
+                        or obj.get("time")
+                        or obj.get("created_at")
+                    )
+                    if since_ts and ts_raw:
+                        try:
+                            ev_ts = datetime.fromisoformat(
+                                str(ts_raw).replace("Z", "+00:00")
+                            )
+                            if ev_ts < since_ts:
+                                continue
+                        except Exception:
+                            pass
+
+                    # Fields may be at the top level or nested under "data".
+                    data = obj.get("data") if isinstance(obj.get("data"), dict) else obj
+                    errors.append(
+                        {
+                            "ts": ts_raw,
+                            "runId": data.get("runId") or obj.get("runId"),
+                            "sessionId": data.get("sessionId") or obj.get("sessionId"),
+                            "provider": data.get("provider") or obj.get("provider"),
+                            "model": data.get("model") or obj.get("model"),
+                            "api": data.get("api") or obj.get("api"),
+                            "error": data.get("error") or obj.get("error"),
+                        }
+                    )
+        except Exception:
+            continue
+
+    errors.sort(key=lambda e: e.get("ts") or "", reverse=True)
+    errors = errors[:50]
+    return jsonify({"errors": errors, "count": len(errors)})
+
+
 @bp_overview.route("/api/cloud-cta/status")
 def cloud_cta_status():
     import dashboard as _d


### PR DESCRIPTION
Closes #601

## Summary

- **`routes/overview.py`** — new `GET /api/prompt-errors?since=<ISO8601>` endpoint; scans the 20 most-recently-modified session JSONL files for `customType: 'openclaw:prompt-error'` events, returns up to 50 sorted newest-first. Handles fields at both top-level and nested under `data`.
- **`dashboard.py` (HTML)** — dismissable red `#prompt-error-banner` div inserted after the existing velocity-alert banner, same visual style.
- **`dashboard.py` (JS)** — `loadPromptErrors()` function called non-blocking from `loadAll()`, same pattern as `loadTokenVelocity`; shows provider, model, error message for up to 5 most recent failures.

## Test plan

- [ ] With no session JSONL files present, `GET /api/prompt-errors` returns `{"errors":[],"count":0}` and no banner appears.
- [ ] Inject a JSONL line `{"type":"custom","customType":"openclaw:prompt-error","provider":"anthropic","model":"claude-3","error":"rate_limit_exceeded"}` into a session file; Overview tab banner appears with provider/model/error.
- [ ] Banner dismiss button (`×`) hides it without a page reload.
- [ ] `?since=<future ISO timestamp>` filters out older events correctly.
- [ ] Pre-existing lint errors unchanged (109 pre-existing, 0 new).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeM2Dp7h6kxJ9wcL9i8STk)_