### PR TITLE
feat(sessions): session type taxonomy — main/heartbeat/user/sub-agent

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3557,6 +3557,7 @@ function clawmetryLogout(){
       <div>
         <div class="stats-footer-label">Sessions</div>
         <div class="stats-footer-value" id="hot-sessions-count">--</div>
+        <div id="hot-sessions-sub" style="font-size:10px;color:var(--text-muted);margin-top:2px;line-height:1.3;"></div>
       </div>
       <div id="hot-sessions-list" style="display:none;">Loading...</div>
     </div>
@@ -5813,6 +5814,15 @@ async function loadMiniWidgets(overview, usage) {
     var sl = sd.sessions || sd || [];
     if (!Array.isArray(sl)) sl = [];
     document.getElementById('hot-sessions-count').textContent = sl.length;
+    // Build session-type breakdown subtitle (heartbeat / user / sub-agent)
+    var typeCounts = {};
+    sl.forEach(function(s) { var t = s.session_type || 'main'; typeCounts[t] = (typeCounts[t] || 0) + 1; });
+    var parts = [];
+    ['heartbeat', 'user', 'sub-agent'].forEach(function(t) {
+      if (typeCounts[t]) parts.push(typeCounts[t] + ' ' + t);
+    });
+    var sub = document.getElementById('hot-sessions-sub');
+    if (sub) sub.textContent = parts.length ? parts.join(' · ') : '';
   }).catch(function() {
     document.getElementById('hot-sessions-count').textContent = overview.sessionCount || 0;
   });

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -31,14 +31,82 @@ _SUBAGENTS_CACHE_TTL_SECONDS = 10
 _SUBAGENTS_SCAN_MAX_FILES = int(os.environ.get("CLAWMETRY_SUBAGENTS_SCAN_MAX_FILES", "120"))
 _SUBAGENTS_SCAN_TAIL_BYTES = int(os.environ.get("CLAWMETRY_SUBAGENTS_SCAN_TAIL_BYTES", str(512 * 1024)))
 
+# Channels that don't identify a user-initiated session (generic/internal)
+_GENERIC_CHANNELS = frozenset({"unknown", "direct", "", "main", "internal"})
+
+
+def _infer_session_type(session):
+    """Classify a session into one of: main / heartbeat / user / sub-agent.
+
+    Priority:
+      1. display name / session id contains "heartbeat"  → heartbeat
+      2. gateway kind == "subagent" or name contains it  → sub-agent
+      3. channel is set and non-generic                  → user
+      4. fallback                                        → main
+    """
+    name = (session.get("displayName") or session.get("sessionId") or "").lower()
+    kind = (session.get("kind") or "").lower()
+    channel = (session.get("channel") or "").lower().strip()
+
+    if "heartbeat" in name:
+        return "heartbeat"
+    if kind == "subagent" or "subagent" in name:
+        return "sub-agent"
+    if channel and channel not in _GENERIC_CHANNELS:
+        return "user"
+    return "main"
+
 
 @bp_sessions.route("/api/sessions")
 def api_sessions():
     import dashboard as _d
     gw_data = _d._gw_invoke("sessions_list", {"limit": 20, "messageLimit": 0})
     if gw_data and "sessions" in gw_data:
-        return jsonify({"sessions": _d._augment_sessions_with_burn(gw_data["sessions"])})
-    return jsonify({"sessions": _d._augment_sessions_with_burn(_d._get_sessions())})
+        sessions = _d._augment_sessions_with_burn(gw_data["sessions"])
+    else:
+        sessions = _d._augment_sessions_with_burn(_d._get_sessions())
+    for s in sessions:
+        if "session_type" not in s:
+            s["session_type"] = _infer_session_type(s)
+    return jsonify({"sessions": sessions})
+
+
+@bp_sessions.route("/api/sessions/by-type")
+def api_sessions_by_type():
+    """Return sessions grouped by type with per-type counts.
+
+    Response:
+      {
+        "counts": {"main": N, "heartbeat": N, "user": N, "sub-agent": N, "total": N},
+        "sessions": [<session objects with session_type field>]
+      }
+
+    Optional query param ?type=<heartbeat|user|sub-agent|main> to filter the
+    returned session list (counts always cover all sessions).
+    """
+    import dashboard as _d
+    gw_data = _d._gw_invoke("sessions_list", {"limit": 50, "messageLimit": 0})
+    if gw_data and "sessions" in gw_data:
+        sessions = _d._augment_sessions_with_burn(gw_data["sessions"])
+    else:
+        sessions = _d._augment_sessions_with_burn(_d._get_sessions())
+
+    for s in sessions:
+        if "session_type" not in s:
+            s["session_type"] = _infer_session_type(s)
+
+    counts = {"main": 0, "heartbeat": 0, "user": 0, "sub-agent": 0}
+    for s in sessions:
+        t = s.get("session_type", "main")
+        counts[t] = counts.get(t, 0) + 1
+    counts["total"] = len(sessions)
+
+    type_filter = request.args.get("type", "").strip()
+    filtered = [
+        s for s in sessions
+        if not type_filter or s.get("session_type") == type_filter
+    ]
+    return jsonify({"counts": counts, "sessions": filtered})
 
 
 @bp_sessions.route("/api/compactions")


### PR DESCRIPTION
Closes #691

## Summary

- **`_infer_session_type(session)`** — new helper in `routes/sessions.py` that classifies each session as `main` / `heartbeat` / `user` / `sub-agent` using display name, gateway `kind` field, and channel (priority order: heartbeat name match → subagent kind/name → non-generic channel → main fallback)
- **`/api/sessions`** — now includes `session_type` on every session object; fully backward-compatible (field is additive)
- **`/api/sessions/by-type`** — new endpoint returning `{counts: {main, heartbeat, user, sub-agent, total}, sessions: [...]}` with optional `?type=` filter for the session list
- **Overview sidebar** — sessions counter gains a type-breakdown subtitle (e.g. `2 heartbeat · 1 user`) rendered from the `session_type` field in the existing `/api/sessions` fetch

## Test plan

- [ ] `GET /api/sessions` — verify each session has a `session_type` field with one of the four valid values
- [ ] `GET /api/sessions/by-type` — verify counts add up to total, sessions list matches
- [ ] `GET /api/sessions/by-type?type=heartbeat` — verify only heartbeat sessions returned, counts still cover all types
- [ ] Overview page — verify the Sessions counter shows a breakdown subtitle when session types are mixed
- [ ] No regressions: existing `/api/sessions` callers that ignore `session_type` continue to work unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS53UmzCspPGGy4GACAyST)_