### PR TITLE
feat: 30-day session activity heatmap on Overview tab (#875)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1670,6 +1670,7 @@ async function loadAll() {
     if (typeof loadDiagnostics === 'function') loadDiagnostics().catch(function(e){console.warn('diagnostics failed',e)});
     if (typeof loadAutonomy === 'function') loadAutonomy().catch(function(e){console.warn('autonomy failed',e)});
     if (typeof loadHeartbeat === 'function') loadHeartbeat().catch(function(e){console.warn('heartbeat panel failed',e)});
+    if (typeof loadActivityHeatmap === 'function') loadActivityHeatmap().catch(function(e){console.warn('activity heatmap failed',e)});
     document.getElementById('refresh-time').textContent = 'Updated ' + new Date().toLocaleTimeString();
 
     if (overview.infra) {
@@ -5405,6 +5406,40 @@ async function loadHeatmap(days) {
   } catch(e) {
     var grid2 = document.getElementById('heatmap-grid');
     if (grid2) grid2.innerHTML = '<span style="color:#555">No activity data</span>';
+  }
+}
+
+// ===== 30-day Session Activity Heatmap (GH#875) =====
+async function loadActivityHeatmap() {
+  var grid = document.getElementById('activity-heatmap-grid');
+  if (!grid) return;
+  try {
+    var data = await fetch('/api/activity-heatmap').then(function(r) { return r.json(); });
+    if (!data || !data.days || !data.days.length) {
+      grid.innerHTML = '<span style="color:var(--text-muted);font-size:12px;">No session data yet</span>';
+      return;
+    }
+    var maxSessions = Math.max(1, Math.max.apply(null, data.days.map(function(d) { return d.sessions; })));
+    var html = '';
+    data.days.forEach(function(day) {
+      var intensity = day.sessions / maxSessions;
+      var color;
+      if (day.sessions === 0) color = '#12122a';
+      else if (intensity < 0.25) color = '#1a3a2a';
+      else if (intensity < 0.5) color = '#2a6a3a';
+      else if (intensity < 0.75) color = '#4a9a2a';
+      else color = '#6adb3a';
+      var fmtTok = day.tokens >= 1000000 ? (day.tokens/1000000).toFixed(1)+'M' : day.tokens >= 1000 ? (day.tokens/1000).toFixed(0)+'K' : String(day.tokens);
+      var fmtCost = day.cost > 0 ? '$'+day.cost.toFixed(2) : '$0.00';
+      var tip = day.label + ': ' + day.sessions + ' session' + (day.sessions !== 1 ? 's' : '') + ', ' + fmtTok + ' tokens, ' + fmtCost;
+      html += '<div class="heatmap-cell" style="background:' + color + ';min-height:20px;" title="' + tip + '"></div>';
+    });
+    grid.innerHTML = html;
+    grid.style.display = 'grid';
+    var legend = document.getElementById('activity-heatmap-legend');
+    if (legend) legend.innerHTML = 'Less <div class="heatmap-legend-cell" style="background:#12122a"></div><div class="heatmap-legend-cell" style="background:#1a3a2a"></div><div class="heatmap-legend-cell" style="background:#2a6a3a"></div><div class="heatmap-legend-cell" style="background:#4a9a2a"></div><div class="heatmap-legend-cell" style="background:#6adb3a"></div> More (sessions per day)';
+  } catch(e) {
+    if (grid) grid.innerHTML = '<span style="color:var(--text-muted);font-size:12px;">No activity data</span>';
   }
 }
 

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -380,4 +380,13 @@
       @keyframes hb-pulse-missed { 0%,100%{opacity:1;box-shadow:0 0 0 0 rgba(239,68,68,.4)} 70%{opacity:.8;box-shadow:0 0 0 8px rgba(239,68,68,0)} }
     </style>
   </div>
+
+  <!-- 30-day Activity Heatmap (GH#875) -->
+  <div style="background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:10px;padding:18px 22px;margin-top:14px;">
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:12px;">📅 30-day Activity</div>
+    <div id="activity-heatmap-grid" class="heatmap-wrap" style="display:grid;grid-template-columns:repeat(30,1fr);gap:3px;">
+      <span style="color:var(--text-muted);font-size:12px;">Loading...</span>
+    </div>
+    <div id="activity-heatmap-legend" class="heatmap-legend" style="margin-top:8px;"></div>
+  </div>
 </div>

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -519,6 +519,47 @@ def api_timeline():
     return jsonify({"days": days, "today": now.strftime("%Y-%m-%d")})
 
 
+@bp_overview.route("/api/activity-heatmap")
+def api_activity_heatmap():
+    """30-day session activity heatmap — sessions/tokens/cost per calendar day.
+
+    Returns {"days": [{date, label, sessions, tokens, cost}, ...]} for the
+    last 30 days, oldest first.  Re-uses the cached _compute_transcript_analytics
+    result so this endpoint adds no extra I/O when /api/usage was already hit.
+    """
+    import dashboard as _d
+
+    n_days = 30
+    now = datetime.now()
+
+    day_keys = []
+    day_map = {}
+    for i in range(n_days - 1, -1, -1):
+        d = now - timedelta(days=i)
+        ds = d.strftime("%Y-%m-%d")
+        day_keys.append(ds)
+        day_map[ds] = {"date": ds, "label": d.strftime("%b %-d"), "sessions": 0, "tokens": 0, "cost": 0.0}
+
+    try:
+        analytics = _d._compute_transcript_analytics()
+        daily_tokens = analytics.get("daily_tokens", {})
+        daily_cost = analytics.get("daily_cost", {})
+        sessions = analytics.get("sessions", [])
+
+        for ds in day_keys:
+            day_map[ds]["tokens"] = int(daily_tokens.get(ds, 0))
+            day_map[ds]["cost"] = round(float(daily_cost.get(ds, 0.0)), 4)
+
+        for s in sessions:
+            day = s.get("day") or ""
+            if day in day_map:
+                day_map[day]["sessions"] += 1
+    except Exception:
+        pass
+
+    return jsonify({"days": [day_map[d] for d in day_keys]})
+
+
 @bp_overview.route("/api/cloud-cta/status")
 def cloud_cta_status():
     import dashboard as _d


### PR DESCRIPTION
## Summary

Adds a GitHub-style 30-day session activity heatmap to the bottom of the Overview tab. Each cell represents one calendar day, coloured by how many agent sessions ran that day. Hovering shows date, session count, total tokens, and estimated cost.

## Changes

- **`routes/overview.py`** — new `GET /api/activity-heatmap` endpoint; calls the cached `_compute_transcript_analytics()` result (shared with `/api/usage`) to aggregate daily session counts, token totals, and costs for the last 30 days. No extra filesystem I/O on warm cache (~35 LOC).
- **`clawmetry/templates/tabs/overview.html`** — new "📅 30-day Activity" card appended at the bottom of the Overview tab; reuses existing `.heatmap-cell` and `.heatmap-legend` CSS (~9 LOC).
- **`clawmetry/static/js/app.js`** — new `loadActivityHeatmap()` async function (5-shade green intensity scale, same palette as the existing hour heatmap); wired into `loadAll()` as a non-blocking secondary panel (~36 LOC).

## Test plan

- [ ] `GET /api/activity-heatmap` returns `{"days": [...30 items...]}` — each item has `date` (YYYY-MM-DD), `label` (e.g. "May 9"), `sessions` (int ≥ 0), `tokens` (int), `cost` (float)
- [ ] Overview tab shows a row of 30 coloured squares at the bottom — darkest on empty days, progressively greener on busier days
- [ ] Tooltip on each cell shows the correct date, session count, tokens, and cost
- [ ] Workspace with no sessions: all cells dark, no JS errors in console
- [ ] `python3 -c 'import ast; ast.parse(open("routes/overview.py").read())'` passes

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #875. Marked draft for human review — mark Ready for Review once happy.

Closes #875

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bay8ySWWDt8kdwYRFr2UHm)_