### PR TITLE
feat: GET /api/agent-intentions — calendar timeline of cron firings (closes #693)

### DIFF
--- a/routes/crons.py
+++ b/routes/crons.py
@@ -463,6 +463,150 @@ def api_cron_kill_all():
     )
 
 
+@bp_crons.route("/api/agent-intentions")
+def api_agent_intentions():
+    """Cron jobs reframed as the agent's planned future actions.
+
+    Returns the same job data as ``/api/crons`` projected onto a calendar
+    timeline: every firing the agent has scheduled in the next ``days``
+    window, plus a ``recently_added`` callout for jobs the agent created
+    in the last 24 hours.
+
+    Query params:
+      days (int, default=7, max=30): timeline window in days from now.
+      include_disabled (bool, default=false): also project disabled jobs.
+      max_events (int, default=200, max=1000): cap on projected firings.
+
+    Interval jobs (``schedule.kind`` ∈ {``every``, ``interval``}) are
+    projected forward by repeatedly adding ``everyMs`` to ``nextRunAtMs``.
+    Cron-expression jobs are surfaced with only their gateway-provided
+    ``nextRunAtMs`` (full cron parsing is intentionally out of scope —
+    needs a dependency we don't ship today).
+    """
+    import dashboard as _d
+
+    try:
+        days = max(1, min(int(request.args.get("days", "7")), 30))
+    except ValueError:
+        days = 7
+    include_disabled = str(request.args.get("include_disabled", "")).lower() in (
+        "1", "true", "yes"
+    )
+    try:
+        max_events = max(10, min(int(request.args.get("max_events", "200")), 1000))
+    except ValueError:
+        max_events = 200
+
+    gw_data = _d._gw_invoke("cron", {"action": "list", "includeDisabled": True}) or {}
+    jobs = gw_data.get("jobs", []) or _d._get_crons()
+    if not isinstance(jobs, list):
+        jobs = []
+
+    now_ms = int(datetime.now().timestamp() * 1000)
+    window_end_ms = now_ms + days * 24 * 3600 * 1000
+    recent_threshold_ms = now_ms - 24 * 3600 * 1000
+
+    intentions: list = []
+    recently_added: list = []
+
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        enabled = bool(job.get("enabled", True))
+        if not enabled and not include_disabled:
+            continue
+
+        job_id = job.get("id", "")
+        job_name = job.get("name", job_id)
+        sched = job.get("schedule") or {}
+        state = job.get("state") or {}
+
+        created_at_ms = job.get("createdAtMs") or 0
+        if isinstance(created_at_ms, str):
+            try:
+                from dateutil import parser as _dtp
+                created_at_ms = int(_dtp.parse(created_at_ms).timestamp() * 1000)
+            except Exception:
+                created_at_ms = 0
+        is_recently_added = bool(created_at_ms and created_at_ms >= recent_threshold_ms)
+        if is_recently_added:
+            recently_added.append({
+                "jobId": job_id,
+                "name": job_name,
+                "createdAtMs": created_at_ms,
+                "schedule": sched,
+                "enabled": enabled,
+            })
+
+        last_status = state.get("lastStatus", "pending")
+        last_run_ms = state.get("lastRunAtMs") or 0
+        if isinstance(last_run_ms, str):
+            try:
+                from dateutil import parser as _dtp
+                last_run_ms = int(_dtp.parse(last_run_ms).timestamp() * 1000)
+            except Exception:
+                last_run_ms = 0
+        next_run_ms = state.get("nextRunAtMs") or 0
+
+        sched_kind = (sched.get("kind") or "").lower() if isinstance(sched, dict) else ""
+        every_ms = sched.get("everyMs") if isinstance(sched, dict) else None
+        try:
+            every_ms = int(every_ms) if every_ms else 0
+        except (TypeError, ValueError):
+            every_ms = 0
+
+        firings: list = []
+        if sched_kind in ("every", "interval") and every_ms > 0:
+            # Walk forward by everyMs from the gateway's nextRunAtMs.
+            # If nextRunAtMs is unset, the gateway hasn't scheduled it yet —
+            # assume the first firing is one interval out.
+            t = int(next_run_ms) if next_run_ms else now_ms + every_ms
+            # If next_run is already in the past, advance to the first future tick
+            if t < now_ms:
+                gap = now_ms - t
+                t += ((gap // every_ms) + 1) * every_ms
+            while t <= window_end_ms and len(firings) < 100:
+                firings.append(t)
+                t += every_ms
+        elif next_run_ms and now_ms <= next_run_ms <= window_end_ms:
+            # Cron-expression / one-shot: only the immediate next firing
+            firings.append(int(next_run_ms))
+
+        for ts in firings:
+            intentions.append({
+                "jobId": job_id,
+                "name": job_name,
+                "scheduledForMs": ts,
+                "scheduleKind": sched_kind or "unknown",
+                "lastStatus": last_status,
+                "lastRunAtMs": last_run_ms,
+                "isRecentlyAdded": is_recently_added,
+                "enabled": enabled,
+            })
+            if len(intentions) >= max_events:
+                break
+        if len(intentions) >= max_events:
+            break
+
+    intentions.sort(key=lambda r: r.get("scheduledForMs", 0))
+    recently_added.sort(key=lambda r: -(r.get("createdAtMs") or 0))
+
+    return jsonify({
+        "intentions": intentions,
+        "recently_added": recently_added,
+        "window": {
+            "startMs": now_ms,
+            "endMs": window_end_ms,
+            "days": days,
+        },
+        "stats": {
+            "total_intentions": len(intentions),
+            "recently_added_count": len(recently_added),
+            "truncated": len(intentions) >= max_events,
+        },
+    })
+
+
 @bp_crons.route("/api/cron-health")
 def api_cron_health():
     """Cron health monitor — run history, success rate, cost per run (GH #306).

--- a/tests/test_cron_health.py
+++ b/tests/test_cron_health.py
@@ -99,6 +99,63 @@ class TestCronHealthSummary:
             assert job["costUsd"] >= 0
 
 
+class TestAgentIntentions:
+    """Tests for GET /api/agent-intentions (GH #693)."""
+
+    def test_returns_200(self, api, base_url):
+        r = get(api, base_url, "/api/agent-intentions")
+        assert r.status_code == 200, f"Expected 200, got {r.status_code}: {r.text[:200]}"
+
+    def test_response_structure(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/agent-intentions"))
+        assert_keys(d, "intentions", "recently_added", "window", "stats")
+
+    def test_window_defaults_to_7_days(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/agent-intentions"))
+        w = d["window"]
+        assert_keys(w, "startMs", "endMs", "days")
+        assert w["days"] == 7
+        assert w["endMs"] > w["startMs"]
+        # endMs should be ~7 days after startMs
+        delta_days = (w["endMs"] - w["startMs"]) / (24 * 3600 * 1000)
+        assert 6.9 < delta_days < 7.1
+
+    def test_days_param_clamped(self, api, base_url):
+        # max=30
+        d = assert_ok(get(api, base_url, "/api/agent-intentions?days=999"))
+        assert d["window"]["days"] == 30
+        # min=1
+        d = assert_ok(get(api, base_url, "/api/agent-intentions?days=0"))
+        assert d["window"]["days"] == 1
+
+    def test_intentions_sorted_chronologically(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/agent-intentions"))
+        intentions = d["intentions"]
+        for i in range(len(intentions) - 1):
+            assert intentions[i]["scheduledForMs"] <= intentions[i + 1]["scheduledForMs"], (
+                "Intentions not sorted by scheduledForMs ascending"
+            )
+
+    def test_intention_fields_if_present(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/agent-intentions"))
+        for it in d["intentions"][:5]:
+            assert_keys(
+                it, "jobId", "name", "scheduledForMs", "scheduleKind",
+                "lastStatus", "isRecentlyAdded", "enabled",
+            )
+            assert isinstance(it["scheduledForMs"], int)
+            assert it["scheduledForMs"] >= d["window"]["startMs"]
+            assert it["scheduledForMs"] <= d["window"]["endMs"]
+
+    def test_stats_consistency(self, api, base_url):
+        d = assert_ok(get(api, base_url, "/api/agent-intentions"))
+        stats = d["stats"]
+        assert_keys(stats, "total_intentions", "recently_added_count", "truncated")
+        assert stats["total_intentions"] == len(d["intentions"])
+        assert stats["recently_added_count"] == len(d["recently_added"])
+        assert isinstance(stats["truncated"], bool)
+
+
 class TestCronRunHistory:
     """Tests for GET /api/cron/<job_id>/runs (GH #302)."""
 


### PR DESCRIPTION
Closes #693

## What

Reframes existing cron data as the agent's planned future actions.

New endpoint `GET /api/agent-intentions` returns:

- `intentions[]` — every projected firing in the next N days (`jobId`, `name`, `scheduledForMs`, `scheduleKind`, `lastStatus`, `isRecentlyAdded`, `enabled`)
- `recently_added[]` — jobs the agent created in the last 24h (per the issue's "recently added intentions" callout)
- `window` — `{ startMs, endMs, days }`
- `stats` — `{ total_intentions, recently_added_count, truncated }`

Query params: `days` (1–30, default 7), `include_disabled`, `max_events` (10–1000, default 200).

## How

- Lives in `routes/crons.py` next to the existing CRUD/health endpoints — no new file, no new dependency.
- Reuses the gateway-provided `cron list` payload that `/api/crons` and `/api/cron/health-summary` already consume, so behaviour for those is unchanged.
- Interval jobs (`schedule.kind ∈ {every, interval}`) are projected forward by adding `everyMs` to the gateway's `nextRunAtMs`. If `nextRunAtMs` isn't set yet, projection starts at `now + everyMs`.
- Cron-expression jobs surface only the immediate `nextRunAtMs` from the gateway. Full cron-string projection is intentionally out of scope here — it needs a parser dependency (`croniter`) we don't ship, and adding it belongs in its own PR.
- Per-job cap of 100 firings + global `max_events` keep the response bounded for long windows / dense intervals.

## UI scope

Per the issue this PR ships the **basic** OSS data layer. The "Agent Intentions" calendar UI is a follow-up — the existing CRUD view remains the user-facing entry point. The `/api/agent-intentions` shape is designed to feed a calendar/Gantt directly without further server-side joins.

## Test plan

`tests/test_cron_health.py::TestAgentIntentions` covers:

- [x] 200 response + top-level structure (`intentions`, `recently_added`, `window`, `stats`)
- [x] Default 7-day window and `days` clamping (999 → 30, 0 → 1)
- [x] Chronological ordering of `intentions`
- [x] Per-intention required fields and that `scheduledForMs` falls inside `window`
- [x] `stats` consistency with array lengths

Smoke-checked locally against my own cron set with `flask test_client`:

```
/api/crons              -> 200 keys: ['jobs']
/api/cron/health-summary-> 200 keys: ['hasAnomalies','hasErrors','hasSilent','jobs','totals']
/api/cron-health        -> 200 keys: ['crons','has_anomalies','totals']
/api/agent-intentions   -> 200 keys: ['intentions','recently_added','stats','window']
```

Existing endpoints are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)