### PR TITLE
feat(sync): track initial sync progress + /api/sync-progress endpoint (#748 part 1)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -237,6 +237,45 @@ def save_state(state: dict) -> None:
     STATE_FILE.write_text(json.dumps(state, indent=2))
 
 
+# ── Initial-sync progress (vivekchand/clawmetry#748) ─────────────────────────
+# Tracks per-phase progress to ~/.clawmetry/sync_progress.json so the local
+# dashboard can show a "syncing…" banner on fresh installs instead of empty
+# tabs. Written atomically (tmp + rename) because the dashboard reads this
+# file on every banner poll.
+SYNC_PROGRESS_FILE = CONFIG_DIR / "sync_progress.json"
+_sync_progress_started_at: str | None = None
+
+
+def _record_sync_progress(
+    phase: str, done: int, total: int = 0, status: str = "running"
+) -> None:
+    global _sync_progress_started_at
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc).isoformat()
+        if _sync_progress_started_at is None:
+            _sync_progress_started_at = now
+        try:
+            cfg = load_config()
+            node_id = cfg.get("node_id", "")
+        except Exception:
+            node_id = ""
+        payload = {
+            "node_id": node_id,
+            "phase": phase,
+            "done": int(done),
+            "total": int(total),
+            "status": status,
+            "started_at": _sync_progress_started_at,
+            "updated_at": now,
+        }
+        tmp = SYNC_PROGRESS_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload, indent=2))
+        os.replace(tmp, SYNC_PROGRESS_FILE)
+    except Exception as e:
+        log.debug(f"Could not record sync progress ({phase}): {e}")
+
+
 # ── HTTP ──────────────────────────────────────────────────────────────────────
 
 
@@ -937,6 +976,7 @@ def sync_sessions(config: dict, state: dict, paths: dict) -> int:
     # exactly where we paused -- no event loss, no double-send.
     if not _sync_allowed():
         return 0
+    _record_sync_progress("sessions", 0)
     sessions_dir = paths["sessions_dir"]
     api_key = config["api_key"]
     enc_key = config.get("encryption_key")
@@ -1030,6 +1070,7 @@ def sync_sessions(config: dict, state: dict, paths: dict) -> int:
         except Exception as e:
             log.warning(f"Session sync error ({fname}): {e}")
 
+    _record_sync_progress("sessions", total, total)
     return total
 
 
@@ -1078,6 +1119,7 @@ def sync_sessions_recent(
     """
     if not _sync_allowed():
         return 0
+    _record_sync_progress("sessions_recent", 0)
     from datetime import timedelta
 
     sessions_dir = paths["sessions_dir"]
@@ -1192,6 +1234,7 @@ def sync_sessions_recent(
         except Exception as e:
             log.warning(f"Recent sync error ({fname}): {e}")
 
+    _record_sync_progress("sessions_recent", total, total)
     return total
 
 
@@ -1595,6 +1638,7 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
     """
     if not _sync_allowed():
         return 0
+    _record_sync_progress("crons", 0)
     api_key = config["api_key"]
     node_id = config["node_id"]
     last_hash = state.get("cron_hash", "")
@@ -1686,6 +1730,7 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
             for job_id, job_hash in emitted_job_ids:
                 job_dedup[job_id] = [job_hash, now_ts]
             state["cron_hash"] = h
+            _record_sync_progress("crons", len(events), len(events))
             return len(events)
         elif not file_unchanged:
             # File mtime/content changed but every job was deduped — still
@@ -1693,6 +1738,7 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
             state["cron_hash"] = h
     except Exception as e:
         log.warning(f"Cron sync error: {e}")
+    _record_sync_progress("crons", 0, 0)
     return 0
 
 
@@ -1708,6 +1754,7 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
     """
     if not _sync_allowed():
         return 0
+    _record_sync_progress("session_metadata", 0)
     api_key = config["api_key"]
     node_id = config["node_id"]
     if state is None:
@@ -1885,9 +1932,11 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                 log.debug(f"Session parse error ({fpath.name}): {e}")
 
         total_uploaded += _flush(batch)
+        _record_sync_progress("session_metadata", total_uploaded, total_uploaded)
         return total_uploaded
     except Exception as e:
         log.warning(f"Session metadata sync failed: {e}")
+        _record_sync_progress("session_metadata", 0, 0)
         return 0
 
 
@@ -1897,6 +1946,7 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
     Skipped when sync is paused (expired trial)."""
     if not _sync_allowed():
         return 0
+    _record_sync_progress("memory", 0)
     workspace = paths.get("workspace", "")
     api_key = config["api_key"]
     enc_key = config.get("encryption_key")
@@ -1925,6 +1975,7 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
                 memory_files.append((f"memory/{f}", os.path.join(mem_dir, f)))
 
     if not memory_files:
+        _record_sync_progress("memory", 0, 0)
         return 0
 
     # Check for changes via content hash; always send all file contents so the
@@ -1954,6 +2005,7 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
             log.debug(f"Memory file read error ({name}): {e}")
 
     if not changed_files:
+        _record_sync_progress("memory", len(memory_files), len(memory_files))
         return 0
 
     # Push memory files as encrypted blob (like session events).
@@ -1985,6 +2037,7 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
     except Exception as e:
         log.warning(f"Memory sync error: {e}")
 
+    _record_sync_progress("memory", synced, len(memory_files))
     return synced
 
     # ── Real-time log streaming ────────────────────────────────────────────────────
@@ -3343,6 +3396,7 @@ def run_daemon() -> None:
     state["last_sync"] = datetime.now(timezone.utc).isoformat()
     save_state(state)
     send_heartbeat(config)
+    _record_sync_progress("complete", 0, 0, status="complete")
     log.info("Recent sync complete — Brain feed should show current activity")
 
     # Validate stored log offsets on startup — prevents silent gaps

--- a/dashboard.py
+++ b/dashboard.py
@@ -8389,6 +8389,21 @@ def detect_config(args=None):
             return _jsonify({"error": "Connect to ClawMetry Cloud to save "
                              "integrations.", "note": _oss_note}), 402
         return _jsonify({"integrations": [], "count": 0, "note": _oss_note})
+
+    # vivekchand/clawmetry#748 — Initial-sync progress for the dashboard
+    # banner. The sync daemon writes ~/.clawmetry/sync_progress.json after
+    # each phase; we just stream it through. Local-only, no auth.
+    @app.route("/api/sync-progress", endpoint="sync_progress")
+    def _sync_progress():
+        from flask import jsonify as _jsonify
+        progress_path = os.path.expanduser("~/.clawmetry/sync_progress.json")
+        if not os.path.isfile(progress_path):
+            return _jsonify({"error": "no sync progress yet"}), 404
+        try:
+            with open(progress_path) as _f:
+                return _jsonify(json.load(_f))
+        except Exception as _e:
+            return _jsonify({"error": f"unreadable: {_e}"}), 500
     # ────────────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #748 (partially — see Scope).

## What
- Add `_record_sync_progress(phase, done, total, status)` helper in `clawmetry/sync.py` that writes `~/.clawmetry/sync_progress.json` atomically (tmp + `os.replace`).
- Hook it at the start and end of `sync_sessions`, `sync_sessions_recent`, `sync_session_metadata`, `sync_memory`, and `sync_crons` so the daemon emits live progress during the initial sync cycle.
- Mark `phase="complete"`, `status="complete"` once the daemon's startup recent-sync block finishes.
- Expose `GET /api/sync-progress` in `dashboard.py` (next to the existing OSS shims) that returns the JSON file — 404 before the first write, 200 with body otherwise. Local-only, no auth.

## How
The progress file uses the same `CONFIG_DIR = ~/.clawmetry` convention already used by `STATE_FILE` and `CONFIG_FILE`. Atomic write protects the dashboard reader from torn JSON. Hooks are positioned after the existing `_sync_allowed()` early-return so we don't lie about progress on paused (expired-trial) accounts.

The new endpoint follows the direct-`@app.route` style of the cloud shims registered inside `detect_config()` rather than introducing a one-route blueprint just for this — keeps the diff to two files.

## Scope
This is **Part 1 — OSS-side state tracking only**. Follow-ups:
- **Part 2:** cloud-side ingest endpoint to receive these progress events from the daemon (so the cloud dashboard can show the banner too, not just the local OSS dashboard).
- **Part 3:** the actual sync-progress banner UI on the dashboard, consuming `/api/sync-progress`.

Net diff: 69 lines across 2 files.

## Test plan
- [ ] On a fresh install, run `clawmetry connect` and confirm `~/.clawmetry/sync_progress.json` appears once the daemon starts.
- [ ] `curl localhost:<dashboard-port>/api/sync-progress` returns the expected JSON shape.
- [ ] Before any sync runs, the same endpoint returns 404 with `{"error": "no sync progress yet"}`.
- [ ] Existing daemon behaviour is unchanged on a system that already has `initial_backfill_done=true` — progress just reports each cycle's results.

Co-Authored-By: Dhriti <noreply@clawmetry.com>