### PR TITLE
fix(docker): pre-create /app/.clawmetry directory to prevent PermissionError

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,14 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy application code
+# Copy application code and necessary files for setup
 COPY dashboard.py .
+COPY history.py .
 COPY setup.py .
+COPY README.md . 
 COPY clawmetry/ ./clawmetry/
+COPY helpers/ ./helpers/
+COPY routes/ ./routes/
 
 # Install clawmetry
 RUN pip install --no-cache-dir -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY routes/ ./routes/
 RUN pip install --no-cache-dir -e .
 
 # Create directories for OpenClaw integration
-RUN mkdir -p /root/.openclaw /tmp/moltbot
+RUN mkdir -p /root/.openclaw /tmp/moltbot /app/.clawmetry
 
 # Expose port
 EXPOSE 8900


### PR DESCRIPTION
## Description

This PR addresses a `PermissionError` encountered when running ClawMetry containers, particularly in environments using podman or rootless container runtimes.

The error occurs because the application attempts to create the `/app/.clawmetry` directory at runtime (during the initialization of `HistoryDB`) but lacks the necessary permissions within the container's filesystem.

## Changes

Updated `Dockerfile` to include `/app/.clawmetry` in the `mkdir -p` command during the build stage.

## Impact

By pre-creating this directory during the image build process, we ensure that it exists and has the correct ownership/permissions from the moment the container starts. This prevents the application from crashing on startup when trying to initialize the history database.

## Verification Results

* Build completes successfully.
  * `docker build -t clawmetry .`
  * `podman build -t clawmetry .`
* Runtime: Running the container no longer triggers `PermissionError: [Errno 13] Permission denied: '/app/.clawmetry'`.