### PR TITLE
feat: prompt-cache hit-rate analytics endpoint (closes #851)

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -16,6 +16,7 @@ Owns the 12 routes registered on bp_usage:
   GET  /api/model-attribution             — per-model turn/session split
   GET  /api/skill-attribution             — per-skill cost attribution
   GET  /api/token-velocity                — runaway-loop detection
+  GET  /api/usage/cache-trends            — prompt-cache hit-rate analytics
 
 Module-level helpers (``_usage_cache``, ``_compute_transcript_analytics``,
 ``_detect_and_store_anomalies``, ``_get_anomaly_db``, ``SESSIONS_DIR`` etc.)
@@ -1077,4 +1078,271 @@ def api_token_velocity():
         'velocity_2min':    total_tokens_2min,
         'cost_per_min':     cost_per_min,
         'flagged_sessions': flagged,
+    })
+
+
+# ── Prompt-cache analytics (GH #851) ────────────────────────────────────
+
+
+def _empty_cache_bucket():
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "input_cost": 0.0,
+        "output_cost": 0.0,
+        "cache_read_cost": 0.0,
+        "cache_write_cost": 0.0,
+        "total_cost": 0.0,
+    }
+
+
+def _summarise_cache_bucket(label, b, key):
+    in_plus_cache = b["input_tokens"] + b["cache_read_tokens"]
+    cache_hit_pct = (
+        round(b["cache_read_tokens"] / in_plus_cache * 100, 1)
+        if in_plus_cache
+        else 0.0
+    )
+    # Anthropic prompt-cache reads cost ~10% of fresh input tokens, so the
+    # "saved" amount is the difference between what those tokens would have
+    # cost as fresh input vs. what they actually cost as cache reads.
+    est_fresh_input_cost = b["cache_read_cost"] * 10.0
+    est_savings = max(0.0, est_fresh_input_cost - b["cache_read_cost"])
+    est_savings_pct = (
+        round(est_savings / (b["input_cost"] + est_fresh_input_cost) * 100, 1)
+        if (b["input_cost"] + est_fresh_input_cost)
+        else 0.0
+    )
+    return {
+        key: label,
+        "input_tokens": b["input_tokens"],
+        "output_tokens": b["output_tokens"],
+        "cache_read_tokens": b["cache_read_tokens"],
+        "cache_write_tokens": b["cache_write_tokens"],
+        "input_cost_usd": round(b["input_cost"], 6),
+        "output_cost_usd": round(b["output_cost"], 6),
+        "cache_read_cost_usd": round(b["cache_read_cost"], 6),
+        "cache_write_cost_usd": round(b["cache_write_cost"], 6),
+        "total_cost_usd": round(b["total_cost"], 6),
+        "cache_hit_ratio_pct": cache_hit_pct,
+        "est_savings_usd": round(est_savings, 6),
+        "est_savings_pct": est_savings_pct,
+    }
+
+
+def _cache_recommendations(totals, by_model):
+    tips = []
+    hit = totals.get("cache_hit_ratio_pct", 0.0)
+    if totals.get("input_tokens", 0) + totals.get("cache_read_tokens", 0) == 0:
+        tips.append(
+            "No cache-eligible traffic in window. Connect a recent agent run to see "
+            "cache analytics."
+        )
+        return tips
+    if hit < 30.0:
+        tips.append(
+            f"Cache hit ratio is low ({hit}%). Stabilise your system prompt and "
+            "front-load static context — Anthropic charges ~10% for cache reads vs. "
+            "fresh input."
+        )
+    elif hit < 60.0:
+        tips.append(
+            f"Cache hit ratio is moderate ({hit}%). Look for prompt suffixes that "
+            "rotate per turn (timestamps, RNG nonces) — they invalidate the cache "
+            "block above them."
+        )
+    else:
+        tips.append(
+            f"Cache hit ratio is healthy ({hit}%). Most repeat prompts are landing "
+            "in the cache."
+        )
+
+    cw = totals.get("cache_write_tokens", 0)
+    cr = totals.get("cache_read_tokens", 0)
+    if cw and cr and cw > cr:
+        tips.append(
+            "Cache writes outweigh reads — sessions are short-lived or your prompt "
+            "block is changing often. A longer-lived session prefix would amortise "
+            "the write cost."
+        )
+
+    poor_models = [
+        m for m in by_model
+        if (m.get("input_tokens", 0) + m.get("cache_read_tokens", 0)) >= 5000
+        and m.get("cache_hit_ratio_pct", 0.0) < 20.0
+    ]
+    if poor_models:
+        names = ", ".join(sorted({m["model"] for m in poor_models})[:3])
+        tips.append(
+            f"Models with notably low cache utilisation: {names}. Check whether "
+            "their system prompt is wrapped in a cache_control breakpoint."
+        )
+    return tips
+
+
+@bp_usage.route("/api/usage/cache-trends")
+def api_usage_cache_trends():
+    """Daily + per-model prompt-cache hit ratio and estimated savings (GH #851).
+
+    Query params:
+      days  — window size in days (default 14, max 90)
+
+    Returns:
+      {
+        days:    int,
+        daily:   [{date, input_tokens, output_tokens, cache_read_tokens,
+                    cache_write_tokens, *cost_usd, cache_hit_ratio_pct,
+                    est_savings_usd, est_savings_pct}],
+        by_model:[same shape, keyed by `model`],
+        totals:  same shape, keyed by `label`,
+        recommendations: [str],
+      }
+    """
+    import dashboard as _d
+
+    try:
+        days = max(1, min(int(request.args.get("days", "14")), 90))
+    except ValueError:
+        days = 14
+
+    sessions_dir = _d._get_sessions_dir()
+    cutoff_ts = time.time() - (days * 86400)
+
+    daily: dict = {}
+    by_model: dict = {}
+
+    if os.path.isdir(sessions_dir):
+        for fname in os.listdir(sessions_dir):
+            if not (fname.endswith(".jsonl") or ".jsonl.reset." in fname):
+                continue
+            if (
+                ".trajectory." in fname
+                or ".checkpoint." in fname
+                or ".deleted." in fname
+            ):
+                continue
+            fpath = os.path.join(sessions_dir, fname)
+            try:
+                fallback_dt = datetime.fromtimestamp(os.path.getmtime(fpath))
+            except OSError:
+                continue
+            # Skip files whose mtime is older than the window AND whose name
+            # doesn't include a reset suffix — saves IO on stale archives.
+            if fallback_dt.timestamp() < cutoff_ts and ".jsonl.reset." not in fname:
+                continue
+            last_seen_model = ""
+            try:
+                with open(fpath, "r", errors="replace") as fh:
+                    for raw in fh:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            ev = json.loads(raw)
+                        except Exception:
+                            continue
+                        t = ev.get("type", "")
+                        if t == "model_change":
+                            m = ev.get("modelId") or ev.get("model") or ""
+                            if m:
+                                last_seen_model = m
+                            continue
+                        msg = ev.get("message", {}) or {}
+                        if not isinstance(msg, dict):
+                            continue
+                        usage = msg.get("usage", {}) or {}
+                        if not isinstance(usage, dict) or not usage:
+                            continue
+                        msg_model = msg.get("model") or last_seen_model or "unknown"
+                        if msg_model:
+                            last_seen_model = msg_model
+
+                        ts = _d._parse_event_timestamp(
+                            ev.get("timestamp")
+                            or ev.get("time")
+                            or ev.get("created_at"),
+                            fallback_dt,
+                        )
+                        if not ts:
+                            ts = fallback_dt
+                        if ts.timestamp() < cutoff_ts:
+                            continue
+                        date_str = ts.strftime("%Y-%m-%d")
+
+                        in_toks = int(
+                            usage.get("input", usage.get("input_tokens", 0)) or 0
+                        )
+                        out_toks = int(
+                            usage.get("output", usage.get("output_tokens", 0)) or 0
+                        )
+                        cr_toks = int(
+                            usage.get(
+                                "cacheRead", usage.get("cache_read_tokens", 0)
+                            )
+                            or 0
+                        )
+                        cw_toks = int(
+                            usage.get(
+                                "cacheWrite", usage.get("cache_write_tokens", 0)
+                            )
+                            or 0
+                        )
+                        cost_obj = usage.get("cost", {}) or {}
+                        if not isinstance(cost_obj, dict):
+                            cost_obj = {}
+                        in_cost = float(cost_obj.get("input", 0) or 0)
+                        out_cost = float(cost_obj.get("output", 0) or 0)
+                        cr_cost = float(cost_obj.get("cacheRead", 0) or 0)
+                        cw_cost = float(cost_obj.get("cacheWrite", 0) or 0)
+                        total_cost = float(
+                            cost_obj.get(
+                                "total", in_cost + out_cost + cr_cost + cw_cost
+                            )
+                            or 0
+                        )
+
+                        for bucket in (
+                            daily.setdefault(date_str, _empty_cache_bucket()),
+                            by_model.setdefault(msg_model, _empty_cache_bucket()),
+                        ):
+                            bucket["input_tokens"] += in_toks
+                            bucket["output_tokens"] += out_toks
+                            bucket["cache_read_tokens"] += cr_toks
+                            bucket["cache_write_tokens"] += cw_toks
+                            bucket["input_cost"] += in_cost
+                            bucket["output_cost"] += out_cost
+                            bucket["cache_read_cost"] += cr_cost
+                            bucket["cache_write_cost"] += cw_cost
+                            bucket["total_cost"] += total_cost
+            except Exception:
+                continue
+
+    today = datetime.now()
+    daily_out = []
+    for i in range(days - 1, -1, -1):
+        d = today - timedelta(days=i)
+        ds = d.strftime("%Y-%m-%d")
+        daily_out.append(
+            _summarise_cache_bucket(ds, daily.get(ds, _empty_cache_bucket()), key="date")
+        )
+
+    by_model_out = [
+        _summarise_cache_bucket(m, b, key="model")
+        for m, b in sorted(by_model.items(), key=lambda kv: -kv[1]["total_cost"])
+    ]
+
+    totals_bucket = _empty_cache_bucket()
+    for b in daily.values():
+        for k in totals_bucket:
+            totals_bucket[k] += b[k]
+    totals_out = _summarise_cache_bucket("totals", totals_bucket, key="label")
+
+    return jsonify({
+        "days": days,
+        "daily": daily_out,
+        "by_model": by_model_out,
+        "totals": totals_out,
+        "recommendations": _cache_recommendations(totals_out, by_model_out),
     })

--- a/tests/test_cache_trends.py
+++ b/tests/test_cache_trends.py
@@ -1,0 +1,180 @@
+"""Tests for /api/usage/cache-trends — prompt-cache hit-rate analytics (GH #851)."""
+
+import json
+import os
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+
+class TestCacheTrends(unittest.TestCase):
+    """Drive the endpoint with a synthetic JSONL transcript."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import argparse
+            import dashboard as _d
+            # detect_config registers blueprints onto the module-level Flask app.
+            # It expects a namespace with the standard CLI fields populated.
+            already_registered = any(
+                "cache-trends" in str(rule) for rule in _d.app.url_map.iter_rules()
+            )
+            if not already_registered:
+                ns = argparse.Namespace(
+                    workspace=None,
+                    log_dir=None,
+                    sessions_dir=None,
+                    name=None,
+                    openclaw_dir=None,
+                    data_dir=None,
+                )
+                _d.detect_config(ns)
+            cls.app = _d.app
+            cls.client = cls.app.test_client()
+            cls.app_available = True
+        except Exception as e:
+            cls.app_available = False
+            cls.skip_reason = str(e)
+
+    def _skip_if_unavailable(self):
+        if not self.app_available:
+            self.skipTest(f"Dashboard app not available: {self.skip_reason}")
+
+    def _write_session(self, sessions_dir, sid, events):
+        path = os.path.join(sessions_dir, f"{sid}.jsonl")
+        with open(path, "w") as f:
+            for ev in events:
+                f.write(json.dumps(ev) + "\n")
+        return path
+
+    def _msg_event(self, ts_iso, model, input_tok, output_tok, cache_read, cache_write):
+        return {
+            "type": "message",
+            "timestamp": ts_iso,
+            "message": {
+                "model": model,
+                "usage": {
+                    "input": input_tok,
+                    "output": output_tok,
+                    "cacheRead": cache_read,
+                    "cacheWrite": cache_write,
+                    "totalTokens": input_tok + output_tok + cache_read + cache_write,
+                    "cost": {
+                        "input": input_tok * 3e-6,
+                        "output": output_tok * 15e-6,
+                        "cacheRead": cache_read * 0.3e-6,
+                        "cacheWrite": cache_write * 3.75e-6,
+                        "total": (
+                            input_tok * 3e-6
+                            + output_tok * 15e-6
+                            + cache_read * 0.3e-6
+                            + cache_write * 3.75e-6
+                        ),
+                    },
+                },
+            },
+        }
+
+    def test_returns_expected_shape(self):
+        self._skip_if_unavailable()
+        import dashboard as _d
+
+        with tempfile.TemporaryDirectory() as tmp:
+            now = time.time()
+            today_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(now))
+            self._write_session(
+                tmp,
+                "sess-cached",
+                [
+                    self._msg_event(today_iso, "claude-sonnet-4-5", 100, 200, 5000, 500),
+                    self._msg_event(today_iso, "claude-sonnet-4-5", 50, 80, 4000, 0),
+                ],
+            )
+            with patch.object(_d, "_get_sessions_dir", return_value=tmp):
+                resp = self.client.get("/api/usage/cache-trends?days=7")
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.data)
+
+        # Required top-level keys
+        for key in ("days", "daily", "by_model", "totals", "recommendations"):
+            self.assertIn(key, data)
+        self.assertEqual(data["days"], 7)
+        self.assertEqual(len(data["daily"]), 7)
+
+        # Per-day rows have a date and the expected metric keys
+        for row in data["daily"]:
+            self.assertIn("date", row)
+            for k in (
+                "input_tokens",
+                "cache_read_tokens",
+                "cache_write_tokens",
+                "cache_hit_ratio_pct",
+                "est_savings_usd",
+            ):
+                self.assertIn(k, row)
+
+        # by_model contains the model we synthesised
+        models = [m["model"] for m in data["by_model"]]
+        self.assertIn("claude-sonnet-4-5", models)
+
+        totals = data["totals"]
+        self.assertEqual(totals["input_tokens"], 150)
+        self.assertEqual(totals["cache_read_tokens"], 9000)
+        # cache_hit = 9000 / (150 + 9000) ≈ 98.4%
+        self.assertGreater(totals["cache_hit_ratio_pct"], 95.0)
+        self.assertGreater(totals["est_savings_usd"], 0)
+
+    def test_empty_sessions_dir_returns_zeroed_window(self):
+        self._skip_if_unavailable()
+        import dashboard as _d
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(_d, "_get_sessions_dir", return_value=tmp):
+                resp = self.client.get("/api/usage/cache-trends?days=3")
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.data)
+        self.assertEqual(data["days"], 3)
+        self.assertEqual(len(data["daily"]), 3)
+        self.assertEqual(data["totals"]["cache_read_tokens"], 0)
+        self.assertEqual(data["by_model"], [])
+        self.assertTrue(any("No cache-eligible" in r for r in data["recommendations"]))
+
+    def test_days_param_clamped(self):
+        self._skip_if_unavailable()
+        import dashboard as _d
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(_d, "_get_sessions_dir", return_value=tmp):
+                resp_low = self.client.get("/api/usage/cache-trends?days=0")
+                resp_high = self.client.get("/api/usage/cache-trends?days=999")
+                resp_bad = self.client.get("/api/usage/cache-trends?days=abc")
+        self.assertEqual(json.loads(resp_low.data)["days"], 1)
+        self.assertEqual(json.loads(resp_high.data)["days"], 90)
+        # bad value falls back to default 14
+        self.assertEqual(json.loads(resp_bad.data)["days"], 14)
+
+    def test_low_hit_ratio_yields_stabilise_tip(self):
+        self._skip_if_unavailable()
+        import dashboard as _d
+
+        with tempfile.TemporaryDirectory() as tmp:
+            now = time.time()
+            today_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(now))
+            # Mostly fresh input, almost no cache reads → low hit ratio
+            self._write_session(
+                tmp,
+                "sess-cold",
+                [self._msg_event(today_iso, "claude-haiku-4-5", 10000, 500, 100, 200)],
+            )
+            with patch.object(_d, "_get_sessions_dir", return_value=tmp):
+                resp = self.client.get("/api/usage/cache-trends?days=7")
+        data = json.loads(resp.data)
+        self.assertLess(data["totals"]["cache_hit_ratio_pct"], 30.0)
+        joined = " ".join(data["recommendations"]).lower()
+        self.assertIn("stabilise", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #851

## What

Adds `GET /api/usage/cache-trends` — a single endpoint that returns the data the issue calls for: daily cache hit ratio over time, per-model cache performance, and a short list of recommendations.

Response shape:
```json
{
  "days": 14,
  "daily":   [{"date": "2026-05-09", "input_tokens": 1234, "cache_read_tokens": 8200,
               "cache_hit_ratio_pct": 86.9, "est_savings_usd": 0.0123, ...}, ...],
  "by_model":[{"model": "claude-sonnet-4-5", "cache_hit_ratio_pct": 92.1, ...}, ...],
  "totals":  {"label": "totals", "cache_hit_ratio_pct": 88.4, "est_savings_usd": 0.42, ...},
  "recommendations": ["Cache hit ratio is healthy (88.4%) ..."]
}
```

## How

- `routes/usage.py` — new `api_usage_cache_trends` handler, plus three small helpers: `_empty_cache_bucket`, `_summarise_cache_bucket`, `_cache_recommendations`. Walks transcripts the same way `/api/cost-split` already does, but buckets by **date** and **model** instead of per-session.
- Reuses the existing dashboard helpers (`_get_sessions_dir`, `_parse_event_timestamp`) for behaviour parity with the rest of the analytics surface.
- Anthropic charges ~10% on prompt-cache reads vs. fresh input, so estimated savings are computed as `9 × cache_read_cost` — matching the heuristic already used in `/api/cost-split`.
- Recommendations fire on three signals: hit ratio < 30% (stabilise prompt), 30–60% (look for rotating suffixes), and cache_writes > cache_reads (prefix is changing too often).

Files older than the requested window with no `.reset.` suffix are skipped to keep IO bounded on long-lived installs.

## Test plan

- [x] `pytest tests/test_cache_trends.py` — 4 new tests pass
  - shape / required-keys
  - empty sessions dir → zero-filled window
  - `days` query param clamped to `[1, 90]`, bad value falls back to 14
  - low-hit-ratio fixture surfaces the "stabilise" recommendation
- [x] Live smoke against real `~/.openclaw/agents/main/sessions` returns 200 with sane numbers (100% hit ratio on the local install — single-day cache reads).
- [x] No changes to existing `/api/cost-split` or `/api/usage` paths.

## Out of scope

- UI wiring for a chart — kept this PR strictly to the data layer so it can ship and be reviewed independently. The same fields can power a Helicone-style chart in a follow-up.