### PR TITLE
feat: context window anatomy panel in Brain tab

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4241,6 +4241,15 @@ function clawmetryLogout(){
       <span style="font-size:14px;font-weight:700;color:var(--text-primary);">🧠 Brain -- Unified Activity Stream</span>
       <button class="refresh-btn" onclick="loadBrainPage()">↻ Refresh</button>
     </div>
+    <!-- Context Window Anatomy (#566) -->
+    <div id="ctx-anatomy-wrap" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;margin-bottom:12px;display:none;">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;">
+        <span style="font-size:11px;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:1px;">Context window anatomy</span>
+        <span id="ctx-pct-label" style="font-size:11px;color:var(--text-muted);">--</span>
+      </div>
+      <div id="ctx-bar" style="display:flex;height:10px;border-radius:4px;overflow:hidden;background:var(--bg-primary);width:100%;margin-bottom:6px;"></div>
+      <div id="ctx-legend" style="display:flex;flex-wrap:wrap;gap:6px;"></div>
+    </div>
     <!-- Activity density chart -->
     <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;margin-bottom:12px;">
       <div style="font-size:11px;color:var(--text-muted);margin-bottom:6px;">Activity density -- last 60 min (30s buckets)</div>
@@ -4949,7 +4958,7 @@ function switchTab(name) {
   if (name === 'limits') loadRateLimits();
   if (name === 'flow') initFlow();
   if (name === 'history') loadHistory();
-  if (name === 'brain') loadBrainPage();
+  if (name === 'brain') { if (typeof loadBrainPage === 'function') loadBrainPage(); loadContextAnatomy(); }
   if (name === 'security') { loadSecurityPage(); loadSecurityPosture(); }
   if (name === 'actions') loadQAHistory();
   if (name === 'logs') { if (!logStream || logStream.readyState === EventSource.CLOSED) startLogStream(); loadLogs(); }
@@ -5701,6 +5710,35 @@ async function loadHeartbeat() {
       sparkEl.innerHTML = '<span style="font-size:11px;color:var(--text-muted);">no beats yet</span>';
     }
   } catch(e) { console.warn('heartbeat panel load failed', e); }
+}
+
+async function loadContextAnatomy() {
+  try {
+    var d = await fetchJsonWithTimeout('/api/context-anatomy', 4000);
+    if (!d || !d.buckets || !d.buckets.length) return;
+    var wrap = document.getElementById('ctx-anatomy-wrap');
+    if (!wrap) return;
+    wrap.style.display = '';
+    var pct = document.getElementById('ctx-pct-label');
+    if (pct) pct.textContent = (d.pct_used || 0) + '% of ' + Math.round((d.context_limit || 200000) / 1000) + 'K window';
+    var total = d.total_estimated || 1;
+    var bar = document.getElementById('ctx-bar');
+    if (bar) {
+      bar.innerHTML = d.buckets.map(function(b) {
+        var w = Math.max(0.5, b.tokens / total * 100).toFixed(1);
+        return '<div title="' + b.label + ': ~' + b.tokens.toLocaleString() + ' tok" style="width:' + w + '%;background:' + b.color + ';"></div>';
+      }).join('');
+    }
+    var legend = document.getElementById('ctx-legend');
+    if (legend) {
+      legend.innerHTML = d.buckets.map(function(b) {
+        var tok = b.tokens > 999 ? Math.round(b.tokens / 1000) + 'K' : b.tokens;
+        return '<span style="display:inline-flex;align-items:center;gap:3px;font-size:10px;color:var(--text-secondary);">' +
+          '<span style="width:8px;height:8px;border-radius:2px;flex-shrink:0;background:' + b.color + ';"></span>' +
+          b.label + ' ~' + tok + '</span>';
+      }).join('');
+    }
+  } catch(e) { /* silent — panel stays hidden when data unavailable */ }
 }
 
 async function loadMiniWidgets(overview, usage) {

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -883,3 +883,133 @@ def api_automation_analysis():
             'error': str(e),
             'lastAnalysis': datetime.now(timezone.utc).isoformat()
         })
+
+
+@bp_config.route("/api/context-anatomy")
+def api_context_anatomy():
+    """Estimate context window consumption broken down by source (#566).
+
+    Returns a list of buckets with token estimates derived from:
+      - Workspace file sizes (SOUL.md, AGENTS.md, TOOLS.md, …)
+      - memory/ directory total
+      - A fixed tool-definition estimate (~1,500 tok)
+      - Session history = last observed input_tokens minus known static buckets
+
+    Token counts are approximations (file_bytes / 3.5 chars-per-token).
+    """
+    import dashboard as _d
+
+    CHARS_PER_TOKEN = 3.5
+    CONTEXT_LIMIT = 200_000  # Claude 200K window
+
+    def _file_tokens(path):
+        try:
+            return max(1, int(os.path.getsize(path) / CHARS_PER_TOKEN))
+        except OSError:
+            return 0
+
+    workspace = _d.WORKSPACE or ""
+    sessions_dir = _d.SESSIONS_DIR or ""
+
+    buckets = []
+
+    # Static workspace files — each gets its own bucket if present
+    _SYSTEM_FILES = [
+        ("SOUL.md",      "#a855f7"),
+        ("AGENTS.md",    "#3b82f6"),
+        ("TOOLS.md",     "#06b6d4"),
+        ("HEARTBEAT.md", "#22c55e"),
+        ("IDENTITY.md",  "#ec4899"),
+        ("USER.md",      "#f59e0b"),
+    ]
+    for fname, color in _SYSTEM_FILES:
+        fpath = os.path.join(workspace, fname) if workspace else ""
+        if fpath and os.path.isfile(fpath):
+            buckets.append({
+                "label": fname,
+                "tokens": _file_tokens(fpath),
+                "color": color,
+                "category": "system",
+            })
+
+    # Memory files — summed into one bucket
+    memory_dir = os.path.join(workspace, "memory") if workspace else ""
+    if memory_dir and os.path.isdir(memory_dir):
+        try:
+            mem_tokens = sum(
+                _file_tokens(os.path.join(memory_dir, f))
+                for f in os.listdir(memory_dir)
+                if f.endswith(".md")
+            )
+        except OSError:
+            mem_tokens = 0
+        if mem_tokens > 0:
+            buckets.append({
+                "label": "Memory files",
+                "tokens": mem_tokens,
+                "color": "#059669",
+                "category": "memory",
+            })
+
+    # Tool definitions — fixed estimate (built-ins + common MCPs)
+    TOOL_EST = 1_500
+    buckets.append({
+        "label": "Tool defs (est.)",
+        "tokens": TOOL_EST,
+        "color": "#d97706",
+        "category": "tools",
+    })
+
+    # Session history: total input_tokens from last active session minus known static
+    session_history_tokens = 0
+    if sessions_dir and os.path.isdir(sessions_dir):
+        try:
+            files = sorted(
+                [
+                    f for f in os.listdir(sessions_dir)
+                    if f.endswith(".jsonl")
+                    and ".deleted." not in f
+                    and ".reset." not in f
+                ],
+                key=lambda f: os.path.getmtime(os.path.join(sessions_dir, f)),
+                reverse=True,
+            )
+            for fname in files[:5]:
+                last_input = 0
+                try:
+                    with open(os.path.join(sessions_dir, fname), errors="replace") as fh:
+                        for line in fh:
+                            try:
+                                ev = json.loads(line.strip())
+                                u = (ev.get("message") or {}).get("usage") or {}
+                                inp = u.get("input_tokens", 0)
+                                if inp:
+                                    last_input = inp
+                            except Exception:
+                                pass
+                except Exception:
+                    pass
+                if last_input > 0:
+                    session_history_tokens = last_input
+                    break
+        except Exception:
+            pass
+
+    if session_history_tokens > 0:
+        known_static = sum(b["tokens"] for b in buckets)
+        dynamic = max(0, session_history_tokens - known_static)
+        if dynamic > 0:
+            buckets.append({
+                "label": "Session history",
+                "tokens": dynamic,
+                "color": "#0891b2",
+                "category": "history",
+            })
+
+    total = sum(b["tokens"] for b in buckets)
+    return jsonify({
+        "buckets": buckets,
+        "total_estimated": total,
+        "context_limit": CONTEXT_LIMIT,
+        "pct_used": round(total / CONTEXT_LIMIT * 100, 1) if CONTEXT_LIMIT else 0,
+    })


### PR DESCRIPTION
Closes #566

## Summary

- Adds `GET /api/context-anatomy` to `routes/infra.py` (`bp_config` blueprint) — reads workspace files (SOUL.md, AGENTS.md, TOOLS.md, HEARTBEAT.md, IDENTITY.md, USER.md) for their byte sizes, sums the `memory/` directory, adds a fixed tool-definition estimate (~1,500 tok), and derives a session-history bucket from the last observed `input_tokens` in session JSONLs minus known static overhead. All token counts use the standard 3.5 chars/token heuristic.
- Adds a stacked-bar "Context window anatomy" panel in the Brain tab (`dashboard.py`), rendered on tab activation via the new `loadContextAnatomy()` JS function. The panel stays hidden when no data is available (fresh install, no sessions).
- Fixes a latent JS `ReferenceError` — `loadBrainPage` was called unconditionally but never defined; now guarded with `typeof`.

## Test plan

- [ ] Switch to Brain tab — context anatomy panel appears above the activity density chart if workspace files exist
- [ ] Hover segments of the stacked bar to see per-bucket token estimates
- [ ] `curl http://localhost:8900/api/context-anatomy` returns valid JSON with `buckets`, `total_estimated`, `context_limit`, `pct_used`
- [ ] Panel stays hidden (no error) on a fresh install with no workspace files
- [ ] `python3 -m py_compile routes/infra.py dashboard.py` passes

https://claude.ai/code/session_01Loz53vWbRD97SxFgezKXaa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Loz53vWbRD97SxFgezKXaa)_