### PR TITLE
feat(selfconfig): attribute file revisions to the session that caused the edit (#689)

### DIFF
--- a/routes/selfconfig.py
+++ b/routes/selfconfig.py
@@ -25,6 +25,7 @@ Endpoints:
 Blueprint: bp_selfconfig
 """
 import difflib
+import glob
 import hashlib
 import json
 import logging
@@ -141,6 +142,213 @@ def _read_file_safe(path):
         return b"", False
 
 
+_EDIT_TOOL_NAMES = {"edit", "write", "multiedit", "notebookedit", "str_replace_editor"}
+_SESSION_LOOKBACK_SECONDS = 24 * 3600
+_SESSION_FILE_SCAN_LIMIT = 30
+
+
+def _sessions_dir() -> str:
+    try:
+        import dashboard as _d
+        sd = getattr(_d, "SESSIONS_DIR", None)
+        if sd:
+            return sd
+    except Exception:
+        pass
+    return os.path.expanduser("~/.openclaw/agents/main/sessions")
+
+
+def _normalise_file_path(path):
+    """Lowercase basename + the last 3 path segments — robust enough to match
+    Edit/Write tool inputs whether they are absolute, ``~/`` expanded, or
+    workspace-relative. Returns a tuple of comparable tokens."""
+    if not isinstance(path, str) or not path:
+        return ()
+    p = os.path.expanduser(path).replace("\\", "/")
+    parts = [seg for seg in p.split("/") if seg]
+    return tuple(s.lower() for s in parts[-3:])
+
+
+def _path_matches(needle_tokens, candidate):
+    if not needle_tokens or not isinstance(candidate, str) or not candidate:
+        return False
+    cand_tokens = _normalise_file_path(candidate)
+    if not cand_tokens:
+        return False
+    # The tracked filename (e.g. "SOUL.md") must appear as the candidate's
+    # final segment. Looser prefix matches would catch unrelated files.
+    return cand_tokens[-1] == needle_tokens[-1]
+
+
+def _session_label_from_index(session_id, sess_index):
+    if not session_id or not isinstance(sess_index, dict):
+        return ""
+    for key, meta in sess_index.items():
+        if not isinstance(meta, dict):
+            continue
+        sid = meta.get("sessionId") or ""
+        if sid == session_id:
+            label = meta.get("displayName") or meta.get("label") or ""
+            if label:
+                return str(label)[:80]
+            # Cron sessions: agent:main:cron:<id>
+            if ":cron:" in key:
+                parts = key.split(":")
+                try:
+                    return "cron:" + parts[parts.index("cron") + 1][:8]
+                except (ValueError, IndexError):
+                    pass
+            if ":subagent:" in key:
+                task = meta.get("task") or ""
+                if task:
+                    return ("subagent: " + str(task))[:80]
+                return "subagent"
+    return ""
+
+
+def _load_session_index(sessions_dir):
+    """Load sessions.json (sessionId → displayName mapping). Returns {} on
+    error so callers can treat missing index as ‘no labels available’."""
+    path = os.path.join(sessions_dir, "sessions.json")
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+            if isinstance(data, dict):
+                return data
+    except Exception:
+        pass
+    return {}
+
+
+def _scan_jsonl_for_edit(jsonl_path, needle_tokens, since_ts, until_ts):
+    """Return (best_event_ts, tool_name) for the most recent Edit/Write tool
+    use in ``jsonl_path`` whose target path matches ``needle_tokens`` and
+    whose timestamp falls in (since_ts, until_ts]. Both timestamps are
+    epoch seconds. Returns None if nothing matches."""
+    best = None  # (epoch_ts, tool_name)
+    try:
+        with open(jsonl_path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or "tool_use" not in line and "toolCall" not in line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+
+                # Pull timestamp — JSONL rows use either ISO or epoch.
+                ts_raw = obj.get("timestamp") or obj.get("time")
+                ev_ts = _parse_ts_to_epoch(ts_raw)
+                if ev_ts is None:
+                    continue
+                if ev_ts <= since_ts or ev_ts > until_ts:
+                    continue
+
+                msg = obj.get("message") or {}
+                content = msg.get("content") if isinstance(msg, dict) else None
+                if not isinstance(content, list):
+                    continue
+
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    btype = block.get("type", "")
+                    if btype == "tool_use":
+                        tool_name = (block.get("name") or "").lower()
+                        inp = block.get("input") or {}
+                    elif btype == "toolCall":
+                        tool_name = (block.get("name") or "").lower()
+                        inp = block.get("arguments") or {}
+                    else:
+                        continue
+                    if tool_name not in _EDIT_TOOL_NAMES:
+                        continue
+                    if not isinstance(inp, dict):
+                        continue
+                    target = (
+                        inp.get("file_path")
+                        or inp.get("path")
+                        or inp.get("filePath")
+                        or ""
+                    )
+                    if _path_matches(needle_tokens, target):
+                        if best is None or ev_ts > best[0]:
+                            best = (ev_ts, tool_name)
+    except Exception as exc:
+        log.debug("selfconfig: scan %s failed: %s", jsonl_path, exc)
+    return best
+
+
+def _parse_ts_to_epoch(ts_raw):
+    if ts_raw is None:
+        return None
+    if isinstance(ts_raw, (int, float)):
+        return float(ts_raw) / (1000.0 if ts_raw > 1e12 else 1.0)
+    if isinstance(ts_raw, str) and ts_raw:
+        s = ts_raw.replace("Z", "+00:00")
+        try:
+            from datetime import datetime
+            return datetime.fromisoformat(s).timestamp()
+        except Exception:
+            return None
+    return None
+
+
+def _find_session_for_file_change(file_path, since_ts, until_ts):
+    """Locate the session whose Edit/Write tool call most likely caused the
+    change to ``file_path`` between ``since_ts`` and ``until_ts``.
+
+    Returns ``{"session_id", "session_label", "tool", "ts"}`` or ``None``.
+    Best-effort: scans the most recently-modified session JSONLs only, so a
+    huge sessions dir does not block the snapshot path.
+    """
+    needle = _normalise_file_path(file_path)
+    if not needle:
+        return None
+    sessions_dir = _sessions_dir()
+    pattern = os.path.join(sessions_dir, "*.jsonl")
+    try:
+        candidates = glob.glob(pattern)
+    except Exception:
+        candidates = []
+    if not candidates:
+        return None
+
+    def _mtime(p):
+        try:
+            return os.path.getmtime(p)
+        except OSError:
+            return 0.0
+
+    candidates = [c for c in candidates if _mtime(c) >= since_ts - 60]
+    candidates.sort(key=_mtime, reverse=True)
+    candidates = candidates[:_SESSION_FILE_SCAN_LIMIT]
+
+    sess_index = _load_session_index(sessions_dir)
+    best = None  # (ev_ts, session_id, tool_name)
+
+    for jsonl in candidates:
+        hit = _scan_jsonl_for_edit(jsonl, needle, since_ts, until_ts)
+        if hit is None:
+            continue
+        ev_ts, tool_name = hit
+        sid = os.path.basename(jsonl)[: -len(".jsonl")] if jsonl.endswith(".jsonl") else os.path.basename(jsonl)
+        if best is None or ev_ts > best[0]:
+            best = (ev_ts, sid, tool_name)
+
+    if best is None:
+        return None
+
+    ev_ts, sid, tool_name = best
+    return {
+        "session_id":    sid,
+        "session_label": _session_label_from_index(sid, sess_index),
+        "tool":          tool_name,
+        "ts":            int(ev_ts),
+    }
+
+
 def _snapshot_if_changed() -> None:
     """
     Walk tracked files; save a new versioned snapshot whenever the content
@@ -153,6 +361,11 @@ def _snapshot_if_changed() -> None:
     last_run = index.get("_last_run_ts", 0)
     if now - last_run < _SNAPSHOT_INTERVAL:
         return
+
+    # Window for session attribution: from the previous snapshot run up to
+    # now. On a cold start (no prior run) fall back to a 24h lookback so we
+    # still pick up the most recent edit instead of giving up.
+    since_ts = last_run if last_run else now - _SESSION_LOOKBACK_SECONDS
 
     index["_last_run_ts"] = now
 
@@ -180,7 +393,19 @@ def _snapshot_if_changed() -> None:
                 continue
 
             revisions = file_meta.get("revisions", [])
-            revisions.append({"ts": ts, "hash": new_hash, "size": len(content)})
+            revision = {"ts": ts, "hash": new_hash, "size": len(content)}
+            try:
+                # File mtime is the closest signal we have for ‘when did the
+                # write actually land?’ Use it as the upper bound so a long
+                # gap between saves does not pull in unrelated tool calls.
+                file_mtime = os.path.getmtime(path)
+                until_ts = max(file_mtime, since_ts) + 1
+                source = _find_session_for_file_change(path, since_ts, until_ts)
+                if source:
+                    revision["source"] = source
+            except Exception as exc:
+                log.debug("selfconfig: source attribution failed for %s: %s", filename, exc)
+            revisions.append(revision)
             index[filename] = {
                 "last_hash": new_hash,
                 "last_modified_ts": int(os.path.getmtime(path)),
@@ -267,12 +492,16 @@ def api_selfconfig_file(filename):
     for rev in revisions_raw:
         ts = rev["ts"]
         version_path = _versioned_path(filename, ts)
-        revisions.append({
+        entry = {
             "ts": ts,
             "hash": rev.get("hash", ""),
             "size": rev.get("size", 0),
             "version_path": version_path,
-        })
+        }
+        source = rev.get("source")
+        if isinstance(source, dict):
+            entry["source"] = source
+        revisions.append(entry)
 
     return jsonify({
         "name": filename,

--- a/tests/test_selfconfig_session_attribution.py
+++ b/tests/test_selfconfig_session_attribution.py
@@ -1,0 +1,237 @@
+"""Unit tests for routes/selfconfig.py session-attribution helpers (#689).
+
+Pure-Python: exercises the helper functions directly without spinning up a
+Flask server, so this file runs in CI without a live ClawMetry instance.
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from routes import selfconfig as sc  # noqa: E402
+
+
+def _write_jsonl(path, rows):
+    with open(path, "w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def _edit_event(ts_iso, file_path, tool="Edit"):
+    return {
+        "type": "message",
+        "timestamp": ts_iso,
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "name": tool, "input": {"file_path": file_path}},
+            ],
+        },
+    }
+
+
+def test_normalise_file_path_lowercases_basename():
+    assert sc._normalise_file_path("/home/vivek/clawd/SOUL.md")[-1] == "soul.md"
+
+
+def test_normalise_file_path_handles_relative_path():
+    tokens = sc._normalise_file_path("workspace/SOUL.md")
+    assert tokens[-1] == "soul.md"
+
+
+def test_normalise_file_path_empty_returns_empty_tuple():
+    assert sc._normalise_file_path("") == ()
+    assert sc._normalise_file_path(None) == ()
+
+
+def test_path_matches_basename_match():
+    needle = sc._normalise_file_path("/abc/SOUL.md")
+    assert sc._path_matches(needle, "/some/other/path/SOUL.md") is True
+
+
+def test_path_matches_different_file_rejected():
+    needle = sc._normalise_file_path("/abc/SOUL.md")
+    assert sc._path_matches(needle, "/some/other/path/USER.md") is False
+
+
+def test_parse_ts_to_epoch_iso():
+    epoch = sc._parse_ts_to_epoch("2026-05-10T01:00:00Z")
+    assert epoch is not None
+    assert 1746000000 < epoch < 1810000000
+
+
+def test_parse_ts_to_epoch_millis():
+    # > 1e12 means millisecond epoch — should be normalised to seconds.
+    millis = 1_777_619_067_124
+    seconds = sc._parse_ts_to_epoch(millis)
+    assert seconds is not None
+    assert 1_777_000_000 < seconds < 1_778_000_000
+
+
+def test_scan_jsonl_finds_matching_edit():
+    needle = sc._normalise_file_path("/ws/SOUL.md")
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as tf:
+        path = tf.name
+    try:
+        _write_jsonl(path, [
+            _edit_event("2026-05-10T01:00:00Z", "/ws/USER.md"),
+            _edit_event("2026-05-10T01:05:00Z", "/ws/SOUL.md", tool="Write"),
+            _edit_event("2026-05-10T01:10:00Z", "/ws/SOUL.md", tool="Edit"),
+        ])
+        since = sc._parse_ts_to_epoch("2026-05-10T00:00:00Z")
+        until = sc._parse_ts_to_epoch("2026-05-10T02:00:00Z")
+        result = sc._scan_jsonl_for_edit(path, needle, since, until)
+        assert result is not None
+        # The most recent matching edit wins.
+        ev_ts, tool_name = result
+        assert tool_name == "edit"
+        assert ev_ts == sc._parse_ts_to_epoch("2026-05-10T01:10:00Z")
+    finally:
+        os.unlink(path)
+
+
+def test_scan_jsonl_ignores_outside_window():
+    needle = sc._normalise_file_path("/ws/SOUL.md")
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as tf:
+        path = tf.name
+    try:
+        _write_jsonl(path, [
+            _edit_event("2026-05-10T01:10:00Z", "/ws/SOUL.md", tool="Edit"),
+        ])
+        # Window before the event — must miss it.
+        since = sc._parse_ts_to_epoch("2026-05-09T00:00:00Z")
+        until = sc._parse_ts_to_epoch("2026-05-09T02:00:00Z")
+        assert sc._scan_jsonl_for_edit(path, needle, since, until) is None
+    finally:
+        os.unlink(path)
+
+
+def test_scan_jsonl_ignores_non_edit_tools():
+    needle = sc._normalise_file_path("/ws/SOUL.md")
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as tf:
+        path = tf.name
+    try:
+        _write_jsonl(path, [
+            {
+                "type": "message",
+                "timestamp": "2026-05-10T01:00:00Z",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "name": "Read", "input": {"file_path": "/ws/SOUL.md"}},
+                    ],
+                },
+            },
+        ])
+        since = sc._parse_ts_to_epoch("2026-05-10T00:00:00Z")
+        until = sc._parse_ts_to_epoch("2026-05-10T02:00:00Z")
+        assert sc._scan_jsonl_for_edit(path, needle, since, until) is None
+    finally:
+        os.unlink(path)
+
+
+def test_scan_jsonl_handles_corrupt_lines():
+    needle = sc._normalise_file_path("/ws/SOUL.md")
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as tf:
+        path = tf.name
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("{not json\n")
+            fh.write(json.dumps(_edit_event("2026-05-10T01:10:00Z", "/ws/SOUL.md")) + "\n")
+            fh.write("}}}\n")
+        since = sc._parse_ts_to_epoch("2026-05-10T00:00:00Z")
+        until = sc._parse_ts_to_epoch("2026-05-10T02:00:00Z")
+        result = sc._scan_jsonl_for_edit(path, needle, since, until)
+        assert result is not None
+    finally:
+        os.unlink(path)
+
+
+def test_find_session_for_file_change_picks_most_recent(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        sessions_dir = os.path.join(tmp, "sessions")
+        os.makedirs(sessions_dir)
+
+        old_jsonl = os.path.join(sessions_dir, "old-session.jsonl")
+        new_jsonl = os.path.join(sessions_dir, "new-session.jsonl")
+        _write_jsonl(old_jsonl, [
+            _edit_event("2026-05-10T01:05:00Z", "/ws/SOUL.md", tool="Edit"),
+        ])
+        _write_jsonl(new_jsonl, [
+            _edit_event("2026-05-10T01:10:00Z", "/ws/SOUL.md", tool="Write"),
+        ])
+        sessions_json = {
+            "agent:main:user:label-old": {"sessionId": "old-session", "displayName": "Old chat"},
+            "agent:main:user:label-new": {"sessionId": "new-session", "displayName": "New chat"},
+        }
+        with open(os.path.join(sessions_dir, "sessions.json"), "w") as fh:
+            json.dump(sessions_json, fh)
+
+        monkeypatch.setattr(sc, "_sessions_dir", lambda: sessions_dir)
+
+        since = sc._parse_ts_to_epoch("2026-05-10T00:00:00Z")
+        until = sc._parse_ts_to_epoch("2026-05-10T02:00:00Z")
+        result = sc._find_session_for_file_change("/ws/SOUL.md", since, until)
+        assert result is not None
+        assert result["session_id"] == "new-session"
+        assert result["session_label"] == "New chat"
+        assert result["tool"] == "write"
+
+
+def test_find_session_for_file_change_returns_none_when_no_match(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        sessions_dir = os.path.join(tmp, "sessions")
+        os.makedirs(sessions_dir)
+        monkeypatch.setattr(sc, "_sessions_dir", lambda: sessions_dir)
+        since = sc._parse_ts_to_epoch("2026-05-10T00:00:00Z")
+        until = sc._parse_ts_to_epoch("2026-05-10T02:00:00Z")
+        assert sc._find_session_for_file_change("/ws/SOUL.md", since, until) is None
+
+
+def test_snapshot_records_source_in_revision(monkeypatch):
+    """End-to-end: writing to a tracked file then triggering a snapshot
+    records the matching session in the revision metadata."""
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = os.path.join(tmp, "workspace")
+        os.makedirs(workspace)
+        soul_path = os.path.join(workspace, "SOUL.md")
+        with open(soul_path, "w") as fh:
+            fh.write("# Soul\nFirst version\n")
+
+        sessions_dir = os.path.join(tmp, "sessions")
+        os.makedirs(sessions_dir)
+        sess_jsonl = os.path.join(sessions_dir, "abc-1234.jsonl")
+        # Edit event timestamp must fall inside the snapshot window — use
+        # ‘now’ rather than a hard-coded date so we don't drift past the
+        # 24-hour lookback window.
+        from datetime import datetime, timezone, timedelta
+        now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        _write_jsonl(sess_jsonl, [
+            _edit_event(now_iso, soul_path, tool="Edit"),
+        ])
+        with open(os.path.join(sessions_dir, "sessions.json"), "w") as fh:
+            json.dump({
+                "agent:main:user:foo": {"sessionId": "abc-1234", "displayName": "Test session"},
+            }, fh)
+
+        history_root = os.path.join(tmp, "history")
+        monkeypatch.setattr(sc, "_history_root", lambda: history_root)
+        monkeypatch.setattr(sc, "_sessions_dir", lambda: sessions_dir)
+        monkeypatch.setattr(sc, "_locate_file", lambda name: soul_path if name == "SOUL.md" else None)
+        # _SNAPSHOT_INTERVAL guards re-runs; force it to 0 so the test is deterministic.
+        monkeypatch.setattr(sc, "_SNAPSHOT_INTERVAL", 0)
+
+        sc._snapshot_if_changed()
+        index = sc._load_index()
+        revisions = index.get("SOUL.md", {}).get("revisions", [])
+        assert revisions, "snapshot must have recorded at least one revision"
+        source = revisions[-1].get("source")
+        assert source is not None, f"revision missing source attribution: {revisions[-1]}"
+        assert source["session_id"] == "abc-1234"
+        assert source["tool"] == "edit"
+        assert source["session_label"] == "Test session"


### PR DESCRIPTION
Closes #689

## What
Self-config revisions now record which session edited the tracked file
(SOUL/USER/AGENTS/TOOLS/IDENTITY/MEMORY.md). Each revision gains an
optional `source` block with `session_id`, `session_label`, `tool`, and
the edit timestamp — closing the **"linked session that caused it"** gap
called out in the issue.

```json
{
  "ts": 1746799200,
  "hash": "…",
  "size": 4012,
  "version_path": "/home/vivek/.clawmetry/selfconfig_history/SOUL.md/v1746799200.md",
  "source": {
    "session_id": "abc-1234",
    "session_label": "Test session",
    "tool": "edit",
    "ts": 1746799199
  }
}
```

## How
On each snapshot, scan recently-modified session JSONLs in `SESSIONS_DIR`
for `Edit` / `Write` / `MultiEdit` / `NotebookEdit` tool calls whose
`file_path` ends in the tracked filename, picking the most recent match
between the previous snapshot run and the file's mtime. Session labels
are resolved from `sessions.json`; missing or corrupt files are tolerated
silently so the snapshot path stays cheap.

Implementation notes:
- Bounded scan: top 30 most-recently-modified JSONLs only; window-bounded
  per-row tests keep the cost roughly O(sessions × edits_per_session).
- Path matching is basename-suffix, lowercased — robust to absolute,
  workspace-relative, or `~/`-prefixed inputs.
- Timestamps accept both ISO strings and millisecond/second epoch ints.

## Tests
`tests/test_selfconfig_session_attribution.py` — 14 unit tests:

- Path normalisation (lowercases basename, handles relative/empty paths).
- ISO + millisecond epoch timestamp parsing.
- JSONL scanning: matching edit, non-edit tool ignored, out-of-window
  ignored, corrupt rows tolerated.
- `_find_session_for_file_change` picks the most-recent matching session.
- End-to-end: writing to a tracked file then triggering a snapshot
  records the matching `source` block on the revision.

```
$ pytest tests/test_selfconfig_session_attribution.py -v
14 passed in 1.22s
```

## Test plan
- [x] `pytest tests/test_selfconfig_session_attribution.py -v`
- [x] `pytest tests/test_circular_import.py -q`
- [ ] Sanity-check the live dashboard: edit `SOUL.md` from a session,
      hit `/api/selfconfig/SOUL.md`, confirm the latest revision carries
      a `source` block pointing at that session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)