### PR TITLE
feat: MCP tool call observability panel

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3618,6 +3618,8 @@ function clawmetryLogout(){
         <div id="sh-security" style="margin-bottom:14px;"></div></div>
         <div id="sh-reliability-wrap" style="display:none;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">📊 Agent Reliability</div>
         <div id="sh-reliability" style="margin-bottom:14px;"></div></div>
+        <div id="sh-mcp-wrap" style="display:none;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--text-muted);font-weight:600;margin-bottom:6px;">🔌 MCP Tool Activity</div>
+        <div id="sh-mcp" style="margin-bottom:14px;"></div></div>
         <!-- 🔍 Diagnostics Panel (GH#28) -->
         <div id="sh-diagnostics-wrap">
           <div style="display:flex;align-items:center;justify-content:space-between;cursor:pointer;padding:4px 0;" onclick="var b=document.getElementById(\'sh-diagnostics-body\');b.style.display=b.style.display===\'none\'?\'block\':\'none\';this.querySelector(\'.diag-chevron\').textContent=b.style.display===\'none\'?\'▶\':\'▼\';">
@@ -5622,6 +5624,7 @@ async function loadAll() {
     if (typeof loadPromptErrors === 'function') loadPromptErrors().catch(function(e){console.warn('prompt errors failed',e)});
     if (typeof loadDiagnostics === 'function') loadDiagnostics().catch(function(e){console.warn('diagnostics failed',e)});
     if (typeof loadHeartbeat === 'function') loadHeartbeat().catch(function(e){console.warn('heartbeat panel failed',e)});
+    if (typeof loadMcpStats === 'function') loadMcpStats().catch(function(e){console.warn('mcp stats failed',e)});
     document.getElementById('refresh-time').textContent = 'Updated ' + new Date().toLocaleTimeString();
 
     if (overview.infra) {
@@ -5679,6 +5682,46 @@ async function loadReliabilityCard() {
     el = document.getElementById('reliability-detail-lt');
     if (el) el.textContent = r.session_count + ' sessions / ' + r.window_days + 'd';
   } catch(e) { console.warn('reliability card load failed', e); }
+}
+
+async function loadMcpStats() {
+  try {
+    var d = await fetchJsonWithTimeout('/api/mcp-stats', 8000);
+    var wrap = document.getElementById('sh-mcp-wrap');
+    var el = document.getElementById('sh-mcp');
+    if (!wrap || !el) return;
+    if (!d.tools || d.tools.length === 0) {
+      wrap.style.display = 'block';
+      el.innerHTML = '<div style="color:var(--text-muted);font-size:12px;">No MCP tool calls detected in recent sessions.</div>';
+      return;
+    }
+    var rows = d.tools.map(function(t) {
+      var errCell = t.errors > 0
+        ? '<span style="color:#e05;">' + t.errors + ' (' + t.error_rate_pct + '%)</span>'
+        : '<span style="color:var(--text-muted);">0</span>';
+      var latCell = t.avg_latency_ms != null
+        ? (t.avg_latency_ms >= 1000
+            ? (t.avg_latency_ms / 1000).toFixed(1) + 's'
+            : t.avg_latency_ms + 'ms')
+        : '<span style="color:var(--text-faint);">—</span>';
+      return '<tr style="border-top:1px solid var(--border-secondary);">'
+        + '<td style="padding:4px 6px 4px 0;font-size:12px;font-family:\'JetBrains Mono\',monospace;color:var(--text-primary);">' + t.name + '</td>'
+        + '<td style="padding:4px 6px;font-size:12px;color:var(--text-secondary);text-align:right;">' + t.calls + '</td>'
+        + '<td style="padding:4px 6px;font-size:12px;text-align:right;">' + errCell + '</td>'
+        + '<td style="padding:4px 0 4px 6px;font-size:12px;color:var(--text-secondary);text-align:right;">' + latCell + '</td>'
+        + '</tr>';
+    }).join('');
+    el.innerHTML = '<table style="width:100%;border-collapse:collapse;">'
+      + '<thead><tr>'
+      + '<th style="padding:0 6px 4px 0;font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--text-faint);text-align:left;font-weight:500;">Tool</th>'
+      + '<th style="padding:0 6px 4px;font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--text-faint);text-align:right;font-weight:500;">Calls</th>'
+      + '<th style="padding:0 6px 4px;font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--text-faint);text-align:right;font-weight:500;">Errors</th>'
+      + '<th style="padding:0 0 4px 6px;font-size:10px;text-transform:uppercase;letter-spacing:1px;color:var(--text-faint);text-align:right;font-weight:500;">Avg Latency</th>'
+      + '</tr></thead>'
+      + '<tbody>' + rows + '</tbody>'
+      + '</table>';
+    wrap.style.display = 'block';
+  } catch(e) { console.warn('mcp stats failed', e); }
 }
 
 async function loadHeartbeat() {

--- a/routes/health.py
+++ b/routes/health.py
@@ -1073,3 +1073,180 @@ def api_loop_detection():
         "loop_count": len(loops),
         "loops": loops,
     })
+
+
+# ---------------------------------------------------------------------------
+# MCP tool call observability (#850)
+# ---------------------------------------------------------------------------
+
+_BUILTIN_TOOLS = frozenset({
+    "exec", "Exec",
+    "Read", "Edit", "Write", "MultiEdit",
+    "Glob", "Grep", "Bash",
+    "web_search", "WebSearch", "web_fetch", "WebFetch",
+    "browser", "Browser",
+    "message", "tts", "image", "canvas",
+    "nodes", "process",
+    "sessions_spawn", "sessions_send", "session_status",
+    "cron", "gateway",
+    "TodoWrite", "TodoRead",
+    "NotebookRead", "NotebookEdit",
+    "computer", "Agent",
+})
+
+
+def _parse_ts_ms(val):
+    """Return milliseconds-since-epoch for a timestamp value, or None."""
+    if val is None:
+        return None
+    if isinstance(val, (int, float)):
+        v = float(val)
+        return v * 1000.0 if v < 1e10 else v
+    try:
+        s = str(val).strip().rstrip("Z")
+        # Handle optional fractional seconds and timezone offset
+        for fmt in (
+            "%Y-%m-%dT%H:%M:%S.%f",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S.%f",
+            "%Y-%m-%d %H:%M:%S",
+        ):
+            try:
+                from datetime import datetime, timezone
+                dt = datetime.strptime(s[:26], fmt)
+                return dt.replace(tzinfo=timezone.utc).timestamp() * 1000.0
+            except ValueError:
+                continue
+    except Exception:
+        pass
+    return None
+
+
+def _collect_mcp_stats(sessions_dir, max_sessions=20):
+    """Scan recent session JSONLs for external (non-builtin) tool call stats.
+
+    Returns (stats_list, files_checked) where stats_list is a list of dicts:
+      {name, calls, errors, error_rate_pct, avg_latency_ms}
+    sorted by call count descending.
+    """
+    try:
+        all_names = [
+            f for f in os.listdir(sessions_dir)
+            if f.endswith(".jsonl")
+            and ".deleted." not in f
+            and ".reset." not in f
+        ]
+    except OSError:
+        return [], 0
+
+    paths = sorted(
+        [os.path.join(sessions_dir, n) for n in all_names],
+        key=lambda p: os.path.getmtime(p),
+        reverse=True,
+    )[:max_sessions]
+
+    # {tool_name: {calls, errors, latencies_ms}}
+    tool_stats: dict = {}
+
+    for fpath in paths:
+        # Map toolCall id -> (name, start_ms) within this file
+        pending: dict = {}
+
+        try:
+            with open(fpath, errors="replace") as fh:
+                for raw in fh:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        ev = json.loads(raw)
+                    except Exception:
+                        continue
+
+                    ev_ts_ms = _parse_ts_ms(ev.get("timestamp"))
+                    msg = ev.get("message") or {}
+                    role = msg.get("role", "")
+
+                    if role == "assistant":
+                        content = msg.get("content") or []
+                        if not isinstance(content, list):
+                            continue
+                        for blk in content:
+                            if not isinstance(blk, dict):
+                                continue
+                            if blk.get("type") != "toolCall":
+                                continue
+                            name = (blk.get("name") or "").strip()
+                            if not name or name in _BUILTIN_TOOLS:
+                                continue
+                            if name not in tool_stats:
+                                tool_stats[name] = {"calls": 0, "errors": 0, "latencies_ms": []}
+                            tool_stats[name]["calls"] += 1
+                            tc_id = blk.get("id", "")
+                            if tc_id:
+                                pending[tc_id] = (name, ev_ts_ms)
+
+                    elif role == "toolResult":
+                        tc_id = msg.get("toolCallId", "")
+                        if not tc_id or tc_id not in pending:
+                            continue
+                        name, start_ms = pending.pop(tc_id)
+                        if msg.get("isError"):
+                            tool_stats[name]["errors"] += 1
+                        if start_ms and ev_ts_ms and ev_ts_ms > start_ms:
+                            latency = ev_ts_ms - start_ms
+                            if latency < 300_000:  # ignore pairs > 5 min apart
+                                tool_stats[name]["latencies_ms"].append(latency)
+        except Exception:
+            continue
+
+    result = []
+    for name, s in tool_stats.items():
+        calls = s["calls"]
+        errors = s["errors"]
+        lats = s["latencies_ms"]
+        result.append({
+            "name": name,
+            "calls": calls,
+            "errors": errors,
+            "error_rate_pct": round(errors * 100.0 / calls, 1) if calls else 0.0,
+            "avg_latency_ms": round(sum(lats) / len(lats)) if lats else None,
+        })
+
+    result.sort(key=lambda x: x["calls"], reverse=True)
+    return result, len(paths)
+
+
+@bp_health.route("/api/mcp-stats")
+def api_mcp_stats():
+    """Per-tool stats for non-builtin (MCP / external) tool calls.
+
+    Scans the 20 most-recently-modified session JSONLs and returns call
+    counts, error rates, and average latency for every tool whose name is
+    not in the standard OpenClaw built-in set.
+
+    Response:
+      {
+        "checked": <int>,
+        "tools": [
+          {"name": str, "calls": int, "errors": int,
+           "error_rate_pct": float, "avg_latency_ms": int|null}
+        ]
+      }
+    """
+    import dashboard as _d
+
+    sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
+        "~/.openclaw/agents/main/sessions"
+    )
+
+    tools: list = []
+    checked = 0
+
+    if os.path.isdir(sessions_dir):
+        try:
+            tools, checked = _collect_mcp_stats(sessions_dir)
+        except Exception:
+            pass
+
+    return jsonify({"checked": checked, "tools": tools})


### PR DESCRIPTION
Closes #850

## Summary
- Adds `GET /api/mcp-stats` to `routes/health.py`: scans the 20 most-recent session JSONLs, identifies non-builtin tool calls by excluding a `_BUILTIN_TOOLS` frozenset, pairs `toolCall`/`toolResult` events to compute per-tool call counts, error counts, error rate %, and avg latency ms.
- Adds `#sh-mcp-wrap` HTML panel to the Health tab in `dashboard.py`, placed after the existing Agent Reliability card.
- Adds `loadMcpStats()` JS function that renders a compact Tool / Calls / Errors / Avg Latency table (or a dimmed "no data" message when the list is empty), wired non-blocking into the page boot sequence.

## Test plan
- [ ] `GET /api/mcp-stats` returns `{"checked": N, "tools": []}` on a workspace with only builtin tool calls.
- [ ] Returns non-empty `tools` list on a workspace where an MCP/external tool was invoked; verify call count and error rate are correct.
- [ ] Health tab renders the "MCP Tool Activity" panel when tools are present; panel is hidden (not broken) when empty.
- [ ] Latency column shows `—` for tools where no timing data could be paired; shows `Xs` for latencies ≥ 1 s.
- [ ] No JS errors in browser console on page load.

https://claude.ai/code/session_011s4kuroyEBb3iKZuNv3f39

---
_Generated by [Claude Code](https://claude.ai/code/session_011s4kuroyEBb3iKZuNv3f39)_