### PR TITLE
feat(errors): smart error categorization library (closes #952)

### DIFF
--- a/clawmetry/error_patterns.py
+++ b/clawmetry/error_patterns.py
@@ -1,0 +1,246 @@
+"""
+clawmetry.error_patterns — translate raw error text into short human summaries.
+
+Operators reading an alert on their phone need a glanceable label, not 4 KB of
+stack trace. ``summarize_error()`` runs the input through:
+
+1. A pre-processor that strips timestamps, log levels, and bracketed tags so the
+   pattern library can match the actual message body.
+2. A regex pattern library grouped by category (network, HTTP, code, DB, auth,
+   file/OS, OpenClaw-specific). First match wins.
+3. A smart fallback chain when no pattern matches: extract ``SomeError: body``,
+   then a leading verb phrase, then a keyword category, then a hard-truncated
+   first clause.
+
+Every return value is capped at ``MAX_SUMMARY_LEN`` characters (default 50).
+
+Adding a new pattern is a one-line append to ``ERROR_PATTERNS`` plus a fixture
+in ``tests/test_error_patterns.py``.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Pattern, Tuple
+
+MAX_SUMMARY_LEN = 50
+
+# Strip ISO timestamps, syslog timestamps, log levels, bracketed tags, leading
+# pid/thread markers — anything that pads the front of a log line and would
+# otherwise prevent the body from matching a pattern.
+_TIMESTAMP_PATTERNS: Tuple[Pattern[str], ...] = (
+    # 2026-05-11T07:23:45.123Z / 2026-05-11 07:23:45,123 / 2026-05-11T07:23:45+00:00
+    re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?\s*"),
+    # May 11 07:23:45 host
+    re.compile(r"^[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\S+\s*"),
+    # 07:23:45.123 / 07:23:45
+    re.compile(r"^\d{2}:\d{2}:\d{2}(?:[.,]\d+)?\s*"),
+)
+
+_LEVEL_PATTERN = re.compile(
+    r"^(?:\[?\s*)(?:TRACE|DEBUG|INFO|NOTICE|WARN(?:ING)?|ERR(?:OR)?|FATAL|CRITICAL)(?:\s*\])?[:\s-]*",
+    re.IGNORECASE,
+)
+
+# [tag] or (tag) at the start, possibly multiple
+_BRACKET_TAG_PATTERN = re.compile(r"^(?:\[[^\]\n]{1,40}\]|\([^)\n]{1,40}\))\s*")
+
+# pid=123 / tid=abc / (12345) on its own
+_PID_PATTERN = re.compile(r"^\(\d+\)\s*|^pid=\d+\s+|^tid=\S+\s+", re.IGNORECASE)
+
+
+def _preprocess(text: str) -> str:
+    """Strip log noise from the front of an error line."""
+    if not text:
+        return ""
+    line = text.strip()
+    # Some inputs are multiline tracebacks — collapse to first non-empty line
+    # but keep the LAST line too because Python tracebacks put the exception
+    # on the final line. We pick whichever line is most informative below.
+    lines = [ln for ln in line.splitlines() if ln.strip()]
+    if lines:
+        # If the last line looks like "SomeError: ...", prefer it.
+        last = lines[-1].strip()
+        if re.match(r"^[A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning)\b", last):
+            line = last
+        else:
+            line = lines[0].strip()
+
+    # Repeatedly strip prefixes until nothing changes.
+    for _ in range(6):
+        before = line
+        for pat in _TIMESTAMP_PATTERNS:
+            line = pat.sub("", line, count=1)
+        line = _PID_PATTERN.sub("", line, count=1)
+        line = _LEVEL_PATTERN.sub("", line, count=1)
+        line = _BRACKET_TAG_PATTERN.sub("", line, count=1)
+        line = line.lstrip()
+        if line == before:
+            break
+    return line
+
+
+# Pattern library. Order matters: earlier = higher priority. Each entry is a
+# compiled regex paired with the canonical short summary. Patterns are matched
+# against the preprocessed error body using ``re.search``.
+_RAW_PATTERNS: Tuple[Tuple[str, str], ...] = (
+    # ---- OpenClaw-specific (match first so they aren't shadowed by generic) ----
+    (r"slack[_ ]bot[_ ]token[^a-z0-9]*(missing|not set|empty)", "Slack bot token missing"),
+    (r"retry failed for delivery", "Delivery retry failed"),
+    (r"socket[- ]mode (failed|disconnected|error)", "Slack socket-mode failed"),
+    (r"allowlist contains unknown", "Allowlist contains unknown entry"),
+    (r"hostname conflict", "Hostname conflict"),
+    (r"missing skill path", "Missing skill path"),
+    (r"gateway (unreachable|connection refused|not responding)", "Gateway unreachable"),
+    # ---- Auth / certs ----
+    (r"\bCERT_HAS_EXPIRED\b", "TLS certificate expired"),
+    (r"\bCERT_NOT_YET_VALID\b", "TLS certificate not yet valid"),
+    (r"\b(SELF_SIGNED_CERT|UNABLE_TO_VERIFY_LEAF_SIGNATURE|DEPTH_ZERO_SELF_SIGNED_CERT)\b", "TLS certificate untrusted"),
+    (r"\btoken (?:has |is )?expired\b", "Auth token expired"),
+    (r"\binvalid (?:\w+\s+){0,2}token\b", "Invalid auth token"),
+    # ---- HTTP status ----
+    (r"\b(?:rate[- ]?limit(?:ed)?|429\b|too many requests)\b", "API rate limit exceeded"),
+    (r"\b401\b|\bunauthorized\b", "HTTP 401 unauthorized"),
+    (r"\b403\b|\bforbidden\b", "HTTP 403 forbidden"),
+    (r"\b404\b|\bnot found\b", "HTTP 404 not found"),
+    (r"\b500\b|\binternal server error\b", "HTTP 500 server error"),
+    (r"\b502\b|\bbad gateway\b", "HTTP 502 bad gateway"),
+    (r"\b503\b|\bservice unavailable\b", "HTTP 503 service unavailable"),
+    (r"\b504\b|\bgateway timeout\b", "HTTP 504 gateway timeout"),
+    # ---- Network ----
+    (r"\bECONNREFUSED\b|connection refused", "Connection refused"),
+    (r"\bECONNRESET\b|connection reset", "Connection reset"),
+    (r"\bETIMEDOUT\b|connection timed out|connect timeout", "Connection timed out"),
+    (r"\bENOTFOUND\b|name (or service )?not (resolved|known)|getaddrinfo (failed|enotfound)", "DNS lookup failed"),
+    (r"\bEADDRINUSE\b|address already in use", "Port already in use"),
+    (r"\bEPERM\b|operation not permitted", "Operation not permitted"),
+    (r"\bEACCES\b|permission denied", "Permission denied"),
+    # ---- Code (JS-ish & Python) ----
+    (r"cannot read propert(?:y|ies) of (?:undefined|null)", "Null property access"),
+    (r"is not a function", "Called non-function value"),
+    (r"\bJSON\.parse\b|JSONDecodeError|expecting value|invalid json|unexpected token\s.+\bin json\b", "JSON parse failed"),
+    (r"\bKeyError: ", "Missing dictionary key"),
+    (r"\bAttributeError: ", "Missing attribute"),
+    (r"\bTypeError: ", "Type error"),
+    (r"\bValueError: ", "Invalid value"),
+    (r"\bImportError: |ModuleNotFoundError: ", "Module not found"),
+    # ---- DB ----
+    (r"\bSQLITE_BUSY\b|database is locked", "SQLite database busy"),
+    (r"\bSQLITE_CORRUPT\b|database disk image is malformed", "SQLite database corrupt"),
+    (r"\bSQLITE_READONLY\b|attempt to write a readonly database", "SQLite database readonly"),
+    # ---- File / OS ----
+    (r"\bENOENT\b|no such file or directory", "File or directory not found"),
+    (r"\bEISDIR\b|is a directory", "Expected file, got directory"),
+    (r"\bENOSPC\b|no space left on device", "Disk full"),
+    (r"\b(out of memory|MemoryError|OOMKilled|cannot allocate memory)\b", "Out of memory"),
+    (r"\bSIGKILL\b|killed( by signal 9)?", "Process killed (SIGKILL)"),
+    (r"\bSIGTERM\b|terminated( by signal 15)?", "Process terminated (SIGTERM)"),
+    (r"\bSIGSEGV\b|segmentation fault", "Segmentation fault"),
+)
+
+# Compile once. Case-insensitive so operators don't have to worry about logger casing.
+ERROR_PATTERNS: List[Tuple[Pattern[str], str]] = [
+    (re.compile(pat, re.IGNORECASE), summary) for pat, summary in _RAW_PATTERNS
+]
+
+
+_VERB_PHRASE_PATTERN = re.compile(
+    r"\b(failed to|cannot|unable to|could not|can't|won't|refused to|did not)\b[^.;\n]{1,60}",
+    re.IGNORECASE,
+)
+
+_PYTHONIC_EXCEPTION = re.compile(r"\b([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning))\s*:\s*(.+)")
+
+_KEYWORD_CATEGORIES: Tuple[Tuple[Pattern[str], str], ...] = (
+    (re.compile(r"\b(connect|socket|tcp|udp|network)\b", re.IGNORECASE), "Network error"),
+    (re.compile(r"\b(permission|denied|forbidden|unauthorized)\b", re.IGNORECASE), "Permission error"),
+    (re.compile(r"\b(invalid|unexpected|malformed|corrupt)\b", re.IGNORECASE), "Invalid input"),
+    (re.compile(r"\b(missing|not found|absent|undefined)\b", re.IGNORECASE), "Missing resource"),
+    (re.compile(r"\b(timeout|timed out|deadline)\b", re.IGNORECASE), "Timeout"),
+)
+
+
+def _truncate(text: str, limit: int = MAX_SUMMARY_LEN) -> str:
+    text = " ".join(text.split())  # collapse whitespace
+    if len(text) <= limit:
+        return text
+    # leave room for a trailing ellipsis
+    return text[: max(1, limit - 1)].rstrip(" ,.;:-_") + "…"
+
+
+def _humanize_pythonic(match: "re.Match[str]") -> str:
+    name, body = match.group(1), match.group(2).strip()
+    # Drop trailing tracebacks (next line). Body may include file paths — keep
+    # the first clause.
+    body = re.split(r"\s+at\s+|\sin\s+/", body, maxsplit=1)[0]
+    short = f"{name}: {body}".strip(" :")
+    return _truncate(short)
+
+
+def _fallback_summary(line: str) -> str:
+    """When no pattern matches, do progressively cheaper extraction."""
+    if not line:
+        return "Unknown error"
+
+    pythonic = _PYTHONIC_EXCEPTION.search(line)
+    if pythonic:
+        return _humanize_pythonic(pythonic)
+
+    verb = _VERB_PHRASE_PATTERN.search(line)
+    if verb:
+        return _truncate(verb.group(0))
+
+    for pat, label in _KEYWORD_CATEGORIES:
+        if pat.search(line):
+            return label
+
+    # Last resort: first clause, truncated. Strip a trailing colon/period that
+    # would otherwise look ragged.
+    first_clause = re.split(r"[.;\n]", line, maxsplit=1)[0]
+    return _truncate(first_clause) or "Unknown error"
+
+
+def summarize_error(text: str) -> str:
+    """Return a short (≤ 50 char) human-readable summary of *text*.
+
+    Never raises. Empty / whitespace-only input becomes ``"Unknown error"``.
+    """
+    if not isinstance(text, str):
+        return "Unknown error"
+
+    line = _preprocess(text)
+    if not line:
+        return "Unknown error"
+
+    for pattern, summary in ERROR_PATTERNS:
+        if pattern.search(line):
+            return _truncate(summary)
+
+    return _fallback_summary(line)
+
+
+def register_pattern(regex: str, summary: str, *, prepend: bool = False) -> None:
+    """Add a custom pattern at runtime.
+
+    ``prepend=True`` puts the new pattern at the front so it wins over earlier
+    matches — useful for product-specific overrides during local development.
+    """
+    compiled = re.compile(regex, re.IGNORECASE)
+    entry = (compiled, summary)
+    if prepend:
+        ERROR_PATTERNS.insert(0, entry)
+    else:
+        ERROR_PATTERNS.append(entry)
+
+
+def iter_patterns() -> Iterable[Tuple[Pattern[str], str]]:
+    """Read-only iterator over the current pattern table (for introspection)."""
+    return tuple(ERROR_PATTERNS)
+
+
+__all__ = [
+    "MAX_SUMMARY_LEN",
+    "ERROR_PATTERNS",
+    "summarize_error",
+    "register_pattern",
+    "iter_patterns",
+]

--- a/tests/test_error_patterns.py
+++ b/tests/test_error_patterns.py
@@ -1,0 +1,191 @@
+"""Tests for clawmetry.error_patterns.summarize_error()."""
+from __future__ import annotations
+
+import pytest
+
+from clawmetry.error_patterns import (
+    ERROR_PATTERNS,
+    MAX_SUMMARY_LEN,
+    register_pattern,
+    summarize_error,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: ≥ 30 real OpenClaw / Python / Node / shell error variants.
+# Each entry: (raw_input, expected_summary). Patterns are matched verbatim;
+# new contributors add one line here when adding a new pattern.
+# ---------------------------------------------------------------------------
+ERROR_FIXTURES = [
+    # ---- Network ----
+    ("connect ECONNREFUSED 127.0.0.1:8080", "Connection refused"),
+    ("Error: connect ECONNRESET", "Connection reset"),
+    ("read ETIMEDOUT after 30000ms", "Connection timed out"),
+    ("getaddrinfo ENOTFOUND api.anthropic.com", "DNS lookup failed"),
+    ("Error: listen EADDRINUSE: address already in use :::3000", "Port already in use"),
+    ("OSError: [Errno 13] Permission denied: '/var/log/clawmetry.log'", "Permission denied"),
+    ("OSError: [Errno 1] Operation not permitted", "Operation not permitted"),
+
+    # ---- HTTP ----
+    ("HTTP 429 Too Many Requests — rate limit exceeded", "API rate limit exceeded"),
+    ("401 Unauthorized: invalid bearer token", "Invalid auth token"),
+    ("403 Forbidden — agent does not have access", "HTTP 403 forbidden"),
+    ("Anthropic API returned 500 Internal Server Error", "HTTP 500 server error"),
+    ("Upstream 502 Bad Gateway", "HTTP 502 bad gateway"),
+    ("503 Service Unavailable from openai.com", "HTTP 503 service unavailable"),
+    ("504 Gateway Timeout after 60s", "HTTP 504 gateway timeout"),
+
+    # ---- Auth / certs ----
+    ("Error: CERT_HAS_EXPIRED", "TLS certificate expired"),
+    ("auth token expired at 2026-05-10T00:00:00Z", "Auth token expired"),
+
+    # ---- Code (JS) ----
+    ("TypeError: Cannot read properties of undefined (reading 'session')", "Null property access"),
+    ("TypeError: obj.fn is not a function", "Called non-function value"),
+    ("SyntaxError: Unexpected token < in JSON at position 0", "JSON parse failed"),
+
+    # ---- Code (Python) ----
+    ("KeyError: 'agent_id'", "Missing dictionary key"),
+    ("AttributeError: 'NoneType' object has no attribute 'cost'", "Missing attribute"),
+    ("TypeError: unsupported operand type(s) for +: 'int' and 'str'", "Type error"),
+    ("ValueError: invalid literal for int() with base 10: 'abc'", "Invalid value"),
+    ("ModuleNotFoundError: No module named 'tiktoken'", "Module not found"),
+
+    # ---- DB ----
+    ("sqlite3.OperationalError: database is locked", "SQLite database busy"),
+    ("sqlite3.DatabaseError: database disk image is malformed", "SQLite database corrupt"),
+    ("sqlite3.OperationalError: attempt to write a readonly database", "SQLite database readonly"),
+
+    # ---- File / OS ----
+    ("ENOENT: no such file or directory, open '/tmp/missing.json'", "File or directory not found"),
+    ("EISDIR: illegal operation on a directory, read", "Expected file, got directory"),
+    ("OSError: [Errno 28] No space left on device", "Disk full"),
+    ("MemoryError", "Out of memory"),
+    ("Process killed by signal 9 (SIGKILL)", "Process killed (SIGKILL)"),
+    ("Worker terminated (SIGTERM)", "Process terminated (SIGTERM)"),
+    ("Segmentation fault (core dumped)", "Segmentation fault"),
+
+    # ---- OpenClaw-specific ----
+    ("Slack bot token missing — set SLACK_BOT_TOKEN", "Slack bot token missing"),
+    ("retry failed for delivery to channel #ops after 5 attempts", "Delivery retry failed"),
+    ("socket-mode failed: WebSocket closed unexpectedly", "Slack socket-mode failed"),
+    ("allowlist contains unknown entry: 'kody-coder-old'", "Allowlist contains unknown entry"),
+    ("Hostname conflict: another node already registered as dhriti-2", "Hostname conflict"),
+    ("missing skill path: skills/clawmetry-release/SKILL.md", "Missing skill path"),
+    ("Gateway unreachable — connection refused on 127.0.0.1:18789", "Gateway unreachable"),
+]
+
+
+@pytest.mark.parametrize("raw,expected", ERROR_FIXTURES)
+def test_summarize_error_fixtures(raw, expected):
+    assert summarize_error(raw) == expected
+
+
+def test_fixture_count_meets_minimum():
+    # The issue mandates ≥ 30 fixtures. Guard against regressions.
+    assert len(ERROR_FIXTURES) >= 30
+
+
+# ---------------------------------------------------------------------------
+# Pre-processor: timestamps, log levels, bracketed tags
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("2026-05-11T07:23:45.123Z ERROR connect ECONNREFUSED", "Connection refused"),
+        ("[2026-05-11 07:23:45,123] [ERROR] connect ECONNREFUSED", "Connection refused"),
+        ("May 11 07:23:45 host1 [WARN] 429 too many requests", "API rate limit exceeded"),
+        ("(12345) ERR: ENOENT no such file or directory", "File or directory not found"),
+        ("WARNING: SQLITE_BUSY: database is locked", "SQLite database busy"),
+        ("[clawmetry][interceptor] retry failed for delivery", "Delivery retry failed"),
+    ],
+)
+def test_preprocessor_strips_log_noise(raw, expected):
+    assert summarize_error(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Fallback chain: Pythonic exception → verb phrase → keyword → first clause
+# ---------------------------------------------------------------------------
+def test_fallback_pythonic_exception_extraction():
+    out = summarize_error("RuntimeError: telemetry pipeline blew up halfway through")
+    assert out.startswith("RuntimeError:")
+    assert len(out) <= MAX_SUMMARY_LEN
+
+
+def test_fallback_verb_phrase():
+    out = summarize_error("clawmetry: unable to reach pricing service at boot")
+    assert "unable to reach" in out.lower()
+    assert len(out) <= MAX_SUMMARY_LEN
+
+
+def test_fallback_keyword_network():
+    assert summarize_error("weird socket hiccup somewhere in the stack") == "Network error"
+
+
+def test_fallback_keyword_timeout():
+    assert summarize_error("operation deadline reached") == "Timeout"
+
+
+def test_fallback_first_clause_truncates_to_limit():
+    long = "this is an unusual error nobody has ever seen before in production"
+    out = summarize_error(long)
+    assert len(out) <= MAX_SUMMARY_LEN
+
+
+def test_unknown_error_for_empty_input():
+    assert summarize_error("") == "Unknown error"
+    assert summarize_error("   \n\t  ") == "Unknown error"
+    assert summarize_error(None) == "Unknown error"  # type: ignore[arg-type]
+
+
+def test_non_string_input_does_not_crash():
+    assert summarize_error(12345) == "Unknown error"  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Multiline tracebacks: prefer the exception line at the bottom
+# ---------------------------------------------------------------------------
+def test_multiline_traceback_prefers_exception_line():
+    traceback = """Traceback (most recent call last):
+  File "/app/dashboard.py", line 815, in _fire_alert
+    raise ValueError("invalid alert payload")
+ValueError: invalid alert payload"""
+    out = summarize_error(traceback)
+    assert out == "Invalid value"
+
+
+# ---------------------------------------------------------------------------
+# Output contract: every summary ≤ MAX_SUMMARY_LEN
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("raw,_expected", ERROR_FIXTURES)
+def test_summary_respects_length_cap(raw, _expected):
+    assert len(summarize_error(raw)) <= MAX_SUMMARY_LEN
+
+
+# ---------------------------------------------------------------------------
+# register_pattern() — runtime extensibility
+# ---------------------------------------------------------------------------
+def test_register_pattern_prepend_wins_over_existing():
+    original_len = len(ERROR_PATTERNS)
+    try:
+        register_pattern(r"\bcustom-widget-failure\b", "Custom widget failed", prepend=True)
+        assert summarize_error("custom-widget-failure on shard 7") == "Custom widget failed"
+        assert len(ERROR_PATTERNS) == original_len + 1
+    finally:
+        # Restore module state so other tests stay deterministic.
+        del ERROR_PATTERNS[0]
+        assert len(ERROR_PATTERNS) == original_len
+
+
+def test_register_pattern_append_is_lower_priority():
+    original_len = len(ERROR_PATTERNS)
+    try:
+        # Append a pattern that would otherwise match an existing case — the
+        # earlier match should still win.
+        register_pattern(r"connection", "Custom connection label")
+        assert summarize_error("Error: connect ECONNREFUSED") == "Connection refused"
+        assert len(ERROR_PATTERNS) == original_len + 1
+    finally:
+        del ERROR_PATTERNS[-1]
+        assert len(ERROR_PATTERNS) == original_len


### PR DESCRIPTION
Closes #952

## What

New `clawmetry/error_patterns.py` module exposes `summarize_error(text)` that turns raw stderr/tracebacks into a ≤ 50-char human-readable label suitable for alert subjects and grouping keys.

Replaces `4 KB stack trace → glanceable phone-sized alert`.

## How

**Pattern library (`ERROR_PATTERNS`)** — ordered list of `(compiled regex, summary)` pairs grouped by category. First match wins. Covers everything called out in the issue:

| Category | Coverage |
|---|---|
| **OpenClaw-specific** | Slack bot token missing, retry-failed-for-delivery, socket-mode failed, allowlist contains unknown, hostname conflict, missing skill path, gateway unreachable |
| **Auth / certs** | `CERT_HAS_EXPIRED`, `CERT_NOT_YET_VALID`, self-signed/untrusted cert, token expired, invalid bearer/auth token |
| **HTTP** | rate-limit (429), 401/403/404/500/502/503/504 |
| **Network** | `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `EADDRINUSE`, `EPERM`, `EACCES` |
| **Code (JS + Py)** | null property access, "is not a function", JSON parse failures (incl. `SyntaxError: Unexpected token … in JSON`), `KeyError`/`AttributeError`/`TypeError`/`ValueError`/`ImportError`/`ModuleNotFoundError` |
| **DB** | `SQLITE_BUSY`, `SQLITE_CORRUPT`, `SQLITE_READONLY` |
| **File / OS** | `ENOENT`, `EISDIR`, `ENOSPC`, `MemoryError`, `SIGKILL`/`SIGTERM`/`SIGSEGV` |

**Pre-processor** strips ISO timestamps, syslog timestamps, log levels (`TRACE`/`DEBUG`/`INFO`/`WARN`/`ERROR`/`FATAL`/`CRITICAL`), bracketed tags (`[clawmetry][interceptor]`), and pid/tid markers so patterns match the real body. Multiline tracebacks prefer the exception line at the bottom.

**Smart fallback chain** when no pattern matches:
1. Pythonic `SomeError: body` extraction.
2. Verb phrases (`failed to …`, `cannot …`, `unable to …`, `could not …`).
3. Keyword categorization (network / permission / invalid / missing / timeout).
4. First clause, truncated with an ellipsis to `MAX_SUMMARY_LEN` (50).

**Runtime extensibility** — `register_pattern(regex, summary, prepend=True/False)` for product-specific overrides without editing the source.

## Tests

`tests/test_error_patterns.py` — 99 assertions, all green:

- 40-entry parametrized fixture (issue requires ≥ 30) spanning every category.
- Pre-processor strips timestamps + levels + brackets correctly.
- Fallback chain: Pythonic extraction → verb phrase → keyword → first-clause truncation.
- Length cap (every summary ≤ `MAX_SUMMARY_LEN`).
- Multiline traceback prefers the exception line.
- Empty / non-string input returns `"Unknown error"` without crashing.
- `register_pattern(prepend=True)` wins over earlier matches; `append` is lower priority.

Verified no regression on adjacent suites (`tests/test_api.py`, `tests/test_circular_import.py`): 149 passed.

## Scope note

Wiring `summarize_error()` into `_fire_alert()` and the alert-grouping schema change (`summary TEXT` column + `(agent_id, summary)` grouping) are deliberately left for a follow-up PR so this stays a pure, additive, easy-to-review foundation. The library is self-contained and ships ready to plug in.

## Acceptance criteria mapped

- [x] `summarize_error()` takes any string and returns a ≤ 50-char summary
- [x] Tested against ≥ 30 real OpenClaw error variants
- [x] Adding a new pattern is a one-line change in `error_patterns.py` + a test fixture
- [ ] (follow-up) Alert messages lead with the summary
- [ ] (follow-up) Alert Center groups by summary
- [ ] (follow-up) Telegram / Slack / email payloads use the summary as the subject

Generated with Dhriti (Claude Opus 4.7) via OpenClaw cron `clawmetry-gh-issues-to-pr`