### PR TITLE
feat(local-store): wire sync.py + dashboard endpoints — completes #958

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1082,6 +1082,17 @@ def _flush_session_batch(
     node_id: str,
     subagent_id: str | None = None,
 ) -> None:
+    # Write-through to local SQLite first (epic #964 / phase 1 / issue #958).
+    # Local is the durable store; cloud is a hot cache. If the cloud POST fails
+    # below, the events are still recorded locally and the dashboard's local
+    # read paths will surface them. Failures here never block cloud sync — the
+    # broad except keeps the legacy behaviour intact for users who somehow
+    # land on a corrupt SQLite or a read-only ~/.clawmetry/.
+    try:
+        _local_ingest_session_batch(batch, fname, node_id, subagent_id)
+    except Exception as _e:
+        log.warning("local-store ingest failed (cloud sync continues): %s", _e)
+
     payload = {"session_file": fname, "node_id": node_id, "events": batch}
     # Include subagent_id so the cloud can correlate blobs → sub-agent sessions.
     # The session key UUID (subagent_id) differs from the .jsonl filename UUID.
@@ -1099,6 +1110,56 @@ def _flush_session_batch(
         )
     else:
         _post("/ingest/events", payload, api_key)
+
+
+def _local_ingest_session_batch(
+    batch: list,
+    session_file: str,
+    node_id: str,
+    subagent_id: str | None,
+) -> None:
+    """Translate a batch of raw OpenClaw transcript events into the local
+    store's normalised shape and queue them for write. Idempotent at the
+    store level — INSERT OR IGNORE on event id."""
+    from clawmetry import local_store  # local import: keeps cli/sync importable on Pythons missing sqlite3
+
+    store = local_store.get_store()
+    rows: list[dict] = []
+    # session_file is like '<uuid>.jsonl' — use the uuid as the canonical
+    # session_id so the dashboard's per-session views can correlate.
+    session_id = subagent_id or session_file.split(".jsonl", 1)[0]
+    for obj in batch:
+        if not isinstance(obj, dict):
+            continue
+        # Stable per-event id: prefer an explicit id from the transcript, then
+        # the openclaw eventId, else compose from session_id + timestamp +
+        # message-id-ish hint. INSERT OR IGNORE makes re-delivery harmless.
+        eid = (
+            obj.get("id")
+            or obj.get("eventId")
+            or obj.get("messageId")
+            or f"{session_id}:{obj.get('timestamp','?')}:{obj.get('type','?')}"
+        )
+        ts = obj.get("timestamp") or obj.get("ts") or ""
+        if not ts:
+            # Skip events with no timestamp — the local store's index assumes
+            # ts is set, and filtering them out is safer than synthesising one.
+            continue
+        rows.append({
+            "id": str(eid),
+            "node_id": node_id,
+            "agent_id": "main",  # OpenClaw harness; Claude Code adapter will use 'claude-code'
+            "session_id": session_id,
+            "workspace_id": obj.get("workspace") or obj.get("workspace_id"),
+            "event_type": str(obj.get("type") or obj.get("event_type") or "unknown"),
+            "ts": str(ts),
+            "data": obj,
+            "cost_usd": obj.get("cost_usd") or obj.get("costUsd"),
+            "token_count": obj.get("token_count") or obj.get("tokens"),
+            "model": obj.get("model"),
+        })
+    if rows:
+        store.ingest_many(rows)
 
 
 def sync_sessions_recent(

--- a/dashboard.py
+++ b/dashboard.py
@@ -8535,6 +8535,37 @@ def detect_config(args=None):
                 return _jsonify(json.load(_f))
         except Exception as _e:
             return _jsonify({"error": f"unreadable: {_e}"}), 500
+
+    # Local SQLite event store (epic #964 / phase 1) — proves the daemon is
+    # writing through to ~/.clawmetry/events.db. The dashboard's main read
+    # paths are migrating to this store progressively; in the meantime this
+    # endpoint exposes the store's own metrics so we can verify the
+    # write-through is working in prod and start the cutover safely.
+    @app.route("/api/local-store/health", endpoint="local_store_health")
+    def _local_store_health():
+        from flask import jsonify as _jsonify
+        try:
+            from clawmetry import local_store
+            return _jsonify(local_store.get_store().health())
+        except Exception as _e:
+            return _jsonify({"error": str(_e)[:300]}), 503
+
+    @app.route("/api/local-store/events", endpoint="local_store_events")
+    def _local_store_events():
+        from flask import jsonify as _jsonify, request as _req
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store()
+            rows = store.query_events(
+                session_id=_req.args.get("session_id"),
+                event_type=_req.args.get("event_type"),
+                since=_req.args.get("since"),
+                until=_req.args.get("until"),
+                limit=int(_req.args.get("limit", "200")),
+            )
+            return _jsonify({"events": rows, "count": len(rows)})
+        except Exception as _e:
+            return _jsonify({"error": str(_e)[:300]}), 500
     # ────────────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_local_store_sync_integration.py
+++ b/tests/test_local_store_sync_integration.py
@@ -1,0 +1,160 @@
+"""Integration test for the sync.py → local_store wire-up (epic #964 phase 1).
+
+Verifies that ``_flush_session_batch`` translates raw OpenClaw transcript events
+into the local store's normalised shape and queues them for write — without
+breaking the cloud POST path (we mock _post and assert it still gets called)."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def sync_with_isolated_store(tmp_path, monkeypatch):
+    """Reload sync + local_store with an isolated DB per test."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.db"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    import clawmetry.local_store as ls
+    import clawmetry.sync as sync
+    importlib.reload(ls)
+    # sync.py grabs local_store via a local import inside the helper, so a
+    # plain reload of sync isn't strictly required — but reloading both keeps
+    # tests independent.
+    importlib.reload(sync)
+    yield sync, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait_for_flush(store, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+    raise AssertionError("flusher did not drain in time")
+
+
+def test_flush_session_batch_writes_to_local_store(sync_with_isolated_store):
+    sync, ls = sync_with_isolated_store
+    batch = [
+        {
+            "id": "ev-1",
+            "type": "tool_call",
+            "timestamp": "2026-05-11T10:00:00Z",
+            "tool": "Bash",
+            "model": "claude-opus-4-7",
+            "tokens": 142,
+            "cost_usd": 0.003,
+        },
+        {
+            "id": "ev-2",
+            "type": "message",
+            "timestamp": "2026-05-11T10:00:05Z",
+            "role": "user",
+            "text": "hello",
+        },
+    ]
+    fname = "session-abc.jsonl"
+    with patch.object(sync, "_post") as mock_post:
+        sync._flush_session_batch(
+            batch, fname, api_key="cm_x", enc_key=None, node_id="agent+test", subagent_id=None
+        )
+    # Cloud path still fires:
+    mock_post.assert_called_once()
+    cloud_args = mock_post.call_args[0]
+    assert cloud_args[0] == "/ingest/events"
+    assert cloud_args[1]["node_id"] == "agent+test"
+    assert len(cloud_args[1]["events"]) == 2
+
+    # Local store path also fires:
+    store = ls.get_store()
+    _wait_for_flush(store)
+    rows = store.query_events(session_id="session-abc")
+    assert len(rows) == 2
+    by_id = {r["id"]: r for r in rows}
+    assert by_id["ev-1"]["event_type"] == "tool_call"
+    assert by_id["ev-1"]["model"] == "claude-opus-4-7"
+    assert by_id["ev-1"]["token_count"] == 142
+    assert round(by_id["ev-1"]["cost_usd"], 6) == 0.003
+    assert by_id["ev-2"]["event_type"] == "message"
+
+
+def test_local_store_failure_does_not_block_cloud_post(sync_with_isolated_store):
+    sync, ls = sync_with_isolated_store
+    batch = [{"id": "ev-x", "type": "tool_call", "timestamp": "2026-05-11T10:00:00Z"}]
+    # Force the local-ingest path to blow up — cloud POST must still happen.
+    with patch.object(sync, "_local_ingest_session_batch", side_effect=RuntimeError("disk full")):
+        with patch.object(sync, "_post") as mock_post:
+            sync._flush_session_batch(
+                batch, "s.jsonl", api_key="cm_x", enc_key=None, node_id="agent+test"
+            )
+    mock_post.assert_called_once()
+
+
+def test_subagent_id_used_as_session_id(sync_with_isolated_store):
+    """When subagent_id is provided, local store rows key on it (not the file UUID)
+    so the dashboard's subagent views can correlate."""
+    sync, ls = sync_with_isolated_store
+    batch = [{"id": "sub-1", "type": "tool_call", "timestamp": "2026-05-11T10:00:00Z"}]
+    with patch.object(sync, "_post"):
+        sync._flush_session_batch(
+            batch,
+            "00b5b41b-file-uuid.jsonl",
+            api_key="cm_x",
+            enc_key=None,
+            node_id="agent+test",
+            subagent_id="317db68b-subagent-uuid",
+        )
+    store = ls.get_store()
+    _wait_for_flush(store)
+    rows = store.query_events(session_id="317db68b-subagent-uuid")
+    assert len(rows) == 1
+    rows_under_file_uuid = store.query_events(session_id="00b5b41b-file-uuid")
+    assert len(rows_under_file_uuid) == 0
+
+
+def test_events_without_timestamp_skipped(sync_with_isolated_store):
+    """Local store requires ts; events missing it are dropped (logged elsewhere).
+    Cloud POST still ships the full batch — cloud has its own validation."""
+    sync, ls = sync_with_isolated_store
+    batch = [
+        {"id": "no-ts", "type": "tool_call"},  # missing timestamp
+        {"id": "ok",    "type": "tool_call", "timestamp": "2026-05-11T10:00:00Z"},
+    ]
+    with patch.object(sync, "_post"):
+        sync._flush_session_batch(
+            batch, "s.jsonl", api_key="cm_x", enc_key=None, node_id="agent+test"
+        )
+    store = ls.get_store()
+    _wait_for_flush(store)
+    rows = store.query_events(session_id="s")
+    assert [r["id"] for r in rows] == ["ok"]
+
+
+def test_id_synthesised_when_missing(sync_with_isolated_store):
+    """Some openclaw events lack an explicit id; the helper composes one from
+    session+ts+type so INSERT OR IGNORE still does the right thing on re-delivery."""
+    sync, ls = sync_with_isolated_store
+    batch = [{"type": "tool_call", "timestamp": "2026-05-11T10:00:00Z"}]
+    with patch.object(sync, "_post"):
+        sync._flush_session_batch(
+            batch, "s.jsonl", api_key="cm_x", enc_key=None, node_id="agent+test"
+        )
+        # Ingest the same batch a second time — should not duplicate.
+        sync._flush_session_batch(
+            batch, "s.jsonl", api_key="cm_x", enc_key=None, node_id="agent+test"
+        )
+    store = ls.get_store()
+    _wait_for_flush(store)
+    rows = store.query_events(session_id="s")
+    assert len(rows) == 1


### PR DESCRIPTION
## Summary

Completes phase 1 of epic #964 by wiring the daemon to the SQLite event store that landed in PR #966, plus exposes two read endpoints the dashboard cutover can target.

## What changes

- **\`sync.py:_flush_session_batch\`** — write-through to \`local_store\` BEFORE the cloud POST. Failures swallowed; cloud sync never blocked.
- **\`_local_ingest_session_batch\`** — translates raw OpenClaw events to the store's normalised shape. Uses \`agent_id='main'\`; Claude Code adapter (private epic #703) will use \`'claude-code'\`.
- **\`subagent_id\`** routes to local store as the canonical \`session_id\` so subagent dashboard views correlate.
- **Two new dashboard endpoints**: \`/api/local-store/health\` and \`/api/local-store/events\`.

## Tests

5 new integration tests + the 22 existing module tests = **27 passing**. Asserts both:
- Local + cloud both fire on a normal flush
- Local failure does NOT block the cloud POST (test_local_store_failure_does_not_block_cloud_post)

## Why ship now

Epic #964 dependency graph has #958 as the foundation for #959–#963. Without this wire-up, the daemon writes nothing to the store; the rest of the epic can't proceed. This is the minimal diff that gets phase 1 to "events flow end-to-end" so the cutover work can begin.

## Test plan

- [x] \`pytest tests/test_local_store*.py\` — 27 passed
- [ ] Run daemon on this machine, confirm \`~/.clawmetry/events.db\` populates within minutes
- [ ] Hit \`/api/local-store/health\` on local dashboard — confirm event_count > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)