### PR TITLE
[RELEASE] local SQLite event store now populated by daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Local-first foundation (epic #964 phase 1)
+- **Local SQLite event store** at `~/.clawmetry/events.db` — durable record of every telemetry event the daemon parses (#966)
+- **Daemon writes through to local store** at parse time — local is now the source of truth, cloud is a hot cache. Failures in the local path never block cloud sync (#983)
+- **Two new diagnostic endpoints** — `/api/local-store/health` and `/api/local-store/events` for verification + test harnesses
+- 27 passing tests cover ingest validation, idempotency, batch flush, query filters, restart persistence, ring overflow, and the full sync→store wire-through
+
 ---
 
 ## v0.12.120


### PR DESCRIPTION
## Summary

First user-facing release of epic #964's phase 1 work. The daemon now writes every JSONL session event to a local SQLite store at \`~/.clawmetry/events.db\` in addition to the cloud sync POST. Prereq for the local-first refactor (epic #964) — every subsequent phase reads from this store.

## What's in this version

- The local-store module (#966)
- The daemon wire-through that populates it (#983)
- Two new endpoints: \`/api/local-store/health\` + \`/api/local-store/events\`
- CHANGELOG entry documenting the above

## How to verify after upgrading

\`\`\`
pip install -U clawmetry
# wait for the next sync cycle (a few seconds)
curl http://localhost:8900/api/local-store/health
\`\`\`

Expected: \`event_count\` > 0, \`size_mb\` non-zero.

## Not in this release (follow-ups)

- Dashboard read-path swap (\`/api/brain-history\` etc. reading FROM local store as primary).
- OSS local-only mode (no-cloud-account flow polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)