### PR TITLE
fix(release-smoke): Config → ClawMetryConfig + add local_store smoke

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -75,7 +75,11 @@ jobs:
           import clawmetry
           from clawmetry import sync, cli, interceptor, providers_pricing
           from clawmetry.sync import _sync_allowed, _post, send_heartbeat, validate_key
-          from clawmetry.config import Config
+          from clawmetry.config import ClawMetryConfig
+          # Smoke that the local store loads (epic #964 phase 1, ships in 0.12.165+)
+          from clawmetry import local_store
+          ls_health = local_store.get_store().health()
+          assert ls_health['engine'] == 'duckdb', f"local_store engine wrong: {ls_health}"
           print('  imports OK')
           "
           echo "▸ Wheel ships runtime assets (templates, static)"


### PR DESCRIPTION
Pre-existing bug: the wheel-smoke step in `release-on-merge.yml` imports `Config` from `clawmetry.config` — but the actual class is `ClawMetryConfig`. This has been silently failing every [RELEASE] attempt; latest two ([RELEASE] PRs #984 + #985) got blocked on this single line. **0.12.164 and 0.12.165 never published to PyPI** despite the merge commits being on main.

While here, extend the smoke to also assert the local store loads + reports the duckdb engine (catches a future regression).

After this merges, the next [RELEASE] commit (or a manual workflow_dispatch) will publish 0.12.166 with all phase-1 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)