### PR TITLE
fix(release-e2e): seed empty OPENCLAW_HOME so daemon doesn't crash on /root probe

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -132,7 +132,13 @@ jobs:
               'connected_at': '2026-05-07T00:00:00Z',
           }, open(os.path.expanduser('~/.clawmetry/config.json'), 'w'))
           "
-          echo "▸ Spawning wheel-installed daemon for 15s"
+          # Give the daemon an empty but valid OpenClaw workspace so its
+          # auto-detection doesn't fall back to /root/.openclaw (which
+          # CI may not have permission to stat).
+          export OPENCLAW_HOME="$HOME/.openclaw-e2e-fixture"
+          mkdir -p "$OPENCLAW_HOME/agents/main/sessions" "$OPENCLAW_HOME/memory" "$OPENCLAW_HOME/logs"
+          echo "{}" > "$OPENCLAW_HOME/agents/main/sessions/sessions.json"
+          echo "▸ Spawning wheel-installed daemon for 15s (OPENCLAW_HOME=$OPENCLAW_HOME)"
           timeout 15 /tmp/smoke-venv/bin/python -m clawmetry.sync > /tmp/daemon.log 2>&1 || true
           if grep -q "Initial heartbeat sent" /tmp/daemon.log; then
             echo "✅ Daemon sent initial heartbeat — wheel + cloud handshake OK"


### PR DESCRIPTION
Second blocker on the publish pipeline (after #986). Daemon falls back to /root/.openclaw and the runner can't stat() it. Seeding an empty workspace under $HOME fixes it.

After this merges, the next [RELEASE] commit will publish 0.12.166 with the local-store + DuckDB work that's been waiting since this morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)