### PR TITLE
feat(local-query): coherent /api/local/* HTTP API over the DuckDB store (#960 phase A)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -112,6 +112,7 @@ from routes.autonomy import bp_autonomy
 from routes.selfconfig import bp_selfconfig
 from routes.reasoning import bp_reasoning
 from routes.plugins import bp_plugins
+from routes.local_query import bp_local_query
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -8492,6 +8493,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_selfconfig)
     app.register_blueprint(bp_reasoning)
     app.register_blueprint(bp_plugins)
+    app.register_blueprint(bp_local_query)
     app.register_blueprint(bp_openapi)
 
     # Local-OSS shims for cloud-only endpoints. Return empty arrays so the

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -1,0 +1,193 @@
+"""routes/local_query.py — coherent local query API over the DuckDB store.
+
+Implements phase 1A of issue #960 (epic #964). Adds an `/api/local/*` HTTP
+surface over `clawmetry.local_store`. Two transports will share these
+shapes:
+
+* **Local HTTP** — what's in this file. Bound to `127.0.0.1:8900` by the
+  OSS dashboard. Used by the OSS local-only browser experience and by any
+  CLI/tooling that wants to introspect the local store.
+* **WebSocket relay** (follow-up PR) — the daemon opens a long-lived WS to
+  `wss://app.clawmetry.com/api/node/relay`; cloud-side dashboards send
+  `{type:"query", shape:"events", args:{...}}` frames; the daemon dispatches
+  to the same in-process functions exposed here, returns chunked rows over
+  the WS. By keeping the dispatch in `_dispatch()`, both transports stay in
+  sync — fix the SQL once, both surfaces benefit.
+
+Response shapes mirror the cloud `/api/cloud/*` JSON so the dashboard can
+swap backends with no client edits — see PRD #964 for the design.
+
+Auth: none. Bound to localhost. Cloud sync of these endpoints — when it
+happens — goes through the WS relay, which has its own auth (cm_ token +
+node_id ownership check).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from flask import Blueprint, jsonify, request
+
+bp_local_query = Blueprint("local_query", __name__)
+
+
+# ── Allowlist of query shapes (used by both HTTP + future WS relay) ────────
+
+# A "shape" is a named query the relay is allowed to dispatch. Keeping it
+# explicit (not raw SQL pass-through) means the cloud relay can never run
+# arbitrary SELECT against the user's local DuckDB — only what we've
+# whitelisted here.
+_SHAPES = {
+    "events":     "query_events",
+    "sessions":   "query_sessions",
+    "aggregates": "query_aggregates",
+    "health":     None,                 # special: no args
+    "transcript": "query_events",       # alias with session_id required
+}
+
+
+def _store():
+    """Lazy-import. Avoids paying duckdb's import cost on Flask boot when
+    the user never hits these endpoints."""
+    from clawmetry import local_store
+    return local_store.get_store()
+
+
+def _coerce_args(shape: str, raw: dict) -> dict:
+    """Strict per-shape arg coercion. Drops anything not in the per-shape
+    allowed-keys set, casts limit/since/until to safe types."""
+    if shape == "events":
+        return {
+            "session_id": raw.get("session_id"),
+            "agent_id":   raw.get("agent_id"),
+            "event_type": raw.get("event_type"),
+            "since":      raw.get("since"),
+            "until":      raw.get("until"),
+            "limit":      _safe_int(raw.get("limit"), default=200, lo=1, hi=5000),
+        }
+    if shape == "sessions":
+        return {
+            "agent_id": raw.get("agent_id"),
+            "since":    raw.get("since"),
+            "until":    raw.get("until"),
+            "limit":    _safe_int(raw.get("limit"), default=100, lo=1, hi=2000),
+        }
+    if shape == "aggregates":
+        return {
+            "agent_id": raw.get("agent_id"),
+            "since":    raw.get("since"),
+            "until":    raw.get("until"),
+        }
+    if shape == "transcript":
+        sid = raw.get("session_id")
+        if not sid:
+            raise ValueError("transcript shape requires session_id")
+        return {
+            "session_id": sid,
+            "limit":      _safe_int(raw.get("limit"), default=500, lo=1, hi=5000),
+        }
+    if shape == "health":
+        return {}
+    raise ValueError(f"unknown shape: {shape}")
+
+
+def _safe_int(v: Any, *, default: int, lo: int, hi: int) -> int:
+    try:
+        n = int(v)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, n))
+
+
+def _dispatch(shape: str, args: dict) -> dict:
+    """Single-source-of-truth shape→method bridge. Both the HTTP and (future)
+    WS transports call this. Returns a JSON-friendly dict ready to ship."""
+    started = time.monotonic()
+    store = _store()
+    if shape == "health":
+        body = store.health()
+    else:
+        method_name = _SHAPES[shape]
+        rows = getattr(store, method_name)(**args)
+        body = {"rows": rows, "count": len(rows)}
+    body["_shape"] = shape
+    body["_elapsed_ms"] = int((time.monotonic() - started) * 1000)
+    return body
+
+
+# ── HTTP routes ────────────────────────────────────────────────────────────
+
+
+@bp_local_query.route("/api/local/health", methods=["GET"])
+def http_health():
+    try:
+        return jsonify(_dispatch("health", {}))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 503
+
+
+@bp_local_query.route("/api/local/events", methods=["GET"])
+def http_events():
+    try:
+        args = _coerce_args("events", request.args.to_dict())
+        return jsonify(_dispatch("events", args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
+@bp_local_query.route("/api/local/sessions", methods=["GET"])
+def http_sessions():
+    try:
+        args = _coerce_args("sessions", request.args.to_dict())
+        return jsonify(_dispatch("sessions", args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
+@bp_local_query.route("/api/local/aggregates", methods=["GET"])
+def http_aggregates():
+    try:
+        args = _coerce_args("aggregates", request.args.to_dict())
+        return jsonify(_dispatch("aggregates", args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
+@bp_local_query.route("/api/local/transcript/<session_id>", methods=["GET"])
+def http_transcript(session_id: str):
+    try:
+        args = _coerce_args("transcript", {"session_id": session_id, **request.args.to_dict()})
+        return jsonify(_dispatch("transcript", args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
+@bp_local_query.route("/api/local/query", methods=["POST"])
+def http_query():
+    """Generic shape-dispatched endpoint. Mirrors the WS relay frame format,
+    so the same JSON body works over either transport.
+    POST /api/local/query  {"shape": "events", "args": {...}}
+    """
+    body = request.get_json(silent=True) or {}
+    shape = body.get("shape")
+    if shape not in _SHAPES:
+        return jsonify({"error": f"unknown shape: {shape!r}",
+                        "allowed_shapes": sorted(_SHAPES.keys())}), 400
+    try:
+        args = _coerce_args(shape, body.get("args") or {})
+        return jsonify(_dispatch(shape, args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
+# ── Public hook for the future WS relay (#960 phase B) ─────────────────────
+
+def relay_dispatch(shape: str, args: dict) -> dict:
+    """Same-process entry point the WS relay client will call when it
+    receives a `{type:"query"}` frame from the cloud. Importing this from
+    the relay module keeps the SQL/coercion logic in one place."""
+    if shape not in _SHAPES:
+        return {"error": f"unknown shape: {shape!r}"}
+    args = _coerce_args(shape, args or {})
+    return _dispatch(shape, args)

--- a/tests/test_local_query_api.py
+++ b/tests/test_local_query_api.py
@@ -1,0 +1,206 @@
+"""Tests for routes/local_query.py — the local HTTP query API over the
+DuckDB store (#960 phase A)."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+import uuid
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Flask test client wired to a fresh isolated local store."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+
+    app = Flask(__name__)
+    app.register_blueprint(lq.bp_local_query)
+    # Trigger store init + flusher start.
+    ls.get_store()
+    yield app.test_client(), ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _ev(**overrides):
+    base = {
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-A",
+        "event_type": "tool_call",
+        "ts": "2026-05-11T10:00:00Z",
+        "data": {"tool": "Bash"},
+        "cost_usd": 0.001,
+        "token_count": 12,
+        "model": "claude-opus-4-7",
+    }
+    base.update(overrides)
+    return base
+
+
+def _wait(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def test_health_endpoint(client):
+    c, _ = client
+    r = c.get("/api/local/health")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["engine"] == "duckdb"
+    assert body["_shape"] == "health"
+    assert "size_bytes" in body
+    assert "_elapsed_ms" in body
+
+
+def test_events_endpoint_returns_inserted_rows(client):
+    c, ls = client
+    store = ls.get_store()
+    for i in range(3):
+        store.ingest(_ev(id=f"ev-{i}", ts=f"2026-05-11T10:00:0{i}Z"))
+    _wait(store)
+    r = c.get("/api/local/events?session_id=sess-A&limit=10")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["count"] == 3
+    assert body["_shape"] == "events"
+    assert {row["id"] for row in body["rows"]} == {"ev-0", "ev-1", "ev-2"}
+
+
+def test_events_endpoint_filters_by_event_type(client):
+    c, ls = client
+    store = ls.get_store()
+    store.ingest(_ev(id="t1", event_type="tool_call"))
+    store.ingest(_ev(id="m1", event_type="message"))
+    _wait(store)
+    r = c.get("/api/local/events?event_type=message")
+    body = r.get_json()
+    assert [row["id"] for row in body["rows"]] == ["m1"]
+
+
+def test_sessions_endpoint(client):
+    c, ls = client
+    store = ls.get_store()
+    store.ingest(_ev(id="a", session_id="X", cost_usd=0.10))
+    store.ingest(_ev(id="b", session_id="X", cost_usd=0.20))
+    store.ingest(_ev(id="c", session_id="Y", cost_usd=0.05))
+    _wait(store)
+    r = c.get("/api/local/sessions")
+    body = r.get_json()
+    assert body["count"] == 2
+    by_sid = {s["session_id"]: s for s in body["rows"]}
+    assert by_sid["X"]["event_count"] == 2
+    assert round(by_sid["X"]["cost_usd"], 4) == 0.30
+
+
+def test_aggregates_endpoint(client):
+    c, ls = client
+    store = ls.get_store()
+    store.ingest(_ev(id="a", ts="2026-05-10T10:00:00Z", cost_usd=0.50))
+    store.ingest(_ev(id="b", ts="2026-05-11T10:00:00Z", cost_usd=0.30))
+    _wait(store)
+    r = c.get("/api/local/aggregates")
+    body = r.get_json()
+    by_day = {row["day"]: row for row in body["rows"]}
+    assert round(by_day["2026-05-10"]["cost_usd"], 4) == 0.50
+    assert round(by_day["2026-05-11"]["cost_usd"], 4) == 0.30
+
+
+def test_transcript_endpoint(client):
+    c, ls = client
+    store = ls.get_store()
+    store.ingest(_ev(id="t1", session_id="sess-T", ts="2026-05-11T10:00:00Z"))
+    store.ingest(_ev(id="t2", session_id="sess-T", ts="2026-05-11T10:00:01Z"))
+    store.ingest(_ev(id="x1", session_id="sess-OTHER"))
+    _wait(store)
+    r = c.get("/api/local/transcript/sess-T")
+    body = r.get_json()
+    assert body["count"] == 2
+    assert all(row["session_id"] == "sess-T" for row in body["rows"])
+
+
+def test_query_post_dispatches_by_shape(client):
+    c, ls = client
+    store = ls.get_store()
+    store.ingest(_ev(id="q1", session_id="sess-Q"))
+    _wait(store)
+    r = c.post(
+        "/api/local/query",
+        data=json.dumps({"shape": "events", "args": {"session_id": "sess-Q"}}),
+        content_type="application/json",
+    )
+    body = r.get_json()
+    assert body["count"] == 1
+    assert body["rows"][0]["id"] == "q1"
+
+
+def test_query_post_rejects_unknown_shape(client):
+    c, _ = client
+    r = c.post(
+        "/api/local/query",
+        data=json.dumps({"shape": "drop_table_users"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "allowed_shapes" in body
+
+
+def test_transcript_shape_requires_session_id(client):
+    c, _ = client
+    r = c.post(
+        "/api/local/query",
+        data=json.dumps({"shape": "transcript", "args": {}}),
+        content_type="application/json",
+    )
+    assert r.status_code == 500
+    assert "session_id" in r.get_json()["error"]
+
+
+def test_limit_is_clamped(client):
+    """A request asking for limit=999999 gets clamped, not an error."""
+    c, ls = client
+    store = ls.get_store()
+    for i in range(20):
+        store.ingest(_ev(id=f"clamp-{i}"))
+    _wait(store)
+    r = c.get("/api/local/events?limit=999999&session_id=sess-A")
+    assert r.status_code == 200
+
+
+def test_relay_dispatch_helper(client):
+    """The relay_dispatch() entry point — used by the future WS relay —
+    runs the same path as the HTTP endpoints. Same SQL, single source of
+    truth."""
+    c, ls = client
+    store = ls.get_store()
+    store.ingest(_ev(id="rd-1", session_id="sess-relay"))
+    _wait(store)
+    import routes.local_query as lq
+    body = lq.relay_dispatch("events", {"session_id": "sess-relay"})
+    assert body["count"] == 1
+    assert body["rows"][0]["id"] == "rd-1"
+
+
+def test_relay_dispatch_rejects_unknown_shape():
+    import routes.local_query as lq
+    body = lq.relay_dispatch("nope", {})
+    assert "error" in body


### PR DESCRIPTION
Phase A of #960 — local DuckDB store now has a clean HTTP surface mirroring `/api/cloud/*` shapes. Sets up the contract the WS relay (phase B follow-up) will tunnel.

## Endpoints
- GET /api/local/health · /events · /sessions · /aggregates · /transcript/<sid>
- POST /api/local/query — same {shape, args} body as the future WS relay frame format

## Single dispatch source
All routes funnel through `_dispatch(shape, args)`. `relay_dispatch()` exposes the same path for the future WS client. Allowlisted shapes only — cloud relay can never run arbitrary SQL on user's local DuckDB.

## Tests
12/12 passing.

## Out of scope (#960 phase B)
WS relay client + cloud broker. Follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)