### PR TITLE
feat(relay): node-side WS relay client (epic #964 phase 3b)

### DIFF
--- a/clawmetry/relay.py
+++ b/clawmetry/relay.py
@@ -1,0 +1,221 @@
+"""clawmetry/relay.py — node-side WebSocket relay client (epic #964 phase 3b).
+
+Maintains a long-lived WebSocket to `wss://app.clawmetry.com/api/node/relay`,
+waits for `{type:"query"}` frames from the cloud, dispatches each via
+`routes.local_query.relay_dispatch()`, returns chunked responses.
+
+Design notes
+------------
+- **Optional dependency.** `websocket-client` is in `extras_require["relay"]`,
+  not the base install. If it's missing the relay simply doesn't start; the
+  daemon keeps working in cloud-ingest-only mode.
+- **Daemon thread.** One thread per process. Reconnects with exponential
+  backoff (2s → 60s cap). The sync daemon's main loop is unaware.
+- **Skipped on OSS-local mode.** If `config` has no `api_key` / `node_id`,
+  the relay never starts — local-only OSS users pay no overhead.
+- **Privacy boundary unchanged.** Encrypted blobs stay encrypted; plaintext
+  columns (token counts, timestamps, event types) ride the WS in the clear
+  (TLS-protected). Same trust model as today's heartbeat / ingest.
+
+Tests live in `tests/test_relay.py` and mock the WebSocket layer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+RELAY_URL_DEFAULT = "wss://app.clawmetry.com/api/node/relay"
+CHUNK_ROWS = 100               # max rows per response frame
+RECONNECT_INITIAL_SEC = 2
+RECONNECT_MAX_SEC = 60
+RECV_TIMEOUT_SEC = 30          # forces a heartbeat ping when idle
+
+# Shapes the node advertises in its register frame. Mirrors the allowlist in
+# `routes/local_query._SHAPES` — keep these in sync.
+_CAPABILITIES = [
+    "query.events",
+    "query.sessions",
+    "query.aggregates",
+    "query.transcript",
+    "query.health",
+]
+
+
+def start_relay_thread(config: dict, version: str = "unknown") -> Optional[threading.Thread]:
+    """Spin up a daemon thread that maintains the WS to cloud.
+
+    Returns the thread object on success, ``None`` when relay can't or
+    shouldn't run (no cloud account, `websocket-client` missing). Callers
+    don't need to do anything with the returned thread — it's daemon=True.
+    """
+    api_key = (config or {}).get("api_key")
+    node_id = (config or {}).get("node_id")
+    if not api_key or not node_id:
+        log.debug("relay: no cloud account (api_key/node_id missing) — relay disabled")
+        return None
+    try:
+        import websocket  # noqa: F401 — pull dep early to fail fast
+    except ImportError:
+        log.info(
+            "relay: websocket-client not installed; cloud cold-data relay disabled. "
+            "Install with `pip install clawmetry[relay]` to enable.")
+        return None
+
+    relay_url = os.environ.get("CLAWMETRY_RELAY_URL", RELAY_URL_DEFAULT)
+    t = threading.Thread(
+        target=_relay_supervisor,
+        args=(relay_url, api_key, node_id, version),
+        daemon=True,
+        name="clawmetry-relay",
+    )
+    t.start()
+    log.info("relay: thread started → %s", relay_url)
+    return t
+
+
+def _relay_supervisor(relay_url: str, api_key: str, node_id: str, version: str) -> None:
+    """Reconnect loop. Each call to `_run_once` is one WS session; on any
+    exception we backoff and retry. Backoff resets after a clean exit."""
+    backoff = RECONNECT_INITIAL_SEC
+    while True:
+        try:
+            _run_once(relay_url, api_key, node_id, version)
+            # Clean exit (server closed gracefully) — reset backoff.
+            backoff = RECONNECT_INITIAL_SEC
+            log.info("relay: connection closed by server; reconnecting in %ds", backoff)
+            time.sleep(backoff)
+        except Exception as e:  # noqa: BLE001 — any failure → retry
+            log.warning("relay: error: %s — reconnecting in %ds", str(e)[:200], backoff)
+            time.sleep(backoff)
+            backoff = min(backoff * 2, RECONNECT_MAX_SEC)
+
+
+def _run_once(relay_url: str, api_key: str, node_id: str, version: str) -> None:
+    """One full WS session lifecycle: connect → register → dispatch
+    incoming frames → return. Raises on any networking failure so the
+    supervisor's backoff loop kicks in."""
+    import websocket
+    url = f"{relay_url}?token={api_key}&node_id={node_id}"
+    ws = websocket.create_connection(
+        url,
+        header=[f"User-Agent: clawmetry-relay/{version}"],
+        timeout=10,
+    )
+    try:
+        # Register frame announces capabilities so the cloud knows which
+        # shapes are safe to route to this node.
+        ws.send(json.dumps({
+            "type": "register",
+            "node_id": node_id,
+            "version": version,
+            "capabilities": _CAPABILITIES,
+        }))
+        ws.settimeout(RECV_TIMEOUT_SEC)
+        while True:
+            try:
+                raw = ws.recv()
+            except websocket.WebSocketTimeoutException:
+                # No traffic in RECV_TIMEOUT_SEC — send our own ping so the
+                # cloud LB doesn't drop us as idle (Cloud Run idle = 5 min).
+                try:
+                    ws.ping()
+                except Exception:
+                    raise
+                continue
+            if not raw:
+                # Empty payload = server requested close.
+                return
+            try:
+                frame = json.loads(raw)
+            except Exception:
+                log.warning("relay: dropping non-JSON frame")
+                continue
+            _handle_frame(ws, frame)
+    finally:
+        try:
+            ws.close()
+        except Exception:
+            pass
+
+
+def _handle_frame(ws, frame: dict) -> None:
+    """Single-frame dispatcher. `ws` is a live websocket.WebSocket."""
+    ftype = frame.get("type")
+    if ftype == "query":
+        _handle_query(ws, frame)
+    elif ftype == "ping":
+        try:
+            ws.send(json.dumps({"type": "pong"}))
+        except Exception:
+            raise
+    else:
+        log.debug("relay: ignoring frame type=%r", ftype)
+
+
+def _handle_query(ws, frame: dict) -> None:
+    """Dispatch a `query` frame through the same path the HTTP API uses,
+    chunk-stream the response back. All errors → `{type:"error"}` frame
+    so the cloud can surface them cleanly."""
+    qid = frame.get("id")
+    shape = frame.get("shape", "")
+    args = frame.get("args") or {}
+
+    try:
+        from routes.local_query import relay_dispatch
+        body = relay_dispatch(shape, args)
+    except Exception as e:  # noqa: BLE001
+        _send_error(ws, qid, "dispatch_exception", str(e)[:300])
+        return
+
+    if isinstance(body, dict) and "error" in body and "rows" not in body:
+        _send_error(ws, qid, "dispatch_error", body["error"])
+        return
+
+    rows = body.get("rows") if isinstance(body, dict) else None
+
+    if not rows:
+        # Single-frame response (health shape, empty result, etc.)
+        ws.send(json.dumps({
+            "type": "response",
+            "id": qid,
+            "chunk": 1,
+            "final": True,
+            "body": body,
+        }))
+        return
+
+    total = len(rows)
+    chunk_count = (total + CHUNK_ROWS - 1) // CHUNK_ROWS
+    for i in range(chunk_count):
+        sl = rows[i * CHUNK_ROWS:(i + 1) * CHUNK_ROWS]
+        is_final = (i == chunk_count - 1)
+        out = {
+            "type": "response",
+            "id": qid,
+            "chunk": i + 1,
+            "final": is_final,
+            "rows": sl,
+        }
+        if is_final:
+            # Carry shape + count metadata on the final frame so the cloud
+            # can validate completeness without re-iterating chunks.
+            out["_shape"] = body.get("_shape")
+            out["_elapsed_ms"] = body.get("_elapsed_ms")
+            out["count"] = body.get("count", total)
+        ws.send(json.dumps(out))
+
+
+def _send_error(ws, qid, code: str, msg: str) -> None:
+    try:
+        ws.send(json.dumps({"type": "error", "id": qid, "code": code, "msg": msg}))
+    except Exception:
+        # If the WS itself is dead, the supervisor loop will catch it on
+        # the next recv() and reconnect — nothing to do here.
+        log.debug("relay: failed to send error frame for qid=%s", qid)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3416,6 +3416,18 @@ def run_daemon() -> None:
     send_heartbeat(config)
     log.info("Initial heartbeat sent")
 
+    # ── Cloud cold-data relay (epic #964 phase 3b) ─────────────────────
+    # Long-lived WS to wss://app.clawmetry.com/api/node/relay so the cloud
+    # dashboard can request data older than its 24h hot window without us
+    # paying for permanent storage. No-op if the user hasn't connected to
+    # cloud or the optional `websocket-client` dep is missing — degrades
+    # gracefully to today's cloud-ingest-only behavior.
+    try:
+        from clawmetry import relay as _relay
+        _relay.start_relay_thread(config, version=_get_version())
+    except Exception as _e:
+        log.warning("relay: failed to start (continuing without cold-data relay): %s", _e)
+
     state = load_state()
 
     # Always sync recent events first (last hour) — makes the dashboard

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,11 @@ setup(
         "duckdb>=0.10",
     ],
     extras_require={
-        "otel": ["opentelemetry-proto>=1.20.0", "protobuf>=4.21.0"],
+        "otel":  ["opentelemetry-proto>=1.20.0", "protobuf>=4.21.0"],
+        # Cloud cold-data relay tunnel (epic #964 phase 3b). Optional —
+        # if missing, the daemon runs in cloud-ingest-only mode and the
+        # cloud dashboard can't request data older than its 24h window.
+        "relay": ["websocket-client>=1.6"],
     },
     entry_points={
         "console_scripts": [

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,0 +1,180 @@
+"""Tests for clawmetry/relay.py — node-side WebSocket relay client.
+
+The relay's networking is mocked end-to-end. We're testing the dispatch +
+chunking logic, not the actual websocket-client library.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _install_fake_websocket():
+    """Install a minimal stub of `websocket-client` so tests don't depend
+    on the optional dep being installed in CI."""
+    if "websocket" in sys.modules:
+        return sys.modules["websocket"]
+    fake = types.ModuleType("websocket")
+    class WebSocketTimeoutException(Exception):
+        pass
+    fake.WebSocketTimeoutException = WebSocketTimeoutException
+    fake.create_connection = MagicMock()
+    sys.modules["websocket"] = fake
+    return fake
+
+
+@pytest.fixture
+def fake_ws(monkeypatch):
+    """Return a MagicMock standing in for a connected WebSocket."""
+    _install_fake_websocket()
+    ws = MagicMock(name="WebSocket")
+    return ws
+
+
+def _send_payloads(ws):
+    """Return list of dicts the relay sent on `ws.send()` calls."""
+    return [json.loads(c.args[0]) for c in ws.send.call_args_list]
+
+
+def test_start_relay_thread_skips_when_no_cloud_account():
+    from clawmetry import relay
+    importlib.reload(relay)
+    assert relay.start_relay_thread({}) is None
+    assert relay.start_relay_thread({"node_id": "x"}) is None
+    assert relay.start_relay_thread({"api_key": "y"}) is None
+
+
+def test_start_relay_thread_skips_when_websocket_missing(monkeypatch):
+    from clawmetry import relay
+    importlib.reload(relay)
+    # Force the import inside start_relay_thread() to fail.
+    sys.modules.pop("websocket", None)
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+    def fake_import(name, *a, **k):
+        if name == "websocket":
+            raise ImportError("forced")
+        return real_import(name, *a, **k)
+    monkeypatch.setitem(__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__, "__import__", fake_import) if isinstance(__builtins__, dict) else monkeypatch.setattr("builtins.__import__", fake_import)
+    assert relay.start_relay_thread({"api_key": "k", "node_id": "n"}) is None
+
+
+def test_handle_query_dispatches_via_local_query(fake_ws, tmp_path, monkeypatch):
+    """End-to-end of the dispatch path: relay calls relay_dispatch(),
+    chunks the response, sends it back over the (fake) WS."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    from clawmetry import relay
+    importlib.reload(relay)
+
+    # Seed one event so the events shape returns something.
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-relay-1",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-relay",
+        "event_type": "tool_call",
+        "ts": "2026-05-11T12:00:00Z",
+        "data": {"tool": "Bash"},
+        "cost_usd": 0.001,
+        "token_count": 5,
+        "model": "claude-opus-4-7",
+    })
+    # Wait for flush.
+    import time
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and store.health()["ring_depth"] > 0:
+        time.sleep(0.02)
+
+    relay._handle_query(fake_ws, {
+        "type": "query",
+        "id": "q-1",
+        "shape": "events",
+        "args": {"session_id": "sess-relay"},
+    })
+
+    payloads = _send_payloads(fake_ws)
+    assert len(payloads) == 1
+    response = payloads[0]
+    assert response["type"] == "response"
+    assert response["id"] == "q-1"
+    assert response["final"] is True
+    assert response["count"] == 1
+    assert response["rows"][0]["id"] == "ev-relay-1"
+
+
+def test_handle_query_chunks_large_results(fake_ws, monkeypatch):
+    """Force >100 rows and confirm we send N chunks with final=True only on the last."""
+    from clawmetry import relay
+    importlib.reload(relay)
+
+    # Stub relay_dispatch to return 250 rows.
+    fake_rows = [{"id": f"ev-{i}"} for i in range(250)]
+    def fake_dispatch(shape, args):
+        return {"_shape": shape, "_elapsed_ms": 1, "rows": fake_rows, "count": 250}
+    monkeypatch.setattr("routes.local_query.relay_dispatch", fake_dispatch)
+
+    relay._handle_query(fake_ws, {"id": "q-2", "shape": "events", "args": {}})
+
+    payloads = _send_payloads(fake_ws)
+    assert len(payloads) == 3   # 100 + 100 + 50
+    assert payloads[0]["chunk"] == 1 and payloads[0]["final"] is False
+    assert payloads[1]["chunk"] == 2 and payloads[1]["final"] is False
+    assert payloads[2]["chunk"] == 3 and payloads[2]["final"] is True
+    assert payloads[2]["count"] == 250
+    assert len(payloads[0]["rows"]) == 100
+    assert len(payloads[2]["rows"]) == 50
+
+
+def test_handle_query_unknown_shape_returns_error(fake_ws):
+    from clawmetry import relay
+    importlib.reload(relay)
+    relay._handle_query(fake_ws, {"id": "q-3", "shape": "drop_table_users", "args": {}})
+    p = _send_payloads(fake_ws)
+    assert len(p) == 1
+    assert p[0]["type"] == "error"
+    assert p[0]["id"] == "q-3"
+    assert "code" in p[0]
+
+
+def test_handle_frame_responds_to_ping(fake_ws):
+    from clawmetry import relay
+    importlib.reload(relay)
+    relay._handle_frame(fake_ws, {"type": "ping"})
+    p = _send_payloads(fake_ws)
+    assert p == [{"type": "pong"}]
+
+
+def test_handle_frame_ignores_unknown_types(fake_ws):
+    from clawmetry import relay
+    importlib.reload(relay)
+    relay._handle_frame(fake_ws, {"type": "weather_report"})
+    assert fake_ws.send.call_count == 0
+
+
+def test_capabilities_match_local_query_shapes():
+    """If a new shape is added to routes/local_query._SHAPES, the relay
+    must advertise it too — otherwise the cloud thinks the node can't
+    serve it."""
+    from clawmetry import relay
+    import routes.local_query as lq
+    importlib.reload(relay)
+    importlib.reload(lq)
+    advertised = {c.split(".", 1)[1] for c in relay._CAPABILITIES}
+    actual = set(lq._SHAPES.keys())
+    assert advertised == actual, (
+        f"relay capabilities drift from _SHAPES — "
+        f"missing in relay: {actual - advertised}; "
+        f"missing in _SHAPES: {advertised - actual}"
+    )


### PR DESCRIPTION
## Summary
- Adds \`clawmetry/relay.py\` — long-lived WebSocket to \`wss://app.clawmetry.com/api/node/relay\`. Listens for \`{type:\"query\"}\` frames, dispatches via the same \`relay_dispatch()\` the local HTTP API uses, returns chunked responses.
- Wires it into the sync daemon's startup (no-op if no cloud account or \`websocket-client\` missing).
- Adds \`websocket-client\` as \`extras_require[\"relay\"]\` — base install unchanged.
- 8 new tests in \`tests/test_relay.py\` covering dispatch, chunking, error frames, capability drift.

This is **phase 3b** of epic #964. The cloud broker side (\`/api/node/relay\` WS endpoint + \`/api/cloud/relay/<shape>\`) is the next PR (#961, in clawmetry-cloud).

## Why
Without the WS tunnel, the cloud dashboard can only show data that's in its 24h hot window. With it, asking for older data triggers a relay frame to the user's node, which streams the result back from the local DuckDB store. Cloud storage cost stops scaling with time.

## Test plan
- [x] \`pytest tests/test_relay.py\` — 8/8 pass
- [x] \`pytest tests/test_local_query_api.py tests/test_local_store.py tests/test_relay.py\` — 42/42 pass
- [ ] Manual: install \`pip install -e .[relay]\`, run \`clawmetry sync\`, watch for \`relay: connected to\` in logs (will fail to actually connect until cloud broker is up — expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)