### PR TITLE
feat(local-store): heartbeat health field + brain fast path (epic #964 phase 1b)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1649,6 +1649,23 @@ def send_heartbeat(config: dict) -> bool:
     sec = _collect_security_posture()
     if sec is not None:
         payload["security_posture"] = sec
+    # Local-store health (epic #964 phase 1 → rollout gate for phase 2).
+    # We need ≥80% of active nodes reporting healthy local stores before
+    # slimming cloud retention to 24h. Best-effort; never blocks heartbeat.
+    try:
+        from clawmetry import local_store
+        h = local_store.get_store().health()
+        payload["local_store"] = {
+            "engine":       h.get("engine"),
+            "size_bytes":   h.get("size_bytes", 0),
+            "events_total": h.get("events_total", 0),
+            "ring_depth":   h.get("ring_depth", 0),
+        }
+        # Convenience field the cloud rollout playbook can group/aggregate on.
+        size_mb = (h.get("size_bytes") or 0) / (1024 * 1024)
+        payload["local_store_size_mb"] = round(size_mb, 3)
+    except Exception:
+        pass  # local store optional — never break heartbeat over it
     last_err = None
     for attempt in range(3):
         try:

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -33,6 +33,64 @@ def _brain_history_bool_arg(value):
     return str(value or "").strip().lower() in {"1", "true", "yes", "on", "all"}
 
 
+def _try_local_store_brain(limit: int, include_artifacts: bool):
+    """Epic #964 phase 1b fast path. Returns a brain-history-shaped dict
+    when CLAWMETRY_LOCAL_STORE_READ=1 AND the local DuckDB store has
+    enough events to be useful. Returns ``None`` to defer to the JSONL
+    parser so the caller can fall through cleanly.
+
+    The shape returned is intentionally a SUBSET of the JSONL parser's
+    rich UI metadata — channel icons, source labels, etc. are not yet
+    enriched here. The full read-path migration is a follow-up; this
+    is a measurable proof that the local store is the right answer for
+    the simple list-of-events case.
+    """
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return None
+    try:
+        store = local_store.get_store()
+        rows = store.query_events(limit=limit)
+    except Exception:
+        return None
+    if not rows:
+        # Empty store → fall through to JSONL parser so a fresh install
+        # without a populated local DB still gets a useful brain feed.
+        return None
+    # Translate the local-store row shape (id/node_id/agent_id/session_id/
+    # event_type/ts/data/cost_usd/...) into the brain-history event shape
+    # the dashboard JS expects (time/type/detail/src/sessionId/...).
+    out = []
+    for r in rows:
+        data = r.get("data") if isinstance(r, dict) else None
+        # `data` from query_events is already JSON-parsed when valid, or a
+        # str/None otherwise — see local_store.query_events.
+        detail = ""
+        if isinstance(data, dict):
+            detail = (data.get("input") or data.get("summary")
+                      or data.get("text") or data.get("name") or "")
+        elif isinstance(data, str):
+            detail = data
+        out.append({
+            "time":       r.get("ts", ""),
+            "type":       (r.get("event_type") or "").upper(),
+            "detail":     str(detail)[:200],
+            "src":        (r.get("session_id") or r.get("agent_id") or "")[:32],
+            "sessionId":  r.get("session_id") or "",
+            "agentId":    r.get("agent_id") or "main",
+            "tokens":     r.get("token_count") or 0,
+            "cost":       float(r.get("cost_usd") or 0.0),
+            "model":      r.get("model") or "",
+        })
+    return {
+        "events":  out,
+        "count":   len(out),
+        "_source": "local_store",
+        "_shape":  "brain_history",
+    }
+
+
 def _brain_history_is_artifact(path):
     name = os.path.basename(path)
     return name.endswith(".trajectory.jsonl") or ".checkpoint." in name
@@ -76,6 +134,14 @@ def api_brain_history():
     include_artifacts = _brain_history_bool_arg(
         request.args.get("include_artifacts") or request.args.get("artifacts")
     )
+    # Epic #964 phase 1b: opt-in local-store fast path. Skip the JSONL
+    # parser entirely when CLAWMETRY_LOCAL_STORE_READ=1 AND the store
+    # has data. Falls through to the full parser otherwise (so a fresh
+    # install with an empty store still gets the rich brain feed).
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_brain(limit, include_artifacts)
+        if fast is not None:
+            return jsonify(fast)
     cache_key = (limit, include_artifacts)
     cached = _BRAIN_HISTORY_CACHE.get(cache_key)
     now_cache = time.time()

--- a/tests/test_brain_local_fastpath.py
+++ b/tests/test_brain_local_fastpath.py
@@ -1,0 +1,124 @@
+"""Tests for epic #964 phase 1b — local-store fast path on /api/brain-history.
+
+The fast path is opt-in via CLAWMETRY_LOCAL_STORE_READ=1 so the legacy
+JSONL parser stays the default until ≥80% adoption (epic's gate).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.brain as br
+    importlib.reload(br)
+
+    a = Flask(__name__)
+    a.register_blueprint(br.bp_brain)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def test_brain_fast_path_returns_local_store_events(app):
+    a, ls = app
+    store = ls.get_store()
+    for i in range(5):
+        store.ingest({
+            "id": f"ev-fast-{i}",
+            "node_id": "agent+test",
+            "agent_id": "main",
+            "session_id": "sess-fast",
+            "event_type": "tool_call",
+            "ts": f"2026-05-11T12:00:0{i}Z",
+            "data": {"tool": "Bash", "input": f"echo hello-{i}"},
+            "cost_usd": 0.001,
+            "token_count": 10,
+            "model": "claude-opus-4-7",
+        })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/brain-history?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    # The fast path tags responses so we can verify no JSONL fallback ran.
+    assert body.get("_source") == "local_store"
+    assert body["count"] == 5
+    types = {ev["type"] for ev in body["events"]}
+    assert "TOOL_CALL" in types
+    # session_id maps to both src and sessionId
+    assert all(ev["sessionId"] == "sess-fast" for ev in body["events"])
+
+
+def test_brain_fast_path_falls_back_when_store_empty(app):
+    """Empty store → fast path returns None so JSONL parser runs.
+    We can't easily exercise the full JSONL parser in unit tests
+    (needs ~/.openclaw fixture), so we just verify the fast path
+    *defers* by returning the JSONL endpoint's typical shape (no
+    `_source: local_store` tag)."""
+    a, _ls = app
+    c = a.test_client()
+    r = c.get("/api/brain-history?limit=10")
+    assert r.status_code == 200
+    body = r.get_json()
+    # Fast path returned None → fell through to legacy parser, which
+    # does NOT add the _source tag.
+    assert body.get("_source") != "local_store"
+
+
+def test_brain_fast_path_disabled_without_env_flag(tmp_path, monkeypatch):
+    """No CLAWMETRY_LOCAL_STORE_READ → fast path never runs, even with
+    populated store. Defaults to legacy JSONL behavior so existing
+    deploys see zero change without explicit opt-in."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.brain as br
+    importlib.reload(br)
+
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-noflag",
+        "node_id": "agent+test", "agent_id": "main", "session_id": "sess-x",
+        "event_type": "tool_call", "ts": "2026-05-11T12:00:00Z",
+        "data": {"tool": "Bash"}, "cost_usd": 0.001, "token_count": 5,
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    a = Flask(__name__)
+    a.register_blueprint(br.bp_brain)
+    r = a.test_client().get("/api/brain-history?limit=10")
+    body = r.get_json()
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
Two minimal but load-bearing additions for epic #964:

1. **Heartbeat now reports \`local_store\` health + \`local_store_size_mb\`** — the field the cloud-side rollout playbook will group/aggregate on. The epic gates Phase 2 (cloud retention slim → 24h) on **≥80% of active nodes reporting a healthy local store**. Now we have the metric.
2. **\`/api/brain-history\` opt-in fast path under \`CLAWMETRY_LOCAL_STORE_READ=1\`** — when set AND the local DuckDB has events, return directly from the store (tagged \`_source: \"local_store\"\`) instead of re-parsing JSONL. Falls through to the legacy parser when the env var is unset OR the store is empty (so a fresh install still gets the rich brain feed).

## Why minimal
A full read-path migration of \`brain-history\` (300+ lines of UI metadata enrichment — channel icons, source labels, subagent metadata) is its own multi-day PR. That's a follow-up issue. The two pieces in this PR are what's needed to **safely** ship Phase 2 later — the metric for the rollout gate, and proof that the local store is the right answer for the simple list-of-events case.

## Out of scope (follow-ups)
- Full \`brain-history\` UI enrichment migration to local store
- \`/api/sessions\`, \`/api/transcripts\` same-pattern fast paths
- Backfill: the local store only has events ingested AFTER 0.12.164 install. A one-shot \`clawmetry backfill\` command to import existing JSONL would be useful but is not blocking.

## Test plan
- [x] \`pytest tests/test_brain_local_fastpath.py\` — 3/3
- [x] \`pytest tests/test_brain_local_fastpath.py tests/test_local_store.py tests/test_local_query_api.py tests/test_local_store_sync_integration.py\` — 42/42
- [ ] Manual: install + run, hit \`http://localhost:8900/api/brain-history\` with and without \`CLAWMETRY_LOCAL_STORE_READ=1\`, verify \`_source\` tag flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)