### PR TITLE
[RELEASE] feat(relay): WS client + heartbeat health + brain fast path (epic #964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## [Unreleased]
 
-### Local-first foundation (epic #964 phase 1)
+### Local-first relay (epic #964 phase 3b + 1b)
+- **Daemon-side WebSocket relay client** (`clawmetry/relay.py`) — long-lived WS to `wss://app.clawmetry.com/api/node/relay`. Listens for `{type:"query"}` frames from the cloud, dispatches via the same `relay_dispatch()` the local HTTP API uses, returns chunked responses. Reconnect with exponential backoff (2s → 60s cap). Skipped silently when no cloud account is configured (OSS-local users pay nothing).
+- **Optional dependency** — `websocket-client>=1.6` is in `extras_require["relay"]`, not the base install. `pip install clawmetry[relay]` to opt in. Daemon falls back to cloud-ingest-only mode when missing.
+- **Heartbeat now reports `local_store_size_mb`** + `local_store` health block (engine, size_bytes, events_total, ring_depth). The cloud-side rollout playbook gates phase 2 (cloud retention slim) on ≥80% adoption of this signal.
+- **Brain history opt-in fast path** — `CLAWMETRY_LOCAL_STORE_READ=1` makes `/api/brain-history` return directly from local DuckDB (tagged `_source: "local_store"`) instead of re-parsing JSONL. Falls through to legacy parser if env var unset OR store is empty — zero-change default.
+- 11 new tests cover relay dispatch, chunking, error frames, capability drift, brain fast path, and JSONL fallback.
+
+### Local-first foundation (epic #964 phase 1) — first shipped in 0.12.164
 - **Local DuckDB event store** at `~/.clawmetry/events.duckdb` — durable record of every telemetry event the daemon parses. Switched from SQLite to DuckDB (decision in clawmetry-cloud meta-PRD): columnar storage makes the dashboard's GROUP BY / time-window analytics 10–100× faster, and unlocks future Parquet export. Adds `duckdb>=0.10` as a dependency.
 - **Daemon writes through to local store** at parse time — local is now the source of truth, cloud is a hot cache. Failures in the local path never block cloud sync.
 - **Two new diagnostic endpoints** — `/api/local-store/health` and `/api/local-store/events` for verification + test harnesses


### PR DESCRIPTION
## Release: 0.12.164 → 0.12.165

Bundles the OSS half of epic #964's relay protocol shipped this morning.

### What's in this release
- **Daemon WS relay client** (\`clawmetry/relay.py\`) — long-lived WS to \`wss://app.clawmetry.com/api/node/relay\`. Cloud dashboard can now request data older than its 24h hot window via the relay. (PR #992)
- **Heartbeat reports \`local_store_size_mb\`** — the metric the cloud-side rollout playbook gates phase 2 (cloud retention slim) on. (PR #993)
- **\`/api/brain-history\` opt-in fast path** — \`CLAWMETRY_LOCAL_STORE_READ=1\` returns from local DuckDB instead of re-parsing JSONL. (PR #993)

Cloud half (broker, SWR helper, fleet fan-out) is already live at app.clawmetry.com via clawmetry-cloud PRs #705, #706, #708.

### What this enables
- Cloud users: dashboard can show data older than the 24h hot window without us paying for permanent cloud storage. The relay tunnel makes the user's own machine the durable record.
- OSS users: zero behavior change — relay only starts if a cloud account is configured.
- Cloud ops: heartbeat field unblocks the rollout gate for phase 2 (cloud retention slim → 24h, ~10–50× smaller \`events\` table per user).

### Optional dep
\`websocket-client\` is in \`extras_require[\"relay\"]\`. Existing users get nothing new in their base install. Power users / cloud users who want cold-data access install with \`pip install clawmetry[relay]\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)