### PR TITLE
feat(local-store): multi-agent schema — sessions/memory/heartbeats (PR 1 of 3)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -73,12 +73,27 @@ LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+
+# ── Two-layer schema (multi-agent) ──────────────────────────────────────────
+#
+# Layer 1: shared core. Every agent (OpenClaw, Claude Code, Hermes, Cursor,
+# Codex, Aider, …) writes here. `agent_type` is the discriminator.
+#
+# Layer 2: agent-specific extensions. Only added when a concept is unique to
+# one agent OR shared by 2+. Keeps the columnar tables clean of NULL columns
+# we'd otherwise carry to support every framework's quirks.
+#
+# Discriminator: `agent_type` is the FRAMEWORK (openclaw/claude_code/hermes/
+# cursor/codex/aider). `agent_id` (already on events) is the INSTANCE within
+# that framework (main/subagent/cron). Both coexist.
 
 _DDL = [
+    # ── Layer 1: shared core ─────────────────────────────────────────────────
     """
     CREATE TABLE IF NOT EXISTS events (
         id            VARCHAR PRIMARY KEY,
+        agent_type    VARCHAR NOT NULL DEFAULT 'openclaw',
         node_id       VARCHAR NOT NULL,
         agent_id      VARCHAR NOT NULL DEFAULT 'main',
         session_id    VARCHAR,
@@ -96,8 +111,32 @@ _DDL = [
     "CREATE INDEX IF NOT EXISTS idx_events_session     ON events(session_id, ts)",
     "CREATE INDEX IF NOT EXISTS idx_events_agent_ts    ON events(agent_id, ts)",
     "CREATE INDEX IF NOT EXISTS idx_events_type_ts     ON events(event_type, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_events_atype_ts    ON events(agent_type, ts)",
+    """
+    CREATE TABLE IF NOT EXISTS sessions (
+        agent_type      VARCHAR NOT NULL DEFAULT 'openclaw',
+        session_id      VARCHAR NOT NULL,
+        node_id         VARCHAR,
+        agent_id        VARCHAR DEFAULT 'main',
+        workspace_id    VARCHAR,
+        title           VARCHAR,
+        started_at      VARCHAR,
+        last_active_at  VARCHAR,
+        ended_at        VARCHAR,
+        status          VARCHAR,
+        total_tokens    INTEGER DEFAULT 0,
+        cost_usd        DOUBLE DEFAULT 0,
+        message_count   INTEGER DEFAULT 0,
+        metadata        BLOB,
+        updated_at      BIGINT NOT NULL,
+        PRIMARY KEY (agent_type, session_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_sessions_active    ON sessions(agent_type, last_active_at)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_node      ON sessions(node_id, last_active_at)",
     """
     CREATE TABLE IF NOT EXISTS daily_aggregates (
+        agent_type    VARCHAR NOT NULL DEFAULT 'openclaw',
         agent_id      VARCHAR NOT NULL,
         workspace_id  VARCHAR,
         day           VARCHAR NOT NULL,
@@ -105,7 +144,90 @@ _DDL = [
         token_count   INTEGER DEFAULT 0,
         event_count   INTEGER DEFAULT 0,
         error_count   INTEGER DEFAULT 0,
-        PRIMARY KEY (agent_id, workspace_id, day)
+        PRIMARY KEY (agent_type, agent_id, workspace_id, day)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS memory_blobs (
+        agent_type    VARCHAR NOT NULL,
+        agent_id      VARCHAR NOT NULL DEFAULT 'main',
+        path          VARCHAR NOT NULL,
+        ts            VARCHAR,
+        blob          BLOB,
+        sha256        VARCHAR,
+        size_bytes    INTEGER,
+        updated_at    BIGINT NOT NULL,
+        PRIMARY KEY (agent_type, agent_id, path)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS heartbeats (
+        agent_type        VARCHAR NOT NULL DEFAULT 'openclaw',
+        node_id           VARCHAR NOT NULL,
+        ts                VARCHAR NOT NULL,
+        version           VARCHAR,
+        e2e               BOOLEAN,
+        size_mb           DOUBLE,
+        events_total      INTEGER,
+        data              BLOB,
+        PRIMARY KEY (agent_type, node_id, ts)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_heartbeats_node_ts ON heartbeats(node_id, ts)",
+    """
+    CREATE TABLE IF NOT EXISTS system_snapshots (
+        agent_type    VARCHAR NOT NULL DEFAULT 'openclaw',
+        node_id       VARCHAR NOT NULL,
+        ts            VARCHAR NOT NULL,
+        kind          VARCHAR NOT NULL,
+        data          BLOB,
+        PRIMARY KEY (agent_type, node_id, ts, kind)
+    )
+    """,
+    # ── Layer 2: agent-specific extensions ───────────────────────────────────
+    # OpenClaw-only: channel context (Telegram/Slack/...). Other agents don't
+    # have this; keeping it out of `sessions` avoids 5 NULL columns per row.
+    """
+    CREATE TABLE IF NOT EXISTS openclaw_channels (
+        session_id    VARCHAR PRIMARY KEY,
+        channel       VARCHAR,
+        chat_type     VARCHAR,
+        subject       VARCHAR,
+        origin_label  VARCHAR
+    )
+    """,
+    # Shared by OpenClaw + Hermes (and any future cron-supporting agent).
+    """
+    CREATE TABLE IF NOT EXISTS crons (
+        agent_type     VARCHAR NOT NULL,
+        cron_id        VARCHAR NOT NULL,
+        agent_id       VARCHAR DEFAULT 'main',
+        name           VARCHAR,
+        schedule       VARCHAR,
+        enabled        BOOLEAN,
+        last_run_at    VARCHAR,
+        last_status    VARCHAR,
+        next_run_at    VARCHAR,
+        data           BLOB,
+        updated_at     BIGINT NOT NULL,
+        PRIMARY KEY (agent_type, cron_id)
+    )
+    """,
+    # Shared by OpenClaw subagents + Claude Code Task tool.
+    """
+    CREATE TABLE IF NOT EXISTS subagents (
+        agent_type        VARCHAR NOT NULL,
+        subagent_id       VARCHAR NOT NULL,
+        parent_session_id VARCHAR,
+        spawned_at        VARCHAR,
+        ended_at          VARCHAR,
+        task              VARCHAR,
+        status            VARCHAR,
+        cost_usd          DOUBLE DEFAULT 0,
+        token_count       INTEGER DEFAULT 0,
+        data              BLOB,
+        updated_at        BIGINT NOT NULL,
+        PRIMARY KEY (agent_type, subagent_id)
     )
     """,
     """
@@ -115,6 +237,62 @@ _DDL = [
     )
     """,
 ]
+
+
+# ── Schema migrations (v1 → v2) ────────────────────────────────────────────
+#
+# DuckDB doesn't support `ALTER TABLE ADD COLUMN IF NOT EXISTS` cleanly, so
+# we check pg_tables-style introspection and run ALTERs only when needed.
+# Idempotent: safe to call on a v2 store.
+
+_MIGRATIONS_V2 = [
+    # Existing 0.12.164 stores have `events` without agent_type — backfill it
+    # to 'openclaw' (the only agent that wrote anything in v1).
+    ("events", "agent_type", "VARCHAR DEFAULT 'openclaw'"),
+    # daily_aggregates also gains agent_type. The PK change is the tricky part —
+    # DuckDB won't let us alter the PK in place. v1 stores will keep their old
+    # PK (agent_id, workspace_id, day); writes from v2 use ON CONFLICT DO
+    # UPDATE on the PK that exists. New stores get the v2 PK directly.
+    ("daily_aggregates", "agent_type", "VARCHAR DEFAULT 'openclaw'"),
+]
+
+
+def _apply_migrations(conn) -> None:
+    """Add columns missing from a v1 store. Idempotent. Tolerant of
+    tables not existing yet (fresh stores have nothing to migrate)."""
+    # Get the set of tables that currently exist; skip migrations for any
+    # table that doesn't.
+    existing_tables = {
+        row[0] for row in conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema='main'"
+        ).fetchall()
+    }
+    for table, col, decl in _MIGRATIONS_V2:
+        if table not in existing_tables:
+            continue
+        existing_cols = {
+            row[1] for row in conn.execute(
+                f"PRAGMA table_info('{table}')"
+            ).fetchall()
+        }
+        if col not in existing_cols:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {decl}")
+
+
+def _to_blob(value: Any) -> bytes | None:
+    """Coerce arbitrary value (dict / list / str / bytes / None) to a BLOB
+    suitable for DuckDB. Used by the non-event ingest helpers (sessions,
+    memory, heartbeats) — events have their own row-builder."""
+    if value is None:
+        return None
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("utf-8", errors="replace")
+    try:
+        return json.dumps(value, separators=(",", ":"), default=str).encode("utf-8")
+    except Exception:
+        return str(value).encode("utf-8", errors="replace")
 
 
 def _open_connection(*, read_only: bool = False) -> duckdb.DuckDBPyConnection:
@@ -172,10 +350,28 @@ class LocalStore:
         self._migrate()
 
     def _migrate(self) -> None:
-        """Apply DDL idempotently and stamp the schema version."""
+        """Bring the store schema up to v2. Order matters:
+          1. v1→v2 column-add migrations (only do anything on legacy stores
+             that pre-date agent_type) — must run BEFORE the DDL because the
+             new `idx_events_atype_ts` index references agent_type.
+          2. Full v2 DDL — CREATE TABLE/INDEX IF NOT EXISTS, no-op on
+             already-migrated tables, creates the new tables on fresh stores.
+          3. Stamp the schema_version row.
+        """
         with self._write_lock:
+            # Step 1: column-add migrations for legacy v1 stores. Tolerant
+            # of "table doesn't exist" — fresh stores have no v1 tables to
+            # migrate, the DDL below will create them at v2 directly.
+            try:
+                _apply_migrations(self._conn)
+            except Exception:
+                log.exception("local store: column-add migrations failed (continuing)")
+            # Step 2: full v2 DDL. CREATE IF NOT EXISTS makes this idempotent
+            # for both fresh stores (creates everything) and migrated stores
+            # (only creates the new tables that didn't exist).
             for stmt in _DDL:
                 self._conn.execute(stmt)
+            # Step 3: stamp the version.
             cur = self._conn.execute("SELECT MAX(version) AS v FROM schema_version")
             row = cur.fetchone()
             current = row[0] if row and row[0] is not None else 0
@@ -244,6 +440,133 @@ class LocalStore:
         for e in events:
             self.ingest(e)
 
+    # ── ingest helpers for the non-event tables ────────────────────────────
+    #
+    # Sessions/memory/heartbeats are low-volume, low-frequency writes (one
+    # per session-update / per memory-file / per minute). They bypass the
+    # ring buffer and write synchronously — simpler than batching, and the
+    # contention with the flusher is negligible at this rate.
+
+    def ingest_session(self, session: dict[str, Any]) -> None:
+        """Upsert one session row. Required: session_id. Other fields optional."""
+        sid = session.get("session_id")
+        if not sid:
+            raise ValueError("session must include 'session_id'")
+        atype = session.get("agent_type") or "openclaw"
+        meta_blob = _to_blob(session.get("metadata"))
+        now_ms = int(time.time() * 1000)
+        params = [
+            atype, sid,
+            session.get("node_id"),
+            session.get("agent_id") or "main",
+            session.get("workspace_id"),
+            session.get("title"),
+            session.get("started_at"),
+            session.get("last_active_at"),
+            session.get("ended_at"),
+            session.get("status"),
+            int(session.get("total_tokens") or 0),
+            float(session.get("cost_usd") or 0),
+            int(session.get("message_count") or 0),
+            meta_blob,
+            now_ms,
+        ]
+        with self._write_lock:
+            # Upsert: replace if (agent_type, session_id) exists.
+            self._conn.execute("""
+                INSERT INTO sessions (
+                    agent_type, session_id, node_id, agent_id, workspace_id,
+                    title, started_at, last_active_at, ended_at, status,
+                    total_tokens, cost_usd, message_count, metadata, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (agent_type, session_id) DO UPDATE SET
+                    node_id        = excluded.node_id,
+                    agent_id       = excluded.agent_id,
+                    workspace_id   = excluded.workspace_id,
+                    title          = COALESCE(excluded.title, sessions.title),
+                    started_at     = COALESCE(sessions.started_at, excluded.started_at),
+                    last_active_at = excluded.last_active_at,
+                    ended_at       = excluded.ended_at,
+                    status         = excluded.status,
+                    total_tokens   = excluded.total_tokens,
+                    cost_usd       = excluded.cost_usd,
+                    message_count  = excluded.message_count,
+                    metadata       = COALESCE(excluded.metadata, sessions.metadata),
+                    updated_at     = excluded.updated_at
+            """, params)
+
+    def ingest_memory_blob(self, blob_row: dict[str, Any]) -> None:
+        """Upsert one memory blob (e.g. CLAUDE.md, ~/.openclaw/memory/notes.md).
+
+        Required: agent_type, path. Optional: agent_id, blob, sha256, ts.
+        Re-ingesting with the same sha256 is a no-op (cheap dedup)."""
+        atype = blob_row.get("agent_type")
+        path = blob_row.get("path")
+        if not atype or not path:
+            raise ValueError("memory blob must include 'agent_type' and 'path'")
+        agent_id = blob_row.get("agent_id") or "main"
+        blob = blob_row.get("blob")
+        if isinstance(blob, str):
+            blob = blob.encode("utf-8", errors="replace")
+        sha = blob_row.get("sha256")
+        if not sha and blob is not None:
+            import hashlib
+            sha = hashlib.sha256(blob).hexdigest()
+        size = blob_row.get("size_bytes")
+        if size is None and blob is not None:
+            size = len(blob)
+        now_ms = int(time.time() * 1000)
+        with self._write_lock:
+            # Skip the write if the blob hasn't changed (sha256 match).
+            if sha:
+                cur = self._conn.execute(
+                    "SELECT sha256 FROM memory_blobs WHERE agent_type=? AND agent_id=? AND path=?",
+                    [atype, agent_id, path],
+                )
+                row = cur.fetchone()
+                if row and row[0] == sha:
+                    return
+            self._conn.execute("""
+                INSERT INTO memory_blobs (
+                    agent_type, agent_id, path, ts, blob, sha256, size_bytes, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (agent_type, agent_id, path) DO UPDATE SET
+                    ts         = excluded.ts,
+                    blob       = excluded.blob,
+                    sha256     = excluded.sha256,
+                    size_bytes = excluded.size_bytes,
+                    updated_at = excluded.updated_at
+            """, [atype, agent_id, path, blob_row.get("ts"), blob, sha, size, now_ms])
+
+    def ingest_heartbeat(self, hb: dict[str, Any]) -> None:
+        """Insert one heartbeat row. Append-only; (agent_type, node_id, ts) PK
+        means duplicate timestamps are silently ignored (the daemon only sends
+        one heartbeat per interval anyway)."""
+        node_id = hb.get("node_id")
+        ts = hb.get("ts")
+        if not node_id or not ts:
+            raise ValueError("heartbeat must include 'node_id' and 'ts'")
+        atype = hb.get("agent_type") or "openclaw"
+        data_blob = _to_blob({k: v for k, v in hb.items()
+                              if k not in {"node_id", "ts", "agent_type",
+                                           "version", "e2e", "size_mb",
+                                           "events_total"}})
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT OR IGNORE INTO heartbeats (
+                    agent_type, node_id, ts, version, e2e, size_mb,
+                    events_total, data
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """, [
+                atype, node_id, ts,
+                hb.get("version"),
+                bool(hb.get("e2e")),
+                hb.get("local_store_size_mb") or hb.get("size_mb"),
+                (hb.get("local_store") or {}).get("events_total")
+                  if isinstance(hb.get("local_store"), dict) else hb.get("events_total"),
+                data_blob,
+            ])
+
     # ── flush ───────────────────────────────────────────────────────────
 
     def _flusher_loop(self) -> None:
@@ -269,9 +592,9 @@ class LocalStore:
                 self._conn.executemany(
                     """
                     INSERT OR IGNORE INTO events
-                      (id, node_id, agent_id, session_id, workspace_id,
+                      (id, agent_type, node_id, agent_id, session_id, workspace_id,
                        event_type, ts, data, cost_usd, token_count, model, created_at)
-                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
                     """,
                     rows,
                 )
@@ -314,7 +637,7 @@ class LocalStore:
             params.append(until)
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         sql = f"""
-            SELECT id, node_id, agent_id, session_id, workspace_id,
+            SELECT id, agent_type, node_id, agent_id, session_id, workspace_id,
                    event_type, ts, data, cost_usd, token_count, model
             FROM events
             {where}
@@ -497,7 +820,7 @@ class LocalStore:
 # ── helpers ────────────────────────────────────────────────────────────────
 
 _EVENT_COLS = [
-    "id", "node_id", "agent_id", "session_id", "workspace_id",
+    "id", "agent_type", "node_id", "agent_id", "session_id", "workspace_id",
     "event_type", "ts", "data", "cost_usd", "token_count", "model",
 ]
 
@@ -515,6 +838,7 @@ def _event_to_row(e: dict[str, Any]) -> tuple:
             data = json.dumps(data, separators=(",", ":")).encode("utf-8")
     return (
         str(e["id"]),
+        str(e.get("agent_type") or "openclaw"),
         str(e["node_id"]),
         str(e.get("agent_id") or "main"),
         e.get("session_id"),

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -267,7 +267,7 @@ def test_health_reports_size_and_count(store):
     h = store.health()
     assert h["event_count"] == 10
     assert h["size_bytes"] > 0
-    assert h["schema_version"] == 1
+    assert h["schema_version"] == 2
     assert h["ring_depth"] == 0
     assert h["ring_dropped_total"] == 0
 

--- a/tests/test_local_store_multi_agent.py
+++ b/tests/test_local_store_multi_agent.py
@@ -1,0 +1,236 @@
+"""Tests for the multi-agent schema expansion (sessions, memory_blobs,
+heartbeats) added in 0.12.165+. Also covers the v1 → v2 migration path
+for stores upgraded from 0.12.164.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import duckdb
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.get_store()
+    yield s
+    try:
+        s.stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_ingest_session_inserts_row(store):
+    store.ingest_session({
+        "session_id": "sess-A",
+        "agent_type": "claude_code",
+        "node_id": "agent+test",
+        "title": "Refactoring routes/sessions.py",
+        "started_at": "2026-05-11T10:00:00Z",
+        "last_active_at": "2026-05-11T10:30:00Z",
+        "status": "active",
+        "total_tokens": 12500,
+        "cost_usd": 0.42,
+        "message_count": 17,
+        "metadata": {"workspace": "/Users/vivek/projects/clawmetry"},
+    })
+    rows = store._fetch(
+        "SELECT agent_type, session_id, title, total_tokens, cost_usd FROM sessions",
+        [],
+    )
+    assert len(rows) == 1
+    assert rows[0][0] == "claude_code"
+    assert rows[0][1] == "sess-A"
+    assert rows[0][2] == "Refactoring routes/sessions.py"
+    assert rows[0][3] == 12500
+    assert abs(rows[0][4] - 0.42) < 1e-9
+
+
+def test_ingest_session_upserts_on_conflict(store):
+    """Same (agent_type, session_id) re-ingested updates the row, doesn't dup."""
+    base = {"session_id": "sess-up", "agent_type": "openclaw",
+            "started_at": "2026-05-11T10:00:00Z", "status": "active"}
+    store.ingest_session({**base, "total_tokens": 100, "cost_usd": 0.01,
+                          "title": "first"})
+    store.ingest_session({**base, "total_tokens": 200, "cost_usd": 0.05,
+                          "status": "ended", "title": None})
+    rows = store._fetch(
+        "SELECT total_tokens, cost_usd, status, title, started_at FROM sessions",
+        [],
+    )
+    assert len(rows) == 1
+    assert rows[0][0] == 200
+    assert abs(rows[0][1] - 0.05) < 1e-9
+    assert rows[0][2] == "ended"
+    # COALESCE preserves first title when second sends None.
+    assert rows[0][3] == "first"
+    # COALESCE preserves first started_at on update.
+    assert rows[0][4] == "2026-05-11T10:00:00Z"
+
+
+def test_ingest_session_isolates_agent_types(store):
+    """Two agents using the same session_id string don't collide."""
+    store.ingest_session({"session_id": "shared", "agent_type": "openclaw",
+                          "title": "openclaw-side"})
+    store.ingest_session({"session_id": "shared", "agent_type": "claude_code",
+                          "title": "cc-side"})
+    rows = store._fetch("SELECT agent_type, title FROM sessions ORDER BY agent_type", [])
+    assert len(rows) == 2
+    assert rows[0] == ("claude_code", "cc-side")
+    assert rows[1] == ("openclaw", "openclaw-side")
+
+
+def test_ingest_memory_blob_dedups_on_sha256(store):
+    blob = b"# Notes\n\nFirst draft of project notes."
+    store.ingest_memory_blob({
+        "agent_type": "openclaw",
+        "agent_id": "main",
+        "path": "~/.openclaw/memory/notes.md",
+        "ts": "2026-05-11T10:00:00Z",
+        "blob": blob,
+    })
+    rows1 = store._fetch("SELECT COUNT(*), MAX(updated_at) FROM memory_blobs", [])
+    # Re-ingest identical content → no new write.
+    store.ingest_memory_blob({
+        "agent_type": "openclaw",
+        "agent_id": "main",
+        "path": "~/.openclaw/memory/notes.md",
+        "ts": "2026-05-11T10:05:00Z",
+        "blob": blob,
+    })
+    rows2 = store._fetch("SELECT COUNT(*), MAX(updated_at) FROM memory_blobs", [])
+    assert rows1[0][0] == 1
+    assert rows2[0][0] == 1
+    # updated_at should NOT advance on the dedup'd write.
+    assert rows1[0][1] == rows2[0][1]
+
+
+def test_ingest_memory_blob_updates_on_change(store):
+    store.ingest_memory_blob({
+        "agent_type": "claude_code", "path": "CLAUDE.md",
+        "blob": b"v1 content", "ts": "2026-05-11T10:00:00Z",
+    })
+    store.ingest_memory_blob({
+        "agent_type": "claude_code", "path": "CLAUDE.md",
+        "blob": b"v2 content updated", "ts": "2026-05-11T11:00:00Z",
+    })
+    rows = store._fetch(
+        "SELECT blob, ts, size_bytes FROM memory_blobs WHERE path = 'CLAUDE.md'", [],
+    )
+    assert len(rows) == 1
+    assert bytes(rows[0][0]) == b"v2 content updated"
+    assert rows[0][1] == "2026-05-11T11:00:00Z"
+    assert rows[0][2] == len(b"v2 content updated")
+
+
+def test_ingest_heartbeat_appends(store):
+    """Heartbeats are append-only by (agent_type, node_id, ts)."""
+    store.ingest_heartbeat({
+        "node_id": "agent+test", "ts": "2026-05-11T10:00:00Z",
+        "version": "0.12.165", "e2e": True,
+        "local_store_size_mb": 0.5,
+        "local_store": {"events_total": 100},
+    })
+    store.ingest_heartbeat({
+        "node_id": "agent+test", "ts": "2026-05-11T10:05:00Z",
+        "version": "0.12.165", "e2e": True,
+        "local_store_size_mb": 0.6,
+        "local_store": {"events_total": 120},
+    })
+    # Same ts is silently ignored (PK conflict).
+    store.ingest_heartbeat({
+        "node_id": "agent+test", "ts": "2026-05-11T10:05:00Z",
+        "version": "0.12.165", "e2e": True, "local_store_size_mb": 999,
+    })
+    rows = store._fetch(
+        "SELECT ts, size_mb, events_total FROM heartbeats ORDER BY ts", [],
+    )
+    assert len(rows) == 2
+    assert rows[0][1] == 0.5
+    assert rows[0][2] == 100
+    assert rows[1][1] == 0.6
+    assert rows[1][2] == 120
+
+
+def test_ingest_session_requires_session_id(store):
+    with pytest.raises(ValueError, match="session_id"):
+        store.ingest_session({"agent_type": "openclaw"})
+
+
+def test_ingest_memory_blob_requires_agent_type_and_path(store):
+    with pytest.raises(ValueError, match="agent_type"):
+        store.ingest_memory_blob({"path": "x"})
+    with pytest.raises(ValueError, match="path"):
+        store.ingest_memory_blob({"agent_type": "claude_code"})
+
+
+def test_v1_to_v2_migration_adds_agent_type_column(tmp_path, monkeypatch):
+    """A store created at SCHEMA_VERSION=1 (events table without agent_type)
+    must auto-upgrade to v2 on next open without losing data."""
+    db_path = tmp_path / "events.duckdb"
+    # Manually create a v1 events table (without agent_type).
+    with duckdb.connect(str(db_path)) as v1_conn:
+        v1_conn.execute("""
+            CREATE TABLE events (
+                id            VARCHAR PRIMARY KEY,
+                node_id       VARCHAR NOT NULL,
+                agent_id      VARCHAR NOT NULL DEFAULT 'main',
+                session_id    VARCHAR,
+                workspace_id  VARCHAR,
+                event_type    VARCHAR NOT NULL,
+                ts            VARCHAR NOT NULL,
+                data          BLOB,
+                cost_usd      DOUBLE,
+                token_count   INTEGER,
+                model         VARCHAR,
+                created_at    BIGINT NOT NULL
+            )
+        """)
+        v1_conn.execute("""
+            CREATE TABLE daily_aggregates (
+                agent_id      VARCHAR NOT NULL,
+                workspace_id  VARCHAR,
+                day           VARCHAR NOT NULL,
+                cost_usd      DOUBLE DEFAULT 0,
+                token_count   INTEGER DEFAULT 0,
+                event_count   INTEGER DEFAULT 0,
+                error_count   INTEGER DEFAULT 0,
+                PRIMARY KEY (agent_id, workspace_id, day)
+            )
+        """)
+        v1_conn.execute("""
+            CREATE TABLE schema_version (
+                version    INTEGER PRIMARY KEY,
+                applied_at BIGINT NOT NULL
+            )
+        """)
+        v1_conn.execute("INSERT INTO schema_version VALUES (1, 1700000000000)")
+        v1_conn.execute(
+            "INSERT INTO events VALUES (?, ?, 'main', NULL, NULL, 'tool_call', ?, NULL, 0.001, 5, 'claude-opus-4-7', ?)",
+            ["legacy-1", "agent+legacy", "2026-05-10T12:00:00Z", 1700000001000],
+        )
+
+    # Open via the production code path → should migrate seamlessly.
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(db_path))
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.get_store()
+    try:
+        cols = {row[1] for row in store._conn.execute("PRAGMA table_info('events')").fetchall()}
+        assert "agent_type" in cols, "v1→v2 migration didn't add agent_type column"
+        # Legacy event is still readable + agent_type backfilled to 'openclaw'.
+        rows = store._fetch(
+            "SELECT id, agent_type, event_type FROM events WHERE id = 'legacy-1'", [],
+        )
+        assert rows[0][1] == "openclaw"
+        assert rows[0][2] == "tool_call"
+    finally:
+        try:
+            store.stop(flush=True)
+        except Exception:
+            pass


### PR DESCRIPTION
## Why
Today the local DuckDB only catches \`/ingest/events\`. The daemon also ships sessions, memory blobs, heartbeats, system snapshots, etc. to cloud — none of which lands locally. This PR adds the schema; PR 2 wires the daemon write-through; PR 3 swaps dashboard reads.

This is also the foundation for **multi-agent**: an \`agent_type\` discriminator (\`openclaw\` / \`claude_code\` / \`hermes\` / \`cursor\` / \`codex\` / \`aider\`) lets every framework write into the same store. Cross-agent queries stay simple SQL; per-agent quirks live in dedicated extension tables.

## Schema design (two layers)

**Layer 1 — shared core** (every agent writes here):
\`events\`, \`sessions\`, \`daily_aggregates\`, \`memory_blobs\`, \`heartbeats\`, \`system_snapshots\`. \`agent_type\` is the discriminator on each.

**Layer 2 — agent-specific extensions** (only added when concept is unique to one agent OR shared by 2+):
\`openclaw_channels\` (only OpenClaw has channels), \`crons\` (OpenClaw + Hermes), \`subagents\` (OpenClaw + Claude Code Task tool).

A new agent (Cursor, Codex) starts by **only writing to the shared layer**. If it has a unique concept the dashboard needs to query, we add an extension table later. **No premature generalisation.**

Trade-off rationale in [the design doc I posted in chat](https://github.com/vivekchand/clawmetry/issues/964) — TL;DR: pure unified schema loses DuckDB's columnar advantage in JSON BLOBs; pure per-agent fragmentation kills cross-agent queries.

## v1 → v2 migration
Stores from 0.12.164 are auto-upgraded on next open: \`ALTER TABLE events ADD COLUMN agent_type DEFAULT 'openclaw'\`. Legacy rows backfilled losslessly. Test \`test_v1_to_v2_migration_adds_agent_type_column\` locks this behavior.

## Ingest helpers added
- \`ingest_session(dict)\` — upserts on (agent_type, session_id), preserves \`started_at\`/\`title\` via COALESCE
- \`ingest_memory_blob(dict)\` — auto-sha256 dedup; same content = no write
- \`ingest_heartbeat(dict)\` — append-only, silent dedup on PK conflict

## Test plan
- [x] \`pytest tests/test_local_store_multi_agent.py\` — 9/9
- [x] \`pytest tests/test_local_store*.py tests/test_local_query_api.py tests/test_brain_local_fastpath.py tests/test_relay.py\` — 59/59 (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)