### PR TITLE
fix(release-ci): retry pip install in post-publish verification

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -187,18 +187,31 @@ jobs:
         run: |
           set -e
           NEW='${{ steps.bump.outputs.new }}'
-          # PyPI's CDN is fast but not instantaneous. Poll up to 90s for
-          # the new version to appear in the JSON metadata before giving
-          # up — most upload→discoverable times are <30s.
+          python3 -m venv /tmp/postpub-venv
+          # PyPI's CDN is fast but not instantaneous, and the JSON metadata
+          # endpoint and the simple index (which pip uses) propagate
+          # independently — JSON can be visible while pip install still
+          # 404s. Poll the actual install path up to 90s before giving up.
+          # Seen in run 25677216433 (2026-05-11): JSON visible at attempt 1,
+          # pip install failed 4s later because /simple/ hadn't propagated,
+          # which aborted the workflow before the version-bump PR step.
+          INSTALL_OK=0
           for i in 1 2 3 4 5 6 7 8 9; do
-            if curl -sf "https://pypi.org/pypi/clawmetry/$NEW/json" > /dev/null; then
-              echo "▸ PyPI metadata for $NEW visible (attempt $i)"
+            if /tmp/postpub-venv/bin/pip install --quiet --no-cache-dir "clawmetry==$NEW" 2>/dev/null; then
+              echo "▸ PyPI install of $NEW succeeded (attempt $i)"
+              INSTALL_OK=1
               break
             fi
             sleep 10
           done
-          python3 -m venv /tmp/postpub-venv
-          /tmp/postpub-venv/bin/pip install --quiet --no-cache-dir "clawmetry==$NEW"
+          if [ "$INSTALL_OK" != "1" ]; then
+            echo "❌ PyPI install of $NEW failed after 90s of retries"
+            echo ""
+            echo "TO YANK $NEW (mark unavailable to new installs while keeping it in history):"
+            echo "  https://pypi.org/manage/project/clawmetry/release/$NEW/  → 'Yank'"
+            echo "Or run a follow-up [RELEASE] PR to publish $NEW patch+1 with the previous code."
+            exit 1
+          fi
           ACTUAL=$(/tmp/postpub-venv/bin/clawmetry --version | tr -d '[:space:]')
           echo "$ACTUAL" | grep -qF "$NEW" || {
             echo "❌ PyPI install reports version $ACTUAL, expected $NEW"


### PR DESCRIPTION
## Summary

The `Post-publish verification` step in `release-on-merge.yml` polled PyPI's JSON metadata endpoint until it appeared, then ran `pip install` exactly once. JSON metadata and the `/simple/` index (which pip uses) propagate independently — when JSON is visible but `/simple/` isn't yet, the install fails and the workflow exits before the version-bump PR step runs.

This caught us today on the merge of #994:

- Run [25677216433](https://github.com/vivekchand/clawmetry/actions/runs/25677216433) (release/0.12.165-relay-client)
- `▸ PyPI metadata for 0.12.165 visible (attempt 1)` — JSON ok
- 4s later: `ERROR: No matching distribution found for clawmetry==0.12.165`
- Workflow exited 1 → no GitHub release tag, no `chore: bump to v0.12.165` PR to main

Result: `pip install clawmetry` gives users **0.12.165** (wheel is on PyPI and works), but `main` still has `__version__ = "0.12.164"`. The E2E health-check cron caught this as a version mismatch.

## Fix

Poll the actual install path with the same 9×10s backoff instead of polling JSON metadata separately. This:
- tolerates transient `/simple/` propagation lag (same root cause as the JSON poll, just on a different endpoint)
- collapses the two timing-sensitive steps into one verification that matches what users experience
- keeps the existing 90s ceiling and the same yank/follow-up guidance on real failures

The wheel-install + CLI/import smoke earlier in the workflow already validates the artifact itself, so this step only needs to confirm PyPI propagation.

## Test plan

- [ ] Next `[RELEASE]` merge: verify post-publish step succeeds end-to-end and the version-bump PR opens against `main`
- [ ] Confirm the failure path still prints yank instructions when `pip install` truly cannot find the version after 90s

🤖 Generated with [Claude Code](https://claude.com/claude-code)