### PR TITLE
feat(sessions): /api/sessions opt-in local-store fast path (PR 3 of 3)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -73,12 +73,27 @@ LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+
+# ── Two-layer schema (multi-agent) ──────────────────────────────────────────
+#
+# Layer 1: shared core. Every agent (OpenClaw, Claude Code, Hermes, Cursor,
+# Codex, Aider, …) writes here. `agent_type` is the discriminator.
+#
+# Layer 2: agent-specific extensions. Only added when a concept is unique to
+# one agent OR shared by 2+. Keeps the columnar tables clean of NULL columns
+# we'd otherwise carry to support every framework's quirks.
+#
+# Discriminator: `agent_type` is the FRAMEWORK (openclaw/claude_code/hermes/
+# cursor/codex/aider). `agent_id` (already on events) is the INSTANCE within
+# that framework (main/subagent/cron). Both coexist.
 
 _DDL = [
+    # ── Layer 1: shared core ─────────────────────────────────────────────────
     """
     CREATE TABLE IF NOT EXISTS events (
         id            VARCHAR PRIMARY KEY,
+        agent_type    VARCHAR NOT NULL DEFAULT 'openclaw',
         node_id       VARCHAR NOT NULL,
         agent_id      VARCHAR NOT NULL DEFAULT 'main',
         session_id    VARCHAR,
@@ -96,8 +111,32 @@ _DDL = [
     "CREATE INDEX IF NOT EXISTS idx_events_session     ON events(session_id, ts)",
     "CREATE INDEX IF NOT EXISTS idx_events_agent_ts    ON events(agent_id, ts)",
     "CREATE INDEX IF NOT EXISTS idx_events_type_ts     ON events(event_type, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_events_atype_ts    ON events(agent_type, ts)",
+    """
+    CREATE TABLE IF NOT EXISTS sessions (
+        agent_type      VARCHAR NOT NULL DEFAULT 'openclaw',
+        session_id      VARCHAR NOT NULL,
+        node_id         VARCHAR,
+        agent_id        VARCHAR DEFAULT 'main',
+        workspace_id    VARCHAR,
+        title           VARCHAR,
+        started_at      VARCHAR,
+        last_active_at  VARCHAR,
+        ended_at        VARCHAR,
+        status          VARCHAR,
+        total_tokens    INTEGER DEFAULT 0,
+        cost_usd        DOUBLE DEFAULT 0,
+        message_count   INTEGER DEFAULT 0,
+        metadata        BLOB,
+        updated_at      BIGINT NOT NULL,
+        PRIMARY KEY (agent_type, session_id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_sessions_active    ON sessions(agent_type, last_active_at)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_node      ON sessions(node_id, last_active_at)",
     """
     CREATE TABLE IF NOT EXISTS daily_aggregates (
+        agent_type    VARCHAR NOT NULL DEFAULT 'openclaw',
         agent_id      VARCHAR NOT NULL,
         workspace_id  VARCHAR,
         day           VARCHAR NOT NULL,
@@ -105,7 +144,90 @@ _DDL = [
         token_count   INTEGER DEFAULT 0,
         event_count   INTEGER DEFAULT 0,
         error_count   INTEGER DEFAULT 0,
-        PRIMARY KEY (agent_id, workspace_id, day)
+        PRIMARY KEY (agent_type, agent_id, workspace_id, day)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS memory_blobs (
+        agent_type    VARCHAR NOT NULL,
+        agent_id      VARCHAR NOT NULL DEFAULT 'main',
+        path          VARCHAR NOT NULL,
+        ts            VARCHAR,
+        blob          BLOB,
+        sha256        VARCHAR,
+        size_bytes    INTEGER,
+        updated_at    BIGINT NOT NULL,
+        PRIMARY KEY (agent_type, agent_id, path)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS heartbeats (
+        agent_type        VARCHAR NOT NULL DEFAULT 'openclaw',
+        node_id           VARCHAR NOT NULL,
+        ts                VARCHAR NOT NULL,
+        version           VARCHAR,
+        e2e               BOOLEAN,
+        size_mb           DOUBLE,
+        events_total      INTEGER,
+        data              BLOB,
+        PRIMARY KEY (agent_type, node_id, ts)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_heartbeats_node_ts ON heartbeats(node_id, ts)",
+    """
+    CREATE TABLE IF NOT EXISTS system_snapshots (
+        agent_type    VARCHAR NOT NULL DEFAULT 'openclaw',
+        node_id       VARCHAR NOT NULL,
+        ts            VARCHAR NOT NULL,
+        kind          VARCHAR NOT NULL,
+        data          BLOB,
+        PRIMARY KEY (agent_type, node_id, ts, kind)
+    )
+    """,
+    # ── Layer 2: agent-specific extensions ───────────────────────────────────
+    # OpenClaw-only: channel context (Telegram/Slack/...). Other agents don't
+    # have this; keeping it out of `sessions` avoids 5 NULL columns per row.
+    """
+    CREATE TABLE IF NOT EXISTS openclaw_channels (
+        session_id    VARCHAR PRIMARY KEY,
+        channel       VARCHAR,
+        chat_type     VARCHAR,
+        subject       VARCHAR,
+        origin_label  VARCHAR
+    )
+    """,
+    # Shared by OpenClaw + Hermes (and any future cron-supporting agent).
+    """
+    CREATE TABLE IF NOT EXISTS crons (
+        agent_type     VARCHAR NOT NULL,
+        cron_id        VARCHAR NOT NULL,
+        agent_id       VARCHAR DEFAULT 'main',
+        name           VARCHAR,
+        schedule       VARCHAR,
+        enabled        BOOLEAN,
+        last_run_at    VARCHAR,
+        last_status    VARCHAR,
+        next_run_at    VARCHAR,
+        data           BLOB,
+        updated_at     BIGINT NOT NULL,
+        PRIMARY KEY (agent_type, cron_id)
+    )
+    """,
+    # Shared by OpenClaw subagents + Claude Code Task tool.
+    """
+    CREATE TABLE IF NOT EXISTS subagents (
+        agent_type        VARCHAR NOT NULL,
+        subagent_id       VARCHAR NOT NULL,
+        parent_session_id VARCHAR,
+        spawned_at        VARCHAR,
+        ended_at          VARCHAR,
+        task              VARCHAR,
+        status            VARCHAR,
+        cost_usd          DOUBLE DEFAULT 0,
+        token_count       INTEGER DEFAULT 0,
+        data              BLOB,
+        updated_at        BIGINT NOT NULL,
+        PRIMARY KEY (agent_type, subagent_id)
     )
     """,
     """
@@ -115,6 +237,62 @@ _DDL = [
     )
     """,
 ]
+
+
+# ── Schema migrations (v1 → v2) ────────────────────────────────────────────
+#
+# DuckDB doesn't support `ALTER TABLE ADD COLUMN IF NOT EXISTS` cleanly, so
+# we check pg_tables-style introspection and run ALTERs only when needed.
+# Idempotent: safe to call on a v2 store.
+
+_MIGRATIONS_V2 = [
+    # Existing 0.12.164 stores have `events` without agent_type — backfill it
+    # to 'openclaw' (the only agent that wrote anything in v1).
+    ("events", "agent_type", "VARCHAR DEFAULT 'openclaw'"),
+    # daily_aggregates also gains agent_type. The PK change is the tricky part —
+    # DuckDB won't let us alter the PK in place. v1 stores will keep their old
+    # PK (agent_id, workspace_id, day); writes from v2 use ON CONFLICT DO
+    # UPDATE on the PK that exists. New stores get the v2 PK directly.
+    ("daily_aggregates", "agent_type", "VARCHAR DEFAULT 'openclaw'"),
+]
+
+
+def _apply_migrations(conn) -> None:
+    """Add columns missing from a v1 store. Idempotent. Tolerant of
+    tables not existing yet (fresh stores have nothing to migrate)."""
+    # Get the set of tables that currently exist; skip migrations for any
+    # table that doesn't.
+    existing_tables = {
+        row[0] for row in conn.execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema='main'"
+        ).fetchall()
+    }
+    for table, col, decl in _MIGRATIONS_V2:
+        if table not in existing_tables:
+            continue
+        existing_cols = {
+            row[1] for row in conn.execute(
+                f"PRAGMA table_info('{table}')"
+            ).fetchall()
+        }
+        if col not in existing_cols:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {decl}")
+
+
+def _to_blob(value: Any) -> bytes | None:
+    """Coerce arbitrary value (dict / list / str / bytes / None) to a BLOB
+    suitable for DuckDB. Used by the non-event ingest helpers (sessions,
+    memory, heartbeats) — events have their own row-builder."""
+    if value is None:
+        return None
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("utf-8", errors="replace")
+    try:
+        return json.dumps(value, separators=(",", ":"), default=str).encode("utf-8")
+    except Exception:
+        return str(value).encode("utf-8", errors="replace")
 
 
 def _open_connection(*, read_only: bool = False) -> duckdb.DuckDBPyConnection:
@@ -172,10 +350,28 @@ class LocalStore:
         self._migrate()
 
     def _migrate(self) -> None:
-        """Apply DDL idempotently and stamp the schema version."""
+        """Bring the store schema up to v2. Order matters:
+          1. v1→v2 column-add migrations (only do anything on legacy stores
+             that pre-date agent_type) — must run BEFORE the DDL because the
+             new `idx_events_atype_ts` index references agent_type.
+          2. Full v2 DDL — CREATE TABLE/INDEX IF NOT EXISTS, no-op on
+             already-migrated tables, creates the new tables on fresh stores.
+          3. Stamp the schema_version row.
+        """
         with self._write_lock:
+            # Step 1: column-add migrations for legacy v1 stores. Tolerant
+            # of "table doesn't exist" — fresh stores have no v1 tables to
+            # migrate, the DDL below will create them at v2 directly.
+            try:
+                _apply_migrations(self._conn)
+            except Exception:
+                log.exception("local store: column-add migrations failed (continuing)")
+            # Step 2: full v2 DDL. CREATE IF NOT EXISTS makes this idempotent
+            # for both fresh stores (creates everything) and migrated stores
+            # (only creates the new tables that didn't exist).
             for stmt in _DDL:
                 self._conn.execute(stmt)
+            # Step 3: stamp the version.
             cur = self._conn.execute("SELECT MAX(version) AS v FROM schema_version")
             row = cur.fetchone()
             current = row[0] if row and row[0] is not None else 0
@@ -244,6 +440,133 @@ class LocalStore:
         for e in events:
             self.ingest(e)
 
+    # ── ingest helpers for the non-event tables ────────────────────────────
+    #
+    # Sessions/memory/heartbeats are low-volume, low-frequency writes (one
+    # per session-update / per memory-file / per minute). They bypass the
+    # ring buffer and write synchronously — simpler than batching, and the
+    # contention with the flusher is negligible at this rate.
+
+    def ingest_session(self, session: dict[str, Any]) -> None:
+        """Upsert one session row. Required: session_id. Other fields optional."""
+        sid = session.get("session_id")
+        if not sid:
+            raise ValueError("session must include 'session_id'")
+        atype = session.get("agent_type") or "openclaw"
+        meta_blob = _to_blob(session.get("metadata"))
+        now_ms = int(time.time() * 1000)
+        params = [
+            atype, sid,
+            session.get("node_id"),
+            session.get("agent_id") or "main",
+            session.get("workspace_id"),
+            session.get("title"),
+            session.get("started_at"),
+            session.get("last_active_at"),
+            session.get("ended_at"),
+            session.get("status"),
+            int(session.get("total_tokens") or 0),
+            float(session.get("cost_usd") or 0),
+            int(session.get("message_count") or 0),
+            meta_blob,
+            now_ms,
+        ]
+        with self._write_lock:
+            # Upsert: replace if (agent_type, session_id) exists.
+            self._conn.execute("""
+                INSERT INTO sessions (
+                    agent_type, session_id, node_id, agent_id, workspace_id,
+                    title, started_at, last_active_at, ended_at, status,
+                    total_tokens, cost_usd, message_count, metadata, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (agent_type, session_id) DO UPDATE SET
+                    node_id        = excluded.node_id,
+                    agent_id       = excluded.agent_id,
+                    workspace_id   = excluded.workspace_id,
+                    title          = COALESCE(excluded.title, sessions.title),
+                    started_at     = COALESCE(sessions.started_at, excluded.started_at),
+                    last_active_at = excluded.last_active_at,
+                    ended_at       = excluded.ended_at,
+                    status         = excluded.status,
+                    total_tokens   = excluded.total_tokens,
+                    cost_usd       = excluded.cost_usd,
+                    message_count  = excluded.message_count,
+                    metadata       = COALESCE(excluded.metadata, sessions.metadata),
+                    updated_at     = excluded.updated_at
+            """, params)
+
+    def ingest_memory_blob(self, blob_row: dict[str, Any]) -> None:
+        """Upsert one memory blob (e.g. CLAUDE.md, ~/.openclaw/memory/notes.md).
+
+        Required: agent_type, path. Optional: agent_id, blob, sha256, ts.
+        Re-ingesting with the same sha256 is a no-op (cheap dedup)."""
+        atype = blob_row.get("agent_type")
+        path = blob_row.get("path")
+        if not atype or not path:
+            raise ValueError("memory blob must include 'agent_type' and 'path'")
+        agent_id = blob_row.get("agent_id") or "main"
+        blob = blob_row.get("blob")
+        if isinstance(blob, str):
+            blob = blob.encode("utf-8", errors="replace")
+        sha = blob_row.get("sha256")
+        if not sha and blob is not None:
+            import hashlib
+            sha = hashlib.sha256(blob).hexdigest()
+        size = blob_row.get("size_bytes")
+        if size is None and blob is not None:
+            size = len(blob)
+        now_ms = int(time.time() * 1000)
+        with self._write_lock:
+            # Skip the write if the blob hasn't changed (sha256 match).
+            if sha:
+                cur = self._conn.execute(
+                    "SELECT sha256 FROM memory_blobs WHERE agent_type=? AND agent_id=? AND path=?",
+                    [atype, agent_id, path],
+                )
+                row = cur.fetchone()
+                if row and row[0] == sha:
+                    return
+            self._conn.execute("""
+                INSERT INTO memory_blobs (
+                    agent_type, agent_id, path, ts, blob, sha256, size_bytes, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (agent_type, agent_id, path) DO UPDATE SET
+                    ts         = excluded.ts,
+                    blob       = excluded.blob,
+                    sha256     = excluded.sha256,
+                    size_bytes = excluded.size_bytes,
+                    updated_at = excluded.updated_at
+            """, [atype, agent_id, path, blob_row.get("ts"), blob, sha, size, now_ms])
+
+    def ingest_heartbeat(self, hb: dict[str, Any]) -> None:
+        """Insert one heartbeat row. Append-only; (agent_type, node_id, ts) PK
+        means duplicate timestamps are silently ignored (the daemon only sends
+        one heartbeat per interval anyway)."""
+        node_id = hb.get("node_id")
+        ts = hb.get("ts")
+        if not node_id or not ts:
+            raise ValueError("heartbeat must include 'node_id' and 'ts'")
+        atype = hb.get("agent_type") or "openclaw"
+        data_blob = _to_blob({k: v for k, v in hb.items()
+                              if k not in {"node_id", "ts", "agent_type",
+                                           "version", "e2e", "size_mb",
+                                           "events_total"}})
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT OR IGNORE INTO heartbeats (
+                    agent_type, node_id, ts, version, e2e, size_mb,
+                    events_total, data
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """, [
+                atype, node_id, ts,
+                hb.get("version"),
+                bool(hb.get("e2e")),
+                hb.get("local_store_size_mb") or hb.get("size_mb"),
+                (hb.get("local_store") or {}).get("events_total")
+                  if isinstance(hb.get("local_store"), dict) else hb.get("events_total"),
+                data_blob,
+            ])
+
     # ── flush ───────────────────────────────────────────────────────────
 
     def _flusher_loop(self) -> None:
@@ -269,9 +592,9 @@ class LocalStore:
                 self._conn.executemany(
                     """
                     INSERT OR IGNORE INTO events
-                      (id, node_id, agent_id, session_id, workspace_id,
+                      (id, agent_type, node_id, agent_id, session_id, workspace_id,
                        event_type, ts, data, cost_usd, token_count, model, created_at)
-                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
                     """,
                     rows,
                 )
@@ -314,7 +637,7 @@ class LocalStore:
             params.append(until)
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         sql = f"""
-            SELECT id, node_id, agent_id, session_id, workspace_id,
+            SELECT id, agent_type, node_id, agent_id, session_id, workspace_id,
                    event_type, ts, data, cost_usd, token_count, model
             FROM events
             {where}
@@ -497,7 +820,7 @@ class LocalStore:
 # ── helpers ────────────────────────────────────────────────────────────────
 
 _EVENT_COLS = [
-    "id", "node_id", "agent_id", "session_id", "workspace_id",
+    "id", "agent_type", "node_id", "agent_id", "session_id", "workspace_id",
     "event_type", "ts", "data", "cost_usd", "token_count", "model",
 ]
 
@@ -515,6 +838,7 @@ def _event_to_row(e: dict[str, Any]) -> tuple:
             data = json.dumps(data, separators=(",", ":")).encode("utf-8")
     return (
         str(e["id"]),
+        str(e.get("agent_type") or "openclaw"),
         str(e["node_id"]),
         str(e.get("agent_id") or "main"),
         e.get("session_id"),

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1162,6 +1162,75 @@ def _local_ingest_session_batch(
         store.ingest_many(rows)
 
 
+def _local_ingest_sessions_batch(rows: list, node_id: str) -> None:
+    """Mirror a batch of session rows (the same dicts we push to /ingest/sessions)
+    into the local DuckDB ``sessions`` table. One upsert per row; safe to call
+    on a store that already has these sessions (ON CONFLICT DO UPDATE)."""
+    if not rows:
+        return
+    from clawmetry import local_store
+
+    store = local_store.get_store()
+    for s in rows:
+        sid = s.get("session_id") or s.get("session_key") or s.get("id")
+        if not sid:
+            continue
+        # Cost field has been called several things in different code paths
+        # (total_cost, cost_usd, totalCostUsd). Take the first non-None.
+        cost = s.get("cost_usd")
+        if cost is None:
+            cost = s.get("total_cost") or s.get("totalCostUsd") or 0
+        # Channel/chat_type/subject move into a separate metadata blob —
+        # they're OpenClaw-specific and (per the multi-agent design) will get
+        # promoted into the openclaw_channels extension table later.
+        meta_extras = {
+            k: v for k, v in s.items()
+            if k in ("channel", "chat_type", "subject", "recent_model",
+                     "session_key")
+            and v
+        }
+        store.ingest_session({
+            "agent_type": s.get("agent_type") or "openclaw",
+            "session_id": sid,
+            "node_id": node_id,
+            "agent_id": s.get("agent_id") or "main",
+            "title": s.get("subject") or s.get("title"),
+            "started_at": s.get("started_at"),
+            "last_active_at": s.get("updated_at") or s.get("last_active_at"),
+            "ended_at": s.get("ended_at"),
+            "status": s.get("status"),
+            "total_tokens": s.get("total_tokens") or 0,
+            "cost_usd": cost,
+            "message_count": s.get("message_count") or 0,
+            "metadata": meta_extras or None,
+        })
+
+
+def _local_ingest_memory_files(all_files: list, changed_paths: list) -> None:
+    """Persist plaintext memory blobs to local DuckDB. ``all_files`` is the
+    full list of (name, content) tuples; ``changed_paths`` is the subset
+    that changed since last sync. We only write the changed ones — the
+    store's sha256 dedup means it's a no-op anyway, but skipping the
+    encode round-trip is cheaper."""
+    if not changed_paths:
+        return
+    from clawmetry import local_store
+
+    store = local_store.get_store()
+    changed_set = set(changed_paths)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    for name, content in all_files:
+        if name not in changed_set:
+            continue
+        store.ingest_memory_blob({
+            "agent_type": "openclaw",  # OpenClaw harness writes these files
+            "agent_id": "main",
+            "path": name,
+            "ts": now_iso,
+            "blob": content,
+        })
+
+
 def sync_sessions_recent(
     config: dict, state: dict, paths: dict, minutes: int = 60
 ) -> int:
@@ -1666,6 +1735,13 @@ def send_heartbeat(config: dict) -> bool:
         payload["local_store_size_mb"] = round(size_mb, 3)
     except Exception:
         pass  # local store optional — never break heartbeat over it
+    # Local-first: persist this heartbeat to local DuckDB so the dashboard
+    # has a per-node liveness history even when offline. Best-effort.
+    try:
+        from clawmetry import local_store
+        local_store.get_store().ingest_heartbeat(payload)
+    except Exception as _le:
+        log.debug("local-store heartbeat ingest failed (continuing): %s", _le)
     last_err = None
     for attempt in range(3):
         try:
@@ -1904,6 +1980,12 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                 for s in rows:
                     if not s.get("model"):
                         s["model"] = fallback
+            # Local-first: write through to ~/.clawmetry/events.duckdb FIRST.
+            # Best-effort — never blocks cloud sync on a local-store failure.
+            try:
+                _local_ingest_sessions_batch(rows, node_id)
+            except Exception as _e:
+                log.warning("local-store sessions ingest failed (cloud sync continues): %s", _e)
             _post("/ingest/sessions", {"node_id": node_id, "sessions": rows}, api_key)
             return len(rows)
 
@@ -2097,6 +2179,14 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
         ],
     }
     try:
+        # Local-first: write changed memory files to local DuckDB BEFORE cloud.
+        # The local store gets PLAINTEXT (it's the user's own machine); cloud
+        # gets ciphertext when E2E is on. Best-effort.
+        try:
+            _local_ingest_memory_files(all_file_contents, changed_files)
+        except Exception as _le:
+            log.warning("local-store memory ingest failed (cloud sync continues): %s", _le)
+
         if enc_key:
             from clawmetry.sync import encrypt_payload
 

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -60,6 +60,15 @@ def _infer_session_type(session):
 @bp_sessions.route("/api/sessions")
 def api_sessions():
     import dashboard as _d
+    # Epic #964 PR 3: opt-in local-store fast path. When
+    # CLAWMETRY_LOCAL_STORE_READ=1 AND the local sessions table has rows,
+    # serve directly from DuckDB. Falls through to gateway/JSONL otherwise
+    # (so a fresh install with no local store, or a non-OpenClaw user, sees
+    # the same data as before — zero-change default).
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_sessions()
+        if fast is not None:
+            return jsonify(fast)
     gw_data = _d._gw_invoke("sessions_list", {"limit": 20, "messageLimit": 0})
     if gw_data and "sessions" in gw_data:
         sessions = _d._augment_sessions_with_burn(gw_data["sessions"])
@@ -69,6 +78,59 @@ def api_sessions():
         if "session_type" not in s:
             s["session_type"] = _infer_session_type(s)
     return jsonify({"sessions": sessions})
+
+
+def _try_local_store_sessions():
+    """Read sessions directly from the local DuckDB. Returns the same
+    response shape as the legacy gateway-backed endpoint (`{"sessions":
+    [...]}`). Returns ``None`` to defer to the JSONL/gateway fallback if:
+      - the local_store module isn't importable
+      - the sessions table is empty
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = store._fetch("""
+            SELECT agent_type, session_id, agent_id, title, started_at,
+                   last_active_at, ended_at, status, total_tokens, cost_usd,
+                   message_count, metadata
+            FROM sessions
+            ORDER BY COALESCE(last_active_at, started_at) DESC NULLS LAST
+            LIMIT 200
+        """, [])
+    except Exception:
+        return None
+    if not rows:
+        return None
+    out = []
+    for r in rows:
+        meta = {}
+        if r[11]:
+            try:
+                import json as _j
+                meta = _j.loads(bytes(r[11]).decode("utf-8"))
+            except Exception:
+                pass
+        out.append({
+            "agent_type":     r[0],
+            "session_id":     r[1],
+            "agent_id":       r[2],
+            "title":          r[3] or "",
+            "started_at":     r[4] or "",
+            "updated_at":     r[5] or "",
+            "ended_at":       r[6] or "",
+            "status":         r[7] or "",
+            "total_tokens":   int(r[8] or 0),
+            "total_cost":     float(r[9] or 0.0),
+            "message_count":  int(r[10] or 0),
+            "channel":        meta.get("channel", ""),
+            "chat_type":      meta.get("chat_type", ""),
+            "subject":        r[3] or meta.get("subject", ""),
+            "session_type":   meta.get("session_type", "main"),
+            "_source":        "local_store",
+        })
+    return {"sessions": out, "_source": "local_store"}
 
 
 @bp_sessions.route("/api/sessions/by-type")

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -267,7 +267,7 @@ def test_health_reports_size_and_count(store):
     h = store.health()
     assert h["event_count"] == 10
     assert h["size_bytes"] > 0
-    assert h["schema_version"] == 1
+    assert h["schema_version"] == 2
     assert h["ring_depth"] == 0
     assert h["ring_dropped_total"] == 0
 

--- a/tests/test_local_store_multi_agent.py
+++ b/tests/test_local_store_multi_agent.py
@@ -1,0 +1,236 @@
+"""Tests for the multi-agent schema expansion (sessions, memory_blobs,
+heartbeats) added in 0.12.165+. Also covers the v1 → v2 migration path
+for stores upgraded from 0.12.164.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import duckdb
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.get_store()
+    yield s
+    try:
+        s.stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_ingest_session_inserts_row(store):
+    store.ingest_session({
+        "session_id": "sess-A",
+        "agent_type": "claude_code",
+        "node_id": "agent+test",
+        "title": "Refactoring routes/sessions.py",
+        "started_at": "2026-05-11T10:00:00Z",
+        "last_active_at": "2026-05-11T10:30:00Z",
+        "status": "active",
+        "total_tokens": 12500,
+        "cost_usd": 0.42,
+        "message_count": 17,
+        "metadata": {"workspace": "/Users/vivek/projects/clawmetry"},
+    })
+    rows = store._fetch(
+        "SELECT agent_type, session_id, title, total_tokens, cost_usd FROM sessions",
+        [],
+    )
+    assert len(rows) == 1
+    assert rows[0][0] == "claude_code"
+    assert rows[0][1] == "sess-A"
+    assert rows[0][2] == "Refactoring routes/sessions.py"
+    assert rows[0][3] == 12500
+    assert abs(rows[0][4] - 0.42) < 1e-9
+
+
+def test_ingest_session_upserts_on_conflict(store):
+    """Same (agent_type, session_id) re-ingested updates the row, doesn't dup."""
+    base = {"session_id": "sess-up", "agent_type": "openclaw",
+            "started_at": "2026-05-11T10:00:00Z", "status": "active"}
+    store.ingest_session({**base, "total_tokens": 100, "cost_usd": 0.01,
+                          "title": "first"})
+    store.ingest_session({**base, "total_tokens": 200, "cost_usd": 0.05,
+                          "status": "ended", "title": None})
+    rows = store._fetch(
+        "SELECT total_tokens, cost_usd, status, title, started_at FROM sessions",
+        [],
+    )
+    assert len(rows) == 1
+    assert rows[0][0] == 200
+    assert abs(rows[0][1] - 0.05) < 1e-9
+    assert rows[0][2] == "ended"
+    # COALESCE preserves first title when second sends None.
+    assert rows[0][3] == "first"
+    # COALESCE preserves first started_at on update.
+    assert rows[0][4] == "2026-05-11T10:00:00Z"
+
+
+def test_ingest_session_isolates_agent_types(store):
+    """Two agents using the same session_id string don't collide."""
+    store.ingest_session({"session_id": "shared", "agent_type": "openclaw",
+                          "title": "openclaw-side"})
+    store.ingest_session({"session_id": "shared", "agent_type": "claude_code",
+                          "title": "cc-side"})
+    rows = store._fetch("SELECT agent_type, title FROM sessions ORDER BY agent_type", [])
+    assert len(rows) == 2
+    assert rows[0] == ("claude_code", "cc-side")
+    assert rows[1] == ("openclaw", "openclaw-side")
+
+
+def test_ingest_memory_blob_dedups_on_sha256(store):
+    blob = b"# Notes\n\nFirst draft of project notes."
+    store.ingest_memory_blob({
+        "agent_type": "openclaw",
+        "agent_id": "main",
+        "path": "~/.openclaw/memory/notes.md",
+        "ts": "2026-05-11T10:00:00Z",
+        "blob": blob,
+    })
+    rows1 = store._fetch("SELECT COUNT(*), MAX(updated_at) FROM memory_blobs", [])
+    # Re-ingest identical content → no new write.
+    store.ingest_memory_blob({
+        "agent_type": "openclaw",
+        "agent_id": "main",
+        "path": "~/.openclaw/memory/notes.md",
+        "ts": "2026-05-11T10:05:00Z",
+        "blob": blob,
+    })
+    rows2 = store._fetch("SELECT COUNT(*), MAX(updated_at) FROM memory_blobs", [])
+    assert rows1[0][0] == 1
+    assert rows2[0][0] == 1
+    # updated_at should NOT advance on the dedup'd write.
+    assert rows1[0][1] == rows2[0][1]
+
+
+def test_ingest_memory_blob_updates_on_change(store):
+    store.ingest_memory_blob({
+        "agent_type": "claude_code", "path": "CLAUDE.md",
+        "blob": b"v1 content", "ts": "2026-05-11T10:00:00Z",
+    })
+    store.ingest_memory_blob({
+        "agent_type": "claude_code", "path": "CLAUDE.md",
+        "blob": b"v2 content updated", "ts": "2026-05-11T11:00:00Z",
+    })
+    rows = store._fetch(
+        "SELECT blob, ts, size_bytes FROM memory_blobs WHERE path = 'CLAUDE.md'", [],
+    )
+    assert len(rows) == 1
+    assert bytes(rows[0][0]) == b"v2 content updated"
+    assert rows[0][1] == "2026-05-11T11:00:00Z"
+    assert rows[0][2] == len(b"v2 content updated")
+
+
+def test_ingest_heartbeat_appends(store):
+    """Heartbeats are append-only by (agent_type, node_id, ts)."""
+    store.ingest_heartbeat({
+        "node_id": "agent+test", "ts": "2026-05-11T10:00:00Z",
+        "version": "0.12.165", "e2e": True,
+        "local_store_size_mb": 0.5,
+        "local_store": {"events_total": 100},
+    })
+    store.ingest_heartbeat({
+        "node_id": "agent+test", "ts": "2026-05-11T10:05:00Z",
+        "version": "0.12.165", "e2e": True,
+        "local_store_size_mb": 0.6,
+        "local_store": {"events_total": 120},
+    })
+    # Same ts is silently ignored (PK conflict).
+    store.ingest_heartbeat({
+        "node_id": "agent+test", "ts": "2026-05-11T10:05:00Z",
+        "version": "0.12.165", "e2e": True, "local_store_size_mb": 999,
+    })
+    rows = store._fetch(
+        "SELECT ts, size_mb, events_total FROM heartbeats ORDER BY ts", [],
+    )
+    assert len(rows) == 2
+    assert rows[0][1] == 0.5
+    assert rows[0][2] == 100
+    assert rows[1][1] == 0.6
+    assert rows[1][2] == 120
+
+
+def test_ingest_session_requires_session_id(store):
+    with pytest.raises(ValueError, match="session_id"):
+        store.ingest_session({"agent_type": "openclaw"})
+
+
+def test_ingest_memory_blob_requires_agent_type_and_path(store):
+    with pytest.raises(ValueError, match="agent_type"):
+        store.ingest_memory_blob({"path": "x"})
+    with pytest.raises(ValueError, match="path"):
+        store.ingest_memory_blob({"agent_type": "claude_code"})
+
+
+def test_v1_to_v2_migration_adds_agent_type_column(tmp_path, monkeypatch):
+    """A store created at SCHEMA_VERSION=1 (events table without agent_type)
+    must auto-upgrade to v2 on next open without losing data."""
+    db_path = tmp_path / "events.duckdb"
+    # Manually create a v1 events table (without agent_type).
+    with duckdb.connect(str(db_path)) as v1_conn:
+        v1_conn.execute("""
+            CREATE TABLE events (
+                id            VARCHAR PRIMARY KEY,
+                node_id       VARCHAR NOT NULL,
+                agent_id      VARCHAR NOT NULL DEFAULT 'main',
+                session_id    VARCHAR,
+                workspace_id  VARCHAR,
+                event_type    VARCHAR NOT NULL,
+                ts            VARCHAR NOT NULL,
+                data          BLOB,
+                cost_usd      DOUBLE,
+                token_count   INTEGER,
+                model         VARCHAR,
+                created_at    BIGINT NOT NULL
+            )
+        """)
+        v1_conn.execute("""
+            CREATE TABLE daily_aggregates (
+                agent_id      VARCHAR NOT NULL,
+                workspace_id  VARCHAR,
+                day           VARCHAR NOT NULL,
+                cost_usd      DOUBLE DEFAULT 0,
+                token_count   INTEGER DEFAULT 0,
+                event_count   INTEGER DEFAULT 0,
+                error_count   INTEGER DEFAULT 0,
+                PRIMARY KEY (agent_id, workspace_id, day)
+            )
+        """)
+        v1_conn.execute("""
+            CREATE TABLE schema_version (
+                version    INTEGER PRIMARY KEY,
+                applied_at BIGINT NOT NULL
+            )
+        """)
+        v1_conn.execute("INSERT INTO schema_version VALUES (1, 1700000000000)")
+        v1_conn.execute(
+            "INSERT INTO events VALUES (?, ?, 'main', NULL, NULL, 'tool_call', ?, NULL, 0.001, 5, 'claude-opus-4-7', ?)",
+            ["legacy-1", "agent+legacy", "2026-05-10T12:00:00Z", 1700000001000],
+        )
+
+    # Open via the production code path → should migrate seamlessly.
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(db_path))
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.get_store()
+    try:
+        cols = {row[1] for row in store._conn.execute("PRAGMA table_info('events')").fetchall()}
+        assert "agent_type" in cols, "v1→v2 migration didn't add agent_type column"
+        # Legacy event is still readable + agent_type backfilled to 'openclaw'.
+        rows = store._fetch(
+            "SELECT id, agent_type, event_type FROM events WHERE id = 'legacy-1'", [],
+        )
+        assert rows[0][1] == "openclaw"
+        assert rows[0][2] == "tool_call"
+    finally:
+        try:
+            store.stop(flush=True)
+        except Exception:
+            pass

--- a/tests/test_local_store_sync_integration.py
+++ b/tests/test_local_store_sync_integration.py
@@ -158,3 +158,101 @@ def test_id_synthesised_when_missing(sync_with_isolated_store):
     _wait_for_flush(store)
     rows = store.query_events(session_id="s")
     assert len(rows) == 1
+
+
+# ── PR 2: write-through for sessions / memory / heartbeat ─────────────────
+
+
+def test_local_ingest_sessions_batch_upserts_into_sessions_table(sync_with_isolated_store):
+    sync, ls = sync_with_isolated_store
+    rows = [
+        {
+            "session_id": "sess-1",
+            "model": "claude-opus-4-7",
+            "total_tokens": 12500,
+            "total_cost": 0.42,
+            "started_at": "2026-05-11T10:00:00Z",
+            "updated_at": "2026-05-11T10:30:00Z",
+            "status": "completed",
+            "subject": "Refactoring routes/sessions.py",
+            "channel": "telegram",
+            "chat_type": "private",
+        },
+        {
+            "session_id": "sess-2",
+            "model": "claude-opus-4-7",
+            "total_tokens": 800,
+            "total_cost": 0.03,
+            "status": "active",
+        },
+    ]
+    sync._local_ingest_sessions_batch(rows, node_id="agent+test")
+    store = ls.get_store()
+    out = store._fetch(
+        "SELECT session_id, total_tokens, cost_usd, title, status FROM sessions ORDER BY session_id",
+        [],
+    )
+    assert len(out) == 2
+    assert out[0] == ("sess-1", 12500, 0.42, "Refactoring routes/sessions.py", "completed")
+    assert out[1][0] == "sess-2"
+    assert out[1][4] == "active"
+
+
+def test_local_ingest_sessions_batch_handles_empty_and_id_aliases(sync_with_isolated_store):
+    """Empty list = no-op. Rows missing session_id but with `id` get stored."""
+    sync, ls = sync_with_isolated_store
+    sync._local_ingest_sessions_batch([], node_id="x")  # must not raise
+    sync._local_ingest_sessions_batch(
+        [{"id": "from-id-field", "model": "m", "total_cost": 0.01}],
+        node_id="agent+test",
+    )
+    out = ls.get_store()._fetch("SELECT session_id FROM sessions", [])
+    assert ("from-id-field",) in out
+
+
+def test_local_ingest_memory_files_writes_only_changed(sync_with_isolated_store):
+    sync, ls = sync_with_isolated_store
+    all_files = [
+        ("MEMORY.md", "# All my notes"),
+        ("AGENTS.md", "# Agent roster"),
+        ("memory/notes.md", "# Subnotes"),
+    ]
+    # Only AGENTS.md changed this cycle.
+    sync._local_ingest_memory_files(all_files, ["AGENTS.md"])
+    store = ls.get_store()
+    rows = store._fetch(
+        "SELECT path, blob FROM memory_blobs ORDER BY path", [],
+    )
+    assert len(rows) == 1
+    assert rows[0][0] == "AGENTS.md"
+    assert bytes(rows[0][1]) == b"# Agent roster"
+
+
+def test_local_ingest_memory_files_dedups_on_resync(sync_with_isolated_store):
+    """Same content re-ingested = sha256 dedup, no row update."""
+    sync, ls = sync_with_isolated_store
+    files = [("MEMORY.md", "stable content here")]
+    sync._local_ingest_memory_files(files, ["MEMORY.md"])
+    rows1 = ls.get_store()._fetch(
+        "SELECT updated_at FROM memory_blobs WHERE path='MEMORY.md'", [],
+    )
+    sync._local_ingest_memory_files(files, ["MEMORY.md"])
+    rows2 = ls.get_store()._fetch(
+        "SELECT updated_at FROM memory_blobs WHERE path='MEMORY.md'", [],
+    )
+    assert rows1[0][0] == rows2[0][0]
+
+
+def test_local_ingest_sessions_batch_failure_does_not_break_caller(sync_with_isolated_store):
+    """If the local store throws (e.g. corrupt file), the caller should
+    catch — verified by patching ingest_session to raise."""
+    sync, ls = sync_with_isolated_store
+    store = ls.get_store()
+    with patch.object(store, "ingest_session", side_effect=RuntimeError("disk full")):
+        # The helper itself doesn't catch; the CALLER (sync_session_metadata's
+        # _flush) catches via try/except. Here we just verify the helper
+        # propagates the exception so the caller's try/except sees it.
+        with pytest.raises(RuntimeError, match="disk full"):
+            sync._local_ingest_sessions_batch(
+                [{"session_id": "x"}], node_id="agent+test"
+            )

--- a/tests/test_sessions_local_fastpath.py
+++ b/tests/test_sessions_local_fastpath.py
@@ -1,0 +1,119 @@
+"""Tests for the /api/sessions local-store fast path (epic #964 PR 3 of 3).
+
+Same opt-in pattern as test_brain_local_fastpath.py:
+- CLAWMETRY_LOCAL_STORE_READ=1 + populated store → returns from DuckDB
+- Flag unset → falls through to legacy gateway/JSONL path
+- Empty store → falls through (so fresh installs see normal data)
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_sessions_fast_path_returns_local_rows(app):
+    a, ls = app
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": "sess-fast-A",
+        "agent_type": "openclaw",
+        "title": "Refactoring routes/sessions.py",
+        "started_at": "2026-05-11T10:00:00Z",
+        "last_active_at": "2026-05-11T10:30:00Z",
+        "status": "active",
+        "total_tokens": 12500,
+        "cost_usd": 0.42,
+        "message_count": 17,
+        "metadata": {"channel": "telegram"},
+    })
+    store.ingest_session({
+        "session_id": "sess-fast-B",
+        "agent_type": "claude_code",
+        "title": "Adding multi-agent schema",
+        "started_at": "2026-05-11T09:00:00Z",
+        "last_active_at": "2026-05-11T11:00:00Z",
+        "status": "active",
+        "total_tokens": 50000,
+        "cost_usd": 1.7,
+    })
+
+    c = a.test_client()
+    r = c.get("/api/sessions")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert len(body["sessions"]) == 2
+    by_id = {s["session_id"]: s for s in body["sessions"]}
+    # Most-recent-first: B (11:00) before A (10:30)
+    assert body["sessions"][0]["session_id"] == "sess-fast-B"
+    assert by_id["sess-fast-A"]["agent_type"] == "openclaw"
+    assert by_id["sess-fast-B"]["agent_type"] == "claude_code"
+    assert by_id["sess-fast-A"]["channel"] == "telegram"
+    assert by_id["sess-fast-A"]["total_cost"] == 0.42
+
+
+def test_sessions_fast_path_falls_back_when_store_empty(app):
+    """Empty store → fast path returns None → legacy path runs (which we
+    can't easily exercise here, so we just verify no _source tag)."""
+    a, _ls = app
+    c = a.test_client()
+    r = c.get("/api/sessions")
+    # Falls through to gateway path (returns 500 in unit-test context with
+    # no gateway, OR returns sessions if there's a workspace; either way
+    # it's NOT tagged _source: local_store).
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+
+
+def test_sessions_fast_path_disabled_without_flag(tmp_path, monkeypatch):
+    """No CLAWMETRY_LOCAL_STORE_READ → fast path never runs even with
+    a populated store. Default = zero behavior change for existing deploys."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": "sess-noflag",
+        "agent_type": "openclaw",
+        "title": "Should not appear",
+        "started_at": "2026-05-11T10:00:00Z",
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    r = a.test_client().get("/api/sessions")
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
Dashboard half of the multi-agent local-store plan. Same opt-in pattern as the brain-history fast path that shipped in 0.12.165:
- \`CLAWMETRY_LOCAL_STORE_READ=1\` + populated sessions table → return directly from local DuckDB (tagged \`_source: \"local_store\"\`)
- Flag unset OR empty store → fall through to existing gateway/JSONL path (zero behavior change for existing deploys)

**Stacks on top of #997 (PR 2: write-through)** which stacks on #995 (PR 1: schema). Merge order: 995 → 997 → this PR.

## Once all three land
- PR 1 (#995): tables for sessions, memory_blobs, heartbeats, system_snapshots, etc.
- PR 2 (#997): daemon writes sessions/memory/heartbeats to local DuckDB on every cloud sync
- PR 3 (this): dashboard reads sessions back from local DuckDB

End-to-end pipeline: events + sessions + memory + heartbeats all live in \`~/.clawmetry/events.duckdb\` and the dashboard can query them without re-parsing JSONL or hitting the gateway. Robust E2E tests become trivial — fixture the DB, hit the API, assert.

## Out of scope (mechanical follow-ups using this PR's pattern)
- \`/api/usage\` local-store fast path — token cost charts → \`daily_aggregates\` table
- \`/api/memory-files\` local-store fast path → \`memory_blobs\` table
- \`/api/heartbeat-history\` new endpoint exposing the \`heartbeats\` table

## Test plan
- [x] \`pytest tests/test_sessions_local_fastpath.py\` — 3/3
- [x] Full local-store regression — 67/67

🤖 Generated with [Claude Code](https://claude.com/claude-code)