### PR TITLE
feat(local-store): rename events.duckdb → clawmetry.duckdb (auto-migrate)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -55,16 +55,59 @@ log = logging.getLogger("clawmetry.local_store")
 # Public knobs — tuned for the common case (one daemon, one dashboard, ≤1 K
 # events/s sustained on a developer laptop). Adjust via env vars only.
 
-# Note: changed from events.db (SQLite, in 0.12.164) → events.duckdb. The
-# old file is left in place if present; the new file is created fresh.
-# The 0.12.164 SQLite file was live for hours at most; treating its data
-# as disposable is fine.
+# Naming history:
+#   0.12.164  → events.db    (SQLite — replaced by DuckDB the same release)
+#   0.12.165  → events.duckdb (DuckDB; name implied "only events" but we
+#                              also store sessions, memory_blobs, heartbeats,
+#                              system_snapshots, spans, etc. in this same DB)
+#   0.12.166+ → clawmetry.duckdb (the all-up local store for whatever
+#                                 ClawMetry needs across multi-agent
+#                                 frameworks — past + future tables)
+#
+# Compatibility: if a user has an existing events.duckdb but no
+# clawmetry.duckdb, the next start renames it in place. Lossless,
+# no schema change. See _migrate_legacy_db_path() below.
 DB_PATH = Path(
     os.environ.get(
         "CLAWMETRY_LOCAL_STORE_PATH",
-        os.path.expanduser("~/.clawmetry/events.duckdb"),
+        os.path.expanduser("~/.clawmetry/clawmetry.duckdb"),
     )
 )
+LEGACY_DB_PATH = Path(os.path.expanduser("~/.clawmetry/events.duckdb"))
+
+
+def _migrate_legacy_db_path() -> None:
+    """If the old events.duckdb exists and the new clawmetry.duckdb doesn't,
+    rename in place. Single os.rename — atomic on POSIX. Safe to call on
+    every start; no-op when there's nothing to migrate.
+
+    We intentionally DON'T touch the legacy file when the new name already
+    exists (would lose data) and DON'T touch CLAWMETRY_LOCAL_STORE_PATH-
+    overridden paths (test fixtures, custom installs)."""
+    if "CLAWMETRY_LOCAL_STORE_PATH" in os.environ:
+        return  # Custom path; user knows what they're doing.
+    if not LEGACY_DB_PATH.exists():
+        return
+    if DB_PATH.exists():
+        # Both files present — keep the new one as live. Don't clobber.
+        log.info("local store: legacy events.duckdb still present alongside "
+                 "clawmetry.duckdb. Keeping clawmetry.duckdb; old file "
+                 "untouched (delete manually if you want to reclaim space).")
+        return
+    try:
+        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        LEGACY_DB_PATH.rename(DB_PATH)
+        # Move the WAL too so DuckDB recovers cleanly on first open.
+        legacy_wal = LEGACY_DB_PATH.with_suffix(LEGACY_DB_PATH.suffix + ".wal")
+        new_wal = DB_PATH.with_suffix(DB_PATH.suffix + ".wal")
+        if legacy_wal.exists() and not new_wal.exists():
+            legacy_wal.rename(new_wal)
+        log.info("local store: migrated legacy %s → %s",
+                 LEGACY_DB_PATH.name, DB_PATH.name)
+    except OSError as e:
+        log.warning("local store: failed to migrate legacy %s → %s: %s. "
+                    "Will create a fresh clawmetry.duckdb; old file "
+                    "untouched.", LEGACY_DB_PATH.name, DB_PATH.name, e)
 
 FLUSH_INTERVAL_SECS = float(os.environ.get("CLAWMETRY_LOCAL_FLUSH_SECS", "2.0"))
 FLUSH_BATCH = int(os.environ.get("CLAWMETRY_LOCAL_FLUSH_BATCH", "1000"))
@@ -346,6 +389,10 @@ class LocalStore:
         self._flusher_stop = threading.Event()
         self._flusher_thread: threading.Thread | None = None
         self._last_flush_ts = time.monotonic()
+        # Rename the legacy events.duckdb in place BEFORE opening — once
+        # we hold a connection we can't atomically rename the file out
+        # from under DuckDB.
+        _migrate_legacy_db_path()
         self._conn = _open_connection(read_only=False)
         self._migrate()
 

--- a/tests/test_local_store_rename.py
+++ b/tests/test_local_store_rename.py
@@ -1,0 +1,133 @@
+"""Tests for the events.duckdb → clawmetry.duckdb rename + auto-migration.
+
+These run against the real default path mechanism (no
+CLAWMETRY_LOCAL_STORE_PATH env var) by monkeypatching the module-level
+constants — the migration intentionally bails out when the env var is
+set, so we can't isolate via tmp_path the way other tests do.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import duckdb
+import pytest
+
+
+def _reload_local_store(monkeypatch, tmp_path, env_override=False):
+    """Reload local_store with DB_PATH and LEGACY_DB_PATH pointed at tmp.
+    By default removes CLAWMETRY_LOCAL_STORE_PATH so the migration runs."""
+    if env_override:
+        monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH",
+                           str(tmp_path / "custom.duckdb"))
+    else:
+        monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_PATH", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Override the module-level paths to live in tmp_path so we don't
+    # touch the user's real ~/.clawmetry/.
+    monkeypatch.setattr(ls, "DB_PATH", tmp_path / "clawmetry.duckdb")
+    monkeypatch.setattr(ls, "LEGACY_DB_PATH", tmp_path / "events.duckdb")
+    return ls
+
+
+def _seed_legacy_file(path: Path):
+    """Write a minimal valid DuckDB file at the legacy location with one row
+    so the migration is observably moving real data, not just an empty file."""
+    with duckdb.connect(str(path)) as c:
+        c.execute("CREATE TABLE marker (token VARCHAR)")
+        c.execute("INSERT INTO marker VALUES ('legacy-file-was-here')")
+
+
+def test_migration_renames_legacy_file_when_new_absent(tmp_path, monkeypatch):
+    legacy = tmp_path / "events.duckdb"
+    new = tmp_path / "clawmetry.duckdb"
+    _seed_legacy_file(legacy)
+    assert legacy.exists()
+    assert not new.exists()
+
+    ls = _reload_local_store(monkeypatch, tmp_path)
+    ls._migrate_legacy_db_path()
+
+    # Legacy file moved to the new name.
+    assert not legacy.exists(), "legacy events.duckdb should be gone"
+    assert new.exists(), "clawmetry.duckdb should exist"
+
+    # Data preserved.
+    with duckdb.connect(str(new)) as c:
+        rows = c.execute("SELECT token FROM marker").fetchall()
+    assert rows == [("legacy-file-was-here",)]
+
+
+def test_migration_skips_when_env_overrides_path(tmp_path, monkeypatch):
+    """If CLAWMETRY_LOCAL_STORE_PATH is set, the user has chosen a custom
+    path (e.g. test fixture). Don't surprise them by renaming files at
+    the default location."""
+    legacy = tmp_path / "events.duckdb"
+    _seed_legacy_file(legacy)
+
+    ls = _reload_local_store(monkeypatch, tmp_path, env_override=True)
+    ls._migrate_legacy_db_path()
+
+    # Legacy file untouched.
+    assert legacy.exists()
+
+
+def test_migration_keeps_new_when_both_exist(tmp_path, monkeypatch):
+    """Both files present (e.g. user hand-copied). Keep the new one;
+    don't clobber. Legacy stays for manual recovery."""
+    legacy = tmp_path / "events.duckdb"
+    new = tmp_path / "clawmetry.duckdb"
+    _seed_legacy_file(legacy)
+    # Seed new with different marker so we can tell them apart.
+    with duckdb.connect(str(new)) as c:
+        c.execute("CREATE TABLE marker (token VARCHAR)")
+        c.execute("INSERT INTO marker VALUES ('new-file-already-existed')")
+
+    ls = _reload_local_store(monkeypatch, tmp_path)
+    ls._migrate_legacy_db_path()
+
+    # Both still exist.
+    assert legacy.exists()
+    assert new.exists()
+    # New file unchanged.
+    with duckdb.connect(str(new)) as c:
+        rows = c.execute("SELECT token FROM marker").fetchall()
+    assert rows == [("new-file-already-existed",)]
+
+
+def test_migration_noop_when_neither_exists(tmp_path, monkeypatch):
+    """Fresh install — nothing to migrate. Must not crash."""
+    ls = _reload_local_store(monkeypatch, tmp_path)
+    ls._migrate_legacy_db_path()
+    assert not (tmp_path / "events.duckdb").exists()
+    assert not (tmp_path / "clawmetry.duckdb").exists()
+
+
+def test_migration_moves_wal_alongside_db(tmp_path, monkeypatch):
+    """DuckDB writes a sibling .wal file. Migration must move both
+    so the next open recovers cleanly instead of seeing an orphaned WAL."""
+    legacy = tmp_path / "events.duckdb"
+    legacy_wal = tmp_path / "events.duckdb.wal"
+    _seed_legacy_file(legacy)
+    legacy_wal.write_bytes(b"fake wal content")
+
+    ls = _reload_local_store(monkeypatch, tmp_path)
+    ls._migrate_legacy_db_path()
+
+    assert not legacy.exists()
+    assert not legacy_wal.exists()
+    assert (tmp_path / "clawmetry.duckdb").exists()
+    assert (tmp_path / "clawmetry.duckdb.wal").exists()
+    assert (tmp_path / "clawmetry.duckdb.wal").read_bytes() == b"fake wal content"
+
+
+def test_default_db_path_is_clawmetry_duckdb(monkeypatch):
+    """Smoke: with no env override, DB_PATH defaults to ~/.clawmetry/clawmetry.duckdb,
+    not events.duckdb. Locks the rename in."""
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_PATH", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    assert ls.DB_PATH.name == "clawmetry.duckdb"
+    assert ls.LEGACY_DB_PATH.name == "events.duckdb"


### PR DESCRIPTION
## Why
The local DuckDB now holds events, sessions, memory_blobs, heartbeats, system_snapshots, crons, subagents (and soon spans for tracing). `events.duckdb` implies only one of those. Renaming to `clawmetry.duckdb` to reflect that this is the all-up local store across multi-agent frameworks.

## Auto-migration
`_migrate_legacy_db_path()` runs at LocalStore.\__init__\() BEFORE the connection opens:
- If `CLAWMETRY_LOCAL_STORE_PATH` env is set → skip (user has custom path)
- If legacy `events.duckdb` doesn't exist → skip (fresh install)
- If `clawmetry.duckdb` already exists → keep new, log warning, leave legacy
- Otherwise → `os.rename` (atomic on POSIX), plus the .wal sibling

Lossless. No schema change. Single os.rename per file.

## Test plan
- [x] 6 new tests in `test_local_store_rename.py` covering happy path, env override, both-files-present, no-op, WAL move, default path
- [x] Full local-store regression — 61/61 passing

## Versioning note
Will land in 0.12.166. Next `[RELEASE]` PR brings it to PyPI.