### PR TITLE
[RELEASE] feat: multi-agent schema, clawmetry.duckdb rename, websocket-client base dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,60 @@
 ## [Unreleased]
 
-### Local-first relay (epic #964 phase 3b + 1b)
-- **Daemon-side WebSocket relay client** (`clawmetry/relay.py`) — long-lived WS to `wss://app.clawmetry.com/api/node/relay`. Listens for `{type:"query"}` frames from the cloud, dispatches via the same `relay_dispatch()` the local HTTP API uses, returns chunked responses. Reconnect with exponential backoff (2s → 60s cap). Skipped silently when no cloud account is configured (OSS-local users pay nothing).
-- **Optional dependency** — `websocket-client>=1.6` is in `extras_require["relay"]`, not the base install. `pip install clawmetry[relay]` to opt in. Daemon falls back to cloud-ingest-only mode when missing.
-- **Heartbeat now reports `local_store_size_mb`** + `local_store` health block (engine, size_bytes, events_total, ring_depth). The cloud-side rollout playbook gates phase 2 (cloud retention slim) on ≥80% adoption of this signal.
-- **Brain history opt-in fast path** — `CLAWMETRY_LOCAL_STORE_READ=1` makes `/api/brain-history` return directly from local DuckDB (tagged `_source: "local_store"`) instead of re-parsing JSONL. Falls through to legacy parser if env var unset OR store is empty — zero-change default.
-- 11 new tests cover relay dispatch, chunking, error frames, capability drift, brain fast path, and JSONL fallback.
+### Local store: multi-agent foundation + naming (epic #964)
+- **Local DB renamed** `events.duckdb` → `clawmetry.duckdb`. The DB now
+  holds events, sessions, memory blobs, heartbeats, system snapshots
+  (and soon spans for tracing) — `events.duckdb` was outgrowing its name.
+  **Auto-migrates** an existing `events.duckdb` (and its `.wal` sibling)
+  on next start. Lossless, no schema change. Skipped if you've set
+  `CLAWMETRY_LOCAL_STORE_PATH` to a custom location.
+- **Multi-agent schema** (SCHEMA_VERSION 1 → 2). New tables: `sessions`,
+  `memory_blobs`, `heartbeats`, `system_snapshots`, `crons`, `subagents`,
+  `openclaw_channels`. `agent_type` discriminator added to `events` and
+  `daily_aggregates` so OpenClaw / Claude Code / Hermes / Cursor / Codex /
+  Aider all coexist in one store. v1 stores auto-upgraded with `ALTER
+  TABLE ADD COLUMN agent_type DEFAULT 'openclaw'` — legacy rows preserved.
+- **Daemon write-through for sessions / memory / heartbeats**. Each cloud
+  sync (`/ingest/sessions`, `/ingest/memory`, `/ingest/heartbeat`) now also
+  persists locally before shipping to cloud. Best-effort; local failures
+  never block cloud sync.
+- **Dashboard reads sessions from local DB** under
+  `CLAWMETRY_LOCAL_STORE_READ=1` (opt-in, falls through to gateway/JSONL
+  when unset OR store is empty).
+
+### Cloud cold-data relay (epic #964 phases 3b + 4)
+- **WebSocket relay client** (`clawmetry/relay.py`) — long-lived WS to
+  `wss://app.clawmetry.com/api/node/relay`. Listens for `{type:"query"}`
+  frames from the cloud, dispatches via the same `relay_dispatch()` the
+  local HTTP API uses, returns chunked responses. Reconnect with
+  exponential backoff (2s → 60s cap). Cloud dashboard can now ask the
+  user's machine for data older than the 24h hot window without us paying
+  for permanent cloud storage.
+- **`websocket-client` is now a base install dep** (was previously
+  `extras_require["relay"]`). The opt-in caused cloud users to silently
+  miss the relay. `pip install clawmetry && clawmetry connect` "just works"
+  again. The `[relay]` extra is kept as a no-op for backwards compat with
+  old install scripts.
+- Cloud-side broker shipped in `clawmetry-cloud#705` + `#711` + `#712`
+  (gunicorn + gevent-websocket migration so flask-sock can do WS upgrades
+  in production).
+
+### Heartbeat
+- **`local_store_size_mb`** + `local_store` health block on every
+  heartbeat. Cloud-side rollout playbook will gate phase 2 (cloud
+  retention slim) on ≥80% of nodes reporting healthy local stores.
+
+### Brain history
+- **Opt-in fast path** under `CLAWMETRY_LOCAL_STORE_READ=1` —
+  `/api/brain-history` returns directly from the local DuckDB (tagged
+  `_source: "local_store"`) instead of re-parsing JSONL. Falls through to
+  the legacy parser when the env var is unset OR the store is empty.
+
+### Tests
+- 70+ new tests covering: relay dispatch, chunking, error frames,
+  capability drift, brain fast-path, sessions fast-path, schema
+  migration v1→v2, ingest_session/memory_blob/heartbeat helpers, daemon
+  write-through, the events.duckdb→clawmetry.duckdb rename + WAL move,
+  env-override skip, no-clobber when both files exist.
 
 ### Local-first foundation (epic #964 phase 1) — first shipped in 0.12.164
 - **Local DuckDB event store** at `~/.clawmetry/events.duckdb` — durable record of every telemetry event the daemon parses. Switched from SQLite to DuckDB (decision in clawmetry-cloud meta-PRD): columnar storage makes the dashboard's GROUP BY / time-window analytics 10–100× faster, and unlocks future Parquet export. Adds `duckdb>=0.10` as a dependency.

--- a/clawmetry/relay.py
+++ b/clawmetry/relay.py
@@ -6,9 +6,9 @@ waits for `{type:"query"}` frames from the cloud, dispatches each via
 
 Design notes
 ------------
-- **Optional dependency.** `websocket-client` is in `extras_require["relay"]`,
-  not the base install. If it's missing the relay simply doesn't start; the
-  daemon keeps working in cloud-ingest-only mode.
+- **Base install dep** since 0.12.166. `websocket-client` is ~100 KB pure
+  Python; the previous `extras_require["relay"]` opt-in caused cloud users
+  to silently miss the relay.
 - **Daemon thread.** One thread per process. Reconnects with exponential
   backoff (2s → 60s cap). The sync daemon's main loop is unaware.
 - **Skipped on OSS-local mode.** If `config` has no `api_key` / `node_id`,
@@ -63,9 +63,12 @@ def start_relay_thread(config: dict, version: str = "unknown") -> Optional[threa
     try:
         import websocket  # noqa: F401 — pull dep early to fail fast
     except ImportError:
-        log.info(
-            "relay: websocket-client not installed; cloud cold-data relay disabled. "
-            "Install with `pip install clawmetry[relay]` to enable.")
+        # 0.12.166+ ships websocket-client as a base dep, so this branch
+        # only fires on a corrupt install. Keep the message anyway in case
+        # someone's pinning to an older clawmetry transitively.
+        log.warning(
+            "relay: websocket-client not importable. The base install should "
+            "include it; reinstall with `pip install --force-reinstall clawmetry`.")
         return None
 
     relay_url = os.environ.get("CLAWMETRY_RELAY_URL", RELAY_URL_DEFAULT)

--- a/dashboard.py
+++ b/dashboard.py
@@ -112,7 +112,6 @@ from routes.selfconfig import bp_selfconfig
 from routes.agents import bp_agents
 from routes.reasoning import bp_reasoning
 from routes.plugins import bp_plugins
-from routes.agents import bp_agents
 from routes.local_query import bp_local_query
 from helpers.openapi import bp_openapi
 
@@ -8495,7 +8494,6 @@ def detect_config(args=None):
     app.register_blueprint(bp_agents)
     app.register_blueprint(bp_reasoning)
     app.register_blueprint(bp_plugins)
-    app.register_blueprint(bp_agents)
     app.register_blueprint(bp_local_query)
 
     # Register built-in agent adapters. External plugins can register more

--- a/setup.py
+++ b/setup.py
@@ -43,17 +43,22 @@ setup(
         "flask>=2.0,<4",
         "waitress>=2.0",
         "cryptography>=3.0",
-        # Local event store at ~/.clawmetry/events.duckdb (epic #964 phase 1).
-        # DuckDB chosen over stdlib sqlite3 for its columnar analytical
-        # advantages on the dashboard's GROUP BY / time-window workloads.
+        # Local store at ~/.clawmetry/clawmetry.duckdb. Holds events,
+        # sessions, memory, heartbeats, system snapshots, traces. ~14 MB
+        # wheel; columnar storage gives 10–100× speed vs SQLite for the
+        # dashboard's GROUP BY/time-window workloads (epic #964).
         "duckdb>=0.10",
+        # Cloud cold-data relay tunnel (epic #964 phase 3b). ~100 KB pure
+        # Python. Was previously in extras_require["relay"]; the opt-in
+        # made cloud users silently miss the relay. Now base install so
+        # `pip install clawmetry && clawmetry connect` "just works".
+        "websocket-client>=1.6",
     ],
     extras_require={
-        "otel":  ["opentelemetry-proto>=1.20.0", "protobuf>=4.21.0"],
-        # Cloud cold-data relay tunnel (epic #964 phase 3b). Optional —
-        # if missing, the daemon runs in cloud-ingest-only mode and the
-        # cloud dashboard can't request data older than its 24h window.
-        "relay": ["websocket-client>=1.6"],
+        "otel": ["opentelemetry-proto>=1.20.0", "protobuf>=4.21.0"],
+        # Kept for back-compat with `pip install clawmetry[relay]` calls
+        # in old install scripts. No-op in 0.12.166+.
+        "relay": [],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## 0.12.165 → 0.12.166

Bundles everything since 0.12.165 + one user-feedback change: `websocket-client` moves from `extras_require["relay"]` to base install.

### Why the websocket-client change
duckdb (14 MB wheel) was base install; websocket-client (~100 KB pure Python) was gated behind `pip install clawmetry[relay]`. That ordering was backwards — and the opt-in caused cloud users to silently miss the relay. Now `pip install clawmetry && clawmetry connect` just works. `[relay]` extra kept as a no-op so old install scripts don't break.

### What's in this release
- **Local DB renamed** `events.duckdb` → `clawmetry.duckdb` with lossless auto-migration of existing files (PR #1014)
- **Multi-agent schema v2** — sessions, memory_blobs, heartbeats, system_snapshots, crons, subagents, openclaw_channels (PR #995)
- **Daemon write-through** — sessions/memory/heartbeats persist locally before cloud sync (PR #997)
- **Dashboard sessions fast path** under `CLAWMETRY_LOCAL_STORE_READ=1` (PR #998)
- **WebSocket relay client** — long-lived WS to the cloud broker for cold-data queries (PR #992)
- **Heartbeat `local_store_size_mb`** field — Phase 2 rollout gate
- **Brain history fast path** — `/api/brain-history` reads from local DuckDB under the flag

### Cloud side (separate PRs in clawmetry-cloud)
- #705 broker, #706 SWR helper, #708 fleet fan-out, #711 auth bypass, #712 gunicorn + gevent migration, #713 dockerignore fix
- End-to-end verified: HTTP/1.1 WS handshake to `wss://app.clawmetry.com/api/node/relay` returns 101 Switching Protocols

### Tests
- 73/73 local-store-related tests passing
- 19/19 cloud-contract smoke passed on candidate before traffic flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)