### PR TITLE
feat(telemetry): anonymous, opt-out, first-run install ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,42 @@ This project is tested with BrowserStack.
 
 [![BrowserStack](https://img.shields.io/badge/tested%20with-BrowserStack-orange.svg)](https://browserstack.com)
 
+## Telemetry
+
+ClawMetry sends a single anonymous "first run" ping to
+`https://app.clawmetry.com/api/install` the first time you run the
+`clawmetry` CLI on a new machine. We use this to count installs (the
+only marketing metric we have for an OSS project) and to learn which
+agent frameworks our users have installed.
+
+**Exactly one POST per install**, containing:
+
+| Field | Example | Why |
+|---|---|---|
+| `install_id` | random UUID stored at `~/.clawmetry/install_id` | dedup; not linked to your email or api_key |
+| `version` | `0.12.167` | what versions are in the wild |
+| `os` / `os_version` | `Darwin` / `25.3.0` | platform support priorities |
+| `python` | `3.11.15` | Python version support matrix |
+| `agent` | `openclaw` / `nemoclaw` / `hermes` / `none` | which agents we should integrate with next |
+| `is_ci` / `ci_provider` | `true` / `github_actions` | separate human installs from CI noise |
+
+**What we do NOT send**: IP (cloud derives the country code server-side
+from the request, then discards the IP), hostname, username, workspace
+path, file contents, your api_key, your email, anything PII or
+workspace-specific. The wire payload is auditable in
+[`clawmetry/telemetry.py`](clawmetry/telemetry.py).
+
+**Opt out** (any one of these disables it permanently):
+
+```bash
+export CLAWMETRY_NO_TELEMETRY=1                # per-shell
+export DO_NOT_TRACK=1                          # W3C cross-tool standard
+touch ~/.clawmetry/notelemetry                 # persistent file marker
+```
+
+A network failure here never blocks `clawmetry` from running — the
+ping is fire-and-forget on a daemon thread with a 3 s timeout.
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=vivekchand%2Fclawmetry&type=date&legend=top-left">

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2070,6 +2070,21 @@ def main() -> None:
     import argparse
     from dashboard import main as dashboard_main
 
+    # Anonymous, opt-out, once-per-install ping. See clawmetry/telemetry.py
+    # for the privacy contract. Fires on a daemon thread so a network
+    # failure can't slow CLI startup; honours CLAWMETRY_NO_TELEMETRY=1
+    # and ~/.clawmetry/notelemetry.
+    try:
+        from clawmetry import telemetry as _telemetry
+        try:
+            from dashboard import __version__ as _ver
+        except Exception:
+            _ver = "unknown"
+        _telemetry.maybe_ping(_ver)
+    except Exception:
+        # Never let telemetry plumbing break startup.
+        pass
+
     # Windows: protect against closed/detached stdout/stderr before any library
     # (argparse colour detection, click._winconsole) calls fileno() on them.
     #

--- a/clawmetry/telemetry.py
+++ b/clawmetry/telemetry.py
@@ -1,0 +1,247 @@
+"""clawmetry/telemetry.py — anonymous, opt-out, first-run install ping.
+
+What we send (one POST, max once per install):
+
+  {
+    "install_id":  "<random uuid4 stored in ~/.clawmetry/install_id>",
+    "event":       "first_run",
+    "version":     "0.12.167",
+    "os":          "Darwin",       # platform.system()
+    "os_version":  "25.3.0",       # platform.release()
+    "python":      "3.11.15",      # platform.python_version()
+    "agent":       "openclaw" | "nemoclaw" | "hermes" | "none",
+    "is_ci":       true / false,
+    "ci_provider": "github_actions" | "gitlab_ci" | …  (only if is_ci)
+  }
+
+What we DO NOT send: hostname, username, IP (cloud derives country from
+the request IP and discards the IP itself), api_key, email, workspace
+path, file contents, anything PII or workspace-specific.
+
+Opt-out (any one disables this module):
+  - export CLAWMETRY_NO_TELEMETRY=1
+  - export DO_NOT_TRACK=1                  (industry standard)
+  - touch ~/.clawmetry/notelemetry         (file marker for shared envs)
+
+The ping is fire-and-forget on a daemon thread with a 3s timeout. A
+network failure, DNS hijack, or the cloud being down NEVER affects
+``clawmetry`` startup or surfaces an error to the user.
+
+Why first-run instead of pip-install: PyPI removed install hooks years
+ago for supply-chain safety, so ``pip install clawmetry`` cannot phone
+home directly. We instead fire on first ``clawmetry`` CLI invocation,
+gated by ``~/.clawmetry/install_id`` so subsequent runs are silent.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import threading
+import time
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+TELEMETRY_URL_DEFAULT = "https://app.clawmetry.com/api/install"
+TELEMETRY_TIMEOUT_SEC = 3
+CONFIG_DIR = Path.home() / ".clawmetry"
+INSTALL_ID_FILE = CONFIG_DIR / "install_id"
+OPTOUT_MARKER = CONFIG_DIR / "notelemetry"
+
+# CI env-var → provider name. Order matters when more than one is set
+# (some providers leave others' vars in for back-compat); pick the most
+# specific. ``CI=true`` is a generic last-resort signal.
+_CI_PROVIDERS = (
+    ("GITHUB_ACTIONS",       "github_actions"),
+    ("GITLAB_CI",            "gitlab_ci"),
+    ("CIRCLECI",             "circleci"),
+    ("TRAVIS",               "travis"),
+    ("BUILDKITE",            "buildkite"),
+    ("JENKINS_URL",          "jenkins"),
+    ("TEAMCITY_VERSION",     "teamcity"),
+    ("BITBUCKET_BUILD_NUMBER","bitbucket"),
+    ("CODEBUILD_BUILD_ID",   "aws_codebuild"),
+    ("DRONE",                "drone"),
+    ("AGENT_NAME",           "azure_pipelines"),  # Azure Pipelines
+    ("CI",                   "generic"),
+)
+
+# Heuristic agent detection: existence of a per-agent state directory.
+# The Hermes adapter PR (#708) and ongoing multi-agent work add new
+# agents — keep this list synced with clawmetry/adapters/.
+_AGENT_DIRS = (
+    ("openclaw", Path.home() / ".openclaw"),
+    ("nemoclaw", Path.home() / ".nemoclaw"),
+    ("hermes",   Path.home() / ".hermes"),
+)
+
+
+def _is_optout() -> bool:
+    """Honour both the env var and the file marker. Either disables.
+
+    DO_NOT_TRACK is the W3C-style cross-tool convention; we honour it
+    out of respect even though it's not a perfect fit for OSS install
+    counters.
+    """
+    if os.environ.get("CLAWMETRY_NO_TELEMETRY", "").strip() not in ("", "0", "false", "False"):
+        return True
+    if os.environ.get("DO_NOT_TRACK", "").strip() not in ("", "0", "false", "False"):
+        return True
+    if OPTOUT_MARKER.exists():
+        return True
+    return False
+
+
+def _detect_ci() -> Tuple[bool, Optional[str]]:
+    """Return (is_ci, provider_name_or_None).
+
+    Walks the ``_CI_PROVIDERS`` list in priority order; first hit wins.
+    "Hit" is any non-empty value, since some providers set the var to
+    things other than ``true``.
+    """
+    for env_var, name in _CI_PROVIDERS:
+        if os.environ.get(env_var, "").strip():
+            return True, name
+    return False, None
+
+
+def _detect_agent() -> str:
+    """Return one of openclaw / nemoclaw / hermes / none.
+
+    Order in ``_AGENT_DIRS`` matters when a host has multiple agents
+    (rare but possible) — first match wins. We pick OpenClaw first since
+    that's our primary integration; users with multi-agent setups still
+    show up under the agent they paired most recently.
+    """
+    for name, p in _AGENT_DIRS:
+        if p.exists():
+            return name
+    return "none"
+
+
+def _ensure_install_id() -> Optional[str]:
+    """Read existing install_id, or create one and persist.
+
+    Returns ``None`` if we can't write to ``CONFIG_DIR`` (e.g. read-only
+    filesystem). In that case we silently skip telemetry rather than
+    pollute logs every time.
+    """
+    try:
+        if INSTALL_ID_FILE.exists():
+            txt = INSTALL_ID_FILE.read_text(encoding="utf-8").strip()
+            # Sanity-check it's a UUID-shaped thing; otherwise regenerate.
+            if 16 < len(txt) <= 64 and all(c in "0123456789abcdef-" for c in txt):
+                return txt
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        new = str(uuid.uuid4())
+        INSTALL_ID_FILE.write_text(new + "\n", encoding="utf-8")
+        return new
+    except Exception as e:
+        log.debug("telemetry: cannot persist install_id: %s", e)
+        return None
+
+
+def _build_payload(version: str) -> dict:
+    """Assemble the JSON body. Pure function — no I/O — so tests can
+    stub the small helpers and assert the shape independently."""
+    is_ci, ci_provider = _detect_ci()
+    return {
+        "install_id":  _ensure_install_id() or "",
+        "event":       "first_run",
+        "version":     version,
+        "os":          platform.system() or "unknown",
+        "os_version":  platform.release() or "",
+        "python":      platform.python_version(),
+        "agent":       _detect_agent(),
+        "is_ci":       is_ci,
+        "ci_provider": ci_provider,
+    }
+
+
+def _post(payload: dict, url: str) -> None:
+    """Fire-and-forget POST. Swallows every exception by design — any
+    failure here must NEVER surface to the user."""
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent":   f"clawmetry/{payload.get('version','?')} install-telemetry",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=TELEMETRY_TIMEOUT_SEC) as r:
+            r.read()  # drain so the connection releases cleanly
+    except Exception as e:
+        log.debug("telemetry: post failed: %s", e)
+
+
+def _has_pinged_this_install(install_id: str) -> bool:
+    """A side marker file ``install_id.pinged`` records that we already
+    posted for this install_id. Cloud also dedups via UNIQUE constraint;
+    this just spares the network roundtrip on every cold start."""
+    if not install_id:
+        return False
+    try:
+        marker = INSTALL_ID_FILE.with_suffix(".pinged")
+        return marker.exists()
+    except Exception:
+        return False
+
+
+def _mark_pinged(install_id: str) -> None:
+    if not install_id:
+        return
+    try:
+        marker = INSTALL_ID_FILE.with_suffix(".pinged")
+        marker.write_text(str(int(time.time())), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _send_in_background(version: str) -> None:
+    """Worker that runs on the daemon thread. Fully isolated — no
+    raised exception can bubble back to the caller."""
+    try:
+        if _is_optout():
+            return
+        payload = _build_payload(version)
+        if not payload.get("install_id"):
+            return
+        if _has_pinged_this_install(payload["install_id"]):
+            return
+        url = os.environ.get("CLAWMETRY_TELEMETRY_URL", TELEMETRY_URL_DEFAULT)
+        _post(payload, url)
+        _mark_pinged(payload["install_id"])
+    except Exception as e:
+        log.debug("telemetry: background failure: %s", e)
+
+
+def maybe_ping(version: str = "unknown") -> Optional[threading.Thread]:
+    """Public entry point. Call once on CLI startup.
+
+    Returns the thread for testing convenience; ``None`` if telemetry
+    is opt-out (caller doesn't need to do anything either way).
+
+    The thread is daemon=True so it never blocks process exit. If the
+    user runs ``clawmetry --version`` and exits in 50ms, the post
+    silently goes nowhere — that's by design; we'd rather miss a count
+    than slow down a CLI invocation.
+    """
+    if _is_optout():
+        return None
+    t = threading.Thread(
+        target=_send_in_background,
+        args=(version,),
+        daemon=True,
+        name="clawmetry-telemetry",
+    )
+    t.start()
+    return t

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,165 @@
+"""Tests for clawmetry/telemetry.py — first-run anonymous install ping.
+
+These tests stub the network layer entirely so nothing actually leaves
+the box. The telemetry module is intentionally fault-tolerant, so we
+also test the failure paths (network down, can't write install_id,
+opt-out) all stay silent.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def telemetry(monkeypatch, tmp_path):
+    """Reload telemetry with CONFIG_DIR pointed at a tmp path so the
+    test never touches the user's real ~/.clawmetry/."""
+    from clawmetry import telemetry as t
+    importlib.reload(t)
+    monkeypatch.setattr(t, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(t, "INSTALL_ID_FILE", tmp_path / "install_id")
+    monkeypatch.setattr(t, "OPTOUT_MARKER", tmp_path / "notelemetry")
+    # Strip any CI env vars the test runner might have set so detection
+    # tests aren't poisoned by GitHub Actions itself.
+    for k in ("CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI", "TRAVIS",
+              "BUILDKITE", "JENKINS_URL", "TEAMCITY_VERSION",
+              "BITBUCKET_BUILD_NUMBER", "CODEBUILD_BUILD_ID", "DRONE",
+              "AGENT_NAME", "CLAWMETRY_NO_TELEMETRY", "DO_NOT_TRACK"):
+        monkeypatch.delenv(k, raising=False)
+    return t
+
+
+def test_optout_via_env(telemetry, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_NO_TELEMETRY", "1")
+    assert telemetry._is_optout() is True
+    assert telemetry.maybe_ping("0.0.0") is None
+
+
+def test_optout_via_do_not_track(telemetry, monkeypatch):
+    """W3C-style cross-tool opt-out should also disable us."""
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    assert telemetry._is_optout() is True
+
+
+def test_optout_env_falsy_values_are_off(telemetry, monkeypatch):
+    """Empty / 0 / false should NOT be treated as opt-out."""
+    for val in ("", "0", "false", "False"):
+        monkeypatch.setenv("CLAWMETRY_NO_TELEMETRY", val)
+        assert telemetry._is_optout() is False, f"unexpected opt-out for {val!r}"
+
+
+def test_optout_via_marker_file(telemetry):
+    telemetry.OPTOUT_MARKER.touch()
+    assert telemetry._is_optout() is True
+
+
+def test_install_id_persisted_and_reused(telemetry):
+    a = telemetry._ensure_install_id()
+    b = telemetry._ensure_install_id()
+    assert a == b, "second call must return the same id"
+    assert telemetry.INSTALL_ID_FILE.exists()
+
+
+def test_install_id_regenerated_if_corrupted(telemetry):
+    """A garbage install_id file should be replaced, not crash."""
+    telemetry.INSTALL_ID_FILE.write_text("not-a-uuid! has spaces and bangs\n")
+    new = telemetry._ensure_install_id()
+    assert new and len(new) > 16
+    assert " " not in new
+
+
+def test_ci_detection_priority(telemetry, monkeypatch):
+    """When multiple CI vars are set, the more-specific one wins."""
+    # Some providers leave CI=true set even when running in a different
+    # provider's environment; the specific provider should be picked.
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    is_ci, name = telemetry._detect_ci()
+    assert is_ci is True
+    assert name == "github_actions"
+
+
+def test_ci_detection_none(telemetry):
+    is_ci, name = telemetry._detect_ci()
+    assert is_ci is False
+    assert name is None
+
+
+def test_agent_detection_openclaw(telemetry, tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".openclaw").mkdir()
+    monkeypatch.setattr(telemetry, "_AGENT_DIRS",
+                        (("openclaw", fake_home / ".openclaw"),))
+    assert telemetry._detect_agent() == "openclaw"
+
+
+def test_agent_detection_none(telemetry, tmp_path, monkeypatch):
+    monkeypatch.setattr(telemetry, "_AGENT_DIRS",
+                        (("openclaw", tmp_path / "nope"),))
+    assert telemetry._detect_agent() == "none"
+
+
+def test_payload_shape(telemetry):
+    p = telemetry._build_payload("9.9.9")
+    # Required fields
+    assert set(p) == {"install_id", "event", "version", "os", "os_version",
+                      "python", "agent", "is_ci", "ci_provider"}
+    assert p["event"] == "first_run"
+    assert p["version"] == "9.9.9"
+    assert p["os"]  # platform.system() always returns something
+    # PII NOT in payload
+    payload_str = json.dumps(p).lower()
+    import getpass, socket
+    assert getpass.getuser().lower() not in payload_str
+    assert socket.gethostname().lower() not in payload_str
+
+
+def test_post_swallows_network_error(telemetry):
+    """A 500 / DNS failure / timeout must NEVER raise."""
+    def boom(*a, **kw):
+        raise OSError("network down")
+    with patch("urllib.request.urlopen", side_effect=boom):
+        # Should not raise.
+        telemetry._post({"install_id": "x", "version": "1.0.0"},
+                        "http://example.invalid/api/install")
+
+
+def test_pinged_marker_prevents_double_post(telemetry):
+    """Once we've successfully pinged, subsequent _send_in_background
+    calls must be no-ops to avoid hammering the cloud."""
+    install_id = telemetry._ensure_install_id()
+    assert telemetry._has_pinged_this_install(install_id) is False
+    telemetry._mark_pinged(install_id)
+    assert telemetry._has_pinged_this_install(install_id) is True
+
+
+def test_maybe_ping_optout_returns_none(telemetry, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_NO_TELEMETRY", "1")
+    with patch("urllib.request.urlopen") as urlopen:
+        result = telemetry.maybe_ping("0.0.0")
+        # No thread spawned, no network call.
+        assert result is None
+        urlopen.assert_not_called()
+
+
+def test_maybe_ping_spawns_daemon_thread(telemetry):
+    """Happy path: thread is started, daemon=True, won't block exit."""
+    with patch("urllib.request.urlopen"):
+        t = telemetry.maybe_ping("0.0.0")
+        assert t is not None
+        assert t.daemon is True
+        t.join(timeout=5)
+
+
+def test_payload_omits_ci_provider_when_not_ci(telemetry):
+    """ci_provider should be None when is_ci is False — server filters
+    these out of the 'CI installs' table."""
+    p = telemetry._build_payload("0.0.0")
+    if not p["is_ci"]:
+        assert p["ci_provider"] is None


### PR DESCRIPTION
## Summary
OSS half of the install-tracking feature (cloud half: vivekchand/clawmetry-cloud#715).

- New \`clawmetry/telemetry.py\` (~245 LOC) — single POST on first \`clawmetry\` CLI invocation. Daemon thread, 3s timeout, every error swallowed.
- Wired into \`clawmetry/cli.py:main()\`.
- 16 unit tests passing.
- README "Telemetry" section: exact payload schema + three opt-out paths.

## Privacy contract
- \`install_id\` = random UUID stored at \`~/.clawmetry/install_id\`. Not linked to email, api_key, hostname, username, workspace path.
- Payload: \`version\`, \`os\`, \`os_version\`, \`python\`, \`agent\` (\`openclaw\`/\`nemoclaw\`/\`hermes\`/\`none\`), \`is_ci\`, \`ci_provider\`.
- IP is **never sent** — cloud derives the country code server-side from the request and discards the IP itself.
- Three opt-out paths (any one disables permanently):
  - \`CLAWMETRY_NO_TELEMETRY=1\`
  - \`DO_NOT_TRACK=1\` (W3C cross-tool standard)
  - \`touch ~/.clawmetry/notelemetry\`

## Why first-run, not pip-install
PyPI removed install hooks years ago for supply-chain safety. \`pip install clawmetry\` cannot phone home directly. We fire on first CLI invocation, gated by \`~/.clawmetry/install_id.pinged\` so subsequent runs are silent (cloud also dedups via UNIQUE constraint).

## Test plan
- [x] \`pytest tests/test_telemetry.py -v\` → 16/16 passing
- [x] Manual: with \`CLAWMETRY_NO_TELEMETRY=1\`, \`maybe_ping()\` returns \`None\` and never spawns a thread
- [x] Manual: with \`GITHUB_ACTIONS=true\`, payload includes \`is_ci=true, ci_provider=github_actions\`
- [x] Manual: \`platform.system() == "Darwin"\` reflected; agent detected as \`openclaw\` because \`~/.openclaw\` exists
- [ ] Post-merge: install fresh wheel in CI, confirm one row appears in cloud's \`installs\` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)