### PR TITLE
[RELEASE] fix(app.js): close _fmtDur() — dashboard JS broken since 0.12.165

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10667,6 +10667,8 @@ function _fmtDur(ms) {
   if (ms == null || ms < 0) return '?';
   if (ms < 1000) return ms + 'ms';
   return (ms / 1000).toFixed(1) + 's';
+}
+
 async function renderModalModelJourney(el) {
   if (!_modalSessionId) {
     el.innerHTML = '<div style="padding:20px;color:var(--text-muted);">No session ID available</div>';


### PR DESCRIPTION
## Summary
**P0 hotfix.** PyPI 0.12.165 and 0.12.166 ship a broken \`static/js/app.js\` that throws \`SyntaxError: Unexpected end of input\` in every browser. The whole JS bundle dies, leaving the dashboard stuck on "Initializing ClawMetry". Every user who upgraded is affected.

## Root cause
PR #753 ("model-change + thinking-level annotations on session timeline", landed in 0.12.165) inserted \`async function renderModalModelJourney(el) {\` immediately after \`_fmtDur\`'s \`return\` statement — but **before** \`_fmtDur\`'s closing \`}\`. The new function got accidentally nested inside \`_fmtDur\`, leaving the file one \`}\` short at EOF.

\`\`\`diff
 function _fmtDur(ms) {
   if (ms == null || ms < 0) return '?';
   if (ms < 1000) return ms + 'ms';
   return (ms / 1000).toFixed(1) + 's';
+}
+
 async function renderModalModelJourney(el) {
\`\`\`

\`acorn.parse()\` confirms PASS after the fix; was failing with \`Unexpected token (11201:0)\` before.

## How this slipped through
- **No JS lint or parse check in OSS CI.** \`make lint\` only checks Python.
- **The wheel-install smoke test only verifies \`/static/js/app.js\` returns 200**, not that the JS parses.
- **No browser smoke test in OSS CI.** The cloud repo has \`tests/e2e/cloud-contract.mjs\` (which DID catch this — that's how I discovered it tonight while debugging an unrelated cloud deploy), but OSS doesn't run it.
- **Manual QA missed it because the dashboard "looks fine"** until you open DevTools — the boot overlay shows briefly, then the page stays blank because every JS function from the bundle is undefined.

## Test plan
- [x] \`acorn.parse()\` succeeds on the fixed file
- [x] Headless playwright on a live dashboard with the fix shows zero \`pageerror\` events
- [ ] CI wheel-install + spinning a dashboard to verify the static JS now parses
- [ ] Cloud's deploy.yml smoke test (which currently catches this against the candidate) passes

## Follow-up (separate PRs)
1. Add \`acorn.parse()\` (or \`node --check\`) on every \`*.js\` in CI \`make lint\` step.
2. Promote a tiny version of cloud-contract.mjs (just "load page, expect zero pageerrors") into OSS CI's wheel-install job so future syntax breaks block release.
3. Audit 0.12.165 + 0.12.166 yank candidacy on PyPI — likely yes, since the dashboard is fully broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)