### PR TITLE
feat(overview): add /api/heartbeat-liveness endpoint (#686)

### DIFF
--- a/routes/overview.py
+++ b/routes/overview.py
@@ -605,6 +605,188 @@ def api_prompt_errors():
     return jsonify({"errors": errors, "count": len(errors)})
 
 
+_HEARTBEAT_CADENCE_DEFAULT_MINS = 30
+_HEARTBEAT_TAIL_BYTES = 4096
+
+
+def _last_assistant_text(fpath):
+    """Tail-read a session JSONL and return the text of the last assistant message.
+
+    Reads only the final _HEARTBEAT_TAIL_BYTES bytes so heartbeat scanning
+    stays fast regardless of session size.  Returns None if no assistant
+    message is found or the file can't be read.
+    """
+    try:
+        with open(fpath, "rb") as fh:
+            fh.seek(0, 2)
+            size = fh.tell()
+            fh.seek(max(0, size - _HEARTBEAT_TAIL_BYTES))
+            raw = fh.read().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+
+    last_text = None
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        msg = ev.get("message") or {}
+        if not isinstance(msg, dict):
+            continue
+        role = (msg.get("role") or ev.get("role") or "").lower()
+        if role != "assistant":
+            continue
+        content = msg.get("content") or ev.get("content") or ""
+        if isinstance(content, str) and content.strip():
+            last_text = content.strip()
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    t = (block.get("text") or "").strip()
+                    if t:
+                        last_text = t
+    return last_text
+
+
+@bp_overview.route("/api/heartbeat-liveness")
+def api_heartbeat_liveness():
+    """Return heartbeat-session liveness metrics for the overview panel.
+
+    Response fields:
+      last_heartbeat_at     — ISO timestamp of the most recent heartbeat session
+      gap_mins              — minutes elapsed since that session (None if unknown)
+      expected_cadence_mins — configured heartbeat interval (default 30)
+      status                — "green" / "amber" / "red" / "unknown"
+                              green  = gap < 1.5 × cadence
+                              amber  = gap < 3.0 × cadence
+                              red    = gap >= 3.0 × cadence
+      heartbeat_ok_count    — heartbeats whose last assistant reply was HEARTBEAT_OK
+      heartbeat_total       — total heartbeat sessions scanned for OK check
+      heartbeat_ok_ratio    — 0-100 float, or null if nothing was scanned
+      recent                — last 5 heartbeat sessions [{session_id, ts, heartbeat_ok}]
+    """
+    import dashboard as _d
+
+    expected_cadence_mins = int(
+        os.environ.get(
+            "OPENCLAW_HEARTBEAT_CADENCE_MINS", str(_HEARTBEAT_CADENCE_DEFAULT_MINS)
+        )
+    )
+
+    gw_data = _d._gw_invoke("sessions_list", {"limit": 100, "messageLimit": 0})
+    if gw_data and "sessions" in gw_data:
+        sessions = _d._augment_sessions_with_burn(gw_data["sessions"])
+    else:
+        sessions = _d._augment_sessions_with_burn(_d._get_sessions())
+
+    heartbeat_sessions = [
+        s for s in sessions
+        if "heartbeat" in (s.get("displayName") or s.get("sessionId") or "").lower()
+    ]
+
+    if not heartbeat_sessions:
+        return jsonify({
+            "last_heartbeat_at": None,
+            "gap_mins": None,
+            "expected_cadence_mins": expected_cadence_mins,
+            "status": "unknown",
+            "heartbeat_ok_count": 0,
+            "heartbeat_total": 0,
+            "heartbeat_ok_ratio": None,
+            "recent": [],
+        })
+
+    def _to_epoch(s):
+        raw = s.get("updatedAt") or s.get("lastActiveMs") or s.get("startedAt") or 0
+        if isinstance(raw, (int, float)):
+            return raw / 1000.0 if raw > 1e10 else float(raw)
+        try:
+            return datetime.fromisoformat(str(raw).replace("Z", "+00:00")).timestamp()
+        except Exception:
+            return 0.0
+
+    heartbeat_sessions.sort(key=_to_epoch, reverse=True)
+
+    now_ts = time.time()
+    last_ts = _to_epoch(heartbeat_sessions[0])
+    last_heartbeat_iso = (
+        datetime.utcfromtimestamp(last_ts).isoformat() + "Z" if last_ts else None
+    )
+    gap_mins = round((now_ts - last_ts) / 60.0, 1) if last_ts else None
+
+    if gap_mins is None:
+        status = "unknown"
+    elif gap_mins < expected_cadence_mins * 1.5:
+        status = "green"
+    elif gap_mins < expected_cadence_mins * 3.0:
+        status = "amber"
+    else:
+        status = "red"
+
+    sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
+        "~/.openclaw/agents/main/sessions"
+    )
+    scan_limit = min(len(heartbeat_sessions), 20)
+    heartbeat_ok_count = 0
+    scanned = 0
+    recent = []
+
+    for s in heartbeat_sessions[:scan_limit]:
+        sid = (s.get("sessionId") or s.get("key") or "").strip()
+        ts_epoch = _to_epoch(s)
+        ts_iso = (
+            datetime.utcfromtimestamp(ts_epoch).isoformat() + "Z" if ts_epoch else None
+        )
+        is_ok = None
+
+        if sid and os.path.isdir(sessions_dir):
+            try:
+                candidates = [
+                    f for f in os.listdir(sessions_dir)
+                    if f.endswith(".jsonl") and f.startswith(sid)
+                ]
+            except OSError:
+                candidates = []
+            for fname in candidates[:1]:
+                fpath = os.path.join(sessions_dir, fname)
+                try:
+                    last_text = _last_assistant_text(fpath)
+                    is_ok = last_text is not None and last_text.strip() == "HEARTBEAT_OK"
+                except Exception:
+                    pass
+
+        if is_ok is not None:
+            scanned += 1
+            if is_ok:
+                heartbeat_ok_count += 1
+
+        if len(recent) < 5:
+            recent.append({
+                "session_id": sid,
+                "ts": ts_iso,
+                "heartbeat_ok": is_ok,
+            })
+
+    heartbeat_ok_ratio = (
+        round(heartbeat_ok_count / scanned * 100.0, 1) if scanned else None
+    )
+
+    return jsonify({
+        "last_heartbeat_at": last_heartbeat_iso,
+        "gap_mins": gap_mins,
+        "expected_cadence_mins": expected_cadence_mins,
+        "status": status,
+        "heartbeat_ok_count": heartbeat_ok_count,
+        "heartbeat_total": scanned,
+        "heartbeat_ok_ratio": heartbeat_ok_ratio,
+        "recent": recent,
+    })
+
+
 @bp_overview.route("/api/cloud-cta/status")
 def cloud_cta_status():
     import dashboard as _d

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1122,3 +1122,51 @@ class TestAlertRulesTokenSpike:
             f"Expected 400 for invalid rule type, got {r.status_code}: {r.text[:200]}"
         )
 
+
+class TestHeartbeatLiveness:
+    def test_heartbeat_liveness_endpoint(self, api, base_url):
+        """GET /api/heartbeat-liveness returns 200 with expected keys."""
+        d = assert_ok(get(api, base_url, "/api/heartbeat-liveness"))
+        assert_keys(
+            d,
+            "last_heartbeat_at",
+            "gap_mins",
+            "expected_cadence_mins",
+            "status",
+            "heartbeat_ok_count",
+            "heartbeat_total",
+            "heartbeat_ok_ratio",
+            "recent",
+        )
+
+    def test_heartbeat_liveness_status_values(self, api, base_url):
+        """status is one of the four expected values."""
+        d = assert_ok(get(api, base_url, "/api/heartbeat-liveness"))
+        assert d["status"] in ("green", "amber", "red", "unknown"), (
+            f"Unexpected status: {d['status']}"
+        )
+
+    def test_heartbeat_liveness_cadence_positive(self, api, base_url):
+        """expected_cadence_mins is a positive integer."""
+        d = assert_ok(get(api, base_url, "/api/heartbeat-liveness"))
+        assert d["expected_cadence_mins"] > 0
+
+    def test_heartbeat_liveness_recent_is_list(self, api, base_url):
+        """recent field is a list of at most 5 items."""
+        d = assert_ok(get(api, base_url, "/api/heartbeat-liveness"))
+        assert isinstance(d["recent"], list)
+        assert len(d["recent"]) <= 5
+
+    def test_heartbeat_liveness_gap_consistent_with_status(self, api, base_url):
+        """When gap_mins is present and status is known, thresholds are correct."""
+        d = assert_ok(get(api, base_url, "/api/heartbeat-liveness"))
+        gap = d.get("gap_mins")
+        status = d["status"]
+        cadence = d["expected_cadence_mins"]
+        if gap is None or status == "unknown":
+            return
+        if status == "green":
+            assert gap < cadence * 1.5, f"green status but gap={gap} >= 1.5×{cadence}"
+        elif status == "amber":
+            assert gap < cadence * 3.0, f"amber status but gap={gap} >= 3.0×{cadence}"
+


### PR DESCRIPTION
## Summary

Adds `GET /api/heartbeat-liveness` — the backend data source for the heartbeat liveness panel described in #686. OpenClaw fires a "heartbeat" session every ~30 minutes; ClawMetry had no way to surface whether the agent was still alive and replying `HEARTBEAT_OK`. This endpoint computes that at query time from existing session data, with no new dependencies or schema changes.

## Changes

- **`routes/overview.py`** — new `GET /api/heartbeat-liveness` route and private `_last_assistant_text()` tail-read helper (~165 lines). Added after `api_prompt_errors`, before the cloud-CTA routes.
- **`tests/test_api.py`** — `TestHeartbeatLiveness` class with 5 tests covering status values, cadence, list shape, and gap/status consistency.

### Response shape
```json
{
  "last_heartbeat_at": "2026-05-11T12:00:00Z",
  "gap_mins": 12.3,
  "expected_cadence_mins": 30,
  "status": "green",
  "heartbeat_ok_count": 4,
  "heartbeat_total": 5,
  "heartbeat_ok_ratio": 80.0,
  "recent": [
    {"session_id": "...", "ts": "2026-05-11T12:00:00Z", "heartbeat_ok": true}
  ]
}
```

Status thresholds: `green` = gap < 1.5× cadence, `amber` = gap < 3×, `red` = gap ≥ 3×, `unknown` = no heartbeat sessions found. Cadence defaults to 30 min, overridable via `OPENCLAW_HEARTBEAT_CADENCE_MINS`.

HEARTBEAT_OK ratio is detected by tail-reading the last 4 KB of each session JSONL — fast regardless of session size, no full file parse needed.

## Test plan

- [ ] `GET /api/heartbeat-liveness` returns 200 with all expected keys on a fresh install (will return `status: "unknown"`, empty `recent`)
- [ ] `python3 -c 'import ast; ast.parse(open("routes/overview.py").read())'` — passes
- [ ] `python3 -c 'import ast; ast.parse(open("tests/test_api.py").read())'` — passes
- [ ] On an install with heartbeat sessions: `status` is one of `green/amber/red`, `recent` has ≤5 entries, `heartbeat_ok_ratio` is 0–100

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #686. Marked draft for human review — mark Ready for Review once happy.

Closes #686

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPjWqRkZLgCkPx2cGYeWcC)_