### PR TITLE
ci: add node --check on every clawmetry/static/js/*.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,22 @@ jobs:
       - name: Lint (warnings only, don't fail)
         run: ruff check dashboard.py --select E,W --ignore E501,W503 || true
 
+      # v0.12.165 shipped clawmetry/static/js/app.js with a missing `}`
+      # (PR #753). Browsers threw "Unexpected end of input" and the whole
+      # dashboard JS bundle died, stranding every user on the boot
+      # overlay. `node --check` catches this in <1s. Required gate.
+      - name: Setup Node (for JS syntax check)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check JS syntax (all clawmetry/static/js/*.js)
+        run: |
+          set -e
+          for f in clawmetry/static/js/*.js; do
+            node --check "$f" || { echo "❌ JS PARSE FAILED: $f"; exit 1; }
+          done
+          echo "✅ JS Syntax OK"
+
   # ── API tests across all 3 platforms ─────────────────────────────────────
   api-tests:
     name: API Tests (${{ matrix.os }})

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,25 @@ test-api:
 test-e2e:
 	CLAWMETRY_URL=http://localhost:8900 CLAWMETRY_TOKEN=dev-token python3 -m pytest tests/test_e2e.py -v
 
-lint:
-	python3 -c "import ast; ast.parse(open('dashboard.py').read()); print('Syntax OK')"
+lint: lint-py lint-js
+
+lint-py:
+	python3 -c "import ast; ast.parse(open('dashboard.py').read()); print('Python syntax OK')"
 	ruff check dashboard.py dashboard_claudecode.py clawmetry/
+
+# v0.12.165 shipped clawmetry/static/js/app.js with a missing `}` (PR #753).
+# Browsers threw "Unexpected end of input" on first parse, killing every
+# function in the bundle and stranding the dashboard on its boot overlay.
+# `node --check` is the cheapest possible gate — runs in <100ms per file
+# and would have failed the offending PR locally and in CI.
+lint-js:
+	@if command -v node >/dev/null 2>&1; then \
+	    for f in clawmetry/static/js/*.js; do \
+	        node --check "$$f" || { echo "JS PARSE FAILED: $$f"; exit 1; }; \
+	    done; \
+	    echo "JS syntax OK"; \
+	else \
+	    echo "WARN: node not installed — skipping JS syntax check (CI installs node automatically)"; \
+	fi
+
+.PHONY: lint lint-py lint-js


### PR DESCRIPTION
## Summary
Permanent guardrail against the class of bug that caused PR #1019 (the v0.12.165/0.12.166 dashboard breakage). \`node --check\` runs in <1s and would have failed PR #753 in CI before merge.

## What changes
- **Makefile**: split \`lint\` into \`lint-py\` + \`lint-js\`. \`make lint\` now runs both.
- **.github/workflows/ci.yml**: \`Syntax & Lint\` job now installs node 20 and runs \`node --check\` on every \`clawmetry/static/js/*.js\`. Failure blocks the job (which gates everything else via \`needs: lint\`).

## Verified
- \`make lint-js\` passes on current main (after #1019).
- \`node --check\` against the broken v0.12.166 file fails immediately:
  \`\`\`
  /private/tmp/app_broken.js:11201
  SyntaxError: Unexpected end of input
  \`\`\`

## Next guardrail (separate PR, not in this one)
- Promote a tiny "load page in headless chromium, assert zero pageerrors" check into the wheel-install job. Would catch runtime JS errors that pass \`node --check\` (e.g. ReferenceError to a missing function).

## Out of scope
- Yanking 0.12.165 + 0.12.166 from PyPI (separate manual step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)