### PR TITLE
fix: per-session stuck-agent detection via heartbeat timeout (#953)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -6711,6 +6711,13 @@ FLEET_API_KEY = os.environ.get("CLAWMETRY_FLEET_KEY", "")
 FLEET_DB_PATH = None  # Set via CLI or auto-detected
 FLEET_NODE_TIMEOUT = 300  # seconds before node is considered offline
 
+# ── Stuck-Session Detection ────────────────────────────────────────────
+STUCK_SESSION_TIMEOUT_SEC = 300   # 5 min silent → warning alert
+STUCK_SESSION_CRITICAL_SEC = 900  # 15 min silent → critical alert
+_STUCK_SESSION_MAX_WINDOW_SEC = 7200  # beyond 2 h, assume completed — stop alerting
+_STUCK_SESSION_COOLDOWN_SEC = 1800  # per-session alert cooldown (30 min)
+_stuck_session_cooldowns: dict = {}  # session_id → last alert timestamp
+
 # ── Budget & Alert Configuration ───────────────────────────────────────
 _budget_paused = False
 _budget_paused_at = 0
@@ -7139,6 +7146,67 @@ def _fleet_maintenance_loop():
 def _start_fleet_maintenance_thread():
     """Start the background fleet maintenance thread."""
     t = threading.Thread(target=_fleet_maintenance_loop, daemon=True)
+    t.start()
+
+
+# ── Stuck-Session Health Loop ──────────────────────────────────────────
+
+
+def _check_stuck_sessions() -> None:
+    """Fire a stuck_session alert for any session silent longer than STUCK_SESSION_TIMEOUT_SEC.
+
+    Uses the session's updatedAt (ms) as the last-activity proxy.  For the
+    gateway-RPC path, sessions.list only contains live sessions, making this
+    reliable.  For the file-based fallback, file mtime serves as the proxy;
+    we cap the upper window at 2 h to avoid alerting on sessions that simply
+    finished without a terminal event.
+    """
+    global _stuck_session_cooldowns
+    now = time.time()
+    try:
+        sessions = _get_sessions()
+    except Exception:
+        return
+    for s in sessions:
+        sid = s.get("sessionId", "")
+        if not sid:
+            continue
+        updated_ms = s.get("updatedAt") or 0
+        if not updated_ms:
+            continue
+        age_sec = now - (updated_ms / 1000.0)
+        if age_sec < STUCK_SESSION_TIMEOUT_SEC:
+            continue  # still active
+        if age_sec > _STUCK_SESSION_MAX_WINDOW_SEC:
+            continue  # too old — likely completed, not stuck
+        last_alerted = _stuck_session_cooldowns.get(sid, 0)
+        if now - last_alerted < _STUCK_SESSION_COOLDOWN_SEC:
+            continue
+        _stuck_session_cooldowns[sid] = now
+        severity = "critical" if age_sec >= STUCK_SESSION_CRITICAL_SEC else "warning"
+        minutes = int(age_sec / 60)
+        label = s.get("displayName") or sid[:16]
+        agent = s.get("agent", "main")
+        msg = (
+            f'Session "{label}" appears stuck — no activity for {minutes} min'
+            f" (agent: {agent})"
+        )
+        _fire_alert(f"stuck_session_{sid[:32]}", "stuck_session", msg, severity=severity)
+
+
+def _session_health_loop() -> None:
+    """Background thread: check for stuck sessions every 30 s."""
+    while True:
+        time.sleep(30)
+        try:
+            _check_stuck_sessions()
+        except Exception as e:
+            print(f"Warning: stuck-session check error: {e}")
+
+
+def _start_session_health_thread() -> None:
+    """Start the background stuck-session detection thread."""
+    t = threading.Thread(target=_session_health_loop, daemon=True)
     t.start()
 
 
@@ -15013,6 +15081,7 @@ def _run_server(args):
     _detect_heartbeat_interval()
     _start_fleet_maintenance_thread()
     _start_budget_monitor_thread()
+    _start_session_health_thread()
 
     try:
         print(BANNER.format(version=__version__))


### PR DESCRIPTION
Closes #953

## Summary

- Adds `STUCK_SESSION_TIMEOUT_SEC = 300` (warning) and `STUCK_SESSION_CRITICAL_SEC = 900` (critical) constants alongside a `_stuck_session_cooldowns` dict for per-session cooldown tracking (30 min between repeat alerts for the same session).
- `_check_stuck_sessions()` — called every 30 s; reads current sessions via `_get_sessions()`, computes activity age from `updatedAt` (ms), skips sessions younger than 5 min (still active) or older than 2 h (likely completed), then fires `_fire_alert("stuck_session_<id>", "stuck_session", …)` with `warning` or `critical` severity.
- `_session_health_loop()` / `_start_session_health_thread()` — daemon thread modelled on `_fleet_maintenance_loop`; wired into app startup after `_start_budget_monitor_thread()`.

## Design note

The 2-hour upper window (`_STUCK_SESSION_MAX_WINDOW_SEC`) is the main heuristic protecting against false-positives on the file-based fallback path (where file mtime = last heartbeat). On the gateway-RPC path `sessions.list` returns only live sessions, so any entry silent for ≥ 5 min is genuinely suspect. "Kill session" / "Pause agent" buttons (#955) are out of scope here — the alert includes the session ID so operators can act via the existing `/api/sessions/<id>/stop` endpoint or the dashboard manually.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` passes (verified).
- [ ] `make lint` — no new errors introduced (pre-existing 112 errors unchanged).
- [ ] Start `clawmetry` locally with a JSONL session file whose mtime is 6-10 minutes ago; confirm a `stuck_session` entry appears in `/api/alerts/active` within 30 s.
- [ ] Confirm no duplicate alert fires within the 30-min cooldown window.
- [ ] Session with mtime > 2 h produces no alert.

---
_Generated by [Claude Code](https://claude.ai/code/session_014o6qFjjGXUvNTiG6i4d1yv)_