### PR TITLE
test(contract): filter /api/diagnostics 410 + /api/config-diagnostics 404

### DIFF
--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -258,7 +258,15 @@ async function testNormalUser() {
       // Dockerfile pin is bumped, every page load throws this error
       // — and that's the very thing release-on-merge needs to ship.
       // See PR #1019 postmortem; revert tracked in #1021 follow-up.
-      !/Unexpected end of input/.test(e)
+      !/Unexpected end of input/.test(e) &&
+      // /api/diagnostics is `cloud-disabled` in the route policy
+      // (returns 410 Gone — it inspects local processes/files which
+      // don't exist on Cloud Run). Dashboard JS calls it anyway and
+      // the console.error is harmless. /api/config-diagnostics same
+      // shape: new OSS endpoint, returns 404 on cloud. Filtering
+      // them here matches the existing /api/skills 410 pattern.
+      !(/\/api\/diagnostics/.test(e) && /\b410\b/.test(e)) &&
+      !(/\/api\/config-diagnostics/.test(e) && /\b404\b/.test(e))
   );
   check('zero unexpected JS errors', real.length === 0, real.slice(0, 5).join('\n      '));
 


### PR DESCRIPTION
## Summary
The cloud-contract smoke is blocking every cloud deploy because the dashboard JS calls \`/api/diagnostics\` and \`/api/config-diagnostics\`, both of which are intentionally \`cloud-disabled\` in the route policy:
- \`/api/diagnostics\` → 410 Gone (local-only — inspects processes/files)
- \`/api/config-diagnostics\` → 404 (new OSS route, no cloud handler)

The browser \`console.error\` for both is harmless noise, but the contract test counts every console.error as a JS-error failure unless explicitly filtered. This PR extends the existing \`/api/skills\` 410 filter pattern to cover both endpoints.

## Why now
Caught while shipping epic #964's PR A (#717 in clawmetry-cloud). Fixing this unblocks the remaining 4 cloud PRs (#718/#719/#720/#721) which were all blocked behind their respective deploy gates failing on the same noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)