### PR TITLE
feat(usage): prompt-cache hit-rate panel in Usage tab

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5657,8 +5657,78 @@ async function loadUsage() {
     loadCostComparison();
     // Load activity heatmap
     loadHeatmap();
+    // Load prompt cache analytics (GH #979)
+    loadCacheAnalytics();
   } catch(e) {
     document.getElementById('usage-chart').innerHTML = '<span style="color:#555">No usage data available</span>';
+  }
+}
+
+async function loadCacheAnalytics() {
+  try {
+    var d = await fetch('/api/usage/cache-trends?days=14').then(function(r) { return r.json(); });
+    var tot = d.totals || {};
+    var hasCache = (tot.cache_read_tokens || 0) + (tot.cache_write_tokens || 0) > 0;
+    var title = document.getElementById('cache-perf-title');
+    var card = document.getElementById('cache-perf-card');
+    if (!title || !card) return;
+    if (!hasCache) return;
+    title.style.display = '';
+    card.style.display = '';
+
+    var hit = tot.cache_hit_ratio_pct || 0;
+    var hitColor = hit >= 60 ? '#22c55e' : hit >= 30 ? '#f59e0b' : '#ef4444';
+    var savings = tot.est_savings_usd || 0;
+    var crToks = tot.cache_read_tokens || 0;
+    var cwToks = tot.cache_write_tokens || 0;
+
+    function fmtToks(n) { return n >= 1e6 ? (n/1e6).toFixed(1)+'M' : n >= 1e3 ? (n/1e3).toFixed(0)+'K' : String(n||0); }
+    function fmtCost(c) { return c >= 0.01 ? '$'+c.toFixed(2) : c > 0 ? '<$0.01' : '$0.00'; }
+
+    var html = '<div style="display:flex;flex-wrap:wrap;gap:16px;align-items:flex-start;">'
+      + '<div style="min-width:120px;text-align:center;">'
+      + '<div style="font-size:32px;font-weight:700;color:'+hitColor+';">'+hit.toFixed(1)+'%</div>'
+      + '<div style="font-size:11px;color:var(--text-muted);margin-top:2px;">cache hit rate</div>'
+      + '<div style="font-size:11px;color:var(--text-muted);margin-top:4px;">'+fmtToks(crToks)+' read · '+fmtToks(cwToks)+' write</div>'
+      + '</div>'
+      + '<div style="flex:1;min-width:180px;">';
+
+    if (savings > 0) {
+      html += '<div style="font-size:13px;margin-bottom:8px;">💰 Est. savings: <strong style="color:#22c55e;">'+fmtCost(savings)+'</strong> vs. uncached</div>';
+    }
+
+    var models = (d.by_model || []).filter(function(m) { return (m.cache_read_tokens||0)+(m.cache_write_tokens||0) > 0; });
+    if (models.length > 0) {
+      html += '<table style="width:100%;border-collapse:collapse;font-size:12px;">'
+        + '<thead><tr>'
+        + '<th style="text-align:left;color:var(--text-muted);padding:2px 8px 4px 0;font-weight:500;">Model</th>'
+        + '<th style="text-align:right;color:var(--text-muted);padding:2px 0 4px 8px;font-weight:500;">Hit %</th>'
+        + '<th style="text-align:right;color:var(--text-muted);padding:2px 0 4px 8px;font-weight:500;">Saved</th>'
+        + '</tr></thead><tbody>';
+      models.forEach(function(m) {
+        var mhit = m.cache_hit_ratio_pct || 0;
+        var mc = mhit >= 60 ? '#22c55e' : mhit >= 30 ? '#f59e0b' : '#ef4444';
+        html += '<tr>'
+          + '<td style="padding:2px 8px 2px 0;color:var(--text-secondary);">'+escHtml(m.model||'—')+'</td>'
+          + '<td style="text-align:right;padding:2px 0 2px 8px;color:'+mc+';font-weight:600;">'+mhit.toFixed(1)+'%</td>'
+          + '<td style="text-align:right;padding:2px 0 2px 8px;color:var(--text-muted);">'+fmtCost(m.est_savings_usd||0)+'</td>'
+          + '</tr>';
+      });
+      html += '</tbody></table>';
+    }
+
+    html += '</div></div>';
+
+    var recs = d.recommendations || [];
+    if (recs.length > 0) {
+      html += '<div style="margin-top:12px;padding:8px 12px;background:var(--bg-secondary);border-radius:6px;border-left:3px solid '+hitColor+';font-size:12px;color:var(--text-secondary);">'
+        + recs.map(function(r) { return escHtml(r); }).join('<br>')
+        + '</div>';
+    }
+
+    document.getElementById('cache-perf-content').innerHTML = html;
+  } catch(e) {
+    // Cache panel is optional — skip silently on error
   }
 }
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -3785,6 +3785,11 @@ function clawmetryLogout(){
   <div class="card" id="cost-comparison-card" style="display:none;">
     <div id="cost-comparison-content" style="min-height:60px;color:var(--text-muted);">Loading...</div>
   </div>
+  <!-- Prompt Cache Analytics (GH #979) -->
+  <div class="section-title" id="cache-perf-title" style="display:none;">⚡ Prompt Cache <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">hit rate · savings · per model · 14 days</span></div>
+  <div class="card" id="cache-perf-card" style="display:none;">
+    <div id="cache-perf-content" style="min-height:48px;color:var(--text-muted);"></div>
+  </div>
     <div class="section-title">🔮 Trace Clusters <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">auto-group sessions by behavior pattern</span></div>
   <div class="card">
     <div id="trace-clusters-content" style="min-height:60px;color:var(--text-muted);">Loading...</div>


### PR DESCRIPTION
## Summary

- `/api/usage/cache-trends` already existed (built for #851) but was never wired into the UI — `loadUsage()` never called it and there was no HTML card for it.
- Adds `loadCacheAnalytics()` in `clawmetry/static/js/app.js` (~65 LOC) called at the end of `loadUsage()`.
- Adds 4 lines of HTML in `dashboard.py` for the `⚡ Prompt Cache` card placeholder in the Usage tab.

The new panel shows:
- Overall cache hit ratio with colour-coded gauge (green ≥ 60 %, amber 30–60 %, red < 30 %)
- Estimated savings vs. uncached cost (10× multiplier on cache-read cost)
- Per-model hit ratio + savings table
- Actionable recommendation pills from `_cache_recommendations()`

Panel stays `display:none` until `cache_read_tokens + cache_write_tokens > 0` — no noise for non-Anthropic setups.

## Test plan

- [ ] Open Usage tab → `⚡ Prompt Cache` card appears when agent sessions include Anthropic model usage with cache tokens.
- [ ] Card stays hidden for sessions with zero cache tokens (e.g., pure Ollama usage).
- [ ] Hit ratio colour coding: run a session with cold cache (expect red), warm cache (expect green).
- [ ] Recommendations pill shows the low-hit-ratio stabilise tip when hit rate < 30 %.
- [ ] `node --check clawmetry/static/js/app.js` passes (no JS parse errors).
- [ ] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` passes.

Closes #979

https://claude.ai/code/session_019nHUbqiaF15NKZQWfPvP8F

---
_Generated by [Claude Code](https://claude.ai/code/session_019nHUbqiaF15NKZQWfPvP8F)_