### PR TITLE
feat(reasoning): reasoning coherence score — detect post-hoc rationalization (#572)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2522,6 +2522,17 @@ function loadReasoningChain(sessionId, containerId) {
         container.innerHTML = '<span style="color:var(--text-muted);font-size:10px;">No reasoning chains found.</span>';
         return;
       }
+      var _coherenceColors = {high: '#10b981', medium: '#eab308', low: '#ef4444'};
+      var _coherenceIcons  = {high: '&#129001;', medium: '&#129000;', low: '&#128997;'};
+      function _coherenceBadge(score, label, small) {
+        if (!score) return '';
+        var col = _coherenceColors[label] || '#6b7280';
+        var ico = _coherenceIcons[label] || '';
+        var fs  = small ? '9px' : '10px';
+        return '<span title="Reasoning coherence: ' + label + ' (' + score + '/100). Measures how much thinking vocabulary appears in the final answer." '
+          + 'style="background:' + col + '22;color:' + col + ';padding:1px 5px;border-radius:8px;font-size:' + fs + ';font-weight:600;">'
+          + ico + ' ' + score + '</span>';
+      }
       var html = '';
       // Summary bar
       html += '<div style="display:flex;gap:8px;flex-wrap:wrap;padding:4px 8px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;font-size:10px;color:var(--text-muted);margin-bottom:4px;">';
@@ -2532,12 +2543,17 @@ function loadReasoningChain(sessionId, containerId) {
         html += '<span>&#9889; Efficiency: ' + summary.avg_efficiency + ':1</span>';
       }
       html += '<span>' + chains.length + ' chain' + (chains.length > 1 ? 's' : '') + '</span>';
+      if (summary.avg_coherence_score > 0) {
+        html += '<span style="display:flex;align-items:center;gap:3px;">Coherence: ' + _coherenceBadge(summary.avg_coherence_score, summary.avg_coherence_label, false) + '</span>';
+      }
       html += '</div>';
       // Render each chain
       chains.forEach(function(chain, ci) {
         html += '<div style="padding:4px 8px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;margin-bottom:4px;">';
         if (chains.length > 1) {
-          html += '<div style="font-size:10px;color:var(--text-muted);margin-bottom:3px;">Chain ' + (ci + 1) + ' &mdash; ' + chain.thinking_tokens + ' tokens</div>';
+          html += '<div style="display:flex;align-items:center;gap:6px;font-size:10px;color:var(--text-muted);margin-bottom:3px;">Chain ' + (ci + 1) + ' &mdash; ' + chain.thinking_tokens + ' tokens'
+            + (chain.coherence_score ? ' ' + _coherenceBadge(chain.coherence_score, chain.coherence_label, true) : '')
+            + '</div>';
         }
         (chain.steps || []).forEach(function(step) {
           var col = _rcStepColors[step.type] || '#6b7280';

--- a/routes/reasoning.py
+++ b/routes/reasoning.py
@@ -2,12 +2,13 @@
 routes/reasoning.py — Reasoning chain viewer endpoint.
 
 Implements GH #565: structured visualization of LLM thinking/reasoning content.
+Extends  GH #572: coherence score — detect when reasoning doesn't support the answer.
 
   GET /api/reasoning?session=SESSION_ID
 
 Returns a structured breakdown of thinking blocks parsed from session JSONL:
 - Chains: each thinking block segmented into typed logical steps
-- Summary: aggregate token/efficiency stats across all chains
+- Summary: aggregate token/efficiency stats + avg coherence across all chains
 """
 
 import glob
@@ -18,6 +19,58 @@ import re
 from flask import Blueprint, jsonify, request
 
 bp_reasoning = Blueprint("reasoning", __name__)
+
+# ── Coherence scoring (GH #572) ──────────────────────────────────────────────
+
+_STOP_WORDS = frozenset(
+    "the a an and or but in on at to for of with is are was were be been "
+    "have has had do does did will would could should may might must shall "
+    "i we you he she it they this that these those which who what when "
+    "how why where my your his her our their its if then else so because "
+    "as by from into through out up down about after before between over "
+    "under more most some all any no not just also only even still same "
+    "can need want get go make take see know think look say come back "
+    "let set use put show keep run try give very well good great here "
+    "there now then too such each both few many much since while".split()
+)
+
+
+def _extract_keywords(text):
+    """Return significant lowercase words (≥4 chars, not stop words)."""
+    return {
+        w
+        for w in re.findall(r"[a-z]{4,}", text.lower())
+        if w not in _STOP_WORDS
+    }
+
+
+def _coherence_score(thinking_text, answer_text):
+    """Compute a reasoning coherence score (0–100) and label.
+
+    Measures keyword overlap between the thinking block and the final answer.
+    High overlap → thinking vocabulary appears in the answer → likely genuine.
+    Low overlap → thinking may be post-hoc rationalization or boilerplate.
+
+    Returns (score: int, label: str) where label is "high" | "medium" | "low".
+    """
+    if not thinking_text or not answer_text:
+        return 0, "low"
+    think_kw = _extract_keywords(thinking_text)
+    answer_kw = _extract_keywords(answer_text)
+    if not think_kw or not answer_kw:
+        return 0, "low"
+    overlap = len(think_kw & answer_kw)
+    score = min(100, round(overlap / len(answer_kw) * 100))
+    if score >= 70:
+        label = "high"
+    elif score >= 35:
+        label = "medium"
+    else:
+        label = "low"
+    return score, label
+
+
+# ── Step classification ───────────────────────────────────────────────────────
 
 # Keyword heuristics for step classification
 _PREMISE_RE = re.compile(
@@ -134,6 +187,7 @@ def _parse_session_reasoning(session_id):
         # Collect thinking + answer blocks from this assistant turn
         thinking_blocks = []
         answer_word_count = 0
+        answer_texts = []
 
         for block in content_obj:
             if not isinstance(block, dict):
@@ -146,6 +200,10 @@ def _parse_session_reasoning(session_id):
             elif btype == "text":
                 text = block.get("text", "") or ""
                 answer_word_count += len(text.split())
+                if text:
+                    answer_texts.append(text)
+
+        answer_combined = " ".join(answer_texts)
 
         for thinking_text in thinking_blocks:
             steps = _segment_thinking(thinking_text)
@@ -155,12 +213,15 @@ def _parse_session_reasoning(session_id):
             efficiency_ratio = (
                 round(thinking_tokens / answer_tokens, 1) if answer_tokens > 0 else 0.0
             )
+            c_score, c_label = _coherence_score(thinking_text, answer_combined)
             chains.append(
                 {
                     "timestamp": ts or "",
                     "thinking_tokens": thinking_tokens,
                     "answer_tokens": answer_tokens,
                     "efficiency_ratio": efficiency_ratio,
+                    "coherence_score": c_score,
+                    "coherence_label": c_label,
                     "steps": steps,
                     "raw_thinking": thinking_text,
                 }
@@ -186,6 +247,19 @@ def api_reasoning():
         else 0.0
     )
 
+    scored_chains = [c for c in chains if c["coherence_score"] > 0]
+    avg_coherence_score = (
+        round(sum(c["coherence_score"] for c in scored_chains) / len(scored_chains))
+        if scored_chains
+        else 0
+    )
+    if avg_coherence_score >= 70:
+        avg_coherence_label = "high"
+    elif avg_coherence_score >= 35:
+        avg_coherence_label = "medium"
+    else:
+        avg_coherence_label = "low"
+
     return jsonify(
         {
             "session_id": session_id,
@@ -195,6 +269,8 @@ def api_reasoning():
                 "total_answer_tokens": total_answer_tokens,
                 "avg_efficiency": avg_efficiency,
                 "chain_count": len(chains),
+                "avg_coherence_score": avg_coherence_score,
+                "avg_coherence_label": avg_coherence_label,
             },
         }
     )


### PR DESCRIPTION
## Summary

Developers paying for extended thinking tokens had no way to tell whether those tokens actually drove the final answer or were post-hoc rationalization. This PR adds a **Reasoning Coherence Score (0–100)** to the existing reasoning chain viewer, surfacing that signal with zero new dependencies.

The score measures keyword overlap between a thinking block and the assistant's answer for the same turn. High overlap means the reasoning vocabulary appeared in the output (likely genuine). Low overlap signals the model may have jumped to a conclusion and generated reasoning as decoration afterward.

## Changes

- **`routes/reasoning.py`** — `_coherence_score(thinking_text, answer_text)` extracts significant keywords (≥4 chars, minus a stop-word list) from each side and computes `overlap / len(answer_keywords) * 100`. Each chain object now includes `coherence_score` (int 0–100) and `coherence_label` (`"high"` / `"medium"` / `"low"`). The summary adds `avg_coherence_score` and `avg_coherence_label` across all scored chains.
- **`clawmetry/static/js/app.js`** — The reasoning chain panel in the Brain tab now shows a colored pill badge (🟢 high / 🟡 medium / 🔴 low) in the summary bar (avg) and in each per-chain header when multiple chains exist. Hovering the badge shows the score and what it means.

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("routes/reasoning.py").read())'` — syntax OK
- [ ] `node --check clawmetry/static/js/app.js` — syntax OK
- [ ] `GET /api/reasoning?session=<session-with-thinking>` — each chain has `coherence_score` + `coherence_label`; summary has `avg_coherence_score` + `avg_coherence_label`
- [ ] Brain tab → expand a session with reasoning chains → coherence badge visible in summary bar
- [ ] Session with a single chain: badge in summary bar only (no per-chain header shown for single chains)
- [ ] Session with no thinking blocks: endpoint still returns `avg_coherence_score: 0` gracefully

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #572. Marked draft for human review — mark Ready for Review once happy.

Closes #572

---
_Generated by [Claude Code](https://claude.ai/code/session_01Motcyf34tMegKyzRq7AZH9)_