### PR TITLE
fix(sync): initialise _sessions_json_cache + global declaration

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1231,6 +1231,9 @@ def _local_ingest_memory_files(all_files: list, changed_paths: list) -> None:
         })
 
 
+_sessions_json_cache: dict = {"ts": 0.0, "data": None, "mtime": 0.0}
+
+
 def sync_sessions_recent(
     config: dict, state: dict, paths: dict, minutes: int = 60
 ) -> int:
@@ -1264,6 +1267,7 @@ def sync_sessions_recent(
 
     # Build subagent map (same logic as sync_sessions)
     # Cache sessions.json for 60 seconds to avoid re-parsing every call
+    global _sessions_json_cache
     file_to_subagent_id: dict[str, str] = {}
     index_path = os.path.join(sessions_dir, "sessions.json")
     if os.path.isfile(index_path):


### PR DESCRIPTION
## Summary

\`sync_sessions_recent\` (\`clawmetry/sync.py:1234\`) reads \`_sessions_json_cache[\"data\"]\` at line 1272 then later assigns \`_sessions_json_cache = {...}\` at line 1282. Two latent bugs:

1. Without \`global _sessions_json_cache\`, Python classifies the name as local for the entire function → the read at 1272 raises **UnboundLocalError** on first call.
2. The variable was never module-level initialised → would raise **NameError** even with \`global\`.

This path triggers whenever \`~/.openclaw/agents/main/sessions/sessions.json\` exists, i.e. any installation with sub-agents.

## Fix

- Initialise \`_sessions_json_cache\` at module scope with the same shape the function writes back.
- Add \`global _sessions_json_cache\` inside \`sync_sessions_recent\`.

## Background

Bug originally identified in #513 by @dumko2001. Reimplemented as a 2-line fix on current main instead of rebasing that 83-line branch which has merge conflicts and a bunch of tangentially-related changes.

## Test plan

- [ ] CI green
- [ ] Manual: trigger \`sync_sessions_recent\` against an OpenClaw workspace with sub-agents → no UnboundLocalError, cache hits work across calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)