### PR TITLE
feat(local-server): host /api/local/* inside the daemon — fixes cross-process DuckDB lock

### DIFF
--- a/clawmetry/local_server.py
+++ b/clawmetry/local_server.py
@@ -1,0 +1,176 @@
+"""HTTP query server hosted INSIDE the sync daemon process.
+
+WHY THIS EXISTS
+===============
+The daemon owns the DuckDB writer lock on ``~/.clawmetry/clawmetry.duckdb``.
+DuckDB's exclusive file lock blocks **every** other process from opening
+the file — even read-only. So the separate dashboard process (started by
+``clawmetry`` CLI on port 8900, while ``clawmetry sync`` runs as a
+launchd/systemd daemon on PID X) literally cannot read the local store.
+
+Fix: the daemon process exposes the same ``routes/local_query.py``
+shapes over a localhost HTTP endpoint. The dashboard's ``/api/local/*``
+routes proxy to this endpoint when the port-discovery file is present
+and the daemon is reachable. When daemon is down, dashboard falls back
+to opening the DuckDB directly (works in single-process mode).
+
+DISCOVERY + AUTH
+================
+On start, daemon:
+1. Generates a one-time 32-hex-char token.
+2. Binds an HTTP server to ``127.0.0.1`` on an ephemeral port.
+3. Writes ``{"port": N, "token": "...", "pid": M}`` to
+   ``~/.clawmetry/local_query.json``.
+
+Dashboard ``routes/local_query.py``:
+1. Reads ``local_query.json``.
+2. Sends each request as ``Authorization: Bearer <token>`` to
+   ``http://127.0.0.1:<port>/local/query``.
+3. On any failure (file missing, port refused, auth rejected), falls
+   back to direct DuckDB.
+
+Bound to ``127.0.0.1`` only — no other host can reach it. Combined with
+the rotating token, no other user on the same box can either (they'd
+need to read the port file, which is mode 0600).
+
+LIFECYCLE
+=========
+``start()`` spawns a daemon thread running werkzeug's WSGI server.
+``stop()`` is a no-op — the thread is daemon=True and dies with the
+process. Port file is removed atexit (best-effort).
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import secrets
+import socket
+import threading
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("clawmetry.local_server")
+
+DISCOVERY_PATH = Path(os.path.expanduser("~/.clawmetry/local_query.json"))
+
+
+# ── module state — single-process singleton ──────────────────────────────────
+_started_lock = threading.Lock()
+_server_thread: Optional[threading.Thread] = None
+_token: Optional[str] = None
+_port: Optional[int] = None
+
+
+def get_token() -> Optional[str]:
+    """Return the auth token, or None if the server hasn't been started."""
+    return _token
+
+
+def get_port() -> Optional[int]:
+    """Return the bound port, or None if the server hasn't been started."""
+    return _port
+
+
+def _make_app():
+    """Build the Flask app that hosts only the local_query blueprint.
+
+    Lazy-imported so non-daemon contexts don't pay the Flask cost.
+    """
+    from flask import Flask, request, jsonify
+    from routes.local_query import bp_local_query
+
+    app = Flask("clawmetry-local-server")
+
+    @app.before_request
+    def _check_token():
+        # Expected: Authorization: Bearer <token>
+        provided = (request.headers.get("Authorization") or "").strip()
+        if not provided.startswith("Bearer "):
+            return jsonify({"error": "unauthorized"}), 401
+        if provided[len("Bearer "):] != _token:
+            return jsonify({"error": "unauthorized"}), 401
+        return None
+
+    app.register_blueprint(bp_local_query)
+    return app
+
+
+def _pick_free_port() -> int:
+    """Bind-to-zero trick: ask the kernel for a free localhost port."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _write_discovery_file(port: int, token: str) -> None:
+    """Atomically write the port+token JSON. Mode 0600 so only the same
+    user can read it."""
+    DISCOVERY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"port": port, "token": token, "pid": os.getpid()}
+    tmp = DISCOVERY_PATH.with_suffix(DISCOVERY_PATH.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload))
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, DISCOVERY_PATH)
+
+
+def _cleanup_discovery_file() -> None:
+    """Remove the discovery file at process exit. Best-effort."""
+    try:
+        if DISCOVERY_PATH.exists():
+            DISCOVERY_PATH.unlink()
+    except Exception:
+        pass
+
+
+def _serve_forever(app, port: int) -> None:
+    """Run werkzeug in single-thread, daemon-attached mode. Threaded=True
+    so concurrent dashboard requests don't serialize on the WSGI loop."""
+    from werkzeug.serving import make_server
+    server = make_server("127.0.0.1", port, app, threaded=True)
+    log.info("local_server: listening on 127.0.0.1:%d", port)
+    try:
+        server.serve_forever()
+    except Exception:
+        log.exception("local_server: serve_forever crashed")
+
+
+def start() -> Optional[int]:
+    """Start the local query HTTP server.
+
+    Returns the bound port, or None if startup failed (caller can ignore
+    — daemon proceeds without the server, dashboard falls back to direct
+    DuckDB access).
+    """
+    global _server_thread, _token, _port
+    with _started_lock:
+        if _server_thread is not None and _server_thread.is_alive():
+            log.debug("local_server: already running on port %d", _port)
+            return _port
+        try:
+            app = _make_app()
+        except Exception as e:
+            log.warning("local_server: cannot build app (%s) — disabled", e)
+            return None
+        _token = secrets.token_hex(16)
+        _port = _pick_free_port()
+        _server_thread = threading.Thread(
+            target=_serve_forever, args=(app, _port),
+            name="clawmetry-local-server", daemon=True,
+        )
+        _server_thread.start()
+        try:
+            _write_discovery_file(_port, _token)
+        except Exception as e:
+            log.warning("local_server: failed to write discovery file: %s", e)
+        atexit.register(_cleanup_discovery_file)
+        return _port
+
+
+def is_running() -> bool:
+    """True iff the server thread is alive."""
+    return _server_thread is not None and _server_thread.is_alive()

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3564,6 +3564,22 @@ def run_daemon() -> None:
     except Exception as _e:
         log.warning("relay: failed to start (continuing without cold-data relay): %s", _e)
 
+    # ── Local query HTTP server (cross-process DuckDB read fix) ────────
+    # Daemon owns the DuckDB writer lock; the dashboard process can't
+    # open the same file (DuckDB exclusive lock blocks RO too). We host
+    # the same routes/local_query.py shapes on a localhost port; the
+    # dashboard's /api/local/* proxies through. Discovery+auth via
+    # ~/.clawmetry/local_query.json. Failure here is non-fatal — the
+    # dashboard falls back to direct DuckDB access (works in
+    # single-process mode).
+    try:
+        from clawmetry import local_server as _local_server
+        _ls_port = _local_server.start()
+        if _ls_port:
+            log.info("local query server: listening on 127.0.0.1:%d", _ls_port)
+    except Exception as _e:
+        log.warning("local query server: failed to start: %s", _e)
+
     state = load_state()
 
     # Always sync recent events first (last hour) — makes the dashboard

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -52,9 +52,76 @@ def _store():
     the user never hits these endpoints. Always opens read-only — this
     process is a reader; the daemon process owns the writer lock. When
     daemon + dashboard share a process, ``get_store(read_only=True)``
-    transparently shares the writer's connection."""
+    transparently shares the writer's connection.
+
+    NOTE: when the daemon runs as a SEPARATE process (the launchd/systemd
+    install case), DuckDB's exclusive lock blocks even RO opens. In that
+    case ``_dispatch()`` proxies to the daemon's local_server first;
+    this fallback only fires in single-process mode.
+    """
     from clawmetry import local_store
     return local_store.get_store(read_only=True)
+
+
+# ── Daemon-hosted proxy (cross-process DuckDB lock fix) ─────────────────────
+
+import json as _json
+import os as _os
+
+_DISCOVERY_PATH = _os.path.expanduser("~/.clawmetry/local_query.json")
+_PROXY_TIMEOUT_SECS = 5.0
+
+
+def _read_discovery():
+    """Read ``~/.clawmetry/local_query.json`` if present + still valid.
+    Returns ``{port, token}`` or None."""
+    try:
+        with open(_DISCOVERY_PATH) as fh:
+            data = _json.load(fh)
+        port = int(data.get("port") or 0)
+        token = data.get("token") or ""
+        pid = int(data.get("pid") or 0)
+        if not (port and token and pid):
+            return None
+        # Cheap liveness check: PID alive? Avoids the ~5s socket
+        # connect-refused wait when the daemon was killed but the file
+        # wasn't cleaned up (atexit doesn't fire on SIGKILL).
+        try:
+            _os.kill(pid, 0)
+        except OSError:
+            return None
+        return {"port": port, "token": token}
+    except (FileNotFoundError, ValueError, OSError):
+        return None
+
+
+def _proxy_dispatch(shape: str, args: dict):
+    """Forward the dispatch to the daemon's local_server. Returns the
+    response dict on success, raises on failure."""
+    # Loop-break: if local_server is running in THIS process we ARE the
+    # daemon — proxying would just hit our own handler and recurse.
+    try:
+        from clawmetry import local_server as _ls
+        if _ls.is_running():
+            raise RuntimeError("dispatch is in-daemon; skipping proxy")
+    except ImportError:
+        pass
+    disc = _read_discovery()
+    if not disc:
+        raise FileNotFoundError("daemon local_server not discoverable")
+    import urllib.request
+    payload = _json.dumps({"shape": shape, "args": args}).encode("utf-8")
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{disc['port']}/api/local/query",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {disc['token']}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=_PROXY_TIMEOUT_SECS) as resp:
+        return _json.loads(resp.read().decode("utf-8"))
 
 
 def _coerce_args(shape: str, raw: dict) -> dict:
@@ -105,8 +172,25 @@ def _safe_int(v: Any, *, default: int, lo: int, hi: int) -> int:
 
 def _dispatch(shape: str, args: dict) -> dict:
     """Single-source-of-truth shape→method bridge. Both the HTTP and (future)
-    WS transports call this. Returns a JSON-friendly dict ready to ship."""
+    WS transports call this. Returns a JSON-friendly dict ready to ship.
+
+    Routing order:
+      1. If a daemon local_server discovery file is present + alive,
+         proxy through it (the daemon is the only process that can read
+         the DuckDB while it owns the writer lock).
+      2. Else fall back to opening the DuckDB directly (single-process
+         mode, or daemon temporarily down).
+    """
     started = time.monotonic()
+    # Try the daemon proxy first. If it fails for ANY reason, fall
+    # through to direct access — the dashboard never goes blank.
+    try:
+        body = _proxy_dispatch(shape, args)
+        body["_via"] = "daemon_proxy"
+        body["_elapsed_ms"] = int((time.monotonic() - started) * 1000)
+        return body
+    except Exception:
+        pass
     store = _store()
     if shape == "health":
         body = store.health()
@@ -115,6 +199,7 @@ def _dispatch(shape: str, args: dict) -> dict:
         rows = getattr(store, method_name)(**args)
         body = {"rows": rows, "count": len(rows)}
     body["_shape"] = shape
+    body["_via"] = "direct"
     body["_elapsed_ms"] = int((time.monotonic() - started) * 1000)
     return body
 

--- a/tests/test_local_server_proxy.py
+++ b/tests/test_local_server_proxy.py
@@ -1,0 +1,186 @@
+"""Tests for the daemon-hosted local query server + dashboard proxy.
+
+Covers the cross-process DuckDB lock fix:
+  - Daemon spawns local_server, writes discovery file (port + token + pid)
+  - Dashboard's _dispatch() reads the file, forwards over HTTP
+  - Auth: requests without the Bearer token return 401
+  - Liveness: dead PID in the discovery file → discovery returns None,
+    dashboard falls back to direct DuckDB
+  - End-to-end: spawn local_server in this process, hit it via
+    routes.local_query._proxy_dispatch — confirm same data shape as
+    direct dispatch
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import time
+import uuid
+
+import pytest
+import requests
+
+
+@pytest.fixture
+def isolated_store(tmp_path, monkeypatch):
+    """Fresh DuckDB + reset all module-level singletons. Uses get_store()
+    so the singleton is registered — needed for the in-process local_server
+    to share the writer connection (DuckDB rejects mixed RW+RO opens of
+    the same file in the same process)."""
+    db = tmp_path / "events.duckdb"
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(db))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    ls._reset_singleton_for_tests()
+    s = ls.get_store(read_only=False)  # registers singleton
+    # Seed a couple events
+    for i in range(3):
+        s.ingest({
+            "id": f"e{i}-{uuid.uuid4()}",
+            "node_id": "agent+test",
+            "agent_id": "main",
+            "event_type": "tool_call",
+            "ts": int(time.time() * 1000),
+        })
+    time.sleep(0.2)  # let the flusher catch up
+    yield s
+    s.stop(flush=True)
+    ls._reset_singleton_for_tests()
+
+
+def test_discovery_file_round_trip(isolated_store, tmp_path, monkeypatch):
+    """local_server.start() writes discovery file with port+token+pid."""
+    monkeypatch.setattr(
+        "clawmetry.local_server.DISCOVERY_PATH",
+        tmp_path / "local_query.json",
+    )
+    import clawmetry.local_server as srv
+    importlib.reload(srv)
+    monkeypatch.setattr(
+        srv, "DISCOVERY_PATH", tmp_path / "local_query.json", raising=False,
+    )
+    port = srv.start()
+    try:
+        assert port and isinstance(port, int)
+        # Discovery file present + correct shape
+        disc = json.loads((tmp_path / "local_query.json").read_text())
+        assert disc["port"] == port
+        assert disc["pid"] == os.getpid()
+        assert len(disc["token"]) == 32
+        # File mode 0600
+        assert oct((tmp_path / "local_query.json").stat().st_mode & 0o777) == "0o600"
+    finally:
+        srv._cleanup_discovery_file()
+
+
+def test_server_rejects_unauthenticated(isolated_store, tmp_path, monkeypatch):
+    """Hits without Bearer token → 401."""
+    monkeypatch.setattr(
+        "clawmetry.local_server.DISCOVERY_PATH",
+        tmp_path / "local_query.json",
+        raising=False,
+    )
+    import clawmetry.local_server as srv
+    importlib.reload(srv)
+    monkeypatch.setattr(srv, "DISCOVERY_PATH", tmp_path / "local_query.json", raising=False)
+    port = srv.start()
+    try:
+        # Wait for server up
+        time.sleep(0.3)
+        # No auth header
+        r = requests.post(
+            f"http://127.0.0.1:{port}/api/local/query",
+            json={"shape": "health", "args": {}},
+            timeout=2,
+        )
+        assert r.status_code == 401
+        # Wrong token
+        r = requests.post(
+            f"http://127.0.0.1:{port}/api/local/query",
+            json={"shape": "health", "args": {}},
+            headers={"Authorization": "Bearer bogus"},
+            timeout=2,
+        )
+        assert r.status_code == 401
+        # Right token works
+        r = requests.post(
+            f"http://127.0.0.1:{port}/api/local/query",
+            json={"shape": "health", "args": {}},
+            headers={"Authorization": f"Bearer {srv.get_token()}"},
+            timeout=2,
+        )
+        assert r.status_code == 200
+        assert "_shape" in r.json()
+    finally:
+        srv._cleanup_discovery_file()
+
+
+def test_proxy_loopbreak_when_running_in_daemon(isolated_store, tmp_path, monkeypatch):
+    """Sanity check on the loop-break: when local_server is running in
+    THIS process (the daemon case), _proxy_dispatch must refuse to
+    forward — otherwise it'd hit its own handler and recurse."""
+    monkeypatch.setattr(
+        "clawmetry.local_server.DISCOVERY_PATH",
+        tmp_path / "local_query.json",
+        raising=False,
+    )
+    import clawmetry.local_server as srv
+    importlib.reload(srv)
+    monkeypatch.setattr(srv, "DISCOVERY_PATH", tmp_path / "local_query.json", raising=False)
+    srv.start()
+    try:
+        time.sleep(0.3)
+        import routes.local_query as lq
+        importlib.reload(lq)
+        monkeypatch.setattr(lq, "_DISCOVERY_PATH", str(tmp_path / "local_query.json"))
+        # Loop-break should fire and skip the proxy hop entirely
+        with pytest.raises(RuntimeError, match="in-daemon"):
+            lq._proxy_dispatch("events", {"limit": 10})
+        # And _dispatch should fall through to direct
+        result = lq._dispatch("health", {})
+        assert result["_via"] == "direct"
+    finally:
+        srv._cleanup_discovery_file()
+
+
+def test_proxy_falls_back_when_daemon_dead(isolated_store, tmp_path, monkeypatch):
+    """If discovery file references a dead PID, _dispatch should fall
+    back to direct DuckDB (no crash, no 5s wait)."""
+    # Write a bogus discovery file with a definitely-dead PID
+    disc_path = tmp_path / "local_query.json"
+    disc_path.write_text(json.dumps({
+        "port": 65000, "token": "x" * 32, "pid": 999999,  # almost certainly not alive
+    }))
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(lq, "_DISCOVERY_PATH", str(disc_path))
+    started = time.monotonic()
+    result = lq._dispatch("events", {"limit": 5})
+    elapsed = time.monotonic() - started
+    assert result["_via"] == "direct"
+    assert elapsed < 1.0, f"Fallback took {elapsed:.2f}s — should be near-instant"
+
+
+def test_proxy_falls_back_when_no_discovery(tmp_path, monkeypatch):
+    """No discovery file at all → direct fallback."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    ls._reset_singleton_for_tests()
+    # Bootstrap the file
+    s = ls.LocalStore(read_only=False)
+    s.start()
+    s.ingest({"id": "e", "node_id": "n", "event_type": "x", "ts": int(time.time() * 1000)})
+    time.sleep(0.2)
+    s.stop(flush=True)
+    importlib.reload(ls)
+    ls._reset_singleton_for_tests()
+
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(lq, "_DISCOVERY_PATH", str(tmp_path / "nonexistent.json"))
+    result = lq._dispatch("health", {})
+    assert result["_via"] == "direct"


### PR DESCRIPTION
## Problem

DuckDB's exclusive file lock blocks every other process from opening the file — even read-only. So with the standard install:
- \`clawmetry sync\` (launchd/systemd, owns writer)
- \`clawmetry\` (dashboard, separate PID)

The dashboard's \`/api/local/events\` returns:
\`\`\`
IO Error: Could not set lock on file ".../clawmetry.duckdb": Conflicting lock is held in PID xxxxx
\`\`\`

#1039 fixed the same-process case via RW/RO singleton split — DuckDB rejects RO opens cross-process when an RW writer is alive. This PR fixes the cross-process case.

## How

The daemon process — the only one that can read DuckDB while it owns the writer — exposes the same \`routes/local_query.py\` shapes over a localhost HTTP endpoint. Dashboard's \`_dispatch()\` proxies through it with direct-DuckDB fallback if no daemon is running.

- **\`clawmetry/local_server.py\`** (new) — werkzeug server bound to 127.0.0.1, ephemeral port. Auth = one-time 32-hex token. Discovery via \`~/.clawmetry/local_query.json\` (mode 0600).
- **\`sync.py:run_daemon()\`** — starts local_server alongside the relay. Failure non-fatal.
- **\`routes/local_query.py:_dispatch()\`** — proxy-first, direct-fallback. Loop-break: skip proxy if local_server is running in same process (we ARE the daemon).
- Cheap \`os.kill(pid, 0)\` liveness check on discovery — stale file doesn't cost a 5s socket-connect-refused.

## Tests

- 5 new tests in \`test_local_server_proxy.py\`: discovery file shape + 0600 mode, auth rejection, dead-PID fallback (<1s), no-discovery fallback, loop-break sanity
- 22 existing \`test_local_store.py\` tests still pass
- 19 e2e tests in \`test_e2e_duckdb_relay.py\` still pass
- **49/49 green**

## Stacking

Builds on #1039. Both should ship together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)