### PR TITLE
feat(heartbeat): read /api/heartbeat from local DuckDB

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -794,6 +794,64 @@ class LocalStore:
                                   "event_count","cost_usd","token_count"])
                 for r in self._fetch(sql, params)]
 
+    def query_heartbeats(
+        self,
+        *,
+        node_id: str | None = None,
+        agent_type: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Read heartbeat rows. Defaults to most recent first.
+
+        Each row is a single daemon liveness ping (one per heartbeat
+        interval, typically every 60s). Use ``since=<iso ts>`` to filter to
+        a recent window (e.g. last 24h). The ``data`` BLOB is decoded back
+        to a JSON dict when valid, str otherwise, None when empty.
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        if node_id:
+            clauses.append("node_id = ?")
+            params.append(node_id)
+        if agent_type:
+            clauses.append("agent_type = ?")
+            params.append(agent_type)
+        if since:
+            clauses.append("ts >= ?")
+            params.append(since)
+        if until:
+            clauses.append("ts <= ?")
+            params.append(until)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT agent_type, node_id, ts, version, e2e, size_mb,
+                   events_total, data
+            FROM heartbeats
+            {where}
+            ORDER BY ts DESC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["agent_type", "node_id", "ts", "version", "e2e", "size_mb",
+                "events_total", "data"]
+        out: list[dict[str, Any]] = []
+        for r in self._fetch(sql, params):
+            d = dict(zip(cols, r))
+            raw = d.get("data")
+            if raw is not None:
+                try:
+                    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                    try:
+                        d["data"] = json.loads(text)
+                    except (ValueError, TypeError):
+                        d["data"] = text
+                except UnicodeDecodeError:
+                    d["data"] = None
+            out.append(d)
+        return out
+
     def query_aggregates(
         self,
         *,

--- a/routes/heartbeat.py
+++ b/routes/heartbeat.py
@@ -159,6 +159,90 @@ def _compute_heartbeat_data(sessions_dir):
     }
 
 
+def _try_local_store_heartbeat(interval, now):
+    """Epic #964 phase 1b fast path. When CLAWMETRY_LOCAL_STORE_READ=1 AND
+    the local DuckDB ``heartbeats`` table has rows, build the same response
+    shape as the legacy session-transcript scanner. Returns ``None`` to
+    defer to the JSONL scanner if:
+
+      - the local_store module isn't importable
+      - the heartbeats table is empty
+      - any unexpected error happens (we'd rather degrade than 500)
+
+    Daemon-emitted heartbeats are pure liveness pings — there is no
+    "action taken" notion at the daemon layer, so every beat is treated
+    as outcome="ok". The session-transcript fallback retains its richer
+    ok/action classification when the daemon isn't writing local rows.
+    """
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return None
+    try:
+        store = local_store.get_store()
+        rows = store.query_heartbeats(limit=500)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    cutoff_24h = now - 86400
+    beats = []
+    for r in rows:
+        ts = _parse_iso_ts(r.get("ts", ""))
+        if ts <= 0:
+            continue
+        beats.append({"ts": ts, "outcome": "ok"})
+    if not beats:
+        return None
+
+    beats.sort(key=lambda b: b["ts"], reverse=True)
+    last_heartbeat_ts = beats[0]["ts"]
+    beats_24h = [b for b in beats if b["ts"] >= cutoff_24h]
+    ok_count = sum(1 for b in beats_24h if b["outcome"] == "ok")
+    action_count = sum(1 for b in beats_24h if b["outcome"] == "action")
+    total_24h = ok_count + action_count
+    ok_ratio = round(ok_count / total_24h, 3) if total_24h > 0 else 1.0
+    recent_beats = list(reversed(beats[:10]))
+
+    age_seconds = int(now - last_heartbeat_ts) if last_heartbeat_ts > 0 else None
+    if last_heartbeat_ts == 0:
+        status = "never"
+    else:
+        gap = now - last_heartbeat_ts
+        if gap <= interval:
+            status = "healthy"
+        elif gap <= interval * 1.5:
+            status = "drifting"
+        else:
+            status = "missed"
+
+    window_seconds = 86400
+    expected_beats = max(1, window_seconds // interval) if interval > 0 else 48
+    actual_beats = len(beats_24h)
+    on_time_ratio = round(actual_beats / expected_beats, 3) if expected_beats > 0 else 0.0
+    on_time_ratio = min(on_time_ratio, 1.0)
+
+    return {
+        "last_heartbeat_ts": last_heartbeat_ts,
+        "last_heartbeat_age_seconds": age_seconds,
+        "expected_interval_seconds": interval,
+        "status": status,
+        "cadence_24h": {
+            "expected_beats": expected_beats,
+            "actual_beats": actual_beats,
+            "on_time_ratio": on_time_ratio,
+        },
+        "ok_vs_action_24h": {
+            "heartbeat_ok_count": ok_count,
+            "action_taken_count": action_count,
+            "ok_ratio": ok_ratio,
+        },
+        "recent_beats": recent_beats,
+        "_source": "local_store",
+    }
+
+
 @bp_heartbeat.route("/api/heartbeat")
 def api_heartbeat():
     """
@@ -187,6 +271,15 @@ def api_heartbeat():
 
     now = time.time()
     interval = int(_d._heartbeat_interval_sec)
+    # Epic #964 phase 1b: opt-in local-store fast path. When
+    # CLAWMETRY_LOCAL_STORE_READ=1 AND the local DuckDB heartbeats table has
+    # rows, serve directly from DuckDB. Falls through to JSONL scan otherwise
+    # (so a fresh install with no local store sees the same data as before —
+    # zero-change default).
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_heartbeat(interval, now)
+        if fast is not None:
+            return jsonify(fast)
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )

--- a/tests/test_heartbeat_local_store.py
+++ b/tests/test_heartbeat_local_store.py
@@ -1,0 +1,235 @@
+"""Tests for epic #964 phase 1b — local-store fast path on /api/heartbeat.
+
+The fast path is opt-in via CLAWMETRY_LOCAL_STORE_READ=1 so the legacy
+session-transcript scanner stays the default until ≥80% adoption.
+
+Daemon-emitted heartbeats are stored in DuckDB's `heartbeats` table by
+sync.py (~once per minute). The fast path queries that table and shapes
+the response to match the existing /api/heartbeat contract.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.heartbeat as hb
+    importlib.reload(hb)
+
+    a = Flask(__name__)
+    a.register_blueprint(hb.bp_heartbeat)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def test_heartbeat_fast_path_returns_local_store_data(app):
+    """Populated `heartbeats` table → fast path serves directly from DuckDB
+    and returns the documented /api/heartbeat response shape."""
+    a, ls = app
+    store = ls.get_store()
+
+    # Seed 5 heartbeats over the last ~5 minutes — well within the
+    # default 30-min interval so they should classify as "healthy".
+    now = time.time()
+    for i in range(5):
+        store.ingest_heartbeat({
+            "node_id": "agent+test",
+            "ts": _iso(now - (i * 60)),
+            "version": "0.12.162",
+            "e2e": True,
+            "size_mb": 12.5,
+            "events_total": 1234 + i,
+        })
+
+    c = a.test_client()
+    r = c.get("/api/heartbeat")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+
+    # Tag confirms fast path took the wheel.
+    assert body.get("_source") == "local_store"
+
+    # Shape matches the documented contract.
+    assert "last_heartbeat_ts" in body
+    assert "last_heartbeat_age_seconds" in body
+    assert "expected_interval_seconds" in body
+    assert "status" in body
+    assert "cadence_24h" in body
+    assert "ok_vs_action_24h" in body
+    assert "recent_beats" in body
+
+    cadence = body["cadence_24h"]
+    assert "expected_beats" in cadence
+    assert "actual_beats" in cadence
+    assert "on_time_ratio" in cadence
+    assert cadence["actual_beats"] == 5
+
+    ok_vs_action = body["ok_vs_action_24h"]
+    # All daemon heartbeats are liveness pings → outcome="ok", no actions.
+    assert ok_vs_action["heartbeat_ok_count"] == 5
+    assert ok_vs_action["action_taken_count"] == 0
+    assert ok_vs_action["ok_ratio"] == 1.0
+
+    # Most recent beat is within seconds → status should be healthy.
+    assert body["status"] == "healthy"
+    assert body["last_heartbeat_age_seconds"] is not None
+    assert body["last_heartbeat_age_seconds"] < 120
+
+    # recent_beats is capped at 10, oldest first.
+    rb = body["recent_beats"]
+    assert len(rb) == 5
+    assert all(b["outcome"] == "ok" for b in rb)
+    assert rb[0]["ts"] <= rb[-1]["ts"]
+
+
+def test_heartbeat_fast_path_status_drifting_when_stale(app):
+    """A heartbeat last seen >interval but ≤1.5×interval ago → drifting.
+    Default interval is 1800s; we backdate the only beat to 2400s ago."""
+    a, ls = app
+    store = ls.get_store()
+
+    now = time.time()
+    store.ingest_heartbeat({
+        "node_id": "agent+stale",
+        "ts": _iso(now - 2400),  # 40 min ago — between 1×30m and 1.5×30m=45m
+        "version": "0.12.162",
+        "e2e": True,
+    })
+
+    c = a.test_client()
+    r = c.get("/api/heartbeat")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    assert body["status"] == "drifting"
+
+
+def test_heartbeat_fast_path_status_missed_when_very_stale(app):
+    """A heartbeat last seen >1.5×interval ago → missed."""
+    a, ls = app
+    store = ls.get_store()
+
+    now = time.time()
+    store.ingest_heartbeat({
+        "node_id": "agent+gone",
+        "ts": _iso(now - 7200),  # 2 hours ago — way past 1.5×30m=45m
+        "version": "0.12.162",
+        "e2e": True,
+    })
+
+    c = a.test_client()
+    r = c.get("/api/heartbeat")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    assert body["status"] == "missed"
+
+
+def test_heartbeat_fast_path_falls_back_when_store_empty(app):
+    """Empty `heartbeats` table → fast path returns None so the JSONL
+    scanner runs. We can't easily exercise the full JSONL parser in unit
+    tests (needs ~/.openclaw fixture), so we just verify the fast path
+    *defers* — the response is missing the `_source: local_store` tag and
+    classifies as `never` because no data is available from any source."""
+    a, _ls = app
+    c = a.test_client()
+    r = c.get("/api/heartbeat")
+    assert r.status_code == 200
+    body = r.get_json()
+    # Fast path returned None → fell through to legacy scanner, which does
+    # NOT add the _source tag.
+    assert body.get("_source") != "local_store"
+    # Empty store + no JSONL fixture → status=never.
+    assert body["status"] in {"never", "missed", "drifting", "healthy"}
+
+
+def test_heartbeat_fast_path_disabled_without_env_flag(tmp_path, monkeypatch):
+    """No CLAWMETRY_LOCAL_STORE_READ → fast path never runs, even with
+    populated store. Defaults to legacy JSONL scanner so existing deploys
+    see zero change without explicit opt-in."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.heartbeat as hb
+    importlib.reload(hb)
+
+    store = ls.get_store()
+    store.ingest_heartbeat({
+        "node_id": "agent+noflag",
+        "ts": _iso(time.time()),
+        "version": "0.12.162",
+        "e2e": True,
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(hb.bp_heartbeat)
+    r = a.test_client().get("/api/heartbeat")
+    body = r.get_json()
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_query_heartbeats_filters(tmp_path, monkeypatch):
+    """LocalStore.query_heartbeats() exposes since/until/node_id/agent_type
+    filters so other consumers (alerts, fleet view) can scope reads."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    store = ls.get_store()
+    try:
+        # Two nodes, three timestamps each.
+        for node in ("a", "b"):
+            for i in range(3):
+                store.ingest_heartbeat({
+                    "node_id": f"agent+{node}",
+                    "ts": f"2026-05-1{i+1}T12:00:00+00:00",
+                    "version": "0.12.162",
+                    "e2e": True,
+                })
+        all_rows = store.query_heartbeats()
+        assert len(all_rows) == 6
+        # Newest first.
+        assert all_rows[0]["ts"] >= all_rows[-1]["ts"]
+
+        only_a = store.query_heartbeats(node_id="agent+a")
+        assert len(only_a) == 3
+        assert all(r["node_id"] == "agent+a" for r in only_a)
+
+        recent = store.query_heartbeats(since="2026-05-12T00:00:00+00:00")
+        # Two nodes × two days (12th, 13th) = 4 rows.
+        assert len(recent) == 4
+    finally:
+        try:
+            store.stop(flush=True)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- Epic #964 phase 1b: opt-in local-store fast path on `/api/heartbeat`, matching the pattern shipped on `/api/sessions` (#) and `/api/brain-history` (#).
- New `LocalStore.query_heartbeats()` helper (`since` / `until` / `node_id` / `agent_type` filters, ~10 lines mirroring `query_events`).
- Adds `_try_local_store_heartbeat()` in `routes/heartbeat.py`, gated on `CLAWMETRY_LOCAL_STORE_READ=1`. Falls through to the legacy `SESSIONS_DIR` jsonl scanner when the table is empty or the env flag is unset — zero-change default for existing deploys.

## Behaviour notes
- Daemon-emitted heartbeats (written by `sync.py` ~once per minute) are pure liveness pings — there is no "action taken" notion at the daemon layer, so every beat on the fast path is `outcome="ok"`. The session-transcript fallback retains its richer ok/action classification.
- Response shape is identical to the existing contract documented in the handler docstring; the only addition is a `_source: "local_store"` tag so callers can verify the path.

## Test plan
- [x] `tests/test_heartbeat_local_store.py` — 6 tests:
  - populated-store happy path returns documented shape + `_source` tag
  - status="drifting" when last beat is between `interval` and `1.5×interval` ago
  - status="missed" when last beat is past `1.5×interval`
  - empty store → fast path returns None, handler falls through (no `_source` tag on response)
  - missing `CLAWMETRY_LOCAL_STORE_READ` env → fast path never runs even with rows present
  - `query_heartbeats()` filters (since / node_id) honour the documented contract
- [x] Existing `tests/test_local_store.py` (25 tests) and `tests/test_brain_local_fastpath.py` (3 tests) still pass — total 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)