### PR TITLE
feat(sessions): read /api/sessions/by-type from local DuckDB

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -149,6 +149,16 @@ def api_sessions_by_type():
     returned session list (counts always cover all sessions).
     """
     import dashboard as _d
+    type_filter = request.args.get("type", "").strip()
+
+    # Epic #964: opt-in local-store fast path. Mirrors /api/sessions — when
+    # CLAWMETRY_LOCAL_STORE_READ=1 AND the local sessions table has rows,
+    # serve directly from DuckDB. Falls through to gateway/JSONL otherwise.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_sessions_by_type(type_filter)
+        if fast is not None:
+            return jsonify(fast)
+
     gw_data = _d._gw_invoke("sessions_list", {"limit": 50, "messageLimit": 0})
     if gw_data and "sessions" in gw_data:
         sessions = _d._augment_sessions_with_burn(gw_data["sessions"])
@@ -165,12 +175,87 @@ def api_sessions_by_type():
         counts[t] = counts.get(t, 0) + 1
     counts["total"] = len(sessions)
 
-    type_filter = request.args.get("type", "").strip()
     filtered = [
         s for s in sessions
         if not type_filter or s.get("session_type") == type_filter
     ]
     return jsonify({"counts": counts, "sessions": filtered})
+
+
+def _try_local_store_sessions_by_type(type_filter: str = ""):
+    """By-type variant of :func:`_try_local_store_sessions`.
+
+    Reads sessions from the local DuckDB and computes the same
+    ``{"counts": {...}, "sessions": [...]}`` shape the legacy gateway/JSONL
+    path returns. ``type_filter`` (``main``/``heartbeat``/``user``/``sub-agent``
+    or empty for all) only narrows the ``sessions`` list — ``counts`` always
+    covers every row in the local store.
+
+    Returns ``None`` to defer to the legacy fallback if:
+      - the ``local_store`` module isn't importable
+      - the sessions table is empty (fresh install / non-OpenClaw user)
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = store._fetch("""
+            SELECT agent_type, session_id, agent_id, title, started_at,
+                   last_active_at, ended_at, status, total_tokens, cost_usd,
+                   message_count, metadata
+            FROM sessions
+            ORDER BY COALESCE(last_active_at, started_at) DESC NULLS LAST
+            LIMIT 200
+        """, [])
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    sessions = []
+    for r in rows:
+        meta = {}
+        if r[11]:
+            try:
+                import json as _j
+                meta = _j.loads(bytes(r[11]).decode("utf-8"))
+            except Exception:
+                pass
+        s = {
+            "agent_type":     r[0],
+            "session_id":     r[1],
+            "agent_id":       r[2],
+            "title":          r[3] or "",
+            "started_at":     r[4] or "",
+            "updated_at":     r[5] or "",
+            "ended_at":       r[6] or "",
+            "status":         r[7] or "",
+            "total_tokens":   int(r[8] or 0),
+            "total_cost":     float(r[9] or 0.0),
+            "message_count":  int(r[10] or 0),
+            "channel":        meta.get("channel", ""),
+            "chat_type":      meta.get("chat_type", ""),
+            "subject":        r[3] or meta.get("subject", ""),
+            "displayName":    r[3] or "",
+            "kind":           meta.get("kind", ""),
+            "_source":        "local_store",
+        }
+        # Honour explicit metadata.session_type when present; otherwise
+        # classify with the same _infer_session_type() the legacy path uses.
+        s["session_type"] = meta.get("session_type") or _infer_session_type(s)
+        sessions.append(s)
+
+    counts = {"main": 0, "heartbeat": 0, "user": 0, "sub-agent": 0}
+    for s in sessions:
+        t = s.get("session_type", "main")
+        counts[t] = counts.get(t, 0) + 1
+    counts["total"] = len(sessions)
+
+    filtered = [
+        s for s in sessions
+        if not type_filter or s.get("session_type") == type_filter
+    ]
+    return {"counts": counts, "sessions": filtered, "_source": "local_store"}
 
 
 @bp_sessions.route("/api/compactions")

--- a/tests/test_sessions_by_type_local_store.py
+++ b/tests/test_sessions_by_type_local_store.py
@@ -1,0 +1,177 @@
+"""Tests for the /api/sessions/by-type local-store fast path
+(epic #964 — engineer-3 follow-up to test_sessions_local_fastpath.py).
+
+Same opt-in pattern as the /api/sessions fast path:
+- CLAWMETRY_LOCAL_STORE_READ=1 + populated store → returns from DuckDB
+- ?type=<filter> narrows the sessions list (counts always cover all rows)
+- Flag unset → falls through to legacy gateway/JSONL path
+- Empty store → falls through (so fresh installs see normal data)
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# All four buckets the legacy by-type handler reports.
+_TYPES = ("main", "heartbeat", "user", "sub-agent")
+
+
+def _seed_one_of_each(store):
+    """Insert one session of each session_type via metadata.session_type."""
+    base_ts = "2026-05-11T10:"
+    rows = [
+        # session_type set explicitly via metadata so we don't depend on
+        # _infer_session_type() to classify the seed data.
+        ("sess-main",      "Working on routes refactor",
+         {"session_type": "main"}),
+        ("sess-heartbeat", "heartbeat ping",
+         {"session_type": "heartbeat"}),
+        ("sess-user",      "Telegram chat with vivek",
+         {"session_type": "user", "channel": "telegram"}),
+        ("sess-subagent",  "Sub-agent: code-review",
+         {"session_type": "sub-agent", "kind": "subagent"}),
+    ]
+    for i, (sid, title, meta) in enumerate(rows):
+        store.ingest_session({
+            "session_id": sid,
+            "agent_type": "openclaw",
+            "title": title,
+            # Stagger last_active_at so most-recent-first ordering is stable.
+            "started_at":     f"{base_ts}{10 + i:02d}:00Z",
+            "last_active_at": f"{base_ts}{30 + i:02d}:00Z",
+            "status": "active",
+            "total_tokens": 1000 * (i + 1),
+            "cost_usd": 0.10 * (i + 1),
+            "message_count": i + 1,
+            "metadata": meta,
+        })
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_by_type_no_filter_returns_all_with_counts(app):
+    """No ?type → all 4 sessions returned, counts dict balances."""
+    a, ls = app
+    _seed_one_of_each(ls.get_store())
+
+    r = a.test_client().get("/api/sessions/by-type")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert len(body["sessions"]) == 4
+
+    counts = body["counts"]
+    assert counts["main"] == 1
+    assert counts["heartbeat"] == 1
+    assert counts["user"] == 1
+    assert counts["sub-agent"] == 1
+    assert counts["total"] == 4
+    # Counts must always sum to total (legacy contract — counts cover every row).
+    assert sum(counts[t] for t in _TYPES) == counts["total"]
+
+
+@pytest.mark.parametrize("type_filter,expected_sid", [
+    ("main",      "sess-main"),
+    ("heartbeat", "sess-heartbeat"),
+    ("user",      "sess-user"),
+    ("sub-agent", "sess-subagent"),
+])
+def test_by_type_filter_narrows_sessions_but_counts_unchanged(
+    app, type_filter, expected_sid
+):
+    """?type=X → sessions narrows to that bucket, counts still cover all 4."""
+    a, ls = app
+    _seed_one_of_each(ls.get_store())
+
+    r = a.test_client().get(f"/api/sessions/by-type?type={type_filter}")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+
+    sessions = body["sessions"]
+    assert len(sessions) == 1
+    assert sessions[0]["session_id"] == expected_sid
+    assert sessions[0]["session_type"] == type_filter
+
+    # counts dict must still report the full population, not the filtered view.
+    counts = body["counts"]
+    assert counts["total"] == 4
+    assert all(counts[t] == 1 for t in _TYPES)
+
+
+def test_by_type_unknown_filter_returns_empty_sessions(app):
+    """?type=<bogus> → empty sessions list, counts still complete."""
+    a, ls = app
+    _seed_one_of_each(ls.get_store())
+
+    r = a.test_client().get("/api/sessions/by-type?type=does-not-exist")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["sessions"] == []
+    assert body["counts"]["total"] == 4
+
+
+def test_by_type_falls_back_when_store_empty(app):
+    """Empty store → fast path returns None → legacy path runs.
+
+    We can't easily exercise the legacy path in a unit-test (no gateway,
+    no workspace), so we just verify the response is NOT tagged as
+    served from local_store.
+    """
+    a, _ls = app
+    body = a.test_client().get("/api/sessions/by-type").get_json() or {}
+    assert body.get("_source") != "local_store"
+
+
+def test_by_type_disabled_without_flag(tmp_path, monkeypatch):
+    """No CLAWMETRY_LOCAL_STORE_READ → fast path never runs even with a
+    populated store. Default = zero behaviour change for existing deploys."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": "sess-noflag",
+        "agent_type": "openclaw",
+        "title": "Should not appear via fast path",
+        "started_at":     "2026-05-11T10:00:00Z",
+        "last_active_at": "2026-05-11T10:00:00Z",
+        "metadata": {"session_type": "main"},
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    body = a.test_client().get("/api/sessions/by-type").get_json() or {}
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- Wires `/api/sessions/by-type` through the same opt-in DuckDB fast path that already powers `/api/sessions` (`_try_local_store_sessions()`). When `CLAWMETRY_LOCAL_STORE_READ=1` and the local sessions table is non-empty, the handler now serves the counts dict and (optionally `?type=`-filtered) sessions list directly from local DuckDB instead of round-tripping the gateway / JSONL.
- Adds `_try_local_store_sessions_by_type(type_filter)` alongside the existing `_try_local_store_sessions()` — does not modify the latter (per Engineer 1's pattern). Reuses `_infer_session_type()` to classify any local-store row whose metadata doesn't carry an explicit `session_type`, so the classification matches the legacy gateway/JSONL path exactly.
- `counts` always covers the full population; `?type=` only narrows the returned sessions list (legacy contract preserved).
- Returns `None` on any failure / empty store so the legacy path runs unchanged. Default off; **zero behaviour change** without the env flag.

## Test plan
- [x] `pytest tests/test_sessions_by_type_local_store.py` — **8/8 pass** (no filter, four parameterized `?type=` filters, unknown-filter empty-list, empty-store fallback, env-flag-disabled fallback).
- [x] `pytest tests/test_sessions_local_fastpath.py` — **3/3 pass** (verified the existing `/api/sessions` fast path is untouched).
- [x] `pytest tests/test_local_store.py` — **25/25 pass** (LocalStore contract unchanged).

Epic #964 follow-up to `test_sessions_local_fastpath.py` (Engineer 1's `/api/sessions` fast path).