### PR TITLE
feat(sessions): decorate session rows with channel context from DuckDB

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -59,6 +59,93 @@ def _infer_session_type(session):
     return "main"
 
 
+def _get_channel_context_map(session_ids=None):
+    """Return ``{session_id: {channel, chat_type, subject, origin_label}}``
+    from the local DuckDB ``openclaw_channels`` table.
+
+    The table is the canonical, typed source for OpenClaw channel attribution
+    (Telegram/Slack/Signal/etc.) — populated by the gateway adapter via
+    ``LocalStore.ingest_channel()``. Today the legacy path infers channel
+    from a free-form ``metadata`` blob; this helper lets the local-store fast
+    path enrich session rows with the cleaner table when it has data.
+
+    Args:
+      session_ids: Optional iterable to scope the lookup. ``None`` returns
+        all rows (cheap — table is one row per session, capped well under
+        the default ``query_channels(limit=500)``).
+
+    Returns ``{}`` (no decoration) on any failure — the local-store module
+    not being importable, the table being empty, or any DuckDB error. The
+    caller treats an empty dict as "nothing to merge", which preserves the
+    pre-existing metadata-blob channel inference unchanged.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        if session_ids is not None:
+            ids = [s for s in session_ids if s]
+            if not ids:
+                return {}
+            rows = []
+            # query_channels supports one session_id at a time; for the typical
+            # /api/sessions response (≤200 rows) one full-table scan is cheaper
+            # than N round-trips.
+            if len(ids) > 20:
+                rows = store.query_channels(limit=2000)
+            else:
+                for sid in ids:
+                    rows.extend(store.query_channels(session_id=sid, limit=1))
+        else:
+            rows = store.query_channels(limit=2000)
+    except Exception:
+        return {}
+    out = {}
+    for r in rows:
+        sid = r.get("session_id")
+        if not sid:
+            continue
+        out[sid] = {
+            "channel":      r.get("channel") or "",
+            "chat_type":    r.get("chat_type") or "",
+            "subject":      r.get("subject") or "",
+            "origin_label": r.get("origin_label") or "",
+        }
+    return out
+
+
+def _decorate_with_channel_context(sessions):
+    """Mutate ``sessions`` in place, overriding empty channel/chat_type/subject
+    fields with values from the ``openclaw_channels`` table when present.
+
+    No-op when the table has no matching rows for any session in the list —
+    keeps existing values (typically inferred from the metadata blob)
+    unchanged. The override is one-way: only blank-on-the-row fields get
+    filled in, so a metadata-blob channel from the legacy path survives if
+    the channels table has nothing for that session.
+    """
+    if not sessions:
+        return sessions
+    ids = [s.get("session_id") or s.get("sessionId") for s in sessions]
+    ctx_map = _get_channel_context_map(ids)
+    if not ctx_map:
+        return sessions
+    for s in sessions:
+        sid = s.get("session_id") or s.get("sessionId")
+        ctx = ctx_map.get(sid)
+        if not ctx:
+            continue
+        # Prefer the typed table value over an empty/blank existing field.
+        if ctx["channel"] and not s.get("channel"):
+            s["channel"] = ctx["channel"]
+        if ctx["chat_type"] and not s.get("chat_type"):
+            s["chat_type"] = ctx["chat_type"]
+        if ctx["subject"] and not s.get("subject"):
+            s["subject"] = ctx["subject"]
+        if ctx["origin_label"] and not s.get("origin_label"):
+            s["origin_label"] = ctx["origin_label"]
+    return sessions
+
+
 @bp_sessions.route("/api/sessions")
 def api_sessions():
     import dashboard as _d
@@ -76,6 +163,13 @@ def api_sessions():
         sessions = _d._augment_sessions_with_burn(gw_data["sessions"])
     else:
         sessions = _d._augment_sessions_with_burn(_d._get_sessions())
+    # Same env-gate as the fast path: when the user has opted into local-store
+    # reads, decorate gateway/JSONL session rows with channel context from the
+    # typed openclaw_channels table. Lets a partially-migrated install (sessions
+    # still from gateway, channels already in DuckDB) get typed channel/chat_type/
+    # subject without waiting for the full session-table cutover.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        _decorate_with_channel_context(sessions)
     for s in sessions:
         if "session_type" not in s:
             s["session_type"] = _infer_session_type(s)
@@ -132,6 +226,9 @@ def _try_local_store_sessions():
             "session_type":   meta.get("session_type", "main"),
             "_source":        "local_store",
         })
+    # Decorate with channel context from the typed openclaw_channels table.
+    # No-op when the table is empty; overrides only blank fields when present.
+    _decorate_with_channel_context(out)
     return {"sessions": out, "_source": "local_store"}
 
 
@@ -213,6 +310,7 @@ def _try_local_store_sessions_by_type(type_filter: str = ""):
         return None
 
     sessions = []
+    explicit_types: dict[str, str] = {}
     for r in rows:
         meta = {}
         if r[11]:
@@ -240,10 +338,17 @@ def _try_local_store_sessions_by_type(type_filter: str = ""):
             "kind":           meta.get("kind", ""),
             "_source":        "local_store",
         }
+        if meta.get("session_type"):
+            explicit_types[s["session_id"]] = meta["session_type"]
+        sessions.append(s)
+    # Decorate channel context BEFORE _infer_session_type so a session with
+    # channel=telegram (typed table) classifies as "user" even if the metadata
+    # blob never carried a channel field.
+    _decorate_with_channel_context(sessions)
+    for s in sessions:
         # Honour explicit metadata.session_type when present; otherwise
         # classify with the same _infer_session_type() the legacy path uses.
-        s["session_type"] = meta.get("session_type") or _infer_session_type(s)
-        sessions.append(s)
+        s["session_type"] = explicit_types.get(s["session_id"]) or _infer_session_type(s)
 
     counts = {"main": 0, "heartbeat": 0, "user": 0, "sub-agent": 0}
     for s in sessions:

--- a/tests/test_channels_local_store.py
+++ b/tests/test_channels_local_store.py
@@ -1,0 +1,190 @@
+"""Tests for /api/sessions channel-context decoration from local DuckDB.
+
+The local DuckDB has a typed ``openclaw_channels`` table that maps
+``session_id → {channel, chat_type, subject, origin_label}``. When the
+``CLAWMETRY_LOCAL_STORE_READ=1`` env gate is on, ``/api/sessions`` reads
+those rows and decorates the session list with channel attribution
+(replacing the legacy free-form ``metadata`` blob inference).
+
+What's covered here:
+  - happy path: seed channel rows + sessions, hit /api/sessions, assert
+    each returned session carries the typed channel/chat_type/subject.
+  - negative path: env unset → no decoration, even with channel rows
+    present in the store.
+  - by-type variant: a Telegram-channelled session classifies as "user"
+    in /api/sessions/by-type once the typed channel context is merged.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed_session(store, sid: str, **kwargs) -> None:
+    """Default-everything-empty session row so the decoration test reflects
+    what /api/sessions would see in the wild before channel attribution."""
+    base = {
+        "session_id": sid,
+        "agent_type": "openclaw",
+        "title": kwargs.get("title", ""),
+        "started_at": "2026-05-12T10:00:00Z",
+        "last_active_at": "2026-05-12T10:30:00Z",
+        "status": "active",
+        "total_tokens": 0,
+        "cost_usd": 0.0,
+        "message_count": 0,
+        # Crucially: NO channel / chat_type in metadata. We want to prove the
+        # decoration helper is what filled those fields, not the legacy blob.
+        "metadata": {},
+    }
+    base.update(kwargs)
+    store.ingest_session(base)
+
+
+def test_api_sessions_decorates_with_channel_context(app):
+    """Seed sessions + channel rows, hit /api/sessions, assert each returned
+    session carries the typed channel/chat_type/subject."""
+    a, ls = app
+    store = ls.get_store()
+    _seed_session(store, "sess-tg", title="Telegram convo")
+    _seed_session(store, "sess-slack", title="Slack thread")
+    _seed_session(store, "sess-plain", title="No channel")  # control
+    store.ingest_channel({
+        "session_id": "sess-tg",
+        "channel": "telegram",
+        "chat_type": "private",
+        "subject": "@alice",
+        "origin_label": "Telegram DM with alice",
+    })
+    store.ingest_channel({
+        "session_id": "sess-slack",
+        "channel": "slack",
+        "chat_type": "channel",
+        "subject": "#deploys",
+        "origin_label": "Slack #deploys",
+    })
+
+    r = a.test_client().get("/api/sessions")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    by_id = {s["session_id"]: s for s in body["sessions"]}
+
+    assert by_id["sess-tg"]["channel"] == "telegram"
+    assert by_id["sess-tg"]["chat_type"] == "private"
+    assert by_id["sess-tg"]["subject"] == "Telegram convo"  # title wins over channel.subject
+    assert by_id["sess-tg"]["origin_label"] == "Telegram DM with alice"
+
+    assert by_id["sess-slack"]["channel"] == "slack"
+    assert by_id["sess-slack"]["chat_type"] == "channel"
+    assert by_id["sess-slack"]["origin_label"] == "Slack #deploys"
+
+    # No channel row → fields stay blank; no error.
+    assert by_id["sess-plain"]["channel"] == ""
+    assert by_id["sess-plain"]["chat_type"] == ""
+
+
+def test_api_sessions_no_decoration_without_env_flag(tmp_path, monkeypatch):
+    """CLAWMETRY_LOCAL_STORE_READ unset → no fast path, no decoration.
+    Channel rows in the store stay invisible to /api/sessions output.
+
+    Verified by checking the response is NOT tagged ``_source: local_store``
+    (the only way to reach the decoration). Without the env flag the fast
+    path is skipped entirely, so neither the local sessions nor the
+    decorated channel context surface in the response.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    store = ls.get_store()
+    _seed_session(store, "sess-noflag", title="Should not be decorated")
+    store.ingest_channel({
+        "session_id": "sess-noflag",
+        "channel": "telegram",
+        "chat_type": "private",
+        "subject": "@bob",
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    body = a.test_client().get("/api/sessions").get_json() or {}
+    # Without the flag the fast path is bypassed; the response goes through
+    # gateway/JSONL (which may 5xx in the unit-test context with no gateway).
+    # Either way it must NOT be tagged local_store and must NOT carry the
+    # decorated channel value.
+    assert body.get("_source") != "local_store"
+    for s in body.get("sessions", []):
+        if s.get("session_id") == "sess-noflag":
+            assert s.get("channel", "") != "telegram"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_decoration_reclassifies_session_type_in_by_type(app):
+    """A session with a Telegram channel row but no ``channel`` field on the
+    session metadata should classify as ``user`` (not ``main``) in the
+    /api/sessions/by-type response, because the decoration runs BEFORE the
+    type-inference pass."""
+    a, ls = app
+    store = ls.get_store()
+    _seed_session(store, "sess-user", title="From Telegram")
+    store.ingest_channel({
+        "session_id": "sess-user",
+        "channel": "telegram",
+        "chat_type": "private",
+        "subject": "@carol",
+    })
+
+    body = a.test_client().get("/api/sessions/by-type").get_json()
+    assert body.get("_source") == "local_store"
+    by_id = {s["session_id"]: s for s in body["sessions"]}
+    assert by_id["sess-user"]["channel"] == "telegram"
+    assert by_id["sess-user"]["session_type"] == "user"
+    assert body["counts"]["user"] >= 1
+
+
+def test_decoration_is_noop_when_channels_table_empty(app):
+    """No rows in openclaw_channels → sessions come back unmodified, no
+    error. Important for fresh installs where the gateway hasn't pushed any
+    channel attribution yet."""
+    a, ls = app
+    store = ls.get_store()
+    _seed_session(store, "sess-only", title="Solo")
+    # No ingest_channel() calls.
+
+    body = a.test_client().get("/api/sessions").get_json()
+    assert body.get("_source") == "local_store"
+    by_id = {s["session_id"]: s for s in body["sessions"]}
+    assert by_id["sess-only"]["channel"] == ""
+    assert by_id["sess-only"]["chat_type"] == ""


### PR DESCRIPTION
## Summary

Wires the new `openclaw_channels` DuckDB table (added in #1045) into `/api/sessions` and `/api/sessions/by-type`. Session rows now carry typed `channel`/`chat_type`/`subject`/`origin_label` from the table when present, instead of relying solely on the legacy free-form `metadata` blob.

- New `_get_channel_context_map()` helper queries `LocalStore.query_channels()` (one full-table scan when more than 20 ids, else N targeted lookups).
- New `_decorate_with_channel_context()` performs a one-way merge — fills only blank fields, so existing metadata-blob channel inference survives untouched on rows the channels table doesn't cover.
- Wired into both fast paths under the existing `CLAWMETRY_LOCAL_STORE_READ=1` env gate, plus the legacy `/api/sessions` path so a partially-migrated install (sessions still from the gateway, channels already in DuckDB) gets typed attribution without waiting for the full session-table cutover.
- For the by-type endpoint the decoration runs **before** `_infer_session_type`, so a session with `channel=telegram` in the typed table classifies as `user` even when the metadata blob was empty.

## Out of scope (next agent)

The per-channel feed routes (`/api/channel/telegram`, `/slack`, etc. in `routes/channels.py`) still tail JSONL log files. The `openclaw_channels` table only stores the session→channel mapping, **not** the chat message bodies — migrating the feeds requires a separate ingest design and is intentionally deferred.

## Test plan

- [x] `tests/test_channels_local_store.py` — 4 new tests, all pass:
  - decoration happy path: seed channel rows + sessions, assert typed fields land on `/api/sessions` response.
  - negative: env unset → no decoration (`_source != local_store`, `channel` stays blank).
  - by-type: Telegram channel row → session classifies as `user` with `counts.user >= 1`.
  - empty channels table → no-op, no error.
- [x] `tests/test_sessions_local_fastpath.py` (3) + `test_sessions_by_type_local_store.py` (8) + `test_local_store.py` (25) + `test_local_store_missing_writers.py` (16) — 51 related tests pass, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)