### PR TITLE
feat(crons): read crons API from local DuckDB

### DIFF
--- a/routes/crons.py
+++ b/routes/crons.py
@@ -35,8 +35,333 @@ from flask import Blueprint, jsonify, request
 bp_crons = Blueprint('crons', __name__)
 
 
+# ── Local DuckDB fast path (epic #964 phase 4 — Crons tab) ──────────────────
+#
+# Opt-in via CLAWMETRY_LOCAL_STORE_READ=1. Mirrors the same pattern used by
+# routes/sessions.py and routes/heartbeat.py: a dedicated helper attempts a
+# DuckDB read and returns ``None`` on any error / empty table so the legacy
+# gateway/JSONL path runs untouched. Fast paths NEVER replace the legacy
+# code — they sit *in front of it*, so a fresh install with no local store
+# (or a non-OpenClaw user) sees the same data as before.
+#
+# The local ``crons`` table is populated by sync.py via LocalStore.ingest_cron
+# (Engineer B's missing-writers PR #1045). Schema:
+#
+#   crons (
+#     agent_type, cron_id, agent_id, name, schedule, enabled,
+#     last_run_at, last_status, next_run_at, data BLOB, updated_at
+#   )
+#
+# We deliberately keep the fast-path response shape identical to the
+# gateway-backed contract — only adding a ``_source: "local_store"`` tag so
+# tests can assert which path served the response.
+
+
+def _parse_iso_to_ms(ts):
+    """Best-effort ISO-8601 → epoch-ms. Returns 0 on any failure."""
+    if not ts:
+        return 0
+    if isinstance(ts, (int, float)):
+        return int(ts)
+    if isinstance(ts, str):
+        try:
+            from datetime import datetime as _dt
+            return int(_dt.fromisoformat(ts.replace("Z", "+00:00")).timestamp() * 1000)
+        except Exception:
+            try:
+                from dateutil import parser as _dtp
+                return int(_dtp.parse(ts).timestamp() * 1000)
+            except Exception:
+                return 0
+    return 0
+
+
+def _row_to_cron_job(row):
+    """Convert a DuckDB ``crons`` row (as returned by ``query_crons``) into
+    the gateway-shaped job dict that the dashboard JS / cost-attribution
+    code expects:
+
+        {id, name, schedule, enabled, createdAtMs,
+         state: {lastRunAtMs, lastStatus, nextRunAtMs, ...}}
+
+    Extras stashed in the freeform ``data`` blob (createdAtMs, runHistory,
+    consecutiveFailures, lastDurationMs, lastError, sched-extras, ...) are
+    spliced through. ``schedule`` may be a JSON-encoded string in the
+    column — try to decode so the JS gets a dict.
+    """
+    state_extras = {}
+    extras = row.get("data") if isinstance(row.get("data"), dict) else {}
+    # Pull state-shaped fields out of the data blob if present.
+    for k in (
+        "lastDurationMs", "consecutiveFailures", "lastError",
+        "runHistory", "lastCostUsd",
+    ):
+        if k in extras:
+            state_extras[k] = extras[k]
+
+    schedule = row.get("schedule")
+    if isinstance(schedule, str):
+        # gateway returns schedule as a dict; if our store has a JSON string
+        # (or a cron expression) try to decode → dict, else keep as-is.
+        try:
+            decoded = json.loads(schedule)
+            if isinstance(decoded, dict):
+                schedule = decoded
+        except Exception:
+            pass
+    if schedule is None and isinstance(extras.get("schedule"), (dict, str)):
+        schedule = extras["schedule"]
+
+    job = {
+        "id": row.get("cron_id", ""),
+        "name": row.get("name") or row.get("cron_id", ""),
+        "schedule": schedule or {},
+        "enabled": bool(row.get("enabled", True)),
+        "createdAtMs": int(extras.get("createdAtMs") or 0),
+        "state": {
+            "lastRunAtMs": _parse_iso_to_ms(row.get("last_run_at")),
+            "lastStatus": row.get("last_status") or "pending",
+            "nextRunAtMs": _parse_iso_to_ms(row.get("next_run_at")),
+            **state_extras,
+        },
+    }
+    # Carry through any extra top-level fields (prompt, channel, model, ...)
+    for k, v in extras.items():
+        if k not in {"createdAtMs", "schedule", "lastDurationMs",
+                     "consecutiveFailures", "lastError", "runHistory",
+                     "lastCostUsd"}:
+            job.setdefault(k, v)
+    return job
+
+
+def _try_local_store_crons():
+    """Return jobs list shaped like ``/api/crons`` from the local DuckDB.
+
+    Returns ``None`` to defer to the legacy gateway/file fallback if:
+      - the ``local_store`` module isn't importable
+      - the ``crons`` table is empty (fresh install / non-OpenClaw user)
+      - any unexpected error happens (we'd rather degrade than 500)
+
+    Cost attribution (``cost_usd`` / ``cost_session_count`` /
+    ``cost_session_ids``) is intentionally returned as zeros from this path
+    — wiring it up requires the transcript analytics pipeline that lives in
+    ``dashboard.py`` and would defeat the whole point of the fast path. The
+    dashboard JS treats missing/zero costs as "not yet attributed" and
+    renders fine.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = store.query_crons(limit=500)
+    except Exception:
+        return None
+    if not rows:
+        return None
+    jobs = []
+    for r in rows:
+        try:
+            j = _row_to_cron_job(r)
+        except Exception:
+            continue
+        # Match the contract from /api/crons cost-enrichment.
+        j.setdefault("cost_usd", 0.0)
+        j.setdefault("cost_session_count", 0)
+        j.setdefault("cost_session_ids", [])
+        jobs.append(j)
+    return {"jobs": jobs, "_source": "local_store"}
+
+
+def _try_local_store_cron_runs(job_id):
+    """Return run history for a single cron job from the local DuckDB.
+
+    Reads the ``events`` table filtered by ``event_type='cron_run'`` and
+    matches rows whose ``agent_id`` or ``data.cron_id`` / ``data.jobId``
+    equals ``job_id``. Each row is shaped into the run-record contract
+    documented by ``_enrich_cron_runs``:
+
+        {sessionId, timestamp, status, durationMs, costUsd, tokens}
+
+    Returns ``None`` to defer to the legacy gateway/transcript fallback.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        evs = store.query_events(event_type="cron_run", limit=500)
+    except Exception:
+        return None
+    if not evs:
+        return None
+    runs = []
+    for ev in evs:
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        # Match by agent_id (gateway emits cron_run with agent_id=cron_id) OR
+        # by cron_id/jobId in the data blob (sync.py / future emitters).
+        if (ev.get("agent_id") != job_id
+                and data.get("cron_id") != job_id
+                and data.get("jobId") != job_id):
+            continue
+        runs.append({
+            "sessionId": ev.get("session_id", "") or data.get("sessionId", ""),
+            "timestamp": _parse_iso_to_ms(ev.get("ts")),
+            "status": data.get("status", "ok"),
+            "durationMs": int(data.get("durationMs") or 0),
+            "costUsd": round(float(ev.get("cost_usd") or data.get("costUsd") or 0.0), 6),
+            "tokens": int(ev.get("token_count") or data.get("tokens") or 0),
+        })
+    if not runs:
+        return None
+    runs.sort(key=lambda r: r.get("timestamp", 0), reverse=True)
+    return runs[:50]
+
+
+def _try_local_store_cron_health_summary():
+    """Return ``/api/cron/health-summary`` payload from the local DuckDB.
+
+    Mirrors :func:`api_cron_health_summary`'s logic but sources jobs from
+    ``query_crons()`` instead of the gateway. Cost-spike / duration-spike
+    anomaly detection requires ``runHistory`` (carried in the ``data``
+    blob if the writer included it) — when absent we report no anomalies
+    but every other field stays meaningful.
+
+    Returns ``None`` on empty/missing store.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = store.query_crons(limit=500)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    now_ms = int(datetime.now().timestamp() * 1000)
+    summary = []
+    total_ok = total_err = total_silent = 0
+
+    for r in rows:
+        try:
+            job = _row_to_cron_job(r)
+        except Exception:
+            continue
+        job_id = job.get("id", "")
+        job_name = job.get("name", job_id)
+        state = job.get("state") or {}
+        enabled = bool(job.get("enabled", True))
+
+        last_run_ms = state.get("lastRunAtMs") or 0
+        last_status = state.get("lastStatus", "pending")
+        last_duration_ms = state.get("lastDurationMs") or 0
+        consecutive_failures = state.get("consecutiveFailures") or 0
+        last_error = state.get("lastError", "") or ""
+        next_run_ms = state.get("nextRunAtMs") or 0
+
+        is_silent = False
+        expected_interval_ms = None
+        sched = job.get("schedule") or {}
+        if isinstance(sched, dict):
+            every_ms = sched.get("everyMs")
+            if every_ms:
+                try:
+                    expected_interval_ms = int(every_ms)
+                    if (enabled and last_run_ms
+                            and (now_ms - last_run_ms) > expected_interval_ms * 2.5):
+                        is_silent = True
+                except (TypeError, ValueError):
+                    pass
+
+        # Cost attribution + anomaly stats are intentionally zero on the
+        # fast path — see _try_local_store_crons docstring.
+        cost_usd = 0.0
+        cost_session_count = 0
+        cost_spike = False
+        duration_spike = False
+        avg_cost = None
+
+        run_history = state.get("runHistory") or []
+        if run_history and len(run_history) > 2:
+            historical_costs = [
+                rh.get("costUsd", 0) for rh in run_history[1:] if rh.get("costUsd")
+            ]
+            if historical_costs:
+                avg_cost = sum(historical_costs) / len(historical_costs)
+                last_cost = run_history[0].get("costUsd", 0)
+                if avg_cost > 0 and last_cost > avg_cost * 2.5:
+                    cost_spike = True
+            historical_durations = [
+                rh.get("durationMs", 0) for rh in run_history[1:] if rh.get("durationMs")
+            ]
+            if historical_durations and last_duration_ms:
+                avg_dur = sum(historical_durations) / len(historical_durations)
+                if avg_dur > 0 and last_duration_ms > avg_dur * 3:
+                    duration_spike = True
+
+        if not enabled:
+            health = "disabled"
+        elif is_silent:
+            health = "silent"
+            total_silent += 1
+        elif consecutive_failures >= 3 or last_status == "error":
+            health = "error"
+            total_err += 1
+        elif cost_spike or duration_spike:
+            health = "warning"
+        else:
+            health = "ok"
+            total_ok += 1
+
+        summary.append({
+            "id": job_id,
+            "name": job_name,
+            "enabled": enabled,
+            "health": health,
+            "lastStatus": last_status,
+            "lastRunAtMs": last_run_ms,
+            "lastDurationMs": last_duration_ms,
+            "nextRunAtMs": next_run_ms,
+            "consecutiveFailures": consecutive_failures,
+            "lastError": last_error,
+            "costUsd": round(float(cost_usd), 6),
+            "costSessionCount": cost_session_count,
+            "monthlyProjectedCost": 0.0,
+            "avgCost": round(avg_cost, 6) if avg_cost else None,
+            "isSilent": is_silent,
+            "costSpike": cost_spike,
+            "durationSpike": duration_spike,
+            "expectedIntervalMs": expected_interval_ms,
+        })
+
+    total_jobs = len(summary)
+    has_anomalies = any(j["costSpike"] or j["durationSpike"] for j in summary)
+    has_errors = total_err > 0
+    has_silent = total_silent > 0
+    return {
+        "jobs": summary,
+        "totals": {
+            "total": total_jobs,
+            "ok": total_ok,
+            "error": total_err,
+            "silent": total_silent,
+            "disabled": sum(1 for j in summary if j["health"] == "disabled"),
+            "warning": sum(1 for j in summary if j["health"] == "warning"),
+        },
+        "hasAnomalies": has_anomalies,
+        "hasErrors": has_errors,
+        "hasSilent": has_silent,
+        "_source": "local_store",
+    }
+
+
 @bp_crons.route("/api/crons")
 def api_crons():
+    # Epic #964 phase 4: opt-in local-store fast path. When
+    # CLAWMETRY_LOCAL_STORE_READ=1 AND the local crons table has rows,
+    # serve directly from DuckDB. Falls through to gateway/file otherwise
+    # (so a fresh install with no local store sees the same data as before
+    # — zero-change default).
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_crons()
+        if fast is not None:
+            return jsonify(fast)
     import dashboard as _d
 
     def _with_costs(jobs):
@@ -220,6 +545,15 @@ def api_cron_runs(job_id):
     for cron candidate sessions attributed to this job.
     Returns enriched list with p50/p95 duration stats.
     """
+    # Epic #964 phase 4: opt-in local-store fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast_runs = _try_local_store_cron_runs(job_id)
+        if fast_runs is not None:
+            import dashboard as _d
+            payload = _d._enrich_cron_runs(job_id, fast_runs)
+            if isinstance(payload, dict):
+                payload["_source"] = "local_store"
+            return jsonify(payload)
     import dashboard as _d
     # Try gateway API first
     result = _d._gw_invoke("cron", {"action": "runs", "jobId": job_id, "limit": 50})
@@ -290,6 +624,11 @@ def api_cron_run_log():
 @bp_crons.route("/api/cron/health-summary")
 def api_cron_health_summary():
     """Aggregate cron health: per-job success rate, cost, anomaly flags, silent detection."""
+    # Epic #964 phase 4: opt-in local-store fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_cron_health_summary()
+        if fast is not None:
+            return jsonify(fast)
     import dashboard as _d
     gw_data = _d._gw_invoke("cron", {"action": "list", "includeDisabled": True}) or {}
     jobs = gw_data.get("jobs", []) or _d._get_crons()
@@ -670,10 +1009,12 @@ def api_cron_health():
             }
         )
 
-    return jsonify(
-        {
-            "crons": crons_out,
-            "totals": raw.get("totals", {}),
-            "has_anomalies": bool(raw.get("hasAnomalies", False)),
-        }
-    )
+    out = {
+        "crons": crons_out,
+        "totals": raw.get("totals", {}),
+        "has_anomalies": bool(raw.get("hasAnomalies", False)),
+    }
+    # Propagate fast-path tag so callers can assert which source served the data.
+    if raw.get("_source"):
+        out["_source"] = raw["_source"]
+    return jsonify(out)

--- a/tests/test_crons_local_store.py
+++ b/tests/test_crons_local_store.py
@@ -1,0 +1,336 @@
+"""Tests for the Crons-tab local-store fast paths (epic #964 phase 4).
+
+Mirrors the opt-in pattern used by ``test_sessions_local_fastpath.py`` and
+``test_heartbeat_local_store.py``:
+
+  CLAWMETRY_LOCAL_STORE_READ=1 + populated ``crons`` table → response is
+  served from DuckDB and tagged ``_source: local_store``. Flag unset OR
+  empty store → fast path returns None and the legacy gateway/file path
+  runs (we patch the gateway out so we can assert on the response shape
+  without standing up a real OpenClaw).
+
+Routes covered:
+  /api/crons
+  /api/cron/<job_id>/runs
+  /api/cron/health-summary
+  /api/cron-health
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+def _build_app(tmp_path, monkeypatch, *, enable_fast_path: bool):
+    """Build an isolated Flask app with bp_crons + a tmp DuckDB.
+
+    Reload order matters: ``local_store`` first (so its module-level path
+    constants pick up the env var), then ``routes.crons`` so its lazy
+    imports resolve against the freshly-loaded store.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    if enable_fast_path:
+        monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    else:
+        monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.crons as cr
+    importlib.reload(cr)
+
+    app = Flask(__name__)
+    # cron-health calls api_cron_health_summary() under
+    # _d.app.test_request_context() — it doesn't need OUR app to be the one,
+    # just Flask's app context. Register the blueprint and we're set.
+    app.register_blueprint(cr.bp_crons)
+    return app, ls, cr
+
+
+@pytest.fixture
+def fast_path_app(tmp_path, monkeypatch):
+    app, ls, cr = _build_app(tmp_path, monkeypatch, enable_fast_path=True)
+    yield app, ls, cr
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def no_flag_app(tmp_path, monkeypatch):
+    """Same shape as fast_path_app but with CLAWMETRY_LOCAL_STORE_READ unset.
+    Used by the negative test that asserts the env gate is honoured."""
+    app, ls, cr = _build_app(tmp_path, monkeypatch, enable_fast_path=False)
+    yield app, ls, cr
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed_two_crons(store):
+    """Insert two cron jobs typical of an OpenClaw install. Timestamps are
+    pinned to ~now so the silent-job detector (>2.5x interval) doesn't fire
+    and shadow the per-status health classification we want to assert on."""
+    import time
+    from datetime import datetime, timezone, timedelta
+    now = datetime.now(timezone.utc)
+    recent_iso = (now - timedelta(seconds=30)).isoformat()
+    next_iso = (now + timedelta(minutes=5)).isoformat()
+    store.ingest_cron({
+        "cron_id": "daily-backup",
+        "name": "Daily Backup",
+        "schedule": '{"kind":"cron","expr":"0 3 * * *"}',
+        "enabled": True,
+        "last_run_at": recent_iso,
+        "last_status": "success",
+        "next_run_at": next_iso,
+        "createdAtMs": int(time.time() * 1000) - 86400000,
+        "lastDurationMs": 4500,
+        "consecutiveFailures": 0,
+    })
+    store.ingest_cron({
+        "cron_id": "metrics-poll",
+        "name": "Metrics Poll",
+        # Long enough interval that the recent_iso last_run_at stays inside
+        # the 2.5x silent-job window.
+        "schedule": '{"kind":"every","everyMs":3600000}',
+        "enabled": True,
+        "last_run_at": recent_iso,
+        "last_status": "error",
+        "next_run_at": next_iso,
+        "createdAtMs": int(time.time() * 1000) - 86400000,
+        "lastDurationMs": 1200,
+        "consecutiveFailures": 4,
+        "lastError": "connection refused",
+    })
+
+
+def _seed_runs_for(store, cron_id, n=5, status="ok"):
+    """Insert n cron_run events for cron_id via the events table."""
+    import time
+    for i in range(n):
+        store.ingest({
+            "id":          f"run-{cron_id}-{i}",
+            "node_id":     "agent+test",
+            "agent_id":    cron_id,
+            "session_id":  f"sess-{cron_id}-{i}",
+            "event_type":  "cron_run",
+            "ts":          f"2026-05-1{i+1}T07:00:00Z",
+            "data":        {"cron_id": cron_id, "status": status, "durationMs": 1000 + i * 100},
+            "cost_usd":    0.012,
+            "token_count": 200 + i,
+        })
+    # Block until ring buffer drains.
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+# ── /api/crons ─────────────────────────────────────────────────────────────
+
+
+def test_crons_fast_path_returns_local_store_data(fast_path_app):
+    """Populated crons table → fast path serves from DuckDB and the response
+    keeps the documented {jobs: [...]} contract."""
+    app, ls, _cr = fast_path_app
+    _seed_two_crons(ls.get_store())
+
+    body = app.test_client().get("/api/crons").get_json()
+    assert body.get("_source") == "local_store"
+    assert "jobs" in body
+    jobs = body["jobs"]
+    assert len(jobs) == 2
+
+    by_id = {j["id"]: j for j in jobs}
+    assert "daily-backup" in by_id
+    assert "metrics-poll" in by_id
+
+    daily = by_id["daily-backup"]
+    # Keys the dashboard JS reads.
+    for k in ("id", "name", "schedule", "enabled", "state",
+              "cost_usd", "cost_session_count", "cost_session_ids"):
+        assert k in daily, f"job missing key {k}: {daily}"
+    assert daily["enabled"] is True
+    assert isinstance(daily["state"], dict)
+    # JSON-encoded schedule string in the column should decode to a dict.
+    assert isinstance(daily["schedule"], dict)
+    assert daily["schedule"].get("kind") == "cron"
+    # ISO timestamps must be reshaped into ms ints for the JS layer.
+    assert isinstance(daily["state"]["lastRunAtMs"], int)
+    assert daily["state"]["lastRunAtMs"] > 0
+    assert isinstance(daily["state"]["nextRunAtMs"], int)
+    assert daily["state"]["nextRunAtMs"] > 0
+    # State extras stashed in the data blob round-trip.
+    assert daily["state"]["lastStatus"] == "success"
+    assert daily["state"]["lastDurationMs"] == 4500
+
+
+def test_crons_fast_path_falls_through_when_store_empty(fast_path_app):
+    """Empty crons table → fast path returns None and the legacy path runs.
+    With no gateway in this test env the legacy path returns {jobs: []}."""
+    app, _ls, _cr = fast_path_app
+    body = app.test_client().get("/api/crons").get_json()
+    # Fell through → no _source tag.
+    assert body.get("_source") != "local_store"
+    assert "jobs" in body
+
+
+def test_crons_fast_path_disabled_without_env_flag(no_flag_app):
+    """Negative test: CLAWMETRY_LOCAL_STORE_READ unset → DuckDB is never
+    queried even with a populated store. The handler defers to the legacy
+    gateway/file path."""
+    app, ls, _cr = no_flag_app
+    _seed_two_crons(ls.get_store())
+
+    body = app.test_client().get("/api/crons").get_json()
+    assert body.get("_source") != "local_store"
+    assert "jobs" in body
+
+
+# ── /api/cron/<job_id>/runs ────────────────────────────────────────────────
+
+
+def test_cron_runs_fast_path_returns_runs(fast_path_app):
+    """Populated events table with cron_run rows → fast path returns the
+    enriched runs payload tagged with ``_source``."""
+    app, ls, _cr = fast_path_app
+    _seed_runs_for(ls.get_store(), "daily-backup", n=5)
+
+    body = app.test_client().get("/api/cron/daily-backup/runs").get_json()
+    assert body.get("_source") == "local_store"
+    assert body.get("jobId") == "daily-backup"
+    assert isinstance(body.get("runs"), list)
+    assert len(body["runs"]) == 5
+
+    # Most-recent first.
+    timestamps = [r["timestamp"] for r in body["runs"]]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+    # Every run must carry the contract keys.
+    for r in body["runs"]:
+        for k in ("sessionId", "timestamp", "status", "durationMs", "costUsd", "tokens"):
+            assert k in r, f"run missing key {k}: {r}"
+
+    # Stats block from _enrich_cron_runs.
+    stats = body.get("stats", {})
+    assert stats.get("totalRuns") == 5
+    assert stats.get("successCount") == 5  # default status='ok' from seed
+
+
+def test_cron_runs_fast_path_filters_by_job_id(fast_path_app):
+    """Events for OTHER cron jobs must not leak into a single-job runs query."""
+    app, ls, _cr = fast_path_app
+    _seed_runs_for(ls.get_store(), "daily-backup", n=3)
+    _seed_runs_for(ls.get_store(), "metrics-poll", n=2)
+
+    body = app.test_client().get("/api/cron/daily-backup/runs").get_json()
+    assert body.get("_source") == "local_store"
+    assert len(body["runs"]) == 3
+    # All session ids should reference the daily-backup job.
+    assert all("daily-backup" in r["sessionId"] for r in body["runs"])
+
+
+def test_cron_runs_fast_path_falls_through_when_no_events(fast_path_app):
+    """No matching events → fast path returns None → legacy path runs."""
+    app, _ls, _cr = fast_path_app
+    body = app.test_client().get("/api/cron/daily-backup/runs").get_json()
+    # Legacy path enriches an empty list — payload must NOT carry _source tag.
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/cron/health-summary ───────────────────────────────────────────────
+
+
+def test_health_summary_fast_path_returns_summary(fast_path_app):
+    """Populated crons table → health-summary fast path runs and the response
+    matches the documented contract."""
+    app, ls, _cr = fast_path_app
+    _seed_two_crons(ls.get_store())
+
+    body = app.test_client().get("/api/cron/health-summary").get_json()
+    assert body.get("_source") == "local_store"
+    for k in ("jobs", "totals", "hasAnomalies", "hasErrors", "hasSilent"):
+        assert k in body, f"health-summary missing key {k}"
+
+    jobs = body["jobs"]
+    assert len(jobs) == 2
+    by_id = {j["id"]: j for j in jobs}
+
+    # daily-backup: enabled, success, no consecutive failures → ok
+    daily = by_id["daily-backup"]
+    assert daily["enabled"] is True
+    assert daily["health"] == "ok"
+    assert daily["lastStatus"] == "success"
+    assert daily["lastDurationMs"] == 4500
+
+    # metrics-poll: enabled, error, 4 consecutive failures → error
+    metrics = by_id["metrics-poll"]
+    assert metrics["enabled"] is True
+    assert metrics["health"] == "error"
+    assert metrics["consecutiveFailures"] == 4
+    assert metrics["lastError"] == "connection refused"
+
+    totals = body["totals"]
+    assert totals["total"] == 2
+    assert totals["error"] >= 1
+    assert body["hasErrors"] is True
+
+
+def test_health_summary_fast_path_falls_through_when_empty(fast_path_app):
+    """Empty crons table → fast path defers to the legacy gateway path
+    (which itself has no gateway in test env, so returns an empty summary)."""
+    app, _ls, _cr = fast_path_app
+    body = app.test_client().get("/api/cron/health-summary").get_json()
+    assert body.get("_source") != "local_store"
+    assert "jobs" in body
+
+
+def test_health_summary_disabled_without_env_flag(no_flag_app):
+    """Env gate honoured: populated store + flag unset → legacy path."""
+    app, ls, _cr = no_flag_app
+    _seed_two_crons(ls.get_store())
+    body = app.test_client().get("/api/cron/health-summary").get_json()
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/cron-health (alias on top of health-summary) ──────────────────────
+
+
+def test_cron_health_alias_inherits_fast_path(fast_path_app):
+    """Since /api/cron-health delegates to /api/cron/health-summary, the
+    fast-path tag should propagate up to the alias's response."""
+    app, ls, _cr = fast_path_app
+    _seed_two_crons(ls.get_store())
+
+    body = app.test_client().get("/api/cron-health").get_json()
+    assert body.get("_source") == "local_store"
+    # Documented alias shape.
+    for k in ("crons", "totals", "has_anomalies"):
+        assert k in body, f"cron-health missing key {k}"
+    crons = body["crons"]
+    assert len(crons) == 2
+    for c in crons:
+        for k in ("id", "name", "enabled", "health", "stats", "recent_runs", "last_error"):
+            assert k in c, f"cron-health row missing key {k}: {c}"
+        for sk in ("success_rate", "total_runs", "avg_duration_ms", "total_cost_usd"):
+            assert sk in c["stats"]
+
+
+def test_cron_health_disabled_without_env_flag(no_flag_app):
+    """Env gate also honoured by the alias: no flag → no fast path."""
+    app, ls, _cr = no_flag_app
+    _seed_two_crons(ls.get_store())
+    body = app.test_client().get("/api/cron-health").get_json()
+    assert body.get("_source") != "local_store"


### PR DESCRIPTION
## Summary

Migrates the Crons tab APIs to read from the local DuckDB store ahead of the gateway/file fallback (epic #964 phase 4). Opt-in via `CLAWMETRY_LOCAL_STORE_READ=1` — same env-gated pattern proven on `/api/sessions`, `/api/sessions/by-type`, `/api/heartbeat`, and `/api/brain-history`.

Builds on Engineer B's missing-writers PR (#1045): uses `LocalStore.ingest_cron()` + `query_crons()` (writes happen in `sync.py`; this PR is read-side only).

## Changes

- `routes/crons.py`: 3 new helpers
  - `_try_local_store_crons` -> `/api/crons` jobs list
  - `_try_local_store_cron_runs` -> `/api/cron/<id>/runs` (events table filtered by `event_type='cron_run'`)
  - `_try_local_store_cron_health_summary` -> `/api/cron/health-summary`
- `/api/cron-health` inherits the fast path automatically (it delegates to `api_cron_health_summary`) and now propagates the `_source: local_store` tag.
- Each helper returns `None` on empty/missing store so the existing legacy code runs untouched. Schema mapping reshapes ISO-8601 timestamps and JSON-encoded schedule strings into the gateway contract (epoch-ms ints, dict schedules, `state{}` sub-object).
- Cost-attribution fields are intentionally returned as zeros from the fast path (the heavyweight transcript analytics pipeline lives in `dashboard.py` and would defeat the point of the fast path). Dashboard JS renders fine with missing/zero costs.

## Test plan

- [x] `tests/test_crons_local_store.py` (11 new) covers all four migrated routes.
  - Positive: populated store -> response served from DuckDB, tagged `_source: local_store`, contract-shaped.
  - Negative: env unset -> falls back to legacy path even when store is populated.
  - Empty store -> falls back to legacy path.
- [x] `python3 -m pytest tests/test_crons_local_store.py tests/test_local_store_missing_writers.py -q` -> **26/26 green** locally.
- [x] `tests/test_cron_health.py` (existing) still passes (40 passed, 3 skipped).

## Constraints respected

- Did not modify existing handler logic — only added the fast path on top.
- Did not remove the legacy fallback.
- Did not touch other engineers' files (only `routes/crons.py` + new test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)