### PR TITLE
feat(overview): read /api/overview + /api/timeline + /api/heartbeat-status from DuckDB

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -751,10 +751,77 @@ def api_service_status():
     )
 
 
+def _try_local_store_heartbeat_status(node_id=None):
+    """Epic #964: opt-in local-store fast path for /api/heartbeat-status.
+
+    Returns the same response shape as ``_get_heartbeat_status()`` derived from
+    the most-recent row in the DuckDB ``heartbeats`` table (optionally scoped
+    to ``node_id``). Returns ``None`` to defer to the in-memory globals if:
+
+      - the local_store module isn't importable
+      - the heartbeats table is empty (fresh install / non-OpenClaw user)
+      - any unexpected error happens (we'd rather degrade than 500)
+
+    The fast path is most useful on multi-node fleets where the dashboard
+    process didn't witness the heartbeat itself (the sync daemon on each node
+    persists its own heartbeat row, but ``_last_heartbeat_ts`` lives in
+    dashboard memory and only sees what the local websocket emitted).
+    """
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return None
+    try:
+        store = local_store.get_store()
+        rows = store.query_heartbeats(limit=1, node_id=node_id) if node_id else store.query_heartbeats(limit=1)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    import dashboard as _d
+    interval = int(_d._heartbeat_interval_sec)
+    threshold = interval * 1.5
+    now = time.time()
+
+    last_ts_str = rows[0].get("ts") or ""
+    try:
+        last_ts = datetime.fromisoformat(last_ts_str.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+    if last_ts <= 0:
+        return None
+
+    gap_sec = now - last_ts
+    if gap_sec <= interval:
+        status = "ok"
+    elif gap_sec <= threshold:
+        status = "warning"
+    else:
+        status = "silent"
+
+    return {
+        "status": status,
+        "last_heartbeat_ts": last_ts,
+        "gap_seconds": int(gap_sec),
+        "interval_seconds": interval,
+        "threshold_seconds": int(threshold),
+        "silent_since": None,
+        "_source": "local_store",
+    }
+
+
 @bp_health.route("/api/heartbeat-status")
 def api_heartbeat_status():
     """Return heartbeat gap alerting status."""
     import dashboard as _d
+    # Epic #964: opt-in local-store fast path. Optional ?node=<node_id> scopes
+    # the lookup to one fleet node (otherwise: most-recent across all nodes).
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        node = (request.args.get("node") or "").strip() or None
+        fast = _try_local_store_heartbeat_status(node)
+        if fast is not None:
+            return jsonify(fast)
     return jsonify(_d._get_heartbeat_status())
 
 

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -202,9 +202,219 @@ def api_channels():
     return jsonify({"channels": configured})
 
 
+def _try_local_store_overview():
+    """Epic #964: opt-in local-store fast path for /api/overview.
+
+    Builds the same response shape as the legacy gateway-backed handler from
+    DuckDB: session counts (from query_sessions), most-recently-active session
+    metadata (model, tokens, updatedAt) — all derivable from
+    ``query_sessions`` + ``query_aggregates`` + ``query_events``.
+
+    System-info and infra blocks still come from local subprocesses; the fast
+    path only replaces the gateway-dependent fields (model, sessionCount,
+    activeSessions, mainSessionUpdated, mainTokens). Cron + memory counts
+    intentionally stay on their existing helpers (they hit the filesystem
+    directly and are already <5ms).
+
+    Returns ``None`` to defer to the legacy handler if:
+      - the local_store module isn't importable
+      - the sessions table is empty (fresh install / non-OpenClaw user)
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    import subprocess as _sub
+    import sys as _sys
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+    except Exception:
+        return None
+    try:
+        sess_rows = store._fetch("""
+            SELECT session_id, agent_id, title, started_at, last_active_at,
+                   ended_at, status, total_tokens, cost_usd, message_count,
+                   metadata
+            FROM sessions
+            ORDER BY COALESCE(last_active_at, started_at) DESC NULLS LAST
+            LIMIT 200
+        """, [])
+    except Exception:
+        return None
+    if not sess_rows:
+        return None
+
+    # Build a normalized view of sessions.
+    sessions = []
+    for r in sess_rows:
+        meta = {}
+        if r[10]:
+            try:
+                meta = json.loads(bytes(r[10]).decode("utf-8"))
+            except Exception:
+                pass
+        sessions.append({
+            "session_id": r[0],
+            "agent_id": r[1],
+            "title": r[2] or "",
+            "started_at": r[3] or "",
+            "last_active_at": r[4] or "",
+            "ended_at": r[5] or "",
+            "status": (r[6] or "").lower(),
+            "total_tokens": int(r[7] or 0),
+            "cost_usd": float(r[8] or 0.0),
+            "message_count": int(r[9] or 0),
+            "model": meta.get("model"),
+        })
+
+    # Pick the most recent non-subagent session as the "main" session.
+    def _is_subagent(s):
+        sid = (s.get("session_id") or "").lower()
+        return "subagent" in sid or "sub-agent" in sid
+    main = next((s for s in sessions if not _is_subagent(s)), sessions[0])
+
+    # Active = status=='active' (DuckDB persists status as a free-form string;
+    # 'active' is what sync.py writes for in-progress sessions).
+    active_count = sum(1 for s in sessions if s["status"] == "active")
+
+    # Model: prefer metadata.model on the main session; fall back to the most
+    # recently observed model across events.
+    model_name = main.get("model") or "unknown"
+    if model_name == "unknown":
+        try:
+            evs = store.query_events(limit=20)
+            for e in evs:
+                m = e.get("model")
+                if m:
+                    model_name = m
+                    break
+        except Exception:
+            pass
+
+    # Pull the latest cron + memory totals using the existing dashboard
+    # helpers. They're already filesystem-backed and fast — and they read
+    # from canonical sources (the gateway / .openclaw memory dir) that the
+    # local store doesn't replicate. We still want the fast path to be 100%
+    # local-only, so we wrap them in try/except so a missing FS doesn't break
+    # the response.
+    import dashboard as _d
+    try:
+        crons = _d._get_crons()
+    except Exception:
+        crons = []
+    enabled = len([j for j in crons if j.get("enabled")])
+    disabled = len(crons) - enabled
+    try:
+        mem_files = _d._get_memory_files()
+    except Exception:
+        mem_files = []
+    total_size = sum(f.get("size", 0) for f in mem_files)
+
+    # System info — copied verbatim from the legacy handler so the response
+    # shape matches byte-for-byte. Each subprocess has a 2s timeout so a slow
+    # df/free/uptime can't hang the request thread.
+    system = []
+    try:
+        disk = (
+            _sub.run(["df", "-h", "/"], capture_output=True, text=True, timeout=2)
+            .stdout.strip().split("\n")[-1].split()
+        )
+        disk_pct = int(disk[4].replace("%", "")) if len(disk) > 4 else 0
+        disk_color = "green" if disk_pct < 80 else ("yellow" if disk_pct < 90 else "red")
+        system.append(["Disk /", f"{disk[2]} / {disk[1]} ({disk[4]})", disk_color])
+    except Exception:
+        system.append(["Disk /", "--", ""])
+
+    try:
+        mem = (
+            _sub.run(["free", "-h"], capture_output=True, text=True, timeout=2)
+            .stdout.strip().split("\n")[1].split()
+        )
+        system.append(["RAM", f"{mem[2]} / {mem[1]}", ""])
+    except Exception:
+        system.append(["RAM", "--", ""])
+
+    try:
+        load = open("/proc/loadavg").read().split()[:3]
+        system.append(["Load", " ".join(load), ""])
+    except Exception:
+        system.append(["Load", "--", ""])
+
+    try:
+        uptime = _sub.run(
+            ["uptime", "-p"], capture_output=True, text=True, timeout=2
+        ).stdout.strip()
+        system.append(["Uptime", uptime.replace("up ", ""), ""])
+    except Exception:
+        system.append(["Uptime", "--", ""])
+
+    if _sys.platform != "win32":
+        try:
+            gw = _sub.run(
+                ["pgrep", "-f", "moltbot"], capture_output=True, text=True, timeout=2
+            )
+            gw_running = gw.returncode == 0
+        except Exception:
+            gw_running = False
+    else:
+        gw_running = False
+    system.append([
+        "Gateway",
+        "Running" if gw_running else "Stopped",
+        "green" if gw_running else "red",
+    ])
+
+    # Infra block — same shape as legacy.
+    infra = {
+        "userName": _d.USER_NAME,
+        "network": _d.get_local_ip(),
+    }
+    try:
+        import platform
+        uname = platform.uname()
+        infra["machine"] = uname.node
+        infra["runtime"] = f"Node.js - {uname.system} {uname.release.split('-')[0]}"
+    except Exception:
+        infra["machine"] = "Host"
+        infra["runtime"] = "Runtime"
+    try:
+        disk_info = (
+            _sub.run(["df", "-h", "/"], capture_output=True, text=True, timeout=2)
+            .stdout.strip().split("\n")[-1].split()
+        )
+        infra["storage"] = f"{disk_info[1]} root"
+    except Exception:
+        infra["storage"] = "Disk"
+
+    return {
+        "model": model_name,
+        "provider": _d._infer_provider_from_model(model_name),
+        "sessionCount": len(sessions),
+        "sessions": len(sessions),  # alias for E2E compatibility
+        "activeSessions": active_count,
+        "mainSessionUpdated": main.get("last_active_at") or main.get("started_at"),
+        "mainTokens": main.get("total_tokens", 0),
+        "contextWindow": 200000,
+        "cronCount": len(crons),
+        "cronEnabled": enabled,
+        "cronDisabled": disabled,
+        "memoryCount": len(mem_files),
+        "memorySize": total_size,
+        "system": system,
+        "infra": infra,
+        "_source": "local_store",
+    }
+
+
 @bp_overview.route("/api/overview")
 def api_overview():
     import dashboard as _d
+
+    # Epic #964: opt-in local-store fast path. When CLAWMETRY_LOCAL_STORE_READ=1
+    # AND the local sessions table has rows, serve directly from DuckDB. Falls
+    # through to gateway/JSONL otherwise (zero-change default).
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_overview()
+        if fast is not None:
+            return jsonify(fast)
 
     # Try gateway API for sessions
     gw_sessions = _d._gw_invoke("sessions_list", {"limit": 20, "messageLimit": 0})
@@ -475,10 +685,102 @@ def api_main_activity():
     )
 
 
+def _try_local_store_timeline():
+    """Epic #964: opt-in local-store fast path for /api/timeline.
+
+    The legacy handler walks 31 daily JSONL log files (one per day for the
+    last 30 days), parsing every line to count events and bucket by hour.
+    On busy nodes that's hundreds of MB of disk I/O on a hot path.
+
+    ``query_aggregates`` is the perfect fit: DuckDB pre-buckets events by day
+    on the columnar layout in single-digit ms even at 100k+ events. We then
+    re-derive the per-hour distribution by querying ``query_events`` once per
+    day with a tight window — only days that already showed activity in the
+    aggregates pass actually get scanned.
+
+    Returns ``None`` to defer to the JSONL fallback if:
+      - the local_store module isn't importable
+      - query_aggregates returns empty (no events seen yet)
+      - any unexpected error happens
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+    except Exception:
+        return None
+    now = datetime.now()
+    cutoff = (now - timedelta(days=30)).strftime("%Y-%m-%d") + "T00:00:00"
+    try:
+        rows = store.query_aggregates(since=cutoff)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    # Roll up per-day counts (sum across agent_ids).
+    day_counts = {}
+    for r in rows:
+        d = r.get("day")
+        if not d:
+            continue
+        day_counts[d] = day_counts.get(d, 0) + int(r.get("event_count", 0) or 0)
+
+    # Build the per-hour distribution. We pull events once for each day that
+    # had activity using the (since, until) window and bucket client-side.
+    days = []
+    import dashboard as _d
+    mem_dir = getattr(_d, "MEMORY_DIR", None)
+    for i in range(30, -1, -1):
+        d = now - timedelta(days=i)
+        ds = d.strftime("%Y-%m-%d")
+        count = day_counts.get(ds, 0)
+        hours = {}
+        if count > 0:
+            try:
+                ev_rows = store.query_events(
+                    since=ds + "T00:00:00",
+                    until=ds + "T23:59:59",
+                    limit=10000,
+                )
+                for ev in ev_rows:
+                    ts = ev.get("ts") or ""
+                    if "T" in ts:
+                        try:
+                            h = int(ts.split("T")[1][:2])
+                            hours[h] = hours.get(h, 0) + 1
+                        except Exception:
+                            pass
+            except Exception:
+                pass
+        mem_file = os.path.join(mem_dir, f"{ds}.md") if mem_dir else None
+        has_memory = bool(mem_file and os.path.exists(mem_file))
+        if count > 0 or has_memory:
+            days.append({
+                "date": ds,
+                "label": d.strftime("%a %b %d"),
+                "events": count,
+                "hasMemory": has_memory,
+                "hours": hours,
+            })
+    return {
+        "days": days,
+        "today": now.strftime("%Y-%m-%d"),
+        "_source": "local_store",
+    }
+
+
 @bp_overview.route("/api/timeline")
 def api_timeline():
     """Return available dates with activity counts for time travel."""
     import dashboard as _d
+
+    # Epic #964: opt-in local-store fast path. When CLAWMETRY_LOCAL_STORE_READ=1
+    # AND query_aggregates returns rows, serve from DuckDB. Falls through to the
+    # 30-day JSONL scan otherwise (zero-change default).
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_timeline()
+        if fast is not None:
+            return jsonify(fast)
 
     now = datetime.now()
     days = []

--- a/tests/test_overview_local_store.py
+++ b/tests/test_overview_local_store.py
@@ -1,0 +1,412 @@
+"""Tests for epic #964 — local-store fast path on the overview routes.
+
+Covers three handlers:
+  - /api/overview          (routes/overview.py)
+  - /api/timeline          (routes/overview.py)
+  - /api/heartbeat-status  (routes/health.py)
+
+The fast path is opt-in via CLAWMETRY_LOCAL_STORE_READ=1 so the legacy
+gateway/JSONL paths stay the default until ≥80% adoption (epic's gate).
+For each route we cover:
+  1. populated store + flag set    → fast path, response tagged _source=local_store
+  2. empty store + flag set        → falls through (no _source tag)
+  3. populated store + flag unset  → falls through (no _source tag)
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def overview_app(tmp_path, monkeypatch):
+    """Flask app + reloaded local_store + reloaded routes.overview blueprint."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.overview as ov
+    importlib.reload(ov)
+
+    a = Flask(__name__)
+    a.register_blueprint(ov.bp_overview)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def health_app(tmp_path, monkeypatch):
+    """Flask app + reloaded local_store + reloaded routes.health blueprint."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as hh
+    importlib.reload(hh)
+
+    a = Flask(__name__)
+    a.register_blueprint(hh.bp_health)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t=2.0):
+    """Wait until the ring is drained to disk so SELECTs see the rows."""
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/overview
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_overview_fast_path_returns_local_store_data(overview_app):
+    """Populated `sessions` table → fast path serves directly from DuckDB
+    and returns the documented /api/overview response shape."""
+    a, ls = overview_app
+    store = ls.get_store()
+
+    store.ingest_session({
+        "session_id": "sess-main-A",
+        "agent_type": "openclaw",
+        "title": "Refactoring overview",
+        "started_at": "2026-05-11T10:00:00+00:00",
+        "last_active_at": "2026-05-11T11:00:00+00:00",
+        "status": "active",
+        "total_tokens": 12500,
+        "cost_usd": 0.42,
+        "message_count": 17,
+        "metadata": {"model": "claude-opus-4-7"},
+    })
+    store.ingest_session({
+        "session_id": "sess-main-B",
+        "agent_type": "openclaw",
+        "title": "Older",
+        "started_at": "2026-05-10T09:00:00+00:00",
+        "last_active_at": "2026-05-10T10:00:00+00:00",
+        "status": "ended",
+        "total_tokens": 50000,
+        "cost_usd": 1.7,
+        "message_count": 30,
+    })
+
+    c = a.test_client()
+    r = c.get("/api/overview")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+
+    # Tag confirms fast path took the wheel.
+    assert body.get("_source") == "local_store"
+
+    # Shape matches the legacy contract.
+    for key in (
+        "model", "provider", "sessionCount", "sessions", "activeSessions",
+        "mainSessionUpdated", "mainTokens", "contextWindow",
+        "cronCount", "cronEnabled", "cronDisabled",
+        "memoryCount", "memorySize", "system", "infra",
+    ):
+        assert key in body, f"missing key: {key}"
+
+    # Content checks.
+    assert body["sessionCount"] == 2
+    assert body["sessions"] == 2  # alias
+    assert body["activeSessions"] == 1  # only sess-main-A is active
+    # Most-recent main session = sess-main-A → its total_tokens flows through.
+    assert body["mainTokens"] == 12500
+    assert body["model"] == "claude-opus-4-7"
+    # System + infra blocks are arrays/dicts even when their subprocess probes fail.
+    assert isinstance(body["system"], list)
+    assert isinstance(body["infra"], dict)
+
+
+def test_overview_fast_path_falls_back_when_store_empty(overview_app):
+    """Empty store → fast path returns None → legacy handler runs.
+    Without a gateway+sessions dir we still get a non-`_source` response."""
+    a, _ls = overview_app
+    c = a.test_client()
+    r = c.get("/api/overview")
+    body = r.get_json() or {}
+    # Fast path returned None → fell through to legacy gateway path, which
+    # does NOT add the _source tag.
+    assert body.get("_source") != "local_store"
+
+
+def test_overview_fast_path_disabled_without_flag(tmp_path, monkeypatch):
+    """No CLAWMETRY_LOCAL_STORE_READ → fast path never runs even with a
+    populated store. Defaults to legacy behavior so existing deploys see
+    zero change without explicit opt-in."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.overview as ov
+    importlib.reload(ov)
+
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": "sess-noflag",
+        "agent_type": "openclaw",
+        "title": "Should not appear via fast path",
+        "started_at": "2026-05-11T10:00:00+00:00",
+        "last_active_at": "2026-05-11T10:30:00+00:00",
+        "status": "active",
+        "total_tokens": 999,
+        "metadata": {"model": "noflag-model"},
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(ov.bp_overview)
+    r = a.test_client().get("/api/overview")
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/timeline
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_timeline_fast_path_returns_local_store_data(overview_app):
+    """Populated `events` table → fast path returns per-day aggregates from
+    DuckDB. Today (UTC date) should appear with our seeded event count."""
+    a, ls = overview_app
+    store = ls.get_store()
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    # Seed 4 events on today's date, two distinct hours.
+    for i, hour in enumerate([9, 9, 14, 14]):
+        store.ingest({
+            "id": f"ev-tl-{i}",
+            "node_id": "agent+test",
+            "agent_id": "main",
+            "session_id": "sess-tl",
+            "event_type": "tool_call",
+            "ts": f"{today}T{hour:02d}:30:0{i}+00:00",
+            "data": {"tool": "Bash"},
+            "cost_usd": 0.001,
+            "token_count": 10,
+            "model": "claude-opus-4-7",
+        })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/timeline")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+
+    assert body.get("_source") == "local_store"
+    assert "days" in body
+    assert "today" in body
+    assert body["today"] == today
+
+    days = body["days"]
+    assert isinstance(days, list)
+    # Today should be one of the days returned.
+    today_entry = next((d for d in days if d["date"] == today), None)
+    assert today_entry is not None, f"today {today} missing from days {[d['date'] for d in days]}"
+    assert today_entry["events"] == 4
+    # Per-hour bucketing should pick up our two distinct hours.
+    assert today_entry["hours"].get(9) == 2 or today_entry["hours"].get("9") == 2
+    assert today_entry["hours"].get(14) == 2 or today_entry["hours"].get("14") == 2
+    # Shape essentials.
+    assert "label" in today_entry
+    assert "hasMemory" in today_entry
+
+
+def test_timeline_fast_path_falls_back_when_store_empty(overview_app):
+    """Empty events table → fast path returns None → legacy JSONL scanner
+    runs and returns a `days` array (possibly empty) without _source tag."""
+    a, _ls = overview_app
+    c = a.test_client()
+    r = c.get("/api/timeline")
+    assert r.status_code == 200
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+    assert "days" in body
+
+
+def test_timeline_fast_path_disabled_without_flag(tmp_path, monkeypatch):
+    """No CLAWMETRY_LOCAL_STORE_READ → fast path never runs even with
+    populated events store."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.overview as ov
+    importlib.reload(ov)
+
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-tl-noflag",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-tl",
+        "event_type": "tool_call",
+        "ts": "2026-05-11T12:00:00+00:00",
+        "data": {"tool": "Bash"},
+        "cost_usd": 0.001,
+        "token_count": 5,
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    a = Flask(__name__)
+    a.register_blueprint(ov.bp_overview)
+    r = a.test_client().get("/api/timeline")
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/heartbeat-status
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_heartbeat_status_fast_path_returns_local_store_data(health_app):
+    """Populated `heartbeats` table → fast path returns the same status shape
+    as the in-memory `_get_heartbeat_status()` helper."""
+    a, ls = health_app
+    store = ls.get_store()
+
+    now = time.time()
+    # Recent heartbeat → status "ok".
+    store.ingest_heartbeat({
+        "node_id": "agent+test",
+        "ts": _iso(now - 30),
+        "version": "0.12.162",
+        "e2e": True,
+    })
+
+    c = a.test_client()
+    r = c.get("/api/heartbeat-status")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+
+    assert body.get("_source") == "local_store"
+    # Shape matches the legacy `_get_heartbeat_status()` output.
+    for key in (
+        "status", "last_heartbeat_ts", "gap_seconds",
+        "interval_seconds", "threshold_seconds", "silent_since",
+    ):
+        assert key in body, f"missing key: {key}"
+    assert body["status"] == "ok"
+    assert body["gap_seconds"] is not None
+    assert body["gap_seconds"] < 120
+
+
+def test_heartbeat_status_fast_path_node_filter(health_app):
+    """?node=<id> scopes the lookup to one fleet node."""
+    a, ls = health_app
+    store = ls.get_store()
+
+    now = time.time()
+    # Node A: very recent → ok
+    store.ingest_heartbeat({
+        "node_id": "node-a",
+        "ts": _iso(now - 10),
+        "version": "0.12.162",
+        "e2e": True,
+    })
+    # Node B: 2h ago → silent (gap > 1.5×30m)
+    store.ingest_heartbeat({
+        "node_id": "node-b",
+        "ts": _iso(now - 7200),
+        "version": "0.12.162",
+        "e2e": True,
+    })
+
+    c = a.test_client()
+
+    r_a = c.get("/api/heartbeat-status?node=node-a")
+    body_a = r_a.get_json()
+    assert body_a.get("_source") == "local_store"
+    assert body_a["status"] == "ok"
+
+    r_b = c.get("/api/heartbeat-status?node=node-b")
+    body_b = r_b.get_json()
+    assert body_b.get("_source") == "local_store"
+    assert body_b["status"] == "silent"
+
+
+def test_heartbeat_status_fast_path_falls_back_when_store_empty(health_app):
+    """Empty heartbeats table → fast path returns None → legacy in-memory
+    `_get_heartbeat_status()` runs (returns "unknown" when never seen)."""
+    a, _ls = health_app
+    c = a.test_client()
+    r = c.get("/api/heartbeat-status")
+    assert r.status_code == 200
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+
+
+def test_heartbeat_status_fast_path_disabled_without_flag(tmp_path, monkeypatch):
+    """No CLAWMETRY_LOCAL_STORE_READ → fast path never runs even with
+    populated heartbeats store."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as hh
+    importlib.reload(hh)
+
+    store = ls.get_store()
+    store.ingest_heartbeat({
+        "node_id": "agent+noflag",
+        "ts": _iso(time.time()),
+        "version": "0.12.162",
+        "e2e": True,
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(hh.bp_health)
+    r = a.test_client().get("/api/heartbeat-status")
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
Epic #964 DuckDB MOAT push (Engineer 8). Adds opt-in local-store fast paths on three composite/aggregate routes that previously hit the gateway, JSONL files, or in-memory globals on every request.

- **`/api/overview`** — sessionCount/activeSessions/mainSession metadata derived from `query_sessions` (system + infra blocks unchanged).
- **`/api/timeline`** — 30-day per-day rollup from `query_aggregates` (perfect fit — DuckDB pre-buckets by day on the columnar layout); per-hour distribution back-filled from `query_events` only on days with activity.
- **`/api/heartbeat-status`** — most-recent heartbeat row via `query_heartbeats`, optionally scoped to `?node=<id>` for the fleet view.

Pattern matches the existing fast paths (`sessions`, `sessions/by-type`, `brain-history`, `heartbeat`):
- Gated on `CLAWMETRY_LOCAL_STORE_READ=1` (zero-change default)
- Returns `None` on any failure → falls through to the legacy handler
- Responses tagged with `_source: "local_store"` so tests + ops can verify which path served the request
- Existing handler logic untouched — purely additive fast path

## Test plan
- [x] 10 new tests in `tests/test_overview_local_store.py` — for each route: populated store + flag → fast path returns correct shape/content; empty store → fall-through; flag unset → fall-through
- [x] Existing local-store tests (heartbeat, brain, sessions, by-type) still pass
- [x] `dashboard.py` still imports cleanly with the modified blueprints
- [x] Syntax check on both modified route modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)