### PR TITLE
feat(health): read 5 Health/Reliability routes from local DuckDB

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -46,17 +46,153 @@ from flask import Blueprint, Response, jsonify, request
 bp_health = Blueprint('health', __name__)
 
 
+# ---------------------------------------------------------------------------
+# Epic #964 — DuckDB local-store fast paths.
+#
+# Each helper below is opt-in via CLAWMETRY_LOCAL_STORE_READ=1 and returns
+# ``None`` on any failure (missing module, empty table, unexpected exception)
+# so the legacy code path runs unchanged. Response shapes match the existing
+# contracts; the only addition is a ``_source: "local_store"`` marker so
+# clients can tell which path served the request.
+# ---------------------------------------------------------------------------
+
+
+def _try_local_store_reliability(window_days: int):
+    """Compute reliability trend from local DuckDB heartbeats + events.
+
+    Builds the same response shape as ``AgentReliabilityScorer.score()``:
+    direction / slope_per_session / significant / session_count /
+    window_days / degrading_dimensions / points.
+
+    Heartbeats are the liveness signal (one per ~minute when the daemon is
+    up); error events are the failure signal. We bucket per-day and run an
+    OLS slope on the per-day delivery_score (= 1 - error_rate). Returns
+    ``None`` to defer to the HistoryDB scorer if anything goes wrong.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+    except Exception:
+        return None
+    try:
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        since_iso = (now - timedelta(days=window_days)).isoformat()
+        hb_rows = store.query_heartbeats(since=since_iso, limit=10000)
+        ev_rows = store.query_events(since=since_iso, limit=10000)
+    except Exception:
+        return None
+    if not hb_rows and not ev_rows:
+        return None
+
+    # Per-day buckets keyed by YYYY-MM-DD.
+    buckets: dict[str, dict[str, int]] = {}
+    for h in hb_rows:
+        ts = (h.get("ts") or "")[:10]
+        if not ts:
+            continue
+        b = buckets.setdefault(ts, {"beats": 0, "errors": 0, "total": 0})
+        b["beats"] += 1
+        b["total"] += 1
+    for e in ev_rows:
+        ts = (e.get("ts") or "")[:10]
+        if not ts:
+            continue
+        et = (e.get("event_type") or "").lower()
+        b = buckets.setdefault(ts, {"beats": 0, "errors": 0, "total": 0})
+        b["total"] += 1
+        if "error" in et or "fail" in et or "stalled" in et or "timeout" in et:
+            b["errors"] += 1
+
+    if not buckets:
+        return None
+
+    ordered_days = sorted(buckets.keys())
+    points = []
+    for day in ordered_days:
+        b = buckets[day]
+        total = max(b["total"], 1)
+        # delivery_score = 1.0 when no errors; drops as errors/total grows.
+        delivery = max(0.0, 1.0 - (b["errors"] / total))
+        success_rate = delivery
+        error_rate = round(b["errors"] / total, 4)
+        points.append({
+            "ts": day,
+            "delivery": round(delivery, 4),
+            "success_rate": round(success_rate, 4),
+            "error_rate": error_rate,
+            "events": b["total"],
+            "beats": b["beats"],
+        })
+
+    # OLS slope on delivery over ordered days. Same logic as the legacy
+    # scorer — keep callers' expectations stable.
+    def _ols_slope(ys):
+        n = len(ys)
+        if n < 2:
+            return 0.0
+        xs = list(range(n))
+        x_mean = sum(xs) / n
+        y_mean = sum(ys) / n
+        num = sum((x - x_mean) * (y - y_mean) for x, y in zip(xs, ys))
+        den = sum((x - x_mean) ** 2 for x in xs)
+        return num / den if den else 0.0
+
+    delivery_slope = _ols_slope([p["delivery"] for p in points])
+    threshold = 0.02
+    if delivery_slope < -threshold:
+        direction = "degrading"
+    elif delivery_slope > threshold:
+        direction = "improving"
+    else:
+        direction = "stable"
+
+    degrading = []
+    if delivery_slope < -threshold:
+        degrading.append("delivery_score")
+
+    # Aggregate rates across the whole window for headline numbers.
+    total_events = sum(b["total"] for b in buckets.values())
+    total_errors = sum(b["errors"] for b in buckets.values())
+    overall_error_rate = round(total_errors / total_events, 4) if total_events else 0.0
+    overall_success_rate = round(1.0 - overall_error_rate, 4)
+
+    return {
+        "direction": direction,
+        "slope_per_session": round(delivery_slope, 6),
+        "significant": abs(delivery_slope) > threshold,
+        "session_count": len(points),
+        "window_days": window_days,
+        "degrading_dimensions": degrading,
+        "delivery_slope": round(delivery_slope, 6),
+        "error_rate": overall_error_rate,
+        "success_rate": overall_success_rate,
+        "points": points[-60:],
+        "_source": "local_store",
+    }
+
+
 @bp_health.route("/api/reliability")
 def api_reliability():
     """Cross-session behavioral reliability trend (AgentReliabilityScorer)."""
     import dashboard as _d
+    try:
+        window = int(request.args.get("window", 30))
+        window = max(1, min(window, 90))
+    except (TypeError, ValueError):
+        window = 30
+    # Epic #964 fast path — only when explicitly opted in. Falls through
+    # to the HistoryDB scorer on any failure so behaviour is identical
+    # for users without local_store data.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_reliability(window)
+        if fast is not None:
+            return jsonify(fast)
     if not _d._history_db or not _d.AgentReliabilityScorer:
         return jsonify(
             {"error": "History module not available", "direction": "insufficient_data"}
         ), 200
     try:
-        window = int(request.args.get("window", 30))
-        window = max(1, min(window, 90))
         scorer = _d.AgentReliabilityScorer(_d._history_db)
         result = scorer.score(window_days=window)
         return jsonify(result)
@@ -629,6 +765,104 @@ def api_diagnostics():
     )
 
 
+def _try_local_store_service_status():
+    """Compose service_status from heartbeats + system_snapshots.
+
+    - ``sync``: True iff a heartbeat row exists within the last 5 minutes
+      (the daemon writes one per minute when up).
+    - ``gateway``: from the most recent system_snapshot of kind 'gateway'
+      (data.up boolean) when present, else inferred from the same heartbeat
+      payload (``data.gateway_up``).
+    - ``channels``: from the most recent system_snapshot of kind 'channels'
+      when present (data.channels list), else from the heartbeat payload's
+      ``channels`` field, else empty.
+    - ``resources``: from the most recent system_snapshot of kind
+      'resources' when present (data.status string), else "ok".
+
+    Returns ``None`` when no recent heartbeat exists — the legacy handler
+    will then live-probe the gateway port + run pgrep, which is the right
+    behaviour for a node that has never written to the local store.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        hb_rows = store.query_heartbeats(limit=1)
+    except Exception:
+        return None
+    if not hb_rows:
+        return None
+    hb = hb_rows[0]
+    hb_data = hb.get("data") if isinstance(hb.get("data"), dict) else {}
+
+    # Sync up = heartbeat seen recently.
+    sync_up = True
+    try:
+        from datetime import datetime, timezone
+        ts = (hb.get("ts") or "").replace("Z", "+00:00")
+        beat_dt = datetime.fromisoformat(ts)
+        age = (datetime.now(timezone.utc) - beat_dt).total_seconds()
+        sync_up = age < 300  # 5 min staleness threshold
+    except Exception:
+        pass
+
+    # Helper to grab the most recent snapshot of a given kind from the
+    # same node, falling back to any node's most recent of that kind.
+    node_id = hb.get("node_id")
+
+    def _latest_snapshot(kind: str):
+        try:
+            rows = store.query_system_snapshots(node_id=node_id, kind=kind, limit=1)
+            if not rows:
+                rows = store.query_system_snapshots(kind=kind, limit=1)
+            return rows[0] if rows else None
+        except Exception:
+            return None
+
+    gw_snap = _latest_snapshot("gateway")
+    if gw_snap and isinstance(gw_snap.get("data"), dict):
+        gw_up = bool(gw_snap["data"].get("up", gw_snap["data"].get("gateway", True)))
+    else:
+        gw_up = bool(hb_data.get("gateway_up", True))
+
+    ch_snap = _latest_snapshot("channels")
+    channels_out = []
+    if ch_snap and isinstance(ch_snap.get("data"), dict):
+        raw = ch_snap["data"].get("channels") or []
+        if isinstance(raw, list):
+            for ch in raw:
+                if isinstance(ch, dict):
+                    channels_out.append({
+                        "name": str(ch.get("name", ch.get("kind", "unknown"))),
+                        "connected": bool(ch.get("connected", ch.get("ok", False))),
+                    })
+    if not channels_out:
+        raw = hb_data.get("channels") or []
+        if isinstance(raw, list):
+            for ch in raw:
+                if isinstance(ch, dict):
+                    channels_out.append({
+                        "name": str(ch.get("name", ch.get("kind", "unknown"))),
+                        "connected": bool(ch.get("connected", ch.get("ok", False))),
+                    })
+
+    res_snap = _latest_snapshot("resources")
+    resources = "ok"
+    if res_snap and isinstance(res_snap.get("data"), dict):
+        s = res_snap["data"].get("status") or res_snap["data"].get("resources")
+        if s in ("ok", "warn", "critical"):
+            resources = s
+
+    return {
+        "service_status": {
+            "gateway": gw_up,
+            "channels": channels_out,
+            "sync": sync_up,
+            "resources": resources,
+        },
+        "_source": "local_store",
+    }
+
+
 @bp_health.route("/api/service-status")
 def api_service_status():
     """Compact service status for fleet heartbeat payloads.
@@ -650,6 +884,11 @@ def api_service_status():
         }
     """
     import dashboard as _d
+    # Epic #964 fast path. Composite of heartbeats + system_snapshots.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_service_status()
+        if fast is not None:
+            return jsonify(fast)
     cfg = _d._load_gw_config()
     # ── Gateway ──────────────────────────────────────────────────────────────
     gw_port = _d._detect_gateway_port()
@@ -871,6 +1110,69 @@ def api_health_stream():
     )
 
 
+def _try_local_store_sandbox_status():
+    """Read sandbox/inference/security from system_snapshots(kind="sandbox").
+
+    The daemon writes a single 'sandbox' kind row per snapshot containing
+    the three sub-dicts (sandbox / inference / security) the legacy handler
+    derives from the local environment. We pick the most-recent row.
+
+    Returns ``None`` if the local_store module is missing, no snapshot of
+    kind 'sandbox' exists, or the row's payload doesn't decode.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = store.query_system_snapshots(kind="sandbox", limit=1)
+    except Exception:
+        return None
+    if not rows:
+        return None
+    payload = rows[0].get("data")
+    if not isinstance(payload, dict):
+        return None
+
+    # Accept either the canonical {sandbox, inference, security} shape
+    # straight from the snapshot, or a flat dict that mirrors the legacy
+    # detection helpers' output.
+    sandbox = payload.get("sandbox")
+    inference = payload.get("inference")
+    security = payload.get("security")
+
+    # Normalise to the same canonical fields the legacy handler emits.
+    if isinstance(sandbox, dict):
+        sandbox = {
+            "name": sandbox.get("name"),
+            "status": sandbox.get("status", "running"),
+            "type": sandbox.get("type"),
+        }
+    else:
+        sandbox = None
+    if isinstance(inference, dict):
+        inference = {
+            "provider": inference.get("provider"),
+            "model": inference.get("model"),
+        }
+    else:
+        inference = None
+    if isinstance(security, dict):
+        sec_fields: dict = {}
+        if "sandbox_enabled" in security:
+            sec_fields["sandbox_enabled"] = bool(security["sandbox_enabled"])
+        if "network_policy" in security:
+            sec_fields["network_policy"] = security["network_policy"]
+        security = sec_fields or None
+    else:
+        security = None
+
+    return {
+        "sandbox": sandbox,
+        "inference": inference,
+        "security": security,
+        "_source": "local_store",
+    }
+
+
 @bp_health.route("/api/sandbox-status")
 def api_sandbox_status():
     """Dedicated endpoint: generic sandbox, inference provider & security posture.
@@ -886,6 +1188,12 @@ def api_sandbox_status():
     metadata cannot be detected (platform-agnostic, no vendor logos/assumptions).
     """
     import dashboard as _d
+    # Epic #964 fast path. When the daemon has written a sandbox snapshot
+    # to DuckDB, prefer that — it's the most recently-collected view.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_sandbox_status()
+        if fast is not None:
+            return jsonify(fast)
     sandbox_raw = _d._detect_sandbox_metadata()
     inference_raw = _d._detect_inference_metadata()
     security_raw = _d._detect_security_metadata()
@@ -1016,6 +1324,86 @@ def _detect_loops_in_sessions(sessions_dir, max_sessions=20, window=10, min_repe
     return loops, len(paths)
 
 
+def _try_local_store_loop_detection(window: int, min_repeats: int):
+    """Detect rapid-repeat tool_call loops from events table.
+
+    Walks all events with event_type='tool_call' (or 'toolCall'), groups
+    them per session, and applies the same sliding-window detection as
+    the JSONL scanner: a tool name + arg fingerprint pair appearing
+    ``min_repeats`` or more times within ``window`` consecutive calls.
+
+    Returns ``None`` when local_store is missing or no tool_call events
+    exist. ``checked`` is the count of distinct sessions inspected.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = []
+        for et in ("tool_call", "toolCall"):
+            try:
+                rows.extend(store.query_events(event_type=et, limit=10000))
+            except Exception:
+                continue
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    # Sort ascending by ts so window-detection is in temporal order.
+    rows.sort(key=lambda r: r.get("ts") or "")
+
+    # Bucket per session.
+    by_session: dict = {}
+    for r in rows:
+        sid = r.get("session_id") or ""
+        if not sid:
+            continue
+        data = r.get("data") if isinstance(r.get("data"), dict) else {}
+        name = (data.get("name") or data.get("tool") or "").strip()
+        if not name:
+            continue
+        # Same fingerprint as the JSONL scanner: stable hash of input dict.
+        inp = data.get("input") or data.get("args") or {}
+        try:
+            raw_args = json.dumps(inp, sort_keys=True, default=str)[:500]
+        except Exception:
+            raw_args = str(inp)[:500]
+        fp = hashlib.md5(raw_args.encode()).hexdigest()[:8]
+        by_session.setdefault(sid, []).append((name, fp, r.get("ts") or ""))
+
+    if not by_session:
+        return None
+
+    loops = []
+    for sid, seq in by_session.items():
+        if len(seq) < min_repeats:
+            continue
+        seen_combos = set()
+        for i in range(max(1, len(seq) - window + 1)):
+            chunk = seq[i:i + window]
+            counts: dict = {}
+            for name, fp, _ts in chunk:
+                combo = (name, fp)
+                counts[combo] = counts.get(combo, 0) + 1
+            for combo, count in counts.items():
+                if count >= min_repeats and combo not in seen_combos:
+                    seen_combos.add(combo)
+                    first_ts = next(ts for n, f, ts in seq if (n, f) == combo)
+                    loops.append({
+                        "session_id": sid,
+                        "tool_name": combo[0],
+                        "repeat_count": count,
+                        "first_seen_ts": first_ts,
+                    })
+
+    return {
+        "checked": len(by_session),
+        "loop_count": len(loops),
+        "loops": loops,
+        "_source": "local_store",
+    }
+
+
 @bp_health.route("/api/loop-detection")
 def api_loop_detection():
     """Scan recent sessions for agent loop/drift patterns.
@@ -1049,6 +1437,14 @@ def api_loop_detection():
         min_repeats = max(2, min(10, int(request.args.get("min_repeats", 3))))
     except (TypeError, ValueError):
         min_repeats = 3
+
+    # Epic #964 fast path. When tool_call events are present in the local
+    # DuckDB, run loop detection directly against the columnar store
+    # instead of walking ~/.openclaw/agents/main/sessions/*.jsonl.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_loop_detection(window, min_repeats)
+        if fast is not None:
+            return jsonify(fast)
 
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
@@ -1217,6 +1613,69 @@ def _collect_mcp_stats(sessions_dir, max_sessions=20):
     return result, len(paths)
 
 
+def _try_local_store_mcp_stats():
+    """Aggregate MCP tool-call stats from events(event_type='mcp_call').
+
+    Each event row is expected to carry the tool ``name`` (and optionally
+    ``error``/``is_error`` and ``latency_ms`` / ``duration_ms``) in its
+    JSON ``data`` payload. Built-in tools are filtered out — same rule as
+    the JSONL scanner.
+
+    Returns ``None`` when the local_store module is missing or no
+    ``mcp_call`` events exist.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = store.query_events(event_type="mcp_call", limit=10000)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    # {tool_name: {calls, errors, latencies_ms}}
+    tool_stats: dict = {}
+    distinct_sessions: set = set()
+    for r in rows:
+        data = r.get("data") if isinstance(r.get("data"), dict) else {}
+        name = (data.get("name") or data.get("tool") or "").strip()
+        if not name or name in _BUILTIN_TOOLS:
+            continue
+        sid = r.get("session_id")
+        if sid:
+            distinct_sessions.add(sid)
+        s = tool_stats.setdefault(name, {"calls": 0, "errors": 0, "latencies_ms": []})
+        s["calls"] += 1
+        if data.get("error") or data.get("is_error") or data.get("isError"):
+            s["errors"] += 1
+        lat = data.get("latency_ms") or data.get("duration_ms")
+        if isinstance(lat, (int, float)) and lat >= 0:
+            s["latencies_ms"].append(float(lat))
+
+    if not tool_stats:
+        return None
+
+    out = []
+    for name, s in tool_stats.items():
+        calls = s["calls"]
+        errors = s["errors"]
+        lats = s["latencies_ms"]
+        out.append({
+            "name": name,
+            "calls": calls,
+            "errors": errors,
+            "error_rate_pct": round(errors * 100.0 / calls, 1) if calls else 0.0,
+            "avg_latency_ms": round(sum(lats) / len(lats)) if lats else None,
+        })
+    out.sort(key=lambda x: x["calls"], reverse=True)
+
+    return {
+        "checked": len(distinct_sessions),
+        "tools": out,
+        "_source": "local_store",
+    }
+
+
 @bp_health.route("/api/mcp-stats")
 def api_mcp_stats():
     """Per-tool stats for non-builtin (MCP / external) tool calls.
@@ -1235,6 +1694,12 @@ def api_mcp_stats():
       }
     """
     import dashboard as _d
+    # Epic #964 fast path. When mcp_call events are present in the local
+    # DuckDB, aggregate from there instead of re-walking session JSONLs.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_mcp_stats()
+        if fast is not None:
+            return jsonify(fast)
 
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"

--- a/tests/test_health_local_store.py
+++ b/tests/test_health_local_store.py
@@ -1,0 +1,562 @@
+"""Tests for epic #964 — local-store fast paths on 5 Health/Reliability routes.
+
+Routes covered:
+  GET /api/reliability       — derived from heartbeats + events
+  GET /api/sandbox-status    — read from system_snapshots(kind='sandbox')
+  GET /api/mcp-stats         — aggregated from events(event_type='mcp_call')
+  GET /api/loop-detection    — derived from rapid-repeat tool_call events
+  GET /api/service-status    — composite from heartbeats + system_snapshots
+
+Each route's fast path is opt-in via CLAWMETRY_LOCAL_STORE_READ=1. Without
+that flag every route falls through to the legacy implementation — pinned
+by the dedicated `*_falls_back_when_env_unset` tests. We don't exercise
+the legacy paths' detail (those are covered elsewhere); we just confirm
+the fast path doesn't fire when the flag is missing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import time
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _wait_flush(store, t: float = 2.0) -> None:
+    """Block until the in-memory ring buffer has drained to DuckDB."""
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _stub_dashboard() -> None:
+    """Install a tiny stub `dashboard` module so routes/health.py's late
+    `import dashboard as _d` succeeds inside the test process. The stub
+    only needs the attributes the LEGACY paths reach for — the fast paths
+    we test never touch `_d`. We still set the attributes the fast paths
+    SOMETIMES read (e.g. `SESSIONS_DIR`) to /nonexistent so any accidental
+    fall-through fails fast instead of scanning the user's real workspace.
+    """
+    if "dashboard" in sys.modules:
+        return
+    stub = types.ModuleType("dashboard")
+    # Reliability legacy path needs these — set to None so it returns the
+    # "History module not available" branch if the fast path defers.
+    stub._history_db = None
+    stub.AgentReliabilityScorer = None
+    # Sandbox / loop / mcp / service-status legacy paths need these.
+    stub.SESSIONS_DIR = "/nonexistent/clawmetry-test-sessions"
+    stub._detect_sandbox_metadata = lambda: None
+    stub._detect_inference_metadata = lambda: None
+    stub._detect_security_metadata = lambda: None
+    stub._load_gw_config = lambda: {}
+    stub._detect_gateway_port = lambda: 18789
+    stub._gw_invoke = lambda *a, **kw: None
+    sys.modules["dashboard"] = stub
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Isolated Flask app with the health blueprint and a tmp DuckDB.
+
+    ``CLAWMETRY_LOCAL_STORE_READ=1`` is set so the fast path is active for
+    every test that uses this fixture; the dedicated negative tests build
+    their own app without the flag.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "clawmetry.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    _stub_dashboard()
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as hp
+    importlib.reload(hp)
+
+    a = Flask(__name__)
+    a.register_blueprint(hp.bp_health)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/reliability
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_reliability_fast_path_serves_from_local_store(app):
+    """Heartbeats + a couple of error events → fast path returns the
+    documented reliability shape with _source=local_store."""
+    a, ls = app
+    store = ls.get_store()
+
+    now = datetime.now(timezone.utc)
+    # 5 days × 4 heartbeats per day, no errors → delivery=1.0 across the window.
+    for d in range(5):
+        for h in range(4):
+            store.ingest_heartbeat({
+                "node_id": "agent+test",
+                "ts": _iso(now - timedelta(days=d, hours=h)),
+                "version": "0.12.162",
+                "e2e": True,
+            })
+    # A small set of events to make sure the events path is exercised.
+    for i in range(3):
+        store.ingest({
+            "id": f"ev-ok-{i}",
+            "node_id": "agent+test",
+            "session_id": "sess-r1",
+            "event_type": "tool_call",
+            "ts": _iso(now - timedelta(days=i)),
+        })
+    _wait_flush(store)
+
+    r = a.test_client().get("/api/reliability?window=7")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+
+    assert body["_source"] == "local_store"
+    assert body["window_days"] == 7
+    assert body["session_count"] >= 1
+    assert body["direction"] in {"improving", "degrading", "stable", "insufficient_data"}
+    assert "points" in body and isinstance(body["points"], list)
+    # Pure-OK window → success_rate should be 1.0, error_rate 0.0.
+    assert body["success_rate"] == 1.0
+    assert body["error_rate"] == 0.0
+    # Every point should carry the per-day rates.
+    for p in body["points"]:
+        assert "ts" in p and "delivery" in p and "error_rate" in p
+
+
+def test_reliability_picks_up_error_events(app):
+    """A burst of error events should drag error_rate above 0.0."""
+    a, ls = app
+    store = ls.get_store()
+    now = datetime.now(timezone.utc)
+    # Mix: 4 ok, 4 errors on the same day.
+    for i in range(4):
+        store.ingest({
+            "id": f"ev-ok-{i}",
+            "node_id": "agent+test",
+            "session_id": "sess-r2",
+            "event_type": "tool_call",
+            "ts": _iso(now - timedelta(minutes=i)),
+        })
+    for i in range(4):
+        store.ingest({
+            "id": f"ev-err-{i}",
+            "node_id": "agent+test",
+            "session_id": "sess-r2",
+            "event_type": "tool_error",
+            "ts": _iso(now - timedelta(minutes=10 + i)),
+        })
+    _wait_flush(store)
+
+    r = a.test_client().get("/api/reliability?window=30")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    assert body["error_rate"] > 0.0
+    assert body["success_rate"] < 1.0
+
+
+def test_reliability_falls_back_when_env_unset(tmp_path, monkeypatch):
+    """No CLAWMETRY_LOCAL_STORE_READ → fast path never runs even with a
+    populated heartbeats table. Legacy path gets the request and returns
+    the 'History module not available' branch (because we stub
+    _history_db=None)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "clawmetry.duckdb"))
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+    _stub_dashboard()
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as hp
+    importlib.reload(hp)
+
+    store = ls.get_store()
+    store.ingest_heartbeat({
+        "node_id": "agent+x",
+        "ts": _iso(datetime.now(timezone.utc)),
+        "version": "0.12.162",
+        "e2e": True,
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(hp.bp_health)
+    body = a.test_client().get("/api/reliability").get_json()
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/sandbox-status
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_sandbox_status_fast_path_returns_snapshot_data(app):
+    """A 'sandbox' kind snapshot in DuckDB → fast path returns its
+    payload, normalised to the canonical shape."""
+    a, ls = app
+    store = ls.get_store()
+    store.ingest_system_snapshot({
+        "node_id": "agent+test",
+        "ts": _iso(datetime.now(timezone.utc)),
+        "kind": "sandbox",
+        "sandbox": {
+            "name": "nemoclaw-prod",
+            "status": "running",
+            "type": "nemoclaw",
+        },
+        "inference": {
+            "provider": "Anthropic",
+            "model": "claude-opus-4-7",
+        },
+        "security": {
+            "sandbox_enabled": True,
+            "network_policy": "deny",
+        },
+    })
+
+    r = a.test_client().get("/api/sandbox-status")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    assert body["sandbox"]["name"] == "nemoclaw-prod"
+    assert body["sandbox"]["status"] == "running"
+    assert body["sandbox"]["type"] == "nemoclaw"
+    assert body["inference"]["provider"] == "Anthropic"
+    assert body["inference"]["model"] == "claude-opus-4-7"
+    assert body["security"]["sandbox_enabled"] is True
+    assert body["security"]["network_policy"] == "deny"
+
+
+def test_sandbox_status_falls_back_when_env_unset(tmp_path, monkeypatch):
+    """No env flag → never read from DuckDB even with a fresh snapshot."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "clawmetry.duckdb"))
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+    _stub_dashboard()
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as hp
+    importlib.reload(hp)
+
+    store = ls.get_store()
+    store.ingest_system_snapshot({
+        "node_id": "agent+x",
+        "ts": _iso(datetime.now(timezone.utc)),
+        "kind": "sandbox",
+        "sandbox": {"name": "should-not-show", "type": "docker"},
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(hp.bp_health)
+    body = a.test_client().get("/api/sandbox-status").get_json()
+    assert body.get("_source") != "local_store"
+    # Legacy path with our stubbed _detect_*=None returns nulls.
+    assert body["sandbox"] is None
+    assert body["inference"] is None
+    assert body["security"] is None
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/mcp-stats
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_mcp_stats_fast_path_aggregates_from_events(app):
+    """A handful of mcp_call events → the fast path returns per-tool
+    counts/errors/avg_latency_ms."""
+    a, ls = app
+    store = ls.get_store()
+    base = datetime.now(timezone.utc)
+
+    for i in range(5):
+        store.ingest({
+            "id": f"mcp-search-{i}",
+            "node_id": "agent+test",
+            "session_id": f"sess-{i % 2}",
+            "event_type": "mcp_call",
+            "ts": _iso(base - timedelta(seconds=i)),
+            "data": {
+                "name": "mcp.search",
+                "latency_ms": 120 + i * 10,
+                "is_error": False,
+            },
+        })
+    # One error to bump the rate.
+    store.ingest({
+        "id": "mcp-search-err",
+        "node_id": "agent+test",
+        "session_id": "sess-0",
+        "event_type": "mcp_call",
+        "ts": _iso(base - timedelta(seconds=10)),
+        "data": {"name": "mcp.search", "is_error": True},
+    })
+    # A second tool with one call.
+    store.ingest({
+        "id": "mcp-fetch-0",
+        "node_id": "agent+test",
+        "session_id": "sess-1",
+        "event_type": "mcp_call",
+        "ts": _iso(base - timedelta(seconds=15)),
+        "data": {"name": "mcp.fetch", "latency_ms": 80},
+    })
+    # A built-in name should be filtered out.
+    store.ingest({
+        "id": "mcp-bash-0",
+        "node_id": "agent+test",
+        "session_id": "sess-1",
+        "event_type": "mcp_call",
+        "ts": _iso(base - timedelta(seconds=20)),
+        "data": {"name": "Bash"},
+    })
+    _wait_flush(store)
+
+    r = a.test_client().get("/api/mcp-stats")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    assert body["checked"] == 2  # two distinct sessions saw mcp calls
+    by_name = {t["name"]: t for t in body["tools"]}
+    assert "mcp.search" in by_name
+    assert "mcp.fetch" in by_name
+    assert "Bash" not in by_name  # built-ins are filtered
+    assert by_name["mcp.search"]["calls"] == 6
+    assert by_name["mcp.search"]["errors"] == 1
+    assert by_name["mcp.search"]["error_rate_pct"] > 0
+    assert by_name["mcp.search"]["avg_latency_ms"] is not None
+    # mcp.search appeared more often → first in sorted output.
+    assert body["tools"][0]["name"] == "mcp.search"
+
+
+def test_mcp_stats_falls_back_when_env_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "clawmetry.duckdb"))
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+    _stub_dashboard()
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as hp
+    importlib.reload(hp)
+
+    store = ls.get_store()
+    store.ingest({
+        "id": "mcp-x",
+        "node_id": "agent+x",
+        "session_id": "s1",
+        "event_type": "mcp_call",
+        "ts": _iso(datetime.now(timezone.utc)),
+        "data": {"name": "mcp.search"},
+    })
+    _wait_flush(store)
+
+    a = Flask(__name__)
+    a.register_blueprint(hp.bp_health)
+    body = a.test_client().get("/api/mcp-stats").get_json()
+    # Legacy scanner ran (sessions_dir=/nonexistent) → empty result, no _source.
+    assert body.get("_source") != "local_store"
+    assert body["checked"] == 0
+    assert body["tools"] == []
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/loop-detection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_loop_detection_fast_path_finds_repeats(app):
+    """Same tool + identical args N times in one session → flagged."""
+    a, ls = app
+    store = ls.get_store()
+    base = datetime.now(timezone.utc)
+
+    # 5 identical calls in one session (>=3 repeats inside default window=10).
+    for i in range(5):
+        store.ingest({
+            "id": f"tc-loop-{i}",
+            "node_id": "agent+test",
+            "session_id": "sess-loop",
+            "event_type": "tool_call",
+            "ts": _iso(base + timedelta(seconds=i)),
+            "data": {"name": "Bash", "input": {"cmd": "ls /tmp"}},
+        })
+    # A few unrelated calls in a second session — should NOT be flagged.
+    for i in range(3):
+        store.ingest({
+            "id": f"tc-no-{i}",
+            "node_id": "agent+test",
+            "session_id": "sess-clean",
+            "event_type": "tool_call",
+            "ts": _iso(base + timedelta(seconds=i)),
+            "data": {"name": f"Tool{i}", "input": {"x": i}},
+        })
+    _wait_flush(store)
+
+    r = a.test_client().get("/api/loop-detection")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    assert body["checked"] == 2
+    assert body["loop_count"] >= 1
+    flagged = [l for l in body["loops"] if l["session_id"] == "sess-loop"]
+    assert flagged, "expected sess-loop to be flagged"
+    assert flagged[0]["tool_name"] == "Bash"
+    assert flagged[0]["repeat_count"] >= 3
+    assert "first_seen_ts" in flagged[0]
+
+
+def test_loop_detection_falls_back_when_env_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "clawmetry.duckdb"))
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+    _stub_dashboard()
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as hp
+    importlib.reload(hp)
+
+    store = ls.get_store()
+    for i in range(5):
+        store.ingest({
+            "id": f"tc-x-{i}",
+            "node_id": "agent+x",
+            "session_id": "sess-loop",
+            "event_type": "tool_call",
+            "ts": _iso(datetime.now(timezone.utc) + timedelta(seconds=i)),
+            "data": {"name": "Bash", "input": {"cmd": "ls"}},
+        })
+    _wait_flush(store)
+
+    a = Flask(__name__)
+    a.register_blueprint(hp.bp_health)
+    body = a.test_client().get("/api/loop-detection").get_json()
+    assert body.get("_source") != "local_store"
+    # Legacy path scans /nonexistent → 0 sessions, no loops.
+    assert body["checked"] == 0
+    assert body["loop_count"] == 0
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# /api/service-status
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_service_status_fast_path_composes_from_heartbeats(app):
+    """Recent heartbeat (<5min) → sync=True; missing snapshots → defaults."""
+    a, ls = app
+    store = ls.get_store()
+    now = datetime.now(timezone.utc)
+    store.ingest_heartbeat({
+        "node_id": "agent+test",
+        "ts": _iso(now),
+        "version": "0.12.162",
+        "e2e": True,
+        "channels": [
+            {"name": "telegram", "connected": True},
+            {"name": "discord", "connected": False},
+        ],
+        "gateway_up": True,
+    })
+
+    r = a.test_client().get("/api/service-status")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    ss = body["service_status"]
+    assert ss["sync"] is True
+    assert ss["gateway"] is True
+    assert ss["resources"] in {"ok", "warn", "critical"}
+    names = {c["name"] for c in ss["channels"]}
+    assert "telegram" in names and "discord" in names
+
+
+def test_service_status_uses_snapshots_when_present(app):
+    """A 'resources' snapshot with status='warn' → propagates to output."""
+    a, ls = app
+    store = ls.get_store()
+    now = datetime.now(timezone.utc)
+    store.ingest_heartbeat({
+        "node_id": "agent+test",
+        "ts": _iso(now),
+        "version": "0.12.162",
+    })
+    store.ingest_system_snapshot({
+        "node_id": "agent+test",
+        "ts": _iso(now),
+        "kind": "resources",
+        "status": "warn",
+    })
+    store.ingest_system_snapshot({
+        "node_id": "agent+test",
+        "ts": _iso(now),
+        "kind": "gateway",
+        "up": False,
+    })
+
+    r = a.test_client().get("/api/service-status")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    ss = body["service_status"]
+    assert ss["resources"] == "warn"
+    assert ss["gateway"] is False
+
+
+def test_service_status_falls_back_when_env_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "clawmetry.duckdb"))
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+    _stub_dashboard()
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as hp
+    importlib.reload(hp)
+
+    store = ls.get_store()
+    store.ingest_heartbeat({
+        "node_id": "agent+x",
+        "ts": _iso(datetime.now(timezone.utc)),
+        "version": "0.12.162",
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(hp.bp_health)
+    body = a.test_client().get("/api/service-status").get_json()
+    assert body.get("_source") != "local_store"
+    assert "service_status" in body
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
Epic #964 — opt-in local-store fast paths for 5 routes in `routes/health.py`. Behaviour is unchanged for users who haven't set `CLAWMETRY_LOCAL_STORE_READ=1`; with the flag, each route reads from DuckDB instead of walking session JSONLs / live-probing the gateway.

- `/api/reliability` — derives error/success rates and an OLS slope from `query_heartbeats` + `query_events`. Same response shape as `AgentReliabilityScorer.score()`, plus `error_rate` / `success_rate` headlines.
- `/api/sandbox-status` — reads the most recent `system_snapshots(kind='sandbox')` row, normalised to the canonical `{sandbox, inference, security}` contract.
- `/api/mcp-stats` — aggregates per-tool calls/errors/avg latency from `events(event_type='mcp_call')`. Built-in tools are filtered out exactly like the JSONL scanner.
- `/api/loop-detection` — runs the same sliding-window repeat detection on `events(event_type='tool_call')`, keyed by tool name + a stable hash of input args.
- `/api/service-status` — composite of the most recent heartbeat (sync liveness, gateway-up signal, channels) plus optional `gateway` / `channels` / `resources` system_snapshots.

Each helper returns `None` on any failure (missing module, empty table, unexpected exception), so the legacy code path runs unchanged. Responses get a `_source: "local_store"` marker so clients can tell which path served the request. Existing handler logic is untouched — the fast path is a single `if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1": ...` block at the top of each handler.

## Test plan
- [x] `tests/test_health_local_store.py` — 12 cases, all passing locally:
  - 5 fast-path positives (one per route) seeding via the matching ingest helper, hitting the Flask client, and asserting shape + content + `_source` tag
  - 5 negative tests (one per route) confirming the fast path NEVER runs with the env flag unset (legacy path returns its normal output)
  - 2 extra: `reliability_picks_up_error_events` (rates flip when errors land), `service_status_uses_snapshots_when_present` (snapshot-driven `resources='warn'` + `gateway=False` propagates)
- [x] Sibling local-store tests still pass: `tests/test_heartbeat_local_store.py`, `tests/test_brain_local_store.py`, `tests/test_sessions_by_type_local_store.py` (17/17)
- [x] `python3 -c "import routes.health"` — module imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)