### PR TITLE
feat(usage): read 8 Usage tab routes from local DuckDB

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -39,11 +39,670 @@ _CLUSTER_CACHE = {"ts": 0.0, "key": None, "data": None}
 _CLUSTER_CACHE_TTL_SECONDS = 120
 
 
+# ────────────────────────────────────────────────────────────────────────────
+# Epic #964 — DuckDB local-store fast paths for the Usage tab.
+#
+# Each helper below is the FIRST path tried by its sibling Flask route when
+# CLAWMETRY_LOCAL_STORE_READ=1. They return ``None`` on any failure (import
+# error, empty store, query crash, unknown shape) so the caller can fall
+# straight through to the legacy JSONL/gateway/OTLP path with no behaviour
+# change. Successful returns carry ``_source: "local_store"`` so callers (and
+# tests) can verify which path served the request.
+#
+# Source data:
+#   * events table — one row per tool call / message / spend event, written
+#     by sync.py + the daemon. Columns: id, agent_type, node_id, agent_id,
+#     session_id, event_type, ts (ISO), data (JSON BLOB), cost_usd,
+#     token_count, model.
+#   * daily_aggregates / sessions tables — pre-rolled summaries, populated
+#     in parallel for cheap queries.
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _ls_get_store():
+    """Lazy-import the local store. Centralised so a missing duckdb wheel
+    only blows up once (and we swallow it gracefully)."""
+    try:
+        from clawmetry import local_store
+        return local_store.get_store()
+    except Exception:
+        return None
+
+
+def _ls_iso_day(ts_str):
+    """Pull YYYY-MM-DD off an ISO timestamp. Tolerates None / short strings."""
+    if not ts_str or not isinstance(ts_str, str) or len(ts_str) < 10:
+        return ""
+    return ts_str[:10]
+
+
+def _ls_event_plugin(ev):
+    """Best-effort plugin/tool name extractor from an events-row data blob.
+
+    Plugins are recorded under several historical keys depending on the
+    writer (gateway, claude-cli adapter, sync.py): ``plugin``, ``tool``,
+    ``tool_name``, ``name``. We try them in order and fall back to the
+    event_type itself.
+    """
+    data = ev.get("data") if isinstance(ev, dict) else None
+    if isinstance(data, dict):
+        for k in ("plugin", "tool", "tool_name", "name"):
+            v = data.get(k)
+            if v and isinstance(v, str):
+                return v
+    et = (ev.get("event_type") or "").strip()
+    return et or "unknown"
+
+
+def _ls_event_skill(ev):
+    """Pull a skill name out of an event's data blob, if any. Returns the
+    bare skill name (e.g. ``review``) or ``None`` when no skill is named."""
+    data = ev.get("data") if isinstance(ev, dict) else None
+    if not isinstance(data, dict):
+        return None
+    for k in ("skill", "skill_name"):
+        v = data.get(k)
+        if v and isinstance(v, str):
+            return v
+    # Detect SKILL.md path references in input/file_path/path keys.
+    for k in ("file_path", "path", "input"):
+        v = data.get(k)
+        if isinstance(v, str) and "SKILL.md" in v.upper():
+            # Pull the parent dir name as the skill identifier.
+            import re as _re
+            m = _re.search(r"[/\\]([^/\\]+)[/\\]SKILL\.md", v, _re.IGNORECASE)
+            if m:
+                return m.group(1)
+    return None
+
+
+def _try_local_store_usage():
+    """Fast path for /api/usage. Builds the daily token/cost chart by
+    aggregating ``daily_aggregates`` (with a ``query_events`` fallback if
+    the aggregates table is empty). Returns the same shape as the legacy
+    handler: days[], today/week/month, todayCost/weekCost/monthCost,
+    modelBreakdown, etc. Returns None to defer."""
+    store = _ls_get_store()
+    if store is None:
+        return None
+    try:
+        # Pull pre-rolled day buckets first — these are the "blessed" data
+        # the daemon writes once per ingest. Falls back to live event scan
+        # when aggregates are empty (e.g. fresh install, only events seeded).
+        agg_rows = store.query_aggregates()
+    except Exception:
+        return None
+    daily_tokens = {}
+    daily_cost = {}
+    if agg_rows:
+        for r in agg_rows:
+            day = r.get("day") or ""
+            if not day:
+                continue
+            daily_tokens[day] = daily_tokens.get(day, 0) + int(r.get("token_count") or 0)
+            daily_cost[day] = daily_cost.get(day, 0.0) + float(r.get("cost_usd") or 0.0)
+    else:
+        try:
+            evs = store.query_events(limit=10000)
+        except Exception:
+            return None
+        if not evs:
+            return None
+        for ev in evs:
+            day = _ls_iso_day(ev.get("ts", ""))
+            if not day:
+                continue
+            daily_tokens[day] = daily_tokens.get(day, 0) + int(ev.get("token_count") or 0)
+            daily_cost[day] = daily_cost.get(day, 0.0) + float(ev.get("cost_usd") or 0.0)
+    if not daily_tokens and not daily_cost:
+        return None
+
+    today = datetime.now()
+    days = []
+    for i in range(13, -1, -1):
+        d = today - timedelta(days=i)
+        ds = d.strftime("%Y-%m-%d")
+        days.append({
+            "date": ds,
+            "tokens": int(daily_tokens.get(ds, 0)),
+            "cost": round(float(daily_cost.get(ds, 0.0)), 6),
+            "inputTokens": 0,
+            "outputTokens": 0,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0,
+        })
+
+    today_str = today.strftime("%Y-%m-%d")
+    week_start = (today - timedelta(days=today.weekday())).strftime("%Y-%m-%d")
+    month_start = today.strftime("%Y-%m-01")
+
+    today_tok = int(daily_tokens.get(today_str, 0))
+    week_tok = int(sum(v for k, v in daily_tokens.items() if k >= week_start))
+    month_tok = int(sum(v for k, v in daily_tokens.items() if k >= month_start))
+    today_cost = float(daily_cost.get(today_str, 0.0))
+    week_cost = float(sum(v for k, v in daily_cost.items() if k >= week_start))
+    month_cost = float(sum(v for k, v in daily_cost.items() if k >= month_start))
+
+    # Per-model breakdown: scan recent events and group.
+    model_usage = {}
+    try:
+        recent = store.query_events(limit=5000)
+        for ev in recent:
+            m = ev.get("model") or "unknown"
+            model_usage[m] = model_usage.get(m, 0) + int(ev.get("token_count") or 0)
+    except Exception:
+        pass
+    model_breakdown = [
+        {"model": k, "tokens": v}
+        for k, v in sorted(model_usage.items(), key=lambda x: -x[1])
+        if v > 0
+    ]
+
+    return {
+        "source": "local_store",
+        "_source": "local_store",
+        "days": days,
+        "today": today_tok,
+        "week": week_tok,
+        "month": month_tok,
+        "todayCost": round(today_cost, 4),
+        "weekCost": round(week_cost, 4),
+        "monthCost": round(month_cost, 4),
+        "modelBreakdown": model_breakdown,
+        "modelBilling": [],
+        "billingSummary": {},
+        "sessionCosts": {},
+        "anomalies": [],
+        "anomalySessionIds": [],
+        "trend": {},
+        "warnings": [],
+    }
+
+
+def _ls_compute_anomalies():
+    """Shared rolling-baseline anomaly detection over events. Used by both
+    /api/usage/anomalies and /api/anomalies. Buckets recent (24h) sessions
+    and flags any whose cost exceeds 2x the 7-day rolling session-cost
+    baseline. Returns ``(anomalies, baseline_avg)`` or ``(None, None)`` to
+    defer."""
+    store = _ls_get_store()
+    if store is None:
+        return None, None
+    try:
+        sessions = store.query_sessions(limit=500)
+    except Exception:
+        return None, None
+    if not sessions:
+        return None, None
+
+    # Convert ISO start timestamps to epoch.
+    def _to_epoch(s):
+        if not s:
+            return 0.0
+        try:
+            from datetime import datetime as _dt
+            return _dt.fromisoformat(str(s).replace("Z", "+00:00")).timestamp()
+        except Exception:
+            return 0.0
+
+    enriched = []
+    for s in sessions:
+        enriched.append({
+            "session_id": s.get("session_id"),
+            "cost_usd": float(s.get("cost_usd") or 0.0),
+            "start_ts": _to_epoch(s.get("started_at")),
+        })
+
+    now_ts = time.time()
+    day_ago = now_ts - 86400
+    week_ago = now_ts - 7 * 86400
+    anomalies = []
+
+    # Sort by start_ts ascending so the rolling-baseline window is well-defined.
+    enriched.sort(key=lambda r: r["start_ts"])
+    for i, sess in enumerate(enriched):
+        ts = sess["start_ts"]
+        if ts < day_ago:
+            continue
+        cost = sess["cost_usd"]
+        if cost <= 0:
+            continue
+        window_start = ts - (7 * 86400)
+        window_costs = [
+            p["cost_usd"] for p in enriched[:i]
+            if p["start_ts"] >= window_start and p["start_ts"] < ts and p["cost_usd"] > 0
+        ]
+        if not window_costs:
+            continue
+        avg = sum(window_costs) / float(len(window_costs))
+        if avg <= 0:
+            continue
+        if cost > (2.0 * avg):
+            anomalies.append({
+                "session_id": sess["session_id"],
+                "cost_usd": round(cost, 6),
+                "rolling_avg_usd": round(avg, 6),
+                "ratio": round(cost / avg, 3),
+                "timestamp": int(ts * 1000),
+            })
+
+    anomalies.sort(key=lambda a: a.get("ratio", 0), reverse=True)
+    baseline_costs = [s["cost_usd"] for s in enriched
+                      if s["start_ts"] >= week_ago and s["cost_usd"] > 0]
+    baseline_avg = (sum(baseline_costs) / float(len(baseline_costs))) if baseline_costs else 0.0
+    return anomalies, baseline_avg
+
+
+def _try_local_store_usage_anomalies():
+    """Fast path for /api/usage/anomalies."""
+    anomalies, baseline_avg = _ls_compute_anomalies()
+    if anomalies is None:
+        return None
+    return {
+        "anomalies": anomalies,
+        "baseline_7d_avg_usd": round(baseline_avg or 0.0, 6),
+        "threshold_multiplier": 2.0,
+        "_source": "local_store",
+    }
+
+
+def _try_local_store_anomalies():
+    """Fast path for /api/anomalies. The legacy handler stores acks in a
+    sqlite db so we mirror its empty/no-ack defaults."""
+    anomalies, baseline_avg = _ls_compute_anomalies()
+    if anomalies is None:
+        return None
+    # Match the legacy response shape (anomaly id + ack + severity), even
+    # though we can't persist acks in the local store yet — those need the
+    # ~/.openclaw/clawmetry.db that the legacy detector owns.
+    out = []
+    for i, a in enumerate(anomalies):
+        ratio = float(a.get("ratio") or 0)
+        sev = "critical" if ratio >= 4.0 else ("high" if ratio >= 3.0 else "medium")
+        out.append({
+            "id": i + 1,
+            "session_key": a.get("session_id"),
+            "metric": "cost_spike",
+            "value": a.get("cost_usd"),
+            "baseline": a.get("rolling_avg_usd"),
+            "ratio": ratio,
+            "severity": sev,
+            "detected_at": (a.get("timestamp") or 0) / 1000.0,
+            "acknowledged": False,
+        })
+    active = [a for a in out if not a.get("acknowledged")]
+    return {
+        "anomalies": out,
+        "active_count": len(active),
+        "has_active": bool(active),
+        "baselines": {"cost_7d_avg_usd": round(baseline_avg or 0.0, 6)},
+        "threshold_cost_multiplier": 2.0,
+        "threshold_token_multiplier": 2.0,
+        "threshold_error_multiplier": 3.0,
+        "_source": "local_store",
+    }
+
+
+def _try_local_store_usage_by_plugin(threshold_pct):
+    """Fast path for /api/usage/by-plugin. Groups events by plugin/tool
+    name, splits each event's tokens/cost across the plugins implicated.
+    Returns shape: {plugins: [...], warnings: [...]}."""
+    store = _ls_get_store()
+    if store is None:
+        return None
+    try:
+        evs = store.query_events(limit=20000)
+    except Exception:
+        return None
+    if not evs:
+        return None
+    plugin_stats = defaultdict(lambda: {"tokens": 0.0, "cost": 0.0, "calls": 0})
+    saw_any = False
+    for ev in evs:
+        plugin = _ls_event_plugin(ev)
+        if not plugin:
+            continue
+        saw_any = True
+        plugin_stats[plugin]["tokens"] += float(ev.get("token_count") or 0)
+        plugin_stats[plugin]["cost"] += float(ev.get("cost_usd") or 0.0)
+        plugin_stats[plugin]["calls"] += 1
+    if not saw_any:
+        return None
+    total_tokens = sum(s["tokens"] for s in plugin_stats.values()) or 1.0
+    rows = []
+    warnings = []
+    for plugin, st in plugin_stats.items():
+        toks = st["tokens"]
+        cost = st["cost"]
+        calls = st["calls"]
+        pct = round((toks / total_tokens) * 100.0, 2)
+        rows.append({
+            "plugin": plugin,
+            "total_tokens": int(round(toks)),
+            "cost_usd": round(cost, 6),
+            "call_count": calls,
+            "pct_of_total": pct,
+            "trend": "flat",
+        })
+        if pct >= threshold_pct:
+            warnings.append({
+                "plugin": plugin,
+                "pct_of_total": pct,
+                "message": f"{plugin} accounts for {pct:.1f}% of total token usage "
+                           f"(threshold: {threshold_pct:.0f}%)",
+                "trend": "flat",
+            })
+    rows.sort(key=lambda r: r["total_tokens"], reverse=True)
+    return {"plugins": rows, "warnings": warnings, "_source": "local_store"}
+
+
+def _try_local_store_usage_by_plugin_trend(days_back):
+    """Fast path for /api/usage/by-plugin/trend. Builds a per-day plugin
+    breakdown from events. Same shape as the legacy handler:
+      {days: [...], plugins: {name: [{day, tokens, cost_usd, calls}, ...]}}.
+    """
+    store = _ls_get_store()
+    if store is None:
+        return None
+    try:
+        evs = store.query_events(limit=20000)
+    except Exception:
+        return None
+    if not evs:
+        return None
+    from datetime import date as _date
+    today = _date.today()
+    day_list = [(today - timedelta(days=i)).strftime("%Y-%m-%d")
+                for i in range(days_back - 1, -1, -1)]
+    day_set = set(day_list)
+    # plugin -> day -> stats
+    plugin_daily: dict = defaultdict(lambda: defaultdict(
+        lambda: {"tokens": 0.0, "cost": 0.0, "calls": 0}
+    ))
+    saw_any = False
+    for ev in evs:
+        day = _ls_iso_day(ev.get("ts", ""))
+        if day not in day_set:
+            continue
+        plugin = _ls_event_plugin(ev)
+        if not plugin:
+            continue
+        saw_any = True
+        bucket = plugin_daily[plugin][day]
+        bucket["tokens"] += float(ev.get("token_count") or 0)
+        bucket["cost"] += float(ev.get("cost_usd") or 0.0)
+        bucket["calls"] += 1
+    if not saw_any:
+        return None
+    result = {}
+    for p in sorted(plugin_daily.keys()):
+        series = []
+        for d in day_list:
+            day_data = plugin_daily[p].get(d, {"tokens": 0.0, "cost": 0.0, "calls": 0})
+            series.append({
+                "day": d,
+                "tokens": int(round(day_data["tokens"])),
+                "cost_usd": round(day_data["cost"], 6),
+                "calls": day_data["calls"],
+            })
+        result[p] = series
+    return {"days": day_list, "plugins": result, "_source": "local_store"}
+
+
+def _try_local_store_cost_comparison():
+    """Fast path for /api/usage/cost-comparison. Sums actual tokens/cost
+    over the past 30 days from the local store, then projects costs against
+    a fixed alternatives table. Mirrors ``dashboard._build_cost_comparison``
+    output shape exactly."""
+    store = _ls_get_store()
+    if store is None:
+        return None
+    try:
+        evs = store.query_events(limit=50000)
+    except Exception:
+        return None
+    if not evs:
+        return None
+
+    # Window: last 30 days.
+    cutoff = datetime.now() - timedelta(days=30)
+    cutoff_iso = cutoff.strftime("%Y-%m-%d")
+
+    actual_tokens = 0
+    actual_cost = 0.0
+    model_token_map: dict = {}
+    saw_any = False
+    for ev in evs:
+        ts = ev.get("ts", "") or ""
+        if ts < cutoff_iso:
+            continue
+        saw_any = True
+        tok = int(ev.get("token_count") or 0)
+        actual_tokens += tok
+        actual_cost += float(ev.get("cost_usd") or 0.0)
+        m = ev.get("model") or ""
+        if m:
+            model_token_map[m] = model_token_map.get(m, 0) + tok
+    if not saw_any:
+        return None
+
+    actual_model = (max(model_token_map, key=lambda k: model_token_map[k])
+                    if model_token_map else "unknown")
+
+    ALTERNATIVES = [
+        ("gemini-2.0-flash",   0.10,  0.40,  "Gemini 2.0 Flash",     "Google"),
+        ("gemini-1.5-flash",   0.075, 0.30,  "Gemini 1.5 Flash",     "Google"),
+        ("gpt-4o-mini",        0.15,  0.60,  "GPT-4o Mini",          "OpenAI"),
+        ("claude-haiku-3.5",   0.80,  4.00,  "Claude Haiku 3.5",     "Anthropic"),
+        ("qwen-plus",          0.40,  1.20,  "Qwen Plus",            "Alibaba"),
+        ("claude-sonnet-3.5",  3.00, 15.00,  "Claude Sonnet 3.5",    "Anthropic"),
+        ("claude-opus-4",     15.00, 75.00,  "Claude Opus 4",        "Anthropic"),
+    ]
+    INPUT_RATIO = 0.60
+    OUTPUT_RATIO = 0.40
+    alternatives = []
+    for alt_id, in_price, out_price, display_name, provider in ALTERNATIVES:
+        if actual_tokens == 0:
+            alt_cost = 0.0
+        else:
+            alt_cost = (
+                actual_tokens * INPUT_RATIO * (in_price / 1_000_000)
+                + actual_tokens * OUTPUT_RATIO * (out_price / 1_000_000)
+            )
+        if actual_cost > 0:
+            savings_pct = round((actual_cost - alt_cost) / actual_cost * 100, 1)
+            savings_usd = round(actual_cost - alt_cost, 4)
+        else:
+            savings_pct = 0.0
+            savings_usd = 0.0
+        alternatives.append({
+            "model_id": alt_id,
+            "display_name": display_name,
+            "provider": provider,
+            "estimated_cost": round(alt_cost, 4),
+            "savings_usd": savings_usd,
+            "savings_pct": savings_pct,
+        })
+    alternatives.sort(key=lambda x: x["estimated_cost"])
+    return {
+        "actual": {
+            "model": actual_model,
+            "tokens": actual_tokens,
+            "cost_usd": round(actual_cost, 4),
+        },
+        "alternatives": alternatives,
+        "period": "30d",
+        "_source": "local_store",
+    }
+
+
+def _try_local_store_model_attribution():
+    """Fast path for /api/model-attribution. Per-model assistant turn count,
+    session count, provider tag, and share %. Switches list is best-effort
+    — derived from per-session model variation."""
+    store = _ls_get_store()
+    if store is None:
+        return None
+    try:
+        evs = store.query_events(limit=20000)
+    except Exception:
+        return None
+    if not evs:
+        return None
+    try:
+        import dashboard as _d
+        provider_fn = getattr(_d, "_provider_from_model", None)
+    except Exception:
+        provider_fn = None
+
+    model_turns: dict = {}
+    sess_models: dict = defaultdict(list)
+    saw_any = False
+    # Iterate oldest-first within each session so we can track switches.
+    evs_sorted = sorted(evs, key=lambda e: (e.get("session_id") or "", e.get("ts") or ""))
+    for ev in evs_sorted:
+        m = (ev.get("model") or "").strip()
+        if not m:
+            continue
+        saw_any = True
+        # Each event is a turn for the purposes of attribution.
+        model_turns[m] = model_turns.get(m, 0) + 1
+        sid = ev.get("session_id") or ""
+        if sid:
+            if not sess_models[sid] or sess_models[sid][-1] != m:
+                sess_models[sid].append(m)
+    if not saw_any:
+        return None
+    model_sessions: dict = {}
+    switches = []
+    for sid, mlist in sess_models.items():
+        primary = mlist[0]
+        model_sessions[primary] = model_sessions.get(primary, 0) + 1
+        for prev, nxt in zip(mlist, mlist[1:]):
+            switches.append({"session": sid, "from_model": prev, "to_model": nxt})
+
+    total_turns = sum(model_turns.values())
+    sorted_models = sorted(model_turns.items(), key=lambda x: -x[1])
+    primary_model = sorted_models[0][0] if sorted_models else ""
+    models_out = []
+    for m, turns in sorted_models:
+        provider = ""
+        if provider_fn:
+            try:
+                provider = provider_fn(m) or ""
+            except Exception:
+                provider = ""
+        models_out.append({
+            "model": m,
+            "turns": turns,
+            "sessions": model_sessions.get(m, 0),
+            "provider": provider,
+            "share_pct": round(turns / total_turns * 100, 2) if total_turns else 0,
+        })
+    return {
+        "models": models_out,
+        "primary_model": primary_model,
+        "total_turns": total_turns,
+        "model_count": len(model_turns),
+        "switches": switches[:50],
+        "switch_count": len(switches),
+        "_source": "local_store",
+    }
+
+
+def _try_local_store_skill_attribution():
+    """Fast path for /api/skill-attribution. Detects skill invocations from
+    events whose data blob mentions a skill (``skill`` key or ``SKILL.md``
+    path), then attributes per-session token cost to those skills with even
+    sharing when multiple skills appear in one session."""
+    store = _ls_get_store()
+    if store is None:
+        return None
+    try:
+        evs = store.query_events(limit=50000)
+    except Exception:
+        return None
+    if not evs:
+        return None
+
+    # Group by session.
+    sess_skills: dict = defaultdict(set)
+    sess_cost: dict = defaultdict(float)
+    sess_last_ts: dict = {}
+    saw_any = False
+    for ev in evs:
+        sid = ev.get("session_id") or ""
+        if not sid:
+            continue
+        skill = _ls_event_skill(ev)
+        if skill:
+            sess_skills[sid].add(skill)
+            saw_any = True
+        sess_cost[sid] += float(ev.get("cost_usd") or 0.0)
+        ts = ev.get("ts") or ""
+        if ts and ts > (sess_last_ts.get(sid) or ""):
+            sess_last_ts[sid] = ts
+    if not saw_any:
+        return None
+
+    skill_stats: dict = defaultdict(lambda: {"invocations": 0, "total_cost": 0.0,
+                                              "last_used_ts": ""})
+    for sid, skills in sess_skills.items():
+        if not skills:
+            continue
+        share = sess_cost.get(sid, 0.0) / len(skills)
+        last_ts = sess_last_ts.get(sid, "")
+        for skill in skills:
+            st = skill_stats[skill]
+            st["invocations"] += 1
+            st["total_cost"] += share
+            if last_ts > st["last_used_ts"]:
+                st["last_used_ts"] = last_ts
+
+    skills_out = []
+    total_cost = 0.0
+    for name, st in sorted(skill_stats.items(), key=lambda x: -x[1]["total_cost"]):
+        inv = st["invocations"]
+        tc = round(float(st["total_cost"]), 6)
+        avg = round(tc / inv, 6) if inv else 0.0
+        last_used = st["last_used_ts"] or None
+        total_cost += tc
+        skills_out.append({
+            "name": name,
+            "invocations": inv,
+            "total_cost_usd": tc,
+            "avg_cost_usd": avg,
+            "last_used": last_used,
+            "clawhub_url": f"https://clawhub.dev/skills/{name}",
+        })
+
+    # Top 5 by cost in the past 7 days (use the session last-used ts as proxy).
+    week_cutoff_iso = (datetime.utcnow() - timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    top5_week = [s for s in skills_out
+                 if s["last_used"] and s["last_used"] >= week_cutoff_iso][:5]
+
+    return {
+        "skills": skills_out,
+        "top5_week": top5_week,
+        "total_cost": round(total_cost, 6),
+        "note": "Skills detected from events table in the local DuckDB store.",
+        "clawhub": {"enabled": False, "url": None},
+        "_source": "local_store",
+    }
+
+
 @bp_usage.route("/api/usage")
 def api_usage():
     """Token/cost tracking from transcript files - Enhanced OTLP workaround."""
     import dashboard as _d
     import time as _time
+
+    # Epic #964 — local-store fast path. Opt-in via CLAWMETRY_LOCAL_STORE_READ=1;
+    # falls through to OTLP/transcript scan when the store is empty / disabled.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_usage()
+        if fast is not None:
+            return jsonify(fast)
 
     now = _time.time()
     if (
@@ -154,6 +813,12 @@ def api_usage_anomalies():
     """Return session cost anomalies vs rolling 7-day baseline."""
     import dashboard as _d
 
+    # Epic #964 — local-store fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_usage_anomalies()
+        if fast is not None:
+            return jsonify(fast)
+
     analytics = _d._compute_transcript_analytics()
     session_summaries = analytics.get("sessions", [])
     anomalies = _d._compute_session_cost_anomalies(session_summaries)
@@ -189,6 +854,12 @@ def api_anomalies():
     - detected_at: Unix timestamp of detection
     """
     import dashboard as _d
+
+    # Epic #964 — local-store fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_anomalies()
+        if fast is not None:
+            return jsonify(fast)
 
     now = time.time()
     if (
@@ -240,6 +911,17 @@ def api_usage_by_plugin():
     when a plugin's cost share exceeds the configured limit (default 50%).
     """
     import dashboard as _d
+
+    try:
+        threshold_pct_arg = float(request.args.get("threshold", 50.0))
+    except (ValueError, TypeError):
+        threshold_pct_arg = 50.0
+
+    # Epic #964 — local-store fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_usage_by_plugin(threshold_pct_arg)
+        if fast is not None:
+            return jsonify(fast)
 
     analytics = _d._compute_transcript_analytics()
     plugin_stats = analytics.get("plugin_stats", {})
@@ -301,14 +983,20 @@ def api_usage_by_plugin_trend():
     """
     import dashboard as _d
 
-    analytics = _d._compute_transcript_analytics()
-    plugin_daily_stats = analytics.get("plugin_daily_stats", {})
-
     try:
         days_back = int(request.args.get("days", 14))
     except (ValueError, TypeError):
         days_back = 14
     days_back = min(max(days_back, 1), 90)
+
+    # Epic #964 — local-store fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_usage_by_plugin_trend(days_back)
+        if fast is not None:
+            return jsonify(fast)
+
+    analytics = _d._compute_transcript_analytics()
+    plugin_daily_stats = analytics.get("plugin_daily_stats", {})
 
     from datetime import date, timedelta
     today = date.today()
@@ -615,6 +1303,12 @@ def api_usage_cost_comparison():
     """Return cost comparison: actual spend vs alternatives (GH#554)."""
     import dashboard as _d
 
+    # Epic #964 — local-store fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_cost_comparison()
+        if fast is not None:
+            return jsonify(fast)
+
     try:
         return jsonify(_d._build_cost_comparison())
     except Exception as e:
@@ -748,6 +1442,12 @@ def api_model_attribution():
     """Per-model turn/session breakdown and switch history (GH #300)."""
     import dashboard as _d
 
+    # Epic #964 — local-store fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_model_attribution()
+        if fast is not None:
+            return jsonify(fast)
+
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser('~/.openclaw/agents/main/sessions')
     model_turns = {}    # model -> assistant turn count
     model_sessions = {} # model -> session count
@@ -859,6 +1559,12 @@ def api_skill_attribution():
     """
     import dashboard as _d
     import re as _re
+
+    # Epic #964 — local-store fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_skill_attribution()
+        if fast is not None:
+            return jsonify(fast)
 
     sessions_dir = _d._get_sessions_dir()
     if not sessions_dir or not os.path.isdir(sessions_dir):

--- a/tests/test_usage_local_store.py
+++ b/tests/test_usage_local_store.py
@@ -1,0 +1,413 @@
+"""Tests for epic #964 — local-store fast paths on the Usage tab routes.
+
+Covers the 8 routes engineer-6 migrated under
+``CLAWMETRY_LOCAL_STORE_READ=1``:
+
+  * /api/usage
+  * /api/usage/anomalies
+  * /api/anomalies
+  * /api/usage/by-plugin
+  * /api/usage/by-plugin/trend
+  * /api/usage/cost-comparison
+  * /api/model-attribution
+  * /api/skill-attribution
+
+Each route gets:
+  1. a positive case — env flag set + populated store → response carries
+     ``_source: "local_store"`` and the legacy contract shape.
+  2. a negative case — env flag UNSET → fast path is skipped entirely
+     (response lacks the ``_source`` tag).
+
+Pattern lifted from ``test_brain_local_store.py`` and
+``test_heartbeat_local_store.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+# ── shared helpers ─────────────────────────────────────────────────────────
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t=2.0):
+    """Block until the in-memory ring has drained to DuckDB."""
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _seed_events(store, *, n=12, models=None, plugins=None, skills=None,
+                  base_cost=0.05, base_tokens=100, sessions=None):
+    """Seed N events spread across the last few days. Returns the event list
+    so tests can introspect what was written."""
+    models = models or ["claude-opus-4", "gpt-4o-mini"]
+    plugins = plugins or ["bash", "edit"]
+    sessions = sessions or ["sess-a", "sess-b"]
+    now = time.time()
+    events = []
+    for i in range(n):
+        sid = sessions[i % len(sessions)]
+        plugin = plugins[i % len(plugins)]
+        model = models[i % len(models)]
+        # Spread events across 0-7 days back so the daily chart has buckets.
+        day_offset = i % 7
+        ts = _iso(now - (day_offset * 86400) - i)
+        data = {"plugin": plugin, "tool": plugin, "input": f"call-{i}"}
+        if skills and i < len(skills):
+            data["skill"] = skills[i]
+        ev = {
+            "id":          f"ev-usage-{i}",
+            "node_id":     "agent+test",
+            "agent_id":    "main",
+            "session_id":  sid,
+            "event_type":  "tool_call",
+            "ts":          ts,
+            "data":        data,
+            "cost_usd":    base_cost * (i + 1),
+            "token_count": base_tokens * (i + 1),
+            "model":       model,
+        }
+        store.ingest(ev)
+        events.append(ev)
+    _wait_flush(store)
+    return events
+
+
+def _seed_anomaly_session(store):
+    """Seed events whose summed per-session cost shows a blow-out spike vs
+    the 7-day baseline. ``query_sessions`` aggregates the events table so we
+    write events (not session rows) here."""
+    now = time.time()
+    # Six baseline sessions over the past 7 days at ~$0.10 each (one event
+    # per session — keeps the cost simple).
+    for i in range(6):
+        ts_iso = _iso(now - ((i + 2) * 86400))
+        store.ingest({
+            "id":          f"ev-baseline-{i}",
+            "node_id":     "agent+test",
+            "agent_id":    "main",
+            "session_id":  f"sess-baseline-{i}",
+            "event_type":  "tool_call",
+            "ts":          ts_iso,
+            "data":        {"plugin": "bash"},
+            "cost_usd":    0.10,
+            "token_count": 1000,
+            "model":       "claude-opus-4",
+        })
+    # One blow-out within the past 24h at $5 (50× baseline) — trips 2× easily.
+    store.ingest({
+        "id":          "ev-spike",
+        "node_id":     "agent+test",
+        "agent_id":    "main",
+        "session_id":  "sess-spike",
+        "event_type":  "tool_call",
+        "ts":          _iso(now - 3600),
+        "data":        {"plugin": "bash"},
+        "cost_usd":    5.0,
+        "token_count": 50000,
+        "model":       "claude-opus-4",
+    })
+    _wait_flush(store)
+
+
+def _build_app(tmp_path, monkeypatch, *, enable_fast_path: bool):
+    """Build an isolated Flask app + populated tmp DuckDB."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    if enable_fast_path:
+        monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    else:
+        monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.usage as usage_mod
+    importlib.reload(usage_mod)
+
+    app = Flask(__name__)
+    app.register_blueprint(usage_mod.bp_usage)
+    return app, ls, usage_mod
+
+
+@pytest.fixture
+def fast_path_app(tmp_path, monkeypatch):
+    app, ls, usage_mod = _build_app(tmp_path, monkeypatch, enable_fast_path=True)
+    yield app, ls, usage_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def legacy_path_app(tmp_path, monkeypatch):
+    """Env flag UNSET — the fast path must be skipped completely. We still
+    populate the store so the legacy path being chosen is provable (the
+    response lacks the ``_source: local_store`` tag despite data existing)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")  # for seeding writes
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    store = ls.get_store()
+    _seed_events(store, n=8, skills=["review", "review", "test"])
+    _seed_anomaly_session(store)
+
+    # Now drop the flag so the route handlers must take the legacy path.
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+    import routes.usage as usage_mod
+    importlib.reload(usage_mod)
+
+    app = Flask(__name__)
+    app.register_blueprint(usage_mod.bp_usage)
+    yield app, ls
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ── /api/usage ─────────────────────────────────────────────────────────────
+
+def test_usage_fast_path_returns_local_store_data(fast_path_app):
+    app, ls, _u = fast_path_app
+    _seed_events(ls.get_store(), n=10)
+
+    body = app.test_client().get("/api/usage").get_json()
+    assert body["_source"] == "local_store"
+    # Legacy contract keys.
+    for k in ("days", "today", "week", "month", "todayCost", "weekCost",
+              "monthCost", "modelBreakdown"):
+        assert k in body, f"missing key {k}"
+    # 14-day rolling chart.
+    assert isinstance(body["days"], list) and len(body["days"]) == 14
+    # Some token volume should land within the window.
+    assert sum(d["tokens"] for d in body["days"]) > 0
+    # Model breakdown lists at least the seeded models.
+    seen_models = {m["model"] for m in body["modelBreakdown"]}
+    assert "claude-opus-4" in seen_models or "gpt-4o-mini" in seen_models
+
+
+def test_usage_legacy_when_env_unset(legacy_path_app):
+    app, _ls = legacy_path_app
+    body = app.test_client().get("/api/usage").get_json()
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/usage/anomalies ───────────────────────────────────────────────────
+
+def test_usage_anomalies_fast_path(fast_path_app):
+    app, ls, _u = fast_path_app
+    _seed_anomaly_session(ls.get_store())
+
+    body = app.test_client().get("/api/usage/anomalies").get_json()
+    assert body["_source"] == "local_store"
+    for k in ("anomalies", "baseline_7d_avg_usd", "threshold_multiplier"):
+        assert k in body
+    assert body["threshold_multiplier"] == 2.0
+    # Spike session at $5 vs ~$0.10 baseline → must be flagged.
+    sids = {a["session_id"] for a in body["anomalies"]}
+    assert "sess-spike" in sids
+
+
+def test_usage_anomalies_legacy_when_env_unset(legacy_path_app):
+    app, _ls = legacy_path_app
+    body = app.test_client().get("/api/usage/anomalies").get_json()
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/anomalies ─────────────────────────────────────────────────────────
+
+def test_anomalies_fast_path(fast_path_app):
+    app, ls, _u = fast_path_app
+    _seed_anomaly_session(ls.get_store())
+
+    body = app.test_client().get("/api/anomalies").get_json()
+    assert body["_source"] == "local_store"
+    for k in ("anomalies", "active_count", "has_active", "baselines",
+              "threshold_cost_multiplier"):
+        assert k in body
+    # Spike must register as active.
+    assert body["has_active"] is True
+    assert body["active_count"] >= 1
+    # Each anomaly row carries the legacy detector's fields.
+    a = body["anomalies"][0]
+    for k in ("id", "session_key", "metric", "value", "baseline", "ratio",
+              "severity", "detected_at", "acknowledged"):
+        assert k in a, f"missing anomaly key {k}"
+    assert a["metric"] == "cost_spike"
+    assert a["severity"] in {"medium", "high", "critical"}
+
+
+def test_anomalies_legacy_when_env_unset(legacy_path_app):
+    app, _ls = legacy_path_app
+    body = app.test_client().get("/api/anomalies").get_json()
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/usage/by-plugin ───────────────────────────────────────────────────
+
+def test_usage_by_plugin_fast_path(fast_path_app):
+    app, ls, _u = fast_path_app
+    _seed_events(ls.get_store(), n=10, plugins=["bash", "edit", "read"])
+
+    body = app.test_client().get("/api/usage/by-plugin").get_json()
+    assert body["_source"] == "local_store"
+    assert "plugins" in body and "warnings" in body
+    plugin_names = {p["plugin"] for p in body["plugins"]}
+    assert {"bash", "edit", "read"}.issubset(plugin_names)
+    # Each row carries the legacy contract fields.
+    for row in body["plugins"]:
+        for k in ("plugin", "total_tokens", "cost_usd", "call_count",
+                  "pct_of_total", "trend"):
+            assert k in row
+    # pct_of_total values sum to ~100.
+    total_pct = sum(p["pct_of_total"] for p in body["plugins"])
+    assert 99.0 <= total_pct <= 101.0
+
+
+def test_usage_by_plugin_threshold_warning(fast_path_app):
+    """One dominant plugin → threshold warning fires."""
+    app, ls, _u = fast_path_app
+    # All events under one plugin → 100% share.
+    _seed_events(ls.get_store(), n=8, plugins=["bash"])
+
+    body = app.test_client().get("/api/usage/by-plugin?threshold=50").get_json()
+    assert body["_source"] == "local_store"
+    assert body["warnings"], "expected at least one threshold warning"
+    assert body["warnings"][0]["plugin"] == "bash"
+
+
+def test_usage_by_plugin_legacy_when_env_unset(legacy_path_app):
+    app, _ls = legacy_path_app
+    body = app.test_client().get("/api/usage/by-plugin").get_json()
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/usage/by-plugin/trend ─────────────────────────────────────────────
+
+def test_usage_by_plugin_trend_fast_path(fast_path_app):
+    app, ls, _u = fast_path_app
+    _seed_events(ls.get_store(), n=14, plugins=["bash", "edit"])
+
+    body = app.test_client().get("/api/usage/by-plugin/trend?days=14").get_json()
+    assert body["_source"] == "local_store"
+    assert "days" in body and "plugins" in body
+    assert len(body["days"]) == 14
+    # Plugins seeded should appear keyed in the trend dict.
+    assert "bash" in body["plugins"]
+    assert "edit" in body["plugins"]
+    # Each plugin's series is one entry per day.
+    for series in body["plugins"].values():
+        assert len(series) == 14
+        for entry in series:
+            for k in ("day", "tokens", "cost_usd", "calls"):
+                assert k in entry
+
+
+def test_usage_by_plugin_trend_legacy_when_env_unset(legacy_path_app):
+    app, _ls = legacy_path_app
+    body = app.test_client().get("/api/usage/by-plugin/trend").get_json()
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/usage/cost-comparison ─────────────────────────────────────────────
+
+def test_cost_comparison_fast_path(fast_path_app):
+    app, ls, _u = fast_path_app
+    _seed_events(ls.get_store(), n=10)
+
+    body = app.test_client().get("/api/usage/cost-comparison").get_json()
+    assert body["_source"] == "local_store"
+    for k in ("actual", "alternatives", "period"):
+        assert k in body
+    assert body["period"] == "30d"
+    assert body["actual"]["tokens"] > 0
+    assert body["actual"]["cost_usd"] > 0
+    # Alternatives sorted ascending by estimated_cost.
+    costs = [a["estimated_cost"] for a in body["alternatives"]]
+    assert costs == sorted(costs)
+    # Each alternative carries the legacy fields.
+    for alt in body["alternatives"]:
+        for k in ("model_id", "display_name", "provider", "estimated_cost",
+                  "savings_usd", "savings_pct"):
+            assert k in alt
+
+
+def test_cost_comparison_legacy_when_env_unset(legacy_path_app):
+    app, _ls = legacy_path_app
+    body = app.test_client().get("/api/usage/cost-comparison").get_json()
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/model-attribution ─────────────────────────────────────────────────
+
+def test_model_attribution_fast_path(fast_path_app):
+    app, ls, _u = fast_path_app
+    _seed_events(ls.get_store(), n=10,
+                  models=["claude-opus-4", "gpt-4o-mini", "claude-opus-4"])
+
+    body = app.test_client().get("/api/model-attribution").get_json()
+    assert body["_source"] == "local_store"
+    for k in ("models", "primary_model", "total_turns", "model_count",
+              "switches", "switch_count"):
+        assert k in body
+    seen = {m["model"] for m in body["models"]}
+    assert "claude-opus-4" in seen
+    assert "gpt-4o-mini" in seen
+    # share_pct sums to ~100.
+    total = sum(m["share_pct"] for m in body["models"])
+    assert 99.0 <= total <= 101.0
+    # Each model row has the legacy fields.
+    for m in body["models"]:
+        for k in ("model", "turns", "sessions", "provider", "share_pct"):
+            assert k in m
+
+
+def test_model_attribution_legacy_when_env_unset(legacy_path_app):
+    app, _ls = legacy_path_app
+    body = app.test_client().get("/api/model-attribution").get_json()
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/skill-attribution ─────────────────────────────────────────────────
+
+def test_skill_attribution_fast_path(fast_path_app):
+    app, ls, _u = fast_path_app
+    _seed_events(ls.get_store(), n=8,
+                  skills=["review", "review", "test", "test"])
+
+    body = app.test_client().get("/api/skill-attribution").get_json()
+    assert body["_source"] == "local_store"
+    for k in ("skills", "top5_week", "total_cost", "note", "clawhub"):
+        assert k in body
+    skill_names = {s["name"] for s in body["skills"]}
+    assert {"review", "test"}.issubset(skill_names)
+    # Each skill row matches the legacy contract.
+    for s in body["skills"]:
+        for k in ("name", "invocations", "total_cost_usd", "avg_cost_usd",
+                  "last_used", "clawhub_url"):
+            assert k in s
+        assert s["clawhub_url"].startswith("https://clawhub.dev/skills/")
+    assert body["clawhub"] == {"enabled": False, "url": None}
+
+
+def test_skill_attribution_legacy_when_env_unset(legacy_path_app):
+    app, _ls = legacy_path_app
+    body = app.test_client().get("/api/skill-attribution").get_json()
+    assert body.get("_source") != "local_store"


### PR DESCRIPTION
## Summary

Epic #964 — adds opt-in `CLAWMETRY_LOCAL_STORE_READ=1` fast paths to 8 Usage tab endpoints in `routes/usage.py` so the Usage tab can be served from the local DuckDB store without touching JSONL / gateway / OTLP. Same pattern as the sessions / heartbeat / brain migrations: try the fast path first, fall through to the existing handler logic on any failure or empty result.

Routes wired (each gated on the env flag, returns `None` on failure → legacy fallback):

| Route | DuckDB source |
|---|---|
| `/api/usage` | `query_aggregates` + `query_events` |
| `/api/usage/anomalies` | `query_sessions` rolling baseline |
| `/api/anomalies` | same baseline detector via DuckDB |
| `/api/usage/by-plugin` | group `query_events` by plugin/tool |
| `/api/usage/by-plugin/trend` | daily plugin breakdown from `query_events` |
| `/api/usage/cost-comparison` | 30d actual spend vs alt-model pricing |
| `/api/model-attribution` | per-model turn/session split |
| `/api/skill-attribution` | per-skill cost attribution |

Successful fast-path responses carry `_source: "local_store"` so callers and tests can verify which path served the request. Legacy handler logic is untouched — only an early return is added.

## Test plan

- [x] `tests/test_usage_local_store.py` — 17 tests, all green
- [x] Positive case (env set + populated store) for every route
- [x] Negative case (env unset → legacy path runs, no `_source` tag) for every route
- [x] Plugin threshold-warning case for `/api/usage/by-plugin`
- [x] Existing local-store suites (`test_brain_local_store`, `test_heartbeat_local_store`, `test_sessions_by_type_local_store`, `test_local_store`) — 42/42 still green

```
$ pytest tests/test_usage_local_store.py -v
17 passed in 2.13s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)