### PR TITLE
feat(relay-v2): daemon dispatches heartbeat-piggybacked queries (Phase 1)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1774,9 +1774,18 @@ def send_heartbeat(config: dict) -> bool:
     last_err = None
     for attempt in range(3):
         try:
-            _post("/ingest/heartbeat", payload, config["api_key"])
+            resp_json = _post("/ingest/heartbeat", payload, config["api_key"])
             if attempt > 0:
                 log.info(f"Heartbeat succeeded after {attempt + 1} attempts")
+            # Phase 1 of relay-v2 (#1053): the cloud may piggyback a small
+            # batch of `pending_queries` on the heartbeat response. Each is
+            # a shape-allowlisted read against the local DuckDB; we run them,
+            # encrypt the result, and POST back to /ingest/cache so the
+            # cloud-side dashboard can serve subsequent requests from the
+            # warm cache without ever touching the local node.
+            pending = (resp_json or {}).get("pending_queries") or []
+            if pending:
+                _dispatch_pending_queries(config, pending)
             return True
         except Exception as e:
             last_err = e
@@ -1784,6 +1793,84 @@ def send_heartbeat(config: dict) -> bool:
                 time.sleep(2**attempt)  # 1s, 2s backoff
     log.warning(f"Heartbeat failed after 3 attempts: {last_err}")
     return False
+
+
+# ── Heartbeat-piggyback query dispatch (relay-v2 phase 1, #1053) ─────────────
+# Allowlist mirrors routes.local_query._SHAPES. Duplicated here so the
+# daemon stays safe when `routes/` isn't on sys.path (some installs run the
+# sync daemon without the dashboard module loaded).
+_PENDING_SHAPES = {"events", "sessions", "aggregates", "health", "transcript"}
+
+
+def _canonical_args_hash(args: dict) -> str:
+    """Stable sha256 of the args dict — sorted keys, no whitespace. Used as
+    the cache_key fingerprint so the cloud can detect arg drift even if the
+    same `cache_key` label is reused."""
+    import hashlib
+    canonical = json.dumps(args or {}, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _local_dispatch_fallback(shape: str, args: dict) -> dict:
+    """Fallback dispatcher used when `routes.local_query` isn't importable
+    (daemon-only installs). Mirrors the minimal shape→method bridge."""
+    from clawmetry import local_store
+    store = local_store.get_store(read_only=True)
+    if shape == "health":
+        return store.health()
+    method_map = {
+        "events":     "query_events",
+        "sessions":   "query_sessions",
+        "aggregates": "query_aggregates",
+        "transcript": "query_events",
+    }
+    method = method_map.get(shape)
+    if not method:
+        raise ValueError(f"unknown shape: {shape}")
+    rows = getattr(store, method)(**(args or {}))
+    return {"rows": rows, "count": len(rows), "_shape": shape, "_via": "fallback"}
+
+
+def _dispatch_pending_queries(config: dict, pending: list) -> None:
+    """Run each cloud-requested query against the local store, encrypt the
+    result, and POST back to /ingest/cache. Failures on individual queries
+    are swallowed (logged) so one bad query never blocks the rest."""
+    try:
+        from routes.local_query import _dispatch as _local_dispatch  # type: ignore
+    except Exception:
+        _local_dispatch = _local_dispatch_fallback
+    api_key = config.get("api_key", "")
+    enc_key = config.get("encryption_key")
+    node_id = config.get("node_id", "")
+    for q in pending or []:
+        try:
+            if not isinstance(q, dict):
+                continue
+            shape = q.get("shape")
+            if shape not in _PENDING_SHAPES:
+                continue  # defensive — cloud should have already filtered
+            qid = q.get("id")
+            cache_key = q.get("cache_key")
+            args = q.get("args") or {}
+            result = _local_dispatch(shape, args)
+            if not enc_key:
+                log.debug("pending_query %s: no encryption key; skipping", qid)
+                continue
+            blob = encrypt_payload(result, enc_key)
+            _post("/ingest/cache", {
+                "node_id": node_id,
+                "id": qid,
+                "cache_key": cache_key,
+                "blob": blob,
+                "shape": shape,
+                "args_hash": _canonical_args_hash(args),
+                "ttl": 3600,
+            }, api_key)
+        except Exception as e:
+            log.warning("pending_query dispatch failed (id=%s shape=%s): %s",
+                        (q or {}).get("id") if isinstance(q, dict) else None,
+                        (q or {}).get("shape") if isinstance(q, dict) else None,
+                        e)
 
 
 def _get_version() -> str:

--- a/tests/test_heartbeat_dispatch.py
+++ b/tests/test_heartbeat_dispatch.py
@@ -1,0 +1,252 @@
+"""Tests for heartbeat-piggyback query dispatch (relay-v2 phase 1, #1053).
+
+The cloud may attach `pending_queries` to its `/ingest/heartbeat` response.
+For each request the daemon runs the named shape against the local DuckDB,
+encrypts the result, and POSTs it back to `/ingest/cache` so the cloud-side
+dashboard can serve future requests warm.
+
+These tests mock `clawmetry.sync._post` to intercept HTTP and seed a tmp
+DuckDB with a few events so the dispatcher has real rows to return.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def sync_with_store(tmp_path, monkeypatch):
+    """Reload `clawmetry.sync` + `clawmetry.local_store` against a fresh
+    DuckDB seeded with a handful of events. Yields (sync_module, config)."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    # Fresh imports so the module-level _TRIAL_STATE / store singleton reset.
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+    sys.modules.pop("routes.local_query", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    # Seed a few events so query_events / query_sessions return real rows.
+    store = ls.get_store()
+    for i in range(3):
+        store.ingest({
+            "id": str(uuid.uuid4()),
+            "node_id": "agent+test",
+            "agent_id": "main",
+            "session_id": "sess-A",
+            "event_type": "tool_call",
+            "ts": f"2026-05-1{i+1}T10:00:00+00:00",
+            "data": {"tool": "Bash"},
+            "cost_usd": 0.001,
+            "token_count": 12,
+            "model": "claude-opus-4-7",
+        })
+    # Wait for the background flusher to drain the ring buffer so
+    # subsequent queries see the seed rows.
+    import time
+    for _ in range(80):
+        if store.health()["ring_depth"] == 0:
+            break
+        time.sleep(0.05)
+
+    config = {
+        "node_id":         "node-test",
+        "api_key":         "cm_test",
+        "encryption_key":  s.generate_encryption_key(),
+    }
+
+    yield s, config
+
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _hb_response(pending):
+    return {"sync_allowed": True, "pending_queries": pending}
+
+
+# ── 1. happy path: 2 pending queries → 2 cache POSTs ────────────────────────
+
+def test_pending_queries_dispatched(sync_with_store, monkeypatch):
+    s, config = sync_with_store
+    cache_posts = []
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/heartbeat":
+            return _hb_response([
+                {"id": "q1", "shape": "events",   "args": {"limit": 10},
+                 "cache_key": "events:limit=10"},
+                {"id": "q2", "shape": "sessions", "args": {"limit": 5},
+                 "cache_key": "sessions:limit=5"},
+            ])
+        if path == "/ingest/cache":
+            cache_posts.append(payload)
+            return {}
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(s, "_post", fake_post)
+    monkeypatch.setattr(s.time, "sleep", lambda *a, **kw: None)
+
+    ok = s.send_heartbeat(config)
+    assert ok is True
+    assert len(cache_posts) == 2
+    ids = {p["id"] for p in cache_posts}
+    assert ids == {"q1", "q2"}
+    for p in cache_posts:
+        assert p["node_id"] == "node-test"
+        assert p["ttl"] == 3600
+        assert p["shape"] in {"events", "sessions"}
+        assert isinstance(p["blob"], str) and len(p["blob"]) > 0
+        assert isinstance(p["args_hash"], str) and len(p["args_hash"]) == 64
+        # Blob is opaque ciphertext — must NOT contain plaintext markers.
+        assert "Bash" not in p["blob"]
+        assert "sess-A" not in p["blob"]
+
+
+# ── 2. unknown shape silently skipped ───────────────────────────────────────
+
+def test_unknown_shape_skipped(sync_with_store, monkeypatch):
+    s, config = sync_with_store
+    cache_posts = []
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/heartbeat":
+            return _hb_response([
+                {"id": "evil", "shape": "evil_shape",
+                 "args": {"q": "DROP TABLE"}, "cache_key": "evil"},
+            ])
+        if path == "/ingest/cache":
+            cache_posts.append(payload)
+            return {}
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(s, "_post", fake_post)
+    monkeypatch.setattr(s.time, "sleep", lambda *a, **kw: None)
+
+    ok = s.send_heartbeat(config)
+    assert ok is True
+    assert cache_posts == [], "evil_shape must be filtered before dispatch"
+
+
+# ── 3. one bad query doesn't kill the rest ──────────────────────────────────
+
+def test_dispatch_failure_doesnt_block_others(sync_with_store, monkeypatch):
+    s, config = sync_with_store
+    cache_posts = []
+
+    # Make the first query blow up inside _local_dispatch; the second must
+    # still POST to /ingest/cache.
+    real_dispatch = s._local_dispatch_fallback
+    call_count = {"n": 0}
+
+    def boom_then_real(shape, args):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("synthetic dispatch failure")
+        return real_dispatch(shape, args)
+
+    # Force the fallback path (skips routes.local_query) so we can intercept.
+    monkeypatch.setattr(s, "_local_dispatch_fallback", boom_then_real)
+    # Also break the routes import path so the daemon falls through to the
+    # fallback dispatcher.
+    sys.modules["routes.local_query"] = None  # type: ignore
+
+    try:
+        def fake_post(path, payload, api_key, timeout=45):
+            if path == "/ingest/heartbeat":
+                return _hb_response([
+                    {"id": "boom", "shape": "events",   "args": {},
+                     "cache_key": "boom"},
+                    {"id": "ok",   "shape": "sessions", "args": {},
+                     "cache_key": "ok"},
+                ])
+            if path == "/ingest/cache":
+                cache_posts.append(payload)
+                return {}
+            raise AssertionError(f"unexpected path {path}")
+
+        monkeypatch.setattr(s, "_post", fake_post)
+        monkeypatch.setattr(s.time, "sleep", lambda *a, **kw: None)
+
+        ok = s.send_heartbeat(config)
+        assert ok is True
+        assert len(cache_posts) == 1
+        assert cache_posts[0]["id"] == "ok"
+    finally:
+        sys.modules.pop("routes.local_query", None)
+
+
+# ── 4. no pending → no cache posts ──────────────────────────────────────────
+
+def test_no_pending_means_no_extra_posts(sync_with_store, monkeypatch):
+    s, config = sync_with_store
+    cache_posts = []
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/heartbeat":
+            return _hb_response([])
+        if path == "/ingest/cache":
+            cache_posts.append(payload)
+            return {}
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(s, "_post", fake_post)
+    monkeypatch.setattr(s.time, "sleep", lambda *a, **kw: None)
+
+    ok = s.send_heartbeat(config)
+    assert ok is True
+    assert cache_posts == []
+
+
+# ── 5. encrypt → decrypt round-trip preserves rows ──────────────────────────
+
+def test_encrypted_blob_decrypts_to_original(sync_with_store, monkeypatch):
+    s, config = sync_with_store
+    captured = {}
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/heartbeat":
+            return _hb_response([
+                {"id": "q1", "shape": "events", "args": {"limit": 50},
+                 "cache_key": "events:50"},
+            ])
+        if path == "/ingest/cache":
+            captured["payload"] = payload
+            return {}
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(s, "_post", fake_post)
+    monkeypatch.setattr(s.time, "sleep", lambda *a, **kw: None)
+
+    ok = s.send_heartbeat(config)
+    assert ok is True
+    assert "payload" in captured
+
+    blob = captured["payload"]["blob"]
+    decoded = s.decrypt_payload(blob, config["encryption_key"])
+    assert isinstance(decoded, dict)
+    assert "rows" in decoded
+    assert decoded["count"] == len(decoded["rows"])
+    # The seeded events should be present in the decrypted payload.
+    assert decoded["count"] >= 1
+    sessions = {r.get("session_id") for r in decoded["rows"]}
+    assert "sess-A" in sessions


### PR DESCRIPTION
## Summary
- Extend `send_heartbeat()` in `clawmetry/sync.py` to consume `pending_queries` from the cloud's `/ingest/heartbeat` response. For each request, dispatch the named shape against the local DuckDB, encrypt the result with the node's E2E key, and POST it back to `/ingest/cache` (TTL 3600s).
- Defensive: shape allowlist (`events`/`sessions`/`aggregates`/`health`/`transcript`), per-query try/except so one bad query never blocks the others, fallback dispatcher when `routes/local_query.py` isn't on `sys.path` (daemon-only installs).
- WS relay path (`clawmetry/relay.py`) untouched — stays as fallback per Phase 1 scope.

Part of #1053 (relay-v2 Phase 1). +88 LOC of production code, no new dependencies.

## Test plan
- [x] `python3 -m pytest tests/test_heartbeat_dispatch.py -q` — 5/5 pass
  - `test_pending_queries_dispatched` — 2 pending queries → 2 cache POSTs with encrypted blobs
  - `test_unknown_shape_skipped` — `evil_shape` silently filtered
  - `test_dispatch_failure_doesnt_block_others` — 1st query raises, 2nd still POSTed
  - `test_no_pending_means_no_extra_posts` — empty `pending_queries` → 0 cache POSTs
  - `test_encrypted_blob_decrypts_to_original` — encrypt→decrypt round-trip preserves rows
- [x] `python3 -m pytest tests/test_sync_trial_gating.py tests/test_heartbeat_dispatch.py -q` — 18/18 pass (no regression on existing sync tests)