### PR TITLE
feat(sessions): /api/transcript reads from local DuckDB (closes E2E gap)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -1578,10 +1578,110 @@ def api_transcripts():
     return jsonify({"transcripts": transcripts[:50]})
 
 
+def _try_local_store_transcript(session_id: str):
+    """Read a session transcript directly from the DuckDB events table.
+
+    Returns the same response shape as the JSONL parser. Returns ``None``
+    to defer to the JSONL fallback if the local_store module isn't importable,
+    the events table has no rows for this session, or anything raises.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = store.query_events(session_id=session_id, limit=10000)
+    except Exception:
+        return None
+    if not rows:
+        return None
+    # query_events returns DESC by ts; transcripts read forward.
+    rows = list(reversed(rows))
+    messages: list[dict] = []
+    model = None
+    total_tokens = 0
+    first_ts = None
+    last_ts = None
+    for ev in rows:
+        obj = ev.get("data")
+        if not isinstance(obj, dict):
+            continue
+        role = obj.get("role", obj.get("type", "unknown"))
+        content = obj.get("content", "")
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    parts.append(part.get("text", str(part)))
+                else:
+                    parts.append(str(part))
+            content = "\n".join(parts)
+        elif not isinstance(content, str):
+            content = str(content) if content else ""
+        if obj.get("tool_calls") or obj.get("tool_use"):
+            tools = obj.get("tool_calls") or obj.get("tool_use") or []
+            if isinstance(tools, list):
+                for tc in tools:
+                    tname = tc.get("name", tc.get("function", {}).get("name", "tool"))
+                    messages.append({
+                        "role": "tool",
+                        "content": f"[Tool Call: {tname}]\n{json.dumps(tc.get('input', tc.get('arguments', {})), indent=2)[:500]}",
+                        "timestamp": obj.get("timestamp") or obj.get("time"),
+                    })
+        if role == "tool_result":
+            role = "tool"
+        ts = obj.get("timestamp") or obj.get("time") or obj.get("created_at") or ev.get("ts")
+        ts_ms = None
+        if ts:
+            if isinstance(ts, (int, float)):
+                ts_ms = int(ts * 1000) if ts < 1e12 else int(ts)
+            else:
+                try:
+                    ts_ms = int(
+                        datetime.fromisoformat(str(ts).replace("Z", "+00:00")).timestamp() * 1000
+                    )
+                except Exception:
+                    ts_ms = None
+            if ts_ms:
+                if not first_ts or ts_ms < first_ts:
+                    first_ts = ts_ms
+                if not last_ts or ts_ms > last_ts:
+                    last_ts = ts_ms
+        if not model:
+            model = obj.get("model") or ev.get("model")
+        usage = obj.get("usage", {})
+        if isinstance(usage, dict):
+            total_tokens += usage.get("total_tokens", 0) or (
+                usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
+            )
+        if content or role in ("user", "assistant", "system"):
+            messages.append({"role": role, "content": content, "timestamp": ts_ms})
+    duration = None
+    if first_ts and last_ts and last_ts > first_ts:
+        dur_sec = (last_ts - first_ts) / 1000
+        if dur_sec < 60:
+            duration = f"{dur_sec:.0f}s"
+        elif dur_sec < 3600:
+            duration = f"{dur_sec / 60:.0f}m"
+        else:
+            duration = f"{dur_sec / 3600:.1f}h"
+    return {
+        "name": session_id[:40],
+        "messageCount": len(messages),
+        "model": model,
+        "totalTokens": total_tokens,
+        "duration": duration,
+        "messages": messages[:500],
+        "_source": "local_store",
+    }
+
+
 @bp_sessions.route("/api/transcript/<session_id>")
 def api_transcript(session_id):
     """Parse and return a session transcript for the chat viewer."""
     import dashboard as _d
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_transcript(session_id)
+        if fast is not None:
+            return jsonify(fast)
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )

--- a/tests/test_transcript_local_store.py
+++ b/tests/test_transcript_local_store.py
@@ -1,0 +1,147 @@
+"""Tests for the /api/transcript/<sid> local-store fast path.
+
+Closes the explicit MOAT gap surfaced in the real-OpenClaw E2E pipeline:
+the transcript endpoint used to read JSONL directly, bypassing DuckDB.
+
+Pattern matches test_sessions_local_fastpath.py:
+- CLAWMETRY_LOCAL_STORE_READ=1 + populated events → returns from DuckDB
+- Flag unset → falls through to legacy JSONL path
+- No events for the session → falls through (so the JSONL path can still serve)
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _ev(event_id, sid, role, content, ts, **extra):
+    obj = {"role": role, "content": content, "timestamp": ts, **extra}
+    return {
+        "id": event_id,
+        "node_id": "node-test",
+        "agent_id": "main",
+        "session_id": sid,
+        "event_type": "message" if role in ("user", "assistant") else role,
+        "ts": ts,
+        "data": json.dumps(obj),
+    }
+
+
+def _drain(store):
+    """Force the ring buffer to flush so the events table is populated."""
+    store._flush_now()
+    # Allow the background flusher one tick.
+    for _ in range(10):
+        if not store._ring:
+            break
+        time.sleep(0.05)
+
+
+def test_transcript_fast_path_returns_local_rows(app):
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-transcript-A"
+    store.ingest(_ev("e1", sid, "user", "hello", "2026-05-12T10:00:00Z"))
+    store.ingest(_ev("e2", sid, "assistant", "hi there",
+                     "2026-05-12T10:00:05Z", model="claude-opus-4-7",
+                     usage={"input_tokens": 12, "output_tokens": 5}))
+    store.ingest(_ev("e3", sid, "user", "what is 2+2?", "2026-05-12T10:00:10Z"))
+    store.ingest(_ev("e4", sid, "assistant", "4",
+                     "2026-05-12T10:00:15Z",
+                     usage={"input_tokens": 8, "output_tokens": 1}))
+    _drain(store)
+
+    c = a.test_client()
+    r = c.get(f"/api/transcript/{sid}")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["messageCount"] == 4
+    assert body["model"] == "claude-opus-4-7"
+    assert body["totalTokens"] == 26
+    # Ascending timeline preserved.
+    roles = [m["role"] for m in body["messages"]]
+    assert roles == ["user", "assistant", "user", "assistant"]
+    contents = [m["content"] for m in body["messages"]]
+    assert contents == ["hello", "hi there", "what is 2+2?", "4"]
+    # Duration: 15s between first and last.
+    assert body["duration"] == "15s"
+
+
+def test_transcript_fast_path_emits_tool_call_messages(app):
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-transcript-tool"
+    store.ingest(_ev("t1", sid, "assistant", "let me check",
+                     "2026-05-12T10:00:00Z",
+                     tool_calls=[{"name": "Bash", "input": {"cmd": "ls"}}]))
+    _drain(store)
+
+    c = a.test_client()
+    r = c.get(f"/api/transcript/{sid}")
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    # tool message inserted before the assistant message
+    tool_msgs = [m for m in body["messages"] if m["role"] == "tool"]
+    assert len(tool_msgs) == 1
+    assert "[Tool Call: Bash]" in tool_msgs[0]["content"]
+    assert "ls" in tool_msgs[0]["content"]
+
+
+def test_transcript_fast_path_falls_back_when_session_empty(app, tmp_path, monkeypatch):
+    """Unknown session → fast path returns None → legacy path runs and 404s
+    because no JSONL exists."""
+    a, _ = app
+    # Point dashboard.SESSIONS_DIR at an empty directory so the legacy
+    # path's existence check fails and we get a 404 (not a crash).
+    import dashboard as _d
+    monkeypatch.setattr(_d, "SESSIONS_DIR", str(tmp_path / "no-such-dir"), raising=False)
+    c = a.test_client()
+    r = c.get("/api/transcript/sess-doesnt-exist")
+    assert r.status_code == 404
+
+
+def test_transcript_fast_path_off_when_flag_unset(app, monkeypatch):
+    a, ls = app
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+    store = ls.get_store()
+    sid = "sess-off"
+    store.ingest(_ev("o1", sid, "user", "should not be served from duckdb",
+                     "2026-05-12T11:00:00Z"))
+    _drain(store)
+
+    # Without the flag, the route falls through to the JSONL path which
+    # 404s because no file exists. Verify the response is NOT tagged with
+    # _source=local_store.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "SESSIONS_DIR", "/tmp/no-such-dir-here", raising=False)
+    c = a.test_client()
+    r = c.get(f"/api/transcript/{sid}")
+    assert r.status_code == 404
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"


### PR DESCRIPTION
## Summary

Closes the explicit MOAT gap surfaced by the real-OpenClaw → daemon → DuckDB → API E2E pipeline (PR #1050): \`/api/transcript/<session_id>\` used to read JSONL directly, bypassing the local DuckDB store.

After this PR, when \`CLAWMETRY_LOCAL_STORE_READ=1\`:
- transcript fast-path serves from \`events\` table via existing \`query_events(session_id=...)\`
- response tagged \`_source: "local_store"\`
- falls through to JSONL when no rows exist for the session (zero-change default)

Same opt-in pattern as the 23 other \`_try_local_store_*\` endpoints. Brings DuckDB-backed endpoint coverage to **24/24**.

## Test plan

4 new tests in \`tests/test_transcript_local_store.py\`:
- [x] Fast path returns local rows + correct messageCount/model/tokens/duration + ascending timeline
- [x] Tool-call events emit synthetic "tool" messages with truncated args
- [x] Unknown session falls through to legacy 404 (proves graceful fallback)
- [x] Flag unset → bypasses fast path entirely

Regression: 26/26 in \`test_sessions_local_fastpath.py\` + \`test_sessions_by_type_local_store.py\` + \`test_e2e_real_openclaw_pipeline.py\` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)