### PR TITLE
feat(routes): tier-1 DuckDB fast paths — 4 endpoints onto local store

### DIFF
--- a/routes/advisor.py
+++ b/routes/advisor.py
@@ -98,6 +98,89 @@ def _summarise_event(ev: dict) -> str:
     return f"[{t}] {src} {typ}: {detail}"
 
 
+def _try_local_store_advisor_context(limit_events: int = MAX_CONTEXT_EVENTS) -> dict | None:
+    """Tier-1 DuckDB fast path for advisor context assembly.
+
+    Reads recent events directly from the local store and emits the same
+    ``{events, usage, recent_sessions, _source}`` shape ``_gather_context``
+    produces from JSONL+brain-history. Used when CLAWMETRY_LOCAL_STORE_READ=1
+    is set so the advisor stays on the same data plane the rest of the
+    fast-path-enabled dashboard uses.
+
+    Returns ``None`` to defer to the legacy gather when:
+      - the ``local_store`` module isn't importable
+      - the events table is empty
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return None
+    try:
+        store = local_store.get_store()
+        rows = store.query_events(limit=limit_events)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    events: list[str] = []
+    sessions_seen: dict[str, dict] = {}
+    today_str = time.strftime("%Y-%m-%d")
+    today_tokens = 0
+
+    for r in rows:
+        t = (r.get("ts") or "")[:19]
+        typ = r.get("event_type") or "?"
+        sid = r.get("session_id") or "main"
+        data = r.get("data") if isinstance(r, dict) else None
+        if isinstance(data, dict):
+            detail = (data.get("input") or data.get("summary")
+                      or data.get("text") or data.get("name") or "")
+        elif isinstance(data, str):
+            detail = data
+        else:
+            detail = ""
+        if isinstance(detail, (dict, list)):
+            try:
+                detail = json.dumps(detail)[:160]
+            except Exception:
+                detail = str(detail)[:160]
+        detail = str(detail).replace("\n", " ")[:200]
+        events.append(f"[{t}] {sid[:12]} {typ}: {detail}")
+
+        sid_key = r.get("session_id") or ""
+        if sid_key:
+            entry = sessions_seen.setdefault(sid_key, {
+                "session_id": sid_key[:8],
+                "model": r.get("model") or "",
+                "tokens": 0,
+                "cost_usd": 0.0,
+                "started_at": t,
+            })
+            entry["tokens"] += int(r.get("token_count") or 0)
+            try:
+                entry["cost_usd"] = round(entry["cost_usd"] + float(r.get("cost_usd") or 0), 4)
+            except Exception:
+                pass
+            if r.get("model") and not entry["model"]:
+                entry["model"] = r["model"]
+            if t and (not entry["started_at"] or t < entry["started_at"]):
+                entry["started_at"] = t
+        if t.startswith(today_str):
+            today_tokens += int(r.get("token_count") or 0)
+
+    return {
+        "events": events[-limit_events:],
+        "usage": {
+            "today_tokens": today_tokens,
+            "total_sessions": len(sessions_seen),
+        },
+        "recent_sessions": list(sessions_seen.values())[:8],
+        "_source": "local_store",
+    }
+
+
 def _gather_context(limit_events: int = MAX_CONTEXT_EVENTS) -> dict:
     """Pull a compact snapshot of the user's current agent state.
 
@@ -105,6 +188,16 @@ def _gather_context(limit_events: int = MAX_CONTEXT_EVENTS) -> dict:
     nothing new computed, just packaged for the LLM.
     """
     import dashboard as _d
+
+    # Tier-1 DuckDB fast path — opt-in via CLAWMETRY_LOCAL_STORE_READ=1.
+    # The legacy gather already calls into the brain endpoint (which has its
+    # own fast path), but this short-circuit keeps the advisor on a single
+    # data plane and avoids the cross-route Flask test_request_context dance
+    # when the local store is the source of truth.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_advisor_context(limit_events)
+        if fast is not None:
+            return fast
 
     out: dict = {"events": [], "usage": {}, "errors": []}
 
@@ -325,20 +418,51 @@ def api_advisor_ask():
 
     answer = _extract_answer(resp)
     usage = resp.get("usage") or {}
-    return jsonify(
-        {
-            "answer": answer or "(no answer returned)",
-            "model": resp.get("model", DEFAULT_MODEL),
-            "input_tokens": usage.get("input_tokens", 0),
-            "output_tokens": usage.get("output_tokens", 0),
-            "events_in_context": len(ctx.get("events", [])),
-        }
-    )
+    body = {
+        "answer": answer or "(no answer returned)",
+        "model": resp.get("model", DEFAULT_MODEL),
+        "input_tokens": usage.get("input_tokens", 0),
+        "output_tokens": usage.get("output_tokens", 0),
+        "events_in_context": len(ctx.get("events", [])),
+    }
+    # Surface the data-plane the advisor used so audits/UIs can confirm
+    # the advisor is on the local store when the fast path was taken.
+    if ctx.get("_source") == "local_store":
+        body["_source"] = "local_store"
+    return jsonify(body)
+
+
+def _try_local_store_advisor_status() -> dict | None:
+    """Tier-1 DuckDB fast path for /api/advisor/status.
+
+    Returns the probe payload tagged ``_source: local_store`` when the
+    local store is reachable. The status probe doesn't actually need event
+    data — it's auth-presence only — but we still surface the fast-path
+    flag so the UI/audits can confirm the advisor is on the local plane.
+
+    Returns ``None`` to defer when local_store import fails or any error.
+    """
+    try:
+        from clawmetry import local_store
+        local_store.get_store()  # smoke check — raises if DuckDB inaccessible
+    except Exception:
+        return None
+    mode, credential = _load_anthropic_auth()
+    return {
+        "available": bool(credential),
+        "auth_mode": mode or "none",
+        "model":     DEFAULT_MODEL,
+        "_source":   "local_store",
+    }
 
 
 @bp_advisor.route("/api/advisor/status")
 def api_advisor_status():
     """Cheap probe so the UI can decide whether to show the input."""
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_advisor_status()
+        if fast is not None:
+            return jsonify(fast)
     mode, credential = _load_anthropic_auth()
     return jsonify(
         {

--- a/routes/autonomy.py
+++ b/routes/autonomy.py
@@ -9,6 +9,8 @@ Blueprint: bp_autonomy
 Endpoint:  GET /api/autonomy
 """
 
+from __future__ import annotations
+
 import json
 import math
 import os
@@ -272,6 +274,156 @@ def _empty_response() -> dict:
     }
 
 
+def _try_local_store_autonomy() -> dict | None:
+    """Tier-1 DuckDB fast path for /api/autonomy.
+
+    Reads ``message`` events from the local store, filters to user-role
+    messages within the last 7 days, and runs the same per-session gap
+    aggregation the JSONL parser does. Returns the canonical autonomy
+    payload (score / median_gap / autonomy_ratio / trend / series_daily)
+    plus ``"_source": "local_store"``.
+
+    Returns ``None`` to defer to the legacy fallback if:
+      - the ``local_store`` module isn't importable
+      - the events table has no qualifying user messages
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return None
+    try:
+        store = local_store.get_store()
+        rows = store.query_events(event_type="message", limit=5000)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    now_utc = datetime.now(tz=timezone.utc)
+    cutoff_ts = now_utc.timestamp() - 7 * 86400
+
+    # session_id → sorted list of user-msg unix timestamps (within the window)
+    per_session: dict[str, list[float]] = defaultdict(list)
+    for r in rows:
+        ts_str = r.get("ts") or ""
+        if not ts_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
+        except Exception:
+            continue
+        if ts < cutoff_ts:
+            continue
+        data = r.get("data") if isinstance(r, dict) else None
+        if not isinstance(data, dict):
+            continue
+        msg = data.get("message") if isinstance(data.get("message"), dict) else data
+        role = msg.get("role") if isinstance(msg, dict) else None
+        if role != "user":
+            continue
+        sid = r.get("session_id") or ""
+        per_session[sid].append(ts)
+
+    if not per_session:
+        return None
+
+    daily: dict = defaultdict(lambda: {
+        "gaps": [], "no_nudge_sessions": 0, "sessions": 0, "user_msgs": 0,
+    })
+    all_gaps: list = []
+    total_sessions_7d = 0
+    no_nudge_sessions_7d = 0
+    total_user_msgs_7d = 0
+
+    for sid, stamps in per_session.items():
+        stamps.sort()
+        total_sessions_7d += 1
+        session_gaps = [
+            stamps[i + 1] - stamps[i]
+            for i in range(len(stamps) - 1)
+            if stamps[i + 1] - stamps[i] > 0
+        ]
+        is_no_nudge = len(stamps) <= 1
+        if is_no_nudge:
+            no_nudge_sessions_7d += 1
+        total_user_msgs_7d += len(stamps)
+        all_gaps.extend(session_gaps)
+        day_key = datetime.fromtimestamp(stamps[0], tz=timezone.utc).strftime("%Y-%m-%d")
+        daily[day_key]["gaps"].extend(session_gaps)
+        daily[day_key]["sessions"] += 1
+        daily[day_key]["user_msgs"] += len(stamps)
+        if is_no_nudge:
+            daily[day_key]["no_nudge_sessions"] += 1
+
+    if total_sessions_7d == 0:
+        return None
+
+    median_gap = _median_safe(all_gaps)
+    autonomy_ratio = (no_nudge_sessions_7d / total_sessions_7d) if total_sessions_7d else None
+
+    series_daily = []
+    import datetime as _dt_mod
+    for offset in range(6, -1, -1):
+        day_dt = now_utc - _dt_mod.timedelta(days=offset)
+        day_str = day_dt.strftime("%Y-%m-%d")
+        bucket = daily.get(day_str)
+        if bucket and bucket["sessions"] > 0:
+            day_median = _median_safe(bucket["gaps"])
+            day_ratio = (bucket["no_nudge_sessions"] / bucket["sessions"]
+                         if bucket["sessions"] else None)
+            series_daily.append({
+                "day": day_str,
+                "median_gap_sec": day_median,
+                "autonomy_ratio": day_ratio,
+                "sessions": bucket["sessions"],
+            })
+        else:
+            series_daily.append({
+                "day": day_str,
+                "median_gap_sec": None,
+                "autonomy_ratio": None,
+                "sessions": 0,
+            })
+
+    xs, ys = [], []
+    for i, entry in enumerate(series_daily):
+        if entry["median_gap_sec"] is not None:
+            xs.append(float(i))
+            ys.append(entry["median_gap_sec"])
+
+    trend_slope_7d = 0.0
+    if len(xs) >= 2:
+        raw_slope = _linear_slope(xs, ys)
+        if median_gap and median_gap > 0:
+            trend_slope_7d = raw_slope / median_gap
+    if trend_slope_7d > 0.02:
+        trend_direction = "improving"
+    elif trend_slope_7d < -0.02:
+        trend_direction = "declining"
+    else:
+        trend_direction = "flat"
+
+    try:
+        ar = autonomy_ratio if autonomy_ratio is not None else 0.0
+        tanh_part = math.tanh(trend_slope_7d * 10) * 0.5
+        raw_score = 0.5 * ar + tanh_part + 0.5
+        score = max(0.0, min(1.0, raw_score))
+    except Exception:
+        score = 0.0
+
+    return {
+        "score": round(score, 4),
+        "median_gap_seconds_7d": median_gap,
+        "autonomy_ratio_7d": autonomy_ratio,
+        "trend_slope_7d": round(trend_slope_7d, 6),
+        "trend_direction": trend_direction,
+        "samples_7d": total_user_msgs_7d,
+        "series_daily": series_daily,
+        "_source": "local_store",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Route
 # ---------------------------------------------------------------------------
@@ -283,6 +435,17 @@ def api_autonomy():
     cached = _AUTONOMY_CACHE.get("data")
     if cached is not None and (now - float(_AUTONOMY_CACHE.get("ts") or 0)) < _AUTONOMY_CACHE_TTL_SECONDS:
         return jsonify(cached)
+
+    # Tier-1 DuckDB fast path — opt-in via CLAWMETRY_LOCAL_STORE_READ=1.
+    # Falls through to legacy JSONL scan when the flag is unset, the store
+    # is empty, or no qualifying user messages exist in the 7-day window.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_autonomy()
+        if fast is not None:
+            _AUTONOMY_CACHE["data"] = fast
+            _AUTONOMY_CACHE["ts"] = now
+            return jsonify(fast)
+
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )

--- a/routes/components.py
+++ b/routes/components.py
@@ -34,6 +34,125 @@ _api_tool_cache = {}
 _api_tool_cache_time = {}
 
 
+# Map tool key to tool names in transcripts (also used by the local-store
+# fast path so the fast path stays in lock-step with the legacy parser).
+_TOOL_MAP = {
+    "session": [
+        "sessions_spawn",
+        "sessions_send",
+        "sessions_list",
+        "sessions_poll",
+    ],
+    "exec": ["exec", "process"],
+    "browser": ["browser", "web_fetch"],
+    "search": ["web_search"],
+    "cron": ["cron"],
+    "tts": ["tts"],
+    "memory": ["Read", "read", "Write", "write", "Edit", "edit"],
+}
+
+
+def _try_local_store_component_tool(name: str):
+    """Tier-1 DuckDB fast path for /api/component/tool/<name>.
+
+    Reads ``tool_call`` events from the local store, filters to today + the
+    requested tool family, and shapes them into the same response the legacy
+    JSONL parser returns (``{events, stats, total, name}``).
+
+    Returns ``None`` to defer to the legacy fallback if:
+      - the ``local_store`` module isn't importable
+      - the events table is empty / has no matches
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return None
+    try:
+        store = local_store.get_store()
+        rows = store.query_events(event_type="tool_call", limit=2000)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    tool_names = set(_TOOL_MAP.get(name, [name]))
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    events = []
+    today_calls = 0
+    today_errors = 0
+    for r in rows:
+        ts = (r.get("ts") or "")
+        if not ts.startswith(today):
+            continue
+        data = r.get("data") if isinstance(r, dict) else None
+        # `data` can be dict (preferred), str, or None
+        tn = ""
+        args = {}
+        status = "ok"
+        if isinstance(data, dict):
+            tn = data.get("name") or data.get("tool") or ""
+            args = data.get("arguments") or data.get("input") or {}
+            if not isinstance(args, dict):
+                args = {"_raw": str(args)[:200]}
+            if data.get("isError") or (isinstance(data.get("result"), dict)
+                                       and data["result"].get("status") == "error"):
+                status = "error"
+        if not tn or tn not in tool_names:
+            continue
+
+        today_calls += 1
+        if status == "error":
+            today_errors += 1
+
+        evt = {"timestamp": ts, "status": status, "tool": tn}
+        if name == "exec":
+            evt["detail"] = (args.get("command") or str(args))[:200]
+            evt["action"] = "exec"
+        elif name == "browser":
+            evt["action"] = args.get("action", "unknown")
+            evt["detail"] = (args.get("targetUrl") or args.get("url")
+                             or args.get("selector") or evt["action"])
+        elif name == "search":
+            evt["detail"] = args.get("query", "?")
+            evt["action"] = "search"
+        elif name == "tts":
+            evt["detail"] = (args.get("text") or "")[:100]
+            evt["action"] = "tts"
+            evt["voice"] = args.get("voice", "")
+        elif name == "memory":
+            path = args.get("file_path") or args.get("path") or "?"
+            evt["detail"] = path
+            evt["action"] = ("write" if tn in ("Write", "write", "Edit", "edit")
+                             else "read")
+        elif name == "session":
+            evt["detail"] = (args.get("sessionId") or args.get("name") or tn)
+            evt["action"] = tn
+            evt["session_status"] = "running"
+        elif name == "cron":
+            evt["detail"] = (args.get("expr") or args.get("action")
+                             or str(args)[:80])
+            evt["action"] = "cron"
+        else:
+            evt["detail"] = str(args)[:120]
+            evt["action"] = tn
+        events.append(evt)
+
+    if not events:
+        return None
+
+    events.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
+    events = events[:50]
+    return {
+        "name":    name,
+        "stats":   {"today_calls": today_calls, "today_errors": today_errors},
+        "events":  events,
+        "total":   today_calls,
+        "_source": "local_store",
+    }
+
+
 @bp_components.route("/api/component/tool/<name>")
 def api_component_tool(name):
     """Parse session transcripts for tool-specific events. Cached for 15s."""
@@ -43,6 +162,16 @@ def api_component_tool(name):
     now = _time.time()
     if name in _api_tool_cache and (now - _api_tool_cache_time.get(name, 0)) < 15:
         return jsonify(_api_tool_cache[name])
+
+    # Tier-1 DuckDB fast path — opt-in via CLAWMETRY_LOCAL_STORE_READ=1.
+    # Falls through to legacy JSONL parser when flag is unset, store is
+    # empty, or no matching events for `name`.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_component_tool(name)
+        if fast is not None:
+            _api_tool_cache[name] = fast
+            _api_tool_cache_time[name] = now
+            return jsonify(fast)
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )
@@ -971,6 +1100,143 @@ def api_component_gateway():
     return jsonify({"routes": page, "stats": stats, "total": total})
 
 
+def _try_local_store_component_brain(limit: int, offset: int):
+    """Tier-1 DuckDB fast path for /api/component/brain.
+
+    Reads ``message`` events from the local store (assistant turns carry
+    LLM usage), filters to today, and shapes them into the same
+    ``{stats, calls, total}`` payload the legacy JSONL parser returns.
+
+    Returns ``None`` to defer to the legacy fallback if:
+      - the ``local_store`` module isn't importable
+      - the events table is empty / no qualifying calls today
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return None
+    try:
+        store = local_store.get_store()
+        # Pull a generous window — events are filtered down by ts/usage below.
+        rows = store.query_events(event_type="message", limit=2000)
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    calls = []
+    total_input = 0
+    total_output = 0
+    total_cache_read = 0
+    total_cache_write = 0
+    total_cost = 0.0
+    durations = []
+    models_seen = set()
+
+    for r in rows:
+        ts = (r.get("ts") or "")
+        if not ts.startswith(today):
+            continue
+        data = r.get("data") if isinstance(r, dict) else None
+        if not isinstance(data, dict):
+            continue
+        msg = data.get("message") if isinstance(data.get("message"), dict) else data
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") and msg.get("role") != "assistant":
+            continue
+        usage = msg.get("usage")
+        if not isinstance(usage, dict):
+            continue
+
+        model = msg.get("model") or r.get("model") or "unknown"
+        models_seen.add(model)
+        tokens_in = (usage.get("input", 0) + usage.get("cacheRead", 0)
+                     + usage.get("cacheWrite", 0))
+        tokens_out = usage.get("output", 0)
+        cache_read = usage.get("cacheRead", 0)
+        cache_write = usage.get("cacheWrite", 0)
+        cost_data = usage.get("cost", {})
+        call_cost = (float(cost_data.get("total", 0))
+                     if isinstance(cost_data, dict) else 0.0)
+        if call_cost == 0 and r.get("cost_usd"):
+            try:
+                call_cost = float(r["cost_usd"])
+            except Exception:
+                pass
+
+        has_thinking = False
+        tools_used = []
+        for c in msg.get("content") or []:
+            if isinstance(c, dict):
+                if c.get("type") == "thinking":
+                    has_thinking = True
+                elif c.get("type") == "toolCall":
+                    tn = c.get("name", "")
+                    if tn and tn not in tools_used:
+                        tools_used.append(tn)
+
+        total_input += usage.get("input", 0)
+        total_output += tokens_out
+        total_cache_read += cache_read
+        total_cache_write += cache_write
+        total_cost += call_cost
+
+        sid = r.get("session_id") or ""
+        session_label = "subagent:" + sid[:8] if "subagent" in sid.lower() else "main"
+
+        calls.append({
+            "timestamp":   ts,
+            "model":       model,
+            "tokens_in":   tokens_in,
+            "tokens_out":  tokens_out,
+            "cache_read":  cache_read,
+            "cache_write": cache_write,
+            "thinking":    has_thinking,
+            "cost":        "${:.4f}".format(call_cost),
+            "cost_raw":    call_cost,
+            "tools_used":  tools_used,
+            "duration_ms": 0,
+            "session":     session_label,
+            "stop_reason": msg.get("stopReason", ""),
+        })
+
+    if not calls:
+        return None
+
+    calls.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
+    total = len(calls)
+    avg_ms = int(sum(durations) / len(durations)) if durations else 0
+    primary_model = (
+        max(models_seen, key=lambda m: sum(1 for c in calls if c["model"] == m))
+        if models_seen else "unknown"
+    )
+    thinking_count = sum(1 for c in calls if c.get("thinking"))
+    cache_hit_count = sum(1 for c in calls if c.get("cache_read", 0) > 0)
+
+    return {
+        "stats": {
+            "today_calls":     total,
+            "today_tokens":    {
+                "input":       total_input,
+                "output":      total_output,
+                "cache_read":  total_cache_read,
+                "cache_write": total_cache_write,
+            },
+            "today_cost":      "${:.2f}".format(total_cost),
+            "model":           primary_model,
+            "avg_response_ms": avg_ms,
+            "thinking_calls":  thinking_count,
+            "cache_hits":      cache_hit_count,
+        },
+        "calls":   calls[offset: offset + limit],
+        "total":   total,
+        "_source": "local_store",
+    }
+
+
 @bp_components.route("/api/component/brain")
 def api_component_brain():
     """Parse session transcripts for LLM API call details."""
@@ -978,6 +1244,14 @@ def api_component_brain():
 
     limit = int(request.args.get("limit", 50))
     offset = int(request.args.get("offset", 0))
+
+    # Tier-1 DuckDB fast path — opt-in via CLAWMETRY_LOCAL_STORE_READ=1.
+    # Falls through to legacy JSONL parser when flag is unset, store is
+    # empty, or no qualifying assistant turns are present.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_component_brain(limit, offset)
+        if fast is not None:
+            return jsonify(fast)
 
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"

--- a/routes/reasoning.py
+++ b/routes/reasoning.py
@@ -10,12 +10,19 @@ Returns a structured breakdown of thinking blocks parsed from session JSONL:
 - Summary: aggregate token/efficiency stats across all chains
 """
 
+from __future__ import annotations
+
 import glob
 import json
 import os
 import re
 
 from flask import Blueprint, jsonify, request
+
+# Tier-1 DuckDB fast path: enable by exporting CLAWMETRY_LOCAL_STORE_READ=1.
+# When set, /api/reasoning reads thinking blocks from the local events
+# table instead of scanning JSONL on disk. Falls through cleanly when
+# the store is empty or local_store is unimportable.
 
 bp_reasoning = Blueprint("reasoning", __name__)
 
@@ -169,12 +176,119 @@ def _parse_session_reasoning(session_id):
     return chains
 
 
+def _try_local_store_reasoning(session_id: str):
+    """Tier-1 DuckDB fast path for /api/reasoning.
+
+    Reads ``message`` events for the requested ``session_id`` from the
+    local store, extracts thinking/text blocks from each assistant turn,
+    and returns the same ``{session_id, chains, summary, _source}`` shape
+    the legacy JSONL parser produces.
+
+    Returns ``None`` to defer to the legacy fallback if:
+      - the ``local_store`` module isn't importable
+      - no message events exist for this session
+      - no thinking blocks are present (chains would be empty)
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return None
+    try:
+        store = local_store.get_store()
+        rows = store.query_events(
+            session_id=session_id, event_type="message", limit=2000,
+        )
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    # query_events returns most-recent-first; reasoning chains read forward
+    # in time (legacy parser walks the JSONL top-to-bottom).
+    rows = list(reversed(rows))
+    chains = []
+    for r in rows:
+        data = r.get("data") if isinstance(r, dict) else None
+        if not isinstance(data, dict):
+            continue
+        msg = data.get("message") if isinstance(data.get("message"), dict) else data
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") and msg.get("role") != "assistant":
+            continue
+        content_obj = msg.get("content")
+        if not isinstance(content_obj, list):
+            continue
+
+        thinking_blocks = []
+        answer_word_count = 0
+        for block in content_obj:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "thinking":
+                tt = block.get("thinking", "")
+                if tt:
+                    thinking_blocks.append(tt)
+            elif btype == "text":
+                text = block.get("text", "") or ""
+                answer_word_count += len(text.split())
+
+        ts = r.get("ts") or ""
+        for thinking_text in thinking_blocks:
+            steps = _segment_thinking(thinking_text)
+            thinking_word_count = sum(s["word_count"] for s in steps)
+            thinking_tokens = int(thinking_word_count * 1.3)
+            answer_tokens = int(answer_word_count * 1.3)
+            efficiency_ratio = (
+                round(thinking_tokens / answer_tokens, 1) if answer_tokens > 0 else 0.0
+            )
+            chains.append({
+                "timestamp":        ts,
+                "thinking_tokens":  thinking_tokens,
+                "answer_tokens":    answer_tokens,
+                "efficiency_ratio": efficiency_ratio,
+                "steps":            steps,
+                "raw_thinking":     thinking_text,
+            })
+
+    if not chains:
+        return None
+
+    total_thinking_tokens = sum(c["thinking_tokens"] for c in chains)
+    total_answer_tokens = sum(c["answer_tokens"] for c in chains)
+    avg_efficiency = (
+        round(total_thinking_tokens / total_answer_tokens, 1)
+        if total_answer_tokens > 0 else 0.0
+    )
+    return {
+        "session_id": session_id,
+        "chains":     chains,
+        "summary": {
+            "total_thinking_tokens": total_thinking_tokens,
+            "total_answer_tokens":   total_answer_tokens,
+            "avg_efficiency":        avg_efficiency,
+            "chain_count":           len(chains),
+        },
+        "_source": "local_store",
+    }
+
+
 @bp_reasoning.route("/api/reasoning")
 def api_reasoning():
     """Return structured reasoning chains for a session."""
     session_id = request.args.get("session", "").strip()
     if not session_id:
         return jsonify({"error": "session parameter required"}), 400
+
+    # Tier-1 DuckDB fast path — opt-in via CLAWMETRY_LOCAL_STORE_READ=1.
+    # Falls through to legacy JSONL parser when flag is unset, the store
+    # has no events for this session, or no thinking blocks are present.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_reasoning(session_id)
+        if fast is not None:
+            return jsonify(fast)
 
     chains = _parse_session_reasoning(session_id)
 

--- a/tests/test_tier1_local_store.py
+++ b/tests/test_tier1_local_store.py
@@ -1,0 +1,429 @@
+"""Tests for the Tier-1 DuckDB fast paths added to four route modules.
+
+Covers the routes the migration touched under
+``CLAWMETRY_LOCAL_STORE_READ=1``:
+
+  * routes/components.py — /api/component/tool/<name>, /api/component/brain
+    (other component routes intentionally NOT migrated — see PR body)
+  * routes/autonomy.py   — /api/autonomy
+  * routes/advisor.py    — /api/advisor/ask, /api/advisor/status
+  * routes/reasoning.py  — /api/reasoning?session=<id>
+
+Each route gets:
+  1. positive case — env flag set + populated store → response carries
+     ``_source: "local_store"`` and the legacy contract fields are non-empty.
+  2. negative case (one per Blueprint) — env flag UNSET → fast path skipped
+     (response lacks the ``_source`` tag).
+
+Pattern lifted from ``test_sessions_local_fastpath.py`` /
+``test_brain_local_fastpath.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+# ── shared helpers ─────────────────────────────────────────────────────────
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _reload_local_store(monkeypatch, tmp_path, *, fast_path: bool):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    if fast_path:
+        monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    else:
+        monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    return ls
+
+
+# ── components: /api/component/tool/<name>, /api/component/brain ───────────
+
+
+@pytest.fixture
+def components_app(tmp_path, monkeypatch):
+    ls = _reload_local_store(monkeypatch, tmp_path, fast_path=True)
+    import routes.components as comp_mod
+    importlib.reload(comp_mod)
+    a = Flask(__name__)
+    a.register_blueprint(comp_mod.bp_components)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_component_tool_fast_path_returns_local_rows(components_app):
+    a, ls = components_app
+    store = ls.get_store()
+    today = datetime.now().strftime("%Y-%m-%d")
+    # Two exec tool_call events today, one Read (memory family) today
+    store.ingest({
+        "id": "ev-tool-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-x", "event_type": "tool_call",
+        "ts": f"{today}T10:00:00Z",
+        "data": {"name": "exec", "arguments": {"command": "ls -la"}},
+        "cost_usd": 0.0, "token_count": 0, "model": "claude-opus-4-7",
+    })
+    store.ingest({
+        "id": "ev-tool-2", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-x", "event_type": "tool_call",
+        "ts": f"{today}T10:01:00Z",
+        "data": {"name": "exec", "arguments": {"command": "echo hi"}},
+        "cost_usd": 0.0, "token_count": 0, "model": "claude-opus-4-7",
+    })
+    store.ingest({
+        "id": "ev-tool-3", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-x", "event_type": "tool_call",
+        "ts": f"{today}T10:02:00Z",
+        "data": {"name": "Read", "arguments": {"file_path": "/tmp/x"}},
+        "cost_usd": 0.0, "token_count": 0, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/component/tool/exec")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["name"] == "exec"
+    assert body["stats"]["today_calls"] == 2
+    assert len(body["events"]) == 2
+    assert body["events"][0]["tool"] == "exec"
+    assert body["events"][0]["action"] == "exec"
+
+
+def test_component_brain_fast_path_returns_local_rows(components_app):
+    a, ls = components_app
+    store = ls.get_store()
+    today = datetime.now().strftime("%Y-%m-%d")
+    store.ingest({
+        "id": "ev-brain-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-llm", "event_type": "message",
+        "ts": f"{today}T11:00:00Z",
+        "data": {
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "usage": {"input": 1200, "output": 350,
+                          "cacheRead": 100, "cacheWrite": 0,
+                          "cost": {"total": 0.0125}},
+                "content": [
+                    {"type": "thinking", "thinking": "let me think about this"},
+                    {"type": "text", "text": "Here's my answer"},
+                    {"type": "toolCall", "name": "Bash"},
+                ],
+                "stopReason": "end_turn",
+            },
+        },
+        "cost_usd": 0.0125, "token_count": 1550, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/component/brain")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["total"] == 1
+    assert body["calls"][0]["model"] == "claude-opus-4-7"
+    assert body["calls"][0]["thinking"] is True
+    assert "Bash" in body["calls"][0]["tools_used"]
+    assert body["stats"]["today_calls"] == 1
+    assert body["stats"]["thinking_calls"] == 1
+    assert body["stats"]["model"] == "claude-opus-4-7"
+
+
+def test_components_fast_path_disabled_without_flag(tmp_path, monkeypatch):
+    """No CLAWMETRY_LOCAL_STORE_READ → fast path never runs even with
+    a populated events store."""
+    ls = _reload_local_store(monkeypatch, tmp_path, fast_path=False)
+    import routes.components as comp_mod
+    importlib.reload(comp_mod)
+    store = ls.get_store()
+    today = datetime.now().strftime("%Y-%m-%d")
+    store.ingest({
+        "id": "ev-noflag-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-x", "event_type": "tool_call",
+        "ts": f"{today}T10:00:00Z",
+        "data": {"name": "exec", "arguments": {"command": "ls"}},
+        "cost_usd": 0.0, "token_count": 0, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    a = Flask(__name__)
+    a.register_blueprint(comp_mod.bp_components)
+    r = a.test_client().get("/api/component/tool/exec")
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ── autonomy: /api/autonomy ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def autonomy_app(tmp_path, monkeypatch):
+    ls = _reload_local_store(monkeypatch, tmp_path, fast_path=True)
+    import routes.autonomy as aut_mod
+    importlib.reload(aut_mod)
+    # Reset the in-process cache so each test gets a fresh compute.
+    aut_mod._AUTONOMY_CACHE["data"] = None
+    aut_mod._AUTONOMY_CACHE["ts"] = 0.0
+    a = Flask(__name__)
+    a.register_blueprint(aut_mod.bp_autonomy)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_autonomy_fast_path_returns_local_aggregates(autonomy_app):
+    a, ls = autonomy_app
+    store = ls.get_store()
+    now = time.time()
+    # Three user messages in one session within the last day → real gaps.
+    for i, gap_min in enumerate([0, 30, 90]):
+        store.ingest({
+            "id": f"ev-aut-{i}", "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-aut-1", "event_type": "message",
+            "ts": _iso(now - 86400 + (gap_min * 60)),
+            "data": {"message": {"role": "user", "content": [{"type": "text", "text": f"hi {i}"}]}},
+            "cost_usd": 0.0, "token_count": 0, "model": "",
+        })
+    # One "no-nudge" session — single user message → counts toward autonomy ratio.
+    store.ingest({
+        "id": "ev-aut-noNudge", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-aut-2", "event_type": "message",
+        "ts": _iso(now - 3600),
+        "data": {"message": {"role": "user", "content": [{"type": "text", "text": "go"}]}},
+        "cost_usd": 0.0, "token_count": 0, "model": "",
+    })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/autonomy")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["samples_7d"] == 4
+    assert body["score"] is not None
+    # 1 of 2 sessions was no-nudge → ratio ~0.5
+    assert body["autonomy_ratio_7d"] == 0.5
+    assert isinstance(body["series_daily"], list)
+    assert len(body["series_daily"]) == 7  # 7-day window
+
+
+def test_autonomy_fast_path_disabled_without_flag(tmp_path, monkeypatch):
+    ls = _reload_local_store(monkeypatch, tmp_path, fast_path=False)
+    import routes.autonomy as aut_mod
+    importlib.reload(aut_mod)
+    aut_mod._AUTONOMY_CACHE["data"] = None
+    aut_mod._AUTONOMY_CACHE["ts"] = 0.0
+    store = ls.get_store()
+    now = time.time()
+    store.ingest({
+        "id": "ev-aut-noflag", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-noflag", "event_type": "message",
+        "ts": _iso(now - 3600),
+        "data": {"message": {"role": "user", "content": [{"type": "text", "text": "x"}]}},
+        "cost_usd": 0.0, "token_count": 0, "model": "",
+    })
+    _wait_flush(store)
+    a = Flask(__name__)
+    a.register_blueprint(aut_mod.bp_autonomy)
+    # The legacy path needs `dashboard.SESSIONS_DIR`; this path won't have one
+    # so it returns the empty response (no `_source` tag either way).
+    r = a.test_client().get("/api/autonomy")
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ── advisor: /api/advisor/ask, /api/advisor/status ────────────────────────
+
+
+@pytest.fixture
+def advisor_app(tmp_path, monkeypatch):
+    # Block advisor from making outbound LLM calls — clear ANTHROPIC_API_KEY
+    # so the auth probe returns "no_auth" deterministically.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    ls = _reload_local_store(monkeypatch, tmp_path, fast_path=True)
+    import routes.advisor as adv_mod
+    importlib.reload(adv_mod)
+    a = Flask(__name__)
+    a.register_blueprint(adv_mod.bp_advisor)
+    yield a, ls, adv_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_advisor_status_fast_path_returns_local_tag(advisor_app):
+    a, _ls, _adv = advisor_app
+    c = a.test_client()
+    r = c.get("/api/advisor/status")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    # Auth presence still surfaced — we cleared ANTHROPIC_API_KEY in the
+    # fixture so the probe should report no auth (model field stays).
+    assert "model" in body
+
+
+def test_advisor_gather_context_fast_path(advisor_app):
+    """The internal context-gather is the load-bearing piece of /ask. We
+    test it directly because the endpoint itself short-circuits on
+    no_auth before the LLM call (which is the expected runtime path
+    when ANTHROPIC_API_KEY isn't set)."""
+    _a, ls, adv_mod = advisor_app
+    store = ls.get_store()
+    now = time.time()
+    for i in range(3):
+        store.ingest({
+            "id": f"ev-adv-{i}", "node_id": "agent+test", "agent_id": "main",
+            "session_id": f"sess-adv-{i}", "event_type": "tool_call",
+            "ts": _iso(now - i * 60),
+            "data": {"name": "Bash", "input": f"echo {i}"},
+            "cost_usd": 0.0005 * (i + 1), "token_count": 25 * (i + 1),
+            "model": "claude-opus-4-7",
+        })
+    _wait_flush(store)
+
+    ctx = adv_mod._gather_context(limit_events=10)
+    assert ctx.get("_source") == "local_store"
+    assert isinstance(ctx.get("events"), list)
+    assert len(ctx["events"]) >= 3
+    assert ctx["usage"]["total_sessions"] >= 3
+    assert isinstance(ctx.get("recent_sessions"), list)
+
+
+def test_advisor_fast_path_disabled_without_flag(tmp_path, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    ls = _reload_local_store(monkeypatch, tmp_path, fast_path=False)
+    import routes.advisor as adv_mod
+    importlib.reload(adv_mod)
+    a = Flask(__name__)
+    a.register_blueprint(adv_mod.bp_advisor)
+    r = a.test_client().get("/api/advisor/status")
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+# ── reasoning: /api/reasoning ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def reasoning_app(tmp_path, monkeypatch):
+    ls = _reload_local_store(monkeypatch, tmp_path, fast_path=True)
+    import routes.reasoning as rea_mod
+    importlib.reload(rea_mod)
+    a = Flask(__name__)
+    a.register_blueprint(rea_mod.bp_reasoning)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_reasoning_fast_path_returns_chains(reasoning_app):
+    a, ls = reasoning_app
+    store = ls.get_store()
+    now = time.time()
+    store.ingest({
+        "id": "ev-rea-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-rea", "event_type": "message",
+        "ts": _iso(now - 60),
+        "data": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking":
+                        "The user wants to refactor the function. "
+                        "Let me try a cleaner approach.\n\n"
+                        "If I extract the helper, the test stays small. "
+                        "So I'll do that."},
+                    {"type": "text", "text": "Here's the refactor."},
+                ],
+            },
+        },
+        "cost_usd": 0.01, "token_count": 200, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/reasoning?session=sess-rea")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["session_id"] == "sess-rea"
+    assert body["summary"]["chain_count"] == 1
+    assert body["chains"][0]["thinking_tokens"] > 0
+    assert isinstance(body["chains"][0]["steps"], list) and body["chains"][0]["steps"]
+
+
+def test_reasoning_fast_path_disabled_without_flag(tmp_path, monkeypatch):
+    ls = _reload_local_store(monkeypatch, tmp_path, fast_path=False)
+    import routes.reasoning as rea_mod
+    importlib.reload(rea_mod)
+    store = ls.get_store()
+    now = time.time()
+    store.ingest({
+        "id": "ev-rea-noflag", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-rea-noflag", "event_type": "message",
+        "ts": _iso(now - 60),
+        "data": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "The user wants help."},
+                    {"type": "text", "text": "Sure."},
+                ],
+            },
+        },
+        "cost_usd": 0.0, "token_count": 50, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+    a = Flask(__name__)
+    a.register_blueprint(rea_mod.bp_reasoning)
+    r = a.test_client().get("/api/reasoning?session=sess-rea-noflag")
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary

Adds `CLAWMETRY_LOCAL_STORE_READ`-gated DuckDB fast paths to four route modules. Each migrated endpoint follows the canonical pattern from `routes/sessions.py:_try_local_store_sessions()` — a `_try_local_store_<endpoint>` helper that reads from `local_store.get_store().query_events(...)`, transforms rows into the legacy response shape, tags `"_source": "local_store"`, and returns `None` to defer to the legacy path on any failure.

Defaults to legacy path when the flag is unset → zero behavior change for existing deploys.

## Migrated endpoints

| Route module | Endpoint | Source data |
|---|---|---|
| `routes/components.py` | `/api/component/tool/<name>` | `event_type=tool_call`, today only, filtered by tool family |
| `routes/components.py` | `/api/component/brain` | `event_type=message`, today only, assistant turns w/ usage |
| `routes/autonomy.py` | `/api/autonomy` | `event_type=message`, role=user, last 7 days, gap aggregation |
| `routes/advisor.py` | `/api/advisor/ask` | `_gather_context()` short-circuits to local-store events |
| `routes/advisor.py` | `/api/advisor/status` | tags response with `_source` when DuckDB reachable |
| `routes/reasoning.py` | `/api/reasoning?session=<id>` | `event_type=message` for session, extracts thinking blocks |

## Skipped (with rationale)

The remaining `/api/component/*` endpoints read OS state or external log files, **not** event data. They are intentionally NOT migrated:

- **`/api/component/runtime`** — Python/OS version, uptime, free/df output. OS state.
- **`/api/component/machine`** — hostname, CPU info from `/proc/cpuinfo`, GPU from `nvidia-smi`. OS state.
- **`/api/component/storage`** — `df -h` output. OS state.
- **`/api/component/network`** — `/proc/net/dev` + `ifconfig` + connectivity ping. OS state.
- **`/api/component/gateway`** — parses external `gateway.log` plain-text file plus systemd uptime. External log/config.

Putting any of these on DuckDB would require a new ingest path (e.g. periodic OS-state snapshots) that doesn't exist yet — out of scope for "tier-1 easy wins". Adding the env-gate without a real fast path would just be noise.

## Test plan

- [x] `tests/test_tier1_local_store.py` (new, 10 cases) — positive per endpoint + negative per Blueprint, follows `test_sessions_local_fastpath.py` pattern
- [x] `python3 -c "import ast; ast.parse(...)"` for each modified file — clean
- [x] `python3 -m pytest tests/test_tier1_local_store.py -v` — 10/10 green
- [x] `python3 -m pytest tests/test_sessions_local_fastpath.py tests/test_e2e_real_openclaw_pipeline.py -v` — 18/18 green (no regressions)
- [x] `python3 -c "import dashboard"` — clean (no circular import)

## How to verify locally

```bash
# Without the flag — legacy path (no _source tag)
curl -s localhost:8900/api/component/tool/exec | jq '._source'  # null

# With the flag — fast path (tagged "local_store" when DuckDB has events)
CLAWMETRY_LOCAL_STORE_READ=1 clawmetry --port 8900 &
curl -s localhost:8900/api/component/tool/exec | jq '._source'  # "local_store"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)