### PR TITLE
feat(memory): memory routes onto local DuckDB (4 endpoints)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1033,6 +1033,69 @@ class LocalStore:
                 "data", "updated_at"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
 
+    def query_memory_blobs(
+        self,
+        *,
+        agent_type: str | None = None,
+        agent_id: str | None = None,
+        path_prefix: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Read memory-blob rows. Defaults to most recent first.
+
+        Each row mirrors the ``memory_blobs`` schema columns
+        (``agent_type``, ``agent_id``, ``path``, ``ts``, ``blob``,
+        ``sha256``, ``size_bytes``, ``updated_at``). The ``blob`` BLOB
+        is decoded back to a UTF-8 string when valid (memory files are
+        always plaintext markdown — CLAUDE.md, SOUL.md, memory/*.md);
+        leaves it as ``bytes`` if decoding fails, ``None`` when empty.
+
+        Filters:
+          - ``agent_type``: exact match on the framework discriminator
+            (e.g. ``"openclaw"``, ``"claude_code"``).
+          - ``agent_id``: exact match on the instance within that
+            framework (``"main"``, ``"subagent"``, ``"cron"``).
+          - ``path_prefix``: SQL ``LIKE prefix%`` on the path column —
+            useful for scoping to ``"memory/"`` daily files vs root
+            workspace files.
+
+        Sort order matches the other ``query_*`` methods: most-recently-
+        updated first. ``LIMIT 200`` default mirrors ``query_subagents``."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if agent_type:
+            clauses.append("agent_type = ?"); params.append(agent_type)
+        if agent_id:
+            clauses.append("agent_id = ?"); params.append(agent_id)
+        if path_prefix:
+            clauses.append("path LIKE ?"); params.append(f"{path_prefix}%")
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT agent_type, agent_id, path, ts, blob, sha256,
+                   size_bytes, updated_at
+            FROM memory_blobs
+            {where}
+            ORDER BY updated_at DESC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["agent_type", "agent_id", "path", "ts", "blob", "sha256",
+                "size_bytes", "updated_at"]
+        out: list[dict[str, Any]] = []
+        for r in self._fetch(sql, params):
+            d = dict(zip(cols, r))
+            raw = d.get("blob")
+            if raw is not None:
+                try:
+                    d["blob"] = (raw.decode("utf-8")
+                                 if isinstance(raw, (bytes, bytearray)) else raw)
+                except UnicodeDecodeError:
+                    # Non-utf8 binary memory file (rare); leave as bytes so
+                    # callers can still get the raw payload.
+                    d["blob"] = bytes(raw)
+            out.append(d)
+        return out
+
     def query_system_snapshots(
         self,
         *,

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -873,7 +873,10 @@ async function loadSelfConfig() {
     var filesReq = fetch('/api/memory-files').then(function(r){return r.json();}).catch(function(){return [];});
     var trackedReq = fetch('/api/selfconfig').then(function(r){return r.json();}).catch(function(){return {files:[]};});
     var results = await Promise.all([filesReq, trackedReq]);
-    var realFiles = results[0] || [];
+    // /api/memory-files used to return a bare array; the local-store fast
+    // path wraps in {files:[...], _source:"local_store"}. Accept both.
+    var rawFiles = results[0];
+    var realFiles = Array.isArray(rawFiles) ? rawFiles : (rawFiles && rawFiles.files) || [];
     var tracked = (results[1] && results[1].files) || [];
 
     _selfconfigTrackedMeta = {};
@@ -4912,7 +4915,10 @@ async function _loadMemoryAllFiles() {
     return;
   }
   loadMemoryAnalytics();
-  var data = await fetch('/api/memory-files').then(r => r.json());
+  var rawData = await fetch('/api/memory-files').then(r => r.json());
+  // /api/memory-files used to return a bare array; the local-store fast
+  // path wraps in {files:[...], _source:"local_store"}. Accept both.
+  var data = Array.isArray(rawData) ? rawData : (rawData && rawData.files) || [];
   var el = document.getElementById('memory-list');
   // Add hover CSS once
   if (!document.getElementById('mem-ide-css')) {

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -361,12 +361,214 @@ def api_logs_stream():
 
 
 # ── Memory files ───────────────────────────────────────────────────────────
+#
+# Local-store fast path (DuckDB MOAT mandate): when
+# CLAWMETRY_LOCAL_STORE_READ=1 AND the local memory_blobs table has rows for
+# this agent, serve directly from DuckDB. Falls through to the legacy
+# filesystem path otherwise (so a fresh install with no local store, or a
+# user who hasn't enabled the gate, sees the same data as before — zero-
+# change default). The POST handler at /api/file intentionally stays on
+# disk; writes are a future ingest hook (sync.py owns memory ingest today).
+
+
+def _try_local_store_memory_files():
+    """Read memory file metadata directly from the local DuckDB. Returns
+    a list shaped identically to ``_get_memory_files()`` (``[{"path":
+    str, "size": int}, ...]``). Returns ``None`` to defer to the
+    filesystem fallback if:
+      - the local_store module isn't importable
+      - the memory_blobs table is empty
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = store.query_memory_blobs(limit=500)
+    except Exception:
+        return None
+    if not rows:
+        return None
+    out = []
+    seen: set[str] = set()
+    for r in rows:
+        path = r.get("path") or ""
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        size = r.get("size_bytes")
+        if size is None:
+            blob = r.get("blob")
+            if isinstance(blob, str):
+                size = len(blob.encode("utf-8", errors="replace"))
+            elif isinstance(blob, (bytes, bytearray)):
+                size = len(blob)
+            else:
+                size = 0
+        out.append({"path": path, "size": int(size or 0)})
+    return out
+
+
+def _try_local_store_file(path: str):
+    """Read one memory file directly from the local DuckDB. Returns the
+    same response shape as the legacy filesystem-backed endpoint
+    (``{"path", "content", "size", "mtime"}``). Returns ``None`` to
+    defer to the filesystem fallback if:
+      - the local_store module isn't importable
+      - no memory_blobs row matches the requested path
+      - the blob payload isn't UTF-8 text (rare; punt to disk path)
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        # query_memory_blobs has no exact-path filter (path_prefix is the
+        # closest), so use prefix=path to narrow then exact-match in Python.
+        # path_prefix="MEMORY.md" matches "MEMORY.md" exactly AND any
+        # accidental "MEMORY.md.bak" — the in-memory filter resolves it.
+        rows = store.query_memory_blobs(path_prefix=path, limit=50)
+    except Exception:
+        return None
+    for r in rows:
+        if (r.get("path") or "") != path:
+            continue
+        blob = r.get("blob")
+        if blob is None:
+            content = ""
+        elif isinstance(blob, str):
+            content = blob
+        else:
+            # Binary blob (non-utf8) — defer to filesystem path which can
+            # at least raise a sensible error to the user.
+            return None
+        size = r.get("size_bytes")
+        if size is None:
+            size = len(content.encode("utf-8", errors="replace"))
+        # ts is an ISO string; convert to epoch seconds for parity with
+        # os.path.getmtime() which returns float seconds.
+        mtime = 0
+        ts = r.get("ts")
+        if ts:
+            try:
+                from datetime import datetime as _dt
+                mtime = int(_dt.fromisoformat(
+                    ts.replace("Z", "+00:00")
+                ).timestamp())
+            except Exception:
+                pass
+        return {
+            "path": path,
+            "content": content[:500_000],
+            "size": int(size or 0),
+            "mtime": mtime,
+            "_source": "local_store",
+        }
+    return None
+
+
+def _try_local_store_memory_analytics(bloat_warn_kb: int, bloat_crit_kb: int):
+    """Compute memory analytics from the local DuckDB. Same response
+    shape as the filesystem-backed endpoint. Returns ``None`` to defer
+    when the local store has no memory_blobs rows."""
+    files = _try_local_store_memory_files()
+    if files is None:
+        return None
+    return _build_memory_analytics(files, bloat_warn_kb, bloat_crit_kb,
+                                   source="local_store")
+
+
+def _build_memory_analytics(files, bloat_warn_kb, bloat_crit_kb, *, source=None):
+    """Pure analytics builder over a ``[{path, size}, ...]`` list. Shared
+    between the local-store fast path and the filesystem fallback so the
+    response shape stays identical regardless of source."""
+    total_bytes = sum(f.get("size", 0) for f in files)
+    root_files = [f for f in files if "/" not in f["path"]]
+    daily_files = [f for f in files if f["path"].startswith("memory/")]
+    est_tokens = total_bytes // 4
+
+    analysis = []
+    recommendations = []
+    for f in files:
+        entry = {
+            "path": f["path"],
+            "sizeBytes": f["size"],
+            "sizeKB": round(f["size"] / 1024, 1),
+            "estTokens": f["size"] // 4,
+            "status": "ok",
+        }
+        kb = f["size"] / 1024
+        if kb >= bloat_crit_kb:
+            entry["status"] = "critical"
+            recommendations.append({
+                "file": f["path"],
+                "severity": "critical",
+                "message": f"{f['path']} is {kb:.1f}KB ({f['size'] // 4} est. tokens). "
+                f"Consider pruning to keep context window budget lean.",
+            })
+        elif kb >= bloat_warn_kb:
+            entry["status"] = "warning"
+            recommendations.append({
+                "file": f["path"],
+                "severity": "warning",
+                "message": f"{f['path']} is {kb:.1f}KB. Growing large, review for stale content.",
+            })
+        analysis.append(entry)
+
+    daily_growth = []
+    date_sizes = {}
+    for f in daily_files:
+        basename = f["path"].replace("memory/", "")
+        date_part = basename.replace(".md", "")[:10]
+        if len(date_part) == 10 and date_part[4] == "-":
+            date_sizes[date_part] = date_sizes.get(date_part, 0) + f["size"]
+    for d in sorted(date_sizes.keys())[-30:]:
+        daily_growth.append({"date": d, "bytes": date_sizes[d]})
+
+    context_budgets = {}
+    for name, limit in [
+        ("claude_200k", 200000),
+        ("gpt4_128k", 128000),
+        ("gemini_1m", 1000000),
+    ]:
+        pct = round((est_tokens / limit) * 100, 1) if limit > 0 else 0
+        context_budgets[name] = {
+            "limit": limit,
+            "memoryTokens": est_tokens,
+            "percentUsed": min(pct, 100),
+            "status": "critical" if pct > 25 else ("warning" if pct > 10 else "ok"),
+        }
+
+    top_files = sorted(analysis, key=lambda x: x["sizeBytes"], reverse=True)[:5]
+    has_bloat = any(r["severity"] == "critical" for r in recommendations)
+    has_warnings = any(r["severity"] == "warning" for r in recommendations)
+
+    payload = {
+        "totalBytes": total_bytes,
+        "totalKB": round(total_bytes / 1024, 1),
+        "estTokens": est_tokens,
+        "fileCount": len(files),
+        "rootFileCount": len(root_files),
+        "dailyFileCount": len(daily_files),
+        "files": analysis,
+        "topFiles": top_files,
+        "dailyGrowth": daily_growth,
+        "contextBudgets": context_budgets,
+        "recommendations": recommendations,
+        "hasBloat": has_bloat,
+        "hasWarnings": has_warnings,
+        "thresholds": {"warnKB": bloat_warn_kb, "critKB": bloat_crit_kb},
+    }
+    if source:
+        payload["_source"] = source
+    return payload
 
 
 @bp_memory.route("/api/memory-files")
 @bp_memory.route("/api/memory")
 def api_memory_files():
     import dashboard as _d
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_memory_files()
+        if fast is not None:
+            return jsonify({"files": fast, "_source": "local_store"})
     return jsonify(_d._get_memory_files())
 
 
@@ -375,6 +577,10 @@ def api_view_file():
     """Return the contents of a memory file."""
     import dashboard as _d
     path = request.args.get("path", "")
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1" and path:
+        fast = _try_local_store_file(path)
+        if fast is not None:
+            return jsonify(fast)
     full = os.path.normpath(os.path.join(_d.WORKSPACE, path))
     if not full.startswith(os.path.normpath(_d.WORKSPACE)):
         return jsonify({"error": "Access denied"}), 403
@@ -424,106 +630,18 @@ def api_write_file():
 def api_memory_analytics():
     """Memory usage analytics with bloat detection and recommendations."""
     import dashboard as _d
-    workspace = _d.WORKSPACE or os.getcwd()
-    memory_dir = _d.MEMORY_DIR or os.path.join(workspace, "memory")
 
     # Configurable thresholds (bytes)
     bloat_warn_kb = int(request.args.get("warn_kb", 8))
     bloat_crit_kb = int(request.args.get("crit_kb", 16))
 
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_memory_analytics(bloat_warn_kb, bloat_crit_kb)
+        if fast is not None:
+            return jsonify(fast)
+
     files = _d._get_memory_files()
-    total_bytes = sum(f.get("size", 0) for f in files)
-    root_files = [f for f in files if "/" not in f["path"]]
-    daily_files = [f for f in files if f["path"].startswith("memory/")]
-
-    # Estimate tokens (rough: 1 token ~ 4 chars ~ 4 bytes for English text)
-    est_tokens = total_bytes // 4
-
-    # Per-file analysis with bloat flags
-    analysis = []
-    recommendations = []
-    for f in files:
-        entry = {
-            "path": f["path"],
-            "sizeBytes": f["size"],
-            "sizeKB": round(f["size"] / 1024, 1),
-            "estTokens": f["size"] // 4,
-            "status": "ok",
-        }
-        kb = f["size"] / 1024
-        if kb >= bloat_crit_kb:
-            entry["status"] = "critical"
-            recommendations.append(
-                {
-                    "file": f["path"],
-                    "severity": "critical",
-                    "message": f"{f['path']} is {kb:.1f}KB ({f['size'] // 4} est. tokens). "
-                    f"Consider pruning to keep context window budget lean.",
-                }
-            )
-        elif kb >= bloat_warn_kb:
-            entry["status"] = "warning"
-            recommendations.append(
-                {
-                    "file": f["path"],
-                    "severity": "warning",
-                    "message": f"{f['path']} is {kb:.1f}KB. Growing large, review for stale content.",
-                }
-            )
-        analysis.append(entry)
-
-    # Daily memory dir growth (count files per date from filenames)
-    daily_growth = []
-    if os.path.isdir(memory_dir):
-        date_sizes = {}
-        for f in daily_files:
-            basename = f["path"].replace("memory/", "")
-            date_part = basename.replace(".md", "")[:10]  # YYYY-MM-DD
-            if len(date_part) == 10 and date_part[4] == "-":
-                date_sizes[date_part] = date_sizes.get(date_part, 0) + f["size"]
-        for d in sorted(date_sizes.keys())[-30:]:
-            daily_growth.append({"date": d, "bytes": date_sizes[d]})
-
-    # Context budget estimation
-    # Common context windows: 200K tokens (Claude), 128K (GPT-4), 1M (Gemini)
-    context_budgets = {}
-    for name, limit in [
-        ("claude_200k", 200000),
-        ("gpt4_128k", 128000),
-        ("gemini_1m", 1000000),
-    ]:
-        pct = round((est_tokens / limit) * 100, 1) if limit > 0 else 0
-        context_budgets[name] = {
-            "limit": limit,
-            "memoryTokens": est_tokens,
-            "percentUsed": min(pct, 100),
-            "status": "critical" if pct > 25 else ("warning" if pct > 10 else "ok"),
-        }
-
-    # Largest files
-    top_files = sorted(analysis, key=lambda x: x["sizeBytes"], reverse=True)[:5]
-
-    has_bloat = any(r["severity"] == "critical" for r in recommendations)
-    has_warnings = any(r["severity"] == "warning" for r in recommendations)
-
-    return jsonify(
-        {
-            "totalBytes": total_bytes,
-            "totalKB": round(total_bytes / 1024, 1),
-            "estTokens": est_tokens,
-            "fileCount": len(files),
-            "rootFileCount": len(root_files),
-            "dailyFileCount": len(daily_files),
-            "files": analysis,
-            "topFiles": top_files,
-            "dailyGrowth": daily_growth,
-            "contextBudgets": context_budgets,
-            "recommendations": recommendations,
-            "hasBloat": has_bloat,
-            "hasWarnings": has_warnings,
-            "thresholds": {"warnKB": bloat_warn_kb, "critKB": bloat_crit_kb},
-        }
-    )
+    return jsonify(_build_memory_analytics(files, bloat_warn_kb, bloat_crit_kb))
 
 
 # ── Security ───────────────────────────────────────────────────────────────

--- a/tests/test_memory_local_store.py
+++ b/tests/test_memory_local_store.py
@@ -1,0 +1,304 @@
+"""Tests for the bp_memory routes' local-store fast path.
+
+Mirrors test_sessions_local_fastpath.py — opt-in via
+CLAWMETRY_LOCAL_STORE_READ=1; falls through to the legacy filesystem path
+when the flag is unset OR the local memory_blobs table is empty.
+
+Routes covered:
+  - /api/memory-files (also /api/memory alias) — list memory files
+  - /api/file?path=... (GET only — POST writes still go to disk)
+  - /api/memory-analytics — aggregate stats with bloat detection
+
+Schema-method coverage:
+  - clawmetry.local_store.LocalStore.query_memory_blobs() — newest-first,
+    filter by agent_type/agent_id/path_prefix, decoded blob payload.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Flask app with bp_memory registered, fresh DuckDB per test, fast-path
+    flag enabled."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.infra as infra_mod
+    importlib.reload(infra_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(infra_mod.bp_memory)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def app_no_flag(tmp_path, monkeypatch):
+    """Same wiring as ``app`` but with the fast-path flag DELETED so the
+    handler must fall through to the filesystem path. WORKSPACE pointed
+    at an empty tmp dir so the legacy code returns an empty list rather
+    than reading the developer's real ~/.openclaw."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import dashboard as _d
+    monkeypatch.setattr(_d, "WORKSPACE", str(tmp_path), raising=False)
+    monkeypatch.setattr(_d, "MEMORY_DIR", str(tmp_path / "memory"), raising=False)
+    import routes.infra as infra_mod
+    importlib.reload(infra_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(infra_mod.bp_memory)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed_blob(store, path: str, content: str = "hello world\n",
+               agent_type: str = "openclaw", agent_id: str = "main",
+               ts: str = "2026-05-12T10:00:00+00:00") -> None:
+    """Seed one memory_blobs row. Default content/timestamp keeps tests
+    terse — pass overrides where the test cares."""
+    store.ingest_memory_blob({
+        "agent_type": agent_type,
+        "agent_id": agent_id,
+        "path": path,
+        "blob": content,
+        "ts": ts,
+    })
+
+
+# ── /api/memory-files (and /api/memory alias) ──────────────────────────────
+
+
+def test_memory_files_fast_path_returns_local_rows(app):
+    a, ls = app
+    store = ls.get_store()
+    _seed_blob(store, "MEMORY.md", "vivek's memory\n")
+    _seed_blob(store, "SOUL.md", "i am claude\n")
+    _seed_blob(store, "memory/2026-05-12.md", "today's notes\n" * 10)
+
+    body = a.test_client().get("/api/memory-files").get_json()
+    assert body.get("_source") == "local_store"
+    paths = {f["path"] for f in body["files"]}
+    assert paths == {"MEMORY.md", "SOUL.md", "memory/2026-05-12.md"}
+    by_path = {f["path"]: f for f in body["files"]}
+    # size = byte length of the seeded blob
+    assert by_path["MEMORY.md"]["size"] == len("vivek's memory\n".encode("utf-8"))
+    assert by_path["memory/2026-05-12.md"]["size"] == len(("today's notes\n" * 10).encode("utf-8"))
+
+
+def test_memory_alias_route_also_fast_paths(app):
+    """/api/memory is documented as an alias of /api/memory-files."""
+    a, ls = app
+    _seed_blob(ls.get_store(), "AGENTS.md")
+    body = a.test_client().get("/api/memory").get_json()
+    assert body.get("_source") == "local_store"
+    assert {f["path"] for f in body["files"]} == {"AGENTS.md"}
+
+
+def test_memory_files_disabled_without_flag(app_no_flag):
+    """Flag unset → no fast path even if writes would land in the store.
+    Falls through to the filesystem helper which returns a bare list (no
+    `_source` tag)."""
+    a, _ls = app_no_flag
+    body = a.test_client().get("/api/memory-files").get_json()
+    if isinstance(body, dict):
+        assert body.get("_source") != "local_store"
+    else:
+        # bare list = legacy filesystem return shape
+        assert isinstance(body, list)
+
+
+# ── /api/file (GET) ────────────────────────────────────────────────────────
+
+
+def test_file_get_fast_path_returns_local_content(app):
+    a, ls = app
+    _seed_blob(ls.get_store(), "MEMORY.md", "the answer is 42\n",
+               ts="2026-05-12T10:00:00+00:00")
+
+    body = a.test_client().get("/api/file?path=MEMORY.md").get_json()
+    assert body.get("_source") == "local_store"
+    assert body["path"] == "MEMORY.md"
+    assert body["content"] == "the answer is 42\n"
+    assert body["size"] == len("the answer is 42\n".encode("utf-8"))
+    # mtime should be epoch seconds parsed from the ISO ts
+    assert body["mtime"] > 0
+
+
+def test_file_get_fast_path_misses_when_path_not_in_store(app, tmp_path, monkeypatch):
+    """Local store has SOUL.md but not USER.md → fast path returns None →
+    falls through to filesystem path. With WORKSPACE pointed at an empty
+    tmp dir we expect a 404 (not a misdirected 200)."""
+    a, ls = app
+    _seed_blob(ls.get_store(), "SOUL.md")
+    import dashboard as _d
+    monkeypatch.setattr(_d, "WORKSPACE", str(tmp_path), raising=False)
+
+    r = a.test_client().get("/api/file?path=USER.md")
+    assert r.status_code == 404
+
+
+def test_file_get_disabled_without_flag(app_no_flag, tmp_path):
+    """Flag unset → fast path never runs; even with a populated store,
+    the handler reads filesystem (which is empty here → 404)."""
+    a, ls = app_no_flag
+    _seed_blob(ls.get_store(), "MEMORY.md", "should-not-be-served")
+    r = a.test_client().get("/api/file?path=MEMORY.md")
+    # Fell through to filesystem — empty WORKSPACE → 404 not 200 with body.
+    body = r.get_json() or {}
+    assert body.get("_source") != "local_store"
+
+
+# ── /api/memory-analytics ──────────────────────────────────────────────────
+
+
+def test_memory_analytics_fast_path_uses_local_blobs(app):
+    a, ls = app
+    store = ls.get_store()
+    # 3 root files + 2 daily files; one of the daily files is bloated
+    _seed_blob(store, "MEMORY.md", "x" * 100)
+    _seed_blob(store, "SOUL.md", "x" * 200)
+    _seed_blob(store, "AGENTS.md", "x" * 50)
+    _seed_blob(store, "memory/2026-05-11.md", "y" * 9_000)   # > 8KB warn
+    _seed_blob(store, "memory/2026-05-12.md", "z" * 17_000)  # > 16KB crit
+
+    body = a.test_client().get("/api/memory-analytics").get_json()
+    assert body.get("_source") == "local_store"
+    assert body["fileCount"] == 5
+    assert body["rootFileCount"] == 3
+    assert body["dailyFileCount"] == 2
+    assert body["totalBytes"] == 100 + 200 + 50 + 9_000 + 17_000
+    # Bloat detection should have flagged the >16KB daily file
+    assert body["hasBloat"] is True
+    assert body["hasWarnings"] is True
+    crit_files = [r["file"] for r in body["recommendations"]
+                  if r["severity"] == "critical"]
+    assert "memory/2026-05-12.md" in crit_files
+    # Daily growth bucketed by date
+    growth_dates = {g["date"] for g in body["dailyGrowth"]}
+    assert growth_dates == {"2026-05-11", "2026-05-12"}
+    # Context budgets present for all three model sizes
+    assert set(body["contextBudgets"].keys()) == {
+        "claude_200k", "gpt4_128k", "gemini_1m",
+    }
+
+
+def test_memory_analytics_threshold_overrides_via_querystring(app):
+    """warn_kb / crit_kb querystring args must still flow through the
+    fast path — the analytics builder doesn't care which source fed it."""
+    a, ls = app
+    _seed_blob(ls.get_store(), "tiny.md", "x" * 600)
+    body = a.test_client().get(
+        "/api/memory-analytics?warn_kb=0&crit_kb=1"
+    ).get_json()
+    assert body.get("_source") == "local_store"
+    assert body["thresholds"] == {"warnKB": 0, "critKB": 1}
+    assert body["hasWarnings"] is True
+
+
+def test_memory_analytics_disabled_without_flag(app_no_flag):
+    """Flag unset → falls through to filesystem path (which sees an empty
+    workspace and returns zero files). Confirm no `_source` tag."""
+    a, _ls = app_no_flag
+    body = a.test_client().get("/api/memory-analytics").get_json()
+    assert body.get("_source") != "local_store"
+    assert body["fileCount"] == 0
+
+
+# ── direct LocalStore.query_memory_blobs() coverage ────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """Fresh isolated DuckDB per test for direct query_memory_blobs() tests
+    (no Flask wiring)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.LocalStore()
+    s.start()
+    yield s
+    s.stop(flush=False)
+
+
+def test_query_memory_blobs_round_trip(store):
+    store.ingest_memory_blob({
+        "agent_type": "openclaw",
+        "path": "MEMORY.md",
+        "blob": "the moat mandate\n",
+        "ts": "2026-05-12T10:00:00+00:00",
+    })
+    rows = store.query_memory_blobs()
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["agent_type"] == "openclaw"
+    assert r["agent_id"] == "main"  # default
+    assert r["path"] == "MEMORY.md"
+    # blob decoded back to UTF-8 string
+    assert r["blob"] == "the moat mandate\n"
+    assert r["sha256"]
+    assert r["size_bytes"] == len("the moat mandate\n".encode("utf-8"))
+    assert r["updated_at"] > 0
+
+
+def test_query_memory_blobs_newest_first(store):
+    """Sort order: most-recently-updated first. Mirrors query_subagents /
+    query_crons / query_heartbeats."""
+    import time as _t
+    store.ingest_memory_blob({"agent_type": "openclaw", "path": "a.md", "blob": "first"})
+    _t.sleep(0.01)
+    store.ingest_memory_blob({"agent_type": "openclaw", "path": "b.md", "blob": "second"})
+    _t.sleep(0.01)
+    store.ingest_memory_blob({"agent_type": "openclaw", "path": "c.md", "blob": "third"})
+    rows = store.query_memory_blobs()
+    assert [r["path"] for r in rows] == ["c.md", "b.md", "a.md"]
+
+
+def test_query_memory_blobs_filter_by_agent_type(store):
+    store.ingest_memory_blob({"agent_type": "openclaw", "path": "MEMORY.md", "blob": "oc"})
+    store.ingest_memory_blob({"agent_type": "claude_code", "path": "CLAUDE.md", "blob": "cc"})
+    oc = store.query_memory_blobs(agent_type="openclaw")
+    cc = store.query_memory_blobs(agent_type="claude_code")
+    assert {r["path"] for r in oc} == {"MEMORY.md"}
+    assert {r["path"] for r in cc} == {"CLAUDE.md"}
+
+
+def test_query_memory_blobs_filter_by_path_prefix(store):
+    store.ingest_memory_blob({"agent_type": "openclaw", "path": "MEMORY.md", "blob": "x"})
+    store.ingest_memory_blob({"agent_type": "openclaw", "path": "memory/2026-05-11.md", "blob": "y"})
+    store.ingest_memory_blob({"agent_type": "openclaw", "path": "memory/2026-05-12.md", "blob": "z"})
+    daily = store.query_memory_blobs(path_prefix="memory/")
+    assert {r["path"] for r in daily} == {
+        "memory/2026-05-11.md", "memory/2026-05-12.md",
+    }
+
+
+def test_query_memory_blobs_limit(store):
+    for i in range(10):
+        store.ingest_memory_blob({
+            "agent_type": "openclaw", "path": f"p{i}.md", "blob": "x",
+        })
+    assert len(store.query_memory_blobs(limit=3)) == 3


### PR DESCRIPTION
## Summary

DuckDB MOAT mandate (Tier-2): migrate the four `bp_memory` GET routes in `routes/infra.py` to read from the local `memory_blobs` table when `CLAWMETRY_LOCAL_STORE_READ=1`. Sync already ingests memory blobs (`clawmetry/sync.py::_local_ingest_memory_files`); the missing pieces were the query method and the route fast paths.

### Endpoints migrated

| Route | Behaviour |
|---|---|
| `GET /api/memory-files` | Lists `[{path, size}, ...]` from `memory_blobs`. Response now wrapped: `{files:[...], _source:"local_store"}`. Dashboard JS updated to accept both bare-list and wrapped shapes. |
| `GET /api/memory` | Documented alias of `/api/memory-files`; same fast path. |
| `GET /api/file?path=...` | Reads one memory file's content from the `blob` column. ISO `ts` decoded to epoch `mtime` for parity with `os.path.getmtime()`. Falls through to disk on row-miss / non-utf8 blob. |
| `GET /api/memory-analytics` | Aggregates total bytes, bloat warnings/criticals, daily growth, context-window budgets — all computed over the local blobs. Threshold querystring args (`warn_kb` / `crit_kb`) flow through unchanged. |

### New query method

```python
LocalStore.query_memory_blobs(*, agent_type=None, agent_id=None,
                              path_prefix=None, limit=200)
```

Newest-first sort (matches `query_subagents` / `query_crons` / `query_heartbeats`), decodes the BLOB back to UTF-8 string when valid (memory files are always plaintext markdown).

### Skipped: `POST /api/file` (writes)

The write handler `api_write_file` keeps going to disk. Memory ingest is owned by `clawmetry/sync.py` today; turning the dashboard into a writer is a separate ingest-hook PR. Read-only by default is also the OSS default per `CLAUDE.md` ("Read-only by default — ClawMetry observes, it doesn't modify agent behavior").

### Backward compatibility

- Fast path is opt-in via `CLAWMETRY_LOCAL_STORE_READ=1` and only fires when the local `memory_blobs` table has rows. Fresh installs / users who haven't enabled the gate get zero behaviour change.
- `_build_memory_analytics(...)` is a pure builder shared by both the DuckDB and filesystem paths so the JSON response shape is identical regardless of source.
- Dashboard JS (`app.js` lines ~876, ~4918) accepts both the legacy bare-list response and the new wrapped `{files, _source}` shape.

## Test plan

- [x] `python3 -m pytest tests/test_memory_local_store.py -v` — 14 new tests, all green
- [x] `python3 -m pytest tests/test_local_store_missing_writers.py -v` — 15 regression tests, no breakage
- [x] `python3 -c "import ast; ast.parse(open('clawmetry/local_store.py').read())"` — parses
- [x] `python3 -c "import ast; ast.parse(open('routes/infra.py').read())"` — parses
- [ ] Manual smoke: dashboard with `CLAWMETRY_LOCAL_STORE_READ=1` + populated DuckDB shows memory files in the IDE explorer + bloat analytics card

🤖 Generated with [Claude Code](https://claude.com/claude-code)