### PR TITLE
feat(sync): brain cache_push on heartbeat (epic #1032 Phase 2 — OSS side)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1764,6 +1764,17 @@ def send_heartbeat(config: dict) -> bool:
         payload["local_store_size_mb"] = round(size_mb, 3)
     except Exception:
         pass  # local store optional — never break heartbeat over it
+    # Phase 2 of relay-v2 (epic #1032): proactively push the top-50 brain
+    # events to the cloud cache so the Brain page paints in <100ms on first
+    # load instead of waiting for a relay round-trip. The blob is the same
+    # E2E ciphertext we use for /ingest/cache, so the cloud never sees
+    # plaintext. Best-effort — heartbeat MUST succeed even if this fails.
+    try:
+        pushes = _build_brain_cache_pushes(config)
+        if pushes:
+            payload["cache_pushes"] = pushes
+    except Exception as _bp_e:
+        log.debug("brain cache_push build failed (continuing): %s", _bp_e)
     # Local-first: persist this heartbeat to local DuckDB so the dashboard
     # has a per-node liveness history even when offline. Best-effort.
     try:
@@ -1829,6 +1840,105 @@ def _local_dispatch_fallback(shape: str, args: dict) -> dict:
         raise ValueError(f"unknown shape: {shape}")
     rows = getattr(store, method)(**(args or {}))
     return {"rows": rows, "count": len(rows), "_shape": shape, "_via": "fallback"}
+
+
+# ── Phase 2: proactive brain cache_push (epic #1032) ─────────────────────────
+# The Brain page is the first thing most users hit on the cloud dashboard. In
+# Phase 1 the cloud only had data for it after a browser /api/cloud/subscribe
+# round-trip (one full heartbeat cycle, up to 60s). Phase 2 pushes the top-50
+# brain events on EVERY heartbeat so the page paints from cache in <100ms.
+#
+# Key shape: `brain:{owner_hash}:{node_id}:recent`. The cloud derives
+# owner_hash from the cm_ token (sha256 hex) — we compute the same value here
+# so both sides agree on the key without needing the daemon to know the
+# cloud's internal user id.
+#
+# TTL: 6h. Each heartbeat overwrites the entry, so TTL only matters when the
+# daemon goes offline — after 6h the cloud treats the cache as cold and
+# re-subscribes. Long enough to cover a typical work-day pause; short enough
+# that stale data doesn't linger after a node is decommissioned.
+BRAIN_CACHE_TTL_SEC = 21600
+BRAIN_CACHE_LIMIT = 50
+
+
+def _owner_hash_for_token(api_key: str) -> str:
+    """Mirror of cloud's `_owner_hash_for(token)` — sha256 hex of the cm_
+    token. The daemon computes it locally so the cache key it sends matches
+    exactly what the cloud derives from the same token on read."""
+    import hashlib
+    return hashlib.sha256((api_key or "").encode("utf-8")).hexdigest()
+
+
+def _build_brain_cache_pushes(config: dict) -> list:
+    """Return the heartbeat `cache_pushes` array — currently a single entry
+    holding the encrypted top-50 brain events for this node.
+
+    Returns an empty list when:
+      - The local store has no events yet (fresh install) — nothing to push.
+      - Encryption key is unset — we never push plaintext.
+      - The local store import fails — degrade silently.
+
+    The blob shape mirrors `routes.brain._try_local_store_brain` so the cloud
+    read path can hand the decrypted dict straight to the existing dashboard
+    JS without translation.
+    """
+    enc_key = config.get("encryption_key")
+    if not enc_key:
+        return []
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not (api_key and node_id):
+        return []
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return []
+    try:
+        store = local_store.get_store(read_only=True)
+        rows = store.query_events(limit=BRAIN_CACHE_LIMIT)
+    except Exception:
+        return []
+    if not rows:
+        return []
+    # Same translation as routes/brain.py:_try_local_store_brain so the
+    # browser sees an identical event shape regardless of which path served
+    # the data (cache hit vs. relay subscribe vs. JSONL fallback).
+    events = []
+    for r in rows:
+        data = r.get("data") if isinstance(r, dict) else None
+        detail = ""
+        if isinstance(data, dict):
+            detail = (data.get("input") or data.get("summary")
+                      or data.get("text") or data.get("name") or "")
+        elif isinstance(data, str):
+            detail = data
+        events.append({
+            "time":      r.get("ts", ""),
+            "type":      (r.get("event_type") or "").upper(),
+            "detail":    str(detail)[:200],
+            "src":       (r.get("session_id") or r.get("agent_id") or "")[:32],
+            "sessionId": r.get("session_id") or "",
+            "agentId":   r.get("agent_id") or "main",
+            "tokens":    r.get("token_count") or 0,
+            "cost":      float(r.get("cost_usd") or 0.0),
+            "model":     r.get("model") or "",
+        })
+    payload = {
+        "events":  events,
+        "count":   len(events),
+        "_source": "local_store",
+        "_shape":  "brain_history",
+    }
+    try:
+        blob = encrypt_payload(payload, enc_key)
+    except Exception:
+        return []
+    owner_hash = _owner_hash_for_token(api_key)
+    return [{
+        "key":    f"brain:{owner_hash}:{node_id}:recent",
+        "ttl_s":  BRAIN_CACHE_TTL_SEC,
+        "blob":   blob,
+    }]
 
 
 def _dispatch_pending_queries(config: dict, pending: list) -> None:

--- a/tests/test_brain_cache_push.py
+++ b/tests/test_brain_cache_push.py
@@ -1,0 +1,242 @@
+"""Tests for Phase 2 of the heartbeat-piggyback relay (epic #1032).
+
+The OSS daemon proactively pushes the top-50 brain events to the cloud cache
+on every heartbeat so the cloud Brain page paints in <100ms (cache hit) on
+first load instead of waiting for a /api/cloud/subscribe round-trip.
+
+These tests cover:
+  1. Happy path: 50 seeded events → `cache_pushes` array with one entry,
+     correct key shape, ttl=21600, encrypted blob is bytes-like (str of
+     base64url ciphertext from `encrypt_payload`).
+  2. Empty store: no events → no `cache_pushes` key in the heartbeat payload.
+  3. Missing encryption key: blob would leak plaintext → no push.
+  4. Round-trip: blob decrypts back to the brain-history shape so the cloud
+     read path gets the same dict the OSS dashboard would render.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import uuid
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sync_with_seeded_events(tmp_path, monkeypatch):
+    """Reload `clawmetry.sync` + `clawmetry.local_store` against a fresh
+    DuckDB seeded with 50 brain events. Yields (sync_module, config)."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    store = ls.get_store()
+    for i in range(50):
+        store.ingest({
+            "id":           str(uuid.uuid4()),
+            "node_id":      "agent+test",
+            "agent_id":     "main",
+            "session_id":   f"sess-{i % 3}",
+            "event_type":   "message",
+            "ts":           f"2026-05-12T10:{i:02d}:00+00:00",
+            "data":         {"text": f"hello world {i}"},
+            "cost_usd":     0.001,
+            "token_count":  42,
+            "model":        "claude-opus-4-7",
+        })
+
+    # Wait for the background flusher.
+    import time
+    for _ in range(80):
+        if store.health()["ring_depth"] == 0:
+            break
+        time.sleep(0.05)
+
+    config = {
+        "node_id":         "node-test",
+        "api_key":         "cm_test_token_xyz",
+        "encryption_key":  s.generate_encryption_key(),
+    }
+
+    yield s, config
+
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def sync_with_empty_store(tmp_path, monkeypatch):
+    """Same as above but no seeded events — covers the "fresh install"
+    degenerate case where there's nothing to push yet."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    config = {
+        "node_id":         "node-empty",
+        "api_key":         "cm_test_token_xyz",
+        "encryption_key":  s.generate_encryption_key(),
+    }
+
+    yield s, config
+
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+# ── 1. happy path: 50 events → 1 cache_push entry ───────────────────────────
+
+
+def test_build_brain_cache_pushes_returns_one_entry(sync_with_seeded_events):
+    s, config = sync_with_seeded_events
+    pushes = s._build_brain_cache_pushes(config)
+
+    assert isinstance(pushes, list)
+    assert len(pushes) == 1
+    entry = pushes[0]
+
+    # Key shape: brain:{owner_hash}:{node}:recent
+    expected_owner = s._owner_hash_for_token(config["api_key"])
+    assert entry["key"] == f"brain:{expected_owner}:node-test:recent"
+
+    assert entry["ttl_s"] == s.BRAIN_CACHE_TTL_SEC == 21600
+
+    # Blob is the encrypted payload — a base64url-encoded string of
+    # nonce||ciphertext. Must be non-empty and not contain plaintext markers
+    # from the seeded events ("hello world" / "sess-").
+    blob = entry["blob"]
+    assert isinstance(blob, str)
+    assert len(blob) > 0
+    assert "hello world" not in blob
+    assert "sess-" not in blob
+
+
+# ── 2. empty store: no push (heartbeat payload won't carry the key) ─────────
+
+
+def test_build_brain_cache_pushes_empty_store_returns_empty(sync_with_empty_store):
+    s, config = sync_with_empty_store
+    pushes = s._build_brain_cache_pushes(config)
+    assert pushes == [], "empty local store must produce no cache_pushes"
+
+
+def test_send_heartbeat_omits_cache_pushes_when_empty(sync_with_empty_store, monkeypatch):
+    """End-to-end: send_heartbeat with an empty store must NOT include
+    `cache_pushes` in the request payload (or include an empty list — either
+    way the cloud's iteration is a no-op)."""
+    s, config = sync_with_empty_store
+    captured = {}
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/heartbeat":
+            captured["payload"] = payload
+            return {"sync_allowed": True, "pending_queries": []}
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(s, "_post", fake_post)
+    monkeypatch.setattr(s.time, "sleep", lambda *a, **kw: None)
+
+    assert s.send_heartbeat(config) is True
+    payload = captured["payload"]
+    # Either omitted entirely or present-but-empty are both acceptable
+    # (cloud iteration is a no-op on []). Default to "omitted" for cleaner
+    # wire format.
+    pushes = payload.get("cache_pushes", [])
+    assert pushes == [] or "cache_pushes" not in payload
+
+
+# ── 3. missing encryption key: never push plaintext ─────────────────────────
+
+
+def test_no_encryption_key_no_push(sync_with_seeded_events):
+    s, config = sync_with_seeded_events
+    config_no_key = dict(config)
+    config_no_key["encryption_key"] = None
+    pushes = s._build_brain_cache_pushes(config_no_key)
+    assert pushes == [], "must not push when encryption key is unset"
+
+
+# ── 4. round-trip: blob decrypts back to the brain-history shape ────────────
+
+
+def test_pushed_blob_decrypts_to_brain_history_shape(sync_with_seeded_events):
+    s, config = sync_with_seeded_events
+    pushes = s._build_brain_cache_pushes(config)
+    assert len(pushes) == 1
+
+    decoded = s.decrypt_payload(pushes[0]["blob"], config["encryption_key"])
+    assert isinstance(decoded, dict)
+    assert decoded["_shape"] == "brain_history"
+    assert decoded["_source"] == "local_store"
+    assert "events" in decoded
+    assert decoded["count"] == len(decoded["events"])
+    # We seeded 50 events; the push should carry exactly that.
+    assert decoded["count"] == 50
+
+    # Each event must carry the dashboard-expected shape
+    # (time/type/detail/src/sessionId/...).
+    sample = decoded["events"][0]
+    for k in ("time", "type", "detail", "src", "sessionId", "agentId",
+              "tokens", "cost", "model"):
+        assert k in sample, f"event missing key {k!r}"
+    # Type came from event_type=message (uppercased).
+    assert sample["type"] == "MESSAGE"
+
+
+# ── 5. send_heartbeat wires the push into the request payload ───────────────
+
+
+def test_send_heartbeat_attaches_cache_pushes(sync_with_seeded_events, monkeypatch):
+    s, config = sync_with_seeded_events
+    captured = {}
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/heartbeat":
+            captured["payload"] = payload
+            return {"sync_allowed": True, "pending_queries": []}
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(s, "_post", fake_post)
+    monkeypatch.setattr(s.time, "sleep", lambda *a, **kw: None)
+
+    assert s.send_heartbeat(config) is True
+    payload = captured["payload"]
+    assert "cache_pushes" in payload
+    assert len(payload["cache_pushes"]) == 1
+    entry = payload["cache_pushes"][0]
+    assert entry["key"].startswith("brain:") and entry["key"].endswith(":node-test:recent")
+    assert entry["ttl_s"] == 21600
+    assert isinstance(entry["blob"], str) and len(entry["blob"]) > 0


### PR DESCRIPTION
## Summary
- OSS daemon now proactively pushes top-50 brain events to the cloud cache on every heartbeat (60s).
- Pairs with cloud-side PR (in flight) that consumes `cache_pushes` and serves the Brain page from cache in <100ms.
- Implements the OSS half of epic #1032 Phase 2 ("Brain proof point").

## Mechanism
`send_heartbeat()` now appends a `cache_pushes` array to the heartbeat payload:

```json
{
  "node_id": "...",
  "ts": "...",
  "cache_pushes": [{
    "key": "brain:{sha256(api_key)}:{node_id}:recent",
    "ttl_s": 21600,
    "blob": "<AES-256-GCM ciphertext, base64url>"
  }]
}
```

The blob shape mirrors `routes/brain.py:_try_local_store_brain` so the cloud read path can hand the decrypted dict straight to the existing dashboard JS.

## Invariants preserved
- **Never plaintext** — same E2E AES-256-GCM path already used by `/ingest/cache`. No encryption key → no push.
- **Empty store → no push** — fresh installs don't bloat the heartbeat with `[]`.
- **Best-effort** — any exception in the build is caught; heartbeat itself never regresses.
- **Symmetric key derivation** — OSS computes `sha256(api_key)`, cloud computes `sha256(token)` from the Authorization header. Same cm_ token in both places → same hash → same key.

## Test plan
- [x] `tests/test_brain_cache_push.py` (6 tests) — happy path, empty store, no encryption key, send_heartbeat wiring, decrypt round-trip
- [x] `tests/test_heartbeat_dispatch.py` (5 tests) — Phase 1 untouched, all green
- [ ] Will be exercised end-to-end after the cloud-side PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)