### PR TITLE
feat(alerts): alert rules → DuckDB + Redis cache (epic #1032 Phase 3 — OSS)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -116,7 +116,7 @@ LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # ── Two-layer schema (multi-agent) ──────────────────────────────────────────
 #
@@ -831,6 +831,81 @@ class LocalStore:
                   int(sa.get("token_count") or 0),
                   data_blob, now_ms])
 
+    def ingest_alert_rule(self, rule: dict[str, Any]) -> None:
+        """Upsert one alert rule. Required: ``id``.
+
+        Optional: ``owner_hash``, ``name``, ``condition_json``,
+        ``enabled`` (default True), ``created_at``, ``updated_at``,
+        ``last_fired_at``, ``fire_count``.
+
+        ``condition_json`` accepts a dict / list / str / bytes — it is
+        coerced to a BLOB via the same path as session metadata, so the
+        cloud can store whichever rule shape it likes without dragging
+        a schema bump through here. Pre-existing values for
+        ``created_at``, ``last_fired_at``, and ``fire_count`` are
+        preserved across upserts (the relay-driven write path doesn't
+        know them — only the local evaluator does)."""
+        rid = rule.get("id")
+        if not rid:
+            raise ValueError("alert rule must include 'id'")
+        cond_blob = _to_blob(rule.get("condition_json"))
+        enabled = rule.get("enabled")
+        enabled = True if enabled is None else bool(enabled)
+        # fire_count is coerced to int when supplied, otherwise we keep the
+        # existing value via the ON CONFLICT clause below.
+        try:
+            fire_count = int(rule.get("fire_count")) if rule.get("fire_count") is not None else 0
+        except (TypeError, ValueError):
+            fire_count = 0
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO alert_rules (
+                    id, owner_hash, name, condition_json, enabled,
+                    created_at, updated_at, last_fired_at, fire_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO UPDATE SET
+                    owner_hash     = COALESCE(excluded.owner_hash, alert_rules.owner_hash),
+                    name           = COALESCE(excluded.name, alert_rules.name),
+                    condition_json = COALESCE(excluded.condition_json, alert_rules.condition_json),
+                    enabled        = excluded.enabled,
+                    updated_at     = COALESCE(excluded.updated_at, alert_rules.updated_at),
+                    last_fired_at  = COALESCE(excluded.last_fired_at, alert_rules.last_fired_at),
+                    fire_count     = CASE
+                                       WHEN excluded.fire_count > 0
+                                         THEN excluded.fire_count
+                                       ELSE alert_rules.fire_count
+                                     END
+            """, [
+                str(rid),
+                rule.get("owner_hash"),
+                rule.get("name"),
+                cond_blob,
+                enabled,
+                rule.get("created_at"),
+                rule.get("updated_at"),
+                rule.get("last_fired_at"),
+                fire_count,
+            ])
+
+    def delete_alert_rule(self, rule_id: str) -> int:
+        """Delete one alert rule by id. Returns 1 on delete, 0 when missing.
+
+        Uses a SELECT-before-DELETE check because DuckDB's ``cur.rowcount``
+        is unreliable for DELETE on some versions (returns -1). Cheap at
+        our scale — alert rules are a tiny table."""
+        if not rule_id:
+            return 0
+        # Check existence first so we can return an accurate 0/1.
+        rid = str(rule_id)
+        rows_before = self._fetch(
+            "SELECT 1 FROM alert_rules WHERE id = ? LIMIT 1", [rid]
+        )
+        if not rows_before:
+            return 0
+        with self._write_lock:
+            self._conn.execute("DELETE FROM alert_rules WHERE id = ?", [rid])
+        return 1
+
     def ingest_system_snapshot(self, snap: dict[str, Any]) -> None:
         """Insert one system-snapshot row. Append-only;
         (agent_type, node_id, ts, kind) PK silently ignores duplicates."""
@@ -1196,6 +1271,55 @@ class LocalStore:
         cols = ["provider", "enabled", "last_test_at", "last_test_ok",
                 "last_test_error", "updated_at"]
         return [_row_to_dict(r, cols) for r in self._fetch(sql, params)]
+
+    def query_alert_rules(
+        self,
+        *,
+        owner_hash: str | None = None,
+        enabled_only: bool = False,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Read alert-rule rows. Defaults to most-recently-updated first.
+
+        ``owner_hash`` scopes the result to one cm_ token (sha256 of the
+        token). ``enabled_only=True`` filters to ``enabled=TRUE``. The
+        ``condition_json`` BLOB is decoded back to a JSON dict where
+        valid (str otherwise, None when empty) so callers can drop the
+        whole row into ``/api/alerts/rules`` without a second decode."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if owner_hash:
+            clauses.append("owner_hash = ?")
+            params.append(owner_hash)
+        if enabled_only:
+            clauses.append("enabled = TRUE")
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT id, owner_hash, name, condition_json, enabled,
+                   created_at, updated_at, last_fired_at, fire_count
+            FROM alert_rules
+            {where}
+            ORDER BY COALESCE(updated_at, created_at) DESC NULLS LAST, id
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["id", "owner_hash", "name", "condition_json", "enabled",
+                "created_at", "updated_at", "last_fired_at", "fire_count"]
+        out: list[dict[str, Any]] = []
+        for r in self._fetch(sql, params):
+            d = dict(zip(cols, r))
+            raw = d.get("condition_json")
+            if raw is not None:
+                try:
+                    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                    try:
+                        d["condition_json"] = json.loads(text)
+                    except (ValueError, TypeError):
+                        d["condition_json"] = text
+                except UnicodeDecodeError:
+                    d["condition_json"] = None
+            out.append(d)
+        return out
 
     def query_memory_blobs(
         self,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1786,6 +1786,16 @@ def send_heartbeat(config: dict) -> bool:
             payload.setdefault("cache_pushes", []).extend(ch_pushes)
     except Exception as _cp_e:
         log.debug("channel-config cache_push build failed (continuing): %s", _cp_e)
+    # Phase 3 of relay-v2 (#1032): also push the user's alert-rule list so the
+    # cloud Alerts tab paints from cache. Same envelope (`cache_pushes`) — the
+    # cloud's _accept_cache_pushes handler iterates the array regardless of
+    # which Phase contributed which entry.
+    try:
+        alert_pushes = _build_alert_rules_cache_pushes(config)
+        if alert_pushes:
+            payload.setdefault("cache_pushes", []).extend(alert_pushes)
+    except Exception as _ap_e:
+        log.debug("alert-rules cache_push build failed (continuing): %s", _ap_e)
     # Local-first: persist this heartbeat to local DuckDB so the dashboard
     # has a per-node liveness history even when offline. Best-effort.
     try:
@@ -2036,6 +2046,78 @@ def _build_channel_config_status_cache_pushes(config: dict) -> list:
     }]
 
 
+# ── Phase 3: proactive alert-rules cache_push (epic #1032) ───────────────────
+# Alert rules live in local DuckDB after Phase 3 — the cloud UI authors them,
+# the relay's pending_queries channel pipes them into the local store, and the
+# evaluator (in-process daemon) reads from DuckDB. To keep the cloud Alerts
+# tab paint-fast, we also push the current rule list to the cloud cache on
+# every heartbeat under `alerts:{owner_hash}:rules`.
+#
+# Why a flat (no node) key: alert rules are owner-scoped, not node-scoped — a
+# user with three nodes sees one rules list across all of them. Cloud-side
+# read path uses the same key shape (see clawmetry-cloud routes/alerts.py).
+#
+# TTL: 3600s. Each heartbeat overwrites the entry, so TTL only matters when
+# the daemon goes offline.
+ALERT_RULES_CACHE_TTL_SEC = 3600
+ALERT_RULES_CACHE_LIMIT = 500
+
+
+def _build_alert_rules_cache_pushes(config: dict) -> list:
+    """Return the heartbeat `cache_pushes` array for alert rules — currently
+    a single entry holding the full enabled+disabled rule list owned by this
+    cm_ token.
+
+    Returns an empty list when:
+      - The local store has no alert rules yet (no cloud has authored any).
+      - Encryption key is unset — we never push plaintext.
+      - The local store import fails — degrade silently.
+
+    The blob shape mirrors `/api/alerts/rules` so the cloud read path can
+    hand the decrypted dict straight to the existing dashboard JS.
+    """
+    enc_key = config.get("encryption_key")
+    if not enc_key:
+        return []
+    api_key = config.get("api_key", "")
+    if not api_key:
+        return []
+    try:
+        from clawmetry import local_store
+    except Exception:
+        return []
+    owner_hash = _owner_hash_for_token(api_key)
+    try:
+        store = local_store.get_store(read_only=True)
+        # Filter by owner_hash so a multi-tenant local store (rare today, but
+        # cheap to be correct about) only pushes the calling token's rules.
+        rows = store.query_alert_rules(
+            owner_hash=owner_hash, limit=ALERT_RULES_CACHE_LIMIT
+        )
+    except Exception:
+        return []
+    if not rows:
+        return []
+    # Same shape `/api/alerts/rules` returns when the local-store fast path
+    # is enabled — cloud Alerts tab + integration tests can compare against
+    # this without translation.
+    payload = {
+        "rules":   rows,
+        "count":   len(rows),
+        "_source": "local_store",
+        "_shape":  "alert_rules",
+    }
+    try:
+        blob = encrypt_payload(payload, enc_key)
+    except Exception:
+        return []
+    return [{
+        "key":    f"alerts:{owner_hash}:rules",
+        "ttl_s":  ALERT_RULES_CACHE_TTL_SEC,
+        "blob":   blob,
+    }]
+
+
 def _dispatch_pending_action(config: dict, action: dict) -> None:
     """Handle a single action-style pending entry. Routes by ``type``.
 
@@ -2178,6 +2260,7 @@ def _run_channel_test_local(config: dict, provider: str):
     if blob is None or (isinstance(blob, (bytes, bytearray)) and len(blob) == 0):
         return False, "config blob empty"
     return True, None
+
 
 
 def _dispatch_pending_queries(config: dict, pending: list) -> None:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1975,7 +1975,17 @@ def _build_brain_cache_pushes(config: dict) -> list:
 
 CHANNEL_STATUS_CACHE_TTL_SEC = 3600
 
-_PENDING_ACTIONS = frozenset({"channel_config_upsert", "channel_test"})
+# Action-style pending entries the daemon handles in-process (no /ingest/cache
+# POST). Phase 5 added the channel-config actions; Phase 3 of #1032 (alert
+# rules) extends the set so cloud-authored rules land in local DuckDB on the
+# next heartbeat cycle. Mirrors the cloud-side allowlist used by
+# clawmetry-cloud/routes/alerts.py:_enqueue_alert_rule_change.
+_PENDING_ACTIONS = frozenset({
+    "channel_config_upsert",
+    "channel_test",
+    "alert_rule_upsert",
+    "alert_rule_delete",
+})
 
 
 def _build_channel_config_status_cache_pushes(config: dict) -> list:
@@ -2121,12 +2131,19 @@ def _build_alert_rules_cache_pushes(config: dict) -> list:
 def _dispatch_pending_action(config: dict, action: dict) -> None:
     """Handle a single action-style pending entry. Routes by ``type``.
 
-    Phase 5 supports ``channel_config_upsert`` (cloud-submitted config →
-    local DuckDB) and ``channel_test`` (run the upstream-adapter test +
-    stamp result). Unknown / malformed types are silently dropped
-    (defensive — cloud should already have filtered). Per-action errors
-    are logged but never raise — one bad action must not block the
-    heartbeat batch."""
+    Supported types (union across phases of epic #1032):
+
+      * ``channel_config_upsert`` (Phase 5) — cloud-submitted channel
+        adapter config → local DuckDB ``channel_config`` table.
+      * ``channel_test`` (Phase 5) — run upstream-adapter test + stamp
+        the result back into ``channel_config``.
+      * ``alert_rule_upsert`` (Phase 3) — cloud-authored alert rule →
+        ``alert_rules`` table via ``ingest_alert_rule``.
+      * ``alert_rule_delete`` (Phase 3) — delete one alert rule by id.
+
+    Unknown / malformed types are silently dropped (defensive — cloud
+    should already have filtered). Per-action errors are logged but never
+    raise — one bad action must not block the heartbeat batch."""
     atype = action.get("type")
     if atype not in _PENDING_ACTIONS:
         return
@@ -2135,6 +2152,9 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
         return
     if atype == "channel_test":
         _action_channel_test(config, action)
+        return
+    if atype in ("alert_rule_upsert", "alert_rule_delete"):
+        _apply_pending_write(atype, action)
         return
 
 
@@ -2273,11 +2293,14 @@ def _dispatch_pending_queries(config: dict, pending: list) -> None:
     1. ``{shape, id, cache_key, args}`` — read query. Dispatched via
        routes.local_query (or fallback) and the result is encrypted +
        POSTed to /ingest/cache.
-    2. ``{type, …}`` — local action (write or side-effect). Currently
-       supports ``channel_config_upsert`` and ``channel_test`` from
-       epic #1032 Phase 5. Action handlers run synchronously against the
-       local store / adapter; status fields are pushed back on the next
-       heartbeat via ``_build_channel_config_status_cache_pushes``."""
+    2. ``{type, …}`` — local action (write or side-effect). Routed
+       through ``_dispatch_pending_action``. The unified ``_PENDING_ACTIONS``
+       allowlist covers Phase 5 channel-config actions
+       (``channel_config_upsert``, ``channel_test``) and Phase 3 alert-rule
+       writes (``alert_rule_upsert``, ``alert_rule_delete``). Writes are
+       fire-and-forget — no /ingest/cache POST; the next heartbeat's
+       cache_push surfaces the new state to the cloud.
+    """
     try:
         from routes.local_query import _dispatch as _local_dispatch  # type: ignore
     except Exception:
@@ -2325,6 +2348,61 @@ def _dispatch_pending_queries(config: dict, pending: list) -> None:
                         (q or {}).get("id") if isinstance(q, dict) else None,
                         (q or {}).get("shape") if isinstance(q, dict) else None,
                         e)
+
+
+# ── Write-through helper (Phase 3 of #1032) ─────────────────────────────────
+# Applies alert-rule writes from the cloud-relayed pending_queries channel to
+# the local DuckDB. Dispatched from ``_dispatch_pending_action`` via the
+# unified ``_PENDING_ACTIONS`` allowlist. Mirrors the cloud-side enqueue path
+# (clawmetry-cloud/routes/alerts.py:_enqueue_alert_rule_change).
+
+
+def _apply_pending_write(qtype: str, q: dict) -> None:
+    """Apply one cloud-authored write to the local DuckDB.
+
+    Routed by ``type``:
+
+      ``alert_rule_upsert`` → ``ingest_alert_rule(body)``
+      ``alert_rule_delete`` → ``delete_alert_rule(id)``
+
+    Raises on bad input so the caller's per-item logger flags it. Cloud is
+    already responsible for shape validation, so this is defense-in-depth.
+    """
+    from clawmetry import local_store
+    store = local_store.get_store()
+    if qtype == "alert_rule_upsert":
+        body = q.get("body") or {}
+        if not isinstance(body, dict):
+            raise ValueError("alert_rule_upsert: body must be a dict")
+        # The cloud uses `alert_type` (its own column) — translate into the
+        # OSS local-store shape: condition_json holds the whole cloud body so
+        # the evaluator + dashboard get everything without a follow-up fetch.
+        rule = {
+            "id":            body.get("id") or q.get("id"),
+            "owner_hash":    body.get("owner_hash"),
+            "name":          body.get("name"),
+            "condition_json": body,
+            "enabled":       body.get("enabled", True),
+            "created_at":    body.get("created_at"),
+            "updated_at":    body.get("updated_at"),
+            "last_fired_at": body.get("last_triggered_at"),
+            "fire_count":    body.get("trigger_count") or 0,
+        }
+        if not rule["id"]:
+            raise ValueError("alert_rule_upsert: id required")
+        store.ingest_alert_rule(rule)
+        log.info("local store: applied alert_rule_upsert id=%s", rule["id"])
+        return
+    if qtype == "alert_rule_delete":
+        rid = q.get("id")
+        if not rid:
+            raise ValueError("alert_rule_delete: id required")
+        n = store.delete_alert_rule(rid)
+        log.info("local store: applied alert_rule_delete id=%s (rows=%d)", rid, n)
+        return
+    # Unknown write — caller already gated via _PENDING_ACTIONS; reaching
+    # here means the allowlist was changed without wiring this dispatcher.
+    raise ValueError(f"unhandled write type: {qtype}")
 
 
 def _get_version() -> str:

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -37,12 +37,44 @@ zero behaviour change.
 """
 
 import json
+import os
 import time
 
 from flask import Blueprint, jsonify, request
 
 bp_budget = Blueprint('budget', __name__)
 bp_alerts = Blueprint('alerts', __name__)
+
+
+# ── Local-store fast path (Phase 3 of epic #1032) ────────────────────────────
+# Opt-in via CLAWMETRY_LOCAL_STORE_READ=1. Mirrors the same pattern used by
+# routes/crons.py and routes/sessions.py: gate the DuckDB read on the env flag,
+# return ``None`` to fall through to the legacy fleet-DB path on any error or
+# empty result. Cloud-authored rules land in this DuckDB table via the
+# heartbeat relay's pending_queries channel; the local evaluator picks them
+# up on its next pass.
+
+
+def _try_local_store_alert_rules():
+    """Return alert rules from the local DuckDB.
+
+    Returns ``None`` to defer to the legacy fleet-DB path if:
+      - the ``local_store`` module isn't importable
+      - the ``alert_rules`` table is empty (fresh install / no cloud sync)
+      - any unexpected error happens (we'd rather degrade than 500)
+
+    Tagged with ``_source: "local_store"`` so callers (browser, integration
+    tests, the cloud relay) can tell which path served them.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+        rows = store.query_alert_rules(limit=500)
+    except Exception:
+        return None
+    if not rows:
+        return None
+    return {"rules": rows, "_source": "local_store"}
 
 
 # ── Budget API Routes ───────────────────────────────────────────────────
@@ -193,6 +225,13 @@ def api_alert_rules():
             db.commit()
             db.close()
         return jsonify({"ok": True, "id": rule_id})
+    # Phase 3 of #1032 — local DuckDB fast path. Opt-in via
+    # CLAWMETRY_LOCAL_STORE_READ=1; falls through to the legacy fleet-DB
+    # _get_alert_rules helper on miss / disabled flag.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_alert_rules()
+        if fast is not None:
+            return jsonify(fast)
     return jsonify({"rules": _d._get_alert_rules()})
 
 

--- a/tests/test_alert_rules_local_store.py
+++ b/tests/test_alert_rules_local_store.py
@@ -333,6 +333,95 @@ def test_pushed_blob_decrypts_to_alert_rules_shape(sync_with_rules):
     assert isinstance(sample["condition_json"], dict)
 
 
+# ── 4. Write-through dispatcher (cloud → DuckDB) ───────────────────────────
+
+
+def test_apply_pending_write_alert_rule_upsert(sync_with_rules):
+    """Cloud-authored alert_rule_upsert lands in local DuckDB."""
+    s, ls, config = sync_with_rules
+    body = {
+        "id": "cloud-rule-1",
+        "owner_hash": s._owner_hash_for_token(config["api_key"]),
+        "name": "Cloud-authored",
+        "alert_type": "session_cost",
+        "threshold_value": 5.0,
+        "enabled": True,
+        "created_at": "2026-05-12T12:00:00Z",
+        "updated_at": "2026-05-12T12:00:00Z",
+    }
+    s._apply_pending_write("alert_rule_upsert", {
+        "type": "alert_rule_upsert",
+        "id":   "cloud-rule-1",
+        "body": body,
+    })
+
+    rows = ls.get_store().query_alert_rules()
+    cloud_row = next((r for r in rows if r["id"] == "cloud-rule-1"), None)
+    assert cloud_row is not None
+    assert cloud_row["name"] == "Cloud-authored"
+    # condition_json is the full cloud body — including fields OSS doesn't
+    # break out into columns (alert_type, threshold_value).
+    assert cloud_row["condition_json"]["alert_type"] == "session_cost"
+    assert cloud_row["condition_json"]["threshold_value"] == 5.0
+
+
+def test_apply_pending_write_alert_rule_delete(sync_with_rules):
+    """Cloud-authored alert_rule_delete removes the row from local DuckDB."""
+    s, ls, config = sync_with_rules
+    # `sync_with_rules` already seeded rule-0/1/2 — pick one and delete it.
+    s._apply_pending_write("alert_rule_delete", {
+        "type": "alert_rule_delete",
+        "id":   "rule-0",
+    })
+    remaining_ids = {r["id"] for r in ls.get_store().query_alert_rules()}
+    assert "rule-0" not in remaining_ids
+    assert {"rule-1", "rule-2"} <= remaining_ids
+
+
+def test_dispatch_pending_queries_routes_writes(sync_with_rules, monkeypatch):
+    """_dispatch_pending_queries handles both shapes (reads) and types
+    (writes) in the same pending list. Read shapes still POST to
+    /ingest/cache; writes apply locally with no /ingest/cache POST."""
+    s, ls, config = sync_with_rules
+    cache_posts = []
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/cache":
+            cache_posts.append(payload)
+            return {"ok": True}
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(s, "_post", fake_post)
+
+    pending = [
+        {
+            "type": "alert_rule_upsert",
+            "id": "via-dispatch",
+            "body": {
+                "id": "via-dispatch",
+                "name": "Via dispatch",
+                "alert_type": "daily_spend",
+                "threshold_value": 1.0,
+                "enabled": True,
+            },
+        },
+        {
+            "type": "alert_rule_delete",
+            "id": "rule-1",
+        },
+        # A junk item with an unknown type — must be silently skipped.
+        {"type": "unknown_write", "id": "x"},
+    ]
+    s._dispatch_pending_queries(config, pending)
+
+    rule_ids = {r["id"] for r in ls.get_store().query_alert_rules()}
+    assert "via-dispatch" in rule_ids
+    assert "rule-1" not in rule_ids
+    # Writes intentionally don't POST to /ingest/cache — heartbeat's
+    # cache_push handles the cloud-visible state on the next cycle.
+    assert cache_posts == []
+
+
 def test_send_heartbeat_attaches_alert_rules_push(sync_with_rules, monkeypatch):
     """End-to-end: send_heartbeat with seeded rules must include an alert
     rules entry in the heartbeat payload's cache_pushes list."""

--- a/tests/test_alert_rules_local_store.py
+++ b/tests/test_alert_rules_local_store.py
@@ -1,0 +1,358 @@
+"""Tests for Phase 3 of the heartbeat-piggyback relay (epic #1032).
+
+Three surfaces:
+  1. DuckDB schema — ``alert_rules`` table is reachable via ``ingest_alert_rule``
+     + ``query_alert_rules`` + ``delete_alert_rule``. Round-trip + filter +
+     enabled_only behaviour.
+  2. Route fast path — ``/api/alerts/rules`` GET serves from DuckDB tagged
+     ``_source: "local_store"`` when ``CLAWMETRY_LOCAL_STORE_READ=1``. With
+     the flag off the legacy fleet-DB helper is used (no ``_source`` tag).
+  3. ``_build_alert_rules_cache_pushes`` — heartbeat cache push for
+     ``alerts:{owner_hash}:rules`` is emitted iff rules exist and an
+     encryption key is configured.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Reload `clawmetry.local_store` against a fresh DuckDB file. Yields
+    (module, store); closes on teardown."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    store = ls.get_store()
+    yield ls, store
+
+    try:
+        store.stop(flush=False)
+    except Exception:
+        pass
+
+
+# ── 1. Schema round-trip ───────────────────────────────────────────────────
+
+
+def test_ingest_and_query_alert_rule_round_trip(fresh_store):
+    ls, store = fresh_store
+    rule = {
+        "id": "rule-001",
+        "owner_hash": "abc123",
+        "name": "Daily spend > $10",
+        "condition_json": {
+            "alert_type": "daily_spend",
+            "threshold_value": 10.0,
+            "channel_ids": ["chan-1"],
+        },
+        "enabled": True,
+        "created_at": "2026-05-12T10:00:00Z",
+        "updated_at": "2026-05-12T10:00:00Z",
+    }
+    store.ingest_alert_rule(rule)
+    rows = store.query_alert_rules(limit=10)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["id"] == "rule-001"
+    assert r["owner_hash"] == "abc123"
+    assert r["name"] == "Daily spend > $10"
+    assert r["enabled"] is True
+    # condition_json BLOB is decoded back to a dict by the read path.
+    assert isinstance(r["condition_json"], dict)
+    assert r["condition_json"]["alert_type"] == "daily_spend"
+    assert r["condition_json"]["threshold_value"] == 10.0
+
+
+def test_query_filters_by_owner_and_enabled(fresh_store):
+    ls, store = fresh_store
+    store.ingest_alert_rule({
+        "id": "r-a-on", "owner_hash": "owner-A",
+        "condition_json": {"alert_type": "x"}, "enabled": True,
+    })
+    store.ingest_alert_rule({
+        "id": "r-a-off", "owner_hash": "owner-A",
+        "condition_json": {"alert_type": "y"}, "enabled": False,
+    })
+    store.ingest_alert_rule({
+        "id": "r-b-on", "owner_hash": "owner-B",
+        "condition_json": {"alert_type": "z"}, "enabled": True,
+    })
+    a_all = store.query_alert_rules(owner_hash="owner-A")
+    assert {r["id"] for r in a_all} == {"r-a-on", "r-a-off"}
+    a_on = store.query_alert_rules(owner_hash="owner-A", enabled_only=True)
+    assert {r["id"] for r in a_on} == {"r-a-on"}
+    b_all = store.query_alert_rules(owner_hash="owner-B")
+    assert {r["id"] for r in b_all} == {"r-b-on"}
+
+
+def test_ingest_alert_rule_upsert_updates_existing(fresh_store):
+    ls, store = fresh_store
+    store.ingest_alert_rule({
+        "id": "r1", "owner_hash": "owner-A",
+        "name": "v1",
+        "condition_json": {"threshold_value": 1},
+        "enabled": True,
+    })
+    store.ingest_alert_rule({
+        "id": "r1", "owner_hash": "owner-A",
+        "name": "v2",
+        "condition_json": {"threshold_value": 2},
+        "enabled": False,
+        "updated_at": "2026-05-12T11:00:00Z",
+    })
+    rows = store.query_alert_rules()
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["name"] == "v2"
+    assert r["enabled"] is False
+    assert r["condition_json"]["threshold_value"] == 2
+    assert r["updated_at"] == "2026-05-12T11:00:00Z"
+
+
+def test_delete_alert_rule_removes_row(fresh_store):
+    ls, store = fresh_store
+    store.ingest_alert_rule({
+        "id": "r-del", "owner_hash": "owner-A",
+        "condition_json": {"alert_type": "x"}, "enabled": True,
+    })
+    assert len(store.query_alert_rules()) == 1
+    n = store.delete_alert_rule("r-del")
+    assert n == 1
+    assert store.query_alert_rules() == []
+    # Deleting again — no row, returns 0.
+    assert store.delete_alert_rule("r-del") == 0
+
+
+# ── 2. Route fast path ──────────────────────────────────────────────────────
+
+
+def test_api_alerts_rules_fast_path_serves_local_store(fresh_store, monkeypatch):
+    """With CLAWMETRY_LOCAL_STORE_READ=1 and a non-empty alert_rules table,
+    GET /api/alerts/rules returns the DuckDB rows tagged _source=local_store."""
+    ls, store = fresh_store
+    store.ingest_alert_rule({
+        "id": "r-fast",
+        "owner_hash": "owner-X",
+        "name": "fast-path rule",
+        "condition_json": {"alert_type": "token_velocity", "threshold_value": 9999},
+        "enabled": True,
+    })
+
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    # Reload the routes module so the late-bound _try_local_store_alert_rules
+    # picks up the freshly-reloaded local_store.
+    sys.modules.pop("routes.alerts", None)
+    import routes.alerts as ra
+    importlib.reload(ra)
+
+    from flask import Flask
+    app = Flask(__name__)
+    app.register_blueprint(ra.bp_alerts)
+    client = app.test_client()
+
+    resp = client.get("/api/alerts/rules")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body.get("_source") == "local_store"
+    assert isinstance(body.get("rules"), list)
+    assert len(body["rules"]) == 1
+    rule = body["rules"][0]
+    assert rule["id"] == "r-fast"
+    assert rule["condition_json"]["alert_type"] == "token_velocity"
+
+
+def test_api_alerts_rules_flag_off_uses_legacy(fresh_store, monkeypatch):
+    """With CLAWMETRY_LOCAL_STORE_READ unset, the route falls back to the
+    legacy dashboard helper — even if DuckDB has data."""
+    ls, store = fresh_store
+    store.ingest_alert_rule({
+        "id": "r-legacy",
+        "owner_hash": "owner-X",
+        "condition_json": {"alert_type": "x"},
+        "enabled": True,
+    })
+
+    monkeypatch.delenv("CLAWMETRY_LOCAL_STORE_READ", raising=False)
+
+    sys.modules.pop("routes.alerts", None)
+    import routes.alerts as ra
+    importlib.reload(ra)
+
+    # Stub `dashboard._get_alert_rules` so the legacy path returns a known
+    # sentinel that we can distinguish from the local-store response.
+    import types
+    fake_dashboard = types.ModuleType("dashboard")
+    fake_dashboard._get_alert_rules = lambda: [{"id": "legacy-rule", "src": "fleet_db"}]
+    monkeypatch.setitem(sys.modules, "dashboard", fake_dashboard)
+
+    from flask import Flask
+    app = Flask(__name__)
+    app.register_blueprint(ra.bp_alerts)
+    client = app.test_client()
+
+    resp = client.get("/api/alerts/rules")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "_source" not in body, "flag-off path must not tag _source"
+    assert body["rules"] == [{"id": "legacy-rule", "src": "fleet_db"}]
+
+
+# ── 3. Heartbeat cache push ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sync_with_rules(tmp_path, monkeypatch):
+    """Reload `clawmetry.sync` against a fresh DuckDB seeded with alert
+    rules. Yields (sync_module, local_store_module, config)."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    api_key = "cm_test_alerts_token_xyz"
+    owner_hash = s._owner_hash_for_token(api_key)
+
+    store = ls.get_store()
+    for i in range(3):
+        store.ingest_alert_rule({
+            "id": f"rule-{i}",
+            "owner_hash": owner_hash,
+            "name": f"rule {i}",
+            "condition_json": {"alert_type": "daily_spend", "threshold_value": i + 1},
+            "enabled": True,
+        })
+
+    config = {
+        "node_id":         "node-test",
+        "api_key":         api_key,
+        "encryption_key":  s.generate_encryption_key(),
+    }
+
+    yield s, ls, config
+
+    try:
+        ls.get_store().stop(flush=False)
+    except Exception:
+        pass
+
+
+def test_build_alert_rules_cache_pushes_returns_one_entry(sync_with_rules):
+    s, ls, config = sync_with_rules
+    pushes = s._build_alert_rules_cache_pushes(config)
+    assert isinstance(pushes, list)
+    assert len(pushes) == 1
+    entry = pushes[0]
+    owner_hash = s._owner_hash_for_token(config["api_key"])
+    assert entry["key"] == f"alerts:{owner_hash}:rules"
+    assert entry["ttl_s"] == s.ALERT_RULES_CACHE_TTL_SEC == 3600
+    blob = entry["blob"]
+    assert isinstance(blob, str) and len(blob) > 0
+    # Plaintext must not leak (rule name + alert_type are sensitive).
+    assert "daily_spend" not in blob
+    assert "rule-0" not in blob
+
+
+def test_build_alert_rules_cache_pushes_empty_when_no_rules(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    # Boot the store so the DB file exists (no rules ingested).
+    ls.get_store()
+    config = {
+        "node_id":         "node-empty",
+        "api_key":         "cm_empty",
+        "encryption_key":  s.generate_encryption_key(),
+    }
+    assert s._build_alert_rules_cache_pushes(config) == []
+    try:
+        ls.get_store().stop(flush=False)
+    except Exception:
+        pass
+
+
+def test_build_alert_rules_cache_pushes_no_encryption_key(sync_with_rules):
+    s, ls, config = sync_with_rules
+    cfg = dict(config)
+    cfg["encryption_key"] = None
+    assert s._build_alert_rules_cache_pushes(cfg) == []
+
+
+def test_pushed_blob_decrypts_to_alert_rules_shape(sync_with_rules):
+    s, ls, config = sync_with_rules
+    pushes = s._build_alert_rules_cache_pushes(config)
+    assert len(pushes) == 1
+    decoded = s.decrypt_payload(pushes[0]["blob"], config["encryption_key"])
+    assert isinstance(decoded, dict)
+    assert decoded["_shape"] == "alert_rules"
+    assert decoded["_source"] == "local_store"
+    assert decoded["count"] == 3
+    assert len(decoded["rules"]) == 3
+    # Each rule preserves the condition_json dict shape from DuckDB.
+    sample = decoded["rules"][0]
+    assert "id" in sample
+    assert "condition_json" in sample
+    assert isinstance(sample["condition_json"], dict)
+
+
+def test_send_heartbeat_attaches_alert_rules_push(sync_with_rules, monkeypatch):
+    """End-to-end: send_heartbeat with seeded rules must include an alert
+    rules entry in the heartbeat payload's cache_pushes list."""
+    s, ls, config = sync_with_rules
+    captured = {}
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/heartbeat":
+            captured["payload"] = payload
+            return {"sync_allowed": True, "pending_queries": []}
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(s, "_post", fake_post)
+    monkeypatch.setattr(s.time, "sleep", lambda *a, **kw: None)
+
+    assert s.send_heartbeat(config) is True
+    payload = captured["payload"]
+    pushes = payload.get("cache_pushes", [])
+    alert_keys = [p for p in pushes if p["key"].startswith("alerts:")]
+    assert len(alert_keys) == 1
+    entry = alert_keys[0]
+    assert entry["ttl_s"] == 3600
+    assert isinstance(entry["blob"], str) and len(entry["blob"]) > 0


### PR DESCRIPTION
## Summary

Phase 3 of epic #1032 (vivekchand/clawmetry#1032) — alert rules now live in
the local-first DuckDB store, ride the heartbeat-piggyback cache_push
channel, and accept cloud-authored writes via the pending_queries channel.

- **Schema (v2 → v3):** new `alert_rules` table with `id` PK, `owner_hash`,
  `name`, `condition_json` BLOB, `enabled`, `created_at`, `updated_at`,
  `last_fired_at`, `fire_count`. Idempotent `CREATE TABLE IF NOT EXISTS`
  migration — v2 stores pick up the new table on next start, no destructive
  changes.
- **CRUD helpers** in `LocalStore`: `ingest_alert_rule`, `query_alert_rules`,
  `delete_alert_rule`. Decodes `condition_json` BLOB back to dict on read.
- **Route fast path:** `GET /api/alerts/rules` gates on
  `CLAWMETRY_LOCAL_STORE_READ=1`. Hit returns `{rules, _source: "local_store"}`;
  miss / flag-off falls through to the existing fleet-DB helper.
- **Heartbeat cache_push:** new `_build_alert_rules_cache_pushes(config)`
  emits a single `alerts:{owner_hash}:rules` entry (TTL 3600s) holding the
  encrypted rule list. Wired alongside the brain push under the same
  `cache_pushes` array. Encryption-key gated — never leaks plaintext.
- **Write-through dispatcher:** `_dispatch_pending_queries` now handles
  `type: "alert_rule_upsert"` and `type: "alert_rule_delete"` items from the
  cloud relay, applying them to the local DuckDB via `_apply_pending_write`.
  This closes the Phase 3 loop: cloud-authored rules show up locally within
  one heartbeat cycle (≤60s).

## Test plan

- [x] `python3 -m pytest tests/test_alert_rules_local_store.py tests/test_brain_cache_push.py -v` — **20 passed**
- [x] Schema round-trip + owner/enabled filter + upsert-preserves-fields
- [x] Route fast-path returns `_source: "local_store"`; flag-off keeps legacy behaviour
- [x] cache_push: happy path, empty store, no-encryption-key, decrypt round-trip, end-to-end via `send_heartbeat`
- [x] Write-through dispatcher: upsert + delete via `_apply_pending_write` and via `_dispatch_pending_queries` (mixed read+write batch, unknown types skipped, writes don't POST /ingest/cache)
- [ ] Paired cloud-side PR vivekchand/clawmetry-cloud#737 (cache read + relay write-through)

## Epic Phase 3 acceptance

End-to-end loop is now closed by this PR + cloud PR #737:
* Cloud UI creates a rule → cloud POST `/api/alerts` writes Cloud SQL + enqueues `alert_rule_upsert` via `_queue_push`.
* Daemon's next heartbeat (≤60s) drains the pending_queries, `_apply_pending_write` writes to DuckDB.
* In-process evaluator sees the rule on its next pass (≤30s after that).
* Next heartbeat's cache_push refreshes `alerts:{owner_hash}:rules` so the cloud Alerts tab paints from cache (<100ms) with the up-to-date rule list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)