### PR TITLE
fix(interceptor): use activate() instead of non-existent patch_all() (dumko2001/#509)

### DIFF
--- a/clawmetry/track.py
+++ b/clawmetry/track.py
@@ -21,8 +21,8 @@ _disabled = _os.environ.get("CLAWMETRY_NO_INTERCEPT", "").strip() in ("1", "true
 
 if not _disabled:
     try:
-        from clawmetry.interceptor import patch_all as _patch_all
-        _patch_all()
+        from clawmetry.interceptor import activate as _activate
+        _activate()
     except Exception:
         pass  # never crash on import
 


### PR DESCRIPTION
## Summary
- The zero-config interceptor shorthand (`clawmetry/track.py`) imports a function that doesn't exist (`patch_all`); the actual symbol is `activate()`.
- The `except Exception: pass` swallowed the `ImportError` so users who did `import clawmetry.track` got nothing — no patching, no cost tracking.
- Original report + fix by @dumko2001 in #509; that PR was conflicting against current main, so this is the rebased equivalent with attribution preserved.

## Test plan
- [ ] `python -c "import clawmetry.track; from clawmetry.interceptor import get_session_stats; print(get_session_stats())"` — no ImportError on import
- [ ] Verify the OSS test suite still passes

Co-authored-by: dumko2001 <dumko.raj@gmail.com>