### PR TITLE
fix(security): prevent path traversal in /api/cron-run-log (dumko2001/#507)

### DIFF
--- a/routes/crons.py
+++ b/routes/crons.py
@@ -597,6 +597,16 @@ def api_cron_run_log():
         return jsonify({"error": "session_id required"}), 400
     sessions_dir = _d._get_sessions_dir()
     fpath = os.path.join(sessions_dir, f"{session_id}.jsonl")
+    # Guard against path-traversal via crafted session_id (e.g. "../../etc/passwd").
+    # Originally reported by @dumko2001 in #507.
+    norm_fpath = os.path.normpath(fpath)
+    norm_sessions_root = os.path.normpath(sessions_dir)
+    if not (
+        norm_fpath == norm_sessions_root
+        or norm_fpath.startswith(norm_sessions_root + os.sep)
+    ):
+        return jsonify({"error": "Invalid session_id"}), 400
+    fpath = norm_fpath
     if not os.path.isfile(fpath):
         return jsonify({"error": "Session not found"}), 404
     events = []


### PR DESCRIPTION
## Summary
- The `session_id` query parameter on `/api/cron-run-log` is joined directly to `sessions_dir` without validation, allowing read of arbitrary `.jsonl` files outside the sessions directory via crafted input.
- Fix: normalize the joined path and verify it stays within `sessions_dir` before opening.
- Originally reported + fixed by @dumko2001 in #507; that PR was conflicting against current main (the route moved from `dashboard.py` to `routes/crons.py` during the routes/ split). Rebased here with attribution preserved.

## Test plan
- [ ] `curl 'http://localhost:8900/api/cron-run-log?session_id=../../../../etc/passwd&token=…'` → returns `{"error":"Invalid session_id"}` 400, not 404 / not file contents
- [ ] Normal cron run-log fetch still works: `?session_id=<real-uuid>` → returns events

Co-authored-by: dumko2001 <dumko.raj@gmail.com>