### PR TITLE
fix(cloud-compat): guard _d.<helper> attrs missing on cloud's dashboard (kills 500s on /api/{delegation-tree,reliability,clusters})

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -188,12 +188,17 @@ def api_reliability():
         fast = _try_local_store_reliability(window)
         if fast is not None:
             return jsonify(fast)
-    if not _d._history_db or not _d.AgentReliabilityScorer:
+    # Cloud's dashboard.py is a different module than OSS's; AgentReliabilityScorer
+    # only lives in OSS. Use getattr so we degrade to a 200 "insufficient_data"
+    # response on cloud instead of 500-ing on AttributeError.
+    history_db = getattr(_d, "_history_db", None)
+    scorer_cls = getattr(_d, "AgentReliabilityScorer", None)
+    if not history_db or not scorer_cls:
         return jsonify(
             {"error": "History module not available", "direction": "insufficient_data"}
         ), 200
     try:
-        scorer = _d.AgentReliabilityScorer(_d._history_db)
+        scorer = scorer_cls(history_db)
         result = scorer.score(window_days=window)
         return jsonify(result)
     except Exception as e:

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -512,11 +512,21 @@ def api_version_impact():
 def api_clusters():
     """Return session clusters grouped by tool call pattern, cost, and error types."""
     import dashboard as _d
-    sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
+    sessions_dir = getattr(_d, "SESSIONS_DIR", None) or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )
+    # Cloud's dashboard.py doesn't ship _build_clusters; fall through to an
+    # empty 200 instead of leaking a 500 with an AttributeError body into the
+    # user's console. (When cloud_route_policy is loaded, this endpoint is
+    # normally returned as 410 by the policy enforcer; this guard is the
+    # defence-in-depth path for environments where the policy isn't active.)
+    build_clusters = getattr(_d, "_build_clusters", None)
+    if build_clusters is None:
+        return jsonify(
+            {"clusters": [], "total_clusters": 0, "sessions_dir": sessions_dir}
+        )
     try:
-        clusters = _d._build_clusters(sessions_dir)
+        clusters = build_clusters(sessions_dir)
         return jsonify(
             {
                 "clusters": clusters,

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -1280,7 +1280,16 @@ def api_delegation_tree():
     and returns per-chain token totals and estimated cost.
     """
     import dashboard as _d
-    sessions_dir = _d._get_sessions_dir()
+    # Cloud's dashboard.py is a different module than OSS's; some helpers
+    # (e.g. _get_sessions_dir, _estimate_usd_per_token) only exist in OSS.
+    # Guard with getattr so we degrade to an empty response instead of 500.
+    _get_sessions_dir = getattr(_d, "_get_sessions_dir", None)
+    _estimate_usd_per_token = getattr(_d, "_estimate_usd_per_token", None)
+    if _get_sessions_dir is None or _estimate_usd_per_token is None:
+        return jsonify(
+            {"chains": [], "total_subagents": 0, "total_chain_cost_usd": 0.0}
+        )
+    sessions_dir = _get_sessions_dir()
     index_path = os.path.join(sessions_dir, "sessions.json")
     try:
         with open(index_path) as f:
@@ -1290,7 +1299,7 @@ def api_delegation_tree():
             {"chains": [], "total_subagents": 0, "total_chain_cost_usd": 0.0}
         )
 
-    usd_per_tok = _d._estimate_usd_per_token()
+    usd_per_tok = _estimate_usd_per_token()
     now_ms = time.time() * 1000
 
     main_sessions = {}


### PR DESCRIPTION
## Summary

Three OSS endpoints were returning HTTP 500 on the ClawMetry Cloud dashboard because they called helpers via `import dashboard as _d` that only exist in OSS's `dashboard.py` — not cloud's. The 500s leaked into the user's DevTools console as "Failed to load resource".

Audit on 2026-05-12 against `app.clawmetry.com/cloud/node/<id>`:

| Endpoint | Status | Missing attr |
|---|---|---|
| `/api/delegation-tree` | 500 ×2 (polled twice) | `_d._estimate_usd_per_token` |
| `/api/reliability` | 500 ×2 (polled twice) | `_d.AgentReliabilityScorer` |
| `/api/clusters` | 500 | `_d._build_clusters` |

## Fix

Wrap each cross-module attribute lookup with `getattr(_d, "...", None)` and fall through to an empty 200 response when the attribute is missing. Same pattern as `_d._history_db` already used elsewhere. Defence-in-depth for cloud and for any OSS user whose dashboard.py predates the routes/ refactor.

## Test plan

- [x] Local E2E via `/tmp/brain-e2e/console_audit2.py`: before fix the per-node page logged 11 errors + 3 warnings; after fix + matching cloud-side suppressions, 0 errors + 0 warnings.
- [x] `python3 -c "import ast; ast.parse(open('routes/{sessions,health,meta}.py').read())"` passes.
- [ ] Cloud will pick this up after the next `[RELEASE]` to PyPI + cloud's `clawmetry==X.Y.Z` bump.
- [ ] Verify in production: open `app.clawmetry.com/cloud/node/<id>`, confirm no 500s on `/api/delegation-tree`, `/api/reliability`, `/api/clusters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)