### PR TITLE
fix(ci): unbreak sync-test workflow (drop Python 3.9, fix Test 3/4)

### DIFF
--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -8,11 +8,13 @@ on:
       - 'clawmetry/cli.py'
       - 'dashboard.py'
       - 'setup.py'
+      - '.github/workflows/sync-test.yml'
   pull_request:
     paths:
       - 'clawmetry/sync.py'
       - 'clawmetry/cli.py'
       - 'dashboard.py'
+      - '.github/workflows/sync-test.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: ['3.9', '3.11', '3.12']
+        python: ['3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
     name: Sync ${{ matrix.os }} / Python ${{ matrix.python }}
 
@@ -41,13 +41,18 @@ jobs:
       - name: Test 2 - cli.py imports cleanly
         run: python -c "from clawmetry import cli; print('CLI Import OK')"
 
-      - name: Test 3 - Config dir created automatically
-        run: python -c "import pathlib; d=pathlib.Path.home()/'.clawmetry'; assert d.exists(); print('Config dir OK')"
+      - name: Test 3 - Config dir is writable
+        shell: python
+        run: |
+          import pathlib
+          d = pathlib.Path.home() / '.clawmetry'
+          d.mkdir(exist_ok=True)
+          (d / 'smoke.txt').write_text('ok')
+          assert (d / 'smoke.txt').read_text() == 'ok'
+          (d / 'smoke.txt').unlink()
+          print('Config dir writable OK')
 
-      - name: Test 4 - load_config fails gracefully without config
-        run: python -c "from clawmetry.sync import load_config; [exit(0) for _ in [1] if (lambda: (load_config(), exit(1)) if True else None)()]" || python -c "from clawmetry.sync import load_config; ok=False; [setattr(__builtins__,'ok',True) for _ in []]; print('Config raises correctly')"
-
-      - name: Test 4b - FileNotFoundError on missing config
+      - name: Test 4 - FileNotFoundError on missing config
         shell: python
         run: |
           from clawmetry.sync import load_config


### PR DESCRIPTION
## Summary
- sync-test.yml has been **failing on every run for at least 50 consecutive runs** (zero jobs created — GitHub couldn't even start the workflow). Cause: Python 3.9 is no longer available on `macos-latest` since the runner moved to ARM64 (3.9 was EOL Oct 2025).
- Drop 3.9, add 3.13 to keep matrix coverage current.
- While in there, fix Test 3 (was asserting `~/.clawmetry` "auto-created" — neither `cli.py` nor `sync.py` creates it on import) and drop the broken one-liner Test 4 (Test 4b is the clean version of the same assertion).

## Test plan
- [x] YAML parses
- [ ] CI green on this PR (proves the matrix expansion works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)