### PR TITLE
feat(sessions): enrich stuck-session banner with session key, duration, and auto-dismiss (#29)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7826,6 +7826,14 @@ function processFlowEvent(line) {
     addFlowFeedItem('⚡ Session activated', '#f0c040', 'system');
     return;
   }
+  if (msg.includes('session state') && (msg.includes('new=completed') || msg.includes('new=error') || msg.includes('new=cancelled') || msg.includes('new=aborted'))) {
+    try {
+      var termObj = JSON.parse(line);
+      var termSid = termObj.session_key || termObj.session || termObj.sessionId || termObj.id || '';
+      _clearStuckBanner(termSid);
+    } catch(e) {}
+    return;
+  }
   if (msg.includes('lane enqueue') && msg.includes('main')) {
     if (now - (flowThrottles['lane']||0) < 2000) return;
     flowThrottles['lane'] = now;
@@ -7853,7 +7861,12 @@ function processFlowEvent(line) {
     flowThrottles['stuck'] = now;
     addFlowFeedItem('⚠️ Session stuck detected', '#e04040');
     _diagPush({kind:'session.stuck', value:1, ts:now});
-    _showStuckBanner();
+    try {
+      var stuckObj = JSON.parse(line);
+      var stuckSid = stuckObj.session_key || stuckObj.session || stuckObj.sessionId || stuckObj.id || '';
+      var stuckAge = stuckObj.age_ms ? Math.round(stuckObj.age_ms / 1000) : (stuckObj.age_s || 0);
+      _showStuckBanner(stuckSid, stuckAge);
+    } catch(e) { _showStuckBanner('', 0); }
     return;
   }
   if (msg.includes('tool end') || msg.includes('tool_end')) {
@@ -7871,15 +7884,44 @@ function _diagPush(event) {
   if (_diagBuffer.length > 200) _diagBuffer = _diagBuffer.slice(-200);
 }
 
-function _showStuckBanner() {
-  var existing = document.getElementById('stuck-session-banner');
-  if (existing) return;
-  var banner = document.createElement('div');
-  banner.id = 'stuck-session-banner';
-  banner.style.cssText = 'position:fixed;top:60px;left:50%;transform:translateX(-50%);z-index:9999;background:#e04040;color:#fff;padding:10px 20px;border-radius:8px;font-size:13px;font-weight:600;box-shadow:0 4px 16px rgba(0,0,0,0.4);display:flex;gap:12px;align-items:center;';
-  banner.innerHTML = '<span>⚠️ Session stuck detected — agent may be looping</span><button onclick="document.getElementById(\'stuck-session-banner\').remove()" style="background:rgba(255,255,255,0.2);border:none;color:#fff;padding:2px 8px;border-radius:4px;cursor:pointer;font-size:12px;">Dismiss</button>';
-  document.body.appendChild(banner);
-  setTimeout(function() { var b = document.getElementById('stuck-session-banner'); if (b) b.remove(); }, 30000);
+var _stuckCount = 0;
+var _stuckSessions = {};
+
+function _updateStuckBadge() {
+  var badge = document.getElementById('nav-stuck-badge');
+  if (!badge) return;
+  if (_stuckCount > 0) { badge.textContent = _stuckCount; badge.style.display = 'inline'; }
+  else { badge.style.display = 'none'; }
+}
+
+function _showStuckBanner(sessionId, ageSec) {
+  _stuckCount++;
+  if (sessionId) _stuckSessions[sessionId] = true;
+  _updateStuckBadge();
+  var banner = document.getElementById('stuck-session-banner');
+  if (!banner) return;
+  var label = sessionId ? sessionId.substring(0, 20) : 'unknown session';
+  var ageStr = ageSec > 0 ? ' (' + ageSec + 's)' : '';
+  var msg = document.getElementById('stuck-session-banner-msg');
+  if (msg) msg.textContent = '⚠️ Session stuck' + ageStr + ': ' + label + ' — agent may be looping';
+  var link = document.getElementById('stuck-session-banner-link');
+  if (link && sessionId) link.href = '#';
+  banner.style.display = 'flex';
+}
+
+function _clearStuckBanner(sessionId) {
+  if (sessionId && _stuckSessions[sessionId]) {
+    delete _stuckSessions[sessionId];
+    _stuckCount = Math.max(0, _stuckCount - 1);
+  } else if (!sessionId) {
+    _stuckCount = 0;
+    _stuckSessions = {};
+  }
+  _updateStuckBadge();
+  if (_stuckCount === 0) {
+    var banner = document.getElementById('stuck-session-banner');
+    if (banner) banner.style.display = 'none';
+  }
 }
 
 // === Overview Split-Screen: Clone flow SVG into overview pane ===

--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -149,6 +149,42 @@
     ">Dismiss</button>
 </div>
 
+<!-- Stuck Session Banner -->
+<div id="stuck-session-banner" style="
+  display:none;
+  padding:10px 16px;
+  border-bottom:2px solid #ef4444;
+  font-size:13px;
+  font-weight:600;
+  align-items:center;
+  gap:10px;
+  background:#450a0a;
+  color:#fca5a5;
+  ">
+  <span style="font-size:18px;">&#9203;</span>
+  <span id="stuck-session-banner-msg" style="flex:1;"></span>
+  <a id="stuck-session-banner-link" href="#" onclick="switchTab('overview');document.getElementById('stuck-session-banner').style.display='none';_stuckCount=0;_updateStuckBadge();" style="
+    background:#991b1b;
+    color:#fff;
+    border:none;
+    border-radius:6px;
+    padding:4px 12px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    text-decoration:none;
+    ">View Session</a>
+  <button onclick="document.getElementById('stuck-session-banner').style.display='none';_stuckCount=0;_updateStuckBadge();" style="
+    background:#7f1d1d;
+    color:#fecaca;
+    border:none;
+    border-radius:6px;
+    padding:4px 10px;
+    font-size:11px;
+    cursor:pointer;
+    ">Dismiss</button>
+</div>
+
 <!-- Budget Cap Banner -->
 <div id="budget-cap-banner" style="
   display:none;

--- a/dashboard.py
+++ b/dashboard.py
@@ -3308,7 +3308,7 @@ function clawmetryLogout(){
   <div class="nav-tabs">
     <div class="nav-tab" onclick="switchTab('flow')">Flow</div>
     <div class="nav-tab" onclick="switchTab('brain')">Brain</div>
-    <div class="nav-tab active" onclick="switchTab('overview')">Overview</div>
+    <div class="nav-tab active" onclick="switchTab('overview')">Overview <span id="nav-stuck-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
     <div class="nav-tab" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">Approvals <span id="nav-approvals-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
     <div class="nav-tab" onclick="switchTab('alerts')" title="Get notified when something goes wrong">Alerts <span id="nav-alerts-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
     <div class="nav-tab" onclick="switchTab('notifications')" title="Slack / Email / PagerDuty / Telegram channels">Notifications</div>
@@ -8995,7 +8995,7 @@ DASHBOARD_HTML = r"""
   <div class="nav-tabs">
     <div class="nav-tab" onclick="switchTab('flow')">Flow</div>
     <div class="nav-tab" onclick="switchTab('brain')">Brain</div>
-    <div class="nav-tab active" onclick="switchTab('overview')">Overview</div>
+    <div class="nav-tab active" onclick="switchTab('overview')">Overview <span id="nav-stuck-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
     <div class="nav-tab" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">Approvals <span id="nav-approvals-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
     <div class="nav-tab" onclick="switchTab('alerts')" title="Get notified when something goes wrong">Alerts <span id="nav-alerts-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:1px 6px;font-size:10px;font-weight:700;margin-left:4px;">0</span></div>
     <div class="nav-tab" onclick="switchTab('notifications')" title="Slack / Email / PagerDuty / Telegram channels">Notifications</div>


### PR DESCRIPTION
## Summary

The existing `_showStuckBanner()` showed a plain floating div saying "Session stuck detected" with no session identity, no duration, and no way to auto-dismiss when the session completes. This PR upgrades the stuck-session alert to match the quality of the other banners (heartbeat, paused, budget-cap) and wires in automatic clearing on terminal session events.

## Changes

- **`clawmetry/templates/partials/banners.html`** — Add `stuck-session-banner` div following the existing show/hide banner pattern (mirrors `heartbeat-banner`); includes session key, age, "View Session" link, and dismiss button
- **`clawmetry/static/js/app.js`** — Rewrite `_showStuckBanner(sessionId, ageSec)` to populate the pre-rendered element; add `_stuckCount` tracker and `_updateStuckBadge()` to drive the new Overview nav badge; add `_clearStuckBanner(sessionId)` that auto-dismisses when a terminal `session.state` (completed/error/cancelled/aborted) arrives; extract `session_key`/`age_ms` from the log JSON in `processFlowEvent`
- **`dashboard.py`** — Add `nav-stuck-badge` span to the Overview tab in both nav bars, matching the existing `nav-alerts-badge` pattern

## Test plan

- [ ] Trigger a `session.stuck` log event (or mock one via the log stream) — banner should appear with session key prefix and age in seconds
- [ ] Send a terminal `session.state new=completed` for the same session key — banner should auto-dismiss and badge should clear
- [ ] Verify manual Dismiss button hides the banner and resets the badge
- [ ] Verify Overview tab badge shows the stuck count when on another tab
- [ ] Verify graceful fallback when `session.stuck` log line has no `session_key` field (shows "unknown session")
- [ ] Verify no JS errors in console on page load

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #29. Marked draft for human review — mark Ready for Review once happy.

Closes #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbTWf8pBvkYcZ6UqfLQ36y)_