### PR TITLE
fix(dashboard-js): skip polling /api/{skills,diagnostics,config-diagnostics} when in cloud iframe

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1394,6 +1394,15 @@ async function loadSkills() {
   var summaryEl = document.getElementById('skills-summary-row');
   var listEl = document.getElementById('skills-list');
   if (!summaryEl || !listEl) return;
+  // Cloud iframes don't have access to the local skills filesystem — the
+  // cloud server returns 410 Gone for /api/skills, which the browser logs
+  // as a console error every time the user opens the Skills tab. Render
+  // an inline empty-state instead so the network call never fires.
+  if (window.CLOUD_MODE) {
+    listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Skills inspector is local-only. Open the dashboard on the host running OpenClaw to view installed skills.</div>';
+    summaryEl.innerHTML = '';
+    return;
+  }
   listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading...</div>';
   try {
     var data = await fetch('/api/skills').then(function(r) { return r.json(); });
@@ -2794,8 +2803,11 @@ async function loadContextInspector() {
     var ov = await fetch('/api/overview').then(function(r){return r.json();}).catch(function(){return {};});
     // Fetch brain history for compaction events + turn count
     var brain = await fetch('/api/brain-history?limit=300').then(function(r){return r.json();}).catch(function(){return {events:[]};});
-    // Fetch skills for header token count
-    var skills = await fetch('/api/skills').then(function(r){return r.json();}).catch(function(){return {skills:[],summary:{}};});
+    // Fetch skills for header token count. /api/skills is cloud-disabled
+    // (410 Gone) — skip the network call in cloud mode and use empty totals.
+    var skills = window.CLOUD_MODE
+      ? {skills:[],summary:{}}
+      : await fetch('/api/skills').then(function(r){return r.json();}).catch(function(){return {skills:[],summary:{}};});
 
     var contextWindow = ov.contextWindow || 200000;
     var mainTokens = ov.mainTokens || 0;
@@ -5468,6 +5480,14 @@ function startSystemHealthRefresh() {
 async function loadDiagnostics() {
   var el = document.getElementById('sh-diagnostics');
   if (!el) return false;
+  // Diagnostics inspect local processes and on-disk OpenClaw config — neither
+  // exists in the cloud iframe. The cloud server returns 410 / 404 for both
+  // URLs, which the browser logs as console errors on every System Health
+  // refresh. Skip the call entirely and render a static "local-only" note.
+  if (window.CLOUD_MODE) {
+    el.innerHTML = '<div style="color:var(--text-muted);">Diagnostics are local-only — open the dashboard on the host to inspect detected config.</div>';
+    return true;
+  }
   try {
     var d = await fetchJsonWithTimeout('/api/diagnostics', 6000).catch(function() {
       return fetchJsonWithTimeout('/api/config-diagnostics', 6000);
@@ -7321,6 +7341,9 @@ function initFlow() {
 }
 
 function _populateFlowSkills() {
+  // /api/skills is cloud-disabled (410 Gone). Skip the fetch in cloud mode
+  // — the Flow tab still renders, just without per-skill mini-badges.
+  if (window.CLOUD_MODE) return;
   fetch('/api/skills').then(function(r){return r.json();}).then(function(d) {
     var skills = (d.skills || []).filter(function(s) { return s.status !== 'dead'; }).slice(0, 6);
     var container = document.getElementById('flow-skills-list');

--- a/dashboard.py
+++ b/dashboard.py
@@ -5050,6 +5050,13 @@ async function loadSkills() {
   var summaryEl = document.getElementById('skills-summary-row');
   var listEl = document.getElementById('skills-list');
   if (!summaryEl || !listEl) return;
+  // /api/skills is cloud-disabled (410 Gone). Render an empty state instead
+  // of triggering a console-error-generating fetch on the cloud iframe.
+  if (window.CLOUD_MODE) {
+    listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Skills inspector is local-only. Open the dashboard on the host running OpenClaw to view installed skills.</div>';
+    summaryEl.innerHTML = '';
+    return;
+  }
   listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading...</div>';
   try {
     var data = await fetch('/api/skills').then(function(r){return r.json();});


### PR DESCRIPTION
## Summary

The cloud dashboard embeds the OSS dashboard in an iframe at `/node/<id>/`. Three OSS endpoints have no meaningful cloud equivalent:
- `/api/skills` -> 410 Gone
- `/api/diagnostics` -> 410 Gone (polled via `loadAll` every 10s on Overview)
- `/api/config-diagnostics` -> 404 (fallback after diagnostics fails)

Result: ~24 console errors per minute per cloud user.

## Fix

Short-circuit the four call sites when `window.CLOUD_MODE === true`:

| Function | File | Behavior in cloud |
|---|---|---|
| `loadDiagnostics` | `clawmetry/static/js/app.js:5480` | Render "local-only" note, skip fetch |
| `loadSkills` | `clawmetry/static/js/app.js:1393` | Render local-only empty state |
| `_populateFlowSkills` | `clawmetry/static/js/app.js:7333` | Noop (Flow renders without skill badges) |
| `loadContextInspector` (skills fetch) | `clawmetry/static/js/app.js:2807` | Use empty `{skills:[],summary:{}}` |
| Embedded `loadSkills` | `dashboard.py:5049` (legacy duplicate) | Same guard for parity |

The cloud-side fetch interceptor is still the safety net — but stopping the calls at the source is the higher-leverage fix.

## Verification

- `node --check clawmetry/static/js/app.js` -> clean
- `python3 -c 'import dashboard'` -> clean
- Pattern matches the existing `if (window.CLOUD_MODE) return;` guards already used 8+ times in app.js

## Test plan
- [ ] Open `https://app.clawmetry.com/cloud/node/<id>` in browser
- [ ] DevTools console: confirm no 410/404 for `/api/skills`, `/api/diagnostics`, `/api/config-diagnostics`
- [ ] Switch through tabs (Overview, Skills, Context, Flow) — confirm sensible empty-states render where the skipped data was used
- [ ] Open OSS dashboard locally (`make dev`, no CLOUD_MODE) — confirm Skills tab + System Health Diagnostics still load real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)