### PR TITLE
fix(sync): swallow PermissionError in detect_paths

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1394,6 +1394,15 @@ async function loadSkills() {
   var summaryEl = document.getElementById('skills-summary-row');
   var listEl = document.getElementById('skills-list');
   if (!summaryEl || !listEl) return;
+  // Cloud iframes don't have access to the local skills filesystem — the
+  // cloud server returns 410 Gone for /api/skills, which the browser logs
+  // as a console error every time the user opens the Skills tab. Render
+  // an inline empty-state instead so the network call never fires.
+  if (window.CLOUD_MODE) {
+    listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Skills inspector is local-only. Open the dashboard on the host running OpenClaw to view installed skills.</div>';
+    summaryEl.innerHTML = '';
+    return;
+  }
   listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading...</div>';
   try {
     var data = await fetch('/api/skills').then(function(r) { return r.json(); });
@@ -2794,8 +2803,11 @@ async function loadContextInspector() {
     var ov = await fetch('/api/overview').then(function(r){return r.json();}).catch(function(){return {};});
     // Fetch brain history for compaction events + turn count
     var brain = await fetch('/api/brain-history?limit=300').then(function(r){return r.json();}).catch(function(){return {events:[]};});
-    // Fetch skills for header token count
-    var skills = await fetch('/api/skills').then(function(r){return r.json();}).catch(function(){return {skills:[],summary:{}};});
+    // Fetch skills for header token count. /api/skills is cloud-disabled
+    // (410 Gone) — skip the network call in cloud mode and use empty totals.
+    var skills = window.CLOUD_MODE
+      ? {skills:[],summary:{}}
+      : await fetch('/api/skills').then(function(r){return r.json();}).catch(function(){return {skills:[],summary:{}};});
 
     var contextWindow = ov.contextWindow || 200000;
     var mainTokens = ov.mainTokens || 0;
@@ -5468,6 +5480,14 @@ function startSystemHealthRefresh() {
 async function loadDiagnostics() {
   var el = document.getElementById('sh-diagnostics');
   if (!el) return false;
+  // Diagnostics inspect local processes and on-disk OpenClaw config — neither
+  // exists in the cloud iframe. The cloud server returns 410 / 404 for both
+  // URLs, which the browser logs as console errors on every System Health
+  // refresh. Skip the call entirely and render a static "local-only" note.
+  if (window.CLOUD_MODE) {
+    el.innerHTML = '<div style="color:var(--text-muted);">Diagnostics are local-only — open the dashboard on the host to inspect detected config.</div>';
+    return true;
+  }
   try {
     var d = await fetchJsonWithTimeout('/api/diagnostics', 6000).catch(function() {
       return fetchJsonWithTimeout('/api/config-diagnostics', 6000);
@@ -7321,6 +7341,9 @@ function initFlow() {
 }
 
 function _populateFlowSkills() {
+  // /api/skills is cloud-disabled (410 Gone). Skip the fetch in cloud mode
+  // — the Flow tab still renders, just without per-skill mini-badges.
+  if (window.CLOUD_MODE) return;
   fetch('/api/skills').then(function(r){return r.json();}).then(function(d) {
     var skills = (d.skills || []).filter(function(s) { return s.status !== 'dead'; }).slice(0, 6);
     var container = document.getElementById('flow-skills-list');

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -908,8 +908,14 @@ def detect_paths() -> dict:
                 f"/var/lib/openshell/sandboxes/{nemoclaw_sandbox}/.openclaw/agents/main/sessions"
             ),
         )
+    def _safe_exists(p):
+        try:
+            return p.exists()
+        except (PermissionError, OSError):
+            return False
+
     found_sessions = docker_paths.get("sessions_dir") or next(
-        (str(p) for p in sessions_candidates if p.exists()), None
+        (str(p) for p in sessions_candidates if _safe_exists(p)), None
     )
     sessions_dir = found_sessions or str(sessions_candidates[0])
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -5050,6 +5050,13 @@ async function loadSkills() {
   var summaryEl = document.getElementById('skills-summary-row');
   var listEl = document.getElementById('skills-list');
   if (!summaryEl || !listEl) return;
+  // /api/skills is cloud-disabled (410 Gone). Render an empty state instead
+  // of triggering a console-error-generating fetch on the cloud iframe.
+  if (window.CLOUD_MODE) {
+    listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Skills inspector is local-only. Open the dashboard on the host running OpenClaw to view installed skills.</div>';
+    summaryEl.innerHTML = '';
+    return;
+  }
   listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading...</div>';
   try {
     var data = await fetch('/api/skills').then(function(r){return r.json();});


### PR DESCRIPTION
## Summary
Sync-test on ubuntu runners fails with \`PermissionError: [Errno 13] Permission denied: '/root/.openclaw/agents/main/sessions'\` because the test container creates that dir as root with restricted perms; \`detect_paths()\`'s candidate scan calls \`p.exists()\` which crashes on stat.

Wrap the call in a small \`_safe_exists()\` that treats \`PermissionError\`/\`OSError\` as "not present" — matches the behavior a non-root user already gets implicitly.

Unblocks PR #1082 (and any other PR touching sync-affecting paths) from a flaky-looking CI failure that has nothing to do with the PR's diff.

## Test plan
- [x] Python syntax + import OK
- [ ] Sync-test green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)