### PR TITLE
feat: 5 new DuckDB fast-paths (37% → 41% coverage)

### DIFF
--- a/DUCKDB_COVERAGE_AUDIT_2026-05-13.md
+++ b/DUCKDB_COVERAGE_AUDIT_2026-05-13.md
@@ -1,0 +1,202 @@
+# DuckDB UI Coverage Audit — 2026-05-13
+
+Snapshot of every dashboard HTTP surface in `routes/*.py`, the data source it
+reads from today, and how hard it would be to flip onto the DuckDB local-store
+fast path (`_try_local_store_*` + `CLAWMETRY_LOCAL_STORE_READ=1`).
+
+## Summary
+
+| Metric | 2026-05-12 baseline | 2026-05-13 (this audit) |
+|---|---|---|
+| Total routes inventoried | 57 | **197** (full sweep across 24 blueprints) |
+| Read-data surfaces (relevant denominator) | 57 | **104** |
+| DuckDB fast-path wired | 9 (~16%) | **38 (~37%)** |
+| Bypass (no DuckDB path) | 44 (~77%) | **52 (~50%)** |
+| N/A — POST mutations / system probes / SSE / cloud-only | — | 14 (~13%) |
+
+The denominator widened because earlier audits only counted "tab-level" surfaces.
+This audit walks every `@bp_*.route(...)` in `routes/`. The DuckDB-fast-path
+share more than doubled (16% → 37%) thanks to the `_try_local_store_*` work
+landed under epics #964 and #1032.
+
+## Legend
+
+- **DuckDB-Full** — `_try_local_store_*` exists and is the first path tried.
+- **DuckDB-Mixed** — partial: DuckDB fast-path exists but most rows still come from gateway/JSONL.
+- **Bypass** — no DuckDB code; reads filesystem, gateway WebSocket, or sqlite directly.
+- **N/A** — POST mutation / SSE stream / system probe / cloud-only / static page.
+- **Difficulty** — Easy = `query_events`/`query_sessions` already covers it; Medium = needs new query helper; Hard = needs schema work or non-trivial transform.
+
+## Sorted by status (Bypass first), then difficulty
+
+### Bypass — Easy (top migration candidates)
+
+| Endpoint | Source | Difficulty | File:Line |
+|---|---|---|---|
+| `/api/prompt-errors` | JSONL scan (`customType=openclaw:prompt-error`) | Easy | routes/overview.py:686 |
+| `/api/transcripts` | listdir on sessions dir | Easy | routes/sessions.py:1554 |
+| `/api/transcript-events/<id>` | JSONL parse for one session | Easy | routes/sessions.py:1810 |
+| `/api/sessions/<id>/cost-breakdown` | JSONL parse, per-turn usage | Easy | routes/sessions.py:2165 |
+| `/api/sessions/cost-breakdown` | `_compute_transcript_analytics()` | Easy | routes/sessions.py:1474 |
+| `/api/sessions/<id>/export` | JSONL parse, JSON/CSV dump | Easy | routes/sessions.py:2297 |
+| `/api/heatmap` | log files + JSONL files | Easy | routes/health.py:208 |
+| `/api/clusters` | `_build_clusters(sessions_dir)` | Easy | routes/meta.py:511 |
+| `/api/cron-run-log` | JSONL parse for cron session | Easy | routes/crons.py:591 |
+| `/api/agents/<name>/sessions` | adapter `list_sessions()` | Easy | routes/agents.py:43 |
+| `/api/sessions/clusters` | JSONL scan + clustering | Easy | routes/usage.py:1028 |
+| `/api/version-impact` | `_d._compute_transcript_analytics()` | Easy | routes/meta.py:420 |
+| `/api/timeline` (legacy fallback) | gateway + JSONL fan-out | Easy | routes/overview.py:634 |
+
+### Bypass — Medium
+
+| Endpoint | Source | Difficulty | File:Line |
+|---|---|---|---|
+| `/api/agents` | `registry.detect_all()` | Medium | routes/agents.py:25 |
+| `/api/agents/<name>` | `adapter.detect()` | Medium | routes/agents.py:31 |
+| `/api/skills` | `~/.openclaw/skills` walker | Medium | routes/skills.py:218 |
+| `/api/skills/<name>` | filesystem | Medium | routes/skills.py:355 |
+| `/api/skills/<name>/file` | filesystem | Medium | routes/skills.py:440 |
+| `/api/plugins` | filesystem walker | Medium | routes/plugins.py:230 |
+| `/api/selfconfig` | filesystem | Medium | routes/selfconfig.py:428 |
+| `/api/selfconfig/<file>` | filesystem | Medium | routes/selfconfig.py:477 |
+| `/api/selfconfig/<file>/diff` | git history of file | Medium | routes/selfconfig.py:513 |
+| `/api/task-runs` | sqlite `~/.openclaw/tasks/runs.sqlite` | Medium | routes/sessions.py:787 |
+| `/api/delegation-tree` | task_runs sqlite + JSONL | Medium | routes/sessions.py:1275 |
+| `/api/subagents` | gateway + sqlite + JSONL | Medium | routes/sessions.py:1050 |
+| `/api/compactions` | JSONL scan | Medium | routes/sessions.py:366 |
+| `/api/session-tools` | JSONL parse | Medium | routes/sessions.py:473 |
+| `/api/cost-split` | analytics + filesystem | Medium | routes/sessions.py:636 |
+| `/api/session-model-journey/<id>` | JSONL parse | Medium | routes/sessions.py:2009 |
+| `/api/llmfit` | filesystem | Medium | routes/infra.py:714 |
+| `/api/cost-optimizer` | analytics merger | Medium | routes/infra.py:734 |
+| `/api/cost-optimization` | analytics merger | Medium | routes/infra.py:920 |
+| `/api/automation-analysis` | analytics merger | Medium | routes/infra.py:981 |
+| `/api/context-anatomy` | JSONL parse | Medium | routes/infra.py:1006 |
+| `/api/security/threats` | gateway | Medium | routes/infra.py:650 |
+| `/api/security/signatures` | filesystem | Medium | routes/infra.py:680 |
+| `/api/security/posture` | composite | Medium | routes/infra.py:700 |
+| `/api/component/runtime` | system probes (mostly N/A) | Medium | routes/components.py:488 |
+| `/api/component/storage` | `df` (system probe) | N/A | routes/components.py:656 |
+| `/api/component/network` | system probes | N/A | routes/components.py:717 |
+| `/api/component/machine` | system probes | N/A | routes/components.py:571 |
+| `/api/component/gateway` | gateway | Medium | routes/components.py:809 |
+| `/api/cron-health` | gateway + analytics | Medium | routes/crons.py:965 |
+| `/api/agent-intentions` | gateway + analytics | Medium | routes/crons.py:821 |
+
+### Bypass — Hard
+
+| Endpoint | Source | Difficulty | File:Line |
+|---|---|---|---|
+| `/api/channel/telegram` | log greps + JSONL | Hard | routes/channels.py:147 |
+| `/api/channel/imessage` | log greps + JSONL | Hard | routes/channels.py:369 |
+| `/api/channel/whatsapp` | log greps + JSONL | Hard | routes/channels.py:503 |
+| `/api/channel/signal` | log greps + JSONL | Hard | routes/channels.py:628 |
+| `/api/channel/discord` | log greps + JSONL | Hard | routes/channels.py:751 |
+| `/api/channel/slack` | log greps + JSONL | Hard | routes/channels.py:906 |
+| `/api/channel/irc` | log greps + JSONL | Hard | routes/channels.py:1062 |
+| `/api/channel/webchat` | log greps + JSONL | Hard | routes/channels.py:1211 |
+| `/api/channel/googlechat` | log greps + JSONL | Hard | routes/channels.py:1371 |
+| `/api/channel/bluebubbles` | log greps + JSONL | Hard | routes/channels.py:1380 |
+| `/api/channel/msteams` | log greps + JSONL | Hard | routes/channels.py:1557 |
+| `/api/channel/tui` | log greps + JSONL | Hard | routes/channels.py:1566 |
+| `/api/channel/matrix` | log greps + JSONL | Hard | routes/channels.py:1687 |
+| `/api/channel/mattermost` | log greps + JSONL | Hard | routes/channels.py:1693 |
+| `/api/channel/{line,nostr,twitch,feishu,zalo,tlon,synology-chat,nextcloud-talk}` | log greps + JSONL | Hard | routes/channels.py:1702-1744 |
+| `/api/component/tool/<name>` (legacy fallback) | JSONL aggregation | Hard | routes/components.py:156 |
+| `/api/health` | composite of many sources | Hard | routes/health.py:482 |
+| `/api/system-health` | composite | Hard | routes/health.py:328 |
+| `/api/diagnostics` / `/api/config-diagnostics` | composite | Hard | routes/health.py:703 |
+
+### DuckDB-Full (already migrated — no work needed)
+
+| Endpoint | Helper | File:Line |
+|---|---|---|
+| `/api/overview` | `_try_local_store_overview` | routes/overview.py:413 |
+| `/api/timeline` | `_try_local_store_timeline` | routes/overview.py:643 |
+| `/api/sessions` | `_try_local_store_sessions` | routes/sessions.py:158 |
+| `/api/sessions/by-type` | `_try_local_store_sessions_by_type` | routes/sessions.py:255 |
+| `/api/transcript/<id>` | `_try_local_store_transcript` | routes/sessions.py:1691 |
+| `/api/usage` | `_try_local_store_usage` | routes/usage.py:703 |
+| `/api/usage/anomalies` | `_try_local_store_usage_anomalies` | routes/usage.py:818 |
+| `/api/anomalies` | `_try_local_store_anomalies` | routes/usage.py:860 |
+| `/api/usage/by-plugin` | `_try_local_store_usage_by_plugin` | routes/usage.py:922 |
+| `/api/usage/by-plugin/trend` | `_try_local_store_usage_by_plugin_trend` | routes/usage.py:994 |
+| `/api/usage/cost-comparison` | `_try_local_store_cost_comparison` | routes/usage.py:1308 |
+| `/api/model-attribution` | `_try_local_store_model_attribution` | routes/usage.py:1447 |
+| `/api/skill-attribution` | `_try_local_store_skill_attribution` | routes/usage.py:1565 |
+| `/api/crons` | `_try_local_store_crons` | routes/crons.py:362 |
+| `/api/cron/<id>/runs` | `_try_local_store_cron_runs` | routes/crons.py:550 |
+| `/api/cron/health-summary` | `_try_local_store_cron_health_summary` | routes/crons.py:639 |
+| `/api/component/tool/<name>` | `_try_local_store_component_tool` | routes/components.py:170 |
+| `/api/component/brain` | `_try_local_store_component_brain` | routes/components.py:1252 |
+| `/api/reasoning` | `_try_local_store_reasoning` | routes/reasoning.py:289 |
+| `/api/autonomy` | `_try_local_store_autonomy` | routes/autonomy.py:443 |
+| `/api/advisor/ask` | `_try_local_store_advisor_context` | routes/advisor.py:198 |
+| `/api/advisor/status` | `_try_local_store_advisor_status` | routes/advisor.py:463 |
+| `/api/reliability` | `_try_local_store_reliability` | routes/health.py:188 |
+| `/api/service-status` | `_try_local_store_service_status` | routes/health.py:894 |
+| `/api/heartbeat-status` | `_try_local_store_heartbeat_status` | routes/health.py:1066 |
+| `/api/sandbox-status` | `_try_local_store_sandbox_status` | routes/health.py:1266 |
+| `/api/loop-detection` | `_try_local_store_loop_detection` | routes/health.py:1517 |
+| `/api/mcp-stats` | `_try_local_store_mcp_stats` | routes/health.py:1772 |
+| `/api/heartbeat` | `_try_local_store_heartbeat` | routes/heartbeat.py:280 |
+| `/api/brain-history` | `_try_local_store_brain` | routes/brain.py:142 |
+| `/api/nemoclaw/pending-approvals` | `_try_local_store_approvals` | routes/nemoclaw.py:305 |
+| `/api/alerts/rules` | `_try_local_store_alert_rules` | routes/alerts.py:232 |
+| `/api/memory-files` | `_try_local_store_memory_files` | routes/infra.py:569 |
+| `/api/file` (GET) | `_try_local_store_file` | routes/infra.py:581 |
+| `/api/memory-analytics` | `_try_local_store_memory_analytics` | routes/infra.py:639 |
+| `/api/channels/<provider>/status` | `_channel_config_status_from_local_store` | routes/channels.py:106 |
+| `/api/channels/status` | inline DuckDB | routes/channels.py:129 |
+| `/api/local/*` (6 endpoints) | direct DuckDB allowlist | routes/local_query.py:210-254 |
+
+### N/A (mutations, SSE, system probes, cloud-only, auth, gateway proxy)
+
+POST/PUT/DELETE on alerts, budget, crons, channels, selfconfig, file write, heartbeat-ping,
+nemoclaw approve/reject, anomalies/ack, sessions/<id>/stop, otel ingestion, gateway proxy
+RPC, version, update, auth/check, otel-status, cloud-cta/* (cloud), update-check/*, fleet
+register/metrics, history snapshots (DuckDB-equivalent already in fleet_history), brain-stream
+SSE, logs-stream SSE, health-stream SSE, flow SSE.
+
+## Per-blueprint coverage rollup
+
+| Blueprint | Read surfaces | DuckDB | % covered |
+|---|---|---|---|
+| usage | 13 | 8 | 62% |
+| health | 11 | 8 | 73% |
+| sessions | 14 | 5 | 36% |
+| crons | 4 | 3 | 75% |
+| overview | 4 | 2 | 50% |
+| infra | 11 | 3 | 27% |
+| components | 7 | 2 | 29% |
+| channels | 24 | 2 | 8% (per-provider chat history hard) |
+| brain | 1 | 1 | 100% |
+| reasoning | 1 | 1 | 100% |
+| autonomy | 1 | 1 | 100% |
+| advisor | 2 | 2 | 100% |
+| heartbeat | 1 | 1 | 100% |
+| alerts | 5 | 1 | 20% |
+| nemoclaw | 4 | 1 | 25% |
+| local_query | 6 | 6 | 100% |
+| agents | 3 | 0 | 0% |
+| skills | 3 | 0 | 0% |
+| plugins | 1 | 0 | 0% |
+| selfconfig | 5 | 0 | 0% (configs are file-of-truth) |
+| selfevolve | 3 | 0 | 0% |
+| fleet_history | 7 | sqlite-backed (counted N/A) | — |
+| meta | 5 | 0 | clusters/version-impact migratable |
+| update_check | 1 | 0 | config file is truth |
+
+## What's getting migrated this PR
+
+`feat/duckdb-coverage-batch-2026-05-13` adds `_try_local_store_*` fast paths to
+the easiest 5 surfaces from the **Bypass — Easy** list above:
+
+1. `/api/prompt-errors` — `_try_local_store_prompt_errors` (overview.py)
+2. `/api/transcripts` — `_try_local_store_transcripts` (sessions.py)
+3. `/api/heatmap` — `_try_local_store_heatmap` (health.py)
+4. `/api/sessions/cost-breakdown` — `_try_local_store_cost_breakdown` (sessions.py)
+5. `/api/sessions/<id>/cost-breakdown` — `_try_local_store_session_cost_breakdown` (sessions.py)
+
+After this PR lands, DuckDB-Full coverage moves **38 → 43** (~37% → ~41%).
+Remaining Bypass-Easy surfaces are tracked in the follow-up issue.

--- a/routes/health.py
+++ b/routes/health.py
@@ -205,6 +205,70 @@ def api_reliability():
         return jsonify({"error": str(e), "direction": "insufficient_data"}), 500
 
 
+def _try_local_store_heatmap(n_days: int):
+    """Fast path for /api/heatmap. Bucket events into a (days × 24h) grid
+    using DuckDB ``query_events`` instead of scanning every log + JSONL.
+
+    Returns ``None`` to defer to the legacy file scan if:
+      - the local_store module isn't importable
+      - the events table is empty inside the requested window
+      - any unexpected error happens
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        cutoff = datetime.now() - timedelta(days=n_days)
+        since_iso = cutoff.replace(microsecond=0).isoformat()
+        # Heatmap is bounded: 90 days × 24h = 2160 cells. 50k events is a
+        # generous cap that covers a very busy single-user node and still
+        # finishes in <50ms on a laptop.
+        evs = store.query_events(since=since_iso, limit=50000)
+    except Exception:
+        return None
+    if not evs:
+        return None
+
+    now = datetime.now()
+    grid = {}
+    day_labels = []
+    for i in range(n_days - 1, -1, -1):
+        d = now - timedelta(days=i)
+        ds = d.strftime("%Y-%m-%d")
+        grid[ds] = [0] * 24
+        lbl = d.strftime("%b %d") if n_days > 7 else d.strftime("%a %d")
+        day_labels.append({"date": ds, "label": lbl})
+
+    counted = 0
+    for ev in evs:
+        ts = ev.get("ts")
+        if not ts:
+            continue
+        try:
+            dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        except Exception:
+            continue
+        # Drop tz to match the naive ``datetime.now()`` grid keys.
+        if dt.tzinfo is not None:
+            dt = dt.replace(tzinfo=None)
+        day_key = dt.strftime("%Y-%m-%d")
+        if day_key in grid:
+            grid[day_key][dt.hour] += 1
+            counted += 1
+    if counted == 0:
+        return None
+
+    max_val = max(max(hours) for hours in grid.values()) if grid else 0
+    days_out = []
+    for dl in day_labels:
+        days_out.append({"label": dl["label"], "hours": grid.get(dl["date"], [0] * 24)})
+    return {
+        "days": days_out,
+        "max": max_val,
+        "n_days": n_days,
+        "_source": "local_store",
+    }
+
+
 @bp_health.route("/api/heatmap")
 def api_heatmap():
     """Activity heatmap - events per hour for the last N days (default 7, max 90).
@@ -217,6 +281,12 @@ def api_heatmap():
         n_days = max(1, min(90, int(request.args.get("days", 7))))
     except (ValueError, TypeError):
         n_days = 7
+
+    # Epic #964 — opt-in DuckDB fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_heatmap(n_days)
+        if fast is not None:
+            return jsonify(fast)
 
     now = datetime.now()
     # Initialize N days × 24 hours grid

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -683,6 +683,53 @@ def api_timeline():
     return jsonify({"days": days, "today": now.strftime("%Y-%m-%d")})
 
 
+def _try_local_store_prompt_errors(since_iso):
+    """Fast path for /api/prompt-errors. Reads ``openclaw:prompt-error``
+    events from DuckDB instead of scanning the 20 most-recent JSONL files.
+
+    Returns ``None`` to defer to the JSONL scan if:
+      - the local_store module isn't importable
+      - the events table is empty / no prompt-error rows
+      - any unexpected error happens (we'd rather degrade than 500)
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        # Two event_type spellings have been seen in the wild — the canonical
+        # ``openclaw:prompt-error`` and the bare ``prompt-error`` from older
+        # ingest paths. Try both.
+        rows = store.query_events(
+            event_type="openclaw:prompt-error",
+            since=since_iso,
+            limit=200,
+        )
+        if not rows:
+            rows = store.query_events(
+                event_type="prompt-error",
+                since=since_iso,
+                limit=200,
+            )
+    except Exception:
+        return None
+    if not rows:
+        return None
+    errors = []
+    for ev in rows:
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        errors.append({
+            "ts": ev.get("ts"),
+            "runId": data.get("runId"),
+            "sessionId": ev.get("session_id") or data.get("sessionId"),
+            "provider": data.get("provider"),
+            "model": ev.get("model") or data.get("model"),
+            "api": data.get("api"),
+            "error": data.get("error"),
+        })
+    errors.sort(key=lambda e: e.get("ts") or "", reverse=True)
+    errors = errors[:50]
+    return {"errors": errors, "count": len(errors), "_source": "local_store"}
+
+
 @bp_overview.route("/api/prompt-errors")
 def api_prompt_errors():
     """Return recent openclaw:prompt-error events from session JSONL files.
@@ -700,6 +747,12 @@ def api_prompt_errors():
             since_ts = datetime.fromisoformat(since_raw.replace("Z", "+00:00"))
         except Exception:
             pass
+
+    # Epic #964 — opt-in DuckDB fast path. Falls through on miss.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_prompt_errors(since_raw)
+        if fast is not None:
+            return jsonify(fast)
 
     session_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -1471,10 +1471,70 @@ def api_export_otlp():
     return jsonify({"resourceSpans": resource_spans})
 
 
+def _try_local_store_cost_breakdown():
+    """Fast path for /api/sessions/cost-breakdown. Aggregates per-session
+    total cost + tokens straight out of DuckDB's ``sessions`` view.
+
+    Returns ``None`` to defer to ``_compute_transcript_analytics`` if:
+      - the local_store module isn't importable
+      - the sessions table is empty
+      - any unexpected error happens
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        rows = store.query_sessions(limit=1000)
+    except Exception:
+        return None
+    if not rows:
+        return None
+    result = []
+    for r in rows:
+        sid = r.get("session_id") or ""
+        if not sid:
+            continue
+        cost = float(r.get("cost_usd") or 0.0)
+        tokens = int(r.get("token_count") or 0)
+        # Day key from started_at (ISO ts) — best-effort.
+        started_iso = r.get("started_at") or ""
+        day = ""
+        start_ts = 0
+        try:
+            dt = datetime.fromisoformat(str(started_iso).replace("Z", "+00:00"))
+            day = dt.strftime("%Y-%m-%d")
+            start_ts = int(dt.timestamp())
+        except Exception:
+            pass
+        result.append({
+            "session_id": sid,
+            "tokens": tokens,
+            "cost_usd": round(cost, 6),
+            "model": "",  # not stored at session level; UI tolerates blank
+            "day": day,
+            "start_ts": start_ts,
+        })
+    result.sort(key=lambda x: x["cost_usd"], reverse=True)
+    top10 = result[:10]
+    total_cost = sum(r["cost_usd"] for r in result)
+    return {
+        "sessions": result,
+        "top10": top10,
+        "total_cost_usd": round(total_cost, 4),
+        "_source": "local_store",
+    }
+
+
 @bp_sessions.route("/api/sessions/cost-breakdown")
 def api_sessions_cost_breakdown():
     """Per-session cost breakdown: top sessions by total cost, sorted descending."""
     import dashboard as _d
+
+    # Epic #964 — opt-in DuckDB fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_cost_breakdown()
+        if fast is not None:
+            return jsonify(fast)
+
     analytics = _d._compute_transcript_analytics()
     sessions = analytics.get("sessions", [])
     usd_per_token = _d._estimate_usd_per_token()
@@ -1551,10 +1611,61 @@ def api_session_stop(session_id):
     )
 
 
+def _try_local_store_transcripts():
+    """Fast path for /api/transcripts. Lists distinct sessions with their
+    event counts + most-recent ts, straight from DuckDB.
+
+    Returns ``None`` to defer to the legacy filesystem listdir if:
+      - the local_store module isn't importable
+      - the sessions table is empty
+      - any unexpected error happens
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        rows = store.query_sessions(limit=50)
+    except Exception:
+        return None
+    if not rows:
+        return None
+    transcripts = []
+    for r in rows:
+        sid = r.get("session_id") or ""
+        if not sid:
+            continue
+        # Coerce ts (ISO string) to ms-since-epoch for parity with the
+        # legacy ``int(os.path.getmtime(fpath) * 1000)`` shape.
+        modified_ms = 0
+        upd = r.get("updated_at")
+        if upd:
+            try:
+                modified_ms = int(
+                    datetime.fromisoformat(str(upd).replace("Z", "+00:00"))
+                    .timestamp() * 1000
+                )
+            except Exception:
+                modified_ms = 0
+        transcripts.append({
+            "id": sid,
+            "name": sid[:40],
+            "messages": int(r.get("event_count") or 0),
+            "size": 0,  # unknown from DuckDB; UI shows "—" when 0
+            "modified": modified_ms,
+        })
+    return {"transcripts": transcripts, "_source": "local_store"}
+
+
 @bp_sessions.route('/api/transcripts')
 def api_transcripts():
     """List available session transcript .jsonl files."""
     import dashboard as _d
+
+    # Epic #964 — opt-in DuckDB fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_transcripts()
+        if fast is not None:
+            return jsonify(fast)
+
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )
@@ -2162,10 +2273,135 @@ def api_session_model_journey(session_id):
     })
 
 
+def _try_local_store_session_cost_breakdown(session_id: str):
+    """Fast path for /api/sessions/<id>/cost-breakdown. Reads per-turn
+    cost+token breakdown from DuckDB events for the given session.
+
+    Returns ``None`` to defer to the JSONL parser if:
+      - the local_store module isn't importable
+      - no events exist for this session_id (fresh sync, etc.)
+      - data blobs aren't shaped like assistant messages
+      - any unexpected error happens
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        evs = store.query_events(session_id=session_id, limit=5000)
+    except Exception:
+        return None
+    if not evs:
+        return None
+    # Walk events oldest-first so turn_index is meaningful.
+    evs_sorted = sorted(evs, key=lambda e: e.get("ts") or "")
+    turns = []
+    last_seen_model = ""
+    turn_index = 0
+    saw_assistant = False
+    for ev in evs_sorted:
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        if ev.get("event_type") == "model_change":
+            m = data.get("modelId") or data.get("model") or ev.get("model") or ""
+            if m:
+                last_seen_model = m
+            continue
+        # Only assistant-message events carry usage in the OpenClaw schema.
+        msg = data.get("message") if isinstance(data.get("message"), dict) else None
+        if not msg or msg.get("role") != "assistant":
+            continue
+        usage = msg.get("usage") or {}
+        if not isinstance(usage, dict):
+            continue
+        saw_assistant = True
+        turn_index += 1
+        msg_model = msg.get("model") or last_seen_model or ev.get("model") or "unknown"
+        if msg_model:
+            last_seen_model = msg_model
+        in_tok = int(usage.get("input", 0) or 0)
+        out_tok = int(usage.get("output", 0) or 0)
+        cr_tok = int(usage.get("cacheRead", 0) or 0)
+        cw_tok = int(usage.get("cacheWrite", 0) or 0)
+        cost_obj = usage.get("cost", {}) or {}
+        if isinstance(cost_obj, dict):
+            in_cost = float(cost_obj.get("input", 0) or 0)
+            out_cost = float(cost_obj.get("output", 0) or 0)
+            cr_cost = float(cost_obj.get("cacheRead", 0) or 0)
+            cw_cost = float(cost_obj.get("cacheWrite", 0) or 0)
+            tot_cost = float(cost_obj.get("total", 0) or 0)
+        else:
+            in_cost = out_cost = cr_cost = cw_cost = tot_cost = 0.0
+        if tot_cost == 0.0 and (in_cost + out_cost + cr_cost + cw_cost) > 0:
+            tot_cost = in_cost + out_cost + cr_cost + cw_cost
+        turns.append({
+            "turn_index": turn_index,
+            "model": msg_model,
+            "timestamp": ev.get("ts") if isinstance(ev.get("ts"), str) else None,
+            "input_tokens": in_tok,
+            "output_tokens": out_tok,
+            "cache_read_tokens": cr_tok,
+            "cache_write_tokens": cw_tok,
+            "input_cost_usd": round(in_cost, 8),
+            "output_cost_usd": round(out_cost, 8),
+            "cache_read_cost_usd": round(cr_cost, 8),
+            "cache_write_cost_usd": round(cw_cost, 8),
+            "total_cost_usd": round(tot_cost, 8),
+        })
+    if not saw_assistant:
+        return None
+
+    def _s(field):
+        return sum(t[field] for t in turns)
+
+    tot_in = _s("input_tokens")
+    tot_out = _s("output_tokens")
+    tot_cr = _s("cache_read_tokens")
+    tot_cw = _s("cache_write_tokens")
+    tot_in_cost = _s("input_cost_usd")
+    tot_out_cost = _s("output_cost_usd")
+    tot_cr_cost = _s("cache_read_cost_usd")
+    tot_cw_cost = _s("cache_write_cost_usd")
+    tot_cost = _s("total_cost_usd")
+    in_plus_cache = tot_in + tot_cr
+    cache_hit_pct = round(tot_cr / in_plus_cache * 100, 1) if in_plus_cache > 0 else 0.0
+    est_fresh_cost = tot_cr_cost * 10.0
+    est_savings = max(0.0, est_fresh_cost - tot_cr_cost)
+    est_savings_pct = (
+        round(est_savings / (tot_in_cost + est_fresh_cost) * 100, 1)
+        if (tot_in_cost + est_fresh_cost) > 0
+        else 0.0
+    )
+    return {
+        "session_id": session_id,
+        "turns": turns,
+        "totals": {
+            "input_tokens": tot_in,
+            "output_tokens": tot_out,
+            "cache_read_tokens": tot_cr,
+            "cache_write_tokens": tot_cw,
+            "total_tokens": tot_in + tot_out + tot_cr + tot_cw,
+            "input_cost_usd": round(tot_in_cost, 6),
+            "output_cost_usd": round(tot_out_cost, 6),
+            "cache_read_cost_usd": round(tot_cr_cost, 6),
+            "cache_write_cost_usd": round(tot_cw_cost, 6),
+            "total_cost_usd": round(tot_cost, 6),
+        },
+        "cache_hit_ratio_pct": cache_hit_pct,
+        "est_cache_savings_usd": round(est_savings, 6),
+        "est_cache_savings_pct": est_savings_pct,
+        "turn_count": len(turns),
+        "_source": "local_store",
+    }
+
+
 @bp_sessions.route("/api/sessions/<session_id>/cost-breakdown")
 def api_session_cost_breakdown(session_id):
     """Per-turn token + cost breakdown for a single session (GH #604)."""
     import dashboard as _d
+
+    # Epic #964 — opt-in DuckDB fast path.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_session_cost_breakdown(session_id)
+        if fast is not None:
+            return jsonify(fast)
 
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"

--- a/tests/test_duckdb_coverage_batch_2026_05_13.py
+++ b/tests/test_duckdb_coverage_batch_2026_05_13.py
@@ -1,0 +1,241 @@
+"""Tests for the DuckDB coverage batch landed 2026-05-13.
+
+Each test verifies the new ``_try_local_store_*`` fast path returns
+``_source: "local_store"`` when DuckDB has the relevant rows. We only
+assert the tag + a couple of structural keys — the legacy paths are
+covered by their own existing tests.
+
+Surfaces under test (5):
+  - /api/prompt-errors                       routes/overview.py
+  - /api/transcripts                         routes/sessions.py
+  - /api/sessions/cost-breakdown             routes/sessions.py
+  - /api/sessions/<id>/cost-breakdown        routes/sessions.py
+  - /api/heatmap                             routes/health.py
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+# ── shared fixtures ────────────────────────────────────────────────────────
+
+
+def _wait_flush(store, t: float = 2.0) -> None:
+    """Wait for the ring buffer to drain so SELECTs see the rows."""
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Reload local_store against a fresh DuckDB file with the read flag on."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    yield ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _client(blueprint_module_name: str, blueprint_attr: str):
+    """Reload `routes/<module>` so its late-bound store handle picks up the
+    freshly-reloaded local_store, then return a Flask test client."""
+    import importlib as _il
+    mod = _il.import_module(blueprint_module_name)
+    _il.reload(mod)
+    a = Flask(__name__)
+    a.register_blueprint(getattr(mod, blueprint_attr))
+    return a.test_client()
+
+
+# ── /api/prompt-errors ─────────────────────────────────────────────────────
+
+
+def test_prompt_errors_fast_path(fresh_store):
+    ls = fresh_store
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-pe-1",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-pe",
+        "event_type": "openclaw:prompt-error",
+        "ts": "2026-05-12T12:00:00Z",
+        "data": {
+            "runId": "run-1",
+            "provider": "anthropic",
+            "model": "claude-opus-4-7",
+            "api": "messages.create",
+            "error": "rate_limited",
+        },
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    c = _client("routes.overview", "bp_overview")
+    r = c.get("/api/prompt-errors")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["count"] == 1
+    e = body["errors"][0]
+    assert e["sessionId"] == "sess-pe"
+    assert e["error"] == "rate_limited"
+
+
+# ── /api/transcripts ───────────────────────────────────────────────────────
+
+
+def test_transcripts_fast_path(fresh_store):
+    ls = fresh_store
+    store = ls.get_store()
+    # Two sessions worth of events → two transcript rows.
+    for sid in ("sess-tx-A", "sess-tx-B"):
+        for i in range(3):
+            store.ingest({
+                "id": f"ev-{sid}-{i}",
+                "node_id": "agent+test",
+                "agent_id": "main",
+                "session_id": sid,
+                "event_type": "message",
+                "ts": f"2026-05-12T1{i}:00:00Z",
+                "data": {"message": {"role": "user", "content": "hi"}},
+            })
+    _wait_flush(store)
+
+    c = _client("routes.sessions", "bp_sessions")
+    r = c.get("/api/transcripts")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    ids = {t["id"] for t in body["transcripts"]}
+    assert {"sess-tx-A", "sess-tx-B"}.issubset(ids)
+    # Each transcript reports its event count (3 messages each).
+    counts = {t["id"]: t["messages"] for t in body["transcripts"]}
+    assert counts["sess-tx-A"] == 3
+    assert counts["sess-tx-B"] == 3
+
+
+# ── /api/sessions/cost-breakdown (top sessions) ────────────────────────────
+
+
+def test_sessions_cost_breakdown_fast_path(fresh_store):
+    ls = fresh_store
+    store = ls.get_store()
+    # Two sessions, different cost totals.
+    store.ingest({
+        "id": "ev-cb-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-cb-cheap", "event_type": "message",
+        "ts": "2026-05-12T10:00:00Z", "cost_usd": 0.01, "token_count": 100,
+    })
+    store.ingest({
+        "id": "ev-cb-2", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-cb-expensive", "event_type": "message",
+        "ts": "2026-05-12T10:00:01Z", "cost_usd": 5.0, "token_count": 50000,
+    })
+    _wait_flush(store)
+
+    c = _client("routes.sessions", "bp_sessions")
+    r = c.get("/api/sessions/cost-breakdown")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    # Sorted by cost desc — expensive session first.
+    assert body["top10"][0]["session_id"] == "sess-cb-expensive"
+    assert body["top10"][0]["cost_usd"] == pytest.approx(5.0)
+    assert body["total_cost_usd"] == pytest.approx(5.01)
+
+
+# ── /api/sessions/<id>/cost-breakdown (per-turn) ──────────────────────────
+
+
+def test_session_cost_breakdown_fast_path(fresh_store):
+    ls = fresh_store
+    store = ls.get_store()
+    # Two assistant turns with usage blocks.
+    for i in range(2):
+        store.ingest({
+            "id": f"ev-tcb-{i}",
+            "node_id": "agent+test",
+            "agent_id": "main",
+            "session_id": "sess-tcb",
+            "event_type": "message",
+            "ts": f"2026-05-12T10:0{i}:00Z",
+            "data": {
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-opus-4-7",
+                    "usage": {
+                        "input": 100,
+                        "output": 50,
+                        "cacheRead": 10,
+                        "cacheWrite": 5,
+                        "cost": {
+                            "input": 0.001,
+                            "output": 0.002,
+                            "cacheRead": 0.0001,
+                            "cacheWrite": 0.0005,
+                            "total": 0.0036,
+                        },
+                    },
+                },
+            },
+            "model": "claude-opus-4-7",
+        })
+    _wait_flush(store)
+
+    c = _client("routes.sessions", "bp_sessions")
+    r = c.get("/api/sessions/sess-tcb/cost-breakdown")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["turn_count"] == 2
+    assert body["totals"]["input_tokens"] == 200
+    assert body["totals"]["output_tokens"] == 100
+    assert body["totals"]["total_cost_usd"] == pytest.approx(0.0072)
+
+
+# ── /api/heatmap ───────────────────────────────────────────────────────────
+
+
+def test_heatmap_fast_path(fresh_store):
+    ls = fresh_store
+    store = ls.get_store()
+    # Stamp a few events at "today, 14:00 local" so they land on today's
+    # row in the grid regardless of the test runner's tz.
+    today = datetime.now()
+    iso = today.replace(hour=14, minute=0, second=0, microsecond=0).isoformat()
+    for i in range(3):
+        store.ingest({
+            "id": f"ev-hm-{i}",
+            "node_id": "agent+test",
+            "agent_id": "main",
+            "session_id": "sess-hm",
+            "event_type": "message",
+            "ts": iso,
+        })
+    _wait_flush(store)
+
+    c = _client("routes.health", "bp_health")
+    r = c.get("/api/heatmap?days=1")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["n_days"] == 1
+    today_hours = body["days"][0]["hours"]
+    assert today_hours[14] == 3


### PR DESCRIPTION
## Summary

Coverage sprint following the [2026-05-13 audit](DUCKDB_COVERAGE_AUDIT_2026-05-13.md). Adds `_try_local_store_*` fast paths to five **Bypass-Easy** read surfaces, lifting DuckDB-Full coverage from **37% → 41%** of the 104 read endpoints.

Each new fast path:
- Gates behind `CLAWMETRY_LOCAL_STORE_READ=1` (matches every other epic-#964 fast path).
- Returns `_source: "local_store"` on hit; returns `None` to defer to the legacy JSONL/gateway path on miss.
- Late-imports `clawmetry.local_store` per CLAUDE.md.

## Surfaces migrated

| Endpoint | Helper | DuckDB query |
|---|---|---|
| `/api/prompt-errors` | `_try_local_store_prompt_errors` | `query_events(event_type="openclaw:prompt-error", since=...)` |
| `/api/transcripts` | `_try_local_store_transcripts` | `query_sessions(limit=50)` |
| `/api/sessions/cost-breakdown` | `_try_local_store_cost_breakdown` | `query_sessions(limit=1000)` |
| `/api/sessions/<id>/cost-breakdown` | `_try_local_store_session_cost_breakdown` | `query_events(session_id=..., limit=5000)` |
| `/api/heatmap` | `_try_local_store_heatmap` | `query_events(since=cutoff_iso, limit=50000)` |

## Audit document

`DUCKDB_COVERAGE_AUDIT_2026-05-13.md` inventories every `@bp_*.route(...)` across the 24 blueprints in `routes/` (197 total routes, 104 of which are read surfaces) and classifies each into DuckDB-Full / Bypass-Easy / Bypass-Medium / Bypass-Hard / N/A. The remaining Bypass-Easy candidates are listed there for follow-up sprints.

## Test plan

- [x] `pytest tests/test_duckdb_coverage_batch_2026_05_13.py` — 5/5 pass
- [x] `pytest tests/test_overview_local_store.py tests/test_sessions_local_fastpath.py tests/test_health_local_store.py` — 26/26 still pass (no regression on adjacent fast paths)
- [x] `pytest tests/test_local_store.py tests/test_circular_import.py` — 33/33 still pass
- [ ] Manual smoke: open dashboard with `CLAWMETRY_LOCAL_STORE_READ=1`, confirm Heatmap + Cost-breakdown panels render

🤖 Generated with [Claude Code](https://claude.com/claude-code)