### PR TITLE
feat: heuristic task-type classifier on Brain tab events

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2471,6 +2471,21 @@ function renderBrainStream(events) {
     if (skillName) {
       skillBadge = '<span class="brain-skill" style="color:#f59e0b;font-size:10px;flex-shrink:0;white-space:nowrap;" title="Skill: ' + escHtml(skillName) + '">🎯 ' + escHtml(skillName.length > 16 ? skillName.slice(0, 14) + '\u2026' : skillName) + '</span>';
     }
+    // Task type badge (issue #571)
+    var taskBadge = '';
+    var _tt = ev.taskType || '';
+    if (_tt) {
+      var _ttMap = {
+        creative:  ['🎨', '#f97316', 'Creative'],
+        factual:   ['🔍', '#3b82f6', 'Factual'],
+        reasoning: ['🧢', '#8b5cf6', 'Reasoning'],
+        mixed:     ['🔀', '#6b7280', 'Mixed']
+      };
+      var _ttCfg = _ttMap[_tt];
+      if (_ttCfg) {
+        taskBadge = '<span class="brain-task-type" style="color:' + _ttCfg[1] + ';font-size:10px;flex-shrink:0;white-space:nowrap;" title="Task type: ' + _ttCfg[2] + '">' + _ttCfg[0] + ' ' + _ttCfg[2] + '</span>';
+      }
+    }
     // Build turn timeline for USER events (Phase 4: Agent Runtime Timeline)
     var turnTimeline = '';
     if (evType === 'USER') {
@@ -2562,6 +2577,7 @@ function renderBrainStream(events) {
     html += '<span class="brain-source" style="color:' + color + ';flex-shrink:0;" title="' + escHtml(fullSrc) + '">' + roleIcon + ' ' + escHtml(shortSrc) + '</span>';
     html += chBadge;
     html += skillBadge;
+    html += taskBadge;
     html += '</div>';
     html += '<span class="brain-detail">' + renderBrainDetail(ev.detail || '') + '</span>';
     html += turnTimeline;

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -28,6 +28,50 @@ _BRAIN_HISTORY_CACHE = {}
 _BRAIN_HISTORY_CACHE_TTL_SECONDS = 3.0
 _BRAIN_HISTORY_TAIL_BYTES = 512 * 1024
 
+# ── Task-type classifier (issue #571) ──────────────────────────────────
+_FACTUAL_KW = frozenset([
+    "extract", "list", "summarize", "find", "what is", "how many",
+    "cite", "return json", "schema", "lookup", "search for", "retrieve",
+    "get the", "fetch", "query", "select", "filter", "count", "calculate",
+    "convert", "parse", "format", "validate", "check if", "verify",
+    "translate", "describe", "define", "explain what", "what are",
+    "show me", "give me", "tell me", "output", "return a",
+])
+_CREATIVE_KW = frozenset([
+    "brainstorm", "write", "imagine", "draft", "generate idea",
+    "story", "poem", "essay", "blog post", "ideate", "invent",
+    "compose", "suggest creative", "come up with", "make up",
+    "creative writing", "fiction", "novel", "screenplay", "narrative", "slogan",
+    "copywriting",
+])
+_REASONING_KW = frozenset([
+    "analyze", "analyse", "explain why", "how does", "compare", "evaluate",
+    "assess", "plan", "strategy", "debug", "diagnose", "reason", "decide",
+    "prioritize", "prioritise", "review", "optimize", "optimise", "refactor",
+    "improve", "think through", "step by step", "consider", "tradeoff",
+    "trade-off", "pros and cons", "should i", "which is better",
+])
+
+
+def _classify_task_type(text):
+    """Return 'creative', 'factual', 'reasoning', 'mixed', or None."""
+    if not text:
+        return None
+    t = text.lower()
+    f = sum(1 for kw in _FACTUAL_KW if kw in t)
+    c = sum(1 for kw in _CREATIVE_KW if kw in t)
+    r = sum(1 for kw in _REASONING_KW if kw in t)
+    if not (f or c or r):
+        return None
+    top = max(f, c, r)
+    if sum(1 for s in (f, c, r) if s == top) > 1:
+        return "mixed"
+    if f == top:
+        return "factual"
+    if c == top:
+        return "creative"
+    return "reasoning"
+
 
 def _brain_history_bool_arg(value):
     return str(value or "").strip().lower() in {"1", "true", "yes", "on", "all"}
@@ -558,6 +602,7 @@ def api_brain_history():
                                 "type": "USER",
                                 "detail": text[:300],
                                 "color": color,
+                                "taskType": _classify_task_type(text),
                             }
                         )
 
@@ -595,6 +640,7 @@ def api_brain_history():
                                         "type": "AGENT",
                                         "detail": text[:300],
                                         "color": color,
+                                        "taskType": _classify_task_type(text),
                                     }
                                 )
                             continue
@@ -886,6 +932,7 @@ def api_brain_stream():
                             "type": "AGENT",
                             "detail": text[:300],
                             "color": color,
+                            "taskType": _classify_task_type(text),
                         }
                 if btype == "tool_use":
                     tool_name = block.get("name", "")
@@ -923,6 +970,7 @@ def api_brain_stream():
                     "type": "USER",
                     "detail": text[:300],
                     "color": color,
+                    "taskType": _classify_task_type(text),
                 }
         return None
 


### PR DESCRIPTION
Closes #571

## Summary

- **`routes/brain.py`** — adds `_classify_task_type(text)` helper with three `frozenset` keyword tables (`_FACTUAL_KW`, `_CREATIVE_KW`, `_REASONING_KW`). Scores each table by substring count, returns `"creative"` / `"factual"` / `"reasoning"` / `"mixed"` / `None`. Stamps a `taskType` field on every `USER` and `AGENT` event returned by `/api/brain-history`.
- **`clawmetry/static/js/app.js`** — reads `ev.taskType` in `renderBrainStream` and renders a small coloured badge (🎨 Creative · 🔍 Factual · 🧢 Reasoning · 🔀 Mixed) in each Brain tab event row, after the existing skill badge. Zero layout change for events with no classification.

**Not in scope this PR** (left for follow-up per plan comment): temperature-based mismatch warnings and Usage-tab mode-distribution chart — these need temperature data not currently in JSONL transcripts.

## Test plan

- [ ] `make test-api` → 141 passed, 6 skipped (verified locally)
- [ ] Open Brain tab; USER/AGENT rows with classifiable prompts show a coloured badge; rows with generic text show nothing
- [ ] Badge tooltip reads "Task type: Creative" (or Factual/Reasoning/Mixed)
- [ ] Existing channel and skill badges are unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_018dLjewFi5LR2kaHCQoPVW7)_