### PR TITLE
feat: 8 more DuckDB fast-paths (41% → ~50% coverage)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1608,6 +1608,7 @@ class LocalStore:
     def query_sessions_table(
         self,
         *,
+        agent_type: str | None = None,
         limit: int = 200,
     ) -> list[dict[str, Any]]:
         """Read rows directly from the typed ``sessions`` table.
@@ -1616,6 +1617,10 @@ class LocalStore:
         table by ``GROUP BY session_id``. The ``sessions`` table is the
         typed-session view written by ``sync.py`` + the daemon — it carries
         title, status, message_count, and a metadata BLOB.
+
+        ``agent_type`` filters rows to a single adapter (e.g. ``"openclaw"``,
+        ``"hermes"``) — used by ``/api/agents/<name>/sessions`` to render
+        per-adapter session lists from DuckDB.
 
         Returns one dict per row with ``metadata`` already JSON-decoded
         (``{}`` when missing or invalid). Rows are ordered most-recently-
@@ -1627,14 +1632,23 @@ class LocalStore:
         (``routes/local_query.py:local_store_via_daemon``) can expose it
         for cross-process callers (issue #1088).
         """
-        rows = self._fetch("""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if agent_type:
+            clauses.append("agent_type = ?")
+            params.append(str(agent_type))
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
             SELECT agent_type, session_id, agent_id, title, started_at,
                    last_active_at, ended_at, status, total_tokens, cost_usd,
                    message_count, metadata
             FROM sessions
+            {where}
             ORDER BY COALESCE(last_active_at, started_at) DESC NULLS LAST
             LIMIT ?
-        """, [int(limit)])
+        """
+        params.append(int(limit))
+        rows = self._fetch(sql, params)
         cols = ["agent_type", "session_id", "agent_id", "title", "started_at",
                 "last_active_at", "ended_at", "status", "total_tokens",
                 "cost_usd", "message_count", "metadata"]

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -15,11 +15,80 @@ contained inside the adapter.
 """
 from __future__ import annotations
 
+import os
+
 from flask import Blueprint, jsonify, request
 
 from clawmetry.adapters import registry
 
 bp_agents = Blueprint("agents", __name__)
+
+
+def _ls_call(method_name, **kwargs):
+    """Cross-process LocalStore call with single-process fallback (issue #1088)."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+def _try_local_store_agent_sessions(name: str, limit: int):
+    """Fast path for /api/agents/<name>/sessions. Reads the typed sessions
+    table filtered by ``agent_type`` and returns the unified Session shape.
+
+    Returns ``None`` to defer to the adapter when the sessions table has no
+    rows for this agent_type (fresh sync, unsupported adapter, etc.).
+    """
+    rows = _ls_call("query_sessions_table", agent_type=name, limit=limit)
+    if not rows:
+        return None
+    sessions = []
+    for r in rows:
+        meta = r.get("metadata") if isinstance(r.get("metadata"), dict) else {}
+        sid = r.get("session_id") or ""
+
+        def _ts_to_seconds(v):
+            if not v:
+                return 0.0
+            if isinstance(v, (int, float)):
+                return float(v) / 1000.0 if v > 1e12 else float(v)
+            try:
+                from datetime import datetime as _dt
+                return _dt.fromisoformat(str(v).replace("Z", "+00:00")).timestamp()
+            except Exception:
+                return 0.0
+
+        sessions.append({
+            "agent": name,
+            "id": sid,
+            "displayName": r.get("title") or sid[:24],
+            "title": r.get("title") or "",
+            "model": meta.get("model") or "",
+            "source": meta.get("source") or "",
+            "startedAt": _ts_to_seconds(r.get("started_at")),
+            "endedAt": _ts_to_seconds(r.get("ended_at")) or None,
+            "parentId": meta.get("parent_id"),
+            "messageCount": int(r.get("message_count") or 0),
+            "totalTokens": int(r.get("total_tokens") or 0),
+            "inputTokens": int(meta.get("input_tokens") or 0),
+            "outputTokens": int(meta.get("output_tokens") or 0),
+            "cacheReadTokens": int(meta.get("cache_read_tokens") or 0),
+            "cacheWriteTokens": int(meta.get("cache_write_tokens") or 0),
+            "reasoningTokens": int(meta.get("reasoning_tokens") or 0),
+            "costUsd": float(r.get("cost_usd")) if r.get("cost_usd") is not None else None,
+            "costStatus": meta.get("cost_status") or "",
+            "endReason": meta.get("end_reason") or "",
+        })
+    return {"sessions": sessions, "_source": "local_store"}
 
 
 @bp_agents.route("/api/agents")
@@ -42,13 +111,17 @@ def api_agent_detail(name: str):
 
 @bp_agents.route("/api/agents/<name>/sessions")
 def api_agent_sessions(name: str):
-    adapter = registry.get(name)
-    if adapter is None:
-        return jsonify({"error": f"Unknown agent: {name}"}), 404
     try:
         limit = max(1, min(1000, int(request.args.get("limit", 100))))
     except (TypeError, ValueError):
         limit = 100
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_agent_sessions(name, limit)
+        if fast is not None:
+            return jsonify(fast)
+    adapter = registry.get(name)
+    if adapter is None:
+        return jsonify({"error": f"Unknown agent: {name}"}), 404
     try:
         sessions = adapter.list_sessions(limit=limit)
     except Exception as exc:

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -57,6 +57,31 @@ bp_crons = Blueprint('crons', __name__)
 # tests can assert which path served the response.
 
 
+def _ls_call(method_name, **kwargs):
+    """Cross-process LocalStore call with single-process fallback.
+
+    Issue #1088: every direct ``get_store().query_*`` call is dead code in
+    the standard install (daemon owns the writer lock, dashboard's open
+    raises ``IOException: Could not set lock``). This wrapper hits the
+    daemon's HTTP proxy first, then falls back to direct open for
+    single-process boots (tests + dev mode). Returns ``None`` on miss so
+    callers can defer to the legacy fallback path.
+    """
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
 def _parse_iso_to_ms(ts):
     """Best-effort ISO-8601 → epoch-ms. Returns 0 on any failure."""
     if not ts:
@@ -588,6 +613,35 @@ def api_cron_kill(job_id):
     return jsonify({"ok": True, "jobId": job_id, "enabled": False, "result": result})
 
 
+def _try_local_store_cron_run_log(session_id: str):
+    """Fast path for /api/cron-run-log. Reads message events for the given
+    session from DuckDB and projects ``role/timestamp/content`` for the modal.
+
+    Issue #1088: routes through the daemon HTTP proxy first via ``_ls_call``,
+    with the standard direct-open fallback for single-process boots. Returns
+    ``None`` to defer to the JSONL parser when the events table has no
+    message rows for this session.
+    """
+    rows = _ls_call("query_events", session_id=session_id, limit=5000)
+    if not rows:
+        return None
+    rows = list(reversed(rows))  # query_events returns DESC
+    events = []
+    for ev in rows:
+        if ev.get("event_type") != "message":
+            continue
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+        events.append({
+            "role": msg.get("role", ""),
+            "timestamp": data.get("timestamp") or ev.get("ts") or "",
+            "content": str(msg.get("content", ""))[:500],
+        })
+    if not events:
+        return None
+    return {"sessionId": session_id, "events": events, "_source": "local_store"}
+
+
 @bp_crons.route("/api/cron-run-log")
 def api_cron_run_log():
     """Return a parsed session transcript for a cron run (for the run-log modal)."""
@@ -595,6 +649,10 @@ def api_cron_run_log():
     session_id = request.args.get("session_id", "")
     if not session_id:
         return jsonify({"error": "session_id required"}), 400
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_cron_run_log(session_id)
+        if fast is not None:
+            return jsonify(fast)
     sessions_dir = _d._get_sessions_dir()
     fpath = os.path.join(sessions_dir, f"{session_id}.jsonl")
     # Guard against path-traversal via crafted session_id (e.g. "../../etc/passwd").

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -515,6 +515,22 @@ def api_clusters():
     sessions_dir = getattr(_d, "SESSIONS_DIR", None) or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )
+    # Issue #1088: opt-in DuckDB fast path. Delegates to the same DuckDB-driven
+    # clustering used by /api/sessions/clusters and exposes a thinner shape
+    # (clusters + total_clusters) — _source: "local_store" for tests.
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        try:
+            from routes.usage import _try_local_store_sessions_clusters
+            fast = _try_local_store_sessions_clusters(30)
+            if fast is not None:
+                return jsonify({
+                    "clusters": fast.get("clusters", []),
+                    "total_clusters": len(fast.get("clusters", [])),
+                    "sessions_dir": sessions_dir,
+                    "_source": "local_store",
+                })
+        except Exception:
+            pass
     # Cloud's dashboard.py doesn't ship _build_clusters; fall through to an
     # empty 200 instead of leaking a 500 with an AttributeError body into the
     # user's console. (When cloud_route_policy is loaded, this endpoint is

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -550,6 +550,23 @@ def api_overview():
     )
 
 
+def _ls_call(method_name, **kwargs):
+    """Cross-process LocalStore call with single-process fallback (issue #1088)."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
 def _try_local_store_timeline():
     """Epic #964: opt-in local-store fast path for /api/timeline.
 
@@ -563,22 +580,17 @@ def _try_local_store_timeline():
     day with a tight window — only days that already showed activity in the
     aggregates pass actually get scanned.
 
+    Issue #1088: routes through the daemon HTTP proxy first via ``_ls_call``,
+    with the standard direct-open fallback for single-process boots.
+
     Returns ``None`` to defer to the JSONL fallback if:
-      - the local_store module isn't importable
+      - neither path can reach the local store
       - query_aggregates returns empty (no events seen yet)
       - any unexpected error happens
     """
-    try:
-        from clawmetry import local_store
-        store = local_store.get_store()
-    except Exception:
-        return None
     now = datetime.now()
     cutoff = (now - timedelta(days=30)).strftime("%Y-%m-%d") + "T00:00:00"
-    try:
-        rows = store.query_aggregates(since=cutoff)
-    except Exception:
-        return None
+    rows = _ls_call("query_aggregates", since=cutoff)
     if not rows:
         return None
 
@@ -601,22 +613,20 @@ def _try_local_store_timeline():
         count = day_counts.get(ds, 0)
         hours = {}
         if count > 0:
-            try:
-                ev_rows = store.query_events(
-                    since=ds + "T00:00:00",
-                    until=ds + "T23:59:59",
-                    limit=10000,
-                )
-                for ev in ev_rows:
-                    ts = ev.get("ts") or ""
-                    if "T" in ts:
-                        try:
-                            h = int(ts.split("T")[1][:2])
-                            hours[h] = hours.get(h, 0) + 1
-                        except Exception:
-                            pass
-            except Exception:
-                pass
+            ev_rows = _ls_call(
+                "query_events",
+                since=ds + "T00:00:00",
+                until=ds + "T23:59:59",
+                limit=10000,
+            ) or []
+            for ev in ev_rows:
+                ts = ev.get("ts") or ""
+                if "T" in ts:
+                    try:
+                        h = int(ts.split("T")[1][:2])
+                        hours[h] = hours.get(h, 0) + 1
+                    except Exception:
+                        pass
         mem_file = os.path.join(mem_dir, f"{ds}.md") if mem_dir else None
         has_memory = bool(mem_file and os.path.exists(mem_file))
         if count > 0 or has_memory:

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2011,10 +2011,109 @@ def api_transcript(session_id):
     )
 
 
+def _try_local_store_transcript_events(session_id: str):
+    """Fast path for /api/transcript-events/<id>. Reads events from DuckDB and
+    re-projects them into the structured-event shape the detail modal expects.
+
+    Issue #1088: routes through the daemon HTTP proxy first, with the standard
+    direct-open fallback inside ``_ls_call``. Returns ``None`` to defer to the
+    JSONL parser when the events table has no rows for this session.
+    """
+    rows = _ls_call("query_events", session_id=session_id, limit=10000)
+    if not rows:
+        return None
+    rows = list(reversed(rows))  # query_events is DESC; the modal reads forward.
+    events: list[dict] = []
+    msg_count = 0
+    for ev in rows:
+        ev_type = ev.get("event_type") or ""
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        ts_raw = data.get("timestamp") or data.get("time") or ev.get("ts")
+        ts_val = None
+        if isinstance(ts_raw, (int, float)):
+            ts_val = int(ts_raw * 1000) if ts_raw < 1e12 else int(ts_raw)
+        elif ts_raw:
+            try:
+                ts_val = int(
+                    datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00")).timestamp() * 1000
+                )
+            except Exception:
+                ts_val = None
+
+        if ev_type == "model_change":
+            events.append({
+                "type": "model_change",
+                "modelId": data.get("modelId") or data.get("model") or "",
+                "provider": data.get("provider") or "",
+                "timestamp": ts_val,
+            })
+            continue
+        if ev_type == "thinking_level_change":
+            events.append({
+                "type": "thinking_level_change",
+                "thinkingLevel": data.get("thinkingLevel") or data.get("level") or "",
+                "timestamp": ts_val,
+            })
+            continue
+
+        msg = data.get("message") if isinstance(data.get("message"), dict) else None
+        if not msg:
+            continue
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        msg_count += 1
+
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type", "")
+                if btype == "thinking":
+                    events.append({
+                        "type": "thinking",
+                        "text": (block.get("thinking") or "")[:2000],
+                        "thinking_chars": len(block.get("thinking") or ""),
+                        "timestamp": ts_val,
+                    })
+                elif btype == "text":
+                    text = block.get("text", "") or ""
+                    if role == "user":
+                        events.append({"type": "user", "text": text[:3000], "timestamp": ts_val})
+                    elif role == "assistant":
+                        events.append({"type": "agent", "text": text[:3000], "timestamp": ts_val})
+                elif btype in ("toolCall", "tool_use"):
+                    name = block.get("name", "?")
+                    args = block.get("arguments") or block.get("input") or {}
+                    args_str = json.dumps(args, indent=2)[:1000] if isinstance(args, dict) else str(args)[:1000]
+                    events.append({
+                        "type": "tool",
+                        "toolName": name,
+                        "args": args_str,
+                        "timestamp": ts_val,
+                    })
+        elif isinstance(content, str) and content:
+            if role == "user":
+                events.append({"type": "user", "text": content[:3000], "timestamp": ts_val})
+            elif role == "assistant":
+                events.append({"type": "agent", "text": content[:3000], "timestamp": ts_val})
+            elif role == "toolResult":
+                events.append({"type": "result", "text": content[:2000], "timestamp": ts_val})
+    return {
+        "events": events[-500:],
+        "messageCount": msg_count,
+        "totalEvents": len(events),
+        "_source": "local_store",
+    }
+
+
 @bp_sessions.route("/api/transcript-events/<session_id>")
 def api_transcript_events(session_id):
     """Parse a session transcript JSONL into structured events for the detail modal."""
     import dashboard as _d
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_transcript_events(session_id)
+        if fast is not None:
+            return jsonify(fast)
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )
@@ -2621,6 +2720,123 @@ def api_session_cost_breakdown(session_id):
     })
 
 
+def _try_local_store_session_export(session_id: str):
+    """Fast path for /api/sessions/<id>/export (JSON shape).
+
+    Reads events from DuckDB and re-projects them into the same export shape
+    the JSONL parser produces. Issue #1088 — uses ``_ls_call`` so the daemon
+    HTTP proxy fires under the standard install. Returns ``None`` to defer to
+    the JSONL parser when the events table has no rows for this session.
+    """
+    rows = _ls_call("query_events", session_id=session_id, limit=10000)
+    if not rows:
+        return None
+    rows = list(reversed(rows))  # query_events is DESC; export reads forward.
+    out = {
+        "session_id": session_id,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "messages": [],
+        "tool_calls": [],
+        "cost_data": {
+            "total_tokens": 0, "input_tokens": 0, "output_tokens": 0,
+            "cache_read_tokens": 0, "cache_write_tokens": 0,
+            "total_cost_usd": 0.0,
+        },
+        "metadata": {
+            "start_time": None, "end_time": None, "model": None,
+            "message_count": 0, "tool_call_count": 0,
+        },
+        "_source": "local_store",
+    }
+    model = None
+    start_time = None
+    end_time = None
+    for ev in rows:
+        ev_type = ev.get("event_type") or ""
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        ts_str = data.get("timestamp") or ev.get("ts")
+        ts_ms = None
+        if isinstance(ts_str, (int, float)):
+            ts_ms = int(ts_str * 1000) if ts_str < 1e12 else int(ts_str)
+        elif ts_str:
+            try:
+                ts_ms = int(datetime.fromisoformat(str(ts_str).replace("Z", "+00:00")).timestamp() * 1000)
+            except Exception:
+                ts_ms = None
+        if ev_type == "model_change":
+            if data.get("modelId"):
+                model = data.get("modelId")
+                out["metadata"]["model"] = model
+        elif ev_type == "message":
+            msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+            role = msg.get("role", "")
+            content = msg.get("content", [])
+            usage = msg.get("usage") or {}
+            text_parts: list[str] = []
+            tool_calls_in_msg: list[dict] = []
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    btype = block.get("type", "")
+                    if btype == "text":
+                        text_parts.append(block.get("text", "") or "")
+                    elif btype == "thinking":
+                        text_parts.append(f"[THINKING] {block.get('thinking', '')}")
+                    elif btype in ("toolCall", "tool_use"):
+                        tool_calls_in_msg.append({
+                            "id": block.get("id", ""),
+                            "name": block.get("name", ""),
+                            "arguments": block.get("arguments") or block.get("input") or {},
+                        })
+            elif isinstance(content, str):
+                text_parts.append(content)
+            msg_entry = {
+                "timestamp": ts_str if isinstance(ts_str, str) else None,
+                "role": role,
+                "content": "\n".join(text_parts) if text_parts else None,
+                "model": msg.get("model") or model,
+            }
+            if isinstance(usage, dict) and usage:
+                in_t = int(usage.get("input", 0) or 0)
+                out_t = int(usage.get("output", 0) or 0)
+                cr_t = int(usage.get("cacheRead", 0) or 0)
+                cw_t = int(usage.get("cacheWrite", 0) or 0)
+                msg_entry["tokens"] = {
+                    "input": in_t, "output": out_t,
+                    "cache_read": cr_t, "cache_write": cw_t,
+                    "total": usage.get("totalTokens", in_t + out_t),
+                }
+                cost_obj = usage.get("cost") or {}
+                if isinstance(cost_obj, dict):
+                    msg_entry["cost_usd"] = cost_obj.get("total", 0.0)
+                    out["cost_data"]["total_cost_usd"] += float(cost_obj.get("total", 0) or 0)
+                    out["cost_data"]["input_tokens"] += in_t
+                    out["cost_data"]["output_tokens"] += out_t
+                    out["cost_data"]["cache_read_tokens"] += cr_t
+                    out["cost_data"]["cache_write_tokens"] += cw_t
+                    out["cost_data"]["total_tokens"] += in_t + out_t + cr_t + cw_t
+            out["messages"].append(msg_entry)
+            out["metadata"]["message_count"] += 1
+            for tc in tool_calls_in_msg:
+                out["tool_calls"].append({
+                    "timestamp": ts_str if isinstance(ts_str, str) else None,
+                    "tool_call_id": tc.get("id"),
+                    "tool_name": tc.get("name"),
+                    "arguments": tc.get("arguments"),
+                    "model": msg.get("model") or model,
+                })
+                out["metadata"]["tool_call_count"] += 1
+        if ts_ms:
+            if start_time is None or ts_ms < start_time:
+                start_time = ts_ms
+            if end_time is None or ts_ms > end_time:
+                end_time = ts_ms
+    out["metadata"]["start_time_ms"] = start_time
+    out["metadata"]["end_time_ms"] = end_time
+    return out
+
+
 @bp_sessions.route("/api/sessions/<session_id>/export")
 def api_session_export(session_id):
     """Export session data as JSON or CSV for external analysis (closes #593)."""
@@ -2629,6 +2845,17 @@ def api_session_export(session_id):
     export_format = request.args.get("format", "json").lower()
     if export_format not in ("json", "csv"):
         return jsonify({"error": "Invalid format. Use 'json' or 'csv'"}), 400
+
+    # JSON-only fast path — CSV branch falls through to the legacy parser
+    # because it relies on text formatting that's not worth duplicating.
+    if export_format == "json" and os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_session_export(session_id)
+        if fast is not None:
+            return Response(
+                json.dumps(fast, indent=2, default=str),
+                mimetype="application/json",
+                headers={"Content-Disposition": f'attachment; filename="{session_id}.json"'},
+            )
 
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -1040,6 +1040,196 @@ def api_usage_by_plugin_trend():
     return jsonify({"days": day_list, "plugins": result})
 
 
+def _build_cluster_payload(session_profiles, *, days, now_ts):
+    """Aggregate per-session profiles into clusters keyed by
+    (tool_category, cost_tier, error_presence, model_family)."""
+    def _model_family(model_str):
+        m = (model_str or "").lower()
+        if "claude" in m:
+            return "claude"
+        if "gpt" in m or "openai" in m:
+            return "gpt"
+        if "gemini" in m or "google" in m:
+            return "gemini"
+        if "llama" in m or "mistral" in m or "groq" in m:
+            return "open-source"
+        return "other"
+
+    def _tool_category(tool_name):
+        t = (tool_name or "").lower()
+        if t in ("none", ""):
+            return "no-tools"
+        if t in ("exec", "bash", "shell", "run"):
+            return "code-execution"
+        if t in ("read", "write", "edit", "file_read", "file_write"):
+            return "file-ops"
+        if t in ("web_search", "web_fetch", "browser"):
+            return "web"
+        if t in ("message", "tts", "send_message"):
+            return "communication"
+        if t in ("sessions_spawn", "sessions_send", "subagents"):
+            return "orchestration"
+        if t in ("memory_search", "memory_get"):
+            return "memory"
+        return "other-tools"
+
+    clusters_map = defaultdict(
+        lambda: {
+            "sessions": [], "total_tokens": 0, "total_cost_usd": 0.0,
+            "error_count": 0, "tool_freq": defaultdict(int),
+        }
+    )
+    for sp in session_profiles:
+        mf = _model_family(sp["model"])
+        tc = _tool_category(sp["top_tool"])
+        has_errors = "errors" if sp["error_count"] > 0 else "clean"
+        cluster_key = f"{tc}|{sp['cost_tier']}|{has_errors}|{mf}"
+        c = clusters_map[cluster_key]
+        c["sessions"].append(sp["session_id"])
+        c["total_tokens"] += sp["tokens"]
+        c["total_cost_usd"] += sp["cost_usd"]
+        c["error_count"] += sp["error_count"]
+        for tool, cnt in sp["tool_counts"].items():
+            c["tool_freq"][tool] += cnt
+        if "tool_category" not in c:
+            c["tool_category"] = tc
+            c["cost_tier"] = sp["cost_tier"]
+            c["has_errors"] = has_errors == "errors"
+            c["model_family"] = mf
+
+    clusters_out = []
+    for key, c in clusters_map.items():
+        n = len(c["sessions"])
+        avg_cost = c["total_cost_usd"] / n if n > 0 else 0.0
+        top_tools_sorted = sorted(c["tool_freq"].items(), key=lambda x: x[1], reverse=True)[:5]
+        tc = c.get("tool_category", "other")
+        cost_tier = c.get("cost_tier", "cheap")
+        mf = c.get("model_family", "other")
+        has_err = c.get("has_errors", False)
+        label_parts = []
+        if tc == "code-execution": label_parts.append("Code execution")
+        elif tc == "file-ops":     label_parts.append("File operations")
+        elif tc == "web":          label_parts.append("Web browsing")
+        elif tc == "communication":label_parts.append("Messaging")
+        elif tc == "orchestration":label_parts.append("Agent orchestration")
+        elif tc == "memory":       label_parts.append("Memory access")
+        elif tc == "no-tools":     label_parts.append("Conversational")
+        else:                       label_parts.append("Mixed tools")
+        if cost_tier == "expensive": label_parts.append("high-cost")
+        elif cost_tier == "medium":  label_parts.append("medium-cost")
+        if has_err: label_parts.append("with errors")
+        if mf not in ("claude", "other"): label_parts.append(mf)
+        clusters_out.append({
+            "cluster_id": key,
+            "label": " ".join(label_parts),
+            "session_count": n,
+            "session_ids": c["sessions"][:10],
+            "total_tokens": c["total_tokens"],
+            "total_cost_usd": round(c["total_cost_usd"], 6),
+            "avg_cost_usd": round(avg_cost, 6),
+            "error_count": c["error_count"],
+            "tool_category": tc,
+            "cost_tier": cost_tier,
+            "has_errors": has_err,
+            "model_family": mf,
+            "top_tools": [{"tool": t, "count": cnt} for t, cnt in top_tools_sorted],
+        })
+    clusters_out.sort(key=lambda x: x["session_count"], reverse=True)
+    return {
+        "clusters": clusters_out,
+        "total_sessions": len(session_profiles),
+        "days": days,
+        "generated_at": int(now_ts * 1000),
+    }
+
+
+def _try_local_store_sessions_clusters(days: int):
+    """Fast path for /api/sessions/clusters. Reads sessions + events from
+    DuckDB and runs the same cluster aggregation as the legacy JSONL walker.
+
+    Issue #1088: routes through the daemon HTTP proxy via ``_ls_call``.
+    Returns ``None`` to defer to the JSONL fallback when DuckDB has no
+    sessions in the time window.
+    """
+    now_ts = time.time()
+    cutoff_ts = now_ts - (days * 86400)
+    cutoff_iso = datetime.utcfromtimestamp(cutoff_ts).isoformat()
+    sessions = _ls_call("query_sessions", since=cutoff_iso, limit=2000)
+    if not sessions:
+        return None
+    # One bulk events fetch; group by session_id (avoids N+1 daemon hops).
+    events = _ls_call("query_events", since=cutoff_iso, limit=20000) or []
+    by_session: dict = defaultdict(list)
+    for ev in events:
+        sid = ev.get("session_id")
+        if sid:
+            by_session[sid].append(ev)
+
+    import dashboard as _d
+    usd_per_tok = _d._estimate_usd_per_token()
+    session_profiles = []
+    for s in sessions:
+        sid = s.get("session_id")
+        if not sid:
+            continue
+        evs = by_session.get(sid, [])
+        tool_counts: dict = defaultdict(int)
+        error_count = 0
+        s_model = "unknown"
+        has_cron = False
+        has_subagent = False
+        turn_count = 0
+        s_tokens = int(s.get("token_count") or 0)
+        for ev in evs:
+            data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+            msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+            mdl = ev.get("model") or msg.get("model") or data.get("model")
+            if mdl:
+                s_model = mdl
+            for t in _d._extract_tool_plugins(data) or []:
+                tool_counts[t] += 1
+            etype = ev.get("event_type") or data.get("type") or ""
+            if etype in ("error", "tool_error"):
+                error_count += 1
+            if isinstance(data.get("error"), dict) and data["error"]:
+                error_count += 1
+            blob = json.dumps(data, default=str).lower()
+            if "cron" in blob or "scheduled" in blob:
+                has_cron = True
+            if "subagent" in blob or "spawned" in blob:
+                has_subagent = True
+            if etype == "message":
+                turn_count += 1
+        # Token fallback: derive from event-level token_count if sessions row was zero.
+        if s_tokens == 0:
+            s_tokens = sum(int(ev.get("token_count") or 0) for ev in evs)
+        if s_tokens == 0 and not tool_counts:
+            continue
+        total_tools = sum(tool_counts.values())
+        top_tool = max(tool_counts, key=tool_counts.get) if tool_counts else "none"
+        cost = float(s.get("cost_usd") or 0.0)
+        if cost == 0.0 and s_tokens:
+            cost = round(s_tokens * usd_per_tok, 6)
+        if cost >= 0.10:
+            cost_tier = "expensive"
+        elif cost >= 0.02:
+            cost_tier = "medium"
+        else:
+            cost_tier = "cheap"
+        session_profiles.append({
+            "session_id": sid, "model": s_model, "top_tool": top_tool,
+            "tool_counts": dict(tool_counts), "total_tools": total_tools,
+            "error_count": error_count, "tokens": s_tokens, "cost_usd": cost,
+            "cost_tier": cost_tier, "has_cron": has_cron,
+            "has_subagent": has_subagent, "turn_count": turn_count,
+        })
+    if not session_profiles:
+        return None
+    payload = _build_cluster_payload(session_profiles, days=days, now_ts=now_ts)
+    payload["_source"] = "local_store"
+    return payload
+
+
 @bp_usage.route("/api/sessions/clusters")
 def api_sessions_clusters():
     """Cluster sessions by behavior pattern (tool usage, cost profile, error type, model).
@@ -1052,6 +1242,14 @@ def api_sessions_clusters():
 
     _CLUSTER_ANALYTICS_TTL = 120  # seconds
     now_ts = time.time()
+    try:
+        days_arg = int(request.args.get("days", 30))
+    except (ValueError, TypeError):
+        days_arg = 30
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_sessions_clusters(days_arg)
+        if fast is not None:
+            return jsonify(fast)
 
     # Optional time window filter (days)
     try:

--- a/tests/test_duckdb_coverage_phase2_2026_05_13.py
+++ b/tests/test_duckdb_coverage_phase2_2026_05_13.py
@@ -1,0 +1,281 @@
+"""Tests for the DuckDB coverage Phase-2 batch landed 2026-05-13.
+
+Each test verifies the new ``_try_local_store_*`` fast path returns
+``_source: "local_store"`` when DuckDB has the relevant rows. We only
+assert the tag + a couple of structural keys — the legacy paths are
+covered by their own existing tests.
+
+Surfaces under test (7 of the 8 from issue #1088):
+  - /api/transcript-events/<id>            routes/sessions.py
+  - /api/sessions/<id>/export              routes/sessions.py
+  - /api/cron-run-log                      routes/crons.py
+  - /api/agents/<name>/sessions            routes/agents.py
+  - /api/timeline                          routes/overview.py
+  - /api/sessions/clusters                 routes/usage.py
+  - /api/clusters                          routes/meta.py
+
+/api/version-impact is intentionally excluded — its before/after stats
+sit on a separate SQLite ``version_events`` table that DuckDB does not
+mirror (Bypass-Medium per issue #1088 follow-up).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+def _wait_flush(store, t: float = 2.0) -> None:
+    """Wait for the ring buffer to drain so SELECTs see the rows."""
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Reload local_store against a fresh DuckDB file with the read flag on."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    yield ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _client(blueprint_module_name: str, blueprint_attr: str):
+    """Reload `routes/<module>` so its late-bound store handle picks up the
+    freshly-reloaded local_store, then return a Flask test client."""
+    import importlib as _il
+    mod = _il.import_module(blueprint_module_name)
+    _il.reload(mod)
+    a = Flask(__name__)
+    a.register_blueprint(getattr(mod, blueprint_attr))
+    return a.test_client()
+
+
+# ── /api/transcript-events/<id> ────────────────────────────────────────────
+
+
+def test_transcript_events_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    store.ingest({
+        "id": "ev-te-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-te", "event_type": "message",
+        "ts": "2026-05-12T12:00:00Z",
+        "data": {
+            "type": "message",
+            "timestamp": "2026-05-12T12:00:00Z",
+            "message": {"role": "user", "content": [{"type": "text", "text": "hi there"}]},
+        },
+    })
+    _wait_flush(store)
+    c = _client("routes.sessions", "bp_sessions")
+    r = c.get("/api/transcript-events/sess-te")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["messageCount"] == 1
+    assert any(e.get("type") == "user" and "hi there" in e.get("text", "")
+               for e in body["events"])
+
+
+# ── /api/sessions/<id>/export ──────────────────────────────────────────────
+
+
+def test_session_export_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    store.ingest({
+        "id": "ev-ex-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-ex", "event_type": "message",
+        "ts": "2026-05-12T12:00:00Z",
+        "data": {
+            "type": "message",
+            "timestamp": "2026-05-12T12:00:00Z",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "content": [{"type": "text", "text": "answer"}],
+                "usage": {
+                    "input": 10, "output": 20,
+                    "cost": {"total": 0.001},
+                },
+            },
+        },
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+    c = _client("routes.sessions", "bp_sessions")
+    r = c.get("/api/sessions/sess-ex/export?format=json")
+    assert r.status_code == 200
+    body = json.loads(r.data)
+    assert body.get("_source") == "local_store"
+    assert body["session_id"] == "sess-ex"
+    assert body["metadata"]["message_count"] == 1
+    assert body["cost_data"]["input_tokens"] == 10
+    assert body["cost_data"]["total_cost_usd"] == pytest.approx(0.001)
+
+
+# ── /api/cron-run-log ──────────────────────────────────────────────────────
+
+
+def test_cron_run_log_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    for i in range(2):
+        store.ingest({
+            "id": f"ev-cr-{i}", "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-cron", "event_type": "message",
+            "ts": f"2026-05-12T12:0{i}:00Z",
+            "data": {
+                "type": "message",
+                "timestamp": f"2026-05-12T12:0{i}:00Z",
+                "message": {"role": "user", "content": "step"},
+            },
+        })
+    _wait_flush(store)
+    c = _client("routes.crons", "bp_crons")
+    r = c.get("/api/cron-run-log?session_id=sess-cron")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["sessionId"] == "sess-cron"
+    assert len(body["events"]) == 2
+
+
+# ── /api/agents/<name>/sessions ────────────────────────────────────────────
+
+
+def test_agent_sessions_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    store.ingest_session({
+        "agent_type": "openclaw",
+        "session_id": "sess-ag-1",
+        "agent_id": "main",
+        "title": "demo run",
+        "started_at": "2026-05-12T11:00:00Z",
+        "last_active_at": "2026-05-12T12:00:00Z",
+        "status": "active",
+        "total_tokens": 1234,
+        "cost_usd": 0.42,
+        "message_count": 7,
+        "metadata": {"model": "claude-opus-4-7", "source": "test"},
+    })
+    _wait_flush(store)
+    c = _client("routes.agents", "bp_agents")
+    r = c.get("/api/agents/openclaw/sessions?limit=10")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert len(body["sessions"]) == 1
+    s = body["sessions"][0]
+    assert s["id"] == "sess-ag-1"
+    assert s["agent"] == "openclaw"
+    assert s["totalTokens"] == 1234
+    assert s["model"] == "claude-opus-4-7"
+
+
+# ── /api/timeline ──────────────────────────────────────────────────────────
+
+
+def test_timeline_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    today = datetime.now()
+    iso = today.replace(hour=15, minute=0, second=0, microsecond=0).isoformat()
+    for i in range(3):
+        store.ingest({
+            "id": f"ev-tl-{i}", "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-tl", "event_type": "message",
+            "ts": iso,
+        })
+    _wait_flush(store)
+    c = _client("routes.overview", "bp_overview")
+    r = c.get("/api/timeline")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert any(d.get("date") == today.strftime("%Y-%m-%d") and d.get("events", 0) >= 3
+               for d in body["days"])
+
+
+# ── /api/sessions/clusters ─────────────────────────────────────────────────
+
+
+def test_sessions_clusters_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    today_iso = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    # One assistant turn with usage so the session has cost > 0 and one tool
+    # call to drive the cluster_key.
+    store.ingest({
+        "id": "ev-cl-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-cl", "event_type": "message",
+        "ts": today_iso,
+        "model": "claude-opus-4-7",
+        "cost_usd": 0.05, "token_count": 1500,
+        "data": {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "content": [
+                    {"type": "text", "text": "running"},
+                    {"type": "toolCall", "name": "exec", "arguments": {"command": "ls"}},
+                ],
+                "usage": {"input": 1000, "output": 500, "cost": {"total": 0.05}},
+            },
+        },
+    })
+    _wait_flush(store)
+    c = _client("routes.usage", "bp_usage")
+    r = c.get("/api/sessions/clusters?days=30")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["total_sessions"] == 1
+    assert len(body["clusters"]) == 1
+    cl = body["clusters"][0]
+    assert cl["session_count"] == 1
+    assert "sess-cl" in cl["session_ids"]
+
+
+# ── /api/clusters ──────────────────────────────────────────────────────────
+
+
+def test_clusters_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    today_iso = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    store.ingest({
+        "id": "ev-cl2-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-cl2", "event_type": "message",
+        "ts": today_iso,
+        "model": "claude-opus-4-7",
+        "cost_usd": 0.05, "token_count": 1500,
+        "data": {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "content": [{"type": "toolCall", "name": "exec", "arguments": {}}],
+                "usage": {"input": 1000, "output": 500, "cost": {"total": 0.05}},
+            },
+        },
+    })
+    _wait_flush(store)
+    c = _client("routes.meta", "bp_clusters")
+    r = c.get("/api/clusters")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["total_clusters"] >= 1


### PR DESCRIPTION
## Summary

Continues the DuckDB MOAT coverage sprint from #1087 + #1091. Migrates **7 of the 8** Bypass-Easy surfaces listed in #1088 to the daemon-HTTP proxy pattern (`local_store_via_daemon` via `routes/local_query.py`).

Each handler now does a `CLAWMETRY_LOCAL_STORE_READ=1` early-return through DuckDB; legacy JSONL/gateway paths stay intact as the fallback so a fresh install or non-OpenClaw user sees identical behaviour.

### Surfaces moved out of the Easy bucket

| Endpoint | File | New helper |
|---|---|---|
| `/api/transcript-events/<id>` | `routes/sessions.py` | `_try_local_store_transcript_events` |
| `/api/sessions/<id>/export` (JSON) | `routes/sessions.py` | `_try_local_store_session_export` |
| `/api/cron-run-log` | `routes/crons.py` | `_try_local_store_cron_run_log` |
| `/api/agents/<name>/sessions` | `routes/agents.py` | `_try_local_store_agent_sessions` |
| `/api/timeline` | `routes/overview.py` | `_try_local_store_timeline` (migrated to `_ls_call`) |
| `/api/sessions/clusters` | `routes/usage.py` | `_try_local_store_sessions_clusters` + `_build_cluster_payload` |
| `/api/clusters` | `routes/meta.py` | delegates to `routes.usage._try_local_store_sessions_clusters` |

CSV branch of `/api/sessions/<id>/export` deliberately falls through to the legacy formatter — the JSON shape is what tooling/clients consume.

### Skipped — promoted to Bypass-Medium

- `/api/version-impact` (`routes/meta.py:420`) — depends on a separate SQLite `version_events` table tracking version transitions. There is no DuckDB equivalent today; the before/after `_compute_session_stats_in_range` calls also need a per-time-range aggregate that `query_aggregates` can't fully express against the JSONL parser's `error/tool_call` counts. Needs schema work — moves to Bypass-Medium.

### LocalStore changes

- `query_sessions_table()` now accepts an optional `agent_type` filter (backwards compatible — default behaviour unchanged). Used by `/api/agents/<name>/sessions` to scope to a single adapter.

No new method names added to the `_DAEMON_METHODS` allowlist — all calls hit existing entries (`query_events`, `query_sessions`, `query_aggregates`, `query_sessions_table`).

## Test plan

- [x] `tests/test_duckdb_coverage_phase2_2026_05_13.py` — 7 new tests, one per surface, all pass
- [x] `make lint` clean (py_compile + dashboard import smoke)
- [x] Existing DuckDB-coverage suite (`test_duckdb_coverage_batch_2026_05_13.py`, `test_local_store.py`, `test_sessions_local_fastpath.py`, `test_brain_local_fastpath.py`, `test_overview_local_store.py`, `test_local_query_api.py`, `test_crons_local_store.py`, `test_circular_import.py`, `test_local_store_missing_writers.py`, `test_local_store_rename.py`) — 100/100 pass
- [x] Wider unit-test sweep — only pre-existing `test_track.py` + `test_session_export.py::test_export_csv_status` failures (unrelated; reproduced on `main`)
- [ ] CI green, then E2E spot check of `/api/timeline` + `/api/agents/openclaw/sessions` against a real OpenClaw workspace

## Coverage tracker

| Phase | Coverage | Source |
|---|---|---|
| Pre-#1087 | 16% | `DUCKDB_COVERAGE_AUDIT_2026-05-13.md` |
| After #1087 | 37% | issue #1088 |
| After #1091 | 41% | issue #1088 |
| **After this PR** | **~49% (51/104)** | 7 new surfaces |

Closes part of #1088. Remaining Bypass-Easy: just `/api/version-impact` (re-classified Medium). Next batch should pick from the Medium bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)