### PR TITLE
feat: 5 medium-tier DuckDB fast-paths (~50% → ~60% coverage)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -789,7 +789,15 @@ class LocalStore:
             ])
 
     def ingest_cron(self, cron: dict[str, Any]) -> None:
-        """Upsert one cron-job row. Required: cron_id."""
+        """Upsert one cron-job row. Required: cron_id.
+
+        Dict-shaped ``schedule`` values (the gateway shape:
+        ``{kind:'every', everyMs:60000}``) are JSON-encoded before storing
+        so ``_row_to_cron_job`` in ``routes/crons.py`` can decode them
+        back. Without this, DuckDB's default ``str(dict)`` representation
+        is not valid JSON and downstream consumers (e.g.
+        ``/api/agent-intentions`` schedule-kind projection) lose the
+        ``kind``/``everyMs`` fields needed to compute firings."""
         cid = cron.get("cron_id")
         if not cid:
             raise ValueError("cron must include 'cron_id'")
@@ -799,6 +807,9 @@ class LocalStore:
                                            "name", "schedule", "enabled",
                                            "last_run_at", "last_status",
                                            "next_run_at"}})
+        schedule = cron.get("schedule")
+        if isinstance(schedule, (dict, list)):
+            schedule = json.dumps(schedule, separators=(",", ":"))
         now_ms = int(time.time() * 1000)
         with self._write_lock:
             self._conn.execute("""
@@ -817,7 +828,7 @@ class LocalStore:
                     data         = COALESCE(excluded.data, crons.data),
                     updated_at   = excluded.updated_at
             """, [atype, cid, cron.get("agent_id") or "main",
-                  cron.get("name"), cron.get("schedule"),
+                  cron.get("name"), schedule,
                   bool(cron.get("enabled", True)),
                   cron.get("last_run_at"), cron.get("last_status"),
                   cron.get("next_run_at"), data_blob, now_ms])
@@ -1667,6 +1678,223 @@ class LocalStore:
                     meta = {}
             d["metadata"] = meta
             out.append(d)
+        return out
+
+    def query_compactions(
+        self,
+        *,
+        session_id: str | None = None,
+        limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Read OpenClaw compaction events (issue #1088 phase 3).
+
+        Compaction events live in the ``events`` table with
+        ``event_type='compaction'``. Their ``data`` blob carries the
+        original transcript shape: ``{type:"compaction", summary:"...",
+        tokensBefore:N, firstKeptEntryId:"...", fromHook:bool,
+        timestamp:"..."}``. This helper projects them into the row shape
+        ``/api/compactions`` returns so the route doesn't need to re-decode.
+
+        ``session_id`` filters to one session (returns full summary text).
+        Defaults to most-recent first."""
+        clauses: list[str] = ["event_type = 'compaction'"]
+        params: list[Any] = []
+        if session_id:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        where = "WHERE " + " AND ".join(clauses)
+        sql = f"""
+            SELECT session_id, ts, data
+            FROM events
+            {where}
+            ORDER BY ts DESC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        out: list[dict[str, Any]] = []
+        for r in self._fetch(sql, params):
+            sid, ts, raw = r
+            data: dict[str, Any] = {}
+            if raw is not None:
+                try:
+                    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                    parsed = json.loads(text) if text else {}
+                    if isinstance(parsed, dict):
+                        data = parsed
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    data = {}
+            out.append({
+                "session_id":          sid,
+                "timestamp":           data.get("timestamp") or ts or "",
+                "summary":             data.get("summary") or "",
+                "tokens_before":       int(data.get("tokensBefore") or data.get("tokens_before") or 0),
+                "first_kept_entry_id": data.get("firstKeptEntryId") or data.get("first_kept_entry_id") or "",
+                "from_hook":           bool(data.get("fromHook") or data.get("from_hook") or False),
+            })
+        return out
+
+    def query_cost_split(
+        self,
+        *,
+        session_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Per-session input/output/cache token + cost split (issue #1088 phase 3).
+
+        Aggregates ``message`` events by ``session_id`` extracting the
+        ``data.message.usage`` block — the same structure
+        ``/api/cost-split`` walks the JSONL for. Returns one row per
+        session ordered by total cost descending.
+
+        ``session_id`` filters to one session (limit ignored). Otherwise
+        returns the top ``limit`` sessions by total cost."""
+        clauses: list[str] = ["event_type = 'message'"]
+        params: list[Any] = []
+        if session_id:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        where = "WHERE " + " AND ".join(clauses)
+        sql = f"""
+            SELECT session_id, model, data
+            FROM events
+            {where}
+            ORDER BY ts ASC
+        """
+        # Aggregate in Python — DuckDB's JSON extraction would work but we
+        # want consistent decoding with query_events (which Python already
+        # does), and the row counts here are bounded by limit*~200 turns.
+        per_session: dict[str, dict[str, Any]] = {}
+        for sid, model, raw in self._fetch(sql, params):
+            if not sid:
+                continue
+            data: dict[str, Any] = {}
+            if raw is not None:
+                try:
+                    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                    parsed = json.loads(text) if text else {}
+                    if isinstance(parsed, dict):
+                        data = parsed
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    data = {}
+            msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+            usage = msg.get("usage") if isinstance(msg.get("usage"), dict) else {}
+            if not usage:
+                continue
+            agg = per_session.setdefault(sid, {
+                "session_id":          sid,
+                "primary_model":       "",
+                "input_tokens":        0,
+                "output_tokens":       0,
+                "cache_read_tokens":   0,
+                "cache_write_tokens":  0,
+                "input_cost_usd":      0.0,
+                "output_cost_usd":     0.0,
+                "cache_read_cost_usd": 0.0,
+                "cache_write_cost_usd": 0.0,
+                "total_cost_usd":      0.0,
+                "_model_tokens":       {},
+            })
+            agg["input_tokens"]       += int(usage.get("input", 0) or 0)
+            agg["output_tokens"]      += int(usage.get("output", 0) or 0)
+            agg["cache_read_tokens"]  += int(usage.get("cacheRead", 0) or 0)
+            agg["cache_write_tokens"] += int(usage.get("cacheWrite", 0) or 0)
+            cost_obj = usage.get("cost") if isinstance(usage.get("cost"), dict) else {}
+            agg["input_cost_usd"]      += float(cost_obj.get("input", 0) or 0)
+            agg["output_cost_usd"]     += float(cost_obj.get("output", 0) or 0)
+            agg["cache_read_cost_usd"] += float(cost_obj.get("cacheRead", 0) or 0)
+            agg["cache_write_cost_usd"] += float(cost_obj.get("cacheWrite", 0) or 0)
+            agg["total_cost_usd"]      += float(cost_obj.get("total", 0) or 0)
+            mt = int(usage.get("totalTokens", 0) or 0)
+            mm = msg.get("model") or model or ""
+            if mt and mm:
+                agg["_model_tokens"][mm] = agg["_model_tokens"].get(mm, 0) + mt
+        out: list[dict[str, Any]] = []
+        for agg in per_session.values():
+            mt = agg.pop("_model_tokens", {})
+            agg["primary_model"] = (
+                max(mt.items(), key=lambda kv: kv[1])[0] if mt else ""
+            )
+            agg["total_tokens"] = (
+                agg["input_tokens"] + agg["output_tokens"]
+                + agg["cache_read_tokens"] + agg["cache_write_tokens"]
+            )
+            input_plus_cache = agg["input_tokens"] + agg["cache_read_tokens"]
+            agg["cache_hit_ratio_pct"] = (
+                round(agg["cache_read_tokens"] / input_plus_cache * 100, 1)
+                if input_plus_cache else 0.0
+            )
+            # Round cost fields to 6 decimals for consistency with the legacy path.
+            for k in ("input_cost_usd", "output_cost_usd", "cache_read_cost_usd",
+                      "cache_write_cost_usd", "total_cost_usd"):
+                agg[k] = round(agg[k], 6)
+            out.append(agg)
+        out.sort(key=lambda r: r.get("total_cost_usd", 0), reverse=True)
+        if session_id:
+            return out
+        return out[:int(limit)]
+
+    def query_session_model_journey(
+        self,
+        *,
+        session_id: str,
+        limit: int = 5000,
+    ) -> list[dict[str, Any]]:
+        """Ordered model + message events for one session (issue #1088 phase 3).
+
+        Returns rows ordered by timestamp ASC, each carrying enough fields
+        to drive ``/api/session-model-journey`` segment computation:
+          * model_change rows: ``{kind:'model_change', model, provider, ts}``
+          * message rows:      ``{kind:'message', model, provider, total_tokens, total_cost, ts}``
+          * thinking rows:     ``{kind:'thinking_level_change', level, ts}``
+
+        Single-session helper — caller passes ``session_id``. Uses the
+        existing events table; no new schema required."""
+        if not session_id:
+            return []
+        sql = """
+            SELECT event_type, ts, data, model
+            FROM events
+            WHERE session_id = ?
+              AND event_type IN ('model_change', 'message', 'thinking_level_change')
+            ORDER BY ts ASC, id ASC
+            LIMIT ?
+        """
+        out: list[dict[str, Any]] = []
+        for et, ts, raw, ev_model in self._fetch(sql, [session_id, int(limit)]):
+            data: dict[str, Any] = {}
+            if raw is not None:
+                try:
+                    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                    parsed = json.loads(text) if text else {}
+                    if isinstance(parsed, dict):
+                        data = parsed
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    data = {}
+            if et == "model_change":
+                out.append({
+                    "kind":      "model_change",
+                    "model":     data.get("modelId") or data.get("model") or ev_model or "",
+                    "provider":  data.get("provider") or "",
+                    "ts":        ts,
+                })
+            elif et == "thinking_level_change":
+                out.append({
+                    "kind":  "thinking_level_change",
+                    "level": data.get("thinkingLevel") or data.get("level") or "",
+                    "ts":    ts,
+                })
+            else:  # message
+                msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+                usage = msg.get("usage") if isinstance(msg.get("usage"), dict) else {}
+                cost_obj = usage.get("cost") if isinstance(usage.get("cost"), dict) else {}
+                out.append({
+                    "kind":         "message",
+                    "model":        msg.get("model") or ev_model or "",
+                    "provider":     msg.get("provider") or "",
+                    "total_tokens": int(usage.get("totalTokens", 0) or 0),
+                    "total_cost":   float(cost_obj.get("total", 0) or 0),
+                    "ts":           ts,
+                })
         return out
 
     def query_aggregates(

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -876,6 +876,127 @@ def api_cron_kill_all():
     )
 
 
+def _project_intentions(jobs, days: int, include_disabled: bool, max_events: int):
+    """Walk the cron job list and produce the ``intentions`` + ``recently_added``
+    payload ``/api/agent-intentions`` returns. Pulled out of the route so the
+    fast-path can reuse the projection logic against ``query_crons`` rows
+    without duplicating the timeline math."""
+    now_ms = int(datetime.now().timestamp() * 1000)
+    window_end_ms = now_ms + days * 24 * 3600 * 1000
+    recent_threshold_ms = now_ms - 24 * 3600 * 1000
+
+    intentions: list = []
+    recently_added: list = []
+
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        enabled = bool(job.get("enabled", True))
+        if not enabled and not include_disabled:
+            continue
+        job_id = job.get("id", "")
+        job_name = job.get("name", job_id)
+        sched = job.get("schedule") or {}
+        state = job.get("state") or {}
+        created_at_ms = job.get("createdAtMs") or 0
+        if isinstance(created_at_ms, str):
+            try:
+                from dateutil import parser as _dtp
+                created_at_ms = int(_dtp.parse(created_at_ms).timestamp() * 1000)
+            except Exception:
+                created_at_ms = 0
+        is_recently_added = bool(created_at_ms and created_at_ms >= recent_threshold_ms)
+        if is_recently_added:
+            recently_added.append({
+                "jobId":       job_id,
+                "name":        job_name,
+                "createdAtMs": created_at_ms,
+                "schedule":    sched,
+                "enabled":     enabled,
+            })
+        last_status = state.get("lastStatus", "pending")
+        last_run_ms = state.get("lastRunAtMs") or 0
+        if isinstance(last_run_ms, str):
+            try:
+                from dateutil import parser as _dtp
+                last_run_ms = int(_dtp.parse(last_run_ms).timestamp() * 1000)
+            except Exception:
+                last_run_ms = 0
+        next_run_ms = state.get("nextRunAtMs") or 0
+        sched_kind = (sched.get("kind") or "").lower() if isinstance(sched, dict) else ""
+        every_ms = sched.get("everyMs") if isinstance(sched, dict) else None
+        try:
+            every_ms = int(every_ms) if every_ms else 0
+        except (TypeError, ValueError):
+            every_ms = 0
+        firings: list = []
+        if sched_kind in ("every", "interval") and every_ms > 0:
+            t = int(next_run_ms) if next_run_ms else now_ms + every_ms
+            if t < now_ms:
+                gap = now_ms - t
+                t += ((gap // every_ms) + 1) * every_ms
+            while t <= window_end_ms and len(firings) < 100:
+                firings.append(t)
+                t += every_ms
+        elif next_run_ms and now_ms <= next_run_ms <= window_end_ms:
+            firings.append(int(next_run_ms))
+        for ts in firings:
+            intentions.append({
+                "jobId":           job_id,
+                "name":            job_name,
+                "scheduledForMs":  ts,
+                "scheduleKind":    sched_kind or "unknown",
+                "lastStatus":      last_status,
+                "lastRunAtMs":     last_run_ms,
+                "isRecentlyAdded": is_recently_added,
+                "enabled":         enabled,
+            })
+            if len(intentions) >= max_events:
+                break
+        if len(intentions) >= max_events:
+            break
+    intentions.sort(key=lambda r: r.get("scheduledForMs", 0))
+    recently_added.sort(key=lambda r: -(r.get("createdAtMs") or 0))
+    return intentions, recently_added, now_ms, window_end_ms
+
+
+def _try_local_store_agent_intentions(days: int, include_disabled: bool, max_events: int):
+    """Fast path for /api/agent-intentions. Reads cron jobs from the local
+    DuckDB ``crons`` table (already populated by sync.py) and runs the
+    same projection ``/api/agent-intentions`` does against the gateway
+    response.
+
+    Issue #1088 phase 3. Returns ``None`` when the crons table is empty
+    so the route falls through to the gateway RPC."""
+    rows = _ls_call("query_crons", limit=500)
+    if not rows:
+        return None
+    jobs = []
+    for r in rows:
+        try:
+            jobs.append(_row_to_cron_job(r))
+        except Exception:
+            continue
+    intentions, recently_added, now_ms, window_end_ms = _project_intentions(
+        jobs, days, include_disabled, max_events
+    )
+    return {
+        "intentions":     intentions,
+        "recently_added": recently_added,
+        "window": {
+            "startMs": now_ms,
+            "endMs":   window_end_ms,
+            "days":    days,
+        },
+        "stats": {
+            "total_intentions":     len(intentions),
+            "recently_added_count": len(recently_added),
+            "truncated":            len(intentions) >= max_events,
+        },
+        "_source": "local_store",
+    }
+
+
 @bp_crons.route("/api/agent-intentions")
 def api_agent_intentions():
     """Cron jobs reframed as the agent's planned future actions.
@@ -910,100 +1031,19 @@ def api_agent_intentions():
     except ValueError:
         max_events = 200
 
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_agent_intentions(days, include_disabled, max_events)
+        if fast is not None:
+            return jsonify(fast)
+
     gw_data = _d._gw_invoke("cron", {"action": "list", "includeDisabled": True}) or {}
     jobs = gw_data.get("jobs", []) or _d._get_crons()
     if not isinstance(jobs, list):
         jobs = []
 
-    now_ms = int(datetime.now().timestamp() * 1000)
-    window_end_ms = now_ms + days * 24 * 3600 * 1000
-    recent_threshold_ms = now_ms - 24 * 3600 * 1000
-
-    intentions: list = []
-    recently_added: list = []
-
-    for job in jobs:
-        if not isinstance(job, dict):
-            continue
-        enabled = bool(job.get("enabled", True))
-        if not enabled and not include_disabled:
-            continue
-
-        job_id = job.get("id", "")
-        job_name = job.get("name", job_id)
-        sched = job.get("schedule") or {}
-        state = job.get("state") or {}
-
-        created_at_ms = job.get("createdAtMs") or 0
-        if isinstance(created_at_ms, str):
-            try:
-                from dateutil import parser as _dtp
-                created_at_ms = int(_dtp.parse(created_at_ms).timestamp() * 1000)
-            except Exception:
-                created_at_ms = 0
-        is_recently_added = bool(created_at_ms and created_at_ms >= recent_threshold_ms)
-        if is_recently_added:
-            recently_added.append({
-                "jobId": job_id,
-                "name": job_name,
-                "createdAtMs": created_at_ms,
-                "schedule": sched,
-                "enabled": enabled,
-            })
-
-        last_status = state.get("lastStatus", "pending")
-        last_run_ms = state.get("lastRunAtMs") or 0
-        if isinstance(last_run_ms, str):
-            try:
-                from dateutil import parser as _dtp
-                last_run_ms = int(_dtp.parse(last_run_ms).timestamp() * 1000)
-            except Exception:
-                last_run_ms = 0
-        next_run_ms = state.get("nextRunAtMs") or 0
-
-        sched_kind = (sched.get("kind") or "").lower() if isinstance(sched, dict) else ""
-        every_ms = sched.get("everyMs") if isinstance(sched, dict) else None
-        try:
-            every_ms = int(every_ms) if every_ms else 0
-        except (TypeError, ValueError):
-            every_ms = 0
-
-        firings: list = []
-        if sched_kind in ("every", "interval") and every_ms > 0:
-            # Walk forward by everyMs from the gateway's nextRunAtMs.
-            # If nextRunAtMs is unset, the gateway hasn't scheduled it yet —
-            # assume the first firing is one interval out.
-            t = int(next_run_ms) if next_run_ms else now_ms + every_ms
-            # If next_run is already in the past, advance to the first future tick
-            if t < now_ms:
-                gap = now_ms - t
-                t += ((gap // every_ms) + 1) * every_ms
-            while t <= window_end_ms and len(firings) < 100:
-                firings.append(t)
-                t += every_ms
-        elif next_run_ms and now_ms <= next_run_ms <= window_end_ms:
-            # Cron-expression / one-shot: only the immediate next firing
-            firings.append(int(next_run_ms))
-
-        for ts in firings:
-            intentions.append({
-                "jobId": job_id,
-                "name": job_name,
-                "scheduledForMs": ts,
-                "scheduleKind": sched_kind or "unknown",
-                "lastStatus": last_status,
-                "lastRunAtMs": last_run_ms,
-                "isRecentlyAdded": is_recently_added,
-                "enabled": enabled,
-            })
-            if len(intentions) >= max_events:
-                break
-        if len(intentions) >= max_events:
-            break
-
-    intentions.sort(key=lambda r: r.get("scheduledForMs", 0))
-    recently_added.sort(key=lambda r: -(r.get("createdAtMs") or 0))
-
+    intentions, recently_added, now_ms, window_end_ms = _project_intentions(
+        jobs, days, include_disabled, max_events
+    )
     return jsonify({
         "intentions": intentions,
         "recently_added": recently_added,

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -299,6 +299,11 @@ _DAEMON_METHODS = frozenset({
     "query_subagents",
     "query_memory_blobs",
     "query_system_snapshots",
+    # Phase 3 (issue #1088 follow-up, 2026-05-13): per-feature aggregation
+    # helpers powering the next batch of Bypass-Medium fast-paths.
+    "query_compactions",
+    "query_cost_split",
+    "query_session_model_journey",
     "health",
 })
 

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -460,6 +460,58 @@ def _try_local_store_sessions_by_type(type_filter: str = ""):
     return {"counts": counts, "sessions": filtered, "_source": "local_store"}
 
 
+def _try_local_store_compactions(wanted_sid: str, summary_chars: int, full_summary: bool):
+    """Fast path for /api/compactions. Reads compaction events from DuckDB
+    via :meth:`LocalStore.query_compactions` and projects them into the
+    same shape the JSONL scanner returns.
+
+    Issue #1088 phase 3. Returns ``None`` when the events table has no
+    ``compaction`` rows so the route falls through to the JSONL scan."""
+    rows = _ls_call(
+        "query_compactions",
+        session_id=wanted_sid or None,
+        limit=1000,
+    )
+    if not rows:
+        return None
+    compactions: list = []
+    total_tokens = 0
+    for r in rows:
+        ts = r.get("timestamp") or ""
+        ts_ms = 0
+        if isinstance(ts, str) and ts:
+            try:
+                ts_ms = int(
+                    datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp() * 1000
+                )
+            except Exception:
+                ts_ms = 0
+        summary = r.get("summary") or ""
+        tokens_before = int(r.get("tokens_before") or 0)
+        total_tokens += tokens_before
+        entry = {
+            "session_id":          r.get("session_id") or "",
+            "timestamp":           ts,
+            "ts_ms":               ts_ms,
+            "tokens_before":       tokens_before,
+            "first_kept_entry_id": r.get("first_kept_entry_id") or "",
+            "from_hook":           bool(r.get("from_hook")),
+        }
+        if full_summary or len(summary) <= summary_chars:
+            entry["summary"] = summary
+        else:
+            entry["summary"] = summary[:summary_chars]
+            entry["summary_truncated"] = True
+        compactions.append(entry)
+    compactions.sort(key=lambda c: c.get("ts_ms", 0), reverse=True)
+    return {
+        "compactions":            compactions,
+        "total_compactions":      len(compactions),
+        "total_tokens_compacted": total_tokens,
+        "_source":                "local_store",
+    }
+
+
 @bp_sessions.route("/api/compactions")
 def api_compactions():
     """Return OpenClaw session-compaction events.
@@ -481,6 +533,11 @@ def api_compactions():
     except ValueError:
         summary_chars = 500
     full_summary = bool(wanted_sid)
+
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_compactions(wanted_sid, summary_chars, full_summary)
+        if fast is not None:
+            return jsonify(fast)
 
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
@@ -567,6 +624,147 @@ def api_compactions():
     })
 
 
+def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
+                                   include_unpaired: bool):
+    """Fast path for /api/session-tools. Reads message events for one
+    session from DuckDB and pairs ``toolCall`` / ``toolResult`` blocks into
+    the same timeline shape the JSONL parser returns.
+
+    Issue #1088 phase 3. Returns ``None`` to defer to the JSONL parser
+    when the events table has no message rows for this session."""
+    rows = _ls_call("query_events", session_id=sid, limit=10000)
+    if not rows:
+        return None
+    rows = list(reversed(rows))  # query_events returns DESC
+
+    def _parse_ts(ts):
+        if not ts or not isinstance(ts, str):
+            return 0
+        try:
+            return int(datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp() * 1000)
+        except Exception:
+            return 0
+
+    def _truncate(val, limit):
+        if limit <= 0 or val is None:
+            return val
+        if isinstance(val, str):
+            return val if len(val) <= limit else val[:limit] + "…"
+        try:
+            s = json.dumps(val, separators=(",", ":"))
+        except Exception:
+            s = str(val)
+        return s if len(s) <= limit else s[:limit] + "…"
+
+    calls: dict = {}
+    result_by_id: dict = {}
+    turn_index = 0
+    saw_message = False
+    for ev in rows:
+        if ev.get("event_type") != "message":
+            continue
+        saw_message = True
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+        role = msg.get("role", "")
+        ev_ts_ms = _parse_ts(data.get("timestamp") or ev.get("ts"))
+        if role == "assistant":
+            turn_index += 1
+            content = msg.get("content") or []
+            if not isinstance(content, list):
+                continue
+            usage = msg.get("usage") if isinstance(msg.get("usage"), dict) else {}
+            cost_obj = usage.get("cost") if isinstance(usage.get("cost"), dict) else {}
+            msg_cost = float(cost_obj.get("total", 0) or 0)
+            msg_model = msg.get("model", "")
+            msg_provider = msg.get("provider", "")
+            for blk in content:
+                if not isinstance(blk, dict) or blk.get("type") != "toolCall":
+                    continue
+                tcid = blk.get("id", "")
+                if not tcid:
+                    continue
+                calls[tcid] = {
+                    "tool_call_id":     tcid,
+                    "tool_name":        blk.get("name", ""),
+                    "arguments":        _truncate(blk.get("arguments"), args_chars),
+                    "start_ms":         ev_ts_ms,
+                    "turn_index":       turn_index,
+                    "model":            msg_model,
+                    "provider":         msg_provider,
+                    "message_cost_usd": msg_cost,
+                }
+        elif role == "toolResult":
+            tcid = msg.get("toolCallId", "")
+            if not tcid:
+                continue
+            details = msg.get("details")
+            result_by_id[tcid] = {
+                "end_ms":         ev_ts_ms,
+                "is_error":       bool(msg.get("isError", False)),
+                "result_size":    len(json.dumps(details)) if details is not None else 0,
+                "result_preview": _truncate(details, result_chars),
+            }
+    if not saw_message:
+        return None
+
+    tools: list = []
+    tool_counts: dict = {}
+    for tcid, call in calls.items():
+        res = result_by_id.get(tcid)
+        if not res and not include_unpaired:
+            continue
+        rec = dict(call)
+        if res:
+            rec["end_ms"] = res["end_ms"]
+            rec["duration_ms"] = max(0, res["end_ms"] - call["start_ms"]) if res["end_ms"] and call["start_ms"] else 0
+            rec["is_error"] = res["is_error"]
+            rec["result_size"] = res["result_size"]
+            rec["result_preview"] = res["result_preview"]
+            rec["paired"] = True
+        else:
+            rec["end_ms"] = 0
+            rec["duration_ms"] = 0
+            rec["is_error"] = False
+            rec["result_size"] = 0
+            rec["result_preview"] = None
+            rec["paired"] = False
+        tools.append(rec)
+        tn = rec["tool_name"] or "unknown"
+        agg = tool_counts.setdefault(tn, {"calls": 0, "errors": 0,
+                                          "total_duration_ms": 0,
+                                          "total_cost_usd": 0.0})
+        agg["calls"] += 1
+        if rec["is_error"]:
+            agg["errors"] += 1
+        agg["total_duration_ms"] += rec["duration_ms"]
+        agg["total_cost_usd"] += float(rec.get("message_cost_usd") or 0.0)
+
+    tools.sort(key=lambda r: r.get("start_ms", 0))
+    by_tool = [
+        {"tool_name": k, **v,
+         "error_rate_pct": round(v["errors"] / v["calls"] * 100, 1) if v["calls"] else 0}
+        for k, v in sorted(tool_counts.items(), key=lambda kv: -kv[1]["calls"])
+    ]
+    first_start = min((r["start_ms"] for r in tools if r.get("start_ms")), default=0)
+    last_end = max((r.get("end_ms", 0) for r in tools), default=0)
+    return {
+        "session_id": sid,
+        "tools": tools,
+        "by_tool": by_tool,
+        "stats": {
+            "total_calls":     len(tools),
+            "paired_calls":    sum(1 for r in tools if r.get("paired")),
+            "error_calls":     sum(1 for r in tools if r.get("is_error")),
+            "distinct_tools":  len(tool_counts),
+            "first_start_ms":  first_start,
+            "last_end_ms":     last_end,
+            "span_ms":         max(0, last_end - first_start) if first_start and last_end else 0,
+        },
+        "_source": "local_store",
+    }
+
+
 @bp_sessions.route("/api/session-tools")
 def api_session_tools():
     """Return the tool_call / tool_result timeline for a single session."""
@@ -585,6 +783,12 @@ def api_session_tools():
     include_unpaired = str(request.args.get("include_unpaired", "")).lower() in (
         "1", "true", "yes"
     )
+
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_session_tools(sid, args_chars, result_chars, include_unpaired)
+        if fast is not None:
+            return jsonify(fast)
+
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )
@@ -730,6 +934,46 @@ def api_session_tools():
     })
 
 
+def _try_local_store_cost_split(wanted_sid: str, limit: int):
+    """Fast path for /api/cost-split. Reads per-session token + cost
+    aggregates from DuckDB via :meth:`LocalStore.query_cost_split` and
+    rolls them into the same ``{sessions, totals}`` shape the JSONL
+    walker returns.
+
+    Issue #1088 phase 3. Returns ``None`` when the events table has no
+    message rows so the route falls through to the JSONL walker."""
+    rows = _ls_call(
+        "query_cost_split",
+        session_id=wanted_sid or None,
+        limit=limit,
+    )
+    if not rows:
+        return None
+    # Compute totals (mirrors the legacy path's aggregation).
+    totals = {
+        "input_tokens":         sum(r["input_tokens"] for r in rows),
+        "output_tokens":        sum(r["output_tokens"] for r in rows),
+        "cache_read_tokens":    sum(r["cache_read_tokens"] for r in rows),
+        "cache_write_tokens":   sum(r["cache_write_tokens"] for r in rows),
+        "total_tokens":         sum(r["total_tokens"] for r in rows),
+        "input_cost_usd":       round(sum(r["input_cost_usd"] for r in rows), 4),
+        "output_cost_usd":      round(sum(r["output_cost_usd"] for r in rows), 4),
+        "cache_read_cost_usd":  round(sum(r["cache_read_cost_usd"] for r in rows), 4),
+        "cache_write_cost_usd": round(sum(r["cache_write_cost_usd"] for r in rows), 4),
+        "total_cost_usd":       round(sum(r["total_cost_usd"] for r in rows), 4),
+        "session_count":        len(rows),
+    }
+    tot_in_cache = totals["input_tokens"] + totals["cache_read_tokens"]
+    totals["cache_hit_ratio_pct"] = (
+        round(totals["cache_read_tokens"] / tot_in_cache * 100, 1)
+        if tot_in_cache else 0.0
+    )
+    if wanted_sid:
+        # Single-session lookup returns the session list as-is, no totals.
+        return {"sessions": rows, "totals": {}, "_source": "local_store"}
+    return {"sessions": rows, "totals": totals, "_source": "local_store"}
+
+
 @bp_sessions.route("/api/cost-split")
 def api_cost_split():
     """Per-token-type token + cost breakdown per session.
@@ -744,6 +988,12 @@ def api_cost_split():
         limit = max(1, min(int(request.args.get("limit", "30")), 500))
     except ValueError:
         limit = 30
+
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_cost_split(wanted_sid, limit)
+        if fast is not None:
+            return jsonify(fast)
+
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )
@@ -2309,6 +2559,132 @@ def api_transcript_events(session_id):
     )
 
 
+def _try_local_store_session_model_journey(session_id: str):
+    """Fast path for /api/session-model-journey/<id>. Reads ordered
+    model_change / thinking_level_change / message rows from DuckDB via
+    :meth:`LocalStore.query_session_model_journey` and folds them into
+    the same ``segments`` shape the JSONL walker produces.
+
+    Issue #1088 phase 3. Returns ``None`` when the events table has no
+    matching rows so the route falls through to the JSONL walker."""
+    rows = _ls_call(
+        "query_session_model_journey",
+        session_id=session_id,
+        limit=5000,
+    )
+    if not rows:
+        return None
+
+    def _parse_ts(ts):
+        if not ts:
+            return 0
+        if isinstance(ts, (int, float)):
+            return int(ts * 1000) if ts < 1e12 else int(ts)
+        try:
+            return int(
+                datetime.fromisoformat(str(ts).replace("Z", "+00:00")).timestamp() * 1000
+            )
+        except Exception:
+            return 0
+
+    segments: list = []
+    thinking_changes: list = []
+    current_model = ""
+    current_provider = ""
+    seg_start_ms = 0
+    seg_tokens = 0
+    seg_cost = 0.0
+    first_ts = 0
+    last_ts = 0
+
+    for r in rows:
+        ts_ms = _parse_ts(r.get("ts"))
+        if ts_ms and not first_ts:
+            first_ts = ts_ms
+        if ts_ms:
+            last_ts = ts_ms
+        kind = r.get("kind")
+        if kind == "model_change":
+            new_model = r.get("model") or ""
+            new_provider = r.get("provider") or ""
+            if not new_model:
+                continue
+            if current_model:
+                segments.append({
+                    "modelId":     current_model,
+                    "provider":    current_provider,
+                    "start_ms":    seg_start_ms,
+                    "end_ms":      ts_ms or last_ts,
+                    "duration_ms": max(0, (ts_ms or last_ts) - seg_start_ms) if seg_start_ms else 0,
+                    "tokens":      seg_tokens,
+                    "cost_usd":    round(seg_cost, 6),
+                })
+            current_model = new_model
+            current_provider = new_provider
+            seg_start_ms = ts_ms
+            seg_tokens = 0
+            seg_cost = 0.0
+        elif kind == "thinking_level_change":
+            thinking_changes.append({
+                "thinkingLevel": r.get("level") or "",
+                "timestamp_ms":  ts_ms,
+            })
+        else:  # message
+            msg_model = r.get("model") or ""
+            if msg_model and not current_model:
+                current_model = msg_model
+                current_provider = r.get("provider") or ""
+                seg_start_ms = ts_ms or first_ts
+            elif msg_model and msg_model != current_model:
+                if current_model:
+                    segments.append({
+                        "modelId":     current_model,
+                        "provider":    current_provider,
+                        "start_ms":    seg_start_ms,
+                        "end_ms":      ts_ms or last_ts,
+                        "duration_ms": max(0, (ts_ms or last_ts) - seg_start_ms) if seg_start_ms else 0,
+                        "tokens":      seg_tokens,
+                        "cost_usd":    round(seg_cost, 6),
+                    })
+                current_model = msg_model
+                current_provider = r.get("provider") or ""
+                seg_start_ms = ts_ms
+                seg_tokens = 0
+                seg_cost = 0.0
+            seg_tokens += int(r.get("total_tokens") or 0)
+            seg_cost += float(r.get("total_cost") or 0)
+
+    if current_model:
+        segments.append({
+            "modelId":     current_model,
+            "provider":    current_provider,
+            "start_ms":    seg_start_ms,
+            "end_ms":      last_ts,
+            "duration_ms": max(0, last_ts - seg_start_ms) if seg_start_ms else 0,
+            "tokens":      seg_tokens,
+            "cost_usd":    round(seg_cost, 6),
+        })
+
+    total_tokens = sum(s["tokens"] for s in segments)
+    total_cost = sum(s["cost_usd"] for s in segments)
+    total_duration = max(0, last_ts - first_ts) if first_ts and last_ts else 0
+    return {
+        "session_id":       session_id,
+        "segments":         segments,
+        "thinking_changes": thinking_changes,
+        "stats": {
+            "total_models_used":  len({s["modelId"] for s in segments}),
+            "total_segments":     len(segments),
+            "total_tokens":       total_tokens,
+            "total_cost_usd":     round(total_cost, 6),
+            "total_duration_ms":  total_duration,
+            "first_ts":           first_ts,
+            "last_ts":            last_ts,
+        },
+        "_source": "local_store",
+    }
+
+
 @bp_sessions.route("/api/session-model-journey/<session_id>")
 def api_session_model_journey(session_id):
     """Return the ordered model journey for a session.
@@ -2320,6 +2696,10 @@ def api_session_model_journey(session_id):
     in the session detail modal.
     """
     import dashboard as _d
+    if os.environ.get("CLAWMETRY_LOCAL_STORE_READ") == "1":
+        fast = _try_local_store_session_model_journey(session_id)
+        if fast is not None:
+            return jsonify(fast)
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"
     )

--- a/tests/test_duckdb_coverage_phase3_2026_05_13.py
+++ b/tests/test_duckdb_coverage_phase3_2026_05_13.py
@@ -1,0 +1,271 @@
+"""Tests for the DuckDB coverage Phase-3 batch landed 2026-05-13.
+
+Each test verifies the new ``_try_local_store_*`` fast path returns
+``_source: "local_store"`` when DuckDB has the relevant rows. We only
+assert the tag + a couple of structural keys — the legacy paths are
+covered by their own existing tests.
+
+Surfaces under test (5 of the Bypass-Medium follow-up to issue #1088):
+  - /api/compactions                    routes/sessions.py
+  - /api/session-tools                  routes/sessions.py
+  - /api/cost-split                     routes/sessions.py
+  - /api/session-model-journey/<id>     routes/sessions.py
+  - /api/agent-intentions               routes/crons.py
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+def _wait_flush(store, t: float = 2.0) -> None:
+    """Wait for the ring buffer to drain so SELECTs see the rows."""
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Reload local_store against a fresh DuckDB file with the read flag on."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    yield ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _client(blueprint_module_name: str, blueprint_attr: str):
+    """Reload `routes/<module>` so its late-bound store handle picks up the
+    freshly-reloaded local_store, then return a Flask test client."""
+    import importlib as _il
+    mod = _il.import_module(blueprint_module_name)
+    _il.reload(mod)
+    a = Flask(__name__)
+    a.register_blueprint(getattr(mod, blueprint_attr))
+    return a.test_client()
+
+
+# ── /api/compactions ───────────────────────────────────────────────────────
+
+
+def test_compactions_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    store.ingest({
+        "id": "ev-cmp-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-cmp", "event_type": "compaction",
+        "ts": "2026-05-12T12:00:00Z",
+        "data": {
+            "type": "compaction",
+            "timestamp": "2026-05-12T12:00:00Z",
+            "summary": "Compacted earlier turns into a 2K summary.",
+            "tokensBefore": 9000,
+            "firstKeptEntryId": "ent-7",
+            "fromHook": False,
+        },
+    })
+    _wait_flush(store)
+    c = _client("routes.sessions", "bp_sessions")
+    r = c.get("/api/compactions")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["total_compactions"] == 1
+    assert body["total_tokens_compacted"] == 9000
+    only = body["compactions"][0]
+    assert only["session_id"] == "sess-cmp"
+    assert only["tokens_before"] == 9000
+    assert "Compacted earlier" in only["summary"]
+
+
+# ── /api/session-tools ─────────────────────────────────────────────────────
+
+
+def test_session_tools_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    # Assistant turn with one toolCall, then a paired toolResult.
+    store.ingest({
+        "id": "ev-st-call", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-st", "event_type": "message",
+        "ts": "2026-05-12T12:00:00Z",
+        "data": {
+            "type": "message",
+            "timestamp": "2026-05-12T12:00:00Z",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "content": [{
+                    "type": "toolCall",
+                    "id": "tc-1",
+                    "name": "Read",
+                    "arguments": {"path": "/tmp/x"},
+                }],
+                "usage": {"cost": {"total": 0.001}},
+            },
+        },
+    })
+    store.ingest({
+        "id": "ev-st-res", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-st", "event_type": "message",
+        "ts": "2026-05-12T12:00:01Z",
+        "data": {
+            "type": "message",
+            "timestamp": "2026-05-12T12:00:01Z",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "tc-1",
+                "details": {"contents": "hello world"},
+                "isError": False,
+            },
+        },
+    })
+    _wait_flush(store)
+    c = _client("routes.sessions", "bp_sessions")
+    r = c.get("/api/session-tools?session_id=sess-st")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["session_id"] == "sess-st"
+    assert body["stats"]["total_calls"] == 1
+    assert body["stats"]["paired_calls"] == 1
+    assert body["tools"][0]["tool_name"] == "Read"
+    assert body["tools"][0]["paired"] is True
+    assert any(bt["tool_name"] == "Read" for bt in body["by_tool"])
+
+
+# ── /api/cost-split ────────────────────────────────────────────────────────
+
+
+def test_cost_split_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    store.ingest({
+        "id": "ev-csp-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-csp", "event_type": "message",
+        "ts": "2026-05-12T12:00:00Z",
+        "model": "claude-opus-4-7",
+        "data": {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "content": [{"type": "text", "text": "ok"}],
+                "usage": {
+                    "input": 1000, "output": 500,
+                    "cacheRead": 2000, "cacheWrite": 100,
+                    "totalTokens": 3600,
+                    "cost": {"input": 0.01, "output": 0.02,
+                             "cacheRead": 0.001, "cacheWrite": 0.0005,
+                             "total": 0.0315},
+                },
+            },
+        },
+    })
+    _wait_flush(store)
+    c = _client("routes.sessions", "bp_sessions")
+    r = c.get("/api/cost-split")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert len(body["sessions"]) == 1
+    s = body["sessions"][0]
+    assert s["session_id"] == "sess-csp"
+    assert s["primary_model"] == "claude-opus-4-7"
+    assert s["input_tokens"] == 1000
+    assert s["cache_read_tokens"] == 2000
+    assert s["total_cost_usd"] == pytest.approx(0.0315, abs=1e-6)
+    assert body["totals"]["session_count"] == 1
+    assert body["totals"]["cache_read_tokens"] == 2000
+
+
+# ── /api/session-model-journey/<id> ────────────────────────────────────────
+
+
+def test_session_model_journey_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    store.ingest({
+        "id": "ev-mj-mc-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-mj", "event_type": "model_change",
+        "ts": "2026-05-12T12:00:00Z",
+        "data": {"modelId": "claude-sonnet-4-5", "provider": "anthropic"},
+    })
+    store.ingest({
+        "id": "ev-mj-msg-1", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-mj", "event_type": "message",
+        "ts": "2026-05-12T12:00:30Z",
+        "model": "claude-sonnet-4-5",
+        "data": {
+            "type": "message",
+            "message": {
+                "role": "assistant", "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "x"}],
+                "usage": {"totalTokens": 250, "cost": {"total": 0.005}},
+            },
+        },
+    })
+    store.ingest({
+        "id": "ev-mj-mc-2", "node_id": "agent+test", "agent_id": "main",
+        "session_id": "sess-mj", "event_type": "model_change",
+        "ts": "2026-05-12T12:01:00Z",
+        "data": {"modelId": "claude-opus-4-7", "provider": "anthropic"},
+    })
+    _wait_flush(store)
+    c = _client("routes.sessions", "bp_sessions")
+    r = c.get("/api/session-model-journey/sess-mj")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["session_id"] == "sess-mj"
+    assert body["stats"]["total_segments"] >= 1
+    assert body["stats"]["total_models_used"] >= 1
+    # First segment is the sonnet stretch with the assistant message tokens.
+    seg0 = body["segments"][0]
+    assert seg0["modelId"] == "claude-sonnet-4-5"
+    assert seg0["tokens"] == 250
+    assert seg0["cost_usd"] == pytest.approx(0.005, abs=1e-6)
+
+
+# ── /api/agent-intentions ──────────────────────────────────────────────────
+
+
+def test_agent_intentions_fast_path(fresh_store):
+    store = fresh_store.get_store()
+    # Schedule firing 1 hour from now so it falls inside the 7-day window.
+    next_run_ms = int(time.time() * 1000) + 3600 * 1000
+    next_run_iso = datetime.fromtimestamp(next_run_ms / 1000, tz=timezone.utc).isoformat()
+    store.ingest_cron({
+        "cron_id":     "cron-ai-1",
+        "agent_type":  "openclaw",
+        "name":        "Hourly heartbeat",
+        "schedule":    {"kind": "every", "everyMs": 3600 * 1000},
+        "enabled":     True,
+        "last_run_at": "2026-05-12T11:00:00Z",
+        "last_status": "ok",
+        "next_run_at": next_run_iso,
+    })
+    _wait_flush(store)
+    c = _client("routes.crons", "bp_crons")
+    r = c.get("/api/agent-intentions?days=7")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body["window"]["days"] == 7
+    # At least the immediate next firing should appear in the timeline.
+    assert body["stats"]["total_intentions"] >= 1
+    first = body["intentions"][0]
+    assert first["jobId"] == "cron-ai-1"
+    assert first["name"] == "Hourly heartbeat"
+    assert first["scheduleKind"] in ("every", "interval")

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -410,3 +410,176 @@ def test_get_store_ro_first_isolated(tmp_path, monkeypatch):
     assert reader._read_only is True
     rows = reader.query_events(limit=5)
     assert len(rows) == 1
+
+
+# ── phase-3 query helpers (issue #1088 follow-up, 2026-05-13) ─────────────
+
+
+def test_query_compactions_round_trip(store):
+    """compaction events round-trip back as projected rows with summary,
+    tokens_before, first_kept_entry_id, and from_hook fields."""
+    store.ingest(_ev(
+        id="cmp-1",
+        session_id="sess-cmp",
+        event_type="compaction",
+        ts="2026-05-12T10:00:00Z",
+        data={
+            "type": "compaction",
+            "timestamp": "2026-05-12T10:00:00Z",
+            "summary": "Compacted 12 messages → 2K-token summary",
+            "tokensBefore": 8500,
+            "firstKeptEntryId": "ent-42",
+            "fromHook": True,
+        },
+    ))
+    store.ingest(_ev(
+        id="cmp-2",
+        session_id="sess-other",
+        event_type="compaction",
+        ts="2026-05-12T11:00:00Z",
+        data={"type": "compaction", "summary": "later one",
+              "tokensBefore": 100, "firstKeptEntryId": "", "fromHook": False},
+    ))
+    _wait_for_flush(store)
+
+    rows = store.query_compactions()
+    assert len(rows) == 2
+    # Most-recent first.
+    assert rows[0]["session_id"] == "sess-other"
+    assert rows[1]["session_id"] == "sess-cmp"
+    assert rows[1]["summary"].startswith("Compacted")
+    assert rows[1]["tokens_before"] == 8500
+    assert rows[1]["first_kept_entry_id"] == "ent-42"
+    assert rows[1]["from_hook"] is True
+
+    # session_id filter narrows.
+    only_one = store.query_compactions(session_id="sess-cmp")
+    assert [r["session_id"] for r in only_one] == ["sess-cmp"]
+
+
+def test_query_cost_split_aggregates_per_session(store):
+    """Two assistant turns in the same session aggregate into one cost-split
+    row with summed tokens + costs and a primary_model derived from the
+    most-used model."""
+    for i in range(2):
+        store.ingest(_ev(
+            id=f"cs-{i}",
+            session_id="sess-cs",
+            event_type="message",
+            ts=f"2026-05-12T10:0{i}:00Z",
+            model="claude-opus-4-7",
+            data={
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "model": "claude-opus-4-7",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "usage": {
+                        "input": 1000, "output": 500,
+                        "cacheRead": 2000, "cacheWrite": 100,
+                        "totalTokens": 3600,
+                        "cost": {"input": 0.01, "output": 0.02,
+                                 "cacheRead": 0.001, "cacheWrite": 0.0005,
+                                 "total": 0.0315},
+                    },
+                },
+            },
+        ))
+    # A different session that should appear as a second row.
+    store.ingest(_ev(
+        id="cs-other",
+        session_id="sess-cs-other",
+        event_type="message",
+        ts="2026-05-12T10:05:00Z",
+        model="claude-haiku-4",
+        data={
+            "type": "message",
+            "message": {
+                "role": "assistant", "model": "claude-haiku-4",
+                "content": [{"type": "text", "text": "x"}],
+                "usage": {"input": 100, "output": 50, "totalTokens": 150,
+                          "cost": {"total": 0.001, "input": 0.0007, "output": 0.0003}},
+            },
+        },
+    ))
+    _wait_for_flush(store)
+
+    rows = store.query_cost_split()
+    assert len(rows) == 2
+    by_sid = {r["session_id"]: r for r in rows}
+    aggregated = by_sid["sess-cs"]
+    assert aggregated["primary_model"] == "claude-opus-4-7"
+    assert aggregated["input_tokens"] == 2000
+    assert aggregated["output_tokens"] == 1000
+    assert aggregated["cache_read_tokens"] == 4000
+    assert aggregated["cache_write_tokens"] == 200
+    assert aggregated["total_tokens"] == 7200
+    assert aggregated["total_cost_usd"] == pytest.approx(0.063, abs=1e-6)
+    # Cache hit ratio = cache_read / (input + cache_read) = 4000 / 6000 = 66.7%
+    assert aggregated["cache_hit_ratio_pct"] == pytest.approx(66.7, abs=0.1)
+    # Single-session lookup ignores aggregations from other sessions.
+    only = store.query_cost_split(session_id="sess-cs")
+    assert len(only) == 1
+    assert only[0]["session_id"] == "sess-cs"
+
+
+def test_query_session_model_journey_orders_segments(store):
+    """model_change + assistant message events emerge in timestamp order with
+    kind tags so the route can fold them into segments."""
+    store.ingest(_ev(
+        id="mj-mc-1",
+        session_id="sess-mj",
+        event_type="model_change",
+        ts="2026-05-12T10:00:00Z",
+        data={"modelId": "claude-sonnet-4-5", "provider": "anthropic"},
+    ))
+    store.ingest(_ev(
+        id="mj-msg-1",
+        session_id="sess-mj",
+        event_type="message",
+        ts="2026-05-12T10:01:00Z",
+        model="claude-sonnet-4-5",
+        data={
+            "type": "message",
+            "message": {
+                "role": "assistant", "model": "claude-sonnet-4-5",
+                "content": [{"type": "text", "text": "hi"}],
+                "usage": {"totalTokens": 200, "cost": {"total": 0.003}},
+            },
+        },
+    ))
+    store.ingest(_ev(
+        id="mj-think-1",
+        session_id="sess-mj",
+        event_type="thinking_level_change",
+        ts="2026-05-12T10:02:00Z",
+        data={"thinkingLevel": "high"},
+    ))
+    store.ingest(_ev(
+        id="mj-mc-2",
+        session_id="sess-mj",
+        event_type="model_change",
+        ts="2026-05-12T10:03:00Z",
+        data={"modelId": "claude-opus-4-7", "provider": "anthropic"},
+    ))
+    # Different session — should not appear in the result.
+    store.ingest(_ev(
+        id="mj-other",
+        session_id="sess-other",
+        event_type="model_change",
+        ts="2026-05-12T10:04:00Z",
+        data={"modelId": "x", "provider": "y"},
+    ))
+    _wait_for_flush(store)
+
+    rows = store.query_session_model_journey(session_id="sess-mj")
+    assert [r["kind"] for r in rows] == [
+        "model_change", "message", "thinking_level_change", "model_change"
+    ]
+    assert rows[0]["model"] == "claude-sonnet-4-5"
+    assert rows[1]["total_tokens"] == 200
+    assert rows[1]["total_cost"] == pytest.approx(0.003, abs=1e-6)
+    assert rows[2]["level"] == "high"
+    assert rows[3]["model"] == "claude-opus-4-7"
+    # Empty session_id returns nothing rather than scanning the table.
+    assert store.query_session_model_journey(session_id="") == []


### PR DESCRIPTION
Phase-3 follow-up to issue #1088 (Bypass-Medium tier). Five high-traffic
surfaces flip from gateway/JSONL reads to local DuckDB via the daemon
HTTP proxy (cross-process safe per #1091), with legacy fall-through on miss.

## Surfaces moved Bypass-Medium → DuckDB-Full

| Endpoint | File:Line | New helper | Backed by |
|---|---|---|---|
| `/api/compactions` | routes/sessions.py:486 | `_try_local_store_compactions` | `query_compactions` |
| `/api/session-tools` | routes/sessions.py:633 | `_try_local_store_session_tools` | `query_events` |
| `/api/cost-split` | routes/sessions.py:835 | `_try_local_store_cost_split` | `query_cost_split` |
| `/api/session-model-journey/<id>` | routes/sessions.py:2604 | `_try_local_store_session_model_journey` | `query_session_model_journey` |
| `/api/agent-intentions` | routes/crons.py:1006 | `_try_local_store_agent_intentions` | `query_crons` |

## New `LocalStore` methods (added to `_DAEMON_METHODS` allowlist)

- `query_compactions(session_id=None, limit=1000)` — projects
  compaction events into the row shape `/api/compactions` returns.
- `query_cost_split(session_id=None, limit=100)` — per-session
  input/output/cache token + cost aggregation across `message` events,
  with derived `cache_hit_ratio_pct` and `primary_model`.
- `query_session_model_journey(session_id, limit=5000)` — ordered
  `model_change` / `thinking_level_change` / `message` rows for one
  session so the route can fold them into model-segments.

## Side fix

`LocalStore.ingest_cron` now JSON-encodes dict-shaped `schedule` values.
Previously DuckDB stored `str(dict)` which `_row_to_cron_job` can't
decode — dropping `kind`/`everyMs` and breaking the `/api/agent-intentions`
schedule-kind projection.

## Architecture compliance

- Late `import dashboard as _d` in every route module (CLAUDE.md).
- Daemon HTTP proxy first via `local_store_via_daemon`, direct
  `get_store(read_only=True)` fallback only for single-process boots
  (tests + dev mode) — never raw `get_store()`.
- Fall-through to legacy on miss is non-negotiable; every fast-path
  returns `None` when the events table is empty for the session.
- Every fast-path returns `_source: "local_store"` so tests can assert
  which path served the response.

## Test plan

- [x] `tests/test_local_store.py` — 3 unit tests covering the new
  `query_compactions`, `query_cost_split`, `query_session_model_journey`
  round-trips.
- [x] `tests/test_duckdb_coverage_phase3_2026_05_13.py` — 5 API tests
  covering each fast-path against a fresh DuckDB.
- [x] Existing 91-test focused suite still passes
  (`test_local_store*`, `test_crons_local_store`, `test_duckdb_coverage_*`).
- [x] `python3 -m ruff check` on all new files: clean.

Refs #1088 (Bypass-Medium follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)