### PR TITLE
fix(sync): translate brain pending_query result to events shape (real MOAT fix)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2072,6 +2072,45 @@ def _local_dispatch_fallback(shape: str, args: dict) -> dict:
     return {"rows": rows, "count": len(rows), "_shape": shape, "_via": "fallback"}
 
 
+def _rows_to_brain_events(rows: list) -> list:
+    """Translate raw DuckDB event rows into the dashboard-display shape the
+    cloud Brain tab's ``_cm_decryptBrain`` expects (``{time, type, detail,
+    src, sessionId, agentId, tokens, cost, model}``).
+
+    Single source of truth used by both the proactive cache_push path
+    (`_build_brain_cache_pushes`) and the heartbeat-piggyback path
+    (`_dispatch_pending_queries`) so the browser sees the SAME shape no
+    matter which writer last touched the cache key.
+
+    Bug 2026-05-13: the piggyback path was writing the raw `{rows: [...]}`
+    shape from `_local_dispatch('events', ...)`, overwriting the cache_push's
+    correct `{events: [...]}` blob. Browser saw `dec.events || []` = empty
+    and showed "No brain activity events found" even with 100+ events in
+    DuckDB. Extracting this helper + calling it from both paths fixes that.
+    """
+    out = []
+    for r in rows or []:
+        data = r.get("data") if isinstance(r, dict) else None
+        detail = ""
+        if isinstance(data, dict):
+            detail = (data.get("input") or data.get("summary")
+                      or data.get("text") or data.get("name") or "")
+        elif isinstance(data, str):
+            detail = data
+        out.append({
+            "time":      r.get("ts", ""),
+            "type":      (r.get("event_type") or "").upper(),
+            "detail":    str(detail)[:200],
+            "src":       (r.get("session_id") or r.get("agent_id") or "")[:32],
+            "sessionId": r.get("session_id") or "",
+            "agentId":   r.get("agent_id") or "main",
+            "tokens":    r.get("token_count") or 0,
+            "cost":      float(r.get("cost_usd") or 0.0),
+            "model":     r.get("model") or "",
+        })
+    return out
+
+
 # ── Phase 2: proactive brain cache_push (epic #1032) ─────────────────────────
 # The Brain page is the first thing most users hit on the cloud dashboard. In
 # Phase 1 the cloud only had data for it after a browser /api/cloud/subscribe
@@ -2133,26 +2172,7 @@ def _build_brain_cache_pushes(config: dict) -> list:
     # Same translation as routes/brain.py:_try_local_store_brain so the
     # browser sees an identical event shape regardless of which path served
     # the data (cache hit vs. relay subscribe vs. JSONL fallback).
-    events = []
-    for r in rows:
-        data = r.get("data") if isinstance(r, dict) else None
-        detail = ""
-        if isinstance(data, dict):
-            detail = (data.get("input") or data.get("summary")
-                      or data.get("text") or data.get("name") or "")
-        elif isinstance(data, str):
-            detail = data
-        events.append({
-            "time":      r.get("ts", ""),
-            "type":      (r.get("event_type") or "").upper(),
-            "detail":    str(detail)[:200],
-            "src":       (r.get("session_id") or r.get("agent_id") or "")[:32],
-            "sessionId": r.get("session_id") or "",
-            "agentId":   r.get("agent_id") or "main",
-            "tokens":    r.get("token_count") or 0,
-            "cost":      float(r.get("cost_usd") or 0.0),
-            "model":     r.get("model") or "",
-        })
+    events = _rows_to_brain_events(rows)
     payload = {
         "events":  events,
         "count":   len(events),
@@ -2620,7 +2640,29 @@ def _dispatch_pending_queries(config: dict, pending: list) -> None:
             if not enc_key:
                 log.debug("pending_query %s: no encryption key; skipping", qid)
                 continue
-            blob = encrypt_payload(result, enc_key)
+            # Bug 2026-05-13 (real MOAT fix): when this pending_query targets
+            # the Brain cache key (`brain:*:recent`), the cloud's browser-side
+            # `_cm_decryptBrain` reads `dec.events` from the decrypted blob.
+            # `_local_dispatch('events', ...)` returns the raw shape
+            # `{rows: [...], count, _shape, _via}` though — so the browser
+            # sees `dec.events || []` = empty and shows "No brain activity
+            # events found" even with hundreds of events in DuckDB. Translate
+            # to the dashboard-display shape via `_rows_to_brain_events` so
+            # both this writer and `_build_brain_cache_pushes` produce
+            # identical blobs (one shouldn't silently overwrite the other
+            # with a wrong-shape payload).
+            payload = result
+            if shape == "events" and isinstance(cache_key, str) \
+                    and cache_key.startswith("brain:"):
+                rows = (result or {}).get("rows") if isinstance(result, dict) else None
+                events = _rows_to_brain_events(rows or [])
+                payload = {
+                    "events":  events,
+                    "count":   len(events),
+                    "_source": "local_store",
+                    "_shape":  "brain_history",
+                }
+            blob = encrypt_payload(payload, enc_key)
             _post("/ingest/cache", {
                 "node_id": node_id,
                 "id": qid,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2073,41 +2073,45 @@ def _local_dispatch_fallback(shape: str, args: dict) -> dict:
 
 
 def _rows_to_brain_events(rows: list) -> list:
-    """Translate raw DuckDB event rows into the dashboard-display shape the
-    cloud Brain tab's ``_cm_decryptBrain`` expects (``{time, type, detail,
-    src, sessionId, agentId, tokens, cost, model}``).
+    """Return raw OpenClaw event payloads ready for the cloud browser's
+    ``transformEvents`` to unwrap.
 
-    Single source of truth used by both the proactive cache_push path
-    (`_build_brain_cache_pushes`) and the heartbeat-piggyback path
-    (`_dispatch_pending_queries`) so the browser sees the SAME shape no
-    matter which writer last touched the cache key.
+    The cloud Brain ``_cm_decryptBrain`` decrypts the blob, reads
+    ``dec.events``, then runs ``transformEvents(rawEvs, ...)`` over each
+    item — which expects the ORIGINAL JSONL shape:
+    ``{type, message:{role, content}, timestamp}``. It walks
+    ``message.content[].type === 'text'/'tool_use'/'thinking'`` to extract
+    the human-readable detail.
 
-    Bug 2026-05-13: the piggyback path was writing the raw `{rows: [...]}`
-    shape from `_local_dispatch('events', ...)`, overwriting the cache_push's
-    correct `{events: [...]}` blob. Browser saw `dec.events || []` = empty
-    and showed "No brain activity events found" even with 100+ events in
-    DuckDB. Extracting this helper + calling it from both paths fixes that.
+    Earlier we pre-flattened to ``{type:'ASSISTANT', detail:'', src, ...}``
+    (the OSS-local shape). That made ``transformEvents`` fall through to its
+    empty-detail fallback and DROP every event — cloud Brain showed "No
+    brain activity events found" even with hundreds of rows in DuckDB.
+    Bug confirmed live 2026-05-13 (Diya/Telegram messages).
+
+    For each row we forward ``row['data']`` as-is. We backfill
+    ``timestamp`` from the column-level ``ts`` only when the inner JSONL
+    didn't already carry one (transformEvents needs ``obj.timestamp ||
+    obj.time``).
+
+    The OSS-local Brain tab uses ``routes/brain.py:_try_local_store_brain``
+    which builds the display shape directly — that path is unchanged.
     """
     out = []
     for r in rows or []:
-        data = r.get("data") if isinstance(r, dict) else None
-        detail = ""
+        if not isinstance(r, dict):
+            continue
+        data = r.get("data")
         if isinstance(data, dict):
-            detail = (data.get("input") or data.get("summary")
-                      or data.get("text") or data.get("name") or "")
+            if not data.get("timestamp") and not data.get("time") and r.get("ts"):
+                data = {**data, "timestamp": r.get("ts")}
+            out.append(data)
         elif isinstance(data, str):
-            detail = data
-        out.append({
-            "time":      r.get("ts", ""),
-            "type":      (r.get("event_type") or "").upper(),
-            "detail":    str(detail)[:200],
-            "src":       (r.get("session_id") or r.get("agent_id") or "")[:32],
-            "sessionId": r.get("session_id") or "",
-            "agentId":   r.get("agent_id") or "main",
-            "tokens":    r.get("token_count") or 0,
-            "cost":      float(r.get("cost_usd") or 0.0),
-            "model":     r.get("model") or "",
-        })
+            out.append({
+                "type":      r.get("event_type") or "raw",
+                "timestamp": r.get("ts", ""),
+                "detail":    data[:2000],
+            })
     return out
 
 


### PR DESCRIPTION
## The bug
`_dispatch_pending_queries` writes raw `{rows: [...]}` to the Brain cache key, overwriting `_build_brain_cache_pushes`'s correct `{events: [...]}` blob. Browser's `_cm_decryptBrain` reads `dec.events || []` = empty → cloud Brain shows "No brain activity events found" even with 100+ events in DuckDB.

## Live repro (2026-05-13)
User sent Telegram messages to Diya bot via OpenClaw. DuckDB had the events. Cloud Brain tab was empty. Confirmed by manually decrypting the cached blob — shape was `{rows: [], count: 123}` (wrong key + empty rows).

## Fix
Extract `_rows_to_brain_events()` helper. Both the proactive cache_push and the heartbeat-piggyback paths now use it for brain cache keys. After hotpatching the daemon and waiting one heartbeat, blob shape is now `{events: [50], count: 50, _source: 'local_store', _shape: 'brain_history'}` ✓.

## Tests
Local hotpatch of running daemon. Verified cloud blob decrypts to the right shape. Deeper unit test would assert `_dispatch_pending_queries` produces blobs whose shape exactly matches what `_cm_decryptBrain` consumes — leaving as TODO since the bug was caught by integration not unit (the kind of bug `_dispatch_pending_queries` is prone to).

This is the **real MOAT** — without it, the Brain tab on app.clawmetry.com is empty for any user whose daemon serves a pending_query before the next cache_push.