### PR TITLE
feat(sync): adaptive heartbeat cadence (3s active / 60s idle) — adaptive sync PR 2/3

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -123,6 +123,17 @@ LOG_FILE = CONFIG_DIR / "sync.log"
 
 POLL_INTERVAL = 15  # seconds between sync cycles
 STREAM_INTERVAL = 2  # seconds between real-time stream pushes
+
+# Adaptive heartbeat cadence (epic #775 — adaptive sync, PR 2/3).
+# When a viewer has the cloud dashboard open, the cloud sets `viewer_active:
+# true` on the heartbeat response and we tighten the loop so Telegram /
+# tool / brain events appear in the cloud Brain tab in ~3s instead of up to
+# 60s. When nobody is watching we drop back to the default 60s cadence to
+# keep idle bandwidth + Cloud Run cost flat. Back-compat: a cloud that
+# hasn't deployed PR 1 of the epic yet won't return the field, and the
+# missing-field branch falls through to SLOW.
+HEARTBEAT_INTERVAL_FAST = 3
+HEARTBEAT_INTERVAL_SLOW = 60
 BATCH_SIZE = (
     200  # events per encrypted POST (was 10; fewer HTTP requests = faster sync)
 )
@@ -1929,8 +1940,39 @@ def _collect_security_posture() -> dict | None:
         return None
 
 
+# Adaptive heartbeat: the most recent /ingest/heartbeat response body so the
+# main loop (and tests) can derive the next sleep interval without changing
+# `send_heartbeat`'s `bool` return type (callers in tests assert `is True`).
+# `None` when no successful heartbeat has been received yet OR after a 5xx.
+_LAST_HEARTBEAT_RESPONSE: dict | None = None
+
+
+def _pick_heartbeat_interval(resp_json: dict | None) -> int:
+    """Adaptive cadence (#775 PR 2/3): FAST when a viewer is watching the
+    cloud dashboard, SLOW otherwise. Pure function so it can be unit-tested
+    without booting the daemon loop.
+
+    Back-compat: a cloud that hasn't deployed PR 1 yet won't return the
+    `viewer_active` field, so missing → SLOW. Same for `None` (no successful
+    heartbeat yet) and any non-dict input.
+    """
+    if not isinstance(resp_json, dict):
+        return HEARTBEAT_INTERVAL_SLOW
+    return (
+        HEARTBEAT_INTERVAL_FAST
+        if resp_json.get("viewer_active", False)
+        else HEARTBEAT_INTERVAL_SLOW
+    )
+
+
 def send_heartbeat(config: dict) -> bool:
-    """Send heartbeat to cloud. Returns True on success, False on failure."""
+    """Send heartbeat to cloud. Returns True on success, False on failure.
+
+    Side effect: on success, stashes the parsed response body in
+    `_LAST_HEARTBEAT_RESPONSE` so the main loop can read `viewer_active`
+    via `_pick_heartbeat_interval()` and adapt the next sleep interval.
+    """
+    global _LAST_HEARTBEAT_RESPONSE
     payload = {
         "node_id": config["node_id"],
         "ts": datetime.now(timezone.utc).isoformat(),
@@ -2018,6 +2060,10 @@ def send_heartbeat(config: dict) -> bool:
             resp_json = _post("/ingest/heartbeat", payload, config["api_key"])
             if attempt > 0:
                 log.info(f"Heartbeat succeeded after {attempt + 1} attempts")
+            # Stash for adaptive-cadence pick (#775 PR 2/3). Normalise to dict
+            # so `_pick_heartbeat_interval` always sees a sensible shape even
+            # if `_post` ever decides to return None on a 204.
+            _LAST_HEARTBEAT_RESPONSE = resp_json if isinstance(resp_json, dict) else {}
             # Phase 1 of relay-v2 (#1053): the cloud may piggyback a small
             # batch of `pending_queries` on the heartbeat response. Each is
             # a shape-allowlisted read against the local DuckDB; we run them,
@@ -2032,6 +2078,9 @@ def send_heartbeat(config: dict) -> bool:
             last_err = e
             if attempt < 2:
                 time.sleep(2**attempt)  # 1s, 2s backoff
+    # Heartbeat failed: clear the stashed response so the next interval pick
+    # falls back to SLOW (don't burn tighter cadence on a stale viewer flag).
+    _LAST_HEARTBEAT_RESPONSE = None
     log.warning(f"Heartbeat failed after 3 attempts: {last_err}")
     return False
 
@@ -4725,7 +4774,9 @@ def run_daemon() -> None:
     except Exception as _e:
         log.warning(f"approvals watcher failed to start: {_e}")
 
-    heartbeat_interval = 60
+    # Default to SLOW; flips to FAST after a heartbeat response with
+    # `viewer_active: true` (epic #775 PR 2/3, adaptive sync cadence).
+    heartbeat_interval = HEARTBEAT_INTERVAL_SLOW
     snapshot_interval = 60  # system snapshot (subagents, flow metrics) every 60s
     log_sync_interval = 60  # log lines are low-priority; streamer covers real-time
     last_heartbeat = time.time()
@@ -4785,12 +4836,25 @@ def run_daemon() -> None:
                         )
                     consecutive_hb_failures = 0
                     last_heartbeat = now
+                    # Adaptive cadence (#775 PR 2/3): if the cloud signalled a
+                    # live viewer, drop to FAST so Telegram / brain events
+                    # appear in the dashboard within seconds. Otherwise stay
+                    # at SLOW. Missing field → SLOW (back-compat with a cloud
+                    # that hasn't deployed PR 1 of the epic yet).
+                    heartbeat_interval = _pick_heartbeat_interval(
+                        _LAST_HEARTBEAT_RESPONSE
+                    )
                 else:
                     consecutive_hb_failures += 1
                     if consecutive_hb_failures >= 5:
                         log.error(
                             f"CRITICAL: {consecutive_hb_failures} consecutive heartbeat failures — node appears offline in cloud"
                         )
+                    # On failure stay on SLOW so we don't hammer a flapping
+                    # cloud. The existing 1s/2s in-call backoff inside
+                    # `send_heartbeat` already covers retry, and the next
+                    # cycle inherits whatever interval we set here.
+                    heartbeat_interval = HEARTBEAT_INTERVAL_SLOW
 
         except Exception as e:
             log.error(f"Sync cycle error: {e}")

--- a/tests/test_adaptive_heartbeat.py
+++ b/tests/test_adaptive_heartbeat.py
@@ -1,0 +1,191 @@
+"""Tests for adaptive heartbeat cadence (epic #775 PR 2/3).
+
+The cloud sets `viewer_active: true` on the `/ingest/heartbeat` response when a
+viewer has the cloud dashboard open. The daemon flips its loop to FAST (3s) so
+new Telegram / tool / brain events appear in the cloud Brain tab in ~3s
+instead of waiting up to 60s. When nobody is watching we stay on SLOW (60s) to
+keep idle bandwidth + Cloud Run cost flat.
+
+Back-compat case: a cloud that hasn't deployed PR 1 of the epic yet won't set
+the field, so missing → SLOW. This file pins all four branches of
+`_pick_heartbeat_interval` plus the success / failure side-effects of
+`send_heartbeat` against the module-level `_LAST_HEARTBEAT_RESPONSE` cache the
+loop reads from.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def sync_mod(tmp_path, monkeypatch):
+    """Reload `clawmetry.sync` against an isolated DuckDB so module state
+    (esp. `_LAST_HEARTBEAT_RESPONSE`) is fresh per test."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    yield s
+
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def config(sync_mod):
+    return {
+        "node_id":         "node-test",
+        "api_key":         "cm_test",
+        "encryption_key":  sync_mod.generate_encryption_key(),
+    }
+
+
+# ── _pick_heartbeat_interval — pure function, all four branches ────────────────
+
+def test_pick_interval_viewer_active_true_returns_fast(sync_mod):
+    """viewer_active: true → FAST (3s)."""
+    assert sync_mod._pick_heartbeat_interval({"viewer_active": True}) == \
+        sync_mod.HEARTBEAT_INTERVAL_FAST
+    assert sync_mod.HEARTBEAT_INTERVAL_FAST == 3
+
+
+def test_pick_interval_viewer_active_false_returns_slow(sync_mod):
+    """viewer_active: false → SLOW (60s)."""
+    assert sync_mod._pick_heartbeat_interval({"viewer_active": False}) == \
+        sync_mod.HEARTBEAT_INTERVAL_SLOW
+    assert sync_mod.HEARTBEAT_INTERVAL_SLOW == 60
+
+
+def test_pick_interval_missing_field_returns_slow(sync_mod):
+    """Back-compat: cloud without PR 1 of #775 deployed won't set the field.
+    Missing → SLOW so we don't accidentally hammer the cloud at 3s before
+    the cloud-side viewer-presence tracker exists.
+    """
+    # Field absent entirely — the typical pre-PR-1 cloud response.
+    assert sync_mod._pick_heartbeat_interval({}) == sync_mod.HEARTBEAT_INTERVAL_SLOW
+    # Realistic shape: cloud only returns plan/sync_allowed today.
+    assert sync_mod._pick_heartbeat_interval(
+        {"plan": "free", "sync_allowed": True}
+    ) == sync_mod.HEARTBEAT_INTERVAL_SLOW
+
+
+def test_pick_interval_none_returns_slow(sync_mod):
+    """No successful heartbeat yet (or a non-dict body) → SLOW."""
+    assert sync_mod._pick_heartbeat_interval(None) == \
+        sync_mod.HEARTBEAT_INTERVAL_SLOW
+    # Defensive: a stray string from a misconfigured _post should not crash.
+    assert sync_mod._pick_heartbeat_interval("nope") == \
+        sync_mod.HEARTBEAT_INTERVAL_SLOW
+
+
+# ── send_heartbeat side-effect: stash response for the loop ───────────────────
+
+def test_send_heartbeat_active_viewer_stashes_for_fast_interval(
+    sync_mod, config, monkeypatch
+):
+    """A successful heartbeat with viewer_active=true must leave the module
+    in a state where the next `_pick_heartbeat_interval(_LAST_HEARTBEAT_RESPONSE)`
+    returns FAST. This is the loop's contract.
+    """
+    monkeypatch.setattr(
+        sync_mod, "_post",
+        lambda url, payload, api_key: {"viewer_active": True, "plan": "pro"},
+    )
+    assert sync_mod.send_heartbeat(config) is True
+    assert sync_mod._LAST_HEARTBEAT_RESPONSE == {
+        "viewer_active": True, "plan": "pro",
+    }
+    assert (
+        sync_mod._pick_heartbeat_interval(sync_mod._LAST_HEARTBEAT_RESPONSE)
+        == sync_mod.HEARTBEAT_INTERVAL_FAST
+    )
+
+
+def test_send_heartbeat_idle_viewer_stashes_for_slow_interval(
+    sync_mod, config, monkeypatch
+):
+    """viewer_active=false on the wire → loop derives SLOW."""
+    monkeypatch.setattr(
+        sync_mod, "_post",
+        lambda url, payload, api_key: {"viewer_active": False},
+    )
+    assert sync_mod.send_heartbeat(config) is True
+    assert (
+        sync_mod._pick_heartbeat_interval(sync_mod._LAST_HEARTBEAT_RESPONSE)
+        == sync_mod.HEARTBEAT_INTERVAL_SLOW
+    )
+
+
+def test_send_heartbeat_back_compat_missing_field(
+    sync_mod, config, monkeypatch
+):
+    """Cloud hasn't deployed PR 1 of #775 yet — response lacks the field.
+    The daemon must NOT regress to the fast cadence speculatively; SLOW only.
+    """
+    # Realistic pre-#775 cloud response shape (see comments on send_heartbeat).
+    monkeypatch.setattr(
+        sync_mod, "_post",
+        lambda url, payload, api_key: {
+            "plan": "free", "sync_allowed": True, "trial_days_left": 5,
+        },
+    )
+    assert sync_mod.send_heartbeat(config) is True
+    assert "viewer_active" not in sync_mod._LAST_HEARTBEAT_RESPONSE
+    assert (
+        sync_mod._pick_heartbeat_interval(sync_mod._LAST_HEARTBEAT_RESPONSE)
+        == sync_mod.HEARTBEAT_INTERVAL_SLOW
+    )
+
+
+def test_send_heartbeat_5xx_clears_response_falls_back_to_slow(
+    sync_mod, config, monkeypatch
+):
+    """Cloud returns 5xx → existing 3-attempt backoff path runs, returns
+    False, and the stashed response is cleared so the next interval pick
+    falls back to SLOW (don't burn FAST on a stale viewer flag from a
+    previous successful heartbeat).
+    """
+    # Pre-seed a previously-active stash so we can prove it gets cleared.
+    sync_mod._LAST_HEARTBEAT_RESPONSE = {"viewer_active": True}
+
+    calls = {"n": 0}
+
+    def _explode(url, payload, api_key):
+        calls["n"] += 1
+        raise RuntimeError("HTTP 503 Service Unavailable")
+
+    monkeypatch.setattr(sync_mod, "_post", _explode)
+    # Skip the real 1s/2s backoff between retries — we just need to assert
+    # the path runs all 3 attempts and the stash is cleared.
+    monkeypatch.setattr(sync_mod.time, "sleep", lambda *_a, **_kw: None)
+
+    assert sync_mod.send_heartbeat(config) is False
+    # Existing backoff path is preserved: 3 attempts before giving up.
+    assert calls["n"] == 3
+    # Stash cleared so the loop's next pick falls back to SLOW.
+    assert sync_mod._LAST_HEARTBEAT_RESPONSE is None
+    assert (
+        sync_mod._pick_heartbeat_interval(sync_mod._LAST_HEARTBEAT_RESPONSE)
+        == sync_mod.HEARTBEAT_INTERVAL_SLOW
+    )


### PR DESCRIPTION
## Summary

Daemon-side half of the adaptive-sync feature (epic [vivekchand/clawmetry-cloud#775](https://github.com/vivekchand/clawmetry-cloud/issues/775)). When the cloud signals a live viewer via `viewer_active: true` on the `/ingest/heartbeat` response, the daemon flips its loop from 60s → 3s so Telegram / tool / brain events appear in the cloud Brain tab in seconds instead of up to a minute. Idle nodes stay on 60s to keep bandwidth + Cloud Run cost flat.

This is **PR 2 of 3**:

- **PR 1 (cloud)** — adds the `viewer_active` field to the `/ingest/heartbeat` response when a recent viewer-presence ping is on file.
- **PR 2 (this PR, OSS daemon)** — reads that field and adapts the heartbeat cadence.
- **PR 3 (browser JS)** — pings the cloud while the dashboard tab is open so PR 1 has data to set the field from.

This PR is **independently shippable** (back-compat: a cloud without PR 1 deployed won't return the field, missing → SLOW), **but no user-visible benefit until cloud PR 1 + browser PR 3 also land**.

## Implementation notes

- `HEARTBEAT_INTERVAL_FAST = 3` / `HEARTBEAT_INTERVAL_SLOW = 60` constants near the existing `POLL_INTERVAL` block.
- `_pick_heartbeat_interval(resp_json) -> int` pure helper — unit-testable without booting the daemon loop.
- `send_heartbeat` keeps its `bool` return type (callers in `tests/test_brain_cache_push.py`, `tests/test_alert_rules_local_store.py`, `tests/test_heartbeat_dispatch.py` assert `is True`); it stashes the parsed response in a module-level `_LAST_HEARTBEAT_RESPONSE` so the loop can derive cadence as a side channel.
- `run_daemon` calls the picker after a successful send; failure path resets to SLOW (don't burn fast cadence on a stale viewer flag from a previous response). The existing 1s/2s in-call backoff inside `send_heartbeat` is untouched.
- **Not touched**: `_build_brain_cache_pushes`, `_dispatch_pending_queries`, the `cache_push` payload shape (PR #1109), or anything in `routes/`.

Diff: 66 lines added in `clawmetry/sync.py` (well under the 200 LOC cap), plus a dedicated `tests/test_adaptive_heartbeat.py`.

## Test plan

- [x] `python3 -m pytest tests/test_adaptive_heartbeat.py -q` — 8 new tests pass (4 pure-helper branches incl. `None` + 4 `send_heartbeat` side-effect branches incl. back-compat + 5xx).
- [x] `python3 -m pytest tests/test_brain_cache_push.py tests/test_alert_rules_local_store.py tests/test_heartbeat_local_store.py -q` — 26 existing heartbeat-touching tests still pass (no regression to the `bool` return contract or the `cache_push` shape).
- [x] `make lint-py` — no new ruff errors introduced (baseline of 20 pre-existing errors in `sync.py` unchanged).
- [x] Back-compat case explicitly tested: `test_send_heartbeat_back_compat_missing_field` mocks the realistic pre-#775 cloud response shape (`{plan, sync_allowed, trial_days_left}` — no `viewer_active`) and asserts the loop's cadence pick falls through to SLOW.
- [ ] Once cloud PR 1 lands, smoke-test against staging: open dashboard → confirm next heartbeat returns `viewer_active: true` → confirm daemon loop tightens to 3s in `~/.clawmetry/sync.log` traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)