### PR TITLE
fix(overview): _read_cloud_token falls back to ~/.clawmetry/config.json (audit P0 #5)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -14636,13 +14636,42 @@ def _get_uptime_str(pid):
 
 
 def _read_cloud_token():
+    """Resolve the cloud bearer the dashboard uses for /api/cloud-proxy/*.
+
+    Two sources of truth (audit P0 #5, clawmetry-cloud#779):
+
+      1. ``~/.openclaw/openclaw.json`` → ``clawmetry.cloudToken`` (legacy
+         OpenClaw sidecar path; written by ``clawmetry connect``).
+      2. ``~/.clawmetry/config.json`` → ``api_key`` (the daemon's own
+         config, written by ``python -m clawmetry.sync`` once the node is
+         paired). Validated by the ``cm_`` prefix.
+
+    Without (2) the dashboard would 401 the entire Alerts UI even on
+    machines where the daemon is fully cloud-paired but never had the
+    OpenClaw sidecar config written.
+    """
+    # Source 1 — OpenClaw sidecar (existing path, kept first so an explicit
+    # `clawmetry connect` write wins over the daemon-side copy).
     cfg_path = os.path.expanduser("~/.openclaw/openclaw.json")
     try:
         with open(cfg_path) as f:
             data = json.load(f)
-        return data.get("clawmetry", {}).get("cloudToken")
+        tok = (data.get("clawmetry", {}) or {}).get("cloudToken", "")
+        if tok:
+            return tok
     except Exception:
-        return None
+        pass
+    # Source 2 — daemon's own config (audit P0 #5 fallback).
+    daemon_cfg = os.path.expanduser("~/.clawmetry/config.json")
+    try:
+        with open(daemon_cfg) as f:
+            data = json.load(f)
+        tok = data.get("api_key", "")
+        if isinstance(tok, str) and tok.startswith("cm_"):
+            return tok
+    except Exception:
+        pass
+    return None
 
 
 def _write_cloud_token(token):

--- a/tests/test_read_cloud_token_fallback.py
+++ b/tests/test_read_cloud_token_fallback.py
@@ -1,0 +1,85 @@
+"""Audit P0 #5 — `_read_cloud_token` falls back to the daemon's own config.
+
+Before this fix, ``dashboard._read_cloud_token`` only looked at
+``~/.openclaw/openclaw.json:clawmetry.cloudToken`` (written by
+``clawmetry connect``). On machines where the daemon was paired via
+``python -m clawmetry.sync`` (which writes ``~/.clawmetry/config.json``)
+the dashboard never saw the bearer and the entire Alerts UI 401'd via
+``/api/cloud-proxy/*`` even though cloud sync was live.
+
+These three cases lock in the new resolution order:
+
+  1. OpenClaw sidecar present → preferred (legacy explicit-connect win).
+  2. Only the daemon config present → fallback returns its ``api_key``.
+  3. Neither present → returns falsy (caller renders Cloud-CTA).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+@pytest.fixture
+def reload_dashboard(tmp_path, monkeypatch):
+    """Point HOME at a clean tmpdir + reimport dashboard so the path
+    helpers in ``_read_cloud_token`` resolve there. Yields the freshly
+    reloaded ``dashboard`` module."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # On macOS some libs read $USER's home via pwd; HOME-based expansion
+    # is what os.path.expanduser uses, which is all we care about here.
+    import dashboard
+    importlib.reload(dashboard)
+    yield dashboard
+
+
+def _write_openclaw(home, token):
+    p = home / ".openclaw"
+    p.mkdir(parents=True, exist_ok=True)
+    (p / "openclaw.json").write_text(
+        json.dumps({"clawmetry": {"cloudToken": token}})
+    )
+
+
+def _write_daemon(home, api_key):
+    p = home / ".clawmetry"
+    p.mkdir(parents=True, exist_ok=True)
+    (p / "config.json").write_text(json.dumps({"api_key": api_key}))
+
+
+def test_openclaw_sidecar_only_present(tmp_path, reload_dashboard):
+    """Legacy path still works: when only the OpenClaw sidecar config
+    is present, its ``cloudToken`` is returned untouched."""
+    _write_openclaw(tmp_path, "openclaw-sidecar-token-xyz")
+    assert reload_dashboard._read_cloud_token() == "openclaw-sidecar-token-xyz"
+
+
+def test_clawmetry_config_only_present(tmp_path, reload_dashboard):
+    """Audit P0 #5 — daemon-only paired machine now resolves to the
+    ``api_key`` instead of returning None and trapping the Alerts UI."""
+    _write_daemon(tmp_path, "cm_551daemonkey")
+    assert reload_dashboard._read_cloud_token() == "cm_551daemonkey"
+
+
+def test_neither_present_returns_falsy(tmp_path, reload_dashboard):
+    """No config at all → falsy so cloud-proxy returns 401 and the UI
+    renders the cloud-CTA panel as designed."""
+    assert not reload_dashboard._read_cloud_token()
+
+
+def test_openclaw_wins_when_both_present(tmp_path, reload_dashboard):
+    """If both sources exist, the OpenClaw sidecar token wins so an
+    explicit ``clawmetry connect`` write isn't shadowed by the daemon
+    pairing key."""
+    _write_openclaw(tmp_path, "openclaw-wins")
+    _write_daemon(tmp_path, "cm_should-not-be-used")
+    assert reload_dashboard._read_cloud_token() == "openclaw-wins"
+
+
+def test_daemon_key_must_have_cm_prefix(tmp_path, reload_dashboard):
+    """A malformed ``api_key`` (no ``cm_`` prefix) is rejected so we
+    don't pass garbage strings as the bearer."""
+    _write_daemon(tmp_path, "garbage-no-prefix")
+    assert not reload_dashboard._read_cloud_token()


### PR DESCRIPTION
## Summary

`dashboard._read_cloud_token` only consulted `~/.openclaw/openclaw.json:clawmetry.cloudToken` (written by `clawmetry connect`). On machines paired via `python -m clawmetry.sync` — which writes `~/.clawmetry/config.json:api_key` — the dashboard never saw the bearer and the **entire Alerts UI 401'd** through `/api/cloud-proxy/*` even though cloud sync was live.

This PR adds a second source: when the OpenClaw sidecar token is missing, read `api_key` from the daemon's own config and accept it when it carries the `cm_` prefix. The sidecar wins when both exist so an explicit `clawmetry connect` write is never shadowed by daemon auto-pairing.

## Why

- Audit `/tmp/audit_overview_alerts_approvals_2026-05-13.md`, **P0 #5** + Section C.3 — confirmed 401 on `/api/cloud-proxy/api/alerts` despite an active, cloud-paired daemon.
- Tracked cloud-side as `clawmetry-cloud#779`.
- Unblocks the entire Alerts UI for daemon-paired-but-no-sidecar users (which today is the majority — `clawmetry connect` is a separate manual step).

## Diff

```
 dashboard.py                                  | 33 +++++++++++++++++++++++++--
 tests/test_read_cloud_token_fallback.py (new) | 85 ++++++++++++++++++++++++++
```

Total: **+116 / −2** (under the 250 LOC bar).

## Test plan

- [x] `pytest tests/test_read_cloud_token_fallback.py` — 5 cases (sidecar-only, daemon-only, neither, both → sidecar wins, malformed key rejected). All pass locally.
- [ ] CI: lint + full matrix.

## Resolution order (final)

1. `~/.openclaw/openclaw.json` → `clawmetry.cloudToken` (existing)
2. `~/.clawmetry/config.json` → `api_key` (new, must start with `cm_`)
3. `None`

## Notes

- No behavioural change for users who already have the OpenClaw sidecar config.
- Helper docstring expanded to explain the two sources of truth.
- This PR does **not** touch `clawmetry/sync.py` — a separate dead-code cleanup is in flight on that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)