### PR TITLE
fix(components): tool-modal DuckDB fast path matches actual event_type (audit P0 #4)

### DIFF
--- a/routes/components.py
+++ b/routes/components.py
@@ -53,16 +53,67 @@ _TOOL_MAP = {
 }
 
 
+def _iter_tool_call_blocks(row: dict):
+    """Yield ``(tool_name, arguments, status)`` for every tool-call block
+    embedded in a DuckDB ``events`` row.
+
+    OpenClaw's transcript shape (verified 2026-05-13 against
+    ``~/.openclaw/agents/main/sessions/*.jsonl``) wraps tool calls inside
+    ``message`` events with ``message.content`` being a list of blocks.
+    A tool call is a block whose ``type`` is ``toolCall`` (current) or
+    ``tool_use`` (Anthropic-style legacy from older transcripts).
+
+    Audit P0 #4: the previous implementation queried for
+    ``event_type='tool_call'`` rows that the daemon never writes — every
+    row in DuckDB has the raw OpenClaw type (``message`` / ``assistant``
+    / ``user`` / …). All 10 component-tool endpoints fell through to the
+    legacy JSONL parser as a result.
+    """
+    data = row.get("data") if isinstance(row, dict) else None
+    if not isinstance(data, dict):
+        return
+    msg = data.get("message")
+    if not isinstance(msg, dict):
+        return
+    # Only the assistant's turn carries tool calls; user turns carry tool
+    # results (which we surface via the role==toolResult branch in the
+    # legacy parser — out of scope here, the modal already shows ok/error
+    # via the toolCall block alone).
+    if msg.get("role") not in (None, "assistant"):
+        return
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return
+    for blk in content:
+        if not isinstance(blk, dict):
+            continue
+        btype = blk.get("type")
+        if btype not in ("toolCall", "tool_use"):
+            continue
+        tool_name = blk.get("name") or blk.get("tool") or ""
+        args = blk.get("arguments") or blk.get("input") or {}
+        if not isinstance(args, dict):
+            args = {"_raw": str(args)[:200]}
+        # Per-block error flag (Anthropic uses isError on tool_use_result;
+        # toolCall blocks don't carry it directly — we leave it ok and let
+        # the toolResult branch in the legacy parser surface failures).
+        status = "error" if blk.get("isError") else "ok"
+        yield tool_name, args, status
+
+
 def _try_local_store_component_tool(name: str):
     """Tier-1 DuckDB fast path for /api/component/tool/<name>.
 
-    Reads ``tool_call`` events from the local store, filters to today + the
-    requested tool family, and shapes them into the same response the legacy
-    JSONL parser returns (``{events, stats, total, name}``).
+    Pulls today's ``message`` / ``assistant`` rows from the local store
+    (the actual OpenClaw event types — see ``clawmetry/sync.py:1375``),
+    walks the ``message.content[]`` blocks for ``toolCall`` / ``tool_use``
+    entries, filters by the tool family for ``name`` (per ``_TOOL_MAP``),
+    and shapes them into the same response the legacy JSONL parser
+    returns (``{events, stats, total, name}``).
 
     Returns ``None`` to defer to the legacy fallback if:
       - the ``local_store`` module isn't importable
-      - the events table is empty / has no matches
+      - the events table is empty / has no matching tool-call blocks
       - any unexpected error happens (we'd rather degrade than 500)
     """
     try:
@@ -71,7 +122,15 @@ def _try_local_store_component_tool(name: str):
         return None
     try:
         store = local_store.get_store()
-        rows = store.query_events(event_type="tool_call", limit=2000)
+        # Fetch a generous window of both event types we know wrap
+        # tool-call blocks. Two queries instead of one OR-filter because
+        # ``query_events`` only takes a single event_type.
+        rows = []
+        for et in ("message", "assistant"):
+            try:
+                rows.extend(store.query_events(event_type=et, limit=2000))
+            except Exception:
+                continue
     except Exception:
         return None
     if not rows:
@@ -87,58 +146,45 @@ def _try_local_store_component_tool(name: str):
         ts = (r.get("ts") or "")
         if not ts.startswith(today):
             continue
-        data = r.get("data") if isinstance(r, dict) else None
-        # `data` can be dict (preferred), str, or None
-        tn = ""
-        args = {}
-        status = "ok"
-        if isinstance(data, dict):
-            tn = data.get("name") or data.get("tool") or ""
-            args = data.get("arguments") or data.get("input") or {}
-            if not isinstance(args, dict):
-                args = {"_raw": str(args)[:200]}
-            if data.get("isError") or (isinstance(data.get("result"), dict)
-                                       and data["result"].get("status") == "error"):
-                status = "error"
-        if not tn or tn not in tool_names:
-            continue
+        for tn, args, status in _iter_tool_call_blocks(r):
+            if not tn or tn not in tool_names:
+                continue
+            today_calls += 1
+            if status == "error":
+                today_errors += 1
 
-        today_calls += 1
-        if status == "error":
-            today_errors += 1
-
-        evt = {"timestamp": ts, "status": status, "tool": tn}
-        if name == "exec":
-            evt["detail"] = (args.get("command") or str(args))[:200]
-            evt["action"] = "exec"
-        elif name == "browser":
-            evt["action"] = args.get("action", "unknown")
-            evt["detail"] = (args.get("targetUrl") or args.get("url")
-                             or args.get("selector") or evt["action"])
-        elif name == "search":
-            evt["detail"] = args.get("query", "?")
-            evt["action"] = "search"
-        elif name == "tts":
-            evt["detail"] = (args.get("text") or "")[:100]
-            evt["action"] = "tts"
-            evt["voice"] = args.get("voice", "")
-        elif name == "memory":
-            path = args.get("file_path") or args.get("path") or "?"
-            evt["detail"] = path
-            evt["action"] = ("write" if tn in ("Write", "write", "Edit", "edit")
-                             else "read")
-        elif name == "session":
-            evt["detail"] = (args.get("sessionId") or args.get("name") or tn)
-            evt["action"] = tn
-            evt["session_status"] = "running"
-        elif name == "cron":
-            evt["detail"] = (args.get("expr") or args.get("action")
-                             or str(args)[:80])
-            evt["action"] = "cron"
-        else:
-            evt["detail"] = str(args)[:120]
-            evt["action"] = tn
-        events.append(evt)
+            evt = {"timestamp": ts, "status": status, "tool": tn}
+            if name == "exec":
+                evt["detail"] = (args.get("command") or str(args))[:200]
+                evt["action"] = "exec"
+            elif name == "browser":
+                evt["action"] = args.get("action", "unknown")
+                evt["detail"] = (args.get("targetUrl") or args.get("url")
+                                 or args.get("selector") or evt["action"])
+            elif name == "search":
+                evt["detail"] = args.get("query", "?")
+                evt["action"] = "search"
+            elif name == "tts":
+                evt["detail"] = (args.get("text") or "")[:100]
+                evt["action"] = "tts"
+                evt["voice"] = args.get("voice", "")
+            elif name == "memory":
+                path = args.get("file_path") or args.get("path") or "?"
+                evt["detail"] = path
+                evt["action"] = ("write" if tn in ("Write", "write", "Edit", "edit")
+                                 else "read")
+            elif name == "session":
+                evt["detail"] = (args.get("sessionId") or args.get("name") or tn)
+                evt["action"] = tn
+                evt["session_status"] = "running"
+            elif name == "cron":
+                evt["detail"] = (args.get("expr") or args.get("action")
+                                 or str(args)[:80])
+                evt["action"] = "cron"
+            else:
+                evt["detail"] = str(args)[:120]
+                evt["action"] = tn
+            events.append(evt)
 
     if not events:
         return None

--- a/tests/test_tool_modal_fastpath_2026_05_13.py
+++ b/tests/test_tool_modal_fastpath_2026_05_13.py
@@ -1,0 +1,204 @@
+"""Audit P0 #4 — tool-modal DuckDB fast path matches the actual event_type.
+
+Before: ``routes/components.py:_try_local_store_component_tool`` queried
+``event_type='tool_call'`` rows that the daemon never writes —
+``clawmetry/sync.py:1375`` writes ``event_type=obj.get('type')`` which is
+the raw OpenClaw type (``message`` / ``assistant`` / ``user`` / …). The
+fast path returned ``None`` for every tool, all 10 component-tool
+endpoints fell through to legacy JSONL parsing, and the audit's
+``_source: 'local_store'`` marker never appeared.
+
+After: the helper queries ``message`` / ``assistant`` rows, walks
+``data.message.content[]`` for ``toolCall`` / ``tool_use`` blocks, and
+filters by tool family. These tests ingest one synthetic event per tool
+name, hit ``/api/component/tool/<name>``, and assert the response carries
+``_source == 'local_store'`` plus the event we just ingested.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Reload local_store + components blueprint against a per-test DuckDB."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.components as comp
+    importlib.reload(comp)
+
+    a = Flask(__name__)
+    a.register_blueprint(comp.bp_components)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _now_iso() -> str:
+    """Today-stamped timestamp so the helper's ``ts.startswith(today)``
+    filter accepts it. UTC because that's what OpenClaw emits."""
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _ingest_message_with_tool_block(
+    store, *, tool_name: str, args: dict, ev_id: str = "ev-1"
+) -> str:
+    """Insert one OpenClaw-shaped ``message`` event whose
+    ``data.message.content[]`` contains a single ``toolCall`` block for
+    ``tool_name`` with ``args``."""
+    ts = _now_iso()
+    store.ingest({
+        "id": ev_id,
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-fast",
+        "event_type": "message",  # the raw OpenClaw type, per sync.py:1375
+        "ts": ts,
+        "data": {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "toolCall", "name": tool_name, "arguments": args},
+                ],
+            },
+        },
+        "cost_usd": 0.0,
+        "token_count": 0,
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+    return ts
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# One test per tool family (10 total — matches audit Section A's table).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# (modal_name, tool_name_in_block, args, expected_action_substring)
+TOOL_CASES = [
+    ("exec",       "exec",            {"command": "ls -la /tmp"},          "exec"),
+    ("browser",    "browser",         {"action": "navigate",
+                                       "targetUrl": "https://example.com"}, "navigate"),
+    ("search",     "web_search",      {"query": "duckdb upsert"},           "search"),
+    ("cron",       "cron",            {"expr": "*/5 * * * *",
+                                       "action": "schedule"},                "cron"),
+    ("tts",        "tts",             {"text": "hello world",
+                                       "voice": "alloy"},                    "tts"),
+    ("memory",     "Read",            {"file_path": "/tmp/notes.md"},       "read"),
+    ("session",    "sessions_spawn",  {"sessionId": "child-1",
+                                       "name": "child"},                    "sessions_spawn"),
+    # Unmapped families fall through to the literal name in _TOOL_MAP.get
+    # (so the block must use the modal name itself) — covers the audit's
+    # last three rows that the legacy parser also matches verbatim.
+    ("storage",    "storage",         {"path": "/var/log/x"},               "storage"),
+    ("network",    "network",         {"host": "1.1.1.1"},                  "network"),
+    ("automation", "automation",      {"flow": "deploy"},                   "automation"),
+]
+
+
+@pytest.mark.parametrize("modal,tool_block_name,args,expected_action", TOOL_CASES,
+                         ids=[c[0] for c in TOOL_CASES])
+def test_tool_modal_serves_from_local_store(
+    app, modal, tool_block_name, args, expected_action
+):
+    """For each of the 10 tool modals: ingest one matching tool_use block
+    and confirm the endpoint returns ``_source: 'local_store'`` + event."""
+    a, ls = app
+    store = ls.get_store()
+    _ingest_message_with_tool_block(
+        store, tool_name=tool_block_name, args=args, ev_id=f"ev-{modal}"
+    )
+
+    r = a.test_client().get(f"/api/component/tool/{modal}")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"{modal} fast path bypassed — body={body}"
+    )
+    assert body["total"] >= 1, body
+    assert body["events"], body
+    # The first event is the most-recent (we sort desc by ts).
+    evt = body["events"][0]
+    assert evt["tool"] == tool_block_name
+    assert evt["status"] == "ok"
+    # Every tool branch sets `action`; check that something matching the
+    # tool is present (loose match so per-tool detail formatting is free
+    # to change without breaking us).
+    assert expected_action in (evt.get("action") or "") + " " + (evt.get("tool") or "")
+
+
+def test_fast_path_falls_through_when_no_tool_blocks(app):
+    """A ``message`` row that only has plain text blocks (no toolCall)
+    must NOT be served by the fast path — let the legacy parser try."""
+    a, ls = app
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-no-tool",
+        "node_id": "agent+test", "agent_id": "main", "session_id": "sess-x",
+        "event_type": "message", "ts": _now_iso(),
+        "data": {
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "no tools here"}],
+            },
+        },
+        "cost_usd": 0.0, "token_count": 0, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    r = a.test_client().get("/api/component/tool/exec")
+    body = r.get_json()
+    assert body.get("_source") != "local_store"
+
+
+def test_fast_path_handles_anthropic_tool_use_alias(app):
+    """Older / Anthropic-direct transcripts use ``type='tool_use'`` and
+    ``input`` instead of ``toolCall`` / ``arguments``. Must still match."""
+    a, ls = app
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-tool-use",
+        "node_id": "agent+test", "agent_id": "main", "session_id": "sess-y",
+        "event_type": "assistant", "ts": _now_iso(),
+        "data": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "name": "exec",
+                     "input": {"command": "uname -a"}},
+                ],
+            },
+        },
+        "cost_usd": 0.0, "token_count": 0, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    r = a.test_client().get("/api/component/tool/exec")
+    body = r.get_json()
+    assert body.get("_source") == "local_store", body
+    assert body["total"] >= 1
+    assert body["events"][0]["tool"] == "exec"
+    assert "uname" in (body["events"][0].get("detail") or "")


### PR DESCRIPTION
## Summary

`routes/components.py:_try_local_store_component_tool` queried `event_type='tool_call'` rows that the daemon never writes — `clawmetry/sync.py:1375` writes `event_type=obj.get('type')`, which is the raw OpenClaw type (`message` / `assistant` / `user` / etc.). All 10 component-tool endpoints fell through to the legacy JSONL parser; the audit's `_source: 'local_store'` marker never appeared.

This PR fixes the filter:
- Queries `message` and `assistant` rows from DuckDB.
- Walks `data.message.content[]` for `toolCall` (current OpenClaw shape) and `tool_use` (Anthropic-direct legacy shape) blocks.
- Post-filters by the tool family from `_TOOL_MAP` (unchanged — same allow-list as the legacy parser).
- Block-walking lives in a small reusable `_iter_tool_call_blocks` helper.

When no matching blocks land, the helper still returns `None` so the legacy fallthrough runs. **Strict superset of previous behaviour.**

## Why

- Audit `/tmp/audit_overview_alerts_approvals_2026-05-13.md`, **P0 #4** + Section A.
- Restores Tier-1 DuckDB acceleration on a tab the migration was supposed to cover.

## Before / After

| modal      | before (`_source`) | after (`_source` when DuckDB has data) |
|------------|--------------------|----------------------------------------|
| exec       | LEGACY             | `local_store`                          |
| browser    | LEGACY             | `local_store`                          |
| search     | LEGACY             | `local_store`                          |
| cron       | LEGACY             | `local_store`                          |
| tts        | LEGACY             | `local_store`                          |
| memory     | LEGACY             | `local_store`                          |
| session    | LEGACY             | `local_store`                          |
| storage    | LEGACY             | `local_store`                          |
| network    | LEGACY             | `local_store`                          |
| automation | LEGACY             | `local_store`                          |

**0/10 → 10/10.**

## Diff

```
 routes/components.py                                | 160 ++++++++++++--------
 tests/test_tool_modal_fastpath_2026_05_13.py (new)  | 204 ++++++++++++++++++++
```

Total: **+307 / −57** in core file = **103 net code lines + 204 test lines** (helper + 12 parametrised tests).

## Test plan

- [x] `pytest tests/test_tool_modal_fastpath_2026_05_13.py` — 12 cases (10 tool families × 1 ingest+assert, plus a no-tool-blocks fallthrough and an Anthropic `tool_use` alias). All pass locally.
- [x] `pytest tests/test_local_store.py tests/test_brain_local_fastpath.py tests/test_overview_local_store.py` — adjacent suites unaffected. (Two pre-existing failures in `test_overview_local_store` / `test_brain_local_fastpath` reproduce on a clean `origin/main` worktree — unrelated to this PR; tracking separately.)
- [ ] CI: lint + full matrix.

## Notes

- This PR does **not** touch `clawmetry/sync.py` — a separate dead-code cleanup is in flight on that file.
- The 15s response cache in `api_component_tool` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)