### PR TITLE
cleanup: delete duplicate run_daemon dead-code shadow (audit P0 #3)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5228,6 +5228,18 @@ ALERTS_EVAL_INTERVAL_SEC = 300  # Re-evaluate alerts every 5 minutes
 def evaluate_alerts(config: dict, state: dict) -> int:
     """Trigger cloud-side alert evaluation for this node.
 
+    .. warning::
+       **Currently UNREACHABLE.** This function has zero callers in the live
+       daemon loop (see ``run_daemon`` at the top of this module). The audit
+       on 2026-05-13 (P0 #2 + P0 #3) found a duplicate ``run_daemon`` shadow
+       at the bottom of this file that *did* call ``evaluate_alerts`` every
+       60s, but that shadow was unreachable itself (the module-level
+       ``if __name__ == "__main__"`` guard fires before the second def runs).
+       The shadow has been deleted; this function is intentionally left in
+       place pending PR-D (clawmetry-cloud#779), which will rewrite it to
+       read from DuckDB and rewire it into the live ``run_daemon``. Until
+       then, alert evaluation is purely cloud-driven (cron-tick or webhook).
+
     The cloud holds the rules and runs the actual threshold checks against the
     sessions/events tables it already syncs from this daemon. We just poke the
     `/api/internal/evaluate-alerts` endpoint on a schedule.
@@ -5276,29 +5288,3 @@ def evaluate_alerts(config: dict, state: dict) -> int:
         # Still record the timestamp so we back off rather than retry on every tick
         state["alerts_last_eval_ts"] = now
         return 0
-
-
-def run_daemon() -> None:
-    """Run the sync daemon - main loop for continuous synchronization."""
-    config = load_config()
-    state = load_state()
-    paths = detect_paths()
-
-    log.info("Starting ClawMetry sync daemon...")
-
-    while True:
-        try:
-            sync_session_metadata(config, state)
-            sync_sessions(config, state, paths)
-            sync_claude_cli_sessions(config, state, paths)
-            sync_logs(config, state, paths)
-            sync_crons(config, state, paths)
-            sync_memory(config, state, paths)
-            sync_system_snapshot(config, state, paths)
-            sync_autonomy(config, state, paths)
-            evaluate_alerts(config, state)
-            save_state(state)
-        except Exception as e:
-            log.error(f"Sync error: {e}")
-
-        time.sleep(60)

--- a/tests/test_run_daemon_uniqueness.py
+++ b/tests/test_run_daemon_uniqueness.py
@@ -1,0 +1,53 @@
+"""Regression test for the duplicate ``run_daemon`` shadow in clawmetry/sync.py.
+
+Audit on 2026-05-13 (P0 #2 + P0 #3) found that ``clawmetry/sync.py`` defined
+``run_daemon`` twice:
+
+- ~line 4641: the LIVE definition that ``python -m clawmetry.sync`` actually
+  executes via the module-level ``if __name__ == "__main__"`` guard.
+- ~line 5281: a 24-line dead SHADOW that overwrote the live name at import
+  time. ``from clawmetry import sync; sync.run_daemon()`` resolved to this
+  shadow, and ``cli.py`` (``clawmetry sync``) called it -- meaning two of the
+  three ways to run the daemon executed completely different code paths.
+
+The shadow was deleted in PR ``cleanup/delete-duplicate-run-daemon-2026-05-13``.
+This test ensures it doesn't sneak back in (e.g., a future PR copy-pasting a
+helper from the bottom of the file).
+"""
+
+import inspect
+
+
+def test_run_daemon_resolves_to_live_definition():
+    """``sync.run_daemon`` must resolve to the live def near the top of the
+    file (the one that acquires the PID lock, starts the relay thread, etc.),
+    not a shadow defined later in the file.
+    """
+    from clawmetry import sync
+
+    line = inspect.getsourcelines(sync.run_daemon)[1]
+    assert line < 4700, (
+        f"sync.run_daemon resolves to line {line}, but the live def lives "
+        f"near line 4641. A duplicate def has likely been re-introduced "
+        f"further down the file -- check `grep -n '^def run_daemon' "
+        f"clawmetry/sync.py` and delete the shadow."
+    )
+
+
+def test_run_daemon_defined_exactly_once():
+    """Belt-and-braces: scan the source file for ``def run_daemon`` at column 0
+    and assert there is exactly one occurrence. Catches the regression even if
+    someone manages to add a shadow that happens to be picked up first.
+    """
+    from clawmetry import sync
+
+    src_path = inspect.getsourcefile(sync)
+    assert src_path is not None
+    with open(src_path, "r", encoding="utf-8") as f:
+        src = f.read()
+    count = sum(1 for line in src.splitlines() if line.startswith("def run_daemon"))
+    assert count == 1, (
+        f"Expected exactly one top-level `def run_daemon` in {src_path}, "
+        f"found {count}. See tests/test_run_daemon_uniqueness.py docstring "
+        f"for the history."
+    )


### PR DESCRIPTION
## Summary

`clawmetry/sync.py` defined `run_daemon` **twice**:

| Location | LOC | What it did | Reachable from |
|---|---|---|---|
| **Line 4641** (live) | ~360 | Acquires PID lock, starts relay thread, runs local-query HTTP server, calls all real `sync_*()` helpers | `python -m clawmetry.sync` (via `if __name__ == "__main__"` at line 5010) |
| **Line 5281** (dead shadow) | 24 | No PID lock, no relay, just loops `sync_*()` + `evaluate_alerts()` every 60s | Anyone who imports the module — the second def overwrites the first at parse time |

So **two of the three daemon entry-points were silently degraded**:

- `python -m clawmetry.sync` → live def (correct)
- `from clawmetry.sync import run_daemon` → shadow (broken)
- `clawmetry sync --foreground` (`cli.py:561`) → shadow (broken)

This PR deletes the shadow so all three paths converge on the live loop.

### Side-effect: `evaluate_alerts` is now formally orphaned

The dead shadow was the only caller of `evaluate_alerts`. The audit confirmed it has fired 0 times in production anyway. We leave it defined and add a docstring warning so future readers don't think it's wired in — **PR-D (`clawmetry-cloud#779`)** will rewrite it to read from DuckDB and rewire it into the live `run_daemon` then. Same applies to `sync_autonomy` and `_compute_autonomy_daily_series`, which were also only called from the dead shadow; those are left untouched pending the same follow-up PR.

### Audit reference

`/tmp/audit_overview_alerts_approvals_2026-05-13.md` — P0 #2 (run_daemon shadow) + P0 #3 (evaluate_alerts unreachable).

### LOC delta

`clawmetry/sync.py`: +12 / -26 (net -14; would be -28 without the new docstring).

## Test plan

- [x] `python3 -c "from clawmetry import sync"` — imports cleanly
- [x] `python3 -c "import inspect; from clawmetry import sync; assert inspect.getsourcelines(sync.run_daemon)[1] < 4700"` — passes (resolves to line 4641, was 5281 before)
- [x] `tests/test_run_daemon_uniqueness.py` — 2/2 pass (asserts source-line invariant + `def run_daemon` count == 1)
- [x] `tests/test_e2e_duckdb_relay.py` — 17/17 pass on this branch (same as origin/main baseline)
- [x] `tests/test_circular_import.py` — 8/8 pass
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — Python syntax OK
- [ ] `make test-api` — requires live server; cleanup is import-graph-only, no behavior change to any sync_*() function, low regression risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)