### PR TITLE
feat(approvals): watcher reads from DuckDB, not OpenClaw JSONL filesystem (PRD #779 PR-E, audit P0 #6)

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -1,7 +1,7 @@
 """clawmetry/approvals.py — cloud-mediated approval policy engine.
 
-Watches the OpenClaw session JSONL stream for tool calls that match a
-user-defined approval policy. When a match fires:
+Watches the unified DuckDB event store (``clawmetry/local_store.py``) for
+tool calls that match a user-defined approval policy. When a match fires:
 
   1. POST the request to ClawMetry cloud (`/api/approvals/request`)
   2. Notify a human (cloud handles delivery — Slack/email/browser link)
@@ -16,18 +16,32 @@ Policies tab for the YAML format.
 Companion to vivekchand/clawmetry#667 (issue) and the cloud receiver in
 vivekchand/clawmetry-cloud#337.
 
+Backward-compat NOTE (PRD vivekchand/clawmetry-cloud#779, audit P0 #6):
+  Prior to 2026-05-13 the watcher tail-globbed
+  ``~/.openclaw/agents/main/sessions/*.jsonl`` directly. That worked only
+  for OpenClaw — Hermes / Codex / Claude Code adapters were invisible to
+  the policy engine. The watcher now reads from
+  ``local_store.query_events()`` which every adapter feeds, so a policy
+  fires regardless of which framework produced the toolCall. The legacy
+  JSONL paths are no longer scanned. If you had tooling that depended on
+  the watcher reading JSONL directly, point it at the DuckDB store
+  (``~/.clawmetry/clawmetry.duckdb``) instead — the same events live
+  there. No flag is provided for graceful migration: the unified store
+  has a strict superset of the old data.
+
 Design notes:
-  * Stateless watcher — restartable any time, replays from current end-of-file
-    and only processes new events. We track per-session high-water-mark to
-    avoid double-firing on policy reload.
-  * One in-flight approval per (session, tool_call_id). Multiple matches on
-    the same call collapse into one request — important so a session that
-    matches both "rm" AND "outside-tmp" policies doesn't get duplicate Slack
-    pings.
-  * NO HTTP retry storm — cloud round-trip uses the existing ``_post`` helper
-    which already backs off + handles 429s.
-  * Soft-fail in OSS-only mode (no cloud configured): log and pass through.
-    The same code runs in pure-local installs without crashing.
+  * Stateless watcher — restartable any time, resumes from a single
+    ``approvals_last_check_ts`` watermark persisted in
+    ``~/.clawmetry/sync-state.json``. The watermark survives daemon
+    restarts, so already-decided approvals are not re-evaluated.
+  * One in-flight approval per (session, tool_call_id). Multiple matches
+    on the same call collapse into one request — important so a session
+    that matches both "rm" AND "outside-tmp" policies doesn't get
+    duplicate Slack pings.
+  * NO HTTP retry storm — cloud round-trip uses the existing ``_post``
+    helper which already backs off + handles 429s.
+  * Soft-fail in OSS-only mode (no cloud configured): log and pass
+    through. The same code runs in pure-local installs without crashing.
 """
 from __future__ import annotations
 
@@ -36,7 +50,6 @@ import re
 import json
 import time
 import uuid
-import glob
 import logging
 import threading
 from pathlib import Path
@@ -434,86 +447,300 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
     return result
 
 
-# ── Watcher: scan session JSONL tail for new toolCalls ────────────────────
+# ── Watcher: scan unified DuckDB event store for new toolCalls ────────────
+#
+# The watermark is the most recent event ts (ISO-8601 string) we've examined
+# AND completely processed. Persisted in ``~/.clawmetry/sync-state.json``
+# under the key ``approvals_last_check_ts`` so a daemon restart doesn't
+# re-evaluate already-decided approvals.
+#
+# We deliberately store/compare ``ts`` as a string. Every adapter ingests its
+# event timestamps as strings (see ``clawmetry/local_store.py`` schema) and
+# DuckDB's ``ORDER BY ts`` sort is lexicographic on that VARCHAR column.
+# Lexicographic sort on properly-padded ISO-8601 timestamps is the same as
+# chronological — that's the whole point of the format. Mixing in a numeric
+# epoch would break the comparison.
+
+# In-memory mirror of the persisted watermark, primed lazily on first
+# iteration. ``None`` → not yet read from disk.
+#
+# ``last_check_ts`` is an ISO-8601 timestamp string. We query
+# ``query_events(since=last_check_ts)`` which uses ``ts >= since``
+# (inclusive). To prevent an event whose ``ts`` exactly equals
+# ``last_check_ts`` from being re-processed on every iteration, we also
+# track ``seen_ids_at_boundary`` — the set of event ids we've already
+# dispatched at the current watermark ts. The set is reset whenever the
+# watermark advances to a strictly newer ts.
+_state: dict = {
+    "last_check_ts": None,        # Optional[str]
+    "seen_ids_at_boundary": set(),  # set[str]
+}
+_state_lock = threading.Lock()
+
+# Where the watermark lives on disk. Co-located with the daemon's other state
+# (``sync-state.json``) so an ops engineer who pokes around ``~/.clawmetry``
+# doesn't have to learn a second file. We use the same key namespace the
+# sync daemon uses (separate top-level key, no collision).
+_STATE_PATH = Path.home() / ".clawmetry" / "sync-state.json"
+_STATE_KEY = "approvals_last_check_ts"
+# Companion key: the set of event ids we've already dispatched at the
+# watermark ts. Persisted alongside the watermark so a daemon restart
+# doesn't replay a boundary event that's already been processed (the
+# events table's ``ts >= since`` filter is inclusive).
+_STATE_KEY_SEEN = "approvals_seen_ids_at_boundary"
+
+# Recognised "this content block is a tool invocation" types. Both flavours
+# coexist in the wild because adapters mirror their underlying agent's wire
+# format:
+#   * OpenClaw / Claude Agent SDK     → ``toolCall``  +  ``arguments``
+#   * Claude Code / Anthropic Messages → ``tool_use`` +  ``input``
+# The watcher tolerates either. ``process_tool_call`` itself is shape-agnostic
+# (it takes a parsed args dict).
+_TOOL_BLOCK_TYPES = ("toolCall", "tool_use")
 
 
-def _sessions_dir() -> Optional[str]:
-    """Locate OpenClaw's sessions directory."""
-    for cand in (
-        os.path.expanduser("~/.openclaw/agents/main/sessions"),
-        os.path.expanduser("~/.clawdbot/agents/main/sessions"),
-    ):
-        if os.path.isdir(cand):
-            return cand
-    return None
+def _read_persisted_watermark() -> tuple[Optional[str], set[str]]:
+    """Read the persisted watermark + boundary-id set from sync-state.json.
+
+    Returns ``(ts, seen_ids)``. ``ts`` is None if the file or key is missing
+    or unreadable; ``seen_ids`` is empty in the same cases. Never raises —
+    a corrupt state file must not stop the watcher from running, only
+    forces a one-time replay."""
+    try:
+        if not _STATE_PATH.exists():
+            return None, set()
+        with _STATE_PATH.open("r", encoding="utf-8") as fh:
+            blob = json.load(fh)
+        v = blob.get(_STATE_KEY)
+        ts = v if isinstance(v, str) and v else None
+        ids_raw = blob.get(_STATE_KEY_SEEN) or []
+        ids = {s for s in ids_raw if isinstance(s, str)}
+        return ts, ids
+    except Exception as e:
+        log.debug(f"approvals: could not read watermark from {_STATE_PATH}: {e}")
+        return None, set()
 
 
-# Per-file high-water-mark (byte offset) so we don't reprocess on restart
-_file_offsets: dict[str, int] = {}
+def _persist_watermark(ts: str, seen_ids: set[str]) -> None:
+    """Atomically update the watermark + boundary-id set in sync-state.json.
+    Reads the existing blob (so we don't clobber sibling keys owned by
+    sync.py) and writes back. Never raises — losing one watermark write
+    means at most a re-replay on the next restart, which is benign because
+    ``_in_flight`` deduplicates."""
+    try:
+        _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        blob: dict = {}
+        if _STATE_PATH.exists():
+            try:
+                with _STATE_PATH.open("r", encoding="utf-8") as fh:
+                    blob = json.load(fh) or {}
+            except Exception:
+                blob = {}
+        blob[_STATE_KEY] = ts
+        # Cap the persisted set: a single ts shouldn't accumulate more than
+        # a few dozen ids in practice, but a buggy adapter could spam the
+        # same ts. 1000 is generous and bounds the on-disk size.
+        blob[_STATE_KEY_SEEN] = sorted(seen_ids)[:1000]
+        tmp_path = _STATE_PATH.with_suffix(".json.tmp")
+        with tmp_path.open("w", encoding="utf-8") as fh:
+            json.dump(blob, fh, indent=2)
+        os.replace(tmp_path, _STATE_PATH)
+    except Exception as e:
+        log.debug(f"approvals: could not persist watermark to {_STATE_PATH}: {e}")
+
+
+def _extract_tool_blocks(row: dict) -> list[tuple[str, str, dict]]:
+    """Walk a single events-table row and return ``(tool_call_id, tool_name,
+    args)`` for every tool-invocation content block found.
+
+    The ``data`` column is the raw transcript event dict (see
+    ``sync._local_ingest_session_batch``). Shape varies by adapter:
+
+      OpenClaw / Hermes / Claude Agent SDK:
+        data = {type: "message", message: {role: "assistant",
+                content: [{type: "toolCall", id, name, arguments}, …]}}
+
+      Claude Code / Anthropic Messages:
+        data = {type: "message", message: {role: "assistant",
+                content: [{type: "tool_use", id, name, input}, …]}}
+
+    Some adapters (notably the relay path) flatten ``message`` onto the top
+    level, e.g. ``{role: "assistant", content: [...]}``. Handle both.
+    Adapters that emit one event per tool invocation (instead of nested
+    inside an assistant message) put the toolCall block at the top level —
+    handle that too. All branches are tolerant: bad/missing keys just
+    yield nothing.
+    """
+    out: list[tuple[str, str, dict]] = []
+    data = row.get("data")
+    if not isinstance(data, dict):
+        return out
+    # Case A: ``data.message.content[]`` (assistant turn carries toolCalls)
+    msg = data.get("message")
+    if isinstance(msg, dict):
+        # Filter to assistant-role messages so we don't fire on tool_result
+        # blocks coming back from the user side (which carry the same
+        # block type names in some transcript formats).
+        if msg.get("role") in (None, "assistant"):
+            for blk in msg.get("content") or []:
+                if isinstance(blk, dict) and blk.get("type") in _TOOL_BLOCK_TYPES:
+                    out.append((
+                        str(blk.get("id") or ""),
+                        str(blk.get("name") or ""),
+                        blk.get("arguments") or blk.get("input") or {},
+                    ))
+    # Case B: ``data.content[]`` (flattened — no nested message)
+    if not out and isinstance(data.get("content"), list):
+        if data.get("role") in (None, "assistant"):
+            for blk in data["content"]:
+                if isinstance(blk, dict) and blk.get("type") in _TOOL_BLOCK_TYPES:
+                    out.append((
+                        str(blk.get("id") or ""),
+                        str(blk.get("name") or ""),
+                        blk.get("arguments") or blk.get("input") or {},
+                    ))
+    # Case C: ``data`` IS the toolCall block (one-event-per-tool emitters)
+    if not out and data.get("type") in _TOOL_BLOCK_TYPES:
+        out.append((
+            str(data.get("id") or ""),
+            str(data.get("name") or ""),
+            data.get("arguments") or data.get("input") or {},
+        ))
+    return out
+
+
+def _query_new_events(since: Optional[str], limit: int) -> list[dict]:
+    """Fetch candidate event rows from the local store since ``since`` (ts).
+
+    ``query_events`` accepts only one ``event_type`` filter at a time, but
+    different adapters ingest the same conceptual "assistant turn" event
+    under different ``event_type`` strings (OpenClaw uses ``"message"``;
+    some Anthropic-shape adapters use ``"assistant"``). Issue both queries
+    and merge. Cost is negligible — both are indexed by
+    ``idx_events_type_ts``.
+    """
+    from clawmetry import local_store
+    try:
+        store = local_store.get_store(read_only=True)
+    except Exception as e:
+        # Daemon may have closed the store, or DuckDB optional dep missing
+        # in a pure-OSS install. Either way the watcher should no-op rather
+        # than crash the loop.
+        log.debug(f"approvals: local_store unavailable ({e})")
+        return []
+    rows: list[dict] = []
+    for et in ("message", "assistant"):
+        try:
+            rows.extend(store.query_events(event_type=et, since=since, limit=limit))
+        except Exception as e:
+            log.debug(f"approvals: query_events({et}) failed: {e}")
+    return rows
 
 
 def watch_iteration(api_key: str, node_id: str,
                     policies: Optional[list[dict]] = None) -> int:
-    """One pass over all session JSONLs. Returns count of toolCalls processed."""
-    sd = _sessions_dir()
-    if not sd:
-        return 0
+    """One pass over the unified event store. Returns count of toolCalls
+    dispatched to ``process_tool_call`` (each in its own thread).
+
+    Re-entrancy: the watermark moves forward only AFTER all matching rows
+    in this pass have been spawned. ``query_events(since=…)`` uses ``ts >=
+    since`` (inclusive), so on the next iteration we may re-see the row at
+    the boundary timestamp; the per-tool-call dedup in ``process_tool_call``
+    (``_in_flight`` keyed by tool_call_id) absorbs the duplicate without a
+    second cloud round-trip.
+    """
     if policies is None:
         policies = load_policies()
     if not policies:
         return 0
+
+    # Lazy-prime the watermark from disk on first iteration. Subsequent
+    # iterations use the in-memory copy.
+    with _state_lock:
+        if _state["last_check_ts"] is None:
+            persisted_ts, persisted_ids = _read_persisted_watermark()
+            # First-ever start: anchor to "now" so we don't replay the entire
+            # event history on a fresh install. ISO-8601 with "Z" suffix to
+            # match the format adapters emit.
+            if persisted_ts is None:
+                persisted_ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                _persist_watermark(persisted_ts, set())
+            _state["last_check_ts"] = persisted_ts
+            _state["seen_ids_at_boundary"] = persisted_ids
+        since = _state["last_check_ts"]
+        seen_at_boundary: set[str] = set(_state["seen_ids_at_boundary"])
+
+    # ``limit=500`` matches the PRD spec. At 2 s polling cadence that's a
+    # 250 toolCalls/sec ceiling, well above any realistic agent throughput.
+    rows = _query_new_events(since=since, limit=500)
+    if not rows:
+        return 0
+
     processed = 0
-    for fpath in glob.glob(os.path.join(sd, "*.jsonl")):
-        if ".checkpoint." in fpath or ".deleted." in fpath:
+    max_seen_ts = since
+    new_seen_at_boundary: set[str] = set(seen_at_boundary)
+    for row in rows:
+        ts = row.get("ts")
+        eid = row.get("id")
+        # Skip rows we've already dispatched at the boundary. ``query_events``
+        # is inclusive on ``since`` (ts >= since), so without this filter we'd
+        # re-fire on every poll for any event whose ts equals our watermark.
+        if isinstance(ts, str) and ts == since and eid in seen_at_boundary:
             continue
-        try:
-            size = os.path.getsize(fpath)
-            # First time we see this file: anchor to current EOF *and persist
-            # the watermark*, so subsequent appends are visible. The previous
-            # version re-defaulted to `size` every iteration, which silently
-            # absorbed any new bytes.
-            if fpath not in _file_offsets:
-                _file_offsets[fpath] = size
+        if isinstance(ts, str) and (max_seen_ts is None or ts > max_seen_ts):
+            max_seen_ts = ts
+        sid = row.get("session_id") or ""
+        row_blocks = _extract_tool_blocks(row)
+        # Even if a row had no toolCall blocks we still mark it as "seen at
+        # this boundary" — otherwise the next poll would keep re-extracting
+        # the same plain assistant message until a later event nudges the
+        # watermark forward.
+        if isinstance(ts, str) and ts == since and isinstance(eid, str):
+            new_seen_at_boundary.add(eid)
+        for tool_call_id, tool_name, args in row_blocks:
+            if not tool_name:
+                # No tool name → no policy can match. Skip rather than
+                # bother process_tool_call.
                 continue
-            offset = _file_offsets[fpath]
-            if offset > size:
-                offset = 0  # log rotated
-            if offset == size:
-                continue
-            with open(fpath, "r", errors="replace") as fh:
-                fh.seek(offset)
-                for line in fh:
-                    if not line.strip():
-                        continue
-                    try:
-                        ev = json.loads(line)
-                    except Exception:
-                        continue
-                    if ev.get("type") != "message":
-                        continue
-                    msg = ev.get("message") or {}
-                    if msg.get("role") != "assistant":
-                        continue
-                    for blk in msg.get("content") or []:
-                        if not isinstance(blk, dict):
-                            continue
-                        if blk.get("type") != "toolCall":
-                            continue
-                        sid = os.path.basename(fpath).replace(".jsonl", "").split(".")[0]
-                        # Run in a background thread so a long approval
-                        # timeout doesn't stall the watcher loop.
-                        t = threading.Thread(
-                            target=process_tool_call,
-                            args=(api_key, node_id, sid, blk.get("id", ""),
-                                  blk.get("name", ""), blk.get("arguments") or {},
-                                  policies),
-                            daemon=True,
-                        )
-                        t.start()
-                        processed += 1
-                _file_offsets[fpath] = fh.tell()
-        except Exception as e:
-            log.debug(f"scan error on {fpath}: {e}")
+            # Run in a background thread so a long approval timeout
+            # doesn't stall the watcher loop.
+            t = threading.Thread(
+                target=process_tool_call,
+                args=(api_key, node_id, sid, tool_call_id, tool_name,
+                      args if isinstance(args, dict) else {}, policies),
+                daemon=True,
+            )
+            t.start()
+            processed += 1
+
+    # Advance the watermark and persist. We move it forward whether or not
+    # any toolCalls fired — the goal is to avoid re-scanning rows whose
+    # timestamp is already in our rear-view mirror, even when none of them
+    # were assistant-with-toolCall events. When the watermark advances to a
+    # strictly newer ts, the boundary-id set is reset (those older events
+    # are now in the rear-view and can't be re-seen with ts >= since).
+    advanced = isinstance(max_seen_ts, str) and max_seen_ts != since
+    with _state_lock:
+        if advanced:
+            _state["last_check_ts"] = max_seen_ts
+            # Anything at the new boundary ts is captured here — repopulate
+            # from this iteration's rows so we don't redispatch them on the
+            # next poll (still within the inclusive ``ts >= since`` window).
+            _state["seen_ids_at_boundary"] = {
+                str(r.get("id")) for r in rows
+                if isinstance(r.get("ts"), str) and r.get("ts") == max_seen_ts
+                and r.get("id") is not None
+            }
+        else:
+            _state["seen_ids_at_boundary"] = new_seen_at_boundary
+        snapshot_ts = _state["last_check_ts"]
+        snapshot_ids = set(_state["seen_ids_at_boundary"])
+    # Persist on every successful iteration. Cheap (single small JSON file)
+    # and means a daemon crash mid-poll loses at most the events from this
+    # iteration — bounded by limit=500.
+    if isinstance(snapshot_ts, str):
+        _persist_watermark(snapshot_ts, snapshot_ids)
+
     return processed
 
 

--- a/tests/test_approvals_duckdb_watcher.py
+++ b/tests/test_approvals_duckdb_watcher.py
@@ -1,0 +1,342 @@
+"""Tests for the DuckDB-backed approvals watcher (PRD #779 PR-E).
+
+Pre-2026-05-13, ``clawmetry/approvals.py:watch_iteration`` tail-globbed
+``~/.openclaw/agents/main/sessions/*.jsonl``. That worked only for OpenClaw
+— Hermes / Codex / Claude Code adapters had no path to the policy engine.
+The watcher now reads ``local_store.query_events()`` directly, which every
+adapter feeds.
+
+These tests exercise the new watcher against an isolated DuckDB and a
+stubbed ``process_tool_call`` so we don't need a real cloud round-trip.
+
+What's covered:
+
+  1. Happy path — ingest 3 fake events with toolCall blocks → run watcher
+     → assert process_tool_call called 3 times with the right payload.
+  2. Dedup / watermark — running the watcher twice in a row must not
+     re-fire on already-seen events.
+  3. Mixed event types — only assistant-with-toolCall events trigger the
+     watcher; plain text messages are ignored.
+  4. Non-OpenClaw adapter — an event tagged ``agent_type='hermes'`` still
+     fires (proves the unified-store contract).
+  5. State persistence — write the watermark, simulate a daemon restart
+     (reload module, reset _state), assert no double-processing.
+
+The fixture pattern mirrors ``tests/test_approvals_local_store.py`` —
+isolated per-test DuckDB under ``tmp_path`` via the
+``CLAWMETRY_LOCAL_STORE_PATH`` env var.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _ts(seconds_offset: float = 0.0) -> str:
+    """Deterministic ISO-8601 ts so test data is sortable + stable across
+    test runs. Lexicographic == chronological for this format."""
+    base = 1_700_000_000  # 2023-11-14T22:13:20Z; long before any real ingest
+    t = base + seconds_offset
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(t))
+
+
+def _msg_event(eid: str, sid: str, ts: str, *,
+               agent_type: str = "openclaw",
+               role: str = "assistant",
+               content: list | None = None) -> dict:
+    """Build a row in the shape ``sync._local_ingest_session_batch`` would
+    write for an OpenClaw / Anthropic-style transcript event."""
+    return {
+        "id": eid,
+        "agent_type": agent_type,
+        "node_id": "node-test",
+        "agent_id": "main",
+        "session_id": sid,
+        "event_type": "message",
+        "ts": ts,
+        "data": {
+            "type": "message",
+            "timestamp": ts,
+            "message": {
+                "role": role,
+                "content": content or [],
+            },
+        },
+    }
+
+
+def _toolcall_block(name: str, args: dict, *, blk_id: str = "tc-1",
+                    style: str = "openclaw") -> dict:
+    """Both flavours of tool-invocation block. ``openclaw`` uses
+    ``toolCall`` + ``arguments``; ``anthropic`` uses ``tool_use`` + ``input``.
+    Both must be detected by the watcher."""
+    if style == "anthropic":
+        return {"type": "tool_use", "id": blk_id, "name": name, "input": args}
+    return {"type": "toolCall", "id": blk_id, "name": name, "arguments": args}
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def watcher(tmp_path, monkeypatch):
+    """Reload local_store + approvals against an isolated DuckDB and a
+    sync-state.json under tmp_path. Captures every process_tool_call
+    invocation for assertion."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+
+    # Reload local_store FIRST so its module-level path constants pick up
+    # the env vars, then reload approvals so its lazy ``from clawmetry
+    # import local_store`` resolves to the freshly-loaded module.
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.approvals as ap
+    importlib.reload(ap)
+
+    # Redirect the watermark file into the per-test tmp dir so we don't
+    # touch the developer's real ~/.clawmetry/sync-state.json.
+    state_path = tmp_path / "sync-state.json"
+    monkeypatch.setattr(ap, "_STATE_PATH", state_path)
+    # Force the in-memory watermark mirror to re-prime from disk.
+    ap._state["last_check_ts"] = None
+    ap._state["seen_ids_at_boundary"] = set()
+
+    # Capture every process_tool_call invocation. Replace it on the module
+    # and turn off the threading.Thread spawn so assertions are
+    # deterministic (real watcher fires-and-forgets in a daemon thread).
+    captured: list[dict] = []
+
+    def _fake_process(api_key, node_id, session_id, tool_call_id,
+                      tool_name, args, policies):
+        captured.append({
+            "api_key": api_key,
+            "node_id": node_id,
+            "session_id": session_id,
+            "tool_call_id": tool_call_id,
+            "tool_name": tool_name,
+            "args": args,
+            "policies": policies,
+        })
+
+    monkeypatch.setattr(ap, "process_tool_call", _fake_process)
+
+    class _SyncThread:
+        """Drop-in for threading.Thread that runs synchronously on .start().
+        Lets the test assert process_tool_call was invoked without sleeping
+        for the daemon thread to schedule. We can't monkey-patch
+        ``threading.Thread`` globally — local_store's flusher uses it too
+        with kwargs (``name=``) that this stub doesn't accept. Instead we
+        replace the *module-bound* reference inside ``approvals``."""
+        def __init__(self, target=None, args=(), kwargs=None, daemon=False, **_kw):
+            self._target = target
+            self._args = args
+            self._kwargs = kwargs or {}
+        def start(self):
+            if self._target is not None:
+                self._target(*self._args, **self._kwargs)
+
+    # Bind the stub on a shim threading module so only ``ap.threading.Thread``
+    # is replaced, not the real module that local_store also imports.
+    import types as _types
+    _shim = _types.SimpleNamespace(Thread=_SyncThread, Event=ap.threading.Event)
+    monkeypatch.setattr(ap, "threading", _shim)
+
+    # A fixed policy that matches every tool call. The watcher only spawns
+    # process_tool_call when at least one policy is loaded; the fake above
+    # ignores the policy match, so any non-empty list works.
+    policies = [{
+        "name": "match-all",
+        "tool": "",
+        "command_regex": None,
+        "command_not_regex": None,
+        "args_regex": None,
+        "action": "require_approval",
+        "timeout": 60,
+        "on_timeout": "deny",
+    }]
+
+    yield ap, ls, captured, policies, state_path
+
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+# ── 1. happy path ─────────────────────────────────────────────────────────
+
+
+def test_watcher_dispatches_three_toolcalls(watcher):
+    """Three assistant events, each with one toolCall block → three
+    process_tool_call invocations with the expected payload shape."""
+    ap, ls, captured, policies, _ = watcher
+    store = ls.get_store()
+
+    # Anchor watermark to "before the test events" so they're all visible.
+    ap._state["last_check_ts"] = _ts(-10)
+
+    for i in range(3):
+        store.ingest(_msg_event(
+            eid=f"ev-{i}",
+            sid=f"sess-{i}",
+            ts=_ts(i),
+            content=[_toolcall_block(
+                name=f"bash_{i}",
+                args={"cmd": f"echo {i}"},
+                blk_id=f"tc-{i}",
+            )],
+        ))
+    store._flush_now()
+
+    n = ap.watch_iteration("api-key-test", "node-test", policies=policies)
+    assert n == 3
+    assert len(captured) == 3
+
+    # Most-recent-first ordering from query_events; sort by tool_call_id
+    # for stable assertions.
+    by_id = {c["tool_call_id"]: c for c in captured}
+    assert set(by_id) == {"tc-0", "tc-1", "tc-2"}
+    assert by_id["tc-0"]["session_id"] == "sess-0"
+    assert by_id["tc-0"]["tool_name"] == "bash_0"
+    assert by_id["tc-0"]["args"] == {"cmd": "echo 0"}
+    assert by_id["tc-2"]["tool_name"] == "bash_2"
+
+
+# ── 2. dedup / watermark advances ─────────────────────────────────────────
+
+
+def test_watcher_does_not_redispatch_on_second_pass(watcher):
+    """One event → first watch_iteration fires once → second pass sees
+    nothing new (watermark advanced past the row's ts)."""
+    ap, ls, captured, policies, _ = watcher
+    store = ls.get_store()
+    ap._state["last_check_ts"] = _ts(-10)
+
+    store.ingest(_msg_event(
+        eid="ev-once", sid="sess-once", ts=_ts(0),
+        content=[_toolcall_block("rm", {"cmd": "rm -rf /tmp/x"}, blk_id="tc-once")],
+    ))
+    store._flush_now()
+
+    first = ap.watch_iteration("k", "n", policies=policies)
+    assert first == 1
+    assert len(captured) == 1
+
+    # Second pass — no new ingest, watermark has moved past the row.
+    second = ap.watch_iteration("k", "n", policies=policies)
+    assert second == 0
+    assert len(captured) == 1, "process_tool_call must not be re-invoked"
+
+
+# ── 3. mixed event types ──────────────────────────────────────────────────
+
+
+def test_watcher_skips_messages_without_toolcall(watcher):
+    """A plain assistant text message must not fire process_tool_call;
+    only the message that carries a toolCall block does."""
+    ap, ls, captured, policies, _ = watcher
+    store = ls.get_store()
+    ap._state["last_check_ts"] = _ts(-10)
+
+    # No-toolCall: just a text block.
+    store.ingest(_msg_event(
+        eid="ev-text", sid="sess-A", ts=_ts(0),
+        content=[{"type": "text", "text": "thinking out loud"}],
+    ))
+    # With a toolCall.
+    store.ingest(_msg_event(
+        eid="ev-tool", sid="sess-A", ts=_ts(1),
+        content=[_toolcall_block("bash", {"cmd": "ls"}, blk_id="tc-yes")],
+    ))
+    store._flush_now()
+
+    n = ap.watch_iteration("k", "n", policies=policies)
+    assert n == 1
+    assert len(captured) == 1
+    assert captured[0]["tool_call_id"] == "tc-yes"
+
+
+# ── 4. non-OpenClaw adapter (Hermes) ──────────────────────────────────────
+
+
+def test_watcher_processes_non_openclaw_adapter(watcher):
+    """Same toolCall but stored under agent_type='hermes' (Anthropic-style
+    ``tool_use`` block, ``input`` instead of ``arguments``). Proves the
+    PRD acceptance: the watcher is adapter-agnostic now."""
+    ap, ls, captured, policies, _ = watcher
+    store = ls.get_store()
+    ap._state["last_check_ts"] = _ts(-10)
+
+    store.ingest(_msg_event(
+        eid="ev-hermes", sid="sess-hermes", ts=_ts(0),
+        agent_type="hermes",
+        content=[_toolcall_block(
+            "bash", {"command": "uname -a"},
+            blk_id="tc-hermes",
+            style="anthropic",
+        )],
+    ))
+    store._flush_now()
+
+    n = ap.watch_iteration("k", "n", policies=policies)
+    assert n == 1
+    assert len(captured) == 1
+    assert captured[0]["session_id"] == "sess-hermes"
+    assert captured[0]["tool_name"] == "bash"
+    # ``input`` was promoted to ``args`` regardless of the wire-format key.
+    assert captured[0]["args"] == {"command": "uname -a"}
+
+
+# ── 5. state persistence across daemon restart ────────────────────────────
+
+
+def test_watermark_survives_daemon_restart(watcher, monkeypatch):
+    """First watcher run advances the watermark on disk; resetting the
+    in-memory mirror (simulating a daemon restart) must reload from disk
+    and skip the already-processed event — no double-fire."""
+    ap, ls, captured, policies, state_path = watcher
+    store = ls.get_store()
+    ap._state["last_check_ts"] = _ts(-10)
+
+    store.ingest(_msg_event(
+        eid="ev-pre-restart", sid="sess-X", ts=_ts(0),
+        content=[_toolcall_block("bash", {"cmd": "true"}, blk_id="tc-pre")],
+    ))
+    store._flush_now()
+
+    n1 = ap.watch_iteration("k", "n", policies=policies)
+    assert n1 == 1
+    assert state_path.exists(), "watermark must be persisted after first iteration"
+
+    # Simulate a daemon restart: clear the in-memory mirror, leave the
+    # store + on-disk watermark intact. The next iteration must reload the
+    # watermark from disk and NOT re-fire on the same event.
+    captured.clear()
+    ap._state["last_check_ts"] = None
+    ap._state["seen_ids_at_boundary"] = set()
+
+    n2 = ap.watch_iteration("k", "n", policies=policies)
+    assert n2 == 0, "post-restart pass must not redispatch the already-seen event"
+    assert captured == []
+
+    # In-memory watermark must now match what we persisted.
+    import json as _j
+    with state_path.open() as fh:
+        blob = _j.load(fh)
+    assert blob.get(ap._STATE_KEY) is not None
+    assert ap._state["last_check_ts"] == blob[ap._STATE_KEY]


### PR DESCRIPTION
## Summary

Rewrite the approvals watcher to read from the unified DuckDB event store instead of glob-tailing OpenClaw's JSONL files.

**The gap:** ``clawmetry/approvals.py:watch_iteration`` was hardcoded to ``~/.openclaw/agents/main/sessions/*.jsonl`` and tracked per-file byte offsets. That meant Hermes, Codex, and Claude Code adapters were invisible to the policy engine — even though their events already lived in the same DuckDB store every other surface reads. (PRD vivekchand/clawmetry-cloud#779, audit report P0 #6.)

**The fix:** the watcher now calls ``local_store.query_events(event_type='message', since=last_check_ts)`` (and ``event_type='assistant'`` for adapters that emit under that label), walks each row's ``data.message.content[]`` for both ``toolCall`` (OpenClaw) and ``tool_use`` (Anthropic Messages) blocks, and dispatches matches to the existing ``process_tool_call`` flow unchanged.

**Acceptance criterion:** a Hermes/Codex/Claude Code agent's toolCall is now subject to the same policy rules as an OpenClaw one. Single event store, single code path.

## Key changes

- `clawmetry/approvals.py`
  - Removed: `_sessions_dir()`, `_file_offsets`, the glob+tail loop, and the ``import glob`` / OpenClaw filesystem assumptions.
  - Added: `_extract_tool_blocks()` (handles three on-the-wire shapes: nested message, flattened content, top-level tool block), `_query_new_events()` (issues two `query_events` calls and merges), and persisted state in `~/.clawmetry/sync-state.json` under `approvals_last_check_ts` + `approvals_seen_ids_at_boundary`.
  - Backward-compat note added to the module docstring explaining the JSONL paths are no longer scanned.
  - `process_tool_call`, the cloud round-trip, the policy-loader, the kill-session logic, and `watcher_loop`'s 2 s polling cadence are all unchanged.
- `tests/test_approvals_duckdb_watcher.py` (new)
  - Happy path (3 events → 3 dispatches with correct payload)
  - Dedup across polls (watermark + boundary-id set)
  - Mixed event types (only assistant-with-toolCall fires)
  - Non-OpenClaw adapter (`agent_type='hermes'`, `tool_use` block)
  - State persistence across a simulated daemon restart

## Test plan

- [x] `python3 -m pytest tests/test_approvals_duckdb_watcher.py -v` — 5/5 pass
- [x] `python3 -m pytest tests/test_approvals*.py -v` — 15/15 pass (no regression in `test_approvals_local_store.py`)
- [x] `python3 -c "import ast; ast.parse(open('clawmetry/approvals.py').read())"` — syntax OK
- [x] Ruff: only the two pre-existing E401 warnings on multi-import lines I didn't touch (`urllib.request, urllib.error` and `importlib.util as _ilu, sys as _s, os as _o`) remain — same count before vs after this PR

## Out of scope (separate PRs)

- PR-C: dedup the duplicate `run_daemon` in `clawmetry/sync.py`
- The cloud `/api/approvals/request` + `/api/approvals/<id>` endpoints already exist and are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)