### PR TITLE
feat(sync): local alerts evaluator reads DuckDB → POSTs cloud dispatch (PRD #779 PR-D pt2, audit P0 #1+#2)

### DIFF
--- a/clawmetry/alert_evaluator.py
+++ b/clawmetry/alert_evaluator.py
@@ -1,0 +1,506 @@
+"""Local alert-rule evaluator — pure logic, no I/O (PRD #779 PR-D part 2).
+
+Used by the OSS daemon to walk DuckDB events against the cached alert rules
+that the cloud relays via the heartbeat ``cache_pushes`` channel, fire matches
+locally, and POST the result to the cloud's ``/api/cloud/alerts/dispatch``
+endpoint for notification fan-out.
+
+Why a separate module:
+* Keeps the evaluator pure (rules + events in, matches + state mutation out)
+  so the unit tests can exercise every condition shape without touching
+  DuckDB, the network, or daemon globals.
+* Lets ``clawmetry/sync.py`` stay focused on I/O (DuckDB read, HTTP POST,
+  state persistence). Closes the architectural inversion called out in the
+  2026-05-13 audit (P0 #1 + #2 — alerts were 100% cloud-evaluated and the
+  local trigger had never fired in this daemon's lifetime).
+
+Rule shape (mirrors what the cloud relays into ``alert_rules.condition_json``;
+see ``clawmetry/local_store.py`` and ``clawmetry/sync.py:_apply_pending_write``):
+
+    {
+      "id": "<rule-id>",
+      "name": "<human label>",
+      "enabled": true,
+      "condition_json": {
+        # PRD #779 spec types (preferred — event-stream native):
+        "type": "count_over_threshold" | "error_rate" | "tool_call_pattern",
+        # Common fields:
+        "event_type": "<event_type>",            # which events to count
+        "threshold": <int|float>,                 # firing line
+        "window_sec": <int>,                      # rolling window
+        "cooldown_sec": <int>,                    # min seconds between fires
+        # tool_call_pattern only:
+        "tool_name": "<name substring or regex-lite>",
+        "arg_pattern": "<substring matched against str(data)>",
+        # legacy cloud aliases — best-effort mapping (see _normalise_rule):
+        "alert_type": "daily_spend" | "session_cost" | "token_velocity"
+                    | "error_rate" | "cron_failure" | "node_offline",
+        "threshold_value": <int|float>,
+      },
+      ...other fields are passed through untouched
+    }
+
+The evaluator never raises on bad input — a malformed rule is logged once and
+skipped. The daemon must keep ticking even if one cloud-authored rule is
+broken.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+log = logging.getLogger("clawmetry.alert_evaluator")
+
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+# Sensible fallbacks when a rule omits these fields. Tuned for the common case
+# (cost / error / velocity rules running on a single-developer node).
+DEFAULT_WINDOW_SEC = 300        # 5-minute rolling window
+DEFAULT_COOLDOWN_SEC = 3600     # 1-hour debounce (matches cloud `_debounce_ok`)
+
+
+# Map cloud-side ``alert_type`` strings to PRD spec evaluator types.
+# Anything not in this map is treated as ``count_over_threshold`` against the
+# rule's ``event_type`` field, which is a safe under-fire default — it won't
+# spam channels with bogus alerts, just under-cover a niche rule shape until
+# we wire its evaluator below. TODO(PRD #779 part 3): add evaluators for
+# ``daily_spend`` (sum cost over UTC day), ``session_cost`` (per-session
+# rollup), ``cron_failure`` (consecutive cron exit_code != 0).
+_LEGACY_ALERT_TYPE_MAP = {
+    "error_rate":      "error_rate",
+    "token_velocity":  "count_over_threshold",  # threshold tokens/min
+    "node_offline":    "count_over_threshold",  # treat absence as count==0
+    "daily_spend":     "count_over_threshold",  # TODO real cost-sum impl
+    "session_cost":    "count_over_threshold",  # TODO real per-session impl
+    "cron_failure":    "count_over_threshold",  # TODO real cron impl
+}
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def evaluate(
+    rules: list[dict[str, Any]] | None,
+    events: list[dict[str, Any]] | None,
+    last_eval_state: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Pure evaluator. Walks ``events`` against ``rules``, returns matches.
+
+    No I/O. ``last_eval_state`` is mutated in place to remember the most
+    recent fire time per rule so a second call within the cooldown window
+    won't re-fire the same rule. Used by the daemon loop and unit tests
+    alike.
+
+    Args:
+        rules: rows from ``local_store.query_alert_rules()``. Each rule is the
+            dict shape stored in DuckDB (``id``, ``name``, ``enabled``,
+            ``condition_json`` decoded back to a dict, etc.). ``None`` and
+            empty lists are tolerated.
+        events: rows from ``local_store.query_events()`` ordered most-recent
+            first. ``None`` and empty lists are tolerated.
+        last_eval_state: per-rule cooldown bookkeeping. Schema:
+            ``{rule_id: {"last_fired_ts": <epoch_seconds>, "last_event_id": <id>}}``.
+            Mutated in place. ``None`` raises (callers should pass an empty
+            dict instead — explicit > silent).
+
+    Returns:
+        List of match dicts ready for the dispatch POST. Each match has:
+            ``rule``: the rule dict (so dispatcher can read id / name / channels)
+            ``event``: the triggering event row (so dispatcher can attach
+                event_id + ts to the cloud notification)
+            ``summary``: short human string ("rule X fired: 7 events of …")
+            ``metadata``: numeric / contextual fields the cloud may want
+    """
+    if last_eval_state is None:
+        raise TypeError("last_eval_state must be a dict (got None)")
+    if not rules:
+        return []
+    if not events:
+        events = []
+
+    # Sort events oldest-first so windowed counts are deterministic and the
+    # "triggering" event is the one that crossed the threshold (not the most
+    # recent of an already-firing window). Stable sort on the ``ts`` ISO
+    # string is correct for our timestamp shape (zero-padded UTC isoformat).
+    events_chrono = sorted(events, key=lambda e: (e.get("ts") or "", e.get("id") or ""))
+
+    matches: list[dict[str, Any]] = []
+    now = time.time()
+    for raw_rule in rules:
+        try:
+            rule = _normalise_rule(raw_rule)
+        except Exception as e:
+            log.warning("alerts: skipping malformed rule %r: %s", raw_rule.get("id"), e)
+            continue
+        if not rule:
+            continue
+        if not rule.get("enabled", True):
+            continue
+        rid = rule["id"]
+        memo = last_eval_state.setdefault(rid, {})
+        cooldown = float(rule.get("cooldown_sec") or DEFAULT_COOLDOWN_SEC)
+        last_fired = float(memo.get("last_fired_ts") or 0)
+        if cooldown > 0 and (now - last_fired) < cooldown:
+            # Within cooldown — skip even if matching events exist. Cooldown
+            # protects channels from notification storms.
+            continue
+
+        try:
+            match = _evaluate_one(rule, events_chrono)
+        except Exception as e:
+            log.warning("alerts: rule %s evaluator errored: %s", rid, e)
+            continue
+        if not match:
+            continue
+
+        # Dedup: if we already fired on this exact event id, don't re-fire.
+        # Cooldown above usually catches this; the event-id check is the
+        # belt-and-braces case where cooldown was 0 or expired and the same
+        # event window is still being walked.
+        evt_id = (match.get("event") or {}).get("id")
+        if evt_id and memo.get("last_event_id") == evt_id:
+            continue
+
+        memo["last_fired_ts"] = now
+        if evt_id:
+            memo["last_event_id"] = evt_id
+
+        matches.append({
+            "rule":     raw_rule,        # pass through the unmodified row
+            "event":    match["event"],
+            "summary":  match["summary"],
+            "metadata": match.get("metadata", {}),
+        })
+
+    return matches
+
+
+# ── Rule normalisation ────────────────────────────────────────────────────────
+
+
+def _normalise_rule(raw_rule: dict[str, Any]) -> dict[str, Any] | None:
+    """Project a raw DuckDB ``alert_rules`` row into the evaluator's expected
+    shape. Reads ``condition_json`` (the cloud rule body) and surfaces the
+    fields the evaluator branches on. Returns ``None`` for rules that are too
+    malformed to even attempt (no id, no condition body)."""
+    rid = raw_rule.get("id")
+    if not rid:
+        return None
+    cond = raw_rule.get("condition_json")
+    if isinstance(cond, str):
+        # Defensive — query_alert_rules already json-decodes, but if a caller
+        # passes a raw string we try once. A non-JSON string means the row
+        # is corrupt; refuse it.
+        import json as _json
+        try:
+            cond = _json.loads(cond)
+        except Exception:
+            return None
+    if not isinstance(cond, dict):
+        return None
+
+    rule_type = cond.get("type")
+    if not rule_type:
+        # Legacy cloud rule — translate ``alert_type`` to evaluator type.
+        legacy = (cond.get("alert_type") or "").strip()
+        if not legacy:
+            # Rule has neither a `type` nor a legacy `alert_type` — there's
+            # no condition to evaluate. Treat as malformed and skip rather
+            # than firing on every event.
+            return None
+        rule_type = _LEGACY_ALERT_TYPE_MAP.get(legacy, "count_over_threshold")
+
+    # Threshold may be under either name. Accept either.
+    threshold = cond.get("threshold")
+    if threshold is None:
+        threshold = cond.get("threshold_value")
+    if threshold is None:
+        threshold = 1  # Default — fire on the first matching event.
+
+    # Convert threshold to a numeric (cloud may send strings from the form).
+    try:
+        threshold = float(threshold)
+    except (TypeError, ValueError):
+        threshold = 1.0
+
+    return {
+        "id":           str(rid),
+        "name":         raw_rule.get("name") or cond.get("name") or "",
+        "enabled":      bool(raw_rule.get("enabled", True)),
+        "type":         rule_type,
+        "event_type":   cond.get("event_type"),
+        "threshold":    threshold,
+        "window_sec":   _coerce_int(cond.get("window_sec"), DEFAULT_WINDOW_SEC),
+        "cooldown_sec": _coerce_int(cond.get("cooldown_sec"), DEFAULT_COOLDOWN_SEC),
+        "tool_name":    cond.get("tool_name"),
+        "arg_pattern":  cond.get("arg_pattern"),
+        # Pass condition through so evaluators that need niche fields (channel
+        # ids, error-event-type list, …) can read them without a re-decode.
+        "condition":    cond,
+    }
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+# ── Per-type evaluators ───────────────────────────────────────────────────────
+
+
+def _evaluate_one(
+    rule: dict[str, Any],
+    events_chrono: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Dispatch on ``rule['type']``. Returns the match dict (rule-agnostic
+    shape) or ``None`` when the rule didn't fire."""
+    rt = rule.get("type")
+    if rt == "count_over_threshold":
+        return _eval_count_over_threshold(rule, events_chrono)
+    if rt == "error_rate":
+        return _eval_error_rate(rule, events_chrono)
+    if rt == "tool_call_pattern":
+        return _eval_tool_call_pattern(rule, events_chrono)
+    # Unknown type — log once and skip. (PRD says: leave a TODO. Here we
+    # explicitly under-fire instead of mis-firing.)
+    log.debug("alerts: unsupported rule type %r — skipped (rule_id=%s)",
+              rt, rule.get("id"))
+    return None
+
+
+def _eval_count_over_threshold(
+    rule: dict[str, Any],
+    events_chrono: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Fire when ``>= threshold`` events of ``event_type`` occur in
+    ``window_sec``. Triggering event = the one whose ts pushes the rolling
+    window count over the line."""
+    et = rule.get("event_type")
+    window_sec = rule["window_sec"]
+    threshold = rule["threshold"]
+
+    # Filter by event_type when set; otherwise count every event (which is
+    # only useful for very loud rules — daemon will gate via the rule
+    # config — but the evaluator stays generic).
+    matching = [e for e in events_chrono
+                if (et is None or e.get("event_type") == et)]
+    if not matching:
+        return None
+    if threshold <= 0:
+        return None
+
+    # Rolling window: for each event, how many matching events fall within
+    # ``window_sec`` ending at this event's ts? When that count first crosses
+    # the threshold, we fire on that event and stop (cooldown handles repeat
+    # suppression).
+    for i, e in enumerate(matching):
+        ts_end = _parse_iso_ts(e.get("ts"))
+        if ts_end is None:
+            continue
+        ts_start = ts_end - window_sec
+        # Count events within [ts_start, ts_end]. The list is chronological
+        # so we walk backwards from i.
+        count = 0
+        for j in range(i, -1, -1):
+            ts_j = _parse_iso_ts(matching[j].get("ts"))
+            if ts_j is None:
+                continue
+            if ts_j < ts_start:
+                break
+            count += 1
+        if count >= threshold:
+            return {
+                "event":   e,
+                "summary": (f"rule fired: {count} '{et or 'any'}' events "
+                            f"in {window_sec}s (threshold={int(threshold)})"),
+                "metadata": {
+                    "count":      count,
+                    "threshold":  threshold,
+                    "window_sec": window_sec,
+                    "event_type": et,
+                },
+            }
+    return None
+
+
+def _eval_error_rate(
+    rule: dict[str, Any],
+    events_chrono: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Fire when error-event fraction over total events in ``window_sec``
+    exceeds ``threshold`` (interpreted as a fraction in [0, 1]; values >1
+    are treated as percentages and divided by 100). Min sample size of 5
+    events to avoid firing on trivially small windows."""
+    window_sec = rule["window_sec"]
+    threshold = rule["threshold"]
+    if threshold > 1.0:
+        threshold = threshold / 100.0
+    if threshold <= 0:
+        return None
+
+    # An event is considered an error when its event_type contains "error",
+    # ``data.status`` indicates failure, ``data.error`` is truthy, or the
+    # explicit ``rule['condition'].get('error_event_types')`` list matches.
+    error_types = set(rule.get("condition", {}).get("error_event_types") or [])
+
+    def _is_error(e: dict[str, Any]) -> bool:
+        et = (e.get("event_type") or "").lower()
+        if "error" in et or "fail" in et:
+            return True
+        if error_types and e.get("event_type") in error_types:
+            return True
+        data = e.get("data")
+        if isinstance(data, dict):
+            if data.get("error"):
+                return True
+            status = (data.get("status") or "").lower()
+            if status in ("error", "failed", "failure"):
+                return True
+        return False
+
+    if not events_chrono:
+        return None
+
+    # Walk forward; at each event's ts, look back over window_sec.
+    for i, e in enumerate(events_chrono):
+        ts_end = _parse_iso_ts(e.get("ts"))
+        if ts_end is None:
+            continue
+        ts_start = ts_end - window_sec
+        total = 0
+        errors = 0
+        for j in range(i, -1, -1):
+            ts_j = _parse_iso_ts(events_chrono[j].get("ts"))
+            if ts_j is None:
+                continue
+            if ts_j < ts_start:
+                break
+            total += 1
+            if _is_error(events_chrono[j]):
+                errors += 1
+        if total < 5:
+            continue  # Sample size too small to be statistically interesting.
+        rate = errors / total
+        if rate >= threshold:
+            return {
+                "event":   e,
+                "summary": (f"rule fired: error rate {rate:.1%} "
+                            f"({errors}/{total}) in {window_sec}s "
+                            f"(threshold={threshold:.1%})"),
+                "metadata": {
+                    "errors":     errors,
+                    "total":      total,
+                    "rate":       round(rate, 4),
+                    "threshold":  threshold,
+                    "window_sec": window_sec,
+                },
+            }
+    return None
+
+
+def _eval_tool_call_pattern(
+    rule: dict[str, Any],
+    events_chrono: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Fire on the first event whose tool name matches ``tool_name`` AND
+    whose ``str(data)`` matches ``arg_pattern`` (substring or simple regex).
+
+    Tool name is matched either against the explicit ``data.tool_name`` /
+    ``data.name`` fields, or against substrings in ``str(data)`` (defensive,
+    since multiple agent frameworks store the tool name in different places).
+    """
+    tool_name = (rule.get("tool_name") or "").strip()
+    arg_pattern = rule.get("arg_pattern")
+    if not tool_name and not arg_pattern:
+        return None
+
+    pattern_re: re.Pattern[str] | None = None
+    if arg_pattern:
+        try:
+            pattern_re = re.compile(arg_pattern, re.IGNORECASE)
+        except re.error:
+            # Fall back to substring match on a malformed regex.
+            pattern_re = None
+
+    for e in events_chrono:
+        data = e.get("data")
+        data_str = ""
+        explicit_name = ""
+        if isinstance(data, dict):
+            explicit_name = (data.get("tool_name") or data.get("name") or "")
+            try:
+                import json as _json
+                data_str = _json.dumps(data, default=str)
+            except Exception:
+                data_str = str(data)
+        elif isinstance(data, str):
+            data_str = data
+
+        # Tool-name match: explicit field exact-eq OR substring in serialised
+        # data. Case-insensitive.
+        name_ok = True
+        if tool_name:
+            tn_lc = tool_name.lower()
+            name_ok = (
+                explicit_name.lower() == tn_lc
+                or tn_lc in explicit_name.lower()
+                or tn_lc in data_str.lower()
+            )
+        if not name_ok:
+            continue
+
+        # Arg pattern match.
+        arg_ok = True
+        if arg_pattern:
+            if pattern_re is not None:
+                arg_ok = bool(pattern_re.search(data_str))
+            else:
+                arg_ok = arg_pattern.lower() in data_str.lower()
+        if not arg_ok:
+            continue
+
+        return {
+            "event":   e,
+            "summary": (f"rule fired: tool_call_pattern matched "
+                        f"tool={tool_name!r} arg_pattern={arg_pattern!r}"),
+            "metadata": {
+                "tool_name":   tool_name,
+                "arg_pattern": arg_pattern,
+                "event_type":  e.get("event_type"),
+            },
+        }
+    return None
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _parse_iso_ts(ts: str | None) -> float | None:
+    """Parse an ISO 8601 timestamp into epoch seconds. Returns None on bad
+    input (which causes the evaluator to skip that event — preferred over
+    raising)."""
+    if not ts or not isinstance(ts, str):
+        return None
+    try:
+        # Python's fromisoformat handles "2026-05-13T04:28:43Z" only on
+        # 3.11+. Strip a trailing Z and add an explicit offset for older
+        # interpreters too.
+        s = ts.rstrip()
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+__all__ = ["evaluate", "DEFAULT_WINDOW_SEC", "DEFAULT_COOLDOWN_SEC"]

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -4831,6 +4831,10 @@ def run_daemon() -> None:
         time.time()
     )  # already synced at startup; next run after log_sync_interval
     consecutive_hb_failures = 0
+    # Alerts evaluator (PRD #779 PR-D pt2). 0 = fire on first cycle so we
+    # exercise the dispatch path immediately if rules + matching events are
+    # already present from startup backfill.
+    last_alerts_eval = 0.0
 
     while True:
         try:
@@ -4861,6 +4865,31 @@ def run_daemon() -> None:
                 log.info(
                     f"Synced {ev} events, {lg} log lines, {mem} memory files, {crons} crons, {sm} session rows ({enc})"
                 )
+
+            # ── Alerts evaluator (PRD #779 PR-D pt2, audit P0 #1 + #2) ──
+            # Reads cached rules + recent events from the local DuckDB and
+            # POSTs each match to the cloud's /api/cloud/alerts/dispatch
+            # endpoint for notification fan-out. Throttled to
+            # ALERTS_EVAL_INTERVAL_SEC. Failure is logged but never raises
+            # into the sync cycle — alerts are best-effort relative to the
+            # ingest path.
+            now_alerts = time.time()
+            if (now_alerts - last_alerts_eval) >= ALERTS_EVAL_INTERVAL_SEC:
+                try:
+                    n_alerts = evaluate_alerts(config, state)
+                    if n_alerts:
+                        log.info(
+                            f"alerts: dispatched {n_alerts} match(es)"
+                        )
+                except Exception as _ae:
+                    log.warning(f"alerts: evaluator tick errored: {_ae}")
+                last_alerts_eval = now_alerts
+                # Persist the eval state (last_eval_ts, cooldown memo) so
+                # cooldown survives a daemon restart.
+                try:
+                    save_state(state)
+                except Exception:
+                    pass
 
             # Re-mirror Docker data if running in Docker mode
             if hasattr(detect_paths, "_docker_cid") or any(
@@ -5222,69 +5251,135 @@ def sync_autonomy(config, state, paths):
         return 0
 
 
-ALERTS_EVAL_INTERVAL_SEC = 300  # Re-evaluate alerts every 5 minutes
+ALERTS_EVAL_INTERVAL_SEC = 60  # Re-evaluate alerts every 60s (PRD #779)
+# Window for the events read from DuckDB on each tick. Wider than the
+# evaluation interval so a slow tick doesn't drop events on the floor.
+_ALERTS_EVENT_LOOKBACK_SEC = 600
+# Cap rows fetched per tick. Generous for a single-node alert evaluator;
+# rolling-window math is O(N²) in the worst case but N is small.
+_ALERTS_EVENT_LIMIT = 2000
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _iso_now_minus(seconds: int) -> str:
+    from datetime import timedelta as _td
+    return (datetime.now(timezone.utc) - _td(seconds=seconds)).isoformat()
 
 
 def evaluate_alerts(config: dict, state: dict) -> int:
-    """Trigger cloud-side alert evaluation for this node.
+    """Local DuckDB evaluation -> cloud dispatch on match (PRD #779 PR-D pt2).
 
-    .. warning::
-       **Currently UNREACHABLE.** This function has zero callers in the live
-       daemon loop (see ``run_daemon`` at the top of this module). The audit
-       on 2026-05-13 (P0 #2 + P0 #3) found a duplicate ``run_daemon`` shadow
-       at the bottom of this file that *did* call ``evaluate_alerts`` every
-       60s, but that shadow was unreachable itself (the module-level
-       ``if __name__ == "__main__"`` guard fires before the second def runs).
-       The shadow has been deleted; this function is intentionally left in
-       place pending PR-D (clawmetry-cloud#779), which will rewrite it to
-       read from DuckDB and rewire it into the live ``run_daemon``. Until
-       then, alert evaluation is purely cloud-driven (cron-tick or webhook).
+    Closes the architectural inversion called out in the 2026-05-13 audit
+    (P0 #1 + P0 #2): the daemon now reads the events it just wrote to
+    DuckDB, walks the cloud-cached alert rules locally via
+    ``clawmetry.alert_evaluator``, and POSTs each match to the cloud's
+    ``/api/cloud/alerts/dispatch`` endpoint (which fans out to Slack/email/
+    PagerDuty). Cloud no longer evaluates rules — it just dispatches
+    notifications for matches the local node certifies.
 
-    The cloud holds the rules and runs the actual threshold checks against the
-    sessions/events tables it already syncs from this daemon. We just poke the
-    `/api/internal/evaluate-alerts` endpoint on a schedule.
+    Returns the count of dispatched matches. Persists ``alerts_last_eval_ts``
+    + ``alerts_eval_memo`` into ``state`` so cooldown survives daemon
+    restart. Skipped silently when:
+      * the user is OSS-only (no ``cm_`` api key) — alerts is Cloud-Pro only,
+      * no rules are cached locally (cloud hasn't authored or pushed any),
+      * the local store is unreachable (the function never raises into the
+        daemon loop — at most logs a WARNING and returns 0).
 
-    Throttled to ALERTS_EVAL_INTERVAL_SEC because:
-      - The 60s sync tick is unnecessarily aggressive for cost / heartbeat /
-        cron-failure rules
-      - Cloud also enforces a 1-hour debounce per alert (`_debounce_ok`), so
-        more frequent calls would waste cycles, not catch more incidents
-
-    Skips silently if the user has no cloud account configured -- alerts is a
-    Cloud-Pro-only feature (see project_alerts_pro_feature memory).
+    See PRD ``clawmetry-cloud#779`` and the cloud endpoint shipped in
+    ``clawmetry-cloud#785`` for the dispatch payload contract.
     """
     api_key = config.get("api_key", "")
     node_id = config.get("node_id", "")
-    if not api_key or not api_key.startswith("cm_"):
-        return 0  # No cloud account: nothing to evaluate
-    if not node_id:
-        return 0
+    if not api_key or not api_key.startswith("cm_") or not node_id:
+        return 0  # OSS / unconfigured node: nothing to dispatch.
 
-    last = state.get("alerts_last_eval_ts", 0)
-    now = time.time()
-    if (now - last) < ALERTS_EVAL_INTERVAL_SEC:
+    try:
+        from clawmetry import local_store, alert_evaluator
+    except Exception as e:
+        log.warning("alerts: local_store/alert_evaluator import failed: %s", e)
         return 0
 
     try:
-        result = _post(
-            "/api/internal/evaluate-alerts",
-            {"node_id": node_id},
-            api_key,
-            timeout=20,
-        )
-        state["alerts_last_eval_ts"] = now
-        triggered = result.get("triggered") if isinstance(result, dict) else None
-        if triggered:
-            log.info(
-                "[alerts] evaluated %s rules, %s triggered",
-                result.get("evaluated", "?"),
-                len(triggered),
-            )
-        return len(triggered or [])
+        store = local_store.get_store()
     except Exception as e:
-        # Cloud may return 402 if user is on Free tier and alerts are gated;
-        # log once and don't keep retrying every cycle.
-        log.warning(f"alerts evaluation skipped: {e}")
-        # Still record the timestamp so we back off rather than retry on every tick
-        state["alerts_last_eval_ts"] = now
+        log.warning("alerts: local store unavailable: %s", e)
         return 0
+
+    # Scope to rules owned by this token. Same hash the cloud uses, so a
+    # multi-tenant local store (rare today) only fires this token's rules.
+    try:
+        owner_hash = _owner_hash_for_token(api_key)
+    except Exception:
+        owner_hash = None
+    try:
+        rules = store.query_alert_rules(
+            owner_hash=owner_hash,
+            enabled_only=True,
+            limit=200,
+        )
+    except Exception as e:
+        log.warning("alerts: query_alert_rules failed: %s", e)
+        return 0
+    if not rules:
+        return 0
+
+    # Read the recent slice of events. ``since`` is whichever is more recent
+    # of (last successful eval ts) or (now - lookback) — bounds the window
+    # so a daemon restart doesn't replay the entire DuckDB history.
+    last_eval_ts = state.get("alerts_last_eval_ts")
+    since = last_eval_ts or _iso_now_minus(_ALERTS_EVENT_LOOKBACK_SEC)
+    try:
+        events = store.query_events(since=since, limit=_ALERTS_EVENT_LIMIT)
+    except Exception as e:
+        log.warning("alerts: query_events failed: %s", e)
+        return 0
+
+    last_eval_state = state.setdefault("alerts_eval_memo", {})
+    if not isinstance(last_eval_state, dict):
+        last_eval_state = {}
+        state["alerts_eval_memo"] = last_eval_state
+
+    try:
+        matches = alert_evaluator.evaluate(rules, events, last_eval_state)
+    except Exception as e:
+        log.warning("alerts: evaluator errored: %s", e)
+        state["alerts_last_eval_ts"] = _iso_now()
+        return 0
+
+    dispatched = 0
+    for m in matches:
+        rule = m.get("rule") or {}
+        evt = m.get("event") or {}
+        try:
+            resp = _post(
+                "/api/cloud/alerts/dispatch",
+                {
+                    "rule_id":       rule.get("id"),
+                    "rule_name":     rule.get("name") or "",
+                    "node_id":       node_id,
+                    "event_id":      evt.get("id"),
+                    "event_summary": (m.get("summary") or "")[:500],
+                    "evaluated_at":  _iso_now(),
+                    "metadata":      m.get("metadata") or {},
+                },
+                api_key,
+                timeout=10,
+            )
+        except Exception as e:
+            log.warning("alerts: dispatch failed (rule=%s): %s",
+                        rule.get("id"), e)
+            continue
+        if isinstance(resp, dict) and resp.get("ok"):
+            dispatched += 1
+            if resp.get("deduped"):
+                log.debug("alerts: rule=%s dispatched (cloud deduped)",
+                          rule.get("id"))
+            else:
+                log.info("alerts: rule=%s dispatched -> %s",
+                         rule.get("id"), resp.get("dispatched") or [])
+
+    state["alerts_last_eval_ts"] = _iso_now()
+    return dispatched

--- a/tests/test_alert_evaluator_unit.py
+++ b/tests/test_alert_evaluator_unit.py
@@ -1,0 +1,359 @@
+"""Pure-unit tests for ``clawmetry.alert_evaluator`` (PRD #779 PR-D pt2).
+
+No DuckDB, no network, no daemon globals — exercises the evaluator's three
+condition types + dedup memo + degenerate inputs. Runs in <1s.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+from clawmetry import alert_evaluator  # noqa: E402
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _rule(rid, **cond):
+    """Build a DuckDB-shape rule row. ``cond`` is the condition_json body."""
+    return {
+        "id":             rid,
+        "name":           cond.pop("name", f"rule {rid}"),
+        "enabled":        cond.pop("enabled", True),
+        "condition_json": cond,
+    }
+
+
+def _events(et, ts_offsets, *, base_ts="2026-05-13T04:00:00+00:00"):
+    """Build a chronological list of events of type ``et``. ``ts_offsets`` is
+    a list of integer second offsets (event[i].ts = base_ts + offsets[i]).
+    Each event gets a unique id so dedup works."""
+    from datetime import datetime, timedelta, timezone
+    base = datetime.fromisoformat(base_ts)
+    if base.tzinfo is None:
+        base = base.replace(tzinfo=timezone.utc)
+    out = []
+    for i, off in enumerate(ts_offsets):
+        ts = (base + timedelta(seconds=off)).isoformat()
+        out.append({
+            "id":         f"{et}-{i}-{off}",
+            "event_type": et,
+            "ts":         ts,
+            "data":       {"i": i},
+        })
+    return out
+
+
+# ── 1. count_over_threshold ───────────────────────────────────────────────────
+
+
+def test_count_over_threshold_fires_when_above_threshold():
+    rule = _rule(
+        "r-count",
+        type="count_over_threshold",
+        event_type="error",
+        threshold=5,
+        window_sec=60,
+        cooldown_sec=0,
+    )
+    events = _events("error", [0, 5, 10, 15, 20])  # 5 events in 20s
+    memo = {}
+    matches = alert_evaluator.evaluate([rule], events, memo)
+    assert len(matches) == 1
+    m = matches[0]
+    assert m["rule"]["id"] == "r-count"
+    assert m["event"]["id"] == "error-4-20"  # the 5th event crosses the line
+    assert m["metadata"]["count"] == 5
+    assert m["metadata"]["threshold"] == 5
+    assert "5 'error' events" in m["summary"]
+
+
+def test_count_over_threshold_no_fire_under_threshold():
+    rule = _rule(
+        "r-count",
+        type="count_over_threshold",
+        event_type="error",
+        threshold=5,
+        window_sec=60,
+        cooldown_sec=0,
+    )
+    events = _events("error", [0, 5, 10])  # only 3 events
+    memo = {}
+    matches = alert_evaluator.evaluate([rule], events, memo)
+    assert matches == []
+
+
+def test_count_over_threshold_window_excludes_old_events():
+    """Events outside the rolling window should NOT contribute to the count."""
+    rule = _rule(
+        "r-count",
+        type="count_over_threshold",
+        event_type="error",
+        threshold=3,
+        window_sec=10,  # tight 10s window
+        cooldown_sec=0,
+    )
+    # 4 events spread across 60s — only 2 will fall inside any 10s window.
+    events = _events("error", [0, 20, 40, 60])
+    memo = {}
+    matches = alert_evaluator.evaluate([rule], events, memo)
+    assert matches == []
+
+
+def test_count_over_threshold_filters_by_event_type():
+    """Events of OTHER types must not contribute to the count."""
+    rule = _rule(
+        "r-count",
+        type="count_over_threshold",
+        event_type="error",
+        threshold=3,
+        window_sec=60,
+        cooldown_sec=0,
+    )
+    # 2 errors + 5 non-errors in the same window — should not fire.
+    events = (
+        _events("error", [0, 5])
+        + _events("info", [10, 15, 20, 25, 30])
+    )
+    memo = {}
+    matches = alert_evaluator.evaluate([rule], events, memo)
+    assert matches == []
+
+
+# ── 2. dedup memo / cooldown ─────────────────────────────────────────────────
+
+
+def test_dedup_memo_prevents_re_firing_same_event():
+    """Calling evaluate() twice with the same matching events should fire only
+    once (the second call's match is suppressed by the dedup memo)."""
+    rule = _rule(
+        "r-dedup",
+        type="count_over_threshold",
+        event_type="error",
+        threshold=3,
+        window_sec=60,
+        cooldown_sec=3600,  # 1h cooldown
+    )
+    events = _events("error", [0, 5, 10])
+    memo = {}
+    first = alert_evaluator.evaluate([rule], events, memo)
+    second = alert_evaluator.evaluate([rule], events, memo)
+    assert len(first) == 1
+    assert second == []
+    # Memo bookkeeping shape
+    assert "r-dedup" in memo
+    assert memo["r-dedup"].get("last_event_id") == first[0]["event"]["id"]
+    assert memo["r-dedup"].get("last_fired_ts", 0) > 0
+
+
+def test_independent_state_per_rule():
+    """Two rules firing on the same events should have independent memos."""
+    rule_a = _rule(
+        "r-a",
+        type="count_over_threshold",
+        event_type="error",
+        threshold=3,
+        window_sec=60,
+        cooldown_sec=3600,
+    )
+    rule_b = _rule(
+        "r-b",
+        type="count_over_threshold",
+        event_type="error",
+        threshold=2,
+        window_sec=60,
+        cooldown_sec=3600,
+    )
+    events = _events("error", [0, 5, 10])
+    memo = {}
+    matches = alert_evaluator.evaluate([rule_a, rule_b], events, memo)
+    rids = sorted(m["rule"]["id"] for m in matches)
+    assert rids == ["r-a", "r-b"]
+    # Each got its own memo entry.
+    assert "r-a" in memo and "r-b" in memo
+    # Second pass: both deduped.
+    assert alert_evaluator.evaluate([rule_a, rule_b], events, memo) == []
+
+
+def test_disabled_rule_never_fires():
+    rule = _rule(
+        "r-off",
+        enabled=False,
+        type="count_over_threshold",
+        event_type="error",
+        threshold=1,
+        window_sec=60,
+        cooldown_sec=0,
+    )
+    events = _events("error", [0, 5, 10])
+    assert alert_evaluator.evaluate([rule], events, {}) == []
+
+
+# ── 3. degenerate inputs ─────────────────────────────────────────────────────
+
+
+def test_empty_rules_returns_empty():
+    assert alert_evaluator.evaluate([], _events("x", [0, 1, 2]), {}) == []
+    assert alert_evaluator.evaluate(None, _events("x", [0, 1, 2]), {}) == []
+
+
+def test_empty_events_returns_empty():
+    rule = _rule(
+        "r1", type="count_over_threshold", event_type="x", threshold=1,
+        window_sec=60, cooldown_sec=0,
+    )
+    assert alert_evaluator.evaluate([rule], [], {}) == []
+    assert alert_evaluator.evaluate([rule], None, {}) == []
+
+
+def test_malformed_rule_does_not_raise():
+    """No id, no condition — evaluator should skip, not crash."""
+    bad = [
+        {},                                # no id
+        {"id": "bad", "condition_json": "not-a-dict"},
+        {"id": "u", "condition_json": {"type": "no_such_type"}},
+    ]
+    events = _events("x", [0, 5, 10])
+    assert alert_evaluator.evaluate(bad, events, {}) == []
+
+
+def test_none_state_raises_typeerror():
+    """Pass an empty dict — None is a programmer error."""
+    rule = _rule(
+        "r1", type="count_over_threshold", event_type="x", threshold=1,
+        window_sec=60, cooldown_sec=0,
+    )
+    with pytest.raises(TypeError):
+        alert_evaluator.evaluate([rule], _events("x", [0]), None)
+
+
+# ── 4. error_rate ────────────────────────────────────────────────────────────
+
+
+def test_error_rate_fires_above_threshold():
+    rule = _rule(
+        "r-err",
+        type="error_rate",
+        threshold=0.4,           # 40% errors
+        window_sec=60,
+        cooldown_sec=0,
+    )
+    # 5 events in window: 3 errors, 2 ok → 60% error rate.
+    events = (
+        _events("error", [0, 5, 10])
+        + _events("ok", [12, 14])
+    )
+    matches = alert_evaluator.evaluate([rule], events, {})
+    assert len(matches) == 1
+    md = matches[0]["metadata"]
+    assert md["errors"] == 3
+    assert md["total"] == 5
+    assert md["rate"] >= 0.6
+
+
+def test_error_rate_under_min_sample_does_not_fire():
+    """With <5 events in window, error_rate suppresses to avoid false positives
+    on trivially small samples."""
+    rule = _rule(
+        "r-err", type="error_rate", threshold=0.4,
+        window_sec=60, cooldown_sec=0,
+    )
+    # 3 events, all errors — would be 100% but sample too small.
+    events = _events("error", [0, 5, 10])
+    assert alert_evaluator.evaluate([rule], events, {}) == []
+
+
+def test_error_rate_percentage_threshold_is_normalised():
+    """Threshold > 1 should be treated as a percentage (cloud-form input)."""
+    rule = _rule(
+        "r-err", type="error_rate",
+        threshold=50,  # i.e. 50% — should be normalised to 0.5
+        window_sec=60, cooldown_sec=0,
+    )
+    events = (
+        _events("error", [0, 5, 10, 15])
+        + _events("ok", [12, 14, 16, 18])
+    )
+    # 4 errors / 8 total = 50%, equals threshold → fires.
+    matches = alert_evaluator.evaluate([rule], events, {})
+    assert len(matches) == 1
+
+
+# ── 5. tool_call_pattern ─────────────────────────────────────────────────────
+
+
+def test_tool_call_pattern_matches_explicit_name():
+    rule = _rule(
+        "r-tool",
+        type="tool_call_pattern",
+        tool_name="exec",
+        cooldown_sec=0,
+    )
+    events = [
+        {"id": "e1", "event_type": "tool", "ts": "2026-05-13T04:00:00+00:00",
+         "data": {"tool_name": "exec", "args": {"cmd": "ls"}}},
+        {"id": "e2", "event_type": "tool", "ts": "2026-05-13T04:00:01+00:00",
+         "data": {"tool_name": "browser", "args": {}}},
+    ]
+    matches = alert_evaluator.evaluate([rule], events, {})
+    assert len(matches) == 1
+    assert matches[0]["event"]["id"] == "e1"
+
+
+def test_tool_call_pattern_with_arg_regex():
+    rule = _rule(
+        "r-tool",
+        type="tool_call_pattern",
+        tool_name="exec",
+        arg_pattern=r"rm\s+-rf",
+        cooldown_sec=0,
+    )
+    events = [
+        {"id": "e1", "event_type": "tool", "ts": "2026-05-13T04:00:00+00:00",
+         "data": {"tool_name": "exec", "args": {"cmd": "ls"}}},
+        {"id": "e2", "event_type": "tool", "ts": "2026-05-13T04:00:01+00:00",
+         "data": {"tool_name": "exec", "args": {"cmd": "rm -rf /"}}},
+    ]
+    matches = alert_evaluator.evaluate([rule], events, {})
+    assert len(matches) == 1
+    assert matches[0]["event"]["id"] == "e2"
+
+
+def test_tool_call_pattern_no_match():
+    rule = _rule(
+        "r-tool", type="tool_call_pattern",
+        tool_name="never_called", cooldown_sec=0,
+    )
+    events = [
+        {"id": "e1", "event_type": "tool", "ts": "2026-05-13T04:00:00+00:00",
+         "data": {"tool_name": "exec", "args": {"cmd": "ls"}}},
+    ]
+    assert alert_evaluator.evaluate([rule], events, {}) == []
+
+
+# ── 6. legacy alert_type aliasing ────────────────────────────────────────────
+
+
+def test_legacy_alert_type_maps_to_count_evaluator():
+    """A cloud rule with alert_type='token_velocity' (no explicit `type`) is
+    treated as count_over_threshold so we at least get coverage instead of
+    silently ignoring the rule."""
+    rule = _rule(
+        "r-legacy",
+        alert_type="token_velocity",     # legacy field
+        event_type="assistant",
+        threshold_value=2,                # legacy field
+        window_sec=60,
+        cooldown_sec=0,
+    )
+    events = _events("assistant", [0, 5, 10])
+    matches = alert_evaluator.evaluate([rule], events, {})
+    assert len(matches) == 1

--- a/tests/test_evaluate_alerts_integration.py
+++ b/tests/test_evaluate_alerts_integration.py
@@ -1,0 +1,246 @@
+"""Integration tests for ``clawmetry.sync.evaluate_alerts`` (PRD #779 PR-D pt2).
+
+Wires up a real DuckDB ``LocalStore`` (against a tmp file) + a stubbed cloud
+``_post`` so we can assert:
+
+  * The function reads rules + events from DuckDB (NOT cloud).
+  * Each evaluator match results in a POST to ``/api/cloud/alerts/dispatch``
+    with the right body shape.
+  * Cloud-unreachable raises into ``_post`` are caught and don't crash the
+    daemon tick.
+  * ``state['alerts_last_eval_ts']`` and ``state['alerts_eval_memo']`` are
+    populated for cooldown persistence across daemon restarts.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Fresh DuckDB LocalStore against a tmp file. Yields (module, store)."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    store = ls.get_store()
+    yield ls, store
+
+    try:
+        store.stop(flush=False)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def sync_module():
+    """Reload sync.py after the local_store reload so any `from clawmetry
+    import local_store` cached at import time gets the fresh module."""
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as s
+    importlib.reload(s)
+    return s
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _now_iso(offset_sec: int = 0) -> str:
+    return (datetime.now(timezone.utc) + timedelta(seconds=offset_sec)).isoformat()
+
+
+def _seed_rule_and_events(store, *, threshold=3, n_events=5):
+    """Seed one count_over_threshold rule and ``n_events`` matching events
+    bunched into the past 30 seconds (well inside the default window).
+    Returns the rule id."""
+    store.ingest_alert_rule({
+        "id":        "rule-int-1",
+        "owner_hash": None,    # accept any caller for the test
+        "name":      "Test count rule",
+        "condition_json": {
+            "type":         "count_over_threshold",
+            "event_type":   "tool_call",
+            "threshold":    threshold,
+            "window_sec":   60,
+            "cooldown_sec": 0,
+        },
+        "enabled": True,
+    })
+    for i in range(n_events):
+        store.ingest({
+            "id":          f"evt-{i}",
+            "node_id":     "test-node",
+            "event_type":  "tool_call",
+            "ts":          _now_iso(-30 + i),
+            "data":        {"i": i},
+        })
+    # CLAWMETRY_LOCAL_FLUSH_BATCH=1 means each ingest triggers a flush
+    # synchronously — no extra step needed before query_events.
+    return "rule-int-1"
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_evaluate_alerts_skips_when_no_cloud_account(sync_module, monkeypatch):
+    """OSS-only nodes (no cm_ key) should silently return 0."""
+    posted = []
+    monkeypatch.setattr(sync_module, "_post",
+                        lambda *a, **k: posted.append((a, k)) or {"ok": True})
+    n = sync_module.evaluate_alerts({"api_key": "", "node_id": "n1"}, {})
+    assert n == 0
+    assert posted == []
+    n = sync_module.evaluate_alerts(
+        {"api_key": "not-cm-prefix", "node_id": "n1"}, {}
+    )
+    assert n == 0
+    assert posted == []
+
+
+def test_evaluate_alerts_skips_when_no_rules(fresh_store, sync_module, monkeypatch):
+    """With cloud configured but zero local rules, dispatch must NOT fire."""
+    posted = []
+    monkeypatch.setattr(sync_module, "_post",
+                        lambda *a, **k: posted.append((a, k)) or {"ok": True})
+    cfg = {"api_key": "cm_test", "node_id": "node-1"}
+    state = {}
+    n = sync_module.evaluate_alerts(cfg, state)
+    assert n == 0
+    assert posted == []
+    # State still gets the last_eval_ts? Spec: only set after we attempted
+    # evaluation. With zero rules we short-circuit before that, so don't
+    # assert presence here — just absence of bogus dispatches.
+
+
+def test_evaluate_alerts_dispatches_match(fresh_store, sync_module, monkeypatch):
+    ls, store = fresh_store
+    rid = _seed_rule_and_events(store, threshold=3, n_events=5)
+
+    posted = []
+
+    def _fake_post(path, payload, api_key, timeout=10):
+        posted.append({
+            "path":    path,
+            "payload": payload,
+            "api_key": api_key,
+            "timeout": timeout,
+        })
+        return {"ok": True, "dispatched": ["slack-1"]}
+
+    monkeypatch.setattr(sync_module, "_post", _fake_post)
+    # owner_hash mismatch is the common failure mode — make
+    # query_alert_rules indifferent to owner by stubbing it to bypass
+    # the hash filter.
+    real_query = store.query_alert_rules
+    monkeypatch.setattr(store, "query_alert_rules",
+                        lambda **kw: real_query(limit=kw.get("limit", 200)))
+    # And make sure sync's local_store.get_store returns OUR store (the
+    # reloaded sync module imported a different singleton).
+    monkeypatch.setattr(sync_module, "_post", _fake_post)
+    # Replace get_store on the module the daemon imports.
+    import clawmetry.local_store as live_ls
+    monkeypatch.setattr(live_ls, "get_store", lambda **kw: store)
+
+    cfg = {"api_key": "cm_test", "node_id": "node-1"}
+    state: dict = {}
+    n = sync_module.evaluate_alerts(cfg, state)
+
+    assert n == 1, f"expected 1 dispatch, got {n} (posted={posted})"
+    assert len(posted) == 1
+    p = posted[0]
+    assert p["path"] == "/api/cloud/alerts/dispatch"
+    assert p["api_key"] == "cm_test"
+    body = p["payload"]
+    assert body["rule_id"] == rid
+    assert body["rule_name"] == "Test count rule"
+    assert body["node_id"] == "node-1"
+    assert body["event_id"], "expected event_id on dispatch body"
+    assert "evaluated_at" in body
+    assert isinstance(body["metadata"], dict)
+    assert body["metadata"]["threshold"] == 3
+    assert body["metadata"]["count"] >= 3
+    # Cooldown bookkeeping persisted into state.
+    assert state.get("alerts_last_eval_ts")
+    assert state.get("alerts_eval_memo", {}).get(rid, {}).get("last_fired_ts", 0) > 0
+
+
+def test_evaluate_alerts_swallows_post_exception(fresh_store, sync_module, monkeypatch):
+    """Cloud unreachable → _post raises → evaluate_alerts logs and returns 0
+    (does NOT propagate the exception into the daemon loop)."""
+    ls, store = fresh_store
+    _seed_rule_and_events(store, threshold=3, n_events=5)
+
+    def _boom(*a, **k):
+        raise RuntimeError("simulated cloud outage")
+
+    monkeypatch.setattr(sync_module, "_post", _boom)
+    real_query = store.query_alert_rules
+    monkeypatch.setattr(store, "query_alert_rules",
+                        lambda **kw: real_query(limit=kw.get("limit", 200)))
+    import clawmetry.local_store as live_ls
+    monkeypatch.setattr(live_ls, "get_store", lambda **kw: store)
+
+    cfg = {"api_key": "cm_test", "node_id": "node-1"}
+    state: dict = {}
+    # Should not raise.
+    n = sync_module.evaluate_alerts(cfg, state)
+    assert n == 0
+    # State still progresses so we don't get stuck retrying inside the same
+    # eval window forever.
+    assert state.get("alerts_last_eval_ts")
+
+
+def test_evaluate_alerts_deduped_response_still_counts_as_dispatched(
+    fresh_store, sync_module, monkeypatch
+):
+    """Cloud may return ``{"ok": true, "deduped": true}`` when a recent
+    notification already fired. The OSS daemon should still count it as
+    dispatched (since the local rule fired) — the cloud just chose not to
+    fan out a second time."""
+    ls, store = fresh_store
+    _seed_rule_and_events(store, threshold=3, n_events=5)
+
+    def _fake_post(path, payload, api_key, timeout=10):
+        return {"ok": True, "deduped": True}
+
+    monkeypatch.setattr(sync_module, "_post", _fake_post)
+    real_query = store.query_alert_rules
+    monkeypatch.setattr(store, "query_alert_rules",
+                        lambda **kw: real_query(limit=kw.get("limit", 200)))
+    import clawmetry.local_store as live_ls
+    monkeypatch.setattr(live_ls, "get_store", lambda **kw: store)
+
+    n = sync_module.evaluate_alerts(
+        {"api_key": "cm_test", "node_id": "node-1"}, {}
+    )
+    assert n == 1
+
+
+# ── Smoke: docstring + name sanity for verification step ──────────────────────
+
+
+def test_docstring_mentions_duckdb(sync_module):
+    """Spec: ``sync.evaluate_alerts.__doc__`` must mention DuckDB after the
+    rewrite (so future agents can cheaply detect the legacy implementation
+    has been replaced)."""
+    assert sync_module.evaluate_alerts.__doc__
+    assert "DuckDB" in sync_module.evaluate_alerts.__doc__


### PR DESCRIPTION
## Summary

Closes the architectural inversion called out in the 2026-05-13 audit
(`/tmp/audit_overview_alerts_approvals_2026-05-13.md`, sections C + E):
**alerts now evaluate locally against the DuckDB write-through cache** and
the daemon POSTs each match to the cloud's `/api/cloud/alerts/dispatch`
endpoint (shipped in `clawmetry-cloud#785`). Cloud is now a notification
fan-out service only — it no longer evaluates rules against its own data
copy.

This implements **PRD #779 PR-D part 2**.

### What changed

- **New `clawmetry/alert_evaluator.py`** — pure evaluator (no I/O). Three
  PRD-spec condition types: `count_over_threshold`, `error_rate`,
  `tool_call_pattern`. Best-effort mapping of legacy cloud `alert_type`
  names (`token_velocity`, `daily_spend`, `node_offline`, …) so existing
  rules keep firing while purpose-built evaluators land in PR-D pt3+.
  Per-rule cooldown memo with belt-and-braces event-id dedup.
- **Rewrote `clawmetry/sync.py:evaluate_alerts`** — queries `alert_rules`
  from DuckDB (filtered by `owner_hash`), pulls recent events via
  `query_events(since=…)`, walks them through `alert_evaluator.evaluate`,
  and POSTs each match to `/api/cloud/alerts/dispatch`. Persists
  `alerts_last_eval_ts` and `alerts_eval_memo` into `sync-state.json` so
  cooldown survives restarts. Never raises into the daemon loop.
- **Wired into the LIVE `run_daemon`** at `sync.py:4641` — runs every
  `ALERTS_EVAL_INTERVAL_SEC` (now 60s, down from 300s since cloud-side
  debounce no longer applies). The dead-code duplicate at `sync.py:5281`
  still exists; deletion is its own follow-up (audit P0 #3).

### Closes

- Audit P0 **#1** — alerts were 100 % cloud-evaluated. Now local.
- Audit P0 **#2** — `evaluate_alerts` had never fired in this daemon's
  lifetime. Now wired into the live loop with a 60s tick.

### Depends on

- `clawmetry-cloud#785` — the `/api/cloud/alerts/dispatch` endpoint.
  This PR will dispatch into 404s until that cloud deploy lands.

### Sunset

The legacy `/api/internal/evaluate-alerts` cloud endpoint stays alive as
a harmless backstop. Deletion deferred to **PR-D part 3** once we
confirm `~/.clawmetry/sync.log` shows `alerts: dispatched N match(es)`
lines on real production traffic post-release.

## Acceptance

After merge + 0.12.179 release + `clawmetry-cloud#785` deployed, every
60s in `~/.clawmetry/sync.log`:

- `alerts: rule=<id> dispatched -> ['slack-1', ...]` when a rule fires
- `alerts: dispatched N match(es)` summary line
- `~/.clawmetry/sync-state.json` gains `alerts_last_eval_ts` and
  `alerts_eval_memo` keys

## Test plan

- [x] `python3 -c "from clawmetry import sync, alert_evaluator; print('ok')"` — clean
- [x] `python3 -m pytest tests/test_alert_evaluator_unit.py tests/test_evaluate_alerts_integration.py -q` — 24 passed
- [x] `python3 -c "import inspect; from clawmetry import sync; assert 'DuckDB' in sync.evaluate_alerts.__doc__"` — docstring OK
- [x] Broader regression: 627 passed locally; the only failures (`test_session_export.py`, `test_brain_cache_push.py`) reproduce on `origin/main` and are unrelated.
- [ ] CI green
- [ ] Post-deploy: confirm `alerts: dispatched` lines appear in production `sync.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)