### PR TITLE
fix(sync): skip trajectory/checkpoint/deleted .jsonl sidecars in DuckDB ingest (#1129 bug 1)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -993,6 +993,20 @@ def _list_session_jsonls(sessions_dir) -> list[str]:
     try:
         for fname in os.listdir(sessions_dir):
             if fname.endswith(".jsonl") or ".jsonl.reset." in fname:
+                # Skip OpenClaw trace-artifact sidecars that live next to
+                # real session files. Without this filter the daemon
+                # ingests <sid>.trajectory.jsonl etc., and
+                # _canonical_session_file() splits at the first `.jsonl`
+                # producing phantom session_ids like '<uuid>.trajectory'
+                # that pollute DuckDB and downstream APIs. The dashboard
+                # read-path applies the same exclusion (dashboard.py,
+                # routes/sessions.py, routes/brain.py, routes/usage.py).
+                if (
+                    ".trajectory." in fname
+                    or ".checkpoint." in fname
+                    or ".deleted." in fname
+                ):
+                    continue
                 out.append(os.path.join(sessions_dir, fname))
     except OSError:
         pass

--- a/tests/test_sync_skip_sidecar_jsonls.py
+++ b/tests/test_sync_skip_sidecar_jsonls.py
@@ -1,0 +1,79 @@
+"""Regression test for #1129 (bug 1).
+
+The cloud sync daemon must NOT ingest OpenClaw's trace-artifact sidecar
+files (`*.trajectory.jsonl`, `*.checkpoint.jsonl`, `*.deleted.jsonl`)
+into DuckDB. They live next to the real session jsonl, are typically
+much larger, and downstream `_canonical_session_file()` would split
+them at the first `.jsonl`, producing phantom session_ids like
+`<uuid>.trajectory` that pollute `/api/sessions` and
+`/api/brain-history`.
+
+The dashboard read-path already excludes these (dashboard.py,
+routes/sessions.py, routes/brain.py, routes/usage.py). This test pins
+the daemon ingest behavior to the same exclusion.
+"""
+
+import os
+import tempfile
+
+from clawmetry.sync import _canonical_session_file, _list_session_jsonls
+
+
+def test_list_session_jsonls_skips_trajectory_checkpoint_deleted_sidecars():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Real session files we DO want to ingest.
+        keep = [
+            "aaa.jsonl",
+            "ccc.jsonl.reset.1234567890",
+        ]
+        # Sidecar files we MUST skip.
+        skip = [
+            "aaa.trajectory.jsonl",
+            "aaa.checkpoint.jsonl",
+            "bbb.deleted.jsonl",
+        ]
+        for name in keep + skip:
+            with open(os.path.join(tmpdir, name), "w") as f:
+                f.write("")
+
+        result = _list_session_jsonls(tmpdir)
+        result_names = sorted(os.path.basename(p) for p in result)
+
+        assert result_names == sorted(keep), (
+            f"Expected only {sorted(keep)}, got {result_names}"
+        )
+
+        # Explicit assertions for the bug we're fixing.
+        for sidecar in skip:
+            assert sidecar not in result_names, (
+                f"Sidecar {sidecar!r} must be excluded from sync ingest "
+                f"(it would create a phantom session_id in DuckDB)"
+            )
+
+
+def test_canonical_session_file_unchanged_for_sidecars():
+    """Document that `_canonical_session_file()` does NOT itself filter
+    sidecars — it splits at the first `.jsonl` and would produce a
+    phantom session_id. The exclusion happens upstream in
+    `_list_session_jsonls()`, so this function never sees these names
+    in production. If that contract ever changes, this test will need
+    revisiting.
+    """
+    # Sanity: real sessions and reset archives canonicalize as expected.
+    assert _canonical_session_file("aaa.jsonl") == "aaa.jsonl"
+    assert _canonical_session_file("aaa.jsonl.reset.1234567890") == "aaa.jsonl"
+    assert _canonical_session_file("/some/path/aaa.jsonl") == "aaa.jsonl"
+
+    # Sidecar names: `_canonical_session_file()` splits at the first
+    # `.jsonl`, so it returns the full sidecar basename unchanged
+    # (e.g. `foo.trajectory.jsonl` → `foo.trajectory.jsonl`). That is
+    # exactly the phantom-session_id form the upstream filter prevents.
+    # Documents the upstream-filter contract: this function never sees
+    # these names in production after the _list_session_jsonls fix.
+    assert (
+        _canonical_session_file("foo.trajectory.jsonl") == "foo.trajectory.jsonl"
+    )
+    assert (
+        _canonical_session_file("foo.checkpoint.jsonl") == "foo.checkpoint.jsonl"
+    )
+    assert _canonical_session_file("foo.deleted.jsonl") == "foo.deleted.jsonl"


### PR DESCRIPTION
## Summary
Fixes bug 1 of 4 tracked in #1129.

The cloud sync daemon's `_list_session_jsonls()` (in `clawmetry/sync.py`) walked every `*.jsonl` file in the OpenClaw sessions directory, including the trace-artifact sidecars OpenClaw writes next to each real session: `<sid>.trajectory.jsonl`, `<sid>.checkpoint.jsonl`, `<sid>.deleted.jsonl`. Downstream, `_canonical_session_file()` splits the basename at the first `.jsonl`, so a sidecar like `abc.trajectory.jsonl` got canonicalized as `abc.trajectory.jsonl` and ingested as session_id `abc.trajectory` — a phantom row that polluted DuckDB and surfaced in `/api/sessions` and `/api/brain-history`.

The dashboard read-path already excludes these (`dashboard.py:7744`, `routes/sessions.py:239`, `routes/brain.py:150`, `routes/usage.py:1283`). This PR brings the ingest path in line by adding the same exclusion at the source.

## Root cause
- `clawmetry/sync.py::_list_session_jsonls` filtered only on `endswith('.jsonl')` / `.jsonl.reset.` — no sidecar exclusion.
- Trajectory files are typically much larger than the real session jsonl, so they bloated DuckDB and slowed cloud sync.

## Fix
Two-line guard inside the existing `if`:
```python
if ".trajectory." in fname or ".checkpoint." in fname or ".deleted." in fname:
    continue
```

## Test plan
- [x] New regression test `tests/test_sync_skip_sidecar_jsonls.py` builds a temp dir with 5 files (real + 3 sidecars + reset archive), asserts only the real session and reset archive come back, and pins `_canonical_session_file()` behavior to document the upstream-filter contract.
- [x] `python3 -m pytest tests/test_sync_skip_sidecar_jsonls.py -q` → 2 passed.
- [x] `python3 -c "import ast; ast.parse(open('clawmetry/sync.py').read())"` → OK.
- [ ] CI green.

Refs: #1129