### PR TITLE
fix(local_store): extract model/tokens from nested OpenClaw event payload on write (#1129 bug 2)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -2304,6 +2304,161 @@ _EVENT_COLS = [
 ]
 
 
+def _extract_event_metrics(
+    e: dict[str, Any],
+) -> tuple[float | None, int | None, str | None]:
+    """Pull (cost_usd, token_count, model) from an event with shape fallbacks.
+
+    Top-level ``cost_usd`` / ``token_count`` / ``model`` are honoured first —
+    that's what the interceptor, claude-cli adapter, sync, and tests already
+    provide. When absent (the OpenClaw gateway/jsonl shape), we fall through
+    nested payload shapes:
+
+      * OpenClaw: ``data.modelId`` + ``data.provider`` +
+        ``data.promptCache.lastCallUsage.{input,output,total,cacheRead,cacheWrite}``
+      * OpenClaw message: ``data.message.usage.{inputTokens,outputTokens,totalTokens}``
+        with ``data.message.usage.cost.total`` (already-priced)
+      * Anthropic SDK:  ``data.usage.{input_tokens,output_tokens,total_tokens}``
+
+    Cost is derived from tokens × pricing only when input/output split AND
+    provider AND model are all known (so we match
+    ``providers_pricing.estimate_cost_usd``'s asymmetric rates). When only
+    ``total`` is available, we leave cost=None — the brain UI / read-side
+    aggregates compute it from tokens+model on demand and shouldn't see a
+    half-correct value here.
+
+    Never raises: any extraction failure quietly leaves the field as None
+    so the store stays a permissive ingest path (#1129)."""
+    cost = e.get("cost_usd")
+    tokens = e.get("token_count")
+    model = e.get("model")
+    provider = e.get("provider")
+
+    d = e.get("data") if isinstance(e.get("data"), dict) else None
+    if d is None:
+        return cost, tokens, model
+
+    if not model:
+        model = d.get("modelId") or d.get("model") or d.get("model_id")
+        # Message-shape: data.message.{model, provider}
+        msg = d.get("message") if isinstance(d.get("message"), dict) else None
+        if not model and msg is not None:
+            model = msg.get("model")
+        if not provider and msg is not None:
+            provider = provider or msg.get("provider")
+    if not provider:
+        provider = d.get("provider")
+
+    tokens_in: int | None = None
+    tokens_out: int | None = None
+
+    if tokens is None:
+        # 1. OpenClaw: data.promptCache.lastCallUsage
+        pc = d.get("promptCache") if isinstance(d.get("promptCache"), dict) else None
+        if pc is not None:
+            lcu = pc.get("lastCallUsage") if isinstance(pc.get("lastCallUsage"), dict) else None
+            if lcu is not None:
+                t = lcu.get("total")
+                i = lcu.get("input") or 0
+                o = lcu.get("output") or 0
+                if t is None and (i or o):
+                    t = int(i) + int(o)
+                if t:
+                    try:
+                        tokens = int(t)
+                    except (TypeError, ValueError):
+                        pass
+                if i:
+                    try:
+                        tokens_in = int(i)
+                    except (TypeError, ValueError):
+                        pass
+                if o:
+                    try:
+                        tokens_out = int(o)
+                    except (TypeError, ValueError):
+                        pass
+
+        # 2. OpenClaw message: data.message.usage.{inputTokens,outputTokens,totalTokens}
+        if tokens is None:
+            msg = d.get("message") if isinstance(d.get("message"), dict) else None
+            usage = msg.get("usage") if msg and isinstance(msg.get("usage"), dict) else None
+            if usage is not None:
+                t = usage.get("totalTokens") or usage.get("total_tokens")
+                i = usage.get("inputTokens") or usage.get("input_tokens") or 0
+                o = usage.get("outputTokens") or usage.get("output_tokens") or 0
+                if t is None and (i or o):
+                    t = int(i) + int(o)
+                if t:
+                    try:
+                        tokens = int(t)
+                    except (TypeError, ValueError):
+                        pass
+                if i and tokens_in is None:
+                    try:
+                        tokens_in = int(i)
+                    except (TypeError, ValueError):
+                        pass
+                if o and tokens_out is None:
+                    try:
+                        tokens_out = int(o)
+                    except (TypeError, ValueError):
+                        pass
+                # Already-priced cost is reliable — prefer it over re-derivation.
+                cost_obj = usage.get("cost") if isinstance(usage.get("cost"), dict) else None
+                if cost is None and cost_obj is not None:
+                    ct = cost_obj.get("total")
+                    if ct is not None:
+                        try:
+                            cost = float(ct)
+                        except (TypeError, ValueError):
+                            pass
+
+        # 3. Anthropic SDK: data.usage.{input_tokens,output_tokens,total_tokens}
+        if tokens is None:
+            u = d.get("usage") if isinstance(d.get("usage"), dict) else None
+            if u is not None:
+                t = u.get("total_tokens") or u.get("totalTokens")
+                i = u.get("input_tokens") or u.get("inputTokens") or 0
+                o = u.get("output_tokens") or u.get("outputTokens") or 0
+                if t is None and (i or o):
+                    t = int(i) + int(o)
+                if t:
+                    try:
+                        tokens = int(t)
+                    except (TypeError, ValueError):
+                        pass
+                if i and tokens_in is None:
+                    try:
+                        tokens_in = int(i)
+                    except (TypeError, ValueError):
+                        pass
+                if o and tokens_out is None:
+                    try:
+                        tokens_out = int(o)
+                    except (TypeError, ValueError):
+                        pass
+
+    # Derive cost only when input/output split + provider + model are all known.
+    # estimate_cost_usd uses asymmetric input/output rates; a single ``total``
+    # can't be priced correctly, so leave cost=None and let read-side compute.
+    if cost is None and provider and model and (tokens_in or tokens_out):
+        try:
+            from clawmetry.providers_pricing import estimate_cost_usd
+            est = estimate_cost_usd(
+                provider=str(provider),
+                tokens_in=int(tokens_in or 0),
+                tokens_out=int(tokens_out or 0),
+                model=str(model),
+            )
+            if est:
+                cost = float(est)
+        except Exception:
+            pass
+
+    return cost, tokens, model
+
+
 def _event_to_row(e: dict[str, Any]) -> tuple:
     """Coerce an event dict into the column tuple for the events table.
     Unknown keys are tolerated and dropped — events come from many sources
@@ -2315,6 +2470,7 @@ def _event_to_row(e: dict[str, Any]) -> tuple:
             data = data.encode("utf-8")
         else:
             data = json.dumps(data, separators=(",", ":")).encode("utf-8")
+    cost, tokens, model = _extract_event_metrics(e)
     return (
         str(e["id"]),
         str(e.get("agent_type") or "openclaw"),
@@ -2325,9 +2481,9 @@ def _event_to_row(e: dict[str, Any]) -> tuple:
         str(e["event_type"]),
         str(e["ts"]),
         data,
-        float(e["cost_usd"]) if e.get("cost_usd") is not None else None,
-        int(e["token_count"]) if e.get("token_count") is not None else None,
-        e.get("model"),
+        float(cost) if cost is not None else None,
+        int(tokens) if tokens is not None else None,
+        model,
         int(time.time() * 1000),
     )
 

--- a/tests/test_event_metrics_extraction.py
+++ b/tests/test_event_metrics_extraction.py
@@ -1,0 +1,169 @@
+"""Regression tests for ``_extract_event_metrics`` (#1129 bug 2).
+
+The local DuckDB store used to read ``e["cost_usd"]`` / ``e["token_count"]``
+/ ``e["model"]`` directly off the top-level event dict — but OpenClaw's
+gateway emits these nested under ``data.modelId`` and
+``data.promptCache.lastCallUsage.{input,output,total}``. Result: every
+event landed in DuckDB with model="", tokens=0, cost=null, and every
+read-side aggregate (brain history, sessions, usage charts) showed empty
+values.
+
+These tests pin down the four shape contracts the helper must honour:
+OpenClaw nested, Anthropic SDK nested, already-extracted top-level
+(interceptor / claude-cli adapter / sync), and totally-empty graceful.
+"""
+
+from __future__ import annotations
+
+from clawmetry.local_store import _extract_event_metrics
+
+
+def test_openclaw_shape_extracts_model_and_tokens():
+    """OpenClaw gateway shape: data.modelId + data.provider +
+    data.promptCache.lastCallUsage.{input,output,total}."""
+    ev = {
+        "id": "e1",
+        "node_id": "agent+n",
+        "event_type": "message",
+        "ts": "2026-05-13T00:00:00Z",
+        "data": {
+            "modelId": "claude-opus-4-7",
+            "provider": "anthropic",
+            "promptCache": {
+                "lastCallUsage": {
+                    "input": 1000,
+                    "output": 234,
+                    "total": 1234,
+                }
+            },
+        },
+    }
+    cost, tokens, model = _extract_event_metrics(ev)
+    assert model == "claude-opus-4-7"
+    assert tokens == 1234
+    # Cost is derived from input/output split + provider + model via pricing
+    # table. anthropic/claude-opus-4 → (15.00, 75.00) per 1M tokens.
+    # = 1000/1M * 15 + 234/1M * 75 = 0.015 + 0.01755 = 0.03255
+    assert cost is not None
+    assert abs(cost - 0.03255) < 1e-6
+
+
+def test_openclaw_total_only_leaves_cost_none():
+    """When only data.promptCache.lastCallUsage.total is known (no
+    input/output split), cost can't be priced correctly with asymmetric
+    rates, so it must be left None — read-side computes on demand."""
+    ev = {
+        "id": "e1b",
+        "node_id": "agent+n",
+        "event_type": "message",
+        "ts": "2026-05-13T00:00:00Z",
+        "data": {
+            "modelId": "claude-opus-4-7",
+            "provider": "anthropic",
+            "promptCache": {"lastCallUsage": {"total": 1234}},
+        },
+    }
+    cost, tokens, model = _extract_event_metrics(ev)
+    assert model == "claude-opus-4-7"
+    assert tokens == 1234
+    assert cost is None
+
+
+def test_anthropic_shape_sums_input_and_output_tokens():
+    """Anthropic SDK shape: data.usage.{input_tokens,output_tokens}.
+    Without total_tokens we sum the two."""
+    ev = {
+        "id": "e2",
+        "node_id": "agent+n",
+        "event_type": "message",
+        "ts": "2026-05-13T00:00:00Z",
+        "data": {
+            "model": "claude-3-5-sonnet-latest",
+            "usage": {"input_tokens": 100, "output_tokens": 50},
+        },
+    }
+    cost, tokens, model = _extract_event_metrics(ev)
+    assert model == "claude-3-5-sonnet-latest"
+    assert tokens == 150
+    # No provider in payload → cost stays None even though tokens are split.
+    assert cost is None
+
+
+def test_top_level_already_extracted_values_are_preserved():
+    """interceptor / claude-cli adapter / sync push fully-extracted events
+    with top-level cost_usd / token_count / model. The helper must not
+    touch nested data when the top-level values are present."""
+    ev = {
+        "id": "e3",
+        "node_id": "agent+n",
+        "event_type": "message",
+        "ts": "2026-05-13T00:00:00Z",
+        "cost_usd": 0.05,
+        "token_count": 99,
+        "model": "gpt-4",
+        # Conflicting nested values — must be ignored when top-level present.
+        "data": {
+            "modelId": "claude-opus-4-7",
+            "promptCache": {"lastCallUsage": {"total": 999999}},
+        },
+    }
+    cost, tokens, model = _extract_event_metrics(ev)
+    assert cost == 0.05
+    assert tokens == 99
+    assert model == "gpt-4"
+
+
+def test_event_with_no_metrics_returns_all_none():
+    """Tool-call / heartbeat / log events have no token usage. Helper must
+    return all-None without raising — the store is permissive on ingest."""
+    ev = {
+        "id": "e4",
+        "node_id": "agent+n",
+        "event_type": "tool_call",
+        "ts": "2026-05-13T00:00:00Z",
+        "data": {"tool": "Read", "args": {"path": "/tmp/x"}},
+    }
+    cost, tokens, model = _extract_event_metrics(ev)
+    assert cost is None
+    assert tokens is None
+    assert model is None
+
+
+def test_event_with_no_data_does_not_crash():
+    """Missing ``data`` key is normal for skeleton events."""
+    ev = {
+        "id": "e5",
+        "node_id": "agent+n",
+        "event_type": "noop",
+        "ts": "2026-05-13T00:00:00Z",
+    }
+    assert _extract_event_metrics(ev) == (None, None, None)
+
+
+def test_openclaw_message_shape_with_priced_cost():
+    """Message events expose data.message.usage with already-priced
+    data.message.usage.cost.total — prefer the priced value over re-derivation
+    so we match what the SDK billed."""
+    ev = {
+        "id": "e6",
+        "node_id": "agent+n",
+        "event_type": "message",
+        "ts": "2026-05-13T00:00:00Z",
+        "data": {
+            "message": {
+                "model": "claude-sonnet-4",
+                "provider": "anthropic",
+                "usage": {
+                    "inputTokens": 200,
+                    "outputTokens": 80,
+                    "totalTokens": 280,
+                    "cost": {"total": 0.0123},
+                },
+            }
+        },
+    }
+    cost, tokens, model = _extract_event_metrics(ev)
+    assert model == "claude-sonnet-4"
+    assert tokens == 280
+    # The pre-priced value wins, not the re-derivation.
+    assert cost == 0.0123


### PR DESCRIPTION
## Summary

Fixes bug 2 from #1129. `_event_to_row` was reading `e["cost_usd"]` / `e["token_count"]` / `e["model"]` directly off the top-level event dict — but OpenClaw's gateway emits these nested under `data.modelId` and `data.promptCache.lastCallUsage.{input,output,total}`. Result: every event landing in DuckDB had `model=""`, `tokens=0`, `cost=null`, and every read-side aggregate (brain history, sessions, usage charts) silently showed empty values.

- New `_extract_event_metrics` helper handles four payload shapes:
  - **OpenClaw gateway**: `data.modelId` + `data.provider` + `data.promptCache.lastCallUsage.{input,output,total}`
  - **OpenClaw message**: `data.message.usage.{inputTokens,outputTokens,totalTokens}` with already-priced `data.message.usage.cost.total`
  - **Anthropic SDK**: `data.usage.{input_tokens,output_tokens,total_tokens}`
  - **Already-extracted top-level**: preserved as-is (interceptor / claude-cli adapter / sync / cloud ingest)
- Cost is derived via `providers_pricing.estimate_cost_usd` when input/output split + provider + model are all known. When only `total` tokens are available (asymmetric input/output rates can't price a single total correctly), cost stays `None` and the read-side computes on demand. Pre-priced `data.message.usage.cost.total` is honoured when present.
- Helper never raises — store stays a permissive ingest path.

## Test plan

- [x] New regression suite `tests/test_event_metrics_extraction.py` (7 tests, all green) — pins down each shape contract plus empty-event safety
- [x] Existing `tests/test_local_store.py` (33 tests) still passes — no regression in the already-extracted-values path
- [x] Syntax check on `clawmetry/local_store.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)