### PR TITLE
fix(sessions): handle OpenClaw transcript shapes + compute message_count on read (#1129 bugs 3+4)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1917,16 +1917,29 @@ class LocalStore:
         clauses: list[str] = []
         params: list[Any] = []
         if agent_type:
-            clauses.append("agent_type = ?")
+            clauses.append("s.agent_type = ?")
             params.append(str(agent_type))
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        # ``sessions.message_count`` is only populated by the typed-session
+        # ingest path (sync.py + claude_code adapter). The OpenClaw events
+        # path never sets it, so reading the column gave ``message_count: 0``
+        # for every OpenClaw session (#1129 bug 4). Compute it on read via a
+        # correlated subquery against ``events`` and fall back to the stored
+        # column for agents that DO populate it (e.g. ingest from sync.py
+        # where the events table may be empty).
         sql = f"""
-            SELECT agent_type, session_id, agent_id, title, started_at,
-                   last_active_at, ended_at, status, total_tokens, cost_usd,
-                   message_count, metadata
-            FROM sessions
+            SELECT s.agent_type, s.session_id, s.agent_id, s.title, s.started_at,
+                   s.last_active_at, s.ended_at, s.status, s.total_tokens, s.cost_usd,
+                   GREATEST(
+                       COALESCE(s.message_count, 0),
+                       (SELECT COUNT(*) FROM events e
+                          WHERE e.session_id = s.session_id
+                            AND e.agent_type = s.agent_type)
+                   ) AS message_count,
+                   s.metadata
+            FROM sessions s
             {where}
-            ORDER BY COALESCE(last_active_at, started_at) DESC NULLS LAST
+            ORDER BY COALESCE(s.last_active_at, s.started_at) DESC NULLS LAST
             LIMIT ?
         """
         params.append(int(limit))

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2046,12 +2046,201 @@ def api_transcripts():
     return jsonify({"transcripts": transcripts[:50]})
 
 
+def _is_openclaw_event(obj: dict) -> bool:
+    """Return True if ``obj`` looks like an OpenClaw event (vs an Anthropic
+    message).
+
+    OpenClaw events carry ``{"type": "<namespace>.<action>", "data": {...}}``
+    with no top-level ``role``. Anthropic-shaped messages have a top-level
+    ``role`` field (``user`` / ``assistant`` / ``system``)."""
+    if not isinstance(obj, dict):
+        return False
+    if obj.get("role"):
+        return False
+    t = obj.get("type")
+    if not isinstance(t, str):
+        return False
+    # OpenClaw types are dotted: prompt.submitted, trace.artifacts, etc.
+    return "." in t
+
+
+def _openclaw_event_tokens(data: dict) -> int:
+    """Sum tokens for one OpenClaw event from its ``promptCache.lastCallUsage``
+    block. Falls back to ``input+output`` when ``total`` is missing.
+
+    OpenClaw writes usage at ``data.promptCache.lastCallUsage`` (per call) and
+    also sometimes at ``data.usage`` (aggregate). We prefer the per-call value
+    so two trace events don't double-count the same call."""
+    if not isinstance(data, dict):
+        return 0
+    pc = data.get("promptCache")
+    if isinstance(pc, dict):
+        lcu = pc.get("lastCallUsage")
+        if isinstance(lcu, dict):
+            total = lcu.get("total")
+            if isinstance(total, (int, float)) and total:
+                return int(total)
+            inp = lcu.get("input") or 0
+            out = lcu.get("output") or 0
+            if inp or out:
+                return int(inp) + int(out)
+    usage = data.get("usage")
+    if isinstance(usage, dict):
+        total = usage.get("total_tokens")
+        if isinstance(total, (int, float)) and total:
+            return int(total)
+        inp = usage.get("input_tokens") or 0
+        out = usage.get("output_tokens") or 0
+        if inp or out:
+            return int(inp) + int(out)
+    return 0
+
+
+def _stringify_content(content) -> str:
+    """Best-effort coerce a transcript message ``content`` field to a string."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict):
+                parts.append(part.get("text", str(part)))
+            else:
+                parts.append(str(part))
+        return "\n".join(parts)
+    return str(content) if content else ""
+
+
+def _expand_openclaw_event(obj: dict, ts_ms):
+    """Map one OpenClaw event into zero or more transcript turns.
+
+    Returns a list of ``{role, content, timestamp}`` dicts. Events that are
+    pure plumbing (``session.*``, ``context.compiled``, ``agent.heartbeat``)
+    or carry no visible content return ``[]`` — never a turn with an empty
+    body or a debug-shaped ``role``."""
+    etype = obj.get("type", "")
+    data = obj.get("data") if isinstance(obj.get("data"), dict) else {}
+    turns: list[dict] = []
+
+    # Plumbing events — never visible in the transcript.
+    if etype in (
+        "session.ended", "session.started", "session.created",
+        "context.compiled", "agent.heartbeat",
+    ):
+        return turns
+
+    if etype == "prompt.submitted":
+        text = data.get("finalPromptText") or data.get("text") or data.get("prompt") or ""
+        text = _stringify_content(text)
+        if text.strip():
+            turns.append({"role": "user", "content": text, "timestamp": ts_ms})
+        return turns
+
+    if etype == "trace.artifacts":
+        # A trace can carry the final prompt, the assistant reply, and the
+        # tool calls that fired during the turn — emit each separately.
+        prompt = data.get("finalPromptText") or ""
+        prompt = _stringify_content(prompt)
+        if prompt.strip():
+            turns.append({"role": "user", "content": prompt, "timestamp": ts_ms})
+
+        atexts = data.get("assistantTexts")
+        if isinstance(atexts, list):
+            for at in atexts:
+                at_s = _stringify_content(at)
+                if at_s.strip():
+                    turns.append({"role": "assistant", "content": at_s, "timestamp": ts_ms})
+        elif isinstance(atexts, str) and atexts.strip():
+            turns.append({"role": "assistant", "content": atexts, "timestamp": ts_ms})
+
+        tool_metas = data.get("toolMetas")
+        if isinstance(tool_metas, list):
+            for tm in tool_metas:
+                if not isinstance(tm, dict):
+                    continue
+                tname = tm.get("name") or tm.get("tool") or "tool"
+                tinput = tm.get("input") or tm.get("arguments") or tm.get("args") or {}
+                toutput = tm.get("output") or tm.get("result")
+                body_parts = [f"[Tool: {tname}]"]
+                try:
+                    body_parts.append(json.dumps(tinput, indent=2)[:500])
+                except (TypeError, ValueError):
+                    body_parts.append(str(tinput)[:500])
+                if toutput is not None:
+                    try:
+                        body_parts.append(json.dumps(toutput, indent=2)[:500])
+                    except (TypeError, ValueError):
+                        body_parts.append(str(toutput)[:500])
+                turns.append({
+                    "role": "tool",
+                    "content": "\n".join(body_parts),
+                    "timestamp": ts_ms,
+                })
+        return turns
+
+    if etype == "model.completed":
+        text = (
+            data.get("completionText")
+            or data.get("text")
+            or data.get("assistantText")
+        )
+        if text is None:
+            atexts = data.get("assistantTexts")
+            if isinstance(atexts, list):
+                text = "\n".join(_stringify_content(a) for a in atexts if a)
+            elif isinstance(atexts, str):
+                text = atexts
+        text = _stringify_content(text) if text is not None else ""
+        if text.strip():
+            turns.append({"role": "assistant", "content": text, "timestamp": ts_ms})
+        return turns
+
+    if etype in ("tool.call", "tool.invoked"):
+        tname = data.get("name") or data.get("tool") or "tool"
+        tinput = data.get("input") or data.get("arguments") or data.get("args") or {}
+        try:
+            body = json.dumps(tinput, indent=2)[:500]
+        except (TypeError, ValueError):
+            body = str(tinput)[:500]
+        turns.append({
+            "role": "tool",
+            "content": f"[Tool: {tname}]\n{body}",
+            "timestamp": ts_ms,
+        })
+        return turns
+
+    if etype in ("tool.result", "tool.completed"):
+        tname = data.get("name") or data.get("tool") or "tool"
+        result = data.get("output") or data.get("result") or ""
+        try:
+            body = json.dumps(result, indent=2)[:500] if not isinstance(result, str) else result[:500]
+        except (TypeError, ValueError):
+            body = str(result)[:500]
+        if body.strip():
+            turns.append({
+                "role": "tool",
+                "content": f"[Tool result: {tname}]\n{body}",
+                "timestamp": ts_ms,
+            })
+        return turns
+
+    # Unknown OpenClaw event — silently skip rather than emit "x.y" role trash.
+    return turns
+
+
 def _try_local_store_transcript(session_id: str):
     """Read a session transcript directly from the DuckDB events table.
 
     Returns the same response shape as the JSONL parser. Returns ``None``
     to defer to the JSONL fallback if the local_store module isn't importable,
     the events table has no rows for this session, or anything raises.
+
+    Handles two event shapes:
+    * **Anthropic-style** messages — ``{role, content, usage, tool_calls}``,
+      written by Claude Code adapters.
+    * **OpenClaw events** — ``{type: "<ns>.<action>", data: {...}}`` — content
+      lives in nested fields (``data.finalPromptText``, ``data.assistantTexts``,
+      ``data.toolMetas``…), tokens in ``data.promptCache.lastCallUsage``.
     """
     try:
         from clawmetry import local_store
@@ -2072,30 +2261,6 @@ def _try_local_store_transcript(session_id: str):
         obj = ev.get("data")
         if not isinstance(obj, dict):
             continue
-        role = obj.get("role", obj.get("type", "unknown"))
-        content = obj.get("content", "")
-        if isinstance(content, list):
-            parts = []
-            for part in content:
-                if isinstance(part, dict):
-                    parts.append(part.get("text", str(part)))
-                else:
-                    parts.append(str(part))
-            content = "\n".join(parts)
-        elif not isinstance(content, str):
-            content = str(content) if content else ""
-        if obj.get("tool_calls") or obj.get("tool_use"):
-            tools = obj.get("tool_calls") or obj.get("tool_use") or []
-            if isinstance(tools, list):
-                for tc in tools:
-                    tname = tc.get("name", tc.get("function", {}).get("name", "tool"))
-                    messages.append({
-                        "role": "tool",
-                        "content": f"[Tool Call: {tname}]\n{json.dumps(tc.get('input', tc.get('arguments', {})), indent=2)[:500]}",
-                        "timestamp": obj.get("timestamp") or obj.get("time"),
-                    })
-        if role == "tool_result":
-            role = "tool"
         ts = obj.get("timestamp") or obj.get("time") or obj.get("created_at") or ev.get("ts")
         ts_ms = None
         if ts:
@@ -2113,6 +2278,34 @@ def _try_local_store_transcript(session_id: str):
                     first_ts = ts_ms
                 if not last_ts or ts_ms > last_ts:
                     last_ts = ts_ms
+
+        if _is_openclaw_event(obj):
+            # OpenClaw shape. Pull model from the top-level (modelId preferred),
+            # tokens from data.promptCache.lastCallUsage.
+            if not model:
+                model = obj.get("modelId") or obj.get("model") or ev.get("model")
+            data = obj.get("data") if isinstance(obj.get("data"), dict) else {}
+            total_tokens += _openclaw_event_tokens(data)
+            for turn in _expand_openclaw_event(obj, ts_ms):
+                if turn.get("content", "").strip():
+                    messages.append(turn)
+            continue
+
+        # Anthropic-style fallback (existing logic).
+        role = obj.get("role", obj.get("type", "unknown"))
+        content = _stringify_content(obj.get("content", ""))
+        if obj.get("tool_calls") or obj.get("tool_use"):
+            tools = obj.get("tool_calls") or obj.get("tool_use") or []
+            if isinstance(tools, list):
+                for tc in tools:
+                    tname = tc.get("name", tc.get("function", {}).get("name", "tool"))
+                    messages.append({
+                        "role": "tool",
+                        "content": f"[Tool Call: {tname}]\n{json.dumps(tc.get('input', tc.get('arguments', {})), indent=2)[:500]}",
+                        "timestamp": ts_ms,
+                    })
+        if role == "tool_result":
+            role = "tool"
         if not model:
             model = obj.get("model") or ev.get("model")
         usage = obj.get("usage", {})

--- a/tests/test_query_sessions_message_count.py
+++ b/tests/test_query_sessions_message_count.py
@@ -1,0 +1,143 @@
+"""Regression test for `LocalStore.query_sessions_table` (#1129 bug 4).
+
+The ``sessions`` table has a ``message_count`` column, but the OpenClaw
+session ingest path never populates it — so every OpenClaw session showed
+``message_count: 0`` in ``/api/sessions``.
+
+The fix computes the count from the ``events`` table via a correlated
+subquery. These tests pin that behaviour.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.02")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.LocalStore()
+    s.start()
+    yield s
+    s.stop(flush=True)
+
+
+def _wait(s, timeout=2.0):
+    import time
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if s.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.01)
+    raise AssertionError("flusher did not drain")
+
+
+def _ingest_event(s, sid, *, ts="2026-05-13T10:00:00Z", agent_type="openclaw"):
+    s.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "agent_type": agent_type,
+        "session_id": sid,
+        "event_type": "brain",
+        "ts": ts,
+        "data": {"type": "model.completed", "data": {"text": "x"}},
+    })
+
+
+def test_message_count_computed_from_events_table(store):
+    """ingest_session never sets message_count; query_sessions_table should
+    still report the actual number of events for that session."""
+    sid = "sess-count-1"
+    store.ingest_session({
+        "session_id": sid,
+        "agent_type": "openclaw",
+        "title": "OpenClaw session",
+        "started_at":     "2026-05-13T10:00:00Z",
+        "last_active_at": "2026-05-13T10:05:00Z",
+        "status": "active",
+        # Note: NO message_count passed — this is the bug.
+    })
+    for i in range(7):
+        _ingest_event(store, sid, ts=f"2026-05-13T10:00:{i:02d}Z")
+    _wait(store)
+
+    rows = store.query_sessions_table(agent_type="openclaw")
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == sid
+    assert rows[0]["message_count"] == 7
+
+
+def test_message_count_falls_back_to_stored_value_when_no_events(store):
+    """sync.py's ingest path DOES set message_count but never writes the
+    events. query_sessions_table must honour the stored value in that case
+    (GREATEST of the two)."""
+    sid = "sess-stored-only"
+    store.ingest_session({
+        "session_id": sid,
+        "agent_type": "claude_code",
+        "title": "Claude Code session (sync.py path)",
+        "started_at":     "2026-05-13T10:00:00Z",
+        "last_active_at": "2026-05-13T10:00:00Z",
+        "message_count": 42,
+    })
+    _wait(store)
+
+    rows = store.query_sessions_table(agent_type="claude_code")
+    assert len(rows) == 1
+    assert rows[0]["message_count"] == 42
+
+
+def test_message_count_uses_max_when_both_set(store):
+    """If both the stored column AND the events table have data, the larger
+    of the two wins — so we never UNDER-count when the stored value is
+    stale (events kept arriving after ingest_session)."""
+    sid = "sess-both"
+    store.ingest_session({
+        "session_id": sid,
+        "agent_type": "openclaw",
+        "title": "both",
+        "started_at":     "2026-05-13T10:00:00Z",
+        "last_active_at": "2026-05-13T10:01:00Z",
+        "message_count": 2,  # stale
+    })
+    for i in range(5):
+        _ingest_event(store, sid, ts=f"2026-05-13T10:00:{i:02d}Z")
+    _wait(store)
+
+    rows = store.query_sessions_table(agent_type="openclaw")
+    assert len(rows) == 1
+    assert rows[0]["message_count"] == 5  # events count wins over stale 2
+
+
+def test_message_count_isolated_per_session(store):
+    """Correlated subquery must filter by session_id — events for OTHER
+    sessions must not inflate the count."""
+    store.ingest_session({
+        "session_id": "sess-A",
+        "agent_type": "openclaw",
+        "started_at":     "2026-05-13T10:00:00Z",
+        "last_active_at": "2026-05-13T10:00:00Z",
+    })
+    store.ingest_session({
+        "session_id": "sess-B",
+        "agent_type": "openclaw",
+        "started_at":     "2026-05-13T10:00:00Z",
+        "last_active_at": "2026-05-13T10:00:01Z",
+    })
+    for i in range(3):
+        _ingest_event(store, "sess-A", ts=f"2026-05-13T10:00:{i:02d}Z")
+    for i in range(10):
+        _ingest_event(store, "sess-B", ts=f"2026-05-13T10:01:{i:02d}Z")
+    _wait(store)
+
+    rows = {r["session_id"]: r for r in store.query_sessions_table(agent_type="openclaw")}
+    assert rows["sess-A"]["message_count"] == 3
+    assert rows["sess-B"]["message_count"] == 10

--- a/tests/test_transcript_openclaw_shapes.py
+++ b/tests/test_transcript_openclaw_shapes.py
@@ -1,0 +1,289 @@
+"""Regression tests for `_try_local_store_transcript` (#1129 bug 3).
+
+Before the fix, the helper assumed every event row in DuckDB looked like an
+Anthropic message (``{role, content, usage, tool_calls}``) — but OpenClaw
+writes a very different shape (``{type: "<ns>.<action>", data: {...}}``).
+Result: every OpenClaw event rendered with ``role="trace.artifacts"``,
+``content=""``, and ``tokens=0``.
+
+This file pins the post-fix behaviour by feeding synthesized OpenClaw events
+through the helper and asserting that:
+
+* ``prompt.submitted`` produces a single user turn.
+* ``trace.artifacts`` may emit user / assistant / tool turns depending on
+  which fields its ``data`` block carries.
+* ``model.completed`` produces an assistant turn.
+* ``tool.call`` / ``tool.result`` produce tool turns.
+* Plumbing events (``session.ended``, ``context.compiled``,
+  ``agent.heartbeat``) emit NOTHING — no debug-typed roles, no empty
+  bodies.
+* Tokens are summed from ``data.promptCache.lastCallUsage`` and the model
+  is taken from ``modelId``.
+* The legacy Anthropic shape still works (mixed-shape sessions, too).
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Per-test isolated DuckDB store + freshly imported routes module."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.02")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    store = ls.get_store()
+    yield store, sessions_mod
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait(store, timeout=2.0):
+    import time
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.01)
+    raise AssertionError("flusher did not drain")
+
+
+def _ingest(store, sid, data, *, ts="2026-05-13T10:00:00Z", event_type="brain"):
+    store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": sid,
+        "event_type": event_type,
+        "ts": ts,
+        "data": data,
+    })
+
+
+# ── unit-level tests on the pure helpers ──────────────────────────────────
+
+
+def test_is_openclaw_event_discriminator():
+    from routes.sessions import _is_openclaw_event
+    assert _is_openclaw_event({"type": "trace.artifacts", "data": {}})
+    assert _is_openclaw_event({"type": "prompt.submitted"})
+    # Anthropic shape — has role.
+    assert not _is_openclaw_event({"role": "user", "content": "hi"})
+    # No type at all.
+    assert not _is_openclaw_event({"content": "hi"})
+    # Non-dotted type (legacy "tool_result" etc.) — keep on Anthropic path.
+    assert not _is_openclaw_event({"type": "tool_result"})
+
+
+def test_openclaw_event_tokens_prefers_per_call_usage():
+    from routes.sessions import _openclaw_event_tokens
+    data = {"promptCache": {"lastCallUsage": {"input": 100, "output": 50, "total": 150}}}
+    assert _openclaw_event_tokens(data) == 150
+    # Fallback to input+output when total missing.
+    data = {"promptCache": {"lastCallUsage": {"input": 100, "output": 50}}}
+    assert _openclaw_event_tokens(data) == 150
+    # Fallback further to data.usage when no promptCache.
+    data = {"usage": {"input_tokens": 7, "output_tokens": 3}}
+    assert _openclaw_event_tokens(data) == 10
+    assert _openclaw_event_tokens({}) == 0
+
+
+# ── end-to-end tests through the helper ───────────────────────────────────
+
+
+def test_prompt_submitted_produces_user_turn(env):
+    store, sessions_mod = env
+    sid = "sess-prompt"
+    _ingest(store, sid, {
+        "type": "prompt.submitted",
+        "data": {"finalPromptText": "What is 2+2?"},
+    })
+    _wait(store)
+    result = sessions_mod._try_local_store_transcript(sid)
+    assert result is not None
+    msgs = result["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["role"] == "user"
+    assert msgs[0]["content"] == "What is 2+2?"
+
+
+def test_trace_artifacts_emits_user_assistant_and_tool(env):
+    store, sessions_mod = env
+    sid = "sess-trace"
+    _ingest(store, sid, {
+        "type": "trace.artifacts",
+        "modelApi": "anthropic-messages",
+        "modelId": "claude-opus-4-7",
+        "provider": "anthropic",
+        "data": {
+            "finalPromptText": "Read README and summarise.",
+            "finalStatus": "success",
+            "promptCache": {"lastCallUsage": {"input": 1234, "output": 567, "total": 1801}},
+            "assistantTexts": ["Sure — here is the summary."],
+            "toolMetas": [
+                {"name": "Read", "input": {"path": "/tmp/README.md"}, "output": "# Title"},
+            ],
+        },
+    })
+    _wait(store)
+    result = sessions_mod._try_local_store_transcript(sid)
+    msgs = result["messages"]
+    roles = [m["role"] for m in msgs]
+    assert "user" in roles
+    assert "assistant" in roles
+    assert "tool" in roles
+    # Model picked up from modelId (NOT from a missing 'model' field).
+    assert result["model"] == "claude-opus-4-7"
+    # Tokens summed from promptCache.lastCallUsage.total.
+    assert result["totalTokens"] == 1801
+    # No turn carries the debug type "trace.artifacts" as a role.
+    assert "trace.artifacts" not in roles
+    # Tool turn body shows the tool name.
+    tool_msg = next(m for m in msgs if m["role"] == "tool")
+    assert "Read" in tool_msg["content"]
+
+
+def test_trace_artifacts_empty_data_emits_nothing(env):
+    """A trace with no prompt/assistant/tool content should yield zero turns
+    rather than a phantom 'trace.artifacts' message."""
+    store, sessions_mod = env
+    sid = "sess-empty-trace"
+    _ingest(store, sid, {
+        "type": "trace.artifacts",
+        "modelId": "claude-opus-4-7",
+        "data": {"finalStatus": "success"},
+    })
+    _wait(store)
+    result = sessions_mod._try_local_store_transcript(sid)
+    assert result is not None
+    assert result["messages"] == []
+
+
+def test_model_completed_emits_assistant(env):
+    store, sessions_mod = env
+    sid = "sess-model"
+    _ingest(store, sid, {
+        "type": "model.completed",
+        "modelId": "claude-opus-4-7",
+        "data": {"completionText": "Final answer: 4"},
+    })
+    _wait(store)
+    result = sessions_mod._try_local_store_transcript(sid)
+    msgs = result["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["role"] == "assistant"
+    assert "Final answer" in msgs[0]["content"]
+
+
+def test_model_completed_with_assistant_texts_list(env):
+    store, sessions_mod = env
+    sid = "sess-model-list"
+    _ingest(store, sid, {
+        "type": "model.completed",
+        "modelId": "claude-opus-4-7",
+        "data": {"assistantTexts": ["part one ", "part two"]},
+    })
+    _wait(store)
+    result = sessions_mod._try_local_store_transcript(sid)
+    assert len(result["messages"]) == 1
+    assert result["messages"][0]["role"] == "assistant"
+    assert "part one" in result["messages"][0]["content"]
+    assert "part two" in result["messages"][0]["content"]
+
+
+def test_tool_call_and_result(env):
+    store, sessions_mod = env
+    sid = "sess-tools"
+    _ingest(store, sid, {
+        "type": "tool.call",
+        "data": {"name": "Bash", "input": {"cmd": "ls"}},
+    }, ts="2026-05-13T10:00:01Z")
+    _ingest(store, sid, {
+        "type": "tool.result",
+        "data": {"name": "Bash", "output": "file1\nfile2"},
+    }, ts="2026-05-13T10:00:02Z")
+    _wait(store)
+    result = sessions_mod._try_local_store_transcript(sid)
+    msgs = result["messages"]
+    assert len(msgs) == 2
+    assert all(m["role"] == "tool" for m in msgs)
+    assert any("Bash" in m["content"] and "ls" in m["content"] for m in msgs)
+    assert any("file1" in m["content"] for m in msgs)
+
+
+def test_plumbing_events_emit_nothing(env):
+    """session.ended, session.started, context.compiled, agent.heartbeat —
+    NONE of these should produce a transcript turn."""
+    store, sessions_mod = env
+    sid = "sess-plumb"
+    for et in ("session.started", "session.ended", "context.compiled", "agent.heartbeat"):
+        _ingest(store, sid, {"type": et, "data": {"status": "ok"}})
+    _wait(store)
+    result = sessions_mod._try_local_store_transcript(sid)
+    assert result is not None
+    assert result["messages"] == []
+    # And no debug-typed role leaks through.
+    for m in result["messages"]:
+        assert "." not in m["role"]
+
+
+def test_unknown_openclaw_event_does_not_emit_garbage(env):
+    """Unknown <ns>.<action> types should be silently skipped — never emit
+    a turn whose role is 'foo.bar'."""
+    store, sessions_mod = env
+    sid = "sess-unknown"
+    _ingest(store, sid, {"type": "foo.bar", "data": {"content": "anything"}})
+    _wait(store)
+    result = sessions_mod._try_local_store_transcript(sid)
+    assert result["messages"] == []
+
+
+def test_anthropic_shape_still_works(env):
+    """Mixed sessions: legacy Anthropic-style rows + OpenClaw rows must both
+    surface their content."""
+    store, sessions_mod = env
+    sid = "sess-mixed"
+    _ingest(store, sid, {
+        "role": "user", "content": "hello", "usage": {"input_tokens": 5, "output_tokens": 0},
+    }, ts="2026-05-13T10:00:00Z")
+    _ingest(store, sid, {
+        "role": "assistant", "content": "hi back!",
+        "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+        "model": "claude-sonnet-4-5",
+    }, ts="2026-05-13T10:00:01Z")
+    _ingest(store, sid, {
+        "type": "trace.artifacts",
+        "modelId": "claude-opus-4-7",
+        "data": {
+            "assistantTexts": ["second turn"],
+            "promptCache": {"lastCallUsage": {"input": 10, "output": 5, "total": 15}},
+        },
+    }, ts="2026-05-13T10:00:02Z")
+    _wait(store)
+    result = sessions_mod._try_local_store_transcript(sid)
+    msgs = result["messages"]
+    contents = " ".join(m["content"] for m in msgs)
+    assert "hello" in contents
+    assert "hi back!" in contents
+    assert "second turn" in contents
+    # Tokens accumulate across both shapes (Anthropic 5 + Anthropic 8 + OpenClaw 15).
+    assert result["totalTokens"] == 5 + 8 + 15
+
+
+def test_empty_store_returns_none(env):
+    """Returning None lets the JSONL fallback take over for fresh installs."""
+    _store, sessions_mod = env
+    assert sessions_mod._try_local_store_transcript("nonexistent-session") is None


### PR DESCRIPTION
## Summary

Closes the last 2 of 4 bugs from #1129.

### Bug #3 — `/api/transcript/<session_id>` returned empty/garbage for OpenClaw sessions

`_try_local_store_transcript` (routes/sessions.py) assumed every DuckDB event row was an Anthropic-shaped message (`{role, content, usage, tool_calls}`). OpenClaw writes a very different shape: `{type: "<ns>.<action>", data: {...}}`. The old code read `obj.get("role")` (None) then fell back to `obj.get("type")` ("trace.artifacts" — a debug type, not a transcript role), with `content=""` and `tokens=0`. Result: every OpenClaw transcript rendered as a wall of `role="trace.artifacts"` empty rows.

The helper now discriminates via a new `_is_openclaw_event()` check and routes OpenClaw events through `_expand_openclaw_event()` which maps:

| OpenClaw type | Transcript turn(s) |
|---|---|
| `prompt.submitted` | `user` (`data.finalPromptText` / `text` / `prompt`) |
| `trace.artifacts` | optional `user` (`finalPromptText`) + `assistant` (`assistantTexts`) + `tool` per `toolMetas[]` |
| `model.completed` | `assistant` (`completionText` / `text` / `assistantTexts`) |
| `tool.call` / `tool.invoked` | `tool` with formatted name + input |
| `tool.result` / `tool.completed` | `tool` with formatted name + output |
| `session.{started,ended,created}`, `context.compiled`, `agent.heartbeat` | **skipped** (plumbing) |
| Unknown `<x>.<y>` | **skipped** (no garbage roles) |

Tokens sum from `data.promptCache.lastCallUsage.total` (or `input+output`), model prefers `obj.modelId`. Anthropic-shaped events still flow through the original logic — mixed sessions work.

### Bug #4 — `/api/sessions` always reported `message_count: 0`

The `sessions` table has a `message_count` column, but the OpenClaw ingest path never populates it (only `sync.py` + Claude Code adapter do). Fixed `query_sessions_table` (clawmetry/local_store.py) to compute the count on read via a correlated subquery against `events`, taking `GREATEST(stored_value, computed_count)` so adapters that DO populate the column (and may have no events table rows) still work.

## Test plan

- [x] New: `tests/test_transcript_openclaw_shapes.py` (12 tests) — each OpenClaw event type produces correct turns; plumbing events emit nothing; unknown types skipped; Anthropic shape still works; tokens summed from `promptCache.lastCallUsage`; model from `modelId`.
- [x] New: `tests/test_query_sessions_message_count.py` (4 tests) — count from events table; falls back to stored column when no events; uses max when both set; isolated per session.
- [x] Both files: `python3 -m pytest tests/test_transcript_openclaw_shapes.py tests/test_query_sessions_message_count.py -q` → 16 passed.
- [x] Adjacent test suites (`test_sessions_by_type_local_store.py`, `test_local_store.py`, `test_local_store_multi_agent.py`) still pass. Two pre-existing failures in `test_sessions_local_fastpath.py` are unaffected by this PR (verified by re-running on `main`).
- [x] `python3 -c "import ast; [ast.parse(open(f).read()) for f in ['routes/sessions.py', 'clawmetry/local_store.py']]"` clean.

## Notes

Event shapes pasted in the issue description matched what the helper sees in practice. No deviations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)