### PR TITLE
feat(health): daemon-error-rate surfaced in /api/system-health + UI card (PRD #1133 layer 4)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5386,6 +5386,49 @@ async function loadSystemHealth() {
       }
     } catch(e) {}
 
+    // Daemon health (PRD #1133 layer 4) — surface sync.log error rate so
+    // the silent-NameError class of bug stops slipping past users.
+    var dmWrap = document.getElementById('sh-daemon-wrap');
+    var dmEl = document.getElementById('sh-daemon');
+    if (d.daemon && dmEl) {
+      var dm = d.daemon;
+      var dmStatus = dm.status || 'healthy';
+      var dmDot = dmStatus === 'healthy' ? '🟢' : (dmStatus === 'degraded' ? '🟡' : '🔴');
+      var dmColor = dmStatus === 'healthy' ? 'var(--text-success,#22c55e)'
+                  : dmStatus === 'degraded' ? '#f59e0b'
+                  : 'var(--text-error,#dc2626)';
+      var dmLabel = dmStatus === 'healthy' ? 'Healthy'
+                  : dmStatus === 'degraded' ? 'Degraded'
+                  : 'BROKEN';
+      var e5 = dm.errors_last_5min || 0;
+      var e1h = dm.errors_last_1h || 0;
+      var msg = dm.last_error_message || '';
+      // Truncate to 200 chars at the UI layer (parser already capped at 500).
+      var msgShort = msg.length > 200 ? msg.slice(0, 200) + '…' : msg;
+      var html = '<div style="padding:8px 14px;background:var(--bg-secondary);border-radius:8px;border:1px solid var(--border-secondary);font-size:13px;">';
+      html += '<div style="display:flex;align-items:center;gap:8px;">';
+      html += dmDot + ' <span style="font-weight:600;color:' + dmColor + ';">' + dmLabel + '</span>';
+      html += '<span style="color:var(--text-muted);font-size:11px;margin-left:auto;">';
+      html += 'Last 5m: <span style="color:' + (e5 > 0 ? dmColor : 'var(--text-muted)') + ';font-weight:600;">' + e5 + '</span>';
+      html += ' &nbsp;·&nbsp; Last 1h: <span style="color:' + (e1h > 0 ? dmColor : 'var(--text-muted)') + ';font-weight:600;">' + e1h + '</span>';
+      html += '</span></div>';
+      if (msgShort) {
+        html += '<div style="margin-top:8px;padding:6px 8px;background:var(--bg-primary);border:1px solid var(--border-secondary);border-radius:6px;font-family:\'JetBrains Mono\',monospace;font-size:11px;color:var(--text-secondary);word-break:break-word;">';
+        html += escHtml(msgShort);
+        if (dm.last_error_ts) {
+          html += '<div style="margin-top:4px;color:var(--text-muted);font-size:10px;">at ' + escHtml(dm.last_error_ts) + '</div>';
+        }
+        html += '</div>';
+      }
+      if (dm.log_path) {
+        html += '<div style="margin-top:6px;font-size:10px;color:var(--text-muted);font-family:\'JetBrains Mono\',monospace;">📄 ' + escHtml(dm.log_path) + '</div>';
+      }
+      html += '</div>';
+      dmEl.innerHTML = html;
+      // Always show the card — daemon is core infrastructure, even "healthy" is reassuring.
+      if (dmWrap) dmWrap.style.display = '';
+    } else if (dmWrap) { dmWrap.style.display = 'none'; }
+
     // Sandbox Status (conditional)
     var sbWrap = document.getElementById('sh-sandbox-wrap');
     var sbEl = document.getElementById('sh-sandbox');

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -180,6 +180,17 @@
           margin-bottom:6px;
           ">Heartbeat</div>
         <div id="sh-heartbeat" style="margin-bottom:14px;"></div>
+        <!-- 🛠️ Daemon health (PRD #1133 layer 4) — surfaces sync.log error rate -->
+        <div id="sh-daemon-wrap" style="display:none;">
+          <div style="
+            font-size:11px;
+            text-transform:uppercase;
+            letter-spacing:1.5px;
+            color:var(--text-muted);
+            font-weight:600;
+            margin-bottom:6px;
+            ">🛠️ Daemon health</div>
+        <div id="sh-daemon" style="margin-bottom:14px;"></div></div>
         <div id="sh-sandbox-wrap" style="display:none;">
           <div style="
             font-size:11px;

--- a/routes/health.py
+++ b/routes/health.py
@@ -35,16 +35,166 @@ Module-level helpers (``_history_db``, ``AgentReliabilityScorer``,
 import hashlib
 import json
 import os
+import re
 import socket
 import subprocess
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
 
 bp_health = Blueprint('health', __name__)
+
+
+# ---------------------------------------------------------------------------
+# Daemon-log error-rate parser (PRD #1133 layer 4 — read side only)
+#
+# Reads the tail of ``~/.clawmetry/sync.log`` and counts ERROR-level lines in
+# rolling 5-min and 1-hour windows so the System Health card can warn the
+# user when the cloud-sync daemon is silently failing (e.g. the
+# ``ALERTS_EVAL_INTERVAL_SEC`` NameError that was logging 4×/min on every
+# install since 0.12.179 with no in-product surface).
+#
+# Pure helpers — no Flask globals — so they can be unit-tested without a
+# running server. The endpoint that consumes these lives below in
+# ``api_system_health``.
+# ---------------------------------------------------------------------------
+
+# Lines look like:
+#   2026-05-13 09:33:52,180 [clawmetry-sync] ERROR Sync cycle error: ...
+# Capture the timestamp + the message body (everything after the level).
+_DAEMON_LOG_LINE_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?:[,.]\d+)?\s+"
+    r"\[[^\]]+\]\s+(?P<level>[A-Z]+)\s+(?P<msg>.*)$"
+)
+
+# How many lines to read from the tail of the log. Safe upper bound: even at
+# 60 ERROR lines/min (well above the PRD trigger of 10/min) a 1-hour window
+# only sees ~3,600 lines, and we cap at 1,000 to stay cheap on slower disks.
+DAEMON_LOG_TAIL_LINES = 1000
+
+
+def _default_daemon_log_path():
+    """Return the canonical sync.log path. Honours ``CLAWMETRY_HOME`` for tests."""
+    home = os.environ.get("CLAWMETRY_HOME") or os.path.expanduser("~/.clawmetry")
+    return os.path.join(home, "sync.log")
+
+
+def _tail_lines(path, n=DAEMON_LOG_TAIL_LINES):
+    """Return the last ``n`` lines of ``path`` (or [] if missing/unreadable).
+
+    Uses a bounded read from the end of the file so we never load multi-MB
+    logs into memory. Falls back to a full read for tiny files.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return []
+    # Estimate ~256 bytes/line average for our log format; cap at 512 KB.
+    read_bytes = min(size, max(256 * n, 64 * 1024), 512 * 1024)
+    try:
+        with open(path, "rb") as f:
+            if size > read_bytes:
+                f.seek(size - read_bytes)
+                # Drop the partial first line so we never split mid-record.
+                f.readline()
+            data = f.read()
+    except OSError:
+        return []
+    try:
+        text = data.decode("utf-8", errors="replace")
+    except Exception:
+        return []
+    lines = text.splitlines()
+    return lines[-n:] if len(lines) > n else lines
+
+
+def _parse_daemon_log_line(line):
+    """Return ``(ts_epoch, level, message)`` or ``None`` if the line is non-conforming.
+
+    Timestamps in the log are local-time without TZ info; we treat them as
+    naive local time (which matches how Python's ``logging`` module writes
+    them). For window arithmetic we convert via ``mktime``.
+    """
+    m = _DAEMON_LOG_LINE_RE.match(line)
+    if not m:
+        return None
+    try:
+        dt = datetime.strptime(m.group("ts"), "%Y-%m-%d %H:%M:%S")
+        ts_epoch = time.mktime(dt.timetuple())
+    except (ValueError, OverflowError):
+        return None
+    return ts_epoch, m.group("level"), m.group("msg")
+
+
+def compute_daemon_health(log_path=None, now=None):
+    """Read the tail of the daemon log and return a health summary dict.
+
+    Returns the structure documented in PRD #1133 layer 4:
+
+        {
+            "log_path": "<absolute path>",
+            "errors_last_5min": int,
+            "errors_last_1h": int,
+            "last_error_message": str | None,
+            "last_error_ts": ISO-8601 str | None,
+            "status": "healthy" | "degraded" | "broken",
+            "log_present": bool,
+        }
+
+    Status thresholds (per PRD): >30 errors in 5 min → ``broken``,
+    >0 → ``degraded``, else ``healthy``. Missing/empty log → ``healthy``
+    so a fresh install doesn't flash red.
+    """
+    path = log_path or _default_daemon_log_path()
+    now_ts = now if now is not None else time.time()
+    summary = {
+        "log_path": path,
+        "errors_last_5min": 0,
+        "errors_last_1h": 0,
+        "last_error_message": None,
+        "last_error_ts": None,
+        "status": "healthy",
+        "log_present": os.path.exists(path),
+    }
+    if not summary["log_present"]:
+        return summary
+
+    cutoff_5m = now_ts - 5 * 60
+    cutoff_1h = now_ts - 60 * 60
+    last_err_ts = None
+    last_err_msg = None
+    for line in _tail_lines(path):
+        parsed = _parse_daemon_log_line(line)
+        if not parsed:
+            continue
+        ts_epoch, level, msg = parsed
+        if level != "ERROR":
+            continue
+        if ts_epoch >= cutoff_1h:
+            summary["errors_last_1h"] += 1
+        if ts_epoch >= cutoff_5m:
+            summary["errors_last_5min"] += 1
+        if last_err_ts is None or ts_epoch >= last_err_ts:
+            last_err_ts = ts_epoch
+            last_err_msg = msg
+
+    if last_err_ts is not None:
+        # Render in UTC so the dashboard can reason about it consistently.
+        summary["last_error_ts"] = (
+            datetime.fromtimestamp(last_err_ts, tz=timezone.utc).isoformat()
+        )
+        # Truncate to 500 chars at the parser layer; UI re-truncates to 200
+        # for display. Keeps the API payload bounded for chatty errors.
+        summary["last_error_message"] = (last_err_msg or "")[:500]
+
+    if summary["errors_last_5min"] > 30:
+        summary["status"] = "broken"
+    elif summary["errors_last_5min"] > 0:
+        summary["status"] = "degraded"
+    return summary
 
 
 # ---------------------------------------------------------------------------
@@ -546,6 +696,23 @@ def api_system_health():
         "resources": resources_state,
     }
 
+    # --- DAEMON ERROR-RATE (PRD #1133 layer 4) ---
+    # Tails ~/.clawmetry/sync.log so the user notices silent NameError-class
+    # daemon bugs without having to ssh in and `tail -f` the log.
+    try:
+        daemon_health = compute_daemon_health()
+    except Exception:
+        # Never crash on bad input — fall back to a healthy-shaped null block.
+        daemon_health = {
+            "log_path": _default_daemon_log_path(),
+            "errors_last_5min": 0,
+            "errors_last_1h": 0,
+            "last_error_message": None,
+            "last_error_ts": None,
+            "status": "healthy",
+            "log_present": False,
+        }
+
     return jsonify(
         {
             "services": services,
@@ -562,6 +729,7 @@ def api_system_health():
             "inference": _d._detect_inference_metadata(),
             "security": _d._detect_security_metadata(),
             "service_status": service_status,
+            "daemon": daemon_health,
         }
     )
 

--- a/tests/test_daemon_health_endpoint.py
+++ b/tests/test_daemon_health_endpoint.py
@@ -1,0 +1,249 @@
+"""Pure-unit tests for the daemon-log error-rate parser (PRD #1133 layer 4).
+
+Covers ``routes.health.compute_daemon_health`` — the helper that powers the
+new ``daemon`` block on ``/api/system-health``. We test the parser directly
+(no Flask server, no network, no sleep) because the integration tests in
+``test_api.py`` already exercise the wider endpoint surface.
+
+Why this matters: shipped 2026-05-13 because the 0.12.179 NameError
+(``ALERTS_EVAL_INTERVAL_SEC``) was logging 4×/min on every install with no
+in-product surface. The user only noticed by manually tailing
+``~/.clawmetry/sync.log``.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from datetime import datetime
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+from routes.health import (  # noqa: E402
+    _DAEMON_LOG_LINE_RE,
+    _parse_daemon_log_line,
+    _tail_lines,
+    compute_daemon_health,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _fmt_ts(epoch):
+    """Format an epoch second as ``YYYY-MM-DD HH:MM:SS,mmm`` (daemon format)."""
+    return datetime.fromtimestamp(epoch).strftime("%Y-%m-%d %H:%M:%S,000")
+
+
+def _err(epoch, msg="Sync cycle error: name 'ALERTS_EVAL_INTERVAL_SEC' is not defined"):
+    return f"{_fmt_ts(epoch)} [clawmetry-sync] ERROR {msg}"
+
+
+def _info(epoch, msg="✓ Cloud sync activated — uploads resumed."):
+    return f"{_fmt_ts(epoch)} [clawmetry-sync] INFO {msg}"
+
+
+def _warn(epoch, msg="pending_query dispatch failed"):
+    return f"{_fmt_ts(epoch)} [clawmetry-sync] WARNING {msg}"
+
+
+def _write_log(tmp_path, lines):
+    p = tmp_path / "sync.log"
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(p)
+
+
+# ── Parser-level tests ─────────────────────────────────────────────────────────
+
+
+class TestLineRegex:
+    def test_matches_real_error_line(self):
+        line = "2026-05-13 09:33:53,864 [clawmetry-sync] ERROR Sync cycle error: name 'X' is not defined"
+        m = _DAEMON_LOG_LINE_RE.match(line)
+        assert m is not None
+        assert m.group("level") == "ERROR"
+        assert m.group("ts") == "2026-05-13 09:33:53"
+        assert m.group("msg").startswith("Sync cycle error:")
+
+    def test_matches_warning_line(self):
+        line = "2026-05-13 09:33:54,014 [clawmetry-sync] WARNING pending_query dispatch failed (id=q_brain)"
+        m = _DAEMON_LOG_LINE_RE.match(line)
+        assert m is not None
+        assert m.group("level") == "WARNING"
+
+    def test_rejects_garbage(self):
+        assert _DAEMON_LOG_LINE_RE.match("Traceback (most recent call last):") is None
+        assert _DAEMON_LOG_LINE_RE.match("") is None
+
+    def test_parse_returns_none_for_garbage(self):
+        assert _parse_daemon_log_line("Traceback (most recent call last):") is None
+        assert _parse_daemon_log_line("") is None
+
+    def test_parse_returns_tuple(self):
+        out = _parse_daemon_log_line(_err(time.time(), msg="boom"))
+        assert out is not None
+        ts_epoch, level, msg = out
+        assert level == "ERROR"
+        assert msg == "boom"
+        assert isinstance(ts_epoch, float)
+
+
+# ── Tail-reader tests ──────────────────────────────────────────────────────────
+
+
+class TestTailLines:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _tail_lines(str(tmp_path / "nope.log")) == []
+
+    def test_reads_small_file(self, tmp_path):
+        p = _write_log(tmp_path, ["a", "b", "c"])
+        assert _tail_lines(p) == ["a", "b", "c"]
+
+    def test_returns_last_n(self, tmp_path):
+        p = _write_log(tmp_path, [f"line {i}" for i in range(5000)])
+        out = _tail_lines(p, n=10)
+        assert len(out) == 10
+        assert out[-1] == "line 4999"
+
+
+# ── compute_daemon_health() — the contract surface ────────────────────────────
+
+
+class TestComputeDaemonHealth:
+    def test_missing_log_is_healthy(self, tmp_path):
+        path = str(tmp_path / "absent.log")
+        out = compute_daemon_health(log_path=path)
+        assert out["log_present"] is False
+        assert out["errors_last_5min"] == 0
+        assert out["errors_last_1h"] == 0
+        assert out["last_error_message"] is None
+        assert out["last_error_ts"] is None
+        assert out["status"] == "healthy"
+        assert out["log_path"] == path
+
+    def test_empty_log_is_healthy(self, tmp_path):
+        p = _write_log(tmp_path, [])
+        out = compute_daemon_health(log_path=p)
+        assert out["log_present"] is True
+        assert out["errors_last_5min"] == 0
+        assert out["status"] == "healthy"
+        assert out["last_error_message"] is None
+
+    def test_only_info_lines_is_healthy(self, tmp_path):
+        now = time.time()
+        p = _write_log(tmp_path, [_info(now - i) for i in range(20)])
+        out = compute_daemon_health(log_path=p, now=now)
+        assert out["errors_last_5min"] == 0
+        assert out["errors_last_1h"] == 0
+        assert out["status"] == "healthy"
+
+    def test_warnings_dont_count_as_errors(self, tmp_path):
+        now = time.time()
+        p = _write_log(tmp_path, [_warn(now - i * 5) for i in range(10)])
+        out = compute_daemon_health(log_path=p, now=now)
+        assert out["errors_last_5min"] == 0
+        assert out["status"] == "healthy"
+
+    def test_few_recent_errors_is_degraded(self, tmp_path):
+        # 3 errors in the last 5 min — above 0, well below 30.
+        now = time.time()
+        lines = [_err(now - 30, msg="boom one"), _err(now - 60, msg="boom two"),
+                 _err(now - 90, msg="boom three")]
+        p = _write_log(tmp_path, lines)
+        out = compute_daemon_health(log_path=p, now=now)
+        assert out["errors_last_5min"] == 3
+        assert out["errors_last_1h"] == 3
+        assert out["status"] == "degraded"
+        assert out["last_error_ts"] is not None
+        # Most recent line's message wins.
+        assert out["last_error_message"] == "boom one"
+
+    def test_50_recent_errors_is_broken(self, tmp_path):
+        # 50 errors all within the last 5 min — exceeds the 30 threshold.
+        now = time.time()
+        lines = [_err(now - i, msg=f"boom {i}") for i in range(50)]
+        p = _write_log(tmp_path, lines)
+        out = compute_daemon_health(log_path=p, now=now)
+        assert out["errors_last_5min"] == 50
+        assert out["errors_last_1h"] == 50
+        assert out["status"] == "broken"
+        assert out["last_error_message"] == "boom 0"
+
+    def test_old_errors_outside_1h_dont_count(self, tmp_path):
+        # 5 errors from 2 hours ago — neither window picks them up.
+        now = time.time()
+        lines = [_err(now - 7200 - i, msg=f"ancient {i}") for i in range(5)]
+        p = _write_log(tmp_path, lines)
+        out = compute_daemon_health(log_path=p, now=now)
+        assert out["errors_last_5min"] == 0
+        assert out["errors_last_1h"] == 0
+        assert out["status"] == "healthy"
+        # The most-recent ERROR line still surfaces in last_error_message
+        # (the user wants to know the daemon DID have errors at some point).
+        assert out["last_error_message"] is not None
+        assert out["last_error_message"].startswith("ancient")
+
+    def test_mixed_window_buckets(self, tmp_path):
+        # 2 errors in the last 5 min, 8 more between 5-60 min, 4 more older.
+        now = time.time()
+        lines = []
+        lines += [_err(now - 30, msg="recent A"), _err(now - 200, msg="recent B")]
+        lines += [_err(now - 600 - i * 60, msg=f"mid {i}") for i in range(8)]
+        lines += [_err(now - 7200 - i, msg=f"old {i}") for i in range(4)]
+        # Throw in some non-error noise to make sure it's filtered.
+        lines += [_info(now - 10), _warn(now - 20)]
+        p = _write_log(tmp_path, lines)
+        out = compute_daemon_health(log_path=p, now=now)
+        assert out["errors_last_5min"] == 2
+        assert out["errors_last_1h"] == 10  # 2 recent + 8 mid
+        assert out["status"] == "degraded"
+        assert out["last_error_message"] == "recent A"
+
+    def test_truncates_very_long_message(self, tmp_path):
+        now = time.time()
+        big = "x" * 5000
+        p = _write_log(tmp_path, [_err(now - 10, msg=big)])
+        out = compute_daemon_health(log_path=p, now=now)
+        assert out["last_error_message"] is not None
+        assert len(out["last_error_message"]) <= 500
+
+    def test_iso_timestamp_is_utc(self, tmp_path):
+        now = time.time()
+        p = _write_log(tmp_path, [_err(now - 5, msg="probe")])
+        out = compute_daemon_health(log_path=p, now=now)
+        assert out["last_error_ts"] is not None
+        # ISO-8601 with explicit timezone offset.
+        assert "T" in out["last_error_ts"]
+        assert out["last_error_ts"].endswith("+00:00") or "Z" in out["last_error_ts"]
+
+    def test_garbage_lines_dont_crash(self, tmp_path):
+        now = time.time()
+        lines = [
+            "Traceback (most recent call last):",
+            '  File "/foo/bar.py", line 12, in <module>',
+            "    raise SystemExit(1)",
+            _err(now - 30, msg="real error"),
+            "",
+            "garbage \x00 line",
+        ]
+        p = _write_log(tmp_path, lines)
+        out = compute_daemon_health(log_path=p, now=now)
+        # Only the one ERROR line counts; garbage is silently dropped.
+        assert out["errors_last_5min"] == 1
+        assert out["last_error_message"] == "real error"
+
+
+class TestEnvOverride:
+    def test_clawmetry_home_env_var_changes_default_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAWMETRY_HOME", str(tmp_path))
+        # No log written — should be log_present=False but pointed at our tmp.
+        out = compute_daemon_health()
+        assert out["log_path"] == str(tmp_path / "sync.log")
+        assert out["log_present"] is False
+        assert out["status"] == "healthy"


### PR DESCRIPTION
## Why

Earlier today the ClawMetry daemon was logging
`Sync cycle error: name 'ALERTS_EVAL_INTERVAL_SEC' is not defined` 4×/min on
**every install since 0.12.179** — 440+ occurrences over 2 hours on a single
machine. The user only discovered it by manually `tail`-ing
`~/.clawmetry/sync.log`. There is no in-product surface for daemon-side
errors today: System Health shows disks/CPU/uptime but says nothing about
whether the cloud-sync daemon itself is failing.

This PR ships the **read side** of [PRD #1133 layer 4](https://github.com/vivekchand/clawmetry/issues/1133)
so the next silent-NameError-class regression is visible on the dashboard
within seconds. No daemon-side changes — purely instrumenting what's
already in the log file.

## What

**Endpoint (`routes/health.py`)** — `/api/system-health` gains a top-level
`daemon` block:

```json
{
  "daemon": {
    "log_path": "/Users/.../.clawmetry/sync.log",
    "errors_last_5min": 3,
    "errors_last_1h": 12,
    "last_error_message": "Sync cycle error: name 'ALERTS_EVAL_INTERVAL_SEC' is not defined",
    "last_error_ts": "2026-05-13T17:42:11+00:00",
    "status": "degraded",
    "log_present": true
  }
}
```

- Tails the last ~1000 lines of `~/.clawmetry/sync.log` (bounded to 512 KB
  from EOF — cheap even on slow disks).
- Counts ERROR-level lines in rolling 5-min and 1-hour windows.
- Status thresholds per PRD: `>30/5min → broken`, `>0 → degraded`, else
  `healthy`. Missing log → `healthy` so fresh installs don't flash red.
- Honours `CLAWMETRY_HOME` for tests / non-default installs.

**UI (`overview.html` + `app.js`)** — new "🛠️ Daemon health" card in the
System Health panel showing:
- Status pill (🟢 Healthy / 🟡 Degraded / 🔴 BROKEN)
- Inline counts: "Last 5m: N · Last 1h: M" (colour-coded)
- Truncated last error message (200 chars) in a monospace box with the
  ISO-8601 timestamp underneath
- Footer with the log path so users know exactly where to tail

**Tests (`tests/test_daemon_health_endpoint.py`)** — 20 pure-unit tests, no
server / network / sleep:
- Empty / missing log → `healthy`
- Only INFO/WARNING noise → `healthy`
- 3 errors in last 5 min → `degraded`
- 50 errors in last 5 min → `broken`
- Mixed window buckets (recent + mid + old) — assert correct counts
- Old errors (>1h) excluded from windows but `last_error_message` still surfaces
- Garbage / traceback lines silently dropped (never crash on bad input)
- Long error messages truncated to 500 chars at parser layer
- `CLAWMETRY_HOME` env override changes default path

## Out of scope (deferred to follow-up PRs)

- Daemon-side `event_type='daemon.error'` heartbeat row to DuckDB
- Cloud sync of the daemon error stream
- Anything that touches daemon code or local_store code

## Test plan

- [x] `python3 -m pytest tests/test_daemon_health_endpoint.py -q` → 20 passed in 0.14s
- [x] `python3 -c "import ast; ast.parse(open('routes/health.py').read())"` → OK
- [x] `node -e "new Function(fs.readFileSync('clawmetry/static/js/app.js','utf8'))"` → OK
- [x] Jinja parse of `tabs/overview.html` → OK
- [ ] Screenshot of the new card on a real install (TODO before merge)
- [ ] Manual smoke against a sync.log with synthetic ERROR lines

## References

- PRD #1133 — daemon-error visibility (this is layer 4, read side)
- Originating bug: 0.12.179 `ALERTS_EVAL_INTERVAL_SEC` NameError, 440+ occurrences

🤖 Generated with [Claude Code](https://claude.com/claude-code)