### PR TITLE
test(e2e): capture full error.stack to surface JS source line (unblocks 0.12.181 diagnosis)

### DIFF
--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -227,7 +227,7 @@ async function testNormalUser() {
   const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
   const page = await ctx.newPage();
   const errors = [];
-  page.on('pageerror', e => errors.push(`pageerror: ${e.message.slice(0, 200)}`));
+  page.on('pageerror', e => errors.push(`pageerror: ${(e.stack || e.toString()).slice(0, 2000)}`));
   page.on('console', m => {
     if (m.type() === 'error') {
       const loc = m.location() || {};


### PR DESCRIPTION
## Summary
- Enrich `tests/e2e/cloud-contract.mjs` pageerror capture: store `e.stack` (truncated to 2000 chars) instead of `e.message.slice(0, 200)`.
- Surfaces the actual file:line where `Cannot read properties of null (reading 'sequence')` originates, unblocking diagnosis of the 0.12.181 release.
- One-line change, assertion logic unchanged.

## Test plan
- [x] `node -c tests/e2e/cloud-contract.mjs` parse-check passes
- [ ] CI re-run will show the file:line stack frame for any future pageerror failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)