### PR TITLE
fix(sync): v3 parser stores data.type for transcript discriminator (closes MOAT)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1498,7 +1498,16 @@ def _parse_v3_event(
 
     # Defaults; overridden per type below.
     event_type = "unknown"
+    # ``data`` mirrors the TRAJECTORY shape that routes/sessions.py expects:
+    # top-level ``type`` + ``timestamp`` + sometimes ``modelId`` for the
+    # discriminator / model picker, and a NESTED ``data`` sub-dict carrying
+    # the content fields (``finalPromptText``, ``completionText``,
+    # ``promptCache``, ``toolMetas`` …) that ``_expand_openclaw_event`` and
+    # ``_openclaw_event_tokens`` read. The legacy flat keys that #1135's
+    # parser stored at the top level are kept alongside the nested copy so
+    # existing brain-feed / debug consumers keep working.
     data: dict = {"_v3_type": t}  # preserve the original tag for debugging
+    inner: dict = {}  # nested ``data.data`` payload — matches trajectory shape
     cost_usd: float | None = None
     token_count: int | None = None
     model: str | None = None
@@ -1513,6 +1522,11 @@ def _parse_v3_event(
             "cwd": obj.get("cwd"),
             "timestamp": ts,
         })
+        inner.update({
+            "id": obj.get("id"),
+            "version": obj.get("version"),
+            "cwd": obj.get("cwd"),
+        })
 
     elif t == "model_change":
         event_type = "model.changed"
@@ -1521,6 +1535,10 @@ def _parse_v3_event(
             "modelId": model,
             "provider": obj.get("provider"),
             "timestamp": ts,
+        })
+        inner.update({
+            "modelId": model,
+            "provider": obj.get("provider"),
         })
 
     elif t == "message":
@@ -1575,8 +1593,10 @@ def _parse_v3_event(
                 "finalPromptText": text,
                 "timestamp": ts,
             })
+            inner["finalPromptText"] = text
             if last_call_usage:
                 data["promptCache"] = {"lastCallUsage": last_call_usage}
+                inner["promptCache"] = {"lastCallUsage": last_call_usage}
         elif role == "assistant":
             event_type = "model.completed"
             model = msg.get("model") or model
@@ -1589,10 +1609,19 @@ def _parse_v3_event(
                 "timestamp": ts,
                 "stopReason": msg.get("stopReason"),
             })
+            inner.update({
+                "completionText": text,
+                "assistantTexts": [text] if text else [],
+                "modelId": model,
+                "provider": msg.get("provider"),
+                "stopReason": msg.get("stopReason"),
+            })
             if tool_metas:
                 data["toolMetas"] = tool_metas
+                inner["toolMetas"] = tool_metas
             if last_call_usage:
                 data["promptCache"] = {"lastCallUsage": last_call_usage}
+                inner["promptCache"] = {"lastCallUsage": last_call_usage}
         else:
             # Unknown role — be conservative, drop rather than mis-classify.
             return None
@@ -1608,6 +1637,11 @@ def _parse_v3_event(
             "id": obj.get("id"),
             "timestamp": ts,
         })
+        inner.update({
+            "name": obj.get("name") or "tool",
+            "input": obj.get("input") or {},
+            "id": obj.get("id"),
+        })
 
     elif t == "tool_use_result":
         event_type = "tool.result"
@@ -1622,12 +1656,31 @@ def _parse_v3_event(
             "is_error": obj.get("is_error"),
             "timestamp": ts,
         })
+        inner.update({
+            "tool_use_id": obj.get("tool_use_id"),
+            "output": result_text,
+            "result": result_text,
+            "is_error": obj.get("is_error"),
+        })
 
     else:
         # Unknown v3 event — log + drop so future schema additions don't
         # silently land as event_type="unknown" rows that pollute analytics.
         log.debug("unknown v3 event type %r — skipping (session=%s)", t, session_id)
         return None
+
+    # MOAT fix: stamp the dot.separated event_type onto data.type so
+    # routes/sessions.py::_is_openclaw_event (PR #1132) recognises this
+    # row as an OpenClaw event. Without this the discriminator sees
+    # data.type == None, falls back to the Anthropic shape, and
+    # /api/transcript/<sid> renders 0 messages even though brain-history
+    # (which reads the event_type column directly) works fine.
+    data["type"] = event_type
+    # MOAT fix part 2: attach the nested ``data`` payload that the
+    # trajectory parser produces (``data: obj`` of the raw event line) so
+    # ``_expand_openclaw_event`` / ``_openclaw_event_tokens`` find the
+    # content + usage at the same key paths as for trajectory events.
+    data["data"] = inner
 
     return {
         "id": str(eid),

--- a/tests/test_moat_e2e_regression_1129.py
+++ b/tests/test_moat_e2e_regression_1129.py
@@ -477,3 +477,124 @@ def test_sessions_message_count_reflects_actual_event_count(isolated_store):
         f"empty session should report message_count=0, got "
         f"{by_sid['s-empty']['message_count']!r}"
     )
+
+
+# ── Test 5 — v3 underscore session renders end-to-end via fast path ───────
+
+
+def test_v3_session_renders_transcript_via_local_store_fast_path(isolated_store):
+    """Bug 5 (MOAT closing): real-world OpenClaw .jsonl files use the v3
+    underscore schema (#1135). PR #1137 added ``_parse_v3_event`` which
+    maps each underscore type to the trajectory-shape dot.separated
+    ``event_type`` column — but the parser dropped ``type`` from the
+    serialised ``data`` blob and stored content fields FLAT at the top
+    level.
+
+    The downstream transcript expander in routes/sessions.py uses
+    ``_is_openclaw_event(obj)`` which checks ``obj.get("type")`` for a dot;
+    on v3-mapped rows that returned None, so the OpenClaw branch never
+    fired, the function fell through to the Anthropic shape, and
+    /api/transcript/<sid> rendered 0 messages even though /api/brain-history
+    (which reads the typed event_type column directly) worked fine.
+
+    This test feeds a synthetic v3 session through the daemon ingest path
+    and asserts that ``_try_local_store_transcript`` returns the local_store
+    fast path with the correct user/assistant/tool turns. On main before
+    this PR: messageCount==0. After: messageCount>=3 (user, assistant, tool).
+    """
+    sync = isolated_store["sync"]
+    ls = isolated_store["ls"]
+    store = ls.get_store()
+
+    sid = "moat-bug5-v3-session"
+    base = datetime.now(timezone.utc)
+    def _ts(offset_sec):
+        return (base + timedelta(seconds=offset_sec)).isoformat().replace("+00:00", "Z")
+
+    # Real-shape v3 events (mirror what OpenClaw writes today).
+    v3_events = [
+        {"type": "session", "version": 3, "id": sid,
+         "timestamp": _ts(0), "cwd": "/tmp/x"},
+        {"type": "model_change", "id": "mc1", "timestamp": _ts(1),
+         "modelId": "claude-opus-4-7", "provider": "anthropic"},
+        {"type": "message", "id": "u1", "timestamp": _ts(2),
+         "message": {"role": "user",
+                     "content": [{"type": "text", "text": "ping"}]}},
+        {"type": "message", "id": "a1", "timestamp": _ts(3),
+         "message": {"role": "assistant",
+                     "content": [{"type": "text", "text": "pong"}],
+                     "model": "claude-opus-4-7",
+                     "usage": {"input": 10, "output": 5, "totalTokens": 15}}},
+        {"type": "tool_use_result", "id": "tr1", "timestamp": _ts(4),
+         "tool_use_id": "tu1",
+         "content": [{"type": "text", "text": "tool ran"}]},
+    ]
+
+    sync._local_ingest_session_batch(
+        v3_events,
+        session_file=f"{sid}.jsonl",
+        node_id="agent+test-1129",
+        subagent_id=None,
+    )
+    _wait_drained(store)
+
+    # Reload routes/sessions.py so it picks up the same local_store singleton.
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    result = sessions_mod._try_local_store_transcript(sid)
+    assert result is not None, (
+        "_try_local_store_transcript returned None for a v3 session — "
+        "the fast path short-circuited (rows empty or exception)."
+    )
+    assert result.get("_source") == "local_store", (
+        f"transcript must come from local_store fast path, got "
+        f"_source={result.get('_source')!r}"
+    )
+
+    msgs = result.get("messages") or []
+    by_role_content = [(m.get("role"), m.get("content")) for m in msgs]
+
+    # Reject phantom rows that the buggy fallback might emit.
+    bad_roles = [m for m in msgs
+                 if m.get("role") in ("session.started", "model.changed",
+                                      "prompt.submitted", "model.completed",
+                                      "tool.result", "unknown")]
+    assert not bad_roles, (
+        f"transcript leaked v3 wire-protocol event types as transcript roles: "
+        f"{bad_roles!r}. The renderer must map them to user/assistant/tool."
+    )
+
+    # The 3 real turns must be present with correct role mapping.
+    assert ("user", "ping") in by_role_content, (
+        f"missing user turn ('ping') from v3 message(user→prompt.submitted). "
+        f"Got: {by_role_content!r}"
+    )
+    assistants = [c for r, c in by_role_content if r == "assistant"]
+    assert any("pong" in (c or "") for c in assistants), (
+        f"missing assistant turn ('pong') from v3 message(assistant→model.completed). "
+        f"Got: {by_role_content!r}"
+    )
+    tools = [c for r, c in by_role_content if r == "tool"]
+    assert any("tool ran" in (c or "") for c in tools), (
+        f"missing tool turn ('tool ran') from v3 tool_use_result→tool.result. "
+        f"Got: {by_role_content!r}"
+    )
+
+    assert result.get("messageCount", 0) >= 3, (
+        f"expected at least 3 transcript turns (user + assistant + tool), got "
+        f"{result.get('messageCount')!r}: {by_role_content!r}. "
+        f"This is the MOAT-closing bug — without data.type the OpenClaw "
+        f"discriminator rejects every v3 row."
+    )
+
+    # Model must be picked up from data.modelId on the assistant turn.
+    assert result.get("model") == "claude-opus-4-7", (
+        f"model not extracted from v3 assistant data.modelId; "
+        f"got {result.get('model')!r}"
+    )
+    # Tokens must come from data.data.promptCache.lastCallUsage.total.
+    assert result.get("totalTokens", 0) >= 15, (
+        f"totalTokens should reflect v3 usage.totalTokens (15), "
+        f"got {result.get('totalTokens')!r}"
+    )

--- a/tests/test_v3_schema_parser.py
+++ b/tests/test_v3_schema_parser.py
@@ -244,6 +244,95 @@ def test_v3_event_without_timestamp_is_skipped():
     assert sync._parse_v3_event(obj, session_id="s", node_id="n") is None
 
 
+# ── data.type mirrors event_type — fixes MOAT transcript discriminator ────
+
+
+@pytest.mark.parametrize("raw_obj,expected_event_type", [
+    # session
+    ({"type": "session", "version": 3, "id": "s", "timestamp": "2026-05-12T22:35:31Z", "cwd": "/x"},
+     "session.started"),
+    # model_change
+    ({"type": "model_change", "id": "m", "timestamp": "2026-05-12T22:35:31Z",
+      "modelId": "claude-opus-4-7", "provider": "anthropic"},
+     "model.changed"),
+    # message (user)
+    ({"type": "message", "id": "u", "timestamp": "2026-05-12T22:35:31Z",
+      "message": {"role": "user", "content": "hi"}},
+     "prompt.submitted"),
+    # message (assistant)
+    ({"type": "message", "id": "a", "timestamp": "2026-05-12T22:35:31Z",
+      "message": {"role": "assistant", "content": [{"type": "text", "text": "yo"}],
+                  "model": "claude-opus-4-7", "usage": {"input": 1, "output": 1, "totalTokens": 2}}},
+     "model.completed"),
+    # tool_use
+    ({"type": "tool_use", "id": "t", "timestamp": "2026-05-12T22:35:31Z",
+      "name": "bash", "input": {"command": "ls"}},
+     "tool.call"),
+    # tool_use_result
+    ({"type": "tool_use_result", "id": "tr", "timestamp": "2026-05-12T22:35:31Z",
+      "tool_use_id": "t", "content": [{"type": "text", "text": "ok"}]},
+     "tool.result"),
+])
+def test_v3_parser_stamps_data_type_matching_event_type(raw_obj, expected_event_type):
+    """MOAT discriminator fix (PR #fix-v3-data-type-discriminator):
+    ``_parse_v3_event`` MUST stamp the dot.separated event_type onto the
+    ``data["type"]`` key for every type it handles.
+
+    Without this, ``routes/sessions.py::_is_openclaw_event`` reads
+    ``data.get("type") -> None`` and rejects the row, falling through to
+    the Anthropic-shape branch which doesn't know how to read v3 content.
+    The result is /api/transcript/<sid> rendering 0 messages even though
+    /api/brain-history (which reads the typed event_type column directly)
+    shows the events fine.
+    """
+    sync = _import_sync()
+    row = sync._parse_v3_event(raw_obj, session_id="sess-1", node_id="n")
+    assert row is not None, f"parser dropped {raw_obj['type']!r}"
+    assert row["event_type"] == expected_event_type
+    # The critical invariant: data.type == event_type column.
+    assert row["data"].get("type") == row["event_type"], (
+        f"data.type ({row['data'].get('type')!r}) must match event_type "
+        f"({row['event_type']!r}) — see PR #1132's _is_openclaw_event "
+        f"discriminator. raw obj: {raw_obj!r}"
+    )
+
+
+@pytest.mark.parametrize("raw_obj,expected_event_type", [
+    ({"type": "message", "id": "u", "timestamp": "2026-05-12T22:35:31Z",
+      "message": {"role": "user", "content": "hi"}},
+     "prompt.submitted"),
+    ({"type": "message", "id": "a", "timestamp": "2026-05-12T22:35:31Z",
+      "message": {"role": "assistant", "content": [{"type": "text", "text": "yo"}],
+                  "model": "claude-opus-4-7", "usage": {"input": 1, "output": 1, "totalTokens": 2}}},
+     "model.completed"),
+    ({"type": "tool_use_result", "id": "tr", "timestamp": "2026-05-12T22:35:31Z",
+      "tool_use_id": "t", "content": [{"type": "text", "text": "ok"}]},
+     "tool.result"),
+])
+def test_v3_parser_nests_content_under_data_data(raw_obj, expected_event_type):
+    """MOAT expander fix: ``_expand_openclaw_event`` reads content from
+    the NESTED ``data.data.*`` path (because trajectory parser stores
+    ``data: obj`` of the raw event, which itself has a nested ``data`` key).
+    The v3 parser must mirror that shape so the same expander works on both."""
+    sync = _import_sync()
+    row = sync._parse_v3_event(raw_obj, session_id="sess-1", node_id="n")
+    assert row is not None
+    assert row["event_type"] == expected_event_type
+    inner = row["data"].get("data")
+    assert isinstance(inner, dict), (
+        f"data.data must be a dict so routes/sessions.py::_expand_openclaw_event "
+        f"can read content fields from it. Got {inner!r}."
+    )
+    if expected_event_type == "prompt.submitted":
+        assert inner.get("finalPromptText") == "hi"
+    elif expected_event_type == "model.completed":
+        assert inner.get("completionText") == "yo"
+        assert inner.get("modelId") == "claude-opus-4-7"
+        assert inner["promptCache"]["lastCallUsage"]["total"] == 2
+    elif expected_event_type == "tool.result":
+        assert inner.get("output") == "ok"
+
+
 def test_v3_tool_use_result_becomes_tool_result():
     sync = _import_sync()
     obj = {


### PR DESCRIPTION
## Summary

Closes the MOAT transcript path for canonical v3 OpenClaw sessions.

The v3 underscore parser (PR #1137) correctly mapped event types onto the dot.separated ``event_type`` column, but the ``data`` JSON blob stored alongside dropped the ``type`` field — only ``_v3_type`` (the original underscore tag) survived.

PR #1132's transcript discriminator in ``routes/sessions.py::_is_openclaw_event`` checks ``obj.get("type")`` for a dot-separator. On v3 rows it saw ``None`` → False → fell through to the Anthropic-shape branch → 0 messages rendered. ``/api/brain-history`` worked fine because it reads the typed ``event_type`` column directly, masking the bug.

Two fixes in ``_parse_v3_event``:

1. **Stamp ``data.type``** = the dot.separated event_type, so the discriminator recognises the row.
2. **Nest content under ``data.data``** mirroring trajectory shape, so ``_expand_openclaw_event`` and ``_openclaw_event_tokens`` find content + usage at the same key paths they already use for trajectory events. Without this the discriminator passes but the expander returns 0 turns because it reads ``data.data.finalPromptText`` etc.

The original flat top-level keys (``finalPromptText``, ``completionText`` …) are kept alongside the nested copy so brain-feed / debug consumers and the existing #1135 parser tests keep working.

Verified live on 0.12.181: synthetic v3 session writes 5 events with correct event_type column but data.type=None. After this fix the transcript fast path returns ``_source: local_store`` with correct user/assistant/tool role mapping and tokens summed from ``data.data.promptCache.lastCallUsage``.

## Test plan

- [x] ``tests/test_v3_schema_parser.py`` — 9 new parametrized tests pin ``data["type"] == row["event_type"]`` for every parser mapping and ``data["data"]`` carries the content fields.
- [x] ``tests/test_moat_e2e_regression_1129.py`` — new layer-1 regression test feeds a synthetic v3 session through ``_local_ingest_session_batch`` and asserts ``_try_local_store_transcript`` returns ``_source: local_store`` with user/assistant/tool turns + model + tokens.
- [x] All 28 v3 parser tests pass; new MOAT test passes; pre-existing test 3 failure (``test_transcript_renders_openclaw_event_shapes``) is unchanged (separate latent bug in the expander's flat-shape handling, not in scope per fix constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)