### PR TITLE
feat(health): gateway process health panel (closes #852)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5429,6 +5429,65 @@ async function loadSystemHealth() {
       if (dmWrap) dmWrap.style.display = '';
     } else if (dmWrap) { dmWrap.style.display = 'none'; }
 
+    // Gateway health (#852) — surface OpenClaw gateway process vitals
+    // (RSS / CPU / uptime). The ~600MB → ~945MB memory-bloat-OOM pattern
+    // was invisible from the dashboard until this card landed.
+    var gwWrap = document.getElementById('sh-gateway-wrap');
+    var gwEl = document.getElementById('sh-gateway');
+    if (d.gateway && gwEl) {
+      var gw = d.gateway;
+      var gwStatus = gw.status || 'not_running';
+      var gwDot, gwLabel, gwColor;
+      if (gwStatus === 'critical') {
+        gwDot = '🔴'; gwLabel = 'Critical'; gwColor = 'var(--text-error,#dc2626)';
+      } else if (gwStatus === 'warning') {
+        gwDot = '🟡'; gwLabel = 'Warning'; gwColor = '#f59e0b';
+      } else if (gwStatus === 'healthy') {
+        gwDot = '🟢'; gwLabel = 'Healthy'; gwColor = 'var(--text-success,#22c55e)';
+      } else {
+        gwDot = '⚫'; gwLabel = 'Not running'; gwColor = 'var(--text-muted)';
+      }
+      var rss = (typeof gw.rss_mb === 'number') ? gw.rss_mb : null;
+      var thr = gw.memory_threshold_mb || 900;
+      var memPct = (rss !== null) ? Math.min(100, Math.round((rss / thr) * 100)) : 0;
+      var memBarColor = (gwStatus === 'critical') ? 'var(--text-error,#dc2626)'
+                      : (gwStatus === 'warning') ? '#f59e0b'
+                      : 'var(--text-success,#22c55e)';
+      // Pretty uptime: "1d 3h", "47m", "12s"
+      function _fmtUp(s) {
+        if (s === null || s === undefined) return '—';
+        s = Math.max(0, Math.floor(s));
+        if (s < 60) return s + 's';
+        if (s < 3600) return Math.floor(s/60) + 'm';
+        if (s < 86400) return Math.floor(s/3600) + 'h ' + Math.floor((s%3600)/60) + 'm';
+        return Math.floor(s/86400) + 'd ' + Math.floor((s%86400)/3600) + 'h';
+      }
+      var gwHtml = '<div style="padding:8px 14px;background:var(--bg-secondary);border-radius:8px;border:1px solid var(--border-secondary);font-size:13px;">';
+      gwHtml += '<div style="display:flex;align-items:center;gap:8px;">';
+      gwHtml += gwDot + ' <span style="font-weight:600;color:' + gwColor + ';">' + gwLabel + '</span>';
+      if (gw.pid) {
+        gwHtml += '<span style="color:var(--text-muted);font-size:11px;font-family:\'JetBrains Mono\',monospace;">PID ' + gw.pid + '</span>';
+      }
+      gwHtml += '<span style="color:var(--text-muted);font-size:11px;margin-left:auto;">Uptime: <span style="color:var(--text-secondary);font-weight:600;">' + _fmtUp(gw.uptime_seconds) + '</span></span>';
+      gwHtml += '</div>';
+      if (rss !== null) {
+        gwHtml += '<div style="margin-top:8px;">';
+        gwHtml += '<div style="display:flex;justify-content:space-between;font-size:11px;color:var(--text-muted);margin-bottom:4px;">';
+        gwHtml += '<span>Memory</span>';
+        gwHtml += '<span style="color:' + gwColor + ';font-weight:600;">' + rss + ' MB</span><span> / ' + thr + ' MB</span>';
+        gwHtml += '</div>';
+        gwHtml += '<div style="height:6px;background:var(--bg-primary);border-radius:3px;overflow:hidden;border:1px solid var(--border-secondary);">';
+        gwHtml += '<div style="height:100%;width:' + memPct + '%;background:' + memBarColor + ';transition:width 0.3s ease;"></div>';
+        gwHtml += '</div></div>';
+      }
+      if (typeof gw.cpu_pct === 'number') {
+        gwHtml += '<div style="margin-top:6px;font-size:11px;color:var(--text-muted);">CPU: <span style="color:var(--text-secondary);font-weight:600;">' + gw.cpu_pct + '%</span></div>';
+      }
+      gwHtml += '</div>';
+      gwEl.innerHTML = gwHtml;
+      if (gwWrap) gwWrap.style.display = '';
+    } else if (gwWrap) { gwWrap.style.display = 'none'; }
+
     // Sandbox Status (conditional)
     var sbWrap = document.getElementById('sh-sandbox-wrap');
     var sbEl = document.getElementById('sh-sandbox');

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -191,6 +191,17 @@
             margin-bottom:6px;
             ">🛠️ Daemon health</div>
         <div id="sh-daemon" style="margin-bottom:14px;"></div></div>
+        <!-- 🛰️ Gateway health (#852) — OpenClaw gateway process vitals -->
+        <div id="sh-gateway-wrap" style="display:none;">
+          <div style="
+            font-size:11px;
+            text-transform:uppercase;
+            letter-spacing:1.5px;
+            color:var(--text-muted);
+            font-weight:600;
+            margin-bottom:6px;
+            ">🛰️ Gateway health</div>
+        <div id="sh-gateway" style="margin-bottom:14px;"></div></div>
         <div id="sh-sandbox-wrap" style="display:none;">
           <div style="
             font-size:11px;

--- a/routes/health.py
+++ b/routes/health.py
@@ -16,6 +16,7 @@ Owns the 11 routes registered on bp_health:
   GET  /api/health-stream         — SSE auto-refresh of health checks (30s)
   GET  /api/sandbox-status        — sandbox / inference / security posture
   GET  /api/loop-detection        — scan recent sessions for repeated tool-call loops (#849)
+  GET  /api/gateway-health        — OpenClaw gateway process vitals (#852)
 
 Module-level helpers (``_history_db``, ``AgentReliabilityScorer``,
 ``_find_log_file``, ``SESSIONS_DIR``, ``_load_gw_config``, ``_detect_gateway_port``,
@@ -195,6 +196,272 @@ def compute_daemon_health(log_path=None, now=None):
     elif summary["errors_last_5min"] > 0:
         summary["status"] = "degraded"
     return summary
+
+
+# ---------------------------------------------------------------------------
+# Gateway process health (#852).
+#
+# OpenClaw's gateway is a separate process listening on :18789. We already
+# socket-check the port from ``/api/system-health`` — this surface adds
+# process-level vitals (RSS, CPU, uptime) so the user can spot the slow
+# memory-bloat-then-crash pattern (~600 MB → ~945 MB OOM) before the gateway
+# dies. ``psutil`` is preferred when available; otherwise we fall back to a
+# bounded ``ps`` invocation so we don't add a hard dependency for OSS installs
+# that don't ship psutil.
+#
+# Pure helpers — no Flask globals — so they're unit-testable without a server.
+# ---------------------------------------------------------------------------
+
+# Memory bloat threshold. OpenClaw gateway has been observed to crash around
+# 945 MB; 900 MB gives us a ~50 MB cushion to surface "critical" before OOM.
+# warning kicks in at 75% of this (= 675 MB).
+GATEWAY_MEMORY_THRESHOLD_MB = 900
+GATEWAY_MEMORY_WARNING_RATIO = 0.75
+
+
+def _default_gateway_pid_path():
+    """Canonical path to OpenClaw's gateway PID file.
+
+    Honours ``OPENCLAW_HOME`` so multi-workspace setups + tests can override.
+    """
+    home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+    return os.path.join(home, "gateway", "gateway.pid")
+
+
+def _read_gateway_pid(pid_path=None):
+    """Return the gateway PID as an int, or ``None`` if missing/unreadable.
+
+    The OpenClaw gateway writes its PID to ``~/.openclaw/gateway/gateway.pid``
+    when it starts. We treat any unreadable/garbage file as "no gateway"
+    rather than crashing — same graceful-degrade contract as the rest of
+    ``routes/health.py``.
+    """
+    path = pid_path or _default_gateway_pid_path()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = f.read().strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    # Some daemons write "<pid>\n<extra metadata>" — take just the first token.
+    first = raw.splitlines()[0].strip().split()[0] if raw.split() else ""
+    try:
+        pid = int(first)
+    except ValueError:
+        return None
+    return pid if pid > 0 else None
+
+
+def _find_gateway_pid_by_cmdline():
+    """Walk running processes for an ``openclaw-gateway`` cmdline.
+
+    Used as a fallback when the PID file is missing (Docker installs, manual
+    starts, stale PID files). Prefers psutil when available; otherwise runs
+    a bounded ``ps -eo pid,command`` and scans cmdlines.
+    """
+    try:
+        import psutil  # type: ignore
+
+        for p in psutil.process_iter(["pid", "cmdline"]):
+            try:
+                cmd = " ".join(p.info.get("cmdline") or [])
+                if "openclaw-gateway" in cmd or "openclaw/gateway" in cmd:
+                    return int(p.info["pid"])
+            except Exception:
+                continue
+        return None
+    except Exception:
+        pass
+    # ps fallback — wide enough cmdline column to spot the gateway.
+    try:
+        out = subprocess.run(
+            ["ps", "-eo", "pid=,command="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        for line in (out.stdout or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if "openclaw-gateway" not in line and "openclaw/gateway" not in line:
+                continue
+            head = line.split(None, 1)
+            if not head:
+                continue
+            try:
+                return int(head[0])
+            except ValueError:
+                continue
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+def _process_vitals_psutil(pid):
+    """Return ``(uptime_seconds, rss_mb, cpu_pct)`` via psutil, or ``None``."""
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return None
+    try:
+        proc = psutil.Process(pid)
+        # cpu_percent() with interval=None returns the value since the last
+        # call; first call returns 0.0. That's fine — the next /api/system-health
+        # poll (and there will be one ~every 30s) returns a real number.
+        with proc.oneshot():
+            rss_bytes = proc.memory_info().rss
+            create_ts = proc.create_time()
+            cpu_pct = proc.cpu_percent(interval=None)
+    except Exception:
+        return None
+    uptime = max(0, int(time.time() - create_ts))
+    rss_mb = round(rss_bytes / (1024 * 1024), 1)
+    return uptime, rss_mb, round(float(cpu_pct), 1)
+
+
+def _process_vitals_ps(pid):
+    """Return ``(uptime_seconds, rss_mb, cpu_pct)`` via ``ps`` fallback, or ``None``.
+
+    ``ps -o rss=,pcpu=,etime= -p <pid>`` works on macOS + Linux. ``rss`` is
+    in kilobytes; ``etime`` is a duration we parse to seconds.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "rss=,pcpu=,etime=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+    line = (out.stdout or "").strip()
+    if not line:
+        return None
+    parts = line.split()
+    if len(parts) < 3:
+        return None
+    try:
+        rss_kb = int(parts[0])
+        cpu_pct = float(parts[1])
+    except ValueError:
+        return None
+    rss_mb = round(rss_kb / 1024.0, 1)
+    uptime = _parse_etime(parts[2])
+    return uptime, rss_mb, round(cpu_pct, 1)
+
+
+def _parse_etime(etime):
+    """Parse ``ps`` ``etime`` (``[[dd-]hh:]mm:ss``) to seconds, or 0 on garbage."""
+    if not etime:
+        return 0
+    days = 0
+    rest = etime
+    if "-" in rest:
+        d, _, rest = rest.partition("-")
+        try:
+            days = int(d)
+        except ValueError:
+            days = 0
+    parts = rest.split(":")
+    try:
+        parts_i = [int(p) for p in parts]
+    except ValueError:
+        return 0
+    if len(parts_i) == 3:
+        h, m, s = parts_i
+    elif len(parts_i) == 2:
+        h, m, s = 0, parts_i[0], parts_i[1]
+    elif len(parts_i) == 1:
+        h, m, s = 0, 0, parts_i[0]
+    else:
+        return 0
+    return days * 86400 + h * 3600 + m * 60 + s
+
+
+def _classify_gateway_status(rss_mb, threshold_mb):
+    """Memory-pressure classification used by the dashboard badge."""
+    if rss_mb is None:
+        return "not_running"
+    if rss_mb > threshold_mb:
+        return "critical"
+    if rss_mb > threshold_mb * GATEWAY_MEMORY_WARNING_RATIO:
+        return "warning"
+    return "healthy"
+
+
+def compute_gateway_health(
+    pid_path=None,
+    threshold_mb=GATEWAY_MEMORY_THRESHOLD_MB,
+    _psutil_vitals=_process_vitals_psutil,
+    _ps_vitals=_process_vitals_ps,
+    _cmdline_pid=_find_gateway_pid_by_cmdline,
+):
+    """Return the gateway-process health payload documented in issue #852.
+
+    Discovery order:
+      1. PID file at ``~/.openclaw/gateway/gateway.pid``.
+      2. Cmdline scan for ``openclaw-gateway`` (psutil, then ``ps``).
+
+    Vitals source order:
+      1. psutil (rss + cpu + create_time).
+      2. ``ps -o rss=,pcpu=,etime= -p <pid>`` fallback.
+
+    Returns the canonical shape — all keys always present, fields default to
+    ``None`` when the gateway isn't running:
+
+        {
+          "pid": int | null,
+          "uptime_seconds": int | null,
+          "rss_mb": float | null,
+          "cpu_pct": float | null,
+          "status": "healthy" | "warning" | "critical" | "not_running",
+          "memory_threshold_mb": 900,
+        }
+    """
+    payload = {
+        "pid": None,
+        "uptime_seconds": None,
+        "rss_mb": None,
+        "cpu_pct": None,
+        "status": "not_running",
+        "memory_threshold_mb": threshold_mb,
+    }
+    pid = _read_gateway_pid(pid_path)
+    if pid is None:
+        try:
+            pid = _cmdline_pid()
+        except Exception:
+            pid = None
+    if pid is None:
+        return payload
+
+    vitals = None
+    try:
+        vitals = _psutil_vitals(pid)
+    except Exception:
+        vitals = None
+    if vitals is None:
+        try:
+            vitals = _ps_vitals(pid)
+        except Exception:
+            vitals = None
+    if vitals is None:
+        # PID exists but we can't read vitals (process gone between calls,
+        # permission denied, ps not on PATH). Report the PID we found but
+        # leave vitals null — UI still renders "Running, vitals unavailable".
+        payload["pid"] = pid
+        payload["status"] = "warning"
+        return payload
+
+    uptime, rss_mb, cpu_pct = vitals
+    payload["pid"] = pid
+    payload["uptime_seconds"] = uptime
+    payload["rss_mb"] = rss_mb
+    payload["cpu_pct"] = cpu_pct
+    payload["status"] = _classify_gateway_status(rss_mb, threshold_mb)
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -713,6 +980,21 @@ def api_system_health():
             "log_present": False,
         }
 
+    # --- GATEWAY PROCESS HEALTH (#852) ---
+    # Surfaces RSS / CPU / uptime so the ~600MB → ~945MB OOM pattern is
+    # visible from the dashboard, not just by tailing logs.
+    try:
+        gateway_health = compute_gateway_health()
+    except Exception:
+        gateway_health = {
+            "pid": None,
+            "uptime_seconds": None,
+            "rss_mb": None,
+            "cpu_pct": None,
+            "status": "not_running",
+            "memory_threshold_mb": GATEWAY_MEMORY_THRESHOLD_MB,
+        }
+
     return jsonify(
         {
             "services": services,
@@ -730,8 +1012,32 @@ def api_system_health():
             "security": _d._detect_security_metadata(),
             "service_status": service_status,
             "daemon": daemon_health,
+            "gateway": gateway_health,
         }
     )
+
+
+@bp_health.route("/api/gateway-health")
+def api_gateway_health():
+    """Standalone JSON probe for gateway process vitals (#852).
+
+    Mirrors the ``gateway`` block returned by ``/api/system-health`` so an
+    operator (or external monitor) can poll just this surface without
+    pulling the full system-health payload.
+    """
+    try:
+        return jsonify(compute_gateway_health())
+    except Exception:
+        return jsonify(
+            {
+                "pid": None,
+                "uptime_seconds": None,
+                "rss_mb": None,
+                "cpu_pct": None,
+                "status": "not_running",
+                "memory_threshold_mb": GATEWAY_MEMORY_THRESHOLD_MB,
+            }
+        )
 
 
 @bp_health.route("/api/health")

--- a/tests/test_gateway_health.py
+++ b/tests/test_gateway_health.py
@@ -1,0 +1,352 @@
+"""Unit tests for the gateway process-health surface (issue #852).
+
+Covers ``routes.health.compute_gateway_health`` — the helper that powers the
+new ``gateway`` block on ``/api/system-health`` (and the standalone
+``/api/gateway-health`` endpoint).
+
+We exercise the pure helper directly (no Flask, no network, no actual gateway
+process) by injecting stub ``psutil``/``ps``/cmdline-scan callables. This
+mirrors how ``test_daemon_health_endpoint.py`` covers the daemon-log parser:
+keep the contract honest, keep the test cheap.
+
+Threshold defaults (per issue #852):
+  - 900 MB hard cap (OpenClaw OOMs ~945 MB) → ``critical``
+  - 75% of cap = 675 MB → ``warning``
+  - everything below → ``healthy``
+  - no gateway process found → all fields null + ``not_running``
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+from routes.health import (  # noqa: E402
+    GATEWAY_MEMORY_THRESHOLD_MB,
+    GATEWAY_MEMORY_WARNING_RATIO,
+    _classify_gateway_status,
+    _parse_etime,
+    _read_gateway_pid,
+    compute_gateway_health,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _write_pid(tmp_path, value):
+    """Write ``value`` (str|int) to a fake gateway.pid file. Returns the path."""
+    gw_dir = tmp_path / "gateway"
+    gw_dir.mkdir(parents=True, exist_ok=True)
+    p = gw_dir / "gateway.pid"
+    p.write_text(str(value), encoding="utf-8")
+    return str(p)
+
+
+def _vitals_stub(uptime, rss_mb, cpu_pct):
+    """Factory: returns a callable that mimics ``_process_vitals_*`` shape."""
+
+    def _fn(pid):
+        return uptime, rss_mb, cpu_pct
+
+    return _fn
+
+
+def _vitals_unavailable(pid):
+    return None
+
+
+def _no_cmdline_scan():
+    return None
+
+
+# ── PID-file parsing ───────────────────────────────────────────────────────────
+
+
+class TestReadGatewayPid:
+    def test_missing_pid_file_returns_none(self, tmp_path):
+        assert _read_gateway_pid(str(tmp_path / "nope.pid")) is None
+
+    def test_reads_clean_pid(self, tmp_path):
+        p = _write_pid(tmp_path, 12345)
+        assert _read_gateway_pid(p) == 12345
+
+    def test_trims_whitespace_and_trailing_newline(self, tmp_path):
+        p = tmp_path / "gw.pid"
+        p.write_text("   54321  \n\n", encoding="utf-8")
+        assert _read_gateway_pid(str(p)) == 54321
+
+    def test_garbage_pid_returns_none(self, tmp_path):
+        p = tmp_path / "gw.pid"
+        p.write_text("not-a-pid", encoding="utf-8")
+        assert _read_gateway_pid(str(p)) is None
+
+    def test_zero_pid_returns_none(self, tmp_path):
+        p = tmp_path / "gw.pid"
+        p.write_text("0", encoding="utf-8")
+        assert _read_gateway_pid(str(p)) is None
+
+    def test_negative_pid_returns_none(self, tmp_path):
+        p = tmp_path / "gw.pid"
+        p.write_text("-1", encoding="utf-8")
+        assert _read_gateway_pid(str(p)) is None
+
+    def test_empty_pid_file_returns_none(self, tmp_path):
+        p = tmp_path / "gw.pid"
+        p.write_text("", encoding="utf-8")
+        assert _read_gateway_pid(str(p)) is None
+
+    def test_multiline_pid_file_takes_first_token(self, tmp_path):
+        # Some daemons write "<pid>\n<port>\n<state>" — we want just the PID.
+        p = tmp_path / "gw.pid"
+        p.write_text("9999\n18789\nstarted", encoding="utf-8")
+        assert _read_gateway_pid(str(p)) == 9999
+
+
+# ── etime parser ───────────────────────────────────────────────────────────────
+
+
+class TestParseEtime:
+    def test_seconds_only(self):
+        assert _parse_etime("42") == 42
+
+    def test_minutes_seconds(self):
+        assert _parse_etime("12:34") == 12 * 60 + 34
+
+    def test_hours_minutes_seconds(self):
+        assert _parse_etime("01:02:03") == 3600 + 120 + 3
+
+    def test_days_hours_minutes_seconds(self):
+        # 2 days, 03:04:05 → 2*86400 + 3*3600 + 4*60 + 5
+        assert _parse_etime("2-03:04:05") == 2 * 86400 + 3 * 3600 + 4 * 60 + 5
+
+    def test_empty_returns_zero(self):
+        assert _parse_etime("") == 0
+
+    def test_garbage_returns_zero(self):
+        assert _parse_etime("not-a-duration") == 0
+
+
+# ── Status classification ─────────────────────────────────────────────────────
+
+
+class TestClassifyGatewayStatus:
+    def test_none_is_not_running(self):
+        assert _classify_gateway_status(None, 900) == "not_running"
+
+    def test_well_below_warning_is_healthy(self):
+        assert _classify_gateway_status(120.0, 900) == "healthy"
+
+    def test_just_under_warning_threshold_is_healthy(self):
+        # 75% of 900 = 675; 674 stays healthy.
+        assert _classify_gateway_status(674.0, 900) == "healthy"
+
+    def test_above_warning_threshold_is_warning(self):
+        # 75% of 900 = 675; 676 trips warning.
+        assert _classify_gateway_status(676.0, 900) == "warning"
+
+    def test_just_under_hard_cap_is_warning(self):
+        assert _classify_gateway_status(899.9, 900) == "warning"
+
+    def test_above_hard_cap_is_critical(self):
+        assert _classify_gateway_status(901.0, 900) == "critical"
+
+    def test_far_above_hard_cap_is_critical(self):
+        assert _classify_gateway_status(945.0, 900) == "critical"
+
+    def test_warning_ratio_default_is_three_quarters(self):
+        # Lock the default so a future "small tweak" doesn't drift it.
+        assert GATEWAY_MEMORY_WARNING_RATIO == 0.75
+
+    def test_threshold_default_is_900mb(self):
+        assert GATEWAY_MEMORY_THRESHOLD_MB == 900
+
+
+# ── compute_gateway_health — the contract surface ──────────────────────────────
+
+
+class TestComputeGatewayHealthNotRunning:
+    def test_missing_pid_file_and_no_cmdline_match_is_not_running(self, tmp_path):
+        out = compute_gateway_health(
+            pid_path=str(tmp_path / "absent.pid"),
+            _psutil_vitals=_vitals_unavailable,
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out == {
+            "pid": None,
+            "uptime_seconds": None,
+            "rss_mb": None,
+            "cpu_pct": None,
+            "status": "not_running",
+            "memory_threshold_mb": 900,
+        }
+
+    def test_cmdline_scan_finds_pid_when_pidfile_missing(self, tmp_path):
+        # No PID file — but the cmdline scan finds an openclaw-gateway proc.
+        out = compute_gateway_health(
+            pid_path=str(tmp_path / "absent.pid"),
+            _psutil_vitals=_vitals_stub(60, 200.0, 1.5),
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=lambda: 7777,
+        )
+        assert out["pid"] == 7777
+        assert out["rss_mb"] == 200.0
+        assert out["status"] == "healthy"
+
+    def test_pid_found_but_vitals_unreadable_is_warning(self, tmp_path):
+        # Process exists (PID file present) but neither psutil nor ps can read
+        # its vitals — surface "warning" rather than fake-healthy.
+        p = _write_pid(tmp_path, 5555)
+        out = compute_gateway_health(
+            pid_path=p,
+            _psutil_vitals=_vitals_unavailable,
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out["pid"] == 5555
+        assert out["status"] == "warning"
+        assert out["rss_mb"] is None
+        assert out["cpu_pct"] is None
+        assert out["uptime_seconds"] is None
+
+
+class TestComputeGatewayHealthThresholds:
+    def test_healthy_well_under_threshold(self, tmp_path):
+        p = _write_pid(tmp_path, 1234)
+        out = compute_gateway_health(
+            pid_path=p,
+            _psutil_vitals=_vitals_stub(3600, 250.0, 4.2),
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out["pid"] == 1234
+        assert out["uptime_seconds"] == 3600
+        assert out["rss_mb"] == 250.0
+        assert out["cpu_pct"] == 4.2
+        assert out["status"] == "healthy"
+        assert out["memory_threshold_mb"] == 900
+
+    def test_warning_between_75pct_and_threshold(self, tmp_path):
+        p = _write_pid(tmp_path, 1234)
+        out = compute_gateway_health(
+            pid_path=p,
+            _psutil_vitals=_vitals_stub(60, 700.0, 12.0),
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out["status"] == "warning"
+
+    def test_critical_above_threshold(self, tmp_path):
+        p = _write_pid(tmp_path, 1234)
+        out = compute_gateway_health(
+            pid_path=p,
+            _psutil_vitals=_vitals_stub(86400, 945.0, 33.0),
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out["status"] == "critical"
+        assert out["rss_mb"] == 945.0
+        assert out["uptime_seconds"] == 86400
+
+    def test_custom_threshold_is_honoured(self, tmp_path):
+        # Operator can override the default cap (e.g. node with more RAM).
+        p = _write_pid(tmp_path, 4242)
+        out = compute_gateway_health(
+            pid_path=p,
+            threshold_mb=1500,
+            _psutil_vitals=_vitals_stub(60, 950.0, 1.0),
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        # 950 MB > 75% of 1500 (1125)? No — 950 < 1125, so still healthy.
+        assert out["status"] == "healthy"
+        assert out["memory_threshold_mb"] == 1500
+
+    def test_falls_back_to_ps_when_psutil_returns_none(self, tmp_path):
+        p = _write_pid(tmp_path, 1234)
+        out = compute_gateway_health(
+            pid_path=p,
+            _psutil_vitals=_vitals_unavailable,
+            _ps_vitals=_vitals_stub(120, 400.0, 8.0),
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out["rss_mb"] == 400.0
+        assert out["uptime_seconds"] == 120
+        assert out["cpu_pct"] == 8.0
+        assert out["status"] == "healthy"
+
+    def test_psutil_takes_precedence_over_ps(self, tmp_path):
+        # When both work, psutil wins (more accurate cpu measurement).
+        p = _write_pid(tmp_path, 1234)
+        out = compute_gateway_health(
+            pid_path=p,
+            _psutil_vitals=_vitals_stub(99, 111.0, 1.0),
+            _ps_vitals=_vitals_stub(88, 222.0, 2.0),
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out["rss_mb"] == 111.0
+        assert out["uptime_seconds"] == 99
+
+
+class TestPayloadShape:
+    def test_keys_always_present(self, tmp_path):
+        out = compute_gateway_health(
+            pid_path=str(tmp_path / "absent.pid"),
+            _psutil_vitals=_vitals_unavailable,
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        for key in (
+            "pid",
+            "uptime_seconds",
+            "rss_mb",
+            "cpu_pct",
+            "status",
+            "memory_threshold_mb",
+        ):
+            assert key in out, f"missing key: {key}"
+
+    def test_status_is_documented_enum(self, tmp_path):
+        # Cycle through every status path and confirm the value is one of the
+        # four canonical strings the frontend knows how to render.
+        valid = {"healthy", "warning", "critical", "not_running"}
+
+        p = _write_pid(tmp_path, 1234)
+        # critical
+        out = compute_gateway_health(
+            pid_path=p,
+            _psutil_vitals=_vitals_stub(1, 1000.0, 0.0),
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out["status"] in valid and out["status"] == "critical"
+
+        # not_running
+        out = compute_gateway_health(
+            pid_path=str(tmp_path / "absent.pid"),
+            _psutil_vitals=_vitals_unavailable,
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out["status"] in valid and out["status"] == "not_running"
+
+
+class TestEnvOverride:
+    def test_openclaw_home_env_var_changes_default_pid_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path))
+        # No PID file under our tmp $OPENCLAW_HOME → not_running.
+        out = compute_gateway_health(
+            _psutil_vitals=_vitals_unavailable,
+            _ps_vitals=_vitals_unavailable,
+            _cmdline_pid=_no_cmdline_scan,
+        )
+        assert out["pid"] is None
+        assert out["status"] == "not_running"


### PR DESCRIPTION
## Summary
- Surfaces OpenClaw gateway process vitals (PID, RSS, CPU, uptime) so the ~600 MB → ~945 MB memory-bloat-OOM pattern is visible from the dashboard instead of from `tail -f`.
- Pure helper `compute_gateway_health()` in `routes/health.py` discovers the gateway via `~/.openclaw/gateway/gateway.pid` first, then cmdline scan; reads vitals via `psutil` when available and falls back to `ps -o rss=,pcpu=,etime= -p <pid>` (no new dependency).
- Adds `/api/gateway-health` standalone endpoint and a `gateway` block on `/api/system-health`; new "🛰️ Gateway health" card on the System Health column next to the Daemon health card.

## Thresholds
| Status | Trigger |
| --- | --- |
| `critical` | RSS > 900 MB (50 MB cushion below observed ~945 MB OOM) |
| `warning` | RSS > 675 MB (75% of 900) |
| `healthy` | RSS ≤ 675 MB |
| `not_running` | no PID file + no cmdline match |

Threshold is overridable per call (`threshold_mb=`); UI bar tracks the active value.

## Restart count
Deferred to v2 — needs cross-poll PID state. Issue notes this is OK to omit for v1.

## Test plan
- [x] `python3 -m pytest tests/test_gateway_health.py -q` — 35 passed
- [x] `python3 -m pytest tests/test_daemon_health_endpoint.py -q` — 20 passed (sibling card unaffected)
- [x] Route registers cleanly under `bp_health` (`/api/gateway-health` + payload merged into `/api/system-health`)
- [ ] Manual smoke: start OpenClaw, hit `/api/gateway-health`, confirm card renders + bar color matches RSS state
- [ ] Confirm "Not running" state when gateway is stopped (card shows ⚫ + "Not running")

🤖 Generated with [Claude Code](https://claude.com/claude-code)