### PR TITLE
feat(crons): per-job run timeline (closes #605)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4560,16 +4560,151 @@ function toggleCronExpand(jobId) {
   renderCrons();
 }
 
+// Renders the per-job run timeline (issue #605): sparkline + stat row + table.
+// Pulled out of loadCronRuns so the markup is reviewable as a single unit and
+// can be unit-tested by passing a synthetic runs array via window.
+function _renderCronRunTimeline(jobId, runs, jobJobs) {
+  if (!runs || !runs.length) return '';
+  // Sparkline: last min(30, runs.length) runs (most-recent FIRST in `runs`).
+  var spark = runs.slice(0, 30).slice().reverse(); // oldest -> newest left-to-right
+  var maxDur = 1;
+  spark.forEach(function(r) {
+    var d = r.duration_ms || 0;
+    if (d > maxDur) maxDur = d;
+  });
+  var W = 240, H = 36, pad = 2;
+  var step = spark.length > 1 ? (W - 2*pad) / (spark.length - 1) : 0;
+  var svg = '<svg width="' + W + '" height="' + H + '" style="display:block;background:var(--bg-secondary,#111);border-radius:4px;" aria-label="Last ' + spark.length + ' runs">';
+  // Polyline for duration trend.
+  var pts = spark.map(function(r, i) {
+    var d = r.duration_ms || 0;
+    var x = pad + i * step;
+    var y = H - pad - (d / maxDur) * (H - 2*pad);
+    return x.toFixed(1) + ',' + y.toFixed(1);
+  }).join(' ');
+  svg += '<polyline fill="none" stroke="var(--text-muted,#888)" stroke-width="1" points="' + pts + '" />';
+  // Status dots
+  spark.forEach(function(r, i) {
+    var d = r.duration_ms || 0;
+    var x = pad + i * step;
+    var y = H - pad - (d / maxDur) * (H - 2*pad);
+    var color = (r.status === 'ok' || r.status === 'success' || r.status === 'completed') ? '#4ade80'
+              : (r.status === 'error' || r.status === 'failed' || r.status === 'failure') ? '#f87171'
+              : '#fbbf24';
+    var tip = new Date(r.ts).toLocaleString() + ' - ' + (r.status||'?') + ' - ' + (d/1000).toFixed(2) + 's';
+    svg += '<circle cx="' + x.toFixed(1) + '" cy="' + y.toFixed(1) + '" r="2.5" fill="' + color + '"><title>' + escHtml(tip) + '</title></circle>';
+  });
+  svg += '</svg>';
+
+  // Stats: success rate, MTBF (mean time between failures), avg tokens/run.
+  var total = runs.length;
+  var okN = 0, errN = 0;
+  var tokSum = 0, tokN = 0;
+  var failTs = [];
+  runs.forEach(function(r) {
+    if (r.status === 'ok' || r.status === 'success' || r.status === 'completed') okN++;
+    else if (r.status === 'error' || r.status === 'failed' || r.status === 'failure') {
+      errN++;
+      if (r.ts) failTs.push(r.ts);
+    }
+    var u = r.usage || {};
+    var t = u.total_tokens || u.totalTokens || ((u.input_tokens||0)+(u.output_tokens||0)) || 0;
+    if (t > 0) { tokSum += t; tokN++; }
+  });
+  var successPct = total ? Math.round(okN / total * 100) : 0;
+  var mtbfStr = '-';
+  if (failTs.length >= 2) {
+    failTs.sort(function(a,b){return a-b;});
+    var gaps = [];
+    for (var i=1; i<failTs.length; i++) gaps.push(failTs[i]-failTs[i-1]);
+    var meanGapMs = gaps.reduce(function(a,b){return a+b;},0) / gaps.length;
+    var meanGapH = meanGapMs / 3600000;
+    if (meanGapH >= 24) mtbfStr = (meanGapH/24).toFixed(1) + 'd';
+    else if (meanGapH >= 1) mtbfStr = meanGapH.toFixed(1) + 'h';
+    else mtbfStr = Math.max(1, Math.round(meanGapMs/60000)) + 'm';
+  } else if (failTs.length <= 1) {
+    mtbfStr = errN === 0 ? 'no failures' : 'n/a';
+  }
+  var avgTok = tokN ? Math.round(tokSum / tokN) : 0;
+  var statRow = '<div style="display:flex;gap:14px;flex-wrap:wrap;color:var(--text-muted);font-size:11px;margin:8px 0;">'
+    + '<span><strong style="color:var(--text-primary);">' + successPct + '%</strong> success last ' + total + '</span>'
+    + '<span>MTBF <strong style="color:var(--text-primary);">' + escHtml(mtbfStr) + '</strong></span>'
+    + (avgTok ? '<span>~<strong style="color:var(--text-primary);">' + avgTok.toLocaleString() + '</strong> tokens/run</span>' : '')
+    + '</div>';
+
+  // Next-run-at line.
+  var nextLine = '';
+  var nextMs = null;
+  for (var k=0; k<runs.length; k++) {
+    if (runs[k].next_run_at) { nextMs = runs[k].next_run_at; break; }
+  }
+  if (!nextMs && jobJobs && jobJobs.state && jobJobs.state.nextRunAtMs) {
+    nextMs = jobJobs.state.nextRunAtMs;
+  }
+  if (nextMs) {
+    nextLine = '<div style="font-size:11px;color:var(--text-muted);margin-bottom:6px;">Next run: <span style="color:var(--text-primary);">' + escHtml(new Date(nextMs).toLocaleString()) + '</span></div>';
+  }
+
+  // Recent-runs table (compact, scrollable).
+  var rows = '';
+  runs.slice(0, 30).forEach(function(r) {
+    var when = r.ts ? new Date(r.ts).toLocaleString() : '-';
+    var dur = r.duration_ms ? (r.duration_ms/1000).toFixed(2) + 's' : '-';
+    var statusCls = (r.status === 'ok' || r.status === 'success' || r.status === 'completed') ? 'run-status-ok'
+                  : (r.status === 'error' || r.status === 'failed' || r.status === 'failure') ? 'run-status-error'
+                  : '';
+    var err = r.error ? escHtml(String(r.error).substring(0,200)) : '';
+    var delivered = r.delivered_at
+      ? '<span title="Delivered at ' + escHtml(new Date(r.delivered_at).toLocaleString()) + '" style="color:#4ade80;">&#x2713;</span>'
+      : '<span style="color:var(--text-muted);">-</span>';
+    rows += '<tr>'
+      + '<td style="padding:3px 8px;white-space:nowrap;">' + escHtml(when) + '</td>'
+      + '<td style="padding:3px 8px;">' + escHtml(dur) + '</td>'
+      + '<td style="padding:3px 8px;" class="' + statusCls + '">' + escHtml(r.status || '?') + '</td>'
+      + '<td style="padding:3px 8px;color:var(--text-error);font-size:10px;max-width:240px;overflow:hidden;text-overflow:ellipsis;" title="' + err + '">' + err + '</td>'
+      + '<td style="padding:3px 8px;text-align:center;">' + delivered + '</td>'
+      + '</tr>';
+  });
+  var table = '<div style="max-height:240px;overflow:auto;border:1px solid var(--border-secondary);border-radius:4px;margin-top:6px;">'
+    + '<table style="width:100%;font-size:11px;border-collapse:collapse;">'
+    + '<thead style="position:sticky;top:0;background:var(--bg-secondary);"><tr style="text-align:left;color:var(--text-muted);">'
+    + '<th style="padding:4px 8px;font-weight:600;">When</th>'
+    + '<th style="padding:4px 8px;font-weight:600;">Duration</th>'
+    + '<th style="padding:4px 8px;font-weight:600;">Status</th>'
+    + '<th style="padding:4px 8px;font-weight:600;">Error</th>'
+    + '<th style="padding:4px 8px;font-weight:600;text-align:center;">Delivered</th>'
+    + '</tr></thead><tbody>' + rows + '</tbody></table></div>';
+
+  return '<div class="cron-run-timeline" data-job-id="' + escHtml(jobId) + '">'
+    + svg + statRow + nextLine + table + '</div>';
+}
+
 async function loadCronRuns(jobId) {
   try {
+    // Issue #605: per-job timeline endpoint reads ~/.openclaw/cron/runs/<id>.jsonl
+    // and returns 200 + empty list if the file is missing. We race it against
+    // the legacy gateway-derived /api/cron/<id>/runs endpoint so the existing
+    // calendar heatmap + status pills still render even when the JSONL feed
+    // is empty (no OpenClaw cron writer yet).
+    var timelinePromise = fetch('/api/crons/' + encodeURIComponent(jobId) + '/runs?limit=30')
+      .then(function(r) { return r.ok ? r.json() : {runs:[]}; })
+      .catch(function() { return {runs:[]}; });
     var resp = await fetch('/api/cron/' + encodeURIComponent(jobId) + '/runs');
     if (!resp.ok) throw new Error('HTTP ' + resp.status);
     var data = await resp.json();
+    var timelineData = await timelinePromise;
+    var timelineRuns = (timelineData && timelineData.runs) || [];
     var el = document.getElementById('cron-runs-' + jobId);
     if (!el) return;
     var runs = (data && data.runs) || [];
-    if (runs.length === 0) {
-      el.innerHTML = '<div style="color:var(--text-muted);">No run history yet — your agent has not reported any runs for this job.</div>';
+    var jobObj = (_cronJobs || []).find(function(j) { return j.id === jobId; });
+    var timelineHtml = _renderCronRunTimeline(jobId, timelineRuns, jobObj);
+    if (runs.length === 0 && timelineRuns.length === 0) {
+      el.innerHTML = (timelineHtml || '') + '<div style="color:var(--text-muted);">No run history yet — your agent has not reported any runs for this job.</div>';
+      return;
+    }
+    if (runs.length === 0 && timelineRuns.length > 0) {
+      el.innerHTML = timelineHtml;
       return;
     }
     // Build calendar heatmap (last 30 days)
@@ -4608,7 +4743,7 @@ async function loadCronRuns(jobId) {
         h += '<div style="color:var(--text-error);font-size:11px;padding:2px 0 4px 8px;border-left:2px solid var(--text-error);margin-left:4px;">' + escHtml(r.error).substring(0,200) + '</div>';
       }
     });
-    el.innerHTML = h;
+    el.innerHTML = (timelineHtml || '') + h;
   } catch(e) {
     var el = document.getElementById('cron-runs-' + jobId);
     if (el) el.innerHTML = '<div style="color:var(--text-error);">Could not load run history (' + escHtml(String(e.message||e)) + '). The endpoint may be unreachable or your gateway is offline.</div>';

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -593,6 +593,178 @@ def api_cron_runs(job_id):
     return jsonify(_d._enrich_cron_runs(job_id, runs))
 
 
+def _resolve_cron_runs_jsonl(job_id):
+    """Return the first `~/.openclaw/cron/runs/<jobId>.jsonl` path that exists.
+
+    Candidate roots (in order):
+      1. ``$OPENCLAW_DATA_DIR/cron/runs/<jobId>.jsonl``
+      2. ``$OPENCLAW_HOME/cron/runs/<jobId>.jsonl``
+      3. ``~/.openclaw/cron/runs/<jobId>.jsonl``
+      4. ``~/.clawdbot/cron/runs/<jobId>.jsonl``
+
+    Returns ``None`` when nothing exists. Path-traversal-safe: normalises
+    ``job_id`` and rejects anything containing ``/`` or ``..``.
+    """
+    # Defence in depth: refuse anything that could escape the runs dir.
+    if not job_id or "/" in job_id or "\\" in job_id or ".." in job_id:
+        return None
+    candidates_roots = []
+    data_dir = os.environ.get("OPENCLAW_DATA_DIR", "").strip()
+    if data_dir:
+        candidates_roots.append(os.path.expanduser(data_dir))
+    home = os.environ.get("OPENCLAW_HOME", "").strip()
+    if home:
+        candidates_roots.append(os.path.expanduser(home))
+    candidates_roots.extend([
+        os.path.expanduser("~/.openclaw"),
+        os.path.expanduser("~/.clawdbot"),
+    ])
+    for root in candidates_roots:
+        runs_dir = os.path.join(root, "cron", "runs")
+        fpath = os.path.normpath(os.path.join(runs_dir, f"{job_id}.jsonl"))
+        # Make sure we didn't escape runs_dir
+        norm_runs_dir = os.path.normpath(runs_dir)
+        if not (fpath == norm_runs_dir or fpath.startswith(norm_runs_dir + os.sep)):
+            continue
+        if os.path.isfile(fpath):
+            return fpath
+    return None
+
+
+def _read_cron_run_lines(fpath, limit):
+    """Read the last ``limit`` JSONL records from ``fpath``.
+
+    Returns a list of run dicts shaped as:
+
+        {ts, duration_ms, status, error, usage, delivered_at, next_run_at}
+
+    Malformed lines are skipped (with a debug log). Order: most-recent first.
+    On any read error returns an empty list — callers expose a 200 with
+    ``runs: []`` so the UI can show "no history yet" rather than a 500.
+    """
+    out = []
+    try:
+        with open(fpath, "r", errors="replace") as f:
+            # Cheap-but-correct: keep only the last `limit` parsed records.
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    # Malformed line — skip silently in prod, debug print in
+                    # dev. Matches the "never crash on bad input" convention.
+                    if os.environ.get("DEBUG"):
+                        print(f"[crons] skip malformed line in {fpath}")
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                # Normalise field names (gateway writers have varied between
+                # camelCase + snake_case over the years).
+                ts = (
+                    obj.get("ts")
+                    or obj.get("timestamp")
+                    or obj.get("startedAt")
+                    or obj.get("started_at")
+                )
+                if isinstance(ts, str):
+                    ts = _parse_iso_to_ms(ts)
+                duration_ms = (
+                    obj.get("duration_ms")
+                    or obj.get("durationMs")
+                    or obj.get("duration")
+                    or 0
+                )
+                try:
+                    duration_ms = int(duration_ms)
+                except (TypeError, ValueError):
+                    duration_ms = 0
+                status = obj.get("status") or obj.get("result") or "unknown"
+                err = obj.get("error") or obj.get("err") or ""
+                if err and not isinstance(err, str):
+                    err = str(err)
+                if err and len(err) > 200:
+                    err = err[:200]
+                usage = obj.get("usage") or {}
+                if not isinstance(usage, dict):
+                    usage = {}
+                delivered_at = (
+                    obj.get("delivered_at")
+                    or obj.get("deliveredAt")
+                    or (
+                        obj.get("deliveryStatus", {}).get("deliveredAt")
+                        if isinstance(obj.get("deliveryStatus"), dict)
+                        else None
+                    )
+                )
+                if isinstance(delivered_at, str):
+                    delivered_at = _parse_iso_to_ms(delivered_at) or None
+                next_run_at = (
+                    obj.get("next_run_at")
+                    or obj.get("nextRunAt")
+                    or obj.get("nextRunAtMs")
+                )
+                if isinstance(next_run_at, str):
+                    next_run_at = _parse_iso_to_ms(next_run_at) or None
+                out.append({
+                    "ts": int(ts or 0),
+                    "duration_ms": duration_ms,
+                    "status": str(status),
+                    "error": err,
+                    "usage": usage,
+                    "delivered_at": delivered_at,
+                    "next_run_at": next_run_at,
+                })
+    except Exception as e:
+        if os.environ.get("DEBUG"):
+            print(f"[crons] failed to read {fpath}: {e}")
+        return []
+    # Most-recent first, then clamp to `limit`.
+    out.sort(key=lambda r: r.get("ts") or 0, reverse=True)
+    return out[:limit]
+
+
+@bp_crons.route("/api/crons/<job_id>/runs")
+def api_crons_job_runs(job_id):
+    """Per-job run timeline for the Cron detail panel (closes #605).
+
+    Reads ``~/.openclaw/cron/runs/<jobId>.jsonl`` and returns the last
+    ``limit`` runs (default 30, capped at 100) most-recent first. This is
+    a deliberately separate endpoint from ``/api/cron/<job_id>/runs``
+    (which returns p50/p95-enriched, gateway-backed history) — this one
+    is the raw per-run feed the timeline UI needs (duration, status,
+    error, usage, delivered, next-run).
+
+    Always returns 200, even when the file is missing or every line is
+    malformed: payload is ``{jobId, runs: [], count: 0, source}``. The
+    Cron UI treats an empty list as "no history yet".
+    """
+    try:
+        limit = int(request.args.get("limit", "30"))
+    except (TypeError, ValueError):
+        limit = 30
+    limit = max(1, min(limit, 100))
+
+    fpath = _resolve_cron_runs_jsonl(job_id)
+    if not fpath:
+        return jsonify({
+            "jobId": job_id,
+            "runs": [],
+            "count": 0,
+            "source": "jsonl",
+            "file": None,
+        })
+    runs = _read_cron_run_lines(fpath, limit)
+    return jsonify({
+        "jobId": job_id,
+        "runs": runs,
+        "count": len(runs),
+        "source": "jsonl",
+        "file": fpath,
+    })
+
+
 @bp_crons.route("/api/cron/<job_id>/kill", methods=["POST"])
 def api_cron_kill(job_id):
     """Kill switch: disable a single cron job by ID.

--- a/tests/test_crons_runs_endpoint.py
+++ b/tests/test_crons_runs_endpoint.py
@@ -1,0 +1,187 @@
+"""Tests for the per-job run timeline endpoint (issue #605).
+
+Covers ``GET /api/crons/<jobId>/runs`` which reads
+``~/.openclaw/cron/runs/{jobId}.jsonl`` and returns the last N runs
+most-recent-first. Endpoint must NEVER 500 — missing file / malformed
+lines must still return 200 with an empty or partial list.
+
+Builds an isolated Flask app with just ``bp_crons`` so we don't have to
+stand up the full dashboard (mirrors ``test_crons_local_store.py``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+
+import pytest
+from flask import Flask
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _build_app(tmp_path, monkeypatch):
+    """Build an isolated Flask app with bp_crons rooted at tmp_path/.openclaw."""
+    fake_home = tmp_path / "openclaw_home"
+    runs_dir = fake_home / "cron" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    # Pin OPENCLAW_HOME so _resolve_cron_runs_jsonl picks our fixture
+    # over the real ~/.openclaw on the dev box.
+    monkeypatch.setenv("OPENCLAW_HOME", str(fake_home))
+    # Force-disable the local-store fast path — irrelevant here, but
+    # keeps the test hermetic if the dev env has CLAWMETRY_LOCAL_STORE_READ=1.
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")
+
+    import routes.crons as cr
+    importlib.reload(cr)
+
+    app = Flask(__name__)
+    app.register_blueprint(cr.bp_crons)
+    return app, runs_dir
+
+
+def _write_jsonl(runs_dir, job_id, records):
+    fpath = runs_dir / f"{job_id}.jsonl"
+    with open(fpath, "w") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+    return fpath
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app_and_runs(tmp_path, monkeypatch):
+    yield _build_app(tmp_path, monkeypatch)
+
+
+# ── tests ──────────────────────────────────────────────────────────────────
+
+
+class TestCronRunsEndpoint:
+    """Spec from issue #605."""
+
+    def test_missing_file_returns_200_empty(self, app_and_runs):
+        app, _runs_dir = app_and_runs
+        client = app.test_client()
+        resp = client.get("/api/crons/does-not-exist/runs")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["jobId"] == "does-not-exist"
+        assert data["runs"] == []
+        assert data["count"] == 0
+        assert data["file"] is None
+
+    def test_reads_jsonl_and_returns_records(self, app_and_runs):
+        app, runs_dir = app_and_runs
+        records = [
+            {
+                "ts": 1_700_000_000_000 + i * 60_000,
+                "duration_ms": 1000 + i * 50,
+                "status": "ok" if i % 2 == 0 else "error",
+                "error": "something failed" if i % 2 else "",
+                "usage": {"total_tokens": 100 + i},
+                "delivered_at": 1_700_000_000_000 + i * 60_000 + 500 if i % 2 == 0 else None,
+                "next_run_at": 1_700_000_000_000 + (i + 1) * 60_000,
+            }
+            for i in range(5)
+        ]
+        _write_jsonl(runs_dir, "test-job", records)
+
+        resp = app.test_client().get("/api/crons/test-job/runs")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["jobId"] == "test-job"
+        assert data["count"] == 5
+        assert len(data["runs"]) == 5
+        # Most-recent first → timestamps must be descending.
+        ts_list = [r["ts"] for r in data["runs"]]
+        assert ts_list == sorted(ts_list, reverse=True)
+        # Sanity: top run carries the expected shape keys.
+        top = data["runs"][0]
+        for k in ("ts", "duration_ms", "status", "error", "usage",
+                  "delivered_at", "next_run_at"):
+            assert k in top, f"missing key {k} in {top}"
+
+    def test_limit_default_30_and_cap_100(self, app_and_runs):
+        app, runs_dir = app_and_runs
+        # 150 records — more than the cap.
+        records = [
+            {"ts": 1_700_000_000_000 + i * 1000, "duration_ms": 10, "status": "ok"}
+            for i in range(150)
+        ]
+        _write_jsonl(runs_dir, "big-job", records)
+
+        client = app.test_client()
+        d1 = client.get("/api/crons/big-job/runs").get_json()
+        assert d1["count"] == 30  # default
+        d2 = client.get("/api/crons/big-job/runs?limit=10").get_json()
+        assert d2["count"] == 10
+        d3 = client.get("/api/crons/big-job/runs?limit=999").get_json()
+        assert d3["count"] == 100  # capped
+        d4 = client.get("/api/crons/big-job/runs?limit=garbage").get_json()
+        assert d4["count"] == 30  # falls back to default
+
+    def test_malformed_lines_are_skipped(self, app_and_runs):
+        app, runs_dir = app_and_runs
+        fpath = runs_dir / "messy.jsonl"
+        with open(fpath, "w") as f:
+            f.write('{"ts": 1700000000000, "status": "ok", "duration_ms": 100}\n')
+            f.write("this is not json\n")
+            f.write("\n")  # blank
+            f.write('{"ts": 1700000060000, "status": "error", "error": "boom"}\n')
+            f.write("{broken json\n")
+        resp = app.test_client().get("/api/crons/messy/runs")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        # Two parseable lines, two malformed/blank skipped.
+        assert data["count"] == 2
+        # Status values survived.
+        statuses = [r["status"] for r in data["runs"]]
+        assert "ok" in statuses
+        assert "error" in statuses
+
+    def test_error_truncated_to_200_chars(self, app_and_runs):
+        app, runs_dir = app_and_runs
+        long_err = "x" * 500
+        _write_jsonl(runs_dir, "err-job", [
+            {"ts": 1, "status": "error", "duration_ms": 0, "error": long_err},
+        ])
+        data = app.test_client().get("/api/crons/err-job/runs").get_json()
+        assert len(data["runs"][0]["error"]) == 200
+
+    def test_path_traversal_rejected(self, app_and_runs):
+        app, _ = app_and_runs
+        client = app.test_client()
+        # Flask's URL routing rejects ".." in <job_id> as a 404 redirect,
+        # so we test the helper directly for the slash + `..` cases that
+        # could otherwise sneak through manual URL-encoding.
+        import routes.crons as cr
+        assert cr._resolve_cron_runs_jsonl("../../etc/passwd") is None
+        assert cr._resolve_cron_runs_jsonl("a/b") is None
+        assert cr._resolve_cron_runs_jsonl("") is None
+
+    def test_camelcase_field_names_also_accepted(self, app_and_runs):
+        """OpenClaw writers have historically alternated camelCase /
+        snake_case. We accept both and normalise to the spec contract."""
+        app, runs_dir = app_and_runs
+        _write_jsonl(runs_dir, "camel", [
+            {
+                "timestamp": "2026-05-13T12:00:00Z",
+                "durationMs": 2500,
+                "status": "ok",
+                "deliveryStatus": {"deliveredAt": "2026-05-13T12:00:03Z"},
+                "nextRunAtMs": 1_800_000_000_000,
+            }
+        ])
+        data = app.test_client().get("/api/crons/camel/runs").get_json()
+        assert data["count"] == 1
+        r = data["runs"][0]
+        assert r["duration_ms"] == 2500
+        assert r["status"] == "ok"
+        assert r["delivered_at"] is not None
+        assert r["next_run_at"] == 1_800_000_000_000
+        assert r["ts"] > 0  # ISO timestamp parsed to ms


### PR DESCRIPTION
## Summary
- New `GET /api/crons/<jobId>/runs?limit=30` reads OpenClaw's per-run JSONL log at `~/.openclaw/cron/runs/<jobId>.jsonl`, returns last N runs most-recent first. Missing file → 200 empty, malformed lines skipped, limit capped at 100. Normalises camelCase ↔ snake_case + ISO ↔ ms fields.
- Cron expand panel in `app.js` now shows: 240x36 SVG sparkline (duration on Y, status as colored dot), stat row (success %, MTBF, avg tokens/run), next-run-at, and a compact 30-row recent-runs table (scrollable, error truncated to 200 chars). Legacy gateway-derived render stays underneath so calendar heatmap keeps working when the JSONL feed is empty.
- 7 unit tests covering missing file, sort order, default/cap limits, malformed-line recovery, error truncation, path-traversal rejection, and camelCase field acceptance.

## Test plan
- [x] `pytest tests/test_crons_runs_endpoint.py` — 7/7 pass
- [x] `pytest tests/test_crons_local_store.py` — 11/11 pass (no regression)
- [x] `node -c clawmetry/static/js/app.js` — JS valid
- [ ] Manual: open Crons tab, click a job, verify sparkline + table render when `~/.openclaw/cron/runs/<id>.jsonl` exists
- [ ] Manual: confirm fresh install with no runs file still shows "No run history yet" cleanly

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)