### PR TITLE
feat(overview): autonomy score KPI (closes #688)

### DIFF
--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -501,4 +501,73 @@
       setInterval(pollOnce, 60000);
     })();
   </script>
+
+  <!-- Issue #688: north-star autonomy KPI. Hydrates the card at the top of
+       the page from /api/overview body.autonomy so the median-gap number,
+       trend arrow + % delta, and sample size are visible on first paint
+       (the existing /api/autonomy fetcher in app.js lazy-loads 2.6s after
+       page load and drives the sparkline / detailed view). Both paths
+       target the same DOM IDs with the same data, so running them in
+       parallel is idempotent. -->
+  <script>
+  (function(){
+    function fmtGap(sec){
+      if (sec == null || !isFinite(sec)) return '—';
+      sec = Math.max(0, Math.round(sec));
+      if (sec < 60) return sec + 's';
+      var m = Math.floor(sec / 60);
+      var s = sec % 60;
+      if (m < 60) return s ? (m + 'm ' + s + 's') : (m + 'm');
+      var h = Math.floor(m / 60);
+      var rm = m % 60;
+      return rm ? (h + 'h ' + rm + 'm') : (h + 'h');
+    }
+    function render(a){
+      if (!a) return;
+      var labelEl = document.getElementById('autonomy-score-label');
+      var gapEl   = document.getElementById('autonomy-median-gap');
+      var trendEl = document.getElementById('autonomy-trend-pct');
+      var badgeEl = document.getElementById('autonomy-trend-badge');
+      var sampEl  = document.getElementById('autonomy-samples');
+      if (labelEl) labelEl.textContent = fmtGap(a.median_gap_seconds);
+      if (gapEl) gapEl.textContent = 'Autonomy: median nudge gap (7d)';
+      var tp = (typeof a.trend_pct === 'number') ? a.trend_pct : 0;
+      if (trendEl) {
+        trendEl.textContent = (tp > 0 ? '+' : '') + tp.toFixed(1) + '% vs prior 7d';
+      }
+      if (badgeEl) {
+        var arrow = tp > 0 ? '▲' : (tp < 0 ? '▼' : '–');
+        badgeEl.textContent = arrow + ' ' + Math.abs(tp).toFixed(1) + '%';
+        if (tp > 0) {
+          badgeEl.style.background = 'rgba(34,197,94,0.15)';
+          badgeEl.style.color = '#22c55e';
+        } else if (tp < 0) {
+          badgeEl.style.background = 'rgba(239,68,68,0.15)';
+          badgeEl.style.color = '#ef4444';
+        } else {
+          badgeEl.style.background = 'rgba(107,114,128,0.15)';
+          badgeEl.style.color = 'var(--text-muted)';
+        }
+      }
+      if (sampEl) {
+        var n = a.sample_size_7d || 0;
+        sampEl.textContent = n + ' user turn' + (n === 1 ? '' : 's');
+      }
+      var card = document.getElementById('autonomy-card');
+      if (card) {
+        card.title = 'Higher = more autonomous. Target: gap grows exponentially over time.';
+      }
+    }
+    async function pull(){
+      try {
+        var r = await fetch('/api/overview', {cache: 'no-store'});
+        if (!r.ok) return;
+        var b = await r.json();
+        if (b && b.autonomy) render(b.autonomy);
+      } catch(e) { /* swallow — placeholder card stays visible */ }
+    }
+    pull();
+    setInterval(pull, 60000);
+  })();
+  </script>
 </div>

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -22,11 +22,13 @@ and are reached via late ``import dashboard as _d``. Pure mechanical move
 import json
 import os
 import re
+import statistics
 import subprocess
 import sys
 import threading
+import time
 import time as _time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
@@ -298,6 +300,178 @@ def _detect_anthropic_oauth(limit=50):
             return result
 
     return result
+
+
+# ── Autonomy score (issue #688) ─────────────────────────────────────────────
+#
+# Surface a north-star metric on /api/overview so the dashboard can show a
+# primary KPI card (above cost). Sourced entirely from the v3 OpenClaw parser's
+# ``prompt.submitted`` events in the local DuckDB store — every event of that
+# type maps 1:1 to a human turn.
+#
+# Shape (top-level field on /api/overview response):
+#   "autonomy": {
+#       "median_gap_seconds": <float|null>,  # median seconds between user
+#                                              turns within a session (7d)
+#       "autonomy_ratio":     <float 0-1>,    # share of sessions completed
+#                                              with <=1 user turn (7d)
+#       "trend_pct":          <float>,        # last-7d median vs prior-7d
+#                                              median, positive = improving
+#       "sample_size_7d":     <int>,          # total user-turn events seen
+#   }
+#
+# Cached in-process for 60s — it's an analytic over up to ~14 days of events,
+# not a hot read. If the store is unreachable or empty we return the canonical
+# "no data" payload (median_gap_seconds=null, ratio=0, trend_pct=0, samples=0)
+# rather than omit the field — the UI can render the placeholder unconditionally.
+
+_AUTONOMY_OVERVIEW_CACHE = {"ts": 0.0, "data": None}
+_AUTONOMY_OVERVIEW_CACHE_TTL = 60.0  # seconds
+
+
+def _autonomy_empty() -> dict:
+    return {
+        "median_gap_seconds": None,
+        "autonomy_ratio": 0.0,
+        "trend_pct": 0.0,
+        "sample_size_7d": 0,
+    }
+
+
+def _ls_call_autonomy(method_name: str, **kwargs):
+    """Cross-process LocalStore call for the autonomy helper.
+
+    Mirrors the pattern in ``_ls_call`` below — tries the daemon HTTP proxy
+    first (covers the standard launchd/systemd install where the daemon owns
+    the DuckDB writer lock), then falls back to a direct ``get_store()`` open
+    for single-process boots (tests + dev mode).
+    """
+    try:
+        from routes.local_query import local_store_via_daemon
+        r = local_store_via_daemon(method_name, **kwargs)
+        if r is not None:
+            return r
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+def _compute_autonomy_overview() -> dict:
+    """Compute the 4-field autonomy block from ``prompt.submitted`` events.
+
+    Pulls the last 14 days of user-turn events from DuckDB (need 14d so we
+    can compare current-7d median against prior-7d for the trend %), buckets
+    by session_id, computes consecutive gaps in seconds, takes the median,
+    and counts "one nudge" sessions (sessions with <=1 user turn = the agent
+    finished without further human input).
+
+    Always returns a dict — never raises. On any error or empty data set,
+    returns ``_autonomy_empty()`` so the UI can render the placeholder card.
+    """
+    now = datetime.now(tz=timezone.utc)
+    cutoff_14d_iso = (now - timedelta(days=14)).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    cutoff_7d_ts = (now - timedelta(days=7)).timestamp()
+    cutoff_14d_ts = (now - timedelta(days=14)).timestamp()
+
+    rows = _ls_call_autonomy(
+        "query_events",
+        event_type="prompt.submitted",
+        since=cutoff_14d_iso,
+        limit=5000,
+    )
+    if not rows:
+        return _autonomy_empty()
+
+    # session_id → [ts_unix, ts_unix, ...] sorted ascending. We collect ALL
+    # 14d events so we can compute both the 7d window (current) and the
+    # 7-14d window (prior) from the same scan.
+    by_session_7d: dict = {}
+    by_session_prior: dict = {}
+
+    for r in rows:
+        ts_str = r.get("ts") or ""
+        if not ts_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
+        except Exception:
+            continue
+        sid = r.get("session_id") or ""
+        if ts >= cutoff_7d_ts:
+            by_session_7d.setdefault(sid, []).append(ts)
+        elif ts >= cutoff_14d_ts:
+            by_session_prior.setdefault(sid, []).append(ts)
+
+    def _stats(by_session):
+        """Return (median_gap_seconds_or_None, ratio_one_nudge, total_msgs,
+        total_sessions) for the per-session bucket."""
+        all_gaps: list = []
+        one_nudge = 0
+        total_msgs = 0
+        total_sessions = 0
+        for stamps in by_session.values():
+            if not stamps:
+                continue
+            stamps.sort()
+            total_sessions += 1
+            total_msgs += len(stamps)
+            if len(stamps) <= 1:
+                one_nudge += 1
+            for i in range(len(stamps) - 1):
+                d = stamps[i + 1] - stamps[i]
+                if d > 0:
+                    all_gaps.append(d)
+        med = statistics.median(all_gaps) if all_gaps else None
+        ratio = (one_nudge / total_sessions) if total_sessions else 0.0
+        return med, ratio, total_msgs, total_sessions
+
+    med_7d, ratio_7d, msgs_7d, sess_7d = _stats(by_session_7d)
+    med_prior, _, _, _ = _stats(by_session_prior)
+
+    # trend_pct: positive when current 7d median > prior-7d median (gaps
+    # growing → user nudging less often → more autonomous). Expressed as a
+    # percentage delta. Zero when either window has no data (we can't claim
+    # improvement without something to compare against).
+    if med_7d is not None and med_prior is not None and med_prior > 0:
+        trend_pct = ((med_7d - med_prior) / med_prior) * 100.0
+    else:
+        trend_pct = 0.0
+
+    if sess_7d == 0 and msgs_7d == 0:
+        return _autonomy_empty()
+
+    return {
+        "median_gap_seconds": float(med_7d) if med_7d is not None else None,
+        "autonomy_ratio": float(ratio_7d),
+        "trend_pct": round(float(trend_pct), 2),
+        "sample_size_7d": int(msgs_7d),
+    }
+
+
+def _autonomy_for_overview() -> dict:
+    """Cached wrapper around ``_compute_autonomy_overview``.
+
+    60s TTL — the metric is over a 7d window, so sub-minute freshness is
+    pointless and the cost of the scan would dominate the /api/overview
+    response time on busy nodes.
+    """
+    now = time.monotonic()
+    cached = _AUTONOMY_OVERVIEW_CACHE.get("data")
+    cached_ts = float(_AUTONOMY_OVERVIEW_CACHE.get("ts") or 0.0)
+    if cached is not None and (now - cached_ts) < _AUTONOMY_OVERVIEW_CACHE_TTL:
+        return cached
+    try:
+        data = _compute_autonomy_overview()
+    except Exception:
+        data = _autonomy_empty()
+    _AUTONOMY_OVERVIEW_CACHE["data"] = data
+    _AUTONOMY_OVERVIEW_CACHE["ts"] = now
+    return data
 
 
 @bp_overview.route("/api/channels")
@@ -673,6 +847,8 @@ def _try_local_store_overview():
         "infra": infra,
         "heartbeat": _get_overview_heartbeat_cached(),
         "client_health": _detect_anthropic_oauth(),
+        # Issue #688: north-star metric. Always present, even on empty data.
+        "autonomy": _autonomy_for_overview(),
         "_source": "local_store",
     }
 
@@ -820,6 +996,8 @@ def api_overview():
             "infra": infra,
             "heartbeat": _get_overview_heartbeat_cached(),
             "client_health": _detect_anthropic_oauth(),
+            # Issue #688: north-star autonomy metric (always present).
+            "autonomy": _autonomy_for_overview(),
         }
     )
 

--- a/tests/test_overview_autonomy_score.py
+++ b/tests/test_overview_autonomy_score.py
@@ -1,0 +1,280 @@
+"""Tests for issue #688 — autonomy score on /api/overview.
+
+Verifies the new top-level ``autonomy`` field that surfaces the north-star
+metric (median seconds between human nudges, 7d) as a primary KPI.
+
+The autonomy block is computed from ``prompt.submitted`` events in the local
+DuckDB store. Each test seeds a fresh in-memory store with known timestamps
+and asserts the derived metrics. Edge cases covered:
+
+  * empty store                       → median=None, ratio=0, samples=0
+  * one event only (no gap to compute)→ median=None, ratio=1.0, samples=1
+  * every session has <=1 user turn   → ratio=1.0 (perfect autonomy)
+  * known per-session gaps            → median matches expected value
+  * trend: current 7d longer than prior 7d → trend_pct > 0
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def overview_app(tmp_path, monkeypatch):
+    """Flask app + reloaded local_store + reloaded routes.overview.
+
+    Each test gets its OWN duckdb file (tmp_path) so cached autonomy data
+    from a previous test can't leak in via the module-level cache. We also
+    short-circuit the daemon HTTP proxy (``local_store_via_daemon``) so the
+    test never accidentally talks to a live developer daemon and reads the
+    real ``~/.clawmetry/events.duckdb`` instead of our tmp file.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Reload local_query AFTER local_store so its in-memory caches start fresh
+    # and so we can monkeypatch the daemon proxy to a no-op (forces tests to
+    # use the direct-open path against our tmp duckdb file).
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **k: None)
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    monkeypatch.setattr(lq, "_cached_discovery", lambda: None)
+
+    import routes.overview as ov
+    importlib.reload(ov)
+    # Reset the 60s cache between tests so the per-test data is honoured.
+    ov._AUTONOMY_OVERVIEW_CACHE["ts"] = 0.0
+    ov._AUTONOMY_OVERVIEW_CACHE["data"] = None
+
+    a = Flask(__name__)
+    a.register_blueprint(ov.bp_overview)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _ingest_prompt(store, *, eid, sid, ts_epoch):
+    """Ingest a single v3-shape ``prompt.submitted`` event."""
+    store.ingest({
+        "id": eid,
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": sid,
+        "event_type": "prompt.submitted",
+        "ts": _iso(ts_epoch),
+        "data": {"type": "prompt.submitted", "finalPromptText": "hi"},
+        "cost_usd": None,
+        "token_count": None,
+        "model": None,
+    })
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# response-shape tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_overview_response_includes_autonomy_field(overview_app):
+    """/api/overview always exposes the four documented autonomy keys."""
+    a, _ = overview_app
+    r = a.test_client().get("/api/overview")
+    assert r.status_code == 200
+    body = r.get_json() or {}
+    assert "autonomy" in body, f"missing autonomy field; body keys: {list(body.keys())}"
+    autonomy = body["autonomy"]
+    for key in ("median_gap_seconds", "autonomy_ratio", "trend_pct", "sample_size_7d"):
+        assert key in autonomy, f"autonomy missing key: {key}"
+
+
+def test_overview_autonomy_empty_store(overview_app):
+    """No events at all → median=None, ratio=0, trend=0, samples=0.
+
+    The placeholder keeps the UI from breaking on a fresh install before any
+    ``prompt.submitted`` events have landed in DuckDB.
+    """
+    a, _ = overview_app
+    body = a.test_client().get("/api/overview").get_json() or {}
+    autonomy = body["autonomy"]
+    assert autonomy["median_gap_seconds"] is None
+    assert autonomy["autonomy_ratio"] == 0.0
+    assert autonomy["trend_pct"] == 0.0
+    assert autonomy["sample_size_7d"] == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# metric-correctness tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_overview_autonomy_single_event_no_gap(overview_app):
+    """A single user message → no consecutive-gap pair → median stays None.
+
+    ``autonomy_ratio`` jumps to 1.0 (the session completed with exactly one
+    nudge, which is the "perfect autonomy" definition).
+    """
+    a, ls = overview_app
+    store = ls.get_store()
+    now = datetime.now(tz=timezone.utc).timestamp()
+    _ingest_prompt(store, eid="ev-1", sid="sess-a", ts_epoch=now - 3600)
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/overview").get_json() or {}
+    autonomy = body["autonomy"]
+    assert autonomy["median_gap_seconds"] is None, "single event has no gap to median"
+    assert autonomy["autonomy_ratio"] == 1.0, "one event = one nudge = perfect"
+    assert autonomy["sample_size_7d"] == 1
+
+
+def test_overview_autonomy_known_median(overview_app):
+    """Two sessions with known gaps → median matches the expected midpoint.
+
+    Session A: gaps [60, 120, 180]   (3 user turns spaced 60-300s apart)
+    Session B: gaps [600]            (2 user turns 10m apart)
+
+    Combined sorted gaps: [60, 120, 180, 600] → median = (120+180)/2 = 150s.
+    """
+    a, ls = overview_app
+    store = ls.get_store()
+    now = datetime.now(tz=timezone.utc).timestamp()
+
+    # Session A: 4 events with consecutive gaps 60s, 120s, 180s.
+    base_a = now - 3600
+    for i, offset in enumerate([0, 60, 60 + 120, 60 + 120 + 180]):
+        _ingest_prompt(store, eid=f"a-{i}", sid="sess-A", ts_epoch=base_a + offset)
+
+    # Session B: 2 events 600s apart.
+    base_b = now - 7200
+    _ingest_prompt(store, eid="b-0", sid="sess-B", ts_epoch=base_b)
+    _ingest_prompt(store, eid="b-1", sid="sess-B", ts_epoch=base_b + 600)
+
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/overview").get_json() or {}
+    autonomy = body["autonomy"]
+    # Tolerance: timestamps round-trip through ISO strings so allow ±2s drift.
+    assert autonomy["median_gap_seconds"] is not None
+    assert abs(autonomy["median_gap_seconds"] - 150.0) < 2.0, (
+        f"expected median ~150s, got {autonomy['median_gap_seconds']}"
+    )
+    # 2 sessions total, neither is single-prompt, so ratio = 0.
+    assert autonomy["autonomy_ratio"] == 0.0
+    # 4 + 2 = 6 user turns
+    assert autonomy["sample_size_7d"] == 6
+
+
+def test_overview_autonomy_ratio_all_one_nudge(overview_app):
+    """Three sessions, each with exactly one user message → ratio = 1.0.
+
+    This is the canonical "agent ran to completion without further input"
+    pattern — the headline KPI the card emphasises.
+    """
+    a, ls = overview_app
+    store = ls.get_store()
+    now = datetime.now(tz=timezone.utc).timestamp()
+    for i, sid in enumerate(["s1", "s2", "s3"]):
+        _ingest_prompt(store, eid=f"ev-{i}", sid=sid, ts_epoch=now - (i + 1) * 600)
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/overview").get_json() or {}
+    autonomy = body["autonomy"]
+    assert autonomy["autonomy_ratio"] == 1.0
+    assert autonomy["sample_size_7d"] == 3
+    # No gaps to median across three single-event sessions.
+    assert autonomy["median_gap_seconds"] is None
+
+
+def test_overview_autonomy_trend_pct_improves(overview_app):
+    """Current 7d gaps wider than prior 7d → trend_pct > 0 (improving).
+
+    Prior window (8-14d ago): consecutive 60s gaps.
+    Current window (0-7d):    consecutive 600s gaps.
+
+    The ratio is ~10x so trend_pct lands well above zero — we just check
+    the sign here since the exact value depends on how the medians line up.
+    """
+    a, ls = overview_app
+    store = ls.get_store()
+    now = datetime.now(tz=timezone.utc).timestamp()
+
+    # Prior 7d window: 2 events 60s apart, 10 days ago.
+    prior_base = now - 10 * 86400
+    _ingest_prompt(store, eid="p-0", sid="sess-prior", ts_epoch=prior_base)
+    _ingest_prompt(store, eid="p-1", sid="sess-prior", ts_epoch=prior_base + 60)
+
+    # Current 7d window: 2 events 600s apart, 1 day ago.
+    cur_base = now - 86400
+    _ingest_prompt(store, eid="c-0", sid="sess-cur", ts_epoch=cur_base)
+    _ingest_prompt(store, eid="c-1", sid="sess-cur", ts_epoch=cur_base + 600)
+
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/overview").get_json() or {}
+    autonomy = body["autonomy"]
+    assert autonomy["trend_pct"] > 0, (
+        f"expected positive trend (current gaps longer than prior); "
+        f"got trend_pct={autonomy['trend_pct']}"
+    )
+    # Only the current-window events count toward sample_size_7d.
+    assert autonomy["sample_size_7d"] == 2
+
+
+def test_overview_autonomy_ignores_other_event_types(overview_app):
+    """Only ``prompt.submitted`` events feed the metric — tool_calls etc.
+    must not pollute the gap distribution or the sample count."""
+    a, ls = overview_app
+    store = ls.get_store()
+    now = datetime.now(tz=timezone.utc).timestamp()
+
+    # 1 user turn that should count.
+    _ingest_prompt(store, eid="real", sid="sess-real", ts_epoch=now - 3600)
+
+    # 5 noise events of other types that must be ignored.
+    for i, etype in enumerate(["tool.call", "tool.result", "model.completed",
+                                "model.changed", "session.started"]):
+        store.ingest({
+            "id": f"noise-{i}",
+            "node_id": "agent+test",
+            "agent_id": "main",
+            "session_id": "sess-real",
+            "event_type": etype,
+            "ts": _iso(now - 1800 + i),
+            "data": {},
+            "cost_usd": None,
+            "token_count": None,
+            "model": None,
+        })
+
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/overview").get_json() or {}
+    autonomy = body["autonomy"]
+    assert autonomy["sample_size_7d"] == 1, "only prompt.submitted should count"


### PR DESCRIPTION
## Summary
- Adds north-star ``autonomy`` block to ``/api/overview`` so the dashboard can render the primary KPI card on first paint (median human-nudge gap, autonomy ratio, trend %, sample size — all 7d).
- Computed from ``prompt.submitted`` events in DuckDB (v3 OpenClaw parser, #1135) via ``local_store_via_daemon`` with a direct-open fallback. 60s in-process cache. Always returns a valid dict; empty store yields the placeholder so a fresh install never breaks the UI.
- Inline JS in ``clawmetry/templates/tabs/overview.html`` populates the existing autonomy card from ``/api/overview.autonomy`` — formatted gap, trend arrow + colour (green positive, red negative), sample count. Runs in parallel with the existing ``/api/autonomy`` lazy fetcher (idempotent — both write the same DOM IDs).

## Why
Per CLAUDE.md positioning (observability, not cost-tracking), the north-star metric belongs above cost on the overview. Krentsel's framing: *"Success = nudges space out exponentially."*

## Card pseudo-text
```
🎯 HOW INDEPENDENT IS YOUR AGENT?
   12m 30s                       ▲ 14.3%
   Autonomy: median nudge gap (7d)
   +14.3% vs prior 7d                       Last 7 days
                                            [sparkline ──╱─]
                                            47 user turns
```

## Test plan
- [x] ``python3 -m pytest tests/test_overview_autonomy_score.py -q`` (7/7 pass)
- [x] Manual: ``/api/overview`` response includes ``autonomy`` block on empty + populated DuckDB
- [ ] Visual: load overview page locally → KPI card top-left renders with formatted gap + trend badge
- [ ] No regression in existing ``/api/overview`` shape (legacy ``model``, ``cronCount``, ``infra`` etc. all preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)