### PR TITLE
fix(crons): show "+ New Job" button in OSS dashboard

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4142,7 +4142,14 @@ function toggleCronAutoRefresh() {
 async function loadCrons() {
   var data = await fetch('/api/crons').then(r => r.json());
   _cronJobs = data.jobs || [];
-  // Show/hide cron action buttons based on gateway support
+  // Cron actions (create / pause / fix / kill-all) hit the local OpenClaw
+  // gateway, which is always reachable from the OSS dashboard but is
+  // cloud-disabled from the iframe. Default to true for the OSS-dashboard
+  // case so the "+ New Job" button is actually visible — the empty-state
+  // copy says to click it. Cloud-iframe stays false so we don't dangle
+  // controls that 410 when used.
+  _cronActionsAvailable = !window.CLOUD_MODE;
+  // Show/hide cron action buttons based on gateway availability
   document.querySelectorAll('.cron-action-btn').forEach(function(btn) {
     btn.style.display = _cronActionsAvailable ? '' : 'none';
   });
@@ -4304,9 +4311,17 @@ function renderCrons() {
 
   var jobs = _cronView === 'paused' ? paused : active;
   if (jobs.length === 0) {
-    var msg = _cronView === 'paused'
-      ? 'No paused jobs. Disable any active job to see it here.'
-      : 'No active cron jobs yet. Click "+ New Job" to create one.';
+    var msg;
+    if (_cronView === 'paused') {
+      msg = 'No paused jobs. Disable any active job to see it here.';
+    } else if (window.CLOUD_MODE) {
+      // In cloud iframe mode the "+ New Job" button is hidden because
+      // cron-create hits a cloud-disabled endpoint; pointing the user
+      // at an invisible button (clawmetry-cloud#793) is a UX dead-end.
+      msg = 'No active cron jobs yet. Create one from the OSS dashboard on the host running OpenClaw.';
+    } else {
+      msg = 'No active cron jobs yet. Click "+ New Job" to create one.';
+    }
     listEl.innerHTML = '<div style="color:var(--text-muted);padding:24px;text-align:center;font-size:13px;">' + msg + '</div>';
     return;
   }


### PR DESCRIPTION
## Summary
- Set \`_cronActionsAvailable = !window.CLOUD_MODE\` inside \`loadCrons()\` so the "+ New Job" / Pause / Fix / Emergency Stop buttons are visible in the OSS dashboard.
- Cloud-iframe stays false (cron-create endpoint is cloud-disabled there) and the empty-state copy switches to "Create one from the OSS dashboard on the host running OpenClaw" so we don't dangle invisible controls.

## Why
\`_cronActionsAvailable\` was declared \`false\` at module init and never reassigned. The empty-state message "Click '+ New Job' to create one" pointed users at a button that was permanently \`display:none\`. Reported in vivekchand/clawmetry-cloud#793 (also mirrors clawmetry/clawmetry#1127).

## Test plan
- [x] \`node -c clawmetry/static/js/app.js\` — syntax OK
- [ ] Live: open OSS dashboard with no crons → "+ New Job" button visible, empty state mentions it.
- [ ] Live: open cloud iframe with no crons → button hidden, empty state directs to OSS dashboard.

Closes one item from vivekchand/clawmetry-cloud#793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)