### PR TITLE
feat(overview): heartbeat liveness panel (closes #686)

### DIFF
--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -26,6 +26,29 @@
     <span class="refresh-time" id="refresh-time" style="font-size:11px;">Loading...</span>
   </div>
 
+  <!-- Heartbeat liveness card (closes #686) — pulse indicator + cadence + ok ratio -->
+  <div id="overview-heartbeat-card" style="background:var(--bg-secondary);border:2px solid var(--border-primary);border-radius:12px;padding:14px 18px;margin-bottom:14px;box-shadow:var(--card-shadow);display:none;align-items:center;gap:18px;flex-wrap:wrap;" title="Your agent fires a heartbeat session every 30 min. Green = on time, amber = drifting, red = missed.">
+    <div style="display:flex;align-items:center;gap:10px;min-width:140px;">
+      <span id="overview-hb-dot" style="width:14px;height:14px;border-radius:50%;background:#6b7280;display:inline-block;flex-shrink:0;"></span>
+      <div>
+        <div style="font-size:12px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.5px;">&#x2764;&#xfe0f; Heartbeat</div>
+        <div id="overview-hb-status-label" style="font-size:13px;font-weight:600;color:var(--text-primary);">--</div>
+      </div>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:2px;min-width:160px;">
+      <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:1px;">Last beat</div>
+      <div id="overview-hb-last-beat" style="font-size:14px;font-weight:600;color:var(--text-primary);">--</div>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:2px;min-width:100px;">
+      <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:1px;">Cadence</div>
+      <div id="overview-hb-cadence" style="font-size:14px;font-weight:600;color:var(--text-primary);">30m</div>
+    </div>
+    <div style="display:flex;flex-direction:column;gap:2px;min-width:140px;">
+      <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:1px;">OK ratio</div>
+      <div id="overview-hb-ok-ratio" style="font-size:14px;font-weight:600;color:var(--text-primary);">--</div>
+    </div>
+  </div>
+
   <!-- Token Velocity Alert Banner (GH #313) -->
   <div id="velocity-alert-banner" style="
     display:none;
@@ -391,4 +414,80 @@
       @keyframes hb-pulse-missed { 0%,100%{opacity:1;box-shadow:0 0 0 0 rgba(239,68,68,.4)} 70%{opacity:.8;box-shadow:0 0 0 8px rgba(239,68,68,0)} }
     </style>
   </div>
+
+  <!-- Renderer for the overview heartbeat card (#686). Reads the `heartbeat`
+       block injected by /api/overview and updates the inline panel. Lives in
+       the template (not app.js) so the card is fully self-contained. -->
+  <script>
+    (function(){
+      function fmtGap(secs){
+        if(secs == null) return '--';
+        if(secs < 60) return Math.max(0, Math.round(secs)) + 's ago';
+        if(secs < 3600) return Math.round(secs/60) + 'm ago';
+        if(secs < 86400) return (secs/3600).toFixed(1) + 'h ago';
+        return Math.round(secs/86400) + 'd ago';
+      }
+      function fmtCadence(secs){
+        if(!secs) return '--';
+        if(secs < 60) return secs + 's';
+        if(secs < 3600) return Math.round(secs/60) + 'm';
+        return (secs/3600).toFixed(1) + 'h';
+      }
+      function statusColor(status){
+        if(status === 'green') return '#22c55e';
+        if(status === 'amber') return '#f59e0b';
+        if(status === 'red') return '#ef4444';
+        return '#6b7280';
+      }
+      function statusLabel(status){
+        if(status === 'green') return 'Healthy';
+        if(status === 'amber') return 'Drifting';
+        if(status === 'red') return 'Missed';
+        return 'No heartbeats yet';
+      }
+      window.renderOverviewHeartbeat = function(hb){
+        var card = document.getElementById('overview-heartbeat-card');
+        if(!card || !hb) return;
+        card.style.display = 'flex';
+        var dot = document.getElementById('overview-hb-dot');
+        if(dot){
+          dot.style.background = statusColor(hb.status);
+          dot.style.boxShadow = hb.status === 'green'
+            ? '0 0 8px ' + statusColor(hb.status) : 'none';
+        }
+        var lbl = document.getElementById('overview-hb-status-label');
+        if(lbl){ lbl.textContent = statusLabel(hb.status); }
+        var last = document.getElementById('overview-hb-last-beat');
+        if(last){ last.textContent = fmtGap(hb.gap_seconds); }
+        var cad = document.getElementById('overview-hb-cadence');
+        if(cad){ cad.textContent = fmtCadence(hb.expected_cadence_seconds); }
+        var ok = document.getElementById('overview-hb-ok-ratio');
+        if(ok){
+          if(hb.ok_ratio == null){
+            ok.textContent = '--';
+          } else {
+            ok.textContent = Math.round(hb.ok_ratio * 100) + '% (last ' + (hb.sample_size || 0) + ')';
+          }
+        }
+      };
+
+      // Self-poll /api/overview so the card stays live without coupling to
+      // app.js. The backend caches the heartbeat block for 30s so this is
+      // cheap; we still poll every 60s to keep the gap counter ticking.
+      function pollOnce(){
+        fetch('/api/overview', {credentials: 'same-origin'})
+          .then(function(r){ return r.ok ? r.json() : null; })
+          .then(function(d){
+            if(d && d.heartbeat){ window.renderOverviewHeartbeat(d.heartbeat); }
+          })
+          .catch(function(){ /* dashboard offline — leave last-rendered state */ });
+      }
+      if(document.readyState === 'loading'){
+        document.addEventListener('DOMContentLoaded', pollOnce);
+      } else {
+        pollOnce();
+      }
+      setInterval(pollOnce, 60000);
+    })();
+  </script>
 </div>

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -23,12 +23,193 @@ import json
 import os
 import subprocess
 import sys
+import threading
+import time as _time
 from datetime import datetime, timedelta
 
 from flask import Blueprint, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
 
 bp_overview = Blueprint('overview', __name__)
+
+
+# Default OpenClaw heartbeat cadence (30 min). Surfaced in /api/overview's
+# `heartbeat` block so the dashboard can compare to actual gap.
+_HEARTBEAT_EXPECTED_SECONDS = 1800
+
+# 30s cache for the heartbeat block. Computing it scans DuckDB and is cheap
+# (~ms), but /api/overview fires on every refresh and we don't need fresher
+# than once-per-30s liveness data.
+_HEARTBEAT_CACHE_TTL = 30.0
+_heartbeat_cache: dict = {"ts": 0.0, "value": None}
+_heartbeat_cache_lock = threading.Lock()
+
+
+def _parse_iso_to_epoch(ts_str):
+    """ISO-8601 string → Unix float. Returns 0.0 on any parse failure."""
+    if not ts_str or not isinstance(ts_str, str):
+        return 0.0
+    try:
+        return datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return 0.0
+
+
+def _classify_heartbeat_outcome(ev_data):
+    """Return ``"ok"`` if the heartbeat event ended with a HEARTBEAT_OK reply,
+    ``"action"`` if any other content was produced.
+
+    The OpenClaw heartbeat replies exactly ``HEARTBEAT_OK`` when nothing needs
+    attention; anything else means the agent took action. We look for the
+    canonical marker in a few common shape variants so we don't miss either
+    the gateway-emitted event shape or the sync-relayed one.
+    """
+    if not isinstance(ev_data, dict):
+        return "action"
+
+    # Direct flags / classifier from upstream — honour first.
+    if ev_data.get("heartbeat_ok") is True:
+        return "ok"
+    if ev_data.get("outcome") in ("ok", "action"):
+        return ev_data["outcome"]
+
+    # Scan likely text fields for the literal marker.
+    candidates = []
+    for key in ("response", "reply", "assistant_text", "content", "text", "body"):
+        v = ev_data.get(key)
+        if isinstance(v, str):
+            candidates.append(v)
+        elif isinstance(v, list):
+            for blk in v:
+                if isinstance(blk, str):
+                    candidates.append(blk)
+                elif isinstance(blk, dict):
+                    t = blk.get("text") or blk.get("content")
+                    if isinstance(t, str):
+                        candidates.append(t)
+    for txt in candidates:
+        if txt.strip() == "HEARTBEAT_OK":
+            return "ok"
+    return "action"
+
+
+def _is_heartbeat_event(ev):
+    """Heuristic: the event came from a heartbeat session.
+
+    The OpenClaw gateway tags heartbeat sessions with ``session_type ==
+    "heartbeat"`` somewhere on the payload; older shapes embed the type in
+    the session_id or event_type. We check all of these so we capture
+    heartbeats regardless of how the upstream tagged them.
+    """
+    data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+    if (data.get("session_type") or "").lower() == "heartbeat":
+        return True
+    if (ev.get("event_type") or "").lower() == "heartbeat":
+        return True
+    sid = (ev.get("session_id") or "").lower()
+    if "heartbeat" in sid:
+        return True
+    return False
+
+
+def _compute_overview_heartbeat(now=None, expected_seconds=_HEARTBEAT_EXPECTED_SECONDS):
+    """Build the `heartbeat` block for /api/overview from DuckDB events.
+
+    Returns a dict with:
+      expected_cadence_seconds — the configured cadence (default 1800)
+      last_heartbeat_ts        — ISO-8601 UTC of most recent heartbeat or None
+      gap_seconds              — seconds since last heartbeat (None if never)
+      ok_ratio                 — of last 20 heartbeats, fraction that were
+                                 HEARTBEAT_OK (vs action taken). None if no
+                                 heartbeats observed.
+      sample_size              — how many heartbeats fed the ratio (≤20)
+      status                   — "green"  if gap < 1.5×expected
+                                 "amber"  if 1.5×–3×
+                                 "red"    if >3×
+                                 None     if no heartbeats observed
+    """
+    if now is None:
+        now = _time.time()
+
+    out = {
+        "expected_cadence_seconds": int(expected_seconds),
+        "last_heartbeat_ts": None,
+        "gap_seconds": None,
+        "ok_ratio": None,
+        "sample_size": 0,
+        "status": None,
+    }
+
+    # Read events from DuckDB. Pull a generous window (200) and filter
+    # client-side — there is no SQL filter on data.session_type today, and
+    # heartbeats are sparse (~48/day) so 200 covers >4 days.
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        rows = store.query_events(agent_id="main", limit=200)
+    except Exception:
+        return out
+
+    if not rows:
+        return out
+
+    heartbeats = []
+    for ev in rows:
+        if not _is_heartbeat_event(ev):
+            continue
+        ts_epoch = _parse_iso_to_epoch(ev.get("ts"))
+        if ts_epoch <= 0:
+            continue
+        outcome = _classify_heartbeat_outcome(ev.get("data"))
+        heartbeats.append({"ts": ts_epoch, "outcome": outcome})
+
+    if not heartbeats:
+        return out
+
+    # Most recent first.
+    heartbeats.sort(key=lambda h: h["ts"], reverse=True)
+
+    last_ts = heartbeats[0]["ts"]
+    gap = max(0.0, now - last_ts)
+
+    last_20 = heartbeats[:20]
+    ok_count = sum(1 for h in last_20 if h["outcome"] == "ok")
+    ratio = round(ok_count / len(last_20), 3) if last_20 else None
+
+    if gap < 1.5 * expected_seconds:
+        status = "green"
+    elif gap < 3.0 * expected_seconds:
+        status = "amber"
+    else:
+        status = "red"
+
+    from datetime import timezone as _tz
+    out["last_heartbeat_ts"] = datetime.fromtimestamp(last_ts, tz=_tz.utc).isoformat()
+    out["gap_seconds"] = int(gap)
+    out["ok_ratio"] = ratio
+    out["sample_size"] = len(last_20)
+    out["status"] = status
+    return out
+
+
+def _get_overview_heartbeat_cached():
+    """30s memoised wrapper around ``_compute_overview_heartbeat``.
+
+    /api/overview is on the dashboard's hot path (fires on every refresh).
+    Heartbeats fire every 30 min, so caching for 30s loses zero fidelity
+    while avoiding repeated DuckDB scans across rapid refreshes.
+    """
+    now_mono = _time.monotonic()
+    with _heartbeat_cache_lock:
+        cached = _heartbeat_cache["value"]
+        if cached is not None and (now_mono - _heartbeat_cache["ts"]) < _HEARTBEAT_CACHE_TTL:
+            return cached
+    # Compute outside the lock — it can hit DuckDB.
+    fresh = _compute_overview_heartbeat()
+    with _heartbeat_cache_lock:
+        _heartbeat_cache["value"] = fresh
+        _heartbeat_cache["ts"] = now_mono
+    return fresh
 
 
 @bp_overview.route("/api/channels")
@@ -402,6 +583,7 @@ def _try_local_store_overview():
         "memorySize": total_size,
         "system": system,
         "infra": infra,
+        "heartbeat": _get_overview_heartbeat_cached(),
         "_source": "local_store",
     }
 
@@ -547,6 +729,7 @@ def api_overview():
             "memorySize": total_size,
             "system": system,
             "infra": infra,
+            "heartbeat": _get_overview_heartbeat_cached(),
         }
     )
 

--- a/tests/test_overview_heartbeat.py
+++ b/tests/test_overview_heartbeat.py
@@ -1,0 +1,337 @@
+"""Tests for issue #686 — heartbeat block on /api/overview.
+
+The handler computes a 5-field `heartbeat` block from DuckDB events where the
+session looks like an OpenClaw heartbeat (`data.session_type == "heartbeat"`,
+event_type == "heartbeat", or session_id containing "heartbeat"). It surfaces:
+
+  - expected_cadence_seconds (default 1800)
+  - last_heartbeat_ts (ISO-8601 UTC, or None)
+  - gap_seconds (now - last beat, or None)
+  - ok_ratio (HEARTBEAT_OK / total over last 20 beats)
+  - sample_size
+  - status: "green" | "amber" | "red" | None
+
+This suite exercises the pure compute function `_compute_overview_heartbeat`
+directly so we don't have to bring up a Flask app + reload the dashboard
+module just to verify the math. A separate end-to-end test confirms the
+block flows through the Flask handler.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture
+def overview_module(tmp_path, monkeypatch):
+    """Fresh local_store + routes.overview against a tmpdir DuckDB."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.overview as ov
+    importlib.reload(ov)
+
+    yield ov, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t=2.0):
+    """Wait for the ring to drain to disk so SELECTs see the rows."""
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _ingest_heartbeat(store, *, ts_epoch: float, outcome: str = "ok",
+                      session_id: str = "heartbeat-2026-05-13"):
+    """Ingest one heartbeat event tagged by data.session_type=='heartbeat'.
+
+    ``outcome='ok'`` => the agent replied HEARTBEAT_OK (no action needed).
+    ``outcome='action'`` => any other reply.
+    """
+    if outcome == "ok":
+        data = {"session_type": "heartbeat", "response": "HEARTBEAT_OK"}
+    else:
+        data = {
+            "session_type": "heartbeat",
+            "response": "Looked at the alerts dashboard, all green.",
+        }
+    store.ingest({
+        "id": f"ev-hb-{ts_epoch}",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": session_id,
+        "event_type": "message",
+        "ts": _iso(ts_epoch),
+        "data": data,
+    })
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pure compute function
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_heartbeat_empty_store_returns_unknown_status(overview_module):
+    """No heartbeats observed → status=None, all metrics None/0."""
+    ov, _ls = overview_module
+    out = ov._compute_overview_heartbeat()
+    assert out["status"] is None
+    assert out["last_heartbeat_ts"] is None
+    assert out["gap_seconds"] is None
+    assert out["ok_ratio"] is None
+    assert out["sample_size"] == 0
+    assert out["expected_cadence_seconds"] == 1800
+
+
+def test_heartbeat_recent_beat_is_green(overview_module):
+    """A heartbeat that fired within 1.5× cadence → status='green'."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    # Fired 5 minutes ago — well within 1.5×1800s = 45 minutes.
+    _ingest_heartbeat(store, ts_epoch=now - 5 * 60, outcome="ok")
+    _wait_flush(store)
+    out = ov._compute_overview_heartbeat(now=now)
+    assert out["status"] == "green"
+    assert out["gap_seconds"] is not None
+    assert 240 <= out["gap_seconds"] <= 360
+    assert out["sample_size"] == 1
+    assert out["ok_ratio"] == 1.0
+    assert out["last_heartbeat_ts"] is not None
+    assert out["last_heartbeat_ts"].endswith("+00:00")
+
+
+def test_heartbeat_drifting_is_amber(overview_module):
+    """Last beat 50 minutes ago (1.5×–3× cadence) → status='amber'."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    _ingest_heartbeat(store, ts_epoch=now - 50 * 60, outcome="ok")
+    _wait_flush(store)
+    out = ov._compute_overview_heartbeat(now=now)
+    assert out["status"] == "amber"
+
+
+def test_heartbeat_missed_is_red(overview_module):
+    """Last beat >3× cadence ago → status='red'."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    # 4 hours ago is way past 3*1800s = 90 minutes.
+    _ingest_heartbeat(store, ts_epoch=now - 4 * 3600, outcome="ok")
+    _wait_flush(store)
+    out = ov._compute_overview_heartbeat(now=now)
+    assert out["status"] == "red"
+    assert out["gap_seconds"] >= 3 * 1800
+
+
+def test_heartbeat_ok_ratio_over_last_20(overview_module):
+    """ok_ratio = HEARTBEAT_OK count / sample_size over the 20 most recent."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    # 15 beats: 3 actions, 12 ok. Ratio over a 15-beat window = 12/15 = 0.8.
+    # Use distinct session_ids so each is treated as its own beat.
+    for i in range(15):
+        outcome = "action" if i < 3 else "ok"
+        _ingest_heartbeat(
+            store,
+            ts_epoch=now - (i + 1) * 60,
+            outcome=outcome,
+            session_id=f"heartbeat-{i}",
+        )
+    _wait_flush(store)
+    out = ov._compute_overview_heartbeat(now=now)
+    assert out["sample_size"] == 15
+    assert out["ok_ratio"] == pytest.approx(12 / 15, abs=1e-3)
+    assert out["status"] == "green"
+
+
+def test_heartbeat_ratio_caps_sample_at_20(overview_module):
+    """sample_size never exceeds 20 even when more beats exist."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    # 25 beats, all ok.
+    for i in range(25):
+        _ingest_heartbeat(
+            store,
+            ts_epoch=now - (i + 1) * 60,
+            outcome="ok",
+            session_id=f"heartbeat-cap-{i}",
+        )
+    _wait_flush(store)
+    out = ov._compute_overview_heartbeat(now=now)
+    assert out["sample_size"] == 20
+    assert out["ok_ratio"] == 1.0
+
+
+def test_heartbeat_ignores_non_heartbeat_events(overview_module):
+    """A non-heartbeat event (e.g. tool_call) must not be counted as a beat."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    store.ingest({
+        "id": "ev-tool",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-tool",
+        "event_type": "tool_call",
+        "ts": _iso(now - 60),
+        "data": {"tool": "Bash"},
+    })
+    _wait_flush(store)
+    out = ov._compute_overview_heartbeat(now=now)
+    # Only the tool_call exists — no heartbeat. Status stays unknown.
+    assert out["status"] is None
+    assert out["sample_size"] == 0
+
+
+def test_heartbeat_detects_via_event_type(overview_module):
+    """Falls back to event_type='heartbeat' when data.session_type missing."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    store.ingest({
+        "id": "ev-hb-via-type",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "regular-session-id",
+        "event_type": "heartbeat",
+        "ts": _iso(now - 60),
+        "data": {"response": "HEARTBEAT_OK"},
+    })
+    _wait_flush(store)
+    out = ov._compute_overview_heartbeat(now=now)
+    assert out["status"] == "green"
+    assert out["sample_size"] == 1
+
+
+def test_heartbeat_detects_via_session_id(overview_module):
+    """Falls back to session_id containing 'heartbeat' when other tags absent."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    store.ingest({
+        "id": "ev-hb-via-sid",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "heartbeat-2026-05-13-12-00",
+        "event_type": "message",
+        "ts": _iso(now - 120),
+        "data": {"text": "HEARTBEAT_OK"},
+    })
+    _wait_flush(store)
+    out = ov._compute_overview_heartbeat(now=now)
+    assert out["status"] == "green"
+    assert out["ok_ratio"] == 1.0
+
+
+def test_heartbeat_picks_most_recent_as_last(overview_module):
+    """gap_seconds reflects the most recent heartbeat, not the oldest."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    # 6 hours ago + 3 minutes ago — latter must win.
+    _ingest_heartbeat(store, ts_epoch=now - 6 * 3600, outcome="action",
+                      session_id="heartbeat-old")
+    _ingest_heartbeat(store, ts_epoch=now - 3 * 60, outcome="ok",
+                      session_id="heartbeat-new")
+    _wait_flush(store)
+    out = ov._compute_overview_heartbeat(now=now)
+    assert out["status"] == "green"
+    assert 120 <= out["gap_seconds"] <= 240
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Flask handler integration
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_api_overview_includes_heartbeat_block(tmp_path, monkeypatch):
+    """End-to-end: /api/overview JSON response contains the `heartbeat` block."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.overview as ov
+    importlib.reload(ov)
+
+    # Seed a session so the fast path engages, and a heartbeat event.
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": "sess-main-X",
+        "agent_type": "openclaw",
+        "title": "Main session",
+        "started_at": "2026-05-13T10:00:00+00:00",
+        "last_active_at": "2026-05-13T11:00:00+00:00",
+        "status": "active",
+        "total_tokens": 100,
+        "message_count": 1,
+        "metadata": {"model": "claude-opus-4-7"},
+    })
+    now = time.time()
+    _ingest_heartbeat(store, ts_epoch=now - 60, outcome="ok")
+    _wait_flush(store)
+
+    from flask import Flask
+    a = Flask(__name__)
+    a.register_blueprint(ov.bp_overview)
+    # Reset the module-level cache so this test sees fresh data.
+    ov._heartbeat_cache["ts"] = 0.0
+    ov._heartbeat_cache["value"] = None
+
+    r = a.test_client().get("/api/overview")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "heartbeat" in body, "overview JSON missing `heartbeat` block"
+    hb = body["heartbeat"]
+    for key in (
+        "expected_cadence_seconds",
+        "last_heartbeat_ts",
+        "gap_seconds",
+        "ok_ratio",
+        "sample_size",
+        "status",
+    ):
+        assert key in hb, f"heartbeat block missing key: {key}"
+    assert hb["expected_cadence_seconds"] == 1800
+    assert hb["status"] == "green"
+    assert hb["sample_size"] == 1
+
+
+def test_heartbeat_cache_returns_cached_value(overview_module):
+    """The 30s memo wrapper returns the same dict on rapid back-to-back calls."""
+    ov, ls = overview_module
+    store = ls.get_store()
+    now = time.time()
+    _ingest_heartbeat(store, ts_epoch=now - 30, outcome="ok")
+    _wait_flush(store)
+    # Reset cache.
+    ov._heartbeat_cache["ts"] = 0.0
+    ov._heartbeat_cache["value"] = None
+
+    first = ov._get_overview_heartbeat_cached()
+    second = ov._get_overview_heartbeat_cached()
+    # Same object identity proves the cache returned the memoised dict.
+    assert first is second


### PR DESCRIPTION
## Summary
- Surfaces the OpenClaw 30-min heartbeat as a dedicated liveness probe on the overview dashboard instead of letting it disappear into the session list (issue #686).
- New `heartbeat` block on `/api/overview` (`expected_cadence_seconds`, `last_heartbeat_ts`, `gap_seconds`, `ok_ratio`, `sample_size`, `status`) computed from DuckDB events with a 30s memo cache.
- Status is `green` (gap < 1.5x cadence) / `amber` (1.5x-3x) / `red` (>3x) / `null` (never), matching the spec's pulse semantics.
- New "Heartbeat" card on the Overview tab matching existing card CSS (autonomy-card style) — pulse dot + "Last beat", "Cadence: 30m", "OK ratio: X% (last N)" — self-polls every 60s, hidden until first response.

## Why
Today ClawMetry treats the heartbeat session like any other turn. If it stops firing, the agent is effectively dead but nobody notices. This puts the liveness signal in the user's face on the first screen they load.

## Implementation notes
- Detection is layered: `data.session_type == "heartbeat"` first (canonical), with fallbacks to `event_type == "heartbeat"` and session_id contains "heartbeat" so older shapes still surface.
- `ok_ratio` is computed over the most recent 20 heartbeats (capped). HEARTBEAT_OK marker scanned across `response` / `reply` / `content` / `text` / `body` fields plus direct boolean flags.
- Backend block lives in `routes/overview.py` and feeds both the local-store fast path and the legacy gateway-backed handler. The 30s memo (`_get_overview_heartbeat_cached`) is thread-safe and keeps `/api/overview` cheap on rapid refreshes.
- Frontend script is inline in the overview template so the card stays self-contained — no app.js coupling.

## Test plan
- [x] `python3 -m pytest tests/test_overview_heartbeat.py -q` — 12 / 12 pass
  - empty store -> `status=None`
  - recent (<1.5x) -> `green`; 50min ago -> `amber`; 4h ago -> `red`
  - ok_ratio math (12/15) and 20-beat cap (25 -> sample_size=20)
  - non-heartbeat events ignored
  - detection via `data.session_type`, `event_type`, `session_id`
  - most-recent beat wins for gap calc
  - end-to-end `/api/overview` JSON contains the `heartbeat` block with all 6 keys
  - 30s cache returns memoised dict on rapid calls
- [ ] Verify card renders green / amber / red against a real OpenClaw workspace before release.

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)