### PR TITLE
feat(transcript): show decoding params (T/top_p/max) per LLM call (closes #564)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6434,7 +6434,35 @@ function _buildReplayEvent(m, idx) {
     extra.from_hook = m.from_hook;
     extra.summary_truncated = m.summary_truncated;
   }
-  return { role: role, type: type, content: m.content || '', timestamp: m.timestamp, tokens: m.tokens || null, originalIndex: idx, extra: extra };
+  // Issue #564: decoding params (temperature / top_p / max_tokens / …) come
+  // through verbatim from the backend on assistant turns so the renderer can
+  // show a "⚙ T=0.7 · top_p=1 · max=4096" pill inline with the message.
+  return {
+    role: role,
+    type: type,
+    content: m.content || '',
+    timestamp: m.timestamp,
+    tokens: m.tokens || null,
+    params: m.params || null,
+    originalIndex: idx,
+    extra: extra
+  };
+}
+
+// Format the decoding-params dict into a compact inline pill. Returns ''
+// when nothing useful is set so callers can cheaply skip rendering.
+function _fmtDecodingParams(p) {
+  if (!p || typeof p !== 'object') return '';
+  var parts = [];
+  if (typeof p.temperature === 'number') parts.push('T=' + p.temperature);
+  if (typeof p.top_p === 'number') parts.push('top_p=' + p.top_p);
+  if (typeof p.top_k === 'number') parts.push('top_k=' + p.top_k);
+  if (typeof p.max_tokens === 'number') parts.push('max=' + p.max_tokens);
+  if (Array.isArray(p.stop_sequences) && p.stop_sequences.length) {
+    parts.push('stop=' + p.stop_sequences.length);
+  }
+  if (!parts.length) return '';
+  return '⚙ ' + parts.join(' · ');
 }
 
 function _renderReplayEvent(ev, highlighted) {
@@ -6458,6 +6486,13 @@ function _renderReplayEvent(ev, highlighted) {
     html += '<div style="white-space:pre-wrap;word-break:break-word;">' + escHtml(content) + '</div>';
   }
   if (ev.tokens) html += '<div style="font-size:11px;color:var(--text-muted);margin-top:4px;">&#128200; ' + ev.tokens + ' tokens</div>';
+  // Issue #564: decoding-config pill — small inline summary of the sampling
+  // params that produced this assistant turn (only present when the backend
+  // could extract at least one known key).
+  var decoded = _fmtDecodingParams(ev.params);
+  if (decoded) {
+    html += '<div class="chat-decoding" title="Sampling parameters" style="font-size:11px;color:var(--text-muted);margin-top:4px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;">' + escHtml(decoded) + '</div>';
+  }
   if (ev.timestamp) html += '<div class="chat-ts">' + new Date(ev.timestamp).toLocaleString() + '</div>';
   html += '</div>';
   return html;

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2228,6 +2228,115 @@ def _expand_openclaw_event(obj: dict, ts_ms):
     return turns
 
 
+# Sampling parameter keys we surface in the "Decoding" pill. Order is the
+# display order in the UI; missing keys are simply dropped.
+_DECODING_KEYS = (
+    "temperature",
+    "top_p",
+    "top_k",
+    "max_tokens",
+    "stop_sequences",
+)
+
+# Camel-case → snake-case aliases — adapters write either style depending on
+# whether they came from Anthropic SDK (snake), OpenAI SDK (snake), or
+# OpenClaw gateway (camel). We collapse them to the canonical snake form.
+_DECODING_ALIASES = {
+    "maxTokens": "max_tokens",
+    "topP": "top_p",
+    "topK": "top_k",
+    "stopSequences": "stop_sequences",
+    "stop": "stop_sequences",
+    # OpenAI also calls it max_completion_tokens on newer models; treat the
+    # same way so the UI still shows a sensible "max=" value.
+    "max_completion_tokens": "max_tokens",
+}
+
+
+def _extract_decoding_params(obj):
+    """Pull ``{temperature, top_p, top_k, max_tokens, stop_sequences}`` out of
+    a parsed event, no matter which nested shape the adapter chose.
+
+    Handles three nested-key shapes (see issue #564):
+
+    1. ``obj["data"]["params"]``         — OpenClaw gateway model.completed
+    2. ``obj["data"]["message"]["params"]`` — Claude Code adapter payload
+    3. ``obj["data"]["config"]``         — generic LLM-client wrapper
+
+    Also handles a flat fallback where the params live directly on the
+    message dict (``obj["params"]`` / ``obj["config"]``) — common when the
+    DuckDB writer has already unwrapped the outer envelope.
+
+    Returns an empty dict when none of the keys are present so callers can
+    cheaply test truthiness without first checking ``is not None``. Never
+    raises on weird input — bad shapes return ``{}``.
+    """
+    if not isinstance(obj, dict):
+        return {}
+
+    # Candidate buckets, in priority order. The first non-empty bucket wins
+    # for any given key; we don't try to merge across buckets to avoid
+    # surfacing stale config from a sibling event.
+    candidates = []
+    data = obj.get("data") if isinstance(obj.get("data"), dict) else None
+    if data is not None:
+        # Path 1 — data.params  (e.g. model.completed gateway events)
+        if isinstance(data.get("params"), dict):
+            candidates.append(data["params"])
+        # Path 2 — data.message.params  (Anthropic SDK request payload)
+        msg = data.get("message") if isinstance(data.get("message"), dict) else None
+        if msg and isinstance(msg.get("params"), dict):
+            candidates.append(msg["params"])
+        if msg and isinstance(msg.get("metadata"), dict):
+            md = msg["metadata"]
+            if isinstance(md.get("params"), dict):
+                candidates.append(md["params"])
+        # Path 3 — data.config  (generic wrappers, our own SDK)
+        if isinstance(data.get("config"), dict):
+            candidates.append(data["config"])
+        # Anthropic non-streaming requests sometimes inline these on `data`
+        # itself when the writer flattened the message.
+        candidates.append(data)
+
+    # Flat fallback — when the caller already passed the message dict.
+    if isinstance(obj.get("params"), dict):
+        candidates.append(obj["params"])
+    if isinstance(obj.get("config"), dict):
+        candidates.append(obj["config"])
+    candidates.append(obj)
+
+    out = {}
+    for bucket in candidates:
+        if not isinstance(bucket, dict):
+            continue
+        for raw_key, val in bucket.items():
+            key = _DECODING_ALIASES.get(raw_key, raw_key)
+            if key not in _DECODING_KEYS:
+                continue
+            if key in out:
+                continue  # earlier bucket already supplied this key
+            # Skip clearly junk values. We accept 0 as a valid temperature.
+            if val is None:
+                continue
+            if key == "stop_sequences":
+                if isinstance(val, str):
+                    out[key] = [val]
+                elif isinstance(val, list):
+                    cleaned = [str(s) for s in val if s is not None]
+                    if cleaned:
+                        out[key] = cleaned
+                continue
+            if key in ("temperature", "top_p"):
+                if isinstance(val, (int, float)):
+                    out[key] = float(val)
+                continue
+            if key in ("top_k", "max_tokens"):
+                if isinstance(val, (int, float)):
+                    out[key] = int(val)
+                continue
+    return out
+
+
 def _try_local_store_transcript(session_id: str):
     """Read a session transcript directly from the DuckDB events table.
 
@@ -2286,9 +2395,15 @@ def _try_local_store_transcript(session_id: str):
                 model = obj.get("modelId") or obj.get("model") or ev.get("model")
             data = obj.get("data") if isinstance(obj.get("data"), dict) else {}
             total_tokens += _openclaw_event_tokens(data)
+            # Issue #564: surface decoding params on assistant turns so the UI
+            # can show the "T=… top_p=… max=…" pill inline with the reply.
+            decoding = _extract_decoding_params(obj)
             for turn in _expand_openclaw_event(obj, ts_ms):
-                if turn.get("content", "").strip():
-                    messages.append(turn)
+                if not turn.get("content", "").strip():
+                    continue
+                if decoding and turn.get("role") == "assistant":
+                    turn["params"] = decoding
+                messages.append(turn)
             continue
 
         # Anthropic-style fallback (existing logic).
@@ -2314,7 +2429,12 @@ def _try_local_store_transcript(session_id: str):
                 usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
             )
         if content or role in ("user", "assistant", "system"):
-            messages.append({"role": role, "content": content, "timestamp": ts_ms})
+            msg_entry = {"role": role, "content": content, "timestamp": ts_ms}
+            if role == "assistant":
+                decoding = _extract_decoding_params(obj)
+                if decoding:
+                    msg_entry["params"] = decoding
+            messages.append(msg_entry)
     duration = None
     if first_ts and last_ts and last_ts > first_ts:
         dur_sec = (last_ts - first_ts) / 1000
@@ -2425,13 +2545,19 @@ def api_transcript(session_id):
                             usage.get("input_tokens", 0) + usage.get("output_tokens", 0)
                         )
                     if content or role in ("user", "assistant", "system"):
-                        messages.append(
-                            {
-                                "role": role,
-                                "content": content,
-                                "timestamp": ts_ms,
-                            }
-                        )
+                        msg_entry = {
+                            "role": role,
+                            "content": content,
+                            "timestamp": ts_ms,
+                        }
+                        # Issue #564: attach decoding config (T/top_p/max…)
+                        # to assistant turns so the UI can render an inline
+                        # pill next to the reply.
+                        if role == "assistant":
+                            decoding = _extract_decoding_params(obj)
+                            if decoding:
+                                msg_entry["params"] = decoding
+                        messages.append(msg_entry)
                 except (json.JSONDecodeError, ValueError):
                     pass
     except Exception as e:

--- a/tests/test_decoding_config_extract.py
+++ b/tests/test_decoding_config_extract.py
@@ -1,0 +1,199 @@
+"""Tests for `_extract_decoding_params` — issue #564.
+
+Anthropic / OpenAI / OpenClaw events all carry sampling params in slightly
+different nested shapes. The transcript modal renders a small "⚙ T=0.7 ·
+top_p=1 · max=4096" pill next to each assistant turn, fed by this helper.
+The pill's correctness depends on the helper handling every shape we've
+seen in the wild without crashing on the weird ones.
+
+The helper lives in ``routes.sessions`` — these tests import it directly
+and never spin up a Flask app, so they stay fast (<200ms total).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from routes.sessions import _extract_decoding_params
+
+
+# ── 1. data.params  (OpenClaw gateway model.completed) ─────────────────────
+def test_extracts_from_data_params():
+    """OpenClaw gateway emits the sampling config as a sibling of `content`
+    on the model.completed event — under ``data.params``."""
+    ev = {
+        "type": "model.completed",
+        "data": {
+            "params": {
+                "temperature": 0.7,
+                "top_p": 0.95,
+                "top_k": 40,
+                "max_tokens": 4096,
+                "stop_sequences": ["</done>"],
+            }
+        },
+    }
+    out = _extract_decoding_params(ev)
+    assert out == {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "top_k": 40,
+        "max_tokens": 4096,
+        "stop_sequences": ["</done>"],
+    }
+
+
+# ── 2. data.message.params  (Anthropic SDK request payload) ────────────────
+def test_extracts_from_data_message_params():
+    """The Anthropic-style adapter wraps the request as
+    ``data.message.params`` — a literal copy of the API request kwargs."""
+    ev = {
+        "data": {
+            "message": {
+                "role": "assistant",
+                "params": {
+                    "temperature": 1.0,
+                    "max_tokens": 8192,
+                },
+            }
+        }
+    }
+    out = _extract_decoding_params(ev)
+    assert out["temperature"] == 1.0
+    assert out["max_tokens"] == 8192
+    assert "top_p" not in out
+
+
+# ── 3. data.config  (generic LLM-client wrapper) ───────────────────────────
+def test_extracts_from_data_config():
+    """Some adapters (our SDK wrapper, LiteLLM) write the sampling config
+    under ``data.config`` instead of ``data.params``."""
+    ev = {
+        "data": {
+            "config": {
+                "temperature": 0.2,
+                "top_p": 0.99,
+            }
+        }
+    }
+    out = _extract_decoding_params(ev)
+    assert out == {"temperature": 0.2, "top_p": 0.99}
+
+
+# ── 4. Mixed shapes — earlier bucket wins ──────────────────────────────────
+def test_data_params_wins_over_data_config_for_same_key():
+    """When the same key appears in multiple buckets we prefer the more
+    specific path (``data.params``) over the generic fallback so a stale
+    ``data.config`` value doesn't shadow the per-call override."""
+    ev = {
+        "data": {
+            "params": {"temperature": 0.1},
+            "config": {"temperature": 0.9, "max_tokens": 2048},
+        }
+    }
+    out = _extract_decoding_params(ev)
+    assert out["temperature"] == 0.1  # data.params wins
+    assert out["max_tokens"] == 2048  # filled from data.config
+
+
+# ── 5. Camel-case aliases — adapters that copy OpenClaw camelCase verbatim ─
+def test_normalizes_camelcase_aliases():
+    ev = {
+        "data": {
+            "params": {
+                "maxTokens": 1024,
+                "topP": 0.8,
+                "topK": 20,
+                "stopSequences": ["EOT"],
+            }
+        }
+    }
+    out = _extract_decoding_params(ev)
+    assert out["max_tokens"] == 1024
+    assert out["top_p"] == 0.8
+    assert out["top_k"] == 20
+    assert out["stop_sequences"] == ["EOT"]
+
+
+def test_openai_max_completion_tokens_alias():
+    """OpenAI's newer models use ``max_completion_tokens`` instead of
+    ``max_tokens``. We map both to ``max_tokens`` so the UI stays uniform."""
+    ev = {"data": {"params": {"max_completion_tokens": 512, "temperature": 0.5}}}
+    out = _extract_decoding_params(ev)
+    assert out["max_tokens"] == 512
+    assert out["temperature"] == 0.5
+
+
+# ── 6. stop_sequences shape coercion ───────────────────────────────────────
+def test_stop_string_promotes_to_list():
+    """OpenAI's ``stop`` parameter is sometimes a bare string. We wrap it
+    in a list so the frontend can `.length`-check uniformly."""
+    ev = {"data": {"params": {"stop": "END", "temperature": 0.3}}}
+    out = _extract_decoding_params(ev)
+    assert out["stop_sequences"] == ["END"]
+
+
+def test_empty_stop_list_dropped():
+    """An empty stop list isn't worth a pill segment."""
+    ev = {"data": {"params": {"stop_sequences": [], "temperature": 0.0}}}
+    out = _extract_decoding_params(ev)
+    assert "stop_sequences" not in out
+    assert out["temperature"] == 0.0  # zero is a valid temperature
+
+
+# ── 7. Flat shape — message dict passed directly ───────────────────────────
+def test_flat_params_on_root():
+    """When the caller passes the unwrapped message dict the helper still
+    finds params via the flat fallback path."""
+    msg = {"role": "assistant", "params": {"temperature": 0.4}}
+    out = _extract_decoding_params(msg)
+    assert out["temperature"] == 0.4
+
+
+# ── 8. Robustness — bad input never raises ────────────────────────────────
+@pytest.mark.parametrize(
+    "bad",
+    [
+        None,
+        "string",
+        123,
+        [],
+        {"data": "not a dict"},
+        {"data": {"params": "not a dict"}},
+        {"data": {"params": {"temperature": None}}},
+        {"data": {"params": {"temperature": "0.7"}}},  # wrong type — dropped
+        {"data": {"message": "not a dict"}},
+        {"data": {"message": {"params": None}}},
+    ],
+)
+def test_bad_input_returns_empty(bad):
+    out = _extract_decoding_params(bad)
+    assert out == {}
+
+
+# ── 9. Missing fields — only present keys returned ────────────────────────
+def test_only_temperature_present():
+    ev = {"data": {"params": {"temperature": 0.6}}}
+    out = _extract_decoding_params(ev)
+    assert out == {"temperature": 0.6}
+
+
+def test_no_decoding_keys_at_all():
+    ev = {"data": {"params": {"unrelated": "value"}}}
+    out = _extract_decoding_params(ev)
+    assert out == {}
+
+
+# ── 10. Zero / boundary values ─────────────────────────────────────────────
+def test_temperature_zero_kept():
+    ev = {"data": {"params": {"temperature": 0}}}
+    out = _extract_decoding_params(ev)
+    assert out["temperature"] == 0.0
+    assert isinstance(out["temperature"], float)
+
+
+def test_top_k_int_coercion():
+    ev = {"data": {"params": {"top_k": 50.0}}}
+    out = _extract_decoding_params(ev)
+    assert out["top_k"] == 50
+    assert isinstance(out["top_k"], int)


### PR DESCRIPTION
## Summary
- Adds an inline "⚙ T=0.7 · top_p=1 · max=4096" pill next to each assistant turn in the transcript replay view so operators can see which sampling config produced each reply (closes #564).
- New `_extract_decoding_params()` helper in `routes/sessions.py` pulls `{temperature, top_p, top_k, max_tokens, stop_sequences}` from three nested shapes (`data.params`, `data.message.params`, `data.config`) plus a flat fallback. Camel-case aliases and `max_completion_tokens` are normalised.
- Both the DuckDB fast-path and the JSONL fallback in `/api/transcript/<sid>` now attach a `params` field to assistant messages when at least one decoding key is captured.

No schema change (parser already stores raw event data in DuckDB's `data` column). No new dependencies. Renders nothing when no params were captured, so older sessions display unchanged.

## Test plan
- [x] `pytest tests/test_decoding_config_extract.py` — 23 cases (3 nested paths, alias normalisation, stop-string promotion, bad-input robustness, T=0 boundary, int coercion). All green.
- [x] `pytest tests/test_transcript_local_store.py` — 4/4 existing transcript tests still green (no regression on the path we touched).
- [x] `node --check clawmetry/static/js/app.js` — clean.
- [ ] Manual: open a session with captured params in the transcript modal, confirm the ⚙ pill renders inline under the assistant message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)