### PR TITLE
feat(budget): per-agent budget limits + tiered 80%/100% alerts (closes #951)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -367,6 +367,23 @@ _DDL = [
     "CREATE INDEX IF NOT EXISTS idx_chmsg_provider_ts  ON channel_messages(provider, ts)",
     "CREATE INDEX IF NOT EXISTS idx_chmsg_channel_ts   ON channel_messages(provider, channel_id, ts)",
     "CREATE INDEX IF NOT EXISTS idx_chmsg_session      ON channel_messages(session_key, ts)",
+    # Issue #951 (2026-05-13) — per-agent budget overrides. One row per
+    # agent_id with a daily and/or monthly USD limit. If a row is missing
+    # for a given agent_id the global ``budget_config`` (daily/monthly_limit)
+    # applies. The dashboard's ``_budget_check`` reads this table on every
+    # cost-entry append and fires tiered alerts (80% warning, 100% critical)
+    # against the matching per-agent limit, falling back to global only when
+    # there is no override. Either limit column may be NULL — that side then
+    # falls back to global independently (e.g. you can set a daily limit
+    # without committing to a monthly one).
+    """
+    CREATE TABLE IF NOT EXISTS agent_budgets (
+        agent_id          VARCHAR PRIMARY KEY,
+        daily_limit_usd   DOUBLE,
+        monthly_limit_usd DOUBLE,
+        updated_at        BIGINT NOT NULL
+    )
+    """,
     """
     CREATE TABLE IF NOT EXISTS schema_version (
         version    INTEGER PRIMARY KEY,
@@ -1041,6 +1058,103 @@ class LocalStore:
             return 0
         with self._write_lock:
             self._conn.execute("DELETE FROM alert_rules WHERE id = ?", [rid])
+        return 1
+
+    # ── Per-agent budgets (issue #951) ───────────────────────────────────
+
+    def set_agent_budget(
+        self,
+        agent_id: str,
+        *,
+        daily_limit_usd: float | None = None,
+        monthly_limit_usd: float | None = None,
+    ) -> None:
+        """Upsert one per-agent budget override row. Required: ``agent_id``.
+
+        Either / both of ``daily_limit_usd`` and ``monthly_limit_usd`` may
+        be ``None`` — that side falls back to the global budget. Pass
+        ``0`` (or any non-positive value) on either column to clear the
+        per-agent limit on that side while preserving the other; pass
+        both as ``None`` and you may as well call ``delete_agent_budget``
+        for symmetry, but the row is preserved either way."""
+        if not agent_id:
+            raise ValueError("agent budget must include 'agent_id'")
+        now_ms = int(time.time() * 1000)
+        # Coerce numeric inputs; None stays NULL in DuckDB.
+        def _coerce(v):
+            if v is None:
+                return None
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return None
+        d = _coerce(daily_limit_usd)
+        m = _coerce(monthly_limit_usd)
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO agent_budgets (
+                    agent_id, daily_limit_usd, monthly_limit_usd, updated_at
+                ) VALUES (?, ?, ?, ?)
+                ON CONFLICT (agent_id) DO UPDATE SET
+                    daily_limit_usd   = excluded.daily_limit_usd,
+                    monthly_limit_usd = excluded.monthly_limit_usd,
+                    updated_at        = excluded.updated_at
+            """, [str(agent_id), d, m, now_ms])
+
+    def get_agent_budget(self, agent_id: str) -> dict[str, Any] | None:
+        """Return one per-agent budget row or ``None`` when no override is
+        configured. Callers should fall back to the global budget config
+        on a ``None`` return."""
+        if not agent_id:
+            return None
+        rows = self._fetch(
+            "SELECT agent_id, daily_limit_usd, monthly_limit_usd, updated_at "
+            "FROM agent_budgets WHERE agent_id = ? LIMIT 1",
+            [str(agent_id)],
+        )
+        if not rows:
+            return None
+        r = rows[0]
+        return {
+            "agent_id": r[0],
+            "daily_limit_usd": r[1],
+            "monthly_limit_usd": r[2],
+            "updated_at": r[3],
+        }
+
+    def query_agent_budgets(self, *, limit: int = 500) -> list[dict[str, Any]]:
+        """Return all per-agent budget overrides, most-recently-updated
+        first. Cheap — this table is tiny (one row per agent)."""
+        rows = self._fetch(
+            "SELECT agent_id, daily_limit_usd, monthly_limit_usd, updated_at "
+            "FROM agent_budgets ORDER BY updated_at DESC LIMIT ?",
+            [int(limit)],
+        )
+        return [
+            {
+                "agent_id": r[0],
+                "daily_limit_usd": r[1],
+                "monthly_limit_usd": r[2],
+                "updated_at": r[3],
+            }
+            for r in rows
+        ]
+
+    def delete_agent_budget(self, agent_id: str) -> int:
+        """Delete one per-agent override row. Returns 1 on delete, 0 when
+        missing. After deletion the agent falls back to the global budget."""
+        if not agent_id:
+            return 0
+        aid = str(agent_id)
+        rows_before = self._fetch(
+            "SELECT 1 FROM agent_budgets WHERE agent_id = ? LIMIT 1", [aid]
+        )
+        if not rows_before:
+            return 0
+        with self._write_lock:
+            self._conn.execute(
+                "DELETE FROM agent_budgets WHERE agent_id = ?", [aid]
+            )
         return 1
 
     def ingest_approval(self, approval: dict[str, Any]) -> None:

--- a/dashboard.py
+++ b/dashboard.py
@@ -700,6 +700,249 @@ def _get_budget_status():
     }
 
 
+# ── Per-agent budgets (issue #951) ─────────────────────────────────────
+#
+# Per-agent overrides live in the DuckDB ``agent_budgets`` table (see
+# ``clawmetry/local_store.py``) so they survive process restarts and ride
+# the same heartbeat-piggyback relay as the rest of the local store.
+# ``_get_agent_budget`` returns ``None`` when no override is present —
+# callers fall back to the global ``daily_limit`` / ``monthly_limit``.
+#
+# Tiered alerts: the in-memory ``_budget_agent_tier_state`` dict tracks
+# {(agent_id, period): "warning" | "critical" | None} for the *current*
+# period bucket (today / this month). Once we fire a warning we don't fire
+# it again until the period resets; once we fire critical we never
+# re-fire warning for the same period. This is the dedup contract the
+# spec asks for: same threshold, same period, same agent → one alert.
+
+
+# (agent_id, period, period_key) -> tier last fired. period_key is the
+# date string for the current bucket so the slot auto-resets at midnight /
+# month-start without an explicit cron.
+_budget_agent_tier_state: dict[tuple, str] = {}
+
+
+def _get_agent_budget(agent_id):
+    """Read one per-agent budget override from the local store. Returns
+    ``None`` when the local store isn't available or the agent has no
+    override row — callers fall back to global limits."""
+    if not agent_id:
+        return None
+    try:
+        from clawmetry import local_store
+
+        store = local_store.get_store()
+        return store.get_agent_budget(agent_id)
+    except Exception:
+        return None
+
+
+def _list_agent_budgets():
+    """Return all per-agent overrides as a list. Returns [] on any error."""
+    try:
+        from clawmetry import local_store
+
+        store = local_store.get_store()
+        return store.query_agent_budgets(limit=500)
+    except Exception:
+        return []
+
+
+def _set_agent_budget(agent_id, daily_limit_usd=None, monthly_limit_usd=None):
+    """Write a per-agent override row. Returns True on success."""
+    if not agent_id:
+        return False
+    try:
+        from clawmetry import local_store
+
+        store = local_store.get_store()
+        store.set_agent_budget(
+            agent_id,
+            daily_limit_usd=daily_limit_usd,
+            monthly_limit_usd=monthly_limit_usd,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _delete_agent_budget(agent_id):
+    """Remove a per-agent override row. Returns 1 on delete, 0 when missing."""
+    if not agent_id:
+        return 0
+    try:
+        from clawmetry import local_store
+
+        store = local_store.get_store()
+        return store.delete_agent_budget(agent_id)
+    except Exception:
+        return 0
+
+
+def _agent_spend_for_period(agent_id, period_start):
+    """Sum cost-store USD entries for one agent since ``period_start``.
+
+    Cost entries written without an ``agent`` key default to ``"main"``,
+    matching how the rest of the dashboard names the primary agent."""
+    total = 0.0
+    with _metrics_lock:
+        for entry in metrics_store["cost"]:
+            ts = entry.get("timestamp", 0)
+            if ts < period_start:
+                continue
+            ent_agent = entry.get("agent", "main") or "main"
+            if ent_agent != agent_id:
+                continue
+            total += float(entry.get("usd", 0) or 0)
+    return total
+
+
+def _period_bounds():
+    """Return (today_start_ts, today_key, month_start_ts, month_key)."""
+    now_dt = datetime.now()
+    today_start = now_dt.replace(
+        hour=0, minute=0, second=0, microsecond=0
+    ).timestamp()
+    today_key = now_dt.strftime("%Y-%m-%d")
+    month_start = now_dt.replace(
+        day=1, hour=0, minute=0, second=0, microsecond=0
+    ).timestamp()
+    month_key = now_dt.strftime("%Y-%m")
+    return today_start, today_key, month_start, month_key
+
+
+def _get_agent_budget_status(agent_id):
+    """Return per-agent budget status dict for the API. Combines per-agent
+    override (when present) with global fallback and current MTD/daily
+    spend. Always returns a populated dict — never ``None``."""
+    config = _get_budget_config()
+    override = _get_agent_budget(agent_id) or {}
+    today_start, _, month_start, _ = _period_bounds()
+    daily_spent = _agent_spend_for_period(agent_id, today_start)
+    monthly_spent = _agent_spend_for_period(agent_id, month_start)
+
+    def _effective(override_val, global_key):
+        if override_val is not None and override_val > 0:
+            return float(override_val), "agent"
+        gv = config.get(global_key, 0) or 0
+        try:
+            gv = float(gv)
+        except (TypeError, ValueError):
+            gv = 0.0
+        return gv, ("global" if gv > 0 else "none")
+
+    daily_limit, daily_source = _effective(
+        override.get("daily_limit_usd"), "daily_limit"
+    )
+    monthly_limit, monthly_source = _effective(
+        override.get("monthly_limit_usd"), "monthly_limit"
+    )
+
+    def _pct(spent, limit):
+        return round((spent / limit * 100), 1) if limit > 0 else 0.0
+
+    def _status(pct):
+        if pct >= 100:
+            return "critical"
+        if pct >= 80:
+            return "warning"
+        if pct >= 50:
+            return "ok"
+        return "ok"
+
+    daily_pct = _pct(daily_spent, daily_limit)
+    monthly_pct = _pct(monthly_spent, monthly_limit)
+    overall_pct = max(daily_pct, monthly_pct)
+
+    return {
+        "agent_id": agent_id,
+        "daily_limit": daily_limit,
+        "daily_limit_usd": daily_limit,
+        "daily_limit_source": daily_source,
+        "daily_spent": round(daily_spent, 4),
+        "daily_pct": daily_pct,
+        "monthly_limit": monthly_limit,
+        "monthly_limit_usd": monthly_limit,
+        "monthly_limit_source": monthly_source,
+        "monthly_spent": round(monthly_spent, 4),
+        "mtd_spend": round(monthly_spent, 4),
+        "monthly_pct": monthly_pct,
+        "status": _status(overall_pct),
+        "has_override": bool(override),
+    }
+
+
+def _budget_check_for_agent(agent_id, *, auto_pause_enabled=None,
+                            warning_pct=80, pause_pct=100):
+    """Tiered-alert check for one agent. Honours dedup-per-period-per-tier.
+
+    Returns True when a critical (100%) breach fired AND auto-pause is
+    enabled — caller (``_budget_check``) treats that as a signal to pause
+    the gateway. Returns False otherwise."""
+    global _budget_agent_tier_state
+    override = _get_agent_budget(agent_id)
+    if not override:
+        return False
+    config = _get_budget_config()
+    if auto_pause_enabled is None:
+        auto_pause_enabled = config.get("auto_pause_enabled", False)
+    today_start, today_key, month_start, month_key = _period_bounds()
+    pause_triggered = False
+
+    for period, period_start, period_key, override_key, global_key in (
+        ("daily", today_start, today_key, "daily_limit_usd", "daily_limit"),
+        ("monthly", month_start, month_key, "monthly_limit_usd", "monthly_limit"),
+    ):
+        limit = override.get(override_key)
+        if limit is None or limit <= 0:
+            # Fall back to global limit for this period if not overridden.
+            try:
+                limit = float(config.get(global_key, 0) or 0)
+            except (TypeError, ValueError):
+                limit = 0.0
+            if limit <= 0:
+                continue
+        spent = _agent_spend_for_period(agent_id, period_start)
+        pct = (spent / limit * 100) if limit > 0 else 0
+        slot_key = (agent_id, period, period_key)
+        prior_tier = _budget_agent_tier_state.get(slot_key)
+
+        # Critical (>=100%) — supersedes warning. Dedup: once per period.
+        if pct >= pause_pct:
+            if prior_tier != "critical":
+                _budget_agent_tier_state[slot_key] = "critical"
+                _fire_alert(
+                    rule_id=f"budget_agent_{agent_id}_{period}_critical_{period_key}",
+                    alert_type="budget.critical",
+                    message=(
+                        f"BUDGET CRITICAL: agent '{agent_id}' {period} spend "
+                        f"${spent:.2f} of ${limit:.2f} (100%) limit"
+                    ),
+                    channels=["banner", "telegram"],
+                )
+                if auto_pause_enabled:
+                    pause_triggered = True
+            continue
+
+        # Warning (>=80% but <100%). Dedup: only fire when crossing from
+        # nothing → warning (don't fire if already at critical, can't
+        # happen here since we continued above, but defensive).
+        if pct >= warning_pct:
+            if prior_tier not in ("warning", "critical"):
+                _budget_agent_tier_state[slot_key] = "warning"
+                _fire_alert(
+                    rule_id=f"budget_agent_{agent_id}_{period}_warning_{period_key}",
+                    alert_type="budget.warning",
+                    message=(
+                        f"Budget warning: agent '{agent_id}' {period} spend "
+                        f"${spent:.2f} is {pct:.0f}% of ${limit:.2f} limit"
+                    ),
+                    channels=["banner", "telegram"],
+                )
+
+    return pause_triggered
+
+
 def _budget_check():
     """Check budget limits and fire alerts/auto-pause if needed."""
     global _budget_paused, _budget_paused_at, _budget_paused_reason
@@ -711,7 +954,44 @@ def _budget_check():
     warning_pct = config.get("warning_threshold_pct", 80)
     pause_pct = config.get("auto_pause_threshold_pct", 100)
 
-    # Check each period
+    # ── Per-agent budgets first (issue #951) ────────────────────────────
+    # We collect the unique set of agents that have either spent something
+    # in the cost store today/this-month OR have an override configured.
+    # Either source can trip a tier, so we union them.
+    agents_to_check = set()
+    try:
+        for ov in _list_agent_budgets():
+            aid = ov.get("agent_id")
+            if aid:
+                agents_to_check.add(aid)
+    except Exception:
+        pass
+    try:
+        with _metrics_lock:
+            for entry in metrics_store["cost"]:
+                agents_to_check.add(entry.get("agent", "main") or "main")
+    except Exception:
+        pass
+    for agent_id in agents_to_check:
+        try:
+            if _budget_check_for_agent(
+                agent_id,
+                auto_pause_enabled=config.get("auto_pause_enabled", False),
+                warning_pct=warning_pct,
+                pause_pct=pause_pct,
+            ):
+                _budget_paused = True
+                _budget_paused_at = time.time()
+                _budget_paused_reason = (
+                    f"Agent '{agent_id}' budget exceeded; gateway paused."
+                )
+                _pause_gateway()
+                return
+        except Exception:
+            # Never let one agent's check kill the whole sweep.
+            continue
+
+    # Check each period (global)
     for period in ["daily", "weekly", "monthly"]:
         limit = config.get(f"{period}_limit", 0)
         if limit <= 0:
@@ -3350,6 +3630,7 @@ function clawmetryLogout(){
       <div class="modal-tab active" onclick="switchBudgetTab('limits',this)">Budget Limits</div>
       <div class="modal-tab" onclick="switchBudgetTab('alerts',this)">Alert Rules</div>
       <div class="modal-tab" onclick="switchBudgetTab('telegram',this)">Telegram</div>
+      <div class="modal-tab" onclick="switchBudgetTab('agents',this)">Per-Agent</div>
       <div class="modal-tab" onclick="switchBudgetTab('history',this)">History</div>
     </div>
     <!-- Budget Limits Tab -->
@@ -3463,6 +3744,25 @@ function clawmetryLogout(){
         </div>
         <div id="tg-status" style="font-size:12px;color:var(--text-muted);"></div>
       </div>
+    </div>
+    <!-- Per-Agent Tab (issue #951) -->
+    <div id="budget-tab-agents" style="display:none;">
+      <div style="font-size:12px;color:var(--text-muted);line-height:1.5;margin-bottom:12px;">
+        Override the global daily / monthly limits for a specific agent. Leave a field blank to fall back to the global limit. Tiered alerts fire at 80% (warning) and 100% (critical) of whichever limit applies.
+      </div>
+      <div style="padding:12px;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:8px;margin-bottom:12px;">
+        <div style="font-size:13px;font-weight:700;color:var(--text-primary);margin-bottom:10px;">Add / Update Override</div>
+        <div style="display:grid;gap:8px;">
+          <input id="agent-budget-id" type="text" placeholder="Agent ID (e.g. main, my-subagent)" style="padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
+          <input id="agent-budget-daily" type="number" step="0.01" min="0" placeholder="Daily limit USD (blank = global)" style="padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
+          <input id="agent-budget-monthly" type="number" step="0.01" min="0" placeholder="Monthly limit USD (blank = global)" style="padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
+          <div style="display:flex;gap:8px;">
+            <button onclick="saveAgentBudget()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;cursor:pointer;">Save Override</button>
+            <span id="agent-budget-status" style="font-size:12px;color:var(--text-muted);display:flex;align-items:center;"></span>
+          </div>
+        </div>
+      </div>
+      <div id="agent-budget-list" style="font-size:13px;color:var(--text-secondary);">Loading...</div>
     </div>
     <!-- History Tab -->
     <div id="budget-tab-history" style="display:none;">
@@ -4693,13 +4993,98 @@ function openBudgetModal() {
 function switchBudgetTab(tab, el) {
   document.querySelectorAll('#budget-modal-tabs .modal-tab').forEach(function(t){t.classList.remove('active');});
   if(el) el.classList.add('active');
-  ['limits','alerts','telegram','history'].forEach(function(t){
+  ['limits','alerts','telegram','agents','history'].forEach(function(t){
     var d = document.getElementById('budget-tab-'+t);
     if(d) d.style.display = t===tab ? 'block' : 'none';
   });
   if(tab==='alerts') { loadAlertRules(); loadWebhookConfig(); }
   if(tab==='telegram') loadTelegramConfig();
+  if(tab==='agents') loadAgentBudgets();
   if(tab==='history') loadAlertHistory();
+}
+
+// Per-agent budgets (issue #951)
+async function loadAgentBudgets() {
+  try {
+    var data = await fetch('/api/budget').then(function(r){return r.json();});
+    var agents = (data && data.agents) || {};
+    var ids = Object.keys(agents);
+    if (ids.length === 0) {
+      document.getElementById('agent-budget-list').innerHTML =
+        '<div style="padding:20px;text-align:center;color:var(--text-muted);">No per-agent overrides yet.</div>';
+      return;
+    }
+    var html = '<table style="width:100%;border-collapse:collapse;font-size:12px;">';
+    html += '<tr style="border-bottom:1px solid var(--border-primary);">'
+         + '<th style="text-align:left;padding:6px;">Agent</th>'
+         + '<th style="text-align:right;padding:6px;">Daily</th>'
+         + '<th style="text-align:right;padding:6px;">Monthly</th>'
+         + '<th style="text-align:right;padding:6px;">Spend (MTD)</th>'
+         + '<th style="text-align:right;padding:6px;">Usage</th>'
+         + '<th style="padding:6px;"></th></tr>';
+    // Fetch live status for each agent (sequential is fine — tiny N).
+    var rows = await Promise.all(ids.map(async function(aid){
+      try {
+        var s = await fetch('/api/agents/'+encodeURIComponent(aid)+'/budget').then(function(r){return r.json();});
+        return [aid, agents[aid], s];
+      } catch(e) { return [aid, agents[aid], null]; }
+    }));
+    rows.forEach(function(t){
+      var aid = t[0], ov = t[1], s = t[2] || {};
+      var pct = Math.max(s.daily_pct||0, s.monthly_pct||0);
+      var barColor = pct >= 80 ? '#dc2626' : (pct >= 50 ? '#f59e0b' : '#16a34a');
+      html += '<tr style="border-bottom:1px solid var(--border-secondary);">';
+      html += '<td style="padding:6px;font-weight:600;">' + escHtml(aid) + '</td>';
+      html += '<td style="padding:6px;text-align:right;">' + (ov.daily_limit_usd != null ? '$' + (+ov.daily_limit_usd).toFixed(2) : '<span style="color:var(--text-muted);">global</span>') + '</td>';
+      html += '<td style="padding:6px;text-align:right;">' + (ov.monthly_limit_usd != null ? '$' + (+ov.monthly_limit_usd).toFixed(2) : '<span style="color:var(--text-muted);">global</span>') + '</td>';
+      html += '<td style="padding:6px;text-align:right;">$' + (+(s.mtd_spend||0)).toFixed(2) + '</td>';
+      html += '<td style="padding:6px;text-align:right;"><div style="display:inline-block;width:80px;height:8px;background:var(--bg-tertiary);border-radius:4px;overflow:hidden;"><div style="width:'+Math.min(100,pct)+'%;height:100%;background:'+barColor+';"></div></div> <span style="font-size:11px;color:var(--text-muted);">'+Math.round(pct)+'%</span></td>';
+      html += '<td style="padding:6px;text-align:right;"><span data-agent-id="'+escHtml(aid)+'" style="cursor:pointer;color:var(--text-error);font-size:14px;" onclick="deleteAgentBudget(this.dataset.agentId)" title="Remove override">&#x1f5d1;</span></td>';
+      html += '</tr>';
+    });
+    html += '</table>';
+    document.getElementById('agent-budget-list').innerHTML = html;
+  } catch(e) {
+    document.getElementById('agent-budget-list').textContent = 'Failed to load';
+  }
+}
+
+async function saveAgentBudget() {
+  var aid = (document.getElementById('agent-budget-id').value || '').trim();
+  if (!aid) {
+    document.getElementById('agent-budget-status').textContent = 'Agent ID required';
+    return;
+  }
+  var d = document.getElementById('agent-budget-daily').value;
+  var m = document.getElementById('agent-budget-monthly').value;
+  var body = {};
+  if (d !== '' && d !== null) body.daily_limit_usd = parseFloat(d);
+  if (m !== '' && m !== null) body.monthly_limit_usd = parseFloat(m);
+  try {
+    var r = await fetch('/api/agents/'+encodeURIComponent(aid)+'/budget', {
+      method:'PUT',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(body),
+    });
+    var j = await r.json();
+    if (j && j.ok) {
+      document.getElementById('agent-budget-status').textContent = 'Saved';
+      document.getElementById('agent-budget-id').value = '';
+      document.getElementById('agent-budget-daily').value = '';
+      document.getElementById('agent-budget-monthly').value = '';
+      loadAgentBudgets();
+    } else {
+      document.getElementById('agent-budget-status').textContent = (j && j.error) || 'Save failed';
+    }
+  } catch(e) {
+    document.getElementById('agent-budget-status').textContent = 'Save failed';
+  }
+}
+
+async function deleteAgentBudget(aid) {
+  if (!aid) return;
+  await fetch('/api/agents/'+encodeURIComponent(aid)+'/budget', {method:'DELETE'});
+  loadAgentBudgets();
 }
 
 async function loadBudgetConfig() {

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -154,6 +154,93 @@ def api_budget_resume():
     return jsonify({"ok": True, "paused": False})
 
 
+# ── Per-agent budget overrides (issue #951) ────────────────────────────
+
+
+@bp_budget.route("/api/budget", methods=["GET"])
+def api_budget_root():
+    """Unified GET — global config + per-agent overrides map.
+
+    Issue #951: the existing ``/api/budget/config`` keeps its shape so old
+    clients don't break; this new collapsed endpoint is convenient for the
+    Budget Settings page which renders both panels in one render.
+    """
+    import dashboard as _d
+    cfg = _d._get_budget_config()
+    overrides_list = _d._list_agent_budgets()
+    overrides = {
+        row.get("agent_id"): {
+            "daily_limit_usd": row.get("daily_limit_usd"),
+            "monthly_limit_usd": row.get("monthly_limit_usd"),
+            "updated_at": row.get("updated_at"),
+        }
+        for row in overrides_list
+        if row.get("agent_id")
+    }
+    return jsonify({"config": cfg, "agents": overrides})
+
+
+@bp_budget.route("/api/agents/<agent_id>/budget", methods=["GET"])
+def api_agent_budget_get(agent_id):
+    """Return one agent's effective budget + current MTD/daily spend.
+
+    Always returns 200 with a populated payload — when the agent has no
+    override row we still report the global limits with
+    ``daily_limit_source`` / ``monthly_limit_source`` of ``global``
+    (or ``none`` when no global is set either)."""
+    import dashboard as _d
+    return jsonify(_d._get_agent_budget_status(agent_id))
+
+
+@bp_budget.route("/api/agents/<agent_id>/budget", methods=["PUT"])
+def api_agent_budget_put(agent_id):
+    """Upsert a per-agent budget override row.
+
+    Body: ``{"daily_limit_usd": 5.0, "monthly_limit_usd": 100.0}``.
+    Either field may be omitted (or null) to fall back to global on that
+    side. Non-numeric inputs are rejected."""
+    import dashboard as _d
+    if not agent_id:
+        return jsonify({"ok": False, "error": "agent_id required"}), 400
+    data = request.get_json(silent=True) or {}
+    raw_daily = data.get("daily_limit_usd")
+    raw_monthly = data.get("monthly_limit_usd")
+
+    def _norm(v, name):
+        if v is None or v == "":
+            return None, None
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            return None, f"{name} must be a number"
+        if f < 0:
+            return None, f"{name} must be >= 0"
+        return f, None
+
+    daily, err = _norm(raw_daily, "daily_limit_usd")
+    if err:
+        return jsonify({"ok": False, "error": err}), 400
+    monthly, err = _norm(raw_monthly, "monthly_limit_usd")
+    if err:
+        return jsonify({"ok": False, "error": err}), 400
+    ok = _d._set_agent_budget(
+        agent_id, daily_limit_usd=daily, monthly_limit_usd=monthly
+    )
+    if not ok:
+        return jsonify({"ok": False, "error": "local store unavailable"}), 500
+    return jsonify({"ok": True, "budget": _d._get_agent_budget_status(agent_id)})
+
+
+@bp_budget.route("/api/agents/<agent_id>/budget", methods=["DELETE"])
+def api_agent_budget_delete(agent_id):
+    """Remove the per-agent override row — agent falls back to global."""
+    import dashboard as _d
+    if not agent_id:
+        return jsonify({"ok": False, "error": "agent_id required"}), 400
+    deleted = _d._delete_agent_budget(agent_id)
+    return jsonify({"ok": True, "deleted": int(deleted)})
+
+
 @bp_budget.route("/api/budget/test-telegram", methods=["POST"])
 def api_budget_test_telegram():
     """Send a test Telegram notification using saved config."""

--- a/tests/test_per_agent_budget.py
+++ b/tests/test_per_agent_budget.py
@@ -1,0 +1,323 @@
+"""Tests for issue #951 — per-agent budget limits + tiered 80%/100% alerts.
+
+Five surfaces:
+  1. ``agent_budgets`` table — round-trip PUT/GET via the local-store API
+     methods (``set_agent_budget`` / ``get_agent_budget`` /
+     ``query_agent_budgets`` / ``delete_agent_budget``).
+  2. ``/api/agents/<id>/budget`` PUT then GET — full HTTP round-trip via the
+     Flask test client.
+  3. 80% trigger — fires ``budget.warning``, does NOT auto-pause.
+  4. 100% trigger — fires ``budget.critical`` AND auto-pauses when
+     ``auto_pause_enabled`` is True.
+  5. Dedup — same threshold crossed twice within the same period only
+     fires once.
+  6. Fallback — agent with no override row uses the global budget.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+import types
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Reload `clawmetry.local_store` against a fresh DuckDB file."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.get_store()
+    yield ls, store
+    try:
+        store.stop(flush=False)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def dashboard_module(fresh_store, monkeypatch, tmp_path):
+    """Import dashboard.py with a clean module slate so ``_get_agent_budget``
+    et al. resolve to the freshly-loaded local_store. Also resets the
+    in-memory cost store and tier-state dedup map between tests."""
+    # Reload routes.alerts so its `import dashboard as _d` indirection
+    # refers to the same dashboard import the test sees.
+    sys.modules.pop("dashboard", None)
+    sys.modules.pop("routes.alerts", None)
+    import dashboard as _d
+    import routes.alerts as ra
+    importlib.reload(ra)
+
+    # Point fleet-DB at a temp file so the test doesn't touch the user's
+    # real ~/.clawmetry/fleet.db (and so each test gets fresh tables).
+    _d.FLEET_DB_PATH = str(tmp_path / "fleet.db")
+
+    # Wipe in-memory cost store + dedup map so each test starts clean.
+    with _d._metrics_lock:
+        _d.metrics_store["cost"].clear()
+    _d._budget_agent_tier_state.clear()
+    _d._budget_alert_cooldowns.clear()
+    _d._budget_paused = False
+    _d._budget_paused_at = 0
+    _d._budget_paused_reason = ""
+
+    # Ensure fleet-DB tables (budget_config, alert_rules, alert_history)
+    # exist for this run — they're lazily initialized on dashboard boot.
+    try:
+        _d._budget_init_db()
+    except Exception:
+        pass
+
+    # Stub out pause/telegram side effects so tests don't hit subprocess /
+    # network. We still want _fire_alert to write to alert_history, so we
+    # keep its internals; just stub the destinations.
+    monkeypatch.setattr(_d, "_pause_gateway", lambda: None)
+    monkeypatch.setattr(_d, "_send_telegram_alert", lambda msg: None)
+
+    yield _d
+
+
+def _add_cost(_d, agent_id, usd, when=None):
+    """Append a cost-store entry tagged with ``agent_id``."""
+    entry = {
+        "timestamp": when if when is not None else time.time(),
+        "usd": float(usd),
+        "agent": agent_id,
+        "model": "test-model",
+    }
+    with _d._metrics_lock:
+        _d.metrics_store["cost"].append(entry)
+
+
+def _count_alerts_for(_d, rule_id_substring):
+    """Count rows in alert_history whose rule_id contains the substring."""
+    try:
+        with _d._fleet_db_lock:
+            db = _d._fleet_db()
+            rows = db.execute(
+                "SELECT rule_id FROM alert_history WHERE rule_id LIKE ?",
+                (f"%{rule_id_substring}%",),
+            ).fetchall()
+            db.close()
+        return len(rows)
+    except Exception:
+        return 0
+
+
+# ── 1. Schema round-trip ───────────────────────────────────────────────────
+
+
+def test_set_get_agent_budget_round_trip(fresh_store):
+    ls, store = fresh_store
+    store.set_agent_budget("agent-a", daily_limit_usd=5.0, monthly_limit_usd=100.0)
+    row = store.get_agent_budget("agent-a")
+    assert row is not None
+    assert row["agent_id"] == "agent-a"
+    assert row["daily_limit_usd"] == 5.0
+    assert row["monthly_limit_usd"] == 100.0
+    assert row["updated_at"] > 0
+
+    # Upsert overwrites
+    store.set_agent_budget("agent-a", daily_limit_usd=7.5, monthly_limit_usd=None)
+    row = store.get_agent_budget("agent-a")
+    assert row["daily_limit_usd"] == 7.5
+    assert row["monthly_limit_usd"] is None
+
+
+def test_query_agent_budgets_lists_all_rows(fresh_store):
+    ls, store = fresh_store
+    store.set_agent_budget("agent-a", daily_limit_usd=1.0)
+    store.set_agent_budget("agent-b", monthly_limit_usd=50.0)
+    rows = store.query_agent_budgets()
+    ids = {r["agent_id"] for r in rows}
+    assert ids == {"agent-a", "agent-b"}
+
+
+def test_delete_agent_budget_removes_row(fresh_store):
+    ls, store = fresh_store
+    store.set_agent_budget("agent-x", daily_limit_usd=2.0)
+    assert store.get_agent_budget("agent-x") is not None
+    n = store.delete_agent_budget("agent-x")
+    assert n == 1
+    assert store.get_agent_budget("agent-x") is None
+    # Idempotent second delete
+    assert store.delete_agent_budget("agent-x") == 0
+
+
+def test_get_agent_budget_returns_none_when_missing(fresh_store):
+    ls, store = fresh_store
+    assert store.get_agent_budget("never-existed") is None
+
+
+# ── 2. HTTP API round-trip ─────────────────────────────────────────────────
+
+
+def _make_client(dashboard_module):
+    from flask import Flask
+    import routes.alerts as ra
+    app = Flask(__name__)
+    app.register_blueprint(ra.bp_budget)
+    return app.test_client()
+
+
+def test_put_then_get_agent_budget_via_api(dashboard_module):
+    client = _make_client(dashboard_module)
+    resp = client.put(
+        "/api/agents/agent-1/budget",
+        json={"daily_limit_usd": 3.0, "monthly_limit_usd": 75.0},
+    )
+    assert resp.status_code == 200, resp.data
+    body = resp.get_json()
+    assert body["ok"] is True
+
+    g = client.get("/api/agents/agent-1/budget")
+    assert g.status_code == 200
+    payload = g.get_json()
+    assert payload["agent_id"] == "agent-1"
+    assert payload["daily_limit"] == 3.0
+    assert payload["monthly_limit"] == 75.0
+    assert payload["daily_limit_source"] == "agent"
+    assert payload["monthly_limit_source"] == "agent"
+
+
+def test_delete_agent_budget_via_api(dashboard_module):
+    client = _make_client(dashboard_module)
+    client.put(
+        "/api/agents/agent-2/budget",
+        json={"daily_limit_usd": 1.0},
+    )
+    d = client.delete("/api/agents/agent-2/budget")
+    assert d.status_code == 200
+    assert d.get_json()["deleted"] == 1
+    # Second delete is a no-op
+    d2 = client.delete("/api/agents/agent-2/budget")
+    assert d2.get_json()["deleted"] == 0
+
+
+def test_put_rejects_non_numeric(dashboard_module):
+    client = _make_client(dashboard_module)
+    resp = client.put(
+        "/api/agents/agent-3/budget",
+        json={"daily_limit_usd": "not a number"},
+    )
+    assert resp.status_code == 400
+
+
+def test_api_budget_root_includes_agent_overrides(dashboard_module):
+    client = _make_client(dashboard_module)
+    client.put(
+        "/api/agents/agent-root/budget",
+        json={"daily_limit_usd": 2.5},
+    )
+    r = client.get("/api/budget")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "config" in body and "agents" in body
+    assert "agent-root" in body["agents"]
+    assert body["agents"]["agent-root"]["daily_limit_usd"] == 2.5
+
+
+# ── 3. Tiered alerts ───────────────────────────────────────────────────────
+
+
+def test_warning_at_80_percent_no_pause(dashboard_module):
+    _d = dashboard_module
+    _d._set_agent_budget("a-warn", daily_limit_usd=10.0)
+    _add_cost(_d, "a-warn", 8.0)  # 80%
+    _d._budget_check()
+    assert _count_alerts_for(_d, "a-warn") >= 1
+    assert _count_alerts_for(_d, "warning") >= 1
+    assert _d._budget_paused is False
+
+
+def test_critical_at_100_percent_pauses_when_enabled(dashboard_module):
+    _d = dashboard_module
+    _d._set_budget_config({"auto_pause_enabled": True})
+    _d._set_agent_budget("a-crit", daily_limit_usd=10.0)
+    _add_cost(_d, "a-crit", 10.0)  # 100%
+    _d._budget_check()
+    assert _count_alerts_for(_d, "a-crit") >= 1
+    assert _count_alerts_for(_d, "critical") >= 1
+    assert _d._budget_paused is True
+
+
+def test_critical_without_autopause_fires_alert_only(dashboard_module):
+    _d = dashboard_module
+    _d._set_budget_config({"auto_pause_enabled": False})
+    _d._set_agent_budget("a-crit-nopause", daily_limit_usd=10.0)
+    _add_cost(_d, "a-crit-nopause", 12.0)  # 120%
+    _d._budget_check()
+    assert _count_alerts_for(_d, "a-crit-nopause") >= 1
+    assert _d._budget_paused is False
+
+
+# ── 4. Dedup ───────────────────────────────────────────────────────────────
+
+
+def test_dedup_same_tier_same_period_fires_once(dashboard_module):
+    _d = dashboard_module
+    _d._set_agent_budget("a-dedup", daily_limit_usd=10.0)
+    _add_cost(_d, "a-dedup", 8.0)
+    _d._budget_check()
+    n1 = _count_alerts_for(_d, "a-dedup")
+    # More spend, but still in the warning tier → should NOT re-fire.
+    _add_cost(_d, "a-dedup", 0.5)
+    _d._budget_check()
+    n2 = _count_alerts_for(_d, "a-dedup")
+    assert n2 == n1, "warning tier deduped within same day"
+
+
+def test_warning_then_critical_both_fire_once_each(dashboard_module):
+    _d = dashboard_module
+    _d._set_budget_config({"auto_pause_enabled": False})
+    _d._set_agent_budget("a-escalate", daily_limit_usd=10.0)
+    _add_cost(_d, "a-escalate", 8.0)  # 80% → warning
+    _d._budget_check()
+    warns1 = _count_alerts_for(_d, "a-escalate_daily_warning")
+    crits1 = _count_alerts_for(_d, "a-escalate_daily_critical")
+    assert warns1 >= 1
+    assert crits1 == 0
+    _add_cost(_d, "a-escalate", 5.0)  # → 130% → critical
+    _d._budget_check()
+    warns2 = _count_alerts_for(_d, "a-escalate_daily_warning")
+    crits2 = _count_alerts_for(_d, "a-escalate_daily_critical")
+    assert warns2 == warns1, "warning should not re-fire after critical"
+    assert crits2 >= 1
+
+
+# ── 5. Fallback to global ──────────────────────────────────────────────────
+
+
+def test_no_override_falls_back_to_global(dashboard_module):
+    _d = dashboard_module
+    # No per-agent override row exists for 'a-fallback'.
+    status = _d._get_agent_budget_status("a-fallback")
+    assert status["daily_limit_source"] in ("none", "global")
+    assert status["has_override"] is False
+
+
+def test_override_takes_precedence_over_global(dashboard_module):
+    _d = dashboard_module
+    _d._set_budget_config({"daily_limit": 99.0, "monthly_limit": 999.0})
+    _d._set_agent_budget("a-precedence", daily_limit_usd=4.0)
+    status = _d._get_agent_budget_status("a-precedence")
+    assert status["daily_limit"] == 4.0
+    assert status["daily_limit_source"] == "agent"
+    # Monthly side falls back to global because override is None.
+    assert status["monthly_limit"] == 999.0
+    assert status["monthly_limit_source"] == "global"


### PR DESCRIPTION
## Summary
- Per-agent overrides in a new ``agent_budgets`` DuckDB table; either daily / monthly column can be NULL to fall back to the global ``daily_limit`` / ``monthly_limit`` independently.
- Tiered alerts: ``budget.warning`` at >=80%, ``budget.critical`` (+ optional auto-pause when ``auto_pause_enabled``) at >=100%, with same-period dedup keyed by ``(agent_id, period, YYYY-MM-DD|YYYY-MM)`` so slots reset naturally at midnight / month-start.
- New endpoints — ``GET /api/budget`` (collapsed config + agents map), ``GET/PUT/DELETE /api/agents/<id>/budget``.
- New "Per-Agent" tab on the Budget modal with inline add/update/delete and a usage bar (green/amber/red).
- ``tests/test_per_agent_budget.py``: 15 tests covering schema round-trip, HTTP round-trip, 80% warning (no pause), 100% critical + auto-pause, 100% without auto-pause, dedup, warning→critical escalation, and global fallback / override-precedence.

Closes #951.

## Test plan
- [x] ``python3 -m pytest tests/test_per_agent_budget.py -q`` — 15 passed
- [x] ``python3 -m pytest tests/test_alert_evaluator_unit.py tests/test_alert_rules_local_store.py tests/test_circular_import.py -q`` — 40 passed (no regressions in adjacent budget/alert surfaces)
- [x] ``python3 -c "import dashboard"`` clean
- [ ] Manual: open the Budget modal → Per-Agent tab → add an override → verify the row paints with the live MTD usage bar
- [ ] Manual: hit 80% of an agent override → see ``budget.warning`` alert; hit 100% with auto-pause on → see ``budget.critical`` + gateway pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)