### PR TITLE
feat(usage): per-session cost breakdown table (closes #68)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5768,6 +5768,8 @@ async function loadUsage() {
     tableHtml += '<tr><td>This Month</td><td>' + fmtTokens(data.month) + '</td><td>' + fmtCost(data.monthCost) + '</td></tr>';
     tableHtml += '</tbody>';
     document.getElementById('usage-cost-table').innerHTML = tableHtml;
+    // Issue #68 — per-session cost breakdown table.
+    renderTopSessionsByCost(data.sessions || []);
     // OTLP-specific sections
     var otelExtra = document.getElementById('otel-extra-sections');
     if (data.source === 'otlp') {
@@ -5817,6 +5819,49 @@ async function loadUsage() {
   } catch(e) {
     document.getElementById('usage-chart').innerHTML = '<span style="color:#555">No usage data available</span>';
   }
+}
+
+// Issue #68 — render "Top sessions by cost" table on the Usage tab.
+// Rows come straight from /api/usage's new ``sessions`` array, already
+// sorted desc by total_cost_usd server-side.
+function renderTopSessionsByCost(rows) {
+  var el = document.getElementById('usage-top-sessions-table');
+  if (!el) return;
+  function fmtCost(c) { return c >= 0.01 ? '$' + c.toFixed(2) : c > 0 ? '<$0.01' : '$0.00'; }
+  function fmtTokens(n) { return n >= 1000000 ? (n/1000000).toFixed(1) + 'M' : n >= 1000 ? (n/1000).toFixed(0) + 'K' : String(n); }
+  function fmtDate(iso) {
+    if (!iso) return '—';
+    var d = String(iso).slice(0, 10);
+    return d || '—';
+  }
+  if (!rows || rows.length === 0) {
+    el.innerHTML = '<tbody><tr><td colspan="6" style="color:#666;">No session cost data yet</td></tr></tbody>';
+    return;
+  }
+  var html = '<thead><tr>'
+    + '<th>Session</th>'
+    + '<th>Agent</th>'
+    + '<th>Model</th>'
+    + '<th style="text-align:right;">Tokens</th>'
+    + '<th style="text-align:right;">Cost</th>'
+    + '<th style="text-align:right;">Msgs</th>'
+    + '<th>Started</th>'
+    + '</tr></thead><tbody>';
+  rows.forEach(function(r) {
+    var sid = String(r.session_id || '');
+    var sidShort = sid.length > 16 ? sid.slice(-16) : sid;
+    html += '<tr>'
+      + '<td><code style="font-size:11px;color:var(--text-muted);">' + escHtml(sidShort) + '</code></td>'
+      + '<td>' + escHtml(r.agent_id || '—') + '</td>'
+      + '<td>' + (r.model ? '<span class="badge model">' + escHtml(r.model) + '</span>' : '—') + '</td>'
+      + '<td style="text-align:right;">' + fmtTokens(r.total_tokens || 0) + '</td>'
+      + '<td style="text-align:right;font-weight:600;">' + fmtCost(r.total_cost_usd || 0) + '</td>'
+      + '<td style="text-align:right;">' + (r.message_count || 0) + '</td>'
+      + '<td style="color:var(--text-muted);font-size:12px;">' + escHtml(fmtDate(r.started_at)) + '</td>'
+      + '</tr>';
+  });
+  html += '</tbody>';
+  el.innerHTML = html;
 }
 
 async function loadCacheAnalytics() {

--- a/clawmetry/templates/tabs/usage.html
+++ b/clawmetry/templates/tabs/usage.html
@@ -36,6 +36,9 @@
   </div>
   <div class="section-title">💰 Cost Breakdown <span id="usage-cost-info-icon" class="tooltip-info-icon" style="display:none;">i</span></div>
   <div class="card"><table class="usage-table" id="usage-cost-table"><tbody><tr><td colspan="3" style="color:#666;">Loading...</td></tr></tbody></table></div>
+  <!-- Issue #68 — top sessions by cost (per-session breakdown) -->
+  <div class="section-title">🏆 Top Sessions by Cost <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">which session burned the budget · top 20</span></div>
+  <div class="card"><table class="usage-table" id="usage-top-sessions-table"><tbody><tr><td colspan="6" style="color:#666;">Loading...</td></tr></tbody></table></div>
   <div id="usage-anomaly-section" style="display:none;">
     <div class="section-title">⚠️ Anomaly Alerts <span id="usage-anomaly-badge" style="
       font-size:11px;

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -228,11 +228,56 @@ def _try_local_store_usage():
         "modelBilling": [],
         "billingSummary": {},
         "sessionCosts": {},
+        "sessions": _ls_top_sessions_by_cost(limit=20),
         "anomalies": [],
         "anomalySessionIds": [],
         "trend": {},
         "warnings": [],
     }
+
+
+def _ls_top_sessions_by_cost(limit=20):
+    """Issue #68 — top-N sessions by total cost. Sources rows from the
+    DuckDB ``events`` table aggregated per session, joined back to a
+    sample event for the model column. Returns ``[]`` on any failure so
+    the caller can drop the key silently."""
+    try:
+        sessions = _ls_call("query_sessions", limit=500)
+    except Exception:
+        sessions = None
+    if not sessions:
+        return []
+    # Sort by cost desc and take top-N before the model lookup so we
+    # avoid scanning events for hundreds of cheap sessions.
+    ranked = sorted(
+        sessions,
+        key=lambda s: float(s.get("cost_usd") or 0.0),
+        reverse=True,
+    )[: max(1, int(limit))]
+    out = []
+    for s in ranked:
+        sid = s.get("session_id") or ""
+        if not sid:
+            continue
+        # Pull the most recent event for this session to grab the model
+        # column. ``query_events`` returns rows newest-first.
+        model = ""
+        try:
+            evs = _ls_call("query_events", session_id=sid, limit=1) or []
+            if evs:
+                model = evs[0].get("model") or ""
+        except Exception:
+            model = ""
+        out.append({
+            "session_id":      sid,
+            "agent_id":        s.get("agent_id") or "",
+            "model":           model,
+            "total_tokens":    int(s.get("token_count") or 0),
+            "total_cost_usd":  round(float(s.get("cost_usd") or 0.0), 6),
+            "message_count":   int(s.get("event_count") or 0),
+            "started_at":      s.get("started_at") or "",
+        })
+    return out
 
 
 def _ls_compute_anomalies():
@@ -799,6 +844,32 @@ def api_usage():
         today_cost, week_cost, month_cost, trend_data, month_tok, billing_summary
     )
 
+    # Issue #68 — top-N sessions by cost for the per-session breakdown
+    # table on the Tokens/Usage tab. We hand back the 20 most expensive
+    # sessions sorted desc so the UI can rank "who burned the budget"
+    # without re-aggregating.
+    top_sessions = sorted(
+        session_summaries,
+        key=lambda s: float(s.get("cost_usd", 0.0) or 0.0),
+        reverse=True,
+    )[:20]
+    top_sessions_rows = [
+        {
+            "session_id":     s.get("session_id") or "",
+            "agent_id":       s.get("agent_id") or "",
+            "model":          s.get("model") or "",
+            "total_tokens":   int(s.get("tokens") or 0),
+            "total_cost_usd": round(float(s.get("cost_usd") or 0.0), 6),
+            "message_count":  int(s.get("message_count") or 0),
+            "started_at":     (
+                datetime.fromtimestamp(float(s.get("start_ts") or 0)).isoformat()
+                if s.get("start_ts") else ""
+            ),
+        }
+        for s in top_sessions
+        if float(s.get("cost_usd") or 0.0) > 0
+    ]
+
     result = {
         "source": "transcripts",
         "days": days,
@@ -812,6 +883,7 @@ def api_usage():
         "modelBilling": model_billing,
         "billingSummary": billing_summary,
         "sessionCosts": session_costs,
+        "sessions": top_sessions_rows,
         "anomalies": anomalies,
         "anomalySessionIds": [a.get("session_id") for a in anomalies],
         "trend": trend_data,

--- a/tests/test_usage_per_session.py
+++ b/tests/test_usage_per_session.py
@@ -1,0 +1,192 @@
+"""Tests for issue #68 — per-session cost breakdown on /api/usage.
+
+The Usage endpoint now returns a top-N ``sessions`` array sorted by
+``total_cost_usd`` desc so the dashboard can show "which session burned
+the budget". This test seeds three sessions with known token + cost
+volumes via the DuckDB local store, hits ``/api/usage`` through the
+local-store fast path, and asserts:
+
+  * the ``sessions`` array is present and respects ordering
+  * each row carries the contract fields specified in issue #68
+  * totals per session match the seeded events
+
+Pattern mirrors ``tests/test_usage_local_store.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t: float = 2.0) -> None:
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _seed_three_sessions(store):
+    """Seed three sessions with deliberately distinct costs so we can
+    assert ordering. Session A is the runaway loop ($5), Session B is
+    the medium burner ($1.50), Session C is a quiet baseline ($0.10).
+    Each session gets multiple events to exercise the per-session
+    aggregation in ``query_sessions``."""
+    now = time.time()
+    seed = [
+        # (session_id, n_events, per_event_cost, per_event_tokens, model)
+        ("sess-runaway", 5, 1.0,  10000, "claude-opus-4"),    # $5.00, 50K tokens
+        ("sess-medium",  3, 0.50, 3000,  "claude-sonnet-4"),  # $1.50, 9K  tokens
+        ("sess-quiet",   2, 0.05, 500,   "gpt-4o-mini"),      # $0.10, 1K  tokens
+    ]
+    for sid, n, cost, tokens, model in seed:
+        for i in range(n):
+            store.ingest({
+                "id":          f"ev-{sid}-{i}",
+                "node_id":     "agent+test",
+                "agent_id":    "main",
+                "session_id":  sid,
+                "event_type":  "tool_call",
+                "ts":          _iso(now - (i * 60)),
+                "data":        {"plugin": "bash"},
+                "cost_usd":    cost,
+                "token_count": tokens,
+                "model":       model,
+            })
+    _wait_flush(store)
+    return seed
+
+
+@pytest.fixture
+def fast_path_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    # Isolate the daemon discovery file — if the dev machine has a real
+    # daemon running, ``local_store_via_daemon`` would proxy our calls
+    # to it and the test would read events from the wrong DuckDB.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "_DISCOVERY_PATH", str(tmp_path / "no-daemon.json"))
+    lq._invalidate_daemon_cache()
+    import routes.usage as usage_mod
+    importlib.reload(usage_mod)
+
+    app = Flask(__name__)
+    app.register_blueprint(usage_mod.bp_usage)
+    yield app, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_usage_sessions_array_present(fast_path_app):
+    """Smoke: /api/usage carries a ``sessions`` array under the fast path."""
+    app, ls = fast_path_app
+    _seed_three_sessions(ls.get_store())
+
+    body = app.test_client().get("/api/usage").get_json()
+    assert body["_source"] == "local_store"
+    assert "sessions" in body, "missing top-level 'sessions' array"
+    assert isinstance(body["sessions"], list)
+    assert len(body["sessions"]) == 3
+
+
+def test_usage_sessions_sorted_by_cost_desc(fast_path_app):
+    """Sessions must be sorted by ``total_cost_usd`` DESC — the whole
+    point of the breakdown is "who burned the budget"."""
+    app, ls = fast_path_app
+    _seed_three_sessions(ls.get_store())
+
+    sessions = app.test_client().get("/api/usage").get_json()["sessions"]
+    ids = [s["session_id"] for s in sessions]
+    assert ids == ["sess-runaway", "sess-medium", "sess-quiet"], (
+        f"unexpected ordering: {ids}"
+    )
+    costs = [s["total_cost_usd"] for s in sessions]
+    assert costs == sorted(costs, reverse=True)
+
+
+def test_usage_session_row_contract(fast_path_app):
+    """Each row carries the issue-#68 contract fields."""
+    app, ls = fast_path_app
+    _seed_three_sessions(ls.get_store())
+
+    sessions = app.test_client().get("/api/usage").get_json()["sessions"]
+    expected_keys = {"session_id", "agent_id", "model", "total_tokens",
+                     "total_cost_usd", "message_count", "started_at"}
+    for row in sessions:
+        assert expected_keys.issubset(row.keys()), (
+            f"row missing keys: {expected_keys - set(row.keys())}"
+        )
+
+
+def test_usage_session_totals_match_seeded_data(fast_path_app):
+    """Per-session totals match what we ingested. Costs use floating
+    arithmetic, so allow a tiny epsilon."""
+    app, ls = fast_path_app
+    _seed_three_sessions(ls.get_store())
+
+    sessions = app.test_client().get("/api/usage").get_json()["sessions"]
+    by_id = {s["session_id"]: s for s in sessions}
+
+    runaway = by_id["sess-runaway"]
+    assert runaway["total_cost_usd"] == pytest.approx(5.0, abs=1e-6)
+    assert runaway["total_tokens"] == 50000
+    assert runaway["message_count"] == 5
+
+    medium = by_id["sess-medium"]
+    assert medium["total_cost_usd"] == pytest.approx(1.5, abs=1e-6)
+    assert medium["total_tokens"] == 9000
+    assert medium["message_count"] == 3
+
+    quiet = by_id["sess-quiet"]
+    assert quiet["total_cost_usd"] == pytest.approx(0.10, abs=1e-6)
+    assert quiet["total_tokens"] == 1000
+    assert quiet["message_count"] == 2
+
+
+def test_usage_session_limit_respects_top_n(fast_path_app):
+    """The helper caps at 20 sessions by default — feed it 25 and
+    confirm only the top 20 (by cost) come back."""
+    app, ls = fast_path_app
+    store = ls.get_store()
+    now = time.time()
+    # 25 sessions, each one event, costs 0.01..0.25 so the cheapest 5
+    # should be trimmed off.
+    for i in range(25):
+        sid = f"sess-{i:02d}"
+        store.ingest({
+            "id":          f"ev-{sid}",
+            "node_id":     "agent+test",
+            "agent_id":    "main",
+            "session_id":  sid,
+            "event_type":  "tool_call",
+            "ts":          _iso(now - (i * 60)),
+            "data":        {"plugin": "bash"},
+            "cost_usd":    0.01 * (i + 1),
+            "token_count": 100 * (i + 1),
+            "model":       "claude-opus-4",
+        })
+    _wait_flush(store)
+
+    sessions = app.test_client().get("/api/usage").get_json()["sessions"]
+    assert len(sessions) == 20
+    # The cheapest 5 (sess-00..sess-04) must NOT appear in the top-20.
+    returned_ids = {s["session_id"] for s in sessions}
+    for i in range(5):
+        assert f"sess-{i:02d}" not in returned_ids


### PR DESCRIPTION
## Summary
- Extends `/api/usage` with a `sessions` array — top-20 sessions sorted by `total_cost_usd` desc, each row `{session_id, agent_id, model, total_tokens, total_cost_usd, message_count, started_at}`.
- Implemented on both the DuckDB fast path (`_ls_top_sessions_by_cost` joins `query_sessions` to a sample event for model) and the legacy transcript-scan path (re-uses the existing `session_summaries`).
- Adds a "Top Sessions by Cost" table to the Tokens/Usage tab template, re-using the existing `usage-table` CSS so it matches the Cost Breakdown table above it.
- `renderTopSessionsByCost` in `app.js` fills the new table from `data.sessions`.

## Why
Issue #68: today `/api/usage` only shows aggregate token/cost totals. A runaway loop disappears in a weekly average but jumps out in a per-session view — this is the #1 actionable metric for cost control.

## Test plan
- [x] `pytest tests/test_usage_per_session.py` — 5 tests pass:
  - sessions array is present under the fast path
  - rows sorted by `total_cost_usd` desc
  - each row carries the contract fields
  - per-session totals match seeded events (5 events × $1 = $5, etc.)
  - top-N caps at 20 even when 25 sessions are seeded
- [ ] Manual UI smoke: load `/page-usage` and confirm the new table renders below "Cost Breakdown" with the expected columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)