### PR TITLE
feat(overview): Anthropic OAuth migration banner (closes #556)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1737,10 +1737,33 @@ function setFlowTextAll(idSuffix, text, maxLen) {
   });
 }
 
+// Issue #556: Anthropic OAuth migration banner. Render when /api/overview
+// reports client_health.using_oauth=true. Dismissal is sticky in localStorage
+// so we don't nag users who acknowledged the message.
+function dismissOauthBanner() {
+  try { localStorage.setItem('cm_oauth_banner_dismissed', '1'); } catch(e) {}
+  var b = document.getElementById('oauth-banner');
+  if (b) b.style.display = 'none';
+}
+function renderOauthBanner(overview) {
+  var b = document.getElementById('oauth-banner');
+  if (!b) return;
+  var ch = overview && overview.client_health;
+  var using = !!(ch && ch.using_oauth);
+  var dismissed = false;
+  try { dismissed = localStorage.getItem('cm_oauth_banner_dismissed') === '1'; } catch(e) {}
+  if (using && !dismissed) {
+    b.style.display = 'flex';
+  } else {
+    b.style.display = 'none';
+  }
+}
+
 async function loadAll() {
   try {
     // Render overview quickly; do not block on heavy usage aggregation.
     var overview = await fetchJsonWithTimeout('/api/overview', 3000);
+    try { renderOauthBanner(overview); } catch(e) {}
 
     // Start only critical secondary panels immediately. Expensive/non-critical
     // cards are staggered below so the initial widget load does not stampede

--- a/dashboard.py
+++ b/dashboard.py
@@ -3620,6 +3620,15 @@ function clawmetryLogout(){
   <button id="alert-resume-btn" onclick="resumeGateway()" style="display:none;background:#16a34a;color:#fff;border:none;border-radius:6px;padding:4px 12px;font-size:12px;cursor:pointer;font-weight:600;">Resume Gateway</button>
 </div>
 
+<!-- Issue #556: Anthropic OAuth migration banner. Hidden until /api/overview
+     returns client_health.using_oauth=true. Dismiss is sticky via localStorage. -->
+<div id="oauth-banner" style="display:none;padding:10px 16px;background:#451a03;border-bottom:2px solid #f59e0b;color:#fbbf24;font-size:13px;font-weight:500;align-items:center;gap:10px;">
+  <span style="font-size:16px;">&#9888;&#65039;</span>
+  <span id="oauth-banner-msg" style="flex:1;">You appear to be using an Anthropic <b>OAuth token</b> (Claude.ai). OAuth tokens have lower rate limits and different pricing than API keys &mdash; switch to an API key from <code>console.anthropic.com</code> for higher limits and metered billing.</span>
+  <a href="https://console.anthropic.com/settings/keys" target="_blank" rel="noopener" style="background:#f59e0b;color:#1a1a2e;text-decoration:none;border:none;border-radius:6px;padding:4px 12px;font-size:12px;cursor:pointer;font-weight:600;">Why migrate?</a>
+  <button onclick="dismissOauthBanner()" style="background:transparent;color:#fbbf24;border:1px solid #f59e0b80;border-radius:6px;padding:4px 10px;font-size:11px;cursor:pointer;">Dismiss</button>
+</div>
+
 <!-- Upgrade Impact Banner -->
 <div id="upgrade-banner" style="display:none;padding:10px 16px;background:linear-gradient(90deg,#1e3a5f 0%,#1a1a2e 100%);border-bottom:2px solid #3b82f6;color:#93c5fd;font-size:13px;font-weight:500;align-items:center;gap:10px;">
   <span style="font-size:16px;">&#128640;</span>

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -21,6 +21,7 @@ and are reached via late ``import dashboard as _d``. Pure mechanical move
 
 import json
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -210,6 +211,93 @@ def _get_overview_heartbeat_cached():
         _heartbeat_cache["value"] = fresh
         _heartbeat_cache["ts"] = now_mono
     return fresh
+
+
+# Issue #556: detect users still on Anthropic Claude.ai OAuth tokens
+# (`sk-ant-oat-...`) and prompt migration to API keys (`sk-ant-api-...`).
+# OAuth tokens have lower rate limits and different pricing, so flagging
+# them in the dashboard is a high-leverage nudge.
+_OAUTH_PREFIX = "sk-ant-oat"
+_API_KEY_PREFIX = "sk-ant-api"
+# Match an OAuth-token bearer inside an Authorization header. Tolerates
+# arbitrary punctuation between the header name and value so it works on
+# both raw HTTP dumps (``Authorization: Bearer …``) and JSON-encoded payloads
+# (``"Authorization": "Bearer …"``). Header name is case-insensitive; the
+# bearer prefix itself is always lowercase.
+_OAUTH_BEARER_RE = re.compile(
+    r"authorization\W+bearer\W+sk-ant-oat[-_a-z0-9]*",
+    re.IGNORECASE,
+)
+
+
+def _detect_anthropic_oauth(limit=50):
+    """Scan the most recent events for evidence of an Anthropic OAuth token
+    (``sk-ant-oat...``) being used instead of an API key (``sk-ant-api...``).
+
+    Two signals, in order of preference:
+
+    1. ``data.api_key_prefix`` — an explicit field some interceptors emit.
+       Values starting with ``sk-ant-oat`` are an unambiguous OAuth hit;
+       ``sk-ant-api`` is an unambiguous API-key hit.
+    2. A raw ``Authorization: Bearer sk-ant-oat...`` substring anywhere in
+       the event payload (covers captured HTTP request dumps).
+
+    Returns ``{"using_oauth": bool, "last_seen_ts": <iso8601 or None>}``.
+
+    Safe to call even when the local store is unreachable — returns
+    ``using_oauth=False`` on any error instead of raising.
+    """
+    result = {"using_oauth": False, "last_seen_ts": None}
+
+    # Read events from *both* the daemon-proxied store (the standard install's
+    # writer) and the local-process store (tests + dev mode). Either path may
+    # legitimately be empty; if both are unreachable we return the default.
+    rows: list = []
+    try:
+        from routes.local_query import local_store_via_daemon
+        d = local_store_via_daemon("query_events", limit=int(limit))
+        if d:
+            rows.extend(d)
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        direct = local_store.get_store(read_only=True).query_events(
+            limit=int(limit)
+        )
+        if direct:
+            rows.extend(direct)
+    except Exception:
+        pass
+    if not rows:
+        return result
+
+    for ev in rows:
+        data = ev.get("data") if isinstance(ev, dict) else None
+        prefix = None
+        if isinstance(data, dict):
+            prefix = data.get("api_key_prefix") or data.get("apiKeyPrefix")
+        if isinstance(prefix, str):
+            p = prefix.strip().lower()
+            if p.startswith(_OAUTH_PREFIX):
+                result["using_oauth"] = True
+                result["last_seen_ts"] = ev.get("ts") or result["last_seen_ts"]
+                return result
+            if p.startswith(_API_KEY_PREFIX):
+                # Explicit API-key prefix — strong negative signal; keep scanning
+                # in case an earlier event used OAuth, but don't flag from this row.
+                continue
+        # Fall back to scanning the JSON-serialised payload for a bearer.
+        try:
+            blob = json.dumps(data) if data is not None else ""
+        except Exception:
+            blob = str(data)
+        if _OAUTH_BEARER_RE.search(blob):
+            result["using_oauth"] = True
+            result["last_seen_ts"] = ev.get("ts") or result["last_seen_ts"]
+            return result
+
+    return result
 
 
 @bp_overview.route("/api/channels")
@@ -584,6 +672,7 @@ def _try_local_store_overview():
         "system": system,
         "infra": infra,
         "heartbeat": _get_overview_heartbeat_cached(),
+        "client_health": _detect_anthropic_oauth(),
         "_source": "local_store",
     }
 
@@ -730,6 +819,7 @@ def api_overview():
             "system": system,
             "infra": infra,
             "heartbeat": _get_overview_heartbeat_cached(),
+            "client_health": _detect_anthropic_oauth(),
         }
     )
 

--- a/tests/test_oauth_detection.py
+++ b/tests/test_oauth_detection.py
@@ -1,0 +1,217 @@
+"""Tests for issue #556 — Anthropic OAuth detection on /api/overview.
+
+Some users authenticate against Anthropic via Claude.ai OAuth (``sk-ant-oat...``)
+rather than an API key (``sk-ant-api...``). OAuth tokens have lower rate
+limits and different pricing, so we surface a dashboard banner prompting
+migration. The backend detector scans the most recent ~50 events for two
+signals:
+
+  1. ``data.api_key_prefix`` field — explicit hint emitted by some
+     interceptors.
+  2. A raw ``Authorization: Bearer sk-ant-oat...`` substring anywhere in
+     the event payload (covers captured HTTP request dumps).
+
+This test seeds the DuckDB local store with events that trigger each path
+and asserts the ``/api/overview`` response carries ``client_health``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def overview_app(tmp_path, monkeypatch):
+    """Flask app + freshly-reloaded local_store + routes.overview blueprint."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.overview as ov
+    importlib.reload(ov)
+
+    a = Flask(__name__)
+    a.register_blueprint(ov.bp_overview)
+    yield a, ls, ov
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t: float = 2.0) -> None:
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# unit tests on the helper directly
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_detect_returns_false_when_store_empty(overview_app):
+    """No events stored → using_oauth=False, last_seen_ts=None."""
+    _a, _ls, ov = overview_app
+    result = ov._detect_anthropic_oauth()
+    assert result == {"using_oauth": False, "last_seen_ts": None}
+
+
+def test_detect_flags_oauth_bearer_in_event_payload(overview_app):
+    """Event with ``Authorization: Bearer sk-ant-oat-...`` in data → True."""
+    _a, ls, ov = overview_app
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-oat-1",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-oat",
+        "event_type": "http_request",
+        "ts": _iso(time.time()),
+        "data": {
+            "method": "POST",
+            "url": "https://api.anthropic.com/v1/messages",
+            "headers": {
+                "Authorization": "Bearer sk-ant-oat-01-abc123def456",
+                "anthropic-version": "2023-06-01",
+            },
+        },
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    result = ov._detect_anthropic_oauth()
+    assert result["using_oauth"] is True
+    assert result["last_seen_ts"]  # non-empty ISO timestamp
+
+
+def test_detect_flags_api_key_prefix_field(overview_app):
+    """Event with explicit ``data.api_key_prefix`` starting ``sk-ant-oat`` → True."""
+    _a, ls, ov = overview_app
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-prefix-1",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-prefix",
+        "event_type": "llm_call",
+        "ts": _iso(time.time()),
+        "data": {"api_key_prefix": "sk-ant-oat-01-xxxx"},
+        "model": "claude-sonnet-4-7",
+    })
+    _wait_flush(store)
+
+    result = ov._detect_anthropic_oauth()
+    assert result["using_oauth"] is True
+
+
+def test_detect_returns_false_for_api_key_events(overview_app):
+    """Events with API-key prefix (sk-ant-api) and no OAuth markers → False."""
+    _a, ls, ov = overview_app
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-api-1",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-api",
+        "event_type": "http_request",
+        "ts": _iso(time.time()),
+        "data": {
+            "headers": {"Authorization": "Bearer sk-ant-api03-abc123def456"},
+            "api_key_prefix": "sk-ant-api03",
+        },
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    result = ov._detect_anthropic_oauth()
+    assert result["using_oauth"] is False
+    assert result["last_seen_ts"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# integration: /api/overview wires client_health into its response body
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_overview_response_includes_client_health_block(overview_app):
+    """/api/overview must always include the client_health block, even when
+    the store is empty (using_oauth=False is the right default)."""
+    a, _ls, _ov = overview_app
+    # Seed a session so the fast path actually runs.
+    store = _ls.get_store()
+    store.ingest_session({
+        "session_id": "sess-shape",
+        "agent_type": "openclaw",
+        "title": "shape check",
+        "started_at": "2026-05-11T10:00:00+00:00",
+        "last_active_at": "2026-05-11T11:00:00+00:00",
+        "status": "active",
+        "total_tokens": 100,
+        "metadata": {"model": "claude-opus-4-7"},
+    })
+
+    r = a.test_client().get("/api/overview")
+    assert r.status_code == 200
+    body = r.get_json() or {}
+    assert "client_health" in body, body
+    ch = body["client_health"]
+    assert isinstance(ch, dict)
+    assert "using_oauth" in ch
+    assert "last_seen_ts" in ch
+    # No OAuth event seeded → flag stays off.
+    assert ch["using_oauth"] is False
+
+
+def test_overview_response_flags_oauth_when_event_present(overview_app):
+    """End-to-end: an OAuth event in the local store flows through the
+    overview fast path as client_health.using_oauth=True."""
+    a, ls, _ov = overview_app
+    store = ls.get_store()
+    # Seed a session so the fast path runs (it returns None on empty sessions).
+    store.ingest_session({
+        "session_id": "sess-oauth-int",
+        "agent_type": "openclaw",
+        "title": "oauth detection check",
+        "started_at": "2026-05-11T10:00:00+00:00",
+        "last_active_at": "2026-05-11T11:00:00+00:00",
+        "status": "active",
+        "total_tokens": 100,
+        "metadata": {"model": "claude-opus-4-7"},
+    })
+    store.ingest({
+        "id": "ev-oat-int",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-oauth-int",
+        "event_type": "http_request",
+        "ts": _iso(time.time()),
+        "data": {"headers": {"Authorization": "Bearer sk-ant-oat-01-xyz"}},
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    r = a.test_client().get("/api/overview")
+    body = r.get_json() or {}
+    ch = body.get("client_health") or {}
+    assert ch.get("using_oauth") is True
+    assert ch.get("last_seen_ts")


### PR DESCRIPTION
## Summary
- Detect Anthropic OAuth tokens (`sk-ant-oat...`) in the most recent ~50 events via `data.api_key_prefix` or raw `Authorization: Bearer sk-ant-oat...` strings.
- Add a `client_health: {using_oauth, last_seen_ts}` block to `/api/overview` (both fast-path and legacy code paths).
- Render a yellow dismissible banner above the dashboard when `using_oauth=true`, linking to `console.anthropic.com/settings/keys` with a "Why migrate?" CTA. Dismissal is sticky in `localStorage`.

OAuth tokens have lower rate limits and different pricing than API keys, so flagging them is a high-leverage nudge for users still on Claude.ai auth.

## Test plan
- [x] `pytest tests/test_oauth_detection.py` — 6 tests, all pass
- [x] No regressions in `tests/test_overview_local_store.py` (pre-existing daemon-bleed failures unrelated to this PR)
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` clean
- [x] `node --check clawmetry/static/js/app.js` clean
- [ ] Manual: visit dashboard with an OAuth-emitting agent — banner renders; click Dismiss; refresh; stays hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)