### PR TITLE
feat(workspace): multi-profile discovery + dashboard switcher (closes #950)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -11259,7 +11259,112 @@ document.addEventListener('DOMContentLoaded', function() {
   initOverviewCompClickHandlers();
   initFlow();
   bootDashboard();
+  // Issue #950: multi-profile workspace switcher
+  try { initWorkspaceSwitcher(); } catch (e) { /* non-fatal */ }
 });
+
+// ── Workspace switcher (issue #950) ───────────────────────────────────
+// Discovers all OpenClaw workspaces on this machine and lets power users
+// flip the dashboard between them. Hidden entirely when only one
+// workspace is found, so the zero-config single-workspace UX is unchanged.
+var _wsList = [];
+var _wsActive = null;
+
+async function initWorkspaceSwitcher() {
+  try {
+    var resp = await fetch('/api/workspaces', { credentials: 'same-origin' });
+    if (!resp.ok) return;
+    var data = await resp.json();
+    _wsList = (data && data.workspaces) || [];
+    _wsActive = data && data.active;
+  } catch (e) {
+    return;
+  }
+  renderWorkspaceSwitcher();
+  // Dismiss menu when clicking outside.
+  document.addEventListener('click', function(ev) {
+    var menu = document.getElementById('workspace-switcher-menu');
+    var btn = document.getElementById('workspace-switcher-btn');
+    if (!menu || menu.style.display === 'none') return;
+    if (menu.contains(ev.target) || (btn && btn.contains(ev.target))) return;
+    menu.style.display = 'none';
+  });
+}
+
+function renderWorkspaceSwitcher() {
+  var wrap = document.getElementById('workspace-switcher');
+  if (!wrap) return;
+  if (!_wsList || _wsList.length <= 1) {
+    wrap.style.display = 'none';
+    return;
+  }
+  wrap.style.display = 'inline-block';
+  var label = document.getElementById('workspace-switcher-label');
+  var activeEntry = _wsList.find(function(w) { return w.path === _wsActive; });
+  if (label) label.textContent = (activeEntry && activeEntry.name) || 'default';
+  var menu = document.getElementById('workspace-switcher-menu');
+  if (!menu) return;
+  menu.innerHTML = '';
+  _wsList.forEach(function(w) {
+    var item = document.createElement('div');
+    var isActive = w.path === _wsActive;
+    item.style.cssText = 'padding:8px 10px;border-radius:6px;cursor:pointer;font-size:12px;display:flex;flex-direction:column;gap:2px;' +
+      (isActive ? 'background:rgba(229,68,58,0.12);' : '');
+    item.onmouseover = function() { if (!isActive) item.style.background = 'rgba(255,255,255,0.06)'; };
+    item.onmouseout = function() { if (!isActive) item.style.background = 'transparent'; };
+    item.onclick = function() { selectWorkspace(w); };
+    var name = document.createElement('div');
+    name.style.cssText = 'font-weight:600;color:var(--text-primary,#fff);';
+    name.textContent = (isActive ? '• ' : '') + (w.name || 'workspace');
+    var path = document.createElement('div');
+    path.style.cssText = 'font-size:10px;color:var(--text-muted,#888);font-family:ui-monospace,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
+    path.title = w.path;
+    path.textContent = w.path;
+    var meta = document.createElement('div');
+    meta.style.cssText = 'font-size:10px;color:var(--text-muted,#888);';
+    var agents = (typeof w.agent_count === 'number') ? w.agent_count : 0;
+    meta.textContent = agents + (agents === 1 ? ' agent' : ' agents');
+    item.appendChild(name);
+    item.appendChild(path);
+    item.appendChild(meta);
+    menu.appendChild(item);
+  });
+}
+
+function toggleWorkspaceSwitcher(ev) {
+  if (ev) ev.stopPropagation();
+  var menu = document.getElementById('workspace-switcher-menu');
+  if (!menu) return;
+  menu.style.display = (menu.style.display === 'none' || !menu.style.display) ? 'block' : 'none';
+}
+
+async function selectWorkspace(w) {
+  if (!w || !w.path || w.path === _wsActive) {
+    var menu = document.getElementById('workspace-switcher-menu');
+    if (menu) menu.style.display = 'none';
+    return;
+  }
+  try {
+    var resp = await fetch('/api/workspaces/active', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: w.name, path: w.path })
+    });
+    if (!resp.ok) {
+      console.warn('workspace switch failed', resp.status);
+      return;
+    }
+    _wsActive = w.path;
+    renderWorkspaceSwitcher();
+    var menu = document.getElementById('workspace-switcher-menu');
+    if (menu) menu.style.display = 'none';
+    // Cleanest reload — every cached tab re-fetches against the new workspace.
+    window.location.reload();
+  } catch (e) {
+    console.warn('workspace switch error', e);
+  }
+}
 
 // ── History Tab ──────────────────────────────────────────────────────
 var _historyRange = 3600; // seconds

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -975,6 +975,176 @@ def detect_paths() -> dict:
     return {"sessions_dir": sessions_dir, "log_dir": log_dir, "workspace": workspace}
 
 
+def discover_workspaces(home: Path | None = None) -> list[dict]:
+    """Discover all OpenClaw workspace profiles on this machine.
+
+    Power users sometimes keep multiple OpenClaw workspaces (work / personal /
+    experiments). Today ClawMetry auto-detects a single ``~/.openclaw`` dir;
+    this helper scans for the common multi-profile patterns so the dashboard
+    can offer a switcher.
+
+    Discovery paths (all safe, no symlink-following, read-only):
+      1. ``~/.openclaw`` — the canonical single-workspace location.
+      2. ``~/.openclaw-*`` — suffix-style profiles (e.g. ``~/.openclaw-work``).
+      3. ``~/.openclaw/profiles/<name>`` — explicit profiles convention.
+      4. ``~/.clawmetry/workspaces.json`` — user-curated list (highest trust).
+
+    A path is treated as a workspace when it contains an ``agents/`` or
+    ``workspace/`` subdir or one of the conventional context files
+    (``SOUL.md`` / ``AGENTS.md`` / ``MEMORY.md``). The check tolerates
+    ``PermissionError`` and never crashes.
+
+    Returns a list of ``{name, path, agent_count, last_active_ts}`` dicts,
+    sorted by ``last_active_ts`` desc. The single-workspace zero-config
+    case still works — it just returns a one-element list.
+    """
+    home = home or Path.home()
+    discovered: dict[str, dict] = {}  # path -> entry (de-dup by abs path)
+
+    def _is_workspace_like(p: Path) -> bool:
+        try:
+            if not p.is_dir() or p.is_symlink():
+                return False
+            # Strong signal: agents/ subdir (OpenClaw's standard layout)
+            if (p / "agents").is_dir():
+                return True
+            if (p / "workspace").is_dir():
+                return True
+            for marker in ("SOUL.md", "AGENTS.md", "MEMORY.md"):
+                if (p / marker).exists():
+                    return True
+        except (PermissionError, OSError):
+            return False
+        return False
+
+    def _agent_count(p: Path) -> int:
+        try:
+            agents_dir = p / "agents"
+            if not agents_dir.is_dir():
+                return 0
+            return sum(
+                1
+                for child in agents_dir.iterdir()
+                if child.is_dir() and not child.is_symlink()
+            )
+        except (PermissionError, OSError):
+            return 0
+
+    def _last_active(p: Path) -> float:
+        """Most-recent mtime across sessions/logs as a rough activity timestamp."""
+        latest = 0.0
+        try:
+            sessions = p / "agents" / "main" / "sessions"
+            if sessions.is_dir():
+                for f in sessions.iterdir():
+                    if f.is_symlink():
+                        continue
+                    try:
+                        m = f.stat().st_mtime
+                        if m > latest:
+                            latest = m
+                    except (PermissionError, OSError):
+                        continue
+            # Fallback: dir mtime
+            if latest == 0.0:
+                latest = p.stat().st_mtime
+        except (PermissionError, OSError):
+            pass
+        return latest
+
+    def _add(name: str, path: Path) -> None:
+        try:
+            abs_path = path.resolve(strict=False)
+        except (OSError, RuntimeError):
+            abs_path = path
+        key = str(abs_path)
+        if key in discovered:
+            return
+        if not _is_workspace_like(path):
+            return
+        discovered[key] = {
+            "name": name,
+            "path": key,
+            "agent_count": _agent_count(path),
+            "last_active_ts": _last_active(path),
+        }
+
+    # 1. Canonical ~/.openclaw
+    default = home / ".openclaw"
+    _add("default", default)
+
+    # 2. Suffix-style profiles: ~/.openclaw-<name>
+    try:
+        for entry in home.iterdir():
+            try:
+                if entry.is_symlink() or not entry.is_dir():
+                    continue
+            except (PermissionError, OSError):
+                continue
+            name = entry.name
+            if not name.startswith(".openclaw-"):
+                continue
+            profile = name[len(".openclaw-"):]
+            if profile:
+                _add(profile, entry)
+    except (PermissionError, OSError, FileNotFoundError):
+        pass
+
+    # 3. ~/.openclaw/profiles/<name> convention
+    profiles_dir = default / "profiles"
+    try:
+        if profiles_dir.is_dir() and not profiles_dir.is_symlink():
+            for entry in profiles_dir.iterdir():
+                try:
+                    if entry.is_symlink() or not entry.is_dir():
+                        continue
+                except (PermissionError, OSError):
+                    continue
+                _add(entry.name, entry)
+    except (PermissionError, OSError):
+        pass
+
+    # 4. User-curated ~/.clawmetry/workspaces.json
+    cfg_path = home / ".clawmetry" / "workspaces.json"
+    try:
+        if cfg_path.is_file() and not cfg_path.is_symlink():
+            with open(cfg_path) as f:
+                cfg = json.load(f)
+            entries = cfg.get("workspaces") if isinstance(cfg, dict) else cfg
+            if isinstance(entries, list):
+                for item in entries:
+                    if not isinstance(item, dict):
+                        continue
+                    raw_path = item.get("path")
+                    name = item.get("name") or ""
+                    if not raw_path or not isinstance(raw_path, str):
+                        continue
+                    p = Path(os.path.expanduser(raw_path))
+                    # Stay within the user's home dir as a safety boundary
+                    # (don't follow paths outside ~ that the JSON might point at).
+                    try:
+                        rp = p.resolve(strict=False)
+                    except (OSError, RuntimeError):
+                        continue
+                    try:
+                        rp.relative_to(home.resolve(strict=False))
+                    except ValueError:
+                        # Allow explicit absolute paths outside home only when
+                        # they exist & are not symlinks — power-user override.
+                        if p.is_symlink():
+                            continue
+                    _add(name or p.name or "workspace", p)
+    except (PermissionError, OSError, json.JSONDecodeError, ValueError):
+        pass
+
+    out = sorted(
+        discovered.values(),
+        key=lambda d: d.get("last_active_ts", 0.0),
+        reverse=True,
+    )
+    return out
+
+
 # ── Sync: session events (full content, encrypted) ────────────────────────────
 
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -114,6 +114,7 @@ from routes.reasoning import bp_reasoning
 from routes.plugins import bp_plugins
 from routes.local_query import bp_local_query
 from routes.update_check import bp_update_check, start_update_check_thread
+from routes.workspaces import bp_workspaces
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -3296,6 +3297,14 @@ function clawmetryLogout(){
 <div class="nav">
   <h1><a href="https://clawmetry.com" style="display:flex;align-items:center;gap:7px;text-decoration:none;color:inherit"><img src="/static/img/logo.svg" width="22" height="22" style="border-radius:4px;vertical-align:middle;flex-shrink:0" alt="ClawMetry"><span><span style="color:#ffffff">Claw</span><span style="color:#E5443A">Metry</span></span></a></h1>
   <span id="version-badge" class="version-badge" title="ClawMetry version">v{{ version }}</span>
+  <div id="workspace-switcher" style="display:none;position:relative;margin-left:8px;">
+    <button id="workspace-switcher-btn" onclick="toggleWorkspaceSwitcher(event)" title="Switch OpenClaw workspace" style="background:transparent;color:inherit;border:1px solid rgba(255,255,255,0.15);border-radius:6px;padding:4px 10px;font-size:12px;font-weight:600;cursor:pointer;display:flex;align-items:center;gap:6px;">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+      <span id="workspace-switcher-label">default</span>
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+    </button>
+    <div id="workspace-switcher-menu" style="display:none;position:absolute;top:calc(100% + 6px);left:0;min-width:240px;max-height:320px;overflow-y:auto;background:var(--bg-card,#1c2333);border:1px solid var(--border-color,rgba(255,255,255,0.1));border-radius:8px;box-shadow:0 6px 18px rgba(0,0,0,0.35);z-index:200;padding:4px;"></div>
+  </div>
   <div class="theme-toggle" onclick="var o=document.getElementById('gw-setup-overlay');o.dataset.mandatory='false';document.getElementById('gw-setup-close').style.display='';o.style.display='flex'" title="Gateway settings" style="cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></div>
   <div class="theme-toggle" id="alerts-bell-btn" onclick="switchTab('alerts')" title="Active alerts" style="cursor:pointer;position:relative;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg><span id="alerts-bell-badge" style="display:none;position:absolute;top:-4px;right:-4px;background:#ef4444;color:#fff;border-radius:10px;padding:0 4px;font-size:9px;font-weight:700;min-width:14px;line-height:14px;text-align:center;">0</span></div>
 
@@ -8716,6 +8725,7 @@ def detect_config(args=None):
     _adapter_registry.register(OpenClawAdapter())
     app.register_blueprint(bp_openapi)
     app.register_blueprint(bp_update_check)
+    app.register_blueprint(bp_workspaces)
 
     # Register built-in agent adapters. External plugins can register more
     # via clawmetry.extensions entry points — see clawmetry/adapters/.
@@ -8983,6 +8993,14 @@ DASHBOARD_HTML = r"""
 <div class="nav">
   <h1><a href="https://clawmetry.com" style="display:flex;align-items:center;gap:7px;text-decoration:none;color:inherit"><img src="/static/img/logo.svg" width="22" height="22" style="border-radius:4px;vertical-align:middle;flex-shrink:0" alt="ClawMetry"><span><span style="color:#ffffff">Claw</span><span style="color:#E5443A">Metry</span></span></a></h1>
   <span id="version-badge" class="version-badge" title="ClawMetry version">v{{ version }}</span>
+  <div id="workspace-switcher" style="display:none;position:relative;margin-left:8px;">
+    <button id="workspace-switcher-btn" onclick="toggleWorkspaceSwitcher(event)" title="Switch OpenClaw workspace" style="background:transparent;color:inherit;border:1px solid rgba(255,255,255,0.15);border-radius:6px;padding:4px 10px;font-size:12px;font-weight:600;cursor:pointer;display:flex;align-items:center;gap:6px;">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+      <span id="workspace-switcher-label">default</span>
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+    </button>
+    <div id="workspace-switcher-menu" style="display:none;position:absolute;top:calc(100% + 6px);left:0;min-width:240px;max-height:320px;overflow-y:auto;background:var(--bg-card,#1c2333);border:1px solid var(--border-color,rgba(255,255,255,0.1));border-radius:8px;box-shadow:0 6px 18px rgba(0,0,0,0.35);z-index:200;padding:4px;"></div>
+  </div>
   <div class="theme-toggle" onclick="var o=document.getElementById('gw-setup-overlay');o.dataset.mandatory='false';document.getElementById('gw-setup-close').style.display='';o.style.display='flex'" title="Gateway settings" style="cursor:pointer;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></div>
   <div class="theme-toggle" id="alerts-bell-btn" onclick="switchTab('alerts')" title="Active alerts" style="cursor:pointer;position:relative;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg><span id="alerts-bell-badge" style="display:none;position:absolute;top:-4px;right:-4px;background:#ef4444;color:#fff;border-radius:10px;padding:0 4px;font-size:9px;font-weight:700;min-width:14px;line-height:14px;text-align:center;">0</span></div>
 

--- a/routes/workspaces.py
+++ b/routes/workspaces.py
@@ -1,0 +1,189 @@
+"""
+routes/workspaces.py — Multi-profile OpenClaw workspace discovery + switcher.
+
+Issue #950: power users keep multiple OpenClaw workspaces (work / personal /
+experiments). This module exposes two endpoints:
+
+  GET  /api/workspaces          — list discovered workspaces.
+  POST /api/workspaces/active   — body {"name": str | "path": str}, switch
+                                  the active workspace for this dashboard
+                                  process. Mutates ``dashboard.WORKSPACE`` /
+                                  ``SESSIONS_DIR`` / ``MEMORY_DIR`` / ``LOG_DIR``
+                                  and re-initialises the DataProvider.
+
+Discovery scans only paths under ``$HOME`` (or an explicit JSON-listed path),
+does not follow symlinks, and never reads file contents outside the
+``~/.clawmetry/workspaces.json`` config file.
+
+Zero-config remains intact: when there is only one ``~/.openclaw``, the
+endpoint just returns a one-element list and the UI shows no dropdown.
+"""
+
+import os
+import json
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request
+
+bp_workspaces = Blueprint("workspaces", __name__)
+
+
+def _list_workspaces():
+    """Wrap clawmetry.sync.discover_workspaces with graceful fallback."""
+    try:
+        from clawmetry.sync import discover_workspaces
+
+        return discover_workspaces()
+    except Exception:
+        # Never crash on bad input — fall back to whatever dashboard already has.
+        try:
+            import dashboard as _d
+
+            ws = getattr(_d, "WORKSPACE", None)
+            if ws and os.path.isdir(ws):
+                return [
+                    {
+                        "name": "default",
+                        "path": ws,
+                        "agent_count": 0,
+                        "last_active_ts": 0.0,
+                    }
+                ]
+        except Exception:
+            pass
+        return []
+
+
+@bp_workspaces.route("/api/workspaces")
+def api_workspaces():
+    """List all discovered OpenClaw workspace profiles.
+
+    Response: ``{"workspaces": [{name, path, agent_count, last_active_ts}],
+                 "active": "<path or null>"}``
+    """
+    import dashboard as _d
+
+    workspaces = _list_workspaces()
+    active = getattr(_d, "WORKSPACE", None)
+    try:
+        active_abs = str(Path(active).resolve(strict=False)) if active else None
+    except (OSError, RuntimeError):
+        active_abs = active
+    return jsonify({"workspaces": workspaces, "active": active_abs})
+
+
+def _persist_active(path: str) -> None:
+    """Best-effort write of the chosen workspace to ~/.clawmetry/last_workspace.
+
+    Survives dashboard restarts but failures are non-fatal (read-only FS, etc.)
+    — the in-process switch still takes effect for this session.
+    """
+    try:
+        cfg_dir = Path(os.path.expanduser("~/.clawmetry"))
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / "last_workspace").write_text(path + "\n")
+    except (PermissionError, OSError):
+        pass
+
+
+@bp_workspaces.route("/api/workspaces/active", methods=["POST"])
+def api_workspaces_set_active():
+    """Switch the active workspace for the running dashboard.
+
+    Body: ``{"name": "<profile-name>"}`` or ``{"path": "/abs/path"}``.
+    """
+    import dashboard as _d
+
+    body = request.get_json(silent=True) or {}
+    name = (body.get("name") or "").strip()
+    path_arg = (body.get("path") or "").strip()
+
+    workspaces = _list_workspaces()
+    target = None
+    if path_arg:
+        try:
+            wanted = str(Path(os.path.expanduser(path_arg)).resolve(strict=False))
+        except (OSError, RuntimeError):
+            wanted = path_arg
+        for w in workspaces:
+            if w.get("path") == wanted:
+                target = w
+                break
+    if target is None and name:
+        for w in workspaces:
+            if w.get("name") == name:
+                target = w
+                break
+    if target is None:
+        return (
+            jsonify(
+                {
+                    "error": "workspace not found",
+                    "hint": "POST {name} or {path} matching /api/workspaces",
+                }
+            ),
+            404,
+        )
+
+    new_ws = target["path"]
+    if not os.path.isdir(new_ws):
+        return jsonify({"error": "workspace path no longer exists"}), 410
+
+    # Pick best matching sub-paths inside this workspace.
+    sessions_candidates = [
+        os.path.join(new_ws, "agents", "main", "sessions"),
+        os.path.join(new_ws, "sessions"),
+    ]
+    # Also scan agents/* for the first one with a sessions/ dir.
+    agents_base = os.path.join(new_ws, "agents")
+    if os.path.isdir(agents_base):
+        try:
+            for agent in sorted(os.listdir(agents_base)):
+                sd = os.path.join(agents_base, agent, "sessions")
+                if sd not in sessions_candidates:
+                    sessions_candidates.append(sd)
+        except OSError:
+            pass
+    sessions_dir = next(
+        (d for d in sessions_candidates if os.path.isdir(d)),
+        sessions_candidates[0],
+    )
+
+    log_candidates = [
+        os.path.join(new_ws, "logs"),
+        os.path.join(new_ws, "log"),
+    ]
+    log_dir = next(
+        (d for d in log_candidates if os.path.isdir(d)),
+        getattr(_d, "LOG_DIR", log_candidates[0]),
+    )
+
+    memory_dir = os.path.join(new_ws, "memory")
+
+    # Mutate module globals so all late `import dashboard as _d` helpers see
+    # the new values. Read-only routes pick this up on the next request.
+    _d.WORKSPACE = new_ws
+    _d.SESSIONS_DIR = sessions_dir
+    _d.MEMORY_DIR = memory_dir
+    _d.LOG_DIR = log_dir
+
+    # Re-init the data provider so DuckDB / LocalDataProvider sees the new dir.
+    init_fn = getattr(_d, "_init_data_provider", None)
+    if callable(init_fn):
+        try:
+            init_fn()
+        except Exception:
+            pass
+
+    _persist_active(new_ws)
+
+    return jsonify(
+        {
+            "ok": True,
+            "active": new_ws,
+            "name": target.get("name"),
+            "sessions_dir": sessions_dir,
+            "memory_dir": memory_dir,
+            "log_dir": log_dir,
+        }
+    )

--- a/tests/test_multi_workspace_discovery.py
+++ b/tests/test_multi_workspace_discovery.py
@@ -1,0 +1,135 @@
+"""
+Tests for multi-profile OpenClaw workspace discovery (issue #950).
+
+Builds a tmpdir as a fake $HOME containing three workspaces in the patterns
+clawmetry should detect:
+
+  - $HOME/.openclaw                  (canonical default)
+  - $HOME/.openclaw-personal         (suffix-style profile)
+  - $HOME/.openclaw/profiles/exp     (profiles/ convention)
+
+Plus negative cases (symlink, non-workspace dir) to confirm safety.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from clawmetry.sync import discover_workspaces
+
+
+def _make_ws(path: Path, agents=("main",)) -> None:
+    """Create a directory that looks like a real OpenClaw workspace."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SOUL.md").write_text("# fake workspace\n")
+    for agent in agents:
+        sd = path / "agents" / agent / "sessions"
+        sd.mkdir(parents=True, exist_ok=True)
+        # touch a session file so last_active_ts is non-zero
+        (sd / "fake.jsonl").write_text("{}\n")
+
+
+@pytest.fixture
+def fake_home(tmp_path):
+    """Yield a tmpdir we can treat as $HOME."""
+    return tmp_path
+
+
+def test_discover_three_workspace_patterns(fake_home):
+    _make_ws(fake_home / ".openclaw")
+    _make_ws(fake_home / ".openclaw-personal")
+    _make_ws(fake_home / ".openclaw" / "profiles" / "exp")
+
+    found = discover_workspaces(home=fake_home)
+    names = {w["name"] for w in found}
+    paths = {w["path"] for w in found}
+
+    assert len(found) >= 3, f"expected 3 workspaces, got {found}"
+    assert "default" in names
+    assert "personal" in names
+    assert "exp" in names
+    assert str((fake_home / ".openclaw").resolve()) in paths
+    assert str((fake_home / ".openclaw-personal").resolve()) in paths
+    assert str((fake_home / ".openclaw" / "profiles" / "exp").resolve()) in paths
+
+
+def test_single_workspace_zero_config(fake_home):
+    """Zero-config: one workspace must still be detected."""
+    _make_ws(fake_home / ".openclaw")
+    found = discover_workspaces(home=fake_home)
+    assert len(found) == 1
+    assert found[0]["name"] == "default"
+
+
+def test_no_workspaces_returns_empty(fake_home):
+    """No openclaw dirs anywhere — empty list, no crash."""
+    found = discover_workspaces(home=fake_home)
+    assert found == []
+
+
+def test_ignores_symlinks(fake_home):
+    """Symlinked profile dirs should be skipped (security guard)."""
+    real = fake_home / "elsewhere"
+    _make_ws(real)
+    link = fake_home / ".openclaw-evil"
+    try:
+        os.symlink(str(real), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+    found = discover_workspaces(home=fake_home)
+    names = {w["name"] for w in found}
+    assert "evil" not in names
+
+
+def test_ignores_random_dotdir(fake_home):
+    """A random dir without OpenClaw markers shouldn't be claimed."""
+    (fake_home / ".openclaw-junk").mkdir()
+    (fake_home / ".openclaw-junk" / "README").write_text("not a workspace")
+    found = discover_workspaces(home=fake_home)
+    names = {w["name"] for w in found}
+    assert "junk" not in names
+
+
+def test_curated_workspaces_json(fake_home):
+    """~/.clawmetry/workspaces.json adds user-curated entries."""
+    custom = fake_home / "my-bot"
+    _make_ws(custom, agents=("main", "research"))
+    cfg_dir = fake_home / ".clawmetry"
+    cfg_dir.mkdir()
+    (cfg_dir / "workspaces.json").write_text(
+        json.dumps({"workspaces": [{"name": "bot", "path": str(custom)}]})
+    )
+    found = discover_workspaces(home=fake_home)
+    names = {w["name"] for w in found}
+    assert "bot" in names
+    bot = next(w for w in found if w["name"] == "bot")
+    assert bot["agent_count"] == 2
+
+
+def test_agent_count_and_last_active(fake_home):
+    """Workspace metadata reports agent count + a non-zero activity ts."""
+    ws = fake_home / ".openclaw"
+    _make_ws(ws, agents=("main", "scheduler"))
+    found = discover_workspaces(home=fake_home)
+    assert len(found) == 1
+    entry = found[0]
+    assert entry["agent_count"] == 2
+    assert entry["last_active_ts"] > 0
+
+
+def test_sorted_by_last_active_desc(fake_home, monkeypatch):
+    """Most-recently-active workspace surfaces first."""
+    old = fake_home / ".openclaw-old"
+    new = fake_home / ".openclaw"
+    _make_ws(old)
+    _make_ws(new)
+    # Backdate the old workspace's session file by 1 day.
+    stale_file = old / "agents" / "main" / "sessions" / "fake.jsonl"
+    backdated = stale_file.stat().st_mtime - 86400
+    os.utime(stale_file, (backdated, backdated))
+    found = discover_workspaces(home=fake_home)
+    assert found[0]["name"] == "default"  # ~/.openclaw (newest)


### PR DESCRIPTION
## Summary
- Discover all OpenClaw workspaces on disk — `~/.openclaw`, `~/.openclaw-<name>`, `~/.openclaw/profiles/<name>`, and a user-curated `~/.clawmetry/workspaces.json` — via a new `clawmetry.sync.discover_workspaces()` helper. Safe by design: no symlink-following, paths confined to `$HOME` unless explicitly listed, `PermissionError`-tolerant.
- New endpoints `GET /api/workspaces` and `POST /api/workspaces/active` (in `routes/workspaces.py`). Active-set rebinds `WORKSPACE` / `SESSIONS_DIR` / `MEMORY_DIR` / `LOG_DIR` in `dashboard` and re-inits the DataProvider so subsequent requests read from the new workspace.
- Nav-bar dropdown (top-left, next to version badge). Hidden when only one workspace exists, so zero-config single-workspace UX is unchanged.

## Test plan
- [x] `pytest tests/test_multi_workspace_discovery.py` — 8/8 pass (3-profile case, single-workspace fallback, empty home, symlink rejection, junk-dir guard, curated JSON, agent_count + last_active_ts, sort-by-activity).
- [x] Flask test client smoke: `GET /api/workspaces` → 200, `POST /api/workspaces/active` with bad name → 404.
- [x] `tests/test_circular_import.py` still passes (no import regressions).
- [ ] Manual: spin up a tmpdir with 2 fake workspaces, point dashboard at it, confirm dropdown appears and a click reloads against the other workspace.

Closes #950.

Generated with Claude Code (Opus 4.7, 1M ctx).