### PR TITLE
feat(flow): historical flow-runs dashboard (closes #611)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -44,6 +44,7 @@ import threading
 import time
 from collections import deque
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable, Iterator
 
@@ -1388,6 +1389,90 @@ class LocalStore:
         cols = ["session_id", "channel", "chat_type", "subject", "origin_label"]
         return [_row_to_dict(r, cols) for r in self._fetch(sql, params)]
 
+    def query_flow_runs(
+        self,
+        *,
+        agent_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Aggregate historical flow runs from the ``events`` table.
+
+        A "flow run" is one session's worth of events. For each session we
+        compute the start time, total duration, distinct models invoked,
+        tool-call count, total cost, and a left-joined channel from the
+        ``openclaw_channels`` per-session metadata table.
+
+        Status is heuristic: any event with ``event_type LIKE '%error%'``
+        flips the run to ``failed``; otherwise ``completed``. We don't try
+        to detect "in-progress" here — the live Flow view is the source of
+        truth for that.
+
+        Ordered most-recent first (by ``MAX(ts)``). Issue #611.
+        """
+        clauses: list[str] = ["e.session_id IS NOT NULL"]
+        params: list[Any] = []
+        if agent_id:
+            clauses.append("e.agent_id = ?")
+            params.append(agent_id)
+        if since:
+            clauses.append("e.ts >= ?")
+            params.append(since)
+        if until:
+            clauses.append("e.ts <= ?")
+            params.append(until)
+        where = "WHERE " + " AND ".join(clauses)
+        sql = f"""
+            SELECT
+              e.session_id                              AS session_id,
+              MIN(e.agent_id)                           AS agent_id,
+              MIN(e.ts)                                 AS started_at,
+              MAX(e.ts)                                 AS updated_at,
+              COUNT(*)                                  AS event_count,
+              COUNT(DISTINCT e.model)
+                  FILTER (WHERE e.model IS NOT NULL)    AS models_invoked,
+              LIST(DISTINCT e.model)
+                  FILTER (WHERE e.model IS NOT NULL)    AS model_list,
+              COUNT(*) FILTER (WHERE
+                  e.event_type IN ('tool_call', 'toolCall', 'tool_use'))
+                                                        AS tools_called,
+              COALESCE(SUM(e.cost_usd), 0)              AS total_cost,
+              COALESCE(SUM(e.token_count), 0)           AS token_count,
+              MAX(CASE WHEN LOWER(e.event_type) LIKE '%error%'
+                       THEN 1 ELSE 0 END)               AS has_error,
+              MIN(c.channel)                            AS channel
+            FROM events e
+            LEFT JOIN openclaw_channels c
+              ON c.session_id = e.session_id
+            {where}
+            GROUP BY e.session_id
+            ORDER BY updated_at DESC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = [
+            "session_id", "agent_id", "started_at", "updated_at",
+            "event_count", "models_invoked", "model_list", "tools_called",
+            "total_cost", "token_count", "has_error", "channel",
+        ]
+        out: list[dict[str, Any]] = []
+        for r in self._fetch(sql, params):
+            row = dict(zip(cols, r))
+            started = row.get("started_at") or ""
+            ended = row.get("updated_at") or ""
+            row["duration_seconds"] = _duration_seconds(started, ended)
+            row["status"] = "failed" if row.pop("has_error", 0) else "completed"
+            ml = row.pop("model_list", None) or []
+            # DuckDB LIST returns a Python list already; coerce just in case.
+            try:
+                row["models"] = [str(m) for m in ml if m]
+            except TypeError:
+                row["models"] = []
+            row["channels_touched"] = 1 if row.get("channel") else 0
+            out.append(row)
+        return out
+
     def query_channel_messages(
         self,
         *,
@@ -2521,6 +2606,29 @@ def _row_to_event(row: tuple, cols: list[str]) -> dict[str, Any]:
 def _row_to_dict(row: tuple, cols: list[str]) -> dict[str, Any]:
     """Generic tuple-to-dict for non-event rows (sessions, aggregates)."""
     return dict(zip(cols, row))
+
+
+def _duration_seconds(start_iso: str, end_iso: str) -> float:
+    """Best-effort ISO-timestamp diff in seconds. Returns 0.0 on parse fail.
+
+    Events arrive from multiple sources with slightly different ISO formats
+    (``Z`` suffix vs ``+00:00`` vs naive). We normalise the common cases
+    and never raise — flow-runs read paths must stay permissive."""
+    if not start_iso or not end_iso:
+        return 0.0
+    def _parse(s: str):
+        try:
+            s2 = s.replace("Z", "+00:00") if s.endswith("Z") else s
+            return datetime.fromisoformat(s2)
+        except (TypeError, ValueError):
+            return None
+    a, b = _parse(start_iso), _parse(end_iso)
+    if a is None or b is None:
+        return 0.0
+    try:
+        return max(0.0, (b - a).total_seconds())
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def _decode_data_blob_rows(rows: Iterable[tuple], cols: list[str]) -> list[dict[str, Any]]:

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7365,10 +7365,150 @@ function _startFlowSse() {
   _flowSse.onerror = function() { setTimeout(_startFlowSse, 5000); };
 }
 
+// ── Flow sub-tabs (Live | Runs) — issue #611 ────────────────────────────
+function switchFlowSubtab(name) {
+  var live = document.getElementById('flow-live-pane');
+  var runs = document.getElementById('flow-runs-pane');
+  if (!live || !runs) return;
+  if (name === 'runs') {
+    live.style.display = 'none';
+    runs.style.display = 'block';
+    loadFlowRuns();
+  } else {
+    live.style.display = '';
+    runs.style.display = 'none';
+  }
+  var tabs = document.querySelectorAll('#flow-subtabs .flow-subtab');
+  for (var i = 0; i < tabs.length; i++) {
+    var active = tabs[i].getAttribute('data-sub') === name;
+    tabs[i].classList.toggle('active', active);
+    tabs[i].style.borderBottom = active
+      ? '2px solid var(--accent-primary,#3b82f6)'
+      : '2px solid transparent';
+    tabs[i].style.color = active
+      ? 'var(--text-primary)'
+      : 'var(--text-muted)';
+  }
+}
+
+function _fmtRunDuration(secs) {
+  var s = Number(secs) || 0;
+  if (s < 1) return '<1s';
+  if (s < 60) return s.toFixed(0) + 's';
+  if (s < 3600) return (s / 60).toFixed(1) + 'm';
+  return (s / 3600).toFixed(1) + 'h';
+}
+
+function _fmtRunCost(c) {
+  var n = Number(c) || 0;
+  if (n === 0) return '$0';
+  if (n < 0.01) return '<$0.01';
+  return '$' + n.toFixed(2);
+}
+
+function _fmtRunStarted(iso) {
+  if (!iso) return '—';
+  try {
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return iso;
+    return d.toLocaleString();
+  } catch (e) { return iso; }
+}
+
+function loadFlowRuns() {
+  var sel = document.getElementById('flow-runs-limit');
+  var tbody = document.getElementById('flow-runs-tbody');
+  var countEl = document.getElementById('flow-runs-count');
+  if (!tbody) return;
+  var lim = sel ? parseInt(sel.value, 10) || 30 : 30;
+  tbody.innerHTML = '<tr><td colspan="8" style="padding:24px;text-align:center;color:var(--text-muted);font-size:12px;">Loading flow runs&hellip;</td></tr>';
+  fetch('/api/flow/runs?limit=' + lim)
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      var runs = (d && d.runs) || [];
+      if (countEl) countEl.textContent = runs.length + ' run' + (runs.length === 1 ? '' : 's');
+      if (!runs.length) {
+        tbody.innerHTML = '<tr><td colspan="8" style="padding:24px;text-align:center;color:var(--text-muted);font-size:12px;">No historical flow runs yet — the live Flow view will populate this once a session completes.</td></tr>';
+        return;
+      }
+      var rows = runs.map(function(r) {
+        var sid = String(r.session_id || '');
+        var sidShort = sid.length > 12 ? sid.slice(0, 8) + '…' : sid;
+        var models = (r.models || []).join(', ') || (r.models_invoked || 0);
+        var status = r.status || 'completed';
+        var statusColor = status === 'failed' ? '#ef4444' : '#22c55e';
+        var ch = r.channel || '—';
+        return ''
+          + '<tr style="border-top:1px solid var(--border-secondary,#2a2a4a);cursor:pointer;" '
+          +     'onclick="showFlowRunDetail(' + JSON.stringify(sid).replace(/"/g, '&quot;') + ')" '
+          +     'onmouseover="this.style.background=\'var(--bg-tertiary,#0d0d1f)\'" '
+          +     'onmouseout="this.style.background=\'\'">'
+          + '<td style="padding:8px 14px;font-family:monospace;color:var(--text-primary);">' + sidShort + '</td>'
+          + '<td style="padding:8px 14px;color:var(--text-muted);">' + _fmtRunStarted(r.started_at) + '</td>'
+          + '<td style="padding:8px 14px;text-align:right;color:var(--text-muted);">' + _fmtRunDuration(r.duration_seconds) + '</td>'
+          + '<td style="padding:8px 14px;color:var(--text-muted);">' + ch + '</td>'
+          + '<td style="padding:8px 14px;text-align:right;color:var(--text-primary);" title="' + models + '">' + (r.models_invoked || 0) + '</td>'
+          + '<td style="padding:8px 14px;text-align:right;color:var(--text-primary);">' + (r.tools_called || 0) + '</td>'
+          + '<td style="padding:8px 14px;text-align:right;color:var(--text-primary);">' + _fmtRunCost(r.total_cost) + '</td>'
+          + '<td style="padding:8px 14px;"><span style="color:' + statusColor + ';font-weight:600;">' + status + '</span></td>'
+          + '</tr>';
+      }).join('');
+      tbody.innerHTML = rows;
+    })
+    .catch(function() {
+      tbody.innerHTML = '<tr><td colspan="8" style="padding:24px;text-align:center;color:#ef4444;font-size:12px;">Failed to load flow runs.</td></tr>';
+    });
+}
+
+function showFlowRunDetail(sid) {
+  var box = document.getElementById('flow-runs-detail');
+  var title = document.getElementById('flow-runs-detail-title');
+  var body = document.getElementById('flow-runs-detail-body');
+  if (!box || !body) return;
+  if (title) title.textContent = 'Run · ' + sid;
+  body.innerHTML = '<div style="color:var(--text-muted);">Loading transcript&hellip;</div>';
+  box.style.display = 'block';
+  // Re-fetch /api/flow/runs to find this row (cheap; ≤200 rows). Then
+  // render a compact summary. The live Flow diagram is intentionally not
+  // re-driven here — the live view stays the source of truth for the
+  // animated SVG. Clicking a row gives users the stats panel for that run.
+  fetch('/api/flow/runs?limit=200')
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      var run = ((d && d.runs) || []).find(function(x) { return String(x.session_id) === String(sid); });
+      if (!run) { body.innerHTML = '<div style="color:#ef4444;">Run not found.</div>'; return; }
+      var models = (run.models || []).map(function(m) {
+        return '<span style="display:inline-block;background:var(--bg-tertiary,#0d0d1f);border:1px solid var(--border-secondary,#2a2a4a);border-radius:6px;padding:2px 8px;margin:2px 4px 2px 0;font-family:monospace;font-size:11px;">' + m + '</span>';
+      }).join('') || '<span style="color:var(--text-muted);">(none)</span>';
+      var statusColor = run.status === 'failed' ? '#ef4444' : '#22c55e';
+      body.innerHTML = ''
+        + '<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:14px;">'
+        + '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">Session</div><div style="font-family:monospace;color:var(--text-primary);word-break:break-all;">' + sid + '</div></div>'
+        + '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">Started</div><div style="color:var(--text-primary);">' + _fmtRunStarted(run.started_at) + '</div></div>'
+        + '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">Duration</div><div style="color:var(--text-primary);">' + _fmtRunDuration(run.duration_seconds) + '</div></div>'
+        + '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">Channel</div><div style="color:var(--text-primary);">' + (run.channel || '—') + '</div></div>'
+        + '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">Tool calls</div><div style="color:var(--text-primary);">' + (run.tools_called || 0) + '</div></div>'
+        + '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">Total cost</div><div style="color:var(--text-primary);">' + _fmtRunCost(run.total_cost) + '</div></div>'
+        + '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">Events</div><div style="color:var(--text-primary);">' + (run.event_count || 0) + '</div></div>'
+        + '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">Status</div><div style="color:' + statusColor + ';font-weight:600;">' + run.status + '</div></div>'
+        + '</div>'
+        + '<div style="margin-top:14px;"><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;">Models invoked</div><div>' + models + '</div></div>'
+        + '<div style="margin-top:14px;"><a href="/api/transcript/' + encodeURIComponent(sid) + '" target="_blank" style="font-size:12px;color:var(--accent-primary,#3b82f6);text-decoration:none;">View full transcript &rarr;</a></div>';
+    })
+    .catch(function() {
+      body.innerHTML = '<div style="color:#ef4444;">Failed to load run detail.</div>';
+    });
+}
+
+function hideFlowRunDetail() {
+  var box = document.getElementById('flow-runs-detail');
+  if (box) box.style.display = 'none';
+}
+
 function initFlow() {
   if (flowInitDone) return;
   flowInitDone = true;
-  
+
   // Performance: Reduce update frequency on mobile
   var updateInterval = window.innerWidth < 768 ? 3000 : 2000;
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -4006,6 +4006,13 @@ function clawmetryLogout(){
 
 <!-- FLOW -->
 <div class="page" id="page-flow">
+  <!-- Flow sub-tabs: Live | Runs (#611) -->
+  <div id="flow-subtabs" style="display:flex;gap:4px;border-bottom:1px solid var(--border-primary);margin:0 0 12px 0;padding:0;font-size:12px;">
+    <div class="flow-subtab active" data-sub="live" onclick="switchFlowSubtab('live')" style="padding:8px 16px;cursor:pointer;border-bottom:2px solid var(--accent-primary,#3b82f6);font-weight:600;color:var(--text-primary);">Live</div>
+    <div class="flow-subtab" data-sub="runs" onclick="switchFlowSubtab('runs')" style="padding:8px 16px;cursor:pointer;border-bottom:2px solid transparent;font-weight:600;color:var(--text-muted);">Runs</div>
+  </div>
+
+  <div id="flow-live-pane">
   <div class="flow-stats">
     <div class="flow-stat"><span class="flow-stat-label">Messages / min</span><span class="flow-stat-value" id="flow-msg-rate">0</span></div>
     <div class="flow-stat"><span class="flow-stat-label">Actions Taken</span><span class="flow-stat-value" id="flow-event-count">0</span></div>
@@ -4271,6 +4278,49 @@ function clawmetryLogout(){
       <div style="color:#555;">Waiting for activity...</div>
     </div>
   </div>
+  </div><!-- end flow-live-pane -->
+
+  <!-- FLOW RUNS PANE (#611) — historical runs aggregated from DuckDB events -->
+  <div id="flow-runs-pane" style="display:none;">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;flex-wrap:wrap;gap:8px;">
+      <div style="font-size:14px;font-weight:700;color:var(--text-primary);">&#128202; Flow Runs <span id="flow-runs-count" style="font-size:11px;color:var(--text-muted);font-weight:400;margin-left:6px;"></span></div>
+      <div style="display:flex;align-items:center;gap:8px;">
+        <label style="font-size:11px;color:var(--text-muted);">Limit:</label>
+        <select id="flow-runs-limit" onchange="loadFlowRuns()" style="font-size:11px;padding:3px 8px;background:var(--bg-primary,#0a0a1a);border:1px solid var(--border-secondary,#2a2a4a);border-radius:6px;color:var(--text-primary);">
+          <option value="10">10</option>
+          <option value="30" selected>30</option>
+          <option value="100">100</option>
+        </select>
+        <button onclick="loadFlowRuns()" style="font-size:11px;padding:3px 10px;border:1px solid var(--border-secondary,#2a2a4a);border-radius:6px;background:var(--bg-primary,#0a0a1a);color:var(--text-primary);cursor:pointer;">&#8635; Refresh</button>
+      </div>
+    </div>
+    <div style="background:var(--bg-secondary,#111128);border:1px solid var(--border-secondary,#2a2a4a);border-radius:10px;overflow:hidden;">
+      <table style="width:100%;border-collapse:collapse;font-size:12px;">
+        <thead>
+          <tr style="background:var(--bg-tertiary,#0d0d1f);color:var(--text-muted);text-align:left;">
+            <th style="padding:10px 14px;font-weight:600;">Session</th>
+            <th style="padding:10px 14px;font-weight:600;">Started</th>
+            <th style="padding:10px 14px;font-weight:600;text-align:right;">Duration</th>
+            <th style="padding:10px 14px;font-weight:600;">Channel</th>
+            <th style="padding:10px 14px;font-weight:600;text-align:right;">Models</th>
+            <th style="padding:10px 14px;font-weight:600;text-align:right;">Tools</th>
+            <th style="padding:10px 14px;font-weight:600;text-align:right;">Cost</th>
+            <th style="padding:10px 14px;font-weight:600;">Status</th>
+          </tr>
+        </thead>
+        <tbody id="flow-runs-tbody">
+          <tr><td colspan="8" style="padding:24px;text-align:center;color:var(--text-muted);font-size:12px;">Loading flow runs&hellip;</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div id="flow-runs-detail" style="margin-top:16px;display:none;background:var(--bg-secondary,#111128);border:1px solid var(--border-secondary,#2a2a4a);border-radius:10px;padding:14px 18px;">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+        <div id="flow-runs-detail-title" style="font-size:13px;font-weight:700;color:var(--text-primary);"></div>
+        <button onclick="hideFlowRunDetail()" style="background:transparent;border:none;color:var(--text-muted);font-size:18px;cursor:pointer;">&times;</button>
+      </div>
+      <div id="flow-runs-detail-body" style="font-size:12px;color:var(--text-muted);line-height:1.7;"></div>
+    </div>
+  </div><!-- end flow-runs-pane -->
 </div><!-- end page-flow -->
 
 <!-- BRAIN -->

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -312,6 +312,52 @@ def api_flow_events():
     )
 
 
+@bp_logs.route("/api/flow/runs")
+def api_flow_runs():
+    """Historical flow-runs list — closes #611.
+
+    Each row is one session_id's worth of events, aggregated from the local
+    DuckDB ``events`` table:
+
+      session_id, agent_id, started_at, duration_seconds, channels_touched,
+      models_invoked, tools_called, total_cost, status (completed/failed),
+      models[], channel
+
+    Query params:
+      ``limit``  — max rows (default 30, hard cap 200)
+      ``since``  — ISO timestamp lower-bound on event ts
+      ``until``  — ISO timestamp upper-bound
+
+    Returns ``{runs: [...], _source: "local_store"|"empty"}``. Never raises
+    — on any store failure we return an empty list with the legacy tag so
+    the Flow tab degrades gracefully.
+    """
+    try:
+        limit_raw = int(request.args.get("limit", 30))
+    except (TypeError, ValueError):
+        limit_raw = 30
+    limit = max(1, min(200, limit_raw))
+    since = request.args.get("since") or None
+    until = request.args.get("until") or None
+    agent_id = request.args.get("agent_id") or None
+
+    runs: list = []
+    source = "empty"
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        runs = store.query_flow_runs(
+            agent_id=agent_id, since=since, until=until, limit=limit,
+        ) or []
+        if runs:
+            source = "local_store"
+    except Exception:
+        runs = []
+        source = "empty"
+
+    return jsonify({"runs": runs, "count": len(runs), "_source": source})
+
+
 @bp_logs.route("/api/logs-stream")
 def api_logs_stream():
     """SSE endpoint - streams new log lines in real-time."""

--- a/tests/test_flow_runs_endpoint.py
+++ b/tests/test_flow_runs_endpoint.py
@@ -1,0 +1,212 @@
+"""Tests for the /api/flow/runs historical flow-runs endpoint (issue #611).
+
+A "flow run" = one session_id's worth of events from the DuckDB ``events``
+table. The endpoint aggregates per-session: duration, distinct models,
+tool-call count, total cost, status, and a left-joined channel.
+
+These tests seed events for three sessions across two channels and two
+models, then assert the grouping + aggregation invariants. The endpoint
+must never crash on missing data and must order most-recent-first.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+from flask import Flask
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.infra as infra_mod
+    importlib.reload(infra_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(infra_mod.bp_logs)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed_three_sessions(store):
+    """Seed events across 3 sessions / 2 channels / 2 models.
+
+    Session A (telegram, claude-opus-4-7):
+      - 2 messages, 1 tool_call, cost $0.30 total, ~10 min duration.
+    Session B (slack, gpt-4o):
+      - 1 message, 2 tool_calls, cost $0.20 total, ~5 min duration.
+    Session C (telegram, claude-opus-4-7 + gpt-4o):
+      - 1 error event → status=failed, cost $0.05, ~2 min duration.
+    """
+    # Session A — telegram, two assistant turns + one tool_call
+    store.ingest_channel({"session_id": "sess-A", "channel": "telegram"})
+    store.ingest({
+        "id": "A-1", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-A", "event_type": "message",
+        "ts": "2026-05-13T10:00:00Z",
+        "data": {"role": "user"},
+        "cost_usd": 0.10, "token_count": 100, "model": "claude-opus-4-7",
+    })
+    store.ingest({
+        "id": "A-2", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-A", "event_type": "tool_call",
+        "ts": "2026-05-13T10:05:00Z",
+        "data": {"tool": "Bash"},
+        "cost_usd": 0.10, "token_count": 50, "model": "claude-opus-4-7",
+    })
+    store.ingest({
+        "id": "A-3", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-A", "event_type": "message",
+        "ts": "2026-05-13T10:10:00Z",
+        "data": {"role": "assistant"},
+        "cost_usd": 0.10, "token_count": 80, "model": "claude-opus-4-7",
+    })
+
+    # Session B — slack, two tool_calls, different model
+    store.ingest_channel({"session_id": "sess-B", "channel": "slack"})
+    store.ingest({
+        "id": "B-1", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-B", "event_type": "message",
+        "ts": "2026-05-13T11:00:00Z",
+        "data": {"role": "user"},
+        "cost_usd": 0.05, "token_count": 50, "model": "gpt-4o",
+    })
+    store.ingest({
+        "id": "B-2", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-B", "event_type": "tool_call",
+        "ts": "2026-05-13T11:02:00Z",
+        "data": {"tool": "Bash"},
+        "cost_usd": 0.08, "token_count": 40, "model": "gpt-4o",
+    })
+    store.ingest({
+        "id": "B-3", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-B", "event_type": "tool_call",
+        "ts": "2026-05-13T11:05:00Z",
+        "data": {"tool": "Read"},
+        "cost_usd": 0.07, "token_count": 30, "model": "gpt-4o",
+    })
+
+    # Session C — telegram, FAILED (has an error event), two models
+    store.ingest_channel({"session_id": "sess-C", "channel": "telegram"})
+    store.ingest({
+        "id": "C-1", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-C", "event_type": "message",
+        "ts": "2026-05-13T12:00:00Z",
+        "data": {"role": "user"},
+        "cost_usd": 0.03, "token_count": 30, "model": "claude-opus-4-7",
+    })
+    store.ingest({
+        "id": "C-2", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-C", "event_type": "tool_error",
+        "ts": "2026-05-13T12:02:00Z",
+        "data": {"error": "boom"},
+        "cost_usd": 0.02, "token_count": 10, "model": "gpt-4o",
+    })
+
+    _wait_flush(store)
+
+
+def test_flow_runs_returns_one_row_per_session(app):
+    a, ls = app
+    _seed_three_sessions(ls.get_store())
+    r = a.test_client().get("/api/flow/runs?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    assert body["count"] == 3
+    sids = {row["session_id"] for row in body["runs"]}
+    assert sids == {"sess-A", "sess-B", "sess-C"}
+
+
+def test_flow_runs_aggregates_cost_tools_models(app):
+    a, ls = app
+    _seed_three_sessions(ls.get_store())
+    r = a.test_client().get("/api/flow/runs?limit=10")
+    runs = {row["session_id"]: row for row in r.get_json()["runs"]}
+
+    a_row = runs["sess-A"]
+    # 3 events, 1 tool_call, 1 distinct model, cost $0.30 (±float dust).
+    assert a_row["event_count"] == 3
+    assert a_row["tools_called"] == 1
+    assert a_row["models_invoked"] == 1
+    assert a_row["models"] == ["claude-opus-4-7"]
+    assert abs(a_row["total_cost"] - 0.30) < 1e-6
+    assert a_row["channel"] == "telegram"
+    assert a_row["channels_touched"] == 1
+    assert a_row["status"] == "completed"
+    # 10 min duration (10:00 → 10:10).
+    assert abs(a_row["duration_seconds"] - 600.0) < 1.0
+
+    b_row = runs["sess-B"]
+    assert b_row["event_count"] == 3
+    assert b_row["tools_called"] == 2
+    assert b_row["models_invoked"] == 1
+    assert b_row["models"] == ["gpt-4o"]
+    assert abs(b_row["total_cost"] - 0.20) < 1e-6
+    assert b_row["channel"] == "slack"
+    assert b_row["status"] == "completed"
+    # 5 min duration (11:00 → 11:05).
+    assert abs(b_row["duration_seconds"] - 300.0) < 1.0
+
+
+def test_flow_runs_marks_error_sessions_failed(app):
+    a, ls = app
+    _seed_three_sessions(ls.get_store())
+    r = a.test_client().get("/api/flow/runs?limit=10")
+    runs = {row["session_id"]: row for row in r.get_json()["runs"]}
+    c_row = runs["sess-C"]
+    # Has a `tool_error` event → status flips to failed.
+    assert c_row["status"] == "failed"
+    # Two distinct models seen in sess-C.
+    assert c_row["models_invoked"] == 2
+    assert set(c_row["models"]) == {"claude-opus-4-7", "gpt-4o"}
+
+
+def test_flow_runs_ordered_most_recent_first(app):
+    a, ls = app
+    _seed_three_sessions(ls.get_store())
+    r = a.test_client().get("/api/flow/runs?limit=10")
+    ids = [row["session_id"] for row in r.get_json()["runs"]]
+    # C (12:02 last) before B (11:05) before A (10:10).
+    assert ids == ["sess-C", "sess-B", "sess-A"]
+
+
+def test_flow_runs_limit_param_caps_rows(app):
+    a, ls = app
+    _seed_three_sessions(ls.get_store())
+    r = a.test_client().get("/api/flow/runs?limit=2")
+    body = r.get_json()
+    assert body["count"] == 2
+    # Most-recent-first slicing — A (oldest) is the one dropped.
+    sids = [row["session_id"] for row in body["runs"]]
+    assert "sess-A" not in sids
+    assert "sess-C" in sids
+
+
+def test_flow_runs_empty_store_returns_empty_list(app):
+    a, _ls = app
+    r = a.test_client().get("/api/flow/runs")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["runs"] == []
+    assert body["count"] == 0
+    assert body["_source"] == "empty"


### PR DESCRIPTION
## Summary
- Adds a **Runs** sub-tab on the Flow page showing historical flow runs aggregated from the local DuckDB `events` table.
- New backend endpoint `GET /api/flow/runs?limit=30` returns per-session summaries: `started_at`, `duration_seconds`, `channels_touched`, `models_invoked`, `tools_called`, `total_cost`, `status` (completed/failed), plus model list and channel.
- Live Flow view is untouched — it remains the default sub-tab and the source of truth for the animated SVG.

## Implementation
- `LocalStore.query_flow_runs(...)` — single `GROUP BY session_id` query with a `LEFT JOIN` onto `openclaw_channels` so each row carries the user-facing channel without an extra round trip. Status is heuristic: any event with `event_type` containing `error` flips the run to `failed`.
- `bp_logs` (`routes/infra.py`) gets the new route next to the existing `/api/flow` SSE — they're siblings of the same Flow surface.
- `page-flow` in `dashboard.py` gets a sub-tab toggle and a runs table; `app.js` gets `switchFlowSubtab`, `loadFlowRuns`, `showFlowRunDetail`.
- Endpoint never raises — empty/missing store degrades to `_source: empty` so the tab stays usable on fresh installs.

## Test plan
- [x] `pytest tests/test_flow_runs_endpoint.py` — 6 cases, all green:
  - per-session grouping (3 sessions seeded, 3 rows returned)
  - cost / tool-call / model aggregations
  - failed-status detection on `tool_error` events
  - most-recent-first ordering
  - `limit` param clamping
  - empty store returns `_source: empty`
- [x] `python3 -c "import dashboard"` — module imports clean
- [x] Adjacent `test_local_store_multi_agent.py` + `test_event_metrics_extraction.py` still green (22/22 in the affected slice)

Closes #611