### PR TITLE
feat(bootstrap): capture BOOTSTRAP.md before self-delete (closes #690)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -117,7 +117,7 @@ LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 # ── Two-layer schema (multi-agent) ──────────────────────────────────────────
 #
@@ -421,6 +421,30 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_cron_runs_job_id     ON cron_runs(job_id, started_at)",
     "CREATE INDEX IF NOT EXISTS idx_cron_runs_started_at ON cron_runs(started_at)",
+    # Issue #690 — "First Contact" bootstrap archive. OpenClaw's BOOTSTRAP.md
+    # runs once at first startup to negotiate agent identity, then SELF-DELETES.
+    # The capture helper in ``clawmetry/sync.py`` snapshots the file (and the
+    # session id active at capture time) into this table BEFORE OpenClaw
+    # removes it, so we keep a read-only "First Contact" artifact for the
+    # life of the node. Dedup key is (node_id, agent_id, content_sha256) —
+    # re-capture on unchanged content is a no-op, but a re-bootstrap with
+    # different content lands as a fresh row so we preserve the full
+    # first-contact history when OpenClaw re-negotiates identity.
+    """
+    CREATE TABLE IF NOT EXISTS bootstrap_archive (
+        node_id           VARCHAR NOT NULL,
+        agent_id          VARCHAR NOT NULL DEFAULT 'main',
+        captured_at       VARCHAR NOT NULL,
+        file_mtime        VARCHAR,
+        content           VARCHAR,
+        content_sha256    VARCHAR,
+        first_session_id  VARCHAR,
+        size_bytes        INTEGER,
+        source_path       VARCHAR,
+        PRIMARY KEY (node_id, agent_id, content_sha256)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_bootstrap_node ON bootstrap_archive(node_id, captured_at)",
     """
     CREATE TABLE IF NOT EXISTS schema_version (
         version    INTEGER PRIMARY KEY,
@@ -1269,6 +1293,120 @@ class LocalStore:
                 "DELETE FROM agent_budgets WHERE agent_id = ?", [aid]
             )
         return 1
+
+    # ── BOOTSTRAP archive (issue #690) ──────────────────────────────────────
+
+    def ingest_bootstrap_archive(self, row: dict[str, Any]) -> bool:
+        """Insert one BOOTSTRAP.md snapshot. Returns True if a new row was
+        written, False if (node_id, agent_id, content_sha256) already exists.
+
+        Required keys: ``node_id``, ``content``. Optional: ``agent_id``
+        (default ``"main"``), ``captured_at`` (default = now UTC ISO),
+        ``file_mtime``, ``first_session_id``, ``source_path``. ``content``
+        is stored as VARCHAR (BOOTSTRAP.md is small markdown — there's no
+        reason to BLOB-encode). ``content_sha256`` is computed here when
+        missing so callers don't have to.
+
+        Idempotent: re-capturing the same content for the same
+        (node_id, agent_id) is a no-op. If the file is rewritten (different
+        content), a new row is inserted — preserving the full first-contact
+        history when the bootstrap is re-negotiated.
+        """
+        if self._read_only:
+            raise RuntimeError(
+                "local_store: ingest_bootstrap_archive() on read-only store"
+            )
+        node_id = row.get("node_id")
+        if not node_id:
+            raise ValueError("bootstrap archive row must include 'node_id'")
+        content = row.get("content")
+        if content is None:
+            raise ValueError("bootstrap archive row must include 'content'")
+        if isinstance(content, (bytes, bytearray)):
+            content = content.decode("utf-8", errors="replace")
+        else:
+            content = str(content)
+        agent_id = row.get("agent_id") or "main"
+        sha = row.get("content_sha256")
+        if not sha:
+            import hashlib
+            sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        captured_at = row.get("captured_at")
+        if not captured_at:
+            from datetime import datetime, timezone
+            captured_at = datetime.now(timezone.utc).isoformat()
+        size_bytes = row.get("size_bytes")
+        if size_bytes is None:
+            size_bytes = len(content.encode("utf-8"))
+        params = [
+            str(node_id),
+            str(agent_id),
+            str(captured_at),
+            row.get("file_mtime"),
+            content,
+            sha,
+            row.get("first_session_id"),
+            int(size_bytes),
+            row.get("source_path"),
+        ]
+        with self._write_lock:
+            # Detect dup BEFORE the insert so we can return an accurate flag.
+            cur = self._conn.execute(
+                "SELECT 1 FROM bootstrap_archive "
+                "WHERE node_id=? AND agent_id=? AND content_sha256=? LIMIT 1",
+                [str(node_id), str(agent_id), sha],
+            )
+            if cur.fetchone():
+                return False
+            self._conn.execute(
+                """
+                INSERT INTO bootstrap_archive (
+                    node_id, agent_id, captured_at, file_mtime, content,
+                    content_sha256, first_session_id, size_bytes, source_path
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                params,
+            )
+        return True
+
+    def query_bootstrap_archive(
+        self,
+        *,
+        node_id: str | None = None,
+        agent_id: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Read bootstrap-archive rows, newest first.
+
+        ``node_id`` scopes the result to one machine; ``agent_id`` further
+        narrows to a single agent within that node. Returns full content —
+        BOOTSTRAP.md is tiny (typically <8 KB) so there's no value in a
+        lazy-content variant."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if node_id:
+            clauses.append("node_id = ?")
+            params.append(str(node_id))
+        if agent_id:
+            clauses.append("agent_id = ?")
+            params.append(str(agent_id))
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT node_id, agent_id, captured_at, file_mtime, content,
+                   content_sha256, first_session_id, size_bytes, source_path
+            FROM bootstrap_archive
+            {where}
+            ORDER BY captured_at DESC, agent_id
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["node_id", "agent_id", "captured_at", "file_mtime", "content",
+                "content_sha256", "first_session_id", "size_bytes",
+                "source_path"]
+        out: list[dict[str, Any]] = []
+        for r in self._fetch(sql, params):
+            out.append(dict(zip(cols, r)))
+        return out
 
     def ingest_approval(self, approval: dict[str, Any]) -> None:
         """Upsert one approval-queue row. Required: ``id``.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -4364,6 +4364,182 @@ def sync_memory(config: dict, state: dict, paths: dict) -> int:
     """Build memory file list for the Memory popup."""
 
 
+# ── BOOTSTRAP.md "First Contact" capture (issue #690) ─────────────────────────
+#
+# OpenClaw's BOOTSTRAP.md runs once at first startup to negotiate agent identity
+# and then SELF-DELETES. We watch for it on every daemon tick and snapshot the
+# file (plus the session id active when we saw it) into the local DuckDB
+# `bootstrap_archive` table BEFORE OpenClaw removes it. The store is the
+# authority — once captured, the artifact is read-only and survives any
+# subsequent re-init / workspace move.
+#
+# Idempotent: `local_store.ingest_bootstrap_archive` dedups on
+# (node_id, agent_id, content_sha256), so re-running the capture on an
+# unchanged file is a no-op. If OpenClaw rewrites BOOTSTRAP.md with new content
+# (re-negotiated identity), a fresh row is inserted, preserving the full
+# first-contact history.
+
+_BOOTSTRAP_CANDIDATE_PATHS = (
+    # Documented spec location.
+    ("agents", "main", "memory", "BOOTSTRAP.md"),
+    # Some OpenClaw builds keep the file at the workspace root.
+    ("agents", "main", "BOOTSTRAP.md"),
+    ("BOOTSTRAP.md",),
+)
+
+
+def _find_bootstrap_file(workspace: str | None = None) -> Path | None:
+    """Return the path to a present BOOTSTRAP.md, or None when absent.
+
+    Checks the documented location first, then a couple of fallbacks that
+    have been observed in the wild. Returns the first hit — bootstrap files
+    don't coexist."""
+    bases: list[Path] = [Path(_get_openclaw_dir())]
+    if workspace:
+        try:
+            bases.append(Path(workspace))
+        except Exception:
+            pass
+    for base in bases:
+        for parts in _BOOTSTRAP_CANDIDATE_PATHS:
+            candidate = base.joinpath(*parts)
+            try:
+                if candidate.is_file():
+                    return candidate
+            except OSError:
+                continue
+    return None
+
+
+def _latest_session_id(workspace: str | None = None) -> str | None:
+    """Best-effort: return the session id of the most-recently-modified
+    JSONL transcript when the bootstrap was captured. We link the artifact
+    to it so the dashboard can show "First Contact ⇄ first session" together.
+    None when no session transcripts exist (bootstrap captured before any
+    session, which is the normal first-boot case)."""
+    candidates: list[Path] = [
+        Path(_get_openclaw_dir()) / "agents" / "main" / "sessions",
+    ]
+    if workspace:
+        try:
+            candidates.append(Path(workspace) / "agents" / "main" / "sessions")
+        except Exception:
+            pass
+    for sessions_dir in candidates:
+        try:
+            if not sessions_dir.is_dir():
+                continue
+        except OSError:
+            continue
+        newest_mtime = -1.0
+        newest: Path | None = None
+        try:
+            for p in sessions_dir.iterdir():
+                if p.suffix != ".jsonl":
+                    continue
+                try:
+                    mt = p.stat().st_mtime
+                except OSError:
+                    continue
+                if mt > newest_mtime:
+                    newest_mtime = mt
+                    newest = p
+        except OSError:
+            continue
+        if newest is not None:
+            # File name is the session id; strip the suffix.
+            return newest.stem
+    return None
+
+
+def capture_bootstrap_if_present(
+    config: dict | None = None,
+    paths: dict | None = None,
+    *,
+    store=None,
+) -> bool:
+    """Daemon tick hook: snapshot BOOTSTRAP.md to the local store when
+    present. Returns True when a NEW row was written, False otherwise
+    (file absent, unchanged, or write failure — failure is logged but
+    never raised, the daemon must keep ticking).
+
+    ``store`` is overridable for tests; defaults to the process-wide
+    LocalStore singleton."""
+    try:
+        config = config or {}
+        node_id = config.get("node_id") or ""
+        if not node_id:
+            # Defensive — run_daemon backfills this on startup. Without it
+            # we can't dedup, so skip silently.
+            return False
+        workspace = ""
+        if paths:
+            workspace = paths.get("workspace") or ""
+        bootstrap_path = _find_bootstrap_file(workspace=workspace)
+        if bootstrap_path is None:
+            return False
+        try:
+            content_bytes = bootstrap_path.read_bytes()
+        except OSError as e:
+            log.warning("bootstrap capture: read failed for %s: %s",
+                        bootstrap_path, e)
+            return False
+        try:
+            content = content_bytes.decode("utf-8", errors="replace")
+        except Exception:
+            content = content_bytes.decode("latin-1", errors="replace")
+        if not content.strip():
+            # Empty BOOTSTRAP.md is meaningless — wait until OpenClaw fills it.
+            return False
+        import hashlib
+        from datetime import datetime, timezone
+
+        sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        try:
+            mtime_iso = datetime.fromtimestamp(
+                bootstrap_path.stat().st_mtime, tz=timezone.utc
+            ).isoformat()
+        except OSError:
+            mtime_iso = None
+
+        # Defer the import so a missing duckdb dep (older installs) doesn't
+        # take the daemon down — bootstrap capture is best-effort.
+        if store is None:
+            try:
+                from clawmetry import local_store as _ls
+                store = _ls.get_store()
+            except Exception as e:
+                log.warning("bootstrap capture: local_store unavailable: %s", e)
+                return False
+
+        first_session = _latest_session_id(workspace=workspace)
+        try:
+            wrote = store.ingest_bootstrap_archive({
+                "node_id": node_id,
+                "agent_id": "main",
+                "captured_at": datetime.now(timezone.utc).isoformat(),
+                "file_mtime": mtime_iso,
+                "content": content,
+                "content_sha256": sha,
+                "first_session_id": first_session,
+                "size_bytes": len(content_bytes),
+                "source_path": str(bootstrap_path),
+            })
+        except Exception as e:
+            log.warning("bootstrap capture: ingest failed: %s", e)
+            return False
+        if wrote:
+            log.info(
+                "bootstrap capture: archived %s (sha=%s, session=%s)",
+                bootstrap_path, sha[:12], first_session or "n/a",
+            )
+        return wrote
+    except Exception as e:
+        # Catch-all so a bug in this helper never crashes the daemon loop.
+        log.warning("bootstrap capture: unexpected error: %s", e)
+        return False
+
+
 def _build_machine_info():
     """Build machine hardware info for the Machine popup."""
     try:
@@ -5762,6 +5938,14 @@ def run_daemon() -> None:
     # Always sync recent events first (last hour) — makes the dashboard
     # immediately useful even when there's a large backlog of old events.
     log.info("Syncing recent activity (last 60 min) first...")
+    # Snapshot BOOTSTRAP.md immediately at startup — it may self-delete before
+    # the first poll cycle on a fast-init OpenClaw. Idempotent; no-op when
+    # the file isn't present (issue #690).
+    try:
+        if capture_bootstrap_if_present(config, paths):
+            log.info("  Bootstrap: archived first-contact snapshot")
+    except Exception as e:
+        log.warning(f"  Bootstrap capture error: {e}")
     try:
         mem = sync_memory(config, state, paths)
         if mem:
@@ -5913,6 +6097,15 @@ def run_daemon() -> None:
     while True:
         try:
             state = load_state()
+
+            # ── BOOTSTRAP.md "First Contact" capture (issue #690) ─────────
+            # Best-effort; runs early in the tick so we snapshot the file
+            # BEFORE any other helper notices OpenClaw has self-deleted it.
+            # Idempotent — duplicate captures dedup at the local-store layer.
+            try:
+                capture_bootstrap_if_present(config, paths)
+            except Exception as _be:
+                log.warning("bootstrap capture failed: %s", _be)
 
             # ── High-priority: memory, flow metrics, subagents, recent sessions ──
             mem = sync_memory(config, state, paths)

--- a/dashboard.py
+++ b/dashboard.py
@@ -115,6 +115,7 @@ from routes.plugins import bp_plugins
 from routes.local_query import bp_local_query
 from routes.update_check import bp_update_check, start_update_check_thread
 from routes.workspaces import bp_workspaces
+from routes.bootstrap import bp_bootstrap
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -9170,6 +9171,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_openapi)
     app.register_blueprint(bp_update_check)
     app.register_blueprint(bp_workspaces)
+    app.register_blueprint(bp_bootstrap)
 
     # Register built-in agent adapters. External plugins can register more
     # via clawmetry.extensions entry points — see clawmetry/adapters/.

--- a/routes/bootstrap.py
+++ b/routes/bootstrap.py
@@ -1,0 +1,128 @@
+"""routes/bootstrap.py — "First Contact" bootstrap artifact endpoints.
+
+Exposes the BOOTSTRAP.md snapshots captured by ``clawmetry/sync.py``
+(:func:`capture_bootstrap_if_present`) over HTTP. OpenClaw's BOOTSTRAP.md
+runs once at first startup to negotiate agent identity, then SELF-DELETES.
+The daemon captures it before it disappears; these routes surface the
+read-only artifact to the dashboard / cloud UI.
+
+  GET /api/bootstrap                — list captured snapshots for this node
+  GET /api/bootstrap/<agent_id>     — single snapshot (newest) + linked first-session ref
+
+Both endpoints return HTTP 404 when no bootstrap has been captured yet
+(fresh install, OpenClaw not running, or workspace already past first-contact
+when ClawMetry was installed). Zero coupling to ``dashboard.py``; talks
+directly to ``clawmetry.local_store``.
+"""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+bp_bootstrap = Blueprint("bootstrap", __name__)
+
+
+def _store():
+    """Return a read-only LocalStore handle, or None when unavailable.
+
+    The daemon owns the writer lock; the dashboard process opens a separate
+    RO handle on the same DuckDB file. Falls back to ``None`` cleanly if
+    ``duckdb`` isn't installed or the store file doesn't exist yet (fresh
+    install — no bootstrap to surface anyway)."""
+    try:
+        from clawmetry import local_store
+        return local_store.get_store(read_only=True)
+    except Exception:
+        return None
+
+
+def _node_id_filter() -> str | None:
+    """Scope queries to the current node when possible.
+
+    Reads the node_id from the on-disk sync config (the same file the daemon
+    consults). Returns None when the config is missing or unreadable — the
+    query helper treats None as "no scope" so we still return the full table
+    in that case (acceptable for OSS single-node installs)."""
+    try:
+        from clawmetry import sync
+        cfg = sync.load_config()
+        nid = cfg.get("node_id")
+        return str(nid) if nid else None
+    except Exception:
+        return None
+
+
+def _row_to_summary(row: dict) -> dict:
+    """Strip the heavy `content` field for list responses — clients can fetch
+    one snapshot at a time for the full text."""
+    return {
+        "node_id": row.get("node_id"),
+        "agent_id": row.get("agent_id"),
+        "captured_at": row.get("captured_at"),
+        "file_mtime": row.get("file_mtime"),
+        "content_sha256": row.get("content_sha256"),
+        "first_session_id": row.get("first_session_id"),
+        "size_bytes": row.get("size_bytes"),
+        "source_path": row.get("source_path"),
+    }
+
+
+@bp_bootstrap.route("/api/bootstrap")
+def api_bootstrap_list():
+    """List captured BOOTSTRAP.md snapshots for the current node.
+
+    Returns 404 when no snapshots exist — the absence of an artifact is
+    a meaningful 404 (vs. an empty list) so clients can branch on it
+    without parsing the body."""
+    try:
+        limit = max(1, min(200, int(request.args.get("limit", 50))))
+    except (TypeError, ValueError):
+        limit = 50
+    store = _store()
+    if store is None:
+        return jsonify({"error": "local store unavailable"}), 503
+    node_id = _node_id_filter()
+    try:
+        rows = store.query_bootstrap_archive(node_id=node_id, limit=limit)
+    except Exception as exc:
+        return jsonify({"error": f"query failed: {exc}"}), 500
+    if not rows:
+        return jsonify({
+            "error": "no bootstrap snapshots captured yet",
+            "node_id": node_id,
+            "snapshots": [],
+        }), 404
+    return jsonify({
+        "node_id": node_id,
+        "snapshots": [_row_to_summary(r) for r in rows],
+        "_source": "local_store",
+    })
+
+
+@bp_bootstrap.route("/api/bootstrap/<agent_id>")
+def api_bootstrap_detail(agent_id: str):
+    """Return the newest BOOTSTRAP.md snapshot for ``agent_id`` on this node.
+
+    Returns 404 when no snapshot exists for that agent. Includes the full
+    `content` field (BOOTSTRAP.md is tiny — typically <8 KB)."""
+    store = _store()
+    if store is None:
+        return jsonify({"error": "local store unavailable"}), 503
+    node_id = _node_id_filter()
+    try:
+        rows = store.query_bootstrap_archive(
+            node_id=node_id, agent_id=agent_id, limit=1,
+        )
+    except Exception as exc:
+        return jsonify({"error": f"query failed: {exc}"}), 500
+    if not rows:
+        return jsonify({
+            "error": f"no bootstrap snapshot for agent_id={agent_id!r}",
+            "agent_id": agent_id,
+            "node_id": node_id,
+        }), 404
+    row = rows[0]
+    return jsonify({
+        "snapshot": row,
+        "first_session_id": row.get("first_session_id"),
+        "_source": "local_store",
+    })

--- a/tests/test_bootstrap_capture.py
+++ b/tests/test_bootstrap_capture.py
@@ -1,0 +1,340 @@
+"""Tests for the "First Contact" BOOTSTRAP.md capture (issue #690).
+
+Three surfaces:
+  1. DuckDB schema — ``bootstrap_archive`` is reachable via
+     ``ingest_bootstrap_archive`` + ``query_bootstrap_archive``. Round-trip,
+     dedup, and re-capture-on-content-change semantics.
+  2. Capture helper — ``clawmetry.sync.capture_bootstrap_if_present`` finds
+     BOOTSTRAP.md under the configured workspace, snapshots it into DuckDB,
+     and no-ops on a re-tick. A subsequent edit of the file results in a NEW
+     row (preserving the full first-contact history when OpenClaw
+     re-negotiates).
+  3. HTTP routes — ``GET /api/bootstrap`` returns 404 when empty and 200
+     with a summary list once a snapshot exists; ``GET /api/bootstrap/main``
+     returns the full content row.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Reload `clawmetry.local_store` against a fresh DuckDB file. Yields
+    (module, store); closes on teardown."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    store = ls.get_store()
+    yield ls, store
+
+    try:
+        store.stop(flush=False)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def fake_openclaw_workspace(tmp_path, monkeypatch):
+    """Build a fake ~/.openclaw layout with a BOOTSTRAP.md present at the
+    documented `agents/main/memory/BOOTSTRAP.md` location. Returns the path
+    to the file so tests can mutate / delete it."""
+    oc_dir = tmp_path / "openclaw"
+    memory_dir = oc_dir / "agents" / "main" / "memory"
+    memory_dir.mkdir(parents=True)
+    bootstrap = memory_dir / "BOOTSTRAP.md"
+    bootstrap.write_text(
+        "# First Contact\n\n"
+        "Hello, agent. You are OpenClaw. Negotiating identity…\n"
+    )
+    # `sync._get_openclaw_dir()` reads this env var.
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(oc_dir))
+    # Also seed a session JSONL so the capture links a first_session_id.
+    sessions_dir = oc_dir / "agents" / "main" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "sess-12345.jsonl").write_text('{"type":"start"}\n')
+    return bootstrap
+
+
+# ── 1. Schema round-trip ───────────────────────────────────────────────────
+
+
+def test_ingest_and_query_bootstrap_round_trip(fresh_store):
+    ls, store = fresh_store
+    row = {
+        "node_id": "node-1",
+        "agent_id": "main",
+        "content": "# BOOTSTRAP\n\nidentity payload",
+        "first_session_id": "sess-abc",
+        "source_path": "/fake/path/BOOTSTRAP.md",
+    }
+    wrote = store.ingest_bootstrap_archive(row)
+    assert wrote is True
+
+    rows = store.query_bootstrap_archive(node_id="node-1")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["node_id"] == "node-1"
+    assert r["agent_id"] == "main"
+    assert r["content"].startswith("# BOOTSTRAP")
+    assert r["first_session_id"] == "sess-abc"
+    assert r["source_path"] == "/fake/path/BOOTSTRAP.md"
+    assert r["content_sha256"]  # auto-computed
+    assert r["size_bytes"] == len(row["content"].encode("utf-8"))
+    assert r["captured_at"]  # auto-filled
+
+
+def test_ingest_bootstrap_dedups_same_content(fresh_store):
+    """Re-capturing the same content for the same (node, agent) is a no-op."""
+    ls, store = fresh_store
+    payload = {
+        "node_id": "node-1",
+        "agent_id": "main",
+        "content": "# BOOTSTRAP\nv1",
+    }
+    assert store.ingest_bootstrap_archive(payload) is True
+    # Second call with identical content — should NOT write a new row.
+    assert store.ingest_bootstrap_archive(payload) is False
+    assert len(store.query_bootstrap_archive(node_id="node-1")) == 1
+
+
+def test_ingest_bootstrap_new_row_on_content_change(fresh_store):
+    """A different content (e.g. OpenClaw rewrote BOOTSTRAP.md after re-init)
+    yields a NEW row — preserving the full first-contact history."""
+    ls, store = fresh_store
+    base = {"node_id": "node-1", "agent_id": "main"}
+    assert store.ingest_bootstrap_archive({**base, "content": "v1 body"}) is True
+    assert store.ingest_bootstrap_archive({**base, "content": "v2 body"}) is True
+
+    rows = store.query_bootstrap_archive(node_id="node-1")
+    assert len(rows) == 2
+    bodies = sorted(r["content"] for r in rows)
+    assert bodies == ["v1 body", "v2 body"]
+
+
+def test_query_filters_by_agent_id(fresh_store):
+    ls, store = fresh_store
+    store.ingest_bootstrap_archive({
+        "node_id": "node-1", "agent_id": "main", "content": "A",
+    })
+    store.ingest_bootstrap_archive({
+        "node_id": "node-1", "agent_id": "subagent-7", "content": "B",
+    })
+    main_only = store.query_bootstrap_archive(
+        node_id="node-1", agent_id="main",
+    )
+    assert len(main_only) == 1
+    assert main_only[0]["content"] == "A"
+
+
+def test_ingest_requires_node_id_and_content(fresh_store):
+    ls, store = fresh_store
+    with pytest.raises(ValueError):
+        store.ingest_bootstrap_archive({"agent_id": "main", "content": "x"})
+    with pytest.raises(ValueError):
+        store.ingest_bootstrap_archive({"node_id": "n", "agent_id": "main"})
+
+
+# ── 2. Capture helper ──────────────────────────────────────────────────────
+
+
+def test_capture_writes_to_store_when_bootstrap_present(
+    fresh_store, fake_openclaw_workspace, monkeypatch,
+):
+    """End-to-end: BOOTSTRAP.md exists on disk → capture helper finds it,
+    reads it, persists it to the local store."""
+    ls, store = fresh_store
+    # Make sync.py see this test's reloaded local_store module too. The
+    # capture helper does ``from clawmetry import local_store`` internally,
+    # which goes through the reloaded module via sys.modules.
+    sys.modules["clawmetry.local_store"] = ls
+
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+    # After reload `sync.capture_bootstrap_if_present` will resolve the
+    # patched _get_openclaw_dir via the monkeypatched env var.
+
+    config = {"node_id": "node-test"}
+    wrote = sync.capture_bootstrap_if_present(config, paths={}, store=store)
+    assert wrote is True
+
+    rows = store.query_bootstrap_archive(node_id="node-test")
+    assert len(rows) == 1
+    r = rows[0]
+    assert "First Contact" in r["content"]
+    assert r["source_path"].endswith("BOOTSTRAP.md")
+    # We seeded one session JSONL — the helper should link it.
+    assert r["first_session_id"] == "sess-12345"
+
+
+def test_capture_is_noop_when_bootstrap_absent(fresh_store, tmp_path, monkeypatch):
+    """No BOOTSTRAP.md on disk → helper returns False, store stays empty."""
+    ls, store = fresh_store
+    sys.modules["clawmetry.local_store"] = ls
+
+    # Point at a directory that has no BOOTSTRAP.md anywhere.
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path / "empty-oc"))
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+
+    config = {"node_id": "node-test"}
+    assert sync.capture_bootstrap_if_present(config, paths={}, store=store) is False
+    assert store.query_bootstrap_archive(node_id="node-test") == []
+
+
+def test_capture_dedups_on_second_tick(
+    fresh_store, fake_openclaw_workspace, monkeypatch,
+):
+    """First tick captures; second tick on unchanged file is a no-op."""
+    ls, store = fresh_store
+    sys.modules["clawmetry.local_store"] = ls
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+
+    config = {"node_id": "node-test"}
+    assert sync.capture_bootstrap_if_present(config, paths={}, store=store) is True
+    # Second tick — same file content.
+    assert sync.capture_bootstrap_if_present(config, paths={}, store=store) is False
+    assert len(store.query_bootstrap_archive(node_id="node-test")) == 1
+
+
+def test_capture_reruns_on_content_change(
+    fresh_store, fake_openclaw_workspace, monkeypatch,
+):
+    """Simulate OpenClaw deleting + re-creating BOOTSTRAP.md with new content
+    (re-negotiated identity). Capture helper writes a SECOND row."""
+    ls, store = fresh_store
+    sys.modules["clawmetry.local_store"] = ls
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+
+    config = {"node_id": "node-test"}
+    assert sync.capture_bootstrap_if_present(config, paths={}, store=store) is True
+
+    # Mimic the self-delete + rewrite cycle.
+    fake_openclaw_workspace.unlink()
+    fake_openclaw_workspace.write_text(
+        "# First Contact (v2)\n\nAgent re-bootstrapped after reset.\n"
+    )
+    assert sync.capture_bootstrap_if_present(config, paths={}, store=store) is True
+    rows = store.query_bootstrap_archive(node_id="node-test")
+    assert len(rows) == 2
+
+
+def test_capture_skips_without_node_id(fresh_store, fake_openclaw_workspace):
+    """No node_id in config → helper short-circuits (can't dedup without it)."""
+    ls, store = fresh_store
+    sys.modules["clawmetry.local_store"] = ls
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+
+    assert sync.capture_bootstrap_if_present({}, paths={}, store=store) is False
+
+
+def test_capture_skips_empty_file(fresh_store, fake_openclaw_workspace, monkeypatch):
+    """Empty / whitespace-only BOOTSTRAP.md is meaningless — wait for content."""
+    fake_openclaw_workspace.write_text("   \n  \n")
+    ls, store = fresh_store
+    sys.modules["clawmetry.local_store"] = ls
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+
+    config = {"node_id": "node-test"}
+    assert sync.capture_bootstrap_if_present(config, paths={}, store=store) is False
+    assert store.query_bootstrap_archive(node_id="node-test") == []
+
+
+# ── 3. HTTP routes ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def flask_client(fresh_store, monkeypatch):
+    """A minimal Flask app wired only to bp_bootstrap. Avoids pulling in the
+    full dashboard.py so unit tests stay fast."""
+    ls, store = fresh_store
+    sys.modules["clawmetry.local_store"] = ls
+
+    # Stub load_config so the route's node_id_filter returns a stable value.
+    import clawmetry.sync as sync
+    monkeypatch.setattr(sync, "load_config", lambda: {"node_id": "node-test"})
+
+    sys.modules.pop("routes.bootstrap", None)
+    import routes.bootstrap as bp_module
+    importlib.reload(bp_module)
+
+    from flask import Flask
+    app = Flask(__name__)
+    app.register_blueprint(bp_module.bp_bootstrap)
+    with app.test_client() as client:
+        yield client, store
+
+
+def test_api_bootstrap_returns_404_when_empty(flask_client):
+    client, _ = flask_client
+    resp = client.get("/api/bootstrap")
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["snapshots"] == []
+    assert body["node_id"] == "node-test"
+
+
+def test_api_bootstrap_list_returns_summary(flask_client):
+    client, store = flask_client
+    store.ingest_bootstrap_archive({
+        "node_id": "node-test", "agent_id": "main",
+        "content": "# hello", "first_session_id": "sess-1",
+    })
+    resp = client.get("/api/bootstrap")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body["snapshots"]) == 1
+    snap = body["snapshots"][0]
+    # Summary endpoint MUST NOT include the heavy `content` field.
+    assert "content" not in snap
+    assert snap["first_session_id"] == "sess-1"
+    assert snap["agent_id"] == "main"
+    assert body["_source"] == "local_store"
+
+
+def test_api_bootstrap_detail_returns_full_content(flask_client):
+    client, store = flask_client
+    store.ingest_bootstrap_archive({
+        "node_id": "node-test", "agent_id": "main",
+        "content": "# DETAILED PAYLOAD",
+        "first_session_id": "sess-1",
+    })
+    resp = client.get("/api/bootstrap/main")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["snapshot"]["content"] == "# DETAILED PAYLOAD"
+    assert body["first_session_id"] == "sess-1"
+
+
+def test_api_bootstrap_detail_missing_agent_returns_404(flask_client):
+    client, store = flask_client
+    store.ingest_bootstrap_archive({
+        "node_id": "node-test", "agent_id": "main", "content": "# main",
+    })
+    resp = client.get("/api/bootstrap/subagent-99")
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["agent_id"] == "subagent-99"

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -267,7 +267,7 @@ def test_health_reports_size_and_count(store):
     h = store.health()
     assert h["event_count"] == 10
     assert h["size_bytes"] > 0
-    assert h["schema_version"] == 4
+    assert h["schema_version"] == 5
     assert h["ring_depth"] == 0
     assert h["ring_dropped_total"] == 0
 

--- a/tests/test_run_daemon_uniqueness.py
+++ b/tests/test_run_daemon_uniqueness.py
@@ -27,10 +27,11 @@ def test_run_daemon_resolves_to_live_definition():
 
     line = inspect.getsourcelines(sync.run_daemon)[1]
     # Threshold bumped 2026-05-13 (#1135) when the v3 underscore parser
-    # added ~326 lines above run_daemon. The shadow that prompted this
-    # test lived at ~5281 in the pre-cleanup file, so we keep a 200-line
-    # safety margin above the live def.
-    assert line < 5200, (
+    # added ~326 lines above run_daemon. Bumped again 2026-05-13 (#690)
+    # when the BOOTSTRAP.md capture helper added ~190 lines above
+    # run_daemon. The shadow that prompted this test lived at ~5281 in
+    # the pre-cleanup file, so we keep a generous margin above the live def.
+    assert line < 5400, (
         f"sync.run_daemon resolves to line {line}, but the live def lives "
         f"near the top of the file. A duplicate def has likely been "
         f"re-introduced further down -- check `grep -n '^def run_daemon' "


### PR DESCRIPTION
## Summary

Closes #690.

OpenClaw's ``BOOTSTRAP.md`` runs once at first startup to negotiate agent identity and then **self-deletes**. Without an external observer, that first-contact contract evaporates and there's no way to audit how a node came online. This PR adds a daemon-side capture so the artifact is preserved as a read-only "First Contact" record in DuckDB.

- New ``bootstrap_archive`` table (schema v5). Dedup on ``(node_id, agent_id, content_sha256)`` — a re-bootstrap with different content lands as a NEW row so the full first-contact history is preserved.
- New ``capture_bootstrap_if_present`` helper in ``clawmetry/sync.py``. Runs once at daemon startup (before any other helper can notice the file) and on every tick. Best-effort; failure is logged, never raised.
- New ``routes/bootstrap.py`` blueprint exposing:
  - ``GET /api/bootstrap`` — list snapshots (summary, no content) — 404 when empty
  - ``GET /api/bootstrap/<agent_id>`` — newest snapshot + full content — 404 when missing
- UI follow-up (panel in Brain / Memory tab) is intentionally deferred — spec flagged it low-priority for v1. The API is sufficient for the cloud dashboard to render the panel on its own.

## Test plan

- [x] ``tests/test_bootstrap_capture.py`` — 15 tests covering schema round-trip, dedup, content-change re-capture, empty-file skip, the capture helper end-to-end against a fake ``~/.openclaw`` layout, and the three HTTP endpoints.
- [x] ``tests/test_local_store.py`` — bumped ``schema_version`` assertion (4 → 5).
- [x] ``tests/test_run_daemon_uniqueness.py`` — bumped line-number threshold (capture helper added ~190 lines above ``run_daemon``).
- [x] Full local-store regression suite (143 tests across 11 files) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)