### PR TITLE
feat(daemon): persist errors as DuckDB events; health card reads DuckDB (DuckDB-first for #1133 layer 4)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -186,6 +186,152 @@ if not log.handlers:
     log.propagate = False
 
 
+# ── Daemon-error → DuckDB event handler (PRD #1133 layer 4, daemon side) ────
+#
+# Why: PR #1139 surfaced daemon errors on the System Health card by parsing
+# ``~/.clawmetry/sync.log`` text on every /api/system-health call — a clear
+# violation of the DuckDB-first rule (memory feedback_duckdb_first_rule.md).
+# This handler tees every ERROR-level log line into a structured
+# ``daemon.error`` event row in the local DuckDB so the read side can do a
+# single indexed query instead of re-tailing the log on each request.
+#
+# Rate-limit: at most one row per (first-80-chars-of-message, 60s bucket).
+# Important because the original ALERTS_EVAL_INTERVAL_SEC NameError fired
+# 4×/min on every install, and we don't want that pattern to spam DuckDB
+# 5,760 rows/day when one row/minute carries the same signal.
+#
+# Failure mode: any exception inside the handler is swallowed and counted —
+# the daemon must never crash because telemetry plumbing broke.
+
+import uuid as _uuid
+import socket as _socket
+
+_DAEMON_ERROR_AGENT_ID = "clawmetry-daemon"
+_DAEMON_ERROR_AGENT_TYPE = "clawmetry"
+_DAEMON_ERROR_EVENT_TYPE = "daemon.error"
+_DAEMON_ERROR_DEDUP_PREFIX_LEN = 80
+_DAEMON_ERROR_DEDUP_BUCKET_SEC = 60
+
+
+class _DaemonErrorDuckDBHandler(logging.Handler):
+    """Logging handler that mirrors ERROR records into DuckDB ``events``.
+
+    One row per (message-prefix, 60-second-bucket) — repeated identical
+    errors within the bucket are dropped so a 4×/min NameError doesn't
+    flood the table. The cap is enforced in-memory; we don't query
+    DuckDB to dedup (would defeat the point).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.ERROR)
+        # Map[prefix → last-emitted-bucket]. Single-process daemon, so a
+        # plain dict guarded by a Lock is fine. Bounded eviction below
+        # keeps memory flat under pathological churn.
+        self._last_emit: dict[str, int] = {}
+        self._lock = threading.Lock()
+        self._dropped = 0
+        self._emitted = 0
+        self._node_id_cache: str | None = None
+
+    def _node_id(self) -> str:
+        if self._node_id_cache:
+            return self._node_id_cache
+        try:
+            cfg = load_config()
+            nid = cfg.get("node_id") or _socket.gethostname() or "unknown"
+        except Exception:
+            nid = _socket.gethostname() or "unknown"
+        self._node_id_cache = str(nid)
+        return self._node_id_cache
+
+    def _should_emit(self, msg: str, now_ts: float) -> bool:
+        """Return True iff this prefix hasn't been emitted in the current
+        60-second bucket. Updates the bookkeeping atomically."""
+        prefix = (msg or "")[:_DAEMON_ERROR_DEDUP_PREFIX_LEN]
+        bucket = int(now_ts // _DAEMON_ERROR_DEDUP_BUCKET_SEC)
+        with self._lock:
+            last = self._last_emit.get(prefix)
+            if last == bucket:
+                self._dropped += 1
+                return False
+            self._last_emit[prefix] = bucket
+            # Bounded eviction — keep the table from growing unbounded if
+            # a misbehaving caller logs millions of unique error messages.
+            if len(self._last_emit) > 1024:
+                # Drop entries older than 2 buckets (~120s).
+                stale_cutoff = bucket - 2
+                for k in [k for k, v in self._last_emit.items() if v < stale_cutoff]:
+                    del self._last_emit[k]
+            return True
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+        try:
+            if record.levelno < logging.ERROR:
+                return
+            try:
+                msg = record.getMessage()
+            except Exception:
+                msg = str(getattr(record, "msg", ""))
+            now_ts = time.time()
+            if not self._should_emit(msg, now_ts):
+                return
+
+            exc_str: str | None = None
+            if record.exc_info:
+                try:
+                    exc_str = logging.Formatter().formatException(record.exc_info)
+                except Exception:
+                    exc_str = None
+
+            from clawmetry import local_store as _ls
+            store = _ls.get_store()
+            event = {
+                "id": _uuid.uuid4().hex,
+                "agent_id": _DAEMON_ERROR_AGENT_ID,
+                "agent_type": _DAEMON_ERROR_AGENT_TYPE,
+                "node_id": self._node_id(),
+                "event_type": _DAEMON_ERROR_EVENT_TYPE,
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "data": {
+                    "message": (msg or "")[:1000],
+                    "exception": (exc_str or "")[:2000] if exc_str else None,
+                    "logger": record.name,
+                },
+            }
+            store.ingest(event)
+            self._emitted += 1
+        except Exception:
+            # Never raise from a logging handler — would break the daemon's
+            # own error logging.
+            try:
+                self._dropped += 1
+            except Exception:
+                pass
+
+
+def install_daemon_error_event_handler(logger: logging.Logger | None = None) -> _DaemonErrorDuckDBHandler | None:
+    """Attach the DuckDB-mirroring handler to the daemon logger.
+
+    Idempotent: re-running won't add a second handler. Returns the handler
+    instance (so tests can introspect ``_emitted`` / ``_dropped``) or None
+    when installation fails — the daemon should keep running either way.
+    """
+    target = logger if logger is not None else log
+    for h in target.handlers:
+        if isinstance(h, _DaemonErrorDuckDBHandler):
+            return h  # type: ignore[return-value]
+    try:
+        h = _DaemonErrorDuckDBHandler()
+        target.addHandler(h)
+        return h
+    except Exception as e:  # pragma: no cover — defensive
+        try:
+            log.warning("install_daemon_error_event_handler failed: %s", e)
+        except Exception:
+            pass
+        return None
+
+
 # ── Encryption (AES-256-GCM) ─────────────────────────────────────────────────
 
 
@@ -5052,6 +5198,15 @@ def run_daemon() -> None:
     paths = detect_paths()
     enc = "🔒 E2E encrypted" if config.get("encryption_key") else "⚠️  unencrypted"
     log.info(f"Starting sync daemon — node={config['node_id']} → {INGEST_URL} ({enc})")
+
+    # ── Install daemon-error → DuckDB tee (PRD #1133 layer 4, daemon side) ──
+    # Must happen AFTER the start-banner so we don't tee that line as an
+    # event. Failure here is non-fatal — the read side keeps its sync.log
+    # fallback.
+    try:
+        install_daemon_error_event_handler()
+    except Exception as _e:
+        log.warning("daemon-error event handler: failed to install: %s", _e)
 
     # ── Startup sync: recent-first so Brain feed shows current activity ──
     send_heartbeat(config)

--- a/routes/health.py
+++ b/routes/health.py
@@ -129,35 +129,115 @@ def _parse_daemon_log_line(line):
     return ts_epoch, m.group("level"), m.group("msg")
 
 
-def compute_daemon_health(log_path=None, now=None):
-    """Read the tail of the daemon log and return a health summary dict.
+def _status_from_counts(errors_last_5min: int) -> str:
+    """Compute status pill from 5-min error count. PR #1139 thresholds."""
+    if errors_last_5min > 30:
+        return "broken"
+    if errors_last_5min > 0:
+        return "degraded"
+    return "healthy"
 
-    Returns the structure documented in PRD #1133 layer 4:
 
-        {
-            "log_path": "<absolute path>",
-            "errors_last_5min": int,
-            "errors_last_1h": int,
-            "last_error_message": str | None,
-            "last_error_ts": ISO-8601 str | None,
-            "status": "healthy" | "degraded" | "broken",
-            "log_present": bool,
-        }
+def _try_local_store_daemon_health(now_ts: float, log_path: str):
+    """DuckDB-first path: query ``events`` for ``daemon.error`` rows in the
+    last hour and aggregate the same fields the log parser produces.
 
-    Status thresholds (per PRD): >30 errors in 5 min → ``broken``,
-    >0 → ``degraded``, else ``healthy``. Missing/empty log → ``healthy``
-    so a fresh install doesn't flash red.
+    Returns the summary dict on success, or ``None`` if the local store is
+    unreachable / has zero rows in the window (so the caller can fall back
+    to log-tail parsing).
     """
-    path = log_path or _default_daemon_log_path()
-    now_ts = now if now is not None else time.time()
+    cutoff_1h_iso = datetime.fromtimestamp(
+        now_ts - 60 * 60, tz=timezone.utc
+    ).isoformat()
+    cutoff_5m_ts = now_ts - 5 * 60
+
+    rows = None
+    # Cross-process safe path (daemon owns the writer lock under the
+    # standard install — direct opens fail). Same pattern as
+    # ``_try_local_store_heatmap``.
+    try:
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon(
+            "query_events",
+            event_type="daemon.error",
+            agent_id="clawmetry-daemon",
+            since=cutoff_1h_iso,
+            limit=5000,
+        )
+    except Exception:
+        rows = None
+    if rows is None:
+        # Single-process fallback (tests / dev mode).
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_events(
+                event_type="daemon.error",
+                agent_id="clawmetry-daemon",
+                since=cutoff_1h_iso,
+                limit=5000,
+            )
+        except Exception:
+            return None
+    if not rows:
+        return None
+
+    errors_5m = 0
+    errors_1h = 0
+    last_err_ts = None
+    last_err_msg = None
+    for ev in rows:
+        ts = ev.get("ts")
+        if not ts:
+            continue
+        try:
+            dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        except Exception:
+            continue
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        ev_ts = dt.timestamp()
+        errors_1h += 1
+        if ev_ts >= cutoff_5m_ts:
+            errors_5m += 1
+        if last_err_ts is None or ev_ts >= last_err_ts:
+            last_err_ts = ev_ts
+            data = ev.get("data") or {}
+            if isinstance(data, dict):
+                last_err_msg = data.get("message") or None
+            elif isinstance(data, str):
+                last_err_msg = data
+
     summary = {
-        "log_path": path,
+        "log_path": log_path,
+        "errors_last_5min": errors_5m,
+        "errors_last_1h": errors_1h,
+        "last_error_message": (last_err_msg or "")[:500] if last_err_msg else None,
+        "last_error_ts": (
+            datetime.fromtimestamp(last_err_ts, tz=timezone.utc).isoformat()
+            if last_err_ts is not None
+            else None
+        ),
+        "status": _status_from_counts(errors_5m),
+        "log_present": os.path.exists(log_path),
+        "_source": "local_store",
+    }
+    return summary
+
+
+def _compute_daemon_health_from_log(log_path: str, now_ts: float):
+    """Legacy log-tail parser. Retained as a fallback for fresh installs
+    that don't yet have ``daemon.error`` rows in DuckDB (pre-this-PR data
+    or first-boot before the handler fires)."""
+    summary = {
+        "log_path": log_path,
         "errors_last_5min": 0,
         "errors_last_1h": 0,
         "last_error_message": None,
         "last_error_ts": None,
         "status": "healthy",
-        "log_present": os.path.exists(path),
+        "log_present": os.path.exists(log_path),
+        "_source": "sync_log",
     }
     if not summary["log_present"]:
         return summary
@@ -166,7 +246,7 @@ def compute_daemon_health(log_path=None, now=None):
     cutoff_1h = now_ts - 60 * 60
     last_err_ts = None
     last_err_msg = None
-    for line in _tail_lines(path):
+    for line in _tail_lines(log_path):
         parsed = _parse_daemon_log_line(line)
         if not parsed:
             continue
@@ -182,19 +262,53 @@ def compute_daemon_health(log_path=None, now=None):
             last_err_msg = msg
 
     if last_err_ts is not None:
-        # Render in UTC so the dashboard can reason about it consistently.
         summary["last_error_ts"] = (
             datetime.fromtimestamp(last_err_ts, tz=timezone.utc).isoformat()
         )
-        # Truncate to 500 chars at the parser layer; UI re-truncates to 200
-        # for display. Keeps the API payload bounded for chatty errors.
         summary["last_error_message"] = (last_err_msg or "")[:500]
 
-    if summary["errors_last_5min"] > 30:
-        summary["status"] = "broken"
-    elif summary["errors_last_5min"] > 0:
-        summary["status"] = "degraded"
+    summary["status"] = _status_from_counts(summary["errors_last_5min"])
     return summary
+
+
+def compute_daemon_health(log_path=None, now=None):
+    """Return a daemon health summary dict, sourced from DuckDB first.
+
+    Returns the structure documented in PRD #1133 layer 4:
+
+        {
+            "log_path": "<absolute path>",
+            "errors_last_5min": int,
+            "errors_last_1h": int,
+            "last_error_message": str | None,
+            "last_error_ts": ISO-8601 str | None,
+            "status": "healthy" | "degraded" | "broken",
+            "log_present": bool,
+            "_source": "local_store" | "sync_log",
+        }
+
+    Status thresholds (per PRD): >30 errors in 5 min → ``broken``,
+    >0 → ``degraded``, else ``healthy``. Missing/empty log + zero DuckDB
+    rows → ``healthy`` so a fresh install doesn't flash red.
+
+    Source order:
+      1. DuckDB ``events`` table (event_type='daemon.error') — populated
+         by the daemon-side handler in ``clawmetry/sync.py``. This is the
+         DuckDB-first canonical path.
+      2. ``~/.clawmetry/sync.log`` tail-parser — fallback for fresh
+         installs that don't yet have ``daemon.error`` rows but DO have
+         pre-existing ERROR lines in the log file.
+    """
+    path = log_path or _default_daemon_log_path()
+    now_ts = now if now is not None else time.time()
+
+    # DuckDB-first.
+    duckdb_summary = _try_local_store_daemon_health(now_ts, path)
+    if duckdb_summary is not None:
+        return duckdb_summary
+
+    # Fallback: log-tail parser (pre-#1133-layer-4 behavior).
+    return _compute_daemon_health_from_log(path, now_ts)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_daemon_error_event_pipeline.py
+++ b/tests/test_daemon_error_event_pipeline.py
@@ -1,0 +1,326 @@
+"""Tests for the daemon-error → DuckDB → health-card pipeline (PRD #1133 layer 4).
+
+PR #1139 surfaced daemon errors on the System Health card by parsing
+``~/.clawmetry/sync.log`` text on every ``/api/system-health`` call — a
+DuckDB-first-rule violation. This follow-up:
+
+  1. Has the daemon ALSO write each ERROR-level log record into the local
+     DuckDB ``events`` table as ``event_type='daemon.error'`` rows.
+  2. Has ``routes.health.compute_daemon_health()`` query DuckDB first and
+     fall back to the legacy log-tail parser only when no DuckDB rows exist
+     (so fresh installs / pre-this-fix data still surface).
+  3. Rate-limits the daemon write: at most one row per
+     (first-80-chars-of-message, 60-second-bucket), so the
+     ``ALERTS_EVAL_INTERVAL_SEC`` regression that fired 4×/min cannot
+     stamp 5,760 rows/day into DuckDB.
+
+Tests:
+
+* TestHandler — direct unit tests for ``_DaemonErrorDuckDBHandler``:
+  basic ingest, INFO/WARNING ignored, exception capture, rate-limit dedup.
+* TestPipeline — end-to-end: 3 ``log.error(...)`` calls → 3 DuckDB rows.
+* TestComputeDaemonHealth — read side reads DuckDB and returns
+  ``_source='local_store'`` with correct counts.
+
+No Flask server, no network, no sleep. ~150ms total.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+import time
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+# ── Fixture: isolated DuckDB + reloaded sync module ─────────────────────────
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Fresh DuckDB per test + reloaded ``clawmetry.sync`` + ``routes.health``
+    so handler installation and read-side both target the tmp file.
+
+    The Python ``logging`` module returns the SAME logger instance across
+    importlib.reload() calls (loggers are process-singletons keyed by
+    name), so we explicitly strip the daemon logger's handlers before each
+    test to avoid handler instances pointing at the previous test's
+    DuckDB store leaking into the current test.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "clawmetry.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    # Also point the daemon's CONFIG_DIR at tmp so load_config() in the
+    # handler's node_id resolution doesn't pull the dev machine's real
+    # ~/.clawmetry/config.json (which would leak the host's node_id into
+    # rows that the read side then ignores).
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Strip pre-existing daemon-error handlers from prior tests (logging
+    # loggers survive importlib.reload).
+    daemon_log = logging.getLogger("clawmetry-sync")
+    pre_existing = list(daemon_log.handlers)
+    for h in pre_existing:
+        if type(h).__name__ == "_DaemonErrorDuckDBHandler":
+            daemon_log.removeHandler(h)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as sync_mod
+    importlib.reload(sync_mod)
+    import routes.health as hp
+    importlib.reload(hp)
+    yield ls, sync_mod, hp
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+    # Tear down our handler so the next test gets a clean logger.
+    for h in list(daemon_log.handlers):
+        if type(h).__name__ == "_DaemonErrorDuckDBHandler":
+            daemon_log.removeHandler(h)
+
+
+def _wait_flush(store, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.01)
+
+
+# ── Handler unit tests ─────────────────────────────────────────────────────
+
+
+class TestHandler:
+    def test_install_is_idempotent(self, env):
+        ls, sync_mod, _ = env
+        h1 = sync_mod.install_daemon_error_event_handler()
+        h2 = sync_mod.install_daemon_error_event_handler()
+        assert h1 is not None and h2 is not None
+        assert h1 is h2  # second call returns the same instance
+
+    def test_info_and_warning_records_are_ignored(self, env):
+        ls, sync_mod, _ = env
+        sync_mod.install_daemon_error_event_handler()
+        sync_mod.log.info("hello world")
+        sync_mod.log.warning("yellow alert")
+        _wait_flush(ls.get_store())
+        rows = ls.get_store().query_events(event_type="daemon.error", limit=100)
+        assert rows == []
+
+    def test_error_writes_one_row(self, env):
+        ls, sync_mod, _ = env
+        sync_mod.install_daemon_error_event_handler()
+        sync_mod.log.error("Sync cycle error: NameError ALERTS_EVAL_INTERVAL_SEC")
+        _wait_flush(ls.get_store())
+        rows = ls.get_store().query_events(event_type="daemon.error", limit=100)
+        assert len(rows) == 1
+        ev = rows[0]
+        assert ev["event_type"] == "daemon.error"
+        assert ev["agent_id"] == "clawmetry-daemon"
+        assert ev["agent_type"] == "clawmetry"
+        assert ev["data"]["message"].startswith("Sync cycle error:")
+
+    def test_exception_info_is_captured(self, env):
+        ls, sync_mod, _ = env
+        sync_mod.install_daemon_error_event_handler()
+        try:
+            raise RuntimeError("boom in tool dispatch")
+        except RuntimeError:
+            sync_mod.log.exception("tool dispatch failed")
+        _wait_flush(ls.get_store())
+        rows = ls.get_store().query_events(event_type="daemon.error", limit=100)
+        assert len(rows) == 1
+        data = rows[0]["data"]
+        assert "tool dispatch failed" in data["message"]
+        assert data.get("exception")
+        assert "RuntimeError" in data["exception"]
+        assert "boom in tool dispatch" in data["exception"]
+
+
+# ── Rate-limit / dedup tests ───────────────────────────────────────────────
+
+
+class TestRateLimit:
+    def test_30_identical_errors_in_one_bucket_writes_one_row(self, env):
+        """The original ALERTS_EVAL_INTERVAL_SEC bug fired 4×/min; the
+        DuckDB tee must collapse that to one row per 60s bucket so a
+        single regression doesn't stamp ~6k rows/day."""
+        ls, sync_mod, _ = env
+        h = sync_mod.install_daemon_error_event_handler()
+        for _ in range(30):
+            sync_mod.log.error("Sync cycle error: name 'ALERTS_EVAL_INTERVAL_SEC' is not defined")
+        _wait_flush(ls.get_store())
+        rows = ls.get_store().query_events(event_type="daemon.error", limit=100)
+        assert len(rows) == 1
+        # Dropped count should reflect the 29 deduped attempts.
+        assert h._dropped >= 29
+        assert h._emitted == 1
+
+    def test_distinct_messages_each_get_a_row(self, env):
+        ls, sync_mod, _ = env
+        sync_mod.install_daemon_error_event_handler()
+        for i in range(5):
+            sync_mod.log.error("error variant %d details here", i)
+        _wait_flush(ls.get_store())
+        rows = ls.get_store().query_events(event_type="daemon.error", limit=100)
+        assert len(rows) == 5
+
+    def test_same_prefix_next_bucket_writes_a_new_row(self, env):
+        """Manually advance the handler's bucket so we don't need to sleep
+        60s. Same message, different bucket → two rows (carries the
+        'errors haven't stopped' signal across the gap).
+
+        We pick a bucket-aligned anchor (1_000_020 // 60 == 16667 exactly)
+        so both ``+0`` and ``+59`` land in the same 60s window.
+        """
+        ls, sync_mod, _ = env
+        h = sync_mod.install_daemon_error_event_handler()
+        anchor = float(60 * 16667)  # 1_000_020.0
+        msg = "repeating cron loop failure"
+        assert h._should_emit(msg, anchor) is True
+        # Within same 60s window → blocked.
+        assert h._should_emit(msg, anchor + 30.0) is False
+        assert h._should_emit(msg, anchor + 59.9) is False
+        # Next bucket → allowed.
+        assert h._should_emit(msg, anchor + 60.0) is True
+
+    def test_dedup_uses_first_80_chars(self, env):
+        """Two messages with identical 80-char prefixes but different
+        suffixes (e.g. a trailing UUID) should still dedup — the prefix
+        is the signal, suffix noise."""
+        ls, sync_mod, _ = env
+        h = sync_mod.install_daemon_error_event_handler()
+        prefix = "x" * 80
+        assert h._should_emit(prefix + "-aaa", 1.0) is True
+        assert h._should_emit(prefix + "-bbb", 30.0) is False
+
+
+# ── End-to-end pipeline: 3 log.error() → 3 DuckDB rows → health card ────────
+
+
+class TestPipeline:
+    def test_three_distinct_errors_land_in_duckdb(self, env):
+        ls, sync_mod, _ = env
+        sync_mod.install_daemon_error_event_handler()
+        sync_mod.log.error("first cycle error")
+        sync_mod.log.error("second cycle error")
+        sync_mod.log.error("third cycle error")
+        _wait_flush(ls.get_store())
+        rows = ls.get_store().query_events(event_type="daemon.error", limit=100)
+        assert len(rows) == 3
+        msgs = sorted([r["data"]["message"] for r in rows])
+        assert msgs == ["first cycle error", "second cycle error", "third cycle error"]
+        for r in rows:
+            assert r["event_type"] == "daemon.error"
+            assert r["agent_id"] == "clawmetry-daemon"
+
+    def test_handler_swallows_local_store_exceptions(self, env, monkeypatch):
+        """If local_store.ingest() raises (writer locked, DuckDB closed,
+        etc.) the daemon must keep logging — telemetry is best-effort."""
+        ls, sync_mod, _ = env
+        h = sync_mod.install_daemon_error_event_handler()
+
+        # Patch ingest to raise.
+        store = ls.get_store()
+        def _boom(*a, **kw):
+            raise RuntimeError("simulated DuckDB outage")
+        monkeypatch.setattr(store, "ingest", _boom)
+
+        # Force a different prefix per call so dedup doesn't mask the test.
+        sync_mod.log.error("alpha error path")
+        sync_mod.log.error("beta error path")
+        # No exception escapes; dropped count tracks the failures.
+        assert h._dropped >= 2
+
+
+# ── Read side: compute_daemon_health() reads DuckDB ─────────────────────────
+
+
+class TestComputeDaemonHealth:
+    def _seed(self, store, *, n_recent=0, n_old=0, last_msg="latest error"):
+        """Seed DuckDB with daemon.error events; ``recent`` = within 5 min,
+        ``old`` = between 5 min and 60 min ago. ``last_msg`` is attached to
+        the single most-recent event.
+
+        Recent events are spaced 1 second apart so up to 290 fit inside the
+        5-min window (matters for the broken-threshold test).
+        """
+        now = datetime.now(timezone.utc)
+        for i in range(n_recent):
+            ts = now - timedelta(seconds=1 + i)
+            store.ingest({
+                "id": f"ev-recent-{i}",
+                "node_id": "test-node",
+                "agent_id": "clawmetry-daemon",
+                "agent_type": "clawmetry",
+                "event_type": "daemon.error",
+                "ts": ts.isoformat(),
+                "data": {"message": last_msg if i == 0 else f"recent err {i}"},
+            })
+        for i in range(n_old):
+            ts = now - timedelta(minutes=10 + i)
+            store.ingest({
+                "id": f"ev-old-{i}",
+                "node_id": "test-node",
+                "agent_id": "clawmetry-daemon",
+                "agent_type": "clawmetry",
+                "event_type": "daemon.error",
+                "ts": ts.isoformat(),
+                "data": {"message": f"old err {i}"},
+            })
+        _wait_flush(store)
+
+    def test_reads_counts_from_duckdb(self, env):
+        ls, _sm, hp = env
+        store = ls.get_store()
+        self._seed(store, n_recent=3, n_old=4, last_msg="latest bug")
+        out = hp.compute_daemon_health()
+        assert out["_source"] == "local_store"
+        assert out["errors_last_5min"] == 3
+        assert out["errors_last_1h"] == 7
+        assert out["last_error_message"] == "latest bug"
+        assert out["status"] == "degraded"
+        assert out["last_error_ts"] is not None
+        assert "T" in out["last_error_ts"]
+
+    def test_zero_rows_falls_back_to_log_tail(self, env, tmp_path):
+        ls, _sm, hp = env
+        # No DuckDB rows. Write a log file with one ERROR line.
+        log_path = tmp_path / "sync.log"
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S,000")
+        log_path.write_text(
+            f"{ts} [clawmetry-sync] ERROR fallback-source probe\n", encoding="utf-8"
+        )
+        out = hp.compute_daemon_health(log_path=str(log_path))
+        # No DuckDB rows → fallback path tagged _source='sync_log'.
+        assert out["_source"] == "sync_log"
+        assert out["errors_last_5min"] == 1
+        assert out["last_error_message"] == "fallback-source probe"
+
+    def test_50_recent_errors_is_broken_via_duckdb(self, env):
+        ls, _sm, hp = env
+        store = ls.get_store()
+        self._seed(store, n_recent=35)
+        out = hp.compute_daemon_health()
+        assert out["_source"] == "local_store"
+        assert out["errors_last_5min"] == 35
+        assert out["status"] == "broken"
+
+    def test_only_old_errors_is_healthy_5min_but_degraded_1h(self, env):
+        ls, _sm, hp = env
+        store = ls.get_store()
+        self._seed(store, n_old=5)
+        out = hp.compute_daemon_health()
+        assert out["_source"] == "local_store"
+        assert out["errors_last_5min"] == 0
+        assert out["errors_last_1h"] == 5
+        # No 5-min errors → status is healthy (matches PR #1139 thresholds).
+        assert out["status"] == "healthy"
+        # last_error_message still surfaces so the card can show "had errors".
+        assert out["last_error_message"] is not None


### PR DESCRIPTION
## Why

PR #1139 surfaced daemon errors on the System Health card by **parsing
`~/.clawmetry/sync.log` text on every `/api/system-health` request** — a
clear violation of the DuckDB-first rule
(`feedback_duckdb_first_rule.md`). The daemon ALREADY logs the errors;
it just doesn't write structured rows. This follow-up wires the
DuckDB-first canonical path so the read side does one indexed query
instead of re-tailing the log on each call.

## What

**Daemon side (`clawmetry/sync.py`)**
- New `_DaemonErrorDuckDBHandler` (subclass of `logging.Handler`,
  level=`ERROR`) tees every ERROR record into the local DuckDB
  `events` table as:
  ```python
  {
    "id": uuid4().hex,
    "agent_id": "clawmetry-daemon",
    "agent_type": "clawmetry",
    "event_type": "daemon.error",
    "ts": iso_now(),
    "data": {"message": <msg>, "exception": <traceback_or_None>, "logger": ...},
  }
  ```
- **Rate-limit**: at most one row per (`message[:80]`, 60-second-bucket).
  The original `ALERTS_EVAL_INTERVAL_SEC` NameError fired 4×/min; without
  this cap that pattern would stamp ~5,760 rows/day for a single
  regression. Dedup map is in-memory, bounded-eviction at 1024 entries.
- Handler is installed via `install_daemon_error_event_handler()` from
  `run_daemon()` right after the start banner. Idempotent.
- Failure modes (ingest raises, DuckDB locked, etc.) are swallowed and
  counted on the handler — the daemon must never crash because
  telemetry plumbing broke.

**Read side (`routes/health.py`)**
- `compute_daemon_health()` is now DuckDB-first:
  1. `_try_local_store_daemon_health()` queries
     `query_events(event_type='daemon.error', agent_id='clawmetry-daemon', since=now-1h)`
     via `routes.local_query.local_store_via_daemon` (cross-process)
     with a single-process fallback to `local_store.get_store()` (tests +
     dev mode).
  2. If DuckDB returns ≥1 row, aggregate `errors_last_5min` /
     `errors_last_1h` / `last_error_message` / `last_error_ts` /
     `status` and tag the response `_source='local_store'`.
  3. Otherwise fall through to the legacy `_tail_lines(sync.log)` path
     (now `_compute_daemon_health_from_log()`, tagged `_source='sync_log'`).
     This handles fresh installs + pre-this-PR data — the user still
     sees the silent NameError on a clean machine.
- Same 5-min / 1-hour windows and `>30 → broken`, `>0 → degraded`,
  else `healthy` thresholds. Response shape unchanged except for the
  new `_source` field.

## Tests

`tests/test_daemon_error_event_pipeline.py` — **14 pure-unit tests**, no
server / network / sleep:

| Class | Test | What |
|---|---|---|
| TestHandler | install_is_idempotent | second install returns same instance |
| TestHandler | info_and_warning_records_are_ignored | only ERROR ingests |
| TestHandler | error_writes_one_row | shape: agent_id / agent_type / event_type / data.message |
| TestHandler | exception_info_is_captured | `log.exception()` → traceback in `data.exception` |
| TestRateLimit | 30_identical_errors_in_one_bucket_writes_one_row | the headline contract |
| TestRateLimit | distinct_messages_each_get_a_row | only IDENTICAL prefixes dedup |
| TestRateLimit | same_prefix_next_bucket_writes_a_new_row | manual time advance |
| TestRateLimit | dedup_uses_first_80_chars | suffix-noise doesn't bust the cap |
| TestPipeline | three_distinct_errors_land_in_duckdb | E2E `log.error()` → DuckDB |
| TestPipeline | handler_swallows_local_store_exceptions | DuckDB outage ≠ daemon crash |
| TestComputeDaemonHealth | reads_counts_from_duckdb | `_source='local_store'` + counts |
| TestComputeDaemonHealth | zero_rows_falls_back_to_log_tail | fresh-install path |
| TestComputeDaemonHealth | 50_recent_errors_is_broken_via_duckdb | status threshold via DuckDB |
| TestComputeDaemonHealth | only_old_errors_is_healthy_5min_but_degraded_1h | window arithmetic |

## Test plan

- [x] `python3 -m pytest tests/test_daemon_error_event_pipeline.py -q` → 14 passed in 0.59s
- [x] `python3 -m pytest tests/test_daemon_health_endpoint.py -q` → 20 passed (PR #1139 contract preserved)
- [x] `python3 -m pytest tests/test_health_local_store.py tests/test_local_store*.py -q` → 79 passed (no regressions)
- [x] `python3 -c "import ast; ast.parse(open('clawmetry/sync.py').read()); ast.parse(open('routes/health.py').read())"` → OK
- [x] `python3 -c "from clawmetry import sync; sync.install_daemon_error_event_handler"` → callable
- [ ] Manual: run daemon, kill it with a synthetic NameError, verify `daemon.error` rows appear in `~/.clawmetry/clawmetry.duckdb`
- [ ] Manual: confirm dashboard `/api/system-health` returns `daemon._source='local_store'` after the daemon writes ≥1 row

## References

- PRD #1133 — daemon-error visibility, layer 4
- PR #1139 — the read side this PR makes DuckDB-first
- Memory: `feedback_duckdb_first_rule.md` — every read surface must
  hit DuckDB, not raw files

🤖 Generated with [Claude Code](https://claude.com/claude-code)