### PR TITLE
feat(crons): ingest cron-run jsonl into DuckDB; API reads from DuckDB (DuckDB-first rule for #605 followup)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -385,6 +385,42 @@ _DDL = [
         updated_at        BIGINT NOT NULL
     )
     """,
+    # Issue #605 follow-up (DuckDB-first rule) — cron-run timeline storage.
+    # One row per JSONL line in ``~/.openclaw/cron/runs/<jobId>.jsonl``. The
+    # daemon's ``sync_cron_runs`` helper scans those files every cycle and
+    # upserts rows here so ``/api/crons/<jobId>/runs`` can read from the
+    # columnar store instead of re-parsing JSONL on every request.
+    #
+    # Schema rationale: we keep a dedicated table (not ``events``) because
+    # ``delivered_at`` / ``next_run_at`` are first-class columns and the
+    # cron-timeline UI's filter + sort patterns
+    # (``WHERE job_id=? ORDER BY started_at DESC``) want a primary-key prefix
+    # match, not a substring scan over ``data`` blobs. ``id`` is the dedup
+    # key — synthesised from ``job_id + ts`` when the JSONL doesn't include
+    # one, so re-ingestion of the same line is a no-op.
+    """
+    CREATE TABLE IF NOT EXISTS cron_runs (
+        id              VARCHAR PRIMARY KEY,
+        node_id         VARCHAR,
+        agent_type      VARCHAR NOT NULL DEFAULT 'openclaw',
+        agent_id        VARCHAR NOT NULL DEFAULT 'main',
+        job_id          VARCHAR NOT NULL,
+        started_at      VARCHAR,
+        ended_at        VARCHAR,
+        duration_ms     INTEGER,
+        status          VARCHAR,
+        error_message   VARCHAR,
+        token_count     INTEGER,
+        cost_usd        DOUBLE,
+        delivered_at    VARCHAR,
+        next_run_at     VARCHAR,
+        raw_jsonl_line  VARCHAR,
+        data            BLOB,
+        created_at      BIGINT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_cron_runs_job_id     ON cron_runs(job_id, started_at)",
+    "CREATE INDEX IF NOT EXISTS idx_cron_runs_started_at ON cron_runs(started_at)",
     """
     CREATE TABLE IF NOT EXISTS schema_version (
         version    INTEGER PRIMARY KEY,
@@ -950,6 +986,82 @@ class LocalStore:
                   bool(cron.get("enabled", True)),
                   cron.get("last_run_at"), cron.get("last_status"),
                   cron.get("next_run_at"), data_blob, now_ms])
+
+    def ingest_cron_run(self, run: dict[str, Any]) -> None:
+        """Upsert one cron-run row (issue #605 DuckDB follow-up).
+
+        Required: ``id`` and ``job_id``. Everything else is optional and
+        defaults to ``None`` / ``0``. Re-ingesting the same id is a no-op
+        which is exactly what we want — the sync daemon scans the JSONL
+        files with an offset cursor, but a restart that re-reads a few
+        bytes (or a JSONL writer that re-emits a line) must not produce
+        duplicate rows.
+
+        Stable id rule: the daemon synthesises ``f"{job_id}:{started_at}"``
+        when the JSONL line doesn't carry one. That keeps the dedup
+        deterministic across re-scans without depending on file offsets
+        for correctness (offsets are still tracked for skip-on-cycle
+        efficiency, but they're a performance hint, not the dedup key)."""
+        rid = run.get("id")
+        if not rid:
+            raise ValueError("cron_run must include 'id'")
+        job_id = run.get("job_id")
+        if not job_id:
+            raise ValueError("cron_run must include 'job_id'")
+        atype = run.get("agent_type") or "openclaw"
+        agent_id = run.get("agent_id") or "main"
+        # Anything callers stuffed in beyond the first-class columns ends up
+        # in the BLOB so we don't lose provenance. ``usage`` is the common
+        # one — gateway writers emit a dict with input/output token splits
+        # we'd otherwise drop.
+        first_class = {
+            "id", "job_id", "node_id", "agent_type", "agent_id",
+            "started_at", "ended_at", "duration_ms", "status",
+            "error_message", "token_count", "cost_usd",
+            "delivered_at", "next_run_at", "raw_jsonl_line",
+        }
+        data_blob = _to_blob({k: v for k, v in run.items()
+                              if k not in first_class})
+        # Coerce numeric fields defensively — JSONL writers have shipped
+        # strings, floats, and missing values across versions.
+        try:
+            duration_ms = int(run.get("duration_ms") or 0)
+        except (TypeError, ValueError):
+            duration_ms = 0
+        try:
+            token_count = int(run.get("token_count") or 0)
+        except (TypeError, ValueError):
+            token_count = 0
+        try:
+            cost_usd = float(run.get("cost_usd") or 0)
+        except (TypeError, ValueError):
+            cost_usd = 0.0
+        err_msg = run.get("error_message") or ""
+        if err_msg and not isinstance(err_msg, str):
+            err_msg = str(err_msg)
+        if err_msg and len(err_msg) > 2000:
+            err_msg = err_msg[:2000]
+        raw_line = run.get("raw_jsonl_line")
+        if raw_line is not None and not isinstance(raw_line, str):
+            raw_line = str(raw_line)
+        now_ms = int(time.time() * 1000)
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO cron_runs (
+                    id, node_id, agent_type, agent_id, job_id,
+                    started_at, ended_at, duration_ms, status, error_message,
+                    token_count, cost_usd, delivered_at, next_run_at,
+                    raw_jsonl_line, data, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO NOTHING
+            """, [
+                str(rid), run.get("node_id"), atype, agent_id, str(job_id),
+                run.get("started_at"), run.get("ended_at"),
+                duration_ms, run.get("status"), err_msg,
+                token_count, cost_usd,
+                run.get("delivered_at"), run.get("next_run_at"),
+                raw_line, data_blob, now_ms,
+            ])
 
     def ingest_subagent(self, sa: dict[str, Any]) -> None:
         """Upsert one subagent rollup row. Required: subagent_id."""
@@ -1788,6 +1900,64 @@ class LocalStore:
         cols = ["agent_type", "cron_id", "agent_id", "name", "schedule",
                 "enabled", "last_run_at", "last_status", "next_run_at",
                 "data", "updated_at"]
+        return _decode_data_blob_rows(self._fetch(sql, params), cols)
+
+    def query_cron_runs(
+        self,
+        *,
+        job_id: str | None = None,
+        agent_type: str | None = None,
+        agent_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Per-job cron-run timeline (issue #605 DuckDB follow-up).
+
+        Returns rows most-recent-first (``ORDER BY started_at DESC``). The
+        ``data`` BLOB carries the freeform per-run extras (``usage`` dict
+        with input/output token split, gateway-specific fields) and is
+        decoded back to a dict where possible — same shape contract as
+        ``query_crons``.
+
+        ``limit`` defaults to 50 (one page in the timeline UI) and is
+        clamped to ``[1, 500]``. Callers wanting a full sweep should
+        page; we deliberately keep the upper bound modest so a buggy
+        client can't yank megabytes of run history in one shot."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if job_id:
+            clauses.append("job_id = ?"); params.append(str(job_id))
+        if agent_type:
+            clauses.append("agent_type = ?"); params.append(agent_type)
+        if agent_id:
+            clauses.append("agent_id = ?"); params.append(agent_id)
+        if since:
+            clauses.append("started_at >= ?"); params.append(since)
+        if until:
+            clauses.append("started_at <= ?"); params.append(until)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        try:
+            lim = int(limit)
+        except (TypeError, ValueError):
+            lim = 50
+        lim = max(1, min(500, lim))
+        sql = f"""
+            SELECT id, node_id, agent_type, agent_id, job_id,
+                   started_at, ended_at, duration_ms, status, error_message,
+                   token_count, cost_usd, delivered_at, next_run_at,
+                   raw_jsonl_line, data, created_at
+            FROM cron_runs
+            {where}
+            ORDER BY started_at DESC, id DESC
+            LIMIT ?
+        """
+        params.append(lim)
+        cols = ["id", "node_id", "agent_type", "agent_id", "job_id",
+                "started_at", "ended_at", "duration_ms", "status",
+                "error_message", "token_count", "cost_usd",
+                "delivered_at", "next_run_at", "raw_jsonl_line",
+                "data", "created_at"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
 
     def query_subagents(

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -3700,6 +3700,220 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
     return 0
 
 
+# ── Cron-run JSONL → DuckDB ingest (issue #605 DuckDB follow-up) ─────────
+#
+# OpenClaw's cron writer appends one JSON record per run to
+# ``~/.openclaw/cron/runs/<jobId>.jsonl``. PR #1147 had the dashboard route
+# parse those files on every request; this helper moves the parse into the
+# sync daemon so the API can read from columnar DuckDB instead.
+#
+# Per-file offset tracking lives under ``state["cron_run_offsets"]`` so the
+# daemon only re-reads new bytes each cycle. Offsets that point past the
+# current file size (post-rotation, truncation) reset to 0 — the
+# ``INSERT OR IGNORE`` on the cron_runs table makes the catch-up scan a
+# no-op for already-stored rows.
+#
+# The function is deliberately resilient: any per-file or per-line failure
+# is logged at debug level and skipped, never raised. ClawMetry is
+# read-only-by-default; a malformed cron jsonl line must not break the
+# rest of the sync cycle.
+
+
+def _cron_run_dirs() -> list[Path]:
+    """Candidate ``cron/runs`` directories, in resolution order. Mirrors
+    ``routes/crons.py:_resolve_cron_runs_jsonl`` so the daemon picks up the
+    same files the API would have read.
+    """
+    roots: list[str] = []
+    data_dir = os.environ.get("OPENCLAW_DATA_DIR", "").strip()
+    if data_dir:
+        roots.append(os.path.expanduser(data_dir))
+    home = os.environ.get("OPENCLAW_HOME", "").strip()
+    if home:
+        roots.append(os.path.expanduser(home))
+    roots.append(_get_openclaw_dir())
+    roots.append(os.path.expanduser("~/.clawdbot"))
+    out: list[Path] = []
+    seen: set[str] = set()
+    for r in roots:
+        p = Path(r) / "cron" / "runs"
+        rp = str(p)
+        if rp in seen:
+            continue
+        seen.add(rp)
+        if p.exists() and p.is_dir():
+            out.append(p)
+    return out
+
+
+def _parse_cron_run_line(line: str, job_id: str, node_id: str) -> dict | None:
+    """Parse one JSONL line into the ``LocalStore.ingest_cron_run`` shape.
+
+    Returns ``None`` on malformed JSON or non-dict payloads. The local
+    store dedups by ``id``; when the writer didn't supply one we
+    synthesise it from ``job_id`` + ``started_at`` so re-reads remain
+    idempotent.
+    """
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        obj = json.loads(line)
+    except Exception:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    # Field-name normalisation matches the older
+    # ``routes/crons.py:_read_cron_run_lines`` so OpenClaw writers shipped
+    # by every gateway version round-trip cleanly.
+    started_at = (
+        obj.get("started_at")
+        or obj.get("startedAt")
+        or obj.get("ts")
+        or obj.get("timestamp")
+    )
+    ended_at = obj.get("ended_at") or obj.get("endedAt")
+    duration_ms = obj.get("duration_ms") or obj.get("durationMs") or obj.get("duration")
+    status = obj.get("status") or obj.get("result") or "unknown"
+    err = obj.get("error") or obj.get("err") or obj.get("error_message") or ""
+    if err and not isinstance(err, str):
+        err = str(err)
+    usage = obj.get("usage") if isinstance(obj.get("usage"), dict) else {}
+    token_count = (
+        obj.get("token_count")
+        or obj.get("tokens")
+        or (usage.get("total_tokens") if isinstance(usage, dict) else None)
+        or (usage.get("totalTokens") if isinstance(usage, dict) else None)
+    )
+    cost_usd = obj.get("cost_usd") or obj.get("costUsd")
+    delivered_at = obj.get("delivered_at") or obj.get("deliveredAt")
+    if not delivered_at and isinstance(obj.get("deliveryStatus"), dict):
+        delivered_at = obj["deliveryStatus"].get("deliveredAt")
+    next_run_at = (
+        obj.get("next_run_at")
+        or obj.get("nextRunAt")
+        or obj.get("nextRunAtMs")
+    )
+    # Coerce timestamps to ISO strings — the DuckDB column is VARCHAR
+    # because the gateway writer hasn't been consistent about epoch-ms
+    # vs ISO-8601 (issue #605 has examples of both). Keeping the column
+    # opaque lets us re-parse on read without a schema change.
+    def _norm_ts(v: Any) -> str | None:
+        if v is None:
+            return None
+        if isinstance(v, (int, float)):
+            return str(int(v))
+        return str(v)
+    rid = obj.get("id") or obj.get("run_id") or obj.get("runId")
+    if not rid:
+        rid = f"{job_id}:{_norm_ts(started_at) or ''}"
+    run = {
+        "id": str(rid),
+        "node_id": node_id,
+        "job_id": job_id,
+        "agent_type": "openclaw",
+        "started_at": _norm_ts(started_at),
+        "ended_at": _norm_ts(ended_at),
+        "duration_ms": duration_ms,
+        "status": str(status) if status is not None else None,
+        "error_message": err,
+        "token_count": token_count,
+        "cost_usd": cost_usd,
+        "delivered_at": _norm_ts(delivered_at),
+        "next_run_at": _norm_ts(next_run_at),
+        "raw_jsonl_line": line[:8000],
+        # Preserve the freeform payload (usage dict, gateway extras) so
+        # ``query_cron_runs`` callers can introspect input/output token
+        # splits without losing fidelity.
+        "usage": usage,
+    }
+    return run
+
+
+def sync_cron_runs(config: dict, state: dict, paths: dict) -> int:
+    """Ingest new lines from ``~/.openclaw/cron/runs/*.jsonl`` into
+    ``cron_runs`` in the local DuckDB store.
+
+    Returns the number of rows newly ingested. Idempotent: lines already
+    in the table (matched on the synthesised ``id``) are skipped by the
+    ``ON CONFLICT DO NOTHING`` clause in ``LocalStore.ingest_cron_run``.
+    Per-file byte offsets are persisted in ``state["cron_run_offsets"]``
+    so subsequent cycles only read appended bytes.
+
+    Failure modes (all degrade silently):
+      * ``local_store`` not importable → return 0, no state mutation.
+      * ``~/.openclaw/cron/runs`` missing → return 0.
+      * Single file unreadable / line malformed → skip that file/line,
+        keep going.
+    """
+    try:
+        from clawmetry import local_store as _ls
+    except Exception as e:
+        log.debug("sync_cron_runs: local_store unavailable: %s", e)
+        return 0
+
+    node_id = config.get("node_id", "") if isinstance(config, dict) else ""
+    offsets: dict = state.setdefault("cron_run_offsets", {})
+    runs_dirs = _cron_run_dirs()
+    if not runs_dirs:
+        return 0
+
+    try:
+        store = _ls.get_store()
+    except Exception as e:
+        log.debug("sync_cron_runs: get_store failed: %s", e)
+        return 0
+
+    n_ingested = 0
+    for runs_dir in runs_dirs:
+        try:
+            jsonl_files = sorted(runs_dir.glob("*.jsonl"))
+        except OSError:
+            continue
+        for fpath in jsonl_files:
+            try:
+                job_id = fpath.stem  # filename without ``.jsonl``
+                if not job_id:
+                    continue
+                # Per-file offset key includes the parent dir so two
+                # candidate roots don't collide on the same jobId.
+                key = f"{runs_dir}/{fpath.name}"
+                last_offset = int(offsets.get(key, 0))
+                try:
+                    size = fpath.stat().st_size
+                except OSError:
+                    continue
+                # Truncation / rotation guard: an offset past EOF means
+                # the file was rewritten — reset to 0 and rely on
+                # INSERT OR IGNORE for dedup.
+                if last_offset > size:
+                    last_offset = 0
+                if last_offset == size:
+                    continue
+                with open(fpath, "r", errors="replace") as fh:
+                    fh.seek(last_offset)
+                    for line in fh:
+                        run = _parse_cron_run_line(line, job_id, node_id)
+                        if run is None:
+                            continue
+                        try:
+                            store.ingest_cron_run(run)
+                            n_ingested += 1
+                        except Exception as e_in:
+                            log.debug(
+                                "sync_cron_runs: ingest failed for %s: %s",
+                                job_id, e_in,
+                            )
+                    new_offset = fh.tell()
+                offsets[key] = new_offset
+            except Exception as e_f:
+                log.debug("sync_cron_runs: file %s failed: %s", fpath, e_f)
+                continue
+    if n_ingested:
+        log.debug("sync_cron_runs: ingested %d new rows", n_ingested)
+    return n_ingested
+
+
 def sync_session_metadata(config: dict, state: dict = None) -> int:
     """Sync OpenClaw session metadata rows to cloud sessions table.
 
@@ -5439,6 +5653,15 @@ def run_daemon() -> None:
             log.info(f"  Crons: {cr} synced")
     except Exception as e:
         log.warning(f"  Cron sync error: {e}")
+    # Issue #605 DuckDB follow-up: ingest cron-run JSONL files so the
+    # ``/api/crons/<jobId>/runs`` endpoint can read from DuckDB instead of
+    # re-parsing JSONL on every request.
+    try:
+        crr = sync_cron_runs(config, state, paths)
+        if crr:
+            log.info(f"  Cron runs: {crr} rows ingested")
+    except Exception as e:
+        log.warning(f"  Cron-run ingest error: {e}")
     # Sync today's log lines immediately so Brain tab shows the most recent
     # activity right away — older log history is backfilled later
     try:
@@ -5569,6 +5792,15 @@ def run_daemon() -> None:
             ev += sync_claude_cli_sessions(config, state, paths)
             sm = sync_session_metadata(config, state)
             crons = sync_crons(config, state, paths)
+            # Issue #605 DuckDB follow-up: tail cron-run JSONL files into
+            # DuckDB so the dashboard's per-job timeline reads from the
+            # columnar store. Failure is non-fatal — the legacy JSONL-read
+            # fallback in routes/crons.py still works.
+            try:
+                cron_runs = sync_cron_runs(config, state, paths)
+            except Exception as _e_cr:
+                log.debug("sync_cron_runs error (non-fatal): %s", _e_cr)
+                cron_runs = 0
 
             # ── Low-priority: log lines (real-time covered by streamer) ──
             lg = 0
@@ -5579,9 +5811,9 @@ def run_daemon() -> None:
 
             state["last_sync"] = datetime.now(timezone.utc).isoformat()
             save_state(state)
-            if ev or lg or mem or crons or sm or snap:
+            if ev or lg or mem or crons or sm or snap or cron_runs:
                 log.info(
-                    f"Synced {ev} events, {lg} log lines, {mem} memory files, {crons} crons, {sm} session rows ({enc})"
+                    f"Synced {ev} events, {lg} log lines, {mem} memory files, {crons} crons, {cron_runs} cron-runs, {sm} session rows ({enc})"
                 )
 
             # ── Alerts evaluator (PRD #779 PR-D pt2, audit P0 #1 + #2) ──

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -725,20 +725,75 @@ def _read_cron_run_lines(fpath, limit):
     return out[:limit]
 
 
+def _cron_runs_from_duckdb(job_id, limit):
+    """Read cron-run rows from the local DuckDB store via the daemon proxy.
+
+    Returns a list of run dicts shaped like the JSONL fallback below
+    (``{ts, duration_ms, status, error, usage, delivered_at, next_run_at}``)
+    so the UI sees a single canonical shape regardless of where the data
+    came from. Returns ``[]`` on any failure or empty result so callers
+    can decide whether to fall through to the JSONL read.
+
+    Reads through ``_ls_call`` which hits the daemon's HTTP proxy first
+    (cross-process DuckDB lock) before falling back to direct open for
+    single-process boots — same pattern the other routes/* fast-paths use.
+    """
+    rows = _ls_call("query_cron_runs", job_id=job_id, limit=int(limit))
+    if not rows:
+        return []
+    out = []
+    for r in rows:
+        try:
+            ts = _parse_iso_to_ms(r.get("started_at"))
+            duration_ms = int(r.get("duration_ms") or 0)
+        except (TypeError, ValueError):
+            ts = 0
+            duration_ms = 0
+        err = r.get("error_message") or ""
+        if err and len(err) > 200:
+            err = err[:200]
+        # ``usage`` lives inside the freeform ``data`` blob that
+        # ``query_cron_runs`` decodes from JSON. Surfaces null when the
+        # writer didn't include one.
+        data = r.get("data") if isinstance(r.get("data"), dict) else {}
+        usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
+        delivered_at = _parse_iso_to_ms(r.get("delivered_at")) or None
+        next_run_at = _parse_iso_to_ms(r.get("next_run_at")) or None
+        out.append({
+            "ts": ts,
+            "duration_ms": duration_ms,
+            "status": str(r.get("status") or "unknown"),
+            "error": err,
+            "usage": usage,
+            "delivered_at": delivered_at,
+            "next_run_at": next_run_at,
+        })
+    # ``query_cron_runs`` already orders DESC by started_at, but the
+    # numeric ``ts`` ordering may differ when the writer mixed ISO + epoch
+    # representations across versions. Re-sort defensively.
+    out.sort(key=lambda r: r.get("ts") or 0, reverse=True)
+    return out
+
+
 @bp_crons.route("/api/crons/<job_id>/runs")
 def api_crons_job_runs(job_id):
     """Per-job run timeline for the Cron detail panel (closes #605).
 
-    Reads ``~/.openclaw/cron/runs/<jobId>.jsonl`` and returns the last
-    ``limit`` runs (default 30, capped at 100) most-recent first. This is
-    a deliberately separate endpoint from ``/api/cron/<job_id>/runs``
-    (which returns p50/p95-enriched, gateway-backed history) — this one
-    is the raw per-run feed the timeline UI needs (duration, status,
-    error, usage, delivered, next-run).
+    DuckDB-first (issue #605 DuckDB follow-up): the sync daemon ingests
+    ``~/.openclaw/cron/runs/<jobId>.jsonl`` into the ``cron_runs`` table
+    every cycle, and this endpoint reads from DuckDB. The legacy JSONL
+    read remains as a fallback for graceful migration — used only when
+    DuckDB has zero rows for the requested job (fresh install, daemon
+    hasn't run yet, or a non-OpenClaw user).
 
-    Always returns 200, even when the file is missing or every line is
-    malformed: payload is ``{jobId, runs: [], count: 0, source}``. The
-    Cron UI treats an empty list as "no history yet".
+    Returns the last ``limit`` runs (default 30, capped at 100) most
+    recent first. Always 200, even when the file is missing and DuckDB
+    is empty — the Cron UI treats an empty list as "no history yet".
+
+    Path-traversal guard: ``job_id`` is rejected if it contains ``/``,
+    ``\\``, or ``..`` before we touch any filesystem path. The DuckDB
+    read is parameterised so it doesn't need the guard, but we apply it
+    uniformly so both transports refuse the same inputs.
     """
     try:
         limit = int(request.args.get("limit", "30"))
@@ -746,13 +801,38 @@ def api_crons_job_runs(job_id):
         limit = 30
     limit = max(1, min(limit, 100))
 
+    # Defence in depth — same as ``_resolve_cron_runs_jsonl``. Refuse
+    # anything that could escape the runs dir before the JSONL fallback.
+    if not job_id or "/" in job_id or "\\" in job_id or ".." in job_id:
+        return jsonify({
+            "jobId": job_id,
+            "runs": [],
+            "count": 0,
+            "source": "duckdb",
+            "file": None,
+        })
+
+    # DuckDB-first read (preferred path).
+    runs = _cron_runs_from_duckdb(job_id, limit)
+    if runs:
+        return jsonify({
+            "jobId": job_id,
+            "runs": runs,
+            "count": len(runs),
+            "source": "duckdb",
+            "file": None,
+        })
+
+    # Fallback: JSONL read. Only fires while the daemon is still building
+    # the cron_runs table for this job — first cycle on a fresh install,
+    # or when local_store isn't available (e.g. a stripped Docker image).
     fpath = _resolve_cron_runs_jsonl(job_id)
     if not fpath:
         return jsonify({
             "jobId": job_id,
             "runs": [],
             "count": 0,
-            "source": "jsonl",
+            "source": "duckdb",
             "file": None,
         })
     runs = _read_cron_run_lines(fpath, limit)

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -296,6 +296,9 @@ _DAEMON_METHODS = frozenset({
     "query_heartbeats",
     "query_channels",
     "query_crons",
+    # Issue #605 DuckDB follow-up: per-job cron-run timeline. Read by
+    # ``routes/crons.py:_cron_runs_from_duckdb`` via the daemon proxy.
+    "query_cron_runs",
     "query_subagents",
     "query_memory_blobs",
     "query_system_snapshots",

--- a/tests/test_cron_runs_duckdb_ingest.py
+++ b/tests/test_cron_runs_duckdb_ingest.py
@@ -1,0 +1,377 @@
+"""Tests for the cron-run JSONL → DuckDB ingest path (issue #605 follow-up).
+
+PR #1147 had the dashboard route parse ``~/.openclaw/cron/runs/*.jsonl``
+on every request — a violation of the DuckDB-first rule. The follow-up
+moves the parse into the sync daemon and exposes a ``query_cron_runs``
+read path. These tests cover:
+
+  1. ``sync_cron_runs`` parses a JSONL file into DuckDB rows.
+  2. Re-running ``sync_cron_runs`` does not duplicate (offset tracking).
+  3. ``LocalStore.query_cron_runs`` filters + sorts correctly.
+  4. ``/api/crons/<jobId>/runs`` reads from DuckDB when the store is
+     populated, and falls back to the JSONL reader otherwise.
+
+Tests are hermetic: each one rebuilds the LocalStore singleton against a
+tmp DuckDB and pins ``OPENCLAW_HOME`` so the resolver picks up the test
+fixture rather than the dev box's real ``~/.openclaw``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+
+import pytest
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    """Reload ``local_store`` + ``sync`` + ``routes.crons`` against an
+    isolated tmp DuckDB and a tmp OpenClaw home. Yields a bundle with
+    the freshly-loaded modules + the runs dir for fixture writes."""
+    db_path = tmp_path / "clawmetry.duckdb"
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(db_path))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    # Pin OPENCLAW_HOME so _cron_run_dirs (in sync.py) + _resolve_cron_runs_jsonl
+    # (in routes.crons) discover OUR fake tree, not the developer laptop's
+    # real ~/.openclaw.
+    fake_home = tmp_path / "openclaw_home"
+    runs_dir = fake_home / "cron" / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("OPENCLAW_HOME", str(fake_home))
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(fake_home))
+    # The legacy CLAWMETRY_LOCAL_STORE_READ gate doesn't apply to the new
+    # endpoint (it always reads from DuckDB first), but the unrelated
+    # ``_try_local_store_cron_runs`` fast path consults it — set 0 so we
+    # don't accidentally serve old data from the events table.
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+    import routes.crons as cr
+    importlib.reload(cr)
+
+    yield {
+        "ls": ls,
+        "sync": sync,
+        "cr": cr,
+        "runs_dir": runs_dir,
+        "fake_home": fake_home,
+    }
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _write_jsonl(runs_dir, job_id, records):
+    fpath = runs_dir / f"{job_id}.jsonl"
+    with open(fpath, "w") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+    return fpath
+
+
+def _build_app(cr):
+    from flask import Flask
+    app = Flask(__name__)
+    app.register_blueprint(cr.bp_crons)
+    return app
+
+
+# ── ingest tests ───────────────────────────────────────────────────────────
+
+
+class TestSyncCronRunsIngest:
+    """``sync_cron_runs`` parses JSONL into DuckDB rows."""
+
+    def test_ingests_five_lines_into_cron_runs(self, isolated):
+        sync = isolated["sync"]
+        ls = isolated["ls"]
+        runs_dir = isolated["runs_dir"]
+        records = [
+            {
+                "id": f"run-{i}",
+                "started_at": f"2026-05-13T10:00:0{i}Z",
+                "duration_ms": 1000 + i * 50,
+                "status": "ok" if i % 2 == 0 else "error",
+                "error": "boom" if i % 2 else "",
+                "usage": {"total_tokens": 100 + i,
+                          "input_tokens": 50 + i,
+                          "output_tokens": 50},
+                "delivered_at": f"2026-05-13T10:00:0{i}.500Z" if i % 2 == 0 else None,
+                "next_run_at": f"2026-05-13T10:01:0{i}Z",
+            }
+            for i in range(5)
+        ]
+        _write_jsonl(runs_dir, "daily-backup", records)
+
+        state = {"cron_run_offsets": {}}
+        config = {"node_id": "test-node", "api_key": "cm_test"}
+        n = sync.sync_cron_runs(config, state, paths={})
+        assert n == 5, f"expected 5 rows ingested, got {n}"
+
+        # Verify rows in DuckDB.
+        store = ls.get_store()
+        rows = store.query_cron_runs(job_id="daily-backup", limit=20)
+        assert len(rows) == 5
+        # Most-recent-first ordering.
+        assert rows[0]["id"] == "run-4"
+        assert rows[-1]["id"] == "run-0"
+        # First-class columns round-trip.
+        assert rows[0]["status"] == "ok"
+        assert rows[0]["duration_ms"] == 1200
+        # Freeform usage payload preserved via the data BLOB.
+        assert isinstance(rows[0]["data"], dict)
+        assert rows[0]["data"].get("usage", {}).get("total_tokens") == 104
+
+    def test_rerun_does_not_duplicate(self, isolated):
+        """The offset cursor + INSERT OR IGNORE combine to keep re-runs
+        idempotent. Re-scanning the same file must not add new rows."""
+        sync = isolated["sync"]
+        ls = isolated["ls"]
+        runs_dir = isolated["runs_dir"]
+        records = [
+            {
+                "id": f"run-{i}",
+                "started_at": f"2026-05-13T11:00:0{i}Z",
+                "duration_ms": 1000 + i * 100,
+                "status": "ok",
+            }
+            for i in range(3)
+        ]
+        _write_jsonl(runs_dir, "deploy-bot", records)
+
+        state = {"cron_run_offsets": {}}
+        config = {"node_id": "test-node"}
+        first = sync.sync_cron_runs(config, state, paths={})
+        assert first == 3
+        # Offset must have advanced past the file.
+        offsets = state["cron_run_offsets"]
+        assert any(k.endswith("deploy-bot.jsonl") for k in offsets), \
+            f"offsets did not record file: {offsets!r}"
+        offset_after_first = list(offsets.values())[0]
+        assert offset_after_first > 0
+
+        # Second pass: file unchanged, offset == size, zero new rows.
+        second = sync.sync_cron_runs(config, state, paths={})
+        assert second == 0, "second sync re-ingested rows"
+
+        store = ls.get_store()
+        rows = store.query_cron_runs(job_id="deploy-bot", limit=20)
+        assert len(rows) == 3
+
+    def test_append_after_first_sync_ingests_only_new(self, isolated):
+        """Append a fourth line after the first sync. Only the new line
+        is parsed (offset moved) but DuckDB rows from before still exist."""
+        sync = isolated["sync"]
+        ls = isolated["ls"]
+        runs_dir = isolated["runs_dir"]
+        fpath = _write_jsonl(runs_dir, "weekly-report", [
+            {"id": "r-0", "started_at": "2026-05-13T12:00:00Z",
+             "duration_ms": 500, "status": "ok"},
+            {"id": "r-1", "started_at": "2026-05-13T12:00:01Z",
+             "duration_ms": 600, "status": "ok"},
+        ])
+        state = {"cron_run_offsets": {}}
+        config = {"node_id": "test"}
+        assert sync.sync_cron_runs(config, state, paths={}) == 2
+
+        # Append one more line.
+        with open(fpath, "a") as f:
+            f.write(json.dumps({"id": "r-2", "started_at": "2026-05-13T12:00:02Z",
+                                "duration_ms": 700, "status": "ok"}) + "\n")
+        assert sync.sync_cron_runs(config, state, paths={}) == 1
+
+        store = ls.get_store()
+        rows = store.query_cron_runs(job_id="weekly-report", limit=20)
+        assert len(rows) == 3
+
+    def test_malformed_lines_skipped_not_raised(self, isolated):
+        """A garbled line in the middle of a file mustn't abort the sync —
+        the rest of the file's valid lines must still ingest."""
+        sync = isolated["sync"]
+        ls = isolated["ls"]
+        runs_dir = isolated["runs_dir"]
+        fpath = runs_dir / "noisy-job.jsonl"
+        with open(fpath, "w") as f:
+            f.write(json.dumps({"id": "ok-1", "started_at": "2026-05-13T13:00:00Z",
+                                "status": "ok", "duration_ms": 100}) + "\n")
+            f.write("{not valid json\n")
+            f.write(json.dumps({"id": "ok-2", "started_at": "2026-05-13T13:00:01Z",
+                                "status": "ok", "duration_ms": 200}) + "\n")
+            f.write("\n")  # blank line
+            f.write("42\n")  # non-dict
+            f.write(json.dumps({"id": "ok-3", "started_at": "2026-05-13T13:00:02Z",
+                                "status": "ok", "duration_ms": 300}) + "\n")
+
+        n = sync.sync_cron_runs({"node_id": "x"}, {"cron_run_offsets": {}},
+                                 paths={})
+        assert n == 3
+
+        store = ls.get_store()
+        rows = store.query_cron_runs(job_id="noisy-job", limit=20)
+        assert sorted(r["id"] for r in rows) == ["ok-1", "ok-2", "ok-3"]
+
+    def test_missing_runs_dir_returns_zero(self, tmp_path, monkeypatch):
+        """No JSONLs → zero rows, no exception. ClawMetry must work on
+        a fresh install where the OpenClaw cron writer hasn't run yet."""
+        monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH",
+                           str(tmp_path / "clawmetry.duckdb"))
+        monkeypatch.setenv("OPENCLAW_HOME", str(tmp_path / "nothing-here"))
+        monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path / "nothing-here"))
+        import clawmetry.local_store as ls
+        import clawmetry.sync as sync
+        importlib.reload(ls)
+        importlib.reload(sync)
+        try:
+            n = sync.sync_cron_runs({"node_id": "x"},
+                                     {"cron_run_offsets": {}},
+                                     paths={})
+            assert n == 0
+        finally:
+            try:
+                ls.get_store().stop(flush=True)
+            except Exception:
+                pass
+
+
+# ── query tests ────────────────────────────────────────────────────────────
+
+
+class TestQueryCronRuns:
+    """``LocalStore.query_cron_runs`` filters + sorts as documented."""
+
+    def test_filter_by_job_id_and_desc_sort(self, isolated):
+        ls = isolated["ls"]
+        store = ls.get_store()
+        # Seed two jobs interleaved by timestamp.
+        for i, job in enumerate(["job-a", "job-b", "job-a", "job-b"]):
+            store.ingest_cron_run({
+                "id": f"{job}:{i}",
+                "job_id": job,
+                "started_at": f"2026-05-13T14:00:0{i}Z",
+                "duration_ms": 100 * (i + 1),
+                "status": "ok",
+            })
+        rows_a = store.query_cron_runs(job_id="job-a", limit=10)
+        assert len(rows_a) == 2
+        # Most-recent-first.
+        assert rows_a[0]["id"] == "job-a:2"
+        assert rows_a[1]["id"] == "job-a:0"
+
+        rows_b = store.query_cron_runs(job_id="job-b", limit=10)
+        assert [r["id"] for r in rows_b] == ["job-b:3", "job-b:1"]
+
+    def test_limit_clamps(self, isolated):
+        ls = isolated["ls"]
+        store = ls.get_store()
+        for i in range(6):
+            store.ingest_cron_run({
+                "id": f"r-{i}",
+                "job_id": "lots-of-runs",
+                "started_at": f"2026-05-13T15:00:0{i}Z",
+                "duration_ms": 10,
+                "status": "ok",
+            })
+        # limit < total → trimmed
+        rows = store.query_cron_runs(job_id="lots-of-runs", limit=2)
+        assert len(rows) == 2
+        # limit=0 clamped to 1
+        rows = store.query_cron_runs(job_id="lots-of-runs", limit=0)
+        assert len(rows) == 1
+        # negative also clamped
+        rows = store.query_cron_runs(job_id="lots-of-runs", limit=-5)
+        assert len(rows) == 1
+
+
+# ── API tests ──────────────────────────────────────────────────────────────
+
+
+class TestApiReadsFromDuckDB:
+    """``GET /api/crons/<jobId>/runs`` prefers DuckDB, falls back to JSONL."""
+
+    def test_endpoint_reads_from_duckdb_when_populated(self, isolated):
+        sync = isolated["sync"]
+        cr = isolated["cr"]
+        runs_dir = isolated["runs_dir"]
+        # Populate DuckDB via the ingest helper (no JSONL needed for this
+        # assertion — the route mustn't depend on the file when the store
+        # has rows).
+        records = [
+            {"id": f"d-{i}",
+             "started_at": f"2026-05-13T16:00:0{i}Z",
+             "duration_ms": 500 + i,
+             "status": "ok"}
+            for i in range(3)
+        ]
+        _write_jsonl(runs_dir, "duckdb-job", records)
+        n = sync.sync_cron_runs({"node_id": "test"},
+                                 {"cron_run_offsets": {}}, paths={})
+        assert n == 3
+
+        app = _build_app(cr)
+        client = app.test_client()
+        resp = client.get("/api/crons/duckdb-job/runs?limit=10")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["jobId"] == "duckdb-job"
+        assert body["source"] == "duckdb"
+        assert body["count"] == 3
+        assert len(body["runs"]) == 3
+        # Most-recent first.
+        assert body["runs"][0]["duration_ms"] == 502
+
+    def test_endpoint_falls_back_to_jsonl_when_duckdb_empty(self, isolated):
+        """If the daemon hasn't ingested yet, the JSONL parser keeps the
+        UI working. This is the graceful-migration path called out in the
+        task spec."""
+        cr = isolated["cr"]
+        runs_dir = isolated["runs_dir"]
+        _write_jsonl(runs_dir, "fresh-job", [
+            {"id": "fresh-0", "started_at": "2026-05-13T17:00:00Z",
+             "duration_ms": 999, "status": "ok"}
+        ])
+        # Don't run sync_cron_runs — DuckDB is empty for this job.
+
+        app = _build_app(cr)
+        client = app.test_client()
+        resp = client.get("/api/crons/fresh-job/runs")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["source"] == "jsonl"
+        assert body["count"] == 1
+        assert body["runs"][0]["duration_ms"] == 999
+
+    def test_endpoint_returns_empty_when_both_paths_empty(self, isolated):
+        cr = isolated["cr"]
+        app = _build_app(cr)
+        client = app.test_client()
+        resp = client.get("/api/crons/nonexistent/runs")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["runs"] == []
+        assert body["count"] == 0
+
+    def test_endpoint_rejects_path_traversal(self, isolated):
+        cr = isolated["cr"]
+        app = _build_app(cr)
+        client = app.test_client()
+        # Flask's URL router blocks bare ``/`` and percent-encoded ``/``
+        # before our handler runs (they hit a 404). The traversal we DO
+        # have to defend against is a literal ``..`` segment inside the
+        # job_id capture, e.g. a request to ``/api/crons/..evil/runs``.
+        # The handler must refuse it and return an empty payload — never
+        # 500, never touch the filesystem.
+        resp = client.get("/api/crons/..evil/runs")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["runs"] == []
+        assert body["file"] is None


### PR DESCRIPTION
## Summary

Follow-up to #1147. The DuckDB-first rule says every feature must persist + read through local DuckDB; PR #1147's `/api/crons/<jobId>/runs` parses `~/.openclaw/cron/runs/<jobId>.jsonl` on every request, which violates that.

This PR keeps #1147's user-facing endpoint, sparkline, and stat row exactly as-is, and adds the DuckDB ingest + read path underneath. The JSONL parser stays as a graceful-migration fallback for the first cycle of a fresh install.

> Stacked on top of #1147. Once #1147 merges, the diff here collapses to the additive commit `14af2cf`. If #1147 merges first this branch already rebases cleanly onto main.

## What's new

- **`clawmetry/local_store.py`** — new `cron_runs` table (dedicated, not `events`), `LocalStore.ingest_cron_run`, `LocalStore.query_cron_runs(job_id, since, until, limit)`.
- **`clawmetry/sync.py`** — `sync_cron_runs(config, state, paths)`. Scans every OpenClaw-candidate `cron/runs` dir, tails each `*.jsonl` from a per-file byte offset under `state["cron_run_offsets"]`, ingests via `ingest_cron_run`. Truncation + rotation guard. Wired into the startup-sync block **and** the main loop in `run_daemon`.
- **`routes/crons.py`** — `api_crons_job_runs` now reads DuckDB via `_ls_call("query_cron_runs", ...)` first, falls through to the JSONL parser only when DuckDB has zero rows. Response shape unchanged so #1147's frontend keeps working.
- **`routes/local_query.py`** — `query_cron_runs` added to the daemon-proxy method allowlist.
- **`tests/test_cron_runs_duckdb_ingest.py`** — 11 tests (ingest, idempotency, query, API fallback, path traversal).

## Schema decision

Went with a **dedicated `cron_runs` table** (not `events` with `event_type LIKE 'cron.run.%'`). The timeline UI filters by `job_id` and sorts by `started_at`; a prefix-indexed standalone table beats a substring scan over a `data` BLOB. First-class columns for `delivered_at` / `next_run_at` / `duration_ms` also let `query_cron_runs` skip blob deserialisation on the hot path.

## Test plan

- [x] `pytest tests/test_cron_runs_duckdb_ingest.py` — 11/11 pass
- [x] `pytest tests/test_crons_runs_endpoint.py tests/test_crons_local_store.py tests/test_local_store.py tests/test_local_store_sync_integration.py` — 63/63 pass (adjacent suites unaffected)
- [x] `pytest tests/test_local_store_default_on.py tests/test_local_store_missing_writers.py tests/test_local_store_multi_agent.py tests/test_local_store_rename.py` — 49/49 pass
- [x] AST parse-check all modified files

## Notes

- No `[RELEASE]` prefix per the task spec.
- Stacked on #1147. If #1147 merges first the diff for this PR is just commit `14af2cf` — additive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)