### PR TITLE
feat(gateway): persist gateway.metric events; 24h sparkline on health card (DuckDB-first for #852 followup)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5395,6 +5395,72 @@ function startHealthStream() {
   healthStream.onerror = function() { setTimeout(startHealthStream, 30000); };
 }
 
+// Gateway-health 24h sparkline (#852 followup, MOAT/DuckDB-first).
+// Pulls daemon-captured `gateway.metric` events from /api/gateway-health/history
+// and renders them as a 240x36 inline SVG inside #sh-gateway-spark. Empty
+// data (fresh install: no daemon yet, or <30s elapsed) renders as a quiet
+// "no history yet" hint so the card never looks broken.
+async function _loadGatewayHealthSparkline() {
+  var el = document.getElementById('sh-gateway-spark');
+  if (!el) return;
+  var rows;
+  try {
+    rows = await fetchJsonWithTimeout('/api/gateway-health/history?hours=24', 6000);
+  } catch (_e) {
+    rows = [];
+  }
+  if (!Array.isArray(rows) || rows.length === 0) {
+    el.innerHTML = '<div style="font-size:10px;color:var(--text-muted);font-style:italic;opacity:0.7;">Sparkline available after daemon captures 24h of samples.</div>';
+    return;
+  }
+  // Only keep rows with a numeric rss_mb — daemon may have written
+  // gateway.metric rows where vitals weren't readable (status=warning,
+  // rss_mb=null). Those break the y-axis; skip them.
+  var pts = rows.filter(function(r) {
+    return r && typeof r.rss_mb === 'number';
+  });
+  if (pts.length === 0) {
+    el.innerHTML = '<div style="font-size:10px;color:var(--text-muted);font-style:italic;opacity:0.7;">Sparkline available after daemon captures 24h of samples.</div>';
+    return;
+  }
+  var W = 240, H = 36, pad = 2;
+  var maxRss = 0, minRss = pts[0].rss_mb;
+  pts.forEach(function(p) {
+    if (p.rss_mb > maxRss) maxRss = p.rss_mb;
+    if (p.rss_mb < minRss) minRss = p.rss_mb;
+  });
+  // Avoid a flat-line that visually collapses to the bottom — give the
+  // y-range a 10MB floor so small fluctuations are still visible.
+  var range = Math.max(10, maxRss - minRss);
+  var step = pts.length > 1 ? (W - 2*pad) / (pts.length - 1) : 0;
+  var coords = pts.map(function(p, i) {
+    var x = pad + i * step;
+    var y = H - pad - ((p.rss_mb - minRss) / range) * (H - 2*pad);
+    return x.toFixed(1) + ',' + y.toFixed(1);
+  });
+  var svg = '<svg width="' + W + '" height="' + H + '" style="display:block;background:var(--bg-primary,#0a0a0a);border-radius:4px;border:1px solid var(--border-secondary);" aria-label="Gateway RSS over last 24h">';
+  // Filled area under the curve for a "memory pressure" feel.
+  var areaPts = coords.slice();
+  areaPts.push((pad + (pts.length-1) * step).toFixed(1) + ',' + (H - pad).toFixed(1));
+  areaPts.push(pad.toFixed(1) + ',' + (H - pad).toFixed(1));
+  svg += '<polygon fill="rgba(34,197,94,0.18)" points="' + areaPts.join(' ') + '" />';
+  // Trend line.
+  svg += '<polyline fill="none" stroke="#22c55e" stroke-width="1.2" points="' + coords.join(' ') + '" />';
+  // Latest-point dot.
+  var last = pts[pts.length - 1];
+  var lastX = pad + (pts.length-1) * step;
+  var lastY = H - pad - ((last.rss_mb - minRss) / range) * (H - 2*pad);
+  svg += '<circle cx="' + lastX.toFixed(1) + '" cy="' + lastY.toFixed(1) + '" r="2" fill="#22c55e"><title>' + last.rss_mb + ' MB @ ' + (last.ts || '') + '</title></circle>';
+  svg += '</svg>';
+  // Min/max caption.
+  var caption = '<div style="font-size:10px;color:var(--text-muted);margin-top:3px;display:flex;justify-content:space-between;">'
+    + '<span>min ' + minRss.toFixed(0) + ' MB</span>'
+    + '<span style="color:var(--text-secondary);">' + pts.length + ' samples · 24h</span>'
+    + '<span>max ' + maxRss.toFixed(0) + ' MB</span>'
+    + '</div>';
+  el.innerHTML = svg + caption;
+}
+
 // ===== System Health Panel =====
 async function loadSystemHealth() {
   try {
@@ -5656,9 +5722,14 @@ async function loadSystemHealth() {
       if (typeof gw.cpu_pct === 'number') {
         gwHtml += '<div style="margin-top:6px;font-size:11px;color:var(--text-muted);">CPU: <span style="color:var(--text-secondary);font-weight:600;">' + gw.cpu_pct + '%</span></div>';
       }
+      // 24h RSS sparkline (#852 followup) — placeholder div; populated
+      // asynchronously by _loadGatewayHealthSparkline() below.
+      gwHtml += '<div id="sh-gateway-spark" style="margin-top:8px;min-height:36px;"></div>';
       gwHtml += '</div>';
       gwEl.innerHTML = gwHtml;
       if (gwWrap) gwWrap.style.display = '';
+      // Kick off the sparkline fetch; never blocks the rest of the card.
+      try { _loadGatewayHealthSparkline(); } catch (_e) {}
     } else if (gwWrap) { gwWrap.style.display = 'none'; }
 
     // Sandbox Status (conditional)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -20,6 +20,7 @@ import threading
 import subprocess
 import urllib.request
 import urllib.error
+import uuid
 from pathlib import Path
 from datetime import datetime, timezone
 from itertools import islice
@@ -2591,6 +2592,138 @@ def _detect_ollama_for_heartbeat():
         pass
 
     return result
+
+
+# ── Gateway process-metric capture (#852 follow-up) ──────────────────────────
+# PR #1146 added a *live* gateway-health snapshot (RSS/CPU/uptime). That's
+# fine for "is it green right now?" but the gateway's slow memory-bloat-OOM
+# pattern (~600 MB → ~945 MB) is only visible if you SEE THE TREND.
+#
+# Per the DuckDB-first rule, historical data lives in DuckDB. We capture
+# gateway vitals every 30s in the daemon loop and write them as
+# ``event_type="gateway.metric"`` events. The dashboard's
+# ``/api/gateway-health/history`` then plots a 24h sparkline.
+#
+# Constraints:
+#   * Every 30s max (rate-cap to keep DB writes cheap).
+#   * Dedupe: if a fresh sample matches the previous one closely (within
+#     5 min and small variance) we skip writing — the gateway is largely
+#     idle between agent calls so otherwise we'd write ~2,880 near-identical
+#     rows/day. With dedupe a typical day is ~50-300 rows.
+#   * Skip writes when the gateway isn't running — no point flooding the
+#     event log with "not_running" rows during dev or after a crash.
+#   * Best-effort: any failure (compute_gateway_health, local_store import,
+#     ingest) is swallowed; the daemon loop keeps ticking.
+
+GATEWAY_METRIC_INTERVAL_SEC = 30
+GATEWAY_METRIC_DEDUP_WINDOW_SEC = 300        # 5 min
+GATEWAY_METRIC_DEDUP_RSS_TOLERANCE_MB = 5.0  # don't re-write within ±5 MB
+GATEWAY_METRIC_DEDUP_CPU_TOLERANCE_PCT = 2.0  # don't re-write within ±2% CPU
+
+# Module-level state for rate-capping + dedupe. (last_write_ts, last_payload).
+# Reset on import; the daemon runs as one long-lived process, so this is fine.
+# Sentinel ``None`` means "no sample written yet" — the rate-cap check skips
+# the comparison so the very first call always falls through to capture.
+_LAST_GATEWAY_METRIC_TS: float | None = None
+_LAST_GATEWAY_METRIC: dict | None = None
+
+
+def _should_dedupe_gateway_metric(prev: dict | None, curr: dict) -> bool:
+    """Return True when *curr* is close enough to *prev* that we should skip
+    the write. The five-minute time window is enforced by the caller — this
+    helper just answers the value-similarity question.
+    """
+    if not isinstance(prev, dict):
+        return False
+    # PID changed → gateway restarted; always write.
+    if prev.get("pid") != curr.get("pid"):
+        return False
+    prev_rss = prev.get("rss_mb")
+    curr_rss = curr.get("rss_mb")
+    if prev_rss is None or curr_rss is None:
+        # Vitals went missing/recovered → write so the gap is visible.
+        return prev_rss == curr_rss
+    if abs(float(curr_rss) - float(prev_rss)) > GATEWAY_METRIC_DEDUP_RSS_TOLERANCE_MB:
+        return False
+    prev_cpu = prev.get("cpu_pct") or 0.0
+    curr_cpu = curr.get("cpu_pct") or 0.0
+    if abs(float(curr_cpu) - float(prev_cpu)) > GATEWAY_METRIC_DEDUP_CPU_TOLERANCE_PCT:
+        return False
+    return True
+
+
+def capture_gateway_metric(config: dict) -> bool:
+    """Capture one ``gateway.metric`` event into local DuckDB.
+
+    Returns True when a row was written, False when skipped (rate-capped,
+    deduped, gateway not running, or any failure).
+
+    Imports ``routes.health.compute_gateway_health`` lazily so the daemon
+    doesn't pull the dashboard module graph at import time (the daemon is
+    optional; ``routes/`` is a peer of ``clawmetry/`` at the repo root).
+    """
+    global _LAST_GATEWAY_METRIC_TS, _LAST_GATEWAY_METRIC
+    now_mono = time.monotonic()
+    if (
+        _LAST_GATEWAY_METRIC_TS is not None
+        and (now_mono - _LAST_GATEWAY_METRIC_TS) < GATEWAY_METRIC_INTERVAL_SEC
+    ):
+        return False
+
+    try:
+        import routes.health as _rh  # late import — daemon is optional
+    except Exception as _e:
+        log.debug("gateway.metric: cannot import routes.health (%s)", _e)
+        return False
+
+    try:
+        # Attribute lookup (NOT a bound reference) so tests + future
+        # hot-reloads pick up monkeypatched implementations.
+        snap = _rh.compute_gateway_health()
+    except Exception as _e:
+        log.debug("gateway.metric: compute_gateway_health failed (%s)", _e)
+        return False
+
+    if not snap or snap.get("status") == "not_running":
+        # Skip noise when the gateway isn't found at all.
+        _LAST_GATEWAY_METRIC_TS = now_mono
+        return False
+
+    curr = {
+        "rss_mb":         snap.get("rss_mb"),
+        "cpu_pct":        snap.get("cpu_pct"),
+        "pid":            snap.get("pid"),
+        "uptime_seconds": snap.get("uptime_seconds"),
+    }
+
+    # Dedupe within DEDUP_WINDOW: if this sample looks like the last one and
+    # we wrote that one less than 5 min ago, skip the write.
+    if _LAST_GATEWAY_METRIC is not None:
+        elapsed = now_mono - _LAST_GATEWAY_METRIC_TS
+        if elapsed < GATEWAY_METRIC_DEDUP_WINDOW_SEC and _should_dedupe_gateway_metric(
+            _LAST_GATEWAY_METRIC, curr
+        ):
+            return False
+
+    try:
+        from clawmetry import local_store as _ls
+        store = _ls.get_store()
+        store.ingest({
+            "id":         uuid.uuid4().hex,
+            "node_id":    config.get("node_id") or "unknown",
+            "agent_id":   "openclaw-gateway",
+            "agent_type": "openclaw",
+            "event_type": "gateway.metric",
+            "ts":         datetime.now(timezone.utc).isoformat(),
+            "data":       curr,
+        })
+    except Exception as _e:
+        log.debug("gateway.metric: ingest failed (%s)", _e)
+        return False
+
+    _LAST_GATEWAY_METRIC_TS = now_mono
+    _LAST_GATEWAY_METRIC = curr
+    return True
 
 
 # ── Daemon-collected snapshots ────────────────────────────────────────────────
@@ -5565,6 +5698,16 @@ def run_daemon() -> None:
             if now_snap - last_snapshot > snapshot_interval:
                 snap = sync_system_snapshot(config, state, paths)  # subagents + flow
                 last_snapshot = now_snap
+
+            # ── Gateway process metric capture (#852 follow-up) ──
+            # Persists RSS/CPU into DuckDB every 30s (rate-capped + deduped
+            # inside the helper) so the dashboard can render a 24h sparkline
+            # of memory pressure, not just a live snapshot. Best-effort.
+            try:
+                capture_gateway_metric(config)
+            except Exception as _gm_e:
+                log.debug("gateway.metric capture failed (continuing): %s", _gm_e)
+
             ev = sync_sessions(config, state, paths)
             ev += sync_claude_cli_sessions(config, state, paths)
             sm = sync_session_metadata(config, state)

--- a/routes/health.py
+++ b/routes/health.py
@@ -1108,6 +1108,19 @@ def api_system_health():
             "status": "not_running",
             "memory_threshold_mb": GATEWAY_MEMORY_THRESHOLD_MB,
         }
+    # 852 follow-up: include a tiny last-hour summary from the daemon-
+    # persisted gateway.metric events so the card can show "memory
+    # trending up over the last hour" without a second roundtrip. Best-
+    # effort — empty / not-installed local_store → zero counts.
+    try:
+        gateway_health["history"] = _summarise_gateway_metric_recent(minutes=60)
+    except Exception:
+        gateway_health["history"] = {
+            "count": 0,
+            "min_rss_mb": None,
+            "max_rss_mb": None,
+            "avg_rss_mb": None,
+        }
 
     return jsonify(
         {
@@ -1152,6 +1165,97 @@ def api_gateway_health():
                 "memory_threshold_mb": GATEWAY_MEMORY_THRESHOLD_MB,
             }
         )
+
+
+def _query_gateway_metric_history(hours: int):
+    """Return ``gateway.metric`` events from the last *hours* hours sorted
+    ASC (oldest → newest). Internal helper so the test suite can drive it
+    without spinning up the Flask app.
+
+    Each row: ``{"ts": ISO8601, "rss_mb": float|None, "cpu_pct": float|None}``.
+    No DuckDB / no events → empty list (NOT an error; fresh installs have no
+    history yet).
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+    except Exception:
+        return []
+    try:
+        since_iso = (
+            datetime.now(timezone.utc) - timedelta(hours=int(hours))
+        ).isoformat()
+        # ``query_events`` defaults to DESC + LIMIT 500. A day at 30s with
+        # max dedupe relaxation is ≤ 2,880 rows; in practice (dedupe) we see
+        # ~50-300/day, but we ask for 10,000 to be safe and sort ASC here.
+        rows = store.query_events(
+            event_type="gateway.metric",
+            since=since_iso,
+            limit=10000,
+        )
+    except Exception:
+        return []
+    out = []
+    for r in rows:
+        data = r.get("data") if isinstance(r.get("data"), dict) else {}
+        out.append({
+            "ts":      r.get("ts"),
+            "rss_mb":  data.get("rss_mb"),
+            "cpu_pct": data.get("cpu_pct"),
+        })
+    out.sort(key=lambda r: r.get("ts") or "")
+    return out
+
+
+def _summarise_gateway_metric_recent(minutes: int = 60):
+    """Return a small {count, min_rss_mb, max_rss_mb, avg_rss_mb} summary
+    suitable for embedding in the existing ``/api/system-health.gateway``
+    block. Cheap (single read of the recent slice); never raises.
+    """
+    rows = _query_gateway_metric_history(hours=max(1, int(minutes / 60) or 1))
+    if not rows:
+        return {"count": 0, "min_rss_mb": None, "max_rss_mb": None, "avg_rss_mb": None}
+    # Restrict to the requested last-N-minutes window in case query padded out.
+    cutoff = (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+    rss_values = [
+        r["rss_mb"]
+        for r in rows
+        if r.get("ts") and r["ts"] >= cutoff and r.get("rss_mb") is not None
+    ]
+    if not rss_values:
+        return {"count": 0, "min_rss_mb": None, "max_rss_mb": None, "avg_rss_mb": None}
+    return {
+        "count":      len(rss_values),
+        "min_rss_mb": round(min(rss_values), 1),
+        "max_rss_mb": round(max(rss_values), 1),
+        "avg_rss_mb": round(sum(rss_values) / len(rss_values), 1),
+    }
+
+
+@bp_health.route("/api/gateway-health/history")
+def api_gateway_health_history():
+    """24h-window sparkline data for the gateway-health card (#852 followup).
+
+    Query string:
+      * ``hours`` — lookback window (1-168, default 24).
+
+    Returns a JSON array of ``{ts, rss_mb, cpu_pct}`` rows, sorted oldest →
+    newest. Empty array (NOT 4xx/5xx) when no events have been written yet
+    — fresh installs need ~30s to capture the first sample, and the frontend
+    treats empty data as "sparkline not available yet" rather than an error.
+    """
+    try:
+        hours = int(request.args.get("hours", "24"))
+    except (TypeError, ValueError):
+        hours = 24
+    # Clamp to a sane range. 1 week max — anything longer should query DuckDB
+    # directly; the dashboard sparkline only needs 24h.
+    hours = max(1, min(168, hours))
+    try:
+        rows = _query_gateway_metric_history(hours=hours)
+    except Exception:
+        rows = []
+    return jsonify(rows)
 
 
 @bp_health.route("/api/health")

--- a/tests/test_gateway_metric_history.py
+++ b/tests/test_gateway_metric_history.py
@@ -1,0 +1,346 @@
+"""Tests for the gateway.metric history surface (issue #852 follow-up).
+
+PR #1146 added the live ``compute_gateway_health()`` snapshot. This PR
+persists that snapshot every 30s into DuckDB as ``event_type="gateway.metric"``
+events and exposes a 24h history endpoint for the dashboard sparkline.
+
+Coverage:
+
+  1. ``capture_gateway_metric()`` writes one row per call when conditions are
+     met (gateway running, rate window elapsed, not deduped).
+  2. Dedupe logic — a near-identical sample within the 5-min window is a
+     no-op; a PID change / large RSS swing / 5 min elapsed all trigger a
+     write.
+  3. ``/api/gateway-health/history`` returns daemon-written rows sorted ASC,
+     and an empty list (not a 4xx) when no events exist.
+  4. The PR #1146 live snapshot endpoint (``/api/gateway-health``) keeps
+     working — regression check that the new field/endpoint didn't break
+     the existing surface.
+  5. ``/api/system-health`` carries the new ``gateway.history`` summary
+     (count/min/max/avg rss_mb).
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _wait_flush(store, t=2.0):
+    """Block until the local-store ring has drained to DuckDB."""
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _seed_metric_event(store, *, ts_iso, rss_mb, cpu_pct=1.0, pid=4242):
+    """Insert a single ``gateway.metric`` event at the given ISO timestamp.
+
+    Mirrors what ``sync.capture_gateway_metric`` writes so the read-side
+    tests don't have to monkeypatch the daemon helper.
+    """
+    store.ingest({
+        "id":         uuid.uuid4().hex,
+        "node_id":    "test-node",
+        "agent_id":   "openclaw-gateway",
+        "agent_type": "openclaw",
+        "event_type": "gateway.metric",
+        "ts":         ts_iso,
+        "data":       {
+            "rss_mb":         rss_mb,
+            "cpu_pct":        cpu_pct,
+            "pid":            pid,
+            "uptime_seconds": 60,
+        },
+    })
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Reload ``clawmetry.local_store`` against a fresh DuckDB file."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.get_store()
+    yield ls, store
+    try:
+        store.stop(flush=False)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def health_app(fresh_store, monkeypatch):
+    """Flask app with ``bp_health`` registered against the fresh DuckDB."""
+    # Ensure routes.health doesn't accidentally find a stale local_store
+    # module pointing at the previous DB file.
+    sys.modules.pop("routes.health", None)
+    import routes.health as health_mod
+    importlib.reload(health_mod)
+    app = Flask(__name__)
+    app.register_blueprint(health_mod.bp_health)
+    yield app, health_mod, fresh_store[1]
+
+
+# ── 1. Daemon capture path ─────────────────────────────────────────────────
+
+
+def test_capture_gateway_metric_writes_row_when_gateway_running(fresh_store, monkeypatch):
+    ls, store = fresh_store
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as sync_mod
+    importlib.reload(sync_mod)
+    # Reset module-level rate-cap state for a clean run.
+    sync_mod._LAST_GATEWAY_METRIC_TS = None
+    sync_mod._LAST_GATEWAY_METRIC = None
+    # Stub compute_gateway_health to return a known-healthy snapshot.
+    snap = {
+        "pid": 4242,
+        "uptime_seconds": 120,
+        "rss_mb": 250.0,
+        "cpu_pct": 1.5,
+        "status": "healthy",
+        "memory_threshold_mb": 900,
+    }
+    import routes.health as health_mod
+    monkeypatch.setattr(health_mod, "compute_gateway_health", lambda: snap)
+
+    assert sync_mod.capture_gateway_metric({"node_id": "test-node"}) is True
+
+    _wait_flush(store)
+    rows = store.query_events(event_type="gateway.metric", limit=10)
+    assert len(rows) == 1
+    assert rows[0]["agent_id"] == "openclaw-gateway"
+    assert rows[0]["data"]["rss_mb"] == 250.0
+    assert rows[0]["data"]["pid"] == 4242
+
+
+def test_capture_gateway_metric_skips_when_not_running(fresh_store, monkeypatch):
+    ls, store = fresh_store
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as sync_mod
+    importlib.reload(sync_mod)
+    sync_mod._LAST_GATEWAY_METRIC_TS = None
+    sync_mod._LAST_GATEWAY_METRIC = None
+    import routes.health as health_mod
+    monkeypatch.setattr(health_mod, "compute_gateway_health", lambda: {
+        "pid": None,
+        "uptime_seconds": None,
+        "rss_mb": None,
+        "cpu_pct": None,
+        "status": "not_running",
+        "memory_threshold_mb": 900,
+    })
+    assert sync_mod.capture_gateway_metric({"node_id": "n"}) is False
+    _wait_flush(store)
+    rows = store.query_events(event_type="gateway.metric", limit=10)
+    assert rows == []
+
+
+def test_capture_gateway_metric_rate_cap_skips_second_call(fresh_store, monkeypatch):
+    ls, store = fresh_store
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as sync_mod
+    importlib.reload(sync_mod)
+    sync_mod._LAST_GATEWAY_METRIC_TS = None
+    sync_mod._LAST_GATEWAY_METRIC = None
+    import routes.health as health_mod
+    monkeypatch.setattr(health_mod, "compute_gateway_health", lambda: {
+        "pid": 1, "uptime_seconds": 1, "rss_mb": 100.0, "cpu_pct": 0.0,
+        "status": "healthy", "memory_threshold_mb": 900,
+    })
+
+    # First write succeeds, second within the 30s window is a no-op.
+    assert sync_mod.capture_gateway_metric({"node_id": "n"}) is True
+    assert sync_mod.capture_gateway_metric({"node_id": "n"}) is False
+    _wait_flush(store)
+    rows = store.query_events(event_type="gateway.metric", limit=10)
+    assert len(rows) == 1
+
+
+def test_should_dedupe_returns_true_for_near_identical_sample():
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as sync_mod
+    importlib.reload(sync_mod)
+    prev = {"pid": 1, "rss_mb": 200.0, "cpu_pct": 1.0, "uptime_seconds": 60}
+    curr = {"pid": 1, "rss_mb": 202.0, "cpu_pct": 2.5, "uptime_seconds": 90}
+    # Within 5MB / 2% CPU → dedupe.
+    assert sync_mod._should_dedupe_gateway_metric(prev, curr) is True
+
+
+def test_should_dedupe_returns_false_for_large_rss_swing():
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as sync_mod
+    importlib.reload(sync_mod)
+    prev = {"pid": 1, "rss_mb": 200.0, "cpu_pct": 1.0}
+    curr = {"pid": 1, "rss_mb": 250.0, "cpu_pct": 1.0}
+    # 50 MB swing >> 5MB tolerance → write.
+    assert sync_mod._should_dedupe_gateway_metric(prev, curr) is False
+
+
+def test_should_dedupe_returns_false_on_pid_change():
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as sync_mod
+    importlib.reload(sync_mod)
+    prev = {"pid": 100, "rss_mb": 200.0, "cpu_pct": 1.0}
+    curr = {"pid": 200, "rss_mb": 200.0, "cpu_pct": 1.0}
+    # PID changed → gateway restarted → always write.
+    assert sync_mod._should_dedupe_gateway_metric(prev, curr) is False
+
+
+def test_should_dedupe_first_sample_writes():
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as sync_mod
+    importlib.reload(sync_mod)
+    # No prior sample → never dedupe.
+    assert sync_mod._should_dedupe_gateway_metric(
+        None, {"pid": 1, "rss_mb": 100.0, "cpu_pct": 0}
+    ) is False
+
+
+# ── 2. Read endpoint contract ──────────────────────────────────────────────
+
+
+def test_history_endpoint_returns_rows_sorted_ascending(health_app):
+    app, health_mod, store = health_app
+    # Seed three samples; insert them OUT OF ORDER to prove the endpoint sorts.
+    now = datetime.now(timezone.utc)
+    _seed_metric_event(store, ts_iso=(now - timedelta(hours=1)).isoformat(),
+                       rss_mb=250.0)
+    _seed_metric_event(store, ts_iso=(now - timedelta(hours=3)).isoformat(),
+                       rss_mb=200.0)
+    _seed_metric_event(store, ts_iso=(now - timedelta(hours=2)).isoformat(),
+                       rss_mb=225.0)
+    _wait_flush(store)
+
+    with app.test_client() as c:
+        resp = c.get("/api/gateway-health/history?hours=24")
+        assert resp.status_code == 200
+        data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 3
+    # Sorted oldest → newest.
+    assert data[0]["rss_mb"] == 200.0
+    assert data[1]["rss_mb"] == 225.0
+    assert data[2]["rss_mb"] == 250.0
+    # Each row only carries ts/rss_mb/cpu_pct (small wire payload).
+    for r in data:
+        assert set(r.keys()) == {"ts", "rss_mb", "cpu_pct"}
+
+
+def test_history_endpoint_empty_when_no_data_is_not_error(health_app):
+    app, health_mod, store = health_app
+    with app.test_client() as c:
+        resp = c.get("/api/gateway-health/history")
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+
+
+def test_history_endpoint_honours_hours_window(health_app):
+    app, health_mod, store = health_app
+    now = datetime.now(timezone.utc)
+    # 1 row inside the 1h window, 1 row outside (5h ago).
+    _seed_metric_event(store, ts_iso=(now - timedelta(minutes=30)).isoformat(),
+                       rss_mb=300.0)
+    _seed_metric_event(store, ts_iso=(now - timedelta(hours=5)).isoformat(),
+                       rss_mb=100.0)
+    _wait_flush(store)
+
+    with app.test_client() as c:
+        resp = c.get("/api/gateway-health/history?hours=1")
+        data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]["rss_mb"] == 300.0
+
+
+def test_history_endpoint_clamps_invalid_hours(health_app):
+    app, health_mod, store = health_app
+    with app.test_client() as c:
+        # Garbage param doesn't 500 — falls back to default (24h).
+        resp = c.get("/api/gateway-health/history?hours=garbage")
+        assert resp.status_code == 200
+        # Way-too-large value gets clamped to 168 (1 week) instead of OOMing.
+        resp = c.get("/api/gateway-health/history?hours=999999")
+        assert resp.status_code == 200
+
+
+# ── 3. Live snapshot regression (PR #1146 still works) ─────────────────────
+
+
+def test_live_snapshot_endpoint_still_works(health_app, monkeypatch):
+    app, health_mod, store = health_app
+    # The endpoint must keep returning the canonical 6-field shape even when
+    # the history table is empty AND psutil/ps both fail.
+    monkeypatch.setattr(health_mod, "compute_gateway_health", lambda: {
+        "pid": None,
+        "uptime_seconds": None,
+        "rss_mb": None,
+        "cpu_pct": None,
+        "status": "not_running",
+        "memory_threshold_mb": health_mod.GATEWAY_MEMORY_THRESHOLD_MB,
+    })
+    with app.test_client() as c:
+        resp = c.get("/api/gateway-health")
+        assert resp.status_code == 200
+        data = resp.get_json()
+    for key in ("pid", "uptime_seconds", "rss_mb", "cpu_pct", "status",
+                "memory_threshold_mb"):
+        assert key in data
+
+
+# ── 4. /api/system-health.gateway.history summary ──────────────────────────
+
+
+def test_recent_summary_helper_aggregates_last_hour(health_app):
+    app, health_mod, store = health_app
+    now = datetime.now(timezone.utc)
+    # 3 in-window + 1 out-of-window. Min/max/avg should ignore the old one.
+    _seed_metric_event(store, ts_iso=(now - timedelta(minutes=10)).isoformat(),
+                       rss_mb=200.0)
+    _seed_metric_event(store, ts_iso=(now - timedelta(minutes=30)).isoformat(),
+                       rss_mb=300.0)
+    _seed_metric_event(store, ts_iso=(now - timedelta(minutes=50)).isoformat(),
+                       rss_mb=400.0)
+    _seed_metric_event(store, ts_iso=(now - timedelta(hours=5)).isoformat(),
+                       rss_mb=1000.0)
+    _wait_flush(store)
+    out = health_mod._summarise_gateway_metric_recent(minutes=60)
+    assert out["count"] == 3
+    assert out["min_rss_mb"] == 200.0
+    assert out["max_rss_mb"] == 400.0
+    assert out["avg_rss_mb"] == 300.0
+
+
+def test_recent_summary_helper_returns_zero_when_no_rows(health_app):
+    app, health_mod, store = health_app
+    out = health_mod._summarise_gateway_metric_recent(minutes=60)
+    assert out == {
+        "count": 0,
+        "min_rss_mb": None,
+        "max_rss_mb": None,
+        "avg_rss_mb": None,
+    }


### PR DESCRIPTION
## Summary

Follow-up to PR #1146. #1146 surfaces the CURRENT gateway snapshot (PID, RSS, CPU, uptime) via psutil/ps. This PR persists those snapshots into DuckDB so the gateway-health card can render a **24h memory-pressure sparkline** — the slow ~600 MB → ~945 MB OOM bloat is only obvious from the trend, not a single sample.

Per the MOAT/DuckDB-first rule: historical observability data belongs in DuckDB, not in repeated /proc reads on every dashboard tick.

**Stacked on #1146** — this PR contains #1146's commit at the base; please merge #1146 first. No \`[RELEASE]\` prefix.

### Changes

- \`clawmetry/sync.py\` — new \`capture_gateway_metric(config)\` writes one \`event_type=\"gateway.metric\"\` event per daemon tick. Rate-capped (30s), deduped (±5 MB RSS / ±2% CPU within 5 min). Wired into the main loop next to \`sync_system_snapshot\`.
- \`routes/health.py\` — new \`GET /api/gateway-health/history?hours=24\` returns \`[{ts, rss_mb, cpu_pct}, ...]\` sorted ASC. Empty list (not 4xx) when no events have been captured yet. Existing \`/api/gateway-health\` live snapshot endpoint is unchanged. \`/api/system-health.gateway\` now also carries a \`history: {count, min_rss_mb, max_rss_mb, avg_rss_mb}\` summary for the last hour.
- \`clawmetry/static/js/app.js\` — 240×36 inline SVG sparkline (polyline + filled area + latest-point dot, same pattern as PR #1147's cron-run sparkline). Fetches the history endpoint on card mount; quiet "no history yet" fallback for fresh installs.
- \`tests/test_gateway_metric_history.py\` — 14 cases covering daemon capture, dedupe logic, endpoint contract (ASC sort, empty-data, hours window, invalid params), live-snapshot regression, and summary helper.

## Test plan

- [x] \`pytest tests/test_gateway_metric_history.py\` (14/14 passing locally)
- [x] \`pytest tests/test_gateway_health.py\` regression (35/35 passing — PR #1146 surface untouched)
- [x] AST parse-check on edited Python + JS files
- [ ] Browser E2E: confirm sparkline renders on gateway-health card after daemon writes >2 samples
- [ ] Daemon e2e: leave \`clawmetry sync\` running for >1 min, then \`SELECT count(*) FROM events WHERE event_type='gateway.metric'\` should be ≥1
- [ ] Confirm \`/api/gateway-health/history\` returns empty array (not 500) on a fresh install with no daemon history

🤖 Generated with [Claude Code](https://claude.com/claude-code)