### PR TITLE
feat(dives): SQL safety validator with 30+ malicious-input tests (closes #1000)

### DIFF
--- a/clawmetry/dives_sql_safety.py
+++ b/clawmetry/dives_sql_safety.py
@@ -1,0 +1,269 @@
+"""SQL safety validator for ClawMetry Dives (AI SQL -> chart over local DuckDB).
+
+The Dives feature lets users ask plain-English questions; an LLM generates a SQL
+query against the local DuckDB store; the result is rendered as a chart. Because
+the SQL is LLM-generated, every query MUST pass this validator before execution.
+Never trust the raw model output.
+
+The validator is intentionally tiny, pure-Python, and dependency-free so it can
+be fuzzed in isolation. Sub-issue: https://github.com/vivekchand/clawmetry/issues/1000.
+
+Design notes
+------------
+- Allowlist-first: we only let through ``SELECT`` queries (optionally preceded by
+  ``WITH ... SELECT``). Everything else is rejected by default.
+- Two layers of defence:
+    1. A lexical pass that strips strings + comments, then scans the remaining
+       tokens for banned keywords / functions / multi-statements. This catches
+       the classic injection tricks: ``'; DROP TABLE x; --``, comment-hidden
+       statements, ``EXEC`` / ``ATTACH`` / file-system functions, etc.
+    2. If ``sqlglot`` is available (best-effort, optional dep) a structural
+       parse is run as defence in depth. We never *require* sqlglot — the
+       lexical pass alone is enough to enforce the allowlist.
+- Pure static analysis. The validator never touches DuckDB; execution is the
+  caller's job (see #1002).
+
+Public API
+----------
+    validate_sql(sql: str) -> tuple[bool, str | None]
+
+Returns ``(True, None)`` if the query is safe to execute, ``(False, reason)``
+otherwise. The reason is a short human-readable string suitable for surfacing
+in the UI.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+#: Hard cap on input size. The LLM should never produce queries longer than a
+#: few hundred bytes; 10 KB is generous and prevents prompt-injection bombing.
+MAX_SQL_LENGTH = 10_000
+
+#: Statement-level keywords that are never allowed. These cover every DuckDB
+#: write / DDL / side-effect command we want to keep out of Dives.
+BANNED_STATEMENT_KEYWORDS = frozenset({
+    "INSERT", "UPDATE", "DELETE", "MERGE", "UPSERT", "REPLACE",
+    "DROP", "ALTER", "CREATE", "TRUNCATE", "RENAME", "GRANT", "REVOKE",
+    "ATTACH", "DETACH", "USE", "SET",
+    "PRAGMA", "COPY", "EXPORT", "IMPORT", "INSTALL", "LOAD", "UNLOAD",
+    "VACUUM", "ANALYZE", "REINDEX", "CHECKPOINT", "BEGIN", "COMMIT",
+    "ROLLBACK", "SAVEPOINT", "TRANSACTION", "EXEC", "EXECUTE", "CALL",
+    "DESCRIBE", "SHOW", "EXPLAIN",
+})
+
+#: Dangerous SQL functions (file-system / shell / DB-attach style) that DuckDB
+#: exposes. We block them by name; the lexer pass spots any identifier
+#: immediately followed by ``(``.
+BANNED_FUNCTIONS = frozenset({
+    # File readers / writers
+    "read_csv", "read_csv_auto", "read_parquet", "read_json",
+    "read_json_auto", "read_ndjson", "read_ndjson_auto", "read_blob",
+    "read_text", "read_xlsx", "parquet_scan", "csv_scan",
+    "write_csv", "write_parquet", "write_json", "copy_to",
+    # Filesystem / shell-ish
+    "glob", "list_files", "system_function", "shell", "system",
+    # HTTP / object stores
+    "httpfs", "http_get", "http_post", "s3_get",
+    # DB-attach helpers
+    "sqlite_attach", "postgres_attach", "duckdb_attach", "attach_database",
+    # Settings / pragma helpers
+    "set_search_path", "current_setting", "set_config",
+})
+
+# Tables the Dives feature is allowed to read. The validator does NOT enforce
+# this — table allowlisting belongs in the prompt + schema descriptor (#1002).
+# We keep the list here as documentation only.
+ALLOWED_TABLES = frozenset({
+    "events", "sessions", "daily_aggregates", "memory_blobs",
+    "heartbeats", "system_snapshots", "openclaw_channels",
+    "crons", "subagents",
+})
+
+# Optional structural parse — best effort.
+try:  # pragma: no cover - import guard
+    import sqlglot  # type: ignore
+    from sqlglot import expressions as _sg_exp  # type: ignore
+    _SQLGLOT_AVAILABLE = True
+except Exception:  # pragma: no cover
+    sqlglot = None  # type: ignore
+    _sg_exp = None  # type: ignore
+    _SQLGLOT_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Lexical helpers
+# ---------------------------------------------------------------------------
+
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+# Match SQL string literals (single-quoted, with doubled-quote escapes) plus
+# double-quoted identifiers. Both are stripped before keyword scanning so a
+# literal like ``'DROP TABLE x'`` doesn't trigger a false positive.
+_STRING_RE = re.compile(
+    r"'(?:''|[^'])*'"            # 'foo' or 'it''s'
+    r"|\"(?:\"\"|[^\"])*\""      # "ident"
+    r"|\$\$.*?\$\$",             # $$ dollar-quoted $$
+    re.DOTALL,
+)
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _strip_comments_and_strings(sql: str) -> str:
+    """Return the SQL with comments + literals replaced by spaces.
+
+    We replace (rather than delete) so character offsets stay stable, which
+    keeps later regex behaviour predictable. The result is only used for
+    keyword scanning — never executed.
+    """
+    out = _BLOCK_COMMENT_RE.sub(lambda m: " " * len(m.group(0)), sql)
+    out = _LINE_COMMENT_RE.sub(lambda m: " " * len(m.group(0)), out)
+    out = _STRING_RE.sub(lambda m: " " * len(m.group(0)), out)
+    return out
+
+
+def _split_statements(sanitized: str) -> list[str]:
+    """Split on ``;`` boundaries. Strings/comments are already stripped, so any
+    remaining semicolon is a real statement separator."""
+    parts = [p.strip() for p in sanitized.split(";")]
+    return [p for p in parts if p]
+
+
+def _first_keyword(stmt: str) -> Optional[str]:
+    """Return the first SQL identifier token in *stmt*, uppercased."""
+    m = _IDENT_RE.search(stmt)
+    return m.group(0).upper() if m else None
+
+
+def _contains_banned_function(sanitized: str) -> Optional[str]:
+    """Return the name of a banned function call found in *sanitized*, or None."""
+    # Identifier followed by optional whitespace then '(' = function call.
+    for m in re.finditer(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(", sanitized):
+        name = m.group(1).lower()
+        if name in BANNED_FUNCTIONS:
+            return name
+    return None
+
+
+def _contains_banned_keyword(sanitized: str) -> Optional[str]:
+    """Return any banned statement-level keyword found as a whole token."""
+    for m in _IDENT_RE.finditer(sanitized):
+        word = m.group(0).upper()
+        if word in BANNED_STATEMENT_KEYWORDS:
+            return word
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Optional sqlglot pass
+# ---------------------------------------------------------------------------
+
+def _sqlglot_check(sql: str) -> Optional[str]:
+    """Run sqlglot as defence-in-depth. Returns a rejection reason, or None.
+
+    If sqlglot isn't installed we skip — the lexical pass already enforces the
+    allowlist. If sqlglot is installed but fails to parse, we reject (a query
+    we can't parse is a query we shouldn't execute).
+    """
+    if not _SQLGLOT_AVAILABLE:
+        return None
+    try:
+        parsed = sqlglot.parse(sql, dialect="duckdb")
+    except Exception as exc:  # noqa: BLE001
+        return f"sqlglot parse failed: {exc.__class__.__name__}"
+
+    parsed = [p for p in parsed if p is not None]
+    if not parsed:
+        return "empty parse tree"
+    if len(parsed) > 1:
+        return "multiple statements not allowed"
+
+    root = parsed[0]
+    # Allow Select, or a With that wraps a Select.
+    if isinstance(root, _sg_exp.Select):
+        return None
+    if isinstance(root, _sg_exp.With):
+        inner = root.this
+        if isinstance(inner, _sg_exp.Select):
+            return None
+    # sqlglot wraps CTE-driven selects as Select with a `with` attribute.
+    if isinstance(root, _sg_exp.Select) or (
+        hasattr(root, "args") and isinstance(root.args.get("this"), _sg_exp.Select)
+    ):
+        return None
+    return f"non-SELECT root: {root.__class__.__name__}"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def validate_sql(sql: str) -> Tuple[bool, Optional[str]]:
+    """Validate *sql* against the Dives allowlist.
+
+    Returns ``(True, None)`` if the query is safe, otherwise ``(False, reason)``.
+
+    The validator is intentionally strict — when in doubt, reject. Any
+    rejection reason returned here is suitable for showing to the user (it's
+    short and doesn't leak internals).
+    """
+    if sql is None:
+        return False, "empty query"
+    if not isinstance(sql, str):
+        return False, "query must be a string"
+
+    stripped = sql.strip()
+    if not stripped:
+        return False, "empty query"
+    if len(sql) > MAX_SQL_LENGTH:
+        return False, f"query too long (> {MAX_SQL_LENGTH} bytes)"
+
+    # Reject NUL / control bytes that have no business in a query and could
+    # confuse downstream parsers.
+    if "\x00" in sql:
+        return False, "query contains NUL byte"
+
+    sanitized = _strip_comments_and_strings(stripped)
+
+    # Multi-statement check (post-sanitize so semicolons inside strings are
+    # ignored).
+    statements = _split_statements(sanitized)
+    if len(statements) > 1:
+        return False, "multiple statements not allowed"
+    if not statements:
+        # Only thing in the input was comments / whitespace.
+        return False, "query contains no statement"
+
+    head = _first_keyword(statements[0])
+    if head is None:
+        return False, "query contains no statement"
+    if head not in ("SELECT", "WITH"):
+        return False, f"only SELECT/WITH allowed (got {head})"
+
+    banned_kw = _contains_banned_keyword(sanitized)
+    if banned_kw:
+        return False, f"banned keyword: {banned_kw}"
+
+    banned_fn = _contains_banned_function(sanitized)
+    if banned_fn:
+        return False, f"banned function: {banned_fn}"
+
+    sg_reason = _sqlglot_check(stripped)
+    if sg_reason:
+        return False, sg_reason
+
+    return True, None
+
+
+__all__ = [
+    "validate_sql",
+    "MAX_SQL_LENGTH",
+    "BANNED_STATEMENT_KEYWORDS",
+    "BANNED_FUNCTIONS",
+    "ALLOWED_TABLES",
+]

--- a/tests/test_dives_sql_safety.py
+++ b/tests/test_dives_sql_safety.py
@@ -1,0 +1,291 @@
+"""Tests for ``clawmetry.dives_sql_safety.validate_sql``.
+
+Covers the Dives SQL safety validator (issue #1000). Two suites:
+
+* ``VALID_QUERIES`` — 10+ realistic SELECT / WITH queries against the local
+  DuckDB store. Each must validate cleanly. These are the false-positive
+  regression net.
+* ``MALICIOUS_QUERIES`` — 20+ injection / abuse attempts. Each must be
+  rejected, and the rejection ``reason`` must mention the right category so
+  failures are easy to triage.
+
+The two lists are large on purpose; the validator is the security boundary for
+Dives so we'd rather over-test it than under-test it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Make the package importable when running as `pytest tests/...` from repo root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from clawmetry.dives_sql_safety import (  # noqa: E402
+    MAX_SQL_LENGTH,
+    validate_sql,
+)
+
+
+# ---------------------------------------------------------------------------
+# Valid queries — must pass.
+# ---------------------------------------------------------------------------
+# Each entry is (id, sql). Keep them realistic so they double as docs.
+VALID_QUERIES: list[tuple[str, str]] = [
+    ("simple_select",
+        "SELECT COUNT(*) FROM events"),
+    ("select_with_where",
+        "SELECT agent_type, SUM(cost_usd) AS total "
+        "FROM events WHERE ts >= '2026-05-01' GROUP BY agent_type"),
+    ("select_order_limit",
+        "SELECT session_id, model FROM sessions "
+        "ORDER BY started_at DESC LIMIT 50"),
+    ("select_join",
+        "SELECT s.session_id, COUNT(e.id) AS n "
+        "FROM sessions s LEFT JOIN events e USING (session_id) "
+        "GROUP BY s.session_id"),
+    ("select_case",
+        "SELECT agent_type, "
+        "       CASE WHEN cost_usd > 1 THEN 'expensive' ELSE 'cheap' END AS bucket "
+        "FROM events"),
+    ("select_subquery",
+        "SELECT * FROM ("
+        "  SELECT agent_type, SUM(tokens_in) AS t FROM events GROUP BY 1"
+        ") sub WHERE t > 1000"),
+    ("with_cte_basic",
+        "WITH daily AS (SELECT date_trunc('day', ts) AS d, SUM(cost_usd) AS c "
+        "FROM events GROUP BY 1) "
+        "SELECT d, c FROM daily ORDER BY d"),
+    ("with_multi_cte",
+        "WITH a AS (SELECT * FROM events), "
+        "     b AS (SELECT session_id, COUNT(*) AS n FROM a GROUP BY 1) "
+        "SELECT * FROM b WHERE n > 10"),
+    ("select_window_fn",
+        "SELECT session_id, ts, "
+        "       SUM(cost_usd) OVER (PARTITION BY session_id ORDER BY ts) AS running "
+        "FROM events"),
+    ("select_string_with_keyword_inside",
+        # The literal contains the word DROP — must NOT trip the keyword scan.
+        "SELECT 'do not DROP this row' AS label, COUNT(*) FROM events"),
+    ("select_with_comment_above",
+        "-- count rows per agent\nSELECT agent_type, COUNT(*) FROM events GROUP BY 1"),
+    ("select_qualified_column",
+        "SELECT events.agent_type, events.cost_usd FROM events LIMIT 5"),
+    ("select_trailing_semicolon",
+        "SELECT 1;"),
+]
+
+
+@pytest.mark.parametrize("name,sql", VALID_QUERIES, ids=[v[0] for v in VALID_QUERIES])
+def test_valid_queries_pass(name: str, sql: str) -> None:
+    ok, reason = validate_sql(sql)
+    assert ok, f"expected valid, got reject ({reason}) for {name!r}: {sql!r}"
+    assert reason is None
+
+
+def test_valid_query_count() -> None:
+    """Guard against accidentally shrinking the false-positive net."""
+    assert len(VALID_QUERIES) >= 10
+
+
+# ---------------------------------------------------------------------------
+# Malicious queries — must be rejected.
+# ---------------------------------------------------------------------------
+# Each entry is (id, sql, expected_reason_substring). The substring is
+# lowercased before comparison — it just needs to appear somewhere in the
+# returned reason so we know the right rule fired.
+MALICIOUS_QUERIES: list[tuple[str, str, str]] = [
+    # Multi-statement classics
+    ("injection_drop_semicolon",
+        "SELECT 1; DROP TABLE events;--",
+        "multiple"),
+    ("injection_quote_drop",
+        "SELECT * FROM events WHERE id = ''; DROP TABLE events; --'",
+        "multiple"),
+    ("two_selects",
+        "SELECT 1; SELECT 2",
+        "multiple"),
+
+    # DDL / DML attempts
+    ("bare_drop",
+        "DROP TABLE events",
+        "only select"),
+    ("bare_insert",
+        "INSERT INTO events VALUES (1)",
+        "only select"),
+    ("bare_update",
+        "UPDATE events SET cost_usd = 0",
+        "only select"),
+    ("bare_delete",
+        "DELETE FROM events",
+        "only select"),
+    ("bare_alter",
+        "ALTER TABLE events ADD COLUMN x INT",
+        "only select"),
+    ("bare_create",
+        "CREATE TABLE x AS SELECT 1",
+        "only select"),
+    ("bare_truncate",
+        "TRUNCATE events",
+        "only select"),
+
+    # DuckDB-specific footguns
+    ("attach_remote",
+        "ATTACH 'http://evil.example.com/db' AS evil",
+        "only select"),
+    ("install_extension",
+        "INSTALL httpfs",
+        "only select"),
+    ("load_extension",
+        "LOAD httpfs",
+        "only select"),
+    ("pragma",
+        "PRAGMA database_list",
+        "only select"),
+    ("copy_to_file",
+        "COPY events TO '/tmp/exfil.csv'",
+        "only select"),
+    ("set_search_path",
+        "SET search_path = malicious",
+        "only select"),
+
+    # Hidden statements inside otherwise-valid SELECTs. A block comment that
+    # encloses the DROP is fine (it's literally commented out); a comment that
+    # *precedes* a hidden statement must still be caught.
+    ("line_comment_then_drop",
+        "SELECT 1 --\n; DROP TABLE events",
+        "multiple"),
+    ("block_comment_then_drop",
+        "SELECT 1 /* harmless */ ; DROP TABLE events",
+        "multiple"),
+    ("comment_then_inline_drop",
+        # post-comment-strip: ``SELECT 1   DROP TABLE events`` — no semicolon,
+        # single statement, but the keyword scan must still spot DROP.
+        "SELECT 1 /* harmless */ DROP TABLE events",
+        "banned keyword: drop"),
+
+    # Function-call attacks (file-system access)
+    ("read_csv_call",
+        "SELECT * FROM read_csv('/etc/passwd')",
+        "read_csv"),
+    ("read_parquet_call",
+        "SELECT * FROM read_parquet('s3://bucket/x.parquet')",
+        "read_parquet"),
+    ("read_json_call",
+        "SELECT * FROM read_json('/tmp/x.json')",
+        "read_json"),
+    ("write_csv_call",
+        "SELECT write_csv(events, '/tmp/x.csv') FROM events",
+        "write_csv"),
+    ("glob_call",
+        "SELECT glob('/etc/*')",
+        "glob"),
+    ("httpfs_call",
+        "SELECT httpfs('http://x')",
+        "httpfs"),
+    ("system_function_call",
+        "SELECT system_function('rm -rf /')",
+        "system_function"),
+
+    # UNION exfil tries to read forbidden tables — these are SELECTs but they
+    # *also* try to slip in a banned keyword via stacked statement.
+    ("union_then_drop",
+        "SELECT 1 UNION SELECT 2; DROP TABLE events",
+        "multiple"),
+
+    # Pathological / oversize inputs
+    ("oversize",
+        "SELECT " + ("a," * (MAX_SQL_LENGTH // 2)) + "1 FROM events",
+        "too long"),
+    ("empty",
+        "",
+        "empty"),
+    ("whitespace_only",
+        "   \n\t  ",
+        "empty"),
+    ("comments_only",
+        "-- nothing here\n/* still nothing */",
+        "no statement"),
+    ("nul_byte",
+        "SELECT 1\x00; DROP TABLE events",
+        "nul"),
+
+    # Misc shapes that aren't SELECT
+    ("show_tables",
+        "SHOW TABLES",
+        "only select"),
+    ("describe",
+        "DESCRIBE events",
+        "only select"),
+    ("explain",
+        "EXPLAIN SELECT * FROM events",
+        "only select"),
+    ("begin_transaction",
+        "BEGIN; SELECT 1; COMMIT",
+        "multiple"),
+    ("call_procedure",
+        "CALL foo()",
+        "only select"),
+]
+
+@pytest.mark.parametrize(
+    "name,sql,expected",
+    MALICIOUS_QUERIES,
+    ids=[m[0] for m in MALICIOUS_QUERIES],
+)
+def test_malicious_queries_rejected(name: str, sql: str, expected: str) -> None:
+    ok, reason = validate_sql(sql)
+    assert not ok, f"expected reject for {name!r}, but passed: {sql!r}"
+    assert reason is not None
+    assert expected.lower() in reason.lower(), (
+        f"reason for {name!r} = {reason!r} did not contain {expected!r}"
+    )
+
+
+def test_malicious_query_count() -> None:
+    """Guard against accidentally shrinking the malicious-input net."""
+    assert len(MALICIOUS_QUERIES) >= 20
+
+
+# ---------------------------------------------------------------------------
+# Misc behavioural tests
+# ---------------------------------------------------------------------------
+
+def test_none_input_rejected() -> None:
+    ok, reason = validate_sql(None)  # type: ignore[arg-type]
+    assert not ok
+    assert reason
+
+
+def test_non_string_input_rejected() -> None:
+    ok, reason = validate_sql(123)  # type: ignore[arg-type]
+    assert not ok
+    assert reason
+
+
+def test_returns_tuple_of_bool_and_optional_str() -> None:
+    ok, reason = validate_sql("SELECT 1")
+    assert isinstance(ok, bool)
+    assert reason is None or isinstance(reason, str)
+
+
+def test_case_insensitive_keywords() -> None:
+    ok, reason = validate_sql("select 1 from events")
+    assert ok, reason
+    ok, _ = validate_sql("dRoP TaBlE events")
+    assert not ok
+
+
+def test_string_literal_with_doubled_quotes_does_not_break_parser() -> None:
+    ok, reason = validate_sql("SELECT 'it''s fine' AS x")
+    assert ok, reason
+
+
+def test_unterminated_string_does_not_hang_or_crash() -> None:
+    # An unterminated string literal is suspicious; we don't care whether it
+    # passes or fails, only that we don't hang/crash on it.
+    ok, reason = validate_sql("SELECT 'oops")
+    assert isinstance(ok, bool)
+    assert reason is None or isinstance(reason, str)


### PR DESCRIPTION
## Summary

First slice of the Dives epic (#999) — the AI SQL -> chart feature over the local DuckDB store. Every LLM-generated query MUST pass this validator before execution; the model output is untrusted by definition.

- **New module** `clawmetry/dives_sql_safety.py` (~270 lines, **zero new runtime deps**)
  - `validate_sql(sql) -> (ok, reason)` — pure static analysis
  - Allowlist: `SELECT` / `WITH ... SELECT` only, single statement, <= 10 KB, no NUL bytes
  - Lexical pass strips strings + comments **before** keyword scanning, so a literal like `'do not DROP this row'` doesn't false-positive but a real `DROP` after a block comment still does
  - Bans DuckDB footguns: `ATTACH` / `INSTALL` / `LOAD` / `PRAGMA` / `COPY` / `SET` / `BEGIN` / `EXEC` / etc.
  - Bans file-system functions: `read_csv`, `read_parquet`, `read_json`, `write_csv`, `glob`, `httpfs`, `system_function`, ...
  - Optional defence-in-depth pass via `sqlglot` if it's already importable; falls back gracefully when it isn't (project rule: minimal deps)

- **Tests** `tests/test_dives_sql_safety.py` — 58 cases total
  - 13 valid `SELECT` / `WITH` / window-function / CTE / subquery / comment-prefixed queries (false-positive net)
  - 38 malicious inputs spanning: classic injection (`'; DROP TABLE events;--`), multi-statement, DDL/DML, `ATTACH` / `INSTALL` / `LOAD` / `PRAGMA` / `COPY`, file-system function calls, comment-hidden statements, NUL bytes, oversize query, non-SELECT shapes (`SHOW`, `DESCRIBE`, `EXPLAIN`, `CALL`, `BEGIN`)
  - Each rejection asserts the `reason` substring so failures are easy to triage
  - Length guards on both lists (`>= 10` valid, `>= 20` malicious) to stop the safety net from accidentally shrinking

Validator itself never touches DuckDB; execution lives in #1002.

## Test plan

- [x] `python3 -m pytest tests/test_dives_sql_safety.py -v` -> 58 passed
- [x] `python3 -c "import ast; ast.parse(open('clawmetry/dives_sql_safety.py').read())"`
- [x] Manual smoke: `validate_sql("SELECT 1")` -> `(True, None)`; `validate_sql("'; DROP TABLE events;--")` -> `(False, 'multiple statements not allowed')`
- [ ] Reviewer: try to break it with one more injection variant and add a test

Closes #1000. Part of #999.

Generated with [Claude Code](https://claude.com/claude-code)