### PR TITLE
fix(ux): alerts badge + notifications count + gw-setup non-Docker path + overlay z-stack + NemoClaw dead-end (closes #1127 UX bucket)

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -96,12 +96,31 @@
     }
     renderRules();
 
+    // Bug #1127: Badge counted local OSS fires while page only checked cloud
+    // history -> badge "20" with page saying "no alerts fired". Fall back to
+    // the same local /api/alerts/history the nav badge uses when cloud has
+    // nothing (or errors), so the two stay consistent.
     try {
-      const hist = await fetch('/api/cloud-proxy/api/alerts/history?limit=10')
+      const hist = await fetch('/api/cloud-proxy/api/alerts/history?limit=20')
         .then(r => r.json());
       alertsState.history = hist.history || [];
     } catch {
       alertsState.history = [];
+    }
+    if (!alertsState.history.length) {
+      try {
+        const local = await fetch('/api/alerts/history?limit=20').then(r => r.json());
+        const localFires = (local.alerts || []).map(a => ({
+          id: a.id,
+          fired_at: a.fired_at,
+          resolved_at: a.acknowledged ? a.ack_at : null,
+          alert_id: a.rule_id,
+          payload: { name: a.type, actual_value: a.message, threshold_unit: '' },
+        }));
+        alertsState.history = localFires;
+      } catch {
+        // keep empty
+      }
     }
     renderHistory();
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3289,7 +3289,10 @@ async function loadNemoClaw() {
 
     if (!data.installed) {
       if (tab) tab.style.display = 'none';
-      page.innerHTML = '<div style="padding:40px 20px;text-align:center;color:var(--text-muted);font-size:14px;">NemoClaw not installed on this host.<br><span style="font-size:12px;">Install via <code style="background:var(--bg-secondary);padding:2px 6px;border-radius:3px;">pip install nemoclaw</code></span></div>';
+      // Issue #1127: previously said "pip install nemoclaw" but the package
+      // is not yet publicly released (only a 0.0.0a1 placeholder exists on
+      // PyPI). Replace with an honest "Coming soon" empty state.
+      page.innerHTML = '<div style="padding:40px 20px;text-align:center;color:var(--text-muted);font-size:14px;">NemoClaw governance is not yet available on this host.<br><span style="font-size:12px;">Coming soon &mdash; NVIDIA NeMo Guardrails integration is in private preview.</span></div>';
       return;
     }
 

--- a/clawmetry/static/js/gw-setup.js
+++ b/clawmetry/static/js/gw-setup.js
@@ -38,11 +38,23 @@ async function checkGwConfig() {
         const d2 = await r2.json();
         if (d2.ok) { updateGwStatus(true, d2.url); return; }
       }
+      // Bug #1127: don't z-stack the gw-setup overlay on top of an already-
+      // open cloud modal — the two share the same backdrop and confuse the
+      // user. Defer until the cloud modal closes.
+      if (_isCloudModalOpen()) return;
       document.getElementById('gw-setup-overlay').style.display = 'flex';
     } else {
       updateGwStatus(true, d.url);
     }
   } catch(e) {}
+}
+
+function _isCloudModalOpen() {
+  var cm = document.getElementById('cloud-modal-overlay');
+  if (cm && cm.style.display && cm.style.display !== 'none') return true;
+  // Defensive: also honour a generic .cloud-modal.active marker if present.
+  if (document.querySelector && document.querySelector('.cloud-modal.active')) return true;
+  return false;
 }
 
 function updateGwStatus(connected, url) {
@@ -106,6 +118,10 @@ document.addEventListener('DOMContentLoaded', checkGwConfig);
 // ClawMetry Cloud CTA
 var _cloudEmail = '';
 function openCloudModal() {
+  // Bug #1127: suppress the gateway-setup overlay so the user doesn't see two
+  // stacked modals (cloud CTA on top, gw-setup peeking behind it).
+  var gw = document.getElementById('gw-setup-overlay');
+  if (gw && gw.dataset.mandatory !== 'true') gw.style.display = 'none';
   var _cmo = document.getElementById('cloud-modal-overlay');
   document.body.appendChild(_cmo);
   _cmo.style.display = 'flex';

--- a/clawmetry/templates/tabs/notifications.html
+++ b/clawmetry/templates/tabs/notifications.html
@@ -145,10 +145,13 @@
     var banner = document.getElementById('notifications-free-banner');
     if (banner) banner.style.display = (state.tier === 'free') ? 'block' : 'none';
 
-    // Status line
+    // Status line. Bug #1127: previously counted state.rows.length, which
+    // includes disabled rows (those render as "Connect" cards). Count only
+    // rows whose card actually says "✓ Edit" — i.e. enabled — so the header
+    // matches what the user sees in the grid.
     var status = document.getElementById('notifications-status');
     if (status) {
-      var n = state.rows.length;
+      var n = state.rows.filter(function(r){ return r && r.enabled; }).length;
       status.textContent = (n ? n + ' channel' + (n === 1 ? '' : 's') + ' configured' : 'No channels configured yet.')
         + ' · plan: ' + state.tier;
     }

--- a/dashboard.py
+++ b/dashboard.py
@@ -10039,7 +10039,12 @@ DASHBOARD_HTML = r"""
     <input id="gw-token-input" type="password" placeholder="Paste your gateway token" 
       style="width:100%; padding:12px 16px; border:1px solid var(--border-primary, #444); border-radius:8px; background:var(--bg-primary, #111); color:var(--text-primary, #fff); font-size:14px; font-family:monospace; box-sizing:border-box; outline:none; margin-bottom:8px;"
       onkeydown="if(event.key==='Enter')gwSetupConnect()">
-    <p id="gw-setup-hint" style="color:var(--text-muted, #888); font-size:12px; margin:0 0 4px; text-align:left;">Find it: <code style="color:var(--text-accent, #0af); background:rgba(0,170,255,0.1); padding:2px 6px; border-radius:4px;">docker exec $(docker ps -q) env | grep TOKEN</code> or <code style="color:var(--text-accent, #0af); background:rgba(0,170,255,0.1); padding:2px 6px; border-radius:4px;">gateway.auth.token</code></p>
+    <div id="gw-setup-hint" style="color:var(--text-muted, #888); font-size:12px; margin:0 0 4px; text-align:left;">
+      <div style="font-weight:600;color:var(--text-secondary, #aaa);margin:6px 0 4px;">Local install (pip / brew / install.sh)</div>
+      <code style="display:block;color:var(--text-accent, #0af); background:rgba(0,170,255,0.1); padding:6px 8px; border-radius:4px; font-size:11px; word-break:break-all;">cat ~/.openclaw/openclaw.json | python3 -c "import json,sys;print(json.load(sys.stdin)['gateway']['auth']['token'])"</code>
+      <div style="font-weight:600;color:var(--text-secondary, #aaa);margin:8px 0 4px;">Docker install</div>
+      <code style="display:block;color:var(--text-accent, #0af); background:rgba(0,170,255,0.1); padding:6px 8px; border-radius:4px; font-size:11px; word-break:break-all;">docker exec $(docker ps -q) env | grep TOKEN</code>
+    </div>
     <p id="gw-url-hint" style="color:var(--text-muted, #666); font-size:11px; margin:0 0 16px; text-align:left;">Optional: <input id="gw-url-input" type="text" placeholder="http://localhost:18789 (auto-detected)" style="width:70%; padding:4px 8px; border:1px solid var(--border-primary, #444); border-radius:4px; background:var(--bg-primary, #111); color:var(--text-primary, #fff); font-size:11px; font-family:monospace;"></p>
     <div id="gw-setup-error" style="color:#ff4444; font-size:13px; margin-bottom:12px; display:none;"></div>
     <div id="gw-setup-status" style="color:var(--text-accent, #0af); font-size:13px; margin-bottom:12px; display:none;"></div>

--- a/tests/test_issue_1127_ux_dead_ends.py
+++ b/tests/test_issue_1127_ux_dead_ends.py
@@ -1,0 +1,120 @@
+"""Regression checks for the issue-#1127 UX dead-end fixes.
+
+Each test pins one of the 5 fixes so future refactors don't silently re-
+introduce the bad copy / code path.
+
+Why a static scan instead of a browser test: every fix is a frontend string
+inside Python templates or a JS file. Spinning up Playwright for one-line
+copy checks is overkill — a focused grep is sufficient and runs in <100 ms.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read(rel_path: str) -> str:
+    with open(os.path.join(ROOT, rel_path), encoding="utf-8") as fh:
+        return fh.read()
+
+
+# ── Bug 1 ────────────────────────────────────────────────────────────────────
+def test_bug1_alerts_page_falls_back_to_local_history() -> None:
+    """When cloud history is empty, the Alerts page now reads local fires so
+    the badge (which already counts local) and the page agree."""
+    js = _read("clawmetry/static/js/alerts.js")
+    assert "/api/alerts/history?limit=20" in js, (
+        "alerts.js must fall back to local /api/alerts/history when cloud "
+        "history returns empty — otherwise the nav badge can show N fires "
+        "while the page says 'No alerts have fired yet'."
+    )
+
+
+# ── Bug 2 ────────────────────────────────────────────────────────────────────
+def test_bug2_notifications_count_only_enabled_rows() -> None:
+    """Disabled channel rows render as 'Connect' cards, so the header
+    'N channels configured' must only count enabled rows."""
+    html = _read("clawmetry/templates/tabs/notifications.html")
+    # Look for the filter we added that excludes disabled rows.
+    assert "state.rows.filter" in html and "r.enabled" in html, (
+        "notifications.html must count only enabled channels in the status "
+        "line; otherwise the header disagrees with the card grid."
+    )
+
+
+# ── Bug 3 ────────────────────────────────────────────────────────────────────
+def test_bug3_gw_setup_modal_has_non_docker_path() -> None:
+    """The gateway-setup modal must show a local-install path before Docker."""
+    py = _read("dashboard.py")
+    assert "Local install (pip / brew / install.sh)" in py, (
+        "Gateway-setup modal must include a local-install instruction so "
+        "non-Docker users have a working command."
+    )
+    # Docker block must still be present for Docker users.
+    assert "Docker install" in py
+
+
+# ── Bug 4 ────────────────────────────────────────────────────────────────────
+def test_bug4_gw_setup_skips_when_cloud_modal_open() -> None:
+    """The gateway-setup overlay must defer when a cloud modal is open, and
+    openCloudModal must hide the gateway overlay when it shows."""
+    js = _read("clawmetry/static/js/gw-setup.js")
+    assert "_isCloudModalOpen" in js, "gw-setup.js missing cloud-modal guard"
+    assert "cloud-modal-overlay" in js
+    # And the cloud modal open path explicitly hides the gw overlay. Match
+    # within the openCloudModal function body (its closing `}` ends the
+    # block).
+    m = re.search(r"function openCloudModal\([^)]*\)\s*\{([\s\S]*?)^\}", js, re.MULTILINE)
+    assert m, "could not locate openCloudModal() body in gw-setup.js"
+    body = m.group(1)
+    assert "gw-setup-overlay" in body and "display = 'none'" in body, (
+        "openCloudModal must suppress gw-setup-overlay (set display='none')"
+    )
+
+
+# ── Bug 5 ────────────────────────────────────────────────────────────────────
+def test_bug5_no_pip_install_nemoclaw_in_user_copy() -> None:
+    """`pip install nemoclaw` only exists as a 0.0.0a1 placeholder on PyPI —
+    instructing users to run it is misleading. Make sure no user-facing
+    string still suggests that command."""
+    checked = [
+        "clawmetry/static/js/app.js",
+        "dashboard.py",
+        "clawmetry/templates/tabs/nemoclaw.html",
+    ]
+    bad: list[str] = []
+    for rel in checked:
+        try:
+            lines = _read(rel).splitlines()
+        except FileNotFoundError:
+            continue
+        for i, line in enumerate(lines, 1):
+            if "pip install nemoclaw" not in line:
+                continue
+            stripped = line.lstrip()
+            # Allow it to live in a code comment that documents the fix.
+            is_comment = (
+                stripped.startswith("//")
+                or stripped.startswith("#")
+                or stripped.startswith("/*")
+                or stripped.startswith("*")
+            )
+            if not is_comment:
+                bad.append(f"{rel}:{i}: {line.strip()}")
+    assert not bad, (
+        "User-facing copy still suggests `pip install nemoclaw`, but the "
+        "package is not publicly available:\n  " + "\n  ".join(bad)
+    )
+
+
+def test_bug5_nemoclaw_empty_state_says_coming_soon() -> None:
+    """Empty state must be an honest 'Coming soon' rather than a broken
+    install command."""
+    js = _read("clawmetry/static/js/app.js")
+    assert "Coming soon" in js and "NemoClaw governance is not yet available" in js, (
+        "NemoClaw empty state must mention 'Coming soon' instead of "
+        "suggesting `pip install nemoclaw`."
+    )


### PR DESCRIPTION
## Summary

Five small, isolated UX dead-end fixes audited under issue #1127:

- **Bug 1 — Alerts badge inconsistency**: badge counted local fires from `/api/alerts/active`, page only read cloud history. `alerts.js` now falls back to the same local `/api/alerts/history` when cloud history is empty so badge and page agree. *(option a — make page reflect what badge counts.)*
- **Bug 2 — Notifications "1 channel configured" but all cards show Connect**: status line counted `state.rows.length` (includes disabled rows); cards only render as Edit for enabled rows. Filter to enabled-only. *(option a — fix count to match cards.)*
- **Bug 3 — Gateway-setup modal only documented Docker**: added a "Local install (pip / brew / install.sh)" block before the Docker block, using a `jq`-free Python one-liner over `~/.openclaw/openclaw.json`.
- **Bug 4 — `openCloudModal()` z-stacked over gw-setup**: guarded `checkGwConfig()` with `_isCloudModalOpen()`, and `openCloudModal()` now proactively hides any showing gateway-setup overlay (unless `data-mandatory="true"`).
- **Bug 5 — NemoClaw empty state told users to `pip install nemoclaw`**: `nemoclaw` only exists on PyPI as a 0.0.0a1 placeholder — not a working package. Replaced with "Coming soon — private preview" copy. *(option b — honest empty state.)*

## Scope discipline

`clawmetry/static/js/app.js` is being edited in parallel by Group B. The only edit here is a single string for Bug 5's empty-state copy (3 lines including the comment); no surrounding logic touched.

## Test plan
- [x] `python3 -m pytest tests/test_issue_1127_ux_dead_ends.py -v` — 6/6 passing
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — OK
- [x] `node --check` on each modified JS file — OK
- [ ] Manual smoke (post-merge): open Alerts tab with empty cloud, confirm page matches badge
- [ ] Manual smoke: Notifications tab with a disabled channel — header reads 0
- [ ] Manual smoke: token-less first launch — only one modal shows when clicking Cloud CTA