### PR TITLE
fix(sync): kill dead WS reconnect + adaptive cycle sleep (real-time MOAT)

### DIFF
--- a/clawmetry/relay.py
+++ b/clawmetry/relay.py
@@ -1,44 +1,47 @@
-"""clawmetry/relay.py — node-side WebSocket relay client (epic #964 phase 3b).
+"""clawmetry/relay.py — DEPRECATED stub.
 
-Maintains a long-lived WebSocket to `wss://app.clawmetry.com/api/node/relay`,
-waits for `{type:"query"}` frames from the cloud, dispatches each via
-`routes.local_query.relay_dispatch()`, returns chunked responses.
+The node-side WebSocket relay client was retired 2026-05-13. The cloud
+endpoint ``wss://app.clawmetry.com/api/node/relay`` was killed 2026-05-12
+(returns 404 in prod) after the simple-websocket handshake-400 dead end
+documented in ``reference_ws_handshake_400_unsolved.md``. Per
+``project_relay_transport_decision``, the replacement is heartbeat
+piggyback: the cloud attaches ``pending_queries`` to the heartbeat
+response, the daemon answers via ``/ingest/cache``. No new long-lived
+connections.
 
-Design notes
-------------
-- **Base install dep** since 0.12.166. `websocket-client` is ~100 KB pure
-  Python; the previous `extras_require["relay"]` opt-in caused cloud users
-  to silently miss the relay.
-- **Daemon thread.** One thread per process. Reconnects with exponential
-  backoff (2s → 60s cap). The sync daemon's main loop is unaware.
-- **Skipped on OSS-local mode.** If `config` has no `api_key` / `node_id`,
-  the relay never starts — local-only OSS users pay no overhead.
-- **Privacy boundary unchanged.** Encrypted blobs stay encrypted; plaintext
-  columns (token counts, timestamps, event types) ride the WS in the clear
-  (TLS-protected). Same trust model as today's heartbeat / ingest.
+This module is kept as a no-op stub so:
+  * old daemon installs that still ``from clawmetry import relay`` don't
+    crash on import, and
+  * the existing unit tests in ``tests/test_relay.py`` can still import
+    the dispatch / chunking helpers (which are unrelated to the dead WS
+    supervisor and continue to drive the heartbeat-piggyback query path
+    via ``routes.local_query.relay_dispatch``).
 
-Tests live in `tests/test_relay.py` and mock the WebSocket layer.
+The reconnect supervisor (``_relay_supervisor``) is intentionally NOT
+exported anymore — calling ``start_relay_thread`` is a no-op that
+returns ``None``.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 import threading
-import time
 from typing import Optional
 
 log = logging.getLogger(__name__)
 
+# Historical constants — preserved so any external code that imported them
+# (or any test that asserts on the module surface) keeps working.
 RELAY_URL_DEFAULT = "wss://app.clawmetry.com/api/node/relay"
 CHUNK_ROWS = 100               # max rows per response frame
 RECONNECT_INITIAL_SEC = 2
 RECONNECT_MAX_SEC = 60
-RECV_TIMEOUT_SEC = 30          # forces a heartbeat ping when idle
+RECV_TIMEOUT_SEC = 30
 
 # Shapes the node advertises in its register frame. Mirrors the allowlist in
-# `routes/local_query._SHAPES` — keep these in sync.
+# ``routes/local_query._SHAPES`` — keep these in sync (the heartbeat-piggyback
+# replacement uses the same dispatch table, so the drift test stays useful).
 _CAPABILITIES = [
     "query.events",
     "query.sessions",
@@ -49,107 +52,23 @@ _CAPABILITIES = [
 
 
 def start_relay_thread(config: dict, version: str = "unknown") -> Optional[threading.Thread]:
-    """Spin up a daemon thread that maintains the WS to cloud.
+    """No-op since 2026-05-13. See module docstring.
 
-    Returns the thread object on success, ``None`` when relay can't or
-    shouldn't run (no cloud account, `websocket-client` missing). Callers
-    don't need to do anything with the returned thread — it's daemon=True.
+    Returns ``None`` unconditionally so callers' ``if t:`` guards stay
+    valid. Logged at DEBUG (not INFO/WARNING) so users don't see a
+    misleading "relay disabled" line on every daemon start.
     """
-    api_key = (config or {}).get("api_key")
-    node_id = (config or {}).get("node_id")
-    if not api_key or not node_id:
-        log.debug("relay: no cloud account (api_key/node_id missing) — relay disabled")
-        return None
-    try:
-        import websocket  # noqa: F401 — pull dep early to fail fast
-    except ImportError:
-        # 0.12.166+ ships websocket-client as a base dep, so this branch
-        # only fires on a corrupt install. Keep the message anyway in case
-        # someone's pinning to an older clawmetry transitively.
-        log.warning(
-            "relay: websocket-client not importable. The base install should "
-            "include it; reinstall with `pip install --force-reinstall clawmetry`.")
-        return None
-
-    relay_url = os.environ.get("CLAWMETRY_RELAY_URL", RELAY_URL_DEFAULT)
-    t = threading.Thread(
-        target=_relay_supervisor,
-        args=(relay_url, api_key, node_id, version),
-        daemon=True,
-        name="clawmetry-relay",
+    log.debug(
+        "relay: start_relay_thread is a no-op (WS retired 2026-05-13, "
+        "replaced by heartbeat-piggyback per project_relay_transport_decision)"
     )
-    t.start()
-    log.info("relay: thread started → %s", relay_url)
-    return t
-
-
-def _relay_supervisor(relay_url: str, api_key: str, node_id: str, version: str) -> None:
-    """Reconnect loop. Each call to `_run_once` is one WS session; on any
-    exception we backoff and retry. Backoff resets after a clean exit."""
-    backoff = RECONNECT_INITIAL_SEC
-    while True:
-        try:
-            _run_once(relay_url, api_key, node_id, version)
-            # Clean exit (server closed gracefully) — reset backoff.
-            backoff = RECONNECT_INITIAL_SEC
-            log.info("relay: connection closed by server; reconnecting in %ds", backoff)
-            time.sleep(backoff)
-        except Exception as e:  # noqa: BLE001 — any failure → retry
-            log.warning("relay: error: %s — reconnecting in %ds", str(e)[:200], backoff)
-            time.sleep(backoff)
-            backoff = min(backoff * 2, RECONNECT_MAX_SEC)
-
-
-def _run_once(relay_url: str, api_key: str, node_id: str, version: str) -> None:
-    """One full WS session lifecycle: connect → register → dispatch
-    incoming frames → return. Raises on any networking failure so the
-    supervisor's backoff loop kicks in."""
-    import websocket
-    url = f"{relay_url}?token={api_key}&node_id={node_id}"
-    ws = websocket.create_connection(
-        url,
-        header=[f"User-Agent: clawmetry-relay/{version}"],
-        timeout=10,
-    )
-    try:
-        # Register frame announces capabilities so the cloud knows which
-        # shapes are safe to route to this node.
-        ws.send(json.dumps({
-            "type": "register",
-            "node_id": node_id,
-            "version": version,
-            "capabilities": _CAPABILITIES,
-        }))
-        ws.settimeout(RECV_TIMEOUT_SEC)
-        while True:
-            try:
-                raw = ws.recv()
-            except websocket.WebSocketTimeoutException:
-                # No traffic in RECV_TIMEOUT_SEC — send our own ping so the
-                # cloud LB doesn't drop us as idle (Cloud Run idle = 5 min).
-                try:
-                    ws.ping()
-                except Exception:
-                    raise
-                continue
-            if not raw:
-                # Empty payload = server requested close.
-                return
-            try:
-                frame = json.loads(raw)
-            except Exception:
-                log.warning("relay: dropping non-JSON frame")
-                continue
-            _handle_frame(ws, frame)
-    finally:
-        try:
-            ws.close()
-        except Exception:
-            pass
+    return None
 
 
 def _handle_frame(ws, frame: dict) -> None:
-    """Single-frame dispatcher. `ws` is a live websocket.WebSocket."""
+    """Single-frame dispatcher. Retained for unit tests; the live WS path
+    is dead, but the dispatch shape is reused by the heartbeat-piggyback
+    handler in ``sync._dispatch_pending_queries``."""
     ftype = frame.get("type")
     if ftype == "query":
         _handle_query(ws, frame)
@@ -163,9 +82,9 @@ def _handle_frame(ws, frame: dict) -> None:
 
 
 def _handle_query(ws, frame: dict) -> None:
-    """Dispatch a `query` frame through the same path the HTTP API uses,
-    chunk-stream the response back. All errors → `{type:"error"}` frame
-    so the cloud can surface them cleanly."""
+    """Dispatch a ``query`` frame through the same path the HTTP API
+    uses, chunk-stream the response back. Retained for back-compat
+    tests; the live network path is dead."""
     qid = frame.get("id")
     shape = frame.get("shape", "")
     args = frame.get("args") or {}
@@ -207,8 +126,6 @@ def _handle_query(ws, frame: dict) -> None:
             "rows": sl,
         }
         if is_final:
-            # Carry shape + count metadata on the final frame so the cloud
-            # can validate completeness without re-iterating chunks.
             out["_shape"] = body.get("_shape")
             out["_elapsed_ms"] = body.get("_elapsed_ms")
             out["count"] = body.get("count", total)
@@ -219,6 +136,4 @@ def _send_error(ws, qid, code: str, msg: str) -> None:
     try:
         ws.send(json.dumps({"type": "error", "id": qid, "code": code, "msg": msg}))
     except Exception:
-        # If the WS itself is dead, the supervisor loop will catch it on
-        # the next recv() and reconnect — nothing to do here.
         log.debug("relay: failed to send error frame for qid=%s", qid)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5905,17 +5905,17 @@ def run_daemon() -> None:
     send_heartbeat(config)
     log.info("Initial heartbeat sent")
 
-    # ── Cloud cold-data relay (epic #964 phase 3b) ─────────────────────
-    # Long-lived WS to wss://app.clawmetry.com/api/node/relay so the cloud
-    # dashboard can request data older than its 24h hot window without us
-    # paying for permanent storage. No-op if the user hasn't connected to
-    # cloud or the optional `websocket-client` dep is missing — degrades
-    # gracefully to today's cloud-ingest-only behavior.
-    try:
-        from clawmetry import relay as _relay
-        _relay.start_relay_thread(config, version=_get_version())
-    except Exception as _e:
-        log.warning("relay: failed to start (continuing without cold-data relay): %s", _e)
+    # WS relay deleted 2026-05-13: replaced by heartbeat-piggyback
+    # (see project_relay_transport_decision). The cloud endpoint
+    # /api/node/relay was killed 2026-05-12 (returns 404 in prod) after
+    # the simple-websocket handshake-400 dead end documented in
+    # reference_ws_handshake_400_unsolved.md. The reconnect loop was
+    # spamming `relay: error: Handshake status 404 Not Found ...
+    # reconnecting in 60s` forever — wasting bandwidth and burying real
+    # errors. Cold-data reads now ride `pending_queries` piggybacked on
+    # the heartbeat response and answered via /ingest/cache (issue #1053).
+    # `clawmetry/relay.py` is retained as a stub so any third-party
+    # importers don't crash, but `start_relay_thread` is no longer called.
 
     # ── Local query HTTP server (cross-process DuckDB read fix) ────────
     # Daemon owns the DuckDB writer lock; the dashboard process can't
@@ -6080,7 +6080,11 @@ def run_daemon() -> None:
 
     # Default to SLOW; flips to FAST after a heartbeat response with
     # `viewer_active: true` (epic #775 PR 2/3, adaptive sync cadence).
-    heartbeat_interval = HEARTBEAT_INTERVAL_SLOW
+    # Seed from the startup heartbeat so the very first cycle picks up
+    # FAST cadence when the user already has the cloud Brain tab open
+    # at daemon start — otherwise the first 60s after startup is stuck
+    # on SLOW even with an active viewer (2026-05-13 real-time MOAT fix).
+    heartbeat_interval = _pick_heartbeat_interval(_LAST_HEARTBEAT_RESPONSE)
     snapshot_interval = 60  # system snapshot (subagents, flow metrics) every 60s
     log_sync_interval = 60  # log lines are low-priority; streamer covers real-time
     last_heartbeat = time.time()
@@ -6220,7 +6224,17 @@ def run_daemon() -> None:
         except Exception as e:
             log.error(f"Sync cycle error: {e}")
 
-        time.sleep(POLL_INTERVAL)
+        # Adaptive cycle sleep (P0 real-time MOAT, 2026-05-13). The
+        # original `time.sleep(POLL_INTERVAL=15)` floored the heartbeat
+        # latency at 15s even when `heartbeat_interval` had dropped to
+        # FAST (3s) on viewer_active. That hard-capped Brain-tab
+        # freshness at ~15s instead of the target 1-2s. We now sleep at
+        # most `heartbeat_interval` so the next cycle (and its
+        # heartbeat-piggyback brain push) fires on the FAST cadence
+        # whenever a viewer is active. When idle (SLOW=60s),
+        # POLL_INTERVAL still rules, so bandwidth + Cloud Run cost stay
+        # flat.
+        time.sleep(max(1, min(POLL_INTERVAL, heartbeat_interval)))
 
 
 def _build_gateway_data(paths: dict = None) -> dict:

--- a/tests/test_adaptive_heartbeat.py
+++ b/tests/test_adaptive_heartbeat.py
@@ -189,3 +189,38 @@ def test_send_heartbeat_5xx_clears_response_falls_back_to_slow(
         sync_mod._pick_heartbeat_interval(sync_mod._LAST_HEARTBEAT_RESPONSE)
         == sync_mod.HEARTBEAT_INTERVAL_SLOW
     )
+
+
+# ── Adaptive cycle-sleep contract (P0 real-time MOAT, 2026-05-13) ──────────────
+#
+# The main loop's tail `time.sleep()` previously hard-coded `POLL_INTERVAL`
+# (15s). With FAST cadence (3s) that floored the heartbeat latency at 15s
+# even with an active viewer. The fix sleeps `min(POLL_INTERVAL,
+# heartbeat_interval)` so FAST actually means FAST.
+
+def test_cycle_sleep_fast_when_viewer_active(sync_mod):
+    """When the loop picks FAST=3s, the cycle sleep must drop to 3s
+    (or less) — not stay at POLL_INTERVAL=15s."""
+    hb = sync_mod._pick_heartbeat_interval({"viewer_active": True})
+    cycle_sleep = max(1, min(sync_mod.POLL_INTERVAL, hb))
+    assert cycle_sleep == sync_mod.HEARTBEAT_INTERVAL_FAST == 3
+    # Sanity: this MUST be strictly tighter than the old 15s floor.
+    assert cycle_sleep < sync_mod.POLL_INTERVAL
+
+
+def test_cycle_sleep_slow_keeps_poll_interval(sync_mod):
+    """When idle (SLOW=60s), POLL_INTERVAL (15s) still rules so we don't
+    accidentally regress to a 60s sync cycle for everyone idle."""
+    hb = sync_mod._pick_heartbeat_interval({"viewer_active": False})
+    cycle_sleep = max(1, min(sync_mod.POLL_INTERVAL, hb))
+    assert cycle_sleep == sync_mod.POLL_INTERVAL
+
+
+def test_cycle_sleep_floor_is_one_second(sync_mod, monkeypatch):
+    """Defensive: if a future change ever sets HEARTBEAT_INTERVAL_FAST
+    to 0 (or POLL_INTERVAL becomes negative on a misconfig), the floor
+    must keep the loop alive, not enter a tight 0s busy-spin."""
+    monkeypatch.setattr(sync_mod, "HEARTBEAT_INTERVAL_FAST", 0)
+    hb = sync_mod._pick_heartbeat_interval({"viewer_active": True})
+    cycle_sleep = max(1, min(sync_mod.POLL_INTERVAL, hb))
+    assert cycle_sleep == 1

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -42,25 +42,21 @@ def _send_payloads(ws):
     return [json.loads(c.args[0]) for c in ws.send.call_args_list]
 
 
-def test_start_relay_thread_skips_when_no_cloud_account():
+def test_start_relay_thread_is_noop():
+    """As of 2026-05-13 the WS relay was retired (404 in prod); the
+    daemon no longer opens any long-lived WebSocket. ``start_relay_thread``
+    is now a no-op that returns ``None`` regardless of config — covers
+    every previously-skipped path in one assertion.
+    See ``project_relay_transport_decision``.
+    """
     from clawmetry import relay
     importlib.reload(relay)
+    # No config — always None.
     assert relay.start_relay_thread({}) is None
+    # Partial config — still None.
     assert relay.start_relay_thread({"node_id": "x"}) is None
     assert relay.start_relay_thread({"api_key": "y"}) is None
-
-
-def test_start_relay_thread_skips_when_websocket_missing(monkeypatch):
-    from clawmetry import relay
-    importlib.reload(relay)
-    # Force the import inside start_relay_thread() to fail.
-    sys.modules.pop("websocket", None)
-    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
-    def fake_import(name, *a, **k):
-        if name == "websocket":
-            raise ImportError("forced")
-        return real_import(name, *a, **k)
-    monkeypatch.setitem(__builtins__ if isinstance(__builtins__, dict) else __builtins__.__dict__, "__import__", fake_import) if isinstance(__builtins__, dict) else monkeypatch.setattr("builtins.__import__", fake_import)
+    # Full config that would previously have spun a thread — also None.
     assert relay.start_relay_thread({"api_key": "k", "node_id": "n"}) is None
 
 


### PR DESCRIPTION
## Summary

P0 fix for the real-time MOAT promise (≤5s Brain-tab freshness, target 1-2s). Two daemon-side regressions found on the live local node:

1. **Dead WS relay reconnect spam.** `clawmetry/relay.py` was still trying to reconnect to `wss://app.clawmetry.com/api/node/relay` every 60s after that endpoint was retired (issue #1053 / `project_relay_transport_decision`). Every attempt got `Handshake status 404 Not Found`, burying real errors in `sync.log`.
2. **Adaptive cadence floored at 15s.** PR #1111 added a 3s FAST cadence when `viewer_active=true`, but the main loop ended every cycle with `time.sleep(POLL_INTERVAL=15)`. So a 3s heartbeat interval still couldn't fire more often than every 15s. Plus the loop initialised `heartbeat_interval = SLOW`, ignoring the stash populated by the startup heartbeat — so the first ~60s post-restart was stuck on SLOW even if the user already had Brain open.

## Fixes

- `clawmetry/relay.py` → no-op stub. `start_relay_thread()` returns `None` unconditionally. Dispatch helpers retained (still used by `sync._dispatch_pending_queries` for heartbeat-piggyback queries and pinned by `tests/test_relay.py`).
- `clawmetry/sync.py:5908-5918` → deleted `start_relay_thread(...)` call, replaced with a comment pointing to `project_relay_transport_decision` and `reference_ws_handshake_400_unsolved`.
- `clawmetry/sync.py:6083` → seeded `heartbeat_interval = _pick_heartbeat_interval(_LAST_HEARTBEAT_RESPONSE)` so the startup heartbeat's `viewer_active` flag is honoured on the FIRST cycle, not the second.
- `clawmetry/sync.py:6223` → `time.sleep(max(1, min(POLL_INTERVAL, heartbeat_interval)))` so FAST=3s actually means a 3s cycle. SLOW=60s still capped by POLL_INTERVAL=15s — idle bandwidth/Cloud-Run cost unchanged.

## Before / after

Before (live local daemon):
```
sync.log: relay: error: Handshake status 404 Not Found ... reconnecting in 60s   ← every minute
heartbeat cycle floor: 15s even with viewer_active=true
```

After (expected once daemon restarts on this build):
```
sync.log: no `relay:` lines
heartbeat cycle on active viewer: 3s
```

The `interval_seconds: 1800` field shown on `/api/system-health` is the OpenClaw **agent** heartbeat (separate concept from the daemon→cloud sync heartbeat), so it's unaffected by this PR.

## Test plan

- [x] `tests/test_adaptive_heartbeat.py` — 8 existing tests pass; +3 new tests pin the cycle-sleep contract (FAST/SLOW/1s-floor).
- [x] `tests/test_relay.py` — collapsed the previous skip cases into one no-op assertion; passes.
- [ ] Restart local daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.dashboard`
- [ ] Verify no `relay: error` lines in `~/.clawmetry/sync.log` for ≥2 minutes.
- [ ] Open cloud Brain tab → send a message in OpenClaw → confirm event lands in cloud Brain within 5s.

## Out of scope (documented)

Free-plan rate limit (`HTTP 429 from /ingest/logs`, retry_after: 38s) is unrelated — Brain rides `/ingest/heartbeat`. Right fix is server-side rate-limit bump for the free plan or smarter client-side log batching; will track separately.

## Refs

- Issue #1053 (heartbeat-piggyback epic)
- PR #1111 (adaptive cadence)
- Memory: `project_relay_transport_decision`, `reference_ws_handshake_400_unsolved`

🤖 Generated with [Claude Code](https://claude.com/claude-code)