### PR TITLE
fix(install): launchd restart + __main__ + uptime portability + token discovery (closes #1127 install bucket)

### DIFF
--- a/clawmetry/__main__.py
+++ b/clawmetry/__main__.py
@@ -1,0 +1,10 @@
+"""Allow `python3 -m clawmetry` to invoke the CLI entry point.
+
+Without this module Python emits "No module named clawmetry.__main__".
+The CLI's argparse-based `main()` lives in clawmetry.cli.
+"""
+
+from clawmetry.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5381,17 +5381,50 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     except Exception:
         system.append(["RAM", "--", ""])
 
+    # Portable uptime: stdlib-only (no `uptime -p` — missing on macOS/BSD).
     try:
-        if sys.platform == "darwin":
-            up = subprocess.run(
-                ["uptime"], capture_output=True, text=True, timeout=5
-            ).stdout.strip()
-            system.append(["Uptime", up.split(",")[0].split("up")[-1].strip(), ""])
+        boot_ts = None
+        try:
+            import psutil  # type: ignore
+
+            boot_ts = float(psutil.boot_time())
+        except Exception:
+            if sys.platform.startswith("linux"):
+                try:
+                    with open("/proc/uptime") as _uf:
+                        boot_ts = time.time() - float(_uf.read().split()[0])
+                except Exception:
+                    pass
+            elif sys.platform == "darwin" or "bsd" in sys.platform:
+                try:
+                    import re as _re
+
+                    _out = subprocess.run(
+                        ["sysctl", "-n", "kern.boottime"],
+                        capture_output=True,
+                        text=True,
+                        timeout=2,
+                    ).stdout
+                    _m = _re.search(r"sec\s*=\s*(\d+)", _out)
+                    if _m:
+                        boot_ts = float(_m.group(1))
+                except Exception:
+                    pass
+        if boot_ts is not None:
+            secs = max(0, int(time.time() - boot_ts))
+            days, rem = divmod(secs, 86400)
+            hours, rem = divmod(rem, 3600)
+            minutes = rem // 60
+            parts = []
+            if days:
+                parts.append(f"{days}d")
+            if hours:
+                parts.append(f"{hours}h")
+            if minutes or not parts:
+                parts.append(f"{minutes}m")
+            system.append(["Uptime", " ".join(parts), ""])
         else:
-            up = subprocess.run(
-                ["uptime", "-p"], capture_output=True, text=True, timeout=5
-            ).stdout.strip()
-            system.append(["Uptime", up.replace("up ", ""), ""])
+            system.append(["Uptime", "--", ""])
     except Exception:
         system.append(["Uptime", "--", ""])
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -2568,10 +2568,19 @@ def _detect_gateway_token():
 
             with open(jp) as f:
                 cfg = _json.load(f)
+            # Primary path on current OpenClaw: cfg["gateway"]["auth"]["token"].
+            # Some installs / older schemas store the token at top-level
+            # cfg["auth"]["token"] (issue #1127). Try the nested gateway
+            # path first, then the top-level auth path so we cover both
+            # without breaking the common case.
             gw = cfg.get("gateway", {})
-            auth = gw.get("auth", {})
-            if isinstance(auth, dict) and "token" in auth:
-                return auth["token"]
+            if isinstance(gw, dict):
+                gw_auth = gw.get("auth", {})
+                if isinstance(gw_auth, dict) and gw_auth.get("token"):
+                    return gw_auth["token"]
+            top_auth = cfg.get("auth", {})
+            if isinstance(top_auth, dict) and top_auth.get("token"):
+                return top_auth["token"]
         except (FileNotFoundError, ValueError, KeyError, TypeError):
             pass
     return None
@@ -9779,10 +9788,17 @@ def _detect_gateway_token():
             import json as _json
             with open(jp) as f:
                 cfg = _json.load(f)
+            # Primary path on current OpenClaw: cfg["gateway"]["auth"]["token"].
+            # Older / alternate schemas put it at top-level cfg["auth"]["token"]
+            # (issue #1127). Try gateway-nested first, fall back to top-level.
             gw = cfg.get('gateway', {})
-            auth = gw.get('auth', {})
-            if isinstance(auth, dict) and 'token' in auth:
-                return auth['token']
+            if isinstance(gw, dict):
+                gw_auth = gw.get('auth', {})
+                if isinstance(gw_auth, dict) and gw_auth.get('token'):
+                    return gw_auth['token']
+            top_auth = cfg.get('auth', {})
+            if isinstance(top_auth, dict) and top_auth.get('token'):
+                return top_auth['token']
         except (FileNotFoundError, ValueError, KeyError, TypeError):
             pass
     return None

--- a/helpers/system.py
+++ b/helpers/system.py
@@ -1,0 +1,126 @@
+"""
+helpers/system.py — Portable system uptime helpers.
+
+The legacy callers shelled out to `uptime -p`, which only exists on
+GNU/coreutils (Linux). On macOS / BSD `uptime` has no `-p` flag and the
+subprocess returns non-zero, so the dashboard rendered "Unknown" on
+every Mac install. Issue #1127.
+
+This module computes boot time using only stdlib:
+  - psutil.boot_time() when psutil is installed (most reliable cross-OS)
+  - /proc/uptime on Linux
+  - `sysctl kern.boottime` on macOS / BSD
+  - WMIC / GetTickCount64 on Windows (best-effort)
+
+Returns a pretty string like "up 3 days, 4 hours, 12 minutes" — matching
+the legacy `uptime -p` output the dashboard JS expects.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import time
+
+
+def boot_time() -> float | None:
+    """Return the POSIX timestamp the host booted at, or None if unknown.
+
+    Never raises — every failure path returns None so callers can render
+    a graceful fallback.
+    """
+    # 1. psutil — most accurate, works on every platform we ship to.
+    try:
+        import psutil  # type: ignore
+
+        return float(psutil.boot_time())
+    except Exception:
+        pass
+
+    # 2. Linux: /proc/uptime is "<uptime_seconds> <idle_seconds>".
+    if sys.platform.startswith("linux"):
+        try:
+            with open("/proc/uptime") as f:
+                up_seconds = float(f.read().split()[0])
+            return time.time() - up_seconds
+        except Exception:
+            pass
+
+    # 3. macOS / BSD: sysctl kern.boottime prints e.g.
+    # `kern.boottime: { sec = 1715000000, usec = 0 } Thu May  7 ...`
+    if sys.platform == "darwin" or "bsd" in sys.platform:
+        try:
+            out = subprocess.run(
+                ["sysctl", "-n", "kern.boottime"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            ).stdout
+            m = re.search(r"sec\s*=\s*(\d+)", out)
+            if m:
+                return float(m.group(1))
+        except Exception:
+            pass
+
+    # 4. Windows: GetTickCount64 via ctypes (no extra deps).
+    if os.name == "nt":
+        try:
+            import ctypes  # type: ignore
+
+            ms = ctypes.windll.kernel32.GetTickCount64()  # type: ignore[attr-defined]
+            return time.time() - (ms / 1000.0)
+        except Exception:
+            pass
+
+    return None
+
+
+def uptime_seconds() -> int | None:
+    """Return seconds since boot, or None if we couldn't determine it."""
+    bt = boot_time()
+    if bt is None:
+        return None
+    return max(0, int(time.time() - bt))
+
+
+def format_uptime(seconds: int | None) -> str:
+    """Format seconds-since-boot as a human string matching `uptime -p`.
+
+    Examples:
+      None      -> "unknown"
+      59        -> "up less than a minute"
+      120       -> "up 2 minutes"
+      3700      -> "up 1 hour, 1 minute"
+      90061     -> "up 1 day, 1 hour, 1 minute"
+
+    Plural form mirrors GNU coreutils so existing JS that strips the
+    leading "up " keeps working.
+    """
+    if seconds is None:
+        return "unknown"
+    if seconds < 60:
+        return "up less than a minute"
+
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes = rem // 60
+
+    parts = []
+    if days:
+        parts.append(f"{days} day{'s' if days != 1 else ''}")
+    if hours:
+        parts.append(f"{hours} hour{'s' if hours != 1 else ''}")
+    if minutes:
+        parts.append(f"{minutes} minute{'s' if minutes != 1 else ''}")
+    if not parts:
+        # >=60s but <60min where minutes==0 (e.g. exactly 60s) — fall back
+        # to minutes so we never emit a bare "up".
+        parts.append("1 minute")
+    return "up " + ", ".join(parts)
+
+
+def uptime_pretty() -> str:
+    """Convenience: portable replacement for `subprocess.run(['uptime', '-p'])`."""
+    return format_uptime(uptime_seconds())

--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,53 @@ $USE_SUDO ln -sf "$INSTALL_DIR/bin/clawmetry" "$BIN_DIR/clawmetry"
 CLAWMETRY_BIN="$BIN_DIR/clawmetry"
 CLAWMETRY_VERSION=$("$INSTALL_DIR/bin/python3" -c "import importlib.metadata; print(importlib.metadata.version('clawmetry'))" 2>/dev/null || echo "installed")
 
+# ── Restart launchd jobs (macOS) ─────────────────────────────────────────────
+# After a venv reinstall, the dashboard/sync daemons launched at boot are
+# still running against the old (now deleted) venv. They'll either keep
+# serving stale code or crash-loop until reboot. `launchctl kickstart -k`
+# restarts them cleanly. Issue #1127.
+#
+# We also detect any plist whose ProgramArguments[0] points at a stale path
+# (e.g. a previous Homebrew clawmetry or ~/.local) and rewrite it to the
+# fresh venv binary so the next reboot picks up the right interpreter.
+if [ "$OS" = "Darwin" ]; then
+  _LA_DIR="$HOME/Library/LaunchAgents"
+  _UID=$(id -u)
+  # Step 1: rewrite stale ProgramArguments[0] in any com.clawmetry.* plist.
+  for _plist in "$_LA_DIR"/com.clawmetry.*.plist; do
+    [ -f "$_plist" ] || continue
+    _current=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "$_plist" 2>/dev/null || echo "")
+    _label=$(basename "$_plist" .plist)
+    case "$_current" in
+      "$INSTALL_DIR/bin/"*)
+        # Already pointing at the fresh venv — no rewrite needed.
+        ;;
+      *)
+        # Sync daemon plists invoke `python3 -m clawmetry.sync`; the
+        # dashboard plist runs the `clawmetry` console script. Pick the
+        # matching target binary inside the new venv.
+        if [ "$_label" = "com.clawmetry.sync" ] || [[ "$_current" == *python* ]]; then
+          _new="$INSTALL_DIR/bin/python3"
+        else
+          _new="$INSTALL_DIR/bin/clawmetry"
+        fi
+        if [ -n "$_current" ] && [ "$_current" != "$_new" ]; then
+          /usr/libexec/PlistBuddy -c "Set :ProgramArguments:0 $_new" "$_plist" 2>/dev/null || true
+        fi
+        ;;
+    esac
+  done
+
+  # Step 2: kickstart any registered com.clawmetry.* job. `|| true` so
+  # systems without launchd running (CI containers, Linux subprocess) don't
+  # abort the installer.
+  for _plist in "$_LA_DIR"/com.clawmetry.*.plist; do
+    [ -f "$_plist" ] || continue
+    _label=$(basename "$_plist" .plist)
+    launchctl kickstart -k "gui/$_UID/$_label" >/dev/null 2>&1 || true
+  done
+fi
+
 echo ""
 echo -e "  ${GREEN}${BOLD}✓ ClawMetry $CLAWMETRY_VERSION installed${NC}"
 echo ""

--- a/routes/components.py
+++ b/routes/components.py
@@ -561,10 +561,13 @@ def api_component_runtime():
         items.append({"label": "OpenClaw", "value": oc_ver, "status": "ok"})
     except Exception:
         items.append({"label": "OpenClaw", "value": "unknown", "status": "warning"})
-    # Uptime
+    # Uptime — portable across macOS/Linux/Win (GNU `uptime -p` is Linux-only).
     try:
-        up = subprocess.check_output(["uptime", "-p"], timeout=5).decode().strip()
-        items.append({"label": "Uptime", "value": up, "status": "ok"})
+        from helpers.system import uptime_pretty
+
+        up = uptime_pretty()
+        if up != "unknown":
+            items.append({"label": "Uptime", "value": up, "status": "ok"})
     except Exception:
         pass
     # Memory

--- a/routes/health.py
+++ b/routes/health.py
@@ -1406,16 +1406,29 @@ def api_health():
             }
         )
 
-    # 4. Uptime
+    # 4. Uptime — portable across macOS/Linux/Win (GNU `uptime -p` is Linux-only).
     try:
-        uptime = (
-            subprocess.run(["uptime", "-p"], capture_output=True, text=True, timeout=2)
-            .stdout.strip()
-            .replace("up ", "")
-        )
-        checks.append(
-            {"id": "uptime", "status": "healthy", "color": "green", "detail": uptime}
-        )
+        from helpers.system import uptime_pretty
+
+        uptime = uptime_pretty().replace("up ", "")
+        if uptime == "unknown":
+            checks.append(
+                {
+                    "id": "uptime",
+                    "status": "warning",
+                    "color": "yellow",
+                    "detail": "Unknown",
+                }
+            )
+        else:
+            checks.append(
+                {
+                    "id": "uptime",
+                    "status": "healthy",
+                    "color": "green",
+                    "detail": uptime,
+                }
+            )
     except Exception:
         checks.append(
             {

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -784,10 +784,15 @@ def _try_local_store_overview():
         system.append(["Load", "--", ""])
 
     try:
-        uptime = _sub.run(
-            ["uptime", "-p"], capture_output=True, text=True, timeout=2
-        ).stdout.strip()
-        system.append(["Uptime", uptime.replace("up ", ""), ""])
+        # Portable: GNU `uptime -p` doesn't exist on macOS / BSD.
+        from helpers.system import uptime_pretty
+
+        uptime = uptime_pretty()
+        system.append([
+            "Uptime",
+            uptime.replace("up ", "") if uptime != "unknown" else "--",
+            "",
+        ])
     except Exception:
         system.append(["Uptime", "--", ""])
 
@@ -925,10 +930,15 @@ def api_overview():
         system.append(["Load", "--", ""])
 
     try:
-        uptime = subprocess.run(
-            ["uptime", "-p"], capture_output=True, text=True, timeout=2
-        ).stdout.strip()
-        system.append(["Uptime", uptime.replace("up ", ""), ""])
+        # Portable: GNU `uptime -p` doesn't exist on macOS / BSD.
+        from helpers.system import uptime_pretty
+
+        uptime = uptime_pretty()
+        system.append([
+            "Uptime",
+            uptime.replace("up ", "") if uptime != "unknown" else "--",
+            "",
+        ])
     except Exception:
         system.append(["Uptime", "--", ""])
 

--- a/tests/test_gateway_token_fallback.py
+++ b/tests/test_gateway_token_fallback.py
@@ -1,0 +1,108 @@
+"""Tests for dashboard._detect_gateway_token fallback hierarchy.
+
+Covers issue #1127: OpenClaw stores the gateway auth token under different
+JSON paths depending on install age / schema. The reader must try
+``gateway.auth.token`` first (current schema) and fall back to top-level
+``auth.token`` (older / alternate schema) before giving up.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import dashboard  # noqa: E402
+
+
+@pytest.fixture
+def isolated_openclaw_dir(tmp_path, monkeypatch):
+    """Point dashboard at a clean tmp openclaw dir and strip the env var."""
+    monkeypatch.delenv("OPENCLAW_GATEWAY_TOKEN", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+    # Block the running-process path (Linux /proc) from leaking a token.
+    monkeypatch.setattr(
+        dashboard.os, "environ", dict(os.environ), raising=False
+    )
+    return tmp_path
+
+
+def _write_cfg(path: Path, cfg: dict):
+    path.write_text(json.dumps(cfg))
+
+
+def test_env_var_wins(isolated_openclaw_dir, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "env-token")
+    _write_cfg(
+        isolated_openclaw_dir / "openclaw.json",
+        {"gateway": {"auth": {"token": "config-token"}}},
+    )
+    assert dashboard._detect_gateway_token() == "env-token"
+
+
+def test_nested_gateway_auth_token(isolated_openclaw_dir):
+    """Current OpenClaw schema: cfg.gateway.auth.token."""
+    _write_cfg(
+        isolated_openclaw_dir / "openclaw.json",
+        {"gateway": {"auth": {"token": "nested-token"}}},
+    )
+    assert dashboard._detect_gateway_token() == "nested-token"
+
+
+def test_top_level_auth_token_fallback(isolated_openclaw_dir):
+    """Older / alternate schema: cfg.auth.token at top level."""
+    _write_cfg(
+        isolated_openclaw_dir / "openclaw.json",
+        {"auth": {"token": "top-level-token"}},
+    )
+    assert dashboard._detect_gateway_token() == "top-level-token"
+
+
+def test_nested_preferred_over_top_level(isolated_openclaw_dir):
+    """When both exist, the gateway-nested path wins (matches current OpenClaw)."""
+    _write_cfg(
+        isolated_openclaw_dir / "openclaw.json",
+        {
+            "gateway": {"auth": {"token": "nested-wins"}},
+            "auth": {"token": "top-level-loses"},
+        },
+    )
+    assert dashboard._detect_gateway_token() == "nested-wins"
+
+
+def test_returns_none_when_no_token_present(isolated_openclaw_dir):
+    _write_cfg(
+        isolated_openclaw_dir / "openclaw.json",
+        {"gateway": {"port": 18789}, "auth": {"profiles": {}}},
+    )
+    assert dashboard._detect_gateway_token() is None
+
+
+def test_returns_none_when_config_missing(isolated_openclaw_dir):
+    # No openclaw.json written.
+    assert dashboard._detect_gateway_token() is None
+
+
+def test_skips_malformed_json(isolated_openclaw_dir):
+    (isolated_openclaw_dir / "openclaw.json").write_text("{not json")
+    assert dashboard._detect_gateway_token() is None
+
+
+def test_empty_token_falls_through(isolated_openclaw_dir):
+    """An empty-string token should not be returned — keep looking."""
+    _write_cfg(
+        isolated_openclaw_dir / "openclaw.json",
+        {
+            "gateway": {"auth": {"token": ""}},
+            "auth": {"token": "real-token"},
+        },
+    )
+    # Empty gateway token must fall through to top-level auth.token.
+    assert dashboard._detect_gateway_token() == "real-token"

--- a/tests/test_uptime_portable.py
+++ b/tests/test_uptime_portable.py
@@ -1,0 +1,90 @@
+"""Tests for helpers/system.py — portable uptime replacement for `uptime -p`.
+
+Covers the GNU/macOS portability fix from issue #1127.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the repo root (where helpers/ lives) is importable when pytest is
+# invoked from anywhere.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from helpers import system as sys_helpers  # noqa: E402
+
+
+def test_format_uptime_none():
+    assert sys_helpers.format_uptime(None) == "unknown"
+
+
+def test_format_uptime_less_than_minute():
+    assert sys_helpers.format_uptime(0) == "up less than a minute"
+    assert sys_helpers.format_uptime(45) == "up less than a minute"
+
+
+def test_format_uptime_singular_plural():
+    # Plural form must match GNU `uptime -p` so the dashboard JS keeps
+    # working (it strips the leading "up ").
+    assert sys_helpers.format_uptime(60) == "up 1 minute"
+    assert sys_helpers.format_uptime(120) == "up 2 minutes"
+    assert sys_helpers.format_uptime(3600) == "up 1 hour"
+    assert sys_helpers.format_uptime(7200) == "up 2 hours"
+    assert sys_helpers.format_uptime(86400) == "up 1 day"
+    assert sys_helpers.format_uptime(2 * 86400) == "up 2 days"
+
+
+def test_format_uptime_compound():
+    # 1 day + 1 hour + 1 minute
+    assert sys_helpers.format_uptime(86400 + 3600 + 60) == "up 1 day, 1 hour, 1 minute"
+    # 3 days + 4 hours + 12 minutes
+    secs = 3 * 86400 + 4 * 3600 + 12 * 60
+    assert sys_helpers.format_uptime(secs) == "up 3 days, 4 hours, 12 minutes"
+
+
+def test_format_uptime_starts_with_up():
+    # Dashboard JS does .replace("up ", "") — every non-unknown response
+    # must start with "up " for that to work.
+    for s in [60, 120, 3700, 90061, 86400]:
+        out = sys_helpers.format_uptime(s)
+        assert out.startswith("up "), f"format_uptime({s}) = {out!r}"
+
+
+def test_boot_time_is_plausible_on_this_host():
+    """boot_time() should return a sane POSIX timestamp on the test host."""
+    import time
+
+    bt = sys_helpers.boot_time()
+    # Test runner has to be running on some OS we support — if it returns
+    # None we've regressed portability.
+    assert bt is not None, "boot_time() returned None on this host"
+    # Boot must be in the past and within the last decade.
+    assert bt < time.time()
+    assert bt > time.time() - (10 * 365 * 86400)
+
+
+def test_uptime_seconds_matches_boot_time():
+    import time
+
+    bt = sys_helpers.boot_time()
+    if bt is None:
+        pytest.skip("boot_time unavailable on this host")
+    expected = int(time.time() - bt)
+    actual = sys_helpers.uptime_seconds()
+    # Allow up to 2s drift between the two clock reads.
+    assert abs(actual - expected) <= 2
+
+
+def test_uptime_pretty_round_trip():
+    """End-to-end: real host -> pretty string starting with 'up '."""
+    out = sys_helpers.uptime_pretty()
+    assert isinstance(out, str)
+    # We don't expect "unknown" on a real test host (Linux/macOS/Win all
+    # have a supported path), but if a future runner lacks all 4 backends
+    # we should still degrade gracefully rather than crash.
+    assert out == "unknown" or out.startswith("up ")


### PR DESCRIPTION
## Summary

Four-bug install/portability fix tied to issue #1127. Each landed
defensively (graceful fallbacks, never crashes), with unit coverage
on the two helpers that needed it.

### #1127 install / launchd bucket — sub-bullets

- [x] **install.sh restarts launchd jobs after install**
  After the venv reinstall, dashboard/sync daemons launched at boot
  are still bound to the deleted venv. Added a Darwin-only block that
  `launchctl kickstart -k`s every `com.clawmetry.*` plist, wrapped in
  `|| true` so Linux/CI without launchd don't abort. Bonus: any plist
  whose `ProgramArguments[0]` points outside the fresh venv is rewritten
  to `~/.clawmetry/bin/{clawmetry,python3}` (matched by label) before
  the kickstart, so the next reboot picks up the right interpreter
  too.

- [x] **`python3 -m clawmetry` fails with "No module named clawmetry.__main__"**
  Added `clawmetry/__main__.py` that does `from clawmetry.cli import main; main()`.
  Verified `importlib.util.find_spec('clawmetry.__main__')` resolves.

- [x] **`uptime -p` is GNU-only — fails on macOS**
  Audit was right; 5 callers across `routes/health.py`,
  `routes/overview.py` (x2), `routes/components.py`,
  `clawmetry/sync.py`. New `helpers/system.py` exposes
  `uptime_pretty()` / `uptime_seconds()` / `boot_time()` /
  `format_uptime()` using psutil → /proc/uptime → sysctl
  kern.boottime → GetTickCount64 fallbacks. Each call site now uses
  the helper; sync.py inlines the equivalent logic (sync.py is the
  installed package, doesn't import from top-level `helpers/`).

- [x] **Gateway-token shape mismatch — try both paths**
  Read real `~/.openclaw/openclaw.json` on this machine — current
  OpenClaw stores the token at `gateway.auth.token` (the existing
  primary path), and top-level `auth` holds OAuth profiles, not
  tokens. To cover the issue reporter's shape without breaking
  the common case, `_detect_gateway_token` now tries
  `cfg.gateway.auth.token` first, then `cfg.auth.token`, then
  falls through to the next config file. Patched both copies of
  `_detect_gateway_token` in `dashboard.py` (there are two — the
  later definition shadows the earlier, but both are now consistent).

## Test plan

- [x] `pytest tests/test_uptime_portable.py tests/test_gateway_token_fallback.py` — 16/16 pass locally on macOS.
- [x] `python3 -m ast` parse on every touched .py — all OK.
- [x] `bash -n install.sh` — OK.
- [x] Smoke: `python3 -m clawmetry` now resolves (`importlib.util.find_spec` returns a real spec).
- [x] Smoke: `_detect_gateway_token()` against real `~/.openclaw/openclaw.json` returns the nested token unchanged.
- [ ] CI matrix — Ubuntu/macOS/Win, py3.9 + py3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)