### PR TITLE
perf(install): use uv for ~5x faster pip install (with fallback)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,6 @@ esac
 
 # ── Install into venv ────────────────────────────────────────────────────────
 
-echo -e "  → Creating virtual environment..."
 # Preserve config before wiping venv (contains node_id, encryption_key)
 _CM_CFG_BAK=""
 if [ -f "$INSTALL_DIR/config.json" ]; then
@@ -72,17 +71,35 @@ elif [ -f "$HOME/.clawmetry/config.json" ] && [ "$INSTALL_DIR" = "$HOME/.clawmet
   cp "$HOME/.clawmetry/config.json" "$_CM_CFG_BAK"
 fi
 $USE_SUDO rm -rf "$INSTALL_DIR"
-$USE_SUDO python3 -m venv "$INSTALL_DIR"
-$USE_SUDO "$INSTALL_DIR/bin/pip" install --upgrade pip >/dev/null 2>&1
+
+# Try `uv` (Astral's Rust-based pip replacement) for ~5x faster installs.
+# Bootstrap a copy if missing; on any failure, silently fall back to pip so
+# corporate proxies / restrictive networks still work.
+if ! command -v uv >/dev/null 2>&1; then
+  echo -e "  → Bootstrapping uv (faster installer)..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true
+  # uv installs to ~/.local/bin (default) or ~/.cargo/bin (older)
+  export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+fi
+
+if command -v uv >/dev/null 2>&1; then
+  echo -e "  → Creating virtual environment (uv)..."
+  $USE_SUDO uv venv "$INSTALL_DIR" --quiet
+  echo -e "  → Installing clawmetry from PyPI (uv)..."
+  $USE_SUDO uv pip install --python "$INSTALL_DIR/bin/python3" --quiet --upgrade clawmetry
+else
+  echo -e "  → Bootstrapping pip fallback (this is slower)..."
+  $USE_SUDO python3 -m venv "$INSTALL_DIR"
+  $USE_SUDO "$INSTALL_DIR/bin/pip" install --upgrade pip >/dev/null 2>&1
+  echo -e "  → Installing clawmetry from PyPI (pip)..."
+  $USE_SUDO "$INSTALL_DIR/bin/pip" install --no-cache-dir --upgrade clawmetry >/dev/null 2>&1
+fi
 
 # Restore config if it was backed up
 if [ -n "$_CM_CFG_BAK" ] && [ -f "$_CM_CFG_BAK" ]; then
   $USE_SUDO cp "$_CM_CFG_BAK" "$INSTALL_DIR/config.json"
   rm -f "$_CM_CFG_BAK"
 fi
-
-echo -e "  → Installing clawmetry from PyPI..."
-$USE_SUDO "$INSTALL_DIR/bin/pip" install --no-cache-dir --upgrade clawmetry >/dev/null 2>&1
 
 # Create symlink
 mkdir -p "$BIN_DIR" 2>/dev/null || $USE_SUDO mkdir -p "$BIN_DIR"


### PR DESCRIPTION
## Summary

- Bootstrap Astral's [uv](https://github.com/astral-sh/uv) (Rust-based pip replacement) at the top of the venv-install block in `install.sh`.
- When uv is available, use `uv venv` + `uv pip install`; otherwise fall back silently to the original `python3 -m venv` + `pip install --no-cache-dir` path.
- Surface progress with one line per step so the install no longer looks silent (a complaint earlier today).

## Why

User feedback: `curl | bash` install takes too long compared to OpenClaw. The bottleneck is `python3 -m venv` (3-5s) + `pip install clawmetry` downloading the ~14 MB duckdb wheel + transitive deps + resolution.

uv runs parallel downloads, ships a faster resolver, and creates venvs in milliseconds.

## Before / after timings

Measured on macOS (Darwin 25.3.0, M-series), cold cache, `--no-cache-dir` parity for fairness:

```
pip path:  bash -c   4.00s user 1.00s system 57% cpu 8.773 total
uv  path:  bash -c   0.35s user 0.27s system 32% cpu 1.880 total
```

**~8.8s -> ~1.9s = 4.6x faster.** Re-ran twice with cleared caches to rule out warm-cache skew, both runs landed in the same ranges.

## Fallback

Never hard-depend on uv. If the bootstrap `curl` hangs (corporate proxy), times out, or `astral.sh` is firewalled, the `|| true` swallows the error and the original pip path runs. Worst case: same speed as before, no regression.

```sh
if ! command -v uv >/dev/null 2>&1; then
  curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 || true
  export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
fi

if command -v uv >/dev/null 2>&1; then
  uv venv "$INSTALL_DIR" --quiet
  uv pip install --python "$INSTALL_DIR/bin/python3" --quiet --upgrade clawmetry
else
  # pip fallback unchanged
fi
```

## Test plan

- [x] `bash -n install.sh` passes
- [x] `pytest tests/test_install_script_linux_restart.py` -> 6/6 pass (Darwin/Linux/WSL post-install branches untouched)
- [x] End-to-end install into a throwaway dir; `clawmetry --version` reports `0.12.182`
- [ ] CI smoke (`install-test.yml`) on Ubuntu / macOS / Windows