### PR TITLE
fix(brain): remove onboarding-text contamination from Live event stream

### DIFF
--- a/routes/brain.py
+++ b/routes/brain.py
@@ -424,41 +424,17 @@ def api_brain_history():
                             "color": "#a855f7",
                         }
                     )
-                else:
-                    msg_lower = msg.lower()
-                    for kw in (
-                        "exec",
-                        "browser",
-                        "web_search",
-                        "web_fetch",
-                        "read",
-                        "write",
-                        "edit",
-                        "message",
-                        "spawn",
-                        "subagents",
-                        "tts",
-                        "nodes",
-                        "canvas",
-                    ):
-                        if kw in msg_lower:
-                            ev_type = tool_to_type(kw)
-                            try:
-                                start = msg_lower.index(kw)
-                                detail = msg[start : start + 300].split("\n")[0].strip()
-                            except Exception:
-                                detail = ""
-                            events.append(
-                                {
-                                    "time": ts,
-                                    "source": "main",
-                                    "sourceLabel": "main",
-                                    "type": ev_type,
-                                    "detail": detail,
-                                    "color": "#a855f7",
-                                }
-                            )
-                            break
+                # NOTE: a previous implementation also did substring keyword
+                # matching here ("if 'browser' in msg_lower → BROWSER event").
+                # That mis-classified benign console messages (e.g. "Opened in
+                # your browser. Keep that tab to control OpenClaw." or "Token
+                # auto-auth included in browser/clipboard URL.") as BROWSER
+                # tool invocations and contaminated the Brain stream with
+                # onboarding/lifecycle text. Removed — only bracketed
+                # ``[tool] ...`` log lines now produce events from this path.
+                # DuckDB-first: real tool calls already arrive via local_store
+                # ingestion, so this fallback is pure noise. (issue: brain
+                # onboarding-text contamination, 2026-05-13.)
         except Exception:
             pass
 

--- a/tests/test_brain_no_log_keyword_noise.py
+++ b/tests/test_brain_no_log_keyword_noise.py
@@ -1,0 +1,134 @@
+"""Regression test — ``/api/brain-history`` must NOT mis-classify benign
+OpenClaw console messages as tool-invocation events.
+
+Background: ``routes/brain.py`` previously did substring keyword matching on
+every OpenClaw log line — any message containing ``"browser"``, ``"read"``,
+``"write"``, ``"exec"``, ``"message"``, ``"spawn"`` etc. was tagged as a
+BROWSER / READ / WRITE / EXEC / MSG / SPAWN event and pushed into the Brain
+feed. That contaminated the live event stream with onboarding/lifecycle text
+like:
+
+  ``Opened in your browser. Keep that tab to control OpenClaw.``
+  ``Token auto-auth included in browser/clipboard URL.``
+
+These lines are NOT tool calls — they are info-level startup messages from
+the OpenClaw CLI. They must not appear as tool events in the Brain feed.
+
+This test seeds a temp OpenClaw log directory with realistic console-log
+lines + one legitimately bracketed ``[browser] ...`` tool log line, points
+``routes.brain`` at it via the ``_get_log_dirs`` shim, hits the JSONL/log
+fallback path (local-store disabled), and asserts:
+
+  1. The "Keep that tab" / "clipboard URL" lines do NOT appear as events
+     (no BROWSER event with detail referring to the lifecycle string).
+  2. The bracketed ``[browser] ...`` line still produces a BROWSER event
+     (we only want to remove the noisy fallback, not the legit format).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def fallback_app(tmp_path, monkeypatch):
+    # Force the legacy JSONL/log fallback path so the keyword-noise branch is
+    # exercised. With CLAWMETRY_LOCAL_STORE_READ=0 the DuckDB fast path bails
+    # out before the log scan runs, which is what we want to inspect.
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")
+
+    log_dir = tmp_path / "openclaw-logs"
+    log_dir.mkdir()
+    log_file = log_dir / "openclaw-2026-05-13.log"
+
+    def _line(msg, ts="2026-05-13T22:50:00.911Z"):
+        return json.dumps({"0": msg, "message": msg, "time": ts}) + "\n"
+
+    log_file.write_text(
+        # Two real-world OpenClaw console messages that USED to be misclassified
+        # as BROWSER events because the substring keyword matcher saw "browser".
+        _line("Opened in your browser. Keep that tab to control OpenClaw.")
+        + _line("Token auto-auth included in browser/clipboard URL.",
+                ts="2026-05-13T22:50:00.912Z")
+        # And one legitimate bracketed tool-log line that MUST still produce
+        # a BROWSER event — we only want to drop the fallback noise, not the
+        # well-formed log format.
+        + _line("[browser] navigate https://example.com",
+                ts="2026-05-13T22:50:01.000Z")
+    )
+
+    # Empty session dir so the JSONL scan finds nothing and we isolate the
+    # log-path branch.
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+
+    import routes.brain as br
+    importlib.reload(br)
+
+    # Patch the late-imported helpers from dashboard.py that the route uses.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_get_log_dirs", lambda: [str(log_dir)], raising=True)
+    monkeypatch.setattr(_d, "SESSIONS_DIR", str(sessions_dir), raising=True)
+    monkeypatch.setattr(_d, "_ext_emit", lambda *a, **k: None, raising=True)
+
+    # The route ALSO hard-codes a glob of ``/tmp/openclaw/openclaw-*.log`` and
+    # then trims to the last 3 files. On a dev machine with real daemon logs
+    # in /tmp/openclaw/, our seeded test log gets shoved out of the window.
+    # Wrap glob.glob inside the brain module to drop those real files so the
+    # only log file the scan sees is our fixture.
+    real_glob = br.glob.glob
+
+    def _scoped_glob(pattern):
+        results = real_glob(pattern)
+        if "/tmp/openclaw" in pattern:
+            return []
+        return results
+
+    monkeypatch.setattr(br.glob, "glob", _scoped_glob)
+
+    a = Flask(__name__)
+    a.register_blueprint(br.bp_brain)
+    return a
+
+
+def test_lifecycle_console_lines_do_not_become_browser_events(fallback_app):
+    c = fallback_app.test_client()
+    r = c.get("/api/brain-history?limit=300")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+
+    # Must NOT have come from the local-store fast path (we forced legacy on).
+    assert body.get("_source") != "local_store"
+
+    events = body.get("events", [])
+
+    # The two onboarding/lifecycle strings must not appear ANYWHERE in the feed.
+    BANNED_FRAGMENTS = (
+        "Keep that tab to control OpenClaw",
+        "browser/clipboard URL",
+    )
+    leaked = [
+        ev for ev in events
+        if any(frag in (ev.get("detail") or "") for frag in BANNED_FRAGMENTS)
+    ]
+    assert not leaked, (
+        f"Brain feed leaked OpenClaw onboarding/lifecycle text as events: "
+        f"{[(ev.get('type'), ev.get('detail')) for ev in leaked]}"
+    )
+
+    # Sanity: a properly bracketed [browser] log line MUST still classify as
+    # BROWSER (we only want to drop the fallback noise, not the legit format).
+    browser_evts = [ev for ev in events if ev.get("type") == "BROWSER"]
+    assert browser_evts, (
+        "Bracketed [browser] log line should still produce a BROWSER event; "
+        "removed substring fallback must not have killed the legit path."
+    )
+    assert any(
+        "navigate https://example.com" in (ev.get("detail") or "")
+        for ev in browser_evts
+    ), [ev.get("detail") for ev in browser_evts]


### PR DESCRIPTION
## Summary
- Drop the substring-keyword fallback in `routes/brain.py`'s log scan that
  was tagging benign OpenClaw console lines as tool events
- Two real-world offenders the user hit at 22:50 today:
  - `Opened in your browser. Keep that tab to control OpenClaw.` rendered
    as `BROWSER` event with detail `browser. Keep that tab to control OpenClaw.`
  - `Token auto-auth included in browser/clipboard URL.` rendered as
    `BROWSER` with detail `browser/clipboard URL.`
- The bracketed `[tool] ...` log format is still parsed; only the loose
  `if "browser" in msg.lower(): emit BROWSER` branch is removed
- Real tool calls flow in via DuckDB `local_store` ingestion, so this
  fallback was pure noise (DuckDB-first rule)

## Root cause
`routes/brain.py:427-461` (legacy JSONL/log fallback) ran a substring scan
over ~12 keywords on every OpenClaw log line. Lines containing the substring
were sliced (`msg[start:start+300]`) and emitted as fake tool events, with
no validation that the line was actually a tool invocation. OpenClaw's
INFO-level lifecycle messages (browser-open hint, clipboard URL hint, etc.)
all matched.

## Test plan
- [x] New regression test `tests/test_brain_no_log_keyword_noise.py` —
  reproduces the bug on `main`, passes with this fix
- [x] Test asserts BOTH:
  - The exact strings from today's user report do NOT appear as events
  - A legit `[browser] navigate https://example.com` line STILL produces
    a BROWSER event (i.e. didn't kill the working code path)
- [x] Existing brain unit tests still pass (the 3 that fail on this branch
  also fail on `main` — daemon-state leakage, unrelated)
- [x] `python3 -c "import routes.brain"` clean
- [ ] After merge: verify `/api/brain-history` on a daemon-less install
  no longer surfaces "Keep that tab" / "clipboard URL" lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)