### PR TITLE
fix(brain): read detail+source from nested v3 event payload (P0 regression in 0.12.182)

### DIFF
--- a/routes/brain.py
+++ b/routes/brain.py
@@ -78,6 +78,121 @@ def _brain_history_bool_arg(value):
     return str(value or "").strip().lower() in {"1", "true", "yes", "on", "all"}
 
 
+def _v3_message_content_to_text(content) -> str:
+    """Flatten an OpenClaw v3 ``data.message.content`` payload into plain text.
+
+    The trajectory ingest path (sync.py L2090-L2102) stores the WHOLE raw event
+    on ``data``, so user/assistant rows arrive with content nested under
+    ``data.message.content`` — either a plain string (user) or a list of typed
+    blocks (assistant: ``[{type:"text", text:...}, {type:"tool_use", ...}]``).
+    Only the ``text`` and ``thinking`` blocks carry transcript content; the
+    rest (tool_use, image, etc.) are summarised separately upstream.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                t = block.get("text") or ""
+                if t:
+                    parts.append(t)
+            elif btype == "thinking":
+                t = block.get("thinking") or block.get("text") or ""
+                if t:
+                    parts.append(t)
+        return "\n".join(parts)
+    return ""
+
+
+def _extract_brain_detail(row: dict) -> str:
+    """Pull a human-readable ``detail`` snippet from a DuckDB event row.
+
+    Two ingest paths populate ``data`` with different shapes (P0 #1143 fix
+    landed the v3 mapper alongside the legacy trajectory parser); this helper
+    handles both plus the original flat-key fallback so brain-history never
+    returns empty strings for events that DO have content:
+
+      * Legacy/trajectory (event_type=user/assistant/attachment/queue-operation):
+        content lives under ``data.message.content`` (string or block list),
+        ``data.content``, or ``data.attachment.{name,filename}``.
+      * v3 underscore (event_type=prompt.submitted/model.completed/tool.result/
+        model.changed/session.started): content lives at the TOP of ``data``
+        under ``finalPromptText`` / ``completionText`` / ``output`` /
+        ``result`` / ``modelId`` / ``cwd``, with a mirror under ``data.data``.
+      * Anything older: the original ``input/summary/text/name`` flat keys.
+    """
+    data = row.get("data") if isinstance(row, dict) else None
+    if isinstance(data, str):
+        return data
+    if not isinstance(data, dict):
+        return ""
+
+    # --- Legacy/trajectory shape: data.message.content ---------------------
+    msg = data.get("message")
+    has_message_envelope = isinstance(msg, dict)
+    if has_message_envelope:
+        text = _v3_message_content_to_text(msg.get("content"))
+        if text:
+            return text
+        # Encrypted-thinking-only assistant turns ship as
+        # ``[{type:"thinking", thinking:"", signature:"…"}]``. The text is
+        # genuinely absent — bail out with a stable placeholder rather than
+        # falling through to noisy fallbacks like cwd / id.
+        role = msg.get("role")
+        if role in ("assistant", "user"):
+            return "(thinking)" if role == "assistant" else ""
+
+    # --- v3 mapper shape: top-level projection -----------------------------
+    for k in ("finalPromptText", "completionText", "output", "result",
+              "input", "summary", "text", "name", "content"):
+        v = data.get(k)
+        if isinstance(v, str) and v:
+            return v
+        if isinstance(v, list):
+            text = _v3_message_content_to_text(v)
+            if text:
+                return text
+
+    # --- v3 mirror shape: data.data.* --------------------------------------
+    inner = data.get("data")
+    if isinstance(inner, dict):
+        for k in ("finalPromptText", "completionText", "output", "result",
+                  "input", "summary", "text", "name"):
+            v = inner.get(k)
+            if isinstance(v, str) and v:
+                return v
+            if isinstance(v, list):
+                text = _v3_message_content_to_text(v)
+                if text:
+                    return text
+        # Assistant texts list (v3 model.completed)
+        atexts = inner.get("assistantTexts")
+        if isinstance(atexts, list):
+            joined = "\n".join(str(x) for x in atexts if isinstance(x, str) and x)
+            if joined:
+                return joined
+
+    # --- Type-specific fallbacks ------------------------------------------
+    # attachment events: surface filename
+    att = data.get("attachment")
+    if isinstance(att, dict):
+        for k in ("filename", "name", "path", "url"):
+            v = att.get(k)
+            if isinstance(v, str) and v:
+                return v
+    # session.started / model.changed: useful identifying labels
+    for k in ("modelId", "cwd", "id", "operation"):
+        v = data.get(k)
+        if isinstance(v, str) and v:
+            return v
+
+    return ""
+
+
 def _try_local_store_brain(limit: int, include_artifacts: bool):
     """Epic #964 phase 1b fast path. Returns a brain-history-shaped dict
     when CLAWMETRY_LOCAL_STORE_READ=1 AND the local DuckDB store has
@@ -117,15 +232,13 @@ def _try_local_store_brain(limit: int, include_artifacts: bool):
     # the dashboard JS expects (time/type/detail/src/sessionId/...).
     out = []
     for r in rows:
-        data = r.get("data") if isinstance(r, dict) else None
-        # `data` from query_events is already JSON-parsed when valid, or a
-        # str/None otherwise — see local_store.query_events.
-        detail = ""
-        if isinstance(data, dict):
-            detail = (data.get("input") or data.get("summary")
-                      or data.get("text") or data.get("name") or "")
-        elif isinstance(data, str):
-            detail = data
+        # P0 regression fix (#1143): the v3 sync mapper nests content under
+        # ``data.data`` and the legacy trajectory parser nests it under
+        # ``data.message.content`` — neither exposes the flat ``input/summary/
+        # text/name`` keys this fast path used to read, so EVERY row came back
+        # with detail="". ``_extract_brain_detail`` knows about all three
+        # shapes (legacy, v3 mapper top-level, v3 mapper mirror).
+        detail = _extract_brain_detail(r)
         out.append({
             "time":       r.get("ts", ""),
             "type":       (r.get("event_type") or "").upper(),

--- a/tests/test_brain_history_v3_event_detail.py
+++ b/tests/test_brain_history_v3_event_detail.py
@@ -1,0 +1,234 @@
+"""Regression test for the P0 bug where /api/brain-history returned
+``detail=""`` for every event after PR #1143's v3 sync mapper landed.
+
+Root cause: the local-store fast path in ``routes/brain.py`` looked for
+``data.input/summary/text/name`` only — flat keys that NEITHER the legacy
+trajectory parser (which nests under ``data.message.content``) nor the v3
+underscore mapper (which projects onto ``data.{finalPromptText,
+completionText, output, result}`` and mirrors under ``data.data``) populates.
+Result: the Brain tab rendered event-type chips with NO content body.
+
+This test pins down the read contract for ALL three shapes by seeding one
+synthetic row of each into a real DuckDB store and asserting the
+brain-history JSON carries non-empty ``detail`` for every one of them.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+from flask import Flask
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def brain_app(tmp_path, monkeypatch):
+    """Isolated Flask app + tmp DuckDB with the fast path enabled.
+
+    Critically: redirect the daemon-discovery path to a tmp non-existent
+    file. Without this, ``routes.brain._try_local_store_brain`` would proxy
+    over HTTP to a real running clawmetry daemon (whose discovery file
+    sits at ``~/.clawmetry/local_query.json``) and our seed rows would be
+    invisible — the test would assert on production data instead.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(
+        lq, "_DISCOVERY_PATH", str(tmp_path / "local_query_absent.json"),
+    )
+    import routes.brain as br
+    importlib.reload(br)
+
+    app = Flask(__name__)
+    app.register_blueprint(br.bp_brain)
+    yield app, ls, br
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _events_by_type(body):
+    """Map ``event_type`` (lowercased) → first matching event from the response."""
+    out = {}
+    for ev in body.get("events", []):
+        out.setdefault((ev.get("type") or "").lower(), ev)
+    return out
+
+
+def test_brain_history_detail_populated_for_v3_and_legacy_shapes(brain_app):
+    """One synthetic row per known shape; every detail must be non-empty.
+
+    Shapes covered:
+      * Legacy assistant (data.message.content = list of {type:text})
+      * Legacy user (data.message.content = string)
+      * v3 mapper top-level (data.completionText)
+      * v3 mapper mirror (data.data.finalPromptText)
+      * v3 tool result (data.output)
+    """
+    app, ls, _br = brain_app
+    store = ls.get_store()
+
+    rows = [
+        # 1. Legacy assistant: data.message.content as block list
+        {
+            "id": "ev-legacy-asst",
+            "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-1", "event_type": "assistant",
+            "ts": "2026-05-13T12:00:01Z",
+            "data": {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Hello from the assistant block list"}
+                    ],
+                },
+            },
+        },
+        # 2. Legacy user: data.message.content as string
+        {
+            "id": "ev-legacy-user",
+            "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-1", "event_type": "user",
+            "ts": "2026-05-13T12:00:02Z",
+            "data": {
+                "type": "user",
+                "message": {"role": "user", "content": "What is the weather today?"},
+            },
+        },
+        # 3. v3 mapper top-level: data.completionText
+        {
+            "id": "ev-v3-completion",
+            "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-1", "event_type": "model.completed",
+            "ts": "2026-05-13T12:00:03Z",
+            "data": {
+                "type": "model.completed",
+                "completionText": "v3 completion text body",
+                "modelId": "claude-opus-4-7",
+                "data": {"completionText": "v3 completion text body"},
+            },
+        },
+        # 4. v3 mapper MIRROR ONLY (top-level keys absent): data.data.finalPromptText
+        #    This is the exact shape that PR #1143 introduced and that the
+        #    pre-fix reader missed entirely — top-level had no flat content.
+        {
+            "id": "ev-v3-prompt-mirror",
+            "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-1", "event_type": "prompt.submitted",
+            "ts": "2026-05-13T12:00:04Z",
+            "data": {
+                "type": "prompt.submitted",
+                "_v3_type": "message",
+                "data": {"finalPromptText": "v3 prompt nested under data.data"},
+            },
+        },
+        # 5. v3 tool result: data.output
+        {
+            "id": "ev-v3-tool-result",
+            "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-1", "event_type": "tool.result",
+            "ts": "2026-05-13T12:00:05Z",
+            "data": {
+                "type": "tool.result",
+                "output": "ls /tmp output: foo bar baz",
+                "result": "ls /tmp output: foo bar baz",
+                "data": {"output": "ls /tmp output: foo bar baz"},
+            },
+        },
+    ]
+    for r in rows:
+        store.ingest(r)
+    _wait_flush(store)
+
+    body = app.test_client().get("/api/brain-history?limit=20").get_json()
+
+    assert body["_source"] == "local_store", (
+        "expected fast-path response (local_store), got: " + str(body)
+    )
+    assert body["count"] >= 5, body
+
+    by_type = _events_by_type(body)
+
+    # Each event_type must have non-empty detail.
+    expected = {
+        "assistant":         "Hello from the assistant block list",
+        "user":              "What is the weather today?",
+        "model.completed":   "v3 completion text body",
+        "prompt.submitted":  "v3 prompt nested under data.data",
+        "tool.result":       "ls /tmp output: foo bar baz",
+    }
+    for et, snippet in expected.items():
+        ev = by_type.get(et)
+        assert ev is not None, f"missing event of type {et!r} in response: {body}"
+        assert ev["detail"], (
+            f"P0 regression: detail empty for event_type={et!r} — pre-fix "
+            f"behaviour. Event: {ev}"
+        )
+        assert snippet in ev["detail"], (
+            f"detail for {et!r} did not include expected snippet "
+            f"{snippet!r}; got {ev['detail']!r}"
+        )
+
+
+def test_extract_brain_detail_unit_handles_all_shapes():
+    """Pure-Python unit cover for the helper, independent of DuckDB. Lets a
+    failing assertion point straight at the extractor instead of a Flask
+    integration suite."""
+    import importlib
+    import routes.brain as br
+    importlib.reload(br)
+
+    # Legacy assistant: block list with text
+    assert br._extract_brain_detail({
+        "data": {"message": {"role": "assistant", "content": [
+            {"type": "text", "text": "alpha"},
+        ]}},
+    }) == "alpha"
+
+    # Legacy user: string content
+    assert br._extract_brain_detail({
+        "data": {"message": {"role": "user", "content": "beta"}},
+    }) == "beta"
+
+    # v3 top-level
+    assert br._extract_brain_detail({
+        "data": {"completionText": "gamma"},
+    }) == "gamma"
+
+    # v3 mirror only
+    assert br._extract_brain_detail({
+        "data": {"data": {"finalPromptText": "delta"}},
+    }) == "delta"
+
+    # Encrypted-thinking-only assistant turn → placeholder, not cwd noise
+    assert br._extract_brain_detail({
+        "data": {
+            "cwd": "/Users/x/workspace",
+            "message": {"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "", "signature": "blob"},
+            ]},
+        },
+    }) == "(thinking)"
+
+    # Empty / non-dict data → empty string (no crash)
+    assert br._extract_brain_detail({}) == ""
+    assert br._extract_brain_detail({"data": None}) == ""
+    assert br._extract_brain_detail({"data": "raw string"}) == "raw string"


### PR DESCRIPTION
## Summary

P0 — every event in the Brain tab rendered with empty body since the v3 sync mapper landed in #1143.

`/api/brain-history`'s local-store fast path looked for FLAT `data.input/summary/text/name` keys only. But:
- Legacy/trajectory ingest (event_type=`user`/`assistant`/`attachment`/`queue-operation`) nests content under `data.message.content` (string OR Anthropic block list).
- v3 mapper from #1143 (event_type=`prompt.submitted`/`model.completed`/`tool.result`/...) projects content onto top-level `data.completionText`/`data.finalPromptText`/`data.output`/`data.result` AND mirrors the same payload under `data.data.*`.

Neither path populates the flat keys → 100% of rows came back `detail=""`.

## Fix

New `_extract_brain_detail(row)` helper in `routes/brain.py` — checks all three shapes in priority order:

1. `data.message.content` (legacy) — flatten text/thinking blocks via `_v3_message_content_to_text`.
2. Top-level `data.{finalPromptText, completionText, output, result, input, summary, text, name, content}` (v3 mapper).
3. Mirror at `data.data.*` (v3 mapper second copy).
4. Type-specific fallbacks: `data.attachment.{filename,name}`, `data.modelId`, `data.cwd`, `data.id`, `data.operation`.

Encrypted thinking-only assistant turns return `"(thinking)"` placeholder instead of leaking the `cwd` path.

## Live verification

Against the running daemon at port 8904, after hot-patching `~/.clawmetry/lib/python3.9/site-packages/routes/brain.py`:

```
Pre-fix:  EMPTY: 10/10
Post-fix: EMPTY: 0/10
[ASSISTANT] '[[reply_to_current]] Still here, still Diya...'
[USER     ] 'Conversation info (untrusted metadata)...'
[TOOL.RESULT] 'tool result string'
[MODEL.COMPLETED] 'Yes — if you read this in the dashboard transcript...'
```

Re. `source`: investigated and the field is `src` (not `source`); it IS populated with the truncated session_id. The bug-report curl checked `e.get('source','?')` — wrong key. No fix needed.

## Test plan

- [x] New `tests/test_brain_history_v3_event_detail.py`:
  - `test_brain_history_detail_populated_for_v3_and_legacy_shapes` — seeds 5 rows (one per shape) into a tmp DuckDB and asserts every event in the response carries the expected snippet.
  - `test_extract_brain_detail_unit_handles_all_shapes` — pure-Python unit cover for the helper, no Flask/DuckDB.
- [x] Live daemon verified (port 8904): 10/10 → 0/10 empty.
- [x] `make lint` → syntax OK.

Refs #1143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)