### PR TITLE
feat(sync): ingest OpenClaw Telegram channel + fix(install): detect+kill duplicate daemons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,9 +75,14 @@ All HTTP endpoints live here, organised by feature. Each module owns one or more
 
 ## How it works
 1. Reads session transcripts from `~/.openclaw/agents/main/sessions/*.jsonl`
-2. Connects to OpenClaw gateway via WebSocket (JSON-RPC, port 18789) for live data
-3. Optionally receives OpenTelemetry metrics/traces on `/v1/metrics` and `/v1/traces`
-4. Serves dashboard UI at `http://localhost:8900`
+2. Reads chat-channel transcripts from `~/.openclaw/<channel>/*.jsonl` —
+   one directory per adapter (`telegram/`, `signal/`, `whatsapp/`,
+   `discord/`, `slack/`, `irc/`, `imessage/`, `webchat/`, …). The 21
+   adapter directories match the routes in `routes/channels.py`. New
+   adapter? Add its dir name to `_CHANNEL_DIRS` in `clawmetry/sync.py`.
+3. Connects to OpenClaw gateway via WebSocket (JSON-RPC, port 18789) for live data
+4. Optionally receives OpenTelemetry metrics/traces on `/v1/metrics` and `/v1/traces`
+5. Serves dashboard UI at `http://localhost:8900`
 
 ## API Endpoints (key ones)
 - `/api/overview` — Main dashboard data (sessions, tokens, crons, health)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2472,6 +2472,326 @@ def sync_claude_cli_sessions(config: dict, state: dict, paths: dict) -> int:
     return total
 
 
+# ── Sync: channel-adapter transcripts (Telegram, Signal, WhatsApp, …) ────────
+#
+# OpenClaw's chat-channel adapters persist inbound/outbound messages to a
+# per-provider directory next to ``agents/``:
+#
+#   ~/.openclaw/telegram/<chat_id>.jsonl
+#   ~/.openclaw/signal/<chat_id>.jsonl
+#   ~/.openclaw/whatsapp/<chat_id>.jsonl
+#   ~/.openclaw/discord/<channel_id>.jsonl
+#   ~/.openclaw/slack/<channel_id>.jsonl
+#   ~/.openclaw/imessage/<chat_id>.jsonl
+#   ~/.openclaw/webchat/<session_id>.jsonl
+#   …                    (one dir per adapter — see routes/channels.py)
+#
+# Until this PR, ``sync.py`` only watched ``agents/main/sessions/`` which made
+# the Brain tab + ``channel_messages`` table miss every chat-channel turn —
+# the user observed "I message Diya on Telegram and ClawMetry shows nothing".
+#
+# DuckDB-first HARD RULE: every event lands in the ``events`` table (so
+# Brain/timeline reads see it) AND, when it parses as a chat turn, in
+# ``channel_messages`` (so per-provider routes in ``routes/channels.py`` see
+# it). No JSONL re-read at request time.
+#
+# The directory layout below is the canonical list maintained alongside the
+# 21 adapter routes in ``routes/channels.py``. If a new adapter ships, add its
+# directory name to ``_CHANNEL_DIRS`` and the daemon will pick it up on the
+# next cycle — no further wiring required.
+_CHANNEL_DIRS: tuple[str, ...] = (
+    "telegram",
+    "signal",
+    "whatsapp",
+    "discord",
+    "slack",
+    "irc",
+    "imessage",
+    "webchat",
+    "googlechat",
+    "msteams",
+    "bluebubbles",
+    "matrix",
+    "mattermost",
+    "line",
+    "nostr",
+    "twitch",
+    "feishu",
+    "zalo",
+    "tlon",
+    "synologychat",
+    "nextcloudtalk",
+)
+
+# Filenames inside ``~/.openclaw/<channel>/`` that are NOT conversation
+# transcripts — they're per-adapter bookkeeping (offset trackers, schema
+# manifests, etc.). Skip them so we don't crash on JSON-object-per-file
+# layouts and don't pollute ``events`` with daemon plumbing.
+_CHANNEL_NON_TRANSCRIPT_BASENAMES: frozenset[str] = frozenset({
+    "update-offset-default.json",
+    "schema.json",
+    "manifest.json",
+})
+
+
+def _list_channel_transcripts(channel_dir: str) -> list[str]:
+    """Return paths to all *transcript* files under a single channel dir.
+
+    A "transcript" is any ``*.jsonl`` (live or archived ``.jsonl.reset.<ts>``);
+    we explicitly skip the per-adapter bookkeeping files listed in
+    ``_CHANNEL_NON_TRANSCRIPT_BASENAMES``. The dashboard read path applies
+    the same exclusion via ``routes/channels.py``.
+    """
+    out: list[str] = []
+    try:
+        for fname in os.listdir(channel_dir):
+            if fname in _CHANNEL_NON_TRANSCRIPT_BASENAMES:
+                continue
+            # We accept .jsonl (live) and .jsonl.reset.<ts> (archived).
+            if fname.endswith(".jsonl") or ".jsonl.reset." in fname:
+                out.append(os.path.join(channel_dir, fname))
+    except OSError:
+        pass
+    return out
+
+
+def _parse_channel_event(
+    obj: dict, *, provider: str, channel_id: str
+) -> tuple[dict | None, dict | None]:
+    """Project one channel-jsonl line into (events_row, channel_messages_row).
+
+    The provider/channel-id are taken from the file path (cheap, robust),
+    and the per-event fields are read from a deliberately permissive set
+    of keys so we accept whatever shape the adapter writes:
+
+    * direction   — ``direction`` | ``"in"`` if a ``from``/``sender`` block
+                    is present | ``"out"`` if an ``assistant`` role / ``to``
+                    block is present. Defaults to ``"in"`` (most adapter
+                    jsonls record inbound first).
+    * body        — first present of ``text`` | ``body`` | ``message`` |
+                    ``content`` (string form) | content[0].text.
+    * sender_id   — ``sender_id`` | ``from.id`` | ``user.id`` | ``user_id``.
+    * sender_name — ``sender_name`` | ``from.username`` | ``from.first_name`` |
+                    ``user.name``.
+    * ts          — ``ts`` | ``timestamp`` | ``date`` (epoch-secs → ISO).
+    * id          — ``id`` | ``message_id`` | ``update_id`` (uniqueness key).
+
+    Returns ``(None, None)`` for lines we can't pin to a timestamp — those
+    are usually heartbeat/keepalive plumbing the adapter writes between
+    real messages. Always returns the events_row when we have a ts (so the
+    Brain tab paints), even if the body is empty.
+    """
+    if not isinstance(obj, dict):
+        return None, None
+
+    # ── ts ───────────────────────────────────────────────────────────────
+    raw_ts = obj.get("ts") or obj.get("timestamp") or obj.get("date")
+    if not raw_ts:
+        return None, None
+    if isinstance(raw_ts, (int, float)):
+        # Telegram/WhatsApp encode date as epoch seconds; coerce so all
+        # downstream sorts work on ISO strings.
+        try:
+            raw_ts = datetime.fromtimestamp(
+                float(raw_ts), tz=timezone.utc
+            ).isoformat()
+        except (ValueError, OSError, OverflowError):
+            return None, None
+    ts = str(raw_ts)
+
+    # ── id (stable across re-ingest) ─────────────────────────────────────
+    raw_id = (
+        obj.get("id")
+        or obj.get("message_id")
+        or obj.get("messageId")
+        or obj.get("update_id")
+        or obj.get("updateId")
+    )
+    if raw_id is None:
+        raw_id = f"{provider}:{channel_id}:{ts}"
+    eid = f"{provider}:{channel_id}:{raw_id}"
+
+    # ── direction ────────────────────────────────────────────────────────
+    direction = obj.get("direction")
+    if direction not in ("in", "out"):
+        if obj.get("role") == "assistant" or obj.get("from_bot") is True:
+            direction = "out"
+        elif obj.get("from") or obj.get("sender") or obj.get("user"):
+            direction = "in"
+        else:
+            direction = "in"
+
+    # ── body ─────────────────────────────────────────────────────────────
+    body = obj.get("text") or obj.get("body") or obj.get("message")
+    if body is None:
+        content = obj.get("content")
+        if isinstance(content, str):
+            body = content
+        elif isinstance(content, list):
+            for c in content:
+                if isinstance(c, dict) and c.get("type") == "text":
+                    body = c.get("text") or ""
+                    if body:
+                        break
+    if body is not None:
+        body = str(body)
+
+    # ── sender ───────────────────────────────────────────────────────────
+    sender_block = obj.get("from") or obj.get("sender") or obj.get("user") or {}
+    if not isinstance(sender_block, dict):
+        sender_block = {}
+    sender_id = (
+        obj.get("sender_id")
+        or sender_block.get("id")
+        or obj.get("user_id")
+        or channel_id
+    )
+    sender_name = (
+        obj.get("sender_name")
+        or sender_block.get("username")
+        or sender_block.get("first_name")
+        or sender_block.get("name")
+    )
+
+    events_row = {
+        "id": eid,
+        "agent_id": "main",
+        # Channel turns share the events table with session turns; the
+        # event_type lets the Brain/timeline filters distinguish them.
+        "event_type": f"channel.{direction}",
+        "ts": ts,
+        # session_id stays None — channel messages don't belong to an agent
+        # session (an LLM turn is a separate row). The session_key column
+        # on channel_messages handles correlation when the adapter writes
+        # one.
+        "session_id": None,
+        "workspace_id": None,
+        "data": obj,
+        "cost_usd": None,
+        "token_count": None,
+        "model": None,
+    }
+    channel_row = {
+        "id": eid,
+        "agent_id": "main",
+        "provider": provider,
+        "channel_id": str(channel_id),
+        "sender_id": str(sender_id) if sender_id is not None else None,
+        "sender_name": sender_name,
+        "body": (body[:4000] if body else None),
+        "ts": ts,
+        "direction": direction,
+        "session_key": obj.get("session_id") or obj.get("session_key"),
+        "raw_blob": obj,
+    }
+    return events_row, channel_row
+
+
+def sync_channel_messages(config: dict, state: dict, paths: dict) -> int:
+    """Tail each ``~/.openclaw/<channel>/*.jsonl`` and ingest both events
+    + channel_messages rows into local DuckDB.
+
+    Returns the number of NEW rows ingested this cycle. Idempotent — the
+    PRIMARY KEY on each table absorbs replays. Per-file offsets live in
+    ``state["last_channel_offsets"]`` so we don't re-scan from byte zero
+    on every cycle.
+    """
+    if not _sync_allowed():
+        return 0
+    _record_sync_progress("channel_messages", 0)
+    from clawmetry import local_store
+
+    openclaw_root = Path(_get_openclaw_dir())
+    offsets: dict = state.setdefault("last_channel_offsets", {})
+    store = local_store.get_store()
+    node_id = config["node_id"]
+    total = 0
+
+    for provider in _CHANNEL_DIRS:
+        if total >= MAX_EVENTS_PER_CYCLE:
+            break
+        channel_dir = openclaw_root / provider
+        if not channel_dir.is_dir():
+            continue
+        for fpath in _list_channel_transcripts(str(channel_dir)):
+            if total >= MAX_EVENTS_PER_CYCLE:
+                break
+            fname = os.path.basename(fpath)
+            # Strip both .jsonl and any .reset.<ts> suffix to get the
+            # canonical chat_id (== filename stem). Telegram writes
+            # ``<chat_id>.jsonl``; archived resets share the same chat_id.
+            channel_id = fname.split(".jsonl", 1)[0]
+            offset_key = f"{provider}/{fname}"
+            offset = int(offsets.get(offset_key, 0))
+            events_batch: list[dict] = []
+            channel_batch: list[dict] = []
+
+            try:
+                with open(fpath, "r", errors="replace") as f:
+                    f.seek(0, 2)
+                    size = f.tell()
+                    if offset > size:
+                        # File was rotated/truncated — restart from byte 0
+                        # rather than skip silently. DuckDB PK dedupes
+                        # any replayed messages on the upstream id.
+                        offset = 0
+                    f.seek(offset)
+                    for raw in f:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        try:
+                            obj = json.loads(raw)
+                        except Exception:
+                            continue
+                        ev, ch = _parse_channel_event(
+                            obj, provider=provider, channel_id=channel_id
+                        )
+                        if ev is None:
+                            continue
+                        # Stamp node_id + agent_type onto the events row
+                        # so the dashboard's per-node filters work. The
+                        # store layer fills agent_type='openclaw' by
+                        # default; we pass it explicitly for forward-
+                        # compat with other harnesses' channel adapters.
+                        ev["node_id"] = node_id
+                        ev["agent_type"] = "openclaw"
+                        events_batch.append(ev)
+                        if ch is not None:
+                            channel_batch.append(ch)
+                        if len(events_batch) >= BATCH_SIZE:
+                            break
+                    offsets[offset_key] = f.tell()
+            except OSError as e:
+                log.warning(
+                    "channel sync error (%s/%s): %s", provider, fname, e
+                )
+                continue
+
+            if events_batch:
+                try:
+                    store.ingest_many(events_batch)
+                except Exception as e:
+                    log.warning(
+                        "channel events ingest failed (%s/%s): %s",
+                        provider, fname, e,
+                    )
+            for ch in channel_batch:
+                try:
+                    store.ingest_channel_message(ch)
+                except Exception as e:
+                    # Per-row try/except so a malformed message can't take
+                    # down the whole batch — the events row already landed.
+                    log.debug(
+                        "channel_message ingest skipped (%s/%s): %s",
+                        provider, fname, e,
+                    )
+            total += len(events_batch)
+
+    _record_sync_progress("channel_messages", total, total)
+    return total
+
+
 # ── Sync: logs (full lines, encrypted) ────────────────────────────────────────
 
 
@@ -6266,6 +6586,15 @@ def run_daemon() -> None:
 
             ev = sync_sessions(config, state, paths)
             ev += sync_claude_cli_sessions(config, state, paths)
+            # Tail ~/.openclaw/<channel>/*.jsonl (Telegram, Signal, WhatsApp,
+            # Discord, Slack, …). Until 2026-05-13 this watch path was missing
+            # entirely — the user observed "I message Diya on Telegram and
+            # ClawMetry shows nothing in Brain." Failure is non-fatal: the
+            # next cycle will retry from the saved offset.
+            try:
+                ev += sync_channel_messages(config, state, paths)
+            except Exception as _ce:
+                log.warning(f"channel sync error (non-fatal): {_ce}")
             sm = sync_session_metadata(config, state)
             crons = sync_crons(config, state, paths)
             # Issue #605 DuckDB follow-up: tail cron-run JSONL files into

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,21 @@ echo -e "  ${BOLD}🦞 ClawMetry${NC}  ${DIM}AI Observability for OpenClaw${NC}"
 echo -e "  $(printf '%.0s─' {1..50})"
 echo ""
 
+# ── Pre-flight: detect existing daemon ──────────────────────────────────────
+# Re-running ``curl install.sh | bash`` against an already-installed copy used
+# to leave the OLD pip-launched daemon (running stale code) alive next to the
+# fresh venv binary. Both processes raced for the DuckDB write lock and every
+# internal query 500'd with "Conflicting lock is held in <python> (PID …)".
+# The launchctl/systemd restart blocks below only kick OS-managed jobs — they
+# do nothing for daemons that the user started by hand. We track the
+# pre-existing daemon here so the post-install cleanup block (further down)
+# can ``pkill -f`` it after the new code is in place.
+CLAWMETRY_RESTART_AFTER=0
+if pgrep -f "clawmetry\.sync|clawmetry --port|clawmetry$" >/dev/null 2>&1; then
+  echo -e "  ${DIM}↻ Existing clawmetry daemon detected — will restart it after upgrade${NC}"
+  CLAWMETRY_RESTART_AFTER=1
+fi
+
 # ── Detect OS ───────────────────────────────────────────────────────────────
 
 OS="$(uname -s)"
@@ -198,6 +213,26 @@ if [ "$OS" = "Linux" ]; then
     echo -e "  ${DIM}If clawmetry was already running, restart it with:${NC}"
     echo -e "  ${DIM}  pkill -f clawmetry && nohup clawmetry &${NC}"
   fi
+fi
+
+# ── Post-install: kill stray pre-existing daemons ───────────────────────────
+# The launchctl/systemd blocks above only restart OS-managed jobs. If the
+# user originally started clawmetry by hand (``pip install clawmetry &&
+# clawmetry --port 8900``), that pid is still attached to the OLD venv we
+# just deleted — and now races the freshly-installed daemon for the DuckDB
+# write lock. ``pkill -f`` here ensures the OLD daemon exits so the NEW one
+# (which the launchctl/systemd block above will respawn, or which the user
+# will respawn with ``clawmetry``) takes over cleanly.
+#
+# Guarded by the pre-flight detect so we don't kill a daemon that wasn't
+# there when the installer started — that case would either (a) be the
+# launchctl/systemd job we just kickstarted, or (b) be unrelated.
+if [ "$CLAWMETRY_RESTART_AFTER" = "1" ]; then
+  pkill -f "clawmetry\.sync" >/dev/null 2>&1 || true
+  # Wait briefly for the kernel to release the DuckDB write lock so the
+  # next ``clawmetry`` invocation doesn't immediately race the dying pid.
+  sleep 1
+  echo -e "  ${DIM}↺ Killed stray pre-existing daemon (lock released)${NC}"
 fi
 
 echo ""

--- a/tests/test_install_script_no_duplicate_daemon.py
+++ b/tests/test_install_script_no_duplicate_daemon.py
@@ -1,0 +1,124 @@
+"""Regression test for install.sh duplicate-daemon detection + cleanup.
+
+Bug pinned by these tests
+-------------------------
+
+Re-running ``curl install.sh | bash`` against an already-installed copy used
+to leave the OLD pip-launched daemon (running stale code) alive next to the
+fresh venv binary. Both processes raced for the DuckDB write lock and every
+internal query 500'd with::
+
+    Conflicting lock is held in /Users/vivek/.local/share/uv/python/
+        cpython-3.11.15-macos-aarch64-none/bin/python3.11 (PID 74211)
+
+The launchctl/systemd restart blocks DON'T kick a daemon the user started by
+hand — only OS-managed jobs. We need an explicit pre-flight detect + a
+post-install ``pkill -f`` to clean the strays.
+
+We can't run a real installer in CI without spinning up a fresh OS, so this
+test asserts the relevant code blocks are present *and* that the script
+remains a valid bash script after the edit.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+
+def _read_install_sh() -> str:
+    assert INSTALL_SH.exists(), f"install.sh missing at {INSTALL_SH}"
+    return INSTALL_SH.read_text()
+
+
+def test_install_sh_syntax_is_valid() -> None:
+    """``bash -n install.sh`` must parse cleanly after the edits."""
+    bash = shutil.which("bash")
+    assert bash, "bash not found on PATH"
+    result = subprocess.run(
+        [bash, "-n", str(INSTALL_SH)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_preflight_detects_existing_daemon() -> None:
+    """Before touching anything, install.sh must check for a running daemon
+    and remember the result for the post-install cleanup block."""
+    body = _read_install_sh()
+    # The detect block sets a flag the post-install block reads.
+    assert "CLAWMETRY_RESTART_AFTER" in body, (
+        "install.sh must remember pre-existing daemon detection in a flag "
+        "so the post-install block can act on it"
+    )
+    # We don't pin the EXACT pgrep regex (it can grow as new entry-points
+    # land) but it must (a) use pgrep -f, (b) match clawmetry.sync, and
+    # (c) match the user-launched ``clawmetry`` invocation.
+    assert "pgrep -f" in body, "must use pgrep -f to find Python procs"
+    assert "clawmetry\\.sync" in body or "clawmetry.sync" in body, (
+        "preflight must match the sync daemon"
+    )
+
+
+def test_postinstall_kills_strays_when_flag_set() -> None:
+    """After the new venv is in place AND the launchctl/systemd block has
+    run, kill any pre-existing pip-launched daemon so the new code wins
+    the DuckDB write lock."""
+    body = _read_install_sh()
+    # Guarded by the pre-flight flag — we MUST NOT pkill if no daemon was
+    # there at install start (could clobber an unrelated process started
+    # mid-install by the launchctl/systemd block).
+    assert 'if [ "$CLAWMETRY_RESTART_AFTER" = "1" ]; then' in body, (
+        "kill block must be guarded by the pre-flight flag"
+    )
+    # Must use ``pkill -f`` so the match works against the sync daemon's
+    # full ``python3 -m clawmetry.sync`` cmdline.
+    assert 'pkill -f "clawmetry\\.sync"' in body or \
+           "pkill -f 'clawmetry\\.sync'" in body, (
+        "post-install block must pkill -f the stray sync daemon"
+    )
+
+
+def test_postinstall_block_runs_after_launchctl_systemd_blocks() -> None:
+    """The kill block must run AFTER the launchctl/systemd restart blocks.
+    Otherwise we'd kill a daemon, then immediately fail to restart it
+    (no plist exists yet for a first install)."""
+    body = _read_install_sh()
+    # Find ordinal positions of each anchor.
+    darwin_anchor = body.find('if [ "$OS" = "Darwin" ]; then')
+    linux_anchor = body.find('if [ "$OS" = "Linux" ]; then')
+    kill_anchor = body.find('if [ "$CLAWMETRY_RESTART_AFTER" = "1" ]; then')
+    assert darwin_anchor != -1, "Darwin restart block missing"
+    assert linux_anchor != -1, "Linux restart block missing"
+    assert kill_anchor != -1, "post-install kill block missing"
+    assert kill_anchor > darwin_anchor, (
+        "kill block must come AFTER Darwin launchctl restart"
+    )
+    assert kill_anchor > linux_anchor, (
+        "kill block must come AFTER Linux systemd restart"
+    )
+
+
+def test_no_kill_when_no_daemon_was_running() -> None:
+    """If the pre-flight detect didn't see a daemon, we must NOT pkill —
+    that would risk killing an unrelated process the launchctl block just
+    started. The test asserts the kill is INSIDE the flag-guard, not at
+    top level."""
+    body = _read_install_sh()
+    # Simple structural check: the pkill -f "clawmetry\.sync" line MUST
+    # follow the flag-guard `if` line and PRECEDE its closing `fi`.
+    guard = 'if [ "$CLAWMETRY_RESTART_AFTER" = "1" ]; then'
+    g_idx = body.find(guard)
+    assert g_idx != -1
+    # Everything between the guard and the next "fi" is the kill block.
+    block_end = body.find("\nfi", g_idx)
+    assert block_end != -1, "guarded block has no closing fi"
+    block = body[g_idx:block_end]
+    assert "pkill -f" in block, (
+        "pkill -f must live inside the CLAWMETRY_RESTART_AFTER guard"
+    )

--- a/tests/test_telegram_ingest.py
+++ b/tests/test_telegram_ingest.py
@@ -1,0 +1,297 @@
+"""Tests for sync_channel_messages — OpenClaw chat-channel ingest.
+
+Bug pinned by these tests
+-------------------------
+
+ClawMetry's sync daemon used to watch ONLY
+``~/.openclaw/agents/main/sessions/*.jsonl``. OpenClaw's chat-channel adapters
+(Telegram, Signal, WhatsApp, Discord, Slack, IRC, iMessage, …) persist their
+inbound + outbound messages to a sibling per-provider directory:
+``~/.openclaw/<channel>/<chat_id>.jsonl``. None of those rows reached DuckDB,
+so the Brain tab and ``channel_messages`` table missed every chat-channel
+turn — the user reported "I message Diya on Telegram and ClawMetry shows
+nothing".
+
+What we cover
+-------------
+1. A Telegram-shaped jsonl file lands in BOTH the ``events`` table (so the
+   Brain timeline paints) AND the ``channel_messages`` table (so the
+   per-provider routes in ``routes/channels.py`` paint).
+2. Outbound (``role: assistant``) messages get ``direction='out'``.
+3. Sibling channel directories (``signal/``, ``slack/``, …) are picked up
+   off the same code path with no extra config.
+4. Per-adapter bookkeeping files (e.g. ``update-offset-default.json``) are
+   skipped — we don't try to parse them as transcripts.
+5. Re-running sync against an unchanged file is a no-op (offset persisted).
+6. Re-running sync after the file grew tails JUST the new lines.
+
+DuckDB-first hard rule (``feedback_duckdb_first_rule``): every chat-channel
+event MUST land in DuckDB. JSONL re-reads at request time are violations.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def store_env(tmp_path, monkeypatch):
+    """Per-test DuckDB + a fake OPENCLAW_HOME we control."""
+    duck = tmp_path / "events.duckdb"
+    oc_home = tmp_path / "openclaw"
+    oc_home.mkdir()
+
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(duck))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(oc_home))
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as sync_mod
+    importlib.reload(sync_mod)
+
+    store = ls.get_store()
+    yield {
+        "store": store,
+        "ls": ls,
+        "sync": sync_mod,
+        "oc_home": oc_home,
+        "duck": duck,
+    }
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed_telegram_chat(oc_home: Path, chat_id: str, lines: list[dict]) -> Path:
+    """Write a Telegram-shaped jsonl (one event per line) to
+    ``<oc_home>/telegram/<chat_id>.jsonl``."""
+    d = oc_home / "telegram"
+    d.mkdir(exist_ok=True)
+    p = d / f"{chat_id}.jsonl"
+    p.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    return p
+
+
+def _stub_config_state_paths(oc_home: Path) -> tuple[dict, dict, dict]:
+    """Minimal config/state/paths a sync_* function needs. ``paths`` is
+    only consulted for ``sessions_dir``/``log_dir`` by other helpers — the
+    channel sync derives its watch root from ``_get_openclaw_dir()``, which
+    we already pinned via the CLAWMETRY_OPENCLAW_DIR env."""
+    return (
+        {"api_key": "test-key", "node_id": "test-node"},
+        {},
+        {"sessions_dir": str(oc_home), "log_dir": str(oc_home)},
+    )
+
+
+def _flush(store) -> None:
+    """Force the local store's background flusher to drain the ring."""
+    store._flush_now()
+
+
+def test_telegram_inbound_lands_in_events_and_channel_messages(store_env):
+    """A user→bot Telegram message lands in BOTH ``events`` and
+    ``channel_messages``, with channel='telegram' and direction='in'."""
+    store = store_env["store"]
+    sync_mod = store_env["sync"]
+    oc_home = store_env["oc_home"]
+
+    _seed_telegram_chat(oc_home, "1532693273", [
+        {
+            "id": 8463,
+            "ts": "2026-05-13T22:00:00Z",
+            "direction": "in",
+            "from": {"id": 1532693273, "username": "vivek", "first_name": "Vivek"},
+            "text": "hey diya — what's the deploy status?",
+        },
+    ])
+
+    cfg, state, paths = _stub_config_state_paths(oc_home)
+    n = sync_mod.sync_channel_messages(cfg, state, paths)
+    _flush(store)
+    assert n == 1, f"expected 1 ingested row, got {n}"
+
+    # ── events table ─────────────────────────────────────────────────────
+    evs = store.query_events(event_type="channel.in", limit=10)
+    assert len(evs) == 1, evs
+    e = evs[0]
+    assert e["agent_id"] == "main"
+    assert e["event_type"] == "channel.in"
+    assert e["ts"] == "2026-05-13T22:00:00Z"
+    assert e["node_id"] == "test-node"
+
+    # ── channel_messages table ───────────────────────────────────────────
+    rows = store._fetch(
+        "SELECT provider, channel_id, sender_id, sender_name, body, "
+        "direction FROM channel_messages WHERE provider = ?",
+        ["telegram"],
+    )
+    assert len(rows) == 1
+    provider, chan_id, sid, sname, body, direction = rows[0]
+    assert provider == "telegram"
+    assert chan_id == "1532693273"
+    assert sid == "1532693273"
+    assert sname in ("vivek", "Vivek")  # username preferred but first_name OK
+    assert "deploy status" in body
+    assert direction == "in"
+
+
+def test_telegram_outbound_assistant_role_marked_out(store_env):
+    """A bot→user message (role='assistant') gets direction='out'."""
+    store = store_env["store"]
+    sync_mod = store_env["sync"]
+    oc_home = store_env["oc_home"]
+
+    _seed_telegram_chat(oc_home, "1532693273", [
+        {
+            "message_id": 8464,
+            "ts": "2026-05-13T22:00:30Z",
+            "role": "assistant",
+            "text": "Deploy is green — last release 12 minutes ago.",
+        },
+    ])
+
+    cfg, state, paths = _stub_config_state_paths(oc_home)
+    sync_mod.sync_channel_messages(cfg, state, paths)
+    _flush(store)
+
+    rows = store._fetch(
+        "SELECT direction, body FROM channel_messages WHERE provider = ?",
+        ["telegram"],
+    )
+    assert len(rows) == 1
+    direction, body = rows[0]
+    assert direction == "out"
+    assert "green" in body
+
+
+def test_sibling_channel_dirs_picked_up(store_env):
+    """Signal + Slack + WhatsApp messages land alongside Telegram with no
+    config — the daemon iterates the canonical channel-dir list."""
+    store = store_env["store"]
+    sync_mod = store_env["sync"]
+    oc_home = store_env["oc_home"]
+
+    # Three sibling channel dirs, one inbound message each.
+    for provider, chat_id, body in (
+        ("signal", "+14155551212", "hey signal user"),
+        ("slack",  "C123ABC", "deploy queue is empty"),
+        ("whatsapp", "447700900000", "ack from whatsapp"),
+    ):
+        d = oc_home / provider
+        d.mkdir()
+        (d / f"{chat_id}.jsonl").write_text(json.dumps({
+            "id": f"{provider}-1",
+            "ts": "2026-05-13T22:01:00Z",
+            "direction": "in",
+            "text": body,
+            "sender_id": chat_id,
+        }) + "\n")
+
+    cfg, state, paths = _stub_config_state_paths(oc_home)
+    n = sync_mod.sync_channel_messages(cfg, state, paths)
+    _flush(store)
+    assert n == 3
+
+    rows = store._fetch(
+        "SELECT provider, channel_id, body FROM channel_messages "
+        "ORDER BY provider",
+        [],
+    )
+    providers_seen = {r[0] for r in rows}
+    assert providers_seen == {"signal", "slack", "whatsapp"}
+
+
+def test_non_transcript_files_are_skipped(store_env):
+    """``update-offset-default.json`` and friends are per-adapter bookkeeping
+    — they're NOT chat transcripts and must not be parsed as one. Asserts no
+    crash + no rows ingested when the directory only has bookkeeping."""
+    store = store_env["store"]
+    sync_mod = store_env["sync"]
+    oc_home = store_env["oc_home"]
+
+    d = oc_home / "telegram"
+    d.mkdir()
+    # The real OpenClaw file shape on the user's machine (2026-05-13).
+    (d / "update-offset-default.json").write_text(json.dumps({
+        "version": 2,
+        "lastUpdateId": 440774875,
+        "botId": "8253463264",
+    }))
+
+    cfg, state, paths = _stub_config_state_paths(oc_home)
+    n = sync_mod.sync_channel_messages(cfg, state, paths)
+    _flush(store)
+    assert n == 0
+    rows = store._fetch(
+        "SELECT COUNT(*) FROM channel_messages WHERE provider = ?",
+        ["telegram"],
+    )
+    assert rows[0][0] == 0
+
+
+def test_offset_advances_so_resync_is_no_op(store_env):
+    """Two back-to-back syncs with no file change → second pass ingests 0."""
+    store = store_env["store"]
+    sync_mod = store_env["sync"]
+    oc_home = store_env["oc_home"]
+
+    _seed_telegram_chat(oc_home, "1532693273", [
+        {"id": 1, "ts": "2026-05-13T22:00:00Z", "direction": "in", "text": "a"},
+        {"id": 2, "ts": "2026-05-13T22:00:01Z", "direction": "in", "text": "b"},
+    ])
+    cfg, state, paths = _stub_config_state_paths(oc_home)
+
+    n1 = sync_mod.sync_channel_messages(cfg, state, paths)
+    n2 = sync_mod.sync_channel_messages(cfg, state, paths)
+    _flush(store)
+
+    assert n1 == 2
+    assert n2 == 0, "offset should have advanced past EOF"
+    # Offset was persisted on the state dict the daemon hands us.
+    offsets = state.get("last_channel_offsets") or {}
+    assert any(k.startswith("telegram/") for k in offsets), offsets
+
+
+def test_appended_lines_picked_up_on_next_cycle(store_env):
+    """Appending new lines to an already-tailed file is picked up on the
+    next sync cycle — only the appended bytes are read."""
+    store = store_env["store"]
+    sync_mod = store_env["sync"]
+    oc_home = store_env["oc_home"]
+
+    p = _seed_telegram_chat(oc_home, "1532693273", [
+        {"id": 10, "ts": "2026-05-13T22:00:00Z", "direction": "in", "text": "first"},
+    ])
+    cfg, state, paths = _stub_config_state_paths(oc_home)
+
+    n1 = sync_mod.sync_channel_messages(cfg, state, paths)
+    assert n1 == 1
+
+    # Append two more lines.
+    with p.open("a") as f:
+        f.write(json.dumps({
+            "id": 11, "ts": "2026-05-13T22:00:05Z",
+            "direction": "in", "text": "second",
+        }) + "\n")
+        f.write(json.dumps({
+            "id": 12, "ts": "2026-05-13T22:00:10Z",
+            "direction": "in", "text": "third",
+        }) + "\n")
+
+    n2 = sync_mod.sync_channel_messages(cfg, state, paths)
+    _flush(store)
+
+    assert n2 == 2
+    rows = store._fetch(
+        "SELECT body FROM channel_messages WHERE provider = ? ORDER BY ts",
+        ["telegram"],
+    )
+    bodies = [r[0] for r in rows]
+    assert bodies == ["first", "second", "third"]


### PR DESCRIPTION
## Why

Two related bugs surfaced when re-installing ClawMetry on a machine with an active Telegram bot:

### Bug 1 — Telegram messages never reached DuckDB (P0 architectural gap)

`sync.py` only watched `~/.openclaw/agents/main/sessions/`. OpenClaw's chat-channel adapters write to **sibling per-provider directories** under `~/.openclaw/`:

```
~/.openclaw/telegram/<chat_id>.jsonl
~/.openclaw/signal/<chat_id>.jsonl
~/.openclaw/whatsapp/<chat_id>.jsonl
~/.openclaw/discord/<channel_id>.jsonl
~/.openclaw/slack/<channel_id>.jsonl
…  (21 dirs total — one per adapter in routes/channels.py)
```

Result: the Brain tab and `channel_messages` table missed every chat-channel turn. The user observed "I message Diya on Telegram and ClawMetry shows nothing."

### Bug 2 — `curl install.sh | bash` spawned a duplicate daemon

A new daemon appeared next to the existing pip-launched one. Both raced for the DuckDB write lock and every internal query 500'd:

```
Conflicting lock is held in /Users/vivek/.local/share/uv/python/
    cpython-3.11.15-macos-aarch64-none/bin/python3.11 (PID 74211)
```

The launchctl/systemd restart blocks added in #1183/#1187 only kick OS-managed jobs — they do nothing for daemons started by hand.

## What changed

### `clawmetry/sync.py`

- New `sync_channel_messages(config, state, paths)` function tails every `~/.openclaw/<channel>/*.jsonl` for the canonical 21-adapter list (`_CHANNEL_DIRS`). Wired into the daemon loop next to `sync_sessions()`.
- Skips per-adapter bookkeeping files (`update-offset-default.json`, `schema.json`, `manifest.json`).
- Permissive event parser accepts the common shapes adapters emit: `text`/`body`/`message` for body; `from`/`sender`/`user` blocks for sender; `role=assistant` → `direction=out`.
- Each row lands in **BOTH** `events` (so Brain/timeline reads see it) AND `channel_messages` (so the per-provider routes in `routes/channels.py` see it). Honors the DuckDB-first hard rule — no JSONL re-read at request time.
- Per-file offsets persisted in `state["last_channel_offsets"]` so re-syncs are O(new bytes), not O(file size).

### `install.sh`

- **Pre-flight detect** at the top: `pgrep -f "clawmetry\.sync|clawmetry --port|clawmetry$"` sets `CLAWMETRY_RESTART_AFTER=1`.
- **Post-install kill** (after the launchctl/systemd restart blocks): when the flag is set, `pkill -f "clawmetry\.sync"` cleans the stray and waits 1s for the kernel to release the DuckDB lock.

### `CLAUDE.md`

- "How it works" section updated with the new channel-dir watch list.

## Tests

- `tests/test_telegram_ingest.py` (6 cases): inbound/outbound parse, sibling-channel pickup, bookkeeping-file skip, offset advance, append-on-next-cycle.
- `tests/test_install_script_no_duplicate_daemon.py` (5 cases): bash-n syntax, pre-flight detect, guarded pkill, post-launchctl ordering, in-guard placement.

```
$ python3 -m pytest tests/test_telegram_ingest.py \
    tests/test_install_script_no_duplicate_daemon.py \
    tests/test_install_script_linux_restart.py \
    tests/test_channels_local_store.py \
    tests/test_sync_skip_sidecar_jsonls.py -q
23 passed in 1.17s
```

Broader sync/channel/install sweep also clean (144 passed, 7 skipped).

## Test plan

- [ ] Merge → `[RELEASE]` PR → `pip install --upgrade clawmetry` on a node with active Telegram traffic
- [ ] Send a message to the bot from Telegram, confirm it appears in `/api/brain-history` within ~60s
- [ ] Confirm `SELECT COUNT(*) FROM channel_messages WHERE provider='telegram'` is non-zero
- [ ] Re-run `curl install.sh | bash`, confirm only ONE clawmetry pid afterwards (no lock 500s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)