### PR TITLE
feat(sync): include channel events in brain cache push (cloud Brain renders Telegram)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2973,6 +2973,64 @@ def _local_dispatch_fallback(shape: str, args: dict) -> dict:
     return {"rows": rows, "count": len(rows), "_shape": shape, "_via": "fallback"}
 
 
+def _channel_enrichment_from_row(r: dict) -> dict:
+    """Pull (provider, chat_id, sender_id, sender, direction) out of a
+    channel.* events row so the cloud Brain renderer can display
+    "Telegram: Vivek Chand: hello" instead of generic agent activity.
+
+    The ingest path in ``sync_channel_messages`` (PR #1191) writes channel
+    transcripts with:
+      * ``event_type`` = ``"channel.in"`` or ``"channel.out"``
+      * ``id`` = ``f"{provider}:{channel_id}:{raw_id}"`` — the only place
+        ``provider`` lives on the events row, since the events table has
+        no provider column.
+      * ``data`` = the original adapter line (``from``/``sender``/``user``
+        block, ``text``/``body``, etc.).
+
+    Returns ``{}`` for non-channel rows so callers can spread it
+    unconditionally. Never raises.
+    """
+    et = r.get("event_type") or ""
+    if not isinstance(et, str) or not et.startswith("channel."):
+        return {}
+    direction = et.split(".", 1)[1] if "." in et else ""
+    eid = r.get("id") or ""
+    provider = ""
+    chat_id = ""
+    if isinstance(eid, str) and eid.count(":") >= 2:
+        # ``{provider}:{channel_id}:{raw_id}`` — raw_id may itself contain
+        # colons (rare, but defensible: split only the first two segments).
+        parts = eid.split(":", 2)
+        provider, chat_id = parts[0], parts[1]
+    data = r.get("data") if isinstance(r.get("data"), dict) else {}
+    sender_block = (
+        data.get("from") or data.get("sender") or data.get("user") or {}
+    )
+    if not isinstance(sender_block, dict):
+        sender_block = {}
+    sender_id = (
+        data.get("sender_id")
+        or sender_block.get("id")
+        or data.get("user_id")
+        or chat_id
+    )
+    sender = (
+        data.get("sender_name")
+        or sender_block.get("username")
+        or sender_block.get("first_name")
+        or sender_block.get("name")
+        or ""
+    )
+    out = {
+        "provider":  provider,
+        "chat_id":   str(chat_id) if chat_id != "" else "",
+        "sender_id": str(sender_id) if sender_id is not None else "",
+        "sender":    str(sender),
+        "direction": direction,
+    }
+    return out
+
+
 def _rows_to_brain_events(rows: list) -> list:
     """Return raw OpenClaw event payloads ready for the cloud browser's
     ``transformEvents`` to unwrap.
@@ -2995,6 +3053,13 @@ def _rows_to_brain_events(rows: list) -> list:
     didn't already carry one (transformEvents needs ``obj.timestamp ||
     obj.time``).
 
+    Channel events (``event_type`` starts with ``channel.``) get extra
+    top-level keys — ``provider`` / ``chat_id`` / ``sender_id`` /
+    ``sender`` / ``direction`` — so the cloud Brain renderer can show
+    "Telegram: Vivek Chand: hello, how are you doing?" instead of generic
+    agent activity. ``transformEvents`` ignores keys it doesn't know about,
+    so this is a forward-compatible enrichment.
+
     The OSS-local Brain tab uses ``routes/brain.py:_try_local_store_brain``
     which builds the display shape directly — that path is unchanged.
     """
@@ -3003,12 +3068,27 @@ def _rows_to_brain_events(rows: list) -> list:
         if not isinstance(r, dict):
             continue
         data = r.get("data")
+        enrich = _channel_enrichment_from_row(r)
         if isinstance(data, dict):
             if not data.get("timestamp") and not data.get("time") and r.get("ts"):
                 data = {**data, "timestamp": r.get("ts")}
+            if enrich:
+                # Enrichment wins — the JSONL payload often carries the
+                # raw ``sender``/``from`` BLOCK under the same key name
+                # (Signal: ``data.sender = {"id":..,"name":..}``); we want
+                # the renderer to read the FLAT string we computed, not
+                # the nested dict. Same for ``provider`` / ``chat_id``
+                # which never appear in adapter payloads.
+                data = {**data, **enrich}
+                # Stamp the channel event type back on so the cloud
+                # renderer's fallback branch (line ~10038 of cloud
+                # dashboard.py) can show "CHANNEL.IN" / "CHANNEL.OUT"
+                # rather than guessing from a missing role.
+                data.setdefault("type", r.get("event_type"))
             out.append(data)
         elif isinstance(data, str):
             out.append({
+                **enrich,
                 "type":      r.get("event_type") or "raw",
                 "timestamp": r.get("ts", ""),
                 "detail":    data[:2000],

--- a/tests/test_brain_cache_push_channel_events.py
+++ b/tests/test_brain_cache_push_channel_events.py
@@ -1,0 +1,319 @@
+"""Tests for channel-event enrichment in the heartbeat-piggyback brain
+cache push (extends epic #1032 Phase 2).
+
+Bug pinned by these tests
+-------------------------
+
+Once aca53ec8's PR #1191 (commit 2dff811) added
+``sync_channel_messages()``, every Telegram/Signal/WhatsApp/Discord turn
+landed in DuckDB with ``event_type='channel.in'``/``'channel.out'``. The
+heartbeat-piggyback brain cache push (``_build_brain_cache_pushes``)
+already pulled them via ``query_events(limit=50)`` — but the cloud Brain
+renderer had no way to display "Telegram: Vivek Chand: hello, how are
+you?" because the OSS daemon shipped the rows without provider /
+chat_id / sender attached at the top level. The cloud's "Conversation
+info (untrusted metadata)" panel needs those fields per row.
+
+What we cover
+-------------
+1. A ``channel.in`` row from ``~/.openclaw/telegram/<chat_id>.jsonl``
+   (the shape PR #1191 writes to ``events.data``) round-trips through
+   ``_build_brain_cache_pushes`` → encrypted blob → ``decrypt_payload``
+   and the decrypted event carries provider='telegram', chat_id matching
+   the file stem, sender / sender_id from the ``from`` block,
+   direction='in'.
+2. ``channel.out`` (assistant) rows mark direction='out' and still
+   surface chat_id (so the cloud can group inbound + outbound under one
+   conversation).
+3. Sibling providers (signal, slack, whatsapp) are enriched the same
+   way — the enrichment is provider-agnostic.
+4. Non-channel rows (the existing session ``message`` / ``user`` /
+   ``assistant`` types) are NOT enriched — the keys must NOT appear so
+   we don't pollute the OpenClaw transcript shape ``transformEvents``
+   already understands.
+5. The encrypted blob still does not leak plaintext (chat ids, sender
+   names) — same E2E invariant as the Phase 2 happy-path test.
+
+DuckDB-first hard rule (``feedback_duckdb_first_rule``): the channel
+events MUST come from the local DuckDB store — no JSONL re-tail at
+heartbeat time. Test seeds DuckDB directly via ``store.ingest`` using
+the same column shape ``sync_channel_messages`` writes.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def sync_with_channel_events(tmp_path, monkeypatch):
+    """Reload sync + local_store against a fresh DuckDB seeded with a
+    realistic mix of channel.in / channel.out / regular session rows."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    store = ls.get_store()
+
+    # ── Telegram inbound (mirrors what sync_channel_messages writes when
+    # ~/.openclaw/telegram/1532693273.jsonl gets a new line). The id is
+    # the canonical "{provider}:{channel_id}:{raw_id}" shape PR #1191
+    # produces.
+    store.ingest({
+        "id":           "telegram:1532693273:8463",
+        "node_id":      "node-test",
+        "agent_id":     "main",
+        "session_id":   None,
+        "event_type":   "channel.in",
+        "ts":           "2026-05-13T22:00:00Z",
+        "data":         {
+            "id": 8463,
+            "ts": "2026-05-13T22:00:00Z",
+            "direction": "in",
+            "from": {
+                "id": 1532693273,
+                "username": "vivekchand",
+                "first_name": "Vivek",
+            },
+            "text": "hey diya — how are you doing?",
+        },
+        "cost_usd":     None,
+        "token_count":  None,
+        "model":        None,
+    })
+
+    # ── Telegram outbound (assistant reply).
+    store.ingest({
+        "id":           "telegram:1532693273:8464",
+        "node_id":      "node-test",
+        "agent_id":     "main",
+        "session_id":   None,
+        "event_type":   "channel.out",
+        "ts":           "2026-05-13T22:00:30Z",
+        "data":         {
+            "message_id": 8464,
+            "ts": "2026-05-13T22:00:30Z",
+            "role": "assistant",
+            "text": "doing well — what's up?",
+        },
+        "cost_usd":     None,
+        "token_count":  None,
+        "model":        None,
+    })
+
+    # ── Sibling provider: signal.
+    store.ingest({
+        "id":           "signal:+14155551212:abc-1",
+        "node_id":      "node-test",
+        "agent_id":     "main",
+        "session_id":   None,
+        "event_type":   "channel.in",
+        "ts":           "2026-05-13T22:01:00Z",
+        "data":         {
+            "id": "abc-1",
+            "ts": "2026-05-13T22:01:00Z",
+            "direction": "in",
+            "sender": {"id": "+14155551212", "name": "Alice"},
+            "text": "ping from signal",
+        },
+        "cost_usd":     None,
+        "token_count":  None,
+        "model":        None,
+    })
+
+    # ── A regular session message (must NOT get channel enrichment).
+    store.ingest({
+        "id":           "session-evt-1",
+        "node_id":      "node-test",
+        "agent_id":     "main",
+        "session_id":   "sess-cli",
+        "event_type":   "message",
+        "ts":           "2026-05-13T22:02:00Z",
+        "data":         {"text": "ordinary CLI session turn"},
+        "cost_usd":     0.001,
+        "token_count":  10,
+        "model":        "claude-opus-4-7",
+    })
+
+    # Wait for the background flusher to drain the ring.
+    import time
+    for _ in range(80):
+        if store.health()["ring_depth"] == 0:
+            break
+        time.sleep(0.05)
+
+    config = {
+        "node_id":         "node-test",
+        "api_key":         "cm_test_token_xyz",
+        "encryption_key":  s.generate_encryption_key(),
+    }
+    yield s, config
+
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _decrypt_pushes(s, config, pushes):
+    assert len(pushes) == 1, pushes
+    decoded = s.decrypt_payload(pushes[0]["blob"], config["encryption_key"])
+    assert isinstance(decoded, dict)
+    assert decoded["_shape"] == "brain_history"
+    return decoded
+
+
+def _by_id(events: list, marker: str) -> dict | None:
+    """Find the first event whose ``text`` contains the marker — used
+    because ``_rows_to_brain_events`` returns rows in newest-first order
+    and we don't want to be index-fragile."""
+    for ev in events:
+        if marker in (ev.get("text") or ""):
+            return ev
+    return None
+
+
+# ── 1. Telegram inbound enriched ────────────────────────────────────────────
+
+
+def test_telegram_inbound_carries_provider_chatid_sender(sync_with_channel_events):
+    s, config = sync_with_channel_events
+    pushes = s._build_brain_cache_pushes(config)
+    decoded = _decrypt_pushes(s, config, pushes)
+
+    ev = _by_id(decoded["events"], "how are you doing?")
+    assert ev is not None, "telegram inbound event missing from cache push"
+    assert ev["provider"] == "telegram"
+    assert ev["chat_id"] == "1532693273"
+    assert ev["sender_id"] == "1532693273"
+    assert ev["sender"] == "vivekchand"
+    assert ev["direction"] == "in"
+    # type stamp lets the cloud renderer's fallback branch label the row
+    assert ev.get("type") == "channel.in"
+
+
+# ── 2. Telegram outbound marked direction=out ───────────────────────────────
+
+
+def test_telegram_outbound_marked_direction_out(sync_with_channel_events):
+    s, config = sync_with_channel_events
+    pushes = s._build_brain_cache_pushes(config)
+    decoded = _decrypt_pushes(s, config, pushes)
+
+    ev = _by_id(decoded["events"], "doing well")
+    assert ev is not None
+    assert ev["provider"] == "telegram"
+    assert ev["chat_id"] == "1532693273"
+    assert ev["direction"] == "out"
+    # No sender name in the assistant payload — we fall back to chat_id
+    # so the renderer always has SOMETHING to display.
+    assert ev["sender_id"] == "1532693273"
+
+
+# ── 3. Sibling providers enriched the same way ──────────────────────────────
+
+
+def test_signal_event_enriched_with_provider_signal(sync_with_channel_events):
+    s, config = sync_with_channel_events
+    pushes = s._build_brain_cache_pushes(config)
+    decoded = _decrypt_pushes(s, config, pushes)
+
+    ev = _by_id(decoded["events"], "ping from signal")
+    assert ev is not None
+    assert ev["provider"] == "signal"
+    assert ev["chat_id"] == "+14155551212"
+    assert ev["sender_id"] == "+14155551212"
+    assert ev["sender"] == "Alice"
+    assert ev["direction"] == "in"
+
+
+# ── 4. Non-channel rows are NOT enriched ────────────────────────────────────
+
+
+def test_regular_session_message_has_no_channel_keys(sync_with_channel_events):
+    s, config = sync_with_channel_events
+    pushes = s._build_brain_cache_pushes(config)
+    decoded = _decrypt_pushes(s, config, pushes)
+
+    ev = _by_id(decoded["events"], "ordinary CLI session turn")
+    assert ev is not None
+    # The enrichment keys must not pollute non-channel rows — otherwise
+    # the cloud's renderer would show empty "Conversation info" labels
+    # on every CLI turn.
+    for k in ("provider", "chat_id", "sender_id", "sender", "direction"):
+        assert k not in ev, (
+            f"non-channel event leaked enrichment key {k!r}: {ev!r}"
+        )
+
+
+# ── 5. Encrypted blob still does not leak plaintext ─────────────────────────
+
+
+def test_blob_still_e2e_encrypted_no_plaintext_leak(sync_with_channel_events):
+    s, config = sync_with_channel_events
+    pushes = s._build_brain_cache_pushes(config)
+    assert len(pushes) == 1
+    blob = pushes[0]["blob"]
+    assert isinstance(blob, str)
+    # Plaintext sender / chat ids / message bodies must not appear in the
+    # ciphertext blob — same E2E invariant the Phase 2 happy-path test
+    # asserts. The cloud only ever stores ciphertext.
+    assert "1532693273" not in blob
+    assert "vivekchand" not in blob
+    assert "how are you doing?" not in blob
+    assert "ping from signal" not in blob
+
+
+# ── 6. Direct unit test on the enrichment helper (no DuckDB) ────────────────
+
+
+def test_channel_enrichment_helper_handles_missing_id_gracefully():
+    """The helper must never raise on malformed rows — fresh installs
+    have legitimately partial data and a brain cache push that 500s on
+    one bad row would silently kill the cache for every other row in
+    the same heartbeat."""
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    # Channel row with no id at all (impossible from sync_channel_messages
+    # but the helper is defensive — heartbeat must never crash).
+    enrich = s._channel_enrichment_from_row({
+        "event_type": "channel.in",
+        "data": {"text": "hi"},
+    })
+    assert enrich["provider"] == ""
+    assert enrich["chat_id"] == ""
+    assert enrich["direction"] == "in"
+
+    # Non-channel row → empty dict (no enrichment keys appear).
+    assert s._channel_enrichment_from_row({
+        "event_type": "message", "data": {}
+    }) == {}
+
+    # raw_id with embedded colons (unusual but legal — Matrix event IDs
+    # contain colons). The helper must split only the first two segments.
+    enrich = s._channel_enrichment_from_row({
+        "event_type": "channel.in",
+        "id": "matrix:!room123:matrix.org:$evt:abc",
+        "data": {"text": "hi"},
+    })
+    assert enrich["provider"] == "matrix"
+    assert enrich["chat_id"] == "!room123"


### PR DESCRIPTION
## Summary

- Extends the OSS daemon's heartbeat-piggyback brain cache push (`_build_brain_cache_pushes`) so the cloud Brain renderer can show "Telegram: Vivek Chand: hello, how are you doing?" instead of generic agent activity for channel events.
- Adds `_channel_enrichment_from_row()` that decomposes the composite event id (`{provider}:{chat_id}:{raw_id}`) and the inner adapter payload (`from`/`sender`/`user` block) into flat top-level keys (`provider`, `chat_id`, `sender_id`, `sender`, `direction`).
- Non-channel rows (regular CLI session messages) are untouched — no key pollution on the existing OpenClaw transcript shape `transformEvents` already understands.
- E2E encryption invariant unchanged: enriched payload still flows through `encrypt_payload()` before leaving the daemon. Test asserts plaintext (chat ids, sender names, message bodies) never appears in the ciphertext blob.

## Coordination with PR #1191 (fix/telegram-ingest-and-install-lock-detect)

PR #1191 (commit `2dff811` by agent aca53ec8) added `sync_channel_messages()` which writes channel transcripts to DuckDB with:
- `event_type` = `"channel.in"` or `"channel.out"`
- `id` = `f"{provider}:{channel_id}:{raw_id}"` (provider only lives here — the events table has no provider column)
- `data` = the original adapter line

This PR consumes those exact contract points on the read side. **Order-independent**:
- If this PR lands first → enrichment is dormant (returns `{}` for non-channel rows; there are 0 channel rows in DuckDB until #1191 lands).
- Once #1191 lands → channel rows automatically pick up the enrichment on the next heartbeat. Zero coupling between merge order.

No changes to `routes/brain.py` (#1190 just landed there).

## DuckDB-first hard rule

Events come from `store.query_events()` — **not** a re-tail of `~/.openclaw/<channel>/`. Honors the project's DuckDB-first invariant.

## Test plan

- [x] Unit: `tests/test_brain_cache_push_channel_events.py` — 6 cases (Telegram inbound enrichment, Telegram outbound direction=out + sender fallback, Signal sibling provider, non-channel rows untouched, ciphertext leaks no plaintext, helper handles malformed rows incl. Matrix-style ids with embedded colons).
- [x] Existing: `tests/test_brain_cache_push.py` — 5/6 still pass (one pre-existing failure on stale shape assertion, present on `main` already).
- [x] Adjacent: `tests/test_brain_local_fastpath.py`, `test_brain_local_store.py`, `test_brain_history_v3_event_detail.py` — all pass.
- [ ] E2E (post-merge): Telegram message → DuckDB → heartbeat cache push → cloud Brain panel shows "Telegram: <sender>: <text>".

🤖 Generated with [Claude Code](https://claude.com/claude-code)