### PR TITLE
feat(ui): render channel events with provider+sender labels (Telegram, Signal, Slack...)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2282,16 +2282,159 @@ var _brainTypeFilter = 'all';
 var _brainChannelFilter = 'all';
 var _brainAllEvents = [];
 
+// Provider → emoji + display name. Mirrors routes/brain.py `_CHANNEL_ICON`
+// and clawmetry/sync.py `_CHANNEL_DIRS` (the canonical 21-adapter list).
+// Keep these three in sync when a new adapter ships.
 var _channelIcons = {
-  'telegram': '📱', 'whatsapp': '💬', 'discord': '🎮', 'slack': '📢',
+  'telegram': '📱', 'whatsapp': '💬', 'discord': '🎮', 'slack': '💼',
   'signal': '📡', 'irc': '💻', 'imessage': '🍎', 'webchat': '🌐',
-  'googlechat': '📧', 'cli': '🖥️', 'cron': '⏰'
+  'googlechat': '🔵', 'matrix': '🔢', 'msteams': '🏢', 'mattermost': '⚡',
+  'line': '💚', 'nostr': '🟣', 'twitch': '💜', 'bluebubbles': '💙',
+  'feishu': '🟠', 'zalo': '🩵', 'tlon': '🟤', 'synologychat': '🟦',
+  'nextcloudtalk': '☁️',
+  'cli': '🖥️', 'tui': '⌨️', 'cron': '⏰'
 };
 var _channelColors = {
   'telegram': '#2f9ef4', 'whatsapp': '#25d366', 'discord': '#5865F2', 'slack': '#4A154B',
   'signal': '#3a76f0', 'irc': '#6B7280', 'imessage': '#34C759', 'webchat': '#0EA5E9',
-  'googlechat': '#1A73E8', 'cli': '#94a3b8', 'cron': '#6B7280'
+  'googlechat': '#1A73E8', 'matrix': '#0DBD8B', 'msteams': '#4B53BC', 'mattermost': '#0072C6',
+  'line': '#06C755', 'nostr': '#9333ea', 'twitch': '#9146FF', 'bluebubbles': '#3478F6',
+  'feishu': '#00D6B9', 'zalo': '#0068FF', 'tlon': '#A78BFA', 'synologychat': '#1A73E8',
+  'nextcloudtalk': '#0082C9',
+  'cli': '#94a3b8', 'tui': '#94a3b8', 'cron': '#6B7280'
 };
+// Display-name overrides for channels whose snake/lower-case key isn't a
+// great human label. (`telegram` → `Telegram` is fine via title-case;
+// `googlechat` → `Google Chat` is not.)
+var _channelDisplayNames = {
+  'googlechat': 'Google Chat',
+  'msteams':    'MS Teams',
+  'bluebubbles':'BlueBubbles',
+  'imessage':   'iMessage',
+  'webchat':    'WebChat',
+  'irc':        'IRC',
+  'cli':        'CLI',
+  'tui':        'TUI',
+  'synologychat': 'Synology Chat',
+  'nextcloudtalk': 'Nextcloud Talk'
+};
+
+function _channelDisplayName(provider) {
+  if (!provider) return '';
+  var key = String(provider).toLowerCase();
+  if (_channelDisplayNames[key]) return _channelDisplayNames[key];
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+// ── Channel-event extraction (Brain row renderer helper) ───────────────
+// Coordinates with the Telegram-ingest agent (PR aca53ec8): the
+// `events`-table row carries `event_type=channel.in|channel.out` and the
+// raw provider payload under `data`. Brain endpoint also enriches some
+// rows with top-level `channel`/`channelSubject`/`chatType` fields. This
+// helper accepts BOTH shapes plus a graceful fallback for the legacy
+// JSONL parser path so we don't regress when ingest hasn't migrated yet.
+//
+// Returned shape (all fields optional, all strings):
+//   { provider, providerLabel, providerIcon, providerColor,
+//     sender, chatId, direction /* 'in' | 'out' */ }
+// Returns null when the event clearly isn't a channel turn.
+function _extractChannelInfo(ev) {
+  if (!ev || typeof ev !== 'object') return null;
+  var data = (ev.data && typeof ev.data === 'object') ? ev.data : {};
+
+  // ── provider ─────────────────────────────────────────────────────────
+  var provider = ev.provider || ev.channel || data.provider || '';
+  if (!provider) {
+    // event_type "channel.in"/"channel.out" doesn't carry provider on its
+    // own — we keep going only if some other field hints at a channel.
+    var src = String(ev.source || ev.src || '');
+    var srcMatch = src.match(/^(?:agent:[^:]+:)?([a-z]+)(?::|$)/);
+    if (srcMatch) {
+      var maybe = srcMatch[1];
+      if (_channelIcons[maybe] && maybe !== 'main' && maybe !== 'cli') {
+        provider = maybe;
+      }
+    }
+  }
+  // event_type can be the discriminator on its own
+  var evType = String(ev.type || ev.event_type || '').toUpperCase();
+  var isChannelType = evType === 'CHANNEL.IN' || evType === 'CHANNEL.OUT' ||
+                       evType === 'CHANNEL_IN' || evType === 'CHANNEL_OUT';
+  if (!provider && !isChannelType) return null;
+  provider = String(provider || '').toLowerCase();
+  // Treat plain CLI/cron sources as non-channel (the Brain renderer has
+  // its own 🖥️/⏰ chips for those).
+  if (provider === 'cli' || provider === 'cron' || provider === 'main') {
+    return null;
+  }
+
+  // ── direction ────────────────────────────────────────────────────────
+  var direction = ev.direction || data.direction || '';
+  if (!direction) {
+    if (evType === 'CHANNEL.OUT' || evType === 'CHANNEL_OUT') direction = 'out';
+    else if (evType === 'CHANNEL.IN' || evType === 'CHANNEL_IN') direction = 'in';
+    else if (data.role === 'assistant' || data.from_bot === true) direction = 'out';
+    else direction = 'in';
+  }
+  direction = String(direction).toLowerCase();
+  if (direction !== 'in' && direction !== 'out') direction = 'in';
+
+  // ── sender ───────────────────────────────────────────────────────────
+  var sender = ev.sender || ev.sender_name || ev.senderName || data.sender_name || '';
+  if (!sender) {
+    var senderBlock = data.from || data.sender || data.user;
+    if (senderBlock && typeof senderBlock === 'object') {
+      sender = senderBlock.username || senderBlock.first_name ||
+               senderBlock.name || senderBlock.id || '';
+    }
+  }
+  sender = sender ? String(sender) : '';
+
+  // ── chat id ──────────────────────────────────────────────────────────
+  var chatId = ev.chat_id || ev.chatId || data.chat_id || data.channel_id || '';
+  if (!chatId && data.chat && typeof data.chat === 'object') {
+    chatId = data.chat.id || '';
+  }
+  chatId = chatId ? String(chatId) : '';
+
+  return {
+    provider:      provider,
+    providerLabel: _channelDisplayName(provider),
+    providerIcon:  _channelIcons[provider] || '📨',
+    providerColor: _channelColors[provider] || '#667',
+    sender:        sender,
+    chatId:        chatId,
+    direction:     direction
+  };
+}
+
+// Render the meta row for a channel event (used by renderBrainStream when
+// _extractChannelInfo returns non-null). Replaces the generic AGENT/USER
+// type tag with a channel pill + sender name + direction arrow.
+function renderChannelEventMeta(ev, info, opts) {
+  opts = opts || {};
+  var html = '';
+  var arrow = info.direction === 'out' ? '↗' : '↘';
+  var arrowColor = info.direction === 'out' ? '#10b981' : '#60a5fa';
+  var arrowTitle = info.direction === 'out' ? 'Outbound (agent reply)' : 'Inbound (from user)';
+  // Channel pill — emoji + provider name in provider colour.
+  html += '<span class="brain-channel-pill" style="display:inline-flex;align-items:center;gap:4px;background:' +
+           info.providerColor + '22;color:' + info.providerColor +
+           ';padding:1px 8px;border-radius:10px;font-size:10px;font-weight:600;flex-shrink:0;white-space:nowrap;" title="' +
+           escHtml(info.provider + (info.chatId ? ' chat=' + info.chatId : '')) + '">' +
+           info.providerIcon + ' ' + escHtml(info.providerLabel) + '</span>';
+  // Direction arrow.
+  html += '<span class="brain-channel-direction" style="color:' + arrowColor +
+           ';font-size:11px;font-weight:700;flex-shrink:0;" title="' +
+           escHtml(arrowTitle) + '">' + arrow + '</span>';
+  // Sender name (italic). Falls back to a neutral placeholder so we never
+  // collapse to nothing — keeps the row scannable even when the upstream
+  // adapter omitted the sender block.
+  var senderText = info.sender || (info.direction === 'out' ? 'agent' : 'user');
+  html += '<span class="brain-channel-sender" style="font-style:italic;color:var(--text-secondary);font-size:11px;flex-shrink:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:160px;" title="' +
+           escHtml(senderText) + '">' + escHtml(senderText) + '</span>';
+  return html;
+}
 
 var _brainTypeIcons = {
   'EXEC': '⚙️', 'SHELL': '⚙️', 'READ': '📖', 'WRITE': '✏️',
@@ -2606,12 +2749,24 @@ function renderBrainStream(events) {
     }
     var _evKey = _brainEvKey(ev);
     var _evExpCls = _brainExpandedKeys[_evKey] ? ' expanded' : '';
+    // Channel-event branch (Telegram, Signal, Slack, …): replace the
+    // generic AGENT/USER tag with a provider pill + sender name + direction
+    // arrow. Triggered when ev exposes channel/provider/sender or carries a
+    // channel.in/channel.out event_type. Coordinates with the Telegram
+    // ingest agent (PR aca53ec8) on field names. Falls back gracefully when
+    // those fields are missing — the legacy renderer still owns CLI/cron/
+    // tool/think rows.
+    var chInfo = _extractChannelInfo(ev);
     html += '<div class="brain-event' + _evExpCls + '" data-evkey="' + escHtml(_evKey) + '" onclick="_toggleBrainEvent(this, this.dataset.evkey)">';
     html += '<div class="brain-meta">';
     html += '<span class="brain-time">' + formatBrainTime(ev.time) + '</span>';
-    html += '<span class="brain-type" style="background:rgba(100,100,100,0.15);color:' + color + ';padding:1px 6px;border-radius:3px;font-size:10px;font-weight:700;min-width:70px;text-align:center;display:inline-block;white-space:nowrap;">' + icon + ' ' + escHtml(evType) + '</span>';
-    html += '<span class="brain-source" style="color:' + color + ';flex-shrink:0;" title="' + escHtml(fullSrc) + '">' + roleIcon + ' ' + escHtml(shortSrc) + '</span>';
-    html += chBadge;
+    if (chInfo) {
+      html += renderChannelEventMeta(ev, chInfo);
+    } else {
+      html += '<span class="brain-type" style="background:rgba(100,100,100,0.15);color:' + color + ';padding:1px 6px;border-radius:3px;font-size:10px;font-weight:700;min-width:70px;text-align:center;display:inline-block;white-space:nowrap;">' + icon + ' ' + escHtml(evType) + '</span>';
+      html += '<span class="brain-source" style="color:' + color + ';flex-shrink:0;" title="' + escHtml(fullSrc) + '">' + roleIcon + ' ' + escHtml(shortSrc) + '</span>';
+      html += chBadge;
+    }
     html += skillBadge;
     html += taskBadge;
     html += '</div>';

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -239,9 +239,10 @@ def _try_local_store_brain(limit: int, include_artifacts: bool):
         # with detail="". ``_extract_brain_detail`` knows about all three
         # shapes (legacy, v3 mapper top-level, v3 mapper mirror).
         detail = _extract_brain_detail(r)
-        out.append({
+        evt_type = (r.get("event_type") or "").upper()
+        row = {
             "time":       r.get("ts", ""),
-            "type":       (r.get("event_type") or "").upper(),
+            "type":       evt_type,
             "detail":     str(detail)[:200],
             "src":        (r.get("session_id") or r.get("agent_id") or "")[:32],
             "sessionId":  r.get("session_id") or "",
@@ -249,7 +250,45 @@ def _try_local_store_brain(limit: int, include_artifacts: bool):
             "tokens":     r.get("token_count") or 0,
             "cost":       float(r.get("cost_usd") or 0.0),
             "model":      r.get("model") or "",
-        })
+        }
+        # ── Channel-event enrichment (PR aca53ec8 / Telegram ingest) ─────
+        # Channel turns land here as event_type=channel.in|channel.out with
+        # the raw provider payload under ``data``. Surface a few flat fields
+        # (provider, sender, chat_id, channel, direction) so the Brain row
+        # renderer can paint a provider pill + sender name without having
+        # to re-parse the data blob client-side.
+        if evt_type.startswith("CHANNEL."):
+            data = r.get("data") or {}
+            if isinstance(data, dict):
+                provider = (data.get("provider") or "").lower()
+                if provider:
+                    row["provider"] = provider
+                    row["channel"] = provider
+                # direction: channel.in → "in", channel.out → "out"
+                row["direction"] = "out" if evt_type.endswith(".OUT") else "in"
+                # sender: prefer flat sender_name, fall back to from/sender/user blocks
+                sender = data.get("sender_name") or data.get("sender") or ""
+                if not sender:
+                    for blk_key in ("from", "user"):
+                        blk = data.get(blk_key)
+                        if isinstance(blk, dict):
+                            sender = (
+                                blk.get("username")
+                                or blk.get("first_name")
+                                or blk.get("name")
+                                or ""
+                            )
+                            if sender:
+                                break
+                if sender:
+                    row["sender"] = str(sender)[:80]
+                # chat_id
+                chat_id = data.get("chat_id") or data.get("channel_id") or ""
+                if not chat_id and isinstance(data.get("chat"), dict):
+                    chat_id = data["chat"].get("id") or ""
+                if chat_id:
+                    row["chat_id"] = str(chat_id)[:80]
+        out.append(row)
     return {
         "events":  out,
         "count":   len(out),

--- a/tests/test_appjs_units.js
+++ b/tests/test_appjs_units.js
@@ -177,5 +177,141 @@ console.log('stuck-session banner dismissal (issue #1127 — resurfaces after re
   truthy(!('s-1' in after), '> 24h entry pruned from store');
 }
 
+// ── Test channel-event renderer (Telegram/Signal/Slack/… provider+sender) ──
+//
+// Coordinates with the Telegram-ingest agent (PR aca53ec8) on the field
+// names: provider, sender, chat_id, direction. Verifies:
+//   1. _extractChannelInfo recognises top-level fields (the path the
+//      Brain endpoint uses after we enrich channel.* events).
+//   2. _extractChannelInfo recognises nested ev.data.{provider,from,…}
+//      (the path when the Brain endpoint passes the raw payload through).
+//   3. _extractChannelInfo returns null for non-channel events (cli/cron/
+//      tool calls) so the legacy render branch keeps owning them.
+//   4. renderChannelEventMeta produces HTML containing the provider emoji,
+//      the human display name, the sender, and a direction arrow.
+//   5. Display-name overrides ("Google Chat", "MS Teams") work.
+console.log('channel event renderer (Brain provider/sender labels)');
+{
+  const sandbox = {
+    Date: Date,
+    console: console,
+  };
+  // Pull in the channel maps + helpers + render branch. We grab a slice of
+  // app.js by line range so we don't have to single-out 4 helpers and 2
+  // dictionaries with separate regexes.
+  const lines = src.split('\n');
+  const startMarker = 'var _channelIcons = {';
+  const endMarker   = '// Render the meta row for a channel event';
+  const startIdx = lines.findIndex(function(l) { return l.indexOf(startMarker) >= 0; });
+  if (startIdx < 0) throw new Error('start marker not found in app.js');
+  const endIdx = lines.findIndex(function(l, i) { return i > startIdx && l.indexOf(endMarker) >= 0; });
+  if (endIdx < 0) throw new Error('end marker not found in app.js');
+  // Slice covers _channelIcons → _channelDisplayName + _extractChannelInfo.
+  let code = lines.slice(startIdx, endIdx).join('\n') + '\n';
+  // Add renderChannelEventMeta — single function definition.
+  code += extractFunction('renderChannelEventMeta') + '\n';
+  // escHtml is a small one-liner; pull it in too.
+  code += extractFunction('escHtml') + '\n';
+  code += '\nthis.api = {' +
+          '  _extractChannelInfo: _extractChannelInfo,' +
+          '  renderChannelEventMeta: renderChannelEventMeta,' +
+          '  _channelDisplayName: _channelDisplayName,' +
+          '  _channelIcons: _channelIcons,' +
+          '};';
+  vm.createContext(sandbox);
+  vm.runInContext(code, sandbox);
+  const api = sandbox.api;
+
+  // (1) Top-level fields — the shape our brain.py enrichment emits.
+  const inboundTop = {
+    type: 'CHANNEL.IN',
+    provider: 'telegram',
+    sender: 'Vivek Chand',
+    chat_id: '1532693273',
+    detail: 'hello, how are you doing?',
+    time: '2026-05-13T10:00:00Z',
+  };
+  const info1 = api._extractChannelInfo(inboundTop);
+  truthy(info1, 'top-level channel event detected');
+  eq(info1.provider, 'telegram', 'provider parsed from top-level field');
+  eq(info1.sender, 'Vivek Chand', 'sender parsed from top-level field');
+  eq(info1.chatId, '1532693273', 'chat_id parsed from top-level field');
+  eq(info1.direction, 'in', 'direction = in for CHANNEL.IN');
+  eq(info1.providerLabel, 'Telegram', 'Telegram → Telegram (title-case)');
+  eq(info1.providerIcon, '📱', 'Telegram emoji');
+
+  // (2) Nested data — the shape if brain enrichment ever drops fields.
+  const inboundNested = {
+    type: 'CHANNEL.IN',
+    data: {
+      provider: 'signal',
+      from: { username: 'vivek', id: '+15551234567' },
+      chat_id: 'sig-abc',
+      text: 'sup',
+    },
+  };
+  const info2 = api._extractChannelInfo(inboundNested);
+  truthy(info2, 'nested-data channel event detected');
+  eq(info2.provider, 'signal', 'provider parsed from data.provider');
+  eq(info2.sender, 'vivek', 'sender parsed from data.from.username');
+  eq(info2.providerIcon, '📡', 'Signal emoji');
+  eq(info2.providerColor, '#3a76f0', 'Signal color');
+
+  // (3) Outbound (agent reply): role=assistant under data, no top-level fields.
+  const outbound = {
+    type: 'CHANNEL.OUT',
+    data: { provider: 'telegram', role: 'assistant', text: 'doing well!' },
+  };
+  const info3 = api._extractChannelInfo(outbound);
+  truthy(info3, 'outbound channel event detected');
+  eq(info3.direction, 'out', 'direction = out for CHANNEL.OUT');
+
+  // (4) Non-channel events fall through (return null).
+  eq(api._extractChannelInfo({ type: 'EXEC', detail: 'ls -la' }), null,
+     'EXEC (tool) event → null');
+  eq(api._extractChannelInfo({ type: 'AGENT', source: 'main', detail: 'thinking' }), null,
+     'AGENT main event → null');
+  eq(api._extractChannelInfo({ type: 'USER', channel: 'cli' }), null,
+     'cli channel → null (legacy branch owns it)');
+  eq(api._extractChannelInfo(null), null, 'null event → null');
+
+  // (5) Render branch: assert HTML contains provider emoji+name, sender, arrow.
+  const html = api.renderChannelEventMeta(inboundTop, info1);
+  truthy(html.indexOf('📱') !== -1, 'rendered HTML contains Telegram emoji');
+  truthy(html.indexOf('Telegram') !== -1, 'rendered HTML contains "Telegram"');
+  truthy(html.indexOf('Vivek Chand') !== -1, 'rendered HTML contains sender name');
+  truthy(html.indexOf('↘') !== -1, 'inbound rendered with ↘ arrow');
+  truthy(html.indexOf('brain-channel-pill') !== -1, 'pill class applied');
+  truthy(html.indexOf('font-style:italic') !== -1, 'sender italicised');
+  // Outbound uses ↗.
+  const htmlOut = api.renderChannelEventMeta(outbound, info3);
+  truthy(htmlOut.indexOf('↗') !== -1, 'outbound rendered with ↗ arrow');
+
+  // (6) Display-name overrides.
+  eq(api._channelDisplayName('googlechat'), 'Google Chat',
+     'googlechat → "Google Chat"');
+  eq(api._channelDisplayName('msteams'), 'MS Teams', 'msteams → "MS Teams"');
+  eq(api._channelDisplayName('imessage'), 'iMessage', 'imessage → "iMessage"');
+  eq(api._channelDisplayName('whatsapp'), 'Whatsapp',
+     'whatsapp → title-case fallback');
+
+  // (7) Detail text is unchanged — channel renderer only owns the meta row,
+  // the existing renderBrainDetail keeps owning the body. This is enforced
+  // by the renderBrainStream wiring rather than this helper, so we only
+  // assert the helper does NOT touch ev.detail.
+  eq(inboundTop.detail, 'hello, how are you doing?',
+     'helper did not mutate ev.detail');
+
+  // (8) HTML is escaped — XSS-style sender names don't break out.
+  const evil = {
+    type: 'CHANNEL.IN', provider: 'telegram',
+    sender: '<script>alert(1)</script>', chat_id: '1',
+  };
+  const evilInfo = api._extractChannelInfo(evil);
+  const evilHtml = api.renderChannelEventMeta(evil, evilInfo);
+  truthy(evilHtml.indexOf('<script>') === -1, 'sender < escaped');
+  truthy(evilHtml.indexOf('&lt;script&gt;') !== -1, 'sender appears escaped');
+}
+
 console.log('\n' + (failed === 0 ? 'PASS' : 'FAIL') + ' — ' + passed + ' passed, ' + failed + ' failed');
 process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Brain rows for chat-channel turns (Telegram, Signal, Slack, …) currently
show the same generic "USER"/"AGENT" type tag as a CLI run, leaving the
user to guess which channel a message came from. Now that the Telegram-
ingest agent (#1192) is in and channel events carry `chat_id` / `sender` /
`provider` / `direction`, the Brain renderer can replace the type tag
with a provider pill, an italic sender name, and an inbound/outbound
arrow:

> 📱 Telegram  ↘  *Vivek Chand* — hello, how are you doing?

## Changes

- `clawmetry/static/js/app.js`
  - Expand `_channelIcons` / `_channelColors` to the canonical 21 adapters
    (matches `routes/brain.py` `_CHANNEL_ICON` and `clawmetry/sync.py`
    `_CHANNEL_DIRS`). Add `_channelDisplayNames` for non-trivial labels
    (`googlechat` → `Google Chat`, `msteams` → `MS Teams`, etc.).
  - New `_extractChannelInfo(ev)` accepts BOTH the enriched flat shape
    (top-level `provider` / `sender` / `chat_id`) AND the raw `ev.data.{…}`
    fallback so the renderer works whether or not the brain endpoint
    enrichment runs first. Returns `null` for non-channel events so the
    legacy AGENT/USER/EXEC render branch still owns them.
  - New `renderChannelEventMeta(ev, info)` paints the provider pill +
    direction arrow (↘ inbound, ↗ outbound) + italic sender name in
    place of the type tag + source span. `renderBrainStream` swaps in
    this branch when `_extractChannelInfo` returns non-null. Detail body
    is untouched — `renderBrainDetail` keeps owning it.

- `routes/brain.py`
  - `_try_local_store_brain` enriches `event_type=channel.in|out` rows
    with flat `provider` / `channel` / `sender` / `chat_id` / `direction`
    fields lifted from `data` (using the same permissive sender-block
    parsing the ingest agent writes with). The pre-existing JSONL parser
    path already exposed `channel`; this gives the local-store fast path
    parity.

- `tests/test_appjs_units.js`
  - 31 new assertions extending the existing PR #1176 harness — no
    JSDOM, no Playwright, ~50 ms.

## Coordination with #1192

Field names match the ingest schema introduced in
[#1192](https://github.com/vivekchand/clawmetry/pull/1192) (commit
2dff811): `provider`, `sender_name`, `chat_id`, `direction` (`in`/`out`),
plus the nested `data.{from,sender,user}` block as the secondary source.
The renderer falls back gracefully if those fields are absent (legacy
renderer remains the default), so the change is safe even on the
small set of installs that haven't picked up the daemon-side fix yet.

## Test plan

- [x] `node tests/test_appjs_units.js` — 50 / 50 pass (19 pre-existing +
      31 new for the channel branch).
- [x] `python3 -m pytest tests/test_brain_local_fastpath.py
      tests/test_brain_local_store.py
      tests/test_brain_history_v3_event_detail.py -q` — 8 / 8 pass
      (existing brain endpoint behaviour unchanged).
- [x] Smoke-tested the brain.py enrichment: a synthetic
      `channel.in` row with `data={provider: telegram, sender_name:
      "Vivek Chand", chat_id: "1532693273"}` is enriched into
      `{provider: telegram, channel: telegram, direction: in, sender:
      "Vivek Chand", chat_id: "1532693273"}`.
- [ ] Local OSS install with a live Telegram bot — verify the Brain tab
      shows `📱 Telegram ↘ Vivek Chand — <message>` for inbound and
      `📱 Telegram ↗ agent — <reply>` for outbound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)