### PR TITLE
feat(sync): parse gateway.log for Telegram messages (ingest into DuckDB)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2973,6 +2973,64 @@ def _local_dispatch_fallback(shape: str, args: dict) -> dict:
     return {"rows": rows, "count": len(rows), "_shape": shape, "_via": "fallback"}
 
 
+def _channel_enrichment_from_row(r: dict) -> dict:
+    """Pull (provider, chat_id, sender_id, sender, direction) out of a
+    channel.* events row so the cloud Brain renderer can display
+    "Telegram: Vivek Chand: hello" instead of generic agent activity.
+
+    The ingest path in ``sync_channel_messages`` (PR #1191) writes channel
+    transcripts with:
+      * ``event_type`` = ``"channel.in"`` or ``"channel.out"``
+      * ``id`` = ``f"{provider}:{channel_id}:{raw_id}"`` — the only place
+        ``provider`` lives on the events row, since the events table has
+        no provider column.
+      * ``data`` = the original adapter line (``from``/``sender``/``user``
+        block, ``text``/``body``, etc.).
+
+    Returns ``{}`` for non-channel rows so callers can spread it
+    unconditionally. Never raises.
+    """
+    et = r.get("event_type") or ""
+    if not isinstance(et, str) or not et.startswith("channel."):
+        return {}
+    direction = et.split(".", 1)[1] if "." in et else ""
+    eid = r.get("id") or ""
+    provider = ""
+    chat_id = ""
+    if isinstance(eid, str) and eid.count(":") >= 2:
+        # ``{provider}:{channel_id}:{raw_id}`` — raw_id may itself contain
+        # colons (rare, but defensible: split only the first two segments).
+        parts = eid.split(":", 2)
+        provider, chat_id = parts[0], parts[1]
+    data = r.get("data") if isinstance(r.get("data"), dict) else {}
+    sender_block = (
+        data.get("from") or data.get("sender") or data.get("user") or {}
+    )
+    if not isinstance(sender_block, dict):
+        sender_block = {}
+    sender_id = (
+        data.get("sender_id")
+        or sender_block.get("id")
+        or data.get("user_id")
+        or chat_id
+    )
+    sender = (
+        data.get("sender_name")
+        or sender_block.get("username")
+        or sender_block.get("first_name")
+        or sender_block.get("name")
+        or ""
+    )
+    out = {
+        "provider":  provider,
+        "chat_id":   str(chat_id) if chat_id != "" else "",
+        "sender_id": str(sender_id) if sender_id is not None else "",
+        "sender":    str(sender),
+        "direction": direction,
+    }
+    return out
+
+
 def _rows_to_brain_events(rows: list) -> list:
     """Return raw OpenClaw event payloads ready for the cloud browser's
     ``transformEvents`` to unwrap.
@@ -2995,6 +3053,13 @@ def _rows_to_brain_events(rows: list) -> list:
     didn't already carry one (transformEvents needs ``obj.timestamp ||
     obj.time``).
 
+    Channel events (``event_type`` starts with ``channel.``) get extra
+    top-level keys — ``provider`` / ``chat_id`` / ``sender_id`` /
+    ``sender`` / ``direction`` — so the cloud Brain renderer can show
+    "Telegram: Vivek Chand: hello, how are you doing?" instead of generic
+    agent activity. ``transformEvents`` ignores keys it doesn't know about,
+    so this is a forward-compatible enrichment.
+
     The OSS-local Brain tab uses ``routes/brain.py:_try_local_store_brain``
     which builds the display shape directly — that path is unchanged.
     """
@@ -3003,12 +3068,27 @@ def _rows_to_brain_events(rows: list) -> list:
         if not isinstance(r, dict):
             continue
         data = r.get("data")
+        enrich = _channel_enrichment_from_row(r)
         if isinstance(data, dict):
             if not data.get("timestamp") and not data.get("time") and r.get("ts"):
                 data = {**data, "timestamp": r.get("ts")}
+            if enrich:
+                # Enrichment wins — the JSONL payload often carries the
+                # raw ``sender``/``from`` BLOCK under the same key name
+                # (Signal: ``data.sender = {"id":..,"name":..}``); we want
+                # the renderer to read the FLAT string we computed, not
+                # the nested dict. Same for ``provider`` / ``chat_id``
+                # which never appear in adapter payloads.
+                data = {**data, **enrich}
+                # Stamp the channel event type back on so the cloud
+                # renderer's fallback branch (line ~10038 of cloud
+                # dashboard.py) can show "CHANNEL.IN" / "CHANNEL.OUT"
+                # rather than guessing from a missing role.
+                data.setdefault("type", r.get("event_type"))
             out.append(data)
         elif isinstance(data, str):
             out.append({
+                **enrich,
                 "type":      r.get("event_type") or "raw",
                 "timestamp": r.get("ts", ""),
                 "detail":    data[:2000],
@@ -6285,11 +6365,26 @@ def run_daemon() -> None:
                 lg = sync_logs(config, state, paths)
                 last_log_sync = now_log
 
+            # ── Telegram outbound from gateway.log (#1192 follow-up) ──
+            # OpenClaw stores Telegram chats in memory only — no JSONL is
+            # written for them. The only on-disk evidence is the
+            # ``[telegram] sendMessage ok ...`` ACKs in gateway.log. This
+            # parser tails those into ``channel_messages`` so the Brain
+            # / Channels tabs render at least the outbound side. Cheap
+            # (byte-tail), idempotent (PRIMARY KEY on id), best-effort.
+            try:
+                tg = sync_telegram_from_gateway_log(config, state, paths)
+            except Exception as _e_tg:
+                log.debug(
+                    "telegram-gw-log tick error (non-fatal): %s", _e_tg,
+                )
+                tg = 0
+
             state["last_sync"] = datetime.now(timezone.utc).isoformat()
             save_state(state)
-            if ev or lg or mem or crons or sm or snap or cron_runs:
+            if ev or lg or mem or crons or sm or snap or cron_runs or tg:
                 log.info(
-                    f"Synced {ev} events, {lg} log lines, {mem} memory files, {crons} crons, {cron_runs} cron-runs, {sm} session rows ({enc})"
+                    f"Synced {ev} events, {lg} log lines, {mem} memory files, {crons} crons, {cron_runs} cron-runs, {sm} session rows, {tg} telegram-out ({enc})"
                 )
 
             # ── Alerts evaluator (PRD #779 PR-D pt2, audit P0 #1 + #2) ──
@@ -6371,6 +6466,270 @@ def run_daemon() -> None:
         # POLL_INTERVAL still rules, so bandwidth + Cloud Run cost stay
         # flat.
         time.sleep(max(1, min(POLL_INTERVAL, heartbeat_interval)))
+
+
+# ── Telegram gateway-log ingest (#1192 follow-up) ──────────────────────────
+#
+# Why this exists
+# ---------------
+# OpenClaw runs Telegram direct-chat sessions ENTIRELY IN MEMORY. No per-
+# session JSONL is ever written under ``~/.openclaw/agents/main/sessions/``
+# or ``~/.openclaw/telegram/`` for inbound or outbound Telegram traffic
+# (see memory ``reference_openclaw_telegram_inmemory.md``). PR #1192 wired
+# up watching ``~/.openclaw/telegram/`` defensively for the day OpenClaw
+# starts persisting, but until that upstream change lands the only on-disk
+# evidence of Telegram activity is regex-recoverable from
+# ``~/.openclaw/logs/gateway.log``.
+#
+# What gets captured
+# ------------------
+# Outbound ACK lines, e.g.
+#
+#   2026-05-13T22:54:19.865+02:00 [telegram] sendMessage ok chat=1532693273 message=8491
+#   2026-05-13T06:00:56.332+02:00 [telegram] sendPhoto ok chat=1532693273 message=8480
+#
+# We synthesize a ``channel_messages`` row with ``direction="out"`` and
+# ``body=None`` (the log only carries the ACK, never the message body).
+# A breadcrumb is left in ``raw_blob`` so the dashboard can flag this row
+# as "ack-only — body not captured" if it wants to.
+#
+# What is NOT captured
+# --------------------
+# * Outbound message bodies — the log never logs the text payload, only
+#   the API ACK. The body lives only in OpenClaw's in-memory session
+#   state.
+# * Inbound messages — the production log emits ONLY long-poll
+#   diagnostics for inbound (``[telegram] Polling stall detected``,
+#   ``[diag] polling cycle finished``). Message bodies are not logged at
+#   any verbosity setting we observed (2026-05-13). If a future OpenClaw
+#   release adds an inbound trace line we can extend the parser, but
+#   today there is nothing to parse.
+#
+# Long-term fix path
+# ------------------
+# 1. OpenClaw upstream change: persist inbound Telegram updates to a
+#    session JSONL like every other channel does. Right thing, out of
+#    ClawMetry's direct control.
+# 2. Live gateway WebSocket tap on ``ws://localhost:18789`` — real-time,
+#    no log parsing, but only catches messages received while the
+#    ClawMetry daemon is running (no historical backfill).
+# This log parser is the only path that works today without an OpenClaw
+# upstream change AND backfills history on first install.
+
+# Outbound API methods we currently parse. ``sendMessage`` covers the
+# common case; the others appear in real production logs and trivially
+# fit the same pattern.
+_TELEGRAM_OUTBOUND_METHODS = (
+    "sendMessage",
+    "sendPhoto",
+    "sendAudio",
+    "sendDocument",
+    "sendVideo",
+    "sendVoice",
+    "sendSticker",
+    "sendAnimation",
+    "sendLocation",
+)
+
+_TELEGRAM_PROVIDER = "telegram"
+_TELEGRAM_OUTBOUND_PATTERN = None  # lazy compile; see helper below
+
+
+def _telegram_outbound_pattern():
+    """Lazily-compiled regex for one outbound telegram ACK line.
+
+    Capture groups:
+      1. ISO-8601 timestamp (with optional Z or +HH:MM offset, optional
+         fractional seconds)
+      2. API method (``sendMessage`` / ``sendPhoto`` / etc.)
+      3. chat id (digits, may be negative for group chats)
+      4. message id (digits)
+    """
+    import re as _re_local
+    global _TELEGRAM_OUTBOUND_PATTERN
+    if _TELEGRAM_OUTBOUND_PATTERN is None:
+        methods = "|".join(_TELEGRAM_OUTBOUND_METHODS)
+        _TELEGRAM_OUTBOUND_PATTERN = _re_local.compile(
+            r"^(\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:?\d{2}))\s+"
+            r"\[telegram\]\s+"
+            r"(" + methods + r")\s+ok\s+"
+            r"chat=(-?\d+)\s+"
+            r"message=(\d+)"
+        )
+    return _TELEGRAM_OUTBOUND_PATTERN
+
+
+def parse_telegram_outbound_line(line: str) -> dict | None:
+    """Parse one gateway.log line into a ``channel_messages`` row dict.
+
+    Returns ``None`` if the line is not an outbound Telegram ACK we
+    recognise (the daemon will then leave the line alone — other parsers
+    may still match it).
+
+    The returned dict is shaped for ``LocalStore.ingest_channel_message()``.
+    Importantly the ``id`` is ``"telegram:<chat>:<message>"`` so re-ingest
+    is a primary-key no-op (idempotent if the byte-offset state is lost).
+    """
+    pat = _telegram_outbound_pattern()
+    m = pat.match(line.strip())
+    if not m:
+        return None
+    ts_iso, method, chat_id, message_id = (
+        m.group(1), m.group(2), m.group(3), m.group(4),
+    )
+    return {
+        "id": f"telegram:{chat_id}:{message_id}",
+        "provider": _TELEGRAM_PROVIDER,
+        "channel_id": f"telegram:{chat_id}",
+        "ts": ts_iso,
+        "direction": "out",
+        # The log carries an ACK, not the message body. We deliberately
+        # set body=None (rather than a placeholder string) so the read
+        # side can render an "(no body captured)" affordance and isn't
+        # tricked into showing literal placeholder text as content.
+        "body": None,
+        "raw_blob": {
+            "source": "gateway.log",
+            "method": method,
+            "message_id": message_id,
+            "chat_id": chat_id,
+            # Breadcrumb for the dashboard / debug:
+            "body_capture": "ack_only",
+            "note": (
+                "OpenClaw stores Telegram chats in memory; "
+                "gateway.log only records the API ACK, not the body."
+            ),
+        },
+    }
+
+
+def _telegram_log_offset_key(log_path: str) -> str:
+    """Per-log-path key under ``state['last_log_offsets']``.
+
+    Keying by absolute path means a workspace switch (different
+    ``CLAWMETRY_OPENCLAW_DIR``) starts a fresh tail rather than skipping
+    forward in the new file.
+    """
+    return f"telegram_gw_log::{os.path.abspath(log_path)}"
+
+
+def sync_telegram_from_gateway_log(
+    config: dict | None,
+    state: dict,
+    paths: dict | None = None,
+) -> int:
+    """Tail the OpenClaw gateway.log for new Telegram outbound ACKs and
+    ingest them into the local DuckDB ``channel_messages`` table.
+
+    Returns the number of messages ingested this call. Designed to be
+    called once per daemon sync cycle. All failure modes are swallowed
+    (the daemon must never crash because telemetry plumbing broke); a
+    warning is logged and ``0`` is returned.
+
+    Tail-and-resume contract
+    ------------------------
+    The last successfully-read byte offset is persisted in
+    ``state['last_log_offsets'][_telegram_log_offset_key(log_path)]``.
+    The caller is responsible for calling ``save_state(state)`` (the
+    main loop already does this every cycle).
+
+    Log rotation / truncation handling: if the file is shorter than the
+    stored offset we reset to ``0`` and re-scan from the top. The
+    ``ingest_channel_message`` PRIMARY KEY makes the re-scan idempotent.
+    """
+    try:
+        if paths and isinstance(paths, dict) and paths.get("logs_dir"):
+            log_path = os.path.join(str(paths["logs_dir"]), "gateway.log")
+        else:
+            log_path = os.path.join(_get_openclaw_dir(), "logs", "gateway.log")
+        if not os.path.exists(log_path):
+            return 0
+
+        offsets = state.setdefault("last_log_offsets", {})
+        key = _telegram_log_offset_key(log_path)
+        prev_offset = int(offsets.get(key, 0) or 0)
+
+        try:
+            size = os.path.getsize(log_path)
+        except OSError:
+            return 0
+        if size < prev_offset:
+            # Log was rotated or truncated. Re-scan from the top; the
+            # PRIMARY KEY on channel_messages.id keeps re-ingest a no-op.
+            log.info(
+                "telegram-gw-log: file shrank (size=%d < offset=%d); "
+                "restarting tail from byte 0",
+                size, prev_offset,
+            )
+            prev_offset = 0
+        if size == prev_offset:
+            return 0
+
+        try:
+            from clawmetry import local_store as _ls
+            store = _ls.get_store()
+        except Exception as e:
+            log.warning("telegram-gw-log: local_store unavailable: %s", e)
+            return 0
+
+        try:
+            with open(log_path, "rb") as fh:
+                fh.seek(prev_offset)
+                # Read in binary so the byte offset we persist is correct
+                # for the next call regardless of multibyte characters in
+                # the log (Telegram bodies aren't logged today, but other
+                # entries do contain unicode).
+                buf = fh.read()
+        except OSError as e:
+            log.warning("telegram-gw-log: read failed: %s", e)
+            return 0
+
+        try:
+            text = buf.decode("utf-8", errors="ignore")
+        except Exception:
+            text = ""
+
+        # Ensure we only consume complete lines this cycle. Anything
+        # after the last newline is a partial line still being written;
+        # leave the offset alone for that fragment so we re-read it next
+        # cycle.
+        last_nl = text.rfind("\n")
+        if last_nl < 0:
+            return 0
+        complete = text[: last_nl + 1]
+        new_offset = prev_offset + len(complete.encode("utf-8", errors="ignore"))
+
+        ingested = 0
+        for raw_line in complete.splitlines():
+            if "[telegram]" not in raw_line:
+                # Cheap pre-filter — only ~0.005% of gateway.log lines
+                # are Telegram, and the regex match is non-trivial.
+                continue
+            row = parse_telegram_outbound_line(raw_line)
+            if not row:
+                continue
+            try:
+                store.ingest_channel_message(row)
+                ingested += 1
+            except Exception as e:
+                # One malformed row must not poison the rest of the tail.
+                log.debug(
+                    "telegram-gw-log: ingest_channel_message failed for "
+                    "%s: %s", row.get("id"), e,
+                )
+                continue
+
+        offsets[key] = new_offset
+        if ingested:
+            log.info(
+                "telegram-gw-log: ingested %d outbound message(s) "
+                "(offset %d → %d)",
+                ingested, prev_offset, new_offset,
+            )
+        return ingested
+    except Exception as e:
+        log.warning("telegram-gw-log: cycle failed: %s", e)
+        return 0
 
 
 def _build_gateway_data(paths: dict = None) -> dict:

--- a/tests/test_telegram_gatewaylog_parser.py
+++ b/tests/test_telegram_gatewaylog_parser.py
@@ -1,0 +1,323 @@
+"""Tests for ``sync.parse_telegram_outbound_line`` and the daemon
+``sync_telegram_from_gateway_log`` helper.
+
+Why this exists
+---------------
+OpenClaw stores Telegram direct chats entirely in memory — no JSONL is
+ever written for them (memory ``reference_openclaw_telegram_inmemory.md``).
+The only on-disk evidence is ``[telegram] sendMessage ok ...`` ACK lines
+in ``~/.openclaw/logs/gateway.log``. This module pins the parser so the
+real production log shapes (captured 2026-05-13 from the user's machine)
+keep round-tripping into DuckDB after future refactors.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """Fresh per-test DuckDB so ``ingest_channel_message`` PRIMARY-KEY
+    semantics are isolated from neighbours."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.get_store()
+    yield s
+    try:
+        s.stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def parser():
+    """Return ``parse_telegram_outbound_line`` from a freshly-imported
+    ``clawmetry.sync``. The lazy regex compile is module-global, so we
+    don't reload here — every test calls into the same precompiled
+    handle, which is exactly the production code path."""
+    from clawmetry import sync
+    return sync.parse_telegram_outbound_line
+
+
+# ── parse_telegram_outbound_line — happy path on real log shapes ───────
+
+
+def test_parses_real_sendmessage_line(parser):
+    """The exact production line shape from gateway.log on 2026-05-13."""
+    line = (
+        "2026-05-13T22:54:19.865+02:00 [telegram] sendMessage ok "
+        "chat=1532693273 message=8491"
+    )
+    row = parser(line)
+    assert row is not None
+    assert row["id"] == "telegram:1532693273:8491"
+    assert row["provider"] == "telegram"
+    assert row["channel_id"] == "telegram:1532693273"
+    assert row["direction"] == "out"
+    # Body MUST be None (the log only carries the ACK, not the message
+    # text). A placeholder string would mislead the renderer.
+    assert row["body"] is None
+    assert row["ts"] == "2026-05-13T22:54:19.865+02:00"
+    assert row["raw_blob"]["method"] == "sendMessage"
+    assert row["raw_blob"]["body_capture"] == "ack_only"
+    assert row["raw_blob"]["source"] == "gateway.log"
+
+
+def test_parses_sendphoto_sendaudio_senddocument(parser):
+    """Other media APIs follow the same pattern. Pinning these prevents
+    a regex tightening from silently dropping non-text media."""
+    cases = [
+        ("sendPhoto", 8480),
+        ("sendAudio", 9001),
+        ("sendDocument", 9002),
+        ("sendVideo", 9003),
+        ("sendVoice", 9004),
+        ("sendSticker", 9005),
+        ("sendAnimation", 9006),
+        ("sendLocation", 9007),
+    ]
+    for method, msg_id in cases:
+        line = (
+            f"2026-05-13T06:00:56.332+02:00 [telegram] {method} ok "
+            f"chat=1532693273 message={msg_id}"
+        )
+        row = parser(line)
+        assert row is not None, f"Failed to parse {method}"
+        assert row["raw_blob"]["method"] == method
+        assert row["id"] == f"telegram:1532693273:{msg_id}"
+        assert row["direction"] == "out"
+
+
+def test_parses_negative_chat_id_for_groups(parser):
+    """Telegram group chat IDs are negative integers. Must round-trip."""
+    line = (
+        "2026-05-13T10:00:00.000+02:00 [telegram] sendMessage ok "
+        "chat=-1001234567890 message=42"
+    )
+    row = parser(line)
+    assert row is not None
+    assert row["id"] == "telegram:-1001234567890:42"
+    assert row["channel_id"] == "telegram:-1001234567890"
+
+
+def test_parses_z_suffix_timestamp(parser):
+    """Some gateway builds emit ``Z`` instead of ``+HH:MM``. Both work."""
+    line = (
+        "2026-05-13T22:54:19Z [telegram] sendMessage ok "
+        "chat=1532693273 message=8491"
+    )
+    row = parser(line)
+    assert row is not None
+    assert row["ts"] == "2026-05-13T22:54:19Z"
+
+
+# ── parse_telegram_outbound_line — non-matches ─────────────────────────
+
+
+@pytest.mark.parametrize("line", [
+    "",
+    "not a log line at all",
+    # Inbound diagnostic — no message ACK, must NOT be ingested as a fake
+    # outbound row.
+    "2026-05-11T17:59:03.570+02:00 [telegram] Polling stall detected (no completed getUpdates for 120.08s)",
+    # Provider startup — same shape but nothing to record.
+    "2026-05-09T12:00:23.582+02:00 [telegram] [default] starting provider (@diya_vivek_bot)",
+    # Menu-shortening warning — common production noise.
+    "2026-05-09T12:00:23.781+02:00 [telegram] menu text exceeded the conservative 5700-character payload budget",
+    # Different channel — must not match.
+    "2026-05-13T10:00:00.000+02:00 [signal] sendMessage ok chat=1 message=2",
+    # Failed call (no `ok` token) — we only ingest acknowledged sends.
+    "2026-05-13T10:00:00.000+02:00 [telegram] sendMessage failed chat=1 message=2",
+])
+def test_rejects_non_outbound_lines(parser, line):
+    assert parser(line) is None
+
+
+# ── sync_telegram_from_gateway_log — daemon helper integration ─────────
+
+
+def _write_log(path, lines):
+    with open(path, "w", encoding="utf-8") as f:
+        for ln in lines:
+            f.write(ln + "\n")
+
+
+def _make_state():
+    return {"last_event_ids": {}, "last_log_offsets": {}, "last_sync": None}
+
+
+SAMPLE_LINES = [
+    "2026-05-13T22:54:19.865+02:00 [telegram] sendMessage ok chat=1532693273 message=8491",
+    "2026-05-13T19:54:35.123+02:00 [telegram] sendMessage ok chat=1532693273 message=8489",
+    "2026-05-13T06:00:56.332+02:00 [telegram] sendPhoto ok chat=1532693273 message=8480",
+    # Noise that must be skipped:
+    "2026-05-13T07:00:00.000+02:00 [telegram] menu text exceeded the conservative 5700-character payload budget",
+    "2026-05-13T08:00:00.000+02:00 [signal] sendMessage ok chat=1 message=2",
+]
+
+
+def test_ingests_outbound_messages_from_log(store, tmp_path, monkeypatch):
+    """Full path: write a gateway.log, run the daemon helper once, query
+    the DuckDB and assert the three outbound ACK rows are present."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    log_path = logs_dir / "gateway.log"
+    _write_log(log_path, SAMPLE_LINES)
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+    from clawmetry import sync
+    importlib.reload(sync)
+
+    state = _make_state()
+    n = sync.sync_telegram_from_gateway_log(config=None, state=state)
+    assert n == 3
+
+    # Round-trip through ingest_channel_message → query the table.
+    rows = store._conn.execute(
+        "SELECT id, provider, direction, channel_id, ts, body "
+        "FROM channel_messages ORDER BY ts"
+    ).fetchall()
+    ids = [r[0] for r in rows]
+    assert "telegram:1532693273:8480" in ids
+    assert "telegram:1532693273:8489" in ids
+    assert "telegram:1532693273:8491" in ids
+    assert all(r[1] == "telegram" for r in rows)
+    assert all(r[2] == "out" for r in rows)
+    assert all(r[3] == "telegram:1532693273" for r in rows)
+    assert all(r[5] is None for r in rows)  # body uncaptured
+
+
+def test_tail_and_resume_does_not_reingest(store, tmp_path, monkeypatch):
+    """Second cycle on an unchanged log returns 0 — the byte offset in
+    state must skip already-read content."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    log_path = logs_dir / "gateway.log"
+    _write_log(log_path, SAMPLE_LINES)
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+    from clawmetry import sync
+    importlib.reload(sync)
+
+    state = _make_state()
+    n1 = sync.sync_telegram_from_gateway_log(config=None, state=state)
+    n2 = sync.sync_telegram_from_gateway_log(config=None, state=state)
+    assert n1 == 3
+    assert n2 == 0
+
+    # New ACK appended → only the new line is ingested.
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(
+            "2026-05-14T08:00:00.000+02:00 [telegram] sendMessage ok "
+            "chat=1532693273 message=8500\n"
+        )
+    n3 = sync.sync_telegram_from_gateway_log(config=None, state=state)
+    assert n3 == 1
+
+
+def test_handles_log_truncation_by_rescanning(store, tmp_path, monkeypatch):
+    """If the file shrinks below the stored offset (rotation /
+    truncation) we re-scan from byte 0. PRIMARY KEY makes the re-ingest
+    a no-op for already-seen rows but new content is captured."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    log_path = logs_dir / "gateway.log"
+    _write_log(log_path, SAMPLE_LINES)
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+    from clawmetry import sync
+    importlib.reload(sync)
+
+    state = _make_state()
+    sync.sync_telegram_from_gateway_log(config=None, state=state)
+
+    # Truncate to a SHORTER set of entries (simulating logrotate copy-
+    # truncate; the new file is smaller than our stored offset).
+    _write_log(log_path, [
+        "2026-05-14T08:00:00.000+02:00 [telegram] sendMessage ok "
+        "chat=1532693273 message=8501",
+    ])
+    n = sync.sync_telegram_from_gateway_log(config=None, state=state)
+    # One brand-new row is ingested; the offset reset is logged.
+    assert n == 1
+    rows = store._conn.execute(
+        "SELECT id FROM channel_messages WHERE id='telegram:1532693273:8501'"
+    ).fetchall()
+    assert len(rows) == 1
+
+
+def test_handles_partial_trailing_line(store, tmp_path, monkeypatch):
+    """A line still being written (no trailing newline) must be left for
+    the next cycle, NOT half-parsed and ingested."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    log_path = logs_dir / "gateway.log"
+    # Two complete lines + one partial (no \n at end).
+    with open(log_path, "w", encoding="utf-8") as f:
+        f.write(
+            "2026-05-13T22:54:19.865+02:00 [telegram] sendMessage ok "
+            "chat=1532693273 message=8491\n"
+        )
+        f.write(
+            "2026-05-13T22:54:20.000+02:00 [telegram] sendMessage ok "
+            "chat=1532693273 message=8492\n"
+        )
+        f.write(
+            "2026-05-13T22:54:21.000+02:00 [telegram] sendMess"
+        )
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+    from clawmetry import sync
+    importlib.reload(sync)
+
+    state = _make_state()
+    n1 = sync.sync_telegram_from_gateway_log(config=None, state=state)
+    assert n1 == 2  # only the two complete lines
+
+    # Complete the partial line + add a third ACK.
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write("age ok chat=1532693273 message=8493\n")
+        f.write(
+            "2026-05-13T22:54:22.000+02:00 [telegram] sendMessage ok "
+            "chat=1532693273 message=8494\n"
+        )
+    n2 = sync.sync_telegram_from_gateway_log(config=None, state=state)
+    assert n2 == 2  # the previously-partial line + the new one
+
+
+def test_missing_log_file_is_noop(store, tmp_path, monkeypatch):
+    """A workspace with no gateway.log (fresh install / OpenClaw not
+    started yet) must return 0 silently."""
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+    from clawmetry import sync
+    importlib.reload(sync)
+    state = _make_state()
+    assert sync.sync_telegram_from_gateway_log(config=None, state=state) == 0
+
+
+def test_ingest_is_idempotent_on_state_loss(store, tmp_path, monkeypatch):
+    """Re-ingesting the same log with a fresh state dict (simulating
+    ``~/.clawmetry/sync-state.json`` deletion) does not duplicate
+    rows — the channel_messages PRIMARY KEY is the safety net behind
+    the byte-offset bookkeeping."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    log_path = logs_dir / "gateway.log"
+    _write_log(log_path, SAMPLE_LINES)
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+    from clawmetry import sync
+    importlib.reload(sync)
+
+    sync.sync_telegram_from_gateway_log(config=None, state=_make_state())
+    sync.sync_telegram_from_gateway_log(config=None, state=_make_state())
+
+    n = store._conn.execute(
+        "SELECT COUNT(*) FROM channel_messages WHERE provider='telegram'"
+    ).fetchone()[0]
+    assert n == 3  # not 6


### PR DESCRIPTION
## Why

OpenClaw runs Telegram direct-chat sessions **entirely in memory**. No per-session JSONL is ever written under `~/.openclaw/agents/main/sessions/` or `~/.openclaw/telegram/` for inbound or outbound Telegram traffic — confirmed today by diagnostic agent on the user's live machine. The only on-disk evidence of Telegram activity is regex-recoverable from `~/.openclaw/logs/gateway.log`.

PR #1192 (just merged) wired up watching `~/.openclaw/telegram/` defensively for the day OpenClaw starts persisting, but until that upstream change lands ClawMetry's Brain feed silently misses **all** Telegram activity. This PR is the only path that works today without an OpenClaw upstream change AND backfills history on first install.

## What's captured

Outbound API ACK lines, e.g.

```
2026-05-13T22:54:19.865+02:00 [telegram] sendMessage ok chat=1532693273 message=8491
2026-05-13T06:00:56.332+02:00 [telegram] sendPhoto    ok chat=1532693273 message=8480
```

Each becomes a `channel_messages` row in DuckDB with:
- `id = "telegram:<chat>:<msg>"` (PRIMARY KEY → idempotent re-ingest)
- `provider = "telegram"`, `direction = "out"`, `channel_id = "telegram:<chat>"`
- `body = None`
- `raw_blob = {source: "gateway.log", method, body_capture: "ack_only", ...}`

Methods covered: `sendMessage`, `sendPhoto`, `sendAudio`, `sendDocument`, `sendVideo`, `sendVoice`, `sendSticker`, `sendAnimation`, `sendLocation`.

## What's NOT captured

- **Outbound message bodies** — `gateway.log` logs only the API ACK, never the message payload. The body lives only in OpenClaw's in-memory session state. We set `body=None` (rather than a placeholder string) so the renderer can show an "(no body captured)" affordance and isn't tricked into rendering literal placeholder text as user content.
- **Inbound messages** — at every verbosity level we observed (today, 2026-05-13), the production log emits **only** long-poll diagnostics for inbound (`[telegram] Polling stall detected`, `[diag] polling cycle finished`). Message bodies are not logged. If a future OpenClaw release adds an inbound trace line we can extend the parser, but today there is nothing to parse.

## Long-term fix path

1. **OpenClaw upstream**: persist inbound Telegram updates to a session JSONL like every other channel does. The right thing — out of ClawMetry's direct control.
2. **Live gateway WebSocket tap** on `ws://localhost:18789` — real-time, no log parsing, but only catches messages received while the ClawMetry daemon is running (no historical backfill).

## Implementation notes

- **Tail-and-resume**: per-log-path byte offset persisted in `state['last_log_offsets']` (existing `~/.clawmetry/sync-state.json` schema, no new file).
- **Log rotation safety**: if `os.path.getsize(log_path) < prev_offset` we restart from byte 0; the `channel_messages` PRIMARY KEY makes the re-scan idempotent.
- **Partial-line safety**: only consume up to the last `\n` each cycle; the trailing fragment is read again next cycle when it completes.
- **Pre-filter**: skip lines without `[telegram]` before regex match (~99.99% of `gateway.log` lines, big perf win).
- **Best-effort**: every failure mode swallowed with a warning so the daemon never crashes if `local_store` is unavailable or the log is mid-rotation.

Wired into the main daemon `while True` cycle right after `sync_logs(...)`.

## Test plan

- [x] 17 new unit tests in `tests/test_telegram_gatewaylog_parser.py` covering:
  - real production line shapes for `sendMessage` + 8 other media APIs
  - negative chat IDs (Telegram groups)
  - both `+HH:MM` and `Z` timestamp suffixes
  - 6 negative cases including inbound polling-stall noise, signal channel, failed sends
  - end-to-end ingest into a tmp DuckDB → assert row shape via SQL
  - tail-and-resume across cycles
  - log truncation / rotation
  - partial trailing line preservation
  - idempotent re-ingest with empty state
  - missing log file no-op
- [x] Existing `test_sync_skip_sidecar_jsonls`, `test_sync_main_block_at_eof`, `test_channels_local_store`, `test_local_store_sync_integration` all still pass (22/22).
- [ ] Manual: install on user's machine, confirm Brain feed shows today's outbound Telegram ACKs after one sync cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)