### PR TITLE
[RELEASE] fix: clawmetry uninstall pkills stray daemons + install.sh per-step spinners

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -157,6 +157,21 @@ def _is_sync_running() -> bool:
     return False
 
 
+def _count_sync_daemons() -> int:
+    """Return number of running clawmetry.sync processes (best-effort)."""
+    import subprocess as _sp
+    try:
+        r = _sp.run(
+            ["pgrep", "-f", "clawmetry.sync"],
+            capture_output=True, text=True, check=False,
+        )
+        if r.returncode == 0:
+            return len([l for l in r.stdout.splitlines() if l.strip()])
+    except Exception:
+        pass
+    return 0
+
+
 def _kill_sync_daemon() -> None:
     """Kill clawmetry.sync processes — no pkill needed."""
     import os
@@ -187,6 +202,15 @@ def _kill_sync_daemon() -> None:
                 pass
     except Exception:
         pass
+    # macOS without psutil + no /proc — fall back to pkill (universally
+    # available on Darwin/Linux/BSD).
+    import shutil as _sh
+    import subprocess as _sp2
+    if _sh.which("pkill"):
+        _sp2.run(
+            ["pkill", "-f", "clawmetry.sync"],
+            check=False, capture_output=True,
+        )
 
 
 def _stop_existing_daemon() -> None:
@@ -1164,6 +1188,15 @@ def _cmd_uninstall() -> None:
             )
             plist.unlink()
             print("  ✅  Stopped and removed launchd daemon")
+        # Belt-and-suspenders: kill any sync daemons started by hand (not via
+        # launchd). Without this, install.sh's pkill is the only thing that takes
+        # them down, which surfaces to the user as "Killed stray pre-existing
+        # daemon" right after a 'clean' uninstall — undermining trust that
+        # uninstall actually worked.
+        _stray = _count_sync_daemons()
+        if _stray > 0:
+            _kill_sync_daemon()
+            print(f"  ✅  Killed {_stray} stray sync process(es)")
     elif system == "Linux":
         svc = home / ".config" / "systemd" / "user" / "clawmetry-sync.service"
         if shutil.which("systemctl"):
@@ -1172,10 +1205,11 @@ def _cmd_uninstall() -> None:
                 check=False,
                 capture_output=True,
             )
+        _stray = _count_sync_daemons()
         _kill_sync_daemon()
         if svc.exists():
             svc.unlink()
-        print("  ✅  Stopped and removed sync daemon")
+        print("  ✅  Stopped and removed sync daemon" + (f" + {_stray} stray process(es)" if _stray else ""))
 
     # 2. Pip uninstall (BEFORE removing venv, since sys.executable may live there)
     print("  ⏳  Uninstalling pip package...")


### PR DESCRIPTION
## Summary

Two related fixes the user surfaced together:

1. **macOS `clawmetry uninstall` left manually-spawned sync daemons alive.**
   The Darwin branch only did `launchctl unload` + `plist.unlink`, never pkilled
   a daemon that was started by hand (e.g. `nohup clawmetry &` from a prior
   session). The Linux branch already called `_kill_sync_daemon()` — Darwin did
   not. Now both paths call it and surface the count of stray procs killed.
   Without this, the very next `curl install.sh | bash` reported "Killed stray
   pre-existing daemon", undermining the user's trust that `uninstall` actually
   worked.

   Also fixed `_kill_sync_daemon()` itself: on macOS without `psutil` installed
   (the most common case), the function was a no-op because `/proc` doesn't
   exist on Darwin. Added a `pkill -f` fallback at the end (only runs after the
   psutil branch fails AND the `/proc` walk finds nothing — no over-kill).

2. **`install.sh` was silent for ~5–30s between "Installing clawmetry..." and
   "Killed stray pre-existing daemon".** Plist rewrites, launchctl restarts,
   and pkill all ran with zero feedback. Added a `_step` spinner helper
   (elapsed/expected seconds with progress %), surfaces pid+cmdline of each
   detected stray daemon up front, and labels every previously silent stage
   (uv install, pip install, launchd refresh, systemd refresh, daemon kill).
   Final line shows total elapsed seconds.

   Mirrors the parallel sibling shipping the same install.sh changes to landing.

## Files changed

- `clawmetry/cli.py` — added `_count_sync_daemons()` helper, added pkill
  fallback to `_kill_sync_daemon()`, wired `_kill_sync_daemon()` into the
  Darwin path of `_cmd_uninstall()`, surfaced stray-count on both paths.
- `install.sh` — added `_step` spinner helper + `_T0` start timer, expanded
  pre-flight detect to print pid+cmdline of each detected proc, wrapped uv +
  pip install commands in `_step`, added section labels for the macOS launchd
  and Linux systemd blocks, replaced the silent `pkill` stage with a labeled
  one, added total elapsed to the final "installed" line.

## Sibling PR

`vivekchand/clawmetry-landing#NNN` — sibling PR shipping the same install.sh
changes to the landing site (so both delivery channels stay in sync; reviewer
can fill in the issue/PR number).

## Sanity checks

- `python3 -c "import ast; ast.parse(open('clawmetry/cli.py').read())"` → OK
- `bash -n install.sh` → OK
- `make lint` not run locally (no `ruff` in worktree); CI will run it.
- Verified the pkill fallback only runs when psutil import fails AND the
  `/proc` walk path completes — no double-kill on Linux+psutil systems.
- Verified `_count_sync_daemons()` returns 0 cleanly when no procs are running
  and the print line stays well-formed (`f"... daemon" + ""` = `"... daemon"`).

## Test plan

- [ ] Local: install with `make dev`, then `clawmetry uninstall` on macOS with
      a manually-spawned sync daemon — verify it gets killed + count surfaced.
- [ ] Reinstall via `curl install.sh | bash` — verify spinners + pid lines
      appear, no stray-daemon message at the end.
- [ ] CI: install-test.yml + ci.yml green across the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)