### PR TITLE
[RELEASE] fix(sync): telegram events parsed but never reach DuckDB (P0)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6932,6 +6932,52 @@ def parse_telegram_outbound_line(line: str) -> dict | None:
     }
 
 
+def _telegram_outbound_event_row(
+    msg: dict, *, node_id: str,
+) -> dict:
+    """Project a ``channel_messages`` row (from ``parse_telegram_outbound_line``)
+    onto the ``events`` table shape that the Brain feed reads.
+
+    The Brain tab calls ``LocalStore.query_events`` and surfaces rows whose
+    ``event_type`` starts with ``CHANNEL.`` (see ``routes/brain.py`` —
+    ``_try_local_store_brain``). Without this projection, telegram outbound
+    rows live ONLY in ``channel_messages`` and the Brain feed silently
+    omits them — exactly the P0 user-visible regression that motivated
+    this helper.
+
+    The ``id`` matches the ``channel_messages.id`` so the events row and
+    the channel_messages row are 1:1 — both use ``ingest_many`` /
+    ``ingest_channel_message``'s ``INSERT OR IGNORE`` / upsert semantics
+    so re-running the parser after a state-file loss is a no-op.
+    """
+    raw = msg.get("raw_blob") or {}
+    return {
+        "id": msg["id"],
+        "node_id": node_id,
+        "agent_type": "openclaw",
+        "agent_id": "main",
+        "event_type": "channel.out",
+        "ts": msg["ts"],
+        # Channel turns are NOT tied to an LLM session — leave session_id
+        # NULL so the per-session token/cost rollups don't double-count.
+        "session_id": None,
+        "workspace_id": None,
+        "data": {
+            "provider": _TELEGRAM_PROVIDER,
+            "channel_id": msg.get("channel_id"),
+            "chat_id": raw.get("chat_id"),
+            "message_id": raw.get("message_id"),
+            "method": raw.get("method"),
+            "direction": "out",
+            "body_capture": raw.get("body_capture"),
+            "source": raw.get("source") or "gateway.log",
+        },
+        "cost_usd": None,
+        "token_count": None,
+        "model": None,
+    }
+
+
 def _telegram_log_offset_key(log_path: str) -> str:
     """Per-log-path key under ``state['last_log_offsets']``.
 
@@ -6948,12 +6994,24 @@ def sync_telegram_from_gateway_log(
     paths: dict | None = None,
 ) -> int:
     """Tail the OpenClaw gateway.log for new Telegram outbound ACKs and
-    ingest them into the local DuckDB ``channel_messages`` table.
+    ingest them into BOTH the local DuckDB ``channel_messages`` table
+    (channel detail view) AND the ``events`` table (Brain feed).
 
     Returns the number of messages ingested this call. Designed to be
     called once per daemon sync cycle. All failure modes are swallowed
     (the daemon must never crash because telemetry plumbing broke); a
     warning is logged and ``0`` is returned.
+
+    Why two writes
+    --------------
+    The Brain tab reads from ``LocalStore.query_events`` (the ``events``
+    table) and renders any row whose ``event_type`` starts with
+    ``CHANNEL.``. Until this dual-write was added, telegram outbound
+    rows landed ONLY in ``channel_messages`` and Brain showed an empty
+    Telegram channel — exactly the P0 user-visible bug this helper was
+    meant to prevent. ``sync_channel_messages`` already dual-writes for
+    JSONL-backed channels (see L2771-L2789); this brings the gateway-log
+    parser into the same contract.
 
     Tail-and-resume contract
     ------------------------
@@ -6964,7 +7022,8 @@ def sync_telegram_from_gateway_log(
 
     Log rotation / truncation handling: if the file is shorter than the
     stored offset we reset to ``0`` and re-scan from the top. The
-    ``ingest_channel_message`` PRIMARY KEY makes the re-scan idempotent.
+    ``ingest_channel_message`` PRIMARY KEY (and ``events`` ``INSERT OR
+    IGNORE``) makes the re-scan idempotent.
     """
     try:
         if paths and isinstance(paths, dict) and paths.get("logs_dir"):
@@ -7028,7 +7087,17 @@ def sync_telegram_from_gateway_log(
         complete = text[: last_nl + 1]
         new_offset = prev_offset + len(complete.encode("utf-8", errors="ignore"))
 
+        # Resolve node_id ONCE per cycle (cheap dict lookup; the daemon
+        # caches it for the life of the process). The events table needs
+        # it on every row.
+        node_id = (
+            (config or {}).get("node_id")
+            or os.environ.get("CLAWMETRY_NODE_ID")
+            or "local"
+        )
+
         ingested = 0
+        events_batch: list[dict] = []
         for raw_line in complete.splitlines():
             if "[telegram]" not in raw_line:
                 # Cheap pre-filter — only ~0.005% of gateway.log lines
@@ -7039,7 +7108,6 @@ def sync_telegram_from_gateway_log(
                 continue
             try:
                 store.ingest_channel_message(row)
-                ingested += 1
             except Exception as e:
                 # One malformed row must not poison the rest of the tail.
                 log.debug(
@@ -7047,6 +7115,25 @@ def sync_telegram_from_gateway_log(
                     "%s: %s", row.get("id"), e,
                 )
                 continue
+            # Dual-write: also enqueue the events-table projection so
+            # /api/brain-history surfaces the message. ingest_many goes
+            # through the ring buffer / flusher so this is cheap.
+            events_batch.append(
+                _telegram_outbound_event_row(row, node_id=node_id)
+            )
+            ingested += 1
+
+        if events_batch:
+            try:
+                store.ingest_many(events_batch)
+            except Exception as e:
+                # Brain rendering will lag by one cycle but the
+                # channel_messages rows already landed — we keep the
+                # progress and let the next cycle retry.
+                log.debug(
+                    "telegram-gw-log: events ingest failed for %d row(s): %s",
+                    len(events_batch), e,
+                )
 
         offsets[key] = new_offset
         if ingested:

--- a/tests/test_telegram_gatewaylog_parser.py
+++ b/tests/test_telegram_gatewaylog_parser.py
@@ -321,3 +321,104 @@ def test_ingest_is_idempotent_on_state_loss(store, tmp_path, monkeypatch):
         "SELECT COUNT(*) FROM channel_messages WHERE provider='telegram'"
     ).fetchone()[0]
     assert n == 3  # not 6
+
+
+# ── REGRESSION: telegram outbound MUST also reach the events table ─────
+
+
+def test_outbound_messages_reach_events_table_for_brain_feed(
+    store, tmp_path, monkeypatch,
+):
+    """P0 regression guard for the 2026-05-14 incident.
+
+    The Brain tab reads from ``LocalStore.query_events`` (the ``events``
+    table). Until the dual-write fix, ``sync_telegram_from_gateway_log``
+    only wrote to ``channel_messages`` — Brain showed an empty Telegram
+    channel even when the parser successfully ingested every line.
+
+    This test pins both halves of the dual-write so future refactors
+    can't silently regress to a channel_messages-only path.
+    """
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    log_path = logs_dir / "gateway.log"
+    _write_log(log_path, SAMPLE_LINES)
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+    from clawmetry import sync
+    importlib.reload(sync)
+
+    state = _make_state()
+    n = sync.sync_telegram_from_gateway_log(
+        config={"node_id": "test-node"}, state=state,
+    )
+    assert n == 3
+
+    # Drain the ring buffer so the rows are visible to a synchronous
+    # query. The flusher fires every ~50ms in the test fixture but we
+    # don't want the assertion to race it.
+    store._flush_now()
+
+    # ── channel_messages assertions (existing contract) ─────────────────
+    cm_rows = store._conn.execute(
+        "SELECT id FROM channel_messages WHERE provider='telegram' "
+        "ORDER BY id"
+    ).fetchall()
+    assert len(cm_rows) == 3
+
+    # ── events assertions (the REGRESSION FIX) ──────────────────────────
+    ev_rows = store._conn.execute(
+        "SELECT id, node_id, event_type, ts FROM events "
+        "WHERE event_type='channel.out' ORDER BY id"
+    ).fetchall()
+    assert len(ev_rows) == 3, (
+        "telegram outbound rows landed in channel_messages but NOT in "
+        "events — Brain feed will be silently empty."
+    )
+    # Same id on both tables → easy 1:1 join + idempotent re-ingest.
+    cm_ids = {r[0] for r in cm_rows}
+    ev_ids = {r[0] for r in ev_rows}
+    assert cm_ids == ev_ids
+    # node_id stamped through from config (Brain filters by node).
+    assert all(r[1] == "test-node" for r in ev_rows)
+    # event_type matches the prefix the brain renderer dispatches on
+    # (routes/brain.py L260: ``if evt_type.startswith("CHANNEL.")``).
+    assert all(r[2] == "channel.out" for r in ev_rows)
+
+    # ── full read-path: query_events returns the rows brain consumes ────
+    api_rows = store.query_events(event_type="channel.out", limit=50)
+    assert len(api_rows) == 3
+    # Brain enrichment expects provider/chat_id under data.
+    for row in api_rows:
+        data = row.get("data") or {}
+        assert data.get("provider") == "telegram"
+        assert data.get("direction") == "out"
+        assert data.get("chat_id")  # non-empty
+
+
+def test_events_dual_write_is_idempotent_across_state_loss(
+    store, tmp_path, monkeypatch,
+):
+    """The events-table dual-write must be idempotent the same way
+    channel_messages is — INSERT OR IGNORE on the shared id column."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    log_path = logs_dir / "gateway.log"
+    _write_log(log_path, SAMPLE_LINES)
+
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path))
+    from clawmetry import sync
+    importlib.reload(sync)
+
+    sync.sync_telegram_from_gateway_log(
+        config={"node_id": "n1"}, state=_make_state(),
+    )
+    sync.sync_telegram_from_gateway_log(
+        config={"node_id": "n1"}, state=_make_state(),
+    )
+    store._flush_now()
+
+    n = store._conn.execute(
+        "SELECT COUNT(*) FROM events WHERE event_type='channel.out'"
+    ).fetchone()[0]
+    assert n == 3  # not 6


### PR DESCRIPTION
## Root cause

**Hypothesis A** was correct — but at one level removed from where I expected.

`sync_telegram_from_gateway_log` was writing to `channel_messages`, but the Brain feed (`/api/brain-history` → `LocalStore.query_events`) only reads from the `events` table. Telegram outbound rows were ingested correctly into one DuckDB table but never projected onto the table the Brain renderer queries — the channel went silently empty even though the parser reported `"telegram-gw-log: ingested 16 outbound message(s)"` on every cycle.

(Verified on the user's live machine: the daemon's local-query proxy returns 16 rows from `query_channel_messages`, but `query_events(event_type='channel.out')` returns zero. The `routes/brain.py` fast path at L260 already knows how to render `CHANNEL.*` rows — it just never sees any from the gateway-log parser.)

`sync_channel_messages` (the JSONL-backed sibling) has done the dual-write correctly since day one (sync.py L2771-L2789); the gateway-log parser drifted out of contract when it was added in #1192.

## Fix (3 lines)

1. New helper `_telegram_outbound_event_row()` projects a parsed channel_messages row onto the `events` schema with `event_type="channel.out"` and `data.{provider, chat_id, direction, ...}`.
2. `sync_telegram_from_gateway_log` builds an `events_batch` alongside the existing `ingest_channel_message` call and flushes it via `store.ingest_many()`.
3. Same `id` on both tables → upsert / `INSERT OR IGNORE` keeps state-file loss idempotent.

## Test that would have caught this

`tests/test_telegram_gatewaylog_parser.py::test_outbound_messages_reach_events_table_for_brain_feed` — writes three real-shape ACK lines, runs the daemon helper, asserts (a) `channel_messages` has 3 rows, (b) `events` has 3 rows with `event_type='channel.out'`, (c) `query_events` returns brain-renderer-shaped enrichment data. Plus an idempotency twin that re-runs with a fresh state dict and asserts no duplicate rows.

The original test only covered the channel_messages side — exactly the failure mode that let this regression ship.

## Hypothesis matrix (for future P0 triage)

- **A — write missing/guarded by flag:** ✅ correct (write was missing for the events table)
- **B — stale offset from previous install:** ruled out (state file exists with reasonable offset; ingest log shows 16 rows landed)
- **C — brain query filters out the source:** ruled out (brain reads `events`, parser writes only `channel_messages` — they don't intersect to begin with)
- **D — multi-daemon write contention:** ruled out (no errors, ingest succeeded, single writer holds the lock)

## Test plan

- [ ] CI green on the new regression test
- [ ] User's next sync cycle ingests historical telegram backlog into events
- [ ] Brain tab shows telegram outbound rows after PyPI propagation + dashboard restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)