### PR TITLE
fix(brain): collapsed-run time range rendered HTML as literal text

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2899,7 +2899,10 @@ function renderBrainStream(events) {
         escHtml(ev.__collapsedCount + ' consecutive outbound ACKs from this chat — bodies not captured (collapsed for readability)') +
         '">↪ ' + ev.__collapsedCount + ' outbound</span>';
       if (rangeLabel) {
-        html += '<span class="brain-collapsed-range" style="color:var(--text-muted);font-size:10px;flex-shrink:0;white-space:nowrap;">' + escHtml(rangeLabel) + '</span>';
+        // rangeLabel is trusted HTML built from formatBrainTime() output
+        // (which wraps the date prefix in a styled <span>) joined with
+        // a literal " → "; do NOT escHtml or the markup renders as text.
+        html += '<span class="brain-collapsed-range" style="color:var(--text-muted);font-size:10px;flex-shrink:0;white-space:nowrap;">' + rangeLabel + '</span>';
       }
       html += '<span class="brain-collapsed-note" style="color:var(--text-muted);font-size:10px;font-style:italic;flex-shrink:0;white-space:nowrap;">(bodies not captured)</span>';
       // Expand affordance — small text button, monospace arrow.


### PR DESCRIPTION
## Summary
- E2E playwright verification of #1212 + #1213 caught literal `<span style=\"opacity:0.45;...\">13 May</span>` text appearing in the Brain tab's collapsed-outbound row.
- `formatBrainTime()` returns trusted HTML; wrapping `rangeLabel` in `escHtml()` turned that markup into visible text.
- One-line fix: drop the `escHtml` call (the literal `→` separator carries no user input, the helper output is trusted).

## Test plan
- [x] Headless chromium against Brain tab, post-fix, shows clean `13 May 22:54:19 → 13 May 19:54:45` instead of escaped `<span>`.
- [x] All 16 telegram CHANNEL.OUT events + 6 OpenClaw TUI events render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)