### PR TITLE
[RELEASE] perf(install): launchd restart + pkill move to background — install completes in <10s

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -581,9 +581,34 @@ def _to_blob(value: Any) -> bytes | None:
 
 
 def _open_connection(*, read_only: bool = False) -> duckdb.DuckDBPyConnection:
-    """Open a DuckDB connection at DB_PATH, creating the directory if needed."""
+    """Open a DuckDB connection at DB_PATH, creating the directory if needed.
+
+    Retries briefly on "Conflicting lock is held" — that error fires when an
+    older sync daemon hasn't fully released the file lock yet (e.g. moments
+    after install.sh's ``pkill -f clawmetry.sync``). install.sh used to
+    ``sleep 1`` defensively; we now retry here so install.sh can return to
+    the prompt immediately and the lock-release race is owned by the
+    daemon-side code that actually cares about it. (#1215)
+    """
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    return duckdb.connect(str(DB_PATH), read_only=read_only)
+    # 5 attempts × 0.5s = 2.5s budget. Beats a fixed install.sh sleep
+    # because (a) most opens succeed on the first try and pay zero, and (b)
+    # if the conflicting holder is genuinely stuck we surface the real
+    # DuckDB error instead of silently sleeping past it.
+    last_exc: Exception | None = None
+    for attempt in range(5):
+        try:
+            return duckdb.connect(str(DB_PATH), read_only=read_only)
+        except duckdb.IOException as exc:
+            msg = str(exc)
+            if "Conflicting lock" not in msg and "could not set lock" not in msg:
+                raise
+            last_exc = exc
+            time.sleep(0.5)
+    # Out of retries — re-raise the last lock error so the caller sees it.
+    if last_exc is not None:
+        raise last_exc
+    return duckdb.connect(str(DB_PATH), read_only=read_only)  # unreachable
 
 
 # ── Singleton store ─────────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -268,17 +268,31 @@ if [ "$OS" = "Darwin" ]; then
     esac
   done
 
-  # Step 2: kickstart any registered com.clawmetry.* job. `|| true` so
-  # systems without launchd running (CI containers, Linux subprocess) don't
-  # abort the installer.
+  # Step 2: kickstart any registered com.clawmetry.* job in the BACKGROUND.
+  #
+  # ``launchctl kickstart -k`` is *synchronous* — it blocks until the daemon
+  # process is alive again. For NemoClaw sandbox plists that run
+  # ``docker exec <container> kubectl exec ...``, "alive" means the docker+
+  # kubectl handshake has completed, which routinely costs 30-50s per plist.
+  # On a machine with two sandbox plists installed that's 60-100s of dead
+  # time install.sh used to wait for. The user's job here is to put fresh
+  # files on disk; the daemon respawn is best-effort and doesn't need to
+  # block the prompt return. (#1215)
+  #
+  # `|| true` so systems without launchd running (CI containers, Linux
+  # subprocess) don't abort the installer.
   for _plist in "$_LA_DIR"/com.clawmetry.*.plist; do
     [ -f "$_plist" ] || continue
     _label=$(basename "$_plist" .plist)
-    launchctl kickstart -k "gui/$_UID/$_label" >/dev/null 2>&1 || true
+    ( launchctl kickstart -k "gui/$_UID/$_label" >/dev/null 2>&1 || true ) &
   done
+  # Detach the backgrounded kicks so install.sh can exit without waiting
+  # for them. ``disown -a`` clears bash's job table; the kernel keeps the
+  # children alive (their parent reparents to launchd/init).
+  disown -a 2>/dev/null || true
 
   if [ "$_DARWIN_PLIST_FOUND" = "1" ]; then
-    echo -e "  ${DIM}  ↺ launchd jobs restarted${NC}"
+    echo -e "  ${DIM}  ↺ launchd jobs restarting in background${NC}"
   fi
 
   # Cross-platform sanity: no plist means user installed via pip directly
@@ -305,11 +319,17 @@ if [ "$OS" = "Linux" ]; then
   # Prefer systemd --user when both systemctl is present AND a clawmetry unit
   # is registered. `list-unit-files` enumerates installed units even when none
   # are running, which is what we want here.
+  #
+  # ``systemctl --user restart`` blocks until the unit reports active, which
+  # for the sync daemon means DuckDB open + cloud heartbeat round-trip
+  # (5-30s on slow networks). We background it with ``--no-block`` so
+  # install.sh doesn't stall on daemon startup — matches the macOS launchd
+  # fire-and-forget pattern. (#1215)
   if [ "$_IS_WSL" = "0" ] && command -v systemctl >/dev/null 2>&1; then
     if systemctl --user list-unit-files 2>/dev/null | grep -q '^clawmetry-sync\.service'; then
       systemctl --user daemon-reload >/dev/null 2>&1 || true
-      if systemctl --user restart clawmetry-sync.service >/dev/null 2>&1; then
-        echo -e "  ${DIM}↺ Restarted clawmetry-sync systemd user service${NC}"
+      if systemctl --user restart --no-block clawmetry-sync.service >/dev/null 2>&1; then
+        echo -e "  ${DIM}↺ clawmetry-sync restarting in background${NC}"
         _RESTARTED=1
       fi
     fi
@@ -341,10 +361,10 @@ fi
 if [ "$CLAWMETRY_RESTART_AFTER" = "1" ]; then
   echo -e "  → Killing stray pre-existing daemon(s)..."
   pkill -f "clawmetry\.sync" >/dev/null 2>&1 || true
-  # Wait briefly for the kernel to release the DuckDB write lock so the
-  # next ``clawmetry`` invocation doesn't immediately race the dying pid.
-  sleep 1
-  echo -e "  ${DIM}  ↺ Lock released${NC}"
+  # No sleep here — the freshly-spawned daemon's DuckDB open already retries
+  # on lock contention (clawmetry/local_store.py), so install.sh doesn't
+  # need to babysit the kernel. Saves 1s of fixed dead time. (#1215)
+  echo -e "  ${DIM}  ↺ Stray daemon(s) signalled${NC}"
 fi
 
 echo ""


### PR DESCRIPTION
## Why

User feedback (verbatim):

> but still why 87 seconds??? can we do something in background & not in a synchronous way?? we need it under 10 seconds

User's screenshot showed:

```
→ Detected macOS
✓ Creating virtual environment (uv) (0s)
✓ Installing clawmetry from PyPI (uv) (1s)
→ Refreshing macOS launchd jobs...
  ↺ launchd jobs restarted
✓ ClawMetry 0.12.181 installed (87s total)
```

Visible labeled steps add up to 1-2s. The other ~85s vanished into the silent ``Refreshing macOS launchd jobs...`` block.

## Profiling

Instrumented ``install.sh`` with millisecond-resolution timestamps (perl Time::HiRes side-channel log) and ran against ``INSTALL_DIR=/tmp/cm-bench-baseline``. Local repro environment: 3 plists installed (``com.clawmetry.dashboard`` + 2 ``com.clawmetry.sandbox.*``).

| Stage | Before | After |
|---|---|---|
| ``preflight_pgrep`` | 36ms | ~36ms |
| ``venv_create`` (uv) | 100ms | ~100ms |
| ``uv_pip_install`` | 450ms | ~450ms |
| ``version_probe`` | 61ms | ~60ms |
| ``plistbuddy_loop`` | 31ms | ~30ms |
| ``kickstart com.clawmetry.dashboard`` | 19ms | backgrounded |
| ``kickstart com.clawmetry.sandbox.nemoclaw-sandbox`` | **45,868ms** | backgrounded |
| ``kickstart com.clawmetry.sandbox.newmoclaw-sandbox2`` | **30,114ms** | backgrounded |
| ``kickstart_loop_total`` | **76,042ms** | **15ms** |
| **TOTAL wall clock** | **77s** (warm) / 87s (user's run) | **<1s** |

## Root cause (one sentence)

``launchctl kickstart -k`` is synchronous and waits for the spawned process to be alive — for NemoClaw sandbox plists that means a 30-50s ``docker exec <container> kubectl exec ...`` handshake per plist, so the foreground loop ate 60-100s of dead time the user couldn't see.

## Fix

1. **Background launchd kicks** with ``( ... ) &`` + ``disown -a`` so install.sh returns immediately. Kicks complete in the background; the kernel reparents them to launchd.
2. **Background systemd restart** on Linux with ``systemctl --user restart --no-block``.
3. **Drop ``sleep 1``** after ``pkill -f clawmetry.sync``.
4. **Move DuckDB lock retry** into ``local_store._open_connection`` (5 × 0.5s on ``Conflicting lock``). install.sh no longer babysits the kernel's lock release; the daemon owns it.

## 3-run timing report

```
$ for i in 1 2 3; do
    rm -rf /tmp/cm-bench-fixed-$i
    CLAWMETRY_SKIP_ONBOARD=1 INSTALL_DIR=/tmp/cm-bench-fixed-$i \
      BIN_DIR=/tmp/cm-bench-fixed-$i-bin time bash install.sh < /dev/null \
      > /tmp/install-fixed-$i.out 2>&1
    grep "installed" /tmp/install-fixed-$i.out
  done

run 1: ✓ ClawMetry 0.12.186 installed (1s total)
run 2: ✓ ClawMetry 0.12.186 installed (1s total)
run 3: ✓ ClawMetry 0.12.186 installed (0s total)
```

**Median: 1s, max: 1s** — well under the 10s target.

## Why fire-and-forget is safe

- install.sh's job is to put fresh files on disk and update plists/units. The daemon respawn is best-effort, exactly like ``apt install``'s post-install hook for a systemd service.
- The ``com.clawmetry.dashboard`` plist (the user-facing surface) restarts in <1s — the dashboard is responsive immediately. The slow plists are sandbox sync daemons whose work is invisible to the user (they upload data into the cloud).
- DuckDB lock-contention is now retried inside ``_open_connection`` with a 2.5s budget, so the freshly-spawned daemon doesn't immediately error out if it races a dying sibling.
- Failures during background kicks were never surfaced anyway (``|| true``), so we lose zero diagnostic signal.

## Daemon recovery verification

After the fixed install.sh exited (1s), I confirmed:

```
$ launchctl print "gui/$UID/com.clawmetry.dashboard" | grep state
    state = running

$ curl -sS -m 3 -o /dev/null -w "HTTP %{http_code} in %{time_total}s\n" http://localhost:8900/
HTTP 200 in 0.053768s
```

Dashboard back online in seconds, serving HTTP 200 in 53ms. The two sandbox plists were ``state = spawn scheduled`` (still completing docker exec in the background — same wall time as before, just no longer blocking the user).

## Test plan

- [x] ``bash -n install.sh`` passes
- [x] ``python3 -c "from clawmetry import local_store; local_store._open_connection().close()"`` works
- [x] 3 clean install runs all complete in ≤1s
- [x] Dashboard plist returns to ``state = running`` and serves HTTP 200 within seconds of exit
- [x] No new dependencies (no ``gtimeout``, no ``parallel`` — just bash builtins)
- [x] Existing ``✓`` / ``→`` labels still show with elapsed time via ``_step``
- [x] Final ``installed (Xs total)`` line reflects the real (now small) wall clock

🤖 Generated with [Claude Code](https://claude.com/claude-code)