### PR TITLE
fix(install): early-exit when version current and daemon healthy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,21 @@ case "$OS" in
     echo -e "${RED}  ✗ Unsupported OS: $OS (macOS and Linux only)${NC}"
     exit 1
     ;;
-esac
+esac 
+
+# ── Early exit: already up to date ──────────────────────────────────────────
+if [ -x "$INSTALL_DIR/bin/clawmetry" ]; then
+  _CURRENT=$("$INSTALL_DIR/bin/clawmetry" --version 2>/dev/null | awk '{print $NF}')
+  _LATEST=$("$INSTALL_DIR/bin/python3" -c "
+import json, urllib.request
+r = urllib.request.urlopen('https://pypi.org/pypi/clawmetry/json')
+print(json.loads(r.read())['info']['version'])
+" 2>/dev/null)
+  if [ -n "$_CURRENT" ] && [ "$_CURRENT" = "$_LATEST" ] && [ -n "$_existing_pids" ]; then
+    echo -e "  ${GREEN}${BOLD}✓ ClawMetry $_CURRENT already up to date${NC}"
+    exit 0
+  fi
+fi
 
 # ── Install into venv ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #1219. Adds an early-exit at the top of `install.sh` when clawmetry is already at the latest version with a healthy daemon, avoiding ~15s of unnecessary work on re-runs.

## Implementation note

The issue proposed using `jq` to parse PyPI's JSON, but `jq` isn't a dependency elsewhere in the script — requiring it would break fresh installs on machines without it. I used the venv's own Python with `urllib.request` instead: no new dependencies, and we're guaranteed Python exists because that's what clawmetry runs on at `$INSTALL_DIR/bin/python3`.

## Acceptance criteria

- [x] Re-running install with current version + healthy daemon → fast-exit with "already up to date" line (logic verified, see below)
- [x] Stale-version case still goes through the full upgrade path (early-exit fails the `$_CURRENT = $_LATEST` check)
- [x] Daemon-not-running case still goes through full install (early-exit fails the `-n "$_existing_pids"` check)
- [ ] CI matrix entry — happy to add in a follow-up PR once this approach is validated

## Verification

I verified the following on my local machine:

- `$INSTALL_DIR/bin/python3 -c "import json, urllib.request; ..."` returns the correct version from PyPI (`0.12.187`)
- The same fetch via `curl -sf https://pypi.org/pypi/clawmetry/json | python3 -c "..."` also returns `0.12.187` (sanity check)
- `$_existing_pids` is populated at `install.sh:117`, well before the insertion point at `install.sh:171`
- `name="clawmetry"` confirmed in `setup.py`, matching the PyPI URL used in the snippet

## Testing limitation

I wasn't able to run a full end-to-end install locally — `uv` hung on the initial PyPI fetch at >12 minutes (network routing issue on my end between my ISP and PyPI's CDN, unrelated to this change). The version-detection logic is verified working in isolation, but I'd appreciate maintainer or CI validation of the three runtime scenarios end-to-end before merging.

Happy to iterate on anything.