### PR TITLE
[RELEASE] feat(sync): walk OpenClaw sessions.json → claude-cli sessions + subagents + tool-results (closes #1226)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2666,7 +2666,14 @@ def _openclaw_claude_session_offset_key(jsonl_path: str) -> str:
 
 
 def _translate_claude_session_line(
-    obj: dict, *, session_id: str, node_id: str, line_no: int,
+    obj: dict,
+    *,
+    session_id: str,
+    node_id: str,
+    line_no: int,
+    openclaw_session_id: str | None = None,
+    kind: str = "top",
+    subagent_file: str | None = None,
 ) -> dict | None:
     """Map a Claude Code session JSONL line onto an ``events`` row.
 
@@ -2674,18 +2681,32 @@ def _translate_claude_session_line(
     non-dict). Never raises.
 
     Field mapping:
-      * ``id``         ← ``f"openclaw-cc:{session_id}:{uuid_or_lineno}"``
+      * ``id``         ← ``f"openclaw-cc:{join_id}:{kind}:{uuid_or_lineno}"``
+                         where ``join_id`` is the OpenClaw session UUID
+                         when provided (sessions.json walk path) or the
+                         Claude Code session UUID (process-inspection
+                         fallback path).
       * ``agent_type`` ← ``"openclaw"`` (so Brain's per-agent filters
                          still match — this transcript belongs to the
                          OpenClaw agent that spawned the claude CLI)
       * ``agent_id``   ← ``"main"``
-      * ``session_id`` ← Claude Code session UUID (from filename)
+      * ``session_id`` ← OpenClaw session UUID when ``openclaw_session_id``
+                         is set (so the ``sessions`` table row written by
+                         the sessions.json walk joins to these events).
+                         Falls back to the Claude Code session UUID for
+                         the process-inspection path which doesn't know
+                         about the OpenClaw binding (closes #1226).
       * ``event_type`` ← Claude Code ``type`` field (user / assistant /
-                         system / queue-operation / attachment / …)
+                         system / queue-operation / attachment / …) —
+                         subagent rows are prefixed ``subagent:`` so
+                         Brain can render them under a sub-agent lane.
       * ``ts``         ← Claude Code ``timestamp``
       * ``data``       ← the full JSON line (verbatim — Brain's
                          ``_extract_brain_detail`` walks several
-                         alternative paths to find the rendered text)
+                         alternative paths to find the rendered text).
+                         The Claude Code session UUID is also embedded
+                         here as ``_claude_session_id`` for cross-ref
+                         and debugging without a schema bump (#1226).
 
     Cost / token / model fields ride along when the line carries them
     (assistant messages with ``message.usage.*``); legacy
@@ -2697,20 +2718,38 @@ def _translate_claude_session_line(
     if not ts:
         return None
     evt_type = str(obj.get("type") or "unknown")
+    if kind == "subagent":
+        evt_type = f"subagent:{evt_type}"
     # Stable id: prefer Claude Code's ``uuid`` / ``id``; otherwise compose
-    # from session+line so re-reads after a state-loss don't dupe.
+    # from session+line so re-reads after a state-loss don't dupe. When
+    # this line is from a subagent file, scope the id with the file basename
+    # so the same uuid/line-number across multiple subagents stays unique.
     eid_inner = obj.get("uuid") or obj.get("id") or f"line:{line_no}"
+    if subagent_file:
+        eid_inner = f"{subagent_file}:{eid_inner}"
+    join_id = openclaw_session_id or session_id
     cost_usd, token_count, model = _extract_cost_tokens_model(obj)
+    # Embed cross-ref metadata in data so Brain / debugging can correlate
+    # the OpenClaw side ↔ Claude CLI side without a schema change. We copy
+    # the dict so we don't mutate the caller's parsed line.
+    out_data = dict(obj)
+    out_data["_claude_session_id"] = session_id
+    if openclaw_session_id:
+        out_data["_openclaw_session_id"] = openclaw_session_id
+    if kind != "top":
+        out_data["_oc_cc_kind"] = kind
+    if subagent_file:
+        out_data["_subagent_file"] = subagent_file
     return {
-        "id": f"openclaw-cc:{session_id}:{eid_inner}",
+        "id": f"openclaw-cc:{join_id}:{kind}:{eid_inner}",
         "node_id": node_id,
         "agent_type": "openclaw",
         "agent_id": "main",
-        "session_id": session_id,
+        "session_id": join_id,
         "workspace_id": obj.get("cwd") or obj.get("workspace_id"),
         "event_type": evt_type,
         "ts": str(ts),
-        "data": obj,
+        "data": out_data,
         "cost_usd": cost_usd,
         "token_count": token_count,
         "model": model,
@@ -2727,10 +2766,24 @@ def sync_openclaw_claude_sessions(
     config: dict | None,
     state: dict,
     paths: dict | None = None,
+    skip_claude_ids: set[str] | None = None,
 ) -> int:
     """Discover OpenClaw-spawned ``claude`` CLI session files via process
     inspection and tail their newly-appended bytes into the local DuckDB
     ``events`` table.
+
+    SECONDARY discovery path. The PRIMARY path is
+    :func:`sync_openclaw_claude_sessions_via_index`, which walks
+    ``sessions.json`` and follows the ``claudeCliSessionId`` binding.
+    This function only fires for sessions whose binding hasn't been
+    written to ``sessions.json`` yet (e.g. mid-session, or after a
+    crash that lost the binding) — exactly the historical failure
+    mode PR #1224 was designed to catch.
+
+    ``skip_claude_ids`` lets the caller suppress sessions already
+    handled by the index path so we don't double-write rows. The
+    events PRIMARY KEY would dedup them anyway, but skipping saves
+    the file IO.
 
     Returns the number of events ingested this call. Designed to be
     called once per daemon sync cycle. All failure modes are swallowed
@@ -2772,6 +2825,13 @@ def sync_openclaw_claude_sessions(
         return 0
     if not targets:
         return 0
+    if skip_claude_ids:
+        targets = [
+            (sid, p) for (sid, p) in targets
+            if sid not in skip_claude_ids
+        ]
+        if not targets:
+            return 0
 
     offsets: dict = state.setdefault("claude_session_byte_offsets", {})
     rows: list[dict] = []
@@ -2854,6 +2914,492 @@ def sync_openclaw_claude_sessions(
             ", ".join(os.path.basename(p) for p in files_touched),
         )
     return len(rows)
+
+
+# ── Sync: OpenClaw → Claude Code sessions via sessions.json (PR #1226) ───────
+#
+# PRIMARY discovery path. Reads ``~/.openclaw/agents/main/sessions/sessions.json``
+# (the same index sync_claude_cli_sessions reads for the cloud-stream path)
+# and follows ``cliSessionIds.claude-cli`` (or legacy ``claudeCliSessionId``)
+# into ``~/.claude/projects/<encoded-cwd>/`` to capture three classes of files:
+#
+#   1. <claude-id>.jsonl                   — top-level transcript
+#   2. <claude-id>/subagents/*.jsonl       — sub-agent transcripts
+#   3. <claude-id>/tool-results/*          — tool-result dumps (opaque text)
+#
+# All three classes write into the local DuckDB ``events`` table keyed under
+# the OpenClaw session UUID (NOT the Claude Code UUID). Plus we upsert one row
+# into ``sessions`` per OpenClaw session so the typed-session view in
+# ``query_sessions_table`` joins against these events.
+#
+# Why this exists: PR #1224 wired up process-inspection discovery and tagged
+# events under the Claude UUID. Brain's join queries miss those rows, and
+# sub-agent transcripts + tool-results were never captured at all. Diya
+# (OpenClaw's bot) flagged these three gaps explicitly when verifying the
+# install. This PR closes them.
+#
+# Diya's diagnosis (verbatim from the user):
+#   "Sub-agent transcripts and large tool outputs live at
+#    49f1d9fc-.../subagents/ and 49f1d9fc-.../tool-results/ — alongside the
+#    top-level transcript."
+#   "It needs to follow claudeCliSessionId into ~/.claude/projects/ to get
+#    the real conversation."
+#   "sessions.json lists a sessionFile at ~/.openclaw/agents/main/sessions/
+#    625c0ad9-….jsonl, but I checked: that file does not exist. The generic
+#    OpenClaw write path only runs when OpenClaw uses its built-in agent
+#    loop. With the Claude CLI provider, that path is bypassed and the CLI
+#    owns the transcript."
+
+# Hard cap on tool-result body length stored in `data` (truncated). We
+# don't want a 1 MB grep dump occupying a single row.
+_OC_CC_TOOL_RESULT_MAX_BYTES = 64 * 1024
+
+# Cap on number of tool-result files ingested per session per cycle, so a
+# fresh discovery of a 100-file dir doesn't stall the cycle.
+_OC_CC_MAX_TOOL_RESULTS_PER_CYCLE = 200
+
+# Cap on number of subagent files inspected per session per cycle.
+_OC_CC_MAX_SUBAGENT_FILES_PER_CYCLE = 50
+
+
+def _walk_openclaw_session_bindings(sessions_dir: str) -> list[dict]:
+    """Read ``~/.openclaw/agents/main/sessions/sessions.json`` and return one
+    binding dict per session that has a Claude CLI binding. Each dict has:
+
+      * ``key``                — sessions.json top-level key (e.g. ``agent:main:main``)
+      * ``openclaw_session_id`` — the OpenClaw session UUID
+      * ``claude_session_id``  — the Claude Code session UUID
+      * ``workspace_dir``      — the agent CWD (from systemPromptReport)
+      * ``title``              — origin.label / chatType / key (best-effort)
+      * ``started_at``         — ISO ts (from sessionStartedAt or startedAt)
+      * ``last_active_at``     — ISO ts (from lastInteractionAt or updatedAt)
+      * ``status``             — sessions.json ``status`` field, default 'active'
+      * ``origin``             — full origin dict (for metadata)
+
+    Returns ``[]`` if the index doesn't exist or can't be parsed. Never
+    raises — best-effort observability.
+    """
+    if not sessions_dir:
+        return []
+    index_path = os.path.join(sessions_dir, "sessions.json")
+    if not os.path.isfile(index_path):
+        return []
+    try:
+        with open(index_path) as fi:
+            idx = json.load(fi)
+    except Exception:
+        return []
+    if not isinstance(idx, dict):
+        return []
+    out: list[dict] = []
+    for key, meta in idx.items():
+        if not isinstance(meta, dict):
+            continue
+        cli_id = meta.get("claudeCliSessionId") or (
+            meta.get("cliSessionIds", {}) or {}
+        ).get("claude-cli")
+        if not cli_id:
+            continue
+        oc_id = meta.get("sessionId")
+        if not oc_id:
+            continue
+        # workspace_dir comes from systemPromptReport.workspaceDir (the CLI's
+        # cwd). When that's missing — e.g. a pre-systemPromptReport session
+        # written by an older OpenClaw — fall back to the OpenClaw default
+        # workspace, which is the only CWD the user has anyway.
+        sp = meta.get("systemPromptReport") or {}
+        workspace = sp.get("workspaceDir") or os.path.join(
+            _get_openclaw_dir(), "workspace",
+        )
+        # Title: origin.label > chatType > key — Brain renders this in the
+        # session list so an empty string is jarring.
+        origin = meta.get("origin") or {}
+        title = (
+            origin.get("label")
+            or meta.get("chatType")
+            or key
+        )
+        # Convert ms-epoch fields to ISO so downstream renderers don't have
+        # to special-case sessions vs events. sessionStartedAt is the canonical
+        # name; older OpenClaw used startedAt.
+        def _iso(ms_or_iso):
+            if not ms_or_iso:
+                return None
+            if isinstance(ms_or_iso, (int, float)):
+                try:
+                    return datetime.fromtimestamp(
+                        ms_or_iso / 1000.0, tz=timezone.utc,
+                    ).isoformat().replace("+00:00", "Z")
+                except (ValueError, OSError):
+                    return None
+            return str(ms_or_iso)
+
+        out.append({
+            "key": key,
+            "openclaw_session_id": str(oc_id),
+            "claude_session_id": str(cli_id),
+            "workspace_dir": workspace,
+            "title": str(title)[:200] if title else key,
+            "started_at": _iso(
+                meta.get("sessionStartedAt") or meta.get("startedAt"),
+            ),
+            "last_active_at": _iso(
+                meta.get("lastInteractionAt") or meta.get("updatedAt"),
+            ),
+            "status": meta.get("status") or "active",
+            "origin": origin,
+            "channel": (
+                origin.get("provider")
+                or meta.get("lastChannel")
+                or (meta.get("deliveryContext") or {}).get("channel")
+            ),
+            "chat_type": meta.get("chatType"),
+        })
+    return out
+
+
+def _claude_session_dir(workspace_dir: str, claude_session_id: str) -> Path:
+    """Return ``~/.claude/projects/<encoded-cwd>/<claude-session-id>/`` —
+    the directory that holds the subagents/ and tool-results/ subdirs.
+    """
+    slug = _encode_cwd_for_claude_projects(workspace_dir)
+    return _claude_projects_root() / slug / claude_session_id
+
+
+def _claude_session_top_level_path(
+    workspace_dir: str, claude_session_id: str,
+) -> Path:
+    """Return the top-level ``<claude-id>.jsonl`` path."""
+    slug = _encode_cwd_for_claude_projects(workspace_dir)
+    return _claude_projects_root() / slug / f"{claude_session_id}.jsonl"
+
+
+def _upsert_openclaw_session_row(binding: dict, node_id: str) -> None:
+    """Upsert a row into the typed ``sessions`` table for an OpenClaw session,
+    keyed by the OpenClaw session UUID. Best-effort — failures are logged
+    and swallowed so observability doesn't block ingest.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+    except Exception as e:
+        log.debug("openclaw-cc upsert_session: store unavailable: %s", e)
+        return
+    try:
+        store.ingest_session({
+            "agent_type": "openclaw",
+            "session_id": binding["openclaw_session_id"],
+            "node_id": node_id,
+            "agent_id": "main",
+            "workspace_id": binding.get("workspace_dir"),
+            "title": binding.get("title"),
+            "started_at": binding.get("started_at"),
+            "last_active_at": binding.get("last_active_at"),
+            "status": binding.get("status") or "active",
+            "metadata": {
+                "claude_session_id": binding.get("claude_session_id"),
+                "key": binding.get("key"),
+                "origin": binding.get("origin"),
+                "channel": binding.get("channel"),
+                "chat_type": binding.get("chat_type"),
+            },
+        })
+    except Exception as e:
+        log.debug("openclaw-cc upsert_session failed (non-fatal): %s", e)
+    # Also write the openclaw_channels row so the channel pill renders.
+    if binding.get("channel") or binding.get("origin"):
+        try:
+            origin = binding.get("origin") or {}
+            store.ingest_channel({
+                "session_id": binding["openclaw_session_id"],
+                "channel": binding.get("channel"),
+                "chat_type": binding.get("chat_type"),
+                "subject": origin.get("label"),
+                "origin_label": origin.get("label"),
+            })
+        except Exception as e:
+            log.debug("openclaw-cc ingest_channel failed (non-fatal): %s", e)
+
+
+def _ingest_jsonl_file_tail(
+    jsonl_path: str,
+    *,
+    state: dict,
+    node_id: str,
+    claude_session_id: str,
+    openclaw_session_id: str | None,
+    kind: str,
+    subagent_file: str | None,
+) -> tuple[list[dict], int]:
+    """Tail a JSONL file by byte offset and translate each new line into
+    an events row. Returns ``(rows, lines_read)``. State is updated in-place.
+
+    Shared between top-level and subagent file ingestion. Idempotent —
+    re-reads emit identical row ids that hit the events PRIMARY KEY.
+    """
+    offsets: dict = state.setdefault("claude_session_byte_offsets", {})
+    key = _openclaw_claude_session_offset_key(jsonl_path)
+    rows: list[dict] = []
+    try:
+        cur_size = os.path.getsize(jsonl_path)
+    except OSError:
+        return rows, 0
+    last_off = int(offsets.get(key, 0) or 0)
+    if last_off > cur_size:
+        last_off = 0
+    if last_off >= cur_size:
+        offsets[key] = cur_size
+        return rows, 0
+    try:
+        with open(jsonl_path, "rb") as f:
+            f.seek(last_off)
+            lines_read = 0
+            buf_lines: list[str] = []
+            for raw in f:
+                lines_read += 1
+                if lines_read > _OC_CC_MAX_LINES_PER_FILE_PER_CYCLE:
+                    break
+                buf_lines.append(raw.decode("utf-8", errors="replace"))
+            new_off = f.tell()
+    except OSError as e:
+        log.debug("openclaw-cc read error %s (non-fatal): %s", jsonl_path, e)
+        return rows, 0
+    for i, raw_line in enumerate(buf_lines):
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        try:
+            obj = json.loads(stripped)
+        except Exception:
+            continue
+        row = _translate_claude_session_line(
+            obj,
+            session_id=claude_session_id,
+            node_id=node_id,
+            line_no=last_off + i,
+            openclaw_session_id=openclaw_session_id,
+            kind=kind,
+            subagent_file=subagent_file,
+        )
+        if row is not None:
+            rows.append(row)
+    offsets[key] = new_off
+    return rows, len(buf_lines)
+
+
+def _ingest_tool_result_files(
+    tool_results_dir: Path,
+    *,
+    state: dict,
+    node_id: str,
+    claude_session_id: str,
+    openclaw_session_id: str,
+) -> list[dict]:
+    """Translate each tool-result file under ``<claude-id>/tool-results/`` into
+    one events row. Tool-results are arbitrary text dumps (the on-disk shape
+    Claude Code uses for large grep / WebFetch / Read outputs that don't fit
+    inline in the transcript). Each file's basename is its stable id, so we
+    dedup by (session, basename) regardless of size or content.
+
+    State tracks per-file mtime; we re-read only on mtime bump (or on first
+    discovery). The body is truncated to ``_OC_CC_TOOL_RESULT_MAX_BYTES``
+    so the row stays small — full dumps live on disk anyway.
+    """
+    rows: list[dict] = []
+    if not tool_results_dir.is_dir():
+        return rows
+    seen_mtimes: dict = state.setdefault("claude_tool_result_mtimes", {})
+    try:
+        entries = list(tool_results_dir.iterdir())
+    except OSError:
+        return rows
+    # Cap so a freshly populated dir doesn't stall the cycle.
+    entries.sort(key=lambda p: p.name)
+    if len(entries) > _OC_CC_MAX_TOOL_RESULTS_PER_CYCLE:
+        entries = entries[:_OC_CC_MAX_TOOL_RESULTS_PER_CYCLE]
+    for entry in entries:
+        try:
+            if not entry.is_file():
+                continue
+            mtime = entry.stat().st_mtime
+        except OSError:
+            continue
+        seen_key = f"{claude_session_id}:{entry.name}"
+        if seen_mtimes.get(seen_key) == mtime:
+            continue
+        # Read up to the truncation cap so we never DoS ourselves on a
+        # multi-MB grep result. Beyond the cap we record metadata only.
+        try:
+            with open(entry, "rb") as f:
+                head_bytes = f.read(_OC_CC_TOOL_RESULT_MAX_BYTES + 1)
+        except OSError:
+            continue
+        truncated = len(head_bytes) > _OC_CC_TOOL_RESULT_MAX_BYTES
+        body = head_bytes[:_OC_CC_TOOL_RESULT_MAX_BYTES].decode(
+            "utf-8", errors="replace",
+        )
+        try:
+            size = entry.stat().st_size
+        except OSError:
+            size = len(head_bytes)
+        ts_iso = datetime.fromtimestamp(
+            mtime, tz=timezone.utc,
+        ).isoformat().replace("+00:00", "Z")
+        rows.append({
+            "id": (
+                f"openclaw-cc:{openclaw_session_id}:tool-result:{entry.name}"
+            ),
+            "node_id": node_id,
+            "agent_type": "openclaw",
+            "agent_id": "main",
+            "session_id": openclaw_session_id,
+            "workspace_id": None,
+            "event_type": "tool-result",
+            "ts": ts_iso,
+            "data": {
+                "_claude_session_id": claude_session_id,
+                "_openclaw_session_id": openclaw_session_id,
+                "_oc_cc_kind": "tool-result",
+                "filename": entry.name,
+                "size_bytes": size,
+                "truncated": truncated,
+                "body": body,
+            },
+            "cost_usd": None,
+            "token_count": None,
+            "model": None,
+        })
+        seen_mtimes[seen_key] = mtime
+    return rows
+
+
+def sync_openclaw_claude_sessions_via_index(
+    config: dict | None,
+    state: dict,
+    paths: dict | None = None,
+) -> tuple[int, set[str]]:
+    """Primary discovery path: walk OpenClaw's sessions.json and tail the
+    top-level + subagent + tool-result files Claude Code wrote for each
+    bound session.
+
+    Returns ``(events_ingested, claude_ids_handled)``. The second tuple
+    element is consumed by the process-inspection fallback so it can skip
+    sessions we've already covered here.
+
+    Default: ON. Same escape hatch as the process-inspection path
+    (``CLAWMETRY_DISABLE_CLAUDE_SESSION_INGEST=1``).
+    """
+    if os.environ.get("CLAWMETRY_DISABLE_CLAUDE_SESSION_INGEST", "").strip() in (
+        "1", "true", "yes", "on",
+    ):
+        return 0, set()
+    try:
+        if not _sync_allowed():
+            return 0, set()
+    except Exception:
+        pass
+
+    node_id = (config or {}).get("node_id") or "local"
+    paths = paths or {}
+    sessions_dir = paths.get("sessions_dir") or os.path.join(
+        _get_openclaw_dir(), "agents", "main", "sessions",
+    )
+    bindings = _walk_openclaw_session_bindings(sessions_dir)
+    if not bindings:
+        return 0, set()
+
+    rows: list[dict] = []
+    handled: set[str] = set()
+    files_touched: list[str] = []
+    sessions_upserted: list[str] = []
+
+    for binding in bindings:
+        claude_id = binding["claude_session_id"]
+        oc_id = binding["openclaw_session_id"]
+        workspace = binding["workspace_dir"]
+
+        top_path = _claude_session_top_level_path(workspace, claude_id)
+        sess_dir = _claude_session_dir(workspace, claude_id)
+        # If neither the top-level file nor the subdir exists, this binding
+        # points at a Claude session that hasn't started writing — skip it
+        # this cycle, the daemon will re-check next cycle.
+        if not top_path.is_file() and not sess_dir.is_dir():
+            continue
+
+        # Always upsert the sessions row first so even an empty / not-yet-
+        # written top-level file produces a renderable session in the UI.
+        # Idempotent (ON CONFLICT DO UPDATE).
+        _upsert_openclaw_session_row(binding, node_id)
+        sessions_upserted.append(oc_id)
+        handled.add(claude_id)
+
+        # 1. Top-level transcript
+        if top_path.is_file():
+            top_rows, _ = _ingest_jsonl_file_tail(
+                str(top_path),
+                state=state,
+                node_id=node_id,
+                claude_session_id=claude_id,
+                openclaw_session_id=oc_id,
+                kind="top",
+                subagent_file=None,
+            )
+            if top_rows:
+                rows.extend(top_rows)
+                files_touched.append(str(top_path))
+
+        # 2. Sub-agent transcripts — one JSONL per spawned sub-agent.
+        subagents_dir = sess_dir / "subagents"
+        if subagents_dir.is_dir():
+            try:
+                sub_files = sorted(subagents_dir.glob("*.jsonl"))
+            except OSError:
+                sub_files = []
+            if len(sub_files) > _OC_CC_MAX_SUBAGENT_FILES_PER_CYCLE:
+                sub_files = sub_files[:_OC_CC_MAX_SUBAGENT_FILES_PER_CYCLE]
+            for sub_path in sub_files:
+                sub_rows, _ = _ingest_jsonl_file_tail(
+                    str(sub_path),
+                    state=state,
+                    node_id=node_id,
+                    claude_session_id=claude_id,
+                    openclaw_session_id=oc_id,
+                    kind="subagent",
+                    subagent_file=sub_path.stem,
+                )
+                if sub_rows:
+                    rows.extend(sub_rows)
+                    files_touched.append(str(sub_path))
+
+        # 3. Tool-result dumps — one event per file, dedup by mtime.
+        tool_dir = sess_dir / "tool-results"
+        tr_rows = _ingest_tool_result_files(
+            tool_dir,
+            state=state,
+            node_id=node_id,
+            claude_session_id=claude_id,
+            openclaw_session_id=oc_id,
+        )
+        if tr_rows:
+            rows.extend(tr_rows)
+            files_touched.append(str(tool_dir))
+
+    if rows:
+        try:
+            from clawmetry import local_store
+            local_store.get_store().ingest_many(rows)
+        except Exception as e:
+            log.warning(
+                "openclaw-cc-index local-store ingest failed (non-fatal): %s", e,
+            )
+            return 0, handled
+
+    if rows or sessions_upserted:
+        log.debug(
+            "openclaw-cc-index: %d events / %d sessions / %d files",
+            len(rows), len(sessions_upserted), len(files_touched),
+        )
+    return len(rows), handled
 
 
 # ── Sync: channel-adapter transcripts (Telegram, Signal, WhatsApp, …) ────────
@@ -7063,17 +7609,37 @@ def run_daemon() -> None:
 
             ev = sync_sessions(config, state, paths)
             ev += sync_claude_cli_sessions(config, state, paths)
-            # Process-discovered Claude Code session JSONLs (PR
-            # release/openclaw-claude-session-ingest, 2026-05-14). The legacy
-            # ``sync_claude_cli_sessions`` above only fires when
-            # ``sessions.json`` carries the ``claudeCliSessionId`` binding —
-            # any session started before OpenClaw wrote that binding (or where
-            # the binding was lost on a crash) is invisible to it. This
-            # complementary path inspects running ``claude`` subprocesses
-            # directly and tails their session files, so capture is
-            # independent of OpenClaw's index. Failure is non-fatal.
+            # PRIMARY: walk OpenClaw's sessions.json → ``cliSessionIds.claude-cli``
+            # → ``~/.claude/projects/<encoded-cwd>/<id>.jsonl`` plus subagents/
+            # and tool-results/. Tags events under the OpenClaw session UUID
+            # and upserts a ``sessions`` row so the typed-session view joins.
+            # Closes #1226 — the P0 follow-up to PR #1224. Failure is
+            # non-fatal: the next cycle will retry from the saved offset.
+            handled_claude_ids: set[str] = set()
             try:
-                oc_cc = sync_openclaw_claude_sessions(config, state, paths)
+                oc_cc_idx, handled_claude_ids = (
+                    sync_openclaw_claude_sessions_via_index(
+                        config, state, paths,
+                    )
+                )
+                ev += oc_cc_idx
+            except Exception as _occ_idx_e:
+                log.debug(
+                    "openclaw-cc-index sync error (non-fatal): %s",
+                    _occ_idx_e,
+                )
+                oc_cc_idx = 0
+            # SECONDARY: process-discovered Claude Code session JSONLs (PR
+            # #1224, 2026-05-14). Catches sessions whose binding hasn't been
+            # written to sessions.json yet — e.g. a brand-new session
+            # mid-spawn, or one whose binding was lost on a crash. Skip
+            # sessions already handled by the index path above so we don't
+            # double-process. Failure is non-fatal.
+            try:
+                oc_cc = sync_openclaw_claude_sessions(
+                    config, state, paths,
+                    skip_claude_ids=handled_claude_ids,
+                )
                 ev += oc_cc
             except Exception as _occ_e:
                 log.debug(

--- a/tests/test_openclaw_sessions_followup.py
+++ b/tests/test_openclaw_sessions_followup.py
@@ -1,0 +1,527 @@
+"""Tests for the sessions.json walk path (PR closes #1226).
+
+These tests cover the three gaps Diya (OpenClaw's bot) flagged when
+verifying PR #1224 on the user's live install:
+
+  1. Sub-agent transcripts under ``<claude-id>/subagents/*.jsonl`` were
+     never captured — the process-inspection path only watched the
+     top-level ``<claude-id>.jsonl``.
+  2. Tool-result dumps under ``<claude-id>/tool-results/*`` were never
+     captured.
+  3. Discovery itself was fragile — process inspection misses any
+     session whose ``claude`` subprocess isn't currently running. The
+     primary path now reads sessions.json directly.
+
+The new ``sync_openclaw_claude_sessions_via_index`` function:
+  * walks ``~/.openclaw/agents/main/sessions/sessions.json``
+  * follows ``cliSessionIds.claude-cli`` → Claude Code session UUID
+  * tails the top-level transcript + every subagents/*.jsonl
+  * ingests one event per tool-results/* file
+  * tags events under the OpenClaw session UUID (NOT the Claude UUID)
+  * upserts one row into the ``sessions`` table per OpenClaw session
+
+so Brain's join-style reads find the session row and render it under
+the right session-list entry.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def sync_with_isolated_store(tmp_path, monkeypatch):
+    """Reload sync + local_store with an isolated DuckDB per test.
+
+    Mirrors the fixture in test_openclaw_claude_session_ingest.py so
+    test isolation matches PR #1224's existing tests.
+    """
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH",
+        str(tmp_path / "events.duckdb"),
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.delenv("CLAWMETRY_DISABLE_CLAUDE_SESSION_INGEST", raising=False)
+    # Point ``~/.claude/projects`` and ``~/.openclaw`` at temp dirs so this
+    # test never touches the user's real installation.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(fake_home / ".claude"))
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(fake_home / ".openclaw"))
+    import clawmetry.local_store as ls
+    import clawmetry.sync as sync
+    importlib.reload(ls)
+    importlib.reload(sync)
+    yield sync, ls, fake_home
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait_for_flush(store, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+    raise AssertionError("flusher did not drain in time")
+
+
+# ── Synthetic OpenClaw + Claude Code on-disk layout ─────────────────────────
+
+OPENCLAW_SESSION_ID = "625c0ad9-71af-4a56-9a3b-cab396860a85"  # Diya's session
+CLAUDE_SESSION_ID = "49f1d9fc-0848-4b6b-8fd7-64633bbc6b58"
+WORKSPACE_DIR = "/Users/test/.openclaw/workspace"
+ENCODED_CWD = "-Users-test--openclaw-workspace"  # the slug Claude Code uses
+
+SUBAGENT_FILE_STEM = "agent-a156b1052348a79c9"
+
+TOP_LEVEL_LINES = [
+    {
+        "type": "user",
+        "message": {"role": "user", "content": "hello, how are you?"},
+        "uuid": "evt-user-001",
+        "timestamp": "2026-05-14T20:12:45.580Z",
+        "cwd": WORKSPACE_DIR,
+        "sessionId": CLAUDE_SESSION_ID,
+    },
+    {
+        "type": "assistant",
+        "message": {
+            "model": "claude-opus-4-7",
+            "id": "msg_abc",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Doing well, thanks!"}],
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 12,
+                "totalTokens": 113,
+                "cost": {"total": 0.000456},
+            },
+        },
+        "uuid": "evt-asst-001",
+        "timestamp": "2026-05-14T20:12:50.000Z",
+        "sessionId": CLAUDE_SESSION_ID,
+    },
+]
+
+SUBAGENT_LINES = [
+    {
+        "parentUuid": None,
+        "isSidechain": True,
+        "type": "user",
+        "message": {"role": "user", "content": "Research TVK ideology"},
+        "uuid": "sub-evt-001",
+        "timestamp": "2026-05-13T04:26:13.458Z",
+        "sessionId": CLAUDE_SESSION_ID,
+        "agentId": "a156b1052348a79c9",
+    },
+    {
+        "type": "assistant",
+        "message": {
+            "model": "claude-opus-4-7",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "TVK was founded by..."}],
+            "usage": {"input_tokens": 1500, "output_tokens": 250, "totalTokens": 1750},
+        },
+        "uuid": "sub-evt-002",
+        "timestamp": "2026-05-13T04:26:30.000Z",
+        "sessionId": CLAUDE_SESSION_ID,
+    },
+]
+
+TOOL_RESULT_FILES = {
+    "bcdef74xu.txt": "file:line:matched-content for grep result\n" * 50,
+    "bg5hiof10.txt": "<html>fetched content</html>",
+}
+
+
+def _setup_layout(fake_home: Path) -> dict:
+    """Materialise the synthetic on-disk layout under the temp home dir.
+    Returns paths so individual tests can inspect them.
+    """
+    sessions_dir = fake_home / ".openclaw" / "agents" / "main" / "sessions"
+    sessions_dir.mkdir(parents=True)
+
+    # sessions.json — exactly the shape we observed on the user's box.
+    sessions_idx = {
+        "agent:main:telegram:direct:1532693273": {
+            "sessionId": OPENCLAW_SESSION_ID,
+            "claudeCliSessionId": CLAUDE_SESSION_ID,
+            "cliSessionIds": {"claude-cli": CLAUDE_SESSION_ID},
+            "sessionFile": str(
+                sessions_dir / f"{OPENCLAW_SESSION_ID}.jsonl"
+            ),
+            "chatType": "direct",
+            "sessionStartedAt": 1778320882571,
+            "lastInteractionAt": 1778790212965,
+            "status": "done",
+            "modelProvider": "claude-cli",
+            "origin": {
+                "label": "Vivek Chand id:1532693273",
+                "provider": "telegram",
+                "surface": "telegram",
+                "chatType": "direct",
+            },
+            "lastChannel": "telegram",
+            "deliveryContext": {"channel": "telegram"},
+            "systemPromptReport": {"workspaceDir": WORKSPACE_DIR},
+        },
+    }
+    (sessions_dir / "sessions.json").write_text(
+        json.dumps(sessions_idx),
+    )
+
+    # Top-level Claude Code transcript.
+    proj_dir = fake_home / ".claude" / "projects" / ENCODED_CWD
+    proj_dir.mkdir(parents=True)
+    top_path = proj_dir / f"{CLAUDE_SESSION_ID}.jsonl"
+    with open(top_path, "w") as f:
+        for obj in TOP_LEVEL_LINES:
+            f.write(json.dumps(obj) + "\n")
+
+    # Subagents subdirectory.
+    sess_dir = proj_dir / CLAUDE_SESSION_ID
+    sub_dir = sess_dir / "subagents"
+    sub_dir.mkdir(parents=True)
+    sub_path = sub_dir / f"{SUBAGENT_FILE_STEM}.jsonl"
+    with open(sub_path, "w") as f:
+        for obj in SUBAGENT_LINES:
+            f.write(json.dumps(obj) + "\n")
+
+    # Tool-results subdirectory.
+    tr_dir = sess_dir / "tool-results"
+    tr_dir.mkdir(parents=True)
+    for fname, body in TOOL_RESULT_FILES.items():
+        (tr_dir / fname).write_text(body)
+
+    return {
+        "sessions_dir": str(sessions_dir),
+        "top_path": top_path,
+        "sub_dir": sub_dir,
+        "sub_path": sub_path,
+        "tr_dir": tr_dir,
+    }
+
+
+def test_index_walk_ingests_top_subagent_and_tool_results(
+    sync_with_isolated_store,
+):
+    """End-to-end: sessions.json walk picks up all three classes (top-
+    level transcript + sub-agent transcript + tool-results) and writes
+    a sessions table row keyed by the OpenClaw UUID."""
+    sync, ls, fake_home = sync_with_isolated_store
+    layout = _setup_layout(fake_home)
+
+    state: dict = {}
+    ingested, handled = sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "node-test"},
+        state,
+        paths={"sessions_dir": layout["sessions_dir"]},
+    )
+
+    # 2 top-level lines + 2 subagent lines + 2 tool-results = 6 events.
+    assert ingested == 6, f"expected 6 events, got {ingested}"
+    # Handled set must contain the Claude UUID so the fallback path
+    # skips this session.
+    assert CLAUDE_SESSION_ID in handled
+
+    store = ls.get_store()
+    _wait_for_flush(store)
+
+    # All six rows are filed under the OpenClaw session UUID, NOT the
+    # Claude Code UUID. This is the key fix from #1226.
+    rows = store.query_events(session_id=OPENCLAW_SESSION_ID, limit=100)
+    assert len(rows) == 6, (
+        f"expected 6 events under OpenClaw UUID, got {len(rows)}"
+    )
+
+    # No events under the bare Claude UUID (the buggy state from #1226).
+    rows_bad = store.query_events(session_id=CLAUDE_SESSION_ID, limit=100)
+    assert len(rows_bad) == 0, (
+        "no events should be filed under the Claude UUID — that's the "
+        "bug #1226 closed"
+    )
+
+    # Each row's ``data`` blob carries the Claude UUID for cross-ref.
+    for r in rows:
+        data = r["data"]
+        if isinstance(data, str):
+            data = json.loads(data)
+        assert data.get("_claude_session_id") == CLAUDE_SESSION_ID, (
+            "every row must embed the Claude session UUID for traceability"
+        )
+        assert data.get("_openclaw_session_id") == OPENCLAW_SESSION_ID
+
+    # Sub-agent rows are typed with the ``subagent:`` prefix so Brain
+    # can lane them separately.
+    by_type: dict[str, int] = {}
+    for r in rows:
+        by_type[r["event_type"]] = by_type.get(r["event_type"], 0) + 1
+    assert by_type.get("subagent:user") == 1, by_type
+    assert by_type.get("subagent:assistant") == 1, by_type
+    assert by_type.get("user") == 1, by_type
+    assert by_type.get("assistant") == 1, by_type
+    assert by_type.get("tool-result") == 2, by_type
+
+
+def test_sessions_table_row_upserted_with_openclaw_uuid(
+    sync_with_isolated_store,
+):
+    """A row in the typed ``sessions`` table is keyed by the OpenClaw
+    session UUID and carries the title/started_at/status from the
+    sessions.json metadata. This is what closes the Brain join issue
+    in #1226."""
+    sync, ls, fake_home = sync_with_isolated_store
+    layout = _setup_layout(fake_home)
+
+    sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "node-test"},
+        {},
+        paths={"sessions_dir": layout["sessions_dir"]},
+    )
+
+    store = ls.get_store()
+    _wait_for_flush(store)
+
+    sessions = store.query_sessions_table(agent_type="openclaw", limit=20)
+    by_id = {s["session_id"]: s for s in sessions}
+    assert OPENCLAW_SESSION_ID in by_id, (
+        f"sessions table must contain a row for OpenClaw UUID "
+        f"{OPENCLAW_SESSION_ID}; got {list(by_id.keys())}"
+    )
+    row = by_id[OPENCLAW_SESSION_ID]
+    assert row["agent_type"] == "openclaw"
+    assert row["agent_id"] == "main"
+    # title pulled from origin.label
+    assert "Vivek Chand" in (row.get("title") or ""), row
+    # status mirrored from sessions.json
+    assert row["status"] == "done"
+    # message_count is computed-on-read against the events table — must
+    # see all six events filed under this session_id.
+    assert row["message_count"] == 6, row
+    # metadata includes the cross-ref to the Claude UUID
+    meta = row["metadata"] or {}
+    assert meta.get("claude_session_id") == CLAUDE_SESSION_ID, meta
+    assert meta.get("channel") == "telegram", meta
+
+
+def test_idempotent_on_re_run(sync_with_isolated_store):
+    """Calling the syncer twice with the same files → still 6 rows
+    (event PRIMARY KEY dedup)."""
+    sync, ls, fake_home = sync_with_isolated_store
+    layout = _setup_layout(fake_home)
+
+    for _ in range(2):
+        sync.sync_openclaw_claude_sessions_via_index(
+            {"node_id": "n"},
+            {},  # discard state to prove dedup is on the row id
+            paths={"sessions_dir": layout["sessions_dir"]},
+        )
+
+    store = ls.get_store()
+    _wait_for_flush(store)
+    rows = store.query_events(session_id=OPENCLAW_SESSION_ID, limit=100)
+    assert len(rows) == 6, f"expected 6 unique rows, got {len(rows)}"
+
+
+def test_offset_tracking_picks_up_only_new_top_level_lines(
+    sync_with_isolated_store,
+):
+    """Append a new line to the top-level transcript and re-run: only
+    the new line is ingested (byte-offset state survives across calls)."""
+    sync, ls, fake_home = sync_with_isolated_store
+    layout = _setup_layout(fake_home)
+    state: dict = {}
+
+    first, _ = sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "n"}, state,
+        paths={"sessions_dir": layout["sessions_dir"]},
+    )
+    assert first == 6
+
+    # Append a fresh user turn to the top-level file.
+    new_line = {
+        "type": "user",
+        "message": {"role": "user", "content": "follow-up"},
+        "uuid": "evt-user-002",
+        "timestamp": "2026-05-14T20:13:00.000Z",
+        "sessionId": CLAUDE_SESSION_ID,
+    }
+    with open(layout["top_path"], "a") as f:
+        f.write(json.dumps(new_line) + "\n")
+
+    second, _ = sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "n"}, state,
+        paths={"sessions_dir": layout["sessions_dir"]},
+    )
+    assert second == 1, f"expected 1 new row, got {second}"
+
+    store = ls.get_store()
+    _wait_for_flush(store)
+    rows = store.query_events(session_id=OPENCLAW_SESSION_ID, limit=100)
+    assert len(rows) == 7
+
+
+def test_skip_claude_ids_propagates_to_process_inspection(
+    sync_with_isolated_store,
+):
+    """The index path returns the set of Claude UUIDs it handled; the
+    process-inspection path must skip those so we don't double-write."""
+    sync, ls, fake_home = sync_with_isolated_store
+    layout = _setup_layout(fake_home)
+
+    _, handled = sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "n"}, {},
+        paths={"sessions_dir": layout["sessions_dir"]},
+    )
+    assert handled == {CLAUDE_SESSION_ID}
+
+    # Now feed those same Claude UUIDs to the process-inspection path
+    # via the skip set — it should short-circuit without touching the
+    # filesystem.
+    from unittest.mock import patch
+    with patch.object(
+        sync,
+        "_discover_openclaw_claude_session_files",
+        return_value=[(CLAUDE_SESSION_ID, str(layout["top_path"]))],
+    ) as mock_disc:
+        out = sync.sync_openclaw_claude_sessions(
+            {"node_id": "n"}, {},
+            paths={"sessions_dir": layout["sessions_dir"]},
+            skip_claude_ids=handled,
+        )
+    assert out == 0
+    mock_disc.assert_called_once()  # discovery still runs but is filtered
+
+
+def test_walk_handles_missing_sessions_json(sync_with_isolated_store):
+    """A fresh OpenClaw install with no sessions.json yet must not
+    crash the daemon — return (0, set())."""
+    sync, ls, fake_home = sync_with_isolated_store
+    # Don't call _setup_layout — sessions.json doesn't exist.
+    out, handled = sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "n"}, {}, paths={"sessions_dir": str(fake_home)},
+    )
+    assert out == 0
+    assert handled == set()
+
+
+def test_walk_handles_missing_claude_files(
+    sync_with_isolated_store,
+):
+    """sessions.json carries a binding but Claude Code hasn't started
+    writing yet (no top-level .jsonl, no subdir). Skip the binding
+    silently — next cycle will pick it up."""
+    sync, ls, fake_home = sync_with_isolated_store
+    # Materialise sessions.json but skip the projects/ tree entirely.
+    sessions_dir = fake_home / ".openclaw" / "agents" / "main" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "sessions.json").write_text(json.dumps({
+        "agent:main:main": {
+            "sessionId": OPENCLAW_SESSION_ID,
+            "claudeCliSessionId": CLAUDE_SESSION_ID,
+            "systemPromptReport": {"workspaceDir": WORKSPACE_DIR},
+        },
+    }))
+
+    out, handled = sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "n"}, {},
+        paths={"sessions_dir": str(sessions_dir)},
+    )
+    assert out == 0
+    # Skipped, not handled — we don't want the fallback path skipping
+    # this session either, since its claude process might be running.
+    assert handled == set()
+
+
+def test_tool_result_truncation_and_dedup(sync_with_isolated_store):
+    """A multi-MB tool-result file is truncated to the cap, and a
+    second pass on the same (mtime-stable) file does not re-emit."""
+    sync, ls, fake_home = sync_with_isolated_store
+    layout = _setup_layout(fake_home)
+    # Replace one tool-result with a >cap blob.
+    big_path = layout["tr_dir"] / "huge.txt"
+    cap = sync._OC_CC_TOOL_RESULT_MAX_BYTES
+    big_path.write_text("x" * (cap * 2))
+
+    state: dict = {}
+    first, _ = sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "n"}, state,
+        paths={"sessions_dir": layout["sessions_dir"]},
+    )
+    # 2 top + 2 subagent + 3 tool-results (2 original + 1 huge) = 7.
+    assert first == 7
+
+    # Re-run with the same state — tool-results should NOT re-emit
+    # because mtime hasn't changed.
+    second, _ = sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "n"}, state,
+        paths={"sessions_dir": layout["sessions_dir"]},
+    )
+    assert second == 0
+
+    store = ls.get_store()
+    _wait_for_flush(store)
+    rows = store.query_events(session_id=OPENCLAW_SESSION_ID, limit=100)
+    big_rows = [
+        r for r in rows
+        if r["event_type"] == "tool-result"
+        and "huge.txt" in (
+            (r["data"] if isinstance(r["data"], dict)
+             else json.loads(r["data"]))
+        ).get("filename", "")
+    ]
+    assert len(big_rows) == 1
+    data = big_rows[0]["data"]
+    if isinstance(data, str):
+        data = json.loads(data)
+    assert data["truncated"] is True
+    assert len(data["body"].encode("utf-8")) <= cap
+    assert data["size_bytes"] == cap * 2
+
+
+def test_escape_hatch_disables_index_path(
+    sync_with_isolated_store, monkeypatch,
+):
+    """CLAWMETRY_DISABLE_CLAUDE_SESSION_INGEST=1 short-circuits the index
+    path same as the process-inspection path."""
+    sync, ls, fake_home = sync_with_isolated_store
+    layout = _setup_layout(fake_home)
+    monkeypatch.setenv("CLAWMETRY_DISABLE_CLAUDE_SESSION_INGEST", "1")
+    out, handled = sync.sync_openclaw_claude_sessions_via_index(
+        {"node_id": "n"}, {},
+        paths={"sessions_dir": layout["sessions_dir"]},
+    )
+    assert out == 0
+    assert handled == set()
+
+
+def test_legacy_uuid_only_path_still_works(sync_with_isolated_store):
+    """Back-compat: when ``_translate_claude_session_line`` is called WITHOUT
+    ``openclaw_session_id`` (the process-inspection fallback path), the
+    session_id falls back to the Claude Code UUID and ``kind`` defaults to
+    ``"top"``. PR #1224's existing tests rely on this signature."""
+    sync, ls, fake_home = sync_with_isolated_store
+    obj = {
+        "type": "user",
+        "message": {"role": "user", "content": "hi"},
+        "uuid": "evt-1",
+        "timestamp": "2026-05-14T20:00:00Z",
+    }
+    row = sync._translate_claude_session_line(
+        obj, session_id="claude-only-uuid", node_id="n", line_no=0,
+    )
+    assert row is not None
+    assert row["session_id"] == "claude-only-uuid"
+    assert row["event_type"] == "user"
+    # data still carries the cross-ref so debugging works
+    assert row["data"]["_claude_session_id"] == "claude-only-uuid"


### PR DESCRIPTION
Closes #1226 — the P0 follow-up review issue from PR #1224.

## Diya's diagnosis (verbatim)

The user's OpenClaw bot Diya verified PR #1224 on the live install and
flagged three specific gaps:

> *Sub-agent transcripts and large tool outputs live at*
> *`49f1d9fc-.../subagents/` and `49f1d9fc-.../tool-results/` — alongside the*
> *top-level transcript.*

> *It needs to follow `claudeCliSessionId` into `~/.claude/projects/` to get*
> *the real conversation.*

> *`sessions.json` lists a `sessionFile` at `~/.openclaw/agents/main/sessions/*
> *625c0ad9-….jsonl`, but I checked: that file does not exist. The generic*
> *OpenClaw write path only runs when OpenClaw uses its built-in agent loop.*
> *With the Claude CLI provider, that path is bypassed and the CLI owns the*
> *transcript.*

That last finding is the same root cause issue #1226 flagged: Brain renders
nothing because the `sessions` table indexes by `625c0ad9` but events from
PR #1224 landed under `49f1d9fc`. Without a session row, even the typed
`query_sessions_table` view is blank, and aggregations/UI render orphans.

## Architecture (after this PR)

```
~/.openclaw/agents/main/sessions/sessions.json
  └─► agent:main:telegram:direct:1532693273
        ├─ sessionId:           625c0ad9-…   (OpenClaw UUID — JOIN KEY)
        ├─ claudeCliSessionId:  49f1d9fc-…   (Claude Code UUID)
        ├─ origin:              {label: "Vivek Chand id:1532693273", …}
        ├─ workspaceDir:        /Users/vivek/.openclaw/workspace
        └─ status:              done
                    │
                    ▼  encode CWD: / → -, . → -
~/.claude/projects/-Users-vivek--openclaw-workspace/
        ├─ 49f1d9fc-….jsonl                  (top-level transcript)
        └─ 49f1d9fc-…/
            ├─ subagents/agent-aXXX.jsonl    (one JSONL per sub-agent)
            └─ tool-results/bXXX.txt         (opaque text dumps)
                    │
                    ▼
DuckDB
  ├─ sessions   — 1 row keyed by OPENCLAW UUID 625c0ad9-…
  │              (title, status, started_at, last_active_at,
  │               metadata.claude_session_id = 49f1d9fc-…)
  └─ events     — N rows with session_id = 625c0ad9-…  (the OpenClaw UUID)
                  data._claude_session_id = 49f1d9fc-…
                  data._openclaw_session_id = 625c0ad9-…
                  event_type = top-level (user/assistant/queue-operation/…)
                             | subagent:user / subagent:assistant / …
                             | tool-result
```

## Three changes

### 1. Replace process-inspection discovery with sessions.json walk

New `sync_openclaw_claude_sessions_via_index()` is the PRIMARY path —
reads sessions.json and follows `cliSessionIds.claude-cli` (or legacy
`claudeCliSessionId`) into `~/.claude/projects/<encoded-cwd>/`. Works on
historical sessions even when no `claude` process is currently alive.

PR #1224's process-inspection logic stays as the SECONDARY fallback for
mid-spawn / post-crash sessions where the binding hasn't been written
yet. It now accepts `skip_claude_ids` so the index path's handled-set
short-circuits double-processing.

### 2. Capture subagents + tool-results

For each binding the new path tails:

  * `<claude-id>.jsonl`           — top-level transcript (existing)
  * `<claude-id>/subagents/*.jsonl` — sub-agent transcripts (NEW)
  * `<claude-id>/tool-results/*`    — tool-result dumps (NEW; one event
                                      per file, mtime-deduped, body
                                      truncated to 64 KB)

Sub-agent rows are typed `subagent:user` / `subagent:assistant` / etc.
so Brain can lane them separately from the parent transcript.

### 3. Upsert sessions row + cross-ref in event data

Per binding we call `local_store.ingest_session(...)` keyed by the
**OpenClaw** session UUID, with title/started_at/status pulled from
sessions.json metadata and `metadata.claude_session_id` for cross-ref.
Brain's `query_sessions_table` now joins to a real row.

Every ingested event carries `session_id = <openclaw-uuid>` (the join
key) AND embeds `_claude_session_id` + `_openclaw_session_id` inside
the `data` blob — no schema change, but full debuggability.

## E2E verification — user's REAL ~/.openclaw + ~/.claude

Per the user's mandate: SEPARATE temp DuckDB at
`/tmp/cm-oc-followup-test/clawmetry.duckdb`, SEPARATE config — the live
daemon's `~/.clawmetry/` state was not touched and the daemon was not
killed.

```
INGESTED: 625 events
HANDLED Claude session UUIDs:
  {49f1d9fc-… (Telegram/Diya), d87f3689-… (webchat)}

=== sessions table rows ===
  session_id=625c0ad9-71a..  title="Vivek Chand id:1532693273"
                             status=done   started_at=2026-05-09T10:01:22Z
                             msg_count=599 channel=telegram
  session_id=4595d095-5b7..  title="direct"
                             status=failed started_at=2026-05-09T10:00:47Z
                             msg_count=26  channel=webchat

=== events under OpenClaw 625c0ad9-… ===
  total: 599
  subagent:assistant: 175
  assistant:          150
  subagent:user:      114
  user:                83
  queue-operation:     48
  subagent:attachment: 13
  attachment:          11
  tool-result:          4   ← was 0 in PR #1224
  system:               1
  + 302 subagent events    ← was 0 in PR #1224

=== rows mentioning "hello, how are you?" ===
  id=openclaw-cc:625c0ad9-…:top:51b0d1f..  ts=2026-05-14T20:12:45.580Z
     type=user  session_id=625c0ad9-71a..  ✓ joins to sessions row
     _claude=49f1d9fc-084..  _oc=625c0ad9-71a..
  id=openclaw-cc:625c0ad9-…:top:line:30..  ts=2026-05-14T20:12:45.555Z
     type=queue-operation  session_id=625c0ad9-71a..
TOTAL MATCHES: 2
```

Brain fast-path read confirms the user's `hello, how are you?` line
renders under `sessionId=625c0ad9-71a..` (the OpenClaw UUID, JOINing
to the new sessions row) — exactly what #1226 needed.

vs PR #1224 baseline: 293 events / 0 sessions rows / 0 subagent events /
0 tool-results / events under the wrong (Claude) UUID.

## Tests

`tests/test_openclaw_sessions_followup.py` — 10 new tests, all green:

- `test_index_walk_ingests_top_subagent_and_tool_results` — full layout
  → 6 events split across top-level / subagent:* / tool-result types,
  all under the OpenClaw UUID with `_claude_session_id` cross-ref intact.
- `test_sessions_table_row_upserted_with_openclaw_uuid` — typed
  `sessions` table has a row keyed by the OpenClaw UUID with title from
  origin.label, status from sessions.json, message_count = 6.
- `test_idempotent_on_re_run` — second pass with empty state still
  yields 6 unique rows (PRIMARY KEY dedup).
- `test_offset_tracking_picks_up_only_new_top_level_lines` — append a
  4th line → second call ingests only that one.
- `test_skip_claude_ids_propagates_to_process_inspection` — primary
  path's handled set short-circuits the secondary path.
- `test_walk_handles_missing_sessions_json` — fresh install with no
  index → returns `(0, set())`, no crash.
- `test_walk_handles_missing_claude_files` — binding present but
  Claude hasn't started writing → silently skip, don't crash.
- `test_tool_result_truncation_and_dedup` — multi-MB file truncated to
  cap; mtime-stable second pass emits 0 rows.
- `test_escape_hatch_disables_index_path` —
  `CLAWMETRY_DISABLE_CLAUDE_SESSION_INGEST=1` short-circuits.
- `test_legacy_uuid_only_path_still_works` — PR #1224's
  `_translate_claude_session_line` signature stays back-compat for the
  process-inspection callers.

PR #1224's `tests/test_openclaw_claude_session_ingest.py` — 7 tests,
still green.
`tests/test_local_store_sync_integration.py` — 12 tests, still green.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('clawmetry/sync.py').read())"` passes
- [x] 10 new unit tests pass
- [x] 7 PR #1224 tests still pass
- [x] 12 sync integration tests still pass
- [x] E2E against user's real ~/.openclaw + ~/.claude into isolated
      temp DuckDB: 625 events ingested, 2 sessions rows upserted, 4
      tool-results captured, 302 subagent events captured, "hello,
      how are you?" appears under OpenClaw UUID 625c0ad9-…
- [x] No touch of `~/.clawmetry/` files; live daemon not killed
- [ ] Post-merge: confirm Brain on user's live install renders the
      Telegram session card (now that the sessions row exists) and the
      sub-agent lane (now that subagents are ingested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)