### PR TITLE
fix(gateway_tap): default WS tap to OFF until OpenClaw scope grant lands

### DIFF
--- a/clawmetry/gateway_tap.py
+++ b/clawmetry/gateway_tap.py
@@ -48,10 +48,9 @@ Failure modes
 Disable
 -------
 
-Set ``CLAWMETRY_DISABLE_WS_TAP=1`` in the environment to opt out
-entirely (escape hatch). Default is ON per the MOAT-mandate
-"DuckDB fast paths must default-on" rule (memory note
-``feedback_local_store_default_off_killed_moat``).
+Set ``CLAWMETRY_ENABLE_WS_TAP=1`` in the environment to opt in.
+Default is OFF until the upstream OpenClaw server grants the
+required ``operator.read`` scope.
 """
 
 from __future__ import annotations
@@ -108,8 +107,8 @@ _BACKOFF_INITIAL_SEC = 2.0
 _BACKOFF_MAX_SEC = 60.0
 
 
-# Disable env var (escape hatch — feature is default-ON).
-_DISABLE_ENV = "CLAWMETRY_DISABLE_WS_TAP"
+# Enable env var (feature is default-OFF until upstream grants scopes).
+_ENABLE_ENV = "CLAWMETRY_ENABLE_WS_TAP"
 
 
 # ── Frame normalization ─────────────────────────────────────────────────
@@ -587,8 +586,8 @@ def start(config: dict) -> GatewayTap | None:
     from the live OpenClaw config (mirroring dashboard's
     ``_detect_gateway_token`` / ``_detect_gateway_port``).
     """
-    if os.environ.get(_DISABLE_ENV, "").strip() in ("1", "true", "TRUE", "yes"):
-        log.info("gateway WS tap disabled (%s=1)", _DISABLE_ENV)
+    if os.environ.get(_ENABLE_ENV, "").strip() not in ("1", "true", "yes"):
+        log.debug("gateway WS tap disabled (set CLAWMETRY_ENABLE_WS_TAP=1 to enable)")
         return None
 
     url, token = _detect_gateway_endpoint()

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6474,8 +6474,8 @@ def run_daemon() -> None:
     # memory; gateway.log only carries outbound ACKs (no body), and no
     # JSONL is written for inbound. Without this tap, ClawMetry can
     # NEVER show real Telegram conversations on the Brain tab.
-    # Default-ON per the MOAT mandate; opt out via
-    # CLAWMETRY_DISABLE_WS_TAP=1.
+    # Default-OFF until upstream grants scopes; opt in via
+    # CLAWMETRY_ENABLE_WS_TAP=1.
     try:
         from clawmetry import gateway_tap as _gw_tap
         _gw_tap.start(config)

--- a/tests/test_gateway_tap.py
+++ b/tests/test_gateway_tap.py
@@ -20,8 +20,8 @@ What this pins
    same ``(provider, chat_id, message_id)`` already exists — the
    COALESCE upsert in ``ingest_channel_message`` makes the body
    stick.
-6. ``CLAWMETRY_DISABLE_WS_TAP=1`` short-circuits ``start()`` to a
-   no-op (escape-hatch behavior).
+6. ``start()`` is a no-op by default; set ``CLAWMETRY_ENABLE_WS_TAP=1``
+   to opt in.
 """
 
 from __future__ import annotations
@@ -49,7 +49,7 @@ def tap_env(tmp_path, monkeypatch):
     monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(duck))
     monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
     monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(oc_home))
-    monkeypatch.delenv("CLAWMETRY_DISABLE_WS_TAP", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENABLE_WS_TAP", raising=False)
     monkeypatch.delenv("OPENCLAW_GATEWAY_TOKEN", raising=False)
 
     import clawmetry.local_store as ls
@@ -432,8 +432,19 @@ def test_full_loop_against_stubbed_websocket(tap_env, monkeypatch):
 
 
 def test_disable_env_var_short_circuits_start(tap_env, monkeypatch):
-    monkeypatch.setenv("CLAWMETRY_DISABLE_WS_TAP", "1")
+    """start() returns None by default (tap is opt-in)."""
+    monkeypatch.delenv("CLAWMETRY_ENABLE_WS_TAP", raising=False)
     res = tap_env["tap"].start({"node_id": "n"})
+    assert res is None
+
+
+def test_enable_env_var_allows_start(tap_env, monkeypatch):
+    """When CLAWMETRY_ENABLE_WS_TAP=1, start() proceeds past the gate
+    (returns None here only because no gateway endpoint is configured)."""
+    monkeypatch.setenv("CLAWMETRY_ENABLE_WS_TAP", "1")
+    res = tap_env["tap"].start({"node_id": "n"})
+    # No gateway configured in test env → still None, but for a
+    # different reason (missing URL/token, not the env-var gate).
     assert res is None
 
 


### PR DESCRIPTION
Closes #1221

## What

Swap the WS gateway tap from default-ON (opt-out via `CLAWMETRY_DISABLE_WS_TAP`) to default-OFF (opt-in via `CLAWMETRY_ENABLE_WS_TAP`).

## Why

OpenClaw 2026.5.7 returns `auth.scopes = []` — the `operator.read` scope required by `sessions.messages.subscribe` isn't granted yet. With default-ON, every install enters a reconnect loop that fills `~/.clawmetry/sync.log` with "degraded" warnings and delivers zero messages.

## Changes

- **`gateway_tap.py`**: Renamed `_DISABLE_ENV` → `_ENABLE_ENV`, flipped the guard in `start()` so it's a no-op unless `CLAWMETRY_ENABLE_WS_TAP=1` is set, updated module docstring.
- **`test_gateway_tap.py`**: Updated fixture to clear the new env var, rewrote `test_disable_env_var_short_circuits_start` to verify default-OFF behavior, added `test_enable_env_var_allows_start` for the opt-in path.

## Flip-day plan

Once upstream [openclaw/openclaw#80836](https://github.com/openclaw/openclaw/issues/80836) lands and scopes are granted, a follow-up PR will:
1. Revert env var to `CLAWMETRY_DISABLE_WS_TAP` (opt-out)
2. Make default-ON
3. Bump `__version__`
4. Add CHANGELOG entry