### PR TITLE
[RELEASE] fix(dashboard): inflight-dedup + close SSE on tab hidden — unblocks Brain timeout

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1677,17 +1677,54 @@ function formatTime(ms) {
   return new Date(ms).toLocaleString('en-GB', {hour:'2-digit',minute:'2-digit',day:'numeric',month:'short'});
 }
 
+// Inflight dedup: 5 long-lived SSE EventSources (brain, flow-brain,
+// flow-events, health, logs) eat 5/6 slots in the browser's HTTP/1.1
+// per-origin connection budget. Pollers firing every 5–10s with no dedup
+// then stack 10+ identical fetches into the last slot and starve every new
+// request into "(pending)" forever — the surface symptom is "Failed to
+// load: timeout" on Brain. Collapsing duplicate URLs keeps inflight to ~1
+// per endpoint regardless of how often the cadence fires.
+var _inflightJsonFetches = {};
 async function fetchJsonWithTimeout(url, timeoutMs) {
+  if (_inflightJsonFetches[url]) return _inflightJsonFetches[url];
   var ctrl = new AbortController();
   var to = setTimeout(function() { ctrl.abort('timeout'); }, timeoutMs);
-  try {
-    var r = await fetch(url, {signal: ctrl.signal});
-    if (!r.ok) throw new Error('HTTP ' + r.status);
-    return await r.json();
-  } finally {
-    clearTimeout(to);
-  }
+  var p = (async function() {
+    try {
+      var r = await fetch(url, {signal: ctrl.signal});
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return await r.json();
+    } finally {
+      clearTimeout(to);
+      delete _inflightJsonFetches[url];
+    }
+  })();
+  _inflightJsonFetches[url] = p;
+  return p;
 }
+
+// Same root cause as above — when the browser tab is hidden the 5 SSE are
+// useless yet still hold connection slots. Close them on hidden; the tab-
+// change handlers re-open the one needed when the user returns (each guards
+// on readyState===CLOSED, so this is idempotent).
+(function _installSSEVisibilityGuard() {
+  if (typeof document === 'undefined' || !document.addEventListener) return;
+  function _closeAllSSE() {
+    ['_brainSSE', '_flowBrainSse', '_flowSse', 'healthStream', 'logStream'].forEach(function(key) {
+      try {
+        var es = window[key];
+        if (es && typeof es.close === 'function') {
+          es.close();
+          window[key] = null;
+        }
+      } catch(e) {}
+    });
+  }
+  document.addEventListener('visibilitychange', function() {
+    if (document.hidden) _closeAllSSE();
+  });
+  window.addEventListener('pagehide', _closeAllSSE);
+})();
 
 async function resolvePrimaryModelFallback() {
   try {


### PR DESCRIPTION
## Symptom

User stuck on "**Failed to load: timeout**" on Brain tab. DevTools shows 127 requests, most `(pending)` for 50s with 0 KB transferred. A few cancel after 3–4 s. Server returns curl in 43 ms.

## Root cause

The page opens up to **5 long-lived SSE EventSources** (`/api/brain-stream` ×2, `/api/flow-events`, `/api/health-stream`, `/api/logs-stream`), each holding a connection slot for life. The browser's HTTP/1.1 cap is **6 connections per origin**. That leaves **1 slot for everything else**. Then ~30 `setInterval` pollers (5 s, 10 s, 30 s) fire into that slot with **zero inflight dedup**, so the same URL stacks 10+ concurrent fetches that never get sent. Surface symptom: Brain's 20 s `fetchJsonWithTimeout` aborts → "Failed to load: timeout".

## Fix

Two surgical changes in `clawmetry/static/js/app.js`:

1. **`fetchJsonWithTimeout` inflight dedup** — URL→Promise map collapses concurrent identical fetches to one in-flight request per endpoint, regardless of how fast the cadence fires.
2. **`visibilitychange` SSE close** — when the tab is hidden, all 5 EventSources close (releasing their connection slots). Tab-change handlers already guard on `readyState===CLOSED` before re-opening, so it's idempotent when the user returns.

44 insertions, 7 deletions. No backend changes, no schema changes, no new endpoints.

## Test plan

- [ ] Server-side endpoints unchanged → existing API tests still pass
- [ ] `node --check app.js` syntax-clean
- [ ] On `app.clawmetry.com`: refresh Brain tab, observe DevTools — concurrent identical `/api/overview` and `/api/brain-history?limit=40` requests collapse to 1
- [ ] Switch to a different browser tab for 30 s, return — Brain SSE re-opens cleanly via `_startBrainSSE` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)