### PR TITLE
[RELEASE] fix(MOAT): read_only=True on DuckDB opens + dedup /api/overview fetches

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3231,9 +3231,9 @@ function _buildSourcesList(events) {
 async function loadContextInspector() {
   try {
     // Fetch overview for model + token info
-    var ov = await fetch('/api/overview').then(function(r){return r.json();}).catch(function(){return {};});
+    var ov = await fetchJsonWithTimeout('/api/overview', 5000).catch(function(){return {};});
     // Fetch brain history for compaction events + turn count
-    var brain = await fetch('/api/brain-history?limit=300').then(function(r){return r.json();}).catch(function(){return {events:[]};});
+    var brain = await fetchJsonWithTimeout('/api/brain-history?limit=300', 8000).catch(function(){return {events:[]};});
     // Fetch skills for header token count. /api/skills is cloud-disabled
     // (410 Gone) — skip the network call in cloud mode and use empty totals.
     var skills = window.CLOUD_MODE
@@ -8227,7 +8227,7 @@ function initFlow() {
   // Hide unconfigured channels in the flow SVG
   hideUnconfiguredChannels(document);
 
-  fetch('/api/overview').then(function(r){return r.json();}).then(async function(d) {
+  fetchJsonWithTimeout('/api/overview', 5000).then(async function(d) {
     if (!d.model || d.model === 'unknown') {
       var fm = await resolvePrimaryModelFallback();
       if (fm && fm !== 'unknown') d.model = fm;
@@ -8424,7 +8424,7 @@ function updateFlowStats() {
   var el3 = document.getElementById('flow-active-tools');
   if (el3) el3.textContent = names.length > 0 ? names.join(', ') : '\u2014';
   if (flowStats.events % 15 === 0) {
-    fetch('/api/overview').then(function(r){return r.json();}).then(function(d) {
+    fetchJsonWithTimeout('/api/overview', 5000).then(function(d) {
       var tok = document.getElementById('flow-tokens');
       if (tok) tok.textContent = (d.mainTokens / 1000).toFixed(0) + 'K';
     }).catch(function(){});

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -69,7 +69,10 @@ def _try_local_store_alert_rules():
     """
     try:
         from clawmetry import local_store
-        store = local_store.get_store()
+        # read_only=True — see crons.py for the same fix. Writable open from
+        # dashboard blocks on the sync daemon's exclusive writer lock and
+        # surfaces as the 6 s timeout cliff for /api/alerts/rules.
+        store = local_store.get_store(read_only=True)
         rows = store.query_alert_rules(limit=500)
     except Exception:
         return None

--- a/routes/autonomy.py
+++ b/routes/autonomy.py
@@ -294,7 +294,10 @@ def _try_local_store_autonomy() -> dict | None:
     except Exception:
         return None
     try:
-        store = local_store.get_store()
+        # read_only=True — see crons.py for the same fix. Writable open from
+        # dashboard blocks on the sync daemon's exclusive writer lock and
+        # surfaces as the 6 s timeout cliff for /api/autonomy.
+        store = local_store.get_store(read_only=True)
         rows = store.query_events(event_type="message", limit=5000)
     except Exception:
         return None

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -177,7 +177,11 @@ def _try_local_store_crons():
     """
     try:
         from clawmetry import local_store
-        store = local_store.get_store()
+        # read_only=True — the sync daemon holds an exclusive writer lock on
+        # the DuckDB file. Opening writable from the dashboard process blocks
+        # indefinitely (surfaces as the 6 s timeout cliff per Engineer #1's
+        # MOAT trace). Read-only opens succeed even while the writer is active.
+        store = local_store.get_store(read_only=True)
         rows = store.query_crons(limit=500)
     except Exception:
         return None
@@ -211,7 +215,11 @@ def _try_local_store_cron_runs(job_id):
     """
     try:
         from clawmetry import local_store
-        store = local_store.get_store()
+        # read_only=True — the sync daemon holds an exclusive writer lock on
+        # the DuckDB file. Opening writable from the dashboard process blocks
+        # indefinitely (surfaces as the 6 s timeout cliff per Engineer #1's
+        # MOAT trace). Read-only opens succeed even while the writer is active.
+        store = local_store.get_store(read_only=True)
         evs = store.query_events(event_type="cron_run", limit=500)
     except Exception:
         return None
@@ -253,7 +261,11 @@ def _try_local_store_cron_health_summary():
     """
     try:
         from clawmetry import local_store
-        store = local_store.get_store()
+        # read_only=True — the sync daemon holds an exclusive writer lock on
+        # the DuckDB file. Opening writable from the dashboard process blocks
+        # indefinitely (surfaces as the 6 s timeout cliff per Engineer #1's
+        # MOAT trace). Read-only opens succeed even while the writer is active.
+        store = local_store.get_store(read_only=True)
         rows = store.query_crons(limit=500)
     except Exception:
         return None


### PR DESCRIPTION
## Why

Engineer #1's MOAT E2E verifier (in-session) found 7 dashboard endpoints time out at the **6 s mark** on a healthy local box: `/api/system-health`, `/api/crons`, `/api/alerts/rules`, `/api/autonomy`, `/api/channels/status`, `/api/channels/telegram/status`, `/api/component/brain`.

Timeout-trace agent identified the **single root cause**: the sync daemon holds an exclusive writer lock on the local DuckDB. The dashboard's `_try_local_store_*` helpers call `local_store.get_store()` which defaults to writable — that blocks on the lock, exception-falls-back to gateway RPC (down), and surfaces as the 6 s timeout cliff.

DuckDB allows concurrent readers + 1 writer, so opening **read-only** from the dashboard succeeds even while the sync daemon is writing.

Plus: user reported "15+ requests to /overview screen, all in pending state". PR #1243 added inflight dedup but only in `fetchJsonWithTimeout`. 3 sites use raw `fetch('/api/overview')` and bypass the dedup. Converting them.

## Changes

| File | Change |
|------|--------|
| `routes/crons.py` | 3× `get_store()` → `get_store(read_only=True)` |
| `routes/alerts.py` | 1× same |
| `routes/autonomy.py` | 1× same |
| `clawmetry/static/js/app.js` | 3× `fetch('/api/overview')` → `fetchJsonWithTimeout('/api/overview', 5000)` |

Total: 4 files, +27 / -9.

## Expected impact

- `/api/crons`, `/api/alerts/rules`, `/api/autonomy` go from **6 s timeout → <500 ms** (Engineer #1 will re-verify after merge)
- Overview tab DevTools shows **1 inflight `/api/overview`** instead of 15
- Other 4 timeout endpoints (system-health, channels/status×2, component/brain) need separate fixes — filed in the umbrella issue #1245 + soon-to-be-filed sub-issues.

## Test plan
- [ ] `make lint`
- [ ] `make test-api`
- [ ] After deploy: `curl -w '%{time_total}\n' http://localhost:8900/api/crons` → <500 ms
- [ ] DevTools network on Overview tab: 1 inflight `/api/overview`

Linked: issue #1245 (umbrella), Engineer #1's report `/tmp/moat_e2e_report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)