### PR TITLE
[RELEASE] fix(MOAT): route 4 timeout endpoints through daemon HTTP proxy (issue #1256)

### DIFF
--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -67,13 +67,17 @@ def _try_local_store_alert_rules():
     Tagged with ``_source: "local_store"`` so callers (browser, integration
     tests, the cloud relay) can tell which path served them.
     """
+    # Issue #1256: route through daemon HTTP proxy. Direct get_store()
+    # raises IOException on multi-process installs (DuckDB's file lock is
+    # exclusive across processes; read_only=True doesn't bypass it).
     try:
-        from clawmetry import local_store
-        # read_only=True — see crons.py for the same fix. Writable open from
-        # dashboard blocks on the sync daemon's exclusive writer lock and
-        # surfaces as the 6 s timeout cliff for /api/alerts/rules.
-        store = local_store.get_store(read_only=True)
-        rows = store.query_alert_rules(limit=500)
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_alert_rules", limit=500)
+        if rows is None:
+            # Daemon unreachable → single-process fallback (tests/dev mode).
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_alert_rules(limit=500)
     except Exception:
         return None
     if not rows:

--- a/routes/autonomy.py
+++ b/routes/autonomy.py
@@ -293,12 +293,16 @@ def _try_local_store_autonomy() -> dict | None:
         from clawmetry import local_store
     except Exception:
         return None
+    # Issue #1256: route through daemon HTTP proxy. Direct get_store()
+    # raises IOException on multi-process installs (DuckDB's file lock is
+    # exclusive across processes; read_only=True doesn't bypass it).
     try:
-        # read_only=True — see crons.py for the same fix. Writable open from
-        # dashboard blocks on the sync daemon's exclusive writer lock and
-        # surfaces as the 6 s timeout cliff for /api/autonomy.
-        store = local_store.get_store(read_only=True)
-        rows = store.query_events(event_type="message", limit=5000)
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_events", event_type="message", limit=5000)
+        if rows is None:
+            # Daemon unreachable → single-process fallback (tests/dev mode).
+            store = local_store.get_store(read_only=True)
+            rows = store.query_events(event_type="message", limit=5000)
     except Exception:
         return None
     if not rows:

--- a/routes/components.py
+++ b/routes/components.py
@@ -1162,14 +1162,17 @@ def _try_local_store_component_brain(limit: int, offset: int):
       - the events table is empty / no qualifying calls today
       - any unexpected error happens (we'd rather degrade than 500)
     """
+    # Issue #1256: route through daemon HTTP proxy. Direct get_store()
+    # raises IOException on multi-process installs (DuckDB's file lock is
+    # exclusive across processes; read_only=True doesn't bypass it).
     try:
-        from clawmetry import local_store
-    except Exception:
-        return None
-    try:
-        store = local_store.get_store()
-        # Pull a generous window — events are filtered down by ts/usage below.
-        rows = store.query_events(event_type="message", limit=2000)
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_events", event_type="message", limit=2000)
+        if rows is None:
+            # Daemon unreachable → single-process fallback (tests/dev mode).
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_events(event_type="message", limit=2000)
     except Exception:
         return None
     if not rows:

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -175,15 +175,12 @@ def _try_local_store_crons():
     dashboard JS treats missing/zero costs as "not yet attributed" and
     renders fine.
     """
-    try:
-        from clawmetry import local_store
-        # read_only=True — the sync daemon holds an exclusive writer lock on
-        # the DuckDB file. Opening writable from the dashboard process blocks
-        # indefinitely (surfaces as the 6 s timeout cliff per Engineer #1's
-        # MOAT trace). Read-only opens succeed even while the writer is active.
-        store = local_store.get_store(read_only=True)
-        rows = store.query_crons(limit=500)
-    except Exception:
+    # Issue #1256: route through _ls_call (daemon HTTP proxy first, direct
+    # open as single-process fallback). Direct get_store() always raised
+    # IOException on multi-process installs because DuckDB's file lock is
+    # exclusive across processes — the read_only=True hint doesn't help.
+    rows = _ls_call("query_crons", limit=500)
+    if rows is None:
         return None
     if not rows:
         return None
@@ -213,15 +210,9 @@ def _try_local_store_cron_runs(job_id):
 
     Returns ``None`` to defer to the legacy gateway/transcript fallback.
     """
-    try:
-        from clawmetry import local_store
-        # read_only=True — the sync daemon holds an exclusive writer lock on
-        # the DuckDB file. Opening writable from the dashboard process blocks
-        # indefinitely (surfaces as the 6 s timeout cliff per Engineer #1's
-        # MOAT trace). Read-only opens succeed even while the writer is active.
-        store = local_store.get_store(read_only=True)
-        evs = store.query_events(event_type="cron_run", limit=500)
-    except Exception:
+    # Issue #1256: route through _ls_call (see _try_local_store_crons).
+    evs = _ls_call("query_events", event_type="cron_run", limit=500)
+    if evs is None:
         return None
     if not evs:
         return None
@@ -259,15 +250,9 @@ def _try_local_store_cron_health_summary():
 
     Returns ``None`` on empty/missing store.
     """
-    try:
-        from clawmetry import local_store
-        # read_only=True — the sync daemon holds an exclusive writer lock on
-        # the DuckDB file. Opening writable from the dashboard process blocks
-        # indefinitely (surfaces as the 6 s timeout cliff per Engineer #1's
-        # MOAT trace). Read-only opens succeed even while the writer is active.
-        store = local_store.get_store(read_only=True)
-        rows = store.query_crons(limit=500)
-    except Exception:
+    # Issue #1256: route through _ls_call (see _try_local_store_crons).
+    rows = _ls_call("query_crons", limit=500)
+    if rows is None:
         return None
     if not rows:
         return None


### PR DESCRIPTION
Closes 4 of 7 endpoints in #1256.

## Why PR #1253's fix didn't work

PR #1253 added \`read_only=True\` to dashboard \`get_store()\` calls. **DuckDB's file lock is exclusive at the OS process level**, regardless of connection mode. Direct test on the deployed 0.12.195:

\`\`\`
$ python3 -c \"import duckdb; duckdb.connect('/Users/vivek/.clawmetry/clawmetry.duckdb', read_only=True)\"
IO Error: Could not set lock on file: Conflicting lock is held in PID <writer> by user vivek
(after 0.002s)
\`\`\`

The exception is caught in \`_try_local_store_*\` helpers, which then return None. The handler falls through to \`_gw_invoke()\` (gateway RPC, unreachable on this user's box) → 6 s timeout.

## What this PR ships

Routes the 4 simplest endpoints through the existing \`local_store_via_daemon\` helper (\`routes/local_query.py:374\`) — daemon owns the writer connection and serves reads via HTTP from the same process, no lock conflict. This is the same pattern \`/api/local/*\` and several other working endpoints already use successfully.

| Endpoint | File | Note |
|---|---|---|
| /api/crons | routes/crons.py (3 sites) | Used existing \`_ls_call\` helper — was unused |
| /api/alerts/rules | routes/alerts.py | Inlined the daemon-proxy pattern |
| /api/autonomy | routes/autonomy.py | Inlined the daemon-proxy pattern |
| /api/component/brain | routes/components.py | Inlined the daemon-proxy pattern |

Each preserves the **single-process fallback** (direct \`get_store(read_only=True)\`) so tests + dev mode continue working without a daemon.

## Diff

4 files, +41 / -45.

## Remaining 3 endpoints (#1256)

Filed for follow-up:

- **/api/system-health** (routes/health.py) — bottleneck is \`_gw_invoke(\"cron\", ...)\` gateway RPC at line 1020, not the local-store open. Needs gateway calls replaced with daemon-proxy DuckDB reads.
- **/api/channels/status** + **/api/channels/telegram/status** (routes/channels.py) — these already fast-fail at 2ms when get_store raises, so the 6s timeout reported by Engineer #1 may be a different bottleneck (worth re-verifying after this PR lands; possibly request-storm from the Brain page firing them concurrently).

## Test plan
- [ ] \`make lint\` / \`make test-api\`
- [ ] After deploy: \`curl -w '%{time_total}\\n' http://localhost:8900/api/crons\` → <500ms
- [ ] After deploy: \`curl -w '%{time_total}\\n' http://localhost:8900/api/alerts/rules\` → <500ms
- [ ] After deploy: \`curl -w '%{time_total}\\n' http://localhost:8900/api/autonomy\` → <500ms
- [ ] After deploy: \`curl -w '%{time_total}\\n' http://localhost:8900/api/component/brain\` → <500ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)