### PR TITLE
[RELEASE] fix(MOAT): add query_alert_rules + query_channel_config_status to daemon allowlist

### DIFF
--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -295,6 +295,14 @@ _DAEMON_METHODS = frozenset({
     "query_aggregates",
     "query_heartbeats",
     "query_channels",
+    # Issue #1256 follow-up: alert_rules + channel_config_status. PR #1258
+    # routed /api/alerts/rules and /api/channels/status through the daemon
+    # proxy but missed adding the methods to the allowlist — every call
+    # 400'd, fell back to direct DuckDB open (lock contention), then to
+    # gateway RPC (down), surfacing as the same 6 s timeout the PR was
+    # supposed to fix. Adding both here closes the loop.
+    "query_alert_rules",
+    "query_channel_config_status",
     "query_crons",
     # Issue #605 DuckDB follow-up: per-job cron-run timeline. Read by
     # ``routes/crons.py:_cron_runs_from_duckdb`` via the daemon proxy.


### PR DESCRIPTION
Closes the alerts/rules outlier from PR #1258.

## Why

PR #1258 routed `/api/alerts/rules` (and `/api/channels/<provider>/status`) through `local_store_via_daemon`, but the corresponding methods weren't in `_DAEMON_METHODS`. Every call hit:

1. POST `/__local_query__/query_alert_rules` → 400 \"method not allowed\"
2. Helper returns None (treated as \"daemon unreachable\")
3. Single-process fallback: `get_store(read_only=True)` → IOException (sync daemon holds the OS-level file lock)
4. Caught → returns None  
5. Handler falls through to legacy gateway-RPC path → 6 s timeout

## Verified

Post-PR #1258 deploy on 0.12.196:

| Endpoint | Time |
|---|---|
| /api/crons | 180 ms ✓ |
| /api/autonomy | 6 ms ✓ |
| /api/component/brain | 5 ms ✓ |
| **/api/alerts/rules** | **5-7 s ✗** |

The 4th one was the outlier — exactly because of this allowlist gap.

## Fix

Add `query_alert_rules` + `query_channel_config_status` to `_DAEMON_METHODS`. Both already exist as LocalStore methods (`clawmetry/local_store.py:2685`).

3 / -0 lines.

## Test plan
- [ ] Post-deploy: `curl -w '%{time_total}\\n' http://localhost:8900/api/alerts/rules` → <500 ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)