### PR TITLE
fix(crons): pick single renderer in cron run panel (closes #1164)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5215,7 +5215,7 @@ async function loadCronRuns(jobId) {
         h += '<div style="color:var(--text-error);font-size:11px;padding:2px 0 4px 8px;border-left:2px solid var(--text-error);margin-left:4px;">' + escHtml(r.error).substring(0,200) + '</div>';
       }
     });
-    el.innerHTML = (timelineHtml || '') + h;
+    el.innerHTML = timelineRuns.length > 0 ? timelineHtml : h;
   } catch(e) {
     var el = document.getElementById('cron-runs-' + jobId);
     if (el) el.innerHTML = '<div style="color:var(--text-error);">Could not load run history (' + escHtml(String(e.message||e)) + '). The endpoint may be unreachable or your gateway is offline.</div>';


### PR DESCRIPTION
Closes #1164

## Summary

- `loadCronRuns` fetches from two sources: the new DuckDB-backed `/api/crons/<id>/runs` and the legacy `/api/cron/<id>/runs` gateway endpoint
- When both returned data, line 5218 stacked both renderers: `el.innerHTML = (timelineHtml || '') + h` — showing a sparkline+stats panel AND a calendar heatmap+pill list simultaneously
- Fix: `el.innerHTML = timelineRuns.length > 0 ? timelineHtml : h` — new timeline wins when present; legacy heatmap is the fallback for installs where the JSONL feed hasn't populated yet

## Test plan

- [ ] Open Crons tab, expand a job that has run history → should see only the sparkline+stats+table (no stacked legacy heatmap below it)
- [ ] On a fresh install with no DuckDB timeline data yet → should see only the legacy calendar heatmap (graceful fallback)
- [ ] `make lint-js` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_018iQGBzPgL5qC88U8qBazxM)_