### PR TITLE
fix(install): add timeout=2 to PyPI version probe (closes #1229)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -173,7 +173,7 @@ if [ -x "$INSTALL_DIR/bin/clawmetry" ]; then
   _CURRENT=$("$INSTALL_DIR/bin/clawmetry" --version 2>/dev/null | awk '{print $NF}')
   _LATEST=$("$INSTALL_DIR/bin/python3" -c "
 import json, urllib.request
-r = urllib.request.urlopen('https://pypi.org/pypi/clawmetry/json')
+r = urllib.request.urlopen('https://pypi.org/pypi/clawmetry/json', timeout=2)
 print(json.loads(r.read())['info']['version'])
 " 2>/dev/null)
   if [ -n "$_CURRENT" ] && [ "$_CURRENT" = "$_LATEST" ] && [ -n "$_existing_pids" ]; then


### PR DESCRIPTION
Closes #1229

## What

Add `timeout=2` to the `urllib.request.urlopen` call that fetches the latest PyPI version inside `install.sh`'s early-exit block.

## How

```diff
-r = urllib.request.urlopen('https://pypi.org/pypi/clawmetry/json')
+r = urllib.request.urlopen('https://pypi.org/pypi/clawmetry/json', timeout=2)
```

That's the entire patch. One line.

## Why

PR #1223 added an early-exit so re-running `install.sh` on an already-current install with a healthy daemon exits in <2s. The probe it relies on has no timeout — meaning on a slow PyPI / degraded DNS / sinkhole network, the "fast path" can hang **longer** than the install it's trying to skip, defeating the purpose.

With `timeout=2`:
- Fast PyPI → behaviour unchanged (probe still returns in well under 2s).
- Slow / unreachable PyPI → `URLError` raised → `_LATEST` is empty → string compare with `_CURRENT` fails → script falls through to the regular install path, which has its own spinners and retries.

Strictly better. Bounded fast-path; same graceful fallback as today.

## Verification

Pointed the probe at sinkhole `https://10.255.255.1/pypi/clawmetry/json`:

```
$ python3 -c "import urllib.request, time; t=time.time()
try: urllib.request.urlopen('https://10.255.255.1/pypi/clawmetry/json', timeout=2)
except Exception as e: print(f'{type(e).__name__} after {time.time()-t:.2f}s')"
URLError after 2.00s
```

Without `timeout=2` the same call hangs for the full system default (~75-130s on Linux). The fix bounds it to 2s as designed.

`bash -n install.sh` passes.

## Acceptance (per #1229)

- [x] `urlopen(..., timeout=2)` added
- [x] Verified by pointing at a sinkhole address — script falls through to full install in ≤3s instead of hanging