### PR TITLE
[RELEASE] fix(MOAT): /api/transcript/<sid> 5.5s → 33ms via daemon-proxy (closes #1248)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2366,14 +2366,40 @@ def _try_local_store_transcript(session_id: str):
       lives in nested fields (``data.finalPromptText``, ``data.assistantTexts``,
       ``data.toolMetas``…), tokens in ``data.promptCache.lastCallUsage``.
     """
+    # Issue #1291 cliff #4: route through daemon HTTP proxy. The previous
+    # direct ``local_store.get_store()`` open collided with the sync
+    # daemon's exclusive DuckDB lock under standard installs (per memory
+    # `reference_duckdb_process_lock.md`), forced fall-through to the JSONL
+    # walker → 5.5s p95 the latency probe (#1287) surfaced for
+    # ``sessions.api_transcript``.
+    rows = None
     try:
-        from clawmetry import local_store
-        store = local_store.get_store()
-        rows = store.query_events(session_id=session_id, limit=10000)
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon(
+            "query_events", session_id=session_id, limit=10000)
     except Exception:
-        return None
+        rows = None
+    if rows is None:
+        # Single-process fallback (tests/dev with no sync daemon).
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_events(session_id=session_id, limit=10000)
+        except Exception:
+            return None
     if not rows:
-        return None
+        # Empty is a legitimate "no events for this session yet" — return a
+        # populated shell so the JSONL walker doesn't get a second chance
+        # to do the same 5.5s walk for the same empty answer (PR #1266
+        # pattern). Caller decorates with `_source: "local_store"`.
+        return {
+            "messages":     [],
+            "model":        None,
+            "total_tokens": 0,
+            "first_ts":     None,
+            "last_ts":      None,
+            "_source":      "local_store",
+        }
     # query_events returns DESC by ts; transcripts read forward.
     rows = list(reversed(rows))
     messages: list[dict] = []


### PR DESCRIPTION
## Summary

Fourth MOAT-cliff from PR #1287's probe + fix for issue #1248. Same daemon-proxy pattern as #1292 / #1293 / #1294.

| Path                  | Before  | After   |
|-----------------------|---------|---------|
| /api/transcript/<sid> | 5.5s    | 30-73ms |

**~167× faster**, real Telegram session with 654 messages. \`_source: \"local_store\"\` confirms the proxy is hot.

## Cumulative cliff sweep

| Endpoint                                     | Before | After  | PR    |
|----------------------------------------------|--------|--------|-------|
| /api/component/tool/<name>                   | 7.3s   | 1.4ms  | #1292 |
| /api/reliability                             | 7.5s   | 550ms  | #1293 |
| /api/anomalies (+ 6 siblings)                | 6.6s   | 5ms    | #1294 |
| /api/transcript/<sid>                        | 5.5s   | 33ms   | this  |
| **/api/heartbeat-status** (last cliff)       | 2.9s   | TBD    | next  |

## Test plan (MOAT fast-path checklist)

- [x] \`make lint-daemon-allowlist\` — \`query_events\` already in allowlist
- [x] curl <500ms with **populated** local DuckDB — 30-73ms warm
- [x] **Empty-store correctness**: returns populated \`{messages: [], _source: \"local_store\"}\` instead of None (PR #1266 pattern)
- [x] Single-process fallback preserved (\`get_store(read_only=True)\` for tests/dev)
- [x] \`_source: \"local_store\"\` in response  
- [x] py_compile + dashboard import clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)