### PR TITLE
[RELEASE] fix(MOAT): /api/heartbeat-status 2.9s → 8ms — final cliff (closes #1291 part 5)

### DIFF
--- a/routes/heartbeat.py
+++ b/routes/heartbeat.py
@@ -175,17 +175,45 @@ def _try_local_store_heartbeat(interval, now):
     as outcome="ok". The session-transcript fallback retains its richer
     ok/action classification when the daemon isn't writing local rows.
     """
+    # Issue #1291 cliff #5 (final): route through daemon HTTP proxy. The
+    # previous direct ``local_store.get_store()`` open collided with the
+    # sync daemon's exclusive DuckDB lock under standard installs (per
+    # memory `reference_duckdb_process_lock.md`), forcing fall-through to
+    # the legacy session-transcript scanner → 2.9s p95 the latency probe
+    # (#1287) surfaced for ``heartbeat.api_heartbeat``.
+    rows = None
     try:
-        from clawmetry import local_store
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_heartbeats", limit=500)
     except Exception:
-        return None
-    try:
-        store = local_store.get_store()
-        rows = store.query_heartbeats(limit=500)
-    except Exception:
-        return None
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_heartbeats(limit=500)
+        except Exception:
+            return None
     if not rows:
-        return None
+        # Empty heartbeats table is a legitimate "daemon hasn't pinged
+        # yet" — don't fall through to the legacy scanner; surface "never"
+        # via the populated shell so the UI knows to show no-data state.
+        return {
+            "status":            "never",
+            "interval_seconds":  interval,
+            "last_heartbeat_ts": 0,
+            "age_seconds":       None,
+            "last_outcome":      None,
+            "expected_beats":    max(1, 86400 // interval) if interval > 0 else 48,
+            "actual_beats":      0,
+            "on_time_ratio":     0.0,
+            "beats_24h":         0,
+            "ok_count":          0,
+            "action_count":      0,
+            "ok_ratio":          1.0,
+            "recent_beats":      [],
+            "_source":           "local_store",
+        }
 
     cutoff_24h = now - 86400
     beats = []


### PR DESCRIPTION
## Summary

Fifth and **final** MOAT-cliff from PR #1287's latency probe. 5/5 cliffs now fixed.

| Path                  | Before  | After   |
|-----------------------|---------|---------|
| /api/heartbeat-status | 2.9s    | 8ms     |

**~360× faster.** \`_source: \"local_store\"\` confirms the daemon-proxy is hot.

## 🎯 MOAT cliff sweep — COMPLETE

| Endpoint                                     | Before | After   | PR     |
|----------------------------------------------|--------|---------|--------|
| /api/component/tool/<name>                   | 7.3s   | 1.4ms   | #1292  |
| /api/reliability                             | 7.5s   | 550ms   | #1293  |
| /api/anomalies (+ 6 sibling /api/usage/*)    | 6.6s   | 5ms     | #1294  |
| /api/transcript/<sid>                        | 5.5s   | 33ms    | #1296  |
| /api/heartbeat-status                        | 2.9s   | 8ms     | **this** |
| **TOTAL**                                    | 29.8s  | 0.6s    | **50×**  |

Plus 6 sibling \`/api/usage/*\` endpoints transparently fixed by the shim in #1294 — total endpoints now on the daemon-proxy fast path: **11**.

## Test plan (MOAT fast-path checklist)

- [x] \`make lint-daemon-allowlist\` — \`query_heartbeats\` already in allowlist
- [x] curl <500ms with **populated** local DuckDB — measured 7-12ms warm
- [x] **Empty-store correctness**: returns \`{status: \"never\", _source: \"local_store\"}\` instead of None (PR #1266 pattern)
- [x] Single-process fallback preserved (\`get_store(read_only=True)\` for tests/dev)
- [x] \`_source: \"local_store\"\` in response  
- [x] py_compile + dashboard import clean

## Why this matters

The probe (#1287) caught these in 1 smoke run after weeks of silent slowness. Without the probe each cliff would have taken its own incident cycle to surface (the /api/sessions cliff in #1278 took ~2 weeks). Together this is the eat-our-own-dogfood story: ClawMetry catches its own dashboard regressions in seconds, ships fixes in hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)