### PR TITLE
[RELEASE] feat(observability): humanise handler-latency panel labels (closes #1290)

### DIFF
--- a/clawmetry/latency_tracker.py
+++ b/clawmetry/latency_tracker.py
@@ -39,6 +39,62 @@ def _percentile(sorted_values: list[float], pct: float) -> float:
     return sorted_values[k]
 
 
+# Issue #1290 — humanise raw Flask blueprint:func identifiers so the
+# operator dashboard reads "Components › Component Tool" instead of the
+# unreadable internal name "components.api_component_tool". Static map
+# wins for the common dashboard surfaces (~30 endpoints); mechanical
+# transform handles the long tail without per-endpoint maintenance.
+_LABEL_OVERRIDES: dict[str, str] = {
+    "overview.api_overview":              "Main dashboard",
+    "sessions.api_sessions":              "Sessions list",
+    "sessions.api_transcript":            "Session transcript",
+    "sessions.api_subagents":             "Sub-agent tracker",
+    "components.api_component_tool":      "Tool detail panel",
+    "components.api_component_runtime":   "Runtime panel",
+    "components.api_component_machine":   "Machine panel",
+    "components.api_component_gateway":   "Gateway panel",
+    "components.api_component_brain":     "Brain panel",
+    "health.api_system_health":           "System health",
+    "health.api_reliability":             "Reliability trend",
+    "health.api_heartbeat_status":        "Heartbeat status",
+    "health.api_diagnostics":             "Diagnostics",
+    "health.api_handler_latency":         "Handler latency (this panel)",
+    "usage.api_usage":                    "Token & cost usage",
+    "usage.api_anomalies":                "Cost anomalies",
+    "usage.api_usage_anomalies":          "Usage anomalies",
+    "brain.api_brain_history":            "Brain feed (history)",
+    "brain.api_brain_stream":             "Brain feed (live)",
+    "crons.api_crons":                    "Cron jobs",
+    "alerts.api_alert_rules":             "Alert rules",
+    "channels.api_channels":              "Chat channels",
+    "heartbeat.api_heartbeat":            "Heartbeat ping (POST)",
+}
+
+
+def humanise_endpoint(endpoint: str) -> str:
+    """Convert a Flask ``blueprint.func`` identifier into a user-readable label.
+
+    1. Exact match in ``_LABEL_OVERRIDES`` wins (curated for the common
+       dashboard surfaces — most readable, zero-cost lookup).
+    2. Otherwise, mechanical transform: drop ``api_`` prefix, replace ``_``
+       with spaces, title-case each word, separate blueprint from func with
+       ``›``. Unknown endpoints get readable fallback like "Components ›
+       Component Tool" without per-endpoint maintenance.
+    3. If the endpoint doesn't have a ``.``, return as-is (already readable
+       e.g. ``static`` or a path-string fallback).
+    """
+    if not endpoint:
+        return endpoint
+    if endpoint in _LABEL_OVERRIDES:
+        return _LABEL_OVERRIDES[endpoint]
+    if "." not in endpoint:
+        return endpoint
+    bp, func = endpoint.split(".", 1)
+    func = func[4:] if func.startswith("api_") else func
+    pretty_func = " ".join(p.capitalize() for p in func.split("_") if p)
+    return f"{bp.capitalize()} › {pretty_func}"
+
+
 def get_stats(top_n: int = 20, slow_threshold_ms: float = 500.0) -> dict[str, Any]:
     """Return rolling-window stats per endpoint, sorted by p95 desc."""
     cutoff = time.time() - _WINDOW_SECONDS
@@ -55,12 +111,13 @@ def get_stats(top_n: int = 20, slow_threshold_ms: float = 500.0) -> dict[str, An
         avg = sum(ordered) / len(ordered)
         out.append({
             "endpoint": endpoint,
-            "count": len(ordered),
-            "p50_ms": round(p50, 1),
-            "p95_ms": round(p95, 1),
-            "avg_ms": round(avg, 1),
-            "max_ms": round(ordered[-1], 1),
-            "is_slow": p95 > slow_threshold_ms,
+            "label":    humanise_endpoint(endpoint),
+            "count":    len(ordered),
+            "p50_ms":   round(p50, 1),
+            "p95_ms":   round(p95, 1),
+            "avg_ms":   round(avg, 1),
+            "max_ms":   round(ordered[-1], 1),
+            "is_slow":  p95 > slow_threshold_ms,
         })
     out.sort(key=lambda r: r["p95_ms"], reverse=True)
     return {

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5998,8 +5998,12 @@ async function loadSystemHealth() {
             var p95Color = bad ? 'var(--text-error,#dc2626)' : 'var(--text-primary)';
             var p95Str = p95 >= 1000 ? (p95/1000).toFixed(2) + 's' : Math.round(p95) + 'ms';
             var p50Str = p50 >= 1000 ? (p50/1000).toFixed(2) + 's' : Math.round(p50) + 'ms';
-            lhtml += '<div style="display:flex;align-items:center;gap:8px;padding:6px 12px;background:' + bg + ';border-radius:6px;border:1px solid ' + border + ';font-size:12px;margin-bottom:4px;">'
-              + '<span style="font-family:monospace;color:var(--text-primary);font-weight:600;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(ep.endpoint) + '</span>'
+            // Issue #1290 — humanised label for non-technical operators;
+            // raw endpoint identifier preserved in the tooltip for engineers
+            // who need it (grep, log correlation).
+            var label = ep.label || ep.endpoint;
+            lhtml += '<div title="' + escHtml(ep.endpoint) + '" style="display:flex;align-items:center;gap:8px;padding:6px 12px;background:' + bg + ';border-radius:6px;border:1px solid ' + border + ';font-size:12px;margin-bottom:4px;">'
+              + '<span style="color:var(--text-primary);font-weight:600;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(label) + '</span>'
               + '<span style="color:var(--text-muted);font-size:10px;">n=' + ep.count + '</span>'
               + '<span style="color:var(--text-muted);font-size:11px;">p50 ' + p50Str + '</span>'
               + '<span style="color:' + p95Color + ';font-weight:600;font-size:11px;">p95 ' + p95Str + '</span>'

--- a/tests/test_latency_tracker.py
+++ b/tests/test_latency_tracker.py
@@ -69,3 +69,37 @@ def test_ignores_negative_or_empty():
     latency_tracker.record("api_x", -1.0)
     stats = latency_tracker.get_stats()
     assert stats["endpoint_count"] == 0
+
+
+def test_humanise_endpoint_static_overrides():
+    # Curated map wins over mechanical transform.
+    assert latency_tracker.humanise_endpoint(
+        "components.api_component_tool") == "Tool detail panel"
+    assert latency_tracker.humanise_endpoint(
+        "health.api_system_health") == "System health"
+    assert latency_tracker.humanise_endpoint(
+        "usage.api_anomalies") == "Cost anomalies"
+
+
+def test_humanise_endpoint_mechanical_fallback():
+    # Unknown endpoint: drop api_ prefix, ›-separated, title-cased.
+    assert latency_tracker.humanise_endpoint(
+        "newblueprint.api_something_new") == "Newblueprint › Something New"
+    # Endpoint without api_ prefix: keep func words as-is.
+    assert latency_tracker.humanise_endpoint(
+        "myblue.helper_method") == "Myblue › Helper Method"
+
+
+def test_humanise_endpoint_edge_cases():
+    # No dot at all: return as-is.
+    assert latency_tracker.humanise_endpoint("static") == "static"
+    # Empty input: return as-is.
+    assert latency_tracker.humanise_endpoint("") == ""
+
+
+def test_get_stats_includes_humanised_label():
+    latency_tracker.record("components.api_component_tool", 50.0)
+    stats = latency_tracker.get_stats()
+    row = stats["endpoints"][0]
+    assert row["endpoint"] == "components.api_component_tool"  # raw preserved
+    assert row["label"] == "Tool detail panel"  # humanised added


### PR DESCRIPTION
## Summary

UX P0 from PR #1287's review. The latency panel was rendering raw Flask \`blueprint.func\` identifiers — unreadable to operators (and definitely to non-technical Cloud users).

## Before / after

| Raw identifier                       | Humanised label              |
|--------------------------------------|------------------------------|
| components.api_component_tool        | Tool detail panel            |
| health.api_reliability               | Reliability trend            |
| sessions.api_transcript              | Session transcript           |
| usage.api_anomalies                  | Cost anomalies               |
| heartbeat.api_heartbeat              | Heartbeat ping (POST)        |

23 hand-curated overrides for the common dashboard surfaces, plus a mechanical fallback for unknown endpoints (drop \`api_\` prefix, replace \`_\` with spaces, title-case, separate blueprint with \` › \`).

## Why hybrid (overrides + mechanical)

- Curated map for common surfaces gives the most-readable labels at zero per-endpoint cost.
- Mechanical fallback handles the long tail without per-endpoint maintenance — new blueprint ships, its endpoints get readable labels automatically.
- Raw \`endpoint\` field still in the response (engineers can grep); UI shows it as the row's tooltip on hover.

## Test plan

- [x] \`pytest tests/test_latency_tracker.py\` — 9/9 pass (5 existing + 4 new)
- [x] \`python3 -c 'import dashboard'\` clean
- [x] Smoke confirms transforms:
  ```
  components.api_component_tool -> Tool detail panel
  newblue.api_something_new      -> Newblue › Something New
  no_dot                          -> no_dot (passthrough)
  ```
- [ ] Post-deploy: open System Health panel, verify rows show "Tool detail panel" not "components.api_component_tool"

🤖 Generated with [Claude Code](https://claude.com/claude-code)