### PR TITLE
fix(ui): humanise Flask blueprint identifiers in Handler Latency panel

### DIFF
--- a/clawmetry/latency_tracker.py
+++ b/clawmetry/latency_tracker.py
@@ -14,7 +14,18 @@ from __future__ import annotations
 import threading
 import time
 from collections import defaultdict, deque
-from typing import Any
+from typing import Any 
+
+def humanise_endpoint(raw: str) -> str:
+    """'components.api_component_tool' -> 'Components > Component Tool'."""
+    parts = raw.split(".", 1)
+    if len(parts) == 2:
+        module, func = parts
+        func = func.removeprefix("api_")
+        return (module.replace("_", " ").title()
+                + " \u203a "
+                + func.replace("_", " ").title())
+    return raw.replace("_", " ").title()
 
 _MAX_PER_ENDPOINT = 200
 _WINDOW_SECONDS = 5 * 60
@@ -55,6 +66,7 @@ def get_stats(top_n: int = 20, slow_threshold_ms: float = 500.0) -> dict[str, An
         avg = sum(ordered) / len(ordered)
         out.append({
             "endpoint": endpoint,
+            "label": humanise_endpoint(endpoint),
             "count": len(ordered),
             "p50_ms": round(p50, 1),
             "p95_ms": round(p95, 1),

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5998,8 +5998,8 @@ async function loadSystemHealth() {
             var p95Color = bad ? 'var(--text-error,#dc2626)' : 'var(--text-primary)';
             var p95Str = p95 >= 1000 ? (p95/1000).toFixed(2) + 's' : Math.round(p95) + 'ms';
             var p50Str = p50 >= 1000 ? (p50/1000).toFixed(2) + 's' : Math.round(p50) + 'ms';
-            lhtml += '<div style="display:flex;align-items:center;gap:8px;padding:6px 12px;background:' + bg + ';border-radius:6px;border:1px solid ' + border + ';font-size:12px;margin-bottom:4px;">'
-              + '<span style="font-family:monospace;color:var(--text-primary);font-weight:600;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(ep.endpoint) + '</span>'
+            lhtml += '<div style="display:flex;align-items:center;gap:8px;padding:6px 12px;background:' + bg + ';border-radius:6px;border:1px solid ' + border + ';font-size:12px;margin-bottom:4px;" title="' + escHtml(ep.endpoint) + '">'
+              + '<span style="color:var(--text-primary);font-weight:600;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(ep.label || ep.endpoint) + '</span>'
               + '<span style="color:var(--text-muted);font-size:10px;">n=' + ep.count + '</span>'
               + '<span style="color:var(--text-muted);font-size:11px;">p50 ' + p50Str + '</span>'
               + '<span style="color:' + p95Color + ';font-weight:600;font-size:11px;">p95 ' + p95Str + '</span>'

--- a/tests/test_latency_tracker.py
+++ b/tests/test_latency_tracker.py
@@ -69,3 +69,27 @@ def test_ignores_negative_or_empty():
     latency_tracker.record("api_x", -1.0)
     stats = latency_tracker.get_stats()
     assert stats["endpoint_count"] == 0
+
+def test_humanise_known_transforms():
+    from clawmetry.latency_tracker import humanise_endpoint
+    assert humanise_endpoint("components.api_component_tool") == "Components \u203a Component Tool"
+    assert humanise_endpoint("usage.api_anomalies") == "Usage \u203a Anomalies"
+    assert humanise_endpoint("overview.api_overview") == "Overview \u203a Overview"
+
+
+def test_humanise_unknown_endpoint():
+    from clawmetry.latency_tracker import humanise_endpoint
+    assert humanise_endpoint("some_new_mod.api_fancy_thing") == "Some New Mod \u203a Fancy Thing"
+
+
+def test_humanise_no_dot_fallback():
+    from clawmetry.latency_tracker import humanise_endpoint
+    assert humanise_endpoint("standalone_func") == "Standalone Func"
+
+
+def test_get_stats_includes_label():
+    latency_tracker.record("components.api_component_tool", 100.0)
+    stats = latency_tracker.get_stats()
+    row = stats["endpoints"][0]
+    assert row["endpoint"] == "components.api_component_tool"
+    assert row["label"] == "Components \u203a Component Tool"


### PR DESCRIPTION
Closes #1290

## What

Raw Flask blueprint:func identifiers like `components.api_component_tool` are now displayed as human-readable labels ("Components › Component Tool") in the Handler Latency panel.

## How

- Added `humanise_endpoint()` in `clawmetry/latency_tracker.py` — a mechanical transform that drops `api_` prefixes, replaces `.` with ` › ` and `_` with spaces, then title-cases. No static map needed, so new/unknown endpoints render readably automatically.
- `get_stats()` now emits a `label` field alongside the raw `endpoint` key.
- JS render loop in `app.js` displays `ep.label` (with `ep.endpoint` fallback) and sets `title` attribute to the raw identifier so engineers can hover to see it.
- Dropped monospace font from the label span since human-readable text shouldn't be monospaced.

## Tests

- Known transforms (`components.api_component_tool` → "Components › Component Tool")
- Unknown/new endpoints fall back gracefully via `.title()`
- No-dot edge case
- `label` key present in `get_stats()` output