### PR TITLE
fix(ui): reframe Cloud Brain empty-state to sell local-first trust value prop

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3579,7 +3579,7 @@ async function loadBrainPage(silent) {
       cloudEl.innerHTML = '<div style="color:var(--text-muted);padding:20px;font-size:13px;">' +
   '<div style="font-size:15px;font-weight:600;margin-bottom:6px;">🔒 Brain activity stays local — by design.</div>' +
   '<div style="margin-bottom:8px;">Your prompts, tool calls, and reasoning never leave your machine. We only see aggregated counts.</div>' +
-  '<a href="#local-first" style="color:var(--text-link, #60a5fa);text-decoration:none;">Why local-first →</a>' + +
+  '<a href="#local-first" style="color:var(--text-link, #60a5fa);text-decoration:none;">Why local-first →</a>' + 
   '</div>';
     }
     return;

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3579,7 +3579,7 @@ async function loadBrainPage(silent) {
       cloudEl.innerHTML = '<div style="color:var(--text-muted);padding:20px;font-size:13px;">' +
   '<div style="font-size:15px;font-weight:600;margin-bottom:6px;">🔒 Brain activity stays local — by design.</div>' +
   '<div style="margin-bottom:8px;">Your prompts, tool calls, and reasoning never leave your machine. We only see aggregated counts.</div>' +
-  '<a href="https://docs.clawmetry.dev/architecture/local-first" style="color:var(--text-link, #60a5fa);text-decoration:none;">Why local-first →</a>' +
+  '<a href="#local-first" style="color:var(--text-link, #60a5fa);text-decoration:none;">Why local-first →</a>' + +
   '</div>';
     }
     return;

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3576,7 +3576,11 @@ async function loadBrainPage(silent) {
   if (window.CLOUD_MODE) {
     var cloudEl = document.getElementById('brain-stream');
     if (cloudEl && /Loading/i.test(cloudEl.innerText || '')) {
-      cloudEl.innerHTML = '<div style="color:var(--text-muted);padding:20px;font-size:13px;">Live event stream is local-only. Open the dashboard on the host running OpenClaw to view brain activity.</div>';
+      cloudEl.innerHTML = '<div style="color:var(--text-muted);padding:20px;font-size:13px;">' +
+  '<div style="font-size:15px;font-weight:600;margin-bottom:6px;">🔒 Brain activity stays local — by design.</div>' +
+  '<div style="margin-bottom:8px;">Your prompts, tool calls, and reasoning never leave your machine. We only see aggregated counts.</div>' +
+  '<a href="https://docs.clawmetry.dev/architecture/local-first" style="color:var(--text-link, #60a5fa);text-decoration:none;">Why local-first →</a>' +
+  '</div>';
     }
     return;
   }


### PR DESCRIPTION
Closes #1247

## What

Replaced the apologetic Cloud Brain empty-state message with copy that leads with ClawMetry's local-first trust value prop.

## Before

> Live event stream is local-only. Open the dashboard on the host running OpenClaw to view brain activity.

## After

> 🔒 Brain activity stays local — by design.
> Your prompts, tool calls, and reasoning never leave your machine. We only see aggregated counts.
> Why local-first →

## Changes

- **`clawmetry/static/js/app.js`**: Updated the cloud-mode branch in `loadBrainPage` — swapped empty-state copy, added 🔒 prefix, added "Why local-first →" link (placeholder URL `https://docs.clawmetry.dev/architecture/local-first` until docs page exists).

## Note

The "Why local-first" link points to a placeholder docs URL. A docs PR may be needed as a follow-up — happy to file a sub-issue if the maintainer wants.