### PR TITLE
[RELEASE] feat(observability): System Health channel-ingest indicator (#1310 follow-up)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5999,6 +5999,59 @@ async function loadSystemHealth() {
       }
     } catch(e) {}
 
+    // Channel ingest (#1310 follow-up) — per-provider message counts so
+    // operators see whether the gateway WS tap is actually writing
+    // Telegram/Signal/Slack/etc. messages to DuckDB. Closes the user-felt
+    // loop on PR #1313 (the env-var fix): if Telegram appears here with a
+    // recent mins_ago, the tap is hot. If "never" / very stale, daemon
+    // didn't pick up the env var and Brain feed will look empty too.
+    try {
+      var ingest = (d && Array.isArray(d.channel_ingest)) ? d.channel_ingest : [];
+      var ciWrap = document.getElementById('sh-channel-ingest-wrap');
+      var ciEl = document.getElementById('sh-channel-ingest');
+      if (ciEl && ciWrap) {
+        if (ingest.length === 0) {
+          ciWrap.style.display = 'none';
+        } else {
+          ciWrap.style.display = '';
+          var emoji = function(p) {
+            return p === 'telegram' ? '✈️'
+                 : p === 'signal'   ? '📡'
+                 : p === 'slack'    ? '💬'
+                 : p === 'discord'  ? '🎮'
+                 : p === 'whatsapp' ? '🟢'
+                 : p === 'imessage' ? '🍎'
+                 : p === 'webchat'  ? '🌐'
+                 : p === 'irc'      ? '#'
+                 : '📨';
+          };
+          var fmtMins = function(m) {
+            if (m == null) return 'never';
+            if (m < 1) return 'just now';
+            if (m < 60) return m + 'm ago';
+            if (m < 1440) return Math.floor(m/60) + 'h ago';
+            return Math.floor(m/1440) + 'd ago';
+          };
+          var cihtml = '';
+          ingest.forEach(function(row) {
+            var mins = row.mins_ago;
+            // Hot < 10m → green, warm < 60m → amber, stale → muted.
+            var dotColor = (mins != null && mins < 10) ? '#16a34a'
+                         : (mins != null && mins < 60) ? '#d97706'
+                         : '#6b7280';
+            var border = (mins != null && mins < 10) ? 'rgba(22,163,74,0.3)' : 'var(--border-secondary)';
+            cihtml += '<div title="total ' + row.total + ' (' + (row.msg_in||0) + ' in / ' + (row.msg_out||0) + ' out)" '
+              + 'style="display:flex;align-items:center;gap:7px;padding:7px 12px;background:var(--bg-secondary);border-radius:8px;border:1px solid ' + border + ';font-size:12px;margin-bottom:4px;">'
+              + '<span style="width:9px;height:9px;border-radius:50%;background:' + dotColor + ';flex-shrink:0;display:inline-block;"></span>'
+              + emoji(row.provider) + ' <span style="font-weight:600;color:var(--text-primary);">' + escHtml(row.provider) + '</span>'
+              + '<span style="color:var(--text-muted);font-size:11px;margin-left:auto;">' + fmtMins(mins) + ' &middot; ' + row.total + ' total</span>'
+              + '</div>';
+          });
+          ciEl.innerHTML = cihtml;
+        }
+      }
+    } catch(e) { /* channel-ingest panel optional */ }
+
     // Handler latency (#1283) — top-N slowest /api/* endpoints, 5-min rolling p50/p95.
     // Surfaces /api/sessions-class regressions in seconds, not weeks.
     try {

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -203,6 +203,20 @@
           margin-bottom:6px;
           ">Heartbeat</div>
         <div id="sh-heartbeat" style="margin-bottom:14px;"></div>
+        <!-- 📨 Channel ingest (#1310 follow-up) — per-provider message
+             counts so operators see whether the gateway WS tap is actually
+             writing channel messages to DuckDB. Hidden until first sample. -->
+        <div id="sh-channel-ingest-wrap" style="display:none;">
+          <div style="
+            font-size:11px;
+            text-transform:uppercase;
+            letter-spacing:1.5px;
+            color:var(--text-muted);
+            font-weight:600;
+            margin-bottom:6px;
+            ">📨 Channel ingest</div>
+          <div id="sh-channel-ingest" style="margin-bottom:14px;"></div>
+        </div>
         <!-- ⏱️ Handler latency (#1283) — p50/p95 per /api/* endpoint, 5-min rolling -->
         <div id="sh-latency-wrap" style="display:none;">
           <div style="

--- a/routes/health.py
+++ b/routes/health.py
@@ -1327,6 +1327,10 @@ def api_system_health():
             "service_status": service_status,
             "daemon": daemon_health,
             "gateway": gateway_health,
+            # Issue #1310 follow-up — per-provider channel ingest summary
+            # so operators see whether the gateway WS tap is actually
+            # writing Telegram/Signal/Slack/etc. messages to DuckDB.
+            "channel_ingest": _channel_ingest_recent(),
             "_source": top_source,
         }
     )
@@ -1393,6 +1397,67 @@ def _query_gateway_metric_history(hours: int):
             "cpu_pct": data.get("cpu_pct"),
         })
     out.sort(key=lambda r: r.get("ts") or "")
+    return out
+
+
+def _channel_ingest_recent():
+    """Per-provider channel-ingest summary for the System Health UI
+    (#1310 follow-up). Returns a list of dicts:
+
+        [{"provider": "telegram", "total": 654, "msg_in": 600,
+          "msg_out": 54, "last_ts": "2026-05-15T11:30:00Z",
+          "mins_ago": 2}, ...]
+
+    Reads ``query_channel_summary`` via the daemon HTTP proxy so it
+    works under the standard install where the dashboard process can't
+    open DuckDB directly. Returns ``[]`` on any failure (this is a
+    decorative panel; never block /api/system-health on it).
+
+    The ``mins_ago`` field is the operator-felt signal: if it's a small
+    number for a given provider, the gateway WS tap is hot for that
+    channel. If it's "never" or huge, the tap is off OR there's been
+    no traffic — the UI distinguishes those by also showing total>0.
+    """
+    rows = None
+    try:
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_channel_summary")
+    except Exception:
+        rows = None
+    if rows is None:
+        # Single-process fallback (tests/dev with no sync daemon).
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_channel_summary()
+        except Exception:
+            return []
+    if not rows:
+        return []
+
+    now = datetime.now(timezone.utc)
+    out = []
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        last_ts = r.get("last_ts")
+        mins_ago = None
+        if last_ts:
+            try:
+                ts = datetime.fromisoformat(str(last_ts).replace("Z", "+00:00"))
+                mins_ago = max(0, int((now - ts).total_seconds() / 60))
+            except Exception:
+                mins_ago = None
+        out.append({
+            "provider": r.get("provider") or "?",
+            "total":    int(r.get("total") or 0),
+            "msg_in":   int(r.get("msg_in") or 0),
+            "msg_out":  int(r.get("msg_out") or 0),
+            "last_ts":  last_ts,
+            "mins_ago": mins_ago,
+        })
+    # Most-recently-active provider first.
+    out.sort(key=lambda r: r.get("mins_ago") if r.get("mins_ago") is not None else 1e9)
     return out
 
 


### PR DESCRIPTION
## Summary

Closes the user-felt loop on PR #1313 (Telegram WS tap default-on). PR #1313 ships the structural fix; this PR shows operators whether it actually took effect on their machine — per-provider message counts + \"last seen Nm ago\" with green/amber/muted status dot.

## Diff

- \`routes/health.py\` — new \`_channel_ingest_recent()\` helper + \`channel_ingest\` field on \`/api/system-health\`. Same daemon-proxy + single-process-fallback pattern from \`feedback_daemon_proxy_pattern.md\`.
- \`clawmetry/templates/tabs/overview.html\` — new \`#sh-channel-ingest-wrap\` card (hidden until first sample).
- \`clawmetry/static/js/app.js\` — render in \`loadSystemHealth\`. Status dot: green if \`mins_ago < 10\` (tap hot), amber if \`< 60\`, muted if older/never.

## Verified

Smoke against user's live install: returns \`[]\` (confirms #1310 — Telegram session exists in OpenClaw but no channel_messages in DuckDB because tap is disabled).

After user runs \`bash install.sh\` (PR #1313's PlistBuddy migration applies the env var) + restarts daemon, the panel will appear with a telegram row showing recent activity within ~5s of the next Telegram message.

## Test plan

- [x] \`python3 -c 'import dashboard'\` clean
- [x] curl \`/api/system-health\` returns \`channel_ingest: []\` on user's broken-state machine (validates the empty-state path)
- [ ] Post-deploy: bash install.sh → restart daemon → send Telegram message → confirm telegram row appears with green dot + recent mins_ago

🤖 Generated with [Claude Code](https://claude.com/claude-code)