### PR TITLE
[RELEASE] fix(nemoclaw): daemon-proxy approvals fast-path (#1282 part 2)

### DIFF
--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -321,6 +321,10 @@ _DAEMON_METHODS = frozenset({
     "query_channel_messages",
     "query_channel_threads",
     "query_channel_summary",
+    # Issue #1282: NeMoClaw approvals fast-path was opening DuckDB writable
+    # in routes/nemoclaw.py — collided with the daemon's writer lock.
+    # Routed through proxy so /api/nemoclaw/pending-approvals stays fast.
+    "query_approvals",
     "health",
 })
 

--- a/routes/nemoclaw.py
+++ b/routes/nemoclaw.py
@@ -67,12 +67,23 @@ def _try_local_store_approvals():
       - the ``approvals`` table is empty (fresh install / no pending rows)
       - any unexpected error happens (we'd rather degrade than 500)
     """
+    # Issue #1282 / memory `feedback_daemon_proxy_pattern.md`: writable
+    # ``get_store`` raced the sync daemon's exclusive DuckDB writer lock
+    # on multi-process installs (launchd/systemd). Try the daemon HTTP
+    # proxy first; fall back to a direct read-only open for single-process
+    # boots (tests, dev mode).
     try:
-        from clawmetry import local_store
-        store = local_store.get_store(read_only=False)
-        rows = store.query_approvals(status="pending", limit=500)
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_approvals", status="pending", limit=500)
     except Exception:
-        return None
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_approvals(status="pending", limit=500)
+        except Exception:
+            return None
     if not rows:
         return None
     approvals = []


### PR DESCRIPTION
## Why
Issue #1282 audit: \`routes/nemoclaw.py:_try_local_store_approvals\` opened DuckDB \`read_only=False\` (writable) to read pending approvals — collided with the sync daemon's exclusive writer lock on multi-process installs and forced \`/api/nemoclaw/pending-approvals\` into the slow openshell-CLI fallback.

## What
Two changes:

1. **routes/nemoclaw.py** — migrate to daemon-proxy pattern (memory \`feedback_daemon_proxy_pattern.md\`):
   - \`local_store_via_daemon("query_approvals", ...)\` first
   - \`get_store(read_only=True)\` fallback for single-process boots
2. **routes/local_query.py** — add \`query_approvals\` to \`_DAEMON_METHODS\` allowlist. Without this the proxy attempt 400s and the fast-path silently fails (the same trap PR #1258 hit with \`query_alert_rules\`).

## Issue #1282 progress
**3 of 6** writable opens migrated. Remaining: reasoning.py, sessions.py:411, overview.py:739/786, health.py.

## Test plan
- [x] \`ast.parse\` both files
- [ ] CI lint + API tests
- [ ] After publish: \`curl /api/nemoclaw/pending-approvals\` returns approvals fast (<100ms warm)