### PR TITLE
[RELEASE] fix(reasoning): daemon-proxy chains fast-path (#1282 part 3)

### DIFF
--- a/routes/reasoning.py
+++ b/routes/reasoning.py
@@ -191,17 +191,28 @@ def _try_local_store_reasoning(session_id: str):
       - no thinking blocks are present (chains would be empty)
       - any unexpected error happens (we'd rather degrade than 500)
     """
+    # Issue #1282 / memory `feedback_daemon_proxy_pattern.md`: writable
+    # ``get_store`` raced the sync daemon's exclusive DuckDB writer lock
+    # on multi-process installs (launchd/systemd). Try the daemon HTTP
+    # proxy first; fall back to a direct read-only open for single-process
+    # boots (tests, dev mode).
     try:
-        from clawmetry import local_store
-    except Exception:
-        return None
-    try:
-        store = local_store.get_store()
-        rows = store.query_events(
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon(
+            "query_events",
             session_id=session_id, event_type="message", limit=2000,
         )
     except Exception:
-        return None
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_events(
+                session_id=session_id, event_type="message", limit=2000,
+            )
+        except Exception:
+            return None
     if not rows:
         return None
 


### PR DESCRIPTION
## Why
Issue #1282 audit: \`routes/reasoning.py:_try_local_store_reasoning_chains\` opened DuckDB writable to read message events for \`/api/reasoning/<session_id>\` — collided with the sync daemon's exclusive writer lock, forcing reasoning-chain rendering into the slow JSONL parser.

## What
Migrated to the daemon-proxy pattern. \`query_events\` already in \`_DAEMON_METHODS\` allowlist — no allowlist change needed.

## Issue #1282 progress
**4 of 6** writable opens migrated.
- ✅ advisor.py (#1323)
- ✅ nemoclaw.py (#1324, in CI)
- ✅ reasoning.py (this PR)
- 🟡 Remaining: sessions.py:411 (raw \`_fetch\` — needs new query method), overview.py (739/786), health.py (2258/2473/2762)

## Test plan
- [x] \`ast.parse\` passes
- [ ] CI lint + API tests
- [ ] After publish: reasoning-chain panel renders fast on multi-process installs