### PR TITLE
[RELEASE] fix(routes): #1282 daemon-proxy audit — overview + health (5 of 6)

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -2253,12 +2253,19 @@ def _try_local_store_sandbox_status():
     Returns ``None`` if the local_store module is missing, no snapshot of
     kind 'sandbox' exists, or the row's payload doesn't decode.
     """
+    # Issue #1282: daemon-proxy first, read-only fallback for single-process boots.
     try:
-        from clawmetry import local_store
-        store = local_store.get_store()
-        rows = store.query_system_snapshots(kind="sandbox", limit=1)
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_system_snapshots", kind="sandbox", limit=1)
     except Exception:
-        return None
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_system_snapshots(kind="sandbox", limit=1)
+        except Exception:
+            return None
     if not rows:
         return None
     payload = rows[0].get("data")
@@ -2468,17 +2475,30 @@ def _try_local_store_loop_detection(window: int, min_repeats: int):
     Returns ``None`` when local_store is missing or no tool_call events
     exist. ``checked`` is the count of distinct sessions inspected.
     """
+    # Issue #1282: daemon-proxy first, read-only fallback for single-process boots.
+    rows: list = []
     try:
-        from clawmetry import local_store
-        store = local_store.get_store()
-        rows = []
+        from routes.local_query import local_store_via_daemon
         for et in ("tool_call", "toolCall"):
             try:
-                rows.extend(store.query_events(event_type=et, limit=10000))
+                proxy_rows = local_store_via_daemon("query_events", event_type=et, limit=10000)
+                if proxy_rows:
+                    rows.extend(proxy_rows)
             except Exception:
                 continue
     except Exception:
-        return None
+        rows = []
+    if not rows:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            for et in ("tool_call", "toolCall"):
+                try:
+                    rows.extend(store.query_events(event_type=et, limit=10000))
+                except Exception:
+                    continue
+        except Exception:
+            return None
     if not rows:
         return None
 
@@ -2757,12 +2777,19 @@ def _try_local_store_mcp_stats():
     Returns ``None`` when the local_store module is missing or no
     ``mcp_call`` events exist.
     """
+    # Issue #1282: daemon-proxy first, read-only fallback for single-process boots.
     try:
-        from clawmetry import local_store
-        store = local_store.get_store()
-        rows = store.query_events(event_type="mcp_call", limit=10000)
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_events", event_type="mcp_call", limit=10000)
     except Exception:
-        return None
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_events(event_type="mcp_call", limit=10000)
+        except Exception:
+            return None
     if not rows:
         return None
 

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -736,7 +736,7 @@ def _try_local_store_overview():
     if sess_rows is None:
         try:
             from clawmetry import local_store
-            sess_rows = local_store.get_store().query_sessions_table(limit=200)
+            sess_rows = local_store.get_store(read_only=True).query_sessions_table(limit=200)
         except Exception:
             return None
     if not sess_rows:
@@ -783,7 +783,7 @@ def _try_local_store_overview():
         if evs is None:
             try:
                 from clawmetry import local_store
-                evs = local_store.get_store().query_events(limit=20)
+                evs = local_store.get_store(read_only=True).query_events(limit=20)
             except Exception:
                 evs = []
         for e in (evs or []):


### PR DESCRIPTION
## Why
Closes the remaining writable \`local_store.get_store()\` callsites flagged in issue #1282 audit. The daemon's exclusive DuckDB writer lock makes any writable open from the dashboard process race-or-hang on multi-process installs.

## What — 5 callsites migrated

**routes/overview.py** (fallback paths — read_only=True swap)
- L739: \`_try_local_store_overview\` sessions fallback
- L786: model-name discovery fallback

**routes/health.py** (PRIMARY writable opens — full daemon-proxy + read_only fallback)
- L2258 \`_try_local_store_security_posture\` — \`query_system_snapshots\`
- L2473 \`_try_local_store_loop_detection\` — \`query_events\` (tool_call + toolCall)
- L2762 \`_try_local_store_mcp_health\` — \`query_events\` (mcp_call)

## Issue #1282 audit complete: 5 of 6
- ✅ advisor.py (#1323)
- ✅ nemoclaw.py (#1324)
- ✅ reasoning.py (#1325)
- ✅ overview.py:739/786 (this PR)
- ✅ health.py:2258/2473/2762 (this PR)
- 🟡 sessions.py:411 — needs new query method (raw \`_fetch\` not allowlistable); deferred to follow-up

## Test plan
- [x] \`ast.parse\` both files
- [ ] CI lint + API tests
- [ ] After publish: /api/system-health, /api/loop-detection, /api/mcp-health all <500ms warm on multi-process installs