### PR TITLE
[RELEASE] fix(sessions): #1282 final callsite — by-type fast path (closes #1282)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -406,48 +406,48 @@ def _try_local_store_sessions_by_type(type_filter: str = ""):
       - the sessions table is empty (fresh install / non-OpenClaw user)
       - any unexpected error happens (we'd rather degrade than 500)
     """
+    # Issue #1282 (final callsite): replace the inline raw ``_fetch`` SELECT —
+    # which forced a writable ``get_store()`` open and raced the sync daemon's
+    # exclusive DuckDB writer lock — with ``query_sessions_table`` via the
+    # daemon HTTP proxy. ``query_sessions_table`` already in
+    # ``_DAEMON_METHODS`` allowlist; returns dict-shaped rows with metadata
+    # JSON-decoded so we can drop the manual tuple-indexing + bytes-decode.
+    rows = None
     try:
-        from clawmetry import local_store
-        store = local_store.get_store()
-        rows = store._fetch("""
-            SELECT agent_type, session_id, agent_id, title, started_at,
-                   last_active_at, ended_at, status, total_tokens, cost_usd,
-                   message_count, metadata
-            FROM sessions
-            ORDER BY COALESCE(last_active_at, started_at) DESC NULLS LAST
-            LIMIT 200
-        """, [])
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_sessions_table", limit=200)
     except Exception:
-        return None
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_sessions_table(limit=200)
+        except Exception:
+            return None
     if not rows:
         return None
 
     sessions = []
     explicit_types: dict[str, str] = {}
     for r in rows:
-        meta = {}
-        if r[11]:
-            try:
-                import json as _j
-                meta = _j.loads(bytes(r[11]).decode("utf-8"))
-            except Exception:
-                pass
+        meta = r.get("metadata") if isinstance(r.get("metadata"), dict) else {}
         s = {
-            "agent_type":     r[0],
-            "session_id":     r[1],
-            "agent_id":       r[2],
-            "title":          r[3] or "",
-            "started_at":     r[4] or "",
-            "updated_at":     r[5] or "",
-            "ended_at":       r[6] or "",
-            "status":         r[7] or "",
-            "total_tokens":   int(r[8] or 0),
-            "total_cost":     float(r[9] or 0.0),
-            "message_count":  int(r[10] or 0),
+            "agent_type":     r.get("agent_type"),
+            "session_id":     r.get("session_id"),
+            "agent_id":       r.get("agent_id"),
+            "title":          r.get("title") or "",
+            "started_at":     r.get("started_at") or "",
+            "updated_at":     r.get("last_active_at") or "",
+            "ended_at":       r.get("ended_at") or "",
+            "status":         r.get("status") or "",
+            "total_tokens":   int(r.get("total_tokens") or 0),
+            "total_cost":     float(r.get("cost_usd") or 0.0),
+            "message_count":  int(r.get("message_count") or 0),
             "channel":        meta.get("channel", ""),
             "chat_type":      meta.get("chat_type", ""),
-            "subject":        r[3] or meta.get("subject", ""),
-            "displayName":    r[3] or "",
+            "subject":        r.get("title") or meta.get("subject", ""),
+            "displayName":    r.get("title") or "",
             "kind":           meta.get("kind", ""),
             "_source":        "local_store",
         }


### PR DESCRIPTION
## Why
\`routes/sessions.py:_try_local_store_sessions_by_type\` was the last writable \`get_store()\` open in the #1282 audit. It used a raw \`store._fetch(SELECT ...)\` — which can't go through the daemon-proxy allowlist — and so couldn't be migrated mechanically.

## What
Refactored the callsite to use the existing \`query_sessions_table\` LocalStore method (already in \`_DAEMON_METHODS\` allowlist):

1. Try \`local_store_via_daemon("query_sessions_table", limit=200)\`.
2. Fall back to \`get_store(read_only=True).query_sessions_table()\` for single-process boots (tests, dev mode).

Row-projection cleaner too: \`query_sessions_table\` returns dict-shaped rows with metadata pre-decoded, so the manual tuple-indexing + bytes→str decode disappears. **Bonus**: this callsite now picks up the GREATEST(stored, COUNT-subquery) \`message_count\` fix from #1129 that the inline SELECT was missing.

## Issue #1282 audit COMPLETE: 6 of 6 ✅
- ✅ advisor.py (#1323)
- ✅ nemoclaw.py (#1324)
- ✅ reasoning.py (#1325)
- ✅ overview.py:739/786 + health.py:2258/2473/2762 (#1330)
- ✅ sessions.py:411 (this PR)

The audit started with 17 callsites flagged in #1282; 6 were primary writable opens, all now migrated.

## Test plan
- [x] \`ast.parse\` passes
- [ ] CI lint + API tests
- [ ] After publish: \`/api/sessions?type=user\` returns from \`_source: local_store\` fast path on multi-process installs