### PR TITLE
[RELEASE] fix(ui): loadAlertRules + loadAlertHistory Retry pattern (#1257 part 4)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -171,7 +171,10 @@ async function loadAlertRules() {
     });
     document.getElementById('alert-rules-list').innerHTML = html;
   } catch(e) {
-    document.getElementById('alert-rules-list').textContent = 'Failed to load';
+    // Issue #1257: replace silent "Failed to load" text with an actionable
+    // Failed-to-load + Retry pattern. Mirror loadCrons / loadAutonomy / loadSystemHealth.
+    var el = document.getElementById('alert-rules-list');
+    if (el) el.innerHTML = '<div style="color:var(--text-error);padding:20px;font-size:13px;">Failed to load: ' + escHtml(String(e)) + ' &nbsp;<button onclick="loadAlertRules()" style="margin-left:8px;background:transparent;border:1px solid var(--border-primary);color:var(--text-secondary);border-radius:4px;padding:2px 10px;font-size:11px;cursor:pointer;">Retry</button></div>';
   }
 }
 
@@ -267,7 +270,9 @@ async function loadAlertHistory() {
     });
     document.getElementById('alert-history-list').innerHTML = html;
   } catch(e) {
-    document.getElementById('alert-history-list').textContent = 'Failed to load';
+    // Issue #1257: Failed-to-load + Retry button pattern (mirror #1314/#1316).
+    var el = document.getElementById('alert-history-list');
+    if (el) el.innerHTML = '<div style="color:var(--text-error);padding:20px;font-size:13px;">Failed to load: ' + escHtml(String(e)) + ' &nbsp;<button onclick="loadAlertHistory()" style="margin-left:8px;background:transparent;border:1px solid var(--border-primary);color:var(--text-secondary);border-radius:4px;padding:2px 10px;font-size:11px;cursor:pointer;">Retry</button></div>';
   }
 }
 


### PR DESCRIPTION
## Why
Issue #1257: when a panel-loader fetch fails, users saw the dead string \"Failed to load\" with no explanation or recovery. Earlier PRs fixed loadCrons (#1314), loadAutonomy + loadSystemHealth (#1316). This PR extends the pattern to the Alerts tab.

## What
Two callsites in \`app.js\` swapped from \`textContent = 'Failed to load'\` to the standard inline pattern: error message + Retry button.

| Line | Function | Tab |
|---|---|---|
| 174 | \`loadAlertRules\` | Alerts → Rules |
| 268 | \`loadAlertHistory\` | Alerts → History |

## Issue #1257 status
The issue called out \`loadAlertsPage\` / \`loadChannelsTab\` / \`loadComponent\` by name — those don't exist verbatim. Mapping to actual loaders:
- ✅ Alerts tab → \`loadAlertRules\` + \`loadAlertHistory\` (this PR)
- 🟡 Channels tab → \`loadGenericChannelData\` (modal-shaped, separate audit)
- 🟡 Components panel → \`loadComponentWithTimeContext\` (panel-shaped, separate audit)

## Test plan
- [x] Node syntax check passes
- [ ] CI lint + API tests
- [ ] Post-deploy: kill /api/alerts/rules in DevTools (Network tab → block URL), reload, confirm Alerts tab shows Failed-to-load + Retry button (not silent text)