### PR TITLE
[RELEASE] fix(ui): channel-modal Retry buttons via _compModalError helper (#1338 part 1)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -9873,6 +9873,22 @@ function openCompModal(nodeId) {
   document.getElementById('comp-modal-overlay').classList.add('open');
 }
 
+// Issue #1338: shared helper for channel-modal error renders. Mirrors the
+// Failed-to-load + Retry pattern from PRs #1314/#1316/#1337 (panel loaders),
+// adapted for the modal-body shape used by per-channel loaders.
+//   retryFn: name string of the function to invoke (becomes onclick="retryFn()")
+//   label:   human-friendly channel/feature name (e.g. 'Telegram', 'Slack')
+//   err:     thrown Error or string
+function _compModalError(retryFn, label, err) {
+  var msg = err && err.message ? err.message : String(err || '');
+  var btn = retryFn
+    ? ' <button onclick="' + retryFn + '()" style="margin-left:8px;background:transparent;border:1px solid var(--border-primary);color:var(--text-secondary);border-radius:4px;padding:2px 10px;font-size:11px;cursor:pointer;">Retry</button>'
+    : '';
+  var labelPart = label ? ' ' + escapeHtml(label) : '';
+  var msgPart   = msg ? ': ' + escapeHtml(msg) : '';
+  return '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load' + labelPart + msgPart + btn + '</div>';
+}
+
 function loadTelegramMessages(isRefresh) {
   var expectedNodeId = 'node-telegram';
   var url = '/api/channel/telegram?limit=50&offset=0';
@@ -9905,7 +9921,7 @@ function loadTelegramMessages(isRefresh) {
   }).catch(function(e) {
     if (!isCompModalActive(expectedNodeId)) return;
     if (!isRefresh) {
-      document.getElementById('comp-modal-body').innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load messages</div>';
+      document.getElementById('comp-modal-body').innerHTML = _compModalError('loadTelegramMessages', 'Telegram messages', null);
     }
   });
 }
@@ -10036,7 +10052,7 @@ function loadIMessageMessages(isRefresh) {
   }).catch(function(e) {
     if (!isCompModalActive(expectedNodeId)) return;
     if (!isRefresh) {
-      document.getElementById('comp-modal-body').innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load iMessages: ' + escapeHtml(e.message) + '</div>';
+      document.getElementById('comp-modal-body').innerHTML = _compModalError('loadIMessageMessages', 'iMessages', e);
     }
   });
 }
@@ -10070,7 +10086,7 @@ function loadWhatsAppMessages(isRefresh) {
   }).catch(function(e) {
     if (!isCompModalActive(expectedNodeId)) return;
     if (!isRefresh) {
-      document.getElementById('comp-modal-body').innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load WhatsApp messages</div>';
+      document.getElementById('comp-modal-body').innerHTML = _compModalError('loadWhatsAppMessages', 'WhatsApp messages', null);
     }
   });
 }
@@ -10104,7 +10120,7 @@ function loadSignalMessages(isRefresh) {
   }).catch(function(e) {
     if (!isCompModalActive(expectedNodeId)) return;
     if (!isRefresh) {
-      document.getElementById('comp-modal-body').innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load Signal messages</div>';
+      document.getElementById('comp-modal-body').innerHTML = _compModalError('loadSignalMessages', 'Signal messages', null);
     }
   });
 }
@@ -10194,7 +10210,7 @@ function loadDiscordMessages(isRefresh) {
     document.getElementById('comp-modal-footer').textContent = 'Last updated: ' + new Date().toLocaleTimeString();
   }).catch(function(e) {
     if (!isCompModalActive(expectedNodeId)) return;
-    document.getElementById('comp-modal-body').innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load Discord: ' + escapeHtml(e.message) + '</div>';
+    document.getElementById('comp-modal-body').innerHTML = _compModalError('loadDiscordMessages', 'Discord', e);
   });
 }
 
@@ -10237,7 +10253,7 @@ function loadSlackMessages(isRefresh) {
     document.getElementById('comp-modal-footer').textContent = 'Last updated: ' + new Date().toLocaleTimeString();
   }).catch(function(e) {
     if (!isCompModalActive(expectedNodeId)) return;
-    document.getElementById('comp-modal-body').innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load Slack: ' + escapeHtml(e.message) + '</div>';
+    document.getElementById('comp-modal-body').innerHTML = _compModalError('loadSlackMessages', 'Slack', e);
   });
 }
 


### PR DESCRIPTION
## Why
Issue #1338 audit found 12 channel-modal callsites still using legacy \`'Failed to load: <err>'\` text without a Retry button. Different shape from the panel-loaders fixed in #1314/#1316/#1337 (modal-body, not list-replace), so they need their own helper.

## What
New helper \`_compModalError(retryFn, label, err)\` near line 9876. Renders the standard error+Retry shell. Each callsite becomes 1 line:
\`\`\`js
document.getElementById('comp-modal-body').innerHTML =
  _compModalError('loadSlackMessages', 'Slack', e);
\`\`\`

## Sites covered (6 of 12)
- loadTelegramMessages, loadIMessageMessages, loadWhatsAppMessages, loadSignalMessages, loadDiscordMessages, loadSlackMessages

## Deferred (6) — need per-site audit
6 callsites whose owning function isn't trivially derivable: lines 9838, 9866, 10684 (brain), 10834 (cost optimizer), 11169 (gateway), 11508. Following up in a Part 2 PR.

## Test plan
- [x] \`node --check\` passes
- [ ] CI green
- [ ] Post-deploy: open Telegram modal, kill /api/channel/telegram in DevTools, confirm Retry button works