### PR TITLE
[RELEASE] fix(ui): channel-modal Retry buttons part 2 — Brain/Cost/Gateway (#1338)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10697,7 +10697,7 @@ function loadBrainData(isRefresh) {
     if (msg.toLowerCase().includes('abort')) {
       msg = 'Request timed out. The brain panel is heavy; please retry in 2-3 seconds.';
     }
-    document.getElementById('comp-modal-body').innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load brain data: ' + msg + '</div>';
+    document.getElementById('comp-modal-body').innerHTML = _compModalError('loadBrainData', 'brain data', { message: msg });
   });
 }
 
@@ -10847,7 +10847,7 @@ function loadCostOptimizerData(isRefresh) {
   }).catch(function(e) {
     if (!isCompModalActive(expectedNodeId)) return;
     if (!isRefresh) {
-      document.getElementById('comp-modal-body').innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load cost optimizer: ' + e.message + '</div>';
+      document.getElementById('comp-modal-body').innerHTML = _compModalError('loadCostOptimizerData', 'cost optimizer', e);
     }
   });
 }
@@ -11182,7 +11182,7 @@ function loadGatewayData(isRefresh) {
   }).catch(function(e) {
     if (!isCompModalActive(expectedNodeId)) return;
     if (!isRefresh) {
-      document.getElementById('comp-modal-body').innerHTML = '<div style="text-align:center;padding:20px;color:var(--text-error);">Failed to load gateway data</div>';
+      document.getElementById('comp-modal-body').innerHTML = _compModalError('loadGatewayData', 'gateway data', null);
     }
   });
 }


### PR DESCRIPTION
## Why
Issue #1338 follow-up. Part 1 (#1339) added the \`_compModalError\` helper + 6 channel-message loaders. This PR wires it to 3 more component-panel loaders.

## What
| Line | Function | Tab |
|---|---|---|
| 10684 | \`loadBrainData\` | Component → Brain panel |
| 10834 | \`loadCostOptimizerData\` | Component → Cost optimizer |
| 11169 | \`loadGatewayData\` | Component → Gateway |

The Brain swap preserves the helpful timeout-friendly error rewrite ("Request timed out. The brain panel is heavy; please retry in 2-3 seconds") by passing it as \`err.message\`.

## Issue #1338 status
- ✅ Part 1 (#1339): 6 channel-message loaders
- ✅ Part 2 (this PR): 3 component-panel loaders
- 🟡 Part 3 (deferred): 3 dispatch-shaped sites (skills modal, generic component, tool-event handler) — owning function names not trivially derivable

## Test plan
- [x] \`node --check\` passes
- [ ] CI lint + API tests
- [ ] Post-deploy: open Brain panel, kill /api/component/brain, confirm Retry button works