### PR TITLE
[RELEASE] feat(approvals): batch checkboxes + bulk Approve/Deny (#1343 Phase 1.3 — closes Phase 1)

### DIFF
--- a/clawmetry/templates/tabs/approvals.html
+++ b/clawmetry/templates/tabs/approvals.html
@@ -27,6 +27,18 @@
   <!-- ═══ SECTION 1: Pending Queue (top of LEFT col) ═══ -->
   <div id="approvals-pending-section" style="margin-bottom:16px;">
     <div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:700;margin-bottom:6px;">Pending Approvals</div>
+
+    <!-- Bulk-action header (#1343 Phase 1.3) — hidden until ≥1 selected.
+         Lets operators triage a flood (e.g. "approve all 12 pending HTTP
+         requests from the same trusted session") without per-row clicks. -->
+    <div id="approvals-bulk-header" style="display:none;background:var(--bg-secondary);border:1px solid var(--border-secondary);border-radius:8px;padding:8px 12px;margin-bottom:8px;align-items:center;gap:10px;flex-wrap:wrap;">
+      <span id="approvals-bulk-count" style="font-size:12px;font-weight:700;color:var(--text-primary);"></span>
+      <input type="text" id="approvals-bulk-reason" placeholder="Bulk decision reason (optional, applied to all)" style="flex:1;min-width:200px;padding:5px 10px;border:1px solid var(--border-secondary);border-radius:6px;background:var(--bg-primary);color:var(--text-primary);font-size:12px;">
+      <button onclick="bulkDecide('approve')" style="background:#22c55e;color:#062614;border:0;padding:6px 14px;border-radius:6px;font-weight:600;font-size:12px;cursor:pointer;">Approve selected</button>
+      <button onclick="bulkDecide('deny')" style="background:#ef4444;color:#fff;border:0;padding:6px 14px;border-radius:6px;font-weight:600;font-size:12px;cursor:pointer;">Deny selected</button>
+      <button onclick="bulkClearSelection()" style="background:transparent;color:var(--text-muted);border:1px solid var(--border-secondary);padding:6px 12px;border-radius:6px;font-size:12px;cursor:pointer;">Clear</button>
+    </div>
+
     <div id="approvals-pending-list">
       <div style="padding:18px;text-align:center;color:var(--text-muted);font-size:12px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;">Loading...</div>
     </div>
@@ -418,6 +430,11 @@
     var when = (r.requested_at || '').replace('T',' ').slice(0,19);
     var html = '<div style="background:var(--bg-secondary);border:1px solid var(--border);border-left:3px solid ' + c + ';border-radius:8px;padding:12px 14px;margin-bottom:8px;">';
     html += '<div style="display:flex;align-items:center;gap:10px;margin-bottom:6px;flex-wrap:wrap;">';
+    if (pending) {
+      // Phase 1.3 (#1343): bulk-select checkbox. Event delegation in
+      // initBulkSelection() listens for change events on the list.
+      html += '<input type="checkbox" class="approval-bulk-checkbox" data-approval-id="' + escHtml(r.id) + '" style="cursor:pointer;flex-shrink:0;" title="Select for bulk action">';
+    }
     html += '<span style="font-weight:700;color:var(--text-primary);font-size:13px;">' + escHtml(r.tool_name || '?') + '</span>';
     html += '<span style="background:' + c + '22;color:' + c + ';border:1px solid ' + c + '44;padding:1px 8px;border-radius:99px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">' + escHtml(r.status) + '</span>';
     if (r.policy_name) {
@@ -471,9 +488,27 @@
       var pe = document.getElementById('approvals-pending-list');
       if (p.length === 0) {
         pe.innerHTML = '<div style="padding:14px;text-align:center;color:var(--text-muted);font-size:12px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;">No pending approvals right now.</div>';
+        // Drop selections for IDs that are no longer pending (decided
+        // elsewhere, expired, etc.) so the bulk header doesn't lie.
+        _approvalsBulkSelected.clear();
       } else {
         pe.innerHTML = p.map(function(r){return _renderRow(r, true);}).join('');
+        // Phase 1.3 (#1343): selection survives across renders. Re-check
+        // boxes for IDs still in the set; prune IDs that aren't on the
+        // page any more (decided/expired elsewhere).
+        var stillThere = new Set();
+        document.querySelectorAll('.approval-bulk-checkbox').forEach(function(cb){
+          var id = cb.dataset.approvalId;
+          if (_approvalsBulkSelected.has(id)) {
+            cb.checked = true;
+            stillThere.add(id);
+          }
+        });
+        _approvalsBulkSelected.forEach(function(id){
+          if (!stillThere.has(id)) _approvalsBulkSelected.delete(id);
+        });
       }
+      _refreshBulkHeader();
 
       // Policies
       renderPresets(policies.policies || []);
@@ -614,13 +649,19 @@
   };
 
   /* ── Decide (approve/deny) ── */
-  window.decideApproval = async function(id, action) {
+  window.decideApproval = async function(id, action, opts) {
     // Phase 1.2 (#1343): pick up the optional decision-reason input rendered
     // alongside each pending row. Backend stores it in the existing
     // ``decision_reason`` column so the audit trail captures WHY, not just
     // who+when. Empty input → omit field (preserves backward compat).
-    var reasonEl = document.getElementById('dec-reason-' + id);
-    var reason = reasonEl && reasonEl.value ? reasonEl.value.trim() : '';
+    // Phase 1.3: opts.reason / opts.silentRefresh / opts.skipReload supported
+    // for bulk-action callers.
+    opts = opts || {};
+    var reason = opts.reason;
+    if (!reason) {
+      var reasonEl = document.getElementById('dec-reason-' + id);
+      reason = reasonEl && reasonEl.value ? reasonEl.value.trim() : '';
+    }
     var body = {action: action};
     if (reason) body.decision_reason = reason;
     try {
@@ -630,11 +671,75 @@
       });
       var d = await r.json();
       if (!r.ok) throw new Error(d.error || ('HTTP ' + r.status));
-      loadApprovalsTab();
+      if (!opts.skipReload) loadApprovalsTab();
+      return {ok: true};
     } catch(e) {
-      alert('Decision failed: ' + e);
+      if (!opts.silentRefresh) alert('Decision failed: ' + e);
+      return {ok: false, error: String(e)};
     }
   };
+
+  /* ── Bulk decide (Phase 1.3 #1343) ──
+   * Tracks selected approval IDs in a Set; bulk-action header shows
+   * Approve/Deny buttons + a shared optional reason input. Sequential
+   * POSTs (not Promise.all) so we don't burst the backend with 50 calls
+   * if a flood lands. Single loadApprovalsTab() refresh at the end.
+   */
+  var _approvalsBulkSelected = new Set();
+
+  function _refreshBulkHeader() {
+    var hdr = document.getElementById('approvals-bulk-header');
+    var cnt = document.getElementById('approvals-bulk-count');
+    if (!hdr || !cnt) return;
+    var n = _approvalsBulkSelected.size;
+    if (n === 0) {
+      hdr.style.display = 'none';
+    } else {
+      hdr.style.display = 'flex';
+      cnt.textContent = n + ' selected';
+    }
+  }
+
+  window.bulkClearSelection = function() {
+    _approvalsBulkSelected.clear();
+    document.querySelectorAll('.approval-bulk-checkbox').forEach(function(cb){ cb.checked = false; });
+    _refreshBulkHeader();
+  };
+
+  window.bulkDecide = async function(action) {
+    var ids = Array.from(_approvalsBulkSelected);
+    if (ids.length === 0) return;
+    var verb = action === 'approve' ? 'Approve' : 'Deny';
+    if (!confirm(verb + ' ' + ids.length + ' selected approval(s)?')) return;
+    var bulkReasonEl = document.getElementById('approvals-bulk-reason');
+    var bulkReason = bulkReasonEl && bulkReasonEl.value ? bulkReasonEl.value.trim() : '';
+    var failed = 0;
+    for (var i = 0; i < ids.length; i++) {
+      var res = await window.decideApproval(ids[i], action, {
+        reason: bulkReason,
+        skipReload: true,
+        silentRefresh: true
+      });
+      if (!res || !res.ok) failed++;
+    }
+    _approvalsBulkSelected.clear();
+    if (bulkReasonEl) bulkReasonEl.value = '';
+    loadApprovalsTab();
+    if (failed > 0) alert(failed + ' of ' + ids.length + ' decisions failed (others succeeded).');
+  };
+
+  // Event delegation: any checkbox change inside the pending list updates
+  // the selection set. Re-renders blow away the DOM, but the Set survives,
+  // so we need to re-sync checkbox checked-state on each render.
+  document.addEventListener('change', function(e) {
+    if (e.target && e.target.classList && e.target.classList.contains('approval-bulk-checkbox')) {
+      var id = e.target.dataset.approvalId;
+      if (!id) return;
+      if (e.target.checked) _approvalsBulkSelected.add(id);
+      else _approvalsBulkSelected.delete(id);
+      _refreshBulkHeader();
+    }
+  });
 
   /* ── Background badge poll ── */
   setInterval(function(){


### PR DESCRIPTION
## Why
Phase 1.3 of #1343. With 1.1 (layout) + 1.2 (per-row context) shipped, operators can see what needs deciding — but a flood (e.g. 12 pending HTTP requests from one trusted session) still demands 12 individual button-clicks. Bulk select solves that.

## What

**UI**
- Per-row checkbox at the start of each pending row
- Bulk-action header above the list (hidden until ≥1 selected): \`N selected\` + reason input + Approve/Deny/Clear

**State**
- \`_approvalsBulkSelected\` Set; event delegation tracks changes
- Re-paint preserves selection for surviving IDs, prunes vanished ones

**Backend**
- No new endpoints. \`decideApproval(id, action, opts)\` extended with \`opts.reason\` / \`opts.skipReload\` / \`opts.silentRefresh\` for bulk callers
- Sequential POSTs (not Promise.all) to avoid bursting the backend
- Single \`loadApprovalsTab()\` reload at the end
- Confirm prompt before bulk action; failure count summarised after

## Issue #1343 status
- ✅ Phase 1.1 (#1344): 2-column layout
- ✅ Phase 1.2 (#1345): per-row context expansion
- ✅ Phase 1.3 (this PR): bulk actions
- 🟡 Phase 2: policy-watcher → DuckDB tool_call ingest hook (event-driven, kill polling)
- 🟡 Phase 3: OpenClaw native \`~/.openclaw/approvals.json\` bridge

**Phase 1 complete after this lands.** The approvals tab is now Langfuse-grade per the user's #1343 ask.

## Test plan
- [ ] CI lint
- [ ] Post-deploy: trigger 3 pending approvals, check 2 of them, click "Approve selected" → verify both decided + audit reason logged + 3rd still pending