### PR TITLE
[RELEASE] feat(approvals): wire watcher_kick into _flush_now (#1343 Phase 2.2 — closes Phase 2)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -2086,6 +2086,20 @@ class LocalStore:
                 if self._ring:
                     self._ring.popleft()
         self._last_flush_ts = time.monotonic()
+        # Issue #1343 Phase 2.2 — kick the approvals watcher when a tool_call
+        # row just landed. The watcher_loop reads from DuckDB; the COMMIT
+        # above is what makes the row visible to it. Kicking before the
+        # commit would race the watcher to an empty read. Coalesces inside
+        # approvals._kick_event so a 50-event burst → 1 wakeup.
+        for e in batch:
+            et = e.get("event_type")
+            if et == "tool_call" or et == "toolCall":
+                try:
+                    from clawmetry import approvals as _approvals
+                    _approvals.watcher_kick()
+                except Exception:
+                    pass  # partial install / approvals.py not importable
+                break  # one kick per batch; coalesces N events into 1 wake
         return len(rows)
 
     # ── queries ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why
Phase 2.2 of #1343. Phase 2.1 (#1350) shipped the kick infrastructure. This wires it: at the end of \`LocalStore._flush_now()\`, if any flushed event was a \`tool_call\`/\`toolCall\`, lazy-import \`approvals.watcher_kick()\` and call it.

## Effect
Detection latency for a fresh tool_call event drops from up to 2 s (watcher's polling interval) → ~0 ms (kick wakes it immediately). Coalesces inside \`approvals._kick_event\` — 50-event flush = 1 wakeup.

## Safety
- Lazy import — partial installs without approvals.py don't crash flush
- try/except swallows unrelated import errors
- Kick AFTER COMMIT (row must be readable when watcher wakes; kick-before would race to empty read)
- \`break\` after first match — one kick per batch
- Backward compat: watcher's 2 s heartbeat is still the safety net

## Issue #1343 status
- ✅ Phase 1.1 (#1344) / 1.2 (#1345) / 1.3 (#1347): UI complete
- ✅ Phase 2.1 (#1350): kick infrastructure
- ✅ Phase 2.2 (this PR): kick wired into ingest path
- 🟡 Phase 3: OpenClaw native bridge

**Phase 2 complete after this lands.** Approvals are event-driven end-to-end.

## Test plan
- [x] \`ast.parse\` passes
- [ ] CI lint + API tests
- [ ] Post-deploy: trigger a synthetic tool_call from openclaw, observe watcher logs show \`scanned 1 new toolCalls\` within ~10ms (vs ~2s today)