### PR TITLE
feat: zero-click localhost auto-login in auth-bootstrap.js (#1356 PR-C)

### DIFF
--- a/clawmetry/static/js/auth-bootstrap.js
+++ b/clawmetry/static/js/auth-bootstrap.js
@@ -1,29 +1,53 @@
 (function(){
   var stored = localStorage.getItem('clawmetry-token');
-  fetch('/api/auth/check' + (stored ? '?token=' + encodeURIComponent(stored) : ''))
-    .then(function(r){return r.json()})
-    .then(function(d){
-      if(d.needsSetup){
-        // No gateway token configured -- show mandatory gateway setup wizard
-        document.getElementById('login-overlay').style.display='none';
-        var overlay=document.getElementById('gw-setup-overlay');
-        overlay.dataset.mandatory='true';
-        document.getElementById('gw-setup-close').style.display='none';
-        overlay.style.display='flex';
-        return;
-      }
-      if(!d.authRequired){
-        document.getElementById('login-overlay').style.display='none';
-        return;
-      }
-      if(d.valid){
-        document.getElementById('login-overlay').style.display='none';
-        var lb=document.getElementById('logout-btn');if(lb)lb.style.display='';
-        return;
-      }
-      localStorage.removeItem('cm-token');localStorage.removeItem('clawmetry-token');sessionStorage.removeItem('cm-token');document.getElementById('login-overlay').style.display='flex';
-    })
-    .catch(function(){document.getElementById('login-overlay').style.display='none';});
+
+  // Zero-click localhost auto-login: if no token in localStorage, ask the
+  // server for the on-disk token (only returned on loopback). If we get one,
+  // persist it and reload so the rest of the app boots logged-in. Falls back
+  // to the manual login overlay on any error / 403 / 404 (endpoint may not be
+  // deployed yet, or the request isn't from localhost).
+  if(!stored){
+    fetch('/api/auth/detected-token')
+      .then(function(r){ return r.ok ? r.json() : null; })
+      .then(function(d){
+        if(d && d.token){
+          localStorage.setItem('clawmetry-token', d.token);
+          location.reload();
+        } else {
+          checkAuth(null);
+        }
+      })
+      .catch(function(){ checkAuth(null); });
+  } else {
+    checkAuth(stored);
+  }
+
+  function checkAuth(tok){
+    fetch('/api/auth/check' + (tok ? '?token=' + encodeURIComponent(tok) : ''))
+      .then(function(r){return r.json()})
+      .then(function(d){
+        if(d.needsSetup){
+          // No gateway token configured -- show mandatory gateway setup wizard
+          document.getElementById('login-overlay').style.display='none';
+          var overlay=document.getElementById('gw-setup-overlay');
+          overlay.dataset.mandatory='true';
+          document.getElementById('gw-setup-close').style.display='none';
+          overlay.style.display='flex';
+          return;
+        }
+        if(!d.authRequired){
+          document.getElementById('login-overlay').style.display='none';
+          return;
+        }
+        if(d.valid){
+          document.getElementById('login-overlay').style.display='none';
+          var lb=document.getElementById('logout-btn');if(lb)lb.style.display='';
+          return;
+        }
+        localStorage.removeItem('cm-token');localStorage.removeItem('clawmetry-token');sessionStorage.removeItem('cm-token');document.getElementById('login-overlay').style.display='flex';
+      })
+      .catch(function(){document.getElementById('login-overlay').style.display='none';});
+  }
 })();
 function clawmetryLogin(){
   var tok=document.getElementById('login-token').value.trim();


### PR DESCRIPTION
## Summary

- Zero-click localhost auto-login: when `localStorage.clawmetry-token` is empty, the bootstrap IIFE now calls `GET /api/auth/detected-token` first. On success it persists the returned token and reloads, so loopback users land on the dashboard with no login overlay shown.
- On 403 / 404 / network failure (e.g. PR-B not yet deployed, or non-localhost request), the code falls back to the existing `/api/auth/check` + login-overlay flow.
- `clawmetryLogin()`, `clawmetryLogout()`, the Authorization header injector, and the version-badge IIFE are all left untouched.

## Depends on

- **#1356 PR-B** — adds the `/api/auth/detected-token` endpoint (loopback-only, returns `{\"token\": \"...\"}`). This PR is forward-compatible with PR-B not yet being deployed; a 404 cleanly degrades to the manual login flow.

## Test plan

The repo's E2E tests (`tests/e2e/real-flow.mjs`, `signup-flow.mjs`, `cloud-contract.mjs`) target the cloud signup/sync flows, not the OSS localhost auth-overlay flow, so this PR documents manual verification:

- [ ] Fresh browser profile (or `localStorage.clear()` in DevTools) → visit `http://localhost:8900` → no overlay flashes, dashboard loads logged-in.
- [ ] Repeat with PR-B not deployed (endpoint returns 404) → manual login overlay appears as before, manual token entry still works.
- [ ] With a stored token already present → bootstrap skips the new fetch entirely and goes straight to `/api/auth/check` (unchanged behavior).
- [ ] Non-localhost visit (LAN IP) where the endpoint returns 403 → falls back to the login overlay.
- [ ] `clawmetryLogout()` still clears the token and reloads; on the next reload the zero-click path runs again and re-detects the on-disk token.