### PR TITLE
feat: CLI prints one-click /auth?token URL on startup (#1356 PR-D)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -16123,6 +16123,25 @@ def cmd_uninstall(args):
     print("[ok] ClawMetry service removed.")
 
 
+def _print_login_url_banner(port, host, token):
+    """Print a one-click /auth?token= URL when GATEWAY_TOKEN is set (#1356 PR-D).
+
+    Behavior:
+      - If token is empty/None -> no-op (preserves prior banner output).
+      - If host binds publicly (0.0.0.0 / ::), still print but reference
+        ``localhost`` so the link only works from the local machine.
+      - Always uses the URL framing (never logs the bare token alone).
+    """
+    if not token:
+        return
+    # Always frame the token inside the /auth URL; never print the bare token.
+    # 0.0.0.0 / :: are bind-all sentinels; the user clicks from localhost.
+    public_binds = ("0.0.0.0", "::", "")
+    display_host = "localhost" if host in public_binds else host
+    url = f"http://{display_host}:{port}/auth?token={token}"
+    print(f"  -> {url}  (one-click sign-in)")
+
+
 def _run_server(args):
     import sys as _sys
 
@@ -16306,6 +16325,16 @@ def _run_server(args):
             )
         if _HAS_OTEL_PROTO:
             print(f"  -> OTLP endpoint: http://{local_ip}:{args.port}/v1/metrics")
+        # One-click login URL when gateway token was detected (#1356 PR-D).
+        # Defense against shoulder-surfing screenshots: only the framed URL is
+        # printed (never the bare token), and only on the interactive startup
+        # banner (stdout). We never log this line to /tmp/clawmetry.log because
+        # the daemon-mode launcher redirects only the noisy server output, not
+        # this one-shot banner that runs before serve().
+        try:
+            _print_login_url_banner(args.port, args.host, GATEWAY_TOKEN)
+        except Exception:
+            pass  # Never let banner printing break the dashboard
         print()
         # Cloud nudge — only if not already connected
         _already_connected = bool(

--- a/tests/test_cli_banner.py
+++ b/tests/test_cli_banner.py
@@ -1,0 +1,71 @@
+"""Tests for the CLI startup banner — one-click /auth?token URL (#1356 PR-D).
+
+The dashboard's `_run_server` foreground banner should print a
+clickable /auth?token=... URL when ``GATEWAY_TOKEN`` was successfully
+detected, and stay silent (preserving the legacy banner) when it was not.
+
+We test the small extracted helper ``dashboard._print_login_url_banner``
+directly so the tests don't have to spin up the whole Flask server.
+"""
+import os
+import sys
+
+import pytest
+
+# Ensure repo root is importable when pytest is invoked from anywhere.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import dashboard  # noqa: E402
+
+
+def test_login_url_printed_when_token_set(capsys):
+    """When GATEWAY_TOKEN is detected, banner prints /auth?token=... URL."""
+    dashboard._print_login_url_banner(8900, "127.0.0.1", "63d3b12b" + "a" * 56)
+    out = capsys.readouterr().out
+    assert "/auth?token=63d3b12b" in out
+    assert "http://127.0.0.1:8900/auth?token=" in out
+    assert "one-click sign-in" in out
+
+
+def test_no_url_printed_when_token_missing(capsys):
+    """No GATEWAY_TOKEN -> no login URL line (preserves legacy behavior)."""
+    dashboard._print_login_url_banner(8900, "127.0.0.1", None)
+    dashboard._print_login_url_banner(8900, "127.0.0.1", "")
+    out = capsys.readouterr().out
+    assert "/auth?token" not in out
+    assert out == ""
+
+
+def test_public_bind_shows_localhost_for_safety(capsys):
+    """--host 0.0.0.0 still prints a URL, but framed as localhost so the
+    one-click link only works from the local machine (not the LAN)."""
+    dashboard._print_login_url_banner(8900, "0.0.0.0", "secret-token-xyz")
+    out = capsys.readouterr().out
+    assert "http://localhost:8900/auth?token=secret-token-xyz" in out
+    assert "0.0.0.0" not in out
+
+
+def test_bare_token_never_printed_alone(capsys):
+    """Defense-in-depth: the bare token MUST always appear inside the URL,
+    never on its own line. Shoulder-surfing screenshots are easier to
+    parse when a token sits alone."""
+    token = "supersecrettokenvalue1234567890"
+    dashboard._print_login_url_banner(8900, "127.0.0.1", token)
+    out = capsys.readouterr().out
+    # Token appears exactly once, embedded in the URL query string.
+    assert out.count(token) == 1
+    assert f"token={token}" in out
+    # And there is no naked line that is just the token.
+    for line in out.splitlines():
+        assert line.strip() != token
+
+
+def test_custom_port_respected(capsys):
+    """Banner uses the actual port the dashboard is bound to."""
+    dashboard._print_login_url_banner(9000, "localhost", "abc123")
+    out = capsys.readouterr().out
+    assert "http://localhost:9000/auth?token=abc123" in out
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
- When `GATEWAY_TOKEN` is detected at dashboard startup, the foreground banner now prints a clickable `http://<host>:<port>/auth?token=...` URL alongside the existing dashboard URL — kills the manual copy/paste hop that new users hit when the dashboard prompts for a token.
- No token detected → banner unchanged (legacy output preserved).
- `--host 0.0.0.0` / `::` still prints, but framed as `localhost` so the one-click link only works from the local machine (defense against accidentally LAN-exposing the token).
- Token always appears embedded in the URL, never on its own line — defense-in-depth against shoulder-surfing screenshots.
- Banner is stdout-only on the interactive startup path; nothing is written to `/tmp/clawmetry.log`.

## Implementation
- New helper `dashboard._print_login_url_banner(port, host, token)` next to `_run_server`.
- Called from the existing URL-printing block in `_run_server` after the dashboard / LAN / OTLP lines, wrapped in try/except so banner printing never breaks the dashboard.
- The `/auth?token=X` route at `routes/meta.py:309` is reused as-is.

## Test plan
- [x] `pytest tests/test_cli_banner.py -v` — 5/5 pass
  - prints URL when token present
  - silent when token missing/empty
  - `0.0.0.0` reframed as `localhost`
  - bare token never appears on its own line
  - custom port respected
- [x] `python3 -c "import dashboard"` — no import regression

Refs #1356.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>