### PR TITLE
[RELEASE] fix(auth): drop reload() from zero-click bootstrap (#1356 PR-C followup)

### DIFF
--- a/clawmetry/static/js/auth-bootstrap.js
+++ b/clawmetry/static/js/auth-bootstrap.js
@@ -3,16 +3,23 @@
 
   // Zero-click localhost auto-login: if no token in localStorage, ask the
   // server for the on-disk token (only returned on loopback). If we get one,
-  // persist it and reload so the rest of the app boots logged-in. Falls back
-  // to the manual login overlay on any error / 403 / 404 (endpoint may not be
-  // deployed yet, or the request isn't from localhost).
+  // persist it and continue inline by re-entering checkAuth with the token.
+  // Falls back to the manual login overlay on any error / 403 / 404 (endpoint
+  // may not be deployed yet, or the request isn't from localhost).
+  //
+  // No location.reload() — the fetch shim below pulls the token from
+  // localStorage on the next /api/* call, so subsequent fetches authenticate
+  // without restarting the page. Reloading here also breaks Playwright/E2E
+  // harnesses, which observe the load event before the bootstrap's async
+  // fetch resolves and then crash when the navigation fires under their feet
+  // ("Execution context was destroyed").
   if(!stored){
     fetch('/api/auth/detected-token')
       .then(function(r){ return r.ok ? r.json() : null; })
       .then(function(d){
         if(d && d.token){
           localStorage.setItem('clawmetry-token', d.token);
-          location.reload();
+          checkAuth(d.token);
         } else {
           checkAuth(null);
         }


### PR DESCRIPTION
## Summary

PR-C (#1358) introduced a `location.reload()` after stashing the auto-detected token in `localStorage`. That reload races the load event and breaks every E2E test at setup with `Page.evaluate: Execution context was destroyed, most likely because of a navigation`. PR #1360 was the first innocent victim — a CLI-banner-only diff failed E2E with 100% test errors despite touching no JS.

## Fix

Re-enter `checkAuth(token)` inline instead of reloading. The fetch shim already pulls the token from `localStorage` on the next `/api/*` call, so subsequent requests authenticate cleanly without a page restart. Same end state, no navigation, faster UX.

## Test plan

- [x] `node --check clawmetry/static/js/auth-bootstrap.js` — JS syntactically valid.
- [ ] CI E2E Browser Tests pass on this PR (the regression we're undoing).
- [ ] Auto-publish via `[RELEASE]` workflow → 0.12.227 on PyPI.
- [ ] Manual: fresh browser → `localhost:8900` → no overlay flicker → dashboard loads first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)