### PR TITLE
feat(moat): surface LoopDetector signals — DuckDB persistence + lightweight UI

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -519,6 +519,31 @@ _DDL = [
     "CREATE INDEX IF NOT EXISTS idx_spans_session     ON spans(session_id, start_ts)",
     "CREATE INDEX IF NOT EXISTS idx_spans_agent_ts    ON spans(agent_type, start_ts)",
     "CREATE INDEX IF NOT EXISTS idx_spans_ts          ON spans(ts)",
+    # Issue #1364 — loop-detection signals from clawmetry/proxy.py's
+    # ``LoopDetector``. Today the detector logs + writes to its private
+    # SQLite (``~/.clawmetry/proxy.db``); the dashboard had no view into
+    # those events. Persisting them here surfaces capability 2.f
+    # ("agent looping / stalling detection") in the Monte Carlo framework
+    # via /api/loop-signals + the Brain tab badge.
+    #
+    # PK is (session_id, signature) so re-detection of the same loop in
+    # the same session is an UPSERT (we keep the running ``repeat_count``
+    # and update ``last_seen``). Different sessions hitting the same
+    # signature are independent rows — looping is a per-session pathology.
+    """
+    CREATE TABLE IF NOT EXISTS loop_signals (
+        session_id     VARCHAR NOT NULL,
+        signature      VARCHAR NOT NULL,
+        repeat_count   INTEGER NOT NULL DEFAULT 1,
+        first_seen     TIMESTAMP NOT NULL,
+        last_seen      TIMESTAMP NOT NULL,
+        severity       VARCHAR DEFAULT 'warning',
+        agent_type     VARCHAR DEFAULT 'openclaw',
+        details        BLOB,
+        PRIMARY KEY (session_id, signature)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_loop_signals_last_seen ON loop_signals(last_seen DESC)",
     """
     CREATE TABLE IF NOT EXISTS schema_version (
         version    INTEGER PRIMARY KEY,
@@ -1342,6 +1367,143 @@ class LocalStore:
                   float(sa.get("cost_usd") or 0),
                   int(sa.get("token_count") or 0),
                   data_blob, now_ms])
+
+    def ingest_loop_signal(
+        self,
+        session_id: str,
+        signature: str,
+        repeat_count: int,
+        first_seen: str | None = None,
+        last_seen: str | None = None,
+        severity: str = "warning",
+        agent_type: str = "openclaw",
+        details: Any = None,
+    ) -> None:
+        """Upsert one loop-detection signal (issue #1364).
+
+        Called from ``clawmetry.proxy.LoopDetector`` whenever a request
+        pattern repeats often enough within the configured window to
+        flag a loop. PK is ``(session_id, signature)`` so the same
+        loop pattern recurring in the same session bumps ``repeat_count``
+        and refreshes ``last_seen`` instead of creating a new row —
+        callers pass the latest cumulative count.
+
+        ``first_seen`` / ``last_seen`` accept ISO-8601 strings; if absent
+        we stamp ``time.time()`` for both. ``details`` is any
+        JSON-friendly value (e.g. ``{"model": "...", "request_hash": ...}``)
+        and is stored as a BLOB so the route can hydrate it back into the
+        UI without a fixed schema.
+
+        Permissive — never raises on bad input; we drop the write rather
+        than crash the proxy. The detector is on the request hot path."""
+        if not session_id or not signature:
+            return
+        try:
+            count = int(repeat_count or 0)
+        except (TypeError, ValueError):
+            count = 0
+        if count <= 0:
+            return
+        # Use local-naive time so the value compares apples-to-apples with
+        # ``current_timestamp - INTERVAL`` in ``query_recent_loop_signals``
+        # (DuckDB's TIMESTAMP column has no zone; mixing UTC strings with
+        # TZ-aware ``current_timestamp`` shifts rows out of the window on
+        # any host whose local TZ != UTC).
+        now_iso = datetime.now().isoformat(timespec="seconds")
+        first = first_seen or now_iso
+        last = last_seen or now_iso
+        sev = (severity or "warning").strip()[:32]
+        atype = (agent_type or "openclaw").strip()[:64]
+        details_blob = _to_blob(details) if details is not None else None
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO loop_signals (
+                    session_id, signature, repeat_count,
+                    first_seen, last_seen, severity, agent_type, details
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (session_id, signature) DO UPDATE SET
+                    repeat_count = GREATEST(loop_signals.repeat_count, excluded.repeat_count),
+                    last_seen    = GREATEST(loop_signals.last_seen, excluded.last_seen),
+                    first_seen   = LEAST(loop_signals.first_seen, excluded.first_seen),
+                    severity     = excluded.severity,
+                    agent_type   = excluded.agent_type,
+                    details      = COALESCE(excluded.details, loop_signals.details)
+            """, [
+                str(session_id)[:128],
+                str(signature)[:256],
+                count,
+                first,
+                last,
+                sev,
+                atype,
+                details_blob,
+            ])
+
+    def query_recent_loop_signals(
+        self,
+        *,
+        limit: int = 20,
+        since_minutes: int = 60,
+    ) -> list[dict[str, Any]]:
+        """Return recent loop-detection signals, newest first (issue #1364).
+
+        Filters to rows whose ``last_seen`` falls within the last
+        ``since_minutes`` minutes; pass ``since_minutes <= 0`` to disable
+        the window and return any row regardless of age. ``limit`` is
+        clamped to ``[1, 200]``."""
+        try:
+            lim = int(limit)
+        except (TypeError, ValueError):
+            lim = 20
+        lim = max(1, min(200, lim))
+        try:
+            window_min = int(since_minutes)
+        except (TypeError, ValueError):
+            window_min = 60
+        clauses: list[str] = []
+        params: list[Any] = []
+        if window_min > 0:
+            # Cast both sides to naive TIMESTAMP so the comparison stays in
+            # local wall-clock — same convention the writer uses.
+            clauses.append(
+                "last_seen >= (current_timestamp::TIMESTAMP - INTERVAL (? * 60) SECOND)"
+            )
+            params.append(window_min)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT session_id, signature, repeat_count,
+                   first_seen, last_seen, severity, agent_type, details
+            FROM loop_signals
+            {where}
+            ORDER BY last_seen DESC, session_id, signature
+            LIMIT ?
+        """
+        params.append(lim)
+        cols = ["session_id", "signature", "repeat_count",
+                "first_seen", "last_seen", "severity", "agent_type", "details"]
+        out: list[dict[str, Any]] = []
+        for r in self._fetch(sql, params):
+            d = dict(zip(cols, r))
+            # Stringify timestamps so JSON serialisation is trivial — DuckDB
+            # returns ``datetime.datetime`` objects which Flask's jsonify
+            # handles, but downstream JS expects ISO strings everywhere
+            # else in the codebase.
+            for tcol in ("first_seen", "last_seen"):
+                v = d.get(tcol)
+                if hasattr(v, "isoformat"):
+                    d[tcol] = v.isoformat()
+            raw = d.get("details")
+            if raw is not None:
+                try:
+                    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                    try:
+                        d["details"] = json.loads(text)
+                    except (ValueError, TypeError):
+                        d["details"] = text
+                except UnicodeDecodeError:
+                    d["details"] = None
+            out.append(d)
+        return out
 
     def ingest_alert_rule(self, rule: dict[str, Any]) -> None:
         """Upsert one alert rule. Required: ``id``.

--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -678,6 +678,24 @@ class LoopDetector:
                 f"Loop detected: {match_count} identical requests from session "
                 f"'{session_id}' in the last {self.config.window_seconds}s"
             )
+            # Issue #1364: also persist to the shared DuckDB local store so
+            # the dashboard can surface a "Loops detected" badge. Best-effort
+            # — the proxy typically runs as its own process and the daemon
+            # owns DuckDB's writer lock; in that case the open will fail and
+            # we keep the legacy SQLite + log path. When proxy and daemon
+            # share a process (single-process dev mode, tests), the row
+            # lands in clawmetry.duckdb and the badge lights up.
+            try:
+                from clawmetry import local_store as _ls
+                _ls.get_store().ingest_loop_signal(
+                    session_id=session_id,
+                    signature=request_hash,
+                    repeat_count=match_count,
+                    severity="warning",
+                    details={"window_seconds": self.config.window_seconds},
+                )
+            except Exception as exc:  # noqa: BLE001 — never break detection
+                logger.debug("loop signal duckdb ingest skipped: %s", exc)
             return True, reason
 
         return False, ""

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3693,6 +3693,62 @@ async function loadBrainPage(silent) {
   if (!_brainSSEConnected && document.getElementById('page-brain') && document.getElementById('page-brain').classList.contains('active')) {
     _brainRefreshTimer = setTimeout(function() { loadBrainPage(true); }, 5000);
   }
+  // Loop-signals badge (#1364) — fire-and-forget; never blocks the Brain tab.
+  loadLoopSignals();
+}
+
+
+// ── LoopDetector signals badge (#1364) ─────────────────────────────────────
+// Backed by /api/loop-signals → DuckDB ``loop_signals`` table populated by
+// clawmetry/proxy.py's LoopDetector. Hidden when the count is 0; clicking
+// expands a flat table (Time | Session | Pattern | Repeat).
+var _loopSignalsExpanded = false;
+
+async function loadLoopSignals() {
+  if (window.CLOUD_MODE) return;
+  var badge = document.getElementById('brain-loops-badge');
+  var countEl = document.getElementById('brain-loops-badge-count');
+  var tableEl = document.getElementById('brain-loops-table');
+  if (!badge || !countEl || !tableEl) return;
+  try {
+    var data = await fetchJsonWithTimeout('/api/loop-signals?limit=20', 5000);
+    var rows = (data && data.signals) || [];
+    if (!rows.length) {
+      badge.style.display = 'none';
+      tableEl.innerHTML = '';
+      return;
+    }
+    badge.style.display = '';
+    countEl.textContent = String(rows.length);
+    // Render table — keep it dead simple: Time | Session | Pattern | Repeat.
+    var head = '<div style="display:grid;grid-template-columns:130px 160px 1fr 70px;gap:10px;padding:4px 0;border-bottom:1px solid var(--border-secondary);font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:1px;">'
+      + '<div>Last seen</div><div>Session</div><div>Pattern</div><div style="text-align:right;">Repeats</div></div>';
+    var body = rows.map(function(r) {
+      var ts = r.last_seen || r.first_seen || '';
+      try { ts = new Date(ts).toLocaleString(); } catch (e) {}
+      var sid = String(r.session_id || '').slice(0, 16);
+      var sig = String(r.signature || '');
+      if (sig.length > 60) sig = sig.slice(0, 57) + '...';
+      var rc = r.repeat_count != null ? r.repeat_count : '-';
+      return '<div style="display:grid;grid-template-columns:130px 160px 1fr 70px;gap:10px;padding:5px 0;border-bottom:1px solid var(--border-secondary);">'
+        + '<div style="color:var(--text-muted);">' + escHtml(ts) + '</div>'
+        + '<div style="color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="' + escHtml(String(r.session_id || '')) + '">' + escHtml(sid) + '</div>'
+        + '<div style="color:var(--text-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="' + escHtml(String(r.signature || '')) + '">' + escHtml(sig) + '</div>'
+        + '<div style="text-align:right;color:#ef4444;font-weight:700;">' + escHtml(String(rc)) + '</div>'
+        + '</div>';
+    }).join('');
+    tableEl.innerHTML = head + body;
+  } catch (e) {
+    // Fail closed: hide the badge so we don't show a stale or wrong count.
+    badge.style.display = 'none';
+  }
+}
+
+function toggleLoopSignalsList() {
+  var panel = document.getElementById('brain-loops-panel');
+  if (!panel) return;
+  _loopSignalsExpanded = !_loopSignalsExpanded;
+  panel.style.display = _loopSignalsExpanded ? '' : 'none';
 }
 
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -4865,8 +4865,22 @@ function clawmetryLogout(){
 <div class="page" id="page-brain">
   <div style="padding:12px 0 8px 0;">
     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;">
-      <span style="font-size:14px;font-weight:700;color:var(--text-primary);">🧠 Brain -- Unified Activity Stream</span>
+      <div style="display:flex;align-items:center;gap:10px;">
+        <span style="font-size:14px;font-weight:700;color:var(--text-primary);">🧠 Brain -- Unified Activity Stream</span>
+        <!-- Loop-signals badge (#1364): hidden until /api/loop-signals returns >0 rows. -->
+        <button id="brain-loops-badge" type="button" onclick="toggleLoopSignalsList()" style="display:none;background:rgba(239,68,68,0.15);color:#ef4444;border:1px solid rgba(239,68,68,0.4);border-radius:10px;padding:2px 9px;font-size:11px;font-weight:700;cursor:pointer;font-family:inherit;" title="LoopDetector signals from clawmetry/proxy.py">
+          <span id="brain-loops-badge-count">0</span> loops
+        </button>
+      </div>
       <button class="refresh-btn" onclick="loadBrainPage()">↻ Refresh</button>
+    </div>
+    <!-- Loop signals list — collapsed until the badge is clicked. -->
+    <div id="brain-loops-panel" style="display:none;background:var(--bg-secondary);border:1px solid rgba(239,68,68,0.4);border-radius:8px;padding:10px 14px;margin-bottom:12px;">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">
+        <span style="font-size:11px;font-weight:600;color:#ef4444;text-transform:uppercase;letter-spacing:1px;">Loops detected (proxy)</span>
+        <span style="font-size:10px;color:var(--text-muted);">From clawmetry proxy LoopDetector — last 60 min</span>
+      </div>
+      <div id="brain-loops-table" style="font-size:11px;font-family:'JetBrains Mono','SF Mono',monospace;color:var(--text-secondary);"></div>
     </div>
     <!-- Context Window Anatomy (#566) -->
     <div id="ctx-anatomy-wrap" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;margin-bottom:12px;display:none;">

--- a/routes/health.py
+++ b/routes/health.py
@@ -2625,6 +2625,59 @@ def api_loop_detection():
 
 
 # ---------------------------------------------------------------------------
+# Loop-detection signals from clawmetry/proxy.py LoopDetector (issue #1364)
+#
+# Distinct from /api/loop-detection above (which scans tool_call sequences
+# in session JSONL). This endpoint serves the persisted signals that the
+# enforcement proxy emits whenever a request hash repeats often enough to
+# trip ``LoopDetectionConfig.max_similar`` in a window. Backed by the
+# DuckDB ``loop_signals`` table; gracefully returns ``[]`` when the local
+# store is unreachable so the Brain badge fails closed (no badge) rather
+# than blowing up the page.
+# ---------------------------------------------------------------------------
+
+
+@bp_health.route("/api/loop-signals")
+def api_loop_signals():
+    """Return recent LoopDetector signals for the dashboard's Brain badge.
+
+    Query params (all optional):
+      limit          — max rows (default 20, clamp 1..200)
+      since_minutes  — last-N minute window (default 60, <=0 disables)
+
+    Response:
+      {
+        "signals": [
+          {"session_id": str, "signature": str, "repeat_count": int,
+           "first_seen": str, "last_seen": str, "severity": str,
+           "agent_type": str, "details": dict|str|None}
+        ],
+        "count": <int>
+      }
+
+    Empty-list fallback (HTTP 200) on any error so the badge never breaks
+    the page.
+    """
+    try:
+        limit = int(request.args.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
+    try:
+        since_minutes = int(request.args.get("since_minutes", 60))
+    except (TypeError, ValueError):
+        since_minutes = 60
+
+    rows = _ls_call(
+        "query_recent_loop_signals",
+        limit=limit,
+        since_minutes=since_minutes,
+    )
+    if rows is None:
+        rows = []
+    return jsonify({"signals": rows, "count": len(rows)})
+
+
+# ---------------------------------------------------------------------------
 # MCP tool call observability (#850)
 # ---------------------------------------------------------------------------
 

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -329,6 +329,10 @@ _DAEMON_METHODS = frozenset({
     # in routes/nemoclaw.py — collided with the daemon's writer lock.
     # Routed through proxy so /api/nemoclaw/pending-approvals stays fast.
     "query_approvals",
+    # Issue #1364: surface clawmetry/proxy.py LoopDetector signals on the
+    # dashboard. Read by routes/health.py:/api/loop-signals via the daemon
+    # proxy so the dashboard process never opens DuckDB writable.
+    "query_recent_loop_signals",
     "health",
 })
 

--- a/tests/test_loop_signals_e2e.py
+++ b/tests/test_loop_signals_e2e.py
@@ -1,0 +1,292 @@
+"""E2E tests for the LoopDetector → DuckDB → /api/loop-signals path (#1364).
+
+Three surfaces:
+  1. Schema round-trip — ``LocalStore.ingest_loop_signal`` writes a row
+     and ``query_recent_loop_signals`` reads it back, ordered newest-first
+     and respecting ``limit`` + ``since_minutes``.
+  2. Upsert semantics — re-ingesting the same ``(session_id, signature)``
+     bumps ``repeat_count`` (kept = max of incoming vs existing) and
+     refreshes ``last_seen``, instead of duplicating the row.
+  3. Route fast path — ``GET /api/loop-signals`` returns the DuckDB rows
+     in ``signals`` with the same shape, gracefully degrading to ``[]``
+     when nothing is detected.
+
+Driver matches the pattern in ``test_alert_rules_local_store.py`` —
+reload ``clawmetry.local_store`` against a tmp DuckDB, exercise the
+public surface, then reload the route module so its late ``_ls_call``
+points at the fresh store.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Reload ``clawmetry.local_store`` against a fresh DuckDB file."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "loops.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    store = ls.get_store()
+    yield ls, store
+
+    try:
+        store.stop(flush=False)
+    except Exception:
+        pass
+
+
+# ── 1. Schema round-trip ───────────────────────────────────────────────────
+
+
+def test_ingest_and_query_loop_signal_round_trip(fresh_store):
+    ls, store = fresh_store
+    store.ingest_loop_signal(
+        session_id="sess-001",
+        signature="abc123def456",
+        repeat_count=5,
+        first_seen="2026-05-15T10:00:00",
+        last_seen="2026-05-15T10:05:00",
+        severity="warning",
+        details={"window_seconds": 300, "model": "claude-sonnet-4"},
+    )
+    rows = store.query_recent_loop_signals(limit=10, since_minutes=0)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["session_id"] == "sess-001"
+    assert r["signature"] == "abc123def456"
+    assert r["repeat_count"] == 5
+    assert r["severity"] == "warning"
+    assert r["agent_type"] == "openclaw"
+    assert r["first_seen"].startswith("2026-05-15T10:00:00")
+    assert r["last_seen"].startswith("2026-05-15T10:05:00")
+    # details BLOB is decoded back to a dict by the read path.
+    assert isinstance(r["details"], dict)
+    assert r["details"]["window_seconds"] == 300
+    assert r["details"]["model"] == "claude-sonnet-4"
+
+
+def test_query_recent_loop_signals_orders_newest_first(fresh_store):
+    ls, store = fresh_store
+    store.ingest_loop_signal(
+        session_id="s-a", signature="sig-a", repeat_count=3,
+        first_seen="2026-05-15T09:00:00", last_seen="2026-05-15T09:00:00",
+    )
+    store.ingest_loop_signal(
+        session_id="s-b", signature="sig-b", repeat_count=4,
+        first_seen="2026-05-15T11:00:00", last_seen="2026-05-15T11:00:00",
+    )
+    store.ingest_loop_signal(
+        session_id="s-c", signature="sig-c", repeat_count=5,
+        first_seen="2026-05-15T10:00:00", last_seen="2026-05-15T10:00:00",
+    )
+    rows = store.query_recent_loop_signals(limit=10, since_minutes=0)
+    assert [r["session_id"] for r in rows] == ["s-b", "s-c", "s-a"]
+    # Repeat counts come back unchanged (no double-counting on insert).
+    assert [r["repeat_count"] for r in rows] == [4, 5, 3]
+
+
+def test_query_recent_loop_signals_respects_limit(fresh_store):
+    ls, store = fresh_store
+    for i in range(5):
+        store.ingest_loop_signal(
+            session_id=f"s-{i}", signature=f"sig-{i}", repeat_count=i + 2,
+            first_seen=f"2026-05-15T10:0{i}:00",
+            last_seen=f"2026-05-15T10:0{i}:00",
+        )
+    assert len(store.query_recent_loop_signals(limit=3, since_minutes=0)) == 3
+    assert len(store.query_recent_loop_signals(limit=10, since_minutes=0)) == 5
+
+
+def test_query_recent_loop_signals_window_filters_old_rows(fresh_store):
+    """``since_minutes>0`` should hide rows whose ``last_seen`` is older
+    than the window. Use an explicit very-old timestamp so the window
+    arithmetic has unambiguous behaviour regardless of test wallclock."""
+    ls, store = fresh_store
+    store.ingest_loop_signal(
+        session_id="recent", signature="sig-recent", repeat_count=3,
+        # Now-ish — DuckDB ``now() - 60min`` will keep this row.
+    )
+    store.ingest_loop_signal(
+        session_id="ancient", signature="sig-ancient", repeat_count=99,
+        first_seen="2020-01-01T00:00:00",
+        last_seen="2020-01-01T00:00:00",
+    )
+    in_window = store.query_recent_loop_signals(limit=10, since_minutes=60)
+    sids = {r["session_id"] for r in in_window}
+    assert "recent" in sids
+    assert "ancient" not in sids
+    # Disabling the window with since_minutes<=0 returns both.
+    all_rows = store.query_recent_loop_signals(limit=10, since_minutes=0)
+    assert {r["session_id"] for r in all_rows} == {"recent", "ancient"}
+
+
+# ── 2. Upsert semantics ────────────────────────────────────────────────────
+
+
+def test_ingest_loop_signal_upserts_increments_repeat(fresh_store):
+    ls, store = fresh_store
+    store.ingest_loop_signal(
+        session_id="s-up", signature="sig-up", repeat_count=3,
+        first_seen="2026-05-15T10:00:00", last_seen="2026-05-15T10:00:00",
+    )
+    # Detector fires again moments later with a higher running count —
+    # the row is upserted, not duplicated.
+    store.ingest_loop_signal(
+        session_id="s-up", signature="sig-up", repeat_count=7,
+        first_seen="2026-05-15T10:01:00", last_seen="2026-05-15T10:02:30",
+    )
+    rows = store.query_recent_loop_signals(limit=10, since_minutes=0)
+    assert len(rows) == 1
+    r = rows[0]
+    # GREATEST(existing, incoming) => 7 wins.
+    assert r["repeat_count"] == 7
+    # last_seen advances, first_seen stays at the earlier timestamp.
+    assert r["last_seen"].startswith("2026-05-15T10:02:30")
+    assert r["first_seen"].startswith("2026-05-15T10:00:00")
+
+
+def test_ingest_loop_signal_invalid_inputs_are_dropped(fresh_store):
+    """Bad input never raises — the proxy is on the request hot path."""
+    ls, store = fresh_store
+    # Missing fields → silently dropped.
+    store.ingest_loop_signal(session_id="", signature="x", repeat_count=3)
+    store.ingest_loop_signal(session_id="s", signature="", repeat_count=3)
+    # Zero / negative count → dropped.
+    store.ingest_loop_signal(session_id="s", signature="x", repeat_count=0)
+    store.ingest_loop_signal(session_id="s", signature="x", repeat_count=-2)
+    # Non-numeric count → dropped.
+    store.ingest_loop_signal(session_id="s", signature="x", repeat_count="abc")  # type: ignore[arg-type]
+    assert store.query_recent_loop_signals(limit=10, since_minutes=0) == []
+
+
+# ── 3. Route fast path ─────────────────────────────────────────────────────
+
+
+def test_api_loop_signals_returns_rows_from_local_store(fresh_store, monkeypatch):
+    """``GET /api/loop-signals`` reads the DuckDB rows and returns them
+    in ``signals`` with the right shape and ordering."""
+    ls, store = fresh_store
+    store.ingest_loop_signal(
+        session_id="ss-1", signature="abcd1234efgh", repeat_count=8,
+        first_seen="2026-05-15T10:00:00", last_seen="2026-05-15T10:05:00",
+        severity="warning",
+        details={"model": "claude-sonnet-4"},
+    )
+    store.ingest_loop_signal(
+        session_id="ss-2", signature="zzzz9999yyyy", repeat_count=4,
+        first_seen="2026-05-15T11:00:00", last_seen="2026-05-15T11:01:00",
+    )
+
+    # Reload routes.health so its module-level _ls_call sees the fresh store.
+    sys.modules.pop("routes.health", None)
+    import routes.health as rh
+    importlib.reload(rh)
+
+    from flask import Flask
+    app = Flask(__name__)
+    app.register_blueprint(rh.bp_health)
+    client = app.test_client()
+
+    resp = client.get("/api/loop-signals?limit=20&since_minutes=0")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["count"] == 2
+    sigs = body["signals"]
+    assert len(sigs) == 2
+    # Newest last_seen first.
+    assert sigs[0]["session_id"] == "ss-2"
+    assert sigs[1]["session_id"] == "ss-1"
+    # Round-trip of the loaded fields.
+    s1 = next(s for s in sigs if s["session_id"] == "ss-1")
+    assert s1["signature"] == "abcd1234efgh"
+    assert s1["repeat_count"] == 8
+    assert s1["severity"] == "warning"
+    assert isinstance(s1["details"], dict)
+    assert s1["details"]["model"] == "claude-sonnet-4"
+
+
+def test_api_loop_signals_empty_when_no_rows(fresh_store, monkeypatch):
+    """Empty DuckDB → ``signals=[]``, ``count=0``, HTTP 200. The Brain
+    badge needs the empty path to be a clean 200, not a 500, so the
+    ``display:none`` default sticks."""
+    sys.modules.pop("routes.health", None)
+    import routes.health as rh
+    importlib.reload(rh)
+
+    from flask import Flask
+    app = Flask(__name__)
+    app.register_blueprint(rh.bp_health)
+    client = app.test_client()
+
+    resp = client.get("/api/loop-signals")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {"signals": [], "count": 0}
+
+
+# ── 4. LoopDetector → LocalStore wiring ────────────────────────────────────
+
+
+def test_loop_detector_persists_signal_on_positive(fresh_store, tmp_path, monkeypatch):
+    """When ``LoopDetector.check`` flags a loop, it should also write a
+    row to ``loop_signals`` (best-effort — single-process mode here makes
+    the call succeed; in production where proxy + daemon are separate
+    processes the call silently no-ops on the lock conflict, by design)."""
+    ls, store = fresh_store
+
+    # Use a tmp proxy SQLite so we don't touch the user's ~/.clawmetry.
+    monkeypatch.setattr(
+        "clawmetry.proxy.PROXY_DB_FILE", tmp_path / "proxy.db"
+    )
+    sys.modules.pop("clawmetry.proxy", None)
+    import clawmetry.proxy as proxy
+    importlib.reload(proxy)
+
+    cfg = proxy.LoopDetectionConfig(
+        enabled=True, window_seconds=300, max_similar=3
+    )
+    pdb = proxy.ProxyDB(db_path=tmp_path / "proxy.db")
+    detector = proxy.LoopDetector(cfg, pdb)
+
+    # Seed enough identical hashes to trip max_similar=3.
+    sid = "loop-sess"
+    rh = "deadbeef00112233"
+    for _ in range(3):
+        pdb.record_usage(
+            provider="anthropic", model="claude-sonnet-4",
+            input_tokens=10, output_tokens=10, cost_usd=0.0,
+            session_id=sid, request_hash=rh,
+        )
+
+    is_loop, reason = detector.check(sid, rh)
+    assert is_loop is True
+    assert "Loop detected" in reason
+
+    rows = store.query_recent_loop_signals(limit=10, since_minutes=0)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["session_id"] == sid
+    assert r["signature"] == rh
+    # match_count is the >= max_similar value at detect time.
+    assert r["repeat_count"] >= 3


### PR DESCRIPTION
## Summary

ClawMetry's `clawmetry/proxy.py` has shipped a working `LoopDetector` for releases — but the only output was a log line + a row in the proxy's private SQLite. The dashboard had **no view** into agent loops, so capability **2.f (looping/stalling detection)** in the Monte Carlo framework was effectively dark.

This wires it up end to end:

- **DuckDB persistence** — new `loop_signals` table + `LocalStore.ingest_loop_signal()` + `query_recent_loop_signals()`
- **Hot-path side-effect** — `LoopDetector.check()` best-effort calls `ingest_loop_signal` on the detect-positive branch (try/except wrapped — when proxy and daemon run as separate processes, the writer-lock conflict silently no-ops and we keep the legacy SQLite path. **No detection-behaviour change.**)
- **Endpoint** — `GET /api/loop-signals?limit=20&since_minutes=60` in `routes/health.py`, daemon-proxy-first via `_ls_call`, `[]` fallback
- **Allowlist** — `query_recent_loop_signals` added to `_DAEMON_METHODS`
- **UI** — tiny red "Loops" badge inline with the Brain tab header (`display:none` until count > 0). Click expands a flat `Time | Session | Pattern (truncated 60c) | Repeats` table. No new nav tab, no chart, no graph.

## DO NOT [RELEASE]-tag

New `_DAEMON_METHODS` entry — sync daemon needs to restart to expose the new method. Per the standing rule, [RELEASE]-tagging would cut a wheel before the daemon is bumped, and `/api/loop-signals` would 404 on every install until users `launchctl kickstart -k com.clawmetry.sync`. Merge as a regular PR; the next release that bundles it will pick it up.

## Files changed

- `clawmetry/local_store.py` — schema (idempotent CREATE IF NOT EXISTS), ingest, query
- `clawmetry/proxy.py` — try/except hook in `LoopDetector.check`
- `routes/local_query.py` — one allowlist entry
- `routes/health.py` — new endpoint
- `dashboard.py` + `clawmetry/static/js/app.js` — Brain badge + collapsible list
- `tests/test_loop_signals_e2e.py` — 9 tests covering schema, upsert, route, empty-state, and detector→store wiring (all green locally)

Diff: ~308 lines under the 400-line cap.

## Test plan

- [x] `pytest tests/test_loop_signals_e2e.py -v` — 9/9 pass
- [x] `pytest tests/test_alert_rules_local_store.py tests/test_brain_local_store.py -v` — 17/17 pass (no regressions in sibling DuckDB schemas)
- [x] `python3 -m py_compile` clean on all touched modules
- [x] JS parses
- [ ] Post-merge: `curl -s http://localhost:8900/api/loop-signals` returns `{"signals":[],"count":0}` after daemon restart
- [ ] Post-merge: trigger a synthetic loop via the proxy (5+ identical hashes in 5 min) and confirm the badge lights up on the Brain tab

Refs #1364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)