### PR TITLE
feat(moat): migrate /api/skills fidelity counts to DuckDB fast-path + E2E verifier

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -2264,6 +2264,90 @@ class LocalStore:
             })
         return out
 
+    def query_recent_read_tool_calls(
+        self,
+        *,
+        since: str | None = None,
+        limit: int = 50_000,
+    ) -> list[dict[str, Any]]:
+        """Tier-1 MOAT (issue #1364): /api/skills fidelity fast-path.
+
+        Returns one row per Read-tool invocation since ``since`` (ISO-8601
+        timestamp), shape ``{ts, session_id, file_path}``. Used by
+        ``routes/skills.py`` to count "body fetched" + "linked file read"
+        events per skill without walking every session JSONL on disk
+        (the legacy scanner re-opens 50-200+ files on every page render).
+
+        Tool-call shapes covered (all three appear in the wild):
+          * v3 top-level events with ``event_type`` in
+            ``{'tool.call', 'toolCall', 'tool_use'}`` — read from
+            ``data.input.file_path`` / ``data.arguments.file_path``.
+          * Assistant ``message`` events with
+            ``data.toolMetas[*].input.file_path`` (PR #1132 trajectory
+            parser shape).
+          * Legacy assistant message events whose
+            ``data.message.content[*]`` still carries raw
+            ``{type:'toolCall'|'tool_use', name, input/arguments}`` blocks
+            (older OpenClaw transcripts that pre-date PR #1132's
+            trajectory projection).
+
+        Tool name is matched case-insensitively against
+        ``{'read', 'readfile', 'read_file'}`` — same set the legacy
+        ``_scan_fidelity_events`` checked. The ``file_path`` argument is
+        pulled from the first non-empty of ``file_path`` / ``path`` /
+        ``filename`` (Anthropic SDK + OpenClaw both shapes seen).
+
+        Rows where no Read-tool path can be extracted are dropped so the
+        caller iterates only useful events.
+
+        ``limit`` clamps total returned rows; defaults to 50k which is
+        ~1 million-token agent-week worth of Read calls. Callers should
+        pass a 7d ``since`` to keep the result set bounded.
+        """
+        try:
+            lim = int(limit)
+        except (TypeError, ValueError):
+            lim = 50_000
+        lim = max(1, min(200_000, lim))
+
+        clauses: list[str] = [
+            "(event_type IN ('tool.call', 'toolCall', 'tool_use')"
+            " OR event_type = 'message')"
+        ]
+        params: list[Any] = []
+        if since:
+            clauses.append("ts >= ?")
+            params.append(since)
+        where = "WHERE " + " AND ".join(clauses)
+        sql = f"""
+            SELECT ts, session_id, event_type, data
+            FROM events
+            {where}
+            ORDER BY ts DESC
+            LIMIT ?
+        """
+        params.append(lim)
+
+        out: list[dict[str, Any]] = []
+        for ts, sid, ev_type, raw in self._fetch(sql, params):
+            data: dict[str, Any] = {}
+            if raw is not None:
+                try:
+                    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                    parsed = json.loads(text) if text else {}
+                    if isinstance(parsed, dict):
+                        data = parsed
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    continue
+
+            for path in _iter_read_tool_paths(ev_type, data):
+                out.append({
+                    "ts":         ts,
+                    "session_id": sid,
+                    "file_path":  path,
+                })
+        return out
+
     # ── flush ───────────────────────────────────────────────────────────
 
     def _flusher_loop(self) -> None:
@@ -3870,6 +3954,79 @@ def _duration_seconds(start_iso: str, end_iso: str) -> float:
         return max(0.0, (b - a).total_seconds())
     except (TypeError, ValueError):
         return 0.0
+
+
+_READ_TOOL_NAMES = frozenset({"read", "readfile", "read_file"})
+
+
+def _iter_read_tool_paths(event_type: str | None, data: dict) -> Iterable[str]:
+    """Yield ``file_path`` arguments for every Read-like tool invocation
+    described by ``data``. Handles all three on-the-wire shapes the
+    OpenClaw + trajectory-projection pipeline emits — see
+    :meth:`LocalStore.query_recent_read_tool_calls` for the full list.
+
+    Yields nothing for non-Read tool calls or when no path argument can
+    be extracted; the caller treats absence as "skip this row".
+    """
+    if not isinstance(data, dict):
+        return
+
+    def _path_from_input(inp: Any) -> str:
+        if isinstance(inp, str):
+            try:
+                inp = json.loads(inp)
+            except (ValueError, TypeError):
+                return ""
+        if not isinstance(inp, dict):
+            return ""
+        for key in ("file_path", "path", "filename"):
+            v = inp.get(key)
+            if isinstance(v, str) and v:
+                return v
+        return ""
+
+    et = (event_type or "").lower()
+
+    # Shape 1: top-level tool.call / toolCall / tool_use event.
+    if et in ("tool.call", "toolcall", "tool_use"):
+        name = (data.get("name") or "").lower()
+        if name in _READ_TOOL_NAMES:
+            p = _path_from_input(data.get("input") or data.get("arguments"))
+            if p:
+                yield p
+        return
+
+    # Shape 2: assistant ``message`` event with ``toolMetas`` projection
+    # (PR #1132 trajectory parser shape).
+    metas = data.get("toolMetas")
+    if isinstance(metas, list):
+        for m in metas:
+            if not isinstance(m, dict):
+                continue
+            if (m.get("name") or "").lower() not in _READ_TOOL_NAMES:
+                continue
+            p = _path_from_input(m.get("input"))
+            if p:
+                yield p
+
+    # Shape 3: legacy assistant message events whose
+    # ``data.message.content`` still carries raw
+    # ``{type:'toolCall'|'tool_use'}`` blocks (older transcripts that
+    # pre-date PR #1132's trajectory projection).
+    msg = data.get("message")
+    if isinstance(msg, dict) and msg.get("role") == "assistant":
+        content = msg.get("content")
+        if isinstance(content, list):
+            for blk in content:
+                if not isinstance(blk, dict):
+                    continue
+                if blk.get("type") not in ("toolCall", "tool_use"):
+                    continue
+                if (blk.get("name") or "").lower() not in _READ_TOOL_NAMES:
+                    continue
+                p = _path_from_input(blk.get("input") or blk.get("arguments"))
+                if p:
+                    yield p
 
 
 def _decode_data_blob_rows(rows: Iterable[tuple], cols: list[str]) -> list[dict[str, Any]]:

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -336,6 +336,12 @@ _DAEMON_METHODS = frozenset({
     # Issue #1364 (MOAT 1.b): surface OTel spans we already persist.
     # Powers /api/spans + the Brain-tab "Spans" table.
     "query_recent_spans",
+    # Issue #1364 (MOAT Tier-1): /api/skills fidelity counts. Replaces a
+    # 7d × N-session JSONL scan (re-walks every transcript on every
+    # /api/skills render). Returns Read-tool calls so the route can
+    # bucket per-skill body-fetch + linked-file-read counts via the
+    # in-memory skill-paths map.
+    "query_recent_read_tool_calls",
     "health",
 })
 

--- a/routes/skills.py
+++ b/routes/skills.py
@@ -16,6 +16,7 @@ Blueprints: bp_skills
 import json
 import os
 import time
+from datetime import datetime, timezone
 
 from flask import Blueprint, jsonify
 
@@ -23,6 +24,116 @@ bp_skills = Blueprint("skills", __name__)
 
 # Subdirectory names that count as linked-file directories
 _LINKED_DIRS = frozenset({"scripts", "references", "assets"})
+
+
+# ── DuckDB Tier-1 fast path (issue #1364) ────────────────────────────────────
+
+
+def _try_local_store_read_tool_calls(*, since_ts: float):
+    """Tier-1 DuckDB fast-path for /api/skills fidelity counts.
+
+    Replaces ``_scan_fidelity_events``'s 7d × N-session JSONL walk with
+    a single SQL pull from the ``events`` table. Returns a list of
+    ``{ts, session_id, file_path}`` rows on success — the caller does
+    the per-skill bucketing in-process (it already has the skill-paths
+    map in memory; no point round-tripping it to the daemon).
+
+    Returns ``None`` on any miss (daemon down + direct open failed,
+    method not allowlisted, etc.) so the caller falls through to the
+    legacy JSONL scanner unchanged.
+
+    ``since_ts`` is a Unix timestamp; we project it to ISO-8601 (the
+    on-the-wire shape the events table indexes on).
+    """
+    since_iso = datetime.fromtimestamp(since_ts, tz=timezone.utc).isoformat()
+    rows = None
+    try:
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon(
+            "query_recent_read_tool_calls",
+            since=since_iso,
+            limit=50_000,
+        )
+    except Exception:
+        rows = None
+    if rows is None:
+        # Single-process fallback (tests + dev mode have no daemon).
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_recent_read_tool_calls(
+                since=since_iso,
+                limit=50_000,
+            )
+        except Exception:
+            return None
+    if not isinstance(rows, list):
+        return None
+    return rows
+
+
+def _bucket_read_calls_per_skill(rows, skill_dirs_map):
+    """Bucket ``query_recent_read_tool_calls`` rows into the per-skill
+    fidelity stats shape ``_scan_fidelity_events`` produces.
+
+    Counts a Read targeting ``<skill_dir>/SKILL.md`` as a body fetch and
+    a Read under ``<skill_dir>/{scripts,references,assets}/...`` as a
+    linked-file read — same matching rules as the legacy JSONL scanner,
+    case-insensitive + slash-normalised so Windows paths still hit.
+    """
+    stats = {
+        name: {
+            "body_fetch_count_7d":       0,
+            "linked_file_read_count_7d": 0,
+            "last_used_ts":              0.0,
+        }
+        for name in skill_dirs_map
+    }
+
+    skill_md_lower: dict = {}
+    linked_prefix_lower: dict = {}
+    for skill_name, skill_dir in skill_dirs_map.items():
+        sm_path = os.path.join(skill_dir, "SKILL.md")
+        skill_md_lower[sm_path.lower().replace("\\", "/")] = skill_name
+        for ldir in _LINKED_DIRS:
+            ldir_path = os.path.join(skill_dir, ldir)
+            linked_prefix_lower[ldir_path.lower().replace("\\", "/")] = skill_name
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        fp = row.get("file_path") or ""
+        if not isinstance(fp, str) or not fp:
+            continue
+        ts_raw = row.get("ts") or ""
+        ev_ts = _ts_to_epoch(ts_raw)
+
+        fp_lower = fp.lower().replace("\\", "/")
+
+        for sm_norm, skill_name in skill_md_lower.items():
+            if fp_lower.endswith(sm_norm) or sm_norm in fp_lower:
+                stats[skill_name]["body_fetch_count_7d"] += 1
+                if ev_ts > stats[skill_name]["last_used_ts"]:
+                    stats[skill_name]["last_used_ts"] = ev_ts
+
+        for lp_norm, skill_name in linked_prefix_lower.items():
+            if lp_norm in fp_lower:
+                stats[skill_name]["linked_file_read_count_7d"] += 1
+                if ev_ts > stats[skill_name]["last_used_ts"]:
+                    stats[skill_name]["last_used_ts"] = ev_ts
+
+    return stats
+
+
+def _ts_to_epoch(ts_raw: str) -> float:
+    """Best-effort ISO-8601 → Unix epoch. Returns 0.0 on parse fail."""
+    if not ts_raw or not isinstance(ts_raw, str):
+        return 0.0
+    s = ts_raw.replace("Z", "+00:00") if ts_raw.endswith("Z") else ts_raw
+    try:
+        return datetime.fromisoformat(s).timestamp()
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def _get_skills_dir():
@@ -264,9 +375,26 @@ def api_skills():
     cutoff_7d = now_ts - 7 * 86400
     cutoff_30d = now_ts - 30 * 86400
 
-    # Scan session transcripts for fidelity events
-    sessions_dir = _d.SESSIONS_DIR or os.path.expanduser("~/.openclaw/agents/main/sessions")
-    fidelity_stats = _scan_fidelity_events(sessions_dir, skill_dirs_map, cutoff_7d)
+    # Scan session transcripts for fidelity events.
+    #
+    # Fast path: pull recent Read tool-call rows from DuckDB and bucket
+    # them in-process. Falls through to the legacy JSONL walker if the
+    # local store isn't enabled / has no rows / the daemon isn't
+    # reachable — same shape, same numbers, just faster (avoids a
+    # 50-200+ JSONL re-walk on every render).
+    fidelity_stats = None
+    try:
+        from clawmetry.config import is_local_store_read_enabled
+        if is_local_store_read_enabled():
+            rows = _try_local_store_read_tool_calls(since_ts=cutoff_7d)
+            if rows is not None:
+                fidelity_stats = _bucket_read_calls_per_skill(rows, skill_dirs_map)
+    except Exception:
+        fidelity_stats = None
+
+    if fidelity_stats is None:
+        sessions_dir = _d.SESSIONS_DIR or os.path.expanduser("~/.openclaw/agents/main/sessions")
+        fidelity_stats = _scan_fidelity_events(sessions_dir, skill_dirs_map, cutoff_7d)
 
     skills_out = []
     total_header_tokens = 0
@@ -380,8 +508,20 @@ def api_skill_detail(skill_name):
         os.path.isdir(os.path.join(skill_dir, ldir)) for ldir in _LINKED_DIRS
     )
 
-    sessions_dir = _d.SESSIONS_DIR or os.path.expanduser("~/.openclaw/agents/main/sessions")
-    fidelity_stats = _scan_fidelity_events(sessions_dir, {skill_name: skill_dir}, cutoff_7d)
+    skill_dirs_map = {skill_name: skill_dir}
+    fidelity_stats = None
+    try:
+        from clawmetry.config import is_local_store_read_enabled
+        if is_local_store_read_enabled():
+            rows = _try_local_store_read_tool_calls(since_ts=cutoff_7d)
+            if rows is not None:
+                fidelity_stats = _bucket_read_calls_per_skill(rows, skill_dirs_map)
+    except Exception:
+        fidelity_stats = None
+
+    if fidelity_stats is None:
+        sessions_dir = _d.SESSIONS_DIR or os.path.expanduser("~/.openclaw/agents/main/sessions")
+        fidelity_stats = _scan_fidelity_events(sessions_dir, skill_dirs_map, cutoff_7d)
     fev = fidelity_stats.get(skill_name, {
         "body_fetch_count_7d": 0,
         "linked_file_read_count_7d": 0,

--- a/tests/test_skills_fidelity_local_store.py
+++ b/tests/test_skills_fidelity_local_store.py
@@ -1,0 +1,289 @@
+"""Tier-1 DuckDB fast path for /api/skills fidelity counts.
+
+The endpoint historically scanned every session JSONL touched in the
+last 7 days on every request, looking for Read-tool calls whose target
+was a SKILL.md or a file under a skill's scripts/references/assets dir.
+With 50-200 active sessions this is the panel's slowest stage.
+
+This test asserts:
+  1. Unit — when the local DuckDB has Read-tool events targeting a
+     skill's SKILL.md / scripts dir, ``query_recent_read_tool_calls``
+     returns one row per call with the file_path payload.
+  2. E2E — synthetic OpenClaw-shaped events round-trip:
+        ingest -> DuckDB -> /api/skills -> body_fetch_count_7d /
+        linked_file_read_count_7d
+     Both v3 ``tool.call`` events and assistant ``message`` events
+     with ``toolMetas`` are accepted.
+  3. Fallback — empty store + empty workspace -> empty fidelity counts
+     (no synthetic data, no crash).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import time
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Flask app with bp_skills registered, fresh DuckDB per test, plus
+    one synthetic skill on disk so /api/skills has something to count
+    against (the skill discovery itself is a cheap directory listing —
+    not what this fast-path migration is about)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+
+    # Lay down a skill on disk: .openclaw/skills/demo-skill/{SKILL.md,scripts/run.py}
+    skills_root = tmp_path / "openclaw" / "skills"
+    skill_dir = skills_root / "demo-skill"
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo-skill\ndescription: a demo skill\n---\nbody line\n"
+    )
+    (skill_dir / "scripts" / "run.py").write_text("print('hello')\n")
+    # Backdate the SKILL.md mtime so age > 7d but < 30d ('unused' bucket
+    # if no body fetches; but we want 'healthy' once we add fetches).
+    old = time.time() - (10 * 86400)
+    os.utime(skill_dir / "SKILL.md", (old, old))
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "WORKSPACE", str(tmp_path / "openclaw"), raising=False)
+    monkeypatch.setattr(_d, "SESSIONS_DIR", str(tmp_path / "sessions_empty"), raising=False)
+
+    import routes.skills as skills_mod
+    importlib.reload(skills_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(skills_mod.bp_skills)
+    yield a, ls, str(skill_dir)
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _ingest_tool_call(store, *, sid: str, ts: str, file_path: str,
+                      ev_id: str | None = None, name: str = "Read"):
+    """Insert one v3 top-level tool.call event."""
+    if ev_id is None:
+        ev_id = f"tc-{sid}-{ts}-{file_path}"
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "tool.call",
+        "ts":         ts,
+        "data":       {"name": name, "input": {"file_path": file_path}},
+    })
+
+
+def _ingest_assistant_with_toolmetas(store, *, sid: str, ts: str,
+                                      file_path: str, name: str = "Read",
+                                      ev_id: str | None = None):
+    """Insert a trajectory-shape assistant message event whose
+    ``data.toolMetas`` carries the Read invocation."""
+    if ev_id is None:
+        ev_id = f"msg-{sid}-{ts}-{file_path}"
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "message",
+        "ts":         ts,
+        "data":       {
+            "type": "model.completed",
+            "completionText": "reading the skill",
+            "toolMetas": [{"name": name, "input": {"file_path": file_path}}],
+        },
+    })
+
+
+# ── E2E: synthetic events round-trip through DuckDB → /api/skills ─────────
+
+
+def test_skills_fast_path_counts_body_fetch_from_tool_call(app):
+    """A v3 tool.call event targeting SKILL.md must increment
+    body_fetch_count_7d for that skill on the next /api/skills hit."""
+    a, ls, skill_dir = app
+    store = ls.get_store()
+    sm = os.path.join(skill_dir, "SKILL.md")
+    _ingest_tool_call(store, sid="s1", ts="2026-05-15T10:00:00+00:00", file_path=sm)
+    _ingest_tool_call(store, sid="s1", ts="2026-05-15T10:01:00+00:00", file_path=sm)
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/skills").get_json()
+    by_name = {s["name"]: s for s in body["skills"]}
+    assert "demo-skill" in by_name
+    assert by_name["demo-skill"]["body_fetch_count_7d"] == 2
+    assert by_name["demo-skill"]["linked_file_read_count_7d"] == 0
+    assert by_name["demo-skill"]["status"] == "stuck" or \
+           by_name["demo-skill"]["status"] == "healthy"
+
+
+def test_skills_fast_path_counts_linked_file_from_assistant_msg(app):
+    """An assistant message event projecting a Read on
+    scripts/run.py via toolMetas must increment
+    linked_file_read_count_7d for the skill."""
+    a, ls, skill_dir = app
+    store = ls.get_store()
+    sm = os.path.join(skill_dir, "SKILL.md")
+    run_py = os.path.join(skill_dir, "scripts", "run.py")
+    _ingest_assistant_with_toolmetas(
+        store, sid="s2", ts="2026-05-15T11:00:00+00:00", file_path=sm,
+    )
+    _ingest_assistant_with_toolmetas(
+        store, sid="s2", ts="2026-05-15T11:01:00+00:00", file_path=run_py,
+    )
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/skills").get_json()
+    by_name = {s["name"]: s for s in body["skills"]}
+    assert by_name["demo-skill"]["body_fetch_count_7d"] == 1
+    assert by_name["demo-skill"]["linked_file_read_count_7d"] == 1
+    # Body+linked → healthy bucket
+    assert by_name["demo-skill"]["status"] == "healthy"
+
+
+def test_skills_fast_path_drops_non_read_tool_calls(app):
+    """Tool calls for non-Read tools (e.g. Bash, Write) must not
+    inflate either fidelity counter."""
+    a, ls, skill_dir = app
+    store = ls.get_store()
+    sm = os.path.join(skill_dir, "SKILL.md")
+    _ingest_tool_call(store, sid="s3", ts="2026-05-15T12:00:00+00:00",
+                      file_path=sm, name="Bash")
+    _ingest_tool_call(store, sid="s3", ts="2026-05-15T12:01:00+00:00",
+                      file_path=sm, name="Write")
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/skills").get_json()
+    by_name = {s["name"]: s for s in body["skills"]}
+    assert by_name["demo-skill"]["body_fetch_count_7d"] == 0
+    assert by_name["demo-skill"]["linked_file_read_count_7d"] == 0
+
+
+def test_skills_fast_path_returns_empty_counts_when_store_empty(app):
+    """No DuckDB rows + empty SESSIONS_DIR -> demo-skill present (it's
+    on disk) but with zero fidelity counts. No exception."""
+    a, _ls, _skill_dir = app
+    body = a.test_client().get("/api/skills").get_json()
+    by_name = {s["name"]: s for s in body["skills"]}
+    assert "demo-skill" in by_name
+    assert by_name["demo-skill"]["body_fetch_count_7d"] == 0
+    assert by_name["demo-skill"]["linked_file_read_count_7d"] == 0
+
+
+# ── Unit: the LocalStore method itself ─────────────────────────────────────
+
+
+def test_query_recent_read_tool_calls_returns_empty_on_empty(app):
+    _a, ls, _sd = app
+    store = ls.get_store()
+    rows = store.query_recent_read_tool_calls(since="2026-05-01T00:00:00Z")
+    assert rows == []
+
+
+def test_query_recent_read_tool_calls_extracts_v3_tool_call(app):
+    _a, ls, _sd = app
+    store = ls.get_store()
+    _ingest_tool_call(store, sid="sx", ts="2026-05-15T13:00:00+00:00",
+                      file_path="/abs/path/SKILL.md")
+    _wait_flush(store)
+    rows = store.query_recent_read_tool_calls(since="2026-05-01T00:00:00Z")
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == "sx"
+    assert rows[0]["file_path"] == "/abs/path/SKILL.md"
+
+
+def test_query_recent_read_tool_calls_extracts_legacy_content_block(app):
+    """Older transcripts whose data.message.content still carries raw
+    {type:'toolCall',name:'Read',...} blocks must be extracted too —
+    closes the gap the legacy scanner depended on."""
+    _a, ls, _sd = app
+    store = ls.get_store()
+    store.ingest({
+        "id":         "leg-1",
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": "leg-sess",
+        "event_type": "message",
+        "ts":         "2026-05-15T14:00:00+00:00",
+        "data":       {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "toolCall", "name": "Read",
+                     "input": {"file_path": "/legacy/SKILL.md"}},
+                ],
+            }
+        },
+    })
+    _wait_flush(store)
+    rows = store.query_recent_read_tool_calls(since="2026-05-01T00:00:00Z")
+    assert len(rows) == 1
+    assert rows[0]["file_path"] == "/legacy/SKILL.md"
+
+
+def test_query_recent_read_tool_calls_respects_since(app):
+    """Events older than ``since`` must be excluded — keeps the
+    7d-window contract /api/skills depends on."""
+    _a, ls, _sd = app
+    store = ls.get_store()
+    _ingest_tool_call(store, sid="old", ts="2026-04-01T00:00:00+00:00",
+                      file_path="/x/SKILL.md")
+    _ingest_tool_call(store, sid="new", ts="2026-05-15T15:00:00+00:00",
+                      file_path="/x/SKILL.md")
+    _wait_flush(store)
+    rows = store.query_recent_read_tool_calls(since="2026-05-10T00:00:00+00:00")
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == "new"
+
+
+# ── Daemon-call mocking: route hits the proxy, not direct open ─────────────
+
+
+def test_skills_route_uses_daemon_proxy_when_available(app, monkeypatch):
+    """When ``local_store_via_daemon`` returns a populated row list, the
+    route must use it (and NOT fall through to direct open / JSONL)."""
+    a, _ls, skill_dir = app
+    sm = os.path.join(skill_dir, "SKILL.md")
+    canned = [
+        {"ts": "2026-05-15T16:00:00+00:00", "session_id": "proxy-1", "file_path": sm},
+        {"ts": "2026-05-15T16:01:00+00:00", "session_id": "proxy-1", "file_path": sm},
+    ]
+    calls = {"n": 0}
+
+    def fake_proxy(method_name, **kwargs):
+        calls["n"] += 1
+        assert method_name == "query_recent_read_tool_calls"
+        return canned
+
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "local_store_via_daemon", fake_proxy)
+
+    body = a.test_client().get("/api/skills").get_json()
+    by_name = {s["name"]: s for s in body["skills"]}
+    assert calls["n"] == 1, "route did not call the daemon proxy"
+    assert by_name["demo-skill"]["body_fetch_count_7d"] == 2


### PR DESCRIPTION
## Summary
- Tier-1 bypass migration. `/api/skills` previously walked every session JSONL touched in the last 7 days on every render to count Read-tool calls targeting `SKILL.md` and files under `<skill>/{scripts,references,assets}/`. With 50-200+ active sessions this is the panel's slowest stage.
- Replaces it with a single `query_recent_read_tool_calls(since, limit)` SQL aggregate over the `events` table, returning `{ts, session_id, file_path}` rows; route buckets per-skill in-process from the in-memory skill-paths map.
- Same playbook as #1370 (context-anatomy), #1372 (spans), #1373 (loop-signals).

## Files
- `clawmetry/local_store.py` — new `query_recent_read_tool_calls` + `_iter_read_tool_paths` helper handling all three on-the-wire tool-call shapes (v3 top-level `tool.call`/`toolCall`/`tool_use`, trajectory-projected `data.toolMetas`, legacy `data.message.content[*]` blocks).
- `routes/local_query.py` — allowlist the new method for daemon proxy.
- `routes/skills.py` — `_try_local_store_read_tool_calls()` + `_bucket_read_calls_per_skill()` + early-return in `api_skills` and `api_skill_detail`. JSONL fallback preserved verbatim.
- `tests/test_skills_fidelity_local_store.py` — 9 tests (E2E synthetic round-trip, unit coverage of all three shapes, since= window, daemon-proxy mocking).

## Test plan
- [x] `make lint-daemon-allowlist` — passes (16 distinct query_* methods, all in allowlist).
- [x] `pytest tests/test_skills_fidelity_local_store.py` — 9/9 pass in 1.0s.
- [x] `pytest tests/test_context_anatomy_local_store.py tests/test_loop_signals_e2e.py tests/test_circular_import.py` — 33/33 pass; sibling fast-paths unchanged.
- [ ] Post-merge: hit `/api/skills` on a node with active sessions; confirm `body_fetch_count_7d` populated without scanning sessions dir.

## Release notes
**Not** `[RELEASE]`-tagged. Adds a new daemon allowlist entry; users need the sync daemon to restart to pick it up (memory: `feedback_restart_both_processes_after_upgrade`). Holding for one normal `[RELEASE]` cycle so installer-driven upgrade kicks both processes.

## User-visible win
Skills tab paints from a single SQL aggregate instead of re-reading every recent session JSONL on every render — same numbers, no JSONL re-walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)