### PR TITLE
[RELEASE] fix(moat): widen event_type predicates to match real OpenClaw v3 (#1385)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -2310,10 +2310,17 @@ class LocalStore:
             lim = 50_000
         lim = max(1, min(200_000, lim))
 
-        clauses: list[str] = [
-            "(event_type IN ('tool.call', 'toolCall', 'tool_use')"
-            " OR event_type = 'message')"
-        ]
+        # Issue #1385: real OpenClaw v3 emits ``assistant`` /
+        # ``subagent:assistant`` (not bare ``message``) for the host
+        # event whose content blocks include the Read tool_use. The
+        # previous predicate matched ``message`` only, so v3 nodes
+        # silently returned zero rows. Widen to cover both legacy + v3
+        # hosts plus the standalone tool.call/toolCall/tool_use
+        # top-level events.
+        host_in = _sql_in_clause(
+            _TOOL_CALL_HOST_EVENT_TYPES + _TOOL_CALL_TOPLEVEL_EVENT_TYPES
+        )
+        clauses: list[str] = [f"event_type IN {host_in}"]
         params: list[Any] = []
         if since:
             clauses.append("ts >= ?")
@@ -2385,10 +2392,17 @@ class LocalStore:
             lim = 50_000
         lim = max(1, min(200_000, lim))
 
-        clauses: list[str] = [
-            "(event_type IN ('tool.call', 'toolCall', 'tool_use')"
-            " OR event_type = 'message')"
-        ]
+        # Issue #1385: real OpenClaw v3 emits ``assistant`` /
+        # ``subagent:assistant`` (not bare ``message``) for the host
+        # event whose content blocks include tool_use. The previous
+        # predicate matched ``message`` only, so v3 nodes silently
+        # returned zero rows for /api/plugins. Widen to cover both
+        # legacy + v3 hosts plus the standalone tool.call/toolCall/
+        # tool_use top-level events.
+        host_in = _sql_in_clause(
+            _TOOL_CALL_HOST_EVENT_TYPES + _TOOL_CALL_TOPLEVEL_EVENT_TYPES
+        )
+        clauses: list[str] = [f"event_type IN {host_in}"]
         params: list[Any] = []
         if since:
             clauses.append("ts >= ?")
@@ -3534,12 +3548,19 @@ class LocalStore:
         # Step 1: most-recent N sessions ordered by last activity. The
         # session table has updated_at; we use events for the same answer
         # so a single index lookup on ts handles it.
+        #
+        # Issue #1385: real OpenClaw v3 doesn't emit ``message``-typed
+        # events; it emits ``assistant`` and ``model.completed``. The
+        # previous filter was legacy-shape only, so v3 nodes silently
+        # returned ``input_tokens=0`` and the dashboard's
+        # /api/context-anatomy "Session history" bucket vanished.
+        ev_in = _sql_in_clause(_ASSISTANT_EVENT_TYPES)
         recent_sessions = self._fetch(
-            """
+            f"""
             SELECT session_id, MAX(ts) AS last_ts
             FROM events
             WHERE session_id IS NOT NULL
-              AND event_type = 'message'
+              AND event_type IN {ev_in}
             GROUP BY session_id
             ORDER BY last_ts DESC
             LIMIT ?
@@ -3550,14 +3571,14 @@ class LocalStore:
             sid, _last_ts = sid_row[0], sid_row[1]
             if not sid:
                 continue
-            # Step 2: walk this session's message events newest-first
-            # until we find the first non-zero reading.
+            # Step 2: walk this session's assistant-turn events
+            # newest-first until we find the first non-zero reading.
             rows = self._fetch(
-                """
+                f"""
                 SELECT ts, data
                 FROM events
                 WHERE session_id = ?
-                  AND event_type = 'message'
+                  AND event_type IN {ev_in}
                 ORDER BY ts DESC, id DESC
                 """,
                 [sid],
@@ -3572,24 +3593,7 @@ class LocalStore:
                             data = parsed
                     except (ValueError, TypeError, UnicodeDecodeError):
                         continue
-                msg = data.get("message") if isinstance(data.get("message"), dict) else {}
-                usage = msg.get("usage") if isinstance(msg.get("usage"), dict) else {}
-                # Sometimes OpenClaw nests usage at top level — fall through
-                if not usage:
-                    usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
-                if not usage:
-                    continue
-                # OpenClaw native field: "input"; Anthropic SDK echo: "input_tokens"
-                tok = (
-                    usage.get("input_tokens")
-                    or usage.get("inputTokens")
-                    or usage.get("input")
-                    or 0
-                )
-                try:
-                    tok = int(tok)
-                except (TypeError, ValueError):
-                    tok = 0
+                tok = _extract_input_tokens(data)
                 if tok > 0:
                     return {
                         "session_id":   sid,
@@ -3638,19 +3642,26 @@ class LocalStore:
 
         # Step 1: pick the N most-recent sessions that have at least one
         # assistant message. CTE keeps this a single round-trip.
-        sql = """
+        #
+        # Issue #1385: real OpenClaw v3 emits ``assistant`` /
+        # ``model.completed`` (not ``message``) for the parent agent
+        # turn. We deliberately exclude ``subagent:assistant`` — the
+        # parent-vs-subagent model difference is intentional (Task tool
+        # spawns a haiku worker from an opus parent), not a fallback.
+        ev_in = _sql_in_clause(_ASSISTANT_EVENT_TYPES)
+        sql = f"""
             WITH recent_sessions AS (
                 SELECT session_id, MAX(ts) AS last_ts
                 FROM events
-                WHERE event_type = 'message' AND session_id IS NOT NULL
+                WHERE event_type IN {ev_in} AND session_id IS NOT NULL
                 GROUP BY session_id
                 ORDER BY last_ts DESC
                 LIMIT ?
             )
-            SELECT e.session_id, e.ts, e.data
+            SELECT e.session_id, e.ts, e.data, e.event_type, e.model
             FROM events e
             INNER JOIN recent_sessions r ON e.session_id = r.session_id
-            WHERE e.event_type = 'message'
+            WHERE e.event_type IN {ev_in}
             ORDER BY e.session_id, e.ts ASC, e.id ASC
         """
         rows = self._fetch(sql, [sl])
@@ -3665,7 +3676,7 @@ class LocalStore:
         prev_provider: str | None = None
         prev_sid: str | None = None
 
-        for sid, ts, raw in rows:
+        for sid, ts, raw, ev_type, ev_model in rows:
             scanned_sids.add(sid)
             if sid != prev_sid:
                 # New session — reset state machine.
@@ -3681,15 +3692,43 @@ class LocalStore:
                         data = parsed
                 except (ValueError, TypeError, UnicodeDecodeError):
                     continue
-            msg = data.get("message") if isinstance(data.get("message"), dict) else data
-            if not isinstance(msg, dict):
+
+            # Issue #1385 — v3 ``model.completed`` events don't carry a
+            # ``data.message`` envelope, but they DO have a top-level
+            # ``modelId`` + ``provider``. Treat those as assistant turns;
+            # legacy ``message`` events keep the old ``data.message``
+            # walker. We also fall back to the row-level ``model`` column
+            # (populated by the ingestor) so router-style sessions where
+            # only the column was set still produce transitions.
+            model = ""
+            provider = ""
+            msg = data.get("message") if isinstance(data.get("message"), dict) else None
+            if msg is not None:
+                if msg.get("role") != "assistant":
+                    continue
+                model = (msg.get("model") or "").strip()
+                provider = (msg.get("provider") or "").strip()
+            elif ev_type in ("model.completed", "assistant"):
+                model = (data.get("modelId") or data.get("model") or "").strip()
+                provider = (data.get("provider") or "").strip()
+            else:
                 continue
-            if msg.get("role") != "assistant":
-                continue
-            model = (msg.get("model") or "").strip()
-            provider = (msg.get("provider") or "").strip()
+            if not model and ev_model:
+                model = str(ev_model).strip()
+            # Issue #1385: a provider-only change WITH AN EMPTY SIDE is
+            # almost always a metadata-emission inconsistency between
+            # v3 ``assistant`` (carries provider) and v3
+            # ``model.completed`` (sometimes doesn't), not a real
+            # router fallback. Skip those to avoid spurious
+            # "opus → opus (anthropic→'')" pairs in the UI. Two
+            # explicit providers (openai → openrouter) still count.
+            same_model = (model == prev_model)
+            empty_provider_flip = (
+                same_model and (not provider or not prev_provider)
+            )
             if prev_model is not None and model and (
-                model != prev_model or provider != prev_provider
+                model != prev_model
+                or (provider != prev_provider and not empty_provider_flip)
             ):
                 key = (prev_model, prev_provider, model, provider)
                 bucket = pair_counts.get(key)
@@ -4154,6 +4193,121 @@ def _duration_seconds(start_iso: str, end_iso: str) -> float:
         return max(0.0, (b - a).total_seconds())
     except (TypeError, ValueError):
         return 0.0
+
+
+# Event-type sets — issue #1385.
+#
+# Real OpenClaw v3 installs emit ``assistant`` / ``subagent:assistant`` /
+# ``model.completed`` (plus ``user``/``subagent:user``) for what the
+# legacy code generically calls a ``message``. Earlier ClawMetry
+# fast-paths filtered on ``event_type='message'`` exclusively, so on
+# v3 boxes they returned silent zeros while the legacy JSONL walker
+# masked the regression. Centralising the sets here keeps the four
+# affected query methods consistent.
+#
+# Three sets, narrowing in scope:
+#  * ``_ASSISTANT_EVENT_TYPES`` — events that carry an assistant turn we
+#    want to inspect for usage / model attribution. Excludes
+#    ``subagent:assistant`` so per-session model-fallback detection
+#    doesn't fire on parent→subagent model differences (those are
+#    intentional, not a fallback).
+#  * ``_TOOL_CALL_HOST_EVENT_TYPES`` — events whose ``data`` may contain
+#    tool invocations (assistant content blocks, ``toolMetas``, or a
+#    top-level ``tool.call``-shaped payload). Subagent assistant rows
+#    DO call tools and should count toward ``/api/skills`` and
+#    ``/api/plugins`` fidelity, so they're included here.
+#  * ``_TOOL_CALL_TOPLEVEL_EVENT_TYPES`` — top-level ``tool.call`` shape
+#    only (i.e. ``data.name`` + ``data.input`` directly, not nested in a
+#    message envelope).
+_ASSISTANT_EVENT_TYPES = (
+    "message",            # legacy / synthetic
+    "assistant",          # OpenClaw v3 main agent turn
+    "model.completed",    # OpenClaw v3 model-completion record
+)
+_TOOL_CALL_HOST_EVENT_TYPES = (
+    "message",
+    "assistant",
+    "subagent:assistant",
+    "model.completed",
+)
+_TOOL_CALL_TOPLEVEL_EVENT_TYPES = (
+    "tool.call", "toolCall", "tool_use", "tool_call",
+)
+
+
+def _sql_in_clause(values: tuple[str, ...]) -> str:
+    """Render a fixed list of literal event_type strings as a SQL IN(...)
+    clause. The values are module-level constants — never user input —
+    so it's safe to interpolate them directly. Centralised so the four
+    fast-path methods can keep their predicates in sync."""
+    return "(" + ", ".join("'" + v.replace("'", "''") + "'" for v in values) + ")"
+
+
+def _extract_input_tokens(data: dict) -> int:
+    """Pull the ``input_tokens`` count from any of the OpenClaw v3 event
+    shapes seen in the wild. Returns 0 when nothing recognisable is
+    found — caller treats that as "skip this row".
+
+    Issue #1385: ``query_context_window_peek`` was reading
+    ``data.message.usage.input_tokens`` only, which works for the
+    legacy ``message``-typed event AND for v3 ``assistant`` events
+    (which carry the same Anthropic-SDK message envelope). It does
+    NOT work for v3 ``model.completed`` events, whose token count
+    lives at ``data.promptCache.lastCallUsage.input``. This helper
+    walks every shape so the same call site handles all of them.
+
+    Shapes covered (probed in this order):
+      1. ``data.message.usage.{input_tokens,inputTokens,input}`` — both
+         the legacy synthetic ``message`` events and v3 ``assistant``
+         events carry this Anthropic-SDK message envelope.
+      2. ``data.usage.{input_tokens,inputTokens,input}`` — some
+         OpenClaw provider adapters lift ``usage`` to the data root.
+      3. ``data.promptCache.lastCallUsage.{input,input_tokens}`` —
+         OpenClaw v3 ``model.completed`` event shape.
+      4. ``data.assistantMessage.usage.{input,input_tokens}`` — drive-by
+         shape noted in PR #1370 (rare; some forked agents emit it).
+    """
+    if not isinstance(data, dict):
+        return 0
+
+    def _read_usage(usage: Any) -> int:
+        if not isinstance(usage, dict):
+            return 0
+        for key in ("input_tokens", "inputTokens", "input"):
+            v = usage.get(key)
+            if v is None:
+                continue
+            try:
+                iv = int(v)
+            except (TypeError, ValueError):
+                continue
+            if iv > 0:
+                return iv
+        return 0
+
+    msg = data.get("message")
+    if isinstance(msg, dict):
+        n = _read_usage(msg.get("usage"))
+        if n > 0:
+            return n
+
+    n = _read_usage(data.get("usage"))
+    if n > 0:
+        return n
+
+    pc = data.get("promptCache")
+    if isinstance(pc, dict):
+        n = _read_usage(pc.get("lastCallUsage"))
+        if n > 0:
+            return n
+
+    am = data.get("assistantMessage")
+    if isinstance(am, dict):
+        n = _read_usage(am.get("usage"))
+        if n > 0:
+            return n
+
+    return 0
 
 
 _READ_TOOL_NAMES = frozenset({"read", "readfile", "read_file"})

--- a/tests/test_context_anatomy_local_store.py
+++ b/tests/test_context_anatomy_local_store.py
@@ -201,3 +201,87 @@ def test_query_context_window_peek_returns_session_id_and_ts(app):
     assert result["input_tokens"] == 42_000
     assert result["session_id"] == "sess-x"
     assert result["ts"] == "2026-05-15T13:00:00Z"
+
+
+# ── v3 real-shape regression (issue #1385) ────────────────────────────────
+
+
+def test_query_context_window_peek_v3_assistant_event(app):
+    """v3 real-shape regression (#1385): real OpenClaw v3 emits
+    ``event_type='assistant'`` (not ``'message'``) for the parent
+    agent turn. The token count lives at
+    ``data.message.usage.input_tokens`` — same as the legacy shape —
+    but the predicate must also accept the new event_type. Fixture
+    extracted from ``/Users/vivek/.clawmetry/clawmetry.duckdb`` on
+    2026-05-15.
+    """
+    _a, ls = app
+    store = ls.get_store()
+    store.ingest({
+        "id":         "v3-assistant-1",
+        "node_id":    "agent+Macbook-Pro-2-local",
+        "agent_id":   "main",
+        "session_id": "575597e9-f609-4e88-9c12-055392f1c107",
+        "event_type": "assistant",
+        "ts":         "2026-05-15T22:22:09.768Z",
+        # Real OpenClaw v3 ``assistant`` event payload (truncated).
+        "data": {
+            "type":     "assistant",
+            "version":  3,
+            "message": {
+                "role":  "assistant",
+                "model": "claude-opus-4-7",
+                "usage": {
+                    "input_tokens":              6,
+                    "output_tokens":             108,
+                    "cache_read_input_tokens":   18498,
+                    "cache_creation_input_tokens": 19325,
+                },
+            },
+        },
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    result = store.query_context_window_peek(scan_sessions=5)
+    assert result["input_tokens"] == 6, (
+        f"v3 assistant event was not counted; result={result}"
+    )
+    assert result["session_id"] == "575597e9-f609-4e88-9c12-055392f1c107"
+
+
+def test_query_context_window_peek_v3_model_completed_event(app):
+    """v3 real-shape regression (#1385): OpenClaw v3 also emits a
+    parallel ``model.completed`` event whose token count lives at
+    ``data.promptCache.lastCallUsage.input`` — a path the legacy
+    ``data.message.usage.input_tokens`` walker missed entirely.
+    Fixture extracted from
+    ``/Users/vivek/.clawmetry/clawmetry.duckdb`` on 2026-05-15.
+    """
+    _a, ls = app
+    store = ls.get_store()
+    store.ingest({
+        "id":         "v3-mcp-1",
+        "node_id":    "agent+Macbook-Pro-2-local",
+        "agent_id":   "main",
+        "session_id": "575597e9-f609-4e88-9c12-055392f1c107",
+        "event_type": "model.completed",
+        "ts":         "2026-05-15T22:22:09.768Z",
+        # Real OpenClaw v3 ``model.completed`` event payload (verbatim).
+        "data": {
+            "type":      "model.completed",
+            "modelId":   "claude-opus-4-7",
+            "provider":  "claude-cli",
+            "promptCache": {
+                "lastCallUsage": {"input": 6, "output": 108, "total": 114},
+            },
+            "stopReason": "stop",
+        },
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    result = store.query_context_window_peek(scan_sessions=5)
+    assert result["input_tokens"] == 6, (
+        f"v3 model.completed event was not counted; result={result}"
+    )

--- a/tests/test_fallbacks_local_store.py
+++ b/tests/test_fallbacks_local_store.py
@@ -259,6 +259,162 @@ def test_api_fallbacks_returns_rows_from_local_store(fresh_store, monkeypatch):
     assert t["count"] == 1
 
 
+# ── v3 real-shape regression (issue #1385) ────────────────────────────────
+
+
+def _ingest_v3_assistant(
+    store, *, session_id: str, ts: str, model: str, provider: str = "anthropic"
+):
+    """Insert a real OpenClaw v3 ``event_type='assistant'`` row.
+    Same Anthropic-SDK message envelope as legacy, just under a
+    different event_type name. Fixture distilled from
+    ``/Users/vivek/.clawmetry/clawmetry.duckdb`` on 2026-05-15."""
+    store.ingest({
+        "id":         str(uuid.uuid4()),
+        "node_id":    "test-node",
+        "agent_id":   "test-agent",
+        "session_id": session_id,
+        "event_type": "assistant",
+        "ts":         ts,
+        "data": json.dumps({
+            "type":    "assistant",
+            "version": 3,
+            "message": {
+                "role":     "assistant",
+                "model":    model,
+                "provider": provider,
+                "usage":    {"input_tokens": 100, "output_tokens": 50},
+                "content":  [],
+            },
+        }),
+        "model": model,
+    })
+
+
+def _ingest_v3_model_completed(
+    store, *, session_id: str, ts: str, model: str, provider: str = "claude-cli"
+):
+    """Insert a real OpenClaw v3 ``event_type='model.completed'`` row.
+    No ``data.message`` envelope; carries ``modelId``/``provider`` at
+    the data root and ``promptCache.lastCallUsage`` for tokens."""
+    store.ingest({
+        "id":         str(uuid.uuid4()),
+        "node_id":    "test-node",
+        "agent_id":   "test-agent",
+        "session_id": session_id,
+        "event_type": "model.completed",
+        "ts":         ts,
+        "data": json.dumps({
+            "type":     "model.completed",
+            "modelId":  model,
+            "provider": provider,
+            "promptCache": {
+                "lastCallUsage": {"input": 100, "output": 50, "total": 150},
+            },
+            "stopReason": "stop",
+        }),
+        "model": model,
+    })
+
+
+def test_query_model_fallbacks_v3_assistant_event_shape(fresh_store):
+    """v3 real-shape regression (#1385): real OpenClaw v3 emits
+    ``event_type='assistant'`` (not ``'message'``). The previous
+    predicate filtered ``= 'message'`` and silently returned
+    ``scanned=0`` on every live install. Widened predicate must
+    detect the v3 transition."""
+    ls, store = fresh_store
+    sid = "v3-sess-1"
+    _ingest_v3_assistant(store, session_id=sid, ts="2026-05-15T10:00:00",
+                         model="claude-opus-4-7")
+    _ingest_v3_assistant(store, session_id=sid, ts="2026-05-15T10:01:00",
+                         model="claude-opus-4-7")
+    _ingest_v3_assistant(store, session_id=sid, ts="2026-05-15T10:02:00",
+                         model="claude-sonnet-4-7")
+    store._flush_now()
+
+    out = store.query_model_fallbacks(session_limit=10, top=10)
+    assert out["scanned"] == 1, f"v3 assistant rows ignored: {out}"
+    assert out["sessions_affected"] == 1
+    assert len(out["top_transitions"]) == 1
+    t = out["top_transitions"][0]
+    assert t["from_model"] == "claude-opus-4-7"
+    assert t["to_model"] == "claude-sonnet-4-7"
+    assert t["count"] == 1
+
+
+def test_query_model_fallbacks_v3_model_completed_shape(fresh_store):
+    """v3 real-shape regression (#1385): ``model.completed`` events
+    don't carry a ``data.message`` envelope — model lives at
+    ``data.modelId`` / ``data.provider``. Widened walker must read
+    those fields, otherwise sessions where ONLY model.completed
+    rows exist (no parallel ``assistant`` event) report no model
+    information at all."""
+    ls, store = fresh_store
+    sid = "v3-mcp-sess"
+    _ingest_v3_model_completed(store, session_id=sid,
+                               ts="2026-05-15T10:00:00",
+                               model="claude-opus-4-7",
+                               provider="claude-cli")
+    _ingest_v3_model_completed(store, session_id=sid,
+                               ts="2026-05-15T10:01:00",
+                               model="claude-haiku-4-7",
+                               provider="claude-cli")
+    store._flush_now()
+
+    out = store.query_model_fallbacks(session_limit=10, top=10)
+    assert out["scanned"] == 1
+    assert out["sessions_affected"] == 1
+    assert len(out["top_transitions"]) == 1
+    t = out["top_transitions"][0]
+    assert t["from_model"] == "claude-opus-4-7"
+    assert t["to_model"] == "claude-haiku-4-7"
+    assert t["from_provider"] == "claude-cli"
+
+
+def test_query_model_fallbacks_excludes_subagent_assistant(fresh_store):
+    """v3 real-shape regression (#1385): parent agent calling Task
+    spawns a ``subagent:assistant`` row with a different model
+    (often haiku from an opus parent). That's intentional — NOT a
+    fallback. The widened predicate must exclude
+    ``subagent:assistant`` so we don't fire false positives."""
+    ls, store = fresh_store
+    sid = "v3-mixed"
+    _ingest_v3_assistant(store, session_id=sid, ts="2026-05-15T10:00:00",
+                         model="claude-opus-4-7")
+    # Subagent emission with a different model — must be IGNORED.
+    store.ingest({
+        "id":         str(uuid.uuid4()),
+        "node_id":    "test-node",
+        "agent_id":   "test-agent",
+        "session_id": sid,
+        "event_type": "subagent:assistant",
+        "ts":         "2026-05-15T10:00:30",
+        "data": json.dumps({
+            "type":    "assistant",
+            "version": 3,
+            "message": {
+                "role":     "assistant",
+                "model":    "claude-haiku-4-5",
+                "provider": "anthropic",
+                "usage":    {"input_tokens": 100},
+                "content":  [],
+            },
+        }),
+        "model": "claude-haiku-4-5",
+    })
+    _ingest_v3_assistant(store, session_id=sid, ts="2026-05-15T10:01:00",
+                         model="claude-opus-4-7")
+    store._flush_now()
+
+    out = store.query_model_fallbacks(session_limit=10, top=10)
+    # Only opus→opus seen at the parent level; no transition.
+    assert out["sessions_affected"] == 0, (
+        f"subagent:assistant leaked into transitions: {out}"
+    )
+    assert out["top_transitions"] == []
+
+
 def test_api_fallbacks_defers_to_legacy_when_store_empty(
     fresh_store, monkeypatch, tmp_path
 ):

--- a/tests/test_skills_fidelity_local_store.py
+++ b/tests/test_skills_fidelity_local_store.py
@@ -261,6 +261,142 @@ def test_query_recent_read_tool_calls_respects_since(app):
     assert rows[0]["session_id"] == "new"
 
 
+# ── v3 real-shape regression (issue #1385) ────────────────────────────────
+
+
+def test_query_recent_read_tool_calls_v3_assistant_event(app):
+    """v3 real-shape regression (#1385): real OpenClaw v3 emits the
+    parent agent's tool-use blocks under ``event_type='assistant'``
+    (not ``'message'``). The previous predicate matched
+    ``message`` only, so v3 nodes silently returned zero Read calls
+    and ``/api/skills`` body_fetch counts went to 0 across the
+    fleet. Fixture distilled from a real
+    ``data.message.content[*]`` block extracted from
+    ``/Users/vivek/.clawmetry/clawmetry.duckdb`` on 2026-05-15."""
+    _a, ls, _sd = app
+    store = ls.get_store()
+    store.ingest({
+        "id":         "v3-asst-read-1",
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": "v3-real",
+        "event_type": "assistant",
+        "ts":         "2026-05-15T22:22:09.768Z",
+        # Real v3 ``assistant`` event payload — content list with a
+        # tool_use block (the same shape Anthropic's SDK echoes).
+        "data": {
+            "type":    "assistant",
+            "version": 3,
+            "message": {
+                "role":  "assistant",
+                "model": "claude-opus-4-7",
+                "content": [
+                    {"type": "thinking", "thinking": "..."},
+                    {
+                        "type": "tool_use",
+                        "id":   "toolu_01abc",
+                        "name": "Read",
+                        "input": {"file_path": "/abs/SKILL.md"},
+                    },
+                ],
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        },
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    rows = store.query_recent_read_tool_calls(since="2026-05-01T00:00:00Z")
+    assert len(rows) == 1, f"v3 assistant tool_use ignored; rows={rows}"
+    assert rows[0]["file_path"] == "/abs/SKILL.md"
+    assert rows[0]["session_id"] == "v3-real"
+
+
+def test_query_recent_read_tool_calls_v3_subagent_assistant_event(app):
+    """v3 real-shape regression (#1385): subagents call Read too
+    (Task → haiku worker scanning files). The widened predicate
+    must include ``subagent:assistant`` so /api/skills credits
+    reads done by subagents (which is the majority of skill-content
+    fetches in real-world OpenClaw sessions)."""
+    _a, ls, _sd = app
+    store = ls.get_store()
+    store.ingest({
+        "id":         "v3-sub-read-1",
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": "v3-real",
+        "event_type": "subagent:assistant",
+        "ts":         "2026-05-15T22:23:00.000Z",
+        "data": {
+            "type":    "assistant",
+            "version": 3,
+            "message": {
+                "role":  "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id":   "toolu_subagent",
+                        "name": "Read",
+                        "input": {"file_path": "/abs/scripts/run.py"},
+                    },
+                ],
+            },
+        },
+        "model": "claude-haiku-4-5",
+    })
+    _wait_flush(store)
+
+    rows = store.query_recent_read_tool_calls(since="2026-05-01T00:00:00Z")
+    assert len(rows) == 1, f"v3 subagent:assistant ignored; rows={rows}"
+    assert rows[0]["file_path"] == "/abs/scripts/run.py"
+
+
+def test_query_tool_call_invocations_v3_assistant_event(app):
+    """v3 real-shape regression (#1385): /api/plugins fast-path
+    (``query_tool_call_invocations``) also filtered on
+    ``event_type='message'`` — same bug, same fix. After the
+    widening, every tool_use block in a v3 ``assistant`` event must
+    contribute one row to the per-plugin invocation counter."""
+    _a, ls, _sd = app
+    store = ls.get_store()
+    store.ingest({
+        "id":         "v3-asst-multitool",
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": "v3-real-2",
+        "event_type": "assistant",
+        "ts":         "2026-05-15T22:30:00.000Z",
+        # Real v3 shape — assistant content list with three tool_use
+        # blocks (verbatim names observed on this box: Bash, Write,
+        # Glob, WebSearch, Read, etc.).
+        "data": {
+            "type":    "assistant",
+            "version": 3,
+            "message": {
+                "role":  "assistant",
+                "model": "claude-opus-4-7",
+                "content": [
+                    {"type": "tool_use", "name": "Bash",
+                     "input": {"command": "ls"}},
+                    {"type": "tool_use", "name": "Write",
+                     "input": {"file_path": "/x", "content": "y"}},
+                    {"type": "tool_use", "name": "Read",
+                     "input": {"file_path": "/x"}},
+                ],
+            },
+        },
+        "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    rows = store.query_tool_call_invocations(since="2026-05-01T00:00:00Z")
+    names = sorted(r["name"] for r in rows)
+    assert names == ["Bash", "Read", "Write"], (
+        f"v3 assistant tool_use names lost; rows={rows}"
+    )
+
+
 # ── Daemon-call mocking: route hits the proxy, not direct open ─────────────
 
 


### PR DESCRIPTION
Closes #1385.

## Root cause
Three (now four — see /api/plugins below) DuckDB fast-paths in
`clawmetry/local_store.py` filtered on `event_type='message'`, but
real OpenClaw v3 emits **`assistant`**, **`subagent:assistant`**,
**`model.completed`**, **`tool-result`** instead. On every live install
the fast-paths silently returned zeros and the legacy JSONL walker
masked the regression.

Distribution observed on a real v3 box (763 events):
```
subagent:assistant: 126  | assistant: 111  | subagent:user: 78
queue-operation: 72      | user: 65        | channel.out: 24
attachment: 11           | tool-result: 4  | model.completed: 2
session.started: 2       | prompt.submitted: 2  | tool.result: 1
message events: 0   <-- ZERO
```

## Live verification (this box, real DuckDB)

| Function | BEFORE (0.12.228) | AFTER |
|---|---|---|
| `query_context_window_peek` | `{input_tokens: 0}` | `{input_tokens: 6, sid: 625c0ad9, ts: ...}` |
| `query_model_fallbacks` | `scanned: 0` | `scanned: 4, sessions_affected: 0` (no real fallbacks) |
| `query_recent_read_tool_calls` | `[]` | 24 rows |
| `query_tool_call_invocations` (`/api/plugins`) | 0 | 169 rows (Bash:62, Read:24, Grep:10, ...) |

`/api/context-anatomy` "Session history" bucket reappears.

## Predicate widening (before -> after)

```
# query_context_window_peek
- WHERE event_type = 'message'
+ WHERE event_type IN ('message','assistant','model.completed')

# query_model_fallbacks (intentionally excludes subagent:assistant —
# Task-spawned haiku workers aren't fallbacks)
- WHERE event_type = 'message'
+ WHERE event_type IN ('message','assistant','model.completed')

# query_recent_read_tool_calls (#1385) and query_tool_call_invocations
# (subagent IS included here — subagents call Read too)
- (event_type IN ('tool.call','toolCall','tool_use') OR event_type = 'message')
+ event_type IN ('message','assistant','subagent:assistant','model.completed',
+                'tool.call','toolCall','tool_use','tool_call')
```

## Per-row data extraction
- `_extract_input_tokens(data)` walks `data.message.usage`,
  `data.usage`, `data.promptCache.lastCallUsage` (v3
  `model.completed` shape — uses `input` not `input_tokens`), and
  `data.assistantMessage.usage`.
- `query_model_fallbacks` reads `data.modelId` / `data.provider` for
  v3 `model.completed` events that lack a `data.message` envelope,
  with row-level `model` column as a final fallback.
- Provider-only flips with one empty side are now suppressed (avoids
  spurious "opus -> opus (anthropic -> '')" pairs caused by metadata
  inconsistency between `assistant` and `model.completed` events).

## Tests
Each affected query gained a "v3 real-shape regression" test using
events distilled verbatim from `/Users/vivek/.clawmetry/clawmetry.duckdb`
on this box. Legacy synthetic-shape tests retained — both pass.

8 new tests:
- `test_query_context_window_peek_v3_assistant_event`
- `test_query_context_window_peek_v3_model_completed_event`
- `test_query_model_fallbacks_v3_assistant_event_shape`
- `test_query_model_fallbacks_v3_model_completed_shape`
- `test_query_model_fallbacks_excludes_subagent_assistant`
- `test_query_recent_read_tool_calls_v3_assistant_event`
- `test_query_recent_read_tool_calls_v3_subagent_assistant_event`
- `test_query_tool_call_invocations_v3_assistant_event`

## [RELEASE] tag
Verified live against the real DuckDB on this box (see live table
above). Ships as 0.12.229.

## Test plan
- [x] All 8 new v3 regression tests pass
- [x] All existing legacy-shape unit tests pass (17 + 8 = 25 of 32 in the touched files)
- [x] Live verification: 4/4 query methods return non-zero on real v3 data
- [x] Subagent exclusion verified — no false-positive opus->haiku transitions
- [x] No regressions in unrelated routes (only `local_store.py` query methods touched)

7 pre-existing E2E test failures in the touched files are unrelated
to this fix — they hit the live local daemon proxy at port 52710
(test isolation bug, not a behaviour bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)