### PR TITLE
feat(accuracy): approvals harness — verify allow/deny round-trip + downstream effects

### DIFF
--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -329,6 +329,14 @@ _DAEMON_METHODS = frozenset({
     # in routes/nemoclaw.py — collided with the daemon's writer lock.
     # Routed through proxy so /api/nemoclaw/pending-approvals stays fast.
     "query_approvals",
+    # Accuracy-harness #1395 follow-up (approvals): drives ground truth
+    # by calling LocalStore.ingest_approval / update_approval_decision via
+    # the daemon proxy (the daemon owns the writer lock — same reason
+    # query_approvals was added). Both methods are read-then-write under
+    # the daemon's _write_lock, so concurrent dashboard / cloud-relay
+    # decisions stay serialized.
+    "ingest_approval",
+    "update_approval_decision",
     # Issue #1364: surface clawmetry/proxy.py LoopDetector signals on the
     # dashboard. Read by routes/health.py:/api/loop-signals via the daemon
     # proxy so the dashboard process never opens DuckDB writable.

--- a/scripts/accuracy_harness/README.md
+++ b/scripts/accuracy_harness/README.md
@@ -1,7 +1,8 @@
 # Accuracy Harness
 
-Synthetic ground-truth verifiers for ClawMetry features. **Tokens is the
-proof-of-concept**; the same shape extends to approvals and alerts next.
+Synthetic ground-truth verifiers for ClawMetry features. **Tokens** was the
+proof-of-concept (PR #1395); **approvals** is the second harness, and the
+same shape extends to alerts / channels / crons next.
 
 ## Why
 
@@ -36,8 +37,11 @@ threshold. Steps 1/3/4/5/6 stay identical — that's the harness shape.
 ## Running it
 
 ```bash
-# Default: 3 messages, auto-detect dashboard on 8900/8903/8905
+# Tokens: default 3 messages, auto-detect dashboard on 8900/8903/8905
 python3 scripts/accuracy_harness/tokens.py
+
+# Approvals: drives 1 approve + 1 deny round
+python3 scripts/accuracy_harness/approvals.py
 
 # Custom message count + URL
 CLAWMETRY_URL=http://localhost:8903 \
@@ -45,6 +49,7 @@ CLAWMETRY_URL=http://localhost:8903 \
 
 # File a GitHub issue per drift (default: print only)
 python3 scripts/accuracy_harness/tokens.py --file-issues
+python3 scripts/accuracy_harness/approvals.py --file-issues
 ```
 
 ### Prerequisites
@@ -71,6 +76,8 @@ per full run** on opus-4-7.
 
 ## What's covered today
 
+### Tokens (`tokens.py`)
+
 | endpoint | window | metrics |
 |---|---|---|
 | `/api/usage` | today | input / output / cacheRead / cacheWrite / total |
@@ -81,7 +88,22 @@ per full run** on opus-4-7.
 
 Tolerance: ±1 token per metric; ±3 for cache splits (rounding).
 
+### Approvals (`approvals.py`)
+
+| surface | stage | assertions |
+|---|---|---|
+| `daemon.query_approvals(status='pending')` | pending | row appears with matching `id`, `action`, `args`, `session_id`, `status='pending'`, `created_at` |
+| `/api/nemoclaw/pending-approvals` | pending | dashboard endpoint includes the row + same fields (legacy NemoClaw shape) |
+| `daemon.query_approvals(status='approved'\|'denied')` | decided | `status` flips, `decision` matches, `resolver` reflects caller, `decision_reason` round-trips, `resolved_at` is within 30s of now |
+| `/api/nemoclaw/pending-approvals` | post-decide | row no longer appears in pending list |
+
+Two rounds per run — one `approve`, one `deny`. The synthetic row uses
+`action='harness:noop'` and an `harness-AUDIT_<run_id>-…` id so it can't
+collide with a real approval policy or with another harness run.
+
 ## What's NOT covered yet (next iteration)
+
+### Tokens
 
 - **1-hour window** — `/api/usage` doesn't expose hourly granularity;
   Tokens tab only buckets per-day. To verify "last hour" you need
@@ -108,6 +130,30 @@ Tolerance: ±1 token per metric; ±3 for cache splits (rounding).
   variant that asserts the same numbers appear on the encrypted upload
   side within N minutes.
 
+### Approvals
+
+- **No `/api/approvals` endpoint** — the legacy `/api/nemoclaw/pending-approvals`
+  is the only public HTTP surface today, and it's `status=pending` only.
+  There's no public endpoint to list `decided` rows; the harness asserts
+  that path via the daemon proxy (`query_approvals`) instead. **Product
+  gap surfaced** by this harness.
+- **No `/api/approvals/decide` endpoint** — decisions are made via
+  cloud-relay heartbeat (cloud → daemon `_apply_approval_decision`) or
+  this harness (direct daemon-proxy `update_approval_decision`). There is
+  no OSS-side button for the user to decide an approval. **Product gap.**
+- **Policy-watcher trigger path** — the harness writes the approval row
+  directly via `ingest_approval`, bypassing `clawmetry/approvals.py`'s
+  policy-match → cloud-POST → poll loop. A separate harness needs to
+  drive a real policy match end-to-end.
+- **`decided_by`/`decided_at` field naming** — the spec uses these names
+  but the schema columns are `resolver`/`resolved_at`. Harness asserts
+  the schema names; if the dashboard ever exposes the spec names through
+  a renderer, add an assertion there.
+- **History-row `reason` rendering** — the harness verifies the
+  `decision_reason` column round-trips; it does not (yet) verify the
+  reason renders in any UI surface, because there's no dashboard tab
+  that shows decided approvals today.
+
 ## Idempotency
 
 Safe to re-run. Each run uses a fresh `ACCURACY_AUDIT_<uuid>` tag, so:
@@ -123,13 +169,20 @@ Safe to re-run. Each run uses a fresh `ACCURACY_AUDIT_<uuid>` tag, so:
 scripts/accuracy_harness/
 ├── README.md       # this file
 ├── __init__.py     # package marker
-└── tokens.py       # tokens-first harness (this PoC)
+├── _lib.py         # shared discovery + HTTP + drift-issue helpers
+├── tokens.py       # tokens harness (PR #1395)
+└── approvals.py    # approvals queue harness (this PR)
 ```
+
+Shared shims live in `_lib.py` (`discover_dashboard_url`,
+`discover_daemon`, `daemon_call`, `drive_openclaw_message`,
+`file_drift_issue_per_endpoint`, …) so each new harness can land in a
+single self-contained file. Refactor: extract another helper into
+`_lib.py` whenever a second harness needs it — no copy-paste.
 
 Future:
 ```
-├── approvals.py    # same shape, drives approval requests
-├── alerts.py       # same shape, trips known thresholds
-└── _common.py      # shared discovery + reporting helpers
-                    # (factor out once 2+ harnesses exist)
+├── alerts.py       # same shape, trips a known threshold
+├── crons.py        # same shape, schedules + verifies a run
+└── channels.py     # same shape, drives a channel send + flow
 ```

--- a/scripts/accuracy_harness/_lib.py
+++ b/scripts/accuracy_harness/_lib.py
@@ -1,0 +1,297 @@
+"""scripts/accuracy_harness/_lib.py — shared helpers for every harness.
+
+Extracted from ``tokens.py`` (PR #1395) when the second harness landed
+(``approvals.py``, this PR). Keeping the discovery / HTTP / openclaw-CLI
+shims in one place means a future ``alerts.py`` / ``crons.py`` /
+``channels.py`` harness can ``from _lib import ...`` without copy-paste,
+and a fix to (e.g.) the daemon discovery flow only needs to land once.
+
+Public surface:
+    DEFAULT_DASHBOARD_PORTS, GH_REPO, OPENCLAW_BIN
+    http_get_json, http_post_json
+    discover_dashboard_url, discover_daemon, daemon_event_count
+    daemon_call (generic ``__local_query__/<method>`` proxy)
+    drive_openclaw_message, extract_openclaw_usage
+    file_drift_issue_per_endpoint, format_drift_issue_body
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+# ─── Constants ──────────────────────────────────────────────────────────────
+
+DEFAULT_DASHBOARD_PORTS = (8900, 8903, 8905)
+GH_REPO = "vivekchand/clawmetry"
+OPENCLAW_BIN = shutil.which("openclaw") or "openclaw"
+LOCAL_QUERY_DISCOVERY = Path.home() / ".clawmetry" / "local_query.json"
+
+
+# ─── HTTP shims ─────────────────────────────────────────────────────────────
+
+def http_get_json(url: str, timeout: float = 10.0,
+                  headers: dict | None = None) -> Any:
+    h = {"Accept": "application/json"}
+    if headers:
+        h.update(headers)
+    req = urllib.request.Request(url, headers=h)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def http_post_json(url: str, body: dict | None = None,
+                   headers: dict | None = None,
+                   timeout: float = 10.0) -> Any:
+    data = json.dumps(body or {}).encode("utf-8")
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if headers:
+        h.update(headers)
+    req = urllib.request.Request(url, data=data, headers=h, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+# ─── Discovery ──────────────────────────────────────────────────────────────
+
+def _port_listening(port: int, host: str = "127.0.0.1") -> bool:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(0.2)
+    try:
+        return s.connect_ex((host, port)) == 0
+    finally:
+        s.close()
+
+
+def discover_dashboard_url(override: str | None,
+                            probe_path: str = "/api/usage",
+                            probe_keys: Iterable[str] = ("days",)) -> str:
+    """Return the first dashboard base URL that responds with JSON containing
+    any of ``probe_keys`` at ``probe_path``. Honours ``--dashboard-url`` >
+    ``$CLAWMETRY_URL`` > auto-scan ``DEFAULT_DASHBOARD_PORTS``.
+    """
+    if override:
+        return override.rstrip("/")
+    env = os.environ.get("CLAWMETRY_URL")
+    if env:
+        return env.rstrip("/")
+    for port in DEFAULT_DASHBOARD_PORTS:
+        if not _port_listening(port):
+            continue
+        url = f"http://localhost:{port}"
+        try:
+            payload = http_get_json(f"{url}{probe_path}", timeout=3.0)
+            if isinstance(payload, dict) and any(k in payload for k in probe_keys):
+                return url
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError, TimeoutError):
+            continue
+    raise RuntimeError(
+        f"could not find a ClawMetry dashboard on any of {DEFAULT_DASHBOARD_PORTS}. "
+        f"Set CLAWMETRY_URL or pass --dashboard-url."
+    )
+
+
+def discover_daemon() -> dict | None:
+    """Return ``{port, token}`` for the daemon's local_query proxy, or None
+    when unavailable. Liveness-checked via ``os.kill(pid, 0)``."""
+    try:
+        with open(LOCAL_QUERY_DISCOVERY) as fh:
+            d = json.load(fh)
+        if not (d.get("port") and d.get("token")):
+            return None
+        try:
+            os.kill(int(d.get("pid") or 0), 0)
+        except (OSError, ValueError):
+            return None
+        return {"port": int(d["port"]), "token": d["token"]}
+    except (FileNotFoundError, ValueError, OSError):
+        return None
+
+
+def daemon_call(daemon: dict, method: str, *, timeout: float = 5.0,
+                **kwargs) -> Any:
+    """Call ``LocalStore.<method>(**kwargs)`` via the daemon's
+    ``/__local_query__/<method>`` proxy. Returns the parsed ``"result"``
+    value on success, raises on HTTP / allowlist / serialisation failure.
+    """
+    url = f"http://127.0.0.1:{daemon['port']}/__local_query__/{method}"
+    body = http_post_json(
+        url, body={"kwargs": kwargs},
+        headers={"Authorization": f"Bearer {daemon['token']}"},
+        timeout=timeout,
+    )
+    if isinstance(body, dict) and "error" in body:
+        raise RuntimeError(f"daemon proxy {method} returned error: {body['error']}")
+    return body.get("result") if isinstance(body, dict) else None
+
+
+def daemon_event_count(daemon: dict) -> int | None:
+    """Return total event_count from ``health``. None if unreachable."""
+    try:
+        result = daemon_call(daemon, "health", timeout=3.0)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError,
+            TimeoutError, OSError, RuntimeError):
+        return None
+    if isinstance(result, dict):
+        ev = result.get("event_count")
+        try:
+            return int(ev) if ev is not None else None
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+# ─── OpenClaw CLI driver (used by tokens harness; reusable) ─────────────────
+
+def drive_openclaw_message(message: str, tag: str,
+                            timeout_s: int = 120) -> dict[str, Any]:
+    """Run ``openclaw agent --agent main --message <m> --json`` once.
+    The tag is appended to the message body so the resulting transcript /
+    DuckDB row is searchable."""
+    full_msg = f"{message} [{tag}]"
+    cmd = [OPENCLAW_BIN, "agent", "--agent", "main", "--message", full_msg, "--json"]
+    proc = subprocess.run(
+        cmd, capture_output=True, text=True, timeout=timeout_s, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"openclaw agent exited {proc.returncode}\nstderr: {proc.stderr[:500]}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"openclaw agent --json returned non-JSON: {e}\nfirst 300 bytes: {proc.stdout[:300]}"
+        )
+
+
+def extract_openclaw_usage(agent_json: dict) -> dict[str, Any] | None:
+    """Pull the usage block out of an ``openclaw agent --json`` response."""
+    meta = (agent_json or {}).get("result", {}).get("meta", {}) or {}
+    agent_meta = meta.get("agentMeta") or {}
+    usage = agent_meta.get("usage") or {}
+    if not usage:
+        return None
+    return {
+        "input":      int(usage.get("input") or 0),
+        "output":     int(usage.get("output") or 0),
+        "cacheRead":  int(usage.get("cacheRead") or 0),
+        "cacheWrite": int(usage.get("cacheWrite") or 0),
+        "sessionId":  agent_meta.get("sessionId") or "",
+        "model":      agent_meta.get("model") or "",
+    }
+
+
+# ─── Drift issue filing (shared shape) ──────────────────────────────────────
+
+def _open_audit_issue_exists(harness_label: str, endpoint: str,
+                              today: str) -> bool:
+    """Cheap dedup probe so re-runs in one day don't fan out N issues."""
+    try:
+        proc = subprocess.run(
+            ["gh", "issue", "list",
+             "--repo", GH_REPO,
+             "--state", "open",
+             "--search",
+             f"[accuracy-audit {today}] {harness_label} drift: {endpoint} in:title",
+             "--json", "number"],
+            check=True, capture_output=True, text=True, timeout=15,
+        )
+        return bool(json.loads(proc.stdout or "[]"))
+    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError,
+            subprocess.TimeoutExpired):
+        return False
+
+
+def file_drift_issue_per_endpoint(
+    *,
+    harness_label: str,
+    drifts: list,                              # list with .endpoint, .delta, .window_label, .metric, .ground, .actual, .tolerance attrs OR dict-likes
+    extra_labels: list[str] | None = None,
+    body_builder=None,                         # callable(endpoint, group) -> str
+) -> int:
+    """Group drifts by endpoint, file ONE issue per endpoint with all
+    drifted (window, metric) rows in the body. Returns count of issues filed.
+
+    ``body_builder`` is an optional callable invoked as
+    ``body_builder(endpoint, group_of_drifts)`` returning a markdown string.
+    Falls back to ``format_drift_issue_body`` when None.
+    """
+    if not shutil.which("gh"):
+        print("[harness] `gh` CLI not on PATH; cannot file issues. Skipping.")
+        return 0
+    grouped: dict[str, list] = {}
+    for c in drifts:
+        ep = getattr(c, "endpoint", None) or (c.get("endpoint") if isinstance(c, dict) else None)
+        if not ep:
+            continue
+        grouped.setdefault(ep, []).append(c)
+    today = datetime.now().strftime("%Y-%m-%d")
+    labels = ["accuracy-audit", harness_label, "bug"]
+    if extra_labels:
+        labels.extend(extra_labels)
+    filed = 0
+    for endpoint, cs in grouped.items():
+        headline = max(cs, key=lambda c: abs(getattr(c, "delta", 0) or 0))
+        title = (
+            f"[accuracy-audit {today}] {harness_label} drift: {endpoint} "
+            f"{getattr(headline, 'window_label', '?')}/{getattr(headline, 'metric', '?')} "
+            f"ground={getattr(headline, 'ground', '?')} "
+            f"actual={getattr(headline, 'actual', '?')} "
+            f"(delta={getattr(headline, 'delta', 0):+d}; {len(cs)} drifts total)"
+        )
+        if _open_audit_issue_exists(harness_label, endpoint, today):
+            print(f"[harness] open issue for {endpoint} already exists today — skipping file")
+            continue
+        body = (body_builder or format_drift_issue_body)(endpoint, cs)
+        cmd = ["gh", "issue", "create", "--repo", GH_REPO,
+               "--title", title, "--body", body]
+        for lbl in labels:
+            cmd += ["--label", lbl]
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            print(f"[harness] filed issue: {title}")
+            filed += 1
+        except subprocess.CalledProcessError:
+            try:
+                proc = subprocess.run(
+                    ["gh", "issue", "create", "--repo", GH_REPO,
+                     "--title", title, "--body", body],
+                    check=True, capture_output=True, text=True,
+                )
+                print(f"[harness] filed (no labels): {proc.stdout.strip()}")
+                filed += 1
+            except subprocess.CalledProcessError as e2:
+                print(f"[harness] FAILED to file issue: {e2.stderr[:300]}",
+                      file=sys.stderr)
+    return filed
+
+
+def format_drift_issue_body(endpoint: str, cs: list) -> str:
+    """Default body shape: drift table (no ground-truth log — harness-specific
+    bodies should subclass via the ``body_builder`` callable instead)."""
+    lines = [
+        f"## Drift report — `{endpoint}`",
+        "",
+        "Auto-filed by `scripts/accuracy_harness/`.",
+        "",
+        "### Drifted (window, metric) pairs",
+        "| window | metric | ground | actual | delta | tolerance |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    for c in cs:
+        lines.append(
+            f"| {getattr(c, 'window_label', '?')} | {getattr(c, 'metric', '?')} | "
+            f"{getattr(c, 'ground', '?')} | {getattr(c, 'actual', '?')} | "
+            f"{getattr(c, 'delta', 0):+d} | "
+            f"±{getattr(c, 'tolerance', 0)} |"
+        )
+    return "\n".join(lines)

--- a/scripts/accuracy_harness/approvals.py
+++ b/scripts/accuracy_harness/approvals.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""scripts/accuracy_harness/approvals.py — approvals queue verifier.
+
+Drives a synthetic approval row → asserts pending state → decides
+approve/deny → asserts decided state. Same drive→wait→assert→report
+shape as ``tokens.py`` (PR #1395); shared helpers live in ``_lib.py``.
+
+GAPS surfaced (documented in README, asserted around, not hidden):
+  * NO ``/api/approvals`` endpoint — only ``/api/nemoclaw/pending-approvals``
+    (status=pending only). Decided rows aren't exposed via HTTP today;
+    harness asserts that surface via the daemon proxy ``query_approvals``.
+  * NO ``/api/approvals/decide`` endpoint. Decisions arrive via cloud
+    relay → daemon ``_apply_approval_decision``, OR via this harness's
+    direct daemon-proxy ``update_approval_decision`` call. No OSS-side
+    UI button decides approvals today.
+  * Schema field rename: spec says ``decided_by``/``decided_at``;
+    schema columns are ``resolver``/``resolved_at``. Harness asserts the
+    schema names (which is what someone debugging the table will see).
+
+Usage:
+    python3 scripts/accuracy_harness/approvals.py
+    python3 scripts/accuracy_harness/approvals.py --file-issues
+
+Exit: 0 = pass, 1 = drift, 2 = harness setup failure.
+"""
+from __future__ import annotations
+
+import os as _os
+import sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+
+import argparse
+import json
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from _lib import (  # noqa: E402
+    discover_daemon,
+    discover_dashboard_url,
+    daemon_call,
+    file_drift_issue_per_endpoint,
+    http_get_json,
+)
+
+# ─── Config ─────────────────────────────────────────────────────────────────
+
+DEFAULT_RESOLVER = "harness@accuracy-audit"
+QUEUE_FLUSH_TIMEOUT_S = 10
+QUEUE_POLL_INTERVAL_S = 0.5
+# How recent ``resolved_at`` must be to pass the freshness check. The harness
+# decides + reads back inside one second on a healthy box; 30s is generous
+# slack for a slow CI runner.
+DECIDED_AT_FRESHNESS_S = 30
+
+# The schema field naming differs from the user-facing spec:
+#   spec name      → DuckDB column
+#   decided_by     → resolver
+#   decided_at     → resolved_at
+# Keep this map in one place so issue bodies use the schema name (which is
+# what someone debugging the table will see).
+SCHEMA_FIELDS = {
+    "decided_by": "resolver",
+    "decided_at": "resolved_at",
+}
+
+
+# ─── Data classes ───────────────────────────────────────────────────────────
+
+@dataclass
+class ApprovalGroundTruth:
+    """One synthetic approval row we drove + the decision we made."""
+    id: str
+    action: str
+    args: dict
+    session_id: str
+    requested_at: str
+    decision_target: str            # "approve" or "deny"
+    resolver: str
+    decision_reason: str
+
+
+@dataclass
+class CheckResult:
+    endpoint: str
+    window_label: str               # used for issue-body grouping; "pending"|"decided"
+    metric: str                     # which field/assertion
+    ground: Any
+    actual: Any
+    tolerance: int = 0
+    passed: bool = False
+
+    @property
+    def delta(self) -> int:
+        # Numeric delta is meaningless for string comparisons; just
+        # carry 0 for "match", 1 for "mismatch" so file_drift_issue_per_endpoint's
+        # ``max(abs(delta))`` headline picks any drift.
+        return 0 if self.passed else 1
+
+
+# ─── Drive: synthetic approval via daemon proxy ─────────────────────────────
+
+def drive_synthetic_approval(daemon: dict, *,
+                              decision_target: str,
+                              tag_prefix: str) -> ApprovalGroundTruth:
+    """Write one synthetic approval row to DuckDB via the daemon. Returns
+    the ground-truth record (id + everything we wrote, for later compare).
+
+    The synthetic row uses a ``harness:noop`` action so it can never trigger
+    a real side effect even if some downstream consumer scans for actions
+    by name. ``args`` is a JSON-serialisable dict so the harness can later
+    compare it field-for-field against the queried row.
+    """
+    aid = f"harness-{tag_prefix}-{decision_target}-{uuid.uuid4().hex[:8]}"
+    now = datetime.now(timezone.utc).isoformat()
+    args = {
+        "synthetic": True,
+        "tag": tag_prefix,
+        "decision_target": decision_target,
+        "note": "ACCURACY_AUDIT — safe to ignore",
+    }
+    row = {
+        "id": aid,
+        "owner_hash": "harness-owner",
+        "requestor_session_id": f"harness-session-{tag_prefix}",
+        "action": "harness:noop",
+        "args": args,
+        "status": "pending",
+        "created_at": now,
+    }
+    daemon_call(daemon, "ingest_approval", approval=row)
+    return ApprovalGroundTruth(
+        id=aid,
+        action="harness:noop",
+        args=args,
+        session_id=row["requestor_session_id"],
+        requested_at=now,
+        decision_target=decision_target,
+        resolver=DEFAULT_RESOLVER,
+        decision_reason=f"harness {decision_target} via {tag_prefix}",
+    )
+
+
+# ─── Wait: poll until row appears in DuckDB ─────────────────────────────────
+
+def wait_for_pending_row(daemon: dict, approval_id: str,
+                          timeout_s: int = QUEUE_FLUSH_TIMEOUT_S) -> dict | None:
+    """Poll ``query_approvals(status='pending')`` until the row with id
+    ``approval_id`` surfaces, or timeout. Returns the row dict or None."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        rows = daemon_call(daemon, "query_approvals", status="pending", limit=500) or []
+        for r in rows:
+            if r.get("id") == approval_id:
+                return r
+        time.sleep(QUEUE_POLL_INTERVAL_S)
+    return None
+
+
+def wait_for_decided_row(daemon: dict, approval_id: str, expected_status: str,
+                          timeout_s: int = QUEUE_FLUSH_TIMEOUT_S) -> dict | None:
+    """Poll ``query_approvals(status=expected_status)`` until the row appears."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        rows = daemon_call(daemon, "query_approvals",
+                           status=expected_status, limit=500) or []
+        for r in rows:
+            if r.get("id") == approval_id:
+                return r
+        time.sleep(QUEUE_POLL_INTERVAL_S)
+    return None
+
+
+# ─── Assertion builders ─────────────────────────────────────────────────────
+
+def _eq_check(endpoint: str, stage: str, metric: str,
+              ground: Any, actual: Any) -> CheckResult:
+    """Equality check shorthand."""
+    return CheckResult(endpoint=endpoint, window_label=stage, metric=metric,
+                       ground=ground, actual=actual, passed=ground == actual)
+
+
+def assert_pending_row(row: dict | None,
+                        ground: ApprovalGroundTruth) -> list[CheckResult]:
+    """Compare a fetched row against ground-truth on the pending side."""
+    ep = "daemon.query_approvals"
+    if row is None:
+        return [_eq_check(ep, "pending", "row_present", ground.id, None)]
+    return [
+        _eq_check(ep, "pending", "row_present", ground.id, row.get("id")),
+        _eq_check(ep, "pending", "action", ground.action, row.get("action")),
+        _eq_check(ep, "pending", "status", "pending", row.get("status")),
+        _eq_check(ep, "pending", "session_id", ground.session_id,
+                  row.get("requestor_session_id")),
+        _eq_check(ep, "pending", "args", ground.args, row.get("args")),
+        _eq_check(ep, "pending", "created_at", ground.requested_at,
+                  row.get("created_at")),
+    ]
+
+
+def assert_dashboard_pending(payload: dict | None,
+                              ground: ApprovalGroundTruth) -> list[CheckResult]:
+    """Verify ``/api/nemoclaw/pending-approvals`` includes the row.
+    The endpoint coerces the schema to a legacy NemoClaw shape; we assert
+    the user-facing fields the dashboard JS reads."""
+    ep = "/api/nemoclaw/pending-approvals"
+    if not isinstance(payload, dict):
+        return [_eq_check(ep, "pending", "payload_type", "dict",
+                          type(payload).__name__)]
+    approvals = payload.get("approvals") or []
+    matching = next((a for a in approvals if a.get("id") == ground.id), None)
+    out = [_eq_check(ep, "pending", "row_present", ground.id,
+                     matching.get("id") if matching else None)]
+    if matching is None:
+        return out
+    out += [
+        _eq_check(ep, "pending", "action", ground.action, matching.get("action")),
+        _eq_check(ep, "pending", "args", ground.args, matching.get("args")),
+        _eq_check(ep, "pending", "status", "pending", matching.get("status")),
+        _eq_check(ep, "pending", "created_at", ground.requested_at,
+                  matching.get("created_at")),
+    ]
+    return out
+
+
+def assert_decided_row(row: dict | None,
+                        ground: ApprovalGroundTruth) -> list[CheckResult]:
+    """Compare a fetched decided row against ground-truth (post update)."""
+    ep = "daemon.query_approvals"
+    expected_status = "approved" if ground.decision_target == "approve" else "denied"
+    if row is None:
+        return [_eq_check(ep, "decided", "row_present", ground.id, None)]
+    out = [
+        _eq_check(ep, "decided", "status", expected_status, row.get("status")),
+        _eq_check(ep, "decided", "decision", ground.decision_target,
+                  row.get("decision")),
+        _eq_check(ep, "decided", SCHEMA_FIELDS["decided_by"], ground.resolver,
+                  row.get("resolver")),
+        _eq_check(ep, "decided", "decision_reason", ground.decision_reason,
+                  row.get("decision_reason")),
+    ]
+    # ``resolved_at`` freshness — must be within DECIDED_AT_FRESHNESS_S of now.
+    fresh_ok = False
+    actual_resolved = row.get("resolved_at")
+    if isinstance(actual_resolved, str) and actual_resolved:
+        try:
+            ra = datetime.fromisoformat(actual_resolved.replace("Z", "+00:00"))
+            fresh_ok = abs((datetime.now(timezone.utc) - ra).total_seconds()
+                            ) < DECIDED_AT_FRESHNESS_S
+        except ValueError:
+            pass
+    out.append(CheckResult(
+        endpoint=ep, window_label="decided",
+        metric=f"{SCHEMA_FIELDS['decided_at']}_fresh",
+        ground=f"<{DECIDED_AT_FRESHNESS_S}s ago",
+        actual=actual_resolved, passed=fresh_ok,
+    ))
+    return out
+
+
+def assert_pending_no_longer_lists(payload: dict | None,
+                                    ground: ApprovalGroundTruth) -> list[CheckResult]:
+    """After a decision, ``/api/nemoclaw/pending-approvals`` must NOT list the row."""
+    ep = "/api/nemoclaw/pending-approvals"
+    if not isinstance(payload, dict):
+        return [_eq_check(ep, "post-decide", "payload_type", "dict",
+                          type(payload).__name__)]
+    leaked = any(a.get("id") == ground.id for a in (payload.get("approvals") or []))
+    return [CheckResult(
+        endpoint=ep, window_label="post-decide",
+        metric="excluded_after_decide", ground="absent",
+        actual="present" if leaked else "absent", passed=not leaked,
+    )]
+
+
+# ─── Issue body builder ─────────────────────────────────────────────────────
+
+def _format_approvals_issue_body(endpoint: str,
+                                  cs: list[CheckResult],
+                                  grounds: list[ApprovalGroundTruth],
+                                  dashboard_url: str) -> str:
+    lines = [
+        f"## Drift report — `{endpoint}`",
+        "",
+        "Auto-filed by `scripts/accuracy_harness/approvals.py`.",
+        "",
+        "### Drifted assertions",
+        "| stage | metric | ground | actual | result |",
+        "|---|---|---|---|---|",
+    ]
+    for c in cs:
+        lines.append(
+            f"| {c.window_label} | {c.metric} | "
+            f"`{json.dumps(c.ground, default=str)[:80]}` | "
+            f"`{json.dumps(c.actual, default=str)[:80]}` | "
+            f"{'PASS' if c.passed else 'DRIFT'} |"
+        )
+    lines += [
+        "",
+        "### Ground-truth approvals (what we drove)",
+        "```json",
+        json.dumps([{
+            "id": g.id, "action": g.action,
+            "decision_target": g.decision_target,
+            "resolver": g.resolver,
+            "requested_at": g.requested_at,
+        } for g in grounds], indent=2),
+        "```",
+        "",
+        "### Root-cause hint",
+        "If `daemon.query_approvals` drifts for `decision`/`resolver`/`resolved_at`, "
+        "the bug is most likely in `clawmetry/local_store.py:update_approval_decision` "
+        "(line ~1860) — that's the single write path. ",
+        "If `/api/nemoclaw/pending-approvals` drifts but the daemon-proxy view is correct, "
+        "the bug is in `routes/nemoclaw.py:_try_local_store_approvals` (line ~61) — that's "
+        "where the schema-to-legacy-shape coercion happens.",
+        "",
+        "### To reproduce",
+        "```bash",
+        f"CLAWMETRY_URL={dashboard_url} \\",
+        "  python3 scripts/accuracy_harness/approvals.py",
+        "```",
+        "",
+        "_The synthetic row uses `action='harness:noop'` and a unique id prefix "
+        "(`harness-…`); these never match a real approval policy._",
+    ]
+    return "\n".join(lines)
+
+
+# ─── Main flow ──────────────────────────────────────────────────────────────
+
+def run_one_round(daemon: dict, dashboard_url: str, *,
+                   decision_target: str, tag_prefix: str
+                   ) -> tuple[ApprovalGroundTruth, list[CheckResult]]:
+    """Drive + assert one approval round (one of approve/deny). Returns
+    (ground-truth, all-check-results) for the round."""
+    print(f"[harness] driving synthetic approval (decision_target={decision_target})…")
+    ground = drive_synthetic_approval(
+        daemon, decision_target=decision_target, tag_prefix=tag_prefix,
+    )
+    print(f"  id={ground.id} action={ground.action} session={ground.session_id}")
+
+    print(f"[harness] waiting for pending row to surface "
+          f"(timeout={QUEUE_FLUSH_TIMEOUT_S}s)…")
+    pending = wait_for_pending_row(daemon, ground.id)
+    if pending is None:
+        print(f"  [drive] FAILED: row never landed in DuckDB")
+    else:
+        print(f"  [drive] row landed (created_at={pending.get('created_at')})")
+    pending_checks = assert_pending_row(pending, ground)
+
+    print("[harness] fetching /api/nemoclaw/pending-approvals…")
+    try:
+        payload = http_get_json(f"{dashboard_url}/api/nemoclaw/pending-approvals",
+                                timeout=10.0)
+    except Exception as e:
+        print(f"  [endpoint] FAILED: {e}")
+        payload = None
+    pending_endpoint_checks = assert_dashboard_pending(payload, ground)
+
+    print(f"[harness] deciding {decision_target!r} via daemon proxy "
+          f"(resolver={ground.resolver})…")
+    n = daemon_call(
+        daemon, "update_approval_decision",
+        approval_id=ground.id,
+        decision=ground.decision_target,
+        resolver=ground.resolver,
+        reason=ground.decision_reason,
+    )
+    if n != 1:
+        print(f"  [decide] FAILED: update_approval_decision returned {n}")
+
+    expected_status = "approved" if decision_target == "approve" else "denied"
+    print(f"[harness] waiting for decided row "
+          f"(status={expected_status}, timeout={QUEUE_FLUSH_TIMEOUT_S}s)…")
+    decided = wait_for_decided_row(daemon, ground.id, expected_status)
+    if decided is None:
+        print("  [decide] FAILED: row never appeared in decided view")
+    else:
+        print(f"  [decide] row decided (resolved_at={decided.get('resolved_at')})")
+    decided_checks = assert_decided_row(decided, ground)
+
+    # Re-fetch pending list and confirm the row is gone.
+    try:
+        payload2 = http_get_json(f"{dashboard_url}/api/nemoclaw/pending-approvals",
+                                 timeout=10.0)
+    except Exception as e:
+        print(f"  [endpoint post-decide] FAILED: {e}")
+        payload2 = None
+    post_decide_checks = assert_pending_no_longer_lists(payload2, ground)
+
+    return ground, pending_checks + pending_endpoint_checks + decided_checks + post_decide_checks
+
+
+def run_harness(args: argparse.Namespace) -> int:
+    print(f"[harness] approvals accuracy audit — {datetime.now(timezone.utc).isoformat()}")
+
+    dashboard_url = discover_dashboard_url(args.dashboard_url,
+                                            probe_path="/api/usage")
+    print(f"[harness] dashboard: {dashboard_url}")
+
+    daemon = discover_daemon()
+    if not daemon:
+        print("[harness] FATAL: daemon not discoverable; "
+              "the approvals harness needs a running daemon to ingest + "
+              "decide rows. See ~/.clawmetry/local_query.json.", file=sys.stderr)
+        return 2
+    print(f"[harness] daemon proxy: 127.0.0.1:{daemon['port']}")
+
+    run_id = uuid.uuid4().hex[:8]
+    tag_prefix = f"AUDIT_{run_id}"
+    print(f"[harness] tag prefix: {tag_prefix}")
+
+    grounds: list[ApprovalGroundTruth] = []
+    all_checks: list[CheckResult] = []
+    for target in ("approve", "deny"):
+        ground, checks = run_one_round(
+            daemon, dashboard_url,
+            decision_target=target, tag_prefix=tag_prefix,
+        )
+        grounds.append(ground)
+        all_checks.extend(checks)
+        print()
+
+    # Report.
+    print("─" * 78)
+    print(f"{'ENDPOINT':<35} {'STAGE':<13} {'METRIC':<25} {'RESULT':<6}")
+    print("─" * 78)
+    drifts: list[CheckResult] = []
+    for c in all_checks:
+        result = "PASS" if c.passed else "DRIFT"
+        if not c.passed:
+            drifts.append(c)
+        print(f"{c.endpoint:<35} {c.window_label:<13} {c.metric:<25} {result:<6}")
+    print("─" * 78)
+    print(f"summary: {sum(1 for c in all_checks if c.passed)} pass / "
+          f"{len(drifts)} drift / {len(all_checks)} total checks")
+    print(f"approvals exercised: {[g.id for g in grounds]}")
+
+    if not drifts:
+        print()
+        print("[harness] ALL CHECKS PASSED — approvals queue is accurate on this build.")
+        return 0
+
+    print()
+    print("[harness] DRIFT DETECTED:")
+    for c in drifts:
+        print(f"  - {c.endpoint} stage={c.window_label} metric={c.metric}: "
+              f"ground={c.ground!r} actual={c.actual!r}")
+
+    if args.file_issues:
+        def _body_builder(endpoint: str, cs: list) -> str:
+            return _format_approvals_issue_body(endpoint, cs, grounds, dashboard_url)
+        file_drift_issue_per_endpoint(
+            harness_label="approvals", drifts=drifts, body_builder=_body_builder,
+        )
+    else:
+        print("[harness] (re-run with --file-issues to open GitHub issues)")
+    return 1
+
+
+# ─── CLI ────────────────────────────────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dashboard-url", type=str, default=None,
+                   help="override dashboard URL (default: auto-detect 8900/8903/8905, "
+                        "or $CLAWMETRY_URL)")
+    p.add_argument("--file-issues", action="store_true",
+                   help="file GitHub issues for any drift (requires `gh` on PATH)")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        return run_harness(args)
+    except KeyboardInterrupt:
+        print("\n[harness] interrupted")
+        return 130
+    except Exception as e:
+        print(f"[harness] FATAL: {e}", file=sys.stderr)
+        import traceback; traceback.print_exc()
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/accuracy_harness/tokens.py
+++ b/scripts/accuracy_harness/tokens.py
@@ -35,33 +35,42 @@ Exit codes
 
 from __future__ import annotations
 
+import os as _os
+import sys as _sys
+# Allow ``python3 scripts/accuracy_harness/tokens.py`` AND ``python3 -m
+# scripts.accuracy_harness.tokens`` to both resolve ``_lib``. When run as a
+# script, the parent dir isn't on sys.path by default.
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+
 import argparse
 import json
-import os
-import shutil
-import socket
-import subprocess
 import sys
 import time
-import urllib.error
-import urllib.request
 import uuid
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
 
-# ─── Config ─────────────────────────────────────────────────────────────────
+# Shared helpers extracted to _lib so other harnesses (approvals, alerts,
+# crons, …) reuse the same discovery + HTTP + drift-issue code paths.
+from _lib import (  # noqa: E402  (script entry-point, sys.path tweaked below)
+    DEFAULT_DASHBOARD_PORTS,
+    GH_REPO,
+    OPENCLAW_BIN,
+    daemon_event_count,
+    discover_daemon,
+    discover_dashboard_url,
+    drive_openclaw_message,
+    extract_openclaw_usage,
+    file_drift_issue_per_endpoint,
+    http_get_json,
+)
 
-DEFAULT_DASHBOARD_PORTS = (8900, 8903, 8905)
 DEFAULT_MESSAGE_TEXT = "Say PONG and nothing else."
 DEFAULT_MESSAGE_COUNT = 3
 TOLERANCE_TOKENS = 1  # cache splits can drift ±1 due to rounding
 FLUSH_TIMEOUT_S = 30
 FLUSH_POLL_INTERVAL_S = 1.0
-OPENCLAW_BIN = shutil.which("openclaw") or "openclaw"
-GH_REPO = "vivekchand/clawmetry"
-LOCAL_QUERY_DISCOVERY = Path.home() / ".clawmetry" / "local_query.json"
 
 
 # ─── Data classes ───────────────────────────────────────────────────────────
@@ -110,149 +119,16 @@ class CheckResult:
         return self.actual - self.ground
 
 
-# ─── Helpers: HTTP ──────────────────────────────────────────────────────────
-
-def _http_get_json(url: str, timeout: float = 10.0) -> Any:
-    req = urllib.request.Request(url, headers={"Accept": "application/json"})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
-
-
-def _http_post_json(url: str, body: dict, headers: dict | None = None, timeout: float = 10.0) -> Any:
-    data = json.dumps(body).encode("utf-8")
-    h = {"Content-Type": "application/json", "Accept": "application/json"}
-    if headers:
-        h.update(headers)
-    req = urllib.request.Request(url, data=data, headers=h, method="POST")
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read().decode("utf-8"))
-
-
-# ─── Helpers: discovery ─────────────────────────────────────────────────────
-
-def _port_listening(port: int, host: str = "127.0.0.1") -> bool:
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.settimeout(0.2)
-    try:
-        return s.connect_ex((host, port)) == 0
-    finally:
-        s.close()
-
-
-def discover_dashboard_url(override: str | None) -> str:
-    if override:
-        return override.rstrip("/")
-    env = os.environ.get("CLAWMETRY_URL")
-    if env:
-        return env.rstrip("/")
-    for port in DEFAULT_DASHBOARD_PORTS:
-        if not _port_listening(port):
-            continue
-        url = f"http://localhost:{port}"
-        # Probe /api/usage to distinguish dashboard from other listeners.
-        try:
-            payload = _http_get_json(f"{url}/api/usage", timeout=3.0)
-            if isinstance(payload, dict) and "days" in payload:
-                return url
-        except (urllib.error.URLError, urllib.error.HTTPError, ValueError, TimeoutError):
-            continue
-    raise RuntimeError(
-        f"could not find a ClawMetry dashboard on any of {DEFAULT_DASHBOARD_PORTS}. "
-        f"Set CLAWMETRY_URL or pass --dashboard-url."
-    )
-
-
-def discover_daemon() -> dict | None:
-    """Return ``{port, token}`` for the daemon proxy, or None if unavailable."""
-    try:
-        with open(LOCAL_QUERY_DISCOVERY) as fh:
-            d = json.load(fh)
-        if not (d.get("port") and d.get("token")):
-            return None
-        # Liveness check.
-        try:
-            os.kill(int(d.get("pid") or 0), 0)
-        except (OSError, ValueError):
-            return None
-        return {"port": int(d["port"]), "token": d["token"]}
-    except (FileNotFoundError, ValueError, OSError):
-        return None
-
-
-def daemon_event_count(daemon: dict) -> int | None:
-    """Return the daemon's total event count via /__local_query__/health.
-    Returns None if the daemon is unreachable."""
-    url = f"http://127.0.0.1:{daemon['port']}/__local_query__/health"
-    try:
-        body = _http_post_json(
-            url, body={},
-            headers={"Authorization": f"Bearer {daemon['token']}"},
-            timeout=3.0,
-        )
-        # Response: {"result": {"event_count": N, ...}}
-        result = body.get("result") if isinstance(body, dict) else None
-        if isinstance(result, dict):
-            ev = result.get("event_count")
-            return int(ev) if ev is not None else None
-        return None
-    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, TimeoutError, OSError):
-        return None
-
-
-# ─── Helpers: driving openclaw ──────────────────────────────────────────────
-
-def drive_message(message: str, tag: str, timeout_s: int = 120) -> dict[str, Any]:
-    """Run ``openclaw agent --agent main --message <m> --json`` once.
-    Returns the parsed JSON (status + result + meta) — caller extracts usage.
-    Tag is embedded into the message for traceability (sessions list / DuckDB).
-    """
-    full_msg = f"{message} [{tag}]"
-    cmd = [OPENCLAW_BIN, "agent", "--agent", "main", "--message", full_msg, "--json"]
-    proc = subprocess.run(
-        cmd, capture_output=True, text=True, timeout=timeout_s, check=False,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError(
-            f"openclaw agent exited {proc.returncode}\nstderr: {proc.stderr[:500]}"
-        )
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError as e:
-        raise RuntimeError(
-            f"openclaw agent --json returned non-JSON: {e}\nfirst 300 bytes: {proc.stdout[:300]}"
-        )
-
-
-def extract_usage(agent_json: dict) -> dict[str, Any] | None:
-    """Pull the ``usage`` block out of an ``openclaw agent --json`` response.
-    Returns dict with input/output/cacheRead/cacheWrite/sessionId/model, or
-    None if the response didn't include billable usage (e.g. an error turn).
-    """
-    meta = (agent_json or {}).get("result", {}).get("meta", {}) or {}
-    agent_meta = meta.get("agentMeta") or {}
-    usage = agent_meta.get("usage") or {}
-    if not usage:
-        return None
-    return {
-        "input":      int(usage.get("input") or 0),
-        "output":     int(usage.get("output") or 0),
-        "cacheRead":  int(usage.get("cacheRead") or 0),
-        "cacheWrite": int(usage.get("cacheWrite") or 0),
-        "sessionId":  agent_meta.get("sessionId") or "",
-        "model":      agent_meta.get("model") or "",
-    }
-
-
 # ─── Endpoint scrapers ──────────────────────────────────────────────────────
 
 def fetch_api_usage(dashboard_url: str) -> dict:
     # /api/usage carries today/week/month + per-day breakdown. There is NO
     # ?window= parameter (Tokens tab derives every window from `days[]`).
-    return _http_get_json(f"{dashboard_url}/api/usage", timeout=15.0)
+    return http_get_json(f"{dashboard_url}/api/usage", timeout=15.0)
 
 
 def fetch_context_anatomy(dashboard_url: str) -> dict:
-    return _http_get_json(f"{dashboard_url}/api/context-anatomy", timeout=10.0)
+    return http_get_json(f"{dashboard_url}/api/context-anatomy", timeout=10.0)
 
 
 # ─── Window math ────────────────────────────────────────────────────────────
@@ -340,11 +216,11 @@ def run_harness(args: argparse.Namespace) -> int:
         tag = f"{tag_prefix}_msg{i+1}"
         t0 = time.time()
         try:
-            resp = drive_message(args.message_text, tag, timeout_s=args.openclaw_timeout)
+            resp = drive_openclaw_message(args.message_text, tag, timeout_s=args.openclaw_timeout)
         except Exception as e:
             print(f"  [msg {i+1}] FAILED to drive: {e}", file=sys.stderr)
             continue
-        usage = extract_usage(resp)
+        usage = extract_openclaw_usage(resp)
         elapsed = time.time() - t0
         if not usage:
             print(f"  [msg {i+1}] no usage in response (skipping); status={resp.get('status')}")
@@ -487,93 +363,20 @@ def run_harness(args: argparse.Namespace) -> int:
               f"(tol=±{c.tolerance})")
 
     if args.file_issues:
-        file_drift_issues(drifts, ground, tag_prefix, dashboard_url)
+        def _body_builder(endpoint: str, cs: list) -> str:
+            return _format_tokens_issue_body(endpoint, cs, ground, tag_prefix, dashboard_url)
+        file_drift_issue_per_endpoint(
+            harness_label="tokens", drifts=drifts, body_builder=_body_builder,
+        )
     else:
         print("[harness] (re-run with --file-issues to open GitHub issues)")
 
     return 1
 
 
-# ─── Issue filing ───────────────────────────────────────────────────────────
+# ─── Issue body builder (tokens-specific — drift table + ground-truth log) ──
 
-def _open_audit_issue_exists(endpoint: str, today: str) -> bool:
-    """Cheap dedup so we don't fill the tracker on repeat runs in one day."""
-    try:
-        proc = subprocess.run(
-            ["gh", "issue", "list",
-             "--repo", GH_REPO,
-             "--state", "open",
-             "--search", f"[accuracy-audit {today}] tokens drift: {endpoint} in:title",
-             "--json", "number"],
-            check=True, capture_output=True, text=True, timeout=15,
-        )
-        return bool(json.loads(proc.stdout or "[]"))
-    except (subprocess.CalledProcessError, json.JSONDecodeError, OSError, subprocess.TimeoutExpired):
-        return False  # If dedup probe fails, let the file go through
-
-
-def file_drift_issues(
-    drifts: list[CheckResult],
-    ground: GroundTruth,
-    tag_prefix: str,
-    dashboard_url: str,
-) -> None:
-    """File one GitHub issue per drifted endpoint. All drifted (window, metric)
-    pairs for that endpoint collapse into one body so we don't fan out
-    N×M near-identical issues when the root cause is shared."""
-    if not shutil.which("gh"):
-        print("[harness] `gh` CLI not on PATH; cannot file issues. Skipping.")
-        return
-
-    # Group drifts by endpoint only — windows/metrics fan out from one root
-    # cause more often than not. If a future check has independent failures
-    # per window, the body table makes that obvious.
-    grouped: dict[str, list[CheckResult]] = {}
-    for c in drifts:
-        grouped.setdefault(c.endpoint, []).append(c)
-
-    today = datetime.now().strftime("%Y-%m-%d")
-    for endpoint, cs in grouped.items():
-        # Title: pick the worst drift as the headline.
-        headline = max(cs, key=lambda c: abs(c.delta))
-        title = (
-            f"[accuracy-audit {today}] tokens drift: {endpoint} "
-            f"{headline.window_label}/{headline.metric} "
-            f"ground={headline.ground} actual={headline.actual} "
-            f"(delta={headline.delta:+d}; {len(cs)} drifts total)"
-        )
-        # Idempotency: skip if an open issue already covers this endpoint
-        # today. A new day → new issue (so weekly trends are visible).
-        if _open_audit_issue_exists(endpoint, today):
-            print(f"[harness] open issue for {endpoint} already exists today — skipping file")
-            continue
-        body = _format_issue_body(endpoint, cs, ground, tag_prefix, dashboard_url)
-        try:
-            subprocess.run(
-                ["gh", "issue", "create",
-                 "--repo", GH_REPO,
-                 "--title", title,
-                 "--body", body,
-                 "--label", "accuracy-audit,tokens,bug"],
-                check=True, capture_output=True, text=True,
-            )
-            print(f"[harness] filed issue: {title}")
-        except subprocess.CalledProcessError as e:
-            # Labels may not exist on the repo — retry without them.
-            try:
-                proc = subprocess.run(
-                    ["gh", "issue", "create",
-                     "--repo", GH_REPO,
-                     "--title", title,
-                     "--body", body],
-                    check=True, capture_output=True, text=True,
-                )
-                print(f"[harness] filed (no labels): {proc.stdout.strip()}")
-            except subprocess.CalledProcessError as e2:
-                print(f"[harness] FAILED to file issue: {e2.stderr[:300]}")
-
-
-def _format_issue_body(
+def _format_tokens_issue_body(
     endpoint: str,
     cs: list[CheckResult],
     ground: GroundTruth,


### PR DESCRIPTION
## Summary

Second harness in the synthetic-ground-truth framework (after tokens, PR #1395). Drives a synthetic approval row through the queue, decides approve + deny, asserts every downstream effect.

- `scripts/accuracy_harness/approvals.py` — drive → wait → assert × 2 (approve + deny)
- `scripts/accuracy_harness/_lib.py` — extracted shared helpers (discovery, HTTP, daemon proxy, openclaw driver, drift-issue filer); tokens harness refactored to import from it (~200 LOC saved)
- `routes/local_query.py` — adds `ingest_approval` + `update_approval_decision` to the daemon-proxy allowlist (write paths the daemon already owns under its `_write_lock`; also enabling work for any future "decide from dashboard" UI)
- README updated with "What's covered" + "What's NOT covered yet" for both harnesses

## Surfaced product gaps (documented in README, asserted around)

- No `/api/approvals` endpoint exists; only `/api/nemoclaw/pending-approvals` (status=pending only). Decided rows aren't exposed via HTTP — harness asserts via the daemon proxy `query_approvals`.
- No `/api/approvals/decide` endpoint. Decisions arrive via cloud-relay heartbeat (`_apply_approval_decision`) or this harness; no OSS-side button decides approvals today.
- Schema rename: spec uses `decided_by`/`decided_at`; columns are `resolver`/`resolved_at`. Harness asserts the schema names.

## Live E2E run (worktree, against running 0.12.229)

```
[harness] approvals accuracy audit — 2026-05-16T04:26:00.103333+00:00
[harness] dashboard: http://localhost:8900
[harness] daemon proxy: 127.0.0.1:65089
[harness] tag prefix: AUDIT_fef63bb7
[harness] driving synthetic approval (decision_target=approve)…
  id=harness-AUDIT_fef63bb7-approve-031cef20 action=harness:noop session=harness-session-AUDIT_fef63bb7
[harness] waiting for pending row to surface (timeout=10s)…
  [drive] row landed (created_at=2026-05-16T04:26:00.198796+00:00)
[harness] fetching /api/nemoclaw/pending-approvals…
[harness] deciding 'approve' via daemon proxy (resolver=harness@accuracy-audit)…
[harness] waiting for decided row (status=approved, timeout=10s)…
  [decide] row decided (resolved_at=2026-05-16T04:26:00.209228+00:00)

[harness] driving synthetic approval (decision_target=deny)…
  id=harness-AUDIT_fef63bb7-deny-184a46ae action=harness:noop session=harness-session-AUDIT_fef63bb7
[harness] waiting for pending row to surface (timeout=10s)…
  [drive] row landed (created_at=2026-05-16T04:26:00.215753+00:00)
[harness] fetching /api/nemoclaw/pending-approvals…
[harness] deciding 'deny' via daemon proxy (resolver=harness@accuracy-audit)…
[harness] waiting for decided row (status=denied, timeout=10s)…
  [decide] row decided (resolved_at=2026-05-16T04:26:00.225120+00:00)

──────────────────────────────────────────────────────────────────────────────
ENDPOINT                            STAGE         METRIC                    RESULT
──────────────────────────────────────────────────────────────────────────────
daemon.query_approvals              pending       row_present               PASS
daemon.query_approvals              pending       action                    PASS
daemon.query_approvals              pending       status                    PASS
daemon.query_approvals              pending       session_id                PASS
daemon.query_approvals              pending       args                      PASS
daemon.query_approvals              pending       created_at                PASS
/api/nemoclaw/pending-approvals     pending       row_present               PASS
/api/nemoclaw/pending-approvals     pending       action                    PASS
/api/nemoclaw/pending-approvals     pending       args                      PASS
/api/nemoclaw/pending-approvals     pending       status                    PASS
/api/nemoclaw/pending-approvals     pending       created_at                PASS
daemon.query_approvals              decided       status                    PASS
daemon.query_approvals              decided       decision                  PASS
daemon.query_approvals              decided       resolver                  PASS
daemon.query_approvals              decided       decision_reason           PASS
daemon.query_approvals              decided       resolved_at_fresh         PASS
/api/nemoclaw/pending-approvals     post-decide   excluded_after_decide     PASS
daemon.query_approvals              pending       row_present               PASS
daemon.query_approvals              pending       action                    PASS
daemon.query_approvals              pending       status                    PASS
daemon.query_approvals              pending       session_id                PASS
daemon.query_approvals              pending       args                      PASS
daemon.query_approvals              pending       created_at                PASS
/api/nemoclaw/pending-approvals     pending       row_present               PASS
/api/nemoclaw/pending-approvals     pending       action                    PASS
/api/nemoclaw/pending-approvals     pending       args                      PASS
/api/nemoclaw/pending-approvals     pending       status                    PASS
/api/nemoclaw/pending-approvals     pending       created_at                PASS
daemon.query_approvals              decided       status                    PASS
daemon.query_approvals              decided       decision                  PASS
daemon.query_approvals              decided       resolver                  PASS
daemon.query_approvals              decided       decision_reason           PASS
daemon.query_approvals              decided       resolved_at_fresh         PASS
/api/nemoclaw/pending-approvals     post-decide   excluded_after_decide     PASS
──────────────────────────────────────────────────────────────────────────────
summary: 34 pass / 0 drift / 34 total checks
approvals exercised: ['harness-AUDIT_fef63bb7-approve-031cef20', 'harness-AUDIT_fef63bb7-deny-184a46ae']

[harness] ALL CHECKS PASSED — approvals queue is accurate on this build.
```

(Run done with the daemon-allowlist patch from this PR hot-applied to the installed wheel; reverted post-run. After this PR merges + a `[RELEASE]` lands, the harness will work against any 0.12.230+ install.)

## Test plan

- [x] `python3 scripts/accuracy_harness/approvals.py` against live 0.12.229 — 34 / 34 PASS
- [x] `python3 scripts/accuracy_harness/tokens.py` still imports & runs (refactored to use `_lib`)
- [x] `python3 scripts/lint_daemon_allowlist.py` — daemon-allowlist OK — 17 distinct query_* methods called from routes/, all in `_DAEMON_METHODS` (29 entries)
- [ ] Reviewer: optionally run `python3 scripts/accuracy_harness/approvals.py --file-issues` against an intentionally-broken build to verify the issue body shape

## Idempotency

Each run uses a fresh `harness-AUDIT_<run_id>-…` id so re-runs never collide. Synthetic rows use `action='harness:noop'` so they can never trigger a real approval policy. The decided rows persist in the local DuckDB but never escape (no cloud relay, no UI render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)