### PR TITLE
[RELEASE] fix(usage): widen /api/usage event_type to match real OpenClaw v3 (#1394)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -3846,6 +3846,198 @@ class LocalStore:
                 })
         return out
 
+    def query_daily_usage_splits(
+        self,
+        *,
+        agent_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit_events: int = 50000,
+    ) -> list[dict[str, Any]]:
+        """Per-day input/output/cache_read/cache_write token + cost split.
+
+        Issue #1394: drives the Tokens-tab daily chart on real OpenClaw v3
+        installs. The legacy ``_try_local_store_usage`` fast-path was
+        building the chart from ``query_aggregates`` (which only sums the
+        coarse ``token_count`` + ``cost_usd`` columns the daemon writes
+        per row), then setting all four splits to 0. On v3 the splits are
+        stamped into the event's ``data`` blob (Anthropic-SDK keys on
+        ``assistant`` events; ``promptCache.lastCallUsage`` on
+        ``model.completed`` events). This helper walks every assistant
+        turn in range, decodes the blob, and aggregates per-day so the
+        chart actually breaks tokens down.
+
+        Returns ``[{day:'YYYY-MM-DD', input_tokens, output_tokens,
+        cache_read_tokens, cache_write_tokens, cost_usd, event_count}]``
+        sorted by ``day`` desc. Empty list when no assistant events
+        match (e.g. fresh install) — caller may fall back to
+        ``query_aggregates`` for a coarse total.
+
+        Dedup note: real OpenClaw v3 emits BOTH an ``assistant`` (full
+        Anthropic envelope, has cache splits) and a sibling
+        ``model.completed`` event (slimmer, no cache) for the same turn.
+        Counting both would double the splits. We pick the
+        ``assistant``/``message`` shape per (session_id, ts) pair when
+        present and fall back to ``model.completed`` only when neither
+        Anthropic-shape sibling exists for that timestamp.
+        """
+        # Step 1: pull every billable-turn event in range, ordered so
+        # we can pick the richer envelope first per (session, ts).
+        clauses: list[str] = [f"event_type IN {_sql_in_clause(_BILLABLE_TURN_EVENT_TYPES)}"]
+        params: list[Any] = []
+        if agent_id:
+            clauses.append("agent_id = ?")
+            params.append(agent_id)
+        if since:
+            clauses.append("ts >= ?")
+            params.append(since)
+        if until:
+            clauses.append("ts <= ?")
+            params.append(until)
+        where = "WHERE " + " AND ".join(clauses)
+        sql = f"""
+            SELECT id, ts, session_id, event_type, data, cost_usd
+            FROM events
+            {where}
+            ORDER BY ts ASC, id ASC
+            LIMIT ?
+        """
+        params.append(int(max(1, limit_events)))
+        rows = self._fetch(sql, params)
+
+        # Per-day buckets keyed by YYYY-MM-DD.
+        day_bucket: dict[str, dict[str, Any]] = {}
+
+        # Dedup: real OpenClaw + Claude Code installs emit both an
+        # ``assistant`` (Anthropic-SDK envelope, has cache splits) and a
+        # ``model.completed`` (slim ``promptCache.lastCallUsage`` only) for
+        # the SAME LLM turn — typically ~100-200 ms apart because they
+        # come from different log writers. Counting both inflates the
+        # input + output buckets by 2× and silently drops cache splits
+        # whenever the slim sibling wins the dedup race.
+        #
+        # Strategy: bucket events by (session_id, ts-rounded-to-second).
+        # When two events hash to the same bucket OR one second apart
+        # (sibling writers race, ~100-300 ms drift seen in the wild),
+        # prefer the richer envelope (assistant/message > model.completed).
+        # ±1 s is wide enough to catch the writer race without colliding
+        # turns: model-completion latency on a hot Anthropic call is
+        # consistently ≥ 2 s, so two distinct LLM turns never round to
+        # adjacent integer seconds in practice.
+        DEDUP_WINDOW_S = 1
+
+        def _priority(et: str | None) -> int:
+            et = (et or "").lower()
+            if et in ("assistant", "subagent:assistant", "message"):
+                return 2  # full Anthropic envelope
+            if et == "model.completed":
+                return 1  # slim sibling
+            return 0
+
+        def _ts_to_epoch_s(ts_str: str) -> int | None:
+            """ISO-8601 → integer seconds since epoch. Returns None on
+            parse failure (caller treats as "skip dedup, count it")."""
+            if not ts_str:
+                return None
+            try:
+                from datetime import datetime as _dt
+                s = ts_str.replace("Z", "+00:00") if ts_str.endswith("Z") else ts_str
+                return int(_dt.fromisoformat(s).timestamp())
+            except (TypeError, ValueError):
+                return None
+
+        # First pass: parse + dedup. Build a map of
+        # (sid, window_start) -> {priority, splits, cost, day, etype, ts}
+        # so we can collapse sibling events deterministically before
+        # bucketing.
+        chosen: dict[tuple[str, int], dict[str, Any]] = {}
+        loose: list[dict[str, Any]] = []  # rows we couldn't dedup-key
+
+        for ev_id, ts, sid, etype, raw, col_cost in rows:
+            data: dict[str, Any] = {}
+            if raw is not None:
+                try:
+                    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                    parsed = json.loads(text) if text else {}
+                    if isinstance(parsed, dict):
+                        data = parsed
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    continue
+            splits = _extract_usage_splits(data)
+            if splits["input_tokens"] <= 0 and splits["output_tokens"] <= 0:
+                # Skip rows with no recoverable usage — the daemon writes
+                # session.started / model.changed / tool.call rows with
+                # the same event_type net but no usage payload.
+                continue
+
+            day = (ts or "")[:10]
+            if not day:
+                continue
+
+            try:
+                cost_val = float(col_cost or 0.0)
+            except (TypeError, ValueError):
+                cost_val = 0.0
+            if cost_val <= 0:
+                cost_val = _extract_usage_cost(data)
+
+            this_pri = _priority(etype)
+            payload = {
+                "priority":    this_pri,
+                "splits":      splits,
+                "cost_usd":    cost_val,
+                "day":         day,
+                "etype":       etype,
+                "ts":          ts,
+            }
+
+            epoch_s = _ts_to_epoch_s(ts)
+            if epoch_s is None or not sid:
+                # No usable dedup key — keep the row but don't dedup it.
+                loose.append(payload)
+                continue
+
+            # Probe the ±DEDUP_WINDOW_S range for an existing sibling.
+            # First match wins; we keep the higher-priority of the two.
+            collision_key: tuple[str, int] | None = None
+            for delta in range(-DEDUP_WINDOW_S, DEDUP_WINDOW_S + 1):
+                k = (sid, epoch_s + delta)
+                if k in chosen:
+                    collision_key = k
+                    break
+
+            if collision_key is None:
+                chosen[(sid, epoch_s)] = payload
+                continue
+
+            existing = chosen[collision_key]
+            if this_pri > existing["priority"]:
+                # Richer envelope wins — replace the slim one.
+                chosen[collision_key] = payload
+
+        # Second pass: aggregate the deduped picks into per-day buckets.
+        for payload in list(chosen.values()) + loose:
+            day = payload["day"]
+            splits = payload["splits"]
+            cost_val = payload["cost_usd"]
+            bucket = day_bucket.setdefault(day, {
+                "day": day,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "cost_usd": 0.0,
+                "event_count": 0,
+            })
+            bucket["input_tokens"]       += splits["input_tokens"]
+            bucket["output_tokens"]      += splits["output_tokens"]
+            bucket["cache_read_tokens"]  += splits["cache_read_tokens"]
+            bucket["cache_write_tokens"] += splits["cache_write_tokens"]
+            bucket["cost_usd"]           += cost_val
+            bucket["event_count"]        += 1
+
+        return sorted(day_bucket.values(), key=lambda r: r["day"], reverse=True)
+
     def query_aggregates(
         self,
         *,
@@ -4246,6 +4438,17 @@ _TOOL_CALL_HOST_EVENT_TYPES = (
     "subagent:assistant",
     "model.completed",
 )
+# Issue #1394: token-usage aggregation MUST count subagent turns (they
+# spend real money for the user even though they're spawned by the
+# parent agent). Distinct from ``_ASSISTANT_EVENT_TYPES`` — that set
+# excludes subagents to keep parent→subagent model differences out of
+# the fallback-detector's noise floor.
+_BILLABLE_TURN_EVENT_TYPES = (
+    "message",
+    "assistant",
+    "subagent:assistant",
+    "model.completed",
+)
 _TOOL_CALL_TOPLEVEL_EVENT_TYPES = (
     "tool.call", "toolCall", "tool_use", "tool_call",
 )
@@ -4283,47 +4486,186 @@ def _extract_input_tokens(data: dict) -> int:
       4. ``data.assistantMessage.usage.{input,input_tokens}`` — drive-by
          shape noted in PR #1370 (rare; some forked agents emit it).
     """
+    splits = _extract_usage_splits(data)
+    return int(splits.get("input_tokens", 0))
+
+
+# Issue #1394: per-metric key sets for ``_extract_usage_splits``. Centralised
+# so cache-read / cache-write probes line up with the SDK + OpenClaw v3
+# vocabulary we have to swallow. Order within each tuple matters — first
+# non-zero wins (e.g. Anthropic SDK's ``cache_read_input_tokens`` beats
+# OpenClaw's bundled ``cacheRead`` when both appear in the same envelope).
+_USAGE_KEYS_INPUT = (
+    "input_tokens", "inputTokens", "input",
+)
+_USAGE_KEYS_OUTPUT = (
+    "output_tokens", "outputTokens", "output",
+)
+_USAGE_KEYS_CACHE_READ = (
+    # Anthropic SDK echo (v3 ``assistant`` event in Claude Code installs).
+    "cache_read_input_tokens", "cacheReadInputTokens",
+    # OpenClaw v3 native ``usage.cacheRead``.
+    "cacheRead", "cache_read",
+    # Legacy snake_case sometimes emitted by alert evaluator helpers.
+    "cache_read_tokens",
+)
+_USAGE_KEYS_CACHE_WRITE = (
+    # Anthropic SDK echo.
+    "cache_creation_input_tokens", "cacheCreationInputTokens",
+    # OpenClaw v3 native.
+    "cacheWrite", "cache_write",
+    # Legacy snake_case.
+    "cache_write_tokens", "cache_creation_tokens",
+)
+
+
+def _read_usage_int(usage: Any, keys: tuple[str, ...]) -> int:
+    """First non-zero ``int(usage[key])`` across ``keys``. Tolerates None,
+    string-ints, and missing keys. Returns 0 on every failure mode.
+    """
+    if not isinstance(usage, dict):
+        return 0
+    for k in keys:
+        v = usage.get(k)
+        if v is None:
+            continue
+        try:
+            iv = int(v)
+        except (TypeError, ValueError):
+            continue
+        if iv > 0:
+            return iv
+    return 0
+
+
+def _extract_usage_splits(data: dict) -> dict[str, int]:
+    """Pull a full ``{input, output, cache_read, cache_write}`` token split
+    out of an event ``data`` blob — handles every OpenClaw + Claude Code
+    SDK shape we've seen on real installs.
+
+    Issue #1394: ``_try_local_store_usage`` was returning 0 for all four
+    splits on every install because the legacy fast-path filled them in
+    from synthetic ``data.message.usage.{input_tokens,output_tokens,
+    cache_read_tokens,cache_write_tokens}`` only. Real OpenClaw v3 uses
+    ``cache_read_input_tokens`` / ``cache_creation_input_tokens`` (the
+    Anthropic SDK names) on ``assistant`` events, and a stripped-down
+    ``promptCache.lastCallUsage.{input,output}`` on ``model.completed``
+    events. This helper walks every shape, returning a fully-populated
+    dict so the caller can update four per-day buckets in one pass.
+
+    Shape priority (first source with a non-zero ``input`` wins):
+      1. ``data.message.usage.*`` — Anthropic SDK envelope used by both
+         legacy ``message`` events AND v3 ``assistant`` events. The v3
+         ``assistant`` rows are the only place ``cache_*_input_tokens``
+         splits exist as Anthropic-native keys.
+      2. ``data.usage.*`` — bare ``usage`` at the root of ``data`` (some
+         OpenClaw provider adapters lift it out of ``message``).
+      3. ``data.promptCache.lastCallUsage.*`` — OpenClaw v3
+         ``model.completed`` shape. NOTE: this envelope only carries
+         ``input`` / ``output`` / ``total`` (no cache split), so the
+         cache buckets will be 0 unless an earlier shape filled them.
+      4. ``data.assistantMessage.usage.*`` — rare; some forked agents.
+
+    Returns ``{input_tokens, output_tokens, cache_read_tokens,
+    cache_write_tokens}`` (all int, all ≥ 0). Caller treats absence as
+    "no usage on this event" and skips bucketing.
+    """
+    out = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
     if not isinstance(data, dict):
-        return 0
+        return out
 
-    def _read_usage(usage: Any) -> int:
-        if not isinstance(usage, dict):
-            return 0
-        for key in ("input_tokens", "inputTokens", "input"):
-            v = usage.get(key)
-            if v is None:
-                continue
-            try:
-                iv = int(v)
-            except (TypeError, ValueError):
-                continue
-            if iv > 0:
-                return iv
-        return 0
-
+    # Walk shapes in priority order; stop at the first envelope that
+    # carries a non-zero ``input`` (the canonical "this row has usage"
+    # signal — matches what ``_extract_input_tokens`` historically did).
+    candidates: list[dict[str, Any] | None] = []
     msg = data.get("message")
     if isinstance(msg, dict):
-        n = _read_usage(msg.get("usage"))
-        if n > 0:
-            return n
-
-    n = _read_usage(data.get("usage"))
-    if n > 0:
-        return n
-
+        candidates.append(msg.get("usage"))
+    candidates.append(data.get("usage"))
     pc = data.get("promptCache")
     if isinstance(pc, dict):
-        n = _read_usage(pc.get("lastCallUsage"))
-        if n > 0:
-            return n
-
+        candidates.append(pc.get("lastCallUsage"))
     am = data.get("assistantMessage")
     if isinstance(am, dict):
-        n = _read_usage(am.get("usage"))
-        if n > 0:
-            return n
+        candidates.append(am.get("usage"))
 
-    return 0
+    for u in candidates:
+        if not isinstance(u, dict):
+            continue
+        inp = _read_usage_int(u, _USAGE_KEYS_INPUT)
+        if inp <= 0:
+            continue
+        out["input_tokens"]       = inp
+        out["output_tokens"]      = _read_usage_int(u, _USAGE_KEYS_OUTPUT)
+        out["cache_read_tokens"]  = _read_usage_int(u, _USAGE_KEYS_CACHE_READ)
+        out["cache_write_tokens"] = _read_usage_int(u, _USAGE_KEYS_CACHE_WRITE)
+        return out
+
+    return out
+
+
+def _extract_usage_cost(data: dict) -> float:
+    """Best-effort ``cost.total`` extraction from an event ``data`` blob.
+
+    Mirrors ``_extract_usage_splits`` — walks ``data.message.usage.cost``,
+    ``data.usage.cost``, ``data.promptCache.lastCallUsage.cost`` (rare)
+    and returns the first non-zero ``cost.total`` (or ``cost.input +
+    cost.output`` when total is absent). Returns 0.0 on any failure.
+
+    Issue #1394: real OpenClaw v3 emits ``usage.cost`` as a nested dict
+    ``{input, output, cacheRead, cacheWrite, total}``. The legacy
+    aggregate fast-path only summed the ``cost_usd`` column, which the
+    sync daemon populates only when ``cost.total`` is present at ingest
+    time. This helper lets the fast-path recompute from the data blob
+    when the column is zero.
+    """
+    if not isinstance(data, dict):
+        return 0.0
+    candidates: list[Any] = []
+    msg = data.get("message")
+    if isinstance(msg, dict):
+        u = msg.get("usage")
+        if isinstance(u, dict):
+            candidates.append(u.get("cost"))
+    u2 = data.get("usage")
+    if isinstance(u2, dict):
+        candidates.append(u2.get("cost"))
+    pc = data.get("promptCache")
+    if isinstance(pc, dict):
+        lcu = pc.get("lastCallUsage")
+        if isinstance(lcu, dict):
+            candidates.append(lcu.get("cost"))
+    for cost in candidates:
+        if isinstance(cost, dict):
+            v = cost.get("total")
+            if v is None:
+                # OpenClaw sometimes emits a per-key cost without ``total``
+                # — fall back to input+output+cacheRead+cacheWrite.
+                try:
+                    parts = [
+                        float(cost.get(k) or 0)
+                        for k in ("input", "output", "cacheRead", "cacheWrite")
+                    ]
+                    s = sum(parts)
+                    if s > 0:
+                        return s
+                except (TypeError, ValueError):
+                    continue
+                continue
+            try:
+                fv = float(v)
+            except (TypeError, ValueError):
+                continue
+            if fv > 0:
+                return fv
+        elif isinstance(cost, (int, float)) and cost > 0:
+            return float(cost)
+    return 0.0
 
 
 _READ_TOOL_NAMES = frozenset({"read", "readfile", "read_file"})

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -293,6 +293,10 @@ _DAEMON_METHODS = frozenset({
     "query_sessions",
     "query_sessions_table",
     "query_aggregates",
+    # Issue #1394: per-day input/output/cache-read/cache-write token
+    # split for the Tokens-tab daily chart. Replaces the legacy fast-path
+    # that returned 0 for every split on real OpenClaw v3 installs.
+    "query_daily_usage_splits",
     "query_heartbeats",
     "query_channels",
     # Issue #1256 follow-up: alert_rules + channel_config_status. PR #1258

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -182,7 +182,17 @@ def _try_local_store_usage():
     aggregating ``daily_aggregates`` (with a ``query_events`` fallback if
     the aggregates table is empty). Returns the same shape as the legacy
     handler: days[], today/week/month, todayCost/weekCost/monthCost,
-    modelBreakdown, etc. Returns None to defer."""
+    modelBreakdown, etc. Returns None to defer.
+
+    Issue #1394: the fast-path used to set every per-day input/output/
+    cache_read/cache_write split to 0 because ``query_aggregates`` only
+    returns the coarse SUM(token_count) column. We now also call
+    ``query_daily_usage_splits``, which walks each ``assistant`` /
+    ``model.completed`` event blob and pulls the v3 Anthropic-SDK
+    cache-token keys (``cache_read_input_tokens`` /
+    ``cache_creation_input_tokens``) so the Tokens tab actually shows
+    the breakdown on real OpenClaw installs.
+    """
     # Pull pre-rolled day buckets first — these are the "blessed" data
     # the daemon writes once per ingest. Falls back to live event scan
     # when aggregates are empty (e.g. fresh install, only events seeded).
@@ -208,7 +218,44 @@ def _try_local_store_usage():
                 continue
             daily_tokens[day] = daily_tokens.get(day, 0) + int(ev.get("token_count") or 0)
             daily_cost[day] = daily_cost.get(day, 0.0) + float(ev.get("cost_usd") or 0.0)
-    if not daily_tokens and not daily_cost:
+
+    # Issue #1394: per-day input/output/cache_read/cache_write split. We
+    # build this from the assistant-event blob walker so we don't have
+    # to wait for the daemon to backfill split columns. Empty list is
+    # fine (caller renders zeros for the missing days).
+    splits_rows = _ls_call("query_daily_usage_splits") or []
+    daily_input = {r["day"]: int(r.get("input_tokens") or 0) for r in splits_rows}
+    daily_output = {r["day"]: int(r.get("output_tokens") or 0) for r in splits_rows}
+    daily_cache_read = {r["day"]: int(r.get("cache_read_tokens") or 0) for r in splits_rows}
+    daily_cache_write = {r["day"]: int(r.get("cache_write_tokens") or 0) for r in splits_rows}
+    # Also fill in cost from splits_rows when query_aggregates' cost_usd
+    # column was empty for that day (real-data common case — sync.py
+    # only stamps cost_usd when ``usage.cost.total`` is present at
+    # ingest time, which Anthropic-SDK echo events omit).
+    for r in splits_rows:
+        d = r["day"]
+        cost_from_split = float(r.get("cost_usd") or 0.0)
+        if cost_from_split > 0 and daily_cost.get(d, 0.0) <= 0:
+            daily_cost[d] = cost_from_split
+
+    # Issue #1394: prefer the deduped (input+output) total over the raw
+    # ``token_count`` aggregate when splits are available. The raw
+    # column counts BOTH the ``assistant`` and the sibling
+    # ``model.completed`` event for each LLM turn (different log
+    # writers race-emit them ~100-300ms apart) — sums end up roughly
+    # 2× the real billable total. The deduped splits already collapsed
+    # those sibling pairs, so adding their input+output is the
+    # billable-token answer the harness compares against.
+    for d in set(list(daily_input.keys()) + list(daily_output.keys())):
+        deduped_total = int(daily_input.get(d, 0)) + int(daily_output.get(d, 0))
+        if deduped_total > 0:
+            daily_tokens[d] = deduped_total
+
+    if (
+        not daily_tokens and not daily_cost
+        and not daily_input and not daily_output
+        and not daily_cache_read and not daily_cache_write
+    ):
         return None
 
     today = datetime.now()
@@ -220,10 +267,10 @@ def _try_local_store_usage():
             "date": ds,
             "tokens": int(daily_tokens.get(ds, 0)),
             "cost": round(float(daily_cost.get(ds, 0.0)), 6),
-            "inputTokens": 0,
-            "outputTokens": 0,
-            "cacheReadTokens": 0,
-            "cacheWriteTokens": 0,
+            "inputTokens": int(daily_input.get(ds, 0)),
+            "outputTokens": int(daily_output.get(ds, 0)),
+            "cacheReadTokens": int(daily_cache_read.get(ds, 0)),
+            "cacheWriteTokens": int(daily_cache_write.get(ds, 0)),
         })
 
     today_str = today.strftime("%Y-%m-%d")

--- a/tests/test_usage_local_store.py
+++ b/tests/test_usage_local_store.py
@@ -133,6 +133,15 @@ def _build_app(tmp_path, monkeypatch, *, enable_fast_path: bool):
 
     import clawmetry.local_store as ls
     importlib.reload(ls)
+    # Steer the daemon-proxy discovery away from the real install so the
+    # ``_ls_call`` helper falls through to the in-process LocalStore (which
+    # is what these tests are actually exercising). Without this, a running
+    # ``com.clawmetry.sync`` daemon serves the request from
+    # ``~/.clawmetry/clawmetry.duckdb`` instead of our tmp_path store.
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "_DISCOVERY_PATH", str(tmp_path / "no-such-discovery.json"))
+    lq._invalidate_daemon_cache()
+
     import routes.usage as usage_mod
     importlib.reload(usage_mod)
 
@@ -163,6 +172,9 @@ def legacy_path_app(tmp_path, monkeypatch):
 
     import clawmetry.local_store as ls
     importlib.reload(ls)
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "_DISCOVERY_PATH", str(tmp_path / "no-such-discovery.json"))
+    lq._invalidate_daemon_cache()
 
     store = ls.get_store()
     _seed_events(store, n=8, skills=["review", "review", "test"])
@@ -411,3 +423,427 @@ def test_skill_attribution_legacy_when_env_unset(legacy_path_app):
     app, _ls = legacy_path_app
     body = app.test_client().get("/api/skill-attribution").get_json()
     assert body.get("_source") != "local_store"
+
+
+# ── v3 real-shape regression (issue #1394) ────────────────────────────────
+
+
+def _ingest_v3_assistant(store, *, sid, ts, ev_id,
+                          input_tokens, output_tokens,
+                          cache_read, cache_write):
+    """Insert one ``assistant``-typed event whose ``data.message.usage``
+    carries the Anthropic-SDK envelope real OpenClaw v3 + Claude Code
+    installs emit. Matches the fixture pulled from
+    ``~/.clawmetry/clawmetry.duckdb`` on 2026-05-16 (issue #1394).
+    """
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "assistant",
+        "ts":         ts,
+        "data": {
+            "type":    "assistant",
+            "version": 3,
+            "message": {
+                "role":  "assistant",
+                "model": "claude-opus-4-7",
+                "type":  "message",
+                "usage": {
+                    "input_tokens":               input_tokens,
+                    "output_tokens":              output_tokens,
+                    "cache_read_input_tokens":    cache_read,
+                    "cache_creation_input_tokens": cache_write,
+                },
+            },
+        },
+        "cost_usd":    0.0,
+        "token_count": input_tokens + output_tokens,
+        "model":       "claude-opus-4-7",
+    })
+
+
+def _ingest_v3_model_completed(store, *, sid, ts, ev_id,
+                                input_tokens, output_tokens):
+    """Insert one ``model.completed`` sibling event (slim envelope, no
+    cache split). The pair (assistant + model.completed) emits ~100 ms
+    apart for every LLM turn on a real install — the fast-path must
+    dedup them so input/output aren't double-counted.
+    """
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "model.completed",
+        "ts":         ts,
+        "data": {
+            "type":     "model.completed",
+            "modelId":  "claude-opus-4-7",
+            "provider": "claude-cli",
+            "promptCache": {
+                "lastCallUsage": {
+                    "input":  input_tokens,
+                    "output": output_tokens,
+                    "total":  input_tokens + output_tokens,
+                },
+            },
+        },
+        "cost_usd":    0.0,
+        "token_count": input_tokens + output_tokens,
+        "model":       "claude-opus-4-7",
+    })
+
+
+def test_usage_v3_real_shape_returns_real_splits(fast_path_app):
+    """v3 real-shape regression (#1394): /api/usage was returning
+    ``inputTokens=0 outputTokens=0 cacheReadTokens=0 cacheWriteTokens=0``
+    on real OpenClaw v3 + Claude Code installs because the fast-path
+    derived the chart from ``query_aggregates`` only (which sums
+    ``token_count``) and stamped 0 into every split. Real installs
+    emit the splits on ``assistant``-typed events, not the legacy
+    synthetic ``message`` shape.
+
+    Three turns @ ``input=6, output=7, cacheRead=28k, cacheWrite=70``
+    each — the same shape the accuracy harness drove on a live box
+    when filing this bug.
+    """
+    app, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    base = f"{today}T10:00"
+
+    # Three turns, each emitting BOTH an assistant + model.completed
+    # event ~150 ms apart (matches the gateway-vs-Claude-Code emit race).
+    for i, (sec_a, sec_mc) in enumerate([("00", "00"), ("04", "04"), ("08", "08")]):
+        _ingest_v3_assistant(
+            store,
+            sid="sess-v3-real",
+            ts=f"{base}:{sec_a}.100Z",
+            ev_id=f"v3-asst-{i}",
+            input_tokens=6, output_tokens=7,
+            cache_read=28_500 + i, cache_write=70 + i,
+        )
+        _ingest_v3_model_completed(
+            store,
+            sid="sess-v3-real",
+            ts=f"{base}:{sec_mc}.250Z",  # ~150ms later
+            ev_id=f"v3-mc-{i}",
+            input_tokens=6, output_tokens=7,
+        )
+    _wait_flush(store)
+
+    body = app.test_client().get("/api/usage").get_json()
+    assert body["_source"] == "local_store"
+
+    today_bucket = next(d for d in body["days"] if d["date"] == today)
+
+    # Splits must reflect the assistant envelope (sums of 3 turns).
+    # input/output are 6+6+6=18 / 7+7+7=21 — DOUBLED if dedup fails.
+    assert today_bucket["inputTokens"] == 18, (
+        f"input drift: got {today_bucket['inputTokens']} (likely sibling "
+        f"event double-count if 36)"
+    )
+    assert today_bucket["outputTokens"] == 21, (
+        f"output drift: got {today_bucket['outputTokens']}"
+    )
+    # Cache splits come ONLY from the assistant envelope (the slim
+    # model.completed sibling has no cache_read/cache_write keys),
+    # so they should NOT double — but they also can't drop to 0.
+    assert today_bucket["cacheReadTokens"] == 28_500 + 28_501 + 28_502, (
+        f"cache_read drift: got {today_bucket['cacheReadTokens']}"
+    )
+    assert today_bucket["cacheWriteTokens"] == 70 + 71 + 72, (
+        f"cache_write drift: got {today_bucket['cacheWriteTokens']}"
+    )
+
+    # Top-line ``today`` scalar should be input+output (39), not the
+    # raw column sum that would inflate to 78 (= 39 × 2 sibling events).
+    assert body["today"] == 39, (
+        f"today scalar drift: got {body['today']} (likely 78 if dedup failed)"
+    )
+
+
+def test_usage_v3_today_week_month_match_when_only_today(fast_path_app):
+    """Issue #1394 — when ALL ingested data falls in ``today``, the
+    today/week/month scalars must agree (no silent zero in the wider
+    windows). The accuracy harness asserts this directly: same
+    ``input/output/cache_read/cache_write/total`` across all four windows
+    when no older data exists.
+    """
+    app, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    _ingest_v3_assistant(
+        store, sid="sess-window-test",
+        ts=f"{today}T11:30:00.100Z", ev_id="v3-w-asst",
+        input_tokens=6, output_tokens=7, cache_read=28_500, cache_write=70,
+    )
+    _ingest_v3_model_completed(
+        store, sid="sess-window-test",
+        ts=f"{today}T11:30:00.250Z", ev_id="v3-w-mc",
+        input_tokens=6, output_tokens=7,
+    )
+    _wait_flush(store)
+
+    body = app.test_client().get("/api/usage").get_json()
+    today_bucket = next(d for d in body["days"] if d["date"] == today)
+
+    # The day bucket is the canonical source — assert today/week/month
+    # all derive from it (week/month start ≤ today, so they sum to
+    # the same value when only today has data).
+    assert today_bucket["inputTokens"] == 6
+    assert today_bucket["outputTokens"] == 7
+    assert today_bucket["cacheReadTokens"] == 28_500
+    assert today_bucket["cacheWriteTokens"] == 70
+
+    # Top-line scalars derive from the same day_bucket sum (today only).
+    assert body["today"] == 13  # 6 + 7 (deduped)
+    # week/month aren't returned as splits in the response — the harness
+    # sums days[] for each window. We mirror that here so the assertion
+    # protects the same surface.
+    today_iso = today
+    week_start = today_iso  # only one day of data → week start ≤ today
+    month_start = today_iso[:8] + "01"
+
+    def _sum_field(field, since):
+        return sum(d.get(field, 0) for d in body["days"] if d["date"] >= since)
+
+    for since in (today_iso, week_start, month_start, "0000-00-00"):
+        assert _sum_field("inputTokens", since) == 6, f"input drift at since={since}"
+        assert _sum_field("outputTokens", since) == 7, f"output drift at since={since}"
+        assert _sum_field("cacheReadTokens", since) == 28_500, f"cache_read drift at since={since}"
+        assert _sum_field("cacheWriteTokens", since) == 70, f"cache_write drift at since={since}"
+        assert _sum_field("tokens", since) == 13, f"total drift at since={since}"
+
+
+def test_usage_v3_subagent_assistant_event(fast_path_app):
+    """Subagent (Task tool) emits ``subagent:assistant`` events with the
+    same Anthropic envelope as the parent ``assistant`` event. They
+    represent real LLM spend the user pays for, so the splits MUST
+    count them. (Different from the model-fallback route, which
+    deliberately excludes them — see #1385.)
+    """
+    app, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    # Parent assistant turn.
+    _ingest_v3_assistant(
+        store, sid="sess-with-subagent",
+        ts=f"{today}T12:00:00.100Z", ev_id="v3-parent",
+        input_tokens=6, output_tokens=7, cache_read=28_500, cache_write=70,
+    )
+
+    # Sub-agent assistant turn (same shape — overrides event_type).
+    store.ingest({
+        "id":         "v3-sub",
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": "sess-with-subagent",
+        "event_type": "subagent:assistant",
+        "ts":         f"{today}T12:00:30.100Z",
+        "data": {
+            "type":    "subagent:assistant",
+            "version": 3,
+            "message": {
+                "role":  "assistant",
+                "model": "claude-haiku-4-7",
+                "type":  "message",
+                "usage": {
+                    "input_tokens":               4,
+                    "output_tokens":              5,
+                    "cache_read_input_tokens":    1_000,
+                    "cache_creation_input_tokens": 10,
+                },
+            },
+        },
+        "cost_usd":    0.0,
+        "token_count": 9,
+        "model":       "claude-haiku-4-7",
+    })
+    _wait_flush(store)
+
+    body = app.test_client().get("/api/usage").get_json()
+    today_bucket = next(d for d in body["days"] if d["date"] == today)
+
+    # Both turns counted: 6+4=10, 7+5=12, 28500+1000=29500, 70+10=80.
+    assert today_bucket["inputTokens"] == 10
+    assert today_bucket["outputTokens"] == 12
+    assert today_bucket["cacheReadTokens"] == 29_500
+    assert today_bucket["cacheWriteTokens"] == 80
+
+
+# ── Unit: query_daily_usage_splits + helpers ───────────────────────────────
+
+
+def test_extract_usage_splits_v3_assistant_shape():
+    """v3 ``assistant`` event carries the Anthropic-SDK envelope. All four
+    splits should round-trip from ``data.message.usage``."""
+    from clawmetry.local_store import _extract_usage_splits
+
+    data = {
+        "message": {
+            "role": "assistant",
+            "usage": {
+                "input_tokens":               6,
+                "output_tokens":              7,
+                "cache_read_input_tokens":    28_668,
+                "cache_creation_input_tokens": 71,
+            },
+        },
+    }
+    assert _extract_usage_splits(data) == {
+        "input_tokens": 6, "output_tokens": 7,
+        "cache_read_tokens": 28_668, "cache_write_tokens": 71,
+    }
+
+
+def test_extract_usage_splits_v3_model_completed_shape():
+    """v3 ``model.completed`` carries only ``promptCache.lastCallUsage``
+    with input/output/total — no cache split. Cache buckets must
+    fall through to 0 (caller pairs this row with the richer
+    ``assistant`` sibling for the splits)."""
+    from clawmetry.local_store import _extract_usage_splits
+
+    data = {
+        "type":      "model.completed",
+        "modelId":   "claude-opus-4-7",
+        "promptCache": {
+            "lastCallUsage": {"input": 6, "output": 7, "total": 13},
+        },
+    }
+    assert _extract_usage_splits(data) == {
+        "input_tokens": 6, "output_tokens": 7,
+        "cache_read_tokens": 0, "cache_write_tokens": 0,
+    }
+
+
+def test_extract_usage_splits_openclaw_native_shape():
+    """OpenClaw native v3 ``message`` event uses camelCase
+    ``usage.cacheRead`` / ``cacheWrite`` (no ``_input_tokens`` suffix)."""
+    from clawmetry.local_store import _extract_usage_splits
+
+    data = {
+        "message": {
+            "role": "assistant",
+            "usage": {
+                "input":      6,
+                "output":     7,
+                "cacheRead":  28_312,
+                "cacheWrite": 72,
+            },
+        },
+    }
+    assert _extract_usage_splits(data) == {
+        "input_tokens": 6, "output_tokens": 7,
+        "cache_read_tokens": 28_312, "cache_write_tokens": 72,
+    }
+
+
+def test_extract_usage_splits_returns_zero_dict_on_empty():
+    """No usage anywhere → all-zero dict (caller treats as "skip row")."""
+    from clawmetry.local_store import _extract_usage_splits
+
+    assert _extract_usage_splits({}) == {
+        "input_tokens": 0, "output_tokens": 0,
+        "cache_read_tokens": 0, "cache_write_tokens": 0,
+    }
+    assert _extract_usage_splits(None) == {  # type: ignore[arg-type]
+        "input_tokens": 0, "output_tokens": 0,
+        "cache_read_tokens": 0, "cache_write_tokens": 0,
+    }
+
+
+def test_query_daily_usage_splits_dedups_sibling_events(fast_path_app):
+    """assistant + model.completed emitted ~150 ms apart for the SAME
+    LLM turn must collapse to one billable count. Without dedup,
+    input/output would double; cache splits would stay correct
+    (only assistant carries them) but the TOTAL row count would
+    lie."""
+    _app, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    _ingest_v3_assistant(
+        store, sid="sess-dedup",
+        ts=f"{today}T10:00:00.100Z", ev_id="dedup-asst",
+        input_tokens=6, output_tokens=7, cache_read=28_500, cache_write=70,
+    )
+    _ingest_v3_model_completed(
+        store, sid="sess-dedup",
+        ts=f"{today}T10:00:00.250Z", ev_id="dedup-mc",
+        input_tokens=6, output_tokens=7,
+    )
+    _wait_flush(store)
+
+    rows = store.query_daily_usage_splits()
+    assert len(rows) == 1
+    assert rows[0]["day"] == today
+    assert rows[0]["input_tokens"] == 6
+    assert rows[0]["output_tokens"] == 7
+    assert rows[0]["cache_read_tokens"] == 28_500
+    assert rows[0]["cache_write_tokens"] == 70
+    assert rows[0]["event_count"] == 1
+
+
+def test_query_daily_usage_splits_keeps_distinct_turns(fast_path_app):
+    """Two turns ≥ 4 s apart in the same session are NOT siblings — the
+    dedup window (±1 s) must not collapse them."""
+    _app, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    _ingest_v3_assistant(
+        store, sid="sess-distinct",
+        ts=f"{today}T10:00:00.100Z", ev_id="t1",
+        input_tokens=6, output_tokens=7, cache_read=28_500, cache_write=70,
+    )
+    _ingest_v3_assistant(
+        store, sid="sess-distinct",
+        ts=f"{today}T10:00:04.500Z", ev_id="t2",  # 4.4 s later
+        input_tokens=6, output_tokens=7, cache_read=28_600, cache_write=71,
+    )
+    _wait_flush(store)
+
+    rows = store.query_daily_usage_splits()
+    assert rows[0]["input_tokens"] == 12  # 6 + 6
+    assert rows[0]["output_tokens"] == 14  # 7 + 7
+    assert rows[0]["cache_read_tokens"] == 57_100  # 28_500 + 28_600
+    assert rows[0]["event_count"] == 2
+
+
+def test_query_daily_usage_splits_skips_zero_usage_rows(fast_path_app):
+    """Events without recoverable usage (queue-operation, session.started,
+    etc.) must not bloat ``event_count``. Only counts rows we actually
+    bucketed."""
+    _app, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    # One real assistant event.
+    _ingest_v3_assistant(
+        store, sid="sess-skip",
+        ts=f"{today}T10:00:00.100Z", ev_id="real",
+        input_tokens=6, output_tokens=7, cache_read=28_500, cache_write=70,
+    )
+    # One assistant event with empty usage — should be skipped.
+    store.ingest({
+        "id":         "empty",
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": "sess-skip",
+        "event_type": "assistant",
+        "ts":         f"{today}T10:00:30.000Z",
+        "data":       {"message": {"role": "assistant"}},
+        "model":      "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    rows = store.query_daily_usage_splits()
+    assert rows[0]["event_count"] == 1


### PR DESCRIPTION
Closes #1394.

## Summary
- The Tokens tab was returning ``input/output/cache_read/cache_write = 0`` across every window on real OpenClaw v3 installs because ``_try_local_store_usage`` derived its per-day chart from ``query_aggregates`` (raw ``token_count`` / ``cost_usd`` columns) and stamped 0 into every split. PR #1386 widened 4 query methods but missed ``/api/usage`` itself.
- Fix walks each ``assistant`` / ``subagent:assistant`` / ``model.completed`` event blob via a new ``_extract_usage_splits`` helper that handles both Anthropic-SDK keys (``cache_read_input_tokens``, ``cache_creation_input_tokens``) and OpenClaw v3 camelCase (``cacheRead``, ``cacheWrite``).
- Sibling dedup: real installs emit BOTH an ``assistant`` (full envelope, has cache splits) AND a ``model.completed`` (slim, no cache) for every LLM turn, ~150 ms apart. New ``query_daily_usage_splits`` collapses sibling pairs via a (session_id, ±1 s) window so input/output don't double.

## Predicates widened (before → after)
- ``query_daily_usage_splits`` (new) filters on ``_BILLABLE_TURN_EVENT_TYPES = (message, assistant, subagent:assistant, model.completed)``.
- Distinct from ``_ASSISTANT_EVENT_TYPES`` (used by fallback detector, excludes subagents intentionally per #1385).

## Helper changes
- New ``_extract_usage_splits(data) -> {input_tokens, output_tokens, cache_read_tokens, cache_write_tokens}`` walks 4 envelope shapes (priority-ordered, first non-zero ``input`` wins).
- New ``_extract_usage_cost(data) -> float`` for the same multi-shape walk over ``cost.total``.
- ``_extract_input_tokens`` refactored to delegate to ``_extract_usage_splits``.

## Live harness verification (real OpenClaw v3)

```
BEFORE 0.12.230:
  summary: 0 pass / 20 drift / 20 total checks
  /api/usage today input        18 → 0    DRIFT
  /api/usage today output       21 → 0    DRIFT
  /api/usage today cache_read   85791 → 0 DRIFT
  /api/usage today cache_write  213 → 0   DRIFT
  (same drift across week/month/all_14d)

AFTER 0.12.230:
  summary: 20 pass / 0 drift / 20 total checks
  [harness] ALL CHECKS PASSED — Tokens tab is accurate on this build.
```

Verified with the harness from PR #1395 (``feat/accuracy-harness-tokens-poc``).

## Test plan
- [x] 10 new pytest cases in ``tests/test_usage_local_store.py``:
  - v3 real-shape regression for ``/api/usage`` (3 assistant + 3 model.completed turns, asserts all 5 metrics)
  - window-equality: today/week/month/all_14d return identical values when only today has data
  - subagent:assistant turns count toward token spend
  - sibling dedup: 150 ms-apart pairs collapse to 1 turn
  - distinct turns ≥ 4 s apart stay distinct
  - ``_extract_usage_splits`` shape coverage (v3 assistant / v3 model.completed / OpenClaw native / empty)
- [x] Live harness on a real OpenClaw v3 box: 20 drifts → 0 drifts
- [x] All 27 ``test_usage_local_store.py`` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)