### PR TITLE
feat(accuracy): meta-harness runner skeleton (sub-runs + aggregate + exit code)

### DIFF
--- a/scripts/accuracy_harness/README.md
+++ b/scripts/accuracy_harness/README.md
@@ -2,8 +2,9 @@
 
 Synthetic ground-truth verifiers for ClawMetry features. **Tokens** was the
 proof-of-concept (PR #1395); **approvals** is the second harness;
-**alerts** is the third, and the same shape extends to channels / crons
-next.
+**alerts** is the third; **all.py** is the meta-runner skeleton that wraps
+every sub-harness and produces ONE scoreboard. The same shape extends to
+channels / crons next.
 
 ## Why
 
@@ -38,6 +39,16 @@ threshold. Steps 1/3/4/5/6 stay identical — that's the harness shape.
 ## Running it
 
 ```bash
+# Meta-runner: shell out to every sub-harness, aggregate scoreboard.
+python3 scripts/accuracy_harness/all.py
+
+# Subset.
+python3 scripts/accuracy_harness/all.py --harnesses tokens,alerts
+
+# Smoke-test the runner without touching OpenClaw / spending LLM budget.
+python3 scripts/accuracy_harness/all.py --dry-run --no-issue
+
+# Or run individual harnesses ─────────────────────────────────────────
 # Tokens: default 3 messages, auto-detect dashboard on 8900/8903/8905
 python3 scripts/accuracy_harness/tokens.py
 
@@ -60,6 +71,35 @@ python3 scripts/accuracy_harness/tokens.py --file-issues
 python3 scripts/accuracy_harness/approvals.py --file-issues
 CLAWMETRY_HARNESS_HOOKS=1 python3 scripts/accuracy_harness/alerts.py --file-issues
 ```
+
+### Meta-runner (`all.py`)
+
+`all.py` is a thin runner: it shells out to each registered sub-harness
+(`tokens.py`, `approvals.py`, `alerts.py`) with a 180s per-harness
+timeout, parses each one's `summary: N pass / N drift` line, prints a
+single scoreboard, and exits with the worst observed status. **It does
+not re-implement any harness logic** — sub-harnesses already own
+ground-truth driving and per-endpoint assertions.
+
+| flag | meaning |
+|---|---|
+| `--harnesses tokens,approvals,alerts` | comma-separated subset (default: all registered) |
+| `--no-issue` | skip the (future) consolidated drift-issue filer |
+| `--dry-run` | short-circuit before shelling out — proves the runner skeleton without spending LLM budget. **Not passed through**: sub-harnesses don't yet support `--dry-run`. |
+
+Exit codes:
+
+| code | meaning |
+|---:|---|
+| 0 | every sub-harness PASS-ed |
+| 1 | at least one drift, no errors |
+| 2 | at least one harness errored or timed out |
+
+The consolidated GitHub-issue filer is intentionally **not** implemented
+in this PR — `file_consolidated_issue` only PRINTS what it would file
+(`Would file consolidated issue: N drifts across M harnesses`). Live
+filing lands in the follow-up iteration once the runner is proven in
+production. Wire to a cloud cron once that lands.
 
 ### Prerequisites
 
@@ -239,7 +279,8 @@ scripts/accuracy_harness/
 ├── _lib.py         # shared discovery + HTTP + drift-issue helpers
 ├── tokens.py       # tokens harness (PR #1395)
 ├── approvals.py    # approvals queue harness (PR #1397)
-└── alerts.py       # alert-rule round-trip harness (this PR)
+├── alerts.py       # alert-rule round-trip harness (PR #1399)
+└── all.py          # meta-runner skeleton — sub-runs + aggregate scoreboard
 ```
 
 Shared shims live in `_lib.py` (`discover_dashboard_url`,

--- a/scripts/accuracy_harness/all.py
+++ b/scripts/accuracy_harness/all.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""scripts/accuracy_harness/all.py — meta-runner for every accuracy harness.
+
+Shells out to each sub-harness, parses its `summary: N pass / N drift`
+line, prints a scoreboard, exits with worst status (0 PASS / 1 DRIFT /
+2 ERROR). Consolidated GitHub-issue filing is deferred to a follow-up PR
+— `file_consolidated_issue` only PRINTS what it would file today.
+
+Sub-harnesses do NOT support --dry-run; the meta `--dry-run` short-
+circuits before shelling out so the runner skeleton is provable without
+spending real LLM budget.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+HARNESSES: list[tuple[str, str]] = [
+    ("tokens",    "scripts/accuracy_harness/tokens.py"),
+    ("approvals", "scripts/accuracy_harness/approvals.py"),
+    ("alerts",    "scripts/accuracy_harness/alerts.py"),
+]
+
+PER_HARNESS_TIMEOUT_S = 180
+SUMMARY_RE = re.compile(r"summary:\s*(\d+)\s*pass\s*/\s*(\d+)\s*drift")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass
+class HarnessResult:
+    name: str
+    exit_code: int       # 0/1/2 from sub-harness; 2 for timeout/exec error
+    pass_count: int      # -1 if summary line unparseable
+    drift_count: int     # -1 if summary line unparseable
+    status: str          # "pass" | "drift" | "error"
+    note: str = ""
+
+    @property
+    def parsed(self) -> bool:
+        return self.pass_count >= 0 and self.drift_count >= 0
+
+
+def run_one(name: str, rel_path: str) -> HarnessResult:
+    abs_path = REPO_ROOT / rel_path
+    if not abs_path.exists():
+        return HarnessResult(name, 2, -1, -1, "error", f"missing: {rel_path}")
+    try:
+        proc = subprocess.run([sys.executable, str(abs_path)],
+                              capture_output=True, text=True,
+                              timeout=PER_HARNESS_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        return HarnessResult(name, 2, -1, -1, "error",
+                             f"timed out after {PER_HARNESS_TIMEOUT_S}s")
+    except Exception as e:
+        return HarnessResult(name, 2, -1, -1, "error", f"exec failed: {e}")
+
+    matches = SUMMARY_RE.findall(proc.stdout or "")
+    if not matches:
+        tail = (proc.stderr or proc.stdout or "").strip().splitlines()[-1:]
+        return HarnessResult(name, max(proc.returncode, 2), -1, -1, "error",
+                             f"unparseable summary; rc={proc.returncode}; tail={tail!r}")
+    p, d = map(int, matches[-1])
+    status = {0: "pass", 1: "drift"}.get(proc.returncode, "error")
+    return HarnessResult(name, proc.returncode, p, d, status, f"rc={proc.returncode}")
+
+
+def print_scoreboard(results: list[HarnessResult]) -> None:
+    print()
+    print("─" * 70)
+    print(f"{'HARNESS':<12} {'STATUS':<7} {'PASS':>5} {'DRIFT':>6} {'EXIT':>5}  NOTE")
+    print("─" * 70)
+    for r in results:
+        p = str(r.pass_count) if r.parsed else "?"
+        d = str(r.drift_count) if r.parsed else "?"
+        print(f"{r.name:<12} {r.status.upper():<7} {p:>5} {d:>6} {r.exit_code:>5}  {r.note}")
+    print("─" * 70)
+    total_p = sum(r.pass_count for r in results if r.parsed)
+    total_d = sum(r.drift_count for r in results if r.parsed)
+    n_err = sum(1 for r in results if r.status == "error")
+    print(f"OVERALL: {total_p} pass / {total_d} drift across "
+          f"{len(results)} harness(es) ({n_err} error)")
+
+
+def overall_exit_code(results: list[HarnessResult]) -> int:
+    if any(r.status == "error" for r in results): return 2
+    if any(r.status == "drift" for r in results): return 1
+    return 0
+
+
+def file_consolidated_issue(results: list[HarnessResult]) -> None:
+    # Skeleton — gh-issue filing lands in the follow-up PR. Print only.
+    n_drifts = sum(r.drift_count for r in results if r.parsed and r.drift_count > 0)
+    n_h = sum(1 for r in results if r.status != "pass")
+    print(f"[meta] Would file consolidated issue: {n_drifts} drifts across "
+          f"{n_h} harness(es) (filer not yet implemented)")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--harnesses", type=str, default="",
+                   help=f"comma-separated subset (default: all). "
+                        f"choices: {','.join(n for n, _ in HARNESSES)}")
+    p.add_argument("--no-issue", action="store_true",
+                   help="skip the (future) consolidated drift-issue filer")
+    p.add_argument("--dry-run", action="store_true",
+                   help="short-circuit before shelling out (sub-harnesses don't "
+                        "support --dry-run yet, so it isn't passed through)")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    selected = {n.strip() for n in args.harnesses.split(",") if n.strip()}
+    plan = [(n, p) for n, p in HARNESSES if not selected or n in selected]
+    if not plan:
+        print(f"[meta] no harnesses match --harnesses={args.harnesses!r}",
+              file=sys.stderr)
+        return 2
+    print(f"[meta] runner skeleton — {len(plan)} harness(es): "
+          f"{', '.join(n for n, _ in plan)}")
+    if args.dry_run:
+        results = [HarnessResult(n, 0, 0, 0, "pass", "dry-run (skipped)")
+                   for n, _ in plan]
+    else:
+        results = [run_one(n, p) for n, p in plan]
+        for r in results:
+            if r.status == "error":
+                print(f"[meta] {r.name}: ERROR — {r.note}", file=sys.stderr)
+    print_scoreboard(results)
+    if not args.no_issue:
+        file_consolidated_issue(results)
+    return overall_exit_code(results)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Pure runner**, no per-harness re-implementation. `scripts/accuracy_harness/all.py` (141 LOC) shells out to each registered sub-harness (`tokens.py`, `approvals.py`, `alerts.py`) with a 180s per-harness timeout, parses each one's `summary: N pass / N drift` line, prints a single scoreboard, and exits with the worst observed status (0 PASS / 1 DRIFT / 2 ERROR).
- Args: `--harnesses tokens,approvals,alerts` (default = all), `--no-issue`, `--dry-run`.
- README updated with a Meta-runner section (flags + exit codes).

## Why a skeleton this iteration

The prior attempt at this PR scope-crept into a 319-LOC `all.py` with monkey-patching the per-harness `file_drift_issue_per_endpoint` import, an in-place GitHub-issue dedup-by-title flow, and `_lib.py` changes — and stalled (likely waiting on a real OpenClaw call inside an inadvertently un-shorted sub-harness path). This iteration is the runner skeleton only:

- Consolidated GitHub-issue filing is intentionally **deferred**. `file_consolidated_issue` is wired behind `--no-issue` but only PRINTS what it would file (`Would file consolidated issue: N drifts across M harnesses`). Live filer lands once the runner is proven in production.
- No `_lib.py` changes — sub-harness summary line is parsed via stdout regex (`summary:\s*(\d+)\s*pass\s*/\s*(\d+)\s*drift`), no monkey-patching.

## Documented gap: sub-harnesses don't support `--dry-run`

`tokens.py` / `approvals.py` / `alerts.py` would error with "unrecognized arguments: --dry-run" if it were passed through. Per the spec, **the meta `--dry-run` short-circuits BEFORE shelling out** — synthetic PASS rows are emitted so the scoreboard + exit-code paths are smoke-testable without spending real LLM budget. Adding `--dry-run` support to the sub-harnesses themselves is out of scope for this PR.

## Dry-run output (from this worktree)

```
$ python3 scripts/accuracy_harness/all.py --dry-run --no-issue
[meta] runner skeleton — 3 harness(es): tokens, approvals, alerts

──────────────────────────────────────────────────────────────────────
HARNESS      STATUS   PASS  DRIFT  EXIT  NOTE
──────────────────────────────────────────────────────────────────────
tokens       PASS        0      0     0  dry-run (skipped)
approvals    PASS        0      0     0  dry-run (skipped)
alerts       PASS        0      0     0  dry-run (skipped)
──────────────────────────────────────────────────────────────────────
OVERALL: 0 pass / 0 drift across 3 harness(es) (0 error)
EXIT=0
```

Subset (`--harnesses tokens,alerts`) and invalid-subset (`--harnesses bogus` → exit 2) paths also verified.

## Test plan

- [x] `python3 scripts/accuracy_harness/all.py --dry-run --no-issue` → exits 0 with synthetic scoreboard
- [x] `python3 scripts/accuracy_harness/all.py --dry-run --harnesses tokens,alerts` → 2 harnesses, exits 0
- [x] `python3 scripts/accuracy_harness/all.py --dry-run --harnesses bogus` → exits 2 with "no harnesses match" error
- [x] `python3 -c "import ast; ast.parse(open('scripts/accuracy_harness/all.py').read())"` → syntax OK
- [ ] Live verification (sub-harnesses actually shelled out, real OpenClaw turns) — **next iteration**

## Next iteration

1. Live verification — run `all.py` (no `--dry-run`) end-to-end against a local stack with `openclaw` + dashboard + sync daemon up. Capture timing, confirm summary parsing handles real outputs.
2. Implement `file_consolidated_issue` for real — gh-issue dedup by `[accuracy-audit YYYY-MM-DD] META …` title prefix + `accuracy-meta` label, body contains drift table per harness, in-place edit on same-day re-runs. Wire to a cloud cron once stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)