### PR TITLE
feat(ci): gate [RELEASE] PRs on accuracy meta-harness PASS (closes #1396)

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -28,6 +28,118 @@ jobs:
       - name: Install build tools
         run: pip install build twine
 
+      # ─── Accuracy meta-harness gate (closes #1396) ────────────────────────
+      # Hard-gates [RELEASE] PRs on `scripts/accuracy_harness/all.py`. The
+      # full harness drives REAL openclaw turns + LLM calls + a live sync
+      # daemon, none of which exist on a vanilla GH runner — so CI runs
+      # the meta-runner in `--dry-run --no-issue` mode (proves the runner
+      # skeleton + every sub-harness path resolves) AND a structural import
+      # gate (proves `tokens.py` / `approvals.py` / `alerts.py` modules are
+      # importable + the HARNESSES registry in `all.py` matches reality).
+      # Together this catches the silent-zero class of bug (#1394) where a
+      # sub-harness vanishes from the registry, an import breaks, or `all.py`
+      # itself crashes — all of which would silently let a broken release
+      # ship if we trusted production-only validation.
+      #
+      # Live ground-truth runs (sub-harnesses against a real OpenClaw + LLM
+      # API key) belong in a periodic cloud cron once the consolidated
+      # GitHub-issue filer in `all.py` is wired against staging; that
+      # follow-up is tracked against #1396. Until then this gate covers the
+      # failure class that previously let #1394's 85K-token cache_read
+      # drift ship silently.
+      - name: Accuracy meta-harness — structural gate
+        id: accuracy_gate
+        run: |
+          set +e
+          # 1. Structural: every registered harness module imports without
+          # side effects, and `all.py`'s HARNESSES registry points at real
+          # files. Catches deletions / renames / import-time NameErrors.
+          python3 - <<'PY'
+          import importlib.util, sys, pathlib
+          root = pathlib.Path(".").resolve()
+          # Must be in sync with the registry inside scripts/accuracy_harness/all.py
+          REGISTRY = ["tokens", "approvals", "alerts"]
+          # `_lib` is shared, must import too.
+          MODULES = ["_lib"] + REGISTRY
+          # Make `from _lib import …` resolve when sub-harnesses import.
+          sys.path.insert(0, str(root / "scripts" / "accuracy_harness"))
+
+          def load(modname, filename):
+              # Register in sys.modules BEFORE exec — required so Python 3.9
+              # dataclass type-resolution (sys.modules[cls.__module__].__dict__)
+              # works on modules loaded by file path.
+              path = root / "scripts" / "accuracy_harness" / filename
+              if not path.exists():
+                  raise FileNotFoundError(str(path))
+              spec = importlib.util.spec_from_file_location(modname, path)
+              mod = importlib.util.module_from_spec(spec)
+              sys.modules[modname] = mod
+              spec.loader.exec_module(mod)
+              return mod
+
+          failed = []
+          for name in MODULES:
+              try:
+                  load(name, f"{name}.py")
+              except Exception as e:
+                  failed.append(f"{name} import: {type(e).__name__}: {e}")
+          # Cross-check that all.py's registry only references files we just verified.
+          try:
+              _all = load("_acc_all_runner", "all.py")
+          except Exception as e:
+              failed.append(f"all.py import: {type(e).__name__}: {e}")
+          else:
+              registered = {n for n, _ in _all.HARNESSES}
+              expected = set(REGISTRY)
+              if registered != expected:
+                  failed.append(f"all.py registry drift: registered={registered} expected={expected}")
+          if failed:
+              print("STRUCTURAL GATE FAILED:")
+              for f in failed: print("  -", f)
+              sys.exit(1)
+          print("structural gate OK: registry + module imports clean")
+          PY
+          STRUCT_RC=$?
+          # 2. Smoke the meta-runner in --dry-run --no-issue mode. This
+          # exercises argument parsing, scoreboard formatting, and the exit
+          # code path. Sub-harnesses don't run (they need OpenClaw); their
+          # contract is asserted by step 1.
+          python3 scripts/accuracy_harness/all.py --dry-run --no-issue \
+            > /tmp/acc-harness.log 2>&1
+          DRY_RC=$?
+          cat /tmp/acc-harness.log
+          if [ "$STRUCT_RC" -ne 0 ] || [ "$DRY_RC" -ne 0 ]; then
+            echo ""
+            echo "❌ Accuracy meta-harness gate FAILED"
+            echo "   structural rc=$STRUCT_RC  dry-run rc=$DRY_RC"
+            echo ""
+            echo "This gate hard-blocks PyPI publish for [RELEASE] PRs."
+            echo "Reproduce locally:"
+            echo "  python3 scripts/accuracy_harness/all.py --dry-run --no-issue"
+            echo ""
+            {
+              echo "## Accuracy meta-harness gate: FAIL"
+              echo ""
+              echo "- structural-import rc: \`$STRUCT_RC\`"
+              echo "- meta-runner dry-run rc: \`$DRY_RC\`"
+              echo ""
+              echo '<details><summary>meta-runner output</summary>'
+              echo ''
+              echo '```'
+              tail -60 /tmp/acc-harness.log
+              echo '```'
+              echo '</details>'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          {
+            echo "## Accuracy meta-harness gate: PASS"
+            echo ""
+            echo '```'
+            tail -20 /tmp/acc-harness.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Bump patch version
         id: bump
         run: |

--- a/scripts/accuracy_harness/README.md
+++ b/scripts/accuracy_harness/README.md
@@ -171,6 +171,50 @@ per full run** on opus-4-7.
 | 1 | one or more drifts (issue filed if `--file-issues`) |
 | 2 | harness itself failed (dashboard down, no openclaw, etc.) |
 
+## CI gate (closes #1396)
+
+`.github/workflows/release-on-merge.yml` runs the meta-harness as a
+**hard gate** on every `[RELEASE]`-titled PR merge, _before_ the PyPI
+publish step. The gate is the `Accuracy meta-harness — structural gate`
+step in the `release` job, inserted between dependency-install and
+version-bump. Any non-zero exit aborts the job, so the wheel never
+builds, twine never uploads, and no GitHub release tag is created.
+
+The CI runner has no `openclaw` binary, no LLM API key, and no live
+sync daemon, so the gate runs in two **structural** modes (not live):
+
+| mode | what it catches |
+|---|---|
+| `import` every registered sub-harness (`_lib`, `tokens`, `approvals`, `alerts`) by file path | sub-harness rename / deletion, top-level `import` errors, `dataclass` field-type regressions, `all.py`'s `_lib.file_consolidated_issue` import drifting |
+| `python3 all.py --dry-run --no-issue` | `all.py` skeleton crashes, scoreboard formatting bugs, exit-code path regressions |
+| HARNESSES-registry cross-check vs. CI's expected list | `all.py` silently dropping a sub-harness (regression of #1394's silent-zero class) |
+
+The CI step writes a PASS/FAIL block to `$GITHUB_STEP_SUMMARY` so the
+PR author sees the scoreboard on the run page without expanding logs.
+
+### Why not live ground-truth runs in CI?
+
+Sub-harnesses drive REAL `openclaw agent` turns (~$0.05 of LLM spend
+per run) against a REAL sync daemon writing to DuckDB. Wiring a
+synthetic OpenClaw + daemon stub into the runner matrix is tracked
+against #1396's follow-up: once the consolidated GitHub-issue filer
+in `all.py` is wired against staging, a periodic cloud cron will run
+the full harness nightly against a real cluster and file drift issues
+with the `accuracy-meta` label. Until then, the structural gate covers
+the failure class that previously let #1394's 85K-token `cache_read`
+drift ship silently (sub-harness present in repo but never invoked).
+
+### Reproducing the gate locally
+
+```bash
+# Exactly what CI runs (no env required):
+python3 scripts/accuracy_harness/all.py --dry-run --no-issue
+```
+
+If the gate fails on your `[RELEASE]` PR, the workflow's
+`Accuracy meta-harness — structural gate` step prints the full
+stderr; re-run locally with the same command to reproduce.
+
 ## What's covered today
 
 ### Tokens (`tokens.py`)


### PR DESCRIPTION
## Summary

Insert a structural-import + dry-run gate into `release-on-merge.yml`'s release job, before version bump and PyPI publish. Hard-blocks `[RELEASE]` PRs from publishing if the accuracy meta-harness regresses.

- Imports every registered sub-harness (`_lib`, `tokens`, `approvals`, `alerts`) by file path with `sys.modules` registration (Python 3.9 dataclass-field-type resolution compat).
- Cross-checks `all.py`'s `HARNESSES` registry against the CI-expected list — catches the silent-zero class of bug (#1394) where a sub-harness vanishes from registration but stays in the repo.
- Runs `python3 scripts/accuracy_harness/all.py --dry-run --no-issue` to exercise scoreboard formatting + exit-code paths.
- On failure: writes a FAIL block to `$GITHUB_STEP_SUMMARY` and exits non-zero — aborts the rest of the release job (build, smoke, daemon-E2E, cloud-contract, twine, release tag, version-bump PR all skip).

## Why structural-only (not live)

CI runners have no `openclaw` binary, no LLM API key, and no live sync daemon — sub-harnesses can't run end-to-end. The structural mode covers the failure class that previously let #1394's 85K-token `cache_read` drift ship silently (a sub-harness present in the repo but never invoked). Live ground-truth runs land in a follow-up: a periodic cloud cron against staging once `all.py`'s consolidated drift-issue filer is wired (tracked against #1396).

## Test plan

- [x] `python3 scripts/accuracy_harness/all.py --dry-run --no-issue` passes locally on post-#1407 main (3 harnesses, 0 drifts, exit 0).
- [x] Structural import gate passes locally on post-#1407 main (registry + module imports clean).
- [x] Forced registry drift (remove `alerts` from CI's expected list) correctly trips the gate with `STRUCTURAL GATE FAILED: all.py registry drift: registered={...} expected={...}` and `RC=1`.
- [x] YAML parses (`yaml.safe_load`); step ordering verified — Gate at idx 3, Bump at idx 4, Publish at idx 11.
- [x] 156 LOC added across 2 files (<300 LOC cap).
- [ ] Manual `gh workflow run` dispatch — **not possible**: `release-on-merge.yml` is triggered by `pull_request: types: [closed]`, no `workflow_dispatch` block. Adding one would re-trigger the release job on a non-`[RELEASE]` PR with the wrong context (no merged PR title), so the existing `if:` would short-circuit anyway. The gate will be exercised on the next real `[RELEASE]` PR merge.
- [ ] Verifying the gate fails closed on a real broken PR can be done by opening a follow-up `[RELEASE]` PR that intentionally breaks the registry (e.g. `from _lib import file_consolidated_issue` deleted) — the job will abort before Bump and never reach Publish.

## Follow-up

Next iteration: synthetic OpenClaw + LLM stub in CI (or hermetic in-process simulator) so the sub-harnesses themselves run live in a few minutes. Until then, real-world live runs happen on the periodic cloud cron once #1396's filer is wired against staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)