### PR TITLE
[RELEASE] fix(accuracy): merge fleet_db rules into local_store GET response (closes #1406)

### DIFF
--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -329,6 +329,19 @@ def api_alert_rules():
     if is_local_store_read_enabled():
         fast = _try_local_store_alert_rules()
         if fast is not None:
+            # DuckDB holds cloud-synced rules; fleet_db (SQLite) holds
+            # locally-created ones written by the POST path above. Without
+            # this merge, a POST-then-GET round-trip drops the new rule
+            # because the fast path returns only DuckDB rows (drift #1406).
+            cloud_ids = {r.get("id") for r in (fast.get("rules") or [])}
+            try:
+                local_only = [r for r in _d._get_alert_rules()
+                              if r.get("id") not in cloud_ids]
+                if local_only:
+                    fast = dict(fast)
+                    fast["rules"] = list(fast.get("rules") or []) + local_only
+            except Exception:
+                pass
             return jsonify(fast)
     return jsonify({"rules": _d._get_alert_rules()})
 


### PR DESCRIPTION
## Summary

- `POST /api/alerts/rules` writes a new rule into **fleet_db (SQLite)**.
- Since v0.12.174, `CLAWMETRY_LOCAL_STORE_READ` defaults ON, so `GET /api/alerts/rules` returns **only DuckDB (cloud-synced) rows** via the local-store fast path.
- The newly created rule is invisible in the POST→GET round-trip — the accuracy harness catches this as a `row_present` DRIFT (issue #1406).

**Fix (`routes/alerts.py`):** after the DuckDB fast path returns its result, fetch any fleet_db rules whose IDs aren't already in the DuckDB set and append them. The merge is wrapped in `try/except` so a fleet_db error degrades gracefully to the DuckDB-only result.

## Root cause

| store | populated by | queried by |
|---|---|---|
| fleet_db (SQLite) | `POST /api/alerts/rules` | `_get_alert_rules()` (legacy path) |
| local_store (DuckDB) | cloud heartbeat relay | `_try_local_store_alert_rules()` (fast path) |

Before this fix, the fast path **replaced** fleet_db results rather than augmenting them.

## Test plan

- [ ] Run accuracy harness: `CLAWMETRY_HARNESS_HOOKS=1 python3 scripts/accuracy_harness/alerts.py`
  - `row_present` check should change from DRIFT → PASS
- [ ] Existing rules still served when DuckDB is empty (no regression)
- [ ] Verify cleanup step still passes (`row_absent_after_delete`)

## Related

- Drift 2 (`real_spend_visible`) already fixed by #1410
- Drifts 3+4 (inject-cost 404, webhook dispatch) self-heal: endpoint `GET /api/_harness/inject-cost` was added in commit `40d262a` alongside the harness — server restart picks it up

https://claude.ai/code/session_01X7T9XprFG4XFNhTUFPFWG9

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7T9XprFG4XFNhTUFPFWG9)_