### PR TITLE
[RELEASE] fix(ux): one-time Tokens-tab banner for cache-split data restoration (closes #1401)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4274,7 +4274,19 @@ function clawmetryLogout(){
   
   <!-- Cost Warnings -->
   <div id="cost-warnings" style="display:none; margin-bottom: 16px;"></div>
-  
+
+  <!-- One-time banner: token splits now accurate (issue #1401) -->
+  <div id="tokens-fix-banner" style="display:none;margin-bottom:16px;padding:10px 14px;background:#1a3a2a;border:1px solid #2a5a3a;border-radius:8px;font-size:13px;color:#60ff80;display:flex;align-items:center;justify-content:space-between;">
+    <span>&#128200; Token splits now include cache reads/writes &mdash; numbers are accurate from this version. <a href="#" onclick="event.preventDefault();" style="color:#60ff80;text-decoration:underline;">See CHANGELOG #1394</a></span>
+    <button onclick="document.getElementById('tokens-fix-banner').style.display='none';localStorage.setItem('clawmetry_tokens_fix_banner_v1','1');" style="background:transparent;border:none;cursor:pointer;font-size:16px;color:#60ff80;padding:0 0 0 12px;">&times;</button>
+  </div>
+  <script>
+  (function(){
+    var b = document.getElementById('tokens-fix-banner');
+    if(b && !localStorage.getItem('clawmetry_tokens_fix_banner_v1')) b.style.display='flex';
+  })();
+  </script>
+
   <!-- Main Usage Stats -->
   <div class="grid">
     <div class="card">


### PR DESCRIPTION
Closes #1401

## Problem
PR #1398 silently fixed input/output/cache_read/cache_write tokens being zero on real OpenClaw v3 installs. Users who visited the Tokens tab before 0.12.230 saw $0 everywhere. After the fix, values jump from $0 → real spend — without context, this looks like a regression or fabrication rather than a fix. Silently-distrusted dashboards bleed Cloud-Pro conversions.

## Fix
One-time dismissible banner at the top of the Tokens tab:

> 📈 Token splits now include cache reads/writes — numbers are accurate from this version.

**Mechanics:**
- Inline `<script>` IIFE checks `localStorage.getItem('clawmetry_tokens_fix_banner_v1')` on page load
- If not dismissed, sets `display:flex` on the banner div
- Dismiss button sets the localStorage key and hides the div
- Fresh installs that never saw the zero state will also see it once — acceptable; it's a one-sentence informational notice, not alarming

**No server-side state, no API call, no dependency.** Banner fires at most once per browser profile.

## Files changed
- `dashboard.py` — 13 lines added inside `#page-usage`, before the Main Usage Stats section

## Test plan
- [ ] Navigate to Tokens tab → banner appears (if not previously dismissed)
- [ ] Click × → banner disappears, `clawmetry_tokens_fix_banner_v1` key set in localStorage
- [ ] Reload page → banner does NOT reappear
- [ ] Open new private/incognito tab → banner appears again
- [ ] Other tabs (Sessions, Brain, etc.) unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ayqq7QzArFJLcw33tzNWy)_