### PR TITLE
feat(insights): add Insights nav tab (gated by CLAWMETRY_INSIGHTS=1)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -13194,3 +13194,18 @@ function _ncEsc(s) {
   } catch(e) {}
 })();
 } } // end if(false) stub */
+
+// On page load: reveal Insights tab if the feature flag is on. Insights endpoints
+// 404 with `{"error":"feature_disabled"}` when CLAWMETRY_INSIGHTS=1 is unset, so
+// a fast HEAD-style probe of /api/insights/config keeps the tab hidden by default
+// (no surface for users who haven't opted in yet) without leaking a spurious 200.
+(function() {
+  try {
+    fetch('/api/insights/config').then(function(r) {
+      if (r.ok) {
+        var t = document.getElementById('insights-tab');
+        if (t) t.style.display = '';
+      }
+    }).catch(function(){});
+  } catch(e) {}
+})();

--- a/dashboard.py
+++ b/dashboard.py
@@ -3933,6 +3933,7 @@ function clawmetryLogout(){
     <div class="nav-tab" onclick="switchTab('memory')">Memory</div>
     <div class="nav-tab" onclick="switchTab('security')">Security</div>
     <div class="nav-tab" id="nemoclaw-tab" onclick="switchTab('nemoclaw')" style="display:none;">NemoClaw</div>
+    <a class="nav-tab" id="insights-tab" href="/insights" style="display:none;text-decoration:none;color:inherit;" title="Weekly LLM-over-DuckDB digest (set CLAWMETRY_INSIGHTS=1 to enable)">Insights</a>
     <!-- History tab hidden until mature -->
     <!-- <div class="nav-tab" onclick="switchTab('history')">History</div> -->
   </div>
@@ -10057,6 +10058,7 @@ DASHBOARD_HTML = r"""
     <div class="nav-tab" onclick="switchTab('memory')">Memory</div>
     <div class="nav-tab" onclick="switchTab('security')">Security</div>
     <div class="nav-tab" id="nemoclaw-tab" onclick="switchTab('nemoclaw')" style="display:none;">NemoClaw</div>
+    <a class="nav-tab" id="insights-tab" href="/insights" style="display:none;text-decoration:none;color:inherit;" title="Weekly LLM-over-DuckDB digest (set CLAWMETRY_INSIGHTS=1 to enable)">Insights</a>
     <!-- History tab hidden until mature -->
     <!-- <div class="nav-tab" onclick="switchTab('history')">History</div> -->
   <div id="cloud-cta-btn" onclick="openCloudModal()" style="display:none;margin-left:8px;cursor:pointer;padding:6px 12px;border:1px solid rgba(96,165,250,0.5);border-radius:8px;font-size:12px;font-weight:600;color:#60a5fa;white-space:nowrap;transition:all 0.2s;user-select:none;" onmouseover="this.style.background='rgba(96,165,250,0.1)'" onmouseout="this.style.background='transparent'"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="display:inline;vertical-align:middle;margin-right:4px"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>Enable Cloud Sync</div>


### PR DESCRIPTION
## Summary
P1 follow-up from the post-merge UX review of PR #1417 — without a nav entry, the Weekly Insights Digest page at `/insights` is unreachable unless you already know the URL.

## Implementation
- New `<a class="nav-tab" id="insights-tab" href="/insights">` entry alongside the existing Memory/Security/NemoClaw tabs (both nav locations updated — OSS variant @ dashboard.py:3935 + cloud variant @ dashboard.py:10059).
- Hidden by default (`style="display:none;"`).
- IIFE on page load probes `/api/insights/config` — returns 404 (`feature_disabled`) when `CLAWMETRY_INSIGHTS=1` is unset (per `routes/insights.py:_gated()`), so the tab stays invisible until the user opts in. Mirrors the existing NemoClaw tab gate pattern (app.js:13186).

## Test plan
- [x] `python3 -c "import dashboard"` — clean
- [ ] Manual w/ `CLAWMETRY_INSIGHTS=1` — Insights tab appears in nav, click navigates to `/insights`
- [ ] Manual w/o the env var — tab stays hidden (no 404 console noise; `r.ok` check skips toggle)

## Out of scope
- The `/insights` page navigates AWAY from the dashboard SPA (full page load) rather than rendering inline. Tradeoff intentional — keeps blast radius small until soak ends. Future: render insights as an in-app tab section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)