### PR TITLE
fix(ui): Tokens-banner link points to real issue (closes #1429)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4384,7 +4384,7 @@ function clawmetryLogout(){
 
   <!-- One-time banner: token splits now accurate (issue #1401) -->
   <div id="tokens-fix-banner" style="display:none;margin-bottom:16px;padding:10px 14px;background:#1a3a2a;border:1px solid #2a5a3a;border-radius:8px;font-size:13px;color:#60ff80;display:flex;align-items:center;justify-content:space-between;">
-    <span>&#128200; Token splits now include cache reads/writes &mdash; numbers are accurate from this version. <a href="#" onclick="event.preventDefault();" style="color:#60ff80;text-decoration:underline;">See CHANGELOG #1394</a></span>
+    <span>&#128200; Token splits now include cache reads/writes &mdash; numbers are accurate from this version. <a href="https://github.com/vivekchand/clawmetry/issues/1394" target="_blank" rel="noopener" style="color:#60ff80;text-decoration:underline;">See issue #1394</a></span>
     <button onclick="document.getElementById('tokens-fix-banner').style.display='none';localStorage.setItem('clawmetry_tokens_fix_banner_v1','1');" style="background:transparent;border:none;cursor:pointer;font-size:16px;color:#60ff80;padding:0 0 0 12px;">&times;</button>
   </div>
   <script>


### PR DESCRIPTION
## Summary
Closes #1429 (UX P0 from PR #1424 review).

The cache-split fix banner shipped in #1424 had a non-functional link:
\`\`\`html
<a href=\"#\" onclick=\"event.preventDefault();\">See CHANGELOG #1394</a>
\`\`\`
Click did nothing — feels like a debug build, especially to the non-technical target audience (\`feedback_simple_ui_for_nontechnical.md\`). Same class of anti-pattern as the \`alert(JSON)\` P0 already fixed in #1421.

## Fix
- Real link to https://github.com/vivekchand/clawmetry/issues/1394
- \`target=\"_blank\" rel=\"noopener\"\` so users keep their dashboard tab open
- Wording \"See issue #1394\" instead of \"See CHANGELOG #1394\" — issue page is what actually has the rationale

## Test plan
- [x] \`python3 -c \"import dashboard\"\` clean
- [ ] Manual: open Tokens tab → click link → opens issue #1394 in new tab; dashboard tab unchanged
- [ ] Banner still dismisses cleanly via the \`×\` button (untouched logic)

## Diff
1 line in \`dashboard.py\`. No functional changes elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)