### PR TITLE
[RELEASE] fix(e2e): allowlist /api/insights/config 404 in cloud-contract spec

### DIFF
--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -82,7 +82,15 @@ function isHarmlessConsoleError(e) {
     // shape: new OSS endpoint, returns 404 on cloud. Filtering
     // them here matches the existing /api/skills 410 pattern.
     (/\/api\/diagnostics/.test(e) && /\b410\b/.test(e)) ||
-    (/\/api\/config-diagnostics/.test(e) && /\b404\b/.test(e))
+    (/\/api\/config-diagnostics/.test(e) && /\b404\b/.test(e)) ||
+    // /api/insights/config returns 404 when CLAWMETRY_INSIGHTS=1 is unset
+    // (the common case on cloud — feature is OSS-only soak per PR #1417).
+    // The IIFE probe in app.js intentionally swallows the failure via
+    // `if (r.ok)` to keep the Insights tab hidden, but the browser still
+    // logs the 404 as console.error which we can't suppress from JS.
+    // Issue #1431 will fix this properly by returning 200 {enabled:false}
+    // instead of 404; until then, allowlist matches the existing pattern.
+    (/\/api\/insights\/config/.test(e) && /\b404\b/.test(e))
   );
 }
 


### PR DESCRIPTION
## Summary
Unblocks cloud deploy of 0.12.234 — failed at 09:22 UTC on \`cloud-contract\` spec's \"zero unexpected JS errors\" check.

[RELEASE]-tagged because cloud's deploy gate pulls the contract spec from OSS main; the fix needs to land in a published OSS version before cloud's next deploy attempt sees it.

## Root cause
The new Insights nav-tab IIFE (PR #1428) probes \`/api/insights/config\`. The endpoint returns 404 on cloud because \`CLAWMETRY_INSIGHTS=1\` is unset (feature is OSS-only soak per PR #1417). The JS \`if (r.ok)\` correctly hides the tab on 404, but the browser auto-logs the failed fetch as \`console.error\` which trips the cloud-contract gate.

## Fix
Allowlist matches the existing pattern for \`/api/diagnostics\` 410 and \`/api/config-diagnostics\` 404 — both \"cloud-disabled returns 4xx but JS handles it gracefully\" cases.

## Test plan
- [x] \`node --check tests/e2e/cloud-contract.mjs\` — clean
- [ ] CI: cloud-contract job (no live run on this PR — verified in prod cloud deploy gate after merge)
- [ ] After release: re-run cloud deploy of 0.12.234 should pass

## Long-term
Issue #1431 tracks the proper fix: change \`routes/insights.py\` \`_gated()\` to return 200 \`{enabled:false}\` instead of 404. That removes the allowlist need entirely and matches the \"Pro-locked vs invisible\" UX direction. Until that lands, this allowlist is the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)