### PR TITLE
[RELEASE] fix(insights): /api/insights/config GET returns 200 {enabled} (closes #1431)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -13195,14 +13195,17 @@ function _ncEsc(s) {
 })();
 } } // end if(false) stub */
 
-// On page load: reveal Insights tab if the feature flag is on. Insights endpoints
-// 404 with `{"error":"feature_disabled"}` when CLAWMETRY_INSIGHTS=1 is unset, so
-// a fast HEAD-style probe of /api/insights/config keeps the tab hidden by default
-// (no surface for users who haven't opted in yet) without leaking a spurious 200.
+// On page load: reveal Insights tab when the feature flag is on. The endpoint
+// always returns 200 (since #1431/PR closing); when disabled it returns
+// `{enabled: false}`, when enabled it returns the full config + `enabled: true`.
+// Probing by JSON flag instead of HTTP status keeps the browser console clean
+// on cloud-rendered dashboards where CLAWMETRY_INSIGHTS=1 is unset.
 (function() {
   try {
     fetch('/api/insights/config').then(function(r) {
-      if (r.ok) {
+      return r.ok ? r.json() : null;
+    }).then(function(d) {
+      if (d && d.enabled === true) {
         var t = document.getElementById('insights-tab');
         if (t) t.style.display = '';
       }

--- a/routes/insights.py
+++ b/routes/insights.py
@@ -127,18 +127,34 @@ def api_send_now():
 
 @bp_insights.route("/api/insights/config", methods=["GET", "POST"])
 def api_config():
-    gated = _gated()
-    if gated is not None:
-        return gated
+    # GET always returns 200 with `{enabled: bool, ...}` so the dashboard's
+    # nav-tab-reveal probe (`app.js` IIFE checking /api/insights/config) can
+    # render the tab in either an active or a Pro-locked state without the
+    # browser console-erroring on a 404. POSTs (writes) still 404 when the
+    # feature flag is off — writes only make sense when the feature is on.
+    #
+    # Fixes #1431 (Pro-locked vs invisible-when-off) AND removes the need
+    # for the cloud-contract 404 allowlist entry from PR #1435.
     from clawmetry.insights import load_config, save_config
+    enabled = _feature_enabled()
     if request.method == "POST":
+        if not enabled:
+            return jsonify({
+                "error": "feature_disabled",
+                "hint": "Set CLAWMETRY_INSIGHTS=1 to enable Weekly Insights Digest.",
+            }), 404
         data = request.get_json(silent=True) or {}
         cfg = save_config(data)
-        return jsonify({"ok": True, "config": cfg})
+        return jsonify({"ok": True, "enabled": True, "config": cfg})
+    # GET: always 200. When disabled, return only the enabled flag (no
+    # config payload — nothing to expose to a viewer who hasn't opted in).
+    if not enabled:
+        return jsonify({"enabled": False})
     cfg = load_config()
     # Don't leak the API key back to the browser — return only a presence flag.
     cfg_safe = dict(cfg)
     cfg_safe["anthropic_api_key"] = "***" if cfg_safe.get("anthropic_api_key") else ""
+    cfg_safe["enabled"] = True
     return jsonify(cfg_safe)
 
 

--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -82,15 +82,11 @@ function isHarmlessConsoleError(e) {
     // shape: new OSS endpoint, returns 404 on cloud. Filtering
     // them here matches the existing /api/skills 410 pattern.
     (/\/api\/diagnostics/.test(e) && /\b410\b/.test(e)) ||
-    (/\/api\/config-diagnostics/.test(e) && /\b404\b/.test(e)) ||
-    // /api/insights/config returns 404 when CLAWMETRY_INSIGHTS=1 is unset
-    // (the common case on cloud — feature is OSS-only soak per PR #1417).
-    // The IIFE probe in app.js intentionally swallows the failure via
-    // `if (r.ok)` to keep the Insights tab hidden, but the browser still
-    // logs the 404 as console.error which we can't suppress from JS.
-    // Issue #1431 will fix this properly by returning 200 {enabled:false}
-    // instead of 404; until then, allowlist matches the existing pattern.
-    (/\/api\/insights\/config/.test(e) && /\b404\b/.test(e))
+    (/\/api\/config-diagnostics/.test(e) && /\b404\b/.test(e))
+    // Note: /api/insights/config 404 allowlist (added in PR #1435) was
+    // removed when issue #1431 landed — the endpoint now returns 200
+    // {enabled: false} when CLAWMETRY_INSIGHTS=1 is unset, so the probe
+    // succeeds cleanly without console.error.
   );
 }
 

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -154,6 +154,34 @@ def test_routes_return_404_when_flag_off(fresh_insights, monkeypatch):
     assert r2.status_code == 404
 
 
+def test_config_get_returns_200_with_enabled_flag_when_flag_off(
+    fresh_insights, monkeypatch
+):
+    """/api/insights/config GET is the dashboard's nav-tab-reveal probe.
+    Returning 404 there caused the browser to console.error on every page
+    load, tripping cloud-contract gates (#1431). Now: always 200, with
+    `enabled: false` when feature off (cheap signal for the probe without
+    leaking config payload), `enabled: true + full config` when on."""
+    monkeypatch.delenv("CLAWMETRY_INSIGHTS", raising=False)
+    sys.modules.pop("routes.insights", None)
+    from flask import Flask
+    from routes.insights import bp_insights
+    app = Flask(__name__)
+    app.register_blueprint(bp_insights)
+    client = app.test_client()
+    r = client.get("/api/insights/config")
+    assert r.status_code == 200, r.data
+    body = r.get_json()
+    assert body == {"enabled": False}, body
+    # POST still 404 when off — writes only make sense when feature is on.
+    r2 = client.post(
+        "/api/insights/config",
+        data=json.dumps({"channel": "slack"}),
+        content_type="application/json",
+    )
+    assert r2.status_code == 404, r2.data
+
+
 def test_routes_serve_when_flag_on(fresh_insights, monkeypatch):
     monkeypatch.setenv("CLAWMETRY_INSIGHTS", "1")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
Closes #1431 (Product P0). Removes the allowlist debt class entirely + sets up the Pro-locked tab pattern.

## Before / After
**Before:** GET `/api/insights/config` returned 404 when `CLAWMETRY_INSIGHTS=1` was unset. The dashboard's nav-tab-reveal IIFE in app.js probes this endpoint on every page load; on cloud (flag always unset) the 404 tripped the cloud-contract gate's "zero unexpected JS errors" check. PR #1435 added a `console.error` allowlist as a stopgap — that was the **third entry** in the allowlist for the same anti-pattern class (`/api/diagnostics` 410, `/api/config-diagnostics` 404, `/api/insights/config` 404).

**After:**
- GET always 200. `{enabled: false}` when off, `{enabled: true, ...cfg}` when on. Cheap probe; no payload leaked when off.
- POST still 404 when off (writes require feature opt-in).
- `/insights` HTML page + preview/history/send-now unchanged (still 404 when off — they have no JS-probe risk).
- app.js IIFE checks `d.enabled === true` instead of `r.ok`.
- Cloud-contract allowlist entry from PR #1435 removed (no longer needed).

## Test plan
- [x] `pytest tests/test_insights.py` — 11/11 pass (added 1 new test asserting GET returns 200 + POST still 404)
- [x] `python3 -c "import dashboard"` clean
- [x] `node --check tests/e2e/cloud-contract.mjs` clean
- [ ] CI matrix
- [ ] After release: cloud deploy retry should pass without the allowlist entry (verifies the systemic fix)

## Knock-on
Future Pro-locked-tab UX can now render an "Insights 🔒" tab pointing to a paywall modal when `enabled=false`, instead of hiding the feature entirely. That's the user-facing half of #1431 (still tracked); ships as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)