### PR TITLE
[RELEASE] fix(e2e): re-add insights/config 404 allowlist (chicken-and-egg unblock)

### DIFF
--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -82,11 +82,19 @@ function isHarmlessConsoleError(e) {
     // shape: new OSS endpoint, returns 404 on cloud. Filtering
     // them here matches the existing /api/skills 410 pattern.
     (/\/api\/diagnostics/.test(e) && /\b410\b/.test(e)) ||
-    (/\/api\/config-diagnostics/.test(e) && /\b404\b/.test(e))
-    // Note: /api/insights/config 404 allowlist (added in PR #1435) was
-    // removed when issue #1431 landed — the endpoint now returns 200
-    // {enabled: false} when CLAWMETRY_INSIGHTS=1 is unset, so the probe
-    // succeeds cleanly without console.error.
+    (/\/api\/config-diagnostics/.test(e) && /\b404\b/.test(e)) ||
+    // Temporarily restored. PR #1437 changed /api/insights/config to return
+    // 200 {enabled: false} instead of 404 and removed this allowlist entry
+    // — but the contract spec runs against PROD (https://app.clawmetry.com),
+    // which is still pinned to a clawmetry version BEFORE #1437. So the
+    // pre-publish gate sees the old 404 and blocks #1437 from publishing.
+    // Classic chicken-and-egg: the OSS fix can't ship until cloud has it,
+    // and cloud can't get it until OSS ships.
+    //
+    // Keep this allowlist entry until cloud Dockerfile is pinned to
+    // clawmetry>=0.12.236 (the version that includes #1437's server-side
+    // fix). After that, remove this and PR #1435's stopgap in one go.
+    (/\/api\/insights\/config/.test(e) && /\b404\b/.test(e))
   );
 }
 


### PR DESCRIPTION
## Summary
Unblocks the publish chain for the systemic insights fix.

## Problem
PR #1437 [RELEASE] (insights config GET → 200) merged at 10:13Z but FAILED to publish because:

1. \`release-on-merge.yml\` runs cloud-contract spec against PROD (\`https://app.clawmetry.com\`) before bumping the version and publishing to PyPI.
2. PROD is pinned to clawmetry==0.12.235, which still returns 404 on \`/api/insights/config\` (the OLD pre-#1437 behavior).
3. PR #1437 removed the cloud-contract allowlist entry for that 404.
4. Without the allowlist + with PROD returning 404 → "zero unexpected JS errors" check fails → publish blocked → cloud can never update → permanent deadlock.

## Fix
Re-add the allowlist entry. Tagged `[RELEASE]` so it ships in the next OSS version.

## Rollout sequence (after this merges)
1. This PR merges + auto-bumps to 0.12.236, publishes to PyPI.
2. Open cloud Dockerfile bump PR pinning clawmetry==0.12.236 (includes #1437's server-side 200 behavior).
3. Cloud deploys 0.12.236; PROD now returns 200 on /api/insights/config.
4. **Then** open a new OSS PR that removes BOTH allowlist entries (this one + PR #1435's original). Pre-publish gate will pass cleanly since PROD now matches the new spec.

## Lesson learned
When changing a behavior AND removing its corresponding allowlist in one PR, make sure the spec runs against the CANDIDATE build, not PROD. Pre-publish gate logic in \`release-on-merge.yml\` needs an option to run against the candidate revision (similar to cloud's deploy.yml \`--tag candidate\` pattern). Tracking as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)