### PR TITLE
fix(alerts): gate per-agent Telegram dispatch behind Cloud-Pro (closes #1168)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -808,6 +808,53 @@ def _get_budget_status():
     }
 
 
+# ── Pro-tier gate (issue #1168) ────────────────────────────────────────
+#
+# Per-agent budget LIMITS are OSS table-stakes (cost control). Per-agent
+# alert DISPATCH (Telegram/Slack) is the Cloud-Pro value-add — see
+# ``project_alerts_pro_feature.md``: Alerts Center is Cloud-Pro, OSS sees
+# a soft paywall, Cloud-Free sees an upgrade CTA. Centralised here so the
+# rule is applied consistently from any per-feature dispatch path.
+#
+# Liveness rule used by the OSS daemon (no async cloud RPC at fire-time):
+#   * No ``cm_`` token on disk           → OSS-only           → NOT pro
+#   * Has ``cm_`` token + cached plan="cloud_pro"|"pro"|"trial" → pro
+#   * Has ``cm_`` token but no cached plan, or plan="free"     → NOT pro
+#
+# The cached plan is populated by the cloud-CTA status route the dashboard
+# already polls; we read it best-effort and fall back to the conservative
+# "not pro" answer so we never accidentally fire paid dispatch on a free
+# node. This means Cloud-Free users see the same paywall OSS users do
+# until they upgrade, which matches the strategic split.
+def _is_pro_user():
+    """Best-effort, fail-closed Pro check used to gate paid dispatch.
+
+    Returns True only when both signals are present:
+      1. ``cm_`` cloud token resolvable on disk (user is paired), and
+      2. The cached plan tier is one of ``cloud_pro`` / ``pro`` / ``trial``.
+
+    Any failure (no token, missing cache, exception) returns False so we
+    never leak a Cloud-Pro dispatch path onto a free / OSS-only node.
+    """
+    try:
+        token = _read_cloud_token() or ""
+    except Exception:
+        token = ""
+    if not isinstance(token, str) or not token.startswith("cm_"):
+        return False
+    # Best-effort plan cache lookup. Populated by the cloud-CTA status
+    # route on each /api/cloud-cta/status hit (see routes/overview.py).
+    plan = ""
+    try:
+        cache = globals().get("_cloud_plan_cache") or {}
+        plan = str(cache.get("plan") or "").strip().lower()
+    except Exception:
+        plan = ""
+    if plan in ("cloud_pro", "pro", "trial"):
+        return True
+    return False
+
+
 # ── Per-agent budgets (issue #951) ─────────────────────────────────────
 #
 # Per-agent overrides live in the DuckDB ``agent_budgets`` table (see
@@ -997,6 +1044,19 @@ def _budget_check_for_agent(agent_id, *, auto_pause_enabled=None,
     today_start, today_key, month_start, month_key = _period_bounds()
     pause_triggered = False
 
+    # Issue #1168: per-agent LIMITS are OSS table-stakes, but per-agent
+    # Telegram dispatch is a Cloud-Pro feature. OSS / Cloud-Free nodes
+    # still get the in-app banner + history row (so the user sees the
+    # breach and the bar paints red), they just don't get the paid
+    # Telegram fan-out. The UI surfaces an inline "Upgrade for Telegram
+    # alerts" link on the per-agent panel.
+    _pro = False
+    try:
+        _pro = bool(_is_pro_user())
+    except Exception:
+        _pro = False
+    _agent_alert_channels = ["banner", "telegram"] if _pro else ["banner"]
+
     for period, period_start, period_key, override_key, global_key in (
         ("daily", today_start, today_key, "daily_limit_usd", "daily_limit"),
         ("monthly", month_start, month_key, "monthly_limit_usd", "monthly_limit"),
@@ -1026,7 +1086,7 @@ def _budget_check_for_agent(agent_id, *, auto_pause_enabled=None,
                         f"BUDGET CRITICAL: agent '{agent_id}' {period} spend "
                         f"${spent:.2f} of ${limit:.2f} (100%) limit"
                     ),
-                    channels=["banner", "telegram"],
+                    channels=_agent_alert_channels,
                 )
                 if auto_pause_enabled:
                     pause_triggered = True
@@ -1045,7 +1105,7 @@ def _budget_check_for_agent(agent_id, *, auto_pause_enabled=None,
                         f"Budget warning: agent '{agent_id}' {period} spend "
                         f"${spent:.2f} is {pct:.0f}% of ${limit:.2f} limit"
                     ),
-                    channels=["banner", "telegram"],
+                    channels=_agent_alert_channels,
                 )
 
     return pause_triggered
@@ -5442,13 +5502,27 @@ function switchBudgetTab(tab, el) {
 }
 
 // Per-agent budgets (issue #951)
+// Issue #1168: per-agent LIMITS are free in OSS, but Telegram dispatch
+// on per-agent thresholds is a Cloud-Pro feature. Server returns
+// `pro_dispatch_enabled` on /api/budget; render an inline upsell when
+// it's false so the user knows the bar will paint red but no message
+// will reach Telegram until they upgrade.
 async function loadAgentBudgets() {
   try {
     var data = await fetch('/api/budget').then(function(r){return r.json();});
     var agents = (data && data.agents) || {};
+    var proEnabled = !!(data && data.pro_dispatch_enabled);
+    var upsellHtml = '';
+    if (!proEnabled) {
+      upsellHtml = '<div style="margin-bottom:10px;padding:10px 12px;background:var(--bg-tertiary);border:1px solid var(--border-primary);border-radius:8px;font-size:12px;color:var(--text-secondary);">'
+        + '<span style="font-weight:600;color:var(--text-primary);">Limits are free.</span> '
+        + 'Telegram alerts on per-agent budgets are a Cloud Pro feature. '
+        + '<a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener" style="color:var(--bg-accent);text-decoration:underline;font-weight:600;">Upgrade to send alerts</a>'
+        + '</div>';
+    }
     var ids = Object.keys(agents);
     if (ids.length === 0) {
-      document.getElementById('agent-budget-list').innerHTML =
+      document.getElementById('agent-budget-list').innerHTML = upsellHtml +
         '<div style="padding:20px;text-align:center;color:var(--text-muted);">No per-agent overrides yet.</div>';
       return;
     }
@@ -5481,7 +5555,7 @@ async function loadAgentBudgets() {
       html += '</tr>';
     });
     html += '</table>';
-    document.getElementById('agent-budget-list').innerHTML = html;
+    document.getElementById('agent-budget-list').innerHTML = upsellHtml + html;
   } catch(e) {
     document.getElementById('agent-budget-list').textContent = 'Failed to load';
   }

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -187,7 +187,19 @@ def api_budget_root():
         for row in overrides_list
         if row.get("agent_id")
     }
-    return jsonify({"config": cfg, "agents": overrides})
+    # Issue #1168: per-agent LIMITS are OSS table-stakes, but Telegram
+    # dispatch on per-agent thresholds is Cloud-Pro only. Surface the
+    # gate so the UI can show an upsell row instead of pretending alerts
+    # will fire when they will not.
+    try:
+        pro_dispatch_enabled = bool(_d._is_pro_user())
+    except Exception:
+        pro_dispatch_enabled = False
+    return jsonify({
+        "config": cfg,
+        "agents": overrides,
+        "pro_dispatch_enabled": pro_dispatch_enabled,
+    })
 
 
 @bp_budget.route("/api/agents/<agent_id>/budget", methods=["GET"])

--- a/tests/test_per_agent_budget.py
+++ b/tests/test_per_agent_budget.py
@@ -321,3 +321,96 @@ def test_override_takes_precedence_over_global(dashboard_module):
     # Monthly side falls back to global because override is None.
     assert status["monthly_limit"] == 999.0
     assert status["monthly_limit_source"] == "global"
+
+
+# ── 6. Pro-tier gate on Telegram dispatch (issue #1168) ──────────────────────
+#
+# Per-agent LIMITS are OSS table-stakes (cost control). Per-agent Telegram
+# DISPATCH is Cloud-Pro only. These tests assert that an OSS user (no
+# ``cm_`` token, no Pro plan) crossing 80% / 100% on a per-agent budget
+# does NOT trigger ``_send_telegram_alert`` even though the banner +
+# alert-history row still fire.
+
+
+@pytest.fixture
+def telegram_spy(dashboard_module, monkeypatch):
+    """Replace ``_send_telegram_alert`` with a counting spy."""
+    _d = dashboard_module
+    calls = []
+    monkeypatch.setattr(_d, "_send_telegram_alert",
+                        lambda msg: calls.append(msg))
+    return _d, calls
+
+
+def test_oss_user_does_not_trigger_telegram_on_per_agent_warning(telegram_spy,
+                                                                  monkeypatch):
+    """Regression for #1168: OSS user with per-agent budget at 80%
+    must NOT fire Telegram dispatch (banner + history row are fine)."""
+    _d, calls = telegram_spy
+    # OSS = not Pro (no cm_ token, no cached plan).
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    _d._set_agent_budget("oss-warn", daily_limit_usd=10.0)
+    _add_cost(_d, "oss-warn", 8.0)  # 80%
+    _d._budget_check()
+
+    # Banner / history row still fires — limits are free, visualisation is free.
+    assert _count_alerts_for(_d, "oss-warn") >= 1
+    # Telegram dispatch is gated.
+    assert calls == [], (
+        "OSS user should not trigger Telegram on per-agent threshold "
+        f"(got {len(calls)} dispatch(es))"
+    )
+
+
+def test_oss_user_does_not_trigger_telegram_on_per_agent_critical(telegram_spy,
+                                                                   monkeypatch):
+    """Same gate at the 100% / critical tier — banner + auto-pause still
+    work (those are free), but Telegram fan-out is Pro-only."""
+    _d, calls = telegram_spy
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+    _d._set_budget_config({"auto_pause_enabled": True})
+    _d._set_agent_budget("oss-crit", daily_limit_usd=10.0)
+    _add_cost(_d, "oss-crit", 12.0)  # 120%
+    _d._budget_check()
+
+    assert _count_alerts_for(_d, "oss-crit") >= 1
+    # Auto-pause is a free cost-control feature, must still trigger.
+    assert _d._budget_paused is True
+    # Telegram dispatch is gated.
+    assert calls == []
+
+
+def test_pro_user_still_triggers_telegram_on_per_agent_warning(telegram_spy,
+                                                                monkeypatch):
+    """Cloud-Pro user gets the same alert PLUS Telegram dispatch."""
+    _d, calls = telegram_spy
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    _d._set_agent_budget("pro-warn", daily_limit_usd=10.0)
+    _add_cost(_d, "pro-warn", 8.0)
+    _d._budget_check()
+
+    assert _count_alerts_for(_d, "pro-warn") >= 1
+    assert len(calls) >= 1, (
+        "Cloud-Pro user should receive Telegram dispatch on per-agent threshold"
+    )
+
+
+def test_api_budget_root_surfaces_pro_dispatch_flag(dashboard_module,
+                                                     monkeypatch):
+    """``/api/budget`` advertises ``pro_dispatch_enabled`` so the UI can
+    render the inline upsell instead of pretending alerts will fire."""
+    _d = dashboard_module
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+    client = _make_client(_d)
+    r = client.get("/api/budget")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "pro_dispatch_enabled" in body
+    assert body["pro_dispatch_enabled"] is False
+
+    # Flip to Pro and confirm the flag propagates.
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+    r2 = client.get("/api/budget")
+    assert r2.get_json()["pro_dispatch_enabled"] is True


### PR DESCRIPTION
Closes #1168.

## Why

Post-merge product review of PR #1152 flagged that per-agent budgets + tiered 80%/100% Telegram alerts shipped free on OSS, leaking the Cloud-Pro Alerts Center funnel. Per `project_alerts_pro_feature.md`, the Alerts Center is Cloud-Pro (OSS sees a paywall, Cloud-Free sees an upgrade CTA), so per-agent **dispatch** to Telegram is the wrong feature to give away. Per-agent **limits** are correct to keep free because they are pure cost-control / table stakes.

Picked option 2 from the issue: keep limits + visualisation in OSS, gate the Telegram fan-out behind `is_pro()`.

## What changed

- `dashboard.py`: new `_is_pro_user()` helper. Fail-closed: requires both a `cm_` cloud token on disk AND a cached plan tier of `cloud_pro` / `pro` / `trial`. Anything else (no token, no cache, plan=`free`, exception) returns False so we never accidentally fire paid dispatch on a free node.
- `dashboard.py` `_budget_check_for_agent`: alert channels now resolve to `["banner", "telegram"]` only when `_is_pro_user()` is True; otherwise just `["banner"]`. Banner + alert-history row + auto-pause all still work for OSS users (those are free cost-control surfaces).
- `routes/alerts.py` `/api/budget`: response now includes `pro_dispatch_enabled` so the UI knows whether to show the upsell.
- `dashboard.py` per-agent panel JS: when `pro_dispatch_enabled === false`, renders an inline upsell row above the table:
  > **Limits are free.** Telegram alerts on per-agent budgets are a Cloud Pro feature. [Upgrade to send alerts](https://app.clawmetry.com/upgrade)

  Copy is plain-language for non-technical users (per `feedback_simple_ui_for_nontechnical.md`) and contains no em-dashes (per `feedback_no_em_dashes_in_user_facing_copy.md`).

## Before / after

**Before:** OSS user sets a $10 daily limit on agent `main`, agent crosses 80% at $8 spend. Telegram fires `[ClawMetry Alert] Budget warning: agent 'main' daily spend $8.00 is 80% of $10.00 limit`. Free, unlimited, on every OSS install.

**After:** Same scenario on OSS / Cloud-Free. Banner still appears, alert-history row still written, auto-pause still triggers if enabled. Telegram is silent. UI shows the upsell row pointing to the upgrade page. Cloud-Pro user sees no upsell and gets the Telegram message exactly as before.

## Tests

`tests/test_per_agent_budget.py` adds 4 regression tests:

- `test_oss_user_does_not_trigger_telegram_on_per_agent_warning` -- monkeypatches `_is_pro_user -> False`, sets a per-agent budget, hits 80%, asserts the banner row was written but the Telegram spy received zero calls.
- `test_oss_user_does_not_trigger_telegram_on_per_agent_critical` -- same gate at 100% / critical with auto-pause enabled. Asserts auto-pause still fires (free) but Telegram is silent.
- `test_pro_user_still_triggers_telegram_on_per_agent_warning` -- monkeypatches `_is_pro_user -> True`, asserts Telegram dispatch fires (regression guard for over-zealous gating).
- `test_api_budget_root_surfaces_pro_dispatch_flag` -- asserts `/api/budget` returns `pro_dispatch_enabled: false` for OSS, `true` for Pro.

## Test plan

- [x] `python3 -m pytest tests/test_per_agent_budget.py -q` -- 19 passed (15 existing + 4 new)
- [x] `python3 -c "import dashboard; import routes.alerts"` -- clean
- [x] Diff size: 184 LOC across 3 files (under the 300-LOC cap)
- [ ] Manual: open Budget modal -> Per-Agent tab on an OSS install. Expect upsell row above the table. Cross 80% on a per-agent budget. Expect banner appears, no Telegram fires.
- [ ] Manual: same flow on a Cloud-Pro paired install. Expect no upsell row, Telegram fires.

## Notes for reviewer

- `_is_pro_user()` reads the plan from `_cloud_plan_cache` populated by the cloud-CTA status route. If that cache is empty (e.g. dashboard just booted, status hasn't polled yet), the helper returns False. This means a paired Pro user might briefly see the upsell on first paint before the cache hydrates. Acceptable trade-off because the inverse (briefly leaking paid dispatch) is the funnel leakage we're fixing.
- Pre-existing `tests/test_alert_rules_local_store.py::test_api_alerts_rules_fast_path_serves_local_store` failure is unrelated -- reproduces on `main` without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)