### PR TITLE
[RELEASE] chore: drop /api/insights/config 404 allowlist (cloud on 0.12.236+)

### DIFF
--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -82,19 +82,7 @@ function isHarmlessConsoleError(e) {
     // shape: new OSS endpoint, returns 404 on cloud. Filtering
     // them here matches the existing /api/skills 410 pattern.
     (/\/api\/diagnostics/.test(e) && /\b410\b/.test(e)) ||
-    (/\/api\/config-diagnostics/.test(e) && /\b404\b/.test(e)) ||
-    // Temporarily restored. PR #1437 changed /api/insights/config to return
-    // 200 {enabled: false} instead of 404 and removed this allowlist entry
-    // — but the contract spec runs against PROD (https://app.clawmetry.com),
-    // which is still pinned to a clawmetry version BEFORE #1437. So the
-    // pre-publish gate sees the old 404 and blocks #1437 from publishing.
-    // Classic chicken-and-egg: the OSS fix can't ship until cloud has it,
-    // and cloud can't get it until OSS ships.
-    //
-    // Keep this allowlist entry until cloud Dockerfile is pinned to
-    // clawmetry>=0.12.236 (the version that includes #1437's server-side
-    // fix). After that, remove this and PR #1435's stopgap in one go.
-    (/\/api\/insights\/config/.test(e) && /\b404\b/.test(e))
+    (/\/api\/config-diagnostics/.test(e) && /\b404\b/.test(e))
   );
 }
 


### PR DESCRIPTION
## Summary
- Removes the temporary `/api/insights/config` 404 allowlist entry from `tests/e2e/cloud-contract.mjs`
- Cloud is now serving `0.12.236` — the endpoint returns 401 (auth required) rather than 404 (not found), confirming PR #1437's server-side fix is live
- Closes the chicken-and-egg loop opened by the cross-version skew window

## Background
PR #1437 changed `/api/insights/config` to return `200 {enabled:false}` instead of `404`, and removed this allowlist entry. The pre-publish gate runs against PROD though, which at the time was still pinned to a version BEFORE #1437 — so the gate kept blocking. PR #1438 restored the allowlist temporarily; cloud bumped to `0.12.236` shortly after; this PR completes the cycle.

## Test plan
- [x] Verified PROD returns 401 (not 404) on `curl https://app.clawmetry.com/api/insights/config`
- [x] Pre-publish gate should now stay green without the allowlist
- [ ] `[RELEASE]` prefix triggers PyPI auto-publish on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)