### PR TITLE
feat(flow): cap Flow Runs to 24h for OSS, gate full retention behind Cloud-Pro (closes #1173)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8626,9 +8626,11 @@ function loadFlowRuns() {
     .then(function(r) { return r.json(); })
     .then(function(d) {
       var runs = (d && d.runs) || [];
+      var cappedAt24h = !!(d && d.capped_at_24h);
       if (countEl) countEl.textContent = runs.length + ' run' + (runs.length === 1 ? '' : 's');
       if (!runs.length) {
-        tbody.innerHTML = '<tr><td colspan="8" style="padding:24px;text-align:center;color:var(--text-muted);font-size:12px;">No historical flow runs yet — the live Flow view will populate this once a session completes.</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="8" style="padding:24px;text-align:center;color:var(--text-muted);font-size:12px;">No historical flow runs yet. The live Flow view will populate this once a session completes.</td></tr>';
+        _renderFlowRunsCap(cappedAt24h);
         return;
       }
       var rows = runs.map(function(r) {
@@ -8654,10 +8656,38 @@ function loadFlowRuns() {
           + '</tr>';
       }).join('');
       tbody.innerHTML = rows;
+      _renderFlowRunsCap(cappedAt24h);
     })
     .catch(function() {
       tbody.innerHTML = '<tr><td colspan="8" style="padding:24px;text-align:center;color:#ef4444;font-size:12px;">Failed to load flow runs.</td></tr>';
     });
+}
+
+// Render a small CTA row below the Flow Runs table when the OSS retention
+// cap kicked in (issue #1173). Lives in its own footer container so the
+// table tbody stays purely tabular.
+function _renderFlowRunsCap(capped) {
+  var foot = document.getElementById('flow-runs-cap-cta');
+  if (!foot) {
+    var tbl = document.getElementById('flow-runs-tbody');
+    if (!tbl || !tbl.parentElement) return;
+    foot = document.createElement('div');
+    foot.id = 'flow-runs-cap-cta';
+    foot.style.cssText = 'padding:10px 14px;font-size:12px;color:var(--text-muted);border-top:1px solid var(--border-secondary,#2a2a4a);display:none;';
+    var host = tbl.closest('table');
+    if (host && host.parentElement) {
+      host.parentElement.appendChild(foot);
+    } else {
+      tbl.parentElement.appendChild(foot);
+    }
+  }
+  if (capped) {
+    foot.style.display = '';
+    foot.innerHTML = 'Showing the last 24 hours. <a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener" style="color:var(--accent,#7c5cff);font-weight:600;">Upgrade to Cloud-Pro for unlimited history</a>';
+  } else {
+    foot.style.display = 'none';
+    foot.innerHTML = '';
+  }
 }
 
 function showFlowRunDetail(sid) {

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -29,7 +29,7 @@ import os
 import select
 import subprocess
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
@@ -328,9 +328,15 @@ def api_flow_runs():
       ``since``  — ISO timestamp lower-bound on event ts
       ``until``  — ISO timestamp upper-bound
 
-    Returns ``{runs: [...], _source: "local_store"|"empty"}``. Never raises
-    — on any store failure we return an empty list with the legacy tag so
-    the Flow tab degrades gracefully.
+    Returns ``{runs: [...], _source: "local_store"|"empty",
+    capped_at_24h: bool}``. Never raises — on any store failure we return
+    an empty list with the legacy tag so the Flow tab degrades gracefully.
+
+    Retention gating (issue #1173): OSS / Cloud-Free users are capped to
+    the last 24 hours of ``started_at``. Cloud-Pro users (validated by
+    ``dashboard._is_pro_user``) get unlimited history. When the cap is
+    enforced we set ``capped_at_24h=true`` so the UI can surface the
+    Cloud-Pro upgrade CTA.
     """
     try:
         limit_raw = int(request.args.get("limit", 30))
@@ -340,6 +346,25 @@ def api_flow_runs():
     since = request.args.get("since") or None
     until = request.args.get("until") or None
     agent_id = request.args.get("agent_id") or None
+
+    # OSS retention cap (issue #1173). Pro users bypass the cap entirely;
+    # everyone else gets clamped to last 24h of started_at.
+    capped_at_24h = False
+    try:
+        import dashboard as _d
+        is_pro = bool(_d._is_pro_user())
+    except Exception:
+        is_pro = False
+    if not is_pro:
+        cap_iso = (
+            datetime.now(timezone.utc) - timedelta(hours=24)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # If caller asked for a window older than the cap (or no `since`
+        # at all), clamp to the cap and flag the response so the UI can
+        # render the upgrade CTA.
+        if not since or since < cap_iso:
+            since = cap_iso
+            capped_at_24h = True
 
     runs: list = []
     source = "empty"
@@ -355,7 +380,12 @@ def api_flow_runs():
         runs = []
         source = "empty"
 
-    return jsonify({"runs": runs, "count": len(runs), "_source": source})
+    return jsonify({
+        "runs": runs,
+        "count": len(runs),
+        "_source": source,
+        "capped_at_24h": capped_at_24h,
+    })
 
 
 @bp_logs.route("/api/logs-stream")

--- a/tests/test_flow_runs_endpoint.py
+++ b/tests/test_flow_runs_endpoint.py
@@ -38,6 +38,13 @@ def app(tmp_path, monkeypatch):
     import routes.infra as infra_mod
     importlib.reload(infra_mod)
 
+    # The pre-#1173 aggregation tests seed historical timestamps that fall
+    # outside the OSS 24h retention cap. Default the fixture to a Pro user
+    # so those assertions still pass; tests that exercise the cap itself
+    # monkeypatch ``_is_pro_user`` explicitly.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
     a = Flask(__name__)
     a.register_blueprint(infra_mod.bp_logs)
     yield a, ls
@@ -210,3 +217,62 @@ def test_flow_runs_empty_store_returns_empty_list(app):
     assert body["runs"] == []
     assert body["count"] == 0
     assert body["_source"] == "empty"
+
+
+# ── Retention cap (issue #1173) ─────────────────────────────────────────────
+#
+# OSS / Cloud-Free users get capped to the last 24h of started_at; Cloud-Pro
+# users (gated by ``dashboard._is_pro_user``) bypass the cap. The response
+# always carries a ``capped_at_24h`` boolean so the UI can render the upgrade
+# CTA when the cap kicks in.
+
+
+def _seed_old_and_recent(store):
+    """One ancient session (8 days old) + one fresh session (now)."""
+    import datetime as _dt
+    now = _dt.datetime.now(_dt.timezone.utc)
+    old_ts = (now - _dt.timedelta(days=8)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    new_ts = (now - _dt.timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    store.ingest({
+        "id": "old-1", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-old", "event_type": "message",
+        "ts": old_ts, "data": {"role": "user"},
+        "cost_usd": 0.10, "token_count": 100, "model": "claude-opus-4-7",
+    })
+    store.ingest({
+        "id": "new-1", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-new", "event_type": "message",
+        "ts": new_ts, "data": {"role": "user"},
+        "cost_usd": 0.05, "token_count": 50, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+
+def test_flow_runs_oss_capped_to_24h(app, monkeypatch):
+    a, ls = app
+    _seed_old_and_recent(ls.get_store())
+    # Force OSS (non-Pro) path.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    r = a.test_client().get("/api/flow/runs?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body["capped_at_24h"] is True
+    sids = {row["session_id"] for row in body["runs"]}
+    # Old session (8 days back) must be excluded; only the fresh one shows.
+    assert sids == {"sess-new"}
+
+
+def test_flow_runs_pro_bypasses_cap(app, monkeypatch):
+    a, ls = app
+    _seed_old_and_recent(ls.get_store())
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    r = a.test_client().get("/api/flow/runs?limit=10")
+    body = r.get_json()
+    assert body["capped_at_24h"] is False
+    sids = {row["session_id"] for row in body["runs"]}
+    # Pro users see the full history including the 8-day-old run.
+    assert sids == {"sess-old", "sess-new"}


### PR DESCRIPTION
## Summary

- OSS / Cloud-Free users now see only the last 24 hours of flow runs in `Flow > Runs`. Cloud-Pro users (validated via `_is_pro_user()` from PR #1440) keep unlimited history.
- Response carries `capped_at_24h: true` when the cap kicks in; the table footer renders an "Upgrade to Cloud-Pro for unlimited history" CTA linking to https://app.clawmetry.com/upgrade.
- Restores the Cloud-Pro retention upsell that PR #1157 leaked when `/api/flow/runs` shipped with no upper bound on `since`. DuckDB retains forever locally, so OSS users were getting unlimited historical flow-run retention for free, killing the hosted-history paywall.

## Gating contract

- `_is_pro_user()` is fail-closed: returns True only when both (a) a `cm_` cloud token is on disk and (b) the cached plan is `cloud_pro` / `pro` / `trial`. Reuses the existing helper, no new gating mechanism.
- If the request hits the cap, the response includes `capped_at_24h: true` so the UI can render the upgrade row. Otherwise the flag is `false`.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_flow_runs_endpoint.py -q` — 8/8 pass
- [x] `python3 -m pytest tests/ -q -k "flow or usage"` — 57 pass, 2 pre-existing unrelated failures (telegram E2E + real-binary E2E, both fail on origin/main as well)
- [x] New tests: OSS caller sees `capped_at_24h=true` and the 8-day-old session is filtered out; Pro caller sees `capped_at_24h=false` and gets the full history.
- [x] Diff is 132 LOC across 3 files (under the 300-LOC cap).
- [x] No em-dashes / double-dashes in any new user-facing copy.
- [x] Existing aggregation tests preserved by defaulting the fixture to a Pro user (their seeded timestamps fall outside the 24h window today).

## Follow-up (noted, separate audit issue)

The issue body asked us to "Confirm the same cap applies to Sessions list and any other surfaces that read from `events` with a time filter." That's a broader audit scoped intentionally outside this PR. Surfaces to walk in a follow-up:

- `/api/sessions` and its DuckDB-backed query paths
- `/api/usage` historical reads (token / cost analytics)
- `/api/brain-history` paginated reasoning events
- `/api/local-events` and any other thin local-store passthroughs

Closes #1173.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>