### PR TITLE
fix(usage): cost-comparison no longer 2× counts v3 sibling pairs (MOAT audit follow-up)

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -608,7 +608,19 @@ def _try_local_store_cost_comparison():
     """Fast path for /api/usage/cost-comparison. Sums actual tokens/cost
     over the past 30 days from the local store, then projects costs against
     a fixed alternatives table. Mirrors ``dashboard._build_cost_comparison``
-    output shape exactly."""
+    output shape exactly.
+
+    MOAT 2026-05-16: the old implementation blindly summed ``token_count``
+    across every event row. On real v3 installs the dual-writer pattern
+    (``assistant`` + sibling ``model.completed``) double-counts every
+    billable turn, inflating ``actual.tokens`` + ``actual.cost_usd`` ~2×
+    and making the "savings vs alternative" dollar amounts look twice as
+    big as truth. We now skip the slimmer ``model.completed`` row when an
+    ``assistant``/``message`` sibling exists for the same
+    (session_id, ts ±1 s) bucket — matches the dedup approach in
+    ``query_daily_usage_splits``. Non-billable-turn rows (tool_call etc.)
+    keep their tokens since they don't have a sibling.
+    """
     store = _ls_get_store()
     if store is None:
         return None
@@ -623,14 +635,54 @@ def _try_local_store_cost_comparison():
     cutoff = datetime.now() - timedelta(days=30)
     cutoff_iso = cutoff.strftime("%Y-%m-%d")
 
-    actual_tokens = 0
-    actual_cost = 0.0
-    model_token_map: dict = {}
-    saw_any = False
+    # Sibling-dedup: per (session_id, ts_sec, ±1 s) bucket, keep only the
+    # richest-envelope row. `assistant`/`message` outrank `model.completed`
+    # for the same turn (writer race emits both ~100 ms apart). Two passes
+    # because `query_events` returns DESC and we'd otherwise count both when
+    # the slim sibling lands first.
+    _RICHER = {"assistant": 2, "message": 2, "model.completed": 1}
+
+    def _ts_sec(ts_str: str) -> int:
+        if not ts_str:
+            return 0
+        try:
+            return int(datetime.fromisoformat(
+                ts_str.replace("Z", "+00:00")).timestamp())
+        except Exception:
+            return 0
+
+    # Pass 1: compute richest rank per (sid, sec) bucket across the ±1 s
+    # writer-race window.
+    bucket_max: dict = {}
+    in_window: list = []
     for ev in evs:
         ts = ev.get("ts", "") or ""
         if ts < cutoff_iso:
             continue
+        in_window.append(ev)
+        et = (ev.get("event_type") or "").strip()
+        if et not in _RICHER:
+            continue
+        sid_v = ev.get("session_id") or ""
+        sec = _ts_sec(ts)
+        rank = _RICHER[et]
+        for key in ((sid_v, sec - 1), (sid_v, sec), (sid_v, sec + 1)):
+            if bucket_max.get(key, 0) < rank:
+                bucket_max[key] = rank
+
+    # Pass 2: count tokens, skipping any sibling whose rank is strictly less
+    # than the richest in its (sid, sec±1) bucket.
+    actual_tokens = 0
+    actual_cost = 0.0
+    model_token_map: dict = {}
+    saw_any = False
+    for ev in in_window:
+        et = (ev.get("event_type") or "").strip()
+        if et in _RICHER:
+            sid_v = ev.get("session_id") or ""
+            sec = _ts_sec(ev.get("ts") or "")
+            if bucket_max.get((sid_v, sec), 0) > _RICHER[et]:
+                continue
         saw_any = True
         tok = int(ev.get("token_count") or 0)
         actual_tokens += tok

--- a/tests/test_usage_local_store.py
+++ b/tests/test_usage_local_store.py
@@ -367,6 +367,40 @@ def test_cost_comparison_legacy_when_env_unset(legacy_path_app):
     assert body.get("_source") != "local_store"
 
 
+def test_cost_comparison_does_not_double_count_v3_sibling_pairs(fast_path_app):
+    """Regression: on real v3 installs every billable turn emits both an
+    ``assistant`` row AND a slim ``model.completed`` sibling ~100 ms later.
+    The cost-comparison fast path used to sum ``token_count`` across every
+    event row, doubling actual tokens + cost on real data and making the
+    "savings vs alternative" $ amounts look 2× as good as truth. We now
+    skip the slimmer sibling when the assistant exists for the same
+    (session_id, ts ±1 s) bucket.
+    """
+    app, ls, _u = fast_path_app
+    store = ls.get_store()
+    # One LLM turn within the 30-day window: 100 in + 50 out = 150 tokens.
+    # Both writers race-emit so two rows land at the same ts.
+    ts_iso = _iso(time.time() - 86400)
+    _ingest_v3_assistant(
+        store, sid="sess-dup", ts=ts_iso, ev_id="ev-assistant",
+        input_tokens=100, output_tokens=50, cache_read=0, cache_write=0,
+    )
+    _ingest_v3_model_completed(
+        store, sid="sess-dup", ts=ts_iso, ev_id="ev-modelcompleted",
+        input_tokens=100, output_tokens=50,
+    )
+    _wait_flush(store)
+
+    body = app.test_client().get("/api/usage/cost-comparison").get_json()
+    assert body["_source"] == "local_store"
+    # The pair represents ONE LLM turn = 150 tokens. Anything > 150 means
+    # the sibling-dedup regressed and we're double-counting again.
+    assert body["actual"]["tokens"] == 150, (
+        f"cost-comparison double-counted sibling pair: "
+        f"got {body['actual']['tokens']}, expected 150 (one deduped turn)"
+    )
+
+
 # ── /api/model-attribution ─────────────────────────────────────────────────
 
 def test_model_attribution_fast_path(fast_path_app):


### PR DESCRIPTION
## Summary

Audit follow-up to PR #1444 (the daily-tokens dedup fix). The cost-comparison fast path had the same shape of bug: it summed `token_count` across every event without dedup. On real OpenClaw v3 installs the dual-writer pattern emits BOTH an `assistant` row AND a slim `model.completed` sibling ~100 ms apart for every LLM turn, both carrying the same `token_count` value. Result: `actual.tokens` + `actual.cost_usd` displayed 2× reality, and the "savings vs alternative model" $ amounts looked twice as good as they actually were.

## Fix

Mirrors the dedup approach already in `query_daily_usage_splits`:

1. **Pass 1** — bucket each `(session_id, ts_sec)` and record the richest envelope rank seen across a ±1 s writer-race window. `assistant`/`message` rank 2; `model.completed` rank 1.
2. **Pass 2** — count tokens once, skipping any row whose envelope rank is strictly less than its bucket max.

Non-billable-turn rows (`tool_call`, etc.) fall through untouched — they have no sibling to dedup against and their token contributions remain.

## Verification

- New regression test: synthesize an assistant + model.completed pair at the same ts, assert `actual.tokens == 150` (one deduped turn), not 300.
- `pytest tests/test_moat_send_message_e2e.py tests/test_usage_local_store.py -q` → **31 passed** (was 30, +1 from new test).
- `pytest tests/ -k usage -q` → **40 passed**.

## MOAT context

Found by the MOAT 11:26Z audit fire (following the dedupe-pattern memory note saved after PR #1444). Two surfaces flagged in that note — this is one; the other (`routes/sessions.py` v3 session-tools bypass) is a bigger refactor and gets a separate follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)