### PR TITLE
fix(sessions): /api/session-tools surfaces v3 standalone tool_call rows (MOAT audit follow-up)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -675,15 +675,65 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
     calls: dict = {}
     result_by_id: dict = {}
     turn_index = 0
-    saw_message = False
+    saw_any = False
     for ev in rows:
-        if ev.get("event_type") != "message":
-            continue
-        saw_message = True
+        et = ev.get("event_type")
         data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        ev_ts_ms = _parse_ts(
+            (data.get("timestamp") if isinstance(data, dict) else None)
+            or ev.get("ts")
+        )
+
+        # v3 standalone tool_call row: self-contained call+result pair.
+        # Real OpenClaw v3 emits these instead of the legacy nested
+        # ``data.message.content[].toolCall`` blocks. Synthesize a tcid
+        # from the event id so the pairing logic below treats it as
+        # an immediately-resolved call.
+        if et == "tool_call":
+            saw_any = True
+            turn_index += 1
+            tcid = ev.get("id") or f"tc-{ev_ts_ms}-{len(calls)}"
+            tool_name = ""
+            args_val = None
+            result_val = None
+            is_error = False
+            if isinstance(data, dict):
+                tool_name = (data.get("tool") or data.get("tool_name")
+                             or data.get("name") or "")
+                args_val = (data.get("args") if data.get("args") is not None
+                            else data.get("arguments"))
+                result_val = data.get("result")
+                is_error = bool(data.get("is_error") or data.get("isError")
+                                or data.get("error"))
+            calls[tcid] = {
+                "tool_call_id":     tcid,
+                "tool_name":        tool_name,
+                "arguments":        _truncate(args_val, args_chars),
+                "start_ms":         ev_ts_ms,
+                "turn_index":       turn_index,
+                "model":            ev.get("model") or "",
+                "provider":         (data.get("provider") if isinstance(data, dict) else "") or "",
+                "message_cost_usd": float(ev.get("cost_usd") or 0.0),
+            }
+            if result_val is not None or is_error:
+                try:
+                    rs = len(json.dumps(result_val, separators=(",", ":")))
+                except Exception:
+                    rs = len(str(result_val or ""))
+                result_by_id[tcid] = {
+                    "end_ms":         ev_ts_ms,
+                    "is_error":       is_error,
+                    "result_size":    rs,
+                    "result_preview": _truncate(result_val, result_chars),
+                }
+            continue
+
+        # Legacy: nested toolCall / toolResult inside message blobs.
+        if et != "message":
+            continue
+        saw_any = True
         msg = data.get("message") if isinstance(data.get("message"), dict) else {}
         role = msg.get("role", "")
-        ev_ts_ms = _parse_ts(data.get("timestamp") or ev.get("ts"))
         if role == "assistant":
             turn_index += 1
             content = msg.get("content") or []
@@ -721,7 +771,7 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
                 "result_size":    len(json.dumps(details)) if details is not None else 0,
                 "result_preview": _truncate(details, result_chars),
             }
-    if not saw_message:
+    if not saw_any:
         return None
 
     tools: list = []

--- a/tests/test_moat_send_message_e2e.py
+++ b/tests/test_moat_send_message_e2e.py
@@ -483,11 +483,7 @@ def test_tool_call_event_surfaces_everywhere(env):
 
     # 4) /api/local/transcript/<sid> — session transcript via local-query
     #    relay shape. Reads the events table directly so it works on any
-    #    event_type. (We deliberately skip /api/session-tools here: that
-    #    endpoint only fires on legacy ``event_type=='message'`` rows with
-    #    nested ``data.message.content[].toolCall`` blocks — neither the v3
-    #    parser NOR the synthetic shape used here produce that combination.
-    #    See routes/sessions.py:_try_local_store_session_tools.)
+    #    event_type.
     r = client.get(f"/api/local/transcript/{SESSION_ID}?limit=100")
     assert r.status_code == 200, r.get_data(as_text=True)
     body = r.get_json()
@@ -500,6 +496,27 @@ def test_tool_call_event_surfaces_everywhere(env):
     rendered = json.dumps(body)
     assert "Bash" in rendered, "Bash tool call missing from /api/local/transcript"
     assert "Read" in rendered, "Read tool call missing from /api/local/transcript"
+
+    # 4b) /api/session-tools — session detail page's "Tools" panel.
+    #     v3 standalone ``event_type='tool_call'`` rows must surface here.
+    #     Before the 2026-05-16 fix this endpoint walked only legacy
+    #     ``event_type='message'`` rows with nested
+    #     ``data.message.content[].toolCall`` blocks, returning 0 tools for
+    #     real v3 installs. Now should return both Bash + Read.
+    r = client.get(f"/api/session-tools?session_id={SESSION_ID}&include_unpaired=1")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"session-tools fast path didn't engage; _source={body.get('_source')!r}"
+    )
+    tool_names = sorted({t.get("tool_name") for t in body.get("tools", [])})
+    assert tool_names == ["Bash", "Read"], (
+        f"/api/session-tools: expected ['Bash', 'Read'] tool names, got {tool_names}"
+    )
+    assert body.get("stats", {}).get("total_calls") == EXPECTED_TOOL_CALLS, (
+        f"/api/session-tools: got {body.get('stats', {}).get('total_calls')} "
+        f"total_calls, expected {EXPECTED_TOOL_CALLS}"
+    )
 
     # 5) /api/usage — token + cost analytics. Costs we injected:
     #    0.0010 + 0.0008 + 0.005 = 0.0068, tokens: 42+33+150 = 225.


### PR DESCRIPTION
## Summary

The 3rd bypass surface from the dedupe-pattern audit (see `feedback_usage_dedupe_pattern.md`). On real OpenClaw v3 installs, tool invocations land in DuckDB as standalone `event_type='tool_call'` rows with the call+result self-contained in the `data` blob. But `/api/session-tools` only walked legacy `event_type='message'` rows looking for nested `data.message.content[].toolCall` blocks — so the session-detail "Tools" panel silently returned **0 tools** for every v3 session.

User impact: open any session-detail page on a real install, see no tools listed even though the agent ran 20+ of them.

## Fix

Extend the fast path to also accept `event_type='tool_call'` rows as self-contained call+result pairs:

- Synthesize a `tool_call_id` from the event id
- Extract tool name from `data.tool` / args from `data.args` / result from `data.result`
- Tolerate `is_error` / `isError` / `error` flags from various daemon writers
- Legacy nested-toolCall parsing preserved so older sessions still work

## Verification

The MOAT verifier (`test_moat_send_message_e2e.py`) used to deliberately skip `/api/session-tools` with a comment explaining the gap:

> (We deliberately skip /api/session-tools here: that endpoint only fires on legacy `event_type=='message'` rows ...)

That comment is now removed and replaced with a hard assertion:

```python
assert tool_names == ["Bash", "Read"]
assert body.get("stats", {}).get("total_calls") == EXPECTED_TOOL_CALLS  # 2
```

- `pytest tests/test_moat_send_message_e2e.py -q` → **3 passed** (was 3 passed before, but #2 was a weaker assertion that skipped this endpoint).

## Out of scope

The pre-existing `test_session_tools_fast_path` in `test_duckdb_coverage_phase3_2026_05_13.py` fails on both `main` and this branch (daemon-discovery monkeypatch leak — unrelated). Separate cleanup PR.

## MOAT context

3rd of 3 dedupe-pattern surfaces flagged in this morning's audit:
- ✅ `/api/usage` daily-tokens (PR #1444 merged)
- ✅ `/api/usage/cost-comparison` sibling double-count (PR #1446 open)
- ✅ `/api/session-tools` v3 tool_call rows (this PR)

After these three the MOAT verifier covers every fast-path the synthetic verifier touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)