### PR TITLE
[RELEASE] fix(ux): shrink workspace-switcher to icon-only, rename tooltip closes #1171

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3964,10 +3964,9 @@ function clawmetryLogout(){
   <h1><a href="https://clawmetry.com" style="display:flex;align-items:center;gap:7px;text-decoration:none;color:inherit"><img src="/static/img/logo.svg" width="22" height="22" style="border-radius:4px;vertical-align:middle;flex-shrink:0" alt="ClawMetry"><span><span style="color:#ffffff">Claw</span><span style="color:#E5443A">Metry</span></span></a></h1>
   <span id="version-badge" class="version-badge" title="ClawMetry version">v{{ version }}</span>
   <div id="workspace-switcher" style="display:none;position:relative;margin-left:8px;">
-    <button id="workspace-switcher-btn" onclick="toggleWorkspaceSwitcher(event)" title="Switch OpenClaw workspace" style="background:transparent;color:inherit;border:1px solid rgba(255,255,255,0.15);border-radius:6px;padding:4px 10px;font-size:12px;font-weight:600;cursor:pointer;display:flex;align-items:center;gap:6px;">
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
-      <span id="workspace-switcher-label">default</span>
-      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+    <button id="workspace-switcher-btn" onclick="toggleWorkspaceSwitcher(event)" title="Switch profile (this machine)" style="background:var(--button-bg);color:var(--text-tertiary);border:none;border-radius:8px;padding:8px 12px;cursor:pointer;display:flex;align-items:center;box-shadow:var(--card-shadow);transition:all 0.15s;">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+      <span id="workspace-switcher-label" style="display:none">default</span>
     </button>
     <div id="workspace-switcher-menu" style="display:none;position:absolute;top:calc(100% + 6px);left:0;min-width:240px;max-height:320px;overflow-y:auto;background:var(--bg-card,#1c2333);border:1px solid var(--border-color,rgba(255,255,255,0.1));border-radius:8px;box-shadow:0 6px 18px rgba(0,0,0,0.35);z-index:200;padding:4px;"></div>
   </div>
@@ -10101,10 +10100,9 @@ DASHBOARD_HTML = r"""
   <h1><a href="https://clawmetry.com" style="display:flex;align-items:center;gap:7px;text-decoration:none;color:inherit"><img src="/static/img/logo.svg" width="22" height="22" style="border-radius:4px;vertical-align:middle;flex-shrink:0" alt="ClawMetry"><span><span style="color:#ffffff">Claw</span><span style="color:#E5443A">Metry</span></span></a></h1>
   <span id="version-badge" class="version-badge" title="ClawMetry version">v{{ version }}</span>
   <div id="workspace-switcher" style="display:none;position:relative;margin-left:8px;">
-    <button id="workspace-switcher-btn" onclick="toggleWorkspaceSwitcher(event)" title="Switch OpenClaw workspace" style="background:transparent;color:inherit;border:1px solid rgba(255,255,255,0.15);border-radius:6px;padding:4px 10px;font-size:12px;font-weight:600;cursor:pointer;display:flex;align-items:center;gap:6px;">
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
-      <span id="workspace-switcher-label">default</span>
-      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+    <button id="workspace-switcher-btn" onclick="toggleWorkspaceSwitcher(event)" title="Switch profile (this machine)" style="background:var(--button-bg);color:var(--text-tertiary);border:none;border-radius:8px;padding:8px 12px;cursor:pointer;display:flex;align-items:center;box-shadow:var(--card-shadow);transition:all 0.15s;">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+      <span id="workspace-switcher-label" style="display:none">default</span>
     </button>
     <div id="workspace-switcher-menu" style="display:none;position:absolute;top:calc(100% + 6px);left:0;min-width:240px;max-height:320px;overflow-y:auto;background:var(--bg-card,#1c2333);border:1px solid var(--border-color,rgba(255,255,255,0.1));border-radius:8px;box-shadow:0 6px 18px rgba(0,0,0,0.35);z-index:200;padding:4px;"></div>
   </div>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Reduces workspace-switcher button to icon-only (folder icon, no label, no chevron), matching the visual weight of the existing gear and bell icon controls
- Hides the `workspace-switcher-label` span (`display:none`) so JS can still update `textContent` without layout impact
- Renames button tooltip from "Switch OpenClaw workspace" → "Switch profile (this machine)" to disambiguate from Cloud-Pro multi-node fleet management
- Applied to both nav template occurrences in `dashboard.py` (lines ~3967 and ~10103)

## What this does NOT change

- No JS changes needed (`renderWorkspaceSwitcher` in `app.js` still updates the hidden span safely)
- DuckDB-first migration for `last_workspace` persistence is a separate multi-file concern; not in scope here
- Fleet tab Pro-gating is unaffected

## Test plan

- [ ] Start `make dev`, open dashboard with ≥2 OpenClaw workspaces configured
- [ ] Verify switcher renders as a single folder icon (no text label, no chevron) matching gear/bell visual weight
- [ ] Hover → tooltip reads "Switch profile (this machine)"
- [ ] Click → dropdown appears with workspace list; selecting one reloads dashboard on new workspace
- [ ] `workspace-switcher-label` span present in DOM but `display:none`
- [ ] Single-workspace installs: switcher remains hidden (existing JS behaviour unchanged)

closes #1171
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0157iTC49ccY5fubWz1dhzJy)_