### PR TITLE
feat(ci): API-latency smoke gate (sidecar daemon + dashboard, p50<500ms / p95<1500ms) (closes #1241)

### DIFF
--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -1,0 +1,124 @@
+name: API Latency Smoke
+
+# Issue #1241 — catches "fast in CI, broken in real two-process install"
+# regressions like PR #1235 (3 endpoints were 7-15s under the sync-daemon
+# + dashboard contention). Single-process CI never sees DuckDB lock fights.
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: "0 6 * * *"   # nightly PyPI-release run
+  workflow_dispatch:
+
+concurrency:
+  group: api-latency-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: ${{ matrix.source == 'pypi' && 'PyPI nightly' || 'PR build' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # PR + push runs the local-wheel slice only. Nightly schedule
+        # additionally exercises the published PyPI release.
+        source: ${{ github.event_name == 'schedule' && fromJSON('["wheel", "pypi"]') || fromJSON('["wheel"]') }}
+    env:
+      CLAWMETRY_TOKEN: ci-smoke-token
+      OPENCLAW_GATEWAY_TOKEN: ci-smoke-token
+      CLAWMETRY_LOCAL_STORE_PATH: ${{ github.workspace }}/.smoke/clawmetry.duckdb
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheel
+        if: matrix.source == 'wheel'
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+
+      - name: Install into isolated venv
+        run: |
+          python -m venv /tmp/vsmoke
+          /tmp/vsmoke/bin/pip install --upgrade pip
+          if [ "${{ matrix.source }}" = "pypi" ]; then
+            /tmp/vsmoke/bin/pip install --no-cache-dir clawmetry flask waitress cryptography duckdb requests
+          else
+            /tmp/vsmoke/bin/pip install dist/clawmetry-*.whl flask waitress cryptography duckdb requests
+          fi
+
+      - name: Write minimal daemon config
+        # The sync-daemon entry point refuses to start without an api_key,
+        # so we drop a fake one. Ingest URL points at a closed port so
+        # network POSTs fail-fast and don't hold up the loop — we only
+        # care about the daemon's local_query HTTP server here.
+        run: |
+          mkdir -p "$HOME/.clawmetry" .smoke
+          cat > "$HOME/.clawmetry/config.json" <<EOF
+          {
+            "node_id": "smoke-ci-node",
+            "api_key": "smoke-ci-fake",
+            "encryption_key": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            "ingest_url": "http://127.0.0.1:9"
+          }
+          EOF
+          chmod 600 "$HOME/.clawmetry/config.json"
+
+      - name: Seed realistic-shape DuckDB fixture (1k events / 200 hb / 50 mem / 5 sess)
+        run: /tmp/vsmoke/bin/python scripts/seed_smoke_duckdb.py
+
+      - name: Start sync daemon (writer) + dashboard (reader)
+        # Daemon owns the DuckDB lock and publishes its local-query port to
+        # ~/.clawmetry/local_query.json. Dashboard proxies through that for
+        # /api/local/* reads. Both running = the contention shape we test.
+        env:
+          CLAWMETRY_INGEST_URL: http://127.0.0.1:9
+        run: |
+          nohup /tmp/vsmoke/bin/python -m clawmetry sync --foreground \
+            > .smoke/daemon.log 2>&1 &
+          echo $! > .smoke/daemon.pid
+          for i in $(seq 1 30); do
+            [ -f "$HOME/.clawmetry/local_query.json" ] && { echo "daemon up after ${i}s"; break; }
+            sleep 1
+          done
+          if [ ! -f "$HOME/.clawmetry/local_query.json" ]; then
+            echo "::error::daemon never published local_query.json"
+            tail -100 .smoke/daemon.log; exit 1
+          fi
+          nohup /tmp/vsmoke/bin/clawmetry --port 8900 --no-debug \
+            > .smoke/dashboard.log 2>&1 &
+          echo $! > .smoke/dashboard.pid
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer $CLAWMETRY_TOKEN" \
+              http://localhost:8900/api/health > /dev/null && \
+              { echo "dashboard up after ${i}s"; break; }
+            sleep 1
+          done
+          curl -sf -H "Authorization: Bearer $CLAWMETRY_TOKEN" \
+            http://localhost:8900/api/health > /dev/null || {
+            echo "::error::dashboard /api/health never returned 200"
+            tail -100 .smoke/dashboard.log; exit 1; }
+
+      - name: Probe endpoints + assert p50/p95 budgets
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+        run: /tmp/vsmoke/bin/python scripts/api_latency_probe.py
+
+      - name: Tail logs on failure
+        if: failure()
+        run: |
+          echo "── daemon.log ──"; tail -200 .smoke/daemon.log || true
+          echo "── dashboard.log ──"; tail -200 .smoke/dashboard.log || true
+
+      - name: Stop background processes
+        if: always()
+        run: |
+          for f in .smoke/dashboard.pid .smoke/daemon.pid; do
+            [ -f "$f" ] && kill "$(cat "$f")" 2>/dev/null || true
+          done

--- a/scripts/api_latency_probe.py
+++ b/scripts/api_latency_probe.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Probe key dashboard endpoints; fail on p50/p95 budget breach (issue #1241).
+Runs each endpoint N times and asserts p50<500ms / p95<1500ms by default.
+Tunable via CLAWMETRY_SMOKE_{RUNS,P50_MS,P95_MS,TIMEOUT,SKIP} env vars."""
+
+from __future__ import annotations
+
+import os
+import statistics
+import sys
+import time
+from typing import Iterable
+
+import requests
+
+BASE_URL = os.environ.get("CLAWMETRY_URL", "http://localhost:8900").rstrip("/")
+TOKEN = os.environ.get("CLAWMETRY_TOKEN", "")
+RUNS = int(os.environ.get("CLAWMETRY_SMOKE_RUNS", "5"))
+P50_BUDGET_MS = float(os.environ.get("CLAWMETRY_SMOKE_P50_MS", "500"))
+P95_BUDGET_MS = float(os.environ.get("CLAWMETRY_SMOKE_P95_MS", "1500"))
+TIMEOUT_S = float(os.environ.get("CLAWMETRY_SMOKE_TIMEOUT", "10"))
+SKIP = {p.strip() for p in os.environ.get("CLAWMETRY_SMOKE_SKIP", "").split(",") if p.strip()}
+
+# Mirrors CLAUDE.md "Key API Endpoints". transcript id matches the seeded
+# session in scripts/seed_smoke_duckdb.py.
+ENDPOINTS: tuple[str, ...] = (
+    "/api/overview",
+    "/api/sessions",
+    "/api/subagents",
+    "/api/transcript/smoke-sess-000",
+    "/api/usage",
+    "/api/flow",
+    "/api/brain-history",
+    "/api/crons",
+    "/api/system-health",
+    "/api/nodes",
+    "/api/budget/status",
+    "/api/alerts/rules",
+    "/api/heartbeat-status",
+    "/api/memory-files",
+)
+
+
+def _percentile(samples: list[float], pct: float) -> float:
+    """Linear-interpolation percentile (matches numpy.percentile method=linear)."""
+    if not samples:
+        return float("nan")
+    s = sorted(samples)
+    if len(s) == 1:
+        return s[0]
+    k = (len(s) - 1) * (pct / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(s) - 1)
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+def _probe_one(session: requests.Session, path: str) -> tuple[list[float], int | None, str]:
+    samples, last_status, err = [], None, ""
+    url = f"{BASE_URL}{path}"
+    for _ in range(RUNS):
+        t0 = time.perf_counter()
+        try:
+            r = session.get(url, timeout=TIMEOUT_S)
+            last_status = r.status_code
+            _ = r.content  # drain body so timing includes serialisation
+        except requests.RequestException as e:
+            err = type(e).__name__
+        samples.append((time.perf_counter() - t0) * 1000)
+    return samples, last_status, err
+
+
+def run(endpoints: Iterable[str] = ENDPOINTS) -> int:
+    headers = {"Authorization": f"Bearer {TOKEN}"} if TOKEN else {}
+    session = requests.Session()
+    session.headers.update(headers)
+
+    print(f"probe target:  {BASE_URL}")
+    print(f"runs/endpoint: {RUNS}")
+    print(f"budgets:       p50<{P50_BUDGET_MS:.0f}ms, p95<{P95_BUDGET_MS:.0f}ms\n")
+    header = f"{'endpoint':<40} {'p50':>8} {'p95':>8} {'max':>8}  status  verdict"
+    print(header)
+    print("-" * len(header))
+
+    failures: list[str] = []
+    for path in endpoints:
+        if path in SKIP:
+            print(f"{path:<40} {'-':>8} {'-':>8} {'-':>8}  skip    SKIP")
+            continue
+        samples, status, err = _probe_one(session, path)
+        p50, p95, smax = _percentile(samples, 50), _percentile(samples, 95), max(samples)
+        verdict, breach_bits = "OK", []
+        # Network errors / 5xx are a hard fail — the endpoint is down, not slow.
+        if status is None or status >= 500:
+            verdict = "FAIL"
+            breach_bits.append(f"status={status or err or 'connerr'}")
+        if p50 > P50_BUDGET_MS:
+            verdict = "FAIL"
+            breach_bits.append(f"p50={p50:.0f}ms>{P50_BUDGET_MS:.0f}ms")
+        if p95 > P95_BUDGET_MS:
+            verdict = "FAIL"
+            breach_bits.append(f"p95={p95:.0f}ms>{P95_BUDGET_MS:.0f}ms")
+        print(f"{path:<40} {p50:>7.0f}ms {p95:>7.0f}ms {smax:>7.0f}ms"
+              f"  {status if status is not None else '---':>4}    {verdict}")
+        if verdict != "OK":
+            failures.append(f"{path}: " + ", ".join(breach_bits))
+
+    print()
+    if failures:
+        print(f"FAIL: {len(failures)} endpoint(s) breached the latency gate:")
+        for line in failures:
+            print(f"  - {line}")
+        return 1
+    print("PASS: all endpoints under p50/p95 budgets.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/scripts/seed_smoke_duckdb.py
+++ b/scripts/seed_smoke_duckdb.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Seed realistic-shape clawmetry.duckdb for the API-latency smoke gate
+(issue #1241). 1k events + 200 heartbeats + 50 memory blobs + 5 sessions
+spread across the last 7 days. Reads CLAWMETRY_LOCAL_STORE_PATH."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import random
+import sys
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Make ``clawmetry.local_store`` importable when running from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from clawmetry import local_store  # noqa: E402
+
+NODE = "smoke-ci-node"
+N_EVENTS, N_HB, N_MEM, N_SESS = 1000, 200, 50, 5
+MODELS = ["claude-sonnet-4-5", "claude-opus-4-5", "gpt-4o", "gpt-4o-mini"]
+ETYPES = ["message", "model.completed", "tool.invoked", "tool.completed", "reasoning"]
+TOOLS = ["bash", "edit", "read", "grep", "write", "glob"]
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def seed() -> None:
+    db_path = os.environ.get("CLAWMETRY_LOCAL_STORE_PATH", "")
+    if not db_path:
+        raise SystemExit("CLAWMETRY_LOCAL_STORE_PATH must be set.")
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    print(f"[seed] target db: {db_path}", flush=True)
+
+    store = local_store.get_store(read_only=False)
+    rng = random.Random(42)  # deterministic across runs
+    horizon = datetime.now(timezone.utc) - timedelta(days=7)
+    span = 7 * 24 * 3600
+
+    sids = [f"smoke-sess-{i:03d}" for i in range(N_SESS)]
+    for i, sid in enumerate(sids):
+        started = horizon + timedelta(hours=rng.uniform(0, 144))
+        store.ingest_session({
+            "session_id": sid, "node_id": NODE, "agent_id": "main",
+            "title": f"Smoke session {i}",
+            "started_at": _iso(started),
+            "last_active_at": _iso(started + timedelta(minutes=rng.randint(5, 90))),
+            "status": "active" if i == 0 else "ended",
+            "total_tokens": rng.randint(1000, 50000),
+            "cost_usd": round(rng.uniform(0.05, 4.5), 4),
+            "message_count": rng.randint(5, 80),
+        })
+
+    for i in range(N_EVENTS):
+        etype = rng.choice(ETYPES)
+        model = rng.choice(MODELS)
+        tokens = rng.randint(50, 4000)
+        store.ingest({
+            "id": f"smoke-evt-{uuid.uuid4().hex}",
+            "node_id": NODE, "agent_id": "main",
+            "session_id": rng.choice(sids),
+            "event_type": etype,
+            "ts": _iso(horizon + timedelta(seconds=rng.uniform(0, span))),
+            "data": {
+                "model": model,
+                "tool": rng.choice(TOOLS) if etype.startswith("tool.") else None,
+                "preview": f"smoke event #{i}",
+            },
+            "cost_usd": round(tokens * 3e-6 + rng.uniform(0, 0.01), 6),
+            "token_count": tokens, "model": model,
+        })
+
+    step = span / N_HB
+    for i in range(N_HB):
+        store.ingest_heartbeat({
+            "node_id": NODE,
+            "ts": _iso(horizon + timedelta(seconds=step * i + rng.uniform(-30, 30))),
+            "version": "0.12.237", "e2e": True,
+            "size_mb": round(rng.uniform(8, 120), 2),
+            "events_total": (i + 1) * 5,
+        })
+
+    for i in range(N_MEM):
+        body = (f"# memory-{i}\n\n" + ("lorem ipsum dolor sit amet " * 50)).encode()
+        store.ingest_memory_blob({
+            "agent_type": "openclaw", "agent_id": "main",
+            "path": f"~/.openclaw/memory/notes_{i:03d}.md",
+            "ts": _iso(horizon + timedelta(seconds=rng.uniform(0, span))),
+            "blob": body,
+            "sha256": hashlib.sha256(body + str(i).encode()).hexdigest(),
+            "size_bytes": len(body),
+        })
+
+    print(f"[seed] sessions={N_SESS} events={N_EVENTS} hb={N_HB} mem={N_MEM}", flush=True)
+
+    # Flush + drop writer so the daemon (different process) can grab the lock.
+    try:
+        store._flush_now()  # noqa: SLF001 — fixture tooling
+    except Exception:
+        pass
+    try:
+        store.stop(flush=True)
+    except TypeError:
+        store.stop()
+    except Exception:
+        pass
+    local_store._reset_singleton_for_tests()
+
+
+if __name__ == "__main__":
+    t0 = time.monotonic()
+    seed()
+    print(f"[seed] done in {time.monotonic() - t0:.1f}s", flush=True)


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/api-latency-smoke.yml` — spins up the sync daemon **and** the dashboard as separate processes (the real two-process shape every `pip install clawmetry` user runs), seeds a realistic DuckDB fixture, then probes the key endpoints from CLAUDE.md and asserts **p50 < 500ms, p95 < 1500ms**. Fails the build on any breach.
- Adds `scripts/seed_smoke_duckdb.py` — 1k events + 200 heartbeats + 50 memory blobs + 5 sessions across the last 7 days. Deterministic seed.
- Adds `scripts/api_latency_probe.py` — 5 samples / endpoint, stdlib-only linear-interpolation percentile, prints a verdict table, exits 1 on breach.
- Bonus nightly job: same workflow shape, but installs `pip install clawmetry` from PyPI instead of the local wheel — catches regressions caused by transitive dep upgrades or environment drift.

## Why P0 (from #1241)
PR #1235 fixed three endpoints that were **7-15s** under the standard install (daemon + dashboard, two processes alive). The bugs sat in main for months and only surfaced when external traffic arrived. Single-process CI never saw the DuckDB writer/reader lock fight, so the slow paths were invisible. This gate would have caught all three.

## Verification
Ran the full workflow locally against a seeded `clawmetry.duckdb` with the real `clawmetry sync` daemon as a sidecar:

```
endpoint                                      p50      p95      max  status  verdict
------------------------------------------------------------------------------------
/api/overview                                 63ms      80ms      84ms   200    OK
/api/sessions                                  9ms      11ms      12ms   200    OK
/api/subagents                                 3ms     221ms     275ms   200    OK
/api/transcript/smoke-sess-000                 5ms       6ms       6ms   200    OK
/api/usage                                    73ms     107ms     113ms   200    OK
/api/flow                                      1ms       2ms       2ms   200    OK
/api/brain-history                             9ms      10ms      10ms   200    OK
/api/crons                                   167ms     183ms     185ms   200    OK
/api/system-health                           178ms     210ms     213ms   200    OK
/api/nodes                                     2ms       3ms       3ms   200    OK
/api/budget/status                          7630ms    9531ms   10006ms   200    FAIL
/api/alerts/rules                              4ms       8ms       8ms   200    OK
/api/heartbeat-status                          5ms       7ms       7ms   200    OK
/api/memory-files                              5ms       5ms       5ms   200    OK
```

- Probe exits **1** when any endpoint breaches budgets (verified with `CLAWMETRY_SMOKE_P50_MS=0` artificial-slow test).
- Probe exits **0** when slow endpoint is skipped via `CLAWMETRY_SMOKE_SKIP=/api/budget/status`.

## Pre-existing slow path the gate caught locally
- **`/api/budget/status` — p50 ~7.6s, p95 ~9.5s, max 10s timeout**. This is exactly the failure mode #1241 was filed to prevent ("influencer arrives, dashboard is broken"). Worth a follow-up issue / daemon-proxy fix; not blocking on this PR since the gate is about catching such bugs going forward.

## Test plan
- [x] `python3 -m py_compile` both scripts
- [x] `yaml.safe_load` the workflow
- [x] Seed script creates a DuckDB readable by an independent process (counts: 1000 events / 5 sessions / 200 heartbeats / 50 memory blobs)
- [x] Probe runs end-to-end against `clawmetry sync` daemon + `clawmetry` dashboard
- [x] Probe exits 1 on real breach, 0 on pass, respects `CLAWMETRY_SMOKE_SKIP`
- [ ] Watch the first CI run on this PR; iterate if any unexpected pre-existing slow paths surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)