### PR TITLE
fix(advisor): dedupe v3 sibling pairs in per-session token + today_tokens rollup

### DIFF
--- a/routes/advisor.py
+++ b/routes/advisor.py
@@ -140,6 +140,45 @@ def _try_local_store_advisor_context(limit_events: int = MAX_CONTEXT_EVENTS) -> 
     today_str = time.strftime("%Y-%m-%d")
     today_tokens = 0
 
+    # Issue #1451: dedupe sibling-doubled billable turns before counting
+    # tokens. On real OpenClaw v3 installs each LLM turn emits BOTH an
+    # ``assistant`` and a sibling ``model.completed`` row ~100 ms apart,
+    # both stamped with the same ``token_count`` value. Without dedup
+    # per-session totals + today_tokens come out 2× reality and the
+    # advisor's recommendations are based on inflated numbers. Same
+    # 2-pass approach as routes/usage.py:_try_local_store_cost_comparison.
+    _RICHER = {"assistant": 2, "message": 2, "model.completed": 1}
+
+    def _ts_sec(ts_str: str) -> int:
+        if not ts_str or not isinstance(ts_str, str):
+            return 0
+        try:
+            from datetime import datetime as _dt
+            return int(_dt.fromisoformat(
+                ts_str.replace("Z", "+00:00")).timestamp())
+        except Exception:
+            return 0
+
+    _bucket_max: dict = {}
+    for _r in rows:
+        _et = (_r.get("event_type") or "").strip()
+        if _et not in _RICHER:
+            continue
+        _sid = _r.get("session_id") or ""
+        _sec = _ts_sec(_r.get("ts") or "")
+        _rank = _RICHER[_et]
+        for _key in ((_sid, _sec - 1), (_sid, _sec), (_sid, _sec + 1)):
+            if _bucket_max.get(_key, 0) < _rank:
+                _bucket_max[_key] = _rank
+
+    def _is_sibling_dup(_r) -> bool:
+        _et = (_r.get("event_type") or "").strip()
+        if _et not in _RICHER:
+            return False
+        _sid = _r.get("session_id") or ""
+        _sec = _ts_sec(_r.get("ts") or "")
+        return _bucket_max.get((_sid, _sec), 0) > _RICHER[_et]
+
     for r in rows:
         t = (r.get("ts") or "")[:19]
         typ = r.get("event_type") or "?"
@@ -161,6 +200,11 @@ def _try_local_store_advisor_context(limit_events: int = MAX_CONTEXT_EVENTS) -> 
         events.append(f"[{t}] {sid[:12]} {typ}: {detail}")
 
         sid_key = r.get("session_id") or ""
+        # Issue #1451: skip token + cost accumulation when this row is the
+        # slim sibling of a richer envelope we already counted. We still
+        # populate sessions_seen metadata (model, started_at) since those
+        # are tag-set not totals.
+        _is_dup = _is_sibling_dup(r)
         if sid_key:
             entry = sessions_seen.setdefault(sid_key, {
                 "session_id": sid_key[:8],
@@ -169,16 +213,17 @@ def _try_local_store_advisor_context(limit_events: int = MAX_CONTEXT_EVENTS) -> 
                 "cost_usd": 0.0,
                 "started_at": t,
             })
-            entry["tokens"] += int(r.get("token_count") or 0)
-            try:
-                entry["cost_usd"] = round(entry["cost_usd"] + float(r.get("cost_usd") or 0), 4)
-            except Exception:
-                pass
+            if not _is_dup:
+                entry["tokens"] += int(r.get("token_count") or 0)
+                try:
+                    entry["cost_usd"] = round(entry["cost_usd"] + float(r.get("cost_usd") or 0), 4)
+                except Exception:
+                    pass
             if r.get("model") and not entry["model"]:
                 entry["model"] = r["model"]
             if t and (not entry["started_at"] or t < entry["started_at"]):
                 entry["started_at"] = t
-        if t.startswith(today_str):
+        if t.startswith(today_str) and not _is_dup:
             today_tokens += int(r.get("token_count") or 0)
 
     return {


### PR DESCRIPTION
## Summary

4th dedupe-pattern bypass surface from `feedback_usage_dedupe_pattern.md` (issue #1451, items 4 & 5 of 5). On real OpenClaw v3 installs the advisor's per-session token rollup and `today_tokens` stat were 2× reality, so the recommendations it surfaces were based on inflated numbers.

## Root cause

Each LLM turn on v3 emits BOTH an `assistant` row AND a sibling `model.completed` row ~100 ms apart, both stamped with the same `token_count` column. `_try_local_store_advisor_context` summed both rows blindly:

```python
entry["tokens"] += int(r.get("token_count") or 0)        # line 172 — 2×
today_tokens += int(r.get("token_count") or 0)            # line 182 — 2×
```

## Fix

Mirrors PR #1446's 2-pass approach used in `_try_local_store_cost_comparison`:

1. **Pass 1**: pre-compute the richest envelope rank per `(session_id, ts_sec)` bucket across a ±1s writer-race window.
2. **Pass 2**: skip the slim sibling (rank-1 `model.completed`) when a richer rank-2 (`assistant`/`message`) exists in the same bucket. Metadata accumulation (`model`, `started_at`) is left untouched since it's tag-set semantics not totals.

## Verification

- `python3 -c "import routes.advisor"` clean.
- The pre-existing `test_advisor_gather_context_fast_path` failure (`total_sessions=1 vs >=3`) reproduces on `main` without this change — verified via `git stash`. Unrelated daemon-discovery test-leak.

## MOAT progress

4/5 dedupe-pattern surfaces from issue #1451 now PR'd (3 surfaces closed via #1444+#1446+#1447, this PR closes 2 more via the advisor). Remaining: `routes/usage.py:521` + `:587` (by-plugin rollups) — separate PR per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)