### PR TITLE
fix(budget): daemon-proxy /api/budget/status (p50 7.6s → < 200ms) (closes #1453)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -683,17 +683,34 @@ def _duckdb_cost_since(since_iso: str) -> float:
 
     Issue #1404: without this, ~99% of OSS installs see a zero spend metric
     inside the alert evaluator and no real-spend rule ever fires.
+
+    Issue #1453: route through the daemon-proxy (memory
+    ``feedback_daemon_proxy_pattern.md``) so /api/budget/status doesn't
+    block on the daemon's exclusive DuckDB writer lock under the standard
+    launchd/systemd install. Direct ``get_store()`` was taking 2.5 s per
+    call on a real install with sync daemon writing — three calls (daily /
+    weekly / monthly) compounded to 7-10 s p50 for the endpoint, stalling
+    the Budget panel on every dashboard load. Fall back to a read-only
+    direct open for single-process boots (tests, dev mode) where the
+    daemon proxy isn't running.
     """
+    # 1. Daemon-proxy fast path — cross-process HTTP call into the sync
+    #    daemon's local_server, which holds the DuckDB writer lock. Returns
+    #    None when the daemon isn't discoverable (single-process boot).
+    rows = None
     try:
-        from clawmetry import local_store
-        store = local_store.get_store()
-        # ``query_aggregates`` is a per-day SUM(cost_usd) rollup keyed by
-        # ``substr(ts, 1, 10)`` — exactly the shape we need to roll back up
-        # into daily / weekly / monthly totals. Cheap on DuckDB (columnar
-        # SUM over a single column with a ts range scan).
-        rows = store.query_aggregates(since=since_iso)
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_aggregates", since=since_iso)
     except Exception:
-        return 0.0
+        rows = None
+    # 2. Read-only direct fallback — tests, dev mode, daemon-down boots.
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_aggregates(since=since_iso)
+        except Exception:
+            return 0.0
     total = 0.0
     for r in rows or []:
         try:

--- a/tests/test_alerts_evaluator_duckdb.py
+++ b/tests/test_alerts_evaluator_duckdb.py
@@ -57,7 +57,14 @@ def fresh_store(tmp_path, monkeypatch):
 def dashboard_module(fresh_store, monkeypatch, tmp_path):
     """Reload dashboard.py so ``_duckdb_cost_since`` resolves to the fresh
     local_store. Also drop the in-process cost buffer to simulate a
-    no-OTLP install (the common OSS case)."""
+    no-OTLP install (the common OSS case).
+
+    Issue #1453: stub out the daemon-proxy by default so tests don't leak
+    into the developer's real running sync daemon (which holds the writer
+    lock on the user's actual DuckDB at ~/.clawmetry/events.duckdb).
+    Individual tests that want to exercise the proxy path override this
+    via their own ``monkeypatch.setattr``.
+    """
     sys.modules.pop("dashboard", None)
     import dashboard as _d
     _d.FLEET_DB_PATH = str(tmp_path / "fleet.db")
@@ -68,6 +75,12 @@ def dashboard_module(fresh_store, monkeypatch, tmp_path):
         _d._budget_init_db()
     except Exception:
         pass
+    # Force-disable the daemon proxy: pretend no daemon is reachable, so
+    # ``_duckdb_cost_since`` falls through to the direct read-only open
+    # against ``fresh_store``'s tmp DuckDB. Tests that need to exercise
+    # the proxy path opt-in with their own monkeypatch.
+    import routes.local_query as _lq
+    monkeypatch.setattr(_lq, "local_store_via_daemon", lambda *a, **kw: None)
     yield _d
 
 
@@ -225,3 +238,147 @@ def test_evaluator_empty_store_returns_zero(dashboard_module):
     assert status["daily_spent"] == 0.0
     # cost_source stays "otlp" since we never switched (no DuckDB rows).
     assert status["cost_source"] == "otlp"
+
+
+# ── Issue #1453 — /api/budget/status daemon-proxy regression ───────────────
+#
+# Background: the API-latency smoke gate (PR #1452) caught
+# /api/budget/status at p50 7.6 s / p95 9.5 s / max 10 s timeout under the
+# realistic two-process shape (sync daemon holds the DuckDB writer lock,
+# dashboard tries to open the same file as a reader). ``_duckdb_cost_since``
+# called ``local_store.get_store()`` three times (daily / weekly / monthly
+# windows), each blocking on the writer lock — total 7-10 s, stalling the
+# Budget panel on every dashboard load.
+#
+# Fix: route through ``local_store_via_daemon`` first (cross-process HTTP
+# proxy into the daemon's local_server, which already holds the lock).
+# Fall back to ``get_store(read_only=True)`` only for single-process boots.
+#
+# Regression contract:
+#   1. When the daemon-proxy is reachable, ``_duckdb_cost_since`` must call
+#      it and NOT touch ``local_store.get_store()``.
+#   2. When the daemon-proxy returns slow/error (timeout, daemon down), the
+#      direct read-only fallback must still produce a correct answer.
+#   3. End-to-end: ``_get_budget_status`` must complete in < 500 ms even
+#      when the direct ``get_store()`` path is artificially slow (proxy
+#      short-circuits the lock-wait).
+
+
+def test_duckdb_cost_since_prefers_daemon_proxy(
+    fresh_store, dashboard_module, monkeypatch,
+):
+    """When ``local_store_via_daemon`` returns rows, ``_duckdb_cost_since``
+    must use them and NOT fall through to direct ``get_store()`` (which
+    would race the daemon's writer lock under the standard install)."""
+    _d = dashboard_module
+    canned_rows = [
+        {"day": "2026-05-16", "agent_id": "main", "cost_usd": 3.50,
+         "token_count": 1000, "event_count": 1},
+    ]
+    calls = {"proxy": 0, "direct": 0}
+
+    def fake_proxy(method_name, **kwargs):
+        calls["proxy"] += 1
+        assert method_name == "query_aggregates"
+        assert "since" in kwargs
+        return canned_rows
+
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "local_store_via_daemon", fake_proxy)
+
+    # If the proxy works, get_store() must NOT be called. Wrap it to count.
+    import clawmetry.local_store as _ls
+    real_get_store = _ls.get_store
+    def counting_get_store(*a, **kw):
+        calls["direct"] += 1
+        return real_get_store(*a, **kw)
+    monkeypatch.setattr(_ls, "get_store", counting_get_store)
+
+    total = _d._duckdb_cost_since("2026-05-16T00:00:00+00:00")
+    assert abs(total - 3.50) <= 0.01, f"expected $3.50 from proxy rows, got {total}"
+    assert calls["proxy"] == 1, "daemon proxy was not consulted"
+    assert calls["direct"] == 0, (
+        f"direct get_store() called {calls['direct']}× — daemon-proxy fast "
+        f"path should have short-circuited"
+    )
+
+
+def test_budget_status_stays_fast_when_direct_path_is_slow(
+    fresh_store, dashboard_module, monkeypatch,
+):
+    """Headline /api/budget/status latency contract (issue #1453).
+
+    Simulates the real production failure: the sync daemon holds the DuckDB
+    writer lock, so a direct ``get_store()`` open blocks for ~2.5 s. With
+    three calls (daily/weekly/monthly) that compounds to 7-10 s p50 — the
+    Budget panel stalls on every dashboard load.
+
+    The fix routes through ``local_store_via_daemon`` (fast HTTP roundtrip
+    into the daemon, < 50 ms). This test monkeypatches the proxy to return
+    instantly AND the direct path to sleep 3 s — if the route correctly
+    prefers the proxy, total wall-clock for ``_get_budget_status`` stays
+    well under 500 ms. If it falls through to the slow path on any of the
+    three windows we'd see 3+ s.
+    """
+    _d = dashboard_module
+
+    def fast_proxy(method_name, **kwargs):
+        assert method_name == "query_aggregates"
+        return [
+            {"day": "2026-05-16", "agent_id": "main", "cost_usd": 0.50,
+             "token_count": 100, "event_count": 1},
+        ]
+
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "local_store_via_daemon", fast_proxy)
+
+    # Booby-trap the direct path: if the route ever falls through here,
+    # this sleep would blow the latency budget loudly.
+    import clawmetry.local_store as _ls
+    def slow_get_store(*a, **kw):
+        time.sleep(3.0)
+        raise RuntimeError("should not be reached — daemon proxy fast path "
+                           "should have answered all three windows")
+    monkeypatch.setattr(_ls, "get_store", slow_get_store)
+
+    started = time.monotonic()
+    status = _d._get_budget_status()
+    elapsed_ms = (time.monotonic() - started) * 1000
+
+    assert elapsed_ms < 500, (
+        f"/api/budget/status equivalent took {elapsed_ms:.0f} ms — issue "
+        f"#1453 contract is p50 < 200 ms / p95 < 500 ms. Daemon-proxy "
+        f"likely not short-circuiting the slow direct path."
+    )
+    # Sanity: the proxy answer was actually used.
+    assert status["cost_source"] == "duckdb"
+    assert status["daily_spent"] > 0
+
+
+def test_duckdb_cost_since_falls_back_when_daemon_unreachable(
+    fresh_store, dashboard_module, monkeypatch,
+):
+    """Single-process boot (tests, dev mode, daemon down): the proxy
+    returns ``None`` and we must fall back to the read-only direct open,
+    NOT crash or return 0."""
+    ls, store = fresh_store
+    _d = dashboard_module
+
+    # Seed one event so the direct fallback has something real to sum.
+    today_iso = datetime.now(timezone.utc).replace(
+        hour=12, minute=0, second=0, microsecond=0
+    ).isoformat()
+    store.ingest(_model_completed_event(cost_usd_total=2.25, ts=today_iso))
+    store._flush_now()
+
+    # Force the proxy to act as if the daemon were unreachable.
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **kw: None)
+
+    daily_iso = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    ).isoformat()
+    total = _d._duckdb_cost_since(daily_iso)
+    assert abs(total - 2.25) <= 0.01, (
+        f"direct fallback should sum $2.25 from DuckDB; got {total}"
+    )


### PR DESCRIPTION
## Summary

- Routes `_duckdb_cost_since` through the daemon-proxy (`local_store_via_daemon('query_aggregates', ...)`) instead of opening DuckDB writable, which was racing the sync daemon's exclusive writer lock and blocking ~2.5s per call (3 calls × 2.5s = 7.6s p50 for `/api/budget/status`).
- Falls back to `get_store(read_only=True)` for single-process boots (tests, dev mode).
- Confirmed locally: direct `get_store()` against the running user daemon fails after 2541 ms with `IOException: Could not set lock`. With the fix `_get_budget_status()` returns in 8-32 ms.
- Adds 3 regression tests including the headline contract: `< 500 ms` even when the direct path sleeps 3s on each of three windows.

## Measured (local)

| Path | Before | After |
|------|-------:|------:|
| Direct `get_store()` open (single call) | 2541 ms (lock fail) | n/a |
| `_get_budget_status()` cold | ~7600 ms (issue baseline) | 32 ms |
| `_get_budget_status()` warm | ~7600 ms | 8-12 ms |

Well under the issue's acceptance gate (p50 < 200ms, p95 < 500ms).

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/ -q -k "budget"` — 28/28 green (including 3 new regression tests)
- [x] `python3 -m pytest tests/test_alerts_evaluator_duckdb.py` — 8/8 green
- [x] Smoke test: 5 sequential `_get_budget_status()` calls against a real running daemon all under 35 ms
- [ ] CI green (pending)
- [ ] PR #1452 latency-gate smoke run (will surface once #1452 lands)

## Follow-ups (same code path, separate PRs)

While auditing the file I noticed these direct `get_store()` callsites in `dashboard.py` that are NOT on `/api/budget/status` but ARE on adjacent budget paths and would benefit from the same migration:

- `_get_agent_budget` (line 906) — called by `/api/agents/<id>/budget`
- `_list_agent_budgets` (line 917) — called by `/api/budget` root
- `_set_agent_budget` (line 930) — write path, may be intentionally direct
- `_delete_agent_budget` (line 948) — write path, may be intentionally direct

Recommend filing a follow-up issue to audit these together with `_DAEMON_METHODS` allowlist (`set_agent_budget`/`delete_agent_budget` are not currently allowlisted, would need adding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)