### PR TITLE
fix(usage): extract sibling-dedupe helper, close 3 remaining 2× spots (closes #1451)

### DIFF
--- a/routes/_dedupe.py
+++ b/routes/_dedupe.py
@@ -1,0 +1,66 @@
+"""routes/_dedupe.py — sibling-dedupe helper for v3 event sums (issue #1451).
+
+Real OpenClaw v3 + Claude Code emit two event rows per billable LLM turn:
+a rich ``assistant``/``message`` envelope plus a slim ``model.completed``
+sibling ~100 ms later. Any analytics surface that blindly sums
+``token_count`` over the events table therefore double-counts every turn.
+
+This module centralises the 2-pass dedupe so every surface picks the
+**richest envelope** per ``(session_id, ts_sec ±1 s)`` bucket. ``±1 s``
+covers the writer-race window between the two emitters.
+
+Usage::
+
+    from routes._dedupe import build_sibling_bucket_max, is_sibling_dup
+
+    bucket_max = build_sibling_bucket_max(events)
+    for ev in events:
+        if is_sibling_dup(ev, bucket_max):
+            continue
+        tokens += int(ev.get("token_count") or 0)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+# ``assistant``/``message`` outrank ``model.completed`` inside one bucket.
+_RICHER = {"assistant": 2, "message": 2, "model.completed": 1}
+
+
+def _ts_sec(ts_str) -> int:
+    """ISO-8601 string → integer epoch second. Returns 0 on any failure."""
+    if not ts_str or not isinstance(ts_str, str):
+        return 0
+    try:
+        return int(datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp())
+    except Exception:
+        return 0
+
+
+def build_sibling_bucket_max(rows) -> dict:
+    """Pass 1: scan rows once, return ``{(sid, sec±1): max_rank}``."""
+    bucket_max: dict = {}
+    for r in rows:
+        et = (r.get("event_type") or "").strip()
+        if et not in _RICHER:
+            continue
+        sid = r.get("session_id") or ""
+        sec = _ts_sec(r.get("ts") or "")
+        rank = _RICHER[et]
+        for key in ((sid, sec - 1), (sid, sec), (sid, sec + 1)):
+            if bucket_max.get(key, 0) < rank:
+                bucket_max[key] = rank
+    return bucket_max
+
+
+def is_sibling_dup(row, bucket_max: dict) -> bool:
+    """Pass 2 predicate: True iff ``row`` is a slim sibling of a richer
+    envelope already in its ``(sid, sec)`` bucket. Non-sibling event types
+    always return False (they don't have a paired writer)."""
+    et = (row.get("event_type") or "").strip()
+    if et not in _RICHER:
+        return False
+    sid = row.get("session_id") or ""
+    sec = _ts_sec(row.get("ts") or "")
+    return bucket_max.get((sid, sec), 0) > _RICHER[et]

--- a/routes/advisor.py
+++ b/routes/advisor.py
@@ -145,39 +145,10 @@ def _try_local_store_advisor_context(limit_events: int = MAX_CONTEXT_EVENTS) -> 
     # ``assistant`` and a sibling ``model.completed`` row ~100 ms apart,
     # both stamped with the same ``token_count`` value. Without dedup
     # per-session totals + today_tokens come out 2× reality and the
-    # advisor's recommendations are based on inflated numbers. Same
-    # 2-pass approach as routes/usage.py:_try_local_store_cost_comparison.
-    _RICHER = {"assistant": 2, "message": 2, "model.completed": 1}
-
-    def _ts_sec(ts_str: str) -> int:
-        if not ts_str or not isinstance(ts_str, str):
-            return 0
-        try:
-            from datetime import datetime as _dt
-            return int(_dt.fromisoformat(
-                ts_str.replace("Z", "+00:00")).timestamp())
-        except Exception:
-            return 0
-
-    _bucket_max: dict = {}
-    for _r in rows:
-        _et = (_r.get("event_type") or "").strip()
-        if _et not in _RICHER:
-            continue
-        _sid = _r.get("session_id") or ""
-        _sec = _ts_sec(_r.get("ts") or "")
-        _rank = _RICHER[_et]
-        for _key in ((_sid, _sec - 1), (_sid, _sec), (_sid, _sec + 1)):
-            if _bucket_max.get(_key, 0) < _rank:
-                _bucket_max[_key] = _rank
-
-    def _is_sibling_dup(_r) -> bool:
-        _et = (_r.get("event_type") or "").strip()
-        if _et not in _RICHER:
-            return False
-        _sid = _r.get("session_id") or ""
-        _sec = _ts_sec(_r.get("ts") or "")
-        return _bucket_max.get((_sid, _sec), 0) > _RICHER[_et]
+    # advisor's recommendations are based on inflated numbers. Shared
+    # helper in ``routes/_dedupe.py``.
+    from routes._dedupe import build_sibling_bucket_max, is_sibling_dup
+    _bucket_max = build_sibling_bucket_max(rows)
 
     for r in rows:
         t = (r.get("ts") or "")[:19]
@@ -204,7 +175,7 @@ def _try_local_store_advisor_context(limit_events: int = MAX_CONTEXT_EVENTS) -> 
         # slim sibling of a richer envelope we already counted. We still
         # populate sessions_seen metadata (model, started_at) since those
         # are tag-set not totals.
-        _is_dup = _is_sibling_dup(r)
+        _is_dup = is_sibling_dup(r, _bucket_max)
         if sid_key:
             entry = sessions_seen.setdefault(sid_key, {
                 "session_id": sid_key[:8],

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -33,6 +33,7 @@ from datetime import datetime, timedelta
 
 from flask import Blueprint, jsonify, make_response, request
 from clawmetry.config import is_local_store_read_enabled
+from routes._dedupe import build_sibling_bucket_max, is_sibling_dup
 
 bp_usage = Blueprint('usage', __name__)
 
@@ -511,11 +512,16 @@ def _try_local_store_usage_by_plugin(threshold_pct):
         return None
     if not evs:
         return None
+    # Issue #1451: sibling-dedupe so v3 assistant + model.completed pairs
+    # don't double-count per-plugin tokens.
+    bucket_max = build_sibling_bucket_max(evs)
     plugin_stats = defaultdict(lambda: {"tokens": 0.0, "cost": 0.0, "calls": 0})
     saw_any = False
     for ev in evs:
         plugin = _ls_event_plugin(ev)
         if not plugin:
+            continue
+        if is_sibling_dup(ev, bucket_max):
             continue
         saw_any = True
         plugin_stats[plugin]["tokens"] += float(ev.get("token_count") or 0)
@@ -570,6 +576,9 @@ def _try_local_store_usage_by_plugin_trend(days_back):
     day_list = [(today - timedelta(days=i)).strftime("%Y-%m-%d")
                 for i in range(days_back - 1, -1, -1)]
     day_set = set(day_list)
+    # Issue #1451: sibling-dedupe so v3 assistant + model.completed pairs
+    # don't double-count per-plugin daily totals.
+    bucket_max = build_sibling_bucket_max(evs)
     # plugin -> day -> stats
     plugin_daily: dict = defaultdict(lambda: defaultdict(
         lambda: {"tokens": 0.0, "cost": 0.0, "calls": 0}
@@ -581,6 +590,8 @@ def _try_local_store_usage_by_plugin_trend(days_back):
             continue
         plugin = _ls_event_plugin(ev)
         if not plugin:
+            continue
+        if is_sibling_dup(ev, bucket_max):
             continue
         saw_any = True
         bucket = plugin_daily[plugin][day]
@@ -635,54 +646,20 @@ def _try_local_store_cost_comparison():
     cutoff = datetime.now() - timedelta(days=30)
     cutoff_iso = cutoff.strftime("%Y-%m-%d")
 
-    # Sibling-dedup: per (session_id, ts_sec, ±1 s) bucket, keep only the
-    # richest-envelope row. `assistant`/`message` outrank `model.completed`
-    # for the same turn (writer race emits both ~100 ms apart). Two passes
-    # because `query_events` returns DESC and we'd otherwise count both when
-    # the slim sibling lands first.
-    _RICHER = {"assistant": 2, "message": 2, "model.completed": 1}
+    # Sibling-dedup (issue #1451 / PR #1446): per (session_id, ts_sec, ±1 s)
+    # bucket, keep only the richest-envelope row. ``assistant``/``message``
+    # outrank ``model.completed`` for the same turn (writer race emits both
+    # ~100 ms apart). Helper in ``routes/_dedupe.py``.
+    in_window = [ev for ev in evs if (ev.get("ts", "") or "") >= cutoff_iso]
+    bucket_max = build_sibling_bucket_max(in_window)
 
-    def _ts_sec(ts_str: str) -> int:
-        if not ts_str:
-            return 0
-        try:
-            return int(datetime.fromisoformat(
-                ts_str.replace("Z", "+00:00")).timestamp())
-        except Exception:
-            return 0
-
-    # Pass 1: compute richest rank per (sid, sec) bucket across the ±1 s
-    # writer-race window.
-    bucket_max: dict = {}
-    in_window: list = []
-    for ev in evs:
-        ts = ev.get("ts", "") or ""
-        if ts < cutoff_iso:
-            continue
-        in_window.append(ev)
-        et = (ev.get("event_type") or "").strip()
-        if et not in _RICHER:
-            continue
-        sid_v = ev.get("session_id") or ""
-        sec = _ts_sec(ts)
-        rank = _RICHER[et]
-        for key in ((sid_v, sec - 1), (sid_v, sec), (sid_v, sec + 1)):
-            if bucket_max.get(key, 0) < rank:
-                bucket_max[key] = rank
-
-    # Pass 2: count tokens, skipping any sibling whose rank is strictly less
-    # than the richest in its (sid, sec±1) bucket.
     actual_tokens = 0
     actual_cost = 0.0
     model_token_map: dict = {}
     saw_any = False
     for ev in in_window:
-        et = (ev.get("event_type") or "").strip()
-        if et in _RICHER:
-            sid_v = ev.get("session_id") or ""
-            sec = _ts_sec(ev.get("ts") or "")
-            if bucket_max.get((sid_v, sec), 0) > _RICHER[et]:
-                continue
+        if is_sibling_dup(ev, bucket_max):
+            continue
         saw_any = True
         tok = int(ev.get("token_count") or 0)
         actual_tokens += tok
@@ -1378,6 +1355,9 @@ def _try_local_store_sessions_clusters(days: int):
         return None
     # One bulk events fetch; group by session_id (avoids N+1 daemon hops).
     events = _ls_call("query_events", since=cutoff_iso, limit=20000) or []
+    # Issue #1451: sibling-dedupe so the per-session token fallback below
+    # doesn't double-count assistant + model.completed pairs on v3 installs.
+    bucket_max = build_sibling_bucket_max(events)
     by_session: dict = defaultdict(list)
     for ev in events:
         sid = ev.get("session_id")
@@ -1398,7 +1378,20 @@ def _try_local_store_sessions_clusters(days: int):
         has_cron = False
         has_subagent = False
         turn_count = 0
-        s_tokens = int(s.get("token_count") or 0)
+        # Issue #1451: ``query_sessions`` returns ``SUM(token_count)`` from
+        # the events table, which on real v3 installs double-counts the
+        # ``assistant`` + ``model.completed`` sibling pair for every billable
+        # turn. Compute s_tokens from the deduped event list instead so the
+        # cluster aggregator doesn't inflate per-session totals. Falls back
+        # to the (still-inflated) session-row sum only when no events were
+        # joined in for this session.
+        s_tokens = sum(
+            int(ev.get("token_count") or 0)
+            for ev in evs
+            if not is_sibling_dup(ev, bucket_max)
+        )
+        if s_tokens == 0:
+            s_tokens = int(s.get("token_count") or 0)
         for ev in evs:
             data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
             msg = data.get("message") if isinstance(data.get("message"), dict) else {}
@@ -1419,9 +1412,6 @@ def _try_local_store_sessions_clusters(days: int):
                 has_subagent = True
             if etype == "message":
                 turn_count += 1
-        # Token fallback: derive from event-level token_count if sessions row was zero.
-        if s_tokens == 0:
-            s_tokens = sum(int(ev.get("token_count") or 0) for ev in evs)
         if s_tokens == 0 and not tool_counts:
             continue
         total_tools = sum(tool_counts.values())

--- a/tests/test_usage_local_store.py
+++ b/tests/test_usage_local_store.py
@@ -881,3 +881,78 @@ def test_query_daily_usage_splits_skips_zero_usage_rows(fast_path_app):
 
     rows = store.query_daily_usage_splits()
     assert rows[0]["event_count"] == 1
+
+
+# ── issue #1451: sibling-dedupe across remaining surfaces ─────────────────
+
+
+def _ingest_v3_pair(store, *, sid, ts_iso, plugin="bash", tokens=150):
+    """Seed one v3 assistant + model.completed sibling pair. Both rows
+    carry ``token_count=tokens`` — a blind sum returns 2×, a deduped sum
+    returns ``tokens``. Used by all #1451 regression tests."""
+    base = {
+        "node_id": "agent+test", "agent_id": "main", "session_id": sid,
+        "cost_usd": 0.0, "token_count": tokens, "model": "claude-opus-4-7",
+    }
+    store.ingest({**base, "id": f"asst-{sid}", "event_type": "assistant",
+                  "ts": ts_iso,
+                  "data": {"plugin": plugin, "message": {"role": "assistant"}}})
+    store.ingest({**base, "id": f"mc-{sid}", "event_type": "model.completed",
+                  "ts": ts_iso, "data": {"plugin": plugin}})
+
+
+def test_by_plugin_does_not_double_count_v3_sibling_pairs(fast_path_app):
+    """Regression: /api/usage/by-plugin summed ``token_count`` per plugin
+    without skipping the slim ``model.completed`` sibling — every turn was
+    counted twice. Shared dedupe helper (issue #1451) must collapse to 1×."""
+    app, ls, _u = fast_path_app
+    _ingest_v3_pair(ls.get_store(), sid="sess-plug-dup",
+                     ts_iso=_iso(time.time() - 3600))
+    _wait_flush(ls.get_store())
+
+    body = app.test_client().get("/api/usage/by-plugin").get_json()
+    assert body["_source"] == "local_store"
+    bash_row = next((r for r in body["plugins"] if r["plugin"] == "bash"), None)
+    assert bash_row is not None, "expected bash plugin row"
+    assert bash_row["total_tokens"] == 150, (
+        f"by-plugin double-counted sibling pair: got "
+        f"{bash_row['total_tokens']}, expected 150"
+    )
+
+
+def test_by_plugin_trend_does_not_double_count_v3_sibling_pairs(fast_path_app):
+    """Same regression as the by-plugin scalar route but for the daily
+    bucket aggregator at /api/usage/by-plugin/trend."""
+    app, ls, _u = fast_path_app
+    today = datetime.now().strftime("%Y-%m-%d")
+    _ingest_v3_pair(ls.get_store(), sid="sess-trend-dup",
+                     ts_iso=f"{today}T10:00:00.100Z")
+    _wait_flush(ls.get_store())
+
+    body = app.test_client().get("/api/usage/by-plugin/trend?days=14").get_json()
+    assert body["_source"] == "local_store"
+    today_entry = next((e for e in (body["plugins"].get("bash") or [])
+                         if e["day"] == today), None)
+    assert today_entry is not None, "expected today entry in bash trend"
+    assert today_entry["tokens"] == 150, (
+        f"by-plugin/trend double-counted sibling pair: got "
+        f"{today_entry['tokens']}, expected 150"
+    )
+
+
+def test_sessions_clusters_does_not_double_count_v3_sibling_pairs(fast_path_app):
+    """Regression: the session aggregator at routes/usage.py:1372 read
+    ``token_count`` from ``query_sessions`` (which returns ``SUM`` over
+    events) and never deduped — every session's tokens were 2× on v3.
+    Shared dedupe helper must collapse to 1×."""
+    app, ls, _u = fast_path_app
+    _ingest_v3_pair(ls.get_store(), sid="sess-clust-dup",
+                     ts_iso=_iso(time.time() - 3600))
+    _wait_flush(ls.get_store())
+
+    body = app.test_client().get("/api/sessions/clusters?days=30").get_json()
+    total = sum(c.get("total_tokens", 0) for c in body.get("clusters", []))
+    assert total == 150, (
+        f"sessions/clusters double-counted sibling pair: got {total}, "
+        f"expected 150"
+    )


### PR DESCRIPTION
## Summary

Closes vivekchand/clawmetry#1451.

Three usage.py surfaces still summed `token_count` blindly across v3 events and double-counted every billable turn (the `assistant` + `model.completed` sibling pair every real OpenClaw v3 install emits ~100 ms apart):

| File:line | Surface | Risk before fix |
|---|---|---|
| `routes/usage.py:521` | `/api/usage/by-plugin` plugin totals | 2× per-plugin tokens |
| `routes/usage.py:587` | `/api/usage/by-plugin/trend` daily series | 2× per-plugin daily |
| `routes/usage.py:1372` | per-session aggregator (clusters) | 2× session tokens |

## What changed

- **New shared helper** at `routes/_dedupe.py` exposing `build_sibling_bucket_max()` + `is_sibling_dup()` — the 2-pass `(session_id, ts_sec ±1 s) → richest envelope` walk that PR #1446 introduced inline.
- **3 usage.py callsites** swapped to the helper (the 3 in the issue).
- **2 retroactive migrations** — `_try_local_store_cost_comparison` (PR #1446) and `_try_local_store_advisor_context` (PR #1454) both had the same 2-pass logic copy-pasted inline; lifted to the helper to prevent future drift.
- For `/api/sessions/clusters` specifically, `query_sessions` returns `SUM(token_count)` from events, which is itself 2×'d on v3. Compute `s_tokens` from the deduped event list as the canonical path and fall back to the session row only when no events joined.

Net diff: **102 LOC** (182 insertions, 80 deletions across 4 files).

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/ -q -k "usage or advisor"` → **44 passed**
- [x] 3 new regression tests in `test_usage_local_store.py` (one per surface) — each seeds a sibling pair and asserts the response shows the deduped one-turn total, not 2×
- [x] All 7 existing cost-comparison/v3-sibling tests still pass after the helper extraction
- [ ] Smoke against a live install with real v3 data before merging (recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)