### PR TITLE
fix(ci): smoke-gate sanity-check + flake-vs-regression annotations (closes #1457)

### DIFF
--- a/.github/workflows/api-latency-smoke.yml
+++ b/.github/workflows/api-latency-smoke.yml
@@ -77,6 +77,10 @@ jobs:
         # Daemon owns the DuckDB lock and publishes its local-query port to
         # ~/.clawmetry/local_query.json. Dashboard proxies through that for
         # /api/local/* reads. Both running = the contention shape we test.
+        #
+        # Failures here are SETUP FLAKES, not perf regressions — emit a
+        # distinct `[setup-flake]` annotation so devs (and downstream
+        # automation) can tell "re-run the workflow" from "fix your code".
         env:
           CLAWMETRY_INGEST_URL: http://127.0.0.1:9
         run: |
@@ -88,8 +92,8 @@ jobs:
             sleep 1
           done
           if [ ! -f "$HOME/.clawmetry/local_query.json" ]; then
-            echo "::error::daemon never published local_query.json"
-            tail -100 .smoke/daemon.log; exit 1
+            echo "::error::[setup-flake] Gate setup failed: daemon did not publish local_query.json within 30s (this is NOT a regression). Re-run the workflow."
+            tail -100 .smoke/daemon.log; exit 2
           fi
           nohup /tmp/vsmoke/bin/clawmetry --port 8900 --no-debug \
             > .smoke/dashboard.log 2>&1 &
@@ -102,8 +106,8 @@ jobs:
           done
           curl -sf -H "Authorization: Bearer $CLAWMETRY_TOKEN" \
             http://localhost:8900/api/health > /dev/null || {
-            echo "::error::dashboard /api/health never returned 200"
-            tail -100 .smoke/dashboard.log; exit 1; }
+            echo "::error::[setup-flake] Gate setup failed: dashboard /api/health never returned 200 within 30s (this is NOT a regression). Re-run the workflow."
+            tail -100 .smoke/dashboard.log; exit 2; }
 
       - name: Probe endpoints + assert p50/p95 budgets
         env:

--- a/scripts/api_latency_probe.py
+++ b/scripts/api_latency_probe.py
@@ -82,30 +82,45 @@ def run(endpoints: Iterable[str] = ENDPOINTS) -> int:
     print("-" * len(header))
 
     failures: list[str] = []
+    annotations: list[str] = []
     for path in endpoints:
         if path in SKIP:
             print(f"{path:<40} {'-':>8} {'-':>8} {'-':>8}  skip    SKIP")
             continue
         samples, status, err = _probe_one(session, path)
         p50, p95, smax = _percentile(samples, 50), _percentile(samples, 95), max(samples)
-        verdict, breach_bits = "OK", []
+        verdict, breach_bits, ann_bits = "OK", [], []
         # Network errors / 5xx are a hard fail — the endpoint is down, not slow.
         if status is None or status >= 500:
             verdict = "FAIL"
             breach_bits.append(f"status={status or err or 'connerr'}")
+            ann_bits.append(f"status={status or err or 'connerr'}")
         if p50 > P50_BUDGET_MS:
             verdict = "FAIL"
             breach_bits.append(f"p50={p50:.0f}ms>{P50_BUDGET_MS:.0f}ms")
+            ann_bits.append(
+                f"p50={p50:.0f}ms exceeds {P50_BUDGET_MS:.0f}ms budget by {p50 - P50_BUDGET_MS:.0f}ms"
+            )
         if p95 > P95_BUDGET_MS:
             verdict = "FAIL"
             breach_bits.append(f"p95={p95:.0f}ms>{P95_BUDGET_MS:.0f}ms")
+            ann_bits.append(
+                f"p95={p95:.0f}ms exceeds {P95_BUDGET_MS:.0f}ms budget by {p95 - P95_BUDGET_MS:.0f}ms"
+            )
         print(f"{path:<40} {p50:>7.0f}ms {p95:>7.0f}ms {smax:>7.0f}ms"
               f"  {status if status is not None else '---':>4}    {verdict}")
         if verdict != "OK":
             failures.append(f"{path}: " + ", ".join(breach_bits))
+            # Machine-readable GitHub annotation, distinct from [setup-flake]
+            # so devs and downstream automation can filter the two classes.
+            annotations.append(f"::error::[regression] {path} {'; '.join(ann_bits)}")
 
     print()
     if failures:
+        # Emit GH annotations AFTER the table so the human-readable summary
+        # stays grouped together; annotations float to the run summary anyway.
+        for ann in annotations:
+            print(ann)
         print(f"FAIL: {len(failures)} endpoint(s) breached the latency gate:")
         for line in failures:
             print(f"  - {line}")


### PR DESCRIPTION
closes #1457

## Summary

The API-latency smoke gate from PR #1452 had no way to distinguish a real perf regression from a setup flake — both showed the same red X. Devs couldn't tell whether to fix code or re-run the workflow.

- Setup failures (daemon didn't publish `local_query.json`, dashboard `/api/health` never returned) now emit `::error::[setup-flake] ... this is NOT a regression. Re-run the workflow.` and exit 2.
- Probe failures emit `::error::[regression] <endpoint> p50=Xms exceeds Yms budget by Zms` per the issue example (or `p95=...`, or `status=...`).
- Distinct exit codes (2 = setup-flake, 1 = regression) so downstream automation can filter.
- Probe stdout table stays human-readable; annotations are additive lines, kept machine-parseable.

Stacked on top of PR #1452 (`ci/api-latency-smoke-1241`); diff narrows to just this change once that lands.

## Test plan

- [x] Pure-bash repro of missing-daemon path: `[setup-flake]` annotation fires, exit code 2 as expected.
- [x] Probe against 700ms mock server emits `[regression] /api/overview p50=706ms exceeds 500ms budget by 206ms` — exact format from the issue body.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/api-latency-smoke.yml'))"` validates.
- [x] `python3 -m py_compile scripts/api_latency_probe.py` clean.
- [ ] Real CI run on this PR exercises the regression path (no slow endpoints expected → should pass).

## Acceptance (issue #1457)

- [x] Gate setup failures emit `[setup-flake]` annotation, not `[regression]`
- [x] Probe failures include endpoint name + numbers + threshold in the failure message
- [x] CI re-run of a flaked gate passes without code change (distinct exit code makes this triagable)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>