### PR TITLE
fix(local-store): dedupe v3 sibling pairs in query_sessions at SQL layer (closes #1460)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -2565,18 +2565,69 @@ class LocalStore:
             clauses.append("ts <= ?")
             params.append(until)
         where = "WHERE " + " AND ".join(clauses)
+        # Issue #1460: on real OpenClaw v3 installs each LLM turn emits BOTH
+        # an ``assistant`` row AND a sibling ``model.completed`` row ~100 ms
+        # apart, both stamped with the same ``token_count`` + ``cost_usd``.
+        # A naive SUM() over the raw events table doubles every billable
+        # turn. The 5 Python fast paths from #1451 worked around this with
+        # a 2-pass walker (``routes/_dedupe.py``); fixing it here closes
+        # the bug class for ALL consumers (cluster aggregator, anomaly
+        # detector, anyone else who reads ``query_sessions().token_count``).
+        #
+        # Approach: dedupe at the SQL layer by (session_id, ts-rounded-to-
+        # second) bucket, picking the richer envelope (assistant/message >
+        # model.completed). ``event_count`` stays RAW (it's "how many rows
+        # did we record", not "how many billable turns") — only cost_usd
+        # + token_count come from the deduped CTE.
         sql = f"""
+            WITH ranked AS (
+              SELECT
+                id, agent_id, session_id, ts, cost_usd, token_count,
+                event_type,
+                CASE event_type
+                  WHEN 'assistant'        THEN 2
+                  WHEN 'message'          THEN 2
+                  WHEN 'model.completed'  THEN 1
+                  ELSE 0
+                END AS envelope_rank,
+                CAST(EXTRACT(EPOCH FROM CAST(ts AS TIMESTAMP)) AS BIGINT)
+                                                 AS ts_sec
+              FROM events
+              {where}
+            ),
+            bucket_max AS (
+              SELECT session_id, ts_sec, MAX(envelope_rank) AS max_rank
+              FROM ranked
+              GROUP BY session_id, ts_sec
+            ),
+            deduped AS (
+              -- Drop the slim ``model.completed`` sibling ONLY when an
+              -- ``assistant``/``message`` (rank=2) exists in the same
+              -- (session_id, ts_sec) bucket. Other event types (rank=0
+              -- tool_calls, etc.) are NEVER dropped — they may legitimately
+              -- share a ts_sec without being sibling pairs.
+              SELECT r.* FROM ranked r
+              JOIN bucket_max bm USING (session_id, ts_sec)
+              WHERE NOT (r.envelope_rank = 1 AND bm.max_rank = 2)
+            ),
+            deduped_sums AS (
+              SELECT session_id,
+                     COALESCE(SUM(cost_usd), 0)    AS cost_usd_d,
+                     COALESCE(SUM(token_count), 0) AS token_count_d
+              FROM deduped
+              GROUP BY session_id
+            )
             SELECT
-              session_id,
-              MIN(agent_id)               AS agent_id,
-              MIN(ts)                     AS started_at,
-              MAX(ts)                     AS updated_at,
-              COUNT(*)                    AS event_count,
-              COALESCE(SUM(cost_usd), 0)  AS cost_usd,
-              COALESCE(SUM(token_count), 0) AS token_count
-            FROM events
-            {where}
-            GROUP BY session_id
+              r.session_id,
+              MIN(r.agent_id)               AS agent_id,
+              MIN(r.ts)                     AS started_at,
+              MAX(r.ts)                     AS updated_at,
+              COUNT(r.id)                   AS event_count,
+              COALESCE(ds.cost_usd_d, 0)    AS cost_usd,
+              COALESCE(ds.token_count_d, 0) AS token_count
+            FROM ranked r
+            LEFT JOIN deduped_sums ds USING (session_id)
+            GROUP BY r.session_id, ds.cost_usd_d, ds.token_count_d
             ORDER BY updated_at DESC
             LIMIT ?
         """

--- a/tests/test_local_query_api.py
+++ b/tests/test_local_query_api.py
@@ -111,6 +111,47 @@ def test_sessions_endpoint(client):
     assert round(by_sid["X"]["cost_usd"], 4) == 0.30
 
 
+def test_sessions_endpoint_dedupes_v3_sibling_pairs(client):
+    """Issue #1460: on real OpenClaw v3 installs each LLM turn emits BOTH
+    an ``assistant`` row AND a sibling ``model.completed`` row ~100 ms
+    apart, both stamped with the same ``token_count`` + ``cost_usd``.
+    The SQL fix in ``query_sessions`` must dedupe at the SQL layer so all
+    consumers (cluster aggregator, anomaly detector, this endpoint, etc.)
+    return the single billable turn — not 2× of it.
+
+    ``event_count`` stays RAW (it is the row-count, not the turn-count) so
+    debug surfaces can still tell you both rows did arrive.
+    """
+    c, ls = client
+    store = ls.get_store()
+    store.ingest(_ev(
+        id="assist-1", session_id="sess-pair",
+        event_type="assistant",
+        ts="2026-05-16T10:00:00Z",
+        cost_usd=0.005, token_count=150,
+    ))
+    store.ingest(_ev(
+        id="mc-1", session_id="sess-pair",
+        event_type="model.completed",
+        ts="2026-05-16T10:00:00Z",
+        cost_usd=0.005, token_count=150,
+    ))
+    _wait(store)
+    r = c.get("/api/local/sessions")
+    body = r.get_json()
+    by_sid = {s["session_id"]: s for s in body["rows"]}
+    row = by_sid["sess-pair"]
+    assert row["event_count"] == 2, "raw event_count should still report both rows"
+    assert row["token_count"] == 150, (
+        f"sibling pair must dedupe to 1 turn = 150 tokens, got "
+        f"{row['token_count']} (regression: SQL layer not deduping)"
+    )
+    assert round(row["cost_usd"], 4) == 0.005, (
+        f"sibling pair must dedupe to 1 turn = $0.005, got "
+        f"{round(row['cost_usd'], 4)}"
+    )
+
+
 def test_aggregates_endpoint(client):
     c, ls = client
     store = ls.get_store()


### PR DESCRIPTION
## Summary

Root-cause fix for the dedupe bug class that PR #1459 worked around in 5 Python fast paths via \`routes/_dedupe.py\`. Closes the bug at the source so the next consumer of \`query_sessions().token_count\` cannot regress it.

## Why this is necessary

On real OpenClaw v3 installs each LLM turn emits BOTH an \`assistant\` row AND a sibling \`model.completed\` row ~100 ms apart, both stamped with the same \`token_count\` + \`cost_usd\`. \`SUM()\` over the raw \`events\` table doubles every billable turn. The Python helper closes this for 5 known surfaces — but ANY other consumer (cluster aggregator, anomaly detector, future surfaces) inherits the 2× without the helper.

## Approach

5-CTE SQL rewrite in \`query_sessions\`:

1. **\`ranked\`** tags each event with envelope rank (assistant/message=2, model.completed=1, others=0) + ts_sec bucket.
2. **\`bucket_max\`** finds the max rank per \`(session_id, ts_sec)\`.
3. **\`deduped\`** drops the slim sibling ONLY when a richer envelope exists in the same bucket. Critical: two \`tool_call\` rows sharing a ts_sec are still both kept (they are not siblings — only the assistant/model.completed pair pattern is).
4. **\`deduped_sums\`** aggregates cost_usd + token_count from deduped.
5. The final SELECT joins back to \`ranked\` so **\`event_count\` stays RAW** — debug surfaces still see all the rows that arrived; only the money-tied numbers get deduped.

## Verification

- \`pytest tests/test_local_query_api.py -q\` → **13 passed** (12 existing + new sibling-pair regression test)
- \`pytest tests/test_moat_send_message_e2e.py\` → **3 passed**
- \`pytest tests/test_usage_local_store.py\` → **28 passed**
- \`pytest tests/test_e2e_duckdb_relay.py\` → all non-pre-existing pass

Two pre-existing failures (\`test_duckdb_read_only_handle_sees_committed_rows\`, \`test_relay_shape_health\`) reproduce on main and are unrelated.

## New regression test

\`test_sessions_endpoint_dedupes_v3_sibling_pairs\` — synthetic assistant + model.completed pair at the same ts, asserts:
- \`token_count == 150\` (deduped to 1 turn, not 2×)
- \`cost_usd == 0.005\` (deduped)
- \`event_count == 2\` (raw, kept for debug visibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)