### PR TITLE
feat(spans): cap OSS span retention to 24h, gate full history behind Cloud-Pro (closes #1374)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -2233,6 +2233,7 @@ class LocalStore:
         *,
         limit: int = 50,
         session_id: str | None = None,
+        since: float | None = None,
     ) -> list[dict[str, Any]]:
         """MOAT issue #1364: read-side surface for spans we already store.
 
@@ -2248,9 +2249,12 @@ class LocalStore:
           limit: Max rows to return (clamped 1-500 by the route layer).
           session_id: Optional session filter — when set, returns spans for
             that one OpenClaw session.
+          since: Optional unix-second floor on ``start_ts``. Used by issue
+            #1374 to enforce the OSS 24h retention cap (Cloud-Pro bypasses).
         """
         rows = self.query_spans(
             session_id=session_id,
+            since=since,
             limit=int(limit),
         )
         # Project to the contract the UI table reads. Keep the BLOB columns

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3939,12 +3939,14 @@ async function loadSpansPanel() {
     var data = await resp.json();
     _spansPanelLoaded = true;
     var spans = (data && data.spans) || [];
+    var cappedAt24h = !!(data && data.capped_at_24h);
     if (countEl) countEl.textContent = String(spans.length);
     if (!spans.length) {
       var hint = (data && data._source === 'unavailable')
-        ? 'Local store unavailable — start the sync daemon or restart with CLAWMETRY_LOCAL_STORE_READ=1.'
+        ? 'Local store unavailable. Start the sync daemon or restart with CLAWMETRY_LOCAL_STORE_READ=1.'
         : 'No OTel spans yet. Wire an OTLP exporter to <code>/v1/traces</code> on this dashboard\'s port to start capturing.';
       wrap.innerHTML = '<div style="color:var(--text-muted);padding:20px;font-size:12px;text-align:center;line-height:1.6;">' + hint + '</div>';
+      _renderSpansCap(cappedAt24h);
       return;
     }
     var rowsHtml = spans.map(function(s) {
@@ -3966,8 +3968,32 @@ async function loadSpansPanel() {
       +   '<th style="padding:4px 8px;font-weight:600;">Session</th>'
       +   '<th style="padding:4px 8px;font-weight:600;">Kind</th>'
       + '</tr></thead><tbody>' + rowsHtml + '</tbody></table>';
+    _renderSpansCap(cappedAt24h);
   } catch (e) {
     wrap.innerHTML = '<div style="color:var(--text-error);padding:20px;font-size:12px;">Failed to load spans: ' + _spansEsc(String(e)) + '</div>';
+  }
+}
+
+// Render a small CTA row below the Spans table when the OSS retention cap
+// kicked in (issue #1374). Mirrors _renderFlowRunsCap; lives in its own
+// footer container appended inside #spans-panel so the table itself stays
+// purely tabular.
+function _renderSpansCap(capped) {
+  var foot = document.getElementById('spans-cap-cta');
+  if (!foot) {
+    var panel = document.getElementById('spans-panel');
+    if (!panel) return;
+    foot = document.createElement('div');
+    foot.id = 'spans-cap-cta';
+    foot.style.cssText = 'padding:10px 0 2px 0;font-size:12px;color:var(--text-muted);border-top:1px solid var(--border);margin-top:8px;display:none;';
+    panel.appendChild(foot);
+  }
+  if (capped) {
+    foot.style.display = '';
+    foot.innerHTML = 'Showing the last 24 hours. <a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener" style="color:var(--accent,#7c5cff);font-weight:600;">Upgrade to Cloud-Pro for unlimited history</a>';
+  } else {
+    foot.style.display = 'none';
+    foot.innerHTML = '';
   }
 }
 

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -4103,6 +4103,11 @@ def api_spans():
     Query params:
       * ``limit`` — max rows (default 50, clamped 1-500)
       * ``session_id`` — optional session filter
+      * ``since`` — optional unix-second floor on ``start_ts``. Issue #1374:
+        OSS / Cloud-Free callers are clamped to ``now - 24h``; Cloud-Pro
+        users (validated by ``dashboard._is_pro_user``) get unlimited
+        history. Response carries ``capped_at_24h`` so the UI can render
+        the upgrade CTA.
 
     Response shape::
 
@@ -4112,13 +4117,14 @@ def api_spans():
                         duration_ms, status, model, tool_name, cost_usd,
                         tokens_input, tokens_output}, ... ],
           "count":   <int>,
-          "_source": "local_store"
+          "_source": "local_store",
+          "capped_at_24h": <bool>
         }
 
     Graceful fallback: when the local store / daemon is unreachable we
-    return ``{"spans": [], "count": 0, "_source": "unavailable"}`` with
-    HTTP 200 so the UI table renders an empty state instead of an error
-    banner.
+    return ``{"spans": [], "count": 0, "_source": "unavailable",
+    "capped_at_24h": <bool>}`` with HTTP 200 so the UI table renders an
+    empty state instead of an error banner.
     """
     try:
         limit = int(request.args.get("limit", 50))
@@ -4127,15 +4133,45 @@ def api_spans():
     limit = max(1, min(500, limit))
     session_id = (request.args.get("session_id") or "").strip() or None
 
+    # Optional unix-second floor (caller-supplied).
+    since_raw = (request.args.get("since") or "").strip()
+    since: float | None
+    try:
+        since = float(since_raw) if since_raw else None
+    except (TypeError, ValueError):
+        since = None
+
+    # OSS retention cap (issue #1374). Cloud-Pro bypasses; everyone else
+    # gets clamped to the last 24 h of ``start_ts``. Mirrors the pattern
+    # used by /api/flow/runs (issue #1173).
+    capped_at_24h = False
+    try:
+        import dashboard as _d
+        is_pro = bool(_d._is_pro_user())
+    except Exception:
+        is_pro = False
+    if not is_pro:
+        cap_floor = time.time() - 24 * 3600
+        if since is None or since < cap_floor:
+            since = cap_floor
+            capped_at_24h = True
+
     rows = _ls_call(
         "query_recent_spans",
         limit=limit,
         session_id=session_id,
+        since=since,
     )
     if rows is None:
-        return jsonify({"spans": [], "count": 0, "_source": "unavailable"})
+        return jsonify({
+            "spans": [],
+            "count": 0,
+            "_source": "unavailable",
+            "capped_at_24h": capped_at_24h,
+        })
     return jsonify({
         "spans":   rows,
         "count":   len(rows),
         "_source": "local_store",
+        "capped_at_24h": capped_at_24h,
     })

--- a/tests/test_spans_e2e.py
+++ b/tests/test_spans_e2e.py
@@ -152,3 +152,48 @@ def test_api_spans_limit_clamped(app):
     r = c.get("/api/spans?limit=garbage")
     assert r.status_code == 200
     assert r.get_json()["count"] == 5
+
+
+# ── Retention cap (issue #1374) ─────────────────────────────────────────────
+#
+# OSS / Cloud-Free callers are clamped to the last 24 h of ``start_ts``;
+# Cloud-Pro users (gated by ``dashboard._is_pro_user``) bypass the cap. The
+# response always carries a ``capped_at_24h`` boolean so the Brain-tab UI
+# can render the upgrade CTA when the cap kicks in.
+
+
+def _seed_old_and_recent_spans(store):
+    """One ancient span (8 days old) + one fresh span (5 min ago)."""
+    now = time.time()
+    store.put_span(_span("span-old", now - 8 * 86400, name="ancient"))
+    store.put_span(_span("span-new", now - 300, name="fresh"))
+
+
+def test_api_spans_oss_capped_to_24h(app, monkeypatch):
+    """Non-Pro users see only spans newer than now-24h; flag set."""
+    a, ls = app
+    _seed_old_and_recent_spans(ls.get_store())
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    r = a.test_client().get("/api/spans?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body["capped_at_24h"] is True
+    sids = {s["span_id"] for s in body["spans"]}
+    # The 8-day-old span must be excluded; only the fresh one shows.
+    assert sids == {"span-new"}
+
+
+def test_api_spans_pro_bypasses_cap(app, monkeypatch):
+    """Pro users get the full history, unflagged."""
+    a, ls = app
+    _seed_old_and_recent_spans(ls.get_store())
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    r = a.test_client().get("/api/spans?limit=10")
+    body = r.get_json()
+    assert body["capped_at_24h"] is False
+    sids = {s["span_id"] for s in body["spans"]}
+    assert sids == {"span-old", "span-new"}


### PR DESCRIPTION
## Summary
- `/api/spans` now clamps `since` to `now - 24h` for non-Pro callers (gated by `dashboard._is_pro_user`); Cloud-Pro bypasses. Response carries `capped_at_24h: bool` so the UI can render an upgrade CTA. Mirrors the pattern PR #1445 introduced for `/api/flow/runs` (issue #1173).
- Brain-tab Spans panel renders a small inline upgrade CTA below the table when capped. New `_renderSpansCap` mirrors `_renderFlowRunsCap`; duplicated rather than generalised because the spans panel host is a `div` (not a table+tbody) so the helper bodies don't share a DOM contract.
- `LocalStore.query_recent_spans` grew a `since` kwarg that passes through to the existing `query_spans` `since` filter — no schema change.

closes #1374

## Test plan
- [x] `python3 -c "import dashboard"` clean
- [x] `pytest tests/test_spans_e2e.py` — 6/6 pass (4 pre-existing + 2 new)
- [x] `pytest tests/test_flow_runs_endpoint.py` — 8/8 pass (no regression in sibling cap pattern)
- [x] No em-dashes in user-facing CTA copy
- [x] Diff under 200 LOC (117 +/6 -)

## New regression coverage
- `test_api_spans_oss_capped_to_24h` — OSS user, 8d-old span filtered out, `capped_at_24h: true`.
- `test_api_spans_pro_bypasses_cap` — Pro user (monkey-patched `_is_pro_user`), full history, `capped_at_24h: false`.

## Follow-ups
- `/api/spans` is the only `since`-accepting span/trace surface in `routes/`. No other span endpoints currently leak unbounded history; OK to skip a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)