### PR TITLE
fix(local-store): dedupe v3 sibling pairs in query_aggregates SQL (root fix)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -4114,17 +4114,61 @@ class LocalStore:
             clauses.append("ts <= ?")
             params.append(until)
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        # Same dedupe shape as ``query_sessions`` (PR #1462). On real v3
+        # OpenClaw installs each LLM turn emits BOTH an ``assistant`` row
+        # AND a sibling ``model.completed`` row ~100 ms apart, both
+        # stamped with the same ``token_count`` + ``cost_usd``. A naive
+        # SUM over the raw events table doubles every billable turn.
+        # ``event_count`` stays RAW (row count, not turn count); only
+        # cost_usd + token_count come from the deduped CTE.
         sql = f"""
+            WITH ranked AS (
+              SELECT
+                id, session_id, agent_id, ts, cost_usd, token_count,
+                event_type,
+                substr(ts, 1, 10) AS day,
+                CASE event_type
+                  WHEN 'assistant'        THEN 2
+                  WHEN 'message'          THEN 2
+                  WHEN 'model.completed'  THEN 1
+                  ELSE 0
+                END AS envelope_rank,
+                CAST(EXTRACT(EPOCH FROM CAST(ts AS TIMESTAMP)) AS BIGINT)
+                                                 AS ts_sec
+              FROM events
+              {where}
+            ),
+            bucket_max AS (
+              SELECT session_id, ts_sec, MAX(envelope_rank) AS max_rank
+              FROM ranked
+              GROUP BY session_id, ts_sec
+            ),
+            deduped AS (
+              -- Drop the slim ``model.completed`` sibling ONLY when an
+              -- ``assistant``/``message`` (rank=2) exists in the same
+              -- (session_id, ts_sec) bucket.
+              SELECT r.* FROM ranked r
+              JOIN bucket_max bm USING (session_id, ts_sec)
+              WHERE NOT (r.envelope_rank = 1 AND bm.max_rank = 2)
+            ),
+            deduped_sums AS (
+              SELECT day, agent_id,
+                     COALESCE(SUM(cost_usd), 0)    AS cost_usd_d,
+                     COALESCE(SUM(token_count), 0) AS token_count_d
+              FROM deduped
+              GROUP BY day, agent_id
+            )
             SELECT
-              substr(ts, 1, 10)            AS day,
-              agent_id,
-              COUNT(*)                     AS event_count,
-              COALESCE(SUM(cost_usd), 0)   AS cost_usd,
-              COALESCE(SUM(token_count), 0) AS token_count
-            FROM events
-            {where}
-            GROUP BY day, agent_id
-            ORDER BY day DESC
+              r.day,
+              r.agent_id,
+              COUNT(r.id)                   AS event_count,
+              COALESCE(ds.cost_usd_d, 0)    AS cost_usd,
+              COALESCE(ds.token_count_d, 0) AS token_count
+            FROM ranked r
+            LEFT JOIN deduped_sums ds
+              ON ds.day = r.day AND ds.agent_id IS NOT DISTINCT FROM r.agent_id
+            GROUP BY r.day, r.agent_id, ds.cost_usd_d, ds.token_count_d
+            ORDER BY r.day DESC
         """
         return [_row_to_dict(r, ["day","agent_id","event_count","cost_usd","token_count"])
                 for r in self._fetch(sql, params)]

--- a/tests/test_local_query_api.py
+++ b/tests/test_local_query_api.py
@@ -111,6 +111,49 @@ def test_sessions_endpoint(client):
     assert round(by_sid["X"]["cost_usd"], 4) == 0.30
 
 
+def test_aggregates_endpoint_dedupes_v3_sibling_pairs(client):
+    """Same dedupe contract as ``test_sessions_endpoint_dedupes_v3_sibling_pairs``,
+    one level up at the daily-aggregate layer. Issue: ``query_aggregates``
+    used to SUM(cost_usd) + SUM(token_count) over the raw events table,
+    doubling every billable turn on real v3 installs. The SQL CTE now
+    drops the slim sibling ONLY when an assistant/message rank-2 row
+    exists in the same (session_id, ts_sec) bucket.
+
+    ``event_count`` stays RAW so debug surfaces see all the rows.
+    """
+    c, ls = client
+    store = ls.get_store()
+    ts = "2026-05-16T10:00:00Z"
+    # Sibling pair = 1 deduped turn @ 150 tokens / $0.005
+    store.ingest(_ev(id="agg-assist", session_id="sess-pair",
+                     event_type="assistant", ts=ts,
+                     cost_usd=0.005, token_count=150))
+    store.ingest(_ev(id="agg-mc", session_id="sess-pair",
+                     event_type="model.completed", ts=ts,
+                     cost_usd=0.005, token_count=150))
+    # Two tool_calls sharing ts_sec are NOT siblings - both count
+    store.ingest(_ev(id="agg-t1", session_id="sess-tools",
+                     event_type="tool_call", ts=ts,
+                     cost_usd=0.10, token_count=12))
+    store.ingest(_ev(id="agg-t2", session_id="sess-tools",
+                     event_type="tool_call", ts=ts,
+                     cost_usd=0.20, token_count=33))
+    _wait(store)
+    r = c.get("/api/local/aggregates")
+    body = r.get_json()
+    by_day = {row["day"]: row for row in body["rows"]}
+    row = by_day["2026-05-16"]
+    assert row["event_count"] == 4, "raw event_count should report all 4 rows"
+    assert row["token_count"] == 195, (
+        f"dedupe wrong: expected 150 (deduped sibling) + 12 + 33 = 195 tokens, "
+        f"got {row['token_count']}"
+    )
+    assert round(row["cost_usd"], 4) == 0.305, (
+        f"dedupe wrong: expected $0.005 (deduped sibling) + $0.10 + $0.20 = $0.305, "
+        f"got {round(row['cost_usd'], 4)}"
+    )
+
+
 def test_sessions_endpoint_dedupes_v3_sibling_pairs(client):
     """Issue #1460: on real OpenClaw v3 installs each LLM turn emits BOTH
     an ``assistant`` row AND a sibling ``model.completed`` row ~100 ms


### PR DESCRIPTION
## Summary

Follows PR #1462's `query_sessions` fix. `query_aggregates` had the same shape of bug: blind `SUM(cost_usd)` + `SUM(token_count)` over the raw events table, doubling every billable turn on real v3 OpenClaw installs (assistant + sibling model.completed each contribute the same token_count).

After this lands, both `query_sessions` AND `query_aggregates` are deduped at the SQL layer. Any future consumer of either reads correct numbers without needing the Python helper from PR #1459 (which stays in place as belt-and-suspenders).

## Approach

Same 4-CTE rewrite as PR #1462:
1. **`ranked`** — tag each event with envelope rank + ts_sec bucket.
2. **`bucket_max`** — max rank per `(session_id, ts_sec)`.
3. **`deduped`** — drop slim `model.completed` sibling ONLY when richer envelope exists in the same bucket. Tool_calls sharing a ts_sec still both kept.
4. **`deduped_sums`** — aggregate cost_usd + token_count from deduped per day+agent.
5. Final SELECT joins back to `ranked` so `event_count` stays RAW (debug surfaces see all rows; only money-tied numbers are deduped).

## Verification

Pre-merge synthetic test:
- Sibling pair at same ts → deduped to 1 turn (150 tokens, $0.005)
- Two tool_calls at same ts → both counted (45 tokens, $0.30)
- Day rollup: event_count=4 (raw), tokens=195, cost=$0.305

New regression test asserts all 3 invariants. Test passes; existing 13 also pass.

## MOAT context

Personas on PR #1462 explicitly flagged `query_aggregates` as "the OTHER read path everyone consumes — fixing it would close `_try_local_store_usage`'s need for the Python dedupe too." This PR closes that loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)