### PR TITLE
feat(approvals): add Cloud-Pro notification upsell CTA on OSS queue (closes #1328)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4262,7 +4262,21 @@ async function loadNemoClawApprovals() {
       listEl.innerHTML = '<div style="color:var(--text-muted);font-size:12px;padding:8px 0;text-align:center;">✓ No pending requests</div>';
       return;
     }
+    // Cloud-Pro upsell CTA (issue #1328): backend stamps ``pro_gated_upsell``
+    // when the queue has >=1 pending row AND the caller is not on Cloud-Pro.
+    // Pro users never see this — OSS / Cloud-Free do. Surface the pending
+    // count in the copy because a specific number ("get pinged on your 3
+    // pending approvals") converts harder than a generic ask.
     var html = '';
+    if (data.pro_gated_upsell) {
+      var count = (typeof data.pending_count === 'number') ? data.pending_count : approvals.length;
+      var label = count + ' pending ' + (count === 1 ? 'approval' : 'approvals');
+      html += '<div style="margin-bottom:10px;padding:10px 12px;border:1px dashed rgba(124,92,255,0.5);border-radius:6px;background:rgba(124,92,255,0.06);font-size:12px;color:var(--text-secondary);line-height:1.5;">'
+        + 'Get pinged on your ' + escHtml(label) + ' the moment they land. '
+        + 'Send instant Slack, PagerDuty, or email alerts so you never miss a request. '
+        + '<a href="https://app.clawmetry.com/upgrade?source=approvals" target="_blank" rel="noopener" style="color:var(--accent,#7c5cff);font-weight:600;text-decoration:none;">Start your 7-day free trial</a>'
+        + '</div>';
+    }
     approvals.forEach(function(a) {
       var ruleDisplay = '';
       if (a.host) {

--- a/routes/nemoclaw.py
+++ b/routes/nemoclaw.py
@@ -304,6 +304,43 @@ def api_nemoclaw_reject():
     return jsonify({'ok': r.returncode == 0, 'output': r.stdout or r.stderr})
 
 
+# ── Cloud-Pro upsell flag (issue #1328) ────────────────────────────────────
+#
+# OSS users can SEE the approvals queue grow but get zero notification surface
+# (Slack / PagerDuty / email dispatch lives in Cloud-Pro per memory
+# ``project_alerts_pro_feature.md``). The dashboard JS renders an inline CTA
+# above the queue table whenever this flag is true: queue has >=1 pending row
+# AND the caller is NOT a Cloud-Pro user. Pro users never see the CTA.
+#
+# Same pattern as ``capped_pro_gated`` on /api/loop-signals (issue #1376):
+# decision lives on the server so the dashboard does not have to re-implement
+# the Pro check. Fails closed (treats any error as "not pro") so we never
+# accidentally suppress the upsell on a free node.
+def _annotate_pro_upsell(payload):
+    """Stamp ``pro_gated_upsell`` + ``pending_count`` on the response when the
+    queue has rows and the caller is NOT Cloud-Pro. No-op on empty queues so
+    the empty-state stays clean."""
+    try:
+        approvals = payload.get("approvals") or []
+        pending_count = len(approvals)
+        payload["pending_count"] = pending_count
+        if pending_count <= 0:
+            payload["pro_gated_upsell"] = False
+            return payload
+        try:
+            import dashboard as _d
+            is_pro = bool(_d._is_pro_user())
+        except Exception:
+            is_pro = False
+        payload["pro_gated_upsell"] = (not is_pro)
+    except Exception:
+        # Never let the CTA flag-stamping break the response — the queue
+        # itself is the load-bearing thing here.
+        payload.setdefault("pro_gated_upsell", False)
+        payload.setdefault("pending_count", 0)
+    return payload
+
+
 @bp_nemoclaw.route('/api/nemoclaw/pending-approvals')
 def api_nemoclaw_pending_approvals():
     """Return pending egress approval requests from openshell.
@@ -312,14 +349,18 @@ def api_nemoclaw_pending_approvals():
     local DuckDB ``approvals`` table has pending rows, serve from there
     and tag ``_source: "local_store"``. Otherwise fall through to the
     legacy ``openshell draft get`` CLI path (response is unchanged).
+
+    Issue #1328: every return path is annotated with ``pro_gated_upsell``
+    + ``pending_count`` so the dashboard JS can render the Cloud-Pro
+    notifications upsell CTA without re-deriving tier on the client.
     """
     if is_local_store_read_enabled():
         fast = _try_local_store_approvals()
         if fast is not None:
-            return jsonify(fast)
+            return jsonify(_annotate_pro_upsell(fast))
     import shutil as _shutil
     if not _shutil.which('openshell'):
-        return jsonify({'installed': False, 'approvals': []})
+        return jsonify(_annotate_pro_upsell({'installed': False, 'approvals': []}))
     try:
         # Get sandbox names
         import subprocess as _sp
@@ -383,6 +424,6 @@ def api_nemoclaw_pending_approvals():
                             'status': 'pending',
                             'ts': None,
                         })
-        return jsonify({'installed': True, 'approvals': approvals})
+        return jsonify(_annotate_pro_upsell({'installed': True, 'approvals': approvals}))
     except Exception as e:
-        return jsonify({'installed': True, 'approvals': [], 'error': str(e)})
+        return jsonify(_annotate_pro_upsell({'installed': True, 'approvals': [], 'error': str(e)}))

--- a/tests/test_approvals_local_store.py
+++ b/tests/test_approvals_local_store.py
@@ -346,6 +346,62 @@ def test_dispatch_pending_queries_applies_approval_decision(fast_path_app):
     assert by_id["app-2"]["status"] == "pending"
 
 
+# ── 9. issue #1328: Cloud-Pro upsell CTA flag on the queue response ────────
+#
+# OSS / Cloud-Free callers with >=1 pending approval get
+# ``pro_gated_upsell=true`` so the dashboard renders the Slack/PagerDuty/email
+# notifications CTA. Cloud-Pro callers never see the flag. Empty queue never
+# triggers the CTA (we don't want to pollute the clean empty state).
+
+
+def test_pending_approvals_pro_gated_upsell_for_oss_user(fast_path_app, monkeypatch):
+    """OSS / Cloud-Free user with pending approvals: response includes
+    ``pro_gated_upsell=true`` + ``pending_count`` so the JS can render the
+    upsell CTA above the queue table."""
+    _app, ls, _nm = fast_path_app
+    _seed_two_pending(ls.get_store())
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    body = _app.test_client().get("/api/nemoclaw/pending-approvals").get_json()
+    assert body.get("pro_gated_upsell") is True
+    assert body.get("pending_count") == 2
+    # The queue itself is still served — gating only adds the CTA flag.
+    assert len(body.get("approvals") or []) == 2
+
+
+def test_pending_approvals_no_upsell_for_pro_user(fast_path_app, monkeypatch):
+    """Cloud-Pro user with pending approvals: ``pro_gated_upsell`` is False
+    so the upsell CTA never renders. Count still surfaces (harmless metadata).
+    """
+    _app, ls, _nm = fast_path_app
+    _seed_two_pending(ls.get_store())
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    body = _app.test_client().get("/api/nemoclaw/pending-approvals").get_json()
+    assert body.get("pro_gated_upsell") is False
+    assert body.get("pending_count") == 2
+    assert len(body.get("approvals") or []) == 2
+
+
+def test_pending_approvals_empty_queue_never_upsells(no_flag_app, monkeypatch):
+    """Empty queue must NOT trigger the CTA — issue #1328 ask #2 explicitly
+    says don't pollute the empty state."""
+    _app, _ls, _nm = no_flag_app
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    body = _app.test_client().get("/api/nemoclaw/pending-approvals").get_json()
+    # Legacy path with no openshell binary returns installed=False, [].
+    # Either way, the upsell must be off when the queue is empty.
+    assert body.get("pro_gated_upsell") is False
+    assert body.get("pending_count") == 0
+
+
 def test_dispatch_pending_queries_approval_decision_missing_id_is_noop(fast_path_app):
     """A malformed approval_decision entry (no id) must NOT crash dispatch
     and must NOT touch the store."""


### PR DESCRIPTION
## Summary

Closes #1328. Post-merge product review of PR #1324 (Approvals queue fast-path) flagged the funnel gap: OSS users see the queue grow but get zero notification surface, since Slack/PagerDuty/email approval alerts live in Cloud-Pro. This wires the natural conversion CTA inline above the queue.

- Backend: `/api/nemoclaw/pending-approvals` now stamps `pro_gated_upsell` + `pending_count` on every return path. Decision runs server-side via `dashboard._is_pro_user()` (fail-closed), same pattern as the loop-signals `capped_pro_gated` flag (#1376).
- Frontend: `loadNemoClawApprovals` renders a single inline dashed-border CTA above the queue when `pro_gated_upsell` is true. CTA surfaces the exact pending count ("Get pinged on your 3 pending approvals") because a specific number converts harder than a generic ask. Click-through goes to `app.clawmetry.com/upgrade?source=approvals`.
- Empty queues never see the CTA (issue ask #2 was explicit about not polluting the empty state). Pro users never see the CTA (gated server-side).
- Plain copy, no em-dashes per memory rule.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_approvals_local_store.py` — 13/13 pass (10 existing + 3 new)
- [x] New tests cover: OSS user with pending approvals sees flag, Pro user does not, empty queue never upsells
- [x] Diff under 150 LOC (115 net additions)
- [ ] Manual smoke: load /nemoclaw tab in OSS, confirm CTA renders above queue when pending > 0, hidden when empty