### PR TITLE
feat(brain): one-time restoration toast after 0.12.182 empty-detail fix (closes #1195)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3806,6 +3806,20 @@ async function loadBrainPage(silent) {
     var streamEl = document.getElementById('brain-stream');
     var wasAtTop = !streamEl || streamEl.scrollTop < 40;
     renderBrainStream(events);
+    // Issue #1195 — One-time "Live event details restored" toast for users
+    // who lived through the 0.12.182 empty-detail regression. Fires only if
+    // (a) at least one event has a non-empty detail, (b) the user hasn't
+    // already seen the toast (localStorage flag), and (c) the install
+    // pre-dates the regression cutoff (epoch derived from config.json
+    // ctime). Fresh installs and repeat visits skip silently.
+    try {
+      var hasDetail = false;
+      for (var _i = 0; _i < events.length; _i++) {
+        var _d = events[_i] && (events[_i].detail || events[_i].text || events[_i].content);
+        if (_d && String(_d).trim() !== '') { hasDetail = true; break; }
+      }
+      if (hasDetail) maybeShowBrainRestorationToast();
+    } catch (_toastErr) { /* never block render */ }
   } catch(e) {
     // Always replace the spinner on error -- previously this only fired
     // when `silent=false`, so a silent retry that errored left the prior
@@ -3831,6 +3845,58 @@ async function loadBrainPage(silent) {
   }
   // Loop-signals badge (#1364) — fire-and-forget; never blocks the Brain tab.
   loadLoopSignals();
+}
+
+
+// ── Brain restoration toast (issue #1195) ─────────────────────────────────
+// One-time "Live event details restored" toast for installs that lived
+// through the 0.12.182 empty-detail regression (shipped 2026-05-12, fixed
+// in #1190 / 0.12.183+). Gating logic:
+//   1. localStorage flag stops re-fire across navigations & daemon restarts.
+//   2. /api/install-age tells us when the config file was first created;
+//      installs that were created AFTER the regression cutoff are fresh
+//      installs that never saw broken Brain, so they get no toast.
+//   3. Fires once per first non-empty Brain load that satisfies (1)+(2).
+var _brainRestorationToastInflight = false;
+// Unix epoch for 2026-05-12 00:00 UTC (regression ship date for 0.12.182).
+var _BRAIN_REGRESSION_CUTOFF_EPOCH = 1778544000;
+var _BRAIN_TOAST_FLAG = 'clawmetry_brain_restoration_toast_shown_v1';
+
+function maybeShowBrainRestorationToast() {
+  try {
+    if (_brainRestorationToastInflight) return;
+    if (window.CLOUD_MODE) return;
+    if (typeof localStorage === 'undefined') return;
+    if (localStorage.getItem(_BRAIN_TOAST_FLAG) === '1') return;
+    _brainRestorationToastInflight = true;
+    fetchJsonWithTimeout('/api/install-age', 4000).then(function(d) {
+      try {
+        // Fresh install OR config newer than regression cutoff: don't toast.
+        // Pre-existing install (ctime older than 2026-05-12): show toast once.
+        if (!d || !d.exists || !d.ctime) return;
+        if (d.ctime >= _BRAIN_REGRESSION_CUTOFF_EPOCH) return;
+        try { localStorage.setItem(_BRAIN_TOAST_FLAG, '1'); } catch (_e) {}
+        _showBrainToast('Live event details restored. Brain stream is back to normal.');
+      } catch (_inner) {}
+    }).catch(function() {
+      // /api/install-age failed (offline daemon, 404 on older builds, etc.).
+      // Fail closed: do nothing so we never spam the toast on errors.
+    });
+  } catch (_outer) {}
+}
+
+function _showBrainToast(msg) {
+  try {
+    var t = document.createElement('div');
+    t.className = 'cron-toast';
+    t.setAttribute('role', 'status');
+    t.textContent = msg;
+    document.body.appendChild(t);
+    setTimeout(function() {
+      t.style.opacity = '0';
+      setTimeout(function() { try { t.remove(); } catch (_e) {} }, 300);
+    }, 5000);
+  } catch (_e) {}
 }
 
 

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -132,6 +132,29 @@ def api_update():
     return {"ok": True, "old_version": old_version, "new_version": new_version}
 
 
+@bp_version.route("/api/install-age")
+def api_install_age():
+    """Return the ctime of ``~/.clawmetry/config.json`` as a Unix epoch.
+
+    Used by the Brain restoration toast (issue #1195) to distinguish
+    fresh installs from upgrades across the 0.12.182 empty-detail
+    regression window. Returns ``{exists: false, ctime: null}`` when the
+    config file is missing (fresh install with no prior daemon).
+    """
+    cfg_path = os.path.expanduser("~/.clawmetry/config.json")
+    try:
+        st = os.stat(cfg_path)
+        # Prefer ctime (inode creation) over mtime, since `clawmetry connect`
+        # rewrites the file on every key change. ctime is closer to "first
+        # ever install" than mtime.
+        return {"exists": True, "ctime": int(st.st_ctime), "mtime": int(st.st_mtime)}
+    except FileNotFoundError:
+        return {"exists": False, "ctime": None, "mtime": None}
+    except Exception:
+        # Never crash on bad filesystem state; treat as fresh-install.
+        return {"exists": False, "ctime": None, "mtime": None}
+
+
 # ── Gateway proxy routes ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- One-time toast "Live event details restored. Brain stream is back to normal." on the first non-empty `/api/brain-history` load post-upgrade. Heals the trust regression for users who hit the empty Brain stream between `0.12.182` (shipped 2026-05-12) and the `0.12.183+` fix from PR #1190.
- New tiny endpoint `GET /api/install-age` in `routes/meta.py` returns the ctime/mtime of `~/.clawmetry/config.json`. Used to distinguish fresh installs (no toast — never saw the bug) from upgrades.
- Gating in `app.js`: localStorage flag + install-ctime check + presence of at least one non-empty `detail`. Reuses existing `.cron-toast` CSS — no new style, no new deps.

Closes #1195.

## Acceptance map

- [x] Toast fires once on first Brain page load post-upgrade when `events.some(e => e.detail !== '')`.
- [x] Fresh installs skip: `/api/install-age` returns ctime >= `2026-05-12` cutoff, helper bails before showing.
- [x] Re-fire across page navigations within same daemon lifetime blocked by localStorage flag (set immediately when toast renders).
- [x] Daemon restart preserves the flag (localStorage is per-origin, browser-persisted).

## Test plan

- [ ] Manual: clear `clawmetry_brain_restoration_toast_shown_v1` from localStorage, ensure `~/.clawmetry/config.json` has a ctime older than 2026-05-12, load `/`, click Brain tab, confirm toast appears once.
- [ ] Manual: reload page, navigate away + back to Brain, confirm toast does NOT re-fire.
- [ ] Manual: `rm ~/.clawmetry/config.json`, restart daemon (regenerates with current ctime), confirm toast does NOT appear (fresh-install gate).
- [ ] `python3 -c "import dashboard"` clean (passed locally).
- [ ] `node --check clawmetry/static/js/app.js` clean (passed locally).

Diff: 89 LOC across 2 files.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>