### PR TITLE
feat(alerts): wire LoopDetector to alerts pipeline + browser notification (closes #1377)

### DIFF
--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -696,6 +696,36 @@ class LoopDetector:
                 )
             except Exception as exc:  # noqa: BLE001 — never break detection
                 logger.debug("loop signal duckdb ingest skipped: %s", exc)
+            # Issue #1377: also emit a ``loop_detected`` event row so the
+            # existing alert pipeline (``clawmetry/alert_evaluator.py`` driven
+            # by ``clawmetry/sync.py::evaluate_alerts``) can fire a Cloud-Pro
+            # rule of type ``count_over_threshold`` / ``event_type=loop_detected``
+            # and fan out to Slack/email/PagerDuty. Same best-effort guard as
+            # the badge write above — never let the alert hop break detection
+            # or block the proxy hot path. Done inline (not threaded) because
+            # ``LocalStore.ingest`` itself only appends to an in-memory ring
+            # buffer and returns in microseconds; the actual DuckDB write is
+            # already async on the flusher thread.
+            try:
+                from clawmetry import local_store as _ls
+                import uuid as _uuid
+                _ls.get_store().ingest({
+                    "id":         _uuid.uuid4().hex,
+                    "node_id":    os.environ.get("CLAWMETRY_NODE_ID") or "local",
+                    "agent_id":   "clawmetry-proxy",
+                    "agent_type": "openclaw",
+                    "event_type": "loop_detected",
+                    "ts":         datetime.now(timezone.utc).isoformat(),
+                    "session_id": session_id,
+                    "data": {
+                        "signature":      request_hash,
+                        "repeat_count":   match_count,
+                        "window_seconds": self.config.window_seconds,
+                        "reason":         reason,
+                    },
+                })
+            except Exception as exc:  # noqa: BLE001 — never break detection
+                logger.debug("loop_detected alert event skipped: %s", exc)
             return True, reason
 
         return False, ""

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3839,6 +3839,45 @@ async function loadBrainPage(silent) {
 // clawmetry/proxy.py's LoopDetector. Hidden when the count is 0; clicking
 // expands a flat table (Time | Session | Pattern | Repeat).
 var _loopSignalsExpanded = false;
+// Issue #1377: fire a browser notification on the FIRST detection per
+// dashboard session — the highest-intent moment a user has for noticing the
+// alerts feature. Tracks the most recent signature we've already alerted on
+// so we don't re-notify on every poll. Reset on page reload (intentional —
+// we re-alert if the user comes back fresh and a loop is still active).
+var _loopSignalsNotifiedSig = null;
+var _loopSignalsPermissionAsked = false;
+
+function _loopSignalsMaybeNotify(rows) {
+  if (!rows || !rows.length) return;
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+  // Pick the newest signature (rows arrive newest-first from the API).
+  var top = rows[0] || {};
+  var sig = String(top.signature || '');
+  if (!sig || sig === _loopSignalsNotifiedSig) return;
+  _loopSignalsNotifiedSig = sig;
+  // TODO #1377: Cloud-Free upsell modal here when CLOUD_MODE && tier === 'free'.
+  // Plain copy, no em-dashes — keeps the message readable to non-tech users
+  // (memory: feedback_no_em_dashes_in_user_facing_copy.md).
+  var title = 'Loop detected in your agent';
+  var body  = 'Loop detected, agent is repeating itself and burning tokens. Open the Brain tab to see why.';
+  function _fire() {
+    try {
+      var n = new Notification(title, { body: body, tag: 'clawmetry-loop' });
+      // Focus the dashboard tab if the user clicks the notification.
+      n.onclick = function() { try { window.focus(); n.close(); } catch (e) {} };
+    } catch (e) { /* notification creation failed — silently ignore */ }
+  }
+  try {
+    if (Notification.permission === 'granted') {
+      _fire();
+    } else if (Notification.permission !== 'denied' && !_loopSignalsPermissionAsked) {
+      _loopSignalsPermissionAsked = true;
+      Notification.requestPermission().then(function(perm) {
+        if (perm === 'granted') _fire();
+      }).catch(function() { /* ignore — older browsers reject promise */ });
+    }
+  } catch (e) { /* Notification API unavailable — silently ignore */ }
+}
 
 async function loadLoopSignals() {
   if (window.CLOUD_MODE) return;
@@ -3860,6 +3899,11 @@ async function loadLoopSignals() {
     }
     badge.style.display = '';
     countEl.textContent = String(totalCount);
+    // Issue #1377: first-detection-per-session browser notification.
+    // Fired here so any tab (Brain or otherwise) that has triggered the
+    // loop-signal poll sees the notification — the highest-intent moment
+    // for an alerts upsell.
+    _loopSignalsMaybeNotify(rows);
     // Render table — keep it dead simple: Time | Session | Pattern | Repeat.
     var head = '<div style="display:grid;grid-template-columns:130px 160px 1fr 70px;gap:10px;padding:4px 0;border-bottom:1px solid var(--border-secondary);font-size:10px;color:var(--text-muted);text-transform:uppercase;letter-spacing:1px;">'
       + '<div>Last seen</div><div>Session</div><div>Pattern</div><div style="text-align:right;">Repeats</div></div>';

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -544,6 +544,53 @@ class TestLoopDetector:
         is_loop, _ = loop_detector.check("", "same")
         assert is_loop is False
 
+    def test_loop_emits_alert_event(self, loop_detector, proxy_db, monkeypatch):
+        """Issue #1377: a positive LoopDetector.check() must also push a
+        ``loop_detected`` event into local_store.ingest() so the daemon's
+        alert evaluator (clawmetry/alert_evaluator.py) can fire matching
+        Cloud-Pro rules. This is the only OSS-side hook the alert pipeline
+        needs — the daemon then walks DuckDB + cached rules and dispatches.
+        """
+        captured: list[dict] = []
+
+        class _FakeStore:
+            def ingest(self, event):
+                captured.append(event)
+
+            def ingest_loop_signal(self, **kwargs):
+                # Existing badge write — not what this test cares about, but
+                # we still accept the call so the detector's first try-block
+                # doesn't raise.
+                pass
+
+        fake = _FakeStore()
+        # Patch get_store at the module the detector imports lazily.
+        from clawmetry import local_store as _ls
+        monkeypatch.setattr(_ls, "get_store", lambda: fake)
+
+        for _ in range(4):
+            proxy_db.record_usage(
+                provider="anthropic",
+                model="test",
+                input_tokens=100,
+                output_tokens=50,
+                cost_usd=0.01,
+                session_id="s-1377",
+                request_hash="loop-sig-1377",
+            )
+        is_loop, _ = loop_detector.check("s-1377", "loop-sig-1377")
+        assert is_loop is True
+
+        # Exactly one loop_detected event was emitted with the expected shape.
+        loop_events = [e for e in captured if e.get("event_type") == "loop_detected"]
+        assert len(loop_events) == 1
+        evt = loop_events[0]
+        assert evt["session_id"] == "s-1377"
+        assert evt["agent_id"] == "clawmetry-proxy"
+        assert evt["data"]["signature"] == "loop-sig-1377"
+        assert evt["data"]["repeat_count"] >= 3
+        assert "id" in evt and "ts" in evt and "node_id" in evt
+
 
 # ── Model Router ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #1377. The highest-intent moment a user has for noticing alerts is the moment their agent starts burning money in a loop. Before this PR, that moment was wasted — LoopDetector's positive branch only wrote a dashboard badge row and a SQLite log entry. No alert, no notification, no funnel hook.

This PR plumbs that moment into the existing alerts pipeline and adds a browser notification on the OSS side, with one cohesive change:

- **OSS (`clawmetry/proxy.py`)** — `LoopDetector.check()` positive branch now also emits a `loop_detected` event row into the local DuckDB store via `local_store.ingest()`. The daemon's existing evaluator (`clawmetry/alert_evaluator.py`, driven by `clawmetry/sync.py::evaluate_alerts`) already walks new events against cached Cloud-Pro rules every tick and POSTs matches to `/api/cloud/alerts/dispatch`. No new pipeline, no new evaluator type — a `count_over_threshold` rule with `event_type=loop_detected` fires today.
- **OSS browser notification (`clawmetry/static/js/app.js`)** — `loadLoopSignals()` now triggers `Notification.requestPermission()` + `new Notification(...)` on the first **new** signature per dashboard session. Tracks the most-recent notified signature so we don't re-fire on every poll. Permission prompt fires at most once. Copy: "Loop detected, agent is repeating itself and burning tokens. Open the Brain tab to see why." (plain comma, no em-dashes per the user-facing-copy memory rule).
- **Cloud-Free upsell** — out of scope; left an inline `TODO #1377` comment in the JS where the cloud-side modal will plug in.
- **Cloud-Pro fan-out** — already handled by the existing daemon evaluator + cloud dispatch endpoint. No new code needed.

Hot-path safety: the `ingest()` call queues to an in-memory ring buffer and returns in microseconds; the flusher thread owns the DuckDB write. Wrapped in the same best-effort `try/except` as the existing #1364 badge write — never let the alert hop break detection.

Diff: 121 LOC across 3 files (well under the 300 cap).

## Test plan

- [x] Unit: new `tests/test_proxy.py::TestLoopDetector::test_loop_emits_alert_event` monkeypatches `local_store.get_store()` and asserts a `loop_detected` event lands with the expected shape after a positive `check()`.
- [x] Regression: all 6 `TestLoopDetector` tests green.
- [x] Regression: `tests/test_loop_signals_e2e.py` + `tests/test_alert_evaluator_unit.py` (28 tests) green.
- [x] Regression: `tests/test_moat_send_message_e2e.py` + `tests/test_local_query_api.py` (17 tests) green.
- [x] Smoke: `python3 -c "import dashboard; import clawmetry.proxy"` clean.
- [x] JS syntax: `node --check clawmetry/static/js/app.js` clean.
- [x] No em-dashes in user-facing notification copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)