### PR TITLE
feat(instrument): anon ping on first-load auth-fail to quantify funnel loss (closes #1365)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -12794,6 +12794,57 @@ function _withTimeout(promise, ms, label) {
   ]);
 }
 
+// ── Anonymous auth-fail-on-first-load instrumentation (issue #1365) ──────
+// The `pgrep openclaw-gatewa` typo in #1357 silently killed gateway-token
+// auto-detect for every fresh install without OPENCLAW_GATEWAY_TOKEN set.
+// We had no way to spot the regression because nothing pinged when first
+// boot rejected the locally-valid token. These pure helpers + the gated
+// emit inside bootDashboard() let us quantify the funnel loss next time.
+// NO token content, NO IP — see /api/anon-auth-fail-ping on the server.
+function _uaClass(ua) {
+  // Bucket the UA into 4 buckets so cardinality stays tiny in analytics.
+  // Order matters: Edge and Opera embed "Chrome" in their UA, so we test
+  // those exclusion-style before falling through to Chrome.
+  var s = String(ua || '').toLowerCase();
+  if (s.indexOf('firefox') !== -1) return 'firefox';
+  // Safari ships "Safari" + "Version/" but Chrome ALSO ships "Safari".
+  // Detect Safari by "safari" present AND "chrome"/"chromium" absent.
+  if (s.indexOf('safari') !== -1 && s.indexOf('chrome') === -1 && s.indexOf('chromium') === -1) return 'safari';
+  if (s.indexOf('chrome') !== -1 || s.indexOf('chromium') !== -1) return 'chrome';
+  return 'other';
+}
+
+function _shouldPingAuthFailFirstLoad(storedToken, authData) {
+  // Fire ONLY when this is genuinely a first-load reject — i.e. the user
+  // has no prior token in localStorage. A 401 with a stored token is a
+  // session timeout / rotated token, not a fresh-install funnel drop, and
+  // would pollute the signal we're trying to measure.
+  if (storedToken) return false;
+  if (!authData) return false;
+  if (authData.needsSetup) return false;  // separate funnel; not our target.
+  return !!(authData.authRequired && !authData.valid);
+}
+
+function _pingAuthFailFirstLoad() {
+  // Fire-and-forget. Never blocks boot, never surfaces errors. The server
+  // logs to local DuckDB/JSONL and best-effort forwards to cloud.
+  try {
+    var badge = document.getElementById('version-badge');
+    var version = badge ? String(badge.textContent || '').replace(/^v/, '').trim() : 'unknown';
+    var body = JSON.stringify({
+      event: 'auth_fail_first_load',
+      version: version || 'unknown',
+      user_agent_class: _uaClass(navigator && navigator.userAgent),
+    });
+    fetch('/api/anon-auth-fail-ping', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body,
+      keepalive: true,
+    }).catch(function() { /* fail-silent by design */ });
+  } catch (e) { /* never crash boot on telemetry */ }
+}
+
 async function bootDashboard() {
   // Hard floor: dismiss overlay after BOOT_HARD_TIMEOUT_MS no matter what.
   // The dashboard stays usable with partial data; individual panels show
@@ -12819,6 +12870,11 @@ async function bootDashboard() {
       return;
     }
     if (authData.authRequired && !authData.valid) {
+      // Anonymous funnel-loss ping (issue #1365). Gated on "no prior token"
+      // so we measure fresh-install rejects, not session timeouts.
+      if (_shouldPingAuthFailFirstLoad(stored, authData)) {
+        _pingAuthFailFirstLoad();
+      }
       document.getElementById('login-overlay').style.display = 'flex';
       _safeFinishBoot();
       return;

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -451,6 +451,138 @@ def api_auth_detected_token():
     return jsonify({"token": token, "source": _detected_token_source(token)})
 
 
+# ── Anonymous funnel-loss instrumentation (issue #1365) ──────────────────────
+# Allowed event names. Keep this tiny — every new value is an analytics
+# schema commitment. Today we only ship the one funnel we got burned on
+# in #1357 (typo'd pgrep killed auto-detect).
+_ANON_ALLOWED_EVENTS = frozenset({"auth_fail_first_load"})
+_ANON_ALLOWED_UA = frozenset({"chrome", "safari", "firefox", "other"})
+_ANON_LOG_PATH = os.path.expanduser("~/.clawmetry/anon_events.jsonl")
+# Hard caps: defence in depth against anything that slips past the JS
+# helpers and posts pathological payloads.
+_ANON_VERSION_MAX = 32
+_ANON_EVENT_MAX = 64
+_ANON_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB rolling cap — older entries pruned.
+
+# Fields that MUST NEVER appear in a body — defense against accidental PII
+# leak if a future caller forgets the schema. Server rejects 400 on any.
+_ANON_FORBIDDEN_FIELDS = frozenset({
+    "token", "auth", "authorization", "bearer", "password", "secret",
+    "ip", "remote_addr", "x_forwarded_for", "user_id", "email", "username",
+    "session_id", "cookie",
+})
+
+
+def _anon_append_local(payload: dict) -> None:
+    """Append ``payload`` as a JSONL line to the local durable log.
+
+    Local DuckDB is process-locked (see memory: DuckDB locks at PROCESS
+    level — daemon owns the writer). We don't want to add a daemon-proxy
+    hop for a fire-and-forget telemetry ping, so we use a plain JSONL
+    file as the durable record. The daemon can flush it to cloud later;
+    losing a few lines on crash is acceptable for a counter ping.
+    """
+    try:
+        os.makedirs(os.path.dirname(_ANON_LOG_PATH), exist_ok=True)
+        # Rolling cap: if the file is over the limit, truncate. We could
+        # do a proper rotate, but this is a counter ping — keeping the
+        # most recent 5 MB is more than enough for funnel-loss analysis.
+        try:
+            if os.path.getsize(_ANON_LOG_PATH) > _ANON_LOG_MAX_BYTES:
+                with open(_ANON_LOG_PATH, "w"):
+                    pass
+        except OSError:
+            pass
+        with open(_ANON_LOG_PATH, "a") as fh:
+            fh.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    except Exception:
+        # Telemetry must never break the dashboard. Eat all errors.
+        pass
+
+
+def _anon_forward_cloud(payload: dict) -> None:
+    """Best-effort POST to the cloud analytics ingest. Fail-silent.
+
+    The cloud endpoint may not exist yet — that's fine, the local JSONL
+    is the durable record. We try anyway so once cloud catches up, the
+    OSS side starts feeding live data without another release.
+    """
+    try:
+        import urllib.request as _ur
+        req = _ur.Request(
+            "https://app.clawmetry.com/api/admin/anon-event",
+            data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        # Short timeout — never block the OSS request thread on the cloud.
+        _ur.urlopen(req, timeout=2).close()
+    except Exception:
+        pass
+
+
+@bp_auth.route("/api/anon-auth-fail-ping", methods=["POST"])
+def api_anon_auth_fail_ping():
+    """Receive an anonymous funnel-loss ping from the dashboard JS.
+
+    Triggered by the OSS dashboard's bootstrap path when ``/api/auth/check``
+    rejects on first page-load with no prior token in localStorage. The
+    typo regression of #1357 was completely invisible to us because no
+    such ping existed; this is the early-warning canary so we catch the
+    next one within a day instead of a week.
+
+    Strict allowlist on schema — any unexpected field, any token-like
+    name, any unbucketed UA class is a 400. We default-deny to keep the
+    "anonymous only" invariant verifiable from a single function.
+    """
+    body = request.get_json(silent=True) or {}
+    if not isinstance(body, dict):
+        return jsonify({"error": "body must be a JSON object"}), 400
+
+    # Defense in depth: reject any forbidden field before parsing the
+    # allowed ones. If a future client (or attacker) tries to sneak
+    # ``{event: ..., token: "leak"}`` past us, we'd rather 400 than
+    # silently drop the token and persist the rest.
+    for key in body.keys():
+        if str(key).strip().lower() in _ANON_FORBIDDEN_FIELDS:
+            return jsonify({"error": "forbidden field in body"}), 400
+
+    event = str(body.get("event") or "").strip()
+    version = str(body.get("version") or "").strip()
+    ua_class = str(body.get("user_agent_class") or "").strip().lower()
+
+    if event not in _ANON_ALLOWED_EVENTS:
+        return jsonify({"error": "unknown event"}), 400
+    if ua_class not in _ANON_ALLOWED_UA:
+        return jsonify({"error": "unknown user_agent_class"}), 400
+    if not version or len(version) > _ANON_VERSION_MAX:
+        return jsonify({"error": "invalid version"}), 400
+    if len(event) > _ANON_EVENT_MAX:
+        return jsonify({"error": "event too long"}), 400
+
+    # Build the durable record. Server stamps ``ts`` (UTC seconds) so the
+    # client clock can't pollute the time series. No IP, no user id, no
+    # token — explicitly so.
+    payload = {
+        "ts": int(time.time()),
+        "event": event,
+        "version": version,
+        "user_agent_class": ua_class,
+    }
+    # Both helpers swallow their own errors, but we wrap defensively
+    # too: if a future refactor accidentally lets an exception escape,
+    # we still return 200 to the dashboard instead of breaking boot.
+    try:
+        _anon_append_local(payload)
+    except Exception:
+        pass
+    try:
+        _anon_forward_cloud(payload)
+    except Exception:
+        pass
+    return jsonify({"ok": True})
+
+
 @bp_auth.route("/auth")
 def auth_token():
     """Accept ?token=XXX, store in localStorage via JS, redirect to /.

--- a/tests/test_anon_auth_fail_ping.py
+++ b/tests/test_anon_auth_fail_ping.py
@@ -1,0 +1,158 @@
+"""Tests for the /api/anon-auth-fail-ping endpoint (issue #1365).
+
+The OSS dashboard fires an anonymous funnel-loss ping when /api/auth/check
+rejects on first page load. The typo regression in PR #1357 was invisible
+to us because no such ping existed; this endpoint is the early-warning
+canary for the next regression of that class.
+
+Invariants exercised:
+  * Happy path: valid {event, version, user_agent_class} → 200 + line on disk.
+  * Strict allowlist on event + UA class + version length → 400 otherwise.
+  * PII defence: any token/auth/ip field in the body → 400 *before* the
+    record is persisted (regression-test the "never leak" promise).
+  * Server stamps ts (no client clock pollution).
+  * Cloud-forward failure is swallowed → endpoint still 200s.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import dashboard  # noqa: E402  (registers shared module state)
+from routes import meta as meta_mod  # noqa: E402
+from routes.meta import bp_auth  # noqa: E402
+
+
+@pytest.fixture
+def log_path(tmp_path, monkeypatch):
+    """Redirect the JSONL log to a tmp dir so tests can read it back."""
+    p = tmp_path / "anon_events.jsonl"
+    monkeypatch.setattr(meta_mod, "_ANON_LOG_PATH", str(p), raising=False)
+    return p
+
+
+@pytest.fixture
+def client(monkeypatch, log_path):
+    """Flask app with bp_auth + cloud-forward stubbed to a no-op."""
+    monkeypatch.setattr(meta_mod, "_anon_forward_cloud", lambda payload: None)
+    a = Flask(__name__)
+    a.register_blueprint(bp_auth)
+    return a.test_client()
+
+
+def _read_lines(p: Path) -> list[dict]:
+    if not p.exists():
+        return []
+    return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
+
+
+# ── happy path + server-stamped ts ─────────────────────────────────────────
+
+def test_happy_path_persists_and_stamps_ts(client, log_path):
+    r = client.post(
+        "/api/anon-auth-fail-ping",
+        json={
+            "event": "auth_fail_first_load",
+            "version": "0.12.238",
+            "user_agent_class": "chrome",
+        },
+    )
+    assert r.status_code == 200, r.get_data(as_text=True)
+    assert r.get_json() == {"ok": True}
+    lines = _read_lines(log_path)
+    assert len(lines) == 1
+    rec = lines[0]
+    assert rec == {
+        "ts": rec["ts"],  # server-stamped; verified below
+        "event": "auth_fail_first_load",
+        "version": "0.12.238",
+        "user_agent_class": "chrome",
+    }
+    assert isinstance(rec["ts"], int) and rec["ts"] > 0
+    # No client-side fields snuck through.
+    assert "client_ts" not in rec
+
+
+# ── strict allowlist on event + UA class + version ─────────────────────────
+
+@pytest.mark.parametrize("body,reason", [
+    ({"event": "auth_fail_session_timeout", "version": "0.12.238",
+      "user_agent_class": "chrome"}, "unknown event"),
+    ({"event": "auth_fail_first_load", "version": "0.12.238",
+      "user_agent_class": "opera"}, "unknown UA bucket"),
+    ({"event": "auth_fail_first_load", "version": "",
+      "user_agent_class": "chrome"}, "missing version"),
+    ({"event": "auth_fail_first_load", "version": "x" * 200,
+      "user_agent_class": "chrome"}, "oversize version"),
+])
+def test_rejects_invalid_payloads(client, log_path, body, reason):
+    r = client.post("/api/anon-auth-fail-ping", json=body)
+    assert r.status_code == 400, f"{reason}: {r.get_data(as_text=True)}"
+    assert _read_lines(log_path) == [], reason
+
+
+def test_rejects_non_object_body(client, log_path):
+    r = client.post(
+        "/api/anon-auth-fail-ping",
+        data=json.dumps([1, 2, 3]),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+# ── PII defence — the "never leak" backstop ────────────────────────────────
+
+@pytest.mark.parametrize("field", [
+    "token", "Token", "authorization", "bearer", "password", "ip",
+    "remote_addr", "user_id", "email", "session_id", "cookie",
+])
+def test_rejects_pii_fields(client, log_path, field):
+    """If anything ever tries to sneak a token-like field past us, the
+    endpoint must 400 *before* persisting the record. Defence in depth
+    for the "anonymous only" invariant — the schema check could one day
+    silently strip the field; this guarantees it never does."""
+    r = client.post(
+        "/api/anon-auth-fail-ping",
+        json={
+            "event": "auth_fail_first_load",
+            "version": "0.12.238",
+            "user_agent_class": "chrome",
+            field: "would-be-leak",
+        },
+    )
+    assert r.status_code == 400, f"field={field} should be rejected"
+    assert _read_lines(log_path) == [], f"field={field} leaked to disk"
+
+
+# ── fail-silent on cloud-forward error ─────────────────────────────────────
+
+def test_cloud_forward_failure_does_not_break_endpoint(monkeypatch, log_path):
+    """If cloud endpoint 5xxs / times out / raises, the OSS endpoint must
+    still return 200 and still persist the local record. The durable
+    signal is the local JSONL; cloud is best-effort display layer."""
+    monkeypatch.setattr(
+        meta_mod, "_anon_forward_cloud",
+        lambda payload: (_ for _ in ()).throw(RuntimeError("cloud is on fire")),
+    )
+    a = Flask(__name__)
+    a.register_blueprint(bp_auth)
+    client = a.test_client()
+    r = client.post(
+        "/api/anon-auth-fail-ping",
+        json={
+            "event": "auth_fail_first_load",
+            "version": "0.12.238",
+            "user_agent_class": "chrome",
+        },
+    )
+    assert r.status_code == 200
+    assert len(_read_lines(log_path)) == 1

--- a/tests/test_appjs_units.js
+++ b/tests/test_appjs_units.js
@@ -534,5 +534,78 @@ console.log('_collapseBodylessOutbound (P1 follow-up to #1205 — collapse outbo
   eq(out8[2].type, 'EXEC', 'EXEC preserved');
 }
 
+// ── Test anon auth-fail funnel-loss ping helpers (issue #1365) ─────────
+// The bootstrap path must fire a ping ONLY when:
+//   - localStorage has no prior token (first-load reject, not session timeout)
+//   - /api/auth/check returned {authRequired:true, valid:false}
+//   - NOT in the needsSetup branch (separate funnel; not our target)
+// And the UA bucketer must squash everything into chrome/safari/firefox/other
+// without leaking version numbers / OS strings into analytics cardinality.
+console.log('anon auth-fail ping helpers (issue #1365)');
+{
+  const sandbox = { Date: Date };
+  vm.createContext(sandbox);
+  const code = extractFunction('_uaClass') + '\n' +
+               extractFunction('_shouldPingAuthFailFirstLoad') + '\n' +
+               'this.api = { _uaClass: _uaClass, _should: _shouldPingAuthFailFirstLoad };';
+  vm.runInContext(code, sandbox);
+  const api = sandbox.api;
+
+  // _uaClass buckets.
+  // Real Chrome UA on Mac:
+  eq(api._uaClass(
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+    '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+  ), 'chrome', 'Mac Chrome → chrome');
+  // Real Safari UA (no "Chrome" token, has "Safari").
+  eq(api._uaClass(
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 ' +
+    '(KHTML, like Gecko) Version/17.4 Safari/605.1.15'
+  ), 'safari', 'Mac Safari → safari');
+  // Real Firefox UA.
+  eq(api._uaClass(
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0'
+  ), 'firefox', 'Mac Firefox → firefox');
+  // Edge embeds Chrome — must bucket as chrome (close enough; we only
+  // want browser-engine cardinality, not vendor).
+  eq(api._uaClass(
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+    '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0'
+  ), 'chrome', 'Edge (Chromium) → chrome bucket');
+  // curl / scripts / unknowns.
+  eq(api._uaClass('curl/8.7.1'), 'other', 'curl → other');
+  eq(api._uaClass(''), 'other', 'empty UA → other');
+  eq(api._uaClass(null), 'other', 'null UA → other');
+  eq(api._uaClass(undefined), 'other', 'undefined UA → other');
+
+  // _shouldPingAuthFailFirstLoad gating matrix.
+  const FAIL = { authRequired: true, valid: false };
+  const OK = { authRequired: true, valid: true };
+  const SETUP = { needsSetup: true, authRequired: true, valid: false };
+
+  // True only for: no stored token AND a fresh auth-fail response.
+  eq(api._should(null, FAIL), true, 'no token + auth fail → fire ping');
+  eq(api._should('', FAIL), true, 'empty token + auth fail → fire ping');
+
+  // Stored token = session-timeout or rotated token, NOT a fresh-install
+  // funnel drop. Polluting the signal would defeat the purpose.
+  eq(api._should('cm_abc', FAIL), false,
+     'stored token + auth fail → suppress (session timeout, not first-load)');
+
+  // Successful auth must never trigger a ping.
+  eq(api._should(null, OK), false, 'no token + auth OK → no ping');
+  eq(api._should('cm_abc', OK), false, 'stored token + auth OK → no ping');
+
+  // needsSetup is a separate funnel (gateway not running at all). Don't
+  // mix it into the "valid token rejected" signal we're trying to surface.
+  eq(api._should(null, SETUP), false, 'needsSetup → suppress (separate funnel)');
+
+  // Defensive: malformed authData must never throw.
+  eq(api._should(null, null), false, 'null authData → no ping');
+  eq(api._should(null, {}), false, 'empty authData → no ping');
+  eq(api._should(null, { authRequired: false }), false,
+     'authRequired:false → no ping');
+}
+
 console.log('\n' + (failed === 0 ? 'PASS' : 'FAIL') + ' — ' + passed + ' passed, ' + failed + ' failed');
 process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

The 4-byte `pgrep openclaw-gatewa` typo in #1357 silently killed gateway-token auto-detect for every fresh-install user without `OPENCLAW_GATEWAY_TOKEN` in env. We had no instrumentation to spot it; the day-zero churn between the typo landing and #1357 fixing it is currently unknowable.

This wires a lightweight, anonymous canary so the next regression of this class is visible within a day:

- **JS bootstrap** (`app.js`): on `/api/auth/check` reject, if `localStorage` has no prior token (i.e. first-load reject, NOT a session timeout / rotated token), POST `/api/anon-auth-fail-ping` with `{event, version, user_agent_class}`. UA is bucketed into `chrome/safari/firefox/other` to keep analytics cardinality tiny. Fire-and-forget; never blocks boot; never surfaces errors.
- **Server endpoint** (`routes/meta.py`): strict allowlist on event + UA bucket + version length. Default-deny on any token / authorization / ip / user-id / email / session-id / cookie field (defence-in-depth backstop for the "anonymous only" invariant). Stamps `ts` server-side, persists to `~/.clawmetry/anon_events.jsonl` (durable local record per local-compute / cloud-display rule), and best-effort POSTs to `https://app.clawmetry.com/api/admin/anon-event` (fail-silent if absent).

NOT PostHog (killed; never reintroduce). The cloud-side ingest + admin display on `app.clawmetry.com/admin/thesecretpageforvivek` is a follow-up PR cloud-side.

## What we can answer with this

1. "Did the 0.12.X release tank first-boot success rates?" — diff yesterday's anon ping count vs today's.
2. "How many installs did we lose between #1357 typo and the fix?" — backfill estimate once the daemon flushes ~/.clawmetry/anon_events.jsonl to cloud (follow-up).

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_moat_send_message_e2e.py tests/test_local_query_api.py -q` (17 passed)
- [x] `python3 -m pytest tests/test_anon_auth_fail_ping.py -q` (18 passed: happy path, allowlist, PII rejection matrix, cloud-forward fail-silent)
- [x] `node tests/test_appjs_units.js` (106 passed, +16 new for `_uaClass` + `_shouldPingAuthFailFirstLoad`)
- [ ] Sanity load dashboard in browser, clear localStorage, mis-type token, confirm exactly one POST to `/api/anon-auth-fail-ping` shows in Network tab (manual smoke; not blocking review)

## Constraints honoured

- Diff: 188 LOC production + 231 LOC tests. Production well under the 300 LOC budget.
- Anonymous: no token, no IP, no user-id, no email — and the server rejects any payload that tries to add one.
- Local-compute / cloud-display: JSONL on local disk is the durable record; cloud is best-effort.
- No PostHog.

closes #1365

🤖 Generated with [Claude Code](https://claude.com/claude-code)