### PR TITLE
fix(tokens-banner): positive reframe + gate on install-age to skip fresh installs (closes #1430)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -4466,8 +4466,8 @@ function clawmetryLogout(){
   </div>
   <script>
   (function(){
-    // Cutoff epoch per issue #1430 (2026-05-15 00:00 UTC, day 0.12.230 shipped).
-    var TOKENS_CUTOFF_EPOCH = 1779062400;
+    // Cutoff epoch: 2026-05-15 00:00 UTC, day 0.12.230 shipped.
+    var TOKENS_CUTOFF_EPOCH = 1778803200;
     var FLAG = 'clawmetry_tokens_attribution_banner_shown_v1';
     try {
       if (typeof localStorage !== 'undefined' && localStorage.getItem(FLAG) === '1') return;

--- a/dashboard.py
+++ b/dashboard.py
@@ -4456,15 +4456,32 @@ function clawmetryLogout(){
   <div id="cost-warnings" style="display:none; margin-bottom: 16px;"></div>
 
 
-  <!-- One-time banner: token splits now accurate (issue #1401) -->
-  <div id="tokens-fix-banner" style="display:none;margin-bottom:16px;padding:10px 14px;background:#1a3a2a;border:1px solid #2a5a3a;border-radius:8px;font-size:13px;color:#60ff80;display:flex;align-items:center;justify-content:space-between;">
-    <span>&#128200; Token splits now include cache reads/writes &mdash; numbers are accurate from this version. <a href="https://github.com/vivekchand/clawmetry/issues/1394" target="_blank" rel="noopener" style="color:#60ff80;text-decoration:underline;">See issue #1394</a></span>
-    <button onclick="document.getElementById('tokens-fix-banner').style.display='none';localStorage.setItem('clawmetry_tokens_fix_banner_v1','1');" style="background:transparent;border:none;cursor:pointer;font-size:16px;color:#60ff80;padding:0 0 0 12px;">&times;</button>
+  <!-- One-time banner: token attribution upgrade announcement (issue #1430) -->
+  <!-- Gated on /api/install-age so fresh installs (post 0.12.230) never see -->
+  <!-- a fix-announcement for a bug they never experienced. Mirrors the -->
+  <!-- maybeShowBrainRestorationToast() pattern from PR #1467. -->
+  <div id="tokens-fix-banner" style="display:none;margin-bottom:16px;padding:10px 14px;background:#1a3a2a;border:1px solid #2a5a3a;border-radius:8px;font-size:13px;color:#60ff80;align-items:center;justify-content:space-between;">
+    <span>&#128200; Token attribution upgraded. Your dashboard now tracks cache reads and writes for the full picture. <a href="https://github.com/vivekchand/clawmetry/issues/1394" target="_blank" rel="noopener" style="color:#60ff80;text-decoration:underline;">See issue #1394</a></span>
+    <button onclick="document.getElementById('tokens-fix-banner').style.display='none';localStorage.setItem('clawmetry_tokens_attribution_banner_shown_v1','1');" style="background:transparent;border:none;cursor:pointer;font-size:16px;color:#60ff80;padding:0 0 0 12px;">&times;</button>
   </div>
   <script>
   (function(){
-    var b = document.getElementById('tokens-fix-banner');
-    if(b && !localStorage.getItem('clawmetry_tokens_fix_banner_v1')) b.style.display='flex';
+    // Cutoff epoch per issue #1430 (2026-05-15 00:00 UTC, day 0.12.230 shipped).
+    var TOKENS_CUTOFF_EPOCH = 1779062400;
+    var FLAG = 'clawmetry_tokens_attribution_banner_shown_v1';
+    try {
+      if (typeof localStorage !== 'undefined' && localStorage.getItem(FLAG) === '1') return;
+    } catch (_e) { return; }
+    fetch('/api/install-age').then(function(r){ return r.json(); }).then(function(d){
+      try {
+        // No config (fresh install with no daemon) OR ctime newer than cutoff:
+        // never saw the buggy state, skip the banner entirely.
+        if (!d || !d.exists || !d.ctime) return;
+        if (d.ctime >= TOKENS_CUTOFF_EPOCH) return;
+        var b = document.getElementById('tokens-fix-banner');
+        if (b) b.style.display = 'flex';
+      } catch (_inner) {}
+    }).catch(function(){ /* fail closed: never show on endpoint error */ });
   })();
   </script>
 


### PR DESCRIPTION
## Summary

Closes #1430 — two coupled P0s on the Tokens-tab fix-announcement banner (added in PR #1424).

### P0a — Positive reframe (no self-incrimination)

**Old:** Token splits now include cache reads/writes — numbers are accurate from this version.
**New:** Token attribution upgraded. Your dashboard now tracks cache reads and writes for the full picture.

Same fact, no admission of failure to the 120K+ install base — the vast majority of whom never noticed the underlying bug. Also drops the em-dash from the issue's suggested copy to comply with the no-em-dashes-in-user-facing-copy rule (period + comma split instead).

### P0b — Gate on install-age

Mirrors the `maybeShowBrainRestorationToast()` pattern from PR #1467:
- `localStorage` flag `clawmetry_tokens_attribution_banner_shown_v1` (dismissal sticks across navigations).
- Probes `/api/install-age` (existing endpoint from #1467 — zero new server work).
- Cutoff epoch `1779062400` per issue body (0.12.230 ship date).
- `ctime >= cutoff` → fresh install, never saw the bug → banner suppressed.
- `ctime < cutoff` → upgrade across the bug window → banner shown once.
- Fails closed on endpoint error (offline daemon, older build without `/api/install-age`) so we never spam.

### Latent CSS bug, fixed as a side-benefit

The original `<div style="...">` set both `display:none` and `display:flex` inline — the second won, meaning the banner was already visible by the time the inline `<script>` checked `localStorage`. The new markup keeps `display:none` and only flips to `flex` after both gates pass.

## Test plan

- [x] `python3 -c "import dashboard"` clean.
- [x] `node --check clawmetry/static/js/app.js` clean.
- [x] `python3 -m pytest tests/test_moat_send_message_e2e.py tests/test_local_query_api.py -q` → 17/17 pass.
- [x] Diff size: 23 inserts / 6 deletes (well under 100 LOC budget).
- [x] No em-dashes (`—`, `--`, `&mdash;`) in user-facing copy.
- [ ] Manual: localStorage cleared + `/api/install-age` ctime < cutoff → banner shows once.
- [ ] Manual: localStorage cleared + ctime >= cutoff → banner suppressed.
- [ ] Manual: dismiss → reload → flag prevents re-fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)