### PR TITLE
feat(alerts): comms banner + last-fired pill + Pro CTA for resolved-rules cohort (closes #1419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Alerts comms: PR #1410 ship moment for the no-OTLP cohort (issue #1419, 2026-05-16)
+- **Changelog callout.** Alert rules now fire on real OpenClaw spend, not just OTLP-fed installs. The ~99% of users without the `[otel]` extra had `daily_spent=0` forever, so "alert when spend > $X" rules never triggered until PR #1410 wired the DuckDB events fallback into `_get_budget_status`.
+- **Alerts tab banner.** When a user has 1+ rules, 0 historical fires, and the oldest rule is more than 24h old, `/api/alerts/rules` returns `_comms.show_alerts_comms_banner: true`. The Alerts tab renders a one-line notice that the previous rules should start triggering normally. Dismissible.
+- **Cloud-Pro CTA.** Same cohort, plus `cost_source == "duckdb"` (no OTLP) plus not already on Pro, surfaces a "richer telemetry plus 90-day retention" upsell inline in the banner.
+- **"Last fired" pill per rule.** Each rule card shows `Last fired: 5m ago` (green pill) when the rule has fired at least once, otherwise `Not yet fired` (muted pill). Converts the silent fix into a visible win the user can pin in muscle memory.
+
 ### MOAT batch: 7 user-visible Tier-1 bypasses → DuckDB fast-path (2026-05-15)
 Single-day push that pulls seven dashboard surfaces off the JSONL/process-stat path and onto the daemon-proxy DuckDB read path. Each migration ships with a synthetic-event E2E test that proves the round-trip (LocalStore.ingest → DuckDB → endpoint returns the expected shape). All seven are paired with `_try_local_store_*` early-returns plus the legacy fallback verbatim — no behavior regression, just latency.
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -153,19 +153,41 @@ async function loadAlertRules() {
     // Tolerate all three shapes: legacy array, {rules,_source:"local_store"},
     // {rules_blob,_source:"cache"} via the shared unwrap helper.
     var rules = await unwrapListAsync(data, 'rules', 'rules_blob');
+    // Issue #1419: PR #1410 comms envelope. Banner = rules configured but
+    // never fired (pre-fix cohort). CTA = same + on the DuckDB cost path
+    // (no OTLP installed — the audience PR #1410 unbroke).
+    var comms = (data && data._comms) || {};
     if(rules.length === 0) {
       document.getElementById('alert-rules-list').innerHTML = '<div style="padding:20px;text-align:center;color:var(--text-muted);">No alert rules configured</div>';
       return;
     }
     var html = '';
+    if (comms.show_alerts_comms_banner) {
+      html += '<div id="alerts-comms-banner" style="padding:12px 14px;margin-bottom:10px;background:var(--bg-secondary);border:1px solid var(--border-primary);border-left:3px solid #16a34a;border-radius:8px;font-size:13px;color:var(--text-primary);display:flex;align-items:flex-start;gap:10px;">';
+      html += '<span style="font-size:16px;line-height:1;">&#x2728;</span>';
+      html += '<div style="flex:1;">';
+      html += '<div style="font-weight:600;margin-bottom:2px;">Heads up: alert rules now fire on real OpenClaw spend.</div>';
+      html += '<div style="color:var(--text-secondary);font-size:12px;">Your previous rules should start triggering normally.';
+      if (comms.show_cloud_pro_cta) {
+        html += ' Want richer telemetry plus 90-day retention? <a href="/cloud/billing" style="color:var(--text-accent);text-decoration:underline;">Upgrade to Cloud-Pro.</a>';
+      }
+      html += '</div></div>';
+      html += '<span style="cursor:pointer;color:var(--text-muted);font-size:18px;line-height:1;" onclick="this.parentElement.style.display=\'none\';" title="Dismiss">&times;</span>';
+      html += '</div>';
+    }
     rules.forEach(function(r) {
       var channels = [];
       try { channels = JSON.parse(r.channels); } catch(e) { channels = [r.channels]; }
-      html += '<div style="padding:10px;border-bottom:1px solid var(--border-secondary);display:flex;align-items:center;gap:8px;">';
+      html += '<div style="padding:10px;border-bottom:1px solid var(--border-secondary);display:flex;align-items:center;gap:8px;flex-wrap:wrap;">';
       html += '<span style="font-weight:600;">' + escHtml(r.type) + '</span>';
       html += '<span style="color:var(--text-accent);">' + (r.type==='spike' ? r.threshold+'x' : '$'+r.threshold) + '</span>';
       html += '<span style="color:var(--text-muted);font-size:11px;">' + channels.join(', ') + '</span>';
       html += '<span style="color:var(--text-muted);font-size:11px;">' + r.cooldown_min + 'min cooldown</span>';
+      if (r.last_fired_at) {
+        html += '<span style="font-size:11px;padding:2px 6px;border-radius:10px;background:rgba(22,163,74,0.12);color:#16a34a;">Last fired: ' + timeAgo(r.last_fired_at * 1000) + '</span>';
+      } else {
+        html += '<span style="font-size:11px;padding:2px 6px;border-radius:10px;background:var(--bg-tertiary);color:var(--text-muted);">Not yet fired</span>';
+      }
       html += '<span style="margin-left:auto;cursor:pointer;color:var(--text-error);font-size:16px;" data-rule-id="'+r.id+'" onclick="deleteAlertRule(this.dataset.ruleId)" title="Delete">&#x1f5d1;</span>';
       html += '</div>';
     });

--- a/dashboard.py
+++ b/dashboard.py
@@ -5695,19 +5695,41 @@ async function loadAlertRules() {
   try {
     var data = await fetch('/api/alerts/rules').then(function(r){return r.json();});
     var rules = data.rules || [];
+    // Issue #1419: PR #1410 comms envelope — banner + per-rule "Last fired" pill.
+    var comms = (data && data._comms) || {};
     if(rules.length === 0) {
       document.getElementById('alert-rules-list').innerHTML = '<div style="padding:20px;text-align:center;color:var(--text-muted);">No alert rules configured</div>';
       return;
     }
     var html = '';
+    if (comms.show_alerts_comms_banner) {
+      html += '<div id="alerts-comms-banner" style="padding:12px 14px;margin-bottom:10px;background:var(--bg-secondary);border:1px solid var(--border-primary);border-left:3px solid #16a34a;border-radius:8px;font-size:13px;color:var(--text-primary);display:flex;align-items:flex-start;gap:10px;">';
+      html += '<span style="font-size:16px;line-height:1;">&#x2728;</span>';
+      html += '<div style="flex:1;">';
+      html += '<div style="font-weight:600;margin-bottom:2px;">Heads up: alert rules now fire on real OpenClaw spend.</div>';
+      html += '<div style="color:var(--text-secondary);font-size:12px;">Your previous rules should start triggering normally.';
+      if (comms.show_cloud_pro_cta) {
+        html += ' Want richer telemetry plus 90-day retention? <a href="/cloud/billing" style="color:var(--text-accent);text-decoration:underline;">Upgrade to Cloud-Pro.</a>';
+      }
+      html += '</div></div>';
+      html += '<span style="cursor:pointer;color:var(--text-muted);font-size:18px;line-height:1;" onclick="this.parentElement.style.display=\'none\';" title="Dismiss">&times;</span>';
+      html += '</div>';
+    }
     rules.forEach(function(r) {
       var channels = [];
       try { channels = JSON.parse(r.channels); } catch(e) { channels = [r.channels]; }
-      html += '<div style="padding:10px;border-bottom:1px solid var(--border-secondary);display:flex;align-items:center;gap:8px;">';
+      html += '<div style="padding:10px;border-bottom:1px solid var(--border-secondary);display:flex;align-items:center;gap:8px;flex-wrap:wrap;">';
       html += '<span style="font-weight:600;">' + escHtml(r.type) + '</span>';
       html += '<span style="color:var(--text-accent);">' + (r.type==='spike' ? r.threshold+'x' : (r.type==='token_spike' ? r.threshold.toLocaleString()+' tok/min' : '$'+r.threshold)) + '</span>';
       html += '<span style="color:var(--text-muted);font-size:11px;">' + channels.join(', ') + '</span>';
       html += '<span style="color:var(--text-muted);font-size:11px;">' + r.cooldown_min + 'min cooldown</span>';
+      if (r.last_fired_at) {
+        var _ago = Math.floor((Date.now()/1000 - r.last_fired_at));
+        var _label = _ago < 60 ? _ago + 's ago' : (_ago < 3600 ? Math.floor(_ago/60) + 'm ago' : (_ago < 86400 ? Math.floor(_ago/3600) + 'h ago' : Math.floor(_ago/86400) + 'd ago'));
+        html += '<span style="font-size:11px;padding:2px 6px;border-radius:10px;background:rgba(22,163,74,0.12);color:#16a34a;">Last fired: ' + _label + '</span>';
+      } else {
+        html += '<span style="font-size:11px;padding:2px 6px;border-radius:10px;background:var(--bg-tertiary);color:var(--text-muted);">Not yet fired</span>';
+      }
       html += '<span style="margin-left:auto;cursor:pointer;color:var(--text-error);font-size:16px;" data-rule-id="'+r.id+'" onclick="deleteAlertRule(this.dataset.ruleId)" title="Delete">&#x1f5d1;</span>';
       html += '</div>';
     });

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -88,6 +88,93 @@ def _try_local_store_alert_rules():
     return {"rules": rows or [], "_source": "local_store"}
 
 
+# ── PR #1410 comms envelope (issue #1419) ─────────────────────────────────
+# Before PR #1410, the alert evaluator only saw ``daily_spent`` from the
+# OTLP metrics buffer — installs without ``[otel]`` had ``daily_spent=0``
+# forever, so "alert when spend > $X" rules never fired on real spend.
+# Now the evaluator falls back to DuckDB-aggregated events (cost_source=
+# "duckdb"). We piggyback three signals on the /api/alerts/rules GET
+# response so the dashboard can surface the silent fix as a visible win:
+#   - show_alerts_comms_banner: one-time "your rules will fire now" notice
+#   - show_cloud_pro_cta:       upsell when on the DuckDB path (lower fidelity)
+#   - per-rule last_fired_at:   "Last fired: 5m ago" pill or "Not yet fired"
+_RULE_AGE_THRESHOLD_SECS = 86400  # 24h
+
+
+def _enrich_rules_with_comms(rules):
+    """Decorate ``rules`` with ``last_fired_at`` and compute comms flags.
+
+    Returns ``(rules_with_last_fired, comms_dict)``. Never raises — bad
+    state degrades to empty comms (no banner, no CTA) so the legacy alerts
+    list keeps rendering.
+    """
+    import dashboard as _d
+    enriched = list(rules or [])
+    # Fan the alert_history table into a {rule_id: max(fired_at)} map. One
+    # query, then dict.get — keeps the per-rule path O(1).
+    last_fired = {}
+    try:
+        for hist in _d._get_alert_history(limit=500) or []:
+            rid = hist.get("rule_id")
+            ts = hist.get("fired_at")
+            if rid and ts and ts > last_fired.get(rid, 0):
+                last_fired[rid] = ts
+    except Exception:
+        last_fired = {}
+    for r in enriched:
+        rid = r.get("id")
+        if rid and rid in last_fired:
+            r["last_fired_at"] = last_fired[rid]
+        # Don't inject ``last_fired_at: None`` when the rule has never
+        # fired — keeps the legacy response shape byte-stable for callers
+        # that do strict-equality asserts (see test_alert_rules_local_store).
+
+    # Comms flags. All three predicates need to be True for the banner:
+    # 1+ rules configured, 0 historical fires across all of them, oldest
+    # rule is >24h old (so we're not nagging a user who just configured
+    # alerts five minutes ago).
+    now = time.time()
+    has_rules = len(enriched) > 0
+    has_any_fire = len(last_fired) > 0
+    oldest_rule_age = 0.0
+    for r in enriched:
+        created = r.get("created_at") or 0
+        try:
+            age = now - float(created)
+        except (TypeError, ValueError):
+            age = 0.0
+        if age > oldest_rule_age:
+            oldest_rule_age = age
+    is_stale_rule_cohort = (
+        has_rules and not has_any_fire and oldest_rule_age > _RULE_AGE_THRESHOLD_SECS
+    )
+
+    # cost_source comes from /api/budget/status (set in dashboard.py:799).
+    # "duckdb" = no OTLP installed — the cohort PR #1410 unbroke and the
+    # right audience for the Cloud-Pro telemetry upsell.
+    cost_source = "unknown"
+    try:
+        cost_source = str(_d._get_budget_status().get("cost_source") or "unknown")
+    except Exception:
+        pass
+
+    is_pro = False
+    try:
+        is_pro = bool(_d._is_pro_user())
+    except Exception:
+        is_pro = False
+
+    show_cloud_pro_cta = (
+        is_stale_rule_cohort and cost_source == "duckdb" and not is_pro
+    )
+
+    return enriched, {
+        "show_alerts_comms_banner": is_stale_rule_cohort,
+        "show_cloud_pro_cta": show_cloud_pro_cta,
+        "cost_source": cost_source,
+    }
+
+
 # ── Budget API Routes ───────────────────────────────────────────────────
 
 
@@ -354,8 +441,16 @@ def api_alert_rules():
                     fast["rules"] = list(fast.get("rules") or []) + local_only
             except Exception:
                 pass
+            # Issue #1419: enrich with last_fired + comms flags so the
+            # Alerts UI can render the PR #1410 "your rules will fire now"
+            # banner and per-rule "Last fired" pills.
+            enriched, comms = _enrich_rules_with_comms(fast.get("rules") or [])
+            fast = dict(fast)
+            fast["rules"] = enriched
+            fast["_comms"] = comms
             return jsonify(fast)
-    return jsonify({"rules": _d._get_alert_rules()})
+    enriched, comms = _enrich_rules_with_comms(_d._get_alert_rules())
+    return jsonify({"rules": enriched, "_comms": comms})
 
 
 @bp_alerts.route("/api/alerts/rules/<rule_id>", methods=["PUT", "DELETE"])

--- a/tests/test_alert_rules_local_store.py
+++ b/tests/test_alert_rules_local_store.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+import time
 
 import pytest
 
@@ -216,6 +217,72 @@ def test_api_alerts_rules_flag_off_uses_legacy(fresh_store, monkeypatch):
     body = resp.get_json()
     assert "_source" not in body, "flag-off path must not tag _source"
     assert body["rules"] == [{"id": "legacy-rule", "src": "fleet_db"}]
+
+
+# ── 2b. Issue #1419 PR #1410 comms envelope ────────────────────────────────
+
+
+def test_alerts_rules_comms_banner_for_stale_rule_cohort(monkeypatch):
+    """The /api/alerts/rules response carries _comms with show_alerts_comms_banner
+    when the user has 1+ rules, 0 fires, and the oldest rule is >24h old.
+
+    Mirrors the PR #1410 conversion cohort: rules configured pre-fix that
+    never triggered because daily_spent was stuck at 0 on no-OTLP installs.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")  # force legacy path
+    sys.modules.pop("routes.alerts", None)
+    import routes.alerts as ra
+    importlib.reload(ra)
+
+    import types
+    fake_d = types.ModuleType("dashboard")
+    # 25h-old rule, never fired
+    fake_d._get_alert_rules = lambda: [
+        {"id": "stale-rule", "type": "threshold", "threshold": 5.0,
+         "created_at": time.time() - 90000}
+    ]
+    fake_d._get_alert_history = lambda limit=50: []
+    fake_d._get_budget_status = lambda: {"cost_source": "duckdb"}
+    fake_d._is_pro_user = lambda: False
+    monkeypatch.setitem(sys.modules, "dashboard", fake_d)
+
+    from flask import Flask
+    app = Flask(__name__)
+    app.register_blueprint(ra.bp_alerts)
+    body = app.test_client().get("/api/alerts/rules").get_json()
+    assert body["_comms"]["show_alerts_comms_banner"] is True, body["_comms"]
+    assert body["_comms"]["show_cloud_pro_cta"] is True, body["_comms"]
+    assert body["_comms"]["cost_source"] == "duckdb"
+
+
+def test_alerts_rules_comms_no_banner_when_rule_recently_fired(monkeypatch):
+    """If any rule has fired, suppress the banner — there's nothing to convert."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")
+    sys.modules.pop("routes.alerts", None)
+    import routes.alerts as ra
+    importlib.reload(ra)
+
+    import types, time as _t
+    fake_d = types.ModuleType("dashboard")
+    fake_d._get_alert_rules = lambda: [
+        {"id": "fired-rule", "type": "threshold", "threshold": 5.0,
+         "created_at": _t.time() - 90000}
+    ]
+    fake_d._get_alert_history = lambda limit=50: [
+        {"rule_id": "fired-rule", "fired_at": _t.time() - 300}
+    ]
+    fake_d._get_budget_status = lambda: {"cost_source": "duckdb"}
+    fake_d._is_pro_user = lambda: False
+    monkeypatch.setitem(sys.modules, "dashboard", fake_d)
+
+    from flask import Flask
+    app = Flask(__name__)
+    app.register_blueprint(ra.bp_alerts)
+    body = app.test_client().get("/api/alerts/rules").get_json()
+    assert body["_comms"]["show_alerts_comms_banner"] is False
+    assert body["_comms"]["show_cloud_pro_cta"] is False
+    # last_fired_at should be stamped onto the rule
+    assert body["rules"][0]["last_fired_at"] is not None
 
 
 # ── 3. Heartbeat cache push ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- PR #1410 unbroke alert threshold rules for ~99% of OSS installs (no `[otel]` extra had `daily_spent=0` forever, so spend-threshold rules never fired on real spend). This wires the fix into the UI so the cohort sees it land.
- `/api/alerts/rules` now returns `_comms.show_alerts_comms_banner` when the user has 1+ rules, 0 historical fires, and the oldest rule is >24h old. Same cohort plus `cost_source == "duckdb"` plus not-already-Pro toggles `show_cloud_pro_cta` for an inline "richer telemetry + 90-day retention" upsell linking to `/cloud/billing`.
- Each rule card carries `last_fired_at`; the Alerts tab renders "Last fired: 5m ago" (green pill) or "Not yet fired" (muted pill). No em-dashes / `--` in user copy per the hard rule.
- Closes #1419.

## Test plan
- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_moat_send_message_e2e.py tests/test_local_query_api.py -q` (17 passed)
- [x] `python3 -m pytest tests/test_alert_rules_local_store.py -q` (16 passed — 2 new tests for the comms envelope, all 14 pre-existing tests still green)
- [x] Diff: 215 LOC inserted across 5 files (well under 300)
- [ ] Manual: configure a $5 threshold rule on a no-OTLP install, wait 24h, confirm banner + CTA + "Not yet fired" pill render; trigger a fire and confirm the pill swaps to "Last fired: Ns ago".

🤖 Generated with [Claude Code](https://claude.com/claude-code)