### PR TITLE
test(moat): fix gauntlet fixture for v3 nested data.data shape

### DIFF
--- a/tests/test_moat_e2e_regression_1129.py
+++ b/tests/test_moat_e2e_regression_1129.py
@@ -292,12 +292,20 @@ def test_transcript_renders_openclaw_event_shapes(isolated_store, monkeypatch):
 
     # Five OpenClaw-shape events. The first three should render as
     # transcript turns; the last two are plumbing and MUST be skipped.
+    # Shape note (per commit 9be80b5): the v3 sync parser stamps
+    # ``data.type`` at the top of the data blob AND nests the original
+    # OpenClaw payload under ``data.data``. The transcript helper reads
+    # content fields from that inner ``data`` dict. The fixture mirrors
+    # that real production shape so we exercise the same code path users hit.
     events = [
         {
             "id": "oc-1", "node_id": "n", "agent_id": "main",
             "session_id": sid, "event_type": "prompt.submitted",
             "ts": _ts(0),
-            "data": {"type": "prompt.submitted", "finalPromptText": "hi"},
+            "data": {
+                "type": "prompt.submitted",
+                "data": {"finalPromptText": "hi"},
+            },
         },
         {
             "id": "oc-2", "node_id": "n", "agent_id": "main",
@@ -306,9 +314,11 @@ def test_transcript_renders_openclaw_event_shapes(isolated_store, monkeypatch):
             "data": {
                 "type": "trace.artifacts",
                 "modelId": "claude-opus-4-7",
-                "assistantTexts": ["hello!"],
-                "promptCache": {
-                    "lastCallUsage": {"input": 50, "output": 30, "total": 80},
+                "data": {
+                    "assistantTexts": ["hello!"],
+                    "promptCache": {
+                        "lastCallUsage": {"input": 50, "output": 30, "total": 80},
+                    },
                 },
             },
         },
@@ -316,20 +326,23 @@ def test_transcript_renders_openclaw_event_shapes(isolated_store, monkeypatch):
             "id": "oc-3", "node_id": "n", "agent_id": "main",
             "session_id": sid, "event_type": "model.completed",
             "ts": _ts(2),
-            "data": {"type": "model.completed", "completionText": "more"},
+            "data": {
+                "type": "model.completed",
+                "data": {"completionText": "more"},
+            },
         },
         # Plumbing — must NOT appear in the transcript.
         {
             "id": "oc-4", "node_id": "n", "agent_id": "main",
             "session_id": sid, "event_type": "session.ended",
             "ts": _ts(3),
-            "data": {"type": "session.ended"},
+            "data": {"type": "session.ended", "data": {}},
         },
         {
             "id": "oc-5", "node_id": "n", "agent_id": "main",
             "session_id": sid, "event_type": "agent.heartbeat",
             "ts": _ts(4),
-            "data": {"type": "agent.heartbeat"},
+            "data": {"type": "agent.heartbeat", "data": {}},
         },
     ]
     for ev in events:


### PR DESCRIPTION
## Summary

Found via MOAT fire verification: \`test_transcript_renders_openclaw_event_shapes\` was the only failing test in \`tests/test_moat_e2e_regression_1129.py\`.

## Root cause

Per commit 9be80b5 (\"v3 parser stamps data.type + nests content under data.data\"), the real sync parser nests OpenClaw content fields one level deeper than the test fixture assumed. The transcript helper (\`_expand_openclaw_event\` in \`routes/sessions.py\`) reads content from that inner \`data\` dict.

The synthetic fixture wrote events with content flat under \`data\` (e.g. \`{type: \"prompt.submitted\", finalPromptText: \"hi\"}\`). The helper looked for \`obj['data']['finalPromptText']\` and got nothing — returned 0 messages.

This is exactly the \`feedback_synthetic_tests_missed_real_event_shape.md\` antipattern: synthetic shape diverged from production shape, and the test stopped catching the bug class it was meant to guard.

## Fix

Nest content fields one level deeper in the test fixture to mirror what the real v3 sync parser produces. Now exercises the same code path real users hit.

## Verification

\`pytest tests/test_moat_e2e_regression_1129.py -q\` -> 5/5 pass (was 4/5).

Persona-skip: pure test-fixture change, no production behavior change.

## Test plan
- [x] All 5 tests in the gauntlet pass locally.
- [ ] CI confirms green.