### PR TITLE
feat(sessions): 24h retention cap on /api/sessions + upgrade CTA (progresses #1448)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4814,12 +4814,36 @@ async function loadSessions() {
   }
 
   document.getElementById('sessions-list').innerHTML = html || '<div style="padding:16px;color:var(--text-muted);">No sessions found</div>';
+  _renderSessionsRetentionCta(!!(sessData && sessData.capped_at_24h));
   mainSessions.forEach(function(s, i) {
     var canvas = document.querySelectorAll('#sessions-list canvas')[i];
     if (!canvas) return;
     var pts = Array.isArray(s.burnSeries) ? s.burnSeries : [];
     drawSessionSparkline(canvas, pts);
   });
+}
+
+// Issue #1448: surface the OSS 24h retention cap as an upgrade CTA above
+// the Sessions list when /api/sessions returns capped_at_24h=true. Cloud-Pro
+// bypasses the cap server-side so this CTA stays hidden for paid users.
+function _renderSessionsRetentionCta(capped) {
+  var list = document.getElementById('sessions-list');
+  if (!list || !list.parentElement) return;
+  var cta = document.getElementById('sessions-retention-cta');
+  if (!cta) {
+    cta = document.createElement('div');
+    cta.id = 'sessions-retention-cta';
+    cta.style.cssText = 'padding:10px 14px;margin-bottom:10px;font-size:12px;color:var(--text-muted);background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:8px;display:none;';
+    list.parentElement.insertBefore(cta, list);
+  }
+  if (capped) {
+    cta.style.display = '';
+    cta.innerHTML = 'Sessions older than 24 hours are available on Cloud-Pro. '
+      + '<a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener" style="color:var(--accent,#7c5cff);font-weight:600;">Upgrade for full history.</a>';
+  } else {
+    cta.style.display = 'none';
+    cta.innerHTML = '';
+  }
 }
 
 async function stopSession(sessionId) {

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -187,6 +187,57 @@ def _decorate_with_channel_context(sessions):
     return sessions
 
 
+def _session_last_active_epoch(s: dict):
+    """Extract a unix-second timestamp for a session row, tolerant of the
+    many shapes the gateway / local-store / JSONL paths produce.
+
+    Returns ``None`` when no usable timestamp is present (in which case
+    the row stays visible — we never drop on missing data, only on data
+    that *proves* the session is older than the cap).
+    """
+    # epoch-millis fields (gateway, unregistered-JSONL backfill)
+    for k in ("updatedAt", "lastActivityAt", "last_active_at_ms"):
+        v = s.get(k)
+        if isinstance(v, (int, float)) and v > 0:
+            return float(v) / 1000.0 if v > 1e12 else float(v)
+    # ISO-8601 fields (local-store path)
+    for k in ("last_active_at", "updated_at", "started_at"):
+        v = s.get(k)
+        if isinstance(v, str) and v:
+            try:
+                iso = v.replace("Z", "+00:00")
+                return datetime.fromisoformat(iso).timestamp()
+            except (ValueError, TypeError):
+                continue
+    return None
+
+
+def _apply_24h_retention_cap(sessions: list) -> bool:
+    """Drop sessions older than 24h for OSS / Cloud-Free callers (issue #1448).
+
+    Cloud-Pro users (validated by ``dashboard._is_pro_user``) bypass the cap.
+    Mutates ``sessions`` in place. Returns ``True`` when the cap kicked in
+    (i.e. caller was non-Pro) so the UI can render the upgrade CTA.
+
+    Mirrors the gating pattern introduced for /api/flow/runs in PR #1445.
+    """
+    try:
+        import dashboard as _d
+        is_pro = bool(_d._is_pro_user())
+    except Exception:
+        is_pro = False
+    if is_pro:
+        return False
+    cap_floor = time.time() - 24 * 3600
+    kept = []
+    for s in sessions:
+        ts = _session_last_active_epoch(s)
+        if ts is None or ts >= cap_floor:
+            kept.append(s)
+    sessions[:] = kept
+    return True
+
+
 @bp_sessions.route("/api/sessions")
 def api_sessions():
     import dashboard as _d
@@ -199,6 +250,8 @@ def api_sessions():
         fast = _try_local_store_sessions()
         if fast is not None:
             _merge_unregistered_jsonls(fast["sessions"])
+            capped = _apply_24h_retention_cap(fast["sessions"])
+            fast["capped_at_24h"] = capped
             return jsonify(fast)
     gw_data = _d._gw_invoke("sessions_list", {"limit": 20, "messageLimit": 0})
     if gw_data and "sessions" in gw_data:
@@ -221,7 +274,8 @@ def api_sessions():
     # registrar runs). Without this merge those sessions stay invisible until
     # the registrar catches up — see MOAT_E2E_REPORT_2026-05-13 root-cause #3.
     _merge_unregistered_jsonls(sessions)
-    return jsonify({"sessions": sessions})
+    capped = _apply_24h_retention_cap(sessions)
+    return jsonify({"sessions": sessions, "capped_at_24h": capped})
 
 
 def _merge_unregistered_jsonls(sessions: list) -> None:

--- a/tests/test_sessions_local_fastpath.py
+++ b/tests/test_sessions_local_fastpath.py
@@ -33,6 +33,13 @@ def app(tmp_path, monkeypatch):
     import routes.sessions as sessions_mod
     importlib.reload(sessions_mod)
 
+    # Issue #1448: the historical 2026-05-11 timestamps these tests seed
+    # fall outside the OSS 24h retention cap. Default this fixture to a Pro
+    # user so the pre-cap aggregation/fastpath assertions still pass; the
+    # cap-specific tests live in test_sessions_retention_cap.py and
+    # monkeypatch ``_is_pro_user`` explicitly.
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
     a = Flask(__name__)
     a.register_blueprint(sessions_mod.bp_sessions)
     yield a, ls

--- a/tests/test_sessions_retention_cap.py
+++ b/tests/test_sessions_retention_cap.py
@@ -1,0 +1,113 @@
+"""Tests for the /api/sessions 24h retention cap (issue #1448 surface 1/4).
+
+PR #1445 capped /api/flow/runs at 24h for OSS / Cloud-Free users. The
+pre-merge product review (issue #1448) flagged that Sessions, Usage,
+Brain-history and Local-events all leaked the same retention upsell. This
+file covers the Sessions slice.
+
+Mirrors the OSS-capped / Pro-bypass pattern from
+tests/test_flow_runs_endpoint.py: a Pro user keeps full history, an OSS
+(non-Pro) caller only sees sessions whose last activity falls inside the
+24h window AND the response carries ``capped_at_24h: true`` so the UI
+can render the upgrade CTA.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    # Isolate sessions dir so the unregistered-JSONL merge doesn't drag in
+    # rows from the dev's local ~/.openclaw workspace.
+    empty_sessions = tmp_path / "sessions_empty"
+    empty_sessions.mkdir()
+    monkeypatch.setenv("OPENCLAW_SESSIONS_DIR", str(empty_sessions))
+    import dashboard as _d
+    monkeypatch.setattr(_d, "SESSIONS_DIR", str(empty_sessions), raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed_old_and_recent(store):
+    """One ancient session (8 days back) + one fresh session (5 min back).
+
+    The local-store fast path returns ISO-8601 last_active_at strings, so
+    that's what we seed; the retention helper handles both ISO and
+    epoch-millis variants.
+    """
+    import datetime as _dt
+    now = _dt.datetime.now(_dt.timezone.utc)
+    old_ts = (now - _dt.timedelta(days=8)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    new_ts = (now - _dt.timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    store.ingest_session({
+        "session_id": "sess-old",
+        "agent_type": "openclaw",
+        "title": "Old session",
+        "started_at": old_ts,
+        "last_active_at": old_ts,
+        "status": "ended",
+        "total_tokens": 100,
+        "cost_usd": 0.1,
+    })
+    store.ingest_session({
+        "session_id": "sess-new",
+        "agent_type": "openclaw",
+        "title": "Fresh session",
+        "started_at": new_ts,
+        "last_active_at": new_ts,
+        "status": "active",
+        "total_tokens": 50,
+        "cost_usd": 0.05,
+    })
+    # Give the background flusher a beat to land both rows on disk.
+    time.sleep(0.2)
+
+
+def test_api_sessions_caps_24h_for_free_users(app, monkeypatch):
+    a, ls = app
+    _seed_old_and_recent(ls.get_store())
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    r = a.test_client().get("/api/sessions")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body["capped_at_24h"] is True
+    sids = {s["session_id"] for s in body["sessions"]}
+    # 8-day-old session must be dropped; fresh session stays visible.
+    assert sids == {"sess-new"}
+
+
+def test_api_sessions_no_cap_for_pro_users(app, monkeypatch):
+    a, ls = app
+    _seed_old_and_recent(ls.get_store())
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    r = a.test_client().get("/api/sessions")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body["capped_at_24h"] is False
+    sids = {s["session_id"] for s in body["sessions"]}
+    # Pro users keep full history including the 8-day-old session.
+    assert sids == {"sess-old", "sess-new"}


### PR DESCRIPTION
## Summary

Surface 1 of 4 from issue #1448. PR #1445 capped `/api/flow/runs` at 24h for OSS / Cloud-Free users and the pre-merge product review flagged that `/api/sessions`, `/api/usage`, `/api/brain-history`, and `/api/local-events` all leaked the same retention upsell. This PR ships the **Sessions** slice; the other 3 surfaces ship separately so a regression on any one doesn't take all four down.

- `routes/sessions.py` -- `_apply_24h_retention_cap` filters sessions older than `now - 24h` when `dashboard._is_pro_user()` returns False. Hooked into both branches of `api_sessions` (local-store fast path + gateway/JSONL fallback). Tolerant timestamp shim handles epoch-ms (`updatedAt`) and ISO-8601 (`last_active_at`).
- `clawmetry/static/js/app.js` -- `_renderSessionsRetentionCta` renders a one-line CTA above `#sessions-list` when the response carries `capped_at_24h: true`. Sibling of `_renderFlowRunsCap`.
- `tests/test_sessions_retention_cap.py` -- new tests for OSS cap + Pro bypass.
- `tests/test_sessions_local_fastpath.py` -- existing fixture now defaults to `_is_pro_user=True` so pre-cap 2026-05-11 timestamps still pass (same shim PR #1445 added).

CTA copy: `Sessions older than 24 hours are available on Cloud-Pro. Upgrade for full history.` (no em-dash, period-split per memory).

Total: 86 LOC production + 113 LOC tests; mirrors PR #1445 contract exactly.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `tests/test_moat_send_message_e2e.py + test_local_query_api.py` -- 17/17 green
- [x] `tests/test_sessions_retention_cap.py` -- 2/2 green (OSS-capped, Pro-bypass)
- [x] `tests/test_sessions_local_fastpath.py` -- 5/5 still green after fixture shim
- [ ] Manual smoke once merged: verify Cloud-Pro acct sees no CTA, OSS acct sees CTA + 24h list

`progresses #1448` (3 surfaces still TBD: Usage, Brain-history, Local-events).

Generated with [Claude Code](https://claude.com/claude-code)