### PR TITLE
feat(usage): 24h retention cap on /api/usage + upgrade CTA (progresses #1448)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6994,6 +6994,10 @@ async function loadUsage() {
       chartHtml += '<div class="usage-bar-wrap"><div class="usage-bar" style="height:' + pct + '%"><div class="usage-bar-value">' + (d.tokens > 0 ? val : '') + '</div></div><div class="usage-bar-label">' + label + '</div></div>';
     });
     document.getElementById('usage-chart').innerHTML = chartHtml;
+    // Issue #1448 surface 2 — OSS / Cloud-Free callers get clamped to 24h
+    // of history; render the upgrade CTA above the chart so users see why
+    // the chart is mostly empty.
+    _renderUsageCapCTA(!!data.capped_at_24h);
     // Cost table
     var usageInfoIcon = document.getElementById('usage-cost-info-icon');
     if (usageInfoIcon) {
@@ -7063,6 +7067,32 @@ async function loadUsage() {
     loadCacheAnalytics();
   } catch(e) {
     document.getElementById('usage-chart').innerHTML = '<span style="color:#555">No usage data available</span>';
+  }
+}
+
+// Issue #1448 surface 2 — render the OSS / Cloud-Free retention upsell
+// row above the Token Usage chart when /api/usage reports capped_at_24h.
+// Sibling of _renderFlowRunsCap (PR #1445).
+function _renderUsageCapCTA(capped) {
+  var hostChart = document.getElementById('usage-chart');
+  if (!hostChart || !hostChart.parentElement) return;
+  var foot = document.getElementById('usage-cap-cta');
+  if (!foot) {
+    foot = document.createElement('div');
+    foot.id = 'usage-cap-cta';
+    foot.style.cssText = 'padding:10px 14px;margin-bottom:10px;font-size:12px;color:var(--text-muted);border:1px solid var(--border-secondary,#2a2a4a);border-radius:6px;display:none;';
+    // Insert just before the chart card (parent is the .card wrapper).
+    var card = hostChart.closest('.card') || hostChart.parentElement;
+    if (card && card.parentElement) {
+      card.parentElement.insertBefore(foot, card);
+    }
+  }
+  if (capped) {
+    foot.style.display = '';
+    foot.innerHTML = 'Usage history older than 24 hours is on Cloud-Pro. <a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener" style="color:var(--accent,#7c5cff);font-weight:600;">Upgrade for the full 90-day picture.</a>';
+  } else {
+    foot.style.display = 'none';
+    foot.innerHTML = '';
   }
 }
 

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -875,6 +875,49 @@ def _try_local_store_skill_attribution():
     }
 
 
+def _apply_oss_24h_cap(result):
+    """Issue #1448 surface 2 — clamp /api/usage history to the last 24h for
+    OSS / Cloud-Free callers. Cloud-Pro users (gated by
+    ``dashboard._is_pro_user``) get the full 14-day chart.
+
+    Returns a (possibly copied) result dict that always carries
+    ``capped_at_24h`` so the UI can render the upsell row. Crucially this
+    runs AFTER ``_usage_cache`` / fast-path dedupe (see
+    ``feedback_usage_dedupe_pattern``) so cached aggregates are never
+    double-truncated; we shallow-copy + rewrite ``days`` so the long-lived
+    cache stays full-fidelity.
+    """
+    try:
+        import dashboard as _d
+        is_pro = bool(_d._is_pro_user())
+    except Exception:
+        is_pro = False
+    if is_pro:
+        result["capped_at_24h"] = False
+        return result
+    # Shallow-copy so we don't mutate the cached object; ``days`` is the
+    # only field we rewrite so a list slice is enough.
+    capped = dict(result)
+    days = list(capped.get("days") or [])
+    # 24h window = today's bucket + yesterday's bucket (covers any clock
+    # crossing midnight). Keep the trailing 2 entries, zero the rest so
+    # the bar chart still renders 14 slots without leaking history.
+    if days:
+        head = max(0, len(days) - 2)
+        for i in range(head):
+            d = dict(days[i])
+            d["tokens"] = 0
+            d["cost"] = 0
+            d["inputTokens"] = 0
+            d["outputTokens"] = 0
+            d["cacheReadTokens"] = 0
+            d["cacheWriteTokens"] = 0
+            days[i] = d
+        capped["days"] = days
+    capped["capped_at_24h"] = True
+    return capped
+
+
 @bp_usage.route("/api/usage")
 def api_usage():
     """Token/cost tracking from transcript files - Enhanced OTLP workaround."""
@@ -886,14 +929,14 @@ def api_usage():
     if is_local_store_read_enabled():
         fast = _try_local_store_usage()
         if fast is not None:
-            return jsonify(fast)
+            return jsonify(_apply_oss_24h_cap(fast))
 
     now = _time.time()
     if (
         _d._usage_cache["data"] is not None
         and (now - _d._usage_cache["ts"]) < _d._USAGE_CACHE_TTL
     ):
-        return jsonify(_d._usage_cache["data"])
+        return jsonify(_apply_oss_24h_cap(_d._usage_cache["data"]))
 
     # Prefer OTLP data when available
     if _d._has_otel_data():
@@ -904,7 +947,7 @@ def api_usage():
             _d._ext_emit("usage.compiled", {"ok": True})
         except Exception:
             pass
-        return jsonify(result)
+        return jsonify(_apply_oss_24h_cap(result))
 
     analytics = _d._compute_transcript_analytics()
     daily_tokens = analytics.get("daily_tokens", {})
@@ -1016,7 +1059,7 @@ def api_usage():
 
     _d._usage_cache["data"] = result
     _d._usage_cache["ts"] = _time.time()
-    return jsonify(result)
+    return jsonify(_apply_oss_24h_cap(result))
 
 
 @bp_usage.route("/api/usage/anomalies")

--- a/tests/test_usage_local_store.py
+++ b/tests/test_usage_local_store.py
@@ -221,6 +221,53 @@ def test_usage_legacy_when_env_unset(legacy_path_app):
     assert body.get("_source") != "local_store"
 
 
+# ── /api/usage 24h retention cap (issue #1448 surface 2) ─────────────────
+#
+# OSS / Cloud-Free callers get clamped to the last 24h of the 14-day chart;
+# Cloud-Pro callers (gated by ``dashboard._is_pro_user``) keep the full
+# window. Response always carries ``capped_at_24h`` so the UI can render
+# the upgrade CTA.
+
+
+def test_api_usage_caps_14d_to_24h_for_free(fast_path_app, monkeypatch):
+    app, ls, _u = fast_path_app
+    # Seed events across 7 days; the cap should zero out everything except
+    # today + yesterday for non-Pro callers.
+    _seed_events(ls.get_store(), n=14, base_tokens=100)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    body = app.test_client().get("/api/usage").get_json()
+    assert body["capped_at_24h"] is True
+    # Chart still has 14 slots so the UI shape is unchanged.
+    assert isinstance(body["days"], list) and len(body["days"]) == 14
+    # Buckets older than today/yesterday must be zeroed.
+    older = body["days"][:-2]
+    for d in older:
+        assert d["tokens"] == 0, f"older bucket {d['date']} leaked tokens"
+        assert d["cost"] == 0
+
+
+def test_api_usage_no_cap_for_pro(fast_path_app, monkeypatch):
+    app, ls, _u = fast_path_app
+    _seed_events(ls.get_store(), n=14, base_tokens=100)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    body = app.test_client().get("/api/usage").get_json()
+    assert body["capped_at_24h"] is False
+    # Pro callers see the full 14-day window with seeded tokens spread
+    # across the whole period (events seeded at day_offset = i % 7).
+    assert isinstance(body["days"], list) and len(body["days"]) == 14
+    # At least one bucket older than yesterday must carry tokens.
+    older = body["days"][:-2]
+    assert any(d["tokens"] > 0 for d in older), (
+        "pro caller should see historical tokens beyond 24h window"
+    )
+
+
 # ── /api/usage/anomalies ───────────────────────────────────────────────────
 
 def test_usage_anomalies_fast_path(fast_path_app):


### PR DESCRIPTION
## Summary

- Surface 2 of 4 from issue #1448. Mirrors PR #1445 (Flow Runs cap) on the Tokens tab.
- OSS / Cloud-Free callers now see only today + yesterday in the 14-day token chart; Cloud-Pro callers (gated by `dashboard._is_pro_user`) keep the full window.
- Response carries `capped_at_24h` so the UI renders an upgrade CTA above the chart: `"Usage history older than 24 hours is on Cloud-Pro. Upgrade for the full 90-day picture."`

## Gating contract

- `_is_pro_user()` is fail-closed (same helper PR #1445 used). No new gating mechanism.
- Cap is applied AFTER the `_usage_cache` lookup AND AFTER the local-store fast-path dedupe so the cached aggregate stays full-fidelity (`feedback_usage_dedupe_pattern` — same handler shipped a regression last week from blindly overwriting an aggregate with a subset; this PR is careful to shallow-copy before rewriting `days`).
- All three return paths in `api_usage` (fast-path, OTLP, transcript) route through `_apply_oss_24h_cap`.
- Chart still renders 14 slots so the UI shape is unchanged; older buckets are zeroed rather than truncated so existing CSS / Chart sizing keeps working.

## Test plan

- [x] `python3 -c "import dashboard"` clean.
- [x] `python3 -m pytest tests/test_usage_local_store.py -q` — 33 pass (31 original + 2 new).
- [x] `python3 -m pytest tests/test_moat_send_message_e2e.py tests/test_local_query_api.py -q` — 17/17 still green.
- [x] `python3 -m pytest tests/test_usage_per_session.py -q` — 5/5 still green.
- [x] New tests: `test_api_usage_caps_14d_to_24h_for_free` (older buckets zero, `capped_at_24h=true`) and `test_api_usage_no_cap_for_pro` (full 14-day history, `capped_at_24h=false`).
- [x] Diff: 124 LOC across 3 files (under 150-LOC cap).
- [x] No em-dashes / double-dashes in any new user-facing copy (CTA uses period-split per `feedback_no_em_dashes_in_user_facing_copy`).

## Follow-up

Surfaces 3 of 4 (`/api/brain-history`) and 4 of 4 (`/api/local-events`) ship separately per issue #1448.

progresses #1448

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>