### PR TITLE
feat(brain): 24h retention cap on /api/brain-history + upgrade CTA (progresses #1448)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3828,6 +3828,10 @@ async function loadBrainPage(silent) {
     var streamEl = document.getElementById('brain-stream');
     var wasAtTop = !streamEl || streamEl.scrollTop < 40;
     renderBrainStream(events);
+    // Issue #1448 surface 3 — OSS / Cloud-Free users are capped to the
+    // last 24h. Render a one-line upgrade CTA above the brain stream so
+    // they know full history exists on Cloud-Pro.
+    _renderBrainHistoryCap(!!(data && data.capped_at_24h));
     // Issue #1195 — One-time "Live event details restored" toast for users
     // who lived through the 0.12.182 empty-detail regression. Fires only if
     // (a) at least one event has a non-empty detail, (b) the user hasn't
@@ -3867,6 +3871,30 @@ async function loadBrainPage(silent) {
   }
   // Loop-signals badge (#1364) — fire-and-forget; never blocks the Brain tab.
   loadLoopSignals();
+}
+
+
+// Render a one-line OSS retention CTA above the Brain stream when the
+// /api/brain-history response carries capped_at_24h (issue #1448 surface
+// 3). Lives in its own container above #brain-stream so the stream itself
+// stays a pure event feed.
+function _renderBrainHistoryCap(capped) {
+  var host = document.getElementById('brain-history-cap-cta');
+  if (!host) {
+    var streamEl = document.getElementById('brain-stream');
+    if (!streamEl || !streamEl.parentElement) return;
+    host = document.createElement('div');
+    host.id = 'brain-history-cap-cta';
+    host.style.cssText = 'padding:10px 14px;margin-bottom:8px;font-size:12px;color:var(--text-muted);border:1px solid var(--border-secondary,#2a2a4a);border-radius:6px;background:var(--bg-secondary,rgba(124,92,255,0.06));display:none;';
+    streamEl.parentElement.insertBefore(host, streamEl);
+  }
+  if (capped) {
+    host.style.display = '';
+    host.innerHTML = 'Brain history older than 24 hours is on Cloud-Pro. <a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener" style="color:var(--accent,#7c5cff);font-weight:600;">Upgrade for full conversation context.</a>';
+  } else {
+    host.style.display = 'none';
+    host.innerHTML = '';
+  }
 }
 
 

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -18,6 +18,7 @@ import glob
 import json
 import os
 import time
+from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
@@ -193,7 +194,7 @@ def _extract_brain_detail(row: dict) -> str:
     return ""
 
 
-def _try_local_store_brain(limit: int, include_artifacts: bool):
+def _try_local_store_brain(limit, include_artifacts, since=None):
     """Epic #964 phase 1b fast path. Returns a brain-history-shaped dict
     when CLAWMETRY_LOCAL_STORE_READ=1 AND the local DuckDB store has
     enough events to be useful. Returns ``None`` to defer to the JSONL
@@ -204,8 +205,14 @@ def _try_local_store_brain(limit: int, include_artifacts: bool):
     enriched here. The full read-path migration is a follow-up; this
     is a measurable proof that the local store is the right answer for
     the simple list-of-events case.
+
+    ``since`` is forwarded to ``query_events`` so the OSS 24h retention
+    cap (issue #1448) is enforced at the SQL layer.
     """
     rows = None
+    qkwargs = {"limit": limit}
+    if since:
+        qkwargs["since"] = since
     # Issue #1088: cross-process fast-path. The standard install runs daemon
     # + dashboard as separate processes and DuckDB's exclusive writer lock
     # blocks the dashboard from opening the file even read-only. Ask the
@@ -213,7 +220,7 @@ def _try_local_store_brain(limit: int, include_artifacts: bool):
     # boots (tests, dev mode).
     try:
         from routes.local_query import local_store_via_daemon
-        rows = local_store_via_daemon("query_events", limit=limit)
+        rows = local_store_via_daemon("query_events", **qkwargs)
     except Exception:
         rows = None
     if rows is None:
@@ -224,12 +231,23 @@ def _try_local_store_brain(limit: int, include_artifacts: bool):
             # install (daemon proxy above is the happy path; this fallback
             # only fires in tests / dev mode).
             store = local_store.get_store(read_only=True)
-            rows = store.query_events(limit=limit)
+            rows = store.query_events(**qkwargs)
         except Exception:
             return None
     if not rows:
         # Empty store → fall through to JSONL parser so a fresh install
         # without a populated local DB still gets a useful brain feed.
+        # Exception: when the OSS 24h cap (issue #1448) is active we MUST
+        # NOT fall through, otherwise the JSONL parser would happily serve
+        # unbounded history and defeat the retention gate.
+        if since:
+            return {
+                "events":        [],
+                "count":         0,
+                "_source":       "local_store",
+                "_shape":        "brain_history",
+                "capped_at_24h": True,
+            }
         return None
     # Translate the local-store row shape (id/node_id/agent_id/session_id/
     # event_type/ts/data/cost_usd/...) into the brain-history event shape
@@ -294,10 +312,11 @@ def _try_local_store_brain(limit: int, include_artifacts: bool):
                     row["chat_id"] = str(chat_id)[:80]
         out.append(row)
     return {
-        "events":  out,
-        "count":   len(out),
-        "_source": "local_store",
-        "_shape":  "brain_history",
+        "events":        out,
+        "count":         len(out),
+        "_source":       "local_store",
+        "_shape":        "brain_history",
+        "capped_at_24h": bool(since),
     }
 
 
@@ -344,15 +363,28 @@ def api_brain_history():
     include_artifacts = _brain_history_bool_arg(
         request.args.get("include_artifacts") or request.args.get("artifacts")
     )
+    # OSS / Cloud-Free 24h retention cap (issue #1448 surface 3). Pro
+    # users bypass entirely; everyone else gets clamped to the last 24h
+    # of ts. ``capped_at_24h`` is mirrored back so the UI can render the
+    # Cloud-Pro upgrade CTA above the brain stream.
+    try:
+        is_pro = bool(_d._is_pro_user())
+    except Exception:
+        is_pro = False
+    cap_since = None
+    if not is_pro:
+        cap_since = (
+            datetime.now(timezone.utc) - timedelta(hours=24)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
     # Epic #964 phase 1b: opt-in local-store fast path. Skip the JSONL
     # parser entirely when CLAWMETRY_LOCAL_STORE_READ=1 AND the store
     # has data. Falls through to the full parser otherwise (so a fresh
     # install with an empty store still gets the rich brain feed).
     if is_local_store_read_enabled():
-        fast = _try_local_store_brain(limit, include_artifacts)
+        fast = _try_local_store_brain(limit, include_artifacts, since=cap_since)
         if fast is not None:
             return jsonify(fast)
-    cache_key = (limit, include_artifacts)
+    cache_key = (limit, include_artifacts, bool(cap_since))
     cached = _BRAIN_HISTORY_CACHE.get(cache_key)
     now_cache = time.time()
     if cached and now_cache - cached[0] < _BRAIN_HISTORY_CACHE_TTL_SECONDS:
@@ -926,6 +958,16 @@ def api_brain_history():
         if m:
             ev["skill"] = m.group(1)
 
+    # OSS 24h cap (issue #1448): drop any JSONL-sourced event older than
+    # the cap before we count + ship. CONTEXT pseudo-events have no
+    # meaningful ts so we keep them regardless (they describe the active
+    # window, not historical activity).
+    if cap_since:
+        events = [
+            ev for ev in events
+            if ev.get("type") == "CONTEXT" or (ev.get("time") or "") >= cap_since
+        ]
+
     # Build channel summary for filter chips
     channel_counts = {}
     for ev in events:
@@ -937,7 +979,13 @@ def api_brain_history():
         _d._ext_emit("brain.event", {"count": len(events)})
     except Exception:
         pass
-    payload = {"events": events, "total": len(events), "sources": sources_seen, "channels": channel_counts}
+    payload = {
+        "events":        events,
+        "total":         len(events),
+        "sources":       sources_seen,
+        "channels":      channel_counts,
+        "capped_at_24h": bool(cap_since),
+    }
     _BRAIN_HISTORY_CACHE[cache_key] = (time.time(), payload)
     if len(_BRAIN_HISTORY_CACHE) > 8:
         oldest_key = min(_BRAIN_HISTORY_CACHE, key=lambda k: _BRAIN_HISTORY_CACHE[k][0])

--- a/tests/test_brain_history_v3_event_detail.py
+++ b/tests/test_brain_history_v3_event_detail.py
@@ -55,6 +55,12 @@ def brain_app(tmp_path, monkeypatch):
     import routes.brain as br
     importlib.reload(br)
 
+    # Pre-#1448 fixtures seed 2026-05-13 timestamps that fall outside the
+    # OSS 24h cap. Default to a Pro user so legacy shape assertions still
+    # see all 5 seeded rows.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
     app = Flask(__name__)
     app.register_blueprint(br.bp_brain)
     yield app, ls, br

--- a/tests/test_brain_local_fastpath.py
+++ b/tests/test_brain_local_fastpath.py
@@ -26,6 +26,12 @@ def app(tmp_path, monkeypatch):
     import routes.brain as br
     importlib.reload(br)
 
+    # Pre-#1448 fixtures seed historical timestamps that fall outside the
+    # OSS 24h retention cap. Default to a Pro user so existing assertions
+    # still pass; the cap tests monkeypatch ``_is_pro_user`` explicitly.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
     a = Flask(__name__)
     a.register_blueprint(br.bp_brain)
     yield a, ls
@@ -122,3 +128,61 @@ def test_brain_fast_path_disabled_without_env_flag(tmp_path, monkeypatch):
         store.stop(flush=True)
     except Exception:
         pass
+
+
+# ── Retention cap (issue #1448 surface 3) ───────────────────────────────────
+#
+# OSS / Cloud-Free users get capped to the last 24h of events on
+# /api/brain-history. Cloud-Pro users (gated by ``dashboard._is_pro_user``)
+# bypass the cap. The response always carries ``capped_at_24h`` so the UI
+# can render the upgrade CTA above the brain stream.
+
+
+def _seed_old_and_recent_events(store):
+    """One ancient event (8 days old) + one fresh event (now)."""
+    import datetime as _dt
+    now = _dt.datetime.now(_dt.timezone.utc)
+    old_ts = (now - _dt.timedelta(days=8)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    new_ts = (now - _dt.timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    store.ingest({
+        "id": "ev-old", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-old", "event_type": "tool_call",
+        "ts": old_ts, "data": {"tool": "Bash", "input": "echo ancient"},
+        "cost_usd": 0.01, "token_count": 10, "model": "claude-opus-4-7",
+    })
+    store.ingest({
+        "id": "ev-new", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-new", "event_type": "tool_call",
+        "ts": new_ts, "data": {"tool": "Bash", "input": "echo fresh"},
+        "cost_usd": 0.01, "token_count": 10, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+
+def test_api_brain_history_caps_24h_for_free(app, monkeypatch):
+    a, ls = app
+    _seed_old_and_recent_events(ls.get_store())
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    r = a.test_client().get("/api/brain-history?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body.get("capped_at_24h") is True
+    sids = {ev["sessionId"] for ev in body["events"]}
+    # 8-day-old event must be excluded; only the fresh one survives.
+    assert sids == {"sess-new"}
+
+
+def test_api_brain_history_no_cap_for_pro(app, monkeypatch):
+    a, ls = app
+    _seed_old_and_recent_events(ls.get_store())
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    r = a.test_client().get("/api/brain-history?limit=10")
+    body = r.get_json()
+    assert body.get("capped_at_24h") is False
+    sids = {ev["sessionId"] for ev in body["events"]}
+    # Pro users see the full history including the 8-day-old event.
+    assert sids == {"sess-old", "sess-new"}

--- a/tests/test_brain_local_store.py
+++ b/tests/test_brain_local_store.py
@@ -72,6 +72,13 @@ def _build_app(tmp_path, monkeypatch, *, enable_fast_path: bool):
     import routes.brain as br
     importlib.reload(br)
 
+    # Pre-#1448 fixtures seed historical 2026-05-11 timestamps that fall
+    # outside the OSS 24h retention cap. Default to a Pro user so the
+    # contract + latency assertions still pass; the cap-specific tests
+    # live in test_brain_local_fastpath.py and monkeypatch explicitly.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
     app = Flask(__name__)
     app.register_blueprint(br.bp_brain)
     return app, ls, br

--- a/tests/test_brain_no_log_keyword_noise.py
+++ b/tests/test_brain_no_log_keyword_noise.py
@@ -75,6 +75,10 @@ def fallback_app(tmp_path, monkeypatch):
     monkeypatch.setattr(_d, "_get_log_dirs", lambda: [str(log_dir)], raising=True)
     monkeypatch.setattr(_d, "SESSIONS_DIR", str(sessions_dir), raising=True)
     monkeypatch.setattr(_d, "_ext_emit", lambda *a, **k: None, raising=True)
+    # 2026-05-13 fixture timestamps fall outside the OSS 24h cap (#1448).
+    # Default to Pro so the BROWSER-classification assertion still sees
+    # the seeded log line.
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True, raising=True)
 
     # The route ALSO hard-codes a glob of ``/tmp/openclaw/openclaw-*.log`` and
     # then trims to the last 3 files. On a dev machine with real daemon logs


### PR DESCRIPTION
## Summary

Surface **3 of 4** from issue #1448. Mirrors the pattern PR #1445 shipped
on `/api/flow/runs`:

- OSS / Cloud-Free users now see only the **last 24 hours** of events on
  `/api/brain-history`. Cloud-Pro users (validated via the existing
  `dashboard._is_pro_user()` helper from PR #1440) keep unlimited history.
- When the cap kicks in, the response carries `capped_at_24h: true`.
- The Brain tab renders a one-line upgrade CTA above the stream:
  `Brain history older than 24 hours is on Cloud-Pro. Upgrade for full
  conversation context.` (no em-dash, period split — per
  `feedback_no_em_dashes_in_user_facing_copy.md`).

## Scope

- `routes/brain.py`: compute `cap_since` once at handler entry, forward
  to both the local-store fast path (via `query_events(since=...)`) and
  the JSONL slow path (post-filter `events` by `time`). CONTEXT
  pseudo-events bypass the cap (they describe the active window, not
  historical activity). Cache key gains the cap flag so Pro vs free
  responses never cross-pollute.
- `routes/brain.py` `_try_local_store_brain`: when the cap is active and
  rows come back empty, return the empty-but-capped payload rather than
  falling through to the unbounded JSONL parser (which would silently
  defeat the gate).
- `clawmetry/static/js/app.js`: new `_renderBrainHistoryCap(capped)`
  helper inserts/updates an upgrade-CTA banner above `#brain-stream`.
- 4 brain test files: default the local fixtures to Pro (matches PR
  #1445's pattern) so existing tests with 2026-05-11/12/13 timestamps
  still pass; new cap tests in `test_brain_local_fastpath.py` explicitly
  monkeypatch `_is_pro_user`.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_moat_send_message_e2e.py tests/test_local_query_api.py tests/test_brain_local_fastpath.py tests/test_brain_local_store.py -q` → 25/25 pass
- [x] All 11 brain-tagged tests green (cap, fast-path, slow-path, v3 shape, log-noise)
- [x] Diff size 167 LOC (96 production + 71 test fixtures + new cap tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)