### PR TITLE
feat(local-events): 24h retention cap on /api/local-events + upgrade CTA (closes #1448)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8881,6 +8881,31 @@ function _renderFlowRunsCap(capped) {
   }
 }
 
+// Issue #1448 surface 4 — OSS / Cloud-Free retention CTA for any UI
+// pane that consumes /api/local/events. Pass the response body and a
+// mount element (any container above the events list/feed); we render a
+// one-line upgrade CTA when ``capped_at_24h`` is truthy. Used by future
+// raw-event panes in the dashboard.
+function _renderLocalEventsCap(respBody, mountEl) {
+  if (!mountEl) return;
+  var capped = !!(respBody && respBody.capped_at_24h);
+  var host = mountEl.querySelector(':scope > .local-events-cap-cta');
+  if (!host) {
+    if (!capped) return;
+    host = document.createElement('div');
+    host.className = 'local-events-cap-cta';
+    host.style.cssText = 'padding:10px 14px;margin-bottom:8px;font-size:12px;color:var(--text-muted);border:1px solid var(--border-secondary,#2a2a4a);border-radius:6px;background:var(--bg-secondary,rgba(124,92,255,0.06));';
+    mountEl.insertBefore(host, mountEl.firstChild);
+  }
+  if (capped) {
+    host.style.display = '';
+    host.innerHTML = 'Raw events older than 24 hours are on Cloud-Pro. <a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener" style="color:var(--accent,#7c5cff);font-weight:600;">Upgrade for full history.</a>';
+  } else {
+    host.style.display = 'none';
+    host.innerHTML = '';
+  }
+}
+
 function showFlowRunDetail(sid) {
   var box = document.getElementById('flow-runs-detail');
   var title = document.getElementById('flow-runs-detail-title');

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -170,6 +170,34 @@ def _safe_int(v: Any, *, default: int, lo: int, hi: int) -> int:
     return max(lo, min(hi, n))
 
 
+def _apply_24h_cap(args: dict) -> bool:
+    """OSS / Cloud-Free retention cap for raw event reads (issue #1448).
+
+    Mutates ``args`` in-place: when the caller is not a Pro user we clamp
+    ``since`` to ``now - 24h``. Returns True when the cap was enforced so
+    the response can surface the upgrade CTA. Pro users (validated via
+    ``dashboard._is_pro_user``) bypass the cap entirely. Any failure
+    fail-closes to non-Pro — we never leak unlimited history on a missing
+    signal.
+    """
+    try:
+        import dashboard as _d
+        is_pro = bool(_d._is_pro_user())
+    except Exception:
+        is_pro = False
+    if is_pro:
+        return False
+    from datetime import datetime, timedelta, timezone
+    cap_iso = (
+        datetime.now(timezone.utc) - timedelta(hours=24)
+    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    since = args.get("since") or ""
+    if not since or since < cap_iso:
+        args["since"] = cap_iso
+        return True
+    return False
+
+
 def _dispatch(shape: str, args: dict) -> dict:
     """Single-source-of-truth shape→method bridge. Both the HTTP and (future)
     WS transports call this. Returns a JSON-friendly dict ready to ship.
@@ -219,7 +247,13 @@ def http_health():
 def http_events():
     try:
         args = _coerce_args("events", request.args.to_dict())
-        return jsonify(_dispatch("events", args))
+        # Issue #1448 surface 4 — OSS / Cloud-Free users get capped to
+        # the last 24h of raw events. Pro users bypass entirely. Mirrors
+        # the pattern PR #1445 set on /api/flow/runs.
+        capped_at_24h = _apply_24h_cap(args)
+        body = _dispatch("events", args)
+        body["capped_at_24h"] = capped_at_24h
+        return jsonify(body)
     except Exception as e:
         return jsonify({"error": str(e)[:300]}), 500
 

--- a/tests/test_local_query_api.py
+++ b/tests/test_local_query_api.py
@@ -24,6 +24,13 @@ def client(tmp_path, monkeypatch):
     import routes.local_query as lq
     importlib.reload(lq)
 
+    # Pre-#1448 events tests seed historical timestamps that fall outside
+    # the OSS 24h retention cap. Default the fixture to Pro so those
+    # assertions still pass; the cap tests below monkeypatch
+    # ``_is_pro_user`` explicitly. Mirrors PR #1445's fixture pattern.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
     app = Flask(__name__)
     app.register_blueprint(lq.bp_local_query)
     # Trigger store init + flusher start.
@@ -288,3 +295,53 @@ def test_relay_dispatch_rejects_unknown_shape():
     import routes.local_query as lq
     body = lq.relay_dispatch("nope", {})
     assert "error" in body
+
+
+# ── Retention cap (issue #1448 surface 4) ──────────────────────────────────
+#
+# OSS / Cloud-Free users get clamped to the last 24h of raw events on
+# /api/local/events. Cloud-Pro users (gated by ``dashboard._is_pro_user``)
+# bypass the cap. The response always carries ``capped_at_24h`` so the UI
+# can surface an upgrade CTA when the cap kicks in. Mirrors PR #1445's
+# pattern for /api/flow/runs.
+
+
+def _seed_old_and_recent(store):
+    """One ancient event (8 days old) + one fresh event (now)."""
+    import datetime as _dt
+    now = _dt.datetime.now(_dt.timezone.utc)
+    old_ts = (now - _dt.timedelta(days=8)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    new_ts = (now - _dt.timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    store.ingest(_ev(id="cap-old", session_id="sess-cap", ts=old_ts))
+    store.ingest(_ev(id="cap-new", session_id="sess-cap", ts=new_ts))
+    _wait(store)
+
+
+def test_api_local_events_caps_24h_for_free(client, monkeypatch):
+    c, ls = client
+    _seed_old_and_recent(ls.get_store())
+    # Force OSS (non-Pro) path.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    r = c.get("/api/local/events?session_id=sess-cap&limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+    assert body["capped_at_24h"] is True
+    ids = {row["id"] for row in body["rows"]}
+    # The 8-day-old event must be excluded; only the fresh one shows.
+    assert ids == {"cap-new"}
+
+
+def test_api_local_events_no_cap_for_pro(client, monkeypatch):
+    c, ls = client
+    _seed_old_and_recent(ls.get_store())
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    r = c.get("/api/local/events?session_id=sess-cap&limit=10")
+    body = r.get_json()
+    assert body["capped_at_24h"] is False
+    ids = {row["id"] for row in body["rows"]}
+    # Pro users see the full history including the 8-day-old event.
+    assert ids == {"cap-old", "cap-new"}


### PR DESCRIPTION
## Summary

- Caps `/api/local/events` to last 24h for OSS / Cloud-Free users; Pro bypasses via `dashboard._is_pro_user()` (mirrors PR #1445 pattern).
- Response carries `capped_at_24h: true` when the cap kicks in; new `_renderLocalEventsCap(respBody, mountEl)` JS helper renders the upgrade CTA above any consuming events feed.
- Surface 4 of 4 from #1448 — sibling agents shipped sessions / usage / brain caps concurrently (#1479 + d8b41c9 + 501b019).

## Scope

- `routes/local_query.py` — new `_apply_24h_cap(args)` clamps `since` to now-24h, fail-closes on any exception. Only the GET endpoint is gated; the POST `/api/local/query` shape contract is intentionally untouched so the future WS relay protocol stays stable.
- `clawmetry/static/js/app.js` — `_renderLocalEventsCap()` helper. Inserts a one-line CTA: `"Raw events older than 24 hours are on Cloud-Pro. Upgrade for full history."` (period split, no em-dash per project copy rules).
- `tests/test_local_query_api.py` — 2 new tests + fixture default of Pro so historical-timestamp tests keep passing under the cap.

Diff: 117 LOC (under 150 budget).

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_moat_send_message_e2e.py tests/test_local_query_api.py -q` → 19 passed (was 17)
- [x] No edits to `routes/sessions.py`, `routes/usage.py`, `routes/brain.py` (concurrent agents)

closes #1448

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)