### PR TITLE
feat(brain): per-LLM-call hallucination risk indicator (closes #567)

### DIFF
--- a/clawmetry/risk.py
+++ b/clawmetry/risk.py
@@ -1,0 +1,368 @@
+"""
+clawmetry/risk.py — Hallucination Risk Indicator (issue #567).
+
+Per-call risk score for LLM completions, surfaced as Low / Medium / High in
+the Brain tab and as a session-level warning badge when any call in a
+session scores High.
+
+Why this exists
+---------------
+Chapter 6 of the agent observability plan: creativity and hallucination are
+the same mechanism. Higher sampling temperature, low-confidence token
+selection, and unusually long outputs all correlate with the model
+extrapolating beyond its training distribution. ClawMetry already captures
+the per-call sampling config (temperature, max_tokens) and per-call output
+token counts, so we can compose a cheap, additive risk score with ZERO new
+data collection and ZERO new dependencies.
+
+Design notes
+------------
+* **Pure function.** ``compute_hallucination_risk`` takes a single event
+  dict (the same shape ``routes/brain.py`` passes around) and returns a
+  ``{"risk_level": ..., "risk_explanation": ...}`` dict. No I/O, no global
+  state, fully unit-testable in isolation.
+
+* **Three additive signals**, weighted equally and summed:
+
+    1. *Temperature* (always available when the adapter recorded it):
+         T < 0.3   → +0  (deterministic, low risk)
+         T < 0.7   → +1  (balanced, medium contribution)
+         T >= 0.7  → +2  (creative, high contribution)
+
+    2. *Token entropy / logprobs* (when present): the mean negative
+       logprob across sampled tokens — proxy for the model's confidence
+       in its own output. Anthropic does NOT expose logprobs today, so we
+       degrade GRACEFULLY when the field is absent: the signal simply
+       contributes 0 and the explanation says so.
+
+    3. *Response length* (always available):
+         <  500 tokens   → +0
+         500-2000        → +1
+         > 2000          → +2
+
+* **Score → label.** total in [0..6]. Threshold band:
+         0-1 → low      (T<0.3 short responses or no signals)
+         2-3 → medium   (one strong signal, e.g. T=0.7 + short response)
+         >=4 → high     (compound risk — high T + long response, etc.)
+
+* **Graceful degradation.** When no signals are available (e.g. a tool
+  call event with no temperature and no token counts), we return
+  ``risk_level="low"`` with an explanation that says "insufficient signal".
+  Never crash on bad input — the dashboard renders thousands of these
+  per page-load.
+
+The plan calls this Phase 1 of the Hallucination Risk Indicator. A future
+phase will add a fourth signal (model self-reported confidence via
+constrained decoding) once OpenClaw exposes it.
+
+Memory respects
+---------------
+* ``feedback_no_em_dashes_in_user_facing_copy.md`` — explanations are
+  plain copy, no em-dashes / "X, Y, and Z — coda" patterns.
+* ``feedback_simple_ui_for_nontechnical.md`` — Low / Medium / High labels
+  are readable without ML training.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+
+# ── Tunable thresholds ──────────────────────────────────────────────────
+# Kept as module-level constants so tests can monkey-patch them when the
+# Anthropic API surface eventually exposes logprobs and we want to add a
+# fourth band without churning every assertion.
+_TEMP_LOW_MAX = 0.3        # T < this → +0 (deterministic)
+_TEMP_MED_MAX = 0.7        # T < this → +1 (balanced)
+                           # T >= 0.7 → +2 (creative / high)
+
+_TOKENS_SHORT_MAX = 500    # output < this → +0
+_TOKENS_MED_MAX = 2000     # output < this → +1
+                           # output >= 2000 → +2
+
+# Score → label thresholds. Inclusive lower bound. Tuned so that a single
+# moderate signal alone never trips "high" — that requires at least one
+# strong signal + one moderate signal.
+_LABEL_BANDS = [
+    (0, "low"),
+    (2, "medium"),
+    (4, "high"),
+]
+
+# Event types that DO represent an LLM call. ``routes/brain.py`` projects
+# many event flavours (USER, RESULT, EXEC, READ, …) into the same stream
+# and the risk score only makes sense on the assistant-output events.
+_LLM_EVENT_TYPES = frozenset({
+    "AGENT",          # legacy JSONL assistant text turn
+    "THINK",          # legacy JSONL extended-thinking block
+    "MODEL.COMPLETED",  # v3 underscore mapper LLM completion event
+})
+
+
+def _band_label(score: int) -> str:
+    """Map an integer score → ``low | medium | high`` using ``_LABEL_BANDS``."""
+    label = "low"
+    for thresh, name in _LABEL_BANDS:
+        if score >= thresh:
+            label = name
+    return label
+
+
+def is_llm_event(event_data: Mapping[str, Any]) -> bool:
+    """Return ``True`` when ``event_data`` represents an assistant LLM call.
+
+    Tolerant of three shapes the Brain pipeline emits:
+
+    * Dashboard-projected events: ``ev["type"]`` is one of ``AGENT/THINK``.
+    * Local-store rows: ``ev["event_type"]`` is ``model.completed`` (lower
+      or upper case).
+    * Raw JSONL turn objects: ``ev["role"] == "assistant"``.
+    """
+    if not isinstance(event_data, Mapping):
+        return False
+    t = (event_data.get("type") or event_data.get("event_type") or "")
+    if isinstance(t, str) and t.upper() in _LLM_EVENT_TYPES:
+        return True
+    return event_data.get("role") == "assistant"
+
+
+def _extract_temperature(event_data: Mapping[str, Any]) -> Optional[float]:
+    """Pull temperature out of the event, no matter which adapter wrote it.
+
+    Mirrors ``routes/sessions._extract_decoding_params`` but inlined here
+    to avoid pulling a heavy import chain (sessions.py imports dashboard
+    helpers) into the risk module. We only care about temperature, so the
+    full alias table isn't needed.
+    """
+    if not isinstance(event_data, Mapping):
+        return None
+    # Flat: explicit projection (some tests pass it pre-extracted).
+    for key in ("temperature",):
+        v = event_data.get(key)
+        if isinstance(v, (int, float)):
+            return float(v)
+
+    data = event_data.get("data") if isinstance(event_data.get("data"), Mapping) else None
+    candidates = []
+    if data is not None:
+        for k in ("params", "config"):
+            sub = data.get(k)
+            if isinstance(sub, Mapping):
+                candidates.append(sub)
+        msg = data.get("message") if isinstance(data.get("message"), Mapping) else None
+        if msg is not None:
+            for k in ("params", "config"):
+                sub = msg.get(k)
+                if isinstance(sub, Mapping):
+                    candidates.append(sub)
+            md = msg.get("metadata") if isinstance(msg.get("metadata"), Mapping) else None
+            if md is not None and isinstance(md.get("params"), Mapping):
+                candidates.append(md["params"])
+        # Some adapters inline the params on `data` itself.
+        candidates.append(data)
+    for k in ("params", "config"):
+        sub = event_data.get(k)
+        if isinstance(sub, Mapping):
+            candidates.append(sub)
+
+    for bucket in candidates:
+        v = bucket.get("temperature")
+        if isinstance(v, (int, float)):
+            return float(v)
+    return None
+
+
+def _extract_output_tokens(event_data: Mapping[str, Any]) -> Optional[int]:
+    """Pull output token count from the event. Returns ``None`` when absent."""
+    if not isinstance(event_data, Mapping):
+        return None
+    # Flat projections used by the Brain stream renderer + local_store row.
+    for key in ("output_tokens", "outputTokens"):
+        v = event_data.get(key)
+        if isinstance(v, (int, float)):
+            return int(v)
+
+    data = event_data.get("data") if isinstance(event_data.get("data"), Mapping) else None
+    buckets: list[Mapping[str, Any]] = []
+    if data is not None:
+        for k in ("usage",):
+            sub = data.get(k)
+            if isinstance(sub, Mapping):
+                buckets.append(sub)
+        msg = data.get("message") if isinstance(data.get("message"), Mapping) else None
+        if msg is not None and isinstance(msg.get("usage"), Mapping):
+            buckets.append(msg["usage"])
+        buckets.append(data)
+    if isinstance(event_data.get("usage"), Mapping):
+        buckets.append(event_data["usage"])
+
+    for bucket in buckets:
+        for k in ("output_tokens", "outputTokens", "completion_tokens"):
+            v = bucket.get(k)
+            if isinstance(v, (int, float)):
+                return int(v)
+
+    # token_count on the local_store row is total, but it's still a useful
+    # length proxy for the response-length signal when nothing finer is
+    # available. Only consult it as a last resort.
+    v = event_data.get("token_count")
+    if isinstance(v, (int, float)) and v > 0:
+        return int(v)
+    return None
+
+
+def _extract_logprob_summary(event_data: Mapping[str, Any]) -> Optional[float]:
+    """Return the MEAN negative logprob across sampled tokens, or ``None``.
+
+    Anthropic does not expose logprobs today (2026-05-16); the field shows
+    up only when the user has wired in an OpenAI-style adapter that
+    captured ``logprobs.content[*].logprob``. We accept either:
+
+    * a pre-computed ``mean_neg_logprob`` scalar (the cheap, common case
+      once a future PR adds aggregation upstream), or
+    * a list of token-level logprob entries (``logprobs.content`` shape).
+
+    Returns ``None`` when neither is present so the temperature + length
+    signals can still produce a useful score (graceful degradation).
+    """
+    if not isinstance(event_data, Mapping):
+        return None
+    # Pre-computed scalar — preferred.
+    v = event_data.get("mean_neg_logprob")
+    if isinstance(v, (int, float)):
+        return float(v)
+    data = event_data.get("data") if isinstance(event_data.get("data"), Mapping) else None
+    if data is not None and isinstance(data.get("mean_neg_logprob"), (int, float)):
+        return float(data["mean_neg_logprob"])
+
+    # Token-level list — compute the mean here. Capped at 256 entries so a
+    # multi-thousand-token completion doesn't dominate Brain rendering.
+    def _from_list(arr):
+        if not isinstance(arr, list) or not arr:
+            return None
+        vals = []
+        for entry in arr[:256]:
+            if isinstance(entry, Mapping):
+                lp = entry.get("logprob")
+                if isinstance(lp, (int, float)):
+                    vals.append(-float(lp))
+        if not vals:
+            return None
+        return sum(vals) / len(vals)
+
+    for bucket in (event_data, data or {}):
+        lp = bucket.get("logprobs")
+        if isinstance(lp, Mapping):
+            mean = _from_list(lp.get("content"))
+            if mean is not None:
+                return mean
+        if isinstance(bucket.get("logprob_content"), list):
+            mean = _from_list(bucket["logprob_content"])
+            if mean is not None:
+                return mean
+    return None
+
+
+def compute_hallucination_risk(event_data: Mapping[str, Any]) -> dict:
+    """Score a single LLM-call event for hallucination risk.
+
+    Returns a dict with two keys:
+
+    * ``risk_level``      — one of ``"low" | "medium" | "high"``.
+    * ``risk_explanation`` — short human-readable string for the tooltip.
+
+    The function is total. Pass it anything and it returns a sensible
+    default rather than raising. Non-LLM events are scored ``low`` with
+    an explanation that says we have no signal to act on.
+    """
+    if not isinstance(event_data, Mapping):
+        return {
+            "risk_level":       "low",
+            "risk_explanation": "No signal available for this event.",
+        }
+    # Non-LLM events (USER, EXEC, READ, …) get a stable low + explanation.
+    # The Brain renderer filters on this and only shows the badge when the
+    # event is an LLM call, but returning a value for everything keeps the
+    # API contract simple.
+    if not is_llm_event(event_data):
+        return {
+            "risk_level":       "low",
+            "risk_explanation": "Not an LLM call; no risk score applied.",
+        }
+
+    score = 0
+    reasons: list[str] = []
+
+    # ── Signal 1: temperature ──────────────────────────────────────────
+    temp = _extract_temperature(event_data)
+    if temp is None:
+        reasons.append("temperature unknown")
+    elif temp < _TEMP_LOW_MAX:
+        # +0; explicit reason still helps the tooltip
+        reasons.append(f"temperature {temp:g} is low")
+    elif temp < _TEMP_MED_MAX:
+        score += 1
+        reasons.append(f"temperature {temp:g} is moderate")
+    else:
+        score += 2
+        reasons.append(f"temperature {temp:g} is high")
+
+    # ── Signal 2: logprobs / entropy ───────────────────────────────────
+    # Mean negative logprob: higher = less confident. Anthropic does not
+    # expose logprobs today, so the typical install will hit the "not
+    # available" branch.
+    mean_neg_lp = _extract_logprob_summary(event_data)
+    if mean_neg_lp is None:
+        reasons.append("token confidence data not available")
+    elif mean_neg_lp < 0.3:
+        reasons.append("token confidence is high")
+    elif mean_neg_lp < 1.0:
+        score += 1
+        reasons.append("token confidence is moderate")
+    else:
+        score += 2
+        reasons.append("token confidence is low")
+
+    # ── Signal 3: response length ──────────────────────────────────────
+    out_tok = _extract_output_tokens(event_data)
+    if out_tok is None:
+        reasons.append("output length unknown")
+    elif out_tok < _TOKENS_SHORT_MAX:
+        reasons.append(f"output is short ({out_tok} tokens)")
+    elif out_tok < _TOKENS_MED_MAX:
+        score += 1
+        reasons.append(f"output is medium length ({out_tok} tokens)")
+    else:
+        score += 2
+        reasons.append(f"output is very long ({out_tok} tokens)")
+
+    # If we got zero signals, downgrade to a stable low + clear message.
+    if temp is None and mean_neg_lp is None and out_tok is None:
+        return {
+            "risk_level":       "low",
+            "risk_explanation": "No risk signals available for this call.",
+        }
+
+    label = _band_label(score)
+    return {
+        "risk_level":       label,
+        "risk_explanation": "; ".join(reasons),
+    }
+
+
+def session_has_high_risk(events: list) -> bool:
+    """Return True if any LLM-call event in ``events`` scored ``high``.
+
+    Convenience helper for the sessions-list renderer: it iterates the
+    Brain history once per page-load and stamps a warning icon on any
+    session whose call mix tripped the high-risk band.
+    """
+    if not events:
+        return False
+    for ev in events:
+        if not isinstance(ev, Mapping):
+            continue
+        risk = ev.get("risk") if isinstance(ev.get("risk"), Mapping) else None
+        if risk and risk.get("risk_level") == "high":
+            return True
+    return False

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2954,6 +2954,58 @@ function _toggleBrainCollapsedRun(btn, key) {
   if (event && event.stopPropagation) event.stopPropagation();
 }
 
+// Hallucination Risk Indicator (issue #567).
+// Backend stamps each LLM-call event with {risk_level, risk_explanation}.
+// We paint a tiny coloured pill next to the chip type. Tooltip explains
+// which signals tripped the band so a developer can act on it without
+// needing to crack open the raw event JSON.
+// Plain copy, no em-dashes (memory: feedback_no_em_dashes_in_user_facing_copy.md).
+var _riskBadgeStyles = {
+  low:    { dot: '🟢', label: 'Low risk',    color: '#16a34a', bg: 'rgba(22,163,74,0.12)' },
+  medium: { dot: '🟡', label: 'Medium risk', color: '#d97706', bg: 'rgba(217,119,6,0.14)' },
+  high:   { dot: '🔴', label: 'High risk',   color: '#dc2626', bg: 'rgba(220,38,38,0.16)' }
+};
+
+function renderRiskBadge(ev) {
+  if (!ev || typeof ev !== 'object') return '';
+  var risk = ev.risk;
+  if (!risk || typeof risk !== 'object') return '';
+  var lvl = String(risk.risk_level || '').toLowerCase();
+  var cfg = _riskBadgeStyles[lvl];
+  if (!cfg) return '';
+  var explanation = String(risk.risk_explanation || cfg.label);
+  // Title attr is plain text; escHtml double-escapes when interpolated
+  // inside an attribute, so we use escHtml exactly once.
+  var tip = cfg.label + '. ' + explanation;
+  return '<span class="brain-risk brain-risk-' + lvl + '" ' +
+    'data-risk-level="' + lvl + '" ' +
+    'style="display:inline-flex;align-items:center;gap:3px;background:' + cfg.bg +
+    ';color:' + cfg.color + ';padding:1px 6px;border-radius:3px;font-size:10px;' +
+    'font-weight:600;flex-shrink:0;white-space:nowrap;" ' +
+    'title="' + escHtml(tip) + '">' + cfg.dot + ' ' + cfg.label + '</span>';
+}
+
+// Walk a Brain event list and return true when any LLM-call event hit
+// the "high" band. Drives the session-row warning icon (issue #567).
+function sessionHasHighRisk(events, sessionId) {
+  if (!events || !events.length || !sessionId) return false;
+  for (var i = 0; i < events.length; i++) {
+    var ev = events[i];
+    if (!ev || !ev.risk) continue;
+    var lvl = String(ev.risk.risk_level || '').toLowerCase();
+    if (lvl !== 'high') continue;
+    // Match by sessionId, src, or source — Brain events tag via different
+    // fields depending on the source path (local-store vs JSONL parser).
+    var sid = ev.sessionId || ev.src || ev.source || '';
+    if (!sid) continue;
+    // Allow suffix match: sessions list often shortens to gateway key.
+    if (sid === sessionId || sessionId.indexOf(sid) >= 0 || sid.indexOf(sessionId) >= 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Plumbing event types: internal queue housekeeping that's noise to anyone
 // debugging an actual conversation. Hidden by default; toggle in the Brain
 // header reveals them. Match is case-insensitive on type AND detail to
@@ -3056,6 +3108,11 @@ function renderBrainStream(events) {
         taskBadge = '<span class="brain-task-type" style="color:' + _ttCfg[1] + ';font-size:10px;flex-shrink:0;white-space:nowrap;" title="Task type: ' + _ttCfg[2] + '">' + _ttCfg[0] + ' ' + _ttCfg[2] + '</span>';
       }
     }
+    // Hallucination risk badge (issue #567). Only painted on LLM-call
+    // chips that the backend stamped with a {risk_level, risk_explanation}
+    // dict. Green/yellow/red dot + tooltip — readable without ML internals
+    // per feedback_simple_ui_for_nontechnical.md.
+    var riskBadge = renderRiskBadge(ev);
     // Build turn timeline for USER events (Phase 4: Agent Runtime Timeline)
     var turnTimeline = '';
     if (evType === 'USER') {
@@ -3215,6 +3272,7 @@ function renderBrainStream(events) {
     }
     html += skillBadge;
     html += taskBadge;
+    html += riskBadge;
     html += '</div>';
     html += '<span class="brain-detail">' + renderBrainDetail(ev.detail || '') + '</span>';
     html += turnTimeline;
@@ -4757,12 +4815,17 @@ async function loadSessions() {
     // In cloud mode: /api/sessions and /api/subagents already handle CLOUD_MODE server-side
     // fetch interceptor appends node_id+token so these hit the cloud endpoints correctly
   }
-  var [sessData, saData, anomalyData, costData, chainData] = await Promise.all([
+  var [sessData, saData, anomalyData, costData, chainData, riskBrain] = await Promise.all([
     fetch('/api/sessions').then(r => r.json()).catch(function() { return {sessions:[]}; }),
     fetch('/api/subagents').then(r => r.json()).catch(function() { return {subagents:[]}; }),
     fetch('/api/usage/anomalies').then(r => r.json()).catch(function() { return {anomalies:[]}; }),
     fetch('/api/sessions/cost-breakdown').then(r => r.json()).catch(function() { return {sessions:[]}; }),
-    fetch('/api/delegation-tree').then(r => r.json()).catch(function() { return {chains:[], total_subagents:0, total_chain_cost_usd:0}; })
+    fetch('/api/delegation-tree').then(r => r.json()).catch(function() { return {chains:[], total_subagents:0, total_chain_cost_usd:0}; }),
+    // Issue #567 — pull recent brain events so we can stamp a high-risk
+    // warning on any session whose latest LLM call tripped the band.
+    // 200 events is enough to cover the active window without blowing
+    // the page-load budget; the fast path serves this in <50 ms.
+    fetch('/api/brain-history?limit=200').then(r => r.json()).catch(function() { return {events:[]}; })
   ]);
   // Build cost lookup map by session_id suffix
   var costMap = {};
@@ -4775,6 +4838,17 @@ async function loadSessions() {
   });
   var anomalySet = {};
   (anomalyData.anomalies || []).forEach(function(a) { if (a && a.session_id) anomalySet[a.session_id] = a; });
+  // Per-session high-risk set for the session-row warning badge.
+  // Issue #567: a session is "high-risk" if ANY of its recent LLM calls
+  // scored "high". Build the lookup once so the per-row test is O(1).
+  var highRiskSessions = {};
+  ((riskBrain && riskBrain.events) || []).forEach(function(ev) {
+    if (!ev || !ev.risk) return;
+    if (String(ev.risk.risk_level || '').toLowerCase() !== 'high') return;
+    var sid = ev.sessionId || ev.src || ev.source || '';
+    if (!sid) return;
+    highRiskSessions[sid] = (highRiskSessions[sid] || 0) + 1;
+  });
   var html = '';
   // Main sessions (non-subagent)
   var mainSessions = sessData.sessions.filter(function(s) { return !(s.sessionId || '').includes('subagent'); });
@@ -4789,6 +4863,15 @@ async function loadSessions() {
     html += '<span>🖥️ ' + escHtml(s.displayName || s.key) + ' <span style="font-size:11px;color:var(--text-muted);font-weight:400;">Main Session</span>';
     if (anomaly) {
       html += '<span class="session-anomaly" title="Cost anomaly: $' + Number(anomaly.cost_usd || 0).toFixed(4) + ' (' + Number(anomaly.ratio || 0).toFixed(2) + 'x rolling avg)">&#9888;&#65039;</span>';
+    }
+    // Issue #567 — high-risk warning. One or more LLM calls in this
+    // session scored "high" on the Hallucination Risk Indicator.
+    var _hrCount = highRiskSessions[sid] || 0;
+    if (_hrCount > 0) {
+      html += '<span class="session-risk-warn" data-session-id="' + escHtml(sid) +
+        '" title="' + _hrCount + ' high-risk call' + (_hrCount > 1 ? 's' : '') +
+        ' in this session. Open the Brain tab for per-call detail."' +
+        ' style="margin-left:6px;color:#dc2626;font-size:13px;">&#9888;</span>';
     }
     html += '</span>';
     html += '<button onclick="event.stopPropagation();stopSession(\'' + escHtml(sid).replace(/'/g, "\\\\'") + '\')" style="background:#b91c1c;color:#fff;border:none;border-radius:6px;padding:4px 10px;font-size:11px;font-weight:700;cursor:pointer;">⏹ Emergency Stop</button>';

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -22,8 +22,31 @@ from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
+from clawmetry.risk import compute_hallucination_risk, is_llm_event
 
 bp_brain = Blueprint('brain', __name__)
+
+
+def _annotate_risk(events):
+    """Stamp each LLM-call event in ``events`` with a ``risk`` field.
+
+    Issue #567 (Hallucination Risk Indicator). Mutates ``events`` in
+    place and returns it for chaining. Non-LLM events (USER/EXEC/READ/…)
+    are left untouched so the dashboard renderer can cheaply branch on
+    ``ev.risk`` presence to decide whether to paint the small risk pill.
+    """
+    if not events:
+        return events
+    for ev in events:
+        try:
+            if is_llm_event(ev):
+                ev["risk"] = compute_hallucination_risk(ev)
+        except Exception:
+            # Never crash on bad input — the dashboard renders thousands
+            # of these per page-load and any one mis-shaped event must
+            # not poison the whole feed (per CLAUDE.md "graceful fallbacks").
+            pass
+    return events
 
 
 _BRAIN_HISTORY_CACHE = {}
@@ -310,6 +333,16 @@ def _try_local_store_brain(limit, include_artifacts, since=None):
                     chat_id = data["chat"].get("id") or ""
                 if chat_id:
                     row["chat_id"] = str(chat_id)[:80]
+        # Issue #567 — Hallucination Risk Indicator. Compute the score
+        # from the RAW DuckDB row (which still carries ``data.params`` /
+        # ``data.usage``), then stamp it onto the trimmed output row.
+        # is_llm_event() filters non-assistant rows so we don't pay the
+        # extraction cost on every tool result / channel turn.
+        try:
+            if is_llm_event(r):
+                row["risk"] = compute_hallucination_risk(r)
+        except Exception:
+            pass
         out.append(row)
     return {
         "events":        out,
@@ -974,6 +1007,15 @@ def api_brain_history():
         ch = ev.get("channel", "")
         if ch:
             channel_counts[ch] = channel_counts.get(ch, 0) + 1
+
+    # Issue #567 — Hallucination Risk Indicator. Stamp every LLM-call
+    # event with a {risk_level, risk_explanation} dict so the Brain
+    # renderer can paint the small pill next to AGENT / THINK chips.
+    # JSONL-sourced events don't carry temperature / usage today so they
+    # fall through to "no risk signals available" — the contract is
+    # stable either way, and the local-store fast path above already
+    # picked up the rich rows.
+    _annotate_risk(events)
 
     try:
         _d._ext_emit("brain.event", {"count": len(events)})

--- a/tests/test_hallucination_risk.py
+++ b/tests/test_hallucination_risk.py
@@ -1,0 +1,330 @@
+"""Unit + integration tests for the Hallucination Risk Indicator (#567).
+
+The score combines three signals (temperature, token entropy, response
+length) into a Low / Medium / High label that the Brain tab paints next
+to every assistant chip. These tests pin the contract for:
+
+  1. ``clawmetry.risk.compute_hallucination_risk`` — pure scoring fn.
+  2. ``clawmetry.risk.is_llm_event``               — event-type filter.
+  3. ``/api/brain-history``                        — risk field on the wire.
+
+Parametrized matrix in ``test_compute_hallucination_risk_table`` keeps
+the band thresholds explicit so a future tuning change has to update the
+table on purpose.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+from flask import Flask
+
+from clawmetry.risk import (
+    compute_hallucination_risk,
+    is_llm_event,
+    session_has_high_risk,
+)
+
+
+# ── 1. Pure-function scoring matrix ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name,event,expected_level",
+    [
+        # ── Single-signal cases ───────────────────────────────────────────
+        # T very low, short output → low risk.
+        (
+            "low_temp_short_output",
+            {
+                "type": "AGENT",
+                "data": {"params": {"temperature": 0.1}, "usage": {"output_tokens": 100}},
+            },
+            "low",
+        ),
+        # T moderate, short output → one signal contributes +1 → low band.
+        (
+            "moderate_temp_short_output",
+            {
+                "type": "AGENT",
+                "data": {"params": {"temperature": 0.5}, "usage": {"output_tokens": 100}},
+            },
+            "low",
+        ),
+        # T high alone (short output) → +2 → just trips medium band.
+        (
+            "high_temp_short_output",
+            {
+                "type": "AGENT",
+                "data": {"params": {"temperature": 0.9}, "usage": {"output_tokens": 100}},
+            },
+            "medium",
+        ),
+        # Long output alone, low T → +2 → medium band.
+        (
+            "low_temp_very_long_output",
+            {
+                "type": "AGENT",
+                "data": {"params": {"temperature": 0.1}, "usage": {"output_tokens": 2500}},
+            },
+            "medium",
+        ),
+        # ── Compound risk cases ───────────────────────────────────────────
+        # High T + very long output → +2 +2 → high band.
+        (
+            "high_temp_very_long_output",
+            {
+                "type": "AGENT",
+                "data": {"params": {"temperature": 0.9}, "usage": {"output_tokens": 2500}},
+            },
+            "high",
+        ),
+        # Medium T + medium length → +1 +1 → medium band.
+        (
+            "medium_temp_medium_output",
+            {
+                "type": "AGENT",
+                "data": {"params": {"temperature": 0.5}, "usage": {"output_tokens": 1000}},
+            },
+            "medium",
+        ),
+        # ── Graceful degradation ──────────────────────────────────────────
+        # No temperature, no usage — backend should NOT crash and should
+        # return a stable low label with an explanatory tooltip.
+        (
+            "no_signals_available",
+            {"type": "AGENT", "data": {}},
+            "low",
+        ),
+        # Has output length signal only (very long) → +2 → medium.
+        (
+            "only_output_length_signal_long",
+            {"type": "AGENT", "data": {"usage": {"output_tokens": 5000}}},
+            "medium",
+        ),
+        # Has temperature signal only (high) → +2 → medium.
+        (
+            "only_temperature_signal_high",
+            {"type": "AGENT", "data": {"params": {"temperature": 1.0}}},
+            "medium",
+        ),
+        # ── Logprobs (when present, as a pre-computed scalar) ─────────────
+        # Low confidence (high mean-neg-logprob) + high T + long → high band.
+        (
+            "logprobs_low_confidence_plus_high_temp",
+            {
+                "type": "AGENT",
+                "mean_neg_logprob": 1.5,
+                "data": {"params": {"temperature": 0.9}, "usage": {"output_tokens": 1500}},
+            },
+            "high",
+        ),
+    ],
+)
+def test_compute_hallucination_risk_table(name, event, expected_level):
+    """Per-signal + compound matrix for ``compute_hallucination_risk``."""
+    out = compute_hallucination_risk(event)
+    assert isinstance(out, dict), f"[{name}] expected dict, got {type(out)}"
+    assert set(out.keys()) >= {"risk_level", "risk_explanation"}, (
+        f"[{name}] missing required keys: {out}"
+    )
+    assert out["risk_level"] == expected_level, (
+        f"[{name}] expected {expected_level!r}, got {out['risk_level']!r}. "
+        f"Explanation: {out['risk_explanation']}"
+    )
+    assert isinstance(out["risk_explanation"], str), (
+        f"[{name}] explanation must be a string, got {type(out['risk_explanation'])}"
+    )
+    assert out["risk_explanation"], f"[{name}] explanation must be non-empty"
+
+
+def test_compute_hallucination_risk_never_raises_on_garbage():
+    """Bad inputs must return a sensible default, never raise."""
+    for garbage in (None, 42, "string", [], object(), {"type": "AGENT", "data": "not-a-dict"}):
+        out = compute_hallucination_risk(garbage)
+        assert isinstance(out, dict)
+        assert out["risk_level"] in ("low", "medium", "high")
+        assert isinstance(out["risk_explanation"], str)
+
+
+def test_compute_hallucination_risk_non_llm_event_is_low():
+    """USER / EXEC / READ events should not get a risk score above low."""
+    for evt_type in ("USER", "EXEC", "READ", "WRITE", "BROWSER", "RESULT"):
+        out = compute_hallucination_risk(
+            {"type": evt_type, "data": {"params": {"temperature": 1.0}}}
+        )
+        assert out["risk_level"] == "low", (
+            f"{evt_type}: non-LLM event got bumped to {out['risk_level']!r}"
+        )
+        assert "not an llm call" in out["risk_explanation"].lower(), out
+
+
+def test_is_llm_event_recognises_all_known_shapes():
+    """``is_llm_event`` must accept dashboard, local-store, and JSONL shapes."""
+    assert is_llm_event({"type": "AGENT"})
+    assert is_llm_event({"type": "THINK"})
+    assert is_llm_event({"event_type": "model.completed"})
+    assert is_llm_event({"event_type": "MODEL.COMPLETED"})
+    assert is_llm_event({"role": "assistant"})
+    # Negatives
+    assert not is_llm_event({"type": "USER"})
+    assert not is_llm_event({"type": "EXEC"})
+    assert not is_llm_event({})
+    assert not is_llm_event(None)
+
+
+def test_session_has_high_risk_helper():
+    """Convenience helper used by the sessions-list renderer."""
+    events = [
+        {"risk": {"risk_level": "low"}},
+        {"risk": {"risk_level": "medium"}},
+    ]
+    assert not session_has_high_risk(events)
+    events.append({"risk": {"risk_level": "high"}})
+    assert session_has_high_risk(events)
+    # Missing risk dict on every event → False, never raises.
+    assert not session_has_high_risk([{"type": "USER"}, {"type": "EXEC"}])
+    assert not session_has_high_risk([])
+    assert not session_has_high_risk(None)
+
+
+# ── 2. Brain-history integration: risk on the wire ───────────────────────
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def brain_app(tmp_path, monkeypatch):
+    """Isolated Flask app + tmp DuckDB with the fast path enabled.
+
+    Mirrors ``tests/test_brain_history_v3_event_detail.py``'s harness so
+    we can assert risk-field presence on the same code path the
+    dashboard hits in production.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(
+        lq, "_DISCOVERY_PATH", str(tmp_path / "local_query_absent.json"),
+    )
+    import routes.brain as br
+    importlib.reload(br)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    app = Flask(__name__)
+    app.register_blueprint(br.bp_brain)
+    yield app, ls, br
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_brain_history_includes_risk_on_llm_events(brain_app):
+    """Three seeded rows: low/medium/high. Each comes back with the
+    matching ``risk.risk_level`` and a non-empty explanation."""
+    app, ls, _br = brain_app
+    store = ls.get_store()
+
+    rows = [
+        # Low risk: T=0.2, 100 output tokens.
+        {
+            "id": "ev-low",
+            "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-low", "event_type": "model.completed",
+            "ts": "2026-05-16T12:00:01Z",
+            "data": {
+                "completionText": "Short low-temp reply.",
+                "params": {"temperature": 0.2},
+                "usage": {"output_tokens": 100},
+            },
+        },
+        # Medium: T=0.9, 100 tokens → +2 +0 → medium.
+        {
+            "id": "ev-medium",
+            "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-medium", "event_type": "model.completed",
+            "ts": "2026-05-16T12:00:02Z",
+            "data": {
+                "completionText": "Short high-temp reply.",
+                "params": {"temperature": 0.9},
+                "usage": {"output_tokens": 100},
+            },
+        },
+        # High: T=0.9, 3000 tokens → +2 +2 → high.
+        {
+            "id": "ev-high",
+            "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-high", "event_type": "model.completed",
+            "ts": "2026-05-16T12:00:03Z",
+            "data": {
+                "completionText": "Very long, very creative reply." * 20,
+                "params": {"temperature": 0.9},
+                "usage": {"output_tokens": 3000},
+            },
+        },
+        # Non-LLM event: tool result. Should NOT carry a risk field.
+        {
+            "id": "ev-tool",
+            "node_id": "agent+test", "agent_id": "main",
+            "session_id": "sess-high", "event_type": "tool.result",
+            "ts": "2026-05-16T12:00:04Z",
+            "data": {"output": "tool result body"},
+        },
+    ]
+    for r in rows:
+        store.ingest(r)
+    _wait_flush(store)
+
+    body = app.test_client().get("/api/brain-history?limit=20").get_json()
+    assert body["count"] >= 4, body
+
+    by_session = {ev.get("sessionId"): ev for ev in body["events"]}
+
+    low = by_session.get("sess-low")
+    assert low is not None, body
+    assert "risk" in low, f"LLM event missing risk field: {low}"
+    assert low["risk"]["risk_level"] == "low", low["risk"]
+    assert low["risk"]["risk_explanation"], low["risk"]
+
+    medium = by_session.get("sess-medium")
+    assert medium is not None, body
+    assert medium["risk"]["risk_level"] == "medium", medium["risk"]
+
+    high = by_session.get("sess-high")
+    # Two events for sess-high; the model.completed should win the by-session
+    # map first (insertion order) — but iterate to find the LLM one.
+    high_evs = [
+        e for e in body["events"]
+        if e.get("sessionId") == "sess-high"
+        and (e.get("type") or "").upper() == "MODEL.COMPLETED"
+    ]
+    assert high_evs, body
+    assert high_evs[0]["risk"]["risk_level"] == "high", high_evs[0]["risk"]
+
+    # Tool-result event must NOT carry a risk field (per contract: only
+    # LLM-call events get scored).
+    tool_evs = [
+        e for e in body["events"]
+        if (e.get("type") or "").upper() == "TOOL.RESULT"
+    ]
+    assert tool_evs, body
+    assert "risk" not in tool_evs[0], (
+        f"non-LLM tool.result event should not carry risk: {tool_evs[0]}"
+    )


### PR DESCRIPTION
## Summary

- Composes per-call risk score from three signals (temperature, output length, optional logprobs) into a Low / Medium / High label surfaced in the Brain tab and on session rows.
- New ``clawmetry/risk.py`` (pure scoring fn) wired into ``/api/brain-history`` so every assistant chip ships with a ``risk: {risk_level, risk_explanation}`` field.
- Frontend renders a small coloured pill next to each LLM-call chip + a high-risk warning icon on sessions whose call mix tripped the band. Tooltip explains which signals contributed so a developer can act without cracking open raw event JSON.

Closes #567.

## Implementation notes

- **Three signals** scored additively (each +0 / +1 / +2):
  - Temperature: ``T < 0.3`` deterministic, ``< 0.7`` balanced, ``>= 0.7`` creative.
  - Token entropy via mean negative logprob (gracefully degrades to "not available" since Anthropic does not expose logprobs today).
  - Output length: ``< 500`` tokens short, ``< 2000`` medium, ``>= 2000`` very long.
- **Band thresholds** chosen so a single moderate signal alone never trips "high" — that requires compound risk (high T + long output).
- **Non-LLM events** (USER / EXEC / READ / ...) are filtered upstream and never carry a risk field, so the dashboard can branch on its presence without an extra type check.
- Local-store fast path computes risk from the raw DuckDB row (which still carries ``data.params`` / ``data.usage``) before the row is trimmed for transport. JSONL fallback also annotates so the contract is stable.
- Sessions list reads ``/api/brain-history?limit=200`` alongside the existing parallel fetch batch (no extra waterfall) and stamps a warning glyph on any session with a recent high-risk call.

## Test plan

- [x] ``python3 -m pytest tests/test_hallucination_risk.py -q`` — 15 cases pass (10 parametrized scoring cases + integration test that seeds three rows in a real DuckDB store).
- [x] ``python3 -m pytest tests/test_moat_send_message_e2e.py tests/test_local_query_api.py -q`` — 19 passed.
- [x] ``python3 -c "import dashboard"`` — clean.
- [x] ``pytest tests/test_brain_history_v3_event_detail.py tests/test_brain_local_fastpath.py tests/test_brain_local_store.py -q`` — 10 passed, no regressions.

## Memory respects

- ``feedback_no_em_dashes_in_user_facing_copy.md`` — risk labels and tooltips use plain copy.
- ``feedback_simple_ui_for_nontechnical.md`` — Low / Medium / High readable without ML jargon.
- ``feedback_duckdb_first_rule.md`` — risk scoring rides on the existing DuckDB fast path; no new JSONL or stat reads.

## Coordination

- Sibling agent (#568) owns timeline-related DOM. Verified ``git diff`` does not touch any timeline helper or DOM id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)