### PR TITLE
feat(brain): per-LLM-call timeline view in Brain tab (closes #568)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3124,14 +3124,27 @@ function renderBrainStream(events) {
           turnTimeline += '<span style="color:var(--text-faint);min-width:50px;flex-shrink:0;">' + teTime + '</span>';
           turnTimeline += '<span style="color:' + teCol + ';min-width:55px;font-weight:600;flex-shrink:0;">' + teIcon + ' ' + te.type + '</span>';
           turnTimeline += '<span style="color:var(--text-secondary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(teDetail) + '</span>';
+          var _rcSid = te.source || 'main';
+          var _rcContainerId = null;
           if (te.type === 'THINK') {
-            var _rcSid = te.source || 'main';
-            var _rcContainerId = 'rc-' + _rcSid.slice(0, 8) + '-' + (te.time || '').replace(/[^0-9]/g, '').slice(-6);
+            _rcContainerId = 'rc-' + _rcSid.slice(0, 8) + '-' + (te.time || '').replace(/[^0-9]/g, '').slice(-6);
             turnTimeline += '<button onclick="event.stopPropagation();loadReasoningChain(\'' + escHtml(_rcSid) + '\',\'' + escHtml(_rcContainerId) + '\')" style="flex-shrink:0;padding:1px 7px;border-radius:10px;border:1px solid #6366f1;background:transparent;color:#818cf8;font-size:10px;cursor:pointer;white-space:nowrap;">&#129504; View chain</button>';
-            turnTimeline += '</div>';
+          }
+          // Issue #568: per-LLM-call Timeline button on AGENT / THINK rows.
+          // Only renders when the row carries an eventId (local-store fast
+          // path); falls back gracefully when older JSONL-only data lacks it.
+          var _tlContainerId = null;
+          if ((te.type === 'AGENT' || te.type === 'THINK') && te.eventId) {
+            var _tlSid = te.sessionId || te.source || '';
+            _tlContainerId = 'timeline-' + (te.eventId || '').replace(/[^a-z0-9-]/gi, '').slice(0, 24);
+            turnTimeline += '<button onclick="event.stopPropagation();loadLlmCallTimeline(\'' + escHtml(te.eventId) + '\',\'' + escHtml(_tlSid) + '\',\'' + escHtml(_tlContainerId) + '\')" style="flex-shrink:0;padding:1px 7px;border-radius:10px;border:1px solid #22c55e;background:transparent;color:#22c55e;font-size:10px;cursor:pointer;white-space:nowrap;" title="Per-LLM-call lifecycle timeline">&#128202; Timeline</button>';
+          }
+          turnTimeline += '</div>';
+          if (_rcContainerId) {
             turnTimeline += '<div id="' + escHtml(_rcContainerId) + '" style="margin:2px 0 4px 56px;"></div>';
-          } else {
-            turnTimeline += '</div>';
+          }
+          if (_tlContainerId) {
+            turnTimeline += '<div id="' + escHtml(_tlContainerId) + '" class="llm-call-timeline-host" style="margin:2px 0 4px 56px;"></div>';
           }
         });
         if (currentSubagent) turnTimeline += '</div>'; // close last sub-agent group
@@ -3292,6 +3305,142 @@ function loadReasoningChain(sessionId, containerId) {
     })
     .catch(function(err) {
       container.innerHTML = '<span style="color:#ef4444;font-size:10px;">Error loading reasoning chain.</span>';
+    });
+}
+
+// ── Per-LLM-call lifecycle Timeline (issue #568) ──────────────────────────
+//
+// Renders an inline horizontal bar showing the 5 (reasoning) or 3 (non
+// reasoning) phase markers of one LLM call: prompt_received,
+// reasoning_started, reasoning_completed, first_output_token, completion.
+// Backend at /api/llm-call-timeline/<event_id> returns absolute ms offsets
+// from the prompt origin so the JS just needs to position absolute divs.
+// No chart library — pure DOM (per CLAUDE.md "no build step").
+
+var _llmTimelinePhaseColors = {
+  prompt_received:     '#60a5fa',  // blue: input
+  reasoning_started:   '#a78bfa',  // purple: thinking starts
+  reasoning_completed: '#8b5cf6',  // purple-dark: thinking ends
+  first_output_token:  '#22c55e',  // green: generation begins
+  completion:          '#10b981'   // green-dark: done
+};
+var _llmTimelinePhaseLabels = {
+  prompt_received:     'Prompt received',
+  reasoning_started:   'Reasoning started',
+  reasoning_completed: 'Reasoning completed',
+  first_output_token:  'First output token',
+  completion:          'Completion'
+};
+
+function _formatTimelineMs(ms) {
+  // Compact monospace label: 0ms / 150ms / 4.2s / 1m12s. Designed to fit
+  // under a marker without overflowing the bar.
+  if (ms == null) return '';
+  var n = Number(ms) || 0;
+  if (n < 1000) return n + 'ms';
+  if (n < 60000) return (n / 1000).toFixed(1) + 's';
+  var m = Math.floor(n / 60000);
+  var s = Math.floor((n % 60000) / 1000);
+  return m + 'm' + (s < 10 ? '0' : '') + s + 's';
+}
+
+function renderLlmCallTimeline(data) {
+  // Pure function — takes the /api/llm-call-timeline payload, returns HTML.
+  // Kept separate from loadLlmCallTimeline so unit tests can exercise it
+  // without faking fetch.
+  if (!data || !Array.isArray(data.phases) || data.phases.length === 0) {
+    return '<span style="color:var(--text-muted);font-size:10px;">No timeline data.</span>';
+  }
+  var total = Math.max(1, Number(data.total_ms) || 0);
+  var phases = data.phases;
+  var html = '';
+  html += '<div class="llm-call-timeline" style="margin:6px 0;padding:8px 10px;background:var(--bg-secondary,rgba(0,0,0,0.15));border:1px solid var(--border,rgba(255,255,255,0.08));border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;">';
+  // Header: model + total span + reasoning flag.
+  html += '<div class="llm-call-timeline-header" style="display:flex;gap:10px;align-items:center;margin-bottom:8px;font-size:10px;color:var(--text-muted);flex-wrap:wrap;">';
+  if (data.model) {
+    html += '<span style="color:#a78bfa;">&#129302; ' + escHtml(data.model) + '</span>';
+  }
+  html += '<span>&#9202; total ' + _formatTimelineMs(total) + '</span>';
+  html += '<span>' + (data.reasoning ? '&#129504; reasoning' : 'no reasoning') + '</span>';
+  html += '<span>' + phases.length + ' phases</span>';
+  html += '</div>';
+  // The bar itself: absolute markers + a subtle baseline track.
+  html += '<div class="llm-call-timeline-bar" style="position:relative;height:14px;background:linear-gradient(90deg,rgba(96,165,250,0.10),rgba(16,185,129,0.10));border-radius:7px;margin-bottom:24px;">';
+  phases.forEach(function(p, idx) {
+    var pct = total > 0 ? (Number(p.ms) || 0) / total * 100 : 0;
+    if (pct < 0) pct = 0;
+    if (pct > 100) pct = 100;
+    var col = _llmTimelinePhaseColors[p.phase] || '#888';
+    // Marker: 10x18 vertical pill centered on the percentage. Clamp the
+    // left % so the first/last marker don't get clipped at the bar edges.
+    var leftStyle = 'left:calc(' + pct.toFixed(2) + '% - 5px)';
+    var titleParts = [
+      _llmTimelinePhaseLabels[p.phase] || p.phase,
+      _formatTimelineMs(p.ms)
+    ];
+    if (p.tokens) titleParts.push(p.tokens + ' tokens');
+    if (p.estimated) titleParts.push('(estimated)');
+    html += '<div class="llm-call-timeline-marker" data-phase="' + escHtml(p.phase) +
+            '" title="' + escHtml(titleParts.join(' · ')) +
+            '" style="position:absolute;top:-2px;' + leftStyle +
+            ';width:10px;height:18px;background:' + col +
+            ';border-radius:3px;box-shadow:0 0 4px ' + col + '88;"></div>';
+    // ms label below the marker. Stagger odd indices down so labels
+    // overlapping in a tight cluster don't pile on top of each other.
+    var staggerTop = (idx % 2 === 0) ? '22px' : '34px';
+    html += '<div class="llm-call-timeline-label" style="position:absolute;top:' +
+            staggerTop + ';left:calc(' + pct.toFixed(2) + '% - 24px);width:48px;text-align:center;font-size:9px;color:' +
+            col + ';white-space:nowrap;">' + escHtml(_formatTimelineMs(p.ms));
+    if (p.estimated) html += '*';
+    html += '</div>';
+  });
+  html += '</div>';
+  // Legend row — one chip per phase so non-technical users can read the
+  // colour key without hovering. Kept terse: emoji + label, no jargon.
+  html += '<div class="llm-call-timeline-legend" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:8px;font-size:9px;">';
+  phases.forEach(function(p) {
+    var col = _llmTimelinePhaseColors[p.phase] || '#888';
+    var lbl = _llmTimelinePhaseLabels[p.phase] || p.phase;
+    html += '<span style="display:inline-flex;align-items:center;gap:3px;padding:1px 6px;border-radius:8px;background:' +
+            col + '22;color:' + col + ';">';
+    html += '<span style="width:7px;height:7px;border-radius:50%;background:' + col + ';display:inline-block;"></span>';
+    html += escHtml(lbl);
+    if (p.estimated) html += ' *';
+    html += '</span>';
+  });
+  html += '</div>';
+  if (phases.some(function(p) { return p.estimated; })) {
+    html += '<div style="margin-top:4px;font-size:9px;color:var(--text-muted);font-style:italic;">* estimated: first-token timing is inferred from completion size when the model did not emit a streaming marker.</div>';
+  }
+  html += '</div>';
+  return html;
+}
+
+function loadLlmCallTimeline(eventId, sessionId, containerId) {
+  // Toggle pattern matches loadReasoningChain: second click clears.
+  var container = document.getElementById(containerId);
+  if (!container) return;
+  if (container.dataset.loaded === '1') {
+    container.innerHTML = '';
+    container.dataset.loaded = '0';
+    return;
+  }
+  container.innerHTML = '<span style="color:var(--text-muted);font-size:10px;">Loading timeline…</span>';
+  var url = '/api/llm-call-timeline/' + encodeURIComponent(eventId);
+  if (sessionId) url += '?session_id=' + encodeURIComponent(sessionId);
+  fetch(url)
+    .then(function(r) {
+      if (!r.ok) {
+        return r.json().then(function(j) { throw new Error(j.error || ('HTTP ' + r.status)); });
+      }
+      return r.json();
+    })
+    .then(function(data) {
+      container.dataset.loaded = '1';
+      container.innerHTML = renderLlmCallTimeline(data);
+    })
+    .catch(function(err) {
+      container.innerHTML = '<span style="color:#ef4444;font-size:10px;">Timeline unavailable: ' + escHtml(String(err && err.message ? err.message : err)) + '</span>';
     });
 }
 

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -272,6 +272,11 @@ def _try_local_store_brain(limit, include_artifacts, since=None):
             "tokens":     r.get("token_count") or 0,
             "cost":       float(r.get("cost_usd") or 0.0),
             "model":      r.get("model") or "",
+            # Issue #568 (LLM-call timeline view): expose the event row id
+            # so the Brain-tab UI can request a per-call lifecycle timeline
+            # via /api/llm-call-timeline/<event_id>. Cheap to add — the JSON
+            # carries one extra short string per row.
+            "eventId":    r.get("id") or "",
         }
         # ── Channel-event enrichment (PR aca53ec8 / Telegram ingest) ─────
         # Channel turns land here as event_type=channel.in|channel.out with
@@ -991,6 +996,349 @@ def api_brain_history():
         oldest_key = min(_BRAIN_HISTORY_CACHE, key=lambda k: _BRAIN_HISTORY_CACHE[k][0])
         _BRAIN_HISTORY_CACHE.pop(oldest_key, None)
     return jsonify(payload)
+
+
+# ── Per-LLM-call lifecycle timeline (issue #568) ─────────────────────────
+#
+# Goal: turn the flat Brain stream into a per-call breakdown so the user
+# can see how much wall-clock each call's reasoning vs generation cost.
+# Reading from the DuckDB events table (DuckDB-first rule), we walk the
+# chain of v3 events the sync.py mapper persists:
+#
+#   prompt.submitted -> trace.artifacts(reasoning) -> model.completed
+#
+# Phase layout (5 markers for reasoning models, 3 when the model emitted
+# no reasoning artifacts — Sonnet without extended-thinking, Haiku, GPT-4
+# without ``o1`` etc.):
+#
+#   prompt_received      | ts of prompt.submitted
+#   reasoning_started    | first trace.artifacts.kind="reasoning"   (if any)
+#   reasoning_completed  | last  trace.artifacts.kind="reasoning"   (if any)
+#   first_output_token   | derived: completion ts - generation_ms
+#   completion           | ts of model.completed
+#
+# For non-reasoning models we still synthesise first_output_token from
+# completion - generation_ms so the bar is at least 3-phase (prompt /
+# first-token / completion). When no usage breakdown is available we
+# collapse to the 2 hard markers (prompt + completion).
+#
+# Cap on chain length: 200 events. Real chains are <50 — this is a guard
+# against pathological agent runs that wedge the read.
+
+_LLM_TIMELINE_REASONING_TYPES = frozenset({
+    "trace.artifacts",          # OpenClaw v3 mapper: reasoning text under data.artifacts
+    "thinking",                 # legacy trajectory parser: assistant thinking blocks
+    "reasoning",                # OpenAI o-series style
+})
+
+
+def _parse_iso_ts(ts):
+    """Best-effort ISO-8601 → epoch-ms parser. Returns None on failure.
+
+    DuckDB rows ship ts as either a plain string ("2026-05-11T12:00:00Z")
+    or a ``datetime`` object — handle both rather than crash on the rare
+    typed return path.
+    """
+    if not ts:
+        return None
+    if isinstance(ts, datetime):
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return int(ts.timestamp() * 1000)
+    if not isinstance(ts, str):
+        return None
+    s = ts.strip()
+    if not s:
+        return None
+    # Accept trailing "Z" (RFC 3339) by swapping in +00:00 for fromisoformat.
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _fetch_session_chain(session_id, limit=200):
+    """Pull every event for ``session_id`` from the local DuckDB store.
+
+    Returns a list of raw event rows (oldest first), or ``None`` when the
+    store is unreachable. Uses the daemon proxy first so we never collide
+    with the daemon's writer lock (issue #1088); falls back to direct open
+    for single-process boots (tests + dev mode — same pattern as
+    ``_try_local_store_brain`` above).
+    """
+    if not session_id:
+        return None
+    rows = None
+    try:
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon(
+            "query_events", session_id=session_id, limit=limit
+        )
+    except Exception:
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_events(session_id=session_id, limit=limit)
+        except Exception:
+            return None
+    if not rows:
+        return []
+    # query_events returns most-recent-first; the timeline walker is
+    # easier to read oldest-first, so flip once here.
+    rows = list(rows)
+    rows.sort(key=lambda r: r.get("ts") or "")
+    return rows
+
+
+def _find_event_by_id(rows, event_id):
+    if not rows or not event_id:
+        return None
+    for r in rows:
+        if r.get("id") == event_id:
+            return r
+    return None
+
+
+def _is_reasoning_event(row):
+    """Return True when ``row`` represents a reasoning / thinking artifact.
+
+    Two shapes covered:
+      * v3 mapper: event_type == "trace.artifacts" with data.kind="reasoning"
+        OR data.artifacts containing a "thinking" block.
+      * Legacy trajectory: event_type starts with "thinking" / "reasoning"
+        OR the data carries a thinking block at top level.
+    """
+    et = (row.get("event_type") or "").lower()
+    if et in _LLM_TIMELINE_REASONING_TYPES:
+        return True
+    if et.startswith("thinking") or et.startswith("reasoning"):
+        return True
+    data = row.get("data") if isinstance(row, dict) else None
+    if isinstance(data, dict):
+        kind = (data.get("kind") or "").lower()
+        if kind in {"reasoning", "thinking"}:
+            return True
+        artifacts = data.get("artifacts")
+        if isinstance(artifacts, list):
+            for a in artifacts:
+                if isinstance(a, dict):
+                    if (a.get("type") or "").lower() in {"thinking", "reasoning"}:
+                        return True
+        msg = data.get("message")
+        if isinstance(msg, dict):
+            content = msg.get("content")
+            if isinstance(content, list):
+                for blk in content:
+                    if isinstance(blk, dict) and blk.get("type") == "thinking":
+                        return True
+    return False
+
+
+def _completion_tokens(row):
+    """Best-effort completion-token count from a model.completed row.
+
+    DuckDB stamps token_count on the row for billing; the v3 mapper also
+    nests usage under data.usage / data.data.usage. Prefer the row total
+    when present.
+    """
+    n = row.get("token_count") or 0
+    try:
+        n = int(n)
+    except (TypeError, ValueError):
+        n = 0
+    if n > 0:
+        return n
+    data = row.get("data") if isinstance(row, dict) else None
+    if isinstance(data, dict):
+        for blob in (data.get("usage"), (data.get("data") or {}).get("usage")):
+            if isinstance(blob, dict):
+                v = blob.get("output_tokens") or blob.get("completion_tokens")
+                try:
+                    return int(v or 0)
+                except (TypeError, ValueError):
+                    continue
+    return 0
+
+
+def _build_llm_call_timeline(rows, anchor):
+    """Walk ``rows`` (oldest first) to build a 3- or 5-phase timeline.
+
+    ``anchor`` is the model.completed (or assistant) row the user clicked.
+    We anchor on it (its ts is the END of the call) and walk backwards to
+    find the nearest preceding ``prompt.submitted`` row in the same chain.
+    Between those two anchors we scan for reasoning artifacts to fill in
+    the 5-phase shape; if none, we synthesise the 3-phase shape so every
+    LLM call gets SOMETHING visual.
+    """
+    if not anchor:
+        return None
+    anchor_idx = None
+    for i, r in enumerate(rows):
+        if r.get("id") == anchor.get("id"):
+            anchor_idx = i
+            break
+    if anchor_idx is None:
+        return None
+    completion_ts = _parse_iso_ts(anchor.get("ts"))
+    model = anchor.get("model") or ""
+    if isinstance(anchor.get("data"), dict):
+        model = model or anchor["data"].get("modelId") or ""
+    # Walk backwards to the nearest prompt.submitted (or user role).
+    prompt_row = None
+    reasoning_rows = []
+    for j in range(anchor_idx - 1, -1, -1):
+        r = rows[j]
+        et = (r.get("event_type") or "").lower()
+        if et in {"prompt.submitted", "user"}:
+            prompt_row = r
+            break
+        if _is_reasoning_event(r):
+            reasoning_rows.append(r)
+    # Reverse so reasoning_rows is oldest-first (we walked backwards).
+    reasoning_rows.reverse()
+    prompt_ts = _parse_iso_ts(prompt_row.get("ts")) if prompt_row else None
+    if prompt_ts is None:
+        # No matching prompt — fall back to the anchor ts so the bar still
+        # renders (just shows the completion marker on its own).
+        prompt_ts = completion_ts
+
+    phases = []
+    base = prompt_ts or completion_ts or 0
+
+    def _ms(ts):
+        return max(0, (ts or base) - base)
+
+    phases.append({
+        "phase": "prompt_received",
+        "ts":    prompt_row.get("ts") if prompt_row else anchor.get("ts"),
+        "ms":    0,
+        "model": model,
+    })
+    has_reasoning = bool(reasoning_rows)
+    if has_reasoning:
+        first_r = reasoning_rows[0]
+        last_r = reasoning_rows[-1]
+        phases.append({
+            "phase":  "reasoning_started",
+            "ts":     first_r.get("ts"),
+            "ms":     _ms(_parse_iso_ts(first_r.get("ts"))),
+            "tokens": _completion_tokens(first_r) or None,
+        })
+        phases.append({
+            "phase":  "reasoning_completed",
+            "ts":     last_r.get("ts"),
+            "ms":     _ms(_parse_iso_ts(last_r.get("ts"))),
+            "tokens": sum(_completion_tokens(r) for r in reasoning_rows) or None,
+        })
+    # First-output-token: synthesised marker positioned between the last
+    # known "thinking" event (reasoning_completed when present, else
+    # prompt_received) and completion. Two cases:
+    #   * usage.output_tokens present → estimate generation slice at
+    #     ~80 tok/s, clamp to 10..90% of the post-reasoning span.
+    #   * no usage breakdown → plant at 70% of the post-reasoning span
+    #     so the marker is visible and ordered correctly.
+    # Marked "estimated":True so the UI can render an honest label.
+    span_ms = max(0, (completion_ts or base) - (prompt_ts or base))
+    out_tokens = _completion_tokens(anchor)
+    # Post-reasoning span is what we slice up for generation; without
+    # reasoning the floor is prompt_received (ms=0).
+    post_reasoning_ms = phases[-1]["ms"] if has_reasoning else 0
+    gen_span_ms = max(0, span_ms - post_reasoning_ms)
+    if gen_span_ms > 0:
+        if out_tokens > 0:
+            gen_ms = int(out_tokens * 1000 / 80)
+            gen_ms = max(int(gen_span_ms * 0.10),
+                         min(gen_ms, int(gen_span_ms * 0.90)))
+        else:
+            gen_ms = int(gen_span_ms * 0.30)
+        first_tok_ms = post_reasoning_ms + max(0, gen_span_ms - gen_ms)
+        phases.append({
+            "phase":  "first_output_token",
+            "ts":     None,  # synthesised — no row-level ts
+            "ms":     first_tok_ms,
+            "estimated": True,
+        })
+    phases.append({
+        "phase":  "completion",
+        "ts":     anchor.get("ts"),
+        "ms":     span_ms,
+        "tokens": out_tokens or None,
+        "model":  model,
+    })
+    return {
+        "event_id":      anchor.get("id"),
+        "session_id":    anchor.get("session_id") or "",
+        "model":         model,
+        "reasoning":     has_reasoning,
+        "phase_count":   len(phases),
+        "total_ms":      span_ms,
+        "phases":        phases,
+    }
+
+
+@bp_brain.route("/api/llm-call-timeline/<event_id>")
+def api_llm_call_timeline(event_id):
+    """Return the per-call lifecycle timeline for one LLM call.
+
+    Reads the DuckDB events table (DuckDB-first rule, ``feedback_duckdb_
+    first_rule.md``) — no JSONL fallback. The endpoint is cheap (one
+    indexed read by session_id, capped at 200 rows) so we don't cache.
+
+    Query params:
+        session_id (optional) — when supplied, narrows the search to one
+            session instead of scanning the full local store. The Brain
+            UI always knows the session of the chip it just rendered, so
+            it should pass this on every click.
+    """
+    sid = (request.args.get("session_id") or "").strip()
+    rows = None
+    if sid:
+        rows = _fetch_session_chain(sid)
+    if rows is None and not sid:
+        # Without a session hint, fall back to a broad read. Capped at the
+        # 200-row default so a runaway local store can't blow up the read.
+        try:
+            from routes.local_query import local_store_via_daemon
+            rows = local_store_via_daemon("query_events", limit=200)
+        except Exception:
+            rows = None
+    if rows is None:
+        return jsonify({"error": "local store unavailable", "event_id": event_id}), 503
+    anchor = _find_event_by_id(rows, event_id)
+    if anchor is None and not sid:
+        return jsonify({"error": "event not found", "event_id": event_id}), 404
+    if anchor is None and sid:
+        return jsonify({"error": "event not found in session",
+                        "event_id": event_id, "session_id": sid}), 404
+    # Anchor must be a model-output row to make sense as an LLM call.
+    et = (anchor.get("event_type") or "").lower()
+    if et not in {"model.completed", "assistant", "message"} and not et.startswith("model"):
+        return jsonify({
+            "error":      "event is not an LLM-call anchor",
+            "event_id":   event_id,
+            "event_type": et,
+        }), 400
+    timeline = _build_llm_call_timeline(rows, anchor)
+    if timeline is None:
+        return jsonify({"error": "could not build timeline",
+                        "event_id": event_id}), 500
+    try:
+        import dashboard as _d
+        _d._ext_emit("brain.llm_call_timeline", {
+            "event_id": event_id,
+            "phase_count": timeline["phase_count"],
+            "reasoning": timeline["reasoning"],
+        })
+    except Exception:
+        pass
+    return jsonify(timeline)
 
 
 @bp_brain.route("/api/brain-stream")

--- a/tests/test_appjs_units.js
+++ b/tests/test_appjs_units.js
@@ -887,6 +887,111 @@ console.log('auth-bootstrap.js zero-click auto-login (issue #1356)');
   })();
 }
 
+// ── Per-LLM-call Timeline renderer (issue #568) ─────────────────────────
+//
+// Pure-function check: renderLlmCallTimeline takes the
+// /api/llm-call-timeline payload and returns HTML. We extract the function
+// + its two phase dictionaries from app.js, run it through node's vm with
+// a stub escHtml, and assert structural properties of the output. No DOM,
+// no fetch — just shape.
+console.log('renderLlmCallTimeline (issue #568 — per-LLM-call lifecycle bar)');
+{
+  const sandbox = { Date: Date, console: console };
+  const lines = src.split('\n');
+  const startMarker = 'var _llmTimelinePhaseColors';
+  const endMarker = 'function loadLlmCallTimeline(';
+  const startIdx = lines.findIndex(function(l) { return l.indexOf(startMarker) === 0; });
+  if (startIdx < 0) throw new Error('start marker not found in app.js');
+  const endIdx = lines.findIndex(function(l, i) { return i > startIdx && l.indexOf(endMarker) === 0; });
+  if (endIdx < 0) throw new Error('end marker not found in app.js');
+  // Slice covers _llmTimelinePhaseColors → _llmTimelinePhaseLabels →
+  // _formatTimelineMs → renderLlmCallTimeline. Stops before
+  // loadLlmCallTimeline (which uses fetch — we don't need it for this test).
+  let code = lines.slice(startIdx, endIdx).join('\n') + '\n';
+  // Stub escHtml — the real one lives elsewhere in app.js; pull it in.
+  code += extractFunction('escHtml') + '\n';
+  code += '\nthis.api = {' +
+          '  renderLlmCallTimeline: renderLlmCallTimeline,' +
+          '  _formatTimelineMs: _formatTimelineMs,' +
+          '  _llmTimelinePhaseColors: _llmTimelinePhaseColors,' +
+          '  _llmTimelinePhaseLabels: _llmTimelinePhaseLabels,' +
+          '};';
+  vm.createContext(sandbox);
+  vm.runInContext(code, sandbox);
+  const api = sandbox.api;
+
+  // (1) _formatTimelineMs covers ms / s / mNNs branches.
+  eq(api._formatTimelineMs(0), '0ms', 'format 0 → "0ms"');
+  eq(api._formatTimelineMs(150), '150ms', 'format 150 → "150ms"');
+  eq(api._formatTimelineMs(4200), '4.2s', 'format 4200 → "4.2s"');
+  eq(api._formatTimelineMs(72500), '1m12s', 'format 72500 → "1m12s"');
+  eq(api._formatTimelineMs(null), '', 'format null → "" (safe)');
+
+  // (2) 5-phase reasoning payload renders 5 markers + legend.
+  const reasoningPayload = {
+    event_id: 'ev-1',
+    session_id: 'sess-r',
+    model: 'claude-opus-4-7',
+    reasoning: true,
+    phase_count: 5,
+    total_ms: 6750,
+    phases: [
+      { phase: 'prompt_received',     ts: '2026-05-13T12:00:00Z', ms: 0 },
+      { phase: 'reasoning_started',   ts: '2026-05-13T12:00:00.150Z', ms: 150 },
+      { phase: 'reasoning_completed', ts: '2026-05-13T12:00:04.350Z', ms: 4350 },
+      { phase: 'first_output_token',  ts: null, ms: 5550, estimated: true },
+      { phase: 'completion',          ts: '2026-05-13T12:00:06.750Z', ms: 6750, tokens: 240 },
+    ],
+  };
+  const html = api.renderLlmCallTimeline(reasoningPayload);
+  truthy(html.indexOf('llm-call-timeline') >= 0, 'wrapper class rendered');
+  truthy(html.indexOf('llm-call-timeline-bar') >= 0, 'bar rendered');
+  // One marker per phase
+  const markerCount = (html.match(/llm-call-timeline-marker/g) || []).length;
+  eq(markerCount, 5, '5 markers rendered for reasoning payload');
+  // Model + reasoning + total span in the header
+  truthy(html.indexOf('claude-opus-4-7') >= 0, 'model name in header');
+  truthy(html.indexOf('6.8s') >= 0 || html.indexOf('6.7s') >= 0, 'total span in header');
+  truthy(html.indexOf('reasoning') >= 0, 'reasoning flag in header');
+  // Estimated marker carries the "*" footnote
+  truthy(html.indexOf('*') >= 0, 'estimated phase carries footnote marker');
+  truthy(html.indexOf('estimated') >= 0, 'footnote line explains "estimated"');
+
+  // (3) 3-phase non-reasoning payload renders 3 markers and "no reasoning".
+  const flatPayload = {
+    event_id: 'ev-2',
+    session_id: 'sess-nr',
+    model: 'claude-haiku-3-5',
+    reasoning: false,
+    phase_count: 3,
+    total_ms: 1200,
+    phases: [
+      { phase: 'prompt_received',    ts: '2026-05-13T12:10:00Z', ms: 0 },
+      { phase: 'first_output_token', ts: null, ms: 840, estimated: true },
+      { phase: 'completion',         ts: '2026-05-13T12:10:01.200Z', ms: 1200, tokens: 8 },
+    ],
+  };
+  const html2 = api.renderLlmCallTimeline(flatPayload);
+  const markerCount2 = (html2.match(/llm-call-timeline-marker/g) || []).length;
+  eq(markerCount2, 3, '3 markers rendered for non-reasoning payload');
+  truthy(html2.indexOf('no reasoning') >= 0, '"no reasoning" label in header');
+  truthy(html2.indexOf('1.2s') >= 0, 'total span 1.2s in header');
+
+  // (4) Empty / malformed payload → graceful fallback (no throw).
+  eq(api.renderLlmCallTimeline(null).indexOf('No timeline data') >= 0, true,
+     'null payload → "No timeline data."');
+  eq(api.renderLlmCallTimeline({phases: []}).indexOf('No timeline data') >= 0, true,
+     'empty phases → "No timeline data."');
+
+  // (5) Marker left% values are positioned proportionally to total_ms.
+  // Marker 0 (prompt_received, ms=0) → "left:calc(0.00% - 5px)".
+  // Marker 4 (completion, ms=6750) → "left:calc(100.00% - 5px)".
+  truthy(html.indexOf('left:calc(0.00% - 5px)') >= 0,
+         'first marker positioned at 0%');
+  truthy(html.indexOf('left:calc(100.00% - 5px)') >= 0,
+         'last marker positioned at 100%');
+}
+
 // Auth-bootstrap scenarios above are async — wait for the microtask /
 // macrotask queue to drain before printing the summary. (The previous
 // synchronous test blocks all completed in-tick, so no wait was needed

--- a/tests/test_brain_llm_call_timeline.py
+++ b/tests/test_brain_llm_call_timeline.py
@@ -1,0 +1,260 @@
+"""Tests for /api/llm-call-timeline/<event_id> (issue #568).
+
+The endpoint returns a per-call phase breakdown so the Brain tab can
+visualise the LLM call lifecycle as a horizontal timeline. Two shapes:
+
+  * Reasoning model — 5-phase output (prompt_received,
+    reasoning_started, reasoning_completed, first_output_token,
+    completion).
+  * Non-reasoning model — 3-phase collapse (prompt_received,
+    first_output_token, completion). first_output_token is synthesised
+    from completion_tokens when no streaming markers exist.
+
+The fixture seeds a synthetic OpenClaw v3 chain (prompt.submitted →
+trace.artifacts → model.completed) into a real DuckDB store, then calls
+the endpoint and asserts the response shape + ordering.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+from flask import Flask
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Isolated Flask app + tmp DuckDB. Daemon-proxy disabled by pointing
+    the discovery file at a non-existent path, so reads hit the fixture
+    store directly via local_store.get_store(read_only=True).
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(
+        lq, "_DISCOVERY_PATH", str(tmp_path / "local_query_absent.json"),
+    )
+    import routes.brain as br
+    importlib.reload(br)
+
+    a = Flask(__name__)
+    a.register_blueprint(br.bp_brain)
+    yield a, ls, br
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+# ── Reasoning model: 5-phase chain ─────────────────────────────────────────
+
+
+def test_timeline_returns_five_phases_for_reasoning_model(app):
+    a, ls, _br = app
+    store = ls.get_store()
+    # Synthetic chain mimicking real v3 ingest:
+    #   t+0ms   prompt.submitted
+    #   t+150ms trace.artifacts (reasoning start)
+    #   t+4350ms trace.artifacts (reasoning end)
+    #   t+6750ms model.completed
+    rows = [
+        ("ev-prompt-1", "prompt.submitted", "2026-05-13T12:00:00.000Z",
+         {"finalPromptText": "Plan a deployment strategy"}),
+        ("ev-reason-1", "trace.artifacts", "2026-05-13T12:00:00.150Z",
+         {"kind": "reasoning",
+          "artifacts": [{"type": "thinking", "text": "let me think"}]}),
+        ("ev-reason-2", "trace.artifacts", "2026-05-13T12:00:04.350Z",
+         {"kind": "reasoning",
+          "artifacts": [{"type": "thinking", "text": "conclusion follows"}]}),
+        ("ev-complete-1", "model.completed", "2026-05-13T12:00:06.750Z",
+         {"completionText": "Here is the plan",
+          "modelId": "claude-opus-4-7",
+          "usage": {"output_tokens": 240}}),
+    ]
+    for eid, etype, ts, data in rows:
+        store.ingest({
+            "id": eid, "node_id": "n1", "agent_id": "main",
+            "session_id": "sess-r1", "event_type": etype, "ts": ts,
+            "data": data, "cost_usd": 0.0,
+            "token_count": data.get("usage", {}).get("output_tokens") or 0,
+            "model": data.get("modelId") or "claude-opus-4-7",
+        })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/llm-call-timeline/ev-complete-1?session_id=sess-r1")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+
+    assert body["event_id"] == "ev-complete-1"
+    assert body["session_id"] == "sess-r1"
+    assert body["reasoning"] is True
+    assert body["phase_count"] == 5
+    assert body["model"] == "claude-opus-4-7"
+
+    phase_names = [p["phase"] for p in body["phases"]]
+    assert phase_names == [
+        "prompt_received",
+        "reasoning_started",
+        "reasoning_completed",
+        "first_output_token",
+        "completion",
+    ]
+    # Phase ms values are monotonically non-decreasing (chronological).
+    ms_values = [p["ms"] for p in body["phases"]]
+    assert ms_values == sorted(ms_values), \
+        f"phases not chronological: {ms_values}"
+    # prompt_received is the origin (0).
+    assert ms_values[0] == 0
+    # Total span matches the prompt→completion ms (6750ms ±5ms).
+    assert 6700 <= body["total_ms"] <= 6800
+    # Reasoning_completed lands at +4200ms (4350 - 150) ±5ms ... wait, we
+    # measure from prompt origin not reasoning start. 4350 - 0 = 4350ms.
+    reasoning_completed = next(
+        p for p in body["phases"] if p["phase"] == "reasoning_completed"
+    )
+    assert 4300 <= reasoning_completed["ms"] <= 4400
+    # first_output_token falls between reasoning_completed and completion.
+    first_tok = next(p for p in body["phases"] if p["phase"] == "first_output_token")
+    completion = next(p for p in body["phases"] if p["phase"] == "completion")
+    assert reasoning_completed["ms"] <= first_tok["ms"] <= completion["ms"]
+
+
+# ── Non-reasoning model: 3-phase collapse ──────────────────────────────────
+
+
+def test_timeline_collapses_to_three_phases_when_no_reasoning(app):
+    a, ls, _br = app
+    store = ls.get_store()
+    # Synthetic chain WITHOUT any reasoning artifacts — Sonnet without
+    # extended-thinking, Haiku, GPT-4 etc.
+    rows = [
+        ("ev-prompt-2", "prompt.submitted", "2026-05-13T12:10:00.000Z",
+         {"finalPromptText": "What is 2+2?"}),
+        ("ev-complete-2", "model.completed", "2026-05-13T12:10:01.200Z",
+         {"completionText": "4",
+          "modelId": "claude-haiku-3-5",
+          "usage": {"output_tokens": 8}}),
+    ]
+    for eid, etype, ts, data in rows:
+        store.ingest({
+            "id": eid, "node_id": "n1", "agent_id": "main",
+            "session_id": "sess-nr1", "event_type": etype, "ts": ts,
+            "data": data, "cost_usd": 0.0,
+            "token_count": data.get("usage", {}).get("output_tokens") or 0,
+            "model": data.get("modelId") or "claude-haiku-3-5",
+        })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/llm-call-timeline/ev-complete-2?session_id=sess-nr1")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+
+    assert body["reasoning"] is False
+    assert body["phase_count"] == 3
+    phase_names = [p["phase"] for p in body["phases"]]
+    assert phase_names == [
+        "prompt_received",
+        "first_output_token",
+        "completion",
+    ]
+    # Total span ≈ 1200ms.
+    assert 1100 <= body["total_ms"] <= 1300
+    # first_output_token is flagged as estimated since no streaming marker
+    # exists in the chain.
+    first_tok = next(p for p in body["phases"] if p["phase"] == "first_output_token")
+    assert first_tok.get("estimated") is True
+
+
+# ── Error paths ────────────────────────────────────────────────────────────
+
+
+def test_timeline_404_for_unknown_event_id(app):
+    a, ls, _br = app
+    store = ls.get_store()
+    # Seed *something* so the local-store path isn't unavailable.
+    store.ingest({
+        "id": "ev-unrelated", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-other", "event_type": "prompt.submitted",
+        "ts": "2026-05-13T12:00:00Z",
+        "data": {"finalPromptText": "hi"}, "cost_usd": 0.0,
+        "token_count": 0, "model": "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/llm-call-timeline/does-not-exist?session_id=sess-other")
+    assert r.status_code == 404
+
+
+def test_timeline_400_when_anchor_is_not_an_llm_call(app):
+    a, ls, _br = app
+    store = ls.get_store()
+    store.ingest({
+        "id": "ev-tool-result", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-tool", "event_type": "tool.result",
+        "ts": "2026-05-13T12:00:00Z",
+        "data": {"output": "ok"}, "cost_usd": 0.0,
+        "token_count": 0, "model": "",
+    })
+    _wait_flush(store)
+
+    c = a.test_client()
+    r = c.get("/api/llm-call-timeline/ev-tool-result?session_id=sess-tool")
+    assert r.status_code == 400
+
+
+# ── Helper unit tests (pure functions) ─────────────────────────────────────
+
+
+def test_parse_iso_ts_handles_z_and_offset():
+    from routes.brain import _parse_iso_ts
+    assert _parse_iso_ts("2026-05-13T12:00:00Z") == _parse_iso_ts(
+        "2026-05-13T12:00:00+00:00"
+    )
+    assert _parse_iso_ts(None) is None
+    assert _parse_iso_ts("") is None
+    assert _parse_iso_ts("not a date") is None
+
+
+def test_is_reasoning_event_detects_v3_and_legacy_shapes():
+    from routes.brain import _is_reasoning_event
+    # v3 mapper shape
+    assert _is_reasoning_event({
+        "event_type": "trace.artifacts",
+        "data": {"kind": "reasoning"},
+    })
+    # legacy thinking event
+    assert _is_reasoning_event({
+        "event_type": "thinking",
+        "data": {},
+    })
+    # legacy block-list shape
+    assert _is_reasoning_event({
+        "event_type": "assistant",
+        "data": {"message": {"role": "assistant",
+                              "content": [{"type": "thinking", "thinking": "..."}]}},
+    })
+    # Non-reasoning rows
+    assert not _is_reasoning_event({
+        "event_type": "prompt.submitted", "data": {},
+    })
+    assert not _is_reasoning_event({
+        "event_type": "tool.call", "data": {},
+    })


### PR DESCRIPTION
## Summary

Adds a per-LLM-call lifecycle Timeline component to the Brain tab. Each AGENT / THINK chip now exposes a "📊 Timeline" affordance that fetches `/api/llm-call-timeline/<event_id>` and renders an inline horizontal bar showing the 3 or 5 phase markers of that one LLM call:

- `prompt_received` → `reasoning_started` → `reasoning_completed` → `first_output_token` → `completion` (reasoning models)
- `prompt_received` → `first_output_token` → `completion` (3-phase collapse when the model emitted no reasoning artifacts)

Closes #568.

## What changed

**Backend** (`routes/brain.py`, +355 LOC):
- New endpoint `GET /api/llm-call-timeline/<event_id>` (optional `?session_id=` hint for narrowed reads).
- Walks the OpenClaw v3 event chain (`prompt.submitted` → `trace.artifacts` → `model.completed`) directly from the DuckDB events table via the daemon-proxy fast path (DuckDB-first rule, per `feedback_duckdb_first_rule.md`).
- Helpers: `_parse_iso_ts`, `_fetch_session_chain`, `_is_reasoning_event`, `_completion_tokens`, `_build_llm_call_timeline`.
- Exposes `eventId` on each row in the existing `/api/brain-history` fast-path output so the frontend has a stable handle to click.

**Frontend** (`clawmetry/static/js/app.js`, +159 LOC):
- `renderLlmCallTimeline(payload)` — pure HTML builder; absolute-positioned divs on a 14px horizontal bar, monospace ts labels, color-coded phases, legend chips below.
- `loadLlmCallTimeline(eventId, sessionId, containerId)` — toggle-style fetcher (second click clears, same UX as the existing `loadReasoningChain`).
- Timeline button wired into the turn-detail timeline next to "View chain" for any AGENT / THINK row that carries an `eventId`.

**Style notes**:
- No chart library, no build step (per CLAUDE.md "no npm").
- Monospace ts labels; subtle background; color-coded markers (blue → purple → green progression).
- All user-facing strings free of em-dashes / `--` (per `feedback_no_em_dashes_in_user_facing_copy.md`).
- `*` footnote when `first_output_token` is estimated from completion size (honest labelling).

**Tests**:
- `tests/test_brain_llm_call_timeline.py` (new, 260 LOC, 6 cases): synthetic v3 chains for reasoning + non-reasoning, error paths (404 unknown id, 400 non-LLM anchor), unit tests for `_parse_iso_ts` and `_is_reasoning_event`.
- `tests/test_appjs_units.js` (+105 LOC, 14 new assertions): `_formatTimelineMs` cases, 5- and 3-phase HTML output, malformed-payload fallback, marker positioning.

## Test plan

- [x] `python3 -c "import dashboard"` clean.
- [x] `python3 -m pytest tests/test_moat_send_message_e2e.py tests/test_local_query_api.py -q` stays green.
- [x] New backend tests: `python3 -m pytest tests/test_brain_llm_call_timeline.py -q` → 6 passed.
- [x] JS unit tests: `node tests/test_appjs_units.js` → 150 passed, 0 failed.
- [x] Related brain tests: `tests/test_brain_local_fastpath.py`, `tests/test_brain_history_v3_event_detail.py` still green.

## Diff budget

Lands at 502 LOC production + 365 LOC tests = 867 total, over the 600-line guidance in the brief. The 5 helper functions needed to walk the OpenClaw v3 chain (`_parse_iso_ts`, `_fetch_session_chain`, `_find_event_by_id`, `_is_reasoning_event`, `_completion_tokens`, `_build_llm_call_timeline`) and the explicit backend + frontend test requirement are load-bearing. Feature is fully shippable; no follow-up subset remains.

## Coordination

Sibling agent on #567 owns Brain-chip RISK BADGES. This PR's helpers/DOM-ids all use `timeline-` prefix; no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)