### PR TITLE
test(chokepoint): monkeypatch _is_pro_user=True to bypass post-#1481 cap

### DIFF
--- a/tests/test_channel_event_chokepoint.py
+++ b/tests/test_channel_event_chokepoint.py
@@ -198,6 +198,13 @@ def test_brain_history_surfaces_chokepoint_row(tmp_path, monkeypatch):
         # Hit /api/brain-history through a real Flask test client.
         import routes.brain as brain
         importlib.reload(brain)
+        # PR #1481 added a 24h retention cap for non-Pro users. The seeded
+        # channel msg has a 2026-05-14 ts (older than 24h) which the cap
+        # would correctly drop. This test is about the chokepoint write
+        # path, not the cap — bypass via Pro stub. Mirrors the fixture
+        # pattern PR #1481 added to test_brain_local_fastpath.py.
+        import dashboard as _d
+        monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
         app = Flask(__name__)
         app.register_blueprint(brain.bp_brain)
         client = app.test_client()


### PR DESCRIPTION
## Summary

Found via MOAT 15m fire: `test_brain_history_surfaces_chokepoint_row` was the ONLY failing MOAT test on main after PR #1481 (brain 24h cap) landed.

## Root cause

PR #1481 added a 24h retention cap to `/api/brain-history` for non-Pro users. The chokepoint test fixture seeds a channel event with `ts="2026-05-14T09:00:00Z"` (older than 24h). The cap correctly drops it -> body[events] empty -> assertion fails.

This test is about the chokepoint WRITE path (channel_messages + events dual-write per #1220), not the retention cap. Bypass via Pro stub.

## Fix

One line: `monkeypatch.setattr(_d, "_is_pro_user", lambda: True)` after the brain reload. Mirrors the same fixture pattern PR #1481 added to `test_brain_local_fastpath.py`.

## Verification

`pytest tests/test_channel_event_chokepoint.py tests/test_brain_local_fastpath.py tests/test_brain_local_store.py tests/test_moat_send_message_e2e.py tests/test_local_query_api.py tests/test_moat_e2e_regression_1129.py tests/test_e2e_real_openclaw_pipeline.py tests/test_duckdb_fastpath_v3_invariants.py tests/test_moat_cloud_roundtrip_e2e.py -q` -> 64/64 (was 63/64).

Persona-skip: pure test-fixture change, no production behavior change.