### PR TITLE
fix: channel ingest card — full emoji coverage, empty state CTA, clickable rows

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6828,21 +6828,40 @@ async function loadSystemHealth() {
       var ciWrap = document.getElementById('sh-channel-ingest-wrap');
       var ciEl = document.getElementById('sh-channel-ingest');
       if (ciEl && ciWrap) {
+        // Always show the wrap — even empty state is diagnostic (#1321).
+        ciWrap.style.display = '';
+        var emoji = function(p) {
+          return p === 'telegram'        ? '✈️'
+               : p === 'signal'         ? '📡'
+               : p === 'slack'          ? '💼'
+               : p === 'discord'        ? '🎮'
+               : p === 'whatsapp'       ? '🟢'
+               : p === 'imessage'       ? '🍎'
+               : p === 'webchat'        ? '🌐'
+               : p === 'irc'            ? '#️⃣'
+               : p === 'googlechat'     ? '💬'
+               : p === 'bluebubbles'    ? '🫧'
+               : p === 'msteams'        ? '🏢'
+               : p === 'tui'            ? '⌨️'
+               : p === 'matrix'         ? '🔷'
+               : p === 'mattermost'     ? '📢'
+               : p === 'line'           ? '🟩'
+               : p === 'nostr'          ? '⚡'
+               : p === 'twitch'         ? '🟣'
+               : p === 'feishu'         ? '🪶'
+               : p === 'zalo'           ? '🔵'
+               : p === 'tlon'           ? '🌊'
+               : p === 'synology-chat'  ? '🖥️'
+               : p === 'nextcloud-talk' ? '☁️'
+               : '📨';
+        };
         if (ingest.length === 0) {
-          ciWrap.style.display = 'none';
+          ciEl.innerHTML = '<div style="color:var(--text-muted);font-size:12px;padding:4px 0;">'
+            + 'No channel activity yet. '
+            + '<a href="#" onclick="switchTab(\'flow\');return false;" '
+            + 'style="color:var(--accent-primary,#3b82f6);text-decoration:underline;">Connect a channel →</a>'
+            + '</div>';
         } else {
-          ciWrap.style.display = '';
-          var emoji = function(p) {
-            return p === 'telegram' ? '✈️'
-                 : p === 'signal'   ? '📡'
-                 : p === 'slack'    ? '💬'
-                 : p === 'discord'  ? '🎮'
-                 : p === 'whatsapp' ? '🟢'
-                 : p === 'imessage' ? '🍎'
-                 : p === 'webchat'  ? '🌐'
-                 : p === 'irc'      ? '#'
-                 : '📨';
-          };
           var fmtMins = function(m) {
             if (m == null) return 'never';
             if (m < 1) return 'just now';
@@ -6859,7 +6878,11 @@ async function loadSystemHealth() {
                          : '#6b7280';
             var border = (mins != null && mins < 10) ? 'rgba(22,163,74,0.3)' : 'var(--border-secondary)';
             cihtml += '<div title="total ' + row.total + ' (' + (row.msg_in||0) + ' in / ' + (row.msg_out||0) + ' out)" '
-              + 'style="display:flex;align-items:center;gap:7px;padding:7px 12px;background:var(--bg-secondary);border-radius:8px;border:1px solid ' + border + ';font-size:12px;margin-bottom:4px;">'
+              + 'onclick="switchTab(\'flow\')" '
+              + 'onmouseover="this.style.background=\'var(--bg-primary)\'" '
+              + 'onmouseout="this.style.background=\'var(--bg-secondary)\'" '
+              + 'style="display:flex;align-items:center;gap:7px;padding:7px 12px;background:var(--bg-secondary);'
+              + 'border-radius:8px;border:1px solid ' + border + ';font-size:12px;margin-bottom:4px;cursor:pointer;">'
               + '<span style="width:9px;height:9px;border-radius:50%;background:' + dotColor + ';flex-shrink:0;display:inline-block;"></span>'
               + emoji(row.provider) + ' <span style="font-weight:600;color:var(--text-primary);">' + escHtml(row.provider) + '</span>'
               + '<span style="color:var(--text-muted);font-size:11px;margin-left:auto;">' + fmtMins(mins) + ' &middot; ' + row.total + ' total</span>'


### PR DESCRIPTION
Closes #1321

Addresses the three UX gaps from @vivekchand's steve/UX review of PR #1318.

## Changes

- **Emoji map 8 → 22 providers** (`app.js` line ~6833): all routes in `routes/channels.py` now map to a distinct glyph — `googlechat` 💬, `msteams` 🏢, `matrix` 🔷, `mattermost` 📢, `bluebubbles` 🫧, `tui` ⌨️, `line` 🟩, `nostr` ⚡, `twitch` 🟣, `feishu` 🪶, `zalo` 🔵, `tlon` 🌊, `synology-chat` 🖥️, `nextcloud-talk` ☁️. No two rows render identically.

- **Empty state CTA** (`app.js` line ~6858): `ciWrap.style.display = ''` now runs unconditionally so the card always shows. When `ingest.length === 0` it renders "No channel activity yet. [Connect a channel →]" (links to Flow tab) instead of the blank rectangle the hide produced.

- **Clickable rows** (`app.js` line ~6880): each provider row gets `onclick="switchTab('flow')"`, `cursor:pointer`, and `onmouseover/onmouseout` background hover — matching the sibling latency/daemon/gateway sub-panel behaviour.

## Test plan

- [ ] Hard-refresh System Health with a paired Telegram/Signal/Slack install — each provider shows its distinct emoji; rows are clickable and navigate to the Flow tab.
- [ ] Fresh install (no channels): confirm the "Channel ingest" section remains visible with the CTA instead of disappearing.
- [ ] Any provider not in the map (future additions) still falls back to 📨 — doesn't break.
- [ ] `node --check clawmetry/static/js/app.js` passes (no syntax errors).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsNqim8SJBiHn4xDNeqzit)_