### PR TITLE
ci: split e2e-tests into hard-gated critical + nightly full suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,12 +117,20 @@ jobs:
           CLAWMETRY_TOKEN: ci-test-token
         run: python3 -m pytest tests/test_api.py -v --tb=short
 
-  # ── E2E Playwright tests (Linux only for speed, allowed to fail) ──────────
-  e2e-tests:
-    name: E2E Browser Tests
+  # ── E2E Playwright tests — critical subset (hard-gate, blocks merge) ──────
+  # Per issue #1528: the prior `e2e-tests` job carried `continue-on-error: true`
+  # which silently masked Playwright regressions. We split the suite into:
+  #   1. `e2e-critical` (this job) — TestTabsLoad: page-load + tab-nav smoke
+  #      tests that have been stable. Hard-fails on regression.
+  #   2. `e2e-nightly`  (.github/workflows/e2e-nightly.yml) — the broader
+  #      TestFlowDiagram suite, which depends on SVG rendering of live data
+  #      and is still flaky. Runs on schedule, not per-PR.
+  # If you add a new e2e test, default it to nightly until it has a clean
+  # run history; promote to critical once it has been green for ~1 week.
+  e2e-critical:
+    name: E2E Browser Tests (critical subset)
     needs: lint
     runs-on: ubuntu-latest
-    continue-on-error: true  # Remove once tests are fully stable
 
     steps:
       - uses: actions/checkout@v4
@@ -140,11 +148,11 @@ jobs:
             curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health && break
             sleep 1
           done
-      - name: Run E2E tests
+      - name: Run E2E tests (critical subset only — hard gate)
         env:
           CLAWMETRY_URL: http://localhost:8900
           CLAWMETRY_TOKEN: ci-test-token
-        run: python3 -m pytest tests/test_e2e.py -v --tb=short
+        run: python3 -m pytest tests/test_e2e.py::TestTabsLoad -v --tb=short
 
   # ── pip install smoke test across platforms ───────────────────────────────
   pip-install:

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,48 @@
+name: E2E Nightly (full suite)
+
+# Companion to the per-PR `e2e-critical` job in ci.yml (issue #1528).
+# This workflow runs the broader Playwright suite — currently the
+# TestFlowDiagram tests, which exercise live-data SVG rendering and have
+# historically been flaky. Running them on a nightly schedule keeps the
+# pre-merge signal sharp (critical tests only) while still surfacing
+# regressions in the broader surface area within 24h.
+#
+# Failure here does NOT block merges. Investigate via the workflow logs
+# linked in the failed-run notification.
+
+on:
+  schedule:
+    # 03:17 UTC daily — off-peak, off the :00/:30 minute crowd.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  e2e-nightly:
+    name: E2E Browser Tests (full suite)
+    runs-on: ubuntu-latest
+    # Nightly is informational, not a gate. Don't fail the workflow run
+    # itself when the broader suite reports flakes — the job result is
+    # what matters for alerting.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install flask pytest pytest-playwright requests
+      - name: Install Playwright browsers
+        run: python3 -m playwright install chromium --with-deps
+      - name: Start server
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=ci-test-token python3 dashboard.py --port 8900 --no-debug &
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health && break
+            sleep 1
+          done
+      - name: Run full E2E suite
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+          CLAWMETRY_TOKEN: ci-test-token
+        run: python3 -m pytest tests/test_e2e.py -v --tb=short


### PR DESCRIPTION
Closes #1528.

## What

The prior `e2e-tests` job in `.github/workflows/ci.yml` carried `continue-on-error: true` with a stale "Remove once tests are fully stable" TODO. That silently masked Playwright regressions — CI reported green even when the suite was broken. Same class of MOAT gap as #1491 (closed by #1527): an invariant existed but had no teeth.

Per the issue's recommended option (rip + replace with hard-gating subset), the suite is now split into:

- **`e2e-critical`** (per-PR, in `ci.yml`) — runs `tests/test_e2e.py::TestTabsLoad` only. Page-load + tab-nav smoke tests that have been stable. No `continue-on-error`. Hard-fails on regression and blocks merge.
- **`e2e-nightly`** (scheduled, new `e2e-nightly.yml`) — runs the full `tests/test_e2e.py` suite, including the flaky `TestFlowDiagram` class that depends on live SVG rendering. Schedule: `17 3 * * *` UTC + `workflow_dispatch`. Failure does not block merges.

This matches the acceptance criteria: `continue-on-error: true` is gone from the per-PR job, the new `e2e-critical` job hard-fails on a stable subset, and the broader flaky suite is moved to nightly.

## How

- `ci.yml`: renamed `e2e-tests` → `e2e-critical`, dropped `continue-on-error: true`, scoped pytest invocation to `tests/test_e2e.py::TestTabsLoad`, added a comment explaining the split + the rule for promoting new tests from nightly → critical.
- `e2e-nightly.yml`: new scheduled workflow. Same setup steps as the critical job, runs the full file. `continue-on-error: true` on the job itself so flaky nightly runs do not turn the workflow run red — the job-level signal is what feeds alerting.

## Test plan

- [ ] CI on this PR: `e2e-critical` runs to completion and reports `TestTabsLoad` results without `continue-on-error` masking.
- [ ] After merge: trigger `e2e-nightly` via `workflow_dispatch` once to confirm the full suite still runs end-to-end.
- [ ] Watch the first scheduled nightly run; investigate any TestFlowDiagram failures (these were already flaky pre-change, so initial nightly runs may report failures — that is the point).

🤖 Generated by the auto-issues cron (see MC task `2a823ooxx`).