### PR TITLE
fix: modernize type hints in clawmetry/ package (PEP 604/585)

### DIFF
--- a/clawmetry/adapters/base.py
+++ b/clawmetry/adapters/base.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, Iterator, List, Optional, Set
+from typing import Any, Iterator
 
 
 class Capability(str, Enum):
@@ -58,8 +58,8 @@ class Session:
     model: str = ""
     source: str = ""
     started_at: float = 0.0
-    ended_at: Optional[float] = None
-    parent_id: Optional[str] = None
+    ended_at: float | None = None
+    parent_id: str | None = None
     message_count: int = 0
     total_tokens: int = 0
     input_tokens: int = 0
@@ -67,12 +67,12 @@ class Session:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
     reasoning_tokens: int = 0
-    cost_usd: Optional[float] = None
+    cost_usd: float | None = None
     cost_status: str = ""
     end_reason: str = ""
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = {
             "agent": self.agent,
             "id": self.id,
@@ -116,12 +116,12 @@ class Event:
     role: str = ""
     content: str = ""
     tool_name: str = ""
-    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
-    parent_id: Optional[str] = None
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    parent_id: str | None = None
     tokens: int = 0
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = {
             "agent": self.agent,
             "sessionId": self.session_id,
@@ -156,10 +156,10 @@ class DetectResult:
     running: bool = False
     workspace: str = ""
     session_count: int = 0
-    capabilities: List[str] = field(default_factory=list)
-    meta: Dict[str, Any] = field(default_factory=dict)
+    capabilities: list[str] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "displayName": self.display_name,
@@ -194,18 +194,18 @@ class AgentAdapter(ABC):
         ...
 
     @abstractmethod
-    def list_sessions(self, limit: int = 100) -> List[Session]:
+    def list_sessions(self, limit: int = 100) -> list[Session]:
         """Return recent sessions, newest first. Empty list if none."""
         ...
 
-    def read_session(self, session_id: str) -> Optional[Session]:
+    def read_session(self, session_id: str) -> Session | None:
         """Return a single session by native ID, or ``None``."""
         return next(
             (s for s in self.list_sessions(limit=1000) if s.id == session_id),
             None,
         )
 
-    def list_events(self, session_id: str, limit: int = 500) -> List[Event]:
+    def list_events(self, session_id: str, limit: int = 500) -> list[Event]:
         """Return events for a session in chronological order."""
         return []
 
@@ -219,7 +219,7 @@ class AgentAdapter(ABC):
         return iter(())
 
     @abstractmethod
-    def capabilities(self) -> Set[Capability]:
+    def capabilities(self) -> set[Capability]:
         """Return the set of :class:`Capability` flags this adapter exposes."""
         ...
 

--- a/clawmetry/adapters/hermes.py
+++ b/clawmetry/adapters/hermes.py
@@ -27,7 +27,7 @@ import os
 import sqlite3
 import threading
 import time
-from typing import Iterator, List, Optional, Set
+from typing import Iterator
 
 from .base import AgentAdapter, Capability, DetectResult, Event, Session
 
@@ -38,7 +38,7 @@ def _hermes_home() -> str:
     return os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
 
 
-def _state_db_path(home: Optional[str] = None) -> str:
+def _state_db_path(home: str | None = None) -> str:
     return os.path.join(home or _hermes_home(), "state.db")
 
 
@@ -142,7 +142,7 @@ class HermesAdapter(AgentAdapter):
     def __init__(self) -> None:
         self._stream_stop = threading.Event()
 
-    def _db(self) -> Optional[sqlite3.Connection]:
+    def _db(self) -> sqlite3.Connection | None:
         path = _state_db_path()
         if not os.path.isfile(path):
             return None
@@ -204,7 +204,7 @@ class HermesAdapter(AgentAdapter):
         except (OSError, ProcessLookupError):
             return False
 
-    def list_sessions(self, limit: int = 100) -> List[Session]:
+    def list_sessions(self, limit: int = 100) -> list[Session]:
         conn = self._db()
         if conn is None:
             return []
@@ -221,7 +221,7 @@ class HermesAdapter(AgentAdapter):
         finally:
             conn.close()
 
-    def read_session(self, session_id: str) -> Optional[Session]:
+    def read_session(self, session_id: str) -> Session | None:
         conn = self._db()
         if conn is None:
             return None
@@ -238,7 +238,7 @@ class HermesAdapter(AgentAdapter):
         finally:
             conn.close()
 
-    def list_events(self, session_id: str, limit: int = 500) -> List[Event]:
+    def list_events(self, session_id: str, limit: int = 500) -> list[Event]:
         conn = self._db()
         if conn is None:
             return []
@@ -303,7 +303,7 @@ class HermesAdapter(AgentAdapter):
     def stop_stream(self) -> None:
         self._stream_stop.set()
 
-    def capabilities(self) -> Set[Capability]:
+    def capabilities(self) -> set[Capability]:
         # Deliberately narrow for v1: Hermes exposes more data (skills
         # dir, cron tick files, memory markdown) but hooking each one
         # into ClawMetry's tabs needs per-feature engineering. Ship the

--- a/clawmetry/adapters/registry.py
+++ b/clawmetry/adapters/registry.py
@@ -9,13 +9,12 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import List, Optional
 
 from .base import AgentAdapter, DetectResult
 
 logger = logging.getLogger("clawmetry.adapters")
 
-_adapters: List[AgentAdapter] = []
+_adapters: list[AgentAdapter] = []
 _lock = threading.Lock()
 
 
@@ -42,13 +41,13 @@ def unregister(name: str) -> None:
         _adapters[:] = [a for a in _adapters if a.name != name]
 
 
-def all_adapters() -> List[AgentAdapter]:
+def all_adapters() -> list[AgentAdapter]:
     """Snapshot of registered adapters — safe to iterate without the lock."""
     with _lock:
         return list(_adapters)
 
 
-def get(name: str) -> Optional[AgentAdapter]:
+def get(name: str) -> AgentAdapter | None:
     with _lock:
         for a in _adapters:
             if a.name == name:
@@ -56,13 +55,13 @@ def get(name: str) -> Optional[AgentAdapter]:
     return None
 
 
-def detect_all() -> List[DetectResult]:
+def detect_all() -> list[DetectResult]:
     """Run :meth:`AgentAdapter.detect` on every registered adapter.
 
     Errors are caught and logged — one broken adapter never blocks the
     others. Result order matches registration order.
     """
-    results: List[DetectResult] = []
+    results: list[DetectResult] = []
     for a in all_adapters():
         try:
             results.append(a.detect())

--- a/clawmetry/config.py
+++ b/clawmetry/config.py
@@ -7,7 +7,6 @@ Currently used for type hints and documentation. dashboard.py globals remain unc
 from __future__ import annotations
 import os
 from dataclasses import dataclass, field
-from typing import List, Optional
 
 
 # ── DuckDB local-store fast-path feature gate ──────────────────────────────
@@ -66,13 +65,13 @@ class ClawMetryConfig:
     # Runtime
     model: str = ""
     provider: str = ""
-    channels: List[str] = field(default_factory=list)
+    channels: list[str] = field(default_factory=list)
     host: str = "127.0.0.1"
     port: int = 8900
     debug: bool = False
 
     # Auth
-    auth_token: Optional[str] = None
+    auth_token: str | None = None
 
     def from_globals(self, _dashboard_module=None) -> "ClawMetryConfig":
         """

--- a/clawmetry/dives_sql_safety.py
+++ b/clawmetry/dives_sql_safety.py
@@ -35,7 +35,6 @@ in the UI.
 from __future__ import annotations
 
 import re
-from typing import Optional, Tuple
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -134,13 +133,13 @@ def _split_statements(sanitized: str) -> list[str]:
     return [p for p in parts if p]
 
 
-def _first_keyword(stmt: str) -> Optional[str]:
+def _first_keyword(stmt: str) -> str | None:
     """Return the first SQL identifier token in *stmt*, uppercased."""
     m = _IDENT_RE.search(stmt)
     return m.group(0).upper() if m else None
 
 
-def _contains_banned_function(sanitized: str) -> Optional[str]:
+def _contains_banned_function(sanitized: str) -> str | None:
     """Return the name of a banned function call found in *sanitized*, or None."""
     # Identifier followed by optional whitespace then '(' = function call.
     for m in re.finditer(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(", sanitized):
@@ -150,7 +149,7 @@ def _contains_banned_function(sanitized: str) -> Optional[str]:
     return None
 
 
-def _contains_banned_keyword(sanitized: str) -> Optional[str]:
+def _contains_banned_keyword(sanitized: str) -> str | None:
     """Return any banned statement-level keyword found as a whole token."""
     for m in _IDENT_RE.finditer(sanitized):
         word = m.group(0).upper()
@@ -163,7 +162,7 @@ def _contains_banned_keyword(sanitized: str) -> Optional[str]:
 # Optional sqlglot pass
 # ---------------------------------------------------------------------------
 
-def _sqlglot_check(sql: str) -> Optional[str]:
+def _sqlglot_check(sql: str) -> str | None:
     """Run sqlglot as defence-in-depth. Returns a rejection reason, or None.
 
     If sqlglot isn't installed we skip — the lexical pass already enforces the
@@ -203,7 +202,7 @@ def _sqlglot_check(sql: str) -> Optional[str]:
 # Public entry point
 # ---------------------------------------------------------------------------
 
-def validate_sql(sql: str) -> Tuple[bool, Optional[str]]:
+def validate_sql(sql: str) -> tuple[bool, str | None]:
     """Validate *sql* against the Dives allowlist.
 
     Returns ``(True, None)`` if the query is safe, otherwise ``(False, reason)``.

--- a/clawmetry/interceptor.py
+++ b/clawmetry/interceptor.py
@@ -25,7 +25,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 import re
 
 # ── Config ─────────────────────────────────────────────────────────────────────
@@ -57,7 +57,7 @@ _patched_requests = False
 
 # ── Pricing table (per 1M tokens, USD) ────────────────────────────────────────
 
-_PRICING: Dict[str, Dict[str, float]] = {
+_PRICING: dict[str, dict[str, float]] = {
     # Anthropic
     "claude-opus-4": {"input": 15.0, "output": 75.0},
     "claude-sonnet-4": {"input": 3.0, "output": 15.0},
@@ -86,7 +86,7 @@ _PRICING: Dict[str, Dict[str, float]] = {
 
 def _estimate_cost(
     model: str, input_tokens: int, output_tokens: int
-) -> Optional[float]:
+) -> float | None:
     """Estimate cost in USD for given model and token counts."""
     if not model or (input_tokens == 0 and output_tokens == 0):
         return None
@@ -129,7 +129,7 @@ def _detect_provider(url: str) -> str:
 # ── Request/Response parsing ───────────────────────────────────────────────────
 
 
-def _extract_model_from_body(body_bytes: bytes, url: str) -> Optional[str]:
+def _extract_model_from_body(body_bytes: bytes, url: str) -> str | None:
     """Try to extract model name from request body JSON."""
     if not body_bytes:
         return None
@@ -149,7 +149,7 @@ def _extract_model_from_body(body_bytes: bytes, url: str) -> Optional[str]:
     return None
 
 
-def _extract_tokens_from_response(body_bytes: bytes, provider: str) -> Dict[str, int]:
+def _extract_tokens_from_response(body_bytes: bytes, provider: str) -> dict[str, int]:
     """Extract input/output token counts from response body."""
     result = {"input_tokens": 0, "output_tokens": 0}
     if not body_bytes:
@@ -178,7 +178,7 @@ def _extract_tokens_from_response(body_bytes: bytes, provider: str) -> Dict[str,
     return result
 
 
-def _extract_model_from_response(body_bytes: bytes, provider: str) -> Optional[str]:
+def _extract_model_from_response(body_bytes: bytes, provider: str) -> str | None:
     """Some providers echo the model in the response."""
     if not body_bytes:
         return None
@@ -195,7 +195,7 @@ def _extract_model_from_response(body_bytes: bytes, provider: str) -> Optional[s
 # ── JSONL writer ───────────────────────────────────────────────────────────────
 
 
-def _write_event(event: Dict[str, Any]) -> None:
+def _write_event(event: dict[str, Any]) -> None:
     """Thread-safely append an event to the JSONL output file."""
     try:
         out_file = _get_output_file()
@@ -211,16 +211,16 @@ def _write_event(event: Dict[str, Any]) -> None:
 def _build_event(
     provider: str,
     url: str,
-    model: Optional[str],
+    model: str | None,
     input_tokens: int,
     output_tokens: int,
     latency_ms: float,
     status_code: int,
     library: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build the event dict to write to JSONL."""
     cost = _estimate_cost(model or "", input_tokens, output_tokens)
-    event: Dict[str, Any] = {
+    event: dict[str, Any] = {
         "type": "llm_call",
         "ts": datetime.now(timezone.utc).isoformat(),
         "provider": provider,
@@ -439,7 +439,7 @@ def _patch_requests() -> bool:
 # ── Public API ─────────────────────────────────────────────────────────────────
 
 
-def activate() -> Dict[str, bool]:
+def activate() -> dict[str, bool]:
     """
     Explicitly activate the interceptor.
 

--- a/clawmetry/providers/__init__.py
+++ b/clawmetry/providers/__init__.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 import logging
 import os
-from typing import Dict, Optional, Type
 
 from clawmetry.providers.base import ClawMetryDataProvider
 
 logger = logging.getLogger("clawmetry.providers")
 
-_registry: Dict[str, Type[ClawMetryDataProvider]] = {}
-_active_provider: Optional[ClawMetryDataProvider] = None
+_registry: dict[str, type[ClawMetryDataProvider]] = {}
+_active_provider: ClawMetryDataProvider | None = None
 
 
-def register_provider(name: str, cls: Type[ClawMetryDataProvider]) -> None:
+def register_provider(name: str, cls: type[ClawMetryDataProvider]) -> None:
     _registry[name] = cls
 
 
@@ -23,7 +22,7 @@ def get_provider(name: str, **kwargs) -> ClawMetryDataProvider:
     return _registry[name](**kwargs)
 
 
-def get_active_provider() -> Optional[ClawMetryDataProvider]:
+def get_active_provider() -> ClawMetryDataProvider | None:
     return _active_provider
 
 

--- a/clawmetry/providers/base.py
+++ b/clawmetry/providers/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 @dataclass
@@ -16,7 +16,7 @@ class Session:
     total_tokens: int = 0
     kind: str = "direct"
     label: str = ""
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -25,7 +25,7 @@ class Event:
     session_id: str
     event_type: str
     ts: str
-    data: Dict[str, Any] = field(default_factory=dict)
+    data: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -33,17 +33,17 @@ class LogEntry:
     ts: str
     level: str
     message: str
-    channel: Optional[str] = None
-    session_id: Optional[str] = None
-    raw: Dict[str, Any] = field(default_factory=dict)
+    channel: str | None = None
+    session_id: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class MemoryFile:
     path: str
     size: int
-    modified: Optional[str] = None
-    content: Optional[str] = None
+    modified: str | None = None
+    content: str | None = None
 
 
 @dataclass
@@ -51,7 +51,7 @@ class MetricPoint:
     metric_type: str
     ts: str
     value: float
-    labels: Dict[str, str] = field(default_factory=dict)
+    labels: dict[str, str] = field(default_factory=dict)
 
 
 class ClawMetryDataProvider(ABC):
@@ -86,18 +86,18 @@ class ClawMetryDataProvider(ABC):
         self,
         limit: int = 30,
         include_subagents: bool = True,
-        since_ms: Optional[int] = None,
-    ) -> List[Session]:
+        since_ms: int | None = None,
+    ) -> list[Session]:
         """Return recent sessions, newest first."""
         ...
 
     @abstractmethod
-    def get_session(self, session_id: str) -> Optional[Session]:
+    def get_session(self, session_id: str) -> Session | None:
         """Return a single session by ID."""
         ...
 
     @abstractmethod
-    def get_session_index(self) -> Dict[str, Dict]:
+    def get_session_index(self) -> dict[str, dict]:
         """Return sessions.json-style map: session_key → metadata dict."""
         ...
 
@@ -105,8 +105,8 @@ class ClawMetryDataProvider(ABC):
 
     @abstractmethod
     def get_events(
-        self, session_id: str, limit: int = 500, tail_bytes: Optional[int] = None
-    ) -> List[Event]:
+        self, session_id: str, limit: int = 500, tail_bytes: int | None = None
+    ) -> list[Event]:
         """Return events for a session. tail_bytes: read only last N bytes of JSONL."""
         ...
 
@@ -114,20 +114,20 @@ class ClawMetryDataProvider(ABC):
 
     @abstractmethod
     def get_log_lines(
-        self, date_str: Optional[str] = None, limit: int = 1000
-    ) -> List[str]:
+        self, date_str: str | None = None, limit: int = 1000
+    ) -> list[str]:
         """Return raw log lines for a date (YYYY-MM-DD). None = today."""
         ...
 
     @abstractmethod
-    def list_log_dates(self, days_back: int = 31) -> List[str]:
+    def list_log_dates(self, days_back: int = 31) -> list[str]:
         """Return list of YYYY-MM-DD strings that have log data."""
         ...
 
     # ── Memory / Workspace ────────────────────────────────────────────────────
 
     @abstractmethod
-    def list_memory_files(self) -> List[MemoryFile]:
+    def list_memory_files(self) -> list[MemoryFile]:
         """Return workspace memory files with metadata."""
         ...
 
@@ -139,12 +139,12 @@ class ClawMetryDataProvider(ABC):
     # ── Crons ─────────────────────────────────────────────────────────────────
 
     @abstractmethod
-    def list_crons(self) -> List[Dict[str, Any]]:
+    def list_crons(self) -> list[dict[str, Any]]:
         """Return cron job definitions."""
         ...
 
     # ── Health ────────────────────────────────────────────────────────────────
 
-    def health_check(self) -> Dict[str, Any]:
+    def health_check(self) -> dict[str, Any]:
         """Return health status. Override for custom checks."""
         return {"provider": self.__class__.__name__, "ok": True}

--- a/clawmetry/providers/local.py
+++ b/clawmetry/providers/local.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime, timezone, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from clawmetry.providers.base import ClawMetryDataProvider, Event, MemoryFile, Session
 
@@ -28,7 +28,7 @@ class LocalDataProvider(ClawMetryDataProvider):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._sessions_index_cache: Optional[Dict] = None
+        self._sessions_index_cache: dict | None = None
         self._sessions_index_mtime: float = 0
 
     # ── Sessions ──────────────────────────────────────────────────────────────
@@ -40,7 +40,7 @@ class LocalDataProvider(ClawMetryDataProvider):
             else ""
         )
 
-    def get_session_index(self) -> Dict[str, Dict]:
+    def get_session_index(self) -> dict[str, dict]:
         idx_path = self._sessions_index_path()
         if not idx_path or not os.path.exists(idx_path):
             return {}
@@ -58,8 +58,8 @@ class LocalDataProvider(ClawMetryDataProvider):
         self,
         limit: int = 30,
         include_subagents: bool = True,
-        since_ms: Optional[int] = None,
-    ) -> List[Session]:
+        since_ms: int | None = None,
+    ) -> list[Session]:
         index = self.get_session_index()
         sessions = []
         for key, meta in index.items():
@@ -93,7 +93,7 @@ class LocalDataProvider(ClawMetryDataProvider):
         sessions.sort(key=lambda s: s.updated_at, reverse=True)
         return sessions[:limit]
 
-    def get_session(self, session_id: str) -> Optional[Session]:
+    def get_session(self, session_id: str) -> Session | None:
         index = self.get_session_index()
         for key, meta in index.items():
             if not isinstance(meta, dict):
@@ -125,8 +125,8 @@ class LocalDataProvider(ClawMetryDataProvider):
     # ── Events ────────────────────────────────────────────────────────────────
 
     def get_events(
-        self, session_id: str, limit: int = 500, tail_bytes: Optional[int] = None
-    ) -> List[Event]:
+        self, session_id: str, limit: int = 500, tail_bytes: int | None = None
+    ) -> list[Event]:
         if not self.sessions_dir:
             return []
         jsonl_path = os.path.join(self.sessions_dir, f"{session_id}.jsonl")
@@ -165,7 +165,7 @@ class LocalDataProvider(ClawMetryDataProvider):
 
     # ── Logs ──────────────────────────────────────────────────────────────────
 
-    def _log_file_path(self, date_str: str) -> Optional[str]:
+    def _log_file_path(self, date_str: str) -> str | None:
         if not self.log_dir:
             return None
         for prefix in ("openclaw", "moltbot"):
@@ -175,8 +175,8 @@ class LocalDataProvider(ClawMetryDataProvider):
         return None
 
     def get_log_lines(
-        self, date_str: Optional[str] = None, limit: int = 1000
-    ) -> List[str]:
+        self, date_str: str | None = None, limit: int = 1000
+    ) -> list[str]:
         if date_str is None:
             date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         path = self._log_file_path(date_str)
@@ -189,7 +189,7 @@ class LocalDataProvider(ClawMetryDataProvider):
         except Exception:
             return []
 
-    def list_log_dates(self, days_back: int = 31) -> List[str]:
+    def list_log_dates(self, days_back: int = 31) -> list[str]:
         dates = []
         today = datetime.now(timezone.utc)
         for i in range(days_back):
@@ -200,7 +200,7 @@ class LocalDataProvider(ClawMetryDataProvider):
 
     # ── Memory / Workspace ────────────────────────────────────────────────────
 
-    def list_memory_files(self) -> List[MemoryFile]:
+    def list_memory_files(self) -> list[MemoryFile]:
         files = []
         if not self.workspace:
             return files
@@ -251,7 +251,7 @@ class LocalDataProvider(ClawMetryDataProvider):
 
     # ── Crons ─────────────────────────────────────────────────────────────────
 
-    def list_crons(self) -> List[Dict[str, Any]]:
+    def list_crons(self) -> list[dict[str, Any]]:
         # Try cron/jobs.json relative to parent of workspace
         candidates = []
         if self.workspace:
@@ -276,7 +276,7 @@ class LocalDataProvider(ClawMetryDataProvider):
 
     # ── Health ────────────────────────────────────────────────────────────────
 
-    def health_check(self) -> Dict[str, Any]:
+    def health_check(self) -> dict[str, Any]:
         return {
             "provider": "LocalDataProvider",
             "ok": True,

--- a/clawmetry/relay.py
+++ b/clawmetry/relay.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import json
 import logging
 import threading
-from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -51,7 +50,7 @@ _CAPABILITIES = [
 ]
 
 
-def start_relay_thread(config: dict, version: str = "unknown") -> Optional[threading.Thread]:
+def start_relay_thread(config: dict, version: str = "unknown") -> threading.Thread | None:
     """No-op since 2026-05-13. See module docstring.
 
     Returns ``None`` unconditionally so callers' ``if t:`` guards stay

--- a/clawmetry/telemetry.py
+++ b/clawmetry/telemetry.py
@@ -43,7 +43,6 @@ import time
 import urllib.request
 import uuid
 from pathlib import Path
-from typing import Optional, Tuple
 
 log = logging.getLogger(__name__)
 
@@ -97,7 +96,7 @@ def _is_optout() -> bool:
     return False
 
 
-def _detect_ci() -> Tuple[bool, Optional[str]]:
+def _detect_ci() -> tuple[bool, str | None]:
     """Return (is_ci, provider_name_or_None).
 
     Walks the ``_CI_PROVIDERS`` list in priority order; first hit wins.
@@ -124,7 +123,7 @@ def _detect_agent() -> str:
     return "none"
 
 
-def _ensure_install_id() -> Optional[str]:
+def _ensure_install_id() -> str | None:
     """Read existing install_id, or create one and persist.
 
     Returns ``None`` if we can't write to ``CONFIG_DIR`` (e.g. read-only
@@ -224,7 +223,7 @@ def _send_in_background(version: str) -> None:
         log.debug("telemetry: background failure: %s", e)
 
 
-def maybe_ping(version: str = "unknown") -> Optional[threading.Thread]:
+def maybe_ping(version: str = "unknown") -> threading.Thread | None:
     """Public entry point. Call once on CLI startup.
 
     Returns the thread for testing convenience; ``None`` if telemetry


### PR DESCRIPTION
Closes #1326

## Summary

- Replaces `Optional[X]` → `X | None`, `Dict[K,V]` → `dict[K,V]`, `List[X]` → `list[X]`, `Tuple[X,Y]` → `tuple[X,Y]`, `Set[X]` → `set[X]`, `Type[X]` → `type[X]` across 11 files in the `clawmetry/` package
- Removes now-unused `typing` imports (`Optional`, `Dict`, `List`, `Tuple`, `Set`, `Type`); retains `Any` and `Iterator` which have no built-in equivalents
- All files already had `from __future__ import annotations`, so the `X | None` union syntax is safe on Python 3.9+ (our minimum)

Files touched: `config.py`, `providers/__init__.py`, `providers/base.py`, `providers/local.py`, `relay.py`, `dives_sql_safety.py`, `telemetry.py`, `interceptor.py`, `adapters/base.py`, `adapters/hermes.py`, `adapters/registry.py`

`dashboard.py` and route modules are out of scope for this PR — follow-up work.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open(f).read())"` — all 11 files parse cleanly
- [x] `python3 -c "from clawmetry.config import ...; from clawmetry.providers import ...; ..."` — all modules import without error
- [x] `make lint` — zero new errors introduced in changed files (pre-existing errors in `dashboard.py` etc. unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgEitwdDBAS6BKRGqmnrZN)_