### PR TITLE
feat(usage): cost forecast card — projected month-end spend + budget alert

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7415,6 +7415,8 @@ async function loadUsage() {
     loadHeatmap();
     // Load prompt cache analytics (GH #979)
     loadCacheAnalytics();
+    // Load cost forecast (issue #1413)
+    loadCostForecast();
   } catch(e) {
     document.getElementById('usage-chart').innerHTML = '<span style="color:#555">No usage data available</span>';
   }
@@ -7672,6 +7674,55 @@ function renderCostComparison(data) {
   html += '</div>';
   html += '<div style="margin-top:10px;font-size:11px;color:var(--text-muted);line-height:1.5;">Estimates based on 60/40 input/output split for ' + tokStr + ' tokens. Actual costs vary by prompt structure and API tier.</div>';
   el.innerHTML = html;
+}
+
+// ===== Cost Forecast (issue #1413) =====
+async function loadCostForecast() {
+  var title = document.getElementById('cost-forecast-title');
+  var card = document.getElementById('cost-forecast-card');
+  var el = document.getElementById('cost-forecast-content');
+  if (!card || !el) return;
+  try {
+    var d = await fetch('/api/usage/forecast').then(function(r){return r.json();});
+    if (!d || !d.available) return;
+    // Hide card when daily rate is effectively zero (no meaningful data yet)
+    if ((d.daily_rate_usd || 0) === 0 && (d.cost_this_month_usd || 0) === 0) return;
+    if (title) title.style.display = '';
+    card.style.display = '';
+    var proj = d.projected_month_usd || 0;
+    var budget = d.monthly_budget_usd || 0;
+    var exceeded = d.budget_exceeded;
+    var color = exceeded ? 'var(--danger, #ef4444)' : '#22c55e';
+    var icon = exceeded ? '⚠️' : '✅';
+    var statusMsg = '';
+    if (budget > 0) {
+      if (exceeded) {
+        var over = proj - budget;
+        statusMsg = 'Will exceed $' + budget.toFixed(2) + ' budget by $' + over.toFixed(2);
+        if (d.days_to_budget !== null && d.days_to_budget <= d.days_remaining_in_month) {
+          statusMsg += ' · exceeds in ~' + Math.ceil(d.days_to_budget) + ' day' + (Math.ceil(d.days_to_budget) !== 1 ? 's' : '');
+        }
+      } else {
+        statusMsg = 'On track vs $' + budget.toFixed(2) + ' budget';
+      }
+    } else {
+      statusMsg = d.days_remaining_in_month + 'd remaining this month';
+    }
+    el.innerHTML =
+      '<div style="display:flex;gap:24px;flex-wrap:wrap;align-items:center;">' +
+        '<div>' +
+          '<div style="font-size:12px;color:var(--text-muted);">Projected month-end</div>' +
+          '<div style="font-size:22px;font-weight:700;color:' + color + ';">' + icon + ' $' + proj.toFixed(2) + '</div>' +
+        '</div>' +
+        '<div style="color:var(--text-muted);font-size:13px;">' + escHtml(statusMsg) + '</div>' +
+        '<div style="margin-left:auto;text-align:right;font-size:12px;color:var(--text-muted);">' +
+          '$' + (d.daily_rate_usd || 0).toFixed(4) + '/day avg<br>' +
+          '$' + (d.cost_this_month_usd || 0).toFixed(2) + ' spent so far' +
+        '</div>' +
+      '</div>';
+  } catch(e) {
+    // silently skip if endpoint unavailable
+  }
 }
 
 function renderTraceClusters(clusters, totalSessions) {

--- a/dashboard.py
+++ b/dashboard.py
@@ -4596,6 +4596,11 @@ function clawmetryLogout(){
   <div class="card" id="cache-perf-card" style="display:none;">
     <div id="cache-perf-content" style="min-height:48px;color:var(--text-muted);"></div>
   </div>
+  <!-- Cost Forecast (issue #1413) -->
+  <div class="section-title" id="cost-forecast-title" style="display:none;">📈 Cost Forecast <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">projected month-end · based on last 7 days</span></div>
+  <div class="card" id="cost-forecast-card" style="display:none;">
+    <div id="cost-forecast-content" style="min-height:48px;color:var(--text-muted);"></div>
+  </div>
     <div class="section-title">🔮 Trace Clusters <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">auto-group sessions by behavior pattern</span></div>
   <div class="card">
     <div id="trace-clusters-content" style="min-height:60px;color:var(--text-muted);">Loading...</div>

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -1780,6 +1780,82 @@ def api_usage_cost_comparison():
         return jsonify({"error": str(e), "alternatives": [], "actual": {}}), 500
 
 
+@bp_usage.route("/api/usage/forecast")
+def api_usage_forecast():
+    """7-day rolling spend rate projected to end-of-month (issue #1413).
+
+    Math: daily_rate = sum(cost_usd last 7 days) / 7
+          projected_month = cost_so_far + daily_rate * days_remaining
+          days_to_budget = (budget - cost_so_far) / daily_rate
+
+    Returns {available, daily_rate_usd, cost_this_month_usd,
+             projected_month_usd, days_remaining_in_month,
+             monthly_budget_usd, budget_exceeded, days_to_budget,
+             window_days, daily_window, _source}.
+    Returns {available: false} when no local-store data is present.
+    """
+    import calendar
+    import dashboard as _d
+    from datetime import datetime, timedelta, timezone
+
+    today = datetime.now(timezone.utc).date()
+
+    rows = _ls_call("query_daily_usage_splits") or []
+    if not rows:
+        rows = _ls_call("query_aggregates") or []
+
+    if not rows:
+        return jsonify({"available": False, "reason": "no_data"})
+
+    daily_costs: dict[str, float] = {}
+    for r in rows:
+        day = r.get("day", "")
+        if day:
+            daily_costs[day] = float(r.get("cost_usd") or 0)
+
+    window_days = 7
+    window: list[float] = []
+    for i in range(window_days):
+        d = (today - timedelta(days=i)).isoformat()
+        window.append(daily_costs.get(d, 0.0))
+
+    daily_rate = sum(window) / window_days
+
+    days_in_month = calendar.monthrange(today.year, today.month)[1]
+    days_elapsed = today.day
+    days_remaining = days_in_month - days_elapsed
+
+    month_str = today.strftime("%Y-%m")
+    cost_this_month = sum(v for k, v in daily_costs.items() if k.startswith(month_str))
+
+    projected_month = cost_this_month + daily_rate * days_remaining
+
+    budget_cfg = _d._get_budget_config()
+    monthly_budget = float(budget_cfg.get("monthly_limit") or 0)
+    monthly_cap = float(budget_cfg.get("monthly_cap_usd") or 0)
+    effective_budget = monthly_budget or monthly_cap or 0.0
+
+    budget_exceeded = bool(effective_budget > 0 and projected_month > effective_budget)
+    days_to_budget: float | None = None
+    if effective_budget > 0 and daily_rate > 0:
+        remaining_budget = effective_budget - cost_this_month
+        days_to_budget = max(0.0, remaining_budget / daily_rate)
+
+    return jsonify({
+        "available": True,
+        "daily_rate_usd": round(daily_rate, 4),
+        "cost_this_month_usd": round(cost_this_month, 4),
+        "projected_month_usd": round(projected_month, 4),
+        "days_remaining_in_month": days_remaining,
+        "monthly_budget_usd": effective_budget,
+        "budget_exceeded": budget_exceeded,
+        "days_to_budget": round(days_to_budget, 1) if days_to_budget is not None else None,
+        "window_days": window_days,
+        "daily_window": [round(c, 4) for c in reversed(window)],
+        "_source": "local_store",
+    })
+
+
 @bp_usage.route("/api/usage/export")
 def api_usage_export():
     """Export usage data as CSV."""


### PR DESCRIPTION
Closes #1413

## Summary

- **`routes/usage.py`** — New `GET /api/usage/forecast` endpoint. Reads daily cost rows from DuckDB via `_ls_call("query_daily_usage_splits")`, computes a 7-day rolling daily rate, projects month-end spend, and compares against any configured `monthly_limit`/`monthly_cap_usd`. Returns `{available: false}` gracefully when no local-store data exists.

- **`dashboard.py`** — Adds the "📈 Cost Forecast" HTML section (title + card, initially hidden) to the Tokens tab, between the Prompt Cache panel and Trace Clusters.

- **`clawmetry/static/js/app.js`** — Adds `loadCostForecast()` (modeled on `loadCostComparison()`). Shows projected spend in green/red depending on whether it exceeds the monthly budget, with "exceeds in ~N days" detail when a limit is configured. Called at the end of `loadUsage()`.

## Test plan

- [ ] Fresh install with no data → forecast card stays hidden (API returns `{available: false}`)
- [ ] Install with ≥ 7 days of DuckDB events → card appears above Trace Clusters showing projected spend
- [ ] Set `monthly_limit` in Budget config → card shows green ✅ or red ⚠️ with days-to-budget
- [ ] `make test-api` → 141 passed, 6 skipped (all pre-existing)
- [ ] `python3 -c "import ast; ast.parse(open('routes/usage.py').read())"` → OK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkZHyKoydtaq3MSAmLPwLr)_