### PR TITLE
feat(usage): add Pro-gated forecast alert CTA

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7699,8 +7699,21 @@ async function loadCostForecast() {
       if (exceeded) {
         var over = proj - budget;
         statusMsg = 'Will exceed $' + budget.toFixed(2) + ' budget by $' + over.toFixed(2);
+        var crossDate = '';
+        if (d.budget_cross_date) {
+          var parsedCrossDate = new Date(d.budget_cross_date + 'T00:00:00Z');
+          if (!isNaN(parsedCrossDate.getTime())) {
+            crossDate = parsedCrossDate.toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+              timeZone: 'UTC'
+            });
+          }
+        }
         if (d.days_to_budget !== null && d.days_to_budget <= d.days_remaining_in_month) {
-          statusMsg += ' · exceeds in ~' + Math.ceil(d.days_to_budget) + ' day' + (Math.ceil(d.days_to_budget) !== 1 ? 's' : '');
+          var dayCount = Math.ceil(d.days_to_budget);
+          var dayText = dayCount <= 0 ? 'today' : '~' + dayCount + ' day' + (dayCount !== 1 ? 's' : '');
+          statusMsg += crossDate ? ' · exceeds on ' + crossDate + ' (' + dayText + ')' : ' · exceeds ' + dayText;
         }
       } else {
         statusMsg = 'On track vs $' + budget.toFixed(2) + ' budget';

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7708,6 +7708,24 @@ async function loadCostForecast() {
     } else {
       statusMsg = d.days_remaining_in_month + 'd remaining this month';
     }
+    var alertGate = d.budget_alert || {};
+    var alertHtml = '';
+    if (exceeded && budget > 0) {
+      if (alertGate.pro_dispatch_enabled || d.pro_dispatch_enabled) {
+        alertHtml =
+          '<button type="button" onclick="switchTab(&quot;alerts&quot;)" ' +
+          'style="border:1px solid rgba(239,68,68,0.45);background:rgba(239,68,68,0.12);color:#fecaca;border-radius:6px;padding:7px 10px;font-size:12px;font-weight:600;cursor:pointer;">' +
+          'Set alert' +
+          '</button>';
+      } else {
+        var upgradeUrl = alertGate.upgrade_url || '/cloud/billing';
+        alertHtml =
+          '<a href="' + escHtml(upgradeUrl) + '" ' +
+          'style="display:inline-flex;align-items:center;border:1px solid rgba(239,68,68,0.45);background:rgba(239,68,68,0.12);color:#fecaca;border-radius:6px;padding:7px 10px;font-size:12px;font-weight:600;text-decoration:none;">' +
+          'Get alerted in Cloud-Pro' +
+          '</a>';
+      }
+    }
     el.innerHTML =
       '<div style="display:flex;gap:24px;flex-wrap:wrap;align-items:center;">' +
         '<div>' +
@@ -7715,6 +7733,7 @@ async function loadCostForecast() {
           '<div style="font-size:22px;font-weight:700;color:' + color + ';">' + icon + ' $' + proj.toFixed(2) + '</div>' +
         '</div>' +
         '<div style="color:var(--text-muted);font-size:13px;">' + escHtml(statusMsg) + '</div>' +
+        (alertHtml ? '<div>' + alertHtml + '</div>' : '') +
         '<div style="margin-left:auto;text-align:right;font-size:12px;color:var(--text-muted);">' +
           '$' + (d.daily_rate_usd || 0).toFixed(4) + '/day avg<br>' +
           '$' + (d.cost_this_month_usd || 0).toFixed(2) + ' spent so far' +

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -1791,11 +1791,12 @@ def api_usage_forecast():
     Returns {available, daily_rate_usd, cost_this_month_usd,
              projected_month_usd, days_remaining_in_month,
              monthly_budget_usd, budget_exceeded, days_to_budget,
-             pro_dispatch_enabled, budget_alert,
+             budget_cross_date, pro_dispatch_enabled, budget_alert,
              window_days, daily_window, _source}.
     Returns {available: false} when no local-store data is present.
     """
     import calendar
+    import math
     import dashboard as _d
     from datetime import datetime, timedelta, timezone
 
@@ -1838,9 +1839,15 @@ def api_usage_forecast():
 
     budget_exceeded = bool(effective_budget > 0 and projected_month > effective_budget)
     days_to_budget: float | None = None
+    budget_cross_date: str | None = None
     if effective_budget > 0 and daily_rate > 0:
         remaining_budget = effective_budget - cost_this_month
         days_to_budget = max(0.0, remaining_budget / daily_rate)
+        if budget_exceeded:
+            cross_offset_days = min(days_remaining, math.ceil(days_to_budget))
+            budget_cross_date = (
+                today + timedelta(days=cross_offset_days)
+            ).isoformat()
 
     try:
         pro_dispatch_enabled = bool(_d._is_pro_user())
@@ -1856,6 +1863,7 @@ def api_usage_forecast():
         "monthly_budget_usd": effective_budget,
         "budget_exceeded": budget_exceeded,
         "days_to_budget": round(days_to_budget, 1) if days_to_budget is not None else None,
+        "budget_cross_date": budget_cross_date,
         "pro_dispatch_enabled": pro_dispatch_enabled,
         "budget_alert": {
             "available": budget_exceeded,

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -1791,6 +1791,7 @@ def api_usage_forecast():
     Returns {available, daily_rate_usd, cost_this_month_usd,
              projected_month_usd, days_remaining_in_month,
              monthly_budget_usd, budget_exceeded, days_to_budget,
+             pro_dispatch_enabled, budget_alert,
              window_days, daily_window, _source}.
     Returns {available: false} when no local-store data is present.
     """
@@ -1841,6 +1842,11 @@ def api_usage_forecast():
         remaining_budget = effective_budget - cost_this_month
         days_to_budget = max(0.0, remaining_budget / daily_rate)
 
+    try:
+        pro_dispatch_enabled = bool(_d._is_pro_user())
+    except Exception:
+        pro_dispatch_enabled = False
+
     return jsonify({
         "available": True,
         "daily_rate_usd": round(daily_rate, 4),
@@ -1850,6 +1856,13 @@ def api_usage_forecast():
         "monthly_budget_usd": effective_budget,
         "budget_exceeded": budget_exceeded,
         "days_to_budget": round(days_to_budget, 1) if days_to_budget is not None else None,
+        "pro_dispatch_enabled": pro_dispatch_enabled,
+        "budget_alert": {
+            "available": budget_exceeded,
+            "pro_required": True,
+            "pro_dispatch_enabled": pro_dispatch_enabled,
+            "upgrade_url": "/cloud/billing",
+        },
         "window_days": window_days,
         "daily_window": [round(c, 4) for c in reversed(window)],
         "_source": "local_store",

--- a/tests/test_usage_local_store.py
+++ b/tests/test_usage_local_store.py
@@ -460,6 +460,7 @@ def test_usage_forecast_surfaces_pro_gate_when_budget_will_be_exceeded(
     _seed_events(ls.get_store(), n=7, base_cost=1.0, base_tokens=10)
 
     import dashboard as _d
+    today = datetime.now(timezone.utc).date().isoformat()
     monkeypatch.setattr(
         _d,
         "_get_budget_config",
@@ -471,6 +472,7 @@ def test_usage_forecast_surfaces_pro_gate_when_budget_will_be_exceeded(
     assert body["_source"] == "local_store"
     assert body["available"] is True
     assert body["budget_exceeded"] is True
+    assert body["budget_cross_date"] == today
     assert body["pro_dispatch_enabled"] is False
     assert body["budget_alert"] == {
         "available": True,

--- a/tests/test_usage_local_store.py
+++ b/tests/test_usage_local_store.py
@@ -448,6 +448,38 @@ def test_cost_comparison_does_not_double_count_v3_sibling_pairs(fast_path_app):
     )
 
 
+# ── /api/usage/forecast ────────────────────────────────────────────────────
+
+def test_usage_forecast_surfaces_pro_gate_when_budget_will_be_exceeded(
+    fast_path_app, monkeypatch
+):
+    """Forecast response carries the Cloud-Pro dispatch gate used by the
+    Tokens-tab CTA when projected month-end spend crosses the configured
+    monthly budget."""
+    app, ls, _u = fast_path_app
+    _seed_events(ls.get_store(), n=7, base_cost=1.0, base_tokens=10)
+
+    import dashboard as _d
+    monkeypatch.setattr(
+        _d,
+        "_get_budget_config",
+        lambda: {"monthly_limit": 1.0, "monthly_cap_usd": 0.0},
+    )
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    body = app.test_client().get("/api/usage/forecast").get_json()
+    assert body["_source"] == "local_store"
+    assert body["available"] is True
+    assert body["budget_exceeded"] is True
+    assert body["pro_dispatch_enabled"] is False
+    assert body["budget_alert"] == {
+        "available": True,
+        "pro_required": True,
+        "pro_dispatch_enabled": False,
+        "upgrade_url": "/cloud/billing",
+    }
+
+
 # ── /api/model-attribution ─────────────────────────────────────────────────
 
 def test_model_attribution_fast_path(fast_path_app):


### PR DESCRIPTION
Follow-up to #1534 for #1413.

## Summary
- expose the existing Cloud-Pro dispatch gate from /api/usage/forecast
- return budget_cross_date when projected month-end spend crosses the configured monthly budget
- show the forecast CTA/date only when projected spend exceeds budget
- send Pro/trial users to Alerts setup, and non-Pro users to the Cloud-Pro billing path
- add focused coverage for the forecast response contract

## Why
#1534 adds the forecast card and endpoint, but the issue acceptance criteria also call out a Pro paywall for the budget-cross alert path and a visible budget-crossing day. This keeps the forecast card read-only until the projection crosses budget, then makes the alert upsell/setup state and crossing date explicit.

## Test plan
- python3 -m py_compile routes/usage.py
- node --check clawmetry/static/js/app.js
- uv run --with pytest --with flask --with duckdb --with requests python -m pytest tests/test_usage_local_store.py::test_usage_forecast_surfaces_pro_gate_when_budget_will_be_exceeded -q
- uv run --with pytest --with flask --with duckdb --with requests python -m pytest tests/test_usage_local_store.py::test_cost_comparison_fast_path tests/test_usage_local_store.py::test_cost_comparison_does_not_double_count_v3_sibling_pairs tests/test_usage_local_store.py::test_usage_forecast_surfaces_pro_gate_when_budget_will_be_exceeded -q
- uv run --with pytest --with flask --with requests python -m pytest tests/test_api.py -q

Note: make test-api is blocked locally because the default Homebrew Python 3.14 does not have pytest installed; the equivalent API suite passed via uv.