### PR TITLE
ci: wire zero-click-auth.mjs into CI (closes PR-E of #1356)

### DIFF
--- a/.github/workflows/zero-click-auth-e2e.yml
+++ b/.github/workflows/zero-click-auth-e2e.yml
@@ -1,0 +1,62 @@
+name: Zero-click Auth E2E
+
+# Wires tests/e2e/zero-click-auth.mjs into CI — closes PR-E from issue #1356.
+#
+# The mjs spec covers three checks the existing auth-bootstrap-guard.yml
+# (inline node smoke) does NOT:
+#   1. Positive  — fresh browser → localhost dashboard renders without
+#                  the login overlay (overlay hidden, token in
+#                  localStorage, no console errors).
+#   2. Negative  — /api/auth/detected-token refuses callers that spoof
+#                  X-Forwarded-For with a public IP. Catches naive
+#                  implementations that trust XFF over the socket peer.
+#   3. Smoke     — #login-overlay element still exists in the DOM
+#                  (regression guard so test 1 can't silently pass by
+#                  the overlay being deleted).
+#
+# Triggers on any PR touching the auth surfaces (server endpoint,
+# bootstrap script, the test itself, or this workflow). Runs on every
+# matching PR — hard-gates merge if any of the three checks fail.
+
+on:
+  pull_request:
+    paths:
+      - "dashboard.py"
+      - "routes/meta.py"
+      - "clawmetry/static/js/auth-bootstrap.js"
+      - "tests/e2e/zero-click-auth.mjs"
+      - "tests/e2e/package.json"
+      - ".github/workflows/zero-click-auth-e2e.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  zero-click-auth-e2e:
+    name: Zero-click localhost auto-login (positive + XFF refuse)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dashboard runtime deps
+        run: pip install flask waitress cryptography requests
+
+      - name: Install Playwright + Chromium
+        working-directory: tests/e2e
+        run: |
+          npm install
+          npx playwright install --with-deps chromium
+
+      - name: Run zero-click-auth E2E
+        working-directory: tests/e2e
+        run: npm run test:zero-click-auth


### PR DESCRIPTION
Refs #1356 (PR-E)

## What

Adds `.github/workflows/zero-click-auth-e2e.yml` — a focused workflow that runs `tests/e2e/zero-click-auth.mjs` on PRs touching the auth surfaces (`dashboard.py`, `routes/meta.py`, `clawmetry/static/js/auth-bootstrap.js`, the test itself, or this workflow).

## How

The `zero-click-auth.mjs` spec covers three checks the existing inline `auth-bootstrap-guard.yml` smoke does **not**:

1. **Positive** — fresh browser → `localhost` dashboard renders with the login overlay hidden, token auto-stashed in `localStorage`, no console errors.
2. **Negative (key gap)** — `/api/auth/detected-token` refuses callers that spoof `X-Forwarded-For` with a public IP. Catches naive implementations that trust XFF over the real socket peer. This is the contract from PR-B that had no automated verifier on any PR until now.
3. **Smoke** — `#login-overlay` element still exists in the DOM (regression guard so test 1 cannot silently pass via element non-existence).

The spec spawns the dashboard itself (with `OPENCLAW_GATEWAY_TOKEN` in the env), so the workflow just needs Python + Node + Chromium — no separate "start server" step. Runs in ~3-5 min; hard-fails on any of the three checks, so XFF leakage regressions can no longer slip in unnoticed.

## Why this PR, not the existing guard

`auth-bootstrap-guard.yml` only triggers on changes under `clawmetry/static/js/*.js`. Backend changes to `routes/meta.py` (where the XFF check lives) wouldn't run any auth E2E. This new workflow's paths filter explicitly includes `dashboard.py` and `routes/meta.py` so the contract is verified whenever the server-side endpoint changes.

## Closes

- The PR-E checkbox from #1356 (the issue tracks PR-A through PR-E; A/B/C/D have landed, this completes E).

Generated by the ClawMetry GH Issues -> MC -> PR cron.