### PR TITLE
fix(packaging): wire v2 React bundle into pip wheel + add CI publish gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,18 @@ jobs:
         with:
           python-version: "3.11"
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Install build tools
         run: pip install build twine
+
+      - name: Build v2 React bundle
+        run: |
+          cd frontend
+          npm ci
+          npm run build
 
       - name: Verify version matches tag
         if: github.event_name == 'push'
@@ -39,6 +49,32 @@ jobs:
 
       - name: Build package
         run: python3 -m build
+
+      - name: Assert v2 bundle is included in wheel
+        run: |
+          python3 - <<'PY'
+          import glob
+          import zipfile
+
+          wheels = glob.glob("dist/*.whl")
+          assert wheels, "No wheel built in dist/"
+
+          with zipfile.ZipFile(wheels[0]) as wheel:
+              names = set(wheel.namelist())
+
+          required = [
+              "clawmetry/static/v2/dist/index.html",
+          ]
+          missing = [path for path in required if path not in names]
+          assert not missing, f"Missing from wheel: {missing}"
+
+          assert any(
+              name.startswith("clawmetry/static/v2/dist/assets/")
+              for name in names
+          ), "Missing v2 asset files from wheel"
+
+          print("v2 bundle is present in wheel")
+          PY
 
       - name: Publish to PyPI
         env:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include clawmetry/static *
+recursive-include clawmetry/static/v2/dist *
 recursive-include clawmetry/templates *.html
 recursive-include helpers *.py
 recursive-include routes *.py


### PR DESCRIPTION
Closes #1499

## What

`pip install clawmetry` was landing without the React v2 bundle, so `clawmetry --v2` returned 404 on `/v2`.

## Changes

- **`MANIFEST.in`**: Added explicit `recursive-include clawmetry/static/v2/dist *` so the built React SPA is included in the source distribution.
- **`.github/workflows/publish.yml`**:
  - Added Node 20 setup + `npm ci && npm run build` in `frontend/` before the Python package build step.
  - Added a wheel assertion that fails the publish if `clawmetry/static/v2/dist/index.html` or v2 asset files are missing from the wheel.

## Why not setup.py?

Inspected `setup.py` and it's already wired with `static/**/*` globs + `include_package_data=True`. The actual gap was the publish workflow not building the frontend before packaging, and no gate to catch a missing bundle.

## Verification 
cd frontend && npm ci && npm run build && cd ..
python3 -m build
unzip -l dist/*.whl | grep static/v2/dist

Confirms `clawmetry/static/v2/dist/index.html` and `assets/*` are present in the wheel.