### PR TITLE
test(local-query): isolate fixture from any running daemon (closes #1538)

### DIFF
--- a/tests/test_local_query_api.py
+++ b/tests/test_local_query_api.py
@@ -24,6 +24,15 @@ def client(tmp_path, monkeypatch):
     import routes.local_query as lq
     importlib.reload(lq)
 
+    # Issue #1538: isolate fixture from any running clawmetry daemon
+    # on the contributor's machine. Without this, _dispatch tries
+    # _proxy_dispatch first; that reads ~/.clawmetry/local_query.json
+    # and POSTs to the daemon, which then queries ITS production DuckDB
+    # (~/.clawmetry/clawmetry.duckdb) instead of this test's tmp_path
+    # fixture. CI never had a daemon so CI passed; laptops with the
+    # daemon running silently failed 11/16. Force direct-mode always.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
     # Pre-#1448 events tests seed historical timestamps that fall outside
     # the OSS 24h retention cap. Default the fixture to Pro so those
     # assertions still pass; the cap tests below monkeypatch


### PR DESCRIPTION
## Summary
- Test fixture in `tests/test_local_query_api.py` calls `_dispatch`, which tries `_proxy_dispatch` first.
- On any contributor laptop that has the clawmetry daemon running, the proxy succeeds and the test ends up querying the daemon's production DuckDB (`~/.clawmetry/clawmetry.duckdb`) instead of the test's `tmp_path` fixture.
- CI never had a daemon, so CI was green; laptops with a running daemon silently failed 11 of 16 cases.
- Fix: monkeypatch `lq._read_discovery` to return `None` in the `client` fixture so `_dispatch` always takes the direct path.

## Test plan
- [ ] `make test-api` clean on a laptop with the sync daemon running (`launchctl list | grep clawmetry`)
- [ ] `make test-api` clean on a laptop with the daemon stopped
- [ ] Verify CI run for this PR shows the test file passing (no behaviour change in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)