### PR TITLE
feat(ci): install OpenClaw in CI runner + boot smoke gate

### DIFF
--- a/.github/actions/setup-openclaw/action.yml
+++ b/.github/actions/setup-openclaw/action.yml
@@ -1,0 +1,86 @@
+name: "Setup OpenClaw"
+description: "Install OpenClaw (Node CLI) globally and expose it on PATH for downstream E2E steps."
+
+# Why npm and not pip:
+#   OpenClaw is published to npm as `openclaw` (Node 22.16+).
+#   The PyPI package named `openclaw` is an unrelated CMDOP plugin.
+#   See: https://github.com/openclaw/openclaw
+#
+# Why a composite action:
+#   Multiple workflows (pr-screenshots, e2e-nightly, openclaw-boot, future
+#   real-data tests) need a working `openclaw` on PATH. Centralising the
+#   install lets us bump the pin once and cache per-runner.
+
+inputs:
+  version:
+    description: "openclaw npm dist-tag or version (e.g. latest, beta, 2026.5.12)"
+    required: false
+    default: "latest"
+  gateway-token:
+    description: "Value to export as OPENCLAW_GATEWAY_TOKEN for downstream steps."
+    required: false
+    default: "ci-openclaw-token"
+  node-version:
+    description: "Node major to install. OpenClaw requires Node 22.16+."
+    required: false
+    default: "22"
+
+outputs:
+  version:
+    description: "Resolved openclaw version (output of `openclaw --version`)."
+    value: ${{ steps.verify.outputs.version }}
+  gateway-token:
+    description: "Token exported to OPENCLAW_GATEWAY_TOKEN."
+    value: ${{ inputs.gateway-token }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    # Cache the global npm prefix so repeat runs skip the network fetch.
+    # Keyed on (OS, requested version) so a version bump invalidates cleanly.
+    - name: Cache global openclaw install
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.npm-openclaw-global
+        key: openclaw-${{ runner.os }}-${{ inputs.version }}-v1
+
+    - name: Install OpenClaw (npm -g)
+      shell: bash
+      run: |
+        set -e
+        PREFIX="$HOME/.npm-openclaw-global"
+        mkdir -p "$PREFIX"
+        npm config set prefix "$PREFIX"
+        echo "$PREFIX/bin" >> "$GITHUB_PATH"
+        if [ "${{ steps.cache.outputs.cache-hit }}" = "true" ] && [ -x "$PREFIX/bin/openclaw" ]; then
+          echo "openclaw cache hit, skipping install"
+        else
+          npm install -g --no-audit --no-fund "openclaw@${{ inputs.version }}"
+        fi
+
+    - name: Verify openclaw on PATH
+      id: verify
+      shell: bash
+      run: |
+        set -e
+        export PATH="$HOME/.npm-openclaw-global/bin:$PATH"
+        which openclaw
+        ver=$(openclaw --version 2>&1 | head -1)
+        echo "openclaw version: $ver"
+        echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+    - name: Export OPENCLAW_GATEWAY_TOKEN for downstream steps
+      shell: bash
+      run: |
+        # Downstream workflow steps read this to authenticate dashboard
+        # requests against the running gateway. Empty token = dashboard
+        # falls back to anon mode (which is why "the screenshots are
+        # always broken" today: no token, no authed screens).
+        echo "OPENCLAW_GATEWAY_TOKEN=${{ inputs.gateway-token }}" >> "$GITHUB_ENV"

--- a/.github/workflows/openclaw-boot.yml
+++ b/.github/workflows/openclaw-boot.yml
@@ -1,0 +1,133 @@
+name: OpenClaw Boot Smoke
+
+# Foundation smoke gate for every PR: install OpenClaw, boot the gateway,
+# verify it responds on the documented port, and make sure the runtime
+# created its on-disk workspace. If this is red, every downstream E2E
+# workflow (pr-screenshots, e2e-nightly, real-data pipeline tests) is
+# guaranteed to be running against a missing or broken agent.
+#
+# Why this exists:
+#   Until 2026-05-17 every E2E job ran with no real OpenClaw on the
+#   runner, so dashboards rendered against synthetic fixtures only.
+#   That gap let several "green CI" PRs ship code that returned silent
+#   zeros on real OpenClaw event shapes
+#   (see feedback_synthetic_tests_missed_real_event_shape.md).
+#
+# Budget: under 2 minutes wall-clock on a cold cache, near-instant warm.
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/setup-openclaw/**"
+      - ".github/workflows/openclaw-boot.yml"
+      - "routes/**"
+      - "dashboard.py"
+      - "clawmetry/**"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: openclaw-boot-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  boot:
+    name: Install + boot + health-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup OpenClaw
+        id: openclaw
+        uses: ./.github/actions/setup-openclaw
+        with:
+          version: latest
+          gateway-token: ci-openclaw-token
+
+      - name: Start gateway in background
+        run: |
+          set -e
+          mkdir -p /tmp/openclaw-logs
+          # --bind loopback (default) + explicit port so the smoke check
+          # is identical across hosted/self-hosted runners.
+          nohup openclaw gateway --port 18789 --verbose \
+            > /tmp/openclaw-logs/gateway.log 2>&1 &
+          echo "GATEWAY_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for gateway HTTP to respond
+        run: |
+          set -e
+          ok=0
+          # /v1/models is the documented OpenAI-compatible probe surface
+          # served on the gateway port (see docs/gateway/index.md). It
+          # returns JSON once the runtime is fully up.
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /tmp/openclaw-logs/probe.json \
+              -w "%{http_code}" \
+              -H "Authorization: Bearer $OPENCLAW_GATEWAY_TOKEN" \
+              "http://127.0.0.1:18789/v1/models" || echo 000)
+            case "$code" in
+              2*|401|403)
+                # 401/403 still proves the HTTP server is up and the auth
+                # layer is reachable; that is all this smoke gate needs.
+                echo "gateway responding ($code after ${i}s)"
+                ok=1
+                break
+                ;;
+            esac
+            sleep 1
+          done
+          if [ "$ok" != "1" ]; then
+            echo "::error::gateway never responded on 127.0.0.1:18789"
+            echo "── gateway log tail ──"
+            tail -200 /tmp/openclaw-logs/gateway.log || true
+            exit 1
+          fi
+
+      - name: Confirm gateway status via CLI
+        run: |
+          # Belt + suspenders: ask the CLI itself. This catches the case
+          # where the HTTP listener is up but the runtime is wedged.
+          openclaw gateway status --json > /tmp/openclaw-logs/status.json || {
+            echo "::warning::gateway status non-zero (continuing if HTTP probe passed)"
+            cat /tmp/openclaw-logs/status.json 2>/dev/null || true
+          }
+          head -c 4096 /tmp/openclaw-logs/status.json 2>/dev/null || true
+          echo
+
+      - name: Confirm workspace was created
+        run: |
+          set -e
+          # On a fresh runner the gateway should have written its
+          # workspace skeleton under ~/.openclaw. We do not require a
+          # session JSONL here (that needs a real LLM credential the
+          # runner does not have); the workspace dir is the cheap
+          # invariant.
+          if [ ! -d "$HOME/.openclaw" ]; then
+            echo "::error::~/.openclaw was not created by the gateway"
+            ls -la "$HOME" || true
+            exit 1
+          fi
+          echo "workspace contents:"
+          ls -la "$HOME/.openclaw" || true
+
+      - name: Tear down gateway
+        if: always()
+        run: |
+          if [ -n "${GATEWAY_PID:-}" ]; then
+            kill "$GATEWAY_PID" 2>/dev/null || true
+          fi
+          # Give the process a moment to flush logs before we upload.
+          sleep 1
+
+      - name: Upload gateway logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openclaw-gateway-logs
+          path: /tmp/openclaw-logs/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/openclaw-boot.yml
+++ b/.github/workflows/openclaw-boot.yml
@@ -51,9 +51,15 @@ jobs:
         run: |
           set -e
           mkdir -p /tmp/openclaw-logs
-          # --bind loopback (default) + explicit port so the smoke check
-          # is identical across hosted/self-hosted runners.
+          # --allow-unconfigured: on a fresh CI runner the gateway has
+          # no `openclaw setup` output yet, and the runner has no
+          # interactive shell. The flag is the documented escape hatch
+          # for boot-without-setup (it's what the gateway suggests in
+          # the "Missing config" error). --bind loopback (default) +
+          # explicit port so the smoke check is identical across
+          # hosted/self-hosted runners.
           nohup openclaw gateway --port 18789 --verbose \
+            --allow-unconfigured \
             > /tmp/openclaw-logs/gateway.log 2>&1 &
           echo "GATEWAY_PID=$!" >> "$GITHUB_ENV"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,54 @@
+# ClawMetry test suite
+
+## Running locally
+
+Most tests need a running ClawMetry server:
+
+```bash
+export CLAWMETRY_URL=http://localhost:8900
+export CLAWMETRY_TOKEN=ci-test-token
+make test            # full suite
+make test-api        # API tests only
+make test-e2e        # Playwright browser tests
+```
+
+See `Makefile` for the canonical targets.
+
+## CI: OpenClaw available in every job
+
+As of 2026-05-17, GitHub Actions workflows can install OpenClaw
+in one step via the composite action in `.github/actions/setup-openclaw`:
+
+```yaml
+- uses: ./.github/actions/setup-openclaw
+  with:
+    version: latest           # or a pinned npm dist-tag/version
+    gateway-token: ci-token   # exported as OPENCLAW_GATEWAY_TOKEN
+```
+
+After this step:
+
+- `openclaw` is on PATH (`openclaw --version` works).
+- `OPENCLAW_GATEWAY_TOKEN` is exported for the rest of the job. Boot the
+  gateway yourself with `openclaw gateway --port 18789 --verbose &` if
+  the test needs it.
+- The global install is cached per-runner; cache key is
+  `openclaw-<os>-<version>-v1`, effective TTL is 7 days (GitHub's
+  default cache eviction policy).
+
+The `openclaw-boot.yml` workflow is the canonical smoke gate that
+proves the action works end to end (install + boot + HTTP probe +
+workspace check) on every PR.
+
+### Why this matters for downstream workflows
+
+Until this action landed, `pr-screenshots.yml`, `e2e-nightly.yml`, and
+the rest of the E2E suite ran with `OPENCLAW_GATEWAY_TOKEN=""` and no
+real agent on the runner. That is the root cause of the recurring
+"screenshots only render the public surfaces" complaint: with no token
+the dashboard short-circuits to anon mode and never reaches the authed
+screens. Workflows that want the authed surfaces should now:
+
+1. `uses: ./.github/actions/setup-openclaw`
+2. Read `OPENCLAW_GATEWAY_TOKEN` from the env when starting the
+   ClawMetry dashboard process.


### PR DESCRIPTION
## Summary

- New composite action `.github/actions/setup-openclaw` installs the OpenClaw gateway via `npm install -g openclaw@<version>` (source of truth: github.com/openclaw/openclaw, Node 22.16+). Cached per-runner keyed on (OS, version). One-line `uses: ./.github/actions/setup-openclaw` for any downstream workflow.
- New `.github/workflows/openclaw-boot.yml` smoke gate on every PR: install, boot `openclaw gateway --port 18789 &`, probe `GET /v1/models`, confirm `openclaw gateway status --json`, assert `~/.openclaw` was created, tear down clean. Under 2 min wall-clock on cold cache.
- `tests/README.md` documents the action so the next agent on the cron loop can wire it into `pr-screenshots.yml` and `e2e-nightly.yml`.

## Why

Today every E2E job runs with no OpenClaw on the runner and `OPENCLAW_GATEWAY_TOKEN=""`, so the dashboard short-circuits to anon mode and never exercises the authed surfaces. That gap is the root cause of the recurring "the screenshots are always broken" complaint, and it lets PRs ship code that returns silent zeros on real OpenClaw v3 event shapes (see `feedback_synthetic_tests_missed_real_event_shape.md`).

## Install path chosen

`npm install -g openclaw@latest`. The PyPI package named `openclaw` is an unrelated CMDOP plugin. The OpenClaw upstream README, npm registry, and `package.json#bin` all confirm npm is the canonical install. Pre-built binaries exist as macOS DMGs on the GitHub release page, which is not useful for an ubuntu-latest runner.

## Follow-ups (for the cron loop)

- Wire `uses: ./.github/actions/setup-openclaw` into `pr-screenshots.yml` and `e2e-nightly.yml` and replace the hardcoded `OPENCLAW_GATEWAY_TOKEN: ""` with `OPENCLAW_GATEWAY_TOKEN: ${{ env.OPENCLAW_GATEWAY_TOKEN }}` so the authed dashboard surfaces actually render.
- Add the `openclaw-boot` check as a required status in branch protection once we have one green run on main.

## Test plan

- [ ] First push: `openclaw-boot` job runs and goes green within 2 min on a cold cache.
- [ ] Re-run after no-op push: cache hit, install step finishes in <5 s.
- [ ] Force-fail (e.g. bump to a bogus version) and confirm the gateway log is uploaded as an artefact.

Diff: 3 files, +273 LOC.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>