### PR TITLE
fix(sync): bulletproof DuckDB write-through under crash/restart

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -113,6 +113,13 @@ def _migrate_legacy_db_path() -> None:
 FLUSH_INTERVAL_SECS = float(os.environ.get("CLAWMETRY_LOCAL_FLUSH_SECS", "2.0"))
 FLUSH_BATCH = int(os.environ.get("CLAWMETRY_LOCAL_FLUSH_BATCH", "1000"))
 RING_MAX = int(os.environ.get("CLAWMETRY_LOCAL_RING_MAX", "10000"))
+# Bounded-retry budget for transient DuckDB write failures (lock contention,
+# brief disk hiccups). Default 3 attempts × ≤1s backoff = ≤1.4s wall. After
+# the budget the flush re-raises and the batch stays queued in the ring for
+# the next tick (or process restart). INSERT OR IGNORE keyed on event id
+# makes any replay a no-op.
+FLUSH_MAX_ATTEMPTS = int(os.environ.get("CLAWMETRY_LOCAL_FLUSH_MAX_ATTEMPTS", "3"))
+FLUSH_RETRY_BASE_SECS = float(os.environ.get("CLAWMETRY_LOCAL_FLUSH_RETRY_BASE_SECS", "0.05"))
 LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
@@ -2557,23 +2564,57 @@ class LocalStore:
         """Drain the ring into DuckDB in one transaction. Returns rows written.
         Snapshot-then-pop pattern: events stay in the ring until the COMMIT
         succeeds, so a write failure leaves them queued for the next attempt
-        instead of vanishing."""
+        instead of vanishing.
+
+        Bounded-retry on transient DuckDB write errors (lock contention, brief
+        disk hiccups) so a single flaky tick doesn't drop a batch. After
+        ``FLUSH_MAX_ATTEMPTS`` failures we log and re-raise — the ring still
+        holds the batch, so the next flusher tick (or process restart) gets
+        another shot. INSERT OR IGNORE keyed on the per-event id makes the
+        replay idempotent."""
         with self._ring_lock:
             if not self._ring:
                 return 0
             batch = list(self._ring)
         rows = [_event_to_row(e) for e in batch]
-        with self._write_lock:
-            with _txn(self._conn):
-                self._conn.executemany(
-                    """
-                    INSERT OR IGNORE INTO events
-                      (id, agent_type, node_id, agent_id, session_id, workspace_id,
-                       event_type, ts, data, cost_usd, token_count, model, created_at)
-                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
-                    """,
-                    rows,
-                )
+        last_exc: Exception | None = None
+        for attempt in range(FLUSH_MAX_ATTEMPTS):
+            try:
+                with self._write_lock:
+                    with _txn(self._conn):
+                        self._conn.executemany(
+                            """
+                            INSERT OR IGNORE INTO events
+                              (id, agent_type, node_id, agent_id, session_id, workspace_id,
+                               event_type, ts, data, cost_usd, token_count, model, created_at)
+                            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+                            """,
+                            rows,
+                        )
+                last_exc = None
+                break
+            except Exception as exc:  # noqa: BLE001 — surface any DuckDB error
+                last_exc = exc
+                if attempt + 1 < FLUSH_MAX_ATTEMPTS:
+                    # Exponential backoff: 0.05s, 0.10s, 0.20s, ... capped at 1s.
+                    delay = min(FLUSH_RETRY_BASE_SECS * (2 ** attempt), 1.0)
+                    log.warning(
+                        "local store: flush attempt %d/%d failed (%s); "
+                        "retrying in %.2fs (ring keeps batch)",
+                        attempt + 1, FLUSH_MAX_ATTEMPTS, exc, delay,
+                    )
+                    time.sleep(delay)
+        if last_exc is not None:
+            # All attempts exhausted. The ring still holds the batch (we never
+            # popped), so a subsequent flush — including one triggered by the
+            # next process start after a crash — will retry from the same
+            # rows. Idempotent: INSERT OR IGNORE collapses any double-write.
+            log.error(
+                "local store: flush failed after %d attempts; %d events stay "
+                "queued for next tick (err=%s)",
+                FLUSH_MAX_ATTEMPTS, len(batch), last_exc,
+            )
+            raise last_exc
         with self._ring_lock:
             for _ in range(len(batch)):
                 if self._ring:
@@ -2594,6 +2635,19 @@ class LocalStore:
                     pass  # partial install / approvals.py not importable
                 break  # one kick per batch; coalesces N events into 1 wake
         return len(rows)
+
+    def flush(self) -> int:
+        """Public synchronous flush. Drains the ring into DuckDB now and
+        returns the row count written. Callers that need write-then-checkpoint
+        semantics (e.g. sync.py advancing a JSONL offset only after the rows
+        are durable in DuckDB) MUST call this before persisting their cursor;
+        otherwise a crash between ring-enqueue and the background flusher
+        tick silently drops events even though the offset advanced.
+
+        No-op in read-only mode (returns 0)."""
+        if self._read_only:
+            return 0
+        return self._flush_now()
 
     # ── queries ─────────────────────────────────────────────────────────
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1455,34 +1455,80 @@ def _flush_session_batch(
     node_id: str,
     subagent_id: str | None = None,
 ) -> None:
-    # Write-through to local SQLite first (epic #964 / phase 1 / issue #958).
-    # Local is the durable store; cloud is a hot cache. If the cloud POST fails
-    # below, the events are still recorded locally and the dashboard's local
-    # read paths will surface them. Failures here never block cloud sync — the
-    # broad except keeps the legacy behaviour intact for users who somehow
-    # land on a corrupt SQLite or a read-only ~/.clawmetry/.
+    # Write-through to local DuckDB FIRST (epic #964 / phase 1 / issue #958),
+    # then synchronously flush so the rows are durable BEFORE the caller
+    # advances its in-memory JSONL line cursor. Local is the durable store;
+    # cloud is a hot cache. If the cloud POST fails below, the events are
+    # still recorded locally.
+    #
+    # Write-then-ack ordering (audit fix, 2026-05-17):
+    #   The caller (sync_sessions / sync_sessions_recent / …) advances
+    #   ``state["last_event_ids"][fname]`` right after we return, and
+    #   ``save_state(state)`` writes that cursor to disk at the end of the
+    #   tick. ``_local_ingest_session_batch`` only ENQUEUES rows into the
+    #   local-store ring buffer; the background flusher commits them ~2s
+    #   later. If the daemon crashed between enqueue and the next flusher
+    #   tick, the cursor would be durable on disk while the events were lost
+    #   to volatile memory — silent ingest gap until the user manually
+    #   rewound state.json. Calling ``flush()`` here makes the DuckDB COMMIT a
+    #   precondition for the caller's offset advance, so a kill -9 anywhere
+    #   in the path leaves the cursor pointing at lines that are either
+    #   (a) already durable or (b) re-read on restart and idempotently
+    #   collapsed by INSERT OR IGNORE on the canonical event id.
+    #
+    # Cloud-sync independence: local ingest+flush failures are logged but do
+    # not block the cloud POST below. The MOAT mandate is local-first, but
+    # cloud-first behaviour is preserved for users on read-only ~/.clawmetry/
+    # or partial installs without DuckDB. The next flusher tick (or daemon
+    # restart) will retry the local write; INSERT OR IGNORE makes it safe.
     try:
         _local_ingest_session_batch(batch, fname, node_id, subagent_id)
+        from clawmetry import local_store as _ls
+        _ls.get_store().flush()
     except Exception as _e:
-        log.warning("local-store ingest failed (cloud sync continues): %s", _e)
+        log.warning("local-store ingest/flush failed (cloud sync continues): %s", _e)
 
     payload = {"session_file": fname, "node_id": node_id, "events": batch}
     # Include subagent_id so the cloud can correlate blobs → sub-agent sessions.
     # The session key UUID (subagent_id) differs from the .jsonl filename UUID.
     if subagent_id:
         payload["subagent_id"] = subagent_id
-    if enc_key:
-        _post(
-            "/ingest/events",
-            {
-                "node_id": node_id,
-                "encrypted": True,
-                "blob": encrypt_payload(payload, enc_key),
-            },
-            api_key,
+    # Cloud-sync independence (audit fix, 2026-05-17):
+    #   The local DuckDB row above is ALREADY committed at this point, so
+    #   the cloud POST is best-effort relative to the local contract. We
+    #   catch the exception here so:
+    #     1. A cloud outage doesn't propagate out of _flush_session_batch and
+    #        abort the per-file iteration in sync_sessions (which then
+    #        skipped batches 2..N of the SAME file even though local could
+    #        have ingested them just fine).
+    #     2. The caller's cursor (``state["last_event_ids"][fname]``)
+    #        advances based on LOCAL durability, not cloud reachability —
+    #        matching the MOAT mandate that local is the source of truth and
+    #        cloud is a hot cache.
+    #   Known trade-off: with this guard, sustained cloud failure permanently
+    #   drops those events from the cloud (cursor moves past them; we don't
+    #   re-read on next tick). A future PR should add a sidecar cloud-retry
+    #   queue keyed on canonical event id. For today the priority is local
+    #   correctness; cloud catches up when the user re-syncs from local.
+    try:
+        if enc_key:
+            _post(
+                "/ingest/events",
+                {
+                    "node_id": node_id,
+                    "encrypted": True,
+                    "blob": encrypt_payload(payload, enc_key),
+                },
+                api_key,
+            )
+        else:
+            _post("/ingest/events", payload, api_key)
+    except Exception as _cloud_e:
+        log.warning(
+            "cloud /ingest/events POST failed for %s (local DuckDB is "
+            "already durable; cursor will advance based on local success): "
+            "%s", fname, _cloud_e,
         )
-    else:
-        _post("/ingest/events", payload, api_key)
 
 
 def _extract_cost_tokens_model(obj: dict) -> tuple:
@@ -7614,6 +7660,18 @@ def run_daemon() -> None:
         log.warning(f"  Recent log sync error: {e}")
 
     state["last_sync"] = datetime.now(timezone.utc).isoformat()
+    # Force a sync local-store flush before persisting the startup cursor.
+    # Same rationale as the per-tick checkpoint inside the main loop: never
+    # commit an offset to disk while the events it represents are still in
+    # volatile ring memory. INSERT OR IGNORE makes any replay a no-op.
+    try:
+        from clawmetry import local_store as _ls
+        _ls.get_store().flush()
+    except Exception as _flush_e:
+        log.warning(
+            "startup pre-checkpoint local-store flush failed (continuing): %s",
+            _flush_e,
+        )
     save_state(state)
     send_heartbeat(config)
     _record_sync_progress("complete", 0, 0, status="complete")
@@ -7836,6 +7894,22 @@ def run_daemon() -> None:
                 tg = 0
 
             state["last_sync"] = datetime.now(timezone.utc).isoformat()
+            # Audit fix (2026-05-17): force a synchronous local-store flush
+            # BEFORE persisting the cursor state. Belt-and-suspenders to
+            # ``_flush_session_batch``'s own per-batch flush — covers any
+            # ingest path (channels, logs, telegram, …) that mutated state
+            # but routed its DuckDB writes through the ring buffer. If this
+            # fails the cursor still advances (preserves legacy non-fatal
+            # contract), but the next flusher tick + INSERT OR IGNORE keep
+            # the events from being silently dropped.
+            try:
+                from clawmetry import local_store as _ls
+                _ls.get_store().flush()
+            except Exception as _flush_e:
+                log.warning(
+                    "pre-checkpoint local-store flush failed (continuing): %s",
+                    _flush_e,
+                )
             save_state(state)
             if ev or lg or mem or crons or sm or snap or cron_runs or tg or oc_cc:
                 log.info(

--- a/tests/test_sync_daemon_crash_recovery.py
+++ b/tests/test_sync_daemon_crash_recovery.py
@@ -1,0 +1,405 @@
+"""Crash-recovery contract for the sync daemon's DuckDB write-through.
+
+Audit (2026-05-17, fix/sync-duckdb-write-through-robust) found that:
+
+  1. ``sync.py`` historically advanced ``state["last_event_ids"][fname]`` and
+     persisted it via ``save_state(state)`` while the rows it represented
+     were still in the local-store ring buffer (volatile memory). A SIGKILL
+     between ring-enqueue and the background flusher tick (every 2 s) would
+     leave the on-disk cursor pointing past lines that were never durable in
+     DuckDB — silent ingest gap.
+
+  2. Local-store write failures had no bounded-retry — a transient lock
+     contention or disk hiccup would drop the batch on the floor with only a
+     warning, even though the ring still held the rows.
+
+The fix wraps:
+
+  * Per-batch ``_flush_session_batch`` calls ``LocalStore.flush()`` AFTER
+    ``_local_ingest_session_batch`` so the DuckDB COMMIT happens before the
+    caller's offset advance.
+  * The daemon's tick checkpoint calls ``LocalStore.flush()`` BEFORE
+    ``save_state(state)`` as a belt-and-suspenders guard for all the other
+    ingest paths (logs / channels / telegram / …).
+  * ``LocalStore._flush_now`` now retries up to ``FLUSH_MAX_ATTEMPTS`` times
+    with exponential backoff before re-raising; the ring still holds the
+    batch on failure, so the next tick (or process restart) gets another
+    deterministic attempt.
+
+This test file pins those invariants:
+
+  * ``test_crash_after_half_burst_no_loss_no_dupes``
+        Fires N events, SIGKILLs the daemon process mid-burst, restarts, and
+        re-fires the same N events. The DuckDB must end with exactly N rows
+        — no loss (proves the write-then-checkpoint ordering) and no dupes
+        (proves the INSERT OR IGNORE idempotency key on the per-event UUID).
+
+  * ``test_local_ingest_succeeds_without_cloud_sync``
+        Disables the cloud POST (raises on every call) and verifies all N
+        events still land in DuckDB. Pins the MOAT mandate that cloud-sync
+        is a separate task that never blocks the local-first ingest path.
+
+Both tests run inside a tmp dir; no real ``~/.openclaw`` or
+``~/.clawmetry`` is touched.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _make_session_jsonl(sessions_dir: Path, session_uuid: str, n: int) -> Path:
+    """Write ``n`` synthetic OpenClaw transcript events to a JSONL file.
+    Each event has a stable per-line id (the index) so a replay produces the
+    SAME canonical event id and INSERT OR IGNORE deduplicates."""
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    fpath = sessions_dir / f"{session_uuid}.jsonl"
+    with open(fpath, "w") as f:
+        for i in range(n):
+            ev = {
+                "id": f"ev-{i:04d}",  # stable id → idempotency key on replay
+                "type": "tool_call",
+                "timestamp": f"2026-05-17T10:00:{i:02d}Z",
+                "tool": "Bash",
+                "tokens": 10,
+                "cost_usd": 0.001,
+            }
+            f.write(json.dumps(ev) + "\n")
+    return fpath
+
+
+def _spawn_ingest_worker(
+    *,
+    workspace: Path,
+    db_path: Path,
+    n_to_emit: int,
+    fail_cloud: bool,
+    pause_per_event: float,
+    max_ticks: int = 1,
+) -> subprocess.Popen:
+    """Spawn a Python subprocess that imports ``clawmetry.sync`` and pumps the
+    session JSONL into DuckDB one event at a time, pausing between events so
+    the test can SIGKILL it mid-burst.
+
+    The worker writes a one-line progress file ``<workspace>/progress`` after
+    each successfully-ACK'd event so the test can SIGKILL deterministically at
+    the N/2 mark instead of racing on timing.
+
+    Stays as a single subprocess.Popen because we kill -9 it later — we can't
+    SIGKILL an in-process thread.
+
+    ``max_ticks`` lets the cloud-independence test simulate multiple daemon
+    loop iterations: each tick re-enters ``sync_sessions`` from the saved
+    cursor, so when cloud raises and the cursor stays put, the next tick
+    picks up the same batch and pushes it again (idempotent on local).
+    """
+    workspace_str = str(workspace)
+    db_path_str = str(db_path)
+    progress_str = str(workspace / "progress")
+    fail_cloud_str = "1" if fail_cloud else "0"
+    pause_str = repr(pause_per_event)
+
+    script = textwrap.dedent(f"""
+        import json, os, sys, time
+        os.environ['CLAWMETRY_LOCAL_STORE_PATH'] = {db_path_str!r}
+        # Fast flusher so a SIGKILL between ring-enqueue and the fix's
+        # explicit flush() is the ONLY thing that can lose an event —
+        # otherwise the background ticker hides bugs we want to catch.
+        os.environ.setdefault('CLAWMETRY_LOCAL_FLUSH_SECS', '60.0')
+        os.environ.setdefault('CLAWMETRY_LOCAL_FLUSH_BATCH', '99999')
+        os.environ['HOME'] = {workspace_str!r}
+        os.environ['CLAWMETRY_HOME'] = {workspace_str!r}
+        sys.path.insert(0, {str(REPO_ROOT)!r})
+
+        from clawmetry import sync, local_store
+
+        # State + paths live inside the test's workspace so each subprocess
+        # gets a fresh, isolated bootstrap.
+        sessions_dir = os.path.join({workspace_str!r}, '.openclaw', 'agents', 'main', 'sessions')
+        state_file = os.path.join({workspace_str!r}, 'state.json')
+        progress_file = {progress_str!r}
+
+        def load_state():
+            if os.path.exists(state_file):
+                with open(state_file) as f:
+                    return json.load(f)
+            return {{'last_event_ids': {{}}, 'last_log_offsets': {{}}}}
+
+        def save_state(s):
+            tmp = state_file + '.tmp'
+            with open(tmp, 'w') as f:
+                json.dump(s, f)
+            os.replace(tmp, state_file)
+
+        # Monkey-patch sync.save_state / load_state so they point at our tmp.
+        sync.save_state = save_state
+        sync.load_state = load_state
+        sync._sync_allowed = lambda: True
+        # Stub the cloud POST.
+        cloud_fail = {fail_cloud_str!r} == '1'
+        def fake_post(path, payload, api_key, timeout=45):
+            if cloud_fail:
+                raise RuntimeError('cloud-sync disabled for this test')
+            return {{'ok': True}}
+        sync._post = fake_post
+
+        # Tiny BATCH_SIZE so each event hits the local-store ingest+flush
+        # path on its own — easy to SIGKILL between events.
+        sync.BATCH_SIZE = 1
+        sync.MAX_EVENTS_PER_CYCLE = 99999
+
+        config = {{
+            'api_key': 'cm_test',
+            'encryption_key': None,
+            'node_id': 'crash-test-node',
+        }}
+        paths = {{'sessions_dir': sessions_dir}}
+
+        # We want to pause AFTER every per-event flush so the parent test
+        # can SIGKILL deterministically. Wrap _flush_session_batch.
+        orig_flush = sync._flush_session_batch
+        emitted = [0]
+        def slow_flush(batch, fname, api_key, enc_key, node_id, subagent_id=None):
+            # Local ingest+flush happens inside orig_flush; if cloud raises
+            # below, the local rows are still durable. We bump the progress
+            # marker only when the WHOLE call succeeds (local + cloud) so
+            # the parent's mid-burst SIGKILL targets are exact.
+            orig_flush(batch, fname, api_key, enc_key, node_id, subagent_id)
+            emitted[0] += len(batch)
+            with open(progress_file, 'w') as f:
+                f.write(str(emitted[0]))
+            f = None
+            time.sleep({pause_str})
+            if emitted[0] >= {n_to_emit}:
+                local_store.get_store().flush()
+                sys.exit(0)
+        sync._flush_session_batch = slow_flush
+
+        # Multi-tick driver — under cloud-failure the per-file ``except`` in
+        # sync_sessions catches each batch's POST error and moves on to the
+        # next file. With cloud failing every batch and only ONE file in
+        # play, the loop bails after batch 1 of the file with the cursor
+        # unchanged. Looping re-enters sync_sessions from the same cursor
+        # and re-emits the same line; local INSERT OR IGNORE de-dupes.
+        #
+        # NOTE: This is the contract we *want* in a future PR to make smarter
+        # (decouple local cursor from cloud cursor). For now the test
+        # documents the observable behaviour.
+        for _tick in range({max_ticks}):
+            state = load_state()
+            try:
+                sync.sync_sessions(config, state, paths)
+                save_state(state)
+            except SystemExit:
+                raise
+            except Exception as e:
+                print('worker error tick', _tick, ':', e, file=sys.stderr)
+                # Don't kill the worker on per-tick error — that's the cloud
+                # exception we're stress-testing. Save what we have and move
+                # to the next tick.
+                try:
+                    save_state(state)
+                except Exception:
+                    pass
+            local_store.get_store().flush()
+
+        local_store.get_store().flush()
+        save_state(state)
+    """)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.Popen(
+        [sys.executable, "-c", script],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _wait_for_progress(workspace: Path, target: int, timeout: float = 15.0) -> int:
+    """Block until ``<workspace>/progress`` reaches at least ``target``."""
+    progress_file = workspace / "progress"
+    deadline = time.monotonic() + timeout
+    last = 0
+    while time.monotonic() < deadline:
+        if progress_file.exists():
+            try:
+                last = int(progress_file.read_text().strip() or "0")
+            except Exception:
+                pass
+            if last >= target:
+                return last
+        time.sleep(0.02)
+    raise AssertionError(
+        f"progress did not reach {target} within {timeout}s "
+        f"(last seen: {last})"
+    )
+
+
+def _count_durable_events(db_path: Path) -> int:
+    """Open the DuckDB file in read-only mode (a separate process / connection
+    from the worker, which is already dead by the time this is called) and
+    count event rows. read_only=True bypasses the writer lock."""
+    import duckdb
+    conn = duckdb.connect(str(db_path), read_only=True)
+    try:
+        return int(conn.execute("SELECT COUNT(*) FROM events").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _query_durable_event_ids(db_path: Path) -> list[str]:
+    import duckdb
+    conn = duckdb.connect(str(db_path), read_only=True)
+    try:
+        rows = conn.execute("SELECT id FROM events ORDER BY id").fetchall()
+        return [r[0] for r in rows]
+    finally:
+        conn.close()
+
+
+# ── tests ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def crash_workspace(tmp_path: Path):
+    """Fresh per-test workspace with an empty sessions dir + DuckDB target.
+    The DuckDB file is created lazily by the worker on first ingest."""
+    sessions_dir = tmp_path / ".openclaw" / "agents" / "main" / "sessions"
+    db_path = tmp_path / "clawmetry.duckdb"
+    yield {
+        "workspace": tmp_path,
+        "sessions_dir": sessions_dir,
+        "db_path": db_path,
+    }
+
+
+def test_crash_after_half_burst_no_loss_no_dupes(crash_workspace):
+    """SIGKILL the worker after it ACKs N/2 events. Restart, re-fire the same
+    JSONL. DuckDB must end with exactly N rows — no loss, no duplicates.
+
+    Why this proves the audit fix:
+      * No loss → ``state["last_event_ids"]`` never advances past events that
+        are not yet durable in DuckDB (write-then-ack ordering).
+      * No dupes → on replay, INSERT OR IGNORE on the canonical event id
+        collapses repeated writes (idempotency key invariant).
+    """
+    N = 10  # small enough that a 0.1 s/event pause keeps the test under 5 s
+    session_uuid = str(uuid.uuid4())
+    _make_session_jsonl(crash_workspace["sessions_dir"], session_uuid, N)
+
+    # ── Run 1 — kill mid-burst ─────────────────────────────────────────
+    proc = _spawn_ingest_worker(
+        workspace=crash_workspace["workspace"],
+        db_path=crash_workspace["db_path"],
+        n_to_emit=N,
+        fail_cloud=False,
+        pause_per_event=0.1,
+    )
+    try:
+        # Wait until at least N/2 events have been ACK'd by the worker.
+        _wait_for_progress(crash_workspace["workspace"], N // 2, timeout=15.0)
+        # SIGKILL — no chance for atexit / final flush. The audit fix says
+        # the cursor on disk must NEVER point past events that aren't in
+        # DuckDB.
+        os.kill(proc.pid, signal.SIGKILL)
+    finally:
+        proc.wait(timeout=5.0)
+
+    # Sanity: the worker actually durably wrote SOMETHING. (At least N/2
+    # because flush happens before progress marker.)
+    mid_count = _count_durable_events(crash_workspace["db_path"])
+    assert mid_count >= N // 2, (
+        f"expected >= {N // 2} events durable after SIGKILL, got {mid_count}"
+    )
+    assert mid_count <= N, (
+        f"DuckDB has {mid_count} > N={N} events after partial burst — "
+        "something is double-writing"
+    )
+
+    # ── Run 2 — restart, re-fire the same N events ─────────────────────
+    proc2 = _spawn_ingest_worker(
+        workspace=crash_workspace["workspace"],
+        db_path=crash_workspace["db_path"],
+        n_to_emit=N,
+        fail_cloud=False,
+        pause_per_event=0.02,  # faster on the resume — no reason to crawl
+    )
+    try:
+        rc = proc2.wait(timeout=20.0)
+    except subprocess.TimeoutExpired:
+        proc2.kill()
+        raise
+    # Worker exits with 0 once it has emitted N events (sys.exit(0) inside
+    # slow_flush). A non-zero exit means the run errored, not "ran clean".
+    assert rc == 0, (
+        f"resume worker exited with rc={rc}; stderr=\n"
+        f"{proc2.stderr.read().decode(errors='replace')}"
+    )
+
+    # ── Assertions ──────────────────────────────────────────────────────
+    final_count = _count_durable_events(crash_workspace["db_path"])
+    assert final_count == N, (
+        f"expected exactly {N} durable events after crash+resume, "
+        f"got {final_count}. Either the write-then-ack ordering is broken "
+        f"(loss) or the idempotency key is broken (dupes)."
+    )
+    ids = _query_durable_event_ids(crash_workspace["db_path"])
+    expected = sorted([f"ev-{i:04d}" for i in range(N)])
+    assert ids == expected, (
+        f"event ids drifted from the source JSONL — expected {expected}, "
+        f"got {ids}"
+    )
+
+
+def test_local_ingest_succeeds_without_cloud_sync(crash_workspace):
+    """MOAT mandate: cloud-sync independence. If every ``_post`` call raises,
+    the local DuckDB must still receive ALL N events in a single sync pass.
+    Pins that cloud is a separate task that never blocks the local-first
+    ingest path: ``_flush_session_batch`` swallows cloud exceptions so the
+    caller's per-file iteration keeps draining local batches even with cloud
+    100% down.
+    """
+    N = 8
+    session_uuid = str(uuid.uuid4())
+    _make_session_jsonl(crash_workspace["sessions_dir"], session_uuid, N)
+
+    proc = _spawn_ingest_worker(
+        workspace=crash_workspace["workspace"],
+        db_path=crash_workspace["db_path"],
+        n_to_emit=N,
+        fail_cloud=True,
+        pause_per_event=0.0,
+        max_ticks=1,  # one tick is enough — fix makes cloud failures non-fatal
+    )
+    try:
+        proc.wait(timeout=20.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        raise
+
+    final_count = _count_durable_events(crash_workspace["db_path"])
+    # The strong invariant: ALL N events land in DuckDB even with cloud
+    # failing every POST, in a SINGLE tick (no retry needed).
+    assert final_count == N, (
+        f"expected ALL {N} durable events with cloud disabled, "
+        f"got {final_count}. Cloud-sync failures are blocking the local "
+        f"write path — either _flush_session_batch is letting cloud "
+        f"exceptions propagate or local ingest happens AFTER cloud POST."
+    )
+    ids = _query_durable_event_ids(crash_workspace["db_path"])
+    assert len(set(ids)) == N, (
+        f"replay introduced duplicates: {sorted(ids)}"
+    )


### PR DESCRIPTION
## Audit findings (`clawmetry/sync.py` + `clawmetry/local_store.py`)

Today's mandate was the "robust" half of "DuckDB + cloud sync robust & stable". 4 gaps found, ranked by severity:

| # | Severity | Gap | Location |
|---|---|---|---|
| 1 | **P0 — silent data loss** | `_flush_session_batch` enqueues into the local-store ring buffer (~2 s flusher tick) but the caller advances the JSONL cursor immediately. A SIGKILL between ring-enqueue and the next flusher tick leaves the cursor durable on disk while the events are lost to volatile memory. | `clawmetry/sync.py:1465` (in `_flush_session_batch`) |
| 2 | **P0 — cloud failure blocks local ingest** | Cloud `_post` raises out of `_flush_session_batch` → caller's per-file `except` aborts the whole file iteration → batches 2..N of the SAME JSONL never reach DuckDB even though local could have ingested them fine. | `clawmetry/sync.py:1496` |
| 3 | **P1 — no bounded retry** | `LocalStore._flush_now` has no retry on transient DuckDB write errors (lock contention, brief disk hiccups). A single flaky tick logs a warning and the batch falls back to "wait for next 2 s tick" with no escalation. | `clawmetry/local_store.py:2557` |
| 4 | **P1 — cursor commits race the flusher across ALL paths** | `run_daemon`'s main-loop tick and startup-sync block call `save_state(state)` without a synchronous local-store flush. Covers logs / channels / telegram / cron / heartbeat / span paths that all enqueue through the ring. | `clawmetry/sync.py:7860` and `clawmetry/sync.py:7638` |

## Fixes (surgical, minimum-risk)

1. **`LocalStore.flush()` (public)** — delegates to `_flush_now()`. Callers that need write-then-checkpoint semantics MUST call this before persisting their cursor.
2. **Bounded retry inside `_flush_now()`** — `FLUSH_MAX_ATTEMPTS=3` × exponential backoff (capped at 1 s/attempt) before re-raising. The snapshot-then-pop pattern already kept the batch on the ring during a failed tx, so re-raise lets the next tick replay safely. Env-tunable: `CLAWMETRY_LOCAL_FLUSH_MAX_ATTEMPTS`, `CLAWMETRY_LOCAL_FLUSH_RETRY_BASE_SECS`.
3. **`_flush_session_batch` does local-then-cloud, with `flush()` between** — DuckDB COMMIT is now a precondition for the caller's offset advance. INSERT OR IGNORE on the canonical event id makes replay-on-restart idempotent.
4. **Cloud POST wrapped in try/except** — cloud failures are logged-only and no longer abort the per-file iteration or block local durability.
5. **`run_daemon` calls `LocalStore.flush()` before every `save_state(state)`** — belt-and-suspenders guard for the ingest paths that don't route through `_flush_session_batch`.

## Test plan

`tests/test_sync_daemon_crash_recovery.py` adds two integration tests, both spawning a worker subprocess that imports `clawmetry.sync` and pumps a real JSONL file through `sync_sessions` with `BATCH_SIZE=1`:

- [x] `test_crash_after_half_burst_no_loss_no_dupes` — fires N=10 events, `SIGKILL` after the N/2-th ACK, restarts, re-fires the same JSONL. Asserts DuckDB has exactly N rows (no loss → write-then-ack ordering; no dupes → INSERT OR IGNORE idempotency).
- [x] `test_local_ingest_succeeds_without_cloud_sync` — every `_post` raises; asserts ALL N events land in DuckDB in a SINGLE tick.

Both tests **fail on baseline** (`main`) and **pass on this branch** — textbook proof of an audit + fix landing.

```
$ python3 -m pytest tests/test_sync_daemon_crash_recovery.py -v
test_crash_after_half_burst_no_loss_no_dupes PASSED
test_local_ingest_succeeds_without_cloud_sync PASSED
```

Existing test suite stays green:

```
$ python3 -m pytest tests/test_local_store_sync_integration.py tests/test_local_store.py
44 passed, 1 deselected (the pre-existing schema_version==6 assertion that landed unfixed in main)
```

Branch fail-count vs `main`: identical except for 2 fewer failures (the two new tests now pass).

## Known follow-up (out of scope today)

Sustained cloud failure currently drops events from the cloud (cursor moves past them; we don't re-read on next tick). A future PR should add a sidecar cloud-retry queue keyed on canonical event id so cloud catches up without re-reading source JSONL or duplicating local rows. Trade-off documented inline in `_flush_session_batch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)