### PR TITLE
fix(budget): gate auto-pause behind Pro license (Product P0)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -81,7 +81,28 @@ async function loadBudgetConfig() {
     document.getElementById('budget-weekly').value = cfg.weekly_limit || 0;
     document.getElementById('budget-monthly').value = cfg.monthly_limit || 0;
     document.getElementById('budget-warn-pct').value = cfg.warning_threshold_pct || 80;
-    document.getElementById('budget-autopause').checked = cfg.auto_pause_enabled || false;
+    var apEl = document.getElementById('budget-autopause');
+    if (apEl) {
+      apEl.checked = cfg.auto_pause_enabled || false;
+      // Issue #1169: auto-pause is a Cloud Pro feature. For OSS / Free
+      // users, disable the toggle and render an inline upsell. The
+      // warning-only banner path stays free as a teaser.
+      var proOk = !!cfg.auto_pause_pro_enabled;
+      apEl.disabled = !proOk;
+      var upsellId = 'budget-autopause-upsell';
+      var existing = document.getElementById(upsellId);
+      if (existing) existing.parentNode.removeChild(existing);
+      if (!proOk) {
+        apEl.checked = false;
+        var note = document.createElement('div');
+        note.id = upsellId;
+        note.style.cssText = 'margin-top:6px;padding:8px 10px;background:var(--bg-tertiary);border:1px solid var(--border-primary);border-radius:6px;font-size:12px;color:var(--text-secondary);';
+        note.innerHTML = '<span style="font-weight:600;color:var(--text-primary);">Auto-pause is a Cloud Pro feature.</span> '
+          + 'Budget warnings still fire here. To stop the gateway automatically at 100%, '
+          + '<a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener" style="color:var(--bg-accent);text-decoration:underline;font-weight:600;">start a 7-day free trial</a>.';
+        if (apEl.parentNode) apEl.parentNode.appendChild(note);
+      }
+    }
   } catch(e) {}
 }
 
@@ -117,7 +138,14 @@ async function saveBudgetConfig() {
     warning_threshold_pct: parseInt(document.getElementById('budget-warn-pct').value) || 80,
     auto_pause_enabled: document.getElementById('budget-autopause').checked,
   };
-  await fetch('/api/budget/config', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(data)});
+  try {
+    var resp = await fetch('/api/budget/config', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(data)}).then(function(r){return r.json();});
+    if (resp && resp.auto_pause_pro_required) {
+      // Server stripped the toggle because the user isn't Pro yet.
+      // Re-render the config so the disabled state + upsell appear.
+      loadBudgetConfig();
+    }
+  } catch(e) {}
   loadBudgetStatus();
 }
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -927,6 +927,32 @@ def _is_pro_user():
     return False
 
 
+# ── Auto-pause Pro gate (issue #1169) ───────────────────────────────────
+# Auto-pause-on-100% (a hard kill switch on the gateway) is a Cloud-Pro
+# feature, not OSS table-stakes. OSS / Cloud-Free nodes still see the
+# in-app budget banner + alert-history row when limits trip, but the
+# gateway-stop fan-out is gated. This keeps the warning-only path free
+# (a useful teaser) without giving away the FinOps-grade enforcement
+# story enterprises pay for. ``_pause_gateway()`` itself is still safe
+# to call from manual buttons (``/api/budget/pause``); this gate only
+# guards the *automatic* trip wires inside ``_budget_check`` and the
+# alert-daemon sweep.
+
+
+def _auto_pause_allowed():
+    """Fail-closed gate for *automatic* gateway pause.
+
+    Returns True only for Cloud-Pro users. Manual pause buttons bypass
+    this gate (the user already made the call). Failures default to
+    False so a flaky cache never leaks a paid enforcement path onto a
+    free node.
+    """
+    try:
+        return bool(_is_pro_user())
+    except Exception:
+        return False
+
+
 # ── Per-agent budgets (issue #951) ─────────────────────────────────────
 #
 # Per-agent overrides live in the DuckDB ``agent_budgets`` table (see
@@ -1212,11 +1238,19 @@ def _budget_check():
                 agents_to_check.add(entry.get("agent", "main") or "main")
     except Exception:
         pass
+    # Issue #1169: auto-pause is a Cloud-Pro feature. Free / OSS users
+    # still get the breach alert (banner + history row) via the regular
+    # tier-check, but the gateway-stop fan-out is gated. We force
+    # ``auto_pause_enabled=False`` into the per-agent check so it never
+    # returns the "pause" signal, then re-fire a single banner alert
+    # with an upsell message so the user knows enforcement is paused.
+    _auto_pause_cfg = bool(config.get("auto_pause_enabled", False))
+    _auto_pause_ok = _auto_pause_allowed() if _auto_pause_cfg else True
     for agent_id in agents_to_check:
         try:
             if _budget_check_for_agent(
                 agent_id,
-                auto_pause_enabled=config.get("auto_pause_enabled", False),
+                auto_pause_enabled=_auto_pause_cfg and _auto_pause_ok,
                 warning_pct=warning_pct,
                 pause_pct=pause_pct,
             ):
@@ -1230,6 +1264,21 @@ def _budget_check():
         except Exception:
             # Never let one agent's check kill the whole sweep.
             continue
+    if _auto_pause_cfg and not _auto_pause_ok:
+        # Surface the gate so the user understands why enforcement did
+        # not fire even though their toggle is on. Banner-only; no
+        # Telegram fan-out (that is also Pro).
+        _fire_alert(
+            rule_id="budget_autopause_pro_required",
+            alert_type="budget.upsell",
+            message=(
+                "Auto-pause is a Cloud Pro feature. Budget breaches "
+                "still alert here, but the gateway will keep running "
+                "until you upgrade. Start a 7-day free trial at "
+                "https://app.clawmetry.com/upgrade"
+            ),
+            channels=["banner"],
+        )
 
     # Check each period (global)
     for period in ["daily", "weekly", "monthly"]:
@@ -1265,8 +1314,22 @@ def _budget_check():
                 channels=["banner", "telegram"],
             )
 
-        # Auto-pause
+        # Auto-pause (issue #1169: Pro-gated; Free users still get the
+        # banner alert, but the gateway is left running.)
         if pct >= pause_pct and config.get("auto_pause_enabled", False):
+            if not _auto_pause_ok:
+                _fire_alert(
+                    rule_id=f"budget_{period}_exceeded_upsell",
+                    alert_type="budget.upsell",
+                    message=(
+                        f"BUDGET EXCEEDED: {period} spending ${spent:.2f} "
+                        f"is over ${limit:.2f}. Auto-pause is a Cloud Pro "
+                        f"feature. Start a 7-day free trial at "
+                        f"https://app.clawmetry.com/upgrade"
+                    ),
+                    channels=["banner"],
+                )
+                continue
             _budget_paused = True
             _budget_paused_at = time.time()
             _budget_paused_reason = (
@@ -5702,7 +5765,26 @@ async function loadBudgetConfig() {
     document.getElementById('budget-weekly').value = cfg.weekly_limit || 0;
     document.getElementById('budget-monthly').value = cfg.monthly_limit || 0;
     document.getElementById('budget-warn-pct').value = cfg.warning_threshold_pct || 80;
-    document.getElementById('budget-autopause').checked = cfg.auto_pause_enabled || false;
+    var apEl = document.getElementById('budget-autopause');
+    if (apEl) {
+      apEl.checked = cfg.auto_pause_enabled || false;
+      // Issue #1169: auto-pause is a Cloud Pro feature; disable + upsell for Free users.
+      var proOk = !!cfg.auto_pause_pro_enabled;
+      apEl.disabled = !proOk;
+      var upsellId = 'budget-autopause-upsell';
+      var existing = document.getElementById(upsellId);
+      if (existing) existing.parentNode.removeChild(existing);
+      if (!proOk) {
+        apEl.checked = false;
+        var note = document.createElement('div');
+        note.id = upsellId;
+        note.style.cssText = 'margin-top:6px;padding:8px 10px;background:var(--bg-tertiary);border:1px solid var(--border-primary);border-radius:6px;font-size:12px;color:var(--text-secondary);';
+        note.innerHTML = '<span style="font-weight:600;color:var(--text-primary);">Auto-pause is a Cloud Pro feature.</span> '
+          + 'Budget warnings still fire here. To stop the gateway automatically at 100%, '
+          + '<a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener" style="color:var(--bg-accent);text-decoration:underline;font-weight:600;">start a 7-day free trial</a>.';
+        if (apEl.parentNode) apEl.parentNode.appendChild(note);
+      }
+    }
   } catch(e) {}
 }
 
@@ -5738,7 +5820,13 @@ async function saveBudgetConfig() {
     warning_threshold_pct: parseInt(document.getElementById('budget-warn-pct').value) || 80,
     auto_pause_enabled: document.getElementById('budget-autopause').checked,
   };
-  await fetch('/api/budget/config', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(data)});
+  try {
+    var resp = await fetch('/api/budget/config', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(data)}).then(function(r){return r.json();});
+    if (resp && resp.auto_pause_pro_required) {
+      // Issue #1169: server stripped auto-pause; re-render upsell.
+      loadBudgetConfig();
+    }
+  } catch(e) {}
   loadBudgetStatus();
 }
 
@@ -9023,6 +9111,10 @@ def _budget_monitor_loop():
             auto_thr = float(cfg.get("auto_pause_threshold_usd", 0) or 0)
             auto_action = str(cfg.get("auto_pause_action", "pause") or "pause").lower()
             if auto_thr > 0 and status.get("daily_spent", 0) >= auto_thr:
+                # Issue #1169: Pro-gate the auto-pause action. Free users
+                # get the same banner, the gateway just keeps running.
+                if auto_action == "pause" and not _auto_pause_allowed():
+                    auto_action = "alert"
                 if auto_action == "pause" and not _budget_paused:
                     _budget_paused = True
                     _budget_paused_at = now

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -203,9 +203,31 @@ def api_budget_config():
         updates = {k: v for k, v in data.items() if k in allowed}
         if not updates:
             return jsonify({"error": "No valid fields provided"}), 400
+        # Issue #1169: refuse to enable auto-pause for non-Pro users.
+        # We accept the rest of the payload so the user can still tune
+        # warning thresholds + limits, but strip the gated toggle and
+        # tell the UI to render the upsell. Free users keep the warning
+        # banner; only the hard kill switch is gated.
+        if updates.get("auto_pause_enabled") and not _d._auto_pause_allowed():
+            updates["auto_pause_enabled"] = False
+            _d._set_budget_config(updates)
+            return jsonify({
+                "ok": True,
+                "auto_pause_pro_required": True,
+                "message": (
+                    "Auto-pause is a Cloud Pro feature. Start a 7-day "
+                    "free trial at https://app.clawmetry.com/upgrade"
+                ),
+            })
         _d._set_budget_config(updates)
         return jsonify({"ok": True})
-    return jsonify(_d._get_budget_config())
+    cfg = _d._get_budget_config()
+    try:
+        cfg = dict(cfg)
+        cfg["auto_pause_pro_enabled"] = bool(_d._auto_pause_allowed())
+    except Exception:
+        pass
+    return jsonify(cfg)
 
 
 @bp_budget.route("/api/budget/status")

--- a/tests/test_per_agent_budget.py
+++ b/tests/test_per_agent_budget.py
@@ -245,8 +245,11 @@ def test_warning_at_80_percent_no_pause(dashboard_module):
     assert _d._budget_paused is False
 
 
-def test_critical_at_100_percent_pauses_when_enabled(dashboard_module):
+def test_critical_at_100_percent_pauses_when_enabled(dashboard_module,
+                                                       monkeypatch):
     _d = dashboard_module
+    # Issue #1169: auto-pause is Cloud-Pro only. Pro user → pauses.
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
     _d._set_budget_config({"auto_pause_enabled": True})
     _d._set_agent_budget("a-crit", daily_limit_usd=10.0)
     _add_cost(_d, "a-crit", 10.0)  # 100%
@@ -365,8 +368,9 @@ def test_oss_user_does_not_trigger_telegram_on_per_agent_warning(telegram_spy,
 
 def test_oss_user_does_not_trigger_telegram_on_per_agent_critical(telegram_spy,
                                                                    monkeypatch):
-    """Same gate at the 100% / critical tier — banner + auto-pause still
-    work (those are free), but Telegram fan-out is Pro-only."""
+    """Same gate at the 100% / critical tier. Banner alert still fires,
+    but Telegram dispatch is Pro-only AND (issue #1169) so is the
+    actual gateway-stop auto-pause."""
     _d, calls = telegram_spy
     monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
     _d._set_budget_config({"auto_pause_enabled": True})
@@ -375,9 +379,10 @@ def test_oss_user_does_not_trigger_telegram_on_per_agent_critical(telegram_spy,
     _d._budget_check()
 
     assert _count_alerts_for(_d, "oss-crit") >= 1
-    # Auto-pause is a free cost-control feature, must still trigger.
-    assert _d._budget_paused is True
-    # Telegram dispatch is gated.
+    # Issue #1169: auto-pause is Cloud-Pro only — banner fires but the
+    # gateway is left running until the user upgrades.
+    assert _d._budget_paused is False
+    # Telegram dispatch is also gated.
     assert calls == []
 
 
@@ -414,3 +419,98 @@ def test_api_budget_root_surfaces_pro_dispatch_flag(dashboard_module,
     monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
     r2 = client.get("/api/budget")
     assert r2.get_json()["pro_dispatch_enabled"] is True
+
+
+# ── 7. Pro-tier gate on auto-pause itself (issue #1169) ──────────────────
+#
+# Per-agent breach ALERTS are OSS table-stakes. Auto-pausing the gateway
+# in response is a Cloud-Pro hard kill switch. These tests assert that a
+# Free user with auto_pause_enabled=True still gets the breach banner
+# (so the bar paints red) but ``_pause_gateway`` is NOT called and the
+# config setter strips the toggle back to False.
+
+
+def test_free_user_global_breach_does_not_pause(dashboard_module, monkeypatch):
+    """Issue #1169: global daily limit at 100% + auto_pause_enabled=True,
+    Free user. Banner fires, gateway stays up."""
+    _d = dashboard_module
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+    called = []
+    monkeypatch.setattr(_d, "_pause_gateway", lambda: called.append(1))
+    _d._set_budget_config({
+        "daily_limit": 10.0,
+        "auto_pause_enabled": True,
+    })
+    _add_cost(_d, "main", 12.0)  # 120% of global daily
+    _d._budget_check()
+    assert called == [], "Free user must not trigger _pause_gateway"
+    assert _d._budget_paused is False
+    # Upsell banner row written for visibility.
+    assert _count_alerts_for(_d, "upsell") >= 1
+
+
+def test_pro_user_global_breach_pauses(dashboard_module, monkeypatch):
+    """Issue #1169: same scenario, Pro user → ``_pause_gateway`` IS called."""
+    _d = dashboard_module
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+    called = []
+    monkeypatch.setattr(_d, "_pause_gateway", lambda: called.append(1))
+    _d._set_budget_config({
+        "daily_limit": 10.0,
+        "auto_pause_enabled": True,
+    })
+    _add_cost(_d, "main", 12.0)
+    _d._budget_check()
+    assert called == [1], "Pro user should trigger _pause_gateway"
+    assert _d._budget_paused is True
+
+
+def test_config_setter_strips_autopause_for_free_user(dashboard_module,
+                                                       monkeypatch):
+    """Issue #1169: POST /api/budget/config with auto_pause_enabled=True
+    from a Free user is accepted (200) but the toggle is silently
+    stripped and the response signals the upsell."""
+    _d = dashboard_module
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+    client = _make_client(_d)
+    resp = client.post(
+        "/api/budget/config",
+        json={"auto_pause_enabled": True, "daily_limit": 5.0},
+    )
+    assert resp.status_code == 200, resp.data
+    body = resp.get_json()
+    assert body.get("ok") is True
+    assert body.get("auto_pause_pro_required") is True
+    # Confirm the persisted config didn't actually flip the toggle.
+    cfg = _d._get_budget_config()
+    assert cfg.get("auto_pause_enabled") is False
+
+
+def test_config_setter_accepts_autopause_for_pro_user(dashboard_module,
+                                                       monkeypatch):
+    """Issue #1169: same POST from a Pro user persists the toggle."""
+    _d = dashboard_module
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+    client = _make_client(_d)
+    resp = client.post(
+        "/api/budget/config",
+        json={"auto_pause_enabled": True, "daily_limit": 5.0},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json().get("ok") is True
+    cfg = _d._get_budget_config()
+    assert cfg.get("auto_pause_enabled") is True
+
+
+def test_config_getter_surfaces_autopause_pro_flag(dashboard_module,
+                                                    monkeypatch):
+    """Issue #1169: GET /api/budget/config returns ``auto_pause_pro_enabled``
+    so the UI can disable the toggle + render the upsell."""
+    _d = dashboard_module
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+    client = _make_client(_d)
+    body = client.get("/api/budget/config").get_json()
+    assert body.get("auto_pause_pro_enabled") is False
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+    body2 = client.get("/api/budget/config").get_json()
+    assert body2.get("auto_pause_pro_enabled") is True


### PR DESCRIPTION
Closes #1169.

## Summary

- **Server gates** added at all three auto-pause trip wires in `dashboard.py` (per-agent in `_budget_check`, global daily/weekly/monthly in `_budget_check`, absolute-USD in the alert-daemon heartbeat sweep). All three reuse the existing `_is_pro_user()` helper via a new `_auto_pause_allowed()` fail-closed wrapper.
- **Config setter** in `routes/alerts.py` strips `auto_pause_enabled=True` from non-Pro payloads and returns `auto_pause_pro_required:true`; GET response now includes `auto_pause_pro_enabled` for the UI.
- **UI** in `clawmetry/static/js/app.js` (and the inline copy in `dashboard.py`) disables the `budget-autopause` checkbox for Free users and renders an inline upsell pointing at the 7-day free trial.
- **Warning-only path stays free** as a teaser. Free users still get the in-app banner + alert-history row when limits trip, just without the gateway-stop fan-out.

## Why this matters

Per the product review on PR #1152: auto-pause-on-100% is the single biggest enterprise sell on the budget surface (FinOps "hard stop"). Giving it away on OSS removed the strongest reason to upgrade.

## Pro-check helper reused

`_is_pro_user()` (dashboard.py:901) — already gates Telegram dispatch (issue #1168). New `_auto_pause_allowed()` wrapper added next to it so future enforcement features can share the same fail-closed semantics.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_per_agent_budget.py -q` — 24/24 pass (18 existing + 6 new for #1169)
- [x] Existing test `test_oss_user_does_not_trigger_telegram_on_per_agent_critical` updated: assertion flipped from `_budget_paused is True` to `False` to reflect new product split (auto-pause moves from Free to Pro).
- [x] No em-dashes in user-facing copy (banner text + upsell modal copy reviewed).
- [ ] Manual: open Budget Limits tab as a Free user; toggle is disabled with upsell row underneath.
- [ ] Manual: open same tab on a Cloud-Pro node; toggle is interactive, saves persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)