### PR TITLE
fix(ci): visual-diff skips publish/comment on fork PRs (403)

### DIFF
--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -194,8 +194,14 @@ jobs:
           [ -n "${HEAD_PID:-}" ] && kill "$HEAD_PID" 2>/dev/null || true
 
       # ── 10. Publish PNGs to orphan pr-screenshots branch ────────────────
+      # GITHUB_TOKEN is read-only for `pull_request` events from forks (GH
+      # security guardrail — declared `permissions:` block does not lift
+      # this for forks). Gate publish + comment steps on same-repo PRs to
+      # avoid 403s. Fork PRs still get screenshots as workflow artifact
+      # (step 12 below). See #1552 (JaiCodes77 fork) for the failure that
+      # surfaced this. Follow-up: workflow_run split for fork PRs.
       - name: Publish screenshots to pr-screenshots branch
-        if: always()
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -250,7 +256,11 @@ jobs:
           cat /tmp/visual-diff-body.md
 
       - name: Post / update PR comment
-        if: always()
+        # Skip for fork PRs — GITHUB_TOKEN cannot post comments on
+        # pull_request events from forks. Reviewers download the
+        # screenshots artefact from the workflow run instead. See #1552
+        # (JaiCodes77 fork). Same-repo PRs unaffected.
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- PR #1552 (@JaiCodes77 fork) hit 403 on \`Publish screenshots to pr-screenshots branch\` + \`Resource not accessible by integration\` on \`Post / update PR comment\`.
- Root cause: GITHUB_TOKEN is read-only for \`pull_request\` events from forks. Workflow-level \`permissions:\` block can NOT lift this — GitHub security guardrail.
- Fix: gate the two failing steps on \`!github.event.pull_request.head.repo.fork\`. Fork PRs still get screenshots as a workflow artefact (step 12); reviewers download from the run page.

## Test plan
- [ ] Re-run visual-diff on #1552 after merge — the publish + comment steps should be skipped, artefact upload should succeed
- [ ] Verify a same-repo PR (eg. #1553) still gets the inline comment
- [ ] File follow-up: \`workflow_run\`-triggered companion so fork PRs ALSO get inline comments (proper solution per GitHub docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)