### PR TITLE
fix(nemo): cap free NeMo ingestion at 1000 events/day + Pro upsell (Product P0)

### DIFF
--- a/clawmetry/adapters/nemo.py
+++ b/clawmetry/adapters/nemo.py
@@ -82,11 +82,108 @@ so the dashboard renders NeMo sessions identically to OpenClaw sessions.
 from __future__ import annotations
 
 import logging
+import threading
 import time
 import uuid
+from datetime import date
 from typing import Any, Optional
 
 logger = logging.getLogger("clawmetry.adapters.nemo")
+
+
+# ── Free-tier daily ingest cap (issue #1170) ───────────────────────────
+#
+# NeMo Agent Toolkit users are the highest-value paid-conversion segment
+# we observe (enterprise GPU buyers). Shipping the adapter under OSS gave
+# the whole NeMo experience away for free, undercutting the sibling
+# ``integrations/nat/`` Cloud-bound variant. The product-P0 fix caps free
+# ingest at ``NEMO_FREE_DAILY_CAP`` events per UTC day; Pro users ingest
+# unlimited. Counter resets at the UTC date boundary.
+#
+# State lives at module scope (not per-adapter) so that two independent
+# NeMoAdapter instances pointing at the same local store share one cap —
+# the cap is a tenant-level economic gate, not a per-instance throttle.
+NEMO_FREE_DAILY_CAP = 1000
+
+# Internal: lock + counter + date-key for the per-day budget.
+_CAP_LOCK = threading.Lock()
+_CAP_STATE: dict[str, Any] = {
+    "date": "",          # UTC YYYY-MM-DD currently being counted
+    "count": 0,          # events ingested today (Pro + Free both count for telemetry)
+    "dropped": 0,        # events dropped today because cap was hit
+    "warned": False,     # only log the cap-hit WARNING once per day
+    "last_drop_ts": "",  # ISO timestamp of most recent drop (for banner staleness)
+}
+
+
+def _today_key() -> str:
+    """UTC date key used to slice the cap counter."""
+    return date.today().isoformat()
+
+
+def _rollover_locked() -> None:
+    """Reset counters when a new UTC day begins. Caller must hold ``_CAP_LOCK``."""
+    today = _today_key()
+    if _CAP_STATE["date"] != today:
+        _CAP_STATE["date"] = today
+        _CAP_STATE["count"] = 0
+        _CAP_STATE["dropped"] = 0
+        _CAP_STATE["warned"] = False
+        _CAP_STATE["last_drop_ts"] = ""
+
+
+def _is_pro() -> bool:
+    """Best-effort Pro check that fails closed (treats unknown as Free).
+
+    Reuses ``dashboard._is_pro_user()`` — the same helper PR #1553 added
+    for auto-pause gating (#1169) and that #1168 uses for Telegram
+    dispatch. Imported lazily so the adapter never hard-requires
+    ``dashboard`` at module load (the adapter ships in the same wheel but
+    standalone usage shouldn't crash if a downstream user vendored only
+    the package directory).
+    """
+    try:
+        import dashboard as _d  # noqa: WPS433
+        return bool(_d._is_pro_user())
+    except Exception:
+        return False
+
+
+def get_nemo_cap_state() -> dict:
+    """Return a snapshot of the daily cap state for the dashboard banner.
+
+    Shape (stable contract used by ``/api/nemo-cap-status`` and the
+    Brain / Tokens-tab upsell banner)::
+
+        {
+            "cap": 1000,                # int — free-tier daily limit
+            "used": 137,                # int — events ingested today
+            "dropped": 0,               # int — events dropped today (free-tier only)
+            "is_pro": False,            # bool — caller is on Cloud-Pro
+            "cap_hit": False,           # bool — free-tier cap reached today
+            "date": "2026-05-17",       # UTC date key for the current bucket
+        }
+    """
+    with _CAP_LOCK:
+        _rollover_locked()
+        return {
+            "cap": NEMO_FREE_DAILY_CAP,
+            "used": int(_CAP_STATE["count"]),
+            "dropped": int(_CAP_STATE["dropped"]),
+            "is_pro": _is_pro(),
+            "cap_hit": (not _is_pro()) and int(_CAP_STATE["count"]) >= NEMO_FREE_DAILY_CAP,
+            "date": _CAP_STATE["date"] or _today_key(),
+        }
+
+
+def _reset_cap_state_for_tests() -> None:
+    """Test-only hook — wipe cap counters between cases."""
+    with _CAP_LOCK:
+        _CAP_STATE["date"] = ""
+        _CAP_STATE["count"] = 0
+        _CAP_STATE["dropped"] = 0
+        _CAP_STATE["warned"] = False
+        _CAP_STATE["last_drop_ts"] = ""
 
 
 # NeMo event-type → ClawMetry dot.separated event_type.
@@ -297,14 +394,40 @@ class NeMoAdapter:
         required fields, …). Never raises — internal errors are logged
         at ``WARNING`` and swallowed, because losing one telemetry event
         should never crash the host agent.
+
+        Issue #1170: free-tier callers are capped at ``NEMO_FREE_DAILY_CAP``
+        events per UTC day. Once the cap is hit we drop subsequent events
+        and surface a banner via ``/api/nemo-cap-status``. Pro users
+        bypass the cap entirely.
         """
         try:
             row = self.map_event(event)
         except Exception as exc:
-            logger.warning("nemo adapter: map_event raised %r — dropping", exc)
+            logger.warning("nemo adapter: map_event raised %r - dropping", exc)
             return None
         if row is None:
             return None
+        # Free-tier daily cap (#1170). Performed AFTER map_event so we
+        # don't even map events that will be dropped, but BEFORE ingest
+        # so we don't pollute DuckDB beyond the cap.
+        with _CAP_LOCK:
+            _rollover_locked()
+            if not _is_pro() and _CAP_STATE["count"] >= NEMO_FREE_DAILY_CAP:
+                _CAP_STATE["dropped"] = int(_CAP_STATE["dropped"]) + 1
+                _CAP_STATE["last_drop_ts"] = _now_iso()
+                if not _CAP_STATE["warned"]:
+                    _CAP_STATE["warned"] = True
+                    logger.warning(
+                        "nemo adapter: free-tier daily cap reached "
+                        "(%d/%d events today). Further NeMo events are "
+                        "dropped until UTC midnight. Upgrade to Cloud-Pro "
+                        "for unlimited ingest: "
+                        "https://app.clawmetry.com/upgrade?source=nemo_cap",
+                        NEMO_FREE_DAILY_CAP,
+                        NEMO_FREE_DAILY_CAP,
+                    )
+                return None
+            _CAP_STATE["count"] = int(_CAP_STATE["count"]) + 1
         try:
             self._store.ingest(row)
         except Exception as exc:
@@ -507,4 +630,9 @@ class NeMoAdapter:
         return row
 
 
-__all__ = ["NeMoAdapter", "MAPPED_EVENT_TYPES"]
+__all__ = [
+    "NeMoAdapter",
+    "MAPPED_EVENT_TYPES",
+    "NEMO_FREE_DAILY_CAP",
+    "get_nemo_cap_state",
+]

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4039,6 +4039,9 @@ async function loadBrainPage(silent) {
     // last 24h. Render a one-line upgrade CTA above the brain stream so
     // they know full history exists on Cloud-Pro.
     _renderBrainHistoryCap(!!(data && data.capped_at_24h));
+    // NeMo daily-cap banner (issue #1170) — only visible when a free-tier
+    // user has tripped the 1000-events/day NeMo ingest ceiling.
+    _refreshNemoCapBanner('brain-stream');
     // Issue #1195 — One-time "Live event details restored" toast for users
     // who lived through the 0.12.182 empty-detail regression. Fires only if
     // (a) at least one event has a non-empty detail, (b) the user hasn't
@@ -7440,9 +7443,57 @@ async function loadUsage() {
     loadCacheAnalytics();
     // Load cost forecast (issue #1413)
     loadCostForecast();
+    // NeMo daily-cap banner (issue #1170) — only visible when a free-tier
+    // user has tripped the 1000-events/day ceiling.
+    _refreshNemoCapBanner('usage-chart');
   } catch(e) {
     document.getElementById('usage-chart').innerHTML = '<span style="color:#555">No usage data available</span>';
   }
+}
+
+// ── NeMo free-tier daily cap banner (issue #1170) ─────────────────────
+// Polls /api/nemo-cap-status and renders a one-line upsell row above the
+// chosen anchor element (Brain stream or Tokens chart) when a Free user
+// has hit the daily NeMo ingest cap. Pro users + un-tripped Free users
+// see nothing. Re-uses the same upgrade CTA pattern as the approvals
+// upsell row (#1328) for visual consistency.
+function _renderNemoCapBanner(anchorId, snapshot) {
+  var anchor = document.getElementById(anchorId);
+  if (!anchor || !anchor.parentElement) return;
+  var hostId = 'nemo-cap-banner-' + anchorId;
+  var host = document.getElementById(hostId);
+  var shouldShow = !!(snapshot && snapshot.cap_hit && !snapshot.is_pro);
+  if (!shouldShow) {
+    if (host) { host.style.display = 'none'; host.innerHTML = ''; }
+    return;
+  }
+  if (!host) {
+    host = document.createElement('div');
+    host.id = hostId;
+    host.style.cssText = 'padding:10px 12px;margin-bottom:10px;font-size:12px;line-height:1.5;color:var(--text-secondary);border:1px dashed rgba(124,92,255,0.5);border-radius:6px;background:rgba(124,92,255,0.06);';
+    anchor.parentElement.insertBefore(host, anchor);
+  }
+  host.style.display = '';
+  var cap = Number(snapshot.cap) || 1000;
+  var used = Math.min(Number(snapshot.used) || 0, cap);
+  host.innerHTML =
+    '<strong>NeMo daily cap reached (' + used + '/' + cap + ')</strong> '
+    + 'Further NeMo events are dropped until UTC midnight. '
+    + '<a href="https://app.clawmetry.com/upgrade?source=nemo_cap" target="_blank" rel="noopener" '
+    + 'style="color:var(--accent,#7c5cff);font-weight:600;text-decoration:none;">'
+    + 'Upgrade to Pro</a> for unlimited NeMo ingest.';
+}
+
+function _refreshNemoCapBanner(anchorId) {
+  try {
+    if (window.CLOUD_MODE) return;
+    fetch('/api/nemo-cap-status').then(function(r) {
+      if (!r.ok) return null;
+      return r.json();
+    }).then(function(snap) {
+      if (snap) _renderNemoCapBanner(anchorId, snap);
+    }).catch(function() { /* swallow — banner is non-critical */ });
+  } catch (_e) { /* never block render */ }
 }
 
 // Issue #1448 surface 2 — render the OSS / Cloud-Free retention upsell

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -2924,3 +2924,31 @@ def api_token_attribution():
         'messages': messages,
         'totals': totals,
         'session_id': wanted_sid if wanted_sid else None,    })
+
+
+# ── NeMo free-tier cap status (issue #1170) ────────────────────────────
+#
+# Powers the upsell banner that the Brain + Tokens tabs render once a
+# free-tier user trips the 1000-events/day NeMo ingest cap. Returns the
+# same shape ``clawmetry.adapters.nemo.get_nemo_cap_state`` produces so
+# the JS can pass through without any reshape.
+@bp_usage.route("/api/nemo-cap-status")
+def api_nemo_cap_status():
+    """Return the current daily NeMo ingest cap snapshot.
+
+    Cheap, side-effect-free read. Never raises out — on any failure we
+    fall back to a "no cap hit, no Pro" payload so the banner stays
+    hidden rather than spuriously showing up.
+    """
+    try:
+        from clawmetry.adapters.nemo import get_nemo_cap_state, NEMO_FREE_DAILY_CAP
+        return jsonify(get_nemo_cap_state())
+    except Exception:
+        return jsonify({
+            "cap": 1000,
+            "used": 0,
+            "dropped": 0,
+            "is_pro": False,
+            "cap_hit": False,
+            "date": "",
+        })

--- a/tests/test_nemo_adapter_pro_gate.py
+++ b/tests/test_nemo_adapter_pro_gate.py
@@ -1,0 +1,162 @@
+"""Tests for the NeMo free-tier daily ingest cap (issue #1170).
+
+PR #1154 shipped the NeMo adapter that mirrors NVIDIA NeMo Agent Toolkit
+telemetry into the local DuckDB. NeMo users are our highest-value paid-
+conversion segment, so the OSS adapter caps free ingest at
+``NEMO_FREE_DAILY_CAP`` events per UTC day. Pro users bypass the cap.
+
+These tests use a fake in-memory store (no DuckDB) so they run fast and
+deterministically — the adapter's contract with the store is just
+``store.ingest(row)``.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _RecordingStore:
+    """Minimal stand-in for clawmetry.local_store.LocalStore."""
+
+    def __init__(self) -> None:
+        self.rows: list[dict] = []
+
+    def ingest(self, row: dict) -> None:
+        self.rows.append(row)
+
+
+def _make_event(i: int) -> dict:
+    return {
+        "event_type": "LLM_END",
+        "trace_id": f"trace-{i}",
+        "span_id": f"span-{i}",
+        "attributes": {
+            "model": "claude-3.5-sonnet",
+            "completion": "x",
+            "input_tokens": 1,
+            "output_tokens": 1,
+        },
+    }
+
+
+@pytest.fixture
+def fresh_adapter(monkeypatch):
+    """Adapter + store with cap state reset; Pro=False by default."""
+    from clawmetry.adapters import nemo as nemo_mod
+
+    nemo_mod._reset_cap_state_for_tests()
+    monkeypatch.setattr(nemo_mod, "_is_pro", lambda: False)
+
+    store = _RecordingStore()
+    adapter = nemo_mod.NeMoAdapter(store, node_id="t", agent_id="t")
+    return adapter, store, nemo_mod
+
+
+# ---------------------------------------------------------------------------
+# Cap-state contract
+# ---------------------------------------------------------------------------
+
+
+def test_cap_constant_is_1000():
+    from clawmetry.adapters.nemo import NEMO_FREE_DAILY_CAP
+    assert NEMO_FREE_DAILY_CAP == 1000
+
+
+def test_cap_state_shape(fresh_adapter):
+    _adapter, _store, nemo_mod = fresh_adapter
+    snap = nemo_mod.get_nemo_cap_state()
+    assert set(snap.keys()) >= {"cap", "used", "dropped", "is_pro", "cap_hit", "date"}
+    assert snap["cap"] == 1000
+    assert snap["used"] == 0
+    assert snap["dropped"] == 0
+    assert snap["is_pro"] is False
+    assert snap["cap_hit"] is False
+
+
+# ---------------------------------------------------------------------------
+# Free-tier cap behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_free_user_capped_at_1000(fresh_adapter, caplog):
+    """Free user fires 5000 events -> first 1000 ingested, 4000 dropped."""
+    adapter, store, nemo_mod = fresh_adapter
+    caplog.set_level("WARNING", logger="clawmetry.adapters.nemo")
+
+    rows_returned = 0
+    for i in range(5000):
+        r = adapter.on_event(_make_event(i))
+        if r is not None:
+            rows_returned += 1
+
+    assert rows_returned == 1000, "exactly 1000 events should be accepted"
+    assert len(store.rows) == 1000, "store should hold exactly 1000 ingested rows"
+
+    snap = nemo_mod.get_nemo_cap_state()
+    assert snap["used"] == 1000
+    assert snap["dropped"] == 4000
+    assert snap["cap_hit"] is True
+    assert snap["is_pro"] is False
+
+    # Warning logged ONCE per day, not 4000 times.
+    cap_warnings = [r for r in caplog.records if "daily cap reached" in r.message]
+    assert len(cap_warnings) == 1, f"expected one cap warning, got {len(cap_warnings)}"
+
+
+def test_pro_user_unlimited(fresh_adapter, monkeypatch):
+    """Pro user fires 5000 events -> all 5000 ingested."""
+    adapter, store, nemo_mod = fresh_adapter
+    monkeypatch.setattr(nemo_mod, "_is_pro", lambda: True)
+
+    for i in range(5000):
+        adapter.on_event(_make_event(i))
+
+    assert len(store.rows) == 5000
+
+    snap = nemo_mod.get_nemo_cap_state()
+    assert snap["used"] == 5000
+    assert snap["dropped"] == 0
+    assert snap["is_pro"] is True
+    # cap_hit is Pro-aware: never true for a Pro caller, even at 5000>>1000.
+    assert snap["cap_hit"] is False
+
+
+def test_counter_resets_at_day_boundary(fresh_adapter):
+    """Cap counter resets when the UTC date changes."""
+    adapter, store, nemo_mod = fresh_adapter
+
+    # Manually shove yesterday's state into place and trip the cap.
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    nemo_mod._CAP_STATE["date"] = yesterday
+    nemo_mod._CAP_STATE["count"] = 1000
+    nemo_mod._CAP_STATE["dropped"] = 500
+    nemo_mod._CAP_STATE["warned"] = True
+
+    # First call on the new day rolls the bucket over and ingests.
+    r = adapter.on_event(_make_event(0))
+    assert r is not None, "first event on a new day should be accepted"
+    assert len(store.rows) == 1
+
+    snap = nemo_mod.get_nemo_cap_state()
+    assert snap["date"] == date.today().isoformat()
+    assert snap["used"] == 1
+    assert snap["dropped"] == 0
+    assert snap["cap_hit"] is False
+
+
+def test_dropped_events_do_not_reach_store(fresh_adapter):
+    """The cap check sits BEFORE store.ingest — dropped rows never land."""
+    adapter, store, _nemo_mod = fresh_adapter
+
+    for i in range(1500):
+        adapter.on_event(_make_event(i))
+
+    # 1500 free attempts -> 1000 ingested, 500 silently dropped.
+    assert len(store.rows) == 1000


### PR DESCRIPTION
Closes #1170.

## Summary

- **Cap**: `clawmetry/adapters/nemo.py` enforces a 1000-events/day free-tier ceiling in `NeMoAdapter.on_event` (counter resets at UTC midnight, module-level state shared across adapter instances). Pro users bypass the cap entirely.
- **Pro check**: reuses the existing `_is_pro_user()` helper in `dashboard.py:901` (same helper #1168/#1169/PR #1553 use). Imported lazily so the adapter never hard-requires `dashboard` at module load.
- **API**: new `GET /api/nemo-cap-status` on `bp_usage` returning `{cap, used, dropped, is_pro, cap_hit, date}` for the banner.
- **Banner**: `_renderNemoCapBanner()` in `clawmetry/static/js/app.js` renders a one-line upsell above the Brain stream (`loadBrainPage`) and Tokens chart (`loadUsage`) only when `cap_hit && !is_pro`. Pro users + un-tripped Free users see nothing.
- **Logging**: single WARNING per UTC day with upgrade pointer (not 4000 warnings if the user fires 5000 events).
- **Tests**: `tests/test_nemo_adapter_pro_gate.py` (6 cases) covers Pro unlimited, Free cap-at-1000, day rollover, dropped rows never reach store, cap state shape contract.

## Why this matters

Per the post-merge product review of PR #1154: NVIDIA NeMo Agent Toolkit users are enterprise GPU buyers — our highest-value paid-conversion segment. Shipping the OSS adapter that mirrored NeMo telemetry into the local DuckDB in identical shape to OpenClaw v3 events gave the whole NeMo experience away for free, undercutting the Cloud-bound sibling `integrations/nat/` PyPI variant.

Picked option 1 (soft cap + upsell) over option 2 (hard gate) per the issue recommendation: option 2 hostile to evaluators (`pip install`, see nothing, abandon), option 1 gives a working demo + clear upgrade path.

## Pro-check helper reused

`_is_pro_user()` at `dashboard.py:901` — same fail-closed helper PR #1553 added for auto-pause Pro-gating. No new helper.

## Diff size

209 LOC (under the 300 LOC budget). Adapter: 132 / app.js: 51 / usage.py: 28.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_nemo_adapter.py tests/test_nemo_adapter_pro_gate.py -q` — 34/34 pass (28 existing + 6 new)
- [x] `python3 -m pytest tests/test_usage_local_store.py tests/test_usage_per_session.py -q` — 38/38 pass
- [x] `python3 -m pytest tests/test_adapters.py tests/test_adapter_hermes.py -q` — green
- [x] `node -c clawmetry/static/js/app.js` — JS syntax clean
- [x] No em-dashes or `--` in user-facing copy (banner HTML, warning log)
- [ ] Manual: fire >1000 synthetic NeMo events as Free user — banner appears on Brain + Tokens tabs
- [ ] Manual: same on a Cloud-Pro node — no banner, all events ingest

🤖 Generated with [Claude Code](https://claude.com/claude-code)