### PR TITLE
fix(gateway-tap): add opt-in banner for users impacted by default-OFF flip (Product P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Gateway-tap opt-in nudge for users impacted by PR #1228 default-OFF flip (issue #1233, 2026-05-17)
+- **Why.** PR #1228 flipped the live WS gateway tap (`clawmetry/gateway_tap.py`) from default-ON to default-OFF for the OpenClaw `operator.read` scope-grant transition. Users who previously relied on the tap for inbound channel-message bodies (Telegram, Signal, Discord, etc.) silently lost capture; the fix landed but no upgrade prompt told them how to re-enable.
+- **Detection (DuckDB, cached 5m).** New `_compute_gateway_tap_comms()` in `routes/overview.py`: tap env unset + 1+ `channel_messages` rows in prior 7d + 0 rows in last 24h. Three predicates so we never nag fresh installs or users who already opted back in.
+- **Banner.** `/api/overview` piggybacks `_comms.show_gateway_tap_banner` + `show_pro_cta`. Dashboard renders a dismissible amber strip explaining how to re-enable (`CLAWMETRY_ENABLE_WS_TAP=1`) and offering Pro defaults to non-Pro users. Sticky dismiss via `localStorage`.
+- **Tests.** `tests/test_gateway_tap_opt_in_banner.py` covers banner-fires / no-prior-activity / recent-activity-suppresses / tap-already-enabled cases against an in-memory DuckDB.
+
 ### Alerts comms: PR #1410 ship moment for the no-OTLP cohort (issue #1419, 2026-05-16)
 - **Changelog callout.** Alert rules now fire on real OpenClaw spend, not just OTLP-fed installs. The ~99% of users without the `[otel]` extra had `daily_spent=0` forever, so "alert when spend > $X" rules never triggered until PR #1410 wired the DuckDB events fallback into `_get_budget_status`.
 - **Alerts tab banner.** When a user has 1+ rules, 0 historical fires, and the oldest rule is more than 24h old, `/api/alerts/rules` returns `_comms.show_alerts_comms_banner: true`. The Alerts tab renders a one-line notice that the previous rules should start triggering normally. Dismissible.

--- a/dashboard.py
+++ b/dashboard.py
@@ -4158,6 +4158,15 @@ function clawmetryLogout(){
   <button onclick="dismissUpgradeBanner()" style="background:transparent;color:#93c5fd;border:1px solid #3b82f680;border-radius:6px;padding:4px 10px;font-size:11px;cursor:pointer;">Dismiss</button>
 </div>
 
+<!-- Issue #1233: gateway WS tap is now opt-in. Hidden until /api/overview returns
+     _comms.show_gateway_tap_banner=true. Dismiss is sticky via localStorage. -->
+<div id="gw-tap-banner" style="display:none;padding:10px 16px;background:linear-gradient(90deg,#3a2d05 0%,#1a1a2e 100%);border-bottom:2px solid #f59e0b;color:#fbbf24;font-size:13px;font-weight:500;align-items:center;gap:10px;">
+  <span style="font-size:16px;">&#9888;&#65039;</span>
+  <span id="gw-tap-banner-msg" style="flex:1;">Live channel watch (Telegram, Signal, Discord, etc.) is now opt-in for safety. Set <code>CLAWMETRY_ENABLE_WS_TAP=1</code> and restart the sync daemon to re-enable inbound message capture.</span>
+  <a id="gw-tap-banner-pro" href="/cloud/billing" style="display:none;background:#f59e0b;color:#1a1a2e;text-decoration:none;border-radius:6px;padding:4px 12px;font-size:12px;cursor:pointer;font-weight:600;">Pro enables this by default</a>
+  <button onclick="dismissGwTapBanner()" style="background:transparent;color:#fbbf24;border:1px solid #f59e0b80;border-radius:6px;padding:4px 10px;font-size:11px;cursor:pointer;">Dismiss</button>
+</div>
+
 <!-- Budget Settings Modal -->
 <div id="budget-modal" style="display:none;position:fixed;inset:0;z-index:1200;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;">
   <div style="background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:16px;width:90%;max-width:560px;padding:24px;box-shadow:0 25px 50px rgba(0,0,0,0.25);">
@@ -6052,6 +6061,13 @@ async function ackAllAlerts() {
   } catch(e) {}
 }
 
+// Issue #1233: sticky dismiss for the gateway-tap opt-in banner.
+function dismissGwTapBanner() {
+  try { localStorage.setItem('gw_tap_banner_dismissed', '1'); } catch(e) {}
+  var el = document.getElementById('gw-tap-banner');
+  if (el) el.style.display = 'none';
+}
+
 // Check alerts every 30s
 setInterval(checkActiveAlerts, 30000);
 setTimeout(checkActiveAlerts, 3000);
@@ -6809,6 +6825,18 @@ async function loadAll() {
       if (i.network) setFlowTextAll('infra-network-text', 'LAN ' + i.network, 18);
       if (i.userName) setFlowTextAll('flow-human-name', i.userName, 10);
     }
+
+    // Issue #1233: surface the opt-in nudge for users impacted by PR #1228
+    // default-OFF flip of the gateway WS tap. Sticky dismiss via localStorage.
+    try {
+      var comms = (overview && overview._comms) || {};
+      var gwBanner = document.getElementById('gw-tap-banner');
+      if (gwBanner && comms.show_gateway_tap_banner && localStorage.getItem('gw_tap_banner_dismissed') !== '1') {
+        gwBanner.style.display = 'flex';
+        var proCta = document.getElementById('gw-tap-banner-pro');
+        if (proCta) proCta.style.display = comms.show_pro_cta ? 'inline-block' : 'none';
+      }
+    } catch(e) { /* never let banner code break overview */ }
 
     // If overview cannot determine model yet, use brain endpoint fallback immediately.
     if (!overview.model || overview.model === 'unknown') {

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -702,6 +702,84 @@ def api_channels():
     return jsonify({"channels": configured})
 
 
+# ── Gateway-tap opt-in comms (issue #1233) ─────────────────────────────────
+#
+# PR #1228 flipped the live WS gateway tap (clawmetry/gateway_tap.py) from
+# default-ON to default-OFF for the OpenClaw scope-grant transition. Users
+# who previously relied on the tap for inbound channel-message bodies
+# (Telegram, Signal, WhatsApp, Discord, ...) now silently see no new rows.
+#
+# We detect the gap from DuckDB: 1+ channel_messages in the prior 7d window
+# AND zero in the last 24h AND the tap env var is not enabled. If all three
+# hold, /api/overview piggybacks a one-line ``_comms.show_gateway_tap_banner``
+# flag so the dashboard frontend can render a dismissible "Channel watch is
+# now opt-in — enable in Settings, or upgrade to Pro for defaults" banner.
+#
+# Cached for 5 min so the dashboard's hot 10s refresh doesn't re-query the
+# store for slow-moving state. Always degrades to ``show=False`` on error
+# (no banner is the safe default — never block the dashboard render).
+_GATEWAY_TAP_COMMS_CACHE = {"ts": 0.0, "value": None}
+_GATEWAY_TAP_COMMS_TTL = 300.0  # 5 min
+
+
+def _compute_gateway_tap_comms() -> dict:
+    """Return ``{"show_gateway_tap_banner": bool, "show_pro_cta": bool}``.
+
+    Heuristic for ``show_gateway_tap_banner``:
+      * The ``CLAWMETRY_ENABLE_WS_TAP`` env var is NOT set (i.e. user is on
+        the post-#1228 default-OFF path).
+      * The DuckDB ``channel_messages`` table has >=1 row in the
+        ``[now-7d, now-24h]`` window (proves the user previously got tap
+        data — they're impacted, not a fresh install).
+      * The DuckDB ``channel_messages`` table has 0 rows in the last 24h
+        (proves the gap is currently active — not a stale historical row).
+
+    ``show_pro_cta`` adds a "Pro defaults this on" hint when the user is not
+    already on Pro. Both flags default to ``False`` on any failure.
+    """
+    now = time.time()
+    cached = _GATEWAY_TAP_COMMS_CACHE.get("value")
+    if cached is not None and (now - _GATEWAY_TAP_COMMS_CACHE["ts"]) < _GATEWAY_TAP_COMMS_TTL:
+        return cached
+
+    out = {"show_gateway_tap_banner": False, "show_pro_cta": False}
+    try:
+        # Tap already opted-in? Nothing to nag about.
+        if os.environ.get("CLAWMETRY_ENABLE_WS_TAP", "").strip() in ("1", "true", "yes"):
+            _GATEWAY_TAP_COMMS_CACHE.update(ts=now, value=out)
+            return out
+
+        # Prior-7d activity (any inbound or outbound channel row).
+        seven_d_iso = datetime.fromtimestamp(now - 7 * 86400, tz=timezone.utc).isoformat()
+        prior = _ls_call("query_channel_messages", since=seven_d_iso, limit=1)
+        if not prior:
+            _GATEWAY_TAP_COMMS_CACHE.update(ts=now, value=out)
+            return out
+
+        # Last-24h activity. If we see ANY row, the tap isn't the gap.
+        one_d_iso = datetime.fromtimestamp(now - 86400, tz=timezone.utc).isoformat()
+        recent = _ls_call("query_channel_messages", since=one_d_iso, limit=1)
+        if recent:
+            _GATEWAY_TAP_COMMS_CACHE.update(ts=now, value=out)
+            return out
+
+        out["show_gateway_tap_banner"] = True
+
+        # Pro CTA — same pattern as routes/alerts.py.
+        try:
+            import dashboard as _d
+            is_pro = bool(_d._is_pro_user())
+        except Exception:
+            is_pro = False
+        out["show_pro_cta"] = not is_pro
+    except Exception:
+        # Never let comms compute break the overview render.
+        out = {"show_gateway_tap_banner": False, "show_pro_cta": False}
+
+    _GATEWAY_TAP_COMMS_CACHE.update(ts=now, value=out)
+    return out
+
+
 def _try_local_store_overview():
     """Epic #964: opt-in local-store fast path for /api/overview.
 
@@ -912,6 +990,8 @@ def _try_local_store_overview():
         "client_health": _detect_anthropic_oauth(),
         # Issue #688: north-star metric. Always present, even on empty data.
         "autonomy": _autonomy_for_overview(),
+        # Issue #1233: opt-in nudge for users impacted by PR #1228 default-OFF flip.
+        "_comms": _compute_gateway_tap_comms(),
         "_source": "local_store",
     }
 
@@ -1066,6 +1146,8 @@ def api_overview():
             "client_health": _detect_anthropic_oauth(),
             # Issue #688: north-star autonomy metric (always present).
             "autonomy": _autonomy_for_overview(),
+            # Issue #1233: opt-in nudge for users impacted by PR #1228 default-OFF flip.
+            "_comms": _compute_gateway_tap_comms(),
         }
     )
 

--- a/tests/test_gateway_tap_opt_in_banner.py
+++ b/tests/test_gateway_tap_opt_in_banner.py
@@ -1,0 +1,137 @@
+"""Tests for issue #1233 — gateway-tap opt-in banner on /api/overview.
+
+PR #1228 flipped the live WS gateway tap to default-OFF. Users who
+previously relied on it (Telegram, Signal, Discord, ...) silently lost
+inbound message capture. This test suite covers the comms surface we
+piggyback on /api/overview to nudge those users back to opt-in.
+
+The helper under test is ``routes.overview._compute_gateway_tap_comms``,
+which inspects the local DuckDB ``channel_messages`` table to decide
+whether to show the banner.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def comms_app(tmp_path, monkeypatch):
+    """Flask app with the overview blueprint + a fresh local DuckDB store.
+
+    The fast path is enabled so /api/overview reads from DuckDB; the tap
+    env var is cleared so the default-OFF cohort is exercised.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    monkeypatch.delenv("CLAWMETRY_ENABLE_WS_TAP", raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    # Short-circuit the daemon HTTP proxy so the test never accidentally
+    # talks to a running developer daemon and reads the real DuckDB.
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **k: None)
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    monkeypatch.setattr(lq, "_cached_discovery", lambda: None)
+    import routes.overview as ov
+    importlib.reload(ov)
+    # Defeat the 5min cache between cases.
+    ov._GATEWAY_TAP_COMMS_CACHE.update(ts=0.0, value=None)
+
+    a = Flask(__name__)
+    a.register_blueprint(ov.bp_overview)
+    yield a, ls, ov
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _ingest_channel_msg(store, *, mid: str, days_ago: float) -> None:
+    """Write a single channel_messages row dated ``days_ago`` days back."""
+    ts = datetime.now(tz=timezone.utc) - timedelta(days=days_ago)
+    store.ingest_channel_message({
+        "id": mid,
+        "agent_id": "main",
+        "provider": "telegram",
+        "channel_id": "chat-1",
+        "sender_id": "user-1",
+        "sender_name": "Tester",
+        "body": "hello",
+        "ts": ts.isoformat(),
+        "direction": "in",
+    })
+
+
+def test_banner_fires_when_prior_activity_but_no_recent(comms_app):
+    """1+ rows in prior 7d, 0 rows in last 24h, tap env unset → banner ON."""
+    _, ls, ov = comms_app
+    store = ls.get_store()
+    # Three messages from 3 days ago — proves the user was previously
+    # capturing inbound channel traffic. Nothing in the last 24h → gap is
+    # active right now.
+    _ingest_channel_msg(store, mid="m-3d-a", days_ago=3.0)
+    _ingest_channel_msg(store, mid="m-3d-b", days_ago=3.0)
+    _ingest_channel_msg(store, mid="m-5d-a", days_ago=5.0)
+
+    out = ov._compute_gateway_tap_comms()
+    assert out["show_gateway_tap_banner"] is True
+    # show_pro_cta is True for non-Pro users (the default in tests).
+    assert out["show_pro_cta"] is True
+
+
+def test_banner_suppressed_when_recent_activity_present(comms_app):
+    """Row in last 24h → tap isn't the gap → banner OFF."""
+    _, ls, ov = comms_app
+    store = ls.get_store()
+    _ingest_channel_msg(store, mid="m-3d", days_ago=3.0)
+    _ingest_channel_msg(store, mid="m-now", days_ago=0.1)  # within 24h
+
+    out = ov._compute_gateway_tap_comms()
+    assert out["show_gateway_tap_banner"] is False
+
+
+def test_banner_suppressed_for_fresh_install(comms_app):
+    """Empty channel_messages → fresh install, no prior activity → banner OFF."""
+    _, _ls, ov = comms_app
+    out = ov._compute_gateway_tap_comms()
+    assert out["show_gateway_tap_banner"] is False
+
+
+def test_banner_suppressed_when_tap_env_enabled(comms_app, monkeypatch):
+    """User already opted back in via CLAWMETRY_ENABLE_WS_TAP=1 → banner OFF."""
+    _, ls, ov = comms_app
+    monkeypatch.setenv("CLAWMETRY_ENABLE_WS_TAP", "1")
+    # Reset cache because the env state changed.
+    ov._GATEWAY_TAP_COMMS_CACHE.update(ts=0.0, value=None)
+    store = ls.get_store()
+    _ingest_channel_msg(store, mid="m-3d", days_ago=3.0)
+
+    out = ov._compute_gateway_tap_comms()
+    assert out["show_gateway_tap_banner"] is False
+
+
+def test_overview_response_carries_comms_envelope(comms_app):
+    """/api/overview surfaces ``_comms`` so the dashboard JS can render."""
+    a, ls, _ov = comms_app
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": "sess-A", "agent_type": "openclaw", "title": "any",
+        "started_at": "2026-05-11T10:00:00+00:00",
+        "last_active_at": "2026-05-11T11:00:00+00:00",
+        "status": "active", "total_tokens": 100,
+        "metadata": {"model": "claude-opus-4-7"},
+    })
+    _ingest_channel_msg(store, mid="m-3d", days_ago=3.0)
+
+    body = a.test_client().get("/api/overview").get_json() or {}
+    assert body.get("_source") == "local_store"
+    assert (body.get("_comms") or {}).get("show_gateway_tap_banner") is True


### PR DESCRIPTION
Closes #1233.

## Why

PR #1228 flipped the live WS gateway tap (`clawmetry/gateway_tap.py`) from default-ON to default-OFF for the OpenClaw `operator.read` scope-grant transition. Users who previously relied on the tap for inbound channel-message bodies (Telegram, Signal, Discord, etc.) silently lost capture; the fix landed but no upgrade prompt told them how to re-enable.

Issue #1233's title frames the original gap as "won't reach users without [RELEASE] prefix" (which was resolved via PR #1382). The post-merge product review reframed it as the broader Product P0 it actually is: the fix shipped but the affected cohort never saw a path back to working channel capture. This PR closes that loop.

## What

- **`routes/overview.py`** — new `_compute_gateway_tap_comms()` helper inspects DuckDB `channel_messages` for the "had data in prior 7d, none in last 24h, env var not set" cohort. Cached 5 min so the dashboard's hot 10s overview refresh doesn't re-query.
- **`/api/overview` response** — piggybacks `_comms.show_gateway_tap_banner` + `show_pro_cta` flags. Wired on both the local-store fast path and the legacy gateway path.
- **`dashboard.py` banner** — dismissible amber strip:
  > Live channel watch (Telegram, Signal, Discord, etc.) is now opt-in for safety. Set `CLAWMETRY_ENABLE_WS_TAP=1` and restart the sync daemon to re-enable inbound message capture.
  Non-Pro users also see a "Pro enables this by default" CTA. Sticky dismiss via `localStorage`.
- **`CHANGELOG.md`** — entry under `[Unreleased]`.
- **`tests/test_gateway_tap_opt_in_banner.py`** — 5 cases (fires / fresh-install / recent-activity suppresses / tap already enabled / end-to-end overview shape). Uses the daemon-proxy isolation pattern from `tests/test_overview_autonomy_score.py`.

## Test plan

- [x] `python3 -c "import dashboard"` clean.
- [x] `python3 -m pytest tests/test_gateway_tap_opt_in_banner.py -q` — 5 passed.
- [x] `python3 -m pytest tests/test_gateway_tap.py -q` — 12 passed (no regression on the existing tap suite).
- [ ] Manual verify on a dashboard with prior Telegram activity: banner renders, dismiss persists across reloads, `CLAWMETRY_ENABLE_WS_TAP=1` removes the banner on next refresh.

## Diff size

253 LOC (137 in the new test file). Two-pole change: detection + render, no new endpoint, no new dependency.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>