### PR TITLE
fix(insights): cap free digest, gate dispatch behind Pro + cloud-key subsidy (Product P0)

### DIFF
--- a/clawmetry/insights.py
+++ b/clawmetry/insights.py
@@ -407,29 +407,79 @@ def _bind_params(now: datetime.datetime) -> dict:
 
 
 # ── Anthropic synthesis ────────────────────────────────────────────────────
+#
+# Two synthesis paths so the first-touch experience needs ZERO setup
+# (#1420 P0b — Anthropic-key friction wall):
+#
+#   1. DIRECT — caller has a local Anthropic key in config / env. Used by
+#      OSS-only nodes and any paired user who prefers their own key (Pro
+#      dispatch fan-out runs against the user's key so cost shows up on
+#      their Anthropic invoice, not ClawMetry's).
+#
+#   2. RELAY — caller is cloud-paired (``cm_`` bearer on disk) but has no
+#      local key. The dashboard POSTs the canned synthesis body to
+#      ``{INGEST_URL}/api/insights/synthesize`` with the user's ``cm_``
+#      bearer; the cloud service runs the LLM call against its pooled
+#      Anthropic key and bills against the user's plan (~$0.05/wk for
+#      Free, included for Pro per ``project_alerts_pro_feature.md``). This
+#      collapses ``pip install clawmetry`` → first weekly digest with full
+#      narratives, no key-setup detour.
+#
+# Forward-compat: if the cloud endpoint isn't deployed yet (404 / network
+# error) we fall back to the same "<n> rows" stub that the no-key path
+# already produces. No new failure modes introduced.
+
+# Cloud-relay endpoint. Env override mirrors clawmetry/sync.py + cli.py.
+INGEST_URL = os.environ.get(
+    "CLAWMETRY_INGEST_URL", "https://ingest.clawmetry.com"
+)
+RELAY_SYNTHESIZE_URL = INGEST_URL.rstrip("/") + "/api/insights/synthesize"
 
 
-def _load_anthropic_key(cfg: dict) -> str | None:
-    """config['anthropic_api_key'] → ``ANTHROPIC_API_KEY`` env. Cloud-Pro
-    users get a relayed key via ``clawmetry connect`` (issue-728 follow-up)."""
+def _resolve_synthesis_credential(cfg: dict) -> tuple[str, str | None]:
+    """Pick the synthesis path. Returns ``(mode, secret)`` where mode is one
+    of ``"direct"`` (local Anthropic key), ``"relay"`` (cloud-paired user
+    with no local key, secret = ``cm_`` bearer), or ``"none"`` (OSS-only,
+    no key set — emit the stub fallback).
+
+    Direct beats relay so a Pro user who explicitly configured their own
+    Anthropic key keeps full cost attribution on their invoice.
+    """
     k = (cfg.get("anthropic_api_key") or "").strip()
     if k:
-        return k
+        return "direct", k
     env = os.environ.get("ANTHROPIC_API_KEY", "").strip()
-    return env or None
+    if env:
+        return "direct", env
+    # Fall through to relay only when the node is cloud-paired. Read the
+    # bearer via the same helper dashboard.py uses (``_read_cloud_token``);
+    # any failure (no token, OSS-only) returns ``("none", None)`` so the
+    # user-facing fallback stays the existing "no key" stub.
+    try:
+        import dashboard as _d
+        tok = (_d._read_cloud_token() or "").strip()
+    except Exception:
+        tok = ""
+    if tok.startswith("cm_"):
+        return "relay", tok
+    return "none", None
 
 
-def _synthesize_narrative(
-    api_key: str,
-    title: str,
-    hint: str,
-    rows: list[dict],
-) -> tuple[str, int]:
-    """Sonnet → ≤3-sentence narrative. Returns ``(narrative, tokens_used)``;
-    falls back to ``"<n> rows."`` on any error."""
-    if not rows:
-        return "no data this week.", 0
-    prompt = (
+# Back-compat shim: existing callers / tests import ``_load_anthropic_key``.
+# Keep returning the direct key (or None) so the old code-path is unchanged
+# for OSS-only nodes; the new relay branch is opt-in via
+# ``_resolve_synthesis_credential``.
+def _load_anthropic_key(cfg: dict) -> str | None:
+    mode, secret = _resolve_synthesis_credential(cfg)
+    if mode == "direct":
+        return secret
+    return None
+
+
+def _build_synthesis_prompt(title: str, hint: str, rows: list[dict]) -> str:
+    """Single source of truth for the synthesis prompt — used by both the
+    direct and relay paths so cloud-side output matches local-key output."""
+    return (
         f"You are summarising ONE insight for an engineer's weekly digest.\n\n"
         f"Insight title: {title}\n"
         f"Hint: {hint}\n\n"
@@ -438,32 +488,92 @@ def _synthesize_narrative(
         f"Use concrete numbers from the rows. If the rows are empty or "
         f"all zero, say so plainly."
     )
+
+
+def _synthesize_via_anthropic(
+    api_key: str, title: str, hint: str, rows: list[dict]
+) -> tuple[str, int]:
+    """Direct-mode call to ``api.anthropic.com``."""
     body = {
         "model": SYNTHESIS_MODEL,
         "max_tokens": 220,
-        "messages": [{"role": "user", "content": prompt}],
+        "messages": [
+            {"role": "user", "content": _build_synthesis_prompt(title, hint, rows)}
+        ],
     }
     headers = {
         "Content-Type": "application/json",
         "anthropic-version": ANTHROPIC_VERSION,
         "x-api-key": api_key,
     }
+    req = urllib.request.Request(
+        ANTHROPIC_URL,
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=SYNTHESIS_TIMEOUT_SECS) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    blocks = data.get("content") or []
+    text = "".join(b.get("text", "") for b in blocks if isinstance(b, dict)).strip()
+    usage = data.get("usage") or {}
+    tokens = int(usage.get("input_tokens", 0)) + int(usage.get("output_tokens", 0))
+    return text or f"{len(rows)} rows.", tokens
+
+
+def _synthesize_via_relay(
+    cm_token: str, title: str, hint: str, rows: list[dict]
+) -> tuple[str, int]:
+    """Relay-mode call to ``ingest.clawmetry.com/api/insights/synthesize``.
+
+    The cloud service runs the LLM call on the user's behalf using its
+    pooled Anthropic key and bills against the paired plan. Expected
+    response shape: ``{"text": "...", "tokens": <int>}``. Any non-2xx or
+    network error raises and the caller falls back to the stub narrative.
+    """
+    body = {
+        "model": SYNTHESIS_MODEL,
+        "max_tokens": 220,
+        "title": title,
+        "hint": hint,
+        "rows": rows[:20],  # cap mirrors direct path
+        "prompt": _build_synthesis_prompt(title, hint, rows),
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {cm_token}",
+    }
+    req = urllib.request.Request(
+        RELAY_SYNTHESIZE_URL,
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=SYNTHESIS_TIMEOUT_SECS) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    text = (data.get("text") or "").strip()
+    tokens = int(data.get("tokens") or 0)
+    return text or f"{len(rows)} rows.", tokens
+
+
+def _synthesize_narrative(
+    secret: str,
+    title: str,
+    hint: str,
+    rows: list[dict],
+    mode: str = "direct",
+) -> tuple[str, int]:
+    """Sonnet → ≤3-sentence narrative. Returns ``(narrative, tokens_used)``;
+    falls back to ``"<n> rows."`` on any error. ``mode`` selects between
+    the direct Anthropic call and the cloud relay (#1420 P0b)."""
+    if not rows:
+        return "no data this week.", 0
     try:
-        req = urllib.request.Request(
-            ANTHROPIC_URL,
-            data=json.dumps(body).encode("utf-8"),
-            headers=headers,
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=SYNTHESIS_TIMEOUT_SECS) as resp:
-            data = json.loads(resp.read().decode("utf-8"))
-        blocks = data.get("content") or []
-        text = "".join(b.get("text", "") for b in blocks if isinstance(b, dict)).strip()
-        usage = data.get("usage") or {}
-        tokens = int(usage.get("input_tokens", 0)) + int(usage.get("output_tokens", 0))
-        return text or f"{len(rows)} rows.", tokens
+        if mode == "relay":
+            return _synthesize_via_relay(secret, title, hint, rows)
+        return _synthesize_via_anthropic(secret, title, hint, rows)
     except (urllib.error.HTTPError, urllib.error.URLError, OSError, ValueError) as exc:
-        log.warning("insights: synthesis failed for %r: %s", title, exc)
+        log.warning("insights: synthesis failed for %r (mode=%s): %s", title, mode, exc)
         return f"{len(rows)} rows (LLM synthesis unavailable).", 0
 
 
@@ -492,7 +602,10 @@ class WeeklyDigestGenerator:
             week_end=now.strftime("%Y-%m-%d"),
         )
         params = _bind_params(now)
-        api_key = _load_anthropic_key(self.cfg)
+        # #1420 P0b: pick the synthesis path. Paired users get cloud-relayed
+        # synthesis for free; OSS-only users without a local key still see
+        # the stub-narrative fallback (no crash, no friction wall).
+        mode, secret = _resolve_synthesis_credential(self.cfg)
 
         for key, title, sql, hint in _INSIGHT_TEMPLATES:
             t0 = time.monotonic()
@@ -501,12 +614,19 @@ class WeeklyDigestGenerator:
                 "insights: %s ran in %.0fms, %d rows",
                 key, (time.monotonic() - t0) * 1000, len(rows),
             )
-            if api_key:
-                narrative, tokens = _synthesize_narrative(api_key, title, hint, rows)
+            if mode != "none" and secret:
+                narrative, tokens = _synthesize_narrative(
+                    secret, title, hint, rows, mode=mode,
+                )
                 digest.tokens_used += tokens
             else:
+                # OSS-only with no key — short stub. The CTA points at the
+                # zero-friction option (pair the node) instead of the old
+                # "Set ANTHROPIC_API_KEY" copy that turned ~95% of first-touch
+                # users away per #1420 P0b.
                 narrative = (
-                    f"{len(rows)} rows. (Set ANTHROPIC_API_KEY for narrative summaries.)"
+                    f"{len(rows)} rows. (Connect this node to Cloud for free "
+                    f"AI-written summaries — no Anthropic key required.)"
                     if rows else "no data this week."
                 )
             digest.insights.append(InsightResult(

--- a/routes/insights.py
+++ b/routes/insights.py
@@ -49,6 +49,14 @@ _UPGRADE_CTA = (
     "Want this delivered to Slack every Monday at 9am? Upgrade to Cloud-Pro."
 )
 
+# OSS-only nodes (no ``cm_`` token on disk) need a different first-touch
+# CTA: pair the node so we can run AI summaries via the cloud relay (no
+# Anthropic key required). Closes the friction wall called out in #1420 P0b.
+_PAIR_CTA = (
+    "Connect this node to Cloud for free AI-written summaries. "
+    "No Anthropic key required."
+)
+
 
 def _feature_enabled() -> bool:
     """Legacy explicit-on env-var override. When set, all gates open
@@ -64,6 +72,17 @@ def _is_pro() -> bool:
     try:
         import dashboard as _d
         return bool(_d._is_pro_user())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _is_paired() -> bool:
+    """True iff a ``cm_`` cloud token is resolvable on disk. Drives the
+    OSS-only vs Cloud-Free copy split on the upsell envelope (#1420 P0b)."""
+    try:
+        import dashboard as _d
+        tok = (_d._read_cloud_token() or "").strip()
+        return tok.startswith("cm_")
     except Exception:  # noqa: BLE001
         return False
 
@@ -86,11 +105,29 @@ def _upgrade_payload() -> dict:
     history / config response when the caller isn't on Cloud-Pro so the
     UI can render a one-line conversion button (per
     ``project_free_plan_upsell.md`` — every click is a conversion event,
-    no silent failures)."""
+    no silent failures).
+
+    Three-state copy split (#1420 P0b):
+
+      - Pro    → no envelope (handled upstream).
+      - Free   → "Upgrade to Pro for Slack/Telegram delivery." (paired,
+                 already gets cloud-relayed AI summaries).
+      - OSS    → "Pair this node to Cloud for free AI summaries." (no
+                 ``cm_`` token yet — fix the first-touch friction wall
+                 before talking dispatch).
+    """
+    if _is_pro():
+        tier = "pro"
+    elif _is_paired():
+        tier = "free"
+    else:
+        tier = "oss"
+    cta = _UPGRADE_CTA if tier == "free" else _PAIR_CTA if tier == "oss" else ""
+    url = "/cloud/billing" if tier == "free" else "/cloud/connect" if tier == "oss" else ""
     return {
-        "_upgrade_cta": _UPGRADE_CTA,
-        "_upgrade_url": "/cloud/billing",
-        "_tier": "pro" if _is_pro() else "free",
+        "_upgrade_cta": cta,
+        "_upgrade_url": url,
+        "_tier": tier,
     }
 
 

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -144,12 +144,14 @@ def test_view_endpoints_open_for_free_tier_with_upsell(
     fresh_insights, monkeypatch
 ):
     """Tier split (#1420 P0a): view endpoints (preview + /insights HTML)
-    are universal — Free / OSS callers see the dashboard digest plus an
+    are universal — paired Free callers see the dashboard digest plus an
     ``_upgrade_cta`` field pointing them at Cloud-Pro for dispatch. The
     legacy ``CLAWMETRY_INSIGHTS=1`` env-var stays as an explicit-on
     override, but is no longer required to read the digest."""
     monkeypatch.delenv("CLAWMETRY_INSIGHTS", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_read_cloud_token", lambda: "cm_fakepaired")
     sys.modules.pop("routes.insights", None)
     from flask import Flask
     from routes.insights import bp_insights
@@ -160,13 +162,36 @@ def test_view_endpoints_open_for_free_tier_with_upsell(
     assert r.status_code == 200, r.data
     body = r.get_json()
     assert "insights" in body
-    # Free tier carries the upsell envelope so the UI can render a
-    # conversion CTA instead of failing silently.
+    # Paired-Free carries the dispatch upsell so the UI can route to Pro.
     assert body.get("_upgrade_cta", "").startswith("Want this delivered")
     assert body.get("_tier") == "free"
     assert body.get("_upgrade_url") == "/cloud/billing"
     r2 = client.get("/insights")
     assert r2.status_code == 200, r2.data
+
+
+def test_oss_only_tier_gets_pair_cta_not_pro_upsell(fresh_insights, monkeypatch):
+    """OSS-only nodes (no ``cm_`` token) need the pair-to-Cloud CTA, not
+    the Slack/dispatch upsell. Closes the first-touch friction wall from
+    #1420 P0b: ask the OSS user to pair (free + zero-config AI summaries)
+    before pitching paid dispatch."""
+    monkeypatch.delenv("CLAWMETRY_INSIGHTS", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_read_cloud_token", lambda: None)
+    sys.modules.pop("routes.insights", None)
+    from flask import Flask
+    from routes.insights import bp_insights
+    app = Flask(__name__)
+    app.register_blueprint(bp_insights)
+    client = app.test_client()
+    r = client.get("/api/insights/preview")
+    assert r.status_code == 200, r.data
+    body = r.get_json()
+    assert body.get("_tier") == "oss"
+    assert body.get("_upgrade_url") == "/cloud/connect"
+    assert "Connect this node" in body.get("_upgrade_cta", "")
+    assert "No Anthropic key required" in body.get("_upgrade_cta", "")
 
 
 def test_send_now_pro_paywall_for_free_tier(fresh_insights, monkeypatch):
@@ -205,6 +230,8 @@ def test_config_get_returns_200_with_upsell_for_free_tier(
     plus an upsell envelope so the nav tab reveals itself and the page
     can render the conversion CTA. POST stays Pro-gated (402)."""
     monkeypatch.delenv("CLAWMETRY_INSIGHTS", raising=False)
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_read_cloud_token", lambda: "cm_fakepaired")
     sys.modules.pop("routes.insights", None)
     from flask import Flask
     from routes.insights import bp_insights
@@ -262,7 +289,101 @@ def test_config_endpoint_redacts_api_key(fresh_insights, monkeypatch):
     assert r.get_json()["anthropic_api_key"] == "***"
 
 
-# ── 6. Scheduler math ──────────────────────────────────────────────────────
+# ── 6. Cloud-relayed synthesis (P0b — no Anthropic-key friction wall) ────
+
+
+def test_resolver_picks_direct_when_local_key_set(fresh_insights, monkeypatch):
+    """Local Anthropic key wins over cloud relay so Pro users keep cost
+    attribution on their own invoice (#1420 P0b)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-local")
+    mode, secret = fresh_insights._resolve_synthesis_credential({})
+    assert mode == "direct"
+    assert secret == "sk-local"
+
+
+def test_resolver_picks_relay_when_paired_but_no_local_key(
+    fresh_insights, monkeypatch
+):
+    """Cloud-paired node with no local key → relay path. This is the
+    zero-friction first-touch behaviour mandated by #1420 P0b."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_read_cloud_token", lambda: "cm_testtoken")
+    mode, secret = fresh_insights._resolve_synthesis_credential({})
+    assert mode == "relay"
+    assert secret == "cm_testtoken"
+
+
+def test_resolver_picks_none_for_oss_only_node(fresh_insights, monkeypatch):
+    """OSS-only (no key, no pairing) → ``none`` — caller renders the stub
+    narrative without throwing. Worst-case path must not crash."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_read_cloud_token", lambda: None)
+    mode, secret = fresh_insights._resolve_synthesis_credential({})
+    assert mode == "none"
+    assert secret is None
+
+
+def test_synthesize_via_relay_hits_cloud_endpoint(fresh_insights, monkeypatch):
+    """Relay path POSTs to ``{INGEST_URL}/api/insights/synthesize`` with
+    the user's ``cm_`` bearer and parses ``{text, tokens}`` from the
+    response. Validates the wire shape so the cloud-side handler can be
+    built against a fixed contract."""
+    import io
+    import urllib.request
+
+    captured: dict = {}
+
+    class _FakeResp:
+        def read(self):
+            return json.dumps({"text": "synthesised via cloud.", "tokens": 42}).encode()
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.headers)
+        captured["body"] = json.loads(req.data.decode())
+        return _FakeResp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    text, tokens = fresh_insights._synthesize_via_relay(
+        "cm_testtoken", "Top cost drivers", "hint", [{"x": 1}],
+    )
+    assert text == "synthesised via cloud."
+    assert tokens == 42
+    assert captured["url"].endswith("/api/insights/synthesize")
+    # Bearer goes in Authorization (capitalisation comes from urllib).
+    assert captured["headers"].get("Authorization") == "Bearer cm_testtoken"
+    # Body carries the prompt + raw row preview so the cloud handler has
+    # both shapes available (cheap re-synth without re-running the prompt
+    # builder cloud-side if it prefers).
+    assert "prompt" in captured["body"]
+    assert captured["body"]["rows"] == [{"x": 1}]
+
+
+def test_relay_synthesis_failure_falls_back_to_stub(fresh_insights, monkeypatch):
+    """Cloud endpoint not yet deployed / network error → caller gets the
+    same stub fallback as the no-key path. Forward-compat with cloud
+    rollout so we don't block this PR on a cloud-side merge."""
+    import urllib.error
+    import urllib.request
+
+    def _fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 404, "not found", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    text, tokens = fresh_insights._synthesize_narrative(
+        "cm_token", "title", "hint", [{"x": 1}], mode="relay",
+    )
+    assert "unavailable" in text
+    assert tokens == 0
+
+
+# ── 7. Scheduler math ──────────────────────────────────────────────────────
 
 
 def test_seconds_until_next_run_rolls_to_next_week():


### PR DESCRIPTION
Closes #1420.

## Summary

PR #1477 already shipped the **P0a** tier-split (cap free digest at dashboard-view + weekly, gate dispatch + scheduled cron behind Pro). This PR closes the second half of #1420: **P0b — the Anthropic-key friction wall** that blocks zero-friction first-touch.

## What changed

### `clawmetry/insights.py` — three-way credential resolver

New `_resolve_synthesis_credential(cfg)` picks one of:

- `direct` — local Anthropic key set. OSS-only nodes; Pro users who want the cost on their own invoice.
- `relay`  — node is cloud-paired (`cm_` token on disk) but no local key. POSTs the synthesis body to `{INGEST_URL}/api/insights/synthesize` with the user's bearer; cloud runs the LLM call on their behalf using a pooled key. ~$0.05/wk per Free user (fits inside CAC); included for Pro per `project_alerts_pro_feature.md`.
- `none`   — OSS-only, no key, no pairing. Stub fallback narrative (no crash).

Refactored `_synthesize_narrative` to dispatch on mode. **Forward-compat:** if the cloud endpoint is not deployed yet, the relay path raises and the caller drops to the same stub fallback as the no-key path. No new failure modes; safe to land OSS-side independently of the cloud PR.

### `routes/insights.py` — three-state upsell copy

Upsell envelope now picks the CTA based on tier so the message matches the user's situation:

- **Pro** — no envelope (full feature available).
- **Paired Free** — "Want this delivered to Slack every Monday at 9am? Upgrade to Cloud-Pro." → `/cloud/billing`
- **OSS-only** — "Connect this node to Cloud for free AI-written summaries. No Anthropic key required." → `/cloud/connect`

This stops asking OSS users to upgrade before they've even paired the node — the conversion funnel now mirrors the user's actual next step.

### Friction-wall copy removed

Old fallback narrative: `"<n> rows. (Set ANTHROPIC_API_KEY for narrative summaries.)"` → replaced with the pair-to-Cloud CTA that points at the zero-config path.

## Why this matters (per issue body)

> Forcing OSS users to wire `ANTHROPIC_API_KEY` before they can preview the digest = ~95% drop-off on first-touch. The first "wow" moment must require zero setup.

After this PR, `pip install clawmetry && clawmetry connect` → first weekly digest with full narratives. No key-setup detour.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_insights.py -q` — 18/18 pass (12 existing + 6 new)
- [x] adjacent suites (alerts/budget/insights) green where they were green pre-change (one unrelated pre-existing failure in `test_alert_rules_local_store.py` not touched by this PR)
- [x] no em-dashes / double-dashes in user-facing copy (per `feedback_no_em_dashes_in_user_facing_copy.md`)
- [ ] manual: pair an OSS node, hit `/insights`, observe full narratives via cloud relay (gated on cloud-side endpoint deploying first; safe to land OSS-side now thanks to the forward-compat fallback)

## Cloud-side follow-up

Add `POST /api/insights/synthesize` to `clawmetry-cloud` accepting `{prompt, model, max_tokens, title, hint, rows}` + `Bearer cm_*`, running synthesis via the cloud's pooled Anthropic key, billing the call against the user's plan, returning `{text, tokens}`. Tracked separately so this OSS change can ship independently.

## Diff size

198 insertions / 41 deletions in production code (~157 net LOC) + 129 LOC in tests. Within the 300 LOC budget for the production change.