### PR TITLE
fix(session-tools): recognise v3 event types in DuckDB fast path (MOAT)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -730,10 +730,22 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
             s = str(val)
         return s if len(s) <= limit else s[:limit] + "…"
 
+    # v3 turn / lifecycle event types — presence of ANY of these in DuckDB
+    # for the session means the daemon HAS ingested it. We must therefore
+    # serve from the fast path even when there are zero tool calls, so the
+    # legacy JSONL fallback is reserved for genuinely missing-from-DuckDB
+    # sessions. See reference_openclaw_v3_event_types.md.
+    _V3_TURN_TYPES = frozenset({
+        "session.started", "prompt.submitted", "model.completed",
+        "model.changed", "tool.call", "tool.result", "tool_use",
+        "tool_use_result", "custom",
+    })
+
     calls: dict = {}
     result_by_id: dict = {}
     turn_index = 0
     saw_any = False
+    earliest_ts_ms = 0
     for ev in rows:
         et = ev.get("event_type")
         data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
@@ -741,14 +753,21 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
             (data.get("timestamp") if isinstance(data, dict) else None)
             or ev.get("ts")
         )
+        if ev_ts_ms and (earliest_ts_ms == 0 or ev_ts_ms < earliest_ts_ms):
+            earliest_ts_ms = ev_ts_ms
+
+        # Any recognised v3 lifecycle / turn event proves the daemon has
+        # ingested this session. Mark saw_any so we return a populated
+        # (possibly tool-empty) structure instead of falling back to JSONL.
+        if et in _V3_TURN_TYPES:
+            saw_any = True
 
         # v3 standalone tool_call row: self-contained call+result pair.
-        # Real OpenClaw v3 emits these instead of the legacy nested
-        # ``data.message.content[].toolCall`` blocks. Synthesize a tcid
-        # from the event id so the pairing logic below treats it as
-        # an immediately-resolved call.
-        if et == "tool_call":
-            saw_any = True
+        # Accepts the legacy ``tool_call`` name AND the daemon-normalised
+        # ``tool.call`` dot.separated name. Synthesize a tcid from the
+        # event id so the pairing logic below treats it as an
+        # immediately-resolved call.
+        if et in ("tool_call", "tool.call"):
             turn_index += 1
             tcid = ev.get("id") or f"tc-{ev_ts_ms}-{len(calls)}"
             tool_name = ""
@@ -759,7 +778,8 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
                 tool_name = (data.get("tool") or data.get("tool_name")
                              or data.get("name") or "")
                 args_val = (data.get("args") if data.get("args") is not None
-                            else data.get("arguments"))
+                            else data.get("arguments") if data.get("arguments") is not None
+                            else data.get("input"))
                 result_val = data.get("result")
                 is_error = bool(data.get("is_error") or data.get("isError")
                                 or data.get("error"))
@@ -786,7 +806,81 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
                 }
             continue
 
-        # Legacy: nested toolCall / toolResult inside message blobs.
+        # v3 tool result event: pairs with a prior tool_use block by id.
+        # Daemon-normalised name is ``tool.result``; ``tool_use_result``
+        # is the raw v3 source type (rarely makes it through, but accept
+        # both for safety).
+        if et in ("tool.result", "tool_use_result"):
+            tcid = (data.get("tool_use_id") or data.get("toolUseId")
+                    or data.get("id") or "")
+            if tcid:
+                result_val = (data.get("output") if data.get("output") is not None
+                              else data.get("result"))
+                is_error = bool(data.get("is_error") or data.get("isError"))
+                try:
+                    rs = len(json.dumps(result_val, separators=(",", ":")))
+                except Exception:
+                    rs = len(str(result_val or ""))
+                result_by_id[tcid] = {
+                    "end_ms":         ev_ts_ms,
+                    "is_error":       is_error,
+                    "result_size":    rs,
+                    "result_preview": _truncate(result_val, result_chars),
+                }
+            continue
+
+        # v3 assistant turn (``model.completed``): tool invocations live as
+        # Anthropic-style ``tool_use`` blocks inside ``data.toolMetas`` (the
+        # ingest in clawmetry/sync.py::_v3_extract_tool_metas projects them
+        # to ``{id, name, input}``) and/or inside ``data.data.toolMetas``
+        # / ``data.message.content[]`` for raw envelopes. Walk all known
+        # locations so we don't miss any.
+        if et == "model.completed":
+            turn_index += 1
+            msg_model = (ev.get("model")
+                         or (data.get("modelId") if isinstance(data, dict) else "")
+                         or "")
+            msg_provider = (data.get("provider") if isinstance(data, dict) else "") or ""
+            msg_cost = float(ev.get("cost_usd") or 0.0)
+            tool_metas: list = []
+            inner = data.get("data") if isinstance(data.get("data"), dict) else {}
+            for src in (data.get("toolMetas"), inner.get("toolMetas")):
+                if isinstance(src, list):
+                    tool_metas.extend(src)
+            # Also walk message.content[] for raw Anthropic-shape tool_use.
+            for envelope in (data.get("message"), inner.get("message")):
+                if isinstance(envelope, dict):
+                    content = envelope.get("content")
+                    if isinstance(content, list):
+                        for blk in content:
+                            if isinstance(blk, dict) and blk.get("type") == "tool_use":
+                                tool_metas.append({
+                                    "id":    blk.get("id"),
+                                    "name":  blk.get("name") or "tool",
+                                    "input": blk.get("input") or {},
+                                })
+            seen_ids: set = set()
+            for meta in tool_metas:
+                if not isinstance(meta, dict):
+                    continue
+                tcid = meta.get("id") or ""
+                if not tcid or tcid in seen_ids:
+                    continue
+                seen_ids.add(tcid)
+                calls[tcid] = {
+                    "tool_call_id":     tcid,
+                    "tool_name":        meta.get("name", "") or "",
+                    "arguments":        _truncate(meta.get("input"), args_chars),
+                    "start_ms":         ev_ts_ms,
+                    "turn_index":       turn_index,
+                    "model":            msg_model,
+                    "provider":         msg_provider,
+                    "message_cost_usd": msg_cost,
+                }
+            continue
+
+        # Legacy: nested toolCall / toolResult inside ``message`` event rows
+        # (pre-v3 OpenClaw envelopes — kept for backward compatibility).
         if et != "message":
             continue
         saw_any = True
@@ -872,6 +966,11 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
     ]
     first_start = min((r["start_ms"] for r in tools if r.get("start_ms")), default=0)
     last_end = max((r.get("end_ms", 0) for r in tools), default=0)
+    # Tool-empty v3 sessions still need a sensible timeline anchor so the
+    # UI can render a "session ran, no tools" state — fall back to the
+    # earliest lifecycle event (typically session.started).
+    if not first_start and earliest_ts_ms:
+        first_start = earliest_ts_ms
     return {
         "session_id": sid,
         "tools": tools,

--- a/tests/test_moat_live_openclaw_e2e.py
+++ b/tests/test_moat_live_openclaw_e2e.py
@@ -613,23 +613,20 @@ def test_every_api_endpoint_returns_correct_data(live):
         f"/api/local/transcript returned 0 events for {sid!r}"
     )
 
-    # /api/session-tools — for a session with zero tool calls the v3 fast
-    # path in routes/sessions.py:_try_local_store_session_tools returns
-    # None and the route falls through to the legacy JSONL parser, which
-    # doesn't tag _source. Accept either as long as the timeline is empty
-    # (legitimate for an auth-failed run) and the shape is correct.
-    # Tracking the fast-path coverage gap as a follow-up.
+    # /api/session-tools — MUST come from the DuckDB fast path now that
+    # _try_local_store_session_tools recognises v3 lifecycle events
+    # (session.started / prompt.submitted / model.completed). A silent
+    # fall-through to the legacy JSONL walker is a MOAT regression.
     r = client.get(f"/api/session-tools?session_id={sid}&include_unpaired=1")
     assert r.status_code == 200, r.get_data(as_text=True)
     body = r.get_json()
     assert "tools" in body and "by_tool" in body and "stats" in body, (
         f"/api/session-tools missing keys: {sorted(body)}"
     )
-    if body.get("tools"):
-        assert body.get("_source") == "local_store", (
-            f"/api/session-tools with tools must come from local_store; "
-            f"_source={body.get('_source')!r}"
-        )
+    assert body.get("_source") == "local_store", (
+        f"/api/session-tools: _source={body.get('_source')!r} "
+        f"(must be local_store; legacy JSONL fallback is a MOAT regression)"
+    )
 
     # /api/usage
     r = client.get("/api/usage")

--- a/tests/test_session_tools_local_store_v3.py
+++ b/tests/test_session_tools_local_store_v3.py
@@ -1,0 +1,200 @@
+"""Synthetic regression guard for /api/session-tools on v3 sessions.
+
+Closes the MOAT coverage gap exposed by PR #1559's live-OpenClaw E2E:
+``_try_local_store_session_tools`` used to filter on
+``event_type='message'`` (legacy) or ``event_type='tool_call'``. Real
+OpenClaw v3 emits NEITHER for the common no-tool turn shape — sessions
+only carry ``session.started`` / ``prompt.submitted`` / ``model.completed``
+rows, so the fast path returned ``None`` and the route silently fell
+through to the legacy JSONL parser. That bypass meant a DuckDB regression
+would never visibly break the session-tools surface.
+
+This file seeds DuckDB with the SAME event shapes the OSS sync daemon
+writes for real v3 sessions (see ``clawmetry/sync.py::_parse_v3_event``)
+and asserts:
+
+1. A session with ONLY lifecycle events (no tool calls) returns
+   ``_source='local_store'`` with an empty ``tools[]``.
+2. A session whose ``model.completed`` event carries a ``toolMetas``
+   block (the daemon's projection of Anthropic-shape ``tool_use``)
+   surfaces those tool calls AND pairs them with a sibling
+   ``tool.result`` event.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    # Issue #1538 pattern: isolate the fixture from a contributor's locally
+    # running clawmetry daemon. Without this, ``_ls_call`` proxies through
+    # ``~/.clawmetry/local_query.json`` and the daemon queries its OWN
+    # production DuckDB instead of our tmp_path fixture — seeded rows
+    # become invisible to the fast path.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _drain(store):
+    store._flush_now()
+    for _ in range(10):
+        if not store._ring:
+            break
+        time.sleep(0.05)
+
+
+def _row(event_id, sid, event_type, ts, data, **extra):
+    """Build a DuckDB events row that matches what
+    ``clawmetry/sync.py::_parse_v3_event`` produces for v3 sessions."""
+    base = {
+        "id":          event_id,
+        "node_id":     "node-test",
+        "agent_type":  "openclaw",
+        "agent_id":    "main",
+        "session_id":  sid,
+        "workspace_id": None,
+        "event_type":  event_type,
+        "ts":          ts,
+        "data":        json.dumps(data),
+    }
+    base.update(extra)
+    return base
+
+
+def test_v3_session_with_no_tools_serves_from_local_store(app):
+    """An auth-failed / chat-only v3 session has session.started +
+    prompt.submitted + model.completed in DuckDB but ZERO tool events.
+    The fast path must return an empty-but-correctly-tagged payload."""
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-v3-notools"
+
+    store.ingest(_row("e1", sid, "session.started", "2026-05-17T10:00:00Z",
+                      {"_v3_type": "session", "type": "session.started",
+                       "id": sid, "version": "3"}))
+    store.ingest(_row("e2", sid, "prompt.submitted", "2026-05-17T10:00:01Z",
+                      {"_v3_type": "message", "type": "prompt.submitted",
+                       "finalPromptText": "hello"}))
+    store.ingest(_row("e3", sid, "model.completed", "2026-05-17T10:00:02Z",
+                      {"_v3_type": "message", "type": "model.completed",
+                       "completionText": "hi back",
+                       "modelId": "claude-opus-4-7",
+                       "provider": "anthropic"},
+                      model="claude-opus-4-7"))
+    _drain(store)
+
+    r = a.test_client().get(f"/api/session-tools?session_id={sid}&include_unpaired=1")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"_source must be local_store for v3 lifecycle-only session; "
+        f"got {body.get('_source')!r}"
+    )
+    assert body.get("tools") == [], f"expected empty tools, got {body.get('tools')!r}"
+    assert body.get("by_tool") == []
+    stats = body.get("stats") or {}
+    assert stats.get("total_calls") == 0
+    assert stats.get("distinct_tools") == 0
+    # first_start_ms must be populated from session.started so the UI has
+    # an anchor for the empty timeline.
+    assert stats.get("first_start_ms", 0) > 0, (
+        f"first_start_ms not set from lifecycle ts: {stats!r}"
+    )
+
+
+def test_v3_session_with_tool_use_in_model_completed_pairs_results(app):
+    """Real v3 tool calls land as ``toolMetas`` ({id, name, input}) inside
+    ``model.completed.data`` and the matching result is a top-level
+    ``tool.result`` event with ``data.tool_use_id``. Both shapes must be
+    parsed and paired."""
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-v3-withtool"
+    tcid = "toolu_abc123"
+
+    store.ingest(_row("e1", sid, "session.started", "2026-05-17T11:00:00Z",
+                      {"_v3_type": "session", "type": "session.started",
+                       "id": sid}))
+    store.ingest(_row("e2", sid, "prompt.submitted", "2026-05-17T11:00:01Z",
+                      {"_v3_type": "message", "type": "prompt.submitted",
+                       "finalPromptText": "read /etc/hosts"}))
+    store.ingest(_row(
+        "e3", sid, "model.completed", "2026-05-17T11:00:02Z",
+        {
+            "_v3_type": "message", "type": "model.completed",
+            "completionText": "I'll read that file.",
+            "modelId": "claude-opus-4-7",
+            "provider": "anthropic",
+            "toolMetas": [
+                {"id": tcid, "name": "Read",
+                 "input": {"path": "/etc/hosts"}},
+            ],
+        },
+        model="claude-opus-4-7", cost_usd=0.0034,
+    ))
+    store.ingest(_row(
+        "e4", sid, "tool.result", "2026-05-17T11:00:03Z",
+        {
+            "_v3_type": "tool_use_result", "type": "tool.result",
+            "tool_use_id": tcid,
+            "output": "127.0.0.1 localhost\n",
+            "result": "127.0.0.1 localhost\n",
+            "is_error": False,
+        },
+    ))
+    _drain(store)
+
+    r = a.test_client().get(f"/api/session-tools?session_id={sid}&include_unpaired=1")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"_source must be local_store; got {body.get('_source')!r}"
+    )
+
+    tools = body.get("tools") or []
+    assert len(tools) == 1, f"expected 1 tool, got {len(tools)}: {tools!r}"
+    rec = tools[0]
+    assert rec.get("tool_call_id") == tcid
+    assert rec.get("tool_name") == "Read"
+    assert rec.get("model") == "claude-opus-4-7"
+    assert rec.get("provider") == "anthropic"
+    assert rec.get("paired") is True, f"tool not paired with result: {rec!r}"
+    assert rec.get("is_error") is False
+    assert "127.0.0.1" in (rec.get("result_preview") or "")
+
+    by_tool = body.get("by_tool") or []
+    assert len(by_tool) == 1 and by_tool[0]["tool_name"] == "Read"
+    assert by_tool[0]["calls"] == 1
+    assert by_tool[0]["errors"] == 0
+
+    stats = body.get("stats") or {}
+    assert stats.get("total_calls") == 1
+    assert stats.get("paired_calls") == 1
+    assert stats.get("distinct_tools") == 1
+    assert stats.get("first_start_ms", 0) > 0
+    assert stats.get("last_end_ms", 0) >= stats["first_start_ms"]


### PR DESCRIPTION
## Summary

Closes a MOAT silent-fallback gap exposed by the live-OpenClaw E2E in PR #1559:
the ``/api/session-tools`` DuckDB fast path
(``_try_local_store_session_tools`` in ``routes/sessions.py``) only
recognised ``event_type='message'`` (legacy) and ``event_type='tool_call'``
when walking events. Real OpenClaw v3 (verified 2026-05-17 on openclaw
2026.5.7) emits NEITHER for the common no-tool turn shape — sessions
carry ``session.started`` / ``prompt.submitted`` / ``model.completed``
rows, with tool invocations projected as ``data.toolMetas`` inside
``model.completed`` and results as top-level ``tool.result`` events.

Effect before this fix: ``saw_any`` stayed False, the helper returned
None, the route fell through to the legacy JSONL parser (no ``_source``
tag). The session-tools surface worked identically whether DuckDB was
correct OR completely broken — the worst kind of MOAT bug. PR #1559
had to relax its assertion to ship; this PR earns that assertion back.

## Changes

**``routes/sessions.py`` (+107 / -8 LOC)**

- Recognises v3 lifecycle events (``session.started``,
  ``prompt.submitted``, ``model.completed``, ``model.changed``,
  ``tool.call``, ``tool.result``, ``custom``) as "session exists in
  DuckDB" markers, so the fast path returns a populated structure
  (possibly with empty ``tools[]``) tagged ``_source='local_store'``
  instead of None.
- Maps v3 tool invocations from ``model.completed.data.toolMetas``
  (``{id, name, input}`` blocks produced by
  ``clawmetry/sync.py::_v3_extract_tool_metas``) AND walks raw
  Anthropic-shape ``message.content[].type='tool_use'`` for envelopes
  that haven't been projected yet.
- Pairs them with ``tool.result`` events using ``data.tool_use_id``
  (daemon-normalised) plus ``tool_use_result`` raw fallback.
- Anchors the timeline on the earliest lifecycle event ts when no tool
  calls are present so the UI can render a "session ran, no tools" state.

**``tests/test_moat_live_openclaw_e2e.py``**

Re-asserts ``_source == 'local_store'`` unconditionally on
``/api/session-tools``. Removes the temporary ``if body.get('tools'):``
guard PR #1559 added to ship around the gap. The test now goes red if
the fast path regresses.

**``tests/test_session_tools_local_store_v3.py`` (new, 196 LOC)**

Synthetic safety net per ``feedback_synthetic_tests_missed_real_event_shape.md``.
Two regression guards seeded against the EXACT daemon-normalised shapes:

1. ``test_v3_session_with_no_tools_serves_from_local_store`` — a
   lifecycle-only session (``session.started`` + ``prompt.submitted`` +
   ``model.completed``, no tools) must serve from local_store with empty
   ``tools[]`` + populated ``first_start_ms``.
2. ``test_v3_session_with_tool_use_in_model_completed_pairs_results`` —
   a session whose ``model.completed`` carries a ``toolMetas`` block
   plus a sibling ``tool.result`` must surface the call, pair it, and
   report it under ``by_tool``.

Both follow the ``_read_discovery=None`` isolation pattern from
``test_local_query_api.py`` so a contributor's locally running daemon
can't shadow the tmp fixture.

## Why this matters

The user's MOAT mandate is "all UI elements rely on DuckDB to query data".
``/api/session-tools`` is hit whenever the user opens a session detail
panel. Silent JSONL fallback meant a DuckDB regression here would never
visibly break anything. After this PR the fast path SUCCEEDS for v3
sessions; the legacy fallback is reserved for genuinely
missing-from-DuckDB cases.

## Test plan

- [x] ``python3 -c "import dashboard"`` — clean.
- [x] ``python3 -m pytest tests/test_session_tools_local_store_v3.py -q`` — 2 passed.
- [x] ``python3 -m pytest tests/test_moat_live_openclaw_e2e.py tests/test_moat_send_message_e2e.py tests/test_local_query_api.py -q`` — 24 passed, 1 skipped (live OpenClaw binary gate).
- [x] ``python3 -m pytest tests/test_duckdb_fastpath_v3_invariants.py tests/test_brain_history_v3_event_detail.py tests/test_v3_schema_parser.py -q`` — adjacent v3 fast-path tests all green.
- [ ] CI: full matrix.
- [ ] Live E2E once a real OpenClaw binary is available in CI (PR #1559 fixture).

## Risk

Diff is 115 LOC in ``routes/sessions.py``, additive: every new code
path is gated on event_type matching a new value. Legacy
``event_type='message'`` flow is untouched, so pre-v3 OpenClaw and
synthetic ``message``-only tests keep working. The
``test_transcript_local_store.py`` 3-failure on this branch reproduces
on ``origin/main`` (pre-existing daemon-on-laptop isolation gap), not
caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)