### PR TITLE
feat(alerts): resurrect orphaned Slack/Discord webhook config UI (closes #1567, refs #1566)

### DIFF
--- a/clawmetry/templates/partials/budget-modal.html
+++ b/clawmetry/templates/partials/budget-modal.html
@@ -220,6 +220,52 @@
           </div>
         </div>
       </div>
+      <!--
+        Webhook delivery channels (resurrected from dead first-DASHBOARD_HTML).
+        Backend: /api/alert-channels (GET/POST) and /api/alert-channels/test in routes/alerts.py.
+        JS handlers (loadWebhookConfig/saveWebhookConfig/testWebhookConfig) live in app.js.
+        This is the OSS-local direct-webhook channel (paste your own Slack/Discord URL);
+        the Cloud-Pro Alerts Center with cloud routing lives on the Alerts tab.
+      -->
+      <div style="padding:12px;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:8px;margin-bottom:12px;">
+        <div style="font-size:13px;font-weight:700;color:var(--text-primary);margin-bottom:6px;">Alert Channels (Webhooks)</div>
+        <div style="font-size:11px;color:var(--text-muted);margin-bottom:10px;line-height:1.4;">
+          Paste your own Slack or Discord incoming-webhook URL to receive alerts directly.
+          For routed delivery (PagerDuty, email, on-call), see the <b>Alerts</b> tab (Pro).
+        </div>
+        <div style="display:grid;gap:8px;">
+          <div style="display:flex;gap:6px;align-items:center;">
+            <input id="alert-webhook-url" type="text" placeholder="Generic webhook URL (JSON payload)" style="flex:1;padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
+            <button onclick="testWebhookConfig('generic')" style="background:#374151;color:#fff;border:none;border-radius:6px;padding:6px 10px;font-size:11px;cursor:pointer;white-space:nowrap;">Test</button>
+          </div>
+          <div style="display:flex;gap:6px;align-items:center;">
+            <input id="alert-slack-url" type="text" placeholder="Slack incoming webhook URL" style="flex:1;padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
+            <button onclick="testWebhookConfig('slack')" style="background:#4a154b;color:#fff;border:none;border-radius:6px;padding:6px 10px;font-size:11px;cursor:pointer;white-space:nowrap;">Test</button>
+          </div>
+          <div style="display:flex;gap:6px;align-items:center;">
+            <input id="alert-discord-url" type="text" placeholder="Discord webhook URL" style="flex:1;padding:8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);">
+            <button onclick="testWebhookConfig('discord')" style="background:#5865f2;color:#fff;border:none;border-radius:6px;padding:6px 10px;font-size:11px;cursor:pointer;white-space:nowrap;">Test</button>
+          </div>
+          <div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center;">
+            <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-cost-spike"> Cost spike alerts</label>
+            <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-agent-error"> Agent error rate alerts</label>
+            <label style="font-size:12px;display:flex;align-items:center;gap:4px;"><input type="checkbox" id="alert-toggle-security"> Security posture changes</label>
+          </div>
+          <div style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;">
+            <label style="font-size:12px;color:var(--text-muted);">Min severity:</label>
+            <select id="alert-min-severity" style="padding:4px 8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);font-size:12px;">
+              <option value="info">Info (all alerts)</option>
+              <option value="warning" selected>Warning and above</option>
+              <option value="critical">Critical only</option>
+            </select>
+          </div>
+          <div style="display:flex;gap:8px;align-items:center;">
+            <button onclick="saveWebhookConfig()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;cursor:pointer;">Save</button>
+            <button onclick="testWebhookConfig('all')" style="background:#16a34a;color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;cursor:pointer;">Test All</button>
+            <span id="alert-webhook-status" style="font-size:12px;color:var(--text-muted);display:flex;align-items:center;"></span>
+          </div>
+        </div>
+      </div>
       <div id="alert-rules-list" style="font-size:13px;color:var(--text-secondary);">Loading...</div>
     </div>
     <!-- Telegram Tab -->


### PR DESCRIPTION
## Summary

Resurrects the Alert webhook config form that was sitting **dead** in the first (overridden) `DASHBOARD_HTML` assignment in `dashboard.py:4246-4279`. The JS handlers were already live in `clawmetry/static/js/app.js`, calling element IDs that had no DOM to bind to. The backend (`routes/alerts.py` + helpers in `dashboard.py`) was already shipped end-to-end. **Only the form HTML was missing.**

This is finding **#2 of #1566** (the umbrella orphaned-feature audit), shipped per the precedent set by PR #1564 (Brain neural-net MVP).

## What changed

Single-file diff: `clawmetry/templates/partials/budget-modal.html` (+46 LOC, port-not-rewrite).

Inserted the "Alert Channels (Webhooks)" block into the existing Alert Rules tab of the Budget & Alerts modal. All element IDs preserved verbatim (`alert-webhook-url`, `alert-slack-url`, `alert-discord-url`, `alert-min-severity`, three toggle checkboxes, `alert-webhook-status`) so the existing JS handlers work unchanged.

## What was already alive

- `loadWebhookConfig()`, `saveWebhookConfig()`, `testWebhookConfig(channel)` in `clawmetry/static/js/app.js` (lines ~236-301).
- `switchBudgetTab('alerts', ...)` already calls `loadWebhookConfig()` on tab open (app.js:72).
- `/api/alert-channels` GET/POST and `/api/alert-channels/test` in `routes/alerts.py` (lines 667-730).
- Helpers `_load_alerts_webhook_config`, `_save_alerts_webhook_config`, `_send_slack_alert`, `_send_discord_alert`, `_send_webhook_alert` in `dashboard.py`.

## Pro-gate handling

Per `project_alerts_pro_feature.md`, **Alerts Center is Cloud-Pro only**. The Pro-gated piece is the rule editor on `/page-alerts` (paywall already lives in `templates/tabs/alerts.html`, served by `alerts.js`).

The webhook config form here is a **distinct surface** — the OSS-local direct-channel where the user pastes their own Slack/Discord incoming-webhook URL and the OSS instance posts to it directly (no cloud routing required). Backend confirms: `/api/alert-channels` has no tier gate. This is correct because OSS users get full value from "paste my Slack URL, get alerts in my Slack" without needing cloud fanout.

To make this distinction clear in-product, the form carries an inline disclaimer:

> *Paste your own Slack or Discord incoming-webhook URL to receive alerts directly. For routed delivery (PagerDuty, email, on-call), see the **Alerts** tab (Pro).*

This matches the existing budget-modal pattern where the "Add Alert Rule" panel above also lets OSS users create local rules without a paywall, while the cloud-routed Alerts Center on `/page-alerts` holds the Pro paywall.

## Acceptance criteria mapping (from #1567)

- [x] Form lands in `clawmetry/templates/partials/budget-modal.html`.
- [x] Fields populate from `GET /api/alert-channels` on Alerts-tab open (existing `loadWebhookConfig()` wiring).
- [x] Save calls `POST /api/alert-channels` (existing `saveWebhookConfig()`).
- [x] Per-channel Test buttons fire `testWebhookConfig('slack' | 'discord' | 'generic')` (already live).
- [x] Pro-gate respected via inline disclaimer pointing to Alerts tab; OSS-local channel correctly remains ungated (matches backend + memory).
- [x] Diff ≤ 200 LOC (46 LOC).
- [x] No new endpoints, no DuckDB bypass, no new deps.

## Verification

- `python3 -c "import dashboard"` clean.
- `node -c clawmetry/static/js/app.js` clean.
- `python3 -m pytest tests/ -k alert -q` -> 55 passed, 4 skipped, 1 pre-existing failure unrelated (`test_api_alerts_rules_fast_path_serves_local_store` fails on main too, DuckDB fast-path issue).
- Manual browser verification on local dashboard (`python3 dashboard.py --port 8901`): opened Budget & Alerts modal, switched to Alert Rules tab, confirmed all 8 form controls render and bind to the live JS handlers. Pre-filled values with `evaluate_script` to validate the rendered form. Screenshot below.

### Screenshot

(Attached as PR comment after open — see `/tmp/webhook-form-1567.png` from the dispatch agent.)

The viewport view shows the modal at typical desktop width with the new "Alert Channels (Webhooks)" panel between the "+ Add Alert Rule" button and the rules list, exactly mirroring the dead source layout.

## Out of scope (deferred to follow-up sub-issues)

- Finding #3 (Self-Config Diff Viewer tab) — needs product call on widget vs full tab.
- Finding #4 (Quick Actions panel) — verify backend liveness first.
- Finding #7 (2000-LOC module prelude un-duplication) — last per umbrella order. **Deliberately did NOT touch the dead source in `dashboard.py`** to preserve the audit baseline.

## Test plan

- [x] `python3 -c "import dashboard"` clean.
- [x] `node -c clawmetry/static/js/app.js` clean.
- [x] Alerts-adjacent tests stay green (55/56; one pre-existing failure unrelated).
- [x] Manual: open Budget & Alerts modal -> Alert Rules tab, confirm webhook channel inputs render.
- [ ] Manual smoke after merge: paste a real Slack webhook URL, click Test, confirm message arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)