### PR TITLE
feat(infra): /api/flow-events DuckDB fast path (refs #1565)

### DIFF
--- a/routes/infra.py
+++ b/routes/infra.py
@@ -83,6 +83,151 @@ def api_logs():
     return jsonify({"lines": lines, "date": date_str})
 
 
+# Tool-name → flow-tab short key. OpenClaw emits these tool names verified
+# against production session JSONLs. Mapped to the short key our Flow SVG
+# path ids expect (exec / browser / search / memory / session / cron / tts).
+# Shared between the legacy SSE parser and the DuckDB fast-path helper so
+# both surfaces emit the same `tool` field for the front-end.
+_FLOW_TOOL_MAP = {
+    "exec": "exec", "process": "exec", "read": "exec", "write": "exec",
+    "write_file": "exec", "edit": "exec", "Bash": "exec", "Read": "exec",
+    "Write": "exec", "Edit": "exec",
+    "web_search": "search", "ollama_web_search": "search",
+    "web_fetch": "browser", "ollama_web_fetch": "browser",
+    "browser": "browser", "image": "browser",
+    "memory_search": "memory", "memory_get": "memory",
+    "sessions_spawn": "session",
+    "cron": "cron", "tts": "tts",
+}
+
+# Channel-label hints carried inside `Sender (untrusted metadata)` user blocks.
+_FLOW_CHANNEL_LABELS = {
+    "openclaw-tui":        "tui",
+    "openclaw-control-ui": "webchat",
+    "openclaw-webchat":    "webchat",
+}
+
+
+def _try_local_store_flow_events(limit=200, since=None):
+    """DuckDB fast path for /api/flow-events. Returns a chronologically-
+    ordered list of normalised flow events ({type, channel|tool, ts,
+    session_id}) drawn from the daemon-ingested ``events`` table, OR
+    ``None`` when the local store has no relevant rows (callers fall
+    through to the legacy JSONL/gateway-log tail).
+
+    Shape mirrors what the SSE parser yields (msg_in / msg_out /
+    tool_call / tool_result) so downstream consumers can treat the JSON
+    envelope as a snapshot prefix of the live stream. Tagged
+    ``_source: 'local_store'`` by the caller. Closes the Tier-1 audit
+    candidate for `/api/flow-events` (refs #1565)."""
+    from routes.sessions import _ls_call  # late import to avoid cycle
+    rows = _ls_call("query_events", since=since, limit=limit) or []
+    if not rows:
+        return None
+
+    # The daemon-normalised v3 event types that map to flow lanes. Real
+    # OpenClaw v3 ingest emits these (see
+    # reference_openclaw_v3_event_types.md); we also accept legacy and
+    # tool-call alternates so older sessions still surface. If NONE of
+    # the rows match we return None so the legacy parser still drives
+    # the SSE timeline (pre-v3 / non-OpenClaw agents).
+    _FLOW_TYPES = frozenset({
+        "prompt.submitted", "model.completed", "model.changed",
+        "tool.call", "tool_call", "tool.result", "tool_use_result",
+        "message", "assistant", "user",
+    })
+    matched = [r for r in rows if r.get("event_type") in _FLOW_TYPES]
+    if not matched:
+        return None
+
+    def _extract_channel(payload):
+        """Pull a channel hint from a `data` blob. Looks at top-level
+        ``channel``/``provider`` first, then walks Sender-metadata in
+        prompt text the same way the SSE parser does."""
+        if not isinstance(payload, dict):
+            return None
+        for key in ("channel", "provider", "origin"):
+            v = payload.get(key)
+            if isinstance(v, str) and v:
+                lk = v.lower()
+                return _FLOW_CHANNEL_LABELS.get(lk, lk)
+        text = payload.get("finalPromptText") or ""
+        if not isinstance(text, str) or "Sender (untrusted metadata)" not in text:
+            return None
+        try:
+            start = text.index("```json")
+            end = text.index("```", start + 8)
+            meta = json.loads(text[start + 7:end].strip())
+            label = str(meta.get("label") or meta.get("id") or "").lower()
+            return _FLOW_CHANNEL_LABELS.get(label, label) or None
+        except Exception:
+            return None
+
+    events: list = []
+    for row in matched:
+        et = row.get("event_type") or ""
+        data = row.get("data") if isinstance(row.get("data"), dict) else {}
+        sid = row.get("session_id") or ""
+        ts = row.get("ts") or ""
+
+        if et == "prompt.submitted" or (et in ("message", "user")
+                                         and (data.get("role") == "user")):
+            ch = _extract_channel(data) or "telegram"
+            events.append({"type": "msg_in", "channel": ch,
+                           "ts": ts, "session_id": sid,
+                           "_source": "local_store"})
+            continue
+
+        if et == "model.completed" or (et in ("message", "assistant")
+                                        and data.get("role") == "assistant"):
+            # Surface tool invocations carried inside the assistant turn
+            # as separate tool_call events so the Flow timeline matches
+            # the SSE shape. Outer assistant reply itself is the
+            # "gateway bubble" — emitted as msg_out so the channel lane
+            # lights up.
+            tool_metas = []
+            inner = data.get("data") if isinstance(data.get("data"), dict) else {}
+            for src in (data.get("toolMetas"), inner.get("toolMetas")):
+                if isinstance(src, list):
+                    tool_metas.extend(src)
+            for tm in tool_metas:
+                if not isinstance(tm, dict):
+                    continue
+                name = tm.get("name") or ""
+                tool_key = _FLOW_TOOL_MAP.get(name, name)
+                events.append({"type": "tool_call", "tool": tool_key,
+                               "ts": ts, "session_id": sid,
+                               "_source": "local_store"})
+            ch = _extract_channel(data) or "telegram"
+            events.append({"type": "msg_out", "channel": ch,
+                           "ts": ts, "session_id": sid,
+                           "_source": "local_store"})
+            continue
+
+        if et in ("tool.call", "tool_call"):
+            name = (data.get("tool") or data.get("tool_name")
+                    or data.get("name") or "")
+            tool_key = _FLOW_TOOL_MAP.get(name, name)
+            events.append({"type": "tool_call", "tool": tool_key,
+                           "ts": ts, "session_id": sid,
+                           "_source": "local_store"})
+            continue
+
+        if et in ("tool.result", "tool_use_result"):
+            name = (data.get("tool") or data.get("tool_name")
+                    or data.get("name") or "")
+            tool_key = _FLOW_TOOL_MAP.get(name, name or "exec")
+            events.append({"type": "tool_result", "tool": tool_key,
+                           "ts": ts, "session_id": sid,
+                           "_source": "local_store"})
+            continue
+
+    # query_events returns DESC; reverse so the caller gets a
+    # chronological snapshot prefix (matches what the SSE stream emits).
+    events.reverse()
+    return events
+
+
 @bp_logs.route("/api/flow-events")
 @bp_logs.route("/api/flow")
 def api_flow_events():
@@ -94,7 +239,20 @@ def api_flow_events():
     # E2E health checks and non-SSE clients get a lightweight JSON response
     accept = request.headers.get("Accept", "")
     if request.method == "HEAD" or "text/event-stream" not in accept:
-        return jsonify({"ok": True, "type": "flow-events", "streaming": True})
+        envelope = {"ok": True, "type": "flow-events", "streaming": True}
+        # DuckDB fast path (refs #1565). Hydrate the JSON envelope with a
+        # snapshot of recent flow events so callers that can't (or don't
+        # want to) hold an SSE connection still see real data. SSE is the
+        # only path that yields LIVE updates; this path is the snapshot.
+        if is_local_store_read_enabled():
+            try:
+                snap = _try_local_store_flow_events(limit=200)
+            except Exception:
+                snap = None
+            if snap is not None:
+                envelope["events"] = snap
+                envelope["_source"] = "local_store"
+        return jsonify(envelope)
     import glob as _glob
 
     def _find_active_jsonl():

--- a/tests/test_flow_events_local_store_v3.py
+++ b/tests/test_flow_events_local_store_v3.py
@@ -1,0 +1,233 @@
+"""Synthetic regression guard for /api/flow-events on v3 sessions.
+
+Closes the Tier-1 audit checkbox for ``/api/flow-events`` in #1565: the
+JSON envelope returned to non-SSE clients used to be a static
+``{ok, type, streaming}`` blob — no DuckDB read, no snapshot of recent
+flow events. Cloud-Pro / external scrapers / E2E health checks that
+can't hold an SSE connection had to round-trip through `/api/transcript`
+to reconstruct the flow timeline.
+
+This file seeds DuckDB with the SAME daemon-normalised event shapes the
+OSS sync daemon writes for real OpenClaw v3 sessions (see
+``clawmetry/sync.py::_parse_v3_event`` + reference_openclaw_v3_event_types.md)
+and asserts:
+
+1. An empty local store falls through (caller fires legacy JSONL parser).
+2. A populated store hydrates the envelope with ``events[]`` + ``_source: 'local_store'``.
+3. Event ordering is chronological (matches SSE prefix).
+4. The four flow lanes are populated correctly: msg_in (user / prompt.submitted),
+   msg_out (assistant / model.completed), tool_call (toolMetas inside
+   model.completed AND standalone tool.call rows), tool_result.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+    import routes.infra as infra_mod
+    importlib.reload(infra_mod)
+
+    # Issue #1538 pattern: isolate fixture from a developer's locally-
+    # running clawmetry daemon (otherwise ``_ls_call`` proxies through
+    # ``~/.clawmetry/local_query.json`` and queries the daemon's production
+    # DuckDB instead of our tmp_path fixture — seeded rows become invisible
+    # to the fast path).
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    a = Flask(__name__)
+    a.register_blueprint(infra_mod.bp_logs)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _drain(store):
+    store._flush_now()
+    for _ in range(10):
+        if not store._ring:
+            break
+        time.sleep(0.05)
+
+
+def _row(event_id, sid, event_type, ts, data, **extra):
+    """Build a DuckDB events row matching what
+    ``clawmetry/sync.py::_parse_v3_event`` produces for v3 sessions."""
+    base = {
+        "id":          event_id,
+        "node_id":     "node-test",
+        "agent_type":  "openclaw",
+        "agent_id":    "main",
+        "session_id":  sid,
+        "workspace_id": None,
+        "event_type":  event_type,
+        "ts":          ts,
+        "data":        json.dumps(data),
+    }
+    base.update(extra)
+    return base
+
+
+def test_empty_local_store_returns_legacy_envelope(app):
+    """When DuckDB has zero flow-relevant rows the helper returns None and
+    the route falls back to the static envelope. Critical: this keeps the
+    legacy SSE-only behaviour intact for fresh installs."""
+    a, _ls = app
+    r = a.test_client().get("/api/flow-events", headers={"Accept": "application/json"})
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("ok") is True
+    assert body.get("type") == "flow-events"
+    assert body.get("streaming") is True
+    # No DuckDB rows → no _source tag, no events list.
+    assert "_source" not in body
+    assert "events" not in body
+
+
+def test_populated_local_store_hydrates_envelope(app):
+    """A real v3 conversation must surface as a chronological list of
+    msg_in / tool_call / msg_out / tool_result events tagged
+    ``_source: 'local_store'``."""
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-flow-v3"
+    tcid = "toolu_flow_abc"
+
+    store.ingest(_row("e1", sid, "session.started", "2026-05-17T12:00:00Z",
+                      {"_v3_type": "session", "type": "session.started",
+                       "id": sid}))
+    store.ingest(_row("e2", sid, "prompt.submitted", "2026-05-17T12:00:01Z",
+                      {"_v3_type": "message", "type": "prompt.submitted",
+                       "finalPromptText": "read /etc/hosts",
+                       "channel": "telegram"}))
+    store.ingest(_row(
+        "e3", sid, "model.completed", "2026-05-17T12:00:02Z",
+        {
+            "_v3_type": "message", "type": "model.completed",
+            "completionText": "I'll read that.",
+            "modelId": "claude-opus-4-7",
+            "provider": "anthropic",
+            "channel": "telegram",
+            "toolMetas": [
+                {"id": tcid, "name": "Read", "input": {"path": "/etc/hosts"}},
+            ],
+        },
+        model="claude-opus-4-7", cost_usd=0.0034,
+    ))
+    store.ingest(_row(
+        "e4", sid, "tool.result", "2026-05-17T12:00:03Z",
+        {
+            "_v3_type": "tool_use_result", "type": "tool.result",
+            "tool_use_id": tcid, "tool_name": "Read",
+            "output": "127.0.0.1 localhost\n",
+            "is_error": False,
+        },
+    ))
+    _drain(store)
+
+    r = a.test_client().get("/api/flow-events", headers={"Accept": "application/json"})
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("ok") is True, f"envelope shape regressed: {body!r}"
+    assert body.get("type") == "flow-events"
+    assert body.get("_source") == "local_store", (
+        f"_source must be local_store on populated store; got {body.get('_source')!r}"
+    )
+    events = body.get("events") or []
+    assert events, f"expected populated events list, got {events!r}"
+
+    # Chronological order (msg_in must precede msg_out / tool_*).
+    types = [e.get("type") for e in events]
+    assert "msg_in" in types, f"missing msg_in lane: {types}"
+    assert "msg_out" in types, f"missing msg_out lane: {types}"
+    assert "tool_call" in types, f"missing tool_call lane: {types}"
+    assert "tool_result" in types, f"missing tool_result lane: {types}"
+    assert types.index("msg_in") < types.index("msg_out"), (
+        f"events not chronological: {types}"
+    )
+
+    # Channel propagation — the prompt + completion both carry channel='telegram'.
+    msg_in = next(e for e in events if e.get("type") == "msg_in")
+    assert msg_in.get("channel") == "telegram", (
+        f"msg_in channel lost: {msg_in!r}"
+    )
+    # Tool key mapping: 'Read' → 'exec'.
+    tool_call = next(e for e in events if e.get("type") == "tool_call")
+    assert tool_call.get("tool") == "exec", (
+        f"tool key mapping broken: {tool_call!r}"
+    )
+    tool_result = next(e for e in events if e.get("type") == "tool_result")
+    assert tool_result.get("tool") == "exec"
+
+    # Every event must carry the session id + per-row source tag for
+    # easy joining on the client.
+    for ev in events:
+        assert ev.get("session_id") == sid
+        assert ev.get("_source") == "local_store"
+
+
+def test_standalone_tool_call_event_is_surfaced(app):
+    """Some adapters emit a standalone tool.call row instead of folding
+    the tool_use into model.completed. Both shapes must populate the
+    tool_call lane."""
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-flow-standalone"
+
+    store.ingest(_row("e1", sid, "session.started", "2026-05-17T13:00:00Z",
+                      {"_v3_type": "session", "type": "session.started"}))
+    store.ingest(_row("e2", sid, "tool.call", "2026-05-17T13:00:01Z",
+                      {"_v3_type": "tool_call", "type": "tool.call",
+                       "tool_name": "web_search"}))
+    _drain(store)
+
+    r = a.test_client().get("/api/flow-events", headers={"Accept": "application/json"})
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    events = body.get("events") or []
+    tool_calls = [e for e in events if e.get("type") == "tool_call"]
+    assert tool_calls, f"standalone tool.call dropped: {events!r}"
+    # web_search → 'search' per _FLOW_TOOL_MAP.
+    assert tool_calls[0].get("tool") == "search"
+
+
+def test_flow_alias_route_preserves_envelope(app):
+    """`/api/flow` is registered as an alias on the same handler. The
+    live-E2E (`test_every_api_endpoint_returns_correct_data`) asserts
+    the basic envelope on `/api/flow`; this guards that the fast path
+    doesn't drop the `ok`/`type` keys."""
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-flow-alias"
+    store.ingest(_row("e1", sid, "prompt.submitted", "2026-05-17T14:00:00Z",
+                      {"_v3_type": "message", "type": "prompt.submitted",
+                       "finalPromptText": "hi"}))
+    _drain(store)
+
+    r = a.test_client().get("/api/flow", headers={"Accept": "application/json"})
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("ok") is True
+    assert body.get("type") == "flow-events"
+    # And fast-path is wired on this route too.
+    assert body.get("_source") == "local_store"


### PR DESCRIPTION
## Summary

Tier-1 audit checkbox from #1565: `/api/flow-events` was the last `JSONL_FALLBACK_ONLY` lane in `routes/infra.py`'s big-three (log/flow/flow-events). The non-SSE JSON envelope returned `{ok, type, streaming}` — no DuckDB read, no snapshot. Callers that can't hold an SSE connection (E2E health checks, headless scrapers, mobile clients) had to round-trip through `/api/transcript` to reconstruct the flow timeline.

## What changed

- New helper `_try_local_store_flow_events(limit, since)` in `routes/infra.py` (mirrors PR #1561's `_try_local_store_session_tools` shape).
- Helper queries the daemon-ingested `events` table for v3 flow-relevant types:
  - `prompt.submitted` → `msg_in` lane (with channel extracted from `data.channel` or `Sender (untrusted metadata)` JSON in `finalPromptText`).
  - `model.completed` → `msg_out` lane + walks `toolMetas` to emit `tool_call` events per Anthropic-shape tool_use block carried inside the assistant turn.
  - Standalone `tool.call` / `tool.result` (and legacy `tool_use_result`) rows → `tool_call` / `tool_result` lanes.
- `api_flow_events()` now hydrates the JSON envelope with `events: [...]` + `_source: 'local_store'` when the helper hits; returns None on empty store so legacy installs and pre-v3 sessions keep current behaviour.
- SSE branch is unchanged — DuckDB has no LISTEN/NOTIFY equivalent so live tailing stays on the file-tail loop (same trade-off as `/api/brain-stream` per the audit's `DUCKDB_PARTIAL` categorisation).

## Shape verification

Real OpenClaw v3 emits namespaced event types (see `reference_openclaw_v3_event_types.md`). The helper accepts the daemon-normalised names (`prompt.submitted`, `model.completed`, `tool.call`, `tool.result`) AND a few legacy aliases (`message`, `assistant`, `tool_call`, `tool_use_result`) so older sessions still light up the flow lanes. Synthetic tests use the exact shapes `clawmetry/sync.py::_parse_v3_event` produces — pulled from the same fixture as `tests/test_session_tools_local_store_v3.py`.

`/api/flow` alias preserves `ok=true, type='flow-events'` so `test_every_api_endpoint_returns_correct_data` (the live OpenClaw E2E) keeps passing — verified locally (5 passed, 1 skipped — the 1 skip is the unrelated tool-call live-key sentinel).

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_flow_events_local_store_v3.py -q` — 4 passed
- [x] `python3 -m pytest tests/test_moat_send_message_e2e.py tests/test_local_query_api.py tests/test_flow_events_local_store_v3.py -q` — 23 passed
- [x] `python3 -m pytest tests/test_moat_live_openclaw_e2e.py -q` — 5 passed, 1 skipped (`/api/flow` envelope intact)
- [x] `python3 -m pytest tests/test_no_direct_get_store_in_routes.py -q` — 2 passed (no raw `get_store()` in routes/)
- [x] Adjacent regression check: `tests/test_flow_runs_endpoint.py` + `tests/test_session_tools_local_store_v3.py` — 10 passed

Checks off the `/api/flow-events` line in #1565's Tier-1 list.

Refs #1565