### PR TITLE
feat(usage): /api/usage/forecast DuckDB fast path (refs #1565)

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -720,6 +720,119 @@ def _try_local_store_cost_comparison():
     }
 
 
+def _try_local_store_usage_forecast():
+    """Fast path for /api/usage/forecast (issue #1565, Tier-1).
+
+    Projects current spend trajectory to end-of-month:
+        daily_rate      = sum(cost_usd last 7 days) / 7
+        projected_month = cost_so_far_this_month + daily_rate * days_remaining
+
+    Source preference (matters because of the dedupe-pattern footgun
+    documented in ``feedback_usage_dedupe_pattern.md``):
+
+      1. ``query_aggregates`` — SQL-side dedupe over the FULL events
+         table (every event row that carries ``cost_usd``, billable-turn
+         and non-message rows alike). Safer for cost projection because
+         the daemon stamps ``cost_usd`` on rows the splits walker skips
+         (e.g. tool retries, fallback turns).
+      2. ``query_daily_usage_splits`` — only walks
+         ``_BILLABLE_TURN_EVENT_TYPES``. Used as a fallback so a fresh
+         install (aggregates empty, only events seeded) still produces
+         a forecast.
+
+    Returns ``None`` when no store is reachable so the route can fall
+    back to the JSONL legacy projection. Returns
+    ``{available: False, _source: 'local_store'}`` when the store IS
+    reachable but holds zero usage rows — the forecast is genuinely
+    unavailable, the UI handles this and renders the empty-state copy.
+    """
+    import calendar
+    from datetime import datetime, timedelta, timezone
+
+    store = _ls_get_store()
+    if store is None:
+        return None
+
+    # Pull aggregates first — they cover every cost-bearing row, deduped
+    # at SQL level (see ``feedback_usage_dedupe_pattern.md`` for why
+    # walking only billable turns silently drops ~30% of cost).
+    daily_costs: dict[str, float] = {}
+    try:
+        agg_rows = store.query_aggregates() or []
+    except Exception:
+        agg_rows = []
+    for r in agg_rows:
+        day = r.get("day", "")
+        if day:
+            daily_costs[day] = daily_costs.get(day, 0.0) + float(r.get("cost_usd") or 0)
+
+    # Fresh-install fallback: aggregates table empty → derive from
+    # the splits walker. Splits dedupe sibling pairs but skip non-message
+    # event types; for forecast we're OK with that because the alternative
+    # is no forecast at all on a fresh install.
+    if not daily_costs:
+        try:
+            split_rows = store.query_daily_usage_splits() or []
+        except Exception:
+            split_rows = []
+        for r in split_rows:
+            day = r.get("day", "")
+            if day:
+                daily_costs[day] = daily_costs.get(day, 0.0) + float(r.get("cost_usd") or 0)
+
+    today = datetime.now(timezone.utc).date()
+    window_days = 7
+    window: list[float] = []
+    for i in range(window_days):
+        d = (today - timedelta(days=i)).isoformat()
+        window.append(daily_costs.get(d, 0.0))
+
+    daily_rate = sum(window) / window_days
+    days_in_month = calendar.monthrange(today.year, today.month)[1]
+    days_elapsed = today.day
+    days_remaining = days_in_month - days_elapsed
+    month_str = today.strftime("%Y-%m")
+    cost_this_month = sum(v for k, v in daily_costs.items() if k.startswith(month_str))
+
+    # If the store is reachable but holds zero usage rows AND we have no
+    # spend this month, surface ``available: False`` with the _source
+    # tag — the UI renders the empty-state copy and the audit can still
+    # see the canary.
+    if not daily_costs and cost_this_month == 0 and daily_rate == 0:
+        return {"available": False, "reason": "no_data", "_source": "local_store"}
+
+    projected_month = cost_this_month + daily_rate * days_remaining
+
+    try:
+        import dashboard as _d
+        budget_cfg = _d._get_budget_config()
+    except Exception:
+        budget_cfg = {}
+    monthly_budget = float(budget_cfg.get("monthly_limit") or 0)
+    monthly_cap = float(budget_cfg.get("monthly_cap_usd") or 0)
+    effective_budget = monthly_budget or monthly_cap or 0.0
+
+    budget_exceeded = bool(effective_budget > 0 and projected_month > effective_budget)
+    days_to_budget: float | None = None
+    if effective_budget > 0 and daily_rate > 0:
+        remaining_budget = effective_budget - cost_this_month
+        days_to_budget = max(0.0, remaining_budget / daily_rate)
+
+    return {
+        "available": True,
+        "daily_rate_usd": round(daily_rate, 4),
+        "cost_this_month_usd": round(cost_this_month, 4),
+        "projected_month_usd": round(projected_month, 4),
+        "days_remaining_in_month": days_remaining,
+        "monthly_budget_usd": effective_budget,
+        "budget_exceeded": budget_exceeded,
+        "days_to_budget": round(days_to_budget, 1) if days_to_budget is not None else None,
+        "window_days": window_days,
+        "daily_window": [round(c, 4) for c in reversed(window)],
+        "_source": "local_store",
+    }
+
+
 def _try_local_store_model_attribution():
     """Fast path for /api/model-attribution. Per-model assistant turn count,
     session count, provider tag, and share %. Switches list is best-effort
@@ -1788,72 +1901,30 @@ def api_usage_forecast():
           projected_month = cost_so_far + daily_rate * days_remaining
           days_to_budget = (budget - cost_so_far) / daily_rate
 
+    Issue #1565 (Tier-1): now goes through
+    ``_try_local_store_usage_forecast`` under the standard
+    ``is_local_store_read_enabled()`` gate so the audit canary
+    (``_source: 'local_store'`` in the JSON body) shows up in browser
+    devtools the same way the rest of the Usage tab does.
+
     Returns {available, daily_rate_usd, cost_this_month_usd,
              projected_month_usd, days_remaining_in_month,
              monthly_budget_usd, budget_exceeded, days_to_budget,
              window_days, daily_window, _source}.
-    Returns {available: false} when no local-store data is present.
+    Returns {available: false} when no usage data is present.
     """
-    import calendar
-    import dashboard as _d
-    from datetime import datetime, timedelta, timezone
+    if is_local_store_read_enabled():
+        fast = _try_local_store_usage_forecast()
+        if fast is not None:
+            return jsonify(fast)
 
-    today = datetime.now(timezone.utc).date()
-
-    rows = _ls_call("query_daily_usage_splits") or []
-    if not rows:
-        rows = _ls_call("query_aggregates") or []
-
-    if not rows:
-        return jsonify({"available": False, "reason": "no_data"})
-
-    daily_costs: dict[str, float] = {}
-    for r in rows:
-        day = r.get("day", "")
-        if day:
-            daily_costs[day] = float(r.get("cost_usd") or 0)
-
-    window_days = 7
-    window: list[float] = []
-    for i in range(window_days):
-        d = (today - timedelta(days=i)).isoformat()
-        window.append(daily_costs.get(d, 0.0))
-
-    daily_rate = sum(window) / window_days
-
-    days_in_month = calendar.monthrange(today.year, today.month)[1]
-    days_elapsed = today.day
-    days_remaining = days_in_month - days_elapsed
-
-    month_str = today.strftime("%Y-%m")
-    cost_this_month = sum(v for k, v in daily_costs.items() if k.startswith(month_str))
-
-    projected_month = cost_this_month + daily_rate * days_remaining
-
-    budget_cfg = _d._get_budget_config()
-    monthly_budget = float(budget_cfg.get("monthly_limit") or 0)
-    monthly_cap = float(budget_cfg.get("monthly_cap_usd") or 0)
-    effective_budget = monthly_budget or monthly_cap or 0.0
-
-    budget_exceeded = bool(effective_budget > 0 and projected_month > effective_budget)
-    days_to_budget: float | None = None
-    if effective_budget > 0 and daily_rate > 0:
-        remaining_budget = effective_budget - cost_this_month
-        days_to_budget = max(0.0, remaining_budget / daily_rate)
-
-    return jsonify({
-        "available": True,
-        "daily_rate_usd": round(daily_rate, 4),
-        "cost_this_month_usd": round(cost_this_month, 4),
-        "projected_month_usd": round(projected_month, 4),
-        "days_remaining_in_month": days_remaining,
-        "monthly_budget_usd": effective_budget,
-        "budget_exceeded": budget_exceeded,
-        "days_to_budget": round(days_to_budget, 1) if days_to_budget is not None else None,
-        "window_days": window_days,
-        "daily_window": [round(c, 4) for c in reversed(window)],
-        "_source": "local_store",
-    })
+    # Local store unavailable (no daemon, tests with the flag off): fall
+    # back to a minimal "no data" response so the route never 500s. The
+    # forecast card is a derived view of the existing /api/usage
+    # aggregate — when DuckDB is unreachable, every other Usage-tab
+    # surface degrades the same way (anomalies, by-plugin, attribution),
+    # so a JSONL re-implementation here would be pure duplication.
+    return jsonify({"available": False, "reason": "no_data"})
 
 
 @bp_usage.route("/api/usage/export")

--- a/tests/test_usage_forecast_local_store_v3.py
+++ b/tests/test_usage_forecast_local_store_v3.py
@@ -1,0 +1,312 @@
+"""Synthetic safety net for /api/usage/forecast DuckDB fast path.
+
+Tier-1 surface #4 in the 2026-05-17 DuckDB coverage audit (issue #1565).
+``_try_local_store_usage_forecast`` projects current spend trajectory to
+end-of-month from the DuckDB ``events`` table — this file pins the v3
+event shape it must accept and guards the three failure modes the
+``feedback_usage_dedupe_pattern.md`` memory flagged:
+
+  1. Real v3 ``assistant`` + ``model.completed`` sibling pairs (every
+     billable turn emits both) must not double the projection.
+  2. Non-message rows that carry ``cost_usd`` (tool retries, fallback
+     turns) MUST be counted toward the projection. The fast path uses
+     ``query_aggregates`` first precisely because the splits walker
+     would silently drop them.
+  3. Zero events → ``available: False`` with ``_source: local_store``
+     still tagged so the audit canary fires.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _today_iso() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _wait_flush(store, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _build_app(tmp_path, monkeypatch, *, enable_fast_path: bool = True):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_READ", "1" if enable_fast_path else "0"
+    )
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Steer the daemon-proxy discovery away from a contributor's locally
+    # running clawmetry daemon. Without this, ``_ls_call`` proxies through
+    # ``~/.clawmetry/local_query.json`` and the daemon queries its OWN
+    # production DuckDB instead of our tmp_path fixture (issue #1538).
+    import routes.local_query as lq
+    monkeypatch.setattr(
+        lq, "_DISCOVERY_PATH", str(tmp_path / "no-such-discovery.json")
+    )
+    lq._invalidate_daemon_cache()
+
+    import routes.usage as usage_mod
+    importlib.reload(usage_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(usage_mod.bp_usage)
+    return a, ls, usage_mod
+
+
+@pytest.fixture
+def fast_path_app(tmp_path, monkeypatch):
+    a, ls, u = _build_app(tmp_path, monkeypatch, enable_fast_path=True)
+    yield a, ls, u
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def legacy_path_app(tmp_path, monkeypatch):
+    a, ls, u = _build_app(tmp_path, monkeypatch, enable_fast_path=False)
+    yield a, ls, u
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _ingest_v3_assistant(store, *, sid, ts, ev_id, cost_usd,
+                          input_tokens=6, output_tokens=7):
+    """Insert the ``assistant`` Anthropic-SDK envelope row that the daemon
+    writes for every real LLM turn (see ``clawmetry/sync.py``)."""
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "assistant",
+        "ts":         ts,
+        "data": {
+            "type":    "assistant",
+            "version": 3,
+            "message": {
+                "role":  "assistant",
+                "model": "claude-opus-4-7",
+                "type":  "message",
+                "usage": {
+                    "input_tokens":               input_tokens,
+                    "output_tokens":              output_tokens,
+                    "cache_read_input_tokens":    0,
+                    "cache_creation_input_tokens": 0,
+                },
+            },
+        },
+        "cost_usd":    cost_usd,
+        "token_count": input_tokens + output_tokens,
+        "model":       "claude-opus-4-7",
+    })
+
+
+def _ingest_v3_model_completed(store, *, sid, ts, ev_id, cost_usd,
+                                input_tokens=6, output_tokens=7):
+    """Slim ``model.completed`` sibling that races the ``assistant`` row
+    by ~100-300 ms. Both rows carry the same ``cost_usd``; the fast path
+    must dedupe so the forecast doesn't run 2× hot."""
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "model.completed",
+        "ts":         ts,
+        "data": {
+            "type":     "model.completed",
+            "modelId":  "claude-opus-4-7",
+            "provider": "claude-cli",
+        },
+        "cost_usd":    cost_usd,
+        "token_count": input_tokens + output_tokens,
+        "model":       "claude-opus-4-7",
+    })
+
+
+def _ingest_tool_result(store, *, sid, ts, ev_id, cost_usd=0.0):
+    """A non-billable-turn event row that may still carry cost (think
+    tool retries that the daemon stamps with a fallback price). Forecast
+    must include it — the splits-walker path silently drops these, which
+    is exactly the bug class ``feedback_usage_dedupe_pattern.md`` flags."""
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "tool.result",
+        "ts":         ts,
+        "data":       {"type": "tool.result", "tool_use_id": "toolu_x"},
+        "cost_usd":   cost_usd,
+        "token_count": 0,
+        "model":       "claude-opus-4-7",
+    })
+
+
+# ── canary: empty store ───────────────────────────────────────────────────
+
+def test_forecast_empty_store_still_tags_local_store(fast_path_app):
+    """Audit canary: a store that's been opened but holds zero usage
+    rows must still respond with the ``_source: 'local_store'`` tag
+    (and ``available: False``). Without the tag, the audit grep at
+    ``reference_duckdb_coverage_audit.md`` would mis-categorise the
+    surface as ``JSONL_FALLBACK_ONLY`` again."""
+    a, ls, _u = fast_path_app
+    # Touch the store so the DuckDB file exists on disk — without
+    # this the read-only opener returns None and the route falls
+    # through to the generic "no_data" reply (no canary).
+    _wait_flush(ls.get_store())
+
+    r = a.test_client().get("/api/usage/forecast")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"empty-store forecast lost the canary: {body!r}"
+    )
+    assert body.get("available") is False
+
+
+# ── happy path: 7-day linear projection ───────────────────────────────────
+
+def test_forecast_projects_seven_day_baseline(fast_path_app):
+    """Seven days of $1/day → daily_rate = $1, projection extends through
+    end-of-month."""
+    a, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    now = time.time()
+    for i in range(7):
+        _ingest_v3_assistant(
+            store,
+            sid=f"sess-day-{i}",
+            ts=_iso(now - i * 86400),
+            ev_id=f"asst-{i}",
+            cost_usd=1.0,
+        )
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/usage/forecast").get_json()
+    assert body["_source"] == "local_store"
+    assert body["available"] is True
+    # 7×$1 / 7 = $1.00/day
+    assert abs(body["daily_rate_usd"] - 1.0) < 0.01, body
+    assert body["window_days"] == 7
+    assert len(body["daily_window"]) == 7
+    # Projection >= cost_this_month (it adds days_remaining * rate on top).
+    assert body["projected_month_usd"] >= body["cost_this_month_usd"]
+
+
+# ── dedupe-pattern regression (feedback_usage_dedupe_pattern.md) ──────────
+
+def test_forecast_dedupes_v3_sibling_pairs(fast_path_app):
+    """Every real v3 LLM turn writes BOTH an ``assistant`` row and a
+    sibling ``model.completed`` row ~150 ms apart, BOTH stamped with the
+    same ``cost_usd``. A blind SUM doubles the projection. The fast path
+    uses ``query_aggregates`` which dedupes at SQL level — confirm the
+    forecast doesn't run 2× hot."""
+    a, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    today = _today_iso()
+    base = f"{today}T10:00"
+
+    # Seven days of one turn each, $0.50 per turn. Sibling-doubling
+    # would inflate to $1.00/day → projection 2×.
+    now = time.time()
+    for i in range(7):
+        sid = f"sess-pair-{i}"
+        ts = _iso(now - i * 86400)
+        _ingest_v3_assistant(
+            store, sid=sid, ts=ts, ev_id=f"a-{i}", cost_usd=0.50,
+        )
+        # Sibling ~150ms later (within the SQL dedupe window).
+        _ingest_v3_model_completed(
+            store, sid=sid, ts=ts, ev_id=f"mc-{i}", cost_usd=0.50,
+        )
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/usage/forecast").get_json()
+    assert body["_source"] == "local_store"
+    # Single-counted: 7×$0.50 / 7 = $0.50/day. Double-counted would
+    # be $1.00 — the canary that catches the bug class.
+    assert abs(body["daily_rate_usd"] - 0.50) < 0.01, (
+        f"sibling-pair double-count regression: daily_rate={body['daily_rate_usd']}"
+    )
+
+
+# ── dedupe-pattern regression: non-message rows must NOT be dropped ─────
+
+def test_forecast_counts_cost_from_non_message_rows(fast_path_app):
+    """``feedback_usage_dedupe_pattern.md``: the splits walker only knows
+    about billable-turn event types — it silently drops cost stamped on
+    ``tool.result`` / retry rows. The forecast helper uses
+    ``query_aggregates`` first (which covers ALL cost-bearing rows) so
+    those costs survive into the projection.
+    """
+    a, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    today = _today_iso()
+    base = f"{today}T10:00"
+
+    # One assistant turn at $0.10 + one tool.result that carries $0.05
+    # of fallback-pricing cost, every day for 7 days. Total daily = $0.15.
+    now = time.time()
+    for i in range(7):
+        ts_iso = _iso(now - i * 86400)
+        _ingest_v3_assistant(
+            store, sid=f"sess-nm-{i}", ts=ts_iso,
+            ev_id=f"asst-nm-{i}", cost_usd=0.10,
+        )
+        _ingest_tool_result(
+            store, sid=f"sess-nm-{i}", ts=_iso(now - i * 86400 + 30),
+            ev_id=f"tr-nm-{i}", cost_usd=0.05,
+        )
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/usage/forecast").get_json()
+    assert body["_source"] == "local_store"
+    # Daily rate must reflect BOTH the message AND tool.result costs.
+    # Splits-walker-only would return $0.10 — that's the silent drop bug.
+    assert abs(body["daily_rate_usd"] - 0.15) < 0.005, (
+        f"non-message cost rows silently dropped: daily_rate="
+        f"{body['daily_rate_usd']} (expected 0.15)"
+    )
+
+
+# ── gate: env flag OFF ────────────────────────────────────────────────────
+
+def test_forecast_falls_through_when_local_store_disabled(legacy_path_app):
+    """With ``CLAWMETRY_LOCAL_STORE_READ=0``, the fast path must be
+    skipped entirely — the response is the legacy ``available: False``
+    shape WITHOUT the canary tag (so the audit can see the gate is
+    respected)."""
+    a, _ls, _u = legacy_path_app
+
+    body = a.test_client().get("/api/usage/forecast").get_json()
+    assert body.get("_source") != "local_store", (
+        f"gate honoured? body={body!r}"
+    )
+    assert body.get("available") is False


### PR DESCRIPTION
## Summary

Tier-1 surface #4 from the 2026-05-17 DuckDB coverage audit (#1565). Migrates `GET /api/usage/forecast` from `JSONL_FALLBACK_ONLY` to `DUCKDB_FAST_PATH` by refactoring the inline handler into a canonical `_try_local_store_usage_forecast()` helper gated by `is_local_store_read_enabled()`.

- Routes the request through the same `_try_local_store_*` helper pattern as the rest of `routes/usage.py` so the audit canary (`_source: "local_store"` in the JSON body) is discoverable in browser devtools.
- Empty-store path keeps the `_source` tag set so the audit grep doesn't mis-categorise the endpoint as a fallback again.

## Shape verification

Real OpenClaw v3 emits BOTH an `assistant` row AND a sibling `model.completed` row ~100-300 ms apart for every billable turn, both stamped with the same `cost_usd`. Counting them both inflates the daily rate 2x and the projection 2x.

Source preference (per `feedback_usage_dedupe_pattern.md`):

1. `query_aggregates` first — SQL-side dedupe over EVERY cost-bearing row (billable turns AND non-message rows like `tool.result` retries that the daemon stamps with fallback pricing). The splits walker would silently drop those non-message rows; aggregates does not.
2. `query_daily_usage_splits` as a fresh-install fallback — covers the case where the daemon has only ingested events and not yet rolled aggregates.

## Tests

`tests/test_usage_forecast_local_store_v3.py` pins five invariants:

- Empty store still emits `_source: "local_store"` (canary).
- 7-day baseline projects daily_rate = sum/7 with `_source` tag.
- v3 `assistant + model.completed` sibling pairs collapse to one billable turn (no 2x doubling).
- Non-message `tool.result` rows that carry `cost_usd` ARE counted (catches the silent-drop bug class).
- `CLAWMETRY_LOCAL_STORE_READ=0` honoured (fast path skipped, no canary).

## Audit checkbox

Checks off `/api/usage/forecast` in the Tier-1 list in #1565 / `reference_duckdb_coverage_audit.md`.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `tests/test_moat_live_openclaw_e2e.py` + `tests/test_moat_send_message_e2e.py` + `tests/test_local_query_api.py` + `tests/test_usage_forecast_local_store_v3.py` all green (29 passed, 1 expected skip)
- [x] `tests/test_usage_local_store.py` still green (33 passed)
- [ ] Browser smoke: hit `/api/usage/forecast` on a live install with `CLAWMETRY_LOCAL_STORE_READ=1` (default), confirm `_source: "local_store"` in response.

Diff: 131 LOC production, 313 LOC tests.

Refs #1565.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>