### PR TITLE
feat(health): /api/rate-limits DuckDB fast path (refs #1565)

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -2138,10 +2138,181 @@ def api_heartbeat_ping():
     return jsonify({"ok": True})
 
 
+def _try_local_store_rate_limits():
+    """Fast path for /api/rate-limits — derive rolling 1m/1h utilisation
+    from the DuckDB ``events`` table instead of the per-process in-memory
+    ``metrics_store`` ring buffer.
+
+    Why the migration: the legacy handler aggregates only the LLM
+    token/cost events the *current dashboard process* witnessed via OTLP
+    + the in-process interceptor (see ``dashboard._record_token_event``
+    callers). On a fresh dashboard restart the buffer is empty and the
+    panel reads "0% utilisation" for several minutes until traffic
+    re-populates it; on multi-node fleets the buffer also misses spend
+    that landed on sibling nodes. The DuckDB ``events`` table is the
+    canonical, cross-process, cross-restart store — every cost-bearing
+    event the sync daemon ingests (Anthropic SDK echo, OpenClaw v3
+    ``model.completed`` bubbles, OTLP-relayed metrics) lands there with
+    a stable ``model``/``cost_usd``/``token_count`` column trio plus a
+    ``data`` blob carrying the raw ``usage`` dict for input/output
+    splits.
+
+    AUDIT FALSE-POSITIVE NOTE (refs #1565): Eng C's audit flagged this
+    route as "JSONL-fallback" but the actual legacy path is the
+    in-memory ``metrics_store`` (no JSONL walker). The migration is
+    still worth doing — promoting to the canonical DuckDB helper makes
+    the response visible to the audit canary (_source tag) and survives
+    dashboard restarts — but the audit row should be relabelled
+    "in-memory ring → DuckDB events" rather than "JSONL → DuckDB".
+
+    Returns ``None`` when the store is unreachable so the legacy
+    in-memory aggregation still serves. Returns a populated zero-shell
+    when the store is reachable but no cost-bearing events exist (fresh
+    install) — same shape the legacy handler emits for an empty buffer,
+    so the dashboard panel renders "no traffic" instantly instead of
+    waiting for the legacy path to confirm the same empty answer.
+    """
+    now = time.time()
+    one_min_ago = now - 60
+    one_hour_ago = now - 3600
+    since_iso = datetime.fromtimestamp(one_hour_ago, tz=timezone.utc).isoformat()
+
+    # query_events sorts newest-first and is bounded by the daemon-proxy
+    # row cap. 5k rows ≈ 80+ requests/min for a full hour — plenty of
+    # headroom while keeping the JSON payload modest. Anything older than
+    # 1h doesn't contribute to either rolling window.
+    rows = _ls_call("query_events", since=since_iso, limit=5000)
+    if rows is None:
+        return None
+
+    import dashboard as _d
+
+    # Buckets keyed by canonical provider name (anthropic/openai/google/...).
+    providers: dict = {}
+
+    def _get_p(prov):
+        if prov not in providers:
+            providers[prov] = {
+                'rpm_1m': 0, 'tokens_in_1m': 0, 'tokens_out_1m': 0,
+                'tokens_in_1h': 0, 'tokens_out_1h': 0,
+                'request_count_1h': 0, 'cost_1h': 0.0,
+                'models': set(),
+            }
+        return providers[prov]
+
+    def _row_ts_epoch(ev):
+        ts = ev.get("ts")
+        if isinstance(ts, (int, float)):
+            return float(ts)
+        try:
+            return datetime.fromisoformat(
+                str(ts).replace("Z", "+00:00")
+            ).timestamp()
+        except Exception:
+            return 0.0
+
+    # Event-type filter: only count cost/token-bearing turns. v3 real
+    # data emits ``model.completed`` and bare ``assistant`` (no synthetic
+    # ``message`` rows — per reference_openclaw_v3_event_types.md and
+    # feedback_synthetic_tests_missed_real_event_shape.md). Keep the
+    # legacy ``message`` string for synthetic harnesses.
+    BILLABLE_TYPES = {
+        "message", "assistant", "model.completed",
+        "subagent:assistant", "user",
+    }
+
+    for ev in rows:
+        et = (ev.get("event_type") or "").strip()
+        if et and et not in BILLABLE_TYPES:
+            continue
+        ts = _row_ts_epoch(ev)
+        if ts < one_hour_ago:
+            continue
+
+        # Extract input/output token splits. The ``token_count`` column
+        # is the SUM, the ``data`` blob carries the breakdown. Walk both
+        # the Anthropic-SDK echo shape (data.message.usage) AND the
+        # OpenClaw-native v3 shape (data.assistantMessage.usage) so we
+        # don't silently zero one or the other.
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        usage = {}
+        msg = data.get("message") if isinstance(data.get("message"), dict) else None
+        am = data.get("assistantMessage") if isinstance(data.get("assistantMessage"), dict) else None
+        if isinstance(msg, dict) and isinstance(msg.get("usage"), dict):
+            usage = msg["usage"]
+        elif isinstance(am, dict) and isinstance(am.get("usage"), dict):
+            usage = am["usage"]
+        elif isinstance(data.get("usage"), dict):
+            usage = data["usage"]
+        in_tok = int(usage.get("input_tokens") or usage.get("input") or 0)
+        out_tok = int(usage.get("output_tokens") or usage.get("output") or 0)
+        # Fall back to the coarse token_count column when the usage dict
+        # is missing entirely (e.g. legacy rows pre-v3).
+        total = int(ev.get("token_count") or 0)
+        if not (in_tok or out_tok) and total:
+            # Best-effort split: count as input (Anthropic-style prompt
+            # counts dominate). Better than zero.
+            in_tok = total
+            out_tok = 0
+
+        model = ev.get("model") or (data.get("model") if isinstance(data.get("model"), str) else "") or "unknown"
+        provider = _d._infer_provider({"provider": data.get("provider"), "model": model})
+
+        p = _get_p(provider)
+        p['models'].add(model)
+        if ts >= one_min_ago:
+            p['rpm_1m'] += 1
+            p['tokens_in_1m'] += in_tok
+            p['tokens_out_1m'] += out_tok
+        p['request_count_1h'] += 1
+        p['tokens_in_1h'] += in_tok
+        p['tokens_out_1h'] += out_tok
+        p['cost_1h'] += float(ev.get("cost_usd") or 0.0)
+
+    result = []
+    for prov, stats in sorted(providers.items()):
+        limits = _d._DEFAULT_RATE_LIMITS.get(
+            prov,
+            {'rpm': 60, 'tpm_input': 100_000, 'tpm_output': 20_000, 'label': prov.title()},
+        )
+        rpm_pct = round(stats['rpm_1m']        / limits['rpm']        * 100, 1) if limits['rpm']        else 0
+        in_pct  = round(stats['tokens_in_1m']  / limits['tpm_input']  * 100, 1) if limits['tpm_input']  else 0
+        out_pct = round(stats['tokens_out_1m'] / limits['tpm_output'] * 100, 1) if limits['tpm_output'] else 0
+        worst = max(rpm_pct, in_pct, out_pct)
+        result.append({
+            'provider': prov,
+            'label':    limits.get('label', prov.title()),
+            'models':   sorted(stats['models']),
+            'rpm':       {'current': stats['rpm_1m'],        'limit': limits['rpm'],        'pct': rpm_pct},
+            'tpm_input': {'current': stats['tokens_in_1m'],  'limit': limits['tpm_input'],  'pct': in_pct},
+            'tpm_output':{'current': stats['tokens_out_1m'], 'limit': limits['tpm_output'], 'pct': out_pct},
+            'hour': {
+                'requests':   stats['request_count_1h'],
+                'tokens_in':  stats['tokens_in_1h'],
+                'tokens_out': stats['tokens_out_1h'],
+                'cost_usd':   round(stats['cost_1h'], 4),
+            },
+            'utilization_pct': worst,
+            'status': 'red' if worst >= 90 else ('amber' if worst >= 70 else 'green'),
+        })
+
+    result.sort(key=lambda x: x['utilization_pct'], reverse=True)
+    return {
+        'providers': result,
+        'timestamp': now,
+        '_source': 'local_store',
+    }
+
+
 @bp_health.route('/api/rate-limits')
 def api_rate_limits():
     """Return rolling 1-minute and 1-hour API rate limit utilisation per provider."""
     import dashboard as _d
+    if is_local_store_read_enabled():
+        fast = _try_local_store_rate_limits()
+        if fast is not None:
+            return jsonify(fast)
+
     now = time.time()
     one_min_ago = now - 60
     one_hour_ago = now - 3600

--- a/tests/test_rate_limits_local_store_v3.py
+++ b/tests/test_rate_limits_local_store_v3.py
@@ -1,0 +1,317 @@
+"""Regression guard for /api/rate-limits DuckDB fast path (Tier-1 #1565).
+
+``routes/health.py:_try_local_store_rate_limits`` reads cost-bearing
+event rows out of DuckDB ``events`` (1h rolling window) and buckets
+rolling 1m / 1h utilisation per provider. Before the fast path, the
+route aggregated only the in-memory ``metrics_store`` ring buffer that
+the current dashboard *process* witnessed — empty after every restart
+and blind to spend that landed on sibling fleet nodes.
+
+This file seeds DuckDB events via ``LocalStore.ingest`` (the same write
+path ``clawmetry/sync.py`` uses) and asserts:
+
+1. Populated path — anthropic + openai events ingested → fast path
+   returns ``_source='local_store'``, splits into separate provider
+   buckets, and computes correct rpm/tokens_in/tokens_out + 1h rollups.
+2. Empty events table → handler returns the populated zero-shell
+   (``_source='local_store'``, providers=[]) instead of None, so the
+   panel renders "no traffic" instantly instead of waiting for the
+   legacy in-memory aggregation to confirm the same empty answer.
+3. v3 real-shape regression — the route MUST recognise OpenClaw v3
+   ``event_type='model.completed'`` rows with ``data.assistantMessage.usage``
+   (NOT the synthetic ``event_type='message'`` + ``data.message.usage``
+   shape that the original synthetic tests asserted on, per
+   feedback_synthetic_tests_missed_real_event_shape.md).
+4. Env gate honoured — with CLAWMETRY_LOCAL_STORE_READ=0 the fast path
+   helper isn't called by the route handler.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+import uuid
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.health as health_mod
+    importlib.reload(health_mod)
+
+    # Isolate from a contributor's running daemon (see Issue #1538 pattern in
+    # test_subagents_local_store_v3.py): without this, ``_ls_call`` proxies
+    # through ``~/.clawmetry/local_query.json`` and the daemon queries its
+    # OWN production DuckDB instead of our tmp_path fixture.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    # Dashboard module supplies _DEFAULT_RATE_LIMITS + _infer_provider used by
+    # the helper. Importing it once initialises module state used elsewhere.
+    import dashboard  # noqa: F401
+
+    a = Flask(__name__)
+    a.register_blueprint(health_mod.bp_health)
+    yield a, ls, health_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _now_iso():
+    from datetime import datetime, timezone
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _ingest_billable_event(store, *, model, provider, input_tokens, output_tokens, cost_usd, event_type="model.completed", ts=None, use_v3_shape=True):
+    """Helper to ingest a single billable event in the v3 OpenClaw shape.
+
+    The fast path walks BOTH the legacy ``data.message.usage`` shape (Anthropic
+    SDK echo) and the v3-native ``data.assistantMessage.usage`` shape — this
+    helper defaults to the v3 shape so tests catch the
+    feedback_synthetic_tests_missed_real_event_shape.md class of bug.
+    """
+    usage_key = "assistantMessage" if use_v3_shape else "message"
+    payload = {
+        "model": model,
+        "provider": provider,
+        usage_key: {"usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        }},
+    }
+    store.ingest({
+        "id":         f"evt-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "agent_type": "openclaw",
+        "agent_id":   "main",
+        "session_id": "sess-test",
+        "event_type": event_type,
+        "ts":         ts or _now_iso(),
+        "data":       payload,
+        "cost_usd":   cost_usd,
+        "token_count": input_tokens + output_tokens,
+        "model":      model,
+    })
+
+
+def test_rate_limits_local_store_tags_source_and_splits_providers(app):
+    """Multi-provider population: anthropic + openai events seeded → fast
+    path returns ``_source='local_store'`` and buckets each provider
+    separately with correct 1m + 1h numbers."""
+    a, ls, _health = app
+    store = ls.get_store()
+
+    # 3 recent Anthropic turns (all within the 1m window).
+    for i in range(3):
+        _ingest_billable_event(
+            store,
+            model="claude-opus-4-7",
+            provider="anthropic",
+            input_tokens=1000,
+            output_tokens=500,
+            cost_usd=0.045,
+        )
+    # 2 OpenAI turns (within 1m).
+    for i in range(2):
+        _ingest_billable_event(
+            store,
+            model="gpt-4o",
+            provider="openai",
+            input_tokens=2000,
+            output_tokens=400,
+            cost_usd=0.06,
+        )
+    # Public sync flush drains ring → DuckDB but keeps the singleton open
+    # so the subsequent ``_ls_call`` path can query the same handle.
+    store.flush()
+    assert len(store.query_events(limit=100)) == 5
+
+    r = a.test_client().get("/api/rate-limits")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"_source must be local_store; got {body.get('_source')!r}"
+    )
+    providers = {p["provider"]: p for p in body.get("providers") or []}
+    assert set(providers.keys()) == {"anthropic", "openai"}, (
+        f"expected separate buckets for each provider; got {set(providers.keys())!r}"
+    )
+
+    ant = providers["anthropic"]
+    assert ant["rpm"]["current"] == 3
+    assert ant["tpm_input"]["current"] == 3000   # 3 × 1000
+    assert ant["tpm_output"]["current"] == 1500  # 3 × 500
+    assert ant["hour"]["requests"] == 3
+    assert ant["hour"]["tokens_in"] == 3000
+    assert ant["hour"]["tokens_out"] == 1500
+    # Cost should be the sum across the 3 turns.
+    assert ant["hour"]["cost_usd"] == pytest.approx(0.135, abs=1e-6)
+
+    oai = providers["openai"]
+    assert oai["rpm"]["current"] == 2
+    assert oai["tpm_input"]["current"] == 4000   # 2 × 2000
+    assert oai["tpm_output"]["current"] == 800   # 2 × 400
+
+    # status colour ladder honours utilisation pct (green/amber/red).
+    for p in providers.values():
+        assert p["status"] in {"green", "amber", "red"}
+
+
+def test_rate_limits_local_store_empty_returns_zero_shell(app):
+    """Empty events table → fast path returns a populated zero-shell
+    (``_source='local_store'``, providers=[]) rather than None, so the
+    panel renders instantly instead of waiting for the slow legacy
+    fallback to confirm the same empty answer (feedback_daemon_proxy
+    pattern, mistake #2 — "Empty result is NOT a miss")."""
+    a, ls, health_mod = app
+    # Sanity: no events ingested.
+    assert ls.get_store().query_events(limit=10) == []
+
+    fast = health_mod._try_local_store_rate_limits()
+    assert fast is not None, (
+        "empty store must still tag _source=local_store to skip the slow legacy path"
+    )
+    assert fast.get("_source") == "local_store"
+    assert fast.get("providers") == []
+    assert "timestamp" in fast
+
+
+def test_rate_limits_local_store_recognises_v3_event_shape(app):
+    """v3 real-shape regression: real OpenClaw emits ``model.completed``
+    rows with usage under ``data.assistantMessage.usage``. The fast path
+    MUST count these — synthetic tests that filter on ``event_type='message'``
+    + ``data.message.usage`` silently drop them on real installs (per
+    feedback_synthetic_tests_missed_real_event_shape.md). One v3 row +
+    one legacy synthetic row → both end up in the bucket."""
+    a, ls, _health = app
+    store = ls.get_store()
+    _ingest_billable_event(
+        store,
+        model="claude-opus-4-7",
+        provider="anthropic",
+        input_tokens=1234,
+        output_tokens=567,
+        cost_usd=0.025,
+        event_type="model.completed",
+        use_v3_shape=True,  # data.assistantMessage.usage
+    )
+    _ingest_billable_event(
+        store,
+        model="claude-opus-4-7",
+        provider="anthropic",
+        input_tokens=100,
+        output_tokens=50,
+        cost_usd=0.004,
+        event_type="message",   # legacy synthetic harness
+        use_v3_shape=False,     # data.message.usage
+    )
+    store.flush()
+
+    r = a.test_client().get("/api/rate-limits")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    providers = {p["provider"]: p for p in body["providers"]}
+    ant = providers["anthropic"]
+    assert ant["rpm"]["current"] == 2, (
+        "BOTH the v3 and legacy event shapes must be counted; got "
+        f"rpm_1m={ant['rpm']['current']}"
+    )
+    assert ant["tpm_input"]["current"] == 1334   # 1234 + 100
+    assert ant["tpm_output"]["current"] == 617   # 567 + 50
+
+
+def test_rate_limits_local_store_ignores_non_billable_event_types(app):
+    """Tool calls / heartbeats / non-LLM events have no business in
+    rate-limit utilisation. They MUST be filtered out by the
+    billable-types allowlist even if they happen to carry a stray
+    ``token_count`` column (e.g. tool retries)."""
+    a, ls, _health = app
+    store = ls.get_store()
+    # Billable.
+    _ingest_billable_event(
+        store,
+        model="claude-opus-4-7",
+        provider="anthropic",
+        input_tokens=1000,
+        output_tokens=200,
+        cost_usd=0.02,
+    )
+    # Non-billable noise: tool_call with a token_count column (synthetic
+    # harnesses sometimes stamp this, real v3 doesn't — either way it's
+    # NOT an LLM turn and must not inflate rate-limit utilisation).
+    store.ingest({
+        "id":         f"evt-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "event_type": "tool_call",
+        "ts":         _now_iso(),
+        "data":       {"tool": "Read", "args": {"file_path": "/etc/hosts"}},
+        "cost_usd":   0.0,
+        "token_count": 9999,
+        "model":      "claude-opus-4-7",
+    })
+    store.flush()
+
+    r = a.test_client().get("/api/rate-limits")
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    ant = next(p for p in body["providers"] if p["provider"] == "anthropic")
+    assert ant["rpm"]["current"] == 1, (
+        "tool_call row must not be counted as an LLM request; got "
+        f"rpm_1m={ant['rpm']['current']}"
+    )
+    assert ant["tpm_input"]["current"] == 1000
+    assert ant["tpm_output"]["current"] == 200
+
+
+def test_rate_limits_env_gate_off_bypasses_fast_path(tmp_path, monkeypatch):
+    """With ``CLAWMETRY_LOCAL_STORE_READ=0`` the route MUST NOT call the
+    fast path — even if the store has cost-bearing events available.
+    Guards against accidental default-ON regressions
+    (feedback_local_store_default_off_killed_moat.md, inverse direction:
+    opt-OUT must work too)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.health as health_mod
+    importlib.reload(health_mod)
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    store = ls.get_store()
+    _ingest_billable_event(
+        store,
+        model="claude-opus-4-7",
+        provider="anthropic",
+        input_tokens=1000,
+        output_tokens=200,
+        cost_usd=0.02,
+    )
+    store.flush()
+
+    import dashboard  # noqa: F401
+    a = Flask(__name__)
+    a.register_blueprint(health_mod.bp_health)
+    r = a.test_client().get("/api/rate-limits")
+    assert r.status_code == 200
+    body = r.get_json()
+    # Legacy path doesn't tag _source — its absence proves the gate held.
+    assert "_source" not in body, (
+        "env-gate OFF must NOT take the local_store fast path; got "
+        f"body={body!r}"
+    )


### PR DESCRIPTION
## Summary

Tier-1 surface #10 from the 2026-05-17 DuckDB coverage audit ([#1565](https://github.com/vivekchand/clawmetry/issues/1565)).

Promotes `/api/rate-limits` to the canonical `_try_local_store_*` helper pattern gated by `is_local_store_read_enabled()`, tagging responses with `_source=local_store` so the audit canary can discover the route.

## Audit false-positive note (similar finding to Eng G on PR #1571)

Eng C's audit row labelled this route as **"JSONL-fallback"** but the actual legacy path reads the **in-memory `metrics_store` ring buffer** — there is no JSONL walker involved.

The migration is still worth doing:

- the per-process ring buffer is empty after every dashboard restart
- it is blind to spend that landed on sibling fleet nodes
- DuckDB events are cross-process and cross-restart

The audit row should be re-labelled `"in-memory ring → DuckDB events"` rather than `"JSONL → DuckDB"`.

## Implementation

- `routes/health.py` — new `_try_local_store_rate_limits()` helper, wired into `api_rate_limits()` behind the env gate. Reuses the existing `_ls_call` daemon-proxy shim and the shared `_DEFAULT_RATE_LIMITS` + `_infer_provider` helpers from `dashboard.py`.
- 171 LOC production diff (well under the 250 budget).

### Data source

`query_events` over the trailing 1h window, filtered to billable event types per `reference_openclaw_v3_event_types.md` and `feedback_synthetic_tests_missed_real_event_shape.md`:

```
message, assistant, model.completed, subagent:assistant, user
```

For each row we walk **both** the Anthropic-SDK echo shape (`data.message.usage`) **and** the OpenClaw-native v3 shape (`data.assistantMessage.usage`) so synthetic and real installs both produce non-zero token splits. Falls back to the coarse `token_count` column for legacy pre-v3 rows.

### Empty-store policy

Per `feedback_daemon_proxy_pattern.md` mistake #2: return a populated zero-shell tagged `_source=local_store` rather than `None` so the panel renders "no traffic" instantly instead of waiting for the legacy aggregation to confirm the same empty answer.

## Test plan

`tests/test_rate_limits_local_store_v3.py` — synthetic safety net + v3 real-shape regression:

- [x] multi-provider population splits into separate `anthropic` + `openai` buckets with correct 1m / 1h rollups
- [x] empty events table returns the populated zero-shell
- [x] v3 `model.completed` + `data.assistantMessage.usage` IS counted (the bug class behind #1385)
- [x] non-billable event types (`tool_call` etc.) are filtered out even when they carry a stray `token_count` column
- [x] env-gate OFF bypasses the fast path entirely

```
$ python3 -m pytest tests/test_moat_live_openclaw_e2e.py \
                   tests/test_moat_send_message_e2e.py \
                   tests/test_local_query_api.py \
                   tests/test_rate_limits_local_store_v3.py -q
29 passed, 1 skipped in 44.06s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)