### PR TITLE
feat(meta): /api/version-impact DuckDB fast path (refs #1565)

### DIFF
--- a/routes/meta.py
+++ b/routes/meta.py
@@ -729,12 +729,216 @@ def api_otel_status():
 # ── Version impact analysis ───────────────────────────────────────────────────
 
 
+def _ls_call(method_name, **kwargs):
+    """Cross-process LocalStore call with single-process fallback.
+
+    Mirrors ``routes/usage.py:_ls_call`` — daemon HTTP proxy first
+    (covers the standard install where the daemon owns the DuckDB writer
+    lock), then falls back to a direct read-only open for single-process
+    boots (tests + dev mode). Returns ``None`` on miss so callers defer
+    to the legacy SQLite + JSONL fallback path.
+    """
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+def _to_epoch(s):
+    """Parse an ISO-8601 timestamp string to a Unix epoch seconds float.
+
+    Returns 0.0 on failure so callers can sort/compare uniformly.
+    """
+    if not s:
+        return 0.0
+    if isinstance(s, (int, float)):
+        return float(s)
+    try:
+        return datetime.fromisoformat(
+            str(s).replace("Z", "+00:00")
+        ).timestamp()
+    except Exception:
+        return 0.0
+
+
+def _try_local_store_version_impact(current_version):
+    """DuckDB fast path for /api/version-impact (Tier-1 #1565).
+
+    Strategy:
+
+    1. Pull every ``session.started`` event (these carry ``data.version``
+       on real OpenClaw v3 installs — see
+       ``clawmetry/sync.py::_parse_v3_event`` and
+       ``reference_openclaw_v3_event_types.md``).
+    2. Group by version → earliest detection timestamp. That gives us the
+       same shape the legacy SQLite ``version_events`` table tracks
+       (version + detected_at), but derived from real session activity
+       rather than per-process polling. Replaces the JSONL re-walk that
+       happened on every request.
+    3. For each adjacent (prev, curr) version pair, aggregate per-session
+       stats (token spend, cost, tool-call count, error count, duration)
+       for sessions that started inside the version's active window.
+       Uses ``query_sessions`` (already sibling-pair deduped at the SQL
+       layer per issue #1460) for cost+tokens, and ``query_events`` for
+       tool/error counts.
+
+    Returns ``None`` when no ``session.started`` events carry a version
+    field — older installs / fresh DuckDB stores fall through to the
+    SQLite + JSONL legacy path so the route never regresses to empty.
+    """
+    started_rows = _ls_call("query_events", event_type="session.started", limit=5000)
+    if started_rows is None:
+        return None
+
+    # Group by version → (earliest_ts, session_ids_seen).
+    versions_seen: dict[str, dict] = {}
+    for row in started_rows:
+        data = row.get("data") if isinstance(row.get("data"), dict) else {}
+        version = (data.get("version") or data.get("openclawVersion")
+                   or data.get("openclaw_version"))
+        if not version:
+            continue
+        version = str(version)
+        ts_epoch = _to_epoch(row.get("ts"))
+        if ts_epoch <= 0:
+            continue
+        entry = versions_seen.setdefault(version, {"earliest": ts_epoch, "sids": set()})
+        if ts_epoch < entry["earliest"]:
+            entry["earliest"] = ts_epoch
+        sid = row.get("session_id")
+        if sid:
+            entry["sids"].add(sid)
+
+    if not versions_seen:
+        # No version-bearing events — defer to SQLite/JSONL fallback.
+        return None
+
+    # Sort versions by earliest-detected ascending — matches the legacy
+    # SQLite ``version_events`` ORDER BY detected_at ASC.
+    version_order = sorted(versions_seen.items(), key=lambda kv: kv[1]["earliest"])
+    now_ts = time.time()
+
+    def _summarise_range(start_ts, end_ts):
+        """Aggregate per-session metrics for sessions started in [start, end)."""
+        since_iso = datetime.fromtimestamp(start_ts, tz=timezone.utc).isoformat()
+        until_iso = datetime.fromtimestamp(end_ts, tz=timezone.utc).isoformat()
+        sessions = _ls_call("query_sessions", since=since_iso, until=until_iso,
+                            limit=10000) or []
+        # tool/error counts come from the raw events table (query_sessions
+        # gives us deduped cost+tokens but not tool-call frequency).
+        events = _ls_call("query_events", since=since_iso, until=until_iso,
+                          limit=20000) or []
+        tool_types = {"tool_call", "tool.call", "toolCall", "tool_use"}
+        error_types = {"error", "session.error", "model.error"}
+        per_sid_tools: dict[str, int] = {}
+        per_sid_errors: dict[str, int] = {}
+        for ev in events:
+            sid = ev.get("session_id")
+            if not sid:
+                continue
+            et = ev.get("event_type") or ""
+            if et in tool_types:
+                per_sid_tools[sid] = per_sid_tools.get(sid, 0) + 1
+            elif et in error_types:
+                per_sid_errors[sid] = per_sid_errors.get(sid, 0) + 1
+
+        total_cost = 0.0
+        total_tokens = 0
+        total_tools = 0
+        total_errors = 0
+        duration_ms_total = 0
+        duration_sessions = 0
+        session_count = 0
+        for s in sessions:
+            sid = s.get("session_id")
+            if not sid:
+                continue
+            session_count += 1
+            total_cost += float(s.get("cost_usd") or 0.0)
+            total_tokens += int(s.get("token_count") or 0)
+            total_tools += per_sid_tools.get(sid, 0)
+            total_errors += per_sid_errors.get(sid, 0)
+            start_s = _to_epoch(s.get("started_at"))
+            end_s = _to_epoch(s.get("updated_at"))
+            if start_s and end_s and end_s > start_s:
+                duration_ms_total += int((end_s - start_s) * 1000)
+                duration_sessions += 1
+        return {
+            "session_count": session_count,
+            "total_cost": total_cost,
+            "total_tokens": total_tokens,
+            "error_count": total_errors,
+            "tool_calls": total_tools,
+            "duration_ms_total": duration_ms_total,
+            "duration_sessions": duration_sessions,
+        }
+
+    import dashboard as _d
+    transitions = []
+    version_history = []
+
+    for i, (version, info) in enumerate(version_order):
+        start_ts = info["earliest"]
+        end_ts = (version_order[i + 1][1]["earliest"]
+                  if i + 1 < len(version_order) else now_ts)
+        version_history.append({
+            "version": version,
+            "detected_at": datetime.fromtimestamp(
+                start_ts, tz=timezone.utc
+            ).isoformat(),
+        })
+        if i == 0:
+            continue
+        prev_version, prev_info = version_order[i - 1]
+        before = _d._stats_to_summary(
+            _summarise_range(prev_info["earliest"], start_ts))
+        after = _d._stats_to_summary(_summarise_range(start_ts, end_ts))
+        transitions.append({
+            "from_version": prev_version,
+            "to_version": version,
+            "upgraded_at": datetime.fromtimestamp(
+                start_ts, tz=timezone.utc
+            ).isoformat(),
+            "before": before,
+            "after": after,
+            "diff": _d._compute_diff(before, after),
+        })
+
+    return {
+        "current_version": (current_version
+                            or version_order[-1][0]
+                            or "unknown"),
+        "version_detected": bool(current_version),
+        "version_history": version_history,
+        "transitions": transitions,
+        "_source": "local_store",
+    }
+
+
 @bp_version_impact.route("/api/version-impact")
 def api_version_impact():
     """Return version transition list with before/after metric comparisons."""
     import dashboard as _d
     current_version = _d._get_openclaw_version()
     _d._record_version_if_changed(current_version)
+
+    # DuckDB fast path: derive version timeline + per-version stats from
+    # session.started events in the local store. Returns None on fresh
+    # installs / pre-v3 data so the legacy SQLite + JSONL walker stays
+    # the canonical fallback.
+    if is_local_store_read_enabled():
+        fast = _try_local_store_version_impact(current_version)
+        if fast is not None:
+            return jsonify(fast)
 
     db = _d._version_impact_db()
     try:

--- a/tests/test_version_impact_local_store_v3.py
+++ b/tests/test_version_impact_local_store_v3.py
@@ -1,0 +1,298 @@
+"""Regression guard for /api/version-impact DuckDB fast path (Tier-1 #1565).
+
+``routes/meta.py:_try_local_store_version_impact`` derives the
+version timeline + per-version aggregates from ``session.started``
+events in the local DuckDB store. Before the fast path, every request
+re-walked every session JSONL on disk (`_compute_session_stats_in_range`
+in ``dashboard.py``) AND read the per-process SQLite ``version_events``
+table — both of which scale poorly once a user has hundreds of sessions
+or has bounced between several OpenClaw releases.
+
+This file seeds DuckDB with the SAME daemon-normalised event shapes the
+OSS sync daemon writes for real OpenClaw v3 sessions (see
+``clawmetry/sync.py::_parse_v3_event`` + reference_openclaw_v3_event_types.md)
+and asserts:
+
+1. An empty local store falls through to the legacy SQLite path.
+2. A populated store with two distinct versions hydrates ``transitions``
+   tagged with ``_source: 'local_store'`` and the per-version aggregates
+   reflect the seeded rows.
+3. Sessions are correctly partitioned into the version window they
+   started in.
+4. The env-gate is honoured — fast path stays dormant when
+   CLAWMETRY_LOCAL_STORE_READ is off.
+5. ``session.started`` rows missing the version field are skipped
+   gracefully (older installs / partial data).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+import uuid
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    # Point the legacy SQLite version_events table at the tmp dir so a
+    # contributor's real ``~/.clawmetry/history.db`` doesn't leak version
+    # rows into the test fixture.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.meta as meta_mod
+    importlib.reload(meta_mod)
+
+    # Issue #1538 pattern: isolate fixture from a developer's locally-
+    # running clawmetry daemon (otherwise ``_ls_call`` proxies through
+    # ``~/.clawmetry/local_query.json`` and queries the daemon's
+    # production DuckDB instead of our tmp_path fixture — seeded rows
+    # become invisible to the fast path).
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    a = Flask(__name__)
+    a.register_blueprint(meta_mod.bp_version_impact)
+    yield a, ls, meta_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _drain(store):
+    store._flush_now()
+    for _ in range(10):
+        if not store._ring:
+            break
+        time.sleep(0.05)
+
+
+def _started_event(sid, ts, version):
+    """A ``session.started`` row matching what
+    ``clawmetry/sync.py::_parse_v3_event`` produces for v3 sessions."""
+    return {
+        "id":          str(uuid.uuid4()),
+        "node_id":     "node-test",
+        "agent_type":  "openclaw",
+        "agent_id":    "main",
+        "session_id":  sid,
+        "workspace_id": None,
+        "event_type":  "session.started",
+        "ts":          ts,
+        "data":        json.dumps({
+            "_v3_type": "session",
+            "type":     "session.started",
+            "id":       sid,
+            "version":  version,
+            "cwd":      "/tmp/wks",
+            "timestamp": ts,
+        }),
+    }
+
+
+def _assistant_event(sid, ts, *, cost_usd=0.0, token_count=0):
+    """An assistant turn — cost + token bookkeeping. ``query_sessions``
+    SQL-side dedupe handles sibling-pair collapsing per issue #1460."""
+    return {
+        "id":          str(uuid.uuid4()),
+        "node_id":     "node-test",
+        "agent_type":  "openclaw",
+        "agent_id":    "main",
+        "session_id":  sid,
+        "workspace_id": None,
+        "event_type":  "assistant",
+        "ts":          ts,
+        "data":        json.dumps({
+            "_v3_type": "message",
+            "type":     "model.completed",
+            "modelId":  "claude-opus-4-7",
+        }),
+        "cost_usd":    cost_usd,
+        "token_count": token_count,
+        "model":       "claude-opus-4-7",
+    }
+
+
+def _tool_call_event(sid, ts):
+    return {
+        "id":          str(uuid.uuid4()),
+        "node_id":     "node-test",
+        "agent_type":  "openclaw",
+        "agent_id":    "main",
+        "session_id":  sid,
+        "workspace_id": None,
+        "event_type":  "tool_call",
+        "ts":          ts,
+        "data":        json.dumps({"tool_name": "Read"}),
+    }
+
+
+def test_empty_store_falls_through_to_legacy_path(app, monkeypatch):
+    """No session.started rows → fast path returns None → caller
+    serves the legacy SQLite envelope (or the "no version history" stub
+    when SQLite is empty too)."""
+    a, _ls, meta_mod = app
+    # Pin the legacy version probe so we don't shell out to ``openclaw``
+    # during the test. Empty SQLite + empty DuckDB should produce the
+    # canonical "no history yet" envelope WITHOUT the _source tag.
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_get_openclaw_version", lambda: None)
+
+    r = a.test_client().get("/api/version-impact")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    # Legacy path's signature: no _source tag.
+    assert "_source" not in body, (
+        f"empty store must not tag _source=local_store; got {body!r}"
+    )
+    assert body.get("current_version") == "unknown"
+    assert body.get("transitions") == []
+
+
+def test_populated_store_tags_local_store_source(app, monkeypatch):
+    """Two distinct versions seeded → fast path returns ``_source='local_store'``
+    with a transition between them, and per-version aggregates reflect
+    the seeded cost + token totals."""
+    a, ls, meta_mod = app
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_get_openclaw_version", lambda: "2026.5.13")
+    monkeypatch.setattr(_d, "_record_version_if_changed", lambda v: None)
+
+    store = ls.get_store()
+    # ── v1: 2026.5.12 — 2 sessions, modest spend.
+    store.ingest(_started_event("sess-v1-a", "2026-05-15T10:00:00Z", "2026.5.12"))
+    store.ingest(_assistant_event("sess-v1-a", "2026-05-15T10:00:05Z",
+                                  cost_usd=0.010, token_count=1000))
+    store.ingest(_tool_call_event("sess-v1-a", "2026-05-15T10:00:06Z"))
+    store.ingest(_assistant_event("sess-v1-a", "2026-05-15T10:00:15Z",
+                                  cost_usd=0.020, token_count=2000))
+
+    store.ingest(_started_event("sess-v1-b", "2026-05-15T11:00:00Z", "2026.5.12"))
+    store.ingest(_assistant_event("sess-v1-b", "2026-05-15T11:00:05Z",
+                                  cost_usd=0.030, token_count=3000))
+
+    # ── v2: 2026.5.13 — 1 session, lower per-session spend.
+    store.ingest(_started_event("sess-v2-a", "2026-05-16T10:00:00Z", "2026.5.13"))
+    store.ingest(_assistant_event("sess-v2-a", "2026-05-16T10:00:05Z",
+                                  cost_usd=0.005, token_count=500))
+    store.ingest(_tool_call_event("sess-v2-a", "2026-05-16T10:00:06Z"))
+    store.ingest(_tool_call_event("sess-v2-a", "2026-05-16T10:00:07Z"))
+    _drain(store)
+
+    r = a.test_client().get("/api/version-impact")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"_source must be local_store on populated store; got {body.get('_source')!r}"
+    )
+    # Version history is ordered earliest-detected first.
+    history = body.get("version_history") or []
+    assert [h["version"] for h in history] == ["2026.5.12", "2026.5.13"], (
+        f"version history mis-ordered: {history!r}"
+    )
+    # Exactly one transition (v1 → v2).
+    transitions = body.get("transitions") or []
+    assert len(transitions) == 1, (
+        f"expected 1 transition, got {len(transitions)}: {transitions!r}"
+    )
+    t = transitions[0]
+    assert t["from_version"] == "2026.5.12"
+    assert t["to_version"] == "2026.5.13"
+    # Before bucket = v1 = 2 sessions, $0.060 total.
+    assert t["before"]["session_count"] == 2, t["before"]
+    assert t["before"]["total_cost"] == pytest.approx(0.060, rel=1e-3), t["before"]
+    # After bucket = v2 = 1 session, $0.005 total.
+    assert t["after"]["session_count"] == 1, t["after"]
+    assert t["after"]["total_cost"] == pytest.approx(0.005, rel=1e-3), t["after"]
+    # Tool-call counts surface in avg_tool_calls.
+    assert t["before"]["avg_tool_calls"] == pytest.approx(0.5, rel=1e-3), t["before"]
+    assert t["after"]["avg_tool_calls"] == pytest.approx(2.0, rel=1e-3), t["after"]
+    # Diff carries the percentage drop in avg_cost.
+    diff = t.get("diff") or {}
+    assert "avg_cost" in diff
+    assert diff["avg_cost"]["before"] > 0
+    assert diff["avg_cost"]["after"] > 0
+
+
+def test_env_gate_skips_fast_path(app, monkeypatch):
+    """With ``CLAWMETRY_LOCAL_STORE_READ`` off the fast path must NOT
+    fire even when DuckDB has rows — preserves the opt-out for users
+    who hit a regression."""
+    a, ls, meta_mod = app
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_get_openclaw_version", lambda: None)
+    monkeypatch.setattr(_d, "_record_version_if_changed", lambda v: None)
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")
+
+    store = ls.get_store()
+    store.ingest(_started_event("sess-x", "2026-05-15T10:00:00Z", "2026.5.12"))
+    _drain(store)
+
+    r = a.test_client().get("/api/version-impact")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert "_source" not in body, (
+        f"env-gate off must NOT tag _source; got {body!r}"
+    )
+
+
+def test_session_started_without_version_skipped(app, monkeypatch):
+    """Some pre-v3 / partial-write rows lack ``data.version``. The fast
+    path must skip them — never crash, never spawn an "unknown" bucket.
+    If NO row carries a version the helper must return None so the
+    legacy path serves the response."""
+    a, ls, meta_mod = app
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_get_openclaw_version", lambda: None)
+    monkeypatch.setattr(_d, "_record_version_if_changed", lambda v: None)
+
+    store = ls.get_store()
+    # session.started without a version field — older installs.
+    no_version = _started_event("sess-noversion", "2026-05-15T10:00:00Z", "")
+    blob = json.loads(no_version["data"])
+    blob.pop("version", None)
+    no_version["data"] = json.dumps(blob)
+    store.ingest(no_version)
+    _drain(store)
+
+    r = a.test_client().get("/api/version-impact")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    # All rows lacked version → fast path bailed → legacy envelope (no _source).
+    assert "_source" not in body
+    assert body.get("transitions") == []
+
+
+def test_single_version_yields_no_transitions(app, monkeypatch):
+    """Only one version observed → version_history populated but no
+    transitions (consistent with the legacy SQLite path's first-version
+    behaviour). _source must still be tagged so the dashboard knows the
+    DuckDB pipeline served the response."""
+    a, ls, meta_mod = app
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_get_openclaw_version", lambda: "2026.5.12")
+    monkeypatch.setattr(_d, "_record_version_if_changed", lambda v: None)
+
+    store = ls.get_store()
+    store.ingest(_started_event("sess-only", "2026-05-15T10:00:00Z", "2026.5.12"))
+    store.ingest(_assistant_event("sess-only", "2026-05-15T10:00:05Z",
+                                  cost_usd=0.01, token_count=100))
+    _drain(store)
+
+    r = a.test_client().get("/api/version-impact")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert len(body.get("version_history") or []) == 1
+    assert body.get("transitions") == []
+    assert body.get("current_version") == "2026.5.12"


### PR DESCRIPTION
## Summary

Tier-1 surface #14 from the 2026-05-17 DuckDB coverage audit (refs #1565). Migrates `/api/version-impact` from its SQLite-`version_events` + per-request JSONL re-walk to a DuckDB fast path that derives both the version timeline AND per-version aggregates from `session.started` events the OSS sync daemon already writes for every v3 session.

- New helper `_try_local_store_version_impact()` in `routes/meta.py`. Gated by `is_local_store_read_enabled()`. Returns `None` (-> legacy fallback) when no `session.started` rows carry `data.version` (older installs / pre-v3 / empty store).
- Tags `_source: 'local_store'` on the response envelope per the audit-canary convention Eng E/F/G's recent PRs (#1569, #1570, #1571) follow.
- Per-version stats use `query_sessions` for cost+tokens (sibling-pair deduped at the SQL layer per issue #1460) and `query_events` for tool-call / error counts.

## Audit-source verification

Per Eng G's PR #1571 finding on `/api/usage/forecast` (already DuckDB-only), I checked whether `/api/version-impact` was a false positive too. It is **not** — the current handler in `routes/meta.py:732` walks SQLite `version_events` and calls `_compute_session_stats_in_range` which `os.listdir`'s the JSONL sessions dir on every request. Migration is real.

## Production diff

`routes/meta.py` +204 LOC (under the 250 LOC cap). Test file +298 LOC (additive). Zero changes outside `routes/meta.py` + the new test file.

## Test plan

- [x] `python3 -c "import dashboard"` clean.
- [x] `python3 -m pytest tests/test_moat_live_openclaw_e2e.py tests/test_moat_send_message_e2e.py tests/test_local_query_api.py tests/test_version_impact_local_store_v3.py -q` -> 29 passed, 1 skipped.
- [x] New test file covers: empty store fall-through, populated store tagging, version-less rows skipped, env-gate respected, single-version (no transition) edge case.
- [ ] Live smoke on real `~/.openclaw/.clawmetry/clawmetry.duckdb` after merge (per `feedback_synthetic_tests_missed_real_event_shape.md`).

Refs #1565.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>