### PR TITLE
feat(usage): /api/token-velocity DuckDB fast path (refs #1565)

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -1031,6 +1031,145 @@ def _apply_oss_24h_cap(result):
     return capped
 
 
+def _try_local_store_token_velocity():
+    """Fast path for /api/token-velocity (issue #1565, Tier-1).
+
+    Reads the last ~5 min of events from DuckDB and computes:
+      * ``velocity_2min`` — total tokens billed across the trailing 2-min
+        window (deduped via ``build_sibling_bucket_max`` so v3 sibling
+        pairs aren't counted twice — same risk as
+        ``feedback_usage_dedupe_pattern.md``).
+      * ``flagged_sessions`` — per-session 2-min token burn + tool-chain
+        length. A session is flagged when ``tokens_2min >= WARN_TOKENS``
+        OR ``tool_chain_len >= CRIT_TOOLS``.
+      * ``cost_per_min`` — projected USD/min from the 2-min total.
+
+    Tool-chain length: count the longest consecutive run of tool-call /
+    assistant events within the last 2 min per session, broken by a
+    user-prompt row (matches the legacy JSONL heuristic).
+
+    Returns ``None`` when the store isn't reachable OR when zero events
+    are present in the trailing 5-min window — the legacy JSONL walker
+    is cheap on a quiet system (mtime filter skips every file with no
+    recent writes) so we don't try to short-circuit it with a zero shell.
+    """
+    from datetime import datetime, timezone
+
+    store = _ls_get_store()
+    if store is None:
+        return None
+
+    WARN_TOKENS = 8000
+    CRIT_TOKENS = 15000
+    CRIT_TOOLS = 20
+
+    now = time.time()
+    window_2min = now - 120
+    # Pull 5 min of context so the tool-chain walker has enough history
+    # for the consecutive-run heuristic without re-fetching.
+    since_iso = datetime.fromtimestamp(now - 300, tz=timezone.utc).isoformat()
+
+    try:
+        rows = store.query_events(since=since_iso, limit=5000) or []
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    # Sort ascending by ts so the consecutive-tool walker sees rows in
+    # write order (query_events returns DESC). Stable on equal ts.
+    def _ts_sec(r):
+        ts = r.get("ts") or ""
+        if not isinstance(ts, str):
+            return 0.0
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+        except Exception:
+            return 0.0
+
+    rows.sort(key=_ts_sec)
+
+    # Dedupe sibling pairs (assistant + model.completed) — same pattern
+    # as _try_local_store_usage to avoid double-counting v3 tokens.
+    bucket_max = build_sibling_bucket_max(rows)
+
+    # Event types that count as "tool / assistant" rows for the
+    # consecutive-chain heuristic. ``prompt.submitted`` / user rows reset
+    # the run. Tool-call alternates cover legacy + v3 daemon names.
+    _CHAIN_TYPES = frozenset({
+        "assistant", "model.completed", "tool.call", "tool_call",
+        "tool.result", "tool_use_result", "message",
+    })
+    _RESET_TYPES = frozenset({"prompt.submitted", "user"})
+
+    per_session: dict = {}
+    for r in rows:
+        sid = r.get("session_id") or ""
+        if not sid:
+            continue
+        et = (r.get("event_type") or "").strip()
+        ts = _ts_sec(r)
+        slot = per_session.setdefault(sid, {
+            "tokens_2min": 0, "consecutive": 0, "max_chain": 0,
+        })
+        # Chain bookkeeping always runs (over the full 5-min window so
+        # the run survives a tool burst that started >2 min ago).
+        if et in _RESET_TYPES:
+            slot["consecutive"] = 0
+        elif et in _CHAIN_TYPES:
+            data = r.get("data") if isinstance(r.get("data"), dict) else {}
+            role = data.get("role") if isinstance(data, dict) else None
+            if et == "message" and role == "user":
+                slot["consecutive"] = 0
+            else:
+                slot["consecutive"] += 1
+                if slot["consecutive"] > slot["max_chain"]:
+                    slot["max_chain"] = slot["consecutive"]
+        # Token accumulation only inside the 2-min window, deduped.
+        if ts >= window_2min and not is_sibling_dup(r, bucket_max):
+            tok = int(r.get("token_count") or 0)
+            if tok > 0:
+                slot["tokens_2min"] += tok
+
+    try:
+        import dashboard as _d
+        usd_per_token = _d._estimate_usd_per_token()
+    except Exception:
+        usd_per_token = 0.0
+
+    total_tokens_2min = 0
+    flagged: list = []
+    for sid, slot in per_session.items():
+        tokens_2min = int(slot["tokens_2min"])
+        max_chain = int(slot["max_chain"])
+        total_tokens_2min += tokens_2min
+        if tokens_2min >= WARN_TOKENS or max_chain >= CRIT_TOOLS:
+            sess_cpm = round(tokens_2min / 2 * usd_per_token, 5)
+            flagged.append({
+                "id":               sid,
+                "tokens_2min":      tokens_2min,
+                "tool_chain_len":   max_chain,
+                "cost_per_min":     sess_cpm,
+            })
+
+    if (total_tokens_2min >= CRIT_TOKENS
+            or any(s["tool_chain_len"] >= CRIT_TOOLS for s in flagged)):
+        level = "critical"
+    elif total_tokens_2min >= WARN_TOKENS:
+        level = "warning"
+    else:
+        level = "ok"
+
+    return {
+        "alert":            level != "ok",
+        "level":            level,
+        "velocity_2min":    total_tokens_2min,
+        "cost_per_min":     round(total_tokens_2min / 2 * usd_per_token, 5),
+        "flagged_sessions": flagged,
+        "_source":          "local_store",
+    }
+
+
 @bp_usage.route("/api/usage")
 def api_usage():
     """Token/cost tracking from transcript files - Enhanced OTLP workaround."""
@@ -2306,8 +2445,19 @@ def api_token_velocity():
     Thresholds:
       warning:  velocity_2min >= 8000
       critical: velocity_2min >= 15000 OR tool_chain_len >= 20
+
+    Issue #1565 (Tier-1): under ``is_local_store_read_enabled()`` the
+    handler now serves from the DuckDB ``events`` table via
+    ``_try_local_store_token_velocity`` (tagged ``_source: 'local_store'``
+    so the audit canary is discoverable). Falls back to the JSONL scan
+    below when the store is empty or unreachable.
     """
     import dashboard as _d
+
+    if is_local_store_read_enabled():
+        fast = _try_local_store_token_velocity()
+        if fast is not None:
+            return jsonify(fast)
 
     WARN_TOKENS   = 8000
     CRIT_TOKENS   = 15000

--- a/tests/test_token_velocity_local_store_v3.py
+++ b/tests/test_token_velocity_local_store_v3.py
@@ -1,0 +1,256 @@
+"""Synthetic safety net for /api/token-velocity DuckDB fast path
+(Tier-1 surface #5 in issue #1565).
+
+``routes/usage.py::_try_local_store_token_velocity`` reads the trailing
+~5 min of events from DuckDB to detect runaway agent loops without
+walking N session JSONLs on every poll (the legacy path opens every
+file mtime'd within 5 min — up to 20 files per request).
+
+This file seeds DuckDB with the SAME daemon-normalised event shapes the
+OSS sync daemon writes for real OpenClaw v3 sessions
+(``reference_openclaw_v3_event_types.md``) and asserts:
+
+1. Populated store within the 2-min window returns ``_source='local_store'``
+   with summed tokens, alert level, and flagged sessions.
+2. Empty store returns None so the legacy JSONL fallback fires for
+   fresh installs whose daemon hasn't ingested anything yet.
+3. Reachable store with rows but none in the trailing 5 min returns
+   None — the legacy JSONL walker is cheap on a quiet system (mtime
+   filter skips every file with no recent writes) so we don't try to
+   short-circuit it with a zero shell.
+4. Dedupe-pattern guard: a v3 sibling pair (``assistant`` + sibling
+   ``model.completed`` ~100ms apart with identical ``token_count``)
+   must NOT double-count. Same risk class as
+   ``feedback_usage_dedupe_pattern.md`` (Eng G hit it on
+   /api/usage/forecast in PR #1571).
+5. Tool-chain length: a long run of tool.call rows on one session
+   trips ``level=critical`` even when token volume alone is low —
+   matches the legacy ``CRIT_TOOLS=20`` rule.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.usage as usage_mod
+    importlib.reload(usage_mod)
+
+    # Issue #1538 pattern: isolate fixture from a developer's locally
+    # running clawmetry daemon. Without this, ``_ls_call`` proxies through
+    # ``~/.clawmetry/local_query.json`` and queries the daemon's
+    # production DuckDB instead of our tmp_path fixture, so seeded rows
+    # are invisible to the fast path.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    a = Flask(__name__)
+    a.register_blueprint(usage_mod.bp_usage)
+    yield a, ls, usage_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _drain(store):
+    store._flush_now()
+    for _ in range(20):
+        if not store._ring:
+            break
+        time.sleep(0.05)
+
+
+def _iso(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()
+
+
+def _row(event_id, sid, event_type, ts, data, **extra):
+    """Build a DuckDB events row matching what
+    ``clawmetry/sync.py::_parse_v3_event`` produces for v3 sessions."""
+    base = {
+        "id":           event_id,
+        "node_id":      "node-test",
+        "agent_type":   "openclaw",
+        "agent_id":     "main",
+        "session_id":   sid,
+        "workspace_id": None,
+        "event_type":   event_type,
+        "ts":           ts,
+        "data":         json.dumps(data),
+    }
+    base.update(extra)
+    return base
+
+
+def test_populated_store_returns_local_store_source(app):
+    """A single hot session burning >WARN_TOKENS in the trailing 2 min
+    should surface ``_source='local_store'`` + a populated
+    ``flagged_sessions`` list with the right token total."""
+    a, ls, _usage = app
+    store = ls.get_store()
+    sid = "sess-velocity-hot"
+    now = time.time()
+
+    # Three model.completed events within the last 2 min, ~3000 tok each
+    # → 9000 total → trips WARN_TOKENS (8000) but not CRIT_TOKENS (15000).
+    for i, dt in enumerate([90, 60, 30]):
+        store.ingest(_row(
+            f"e{i}", sid, "model.completed", _iso(now - dt),
+            {"_v3_type": "message", "type": "model.completed",
+             "provider": "anthropic", "modelId": "claude-opus-4-7"},
+            cost_usd=0.012, token_count=3000, model="claude-opus-4-7",
+        ))
+    _drain(store)
+
+    r = a.test_client().get("/api/token-velocity")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"_source must be local_store; got {body.get('_source')!r}"
+    )
+    assert body.get("velocity_2min") == 9000, (
+        f"expected 9000 tokens in 2-min window, got {body.get('velocity_2min')}"
+    )
+    assert body.get("level") == "warning", (
+        f"9000 tokens should bucket as warning; got {body.get('level')!r}"
+    )
+    assert body.get("alert") is True
+    flagged = body.get("flagged_sessions") or []
+    assert len(flagged) == 1
+    assert flagged[0]["id"] == sid
+    assert flagged[0]["tokens_2min"] == 9000
+
+
+def test_empty_store_returns_none_for_legacy_fallback(app):
+    """No rows at all → helper returns None so the legacy JSONL walker
+    fires. Critical for fresh installs whose daemon hasn't snapshotted
+    anything yet — without this guard, brand-new dashboards would
+    silently render an empty velocity panel even when session JSONLs
+    on disk DO contain recent activity."""
+    a, ls, usage_mod = app
+    # Sanity: store is empty.
+    assert ls.get_store().query_events(limit=10) == []
+
+    fast = usage_mod._try_local_store_token_velocity()
+    assert fast is None, (
+        f"empty store must return None for legacy fallback; got {fast!r}"
+    )
+
+
+def test_store_with_only_old_events_returns_none(app):
+    """Store has rows but ALL of them are >5 min old → helper returns
+    None so the legacy JSONL walker fires. The walker is cheap on a
+    quiet system (mtime filter skips every file with no recent writes)
+    so we don't try to short-circuit with a zero shell."""
+    a, ls, usage_mod = app
+    store = ls.get_store()
+    now = time.time()
+    # 10 minutes old → outside the 5-min query window.
+    store.ingest(_row(
+        "e-old", "sess-cold", "model.completed", _iso(now - 600),
+        {"_v3_type": "message", "type": "model.completed"},
+        cost_usd=0.01, token_count=2000, model="claude-opus-4-7",
+    ))
+    _drain(store)
+
+    fast = usage_mod._try_local_store_token_velocity()
+    assert fast is None, (
+        f"old events only → must return None for legacy fallback; got {fast!r}"
+    )
+
+
+def test_v3_sibling_pair_does_not_double_count(app):
+    """v3 dedupe guard (matches ``feedback_usage_dedupe_pattern.md``).
+
+    Real OpenClaw v3 emits an ``assistant`` row AND a sibling
+    ``model.completed`` ~100 ms later, both stamped with the same
+    ``token_count``. A naive sum doubles every billable turn — same
+    bug class that bit /api/usage and /api/usage/forecast.
+
+    Seed: one assistant + one model.completed sibling, both with
+    token_count=5000 within the 2-min window. Expected: velocity_2min
+    == 5000 (NOT 10000), level=='ok' (below 8000 WARN).
+    """
+    a, ls, _usage = app
+    store = ls.get_store()
+    sid = "sess-sibling"
+    now = time.time()
+    ts_iso = _iso(now - 30)
+    # Sibling pair on the SAME second so build_sibling_bucket_max
+    # collapses them.
+    store.ingest(_row(
+        "e-assistant", sid, "assistant", ts_iso,
+        {"_v3_type": "message", "type": "assistant",
+         "modelId": "claude-opus-4-7"},
+        cost_usd=0.02, token_count=5000, model="claude-opus-4-7",
+    ))
+    store.ingest(_row(
+        "e-completed", sid, "model.completed", ts_iso,
+        {"_v3_type": "message", "type": "model.completed",
+         "modelId": "claude-opus-4-7"},
+        cost_usd=0.02, token_count=5000, model="claude-opus-4-7",
+    ))
+    _drain(store)
+
+    fast = _app_get_fast(a, _usage)
+    assert fast.get("_source") == "local_store"
+    assert fast.get("velocity_2min") == 5000, (
+        "v3 sibling pair double-counted — dedupe regression; "
+        f"got velocity_2min={fast.get('velocity_2min')}"
+    )
+    assert fast.get("level") == "ok"
+
+
+def test_long_tool_chain_trips_critical(app):
+    """A session burning a long tool chain (>=CRIT_TOOLS=20 consecutive
+    tool calls without a user prompt break) should classify as
+    ``level='critical'`` even when token volume is below CRIT_TOKENS.
+    This matches the legacy JSONL handler's ``max_chain >= CRIT_TOOLS``
+    branch — runaway-loop detection without waiting for the cost spike."""
+    a, ls, _usage = app
+    store = ls.get_store()
+    sid = "sess-loop"
+    now = time.time()
+    # 25 tool.call rows in the last 90s → max_chain >= 20.
+    for i in range(25):
+        store.ingest(_row(
+            f"e-tool-{i}", sid, "tool.call", _iso(now - 90 + i),
+            {"_v3_type": "tool_call", "type": "tool.call",
+             "tool_name": "Bash"},
+        ))
+    _drain(store)
+
+    fast = _app_get_fast(a, _usage)
+    assert fast.get("_source") == "local_store"
+    assert fast.get("level") == "critical", (
+        f"long tool chain should trip critical; got {fast.get('level')!r}"
+    )
+    assert fast.get("alert") is True
+    flagged = fast.get("flagged_sessions") or []
+    assert any(s["id"] == sid and s["tool_chain_len"] >= 20 for s in flagged), (
+        f"flagged_sessions missing the looping session: {flagged!r}"
+    )
+
+
+def _app_get_fast(a, usage_mod):
+    """Helper: call the fast path directly so we can introspect the dict
+    shape (rather than reaching through the JSON envelope)."""
+    fast = usage_mod._try_local_store_token_velocity()
+    assert fast is not None
+    return fast


### PR DESCRIPTION
## Summary

Tier-1 surface #5 from the 2026-05-17 DuckDB coverage audit (issue #1565). Migrates `/api/token-velocity` from a per-poll JSONL scan of up to 20 active session files to a single DuckDB query over the trailing 5 min of events, gated by `is_local_store_read_enabled()` so the audit canary (`_source: 'local_store'`) is discoverable in the response body alongside the rest of the Usage tab fast paths.

**Audit classification verified:** legacy handler was JSONL-only — opens `~/.openclaw/agents/main/sessions/*.jsonl`, parses each line, walks `message.usage.{total_tokens,totalTokens}`. No DuckDB path existed. Not a false-positive like `/api/usage/forecast` was.

**Helper design (`_try_local_store_token_velocity`):**
- Pulls 5 min of events via `query_events(since=..., limit=5000)`. 5-min context (not 2) so the tool-chain walker sees enough history for the consecutive-run heuristic that survives bursts starting >2 min ago.
- Sums `token_count` per session inside the 2-min window, deduped via `build_sibling_bucket_max` / `is_sibling_dup` — same pattern `_try_local_store_usage` uses to avoid double-counting v3 sibling pairs (`assistant` + `model.completed` ~100 ms apart with identical `token_count`).
- Tool-chain length: longest consecutive run of `assistant` / `tool.call` / `model.completed` events without a `user` / `prompt.submitted` break. Matches the legacy `CRIT_TOOLS=20` runaway-loop heuristic.
- Returns `None` on empty 5-min windows so the legacy JSONL walker still fires for fresh installs whose daemon hasn't ingested yet (cheap on quiet systems thanks to its mtime filter).

**Test coverage (`tests/test_token_velocity_local_store_v3.py`):**
1. Populated 2-min burn → `_source='local_store'`, correct `velocity_2min`, `level='warning'`.
2. Empty store → returns `None` so legacy fallback fires.
3. Store with only old (>5 min) events → returns `None` (don't hide active sessions on disk).
4. v3 sibling pair dedupe guard — `assistant` + `model.completed` with same `token_count=5000` must NOT double-count (5000, not 10000).
5. Long tool chain (25 consecutive `tool.call` rows) trips `level='critical'` even when token volume alone is below CRIT.

## Test plan

- [x] `python3 -c "import dashboard"` — clean.
- [x] `python3 -m pytest tests/test_moat_live_openclaw_e2e.py tests/test_moat_send_message_e2e.py tests/test_local_query_api.py tests/test_token_velocity_local_store_v3.py tests/test_usage_forecast_local_store_v3.py -q` — 34 passed, 1 skipped.
- [x] `python3 -m pytest tests/test_duckdb_fastpath_v3_invariants.py tests/test_usage_local_store.py -q` — 41 passed (no regression in sibling Usage fast paths).
- [x] Rebased onto `be9ad4d` after Eng G's PR #1571 (`_try_local_store_usage_forecast`) landed mid-task — no conflict, the two helpers live in different sections of `routes/usage.py`.

## Notes for next audit refresh

- `/api/token-velocity` checkbox can be ticked off in #1565.
- Production diff is 150 LOC (under the 250 budget); test file adds 245.