### PR TITLE
feat(sessions): /api/task-runs DuckDB fast path (refs #1565)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -1354,13 +1354,168 @@ def api_cost_split():
     return jsonify({"sessions": top, "totals": totals})
 
 
+def _try_local_store_task_runs(*, limit, status_filter, parent_filter,
+                               requester_filter):
+    """Fast path for /api/task-runs. Reads the pre-aggregated ``subagents``
+    DuckDB table — the same source PR #1569 wired into
+    ``_try_local_store_subagents``. OpenClaw's ``~/.openclaw/tasks/runs.sqlite``
+    and the subagents snapshot the sync daemon write-throughs from each
+    system-snapshot pass (see ``clawmetry/sync.py`` ``ingest_subagent`` call
+    site) carry the same lifecycle rows — the ``subagents`` table schema
+    comment in ``clawmetry/local_store.py`` calls this out explicitly
+    ("Shared by OpenClaw subagents + Claude Code Task tool.").
+
+    Audit hint for #1565 was "derive from query_events task lifecycle
+    types" — verified 2026-05-17 against ``sync.py::_parse_v3_event``:
+    no ``task.started`` / ``task.completed`` event types exist in v3
+    ingest. The canonical DuckDB source for task lifecycle IS the
+    ``subagents`` table; the audit hint was directionally correct
+    (DuckDB, not sqlite/JSONL) but pointed at the wrong table.
+
+    Returns ``None`` when the table is empty so the legacy
+    ``~/.openclaw/tasks/runs.sqlite`` fallback fires for installs whose
+    daemon hasn't snapshotted yet. Field shape matches the legacy
+    handler's output exactly so the Subagents modal (``app.js``
+    ``renderModalSubagents``) — which keys on ``task_id``,
+    ``parent_task_id``, ``child_session_key``, ``status``,
+    ``duration_ms``, ``label``, ``task``, ``terminal_outcome`` —
+    keeps working bit-for-bit.
+    """
+    rows = _ls_call("query_subagents", limit=max(limit, 500))
+    if not rows:
+        return None
+
+    # Snapshot status (from gateway subagents list) uses a different
+    # vocabulary than runs.sqlite. The UI keys on the runs.sqlite shape
+    # (`running` / `succeeded` / `failed` / `pending`) for colour pills
+    # and the "Failed" stat chip — normalise so the modal renders
+    # consistently across data sources.
+    _status_map = {
+        "active":    "running",
+        "running":   "running",
+        "idle":      "running",
+        "completed": "succeeded",
+        "succeeded": "succeeded",
+        "done":      "succeeded",
+        "failed":    "failed",
+        "error":     "failed",
+        "pending":   "pending",
+        "stale":     "pending",
+    }
+
+    tasks: list = []
+    counts: dict = {}
+    for r in rows:
+        sid = r.get("subagent_id") or ""
+        if not sid:
+            continue
+        extra = r.get("data") if isinstance(r.get("data"), dict) else {}
+
+        # Derive the runs.sqlite field names from subagents columns + data blob.
+        # ``subagent_id`` IS the task_id (one row per task spawn). The
+        # ``child_session_key`` is OpenClaw's canonical key shape; the
+        # parent (``requester_session_key``) is the session that issued
+        # the spawn. ``parent_task_id`` is only set for nested spawns and
+        # may not exist in the snapshot — fall back to extra dict.
+        parent_sid = r.get("parent_session_id") or extra.get("spawnedBy") or ""
+        child_key = extra.get("key") or f"agent:main:subagent:{sid}"
+        requester_key = (extra.get("requester_session_key")
+                         or (f"agent:main:{parent_sid}" if parent_sid else ""))
+
+        # Apply caller filters BEFORE building the row so the response
+        # honours ``status=`` / ``parent_task_id=`` / ``requester_session_key=``
+        # exactly like the legacy sqlite WHERE clause.
+        raw_status = (r.get("status") or "").strip().lower()
+        mapped_status = _status_map.get(raw_status, raw_status or "unknown")
+        if status_filter and mapped_status != status_filter and raw_status != status_filter:
+            continue
+        if parent_filter and (extra.get("parent_task_id") or "") != parent_filter:
+            continue
+        if requester_filter and requester_key != requester_filter:
+            continue
+
+        # started/ended come from the snapshot's ms timestamps (data blob)
+        # when available; spawned_at/ended_at strings are best-effort
+        # ISO fallbacks. duration_ms mirrors the legacy formula.
+        started_ms = int(extra.get("started_at_ms")
+                         or extra.get("updated_at_ms") or 0)
+        ended_ms = int(extra.get("ended_at_ms") or 0)
+        if not started_ms and r.get("spawned_at"):
+            try:
+                started_ms = int(datetime.fromisoformat(
+                    str(r["spawned_at"]).replace("Z", "+00:00")
+                ).timestamp() * 1000)
+            except Exception:
+                started_ms = 0
+        if not ended_ms and r.get("ended_at"):
+            try:
+                ended_ms = int(datetime.fromisoformat(
+                    str(r["ended_at"]).replace("Z", "+00:00")
+                ).timestamp() * 1000)
+            except Exception:
+                ended_ms = 0
+        duration_ms = max(0, ended_ms - started_ms) if started_ms and ended_ms else 0
+
+        task_d = {
+            "task_id":              sid,
+            "parent_task_id":       extra.get("parent_task_id") or "",
+            "child_session_key":    child_key,
+            "requester_session_key": requester_key,
+            "agent_id":             extra.get("agent_id") or "main",
+            "run_id":               extra.get("runId") or extra.get("run_id") or "",
+            "label":                extra.get("label") or extra.get("displayName") or "",
+            "task":                 r.get("task") or "",
+            "status":               mapped_status,
+            "delivery_status":      extra.get("delivery_status") or "",
+            "task_kind":            extra.get("task_kind") or "subagent",
+            "parent_flow_id":       extra.get("parent_flow_id") or "",
+            "created_at":           started_ms,
+            "started_at":           started_ms,
+            "ended_at":             ended_ms,
+            "last_event_at":        int(extra.get("updated_at_ms") or 0),
+            "error":                extra.get("error") or "",
+            "progress_summary":     extra.get("progress_summary") or "",
+            "terminal_summary":     extra.get("terminal_summary")
+                                    or extra.get("completionResult") or "",
+            "terminal_outcome":     extra.get("terminal_outcome")
+                                    or extra.get("completionStatus") or "",
+            "duration_ms":          duration_ms,
+        }
+        tasks.append(task_d)
+        counts[mapped_status] = counts.get(mapped_status, 0) + 1
+        if len(tasks) >= limit:
+            break
+
+    # Sort newest-first by started_at then created_at, matching the
+    # legacy ``ORDER BY COALESCE(started_at, created_at, 0) DESC`` clause.
+    tasks.sort(key=lambda t: t.get("started_at") or t.get("created_at") or 0,
+               reverse=True)
+
+    total = len(tasks)
+    failed = counts.get("failed", 0)
+    err_rate = round(failed / total * 100, 1) if total else 0
+    return {
+        "tasks":   tasks,
+        "counts":  counts,
+        "stats": {
+            "total":          total,
+            "succeeded":      counts.get("succeeded", 0),
+            "failed":         failed,
+            "running":        counts.get("running", 0),
+            "error_rate_pct": err_rate,
+        },
+        "_source": "local_store",
+    }
+
+
 @bp_sessions.route("/api/task-runs")
 def api_task_runs():
-    """Read ~/.openclaw/tasks/runs.sqlite — the canonical subagent/task registry."""
+    """Subagent / task registry. Prefers the DuckDB ``subagents`` table
+    fast path (populated by the sync daemon's snapshot pass); falls
+    back to OpenClaw's ``~/.openclaw/tasks/runs.sqlite`` for installs
+    whose daemon hasn't run yet.
+    """
     import sqlite3
-    p = os.path.expanduser("~/.openclaw/tasks/runs.sqlite")
-    if not os.path.isfile(p):
-        return jsonify({"tasks": [], "counts": {}, "note": "runs.sqlite not found"})
     try:
         limit = max(1, min(int(request.args.get("limit", "500")), 5000))
     except ValueError:
@@ -1368,6 +1523,22 @@ def api_task_runs():
     status_filter = (request.args.get("status", "") or "").strip()
     parent_filter = (request.args.get("parent_task_id", "") or "").strip()
     requester_filter = (request.args.get("requester_session_key", "") or "").strip()
+
+    # DuckDB fast path — skips the sqlite open entirely when the daemon
+    # has snapshotted at least one subagent row.
+    if is_local_store_read_enabled():
+        fast = _try_local_store_task_runs(
+            limit=limit,
+            status_filter=status_filter,
+            parent_filter=parent_filter,
+            requester_filter=requester_filter,
+        )
+        if fast is not None:
+            return jsonify(fast)
+
+    p = os.path.expanduser("~/.openclaw/tasks/runs.sqlite")
+    if not os.path.isfile(p):
+        return jsonify({"tasks": [], "counts": {}, "note": "runs.sqlite not found"})
     where = []
     args = []
     if status_filter:

--- a/tests/test_task_runs_local_store_v3.py
+++ b/tests/test_task_runs_local_store_v3.py
@@ -1,0 +1,265 @@
+"""Regression guard for /api/task-runs DuckDB fast path (Tier-1 #1565).
+
+``routes/sessions.py:_try_local_store_task_runs`` reads the
+pre-aggregated ``subagents`` DuckDB table (same source PR #1569 wired
+into ``_try_local_store_subagents``) and maps it onto the legacy
+``~/.openclaw/tasks/runs.sqlite`` response shape so the Subagents modal
+(``app.js`` ``renderModalSubagents``) keeps working bit-for-bit when
+the daemon serves it from DuckDB instead of opening the sqlite file.
+
+Audit-hint check: the #1565 hint said "derive from query_events task
+lifecycle types", but verified 2026-05-17 against
+``sync.py::_parse_v3_event`` — no ``task.started`` / ``task.completed``
+event types exist in v3 ingest. The canonical DuckDB source for task
+lifecycle IS the ``subagents`` table (its schema comment in
+``local_store.py`` explicitly says "Shared by OpenClaw subagents +
+Claude Code Task tool."). Test seeds DuckDB via the daemon's canonical
+``LocalStore.ingest_subagent`` helper (matching sync.py call site).
+
+This file asserts:
+
+1. Populated path → fast path returns ``_source='local_store'`` and the
+   shape the modal needs (``task_id``, ``parent_task_id``,
+   ``child_session_key``, ``status``, ``duration_ms``, ``label``,
+   ``task``, ``terminal_outcome``).
+2. Empty store → returns ``None`` so the legacy sqlite fallback fires.
+3. Status normalisation — gateway snapshot vocabulary
+   (``active`` / ``completed`` / ``failed``) maps onto the
+   runs.sqlite UI vocabulary (``running`` / ``succeeded`` / ``failed``)
+   so the colour pills + Failed stat chip render consistently.
+4. Filter params (``status=``, ``requester_session_key=``) are honoured
+   exactly like the legacy sqlite WHERE clause — guards against the
+   silent-drop pattern flagged in
+   ``feedback_usage_dedupe_pattern.md``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    # Issue #1538 pattern — isolate the fixture from a contributor's locally
+    # running clawmetry daemon. Without this, ``_ls_call`` proxies through
+    # ``~/.clawmetry/local_query.json`` and the daemon queries its OWN
+    # production DuckDB instead of our tmp_path fixture.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_task_runs_local_store_returns_local_store_source(app):
+    """Two children for one parent → fast path returns both rows tagged
+    with ``_source='local_store'`` and the UI-keyed shape preserved on
+    each row (``task_id`` / ``child_session_key`` / ``duration_ms`` /
+    ``label`` / ``terminal_outcome``)."""
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "parent-session-xyz"
+    now_ms = int(time.time() * 1000)
+
+    store.ingest_subagent({
+        "subagent_id":       "child-a",
+        "agent_type":        "openclaw",
+        "parent_session_id": parent_sid,
+        "spawned_at":        "2026-05-17T10:00:00Z",
+        "ended_at":          "2026-05-17T10:00:15Z",
+        "task":              "refactor auth.py",
+        "status":            "completed",
+        "cost_usd":          0.0234,
+        "token_count":       4200,
+        "label":             "auth-refactor",
+        "displayName":       "auth-refactor",
+        "runId":             "run-aaaa",
+        "started_at_ms":     now_ms - 15000,
+        "ended_at_ms":       now_ms,
+        "updated_at_ms":     now_ms,
+        "completionStatus":  "ok",
+        "completionResult":  "Refactor complete, 3 files touched.",
+    })
+    store.ingest_subagent({
+        "subagent_id":       "child-b",
+        "agent_type":        "openclaw",
+        "parent_session_id": parent_sid,
+        "spawned_at":        "2026-05-17T10:01:00Z",
+        "task":              "summarise transcripts",
+        "status":            "active",  # gateway vocabulary
+        "cost_usd":          0.0089,
+        "token_count":       1800,
+        "label":             "summariser",
+        "started_at_ms":     now_ms - 8000,
+        "updated_at_ms":     now_ms,
+    })
+
+    r = a.test_client().get("/api/task-runs")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"_source must be local_store; got {body.get('_source')!r}"
+    )
+    tasks = body.get("tasks") or []
+    ids = {t["task_id"] for t in tasks}
+    assert ids == {"child-a", "child-b"}, f"expected both children, got {ids!r}"
+
+    by_id = {t["task_id"]: t for t in tasks}
+    a_row = by_id["child-a"]
+    # Status normalisation: gateway ``completed`` → UI ``succeeded``.
+    assert a_row["status"] == "succeeded", a_row["status"]
+    assert a_row["label"] == "auth-refactor"
+    assert a_row["task"] == "refactor auth.py"
+    assert a_row["child_session_key"].startswith("agent:main:subagent:")
+    assert a_row["terminal_summary"] == "Refactor complete, 3 files touched."
+    assert a_row["terminal_outcome"] == "ok"
+    assert a_row["run_id"] == "run-aaaa"
+    # duration_ms must mirror the legacy ``ended - started`` formula
+    # (only set when BOTH endpoints exist).
+    assert a_row["duration_ms"] == 15000, a_row["duration_ms"]
+
+    b_row = by_id["child-b"]
+    # Gateway ``active`` → UI ``running`` so the colour pill stays green.
+    assert b_row["status"] == "running", b_row["status"]
+    # Still-running task → no ended_at → duration_ms == 0.
+    assert b_row["duration_ms"] == 0
+
+    counts = body.get("counts") or {}
+    assert counts.get("running") == 1
+    assert counts.get("succeeded") == 1
+
+    stats = body.get("stats") or {}
+    assert stats["total"] == 2
+    assert stats["succeeded"] == 1
+    assert stats["running"] == 1
+    assert stats["failed"] == 0
+    assert stats["error_rate_pct"] == 0
+
+
+def test_task_runs_local_store_returns_none_when_empty(app):
+    """No rows in the ``subagents`` table → fast path returns None so
+    the legacy ``~/.openclaw/tasks/runs.sqlite`` fallback fires. The
+    handler must NOT short-circuit to a populated zero-shell here:
+    older OpenClaw installs whose daemon hasn't snapshotted yet need
+    the sqlite path to find their task registry on disk."""
+    _, ls = app
+    assert ls.get_store().query_subagents(limit=10) == []
+
+    import routes.sessions as sessions_mod
+    fast = sessions_mod._try_local_store_task_runs(
+        limit=500, status_filter="", parent_filter="", requester_filter="",
+    )
+    assert fast is None, (
+        f"empty store must return None for legacy fallback; got {fast!r}"
+    )
+
+
+def test_task_runs_local_store_failed_transitions(app):
+    """Failed status path: gateway ``failed`` → UI ``failed`` (no
+    normalisation needed), error message survives the data-blob
+    round-trip, and the stats block reports a non-zero
+    ``error_rate_pct``."""
+    a, ls = app
+    store = ls.get_store()
+    now_ms = int(time.time() * 1000)
+
+    store.ingest_subagent({
+        "subagent_id":      "bad-child",
+        "agent_type":       "openclaw",
+        "parent_session_id": "parent-x",
+        "spawned_at":       "2026-05-17T10:00:00Z",
+        "ended_at":         "2026-05-17T10:00:02Z",
+        "task":             "broken",
+        "status":           "failed",
+        "error":            "tool unavailable",
+        "started_at_ms":    now_ms - 2000,
+        "ended_at_ms":      now_ms,
+        "updated_at_ms":    now_ms,
+    })
+    store.ingest_subagent({
+        "subagent_id":      "ok-child",
+        "agent_type":       "openclaw",
+        "parent_session_id": "parent-x",
+        "spawned_at":       "2026-05-17T10:00:01Z",
+        "task":             "fine",
+        "status":           "succeeded",
+        "started_at_ms":    now_ms - 1000,
+        "ended_at_ms":      now_ms,
+        "updated_at_ms":    now_ms,
+    })
+
+    r = a.test_client().get("/api/task-runs")
+    body = r.get_json()
+    by_id = {t["task_id"]: t for t in (body.get("tasks") or [])}
+    assert by_id["bad-child"]["status"] == "failed"
+    assert by_id["bad-child"]["error"] == "tool unavailable"
+    assert body["stats"]["failed"] == 1
+    # 1 failed out of 2 → 50% error rate.
+    assert body["stats"]["error_rate_pct"] == 50.0
+
+
+def test_task_runs_local_store_filters_honoured(app):
+    """``status=`` and ``requester_session_key=`` filters must be
+    applied to the DuckDB rows before they hit the response — same
+    semantics as the legacy sqlite WHERE clause. Guards against the
+    silent-drop pattern from ``feedback_usage_dedupe_pattern.md``
+    where blind aggregate-replace lost non-matching rows."""
+    a, ls = app
+    store = ls.get_store()
+    now_ms = int(time.time() * 1000)
+
+    parent_a = "parent-aaa"
+    parent_b = "parent-bbb"
+    for sid, parent, status in [
+        ("t1", parent_a, "running"),
+        ("t2", parent_a, "succeeded"),
+        ("t3", parent_b, "failed"),
+    ]:
+        store.ingest_subagent({
+            "subagent_id":       sid,
+            "agent_type":        "openclaw",
+            "parent_session_id": parent,
+            "spawned_at":        "2026-05-17T10:00:00Z",
+            "task":              sid,
+            "status":            status,
+            "started_at_ms":     now_ms,
+            "updated_at_ms":     now_ms,
+        })
+
+    # status filter: only the failed row should come back.
+    r = a.test_client().get("/api/task-runs?status=failed")
+    body = r.get_json()
+    ids = [t["task_id"] for t in (body.get("tasks") or [])]
+    assert ids == ["t3"], f"status=failed filter dropped or duplicated rows: {ids!r}"
+    assert body["_source"] == "local_store"
+
+    # requester_session_key filter: only t1 + t2 belong to parent_a.
+    # _try_local_store_task_runs derives requester_session_key as
+    # ``agent:main:<parent_session_id>`` when no override is stamped.
+    r2 = a.test_client().get(
+        "/api/task-runs?requester_session_key=agent:main:" + parent_a
+    )
+    body2 = r2.get_json()
+    ids2 = sorted(t["task_id"] for t in (body2.get("tasks") or []))
+    assert ids2 == ["t1", "t2"], (
+        f"requester filter dropped or leaked rows: {ids2!r}"
+    )


### PR DESCRIPTION
## Summary

Tier-1 surface #1 from the 2026-05-17 DuckDB coverage audit (#1565). `/api/task-runs` previously opened `~/.openclaw/tasks/runs.sqlite` per request; now reads the pre-aggregated DuckDB `subagents` table the daemon already snapshots on every system-snapshot pass (same source PR #1569 wired into `_try_local_store_subagents`). Tagged `_source: 'local_store'`; legacy sqlite path still fires when the table is empty (fresh installs whose daemon hasn't snapshotted yet).

## Audit hint correction (false-positive flagged)

The #1565 hint said "derive from query_events task lifecycle types". Verified against `clawmetry/sync.py::_parse_v3_event` — no `task.started` / `task.completed` / `task.failed` event types exist in v3 ingest. The canonical DuckDB source IS the `subagents` table; its schema comment in `clawmetry/local_store.py` (line 310-326) explicitly states *"Shared by OpenClaw subagents + Claude Code Task tool."* — the audit hint was directionally correct (DuckDB, not sqlite) but pointed at the wrong table. Migration delivered against `subagents`; recorded inline in the helper docstring for the next sweep.

## Shape preserved

The Subagents modal in `app.js` (`renderModalSubagents`) keys on `task_id` / `parent_task_id` / `child_session_key` / `status` / `duration_ms` / `label` / `task` / `terminal_outcome`. All preserved, derived from `subagents` columns + the `data` blob. Status normalised: gateway vocabulary (`active` / `completed` / `failed` / `stale`) → runs.sqlite vocabulary (`running` / `succeeded` / `failed` / `pending`) so colour pills and the Failed stat chip render identically across data sources.

## Silent-drop guard

Filters (`status=`, `parent_task_id=`, `requester_session_key=`) applied row-by-row before the row is built — matches the legacy sqlite WHERE-clause semantics exactly. Guards against the silent-drop pattern flagged in `feedback_usage_dedupe_pattern.md`. Test `test_task_runs_local_store_filters_honoured` validates both filters.

## Diff size

`+175/-4` production LOC in `routes/sessions.py` (≤250 LOC budget). New helper next to `_try_local_store_subagents`. Tests add `tests/test_task_runs_local_store_v3.py` (~250 LOC, no production impact).

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_task_runs_local_store_v3.py -q` — 4 passed (populated path, empty fallback, failed-status round-trip + error_rate_pct, filter honouring)
- [x] `python3 -m pytest tests/test_moat_live_openclaw_e2e.py tests/test_moat_send_message_e2e.py tests/test_local_query_api.py tests/test_subagents_local_store_v3.py tests/test_task_runs_local_store_v3.py -q` — 31 passed, 1 skipped
- [x] Real-shape regression guard per `feedback_synthetic_tests_missed_real_event_shape.md` — tests ingest via the canonical `LocalStore.ingest_subagent` helper that `sync.py` calls in prod
- [ ] Smoke against live `~/.openclaw/.clawmetry/clawmetry.duckdb` once a real install has snapshotted subagents (covered post-merge by the MOAT cron's send-message E2E)

Refs #1565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)