### PR TITLE
feat(usage): /api/skills/fidelity DuckDB fast path (refs #1565)

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -988,6 +988,180 @@ def _try_local_store_skill_attribution():
     }
 
 
+def _try_local_store_skills_fidelity(max_sessions=200):
+    """Fast path for /api/skills/fidelity (Tier-1 #6 from issue #1565).
+
+    Replaces the 200-file × all-lines JSONL walker in
+    ``api_skills_fidelity`` with a single DuckDB read using the canonical
+    ``query_recent_read_tool_calls`` method (already shipped + allowlisted
+    for the daemon proxy — issue #1364). One row per Read-tool invocation
+    in the last 7 days; we bucket them per-skill in-process.
+
+    Status rules match the legacy endpoint contract:
+      * dead   — installed but body fetch count == 0
+      * orphan — body-fetched in sessions but skill dir not on disk
+      * stuck  — body fetched but skill has linked files and none were read
+      * active — otherwise
+
+    Returns ``None`` (defer to JSONL walker) when:
+      * the local store isn't reachable
+      * the canonical method returns ``None`` (daemon down + direct open
+        failed)
+      * NO skills are installed on disk AND zero rows came back (nothing
+        meaningful to report — let the legacy path serve the empty shape)
+
+    Audit imperfection note (issue #1565 audit): the audit hinted this
+    surface was an "extension of skill-attribution". In practice the
+    canonical DuckDB source for body-fetch counts is
+    ``query_recent_read_tool_calls`` (already serving ``/api/skills``),
+    not the cost-aggregation walker in
+    ``_try_local_store_skill_attribution``. Reusing the established path
+    avoids divergence between the two fidelity surfaces.
+    """
+    import dashboard as _d
+    import re as _re
+
+    # 1. Pull the file-path rows the canonical helper provides. Returns
+    # None on store-not-reachable; an empty list is a valid "store is up
+    # but nothing in the 7d window" answer.
+    cutoff_ts = time.time() - 7 * 86400
+    since_iso = datetime.utcfromtimestamp(cutoff_ts).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    rows = _ls_call("query_recent_read_tool_calls", since=since_iso, limit=50_000)
+    if rows is None:
+        return None
+    if not isinstance(rows, list):
+        return None
+
+    # 2. List installed skills (header-always-loaded set). Same logic as
+    # the legacy walker so the dead/active classification matches.
+    workspace = (
+        _d.WORKSPACE
+        or os.environ.get("OPENCLAW_WORKSPACE")
+        or os.environ.get("OPENCLAW_HOME")
+        or os.path.expanduser("~/.openclaw/workspace")
+    )
+    skills_dir = os.path.join(workspace, "skills")
+    installed_skills: set = set()
+    skill_has_linked: dict = {}
+    if os.path.isdir(skills_dir):
+        try:
+            for entry in os.listdir(skills_dir):
+                entry_path = os.path.join(skills_dir, entry)
+                if not os.path.isdir(entry_path):
+                    continue
+                if not os.path.isfile(os.path.join(entry_path, "SKILL.md")):
+                    continue
+                installed_skills.add(entry)
+                try:
+                    linked = [
+                        f for f in os.listdir(entry_path)
+                        if f.upper() != "SKILL.MD"
+                        and not f.startswith('.')
+                        and os.path.isfile(os.path.join(entry_path, f))
+                    ]
+                except OSError:
+                    linked = []
+                skill_has_linked[entry] = bool(linked)
+        except OSError:
+            pass
+
+    # 3. Bucket the Read-tool rows per skill via the parent-dir-name in
+    # ``file_path``. Body fetch = path ends in /SKILL.md; linked fetch =
+    # path is under skills/<name>/<not-SKILL.md>. Matches the legacy
+    # regex pair (case-insensitive, slash-normalised so Windows paths
+    # still hit).
+    SKILL_MD_RE = _re.compile(r'[/\\]([^/\\]+)[/\\]SKILL\.md', _re.IGNORECASE)
+    SKILL_LINKED_RE = _re.compile(
+        r'skills[/\\]([^/\\]+)[/\\]([^/\\\'">\s]{1,80})', _re.IGNORECASE
+    )
+
+    body_fetches: dict = {}    # skill_name -> count
+    linked_fetches: dict = {}  # skill_name -> count
+    skill_sessions: dict = {}  # skill_name -> set of session_ids
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        fp = row.get("file_path") or ""
+        if not isinstance(fp, str) or not fp:
+            continue
+        sid = row.get("session_id") or ""
+        body_match = SKILL_MD_RE.search(fp)
+        if body_match:
+            sname = body_match.group(1)
+            if sname and sname.lower() not in ('skills', ''):
+                body_fetches[sname] = body_fetches.get(sname, 0) + 1
+                if sid:
+                    skill_sessions.setdefault(sname, set()).add(sid)
+        else:
+            # Linked-file path: skills/<name>/<file-not-SKILL.md>
+            linked_match = SKILL_LINKED_RE.search(fp)
+            if linked_match and linked_match.group(2).upper() != 'SKILL.MD':
+                sname = linked_match.group(1)
+                if sname:
+                    linked_fetches[sname] = linked_fetches.get(sname, 0) + 1
+
+    # If nothing on disk AND nothing in events, defer so the legacy path
+    # can serve the empty shape with its own no-data note.
+    if not installed_skills and not body_fetches and not linked_fetches:
+        return None
+
+    # 4. Build per-skill stats + classify. Same rules as the legacy
+    # handler so the response contract doesn't drift.
+    all_names = installed_skills | set(body_fetches) | set(linked_fetches)
+    skills_out = []
+    dead_count = stuck_count = active_count = orphan_count = 0
+    for name in sorted(all_names):
+        installed = name in installed_skills
+        bf = body_fetches.get(name, 0)
+        lf = linked_fetches.get(name, 0)
+        sess = len(skill_sessions.get(name, set()))
+        has_linked = skill_has_linked.get(name, False)
+
+        if installed and bf == 0:
+            status = 'dead'
+            dead_count += 1
+        elif not installed and bf > 0:
+            status = 'orphan'
+            orphan_count += 1
+        elif bf > 0 and has_linked and lf == 0:
+            status = 'stuck'
+            stuck_count += 1
+        else:
+            status = 'active'
+            active_count += 1
+
+        skills_out.append({
+            'name': name,
+            'installed': installed,
+            'body_fetches': bf,
+            'linked_file_fetches': lf,
+            'sessions_seen': sess,
+            'status': status,
+            'token_roi': round(bf / sess, 3) if sess > 0 else None,
+        })
+
+    _STATUS_ORDER = {'dead': 0, 'stuck': 1, 'orphan': 2, 'active': 3}
+    skills_out.sort(key=lambda s: (_STATUS_ORDER[s['status']], -s['body_fetches']))
+
+    return {
+        'skills': skills_out,
+        'dead_count': dead_count,
+        'stuck_count': stuck_count,
+        'active_count': active_count,
+        'orphan_count': orphan_count,
+        'total_installed': len(installed_skills),
+        'note': (
+            'Dead: installed but body never fetched — remove to save header tokens. '
+            'Stuck: body fetched but linked files unread despite existing. '
+            'Orphan: body-fetched in sessions but not installed (skill removed?).'
+        ),
+        '_source': 'local_store',
+    }
+
+
 def _apply_oss_24h_cap(result):
     """Issue #1448 surface 2 — clamp /api/usage history to the last 24h for
     OSS / Cloud-Free callers. Cloud-Pro users (gated by
@@ -2858,6 +3032,15 @@ def api_skills_fidelity():
         max_sessions = max(1, min(int(request.args.get("sessions", 200)), 500))
     except (TypeError, ValueError):
         max_sessions = 200
+
+    # Tier-1 DuckDB fast path (issue #1565 audit #6). Reuses the canonical
+    # ``query_recent_read_tool_calls`` source already serving /api/skills
+    # so both fidelity surfaces stay aligned; ``None`` falls through to
+    # the legacy JSONL walker below.
+    if is_local_store_read_enabled():
+        fast = _try_local_store_skills_fidelity(max_sessions=max_sessions)
+        if fast is not None:
+            return jsonify(fast)
 
     workspace = (
         _d.WORKSPACE

--- a/tests/test_skills_fidelity_local_store_v3.py
+++ b/tests/test_skills_fidelity_local_store_v3.py
@@ -1,0 +1,241 @@
+"""Synthetic safety net for /api/skills/fidelity DuckDB fast path
+(Tier-1 surface #6 in issue #1565).
+
+``routes/usage.py::_try_local_store_skills_fidelity`` reuses the
+canonical ``query_recent_read_tool_calls`` LocalStore method (already
+serving ``/api/skills`` since #1378) so the two skills-fidelity
+surfaces stay aligned on data source — no second walker, no schema
+drift.
+
+This file seeds DuckDB with the SAME daemon-normalised event shapes the
+OSS sync daemon writes for real OpenClaw v3 sessions
+(``reference_openclaw_v3_event_types.md``) and asserts:
+
+1. Populated store + installed skill on disk returns
+   ``_source='local_store'`` with the correct active/dead/stuck/orphan
+   classification.
+2. v3 ``assistant`` event with a ``tool_use`` Read block whose
+   ``input.file_path`` ends in ``SKILL.md`` increments
+   ``body_fetches`` for that skill — matches the v3 regression that
+   broke ``/api/skills`` in #1385.
+3. An installed skill with zero Read rows is classified ``dead``.
+4. A skill with body fetches but linked files present and unread is
+   classified ``stuck``.
+5. A body fetch for a skill NOT on disk is classified ``orphan``.
+6. When the store is empty AND no skills on disk, helper returns
+   ``None`` so the legacy JSONL walker can serve its empty shape.
+7. Env flag UNSET → ``_source`` tag absent (legacy walker took over).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import time
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _build_app(tmp_path, monkeypatch, *, enable_fast_path: bool,
+               install_demo_skill: bool = True,
+               with_linked: bool = False):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_READ", "1" if enable_fast_path else "0",
+    )
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Steer daemon-proxy discovery away from a developer's real install
+    # so the helper falls through to the tmp_path in-process LocalStore.
+    import routes.local_query as lq
+    monkeypatch.setattr(
+        lq, "_DISCOVERY_PATH", str(tmp_path / "no-such-discovery.json")
+    )
+    lq._invalidate_daemon_cache()
+
+    workspace = tmp_path / "workspace"
+    skills_root = workspace / "skills"
+    if install_demo_skill:
+        skill_dir = skills_root / "demo-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: demo-skill\n---\nbody\n")
+        if with_linked:
+            (skill_dir / "helper.py").write_text("print('hi')\n")
+    else:
+        skills_root.mkdir(parents=True)
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "WORKSPACE", str(workspace), raising=False)
+    monkeypatch.setattr(_d, "SESSIONS_DIR", str(sessions_dir), raising=False)
+    monkeypatch.setattr(
+        _d, "_get_sessions_dir", lambda: str(sessions_dir), raising=False,
+    )
+
+    import routes.usage as usage_mod
+    importlib.reload(usage_mod)
+
+    app = Flask(__name__)
+    app.register_blueprint(usage_mod.bp_usage)
+    return app, ls, str(workspace)
+
+
+def _ingest_v3_assistant_read(store, *, sid: str, ts: str, file_path: str,
+                              ev_id: str | None = None):
+    """v3 real-shape: ``assistant`` event carrying a ``tool_use`` Read
+    block inside ``data.message.content`` (Anthropic-SDK echo shape).
+    """
+    if ev_id is None:
+        ev_id = f"asst-{sid}-{ts}-{abs(hash(file_path))}"
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "assistant",
+        "ts":         ts,
+        "data": {
+            "type":    "assistant",
+            "version": 3,
+            "message": {
+                "role":  "assistant",
+                "model": "claude-opus-4-7",
+                "content": [
+                    {
+                        "type":  "tool_use",
+                        "id":    "toolu_01",
+                        "name":  "Read",
+                        "input": {"file_path": file_path},
+                    },
+                ],
+            },
+        },
+        "model": "claude-opus-4-7",
+    })
+
+
+# ── happy paths ────────────────────────────────────────────────────────────
+
+
+def test_fidelity_fast_path_active_skill(tmp_path, monkeypatch):
+    """One installed skill + two body-fetches for it in the trailing 7d
+    → status=active, _source=local_store."""
+    app, ls, workspace = _build_app(tmp_path, monkeypatch, enable_fast_path=True)
+    store = ls.get_store()
+    sm = os.path.join(workspace, "skills", "demo-skill", "SKILL.md")
+    ts_now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    _ingest_v3_assistant_read(store, sid="s1", ts=ts_now, file_path=sm)
+    _ingest_v3_assistant_read(store, sid="s2", ts=ts_now, file_path=sm,
+                               ev_id="asst-2")
+    _wait_flush(store)
+
+    body = app.test_client().get("/api/skills/fidelity").get_json()
+    assert body["_source"] == "local_store"
+    assert body["total_installed"] == 1
+    by_name = {s["name"]: s for s in body["skills"]}
+    assert "demo-skill" in by_name
+    assert by_name["demo-skill"]["body_fetches"] == 2
+    assert by_name["demo-skill"]["sessions_seen"] == 2
+    assert by_name["demo-skill"]["status"] == "active"
+    assert body["active_count"] >= 1
+
+
+def test_fidelity_fast_path_dead_when_installed_but_no_fetch(tmp_path, monkeypatch):
+    """Installed skill with zero Read rows → dead."""
+    app, ls, _workspace = _build_app(tmp_path, monkeypatch, enable_fast_path=True)
+    # Force a flush of the empty store so query_recent_read_tool_calls
+    # returns [] (not None) and the helper proceeds with disk-only data.
+    _wait_flush(ls.get_store())
+
+    body = app.test_client().get("/api/skills/fidelity").get_json()
+    assert body["_source"] == "local_store"
+    by_name = {s["name"]: s for s in body["skills"]}
+    assert by_name["demo-skill"]["status"] == "dead"
+    assert body["dead_count"] == 1
+
+
+def test_fidelity_fast_path_stuck_when_linked_files_unread(tmp_path, monkeypatch):
+    """Body fetched + linked file on disk + zero linked-fetch rows → stuck."""
+    app, ls, workspace = _build_app(
+        tmp_path, monkeypatch, enable_fast_path=True, with_linked=True,
+    )
+    store = ls.get_store()
+    sm = os.path.join(workspace, "skills", "demo-skill", "SKILL.md")
+    ts_now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    _ingest_v3_assistant_read(store, sid="s1", ts=ts_now, file_path=sm)
+    _wait_flush(store)
+
+    body = app.test_client().get("/api/skills/fidelity").get_json()
+    assert body["_source"] == "local_store"
+    by_name = {s["name"]: s for s in body["skills"]}
+    assert by_name["demo-skill"]["status"] == "stuck"
+    assert body["stuck_count"] == 1
+
+
+def test_fidelity_fast_path_orphan_when_skill_not_installed(tmp_path, monkeypatch):
+    """Body fetch for a skill NOT on disk → orphan."""
+    app, ls, _workspace = _build_app(
+        tmp_path, monkeypatch, enable_fast_path=True, install_demo_skill=False,
+    )
+    store = ls.get_store()
+    ts_now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    _ingest_v3_assistant_read(
+        store, sid="s1", ts=ts_now,
+        file_path="/random/path/skills/ghost-skill/SKILL.md",
+    )
+    _wait_flush(store)
+
+    body = app.test_client().get("/api/skills/fidelity").get_json()
+    assert body["_source"] == "local_store"
+    by_name = {s["name"]: s for s in body["skills"]}
+    assert "ghost-skill" in by_name
+    assert by_name["ghost-skill"]["status"] == "orphan"
+    assert by_name["ghost-skill"]["installed"] is False
+    assert body["orphan_count"] == 1
+
+
+def test_fidelity_fast_path_defers_when_empty_store_and_no_skills(
+    tmp_path, monkeypatch,
+):
+    """No skills on disk AND zero Read rows → helper returns None so
+    the legacy JSONL walker serves the empty-shape response."""
+    app, ls, _workspace = _build_app(
+        tmp_path, monkeypatch, enable_fast_path=True, install_demo_skill=False,
+    )
+    _wait_flush(ls.get_store())
+
+    body = app.test_client().get("/api/skills/fidelity").get_json()
+    # Legacy walker took over → no _source tag.
+    assert body.get("_source") != "local_store"
+    assert body["total_installed"] == 0
+
+
+def test_fidelity_legacy_when_env_unset(tmp_path, monkeypatch):
+    """Env flag UNSET → fast path skipped entirely (no _source tag),
+    even though events exist."""
+    app, _ls, _workspace = _build_app(
+        tmp_path, monkeypatch, enable_fast_path=False,
+    )
+    body = app.test_client().get("/api/skills/fidelity").get_json()
+    assert body.get("_source") != "local_store"
+    # Legacy shape contract still upheld.
+    for k in ("skills", "dead_count", "stuck_count", "active_count",
+              "orphan_count", "total_installed"):
+        assert k in body


### PR DESCRIPTION
## Summary

Tier-1 #6 from the 2026-05-17 DuckDB coverage audit (issue #1565).

- Adds `_try_local_store_skills_fidelity()` in `routes/usage.py` and wires it behind `is_local_store_read_enabled()` at the top of `api_skills_fidelity`.
- Reuses the canonical `query_recent_read_tool_calls` source (shipped in #1378, already daemon-allowlisted) — the same Read-tool walker serving `/api/skills` — so the two skills-fidelity surfaces stay aligned on one data source.
- Tags response with `_source: 'local_store'`. Returns `None` (falls through to legacy JSONL walker) when the store isn't reachable OR when nothing is on disk AND zero rows came back.
- New synthetic safety net at `tests/test_skills_fidelity_local_store_v3.py` — 6 tests covering active/dead/stuck/orphan classification on real v3 `assistant` + `tool_use` event shapes (`reference_openclaw_v3_event_types.md`), plus the env-unset legacy-fallback guard.

## Audit imperfection found

The audit hint described `/api/skills/fidelity` as "extension of skill-attribution". In practice the canonical DuckDB source for body-fetch counts is `query_recent_read_tool_calls` (already serving `/api/skills` since #1378), **not** the cost-aggregation walker in `_try_local_store_skill_attribution`. Reusing the established Read-tool path avoids schema drift between the two fidelity surfaces.

Also notable: `/api/skills/fidelity` is registered + tested but has **no UI consumer** — `grep -r 'skills/fidelity' clawmetry/static/` returns zero hits. The dead/stuck/orphan shape is API-only (test_phase_2_to_5_live_e2e.py:173 references it). The fast path still aligns it on DuckDB so any future UI consumer doesn't pay the JSONL tax.

## Storage answer (DuckDB-first checklist)

- **Reads:** DuckDB (`events` table via `query_recent_read_tool_calls`).
- **Writes:** none (read-only endpoint).

## Test plan

- [x] `python3 -c "import dashboard"` clean.
- [x] `python3 -m pytest tests/test_moat_live_openclaw_e2e.py tests/test_moat_send_message_e2e.py tests/test_local_query_api.py tests/test_skills_fidelity_local_store_v3.py -q` → 30 passed, 1 skipped.
- [x] `python3 -m pytest tests/test_skills_fidelity_local_store_v3.py -q` → 6 passed.
- [x] Diff is 183 LOC production (well under 250 LOC budget).
- [ ] Live smoke against real `~/.clawmetry/clawmetry.duckdb` after merge — verifies the canonical-source reuse holds on real v3 data (per `feedback_synthetic_tests_missed_real_event_shape.md`).

Refs #1565.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>