### PR TITLE
feat(health): /api/gateway-health DuckDB fast path (refs #1565)

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -1336,6 +1336,87 @@ def api_system_health():
     )
 
 
+# Freshness window for the DuckDB fast path. The sync daemon captures one
+# ``gateway.metric`` sample every 30s and dedupes near-identical samples for
+# up to 5 min (GATEWAY_METRIC_INTERVAL_SEC + GATEWAY_METRIC_DEDUP_WINDOW_SEC
+# in clawmetry/sync.py). 10 min keeps us safely past the dedupe horizon
+# while still flagging "DuckDB has nothing recent → defer to live psutil".
+_GATEWAY_HEALTH_FAST_PATH_MAX_AGE_SEC = 600
+
+
+def _try_local_store_gateway_health():
+    """Fast path for /api/gateway-health — read the most-recent
+    ``gateway.metric`` event the sync daemon has already captured to
+    DuckDB instead of re-running the psutil/ps live probe on every poll
+    (Tier-1 #1565).
+
+    Why the migration:
+      * The legacy ``compute_gateway_health()`` shells out to ``ps`` (or
+        invokes ``psutil``) every request, which costs ~30-80ms on macOS
+        per call and is the dominant cost when an external monitor polls
+        this endpoint at sub-minute cadence.
+      * On a multi-node fleet, the dashboard process may not see the
+        gateway PID at all (different container / different namespace),
+        producing a misleading ``not_running`` even when DuckDB has
+        recent samples written by the sibling daemon on the host where
+        the gateway actually lives.
+      * The sync daemon already writes ``gateway.metric`` events every
+        30s (clawmetry/sync.py::capture_gateway_metric) with the exact
+        ``{pid, uptime_seconds, rss_mb, cpu_pct}`` quartet we need.
+
+    Returns the canonical ``compute_gateway_health()`` shape with the
+    additional ``_source: 'local_store'`` marker so the audit canary can
+    confirm DuckDB-first service. Returns ``None`` to defer to the live
+    probe when:
+      * DuckDB is unreachable (no daemon, no fallback handle), OR
+      * no ``gateway.metric`` event exists in the freshness window
+        (fresh install or daemon down for >10 min).
+
+    The freshness gate is intentional: a 30-minute-old DuckDB sample is
+    NOT a useful health reading; the operator wants to know the gateway
+    is alive *now*, so we defer to ``compute_gateway_health()`` which
+    will correctly report ``not_running`` instead of returning stale
+    vitals tagged ``healthy``.
+    """
+    cutoff_iso = (
+        datetime.now(timezone.utc)
+        - timedelta(seconds=_GATEWAY_HEALTH_FAST_PATH_MAX_AGE_SEC)
+    ).isoformat()
+    # Pull just enough rows to find the freshest sample (DuckDB returns
+    # newest-first under ``query_events``). limit=1 keeps the daemon-proxy
+    # round-trip cheap.
+    rows = _ls_call(
+        "query_events",
+        event_type="gateway.metric",
+        since=cutoff_iso,
+        limit=1,
+    )
+    if not rows:
+        return None
+    row = rows[0]
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    rss_mb = data.get("rss_mb")
+    cpu_pct = data.get("cpu_pct")
+    pid = data.get("pid")
+    uptime = data.get("uptime_seconds")
+    # The sync daemon never writes a sample with status=not_running
+    # (capture_gateway_metric returns early on that branch), so any row we
+    # find here represents a live gateway as of `ts`. Re-classify from
+    # rss_mb so we honour the same warning/critical thresholds the legacy
+    # path uses.
+    status = _classify_gateway_status(rss_mb, GATEWAY_MEMORY_THRESHOLD_MB)
+    return {
+        "pid": pid,
+        "uptime_seconds": uptime,
+        "rss_mb": rss_mb,
+        "cpu_pct": cpu_pct,
+        "status": status,
+        "memory_threshold_mb": GATEWAY_MEMORY_THRESHOLD_MB,
+        "sample_ts": row.get("ts"),
+        "_source": "local_store",
+    }
+
+
 @bp_health.route("/api/gateway-health")
 def api_gateway_health():
     """Standalone JSON probe for gateway process vitals (#852).
@@ -1343,7 +1424,19 @@ def api_gateway_health():
     Mirrors the ``gateway`` block returned by ``/api/system-health`` so an
     operator (or external monitor) can poll just this surface without
     pulling the full system-health payload.
+
+    Issue #1565 Tier-1: prefer the DuckDB fast path (recent
+    ``gateway.metric`` event written by the sync daemon) when
+    ``CLAWMETRY_LOCAL_STORE_READ=1``. Falls through to the live psutil/ps
+    probe when DuckDB has no recent sample or the env gate is off.
     """
+    if is_local_store_read_enabled():
+        try:
+            fast = _try_local_store_gateway_health()
+        except Exception:
+            fast = None
+        if fast is not None:
+            return jsonify(fast)
     try:
         return jsonify(compute_gateway_health())
     except Exception:

--- a/tests/test_gateway_health_local_store_v3.py
+++ b/tests/test_gateway_health_local_store_v3.py
@@ -1,0 +1,253 @@
+"""Regression guard for /api/gateway-health DuckDB fast path (Tier-1 #1565).
+
+``routes/health.py:_try_local_store_gateway_health`` reads the most-recent
+``gateway.metric`` event the sync daemon has already captured to DuckDB
+(see ``clawmetry/sync.py::capture_gateway_metric`` — runs every 30s when
+the daemon is up) instead of re-running the psutil/ps live probe on every
+poll.
+
+Why this matters:
+
+* External monitors poll ``/api/gateway-health`` at sub-minute cadence;
+  the live ``ps``/``psutil`` shell-out is the dominant per-request cost.
+* On multi-node fleets, the dashboard process may not see the gateway
+  PID at all (different container/namespace) and ``compute_gateway_health``
+  returns a misleading ``not_running`` even when DuckDB has fresh samples
+  written by the sibling daemon on the host where the gateway lives.
+
+This file seeds DuckDB ``gateway.metric`` events via ``LocalStore.ingest``
+(the same write path the sync daemon uses) and asserts:
+
+1. Populated path — recent ``gateway.metric`` event → fast path returns
+   ``_source='local_store'`` and surfaces pid/rss/cpu/uptime from the
+   sample plus the standard ``memory_threshold_mb`` field.
+2. Status re-classification — rss_mb beyond the warning/critical
+   thresholds is mapped through ``_classify_gateway_status`` (DuckDB
+   only stores raw vitals, NOT the classification).
+3. Freshness gate — a sample older than the 10-minute freshness window
+   is treated as "DuckDB has nothing recent" and the helper returns
+   ``None`` so the caller defers to the live psutil/ps probe (a
+   30-minute-old sample tagged ``healthy`` would actively mislead an
+   operator triaging an outage).
+4. Empty events table → helper returns ``None`` (NOT a populated zero
+   shell) so the route falls back to the live probe which can still
+   correctly report ``not_running`` from the missing PID file.
+5. Env gate honoured — with ``CLAWMETRY_LOCAL_STORE_READ=0`` the route
+   handler MUST NOT take the fast path even if a fresh DuckDB sample
+   exists.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+def _now_iso():
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _iso_minutes_ago(minutes: int) -> str:
+    return (
+        datetime.now(tz=timezone.utc) - timedelta(minutes=minutes)
+    ).isoformat()
+
+
+def _ingest_gateway_metric(
+    store,
+    *,
+    pid: int = 4321,
+    rss_mb: float = 320.0,
+    cpu_pct: float = 1.4,
+    uptime_seconds: int = 7200,
+    ts: str | None = None,
+):
+    """Helper: ingest one ``gateway.metric`` event in the shape
+    ``clawmetry/sync.py::capture_gateway_metric`` writes."""
+    store.ingest({
+        "id":         f"gm-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "agent_type": "openclaw",
+        "agent_id":   "openclaw-gateway",
+        "event_type": "gateway.metric",
+        "ts":         ts or _now_iso(),
+        "data": {
+            "rss_mb":         rss_mb,
+            "cpu_pct":        cpu_pct,
+            "pid":            pid,
+            "uptime_seconds": uptime_seconds,
+        },
+    })
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.health as health_mod
+    importlib.reload(health_mod)
+
+    # Isolate from a contributor's running daemon: without this, ``_ls_call``
+    # proxies through ``~/.clawmetry/local_query.json`` and the daemon
+    # queries its OWN production DuckDB instead of our tmp_path fixture.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    import dashboard  # noqa: F401
+
+    a = Flask(__name__)
+    a.register_blueprint(health_mod.bp_health)
+    yield a, ls, health_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_gateway_health_local_store_tags_source_and_returns_vitals(app):
+    """Recent ``gateway.metric`` event → fast path returns
+    ``_source='local_store'`` with pid/rss/cpu/uptime drawn from the
+    DuckDB sample plus the standard ``memory_threshold_mb`` field."""
+    a, ls, _h = app
+    store = ls.get_store()
+    _ingest_gateway_metric(
+        store,
+        pid=9876,
+        rss_mb=384.5,
+        cpu_pct=2.1,
+        uptime_seconds=12345,
+    )
+    store.flush()
+    assert len(store.query_events(event_type="gateway.metric", limit=5)) == 1
+
+    r = a.test_client().get("/api/gateway-health")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"_source must be local_store; got {body.get('_source')!r}"
+    )
+    assert body.get("pid") == 9876
+    assert body.get("rss_mb") == pytest.approx(384.5)
+    assert body.get("cpu_pct") == pytest.approx(2.1)
+    assert body.get("uptime_seconds") == 12345
+    # 384.5 MB < 75% of 900 → healthy ladder rung.
+    assert body.get("status") == "healthy"
+    # The threshold MUST be echoed back so dashboard UI can render the
+    # gauge against the canonical OpenClaw OOM cliff.
+    assert body.get("memory_threshold_mb") == 900
+    # Sample timestamp must be surfaced so operators can tell how stale
+    # the reading is.
+    assert body.get("sample_ts"), "sample_ts must be present on the fast path"
+
+
+def test_gateway_health_local_store_reclassifies_status_from_rss(app):
+    """DuckDB only stores raw vitals; the fast path MUST re-derive the
+    warning/critical status badge so the UI shows the same threshold
+    ladder the legacy path uses (not just the raw bytes)."""
+    a, ls, _h = app
+    store = ls.get_store()
+    # 950 MB sits above the 900 MB hard cap → critical rung.
+    _ingest_gateway_metric(store, rss_mb=950.0, pid=1111)
+    store.flush()
+
+    r = a.test_client().get("/api/gateway-health")
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    assert body["status"] == "critical", (
+        f"rss_mb=950 must classify as critical (>900 MB cap); got {body['status']!r}"
+    )
+
+
+def test_gateway_health_local_store_freshness_gate_defers_old_samples(app):
+    """A sample older than the 10-minute freshness window MUST be ignored
+    and the helper returns ``None`` so the route defers to the live
+    psutil/ps probe. Otherwise a daemon that died 30 min ago would keep
+    reporting ``healthy`` to operators triaging an outage."""
+    a, ls, health_mod = app
+    store = ls.get_store()
+    # 25 min ago — comfortably past the 10-min freshness gate.
+    _ingest_gateway_metric(store, ts=_iso_minutes_ago(25))
+    store.flush()
+    # Sanity: the row is in DuckDB; only the freshness gate should hide it.
+    assert len(store.query_events(event_type="gateway.metric", limit=5)) == 1
+
+    fast = health_mod._try_local_store_gateway_health()
+    assert fast is None, (
+        "stale gateway.metric sample must NOT serve the fast path; "
+        "operator needs the live probe to flag the outage"
+    )
+
+
+def test_gateway_health_local_store_empty_returns_none(app):
+    """Empty events table → helper returns ``None`` so the route falls
+    back to ``compute_gateway_health()``. Unlike rate-limits (where an
+    empty zero-shell is meaningful), gateway-health's empty answer
+    requires the live psutil probe — DuckDB silence doesn't prove the
+    gateway is down, it just proves the daemon hasn't written yet."""
+    a, ls, health_mod = app
+    assert ls.get_store().query_events(event_type="gateway.metric", limit=5) == []
+    fast = health_mod._try_local_store_gateway_health()
+    assert fast is None, (
+        "no gateway.metric rows → helper must defer; legacy probe is the "
+        "only source of ground truth here"
+    )
+
+
+def test_gateway_health_env_gate_off_bypasses_fast_path(tmp_path, monkeypatch):
+    """With ``CLAWMETRY_LOCAL_STORE_READ=0`` the route MUST NOT call the
+    fast path even when a fresh DuckDB sample exists. Guards against
+    accidental default-ON regressions
+    (feedback_local_store_default_off_killed_moat.md, inverse: opt-OUT
+    must work too)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "0")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.health as health_mod
+    importlib.reload(health_mod)
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    store = ls.get_store()
+    _ingest_gateway_metric(store, pid=2222, rss_mb=300.0)
+    store.flush()
+
+    import dashboard  # noqa: F401
+    a = Flask(__name__)
+    a.register_blueprint(health_mod.bp_health)
+
+    # Force the legacy path to report a deterministic "not_running" so
+    # the assertion below doesn't accidentally hit a real local gateway
+    # on a contributor's box.
+    import routes.health as _rh
+    monkeypatch.setattr(
+        _rh, "compute_gateway_health",
+        lambda *a, **kw: {
+            "pid": None, "uptime_seconds": None, "rss_mb": None,
+            "cpu_pct": None, "status": "not_running",
+            "memory_threshold_mb": 900,
+        },
+    )
+
+    r = a.test_client().get("/api/gateway-health")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") is None, (
+        "env-gate OFF must NOT take the local_store fast path; got "
+        f"_source={body.get('_source')!r}"
+    )
+    # The legacy stub above returned not_running → confirm we received it.
+    assert body.get("status") == "not_running"
+    assert body.get("pid") is None


### PR DESCRIPTION
## Summary

Tier-1 #8 from the [2026-05-17 DuckDB coverage audit (#1565)](https://github.com/vivekchand/clawmetry/issues/1565). Promotes `/api/gateway-health` from a per-request `psutil`/`ps` shell-out to a DuckDB read of the most-recent `gateway.metric` event the sync daemon already captures every 30s. Tags `_source='local_store'` so the audit canary can confirm DuckDB-first service.

## Why

- The legacy `compute_gateway_health()` shells out to `ps`/`psutil` on every request (~30-80ms on macOS); the dominant cost when external monitors poll at sub-minute cadence.
- On multi-node fleets, the dashboard process may not see the gateway PID at all (different container/namespace) and currently returns a misleading `not_running` even when DuckDB has fresh samples from the sibling daemon on the host where the gateway actually lives.
- `gateway.metric` events already land in DuckDB via `clawmetry/sync.py::capture_gateway_metric` — **the daemon-ingest work the audit hinted at is already done**, so this is a route-side-only migration.

## Audit hint vs reality

The audit row for `/api/gateway-health` was tagged "needs daemon ingest of `gateway.metric` events" — that work already shipped (see `clawmetry/sync.py:4097`). Route-side migration is the only remaining piece; no sub-issue needed. Note for the audit: legacy route was NOT JSONL-fallback (it was a live psutil/ps probe), but tagging `_source='local_store'` still makes the new DuckDB-first behaviour visible and unblocks the multi-node/external-monitor scenarios.

## Design

- `_try_local_store_gateway_health()` reads via `_ls_call` (daemon HTTP proxy first, single-process DuckDB fallback) — same pattern as the rate-limits fast path (PR #1572) and `_query_gateway_metric_history`.
- **10-minute freshness gate.** A 30-min-old sample tagged `healthy` would actively mislead an operator triaging an outage, so stale rows defer to the live probe (which correctly reports `not_running`).
- **Status re-derived** from `rss_mb` through `_classify_gateway_status` so the warning/critical badge ladder matches the legacy path exactly (DuckDB only stores raw vitals).
- **Empty events table → return `None`** (NOT a zero-shell) so the legacy probe still runs. DuckDB silence doesn't prove the gateway is down.
- Wired behind `is_local_store_read_enabled()` — opt-in via `CLAWMETRY_LOCAL_STORE_READ=1`, same env gate the rest of the MOAT migration uses.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `tests/test_gateway_health_local_store_v3.py` (5 new): populated path tags `_source=local_store`, status re-classification, freshness gate defers stale samples, empty store defers to live probe, env-gate OFF bypasses fast path
- [x] `tests/test_gateway_health.py` + `tests/test_gateway_metric_history.py` (49 existing) still green — no regression in the legacy probe or sparkline endpoint
- [x] Full required suite: `test_moat_live_openclaw_e2e.py + test_moat_send_message_e2e.py + test_local_query_api.py + test_rate_limits_local_store_v3.py + test_gateway_health_local_store_v3.py` → 34 passed, 1 skipped
- [x] Production diff 93 LOC (≤250 budget)

Refs #1565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)