### PR TITLE
feat(usage): /api/token-attribution DuckDB fast path (refs #1565)

### DIFF
--- a/routes/usage.py
+++ b/routes/usage.py
@@ -1344,6 +1344,242 @@ def _try_local_store_token_velocity():
     }
 
 
+def _try_local_store_token_attribution(wanted_sid: str = "", limit: int = 100):
+    """Fast path for /api/token-attribution (issue #1565 Tier-1 #7).
+
+    Audit imperfection (#1565) captured here as a silent user-visible
+    bug: the legacy JSONL walker (``api_token_attribution`` below)
+    filters on ``ev['type'] == 'message'``, which is the pre-v3
+    synthetic shape only. On real OpenClaw v3 installs the daemon-
+    normalised event types are ``assistant`` / ``model.completed`` (see
+    ``reference_openclaw_v3_event_types.md``), so the legacy handler
+    silently returns an empty ``messages`` array on every v3 install.
+    Same failure family as Eng G's PR #1571 (forecast) and Eng L's
+    cost-optimizer ring-reset.
+
+    Shape parity contract: ``messages[].{session_id, timestamp, model,
+    role, tokens{}, cost{}, cache_hit_ratio}`` plus ``totals{}`` and
+    ``session_id``.
+
+    Dedupe via ``build_sibling_bucket_max`` (same approach as
+    ``_try_local_store_token_velocity``) — exactly the bug family
+    ``feedback_usage_dedupe_pattern.md`` warns about. Returns ``None``
+    on store-unreachable or zero matching rows so the JSONL walker
+    fires (rather than claiming ``_source: 'local_store'`` falsely on
+    an empty answer).
+    """
+    store = _ls_get_store()
+    if store is None:
+        return None
+
+    # 14-day window matches the headline ``/api/usage`` chart. The legacy
+    # walker has no window cap, but on a busy box it scans 50 mtime-sorted
+    # files anyway — 14d covers every billable turn the cost dashboard
+    # actually charts.
+    cutoff_ts = time.time() - 14 * 86400
+    since_iso = datetime.utcfromtimestamp(cutoff_ts).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    try:
+        if wanted_sid:
+            rows = store.query_events(
+                session_id=wanted_sid, since=since_iso, limit=10000,
+            ) or []
+        else:
+            rows = store.query_events(since=since_iso, limit=10000) or []
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    # Sibling-pair dedupe (issue #1460 family). assistant/message outrank
+    # model.completed; we drop only the slim sibling when a rich envelope
+    # exists in the same (sid, sec±1) bucket.
+    bucket_max = build_sibling_bucket_max(rows)
+
+    _ROLE_BY_EVENT = {
+        "assistant":        "assistant",
+        "message":          "assistant",  # legacy synthetic
+        "model.completed":  "assistant",
+        "prompt.submitted": "user",
+        "user":             "user",
+    }
+
+    messages = []
+    totals = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "total_tokens": 0,
+        "input_cost": 0.0,
+        "output_cost": 0.0,
+        "cache_read_cost": 0.0,
+        "cache_write_cost": 0.0,
+        "total_cost": 0.0,
+    }
+
+    # Lazy import — only this fast path needs the v3 split extractor.
+    try:
+        from clawmetry.local_store import (
+            _extract_usage_splits, _extract_usage_cost,
+        )
+    except Exception:
+        return None
+
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        if is_sibling_dup(r, bucket_max):
+            continue
+        et = (r.get("event_type") or "").strip()
+        # Only attribute rows that actually carry usage. Tool calls /
+        # session.started / model.changed don't get a row in the legacy
+        # contract either.
+        if et not in _ROLE_BY_EVENT and et not in ("assistant", "message", "model.completed"):
+            continue
+
+        data = r.get("data") if isinstance(r.get("data"), dict) else {}
+        splits = _extract_usage_splits(data) if isinstance(data, dict) else {
+            "input_tokens": 0, "output_tokens": 0,
+            "cache_read_tokens": 0, "cache_write_tokens": 0,
+        }
+        input_tok  = int(splits.get("input_tokens", 0) or 0)
+        output_tok = int(splits.get("output_tokens", 0) or 0)
+        cache_read = int(splits.get("cache_read_tokens", 0) or 0)
+        cache_write = int(splits.get("cache_write_tokens", 0) or 0)
+        total_tok = input_tok + output_tok + cache_read + cache_write
+
+        # Fall back to the daemon-stamped scalar column when the data
+        # blob splits are empty (e.g. slim ``model.completed`` rows that
+        # survived the sibling dedupe because no rich envelope existed).
+        # We attribute the whole row to ``input_tokens`` in that case so
+        # the totals don't drop the row — see Eng G's PR #1571 lesson:
+        # *don't blindly replace an aggregate with a deduped subset*.
+        if total_tok == 0:
+            col_tok = int(r.get("token_count") or 0)
+            if col_tok > 0:
+                input_tok = col_tok
+                total_tok = col_tok
+
+        if total_tok == 0:
+            continue
+
+        # Per-bucket cost split: prefer the v3 ``cost.{input,...}`` shape
+        # under data.message.usage when present, fall back to the
+        # daemon-stamped scalar for total.
+        in_cost = out_cost = cr_cost = cw_cost = 0.0
+        col_cost = 0.0
+        try:
+            col_cost = float(r.get("cost_usd") or 0.0)
+        except (TypeError, ValueError):
+            col_cost = 0.0
+        # Walk message.usage.cost for the per-bucket split (legacy shape).
+        msg_dict = data.get("message") if isinstance(data, dict) else None
+        if isinstance(msg_dict, dict):
+            u = msg_dict.get("usage") or {}
+            if isinstance(u, dict):
+                cost_obj = u.get("cost") or {}
+                if isinstance(cost_obj, dict):
+                    in_cost = float(cost_obj.get("input", 0) or 0)
+                    out_cost = float(cost_obj.get("output", 0) or 0)
+                    cr_cost = float(cost_obj.get("cacheRead", 0) or 0)
+                    cw_cost = float(cost_obj.get("cacheWrite", 0) or 0)
+        # Total: prefer scalar column (the daemon already wrote it from
+        # the cheapest source); fall back to extractor walk for legacy
+        # snapshots; finally sum the per-bucket splits.
+        total_cost = col_cost
+        if total_cost <= 0 and isinstance(data, dict):
+            total_cost = _extract_usage_cost(data)
+        if total_cost <= 0:
+            total_cost = in_cost + out_cost + cr_cost + cw_cost
+
+        # Model: prefer the column; data blob fallback covers older v3
+        # snapshots where the daemon didn't populate the scalar.
+        model = r.get("model") or ""
+        if not model and isinstance(data, dict):
+            if isinstance(msg_dict, dict):
+                model = msg_dict.get("model") or ""
+            if not model:
+                model = data.get("modelId") or data.get("model") or ""
+        model = model or "unknown"
+
+        # Role: prefer the explicit message.role (v3 assistants carry it
+        # in the Anthropic envelope), else infer from event_type.
+        role = "unknown"
+        if isinstance(msg_dict, dict):
+            r_role = msg_dict.get("role")
+            if isinstance(r_role, str) and r_role:
+                role = r_role
+        if role == "unknown":
+            role = _ROLE_BY_EVENT.get(et, "unknown")
+
+        sid = r.get("session_id") or ""
+        ts = r.get("ts") or ""
+        cache_hit_pct = (
+            round(cache_read / (input_tok + cache_read) * 100, 1)
+            if (input_tok + cache_read) > 0 else 0.0
+        )
+        messages.append({
+            "session_id": sid,
+            "timestamp": ts,
+            "model": model,
+            "role": role,
+            "tokens": {
+                "input": input_tok,
+                "output": output_tok,
+                "cache_read": cache_read,
+                "cache_write": cache_write,
+                "total": total_tok,
+            },
+            "cost": {
+                "input": round(in_cost, 8),
+                "output": round(out_cost, 8),
+                "cache_read": round(cr_cost, 8),
+                "cache_write": round(cw_cost, 8),
+                "total": round(total_cost, 8),
+            },
+            "cache_hit_ratio": cache_hit_pct,
+        })
+        totals["input_tokens"]       += input_tok
+        totals["output_tokens"]      += output_tok
+        totals["cache_read_tokens"]  += cache_read
+        totals["cache_write_tokens"] += cache_write
+        totals["total_tokens"]       += total_tok
+        totals["input_cost"]         += in_cost
+        totals["output_cost"]        += out_cost
+        totals["cache_read_cost"]    += cr_cost
+        totals["cache_write_cost"]   += cw_cost
+        totals["total_cost"]         += total_cost
+
+    if not messages:
+        return None
+
+    for k in ("input_cost", "output_cost", "cache_read_cost",
+              "cache_write_cost", "total_cost"):
+        totals[k] = round(totals[k], 6)
+
+    # Sort by timestamp descending and apply limit. ISO-8601 sorts
+    # lexically when zones match — which they always do here since the
+    # daemon writes UTC.
+    messages.sort(key=lambda m: m.get("timestamp") or "", reverse=True)
+    messages = messages[:limit]
+
+    input_plus_cache = totals["input_tokens"] + totals["cache_read_tokens"]
+    totals["cache_hit_ratio_pct"] = (
+        round(totals["cache_read_tokens"] / input_plus_cache * 100, 1)
+        if input_plus_cache else 0.0
+    )
+
+    return {
+        "messages":   messages,
+        "totals":     totals,
+        "session_id": wanted_sid if wanted_sid else None,
+        "_source":    "local_store",
+    }
+
+
 @bp_usage.route("/api/usage")
 def api_usage():
     """Token/cost tracking from transcript files - Enhanced OTLP workaround."""
@@ -3190,6 +3426,20 @@ def api_token_attribution():
         limit = max(1, min(int(request.args.get('limit', '100')), 1000))
     except ValueError:
         limit = 100
+
+    # Tier-1 DuckDB fast path (issue #1565 audit #7). Reads deduped v3
+    # events; tagged ``_source: 'local_store'``. Returns ``None`` to
+    # defer to the JSONL walker when the store is unreachable or empty.
+    # NOTE: the legacy walker only handles the pre-v3 synthetic
+    # ``type=='message'`` shape, so on real v3 installs the fast path is
+    # the ONLY surface that returns rows — see audit-imperfection note
+    # in the helper docstring.
+    if is_local_store_read_enabled():
+        fast = _try_local_store_token_attribution(
+            wanted_sid=wanted_sid, limit=limit,
+        )
+        if fast is not None:
+            return jsonify(fast)
 
     sessions_dir = _d._get_sessions_dir()
     if not os.path.isdir(sessions_dir):

--- a/tests/test_token_attribution_local_store_v3.py
+++ b/tests/test_token_attribution_local_store_v3.py
@@ -1,0 +1,291 @@
+"""Synthetic safety net for /api/token-attribution DuckDB fast path
+(Tier-1 surface #7 in issue #1565).
+
+``routes/usage.py::_try_local_store_token_attribution`` returns per-LLM-
+turn token + cost rows from DuckDB, replacing a JSONL walker whose
+``ev['type'] == 'message'`` filter silently misses every v3 install
+(real OpenClaw v3 emits ``assistant`` / ``model.completed`` after the
+daemon's namespace rewrite — see ``reference_openclaw_v3_event_types.md``).
+
+This file seeds DuckDB with the SAME daemon-normalised event shapes
+that ``clawmetry/sync.py::_parse_v3_event`` writes and asserts:
+
+1. Populated store returns ``_source='local_store'`` with one row per
+   billable turn and correct token/cost totals.
+2. Empty store → None so the legacy JSONL walker fires.
+3. v3 sibling pair (``assistant`` + slim ``model.completed`` ~100 ms apart,
+   identical ``token_count``) must NOT double-count. Same risk class as
+   ``feedback_usage_dedupe_pattern.md`` (PR #1444, PR #1571).
+4. ``session_id=`` query filter restricts the result set.
+5. Slim ``model.completed`` row with no rich sibling still surfaces via
+   the scalar-column fallback (defends against Eng G's "blind-replace-
+   aggregate-with-deduped-subset" failure mode).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.usage as usage_mod
+    importlib.reload(usage_mod)
+
+    # Issue #1538 pattern: isolate fixture from a developer's locally
+    # running clawmetry daemon. Without this the proxy reaches into
+    # ``~/.clawmetry/local_query.json`` and queries the dev daemon's
+    # production DuckDB instead of our tmp_path fixture.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    a = Flask(__name__)
+    a.register_blueprint(usage_mod.bp_usage)
+    yield a, ls, usage_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _drain(store):
+    store._flush_now()
+    for _ in range(20):
+        if not store._ring:
+            break
+        time.sleep(0.05)
+
+
+def _iso(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()
+
+
+def _assistant_row(event_id, sid, ts, *, input_t, output_t,
+                   cache_read=0, cache_write=0, cost_total=0.0,
+                   model="claude-opus-4-7"):
+    """Build the v3 ``assistant`` event row the daemon writes for one
+    LLM turn — Anthropic-SDK envelope under data.message.usage."""
+    data = {
+        "_v3_type": "message",
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "model": model,
+            "usage": {
+                "input_tokens": input_t,
+                "output_tokens": output_t,
+                "cache_read_input_tokens": cache_read,
+                "cache_creation_input_tokens": cache_write,
+                "cost": {
+                    "input": cost_total * 0.4,
+                    "output": cost_total * 0.5,
+                    "cacheRead": cost_total * 0.05,
+                    "cacheWrite": cost_total * 0.05,
+                    "total": cost_total,
+                },
+            },
+        },
+    }
+    return {
+        "id":           event_id,
+        "node_id":      "node-test",
+        "agent_type":   "openclaw",
+        "agent_id":     "main",
+        "session_id":   sid,
+        "workspace_id": None,
+        "event_type":   "assistant",
+        "ts":           ts,
+        "data":         json.dumps(data),
+        "cost_usd":     cost_total,
+        "token_count":  input_t + output_t + cache_read + cache_write,
+        "model":        model,
+    }
+
+
+def _model_completed_row(event_id, sid, ts, *, tokens, cost,
+                         model="claude-opus-4-7"):
+    """Slim ``model.completed`` sibling — no usage splits, just the
+    daemon-stamped scalar token_count / cost_usd columns."""
+    data = {
+        "_v3_type": "message",
+        "type": "model.completed",
+        "modelId": model,
+    }
+    return {
+        "id":           event_id,
+        "node_id":      "node-test",
+        "agent_type":   "openclaw",
+        "agent_id":     "main",
+        "session_id":   sid,
+        "workspace_id": None,
+        "event_type":   "model.completed",
+        "ts":           ts,
+        "data":         json.dumps(data),
+        "cost_usd":     cost,
+        "token_count":  tokens,
+        "model":        model,
+    }
+
+
+def test_populated_store_returns_local_store_source(app):
+    """Two assistant turns on one session — fast path must return both,
+    correctly summed, with ``_source='local_store''."""
+    a, ls, _usage = app
+    store = ls.get_store()
+    sid = "sess-token-attr"
+    now = time.time()
+
+    store.ingest(_assistant_row(
+        "e1", sid, _iso(now - 120),
+        input_t=1000, output_t=500, cache_read=200, cache_write=100,
+        cost_total=0.012,
+    ))
+    store.ingest(_assistant_row(
+        "e2", sid, _iso(now - 60),
+        input_t=2000, output_t=800, cache_read=400, cache_write=0,
+        cost_total=0.025,
+    ))
+    _drain(store)
+
+    r = a.test_client().get("/api/token-attribution")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"expected _source=local_store; got {body.get('_source')!r}"
+    )
+    msgs = body.get("messages") or []
+    assert len(msgs) == 2, f"expected 2 attributed turns; got {len(msgs)}"
+    totals = body.get("totals") or {}
+    assert totals.get("input_tokens") == 3000
+    assert totals.get("output_tokens") == 1300
+    assert totals.get("cache_read_tokens") == 600
+    assert totals.get("cache_write_tokens") == 100
+    assert totals.get("total_tokens") == 5000
+    # Cost totals (allow tiny float wobble).
+    assert abs(totals.get("total_cost", 0) - 0.037) < 1e-6
+    assert totals.get("cache_hit_ratio_pct") == round(600 / 3600 * 100, 1)
+
+
+def test_empty_store_returns_none_for_legacy_fallback(app):
+    """No events at all → helper must return None so the legacy JSONL
+    walker fires. Without this guard, a brand-new install would render
+    a falsely-tagged ``_source='local_store'`` empty shell even when
+    session JSONLs on disk DO carry attributable rows."""
+    a, ls, usage_mod = app
+    assert ls.get_store().query_events(limit=10) == []
+
+    fast = usage_mod._try_local_store_token_attribution()
+    assert fast is None, (
+        f"empty store must return None; got {fast!r}"
+    )
+
+
+def test_v3_sibling_pair_does_not_double_count(app):
+    """v3 dedupe guard (matches ``feedback_usage_dedupe_pattern.md``).
+
+    A rich ``assistant`` row + a slim sibling ``model.completed`` ~0 s
+    apart, both stamped with the same ``token_count``, must NOT yield
+    two attribution rows or doubled totals. ``build_sibling_bucket_max``
+    drops the slim sibling.
+    """
+    a, ls, usage_mod = app
+    store = ls.get_store()
+    sid = "sess-sibling"
+    now = time.time()
+    ts_iso = _iso(now - 30)
+
+    store.ingest(_assistant_row(
+        "e-rich", sid, ts_iso,
+        input_t=3000, output_t=1500, cost_total=0.02,
+    ))
+    store.ingest(_model_completed_row(
+        "e-slim", sid, ts_iso,
+        tokens=4500, cost=0.02,
+    ))
+    _drain(store)
+
+    fast = usage_mod._try_local_store_token_attribution()
+    assert fast is not None
+    msgs = fast.get("messages") or []
+    assert len(msgs) == 1, (
+        f"sibling pair double-counted; got {len(msgs)} rows: {msgs!r}"
+    )
+    totals = fast.get("totals") or {}
+    assert totals.get("total_tokens") == 4500, (
+        f"sibling double-count: expected 4500 total tokens, "
+        f"got {totals.get('total_tokens')}"
+    )
+    assert abs(totals.get("total_cost", 0) - 0.02) < 1e-6
+
+
+def test_session_id_filter_restricts_rows(app):
+    """``?session_id=X`` must restrict the result to that session's
+    turns only — query param is the explicit single-session drill-down
+    contract the legacy handler offered."""
+    a, ls, _usage = app
+    store = ls.get_store()
+    now = time.time()
+
+    store.ingest(_assistant_row(
+        "e-a", "sess-A", _iso(now - 60),
+        input_t=1000, output_t=500, cost_total=0.01,
+    ))
+    store.ingest(_assistant_row(
+        "e-b", "sess-B", _iso(now - 30),
+        input_t=2000, output_t=1000, cost_total=0.02,
+    ))
+    _drain(store)
+
+    r = a.test_client().get("/api/token-attribution?session_id=sess-A")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert body.get("session_id") == "sess-A"
+    msgs = body.get("messages") or []
+    assert len(msgs) == 1
+    assert msgs[0]["session_id"] == "sess-A"
+    assert msgs[0]["tokens"]["total"] == 1500
+
+
+def test_slim_completed_without_sibling_still_surfaces(app):
+    """A standalone ``model.completed`` row (no rich sibling within the
+    ±1 s window) must still produce an attribution row via the scalar-
+    column fallback. Guards against the Eng G failure mode: don't
+    silently drop tokens just because the rich envelope is absent."""
+    a, ls, _usage = app
+    store = ls.get_store()
+    sid = "sess-slim-only"
+    now = time.time()
+
+    store.ingest(_model_completed_row(
+        "e-solo", sid, _iso(now - 45),
+        tokens=2500, cost=0.015,
+    ))
+    _drain(store)
+
+    r = a.test_client().get("/api/token-attribution")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    msgs = body.get("messages") or []
+    assert len(msgs) == 1, (
+        f"slim model.completed dropped silently; got {msgs!r}"
+    )
+    totals = body.get("totals") or {}
+    assert totals.get("total_tokens") == 2500
+    assert abs(totals.get("total_cost", 0) - 0.015) < 1e-6
+    # Role inferred from event_type when message envelope is absent.
+    assert msgs[0]["role"] == "assistant"


### PR DESCRIPTION
## Summary

- Tier-1 #7 from the 2026-05-17 DuckDB coverage audit (issue #1565). Adds `_try_local_store_token_attribution` to `routes/usage.py`; wires it ahead of the JSONL walker in `/api/token-attribution`. Tagged `_source: 'local_store'`, falls through to legacy on store-unreachable or empty.
- Sibling-pair dedupe via shared `build_sibling_bucket_max` / `is_sibling_dup` helpers (PR #1462 family). Scalar-column fallback for standalone `model.completed` rows so we don't trip the Eng G "blindly replace aggregate with deduped subset" failure mode.
- 250 LOC production. New synthetic safety net at `tests/test_token_attribution_local_store_v3.py` (5 tests: populated / empty / sibling-pair dedupe / session_id filter / slim-completed fallback).

## Silent user-visible bug found

Captured in the helper docstring + commit body: the legacy JSONL walker filters on `ev['type'] == 'message'`, which is the **pre-v3 synthetic shape** only. On real OpenClaw v3 installs the daemon-normalised event types are `assistant` / `model.completed` (see `reference_openclaw_v3_event_types.md`), so the legacy `/api/token-attribution` silently returned an **empty `messages` array on every v3 install**. Same family as Eng G's PR #1571 (forecast) and Eng L's cost-optimizer ring-reset — surfaces that "work" against synthetic tests but flunk against the v3 vocabulary. This fast path closes the gap; the JSONL fallback remains for legacy snapshots.

## Where does this read/write live?

DuckDB only — `query_events` via the daemon HTTP proxy (`_ls_get_store` → `_DaemonProxyStore`), with single-process fallback for tests. No new Postgres reads, no JSONL reads on the fast path.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_moat_live_openclaw_e2e.py tests/test_moat_send_message_e2e.py tests/test_local_query_api.py tests/test_token_attribution_local_store_v3.py tests/test_usage_forecast_local_store_v3.py tests/test_token_velocity_local_store_v3.py tests/test_skills_fidelity_local_store_v3.py -q` → 45 passed, 1 skipped
- [x] Diff ≤ 250 LOC production (exact)

Refs #1565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)