### PR TITLE
feat(channels): telegram + signal DuckDB fast path (refs #1565)

### DIFF
--- a/routes/channels.py
+++ b/routes/channels.py
@@ -393,6 +393,163 @@ def _try_local_store_provider_messages(
     return _format_local_store_provider_messages(provider, rows, limit, extras)
 
 
+# ── Tier-1 #1565: v3 events-table fallback for channel messages ────────────
+#
+# Background: ``_try_local_store_provider_messages`` above reads from the
+# specialized ``channel_messages`` table (Phase 5). That table can be empty
+# even when the daemon has already captured channel turns into the unified
+# ``events`` table — there are real ingest paths where the chokepoint
+# wrote the ``events`` projection but the ``channel_messages`` UPSERT was
+# skipped (e.g. PRIMARY KEY conflicts on re-ingest after a daemon
+# restart, or a legacy ``ingest`` caller that wrote only the events row).
+#
+# Without this fallback every Telegram / Signal poll would silently fall
+# through to the legacy gateway.log grep + JSONL walker — exactly the
+# silent-zero bug class memory `feedback_synthetic_tests_missed_real_event_shape.md`
+# warns about: synthetic tests pass on the specialised table while real
+# v3 data only lands in ``events``.
+#
+# The chokepoint contract (``LocalStore.ingest_channel_event`` — see PR
+# #1220) stamps EACH channel turn with ``event_type='channel.in'`` or
+# ``'channel.out'`` and embeds the provider tag under ``data.provider``,
+# so we can serve telegram/signal/etc. from a single events query.
+
+# Newest-first window we scan when the dedicated channel_messages table
+# came back empty. Matches ``query_channel_messages``' default page-size
+# upper bound so the today-counters stay accurate.
+_CHANNEL_EVENTS_FAST_PATH_LIMIT = 1000
+
+
+def _format_channel_event_row(ev):
+    """Project one ``events`` row (event_type='channel.in'|'channel.out')
+    into the legacy ``{timestamp, direction, sender, text, chatId,
+    sessionId}`` envelope the per-channel routes return.
+
+    Mirrors ``routes/brain.py`` channel-event enrichment so the field
+    extraction follows a single shared shape. Returns ``None`` if the row
+    is unusable (no data dict / no body anywhere)."""
+    data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+    if not isinstance(data, dict):
+        return None
+    direction = "out" if str(ev.get("event_type") or "").endswith(".out") else "in"
+    # Body lookup order matches the chokepoint write rules
+    # (``ingest_channel_event``): the JSONL/WS path leaves the full payload
+    # under data and the gateway-log path stamps a small breadcrumb.
+    body = (
+        data.get("body")
+        or data.get("text")
+        or data.get("message")
+        or ""
+    )
+    if isinstance(body, dict):
+        body = body.get("text") or body.get("body") or ""
+    body = str(body)[:300]
+    # sender: prefer flat sender_name, fall back to the from/user blocks
+    # the WS-tap path emits (mirrors routes/brain.py logic).
+    sender = data.get("sender_name") or data.get("sender") or ""
+    if not sender:
+        for blk_key in ("from", "user"):
+            blk = data.get(blk_key)
+            if isinstance(blk, dict):
+                sender = (
+                    blk.get("username")
+                    or blk.get("first_name")
+                    or blk.get("name")
+                    or ""
+                )
+                if sender:
+                    break
+    if not sender:
+        sender = "User" if direction == "in" else "Clawd"
+    chat_id = data.get("channel_id") or data.get("chat_id") or ""
+    if not chat_id and isinstance(data.get("chat"), dict):
+        chat_id = data["chat"].get("id") or ""
+    return {
+        "timestamp":  ev.get("ts") or "",
+        "direction":  direction,
+        "sender":     str(sender)[:80],
+        "text":       body,
+        "chatId":     str(chat_id)[:80] if chat_id else "",
+        "sessionId":  ev.get("session_id") or "",
+    }
+
+
+def _try_local_store_channel_events(provider, limit):
+    """Tier-1 #1565 v3 events-table fallback for per-provider channel
+    routes. Used by ``api_channel_telegram`` + ``api_channel_signal``
+    (and ready for the other 6 chat channels) AFTER the
+    ``channel_messages`` fast path returns None.
+
+    Why a second helper instead of just one query:
+    ``_try_local_store_provider_messages`` reads the specialised
+    ``channel_messages`` table, which is the canonical projection but
+    can lag the ``events`` table when an ingest path took the ``ingest``
+    side-door instead of the ``ingest_channel_event`` chokepoint (PR
+    #1220 closed the known gaps but a row can still be in ``events`` and
+    not in ``channel_messages`` on rare schema-drift / re-ingest paths).
+    Without this fallback the route silently falls through to the
+    gateway.log grep + JSONL walker — the same silent-zero hazard memory
+    `feedback_synthetic_tests_missed_real_event_shape.md` warns about.
+
+    Queries both ``channel.in`` and ``channel.out`` events, filters by
+    ``data.provider`` in Python (DuckDB JSON predicate would need an
+    extra ``LocalStore`` helper — keeping the daemon-proxy contract
+    surface minimal), reshapes via ``_format_channel_event_row``, and
+    returns the legacy envelope tagged ``_source: 'local_store_v3'`` so
+    the audit canary can distinguish the events-table path from the
+    specialised-table path.
+
+    Returns ``None`` when ``events`` also has nothing for this provider
+    so callers fall through to the legacy log-grep walker."""
+    provider_key = (provider or "").lower().strip()
+    if not provider_key:
+        return None
+    # ``query_events`` takes a single event_type filter; we make two calls
+    # (cheap — both rows ORDER BY ts DESC + LIMIT N) and merge.
+    rows_in = _ls_call(
+        "query_events",
+        event_type="channel.in",
+        limit=_CHANNEL_EVENTS_FAST_PATH_LIMIT,
+    ) or []
+    rows_out = _ls_call(
+        "query_events",
+        event_type="channel.out",
+        limit=_CHANNEL_EVENTS_FAST_PATH_LIMIT,
+    ) or []
+    matched = []
+    for ev in list(rows_in) + list(rows_out):
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        if not isinstance(data, dict):
+            continue
+        # Provider tag is stamped by ``ingest_channel_event``'s data
+        # projection (see clawmetry/local_store.py:1233-1248). Case-fold
+        # to defend against legacy producers that wrote mixed case.
+        ev_provider = str(data.get("provider") or "").lower().strip()
+        if ev_provider != provider_key:
+            continue
+        row = _format_channel_event_row(ev)
+        if row is not None:
+            matched.append(row)
+    if not matched:
+        return None
+    # Newest-first across the union of the two event_type pulls.
+    matched.sort(key=lambda r: r.get("timestamp") or "", reverse=True)
+    today = datetime.now().strftime("%Y-%m-%d")
+    today_in = sum(
+        1 for r in matched if r["direction"] == "in" and today in str(r["timestamp"])
+    )
+    today_out = sum(
+        1 for r in matched if r["direction"] == "out" and today in str(r["timestamp"])
+    )
+    return {
+        "messages":  matched[:limit],
+        "total":     len(matched),
+        "todayIn":   today_in,
+        "todayOut":  today_out,
+        "_source":   "local_store_v3",
+    }
+
+
 @bp_channels.route("/api/channels/<provider>/messages")
 def api_channel_messages(provider: str):
     """List recent messages for one provider — DuckDB fast path
@@ -490,6 +647,16 @@ def api_channel_telegram():
             # Honour the legacy ``offset`` paginator the Telegram tab uses
             # for "load more". The other per-provider routes don't expose
             # offset so the shared helper doesn't bake it in.
+            msgs = fast.get("messages") or []
+            fast["messages"] = msgs[offset : offset + limit]
+            return jsonify(fast)
+        # Tier-1 #1565: v3 events-table fallback when the specialised
+        # ``channel_messages`` table is empty but ``events`` carries the
+        # channel.in / channel.out turns the daemon already captured. See
+        # ``_try_local_store_channel_events`` docstring for the silent-zero
+        # bug-class this guards against.
+        fast = _try_local_store_channel_events("telegram", limit + offset)
+        if fast is not None:
             msgs = fast.get("messages") or []
             fast["messages"] = msgs[offset : offset + limit]
             return jsonify(fast)
@@ -987,6 +1154,17 @@ def api_channel_signal():
 
     if _local_store_read_enabled():
         fast = _try_local_store_provider_messages("signal", limit)
+        if fast is not None:
+            return jsonify(fast)
+        # Tier-1 #1565: v3 events-table fallback. Signal DOES land JSONL
+        # under ``~/.openclaw/signal/*.jsonl`` so the legacy walker isn't
+        # purely dead code, but on real OpenClaw v3 installs the daemon
+        # ingests those JSONLs into the ``events`` table directly via the
+        # ``ingest_channel_event`` chokepoint — meaning a daemon that
+        # restarted between channel_messages writes can leave ``events``
+        # populated but ``channel_messages`` empty. Same bug class as the
+        # MOAT silent-zero memory `feedback_synthetic_tests_missed_real_event_shape.md`.
+        fast = _try_local_store_channel_events("signal", limit)
         if fast is not None:
             return jsonify(fast)
 

--- a/tests/test_channel_signal_local_store_v3.py
+++ b/tests/test_channel_signal_local_store_v3.py
@@ -1,0 +1,233 @@
+"""Regression guard for the /api/channel/signal DuckDB v3 events fast path
+(Tier-1 #1565, refs #1583's coverage audit).
+
+Same shape as ``test_channel_telegram_local_store_v3.py`` — both routes
+share ``_try_local_store_channel_events`` and the silent-zero contract
+this guards against (events table populated, channel_messages empty after
+a daemon restart or a legacy ``ingest()`` side-door) applies equally to
+the Signal adapter.
+
+Tests cover:
+
+  1. Populated path — telegram + signal rows seeded; signal route returns
+     ONLY the signal rows tagged ``_source='local_store_v3'``.
+  2. Empty events table → helper returns None so route defers to legacy.
+  3. ``event_type`` discipline — only ``channel.in`` and ``channel.out``
+     project into the response. A stray ``message`` / ``model.completed``
+     row with ``provider='signal'`` MUST NOT show up (the bug class
+     `feedback_synthetic_tests_missed_real_event_shape.md` flagged: a
+     loose filter could capture v3 LLM events that happen to mention the
+     provider in their data blob).
+  4. Time-range / sort — newest-first ordering across the union of
+     channel.in + channel.out reads.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+def _now_iso():
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _iso_minutes_ago(minutes: int) -> str:
+    return (datetime.now(tz=timezone.utc) - timedelta(minutes=minutes)).isoformat()
+
+
+def _ingest_channel_event(
+    store,
+    *,
+    provider: str,
+    direction: str,
+    body: str = "hello",
+    sender_name: str = "alice",
+    channel_id: str = "signal-chat-1",
+    ts: str | None = None,
+):
+    store.ingest({
+        "id":         f"ch-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "agent_type": "openclaw",
+        "agent_id":   "main",
+        "event_type": f"channel.{direction}",
+        "ts":         ts or _now_iso(),
+        "session_id": None,
+        "workspace_id": None,
+        "data": {
+            "provider":    provider,
+            "channel_id":  channel_id,
+            "direction":   direction,
+            "sender_name": sender_name,
+            "body":        body,
+        },
+        "cost_usd":    None,
+        "token_count": None,
+        "model":       None,
+    })
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.channels as channels_mod
+    importlib.reload(channels_mod)
+
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    import dashboard  # noqa: F401
+
+    a = Flask(__name__)
+    a.register_blueprint(channels_mod.bp_channels)
+    yield a, ls, channels_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_signal_v3_events_path_serves_when_channel_messages_empty(app):
+    """Populated v3 events but empty ``channel_messages`` → fast path
+    must return ``_source='local_store_v3'`` with only signal rows."""
+    a, ls, _c = app
+    store = ls.get_store()
+    _ingest_channel_event(
+        store,
+        provider="signal",
+        direction="in",
+        body="hey from signal",
+        sender_name="bob",
+        channel_id="signal-chat-1",
+    )
+    _ingest_channel_event(
+        store,
+        provider="signal",
+        direction="out",
+        body="ack",
+        channel_id="signal-chat-1",
+    )
+    # Cross-provider row must NOT pollute the signal response.
+    _ingest_channel_event(
+        store,
+        provider="telegram",
+        direction="in",
+        body="tg cross-channel",
+        sender_name="alice",
+    )
+    store.flush()
+    assert store.query_channel_messages(provider="signal", limit=5) == []
+
+    r = a.test_client().get("/api/channel/signal?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3", (
+        f"_source must be local_store_v3 (v3 events fallback); got "
+        f"{body.get('_source')!r}"
+    )
+    msgs = body.get("messages") or []
+    assert len(msgs) == 2, f"expected 2 signal rows, got {len(msgs)}: {msgs}"
+    inbound = next(m for m in msgs if m["direction"] == "in")
+    assert inbound["sender"] == "bob"
+    assert inbound["text"] == "hey from signal"
+    assert inbound["chatId"] == "signal-chat-1"
+
+
+def test_signal_v3_events_empty_returns_legacy_fallback(app):
+    """Empty events → helper returns None, route falls through to legacy
+    walker. The legacy walker on a test box with no log files MUST NOT
+    carry the ``_source='local_store_v3'`` audit tag."""
+    a, ls, _c = app
+    assert ls.get_store().query_events(event_type="channel.in", limit=5) == []
+    r = a.test_client().get("/api/channel/signal")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") != "local_store_v3"
+
+
+def test_signal_v3_events_ignores_non_channel_event_types(app):
+    """Only ``channel.in`` / ``channel.out`` rows project. A v3
+    ``message`` row that happens to carry ``data.provider='signal'``
+    MUST NOT show up — that would inflate the signal counters with LLM
+    turns and re-create the bug class
+    `feedback_synthetic_tests_missed_real_event_shape.md` warns about."""
+    a, ls, _c = app
+    store = ls.get_store()
+    _ingest_channel_event(
+        store,
+        provider="signal",
+        direction="in",
+        body="real signal turn",
+    )
+    # Stray non-channel event with provider tag — should be ignored.
+    store.ingest({
+        "id":         f"msg-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "agent_type": "openclaw",
+        "agent_id":   "main",
+        "event_type": "message",
+        "ts":         _now_iso(),
+        "session_id": "sess-llm",
+        "workspace_id": None,
+        "data": {
+            "provider": "signal",
+            "body":     "this is an LLM turn that mentions signal",
+        },
+        "cost_usd": 0.001, "token_count": 100, "model": "claude-3-5-sonnet",
+    })
+    store.flush()
+
+    r = a.test_client().get("/api/channel/signal?limit=10")
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3"
+    msgs = body.get("messages") or []
+    assert len(msgs) == 1, (
+        f"only the channel.in row should surface; got {len(msgs)} rows: "
+        f"{[m['text'] for m in msgs]}"
+    )
+    assert msgs[0]["text"] == "real signal turn"
+
+
+def test_signal_v3_events_newest_first_across_in_and_out(app):
+    """Helper merges separate channel.in + channel.out pulls and MUST
+    return newest-first. Guards against the union being returned in
+    in-then-out (or out-then-in) chunk order, which would put a fresh
+    outbound under a stale inbound on the Signal tab."""
+    a, ls, _c = app
+    store = ls.get_store()
+    # Older inbound — 30 min ago.
+    _ingest_channel_event(
+        store,
+        provider="signal",
+        direction="in",
+        body="older inbound",
+        ts=_iso_minutes_ago(30),
+    )
+    # Fresher outbound — now.
+    _ingest_channel_event(
+        store,
+        provider="signal",
+        direction="out",
+        body="fresh outbound",
+    )
+    store.flush()
+
+    r = a.test_client().get("/api/channel/signal?limit=10")
+    body = r.get_json()
+    assert body["_source"] == "local_store_v3"
+    msgs = body.get("messages") or []
+    assert len(msgs) == 2
+    # The fresh outbound must come first.
+    assert msgs[0]["text"] == "fresh outbound"
+    assert msgs[1]["text"] == "older inbound"

--- a/tests/test_channel_telegram_local_store_v3.py
+++ b/tests/test_channel_telegram_local_store_v3.py
@@ -1,0 +1,265 @@
+"""Regression guard for the /api/channel/telegram DuckDB v3 events fast path
+(Tier-1 #1565, refs #1583's coverage audit).
+
+``routes/channels.py:_try_local_store_channel_events`` is a second-tier fast
+path layered AFTER ``_try_local_store_provider_messages`` (which reads the
+specialised ``channel_messages`` table). When the dedicated table is empty
+but the unified ``events`` table has ``channel.in`` / ``channel.out`` rows
+the sync daemon already wrote, this helper still serves DuckDB-first
+instead of falling through to the legacy gateway.log grep + JSONL walker.
+
+Why a separate v3 path:
+
+  * On real OpenClaw v3 installs the daemon's chokepoint
+    (``LocalStore.ingest_channel_event``) writes to BOTH ``channel_messages``
+    AND ``events``, but only the ``events`` write is guaranteed — see
+    ``feedback_synthetic_tests_missed_real_event_shape.md`` for the
+    silent-zero bug class on this kind of dual-write contract.
+  * Without this fallback, a daemon that restarted between writes (or a
+    legacy ingest path that took the bare ``ingest()`` side-door) would
+    leave the route silently log-scraping on every poll.
+
+Tests cover:
+
+  1. Populated v3 events → fast path returns ``_source='local_store_v3'``
+     with telegram-only rows and the legacy ``{messages,total,todayIn,
+     todayOut}`` envelope.
+  2. Empty events table → helper returns ``None`` so the route falls
+     through to the legacy walker.
+  3. Provider filter — events for OTHER providers (signal/slack) must
+     NOT bleed into the telegram response.
+  4. Time-range / today counters honour the daemon's ISO ts strings
+     (the 2026-05-17 audit found a class of routes that returned all
+     events under "todayIn" because the ts substring match was loose).
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+def _now_iso():
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _ingest_channel_event(
+    store,
+    *,
+    provider: str,
+    direction: str,
+    body: str = "hello",
+    sender_name: str = "alice",
+    channel_id: str = "1532693273",
+    ts: str | None = None,
+    session_id: str | None = None,
+):
+    """Seed one channel event row in the exact shape
+    ``LocalStore.ingest_channel_event`` would write (see
+    clawmetry/local_store.py:1250-1264).
+
+    We bypass the chokepoint here and call ``ingest`` directly so the test
+    actually exercises the silent-zero contract: events-table populated,
+    channel_messages table EMPTY — the very case the v3 fallback exists
+    for."""
+    store.ingest({
+        "id":         f"ch-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "agent_type": "openclaw",
+        "agent_id":   "main",
+        "event_type": f"channel.{direction}",
+        "ts":         ts or _now_iso(),
+        "session_id": session_id,
+        "workspace_id": None,
+        "data": {
+            "provider":    provider,
+            "channel_id":  channel_id,
+            "direction":   direction,
+            "sender_name": sender_name,
+            "body":        body,
+        },
+        "cost_usd":    None,
+        "token_count": None,
+        "model":       None,
+    })
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.channels as channels_mod
+    importlib.reload(channels_mod)
+
+    # Isolate from a contributor's running daemon: without this, ``_ls_call``
+    # proxies through ``~/.clawmetry/local_query.json`` and the daemon
+    # queries its OWN production DuckDB instead of our tmp_path fixture.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    import dashboard  # noqa: F401
+
+    a = Flask(__name__)
+    a.register_blueprint(channels_mod.bp_channels)
+    yield a, ls, channels_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_telegram_v3_events_path_serves_when_channel_messages_empty(app):
+    """Populated v3 events but empty ``channel_messages`` → fast path
+    must return ``_source='local_store_v3'`` with the seeded rows."""
+    a, ls, _c = app
+    store = ls.get_store()
+    _ingest_channel_event(
+        store,
+        provider="telegram",
+        direction="in",
+        body="hello clawd",
+        sender_name="vivek",
+        channel_id="1532693273",
+    )
+    _ingest_channel_event(
+        store,
+        provider="telegram",
+        direction="out",
+        body="hi back",
+        channel_id="1532693273",
+    )
+    store.flush()
+    # Contract check: events table populated, channel_messages NOT
+    # (the v3 events helper is the only thing that can serve this).
+    assert len(store.query_events(event_type="channel.in", limit=5)) >= 1
+    assert len(store.query_events(event_type="channel.out", limit=5)) >= 1
+    assert store.query_channel_messages(provider="telegram", limit=5) == []
+
+    r = a.test_client().get("/api/channel/telegram?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3", (
+        f"_source must be local_store_v3 (v3 events fallback); got "
+        f"{body.get('_source')!r}"
+    )
+    msgs = body.get("messages") or []
+    assert len(msgs) == 2, f"expected 2 telegram messages, got {len(msgs)}"
+    directions = sorted(m["direction"] for m in msgs)
+    assert directions == ["in", "out"]
+    # sender_name surfaced from the data blob (not "User" fallback).
+    inbound = next(m for m in msgs if m["direction"] == "in")
+    assert inbound["sender"] == "vivek"
+    assert inbound["text"] == "hello clawd"
+    assert inbound["chatId"] == "1532693273"
+
+
+def test_telegram_v3_events_empty_returns_legacy_fallback(app):
+    """Empty events table → helper returns ``None`` so the route falls
+    through to the legacy gateway.log + JSONL walker. The walker on a
+    test box with no log files yields an empty payload but MUST NOT carry
+    ``_source='local_store_v3'`` (that tag is reserved for the fast
+    path)."""
+    a, ls, _c = app
+    # Sanity: nothing seeded.
+    assert ls.get_store().query_events(event_type="channel.in", limit=5) == []
+    assert ls.get_store().query_events(event_type="channel.out", limit=5) == []
+
+    r = a.test_client().get("/api/channel/telegram")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") != "local_store_v3", (
+        "empty events → fast path must defer to legacy walker; got "
+        f"_source={body.get('_source')!r}"
+    )
+
+
+def test_telegram_v3_events_filters_by_provider(app):
+    """A signal/slack event MUST NOT bleed into the telegram response.
+    The provider tag lives on ``data.provider`` and the helper filters in
+    Python — guard against the helper accidentally serving the whole
+    channel.in / channel.out cross-section."""
+    a, ls, _c = app
+    store = ls.get_store()
+    _ingest_channel_event(
+        store,
+        provider="telegram",
+        direction="in",
+        body="tg msg",
+        sender_name="alice",
+    )
+    _ingest_channel_event(
+        store,
+        provider="signal",
+        direction="in",
+        body="signal msg",
+        sender_name="bob",
+    )
+    _ingest_channel_event(
+        store,
+        provider="slack",
+        direction="in",
+        body="slack msg",
+        sender_name="carol",
+    )
+    store.flush()
+
+    r = a.test_client().get("/api/channel/telegram?limit=10")
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3"
+    msgs = body.get("messages") or []
+    assert len(msgs) == 1, (
+        f"telegram route must filter to provider=telegram only; got {len(msgs)} "
+        f"rows: {[m['text'] for m in msgs]}"
+    )
+    assert msgs[0]["text"] == "tg msg"
+    assert msgs[0]["sender"] == "alice"
+
+
+def test_telegram_v3_events_today_counters_match_iso_prefix(app):
+    """Today-in/today-out counters use the ``YYYY-MM-DD`` prefix on the
+    ISO ts. Seed a fresh-today row + an old-2024 row and confirm only the
+    fresh-today row counts. Guards against the loose substring match the
+    2026-05-17 audit flagged in a peer route."""
+    a, ls, _c = app
+    store = ls.get_store()
+    _ingest_channel_event(
+        store,
+        provider="telegram",
+        direction="in",
+        body="today inbound",
+    )
+    _ingest_channel_event(
+        store,
+        provider="telegram",
+        direction="out",
+        body="today outbound",
+    )
+    _ingest_channel_event(
+        store,
+        provider="telegram",
+        direction="in",
+        body="old inbound",
+        ts="2024-01-01T08:30:00+00:00",
+    )
+    store.flush()
+
+    r = a.test_client().get("/api/channel/telegram?limit=10")
+    body = r.get_json()
+    assert body["_source"] == "local_store_v3"
+    # 3 telegram rows total — old one still surfaces in ``messages``, just
+    # not in today counters.
+    assert body["total"] == 3
+    assert body["todayIn"] == 1, (
+        f"only 1 inbound row carries today's date prefix; got todayIn="
+        f"{body['todayIn']}"
+    )
+    assert body["todayOut"] == 1


### PR DESCRIPTION
## Summary

- Promotes `/api/channel/telegram` and `/api/channel/signal` from `DUCKDB_PARTIAL` to full `DUCKDB_FAST_PATH` per the 2026-05-17 coverage audit (`reference_duckdb_coverage_audit.md`, refs #1565).
- Adds a second-tier `_try_local_store_channel_events` helper that reads `channel.in` / `channel.out` rows from the unified `events` table when the specialised `channel_messages` projection is empty (silent-zero bug class — same family as #1582).
- Single shared helper used by both routes and ready to wire onto the other 6 chat channels (whatsapp/discord/slack/irc/webchat/imessage) without code duplication.

## Why this matters

Both routes already had a Phase-5 fast path against the `channel_messages` table. That table can be empty even when the daemon's `events` table has the channel turns — happens on daemon restart between dual-writes, or when a legacy ingest path took the bare `ingest()` side-door instead of the `ingest_channel_event` chokepoint (PR #1220). Without the second-tier fallback, every poll silently falls through to the gateway.log grep + JSONL walker — exactly the silent-zero hazard memory `feedback_synthetic_tests_missed_real_event_shape.md` warns about.

The v3 events helper is tagged `_source: 'local_store_v3'` (distinct from the `local_store` tag on the channel_messages path) so the audit canary can tell the two tiers apart in cloud-side logs.

## Bug-class audit (per #1582 + `reference_openclaw_v3_event_types`)

- Verified event_type names `channel.in` and `channel.out` against `LocalStore.ingest_channel_event` (clawmetry/local_store.py:1199-1265), `sync.sync_channel_messages`, and `gateway_tap`. No pre-v3 `channel.message` filter was used anywhere in the new code.
- `test_signal_v3_events_ignores_non_channel_event_types` explicitly seeds a stray `message` row with `data.provider='signal'` and asserts it does NOT bleed through (the equivalent of #1582's `message`-vs-`model.completed` silent-zero).
- No silent-zero finds in the current Telegram / Signal handler bodies — the legacy walkers run only after BOTH DuckDB tiers return None, which is correct.

## Telegram-specific note

`reference_openclaw_telegram_inmemory.md` calls out that Telegram has zero on-disk JSONL — the daemon harvests from `gateway.log` or the WS tap. The new fast path works regardless of the harvest source because the chokepoint normalises all three (gateway-log / ws-tap / JSONL) into the same `events` row shape.

## LOC budget

178 production + 498 test (under the 200/channel budget).

## Test plan

- [x] `pytest tests/test_channel_telegram_local_store_v3.py` — 4/4 passing
- [x] `pytest tests/test_channel_signal_local_store_v3.py` — 4/4 passing
- [x] `python3 -c "import dashboard; import routes.channels"` — no import regressions
- [x] Re-ran the existing `tests/test_channel*` suite — no NEW failures vs origin/main baseline (2 pre-existing failures present on both branches)
- [ ] CI smoke + persona reviews to confirm before merge

DO NOT MERGE. Awaiting Steve / Elon persona review per `feedback_persona_gate_before_merge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)