### PR TITLE
feat(brain): per-token confidence visualizer (refs #563)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3224,12 +3224,23 @@ function renderBrainStream(events) {
             _tlContainerId = 'timeline-' + (te.eventId || '').replace(/[^a-z0-9-]/gi, '').slice(0, 24);
             turnTimeline += '<button onclick="event.stopPropagation();loadLlmCallTimeline(\'' + escHtml(te.eventId) + '\',\'' + escHtml(_tlSid) + '\',\'' + escHtml(_tlContainerId) + '\')" style="flex-shrink:0;padding:1px 7px;border-radius:10px;border:1px solid #22c55e;background:transparent;color:#22c55e;font-size:10px;cursor:pointer;white-space:nowrap;" title="Per-LLM-call lifecycle timeline">&#128202; Timeline</button>';
           }
+          // Issue #563: per-LLM-call Token Confidence button on AGENT rows.
+          // Renders heatmap when upstream captured logprobs; otherwise shows
+          // a single-line "not available" hint with how to enable it.
+          var _tcContainerId = null;
+          if (te.type === 'AGENT') {
+            _tcContainerId = 'tokconf-' + ((te.eventId || (te.time || '') + (te.source || '')) + '').replace(/[^a-z0-9-]/gi, '').slice(0, 24);
+            turnTimeline += '<button onclick="event.stopPropagation();toggleTokenConfidence(this,\'' + escHtml(_tcContainerId) + '\')" data-tc=\'' + escHtml(JSON.stringify(te.token_confidence || null)) + '\' style="flex-shrink:0;padding:1px 7px;border-radius:10px;border:1px solid #38bdf8;background:transparent;color:#38bdf8;font-size:10px;cursor:pointer;white-space:nowrap;" title="How confident was the model in each word?">&#128202; Confidence</button>';
+          }
           turnTimeline += '</div>';
           if (_rcContainerId) {
             turnTimeline += '<div id="' + escHtml(_rcContainerId) + '" style="margin:2px 0 4px 56px;"></div>';
           }
           if (_tlContainerId) {
             turnTimeline += '<div id="' + escHtml(_tlContainerId) + '" class="llm-call-timeline-host" style="margin:2px 0 4px 56px;"></div>';
+          }
+          if (_tcContainerId) {
+            turnTimeline += '<div id="' + escHtml(_tcContainerId) + '" class="token-confidence-host" style="margin:2px 0 4px 56px;"></div>';
           }
         });
         if (currentSubagent) turnTimeline += '</div>'; // close last sub-agent group
@@ -3528,6 +3539,118 @@ function loadLlmCallTimeline(eventId, sessionId, containerId) {
     .catch(function(err) {
       container.innerHTML = '<span style="color:#ef4444;font-size:10px;">Timeline unavailable: ' + escHtml(String(err && err.message ? err.message : err)) + '</span>';
     });
+}
+
+// Issue #563 — Token Probability Visualizer.
+// "How confident was the model in each word?" — per-token heatmap rendered
+// inline below an AGENT row when upstream captured logprobs. When no
+// logprobs are present (every Anthropic call today), we show a single
+// explanatory line with how to enable the feature so the panel is never
+// a dead-end. Plain copy, no em-dashes (memory:
+// feedback_no_em_dashes_in_user_facing_copy.md).
+var _TOKEN_CONF_BAND = {
+  h: { color: '#16a34a', bg: 'rgba(22,163,74,0.18)',  label: 'High'   },
+  m: { color: '#d97706', bg: 'rgba(217,119,6,0.18)',  label: 'Medium' },
+  l: { color: '#ea580c', bg: 'rgba(234,88,12,0.20)',  label: 'Low'    },
+  v: { color: '#dc2626', bg: 'rgba(220,38,38,0.24)',  label: 'Very low' }
+};
+
+function _renderTokenConfidenceHeatmap(payload) {
+  if (!payload || !Array.isArray(payload.tokens) || !payload.tokens.length) return '';
+  var s = payload.summary || {};
+  var avgPct = Math.round(((s.avg_prob || 0) * 100));
+  var headline = 'Avg confidence: ' + avgPct + '% &middot; ' +
+    (s.token_count || 0) + ' tokens';
+  if (s.high_variance_count) {
+    headline += ' &middot; <span style="color:#dc2626;font-weight:600;">' +
+      s.high_variance_count + ' low-confidence</span>';
+  }
+  var html = '<div class="token-confidence-panel" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:8px 10px;font-size:11px;">';
+  html += '<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px;">';
+  html += '<span style="color:var(--text-muted);">' + headline + '</span>';
+  html += '<span style="color:var(--text-faint);font-size:10px;">hover a token to see what else the model considered</span>';
+  html += '</div>';
+  html += '<div class="token-confidence-tokens" style="line-height:1.9;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;word-break:break-word;">';
+  payload.tokens.forEach(function(t) {
+    var cfg = _TOKEN_CONF_BAND[t.band] || _TOKEN_CONF_BAND.m;
+    var pct = Math.round((t.prob || 0) * 100);
+    var icon = (t.band === 'v') ? ' ⚡' : '';
+    // Build tooltip: chosen token + top-k alternatives + cumulative mass.
+    var tipLines = ['"' + (t.token || '') + '"  ' + pct + '%' + (t.rank > 1 ? '  (rank ' + t.rank + ')' : '')];
+    if (Array.isArray(t.top_k) && t.top_k.length) {
+      tipLines.push('');
+      tipLines.push('Top alternatives:');
+      var mass = 0;
+      t.top_k.forEach(function(alt) {
+        var ap = Math.round((alt.prob || 0) * 100);
+        tipLines.push('  ' + ap + '%  "' + (alt.token || '') + '"');
+        mass += (alt.prob || 0);
+      });
+      tipLines.push('');
+      tipLines.push(Math.round(mass * 100) + '% of probability mass in top ' + t.top_k.length);
+    }
+    var visible = (t.token || '').replace(/\n/g, '↵').replace(/\t/g, '→');
+    html += '<span class="token-conf-cell" title="' + escHtml(tipLines.join('\n')) +
+      '" style="display:inline-block;padding:1px 3px;margin:1px 1px;border-radius:3px;background:' +
+      cfg.bg + ';color:' + cfg.color + ';border-bottom:2px solid ' + cfg.color + ';cursor:help;">' +
+      escHtml(visible) + icon + '</span>';
+  });
+  if (payload.truncated) {
+    html += '<span style="color:var(--text-muted);font-style:italic;margin-left:6px;">&hellip; ' +
+      ((s.total_tokens || 0) - (s.token_count || 0)) + ' more tokens</span>';
+  }
+  html += '</div>';
+  // Legend
+  html += '<div style="display:flex;gap:10px;margin-top:8px;font-size:10px;color:var(--text-muted);flex-wrap:wrap;">';
+  ['h','m','l','v'].forEach(function(b) {
+    var cfg = _TOKEN_CONF_BAND[b];
+    html += '<span><span style="display:inline-block;width:10px;height:10px;background:' + cfg.bg +
+      ';border:1px solid ' + cfg.color + ';border-radius:2px;margin-right:3px;vertical-align:middle;"></span>' +
+      escHtml(cfg.label) + '</span>';
+  });
+  html += '</div>';
+  html += '</div>';
+  return html;
+}
+
+function _renderTokenConfidenceUnavailable() {
+  // Friendly explanation when upstream did NOT capture logprobs. Common
+  // case today since Anthropic does not expose per-token logprobs. Keep
+  // it short and tell the user what would unblock it.
+  return '<div class="token-confidence-panel token-confidence-empty" style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:6px;padding:10px 12px;font-size:12px;color:var(--text-secondary);">' +
+    '<div style="font-weight:600;color:var(--text-primary);margin-bottom:4px;">' +
+    '&#128202; Per-token confidence not available for this call</div>' +
+    '<div style="color:var(--text-muted);font-size:11px;line-height:1.5;">' +
+    'How confident was the model in each word? When the API provider returns ' +
+    '<code style="background:var(--bg-primary);padding:1px 4px;border-radius:3px;">logprobs</code>, ' +
+    'we paint a colour-coded heatmap here so you can spot the tokens the model was guessing on. ' +
+    'OpenAI and Gemini compatible providers support this today. ' +
+    'Anthropic does not expose per-token logprobs yet, so Claude calls fall through to this hint. ' +
+    'Track upstream work in <a href="https://github.com/vivekchand/clawmetry/issues/563" target="_blank" rel="noopener" style="color:#60a5fa;">#563</a>.' +
+    '</div></div>';
+}
+
+window.toggleTokenConfidence = function(btn, containerId) {
+  var container = document.getElementById(containerId);
+  if (!container) return;
+  if (container.dataset.loaded === '1') {
+    container.innerHTML = '';
+    container.dataset.loaded = '0';
+    return;
+  }
+  var raw = btn && btn.getAttribute ? btn.getAttribute('data-tc') : null;
+  var payload = null;
+  try { payload = raw ? JSON.parse(raw) : null; } catch (e) { payload = null; }
+  container.innerHTML = payload
+    ? _renderTokenConfidenceHeatmap(payload)
+    : _renderTokenConfidenceUnavailable();
+  container.dataset.loaded = '1';
+};
+
+// Exported for unit tests (Node + jsdom). No-op in the browser global.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports._renderTokenConfidenceHeatmap = _renderTokenConfidenceHeatmap;
+  module.exports._renderTokenConfidenceUnavailable = _renderTokenConfidenceUnavailable;
 }
 
 function renderBrainChart(events) {

--- a/clawmetry/token_confidence.py
+++ b/clawmetry/token_confidence.py
@@ -1,0 +1,235 @@
+"""
+clawmetry/token_confidence.py — Token Probability Visualizer (issue #563).
+
+Per-LLM-call "How confident was the model in each word?" panel for the
+Brain tab. Pure function: takes one event dict, returns a small payload the
+frontend renders as an inline heatmap with hover-tooltip alternatives.
+
+Phase 1 (this module): wire the data path end-to-end whenever upstream
+already captured ``logprobs`` (OpenAI / Gemini compatible providers). When
+no logprobs are present (every Anthropic call today, 2026-05-16) we return
+``None`` so the frontend can paint a single-line "not available" hint
+instead of an empty box.
+
+Phase 2 (separate issue): land an OpenClaw adapter PR that requests
+``logprobs=True`` from supporting providers and stores the per-token
+distribution on the event row. ClawMetry only needs to read it.
+
+Design notes
+------------
+* **Pure + total.** ``extract_token_confidence`` takes any event-shaped
+  dict and returns either a payload dict or ``None``. Never raises.
+* **No new dependencies.** Reads the same ``logprobs.content`` shape
+  ``risk.py`` already understands (OpenAI chat-completions response):
+  ``[{"token": str, "logprob": float, "top_logprobs": [{"token", "logprob"}]}]``.
+* **Cap at 200 tokens.** Brain tab paints these inline; we don't want a
+  5,000-token transcript to dominate the DOM. Tail tokens get summarised.
+* **No-em-dash copy** in the explanation strings (memory:
+  ``feedback_no_em_dashes_in_user_facing_copy.md``).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping, Optional
+
+# Hard cap so a multi-thousand-token completion does NOT blow up the Brain
+# tab DOM. Matches the cap in ``risk._extract_logprob_summary`` for
+# consistency. The frontend shows "… N more tokens" when truncated.
+_MAX_TOKENS = 200
+
+# How many alternative top-k tokens to surface in the hover tooltip. The
+# OpenAI API caps top_logprobs at 20; 5 is a reasonable default for an
+# inline tooltip (matches the issue spec).
+_TOP_K = 5
+
+# Probability bands → colour pill rendered by the frontend. Boundaries
+# match the issue spec exactly.
+#
+#   p >= 0.9  → green   (high confidence)
+#   p >= 0.5  → yellow  (medium)
+#   p >= 0.2  → orange  (low)
+#   p <  0.2  → red     (high-variance decision point)
+#
+# The frontend owns the colour mapping; we just stamp a band letter so the
+# contract is forward-compatible (re-skinning is a CSS change).
+_BANDS = [
+    (0.9, "h"),  # high
+    (0.5, "m"),  # medium
+    (0.2, "l"),  # low
+    (0.0, "v"),  # very-low (high variance)
+]
+
+
+def _band_for(prob: float) -> str:
+    for threshold, label in _BANDS:
+        if prob >= threshold:
+            return label
+    return "v"
+
+
+def _logprob_to_prob(lp: float) -> float:
+    """Convert a (typically negative) logprob to a probability in [0, 1]."""
+    try:
+        p = math.exp(float(lp))
+    except (OverflowError, ValueError):
+        return 0.0
+    # Clamp to defend against floating-point > 1.0 from upstream.
+    if p < 0.0:
+        return 0.0
+    if p > 1.0:
+        return 1.0
+    return p
+
+
+def _find_logprobs_list(event_data: Mapping[str, Any]) -> Optional[list]:
+    """Return the ``logprobs.content`` list from any common event shape."""
+    if not isinstance(event_data, Mapping):
+        return None
+    candidates = [event_data]
+    data = event_data.get("data") if isinstance(event_data.get("data"), Mapping) else None
+    if data is not None:
+        candidates.append(data)
+        msg = data.get("message") if isinstance(data.get("message"), Mapping) else None
+        if msg is not None:
+            candidates.append(msg)
+    for bucket in candidates:
+        if not isinstance(bucket, Mapping):
+            continue
+        lp = bucket.get("logprobs")
+        if isinstance(lp, Mapping):
+            content = lp.get("content")
+            if isinstance(content, list) and content:
+                return content
+        # Some adapters flatten to ``logprob_content`` directly.
+        if isinstance(bucket.get("logprob_content"), list) and bucket["logprob_content"]:
+            return bucket["logprob_content"]
+    return None
+
+
+def _token_row(entry: Mapping[str, Any]) -> Optional[dict]:
+    """Project one OpenAI-shape token entry into the Brain payload row."""
+    if not isinstance(entry, Mapping):
+        return None
+    token = entry.get("token")
+    lp = entry.get("logprob")
+    if not isinstance(token, str) or not isinstance(lp, (int, float)):
+        return None
+    prob = _logprob_to_prob(lp)
+
+    # Top-k alternatives. We keep them sorted by descending probability and
+    # capped at ``_TOP_K``. Each alt mirrors the {token, prob} shape so the
+    # frontend doesn't have to do logprob math.
+    alts_raw = entry.get("top_logprobs")
+    alts: list[dict] = []
+    if isinstance(alts_raw, list):
+        for alt in alts_raw:
+            if not isinstance(alt, Mapping):
+                continue
+            at = alt.get("token")
+            alp = alt.get("logprob")
+            if not isinstance(at, str) or not isinstance(alp, (int, float)):
+                continue
+            alts.append({"token": at, "prob": round(_logprob_to_prob(alp), 4)})
+        alts.sort(key=lambda r: r["prob"], reverse=True)
+        alts = alts[:_TOP_K]
+
+    # Rank: how many alternatives outranked the chosen token? Rank 1 = the
+    # model picked its top choice; rank >= 2 means decoding sampled a
+    # lower-probability option (interesting for debugging).
+    rank = 1
+    for alt in alts:
+        if alt["prob"] > prob and alt["token"] != token:
+            rank += 1
+
+    return {
+        "token": token,
+        "prob": round(prob, 4),
+        "band": _band_for(prob),
+        "top_k": alts,
+        "rank": rank,
+    }
+
+
+def extract_token_confidence(event_data: Mapping[str, Any]) -> Optional[dict]:
+    """Return a payload describing per-token confidence, or ``None``.
+
+    Payload shape::
+
+        {
+          "tokens": [
+            {"token": "Hello", "prob": 0.98, "band": "h",
+             "top_k": [{"token": "Hi", "prob": 0.01}, ...], "rank": 1},
+            ...
+          ],
+          "summary": {
+            "token_count": 42,           # tokens included after capping
+            "total_tokens": 42,          # raw count before capping
+            "avg_prob": 0.83,            # mean across included tokens
+            "min_prob": 0.18,            # the most "surprising" token
+            "high_variance_count": 3,    # # tokens in red band (p < 0.2)
+            "band": "h" | "m" | "l" | "v",
+          },
+          "truncated": false,
+        }
+
+    Returns ``None`` when no logprobs are available (the common case until
+    OpenClaw wires logprobs collection in Phase 2). The frontend uses
+    ``None`` as the signal to paint the "not available" hint instead.
+    """
+    content = _find_logprobs_list(event_data)
+    if not content:
+        return None
+
+    rows: list[dict] = []
+    for entry in content[:_MAX_TOKENS]:
+        row = _token_row(entry)
+        if row is not None:
+            rows.append(row)
+    if not rows:
+        return None
+
+    probs = [r["prob"] for r in rows]
+    avg_prob = sum(probs) / len(probs)
+    min_prob = min(probs)
+    high_variance_count = sum(1 for p in probs if p < 0.2)
+    summary = {
+        "token_count": len(rows),
+        "total_tokens": len(content),
+        "avg_prob": round(avg_prob, 4),
+        "min_prob": round(min_prob, 4),
+        "high_variance_count": high_variance_count,
+        "band": _band_for(avg_prob),
+    }
+    return {
+        "tokens": rows,
+        "summary": summary,
+        "truncated": len(content) > _MAX_TOKENS,
+    }
+
+
+def annotate_events(events) -> None:
+    """Stamp ``ev["token_confidence"]`` on every LLM-call event in place.
+
+    Mirrors ``routes/brain._annotate_risk``. Silent fallback per event so
+    one mis-shaped row never poisons the whole feed (CLAUDE.md "graceful
+    fallbacks on bad input").
+    """
+    if not events:
+        return
+    # Lazy import to avoid pulling routes.brain into clawmetry.* at import
+    # time (routes/* already imports clawmetry/*).
+    try:
+        from clawmetry.risk import is_llm_event
+    except Exception:
+        return
+    for ev in events:
+        try:
+            if not is_llm_event(ev):
+                continue
+            payload = extract_token_confidence(ev)
+            if payload is not None:
+                ev["token_confidence"] = payload
+        except Exception:
+            # Never crash — Brain renders thousands per page-load.
+            pass

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta, timezone
 from flask import Blueprint, Response, jsonify, request
 from clawmetry.config import is_local_store_read_enabled
 from clawmetry.risk import compute_hallucination_risk, is_llm_event
+from clawmetry.token_confidence import annotate_events as _annotate_token_confidence
 
 bp_brain = Blueprint('brain', __name__)
 
@@ -1021,6 +1022,17 @@ def api_brain_history():
     # stable either way, and the local-store fast path above already
     # picked up the rich rows.
     _annotate_risk(events)
+
+    # Issue #563 — Token Probability Visualizer. Per-token confidence
+    # heatmap on assistant responses. Only stamps when upstream captured
+    # logprobs (OpenAI / Gemini compatible providers today). Anthropic
+    # calls fall through to a "not available" hint in the frontend.
+    try:
+        _annotate_token_confidence(events)
+    except Exception:
+        # Never crash the Brain feed on annotation failure — the rest of
+        # the payload is still useful even if confidence stamping fails.
+        pass
 
     try:
         _d._ext_emit("brain.event", {"count": len(events)})

--- a/tests/test_token_confidence.py
+++ b/tests/test_token_confidence.py
@@ -1,0 +1,152 @@
+"""Unit tests for ``clawmetry/token_confidence.py`` (issue #563)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from clawmetry.token_confidence import (
+    annotate_events,
+    extract_token_confidence,
+)
+
+
+def _entry(token, logprob, top=()):
+    """Build one OpenAI-shape logprob entry (token + optional alternatives)."""
+    return {
+        "token": token,
+        "logprob": logprob,
+        "top_logprobs": [{"token": t, "logprob": lp} for t, lp in top],
+    }
+
+
+def test_extract_returns_none_when_no_logprobs():
+    """Anthropic-shaped events lack logprobs; we must return ``None``."""
+    for ev in (
+        {},
+        {"type": "AGENT"},
+        {"type": "AGENT", "data": {"message": {"content": "hi"}}},
+        None,
+        42,
+    ):
+        assert extract_token_confidence(ev) is None
+
+
+def test_extract_openai_shape_logprobs_top_level():
+    """Reads ``logprobs.content`` at the event root (legacy adapter shape)."""
+    ev = {
+        "type": "AGENT",
+        "logprobs": {
+            "content": [
+                _entry("Hello", math.log(0.95), top=[("Hi", math.log(0.03))]),
+                _entry(" world", math.log(0.40), top=[("there", math.log(0.55))]),
+            ]
+        },
+    }
+    out = extract_token_confidence(ev)
+    assert out is not None
+    assert out["summary"]["token_count"] == 2
+    assert out["summary"]["total_tokens"] == 2
+    assert not out["truncated"]
+    # Bands: 0.95 → h, 0.40 → l
+    assert out["tokens"][0]["band"] == "h"
+    assert out["tokens"][1]["band"] == "l"
+    # The first token's chosen rank should be 1 (it WAS top).
+    assert out["tokens"][0]["rank"] == 1
+    # The second token had a higher-probability alternative → rank 2.
+    assert out["tokens"][1]["rank"] == 2
+    # Top-k alternatives present + sorted descending by prob.
+    assert out["tokens"][1]["top_k"][0]["token"] == "there"
+
+
+def test_extract_openai_shape_logprobs_nested_under_data_message():
+    """Reads ``data.message.logprobs.content`` (v3 mapper shape)."""
+    ev = {
+        "type": "AGENT",
+        "data": {
+            "message": {
+                "logprobs": {
+                    "content": [_entry("Ok", math.log(0.99))]
+                }
+            }
+        },
+    }
+    out = extract_token_confidence(ev)
+    assert out is not None
+    assert out["tokens"][0]["token"] == "Ok"
+    assert out["tokens"][0]["band"] == "h"
+
+
+def test_extract_caps_tokens_at_200_and_marks_truncated():
+    """Multi-thousand-token completions must not blow up the Brain DOM."""
+    content = [_entry("x", math.log(0.5)) for _ in range(500)]
+    ev = {"type": "AGENT", "logprobs": {"content": content}}
+    out = extract_token_confidence(ev)
+    assert out is not None
+    assert out["summary"]["token_count"] == 200
+    assert out["summary"]["total_tokens"] == 500
+    assert out["truncated"] is True
+
+
+def test_summary_flags_high_variance_tokens():
+    """Red-band (p < 0.2) tokens are counted in ``high_variance_count``."""
+    ev = {
+        "type": "AGENT",
+        "logprobs": {
+            "content": [
+                _entry("safe", math.log(0.95)),
+                _entry("risky", math.log(0.15)),
+                _entry("risky2", math.log(0.10)),
+            ]
+        },
+    }
+    out = extract_token_confidence(ev)
+    assert out["summary"]["high_variance_count"] == 2
+
+
+def test_annotate_events_stamps_only_llm_events():
+    """``annotate_events`` mutates LLM events in place; skips non-LLM rows."""
+    events = [
+        {"type": "USER", "detail": "hi"},  # never stamped
+        {
+            "type": "AGENT",
+            "logprobs": {"content": [_entry("ok", math.log(0.99))]},
+        },
+        {"type": "EXEC", "detail": "ls"},  # never stamped
+    ]
+    annotate_events(events)
+    assert "token_confidence" not in events[0]
+    assert "token_confidence" in events[1]
+    assert events[1]["token_confidence"]["summary"]["token_count"] == 1
+    assert "token_confidence" not in events[2]
+
+
+def test_annotate_events_does_not_raise_on_garbage():
+    """One malformed row must not poison the whole feed (graceful fallback)."""
+    events = [
+        {"type": "AGENT", "logprobs": "not-a-dict"},
+        None,
+        {"type": "AGENT", "logprobs": {"content": [{"bad": "shape"}]}},
+        42,
+    ]
+    annotate_events(events)  # must not raise
+    # None of these should have been stamped — all are unusable.
+    assert not any(isinstance(ev, dict) and "token_confidence" in ev for ev in events if isinstance(ev, dict))
+
+
+def test_brain_history_stamps_token_confidence_when_logprobs_present(monkeypatch):
+    """Integration: ``_annotate_token_confidence`` wires into the Brain pipeline."""
+    import routes.brain as br
+    events = [
+        {
+            "type": "AGENT",
+            "logprobs": {"content": [_entry("Hello", math.log(0.95))]},
+        },
+        {"type": "USER", "detail": "hi"},
+    ]
+    # Use the same indirection ``brain.py`` uses — annotate_events on
+    # _annotate_token_confidence ensures the import contract is stable.
+    br._annotate_token_confidence(events)
+    assert events[0].get("token_confidence", {}).get("summary", {}).get("token_count") == 1
+    assert "token_confidence" not in events[1]


### PR DESCRIPTION
## Summary
- Adds a "Confidence" button to expanded AGENT rows in the Brain tab. Clicking it paints an inline per-token heatmap (green / yellow / orange / red bands per the issue spec) with hover tooltips showing the top 5 alternative tokens + cumulative probability mass.
- New pure module `clawmetry/token_confidence.py` extracts `{tokens, summary}` from any event carrying `logprobs.content` (top-level, nested under `data.message`, or flat `logprob_content`). Capped at 200 tokens so a 5k-token completion does NOT blow up the Brain DOM.
- `routes/brain.py` stamps `ev["token_confidence"]` via `annotate_events()`, mirroring the existing `_annotate_risk` pattern. Silent per-row fallback on bad input.
- When the provider did not return logprobs (every Anthropic call today), the panel renders a one-line "not available" hint that links back to #563 instead of an empty box.

## Why Phase 1 (refs, not closes)
The issue asks for end-to-end logprob visualization. Anthropic does not yet expose per-token logprobs, so most ClawMetry deploys (Claude-driven OpenClaw) currently have zero logprob data. OpenAI + Gemini compatible adapters DO return `logprobs.content` in the exact shape `risk.py` already reads, so we can light the heatmap up for those calls **today** with zero new collection. Phase 2 (separate issue) will wire logprob capture through OpenClaw for every supporting provider; this PR is the consumer surface that proves the round trip works.

## Memory respects
- `feedback_no_em_dashes_in_user_facing_copy.md`: no em-dashes in any user-facing copy.
- `feedback_simple_ui_for_nontechnical.md`: headline is "How confident was the model in each word?" with plain Avg / Low / High / Very low labels.
- `feedback_duckdb_first_rule.md`: zero new JSONL or log scraping; reads only the event row Brain already pulls from DuckDB.

## Test plan
- [x] `python3 -m pytest tests/test_token_confidence.py -q` (8 new tests, all green: OpenAI shape parsing, nested `data.message` path, 200-token cap + truncation flag, high-variance counting, `annotate_events` skips non-LLM rows, graceful fallback on garbage, end-to-end stamping via `routes.brain`).
- [x] `python3 -m pytest tests/test_brain_history_v3_event_detail.py tests/test_hallucination_risk.py tests/test_brain_no_log_keyword_noise.py -q` (26 passed, no regressions).
- [x] `python3 -c "import dashboard"` clean.
- Visual smoke (post-merge): Brain tab → expand an AGENT row → click `Confidence`. Heatmap renders for OpenAI-adapter calls; "not available" hint for Anthropic calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)