### PR TITLE
fix(sessions): tool_calls rollup includes sub-agent attribution (closes #1597)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -2712,6 +2712,69 @@ class LocalStore:
         params.append(int(limit))
         return [_row_to_event(r, _EVENT_COLS) for r in self._fetch(sql, params)]
 
+    def query_events_with_subagents(
+        self,
+        *,
+        session_id: str,
+        limit: int = 10000,
+    ) -> list[dict[str, Any]]:
+        """Return events for ``session_id`` UNIONed with events from every
+        sub-agent session whose ``subagents.parent_session_id`` matches.
+
+        Issue #1597: every per-session tool/cost/transcript read path was
+        scoped to ``WHERE session_id = ?`` on the events table, but
+        sub-agent events live under the sub-agent's OWN ``session_id`` —
+        the parent linkage lives only on the ``subagents`` table. As a
+        result a parent session that delegated 50 tool calls to a child
+        rendered as ``tool_calls=0`` in the UI.
+
+        Events sourced from a child session are tagged with
+        ``data._via_subagent_id`` (carrying the child's session_id) so
+        downstream UI code can render "via sub-agent X" markers without
+        re-querying. Orphan tool calls (no parent_sid linkage) stay where
+        they are — only events whose session is registered as a child of
+        ``session_id`` get rolled up.
+
+        ``limit`` is applied PER source session (parent + each child) so a
+        chatty child can't starve the parent's events out of the result.
+        """
+        # 1. Parent's own events.
+        out: list[dict[str, Any]] = self.query_events(
+            session_id=session_id, limit=limit,
+        )
+
+        # 2. Discover sub-agent sessions whose parent matches.
+        try:
+            subs = self.query_subagents(
+                parent_session_id=session_id, limit=500,
+            )
+        except Exception:
+            subs = []
+
+        # 3. Pull each child's events and tag them with the child's id.
+        for sa in subs:
+            child_sid = sa.get("subagent_id")
+            if not child_sid or child_sid == session_id:
+                continue
+            try:
+                child_rows = self.query_events(
+                    session_id=child_sid, limit=limit,
+                )
+            except Exception:
+                continue
+            for ev in child_rows:
+                data = ev.get("data")
+                if not isinstance(data, dict):
+                    data = {}
+                    ev["data"] = data
+                data["_via_subagent_id"] = child_sid
+                out.append(ev)
+
+        # 4. Re-sort DESC by ts so the merged stream looks like a single
+        # ``query_events`` result to callers that iterate it.
+        out.sort(key=lambda e: (e.get("ts") or ""), reverse=True)
+        return out
+
     def query_sessions(
         self,
         *,

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -346,6 +346,12 @@ _DAEMON_METHODS = frozenset({
     # ``routes/crons.py:_cron_runs_from_duckdb`` via the daemon proxy.
     "query_cron_runs",
     "query_subagents",
+    # Issue #1597: parent session tool-timeline rollup needs to merge in
+    # events from every child sub-agent session (the events table has no
+    # parent_session_id column; the link lives on the subagents table). The
+    # helper UNIONs parent + child query_events() results and tags child
+    # rows with ``data._via_subagent_id``.
+    "query_events_with_subagents",
     "query_memory_blobs",
     "query_system_snapshots",
     # Phase 3 (issue #1088 follow-up, 2026-05-13): per-feature aggregation

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -706,8 +706,21 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
     the same timeline shape the JSONL parser returns.
 
     Issue #1088 phase 3. Returns ``None`` to defer to the JSONL parser
-    when the events table has no message rows for this session."""
-    rows = _ls_call("query_events", session_id=sid, limit=10000)
+    when the events table has no message rows for this session.
+
+    Issue #1597: ALSO unions in events from any sub-agent session whose
+    ``subagents.parent_session_id`` matches ``sid`` — without this a
+    parent that delegated tool calls to a child rendered ``tool_calls=0``.
+    Sub-agent events are tagged with ``data._via_subagent_id`` upstream
+    so the resulting ``tools[]`` rows carry the same marker for the UI.
+    """
+    rows = _ls_call("query_events_with_subagents", session_id=sid, limit=10000)
+    # Pre-1597 daemons (older wheel running, fresh dashboard) won't have the
+    # helper allowlisted yet — fall back to the parent-only query so the
+    # endpoint still works during a staged rollout. The rollup will simply
+    # under-report sub-agent activity until the daemon is restarted.
+    if rows is None:
+        rows = _ls_call("query_events", session_id=sid, limit=10000)
     if not rows:
         return None
     rows = list(reversed(rows))  # query_events returns DESC
@@ -750,6 +763,10 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
     for ev in rows:
         et = ev.get("event_type")
         data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        # Issue #1597: events sourced from a child sub-agent session are
+        # tagged by ``LocalStore.query_events_with_subagents`` so the
+        # rollup can attribute them in the UI ("via sub-agent X").
+        via_subagent_id = data.get("_via_subagent_id") if isinstance(data, dict) else None
         ev_ts_ms = _parse_ts(
             (data.get("timestamp") if isinstance(data, dict) else None)
             or ev.get("ts")
@@ -793,6 +810,7 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
                 "model":            ev.get("model") or "",
                 "provider":         (data.get("provider") if isinstance(data, dict) else "") or "",
                 "message_cost_usd": float(ev.get("cost_usd") or 0.0),
+                "via_subagent_id":  via_subagent_id or "",
             }
             if result_val is not None or is_error:
                 try:
@@ -877,6 +895,7 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
                     "model":            msg_model,
                     "provider":         msg_provider,
                     "message_cost_usd": msg_cost,
+                    "via_subagent_id":  via_subagent_id or "",
                 }
             continue
 
@@ -912,6 +931,7 @@ def _try_local_store_session_tools(sid: str, args_chars: int, result_chars: int,
                     "model":            msg_model,
                     "provider":         msg_provider,
                     "message_cost_usd": msg_cost,
+                    "via_subagent_id":  via_subagent_id or "",
                 }
         elif role == "toolResult":
             tcid = msg.get("toolCallId", "")

--- a/tests/test_subagent_attribution_v3.py
+++ b/tests/test_subagent_attribution_v3.py
@@ -1,0 +1,327 @@
+"""Regression guard for sub-agent tool-call attribution (issue #1597).
+
+Before this fix, ``_try_local_store_session_tools`` queried
+``events WHERE session_id = ?`` and never followed the
+``subagents.parent_session_id`` link. A parent session that delegated
+50 tool calls to a child rendered as ``tool_calls=0`` in the UI even
+though the tool events sat right next to it in DuckDB under the child's
+own ``session_id``.
+
+The new ``LocalStore.query_events_with_subagents`` helper UNIONs the
+parent's events with every child session's events (matched on
+``subagents.parent_session_id``) and tags child rows with
+``data._via_subagent_id``. ``/api/session-tools`` propagates that marker
+onto each row in the response so the UI can render "via sub-agent X".
+
+Four scenarios are asserted to nail down the class bug:
+
+1. Parent with 0 direct tool calls + 3 sub-agent calls → rollup == 3.
+2. Parent with 2 direct + 3 sub-agent → rollup == 5, sub rows tagged.
+3. Sub-agent rollup from the CHILD's perspective counts only its own
+   tool calls (no upward bleed).
+4. Orphan tool call whose session has no ``subagents`` row does NOT
+   bleed into an unrelated parent's rollup.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    # Issue #1538 pattern: isolate the fixture from a contributor's locally
+    # running clawmetry daemon. Without this, ``_ls_call`` proxies through
+    # ``~/.clawmetry/local_query.json`` and the daemon queries its OWN
+    # production DuckDB instead of our tmp_path fixture — seeded rows
+    # become invisible to the fast path.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _drain(store):
+    store._flush_now()
+    for _ in range(10):
+        if not store._ring:
+            break
+        time.sleep(0.05)
+
+
+def _row(event_id, sid, event_type, ts, data, **extra):
+    """Build a DuckDB events row matching the daemon's v3 projection
+    (see ``clawmetry/sync.py::_parse_v3_event``)."""
+    base = {
+        "id":           event_id,
+        "node_id":      "node-test",
+        "agent_type":   "openclaw",
+        "agent_id":     "main",
+        "session_id":   sid,
+        "workspace_id": None,
+        "event_type":   event_type,
+        "ts":           ts,
+        "data":         json.dumps(data),
+    }
+    base.update(extra)
+    return base
+
+
+def _seed_tool_call(store, *, event_id, sid, ts, tcid, tool_name, result_text=None):
+    """Seed one model.completed event whose ``toolMetas`` carries a single
+    ``tool_use`` block, optionally paired with a ``tool.result`` sibling."""
+    store.ingest(_row(
+        event_id, sid, "model.completed", ts,
+        {
+            "_v3_type": "message", "type": "model.completed",
+            "completionText": f"calling {tool_name}",
+            "modelId":  "claude-opus-4-7",
+            "provider": "anthropic",
+            "toolMetas": [
+                {"id": tcid, "name": tool_name, "input": {"path": "/x"}},
+            ],
+        },
+        model="claude-opus-4-7", cost_usd=0.001,
+    ))
+    if result_text is not None:
+        # Result lands ~1s later under the SAME session_id as the call.
+        result_id = f"{event_id}-r"
+        # ts + 1s — keep it lexicographically sortable.
+        result_ts = ts.replace(":02Z", ":03Z").replace(":00Z", ":01Z")
+        store.ingest(_row(
+            result_id, sid, "tool.result", result_ts,
+            {
+                "_v3_type": "tool_use_result", "type": "tool.result",
+                "tool_use_id": tcid,
+                "output":  result_text,
+                "result":  result_text,
+                "is_error": False,
+            },
+        ))
+
+
+def _api_tools(client, sid):
+    r = client.get(f"/api/session-tools?session_id={sid}&include_unpaired=1")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    return r.get_json()
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Scenario 1: parent has 0 direct tool calls + 3 sub-agent tool calls.
+# Rollup must report 3 (was reporting 0 pre-fix).
+# ────────────────────────────────────────────────────────────────────────────
+def test_parent_with_only_subagent_tool_calls_rolls_up(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "parent-only-subagent"
+    child_sid = "child-with-tools"
+
+    # Parent: just a lifecycle anchor so the fast path doesn't return None.
+    store.ingest(_row(
+        "p1", parent_sid, "session.started", "2026-05-17T12:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    # Register the sub-agent link.
+    store.ingest_subagent({
+        "subagent_id":       child_sid,
+        "agent_type":        "openclaw",
+        "parent_session_id": parent_sid,
+        "spawned_at":        "2026-05-17T12:00:01Z",
+        "task":              "do all the work",
+        "status":            "active",
+    })
+    # Three tool calls under the CHILD's session_id.
+    _seed_tool_call(store, event_id="c1", sid=child_sid,
+                    ts="2026-05-17T12:00:02Z", tcid="t1",
+                    tool_name="Read", result_text="contents-1")
+    _seed_tool_call(store, event_id="c2", sid=child_sid,
+                    ts="2026-05-17T12:01:02Z", tcid="t2",
+                    tool_name="Write", result_text="ok")
+    _seed_tool_call(store, event_id="c3", sid=child_sid,
+                    ts="2026-05-17T12:02:02Z", tcid="t3",
+                    tool_name="Read", result_text="contents-3")
+    _drain(store)
+
+    body = _api_tools(a.test_client(), parent_sid)
+    assert body["_source"] == "local_store"
+    assert body["stats"]["total_calls"] == 3, (
+        f"parent rollup must include 3 sub-agent tool calls; "
+        f"got total_calls={body['stats']['total_calls']!r} (tools={body['tools']!r})"
+    )
+    # Every tool row should be attributed to the child.
+    for rec in body["tools"]:
+        assert rec.get("via_subagent_id") == child_sid, (
+            f"sub-agent rollup row missing via_subagent_id={child_sid!r}: {rec!r}"
+        )
+    # by_tool buckets remain correct.
+    by_name = {t["tool_name"]: t for t in body["by_tool"]}
+    assert by_name["Read"]["calls"] == 2
+    assert by_name["Write"]["calls"] == 1
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Scenario 2: parent has 2 direct + 3 sub-agent tool calls → 5.
+# ────────────────────────────────────────────────────────────────────────────
+def test_parent_rollup_mixes_direct_and_subagent_calls(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "parent-mixed"
+    child_sid = "child-mixed"
+
+    store.ingest(_row(
+        "p1", parent_sid, "session.started", "2026-05-17T13:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    # Direct parent calls.
+    _seed_tool_call(store, event_id="p2", sid=parent_sid,
+                    ts="2026-05-17T13:00:02Z", tcid="dp1",
+                    tool_name="Glob", result_text="found 3")
+    _seed_tool_call(store, event_id="p3", sid=parent_sid,
+                    ts="2026-05-17T13:01:02Z", tcid="dp2",
+                    tool_name="Grep", result_text="2 matches")
+
+    # Sub-agent link + 3 child calls.
+    store.ingest_subagent({
+        "subagent_id":       child_sid,
+        "agent_type":        "openclaw",
+        "parent_session_id": parent_sid,
+        "spawned_at":        "2026-05-17T13:00:01Z",
+        "task":              "deep dive",
+        "status":            "completed",
+    })
+    _seed_tool_call(store, event_id="c1", sid=child_sid,
+                    ts="2026-05-17T13:02:02Z", tcid="t1",
+                    tool_name="Read", result_text="x")
+    _seed_tool_call(store, event_id="c2", sid=child_sid,
+                    ts="2026-05-17T13:03:02Z", tcid="t2",
+                    tool_name="Read", result_text="y")
+    _seed_tool_call(store, event_id="c3", sid=child_sid,
+                    ts="2026-05-17T13:04:02Z", tcid="t3",
+                    tool_name="Bash", result_text="exit 0")
+    _drain(store)
+
+    body = _api_tools(a.test_client(), parent_sid)
+    assert body["_source"] == "local_store"
+    assert body["stats"]["total_calls"] == 5, (
+        f"parent rollup must sum direct (2) + sub-agent (3) = 5; "
+        f"got {body['stats']['total_calls']!r}"
+    )
+    by_attribution = {}
+    for rec in body["tools"]:
+        key = rec.get("via_subagent_id") or "_direct"
+        by_attribution.setdefault(key, []).append(rec["tool_name"])
+    assert sorted(by_attribution.get("_direct", [])) == ["Glob", "Grep"], (
+        f"expected 2 direct calls (Glob, Grep); got {by_attribution.get('_direct')!r}"
+    )
+    assert sorted(by_attribution.get(child_sid, [])) == ["Bash", "Read", "Read"], (
+        f"expected 3 sub-agent calls; got {by_attribution.get(child_sid)!r}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Scenario 3: from the CHILD's perspective, the rollup contains the child's
+# own tool calls only — not its parent's. The helper must be one-directional
+# (parent → children), never children → parent.
+# ────────────────────────────────────────────────────────────────────────────
+def test_child_view_does_not_bleed_parent_tool_calls(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "parent-direction-test"
+    child_sid = "child-direction-test"
+
+    # Parent: 4 direct tool calls of its own.
+    store.ingest(_row(
+        "p1", parent_sid, "session.started", "2026-05-17T14:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    for i in range(4):
+        _seed_tool_call(store, event_id=f"p{i+2}", sid=parent_sid,
+                        ts=f"2026-05-17T14:0{i}:02Z", tcid=f"pt{i}",
+                        tool_name="Read", result_text="ok")
+
+    # Child: 1 tool call, registered as a sub-agent of parent.
+    store.ingest_subagent({
+        "subagent_id":       child_sid,
+        "agent_type":        "openclaw",
+        "parent_session_id": parent_sid,
+        "spawned_at":        "2026-05-17T14:05:00Z",
+        "status":            "active",
+    })
+    store.ingest(_row(
+        "c0", child_sid, "session.started", "2026-05-17T14:05:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": child_sid},
+    ))
+    _seed_tool_call(store, event_id="c1", sid=child_sid,
+                    ts="2026-05-17T14:05:02Z", tcid="ct1",
+                    tool_name="Write", result_text="done")
+    _drain(store)
+
+    # Hitting the CHILD's session_id must return only the 1 tool — not 5.
+    body = _api_tools(a.test_client(), child_sid)
+    assert body["_source"] == "local_store"
+    assert body["stats"]["total_calls"] == 1, (
+        f"child view must NOT include parent's 4 tool calls; "
+        f"got total_calls={body['stats']['total_calls']!r}"
+    )
+    assert body["tools"][0]["tool_name"] == "Write"
+    assert body["tools"][0].get("via_subagent_id") in ("", None)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Scenario 4: an orphan tool call (its session has no row in the subagents
+# table) must NOT bleed into an unrelated parent's rollup.
+# ────────────────────────────────────────────────────────────────────────────
+def test_orphan_tool_call_does_not_bleed_into_unrelated_parent(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "parent-isolated"
+    orphan_sid = "session-no-parent-link"
+
+    # Parent: 1 direct tool call.
+    store.ingest(_row(
+        "p1", parent_sid, "session.started", "2026-05-17T15:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    _seed_tool_call(store, event_id="p2", sid=parent_sid,
+                    ts="2026-05-17T15:00:02Z", tcid="pt1",
+                    tool_name="Read", result_text="parent-data")
+
+    # Orphan session with its own tool — NO ingest_subagent call, so no link.
+    store.ingest(_row(
+        "o1", orphan_sid, "session.started", "2026-05-17T15:00:10Z",
+        {"_v3_type": "session", "type": "session.started", "id": orphan_sid},
+    ))
+    _seed_tool_call(store, event_id="o2", sid=orphan_sid,
+                    ts="2026-05-17T15:00:12Z", tcid="ot1",
+                    tool_name="Bash", result_text="exit 0")
+    _drain(store)
+
+    body = _api_tools(a.test_client(), parent_sid)
+    assert body["_source"] == "local_store"
+    assert body["stats"]["total_calls"] == 1, (
+        f"parent rollup must not include orphan tool calls; "
+        f"got total_calls={body['stats']['total_calls']!r}, tools={body['tools']!r}"
+    )
+    assert body["tools"][0]["tool_name"] == "Read"
+    assert body["tools"][0].get("via_subagent_id") in ("", None)


### PR DESCRIPTION
## Summary
- Parent sessions rendered ``tool_calls=0`` whenever the work was delegated to a sub-agent. The read path queried ``events WHERE session_id = ?`` and never followed ``subagents.parent_session_id`` — sub-agent events live under the child's OWN ``session_id``, so they were invisible to the parent view.
- New helper ``LocalStore.query_events_with_subagents(session_id=...)`` UNIONs the parent's events with each child sub-agent session's events (matched on the ``subagents`` table) and tags child rows with ``data._via_subagent_id``.
- ``_try_local_store_session_tools`` switches to the new helper and propagates the marker onto each ``tools[]`` row as ``via_subagent_id`` so the UI can later render "via sub-agent X" without re-querying.
- Bug-class guard: pre-1597 daemons (older wheel running, newer dashboard) fall back to plain ``query_events`` so the endpoint stays online during the staged rollout (just under-reporting until the daemon restarts).

## Test plan
4 scenarios in ``tests/test_subagent_attribution_v3.py``:
- [x] Parent with 0 direct tool calls + 3 sub-agent tool calls → rollup ``total_calls == 3``, every row tagged ``via_subagent_id == child_sid``.
- [x] Parent with 2 direct + 3 sub-agent calls → rollup ``total_calls == 5``, direct rows untagged, sub rows tagged.
- [x] From the CHILD's perspective, only the child's own calls are returned (no upward bleed — the helper walks parent→children, never children→parent).
- [x] Orphan tool call whose session has NO ``subagents`` row does NOT bleed into an unrelated parent's rollup.

Also verified:
- [x] ``python3 -c "import dashboard"`` clean.
- [x] ``tests/test_subagents_local_store_v3.py`` (existing sub-agent fast-path) + ``tests/test_session_tools_local_store_v3.py`` (existing v3 session-tools) + ``tests/test_local_store.py`` — all green except a pre-existing schema-version-drift failure on ``test_health_reports_size_and_count`` that reproduces on a clean ``origin/main`` checkout (unrelated).

## Class-bug follow-up (NOT fixed in this PR)
Same parent_sid blindness exists in every per-session events read path. Surfaced here for a follow-up; deliberately out of scope for this 100-LOC PR:

| Endpoint / function | File | Reads |
|---|---|---|
| ``/api/transcript/<sid>`` (``_try_local_store_transcript_events``) | routes/sessions.py:3171 | ``query_events(session_id=sid)`` |
| ``/api/session-export`` (``_try_local_store_session_export``) | routes/sessions.py:4028 | ``query_events(session_id=sid)`` |
| ``/api/session-cost-breakdown`` (``_try_local_store_session_cost_breakdown``) | routes/sessions.py:3760 | ``query_events(session_id=sid)`` |
| ``/api/cron-detail/<job_id>`` per-session walk | routes/crons.py:875 | ``query_events(session_id=sid)`` |
| ``/api/brain-history`` filter by session | routes/brain.py:1140 | ``query_events(session_id=sid)`` |
| ``query_cost_split(session_id=...)`` (powers ``/api/cost-split``) | clawmetry/local_store.py:3711 | ``events WHERE session_id = ?`` |
| ``query_session_model_journey(session_id=...)`` | clawmetry/local_store.py:4068 | ``events WHERE session_id = ?`` |
| ``query_context_window_peek(session_id=...)`` | clawmetry/local_store.py:3811 | ``events WHERE session_id = ?`` |

All of these likely under-report when a session has spawned sub-agents. The same ``query_events_with_subagents`` pattern (or a ``WHERE session_id IN (?, child1, child2, …)`` rewrite at the SQL layer) cleans the family up.

Closes #1597

🤖 Generated with [Claude Code](https://claude.com/claude-code)