### PR TITLE
fix(class-bug): parent_sid rollup drain — 8 per-session reads now follow sub-agent attribution (refs #1597)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -3808,6 +3808,60 @@ class LocalStore:
             return out
         return out[:int(limit)]
 
+    def query_cost_split_with_subagents(
+        self,
+        *,
+        session_id: str,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Per-session cost split UNIONed across ``session_id`` + every
+        child sub-agent session (issue #1597 class drain).
+
+        Same shape as ``query_cost_split(session_id=...)`` but the returned
+        rows include sub-agent sessions whose ``subagents.parent_session_id``
+        matches the requested parent. Each child row carries
+        ``_via_subagent_id`` set to the child's session_id so the caller can
+        attribute cost back to the spawning Task tool. The parent's own row
+        keeps ``_via_subagent_id=""``.
+
+        Sub-agent rows are returned as SEPARATE entries (one per child
+        session) rather than collapsed into the parent's totals so the
+        Cost-tab can render "parent: $X / sub-agent A: $Y / sub-agent B: $Z"
+        without re-querying. Callers that want a flat sum should reduce the
+        returned list themselves.
+
+        Behaviour when ``session_id`` has no sub-agent links: identical to
+        ``query_cost_split(session_id=session_id)`` — one row, no children.
+        """
+        out: list[dict[str, Any]] = []
+        own = self.query_cost_split(session_id=session_id, limit=limit)
+        for r in own:
+            r["_via_subagent_id"] = ""
+            out.append(r)
+        try:
+            subs = self.query_subagents(
+                parent_session_id=session_id, limit=500,
+            )
+        except Exception:
+            subs = []
+        for sa in subs:
+            child_sid = sa.get("subagent_id")
+            if not child_sid or child_sid == session_id:
+                continue
+            try:
+                child_rows = self.query_cost_split(
+                    session_id=child_sid, limit=limit,
+                )
+            except Exception:
+                continue
+            for r in child_rows:
+                r["_via_subagent_id"] = child_sid
+                out.append(r)
+        # Re-sort by total_cost_usd desc so the parent's row tends to land
+        # first when it dominates (matches the limit-less filter shape).
+        out.sort(key=lambda r: r.get("total_cost_usd", 0), reverse=True)
+        return out
+
     def query_context_window_peek(
         self,
         *,
@@ -3820,6 +3874,15 @@ class LocalStore:
         non-zero ``usage.input_tokens`` reading from a ``message`` event.
         That number represents the live conversation's running context
         size as observed by the model on its most recent turn.
+
+        Issue #1597 class drain — intentionally NO sub-agent rollup: the
+        gauge measures the LIVE prompt context for a single conversation.
+        A child sub-agent has its OWN context window (separate prompt,
+        separate compaction history), not the parent's. Rolling parent +
+        child would surface the most-recent CHILD's context as if it were
+        the parent's, which is wrong — the parent's context-window
+        pressure is what the user-facing "approaching context limit"
+        banner needs to reflect.
 
         Why a dedicated query: the existing ``query_cost_split`` returns
         SUMMED input_tokens across the whole session, which is the wrong
@@ -4127,6 +4190,60 @@ class LocalStore:
                     "total_cost":   float(cost_obj.get("total", 0) or 0),
                     "ts":           ts,
                 })
+        return out
+
+    def query_session_model_journey_with_subagents(
+        self,
+        *,
+        session_id: str,
+        limit: int = 5000,
+    ) -> list[dict[str, Any]]:
+        """Model + message events for ``session_id`` UNIONed with every
+        child sub-agent session (issue #1597 class drain).
+
+        A parent that delegates to a sub-agent (Task tool spawns a Haiku
+        worker from an Opus parent — a common cost-saver pattern) shows up
+        in the model-journey view as a "transition" only if the child's
+        ``model_change`` / ``message`` events are merged in. Without this
+        rollup the journey for a parent that immediately delegated 100% of
+        work to a child renders as a single-model line.
+
+        Same row shape as ``query_session_model_journey`` plus each row
+        carries ``_via_subagent_id`` (empty for parent rows, the child
+        session_id for child rows) so the UI can paint a sub-agent swimlane
+        without re-querying.
+
+        Re-sorted by ``ts`` ASC at the end so callers can keep their
+        chronological walk untouched.
+        """
+        if not session_id:
+            return []
+        out: list[dict[str, Any]] = []
+        for r in self.query_session_model_journey(
+            session_id=session_id, limit=limit,
+        ):
+            r["_via_subagent_id"] = ""
+            out.append(r)
+        try:
+            subs = self.query_subagents(
+                parent_session_id=session_id, limit=500,
+            )
+        except Exception:
+            subs = []
+        for sa in subs:
+            child_sid = sa.get("subagent_id")
+            if not child_sid or child_sid == session_id:
+                continue
+            try:
+                child_rows = self.query_session_model_journey(
+                    session_id=child_sid, limit=limit,
+                )
+            except Exception:
+                continue
+            for r in child_rows:
+                r["_via_subagent_id"] = child_sid
+                out.append(r)
+        out.sort(key=lambda r: (r.get("ts") or ""))
         return out
 
     def query_daily_usage_splits(

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -1130,6 +1130,18 @@ def _fetch_session_chain(session_id, limit=200):
     with the daemon's writer lock (issue #1088); falls back to direct open
     for single-process boots (tests + dev mode — same pattern as
     ``_try_local_store_brain`` above).
+
+    Issue #1597 class drain — intentionally NOT using
+    ``query_events_with_subagents``: this helper feeds
+    ``_build_llm_call_timeline`` which walks back from an anchor event for
+    the nearest preceding ``prompt.submitted`` row of the SAME LLM call.
+    A single LLM call's lifecycle (prompt → reasoning → completion) lives
+    in one session — sub-agents are separate sessions with their own LLM
+    calls. Rolling parent + child here would mix two unrelated call chains
+    and the "preceding prompt.submitted" walk would jump across sessions.
+    The Brain feed already passes the row's OWN session_id when the user
+    clicks a child chip (see ``app.js::loadLlmCallTimeline``), so child
+    timelines work end-to-end without rollup.
     """
     if not session_id:
         return None

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -871,8 +871,15 @@ def _try_local_store_cron_run_log(session_id: str):
     with the standard direct-open fallback for single-process boots. Returns
     ``None`` to defer to the JSONL parser when the events table has no
     message rows for this session.
+
+    Issue #1597 class drain: a cron run that delegates work to a Task-tool
+    sub-agent renders as "no messages" in the run-log modal without rollup.
+    UNION sub-agent events so the run log reflects the work actually done.
+    Falls back to parent-only on older daemons.
     """
-    rows = _ls_call("query_events", session_id=session_id, limit=5000)
+    rows = _ls_call("query_events_with_subagents", session_id=session_id, limit=5000)
+    if rows is None:
+        rows = _ls_call("query_events", session_id=session_id, limit=5000)
     if not rows:
         return None
     rows = list(reversed(rows))  # query_events returns DESC

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -358,7 +358,14 @@ _DAEMON_METHODS = frozenset({
     # helpers powering the next batch of Bypass-Medium fast-paths.
     "query_compactions",
     "query_cost_split",
+    # Issue #1597 class drain: sister helpers that UNION parent + child
+    # sub-agent rows on per-session reads. Same pattern as
+    # query_events_with_subagents — without these a parent that delegated
+    # cost / model transitions to a Task-tool sub-agent reported zero on
+    # the cost-split + session-model-journey routes.
+    "query_cost_split_with_subagents",
     "query_session_model_journey",
+    "query_session_model_journey_with_subagents",
     # Tier-1 (2026-05-15): /api/context-anatomy session-history bucket
     # off the JSONL scanner. Returns last non-zero usage.input_tokens
     # from the most-recent active session.

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -1185,12 +1185,32 @@ def _try_local_store_cost_split(wanted_sid: str, limit: int):
     walker returns.
 
     Issue #1088 phase 3. Returns ``None`` when the events table has no
-    message rows so the route falls through to the JSONL walker."""
-    rows = _ls_call(
-        "query_cost_split",
-        session_id=wanted_sid or None,
-        limit=limit,
-    )
+    message rows so the route falls through to the JSONL walker.
+
+    Issue #1597 class drain: when scoped to a single session
+    (``wanted_sid``), uses the sub-agent-rollup variant so a parent that
+    delegated cost to a Task-tool child still attributes that cost back.
+    Top-N mode (no ``wanted_sid``) keeps the flat per-session listing —
+    rollup is only meaningful when the caller has a target parent.
+    """
+    if wanted_sid:
+        rows = _ls_call(
+            "query_cost_split_with_subagents",
+            session_id=wanted_sid,
+            limit=limit,
+        )
+        if rows is None:
+            rows = _ls_call(
+                "query_cost_split",
+                session_id=wanted_sid,
+                limit=limit,
+            )
+    else:
+        rows = _ls_call(
+            "query_cost_split",
+            session_id=None,
+            limit=limit,
+        )
     if not rows:
         return None
     # Compute totals (mirrors the legacy path's aggregation).
@@ -3167,8 +3187,15 @@ def _try_local_store_transcript_events(session_id: str):
     Issue #1088: routes through the daemon HTTP proxy first, with the standard
     direct-open fallback inside ``_ls_call``. Returns ``None`` to defer to the
     JSONL parser when the events table has no rows for this session.
+
+    Issue #1597 class drain: UNIONs sub-agent events so the transcript modal
+    on a parent session shows every model/tool turn the parent delegated to a
+    Task-tool child. Falls back to the parent-only query when the daemon
+    predates the helper (staged rollout).
     """
-    rows = _ls_call("query_events", session_id=session_id, limit=10000)
+    rows = _ls_call("query_events_with_subagents", session_id=session_id, limit=10000)
+    if rows is None:
+        rows = _ls_call("query_events", session_id=session_id, limit=10000)
     if not rows:
         return None
     rows = list(reversed(rows))  # query_events is DESC; the modal reads forward.
@@ -3465,12 +3492,24 @@ def _try_local_store_session_model_journey(session_id: str):
     the same ``segments`` shape the JSONL walker produces.
 
     Issue #1088 phase 3. Returns ``None`` when the events table has no
-    matching rows so the route falls through to the JSONL walker."""
+    matching rows so the route falls through to the JSONL walker.
+
+    Issue #1597 class drain: uses the sub-agent-rollup variant so a parent
+    that delegated to a Task-tool child with a different model (e.g. Opus
+    parent → Haiku worker) shows the full model journey instead of just
+    the parent's initial line. Falls back to parent-only on older daemons.
+    """
     rows = _ls_call(
-        "query_session_model_journey",
+        "query_session_model_journey_with_subagents",
         session_id=session_id,
         limit=5000,
     )
+    if rows is None:
+        rows = _ls_call(
+            "query_session_model_journey",
+            session_id=session_id,
+            limit=5000,
+        )
     if not rows:
         return None
 
@@ -3756,8 +3795,14 @@ def _try_local_store_session_cost_breakdown(session_id: str):
       - no events exist for this session_id (fresh sync, etc.)
       - data blobs aren't shaped like assistant messages
       - any unexpected error happens
+
+    Issue #1597 class drain: UNIONs sub-agent events so the per-turn cost
+    breakdown attributes Task-tool sub-agent turns back to the parent.
+    Falls back to the parent-only query on older daemons.
     """
-    evs = _ls_call("query_events", session_id=session_id, limit=5000)
+    evs = _ls_call("query_events_with_subagents", session_id=session_id, limit=5000)
+    if evs is None:
+        evs = _ls_call("query_events", session_id=session_id, limit=5000)
     if not evs:
         return None
     # Walk events oldest-first so turn_index is meaningful.
@@ -4024,8 +4069,15 @@ def _try_local_store_session_export(session_id: str):
       subset" failure mode.
     * Returns ``None`` (not an empty-messages dict) when no attributable
       rows survived, so the JSONL parser fallback fires.
+
+    Issue #1597 class drain: the export now UNIONs sub-agent events so
+    downstream re-import / audit pipelines see the full delegated work, not
+    just the parent's direct turns. Falls back to parent-only on older
+    daemons (pre-#1611 wheel).
     """
-    rows = _ls_call("query_events", session_id=session_id, limit=10000)
+    rows = _ls_call("query_events_with_subagents", session_id=session_id, limit=10000)
+    if rows is None:
+        rows = _ls_call("query_events", session_id=session_id, limit=10000)
     if not rows:
         return None
     rows = list(reversed(rows))  # query_events is DESC; export reads forward.

--- a/tests/test_class_bug_parent_sid_drain.py
+++ b/tests/test_class_bug_parent_sid_drain.py
@@ -1,0 +1,625 @@
+"""Class-bug drain: parent_sid blindness across 6 per-session reads (refs #1597).
+
+PR #1611 fixed ``_try_local_store_session_tools`` by adding the
+``query_events_with_subagents`` helper that UNIONs the parent's events
+with every child sub-agent session's events. The same class bug existed
+on 8 sibling per-session read paths; this test pins down the rollup
+behaviour for the 6 sites we fixed in the class-bug drain PR and the 2
+sites that legitimately stay per-session-only.
+
+The 6 fixed sites
+=================
+1. ``routes/sessions.py:_try_local_store_transcript_events`` —
+   /api/transcript-events/<id> — transcript modal events.
+2. ``routes/sessions.py:_try_local_store_session_export`` —
+   /api/sessions/<id>/export — JSON export.
+3. ``routes/sessions.py:_try_local_store_session_cost_breakdown`` —
+   /api/sessions/<id>/cost-breakdown — per-turn cost+token breakdown.
+4. ``routes/crons.py:_try_local_store_cron_run_log`` —
+   /api/cron-run-log — cron run-log modal.
+5. ``routes/sessions.py:_try_local_store_cost_split`` (wanted_sid mode) —
+   /api/cost-split?session=<id> — per-session token + cost split.
+6. ``routes/sessions.py:_try_local_store_session_model_journey`` —
+   /api/session-model-journey/<id> — ordered model + message events.
+
+The 2 per-session-only sites (no rollup)
+========================================
+* ``routes/brain.py:_fetch_session_chain`` — /api/llm-call-timeline/<event_id>:
+  walks back from an anchor to the nearest preceding ``prompt.submitted``
+  in the SAME LLM call; rolling parent+child would mix two unrelated
+  call chains. Test enforces no-rollup so the timeline can't regress.
+* ``clawmetry/local_store.py::query_context_window_peek`` — context-anatomy
+  gauge for the LIVE prompt context of one conversation. A child has its
+  own context window; rolling would surface the child's most-recent
+  context as the parent's.
+
+All 8 sites are exercised end-to-end so a future refactor that
+re-introduces the parent_sid blindness on a "fixed" site OR adds rollup
+to a "no-rollup" site flips this test red.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+from flask import Flask
+
+
+# ─── Fixture ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Spin up a Flask app with fresh routes/sessions, routes/crons,
+    routes/brain blueprints rooted at a tmp_path DuckDB.
+
+    Matches the isolation pattern from ``test_subagent_attribution_v3.py``:
+    sets CLAWMETRY_LOCAL_STORE_PATH, reloads the store + routes, and
+    monkey-patches ``_read_discovery`` so the test never proxies to a
+    contributor's running daemon."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+    import routes.crons as crons_mod
+    importlib.reload(crons_mod)
+    import routes.brain as brain_mod
+    importlib.reload(brain_mod)
+
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    a.register_blueprint(crons_mod.bp_crons)
+    a.register_blueprint(brain_mod.bp_brain)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _drain(store):
+    store._flush_now()
+    for _ in range(10):
+        if not store._ring:
+            break
+        time.sleep(0.05)
+
+
+def _row(event_id, sid, event_type, ts, data, **extra):
+    base = {
+        "id":           event_id,
+        "node_id":      "node-test",
+        "agent_type":   "openclaw",
+        "agent_id":     "main",
+        "session_id":   sid,
+        "workspace_id": None,
+        "event_type":   event_type,
+        "ts":           ts,
+        "data":         json.dumps(data),
+    }
+    base.update(extra)
+    return base
+
+
+def _seed_assistant_turn(store, *, event_id, sid, ts, model, in_tok, out_tok,
+                         cr_tok=0, cw_tok=0, cost_input=0.0, cost_output=0.0,
+                         cost_cr=0.0, cost_cw=0.0):
+    """Emit a v3-shape assistant turn carrying a full Anthropic-SDK envelope
+    so the cost/breakdown helpers all parse usage cleanly."""
+    cost_total = cost_input + cost_output + cost_cr + cost_cw
+    store.ingest(_row(
+        event_id, sid, "message", ts,
+        {
+            "_v3_type": "message", "type": "message",
+            "message": {
+                "role":  "assistant",
+                "model": model,
+                "content": [{"type": "text", "text": "ok"}],
+                "usage": {
+                    "input":      in_tok,
+                    "output":     out_tok,
+                    "cacheRead":  cr_tok,
+                    "cacheWrite": cw_tok,
+                    "totalTokens": in_tok + out_tok + cr_tok + cw_tok,
+                    "cost": {
+                        "input":      cost_input,
+                        "output":     cost_output,
+                        "cacheRead":  cost_cr,
+                        "cacheWrite": cost_cw,
+                        "total":      cost_total,
+                    },
+                },
+            },
+        },
+        model=model, cost_usd=cost_total, token_count=in_tok + out_tok,
+    ))
+
+
+def _seed_model_change(store, *, event_id, sid, ts, model, provider="anthropic"):
+    store.ingest(_row(
+        event_id, sid, "model_change", ts,
+        {"_v3_type": "model_change", "type": "model_change",
+         "modelId": model, "provider": provider},
+        model=model,
+    ))
+
+
+def _link_subagent(store, *, child_sid, parent_sid, spawned_at, task="work"):
+    store.ingest_subagent({
+        "subagent_id":       child_sid,
+        "agent_type":        "openclaw",
+        "parent_session_id": parent_sid,
+        "spawned_at":        spawned_at,
+        "task":              task,
+        "status":            "active",
+    })
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Site 1: /api/transcript-events/<id> — _try_local_store_transcript_events.
+# A parent with 0 direct + 2 sub-agent message events must show 2 events
+# in the transcript modal (and the child events must be tagged).
+# ────────────────────────────────────────────────────────────────────────────
+def test_site1_transcript_events_rolls_up_subagent_messages(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "s1-parent"
+    child_sid = "s1-child"
+
+    store.ingest(_row(
+        "s1-p0", parent_sid, "session.started", "2026-05-17T10:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    _link_subagent(store, child_sid=child_sid, parent_sid=parent_sid,
+                   spawned_at="2026-05-17T10:00:01Z", task="research")
+    _seed_assistant_turn(store, event_id="s1-c1", sid=child_sid,
+                         ts="2026-05-17T10:00:02Z", model="claude-opus-4-7",
+                         in_tok=100, out_tok=50, cost_input=0.001,
+                         cost_output=0.002)
+    _seed_assistant_turn(store, event_id="s1-c2", sid=child_sid,
+                         ts="2026-05-17T10:01:02Z", model="claude-haiku-4-7",
+                         in_tok=200, out_tok=80, cost_input=0.0005,
+                         cost_output=0.001)
+    _drain(store)
+
+    r = a.test_client().get(f"/api/transcript-events/{parent_sid}")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    # 2 child message events should now appear in the parent's transcript.
+    assert body["messageCount"] == 2, (
+        f"parent transcript must include 2 sub-agent messages; "
+        f"got messageCount={body['messageCount']!r}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Site 2: /api/sessions/<id>/export — _try_local_store_session_export.
+# A parent with 0 direct messages + 3 sub-agent assistant turns must export
+# 3 messages and a non-zero cost_data.total_cost_usd.
+# ────────────────────────────────────────────────────────────────────────────
+def test_site2_session_export_rolls_up_subagent_cost(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "s2-parent"
+    child_sid = "s2-child"
+
+    store.ingest(_row(
+        "s2-p0", parent_sid, "session.started", "2026-05-17T11:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    _link_subagent(store, child_sid=child_sid, parent_sid=parent_sid,
+                   spawned_at="2026-05-17T11:00:01Z")
+    for i in range(3):
+        _seed_assistant_turn(store, event_id=f"s2-c{i}", sid=child_sid,
+                             ts=f"2026-05-17T11:0{i+1}:00Z",
+                             model="claude-opus-4-7",
+                             in_tok=500, out_tok=200,
+                             cost_input=0.005, cost_output=0.003)
+    _drain(store)
+
+    r = a.test_client().get(f"/api/sessions/{parent_sid}/export")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", (
+        f"export must hit local_store fast path; body keys={list(body.keys())!r}"
+    )
+    assert len(body["messages"]) == 3, (
+        f"export must include 3 sub-agent messages; got {len(body['messages'])}"
+    )
+    # 3 turns * (0.005 + 0.003) = 0.024 USD.
+    assert body["cost_data"]["total_cost_usd"] > 0.02, (
+        f"export cost must include sub-agent spend; "
+        f"got total_cost_usd={body['cost_data']['total_cost_usd']!r}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Site 3: /api/sessions/<id>/cost-breakdown —
+# _try_local_store_session_cost_breakdown. A parent with 0 direct turns +
+# 4 sub-agent turns must report 4 turns and the correct token totals.
+# ────────────────────────────────────────────────────────────────────────────
+def test_site3_cost_breakdown_rolls_up_subagent_turns(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "s3-parent"
+    child_sid = "s3-child"
+
+    store.ingest(_row(
+        "s3-p0", parent_sid, "session.started", "2026-05-17T12:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    _link_subagent(store, child_sid=child_sid, parent_sid=parent_sid,
+                   spawned_at="2026-05-17T12:00:01Z")
+    for i in range(4):
+        _seed_assistant_turn(store, event_id=f"s3-c{i}", sid=child_sid,
+                             ts=f"2026-05-17T12:0{i+1}:00Z",
+                             model="claude-opus-4-7",
+                             in_tok=1000, out_tok=400, cr_tok=200,
+                             cost_input=0.01, cost_output=0.006,
+                             cost_cr=0.001)
+    _drain(store)
+
+    r = a.test_client().get(f"/api/sessions/{parent_sid}/cost-breakdown")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("turn_count") == 4, (
+        f"parent cost breakdown must include 4 sub-agent turns; "
+        f"got turn_count={body.get('turn_count')!r}"
+    )
+    # 4 turns * 1000 input each = 4000.
+    assert body["totals"]["input_tokens"] == 4000
+    assert body["totals"]["output_tokens"] == 1600
+    assert body["totals"]["cache_read_tokens"] == 800
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Site 4: /api/cron-run-log — _try_local_store_cron_run_log.
+# A cron run that delegated to a sub-agent must show the sub-agent's
+# messages, not return an empty events list.
+# ────────────────────────────────────────────────────────────────────────────
+def test_site4_cron_run_log_rolls_up_subagent_messages(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "s4-cron-run"
+    child_sid = "s4-child"
+
+    store.ingest(_row(
+        "s4-p0", parent_sid, "session.started", "2026-05-17T13:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    _link_subagent(store, child_sid=child_sid, parent_sid=parent_sid,
+                   spawned_at="2026-05-17T13:00:01Z", task="nightly cleanup")
+    # 2 child messages.
+    _seed_assistant_turn(store, event_id="s4-c1", sid=child_sid,
+                         ts="2026-05-17T13:00:02Z", model="claude-opus-4-7",
+                         in_tok=50, out_tok=20)
+    _seed_assistant_turn(store, event_id="s4-c2", sid=child_sid,
+                         ts="2026-05-17T13:00:05Z", model="claude-opus-4-7",
+                         in_tok=60, out_tok=15)
+    _drain(store)
+
+    r = a.test_client().get(f"/api/cron-run-log?session_id={parent_sid}")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    assert len(body["events"]) == 2, (
+        f"cron run-log must include 2 sub-agent messages; "
+        f"got {len(body['events'])} events"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Site 5: /api/cost-split?session=<id> — _try_local_store_cost_split
+# (wanted_sid branch). A parent with 0 direct + sub-agent cost must return
+# at least one ``sessions`` row with non-zero total_cost_usd attributable to
+# the child via ``_via_subagent_id``.
+# ────────────────────────────────────────────────────────────────────────────
+def test_site5_cost_split_rolls_up_subagent_sessions(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "s5-parent"
+    child_sid = "s5-child"
+
+    store.ingest(_row(
+        "s5-p0", parent_sid, "session.started", "2026-05-17T14:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    _link_subagent(store, child_sid=child_sid, parent_sid=parent_sid,
+                   spawned_at="2026-05-17T14:00:01Z")
+    _seed_assistant_turn(store, event_id="s5-c1", sid=child_sid,
+                         ts="2026-05-17T14:00:02Z", model="claude-opus-4-7",
+                         in_tok=1000, out_tok=400,
+                         cost_input=0.01, cost_output=0.006)
+    _drain(store)
+
+    r = a.test_client().get(f"/api/cost-split?session_id={parent_sid}")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store"
+    sess = body["sessions"]
+    # The single child row should be returned as the sole session entry,
+    # tagged with _via_subagent_id pointing at the child.
+    child_rows = [s for s in sess if s.get("_via_subagent_id") == child_sid]
+    assert child_rows, (
+        f"cost-split must surface a sub-agent row tagged with _via_subagent_id; "
+        f"got sessions={sess!r}"
+    )
+    assert child_rows[0]["total_cost_usd"] > 0.0
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Site 6: /api/session-model-journey/<id> —
+# _try_local_store_session_model_journey. A parent that ran model A then
+# delegated to a child running model B must show BOTH models in the
+# journey segments — not just A.
+# ────────────────────────────────────────────────────────────────────────────
+def test_site6_model_journey_rolls_up_subagent_models(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "s6-parent"
+    child_sid = "s6-child"
+
+    # Parent: one direct assistant turn on Opus.
+    store.ingest(_row(
+        "s6-p0", parent_sid, "session.started", "2026-05-17T15:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    _seed_model_change(store, event_id="s6-pmc", sid=parent_sid,
+                       ts="2026-05-17T15:00:01Z", model="claude-opus-4-7")
+    _seed_assistant_turn(store, event_id="s6-p1", sid=parent_sid,
+                         ts="2026-05-17T15:00:02Z", model="claude-opus-4-7",
+                         in_tok=100, out_tok=50,
+                         cost_input=0.001, cost_output=0.002)
+    # Sub-agent: Haiku worker.
+    _link_subagent(store, child_sid=child_sid, parent_sid=parent_sid,
+                   spawned_at="2026-05-17T15:00:03Z")
+    _seed_model_change(store, event_id="s6-cmc", sid=child_sid,
+                       ts="2026-05-17T15:00:04Z", model="claude-haiku-4-7")
+    _seed_assistant_turn(store, event_id="s6-c1", sid=child_sid,
+                         ts="2026-05-17T15:00:05Z", model="claude-haiku-4-7",
+                         in_tok=200, out_tok=80,
+                         cost_input=0.0005, cost_output=0.0008)
+    _drain(store)
+
+    r = a.test_client().get(f"/api/session-model-journey/{parent_sid}")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    models_used = {s.get("modelId") for s in body.get("segments", [])}
+    assert "claude-opus-4-7" in models_used and "claude-haiku-4-7" in models_used, (
+        f"model journey must include parent Opus AND child Haiku; "
+        f"got models_used={models_used!r}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Cross-cutting guard A: CHILD view never bleeds the parent's events.
+# Hitting any per-session endpoint with a child's session_id must NOT pull
+# the parent's events in via reverse rollup. Validates the one-directional
+# walk (parent → children, never children → parent).
+# ────────────────────────────────────────────────────────────────────────────
+def test_child_view_never_bleeds_parent_events(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "guardA-parent"
+    child_sid = "guardA-child"
+
+    # Parent: 5 direct assistant turns (the value we'd see if rollup
+    # accidentally walked children → parent).
+    store.ingest(_row(
+        "ga-p0", parent_sid, "session.started", "2026-05-17T16:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    for i in range(5):
+        _seed_assistant_turn(store, event_id=f"ga-p{i+1}", sid=parent_sid,
+                             ts=f"2026-05-17T16:0{i+1}:00Z",
+                             model="claude-opus-4-7",
+                             in_tok=999, out_tok=111)
+    # Child: 1 direct turn, registered as parent's sub-agent.
+    _link_subagent(store, child_sid=child_sid, parent_sid=parent_sid,
+                   spawned_at="2026-05-17T16:10:00Z")
+    store.ingest(_row(
+        "ga-c0", child_sid, "session.started", "2026-05-17T16:10:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": child_sid},
+    ))
+    _seed_assistant_turn(store, event_id="ga-c1", sid=child_sid,
+                         ts="2026-05-17T16:10:01Z", model="claude-haiku-4-7",
+                         in_tok=10, out_tok=5)
+    _drain(store)
+
+    # Hitting the CHILD's session_id on /api/sessions/<id>/cost-breakdown
+    # must report 1 turn, not 6.
+    r = a.test_client().get(f"/api/sessions/{child_sid}/cost-breakdown")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("turn_count") == 1, (
+        f"child cost breakdown must NOT pull in parent's 5 turns "
+        f"(one-directional walk only); got turn_count={body.get('turn_count')!r}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Cross-cutting guard B: orphan tool calls must NOT leak into an
+# unrelated parent's rollup. An "orphan" is a session that has no row in
+# the subagents table — typical of pre-#1611 ingest paths that wrote
+# events but not subagent rollups.
+# ────────────────────────────────────────────────────────────────────────────
+def test_orphan_session_never_leaks_into_unrelated_parent(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "guardB-parent"
+    orphan_sid = "guardB-orphan-no-link"
+
+    # Parent: 1 direct turn.
+    store.ingest(_row(
+        "gb-p0", parent_sid, "session.started", "2026-05-17T17:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    _seed_assistant_turn(store, event_id="gb-p1", sid=parent_sid,
+                         ts="2026-05-17T17:00:01Z", model="claude-opus-4-7",
+                         in_tok=100, out_tok=50,
+                         cost_input=0.001, cost_output=0.002)
+    # Orphan: 10 turns, NO ingest_subagent linkage.
+    store.ingest(_row(
+        "gb-o0", orphan_sid, "session.started", "2026-05-17T17:01:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": orphan_sid},
+    ))
+    for i in range(10):
+        _seed_assistant_turn(store, event_id=f"gb-o{i+1}", sid=orphan_sid,
+                             ts=f"2026-05-17T17:01:{i:02d}Z",
+                             model="claude-opus-4-7",
+                             in_tok=9999, out_tok=9999)
+    _drain(store)
+
+    r = a.test_client().get(f"/api/sessions/{parent_sid}/cost-breakdown")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("turn_count") == 1, (
+        f"parent rollup must NOT include orphan session's 10 turns; "
+        f"got turn_count={body.get('turn_count')!r}"
+    )
+    # And the totals match the parent's single turn only.
+    assert body["totals"]["input_tokens"] == 100, (
+        f"orphan turns must not pollute parent totals; "
+        f"got input_tokens={body['totals']['input_tokens']!r}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Site 7 (no-rollup): brain.py::_fetch_session_chain must STAY per-session.
+# /api/llm-call-timeline/<event_id>?session_id=<child> must succeed without
+# the parent's events polluting the chain walk. Conversely, looking up an
+# event_id that only exists in a child while passing the parent's
+# session_id must NOT silently find it via reverse rollup.
+# ────────────────────────────────────────────────────────────────────────────
+def test_site7_llm_call_timeline_stays_per_session_no_rollup(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "s7-parent"
+    child_sid = "s7-child"
+
+    # Parent: prompt.submitted + model.completed pair on Opus.
+    store.ingest(_row(
+        "s7-pp", parent_sid, "prompt.submitted", "2026-05-17T18:00:00Z",
+        {"_v3_type": "user", "type": "prompt.submitted",
+         "finalPromptText": "parent prompt"},
+    ))
+    store.ingest(_row(
+        "s7-pm", parent_sid, "model.completed", "2026-05-17T18:00:01Z",
+        {"_v3_type": "message", "type": "model.completed",
+         "modelId": "claude-opus-4-7", "provider": "anthropic"},
+        model="claude-opus-4-7",
+    ))
+    # Child: prompt.submitted + model.completed pair on Haiku.
+    _link_subagent(store, child_sid=child_sid, parent_sid=parent_sid,
+                   spawned_at="2026-05-17T18:01:00Z")
+    store.ingest(_row(
+        "s7-cp", child_sid, "prompt.submitted", "2026-05-17T18:01:01Z",
+        {"_v3_type": "user", "type": "prompt.submitted",
+         "finalPromptText": "child prompt"},
+    ))
+    store.ingest(_row(
+        "s7-cm", child_sid, "model.completed", "2026-05-17T18:01:02Z",
+        {"_v3_type": "message", "type": "model.completed",
+         "modelId": "claude-haiku-4-7", "provider": "anthropic"},
+        model="claude-haiku-4-7",
+    ))
+    _drain(store)
+
+    # Asking for the CHILD's call timeline with the CHILD's session_id
+    # must succeed. (Validates the no-rollup design — when the UI passes
+    # the row's own session_id, the lookup works without help.)
+    r = a.test_client().get(
+        f"/api/llm-call-timeline/s7-cm?session_id={child_sid}"
+    )
+    assert r.status_code == 200, r.get_data(as_text=True)
+
+    # Asking for the CHILD's call timeline with the PARENT's session_id
+    # must FAIL ("event not found in session"). If a future refactor
+    # accidentally adds query_events_with_subagents to _fetch_session_chain,
+    # this call would silently succeed by walking children — masking the
+    # cross-session bug. The 404 keeps the per-session contract honest.
+    r = a.test_client().get(
+        f"/api/llm-call-timeline/s7-cm?session_id={parent_sid}"
+    )
+    assert r.status_code == 404, (
+        f"parent-session lookup must NOT pull a child event in via rollup; "
+        f"got status={r.status_code} body={r.get_data(as_text=True)!r}"
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Site 8 (no-rollup): query_context_window_peek must NOT roll children into
+# the latest active session's context window. The gauge represents the
+# live prompt for one conversation; a child has its own context. Test
+# directly against the LocalStore method since the route reads /api/
+# context-anatomy through a thicker stack.
+# ────────────────────────────────────────────────────────────────────────────
+def test_site8_context_window_peek_stays_per_session_no_rollup(app):
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "s8-parent"
+    child_sid = "s8-child"
+
+    # Parent: latest activity, input_tokens=12345 (the value the gauge
+    # should report).
+    store.ingest(_row(
+        "s8-p0", parent_sid, "session.started", "2026-05-17T19:00:00Z",
+        {"_v3_type": "session", "type": "session.started", "id": parent_sid},
+    ))
+    store.ingest(_row(
+        "s8-p1", parent_sid, "message", "2026-05-17T19:00:01Z",
+        {"_v3_type": "message", "type": "message",
+         "message": {
+            "role": "assistant", "model": "claude-opus-4-7",
+            "usage": {"input": 12345, "output": 100},
+        }},
+        model="claude-opus-4-7",
+    ))
+    # Child: latest activity is LATER than parent's, with a DIFFERENT
+    # input_tokens (99999). If rollup leaks in, the gauge would report
+    # 99999 — the child's context, not the parent's.
+    _link_subagent(store, child_sid=child_sid, parent_sid=parent_sid,
+                   spawned_at="2026-05-17T19:00:10Z")
+    store.ingest(_row(
+        "s8-c1", child_sid, "message", "2026-05-17T19:00:11Z",
+        {"_v3_type": "message", "type": "message",
+         "message": {
+            "role": "assistant", "model": "claude-haiku-4-7",
+            "usage": {"input": 99999, "output": 100},
+        }},
+        model="claude-haiku-4-7",
+    ))
+    _drain(store)
+
+    # The peek scans the most-recent N active sessions; the child wins
+    # the "latest" ordering on its own merits. That's expected — the
+    # gauge picks the latest conversation, period. What we're guarding
+    # against is collapsing parent + child into a single per-session
+    # walk that returns one merged blob: each session's input_tokens
+    # must remain attributed to its OWN session_id.
+    peek = store.query_context_window_peek(scan_sessions=10)
+    assert peek["input_tokens"] in (12345, 99999), (
+        f"peek must return one session's own input_tokens, not a sum; "
+        f"got {peek['input_tokens']!r}"
+    )
+    # Whichever session wins, its OWN session_id must come back — not a
+    # collapsed "parent" sid for a value that came from the child.
+    if peek["input_tokens"] == 12345:
+        assert peek["session_id"] == parent_sid
+    else:
+        assert peek["session_id"] == child_sid, (
+            f"peek must attribute the 99999 reading to the child's sid; "
+            f"got session_id={peek['session_id']!r}"
+        )


### PR DESCRIPTION
## Summary

PR #1611 added `LocalStore.query_events_with_subagents` to fix `_try_local_store_session_tools`. Eng SS's audit surfaced **8 sibling per-session read paths** with the same `parent_sid` blindness — a parent that delegated work to a Task-tool sub-agent rendered `tool_calls=0` / `cost=0` / empty transcripts on those reads, even though the events sat right next to it in DuckDB under the child's own `session_id`. This PR drains the class bug in one go.

## What changed

### 6 sites now use sub-agent rollup

Each call swaps to a `..._with_subagents` helper that UNIONs the parent's rows with every child sub-agent session's rows (matched on `subagents.parent_session_id`) and tags child rows with `_via_subagent_id`. All keep the staged-rollout fallback from PR #1611 (parent-only query if the daemon predates the helper).

| # | Site | Endpoint |
|---|------|----------|
| 1 | `routes/sessions.py:_try_local_store_transcript_events` | `/api/transcript-events/<id>` |
| 2 | `routes/sessions.py:_try_local_store_session_export` | `/api/sessions/<id>/export` |
| 3 | `routes/sessions.py:_try_local_store_session_cost_breakdown` | `/api/sessions/<id>/cost-breakdown` |
| 4 | `routes/sessions.py:_try_local_store_cost_split` (wanted_sid branch) | `/api/cost-split?session_id=<id>` |
| 5 | `routes/sessions.py:_try_local_store_session_model_journey` | `/api/session-model-journey/<id>` |
| 6 | `routes/crons.py:_try_local_store_cron_run_log` | `/api/cron-run-log` |

### 2 sister helpers added (sites 4 + 5)

`query_events_with_subagents` isn't a fit when the route reads a pre-aggregated per-session shape. Two new helpers in `clawmetry/local_store.py` follow the same UNION pattern:

- `query_cost_split_with_subagents` — parent row first, then one row per child session tagged with `_via_subagent_id`.
- `query_session_model_journey_with_subagents` — chronological event stream merging parent + children.

Both allowlisted in `routes/local_query.py::_DAEMON_METHODS`.

### 2 sites STAY per-session-only (documented inline)

| Site | Why no rollup |
|------|---------------|
| `routes/brain.py:_fetch_session_chain` | Feeds `/api/llm-call-timeline`, which walks back from an anchor for the nearest preceding `prompt.submitted` in the SAME LLM call. Rolling parent + child would mix two unrelated call chains. The Brain feed already passes the row's OWN `session_id` (child or parent) when the user clicks a chip, so child timelines work end-to-end without rollup. |
| `clawmetry/local_store.py:query_context_window_peek` | Measures the LIVE prompt context for one conversation. A child sub-agent has its own context window; collapsing parent + child would surface the child's most-recent context as the parent's — exactly what the "approaching context limit" banner must NOT do. |

Both have explicit `Issue #1597 class drain — intentionally NOT using …` comments so a future drain doesn't re-flag them.

## Test plan

- [x] `python3 -m pytest tests/test_class_bug_parent_sid_drain.py` — 10/10 pass (8 per-site scenarios + 2 cross-cutting guards: child view never bleeds parent, orphan session never leaks into unrelated parent).
- [x] `python3 -m pytest tests/test_subagent_attribution_v3.py` — 4/4 pass (PR #1611's existing guard suite stays green).
- [x] `python3 -m pytest tests/test_moat_bug_class_v3_event_shape_gate.py` — 3/3 pass (no v3-shape silent-zero filter regressed).
- [x] `python3 -m pytest tests/test_session_tools_local_store_v3.py tests/test_subagents_local_store_v3.py` — 5/5 pass.
- [x] `python3 -c "import dashboard"` — clean.
- [x] `python3 -m py_compile clawmetry/local_store.py routes/{sessions,crons,brain,local_query}.py tests/test_class_bug_parent_sid_drain.py` — clean.

## LOC budget

- Production: 195 net LOC (cap 250).
- Tests: 625 LOC / 523 non-comment (cap 400 — over because each site needs a full v3-shape fixture; explicit fixtures aid future regression debugging).

## Notes

- **Do NOT merge** per the brief — class-drain PR for review only.
- Staged-rollout safe: every fixed site falls back to the parent-only query when the daemon hasn't allowlisted the new helper yet (matches PR #1611's pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)