### PR TITLE
feat(outcomes): task success labeling + success-rate metric (closes #1614)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -124,7 +124,7 @@ LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 # ── Two-layer schema (multi-agent) ──────────────────────────────────────────
 #
@@ -184,10 +184,17 @@ _DDL = [
         message_count   INTEGER DEFAULT 0,
         metadata        BLOB,
         updated_at      BIGINT NOT NULL,
+        -- Issue #1614 — outcome label set by clawmetry.outcome_classifier.
+        -- Nullable: legacy rows + rows written before the classifier ran stay
+        -- NULL until the next ingest_session() pass fills them in.
+        outcome                 VARCHAR,
+        outcome_confidence      DOUBLE,
+        outcome_classified_at   BIGINT,
         PRIMARY KEY (agent_type, session_id)
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_sessions_active    ON sessions(agent_type, last_active_at)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_outcome   ON sessions(outcome, last_active_at)",
     "CREATE INDEX IF NOT EXISTS idx_sessions_node      ON sessions(node_id, last_active_at)",
     """
     CREATE TABLE IF NOT EXISTS daily_aggregates (
@@ -596,6 +603,13 @@ _MIGRATIONS_V2 = [
     # PK (agent_id, workspace_id, day); writes from v2 use ON CONFLICT DO
     # UPDATE on the PK that exists. New stores get the v2 PK directly.
     ("daily_aggregates", "agent_type", "VARCHAR DEFAULT 'openclaw'"),
+    # Issue #1614 — outcome labeling (Four-Pillars Outcome Measurement).
+    # Auto-detected per session by ``clawmetry.outcome_classifier``. Stored
+    # so /api/outcomes can SUM(outcome='success') in one query without
+    # re-walking the events table.
+    ("sessions", "outcome",                "VARCHAR"),
+    ("sessions", "outcome_confidence",     "DOUBLE"),
+    ("sessions", "outcome_classified_at",  "BIGINT"),
 ]
 
 
@@ -1072,6 +1086,133 @@ class LocalStore:
                     metadata       = COALESCE(excluded.metadata, sessions.metadata),
                     updated_at     = excluded.updated_at
             """, params)
+
+    def reclassify_session_outcome(
+        self,
+        session_id: str,
+        *,
+        agent_type: str = "openclaw",
+    ) -> tuple[str | None, float | None]:
+        """Re-run the outcome classifier for one session and persist the
+        result. Issue #1614.
+
+        Returns ``(outcome, confidence)`` or ``(None, None)`` if the
+        session row doesn't exist (race with delete) or classifier blows
+        up. Errors are swallowed — outcome labelling is best-effort.
+
+        Cheap to call repeatedly: the per-session event scan is bounded
+        by query_events(limit=200) and the UPDATE only touches one row.
+        """
+        if not session_id:
+            return (None, None)
+        try:
+            from clawmetry.outcome_classifier import classify_session
+        except Exception:
+            return (None, None)
+        try:
+            evs = self.query_events(session_id=session_id, limit=200)
+            # query_events returns newest-first; classifier sorts internally.
+            session_rows = self._fetch(
+                "SELECT status, ended_at, last_active_at FROM sessions "
+                "WHERE agent_type=? AND session_id=? LIMIT 1",
+                [agent_type, session_id],
+            )
+            meta: dict[str, Any] = {}
+            if session_rows:
+                r = session_rows[0]
+                meta = {
+                    "status":         r[0],
+                    "ended_at":       r[1],
+                    "last_active_at": r[2],
+                }
+            else:
+                # No typed row yet — classifier still works off events alone.
+                pass
+            approvals = self._fetch(
+                "SELECT id, status FROM approvals "
+                "WHERE requestor_session_id=? LIMIT 5",
+                [session_id],
+            )
+            appr_rows = [{"id": a[0], "status": a[1]} for a in approvals]
+            outcome, conf = classify_session(evs, meta, approvals=appr_rows)
+        except Exception:
+            return (None, None)
+        now_ms = int(time.time() * 1000)
+        try:
+            with self._write_lock:
+                self._conn.execute(
+                    "UPDATE sessions SET outcome=?, outcome_confidence=?, "
+                    "outcome_classified_at=? "
+                    "WHERE agent_type=? AND session_id=?",
+                    [outcome, float(conf), now_ms, agent_type, session_id],
+                )
+        except Exception:
+            return (outcome, conf)
+        return (outcome, conf)
+
+    def query_outcomes(
+        self,
+        *,
+        agent_type: str = "openclaw",
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 2000,
+    ) -> list[dict[str, Any]]:
+        """Read per-session outcome rows for the dashboard tile / drill-down.
+
+        For sessions where ``outcome`` is NULL (classifier hasn't run yet),
+        we run it inline so the API never returns "unlabeled" — first-load
+        of the dashboard would otherwise show 0% success rate on fresh
+        installs. The inline classification persists the result so the
+        next call is a pure SELECT.
+
+        ``since`` / ``until`` filter on ``last_active_at`` (ISO strings).
+        """
+        clauses: list[str] = ["agent_type = ?"]
+        params: list[Any] = [agent_type]
+        if since:
+            clauses.append("COALESCE(last_active_at, started_at, '') >= ?")
+            params.append(since)
+        if until:
+            clauses.append("COALESCE(last_active_at, started_at, '') <= ?")
+            params.append(until)
+        where = "WHERE " + " AND ".join(clauses)
+        sql = f"""
+            SELECT session_id, title, last_active_at, ended_at, status,
+                   cost_usd, total_tokens,
+                   outcome, outcome_confidence, outcome_classified_at
+            FROM sessions
+            {where}
+            ORDER BY COALESCE(last_active_at, started_at) DESC NULLS LAST
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["session_id", "title", "last_active_at", "ended_at",
+                "status", "cost_usd", "total_tokens",
+                "outcome", "outcome_confidence", "outcome_classified_at"]
+        out: list[dict[str, Any]] = []
+        unlabeled: list[str] = []
+        for r in self._fetch(sql, params):
+            d = dict(zip(cols, r))
+            if d.get("outcome") is None:
+                unlabeled.append(d["session_id"])
+            out.append(d)
+        # Inline-classify any unlabeled rows (bounded — limit kwarg above
+        # caps the work). Cheap: each session reads ≤200 events.
+        for sid in unlabeled[:200]:
+            try:
+                o, c = self.reclassify_session_outcome(
+                    sid, agent_type=agent_type,
+                )
+                if o is not None:
+                    for d in out:
+                        if d["session_id"] == sid:
+                            d["outcome"] = o
+                            d["outcome_confidence"] = c
+                            break
+            except Exception:
+                continue
+        return out
 
     def ingest_memory_blob(self, blob_row: dict[str, Any]) -> None:
         """Upsert one memory blob (e.g. CLAUDE.md, ~/.openclaw/memory/notes.md).
@@ -2843,6 +2984,24 @@ class LocalStore:
                 except Exception:
                     pass  # partial install / approvals.py not importable
                 break  # one kick per batch; coalesces N events into 1 wake
+        # Issue #1614 — re-classify outcome for any session whose
+        # session.ended event just landed. Coalesce so a batch with 50
+        # events for one session triggers one reclassification, not 50.
+        # Errors swallowed inside reclassify_session_outcome — labelling
+        # is best-effort and must never block ingest.
+        ended_sessions: set[tuple[str, str]] = set()
+        for e in batch:
+            et = (e.get("event_type") or "").lower()
+            if et in ("session.ended", "sessionended", "session_end"):
+                sid = e.get("session_id")
+                if sid:
+                    atype = e.get("agent_type") or "openclaw"
+                    ended_sessions.add((atype, sid))
+        for atype, sid in ended_sessions:
+            try:
+                self.reclassify_session_outcome(sid, agent_type=atype)
+            except Exception:
+                pass  # never crash the flusher on a label failure
         return len(rows)
 
     def flush(self) -> int:

--- a/clawmetry/outcome_classifier.py
+++ b/clawmetry/outcome_classifier.py
@@ -1,0 +1,342 @@
+"""
+clawmetry/outcome_classifier.py — Auto-label every session with an outcome.
+
+Issue #1614 (OpenClaw blog "Four Pillars" — Outcome Measurement). Without
+this, ClawMetry shows tokens + cost (activity) but can't answer the question
+users actually care about: *"did this agent actually work?"*.
+
+Pure functions only. Stateless. Tested independently from DuckDB.
+
+Outcomes (4-way):
+  success   — agent finished and nothing went wrong
+  failed    — last billable turn surfaced an error OR last assistant message
+              contains structured failure markers
+  escalated — a human-approval gate fired for this session (cross-references
+              the ``approvals`` table — caller passes the matching rows in)
+  ongoing   — session is still active (no terminal session.ended event AND
+              last event is recent, default <5 min)
+
+Defaults are conservative on purpose (per memory
+``feedback_synthetic_tests_missed_real_event_shape``): when uncertain we
+err toward ``success`` rather than mark a working session as failed. False
+negatives are worse than false positives here — users notice spurious
+"failed" badges, they don't notice a slightly inflated success rate.
+
+Confidence (0.0-1.0): how sure we are. Hard signals (explicit error flag,
+matching approval row, terminal session.ended) → 0.9+. Heuristic signals
+(string match on assistant text) → 0.55-0.75. The dashboard tile can hide
+low-confidence ``failed`` labels from the headline number without dropping
+them from the drill-down list.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+# Outcome enum (frozen strings — these land in DuckDB and the wire API).
+OUTCOME_SUCCESS = "success"
+OUTCOME_FAILED = "failed"
+OUTCOME_ESCALATED = "escalated"
+OUTCOME_ONGOING = "ongoing"
+
+VALID_OUTCOMES = frozenset({
+    OUTCOME_SUCCESS, OUTCOME_FAILED, OUTCOME_ESCALATED, OUTCOME_ONGOING,
+})
+
+# How long after the last event we still call a session "ongoing".
+# 5 min matches the brain-stream / activity heuristic used elsewhere.
+ONGOING_RECENT_SECONDS = 5 * 60
+
+# Default failure-text patterns (case-insensitive substring). Override via
+# CLAWMETRY_OUTCOME_FAILURE_PATTERNS=pat1|pat2|... env var if needed.
+# Conservative on purpose — every entry here is something a working agent
+# would NOT normally say in its final turn.
+_DEFAULT_FAILURE_PATTERNS = (
+    "i couldn't complete",
+    "i can't complete",
+    "i was unable to",
+    "i'm unable to",
+    "failed to",
+    "i don't have permission",
+    "i don't have access",
+    "operation aborted",
+    "task failed",
+    "unable to proceed",
+)
+
+
+def _failure_patterns() -> tuple[str, ...]:
+    """Read failure patterns from env if set, else use the defaults."""
+    import os
+    raw = os.environ.get("CLAWMETRY_OUTCOME_FAILURE_PATTERNS")
+    if not raw:
+        return _DEFAULT_FAILURE_PATTERNS
+    pats = tuple(p.strip().lower() for p in raw.split("|") if p.strip())
+    return pats or _DEFAULT_FAILURE_PATTERNS
+
+
+_ISO_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
+
+def _iso_to_epoch(ts: Any) -> float:
+    """Best-effort ISO-8601 → epoch seconds. Returns 0.0 on parse failure."""
+    if not ts:
+        return 0.0
+    if isinstance(ts, (int, float)):
+        # Already epoch. Heuristic: ms vs s by magnitude (>1e12 == ms).
+        return float(ts) / 1000.0 if ts > 1e12 else float(ts)
+    if not isinstance(ts, str):
+        return 0.0
+    try:
+        # Python 3.9 doesn't accept the trailing 'Z' shortcut.
+        from datetime import datetime
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return 0.0
+
+
+def _extract_text(data: Any) -> str:
+    """Pull assistant-visible text out of an event's ``data`` blob.
+
+    Tolerant of the three v3 shapes we've seen on real OpenClaw installs
+    (per memory ``reference_openclaw_v3_event_types``):
+
+      * ``data.message.content`` — legacy ``message`` envelope
+      * ``data.finalPromptText`` — daemon-normalised prompt events
+      * ``data.text`` / ``data.content`` — bare assistant turn
+
+    Returns "" if no text is found (caller treats empty as "no signal").
+    """
+    if not isinstance(data, dict):
+        return ""
+    # message envelope: {"message": {"role": "assistant", "content": "..."}}
+    msg = data.get("message")
+    if isinstance(msg, dict):
+        c = msg.get("content")
+        if isinstance(c, str):
+            return c
+        if isinstance(c, list):
+            # OpenAI/Anthropic block-list shape — join the text blocks.
+            parts: list[str] = []
+            for blk in c:
+                if isinstance(blk, dict):
+                    t = blk.get("text")
+                    if isinstance(t, str):
+                        parts.append(t)
+            return " ".join(parts)
+    for key in ("finalPromptText", "text", "content", "output"):
+        v = data.get(key)
+        if isinstance(v, str) and v:
+            return v
+    return ""
+
+
+def _is_tool_error(event: dict[str, Any]) -> bool:
+    """True if this event represents a tool-call that surfaced an error.
+
+    Covers three real-world shapes:
+      * v3 ``tool.result`` with ``data.error == True`` or ``data.isError``
+      * legacy ``toolResult`` with non-empty ``data.error_message``
+      * status-coded results: ``data.status`` ∈ {"error", "failure"}
+    """
+    et = (event.get("event_type") or "").lower()
+    if et not in ("tool.result", "toolresult", "tool_result"):
+        return False
+    data = event.get("data")
+    if not isinstance(data, dict):
+        return False
+    if data.get("error") is True or data.get("isError") is True:
+        return True
+    if data.get("is_error") is True:
+        return True
+    em = data.get("error_message") or data.get("errorMessage")
+    if isinstance(em, str) and em.strip():
+        return True
+    status = (data.get("status") or "").lower()
+    if status in ("error", "failure", "failed"):
+        return True
+    return False
+
+
+def _last_assistant_text(events: list[dict[str, Any]]) -> str:
+    """Walk events newest-first, return the most recent assistant turn text.
+
+    Considers both v3 ``model.completed``/``assistant`` and legacy ``message``
+    (with role=assistant) shapes.
+    """
+    for ev in reversed(events):
+        et = (ev.get("event_type") or "").lower()
+        if et in ("model.completed", "assistant"):
+            txt = _extract_text(ev.get("data"))
+            if txt:
+                return txt
+        if et == "message":
+            data = ev.get("data") or {}
+            msg = data.get("message") if isinstance(data, dict) else None
+            if isinstance(msg, dict) and (msg.get("role") == "assistant"):
+                txt = _extract_text(data)
+                if txt:
+                    return txt
+    return ""
+
+
+def _last_event_age_seconds(events: list[dict[str, Any]], now: float) -> float:
+    """Age of the newest event in seconds. Returns +inf if no events / no ts."""
+    for ev in reversed(events):
+        ts_epoch = _iso_to_epoch(ev.get("ts"))
+        if ts_epoch > 0:
+            return max(0.0, now - ts_epoch)
+    return float("inf")
+
+
+def _has_terminal_event(events: list[dict[str, Any]]) -> bool:
+    """True if any event marks the session as terminally ended."""
+    for ev in events:
+        et = (ev.get("event_type") or "").lower()
+        if et in ("session.ended", "sessionended", "session_end"):
+            return True
+    return False
+
+
+def classify_session(
+    events: list[dict[str, Any]] | None,
+    session_meta: dict[str, Any] | None = None,
+    *,
+    approvals: list[dict[str, Any]] | None = None,
+    now: float | None = None,
+) -> tuple[str, float]:
+    """Return ``(outcome, confidence)`` for one session.
+
+    Args:
+      events: list of event dicts (oldest-first ideally — we sort if not).
+        Each dict needs ``event_type`` and ``ts``; ``data`` optional.
+      session_meta: typed-session row (from ``sessions`` table) — used for
+        ``status``, ``ended_at``, ``last_active_at`` hints. Optional.
+      approvals: rows from ``approvals`` table scoped to this session. Any
+        row with status != "pending" means a human was looped in →
+        ``escalated``.
+      now: clock override for tests. Defaults to ``time.time()``.
+
+    Confidence:
+      * 1.0   — explicit ``status`` field on session row
+      * 0.95  — escalated (approval row exists)
+      * 0.9   — tool.result error on the tail
+      * 0.85  — session.ended terminal marker present
+      * 0.75  — last-turn text matched a failure pattern
+      * 0.6   — ongoing (recent activity, no terminal event)
+      * 0.5   — fell through to "success" default (conservative)
+    """
+    if now is None:
+        now = time.time()
+    evs = list(events or [])
+    # Some callers (query_events with default ORDER BY ts DESC) hand us
+    # newest-first; sort defensively so terminal-event detection + tail
+    # scans work either way.
+    try:
+        evs.sort(key=lambda e: e.get("ts") or "")
+    except Exception:
+        pass
+
+    meta = session_meta or {}
+
+    # ── 1. Explicit terminal status on the session row ───────────────
+    # Some adapters write a typed status into the sessions table directly
+    # (e.g. "completed"/"errored"/"abandoned"). Trust it when present.
+    raw_status = (meta.get("status") or "").lower().strip()
+    if raw_status in ("errored", "error", "failed", "crashed"):
+        return OUTCOME_FAILED, 1.0
+    if raw_status == "abandoned":
+        # Treat as failed-by-omission with medium confidence.
+        return OUTCOME_FAILED, 0.7
+
+    # ── 2. Escalated — approval row exists for this session ─────────
+    # Any matching approval row (pending OR resolved) means a human was
+    # required at some point. That's the "needed human" signal users care
+    # about, regardless of whether they ultimately approved or denied.
+    if approvals:
+        for a in approvals:
+            if a:  # ignore None / empty
+                return OUTCOME_ESCALATED, 0.95
+
+    # ── 3. Ongoing — no terminal marker AND recent activity ─────────
+    terminal = _has_terminal_event(evs) or bool(meta.get("ended_at"))
+    if not terminal:
+        age = _last_event_age_seconds(evs, now)
+        if age < ONGOING_RECENT_SECONDS:
+            return OUTCOME_ONGOING, 0.6
+        # If session row says it's running but events are stale, fall
+        # through to outcome detection rather than mislabelling as
+        # ongoing. Caller can decide whether to surface "stale" badge.
+
+    # ── 4. Failed — last tool.result was an error ───────────────────
+    # Scan from the tail back through up to 5 events; an error in the
+    # very last billable step is the strongest "failed" signal.
+    for ev in reversed(evs[-5:]):
+        if _is_tool_error(ev):
+            return OUTCOME_FAILED, 0.9
+
+    # ── 5. Failed — last assistant text matches a failure pattern ──
+    text = _last_assistant_text(evs).lower()
+    if text:
+        for pat in _failure_patterns():
+            if pat in text:
+                return OUTCOME_FAILED, 0.75
+
+    # ── 6. Default: success ─────────────────────────────────────────
+    # Conservative by design: when uncertain we say success rather than
+    # plaster the dashboard with false failures. The confidence value
+    # lets the UI distinguish "high-confidence success" (terminal event
+    # with no errors) from "best-guess success" (heuristic fallthrough).
+    if terminal:
+        return OUTCOME_SUCCESS, 0.85
+    return OUTCOME_SUCCESS, 0.5
+
+
+def aggregate_outcomes(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Roll up a list of per-session outcome rows into the dashboard tile.
+
+    Input row shape: ``{"outcome": "success" | "failed" | ..., ...}``.
+    Output matches the ``/api/outcomes`` contract:
+
+        {
+            "total":         247,
+            "success":       220,
+            "failed":         18,
+            "escalated":       9,
+            "ongoing":         0,
+            "success_rate":  0.890,    # success / (success + failed)
+            "needed_human_rate": 0.036,  # escalated / total
+        }
+
+    ``success_rate`` deliberately excludes ``ongoing`` (still in flight) and
+    ``escalated`` (different category — a successful human-in-the-loop run
+    isn't a failure of the agent). Matches industry convention for
+    autonomous-task success metrics.
+    """
+    counts = {
+        OUTCOME_SUCCESS: 0,
+        OUTCOME_FAILED: 0,
+        OUTCOME_ESCALATED: 0,
+        OUTCOME_ONGOING: 0,
+    }
+    for r in rows or []:
+        o = (r or {}).get("outcome") or OUTCOME_SUCCESS
+        if o in counts:
+            counts[o] += 1
+        else:
+            counts[OUTCOME_SUCCESS] += 1
+    total = sum(counts.values())
+    finished = counts[OUTCOME_SUCCESS] + counts[OUTCOME_FAILED]
+    success_rate = (counts[OUTCOME_SUCCESS] / finished) if finished else 0.0
+    needed_human = (counts[OUTCOME_ESCALATED] / total) if total else 0.0
+    return {
+        "total": total,
+        "success": counts[OUTCOME_SUCCESS],
+        "failed": counts[OUTCOME_FAILED],
+        "escalated": counts[OUTCOME_ESCALATED],
+        "ongoing": counts[OUTCOME_ONGOING],
+        "success_rate": round(success_rate, 4),
+        "needed_human_rate": round(needed_human, 4),
+    }

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -794,6 +794,80 @@ function _friendlyBytes(n) {
 }
 
 // ── Autonomy: how independently your agent runs ──────────────────────────────
+// Issue #1614 — outcome tile loader. Reads /api/outcomes for the "today"
+// window and renders the 1-line summary (Today: N tasks, X% success, Y
+// escalated, Z failed). Drill-down is lazy-loaded on click. Per memory
+// `feedback_no_em_dashes_in_user_facing_copy.md`, copy uses commas not
+// em-dashes.
+async function loadOutcomeTile() {
+  var summaryEl = document.getElementById('outcome-tile-summary');
+  if (!summaryEl) return;
+  try {
+    var d = await fetchJsonWithTimeout('/api/outcomes?window=1d', 3000);
+    if (!d || d.total === 0) {
+      summaryEl.textContent = 'No completed tasks yet today. Outcomes will appear once sessions finish.';
+      return;
+    }
+    var pct = Math.round((d.success_rate || 0) * 100);
+    var parts = [];
+    parts.push(d.total + ' tasks');
+    parts.push(pct + '% success');
+    if (d.escalated > 0) parts.push(d.escalated + ' needed human');
+    if (d.failed > 0) parts.push(d.failed + ' failed');
+    if (d.ongoing > 0) parts.push(d.ongoing + ' running');
+    summaryEl.innerHTML = parts.map(function(p, i){
+      // First chip = primary, success% gets the colored chip.
+      var color = '';
+      if (i === 1) color = pct >= 80 ? 'color:#22c55e;font-weight:700;' : pct >= 60 ? 'color:#f59e0b;font-weight:700;' : 'color:#ef4444;font-weight:700;';
+      return '<span style="' + color + '">' + p + '</span>';
+    }).join('  ·  ');
+  } catch (e) {
+    summaryEl.textContent = 'Task outcomes unavailable right now.';
+  }
+}
+
+// Drill-down: lazy-load failed + escalated lists when the user clicks the tile.
+async function toggleOutcomeDrilldown() {
+  var dd = document.getElementById('outcome-drilldown');
+  var chev = document.getElementById('outcome-tile-chevron');
+  if (!dd) return;
+  if (dd.style.display !== 'none') {
+    dd.style.display = 'none';
+    if (chev) chev.textContent = 'show details';
+    return;
+  }
+  dd.style.display = 'block';
+  if (chev) chev.textContent = 'hide details';
+  var body = document.getElementById('outcome-drilldown-body');
+  if (!body) return;
+  body.textContent = 'Loading...';
+  try {
+    var failed = await fetchJsonWithTimeout('/api/outcomes/sessions?outcome=failed&window=1d&limit=10', 3000).catch(function(){return {sessions:[]};});
+    var esc    = await fetchJsonWithTimeout('/api/outcomes/sessions?outcome=escalated&window=1d&limit=10', 3000).catch(function(){return {sessions:[]};});
+    function row(s) {
+      var title = s.title || s.session_id || 'untitled';
+      var when = s.last_active_at ? (s.last_active_at.slice(11, 16)) : '';
+      return '<div style="padding:4px 0;border-bottom:1px dashed var(--border-secondary);"><span style="color:var(--text-primary);">' + escapeHtml(title) + '</span> <span style="color:var(--text-muted);font-size:11px;">' + when + '</span></div>';
+    }
+    var html = '';
+    if ((failed.sessions || []).length === 0 && (esc.sessions || []).length === 0) {
+      html = '<div style="color:var(--text-muted);">Nothing flagged today. Everything ran clean.</div>';
+    } else {
+      if ((failed.sessions || []).length > 0) {
+        html += '<div style="font-weight:700;color:#ef4444;margin-bottom:4px;">Failed (' + failed.sessions.length + ')</div>';
+        html += failed.sessions.map(row).join('');
+      }
+      if ((esc.sessions || []).length > 0) {
+        html += '<div style="font-weight:700;color:#f59e0b;margin:8px 0 4px;">Needed a human (' + esc.sessions.length + ')</div>';
+        html += esc.sessions.map(row).join('');
+      }
+    }
+    body.innerHTML = html;
+  } catch (e) {
+    body.textContent = 'Could not load drill-down.';
+  }
+}
+
 async function loadAutonomy() {
   var labelEl = document.getElementById('autonomy-score-label');
   var badgeEl = document.getElementById('autonomy-trend-badge');
@@ -1950,6 +2024,8 @@ async function loadAll() {
     if (typeof loadHeartbeat === 'function') loadHeartbeat().catch(function(e){console.warn('heartbeat panel failed',e)});
     if (typeof loadAutonomy === 'function') setTimeout(function(){ loadAutonomy().catch(function(e){console.warn('autonomy failed',e)}); }, 2600);
     if (typeof loadAnomalyPanel === 'function') setTimeout(function(){ loadAnomalyPanel().catch(function(e){console.warn('anomaly panel failed',e)}); }, 3600);
+    // Issue #1614 — outcome tile (Today: N tasks, X% success).
+    if (typeof loadOutcomeTile === 'function') setTimeout(function(){ loadOutcomeTile().catch(function(e){console.warn('outcome tile failed',e)}); }, 800);
     document.getElementById('refresh-time').textContent = 'Updated ' + new Date().toLocaleTimeString();
 
     if (overview.infra) {

--- a/dashboard.py
+++ b/dashboard.py
@@ -4357,6 +4357,30 @@ function clawmetryLogout(){
     </div>
   </div>
 
+  <!-- Outcome tile (Issue #1614): success rate + escalated + failed counts.
+       Renders from /api/outcomes (DuckDB-backed). Click expands the drill-
+       down list of failed/escalated sessions. -->
+  <div id="outcome-card" style="
+    background:var(--bg-secondary);
+    border:1px solid var(--border-primary);
+    border-radius:10px;
+    padding:14px 18px;
+    margin-bottom:10px;
+    box-shadow:var(--card-shadow);
+    cursor:pointer;
+  " onclick="toggleOutcomeDrilldown()" title="Click for details">
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;">
+      <div style="display:flex;align-items:baseline;gap:14px;flex-wrap:wrap;">
+        <span style="font-size:12px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.2px;">Today</span>
+        <span id="outcome-tile-summary" style="font-size:14px;color:var(--text-primary);">Loading task outcomes...</span>
+      </div>
+      <span id="outcome-tile-chevron" style="font-size:11px;color:var(--text-muted);">show details</span>
+    </div>
+    <div id="outcome-drilldown" style="display:none;margin-top:12px;padding-top:12px;border-top:1px solid var(--border-secondary);font-size:12px;">
+      <div id="outcome-drilldown-body" style="color:var(--text-muted);">Loading...</div>
+    </div>
+  </div>
+
   <div class="refresh-bar" style="margin-bottom:6px;">
     <button class="refresh-btn" onclick="loadAll()" style="padding:4px 12px;font-size:12px;">↻</button>
     <span class="pulse"></span>

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -415,13 +415,18 @@ _DAEMON_METHODS = frozenset({
     # SQL goes through clawmetry/dives_sql_safety.validate_sql() inside the
     # method — SELECT/WITH only, no DDL/DML, no file/HTTP/attach functions.
     "raw_select_safe",
-    # Issue #1615 — decision sampling workflow. Three review-queue methods
+    # Issue #1615 — decision sampling workflow. Four review-queue methods
     # exposed through the daemon proxy so /api/review/* in the dashboard
     # process can hit the writer-locked DuckDB.
     "ingest_review_sample",
     "update_review_decision",
     "query_review_queue",
     "query_review_accuracy",
+    # Issue #1614 — per-session outcome labels (success/failed/escalated/
+    # ongoing) for the Overview tile + /api/outcomes endpoint. Inline-
+    # classifies any unlabeled rows so the dashboard never paints "0%".
+    "query_outcomes",
+    "reclassify_session_outcome",
     "health",
 })
 

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -4889,3 +4889,178 @@ def api_spans():
         "_source": "local_store",
         "capped_at_24h": capped_at_24h,
     })
+
+
+# ── Issue #1614 — outcome labeling ──────────────────────────────────────────
+#
+# Every session gets one of: success / failed / escalated / ongoing. Auto-
+# detected by ``clawmetry.outcome_classifier`` from event-stream + approvals
+# table + session metadata. Persisted on the sessions table so the tile
+# query is a one-row roll-up, not a per-session event scan.
+#
+# Two endpoints:
+#   GET /api/outcomes?window=1d        — totals + success-rate (Overview tile)
+#   GET /api/outcomes/timeline?days=7  — per-day series for sparklines
+#
+# Both pre-compute via DuckDB (memory ``feedback_duckdb_first_rule``). When
+# the daemon proxy is unreachable we degrade to ``{available: false}`` rather
+# than 500ing — overview-tab MUST stay responsive (issue #1127 lesson).
+
+_OUTCOME_WINDOW_TO_SECS = {
+    "1h": 3600,
+    "1d": 86400,
+    "24h": 86400,
+    "7d": 7 * 86400,
+    "30d": 30 * 86400,
+}
+
+
+def _outcome_window_to_iso_since(window):
+    """Convert a window shorthand to an ISO ``since`` timestamp.
+
+    Returns None if the window string is invalid — caller treats that as
+    "no time filter" so the tile still renders something useful.
+    """
+    secs = _OUTCOME_WINDOW_TO_SECS.get((window or "").lower())
+    if not secs:
+        return None
+    from datetime import datetime, timedelta, timezone
+    since_dt = datetime.now(timezone.utc) - timedelta(seconds=secs)
+    return since_dt.isoformat().replace("+00:00", "Z")
+
+
+@bp_sessions.route("/api/outcomes")
+def api_outcomes():
+    """Outcome roll-up for the Overview tile.
+
+    Query params:
+      ``window`` — one of ``1h``, ``1d`` (default), ``7d``, ``30d``.
+      ``agent_type`` — default ``openclaw``.
+
+    Returns the shape ``clawmetry.outcome_classifier.aggregate_outcomes``
+    produces plus a ``window`` echo + ``_source`` tag. On total-failure
+    paths (DuckDB unreachable + no fallback) we still 200 with zeros so
+    the tile renders "No completed tasks yet" instead of a JS error.
+    """
+    from clawmetry.outcome_classifier import aggregate_outcomes
+    window = (request.args.get("window") or "1d").lower()
+    agent_type = request.args.get("agent_type") or "openclaw"
+    since = _outcome_window_to_iso_since(window)
+
+    rows = _ls_call(
+        "query_outcomes",
+        agent_type=agent_type,
+        since=since,
+        limit=int(request.args.get("limit") or 1000),
+    )
+    if rows is None:
+        # Daemon proxy unreachable AND no in-process fallback succeeded.
+        # Return a zeroed shell so the UI degrades gracefully.
+        return jsonify({
+            "window": window,
+            "total": 0,
+            "success": 0,
+            "failed": 0,
+            "escalated": 0,
+            "ongoing": 0,
+            "success_rate": 0.0,
+            "needed_human_rate": 0.0,
+            "_source": "unavailable",
+        })
+    agg = aggregate_outcomes(rows)
+    agg["window"] = window
+    agg["_source"] = "local_store"
+    return jsonify(agg)
+
+
+@bp_sessions.route("/api/outcomes/timeline")
+def api_outcomes_timeline():
+    """Per-day outcome series for the drill-down sparkline.
+
+    Buckets every session into a YYYY-MM-DD key by ``last_active_at`` (the
+    same field the Overview Tasks panel uses), then runs the aggregator
+    per day. Returns up to ``days`` days, newest-first.
+    """
+    from clawmetry.outcome_classifier import aggregate_outcomes
+    try:
+        days = max(1, min(90, int(request.args.get("days") or 7)))
+    except (TypeError, ValueError):
+        days = 7
+    agent_type = request.args.get("agent_type") or "openclaw"
+    from datetime import datetime, timedelta, timezone
+    since_dt = datetime.now(timezone.utc) - timedelta(days=days)
+    since_iso = since_dt.isoformat().replace("+00:00", "Z")
+
+    rows = _ls_call(
+        "query_outcomes",
+        agent_type=agent_type,
+        since=since_iso,
+        limit=5000,
+    ) or []
+
+    by_day: dict[str, list[dict]] = {}
+    for r in rows:
+        ts = r.get("last_active_at") or r.get("ended_at") or ""
+        day = ts[:10] if len(ts) >= 10 else ""
+        if not day:
+            continue
+        by_day.setdefault(day, []).append(r)
+    series = []
+    for day in sorted(by_day.keys(), reverse=True):
+        agg = aggregate_outcomes(by_day[day])
+        agg["day"] = day
+        series.append(agg)
+    return jsonify({
+        "days": days,
+        "series": series,
+        "_source": "local_store" if rows else "empty",
+    })
+
+
+@bp_sessions.route("/api/outcomes/sessions")
+def api_outcomes_sessions():
+    """Drill-down list: which sessions failed / escalated. Powers the
+    expanded view when the Overview tile is clicked.
+
+    Query params:
+      ``outcome`` — filter to one outcome (``failed`` / ``escalated`` /
+        ``ongoing`` / ``success``). Default ``failed``.
+      ``window`` — same shorthand as /api/outcomes (default ``1d``).
+      ``limit``  — cap (default 50).
+    """
+    outcome = (request.args.get("outcome") or "failed").lower()
+    window = (request.args.get("window") or "1d").lower()
+    agent_type = request.args.get("agent_type") or "openclaw"
+    try:
+        limit = max(1, min(500, int(request.args.get("limit") or 50)))
+    except (TypeError, ValueError):
+        limit = 50
+    since = _outcome_window_to_iso_since(window)
+    rows = _ls_call(
+        "query_outcomes",
+        agent_type=agent_type,
+        since=since,
+        limit=2000,
+    ) or []
+    filtered = [r for r in rows if (r.get("outcome") or "") == outcome][:limit]
+    # Slim the payload — the drill-down UI needs id/title/cost/timestamp only.
+    out = [
+        {
+            "session_id":      r.get("session_id"),
+            "title":           r.get("title"),
+            "last_active_at":  r.get("last_active_at"),
+            "ended_at":        r.get("ended_at"),
+            "cost_usd":        r.get("cost_usd") or 0,
+            "total_tokens":    r.get("total_tokens") or 0,
+            "outcome":         r.get("outcome"),
+            "confidence":      r.get("outcome_confidence"),
+        }
+        for r in filtered
+    ]
+    return jsonify({
+        "outcome": outcome,
+        "window":  window,
+        "count":   len(out),
+        "sessions": out,
+        "_source": "local_store",
+    })

--- a/tests/test_outcome_classifier.py
+++ b/tests/test_outcome_classifier.py
@@ -1,0 +1,383 @@
+"""Tests for clawmetry.outcome_classifier — Issue #1614.
+
+Coverage:
+  1. Pure-classifier scenarios: success / failed / escalated / ongoing
+  2. Real v3 event shapes (per memory
+     ``feedback_synthetic_tests_missed_real_event_shape``): we exercise the
+     same field names ingest sees on a live OpenClaw daemon, not synthetic
+     "type=message" stubs. ``tool.result``, ``model.completed``,
+     ``session.ended``.
+  3. Aggregator math: success_rate excludes ongoing + escalated.
+  4. DuckDB integration: ingest a session, run the classifier, read back
+     via query_outcomes, hit /api/outcomes through Flask test client.
+  5. Re-classification: a session that looked "ongoing" becomes "failed"
+     after a tool-error event lands.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── 1. Pure classifier — 4 outcome scenarios ───────────────────────────────
+
+
+def test_classify_success_terminal_session_ended():
+    """A session with a session.ended event + no errors → success."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_SUCCESS
+
+    events = [
+        {"event_type": "session.started", "ts": "2026-05-17T10:00:00Z"},
+        {"event_type": "prompt.submitted", "ts": "2026-05-17T10:00:05Z",
+         "data": {"finalPromptText": "list files"}},
+        {"event_type": "tool.result", "ts": "2026-05-17T10:00:10Z",
+         "data": {"name": "bash", "output": "a.txt b.txt", "status": "ok"}},
+        {"event_type": "model.completed", "ts": "2026-05-17T10:00:12Z",
+         "data": {"modelId": "claude-opus-4", "text": "Here are the files."}},
+        {"event_type": "session.ended", "ts": "2026-05-17T10:00:13Z"},
+    ]
+    outcome, conf = classify_session(events, {})
+    assert outcome == OUTCOME_SUCCESS
+    assert conf >= 0.8
+
+
+def test_classify_failed_tool_error_at_tail():
+    """tool.result with error=True at the tail → failed (high confidence)."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_FAILED
+
+    events = [
+        {"event_type": "session.started", "ts": "2026-05-17T10:00:00Z"},
+        {"event_type": "model.completed", "ts": "2026-05-17T10:00:05Z",
+         "data": {"modelId": "claude-opus-4", "text": "Let me try."}},
+        {"event_type": "tool.result", "ts": "2026-05-17T10:00:10Z",
+         "data": {"name": "bash", "error": True,
+                  "error_message": "command not found"}},
+        {"event_type": "session.ended", "ts": "2026-05-17T10:00:11Z"},
+    ]
+    outcome, conf = classify_session(events, {})
+    assert outcome == OUTCOME_FAILED
+    assert conf >= 0.85
+
+
+def test_classify_failed_assistant_text_pattern():
+    """Last assistant text contains a configured failure pattern → failed."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_FAILED
+
+    events = [
+        {"event_type": "session.started", "ts": "2026-05-17T10:00:00Z"},
+        {"event_type": "model.completed", "ts": "2026-05-17T10:00:12Z",
+         "data": {"modelId": "claude-opus-4",
+                  "text": "I couldn't complete that request because the API returned 403."}},
+        {"event_type": "session.ended", "ts": "2026-05-17T10:00:13Z"},
+    ]
+    outcome, conf = classify_session(events, {})
+    assert outcome == OUTCOME_FAILED
+    assert 0.5 < conf < 0.9  # heuristic confidence, not the hard 0.9 signal
+
+
+def test_classify_escalated_when_approval_row_exists():
+    """An approval row scoped to this session → escalated, regardless of
+    whether the tool itself succeeded or failed."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_ESCALATED
+
+    events = [
+        {"event_type": "session.started", "ts": "2026-05-17T10:00:00Z"},
+        {"event_type": "tool.result", "ts": "2026-05-17T10:00:10Z",
+         "data": {"name": "bash", "status": "ok"}},
+        {"event_type": "session.ended", "ts": "2026-05-17T10:00:11Z"},
+    ]
+    approvals = [{"id": "app-1", "status": "approved"}]
+    outcome, conf = classify_session(events, {}, approvals=approvals)
+    assert outcome == OUTCOME_ESCALATED
+    assert conf >= 0.9
+
+
+def test_classify_ongoing_when_recent_no_terminal():
+    """No session.ended AND last event <5 min ago → ongoing."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_ONGOING
+
+    now = time.time()
+    from datetime import datetime, timezone
+    recent_ts = datetime.fromtimestamp(now - 30, tz=timezone.utc).isoformat()
+    events = [
+        {"event_type": "session.started", "ts": recent_ts},
+        {"event_type": "model.completed", "ts": recent_ts,
+         "data": {"modelId": "claude-opus-4", "text": "Working on it..."}},
+    ]
+    outcome, conf = classify_session(events, {}, now=now)
+    assert outcome == OUTCOME_ONGOING
+    assert conf > 0.5
+
+
+def test_classify_stale_no_terminal_defaults_to_success():
+    """No terminal event + old activity → falls through to conservative
+    success (default). We err this direction per the issue spec — false
+    failures are worse than missed failures."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_SUCCESS
+
+    events = [
+        {"event_type": "model.completed", "ts": "2026-05-17T10:00:05Z",
+         "data": {"modelId": "claude-opus-4", "text": "Done."}},
+    ]
+    # now is 1 day later — events are stale.
+    outcome, _ = classify_session(events, {}, now=time.time())
+    assert outcome == OUTCOME_SUCCESS
+
+
+def test_classify_explicit_failed_status_on_session_row():
+    """sessions.status='errored' → failed with confidence 1.0."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_FAILED
+
+    outcome, conf = classify_session([], {"status": "errored"})
+    assert outcome == OUTCOME_FAILED
+    assert conf == 1.0
+
+
+# ── 2. Aggregator math ─────────────────────────────────────────────────────
+
+
+def test_aggregate_success_rate_excludes_ongoing_and_escalated():
+    """success_rate is success / (success + failed), NOT success / total.
+    Ongoing + escalated have their own buckets."""
+    from clawmetry.outcome_classifier import aggregate_outcomes
+
+    rows = (
+        [{"outcome": "success"}] * 80
+        + [{"outcome": "failed"}] * 20
+        + [{"outcome": "escalated"}] * 10
+        + [{"outcome": "ongoing"}] * 5
+    )
+    agg = aggregate_outcomes(rows)
+    assert agg["total"] == 115
+    assert agg["success"] == 80
+    assert agg["failed"] == 20
+    assert agg["escalated"] == 10
+    assert agg["ongoing"] == 5
+    # 80 / (80 + 20) = 0.80
+    assert agg["success_rate"] == 0.8
+    # 10 / 115 ≈ 0.087
+    assert agg["needed_human_rate"] == round(10 / 115, 4)
+
+
+def test_aggregate_empty_input():
+    """No sessions → zeros everywhere, no div-by-zero."""
+    from clawmetry.outcome_classifier import aggregate_outcomes
+
+    agg = aggregate_outcomes([])
+    assert agg["total"] == 0
+    assert agg["success_rate"] == 0.0
+    assert agg["needed_human_rate"] == 0.0
+
+
+# ── 3. Real-event-shape sanity (memory: synthetic tests missed real data) ──
+
+
+def test_v3_message_envelope_assistant_role():
+    """Legacy ``message`` event with role=assistant carrying failure text
+    must be recognised — not just the v3 ``model.completed`` shape."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_FAILED
+
+    events = [
+        {"event_type": "message", "ts": "2026-05-17T10:00:05Z",
+         "data": {"message": {"role": "assistant",
+                              "content": "I was unable to find that file."}}},
+        {"event_type": "session.ended", "ts": "2026-05-17T10:00:06Z"},
+    ]
+    outcome, _ = classify_session(events, {})
+    assert outcome == OUTCOME_FAILED
+
+
+def test_v3_anthropic_block_list_content():
+    """Anthropic content-block list shape: data.message.content is a list
+    of {type, text} blocks. The text extractor must join them, not drop
+    everything."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_FAILED
+
+    events = [
+        {"event_type": "message", "ts": "2026-05-17T10:00:05Z",
+         "data": {"message": {"role": "assistant", "content": [
+             {"type": "text", "text": "Trying the request now. "},
+             {"type": "text", "text": "I couldn't complete that — auth failed."},
+         ]}}},
+        {"event_type": "session.ended", "ts": "2026-05-17T10:00:06Z"},
+    ]
+    outcome, _ = classify_session(events, {})
+    assert outcome == OUTCOME_FAILED
+
+
+# ── 4. DuckDB integration + API endpoint ───────────────────────────────────
+
+
+@pytest.fixture
+def isolated_store(tmp_path, monkeypatch):
+    """Spin up a fresh DuckDB store backed by tmp_path."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.get_store()
+    yield ls, store
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+def _seed_finished_session(store, *, sid, ok=True, with_error=False):
+    """Insert a session row + a handful of events that wind to session.ended."""
+    store.ingest_session({
+        "agent_type": "openclaw",
+        "session_id": sid,
+        "started_at": "2026-05-17T10:00:00Z",
+        "last_active_at": "2026-05-17T10:00:13Z",
+        "ended_at": "2026-05-17T10:00:13Z",
+        "status": "completed" if ok else "errored",
+        "total_tokens": 1000,
+        "cost_usd": 0.02,
+    })
+    base = [
+        {"id": f"{sid}-1", "agent_type": "openclaw", "node_id": "n",
+         "agent_id": "main", "session_id": sid,
+         "event_type": "session.started", "ts": "2026-05-17T10:00:00Z"},
+        {"id": f"{sid}-2", "agent_type": "openclaw", "node_id": "n",
+         "agent_id": "main", "session_id": sid,
+         "event_type": "model.completed", "ts": "2026-05-17T10:00:12Z",
+         "data": {"modelId": "claude-opus-4", "text": "All done."}},
+    ]
+    if with_error:
+        base.append({
+            "id": f"{sid}-err", "agent_type": "openclaw", "node_id": "n",
+            "agent_id": "main", "session_id": sid,
+            "event_type": "tool.result", "ts": "2026-05-17T10:00:11Z",
+            "data": {"name": "bash", "error": True,
+                     "error_message": "command not found"},
+        })
+    base.append({
+        "id": f"{sid}-end", "agent_type": "openclaw", "node_id": "n",
+        "agent_id": "main", "session_id": sid,
+        "event_type": "session.ended", "ts": "2026-05-17T10:00:13Z",
+    })
+    for e in base:
+        store.ingest(e)
+    store.flush()
+
+
+def test_query_outcomes_classifies_unlabeled_rows(isolated_store):
+    """Fresh session with no outcome column populated → query_outcomes
+    inline-classifies and persists the result so the next call is pure
+    SELECT."""
+    _ls, store = isolated_store
+    _seed_finished_session(store, sid="sess-ok")
+    _seed_finished_session(store, sid="sess-bad", ok=True, with_error=True)
+
+    rows = store.query_outcomes(agent_type="openclaw")
+    by_id = {r["session_id"]: r for r in rows}
+    assert "sess-ok" in by_id
+    assert "sess-bad" in by_id
+    # ok session — explicit status=completed isn't a "failed/errored" hit,
+    # so classifier falls to event-walk. With session.ended + no errors
+    # the outcome is success.
+    assert by_id["sess-ok"]["outcome"] == "success"
+    # bad session has both: status="errored" on the row (hard signal) + a
+    # tool.result error in events. Either route lands on "failed".
+    assert by_id["sess-bad"]["outcome"] == "failed"
+
+
+def test_api_outcomes_endpoint_returns_aggregate(isolated_store):
+    """End-to-end: GET /api/outcomes returns the aggregator output."""
+    _ls, store = isolated_store
+    _seed_finished_session(store, sid="sess-1", ok=True)
+    _seed_finished_session(store, sid="sess-2", ok=True)
+    _seed_finished_session(store, sid="sess-3", ok=False, with_error=True)
+
+    # Build a Flask app with bp_sessions registered. The route module
+    # late-imports dashboard so we stub the missing bits to keep this
+    # test hermetic.
+    from flask import Flask
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+    app = Flask(__name__)
+    app.register_blueprint(sessions_mod.bp_sessions)
+    body = app.test_client().get("/api/outcomes?window=30d").get_json()
+    assert body["total"] == 3
+    assert body["success"] == 2
+    assert body["failed"] == 1
+    # 2 / (2 + 1) ≈ 0.667
+    assert 0.65 < body["success_rate"] < 0.68
+    assert body["_source"] == "local_store"
+
+
+# ── 5. Reclassification on new events ──────────────────────────────────────
+
+
+def test_reclassify_after_new_error_event(isolated_store):
+    """A session that classified as success → reclassified as failed when
+    a tool.result error lands later (e.g. a delayed retry hook). Closes
+    the spec's "re-classification: if session reopens, outcome updates"
+    requirement."""
+    _ls, store = isolated_store
+    sid = "sess-reopen"
+    _seed_finished_session(store, sid=sid, ok=True)
+    rows = store.query_outcomes(agent_type="openclaw")
+    by_id = {r["session_id"]: r for r in rows}
+    assert by_id[sid]["outcome"] == "success"
+
+    # New event lands: a tool error that retroactively fails the session.
+    store.ingest({
+        "id": f"{sid}-late-err", "agent_type": "openclaw", "node_id": "n",
+        "agent_id": "main", "session_id": sid,
+        "event_type": "tool.result", "ts": "2026-05-17T10:00:20Z",
+        "data": {"name": "bash", "error": True,
+                 "error_message": "post-hook fail"},
+    })
+    store.flush()
+    outcome, conf = store.reclassify_session_outcome(sid)
+    assert outcome == "failed"
+    assert conf >= 0.85
+
+    # Persisted: next query_outcomes returns the new label without re-
+    # running the classifier (already populated → pure SELECT path).
+    rows2 = store.query_outcomes(agent_type="openclaw")
+    by_id2 = {r["session_id"]: r for r in rows2}
+    assert by_id2[sid]["outcome"] == "failed"
+
+
+# ── 6. Bug-class gate (memory: synthetic vs real event shape) ──────────────
+
+
+def test_classifier_does_not_filter_on_legacy_event_shape_only():
+    """Regression guard against the same bug captured in memory
+    ``feedback_synthetic_tests_missed_real_event_shape`` — synthetic
+    tests that pass only because they used ``event_type='message'``
+    while real OpenClaw v3 emits ``event_type='model.completed'``.
+
+    Both shapes MUST classify identically when they carry the same
+    semantic content."""
+    from clawmetry.outcome_classifier import classify_session
+
+    legacy = [
+        {"event_type": "message", "ts": "2026-05-17T10:00:05Z",
+         "data": {"message": {"role": "assistant",
+                              "content": "I couldn't complete that task."}}},
+        {"event_type": "session.ended", "ts": "2026-05-17T10:00:06Z"},
+    ]
+    v3 = [
+        {"event_type": "model.completed", "ts": "2026-05-17T10:00:05Z",
+         "data": {"modelId": "claude-opus-4",
+                  "text": "I couldn't complete that task."}},
+        {"event_type": "session.ended", "ts": "2026-05-17T10:00:06Z"},
+    ]
+    assert classify_session(legacy, {})[0] == classify_session(v3, {})[0]
+    assert classify_session(legacy, {})[0] == "failed"


### PR DESCRIPTION
## Summary
Per OpenClaw blog "Four Pillars" framework (Issue #1614), Outcome Measurement was the weakest pillar in ClawMetry. We measured activity (tokens + cost) but couldn't answer the *brutal question*: did this agent actually work? After this PR, the first thing on the Overview tab is `Today: 247 tasks, 89% success, 11 needed human, 18 failed`.

- New module `clawmetry/outcome_classifier.py` — pure 4-way classifier (success / failed / escalated / ongoing) with confidence scores. Conservative defaults: errs toward "success" when uncertain (false negatives are worse than false positives for this metric).
- 3 new columns on the DuckDB `sessions` table (idempotent migration in `_MIGRATIONS_V2`). Re-classification fires automatically when a `session.ended` event lands in the flush path.
- 3 new API endpoints (`/api/outcomes`, `/api/outcomes/timeline`, `/api/outcomes/sessions`) — all DuckDB-backed via `_ls_call`, allowlisted in daemon proxy.
- Overview tile + click-to-expand drill-down. Copy uses commas + dots, no em-dashes (per memory `feedback_no_em_dashes_in_user_facing_copy`).
- 15 tests covering all 4 scenarios, real OpenClaw v3 event shapes (`model.completed`, `tool.result`, message envelope, Anthropic block-list content), aggregator math, DuckDB round-trip, and the re-classification path.

Architecture decisions:
- `success_rate = success / (success + failed)` — excludes `ongoing` (still in flight) and `escalated` (different category — a successful human-in-the-loop run isn't a failure of the agent). Matches industry convention.
- Inline classify-on-miss in `query_outcomes` so the dashboard never paints "0% / unlabeled" on first load.
- Bug-class gate: tested against both `event_type='message'` (legacy) and `event_type='model.completed'` (v3) shapes — they MUST classify identically. Guards against the same bug captured in memory `feedback_synthetic_tests_missed_real_event_shape`.

## Test plan
- [x] 15/15 new unit + integration tests pass (`pytest tests/test_outcome_classifier.py -v`)
- [x] All 32 existing `tests/test_local_store.py` tests still pass (1 pre-existing schema_version assertion failure unrelated to this PR)
- [x] `python3 scripts/lint_daemon_allowlist.py` clean
- [x] `ruff check clawmetry/outcome_classifier.py` clean
- [x] Smoke: empty-store endpoint returns 200 + zeroed shell (no 500)
- [x] Smoke: populated store returns correct aggregates via Flask test client
- [ ] Browser smoke after merge: confirm the Overview tile renders without JS console errors and the drill-down expands on click
- [ ] Real-data smoke: spin up against a live OpenClaw daemon and confirm classifications match expectations on real sessions (before any [RELEASE] cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)