### PR TITLE
feat(evals): Phase 1 — local-first LLM-as-judge on completed sessions (refs #1619)

### DIFF
--- a/clawmetry/eval_runner.py
+++ b/clawmetry/eval_runner.py
@@ -1,0 +1,733 @@
+"""
+clawmetry/eval_runner.py — Local-first LLM-as-judge scoring of completed sessions.
+
+This is the MOAT-aligned eval surface (refs #1619 Phase 1 of 4): every
+competitor (LangSmith, Langfuse, Phoenix, Helicone) cloud-hosts their eval
+product — your prompts + responses leave the box for scoring. ClawMetry runs
+the judge LLM call on the user's existing API key, persists the score to the
+local DuckDB, and never roundtrips through ClawMetry cloud for scoring. The
+cloud only sees the pre-computed aggregate that arrives via the normal
+heartbeat-piggyback channel.
+
+Design constraints (see CLAUDE.md + PRD #1619):
+  * No new auth path — reuse the user's ANTHROPIC_API_KEY / OPENAI_API_KEY,
+    same envelope clawmetry/interceptor.py already monkey-patches.
+  * No cloud roundtrip for scoring — judge call goes provider-direct.
+  * Cost guard — skip <10-token sessions (trivial heartbeats) and cap at
+    100 sessions/hour (worst-case ~$2.40/day per user with Haiku).
+  * Default-on but disable-able via CLAWMETRY_EVALS_ENABLED=0.
+  * Configurable judge model + rubric in ~/.clawmetry/evals.yaml.
+  * Failure is best-effort — judge LLM down → eval_score stays NULL, log
+    a warning, scheduler tries again on the next pass. Never crashes the
+    daemon.
+
+Public API:
+    EvalRunner(rubric_name='default')
+        .score_session(session_id, *, dry_run=False) -> EvalResult | None
+    load_rubric(name='default') -> dict   # rubric YAML → dict (with defaults)
+    parse_score(text) -> (score, reason)  # exposed for testing
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("clawmetry.eval_runner")
+
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+
+# Disable the whole eval surface (env switch). Default-on per PRD; user
+# escape hatch for cost-sensitive or air-gapped setups.
+def is_enabled() -> bool:
+    """Env-gated kill switch. Default True (Phase 1 ships default-on)."""
+    return os.environ.get("CLAWMETRY_EVALS_ENABLED", "1") not in ("0", "false", "False", "")
+
+
+# Rate-limit knobs — bound worst-case spend even with a chatty workspace.
+# 100/hour × $0.001/Haiku call = ~$2.40/day ceiling, well inside the
+# PRD cost envelope. Overridable for ops tuning.
+RATE_LIMIT_PER_HOUR = int(os.environ.get("CLAWMETRY_EVALS_RATE_LIMIT", "100"))
+# Sessions below this token budget are trivial heartbeats / smoke pings;
+# scoring them wastes judge spend and skews the rubric average.
+MIN_TOKENS_FOR_SCORING = int(os.environ.get("CLAWMETRY_EVALS_MIN_TOKENS", "10"))
+# Judge HTTP timeout — Haiku is fast (<2s typical); cap at 30s so a slow
+# judge can't stall the whole scheduler tick.
+JUDGE_TIMEOUT_SECS = float(os.environ.get("CLAWMETRY_EVALS_JUDGE_TIMEOUT", "30"))
+
+# Rubric config path. Single file with one top-level dict per rubric name.
+RUBRIC_PATH = Path(
+    os.environ.get(
+        "CLAWMETRY_EVALS_RUBRIC_PATH",
+        os.path.expanduser("~/.clawmetry/evals.yaml"),
+    )
+)
+
+
+# Default rubric — used when ~/.clawmetry/evals.yaml is absent or doesn't
+# define the requested rubric. Codified inline so a fresh install scores
+# sessions out of the box without any user setup.
+DEFAULT_RUBRIC: dict[str, Any] = {
+    "judge_model": "claude-haiku-4-5",
+    "prompt": (
+        "You're evaluating an AI agent's response. Score 0-5:\n"
+        "  5: Fully addressed user's request, correct and complete\n"
+        "  4: Mostly correct, minor gaps\n"
+        "  3: Partial answer, missed key points\n"
+        "  2: Misunderstood the request\n"
+        "  1: Wrong or harmful answer\n"
+        "  0: Failed to respond\n"
+        "Output exactly two lines:\n"
+        "SCORE: <0-5>\n"
+        "REASON: <one short sentence>"
+    ),
+}
+
+
+# Default-rubric YAML written to disk on first save when no file exists.
+# Kept in sync with DEFAULT_RUBRIC above so what the user sees in the
+# editor matches what the runner uses out of the box.
+DEFAULT_RUBRIC_YAML = (
+    "# clawmetry evals rubric — edited via the dashboard or by hand.\n"
+    "# See clawmetry/eval_runner.py for the in-code default.\n"
+    "default:\n"
+    "  judge_model: claude-haiku-4-5\n"
+    "  prompt: |\n"
+    "    You're evaluating an AI agent's response. Score 0-5:\n"
+    "      5: Fully addressed user's request, correct and complete\n"
+    "      4: Mostly correct, minor gaps\n"
+    "      3: Partial answer, missed key points\n"
+    "      2: Misunderstood the request\n"
+    "      1: Wrong or harmful answer\n"
+    "      0: Failed to respond\n"
+    "    Output exactly two lines:\n"
+    "    SCORE: <0-5>\n"
+    "    REASON: <one short sentence>\n"
+)
+
+
+# Centralised event-type set so the bug-class gate (PRD: real v3 event
+# shapes) stays satisfied as new shapes appear. Mirrors the canonical
+# union-set pattern documented in clawmetry/local_store.py
+# (``_ASSISTANT_EVENT_TYPES``) — prompt + assistant turns across legacy
+# and OpenClaw v3 shapes.
+_PROMPT_EVENT_TYPES = (
+    "prompt.submitted",   # OpenClaw v3
+    "message",            # legacy + Claude Code synthetic
+    "user",               # OpenClaw v3 user-turn
+    "subagent:user",      # OpenClaw v3 sub-agent user-turn
+)
+_RESPONSE_EVENT_TYPES = (
+    "model.completed",    # OpenClaw v3 main agent completion
+    "assistant",          # OpenClaw v3 assistant turn
+    "message",            # legacy + Claude Code synthetic
+    "subagent:assistant", # OpenClaw v3 sub-agent assistant turn
+)
+
+
+# ── Rubric loading ─────────────────────────────────────────────────────────────
+
+
+def _load_yaml_safe(path: Path) -> dict[str, Any]:
+    """Parse a YAML file into a dict. Falls back to a minimal parser when
+    PyYAML isn't installed (we don't want a new dep just for evals)."""
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        import yaml  # type: ignore
+        loaded = yaml.safe_load(text)
+        return loaded if isinstance(loaded, dict) else {}
+    except ImportError:
+        return _minimal_yaml_parse(text)
+    except Exception as e:
+        log.warning("evals: rubric YAML parse failed (%s); using defaults", e)
+        return {}
+
+
+def _minimal_yaml_parse(text: str) -> dict[str, Any]:
+    """Tiny YAML subset parser — handles the rubric shape only.
+
+    Format supported:
+        <name>:
+          judge_model: <str>
+          prompt: |
+            <multi-line>
+
+    Returns ``{name: {judge_model, prompt}, ...}``. Anything outside that
+    shape is ignored. This exists so installs without PyYAML still get a
+    working rubric editor; the dependency is optional.
+    """
+    out: dict[str, Any] = {}
+    cur_name: str | None = None
+    cur_dict: dict[str, Any] | None = None
+    in_block: str | None = None
+    block_lines: list[str] = []
+    block_indent: int | None = None
+    for raw in text.splitlines():
+        if raw.strip().startswith("#") or not raw.strip():
+            if in_block is not None:
+                # blank lines inside a block scalar are preserved
+                block_lines.append("")
+            continue
+        # Block scalar accumulator
+        if in_block is not None and cur_dict is not None:
+            stripped = raw.rstrip()
+            indent = len(raw) - len(raw.lstrip(" "))
+            if block_indent is None:
+                block_indent = indent if indent > 0 else 4
+            if indent >= block_indent and stripped:
+                block_lines.append(raw[block_indent:])
+                continue
+            # Dedented out of block — flush.
+            cur_dict[in_block] = "\n".join(block_lines).rstrip() + "\n"
+            in_block = None
+            block_lines = []
+            block_indent = None
+        m_top = re.match(r"^([A-Za-z0-9_\-]+):\s*$", raw)
+        if m_top:
+            cur_name = m_top.group(1)
+            cur_dict = {}
+            out[cur_name] = cur_dict
+            continue
+        m_kv = re.match(r"^\s+([A-Za-z0-9_\-]+):\s*(.*)$", raw)
+        if m_kv and cur_dict is not None:
+            key = m_kv.group(1)
+            val = m_kv.group(2).strip()
+            if val == "|" or val == "|-":
+                in_block = key
+                block_lines = []
+                block_indent = None
+            else:
+                cur_dict[key] = val
+    if in_block is not None and cur_dict is not None:
+        cur_dict[in_block] = "\n".join(block_lines).rstrip() + "\n"
+    return out
+
+
+def load_rubric(name: str = "default") -> dict[str, Any]:
+    """Return the rubric dict for ``name``, falling back to DEFAULT_RUBRIC.
+
+    User rubrics in ``~/.clawmetry/evals.yaml`` override the defaults
+    field-by-field — a custom rubric that only sets ``judge_model`` still
+    gets the default prompt, and vice versa.
+    """
+    rubrics = _load_yaml_safe(RUBRIC_PATH)
+    merged: dict[str, Any] = dict(DEFAULT_RUBRIC)
+    user_rubric = rubrics.get(name) if isinstance(rubrics.get(name), dict) else None
+    if user_rubric:
+        for k, v in user_rubric.items():
+            if v is not None and v != "":
+                merged[k] = v
+    return merged
+
+
+def save_rubric_yaml(text: str) -> None:
+    """Persist the rubric YAML text verbatim. Validates parse before write
+    so a syntax error doesn't brick scoring. Idempotent — re-saving the
+    same text is a no-op on the filesystem level."""
+    # Parse-validate before write so we never persist a file that
+    # ``load_rubric`` can't read back.
+    _minimal_yaml_parse(text)
+    RUBRIC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    RUBRIC_PATH.write_text(text, encoding="utf-8")
+
+
+def get_rubric_yaml() -> str:
+    """Return the raw YAML on disk, or the default template if absent."""
+    if RUBRIC_PATH.exists():
+        try:
+            return RUBRIC_PATH.read_text(encoding="utf-8")
+        except OSError:
+            pass
+    return DEFAULT_RUBRIC_YAML
+
+
+# ── Score parsing ──────────────────────────────────────────────────────────────
+
+
+_SCORE_RE = re.compile(r"SCORE\s*:\s*([0-9]+(?:\.\d+)?)", re.IGNORECASE)
+_REASON_RE = re.compile(r"REASON\s*:\s*(.+?)(?:\n|$)", re.IGNORECASE | re.DOTALL)
+
+
+def parse_score(text: str) -> tuple[float | None, str | None]:
+    """Extract ``(score, reason)`` from a judge model's reply.
+
+    Tolerant of leading/trailing whitespace, extra prose, and the model
+    occasionally answering as ``Score: 4`` or wrapping the value in
+    backticks. Returns ``(None, None)`` if neither field is recognisable
+    so the caller can log + skip rather than persist garbage.
+    """
+    if not text:
+        return None, None
+    cleaned = text.replace("`", "").strip()
+    score: float | None = None
+    m = _SCORE_RE.search(cleaned)
+    if m:
+        try:
+            val = float(m.group(1))
+            if 0.0 <= val <= 5.0:
+                score = val
+        except ValueError:
+            pass
+    reason: str | None = None
+    r = _REASON_RE.search(cleaned)
+    if r:
+        reason = r.group(1).strip()
+        # Truncate runaway reasons to a tweet's length so the column
+        # doesn't bloat the DuckDB row size.
+        if len(reason) > 280:
+            reason = reason[:277] + "..."
+    return score, reason
+
+
+# ── Result envelope ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class EvalResult:
+    """One scored session. Persisted columns mirror this shape (see
+    ``clawmetry/local_store.py`` v8 migration)."""
+    session_id: str
+    score: float | None
+    reason: str | None
+    judge_model: str
+    rubric_name: str
+    scored_at: int  # epoch millis
+    skipped: bool = False
+    skip_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ── Rate limiter (in-process, sliding hour window) ────────────────────────────
+
+
+class _RateLimiter:
+    """Simple sliding-window counter. ``allow()`` returns True at most
+    ``cap`` times in any 3600-second window. Process-local — the daemon
+    is the only scoring writer so we don't need cross-process state."""
+    def __init__(self, cap: int):
+        self.cap = max(1, int(cap))
+        self._lock = threading.Lock()
+        self._hits: list[float] = []
+
+    def allow(self, *, now: float | None = None) -> bool:
+        now = time.time() if now is None else now
+        cutoff = now - 3600.0
+        with self._lock:
+            # Drop hits outside the window.
+            self._hits = [t for t in self._hits if t > cutoff]
+            if len(self._hits) >= self.cap:
+                return False
+            self._hits.append(now)
+            return True
+
+    def hits_in_window(self, *, now: float | None = None) -> int:
+        now = time.time() if now is None else now
+        cutoff = now - 3600.0
+        with self._lock:
+            self._hits = [t for t in self._hits if t > cutoff]
+            return len(self._hits)
+
+
+# ── Transcript extraction ──────────────────────────────────────────────────────
+
+
+def _event_text(ev: dict[str, Any], event_types: tuple[str, ...]) -> str:
+    """Extract human-readable text from an event row for the judge prompt.
+
+    Probes the v3 + legacy shapes documented in the MEMORY canonical event
+    notes: ``finalPromptText`` for prompts; ``message.content`` / ``text``
+    / ``output`` for assistants.
+    """
+    et = ev.get("event_type") or ev.get("type") or ""
+    if et not in event_types:
+        return ""
+    data = ev.get("data") or {}
+    if isinstance(data, (bytes, bytearray)):
+        try:
+            data = json.loads(data.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return ""
+    if not isinstance(data, dict):
+        return ""
+    # Prompt-side probes (v3 + legacy).
+    for key in ("finalPromptText", "promptText", "text", "input", "content"):
+        v = data.get(key)
+        if isinstance(v, str) and v.strip():
+            return v
+    # Anthropic SDK envelope: data.message.content can be str or list-of-blocks.
+    msg = data.get("message") if isinstance(data.get("message"), dict) else None
+    if msg:
+        c = msg.get("content")
+        if isinstance(c, str) and c.strip():
+            return c
+        if isinstance(c, list):
+            parts: list[str] = []
+            for blk in c:
+                if isinstance(blk, dict) and isinstance(blk.get("text"), str):
+                    parts.append(blk["text"])
+            if parts:
+                return "\n".join(parts)
+        t = msg.get("text")
+        if isinstance(t, str) and t.strip():
+            return t
+    # v3 model.completed sometimes carries the final text in data.output.
+    out = data.get("output")
+    if isinstance(out, str) and out.strip():
+        return out
+    return ""
+
+
+# ── Runner ─────────────────────────────────────────────────────────────────────
+
+
+class EvalRunner:
+    """Score completed sessions using an LLM-as-judge.
+
+    Usage:
+        runner = EvalRunner()
+        result = runner.score_session("sess-abc")
+
+    The runner is stateful only for the rate limiter; everything else is
+    derived per-call so it's safe to share one instance across the
+    scheduler thread + ad-hoc /api/evals/rescore handlers.
+    """
+
+    def __init__(
+        self,
+        *,
+        rubric_name: str = "default",
+        rate_limiter: _RateLimiter | None = None,
+        store: Any = None,
+    ):
+        self.rubric_name = rubric_name
+        self.rate_limiter = rate_limiter or _RateLimiter(RATE_LIMIT_PER_HOUR)
+        # ``store`` injectable so tests can hand in a fake without going
+        # through the real DuckDB singleton.
+        self._store = store
+
+    # -- internals --
+
+    def _get_store(self) -> Any:
+        if self._store is not None:
+            return self._store
+        from clawmetry import local_store
+        self._store = local_store.get_store()
+        return self._store
+
+    def _build_prompt(self, rubric: dict[str, Any], transcript: str) -> str:
+        """Compose the final judge prompt: rubric instructions + transcript."""
+        instructions = str(rubric.get("prompt") or DEFAULT_RUBRIC["prompt"])
+        # Cap transcript length so a 100K-token session doesn't run the
+        # judge bill into the ground. The first/last ~4K chars carry the
+        # signal we need (intent + outcome) without the toolchain noise.
+        if len(transcript) > 8000:
+            head = transcript[:4000]
+            tail = transcript[-4000:]
+            transcript = head + "\n\n[... transcript truncated ...]\n\n" + tail
+        return instructions + "\n\n---\nTRANSCRIPT:\n" + transcript + "\n---"
+
+    def _collect_transcript(self, session_id: str) -> tuple[str, int]:
+        """Pull session events from DuckDB and render a compact transcript.
+
+        Returns ``(transcript_text, total_tokens)``. ``total_tokens`` is the
+        DuckDB-summed token_count for the session — used by the trivial-
+        session guard to skip empty heartbeats.
+        """
+        store = self._get_store()
+        events: list[dict[str, Any]] = []
+        try:
+            events = store.query_events(session_id=session_id, limit=200)
+        except Exception as e:
+            log.warning("evals: query_events(%s) failed: %s", session_id, e)
+            return "", 0
+        # query_events returns DESC; we want chronological for the judge.
+        events = list(reversed(events))
+
+        prompts: list[str] = []
+        responses: list[str] = []
+        total_tokens = 0
+        for ev in events:
+            tc = ev.get("token_count") or 0
+            try:
+                total_tokens += int(tc)
+            except (TypeError, ValueError):
+                pass
+            p = _event_text(ev, _PROMPT_EVENT_TYPES)
+            if p:
+                prompts.append(p)
+                continue
+            r = _event_text(ev, _RESPONSE_EVENT_TYPES)
+            if r:
+                responses.append(r)
+
+        if not prompts and not responses:
+            return "", total_tokens
+
+        parts: list[str] = []
+        # Take the FIRST user prompt and LAST assistant response — that's
+        # the canonical intent-vs-outcome pair the rubric scores.
+        if prompts:
+            parts.append("USER: " + prompts[0].strip())
+        if responses:
+            parts.append("ASSISTANT: " + responses[-1].strip())
+        return "\n\n".join(parts), total_tokens
+
+    # -- public API --
+
+    def score_session(
+        self,
+        session_id: str,
+        *,
+        dry_run: bool = False,
+        judge_call: Any = None,
+    ) -> EvalResult | None:
+        """Score one session. Returns ``EvalResult`` (which may be a skip)
+        or ``None`` if the env switch disables evals.
+
+        ``dry_run`` runs the full pipeline but skips DuckDB persistence —
+        used by the /api/evals/rescore preview path.
+
+        ``judge_call`` is an optional injectable callable
+        ``(model, prompt, *, timeout) -> str``. Defaults to the real
+        Anthropic Messages call. Tests inject a recorded-response stub.
+        """
+        if not is_enabled():
+            return None
+
+        rubric = load_rubric(self.rubric_name)
+        judge_model = str(rubric.get("judge_model") or DEFAULT_RUBRIC["judge_model"])
+        scored_at = int(time.time() * 1000)
+
+        transcript, total_tokens = self._collect_transcript(session_id)
+
+        # Trivial-session guard. The threshold is intentionally low —
+        # we want to score real sessions, not skip them.
+        if total_tokens < MIN_TOKENS_FOR_SCORING:
+            result = EvalResult(
+                session_id=session_id,
+                score=None,
+                reason=None,
+                judge_model=judge_model,
+                rubric_name=self.rubric_name,
+                scored_at=scored_at,
+                skipped=True,
+                skip_reason=f"trivial session ({total_tokens} tokens < {MIN_TOKENS_FOR_SCORING})",
+            )
+            log.debug("evals: skip %s (%s)", session_id, result.skip_reason)
+            return result
+
+        if not transcript:
+            return EvalResult(
+                session_id=session_id,
+                score=None,
+                reason=None,
+                judge_model=judge_model,
+                rubric_name=self.rubric_name,
+                scored_at=scored_at,
+                skipped=True,
+                skip_reason="no extractable transcript",
+            )
+
+        # Cost guard — 100 calls/hour ceiling. Returning a skip (not a
+        # failure) lets the scheduler retry on the next pass without
+        # repeatedly logging warnings.
+        if not self.rate_limiter.allow():
+            return EvalResult(
+                session_id=session_id,
+                score=None,
+                reason=None,
+                judge_model=judge_model,
+                rubric_name=self.rubric_name,
+                scored_at=scored_at,
+                skipped=True,
+                skip_reason=f"rate limit hit ({RATE_LIMIT_PER_HOUR}/hour)",
+            )
+
+        prompt = self._build_prompt(rubric, transcript)
+        caller = judge_call or _call_judge
+        try:
+            reply = caller(judge_model, prompt, timeout=JUDGE_TIMEOUT_SECS)
+        except Exception as e:
+            # Judge failure is best-effort — surface as a non-skipped
+            # NULL score so the scheduler will pick it up again later,
+            # and so /api/evals/recent can show "judge unavailable".
+            log.warning("evals: judge call failed for %s: %s", session_id, e)
+            return EvalResult(
+                session_id=session_id,
+                score=None,
+                reason=None,
+                judge_model=judge_model,
+                rubric_name=self.rubric_name,
+                scored_at=scored_at,
+                skipped=False,
+                skip_reason=f"judge error: {type(e).__name__}",
+            )
+
+        score, reason = parse_score(reply)
+        result = EvalResult(
+            session_id=session_id,
+            score=score,
+            reason=reason,
+            judge_model=judge_model,
+            rubric_name=self.rubric_name,
+            scored_at=scored_at,
+        )
+
+        if not dry_run and score is not None:
+            try:
+                store = self._get_store()
+                store.persist_eval_score(
+                    session_id=session_id,
+                    score=score,
+                    reason=reason or "",
+                    judge_model=judge_model,
+                    scored_at=scored_at,
+                    rubric=self.rubric_name,
+                )
+            except Exception as e:
+                log.warning("evals: persist failed for %s: %s", session_id, e)
+        return result
+
+
+# ── Judge LLM call ─────────────────────────────────────────────────────────────
+
+
+def _call_judge(model: str, prompt: str, *, timeout: float = 30.0) -> str:
+    """Call the Anthropic Messages API with the user's existing API key.
+
+    Routed through ``httpx`` so ``clawmetry/interceptor.py``'s cost
+    tracking picks up the call — eval spend shows up in /api/usage like
+    any other LLM call.
+
+    Returns the judge's reply text. Raises on any HTTP / network /
+    JSON-decoding failure — the caller catches and degrades gracefully.
+
+    Provider routing follows the model prefix:
+      * ``claude-*``  → api.anthropic.com (ANTHROPIC_API_KEY)
+      * ``gpt-*``, ``o1-*``, ``o3-*`` → api.openai.com (OPENAI_API_KEY)
+    Anything else falls back to Anthropic — Phase 1 is Haiku-by-default,
+    so the long tail of providers can wait for Phase 2.
+    """
+    import httpx
+
+    model_lower = model.lower()
+    if model_lower.startswith(("gpt-", "o1-", "o3-", "o4-")):
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY not set")
+        url = "https://api.openai.com/v1/chat/completions"
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 200,
+            "temperature": 0,
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        with httpx.Client(timeout=timeout) as client:
+            r = client.post(url, json=payload, headers=headers)
+            r.raise_for_status()
+            data = r.json()
+        choices = data.get("choices") or []
+        if not choices:
+            return ""
+        return choices[0].get("message", {}).get("content", "") or ""
+
+    # Default: Anthropic (Claude Haiku/Sonnet/Opus).
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY not set")
+    url = "https://api.anthropic.com/v1/messages"
+    payload = {
+        "model": model,
+        "max_tokens": 200,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+    }
+    with httpx.Client(timeout=timeout) as client:
+        r = client.post(url, json=payload, headers=headers)
+        r.raise_for_status()
+        data = r.json()
+    blocks = data.get("content") or []
+    parts: list[str] = []
+    for blk in blocks:
+        if isinstance(blk, dict) and isinstance(blk.get("text"), str):
+            parts.append(blk["text"])
+    return "\n".join(parts)
+
+
+# ── Scheduler ──────────────────────────────────────────────────────────────────
+
+
+# Module-level singleton rate limiter shared by the scheduler loop and any
+# ad-hoc /api/evals/rescore calls so the 100/hour ceiling applies globally.
+_GLOBAL_RATE_LIMITER = _RateLimiter(RATE_LIMIT_PER_HOUR)
+
+
+def _runner_factory() -> EvalRunner:
+    return EvalRunner(rate_limiter=_GLOBAL_RATE_LIMITER)
+
+
+def score_pending_sessions(
+    *,
+    batch_size: int = 10,
+    runner: EvalRunner | None = None,
+) -> int:
+    """One scheduler tick: pick up to ``batch_size`` unscored completed
+    sessions and score them. Returns the count of sessions that produced
+    a numeric score (skips + judge failures don't count).
+
+    Called every ``EVAL_INTERVAL_SECS`` by the background thread in
+    ``clawmetry/sync.py``. Idempotent — sessions already carrying an
+    ``eval_score`` are filtered out at the DuckDB level.
+    """
+    if not is_enabled():
+        return 0
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+    except Exception as e:
+        log.warning("evals: local store unavailable: %s", e)
+        return 0
+    try:
+        pending = store.query_unscored_sessions(limit=batch_size)
+    except Exception as e:
+        log.warning("evals: query_unscored_sessions failed: %s", e)
+        return 0
+    if not pending:
+        return 0
+    r = runner or _runner_factory()
+    scored = 0
+    for row in pending:
+        sid = row.get("session_id")
+        if not sid:
+            continue
+        try:
+            result = r.score_session(sid)
+        except Exception as e:
+            log.warning("evals: score_session(%s) crashed: %s", sid, e)
+            continue
+        if result and result.score is not None:
+            scored += 1
+    return scored

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -190,12 +190,26 @@ _DDL = [
         outcome                 VARCHAR,
         outcome_confidence      DOUBLE,
         outcome_classified_at   BIGINT,
+        -- Issue #1619 Phase 1 — LLM-as-judge eval scores. Columns are
+        -- populated by clawmetry/eval_runner.py via persist_eval_score().
+        -- Adjacent to (not replacing) the #1614 outcome columns; the two
+        -- views are complementary (outcome = did the session finish well;
+        -- eval = how good was the actual response, 0-5).
+        eval_score              DOUBLE,
+        eval_reason             VARCHAR,
+        eval_judge_model        VARCHAR,
+        eval_scored_at          BIGINT,
+        eval_rubric             VARCHAR,
         PRIMARY KEY (agent_type, session_id)
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_sessions_active    ON sessions(agent_type, last_active_at)",
     "CREATE INDEX IF NOT EXISTS idx_sessions_outcome   ON sessions(outcome, last_active_at)",
     "CREATE INDEX IF NOT EXISTS idx_sessions_node      ON sessions(node_id, last_active_at)",
+    # Issue #1619 Phase 1 — speeds up /api/evals/recent (ORDER BY
+    # eval_scored_at DESC) and the scheduler's unscored-session probe
+    # (WHERE eval_score IS NULL).
+    "CREATE INDEX IF NOT EXISTS idx_sessions_eval_scored_at ON sessions(eval_scored_at)",
     """
     CREATE TABLE IF NOT EXISTS daily_aggregates (
         agent_type    VARCHAR NOT NULL DEFAULT 'openclaw',
@@ -610,6 +624,16 @@ _MIGRATIONS_V2 = [
     ("sessions", "outcome",                "VARCHAR"),
     ("sessions", "outcome_confidence",     "DOUBLE"),
     ("sessions", "outcome_classified_at",  "BIGINT"),
+    # Issue #1619 Phase 1 — LLM-as-judge eval columns. Idempotent column-adds
+    # so existing v2 stores pick up the eval surface without a fresh DB. The
+    # DDL above carries the same columns for fresh stores. Composes cleanly
+    # with the #1614 outcome-labeling columns above (separate names, same
+    # ALTER pattern — both engineers verified compose-clean before merging).
+    ("sessions", "eval_score",        "DOUBLE"),
+    ("sessions", "eval_reason",       "VARCHAR"),
+    ("sessions", "eval_judge_model",  "VARCHAR"),
+    ("sessions", "eval_scored_at",    "BIGINT"),
+    ("sessions", "eval_rubric",       "VARCHAR"),
 ]
 
 
@@ -3924,6 +3948,184 @@ class LocalStore:
         params.append(int(limit))
         cols = ["agent_type", "node_id", "ts", "kind", "data"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
+
+    # ── Evals (issue #1619 Phase 1) ──────────────────────────────────────
+
+    def persist_eval_score(
+        self,
+        *,
+        session_id: str,
+        score: float,
+        reason: str,
+        judge_model: str,
+        scored_at: int,
+        rubric: str = "default",
+    ) -> None:
+        """Persist a single LLM-as-judge score onto the ``sessions`` row.
+
+        Writes through the same single-writer connection (guarded by
+        ``_write_lock``) as the regular ingest path so concurrent ticks
+        of the eval scheduler don't trip the DuckDB writer-exclusive
+        lock. Upsert semantics — re-scoring the same session overwrites
+        the prior score in place; we keep one row per session and treat
+        the eval columns as the latest evaluation rather than time-
+        series. (History will land in a sibling ``eval_history`` table
+        in Phase 2; keeping the latest-only shape here matches what the
+        overview tile + sessions list want to render today.)
+        """
+        with self._write_lock:
+            try:
+                self._conn.execute(
+                    """
+                    UPDATE sessions
+                       SET eval_score        = ?,
+                           eval_reason       = ?,
+                           eval_judge_model  = ?,
+                           eval_scored_at    = ?,
+                           eval_rubric       = ?
+                     WHERE session_id        = ?
+                    """,
+                    [float(score), reason or "", judge_model or "",
+                     int(scored_at), rubric or "default", session_id],
+                )
+            except Exception:
+                log.exception("local store: persist_eval_score failed for %s",
+                              session_id)
+
+    def query_unscored_sessions(
+        self,
+        *,
+        limit: int = 10,
+        lookback_hours: int = 24,
+    ) -> list[dict[str, Any]]:
+        """Return up to ``limit`` completed sessions that have NOT been
+        eval-scored yet. Drives the background scheduler.
+
+        Filter logic:
+          * ``eval_score IS NULL`` — un-scored.
+          * ``last_active_at`` within ``lookback_hours`` — bound the
+            backfill so a fresh install doesn't burn through judge spend
+            on stale sessions.
+          * ``ended_at IS NOT NULL OR status IN ('completed', 'failed',
+            'escalated')`` — skip in-flight sessions; their transcript
+            is still mutating.
+        """
+        try:
+            from datetime import datetime, timedelta, timezone
+            cutoff = (datetime.now(timezone.utc) - timedelta(hours=lookback_hours)).isoformat()
+        except Exception:
+            cutoff = ""
+        sql = """
+            SELECT session_id, agent_type, agent_id, title, last_active_at,
+                   ended_at, status, total_tokens
+              FROM sessions
+             WHERE eval_score IS NULL
+               AND total_tokens IS NOT NULL
+               AND total_tokens > 0
+               AND (
+                    ended_at IS NOT NULL
+                    OR status IN ('completed', 'failed', 'escalated', 'success', 'error')
+               )
+               AND (? = '' OR COALESCE(last_active_at, started_at, '') >= ?)
+             ORDER BY COALESCE(last_active_at, started_at) DESC NULLS LAST
+             LIMIT ?
+        """
+        rows = self._fetch(sql, [cutoff, cutoff, int(limit)])
+        cols = ["session_id", "agent_type", "agent_id", "title",
+                "last_active_at", "ended_at", "status", "total_tokens"]
+        return [dict(zip(cols, r)) for r in rows]
+
+    def query_recent_evals(
+        self,
+        *,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return recently-scored sessions, newest first. Drives
+        ``/api/evals/recent``."""
+        sql = """
+            SELECT session_id, agent_type, agent_id, title, last_active_at,
+                   total_tokens, cost_usd,
+                   eval_score, eval_reason, eval_judge_model,
+                   eval_scored_at, eval_rubric
+              FROM sessions
+             WHERE eval_score IS NOT NULL
+             ORDER BY eval_scored_at DESC NULLS LAST
+             LIMIT ?
+        """
+        rows = self._fetch(sql, [int(limit)])
+        cols = ["session_id", "agent_type", "agent_id", "title",
+                "last_active_at", "total_tokens", "cost_usd",
+                "eval_score", "eval_reason", "eval_judge_model",
+                "eval_scored_at", "eval_rubric"]
+        return [dict(zip(cols, r)) for r in rows]
+
+    def query_eval_summary(
+        self,
+        *,
+        window_hours: int = 24,
+    ) -> dict[str, Any]:
+        """Aggregate scores over the recent window. Drives
+        ``/api/evals/summary``.
+
+        Returns ``{avg_score, total, scored, p50, p10, window_hours}``.
+        ``total`` is sessions touched in the window (scored OR not);
+        ``scored`` is the subset with a numeric eval_score. The ratio
+        ``scored/total`` surfaces coverage on the overview tile.
+        """
+        try:
+            from datetime import datetime, timedelta, timezone
+            cutoff = (datetime.now(timezone.utc) - timedelta(hours=int(window_hours))).isoformat()
+        except Exception:
+            cutoff = ""
+        # Two queries — one for totals (scored + un-scored), one for the
+        # quantile/avg over the scored subset. Keeps the SQL readable
+        # without a CTE that would have to handle NULLs in two places.
+        try:
+            total_row = self._fetch(
+                """
+                SELECT COUNT(*) AS total,
+                       COUNT(eval_score) AS scored
+                  FROM sessions
+                 WHERE (? = '' OR COALESCE(last_active_at, started_at, '') >= ?)
+                """,
+                [cutoff, cutoff],
+            )
+        except Exception as e:
+            log.warning("local store: eval summary totals failed: %s", e)
+            total_row = [(0, 0)]
+        total = int(total_row[0][0] or 0) if total_row else 0
+        scored = int(total_row[0][1] or 0) if total_row else 0
+
+        avg = 0.0
+        p50 = 0.0
+        p10 = 0.0
+        if scored > 0:
+            try:
+                stats = self._fetch(
+                    """
+                    SELECT AVG(eval_score)                      AS avg_score,
+                           quantile_cont(eval_score, 0.5)       AS p50,
+                           quantile_cont(eval_score, 0.1)       AS p10
+                      FROM sessions
+                     WHERE eval_score IS NOT NULL
+                       AND (? = '' OR COALESCE(last_active_at, started_at, '') >= ?)
+                    """,
+                    [cutoff, cutoff],
+                )
+                if stats:
+                    avg = float(stats[0][0] or 0.0)
+                    p50 = float(stats[0][1] or 0.0)
+                    p10 = float(stats[0][2] or 0.0)
+            except Exception as e:
+                log.warning("local store: eval summary quantiles failed: %s", e)
+        return {
+            "avg_score":     round(avg, 2),
+            "total":         total,
+            "scored":        scored,
+            "p50":           round(p50, 2),
+            "p10":           round(p10, 2),
+            "window_hours":  int(window_hours),
+        }
 
     def query_sessions_table(
         self,

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2150,7 +2150,94 @@ async function loadMiniWidgets(overview, usage) {
   
   // 🐝 Worker Bees (Sub-Agents)
   loadSubAgents();
-  
+
+  // Issue #1619 Phase 1 — eval score tile. Lazy, non-blocking; tile shows
+  // a dash on miss so a slow daemon doesn't gate the overview render.
+  loadEvalSummary();
+}
+
+// Issue #1619 Phase 1 — pull aggregate score for the overview tile.
+// Reads /api/evals/summary?window=24h and renders avg + coverage. Score
+// is shown as "4.2 / 5" with a color band; coverage as "220 / 247 scored".
+async function loadEvalSummary() {
+  var avgEl = document.getElementById('eval-avg-score');
+  var covEl = document.getElementById('eval-coverage');
+  if (!avgEl) return;
+  try {
+    var data = await fetch('/api/evals/summary?window=24h').then(function(r){return r.json();}).catch(function(){return null;});
+    if (!data || typeof data.scored !== 'number') {
+      avgEl.textContent = '--';
+      if (covEl) covEl.textContent = '';
+      return;
+    }
+    if (data.scored === 0) {
+      avgEl.textContent = '--';
+      avgEl.style.color = 'var(--text-muted)';
+      if (covEl) covEl.textContent = 'no scored sessions yet';
+      return;
+    }
+    var avg = Number(data.avg_score || 0);
+    avgEl.textContent = avg.toFixed(1) + ' / 5';
+    // Color band: 4+ green, 3-4 yellow, <3 red. Matches the per-session pill.
+    avgEl.style.color = avg >= 4 ? '#22c55e' : avg >= 3 ? '#f59e0b' : '#ef4444';
+    if (covEl) covEl.textContent = data.scored + ' / ' + data.total + ' scored';
+  } catch (e) {
+    avgEl.textContent = '--';
+    if (covEl) covEl.textContent = '';
+  }
+}
+
+// Issue #1619 Phase 1 — rubric editor. Modal opens with the current YAML;
+// Save POSTs back to /api/evals/rubric which validates parse before write.
+async function openEvalRubricModal() {
+  var modal = document.getElementById('eval-rubric-modal');
+  var ta = document.getElementById('eval-rubric-yaml');
+  var status = document.getElementById('eval-rubric-status');
+  var pathEl = document.getElementById('eval-rubric-path');
+  if (!modal || !ta) return;
+  modal.style.display = 'flex';
+  if (status) status.textContent = 'Loading...';
+  try {
+    var data = await fetch('/api/evals/rubric').then(function(r){return r.json();});
+    ta.value = data.yaml || '';
+    if (pathEl && data.rubric_path) pathEl.textContent = data.rubric_path;
+    if (status) {
+      status.textContent = data.enabled === false
+        ? 'Evals are disabled (CLAWMETRY_EVALS_ENABLED=0).'
+        : 'Loaded.';
+    }
+  } catch (e) {
+    if (status) status.textContent = 'Failed to load: ' + e.message;
+  }
+}
+
+function closeEvalRubricModal() {
+  var modal = document.getElementById('eval-rubric-modal');
+  if (modal) modal.style.display = 'none';
+}
+
+async function saveEvalRubric() {
+  var ta = document.getElementById('eval-rubric-yaml');
+  var status = document.getElementById('eval-rubric-status');
+  if (!ta) return;
+  var body = JSON.stringify({yaml: ta.value || ''});
+  if (status) status.textContent = 'Saving...';
+  try {
+    var resp = await fetch('/api/evals/rubric', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: body,
+    });
+    var data = await resp.json();
+    if (!resp.ok || data.error) {
+      if (status) status.textContent = 'Save failed: ' + (data.error || resp.status);
+      return;
+    }
+    if (status) status.textContent = 'Saved. New scores use this rubric on the next scheduler tick.';
+    setTimeout(closeEvalRubricModal, 1200);
+  } catch (e) {
+    if (status) status.textContent = 'Save failed: ' + e.message;
+  }
 }
 
 async function loadSubAgents() {
@@ -5682,7 +5769,7 @@ async function loadSessions() {
     // In cloud mode: /api/sessions and /api/subagents already handle CLOUD_MODE server-side
     // fetch interceptor appends node_id+token so these hit the cloud endpoints correctly
   }
-  var [sessData, saData, anomalyData, costData, chainData, riskBrain] = await Promise.all([
+  var [sessData, saData, anomalyData, costData, chainData, riskBrain, evalData] = await Promise.all([
     fetch('/api/sessions').then(r => r.json()).catch(function() { return {sessions:[]}; }),
     fetch('/api/subagents').then(r => r.json()).catch(function() { return {subagents:[]}; }),
     fetch('/api/usage/anomalies').then(r => r.json()).catch(function() { return {anomalies:[]}; }),
@@ -5692,8 +5779,17 @@ async function loadSessions() {
     // warning on any session whose latest LLM call tripped the band.
     // 200 events is enough to cover the active window without blowing
     // the page-load budget; the fast path serves this in <50 ms.
-    fetch('/api/brain-history?limit=200').then(r => r.json()).catch(function() { return {events:[]}; })
+    fetch('/api/brain-history?limit=200').then(r => r.json()).catch(function() { return {events:[]}; }),
+    // Issue #1619 Phase 1 — eval scores. Joined client-side onto the
+    // sessions list so the Score column doesn't require a server-side
+    // join with the in-flight #1614 outcome columns.
+    fetch('/api/evals/recent?limit=200').then(r => r.json()).catch(function() { return {evals:[]}; })
   ]);
+  // Build a session_id → eval lookup for O(1) overlay.
+  var evalMap = {};
+  ((evalData && evalData.evals) || []).forEach(function(e) {
+    if (e && e.session_id) evalMap[e.session_id] = e;
+  });
   // Build cost lookup map by session_id suffix
   var costMap = {};
   (costData.sessions || []).forEach(function(c) {
@@ -5749,6 +5845,15 @@ async function loadSessions() {
     if (s.channel !== 'unknown') html += '<span><span class="badge channel">' + s.channel + '</span></span>';
     if (sessCost && sessCost.cost_usd > 0) {
       html += '<span style="font-size:11px;color:var(--text-success);font-weight:600;">💰 $' + Number(sessCost.cost_usd||0).toFixed(4) + ' total</span>';
+    }
+    // Issue #1619 Phase 1 — Score pill. Color band matches the overview
+    // tile (4+ green, 3-4 yellow, <3 red). Hover shows the judge's reason.
+    var evalRow = evalMap[sid];
+    if (evalRow && evalRow.eval_score !== null && evalRow.eval_score !== undefined) {
+      var scoreVal = Number(evalRow.eval_score);
+      var scoreColor = scoreVal >= 4 ? '#22c55e' : scoreVal >= 3 ? '#f59e0b' : '#ef4444';
+      var reason = String(evalRow.eval_reason || '').replace(/"/g, '&quot;');
+      html += '<span title="' + reason + ' (judge: ' + escHtml(evalRow.eval_judge_model || '') + ')" style="font-size:11px;font-weight:700;color:' + scoreColor + ';padding:1px 8px;border:1px solid ' + scoreColor + ';border-radius:10px;">⭐ ' + scoreVal.toFixed(1) + '</span>';
     }
     html += '<span>Updated ' + timeAgo(s.updatedAt) + '</span>';
     html += '</div>';

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7982,6 +7982,13 @@ def run_daemon() -> None:
     # exercise the dispatch path immediately if rules + matching events are
     # already present from startup backfill.
     last_alerts_eval = 0.0
+    # Issue #1619 Phase 1 — LLM-as-judge scheduler. Sister cadence to the
+    # alerts evaluator; 5-minute tick picks up to EVAL_BATCH unscored
+    # completed sessions and persists scores in-process via the user's
+    # existing API key (no cloud roundtrip). Default-on; CLAWMETRY_EVALS_
+    # ENABLED=0 disables cleanly. 0 = fire on first cycle so a daemon
+    # restart scores the backlog without waiting 5 min.
+    last_evals_run = 0.0
 
     while True:
         try:
@@ -8142,6 +8149,27 @@ def run_daemon() -> None:
                     save_state(state)
                 except Exception:
                     pass
+
+            # ── Eval scheduler (issue #1619 Phase 1) ──
+            # Sister of the alerts evaluator. Picks unscored completed
+            # sessions from DuckDB and runs them through the LLM-as-
+            # judge runner. Failure swallowed so a judge outage can't
+            # take down the sync cycle.
+            now_evals = time.time()
+            if (now_evals - last_evals_run) >= EVAL_INTERVAL_SEC:
+                try:
+                    from clawmetry import eval_runner as _eval_runner
+                    if _eval_runner.is_enabled():
+                        n_scored = _eval_runner.score_pending_sessions(
+                            batch_size=EVAL_BATCH,
+                        )
+                        if n_scored:
+                            log.info(
+                                "evals: scored %d session(s)", n_scored
+                            )
+                except Exception as _ee:
+                    log.warning("evals: scheduler tick errored: %s", _ee)
+                last_evals_run = now_evals
 
             # Re-mirror Docker data if running in Docker mode
             if hasattr(detect_paths, "_docker_cid") or any(
@@ -8792,6 +8820,14 @@ def sync_autonomy(config, state, paths):
 
 
 ALERTS_EVAL_INTERVAL_SEC = 60  # Re-evaluate alerts every 60s (PRD #779)
+
+# Issue #1619 Phase 1 — LLM-as-judge eval scheduler cadence. 300s (5 min)
+# matches the PRD: every 5 min, pick up to EVAL_BATCH unscored completed
+# sessions and persist their scores. Lower bound is the rate limiter
+# (100/hour cap in clawmetry/eval_runner.py), so a chatty workspace
+# self-throttles regardless of interval.
+EVAL_INTERVAL_SEC = int(os.environ.get("CLAWMETRY_EVALS_INTERVAL_SEC", "300"))
+EVAL_BATCH = int(os.environ.get("CLAWMETRY_EVALS_BATCH", "10"))
 # Window for the events read from DuckDB on each tick. Wider than the
 # evaluation interval so a slow tick doesn't drop events on the floor.
 _ALERTS_EVENT_LOOKBACK_SEC = 600

--- a/dashboard.py
+++ b/dashboard.py
@@ -118,6 +118,7 @@ from routes.workspaces import bp_workspaces
 from routes.bootstrap import bp_bootstrap
 from routes.insights import bp_insights
 from routes.review import bp_review
+from routes.evals import bp_evals
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -4453,6 +4454,32 @@ function clawmetryLogout(){
         <div class="stats-footer-value" id="reliability-direction">--</div>
       </div>
       <span class="stats-footer-sub" style="margin-left:auto;" id="reliability-detail"></span>
+    </div>
+    <!-- Issue #1619 Phase 1 — eval score tile. Click opens the rubric editor. -->
+    <div class="stats-footer-item" id="eval-card" style="cursor:pointer;" title="Click to edit the rubric" onclick="openEvalRubricModal()">
+      <span class="stats-footer-icon">⭐</span>
+      <div>
+        <div class="stats-footer-label">Eval score (24h)</div>
+        <div class="stats-footer-value" id="eval-avg-score">--</div>
+      </div>
+      <span class="stats-footer-sub" style="margin-left:auto;" id="eval-coverage"></span>
+    </div>
+  </div>
+
+  <!-- Issue #1619 Phase 1 — rubric editor modal. Loaded lazily; hidden by default. -->
+  <div id="eval-rubric-modal" style="display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.6);z-index:1000;align-items:center;justify-content:center;">
+    <div style="background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:12px;padding:20px;max-width:640px;width:90%;max-height:80vh;display:flex;flex-direction:column;gap:12px;">
+      <div style="display:flex;justify-content:space-between;align-items:center;">
+        <h3 style="margin:0;font-size:14px;font-weight:700;color:var(--text-primary);">Eval rubric</h3>
+        <button onclick="closeEvalRubricModal()" style="background:transparent;border:none;color:var(--text-muted);font-size:18px;cursor:pointer;">&times;</button>
+      </div>
+      <div style="font-size:11px;color:var(--text-muted);">Edit the YAML rubric used by the local LLM judge. Saved to <code id="eval-rubric-path">~/.clawmetry/evals.yaml</code>. Disable scoring entirely with <code>CLAWMETRY_EVALS_ENABLED=0</code>.</div>
+      <textarea id="eval-rubric-yaml" style="font-family:monospace;font-size:12px;width:100%;min-height:280px;padding:10px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:8px;resize:vertical;" spellcheck="false"></textarea>
+      <div id="eval-rubric-status" style="font-size:11px;color:var(--text-muted);min-height:14px;"></div>
+      <div style="display:flex;justify-content:flex-end;gap:8px;">
+        <button onclick="closeEvalRubricModal()" style="background:transparent;color:var(--text-muted);border:1px solid var(--border-primary);border-radius:6px;padding:6px 12px;font-size:12px;cursor:pointer;">Cancel</button>
+        <button onclick="saveEvalRubric()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;font-weight:600;cursor:pointer;">Save</button>
+      </div>
     </div>
   </div>
 
@@ -10282,6 +10309,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_bootstrap)
     app.register_blueprint(bp_insights)
     app.register_blueprint(bp_review)
+    app.register_blueprint(bp_evals)
 
     # ── v2 React SPA (opt-in) ───────────────────────────────────────────────
     # Default OFF so existing v1 users notice nothing. Enabled when the user

--- a/routes/evals.py
+++ b/routes/evals.py
@@ -1,0 +1,153 @@
+"""
+routes/evals.py — Eval (LLM-as-judge) endpoints.
+
+Phase 1 of issue #1619. The scoring path runs in ``clawmetry/eval_runner.py``
+on the user's own API key; these endpoints just expose the persisted scores
+(local DuckDB) to the dashboard UI and to ad-hoc re-score requests.
+
+Routes:
+  GET   /api/evals/recent           — recent scored sessions
+  GET   /api/evals/summary          — aggregate avg/p50/p10 over a window
+  POST  /api/evals/rescore/<sid>    — manual re-eval trigger for one session
+  GET   /api/evals/rubric           — raw rubric YAML text
+  POST  /api/evals/rubric           — replace rubric YAML text (validates parse)
+
+All endpoints degrade gracefully when the local store or eval runner is
+unavailable — the dashboard treats an empty payload as "evals not yet
+populated" rather than an error.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+bp_evals = Blueprint("evals", __name__)
+
+
+def _store_via_daemon_or_direct(method_name: str, **kwargs):
+    """Mirror of routes/sessions.py:_ls_call — daemon HTTP proxy first,
+    then direct DuckDB open as fallback. Returns ``None`` on miss."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+@bp_evals.route("/api/evals/recent", methods=["GET"])
+def evals_recent():
+    """Recent scored sessions. ``?limit=`` defaults to 50, capped at 200."""
+    try:
+        limit = max(1, min(200, int(request.args.get("limit", "50"))))
+    except (TypeError, ValueError):
+        limit = 50
+    rows = _store_via_daemon_or_direct("query_recent_evals", limit=limit) or []
+    return jsonify({"evals": rows, "limit": limit})
+
+
+@bp_evals.route("/api/evals/summary", methods=["GET"])
+def evals_summary():
+    """Aggregate over the recent window. ``?window=1d`` (1d, 6h, 24h ok)."""
+    raw = (request.args.get("window") or "24h").strip().lower()
+    # Tiny human-readable window parser; defaults to 24h on anything weird.
+    hours = 24
+    try:
+        if raw.endswith("d"):
+            hours = int(float(raw[:-1]) * 24)
+        elif raw.endswith("h"):
+            hours = int(float(raw[:-1]))
+        elif raw.endswith("m"):
+            hours = max(1, int(float(raw[:-1]) // 60))
+        else:
+            hours = int(float(raw))
+    except (TypeError, ValueError):
+        hours = 24
+    hours = max(1, min(24 * 30, hours))
+    payload = _store_via_daemon_or_direct(
+        "query_eval_summary", window_hours=hours,
+    )
+    if not payload:
+        payload = {
+            "avg_score":    0.0,
+            "total":        0,
+            "scored":       0,
+            "p50":          0.0,
+            "p10":          0.0,
+            "window_hours": hours,
+        }
+    return jsonify(payload)
+
+
+@bp_evals.route("/api/evals/rescore/<session_id>", methods=["POST"])
+def evals_rescore(session_id: str):
+    """Manually trigger a re-score for one session. Synchronous — returns
+    the new score (or skip / failure) so the UI can flash a toast.
+
+    We deliberately keep this synchronous: the user's intent is "I want
+    to see the new score NOW", and a Haiku judge call typically returns
+    in under 2 seconds.
+    """
+    try:
+        from clawmetry import eval_runner
+    except Exception as e:
+        return jsonify({"error": f"eval runner unavailable: {e}"}), 503
+    if not eval_runner.is_enabled():
+        return jsonify({
+            "error": "evals are disabled (CLAWMETRY_EVALS_ENABLED=0)",
+        }), 409
+    runner = eval_runner.EvalRunner()
+    try:
+        result = runner.score_session(session_id)
+    except Exception as e:
+        return jsonify({"error": f"score_session failed: {e}"}), 500
+    if result is None:
+        return jsonify({"error": "evals disabled"}), 409
+    return jsonify(result.to_dict())
+
+
+@bp_evals.route("/api/evals/rubric", methods=["GET"])
+def evals_rubric_get():
+    """Return the raw rubric YAML text + the parsed default for reference."""
+    try:
+        from clawmetry import eval_runner
+    except Exception as e:
+        return jsonify({"error": f"eval runner unavailable: {e}"}), 503
+    return jsonify({
+        "yaml":           eval_runner.get_rubric_yaml(),
+        "rubric_path":    str(eval_runner.RUBRIC_PATH),
+        "default":        eval_runner.DEFAULT_RUBRIC,
+        "enabled":        eval_runner.is_enabled(),
+    })
+
+
+@bp_evals.route("/api/evals/rubric", methods=["POST"])
+def evals_rubric_save():
+    """Replace the rubric YAML. Validates parse before writing.
+
+    Body: ``{"yaml": "<text>"}``. Returns the parsed default merged with
+    the saved rubric so the UI can confirm the round-trip worked.
+    """
+    try:
+        from clawmetry import eval_runner
+    except Exception as e:
+        return jsonify({"error": f"eval runner unavailable: {e}"}), 503
+    body = request.get_json(silent=True) or {}
+    text = body.get("yaml")
+    if not isinstance(text, str) or not text.strip():
+        return jsonify({"error": "missing 'yaml' field"}), 400
+    try:
+        eval_runner.save_rubric_yaml(text)
+    except Exception as e:
+        return jsonify({"error": f"rubric save failed: {e}"}), 400
+    return jsonify({
+        "ok":      True,
+        "rubric":  eval_runner.load_rubric("default"),
+    })

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -427,6 +427,13 @@ _DAEMON_METHODS = frozenset({
     # classifies any unlabeled rows so the dashboard never paints "0%".
     "query_outcomes",
     "reclassify_session_outcome",
+    # Issue #1619 Phase 1: LLM-as-judge eval surface. Reads + the persist
+    # write all go via the daemon (writer-lock owner) so the dashboard
+    # process can render scores without opening DuckDB itself.
+    "query_unscored_sessions",
+    "query_recent_evals",
+    "query_eval_summary",
+    "persist_eval_score",
     "health",
 })
 

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -1,0 +1,377 @@
+"""Tests for ``clawmetry.eval_runner`` — Phase 1 LLM-as-judge (refs #1619).
+
+Six scenarios per the PRD:
+  1. Score parsing (SCORE: 4 / REASON: ...)
+  2. Rubric YAML loading (default + custom)
+  3. Rate-limit guard (100/hour cap)
+  4. Skip trivial sessions (<10 tokens)
+  5. Judge LLM failure (graceful — NULL score + warning)
+  6. Aggregate summary returns correct avg
+
+Plus a smoke test of the canonical event-shape union (bug-class gate per
+``feedback_synthetic_tests_missed_real_event_shape.md``): scoring exercises
+real OpenClaw v3 ``prompt.submitted`` + ``model.completed`` shapes alongside
+the legacy ``message`` shape.
+
+All tests use mocked judge calls. The live-API smoke is gated on
+``CI_ANTHROPIC_API_KEY`` so CI doesn't burn credits on every push.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+from clawmetry import eval_runner  # noqa: E402
+from clawmetry.eval_runner import (  # noqa: E402
+    EvalRunner,
+    DEFAULT_RUBRIC,
+    DEFAULT_RUBRIC_YAML,
+    _RateLimiter,
+    load_rubric,
+    parse_score,
+    save_rubric_yaml,
+)
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+
+class _FakeStore:
+    """In-memory stand-in for ``LocalStore`` that records persisted scores
+    and serves a canned event timeline. Lets us exercise the full runner
+    without DuckDB or the daemon proxy."""
+
+    def __init__(self, events):
+        # ``events`` is iterable of dicts; mirror DuckDB's DESC ordering.
+        self._events = list(events)
+        self.persisted: list[dict] = []
+
+    def query_events(self, *, session_id, limit=200):
+        rows = [e for e in self._events if e.get("session_id") == session_id]
+        rows.sort(key=lambda r: r.get("ts", ""), reverse=True)
+        return rows[:limit]
+
+    def persist_eval_score(self, **kwargs):
+        self.persisted.append(kwargs)
+
+
+def _events_v3_shape(session_id="s-1"):
+    """Realistic OpenClaw v3 event shapes — the bug-class gate per
+    ``feedback_synthetic_tests_missed_real_event_shape.md`` requires real
+    event_type strings (``prompt.submitted`` + ``model.completed``), not
+    synthetic ``message``."""
+    return [
+        {
+            "session_id":  session_id,
+            "event_type":  "prompt.submitted",
+            "ts":          "2026-05-17T19:00:00+00:00",
+            "data":        {"finalPromptText": "Write me a haiku about Rust."},
+            "token_count": 18,
+        },
+        {
+            "session_id":  session_id,
+            "event_type":  "model.completed",
+            "ts":          "2026-05-17T19:00:02+00:00",
+            "data":        {
+                "modelId":  "claude-haiku-4-5",
+                "provider": "anthropic",
+                "output":   "Borrow checker hums\nLifetimes weave through every scope\nMemory rests safe",
+            },
+            "token_count": 42,
+        },
+    ]
+
+
+# ── 1. Score parsing ─────────────────────────────────────────────────────────
+
+
+def test_parse_score_extracts_score_and_reason():
+    s, r = parse_score("SCORE: 4\nREASON: Mostly correct but missed the closing tag.")
+    assert s == 4.0
+    assert r == "Mostly correct but missed the closing tag."
+
+
+def test_parse_score_tolerates_extra_prose_and_case():
+    s, r = parse_score("Sure! score: 5\nreason: Great answer.\n\n--end--")
+    assert s == 5.0
+    assert r and "Great answer" in r
+
+
+def test_parse_score_handles_float_score():
+    s, _ = parse_score("SCORE: 3.5\nREASON: Close.")
+    assert s == 3.5
+
+
+def test_parse_score_returns_none_when_garbage():
+    s, r = parse_score("I cannot help with this request.")
+    assert s is None and r is None
+
+
+def test_parse_score_rejects_out_of_band_value():
+    s, _ = parse_score("SCORE: 11\nREASON: Off scale.")
+    assert s is None  # 11 isn't in 0-5; bail rather than persist
+
+
+# ── 2. Rubric loading ────────────────────────────────────────────────────────
+
+
+def test_load_rubric_defaults_when_no_file(tmp_path, monkeypatch):
+    missing = tmp_path / "missing.yaml"
+    monkeypatch.setattr(eval_runner, "RUBRIC_PATH", missing)
+    r = load_rubric()
+    assert r["judge_model"] == DEFAULT_RUBRIC["judge_model"]
+    assert "SCORE:" in r["prompt"]
+
+
+def test_load_rubric_custom_overrides_default(tmp_path, monkeypatch):
+    p = tmp_path / "evals.yaml"
+    p.write_text(
+        "default:\n"
+        "  judge_model: claude-sonnet-4-5\n"
+        "  prompt: |\n"
+        "    Custom rubric:\n"
+        "    SCORE: <0-5>\n"
+        "    REASON: <why>\n"
+    )
+    monkeypatch.setattr(eval_runner, "RUBRIC_PATH", p)
+    r = load_rubric("default")
+    assert r["judge_model"] == "claude-sonnet-4-5"
+    assert "Custom rubric:" in r["prompt"]
+
+
+def test_load_rubric_partial_override_keeps_default_prompt(tmp_path, monkeypatch):
+    p = tmp_path / "evals.yaml"
+    p.write_text("default:\n  judge_model: claude-opus-4-5\n")
+    monkeypatch.setattr(eval_runner, "RUBRIC_PATH", p)
+    r = load_rubric("default")
+    assert r["judge_model"] == "claude-opus-4-5"
+    # Default prompt is still wired in.
+    assert r["prompt"] == DEFAULT_RUBRIC["prompt"]
+
+
+def test_save_rubric_round_trips(tmp_path, monkeypatch):
+    p = tmp_path / "evals.yaml"
+    monkeypatch.setattr(eval_runner, "RUBRIC_PATH", p)
+    save_rubric_yaml(DEFAULT_RUBRIC_YAML)
+    assert p.exists()
+    r = load_rubric("default")
+    assert r["judge_model"] == DEFAULT_RUBRIC["judge_model"]
+
+
+# ── 3. Rate-limit guard ─────────────────────────────────────────────────────
+
+
+def test_rate_limiter_allows_up_to_cap_then_blocks_in_window():
+    rl = _RateLimiter(cap=100)
+    fixed_now = 1_700_000_000.0
+    for _ in range(100):
+        assert rl.allow(now=fixed_now) is True
+    # 101st call within the hour bucket must be denied.
+    assert rl.allow(now=fixed_now + 30) is False
+
+
+def test_rate_limiter_recovers_after_window():
+    rl = _RateLimiter(cap=2)
+    base = 1_700_000_000.0
+    assert rl.allow(now=base) is True
+    assert rl.allow(now=base + 10) is True
+    assert rl.allow(now=base + 20) is False
+    # Past the 1-hour window — old hits dropped.
+    assert rl.allow(now=base + 3601) is True
+
+
+def test_runner_skips_when_rate_limit_exhausted():
+    """End-to-end: a runner with an exhausted limiter returns a skip
+    (not a failure) so the scheduler retries on the next tick."""
+    rl = _RateLimiter(cap=1)
+    rl.allow()  # burn the single slot
+    store = _FakeStore(_events_v3_shape())
+    runner = EvalRunner(rate_limiter=rl, store=store)
+    res = runner.score_session("s-1", judge_call=lambda *a, **kw: "SCORE: 5\nREASON: ok")
+    assert res is not None
+    assert res.skipped is True
+    assert "rate limit" in (res.skip_reason or "")
+    assert res.score is None
+    # Nothing persisted — the row stays NULL for the next pass.
+    assert store.persisted == []
+
+
+# ── 4. Skip trivial sessions ────────────────────────────────────────────────
+
+
+def test_skip_trivial_session_under_min_tokens():
+    """Sessions with <10 tokens are heartbeat/smoke pings — score them and
+    you skew the rubric average."""
+    tiny = [{
+        "session_id":  "s-tiny",
+        "event_type":  "prompt.submitted",
+        "ts":          "2026-05-17T19:00:00+00:00",
+        "data":        {"finalPromptText": "hi"},
+        "token_count": 2,
+    }]
+    store = _FakeStore(tiny)
+    called = {"n": 0}
+    def _fake_judge(*a, **kw):
+        called["n"] += 1
+        return "SCORE: 5\nREASON: x"
+    runner = EvalRunner(store=store)
+    res = runner.score_session("s-tiny", judge_call=_fake_judge)
+    assert res is not None
+    assert res.skipped is True
+    assert "trivial" in (res.skip_reason or "")
+    # No judge call → no spend.
+    assert called["n"] == 0
+    assert store.persisted == []
+
+
+# ── 5. Judge LLM failure ────────────────────────────────────────────────────
+
+
+def test_judge_failure_returns_null_score_and_logs(caplog):
+    store = _FakeStore(_events_v3_shape())
+    runner = EvalRunner(store=store)
+    def _exploding_judge(model, prompt, *, timeout):
+        raise RuntimeError("judge offline")
+    with caplog.at_level("WARNING", logger="clawmetry.eval_runner"):
+        res = runner.score_session("s-1", judge_call=_exploding_judge)
+    assert res is not None
+    assert res.score is None
+    assert res.skipped is False  # not a skip — a failure we want to retry
+    assert "RuntimeError" in (res.skip_reason or "")
+    # No DuckDB write on failure — the row stays NULL.
+    assert store.persisted == []
+    # Warning was logged so ops can see the judge outage.
+    assert any("judge call failed" in r.message for r in caplog.records)
+
+
+def test_score_persists_when_judge_succeeds():
+    store = _FakeStore(_events_v3_shape())
+    runner = EvalRunner(store=store)
+    res = runner.score_session(
+        "s-1",
+        judge_call=lambda *a, **kw: "SCORE: 4\nREASON: Solid haiku.",
+    )
+    assert res is not None
+    assert res.score == 4.0
+    assert res.reason == "Solid haiku."
+    assert len(store.persisted) == 1
+    p = store.persisted[0]
+    assert p["session_id"] == "s-1"
+    assert p["score"] == 4.0
+    assert p["judge_model"] == DEFAULT_RUBRIC["judge_model"]
+
+
+# ── 6. Aggregate summary ────────────────────────────────────────────────────
+#
+# Exercises ``LocalStore.query_eval_summary`` end-to-end against a real
+# DuckDB file so we catch quantile/AVG regressions. Uses a tmp DB so
+# nothing touches the user's clawmetry.duckdb.
+
+
+def test_eval_summary_avg_matches_persisted_scores(tmp_path, monkeypatch):
+    db_path = tmp_path / "clawmetry.duckdb"
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(db_path))
+    # Force module-level singletons to re-init against the tmp path.
+    from clawmetry import local_store
+    monkeypatch.setattr(local_store, "DB_PATH", db_path)
+    monkeypatch.setattr(local_store, "_STORE", None, raising=False)
+    store = local_store.LocalStore()
+    # Seed three completed sessions with known scores.
+    now_iso = "2026-05-17T19:00:00+00:00"
+    with store._write_lock:
+        for sid, tok in [("a", 50), ("b", 60), ("c", 70)]:
+            store._conn.execute(
+                """
+                INSERT INTO sessions
+                  (agent_type, session_id, node_id, agent_id, started_at,
+                   last_active_at, ended_at, status, total_tokens, updated_at)
+                VALUES ('openclaw', ?, 'node-x', 'main', ?, ?, ?, 'completed', ?, ?)
+                """,
+                [sid, now_iso, now_iso, now_iso, tok, int(time.time() * 1000)],
+            )
+    store.persist_eval_score(session_id="a", score=5.0, reason="r", judge_model="m", scored_at=1, rubric="default")
+    store.persist_eval_score(session_id="b", score=3.0, reason="r", judge_model="m", scored_at=2, rubric="default")
+    store.persist_eval_score(session_id="c", score=4.0, reason="r", judge_model="m", scored_at=3, rubric="default")
+    summary = store.query_eval_summary(window_hours=24 * 365)
+    assert summary["scored"] == 3
+    assert summary["total"] == 3
+    assert summary["avg_score"] == pytest.approx(4.0)
+    # quantiles depend on duckdb's continuous interpolation; just sanity-check bounds.
+    assert 3.0 <= summary["p50"] <= 5.0
+    assert 3.0 <= summary["p10"] <= 5.0
+
+
+# ── Bug-class gate: real v3 event shape extraction ─────────────────────────
+
+
+def test_runner_extracts_v3_prompt_submitted_and_model_completed():
+    """Bug-class gate per ``feedback_synthetic_tests_missed_real_event_shape``.
+    Runner MUST handle ``prompt.submitted`` (v3) and ``model.completed``
+    (v3) shapes — earlier ClawMetry fast-paths silently returned zeros
+    because they only knew the synthetic ``message`` shape.
+    """
+    store = _FakeStore(_events_v3_shape())
+    runner = EvalRunner(store=store)
+    captured = {}
+    def _capturing_judge(model, prompt, *, timeout):
+        captured["prompt"] = prompt
+        return "SCORE: 5\nREASON: ok"
+    res = runner.score_session("s-1", judge_call=_capturing_judge)
+    assert res is not None and res.score == 5.0
+    # The judge prompt must include BOTH the user input (from
+    # prompt.submitted.finalPromptText) and the model output (from
+    # model.completed.output) — proving the v3 extractor works.
+    assert "haiku about Rust" in captured["prompt"]
+    assert "Borrow checker" in captured["prompt"]
+
+
+# ── Env-switch disable ──────────────────────────────────────────────────────
+
+
+def test_disabled_env_var_short_circuits(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_EVALS_ENABLED", "0")
+    store = _FakeStore(_events_v3_shape())
+    runner = EvalRunner(store=store)
+    res = runner.score_session(
+        "s-1",
+        judge_call=lambda *a, **kw: "SCORE: 5\nREASON: x",
+    )
+    assert res is None
+    assert store.persisted == []
+    assert eval_runner.is_enabled() is False
+
+
+def test_enabled_by_default_when_env_unset(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_EVALS_ENABLED", raising=False)
+    assert eval_runner.is_enabled() is True
+
+
+# ── Live-API smoke (gated on CI_ANTHROPIC_API_KEY) ─────────────────────────
+
+
+@pytest.mark.skipif(
+    not os.environ.get("CI_ANTHROPIC_API_KEY"),
+    reason="CI_ANTHROPIC_API_KEY not set — skipping live judge call",
+)
+def test_live_haiku_judge_round_trip(monkeypatch):
+    """End-to-end test against the real Anthropic Haiku endpoint. Gated
+    behind CI_ANTHROPIC_API_KEY so push-CI doesn't burn credits."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", os.environ["CI_ANTHROPIC_API_KEY"])
+    store = _FakeStore(_events_v3_shape())
+    runner = EvalRunner(store=store)
+    res = runner.score_session("s-1")
+    assert res is not None
+    # A live Haiku run on the canned haiku above should produce a numeric
+    # score; tolerate any value in band rather than asserting equality.
+    if res.score is not None:
+        assert 0.0 <= res.score <= 5.0


### PR DESCRIPTION
## Summary

Phase 1 of 4 for ClawMetry evals (PRD #1619). Auto-scoring with LLM-as-judge on every completed session, using a configurable rubric. Marketing line: *evals where your prompts never leave your machine.*

- **Local-first MOAT play.** Every competitor (LangSmith, Langfuse, Phoenix, Helicone) cloud-hosts their eval product. ClawMetry runs the judge LLM call on the user's existing API key (same provider routing as `clawmetry/interceptor.py`), persists scores to the local DuckDB, and never roundtrips through cloud for scoring.
- **Composes cleanly with #1614 outcome labeling** (Eng XX's PR #1622, just merged): eval_score columns sit ADJACENT to outcome columns; idempotent ALTER TABLE pattern is the same. Verified by rebasing onto current main and running the outcome + review test suites green.
- **Feeds #1615 Review queue** (Eng YY's PR #1621): the review queue can `ORDER BY eval_score ASC` to surface lowest-quality sessions for human review.

## Architecture

| Layer | File | Notes |
|-------|------|-------|
| Module | `clawmetry/eval_runner.py` | `EvalRunner.score_session()` + rubric loader + rate limiter + judge HTTP call (Anthropic + OpenAI) |
| Schema | `clawmetry/local_store.py` | 5 nullable columns on `sessions`; idempotent ALTER migration; 3 new query methods + 1 writer |
| Scheduler | `clawmetry/sync.py` | Sister of `evaluate_alerts` — every 5 min picks up to 10 unscored completed sessions |
| API | `routes/evals.py` | `/api/evals/recent`, `/api/evals/summary`, `POST /api/evals/rescore/<sid>`, GET+POST `/api/evals/rubric` |
| Proxy | `routes/local_query.py` | 4 new allowlisted methods so dashboard can read scores cross-process |
| UI | `dashboard.py` + `clawmetry/static/js/app.js` | Overview tile, per-session Score pill, rubric editor modal |

## Cost model

- **Default judge:** `claude-haiku-4-5` (~$0.001 per session scored).
- **Typical workload:** 247 sessions/day × $0.001 = **$0.25/day per user**.
- **Worst case:** rate limit ceiling of 100 calls/hour = **$2.40/day per user**.
- **Trivial-session guard:** sessions <10 tokens are skipped (no judge call).
- **Cost guard verification:** unit test asserts the 101st call within a 1-hour window is denied (`test_rate_limiter_allows_up_to_cap_then_blocks_in_window`).

## How to disable

```bash
export CLAWMETRY_EVALS_ENABLED=0
```

Tested via `test_disabled_env_var_short_circuits` — runner returns `None` cleanly, no DuckDB write, no judge call.

## Bug-class gate (real v3 event shapes)

Transcript extraction handles real OpenClaw v3 event shapes (`prompt.submitted`, `model.completed`, `assistant`) plus legacy synthetic `message` — same canonical union-set pattern as `_ASSISTANT_EVENT_TYPES` in `local_store.py`. Verified by `test_runner_extracts_v3_prompt_submitted_and_model_completed`.

## Tests

19 unit tests + 1 live-API smoke (gated on `CI_ANTHROPIC_API_KEY`). All 19 pass locally; live smoke skipped by default.

Coverage:
1. Score parsing (5 cases incl. out-of-band rejection)
2. Rubric YAML loading (default + custom + partial-override + round-trip)
3. Rate-limit guard (cap, recovery, end-to-end skip)
4. Trivial session skip (<10 tokens)
5. Judge LLM failure (graceful — NULL score + warning log, no persist)
6. Aggregate summary against real DuckDB
7. Real v3 event-shape extraction
8. Env-switch disable + default-on

Plus regression check: re-ran 41 `test_local_store*` tests and 34 outcome+review tests after rebase — all green.

## Test plan

- [ ] `pytest tests/test_eval_runner.py` — 19/19 pass
- [ ] `pytest tests/test_local_store.py tests/test_outcome_classifier.py tests/test_review_queue.py` — confirms schema composition with #1614 + #1615
- [ ] `python3 -c "import dashboard"` clean
- [ ] Manual: set ANTHROPIC_API_KEY, run daemon, observe `/api/evals/summary` populated after the 5-min scheduler tick
- [ ] Manual: edit rubric via overview-tile modal, verify `~/.clawmetry/evals.yaml` round-trips

## Follow-ups (out of scope for Phase 1)

- Phase 2: Golden test sets + CLI runner + release-gating Action
- Phase 3: Regression-replay (re-run yesterday's fails with new prompts)
- Phase 4: A/B online evals
- `eval_history` table for time-series of re-scores (Phase 1 keeps latest-only)

Refs #1619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)