### PR TITLE
fix(sync): AESGCM encryption failure → DLQ, not silent-drop (closes #1601)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -124,7 +124,7 @@ LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 # ── Two-layer schema (multi-agent) ──────────────────────────────────────────
 #
@@ -578,6 +578,30 @@ _DDL = [
         applied_at BIGINT NOT NULL
     )
     """,
+    # ── Sync dead-letter queue (#1601) ─────────────────────────────────────
+    # Persists payloads whose AES-GCM encryption raised inside the cloud
+    # POST path (rare: malformed payload, key rotation race, corrupt key).
+    # Survives daemon restart so a transient bad-key window doesn't
+    # silently lose batches. Replayed on every sync tick; rows are deleted
+    # only after a successful re-encrypt+POST. ``attempts`` lets the
+    # replayer abandon a permanently-poisoned row after N tries instead of
+    # spinning forever.
+    """
+    CREATE TABLE IF NOT EXISTS sync_dlq (
+        id           VARCHAR PRIMARY KEY,
+        kind         VARCHAR NOT NULL,
+        endpoint     VARCHAR NOT NULL,
+        fname        VARCHAR,
+        node_id      VARCHAR,
+        subagent_id  VARCHAR,
+        payload_json VARCHAR NOT NULL,
+        error        VARCHAR,
+        attempts     INTEGER NOT NULL DEFAULT 0,
+        created_at   BIGINT NOT NULL,
+        last_try_at  BIGINT
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_sync_dlq_created ON sync_dlq(created_at)",
 ]
 
 
@@ -4708,6 +4732,91 @@ class LocalStore:
 
     # ── ops / maintenance ──────────────────────────────────────────────
 
+    # ── Sync dead-letter queue (#1601) ──────────────────────────────────
+    # Used by sync.py when AES-GCM encryption fails on the cloud POST path.
+    # Persistent (DuckDB) so a daemon restart can't lose the row; replayed
+    # on every sync tick. ``dlq_enqueue`` is idempotent on ``id``.
+
+    def dlq_enqueue(
+        self,
+        *,
+        dlq_id: str,
+        kind: str,
+        endpoint: str,
+        payload_json: str,
+        fname: str | None = None,
+        node_id: str | None = None,
+        subagent_id: str | None = None,
+        error: str = "",
+    ) -> None:
+        """Persist a payload that failed encryption. Idempotent on dlq_id."""
+        if self._read_only:
+            raise RuntimeError("local_store: dlq_enqueue requires writer mode")
+        now = int(time.time() * 1000)
+        with self._write_lock:
+            self._conn.execute(
+                """
+                INSERT INTO sync_dlq
+                  (id, kind, endpoint, fname, node_id, subagent_id,
+                   payload_json, error, attempts, created_at, last_try_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, NULL)
+                ON CONFLICT (id) DO UPDATE SET
+                  error = excluded.error,
+                  last_try_at = excluded.created_at
+                """,
+                [dlq_id, kind, endpoint, fname, node_id, subagent_id,
+                 payload_json, error[:2000], now],
+            )
+
+    def dlq_list(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        """Oldest-first list of pending DLQ rows for the replayer."""
+        rows = self._fetch(
+            """
+            SELECT id, kind, endpoint, fname, node_id, subagent_id,
+                   payload_json, attempts, created_at
+            FROM sync_dlq
+            ORDER BY created_at ASC
+            LIMIT ?
+            """,
+            [int(limit)],
+        )
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            out.append({
+                "id": r[0], "kind": r[1], "endpoint": r[2],
+                "fname": r[3], "node_id": r[4], "subagent_id": r[5],
+                "payload_json": r[6], "attempts": int(r[7] or 0),
+                "created_at": int(r[8] or 0),
+            })
+        return out
+
+    def dlq_mark_attempt(self, dlq_id: str, error: str = "") -> None:
+        """Record a failed replay attempt (keep the row, bump attempts)."""
+        if self._read_only:
+            raise RuntimeError("local_store: dlq_mark_attempt requires writer mode")
+        with self._write_lock:
+            self._conn.execute(
+                """
+                UPDATE sync_dlq
+                SET attempts = attempts + 1,
+                    last_try_at = ?,
+                    error = ?
+                WHERE id = ?
+                """,
+                [int(time.time() * 1000), error[:2000], dlq_id],
+            )
+
+    def dlq_delete(self, dlq_id: str) -> None:
+        """Drop a DLQ row after a successful replay (or permanent abandon)."""
+        if self._read_only:
+            raise RuntimeError("local_store: dlq_delete requires writer mode")
+        with self._write_lock:
+            self._conn.execute("DELETE FROM sync_dlq WHERE id = ?", [dlq_id])
+
+    def dlq_count(self) -> int:
+        rows = self._fetch("SELECT COUNT(*) FROM sync_dlq", [])
+        return int(rows[0][0]) if rows else 0
+
     def health(self) -> dict[str, Any]:
         """Snapshot of store state — for the /local/health endpoint and the
         dashboard footer."""
@@ -4734,6 +4843,7 @@ class LocalStore:
             "ring_dropped_total": dropped,
             "schema_version": SCHEMA_VERSION,
             "last_flush_ago_s": round(time.monotonic() - self._last_flush_ts, 2),
+            "sync_dlq_depth": self.dlq_count(),
         }
 
     def vacuum(self, *, prune_to_bytes: int | None = None) -> dict[str, Any]:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -540,6 +540,141 @@ def decrypt_payload(blob: str, key_b64: str) -> dict:
     return json.loads(cipher.decrypt(nonce, ct, None))
 
 
+# ── Sync DLQ for AES-GCM encryption failures (#1601) ────────────────────────
+# When ``encrypt_payload`` raises inside a write-path POST (rare: corrupt key,
+# key rotation race, payload contains non-JSON-serialisable bytes), the
+# affected batch is parked in the local DuckDB ``sync_dlq`` table instead of
+# being silently dropped. The replay loop (``_dlq_replay``) drains the queue
+# on each sync tick. Persistent across daemon restarts.
+#
+# Metric: ``sync_encryption_failures`` (process-local counter) exposed via
+# ``get_encryption_failure_count`` for dashboards / health probes.
+
+_ENCRYPTION_FAILURE_COUNT = 0
+_DLQ_MAX_ATTEMPTS = int(os.environ.get("CLAWMETRY_SYNC_DLQ_MAX_ATTEMPTS", "10"))
+_DLQ_REPLAY_BATCH = int(os.environ.get("CLAWMETRY_SYNC_DLQ_REPLAY_BATCH", "50"))
+
+
+def get_encryption_failure_count() -> int:
+    """Return the process-local count of AES-GCM encryption failures
+    encountered during write-path sync. Reset on daemon restart; for a
+    durable count consult ``sync_dlq`` row count via local_store.health()."""
+    return _ENCRYPTION_FAILURE_COUNT
+
+
+def _dlq_enqueue_encryption_failure(
+    *,
+    kind: str,
+    endpoint: str,
+    payload: dict,
+    fname: str | None = None,
+    node_id: str | None = None,
+    subagent_id: str | None = None,
+    error: str = "",
+) -> None:
+    """Persist a payload that failed AES-GCM encryption. Best-effort: if the
+    local store itself is unavailable we re-raise so the caller can log."""
+    global _ENCRYPTION_FAILURE_COUNT
+    _ENCRYPTION_FAILURE_COUNT += 1
+    # Stable id: node + fname + first/last event ids if available, else hash.
+    # Makes enqueue idempotent if the same batch fails encryption twice
+    # before the replayer drains the queue.
+    try:
+        body = json.dumps(payload, sort_keys=True, default=str)
+    except Exception:
+        # If even the json dump fails the payload is unrecoverable for cloud;
+        # stash a stringified repr so the user has *something* to debug.
+        body = repr(payload)
+    dlq_id = (
+        f"{kind}:{node_id or 'n'}:{fname or 'f'}:"
+        f"{__import__('hashlib').sha256(body.encode('utf-8', 'replace')).hexdigest()[:16]}"
+    )
+    from clawmetry import local_store as _ls
+    store = _ls.get_store()
+    store.dlq_enqueue(
+        dlq_id=dlq_id,
+        kind=kind,
+        endpoint=endpoint,
+        payload_json=body,
+        fname=fname,
+        node_id=node_id,
+        subagent_id=subagent_id,
+        error=error,
+    )
+
+
+def _dlq_replay(api_key: str, enc_key: str | None) -> int:
+    """Drain the encryption DLQ. Returns the number of rows successfully
+    re-encrypted and POSTed. Called from the sync loop on every tick. Cheap
+    no-op when the queue is empty (single COUNT(*) on a tiny table)."""
+    if not enc_key:
+        return 0  # No key configured — replay is a no-op, rows stay parked.
+    try:
+        from clawmetry import local_store as _ls
+        store = _ls.get_store()
+    except Exception:
+        return 0
+    try:
+        rows = store.dlq_list(limit=_DLQ_REPLAY_BATCH)
+    except Exception as _e:
+        log.debug("dlq_replay: dlq_list failed (continuing): %s", _e)
+        return 0
+    if not rows:
+        return 0
+    replayed = 0
+    for row in rows:
+        dlq_id = row["id"]
+        if row["attempts"] >= _DLQ_MAX_ATTEMPTS:
+            # Abandon rather than spin forever on a permanently-poisoned row.
+            log.error(
+                "sync_dlq: abandoning %s after %d attempts (last err: see DLQ row)",
+                dlq_id, row["attempts"],
+            )
+            try:
+                store.dlq_delete(dlq_id)
+            except Exception:
+                pass
+            continue
+        try:
+            payload = json.loads(row["payload_json"])
+        except Exception as _e:
+            log.warning("sync_dlq: payload not valid JSON for %s — dropping: %s",
+                        dlq_id, _e)
+            try:
+                store.dlq_delete(dlq_id)
+            except Exception:
+                pass
+            continue
+        try:
+            blob = encrypt_payload(payload, enc_key)
+        except Exception as _enc_e:
+            try:
+                store.dlq_mark_attempt(dlq_id, str(_enc_e))
+            except Exception:
+                pass
+            continue  # Still bad key — try next row, leave this one parked.
+        try:
+            _post(
+                row["endpoint"],
+                {"node_id": row["node_id"], "encrypted": True, "blob": blob},
+                api_key,
+            )
+        except Exception as _post_e:
+            try:
+                store.dlq_mark_attempt(dlq_id, f"post: {_post_e}")
+            except Exception:
+                pass
+            continue
+        try:
+            store.dlq_delete(dlq_id)
+        except Exception:
+            pass
+        replayed += 1
+    if replayed:
+        log.info("sync_dlq: replayed %d parked batch(es) to cloud", replayed)
+    return replayed
+
+
 # ── Config ─────────────────────────────────────────────────────────────────────
 
 
@@ -1659,15 +1794,49 @@ def _flush_session_batch(
     #   re-read on next tick). A future PR should add a sidecar cloud-retry
     #   queue keyed on canonical event id. For today the priority is local
     #   correctness; cloud catches up when the user re-syncs from local.
+    # Split encryption from POST so the diagnostic for each path is distinct
+    # and an encryption failure no longer silently drops the batch (#1601).
+    # Encryption can fail on: corrupted/rotated key, payload containing
+    # non-JSON-serialisable bytes, missing cryptography wheel. POST can fail
+    # on: network outage, cloud 5xx. Conflating them sends users on a
+    # wild-goose chase for a network problem when the real issue is the key.
+    blob: str | None = None
+    if enc_key:
+        try:
+            blob = encrypt_payload(payload, enc_key)
+        except Exception as _enc_e:
+            # Persist to local DLQ so the next sync tick (or a daemon restart
+            # after the user rotates the key back) can re-encrypt and POST.
+            # The local DuckDB row is already durable above; this only protects
+            # the cloud side of the pipeline from silent loss.
+            try:
+                _dlq_enqueue_encryption_failure(
+                    kind="session_batch",
+                    endpoint="/ingest/events",
+                    payload=payload,
+                    fname=fname,
+                    node_id=node_id,
+                    subagent_id=subagent_id,
+                    error=str(_enc_e),
+                )
+            except Exception as _dlq_e:
+                log.exception(
+                    "E2E encryption AND DLQ persist both failed for %s "
+                    "(events permanently dropped from cloud): enc=%s dlq=%s",
+                    fname, _enc_e, _dlq_e,
+                )
+            else:
+                log.error(
+                    "E2E encryption failed for %s — batch parked in sync_dlq "
+                    "for replay (key rotation? corrupt key?): %s",
+                    fname, _enc_e,
+                )
+            return
     try:
-        if enc_key:
+        if blob is not None:
             _post(
                 "/ingest/events",
-                {
-                    "node_id": node_id,
-                    "encrypted": True,
-                    "blob": encrypt_payload(payload, enc_key),
-                },
+                {"node_id": node_id, "encrypted": True, "blob": blob},
                 api_key,
             )
         else:
@@ -8012,6 +8181,16 @@ def run_daemon() -> None:
                 capture_gateway_metric(config)
             except Exception as _gm_e:
                 log.debug("gateway.metric capture failed (continuing): %s", _gm_e)
+
+            # ── Drain sync DLQ (#1601) ──
+            # Replay any batches that previously failed AES-GCM encryption
+            # (e.g. a key rotation race). Cheap no-op when the queue is
+            # empty (single COUNT(*) on a tiny table). Failure here is
+            # non-fatal — bad rows stay parked and we try again next tick.
+            try:
+                _dlq_replay(config.get("api_key"), config.get("encryption_key"))
+            except Exception as _dlq_e:
+                log.debug("sync_dlq replay failed (continuing): %s", _dlq_e)
 
             ev = sync_sessions(config, state, paths)
             ev += sync_claude_cli_sessions(config, state, paths)

--- a/tests/test_aesgcm_swallow_fix.py
+++ b/tests/test_aesgcm_swallow_fix.py
@@ -1,0 +1,310 @@
+"""Regression test for issue #1601 — AES-GCM encryption failure inside
+``_flush_session_batch`` silently swallowed the entire batch.
+
+## The bug (pre-fix)
+
+``clawmetry/sync.py::_flush_session_batch`` wrapped BOTH ``encrypt_payload``
+and ``_post`` in a single ``try/except``. When encryption raised (corrupt
+key, key rotation race, payload contains non-JSON-serialisable bytes), the
+same ``except`` caught it and logged ``cloud /ingest/events POST failed`` —
+falsely pointing at the network. Local DuckDB was already durable above,
+so the caller's cursor advanced normally and the events were permanently
+dropped from the cloud side until the user manually rewound state.json.
+
+## The fix (this PR)
+
+1. Split the try/except: encryption failure is a distinct error path with
+   a distinct log line and a persistent DLQ enqueue.
+2. ``sync_dlq`` table in local_store.py holds the failed payload + ctx.
+3. ``_dlq_replay`` drains the queue on every sync tick. Re-encrypt
+   succeeds the moment the key is rotated back / patched.
+4. DLQ is in DuckDB → survives daemon restart (key requirement from #1601).
+5. ``get_encryption_failure_count()`` exposes a per-process counter for
+   ops dashboards.
+
+## Scenarios
+
+1. Normal encrypt → no DLQ row (happy path stays untouched).
+2. Encrypt fails (mocked) → payload persisted to DLQ.
+3. Replay on next sync cycle re-encrypts and POSTs → DLQ drained.
+4. DLQ row survives a real subprocess restart of the daemon.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+# ── Fixture infrastructure ──────────────────────────────────────────────────
+
+def _reload_local_store(tmp_path, monkeypatch):
+    """Point local_store at an isolated DuckDB file and reload the module
+    so module-level singletons see the new path. Returns the reloaded
+    module."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH",
+        str(tmp_path / "clawmetry.duckdb"),
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    return ls
+
+
+def _reload_sync(monkeypatch):
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+    return sync
+
+
+# ── Scenario 1: happy path — no DLQ row ─────────────────────────────────────
+
+def test_normal_encrypt_writes_no_dlq_row(tmp_path, monkeypatch):
+    ls = _reload_local_store(tmp_path, monkeypatch)
+    sync = _reload_sync(monkeypatch)
+
+    posted: list[tuple] = []
+    monkeypatch.setattr(sync, "_post",
+                        lambda path, body, key: posted.append((path, body)))
+    monkeypatch.setattr(sync, "_local_ingest_session_batch", lambda *a, **k: None)
+
+    # Real AES key (any 32-byte base64url string works).
+    enc_key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+
+    sync._flush_session_batch(
+        [{"id": "ev-1", "type": "message"}],
+        "sess-1.jsonl",
+        api_key="k",
+        enc_key=enc_key,
+        node_id="n1",
+    )
+
+    store = ls.get_store()
+    try:
+        assert store.dlq_count() == 0, "happy path should not populate DLQ"
+        assert len(posted) == 1
+        assert posted[0][0] == "/ingest/events"
+        assert posted[0][1]["encrypted"] is True
+        assert isinstance(posted[0][1]["blob"], str)
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass
+
+
+# ── Scenario 2: encrypt fails → persisted to DLQ, not lost ──────────────────
+
+def test_encrypt_failure_persists_to_dlq(tmp_path, monkeypatch):
+    ls = _reload_local_store(tmp_path, monkeypatch)
+    sync = _reload_sync(monkeypatch)
+
+    monkeypatch.setattr(sync, "_local_ingest_session_batch", lambda *a, **k: None)
+    posted: list[tuple] = []
+    monkeypatch.setattr(sync, "_post",
+                        lambda path, body, key: posted.append((path, body)))
+
+    def _boom(payload, key):
+        raise RuntimeError("simulated AESGCM failure (corrupt key)")
+    monkeypatch.setattr(sync, "encrypt_payload", _boom)
+
+    before = sync.get_encryption_failure_count()
+    sync._flush_session_batch(
+        [{"id": "ev-2", "type": "message"}],
+        "sess-2.jsonl",
+        api_key="k",
+        enc_key="any-non-empty-key",
+        node_id="n1",
+    )
+
+    store = ls.get_store()
+    try:
+        # Critical: the silent-swallow was a write-path bug. After the fix
+        # the batch is durable in the DLQ table — NOT silently dropped.
+        assert store.dlq_count() == 1, "encrypt failure must persist to DLQ"
+        rows = store.dlq_list()
+        assert rows[0]["fname"] == "sess-2.jsonl"
+        assert rows[0]["node_id"] == "n1"
+        assert rows[0]["endpoint"] == "/ingest/events"
+        # Payload round-trips intact — the replayer needs it.
+        payload = json.loads(rows[0]["payload_json"])
+        assert payload["session_file"] == "sess-2.jsonl"
+        assert payload["events"][0]["id"] == "ev-2"
+        # POST must NOT have been attempted (no blob to send).
+        assert posted == [], "POST must be skipped when encryption fails"
+        # Counter incremented (ops metric).
+        assert sync.get_encryption_failure_count() == before + 1
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass
+
+
+# ── Scenario 3: replay on next sync tick drains the DLQ ─────────────────────
+
+def test_dlq_replay_drains_on_next_cycle(tmp_path, monkeypatch):
+    ls = _reload_local_store(tmp_path, monkeypatch)
+    sync = _reload_sync(monkeypatch)
+
+    # First call: encryption fails → row parked in DLQ.
+    monkeypatch.setattr(sync, "_local_ingest_session_batch", lambda *a, **k: None)
+    monkeypatch.setattr(sync, "_post", lambda *a, **k: None)
+    monkeypatch.setattr(sync, "encrypt_payload",
+                        lambda payload, key: (_ for _ in ()).throw(
+                            RuntimeError("transient bad-key window")))
+
+    enc_key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+    sync._flush_session_batch(
+        [{"id": "ev-3", "type": "message"}],
+        "sess-3.jsonl",
+        api_key="k",
+        enc_key=enc_key,
+        node_id="n1",
+    )
+    store = ls.get_store()
+    assert store.dlq_count() == 1, "precondition: DLQ has the parked batch"
+
+    # Second call: user rotates the key back / patches the bug.
+    # Restore the real encryptor + capture the POST.
+    importlib.reload(sync)  # gets real encrypt_payload back
+    posted: list[tuple] = []
+    monkeypatch.setattr(sync, "_post",
+                        lambda path, body, key: posted.append((path, body)))
+
+    replayed = sync._dlq_replay(api_key="k", enc_key=enc_key)
+    try:
+        assert replayed == 1, f"expected 1 replay, got {replayed}"
+        assert store.dlq_count() == 0, "DLQ must be drained after success"
+        assert len(posted) == 1
+        assert posted[0][0] == "/ingest/events"
+        assert posted[0][1]["encrypted"] is True
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass
+
+
+# ── Scenario 4: DLQ row survives a real daemon restart (subprocess) ─────────
+
+def test_dlq_survives_daemon_restart(tmp_path):
+    """End-to-end persistence test using two real Python subprocesses.
+
+    Per ``feedback_synthetic_tests_missed_real_event_shape.md`` — a mocked
+    "restart" wouldn't exercise the real DuckDB file path. The whole point
+    of moving the DLQ from in-memory to DuckDB is that the row survives
+    ``kill -9`` + relaunch. Verify that explicitly."""
+    db = tmp_path / "clawmetry.duckdb"
+
+    # Process A: enqueue a DLQ row, then exit.
+    write_script = textwrap.dedent(f"""
+        import importlib, os, sys
+        os.environ['CLAWMETRY_LOCAL_STORE_PATH'] = {str(db)!r}
+        os.environ['CLAWMETRY_LOCAL_FLUSH_SECS'] = '0.05'
+        sys.path.insert(0, {os.getcwd()!r})
+        import clawmetry.local_store as ls
+        importlib.reload(ls)
+        import clawmetry.sync as sync
+        importlib.reload(sync)
+
+        def _boom(payload, key):
+            raise RuntimeError('subproc encrypt failure')
+        sync.encrypt_payload = _boom
+        sync._local_ingest_session_batch = lambda *a, **k: None
+        sync._post = lambda *a, **k: None
+
+        sync._flush_session_batch(
+            [{{'id': 'ev-restart', 'type': 'message'}}],
+            'sess-restart.jsonl',
+            api_key='k',
+            enc_key='any-non-empty-key',
+            node_id='n1',
+        )
+        store = ls.get_store()
+        print('DLQ_DEPTH_A=' + str(store.dlq_count()))
+        store.stop(flush=True)
+    """)
+    a = subprocess.run(
+        [sys.executable, "-c", write_script],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert a.returncode == 0, f"write subproc failed: {a.stderr}"
+    assert "DLQ_DEPTH_A=1" in a.stdout, f"DLQ not enqueued: {a.stdout}"
+
+    # Process B: open the SAME DuckDB file and read the DLQ.
+    read_script = textwrap.dedent(f"""
+        import importlib, os, sys
+        os.environ['CLAWMETRY_LOCAL_STORE_PATH'] = {str(db)!r}
+        sys.path.insert(0, {os.getcwd()!r})
+        import clawmetry.local_store as ls
+        importlib.reload(ls)
+        store = ls.get_store()
+        rows = store.dlq_list()
+        print('DLQ_DEPTH_B=' + str(store.dlq_count()))
+        if rows:
+            print('FNAME=' + str(rows[0]['fname']))
+            print('ENDPOINT=' + str(rows[0]['endpoint']))
+        store.stop(flush=False)
+    """)
+    b = subprocess.run(
+        [sys.executable, "-c", read_script],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert b.returncode == 0, f"read subproc failed: {b.stderr}"
+    assert "DLQ_DEPTH_B=1" in b.stdout, (
+        f"DLQ did NOT survive daemon restart — out:\n{b.stdout}\nerr:\n{b.stderr}"
+    )
+    assert "FNAME=sess-restart.jsonl" in b.stdout
+    assert "ENDPOINT=/ingest/events" in b.stdout
+
+
+# ── Bonus: DLQ replayer abandons permanently-poisoned rows ──────────────────
+
+def test_dlq_abandons_after_max_attempts(tmp_path, monkeypatch):
+    """If encryption keeps failing (truly corrupt key never rotated back),
+    the replayer must NOT spin forever on the same row. After
+    ``_DLQ_MAX_ATTEMPTS`` it deletes the row and logs an abandonment.
+    Prevents the DLQ from becoming a runaway log spammer."""
+    ls = _reload_local_store(tmp_path, monkeypatch)
+    sync = _reload_sync(monkeypatch)
+
+    monkeypatch.setattr(sync, "_local_ingest_session_batch", lambda *a, **k: None)
+    monkeypatch.setattr(sync, "_post", lambda *a, **k: None)
+    monkeypatch.setattr(sync, "encrypt_payload",
+                        lambda payload, key: (_ for _ in ()).throw(
+                            RuntimeError("permanent corrupt key")))
+
+    # Park one row.
+    sync._flush_session_batch(
+        [{"id": "ev-abandon", "type": "message"}],
+        "sess-abandon.jsonl",
+        api_key="k",
+        enc_key="any-key",
+        node_id="n1",
+    )
+    store = ls.get_store()
+    assert store.dlq_count() == 1
+
+    # Shrink max-attempts so the test runs fast.
+    monkeypatch.setattr(sync, "_DLQ_MAX_ATTEMPTS", 2)
+    # Three replay cycles: first two bump attempts to 2, third sees
+    # attempts>=max and abandons.
+    for _ in range(3):
+        sync._dlq_replay(api_key="k", enc_key="any-key")
+
+    try:
+        assert store.dlq_count() == 0, (
+            "abandoned row must be deleted after exceeding max attempts"
+        )
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

Closes #1601. Sibling of #1590 (concurrent flush race, PR #1608) and #1593 (SIGTERM ring drop, PR #1612). Rounds out the **A-family (write-path data loss)** silent-failure inventory surfaced by Eng NN's failure-mode taxonomy.

## The bug

`_flush_session_batch` wrapped BOTH `encrypt_payload` and `_post` in one `try/except`. When AES-GCM encryption raised (corrupt key, key rotation race, payload contains non-JSON-serialisable bytes), the same `except` logged `cloud /ingest/events POST failed` — pointing the user at the network instead of the real cause (the key). Local DuckDB was already durable above, the caller's cursor advanced, and the events were **permanently dropped from the cloud side**.

## The fix

1. **Split the try/except in `_flush_session_batch`.** Encryption gets its own block with a distinct `E2E encryption failed for X — key rotation?` log line. POST gets the existing block, unchanged.
2. **Persistent DLQ.** New `sync_dlq` table in `local_store.py` holds failed payloads + context (kind, endpoint, fname, node_id, attempts). **DuckDB, not in-memory** → survives daemon restart (explicit requirement from #1601).
3. **Replayer.** `_dlq_replay()` drains the queue on every sync tick (right after `capture_gateway_metric`, before `sync_sessions`). Cheap no-op when empty. Re-encrypts + POSTs; deletes on success. Abandons rows after `_DLQ_MAX_ATTEMPTS` (default 10) so a permanently poisoned row can't spin forever.
4. **Metric.** `get_encryption_failure_count()` exposes a per-process counter; `health()["sync_dlq_depth"]` exposes the durable count.
5. **Schema migration.** `SCHEMA_VERSION` 8 → 9; idempotent `CREATE TABLE IF NOT EXISTS sync_dlq`.

## Audit of sibling silent-swallow patterns

I scanned every `encrypt_payload` callsite in sync.py:

| Line  | Caller                        | Disposition                                                                                                                |
|-------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------|
| 1669  | `_flush_session_batch`        | **Fixed in this PR** — was the write-path bug.                                                                             |
| 4128  | `_flush_log_batch`            | Exception propagates to caller (`sync_logs`), which logs and moves on. Same family; logs are best-effort + re-tailed.      |
| 4759  | `_cache_push_brain`           | Heartbeat cache; refreshed every heartbeat. `return []` is fine — no data loss.                                            |
| 4852  | `_cache_push_memory`          | Heartbeat cache; same as above.                                                                                            |
| 4949  | `_cache_push_channel_status`  | Heartbeat cache.                                                                                                           |
| 5022  | `_cache_push_alert_rules`     | Heartbeat cache.                                                                                                           |
| 5251  | `_cache_push_approvals_queue` | Heartbeat cache.                                                                                                           |
| 5334  | `_dispatch_pending_queries`   | Cloud-requested query; failure is logged and one query is dropped. Acceptable — cloud retries.                              |
| 7451  | `sync_system_snapshot`        | Sibling of the bug. Pre-existing try/except catches encrypt+POST together. **Lower severity** (snapshot is point-in-time + re-emitted every cycle). Worth same treatment in a future PR; out of scope here to keep this one tight. |

## Test plan

`tests/test_aesgcm_swallow_fix.py` — 5 scenarios:

- [x] Normal encrypt → no DLQ row (happy path untouched)
- [x] Encrypt fails (mocked) → DLQ row persisted with full payload
- [x] DLQ replay on next sync cycle drains the queue
- [x] DLQ row survives a real subprocess daemon restart (per `feedback_synthetic_tests_missed_real_event_shape` — mocked restart wouldn't exercise the real DuckDB file path)
- [x] Abandons permanently-poisoned rows after `_DLQ_MAX_ATTEMPTS`

Sibling tests still green:
- [x] `test_local_store_concurrent_flush_1590.py` (6 tests)
- [x] `test_sigterm_ring_flush.py` (5 tests)
- [x] **`test_moat_bug_class_v3_event_shape_gate.py`** (3 tests — **bug-class gate passes**)
- [x] `python3 -c "import dashboard"` clean
- [x] Pre-existing test failures verified unchanged via `git stash` compare (72 failures pre-PR → 71 failures post-PR; no new regressions)

## DO NOT MERGE

Per task instructions — opened for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)