### PR TITLE
fix(sync): system_snapshot encryption swallow → DLQ (sister of #1601)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7611,14 +7611,45 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     except Exception as _e:
         log.debug("local_store: snapshot/subagent write-through failed: %s", _e)
 
+    # Split encryption from POST so the two failure modes have distinct
+    # diagnostics + dispositions (sibling of #1601 / PR #1624).
+    #   - Encryption failure → park in sync_dlq (corrupt/rotated key, payload
+    #     containing non-JSON-serialisable bytes, missing cryptography wheel).
+    #     The next sync tick's _dlq_replay picks it up automatically — the
+    #     drainer is kind-agnostic and uses each row's stored endpoint.
+    #   - POST failure → existing log.warning + drop. Lower severity than the
+    #     session-batch path because the snapshot is re-emitted every cycle
+    #     (no cumulative loss); cloud catches up on the next heartbeat.
+    blob: str | None = None
+    try:
+        blob = encrypt_payload(payload, enc_key)
+    except Exception as _enc_e:
+        try:
+            _dlq_enqueue_encryption_failure(
+                kind="system_snapshot",
+                endpoint="/ingest/system-snapshot",
+                payload=payload,
+                node_id=node_id,
+                error=str(_enc_e),
+            )
+        except Exception as _dlq_e:
+            log.exception(
+                "E2E encryption AND DLQ persist both failed for "
+                "system_snapshot (snapshot dropped from cloud; next cycle "
+                "will re-emit): enc=%s dlq=%s",
+                _enc_e, _dlq_e,
+            )
+        else:
+            log.error(
+                "E2E encryption failed for system_snapshot — parked in "
+                "sync_dlq for replay (key rotation? corrupt key?): %s",
+                _enc_e,
+            )
+        return 0
     try:
         _post(
             "/ingest/system-snapshot",
-            {
-                "node_id": node_id,
-                "encrypted": True,
-                "blob": encrypt_payload(payload, enc_key),
-            },
+            {"node_id": node_id, "encrypted": True, "blob": blob},
             api_key,
         )
         return 1

--- a/tests/test_system_snapshot_dlq.py
+++ b/tests/test_system_snapshot_dlq.py
@@ -1,0 +1,208 @@
+"""Regression test for the ``sync_system_snapshot`` sibling of #1601.
+
+PR #1624 fixed the silent AES-GCM swallow inside ``_flush_session_batch``
+but explicitly called out ``sync_system_snapshot`` (sync.py line ~7451) as
+sharing the same anti-pattern at lower severity (snapshot is re-emitted
+every cycle, so a single drop doesn't cause cumulative loss). This PR
+applies the same DLQ pattern so the *first* encryption failure is also
+visible + recoverable instead of silently logged as a network error.
+
+## The bug (pre-fix)
+
+``sync_system_snapshot`` wrapped BOTH ``encrypt_payload`` and ``_post`` in
+one ``try/except Exception as e``. A corrupt / rotated key raised inside
+``encrypt_payload``, the same ``except`` caught it and logged ``System
+snapshot sync error`` — pointing the user at the network instead of the
+real cause (the key). The snapshot for that cycle was lost.
+
+## The fix (this PR)
+
+Sister of #1624: split the try/except. Encryption failure → persist to
+``sync_dlq`` via ``_dlq_enqueue_encryption_failure`` with
+``kind='system_snapshot'``. POST failure → existing log.warning + drop
+(acceptable, snapshot re-emitted next cycle). The kind-agnostic
+``_dlq_replay`` drainer added in #1624 picks up these rows on the next
+sync tick — no drainer change needed.
+
+## Scenarios
+
+1. Happy path → snapshot encrypts + POSTs, no DLQ row.
+2. Encrypt fails (mocked) → DLQ row created with ``kind='system_snapshot'``.
+3. Replay drains the DLQ on next cycle once the key recovers.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+# ── Fixture infrastructure (mirrors test_aesgcm_swallow_fix.py) ─────────────
+
+def _reload_local_store(tmp_path, monkeypatch):
+    """Isolate the DuckDB file per-test so DLQ counts don't leak across
+    test runs / parallel xdist workers."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH",
+        str(tmp_path / "clawmetry.duckdb"),
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    return ls
+
+
+def _reload_sync(monkeypatch):
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+    return sync
+
+
+def _minimal_config():
+    """Smallest config that lets ``sync_system_snapshot`` reach the
+    encrypt/POST step without bailing on the trial-paused / no-key guards.
+    The 64-char hex string is decoded base64-style by ``encrypt_payload``;
+    any 32-byte key works for the happy-path test."""
+    return {
+        "api_key": "k",
+        "node_id": "n1",
+        "encryption_key":
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+    }
+
+
+# ── Scenario 1: happy path → snapshot encrypts + POSTs, no DLQ row ──────────
+
+def test_snapshot_happy_path_no_dlq(tmp_path, monkeypatch):
+    ls = _reload_local_store(tmp_path, monkeypatch)
+    sync = _reload_sync(monkeypatch)
+
+    posted: list[tuple] = []
+    monkeypatch.setattr(sync, "_post",
+                        lambda path, body, key: posted.append((path, body)))
+    # Force the trial gate open so the function doesn't early-return.
+    monkeypatch.setattr(sync, "_sync_allowed", lambda: True)
+
+    rc = sync.sync_system_snapshot(
+        _minimal_config(),
+        state={"spending": {"today": 0, "week": 0, "month": 0}},
+        paths={"workspace": str(tmp_path), "sessions_dir": str(tmp_path)},
+    )
+
+    store = ls.get_store()
+    try:
+        assert rc == 1, "happy path must return 1 (POSTed)"
+        assert store.dlq_count() == 0, "happy path must not populate DLQ"
+        assert len(posted) == 1
+        assert posted[0][0] == "/ingest/system-snapshot"
+        assert posted[0][1]["encrypted"] is True
+        assert isinstance(posted[0][1]["blob"], str)
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass
+
+
+# ── Scenario 2: encrypt fails → DLQ entry created with system_snapshot ─────
+
+def test_snapshot_encrypt_failure_persists_to_dlq(tmp_path, monkeypatch):
+    ls = _reload_local_store(tmp_path, monkeypatch)
+    sync = _reload_sync(monkeypatch)
+
+    posted: list[tuple] = []
+    monkeypatch.setattr(sync, "_post",
+                        lambda path, body, key: posted.append((path, body)))
+    monkeypatch.setattr(sync, "_sync_allowed", lambda: True)
+
+    def _boom(payload, key):
+        raise RuntimeError("simulated AESGCM failure (corrupt key)")
+    monkeypatch.setattr(sync, "encrypt_payload", _boom)
+
+    before = sync.get_encryption_failure_count()
+    rc = sync.sync_system_snapshot(
+        _minimal_config(),
+        state={"spending": {"today": 0, "week": 0, "month": 0}},
+        paths={"workspace": str(tmp_path), "sessions_dir": str(tmp_path)},
+    )
+
+    store = ls.get_store()
+    try:
+        # Pre-fix the rc was still 0, but the snapshot was silently lost.
+        # Post-fix the snapshot is durable in DLQ — recoverable on replay.
+        assert rc == 0, "encrypt failure path returns 0"
+        assert store.dlq_count() == 1, "encrypt failure must persist to DLQ"
+        rows = store.dlq_list()
+        assert rows[0]["kind"] == "system_snapshot", (
+            f"DLQ row must be tagged kind=system_snapshot, got {rows[0]['kind']!r}"
+        )
+        assert rows[0]["endpoint"] == "/ingest/system-snapshot"
+        assert rows[0]["node_id"] == "n1"
+        # Payload survives round-trip — the replayer needs it intact.
+        payload = json.loads(rows[0]["payload_json"])
+        assert "system" in payload, "snapshot payload shape preserved"
+        # POST must NOT have been attempted (no blob to send).
+        assert posted == [], "POST must be skipped when encryption fails"
+        # Counter incremented (ops metric shared with session-batch path).
+        assert sync.get_encryption_failure_count() == before + 1
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass
+
+
+# ── Scenario 3: DLQ row drains on next sync cycle once key recovers ─────────
+
+def test_snapshot_dlq_replay_drains_on_next_cycle(tmp_path, monkeypatch):
+    """Confirm the kind-agnostic ``_dlq_replay`` from #1624 picks up the
+    new ``kind='system_snapshot'`` rows without modification. This is the
+    whole reason the drainer is kind-agnostic — sister fixes shouldn't
+    each need their own replayer."""
+    ls = _reload_local_store(tmp_path, monkeypatch)
+    sync = _reload_sync(monkeypatch)
+
+    monkeypatch.setattr(sync, "_sync_allowed", lambda: True)
+    monkeypatch.setattr(sync, "_post", lambda *a, **k: None)
+
+    # Tick 1: encryption fails, snapshot parked in DLQ.
+    monkeypatch.setattr(sync, "encrypt_payload",
+                        lambda payload, key: (_ for _ in ()).throw(
+                            RuntimeError("transient bad-key window")))
+    enc_key = (
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+    )
+    sync.sync_system_snapshot(
+        _minimal_config(),
+        state={"spending": {"today": 0, "week": 0, "month": 0}},
+        paths={"workspace": str(tmp_path), "sessions_dir": str(tmp_path)},
+    )
+    store = ls.get_store()
+    assert store.dlq_count() == 1, "precondition: snapshot parked in DLQ"
+    rows = store.dlq_list()
+    assert rows[0]["kind"] == "system_snapshot"
+    assert rows[0]["endpoint"] == "/ingest/system-snapshot"
+
+    # Tick 2: user rotates the key back. Restore real encrypt_payload by
+    # reloading the module, then capture the POST that the drainer fires.
+    importlib.reload(sync)
+    posted: list[tuple] = []
+    monkeypatch.setattr(sync, "_post",
+                        lambda path, body, key: posted.append((path, body)))
+
+    replayed = sync._dlq_replay(api_key="k", enc_key=enc_key)
+    try:
+        assert replayed == 1, f"expected 1 replay, got {replayed}"
+        assert store.dlq_count() == 0, "DLQ must be drained after success"
+        assert len(posted) == 1
+        # Drainer must route the row to its ORIGINAL endpoint, not the
+        # session-batch endpoint — that's why the row stores it explicitly.
+        assert posted[0][0] == "/ingest/system-snapshot"
+        assert posted[0][1]["encrypted"] is True
+        assert posted[0][1]["node_id"] == "n1"
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass


### PR DESCRIPTION
Sister of #1601 / PR #1624. Eng AD's audit table in #1624 flagged
`sync_system_snapshot` (sync.py line ~7451) as sharing the same
encrypt-and-POST anti-pattern but punted it as a future-PR to keep
the parent PR tight. This is that future PR.

## The bug

`sync_system_snapshot` wrapped BOTH `encrypt_payload` and `_post` in
one `try/except Exception as e`. When AES-GCM encryption raised (corrupt
key, key rotation race, non-JSON-serialisable bytes in payload), the
same `except` caught it and logged `System snapshot sync error` —
pointing the user at the network instead of the key. The snapshot for
that cycle was silently lost.

## Why lower severity than #1601

The snapshot is re-emitted on every sync cycle (per the existing
"snapshot is point-in-time + re-emitted every cycle" comment in
#1624's audit table). A single drop doesn't cause cumulative loss the
way the session-batch path did. Still worth fixing for:

1. Diagnostic clarity — a corrupt-key bug shouldn't masquerade as a
   network outage in the user's logs.
2. Symmetry with #1624 — closing the audit table out cleanly.
3. The first encryption failure becomes recoverable on the next tick
   instead of waiting for the next snapshot cycle.

## The fix

Split the try/except inside `sync_system_snapshot`:

- **Encryption failure** → persist to `sync_dlq` via
  `_dlq_enqueue_encryption_failure(kind='system_snapshot', endpoint=
  '/ingest/system-snapshot', ...)`. Log line clearly labels it as
  encryption, not POST.
- **POST failure** → unchanged `log.warning` + return 0. The snapshot
  is re-emitted next cycle so cloud catches up automatically.

The `_dlq_replay` drainer added in #1624 is kind-agnostic — it iterates
all rows and uses each row's stored `endpoint` + `node_id`. So the new
`kind='system_snapshot'` rows are picked up on the next sync tick
without any drainer change. Test scenario 3 confirms this explicitly.

## Audit of remaining encrypt+POST callsites

Re-walked every `encrypt_payload(` callsite. The full table from #1624
still holds, with one new entry surfaced:

| Line  | Caller                                | Status                                                                                                                            |
|-------|---------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
| 1806  | `_flush_session_batch`                | Fixed in #1624 — split try/except + DLQ enqueue                                                                                   |
| 7625  | `sync_system_snapshot`                | **Fixed in this PR**                                                                                                              |
| 6292  | `sync_memory`                         | **Same anti-pattern — class-bug followup.** encrypt+POST in one try/except. Memory files re-uploaded on change, so single-cycle drop ≈ silent for stable files. Worth a sister PR.       |
| 4297  | `_flush_log_batch`                    | Exception propagates to `sync_logs` (caller logs + moves on). Best-effort logs path; acceptable as-is.                            |
| 4928  | `_cache_push_brain`                   | Heartbeat cache — refreshed every heartbeat. Acceptable.                                                                          |
| 5021  | `_cache_push_memory`                  | Heartbeat cache. Acceptable.                                                                                                      |
| 5118  | `_cache_push_channel_config_status`   | Heartbeat cache. Acceptable.                                                                                                      |
| 5191  | `_cache_push_alert_rules`             | Heartbeat cache. Acceptable.                                                                                                      |
| 5420  | `_cache_push_approvals`               | Heartbeat cache. Acceptable.                                                                                                      |
| 5503  | `_dispatch_pending_queries`           | Cloud-requested query — cloud retries on its side. Acceptable.                                                                    |

**Class-bug followup to open:** `sync_memory` — same DLQ treatment.
Out of scope here to keep this PR tight.

## Test plan

`tests/test_system_snapshot_dlq.py` — 3 scenarios:

- [x] Happy path: snapshot encrypts + POSTs cleanly, no DLQ row
- [x] Encrypt fails (mocked): DLQ entry created with `kind='system_snapshot'`, POST not attempted, ops counter increments
- [x] Replay drains: row consumed on next sync cycle when the key recovers; drainer correctly routes to `/ingest/system-snapshot` (not the session-batch endpoint)

Sister tests still green:
- [x] `tests/test_aesgcm_swallow_fix.py` (5/5)
- [x] `python3 -c "import dashboard"` clean

## Budget

- Production: 36 LOC (budget 80) — small comment block + 30 lines of split try/except
- Tests: 208 LOC including docstring (~110 LOC of actual test bodies; budget 150)

## DO NOT MERGE

Per task instructions — opened for review only.