### PR TITLE
fix(schema): migration-failure version-stamp integrity + auto-tracking test (closes #1602, closes #1627)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -955,7 +955,18 @@ class LocalStore:
             _migrate_legacy_db_path()
         self._conn = _open_connection(read_only=read_only)
         if not read_only:
-            self._migrate()
+            try:
+                self._migrate()
+            except Exception:
+                # Release the file lock so the next boot can open the
+                # db cleanly and retry the migration (#1602). Without
+                # this, a failed __init__ leaves DuckDB holding the
+                # exclusive lock until GC, blocking restart.
+                try:
+                    self._conn.close()
+                except Exception:
+                    pass
+                raise
 
     def _migrate(self) -> None:
         """Bring the store schema up to current SCHEMA_VERSION. Order matters:
@@ -995,12 +1006,16 @@ class LocalStore:
                 cur = self._conn.execute("SELECT MAX(version) AS v FROM schema_version")
                 row = cur.fetchone()
                 current = row[0] if row and row[0] is not None else 0
+                migration_failed = False
                 if current < 7:
                     # v6 → v7: collapse Claude Code event duplicates the three
-                    # ingest paths used to produce (#1232). Wrapped in try/except
-                    # so a regex/lock issue doesn't brick daemon startup — the
-                    # write-side fix in sync.py is the real correctness path; this
-                    # cleanup is opportunistic.
+                    # ingest paths used to produce (#1232). If this raises we
+                    # MUST NOT stamp SCHEMA_VERSION — otherwise the next boot
+                    # sees v9+ stamped and skips the migration, leaving the
+                    # schema in a broken half-state (#1602). We log + flip a
+                    # flag, then re-raise after the version-stamp block so the
+                    # transaction rolls back cleanly. Daemon startup propagates
+                    # the failure rather than booting on a half-migrated db.
                     try:
                         before = self._conn.execute(
                             "SELECT COUNT(*) FROM events"
@@ -1023,14 +1038,23 @@ class LocalStore:
                             )
                     except Exception:
                         log.exception(
-                            "local store: v7 dedup migration failed (continuing — "
-                            "future writes still dedup via canonical id)"
+                            "local store: v7 dedup migration FAILED — schema "
+                            "version will NOT be stamped; next boot will retry"
                         )
-                # Step 4: stamp the version.
-                if current < SCHEMA_VERSION:
+                        migration_failed = True
+                # Step 4: stamp the version — ONLY if every gated migration
+                # succeeded. Stamping after a swallowed failure is the #1602
+                # silent-half-state bug.
+                if not migration_failed and current < SCHEMA_VERSION:
                     self._conn.execute(
                         "INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, ?)",
                         [SCHEMA_VERSION, int(time.time() * 1000)],
+                    )
+                if migration_failed:
+                    # Roll back the whole transaction (no partial DDL leaks)
+                    # and surface the failure to the caller.
+                    raise RuntimeError(
+                        "local store: schema migration failed; version not stamped"
                     )
                 self._conn.execute("COMMIT")
             except Exception:

--- a/tests/test_e2e_duckdb_relay.py
+++ b/tests/test_e2e_duckdb_relay.py
@@ -378,7 +378,10 @@ def test_duckdb_read_only_handle_sees_committed_rows(pipeline):
         ro.close()
 
     assert n == EXPECTED_TOTAL_EVENTS
-    assert sv == ls.SCHEMA_VERSION == 5
+    # Read the constant rather than hardcoding (#1627) — the version
+    # bumps periodically (5→6→…→9 and counting); the contract being
+    # asserted here is "stamped version matches the module constant".
+    assert sv == ls.SCHEMA_VERSION
 
 
 def test_duckdb_indexes_present(pipeline):
@@ -547,7 +550,8 @@ def test_relay_shape_health(pipeline):
     assert body["_shape"] == "health"
     assert body["engine"] == "duckdb"
     assert body["event_count"] == EXPECTED_TOTAL_EVENTS
-    assert body["schema_version"] == 6
+    # Read the constant rather than hardcoding (#1627).
+    assert body["schema_version"] == pipeline["ls"].SCHEMA_VERSION
     assert body["oldest_ts"] == f"{DAY_A}T10:00:00Z"
     assert body["newest_ts"] == f"{DAY_B}T12:00:00Z"
     assert body["ring_depth"] == 0

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -267,10 +267,13 @@ def test_health_reports_size_and_count(store):
     h = store.health()
     assert h["event_count"] == 10
     assert h["size_bytes"] > 0
-    # Bumped to 6 by issue #1007 (spans table) on top of v5 (bootstrap_archive
-    # + cron_runs). Re-asserting the version explicitly catches future schema
-    # bumps that forget to update tests.
-    assert h["schema_version"] == 6
+    # Re-assert the version comes out of health() rather than hardcoding it.
+    # Hardcoded values silently drift each time someone bumps SCHEMA_VERSION
+    # (was 6 at #1007, drifted to 9 by #1626; #1627). Reading the constant
+    # lets the assertion auto-track future bumps while still catching the
+    # "schema_version reported wrong" class of bug.
+    from clawmetry.local_store import SCHEMA_VERSION
+    assert h["schema_version"] == SCHEMA_VERSION
     assert h["ring_depth"] == 0
     assert h["ring_dropped_total"] == 0
 

--- a/tests/test_schema_migration_failure_integrity.py
+++ b/tests/test_schema_migration_failure_integrity.py
@@ -1,0 +1,148 @@
+"""Regression tests for schema-migration failure-mode integrity (#1602).
+
+Bug class: the migration runner stamped ``schema_version`` even when the
+gated migration body itself raised. On the next boot the version gate
+("current < 7") was False, the migration was skipped, and the store
+quietly ran on a half-migrated schema.
+
+These tests assert the opposite contract:
+
+  1. If a gated migration raises, the version row is NOT stamped.
+  2. The first ``LocalStore()`` constructor that hits the failure raises
+     (loudly — daemons see it in logs and CI catches it).
+  3. The DuckDB file is left in a clean state — a subsequent boot, with
+     the failure mode removed, completes the migration and stamps the
+     version exactly as if the failure had never occurred.
+
+We simulate the failure by monkey-patching ``_run_dedup_migration_v7``
+to raise. That's the only currently-gated migration; if future bumps
+add more we extend the same pattern.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+
+@pytest.fixture
+def fresh_store_env(tmp_path, monkeypatch):
+    """Isolated DuckDB path + tight flusher, but DON'T construct the
+    store — these tests instantiate it themselves so they can observe
+    the migration phase."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    return ls
+
+
+def _read_schema_version(ls_mod) -> int:
+    """Open a throwaway connection straight to the file and read the
+    stamped version. Bypasses LocalStore so we can inspect even when
+    construction failed."""
+    conn = ls_mod._open_connection(read_only=True)
+    try:
+        row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+        return row[0] if row and row[0] is not None else 0
+    finally:
+        conn.close()
+
+
+def test_migration_failure_does_not_stamp_version(fresh_store_env, monkeypatch):
+    """If the v7 migration body raises, the version row must NOT be
+    stamped — otherwise the next boot would skip the retry and leave
+    the schema in a permanent half-state (#1602)."""
+    ls = fresh_store_env
+
+    # Pre-create the events table at "v6" (no schema_version stamped) so
+    # the migration gate ``current < 7`` actually fires.  We do this by
+    # opening a writer connection, creating just the events table, then
+    # closing it before LocalStore() opens its own connection.
+    conn = ls._open_connection(read_only=False)
+    try:
+        for stmt in ls._DDL:
+            conn.execute(stmt)
+        # Wipe any version rows the DDL itself might have left behind so
+        # we genuinely look like a v6-or-older store.
+        conn.execute("DELETE FROM schema_version")
+    finally:
+        conn.close()
+
+    # Inject the failure.
+    boom = RuntimeError("simulated v7 dedup failure")
+    def _failing(_conn):
+        raise boom
+    monkeypatch.setattr(ls, "_run_dedup_migration_v7", _failing)
+
+    # Construct → must raise. (The fix re-raises after rolling back.)
+    with pytest.raises(Exception):
+        ls.LocalStore()
+
+    # Critical: schema_version stayed at the pre-migration value.
+    assert _read_schema_version(ls) < 7, (
+        "version was stamped despite migration failure — #1602 has regressed"
+    )
+
+
+def test_migration_recovers_on_next_boot_after_failure(fresh_store_env, monkeypatch):
+    """The whole point of NOT stamping is so the next boot retries.
+    Verify the recovery path end-to-end: fail once, un-break the
+    migration, boot again, observe the version stamp + working store."""
+    ls = fresh_store_env
+
+    # Same v6-shaped store prep as above.
+    conn = ls._open_connection(read_only=False)
+    try:
+        for stmt in ls._DDL:
+            conn.execute(stmt)
+        conn.execute("DELETE FROM schema_version")
+    finally:
+        conn.close()
+
+    # Boot 1: failure path.
+    real_migration = ls._run_dedup_migration_v7
+    call_count = {"n": 0}
+    def _flaky(c):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated transient v7 failure")
+        return real_migration(c)
+    monkeypatch.setattr(ls, "_run_dedup_migration_v7", _flaky)
+
+    with pytest.raises(Exception):
+        ls.LocalStore()
+    assert _read_schema_version(ls) < 7
+
+    # Boot 2: the un-patched migration is wrapped by ``_flaky`` and
+    # succeeds on attempt #2 — exactly the "transient failure cleared
+    # itself" recovery scenario.
+    store = ls.LocalStore()
+    try:
+        store.start()
+        assert call_count["n"] == 2, (
+            "second boot did NOT retry the migration — recovery contract "
+            "broken; #1602 fix is incomplete"
+        )
+        # Version stamped at current SCHEMA_VERSION now that the gated
+        # migration finally succeeded.
+        h = store.health()
+        assert h["schema_version"] == ls.SCHEMA_VERSION
+    finally:
+        store.stop(flush=False)
+
+
+def test_fresh_store_stamps_version_normally(fresh_store_env):
+    """Sanity check: the fix didn't break the happy path. A brand-new
+    store with no failures should construct cleanly and stamp the
+    current SCHEMA_VERSION."""
+    ls = fresh_store_env
+    store = ls.LocalStore()
+    try:
+        store.start()
+        assert store.health()["schema_version"] == ls.SCHEMA_VERSION
+    finally:
+        store.stop(flush=False)

--- a/tests/test_spans_ingest.py
+++ b/tests/test_spans_ingest.py
@@ -78,27 +78,31 @@ def _span(**overrides):
 # ── schema / migration ──────────────────────────────────────────────────────
 
 
-def test_schema_version_bumped_to_6(store):
-    """SCHEMA_VERSION must be exactly 6 — issue #1007 bumps 5 → 6
-    (on top of v5 = bootstrap_archive + cron_runs from #1158 / #1160).
+def test_schema_version_stamped_and_idempotent(store):
+    """The current SCHEMA_VERSION must be stamped and re-running
+    _migrate() must not double-stamp.
 
-    Guards against a concurrent migration silently re-bumping us past 6
-    without updating callers / cloud relay that pin schema-aware reads."""
+    Original assertion hardcoded == 6 (#1007); it silently drifted as
+    #1232/#1234/#1626 each bumped the constant without test updates
+    (#1627). Read from the module constant so this assertion auto-
+    tracks future bumps."""
     import clawmetry.local_store as ls
-    assert ls.SCHEMA_VERSION == 6
+    expected = ls.SCHEMA_VERSION
     # And exactly one row stamped — re-running _migrate is idempotent.
     rows = store._fetch(
         "SELECT version FROM schema_version ORDER BY version", []
     )
     versions = [r[0] for r in rows]
-    assert 6 in versions
-    # Re-invoke migrate; the version 6 row must NOT double-up.
+    assert expected in versions
+    # Re-invoke migrate; the current-version row must NOT double-up.
     store._migrate()
     rows2 = store._fetch(
         "SELECT version, COUNT(*) FROM schema_version GROUP BY version", []
     )
     counts = {v: c for v, c in rows2}
-    assert counts.get(6, 0) == 1, f"schema_version row for v6 duplicated: {counts}"
+    assert counts.get(expected, 0) == 1, (
+        f"schema_version row for v{expected} duplicated: {counts}"
+    )
 
 
 def test_spans_table_exists(store):


### PR DESCRIPTION
## Summary

Two related schema-version bugs, one PR:

### #1602 (silent-failure taxonomy P1): half-migrated stores baked in permanently

The v6→v7 dedup migration had an inner `try/except` that swallowed failures (regex / lock / disk hiccup), but the outer migration runner still stamped `SCHEMA_VERSION` in the same transaction. Result: a failed migration left the store half-migrated; the next boot saw `current >= 7` and skipped the retry. Permanent broken state.

**Fix**: flip a `migration_failed` flag on swallow, skip the version stamp, roll back the transaction, close the connection so the lock releases, and re-raise so the daemon surfaces the failure. Next boot retries cleanly.

### #1627: tests hardcoded `schema_version == 6` while real value drifted to 9

Three tests asserted exact integer schema versions — they silently went stale as `#1232` / `#1234` / `#1626` bumped the constant without updating callers. Replaced with `from clawmetry.local_store import SCHEMA_VERSION; assert ... == SCHEMA_VERSION` so the assertion auto-tracks future bumps while still catching the "schema_version reported wrong" class of bug.

Swept the class — not just the instance:
- `tests/test_local_store.py::test_health_reports_size_and_count`
- `tests/test_spans_ingest.py::test_schema_version_bumped_to_6` (renamed → `test_schema_version_stamped_and_idempotent`)
- `tests/test_e2e_duckdb_relay.py` (two call sites)

### Bonus regression test

`tests/test_schema_migration_failure_integrity.py` — three tests:
1. `test_migration_failure_does_not_stamp_version` — monkeypatches v7 dedup to raise, asserts version stays at pre-migration value.
2. `test_migration_recovers_on_next_boot_after_failure` — fails once, then un-patches, boots again, asserts version IS stamped and the store works. **Critical**: this exercises the full failure-and-recovery cycle the user flagged as the test-it-carefully requirement. Verified the second-boot retry actually fires (`call_count["n"] == 2`).
3. `test_fresh_store_stamps_version_normally` — happy-path sanity check that the fix didn't break clean installs.

## Budget

- Production: +42 lines (budget: 80)
- Tests: +148 (new file) + ~43 (modified) = ~190 (budget: 200)

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `tests/test_local_store.py` — all 33 tests pass (incl. fixed `test_health_reports_size_and_count`)
- [x] `tests/test_spans_ingest.py` — all 9 tests pass (incl. renamed test)
- [x] `tests/test_schema_migration_failure_integrity.py` — all 3 new tests pass, including the round-trip recovery test
- [x] Class-of-bug sweep: grep'd `schema_version.*==\s*\d` across `tests/` — 3 stale hardcodes found and fixed
- [x] Pre-existing `test_e2e_duckdb_relay.py` failures (10 of them) confirmed present on `origin/main` before any of my changes — not introduced by this PR

## DO NOT MERGE

Per the requesting task, leaving this PR open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)