### PR TITLE
feat(evals): Phase 3 — regression-replay of failed sessions (refs #1619)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2147,6 +2147,13 @@ def _cmd_eval(args) -> None:
     import json as _json
     from clawmetry import eval_suite_runner as esr
 
+    # Phase 3 — regression replay path. Mutually exclusive with --suite
+    # (the two flows produce different table shapes; mixing them in one
+    # invocation only confuses CI logs).
+    if getattr(args, "regression", False):
+        _cmd_eval_regression(args)
+        return
+
     if getattr(args, "list_suites", False):
         suites = esr.list_suites()
         if not suites:
@@ -2207,6 +2214,85 @@ def _cmd_eval(args) -> None:
     run = esr.run_suite(suite, persist=persist)
     _print_result(run)
     sys.exit(run.exit_code)
+
+
+def _cmd_eval_regression(args) -> None:
+    """Phase 3 evals — replay last week's failed sessions against current
+    config. MANUAL invocation only: every replay costs API tokens, so the
+    runner enforces a hard ceiling (CLAWMETRY_EVALS_REGRESSION_MAX or the
+    --limit flag, defaulting to 10).
+
+    Exit code mirrors the eval-suite convention:
+        0 → ran cleanly (any mix of improved/same is fine)
+        1 → at least one regressed/errored row (signal worth investigating)
+    """
+    import json as _json
+    from clawmetry import eval_regression_replay as err
+
+    # Parse --window into days. Reuse the tiny human-readable parser style
+    # from routes/evals.py so flags + URL params behave the same.
+    raw = (getattr(args, "window", None) or "7d").strip().lower()
+    try:
+        if raw.endswith("d"):
+            window_days = int(float(raw[:-1]))
+        elif raw.endswith("h"):
+            window_days = max(1, int(float(raw[:-1]) // 24))
+        else:
+            window_days = int(float(raw))
+    except (TypeError, ValueError):
+        window_days = 7
+    window_days = max(1, min(90, window_days))
+
+    limit = getattr(args, "limit", None)
+    if limit is None:
+        limit = err.DEFAULT_REPLAY_BUDGET
+    limit = max(1, int(limit))
+
+    if not err.is_enabled():
+        print(
+            "Regression replay is disabled "
+            "(CLAWMETRY_EVALS_REGRESSION_ENABLED=0).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    print(
+        f"Replaying up to {limit} failed session(s) from the last "
+        f"{window_days}d... (manual cost-guarded run)",
+        flush=True,
+    )
+    run = err.run_regression(window_days=window_days, limit=limit)
+
+    if getattr(args, "as_json", False):
+        print(_json.dumps({
+            "ran_at":       run.ran_at,
+            "window_days":  run.window_days,
+            "tested":       run.tested,
+            "improved":     run.improved,
+            "regressed":    run.regressed,
+            "same":         run.same,
+            "errored":      run.errored,
+            "results":      [r.to_dict() for r in run.results],
+        }, indent=2))
+    else:
+        if not run.results:
+            print("No failed sessions in the window. Nothing to replay.")
+        else:
+            for r in run.results:
+                old_s = "-" if r.original_score is None else f"{r.original_score:.1f}"
+                new_s = "-" if r.new_score is None else f"{r.new_score:.1f}"
+                print(
+                    f"  {r.status.upper():<10} {r.session_id[:24]:<24} "
+                    f"{old_s} -> {new_s}  {r.reason[:60]}"
+                )
+            print()
+            print(
+                f"{run.improved} improved, {run.regressed} regressed, "
+                f"{run.same} same, {run.errored} errored "
+                f"({run.tested} tested over last {window_days}d)"
+            )
+    exit_code = 1 if (run.regressed > 0 or run.errored > 0) else 0
+    sys.exit(exit_code)
 
 
 def _cmd_update() -> None:
@@ -2518,6 +2604,34 @@ def main() -> None:
         action="store_true",
         dest="as_json",
         help="Emit machine-readable JSON instead of the table",
+    )
+    # Phase 3 (refs #1619) — regression replay of last week's failed sessions.
+    # MANUAL invocation only by design (no cron): replay costs API tokens, so
+    # the user opts in every time. ``--regression`` is mutually-exclusive with
+    # ``--suite`` at the handler level.
+    p_eval.add_argument(
+        "--regression",
+        action="store_true",
+        dest="regression",
+        help=(
+            "Replay last week's failed sessions against the current "
+            "config (manual cost-guarded; see --window / --limit)"
+        ),
+    )
+    p_eval.add_argument(
+        "--window",
+        metavar="DURATION",
+        default="7d",
+        help="Lookback window for --regression (e.g. 7d, 14d; default 7d)",
+    )
+    p_eval.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help=(
+            "Hard ceiling on replays per --regression invocation "
+            "(default: CLAWMETRY_EVALS_REGRESSION_MAX or 10)"
+        ),
     )
 
     # update — self-update to latest PyPI version

--- a/clawmetry/eval_regression_replay.py
+++ b/clawmetry/eval_regression_replay.py
@@ -1,0 +1,619 @@
+"""
+clawmetry/eval_regression_replay.py — Phase 3 evals: regression-replay.
+
+Closes the eval loop. Phase 1 (#1623) scored real sessions with an
+LLM-as-judge. Phase 2 (#1626) added golden test suites for release gating.
+Phase 3 answers the question the first two leave open: *is my agent
+getting BETTER over time?*
+
+The recipe: pull yesterday's failed sessions out of DuckDB, re-run each
+one's ORIGINAL user input through the current agent + prompt config, and
+compare the new outcome against the original. If a session that failed
+last week passes this week, that's a real, measurable improvement — and
+it goes straight onto the overview tile so the user can see their work
+moving the needle.
+
+Design constraints (composes with Phase 1 + Phase 2):
+  * Reuse Phase 1's judge call (``eval_runner._call_judge``), Phase 2's
+    agent shell-out (``eval_suite_runner._default_agent_call``), Phase 1
+    rate limiter pattern. No new HTTP code paths.
+  * Pull replay inputs from the local DuckDB ``events`` table, NOT from
+    JSONL re-reads. Honours feedback_duckdb_first_rule + the bug-class
+    gate in feedback_synthetic_tests_missed_real_event_shape (use real
+    event shapes — same canonical type-union as eval_runner._PROMPT_*).
+  * Cost guard. Replay COSTS API tokens (agent re-run + judge call) —
+    every safety belt from Phase 1 applies double here. Default to
+    ``manual`` invocation, no cron. Replays per-run are hard-capped.
+  * Persistence in a new ``eval_regression_runs`` table; the schema
+    migration bumps SCHEMA_VERSION to 10. Idempotent on
+    (session_id, replayed_at).
+  * Never crashes the daemon — every external call (agent, judge,
+    store) is wrapped; failures degrade to a status row, not an
+    exception.
+
+Public API:
+    find_failed_sessions(*, window_days=7, limit=50) -> list[dict]
+    replay_session(session_id, *, agent_call=None) -> ReplayResult
+    compare_outcomes(old_session, new_run) -> str   # improved/regressed/same
+    run_regression(*, window_days=7, limit=10) -> RegressionRun
+    regression_summary(*, window_days=7) -> dict    # for /api/evals/regression-summary
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Any, Callable
+
+log = logging.getLogger("clawmetry.eval_regression_replay")
+
+
+# ── Config ─────────────────────────────────────────────────────────────────────
+
+# Master kill switch. Default ON so the CLI is usable out of the box, but
+# the scheduler will NEVER call us unless the user explicitly types
+# ``clawmetry eval --regression`` (see feedback note in module docstring).
+def is_enabled() -> bool:
+    return os.environ.get("CLAWMETRY_EVALS_REGRESSION_ENABLED", "1") not in (
+        "0", "false", "False", "",
+    )
+
+
+# Hard ceiling on a single regression run — every replay = 1 agent call +
+# 1 judge call ≈ a few cents. 10 by default keeps a manual ``--regression``
+# under a quarter even on Sonnet, and the user can raise it explicitly.
+DEFAULT_REPLAY_BUDGET = int(os.environ.get("CLAWMETRY_EVALS_REGRESSION_MAX", "10"))
+
+# How far back to look for failed sessions. 7 days mirrors the PRD ("last
+# week's failures"). Bounded to 90 days because anything older almost
+# certainly involves a config + version drift the replay can't reason about.
+DEFAULT_WINDOW_DAYS = int(os.environ.get("CLAWMETRY_EVALS_REGRESSION_WINDOW_DAYS", "7"))
+
+# "Failed" rubric. A session is replay-worthy if EITHER:
+#   * outcome label says it broke (failed/escalated), OR
+#   * the eval score is below this threshold.
+# The two signals are deliberately additive — outcome is binary and noisy;
+# eval score is graded and noisy in a different direction. Both together
+# catch more real failures with fewer false positives.
+LOW_SCORE_THRESHOLD = float(
+    os.environ.get("CLAWMETRY_EVALS_REGRESSION_LOW_SCORE", "3.0")
+)
+
+
+# Same canonical event-type union as eval_runner. Centralising it would be
+# nice; for now keep a copy + the comment that they must stay in sync. Both
+# get bumped together when a new agent shape lands.
+_PROMPT_EVENT_TYPES = (
+    "prompt.submitted",
+    "message",
+    "user",
+    "subagent:user",
+)
+
+
+# ── Data classes ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class FailedSession:
+    """One row from ``find_failed_sessions``. Used as the input envelope
+    for ``replay_session`` so callers don't re-query the store."""
+    session_id: str
+    title: str
+    original_input: str
+    original_outcome: str
+    original_score: float | None
+    last_active_at: str
+
+
+@dataclass
+class ReplayResult:
+    """One executed replay. ``status`` is one of ``improved`` / ``regressed``
+    / ``same`` / ``error``. ``error`` = the harness itself broke (agent
+    crash, judge unavailable, missing original input)."""
+    session_id: str
+    status: str
+    original_outcome: str
+    new_outcome: str
+    original_score: float | None
+    new_score: float | None
+    reason: str
+    replayed_at: int  # epoch millis
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RegressionRun:
+    """Aggregate of one ``run_regression`` invocation."""
+    ran_at: int
+    window_days: int
+    results: list[ReplayResult] = field(default_factory=list)
+
+    @property
+    def tested(self) -> int:
+        return len(self.results)
+
+    @property
+    def improved(self) -> int:
+        return sum(1 for r in self.results if r.status == "improved")
+
+    @property
+    def regressed(self) -> int:
+        return sum(1 for r in self.results if r.status == "regressed")
+
+    @property
+    def same(self) -> int:
+        return sum(1 for r in self.results if r.status == "same")
+
+    @property
+    def errored(self) -> int:
+        return sum(1 for r in self.results if r.status == "error")
+
+
+# ── Failed-session probe ──────────────────────────────────────────────────────
+
+
+def _get_store(store: Any = None) -> Any:
+    """Return the injected store or fall back to the daemon's singleton.
+    Read-only — replay doesn't need write access until ``run_regression``
+    persists results."""
+    if store is not None:
+        return store
+    from clawmetry import local_store
+    return local_store.get_store()
+
+
+def _extract_first_prompt(events: list[dict[str, Any]]) -> str:
+    """Pull the user's first prompt text from a session's event list.
+
+    Honours the bug-class gate from feedback_synthetic_tests_missed_real_
+    event_shape: probes all four real event shapes the v3 daemon emits,
+    not just ``message``. Returns the first non-empty match in chronological
+    order; falls back to "" so the caller can mark the replay as errored
+    rather than re-running garbage.
+    """
+    # Events arrive newest-first from ``query_events``; we want chronological.
+    for ev in reversed(events):
+        et = ev.get("event_type") or ev.get("type") or ""
+        if et not in _PROMPT_EVENT_TYPES:
+            continue
+        data = ev.get("data") or {}
+        if isinstance(data, (bytes, bytearray)):
+            try:
+                data = json.loads(data.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                continue
+        if not isinstance(data, dict):
+            continue
+        for key in ("finalPromptText", "promptText", "text", "input", "content"):
+            v = data.get(key)
+            if isinstance(v, str) and v.strip():
+                return v
+        msg = data.get("message") if isinstance(data.get("message"), dict) else None
+        if msg:
+            c = msg.get("content")
+            if isinstance(c, str) and c.strip():
+                return c
+            if isinstance(c, list):
+                parts = [b.get("text", "") for b in c if isinstance(b, dict)]
+                joined = "\n".join(p for p in parts if p)
+                if joined.strip():
+                    return joined
+    return ""
+
+
+def find_failed_sessions(
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    limit: int = 50,
+    store: Any = None,
+) -> list[FailedSession]:
+    """Return sessions worth replaying: outcome in (failed/escalated) OR
+    eval_score below ``LOW_SCORE_THRESHOLD``, within the last
+    ``window_days``. Newest first so the replay budget gets spent on the
+    most relevant signals if it runs out.
+
+    The original input is extracted in the same pass — saves the caller
+    a follow-up ``query_events`` round trip per session.
+    """
+    store = _get_store(store)
+    try:
+        from datetime import datetime, timedelta, timezone
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=int(window_days))).isoformat()
+    except Exception:
+        cutoff = ""
+
+    sql = """
+        SELECT session_id, COALESCE(title, ''), COALESCE(outcome, ''),
+               eval_score, COALESCE(last_active_at, started_at, '')
+          FROM sessions
+         WHERE (
+                  outcome IN ('failed', 'escalated')
+               OR (eval_score IS NOT NULL AND eval_score < ?)
+              )
+           AND (? = '' OR COALESCE(last_active_at, started_at, '') >= ?)
+         ORDER BY COALESCE(last_active_at, started_at) DESC NULLS LAST
+         LIMIT ?
+    """
+    try:
+        rows = store._fetch(sql, [LOW_SCORE_THRESHOLD, cutoff, cutoff, int(limit)])
+    except Exception as e:
+        log.warning("regression: find_failed_sessions query failed: %s", e)
+        return []
+
+    out: list[FailedSession] = []
+    for sid, title, outcome, score, last_active in rows:
+        try:
+            events = store.query_events(session_id=sid, limit=200)
+        except Exception:
+            events = []
+        original_input = _extract_first_prompt(events)
+        out.append(FailedSession(
+            session_id=str(sid),
+            title=str(title or ""),
+            original_input=original_input,
+            original_outcome=str(outcome or "unknown"),
+            original_score=float(score) if score is not None else None,
+            last_active_at=str(last_active or ""),
+        ))
+    return out
+
+
+# ── Replay one session ────────────────────────────────────────────────────────
+
+
+def _default_agent_call(test_input: str):
+    """Lazy-import the Phase 2 agent shell-out so importing this module
+    in environments without OpenClaw works for testing + summary reads."""
+    from clawmetry.eval_suite_runner import _default_agent_call as inner
+    return inner(test_input)
+
+
+def _default_judge_call(model: str, prompt: str, *, timeout: float = 30.0) -> str:
+    """Lazy import of Phase 1 judge call. Keeps httpx out of import-time
+    requirements for the summary endpoint."""
+    from clawmetry.eval_runner import _call_judge
+    return _call_judge(model, prompt, timeout=timeout)
+
+
+def replay_session(
+    session_id: str,
+    *,
+    failed_session: FailedSession | None = None,
+    agent_call: Callable[[str], Any] | None = None,
+    judge_call: Callable[..., str] | None = None,
+    judge_model: str = "claude-haiku-4-5",
+    store: Any = None,
+) -> ReplayResult:
+    """Re-run one failed session's original input through the current
+    agent + prompt config, score the new output, and return a comparison.
+
+    All external callables are injectable so tests can drive deterministic
+    paths without subprocesses or HTTP. The ``failed_session`` envelope
+    can be passed in to skip the (already-done) original-input lookup.
+    """
+    replayed_at = int(time.time() * 1000)
+    agent_call = agent_call or _default_agent_call
+    judge_call = judge_call or _default_judge_call
+
+    # Reload the failed session envelope if the caller didn't pass one.
+    if failed_session is None:
+        store_obj = _get_store(store)
+        try:
+            events = store_obj.query_events(session_id=session_id, limit=200)
+        except Exception:
+            events = []
+        original_input = _extract_first_prompt(events)
+        # Look up outcome + score off the sessions row.
+        try:
+            row = store_obj._fetch(
+                "SELECT COALESCE(outcome, ''), eval_score FROM sessions WHERE session_id = ?",
+                [session_id],
+            )
+            if row:
+                orig_outcome = str(row[0][0] or "unknown")
+                orig_score = float(row[0][1]) if row[0][1] is not None else None
+            else:
+                orig_outcome, orig_score = "unknown", None
+        except Exception:
+            orig_outcome, orig_score = "unknown", None
+        failed_session = FailedSession(
+            session_id=session_id,
+            title="",
+            original_input=original_input,
+            original_outcome=orig_outcome,
+            original_score=orig_score,
+            last_active_at="",
+        )
+
+    if not failed_session.original_input.strip():
+        return ReplayResult(
+            session_id=session_id,
+            status="error",
+            original_outcome=failed_session.original_outcome,
+            new_outcome="unknown",
+            original_score=failed_session.original_score,
+            new_score=None,
+            reason="no original input extractable from session events",
+            replayed_at=replayed_at,
+        )
+
+    # Re-run through the current agent. Defensive: ANY failure becomes an
+    # error row rather than a daemon-crashing exception.
+    try:
+        response = agent_call(failed_session.original_input)
+    except Exception as e:
+        return ReplayResult(
+            session_id=session_id,
+            status="error",
+            original_outcome=failed_session.original_outcome,
+            new_outcome="failed",
+            original_score=failed_session.original_score,
+            new_score=None,
+            reason=f"agent crashed: {type(e).__name__}: {e}",
+            replayed_at=replayed_at,
+        )
+
+    if getattr(response, "error", None):
+        return ReplayResult(
+            session_id=session_id,
+            status="error",
+            original_outcome=failed_session.original_outcome,
+            new_outcome=getattr(response, "outcome", "failed") or "failed",
+            original_score=failed_session.original_score,
+            new_score=None,
+            reason=str(response.error),
+            replayed_at=replayed_at,
+        )
+
+    # Score the new output with the Phase 1 judge.
+    new_score: float | None = None
+    judge_reason = ""
+    try:
+        from clawmetry.eval_runner import DEFAULT_RUBRIC, parse_score
+        prompt = (
+            str(DEFAULT_RUBRIC["prompt"])
+            + "\n\n---\nTRANSCRIPT:\nUSER: "
+            + failed_session.original_input.strip()
+            + "\n\nASSISTANT: "
+            + (getattr(response, "text", "") or "").strip()
+            + "\n---"
+        )
+        reply = judge_call(judge_model, prompt, timeout=30.0)
+        new_score, parsed_reason = parse_score(reply)
+        if parsed_reason:
+            judge_reason = parsed_reason
+    except Exception as e:
+        return ReplayResult(
+            session_id=session_id,
+            status="error",
+            original_outcome=failed_session.original_outcome,
+            new_outcome=getattr(response, "outcome", "success") or "success",
+            original_score=failed_session.original_score,
+            new_score=None,
+            reason=f"judge unavailable: {type(e).__name__}: {e}",
+            replayed_at=replayed_at,
+        )
+
+    new_outcome = str(getattr(response, "outcome", "success") or "success")
+    status = compare_outcomes(
+        old_outcome=failed_session.original_outcome,
+        old_score=failed_session.original_score,
+        new_outcome=new_outcome,
+        new_score=new_score,
+    )
+    return ReplayResult(
+        session_id=session_id,
+        status=status,
+        original_outcome=failed_session.original_outcome,
+        new_outcome=new_outcome,
+        original_score=failed_session.original_score,
+        new_score=new_score,
+        reason=judge_reason or f"{failed_session.original_outcome} -> {new_outcome}",
+        replayed_at=replayed_at,
+    )
+
+
+def compare_outcomes(
+    *,
+    old_outcome: str,
+    old_score: float | None,
+    new_outcome: str,
+    new_score: float | None,
+) -> str:
+    """Classify a replay as improved / regressed / same.
+
+    Rules, in order of precedence:
+      1. Outcome transition wins. failed/escalated -> success/any is an
+         improvement; the reverse is a regression. (Outcome is the
+         human-meaningful signal; the eval score is supporting evidence.)
+      2. If outcome is unchanged, fall back to score delta with a 0.5
+         dead band so judge noise (Haiku is not bit-exact) doesn't get
+         counted as a real swing.
+      3. Anything ambiguous (one side missing, no score change) → ``same``.
+    """
+    _failed = ("failed", "escalated")
+    old_failed = old_outcome in _failed
+    new_failed = new_outcome in _failed
+    if old_failed and not new_failed:
+        return "improved"
+    if not old_failed and new_failed:
+        return "regressed"
+    # Outcome unchanged — try score delta.
+    if old_score is not None and new_score is not None:
+        delta = new_score - old_score
+        if delta >= 0.5:
+            return "improved"
+        if delta <= -0.5:
+            return "regressed"
+    return "same"
+
+
+# ── Persistence ───────────────────────────────────────────────────────────────
+
+
+def _persist_result(result: ReplayResult, *, store: Any = None) -> None:
+    """Write one ``ReplayResult`` row to ``eval_regression_runs``. Best-
+    effort — a missing daemon or RO connection logs a warning and returns
+    without crashing the CLI."""
+    if store is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store()
+        except Exception as e:
+            log.warning("regression: local_store unavailable: %s", e)
+            return
+    persister = getattr(store, "persist_eval_regression_run", None)
+    if persister is None:
+        log.warning(
+            "regression: store has no persist_eval_regression_run "
+            "(older schema? expected v10)"
+        )
+        return
+    try:
+        persister(
+            session_id=result.session_id,
+            status=result.status,
+            original_outcome=result.original_outcome,
+            new_outcome=result.new_outcome,
+            original_score=result.original_score,
+            new_score=result.new_score,
+            reason=result.reason,
+            replayed_at=result.replayed_at,
+        )
+    except Exception as e:
+        log.warning("regression: persist row %s failed: %s", result.session_id, e)
+
+
+# ── Top-level driver ──────────────────────────────────────────────────────────
+
+
+def run_regression(
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    limit: int = DEFAULT_REPLAY_BUDGET,
+    agent_call: Callable[[str], Any] | None = None,
+    judge_call: Callable[..., str] | None = None,
+    judge_model: str = "claude-haiku-4-5",
+    store: Any = None,
+    persist: bool = True,
+) -> RegressionRun:
+    """End-to-end: find failed sessions, replay each, persist results.
+
+    ``limit`` is a HARD ceiling on replays per invocation — this is the
+    cost guard. Default 10 keeps a single ``--regression`` invocation
+    under a few cents even on Sonnet. The user can override with
+    ``CLAWMETRY_EVALS_REGRESSION_MAX`` if they're confident in their bill.
+    """
+    ran_at = int(time.time() * 1000)
+    run = RegressionRun(ran_at=ran_at, window_days=int(window_days))
+
+    if not is_enabled():
+        log.info("regression: CLAWMETRY_EVALS_REGRESSION_ENABLED=0, skipping")
+        return run
+
+    failed = find_failed_sessions(
+        window_days=window_days,
+        limit=max(int(limit), 1),
+        store=store,
+    )
+    if not failed:
+        return run
+
+    for fs in failed[: int(limit)]:
+        try:
+            result = replay_session(
+                fs.session_id,
+                failed_session=fs,
+                agent_call=agent_call,
+                judge_call=judge_call,
+                judge_model=judge_model,
+                store=store,
+            )
+        except Exception as e:
+            log.warning("regression: replay_session(%s) crashed: %s", fs.session_id, e)
+            result = ReplayResult(
+                session_id=fs.session_id,
+                status="error",
+                original_outcome=fs.original_outcome,
+                new_outcome="unknown",
+                original_score=fs.original_score,
+                new_score=None,
+                reason=f"replay crashed: {type(e).__name__}: {e}",
+                replayed_at=int(time.time() * 1000),
+            )
+        run.results.append(result)
+        if persist:
+            _persist_result(result, store=store)
+    return run
+
+
+# ── Summary surface (drives /api/evals/regression-summary + UI tile) ──────────
+
+
+def regression_summary(
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    store: Any = None,
+) -> dict[str, Any]:
+    """Aggregate persisted replay rows over the recent window. Drives
+    the ``/api/evals/regression-summary`` endpoint and the overview tile's
+    "Regression: X fixed" mini-line.
+
+    Returns ``{tested, improved, regressed, same, errored, window_days,
+    last_run_at}``. Empty payload (all zeros + ``last_run_at: None``) on
+    a fresh install where no regression has run yet.
+    """
+    payload: dict[str, Any] = {
+        "tested":       0,
+        "improved":     0,
+        "regressed":    0,
+        "same":         0,
+        "errored":      0,
+        "window_days":  int(window_days),
+        "last_run_at":  None,
+    }
+    try:
+        store_obj = _get_store(store)
+    except Exception as e:
+        log.warning("regression: summary store unavailable: %s", e)
+        return payload
+    try:
+        from datetime import datetime, timedelta, timezone
+        cutoff_ms = int(
+            (datetime.now(timezone.utc) - timedelta(days=int(window_days))).timestamp() * 1000
+        )
+    except Exception:
+        cutoff_ms = 0
+    try:
+        rows = store_obj._fetch(
+            """
+            SELECT status, COUNT(*) AS n, MAX(replayed_at) AS last_ms
+              FROM eval_regression_runs
+             WHERE replayed_at >= ?
+             GROUP BY status
+            """,
+            [cutoff_ms],
+        )
+    except Exception as e:
+        log.warning("regression: summary query failed: %s", e)
+        return payload
+    last_ms = 0
+    for status, n, lm in rows:
+        n = int(n or 0)
+        payload["tested"] += n
+        if status in ("improved", "regressed", "same", "errored"):
+            payload[status] += n
+        try:
+            lm_int = int(lm or 0)
+            if lm_int > last_ms:
+                last_ms = lm_int
+        except (TypeError, ValueError):
+            pass
+    payload["last_run_at"] = last_ms or None
+    return payload

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -124,7 +124,7 @@ LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 # ── Two-layer schema (multi-agent) ──────────────────────────────────────────
 #
@@ -614,6 +614,28 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_eval_suite_runs_ran_at ON eval_suite_runs(ran_at)",
     "CREATE INDEX IF NOT EXISTS idx_eval_suite_runs_suite  ON eval_suite_runs(suite_name, ran_at)",
+    # Issue #1619 Phase 3 — regression-replay runs. One row per
+    # replayed-failed-session per invocation. Drives the
+    # /api/evals/regression-summary endpoint and the overview tile's
+    # "Regression: X fixed since last week" mini-line. Composes with the
+    # other two eval surfaces: ``sessions.eval_score`` = production scores
+    # (Phase 1), ``eval_suite_runs`` = golden bench (Phase 2),
+    # ``eval_regression_runs`` = "did yesterday's fail get fixed?" (Phase 3).
+    """
+    CREATE TABLE IF NOT EXISTS eval_regression_runs (
+        session_id        VARCHAR NOT NULL,
+        replayed_at       BIGINT  NOT NULL,
+        status            VARCHAR NOT NULL,
+        original_outcome  VARCHAR,
+        new_outcome       VARCHAR,
+        original_score    DOUBLE,
+        new_score         DOUBLE,
+        reason            VARCHAR,
+        PRIMARY KEY (session_id, replayed_at)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_eval_regression_replayed_at ON eval_regression_runs(replayed_at)",
+    "CREATE INDEX IF NOT EXISTS idx_eval_regression_status     ON eval_regression_runs(status, replayed_at)",
     """
     CREATE TABLE IF NOT EXISTS schema_version (
         version    INTEGER PRIMARY KEY,
@@ -4239,6 +4261,73 @@ class LocalStore:
             rows = self._fetch(sql, params)
         except Exception as e:
             log.warning("local store: query_recent_suite_runs failed: %s", e)
+            return []
+        return [dict(zip(cols, r)) for r in rows]
+
+    # ── Issue #1619 Phase 3 — regression replay runs ────────────────────────
+
+    def persist_eval_regression_run(
+        self,
+        *,
+        session_id: str,
+        status: str,
+        original_outcome: str,
+        new_outcome: str,
+        original_score: float | None,
+        new_score: float | None,
+        reason: str,
+        replayed_at: int,
+    ) -> None:
+        """Write one row of the ``eval_regression_runs`` table. Idempotent on
+        ``(session_id, replayed_at)`` — re-running with the same timestamp
+        overwrites in place; a new run gets a new ``replayed_at`` so the
+        trend history grows by one row per (session, replay)."""
+        with self._write_lock:
+            try:
+                self._conn.execute(
+                    """
+                    INSERT OR REPLACE INTO eval_regression_runs
+                        (session_id, replayed_at, status, original_outcome,
+                         new_outcome, original_score, new_score, reason)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        session_id or "",
+                        int(replayed_at),
+                        status or "error",
+                        (original_outcome or "")[:64],
+                        (new_outcome or "")[:64],
+                        None if original_score is None else float(original_score),
+                        None if new_score is None else float(new_score),
+                        (reason or "")[:500],
+                    ],
+                )
+            except Exception:
+                log.exception(
+                    "local store: persist_eval_regression_run failed for %s",
+                    session_id,
+                )
+
+    def query_recent_regression_runs(
+        self,
+        *,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return recent ``eval_regression_runs`` rows, newest first."""
+        sql = (
+            "SELECT session_id, replayed_at, status, original_outcome, "
+            "       new_outcome, original_score, new_score, reason "
+            "  FROM eval_regression_runs "
+            " ORDER BY replayed_at DESC LIMIT ?"
+        )
+        cols = [
+            "session_id", "replayed_at", "status", "original_outcome",
+            "new_outcome", "original_score", "new_score", "reason",
+        ]
+        try:
+            rows = self._fetch(sql, [int(limit)])
+        except Exception as e:
+            log.warning("local store: query_recent_regression_runs failed: %s", e)
             return []
         return [dict(zip(cols, r)) for r in rows]
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2154,6 +2154,8 @@ async function loadMiniWidgets(overview, usage) {
   // Issue #1619 Phase 1 — eval score tile. Lazy, non-blocking; tile shows
   // a dash on miss so a slow daemon doesn't gate the overview render.
   loadEvalSummary();
+  // Phase 3 — regression-replay mini-line under the eval tile.
+  loadEvalRegressionSummary();
 }
 
 // Issue #1619 Phase 1 — pull aggregate score for the overview tile.
@@ -2184,6 +2186,39 @@ async function loadEvalSummary() {
   } catch (e) {
     avgEl.textContent = '--';
     if (covEl) covEl.textContent = '';
+  }
+}
+
+// Issue #1619 Phase 3 — regression-replay summary line under the eval tile.
+// Reads /api/evals/regression-summary?window=7d and renders a single-line
+// status like "Regression: 8 fixed since last week". Silent on a fresh
+// install (tested=0) so the tile doesn't dangle a useless zero.
+async function loadEvalRegressionSummary() {
+  var el = document.getElementById('eval-regression-line');
+  if (!el) return;
+  try {
+    var data = await fetch('/api/evals/regression-summary?window=7d').then(function(r){return r.json();}).catch(function(){return null;});
+    if (!data || typeof data.tested !== 'number' || data.tested === 0) {
+      el.textContent = '';
+      return;
+    }
+    var parts = [];
+    if (data.improved > 0) parts.push(data.improved + ' fixed');
+    if (data.regressed > 0) parts.push(data.regressed + ' regressed');
+    if (data.same > 0) parts.push(data.same + ' same');
+    if (!parts.length) { el.textContent = ''; return; }
+    el.textContent = 'Regression: ' + parts.join(', ') + ' (7d)';
+    // Subtle color signal: red if anything regressed, green if any fixed
+    // and none regressed, muted otherwise.
+    if (data.regressed > 0) {
+      el.style.color = '#ef4444';
+    } else if (data.improved > 0) {
+      el.style.color = '#22c55e';
+    } else {
+      el.style.color = 'var(--text-muted)';
+    }
+  } catch (e) {
+    el.textContent = '';
   }
 }
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -4455,12 +4455,15 @@ function clawmetryLogout(){
       </div>
       <span class="stats-footer-sub" style="margin-left:auto;" id="reliability-detail"></span>
     </div>
-    <!-- Issue #1619 Phase 1 — eval score tile. Click opens the rubric editor. -->
+    <!-- Issue #1619 Phase 1 — eval score tile. Click opens the rubric editor.
+         Phase 3 adds the ``eval-regression-line`` mini-line under the score,
+         populated by loadEvalRegressionSummary() — silent on a fresh install. -->
     <div class="stats-footer-item" id="eval-card" style="cursor:pointer;" title="Click to edit the rubric" onclick="openEvalRubricModal()">
       <span class="stats-footer-icon">⭐</span>
       <div>
         <div class="stats-footer-label">Eval score (24h)</div>
         <div class="stats-footer-value" id="eval-avg-score">--</div>
+        <div id="eval-regression-line" style="font-size:10px;color:var(--text-muted);margin-top:2px;line-height:1.2;"></div>
       </div>
       <span class="stats-footer-sub" style="margin-left:auto;" id="eval-coverage"></span>
     </div>

--- a/routes/evals.py
+++ b/routes/evals.py
@@ -6,11 +6,12 @@ on the user's own API key; these endpoints just expose the persisted scores
 (local DuckDB) to the dashboard UI and to ad-hoc re-score requests.
 
 Routes:
-  GET   /api/evals/recent           — recent scored sessions
-  GET   /api/evals/summary          — aggregate avg/p50/p10 over a window
-  POST  /api/evals/rescore/<sid>    — manual re-eval trigger for one session
-  GET   /api/evals/rubric           — raw rubric YAML text
-  POST  /api/evals/rubric           — replace rubric YAML text (validates parse)
+  GET   /api/evals/recent              — recent scored sessions
+  GET   /api/evals/summary             — aggregate avg/p50/p10 over a window
+  POST  /api/evals/rescore/<sid>       — manual re-eval trigger for one session
+  GET   /api/evals/rubric              — raw rubric YAML text
+  POST  /api/evals/rubric              — replace rubric YAML text (validates parse)
+  GET   /api/evals/regression-summary  — Phase 3: aggregate replay outcomes
 
 All endpoints degrade gracefully when the local store or eval runner is
 unavailable — the dashboard treats an empty payload as "evals not yet
@@ -126,6 +127,43 @@ def evals_rubric_get():
         "default":        eval_runner.DEFAULT_RUBRIC,
         "enabled":        eval_runner.is_enabled(),
     })
+
+
+@bp_evals.route("/api/evals/regression-summary", methods=["GET"])
+def evals_regression_summary():
+    """Phase 3 (refs #1619) — aggregate replay outcomes over a window.
+
+    ``?window=7d`` (1d, 7d, 30d ok; bounded to 90d). Returns the same
+    payload shape ``run_regression`` builds, except aggregated from the
+    persisted ``eval_regression_runs`` table:
+
+        {tested: N, improved: X, regressed: Y, same: Z, errored: E,
+         window_days: D, last_run_at: <epoch_ms | null>}
+
+    Empty payload (all zeros + ``last_run_at: null``) on a fresh install
+    where the user hasn't run ``clawmetry eval --regression`` yet.
+    """
+    raw = (request.args.get("window") or "7d").strip().lower()
+    days = 7
+    try:
+        if raw.endswith("d"):
+            days = int(float(raw[:-1]))
+        elif raw.endswith("h"):
+            days = max(1, int(float(raw[:-1]) // 24))
+        else:
+            days = int(float(raw))
+    except (TypeError, ValueError):
+        days = 7
+    days = max(1, min(90, days))
+    try:
+        from clawmetry import eval_regression_replay as err
+        payload = err.regression_summary(window_days=days)
+    except Exception:
+        payload = {
+            "tested": 0, "improved": 0, "regressed": 0, "same": 0,
+            "errored": 0, "window_days": days, "last_run_at": None,
+        }
+    return jsonify(payload)
 
 
 @bp_evals.route("/api/evals/rubric", methods=["POST"])

--- a/tests/test_eval_regression_replay.py
+++ b/tests/test_eval_regression_replay.py
@@ -1,0 +1,480 @@
+"""Tests for ``clawmetry.eval_regression_replay`` — Phase 3 evals (refs #1619).
+
+Eight scenarios per the PRD:
+  1. find_failed_sessions — picks outcome IN (failed, escalated) + low-score
+  2. replay_session — improved (failed -> success with higher score)
+  3. replay_session — regressed (success -> failed)
+  4. replay_session — same (no meaningful delta)
+  5. compare_outcomes — pure-function rules (outcome > score)
+  6. persistence — run_regression writes rows to a fake store
+  7. API — /api/evals/regression-summary returns the aggregate shape
+  8. CLI — `clawmetry eval --regression` happy path + cost-guarded limit
+
+Honours the bug-class gate from feedback_synthetic_tests_missed_real_
+event_shape.md: real OpenClaw v3 event shapes (prompt.submitted with
+finalPromptText) feed the replay path, NOT synthetic ``message`` rows.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+from clawmetry import eval_regression_replay as err  # noqa: E402
+from clawmetry.eval_regression_replay import (  # noqa: E402
+    FailedSession,
+    ReplayResult,
+    compare_outcomes,
+    find_failed_sessions,
+    regression_summary,
+    replay_session,
+    run_regression,
+)
+from clawmetry.eval_suite_runner import AgentResponse  # noqa: E402
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+
+class _FakeStore:
+    """In-memory stand-in for ``LocalStore``. Serves canned ``sessions``
+    rows + per-session events, records persisted regression rows."""
+
+    def __init__(self, sessions=None, events=None):
+        # sessions: list of (sid, title, outcome, eval_score, last_active)
+        self._sessions = list(sessions or [])
+        # events: dict[session_id -> list[event dict]]
+        self._events = dict(events or {})
+        self.persisted: list[dict] = []
+
+    def _fetch(self, sql, params):
+        sql_l = " ".join(sql.split()).lower()
+        if "from sessions" in sql_l and "where" in sql_l and "outcome in" in sql_l:
+            # find_failed_sessions filter
+            low_thresh = float(params[0])
+            cutoff = params[1]
+            limit = int(params[-1])
+            out = []
+            for sid, title, outcome, score, last_active in self._sessions:
+                fails_outcome = outcome in ("failed", "escalated")
+                low_score = score is not None and score < low_thresh
+                if not (fails_outcome or low_score):
+                    continue
+                if cutoff and last_active and last_active < cutoff:
+                    continue
+                out.append((sid, title, outcome, score, last_active))
+            return out[:limit]
+        if "from sessions where session_id" in sql_l:
+            sid = params[0]
+            for s_sid, _t, outcome, score, _la in self._sessions:
+                if s_sid == sid:
+                    return [(outcome, score)]
+            return []
+        if "from eval_regression_runs" in sql_l:
+            cutoff_ms = int(params[0])
+            counts: dict[str, int] = {}
+            last_ms = 0
+            for r in self.persisted:
+                if r["replayed_at"] < cutoff_ms:
+                    continue
+                counts[r["status"]] = counts.get(r["status"], 0) + 1
+                if r["replayed_at"] > last_ms:
+                    last_ms = r["replayed_at"]
+            return [(s, n, last_ms) for s, n in counts.items()]
+        return []
+
+    def query_events(self, *, session_id, limit=200):
+        # Mirror DuckDB DESC ordering — newest ts first.
+        evs = list(self._events.get(session_id, []))
+        evs.sort(key=lambda e: e.get("ts", ""), reverse=True)
+        return evs[:limit]
+
+    def persist_eval_regression_run(self, **kwargs):
+        self.persisted.append(kwargs)
+
+
+def _v3_events(session_id, prompt_text="I need a refund"):
+    """Real OpenClaw v3 event shapes — prompt.submitted carries finalPromptText.
+    Honours the bug-class gate per feedback_synthetic_tests_missed_real_event_shape."""
+    return [
+        {
+            "session_id": session_id,
+            "event_type": "prompt.submitted",
+            "ts": "2026-05-15T10:00:00+00:00",
+            "data": {"finalPromptText": prompt_text},
+            "token_count": 12,
+        },
+        {
+            "session_id": session_id,
+            "event_type": "model.completed",
+            "ts": "2026-05-15T10:00:02+00:00",
+            "data": {"output": "Sorry, I cannot help."},
+            "token_count": 24,
+        },
+    ]
+
+
+# ── 1. find_failed_sessions picks the right rows ─────────────────────────────
+
+
+def test_find_failed_sessions_picks_failed_and_low_score():
+    store = _FakeStore(
+        sessions=[
+            ("s-fail", "Refund issue", "failed", None, "2026-05-15T10:00:00+00:00"),
+            ("s-esc", "Hand-off", "escalated", 4.0, "2026-05-15T11:00:00+00:00"),
+            ("s-low", "Bad answer", "success", 2.0, "2026-05-15T12:00:00+00:00"),
+            ("s-good", "Worked", "success", 5.0, "2026-05-15T13:00:00+00:00"),
+            ("s-unscored", "Unscored", "success", None, "2026-05-15T14:00:00+00:00"),
+        ],
+        events={
+            "s-fail": _v3_events("s-fail", "I need a refund"),
+            "s-esc": _v3_events("s-esc", "Escalate this"),
+            "s-low": _v3_events("s-low", "Help me"),
+        },
+    )
+    failed = find_failed_sessions(window_days=30, limit=10, store=store)
+    sids = {f.session_id for f in failed}
+    assert sids == {"s-fail", "s-esc", "s-low"}
+    by_id = {f.session_id: f for f in failed}
+    # Verifies the real-event-shape extraction reaches finalPromptText.
+    assert by_id["s-fail"].original_input == "I need a refund"
+    assert by_id["s-fail"].original_outcome == "failed"
+
+
+# ── 2. replay_session — improved (failed -> success with higher score) ───────
+
+
+def test_replay_session_improved():
+    fs = FailedSession(
+        session_id="s-1",
+        title="Refund failure",
+        original_input="I need a refund",
+        original_outcome="failed",
+        original_score=1.5,
+        last_active_at="2026-05-15T10:00:00+00:00",
+    )
+    agent = lambda inp: AgentResponse(text="Issued refund #1234.", tools_used=["refund"], outcome="success")
+    judge = lambda model, prompt, *, timeout=None: "SCORE: 5\nREASON: clean refund flow"
+    result = replay_session("s-1", failed_session=fs, agent_call=agent, judge_call=judge)
+    assert result.status == "improved"
+    assert result.original_outcome == "failed"
+    assert result.new_outcome == "success"
+    assert result.new_score == 5.0
+
+
+# ── 3. replay_session — regressed (success -> failed) ────────────────────────
+
+
+def test_replay_session_regressed():
+    fs = FailedSession(
+        session_id="s-2",
+        title="Was good",
+        original_input="What's the weather?",
+        original_outcome="success",
+        original_score=4.5,
+        last_active_at="",
+    )
+    # Original outcome is "success" but the session is low-score-flagged; new
+    # run produces an outright failure -> regression.
+    agent = lambda inp: AgentResponse(text="error", tools_used=[], outcome="failed")
+    judge = lambda model, prompt, *, timeout=None: "SCORE: 1\nREASON: broken"
+    result = replay_session("s-2", failed_session=fs, agent_call=agent, judge_call=judge)
+    assert result.status == "regressed"
+    assert result.new_outcome == "failed"
+
+
+# ── 4. replay_session — same (no meaningful delta) ───────────────────────────
+
+
+def test_replay_session_same_when_no_delta():
+    fs = FailedSession(
+        session_id="s-3",
+        title="Borderline",
+        original_input="hello",
+        original_outcome="failed",
+        original_score=2.0,
+        last_active_at="",
+    )
+    # Failed -> failed, score within dead band.
+    agent = lambda inp: AgentResponse(text="still broken", tools_used=[], outcome="failed")
+    judge = lambda model, prompt, *, timeout=None: "SCORE: 2.2\nREASON: same shape"
+    result = replay_session("s-3", failed_session=fs, agent_call=agent, judge_call=judge)
+    assert result.status == "same"
+
+
+def test_replay_session_error_when_no_input():
+    fs = FailedSession(
+        session_id="s-4", title="Empty", original_input="",
+        original_outcome="failed", original_score=None, last_active_at="",
+    )
+    agent = lambda inp: AgentResponse(text="x", tools_used=[], outcome="success")
+    result = replay_session("s-4", failed_session=fs, agent_call=agent)
+    assert result.status == "error"
+    assert "no original input" in result.reason.lower()
+
+
+# ── 5. compare_outcomes — pure rules ─────────────────────────────────────────
+
+
+def test_compare_outcomes_outcome_transition_wins():
+    assert compare_outcomes(
+        old_outcome="failed", old_score=4.5,
+        new_outcome="success", new_score=1.0,
+    ) == "improved"
+    assert compare_outcomes(
+        old_outcome="success", old_score=1.0,
+        new_outcome="failed", new_score=4.5,
+    ) == "regressed"
+
+
+def test_compare_outcomes_score_delta_in_dead_band():
+    # Outcome unchanged, score moves by less than 0.5 -> same.
+    assert compare_outcomes(
+        old_outcome="success", old_score=3.0,
+        new_outcome="success", new_score=3.3,
+    ) == "same"
+    # >= 0.5 delta crosses the dead band.
+    assert compare_outcomes(
+        old_outcome="success", old_score=3.0,
+        new_outcome="success", new_score=3.5,
+    ) == "improved"
+    assert compare_outcomes(
+        old_outcome="success", old_score=3.0,
+        new_outcome="success", new_score=2.5,
+    ) == "regressed"
+
+
+# ── 6. Persistence — run_regression writes to the fake store ─────────────────
+
+
+def test_run_regression_persists_to_store():
+    store = _FakeStore(
+        sessions=[
+            ("s-a", "Refund", "failed", 1.0, "2026-05-15T10:00:00+00:00"),
+            ("s-b", "Hand-off", "escalated", None, "2026-05-15T11:00:00+00:00"),
+        ],
+        events={
+            "s-a": _v3_events("s-a", "refund please"),
+            "s-b": _v3_events("s-b", "escalate"),
+        },
+    )
+    agent = lambda inp: AgentResponse(text="fixed", tools_used=["refund"], outcome="success")
+    judge = lambda model, prompt, *, timeout=None: "SCORE: 5\nREASON: ok"
+    run = run_regression(
+        window_days=30, limit=10, store=store,
+        agent_call=agent, judge_call=judge, persist=True,
+    )
+    assert run.tested == 2
+    assert run.improved == 2
+    assert run.regressed == 0
+    assert len(store.persisted) == 2
+    # All rows carry the canonical column set the schema migration expects.
+    for row in store.persisted:
+        assert set(row.keys()) >= {
+            "session_id", "status", "original_outcome", "new_outcome",
+            "original_score", "new_score", "reason", "replayed_at",
+        }
+        assert row["status"] == "improved"
+
+
+def test_regression_summary_aggregates_persisted_rows():
+    store = _FakeStore()
+    # Pre-populate the persisted log directly so we test the read path.
+    import time as _t
+    now_ms = int(_t.time() * 1000)
+    store.persisted.extend([
+        {"session_id": "x1", "status": "improved", "replayed_at": now_ms,
+         "original_outcome": "failed", "new_outcome": "success",
+         "original_score": 1.0, "new_score": 5.0, "reason": ""},
+        {"session_id": "x2", "status": "improved", "replayed_at": now_ms - 1000,
+         "original_outcome": "failed", "new_outcome": "success",
+         "original_score": 1.0, "new_score": 5.0, "reason": ""},
+        {"session_id": "x3", "status": "regressed", "replayed_at": now_ms - 2000,
+         "original_outcome": "success", "new_outcome": "failed",
+         "original_score": 4.5, "new_score": 1.0, "reason": ""},
+        {"session_id": "x4", "status": "same", "replayed_at": now_ms - 3000,
+         "original_outcome": "failed", "new_outcome": "failed",
+         "original_score": 2.0, "new_score": 2.1, "reason": ""},
+    ])
+    out = regression_summary(window_days=7, store=store)
+    assert out["tested"] == 4
+    assert out["improved"] == 2
+    assert out["regressed"] == 1
+    assert out["same"] == 1
+    assert out["window_days"] == 7
+    assert out["last_run_at"] == now_ms
+
+
+# ── 7. API — /api/evals/regression-summary returns the aggregate shape ───────
+
+
+def test_api_regression_summary_endpoint_shape(monkeypatch):
+    """Exercise the Flask route end-to-end via the test client. Patches the
+    summary helper so the endpoint doesn't reach the live DuckDB."""
+    sample = {
+        "tested": 5, "improved": 3, "regressed": 1, "same": 1,
+        "errored": 0, "window_days": 7, "last_run_at": 1234567890123,
+    }
+    monkeypatch.setattr(err, "regression_summary", lambda **kw: dict(sample))
+
+    from flask import Flask
+    from routes.evals import bp_evals
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_evals)
+    client = app.test_client()
+    resp = client.get("/api/evals/regression-summary?window=7d")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tested"] == 5
+    assert body["improved"] == 3
+    assert body["regressed"] == 1
+    assert body["window_days"] == 7
+    assert body["last_run_at"] == 1234567890123
+
+
+def test_api_regression_summary_handles_empty_store(monkeypatch):
+    """A fresh install (no run yet) returns the empty payload, not an error."""
+    monkeypatch.setattr(
+        err, "regression_summary",
+        lambda **kw: {
+            "tested": 0, "improved": 0, "regressed": 0, "same": 0,
+            "errored": 0, "window_days": 7, "last_run_at": None,
+        },
+    )
+    from flask import Flask
+    from routes.evals import bp_evals
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_evals)
+    client = app.test_client()
+    resp = client.get("/api/evals/regression-summary")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["tested"] == 0
+    assert body["last_run_at"] is None
+
+
+# ── 8. CLI — `clawmetry eval --regression` ──────────────────────────────────
+
+
+def test_cli_regression_invokes_run_regression(monkeypatch, capsys):
+    """Drive _cmd_eval through a synthetic argparse namespace; verify the
+    cost-guarded limit is respected and the summary prints. We patch the
+    runner module to avoid touching DuckDB or HTTP."""
+    from clawmetry import cli, eval_regression_replay as err_mod
+
+    captured = {}
+
+    def fake_run_regression(*, window_days, limit, **kwargs):
+        captured["window_days"] = window_days
+        captured["limit"] = limit
+        run = err_mod.RegressionRun(ran_at=1, window_days=window_days)
+        run.results.append(err_mod.ReplayResult(
+            session_id="abc", status="improved",
+            original_outcome="failed", new_outcome="success",
+            original_score=1.0, new_score=5.0,
+            reason="fixed", replayed_at=2,
+        ))
+        return run
+
+    monkeypatch.setattr(err_mod, "run_regression", fake_run_regression)
+    monkeypatch.setattr(err_mod, "is_enabled", lambda: True)
+
+    class _Args:
+        regression = True
+        window = "14d"
+        limit = 3
+        as_json = False
+
+    with pytest.raises(SystemExit) as exc:
+        cli._cmd_eval(_Args())
+    # 0 because no regressed/errored rows.
+    assert exc.value.code == 0
+    assert captured["window_days"] == 14
+    assert captured["limit"] == 3
+    out = capsys.readouterr().out
+    assert "1 improved" in out
+    assert "0 regressed" in out
+
+
+def test_cli_regression_exit_code_nonzero_on_regression(monkeypatch):
+    """A regressed row in the run should make the CLI exit 1 — that's the
+    CI-gate contract that mirrors --suite behavior."""
+    from clawmetry import cli, eval_regression_replay as err_mod
+
+    def fake_run(*, window_days, limit, **kwargs):
+        run = err_mod.RegressionRun(ran_at=1, window_days=window_days)
+        run.results.append(err_mod.ReplayResult(
+            session_id="z", status="regressed",
+            original_outcome="success", new_outcome="failed",
+            original_score=4.5, new_score=1.0,
+            reason="broke", replayed_at=2,
+        ))
+        return run
+
+    monkeypatch.setattr(err_mod, "run_regression", fake_run)
+    monkeypatch.setattr(err_mod, "is_enabled", lambda: True)
+
+    class _Args:
+        regression = True
+        window = "7d"
+        limit = None
+        as_json = False
+
+    with pytest.raises(SystemExit) as exc:
+        cli._cmd_eval(_Args())
+    assert exc.value.code == 1
+
+
+# ── Smoke: DuckDB v10 migration creates the regression table ────────────────
+
+
+def test_schema_v10_creates_eval_regression_runs_table(tmp_path, monkeypatch):
+    """End-to-end: opening a fresh LocalStore at v10 must create the table
+    and the persist + query methods must round-trip a row. Catches schema
+    drift bugs that synthetic _FakeStore tests would miss."""
+    db_file = tmp_path / "store.duckdb"
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(db_file))
+    # Force fresh import so the env var is honoured + reset singletons.
+    for mod in ("clawmetry.local_store",):
+        if mod in sys.modules:
+            del sys.modules[mod]
+    from clawmetry import local_store as ls
+    assert ls.SCHEMA_VERSION >= 10
+    # Patch DB_PATH on the freshly-loaded module — env-var-via-Path() was
+    # evaluated at import time so this belt+suspenders ensures the tmp file.
+    monkeypatch.setattr(ls, "DB_PATH", db_file)
+    store = ls.LocalStore()
+    try:
+        store.persist_eval_regression_run(
+            session_id="sid-1",
+            status="improved",
+            original_outcome="failed",
+            new_outcome="success",
+            original_score=1.0,
+            new_score=5.0,
+            reason="r",
+            replayed_at=10_000,
+        )
+        rows = store.query_recent_regression_runs(limit=10)
+        assert len(rows) == 1
+        assert rows[0]["session_id"] == "sid-1"
+        assert rows[0]["status"] == "improved"
+        assert rows[0]["new_score"] == 5.0
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass
+        ls._reset_singleton_for_tests()


### PR DESCRIPTION
## Summary
- New `clawmetry/eval_regression_replay.py` module: pulls yesterday's failed sessions from DuckDB (outcome IN failed/escalated OR eval_score < 3.0), replays each one's ORIGINAL user input through the current agent + prompt config, and persists improved/regressed/same rows. Reuses Phase 1 judge call + Phase 2 agent shell-out, so no new HTTP code paths and no new auth.
- Schema v9 → v10: `eval_regression_runs` table + `persist_eval_regression_run` / `query_recent_regression_runs` methods on `LocalStore`. Idempotent migration.
- New `GET /api/evals/regression-summary` endpoint returning `{tested, improved, regressed, same, errored, window_days, last_run_at}`.
- `clawmetry eval --regression --window 7d --limit N` CLI extension. Exit 1 on regressed/errored to mirror the `--suite` CI-gate contract.
- Eval tile gains a "Regression: X fixed, Y regressed (7d)" mini-line (silent on fresh installs).

## Cost guard
Every replay costs API tokens. The runner enforces a hard ceiling per invocation (`CLAWMETRY_EVALS_REGRESSION_MAX=10`) and the CLI is **manual invocation only** — no scheduler hook, no cron. User opts in every time.

## Closes the eval loop
- Phase 1 (#1623) = continuous LLM-as-judge on real sessions
- Phase 2 (#1626) = golden test sets + CLI runner
- Phase 3 (this PR) = "is my agent getting BETTER over time?"

## Memory respects
- `feedback_duckdb_first_rule` — all data flows through DuckDB; never reads JSONL.
- `feedback_no_em_dashes_in_user_facing_copy` — CLI/UI strings audited.
- `feedback_synthetic_tests_missed_real_event_shape` — replay path extracts `finalPromptText` from real OpenClaw v3 `prompt.submitted` events; v10-schema test round-trips persist+query through a real DuckDB file rather than only a `_FakeStore`.

## Test plan
- [x] 14 unit/integration tests pass (`tests/test_eval_regression_replay.py`)
  - find_failed_sessions picks failed + escalated + low-score rows
  - replay_session: improved / regressed / same / error-when-no-input
  - compare_outcomes: outcome transition wins, score delta dead-band
  - run_regression persists to store with the canonical column set
  - regression_summary aggregates persisted rows correctly
  - API endpoint shape + empty-store fallback
  - CLI happy path + non-zero exit on regression
  - v10 schema migration round-trip on a fresh DuckDB file
- [x] Phase 1 + Phase 2 test suites still green (34 passed, 1 skipped)
- [x] `python3 -m py_compile` clean on all touched modules
- [x] `dashboard.py` imports cleanly with the new blueprint route

DO NOT MERGE per task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)