### PR TITLE
fix(onboarding): first-heartbeat race shows 'Setting up your node' not blank (closes #1604)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -572,6 +572,81 @@ async function checkHeartbeatStatus() {
 visibilitySetInterval(checkHeartbeatStatus, 30000);
 setTimeout(checkHeartbeatStatus, 5000);
 
+// === Onboarding / First-Heartbeat Banner (closes #1604) =====================
+// After a fresh signup the daemon needs ~30s to come up + emit its first
+// heartbeat. Without a banner the dashboard shows empty cards that look
+// broken or - worse - might surface stale data from a prior tenant on the
+// same machine_id. We poll /api/heartbeat-status every 5s and:
+//   * status === "unknown" (no heartbeat yet) -> show "Setting up your node"
+//   * first heartbeat lands -> hide banner + trigger one full loadAll() so
+//     the live cards swap in smoothly instead of waiting for the 30s cycle.
+//   * 90s elapsed with no heartbeat -> switch copy to actionable error.
+var _cmOnboardingFirstSeenMs = 0;
+var _cmOnboardingDismissed = false;
+var _cmOnboardingTimer = null;
+var _CM_ONBOARDING_STALL_MS = 90 * 1000;
+
+async function checkOnboardingStatus() {
+  if (_cmOnboardingDismissed) return;
+  var banner = document.getElementById('onboarding-banner');
+  if (!banner) return;
+  var msgEl = document.getElementById('onboarding-banner-msg');
+  var etaEl = document.getElementById('onboarding-banner-eta');
+  var spinEl = document.getElementById('onboarding-banner-spinner');
+  try {
+    var data = await fetch('/api/heartbeat-status').then(function(r){return r.json();});
+    var firstHeartbeatLanded = (
+      data && data.status && data.status !== 'unknown' &&
+      data.last_heartbeat_ts && data.last_heartbeat_ts > 0
+    );
+    if (firstHeartbeatLanded) {
+      // Smooth handoff: hide the banner, mark as dismissed for this session
+      // so we don't re-flash on a transient blip, and kick a fresh loadAll
+      // so the now-live cards render without waiting for the next 30s tick.
+      banner.style.display = 'none';
+      _cmOnboardingDismissed = true;
+      if (_cmOnboardingTimer) { clearInterval(_cmOnboardingTimer); _cmOnboardingTimer = null; }
+      if (typeof loadAll === 'function') {
+        try { loadAll(); } catch(e) {}
+      }
+      return;
+    }
+    // Still waiting. Show the banner; track when we first saw the empty
+    // state so we can flip to the stall message after 90s.
+    if (_cmOnboardingFirstSeenMs === 0) _cmOnboardingFirstSeenMs = Date.now();
+    var waitedMs = Date.now() - _cmOnboardingFirstSeenMs;
+    banner.style.display = 'flex';
+    if (waitedMs < _CM_ONBOARDING_STALL_MS) {
+      var remainingSec = Math.max(5, Math.round((_CM_ONBOARDING_STALL_MS - waitedMs) / 1000));
+      if (msgEl) msgEl.textContent = 'Setting up your node. First check-in usually arrives in about 30 seconds.';
+      if (etaEl) etaEl.textContent = 'checking again in 5s';
+      if (spinEl) spinEl.style.display = 'inline-block';
+      banner.style.background = 'linear-gradient(90deg,#0c1d3a 0%,#1a1a2e 100%)';
+      banner.style.borderColor = '#3b82f6';
+      banner.style.color = '#93c5fd';
+      void remainingSec;
+    } else {
+      // Stalled past 90s. Swap to actionable copy. No demo data, no
+      // pretend-it-worked - just tell the user what to check.
+      if (msgEl) msgEl.textContent = "Still waiting for your daemon's first check-in. Try: run 'clawmetry status' in a terminal, or restart with 'clawmetry'.";
+      if (etaEl) etaEl.textContent = 'still retrying every 5s';
+      if (spinEl) spinEl.style.display = 'none';
+      banner.style.background = '#3f2a06';
+      banner.style.borderColor = '#f59e0b';
+      banner.style.color = '#fbbf24';
+    }
+  } catch(e) {
+    // Transient fetch failure - keep the banner in its current state, do
+    // NOT dismiss (per feedback_persistent_sessions: don't surface auth /
+    // network blips as terminal user-facing errors).
+  }
+}
+
+// Poll every 5s while the banner is active. First check is fast (300ms)
+// so a returning user with an already-warm daemon barely sees the banner.
+_cmOnboardingTimer = setInterval(checkOnboardingStatus, 5000);
+setTimeout(checkOnboardingStatus, 300);
+
 function dismissPausedBanner() {
   localStorage.setItem('cm_paused_banner_dismissed', String(Date.now()));
   var banner = document.getElementById('paused-banner');

--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -123,6 +123,40 @@
     ">Dismiss</button>
 </div>
 
+<!-- Onboarding / First-Heartbeat Banner (closes #1604) -->
+<!-- Shown on fresh signup until the first heartbeat lands. Auto-refreshes -->
+<!-- every 5s. After 90s with no heartbeat we switch to an actionable error -->
+<!-- so a stuck daemon doesn't masquerade as "loading forever". -->
+<div id="onboarding-banner" style="
+  display:none;
+  padding:12px 16px;
+  border-bottom:2px solid #3b82f6;
+  font-size:13px;
+  font-weight:600;
+  align-items:center;
+  gap:12px;
+  background:linear-gradient(90deg,#0c1d3a 0%,#1a1a2e 100%);
+  color:#93c5fd;
+  ">
+  <span id="onboarding-banner-spinner" style="
+    display:inline-block;
+    width:14px;
+    height:14px;
+    border:2px solid #3b82f680;
+    border-top-color:#60a5fa;
+    border-radius:50%;
+    animation:onboarding-spin 0.9s linear infinite;
+    flex-shrink:0;
+    "></span>
+  <span id="onboarding-banner-msg" style="flex:1;">Setting up your node. First check-in usually arrives in about 30 seconds.</span>
+  <span id="onboarding-banner-eta" style="font-size:11px;font-weight:400;color:#60a5fa;opacity:0.85;"></span>
+</div>
+<style>
+@keyframes onboarding-spin {
+  to { transform: rotate(360deg); }
+}
+</style>
+
 <!-- Heartbeat Gap Banner -->
 <div id="heartbeat-banner" style="
   display:none;

--- a/tests/test_first_heartbeat_onboarding.py
+++ b/tests/test_first_heartbeat_onboarding.py
@@ -1,0 +1,190 @@
+"""Tests for issue #1604 — first-heartbeat race after signup.
+
+Symptom: between user signup and the first heartbeat (~30s window) the
+dashboard would render either an empty grid (looks broken) or — worst
+case — stale data from a prior tenant on the same machine_id (privacy-
+adjacent). The fix surfaces an explicit "Setting up your node" banner
+that auto-refreshes every 5s and transitions cleanly on first heartbeat.
+Past 90s it switches to actionable error copy so a stuck daemon does
+not masquerade as "loading forever".
+
+The OSS dashboard's source of truth for "has the daemon checked in yet"
+is ``/api/heartbeat-status`` (returns ``status="unknown"`` while
+``_last_heartbeat_ts == 0``). This suite pins:
+
+  * the API contract the banner JS depends on (3 scenarios)
+  * the banner partial actually carries the user-facing copy + auto-
+    refresh metadata the JS toggles between
+  * memory respects (no em-dashes, simple-non-technical copy, no
+    sign-out / location.reload on transient empty state).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+
+# ── Scenario 1: fresh signup, no heartbeat yet → "setting up" state ───────
+def test_no_heartbeat_yet_returns_unknown_status(monkeypatch):
+    """Fresh dashboard import + no heartbeat recorded → status='unknown'.
+
+    This is the exact predicate the onboarding banner JS gates on:
+    ``data.status === 'unknown'`` keeps the banner visible. Anything else
+    here would mean either (a) the banner never shows (regression) or
+    (b) the banner shows even after a real heartbeat (regression).
+    """
+    import dashboard as _d
+    # Simulate a fresh process: no heartbeat has ever been recorded.
+    monkeypatch.setattr(_d, "_last_heartbeat_ts", 0, raising=False)
+    monkeypatch.setattr(_d, "_heartbeat_silent_since", 0, raising=False)
+
+    payload = _d._get_heartbeat_status()
+    assert payload["status"] == "unknown", (
+        "fresh-signup pre-first-heartbeat MUST return status='unknown' so "
+        "the onboarding banner gates on it; got " + repr(payload["status"])
+    )
+    # The banner JS also reads last_heartbeat_ts; must be falsy.
+    assert not payload["last_heartbeat_ts"], (
+        "must not surface a stale ts during the pre-first-heartbeat window "
+        "(privacy-adjacent — see issue #1604 root cause)"
+    )
+    # gap_seconds MUST be None — anything else implies we're computing a gap
+    # against epoch-0 and would render "57 years ago" in the UI.
+    assert payload["gap_seconds"] is None
+
+
+# ── Scenario 2: first heartbeat arrives → banner JS detects + hides ──────
+def test_first_heartbeat_flips_status_off_unknown(monkeypatch):
+    """Once ``_last_heartbeat_ts`` is set, status must leave ``unknown``.
+
+    The onboarding banner JS treats any status !== 'unknown' AND a non-
+    zero ``last_heartbeat_ts`` as "first heartbeat landed → hide banner
+    + kick a fresh loadAll()". Both fields are checked here.
+    """
+    import dashboard as _d
+    now = time.time()
+    monkeypatch.setattr(_d, "_last_heartbeat_ts", now, raising=False)
+    monkeypatch.setattr(_d, "_heartbeat_silent_since", 0, raising=False)
+
+    payload = _d._get_heartbeat_status()
+    assert payload["status"] != "unknown", (
+        "after first heartbeat the banner JS hides on status != 'unknown'; "
+        "anything still 'unknown' here would leave the banner stuck on"
+    )
+    # 'ok' is the expected freshly-pinged state (gap <= interval).
+    assert payload["status"] == "ok"
+    assert payload["last_heartbeat_ts"] == pytest.approx(now, rel=1e-3)
+    assert payload["gap_seconds"] is not None
+    assert payload["gap_seconds"] >= 0
+
+
+# ── Scenario 3: heartbeat NEVER arrives (>90s stall) → still 'unknown' ───
+def test_long_stall_keeps_status_unknown_so_banner_can_swap_to_error(monkeypatch):
+    """A daemon that never reports must keep status='unknown' indefinitely.
+
+    The banner JS tracks wall-clock since the first 'unknown' response
+    and after 90s swaps copy from "Setting up your node..." to an
+    actionable "still waiting — try 'clawmetry status'..." error. The
+    backend's job is just to keep returning 'unknown' so the JS can
+    own the timeout policy without races between cron + render.
+    """
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_last_heartbeat_ts", 0, raising=False)
+    monkeypatch.setattr(_d, "_heartbeat_silent_since", 0, raising=False)
+
+    # First poll - the JS would start its 90s wall-clock here.
+    p1 = _d._get_heartbeat_status()
+    assert p1["status"] == "unknown"
+    # Simulate the JS still polling 100s later (over the stall threshold).
+    # The backend MUST still report 'unknown' (not 'silent' or 'missed'
+    # or - worst - 'ok' because some other code path stamped the ts).
+    p2 = _d._get_heartbeat_status()
+    assert p2["status"] == "unknown", (
+        "even at 100s+ post-signup the backend keeps reporting 'unknown' "
+        "so the banner JS owns the 90s timeout policy"
+    )
+    assert p2["last_heartbeat_ts"] == 0
+
+
+# ── Banner partial: user-facing copy + memory respects ────────────────────
+def _read_banners_html():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    path = os.path.join(here, "clawmetry", "templates", "partials", "banners.html")
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _read_app_js():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    path = os.path.join(here, "clawmetry", "static", "js", "app.js")
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_onboarding_banner_partial_carries_setting_up_copy():
+    html = _read_banners_html()
+    assert 'id="onboarding-banner"' in html, (
+        "onboarding banner element must exist in banners.html partial"
+    )
+    # Per feedback_simple_ui_for_nontechnical: "Setting up your node",
+    # NOT "Awaiting initial heartbeat" or similar jargon.
+    assert "Setting up your node" in html
+    # Must explain the ~30s expectation so users do not assume it broke.
+    assert "30 seconds" in html
+
+
+def test_onboarding_banner_partial_avoids_em_dashes_in_user_copy():
+    """Per memory ``feedback_no_em_dashes_in_user_facing_copy``."""
+    html = _read_banners_html()
+    # Find the onboarding banner block and assert no em-dash inside the
+    # user-visible copy region. (Other banners in the file are out of
+    # scope for this fire.)
+    start = html.find('id="onboarding-banner"')
+    assert start != -1
+    end = html.find("</div>", start + html[start:].find('</span>'))
+    block = html[start:end + 6]
+    assert "—" not in block, "em-dash banned in user-facing onboarding copy"
+
+
+def test_onboarding_js_does_not_reload_or_sign_out_on_transient_failure():
+    """Per memory ``feedback_no_reload_in_bootstrap_e2e`` and
+    ``feedback_persistent_sessions`` — the banner refresh loop must NOT
+    call ``location.reload()`` or redirect to /login on a fetch failure.
+    """
+    js = _read_app_js()
+    # Locate the onboarding block by its sentinel constant name and
+    # extract just that function for the assertions.
+    anchor = js.find("checkOnboardingStatus")
+    assert anchor != -1, "checkOnboardingStatus must be defined in app.js"
+    # Pull a generous window (~5 KB) starting at the anchor — should
+    # contain the whole function + its setInterval registration.
+    block = js[anchor:anchor + 5000]
+    assert "location.reload" not in block, (
+        "onboarding banner must not page-reload during the warm-up window "
+        "(per feedback_no_reload_in_bootstrap_e2e.md)"
+    )
+    assert "/login" not in block, (
+        "onboarding banner must not redirect to /login on transient empty "
+        "state (per feedback_persistent_sessions.md)"
+    )
+    # Auto-refresh contract: must poll every 5s per the issue spec.
+    assert "5000" in block, "banner must auto-refresh every 5s per issue #1604"
+    # Stall threshold contract: must flip to actionable copy at 90s.
+    assert "_CM_ONBOARDING_STALL_MS" in block or "90 * 1000" in block
+
+
+def test_onboarding_js_kicks_loadall_on_first_heartbeat():
+    """Smooth handoff: when the first heartbeat lands the banner must
+    trigger a fresh loadAll() so the live cards swap in instantly
+    instead of waiting for the next 30s tick."""
+    js = _read_app_js()
+    anchor = js.find("checkOnboardingStatus")
+    assert anchor != -1
+    block = js[anchor:anchor + 5000]
+    assert "loadAll" in block, (
+        "first-heartbeat handoff must call loadAll() so live cards render "
+        "immediately, not after the next refresh cycle (issue #1604)"
+    )


### PR DESCRIPTION
## Summary

Issue #1604 (P1, silent-failure taxonomy / privacy-adjacent): between user signup and the daemon's first heartbeat (~30s window), the dashboard rendered an empty grid that looks broken, and in the worst case could surface stale data from a prior tenant on the same machine_id.

This OSS-side fix adds an explicit **"Setting up your node"** banner:

- Shows the banner whenever `/api/heartbeat-status` reports `status='unknown'` (i.e. `_last_heartbeat_ts == 0`).
- Auto-refreshes every 5s.
- The moment the first heartbeat lands, hides the banner AND calls `loadAll()` so the live cards render instantly instead of waiting for the next 30s refresh tick.
- After 90s with no heartbeat, swaps copy from "Setting up your node..." to actionable error pointing at `clawmetry status` so a stuck daemon does not masquerade as "loading forever".

Memory respects baked in as test contracts:
- No em-dashes in user-facing copy (`feedback_no_em_dashes_in_user_facing_copy.md`)
- "Setting up your node" not "Awaiting initial heartbeat" (`feedback_simple_ui_for_nontechnical.md`)
- No `location.reload()` / no `/login` redirect on transient fetch failure (`feedback_no_reload_in_bootstrap_e2e.md` + `feedback_persistent_sessions.md`)

## Surface decision

The issue noted "cross-repo" but the actual rendering surface a new user lands on after `clawmetry` boots is the **OSS dashboard at `localhost:8900`** — the cloud dashboard is opt-in via "Enable Cloud Sync". Fixing the OSS surface kills the empty-state-looks-broken bug at the root. A follow-up cloud-side ticket can mirror this banner on `app.clawmetry.com/cloud` for users who jump straight there.

## LOC

- 75 LOC `clawmetry/static/js/app.js` (`checkOnboardingStatus()` + polling)
- 34 LOC `clawmetry/templates/partials/banners.html` (banner element + spinner keyframes)
- 190 LOC `tests/test_first_heartbeat_onboarding.py` (7 cases: 3 issue scenarios + 4 memory-respect contracts)

Production: 109 LOC (under 150 budget). Tests: 190 LOC (slightly over 150 budget, justified by the 4 explicit memory-respect contract assertions the prompt requested).

## Test plan

- [x] `python3 -m pytest tests/test_first_heartbeat_onboarding.py -v` — 7/7 pass
- [x] `python3 -c "import dashboard"` — clean
- [x] `node -c clawmetry/static/js/app.js` — clean
- [x] `jinja2.Environment.render('partials/banners.html')` — banner element + copy present, no em-dashes
- [ ] Manual smoke: start fresh `clawmetry`, watch banner show + auto-hide on first heartbeat
- [ ] Manual smoke: kill daemon, watch banner flip to actionable error at 90s

🤖 Generated with [Claude Code](https://claude.com/claude-code)