### PR TITLE
fix(local_store): LOCAL_MAX_BYTES auto-vacuum on write (closes #1594)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -124,6 +124,57 @@ LOCAL_MAX_BYTES = int(
     float(os.environ.get("CLAWMETRY_LOCAL_MAX_GB", "5.0")) * 1024 * 1024 * 1024
 )
 
+# Issue #1594 — auto-vacuum knobs. Vacuum is destructive (deletes oldest
+# events permanently), so the defaults are conservative:
+#   * AUTO_VACUUM_ENABLED — default ON. Set CLAWMETRY_AUTO_VACUUM=0 to
+#     disable for users who manage retention externally (rsync, snapshots).
+#   * AUTO_VACUUM_CHECK_EVERY_BYTES — only stat() + size-check after every
+#     N bytes flushed (default 100 MB). Cheap, predictable, no periodic
+#     thread to leak.
+#   * AUTO_VACUUM_HIGH_WATER_PCT — only fire when DB has crossed this
+#     fraction of LOCAL_MAX_BYTES (default 0.95). Below the high-water
+#     mark we leave the store alone; the user paid for retention up to
+#     the cap, we honour it.
+# When vacuum still can't bring the store under the cap (retention rules
+# too generous, or single event rows pathologically large), we log a loud
+# WARNING + emit a ``local_store_over_cap`` event into the store itself so
+# /local/health + cloud dashboards can surface the cap_exceeded flag.
+AUTO_VACUUM_ENABLED = os.environ.get("CLAWMETRY_AUTO_VACUUM", "1") not in ("0", "false", "False", "")
+AUTO_VACUUM_CHECK_EVERY_BYTES = int(
+    float(os.environ.get("CLAWMETRY_AUTO_VACUUM_CHECK_MB", "100")) * 1024 * 1024
+)
+AUTO_VACUUM_HIGH_WATER_PCT = float(
+    os.environ.get("CLAWMETRY_AUTO_VACUUM_HIGH_WATER_PCT", "0.95")
+)
+# Min seconds between LOCAL_STORE_OVER_CAP warning / marker emissions.
+# Rate-limit because DuckDB doesn't shrink the file in-place after DELETE
+# — the file size plateaus near the high-water mark and would otherwise
+# spam every flush. 5 min is short enough to surface the regression
+# quickly but long enough that a tail -f doesn't drown.
+AUTO_VACUUM_OVER_CAP_COOLDOWN_S = float(
+    os.environ.get("CLAWMETRY_AUTO_VACUUM_OVER_CAP_COOLDOWN_S", "300.0")
+)
+
+
+def _on_disk_bytes() -> int:
+    """Total on-disk footprint = main DB file + WAL. The DuckDB main file
+    only grows on CHECKPOINT; at runtime the bulk of recently-flushed data
+    sits in the ``.wal`` file. Looking only at ``DB_PATH.stat()`` (as the
+    pre-#1594 ``health()`` and ``vacuum()`` did) silently under-counts the
+    real footprint by 10×+ during active ingest — the cap never trips even
+    when the wallclock disk usage is already over."""
+    total = 0
+    try:
+        total += DB_PATH.stat().st_size
+    except OSError:
+        pass
+    wal = DB_PATH.with_suffix(DB_PATH.suffix + ".wal")
+    try:
+        total += wal.stat().st_size
+    except OSError:
+        pass
+    return total
+
 SCHEMA_VERSION = 10
 
 # ── Two-layer schema (multi-agent) ──────────────────────────────────────────
@@ -968,6 +1019,32 @@ class LocalStore:
         self._flusher_stop = threading.Event()
         self._flusher_thread: threading.Thread | None = None
         self._last_flush_ts = time.monotonic()
+        # Issue #1594 — auto-vacuum bookkeeping. ``_bytes_since_vacuum_check``
+        # accumulates an approximation of the bytes flushed since we last
+        # stat()ed the DB file; once it crosses ``AUTO_VACUUM_CHECK_EVERY_BYTES``
+        # we check the real on-disk size against the high-water mark. We don't
+        # stat on EVERY flush because stat() on the DuckDB file is cheap but
+        # not free and flushes can run 10/s. ``_cap_exceeded`` is the public
+        # /local/health flag the dashboard footer surfaces (#1594 detection
+        # strategy); ``_auto_vacuum_running`` guards against re-entrant vacuum
+        # calls if a flush triggers vacuum which itself triggers a flush.
+        self._bytes_since_vacuum_check = 0
+        self._cap_exceeded = False
+        self._auto_vacuum_running = False
+        self._auto_vacuum_lock = threading.Lock()
+        # Issue #1594 — DuckDB does not shrink the main file in-place
+        # after DELETE; freed pages are reused by subsequent inserts but
+        # the on-disk size plateaus at the high-water mark. Without a
+        # cooldown, every flush would re-trigger the over-cap path and
+        # spam the log + repeatedly emit marker events. We rate-limit
+        # the warning + marker to once per cooldown window.
+        # ``None`` sentinel = "no warning yet" — the cooldown check uses
+        # ``None`` to mean "always fire on first hit", independent of
+        # the cooldown window or process uptime. Using a numeric 0
+        # sentinel would break tests that set the cooldown larger than
+        # process uptime (first warning would mis-fire as already-on-
+        # cooldown because ``time.monotonic() - 0 < cooldown``).
+        self._last_over_cap_warning_ts: float | None = None
         if not read_only:
             # Rename the legacy events.duckdb in place BEFORE opening — once
             # we hold a connection we can't atomically rename the file out
@@ -3034,7 +3111,18 @@ class LocalStore:
         snapshot the same batch and each pop ``len(batch)`` items, evicting
         events the other snapshotted but had not yet written."""
         with self._flush_lock:
-            return self._flush_now_locked()
+            n = self._flush_now_locked()
+        # Issue #1594 — auto-vacuum check runs OUTSIDE ``_flush_lock`` so
+        # the vacuum body (which itself acquires ``_write_lock`` and does
+        # an internal CHECKPOINT + possible row delete) does not block
+        # subsequent flushes longer than necessary, and more importantly
+        # so re-entering ``_flush_now`` from inside the vacuum path (it
+        # used to call ``self._flush_now()`` at the top) cannot deadlock.
+        try:
+            self._maybe_auto_vacuum()
+        except Exception:
+            log.exception("local store: auto-vacuum gate failed")
+        return n
 
     def _flush_now_locked(self) -> int:
         with self._ring_lock:
@@ -3085,6 +3173,15 @@ class LocalStore:
                 if self._ring:
                     self._ring.popleft()
         self._last_flush_ts = time.monotonic()
+        # Issue #1594 — accumulate an approximation of bytes flushed; the
+        # real on-disk size is checked only when this crosses
+        # ``AUTO_VACUUM_CHECK_EVERY_BYTES`` to keep the hot path fast.
+        # 512 B/row is a coarse upper bound for the typical event shape
+        # (id + small JSON blob); a few-pct overshoot just means we stat()
+        # slightly earlier than strictly necessary, which is fine. The
+        # actual auto-vacuum check fires in ``_flush_now`` AFTER we drop
+        # ``_flush_lock`` — see comment there.
+        self._bytes_since_vacuum_check += len(rows) * 512
         # Issue #1343 Phase 2.2 — kick the approvals watcher when a tool_call
         # row just landed. The watcher_loop reads from DuckDB; the COMMIT
         # above is what makes the row visible to it. Kicking before the
@@ -5385,7 +5482,11 @@ class LocalStore:
     def health(self) -> dict[str, Any]:
         """Snapshot of store state — for the /local/health endpoint and the
         dashboard footer."""
-        size_bytes = DB_PATH.stat().st_size if DB_PATH.exists() else 0
+        # Issue #1594 — measure main + WAL. The WAL is where DuckDB stages
+        # recent writes until CHECKPOINT; ignoring it under-counted the
+        # real disk footprint by an order of magnitude during active
+        # ingest, which is exactly when the dashboard most wants to know.
+        size_bytes = _on_disk_bytes()
         rows = self._fetch(
             "SELECT COUNT(*) AS n, MIN(ts) AS oldest, MAX(ts) AS newest FROM events",
             []
@@ -5400,6 +5501,13 @@ class LocalStore:
             "size_bytes": int(size_bytes),
             "size_mb": round(size_bytes / 1024 / 1024, 2),
             "size_cap_bytes": LOCAL_MAX_BYTES,
+            # Issue #1594 — surfaced to dashboard footer + cloud-side
+            # alerts. True when the last auto-vacuum attempt could not
+            # bring the store back under LOCAL_MAX_BYTES; remains True
+            # until either retention shrinks naturally or the next
+            # vacuum succeeds.
+            "cap_exceeded": bool(self._cap_exceeded),
+            "auto_vacuum_enabled": bool(AUTO_VACUUM_ENABLED),
             "event_count": int(n or 0),
             "oldest_ts": oldest,
             "newest_ts": newest,
@@ -5414,9 +5522,35 @@ class LocalStore:
     def vacuum(self, *, prune_to_bytes: int | None = None) -> dict[str, Any]:
         """Reclaim space. If ``prune_to_bytes`` is set (or the DB has exceeded
         ``LOCAL_MAX_BYTES``), delete oldest events first until the projected
-        size fits, then run a CHECKPOINT to reclaim file size."""
+        size fits, then run a CHECKPOINT to reclaim file size.
+
+        Issue #1594 — ``before_size`` is now main+WAL (was just main), so the
+        prune decision matches the real on-disk footprint instead of the
+        post-checkpoint snapshot. Without this, ``before_size`` typically
+        showed 12 KB during active ingest while the WAL held 10 MB, so the
+        prune branch never fired even when the daemon was already over cap."""
+        # Public entry: drain the ring first so the prune accounting includes
+        # everything currently in flight. Auto-vacuum (called from inside
+        # ``_flush_now_locked``) skips this step via ``_vacuum_locked`` —
+        # re-entering ``_flush_now`` here would deadlock on ``_flush_lock``.
         self._flush_now()
-        before_size = DB_PATH.stat().st_size if DB_PATH.exists() else 0
+        return self._vacuum_locked(prune_to_bytes=prune_to_bytes)
+
+    def _vacuum_locked(self, *, prune_to_bytes: int | None = None) -> dict[str, Any]:
+        """Core vacuum body — assumes ring is already drained (or that the
+        caller is fine with skipping in-flight events). Safe to call from
+        any thread that does NOT currently hold ``_flush_lock``-protected
+        state; specifically called from ``_maybe_auto_vacuum`` AFTER the
+        flush body has released its locks via the outer scheduling."""
+        # CHECKPOINT first so the main file reflects everything we just
+        # flushed; then both ``before_size`` and the row-arithmetic below
+        # operate on a consistent snapshot.
+        with self._write_lock:
+            try:
+                self._conn.execute("CHECKPOINT")
+            except Exception:
+                log.exception("local store: pre-prune CHECKPOINT failed")
+        before_size = _on_disk_bytes()
         cap = prune_to_bytes if prune_to_bytes is not None else LOCAL_MAX_BYTES
         deleted = 0
         if before_size > cap:
@@ -5425,6 +5559,17 @@ class LocalStore:
                 bytes_per_row = before_size / n_rows
                 excess_bytes = (before_size - cap) * 1.2
                 rows_to_drop = int(excess_bytes / bytes_per_row) if bytes_per_row else 0
+                # Issue #1594 — never drop more than 80 % of rows in
+                # one pass. The bytes-per-row estimate is coarse (DuckDB
+                # WAL + page layout differs across writes), and on a
+                # heavily-over-cap store (e.g. cap=1 B test fixture, or
+                # a real install hit by burst ingest) the naive estimate
+                # can compute ``rows_to_drop > n_rows``. DELETE ... LIMIT
+                # with that value would wipe the entire history in one
+                # cycle. Capping preserves the oldest-evicted invariant
+                # while leaving the user some recent data; subsequent
+                # flushes will continue to vacuum if still over cap.
+                rows_to_drop = min(rows_to_drop, max(1, int(n_rows * 0.8)))
                 if rows_to_drop > 0:
                     with self._write_lock:
                         with _txn(self._conn):
@@ -5450,7 +5595,7 @@ class LocalStore:
                 self._conn.execute("CHECKPOINT")
             except Exception:
                 log.exception("local store: CHECKPOINT failed")
-        after_size = DB_PATH.stat().st_size if DB_PATH.exists() else 0
+        after_size = _on_disk_bytes()
         return {
             "deleted_rows": int(deleted),
             "before_bytes": before_size,
@@ -5458,6 +5603,141 @@ class LocalStore:
             "cap_bytes": cap,
             "reclaimed_bytes": max(0, before_size - after_size),
         }
+
+    # ── Issue #1594 — on-write auto-vacuum ──────────────────────────────
+    #
+    # Called from ``_flush_now_locked`` after every successful flush.
+    # Cheap fast path: increment a byte-counter and bail unless we've
+    # crossed the check threshold. Hot path is two int compares + a
+    # branch; the stat() / size compare / vacuum call only runs once
+    # per ~100 MB written.
+    def _maybe_auto_vacuum(self) -> None:
+        """Auto-vacuum gate (#1594). Runs after each flush; fires the real
+        vacuum only when we've written enough since the last check AND the
+        store has crossed ``AUTO_VACUUM_HIGH_WATER_PCT`` of the cap.
+
+        Reentrancy: ``_auto_vacuum_running`` guards against vacuum →
+        flush → vacuum cycles. Errors are swallowed (logged) — auto-vacuum
+        must never crash the flusher; the manual ``vacuum()`` endpoint and
+        the next tick will retry."""
+        if not AUTO_VACUUM_ENABLED:
+            return
+        if self._bytes_since_vacuum_check < AUTO_VACUUM_CHECK_EVERY_BYTES:
+            return
+        # Acquire under lock so concurrent flushers don't both pass the
+        # gate; the second waits, sees _auto_vacuum_running and returns.
+        with self._auto_vacuum_lock:
+            if self._auto_vacuum_running:
+                return
+            if self._bytes_since_vacuum_check < AUTO_VACUUM_CHECK_EVERY_BYTES:
+                return  # someone else already drained the counter
+            self._auto_vacuum_running = True
+            self._bytes_since_vacuum_check = 0
+        try:
+            size = _on_disk_bytes()
+            high_water = int(LOCAL_MAX_BYTES * AUTO_VACUUM_HIGH_WATER_PCT)
+            if size < high_water:
+                # Healthy — clear any prior cap_exceeded flag and bail.
+                self._cap_exceeded = False
+                return
+            log.info(
+                "local store: auto-vacuum fired (size=%d B, high_water=%d B, "
+                "cap=%d B) — pruning oldest events to fit",
+                size, high_water, LOCAL_MAX_BYTES,
+            )
+            # Use the locked body directly — we're already past the flush
+            # boundary and re-entering the public ``vacuum()`` would call
+            # ``_flush_now`` which (depending on stack ordering) can race
+            # with the very next flusher tick. The ring just drained.
+            res = self._vacuum_locked()
+            after = res.get("after_bytes", 0)
+            deleted = res.get("deleted_rows", 0)
+            if after > LOCAL_MAX_BYTES:
+                # Hard-cap miss: vacuum ran but the on-disk file is
+                # still above cap. Two failure modes:
+                #   a) deleted == 0 — we couldn't fit any rows (cap
+                #      pathologically small, e.g. 1 B). Real escalation.
+                #   b) deleted > 0 — rows came out but DuckDB hasn't
+                #      shrunk the main file (DELETE doesn't compact in
+                #      v1.4.x). Freed pages WILL be reused by subsequent
+                #      ingest, so growth is bounded — but we still flag
+                #      cap_exceeded so dashboards/cloud can surface the
+                #      condition. Rate-limit the warning + marker
+                #      (every flush would otherwise re-fire it).
+                self._cap_exceeded = True
+                now = time.monotonic()
+                cooled_down = (
+                    self._last_over_cap_warning_ts is None
+                    or (now - self._last_over_cap_warning_ts)
+                       >= AUTO_VACUUM_OVER_CAP_COOLDOWN_S
+                )
+                if cooled_down:
+                    self._last_over_cap_warning_ts = now
+                    log.warning(
+                        "local store: LOCAL_STORE_OVER_CAP — vacuum could "
+                        "not bring on-disk size under cap (after=%d B, "
+                        "cap=%d B, deleted_rows=%d). DuckDB does not "
+                        "shrink the main file after DELETE; freed pages "
+                        "will be reused by new ingest so growth is "
+                        "bounded, but consider lowering retention, "
+                        "raising CLAWMETRY_LOCAL_MAX_GB, or setting "
+                        "CLAWMETRY_AUTO_VACUUM=0 to manage retention "
+                        "externally.",
+                        after, LOCAL_MAX_BYTES, deleted,
+                    )
+                    try:
+                        self._emit_over_cap_marker(after)
+                    except Exception:
+                        # Marker is best-effort: never crash the flusher
+                        # on a write failure inside the metric path.
+                        log.exception("local store: over-cap marker emit failed")
+            else:
+                self._cap_exceeded = False
+                log.info(
+                    "local store: auto-vacuum reclaimed %d B (deleted %d rows, "
+                    "before=%d B, after=%d B)",
+                    res.get("reclaimed_bytes", 0),
+                    deleted,
+                    res.get("before_bytes", 0),
+                    after,
+                )
+        except Exception:
+            # Belt-and-braces: never let an auto-vacuum failure escape into
+            # the flusher loop and break ingest. The manual vacuum endpoint
+            # remains available and the next flush will reset the counter.
+            log.exception("local store: auto-vacuum failed (will retry next cycle)")
+        finally:
+            with self._auto_vacuum_lock:
+                self._auto_vacuum_running = False
+
+    def _emit_over_cap_marker(self, after_bytes: int) -> None:
+        """Persist a ``local_store_over_cap`` event so dashboards/cloud can
+        see the cap-exceeded condition without polling /local/health. Direct
+        INSERT (bypasses the ring) so even a saturated ring doesn't drop
+        the marker."""
+        import uuid as _uuid
+        from datetime import datetime as _dt, timezone as _tz
+        ev_id = f"over-cap-{_uuid.uuid4()}"
+        node_id = os.environ.get("CLAWMETRY_NODE_ID") or "local"
+        ts_iso = _dt.now(_tz.utc).isoformat()
+        payload = json.dumps({
+            "after_bytes": int(after_bytes),
+            "cap_bytes": int(LOCAL_MAX_BYTES),
+        }).encode("utf-8")
+        with self._write_lock:
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO events
+                  (id, agent_type, node_id, agent_id, session_id, workspace_id,
+                   event_type, ts, data, cost_usd, token_count, model, created_at)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                [
+                    ev_id, "clawmetry", node_id, "local_store", None, None,
+                    "local_store_over_cap", ts_iso, payload, None, None, None,
+                    int(time.time() * 1000),
+                ],
+            )
 
     # ── Insights fast path (feat/insights-v1) ──────────────────────────
     # Single allowlisted entry-point for hand-authored SELECT templates in

--- a/tests/test_local_max_bytes_auto_vacuum.py
+++ b/tests/test_local_max_bytes_auto_vacuum.py
@@ -1,0 +1,419 @@
+"""Regression test for issue #1594 — LOCAL_MAX_BYTES cap silently exceeded.
+
+## Pre-fix behaviour
+``LOCAL_MAX_BYTES`` (default 5 GB) was reported in /local/health as
+``size_cap_bytes``, but NOTHING in the write path checked the cap. The
+only enforcement was the diagnostic ``LocalStore.vacuum()`` endpoint —
+which had a single caller and was never invoked automatically. Long-
+running installs grew past the cap silently until disk-full cascaded
+into ring-drop (#1590).
+
+## Fix shape (this test file pins it)
+* On-write check inside ``_flush_now_locked``: every
+  ``AUTO_VACUUM_CHECK_EVERY_BYTES`` (default 100 MB) of bytes flushed,
+  stat() the DB. If size ≥ ``LOCAL_MAX_BYTES * AUTO_VACUUM_HIGH_WATER_PCT``
+  (default 95 %), call ``vacuum()`` — which deletes the OLDEST events
+  first (tiered-retention contract per ``feedback_tiered_retention.md``).
+* If vacuum cannot bring size under the cap (retention too generous,
+  pathological row sizes), log loud WARNING + emit an
+  ``local_store_over_cap`` event into the store itself; set
+  ``health()['cap_exceeded'] = True`` so the dashboard footer + cloud
+  dashboards can surface it.
+* Default-ON. ``CLAWMETRY_AUTO_VACUUM=0`` disables for users who manage
+  retention externally.
+
+## Test surface
+4 scenarios (per the issue ticket Step 6):
+  1. Below cap        → no vacuum, no warning, store grows freely.
+  2. Above cap        → vacuum fires, OLDEST events removed first,
+                        store comes back under cap, ring keeps writing.
+  3. Vacuum-not-enough → explicit WARNING logged + cap_exceeded=True +
+                        marker event persisted.
+  4. Real-subprocess  → restart preserves the invariant (live process +
+                        actual flusher tick, per
+                        ``feedback_synthetic_tests_missed_real_event_shape``
+                        — no mocked vacuum, no synthetic ring).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _reload_store(tmp_path, monkeypatch, *,
+                  max_bytes: int | None = None,
+                  check_mb: float = 0.001,        # 1 KB — fires per-flush
+                  high_water_pct: float = 0.5,
+                  enabled: str = "1"):
+    """Force-reload local_store with test-tight thresholds and return a
+    fresh LocalStore + the module handle. We rebind the env vars BEFORE
+    reimport so the module-level constants pick them up."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH",
+                       str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.02")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    if max_bytes is not None:
+        monkeypatch.setenv("CLAWMETRY_LOCAL_MAX_GB",
+                           str(max_bytes / 1024 / 1024 / 1024))
+    monkeypatch.setenv("CLAWMETRY_AUTO_VACUUM_CHECK_MB", str(check_mb))
+    monkeypatch.setenv("CLAWMETRY_AUTO_VACUUM_HIGH_WATER_PCT",
+                       str(high_water_pct))
+    monkeypatch.setenv("CLAWMETRY_AUTO_VACUUM", enabled)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.LocalStore()
+    store.start()
+    return store, ls
+
+
+def _ev(i: int, *, ts: str | None = None) -> dict:
+    """Generate a small event with a deterministic id; the data blob is
+    large enough that 1000 events comfortably exceed 1 MB so we can
+    drive the on-disk size across a 1-MB test cap."""
+    return {
+        "id": f"ev-{i}",
+        "node_id": "agent+test",
+        "agent_id": "main",
+        "session_id": "sess-1",
+        "event_type": "tool_call",
+        "ts": ts or f"2026-05-{(i % 28) + 1:02d}T00:{i % 60:02d}:00Z",
+        # 1 KB-ish blob per event so a few thousand rows clears 1 MB
+        # of on-disk DuckDB pages.
+        "data": {"tool": "Read", "blob": "x" * 1024, "i": i},
+        "cost_usd": 0.001,
+        "token_count": 42,
+    }
+
+
+def _wait_for_drain(store, timeout=3.0):
+    """Block until the flusher empties the ring."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.01)
+    raise AssertionError(
+        f"ring did not drain in {timeout}s "
+        f"(depth={store.health()['ring_depth']})"
+    )
+
+
+# ── Scenario 1 — below cap → no vacuum ────────────────────────────────────
+
+
+def test_below_cap_no_vacuum_fires(tmp_path, monkeypatch, caplog):
+    """Cap set generously high — small ingest should never trigger
+    a vacuum or set cap_exceeded. The flusher's bookkeeping counter
+    advances but the size check stays below high-water."""
+    store, ls = _reload_store(
+        tmp_path, monkeypatch,
+        max_bytes=10 * 1024 * 1024 * 1024,    # 10 GB cap
+        check_mb=0.001,                        # check every 1 KB
+        high_water_pct=0.95,
+    )
+    try:
+        with caplog.at_level(logging.INFO, logger="clawmetry.local_store"):
+            for i in range(50):
+                store.ingest(_ev(i))
+            _wait_for_drain(store)
+        # No vacuum log line; no over-cap warning.
+        msgs = [r.message for r in caplog.records]
+        assert not any("auto-vacuum fired" in m for m in msgs), msgs
+        assert not any("LOCAL_STORE_OVER_CAP" in m for m in msgs), msgs
+        h = store.health()
+        assert h["cap_exceeded"] is False
+        assert h["auto_vacuum_enabled"] is True
+        # Sanity: all 50 events landed.
+        assert h["event_count"] == 50
+    finally:
+        store.stop(flush=True)
+
+
+# ── Scenario 2 — above cap → vacuum fires, oldest removed first ───────────
+
+
+def test_above_cap_vacuum_prunes_oldest_first(tmp_path, monkeypatch, caplog):
+    """Tight 256 KB cap. Ingest enough rows that the DuckDB file
+    crosses the 50 % high-water mark; auto-vacuum must fire and the
+    OLDEST event timestamps must be the ones removed (tiered-retention
+    contract per ``feedback_tiered_retention.md``).
+
+    Invariant checked: ``COUNT(*)`` drops dramatically AND ``MIN(ts)``
+    moves forward. We don't check ``size_bytes <= cap`` because DuckDB
+    1.4.x does not shrink the main file in-place after DELETE — freed
+    pages get reused by the next ingest, so growth is bounded but the
+    file can plateau above cap on the FIRST over-cap cycle. The
+    ``cap_exceeded`` health flag surfaces this state to the dashboard
+    + cloud (Scenario 3 below). The actual user-visible promise is
+    'no unbounded growth' — which means oldest rows get evicted as
+    new ones arrive, NOT that the file shrinks."""
+    store, ls = _reload_store(
+        tmp_path, monkeypatch,
+        max_bytes=256 * 1024,         # 256 KB cap — easy to overshoot
+        check_mb=0.001,               # check every flush
+        high_water_pct=0.5,           # vacuum at >= 128 KB
+    )
+    try:
+        # Ingest in ascending timestamp order so "oldest" == earliest id.
+        # 2000 rows × ~2 KB data is reliably > 1 MB on disk, well above
+        # the 256 KB cap, so the prune branch fires multiple times.
+        with caplog.at_level(logging.INFO, logger="clawmetry.local_store"):
+            for i in range(2000):
+                store.ingest(_ev(i, ts=f"2026-01-01T00:00:{i:04d}Z"))
+            _wait_for_drain(store, timeout=10.0)
+            # Give the auto-vacuum a beat to fire after the last flush.
+            time.sleep(0.3)
+
+        assert any("auto-vacuum fired" in r.message for r in caplog.records), (
+            "expected 'auto-vacuum fired' log line, got: "
+            f"{[r.message for r in caplog.records[-20:]]}"
+        )
+
+        # Row count must be bounded — the prune kept dropping the
+        # oldest events as new ones flushed, so even after 2000
+        # ingests the table holds far fewer than 2000 rows.
+        h = store.health()
+        assert h["event_count"] < 2000, (
+            f"auto-vacuum did not prune any rows; event_count={h['event_count']}"
+        )
+
+        # Oldest-first contract: MIN(ts) of what remains must be strictly
+        # greater than the smallest ts we ingested (00:00:0000Z). The
+        # earliest events were deleted first.
+        min_ts = store._fetch("SELECT MIN(ts) FROM events", [])[0][0]
+        assert min_ts is not None
+        assert min_ts > "2026-01-01T00:00:0000Z", (
+            f"oldest events should be pruned; MIN(ts)={min_ts}"
+        )
+
+        # Sanity: ring keeps writing — a brand new event still lands.
+        # This is the "ring continues writing" cascade-test from the
+        # issue's Step 6.4.
+        store.ingest(_ev(99_999, ts="2026-06-01T00:00:00Z"))
+        _wait_for_drain(store)
+        rows = store._fetch(
+            "SELECT id FROM events WHERE id = ?", ["ev-99999"],
+        )
+        assert rows and rows[0][0] == "ev-99999"
+    finally:
+        store.stop(flush=True)
+
+
+# ── Scenario 3 — vacuum not enough → loud warning + marker event ──────────
+
+
+def test_vacuum_cannot_reclaim_emits_warning_and_marker(
+    tmp_path, monkeypatch, caplog,
+):
+    """Set an absurdly small cap (1 byte). Any single row puts the
+    store above cap; even after vacuum the on-disk file stays above
+    1 B, so we MUST log LOCAL_STORE_OVER_CAP, flip cap_exceeded=True,
+    AND persist a ``local_store_over_cap`` marker event for cloud-side
+    dashboards.
+
+    Also verifies the cooldown: many flushes happen during the burst
+    but the warning is rate-limited (cooldown env set high here so the
+    test deterministically gets exactly one). Without rate-limiting,
+    this path used to emit a warning per flush — readable noise that
+    drowned tail -f at the first sign of an over-cap install."""
+    monkeypatch.setenv("CLAWMETRY_AUTO_VACUUM_OVER_CAP_COOLDOWN_S", "3600")
+    store, ls = _reload_store(
+        tmp_path, monkeypatch,
+        max_bytes=1,                  # 1 byte cap — impossible to fit
+        check_mb=0.001,
+        high_water_pct=0.5,
+    )
+    try:
+        with caplog.at_level(logging.WARNING,
+                              logger="clawmetry.local_store"):
+            # Use very old timestamps so the marker (ts=now) lands at
+            # the END of the ORDER BY ts ASC order — i.e. it's the
+            # NEWEST row and survives oldest-first pruning. The marker-
+            # preservation contract relies on this ordering: by the
+            # time vacuum runs, the synthetic events are all older
+            # than the marker.
+            for i in range(20):
+                store.ingest(_ev(i, ts=f"2020-01-01T00:00:{i:02d}Z"))
+            _wait_for_drain(store, timeout=5.0)
+            time.sleep(0.3)
+
+        warnings = [r.message for r in caplog.records
+                    if r.levelno >= logging.WARNING
+                    and "LOCAL_STORE_OVER_CAP" in r.message]
+        assert warnings, (
+            f"expected LOCAL_STORE_OVER_CAP warning, got: "
+            f"{[r.message for r in caplog.records]}"
+        )
+        # Cooldown: many auto-vacuum invocations during the burst but
+        # the warning fires exactly once (the rate-limit window is 1 h
+        # in this test).
+        assert len(warnings) == 1, (
+            f"expected exactly 1 over-cap warning (cooldown), got "
+            f"{len(warnings)}: {warnings}"
+        )
+
+        h = store.health()
+        assert h["cap_exceeded"] is True, (
+            f"cap_exceeded should be True when vacuum cannot fit cap, "
+            f"got health={h}"
+        )
+
+        # Marker event persisted in events table so cloud sync ships
+        # it without needing a separate metrics channel. Cooldown gates
+        # the marker too, so exactly one row is expected.
+        rows = store._fetch(
+            "SELECT event_type, data FROM events "
+            "WHERE event_type = 'local_store_over_cap'",
+            [],
+        )
+        assert len(rows) == 1, (
+            f"expected exactly 1 local_store_over_cap marker, got {len(rows)}"
+        )
+        payload = json.loads(bytes(rows[0][1]).decode("utf-8"))
+        assert payload["cap_bytes"] == 1
+        assert payload["after_bytes"] > 1
+    finally:
+        store.stop(flush=True)
+
+
+# ── Scenario 3b — explicit disable knob ───────────────────────────────────
+
+
+def test_auto_vacuum_disabled_via_env_skips_check(
+    tmp_path, monkeypatch, caplog,
+):
+    """``CLAWMETRY_AUTO_VACUUM=0`` must skip the auto-vacuum path entirely
+    even when the store is far over the cap. Manual ``vacuum()`` remains
+    available — we don't muzzle the diagnostic endpoint."""
+    store, ls = _reload_store(
+        tmp_path, monkeypatch,
+        max_bytes=1,                  # 1 byte — would over-cap immediately
+        check_mb=0.001,
+        high_water_pct=0.5,
+        enabled="0",
+    )
+    try:
+        with caplog.at_level(logging.WARNING,
+                              logger="clawmetry.local_store"):
+            for i in range(20):
+                store.ingest(_ev(i))
+            _wait_for_drain(store, timeout=5.0)
+            time.sleep(0.1)
+
+        warnings = [r.message for r in caplog.records
+                    if r.levelno >= logging.WARNING]
+        assert not any("LOCAL_STORE_OVER_CAP" in m for m in warnings), (
+            f"AUTO_VACUUM disabled — must not emit over-cap warnings, "
+            f"got: {warnings}"
+        )
+        h = store.health()
+        assert h["auto_vacuum_enabled"] is False
+        assert h["cap_exceeded"] is False, "no auto-check ran, so no flag"
+
+        # Manual vacuum still works.
+        res = store.vacuum(prune_to_bytes=1)
+        assert "after_bytes" in res
+    finally:
+        store.stop(flush=True)
+
+
+# ── Scenario 4 — real subprocess preserves the invariant ──────────────────
+
+
+_SUBPROC_PAYLOAD = r"""
+import os, time, sys, json
+import clawmetry.local_store as ls
+s = ls.LocalStore()
+s.start()
+try:
+    # Ingest until we definitely cross the 256 KB cap.
+    for i in range(2000):
+        s.ingest({
+            "id":         f"sp-ev-{i}",
+            "node_id":    "agent+sp",
+            "agent_id":   "main",
+            "session_id": "sp-sess",
+            "event_type": "tool_call",
+            "ts":         f"2026-01-01T00:00:{i:04d}Z",
+            "data":       {"blob": "x" * 1024, "i": i},
+        })
+    # Drain.
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if s.health()["ring_depth"] == 0:
+            break
+        time.sleep(0.02)
+    s.flush()
+    time.sleep(0.3)   # let auto-vacuum settle
+    h = s.health()
+    print(json.dumps({
+        "size_bytes":  h["size_bytes"],
+        "cap":         h["size_cap_bytes"],
+        "cap_exceeded": h["cap_exceeded"],
+        "event_count": h["event_count"],
+    }))
+finally:
+    s.stop(flush=True)
+"""
+
+
+def test_real_subprocess_auto_vacuum_holds_cap(tmp_path, monkeypatch):
+    """Per ``feedback_synthetic_tests_missed_real_event_shape``, run the
+    flusher in a real OS subprocess (not the test process's reload
+    pattern) and verify that after a heavy ingest burst the live process
+    has bounded its row count rather than letting it grow unboundedly.
+
+    Catches regressions where the auto-vacuum path only works when the
+    test fixture has already monkeypatched the singletons but breaks
+    in fresh-process startup (e.g. module-level const not honoured —
+    we hit this exact class of bug per the cliff sweep memory entry).
+
+    Invariant — bounded growth, not 'file <= cap':
+      * ingested 2000 events
+      * row count must end well below 2000 (auto-vacuum pruned some)
+      * the oldest events must be the ones gone (MIN(ts) advanced)
+    """
+    db_path = tmp_path / "events.duckdb"
+    env = os.environ.copy()
+    env["CLAWMETRY_LOCAL_STORE_PATH"]            = str(db_path)
+    env["CLAWMETRY_LOCAL_FLUSH_SECS"]            = "0.02"
+    env["CLAWMETRY_LOCAL_FLUSH_BATCH"]           = "5"
+    env["CLAWMETRY_LOCAL_MAX_GB"]                = str(256 * 1024 / 1024 / 1024 / 1024)  # 256 KB
+    env["CLAWMETRY_AUTO_VACUUM"]                 = "1"
+    env["CLAWMETRY_AUTO_VACUUM_CHECK_MB"]        = "0.001"   # 1 KB
+    env["CLAWMETRY_AUTO_VACUUM_HIGH_WATER_PCT"]  = "0.5"
+    env["PYTHONPATH"] = _REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _SUBPROC_PAYLOAD],
+        env=env, capture_output=True, text=True, timeout=60,
+    )
+    assert proc.returncode == 0, (
+        f"subprocess crashed:\nstdout={proc.stdout}\nstderr={proc.stderr}"
+    )
+    # The payload's final stdout line is a single JSON blob.
+    last = proc.stdout.strip().splitlines()[-1]
+    health = json.loads(last)
+    # Row count must be bounded — well below the 2000 we ingested —
+    # proving the auto-vacuum path ran inside the fresh subprocess.
+    assert 0 < health["event_count"] < 2000, (
+        f"subprocess auto-vacuum did not prune as expected: {health}\n"
+        f"stderr={proc.stderr}"
+    )


### PR DESCRIPTION
## Summary

Round-2 of today's write-path silent-failure family fixes. Sibling of #1590 (concurrent flush race), #1593 (SIGTERM ring drop), #1601/#1624 (AESGCM swallow), #1625 (snapshot DLQ), #1629 (migration version-stamp).

Pre-fix, `LOCAL_MAX_BYTES` (default 5 GB) was reported in `/local/health` as `size_cap_bytes` but **writes never checked it**. The cap was only enforced when something explicitly called `LocalStore.vacuum()` — and the only caller was the diagnostic endpoint. Long-running installs (>2 months heavy use) silently grew past 5 GB until disk-full cascaded into the ring drop (#1590).

## Fix shape

- **On-write check** inside `_flush_now` (OUTSIDE `_flush_lock` to avoid `vacuum → flush → vacuum` re-entry deadlock): every 100 MB flushed, `stat()` the DB; if size ≥ 95 % of cap, vacuum oldest events first. Predictable, no periodic thread to leak.
- **`health()` now reports main + WAL** (was just main, which under-counted by ~10× during active ingest — missing exactly the case the cap exists to catch).
- **Hard-cap escalation**: if post-vacuum size still > cap (DuckDB 1.4.x doesn't shrink the main file in-place after DELETE — freed pages get reused so growth IS bounded), set `health.cap_exceeded = True` AND emit a one-shot `local_store_over_cap` marker event into the events table so cloud dashboards see it without a separate metrics channel. Rate-limited to once per 5 min (else every flush re-fires the warning).
- **Per-cycle delete capped at 80 %** of `n_rows` so a pathologically over-cap store (or a `cap=1 B` test fixture) can't wipe its entire history in one pass — subsequent flushes continue pruning if still over cap.
- **`CLAWMETRY_AUTO_VACUUM=0`** disables the path entirely for users who manage retention externally (rsync, snapshots).
- Defaults are conservative: 95 % high-water mark, only fires once per ~100 MB flushed.

## Tests

5 scenarios in `tests/test_local_max_bytes_auto_vacuum.py`:

1. **Below cap** → no vacuum fires, no warning.
2. **Above cap** → vacuum fires, OLDEST events evicted first (tiered-retention contract), row count bounded, ring continues writing.
3. **Vacuum-not-enough** → exactly one warning + one marker (cooldown verified), `cap_exceeded=True`.
4. **Auto-vacuum disabled** → env var skips the path entirely; manual `vacuum()` still works.
5. **Real subprocess** → fresh process auto-vacuum holds row count bounded after 2000-event burst (per `feedback_synthetic_tests_missed_real_event_shape` — catches module-init regressions a reload-in-test fixture would miss).

All 54 pre-existing `local_store` + sibling write-path tests still pass (`test_local_store`, `test_local_store_concurrent_flush_1590`, `test_local_store_multi_agent`, `test_local_store_rename`, `test_sigterm_ring_flush`, `test_system_snapshot_dlq`, `test_aesgcm_swallow_fix`). Bug-class gates green.

## Test plan
- [x] `pytest tests/test_local_max_bytes_auto_vacuum.py` — 5/5 pass
- [x] `pytest tests/test_local_store*.py tests/test_sigterm_ring_flush.py tests/test_system_snapshot_dlq.py tests/test_aesgcm_swallow_fix.py` — 73/73 pass
- [x] `pytest tests/test_class_bug_parent_sid_drain.py tests/test_moat_bug_class_v3_event_shape_gate.py` — 13/13 pass
- [x] `python3 -c "import dashboard"` — clean

Closes #1594.