### PR TITLE
fix(tier): server-side paywall gate eliminates Pro feature flash (closes #1603)

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -259,6 +259,12 @@
       rule = EXAMPLE_RULES.find(r => r.id === ruleId);
     }
     if (!rule) return;
+    // Issue #1603: the editor modal DOM is server-side gated to Pro users
+    // so Free users get the upsell here instead of a null-deref on
+    // ``alerts-editor-modal``. Matches the alertsHandleNewRule gate above.
+    if (alertsState.tier !== 'pro' && alertsState.tier !== 'trial') {
+      return openPaywall();
+    }
     alertsState.editorRule = rule;
     alertsState.editorType = rule.alert_type;
     openEditor();

--- a/clawmetry/templates/partials/paywall_modal.html
+++ b/clawmetry/templates/partials/paywall_modal.html
@@ -1,0 +1,40 @@
+<!--
+  Server-side paywall partial — rendered in place of a Pro-feature DOM
+  shell when ``is_pro`` is False. Replaces the pre-#1603 pattern of
+  rendering the full Pro UI plus a client-side overlay that slammed down
+  on a subsequent tick (the "Pro feature flash" bug).
+
+  Callers pass two optional context vars via Jinja ``with`` blocks:
+    paywall_feature  — feature name shown in the headline (e.g. "NemoClaw
+                       governance"). Defaults to "this feature".
+    paywall_pitch    — short reason this feature is Pro. One line, plain
+                       prose, no em-dashes (memory: no_em_dashes).
+
+  Copy is intentionally upsell-first (memory: free_plan_upsell). Every
+  gated click is a conversion opportunity, not a wall. Keep it readable
+  for non-technical users (memory: simple_ui_for_nontechnical).
+-->
+<div class="page" id="page-{{ paywall_page_id|default('paywall') }}">
+  <div style="max-width:560px;margin:48px auto;padding:32px;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:12px;text-align:center;">
+    <div style="font-size:36px;margin-bottom:12px;">🔒</div>
+    <h2 style="margin:0 0 8px 0;font-size:18px;font-weight:700;color:var(--text-primary);">
+      {{ paywall_feature|default('This feature') }} is part of ClawMetry Pro
+    </h2>
+    <p style="margin:0 0 20px 0;font-size:13px;line-height:1.55;color:var(--text-secondary);">
+      {{ paywall_pitch|default('Pro unlocks the full workflow with no caps on history, alerts, or governance policies.') }}
+    </p>
+    <div style="display:flex;gap:10px;justify-content:center;flex-wrap:wrap;">
+      <a href="https://app.clawmetry.com/upgrade" target="_blank" rel="noopener"
+         style="background:var(--bg-accent);color:#fff;border:0;border-radius:8px;padding:10px 18px;font-size:13px;font-weight:600;text-decoration:none;cursor:pointer;">
+        Start 7-day free trial
+      </a>
+      <a href="https://clawmetry.com/pricing" target="_blank" rel="noopener"
+         style="background:transparent;color:var(--text-secondary);border:1px solid var(--border-primary);border-radius:8px;padding:10px 18px;font-size:13px;font-weight:600;text-decoration:none;cursor:pointer;">
+        See pricing
+      </a>
+    </div>
+    <div style="margin-top:14px;font-size:11px;color:var(--text-muted);">
+      No credit card required. Cancel anytime.
+    </div>
+  </div>
+</div>

--- a/clawmetry/templates/tabs/alerts.html
+++ b/clawmetry/templates/tabs/alerts.html
@@ -62,6 +62,16 @@
   </div>
 </div>
 
+{# Issue #1603: server-side gate on the rule editor modal. Free users
+   keep the canned-example teaser shell above (intentional per
+   project_free_plan_upsell memory) but the editor's 6 alert-type buttons,
+   channel picker, and re-alert cadence inputs are Pro-only DOM. Pre-fix,
+   a Free user could open the editor on a frame-perfect click before the
+   client-side paywall mounted, then inspect or screenshot the full Pro
+   composer. The {% if is_pro %} branch keeps the editor entirely out of
+   the page for non-Pro users; alerts.js still calls alertsOpenPaywall()
+   on the + New alert rule button so the upsell flow is unchanged. #}
+{% if is_pro %}
 <!-- ── Rule editor modal (Pro-tier only) ────────────────────────────────── -->
 <div class="alerts-modal-overlay" id="alerts-editor-modal" style="display:none;" onclick="alertsCloseEditor(event)">
   <div class="alerts-editor-card" onclick="event.stopPropagation()">
@@ -115,3 +125,4 @@
     </div>
   </div>
 </div>
+{% endif %}

--- a/clawmetry/templates/tabs/nemoclaw.html
+++ b/clawmetry/templates/tabs/nemoclaw.html
@@ -1,3 +1,15 @@
+{# Issue #1603: server-side Pro-tier gate. Pre-fix, the full NemoClaw
+   governance shell (sandbox state, policy hash, drift detection, egress
+   approvals) shipped in the HTML for every user — Free users saw a brief
+   flash of the Pro DOM before the client-side overlay mounted. Fail-closed:
+   if ``is_pro`` is undefined (older render pathway) we treat the user as
+   Free so we never leak Pro DOM by default. #}
+{% if not is_pro %}
+{% with paywall_page_id='nemoclaw', paywall_feature='NemoClaw governance',
+        paywall_pitch='Pro adds the NemoClaw sandbox, policy drift detection, and one-click egress approvals so you can prove your agents are inside the lines.' %}
+  {% include 'partials/paywall_modal.html' %}
+{% endwith %}
+{% else %}
 <div class="page" id="page-nemoclaw">
   <div style="padding:12px 0 8px 0;">
     <!-- Header row -->
@@ -151,3 +163,4 @@
     </div>
   </div>
 </div><!-- end page-nemoclaw (theme 2) -->
+{% endif %}

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -644,11 +644,24 @@ def index():
     # same env var the v2 blueprint registration in dashboard.py uses, so we
     # never advertise /v2 to users who'd hit a 404.
     v2_enabled = os.environ.get("CLAWMETRY_V2") == "1"
+    # Issue #1603: server-side Pro-tier gate. Tab templates branch on this
+    # so the Pro-feature DOM (NemoClaw governance shell, alerts rule editor
+    # modal) never enters the page for Free users. Eliminates the first-paint
+    # flash where the full Pro UI rendered, then a client-side overlay slammed
+    # down on top — a frame-perfect click could bypass the gate, and Free
+    # users could screenshot the Pro UI source. Fail-closed: any error in
+    # ``_is_pro_user`` returns False, which matches the conservative default
+    # the helper itself uses.
+    try:
+        is_pro = bool(_d._is_pro_user())
+    except Exception:
+        is_pro = False
     resp = make_response(
         render_template_string(
             _d.DASHBOARD_HTML,
             version=_d.__version__,
             v2_enabled=v2_enabled,
+            is_pro=is_pro,
         )
     )
     resp.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"

--- a/tests/test_tier_pro_paywall_no_flash.py
+++ b/tests/test_tier_pro_paywall_no_flash.py
@@ -1,0 +1,195 @@
+"""Regression tests for issue #1603 — Pro feature flash.
+
+Pre-fix, the full Pro-feature DOM (NemoClaw governance shell, alerts
+rule-editor modal) shipped in the dashboard HTML for every user. A
+client-side overlay then mounted on a later tick to cover it. Free users
+could:
+  1. See the Pro UI rendered for ~1-3 frames (perception of paywall as
+     artificial).
+  2. Inspect/screenshot the Pro UI source.
+  3. Land a frame-perfect click on the Pro feature before the overlay
+     mounted — bypassing the gate entirely.
+
+The fix is a server-side Jinja gate in ``routes/meta.py:index()`` that
+branches on ``dashboard._is_pro_user()`` BEFORE the page is rendered.
+Pro users get the full feature shell; Free / OSS users get the
+``partials/paywall_modal.html`` partial in its place.
+
+The tests below pin three scenarios:
+  - Free / OSS user: NemoClaw shell is NOT in the response, alerts
+    editor modal is NOT in the response, paywall partial IS.
+  - Pro user: NemoClaw shell IS in the response, alerts editor modal
+    IS in the response, paywall partial is NOT.
+  - Exception in tier check: fail-closed to Free (no Pro DOM leaks).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import dashboard  # noqa: E402  (import registers shared module state)
+from routes.meta import bp_auth  # noqa: E402
+
+
+# Stable DOM markers that uniquely identify each surface. Picked over CSS
+# class names because the latter change every redesign — these IDs come
+# straight from the templates and are referenced by JS handlers, so they
+# are load-bearing and unlikely to drift silently.
+NEMOCLAW_SHELL_MARKER = 'id="page-nemoclaw"'
+ALERTS_EDITOR_MARKER = 'id="alerts-editor-modal"'
+PAYWALL_MARKER = 'id="page-nemoclaw"'  # paywall partial reuses the id
+PAYWALL_FEATURE_MARKER = "NemoClaw governance"
+PAYWALL_CTA_MARKER = "Start 7-day free trial"
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Mount only ``bp_auth`` so the test stays hermetic.
+
+    The auth blueprint owns the ``/`` index handler. We point the Flask
+    app at the real templates directory so ``{% include 'tabs/...' %}``
+    resolves the same files prod renders.
+    """
+    a = Flask(
+        __name__,
+        template_folder=os.path.join(ROOT, "clawmetry", "templates"),
+    )
+    a.register_blueprint(bp_auth)
+    # Loopback peer so the @before_request auth hook (if any leaks in
+    # through dashboard import) does not block the test client.
+    monkeypatch.setattr(dashboard, "GATEWAY_TOKEN", "", raising=False)
+    return a.test_client()
+
+
+def _get_index(client):
+    r = client.get("/", environ_overrides={"REMOTE_ADDR": "127.0.0.1"})
+    assert r.status_code == 200, r.get_data(as_text=True)[:500]
+    return r.get_data(as_text=True)
+
+
+# ─── Scenario 1: Free / OSS user ─────────────────────────────────────────
+
+
+def test_free_user_index_omits_nemoclaw_pro_shell(client, monkeypatch):
+    """Free user GET / must NOT include the NemoClaw governance shell.
+
+    The pre-fix bug was that the shell rendered first then was covered
+    by a JS overlay. With the server-side gate, the shell DOM should
+    never enter the response in the first place.
+    """
+    monkeypatch.setattr(dashboard, "_is_pro_user", lambda: False)
+    html = _get_index(client)
+    # The shell's distinctive sandbox / policy / drift markers should be
+    # gone. We can't just check ``id="page-nemoclaw"`` because the
+    # paywall partial reuses that id (so JS switchTab still finds a
+    # page to activate). Pick markers that ONLY appear in the shell.
+    assert "nc-sandbox-status" not in html, (
+        "NemoClaw sandbox status table leaked into Free-tier HTML "
+        "(issue #1603 regression)."
+    )
+    assert "nc-policy-table" not in html, (
+        "NemoClaw policy table leaked into Free-tier HTML."
+    )
+    assert "nc-approvals-list" not in html, (
+        "NemoClaw approvals list leaked into Free-tier HTML."
+    )
+
+
+def test_free_user_index_omits_alerts_editor_modal(client, monkeypatch):
+    """Free user GET / must NOT include the alerts rule editor modal.
+
+    The canned-example teaser shell is intentional (memory:
+    project_free_plan_upsell — let users invest in config before the
+    paywall fires) so that part stays. But the editor's 6 alert-type
+    buttons + channel picker + re-alert cadence inputs are Pro-only
+    DOM that lets a Free user build a rule they can never save.
+    """
+    monkeypatch.setattr(dashboard, "_is_pro_user", lambda: False)
+    html = _get_index(client)
+    assert ALERTS_EDITOR_MARKER not in html, (
+        "Alerts editor modal leaked into Free-tier HTML "
+        "(issue #1603 regression)."
+    )
+    # The canned-example teaser shell must STILL be present — that is
+    # the intentional upsell path.
+    assert 'id="page-alerts"' in html
+    assert "alerts-rules-list" in html
+
+
+def test_free_user_index_includes_paywall_partial(client, monkeypatch):
+    """Free user GET / must include the server-side paywall partial.
+
+    Replaces the pre-fix client-side overlay that mounted on a later
+    tick. Same render pass = no flash.
+    """
+    monkeypatch.setattr(dashboard, "_is_pro_user", lambda: False)
+    html = _get_index(client)
+    assert PAYWALL_FEATURE_MARKER in html, (
+        "Paywall partial missing its NemoClaw feature headline."
+    )
+    assert PAYWALL_CTA_MARKER in html, (
+        "Paywall partial missing the trial CTA."
+    )
+
+
+# ─── Scenario 2: Pro user ────────────────────────────────────────────────
+
+
+def test_pro_user_index_includes_nemoclaw_full_shell(client, monkeypatch):
+    """Pro user GET / must include the full NemoClaw governance shell.
+
+    Critical: if the server-side gate is wrong we ship paywalls to
+    paying customers, which is worse than the original flash bug.
+    """
+    monkeypatch.setattr(dashboard, "_is_pro_user", lambda: True)
+    html = _get_index(client)
+    assert "nc-sandbox-status" in html
+    assert "nc-policy-table" in html
+    assert "nc-approvals-list" in html
+
+
+def test_pro_user_index_includes_alerts_editor_modal(client, monkeypatch):
+    """Pro user GET / must include the alerts rule editor modal."""
+    monkeypatch.setattr(dashboard, "_is_pro_user", lambda: True)
+    html = _get_index(client)
+    assert ALERTS_EDITOR_MARKER in html
+
+
+def test_pro_user_index_omits_paywall_partial(client, monkeypatch):
+    """Pro user GET / must NOT include the paywall partial."""
+    monkeypatch.setattr(dashboard, "_is_pro_user", lambda: True)
+    html = _get_index(client)
+    assert PAYWALL_FEATURE_MARKER not in html, (
+        "Paywall partial leaked into Pro-tier HTML — paying users "
+        "would see the upsell where their feature should be."
+    )
+
+
+# ─── Scenario 3: fail-closed on errors ───────────────────────────────────
+
+
+def test_index_fails_closed_when_tier_check_raises(client, monkeypatch):
+    """If ``_is_pro_user`` raises, treat the user as Free.
+
+    Matches the helper's own conservative default (a flaky cache must
+    never leak Pro DOM onto a free node). The pre-fix bug had the
+    inverse default — undefined-tier → showed Pro UI briefly — which is
+    exactly how Free users could screenshot the Pro source.
+    """
+    def boom():
+        raise RuntimeError("tier check failed")
+    monkeypatch.setattr(dashboard, "_is_pro_user", boom)
+    html = _get_index(client)
+    # No Pro shell, paywall present.
+    assert "nc-sandbox-status" not in html
+    assert ALERTS_EDITOR_MARKER not in html
+    assert PAYWALL_FEATURE_MARKER in html


### PR DESCRIPTION
## Summary

- Pre-fix, NemoClaw governance shell + Alerts rule-editor modal shipped in dashboard HTML for every user, then a JS overlay mounted on a later tick. Free users saw a 1-3 frame flash of Pro UI; on a frame-perfect click they could bypass the gate entirely.
- Fix: branch on ``dashboard._is_pro_user()`` server-side in ``routes/meta.py:index()`` and pass ``is_pro`` to Jinja. Pro-feature templates now render either the full shell OR ``partials/paywall_modal.html``, never both. Same render pass = no flash.
- New paywall partial reuses the page id (``page-nemoclaw``) so ``switchTab('nemoclaw')`` keeps working with no JS changes.

## Files

- ``routes/meta.py``: pass ``is_pro`` template var, fail-closed on exception.
- ``clawmetry/templates/partials/paywall_modal.html``: new reusable upsell partial. Copy is upsell-first per ``project_free_plan_upsell`` memory, no em-dashes per ``feedback_no_em_dashes_in_user_facing_copy``.
- ``clawmetry/templates/tabs/nemoclaw.html``: full shell behind ``{% if is_pro %}``, Free users get the paywall partial.
- ``clawmetry/templates/tabs/alerts.html``: rule-editor modal behind ``{% if is_pro %}``. Canned-example teaser shell stays for all tiers (intentional per ``project_alerts_pro_feature`` memory).
- ``clawmetry/static/js/alerts.js``: ``alertsHandleEdit`` tier gate so a Free user clicking a canned example hits ``openPaywall()`` instead of null-derefing the now-absent editor modal.

## Critical safety check

Wrong gate ships paywalls to paying customers (worse than original flash). Tests pin the inverse direction:

- ``test_pro_user_index_includes_nemoclaw_full_shell`` - paying users see the shell.
- ``test_pro_user_index_includes_alerts_editor_modal`` - paying users see the editor.
- ``test_pro_user_index_omits_paywall_partial`` - paying users do not see the upsell.

## Test plan

- [x] ``python3 -c 'import dashboard'`` clean
- [x] ``pytest tests/test_tier_pro_paywall_no_flash.py -v`` (7/7 pass)
- [x] ``pytest tests/test_auth_detected_token.py tests/test_anon_auth_fail_ping.py`` (45/45 pass, no adjacent regression)
- [ ] Manual Playwright visual-diff on first-paint for Free vs Pro tier (CI)
- [ ] Smoke against real OpenClaw v3 cloud-paired node post-merge

Closes #1603.

Generated with [Claude Code](https://claude.com/claude-code)