### PR TITLE
fix(onboarding): explicit 'No OpenClaw/NemoClaw detected' empty-state when no agent installed

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -647,6 +647,51 @@ async function checkOnboardingStatus() {
 _cmOnboardingTimer = setInterval(checkOnboardingStatus, 5000);
 setTimeout(checkOnboardingStatus, 300);
 
+// === No-Agent-Detected Empty-State Banner ===================================
+// Distinct from the first-heartbeat onboarding banner above:
+//   * onboarding-banner fires when "agent installed but no heartbeat yet"
+//     (transient race that resolves in ~30s)
+//   * no-agent-banner fires when "no agent installed at all" — persistent
+//     until the user installs OpenClaw or NVIDIA NemoClaw.
+// Mutual exclusion: if openclaw or nemoclaw IS detected (heartbeat just
+// hasn't landed yet), we hide this banner and let onboarding-banner do
+// its thing. Polls every 60s — filesystem state for "did the user pip
+// install an agent" changes on the order of minutes, not seconds.
+async function checkAgentPresence() {
+  var banner = document.getElementById('no-agent-banner');
+  if (!banner) return;
+  try {
+    var data = await fetch('/api/agent-presence').then(function(r){return r.json();});
+    var noAgent = !!(data && data.no_agent === true);
+    if (noAgent) {
+      // No OpenClaw, no NemoClaw, no local data — show the persistent
+      // empty-state banner and hide the first-heartbeat one so we don't
+      // double up. Setting _cmOnboardingDismissed stops the 5s poller
+      // from re-flashing the "Setting up your node" copy.
+      var ob = document.getElementById('onboarding-banner');
+      if (ob) ob.style.display = 'none';
+      _cmOnboardingDismissed = true;
+      banner.style.display = 'flex';
+    } else {
+      // Agent appeared. Hide the no-agent banner and (if the dashboard
+      // was already showing it) reload the data so cards render.
+      var wasShown = banner.style.display !== 'none';
+      banner.style.display = 'none';
+      if (wasShown && typeof loadAll === 'function') {
+        try { loadAll(); } catch(e) {}
+      }
+    }
+  } catch(e) {
+    // Transient fetch failure. Per feedback_persistent_sessions: never
+    // surface a network blip as a terminal user-facing error. Keep the
+    // banner in whatever state it was in.
+  }
+}
+// Fast first check (500ms) so brand-new users see the banner before
+// staring at an empty dashboard. Re-poll every 60s thereafter.
+setTimeout(checkAgentPresence, 500);
+visibilitySetInterval(checkAgentPresence, 60000);
+
 function dismissPausedBanner() {
   localStorage.setItem('cm_paused_banner_dismissed', String(Date.now()));
   var banner = document.getElementById('paused-banner');

--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -123,6 +123,55 @@
     ">Dismiss</button>
 </div>
 
+<!-- No-Agent-Detected Empty-State Banner -->
+<!-- Shown when ClawMetry is installed but NEITHER OpenClaw nor NVIDIA -->
+<!-- NemoClaw is detected on this machine, AND the local store has zero -->
+<!-- events. Distinct from the first-heartbeat-race banner below: -->
+<!--   * this one is persistent (until the user installs an agent) -->
+<!--   * the first-heartbeat one is transient (~30s after install) -->
+<!-- Mutual-exclusion is enforced in app.js so we never show both. -->
+<div id="no-agent-banner" style="
+  display:none;
+  padding:14px 18px;
+  border-bottom:2px solid #f59e0b;
+  font-size:13px;
+  font-weight:600;
+  align-items:center;
+  gap:14px;
+  background:linear-gradient(90deg,#3f2a06 0%,#1a1a2e 100%);
+  color:#fbbf24;
+  flex-wrap:wrap;
+  ">
+  <span style="font-size:18px;">&#9888;&#65039;</span>
+  <span id="no-agent-banner-msg" style="flex:1;min-width:240px;">
+    No OpenClaw or NVIDIA NemoClaw detected. Install one to start seeing data.
+  </span>
+  <a href="https://github.com/openclaw/openclaw#install" target="_blank" rel="noopener" style="
+    background:#16a34a;
+    color:#fff;
+    border:none;
+    border-radius:6px;
+    padding:6px 14px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    text-decoration:none;
+    white-space:nowrap;
+    ">Install OpenClaw</a>
+  <a href="https://docs.nvidia.com/nemo/guardrails/" target="_blank" rel="noopener" style="
+    background:#76b900;
+    color:#000;
+    border:none;
+    border-radius:6px;
+    padding:6px 14px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
+    text-decoration:none;
+    white-space:nowrap;
+    ">Install NVIDIA NemoClaw</a>
+</div>
+
 <!-- Onboarding / First-Heartbeat Banner (closes #1604) -->
 <!-- Shown on fresh signup until the first heartbeat lands. Auto-refreshes -->
 <!-- every 5s. After 90s with no heartbeat we switch to an actionable error -->

--- a/dashboard.py
+++ b/dashboard.py
@@ -8306,6 +8306,135 @@ def _get_heartbeat_status():
     }
 
 
+# ── Agent-presence detection (no-agent empty-state, sibling of #1604) ──
+# Distinct from ``_get_heartbeat_status``:
+#   * heartbeat-status answers "has THIS install's daemon checked in yet?"
+#     (transient race, resolves in ~30s — drives #1631's onboarding banner)
+#   * detect_agent_install() answers "is there any underlying agent at
+#     all?" (persistent until the user installs one — drives the
+#     "No OpenClaw or NemoClaw detected" page-level empty-state).
+# Cached 60s so every tab switch doesn't re-stat 4+ paths and shell out
+# to ``shutil.which``.
+_agent_presence_cache = {"ts": 0.0, "value": None}
+_AGENT_PRESENCE_TTL_SEC = 60
+
+
+def _detect_openclaw_install():
+    """Return True if OpenClaw appears installed (any of: PID file present,
+    workspace dir exists, session JSONLs exist, OPENCLAW_HOME env set to a
+    real dir). Cheap stat-only checks — no subprocess, no DuckDB."""
+    home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+    if not home:
+        return False
+    # 1. Gateway PID file — strongest "openclaw is/was running" signal.
+    pid_path = os.path.join(home, "gateway", "gateway.pid")
+    if os.path.exists(pid_path):
+        return True
+    # 2. Session JSONLs (agent has produced events at some point).
+    sess_dir = os.path.join(home, "agents", "main", "sessions")
+    if os.path.isdir(sess_dir):
+        try:
+            for name in os.listdir(sess_dir):
+                if name.endswith(".jsonl"):
+                    return True
+        except OSError:
+            pass
+    # 3. Workspace marker files (SOUL.md / AGENTS.md / MEMORY.md).
+    ws = os.path.join(home, "workspace")
+    for marker in ("SOUL.md", "AGENTS.md", "MEMORY.md"):
+        if os.path.exists(os.path.join(ws, marker)):
+            return True
+    # 4. ~/.openclaw dir exists with *any* content (catches fresh installs
+    # that haven't run yet but have at least laid down config).
+    if os.path.isdir(home):
+        try:
+            if any(True for _ in os.scandir(home)):
+                return True
+        except OSError:
+            pass
+    return False
+
+
+def _detect_nemoclaw_install():
+    """Return True if NemoClaw appears installed. Defers to the existing
+    ``_detect_nemoclaw`` helper but only needs the boolean — avoids the
+    expensive ``nemoclaw list`` subprocess call by short-circuiting on
+    ``shutil.which`` and the config dir."""
+    import shutil as _shutil
+    if _shutil.which("nemoclaw"):
+        return True
+    cfg = os.path.expanduser("~/.nemoclaw")
+    if os.path.isdir(cfg):
+        try:
+            if any(True for _ in os.scandir(cfg)):
+                return True
+        except OSError:
+            pass
+    return False
+
+
+def _detect_any_local_data():
+    """Return True if local DuckDB store has *any* events row. Used as the
+    third leg of the no-agent decision so that an OpenClaw-less user who
+    is none-the-less getting OTLP traces in still gets the normal UI."""
+    try:
+        from clawmetry import local_store  # type: ignore
+        store = local_store.get_store(read_only=True)
+    except Exception:
+        return False
+    # Best-effort: any of these public query helpers returning a row means
+    # "we have data". Wrapped in try/except so a missing-table on a half-
+    # initialised DB never raises into the UI thread.
+    for method, kwargs in (
+        ("query_events", {"limit": 1}),
+        ("query_heartbeats", {"limit": 1}),
+    ):
+        try:
+            fn = getattr(store, method, None)
+            if fn is None:
+                continue
+            rows = fn(**kwargs)
+            if rows:
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def detect_agent_install():
+    """Return ``{openclaw_detected, nemoclaw_detected, any_data, signals}``
+    answering "is there an underlying agent producing data?".
+
+    Cached for ``_AGENT_PRESENCE_TTL_SEC`` (60s) — every tab switch on the
+    dashboard polls this; the underlying filesystem state changes on the
+    order of minutes-hours, not milliseconds.
+    """
+    now = time.time()
+    cached = _agent_presence_cache.get("value")
+    if cached and (now - _agent_presence_cache["ts"]) < _AGENT_PRESENCE_TTL_SEC:
+        return cached
+    openclaw = bool(_detect_openclaw_install())
+    nemoclaw = bool(_detect_nemoclaw_install())
+    any_data = bool(_detect_any_local_data())
+    signals = []
+    if openclaw:
+        signals.append("openclaw")
+    if nemoclaw:
+        signals.append("nemoclaw")
+    if any_data:
+        signals.append("local_data")
+    payload = {
+        "openclaw_detected": openclaw,
+        "nemoclaw_detected": nemoclaw,
+        "any_data": any_data,
+        "signals": signals,
+        "no_agent": not (openclaw or nemoclaw or any_data),
+    }
+    _agent_presence_cache["ts"] = now
+    _agent_presence_cache["value"] = payload
+    return payload
+
+
 # ── OTLP Metrics Store ─────────────────────────────────────────────────
 METRICS_FILE = None  # Set via CLI/env, defaults to {WORKSPACE}/.clawmetry-metrics.json
 _metrics_lock = threading.Lock()

--- a/routes/health.py
+++ b/routes/health.py
@@ -12,6 +12,7 @@ Owns the 11 routes registered on bp_health:
   GET  /api/service-status        — compact service_status for fleet heartbeat
   GET  /api/heartbeat-status      — heartbeat gap alerting status
   POST /api/heartbeat-ping        — record a heartbeat from frontend
+  GET  /api/agent-presence        — is any underlying agent (OpenClaw / NemoClaw) installed?
   GET  /api/rate-limits           — rolling 1m/1h API rate-limit utilisation
   GET  /api/health-stream         — SSE auto-refresh of health checks (30s)
   GET  /api/sandbox-status        — sandbox / inference / security posture
@@ -2229,6 +2230,22 @@ def api_heartbeat_ping():
     import dashboard as _d
     _d._record_heartbeat()
     return jsonify({"ok": True})
+
+
+@bp_health.route("/api/agent-presence")
+def api_agent_presence():
+    """Return whether any underlying agent (OpenClaw / NVIDIA NemoClaw) is
+    installed and producing data. Sibling of ``/api/heartbeat-status``
+    that answers a different question (see ``detect_agent_install``
+    docstring in dashboard.py).
+
+    Frontend uses this to render the "No agent detected" page-level empty
+    state when ``no_agent=true``, so users who installed ClawMetry without
+    an agent see actionable copy + install links instead of an empty
+    dashboard that looks broken.
+    """
+    import dashboard as _d
+    return jsonify(_d.detect_agent_install())
 
 
 def _try_local_store_rate_limits():

--- a/tests/test_no_agent_detected_state.py
+++ b/tests/test_no_agent_detected_state.py
@@ -1,0 +1,288 @@
+"""Tests for the "No OpenClaw or NVIDIA NemoClaw detected" empty-state.
+
+Symptom: ClawMetry installs and registers as a node in cloud even when
+the user has not installed any underlying agent. Every tab (Brain, AI
+Model, Channels, Sessions) renders empty or shows stale data because
+there is no agent producing events. Users see a broken-looking
+dashboard and bounce.
+
+The fix detects "no agent installed at all" at boot and surfaces an
+explicit, persistent banner with install CTAs for both OpenClaw and
+NVIDIA NemoClaw. Distinct from issue #1604 / PR #1631 (first-heartbeat
+race) which handles the transient "agent installed but no heartbeat
+yet" window — see the JS mutual-exclusion in ``checkAgentPresence``.
+
+This suite pins five scenarios + the user-facing copy contract:
+  1. No openclaw + no nemoclaw + empty local store → no-agent state
+  2. OpenClaw installed + running, no first heartbeat yet → NOT the
+     no-agent state (#1631's banner owns that window)
+  3. OpenClaw installed + heartbeat received → normal dashboard
+  4. NemoClaw installed only → normal dashboard
+  5. Both installed → normal dashboard
+plus the banner partial + JS contract assertions.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+# ── Shared monkeypatch helpers ───────────────────────────────────────────
+def _reset_cache(monkeypatch):
+    """Force a fresh detect_agent_install() call by clearing the 60s
+    cache. Every scenario test depends on a fresh evaluation, otherwise
+    test order would leak state across cases."""
+    import dashboard as _d
+    monkeypatch.setattr(
+        _d, "_agent_presence_cache", {"ts": 0.0, "value": None}, raising=False
+    )
+
+
+def _force(monkeypatch, openclaw, nemoclaw, any_data):
+    """Stub all three detectors so a test can drive the exact combo it
+    wants without touching the real filesystem or DuckDB."""
+    import dashboard as _d
+    _reset_cache(monkeypatch)
+    monkeypatch.setattr(_d, "_detect_openclaw_install", lambda: openclaw)
+    monkeypatch.setattr(_d, "_detect_nemoclaw_install", lambda: nemoclaw)
+    monkeypatch.setattr(_d, "_detect_any_local_data", lambda: any_data)
+
+
+# ── Scenario 1: no openclaw + no nemoclaw + empty store → no-agent ──────
+def test_no_agent_at_all_reports_no_agent_true(monkeypatch):
+    """The exact predicate the banner JS gates on: ``no_agent === true``.
+
+    If any of the three detectors returned True here it would mean either
+    (a) the banner never shows on a truly empty machine (regression) or
+    (b) we are silently masking a detection bug — both have caused real
+    user-visible "broken dashboard" reports.
+    """
+    import dashboard as _d
+    _force(monkeypatch, openclaw=False, nemoclaw=False, any_data=False)
+    payload = _d.detect_agent_install()
+    assert payload["no_agent"] is True, (
+        "with no openclaw + no nemoclaw + no local data the banner JS "
+        "needs no_agent=true to render the empty state; got " + repr(payload)
+    )
+    assert payload["openclaw_detected"] is False
+    assert payload["nemoclaw_detected"] is False
+    assert payload["any_data"] is False
+    assert payload["signals"] == [], (
+        "signals list MUST be empty when nothing is detected so the UI "
+        "does not display a misleading 'detected via X' tag"
+    )
+
+
+# ── Scenario 2: openclaw installed but heartbeat hasn't landed yet ──────
+def test_openclaw_installed_but_no_heartbeat_is_NOT_no_agent_state(monkeypatch):
+    """The first-heartbeat race is #1631's territory, NOT this PR's.
+
+    If openclaw IS installed (PID file, workspace dir, anything) we must
+    return ``no_agent=false`` so the persistent no-agent banner stays
+    hidden and the transient "Setting up your node" banner from #1631
+    owns the ~30s warm-up window. Showing both would be visually
+    confusing and contradict each other.
+    """
+    import dashboard as _d
+    _force(monkeypatch, openclaw=True, nemoclaw=False, any_data=False)
+    payload = _d.detect_agent_install()
+    assert payload["no_agent"] is False, (
+        "openclaw installed → no_agent MUST be false even if no heartbeat "
+        "yet (issue #1604 / PR #1631 owns that transient window)"
+    )
+    assert payload["openclaw_detected"] is True
+    assert "openclaw" in payload["signals"]
+
+
+# ── Scenario 3: openclaw installed + heartbeat → normal dashboard ───────
+def test_openclaw_installed_and_data_present_is_normal_dashboard(monkeypatch):
+    """The steady-state happy path. ``no_agent=false`` and BOTH the
+    openclaw_detected flag AND the local-store signal must be set so
+    the system-health card can show a green "OpenClaw OK" pill.
+    """
+    import dashboard as _d
+    _force(monkeypatch, openclaw=True, nemoclaw=False, any_data=True)
+    payload = _d.detect_agent_install()
+    assert payload["no_agent"] is False
+    assert payload["openclaw_detected"] is True
+    assert payload["any_data"] is True
+    assert "openclaw" in payload["signals"]
+    assert "local_data" in payload["signals"]
+
+
+# ── Scenario 4: nemoclaw installed only → normal dashboard ──────────────
+def test_nemoclaw_only_install_is_normal_dashboard(monkeypatch):
+    """A pure NemoClaw user (no OpenClaw) must NOT see the no-agent
+    banner. Per memory ``feedback_em_style_judgment`` we treat OpenClaw
+    and NemoClaw as equal first-class agents — neither's absence alone
+    triggers the empty state.
+    """
+    import dashboard as _d
+    _force(monkeypatch, openclaw=False, nemoclaw=True, any_data=False)
+    payload = _d.detect_agent_install()
+    assert payload["no_agent"] is False, (
+        "nemoclaw alone is enough to hide the no-agent banner — they are "
+        "treated as equal first-class agents (feedback_em_style_judgment)"
+    )
+    assert payload["nemoclaw_detected"] is True
+    assert "nemoclaw" in payload["signals"]
+
+
+# ── Scenario 5: both installed → normal dashboard ───────────────────────
+def test_both_agents_installed_is_normal_dashboard(monkeypatch):
+    """Belt-and-braces: both signals true MUST keep no_agent=false and
+    surface BOTH in the signals list so the UI can attribute data
+    correctly across the two agents.
+    """
+    import dashboard as _d
+    _force(monkeypatch, openclaw=True, nemoclaw=True, any_data=True)
+    payload = _d.detect_agent_install()
+    assert payload["no_agent"] is False
+    assert payload["openclaw_detected"] is True
+    assert payload["nemoclaw_detected"] is True
+    assert set(payload["signals"]) == {"openclaw", "nemoclaw", "local_data"}
+
+
+# ── Cache contract: TTL prevents storming the FS on every tab switch ────
+def test_detection_result_is_cached_for_60s(monkeypatch):
+    """Every tab switch on the dashboard pings ``/api/agent-presence`` —
+    without a cache that would re-stat the workspace + shell out to
+    ``shutil.which`` on every page load. The 60s TTL is the contract.
+    """
+    import dashboard as _d
+    _reset_cache(monkeypatch)
+    calls = {"openclaw": 0, "nemoclaw": 0, "data": 0}
+
+    def _oc():
+        calls["openclaw"] += 1
+        return False
+
+    def _nc():
+        calls["nemoclaw"] += 1
+        return False
+
+    def _da():
+        calls["data"] += 1
+        return False
+
+    monkeypatch.setattr(_d, "_detect_openclaw_install", _oc)
+    monkeypatch.setattr(_d, "_detect_nemoclaw_install", _nc)
+    monkeypatch.setattr(_d, "_detect_any_local_data", _da)
+
+    # First call: detectors run.
+    _d.detect_agent_install()
+    assert calls == {"openclaw": 1, "nemoclaw": 1, "data": 1}
+    # Second call within TTL: detectors must NOT run again.
+    _d.detect_agent_install()
+    _d.detect_agent_install()
+    assert calls == {"openclaw": 1, "nemoclaw": 1, "data": 1}, (
+        "cache MUST suppress re-running the detectors within the 60s TTL — "
+        "otherwise every tab switch storms the filesystem"
+    )
+
+
+# ── Banner partial + JS contract ────────────────────────────────────────
+def _read_banners_html():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    path = os.path.join(here, "clawmetry", "templates", "partials", "banners.html")
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _read_app_js():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    path = os.path.join(here, "clawmetry", "static", "js", "app.js")
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_no_agent_banner_partial_carries_both_install_ctas():
+    """User-facing copy must name BOTH agents and offer install links
+    for each. Per memory ``feedback_em_style_judgment`` we do NOT pick
+    one over the other — listing both lets the user choose.
+    """
+    html = _read_banners_html()
+    assert 'id="no-agent-banner"' in html, (
+        "no-agent banner element must exist in banners.html partial"
+    )
+    # Copy MUST name both agents — the entire point of this PR.
+    assert "OpenClaw" in html
+    assert "NemoClaw" in html or "NVIDIA NemoClaw" in html
+    # Both install CTAs must be present and clickable.
+    assert "Install OpenClaw" in html
+    assert "Install NVIDIA NemoClaw" in html or "Install NemoClaw" in html
+
+
+def test_no_agent_banner_avoids_em_dashes_in_user_copy():
+    """Per memory ``feedback_no_em_dashes_in_user_facing_copy``."""
+    html = _read_banners_html()
+    start = html.find('id="no-agent-banner"')
+    assert start != -1
+    # Grab a generous window covering the entire banner block.
+    block = html[start:start + 2500]
+    # Slice off after the closing </div> for THIS banner so we don't
+    # accidentally lint siblings.
+    end_marker = "<!-- Onboarding"
+    end = block.find(end_marker)
+    if end != -1:
+        block = block[:end]
+    assert "—" not in block, (
+        "em-dash banned in user-facing no-agent banner copy "
+        "(feedback_no_em_dashes_in_user_facing_copy.md)"
+    )
+
+
+def test_no_agent_js_does_not_reload_or_sign_out_on_transient_failure():
+    """Per memory ``feedback_no_reload_in_bootstrap_e2e`` +
+    ``feedback_persistent_sessions``: never page-reload or redirect to
+    /login when ``/api/agent-presence`` returns transiently bad data.
+    """
+    js = _read_app_js()
+    anchor = js.find("checkAgentPresence")
+    assert anchor != -1, "checkAgentPresence must be defined in app.js"
+    block = js[anchor:anchor + 5000]
+    assert "location.reload" not in block, (
+        "no-agent banner must not page-reload on transient empty state "
+        "(feedback_no_reload_in_bootstrap_e2e.md)"
+    )
+    assert "/login" not in block, (
+        "no-agent banner must not redirect to /login on transient empty "
+        "state (feedback_persistent_sessions.md)"
+    )
+
+
+def test_no_agent_js_is_mutually_exclusive_with_first_heartbeat_banner():
+    """If openclaw or nemoclaw IS detected (and we're just in the
+    first-heartbeat warm-up window), the no-agent banner must hide and
+    let #1631's onboarding-banner own that scenario. The two must
+    never both display at once.
+    """
+    js = _read_app_js()
+    anchor = js.find("checkAgentPresence")
+    assert anchor != -1
+    block = js[anchor:anchor + 5000]
+    # When no_agent is true the JS hides the onboarding-banner so we
+    # don't double up. Look for the explicit handoff.
+    assert "onboarding-banner" in block, (
+        "mutual-exclusion: when no_agent=true the JS must explicitly "
+        "hide the onboarding-banner so the two banners never stack"
+    )
+    # And inversely it must reference its own element id.
+    assert "no-agent-banner" in block
+
+
+def test_no_agent_js_polls_at_least_every_minute():
+    """The detection result is cached 60s server-side; the client poll
+    cadence should match so users who install an agent mid-session see
+    the banner disappear within a minute, not on the next page load.
+    """
+    js = _read_app_js()
+    anchor = js.find("checkAgentPresence")
+    assert anchor != -1
+    block = js[anchor:anchor + 5000]
+    assert "60000" in block, (
+        "no-agent banner must re-poll at the 60s server-cache cadence so "
+        "an agent installed mid-session clears the banner within ~1 min"
+    )


### PR DESCRIPTION
## Summary

Currently ClawMetry installs and registers as a node in cloud even when the user has not installed any underlying agent. Every tab (Brain, AI Model card, Channels, Sessions) renders empty or shows stale data because there is no agent producing events, so users see a broken-looking dashboard for their entire first 60 seconds.

This adds an explicit page-level banner that detects "no OpenClaw, no NVIDIA NemoClaw, no local events" and tells the user exactly what is missing + offers install CTAs for both agents.

- New ``detect_agent_install()`` helper in ``dashboard.py`` (60s cache) — combines: gateway PID file present, session JSONLs exist, OPENCLAW_HOME dir non-empty, ``shutil.which('nemoclaw')``, ``~/.nemoclaw`` non-empty, and any local-store events
- New ``/api/agent-presence`` endpoint in ``routes/health.py`` (sibling of ``/api/heartbeat-status``)
- New ``#no-agent-banner`` partial in ``banners.html`` with two equal-weight install CTAs (OpenClaw / NVIDIA NemoClaw)
- New ``checkAgentPresence()`` JS in ``app.js`` — polls every 60s, mutually exclusive with #1631's first-heartbeat onboarding banner

### Distinct from #1631

| Scenario | Banner |
|---|---|
| Agent installed, no heartbeat yet (~30s warm-up) | #1631's "Setting up your node" (transient) |
| No agent installed at all | THIS PR's "No agent detected" (persistent) |

The JS enforces mutual exclusion: when ``no_agent=true`` we hide the onboarding-banner element AND set ``_cmOnboardingDismissed=true`` so the 5s onboarding poller stops re-flashing.

## Memory respects

- ``feedback_no_em_dashes_in_user_facing_copy`` — verified by test, no em-dashes in banner copy
- ``feedback_simple_ui_for_nontechnical`` — "Install OpenClaw" / "Install NVIDIA NemoClaw" reads to non-tech users
- ``feedback_em_style_judgment`` — lists both agents equally, no editorialising
- ``feedback_no_reload_in_bootstrap_e2e`` + ``feedback_persistent_sessions`` — no ``location.reload()`` / no ``/login`` redirect on transient fetch failure (verified by test)
- ``project_sync_progress_banner`` — sister of this work, same "explain what is happening" UX philosophy

## Test plan

- [x] ``tests/test_no_agent_detected_state.py`` — 11 cases, all green:
  - 5 detection scenarios (no-agent / openclaw-only-no-heartbeat / openclaw-with-data / nemoclaw-only / both)
  - 60s cache contract (detectors must not re-run within TTL)
  - banner partial carries both install CTAs
  - banner partial has no em-dashes in user copy
  - JS does not reload or sign out on transient failure
  - JS is mutually exclusive with #1631's onboarding banner
  - JS polls at the 60s server-cache cadence
- [x] ``tests/test_first_heartbeat_onboarding.py`` (PR #1631's suite) — still green, 7/7
- [x] Flask test-client smoke: ``GET /api/agent-presence`` returns 200 + valid JSON shape ``{openclaw_detected, nemoclaw_detected, any_data, signals, no_agent}``

DO NOT MERGE — per task instructions.

Generated with [Claude Code](https://claude.com/claude-code)