### PR TITLE
fix(sync): bounded heartbeat-piggyback queue with drop-oldest (closes #1595)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -103,7 +103,7 @@ from routes.overview import bp_overview
 from routes.components import bp_components
 from routes.fleet_history import bp_fleet, bp_history
 from routes.infra import bp_logs, bp_memory, bp_security, bp_config
-from routes.meta import bp_auth, bp_gateway, bp_otel, bp_version, bp_version_impact, bp_clusters
+from routes.meta import bp_auth, bp_cloud_relay, bp_gateway, bp_otel, bp_version, bp_version_impact, bp_clusters
 from routes.nemoclaw import bp_nemoclaw
 from routes.skills import bp_skills
 from routes.heartbeat import bp_heartbeat
@@ -10421,6 +10421,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_version)
     app.register_blueprint(bp_version_impact)
     app.register_blueprint(bp_clusters)
+    app.register_blueprint(bp_cloud_relay)
     app.register_blueprint(bp_nemoclaw)
     app.register_blueprint(bp_skills)
     app.register_blueprint(bp_heartbeat)

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -30,11 +30,16 @@ Flask app, not a Blueprint, so it stays in ``dashboard.py``.
 Pure mechanical move — zero behaviour change.
 """
 
+import collections
+import hashlib
 import html
 import json
+import logging
 import os
 import sys
+import threading
 import time
+import uuid
 from datetime import datetime, timezone
 
 from flask import Blueprint, jsonify, make_response, render_template_string, request
@@ -46,6 +51,7 @@ bp_auth = Blueprint('auth', __name__)
 bp_otel = Blueprint('otel', __name__)
 bp_version_impact = Blueprint('version_impact', __name__)
 bp_clusters = Blueprint('clusters', __name__)
+bp_cloud_relay = Blueprint('cloud_relay', __name__)
 
 
 # ── Version check & self-update routes ────────────────────────────────────────
@@ -1081,3 +1087,176 @@ def api_clusters():
         )
     except Exception as e:
         return jsonify({"error": str(e), "clusters": []}), 500
+
+
+# ── Heartbeat-piggyback subscribe queue (issue #1595) ────────────────────────
+# The cloud-relay path queues query-shape requests against a per-(owner, node)
+# list that the daemon drains during its next /ingest/heartbeat. With no upper
+# bound, a refresh-happy viewer (5 panels x 12 polls/min x 10 min open) can
+# stuff 500+ stale entries into the queue, starving the freshest subscribes
+# behind dead work. The fix:
+#
+#   * Cap each (owner, node) queue at QUEUE_MAX_LEN (env-overridable).
+#   * On overflow: drop the OLDEST entry (FIFO eviction). Recent subscribes
+#     are more likely to reflect current viewer intent — dropping the
+#     newest would punish the active tab.
+#   * Emit a ``subscribe_queue_overflow`` metric (counter + sample dropped
+#     key) so cloud can alert on stuck viewers.
+#   * Surface ``queue_len`` in the subscribe response so clients can
+#     back off when the queue starts to fill (signal to the polling JS to
+#     slow its auto-refresh until the daemon catches up).
+#
+# The real cloud-side implementation lives in ``clawmetry-cloud``; this OSS
+# copy is the canonical reference + smoke target so we can drift-test the
+# contract from this repo's CI without spinning up the cloud Flask app.
+
+# Per-(owner, node) ring buffer cap. 100 covers a generous 5-panel
+# dashboard burst at the default 60 s drain cadence; lower it in tests
+# via the env var to exercise the overflow path without enqueueing 100
+# entries.
+QUEUE_MAX_LEN = max(1, int(os.environ.get("CLAWMETRY_SUBSCRIBE_QUEUE_MAX", "100")))
+
+# Allowlist mirrors the cloud-side gatekeeper + routes/local_query._SHAPES.
+# Keep these in sync — drift is caught by tests/test_heartbeat_relay_e2e.py.
+_SUBSCRIBE_ALLOWED_SHAPES = frozenset({
+    "events", "sessions", "aggregates", "health", "transcript",
+})
+
+# Module state. The lock is held across the small critical section that
+# coalesces dupes + appends + computes queue_len so two concurrent subscribes
+# can't race past the cap.
+_subscribe_queues: dict = {}            # (owner, node) -> deque[query dict]
+_subscribe_memo: dict = {}              # (owner, node, args_hash) -> cache_key
+_subscribe_lock = threading.Lock()
+
+# Overflow metric. ``count`` ticks once per dropped entry; ``last_dropped``
+# keeps a sample so an operator can see *which* key starved (owner/node/shape
+# + the args_hash that was evicted). Cleared by tests via _reset_subscribe_state.
+subscribe_queue_overflow = {
+    "count": 0,
+    "last_dropped": None,  # {"owner", "node", "shape", "args_hash", "ts"}
+}
+
+_log = logging.getLogger(__name__)
+
+
+def _hash_subscribe_args(shape: str, args: dict) -> str:
+    """Deterministic short hash so identical (shape, args) collapse to one
+    cache_key — matches the cloud-side hashing in
+    ``tests/test_heartbeat_relay_e2e.py:_hash_args``."""
+    payload = json.dumps({"shape": shape, "args": args or {}}, sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()[:32]
+
+
+def _reset_subscribe_state() -> None:
+    """Test-only helper. Clear queues + memo + overflow metric so each
+    test starts from a clean module state."""
+    with _subscribe_lock:
+        _subscribe_queues.clear()
+        _subscribe_memo.clear()
+        subscribe_queue_overflow["count"] = 0
+        subscribe_queue_overflow["last_dropped"] = None
+
+
+@bp_cloud_relay.route("/api/cloud/subscribe", methods=["POST"])
+def api_cloud_subscribe():
+    """Enqueue a (shape, args) cache_key for the next daemon heartbeat drain.
+
+    Response shape:
+      { cache_key, query_id, status: "queued"|"cache_hit"|"rejected",
+        eta_sec, queue_len }
+
+    ``queue_len`` is the post-append depth of THIS subscribe's
+    (owner, node) queue — the dashboard JS should treat anything
+    >= QUEUE_MAX_LEN * 0.8 as a backpressure signal and slow its
+    auto-refresh until the next drain catches up.
+
+    On overflow the oldest queued entry is dropped (FIFO eviction) and
+    the ``subscribe_queue_overflow`` counter ticks. The newly enqueued
+    subscribe is always accepted — recent intent wins.
+    """
+    body = request.get_json(silent=True) or {}
+    owner = (body.get("owner") or "default").strip() or "default"
+    node_id = (body.get("node_id") or "").strip()
+    shape = body.get("shape")
+    args = body.get("args") or {}
+
+    if not node_id:
+        return jsonify({"error": "node_id required"}), 400
+    if shape not in _SUBSCRIBE_ALLOWED_SHAPES:
+        return jsonify({
+            "error": f"unknown shape: {shape!r}",
+            "allowed_shapes": sorted(_SUBSCRIBE_ALLOWED_SHAPES),
+            "status": "rejected",
+        }), 400
+
+    args_hash = _hash_subscribe_args(shape, args)
+    queue_key = (owner, node_id)
+    memo_key = (owner, node_id, args_hash)
+
+    with _subscribe_lock:
+        # Coalesce: if this exact (owner, node, shape, args) is already
+        # queued, return the same cache_key instead of stacking dupes.
+        existing = _subscribe_memo.get(memo_key)
+        if existing is not None:
+            depth = len(_subscribe_queues.get(queue_key, ()))
+            return jsonify({
+                "cache_key": existing,
+                "query_id": existing,
+                "status": "queued",
+                "eta_sec": 60,
+                "queue_len": depth,
+            })
+
+        cache_key = f"ck_{uuid.uuid4().hex[:24]}"
+        entry = {
+            "id": cache_key,
+            "cache_key": cache_key,
+            "shape": shape,
+            "args": args,
+            "args_hash": args_hash,
+            "enqueued_at": time.time(),
+        }
+
+        q = _subscribe_queues.get(queue_key)
+        if q is None:
+            q = collections.deque(maxlen=QUEUE_MAX_LEN)
+            _subscribe_queues[queue_key] = q
+
+        # Drop-oldest FIFO: if we're at cap, evict head BEFORE appending so
+        # we can capture the dropped entry for the overflow metric. (deque
+        # with maxlen would silently drop on append; doing it explicitly
+        # lets us emit the metric.)
+        if len(q) >= q.maxlen:
+            dropped = q.popleft()
+            # Forget the memo so a re-subscribe for the dropped shape is
+            # accepted rather than coalesced onto a key the daemon will
+            # never see.
+            _subscribe_memo.pop(
+                (owner, node_id, dropped.get("args_hash", "")), None
+            )
+            subscribe_queue_overflow["count"] += 1
+            subscribe_queue_overflow["last_dropped"] = {
+                "owner": owner,
+                "node": node_id,
+                "shape": dropped.get("shape"),
+                "args_hash": dropped.get("args_hash"),
+                "ts": time.time(),
+            }
+            _log.warning(
+                "subscribe_queue_overflow owner=%s node=%s dropped_shape=%s "
+                "queue_cap=%d", owner, node_id,
+                dropped.get("shape"), q.maxlen,
+            )
+
+        q.append(entry)
+        _subscribe_memo[memo_key] = cache_key
+        depth = len(q)
+
+    return jsonify({
+        "cache_key": cache_key,
+        "query_id": cache_key,
+        "status": "queued",
+        "eta_sec": 60,
+        "queue_len": depth,
+    })

--- a/tests/test_subscribe_queue_bounded.py
+++ b/tests/test_subscribe_queue_bounded.py
@@ -1,0 +1,254 @@
+"""Tests for the heartbeat-piggyback bounded subscribe queue (issue #1595).
+
+The cloud-relay path queues query subscribes per (owner, node) for the next
+daemon heartbeat to drain. Before this fix the queue was unbounded — a
+viewer auto-refreshing 5 panels every 5 s for 10 minutes could stack 500+
+entries, starving fresh subscribes behind dead work.
+
+Invariants exercised:
+
+  1. Queue under cap: every subscribe is preserved, ``queue_len`` rises
+     monotonically, and the overflow metric never ticks.
+  2. Queue at cap, new subscribe: the OLDEST entry is dropped (FIFO), the
+     newest is accepted, ``subscribe_queue_overflow.count`` rises by 1,
+     and ``last_dropped`` carries the evicted owner/node/shape.
+  3. Multiple (owner, node) pairs are independent — pair A hitting its
+     cap MUST NOT evict from pair B.
+  4. ``queue_len`` in the response equals the post-append depth of THIS
+     subscribe's queue (clients use it for backpressure).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Flask app with bp_cloud_relay + a tiny QUEUE_MAX_LEN (5) so we can
+    exercise overflow without enqueueing 100 entries per test.
+
+    Reload routes.meta after setting the env var so QUEUE_MAX_LEN picks up
+    the override (it's a module-level constant baked at import time).
+    """
+    monkeypatch.setenv("CLAWMETRY_SUBSCRIBE_QUEUE_MAX", "5")
+
+    # Force re-evaluation of QUEUE_MAX_LEN from the env var.
+    import routes.meta as meta_mod
+    importlib.reload(meta_mod)
+    assert meta_mod.QUEUE_MAX_LEN == 5, (
+        f"QUEUE_MAX_LEN env override failed: {meta_mod.QUEUE_MAX_LEN}"
+    )
+    meta_mod._reset_subscribe_state()
+
+    app = Flask(__name__)
+    app.register_blueprint(meta_mod.bp_cloud_relay)
+    yield {"client": app.test_client(), "mod": meta_mod}
+
+    # Tear down so a subsequent test reload doesn't inherit stale state.
+    meta_mod._reset_subscribe_state()
+
+
+def _subscribe(client, *, shape="events", args=None, owner="alice",
+               node_id="node-1"):
+    """Helper. POSTs to /api/cloud/subscribe and returns the parsed JSON."""
+    body = {
+        "owner": owner,
+        "node_id": node_id,
+        "shape": shape,
+        "args": args or {},
+    }
+    r = client.post(
+        "/api/cloud/subscribe",
+        json=body,
+    )
+    assert r.status_code == 200, (
+        f"subscribe failed: {r.status_code} {r.data!r}"
+    )
+    return r.get_json()
+
+
+# ── 1. Queue under cap: everything preserved ─────────────────────────────
+
+
+def test_queue_under_cap_preserves_all_items(client):
+    c = client["client"]
+    mod = client["mod"]
+
+    # Cap is 5 — enqueue 4 distinct subscribes. None should be dropped.
+    keys = []
+    for i in range(4):
+        resp = _subscribe(c, args={"session_id": f"sess-{i}"})
+        assert resp["status"] == "queued"
+        keys.append(resp["cache_key"])
+
+    # All 4 keys distinct, last response reports queue_len == 4, overflow
+    # counter never ticked.
+    assert len(set(keys)) == 4, "cache_keys must be unique per (shape, args)"
+    assert resp["queue_len"] == 4
+    assert mod.subscribe_queue_overflow["count"] == 0
+    assert mod.subscribe_queue_overflow["last_dropped"] is None
+
+    # And the in-memory deque really holds 4 entries for this (owner, node).
+    q = mod._subscribe_queues[("alice", "node-1")]
+    assert len(q) == 4
+    assert [e["cache_key"] for e in q] == keys
+
+
+# ── 2. Queue at cap: oldest dropped, newest accepted, metric fires ───────
+
+
+def test_queue_at_cap_drops_oldest_and_fires_metric(client):
+    c = client["client"]
+    mod = client["mod"]
+
+    # Fill the queue exactly to cap (5).
+    fill_keys = []
+    for i in range(5):
+        resp = _subscribe(c, args={"session_id": f"sess-fill-{i}"})
+        fill_keys.append(resp["cache_key"])
+    assert resp["queue_len"] == 5
+    assert mod.subscribe_queue_overflow["count"] == 0
+
+    # One more subscribe — must evict fill_keys[0] (the oldest) and accept
+    # the new one. queue_len stays at cap.
+    overflow_resp = _subscribe(c, args={"session_id": "sess-newest"})
+    assert overflow_resp["status"] == "queued"
+    assert overflow_resp["queue_len"] == 5, (
+        f"queue_len must stay at cap after eviction: {overflow_resp}"
+    )
+
+    # Overflow metric ticked exactly once, with a sample of the dropped key.
+    assert mod.subscribe_queue_overflow["count"] == 1
+    last = mod.subscribe_queue_overflow["last_dropped"]
+    assert last is not None
+    assert last["owner"] == "alice"
+    assert last["node"] == "node-1"
+    assert last["shape"] == "events"
+    assert "args_hash" in last and last["args_hash"]
+    assert "ts" in last
+
+    # The in-memory deque now contains fill_keys[1:] + [overflow_resp.key].
+    q = mod._subscribe_queues[("alice", "node-1")]
+    actual_keys = [e["cache_key"] for e in q]
+    expected_keys = fill_keys[1:] + [overflow_resp["cache_key"]]
+    assert actual_keys == expected_keys, (
+        f"FIFO eviction broken — got {actual_keys}, want {expected_keys}"
+    )
+
+    # And the dropped sess-fill-0 entry's memo was cleared, so a re-subscribe
+    # for it goes through cleanly (instead of being coalesced onto a
+    # cache_key the daemon will never see).
+    resub = _subscribe(c, args={"session_id": "sess-fill-0"})
+    assert resub["cache_key"] != fill_keys[0], (
+        "memo for evicted entry must be cleared so re-subscribe gets a "
+        "fresh cache_key"
+    )
+    # That re-subscribe itself caused another overflow (queue was at cap).
+    assert mod.subscribe_queue_overflow["count"] == 2
+
+
+# ── 3. Multiple (owner, node) pairs: per-key cap, not global ─────────────
+
+
+def test_per_owner_node_cap_is_independent(client):
+    c = client["client"]
+    mod = client["mod"]
+
+    # Fill (alice, node-1) to cap.
+    for i in range(5):
+        _subscribe(c, owner="alice", node_id="node-1",
+                   args={"session_id": f"a-{i}"})
+    assert mod.subscribe_queue_overflow["count"] == 0
+    assert len(mod._subscribe_queues[("alice", "node-1")]) == 5
+
+    # Now hammer (bob, node-2) with 4 subscribes. Even though the global
+    # subscribe count is now 9 (well past 5), bob's queue is independent
+    # and well under cap.
+    for i in range(4):
+        resp = _subscribe(c, owner="bob", node_id="node-2",
+                          args={"session_id": f"b-{i}"})
+    assert resp["queue_len"] == 4
+    assert mod.subscribe_queue_overflow["count"] == 0, (
+        "bob's queue must NOT count against alice's cap"
+    )
+    assert len(mod._subscribe_queues[("alice", "node-1")]) == 5
+    assert len(mod._subscribe_queues[("bob", "node-2")]) == 4
+
+    # And different node ids under the SAME owner are also independent
+    # (the cap is keyed on the (owner, node) pair, not owner alone).
+    for i in range(3):
+        resp = _subscribe(c, owner="alice", node_id="node-other",
+                          args={"session_id": f"ao-{i}"})
+    assert resp["queue_len"] == 3
+    assert mod.subscribe_queue_overflow["count"] == 0
+    assert len(mod._subscribe_queues[("alice", "node-other")]) == 3
+    # Alice's original node-1 queue is untouched.
+    assert len(mod._subscribe_queues[("alice", "node-1")]) == 5
+
+
+# ── 4. queue_len in response matches post-append depth ───────────────────
+
+
+def test_queue_len_reflects_post_append_depth(client):
+    c = client["client"]
+
+    # Each new (shape, args) subscribe should bump queue_len by exactly 1.
+    for expected_len in range(1, 6):
+        resp = _subscribe(c, args={"session_id": f"sess-len-{expected_len}"})
+        assert resp["queue_len"] == expected_len, (
+            f"queue_len must equal post-append depth — got "
+            f"{resp['queue_len']}, expected {expected_len}"
+        )
+
+    # A coalesced (duplicate) subscribe must return the EXISTING queue_len
+    # without incrementing — coalesce is idempotent.
+    coalesced = _subscribe(c, args={"session_id": "sess-len-1"})
+    assert coalesced["queue_len"] == 5
+    assert coalesced["status"] == "queued"
+
+    # Overflow: queue_len caps at cap (5) and does not exceed it.
+    over = _subscribe(c, args={"session_id": "sess-len-overflow"})
+    assert over["queue_len"] == 5
+
+
+# ── Bonus: invalid shape returns 400 + status=rejected ───────────────────
+
+
+def test_invalid_shape_rejected_without_queueing(client):
+    c = client["client"]
+    mod = client["mod"]
+
+    r = c.post(
+        "/api/cloud/subscribe",
+        json={
+            "owner": "alice",
+            "node_id": "node-1",
+            "shape": "drop_table_users",
+            "args": {},
+        },
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert body["status"] == "rejected"
+    assert "allowed_shapes" in body
+    # Nothing should have been enqueued.
+    assert ("alice", "node-1") not in mod._subscribe_queues
+
+
+def test_missing_node_id_returns_400(client):
+    c = client["client"]
+    r = c.post(
+        "/api/cloud/subscribe",
+        json={"owner": "alice", "shape": "events", "args": {}},
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## Summary
Caps the heartbeat-piggyback subscribe queue at `QUEUE_MAX_LEN` (default 100, env-overridable) per `(owner, node)` with **drop-oldest FIFO** eviction so a refresh-happy viewer can't starve fresh subscribes behind hundreds of stale entries.

- New blueprint `bp_cloud_relay` in `routes/meta.py` owning `/api/cloud/subscribe` as the canonical OSS-side reference for the contract the cloud handler mirrors.
- Drop-oldest semantics on overflow — recent subscribes more likely reflect current viewer intent; newest always wins. Memo is cleared for the evicted key so a re-subscribe lands a fresh `cache_key` rather than coalescing onto one the daemon will never see.
- Emits `subscribe_queue_overflow` metric (counter + sample of dropped owner/node/shape/args_hash) so cloud can alert on stuck viewers.
- Returns `queue_len` in the subscribe response so the dashboard JS can detect backpressure and slow auto-refresh until the daemon catches up.
- Thread-safe critical section (`_subscribe_lock`) covers coalesce + append + queue_len computation so concurrent subscribes can't race past the cap.

## Issue
Closes #1595 — silent-failure inventory, sync-path family.

## Test plan
- [x] `python3 -c "import dashboard"` clean
- [x] `tests/test_subscribe_queue_bounded.py` — 6 scenarios pass
  - Under cap: all preserved, overflow metric never ticks
  - At cap: oldest dropped, newest accepted, `subscribe_queue_overflow.count` ticks with sample
  - Multiple `(owner, node)` pairs independent — bob's queue does NOT count against alice's cap
  - `queue_len` equals post-append depth, coalesced dupes don't increment, caps at `QUEUE_MAX_LEN`
  - Invalid shape returns 400 + `status=rejected` without queueing
  - Missing `node_id` returns 400
- [x] `tests/test_heartbeat_relay_e2e.py` — all 5 existing tests still pass
- [x] `tests/test_moat_bug_class_v3_event_shape_gate.py` — all 3 gate tests pass
- [x] `make lint-py lint-daemon-allowlist` clean
- [ ] **DO NOT MERGE** — coordinate with cloud-side mirror PR first

## Follow-ups (not in this PR)
- Cloud-side `clawmetry-cloud/cloud_cache.py` + `routes/heartbeat_relay.py` need the same bounded-queue logic (cloud is the actual production hot path; OSS endpoint is the contract reference).
- Dashboard JS should consume `queue_len` and back off auto-refresh when `>= QUEUE_MAX_LEN * 0.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)