### PR TITLE
fix(no-agent-banner): point install CTAs to openclaw.ai + nvidia.com/nemoclaw

### DIFF
--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -146,7 +146,7 @@
   <span id="no-agent-banner-msg" style="flex:1;min-width:240px;">
     No OpenClaw or NVIDIA NemoClaw detected. Install one to start seeing data.
   </span>
-  <a href="https://github.com/openclaw/openclaw#install" target="_blank" rel="noopener" style="
+  <a href="https://openclaw.ai/" target="_blank" rel="noopener" style="
     background:#16a34a;
     color:#fff;
     border:none;
@@ -158,7 +158,7 @@
     text-decoration:none;
     white-space:nowrap;
     ">Install OpenClaw</a>
-  <a href="https://docs.nvidia.com/nemo/guardrails/" target="_blank" rel="noopener" style="
+  <a href="https://www.nvidia.com/en-us/ai/nemoclaw/" target="_blank" rel="noopener" style="
     background:#76b900;
     color:#000;
     border:none;


### PR DESCRIPTION
## Summary
- "Install OpenClaw" CTA → `https://openclaw.ai/` (was `github.com/openclaw/openclaw#install`)
- "Install NVIDIA NemoClaw" CTA → `https://www.nvidia.com/en-us/ai/nemoclaw/` (was `docs.nvidia.com/nemo/guardrails/`)

User noticed the buttons in the no-agent empty-state pointed at generic docs instead of the canonical product pages. 2-line diff in `clawmetry/templates/partials/banners.html`.

Cloud-side parity PR: vivekchand/clawmetry-cloud#942

## Test plan
- [ ] Click both CTAs in the rendered dashboard, confirm correct destination + opens in new tab