### PR TITLE
feat(memory): Memory / RAG SQLite inspector — /api/memory-rag endpoints (#610)

### DIFF
--- a/routes/infra.py
+++ b/routes/infra.py
@@ -27,6 +27,7 @@ mechanical move — zero behaviour change.
 import json
 import os
 import select
+import sqlite3
 import subprocess
 import time
 from datetime import datetime, timedelta, timezone
@@ -1000,6 +1001,151 @@ def api_memory_analytics():
 
     files = _d._get_memory_files()
     return jsonify(_build_memory_analytics(files, bloat_warn_kb, bloat_crit_kb))
+
+
+# ── Memory RAG / SQLite inspector (issue #610) ─────────────────────────────
+
+
+def _open_rag_db():
+    """Open ~/.openclaw/memory/main.sqlite read-only.
+
+    Returns a sqlite3.Connection, or None when the file is absent, the
+    memory dir is unknown, or any other error prevents opening (we prefer a
+    graceful empty response over a 500).
+    """
+    import dashboard as _d
+    mem_dir = getattr(_d, "MEMORY_DIR", None) or ""
+    if not mem_dir:
+        return None
+    db_path = os.path.join(mem_dir, "main.sqlite")
+    if not os.path.isfile(db_path):
+        return None
+    try:
+        uri = f"file:{db_path}?mode=ro"
+        return sqlite3.connect(uri, uri=True, timeout=2.0)
+    except Exception:
+        return None
+
+
+@bp_memory.route("/api/memory-rag")
+def api_memory_rag():
+    """Return RAG document-store stats and file list from main.sqlite.
+
+    Response shape:
+      {"available": bool, "stats": {...}, "files": [...]}
+    When main.sqlite does not exist, returns {"available": false, ...} with
+    HTTP 200 so the frontend can render a "not yet indexed" state without
+    treating it as an error.
+    """
+    conn = _open_rag_db()
+    if conn is None:
+        return jsonify({"available": False, "stats": {}, "files": []})
+
+    try:
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+
+        try:
+            file_rows = cur.execute(
+                "SELECT f.path, f.size, f.mtime, COUNT(c.id) AS chunk_count "
+                "FROM files f LEFT JOIN chunks c ON c.file_id = f.id "
+                "GROUP BY f.id ORDER BY f.size DESC"
+            ).fetchall()
+            files = [
+                {
+                    "path": r["path"],
+                    "size": r["size"] or 0,
+                    "mtime": r["mtime"] or 0,
+                    "chunkCount": r["chunk_count"] or 0,
+                }
+                for r in file_rows
+            ]
+        except Exception:
+            files = []
+
+        stats: dict = {}
+        try:
+            agg = cur.execute(
+                "SELECT COUNT(*) AS file_count, "
+                "       COALESCE(SUM(size), 0) AS total_bytes, "
+                "       MAX(mtime) AS last_indexed "
+                "FROM files"
+            ).fetchone()
+            stats = {
+                "fileCount": agg["file_count"] or 0,
+                "totalBytes": agg["total_bytes"] or 0,
+                "lastIndexed": agg["last_indexed"],
+            }
+        except Exception:
+            pass
+
+        try:
+            chunk_row = cur.execute("SELECT COUNT(*) AS n FROM chunks").fetchone()
+            stats["chunkCount"] = chunk_row["n"] or 0
+        except Exception:
+            pass
+
+        return jsonify({"available": True, "stats": stats, "files": files})
+    except Exception as exc:
+        return jsonify({"available": False, "error": str(exc), "stats": {}, "files": []})
+    finally:
+        conn.close()
+
+
+@bp_memory.route("/api/memory-rag/search")
+def api_memory_rag_search():
+    """FTS5 full-text search over RAG chunks.
+
+    Query params:
+      q      — search terms (required)
+      limit  — max results (default 20, max 100)
+
+    Result shape:
+      {"available": bool, "query": str, "total": int, "results": [
+        {"path": str, "snippet": str, "rank": float}, ...
+      ]}
+    """
+    q = (request.args.get("q") or "").strip()
+    if not q:
+        return jsonify({"available": True, "query": "", "total": 0, "results": []})
+
+    try:
+        limit = min(int(request.args.get("limit", 20)), 100)
+    except ValueError:
+        limit = 20
+
+    conn = _open_rag_db()
+    if conn is None:
+        return jsonify({"available": False, "query": q, "total": 0, "results": []})
+
+    try:
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+        try:
+            rows = cur.execute(
+                "SELECT f.path, "
+                "       snippet(chunks_fts, 0, '<mark>', '</mark>', '...', 16) AS snippet, "
+                "       rank "
+                "FROM chunks_fts "
+                "JOIN chunks c  ON c.id  = chunks_fts.rowid "
+                "JOIN files  f  ON f.id  = c.file_id "
+                "WHERE chunks_fts MATCH ? "
+                "ORDER BY rank "
+                "LIMIT ?",
+                (q, limit),
+            ).fetchall()
+            results = [
+                {"path": r["path"], "snippet": r["snippet"], "rank": r["rank"]}
+                for r in rows
+            ]
+        except Exception as exc:
+            return jsonify({
+                "available": True, "query": q, "total": 0,
+                "results": [], "error": str(exc),
+            })
+        return jsonify({"available": True, "query": q, "total": len(results), "results": results})
+    finally:
+        conn.close()
 
 
 # ── Security ───────────────────────────────────────────────────────────────

--- a/tests/test_memory_rag.py
+++ b/tests/test_memory_rag.py
@@ -1,0 +1,179 @@
+"""Tests for /api/memory-rag and /api/memory-rag/search (issue #610).
+
+Creates a minimal in-process SQLite database with the expected schema
+(files, chunks, chunks_fts FTS5), mounts it as the RAG store, and
+exercises the two bp_memory routes without spinning up a real server.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sqlite3
+
+import pytest
+from flask import Flask
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_rag_db(path: str) -> None:
+    """Create a minimal main.sqlite with files + chunks + FTS5 table."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE files (
+            id    INTEGER PRIMARY KEY AUTOINCREMENT,
+            path  TEXT NOT NULL,
+            size  INTEGER DEFAULT 0,
+            mtime INTEGER DEFAULT 0
+        );
+        CREATE TABLE chunks (
+            id      INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_id INTEGER NOT NULL,
+            content TEXT NOT NULL
+        );
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            content,
+            content=chunks,
+            content_rowid=id
+        );
+        CREATE TRIGGER chunks_ai AFTER INSERT ON chunks BEGIN
+            INSERT INTO chunks_fts(rowid, content) VALUES (new.id, new.content);
+        END;
+        """
+    )
+    conn.execute("INSERT INTO files (path, size, mtime) VALUES (?, ?, ?)",
+                 ("notes/project.md", 1024, 1700000000))
+    conn.execute("INSERT INTO files (path, size, mtime) VALUES (?, ?, ?)",
+                 ("notes/archive.md", 512, 1699000000))
+    file_id_1 = conn.execute("SELECT id FROM files WHERE path='notes/project.md'").fetchone()[0]
+    file_id_2 = conn.execute("SELECT id FROM files WHERE path='notes/archive.md'").fetchone()[0]
+    conn.execute("INSERT INTO chunks (file_id, content) VALUES (?, ?)",
+                 (file_id_1, "The project uses Python and Flask for the backend."))
+    conn.execute("INSERT INTO chunks (file_id, content) VALUES (?, ?)",
+                 (file_id_1, "Frontend is embedded HTML with no build step required."))
+    conn.execute("INSERT INTO chunks (file_id, content) VALUES (?, ?)",
+                 (file_id_2, "Archived notes about the old architecture."))
+    conn.commit()
+    conn.close()
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    """Flask test app with bp_memory, pointing MEMORY_DIR at a temp dir
+    that contains a fully-populated main.sqlite."""
+    db_path = tmp_path / "main.sqlite"
+    _make_rag_db(str(db_path))
+
+    import routes.infra as infra_mod
+    importlib.reload(infra_mod)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "MEMORY_DIR", str(tmp_path), raising=False)
+
+    a = Flask(__name__)
+    a.register_blueprint(infra_mod.bp_memory)
+    return a
+
+
+@pytest.fixture
+def app_no_db(tmp_path, monkeypatch):
+    """Flask test app where main.sqlite does NOT exist."""
+    import routes.infra as infra_mod
+    importlib.reload(infra_mod)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "MEMORY_DIR", str(tmp_path), raising=False)
+
+    a = Flask(__name__)
+    a.register_blueprint(infra_mod.bp_memory)
+    return a
+
+
+# ── /api/memory-rag ────────────────────────────────────────────────────────
+
+
+def test_memory_rag_available(app):
+    with app.test_client() as c:
+        r = c.get("/api/memory-rag")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["available"] is True
+    assert data["stats"]["fileCount"] == 2
+    assert data["stats"]["chunkCount"] == 3
+    assert data["stats"]["totalBytes"] == 1024 + 512
+
+
+def test_memory_rag_files_sorted_by_size(app):
+    with app.test_client() as c:
+        data = c.get("/api/memory-rag").get_json()
+    files = data["files"]
+    assert len(files) == 2
+    assert files[0]["path"] == "notes/project.md"
+    assert files[0]["size"] == 1024
+    assert files[0]["chunkCount"] == 2
+    assert files[1]["path"] == "notes/archive.md"
+    assert files[1]["chunkCount"] == 1
+
+
+def test_memory_rag_last_indexed(app):
+    with app.test_client() as c:
+        data = c.get("/api/memory-rag").get_json()
+    assert data["stats"]["lastIndexed"] == 1700000000
+
+
+def test_memory_rag_unavailable_when_no_db(app_no_db):
+    with app_no_db.test_client() as c:
+        r = c.get("/api/memory-rag")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["available"] is False
+    assert data["files"] == []
+
+
+# ── /api/memory-rag/search ─────────────────────────────────────────────────
+
+
+def test_memory_rag_search_hit(app):
+    with app.test_client() as c:
+        r = c.get("/api/memory-rag/search?q=Python")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["available"] is True
+    assert data["total"] >= 1
+    paths = [res["path"] for res in data["results"]]
+    assert "notes/project.md" in paths
+    snippets = [res["snippet"] for res in data["results"]]
+    assert any("Python" in s or "<mark>" in s for s in snippets)
+
+
+def test_memory_rag_search_no_results(app):
+    with app.test_client() as c:
+        data = c.get("/api/memory-rag/search?q=xyzzy_nonexistent_token").get_json()
+    assert data["available"] is True
+    assert data["total"] == 0
+    assert data["results"] == []
+
+
+def test_memory_rag_search_empty_query(app):
+    with app.test_client() as c:
+        data = c.get("/api/memory-rag/search").get_json()
+    assert data["total"] == 0
+    assert data["results"] == []
+
+
+def test_memory_rag_search_unavailable_when_no_db(app_no_db):
+    with app_no_db.test_client() as c:
+        data = c.get("/api/memory-rag/search?q=anything").get_json()
+    assert data["available"] is False
+
+
+def test_memory_rag_search_limit(app):
+    with app.test_client() as c:
+        data = c.get("/api/memory-rag/search?q=notes&limit=1").get_json()
+    assert len(data["results"]) <= 1


### PR DESCRIPTION
## Summary

Adds two new read-only endpoints to the `bp_memory` blueprint so ClawMetry can inspect OpenClaw's RAG document store (`~/.openclaw/memory/main.sqlite`) — the SQLite database that holds indexed files, chunks, and an FTS5 full-text search index. Both endpoints degrade gracefully when the file is absent (returns `{"available": false}`) so the UI can render a "not yet indexed" placeholder without treating the missing file as an error.

## Changes

- **`routes/infra.py`** — adds `import sqlite3`, helper `_open_rag_db()` (read-only URI open with 2 s timeout), and two new routes on `bp_memory`:
  - `GET /api/memory-rag` — file list with per-file chunk count, plus aggregate stats (file count, total bytes, last-indexed epoch, total chunk count)
  - `GET /api/memory-rag/search?q=<terms>&limit=<n>` — FTS5 `MATCH` query over `chunks_fts` returning ranked results with `snippet()` highlights wrapped in `<mark>` tags; hard-capped at 100 results
- **`tests/test_memory_rag.py`** — 9 unit tests using a real in-process SQLite with an FTS5 trigger; covers happy path, empty query, no-DB fallback, and the `limit` param

No new package dependencies — uses stdlib `sqlite3` only.

## Test plan

- [ ] `python3 -m pytest tests/test_memory_rag.py -v` — 9/9 pass
- [ ] `python3 -c 'import ast; ast.parse(open("routes/infra.py").read())'` — no syntax errors
- [ ] Start the server and hit `GET /api/memory-rag` — returns `{"available": false, ...}` when no `main.sqlite` exists; returns file list + stats when it does
- [ ] Hit `GET /api/memory-rag/search?q=python` — returns matching chunks with `<mark>` highlights

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #610. Marked draft for human review — mark Ready for Review once happy.

Note on scope: the tool-call telemetry view (hit/miss rate, sessions that never query memory) requested in the April 17 comment lives in a separate data path (session JSONL files) and is tracked as a follow-on. This PR wires up the document browser half only.

Closes #610

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtnQtQPGNQaJbuccSjPH3R)_