### PR TITLE
fix: enable gateway WS tap by default (closes Telegram watch no-op)

### DIFF
--- a/clawmetry/gateway_tap.py
+++ b/clawmetry/gateway_tap.py
@@ -48,9 +48,11 @@ Failure modes
 Disable
 -------
 
-Set ``CLAWMETRY_ENABLE_WS_TAP=1`` in the environment to opt in.
-Default is OFF until the upstream OpenClaw server grants the
-required ``operator.read`` scope.
+Default is ON. Set ``CLAWMETRY_ENABLE_WS_TAP=0`` in the environment to
+opt out. When the upstream OpenClaw server has not yet granted the
+required ``operator.read`` scope the tap connects in degraded mode
+(no message bodies, one WARNING logged) — same observable behaviour as
+when the tap is disabled, but future scope grants start working immediately.
 """
 
 from __future__ import annotations
@@ -107,7 +109,7 @@ _BACKOFF_INITIAL_SEC = 2.0
 _BACKOFF_MAX_SEC = 60.0
 
 
-# Enable env var (feature is default-OFF until upstream grants scopes).
+# Opt-out env var (feature is default-ON; set to "0"/"false"/"no" to disable).
 _ENABLE_ENV = "CLAWMETRY_ENABLE_WS_TAP"
 
 
@@ -577,8 +579,9 @@ def start(config: dict) -> GatewayTap | None:
     from the live OpenClaw config (mirroring dashboard's
     ``_detect_gateway_token`` / ``_detect_gateway_port``).
     """
-    if os.environ.get(_ENABLE_ENV, "").strip() not in ("1", "true", "yes"):
-        log.debug("gateway WS tap disabled (set CLAWMETRY_ENABLE_WS_TAP=1 to enable)")
+    if os.environ.get(_ENABLE_ENV, "1").strip().lower() in ("0", "false", "no"):
+        log.debug("gateway WS tap disabled (CLAWMETRY_ENABLE_WS_TAP=%s)",
+                  os.environ.get(_ENABLE_ENV, "1"))
         return None
 
     url, token = _detect_gateway_endpoint()

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7953,8 +7953,7 @@ def run_daemon() -> None:
     # memory; gateway.log only carries outbound ACKs (no body), and no
     # JSONL is written for inbound. Without this tap, ClawMetry can
     # NEVER show real Telegram conversations on the Brain tab.
-    # Default-OFF until upstream grants scopes; opt in via
-    # CLAWMETRY_ENABLE_WS_TAP=1.
+    # Default-ON; opt out via CLAWMETRY_ENABLE_WS_TAP=0.
     try:
         from clawmetry import gateway_tap as _gw_tap
         _gw_tap.start(config)


### PR DESCRIPTION
Closes #1196

## What and why

`gateway_tap.py` already contained the correct fix for the Telegram "no-op" bug: a live WebSocket subscriber that calls `ingest_channel_event()` for every gateway frame, bypassing the filesystem entirely. The module was just **opt-IN by default** (`CLAWMETRY_ENABLE_WS_TAP=1` required), so no real user ever got channel messages.

This PR flips the default to **opt-OUT** — the tap starts automatically; set `CLAWMETRY_ENABLE_WS_TAP=0` to disable.

## Changes

- **`clawmetry/gateway_tap.py`** — invert env-var check (default `"1"` → disabled by `"0"/"false"/"no"`); update docstring/inline comments to match new default
- **`clawmetry/sync.py`** — update the one-line comment that described the tap as default-OFF

## Behaviour when `operator.read` scope is missing (today's OpenClaw)

The tap connects to the gateway, the `sessions.messages.subscribe` call is rejected with a scope error, and the tap logs one WARNING:
> `gateway WS tap: sessions.messages.subscribe rejected (missing scope: operator.read) — inbound channel bodies will not arrive until OpenClaw grants operator.read scope`

Then it stays alive in degraded mode — zero channel rows ingested, identical to the prior disabled state. When OpenClaw ships the scope grant, existing installs start seeing channel messages without any user action.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/gateway_tap.py').read())"` passes ✅
- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/sync.py').read())"` passes ✅
- [ ] Confirm `CLAWMETRY_ENABLE_WS_TAP=0` skips tap startup (check log for debug message)
- [ ] Confirm default (no env var) attempts gateway connection on daemon start

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFiCxaVhbCKzAvYCMQZkDa)_