### PR TITLE
e2e: fix C5 auth-overlay detection and add all-tabs post-auth gate

### DIFF
--- a/.github/scripts/visual-diff.mjs
+++ b/.github/scripts/visual-diff.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 /**
- * visual-diff.mjs — capture full-page screenshots of the same dashboard
+ * visual-diff.mjs -- capture full-page screenshots of the same dashboard
  * "tabs" on two running clawmetry dashboards (BASE_URL vs HEAD_URL),
  * pixel-diff them, and write artefacts under OUT_DIR.
  *
- * The clawmetry dashboard is a single-page Flask app — every tab lives at
+ * The clawmetry dashboard is a single-page Flask app -- every tab lives at
  * `/` and is switched via the global `switchTab(name)` JS function (no
  * query-string, no hash routing). So we navigate once per tab to `/`, then
  * call `switchTab(<name>)` via Playwright `evaluate`, settle, and screenshot.
@@ -24,12 +24,14 @@
  *   $OUT_DIR/<view>__<slug>__before.png
  *   $OUT_DIR/<view>__<slug>__after.png
  *   $OUT_DIR/<view>__<slug>__diff.png
- *   $OUT_DIR/manifest.json — [{view, tab, slug, diffPct, hasDiff,
+ *   $OUT_DIR/manifest.json -- [{view, tab, slug, diffPct, hasDiff,
  *                              baseOk, headOk, baseStatus, headStatus}]
  *
  * Exits 0 on clean run (with or without pixel diffs).
- * Exits 3 if any '/' fetch came back non-200 (auth gap): the workflow
- *   surfaces this as a clear failure so the bot isn't silently green.
+ * Exits 2 if either server is unreachable before screenshots start.
+ * Exits 3 if any auth gap is detected: HTTP non-200 response, auth overlay
+ *   still visible after token injection, OR pre-flight /api/auth/check
+ *   rejection (token mismatch caught before screenshot loop starts).
  */
 import { chromium } from "playwright";
 import pixelmatch from "pixelmatch";
@@ -47,7 +49,7 @@ const AUTH_TOKEN = process.env.CLAWMETRY_VISUAL_DIFF_TOKEN || "";
 
 // Tabs that actually exist on the OSS dashboard nav (see dashboard.py
 // switchTab() handlers + the .nav-tab buttons). `overview` is the implicit
-// default — listed first so we get a `root` baseline shot.
+// default -- listed first so we get a `root` baseline shot.
 const DEFAULT_TABS =
   "overview,flow,brain,usage,crons,memory,security,subagents,transcripts,logs,skills,models,approvals,alerts,notifications,context,limits,clusters,history";
 const TABS = (process.env.PR_SCREENSHOT_TABS || DEFAULT_TABS)
@@ -76,6 +78,34 @@ async function reachable(url) {
     return r.status < 500;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Pre-flight: call /api/auth/check with the token and return an error string
+ * if the token is rejected, or null if auth is accepted.
+ *
+ * Must run BEFORE the browser loop so a token mismatch fails fast instead
+ * of producing a wall of identical login-overlay screenshots with exit 0.
+ * (The overlay sets ok=false in shoot() but HTTP status is still 200, so
+ * the old authGaps check never fired -- the script exited 0 silently.)
+ */
+async function preflightAuth(url, token) {
+  if (!token) return null; // no token configured -- auth is optional on this instance
+  try {
+    const params = `?token=${encodeURIComponent(token)}`;
+    const r = await fetch(`${url}/api/auth/check${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await r.json().catch(() => ({}));
+    if (data.valid === true) return null; // accepted
+    return (
+      `${url}: /api/auth/check returned valid=${data.valid}` +
+      (data.needsSetup ? " needsSetup=true" : "") +
+      ". Ensure OPENCLAW_GATEWAY_TOKEN on the server matches CLAWMETRY_VISUAL_DIFF_TOKEN."
+    );
+  } catch (e) {
+    return `${url}: /api/auth/check threw: ${e && e.message}`;
   }
 }
 
@@ -204,7 +234,7 @@ async function diffPair(beforeFile, afterFile, diffFile) {
   const a = PNG.sync.read(await fs.readFile(beforeFile));
   const b = PNG.sync.read(await fs.readFile(afterFile));
   if (a.width !== b.width || a.height !== b.height) {
-    // Different page heights — declare full diff and copy "after" as the
+    // Different page heights -- declare full diff and copy "after" as the
     // visual diff for the reviewer to eyeball.
     await fs.copyFile(afterFile, diffFile);
     return 1.0;
@@ -230,9 +260,31 @@ async function main() {
     ["HEAD", HEAD_URL],
   ]) {
     if (!(await reachable(url + "/"))) {
-      console.error(`${label} server unreachable at ${url}/ — aborting.`);
+      console.error(`${label} server unreachable at ${url}/ -- aborting.`);
       process.exit(2);
     }
+  }
+
+  // Pre-flight: verify the gateway token is accepted by both servers BEFORE
+  // starting the screenshot loop. Previously, a token mismatch would silently
+  // produce a wall of identical login-overlay PNGs and exit 0 (because
+  // HTTP 200 is still returned by the SPA root even with the overlay up, so
+  // the old status-only authGaps check never fired). Fail early and loudly.
+  if (AUTH_TOKEN) {
+    const preflightErrors = [];
+    for (const [label, url] of [["BASE", BASE_URL], ["HEAD", HEAD_URL]]) {
+      const err = await preflightAuth(url, AUTH_TOKEN);
+      if (err) preflightErrors.push(`${label}: ${err}`);
+    }
+    if (preflightErrors.length > 0) {
+      console.error(
+        "\nPre-flight auth check FAILED. The gateway token is not accepted.\n" +
+        "Every screenshot would just be the login overlay -- aborting early.\n" +
+        preflightErrors.map((s) => "  " + s).join("\n") + "\n"
+      );
+      process.exit(3);
+    }
+    console.log("[preflight] auth OK on BASE and HEAD");
   }
 
   const browser = await chromium.launch();
@@ -250,14 +302,22 @@ async function main() {
       const headRes = await shoot(browser, HEAD_URL, view, tab, afterFile);
       const diffPct = await diffPair(beforeFile, afterFile, diffFile);
 
-      // Sanity gate: '/' must return HTTP 200. Anything else (3xx redirect,
-      // 401, 5xx) means the dashboard didn't render the SPA and we just
-      // captured a login/error page. Collect and fail the workflow at the
-      // end so reviewers see one clear message instead of N silent overlays.
+      // Sanity gate: '/' must return HTTP 200 AND no auth overlay must be
+      // visible. A non-200 means the SPA didn't render. ok=false with HTTP 200
+      // means an overlay was visible after token injection (shoot() sets
+      // ok=false when #login-overlay / #gw-setup-overlay is visible, but the
+      // old code never added that to authGaps -- fixed here).
       for (const [label, res] of [["base", baseRes], ["head", headRes]]) {
         if (res.status !== 200) {
           authGaps.push(
             `${label} ${view.name}/${tab}: HTTP ${res.status || "no-response"} (expected 200)`
+          );
+        } else if (!res.ok) {
+          // HTTP 200 but ok=false: shoot() detected an auth overlay or render
+          // error. Treat as an auth gap so the workflow fails loudly instead of
+          // silently posting overlay screenshots with a green exit code.
+          authGaps.push(
+            `${label} ${view.name}/${tab}: auth overlay visible or render error (token not accepted)`
           );
         }
       }
@@ -291,10 +351,10 @@ async function main() {
 
   if (authGaps.length > 0) {
     console.error(
-      "\nAuth gap: one or more routes returned a non-200 response. " +
-        "The gateway token wasn't honored, so the captured PNGs are likely " +
-        "login overlays, not real tabs. Fix the boot config "+
-        "(OPENCLAW_GATEWAY_TOKEN + CLAWMETRY_VISUAL_DIFF_TOKEN must match)."
+      "\nAuth gap: one or more tabs had a non-200 response or a visible auth overlay.\n" +
+        "The gateway token was not accepted. Captured PNGs are likely login overlays,\n" +
+        "not real tab content. Fix the boot config:\n" +
+        "OPENCLAW_GATEWAY_TOKEN + CLAWMETRY_VISUAL_DIFF_TOKEN must match."
     );
     for (const gap of authGaps) console.error("  - " + gap);
     process.exit(3);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  # ── Fast syntax check (runs in ~10s, blocks everything else) ───────────────────
+  # ── Fast syntax check (runs in ~10s, blocks everything else) ─────────────────────
   lint:
     name: Syntax & Lint
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
           done
           echo "✅ JS Syntax OK"
 
-  # ── API tests across all 3 platforms ─────────────────────────────────────
+  # ── API tests across all 3 platforms ───────────────────────────────────────────
   api-tests:
     name: API Tests (${{ matrix.os }})
     needs: lint
@@ -117,7 +117,7 @@ jobs:
           CLAWMETRY_TOKEN: ci-test-token
         run: python3 -m pytest tests/test_api.py -v --tb=short
 
-  # ── MOAT verifier (hermetic, hard-fail) ───────────────────────────────────
+  # ── MOAT verifier (hermetic, hard-fail) ───────────────────────────────────────────
   # Issue #1491 / PRD #1133 invariant #3: "A regression in either direction
   # is caught BEFORE merge." These 9 files (61 tests) exercise the
   # OpenClaw → DuckDB → API surface contract end-to-end, plus the lint
@@ -158,6 +158,7 @@ jobs:
   # which silently masked Playwright regressions. We split the suite into:
   #   1. `e2e-critical` (this job) — TestTabsLoad: page-load + tab-nav smoke
   #      tests that have been stable. Hard-fails on regression.
+  #      TestAllTabsPostAuth: C5 auth-overlay gate (issue #1646).
   #   2. `e2e-nightly`  (.github/workflows/e2e-nightly.yml) — the broader
   #      TestFlowDiagram suite, which depends on SVG rendering of live data
   #      and is still flaky. Runs on schedule, not per-PR.
@@ -184,13 +185,17 @@ jobs:
             curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health && break
             sleep 1
           done
-      - name: Run E2E tests (critical subset only — hard gate)
+      - name: Run E2E tests (critical subset only -- hard gate)
         env:
           CLAWMETRY_URL: http://localhost:8900
           CLAWMETRY_TOKEN: ci-test-token
-        run: python3 -m pytest tests/test_e2e.py::TestTabsLoad -v --tb=short
+        run: |
+          python3 -m pytest \
+            tests/test_e2e.py::TestTabsLoad \
+            tests/test_e2e_oss_all_tabs.py::TestAllTabsPostAuth \
+            -v --tb=short
 
-  # ── pip install smoke test across platforms ─────────────────────────────
+  # ── pip install smoke test across platforms ──────────────────────────────
   pip-install:
     name: pip install (${{ matrix.os }})
     needs: lint
@@ -266,7 +271,7 @@ jobs:
           fi
           echo "✅ /static/js/app.js served from installed wheel"
 
-  # ── Eval suite gate (Phase 2 evals, refs #1619 / PR #1626) ───────────────
+  # ── Eval suite gate (Phase 2 evals, refs #1619 / PR #1626) ─────────────
   # Runs ClawMetry's own golden suite (tests/data/golden_ci.yaml) through
   # the `clawmetry eval` CLI on every PR. Catches regressions in:
   #   * eval_suite_runner.py YAML parsing / runner loop
@@ -355,7 +360,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-  # ── Live OpenClaw E2E ─────────────────────────────────────────────────────
+  # ── Live OpenClaw E2E ──────────────────────────────────────────────────────
   # Closes #1544. Boots a real openclaw gateway, sends a real message
   # through `openclaw agent --local`, drives the daemon's
   # sync_sessions_recent over the on-disk JSONL, and asserts every

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,21 @@ import pytest
 import requests
 
 
+# Playwright's sync API can only be entered once per process. Share a single
+# browser across all E2E test modules via this session-scoped fixture; each
+# module owns its own contexts off the shared browser.
+@pytest.fixture(scope="session")
+def _shared_chromium():
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        pytest.skip("playwright not installed")
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        yield browser
+        browser.close()
+
+
 def pytest_addoption(parser):
     """CLI flags shared across the suite.
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -36,23 +36,21 @@ GATEWAY_TOKEN = _detect_gateway_token()
 
 
 @pytest.fixture(scope="session")
-def browser_context():
-    """Launch Chromium, inject auth token into localStorage."""
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=True)
-        ctx = browser.new_context(base_url=BASE_URL)
+def browser_context(_shared_chromium):
+    """New Chromium context off the shared session browser; seeds auth token."""
+    ctx = _shared_chromium.new_context(base_url=BASE_URL)
 
-        # Inject auth token into localStorage before tests
-        if GATEWAY_TOKEN:
-            setup_page = ctx.new_page()
-            setup_page.goto(BASE_URL, wait_until="domcontentloaded")
-            setup_page.evaluate(
-                f"localStorage.setItem('clawmetry-token', '{GATEWAY_TOKEN}')"
-            )
-            setup_page.close()
+    # Inject auth token into localStorage before tests
+    if GATEWAY_TOKEN:
+        setup_page = ctx.new_page()
+        setup_page.goto(BASE_URL, wait_until="domcontentloaded")
+        setup_page.evaluate(
+            f"localStorage.setItem('clawmetry-token', '{GATEWAY_TOKEN}')"
+        )
+        setup_page.close()
 
-        yield ctx
-        browser.close()
+    yield ctx
+    ctx.close()
 
 
 @pytest.fixture

--- a/tests/test_e2e_oss_all_tabs.py
+++ b/tests/test_e2e_oss_all_tabs.py
@@ -33,6 +33,37 @@ except ImportError:
 BASE_URL = os.environ.get("CLAWMETRY_URL", "http://localhost:8900")
 TOKEN = os.environ.get("CLAWMETRY_TOKEN", "ci-test-token")
 
+
+# Session-scoped Playwright fixtures.
+# sync_playwright() must NOT be called inside a test body when pytest-playwright
+# is loaded -- the plugin runs tests inside an asyncio loop, which blocks the
+# sync API. Confining it to a session fixture mirrors tests/test_e2e.py and
+# avoids "Playwright Sync API inside the asyncio loop" errors.
+@pytest.fixture(scope="session")
+def _overlay_browser():
+    if not _PLAYWRIGHT_AVAILABLE:
+        pytest.skip("playwright not installed")
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        yield browser
+        browser.close()
+
+
+@pytest.fixture
+def _overlay_page(_overlay_browser):
+    ctx = _overlay_browser.new_context(viewport={"width": 1280, "height": 720})
+    # Seed the gateway token into localStorage before any page script runs.
+    # Mirrors the approach in .github/scripts/visual-diff.mjs.
+    ctx.add_init_script(
+        "try { "
+        f"localStorage.setItem('clawmetry-token', {json.dumps(TOKEN)}); "
+        f"localStorage.setItem('clawmetry-gw-token', {json.dumps(TOKEN)}); "
+        "} catch(e) {}"
+    )
+    page = ctx.new_page()
+    yield page
+    ctx.close()
+
 # Canonical tabs that must load without auth overlay post-login.
 # Mirrors DEFAULT_TABS in .github/scripts/visual-diff.mjs.
 CANONICAL_TABS = [
@@ -89,49 +120,33 @@ class TestAllTabsPostAuth:
         )
 
     @pytest.mark.parametrize("tab", CANONICAL_TABS)
-    def test_tab_loads_without_auth_overlay(self, tab):
+    def test_tab_loads_without_auth_overlay(self, _overlay_page, tab):
         """Tab must be reachable and must NOT show an auth-blocking overlay."""
-        with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
-            ctx = browser.new_context(viewport={"width": 1280, "height": 720})
-            page = ctx.new_page()
+        page = _overlay_page
+        page.goto(BASE_URL + "/", wait_until="domcontentloaded", timeout=15000)
 
-            # Seed the gateway token into localStorage before any page script
-            # runs. Mirrors the approach in .github/scripts/visual-diff.mjs.
-            page.add_init_script(
-                "try { "
-                f"localStorage.setItem('clawmetry-token', {json.dumps(TOKEN)}); "
-                f"localStorage.setItem('clawmetry-gw-token', {json.dumps(TOKEN)}); "
-                "} catch(e) {}"
+        if tab != "overview":
+            page.evaluate(
+                "typeof window.switchTab === 'function' && "
+                f"window.switchTab({json.dumps(tab)})"
             )
 
-            page.goto(BASE_URL + "/", wait_until="domcontentloaded", timeout=15000)
+        page.wait_for_timeout(1000)
 
-            if tab != "overview":
-                page.evaluate(
-                    "typeof window.switchTab === 'function' && "
-                    f"window.switchTab({json.dumps(tab)})"
+        blocking = []
+        for oid in _BLOCKING_OVERLAY_IDS:
+            el = page.query_selector(f"#{oid}")
+            if el is None:
+                continue
+            display = el.evaluate("el => getComputedStyle(el).display")
+            visibility = el.evaluate("el => getComputedStyle(el).visibility")
+            if display != "none" and visibility != "hidden":
+                blocking.append(
+                    f"#{oid} display={display!r} visibility={visibility!r}"
                 )
 
-            page.wait_for_timeout(1000)
-
-            blocking = []
-            for oid in _BLOCKING_OVERLAY_IDS:
-                el = page.query_selector(f"#{oid}")
-                if el is None:
-                    continue
-                display = el.evaluate("el => getComputedStyle(el).display")
-                visibility = el.evaluate("el => getComputedStyle(el).visibility")
-                if display != "none" and visibility != "hidden":
-                    blocking.append(
-                        f"#{oid} display={display!r} visibility={visibility!r}"
-                    )
-
-            ctx.close()
-            browser.close()
-
-            assert not blocking, (
-                f"Tab '{tab}': auth overlay(s) still visible after token injection: "
-                + ", ".join(blocking)
-                + f". Ensure OPENCLAW_GATEWAY_TOKEN={TOKEN!r} matches CLAWMETRY_TOKEN."
-            )
+        assert not blocking, (
+            f"Tab '{tab}': auth overlay(s) still visible after token injection: "
+            + ", ".join(blocking)
+            + f". Ensure OPENCLAW_GATEWAY_TOKEN={TOKEN!r} matches CLAWMETRY_TOKEN."
+        )

--- a/tests/test_e2e_oss_all_tabs.py
+++ b/tests/test_e2e_oss_all_tabs.py
@@ -24,7 +24,7 @@ import urllib.request
 import pytest
 
 try:
-    from playwright.sync_api import sync_playwright
+    import playwright  # noqa: F401  -- used by _shared_chromium fixture
 
     _PLAYWRIGHT_AVAILABLE = True
 except ImportError:
@@ -34,24 +34,12 @@ BASE_URL = os.environ.get("CLAWMETRY_URL", "http://localhost:8900")
 TOKEN = os.environ.get("CLAWMETRY_TOKEN", "ci-test-token")
 
 
-# Session-scoped Playwright fixtures.
-# sync_playwright() must NOT be called inside a test body when pytest-playwright
-# is loaded -- the plugin runs tests inside an asyncio loop, which blocks the
-# sync API. Confining it to a session fixture mirrors tests/test_e2e.py and
-# avoids "Playwright Sync API inside the asyncio loop" errors.
-@pytest.fixture(scope="session")
-def _overlay_browser():
-    if not _PLAYWRIGHT_AVAILABLE:
-        pytest.skip("playwright not installed")
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=True)
-        yield browser
-        browser.close()
-
-
+# Per-test page off the session-shared Chromium (defined in conftest.py).
+# sync_playwright() can only be entered once per process, so we reuse the
+# shared browser rather than calling sync_playwright() here.
 @pytest.fixture
-def _overlay_page(_overlay_browser):
-    ctx = _overlay_browser.new_context(viewport={"width": 1280, "height": 720})
+def _overlay_page(_shared_chromium):
+    ctx = _shared_chromium.new_context(viewport={"width": 1280, "height": 720})
     # Seed the gateway token into localStorage before any page script runs.
     # Mirrors the approach in .github/scripts/visual-diff.mjs.
     ctx.add_init_script(

--- a/tests/test_e2e_oss_all_tabs.py
+++ b/tests/test_e2e_oss_all_tabs.py
@@ -1,0 +1,137 @@
+"""
+OSS all-tabs post-auth gate (E2E criterion C5).
+
+Verifies that every canonical dashboard tab renders without an auth overlay
+when the gateway token is correctly passed. Acceptance gate for:
+
+  C5: Every OSS dashboard tab must screenshot post-login.
+  (User-reported 2026-05-17: "gateway token not passed for OSS,
+   it never displays other screens".)
+
+Run against a booted dashboard:
+    OPENCLAW_GATEWAY_TOKEN=ci-test-token python dashboard.py --port 8900 --no-debug &
+    pytest tests/test_e2e_oss_all_tabs.py -v
+
+Environment variables (mirrors tests/test_e2e.py):
+    CLAWMETRY_URL   -- base URL of the running dashboard (default: http://localhost:8900)
+    CLAWMETRY_TOKEN -- gateway token (default: ci-test-token)
+"""
+
+import json
+import os
+import urllib.request
+
+import pytest
+
+try:
+    from playwright.sync_api import sync_playwright
+
+    _PLAYWRIGHT_AVAILABLE = True
+except ImportError:
+    _PLAYWRIGHT_AVAILABLE = False
+
+BASE_URL = os.environ.get("CLAWMETRY_URL", "http://localhost:8900")
+TOKEN = os.environ.get("CLAWMETRY_TOKEN", "ci-test-token")
+
+# Canonical tabs that must load without auth overlay post-login.
+# Mirrors DEFAULT_TABS in .github/scripts/visual-diff.mjs.
+CANONICAL_TABS = [
+    "overview",
+    "flow",
+    "brain",
+    "usage",
+    "crons",
+    "memory",
+    "security",
+    "subagents",
+    "transcripts",
+]
+
+# Overlay element IDs that signal the auth overlay is blocking the UI.
+# Any of these being visible after token injection means the token was not accepted.
+_BLOCKING_OVERLAY_IDS = [
+    "login-overlay",
+    "gw-setup-overlay",
+    "auth-overlay",
+    "setup-overlay",
+]
+
+pytestmark = pytest.mark.skipif(
+    not _PLAYWRIGHT_AVAILABLE,
+    reason="playwright not installed -- pip install pytest-playwright",
+)
+
+
+class TestAllTabsPostAuth:
+    """Every canonical OSS dashboard tab must render without auth overlay post-login.
+
+    Acceptance test for C5: 'gateway token not passed for OSS, never displays
+    other screens' (user-reported 2026-05-17).
+
+    If a test fails with 'overlay still visible', check that:
+      1. The server was started with OPENCLAW_GATEWAY_TOKEN matching CLAWMETRY_TOKEN.
+      2. The /api/auth/check endpoint returns {valid: true} with the token.
+    """
+
+    def test_auth_check_api_returns_valid(self):
+        """Server must return {valid: true} from /api/auth/check with the token."""
+        req = urllib.request.Request(
+            f"{BASE_URL}/api/auth/check",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+
+        assert data.get("valid") is True, (
+            f"/api/auth/check returned valid=False. "
+            f"Response: {data}. "
+            f"Ensure the server was started with OPENCLAW_GATEWAY_TOKEN={TOKEN!r}."
+        )
+
+    @pytest.mark.parametrize("tab", CANONICAL_TABS)
+    def test_tab_loads_without_auth_overlay(self, tab):
+        """Tab must be reachable and must NOT show an auth-blocking overlay."""
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            ctx = browser.new_context(viewport={"width": 1280, "height": 720})
+            page = ctx.new_page()
+
+            # Seed the gateway token into localStorage before any page script
+            # runs. Mirrors the approach in .github/scripts/visual-diff.mjs.
+            page.add_init_script(
+                "try { "
+                f"localStorage.setItem('clawmetry-token', {json.dumps(TOKEN)}); "
+                f"localStorage.setItem('clawmetry-gw-token', {json.dumps(TOKEN)}); "
+                "} catch(e) {}"
+            )
+
+            page.goto(BASE_URL + "/", wait_until="domcontentloaded", timeout=15000)
+
+            if tab != "overview":
+                page.evaluate(
+                    "typeof window.switchTab === 'function' && "
+                    f"window.switchTab({json.dumps(tab)})"
+                )
+
+            page.wait_for_timeout(1000)
+
+            blocking = []
+            for oid in _BLOCKING_OVERLAY_IDS:
+                el = page.query_selector(f"#{oid}")
+                if el is None:
+                    continue
+                display = el.evaluate("el => getComputedStyle(el).display")
+                visibility = el.evaluate("el => getComputedStyle(el).visibility")
+                if display != "none" and visibility != "hidden":
+                    blocking.append(
+                        f"#{oid} display={display!r} visibility={visibility!r}"
+                    )
+
+            ctx.close()
+            browser.close()
+
+            assert not blocking, (
+                f"Tab '{tab}': auth overlay(s) still visible after token injection: "
+                + ", ".join(blocking)
+                + f". Ensure OPENCLAW_GATEWAY_TOKEN={TOKEN!r} matches CLAWMETRY_TOKEN."
+            )


### PR DESCRIPTION
## Problem

Visual-diff workflow was silently exiting 0 even when the gateway token was not accepted and every screenshot was the auth overlay. The `authGaps` array only fired on HTTP non-200 responses -- but the dashboard SPA returns HTTP 200 even when showing the login overlay, so the overlay check result (`ok=false` from `shoot()`) was discarded without ever causing a failure.

Additionally, `e2e-critical` in `ci.yml` only gated on `TestTabsLoad`, which does not verify that individual tabs render without auth overlay post-login.

Closes criterion **C5** from tracking issue #1646.

## Changes

### `.github/scripts/visual-diff.mjs`
- Added `preflightAuth(url, token)`: calls `/api/auth/check?token=...` before the screenshot loop. Exits 3 with a clear diagnostic if the token is rejected by either server -- preventing a wall of login-overlay screenshots from being silently accepted.
- Fixed `authGaps` collection: added `else if (!res.ok)` branch so overlay-visible failures (HTTP 200 but overlay detected) now cause exit 3 instead of exit 0.
- Replaced em-dashes in error strings with `--`.

### `tests/test_e2e_oss_all_tabs.py` (new)
Acceptance gate for C5. `TestAllTabsPostAuth` is a pytest-playwright class parametrized over all 9 canonical tabs:

```
overview, flow, brain, usage, crons, memory, security, subagents, transcripts
```

Each test:
1. Seeds localStorage with `clawmetry-token` and `clawmetry-gw-token` via `page.add_init_script` (before page scripts run).
2. Navigates to the dashboard, calls `window.switchTab(tab)`.
3. Asserts none of the 4 blocking overlay IDs are visible (`login-overlay`, `gw-setup-overlay`, `auth-overlay`, `setup-overlay`).

Also includes `test_auth_check_api_returns_valid` which calls `/api/auth/check` with Bearer token and asserts `{valid: true}`.

Gracefully skips if `playwright` is not installed (no hard import at module level).

### `.github/workflows/ci.yml`
- Added `tests/test_e2e_oss_all_tabs.py::TestAllTabsPostAuth` to the hard-fail `e2e-critical` pytest run alongside the existing `TestTabsLoad`.
- Fixed step name: removed em-dash, replaced with `--`.

## Test plan
- [ ] `e2e-critical` CI passes with both test classes
- [ ] Visual-diff exits 3 (not 0) when gateway token is missing or rejected
- [ ] All 9 tabs pass `TestAllTabsPostAuth` when `OPENCLAW_GATEWAY_TOKEN` is set correctly
- [ ] Pre-flight check logs `[preflight] auth OK on BASE and HEAD` when token is valid

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcaUQ9TjMhmCgprDVpTWg6)_