### PR TITLE
fix(e2e): C5 env-var fallback in api_auth_check + all 19 tabs in TestAllTabsPostAuth

### DIFF
--- a/routes/meta.py
+++ b/routes/meta.py
@@ -53,7 +53,7 @@ bp_version_impact = Blueprint('version_impact', __name__)
 bp_cloud_relay = Blueprint('cloud_relay', __name__)
 
 
-# ── Version check & self-update routes ────────────────────────────────────────
+# ── Version check & self-update routes ─────────────────────────────────────────────
 
 
 @bp_version.route("/api/version")
@@ -160,7 +160,7 @@ def api_install_age():
         return {"exists": False, "ctime": None, "mtime": None}
 
 
-# ── Gateway proxy routes ──────────────────────────────────────────────────────
+# ── Gateway proxy routes ────────────────────────────────────────────────────────────────
 
 
 @bp_gateway.route("/api/gw/config", methods=["GET", "POST"])
@@ -313,19 +313,24 @@ def api_gw_rpc():
     return jsonify(result)
 
 
-# ── Auth routes ───────────────────────────────────────────────────────────────
+# ── Auth routes ─────────────────────────────────────────────────────────────────────────
 
 
 @bp_auth.route("/api/auth/check")
 def api_auth_check():
     """Check if auth is required and validate token."""
     import dashboard as _d
-    if not _d.GATEWAY_TOKEN:
+    # Defensive env-var fallback: if _d.GATEWAY_TOKEN is not yet populated
+    # (e.g. visual-diff preflight hits this endpoint before _load_gw_config
+    # has run), read OPENCLAW_GATEWAY_TOKEN directly so CI never returns
+    # needsSetup:true when the token was correctly injected via env.
+    gateway_token = _d.GATEWAY_TOKEN or os.environ.get("OPENCLAW_GATEWAY_TOKEN", "").strip()
+    if not gateway_token:
         return jsonify({"authRequired": True, "valid": False, "needsSetup": True})
     token = request.headers.get("Authorization", "").replace("Bearer ", "").strip()
     if not token:
         token = request.args.get("token", "").strip()
-    if token == _d.GATEWAY_TOKEN:
+    if token == gateway_token:
         try:
             _d._ext_emit("auth.check", {"ok": True})
         except Exception:
@@ -479,7 +484,7 @@ def api_auth_detected_token():
     return jsonify({"token": token, "source": _detected_token_source(token)})
 
 
-# ── Anonymous funnel-loss instrumentation (issue #1365) ──────────────────────
+# ── Anonymous funnel-loss instrumentation (issue #1365) ──────────────────────────────────
 # Allowed event names. Keep this tiny — every new value is an analytics
 # schema commitment. Today we only ship the one funnel we got burned on
 # in #1357 (typo'd pgrep killed auto-detect).
@@ -680,7 +685,7 @@ def index():
     return resp
 
 
-# ── OTLP receiver routes ──────────────────────────────────────────────────────
+# ── OTLP receiver routes ──────────────────────────────────────────────────────────────────
 
 
 @bp_otel.route("/v1/metrics", methods=["POST"])
@@ -751,7 +756,7 @@ def api_otel_status():
     )
 
 
-# ── Version impact analysis ───────────────────────────────────────────────────
+# ── Version impact analysis ─────────────────────────────────────────────────────────────────────
 
 
 def _ls_call(method_name, **kwargs):

--- a/tests/test_e2e_oss_all_tabs.py
+++ b/tests/test_e2e_oss_all_tabs.py
@@ -53,7 +53,8 @@ def _overlay_page(_shared_chromium):
     ctx.close()
 
 # Canonical tabs that must load without auth overlay post-login.
-# Mirrors DEFAULT_TABS in .github/scripts/visual-diff.mjs.
+# Matches PR_SCREENSHOT_TABS in .github/workflows/pr-screenshots.yml
+# so the Playwright gate covers the same surface as the visual-diff workflow.
 CANONICAL_TABS = [
     "overview",
     "flow",
@@ -64,6 +65,16 @@ CANONICAL_TABS = [
     "security",
     "subagents",
     "transcripts",
+    "logs",
+    "skills",
+    "models",
+    "approvals",
+    "alerts",
+    "notifications",
+    "context",
+    "limits",
+    "clusters",
+    "history",
 ]
 
 # Overlay element IDs that signal the auth overlay is blocking the UI.


### PR DESCRIPTION
## Problem (C5: visual-diff gateway-token bug)

User-reported 2026-05-17: "gateway token not passed for OSS so it never displays other screens." Every visual-diff screenshot was showing the login overlay instead of the actual tab content.

Two root causes:

**1. `api_auth_check()` has no env-var fallback**

`routes/meta.py::api_auth_check()` returns `{needsSetup: true}` when `_d.GATEWAY_TOKEN` is falsy. In `pr-screenshots.yml` the token is injected as `OPENCLAW_GATEWAY_TOKEN` in the environment, and `_load_gw_config()` does populate `GATEWAY_TOKEN` at server startup -- but the visual-diff preflight hits `/api/auth/check` very early in the process lifecycle before any request has been served, and in some CI orderings the module-level global has not been initialised yet.

**2. `CANONICAL_TABS` covers only 9 of 19 tabs**

`tests/test_e2e_oss_all_tabs.py` only tested 9 tabs; `pr-screenshots.yml` screenshots 19. The Playwright gate was not exercising the same surface area as the visual-diff workflow.

## Fix

**`routes/meta.py`** -- defensive env-var fallback in `api_auth_check()`:
```python
# Before
if not _d.GATEWAY_TOKEN:
    return jsonify({"authRequired": True, "valid": False, "needsSetup": True})
token = ...
if token == _d.GATEWAY_TOKEN:

# After
gateway_token = _d.GATEWAY_TOKEN or os.environ.get("OPENCLAW_GATEWAY_TOKEN", "").strip()
if not gateway_token:
    return jsonify({"authRequired": True, "valid": False, "needsSetup": True})
token = ...
if token == gateway_token:
```

`OPENCLAW_GATEWAY_TOKEN` is already set in the pr-screenshots job env, so this is always available when CI injects it -- no new secrets or workflow changes needed.

**`tests/test_e2e_oss_all_tabs.py`** -- expand `CANONICAL_TABS` from 9 to 19:
```
logs, skills, models, approvals, alerts, notifications, context, limits, clusters, history
```
added to match `PR_SCREENSHOT_TABS` in `pr-screenshots.yml` exactly.

## Test plan

- [ ] `pytest tests/test_e2e_oss_all_tabs.py -v` with `OPENCLAW_GATEWAY_TOKEN=ci-test-token` passes all 19 tab parametrize cases
- [ ] `pytest tests/test_e2e_oss_all_tabs.py::TestAllTabsPostAuth::test_auth_check_api_returns_valid` returns `valid=true`
- [ ] Visual-diff run on this PR shows all 19 tab screenshots without login overlay
- [ ] Existing `tests/test_e2e.py` unaffected

Closes #1546
Tracking: #1646 (C5)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwP49gszvMMfuwjVtgt3Re)_