### PR TITLE
feat(sync): add tool_calls_today + exec/browser/messages counters to heartbeat (closes #1652)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -4573,6 +4573,124 @@ def _collect_security_posture() -> dict | None:
         return None
 
 
+# Tool-name classifiers for `_collect_activity_counters_today` (issue #1652).
+# Mirrors the lower-cased substring match used by `routes/brain.py::tool_to_type`
+# so the heartbeat counters line up with the same buckets the OSS Brain page
+# would show. Centralised here so the daemon doesn't have to import routes.
+def _classify_tool_name(name: str) -> str:
+    """Return the activity bucket for a tool ``name``. One of:
+    ``exec``, ``browser``, ``other``. Lower-cased before matching."""
+    tn = (name or "").lower()
+    if not tn:
+        return "other"
+    if tn in ("exec", "process") or "shell" in tn or "bash" in tn:
+        return "exec"
+    if "browser" in tn:
+        return "browser"
+    return "other"
+
+
+# Plaintext message-class events (issue #1652). These are the v3 + legacy
+# event types that count as "the agent did one round-trip with the user or
+# the model". Match the dedup set in `local_store.query_aggregates`.
+_MESSAGE_EVENT_TYPES_TODAY = (
+    "message", "prompt.submitted", "model.completed",
+)
+
+
+def _today_start_iso_utc() -> str:
+    """Midnight-UTC of the current day as ISO-8601, suitable for the
+    ``events.ts`` VARCHAR column's lexical ordering (UTC ISO sorts correctly
+    as strings)."""
+    now = datetime.now(timezone.utc)
+    start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    return start.isoformat()
+
+
+def _collect_activity_counters_today() -> dict | None:
+    """Plaintext activity counters for the heartbeat envelope (issue #1652).
+
+    Cloud has no plaintext source for real exec/tool-call activity counts —
+    sessions + nodes.metadata carry version/health bits but no per-day
+    counters, and the brain cache push is encrypted (cloud can't read it).
+    This helper aggregates COUNTS (not session content) from the local
+    DuckDB events table for today UTC, so cloud's Flow Exec modal (#953)
+    and adjacent surfaces (#967 messages, #968 browser) can swap from the
+    session-liveness proxy to real numbers in their next iteration.
+
+    Returns a dict with five integer fields (all >= 0):
+
+      * ``tool_calls_today`` — every tool invocation (exec + browser + other)
+      * ``exec_calls_today`` — subset whose name classifies as shell/bash/exec
+      * ``browser_actions_today`` — subset whose name contains ``browser``
+      * ``unique_tools_today`` — count of distinct tool names invoked today
+      * ``messages_today`` — count of ``message`` / ``prompt.submitted`` /
+        ``model.completed`` events today
+
+    Best-effort: returns ``None`` if local_store isn't importable or the
+    underlying read raises — heartbeat MUST succeed even if counters fail.
+    Why plaintext is OK: these are aggregates, not session content.
+    No PII risk — same trust model as the existing `local_store_size_mb`.
+    """
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store()
+    except Exception:
+        return None
+
+    try:
+        since = _today_start_iso_utc()
+
+        # Tool calls: re-use the per-invocation reader so we count once
+        # per ACTUAL tool call, not once per row (an assistant message
+        # carrying 3 toolMetas yields 3 invocations, not 1).
+        try:
+            invs = store.query_tool_call_invocations(since=since, limit=200_000)
+        except Exception:
+            invs = []
+        tool_calls = 0
+        exec_calls = 0
+        browser_actions = 0
+        unique_names: set[str] = set()
+        for row in invs:
+            name = row.get("name") if isinstance(row, dict) else None
+            if not isinstance(name, str) or not name:
+                continue
+            tool_calls += 1
+            unique_names.add(name.lower())
+            bucket = _classify_tool_name(name)
+            if bucket == "exec":
+                exec_calls += 1
+            elif bucket == "browser":
+                browser_actions += 1
+
+        # Messages: count rows directly via query_events. We don't dedup the
+        # assistant/model.completed twin here — message counts are a coarse
+        # "did the agent talk today" signal and the dedupe would obscure
+        # legitimately distinct prompt.submitted rows. Cloud uses this as a
+        # heartbeat liveness proxy, not a billing aggregate.
+        messages_today = 0
+        for et in _MESSAGE_EVENT_TYPES_TODAY:
+            try:
+                rows = store.query_events(
+                    event_type=et, since=since, limit=100_000,
+                )
+            except Exception:
+                continue
+            messages_today += len(rows)
+
+        return {
+            "tool_calls_today":      int(tool_calls),
+            "exec_calls_today":      int(exec_calls),
+            "browser_actions_today": int(browser_actions),
+            "unique_tools_today":    int(len(unique_names)),
+            "messages_today":        int(messages_today),
+        }
+    except Exception as e:
+        log.debug("_collect_activity_counters_today failed: %s", e)
+        return None
+
+
 # Adaptive heartbeat: the most recent /ingest/heartbeat response body so the
 # main loop (and tests) can derive the next sleep interval without changing
 # `send_heartbeat`'s `bool` return type (callers in tests assert `is True`).
@@ -4635,6 +4753,16 @@ def send_heartbeat(config: dict) -> bool:
         payload["local_store_size_mb"] = round(size_mb, 3)
     except Exception:
         pass  # local store optional — never break heartbeat over it
+    # Issue #1652: plaintext per-day activity counters so the cloud Flow Exec
+    # modal (#953/#966), messages widget (#967) and browser widget (#968)
+    # can show REAL numbers instead of inferring from session liveness.
+    # Same trust model as `local_store_size_mb` — counts only, no content.
+    try:
+        counters = _collect_activity_counters_today()
+        if counters:
+            payload.update(counters)
+    except Exception as _ce:
+        log.debug("activity counters build failed (continuing): %s", _ce)
     # Phase 2 of relay-v2 (epic #1032): proactively push the top-50 brain
     # events to the cloud cache so the Brain page paints in <100ms on first
     # load instead of waiting for a relay round-trip. The blob is the same

--- a/tests/test_heartbeat_envelope.py
+++ b/tests/test_heartbeat_envelope.py
@@ -1,0 +1,175 @@
+"""Issue #1652 — heartbeat envelope plaintext activity counters."""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def sync_with_store(tmp_path, monkeypatch):
+    """Reload ``clawmetry.sync`` + ``clawmetry.local_store`` against a
+    fresh DuckDB. Yields (sync_module, local_store_module, config)."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as s
+    importlib.reload(s)
+
+    config = {
+        "node_id":         "node-test",
+        "api_key":         "cm_test",
+        "encryption_key":  s.generate_encryption_key(),
+    }
+
+    yield s, ls, config
+
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _drain_ring(store, max_wait_secs: float = 4.0) -> None:
+    """Block until the background flusher has drained the ring buffer."""
+    deadline = time.time() + max_wait_secs
+    while time.time() < deadline:
+        try:
+            if store.health()["ring_depth"] == 0:
+                return
+        except Exception:
+            return
+        time.sleep(0.05)
+
+
+def _today_iso(seconds_into_day: int = 0) -> str:
+    """A UTC ISO timestamp inside today, deliberately at midnight + N sec
+    so even tests run a few ms before/after rollover still land in-day."""
+    now = datetime.now(timezone.utc)
+    start = now.replace(hour=12, minute=0, second=0, microsecond=0)
+    return start.replace(second=(seconds_into_day % 60)).isoformat()
+
+
+# ── 1. shape: helper returns the documented dict ────────────────────────────
+
+def test_helper_returns_five_int_fields_on_empty_store(sync_with_store):
+    s, _ls, _config = sync_with_store
+    out = s._collect_activity_counters_today()
+    assert isinstance(out, dict), "helper must return a dict (or None)"
+    for field in (
+        "tool_calls_today", "exec_calls_today", "browser_actions_today",
+        "unique_tools_today", "messages_today",
+    ):
+        assert field in out, f"missing field: {field}"
+        assert isinstance(out[field], int), f"{field} must be int"
+        assert out[field] >= 0, f"{field} must be >= 0"
+    # Empty store → every count is exactly zero.
+    assert sum(out.values()) == 0
+
+
+# ── 2. math: counters reflect seeded events ────────────────────────────────
+
+def test_helper_counts_tool_calls_exec_browser_messages(sync_with_store):
+    s, ls, _config = sync_with_store
+    store = ls.get_store()
+
+    # 3 tool calls: one Bash (exec), one browser_action (browser), one Read.
+    seed = [
+        ("tool.call", {"name": "Bash"}),
+        ("tool.call", {"name": "browser_action"}),
+        ("tool.call", {"name": "Read"}),
+        # 2 messages: one assistant, one prompt.submitted.
+        ("message", {"message": {"role": "assistant", "content": []}}),
+        ("prompt.submitted", {"finalPromptText": "hi"}),
+    ]
+    for et, data in seed:
+        store.ingest({
+            "id":         str(uuid.uuid4()),
+            "node_id":    "agent+test",
+            "agent_id":   "main",
+            "session_id": "sess-A",
+            "event_type": et,
+            "ts":         _today_iso(),
+            "data":       data,
+        })
+    _drain_ring(store)
+
+    out = s._collect_activity_counters_today()
+    assert out is not None
+    assert out["tool_calls_today"] == 3
+    assert out["exec_calls_today"] == 1, "Bash should classify as exec"
+    assert out["browser_actions_today"] == 1, "browser_action should classify"
+    assert out["unique_tools_today"] == 3, "Bash, browser_action, Read distinct"
+    assert out["messages_today"] == 2
+
+
+# ── 3. wiring: send_heartbeat injects the counters into the POST payload ────
+
+def test_send_heartbeat_payload_includes_counters(sync_with_store, monkeypatch):
+    s, ls, config = sync_with_store
+    store = ls.get_store()
+
+    # Seed one exec tool call so counters are >0 and visibly distinct from
+    # the empty-store baseline. Also tags messages_today with one row so
+    # cloud has a non-zero "is this node talking today?" signal.
+    store.ingest({
+        "id":         str(uuid.uuid4()),
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": "sess-A",
+        "event_type": "tool.call",
+        "ts":         _today_iso(),
+        "data":       {"name": "Bash"},
+    })
+    store.ingest({
+        "id":         str(uuid.uuid4()),
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": "sess-A",
+        "event_type": "message",
+        "ts":         _today_iso(),
+        "data":       {"message": {"role": "assistant", "content": []}},
+    })
+    _drain_ring(store)
+
+    captured: list[dict] = []
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/heartbeat":
+            captured.append(payload)
+            return {"sync_allowed": True, "pending_queries": []}
+        return {"ok": True}
+
+    monkeypatch.setattr(s, "_post", fake_post)
+
+    assert s.send_heartbeat(config) is True
+    assert captured, "send_heartbeat must POST exactly one /ingest/heartbeat"
+    pl = captured[0]
+    for field in (
+        "tool_calls_today", "exec_calls_today", "browser_actions_today",
+        "unique_tools_today", "messages_today",
+    ):
+        assert field in pl, f"heartbeat payload missing {field}"
+        assert isinstance(pl[field], int)
+        assert pl[field] >= 0
+    assert pl["tool_calls_today"] >= 1
+    assert pl["exec_calls_today"] >= 1
+    assert pl["messages_today"] >= 1

--- a/tests/test_moat_cross_repo_version_skew.py
+++ b/tests/test_moat_cross_repo_version_skew.py
@@ -134,6 +134,10 @@ class _CloudState:
             "security_posture", "local_store", "local_store_size_mb",
             "cache_pushes", "node_meta", "hostname",
             "auto_update", "events", "blob", "encrypted",
+            # Issue #1652 activity counters (cloud Flow Exec / messages /
+            # browser widgets read these directly off nodes.metadata).
+            "tool_calls_today", "exec_calls_today", "browser_actions_today",
+            "unique_tools_today", "messages_today",
         }
 
 


### PR DESCRIPTION
## Summary

Adds five plaintext integer counters to the heartbeat envelope so cloud's Flow Exec modal (#953/#966), messages widget (#967) and browser widget (#968) can swap their session-liveness proxy for real numbers.

Computed from today's UTC events in the local DuckDB via the existing `query_tool_call_invocations` + `query_events` helpers (no new connections — respects the daemon-only process-lock rule):

- `tool_calls_today` — every recognised tool invocation
- `exec_calls_today` — `Bash` / `shell` / `exec` / `process` (mirrors `routes/brain.py::tool_to_type`)
- `browser_actions_today` — any tool name containing `browser`
- `unique_tools_today` — distinct tool names today
- `messages_today` — `message` / `prompt.submitted` / `model.completed`

Plaintext is OK here: these are counts, not session content. Same trust model as `local_store_size_mb`.

Also extends the cross-repo version-skew contract test's `known_top_level_fields` so older clouds correctly classify the new keys as recognised on a wire-shape audit.

## Why

Cloud Flow Exec modal (#953) currently shows "No exec commands today" on a heartbeating node because cloud has no plaintext source for tool-call counts. PR #966 ships a session-liveness proxy as a temporary fix; this PR makes the real counter available so cloud can switch in its next iteration.

## Test plan

- [x] `pytest tests/test_heartbeat_envelope.py -q` — 3 new tests pass (helper shape, helper math, send_heartbeat wiring)
- [x] `pytest tests/test_moat_send_message_e2e.py tests/test_moat_bug_class_v3_event_shape_gate.py -q` — 6/6 MOAT verifier tests pass
- [x] `pytest tests/test_moat_cross_repo_version_skew.py tests/test_first_heartbeat_onboarding.py tests/test_adaptive_heartbeat.py -q` — 27/27 related heartbeat tests pass
- [x] `python3 -c "import dashboard"` clean
- [ ] Cloud roundtrip: verify `tool_calls_today` lands in `nodes.metadata` on the cloud side (follow-up cloud PR can read it via `cloud_node_components`)
- [ ] Cloud PR #966 follow-up: swap session-liveness proxy for `nodes.metadata.tool_calls_today`

Closes #1652.