### PR TITLE
fix(channels): wire DuckDB fast-path to /api/channel/tui

### DIFF
--- a/routes/channels.py
+++ b/routes/channels.py
@@ -556,6 +556,175 @@ def _try_local_store_channel_events(provider, limit):
     }
 
 
+# ── Issue #1656: DuckDB fast path for /api/channel/tui ─────────────────────
+#
+# Unlike Telegram / Signal / BlueBubbles, the OpenClaw TUI does NOT have a
+# dedicated channel adapter directory under ``~/.openclaw/`` — it writes
+# directly into the active session JSONL with a ``Sender (untrusted
+# metadata)`` JSON preamble tagged ``openclaw-tui``. That means there is
+# no ``channel.in`` / ``channel.out`` event for TUI turns, so
+# ``_try_local_store_channel_events`` cannot serve them.
+#
+# However the daemon's v3 mapper (``sync._parse_v3_event``) ALREADY
+# normalises every session-JSONL ``message`` line into ``prompt.submitted``
+# (user role) and ``model.completed`` (assistant role), preserving the
+# raw ``finalPromptText`` verbatim — Sender block included. So the TUI
+# marker survives the ingest and we can query DuckDB for the same rows
+# the legacy JSONL walker reconstructs from disk, just without the
+# O(sessions) directory scan.
+#
+# This is the MOAT-first read path for #1656: try DuckDB first, fall
+# back to the legacy session-JSONL walker when the daemon hasn't
+# ingested anything yet (fresh install / read flag OFF / daemon down).
+
+_TUI_MARKER = "openclaw-tui"
+
+
+def _strip_tui_sender_block(text: str) -> str:
+    """Remove the ```json {...}``` Sender preamble from a TUI prompt body
+    so the bubble shows the user's real message. Mirrors the legacy
+    ``_strip_sender_block`` inside ``api_channel_tui``."""
+    import re as _re
+    if not isinstance(text, str):
+        return text
+    m = _re.search(r"```json\s*\{[^`]*?\}\s*```\s*", text, _re.DOTALL)
+    return (text[m.end():] if m else text).strip()
+
+
+def _try_local_store_channel_tui(limit):
+    """Issue #1656 DuckDB fast path for the TUI channel.
+
+    Reads ``prompt.submitted`` events whose ``data.finalPromptText`` carries
+    the ``openclaw-tui`` marker (the same Sender-block preamble the JSONL
+    walker matched on at routes/channels.py:2318) and pairs each one with
+    the next ``model.completed`` event in the same ``session_id`` as the
+    outbound reply.
+
+    Same dual-tier contract memory ``feedback_synthetic_tests_missed_real_event_shape.md``
+    warns about: read against the REAL OpenClaw v3 event shape
+    (``prompt.submitted`` / ``model.completed``) — not a synthetic
+    ``channel.*`` row that production never writes for TUI.
+
+    Returns ``None`` when DuckDB has no TUI-tagged prompts so the route
+    falls through to the legacy JSONL walker."""
+    prompts = _ls_call(
+        "query_events",
+        event_type="prompt.submitted",
+        limit=_CHANNEL_EVENTS_FAST_PATH_LIMIT,
+    ) or []
+    # Filter to TUI-tagged prompts in Python (DuckDB JSON predicate would
+    # need an extra LocalStore helper — keep the daemon-proxy surface
+    # minimal, same pattern as ``_try_local_store_channel_events``).
+    tui_prompts = []
+    sessions_with_tui = set()
+    for ev in prompts:
+        data = ev.get("data") if isinstance(ev.get("data"), dict) else {}
+        if not isinstance(data, dict):
+            continue
+        # ``finalPromptText`` lives at either ``data.finalPromptText`` or
+        # ``data.data.finalPromptText`` — ``_parse_v3_event`` dual-writes
+        # so either lookup works, but check both for resilience against
+        # future shape drift.
+        text = data.get("finalPromptText") or ""
+        if not text:
+            inner = data.get("data") if isinstance(data.get("data"), dict) else {}
+            text = inner.get("finalPromptText") or ""
+        if not isinstance(text, str) or _TUI_MARKER not in text:
+            continue
+        tui_prompts.append((ev, text))
+        sid = ev.get("session_id") or ""
+        if sid:
+            sessions_with_tui.add(sid)
+
+    if not tui_prompts:
+        return None
+
+    # Pull completions for the sessions we have TUI prompts in so we can
+    # pair each prompt with the next assistant reply by timestamp.
+    completions_by_session: dict[str, list[dict]] = {}
+    if sessions_with_tui:
+        # ``query_events`` doesn't take a session-IN filter; pull a
+        # generous global window and bucket in Python. Cheap because
+        # _CHANNEL_EVENTS_FAST_PATH_LIMIT caps both pulls at 1000 each.
+        completions = _ls_call(
+            "query_events",
+            event_type="model.completed",
+            limit=_CHANNEL_EVENTS_FAST_PATH_LIMIT,
+        ) or []
+        for ev in completions:
+            sid = ev.get("session_id") or ""
+            if sid in sessions_with_tui:
+                completions_by_session.setdefault(sid, []).append(ev)
+        # Sort each session's completions OLDEST-FIRST so the pairing loop
+        # can pop the first one strictly after each TUI prompt's ts.
+        for sid in completions_by_session:
+            completions_by_session[sid].sort(key=lambda e: e.get("ts") or "")
+
+    messages = []
+    today = datetime.now().strftime("%Y-%m-%d")
+    today_in = 0
+    today_out = 0
+    used_completion_ids: set[str] = set()
+
+    for ev, text in tui_prompts:
+        ts = ev.get("ts") or ""
+        body = _strip_tui_sender_block(text)
+        messages.append({
+            "timestamp": ts,
+            "direction": "in",
+            "sender":    "User",
+            "text":      body,
+        })
+        if today and today in str(ts):
+            today_in += 1
+
+        sid = ev.get("session_id") or ""
+        for c_ev in completions_by_session.get(sid, []):
+            c_id = c_ev.get("id") or ""
+            if c_id in used_completion_ids:
+                continue
+            c_ts = c_ev.get("ts") or ""
+            if c_ts <= ts:
+                # ISO strings sort lexicographically; skip completions
+                # that came BEFORE this prompt.
+                continue
+            c_data = c_ev.get("data") if isinstance(c_ev.get("data"), dict) else {}
+            reply = ""
+            if isinstance(c_data, dict):
+                reply = c_data.get("completionText") or ""
+                if not reply:
+                    inner = c_data.get("data") if isinstance(c_data.get("data"), dict) else {}
+                    reply = inner.get("completionText") or ""
+            if not reply:
+                # Empty completion (tool-only turn). Mark consumed so we
+                # don't re-pair it with a later TUI prompt, then move on.
+                used_completion_ids.add(c_id)
+                continue
+            messages.append({
+                "timestamp": c_ts,
+                "direction": "out",
+                "sender":    "Clawd",
+                "text":      str(reply),
+            })
+            if today and today in str(c_ts):
+                today_out += 1
+            used_completion_ids.add(c_id)
+            break
+
+    # Newest-first, cap to ``limit``.
+    messages.sort(key=lambda m: m.get("timestamp") or "", reverse=True)
+    capped = messages[:limit]
+
+    return {
+        "messages": capped,
+        "total":    len(messages),
+        "todayIn":  today_in,
+        "todayOut": today_out,
+        "status":   "local_store_v3",
+        "_source":  "local_store_v3",
+    }
+
+
 @bp_channels.route("/api/channels/<provider>/messages")
 def api_channel_messages(provider: str):
     """List recent messages for one provider — DuckDB fast path
@@ -2259,12 +2428,28 @@ def api_channel_tui():
     Unlike Telegram/Signal/etc which have dedicated channel adapters and
     log to `gateway.log`, the OpenClaw TUI writes directly into the active
     session JSONL — so we reconstruct the conversation from there.
+
+    Issue #1656 DuckDB fast path: when the daemon has already ingested
+    the same session JSONLs into the local store (`prompt.submitted` +
+    `model.completed` events tagged with the `openclaw-tui` Sender
+    marker), serve from DuckDB first to avoid the O(sessions) directory
+    scan on every poll. Falls through to the legacy JSONL walker on
+    miss so fresh installs (daemon hasn't caught up) still work.
     """
     import dashboard as _d
     import re as _re
 
     limit = request.args.get("limit", 50, type=int)
     today = datetime.now().strftime("%Y-%m-%d")
+
+    # MOAT-first read path (#1656). Mirrors the bluebubbles/telegram/signal
+    # sibling pattern at routes/channels.py:2048-2063 — try the v3 events
+    # table FIRST; only fall through to the legacy walker if DuckDB has no
+    # TUI-tagged prompts yet.
+    if _local_store_read_enabled():
+        fast = _try_local_store_channel_tui(limit)
+        if fast is not None:
+            return jsonify(fast)
 
     sessions_dir = _d.SESSIONS_DIR or os.path.expanduser(
         "~/.openclaw/agents/main/sessions"

--- a/tests/test_channel_tui_duckdb_fastpath.py
+++ b/tests/test_channel_tui_duckdb_fastpath.py
@@ -1,0 +1,340 @@
+"""Regression guard for the /api/channel/tui DuckDB fast path (issue #1656).
+
+Until this fix landed, ``routes/channels.py:api_channel_tui`` was the last
+Tier-1 channel route still walking session JSONLs on every poll — the
+2026-05-18 MOAT coverage audit flagged it as the sole remaining BYPASS
+violation across all 230 dashboard endpoints.
+
+The fix wires ``_try_local_store_channel_tui`` BEFORE the legacy JSONL
+walker. Unlike Telegram/Signal/BlueBubbles (which carry dedicated
+``channel.in`` / ``channel.out`` events), TUI turns live in the unified
+``events`` table as ``prompt.submitted`` (user role) + ``model.completed``
+(assistant role), with the ``openclaw-tui`` Sender marker preserved
+verbatim inside ``data.finalPromptText`` by the daemon's v3 mapper
+(``clawmetry/sync.py:_parse_v3_event``).
+
+These tests assert:
+
+  1. DuckDB-seeded ``prompt.submitted`` (with the TUI marker) + the next
+     ``model.completed`` in the same session pair into the legacy
+     ``{messages, todayIn, todayOut, total, status}`` envelope.
+  2. The Sender-block JSON preamble is stripped from the rendered user
+     bubble (matches the legacy walker's ``_strip_sender_block`` shape).
+  3. A ``prompt.submitted`` row WITHOUT the ``openclaw-tui`` marker
+     (e.g. an inbound from Telegram via the same session JSONL) does
+     NOT surface on the TUI route — guards the silent-zero bug class
+     memory ``feedback_synthetic_tests_missed_real_event_shape.md``
+     warns about.
+  4. Empty DuckDB → helper returns ``None`` so the route falls through
+     to the legacy JSONL walker (which on a test box with no sessions
+     dir returns ``status='no sessions dir'`` — confirms the
+     ``_source='local_store_v3'`` tag is reserved for the fast path).
+
+The test fixture isolates DuckDB to a tmp_path (mirrors
+``tests/test_channel_bluebubbles_local_store_v3.py``) and shorts out
+the daemon-proxy discovery so a contributor's running daemon doesn't
+serve stale rows out of its own production DuckDB.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _iso_seconds_offset(seconds: int) -> str:
+    return (datetime.now(tz=timezone.utc) + timedelta(seconds=seconds)).isoformat()
+
+
+def _seed_tui_prompt(
+    store,
+    *,
+    body: str,
+    session_id: str,
+    ts: str | None = None,
+    with_marker: bool = True,
+):
+    """Seed one ``prompt.submitted`` event in the exact shape
+    ``sync._parse_v3_event`` writes for a TUI user turn — Sender block
+    preamble preserved in ``data.finalPromptText``.
+
+    ``with_marker=False`` produces a non-TUI prompt (no ``openclaw-tui``
+    marker) so we can prove the helper filters by marker, not by event
+    type alone."""
+    if with_marker:
+        text = (
+            '```json\n'
+            '{"channel":"openclaw-tui","user":"vivek"}\n'
+            '```\n'
+            + body
+        )
+    else:
+        text = body
+    store.ingest({
+        "id":         f"prompt-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "agent_type": "openclaw",
+        "agent_id":   "main",
+        "event_type": "prompt.submitted",
+        "ts":         ts or _now_iso(),
+        "session_id": session_id,
+        "workspace_id": None,
+        "data": {
+            "finalPromptText": text,
+            "timestamp":       ts or _now_iso(),
+            "type":            "prompt.submitted",
+            "data":            {"finalPromptText": text},
+        },
+        "cost_usd":    None,
+        "token_count": None,
+        "model":       None,
+    })
+
+
+def _seed_assistant_reply(
+    store,
+    *,
+    completion_text: str,
+    session_id: str,
+    ts: str | None = None,
+):
+    """Seed one ``model.completed`` event in the same shape
+    ``sync._parse_v3_event`` writes for an assistant turn."""
+    store.ingest({
+        "id":         f"completion-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "agent_type": "openclaw",
+        "agent_id":   "main",
+        "event_type": "model.completed",
+        "ts":         ts or _now_iso(),
+        "session_id": session_id,
+        "workspace_id": None,
+        "data": {
+            "completionText": completion_text,
+            "assistantTexts": [completion_text] if completion_text else [],
+            "modelId":        "claude-opus-4-7",
+            "timestamp":      ts or _now_iso(),
+            "type":           "model.completed",
+            "data":           {"completionText": completion_text},
+        },
+        "cost_usd":    0.001,
+        "token_count": 50,
+        "model":       "claude-opus-4-7",
+    })
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    # Point SESSIONS_DIR at an empty tmp dir so the legacy JSONL walker
+    # path (used for the empty-DuckDB fallback test) returns the
+    # well-known "no sessions dir" envelope instead of leaking events
+    # from a contributor's real ~/.openclaw.
+    empty_sessions = tmp_path / "empty_sessions"
+    empty_sessions.mkdir()
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.channels as channels_mod
+    importlib.reload(channels_mod)
+
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    import dashboard  # noqa: F401
+
+    # Override the dashboard's SESSIONS_DIR so the legacy walker has
+    # nothing to read — this isolates the fallback assertion from any
+    # ambient OpenClaw install on the test machine.
+    monkeypatch.setattr(dashboard, "SESSIONS_DIR", str(tmp_path / "missing_sessions"))
+
+    a = Flask(__name__)
+    a.register_blueprint(channels_mod.bp_channels)
+    yield a, ls, channels_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_tui_v3_fast_path_serves_when_duckdb_has_tui_prompts(app):
+    """Seeded TUI ``prompt.submitted`` + next ``model.completed`` pair
+    into the legacy envelope and the response is tagged
+    ``_source='local_store_v3'`` (audit canary for the fast path)."""
+    a, ls, _c = app
+    store = ls.get_store()
+    sid = "sess-tui-1"
+    prompt_ts = _iso_seconds_offset(-60)
+    reply_ts = _iso_seconds_offset(-30)
+    _seed_tui_prompt(store, body="hello clawd", session_id=sid, ts=prompt_ts)
+    _seed_assistant_reply(
+        store, completion_text="hi from clawd", session_id=sid, ts=reply_ts,
+    )
+    store.flush()
+
+    # Contract check: DuckDB has the rows the fast path needs.
+    assert len(store.query_events(event_type="prompt.submitted", limit=5)) >= 1
+    assert len(store.query_events(event_type="model.completed", limit=5)) >= 1
+
+    r = a.test_client().get("/api/channel/tui?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3", (
+        f"_source must be local_store_v3 (DuckDB fast path); got "
+        f"{body.get('_source')!r}"
+    )
+    msgs = body.get("messages") or []
+    assert len(msgs) == 2, f"expected 1 in + 1 out, got {len(msgs)}"
+    # Newest-first: assistant reply (ts=-30s) precedes user prompt (ts=-60s).
+    assert msgs[0]["direction"] == "out"
+    assert msgs[0]["text"] == "hi from clawd"
+    assert msgs[0]["sender"] == "Clawd"
+    assert msgs[1]["direction"] == "in"
+    assert msgs[1]["text"] == "hello clawd", (
+        f"Sender block must be stripped from the rendered bubble; got "
+        f"{msgs[1]['text']!r}"
+    )
+    assert msgs[1]["sender"] == "User"
+
+
+def test_tui_v3_fast_path_strips_sender_block_preamble(app):
+    """The ```json {...}``` Sender-block preamble that the OpenClaw TUI
+    writes into ``finalPromptText`` MUST be stripped before the body is
+    handed to the UI — matches the legacy walker's
+    ``_strip_sender_block`` shape so the dashboard render path stays
+    identical between the fast path and the fallback."""
+    a, ls, _c = app
+    store = ls.get_store()
+    _seed_tui_prompt(
+        store,
+        body="real user message",
+        session_id="sess-tui-strip",
+        ts=_now_iso(),
+    )
+    store.flush()
+
+    r = a.test_client().get("/api/channel/tui?limit=10")
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3"
+    msgs = body.get("messages") or []
+    assert len(msgs) == 1
+    rendered = msgs[0]["text"]
+    assert "```json" not in rendered, (
+        f"Sender-block fence must be stripped; got {rendered!r}"
+    )
+    assert "openclaw-tui" not in rendered, (
+        f"Sender-block marker must be stripped; got {rendered!r}"
+    )
+    assert rendered == "real user message"
+
+
+def test_tui_v3_fast_path_ignores_non_tui_prompts(app):
+    """A ``prompt.submitted`` row WITHOUT the ``openclaw-tui`` marker
+    (e.g. an inbound from Telegram routed through the same session
+    JSONL) MUST NOT surface on the TUI route. Guards the silent-zero
+    bug class memory ``feedback_synthetic_tests_missed_real_event_shape.md``
+    warns about — easy to write a helper that grabs ALL prompts and
+    inflate the TUI counters with cross-channel turns."""
+    a, ls, _c = app
+    store = ls.get_store()
+    _seed_tui_prompt(
+        store, body="real tui prompt", session_id="sess-1", ts=_now_iso(),
+    )
+    _seed_tui_prompt(
+        store,
+        body="this is from telegram, not TUI",
+        session_id="sess-1",
+        ts=_now_iso(),
+        with_marker=False,
+    )
+    store.flush()
+
+    r = a.test_client().get("/api/channel/tui?limit=10")
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3"
+    msgs = body.get("messages") or []
+    inbound = [m for m in msgs if m["direction"] == "in"]
+    assert len(inbound) == 1, (
+        f"only the TUI-tagged prompt should surface; got {len(inbound)} "
+        f"rows: {[m['text'] for m in inbound]}"
+    )
+    assert inbound[0]["text"] == "real tui prompt"
+
+
+def test_tui_v3_fast_path_empty_falls_back_to_legacy_walker(app):
+    """Empty DuckDB → helper returns ``None`` so the route falls through
+    to the legacy JSONL walker. The walker on a test box with no
+    sessions dir returns the well-known ``status='no sessions dir'``
+    envelope; the ``_source='local_store_v3'`` tag MUST NOT be present
+    (it is reserved for the fast path)."""
+    a, ls, _c = app
+    assert ls.get_store().query_events(
+        event_type="prompt.submitted", limit=5,
+    ) == []
+
+    r = a.test_client().get("/api/channel/tui?limit=10")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") != "local_store_v3", (
+        "empty DuckDB → must defer to legacy walker; got "
+        f"_source={body.get('_source')!r}"
+    )
+    # Legacy walker's well-known shape — confirms the fallback executed.
+    assert body.get("status") == "no sessions dir"
+    assert body.get("messages") == []
+
+
+def test_tui_v3_fast_path_today_counters_use_iso_prefix(app):
+    """``todayIn`` / ``todayOut`` use the ``YYYY-MM-DD`` ISO prefix on
+    the daemon's ts strings. Seed a fresh-today TUI pair + an ancient
+    2024 pair and confirm only today's rows are counted (guards against
+    the loose substring match the 2026-05-17 audit flagged in a peer
+    route)."""
+    a, ls, _c = app
+    store = ls.get_store()
+    # Today's pair.
+    _seed_tui_prompt(
+        store, body="today msg", session_id="sess-today", ts=_now_iso(),
+    )
+    _seed_assistant_reply(
+        store,
+        completion_text="today reply",
+        session_id="sess-today",
+        ts=_iso_seconds_offset(5),
+    )
+    # Ancient 2024 pair.
+    _seed_tui_prompt(
+        store,
+        body="ancient msg",
+        session_id="sess-ancient",
+        ts="2024-01-01T08:30:00+00:00",
+    )
+    _seed_assistant_reply(
+        store,
+        completion_text="ancient reply",
+        session_id="sess-ancient",
+        ts="2024-01-01T08:30:05+00:00",
+    )
+    store.flush()
+
+    r = a.test_client().get("/api/channel/tui?limit=20")
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3"
+    assert body.get("todayIn") == 1, (
+        f"only the today prompt counts; got todayIn={body.get('todayIn')}"
+    )
+    assert body.get("todayOut") == 1, (
+        f"only the today reply counts; got todayOut={body.get('todayOut')}"
+    )
+    assert body.get("total") == 4


### PR DESCRIPTION
## Summary

- Adds `_try_local_store_channel_tui` helper that reads `prompt.submitted` events (filtered to those carrying the `openclaw-tui` Sender marker in `data.finalPromptText`) and pairs each with the next `model.completed` event in the same session. Mirrors the sibling DuckDB-first pattern at `routes/channels.py:2048-2063` (bluebubbles).
- Wires it into `api_channel_tui` BEFORE the legacy session-JSONL walker. Falls through to the walker on miss so fresh installs (daemon hasn't ingested) keep working.
- Adds `tests/test_channel_tui_duckdb_fastpath.py` (5 tests, all green) covering in/out pairing, Sender-block stripping, non-TUI prompt rejection, empty-DuckDB legacy fallback, and ISO-prefix today counters.

## Why

MOAT coverage audit 2026-05-18 flagged `/api/channel/tui` as the last Tier-1 channel route still walking session JSONLs O(sessions) on every poll. Closes the bypass.

Note on event shape: unlike telegram/signal/bluebubbles (which carry dedicated `channel.in`/`channel.out` events), TUI turns live in the unified `events` table as `prompt.submitted` + `model.completed` because the OpenClaw TUI writes directly into the session JSONL with no dedicated channel adapter. The daemon's v3 mapper (`sync._parse_v3_event`) preserves the `openclaw-tui` marker verbatim inside `data.finalPromptText` — so the helper can match on the same string the legacy walker matched on at `routes/channels.py:2318`.

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_channel_tui_duckdb_fastpath.py -q` — 5 passed
- [x] `python3 -m pytest tests/test_moat_*.py -q` — 34 passed, 1 skipped; one flaky `test_baseline_regression` re-ran clean (token_velocity sub-ms noise, unrelated to TUI)
- [ ] Smoke against a live daemon: hit `/api/channel/tui` with daemon ingesting real `~/.openclaw/agents/main/sessions/*.jsonl`, confirm `_source='local_store_v3'` in response

closes #1656

Diff size: +525 LOC (185 in `routes/channels.py`, 340 test).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)