### PR TITLE
fix(channels): wire DuckDB fast-path to /api/channel/whatsapp

### DIFF
--- a/routes/channels.py
+++ b/routes/channels.py
@@ -1198,6 +1198,18 @@ def api_channel_whatsapp():
         fast = _try_local_store_provider_messages("whatsapp", limit)
         if fast is not None:
             return jsonify(fast)
+        # Tier-2 #1565 v3 events-table fallback (2026-05-18 coverage audit).
+        # WhatsApp is in ``sync._CHANNEL_DIRS`` so the daemon ingests
+        # ``~/.openclaw/whatsapp/*.jsonl`` through ``ingest_channel_event``,
+        # but a daemon restart between the ``channel_messages`` projection
+        # write and the ``events`` chokepoint can leave ``channel_messages``
+        # empty while ``events`` carries the ``channel.in`` / ``channel.out``
+        # rows — same silent-zero hazard memory
+        # ``feedback_synthetic_tests_missed_real_event_shape.md`` warns
+        # about and Telegram / Signal / BlueBubbles already guard for.
+        fast = _try_local_store_channel_events("whatsapp", limit)
+        if fast is not None:
+            return jsonify(fast)
 
     messages = []
     today = datetime.now().strftime("%Y-%m-%d")

--- a/tests/test_channel_whatsapp_duckdb_fastpath.py
+++ b/tests/test_channel_whatsapp_duckdb_fastpath.py
@@ -1,0 +1,234 @@
+"""Regression guard for the /api/channel/whatsapp DuckDB v3 events fast path
+(Tier-2 #1565, 2026-05-18 coverage audit).
+
+Sister of ``test_channel_signal_local_store_v3.py`` —
+``api_channel_whatsapp`` now shares the same dual-tier contract
+(``_try_local_store_provider_messages`` first, then
+``_try_local_store_channel_events`` for the v3 events-table fallback)
+that Telegram / Signal / BlueBubbles already enforce. The silent-zero
+hazard memory ``feedback_synthetic_tests_missed_real_event_shape.md``
+warns about applies equally to WhatsApp.
+
+Tests cover:
+
+  1. Populated path — whatsapp + telegram rows seeded; whatsapp route
+     returns ONLY the whatsapp rows tagged ``_source='local_store_v3'``.
+  2. Empty events table → helper returns None so route defers to legacy
+     log/JSONL walker (no ``_source='local_store_v3'`` tag).
+  3. ``event_type`` discipline — only ``channel.in`` and ``channel.out``
+     project; a stray ``message`` row with ``data.provider='whatsapp'``
+     MUST NOT show up.
+  4. Time-range / sort — newest-first ordering across the union of
+     channel.in + channel.out reads.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import Flask
+
+
+def _now_iso():
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _iso_minutes_ago(minutes: int) -> str:
+    return (datetime.now(tz=timezone.utc) - timedelta(minutes=minutes)).isoformat()
+
+
+def _ingest_channel_event(
+    store,
+    *,
+    provider: str,
+    direction: str,
+    body: str = "hello",
+    sender_name: str = "alice",
+    channel_id: str = "whatsapp-chat-1",
+    ts: str | None = None,
+):
+    store.ingest({
+        "id":         f"ch-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "agent_type": "openclaw",
+        "agent_id":   "main",
+        "event_type": f"channel.{direction}",
+        "ts":         ts or _now_iso(),
+        "session_id": None,
+        "workspace_id": None,
+        "data": {
+            "provider":    provider,
+            "channel_id":  channel_id,
+            "direction":   direction,
+            "sender_name": sender_name,
+            "body":        body,
+        },
+        "cost_usd":    None,
+        "token_count": None,
+        "model":       None,
+    })
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.channels as channels_mod
+    importlib.reload(channels_mod)
+
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    import dashboard  # noqa: F401
+
+    a = Flask(__name__)
+    a.register_blueprint(channels_mod.bp_channels)
+    yield a, ls, channels_mod
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_whatsapp_v3_events_path_serves_when_channel_messages_empty(app):
+    """Populated v3 events but empty ``channel_messages`` → fast path
+    must return ``_source='local_store_v3'`` with only whatsapp rows."""
+    a, ls, _c = app
+    store = ls.get_store()
+    _ingest_channel_event(
+        store,
+        provider="whatsapp",
+        direction="in",
+        body="hey from whatsapp",
+        sender_name="bob",
+        channel_id="whatsapp-chat-1",
+    )
+    _ingest_channel_event(
+        store,
+        provider="whatsapp",
+        direction="out",
+        body="ack",
+        channel_id="whatsapp-chat-1",
+    )
+    # Cross-provider row must NOT pollute the whatsapp response.
+    _ingest_channel_event(
+        store,
+        provider="telegram",
+        direction="in",
+        body="tg cross-channel",
+        sender_name="alice",
+    )
+    store.flush()
+    assert store.query_channel_messages(provider="whatsapp", limit=5) == []
+
+    r = a.test_client().get("/api/channel/whatsapp?limit=10")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3", (
+        f"_source must be local_store_v3 (v3 events fallback); got "
+        f"{body.get('_source')!r}"
+    )
+    msgs = body.get("messages") or []
+    assert len(msgs) == 2, f"expected 2 whatsapp rows, got {len(msgs)}: {msgs}"
+    inbound = next(m for m in msgs if m["direction"] == "in")
+    assert inbound["sender"] == "bob"
+    assert inbound["text"] == "hey from whatsapp"
+    assert inbound["chatId"] == "whatsapp-chat-1"
+
+
+def test_whatsapp_v3_events_empty_returns_legacy_fallback(app):
+    """Empty events → helper returns None, route falls through to legacy
+    walker. The legacy walker on a test box with no log files MUST NOT
+    carry the ``_source='local_store_v3'`` audit tag."""
+    a, ls, _c = app
+    assert ls.get_store().query_events(event_type="channel.in", limit=5) == []
+    r = a.test_client().get("/api/channel/whatsapp")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body.get("_source") != "local_store_v3"
+
+
+def test_whatsapp_v3_events_ignores_non_channel_event_types(app):
+    """Only ``channel.in`` / ``channel.out`` rows project. A v3
+    ``message`` row that happens to carry ``data.provider='whatsapp'``
+    MUST NOT show up — that would inflate the whatsapp counters with LLM
+    turns and re-create the bug class
+    ``feedback_synthetic_tests_missed_real_event_shape.md`` warns
+    about."""
+    a, ls, _c = app
+    store = ls.get_store()
+    _ingest_channel_event(
+        store,
+        provider="whatsapp",
+        direction="in",
+        body="real whatsapp turn",
+    )
+    # Stray non-channel event with provider tag — should be ignored.
+    store.ingest({
+        "id":         f"msg-{uuid.uuid4().hex[:12]}",
+        "node_id":    "node-test",
+        "agent_type": "openclaw",
+        "agent_id":   "main",
+        "event_type": "message",
+        "ts":         _now_iso(),
+        "session_id": "sess-llm",
+        "workspace_id": None,
+        "data": {
+            "provider": "whatsapp",
+            "body":     "this is an LLM turn that mentions whatsapp",
+        },
+        "cost_usd": 0.001, "token_count": 100, "model": "claude-3-5-sonnet",
+    })
+    store.flush()
+
+    r = a.test_client().get("/api/channel/whatsapp?limit=10")
+    body = r.get_json()
+    assert body.get("_source") == "local_store_v3"
+    msgs = body.get("messages") or []
+    assert len(msgs) == 1, (
+        f"only the channel.in row should surface; got {len(msgs)} rows: "
+        f"{[m['text'] for m in msgs]}"
+    )
+    assert msgs[0]["text"] == "real whatsapp turn"
+
+
+def test_whatsapp_v3_events_newest_first_across_in_and_out(app):
+    """Helper merges separate channel.in + channel.out pulls and MUST
+    return newest-first. Guards against the union being returned in
+    in-then-out (or out-then-in) chunk order, which would put a fresh
+    outbound under a stale inbound on the WhatsApp tab."""
+    a, ls, _c = app
+    store = ls.get_store()
+    # Older inbound — 30 min ago.
+    _ingest_channel_event(
+        store,
+        provider="whatsapp",
+        direction="in",
+        body="older inbound",
+        ts=_iso_minutes_ago(30),
+    )
+    # Fresher outbound — now.
+    _ingest_channel_event(
+        store,
+        provider="whatsapp",
+        direction="out",
+        body="fresh outbound",
+    )
+    store.flush()
+
+    r = a.test_client().get("/api/channel/whatsapp?limit=10")
+    body = r.get_json()
+    assert body["_source"] == "local_store_v3"
+    msgs = body.get("messages") or []
+    assert len(msgs) == 2
+    # The fresh outbound must come first.
+    assert msgs[0]["text"] == "fresh outbound"
+    assert msgs[1]["text"] == "older inbound"


### PR DESCRIPTION
## Summary

2026-05-18 coverage audit flagged `/api/channel/whatsapp` as a Tier-2 BYPASS:

> `routes/channels.py:api_channel_whatsapp:1017-1148` — reads from gateway logs + session JSONL (no DuckDB path yet, though WhatsApp is in `sync._CHANNEL_DIRS`) — Tier-2 candidate for v3 fallback migration

WhatsApp already had the Phase 5 `channel_messages` fast path, but was missing the Tier-2 #1565 v3 events-table fallback (`_try_local_store_channel_events`) that Telegram, Signal, and BlueBubbles already enforce. This PR closes that gap.

## Why it matters

Same silent-zero hazard that memory `feedback_synthetic_tests_missed_real_event_shape.md` warns about: the `ingest_channel_event` chokepoint dual-writes to both `channel_messages` and `events`, but a daemon restart between writes can leave `channel_messages` empty while `events` still carries the `channel.in` / `channel.out` rows. Without this fallback the route silently falls through to the gateway.log grep + JSONL walker, returning zero WhatsApp messages on the dashboard even though DuckDB has them.

## Changes

- `routes/channels.py` (+12 LOC): one `_try_local_store_channel_events("whatsapp", limit)` call inserted between the existing `channel_messages` fast path and the legacy log-grep walker, guarded by the existing `_local_store_read_enabled()` gate.
- `tests/test_channel_whatsapp_duckdb_fastpath.py` (+234 LOC): mirrors `test_channel_signal_local_store_v3.py` exactly.

No new shared helpers. No new daemon-proxy contract surface.

## Test plan

- [x] `python3 -m pytest tests/test_channel_whatsapp_duckdb_fastpath.py -q` → 4 passed
  - Populated v3 events serve when `channel_messages` empty
  - Empty events → legacy fallback (no `local_store_v3` tag)
  - Stray `message` row with `data.provider='whatsapp'` is ignored (silent-zero bug class guard)
  - Newest-first sort across `channel.in` + `channel.out` union
- [x] `python3 -m pytest tests/test_moat_*.py -q` → 34 passed, 1 skipped, 1 unrelated perf-budget flake (`version_impact` p50 ratio 2.04× vs 2.00× budget — does not touch channels)
- [x] `python3 -c "import dashboard"` clean

## Memory respects

- `feedback_duckdb_first_rule.md` — DuckDB read attempted before log/JSONL fallback.
- `reference_duckdb_process_lock.md` — uses `_ls_call` (daemon-proxy via `local_query`), never opens DuckDB directly.
- `feedback_synthetic_tests_missed_real_event_shape.md` — tests use the real `ingest_channel_event` event shape (`channel.in` / `channel.out` with `data.provider`).