### PR TITLE
fix(brain): /api/autonomy and /api/reasoning now read model.completed events

### DIFF
--- a/routes/autonomy.py
+++ b/routes/autonomy.py
@@ -296,13 +296,31 @@ def _try_local_store_autonomy() -> dict | None:
     # Issue #1256: route through daemon HTTP proxy. Direct get_store()
     # raises IOException on multi-process installs (DuckDB's file lock is
     # exclusive across processes; read_only=True doesn't bypass it).
+    #
+    # 2026-05-18 silent-zero bug-class fix (6th instance today, per memory
+    # ``feedback_synthetic_tests_missed_real_event_shape.md`` +
+    # ``reference_openclaw_v3_event_types.md``). User turns land in DuckDB
+    # under THREE different ``event_type`` values depending on the agent
+    # runtime:
+    #   * ``message``         — legacy installs; data.message.role=="user"
+    #   * ``user``            — Claude Code daemon-normalised
+    #   * ``prompt.submitted``— OpenClaw v3 daemon-normalised (no role
+    #                           field; presence implies user turn)
+    # Querying only ``message`` returned 0 rows on real installs → the
+    # Overview "How independent is your agent?" widget rendered blank ``—``.
     try:
         from routes.local_query import local_store_via_daemon
-        rows = local_store_via_daemon("query_events", event_type="message", limit=5000)
-        if rows is None:
+        rows = []
+        for et in ("message", "user", "prompt.submitted"):
+            sub = local_store_via_daemon("query_events", event_type=et, limit=5000)
+            if sub:
+                rows.extend(sub)
+        if not rows:
             # Daemon unreachable → single-process fallback (tests/dev mode).
             store = local_store.get_store(read_only=True)
-            rows = store.query_events(event_type="message", limit=5000)
+            for et in ("message", "user", "prompt.submitted"):
+                sub = store.query_events(event_type=et, limit=5000) or []
+                rows.extend(sub)
     except Exception:
         return None
     if not rows:
@@ -326,9 +344,27 @@ def _try_local_store_autonomy() -> dict | None:
         data = r.get("data") if isinstance(r, dict) else None
         if not isinstance(data, dict):
             continue
-        msg = data.get("message") if isinstance(data.get("message"), dict) else data
-        role = msg.get("role") if isinstance(msg, dict) else None
-        if role != "user":
+        # User-turn detection across three event shapes (silent-zero fix):
+        #   * legacy ``message`` event → data.message.role=="user"
+        #   * Claude Code ``user`` event → top-level event_type already says
+        #     user; data.message may be absent or carry role=="user"
+        #   * v3 ``prompt.submitted`` event → no role field; the event_type
+        #     itself is the user-turn marker. data.finalPromptText is set.
+        et = (r.get("event_type") or "").lower()
+        is_user_turn = False
+        if et == "prompt.submitted":
+            is_user_turn = True
+        elif et == "user":  # v3-shape-gate: allow (reason: handles legacy+v3 in same fn — prompt.submitted branch above covers v3)
+            # Claude Code daemon event. Accept unless an inner role
+            # contradicts (defensive — should never happen).
+            inner = data.get("message") if isinstance(data.get("message"), dict) else None
+            role = inner.get("role") if isinstance(inner, dict) else None
+            is_user_turn = role in (None, "", "user")
+        else:
+            msg = data.get("message") if isinstance(data.get("message"), dict) else data
+            role = msg.get("role") if isinstance(msg, dict) else None
+            is_user_turn = (role == "user")
+        if not is_user_turn:
             continue
         sid = r.get("session_id") or ""
         per_session[sid].append(ts)

--- a/routes/reasoning.py
+++ b/routes/reasoning.py
@@ -235,58 +235,104 @@ def _try_local_store_reasoning(session_id: str):
     # on multi-process installs (launchd/systemd). Try the daemon HTTP
     # proxy first; fall back to a direct read-only open for single-process
     # boots (tests, dev mode).
+    #
+    # 2026-05-18 silent-zero bug-class fix (7th instance today, per memory
+    # ``feedback_synthetic_tests_missed_real_event_shape.md`` +
+    # ``reference_openclaw_v3_event_types.md``). Assistant turns land in
+    # DuckDB under THREE different ``event_type`` values:
+    #   * ``message``         — legacy installs, data.message.content[]
+    #   * ``assistant``       — Claude Code daemon-normalised
+    #   * ``model.completed`` — OpenClaw v3 daemon-normalised (no nested
+    #                           message; thinking lives in
+    #                           data.assistantTexts + data.completionText)
+    # Querying only ``message`` returned 0 rows on real installs → the
+    # Brain tab reasoning view rendered an empty timeline.
+    rows = []
     try:
         from routes.local_query import local_store_via_daemon
-        rows = local_store_via_daemon(
-            "query_events",
-            session_id=session_id, event_type="message", limit=2000,
-        )
+        for et in ("message", "assistant", "model.completed"):
+            sub = local_store_via_daemon(
+                "query_events",
+                session_id=session_id, event_type=et, limit=2000,
+            )
+            if sub:
+                rows.extend(sub)
     except Exception:
-        rows = None
-    if rows is None:
+        rows = []
+    if not rows:
         try:
             from clawmetry import local_store
             store = local_store.get_store(read_only=True)
-            rows = store.query_events(
-                session_id=session_id, event_type="message", limit=2000,
-            )
+            for et in ("message", "assistant", "model.completed"):
+                sub = store.query_events(
+                    session_id=session_id, event_type=et, limit=2000,
+                ) or []
+                rows.extend(sub)
         except Exception:
             return None
     if not rows:
         return None
 
     # query_events returns most-recent-first; reasoning chains read forward
-    # in time (legacy parser walks the JSONL top-to-bottom).
-    rows = list(reversed(rows))
+    # in time (legacy parser walks the JSONL top-to-bottom). Sort the
+    # unioned list by ts to keep that contract when the three event-type
+    # buckets above were merged out of order.
+    rows = sorted(rows, key=lambda r: (r.get("ts") or ""))
     chains = []
     for r in rows:
         data = r.get("data") if isinstance(r, dict) else None
         if not isinstance(data, dict):
             continue
-        msg = data.get("message") if isinstance(data.get("message"), dict) else data
-        if not isinstance(msg, dict):
-            continue
-        if msg.get("role") and msg.get("role") != "assistant":
-            continue
-        content_obj = msg.get("content")
-        if not isinstance(content_obj, list):
-            continue
 
-        thinking_blocks = []
+        # Resolve thinking + answer text across three shapes:
+        #   (A) data.message.content = list of {type:thinking|text} blocks
+        #       (legacy ``message`` + Claude-Code ``assistant``)
+        #   (B) v3 ``model.completed`` with NO data.message — thinking +
+        #       answer live in top-level data.{assistantTexts,
+        #       completionText}. assistantTexts is a list[str] of extracted
+        #       thinking; completionText is the final answer text. The
+        #       daemon never emits separate ``{type:thinking}`` blocks for
+        #       this shape, so we treat assistantTexts entries as
+        #       independent thinking blocks.
+        thinking_blocks: list[str] = []
         answer_word_count = 0
         answer_parts: list[str] = []
-        for block in content_obj:
-            if not isinstance(block, dict):
+
+        msg = data.get("message") if isinstance(data.get("message"), dict) else None
+        content_obj = msg.get("content") if isinstance(msg, dict) else None
+
+        if isinstance(content_obj, list):
+            # Shape A — content-block walk
+            if isinstance(msg, dict) and msg.get("role") and msg.get("role") != "assistant":
                 continue
-            btype = block.get("type", "")
-            if btype == "thinking":
-                tt = block.get("thinking", "")
-                if tt:
-                    thinking_blocks.append(tt)
-            elif btype == "text":
-                text = block.get("text", "") or ""
-                answer_word_count += len(text.split())
-                answer_parts.append(text)
+            for block in content_obj:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type", "")
+                if btype == "thinking":
+                    tt = block.get("thinking", "")
+                    if tt:
+                        thinking_blocks.append(tt)
+                elif btype == "text":
+                    text = block.get("text", "") or ""
+                    answer_word_count += len(text.split())
+                    answer_parts.append(text)
+        else:
+            # Shape B — v3 model.completed. Skip non-assistant events that
+            # leaked into the union (eg legacy ``message`` with role=user
+            # and string content).
+            et = (r.get("event_type") or "").lower()
+            if et not in ("model.completed", "assistant"):
+                continue
+            atexts = data.get("assistantTexts")
+            if isinstance(atexts, list):
+                for t in atexts:
+                    if isinstance(t, str) and t:
+                        thinking_blocks.append(t)
+            answer = data.get("completionText")
+            if isinstance(answer, str) and answer:
+                answer_word_count = len(answer.split())
+                answer_parts.append(answer)
 
         ts = r.get("ts") or ""
         answer_text = " ".join(answer_parts)

--- a/tests/test_autonomy_v3_shape.py
+++ b/tests/test_autonomy_v3_shape.py
@@ -1,0 +1,138 @@
+"""Silent-zero regression test for /api/autonomy on real OpenClaw v3 installs.
+
+Bug class (6th instance — 2026-05-18): the fast path in
+``routes/autonomy.py`` queried only ``event_type="message"``. Real v3 writes
+user turns as ``prompt.submitted``; Claude Code writes ``user``. Result:
+0 rows on real installs → Overview widget blank. See
+``feedback_synthetic_tests_missed_real_event_shape.md``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+def _iso(s: float) -> str:
+    return datetime.fromtimestamp(s, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def autonomy_app(tmp_path, monkeypatch):
+    """Flask app + tmp DuckDB with daemon proxy short-circuited."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **k: None)
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    monkeypatch.setattr(lq, "_cached_discovery", lambda: None)
+    import routes.autonomy as aut
+    importlib.reload(aut)
+    aut._AUTONOMY_CACHE["data"] = None
+    aut._AUTONOMY_CACHE["ts"] = 0.0
+    a = Flask(__name__)
+    a.register_blueprint(aut.bp_autonomy)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _ingest(store, *, eid, sid, et, ts, data):
+    store.ingest({
+        "id": eid, "node_id": "agent+test", "agent_id": "main",
+        "session_id": sid, "event_type": et, "ts": _iso(ts),
+        "data": data, "cost_usd": None, "token_count": None, "model": None,
+    })
+
+
+def test_autonomy_reads_v3_prompt_submitted_events(autonomy_app):
+    """Pre-fix: 0 rows → empty response. Post-fix: 4 samples + ratio 0.5."""
+    a, ls = autonomy_app
+    store = ls.get_store()
+    now = time.time()
+    for i, gap in enumerate([0, 60, 180]):
+        _ingest(store, eid=f"a-{i}", sid="sess-a", et="prompt.submitted",
+                ts=now - 3600 + gap, data={"finalPromptText": f"t{i}"})
+    _ingest(store, eid="b-0", sid="sess-b", et="prompt.submitted",
+            ts=now - 7200, data={"finalPromptText": "one-shot"})
+    _wait_flush(store)
+    body = a.test_client().get("/api/autonomy").get_json() or {}
+    assert body.get("_source") == "local_store", body
+    assert body["samples_7d"] == 4, body
+    assert body["score"] is not None
+    assert body["autonomy_ratio_7d"] == 0.5
+    assert len([d for d in body["series_daily"] if d.get("sessions")]) >= 1
+
+
+def test_autonomy_reads_claude_code_user_events(autonomy_app):
+    """Claude Code shape: event_type='user'. Pre-fix: never queried."""
+    a, ls = autonomy_app
+    store = ls.get_store()
+    now = time.time()
+    for i in range(2):
+        _ingest(store, eid=f"cc-{i}", sid=f"sess-cc-{i}", et="user",
+                ts=now - 1800 - i * 60,
+                data={"message": {"role": "user", "content": f"hi {i}"}})
+    _wait_flush(store)
+    body = a.test_client().get("/api/autonomy").get_json() or {}
+    assert body.get("_source") == "local_store", body
+    assert body["samples_7d"] == 2
+    assert body["autonomy_ratio_7d"] == 1.0
+
+
+def test_autonomy_unions_all_three_event_shapes(autonomy_app):
+    """Mixed store — one of each shape. All three counted."""
+    a, ls = autonomy_app
+    store = ls.get_store()
+    now = time.time()
+    _ingest(store, eid="m", sid="s1", et="message", ts=now - 600,
+            data={"message": {"role": "user", "content": "legacy"}})
+    _ingest(store, eid="u", sid="s2", et="user", ts=now - 700,
+            data={"message": {"role": "user", "content": "cc"}})
+    _ingest(store, eid="p", sid="s3", et="prompt.submitted", ts=now - 800,
+            data={"finalPromptText": "v3"})
+    _wait_flush(store)
+    body = a.test_client().get("/api/autonomy").get_json() or {}
+    assert body.get("_source") == "local_store", body
+    assert body["samples_7d"] == 3, body
+    assert body["autonomy_ratio_7d"] == 1.0
+
+
+def test_autonomy_ignores_assistant_events_in_mixed_store(autonomy_app):
+    """Assistant events on message/assistant/model.completed must NOT count."""
+    a, ls = autonomy_app
+    store = ls.get_store()
+    now = time.time()
+    _ingest(store, eid="real", sid="sess-mix", et="prompt.submitted",
+            ts=now - 600, data={"finalPromptText": "real"})
+    _ingest(store, eid="ac", sid="sess-mix", et="model.completed",
+            ts=now - 500, data={"completionText": "asst"})
+    _ingest(store, eid="aa", sid="sess-mix", et="assistant", ts=now - 400,
+            data={"message": {"role": "assistant",
+                              "content": [{"type": "text", "text": "ok"}]}})
+    _ingest(store, eid="am", sid="sess-mix", et="message", ts=now - 300,
+            data={"message": {"role": "assistant",
+                              "content": [{"type": "text", "text": "ok2"}]}})
+    _wait_flush(store)
+    body = a.test_client().get("/api/autonomy").get_json() or {}
+    assert body.get("_source") == "local_store", body
+    assert body["samples_7d"] == 1, body

--- a/tests/test_reasoning_v3_shape.py
+++ b/tests/test_reasoning_v3_shape.py
@@ -1,0 +1,149 @@
+"""Silent-zero regression test for /api/reasoning on real OpenClaw v3 installs.
+
+Bug class (7th instance — 2026-05-18): the fast path in
+``routes/reasoning.py`` queried only ``event_type="message"``. Real v3
+writes assistant turns as ``model.completed`` with thinking in
+``data.assistantTexts`` and answer in ``data.completionText`` — no
+``data.message.content`` block to walk. Claude Code writes ``assistant``.
+See ``feedback_synthetic_tests_missed_real_event_shape.md`` +
+``reference_openclaw_v3_event_types.md``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+def _iso(s: float) -> str:
+    return datetime.fromtimestamp(s, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def reasoning_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **k: None)
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    monkeypatch.setattr(lq, "_cached_discovery", lambda: None)
+    import routes.reasoning as rea
+    importlib.reload(rea)
+    a = Flask(__name__)
+    a.register_blueprint(rea.bp_reasoning)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _ingest(store, *, eid, sid, et, ts, data, model="claude-opus-4-7"):
+    store.ingest({
+        "id": eid, "node_id": "agent+test", "agent_id": "main",
+        "session_id": sid, "event_type": et, "ts": _iso(ts),
+        "data": data, "cost_usd": 0.01, "token_count": 100, "model": model,
+    })
+
+
+def test_reasoning_extracts_chain_from_model_completed(reasoning_app):
+    """v3 shape: data.assistantTexts + data.completionText, NO data.message."""
+    a, ls = reasoning_app
+    store = ls.get_store()
+    thinking = (
+        "The user wants to refactor this function. Let me try a cleaner "
+        "approach. If I extract the helper, the test stays small. So I'll do that."
+    )
+    answer = "Here's the refactored function with the helper extracted."
+    _ingest(store, eid="v1", sid="sess-v", et="model.completed",
+            ts=time.time() - 120,
+            data={"modelId": "claude-opus-4-7",
+                  "completionText": answer, "assistantTexts": [thinking]})
+    _wait_flush(store)
+    r = a.test_client().get("/api/reasoning?session=sess-v")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json() or {}
+    assert body.get("_source") == "local_store", body
+    assert body["summary"]["chain_count"] == 1, body
+    c = body["chains"][0]
+    assert c["thinking_tokens"] > 0
+    assert c["answer_tokens"] > 0
+    assert c["steps"]
+    assert thinking in c["raw_thinking"]
+
+
+def test_reasoning_extracts_chain_from_claude_code_assistant(reasoning_app):
+    """Claude Code shape: event_type='assistant' + legacy content block list."""
+    a, ls = reasoning_app
+    store = ls.get_store()
+    _ingest(store, eid="c1", sid="sess-c", et="assistant",
+            ts=time.time() - 60,
+            data={"message": {"role": "assistant", "content": [
+                {"type": "thinking", "thinking":
+                    "The user wants the file. Let me look at the imports. "
+                    "If I check the package, the answer will be obvious. "
+                    "So I'll grep for it."},
+                {"type": "text", "text": "Found it. The import is on line 12."},
+            ]}})
+    _wait_flush(store)
+    body = a.test_client().get("/api/reasoning?session=sess-c").get_json() or {}
+    assert body.get("_source") == "local_store", body
+    assert body["summary"]["chain_count"] == 1, body
+    c = body["chains"][0]
+    assert c["thinking_tokens"] > 0
+    assert c["answer_tokens"] > 0
+
+
+def test_reasoning_unions_legacy_and_v3_shapes(reasoning_app):
+    """One legacy 'message' + one v3 'model.completed' → 2 chains, ts-sorted."""
+    a, ls = reasoning_app
+    store = ls.get_store()
+    now = time.time()
+    _ingest(store, eid="m1", sid="sess-mix", et="message", ts=now - 600,
+            data={"message": {"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "The user wants a small change."},
+                {"type": "text", "text": "Done — see the patch."},
+            ]}})
+    _ingest(store, eid="v1", sid="sess-mix", et="model.completed", ts=now - 60,
+            data={"modelId": "claude-opus-4-7",
+                  "completionText": "And here's the follow-up.",
+                  "assistantTexts": [
+                      "The user wants a follow-up. Let me look at the test. "
+                      "If it still passes, I can proceed. So I'll add the feature."
+                  ]})
+    _wait_flush(store)
+    body = a.test_client().get("/api/reasoning?session=sess-mix").get_json() or {}
+    assert body.get("_source") == "local_store", body
+    assert body["summary"]["chain_count"] == 2, body
+    ts_seq = [c["timestamp"] for c in body["chains"]]
+    assert ts_seq == sorted(ts_seq), ts_seq
+
+
+def test_reasoning_empty_when_no_thinking_present(reasoning_app):
+    """model.completed with no assistantTexts must not fabricate chains."""
+    a, ls = reasoning_app
+    store = ls.get_store()
+    _ingest(store, eid="nt", sid="sess-nt", et="model.completed",
+            ts=time.time() - 60,
+            data={"modelId": "claude-opus-4-7",
+                  "completionText": "Answer with no thinking."})
+    _wait_flush(store)
+    body = a.test_client().get("/api/reasoning?session=sess-nt").get_json() or {}
+    assert body.get("summary", {}).get("chain_count", 0) == 0, body


### PR DESCRIPTION
## Summary

Silent-zero bug-class fix — **6th + 7th instances today**. Two more Tier-1 fast paths were querying only `event_type="message"` and silently returning empty/zero on real OpenClaw v3 installs.

Pre-fix on real installs:
- Overview "How independent is your agent?" widget rendered blank `—` (autonomy returned `None` ratios + empty `series_daily`)
- Brain tab reasoning view rendered empty timeline

Real v3 daemon-normalised ingest writes:
- user turns → `event_type="prompt.submitted"` (text in `data.finalPromptText`, no role field)
- assistant turns → `event_type="model.completed"` (thinking in `data.assistantTexts`, answer in `data.completionText`, **NO `data.message`**)

Claude Code daemon-normalised ingest writes `user` + `assistant`.

## Changes

### `routes/autonomy.py`
- Query `("message", "user", "prompt.submitted")` via daemon proxy + unioned in-process fallback
- Loop now classifies a user turn by `event_type` first (v3 `prompt.submitted` and Claude Code `user` carry no `role` field)
- `# v3-shape-gate: allow` annotation on the `user` branch (legacy+v3 in same fn)

### `routes/reasoning.py`
- Query `("message", "assistant", "model.completed")` via daemon proxy + unioned in-process fallback
- Parallel extraction branch for `model.completed`: reads thinking from `data.assistantTexts` and answer from `data.completionText`
- Merged buckets sorted by `ts` so chains stay chronological

### Tests
- `tests/test_autonomy_v3_shape.py` — 4 cases (prompt.submitted-only, user-only, all-three union, assistant-events-must-be-filtered)
- `tests/test_reasoning_v3_shape.py` — 4 cases (model.completed-only, assistant-only, legacy+v3 union ts-sorted, no-thinking returns empty)

## Verification

Manual curl against real user DuckDB:

```
curl /api/autonomy
  → "_source": "local_store", "samples_7d": 152, "autonomy_ratio_7d": 0.6
  (pre-fix: 0 samples, all-null series_daily)

curl /api/reasoning?session=<session-with-model.completed>
  → "_source": "local_store", "chain_count": 3
  (chains extracted from data.assistantTexts + data.completionText)
  (pre-fix: empty chains list)
```

## Test plan

- [x] `python3 -c "import dashboard"` clean
- [x] 8 new tests pass (`pytest tests/test_autonomy_v3_shape.py tests/test_reasoning_v3_shape.py`)
- [x] Full MOAT suite stays green (43/43 + 8 new), including the `test_moat_bug_class_v3_event_shape_gate` regression gate
- [x] Manual curl against running daemon shows non-empty `_source: local_store` payloads

Refs:
- `feedback_synthetic_tests_missed_real_event_shape.md` (the bug-class memory)
- `reference_openclaw_v3_event_types.md` (the event-type cheat sheet)
- Sibling fixes earlier today: brain (#1662), tui (#1657), whatsapp (#1658), brain-model (#1662 follow-up), component-tool (#1663)

NO `[RELEASE]` tag.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>