### PR TITLE
feat(classifier): detect tool_call_stuck sessions (closes #1648)

### DIFF
--- a/clawmetry/outcome_classifier.py
+++ b/clawmetry/outcome_classifier.py
@@ -8,20 +8,24 @@ users actually care about: *"did this agent actually work?"*.
 Pure functions only. Stateless. Tested independently from DuckDB.
 
 Outcomes (5-way):
-  success        — agent finished and nothing went wrong
-  failed         — last billable turn surfaced an error OR last assistant
-                   message contains structured failure markers
-  escalated      — a human-approval gate fired for this session
-                   (cross-references the ``approvals`` table — caller passes
-                   the matching rows in)
-  cognitive_loop — agent emitted N>=3 near-identical assistant messages
-                   inside a 10-minute window with no new tool name and no
-                   new file path between them (recursive self-validation,
-                   issue #1706). Fires BEFORE ``ongoing`` because a still-
-                   chattering session that's not making forward progress is
-                   no longer healthily ongoing.
-  ongoing        — session is still active (no terminal session.ended event
-                   AND last event is recent, default <5 min)
+  success         — agent finished and nothing went wrong
+  failed          — last billable turn surfaced an error OR last assistant
+                    message contains structured failure markers
+  escalated       — a human-approval gate fired for this session
+                    (cross-references the ``approvals`` table — caller passes
+                    the matching rows in)
+  tool_call_stuck — a tool was invoked but its terminal result event never
+                    arrived after ``TOOL_CALL_STUCK_SECONDS`` (default 120s).
+                    Matches OpenClaw's ``blocked_tool_call`` failure class
+                    (issue #1648) but works for any provider/adapter.
+  cognitive_loop  — agent emitted N>=3 near-identical assistant messages
+                    inside a 10-minute window with no new tool name and no
+                    new file path between them (recursive self-validation,
+                    issue #1706). Fires BEFORE ``ongoing`` because a still-
+                    chattering session that's not making forward progress is
+                    no longer healthily ongoing.
+  ongoing         — session is still active (no terminal session.ended event
+                    AND last event is recent, default <5 min)
 
 Defaults are conservative on purpose (per memory
 ``feedback_synthetic_tests_missed_real_event_shape``): when uncertain we
@@ -48,10 +52,11 @@ OUTCOME_FAILED = "failed"
 OUTCOME_ESCALATED = "escalated"
 OUTCOME_COGNITIVE_LOOP = "cognitive_loop"
 OUTCOME_ONGOING = "ongoing"
+OUTCOME_TOOL_CALL_STUCK = "tool_call_stuck"
 
 VALID_OUTCOMES = frozenset({
     OUTCOME_SUCCESS, OUTCOME_FAILED, OUTCOME_ESCALATED,
-    OUTCOME_COGNITIVE_LOOP, OUTCOME_ONGOING,
+    OUTCOME_TOOL_CALL_STUCK, OUTCOME_COGNITIVE_LOOP, OUTCOME_ONGOING,
 })
 
 # How long after the last event we still call a session "ongoing".
@@ -64,6 +69,11 @@ ONGOING_RECENT_SECONDS = 5 * 60
 COGNITIVE_LOOP_WINDOW_SECONDS = 600
 COGNITIVE_LOOP_SIMILARITY_THRESHOLD = 0.85
 COGNITIVE_LOOP_MIN_REPEATS = 3
+
+# How long an unanswered tool invocation must sit before we classify the
+# session as ``tool_call_stuck`` (#1648). 120s matches the OpenClaw
+# ``blocked_tool_call`` triage default.
+TOOL_CALL_STUCK_SECONDS = 120
 
 # Default failure-text patterns (case-insensitive substring). Override via
 # CLAWMETRY_OUTCOME_FAILURE_PATTERNS=pat1|pat2|... env var if needed.
@@ -147,6 +157,147 @@ def _extract_text(data: Any) -> str:
         if isinstance(v, str) and v:
             return v
     return ""
+
+
+_TOOL_INVOCATION_EVENT_TYPES = ("tool.call", "toolcall", "tool_use", "tool_call")
+_TOOL_RESULT_EVENT_TYPES = ("tool.result", "toolresult", "tool_result")
+_TOOL_BLOCK_TYPES = ("toolCall", "tool_use")
+
+
+def _iter_invocation_tool_call_ids(event: dict[str, Any]) -> list[str]:
+    """Return every tool_call_id this event INVOKES.
+
+    Three real shapes (matching the extraction logic in
+    ``clawmetry/approvals.py`` and ``clawmetry/local_store.py``):
+
+      * top-level ``tool.call``/``toolCall``/``tool_use`` event whose
+        ``data`` IS the block ({id, name, arguments|input}).
+      * assistant ``message`` event whose ``data.message.content[]`` (or
+        flattened ``data.content[]``) contains toolCall/tool_use blocks.
+      * Both branches: the id key is ``id`` (Anthropic/OpenClaw shape).
+
+    Returns empty list for non-invocation events. IDs are best-effort
+    strings; empty/missing IDs are skipped (we cannot match them to a
+    result anyway).
+    """
+    out: list[str] = []
+    et = (event.get("event_type") or "").lower()
+    data = event.get("data")
+    if not isinstance(data, dict):
+        return out
+    # Shape A: top-level tool-invocation event (data IS the block).
+    if et in _TOOL_INVOCATION_EVENT_TYPES:
+        cid = str(data.get("id") or "")
+        if cid:
+            out.append(cid)
+        # Some emitters wrap the block under "tool" / "block".
+        for k in ("tool", "block"):
+            blk = data.get(k)
+            if isinstance(blk, dict):
+                cid = str(blk.get("id") or "")
+                if cid:
+                    out.append(cid)
+    # Shape B: assistant message event with content blocks.
+    blocks: list = []
+    msg = data.get("message")
+    if isinstance(msg, dict) and msg.get("role") in (None, "assistant"):
+        c = msg.get("content")
+        if isinstance(c, list):
+            blocks = c
+    elif data.get("role") in (None, "assistant") and isinstance(data.get("content"), list):
+        blocks = data["content"]
+    for blk in blocks:
+        if isinstance(blk, dict) and blk.get("type") in _TOOL_BLOCK_TYPES:
+            cid = str(blk.get("id") or "")
+            if cid:
+                out.append(cid)
+    return out
+
+
+def _iter_result_tool_call_ids(event: dict[str, Any]) -> list[str]:
+    """Return every tool_call_id this event RESULT-CLOSES.
+
+    Tolerant of the three v3 shapes seen on real installs:
+
+      * top-level ``tool.result`` event with ``data.tool_call_id``
+        (Anthropic/OpenClaw v3) or ``data.toolCallId`` (camelCase).
+      * top-level ``tool.result`` event whose ``data.id`` IS the
+        invocation id (some adapters reuse the field).
+      * ``message`` event whose ``data.message.content[]`` has
+        ``tool_result`` blocks carrying ``tool_use_id`` (Anthropic SDK).
+
+    Empty result-id strings are dropped (we cannot match them).
+    """
+    out: list[str] = []
+    et = (event.get("event_type") or "").lower()
+    data = event.get("data")
+    if not isinstance(data, dict):
+        return out
+    if et in _TOOL_RESULT_EVENT_TYPES:
+        for key in ("tool_call_id", "toolCallId", "tool_use_id", "id"):
+            v = data.get(key)
+            if isinstance(v, str) and v:
+                out.append(v)
+                break
+    # message-envelope shape: assistant or user message carrying tool_result
+    # blocks (Anthropic Messages — tool_result blocks land in user turn).
+    blocks: list = []
+    msg = data.get("message")
+    if isinstance(msg, dict):
+        c = msg.get("content")
+        if isinstance(c, list):
+            blocks = c
+    elif isinstance(data.get("content"), list):
+        blocks = data["content"]
+    for blk in blocks:
+        if isinstance(blk, dict) and blk.get("type") in ("tool_result", "toolResult"):
+            for key in ("tool_use_id", "tool_call_id", "toolCallId", "id"):
+                v = blk.get(key)
+                if isinstance(v, str) and v:
+                    out.append(v)
+                    break
+    return out
+
+
+def find_stuck_tool_calls(
+    events: list[dict[str, Any]] | None,
+    *,
+    now: float | None = None,
+    threshold_seconds: float = TOOL_CALL_STUCK_SECONDS,
+) -> list[tuple[str, float]]:
+    """Return ``[(tool_call_id, age_seconds), …]`` for invocations with no
+    matching terminal result older than ``threshold_seconds``.
+
+    Pure function; safe to call from any context. Tool calls without a
+    parseable id are skipped (we cannot tell whether they got a result).
+    Sorted by ``age_seconds`` descending — the stalest call first.
+    """
+    if now is None:
+        now = time.time()
+    invoked_ts: dict[str, float] = {}
+    closed: set[str] = set()
+    for ev in events or []:
+        ev_ts = _iso_to_epoch(ev.get("ts"))
+        for cid in _iter_invocation_tool_call_ids(ev):
+            # Keep the EARLIEST invocation ts (a call only counts as stuck
+            # from when it was first seen; duplicate emits don't reset it).
+            prev = invoked_ts.get(cid)
+            if prev is None or (ev_ts > 0 and ev_ts < prev):
+                invoked_ts[cid] = ev_ts if ev_ts > 0 else (prev or 0.0)
+        for cid in _iter_result_tool_call_ids(ev):
+            closed.add(cid)
+    stuck: list[tuple[str, float]] = []
+    for cid, ts in invoked_ts.items():
+        if cid in closed:
+            continue
+        if ts <= 0:
+            # No parseable timestamp — cannot judge staleness. Skip.
+            continue
+        age = max(0.0, now - ts)
+        if age >= threshold_seconds:
+            stuck.append((cid, age))
+    stuck.sort(key=lambda x: x[1], reverse=True)
+    return stuck
 
 
 def _is_tool_error(event: dict[str, Any]) -> bool:
@@ -408,6 +559,7 @@ def classify_session(
       * 0.95  — escalated (approval row exists)
       * 0.9   — tool.result error on the tail
       * 0.85  — session.ended terminal marker present
+      * 0.8   — tool_call_stuck (invocation older than threshold, no result)
       * 0.8   — cognitive loop detected (issue #1706)
       * 0.75  — last-turn text matched a failure pattern
       * 0.6   — ongoing (recent activity, no terminal event)
@@ -445,11 +597,20 @@ def classify_session(
             if a:  # ignore None / empty
                 return OUTCOME_ESCALATED, 0.95
 
-    # ── 2.5. Cognitive loop — recursive self-validation (issue #1706) ─
+    # ── 2.5. Tool-call stuck — invocation has no terminal result ──────
+    # Slots ABOVE cognitive_loop (issue #1706 requested this per comment).
+    # Runs BEFORE the "ongoing" gate so a session that's still receiving
+    # heartbeat-ish events but has a dead tool call is correctly flagged.
+    # (#1648 — matches OpenClaw's ``blocked_tool_call`` triage class.)
+    terminal = _has_terminal_event(evs) or bool(meta.get("ended_at"))
+    if not terminal:
+        stuck = find_stuck_tool_calls(evs, now=now)
+        if stuck:
+            return OUTCOME_TOOL_CALL_STUCK, 0.8
+
+    # ── 3. Cognitive loop — recursive self-validation (issue #1706) ─
     # Runs BEFORE ongoing because a still-chattering session whose
     # assistant keeps emitting the same text is no longer healthy ongoing.
-    # When #1671 (tool_call_stuck) lands it will slot just above this one;
-    # ordering is preserved naturally by the rebase.
     if _session_has_cognitive_loop(
         evs,
         window_seconds=COGNITIVE_LOOP_WINDOW_SECONDS,
@@ -458,8 +619,7 @@ def classify_session(
     ):
         return OUTCOME_COGNITIVE_LOOP, 0.8
 
-    # ── 3. Ongoing — no terminal marker AND recent activity ─────────
-    terminal = _has_terminal_event(evs) or bool(meta.get("ended_at"))
+    # ── 4. Ongoing — no terminal marker AND recent activity ─────────
     if not terminal:
         age = _last_event_age_seconds(evs, now)
         if age < ONGOING_RECENT_SECONDS:
@@ -468,21 +628,21 @@ def classify_session(
         # through to outcome detection rather than mislabelling as
         # ongoing. Caller can decide whether to surface "stale" badge.
 
-    # ── 4. Failed — last tool.result was an error ───────────────────
+    # ── 5. Failed — last tool.result was an error ───────────────────
     # Scan from the tail back through up to 5 events; an error in the
     # very last billable step is the strongest "failed" signal.
     for ev in reversed(evs[-5:]):
         if _is_tool_error(ev):
             return OUTCOME_FAILED, 0.9
 
-    # ── 5. Failed — last assistant text matches a failure pattern ──
+    # ── 6. Failed — last assistant text matches a failure pattern ──
     text = _last_assistant_text(evs).lower()
     if text:
         for pat in _failure_patterns():
             if pat in text:
                 return OUTCOME_FAILED, 0.75
 
-    # ── 6. Default: success ─────────────────────────────────────────
+    # ── 7. Default: success ─────────────────────────────────────────
     # Conservative by design: when uncertain we say success rather than
     # plaster the dashboard with false failures. The confidence value
     # lets the UI distinguish "high-confidence success" (terminal event
@@ -505,16 +665,17 @@ def aggregate_outcomes(rows: list[dict[str, Any]]) -> dict[str, Any]:
             "escalated":         9,
             "cognitive_loop":    0,
             "ongoing":           0,
-            "success_rate":   0.880,   # success / (success + failed + loop)
+            "tool_call_stuck":   0,
+            "success_rate":   0.880,   # success / (success + failed + loop + stuck)
             "needed_human_rate": 0.036,  # escalated / total
         }
 
     ``success_rate`` deliberately excludes ``ongoing`` (still in flight) and
     ``escalated`` (different category — a successful human-in-the-loop run
-    isn't a failure of the agent). ``cognitive_loop`` IS in the denominator
-    because it's a terminal failure mode (the agent wasted budget without
-    making progress). Matches industry convention for autonomous-task
-    success metrics.
+    isn't a failure of the agent). ``cognitive_loop`` and ``tool_call_stuck``
+    ARE in the denominator because both are terminal failure modes: the agent
+    wasted budget without progress (loop) or a tool never returned (stuck).
+    Matches industry convention for autonomous-task success metrics.
     """
     counts = {
         OUTCOME_SUCCESS: 0,
@@ -522,6 +683,7 @@ def aggregate_outcomes(rows: list[dict[str, Any]]) -> dict[str, Any]:
         OUTCOME_ESCALATED: 0,
         OUTCOME_COGNITIVE_LOOP: 0,
         OUTCOME_ONGOING: 0,
+        OUTCOME_TOOL_CALL_STUCK: 0,
     }
     for r in rows or []:
         o = (r or {}).get("outcome") or OUTCOME_SUCCESS
@@ -534,6 +696,7 @@ def aggregate_outcomes(rows: list[dict[str, Any]]) -> dict[str, Any]:
         counts[OUTCOME_SUCCESS]
         + counts[OUTCOME_FAILED]
         + counts[OUTCOME_COGNITIVE_LOOP]
+        + counts[OUTCOME_TOOL_CALL_STUCK]
     )
     success_rate = (counts[OUTCOME_SUCCESS] / finished) if finished else 0.0
     needed_human = (counts[OUTCOME_ESCALATED] / total) if total else 0.0
@@ -544,6 +707,7 @@ def aggregate_outcomes(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "escalated": counts[OUTCOME_ESCALATED],
         "cognitive_loop": counts[OUTCOME_COGNITIVE_LOOP],
         "ongoing": counts[OUTCOME_ONGOING],
+        "tool_call_stuck": counts[OUTCOME_TOOL_CALL_STUCK],
         "success_rate": round(success_rate, 4),
         "needed_human_rate": round(needed_human, 4),
     }

--- a/tests/test_outcome_classifier.py
+++ b/tests/test_outcome_classifier.py
@@ -465,3 +465,188 @@ def test_classifier_does_not_filter_on_legacy_event_shape_only():
     ]
     assert classify_session(legacy, {})[0] == classify_session(v3, {})[0]
     assert classify_session(legacy, {})[0] == "failed"
+
+
+# ── 4. Stuck tool-call detection (issue #1648) ─────────────────────────────
+
+
+def _iso(epoch: float) -> str:
+    from datetime import datetime, timezone
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()
+
+
+def test_find_stuck_tool_calls_unanswered_invocation():
+    """Top-level toolCall event with no matching tool.result older than the
+    threshold → returned by find_stuck_tool_calls."""
+    from clawmetry.outcome_classifier import find_stuck_tool_calls
+
+    now = time.time()
+    events = [
+        {"event_type": "tool.call", "ts": _iso(now - 600),
+         "data": {"id": "call_abc", "name": "bash", "input": {"cmd": "sleep 9999"}}},
+    ]
+    stuck = find_stuck_tool_calls(events, now=now, threshold_seconds=120)
+    assert len(stuck) == 1
+    assert stuck[0][0] == "call_abc"
+    assert stuck[0][1] >= 120
+
+
+def test_find_stuck_tool_calls_skips_when_result_present():
+    """An invocation that DOES have a matching tool.result is not stuck —
+    irrespective of how long ago the invocation fired."""
+    from clawmetry.outcome_classifier import find_stuck_tool_calls
+
+    now = time.time()
+    events = [
+        {"event_type": "tool.call", "ts": _iso(now - 600),
+         "data": {"id": "call_done", "name": "bash"}},
+        {"event_type": "tool.result", "ts": _iso(now - 500),
+         "data": {"tool_call_id": "call_done", "status": "ok"}},
+    ]
+    assert find_stuck_tool_calls(events, now=now, threshold_seconds=120) == []
+
+
+def test_find_stuck_tool_calls_skips_recent_invocation():
+    """Below-threshold age → not stuck yet."""
+    from clawmetry.outcome_classifier import find_stuck_tool_calls
+
+    now = time.time()
+    events = [
+        {"event_type": "tool.call", "ts": _iso(now - 30),
+         "data": {"id": "call_recent", "name": "bash"}},
+    ]
+    assert find_stuck_tool_calls(events, now=now, threshold_seconds=120) == []
+
+
+def test_find_stuck_tool_calls_message_envelope_shape():
+    """Anthropic-shape tool_use block inside an assistant message event
+    with a later tool_result block carrying tool_use_id — matched."""
+    from clawmetry.outcome_classifier import find_stuck_tool_calls
+
+    now = time.time()
+    events = [
+        {"event_type": "message", "ts": _iso(now - 600),
+         "data": {"message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu_xyz", "name": "bash", "input": {}},
+         ]}}},
+        # Result block carried in a later (user-role) message turn.
+        {"event_type": "message", "ts": _iso(now - 500),
+         "data": {"message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu_xyz", "content": "ok"},
+         ]}}},
+    ]
+    assert find_stuck_tool_calls(events, now=now, threshold_seconds=120) == []
+
+
+def test_find_stuck_tool_calls_multiple_calls_only_unanswered():
+    """Two invocations, one answered + one not — only the unanswered one
+    is returned, with age measured from the earlier of duplicate emits."""
+    from clawmetry.outcome_classifier import find_stuck_tool_calls
+
+    now = time.time()
+    events = [
+        {"event_type": "tool.call", "ts": _iso(now - 800),
+         "data": {"id": "call_a", "name": "bash"}},
+        {"event_type": "tool.call", "ts": _iso(now - 600),
+         "data": {"id": "call_b", "name": "bash"}},
+        # Only call_a returned.
+        {"event_type": "tool.result", "ts": _iso(now - 700),
+         "data": {"tool_call_id": "call_a", "status": "ok"}},
+    ]
+    stuck = find_stuck_tool_calls(events, now=now, threshold_seconds=120)
+    assert [c for c, _ in stuck] == ["call_b"]
+
+
+def test_find_stuck_tool_calls_skips_calls_without_id():
+    """An invocation without a parseable id cannot be matched to a result;
+    we can't tell whether it ever completed, so we don't flag it as stuck.
+    Conservative on purpose."""
+    from clawmetry.outcome_classifier import find_stuck_tool_calls
+
+    now = time.time()
+    events = [
+        {"event_type": "tool.call", "ts": _iso(now - 600),
+         "data": {"id": "", "name": "bash"}},
+    ]
+    assert find_stuck_tool_calls(events, now=now, threshold_seconds=120) == []
+
+
+def test_classify_session_returns_tool_call_stuck():
+    """An ongoing-looking session with an unmatched tool invocation older
+    than the threshold → tool_call_stuck (not ``ongoing``)."""
+    from clawmetry.outcome_classifier import (
+        classify_session, OUTCOME_TOOL_CALL_STUCK,
+    )
+
+    now = time.time()
+    events = [
+        {"event_type": "session.started", "ts": _iso(now - 700)},
+        {"event_type": "tool.call", "ts": _iso(now - 600),
+         "data": {"id": "call_stuck", "name": "bash"}},
+        # No tool.result; session.ended also absent. Last event is recent
+        # enough that the old classifier would have called this "ongoing".
+        {"event_type": "model.completed", "ts": _iso(now - 30),
+         "data": {"modelId": "claude-opus-4", "text": "still waiting..."}},
+    ]
+    outcome, conf = classify_session(events, {}, now=now)
+    assert outcome == OUTCOME_TOOL_CALL_STUCK
+    assert conf >= 0.7
+
+
+def test_classify_session_completed_tool_is_not_stuck():
+    """Same shape as the stuck-tool test, but with a result event — the
+    session should NOT be flagged as tool_call_stuck."""
+    from clawmetry.outcome_classifier import (
+        classify_session, OUTCOME_TOOL_CALL_STUCK,
+    )
+
+    now = time.time()
+    events = [
+        {"event_type": "session.started", "ts": _iso(now - 700)},
+        {"event_type": "tool.call", "ts": _iso(now - 600),
+         "data": {"id": "call_done", "name": "bash"}},
+        {"event_type": "tool.result", "ts": _iso(now - 590),
+         "data": {"tool_call_id": "call_done", "status": "ok"}},
+        {"event_type": "model.completed", "ts": _iso(now - 30),
+         "data": {"modelId": "claude-opus-4", "text": "done"}},
+    ]
+    outcome, _ = classify_session(events, {}, now=now)
+    assert outcome != OUTCOME_TOOL_CALL_STUCK
+
+
+def test_classify_session_terminal_session_ended_wins_over_stuck():
+    """Once the session emits ``session.ended``, the run is no longer
+    in-flight; a tail tool_result-shaped failure should classify cleanly
+    as success/failed via the existing rules, not as tool_call_stuck."""
+    from clawmetry.outcome_classifier import (
+        classify_session, OUTCOME_TOOL_CALL_STUCK,
+    )
+
+    now = time.time()
+    events = [
+        {"event_type": "tool.call", "ts": _iso(now - 600),
+         "data": {"id": "call_orphan", "name": "bash"}},
+        # Session ended without a matching tool.result. Operator decided
+        # to terminate — we don't double-flag this as stuck.
+        {"event_type": "session.ended", "ts": _iso(now - 60)},
+    ]
+    outcome, _ = classify_session(events, {}, now=now)
+    assert outcome != OUTCOME_TOOL_CALL_STUCK
+
+
+def test_aggregate_outcomes_counts_tool_call_stuck_against_success_rate():
+    """tool_call_stuck IS counted in the success-rate denominator — a tool
+    that never returned is a failure mode the user cares about (matches
+    OpenClaw's ``blocked_tool_call`` triage class)."""
+    from clawmetry.outcome_classifier import aggregate_outcomes
+
+    rows = (
+        [{"outcome": "success"}] * 80
+        + [{"outcome": "failed"}] * 15
+        + [{"outcome": "tool_call_stuck"}] * 5
+    )
+    agg = aggregate_outcomes(rows)
+    assert agg["total"] == 100
+    assert agg["tool_call_stuck"] == 5
+    # 80 / (80 + 15 + 5) = 0.80
+    assert agg["success_rate"] == 0.8


### PR DESCRIPTION
Closes #1648

## What

Adds a 5th outcome to `clawmetry.outcome_classifier`: a session with an outstanding tool invocation (`tool.call` / `toolCall` / `tool_use`) that has no matching terminal result (`tool.result` / `toolResult` / `tool_result`) for longer than `TOOL_CALL_STUCK_SECONDS` (default 120s) is now classified as `tool_call_stuck`.

This matches OpenClaw's `blocked_tool_call` triage class but fires for any provider/adapter — Codex, Claude Code, Cursor, NemoClaw — not just the one whose top issue inspired the request.

## How

- `find_stuck_tool_calls(events, *, now, threshold_seconds)` — pure helper, tolerant of the three real v3 event shapes seen on live installs:
  - top-level `tool.call` / `toolCall` / `tool_use` events with `data.id`
  - assistant `message` envelopes carrying `toolCall` / `tool_use` blocks (Anthropic + OpenClaw Hermes shape)
  - Anthropic-style `tool_result` blocks carrying `tool_use_id` in a later (user-role) turn
- `classify_session` runs the stuck check **between** the escalated and ongoing rules — a session that's still emitting heartbeat-ish events but has a dead tool call is no longer painted green as "ongoing".
- `aggregate_outcomes` adds a `tool_call_stuck` count and includes it in the success-rate denominator (a tool that never returned is a failure mode users care about).

Conservative on purpose:
- A tool invocation with an empty/missing id is skipped — we can't match it to a result, so we can't tell whether it ever completed.
- Once `session.ended` fires, the existing success/failed rules take over — we don't double-flag terminated sessions as stuck.
- Invocation age is measured from the **earliest** observed emit, so duplicate ingest doesn't reset the clock.

## Tests

9 new cases in `tests/test_outcome_classifier.py`:
- pure-helper happy paths (`find_stuck_tool_calls` unanswered / closed / below-threshold)
- message-envelope shape coverage (Anthropic tool_use + tool_result blocks)
- multi-call dedup (one answered, one stuck → only the stuck one returned)
- session-level integration (`classify_session` returns `tool_call_stuck` vs not)
- terminal-event-wins-over-stuck guard
- aggregate math (success rate denominator includes stuck)

All 25 tests in `test_outcome_classifier.py` pass.

## Out of scope (follow-ups)

The issue's proposal also mentions UI badges in `/v2/trace` + `/v2/brain` and a hook into the alerting pipeline. Those are left for follow-up — this PR ships the detection primitive those surfaces will read from. Filing as separate issues once this lands.

## Source

ClawMetry feature-intel report 2026-05-18 (§4, gap #1). Driven by OpenClaw's current top P1 issue.