### PR TITLE
[RELEASE] fix(banner): dismiss 'Setting up your node' when hero cards have real data

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -586,6 +586,33 @@ var _cmOnboardingDismissed = false;
 var _cmOnboardingTimer = null;
 var _CM_ONBOARDING_STALL_MS = 90 * 1000;
 
+// P0 user report 2026-05-18: the "Setting up your node" banner kept
+// showing on the cloud Node Detail modal even while MODEL, TOKENS,
+// SPENDING and "Connected, last sync 28s ago" were ALL clearly
+// populated from other endpoints. `/api/heartbeat-status` alone is
+// not authoritative — when any hero card has flipped from its "--"
+// placeholder to a real value, the banner is lying and must dismiss.
+function _cmAnyVisibleDataSignal(){
+  var ids = [
+    'cost-today',       // Spending
+    'model-primary',    // Model
+    'token-rate',       // Tokens
+    'tokens-today',     // Today
+    'hot-sessions-count' // Sessions
+  ];
+  for (var i = 0; i < ids.length; i++){
+    var el = document.getElementById(ids[i]);
+    if (!el) continue;
+    var txt = (el.textContent || '').trim();
+    if (!txt) continue;
+    if (/^[-—\s]*$/.test(txt)) continue;
+    if (/^loading/i.test(txt)) continue;
+    if (txt === '$0.00') continue;      // default Spending placeholder
+    if (/\d/.test(txt) || /[a-z]/i.test(txt)) return true;
+  }
+  return false;
+}
+
 async function checkOnboardingStatus() {
   if (_cmOnboardingDismissed) return;
   var banner = document.getElementById('onboarding-banner');
@@ -593,12 +620,25 @@ async function checkOnboardingStatus() {
   var msgEl = document.getElementById('onboarding-banner-msg');
   var etaEl = document.getElementById('onboarding-banner-eta');
   var spinEl = document.getElementById('onboarding-banner-spinner');
+  // Short-circuit: if any hero card is already showing real data, the
+  // banner is lying — dismiss it permanently for this session.
+  if (_cmAnyVisibleDataSignal()) {
+    banner.style.display = 'none';
+    _cmOnboardingDismissed = true;
+    if (_cmOnboardingTimer) { clearInterval(_cmOnboardingTimer); _cmOnboardingTimer = null; }
+    return;
+  }
   try {
     var data = await fetch('/api/heartbeat-status').then(function(r){return r.json();});
     var firstHeartbeatLanded = (
       data && data.status && data.status !== 'unknown' &&
       data.last_heartbeat_ts && data.last_heartbeat_ts > 0
     );
+    // Belt-and-braces: even if heartbeat-status didn't update, recheck
+    // visible signals after the network round-trip in case they landed.
+    if (!firstHeartbeatLanded && _cmAnyVisibleDataSignal()) {
+      firstHeartbeatLanded = true;
+    }
     if (firstHeartbeatLanded) {
       // Smooth handoff: hide the banner, mark as dismissed for this session
       // so we don't re-flash on a transient blip, and kick a fresh loadAll


### PR DESCRIPTION
## P0 — visible bug on prod cloud Node Detail modal

User screenshot (2026-05-18, 22:50Z): "Setting up your node. First check-in usually arrives in about 30 seconds." banner showing simultaneously with **MODEL: claude-opus-4-7**, **TOKENS: 1K (today: 17)**, **SPENDING: <\$0.01**, **Connected, last sync 28s ago** all populated. Banner lying. User: "now the cloud looks like this -- I've no idea what you are pushing."

## Root cause

`checkOnboardingStatus()` in `clawmetry/static/js/app.js:589` only trusted `/api/heartbeat-status`. When that endpoint returns `status: 'unknown'` or `last_heartbeat_ts: 0` (transient cloud-proxy stall, race on first paint, 401 on a cookie-only session), it keeps the banner up — even though other endpoints had already populated every hero card.

## Fix

- New `_cmAnyVisibleDataSignal()` helper probes `#cost-today`, `#model-primary`, `#token-rate`, `#tokens-today`, `#hot-sessions-count` and returns true if any has flipped past its placeholder.
- Called at top of `checkOnboardingStatus()` — short-circuits before any network round-trip.
- Re-checked after the fetch returns (belt-and-braces) so a card that just landed mid-poll also wins.
- Once dismissed, the 5s poller stops + dismissed flag is set for the session.

## Verification

- `python3 -c 'import dashboard'` clean
- `node -c clawmetry/static/js/app.js` clean
- Diff is +40 LOC, 1 file. No behavior change when cards ARE empty (the original heartbeat-status path still runs).

## Related

- Cloud-side guard `_cmAnyDataReceived()` (PR #975 on clawmetry-cloud, merged) is the SAME pattern but on cloud's main `/cloud` page. This is the missing sibling for the OSS-inside-iframe rendering path that the cloud Node Detail modal uses.
- Agent a02532c0 flagged this OSS-side gap explicitly in PR #975's report.