### PR TITLE
ci(moat): wire keystone E2E verifier into per-PR required check + nightly drive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,104 @@ jobs:
             tests/test_moat_perf_benchmark.py \
             -q
 
+  # ── MOAT keystone (DuckDB-first invariant, 13-endpoint bar) ──────────────
+  # Implements `docs/MOAT_BAR.md` Section 5 acceptance criterion #1:
+  # `keystone_e2e.py --no-drive` exits 0 on every PR. The keystone is the
+  # canonical 13-endpoint verifier (PR #1672) that asserts every
+  # UI-backing API surface returns non-zero, correctly shaped data
+  # against live DuckDB rows.
+  #
+  # Why this gate exists: PR #1682 found a silent-zero bug in
+  # `/api/component/tool/exec` AFTER it shipped to main because the
+  # keystone was only being hand-run by Principal A. Wiring it as a
+  # required CI check stops that class of regression at the PR boundary.
+  #
+  # Boot pattern mirrors the existing `api-tests` job: dashboard on 8900
+  # with a deterministic gateway token, then a minimal local_query
+  # server (writes ~/.clawmetry/local_query.json which the keystone
+  # discovers). `--no-drive` skips the real openclaw turn (LLM budget)
+  # and instead verifies every probe against whatever rows the daemon's
+  # startup bootstrap landed. Drive mode runs nightly via
+  # `.github/workflows/moat-keystone-drive-nightly.yml`.
+  moat-keystone:
+    name: MOAT Keystone (13-endpoint bar)
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install flask waitress cryptography duckdb requests psutil
+
+      - name: "Guard: keystone harness file present"
+        # Until PR #1672 merges, the keystone script lives only on the
+        # feat/moat-keystone-e2e-verifier branch. Once that PR lands on
+        # main, this guard becomes a no-op pass and the job becomes a
+        # hard gate. Until then, this surfaces an explicit warning rather
+        # than a confusing "file not found" failure.
+        run: |
+          if [ ! -f scripts/accuracy_harness/keystone_e2e.py ]; then
+            echo "::warning::scripts/accuracy_harness/keystone_e2e.py not present on this commit. Merge PR #1672 first to activate the keystone gate."
+            echo "KEYSTONE_PRESENT=0" >> "$GITHUB_ENV"
+          else
+            echo "KEYSTONE_PRESENT=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Start dashboard
+        if: env.KEYSTONE_PRESENT == '1'
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=ci-test-token python3 dashboard.py --port 8900 --no-debug \
+            > /tmp/dashboard.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health && echo "Dashboard ready" && break
+            sleep 1
+          done
+
+      - name: Start local_server (DuckDB query proxy for keystone)
+        if: env.KEYSTONE_PRESENT == '1'
+        # The full sync daemon needs a configured node (clawmetry connect)
+        # which CI doesn't have. The keystone only depends on the
+        # `local_query` HTTP proxy (writes ~/.clawmetry/local_query.json);
+        # we boot just that piece in a background process. This matches
+        # the in-process startup the real daemon does at sync.py:8452.
+        run: |
+          nohup python3 -c "
+          import os, time, json, pathlib
+          from clawmetry import local_server
+          port = local_server.start()
+          assert port, 'local_server failed to start'
+          # Re-stamp pid so discover_daemon() resolves to a live process.
+          disc = pathlib.Path.home() / '.clawmetry' / 'local_query.json'
+          d = json.loads(disc.read_text())
+          d['pid'] = os.getpid()
+          disc.write_text(json.dumps(d))
+          while True: time.sleep(60)
+          " > /tmp/local_server.log 2>&1 &
+          for i in $(seq 1 10); do
+            [ -f "$HOME/.clawmetry/local_query.json" ] && echo "local_query.json present" && break
+            sleep 1
+          done
+
+      - name: Run keystone verifier (--no-drive)
+        if: env.KEYSTONE_PRESENT == '1'
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+        run: make moat-check
+
+      - name: Dashboard log tail (on failure)
+        if: failure() && env.KEYSTONE_PRESENT == '1'
+        run: |
+          echo "── dashboard.log tail ──"
+          tail -200 /tmp/dashboard.log || true
+          echo "── local_server.log tail ──"
+          tail -200 /tmp/local_server.log || true
+
   # ── E2E Playwright tests — critical subset (hard-gate, blocks merge) ──────
   # Per issue #1528: the prior `e2e-tests` job carried `continue-on-error: true`
   # which silently masked Playwright regressions. We split the suite into:

--- a/.github/workflows/moat-keystone-drive-nightly.yml
+++ b/.github/workflows/moat-keystone-drive-nightly.yml
@@ -1,0 +1,196 @@
+name: MOAT Keystone (drive mode, nightly)
+
+# Companion to the per-PR `moat-keystone` job in ci.yml.
+#
+# Per-PR runs `--no-drive`: verifies every probe against whatever DuckDB
+# rows the daemon's startup bootstrap already landed. That catches
+# regressions in routes/* and the local_store reader path, but it cannot
+# catch regressions in the actual write path (openclaw -> daemon ingest
+# -> DuckDB row), because no fresh event is generated.
+#
+# This workflow runs FULL drive mode: a real `openclaw agent --message`
+# turn, polls the daemon until the event lands, then runs all 13
+# probes. Costs ~1 LLM round-trip per night (Anthropic, sub-cent) so
+# nightly + main-only is the right cadence. If the drive fails, this
+# job auto-files a P0 GitHub issue mirroring the
+# `accuracy_harness/all.py` consolidated-issue pattern.
+#
+# Acceptance criterion: docs/MOAT_BAR.md Section 5, AC#4.
+
+on:
+  schedule:
+    # 04:00 UTC daily, off the e2e-nightly :17 minute slot.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: moat-keystone-drive-nightly
+  cancel-in-progress: false
+
+jobs:
+  drive:
+    name: Keystone Drive (real openclaw turn -> 13 probes)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Nightly informational at the workflow level, but we still auto-file
+    # a P0 issue on failure so a human picks it up within the SLA.
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: "Guard: keystone harness file present"
+        # Until PR #1672 merges, the script lives only on its feature
+        # branch. Skip gracefully (with a warning) on commits where it
+        # is absent; gate becomes active automatically once #1672 lands.
+        run: |
+          if [ ! -f scripts/accuracy_harness/keystone_e2e.py ]; then
+            echo "::warning::scripts/accuracy_harness/keystone_e2e.py not present yet. Merge PR #1672 to activate the nightly drive gate."
+            echo "KEYSTONE_PRESENT=0" >> "$GITHUB_ENV"
+          else
+            echo "KEYSTONE_PRESENT=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Setup OpenClaw
+        if: env.KEYSTONE_PRESENT == '1'
+        uses: ./.github/actions/setup-openclaw
+        with:
+          version: latest
+          gateway-token: moat-keystone-drive-token
+
+      - name: Install Python deps
+        if: env.KEYSTONE_PRESENT == '1'
+        run: pip install flask waitress cryptography duckdb requests psutil
+
+      - name: Start dashboard
+        if: env.KEYSTONE_PRESENT == '1'
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=moat-keystone-drive-token python3 dashboard.py --port 8900 --no-debug \
+            > /tmp/dashboard.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer moat-keystone-drive-token" http://localhost:8900/api/health && echo "Dashboard ready" && break
+            sleep 1
+          done
+
+      - name: Start local_server (DuckDB query proxy)
+        if: env.KEYSTONE_PRESENT == '1'
+        # Same minimum-viable-daemon trick as the per-PR job: boot just
+        # the local_query HTTP proxy so the keystone's discover_daemon()
+        # call resolves. The full sync daemon needs `clawmetry connect`
+        # which CI does not have.
+        run: |
+          nohup python3 -c "
+          import os, time, json, pathlib
+          from clawmetry import local_server
+          port = local_server.start()
+          assert port, 'local_server failed to start'
+          disc = pathlib.Path.home() / '.clawmetry' / 'local_query.json'
+          d = json.loads(disc.read_text())
+          d['pid'] = os.getpid()
+          disc.write_text(json.dumps(d))
+          while True: time.sleep(60)
+          " > /tmp/local_server.log 2>&1 &
+          for i in $(seq 1 10); do
+            [ -f "$HOME/.clawmetry/local_query.json" ] && echo "local_query.json present" && break
+            sleep 1
+          done
+
+      - name: Run keystone verifier (drive mode)
+        if: env.KEYSTONE_PRESENT == '1'
+        id: drive
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+          # Real LLM call -- uses the same secret the live-openclaw-e2e
+          # job in ci.yml uses. Rotate via console.anthropic.com if leaked.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set +e
+          python3 scripts/accuracy_harness/keystone_e2e.py 2>&1 | tee /tmp/keystone-drive.log
+          echo "EXIT_CODE=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          exit ${PIPESTATUS[0]}
+
+      - name: Dashboard log tail (on failure)
+        if: failure() && env.KEYSTONE_PRESENT == '1'
+        run: |
+          echo "── dashboard.log tail ──"
+          tail -200 /tmp/dashboard.log || true
+          echo "── local_server.log tail ──"
+          tail -200 /tmp/local_server.log || true
+
+      - name: File P0 issue on failure
+        # Mirror of scripts/accuracy_harness/all.py file_consolidated_issue
+        # pattern: idempotent per UTC date (search by date-prefixed title,
+        # edit in place if present, create otherwise). Label: P0 so the
+        # issue-picker cron (feedback_issue_picker_cron.md) dispatches a
+        # subagent within the hour.
+        if: failure() && env.KEYSTONE_PRESENT == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          TODAY=$(date -u +%Y-%m-%d)
+          TITLE_PREFIX="[moat-keystone-drive ${TODAY}]"
+          TITLE="${TITLE_PREFIX} nightly drive failed (see workflow logs)"
+          LOG_TAIL=$(tail -200 /tmp/keystone-drive.log 2>/dev/null | head -c 60000 || echo '(no log captured)')
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY=$(cat <<EOF
+          ## MOAT keystone drive failed nightly run
+
+          - Date (UTC): ${TODAY}
+          - Workflow run: ${RUN_URL}
+          - Exit code: ${{ steps.drive.outputs.EXIT_CODE }}
+
+          ### What this means
+
+          The keystone drive job runs a real \`openclaw agent --message\` turn and
+          asserts all 13 dashboard-backing API surfaces returned shape + non-zero
+          data. A failure here means either the openclaw -> daemon -> DuckDB
+          write path is broken OR one of the 13 read-side routes regressed.
+
+          Per \`docs/MOAT_BAR.md\` Section 5 AC#4 this is P0.
+
+          ### Verifier log tail
+
+          \`\`\`
+          ${LOG_TAIL}
+          \`\`\`
+
+          ### Runbook
+
+          1. Reproduce locally:
+             \`\`\`
+             make dev &
+             python3 -m clawmetry.sync &
+             make moat-check-drive
+             \`\`\`
+          2. If the FAIL line points at a specific endpoint, the harness prints
+             the DuckDB \`event_type\` histogram inline as the very next line.
+             That distinguishes silent-zero (rows present, route returns 0) from
+             write-path failure (no rows).
+          3. Mark this issue closed once the next nightly run goes green or
+             you cut a fix PR with the keystone re-verified locally.
+          EOF
+          )
+
+          # Idempotent per UTC date: edit in place if today's issue exists.
+          EXISTING=$(gh issue list --repo "${{ github.repository }}" \
+            --state open --search "${TITLE_PREFIX} in:title" \
+            --json number --jq '.[0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --repo "${{ github.repository }}" \
+              --title "$TITLE" --body "$BODY"
+            echo "edited existing issue #$EXISTING"
+          else
+            # Try with P0 label; fall back to no label if repo lacks it.
+            gh issue create --repo "${{ github.repository }}" \
+              --title "$TITLE" --body "$BODY" \
+              --label "P0" --label "moat-keystone" || \
+            gh issue create --repo "${{ github.repository }}" \
+              --title "$TITLE" --body "$BODY"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-api test-e2e test-fast test-e2e-duckdb test-moat dev lint lint-daemon-allowlist
+.PHONY: test test-api test-e2e test-fast test-e2e-duckdb test-moat moat-check moat-check-drive dev lint lint-daemon-allowlist
 
 dev:
 	OPENCLAW_GATEWAY_TOKEN=dev-token python3 dashboard.py --port 8900
@@ -34,6 +34,27 @@ test-moat:
 	    tests/test_no_direct_get_store_in_routes.py \
 	    tests/test_local_query_api.py \
 	    -q
+
+# MOAT keystone bar (docs/MOAT_BAR.md Section 5, AC#1). The 13-endpoint
+# verifier that drives a real openclaw turn (or skips it via --no-drive)
+# and asserts every UI-backing API surface returns non-zero, correctly
+# shaped data. Hard-gate on every PR via the moat-keystone job in
+# .github/workflows/ci.yml. ~2s in --no-drive mode against a warm
+# DuckDB; 30-60s when driving a real openclaw turn.
+#
+# Requires: dashboard listening on 127.0.0.1:8900 AND sync daemon
+# running (writes ~/.clawmetry/local_query.json). Locally:
+#   make dev   # starts dashboard
+#   python3 -m clawmetry.sync   # starts daemon
+#   make moat-check
+moat-check:
+	@python3 scripts/accuracy_harness/keystone_e2e.py --no-drive
+
+# Drive mode (real openclaw agent turn -> +2 events in DuckDB -> 13
+# probes). Costs LLM tokens, so runs nightly on main via
+# .github/workflows/moat-keystone-drive-nightly.yml — never per-PR.
+moat-check-drive:
+	@python3 scripts/accuracy_harness/keystone_e2e.py
 
 lint: lint-py lint-js lint-daemon-allowlist
 


### PR DESCRIPTION
## Summary

Codifies [`docs/MOAT_BAR.md`](https://github.com/vivekchand/clawmetry/blob/main/docs/MOAT_BAR.md) Section 5 acceptance criteria #1 ("`keystone_e2e.py --no-drive` exits 0 on every PR (wire into CI as required check)") and #4 (nightly drive on main + auto-P0 on failure).

| Layer | Change |
|---|---|
| `Makefile` | New `moat-check` (`--no-drive`, ~2s local) and `moat-check-drive` (real openclaw turn, ~30-60s) targets. |
| `.github/workflows/ci.yml` | New `moat-keystone` job. Boots dashboard on 8900 + a minimal `clawmetry.local_server` (the DuckDB query proxy that `keystone_e2e.py` discovers via `~/.clawmetry/local_query.json`), then runs `make moat-check`. |
| `.github/workflows/moat-keystone-drive-nightly.yml` | New nightly workflow at `0 4 * * *`. Runs full drive mode (real openclaw + real Anthropic round-trip), auto-files an idempotent-per-UTC-date P0 issue on failure. |

## Why now

PR #1682 found a silent-zero bug in `/api/component/tool/exec` that shipped to main because the keystone was only being hand-run by Principal A. Wiring it as a required PR check stops that class of regression at the boundary.

## Boot pattern (per-PR job)

The full `clawmetry.sync` daemon needs `clawmetry connect` (writes `~/.clawmetry/config.json`) which CI does not have. The keystone only depends on the `local_query` HTTP proxy that the daemon happens to host, so the CI job bootstraps just `clawmetry.local_server.start()` in a background process. That writes the discovery file the keystone needs and matches what the real daemon does at `sync.py:8452`.

## Activation note

The keystone script (`scripts/accuracy_harness/keystone_e2e.py`) is delivered by PR #1672, which is still open at time of writing. Both new jobs include a `Guard: keystone harness file present` step that:

- emits a `::warning::` and short-circuits the job (returning success) when the file is missing
- becomes a hard gate the moment #1672 merges to main (file present -> `KEYSTONE_PRESENT=1` -> the actual verifier runs)

No coordination required; the gate self-arms.

## Local verification

```
$ make moat-check
[keystone] Pre-flight: discovering dashboard + daemon...
[keystone]   dashboard = http://localhost:8900
[keystone]   daemon    = 127.0.0.1:58002
[keystone] Baseline event_count = 1507
[keystone] Per-endpoint results:
  [PASS] /api/brain-history    events>0 count=10 sample_types=['ASSISTANT', 'MODEL.COMPLETED', 'PROMPT.SUBMITTED']
  [PASS] /api/sessions         sessions>0 count=2
  [PASS] /api/transcript/...   messages>0 count=40
  [PASS] /api/usage            tokens+breakdown today=0 nonzero_days=1/14 models=2
  [PASS] /api/flow             shape+ok events=10 streaming=True
  [PASS] /api/component/tool/exec    shape events=0 today_calls=0
  [PASS] /api/component/runtime      items>0 count=6
  [PASS] /api/component/machine      items>0 count=7
  [PASS] /api/component/gateway      items>0 count=50
  [PASS] /api/system-health    shape sections=['channel_ingest', 'channels', 'crons']
  [PASS] /api/subagents        shape counts=...
  [PASS] /api/crons            shape jobs=0
  [PASS] /api/memory-files     files>0 count=6
[keystone] Summary: 13 pass / 0 fail / 0 skip (total 13)
make moat-check  0.07s user 0.03s system 5% cpu 1.740 total
```

Wall-clock: ~1.7s end-to-end against a warm DuckDB on my host.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` and same for nightly workflow -> both parse
- [x] `make moat-check` locally -> 13 pass / 0 fail in 1.7s
- [ ] Open PR triggers `moat-keystone` job, sees Guard warning (keystone file not yet on main), short-circuits green
- [ ] After PR #1672 merges, next PR hits the actual gate -> hard fail on any silent-zero regression
- [ ] **Manual follow-up after merge**: toggle `MOAT Keystone (13-endpoint bar)` to required in Settings -> Branches -> main branch protection. (No `branch-protection` config file in this repo; required checks live in GitHub UI only.)

## What this does NOT do

- Does not touch `scripts/accuracy_harness/keystone_e2e.py` (PR #1672's deliverable, and PR #1682 has already extended it).
- Does not add `keystone` to the `scripts/accuracy_harness/all.py` meta-runner (separate follow-up noted in PR #1672 test plan).
- Does not gate cloud (`clawmetry-cloud#975` ships the cloud-side keystone separately).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>