### PR TITLE
fix(sync): pending_query dispatch filters cloud-injected node_id kwarg

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5016,7 +5016,13 @@ def _canonical_args_hash(args: dict) -> str:
 
 def _local_dispatch_fallback(shape: str, args: dict) -> dict:
     """Fallback dispatcher used when `routes.local_query` isn't importable
-    (daemon-only installs). Mirrors the minimal shape→method bridge."""
+    (daemon-only installs). Mirrors the minimal shape→method bridge.
+
+    Cloud-side pending_queries may carry kwargs the local store doesn't
+    recognise (e.g. ``node_id`` — the cloud uses it to route between
+    nodes, but the local DuckDB IS a single-node store). Filter to a
+    per-shape allowlist so those extras don't surface as TypeErrors.
+    """
     from clawmetry import local_store
     store = local_store.get_store(read_only=True)
     if shape == "health":
@@ -5030,8 +5036,28 @@ def _local_dispatch_fallback(shape: str, args: dict) -> dict:
     method = method_map.get(shape)
     if not method:
         raise ValueError(f"unknown shape: {shape}")
-    rows = getattr(store, method)(**(args or {}))
+    rows = getattr(store, method)(**_filter_store_kwargs(shape, args or {}))
     return {"rows": rows, "count": len(rows), "_shape": shape, "_via": "fallback"}
+
+
+# Per-shape allowlist of kwargs accepted by the underlying ``LocalStore``
+# methods. Kept in sync with ``LocalStore.query_*`` signatures in
+# ``clawmetry/local_store.py``. Mirrors ``routes.local_query._coerce_args``
+# but defined here so the daemon-only fallback path doesn't need the
+# routes package on sys.path.
+_SHAPE_ALLOWED_KWARGS = {
+    "events":     {"session_id", "agent_id", "event_type", "since", "until", "limit"},
+    "sessions":   {"agent_id", "since", "until", "limit"},
+    "aggregates": {"agent_id", "since", "until"},
+    "transcript": {"session_id", "limit"},
+}
+
+
+def _filter_store_kwargs(shape: str, args: dict) -> dict:
+    allowed = _SHAPE_ALLOWED_KWARGS.get(shape)
+    if allowed is None:
+        return dict(args)
+    return {k: v for k, v in args.items() if k in allowed}
 
 
 def _channel_enrichment_from_row(r: dict) -> dict:

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -208,8 +208,24 @@ def _dispatch(shape: str, args: dict) -> dict:
          the DuckDB while it owns the writer lock).
       2. Else fall back to opening the DuckDB directly (single-process
          mode, or daemon temporarily down).
+
+    Arg coercion: callers are NOT required to pre-filter ``args``. Cloud-side
+    callers (heartbeat-piggyback ``pending_queries`` from
+    ``clawmetry-cloud/routes/cloud.py``) sometimes attach metadata like
+    ``node_id`` for cloud-side routing that the local DuckDB-backed
+    ``LocalStore`` methods don't accept. Without coercion that surfaced as
+    a TypeError per heartbeat (one of the root causes behind the 2026-05-18
+    "cloud shows 0 sessions" P0). ``_coerce_args`` runs the per-shape
+    allowlist so unknown kwargs are dropped before the store call.
     """
     started = time.monotonic()
+    try:
+        args = _coerce_args(shape, args or {})
+    except ValueError:
+        # ``_coerce_args`` raises for required-arg violations (e.g. transcript
+        # missing session_id). Let the caller see the original ValueError so
+        # the cloud dispatcher logs a meaningful message.
+        raise
     # Try the daemon proxy first. If it fails for ANY reason, fall
     # through to direct access — the dashboard never goes blank.
     try:

--- a/tests/test_pending_query_dispatch.py
+++ b/tests/test_pending_query_dispatch.py
@@ -1,0 +1,195 @@
+"""Regression tests for the 2026-05-18 P0 where cloud-side ``pending_queries``
+attach kwargs (e.g. ``node_id``) that ``LocalStore.query_sessions()`` doesn't
+accept.
+
+Root cause: cloud's ``/api/cloud/node/<id>/sessions`` enqueues a pending
+query with ``args = {"node_id": node_id}``. The daemon's
+``_dispatch_pending_queries`` forwarded the args straight into
+``store.query_sessions(**args)`` and tripped::
+
+    TypeError: LocalStore.query_sessions() got an unexpected keyword
+    argument 'node_id'
+
+Every heartbeat fired this 3x and the sessions cache on cloud never
+populated -> "Embodied" tab empty, ``/api/cloud/node/<id>/sessions``
+returned ``_source: relay_pending, eta_sec: 60`` indefinitely.
+
+Fix: both transport entry points (``routes.local_query._dispatch`` and the
+daemon-only ``clawmetry.sync._local_dispatch_fallback``) now filter args to
+the per-shape allowlist before calling the underlying ``LocalStore``
+method. These tests pin that behaviour so a future signature change can't
+regress us.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def fresh_modules(tmp_path, monkeypatch):
+    """Reload sync + local_store + routes.local_query against a tmp DuckDB
+    so the per-shape kwarg filter is exercised against the same on-disk
+    schema the daemon would see in production."""
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb")
+    )
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+
+    sys.modules.pop("clawmetry.local_store", None)
+    sys.modules.pop("clawmetry.sync", None)
+    sys.modules.pop("routes.local_query", None)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import clawmetry.sync as s
+    importlib.reload(s)
+    import routes.local_query as lq
+    importlib.reload(lq)
+
+    # Force-create the writer connection so read_only opens later in the
+    # test won't trip "database does not exist". Mirrors what the daemon
+    # does on boot.
+    ls.get_store()
+
+    yield {"sync": s, "local_store": ls, "local_query": lq}
+
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+# ── 1. Fallback dispatcher drops node_id without raising ───────────────────
+
+def test_fallback_dispatch_drops_node_id_for_sessions(fresh_modules):
+    """Cloud sends ``shape=sessions, args={node_id: ...}``. The daemon's
+    fallback dispatcher must NOT raise ``TypeError: unexpected keyword
+    argument 'node_id'``."""
+    s = fresh_modules["sync"]
+    # Pre-fix: this raised TypeError. Post-fix: returns the empty-rows
+    # envelope cleanly because no events have been ingested.
+    result = s._local_dispatch_fallback("sessions", {"node_id": "node-XYZ"})
+    assert isinstance(result, dict)
+    assert result.get("_shape") == "sessions"
+    assert "rows" in result and isinstance(result["rows"], list)
+
+
+def test_fallback_dispatch_drops_node_id_for_events(fresh_modules):
+    s = fresh_modules["sync"]
+    result = s._local_dispatch_fallback(
+        "events", {"node_id": "node-XYZ", "limit": 5}
+    )
+    assert isinstance(result, dict)
+    assert result.get("_shape") == "events"
+    # ``limit`` is in the allowlist; ``node_id`` should have been filtered.
+
+
+def test_fallback_dispatch_drops_node_id_for_aggregates(fresh_modules):
+    s = fresh_modules["sync"]
+    result = s._local_dispatch_fallback(
+        "aggregates", {"node_id": "node-XYZ"}
+    )
+    assert isinstance(result, dict)
+    assert result.get("_shape") == "aggregates"
+
+
+# ── 2. Primary dispatcher (routes.local_query) drops node_id too ───────────
+
+def test_primary_dispatch_drops_node_id_for_sessions(fresh_modules):
+    """``routes.local_query._dispatch`` is the path taken when the daemon
+    can import the routes package (the common case). It must apply the
+    same kwarg filter."""
+    lq = fresh_modules["local_query"]
+    # Without the fix this raised TypeError before returning.
+    result = lq._dispatch("sessions", {"node_id": "node-XYZ"})
+    assert isinstance(result, dict)
+    assert result.get("_shape") == "sessions"
+
+
+# ── 3. Allowlist is explicit + per-shape ───────────────────────────────────
+
+def test_filter_kwargs_allowlist_per_shape(fresh_modules):
+    """Lock in the per-shape kwarg allowlist so a future drift between the
+    cloud + local store can't silently reintroduce the bug class."""
+    s = fresh_modules["sync"]
+    f = s._filter_store_kwargs
+
+    # node_id is dropped for every known shape.
+    for shape in ("events", "sessions", "aggregates", "transcript"):
+        out = f(shape, {"node_id": "n", "limit": 10})
+        assert "node_id" not in out, f"node_id leaked for shape={shape}"
+
+    # Known kwargs pass through untouched.
+    assert f("sessions", {"agent_id": "main", "limit": 25}) == {
+        "agent_id": "main", "limit": 25,
+    }
+    assert f("transcript", {"session_id": "sess-A", "limit": 50}) == {
+        "session_id": "sess-A", "limit": 50,
+    }
+
+
+# ── 4. End-to-end through send_heartbeat ───────────────────────────────────
+
+def test_pending_query_with_node_id_completes_without_warning(
+    fresh_modules, monkeypatch, caplog
+):
+    """Wire the full ``send_heartbeat`` pipeline with a fake ``_post`` and
+    confirm the ``pending_query dispatch failed`` warning is NOT logged
+    when the cloud attaches ``args={'node_id': ...}``."""
+    import logging
+
+    s = fresh_modules["sync"]
+    cache_posts = []
+
+    def fake_post(path, payload, api_key, timeout=45):
+        if path == "/ingest/heartbeat":
+            return {
+                "sync_allowed": True,
+                "pending_queries": [
+                    {
+                        "id": "q_node_sessions_refresh_test",
+                        "shape": "sessions",
+                        "args": {"node_id": "node-XYZ"},
+                        "cache_key": "node:node-XYZ:sessions",
+                    },
+                ],
+            }
+        if path == "/ingest/cache":
+            cache_posts.append(payload)
+            return {}
+        raise AssertionError(f"unexpected path {path}")
+
+    monkeypatch.setattr(s, "_post", fake_post)
+    monkeypatch.setattr(s.time, "sleep", lambda *a, **kw: None)
+
+    config = {
+        "node_id":        "node-XYZ",
+        "api_key":        "cm_test",
+        "encryption_key": s.generate_encryption_key(),
+    }
+
+    caplog.set_level(logging.WARNING, logger="clawmetry-sync")
+    ok = s.send_heartbeat(config)
+
+    assert ok is True
+    # Cache POST should have fired - sessions list (even if empty) was dispatched.
+    assert len(cache_posts) == 1
+    assert cache_posts[0]["id"] == "q_node_sessions_refresh_test"
+    # And critically: the regressed warning must NOT be present.
+    failures = [
+        r for r in caplog.records
+        if "pending_query dispatch failed" in r.getMessage()
+    ]
+    assert not failures, f"unexpected dispatch failures: {[r.getMessage() for r in failures]}"


### PR DESCRIPTION
## Summary

Fixes the root cause behind the 2026-05-18 P0 where the cloud showed `0/lifetime` and the **Embodied** tab stayed empty.

Every heartbeat fired 3x:

```
WARNING pending_query dispatch failed (id=q_node_sessions_refresh_<ts>
shape=sessions): LocalStore.query_sessions() got an unexpected
keyword argument 'node_id'
```

- Cloud's `/api/cloud/node/<id>/sessions` enqueues a heartbeat-relay pending_query with `args = {"node_id": node_id}` (it uses it for cloud-side routing across multiple nodes).
- The daemon forwarded `args` straight into `LocalStore.query_sessions(**args)`.
- `query_sessions()` has no `node_id` kwarg (the local store IS a single-node store), so it raised `TypeError` per dispatch.
- The sessions cache never populated -> `/api/cloud/node/<id>/sessions` returned `_source: relay_pending, eta_sec: 60` forever.

## Fix

Per-shape kwarg allowlist applied at **both** dispatch entry points so cloud-side routing metadata can't trip the local store:

- `routes/local_query.py:_dispatch` now calls the existing `_coerce_args(shape, args)` helper before invoking the store. This keeps both HTTP and heartbeat-piggyback transports on the same safety rail.
- `clawmetry/sync.py:_local_dispatch_fallback` (used when `routes/` isn't on `sys.path` for daemon-only installs) gets a duplicated `_SHAPE_ALLOWED_KWARGS` + `_filter_store_kwargs()` so it stays zero-dep.

Diff: 44 LOC under code, 196 LOC of test, all in the same blast radius as the bug.

## Regression test

`tests/test_pending_query_dispatch.py` — 6 cases covering both transport paths + the per-shape allowlist matrix. The crucial one (`test_pending_query_with_node_id_completes_without_warning`) wires `send_heartbeat` end-to-end with a fake `_post` and asserts the `pending_query dispatch failed` warning is **not** logged.

## Test plan

- [x] `pytest tests/test_pending_query_dispatch.py` -> 6 passed.
- [x] `pytest tests/test_local_query_api.py` -> 16 passed (no regression on HTTP path).
- [x] `pytest tests/test_heartbeat_dispatch.py` -> 4 passed, 1 pre-existing failure unrelated (`test_encrypted_blob_decrypts_to_original` -> already red on main).
- [x] `python3 -c 'import dashboard'` clean.
- [x] Local daemon restart + 100s window: **0** `node_id` `TypeError` dispatch failures (was 3 every 10s pre-fix).
- [x] `scripts/accuracy_harness/cloud_keystone_e2e.py` (from PR #1681): `/api/cloud/node/<id>/sessions` flipped from `_source: relay_pending, sessions=0` to `_source: cache, sessions_blob=<populated>`.

## Note on related residual log noise

One `pending_query dispatch failed: Expecting value: line 1 column 1 (char 0)` appears at boot (proxy_dispatch race against the local_server thread before it binds). That's pre-existing, not the same root cause, and the dispatch failure is caught + retried on the next heartbeat. Out of scope for this PR; can be cleaned up separately by retrying the proxy once after a short backoff if `is_running()` was true but the socket wasn't ready.

No `[RELEASE]` tag -> @vivekchand has the merge auth power for this P0.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>