### PR TITLE
[RELEASE] chore: bump to v0.12.243 (sync.py drift fix + keystone CI gate)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -146,7 +146,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.242"
+__version__ = "0.12.243"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Ships PRs #1686 (sync drift root-cause fix, verified live), #1684 (reliability tests), #1685 (keystone CI gate) to PyPI. Auto-publishes on merge.