### PR TITLE
[RELEASE] chore: bump to v0.12.244 (carries cloud-contract IA fix forward)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -146,7 +146,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.243"
+__version__ = "0.12.244"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Cuts a fresh release so cloud's auto-pin picks up the cloud-contract IA-selector fix (PR #1687) plus the still-unpublished sync.py drift fix from 0.12.243 (release-on-merge failed pre-fix; re-run in progress, this PR provides a clean publish path either way).