### PR TITLE
fix(sync): resolve DuckDB writer-vs-reader contention in telegram-gw-log + checkpoint flush + channel sync

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8451,6 +8451,44 @@ def run_daemon() -> None:
     except Exception as _e:
         log.warning("daemon-error event handler: failed to install: %s", _e)
 
+    # ── Eagerly take the DuckDB writer lock BEFORE any read-only opener ──
+    # DuckDB enforces a PROCESS-level lock on the file. Two failure modes
+    # this warm-up addresses:
+    #
+    # 1. INTRA-process (the original bug): once a RO handle exists in THIS
+    #    process, no RW handle can be opened (the singleton in
+    #    ``local_store.get_store`` raises "cannot open writer — read-only
+    #    handle already exists in this process"). Several startup paths
+    #    request a RO store (heartbeat agent-install detection, cache push
+    #    builders), and the main loop later tries to flush via the writer.
+    #    Opening the writer FIRST means ``get_store(read_only=True)`` callers
+    #    in this process transparently share the writer connection (see
+    #    ``local_store.get_store`` lines 960-963) and no path is blocked.
+    #
+    # 2. INTER-process: a stray dashboard / second daemon / orphaned worktree
+    #    can still own the writer lock. DuckDB then raises ``IO Error: Could
+    #    not set lock on file ... Conflicting lock is held in <path> (PID
+    #    <pid>) ...``. We surface that as an ERROR (not WARNING) with
+    #    triage breadcrumbs because EVERY downstream writer call will fail
+    #    until the offender exits, and the cascade of generic warnings
+    #    elsewhere ("channel sync error", "telegram-gw-log unavailable",
+    #    "pre-checkpoint flush failed") doesn't name the offending PID.
+    try:
+        from clawmetry import local_store as _ls_warmup
+        _ls_warmup.get_store(read_only=False)
+        log.info("local_store writer warm-up: owned (intra-process RO upgrades will share this handle)")
+    except Exception as _ws_e:
+        _msg = str(_ws_e)
+        if "Conflicting lock" in _msg or "Could not set lock" in _msg:
+            log.error(
+                "local_store writer warm-up: ANOTHER PROCESS HOLDS THE "
+                "DUCKDB WRITER LOCK. ALL writes will fail until it exits. "
+                "Check the offending PID in: %s",
+                _msg,
+            )
+        else:
+            log.warning("local_store writer warm-up failed (continuing): %s", _ws_e)
+
     # ── Startup sync: recent-first so Brain feed shows current activity ──
     send_heartbeat(config)
     log.info("Initial heartbeat sent")


### PR DESCRIPTION
## Summary

DuckDB enforces a process-level lock on the local store file. The sync daemon was opening a **read-only** handle FIRST at startup (`send_heartbeat` -> `_detect_any_local_data_for_heartbeat` -> `get_store(read_only=True)`) and then trying to open the **writer** later for ingest / flush paths. `local_store.get_store` raises `cannot open writer -- read-only handle already exists in this process` on that upgrade, and the cascade surfaces as three recurring warnings the user reported:

```
WARNING telegram-gw-log: local_store unavailable: local_store: cannot open writer ...
WARNING pre-checkpoint local-store flush failed (continuing): local_store: cannot open writer ...
WARNING channel sync error (non-fatal): local_store: cannot open writer ...
```

**Fix:** warm up the writer eagerly at daemon startup, right after `install_daemon_error_event_handler` and BEFORE `send_heartbeat`. Once the writer singleton exists, `get_store(read_only=True)` callers in the same process transparently share it (per `local_store.get_store` lines 960-963), so every downstream code path is unblocked.

## Bonus diagnostic

While reproducing this locally I discovered a **second** failure mode masquerading as the same warning: a stray `dashboard.py` from a different worktree (PID 18885, `/private/tmp/oss-pr-1662/dashboard.py --port 8902`) was holding the writer lock at the OS level. DuckDB raises a different message in that case (`IO Error: Could not set lock on file ... Conflicting lock is held in <path> (PID <pid>)`) but the downstream warnings all read identically, making triage painful. The warm-up now detects that variant and logs it as **ERROR** with the offending PID surfaced, so on-call can find and kill the squatter immediately.

## Test plan

- [x] `python3 -c 'import dashboard'` clean
- [x] `python3 -m py_compile clawmetry/sync.py` clean
- [x] Restart sync daemon, wait 60s, verify warnings clear:
    - Before: 1357 "cannot open writer" warnings across full sync.log
    - After:  0 new "cannot open writer" warnings in the post-restart window
- [x] New INFO line confirms ownership: `local_store writer warm-up: owned (intra-process RO upgrades will share this handle)`
- [x] Inter-process variant verified by intentionally leaving the stray dashboard running before the second restart, then killing it for the third restart -> warnings dropped from 66 to 0

## Scope

- 38 LOC added (1 file: `clawmetry/sync.py`)
- No `[RELEASE]` tag (per task scope)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)