### PR TITLE
[RELEASE] chore: re-cut for v0.12.244 (workflow swallowed prior bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,3 +489,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - New `--enc-key` flag: non-interactive connect for sandboxes
 - Only sandboxes appear in app.clawmetry.com, not the host
 - Clean end message after NemoClaw install
+
+## v0.12.244 (re-cut: workflow ate the previous bump)
+- Re-trigger PyPI publish so cloud auto-pin picks up the v0.12.243 sync.py drift fix at v0.12.244


### PR DESCRIPTION
Two prior [RELEASE] PRs (#1688/#1689) merged but the release-on-merge workflow computes next-version from latest-PyPI+1, ignoring the explicit __version__ in the merged commit. PyPI advanced 0.12.241 → 0.12.242 → 0.12.243; main's __version__ got auto-reverted to 0.12.243 by the housekeeping PR.

Re-cutting so the workflow publishes 0.12.244. Same payload (sync.py drift fix + IA-selector fix) — just a fresh trigger.