### PR TITLE
fix(sync): upload event_count + size_bytes per session

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6644,6 +6644,19 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                 # pick the dominant one as the primary.
                 model_tokens: dict = {}
                 last_seen_model = ""
+                # event_count (= JSONL line count) is the "messages" badge
+                # the Embodied tab renders. The cloud Postgres copy of the
+                # sessions table was previously plaintext-blank for this
+                # column because the daemon never uploaded it, so every
+                # cloud row showed "0 messages" even on actively chatting
+                # sessions (cloud fix/embodied-tab-zeros). Counting bytes
+                # too lets the cloud render "8.4 KB" rather than "0 B".
+                event_count = 0
+                size_bytes = 0
+                try:
+                    size_bytes = int(fpath.stat().st_size)
+                except Exception:
+                    pass
 
                 # Scan session file for metadata, tokens, cost, model
                 # Read head for start info, scan all for usage, tail for end
@@ -6652,6 +6665,7 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                         raw = raw.strip()
                         if not raw:
                             continue
+                        event_count += 1
                         try:
                             ev = json.loads(raw)
                         except Exception:
@@ -6711,6 +6725,11 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
                         "total_cost": total_cost,
                         "started_at": started_at,
                         "updated_at": updated_at,
+                        # Plaintext aggregates so the cloud Embodied tab can
+                        # render real "55 messages, 8.4 KB" rows instead of
+                        # zeros. Older cloud servers ignore unknown keys.
+                        "event_count": event_count,
+                        "size_bytes": size_bytes,
                     }
                 )
                 last_mtimes[fpath.name] = current_mtime


### PR DESCRIPTION
## Summary
- Daemon now reports JSONL line count + file size in `/ingest/sessions` so the cloud Embodied tab can render real "55 messages, 8.4 KB" badges instead of zeros.
- Counts are derived inside the existing per-session scan loop (no extra IO) and tagged with a defensive `st_size` stat.
- Pairs with cloud PR \`fix/embodied-tab-zeros\` which reads the new fields and surfaces them on `/api/transcripts`.

## Root cause
- Cloud's `/api/transcripts` (dashboard.py:16747) hardcoded `messages=0, size=0, modified=0` because epic #1032 retired the events-table reads. The daemon never uploaded the plaintext line count as a substitute, so every cloud row showed "0 messages, 0 B, never" even on actively chatting sessions.

## Verification
- Curl `https://app.clawmetry.com/api/transcripts?token=cm_...` before: `{"messages":0,"modified":0}` for every session.
- After the cloud-side PR merges and the daemon restarts on this branch, the same curl returns `{"messages":55,"size":...,"modified":1779140401196}` matching local `http://localhost:8906/api/transcripts`.

## Test plan
- [ ] CI green (lint + sync unit tests).
- [ ] Local daemon restart, observe one `/ingest/sessions` POST including `event_count` and `size_bytes` in the JSON body.
- [ ] Confirm cloud sessions row has non-NULL `event_count` for the touched session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)