### PR TITLE
feat(replay): query DuckDB for Token Usage Over Time chart + clearer empty state

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -15120,9 +15120,20 @@ async function loadHistory() {
     }
     document.getElementById('history-cron-table').innerHTML = cronHtml;
 
-    // Update status
+    // Update status. Empty state copy (2026-05-18): the old line read
+    // "No data yet -- collector polls every 60s", which was misleading on
+    // the default install where no collector runs. New copy tells the
+    // user how to populate the chart and points at the Live trace tab.
     var totalPts = (tokIn.data||[]).length + (costData.data||[]).length;
-    status.textContent = totalPts > 0 ? totalPts + ' data points' : 'No data yet -- collector polls every 60s';
+    if (totalPts > 0) {
+      status.textContent = totalPts + ' data points';
+    } else {
+      status.innerHTML = 'Token usage chart populates as your agent runs. '
+        + 'Send a message in OpenClaw to see the first datapoint, or '
+        + '<a href="#flow" onclick="switchTab(\'flow\');return false;" '
+        + 'style="color:var(--accent-primary,#3b82f6);text-decoration:underline;">'
+        + 'open the Live trace</a>.';
+    }
   } catch(e) {
     status.textContent = 'Error: ' + e.message;
     console.error('History load error:', e);

--- a/routes/fleet_history.py
+++ b/routes/fleet_history.py
@@ -29,11 +29,104 @@ Module-level helpers (``_fleet_db``, ``_fleet_db_lock``, ``_fleet_check_key``,
 
 import json
 import time
+from datetime import datetime, timezone
 
 from flask import Blueprint, jsonify, request
 
 bp_fleet = Blueprint('fleet', __name__)
 bp_history = Blueprint('history', __name__)
+
+
+# ── DuckDB-first source for /api/history/metrics token + cost series ───────
+#
+# Issue (user P0, 2026-05-18): the Replay tab's "Token Usage Over Time"
+# chart was wired exclusively to the optional ``history.py`` SQLite collector
+# (~/.clawmetry/history.db ``snapshots`` table). That collector is not
+# installed in the default ``pip install clawmetry`` flow, so every user
+# whose token data lives in DuckDB (via the sync daemon's
+# ``query_daily_usage_splits``) saw an empty chart with a misleading
+# "collector polls every 60s" status — even when /api/usage proved the
+# data was sitting RIGHT THERE in DuckDB.
+#
+# Fix: when the requested metric is one of the three the Replay chart wires
+# (``tokens_in_total``, ``tokens_out_total``, ``cost_total``), pull from
+# DuckDB via ``query_daily_usage_splits`` first, reshape into the
+# ``{bucket_ts, avg_val}`` rows the chart consumer expects, and fall back
+# to the legacy SQLite path when DuckDB returns nothing (so existing users
+# with a populated ``snapshots`` table do NOT regress).
+#
+# Per-day granularity is intentionally coarser than the SQLite minute/hour
+# buckets — splits are computed by walking event blobs and ts→day truncation
+# is built into the helper. For the 1h/6h/24h ranges the chart still draws
+# a meaningful line (today's day bucket gets bigger as events accumulate);
+# for 7d/30d it draws the full daily history. Deeper refactor to honour
+# sub-day intervals is flagged in the PR body.
+
+_DUCKDB_BACKED_METRICS = frozenset({
+    "tokens_in_total",
+    "tokens_out_total",
+    "cost_total",
+})
+
+
+def _ts_to_iso(ts_epoch):
+    """Epoch seconds → ISO-8601 UTC string the DuckDB ``since``/``until``
+    columns expect. Returns ``None`` on bad input so callers can skip
+    filtering."""
+    try:
+        return datetime.fromtimestamp(float(ts_epoch), tz=timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _day_to_epoch_midnight(day_str):
+    """``YYYY-MM-DD`` → epoch seconds at 00:00 UTC. Used to stamp the
+    ``bucket_ts`` the Replay chart's x-axis consumes. Returns ``None`` on
+    parse failure (caller drops the row)."""
+    try:
+        dt = datetime.strptime(day_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
+    except (TypeError, ValueError):
+        return None
+
+
+def _duckdb_history_metric(metric, from_ts, to_ts):
+    """Return ``[{bucket_ts, avg_val}]`` rows for the Replay chart sourced
+    from DuckDB via the daemon proxy. Returns ``None`` when DuckDB is
+    unreachable or yields no rows so the caller can fall back to SQLite."""
+    try:
+        from routes.local_query import local_store_via_daemon
+    except ImportError:
+        return None
+    since_iso = _ts_to_iso(from_ts)
+    until_iso = _ts_to_iso(to_ts)
+    kwargs = {}
+    if since_iso:
+        kwargs["since"] = since_iso
+    if until_iso:
+        kwargs["until"] = until_iso
+    splits = local_store_via_daemon("query_daily_usage_splits", **kwargs)
+    if not splits:
+        return None
+    key = {
+        "tokens_in_total":  "input_tokens",
+        "tokens_out_total": "output_tokens",
+        "cost_total":       "cost_usd",
+    }.get(metric)
+    if key is None:
+        return None
+    out = []
+    for r in splits:
+        bucket_ts = _day_to_epoch_midnight(r.get("day", ""))
+        if bucket_ts is None:
+            continue
+        try:
+            val = float(r.get(key) or 0)
+        except (TypeError, ValueError):
+            val = 0.0
+        out.append({"bucket_ts": bucket_ts, "avg_val": val})
+    out.sort(key=lambda d: d["bucket_ts"])
+    return out or None
 
 
 # ── Fleet (multi-node) API Routes ───────────────────────────────────────
@@ -223,16 +316,30 @@ def api_node_detail(node_id):
 
 @bp_history.route("/api/history/metrics")
 def api_history_metrics():
-    """Query historical metrics. Params: metric, from, to, interval."""
-    import dashboard as _d
-    if not _d._history_db:
-        return jsonify({"error": "History not available", "data": []}), 200
+    """Query historical metrics. Params: metric, from, to, interval.
+
+    DuckDB-first (issue: Replay-tab empty chart 2026-05-18): for the three
+    metrics the Replay chart wires (tokens in/out, cost), query DuckDB via
+    the sync daemon's ``query_daily_usage_splits`` BEFORE touching SQLite.
+    Falls back to the legacy SQLite ``snapshots``-table path when DuckDB
+    returns no rows so users who DO run the ``history.py`` collector keep
+    working.
+    """
     metric = request.args.get("metric", "tokens_in_total")
     from_ts = request.args.get("from", type=float, default=time.time() - 3600)
     to_ts = request.args.get("to", type=float, default=time.time())
     interval = request.args.get("interval", None)
+
+    if metric in _DUCKDB_BACKED_METRICS:
+        rows = _duckdb_history_metric(metric, from_ts, to_ts)
+        if rows:
+            return jsonify({"data": rows, "metric": metric, "_source": "duckdb"})
+
+    import dashboard as _d
+    if not _d._history_db:
+        return jsonify({"data": [], "metric": metric, "_source": "empty"}), 200
     data = _d._history_db.query_metrics(metric, from_ts, to_ts, interval)
-    return jsonify({"data": data, "metric": metric})
+    return jsonify({"data": data, "metric": metric, "_source": "sqlite"})
 
 
 @bp_history.route("/api/history/metrics/list")


### PR DESCRIPTION
## Summary

User P0: the **Replay tab** ("History" in the page header) on both `localhost:8906` and `app.clawmetry.com/cloud` showed an empty "Token Usage Over Time" chart with the misleading status `No data yet -- collector polls every 60s`, even when `/api/usage` returned 200k+ tokens for today from DuckDB. The chart was wired exclusively to the optional `history.py` SQLite collector (`~/.clawmetry/history.db` `snapshots` table), which is **not** installed in the default `pip install clawmetry` flow.

User quote: *"the replay ui is fully empty -- I'm unable to understand what to expect from it"*.

- `routes/fleet_history.py` `/api/history/metrics`: when the requested metric is one of `tokens_in_total` / `tokens_out_total` / `cost_total`, query DuckDB via the sync daemon's `query_daily_usage_splits` first (already daemon-allowlisted at `routes/local_query.py:349`). Reshape `[{day, input_tokens, output_tokens, cost_usd}]` into the `[{bucket_ts, avg_val}]` shape the existing chart consumer expects. Window bounds are translated from epoch to ISO-8601 to match the DuckDB `ts` column.
- Legacy SQLite path is kept as a fallback (DuckDB empty -> falls through to `_d._history_db.query_metrics`), so users who DO run `history.py` continue working.
- `clawmetry/static/js/app.js`: empty-state copy now reads `Token usage chart populates as your agent runs. Send a message in OpenClaw to see the first datapoint, or open the Live trace.` with a click-through to the Live trace tab. No em-dashes.

## Before / after

```
GET /api/history/metrics?metric=tokens_in_total&from=<24h-ago>&to=<now>&interval=hour

BEFORE: {"data": [], "error": "History not available"}
AFTER:  {"_source": "duckdb", "data": [{"avg_val": 28822.0, "bucket_ts": 1779062400}], "metric": "tokens_in_total"}

GET /api/history/metrics?metric=tokens_out_total&from=<7d-ago>&to=<now>&interval=day
AFTER:  7 daily points returned, peaks at 132,437 today and 110,425 on 2026-05-13
```

Empty-state copy:
- **Before**: `No data yet -- collector polls every 60s`
- **After**: `Token usage chart populates as your agent runs. Send a message in OpenClaw to see the first datapoint, or open the Live trace.`

Screenshot: `.claude/screenshots/replay-duckdb-2026-05-19.png` (7d view, status reads "14 data points", chart shows scaled axes 0-140,000 with a sharp spike from today's activity).

## Trade-offs / follow-ups

- **Granularity**: `query_daily_usage_splits` returns YYYY-MM-DD buckets. For the 1h/6h/24h Replay buttons this draws today's full-day bucket as one point; for 7d/30d it draws the full daily history. Existing SQLite collector users get the original minute/hour resolution when DuckDB returns nothing. A deeper refactor to honour sub-day intervals (hourly DuckDB rollup helper) is a follow-up rather than blocking the user-reported fix.
- Non-token metrics (`sessions_active` etc.) still flow through the SQLite path unchanged.

## Test plan

- [x] `python3 -c 'import dashboard'` clean
- [x] `python3 -c 'from routes import fleet_history'` clean
- [x] Started dashboard from worktree on port 8957, hit `/api/history/metrics` for all three DuckDB-backed metrics across 1h/24h/7d/30d windows
- [x] Verified `_source: "sqlite"` fallback fires when DuckDB returns nothing (`sessions_active`, and `tokens_in_total` 1h-window with no events in range)
- [x] Playwright screenshot of `/#history` on 7d view shows the chart drawing real data + "14 data points" in the status text
- [ ] Smoke against `app.clawmetry.com/cloud` after merge + cloud bump