### PR TITLE
fix(cloud-nav): hide Version impact tab in cloud mode (irrelevant outside OSS)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -14837,6 +14837,17 @@ async function bootDashboard() {
   setTimeout(_safeFinishBoot, 180);
 }
 
+// Version impact is a per-OpenClaw-release report — only meaningful when the
+// user controls their own OpenClaw install. In cloud mode ClawMetry manages
+// versions, so the tab is irrelevant. Hide nav item + page (deep-link too).
+function _hideCloudIrrelevantNav() {
+  if (!window.CLOUD_MODE) return;
+  var navItem = document.querySelector('.left-nav-item[data-tab="version-impact"]');
+  if (navItem) navItem.style.display = 'none';
+  var page = document.getElementById('page-version-impact');
+  if (page) page.style.display = 'none';
+}
+
 document.addEventListener('DOMContentLoaded', function() {
   initTheme();
   initZoom();
@@ -14847,6 +14858,7 @@ document.addEventListener('DOMContentLoaded', function() {
   bootDashboard();
   // Issue #950: multi-profile workspace switcher
   try { initWorkspaceSwitcher(); } catch (e) { /* non-fatal */ }
+  try { _hideCloudIrrelevantNav(); } catch (e) { /* non-fatal */ }
 });
 
 // ── Workspace switcher (issue #950) ───────────────────────────────────


### PR DESCRIPTION
## Summary
- Hide the **Version impact** sub-nav entry and `#page-version-impact` page when `window.CLOUD_MODE === true`.
- Version impact reports per-OpenClaw-release blast-radius. Cloud users don't control their OpenClaw version (ClawMetry does), so the tab is irrelevant noise in the Advanced sub-nav.
- Routes stay registered. The cloud-route policy already 410-stubs `/api/version-impact/*` separately.

## Why JS guard (not Jinja)
`window.CLOUD_MODE` is injected by the cloud iframe wrapper at runtime, not via Jinja context. The nav HTML in `dashboard.py` is rendered once on the OSS server and re-served to the cloud iframe. Existing cloud-aware features (Skills, Workspaces, Crons) all follow the same `if (window.CLOUD_MODE) return;` pattern, so this PR keeps that convention.

## Diff
12 LOC added in `clawmetry/static/js/app.js`. Tiny `_hideCloudIrrelevantNav()` helper wired into the existing `DOMContentLoaded` init.

## Test plan
- [x] `python3 -c 'import dashboard'` clean
- [x] `node --check clawmetry/static/js/app.js` clean
- [x] Local OSS (port 8917, no CLOUD_MODE): Version impact visible in Advanced
- [x] Local cloud-mode (port 8918, CLOUD_MODE=1) serves the same HTML; cloud iframe sets `window.CLOUD_MODE=true` before app.js runs, JS guard hides nav item + page
- [ ] Post-merge: cloud production check that Advanced sub-nav no longer lists Version impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)