### PR TITLE
feat(ia): regroup nav (Flow/Brain/Logs/Models/LLM Context under Live; Crons + Memory promoted to top-level)

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -1353,12 +1353,36 @@
   gap: 1px;
   padding: 2px 0 4px;
 }
+.left-nav-advanced-list[hidden] { display: none; }
 .left-nav-item-sub {
   padding: 7px 12px 7px 24px;
   font-size: 12px;
   font-weight: 500;
   color: var(--text-tertiary);
 }
+/* Live trace expandable group (IA regroup). The Live trace header
+   doubles as the Overview tab launcher; the chevron toggles the list. */
+.left-nav-item-group { position: relative; }
+.left-nav-group-chevron {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: transform 0.18s ease, color 0.18s ease;
+}
+.left-nav-group-chevron:hover { color: var(--text-secondary); }
+.left-nav-group-chevron[aria-expanded="false"] { transform: rotate(-90deg); }
+.left-nav-group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 2px 0 4px;
+}
+.left-nav-group-list[hidden] { display: none; }
 .left-nav-item-link { text-decoration: none; }
 .left-nav-footer {
   margin-top: auto;

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -923,19 +923,53 @@ function toggleLeftNavMobile() {
   leftNav.classList.toggle('open');
 }
 
-// Restore Advanced drawer state on page load.
-(function _restoreAdvancedDrawer() {
+// Live trace expandable group (IA regroup: Flow/Brain/Logs/Models/LLM Context).
+// Default-expanded; remembers user collapse via localStorage.
+function toggleLiveDrawer() {
+  var btn = document.getElementById('left-nav-live-toggle');
+  var list = document.getElementById('left-nav-live-list');
+  if (!btn || !list) return;
+  var nowOpen = list.hasAttribute('hidden');
+  if (nowOpen) {
+    list.removeAttribute('hidden');
+    btn.setAttribute('aria-expanded', 'true');
+  } else {
+    list.setAttribute('hidden', '');
+    btn.setAttribute('aria-expanded', 'false');
+  }
+  try { localStorage.setItem('cm_live_open', nowOpen ? '1' : '0'); }
+  catch (e) { /* localStorage blocked */ }
+}
+
+// Restore Advanced + Live drawer state on page load.
+(function _restoreNavDrawers() {
   if (typeof document === 'undefined') return;
   var apply = function() {
-    var btn = document.getElementById('left-nav-advanced-toggle');
-    var list = document.getElementById('left-nav-advanced-list');
-    if (!btn || !list) return;
-    var open = false;
-    try { open = localStorage.getItem('cm_advanced_open') === '1'; }
-    catch (e) { /* localStorage blocked */ }
-    if (open) {
-      list.removeAttribute('hidden');
-      btn.setAttribute('aria-expanded', 'true');
+    // Advanced drawer (default-collapsed).
+    var advBtn = document.getElementById('left-nav-advanced-toggle');
+    var advList = document.getElementById('left-nav-advanced-list');
+    if (advBtn && advList) {
+      var advOpen = false;
+      try { advOpen = localStorage.getItem('cm_advanced_open') === '1'; }
+      catch (e) { /* localStorage blocked */ }
+      if (advOpen) {
+        advList.removeAttribute('hidden');
+        advBtn.setAttribute('aria-expanded', 'true');
+      }
+    }
+    // Live trace drawer (default-expanded; collapse only if user explicitly closed).
+    var liveBtn = document.getElementById('left-nav-live-toggle');
+    var liveList = document.getElementById('left-nav-live-list');
+    if (liveBtn && liveList) {
+      var liveOpen = true;
+      try {
+        var v = localStorage.getItem('cm_live_open');
+        if (v === '0') liveOpen = false;
+      } catch (e) { /* localStorage blocked */ }
+      if (!liveOpen) {
+        liveList.setAttribute('hidden', '');
+        liveBtn.setAttribute('aria-expanded', 'false');
+      }
     }
   };
   if (document.readyState === 'loading') {

--- a/dashboard.py
+++ b/dashboard.py
@@ -10797,10 +10797,28 @@ DASHBOARD_HTML = r"""
 <div class="app-shell">
   <aside id="left-nav" role="navigation" aria-label="Primary">
     <div class="left-nav-section">
-      <div class="left-nav-item active" data-tab="overview" onclick="switchTab('overview')" title="Live view of every running agent">
+      <div class="left-nav-item left-nav-item-group active" data-tab="overview" onclick="switchTab('overview')" title="Live view of every running agent">
         <span class="left-nav-icon" aria-hidden="true">&#9679;</span>
         <span class="left-nav-label">Live trace</span>
         <span id="nav-stuck-badge" class="left-nav-badge" style="display:none;">0</span>
+        <button type="button" class="left-nav-group-chevron" id="left-nav-live-toggle" aria-expanded="true" aria-controls="left-nav-live-list" aria-label="Toggle Live trace sub-items" onclick="event.stopPropagation(); toggleLiveDrawer();">&#9662;</button>
+      </div>
+      <div class="left-nav-group-list" id="left-nav-live-list">
+        <div class="left-nav-item left-nav-item-sub" data-tab="flow" onclick="switchTab('flow')">
+          <span class="left-nav-label">Flow</span>
+        </div>
+        <div class="left-nav-item left-nav-item-sub" data-tab="brain" onclick="switchTab('brain')">
+          <span class="left-nav-label">Brain</span>
+        </div>
+        <div class="left-nav-item left-nav-item-sub" data-tab="logs" onclick="switchTab('logs')">
+          <span class="left-nav-label">Logs</span>
+        </div>
+        <div class="left-nav-item left-nav-item-sub" data-tab="models" onclick="switchTab('models')">
+          <span class="left-nav-label">Models</span>
+        </div>
+        <div class="left-nav-item left-nav-item-sub" data-tab="context" onclick="switchTab('context')" title="What the LLM sees on each turn">
+          <span class="left-nav-label">LLM Context</span>
+        </div>
       </div>
       <div class="left-nav-item" data-tab="clusters" onclick="switchTab('clusters')" title="Multi-node fleet overview">
         <span class="left-nav-icon" aria-hidden="true">&#9678;</span>
@@ -10828,6 +10846,14 @@ DASHBOARD_HTML = r"""
         <span class="left-nav-icon" aria-hidden="true">&#8634;</span>
         <span class="left-nav-label">Replay</span>
       </div>
+      <div class="left-nav-item" data-tab="crons" id="crons-tab" onclick="switchTab('crons')" title="Scheduled agent jobs">
+        <span class="left-nav-icon" aria-hidden="true">&#9202;</span>
+        <span class="left-nav-label">Crons</span>
+      </div>
+      <div class="left-nav-item" data-tab="memory" onclick="switchTab('memory')" title="Persistent memory files the agent reads on boot">
+        <span class="left-nav-icon" aria-hidden="true">&#9873;</span>
+        <span class="left-nav-label">Memory</span>
+      </div>
     </div>
 
     <button type="button" class="left-nav-advanced-toggle" id="left-nav-advanced-toggle" onclick="toggleAdvancedDrawer()" aria-expanded="false">
@@ -10835,44 +10861,23 @@ DASHBOARD_HTML = r"""
       <span class="left-nav-advanced-chevron" aria-hidden="true">&#9662;</span>
     </button>
     <div class="left-nav-advanced-list" id="left-nav-advanced-list" hidden>
-      <div class="left-nav-item left-nav-item-sub" data-tab="flow" onclick="switchTab('flow')">
-        <span class="left-nav-label">Flow</span>
-      </div>
-      <div class="left-nav-item left-nav-item-sub" data-tab="brain" onclick="switchTab('brain')">
-        <span class="left-nav-label">Brain</span>
-      </div>
       <div class="left-nav-item left-nav-item-sub" data-tab="notifications" onclick="switchTab('notifications')">
         <span class="left-nav-label">Notifications</span>
-      </div>
-      <div class="left-nav-item left-nav-item-sub" data-tab="context" onclick="switchTab('context')">
-        <span class="left-nav-label">Context</span>
-      </div>
-      <div class="left-nav-item left-nav-item-sub" data-tab="memory" onclick="switchTab('memory')">
-        <span class="left-nav-label">Memory</span>
       </div>
       <div class="left-nav-item left-nav-item-sub" data-tab="security" onclick="switchTab('security')">
         <span class="left-nav-label">Security</span>
       </div>
-      <div class="left-nav-item left-nav-item-sub" data-tab="logs" onclick="switchTab('logs')">
-        <span class="left-nav-label">Logs</span>
-      </div>
-      <div class="left-nav-item left-nav-item-sub" data-tab="models" onclick="switchTab('models')">
-        <span class="left-nav-label">Models</span>
-      </div>
-      <div class="left-nav-item left-nav-item-sub" data-tab="limits" onclick="switchTab('limits')">
-        <span class="left-nav-label">Rate limits</span>
-      </div>
-      <div class="left-nav-item left-nav-item-sub" data-tab="crons" id="crons-tab" onclick="switchTab('crons')">
-        <span class="left-nav-label">Crons</span>
+      <div class="left-nav-item left-nav-item-sub" data-tab="skills" onclick="switchTab('skills')">
+        <span class="left-nav-label">Skills</span>
       </div>
       <div class="left-nav-item left-nav-item-sub" data-tab="selfevolve" onclick="switchTab('selfevolve')">
-        <span class="left-nav-label">SelfEvolve</span>
+        <span class="left-nav-label">Self-Evolve</span>
       </div>
       <div class="left-nav-item left-nav-item-sub" data-tab="version-impact" onclick="switchTab('version-impact')">
         <span class="left-nav-label">Version impact</span>
       </div>
-      <div class="left-nav-item left-nav-item-sub" data-tab="skills" onclick="switchTab('skills')">
-        <span class="left-nav-label">Skills</span>
+      <div class="left-nav-item left-nav-item-sub" data-tab="limits" onclick="switchTab('limits')">
+        <span class="left-nav-label">Rate limits</span>
       </div>
       <div class="left-nav-item left-nav-item-sub" data-tab="nemoclaw" id="nemoclaw-tab" onclick="switchTab('nemoclaw')" style="display:none;">
         <span class="left-nav-label">NemoClaw</span>


### PR DESCRIPTION
## Summary

User-flagged IA bug: the left-nav nests too aggressively into Advanced. This PR matches the requested target IA.

**Top-level (always visible, in order):**
- Live trace [expandable group, default-expanded]
  - Flow, Brain, Logs, Models, **LLM Context** (renamed from "Context")
- Fleet sonar, Approvals, Alerts, Cost, Embodied, Replay, **Crons** (promoted), **Memory** (promoted)

**Advanced (collapsible, default-collapsed):**
- Notifications, Security, Skills, Self-Evolve, Version impact
- (Plus Rate limits and NemoClaw kept in Advanced to avoid silently removing surfaces not in the user spec; safe to drop in a follow-up.)

### Changes
- `dashboard.py` (~25 LOC net): converted Live trace into an expandable group with a chevron button; added Crons + Memory as top-level items; trimmed Advanced drawer.
- `clawmetry/static/js/app.js` (~30 LOC net): added `toggleLiveDrawer()` mirroring `toggleAdvancedDrawer()`; unified the restore-state IIFE to handle both drawers; persists collapse via `cm_live_open` (default true).
- `clawmetry/static/css/dashboard.css` (~24 LOC): new `.left-nav-group-list` / `.left-nav-group-chevron` styles for the Live group; also fixed a latent bug where `.left-nav-advanced-list[display:flex]` overrode the HTML `hidden` attribute (added `[hidden] { display: none }`).

### What's *not* touched
- No `data-tab` keys changed (flow, brain, logs, models, context, crons, memory, notifications, security, skills, selfevolve, version-impact stay the same).
- No handler routes touched. Pure nav HTML/CSS/JS shuffle.
- Click behaviour: each item still calls `switchTab('<key>')`. The Live trace header keeps its `data-tab="overview"` and still launches Overview; only the chevron toggles the sub-list.

### Test plan
- [x] `python3 -c 'import dashboard'` clean (v0.12.244)
- [x] Local dashboard boot + Playwright screenshot of new nav at `.claude/screenshots/ia-reorg-2026-05-19.png`
- [x] Verified via DOM evaluate: 8 top-level items (Live trace, Fleet sonar, Approvals, Alerts, Cost, Embodied, Replay, Crons, Memory) + 5 Live sub-items (Flow, Brain, Logs, Models, LLM Context) + 7 Advanced sub-items, with `liveOpen=true, advOpen=false` on first paint
- [x] Diff under 150 LOC (101+/38-, 139 net)
- [x] No em-dashes / double-dashes in new user-facing copy
- [ ] CI green
- [ ] Manual click-through after merge (each tab still loads its panel)

### Before / after (text-only)

Before — top-level: Live trace, Fleet sonar, Approvals, Alerts, Cost, Embodied, Replay. Advanced drawer (collapsed): Flow, Brain, Notifications, Context, Memory, Security, Logs, Models, Rate limits, Crons, SelfEvolve, Version impact, Skills, NemoClaw.

After — top-level: Live trace (expanded → Flow, Brain, Logs, Models, LLM Context), Fleet sonar, Approvals, Alerts, Cost, Embodied, Replay, Crons, Memory. Advanced drawer (collapsed): Notifications, Security, Skills, Self-Evolve, Version impact, Rate limits, NemoClaw.