### PR TITLE
feat(classifier): detect cognitive loops (recursive self-validation), 6th outcome class (closes #1706)

### DIFF
--- a/clawmetry/outcome_classifier.py
+++ b/clawmetry/outcome_classifier.py
@@ -7,14 +7,21 @@ users actually care about: *"did this agent actually work?"*.
 
 Pure functions only. Stateless. Tested independently from DuckDB.
 
-Outcomes (4-way):
-  success   — agent finished and nothing went wrong
-  failed    — last billable turn surfaced an error OR last assistant message
-              contains structured failure markers
-  escalated — a human-approval gate fired for this session (cross-references
-              the ``approvals`` table — caller passes the matching rows in)
-  ongoing   — session is still active (no terminal session.ended event AND
-              last event is recent, default <5 min)
+Outcomes (5-way):
+  success        — agent finished and nothing went wrong
+  failed         — last billable turn surfaced an error OR last assistant
+                   message contains structured failure markers
+  escalated      — a human-approval gate fired for this session
+                   (cross-references the ``approvals`` table — caller passes
+                   the matching rows in)
+  cognitive_loop — agent emitted N>=3 near-identical assistant messages
+                   inside a 10-minute window with no new tool name and no
+                   new file path between them (recursive self-validation,
+                   issue #1706). Fires BEFORE ``ongoing`` because a still-
+                   chattering session that's not making forward progress is
+                   no longer healthily ongoing.
+  ongoing        — session is still active (no terminal session.ended event
+                   AND last event is recent, default <5 min)
 
 Defaults are conservative on purpose (per memory
 ``feedback_synthetic_tests_missed_real_event_shape``): when uncertain we
@@ -39,15 +46,24 @@ from typing import Any
 OUTCOME_SUCCESS = "success"
 OUTCOME_FAILED = "failed"
 OUTCOME_ESCALATED = "escalated"
+OUTCOME_COGNITIVE_LOOP = "cognitive_loop"
 OUTCOME_ONGOING = "ongoing"
 
 VALID_OUTCOMES = frozenset({
-    OUTCOME_SUCCESS, OUTCOME_FAILED, OUTCOME_ESCALATED, OUTCOME_ONGOING,
+    OUTCOME_SUCCESS, OUTCOME_FAILED, OUTCOME_ESCALATED,
+    OUTCOME_COGNITIVE_LOOP, OUTCOME_ONGOING,
 })
 
 # How long after the last event we still call a session "ongoing".
 # 5 min matches the brain-stream / activity heuristic used elsewhere.
 ONGOING_RECENT_SECONDS = 5 * 60
+
+# Cognitive-loop detector tunables (issue #1706). Defaults match the
+# OpenClaw blog post acceptance criteria: 3+ near-identical assistant
+# messages in a 10-minute window, no new tool/file invoked in between.
+COGNITIVE_LOOP_WINDOW_SECONDS = 600
+COGNITIVE_LOOP_SIMILARITY_THRESHOLD = 0.85
+COGNITIVE_LOOP_MIN_REPEATS = 3
 
 # Default failure-text patterns (case-insensitive substring). Override via
 # CLAWMETRY_OUTCOME_FAILURE_PATTERNS=pat1|pat2|... env var if needed.
@@ -200,6 +216,174 @@ def _has_terminal_event(events: list[dict[str, Any]]) -> bool:
     return False
 
 
+# ── Cognitive-loop detection helpers (issue #1706) ─────────────────────────
+#
+# Pure functions, no DuckDB / IO. Cheap by design: token-level Jaccard on
+# normalised last-200-chars of each assistant turn. Future work: swap in a
+# tiny embedding model for true semantic similarity; the public API of
+# ``find_cognitive_loops`` is the LLM-swap escape hatch.
+
+_NUM_OR_UUID_RE = re.compile(r"\b[0-9a-f]{6,}\b|\d+")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _normalize_for_similarity(text: str) -> str:
+    """Lowercase, strip digits + hex/UUID runs, collapse whitespace, tail 200.
+
+    Goal: two assistant turns that say the same thing modulo timestamps,
+    request IDs, or other numeric noise normalise to the same string so the
+    Jaccard score actually fires. Last 200 chars keeps cost bounded.
+    """
+    s = (text or "").lower().strip()
+    s = _NUM_OR_UUID_RE.sub(" ", s)
+    s = _WHITESPACE_RE.sub(" ", s).strip()
+    return s[-200:]
+
+
+def _token_jaccard(a: str, b: str) -> float:
+    """Token-level Jaccard similarity on whitespace-split tokens. 0.0..1.0."""
+    ta = set(a.split())
+    tb = set(b.split())
+    if not ta and not tb:
+        return 1.0
+    if not ta or not tb:
+        return 0.0
+    union = len(ta | tb)
+    return len(ta & tb) / union if union else 0.0
+
+
+def _tool_uses_in_event(event: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return [(tool_name, file_path_or_empty), ...] for an assistant event.
+
+    Looks at ``data.message.content[*]`` for entries with ``type=tool_use``
+    (Anthropic block-list shape). Returns [] if none — e.g. ``model.completed``
+    on a non-Anthropic provider, or a pure-text turn.
+    """
+    out: list[tuple[str, str]] = []
+    data = event.get("data") or {}
+    if not isinstance(data, dict):
+        return out
+    msg = data.get("message")
+    if not isinstance(msg, dict):
+        return out
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return out
+    for blk in content:
+        if not isinstance(blk, dict):
+            continue
+        if blk.get("type") != "tool_use":
+            continue
+        name = str(blk.get("name") or "").strip()
+        ipt = blk.get("input") or {}
+        path = ""
+        if isinstance(ipt, dict):
+            for k in ("file_path", "path", "filename", "filepath"):
+                v = ipt.get(k)
+                if isinstance(v, str) and v:
+                    path = v
+                    break
+        out.append((name, path))
+    return out
+
+
+def _session_has_cognitive_loop(
+    sess_events: list[dict[str, Any]],
+    *,
+    window_seconds: int,
+    similarity_threshold: float,
+    min_repeats: int,
+) -> bool:
+    """True if this single session's assistant turns are spinning in place.
+
+    Algorithm: for each anchor assistant message, slide forward through the
+    time window collecting near-identical follow-ups. Bail the moment a new
+    tool name or new file path appears (that's forward progress, not a
+    loop). Fire if the anchor accumulates >= min_repeats matches.
+    """
+    try:
+        sess_events = sorted(sess_events, key=lambda e: e.get("ts") or "")
+    except Exception:
+        pass
+    items: list[dict[str, Any]] = []
+    for ev in sess_events:
+        et = (ev.get("event_type") or "").lower()
+        if et not in ("assistant", "message", "model.completed"):
+            continue
+        txt = _extract_text(ev.get("data"))
+        if not txt:
+            continue
+        items.append({
+            "ts": _iso_to_epoch(ev.get("ts")),
+            "norm": _normalize_for_similarity(txt),
+            "tools": _tool_uses_in_event(ev),
+        })
+    if len(items) < min_repeats:
+        return False
+    for i, anchor in enumerate(items):
+        matches = 1
+        seen_tools = {n for n, _ in anchor["tools"] if n}
+        seen_paths = {p for _, p in anchor["tools"] if p}
+        for j in range(i + 1, len(items)):
+            cand = items[j]
+            if anchor["ts"] and cand["ts"] and (
+                cand["ts"] - anchor["ts"] > window_seconds
+            ):
+                break
+            cand_tools = {n for n, _ in cand["tools"] if n}
+            cand_paths = {p for _, p in cand["tools"] if p}
+            if (cand_tools - seen_tools) or (cand_paths - seen_paths):
+                # Forward progress: a new tool or file appeared. Not stuck.
+                break
+            if _token_jaccard(anchor["norm"], cand["norm"]) >= similarity_threshold:
+                matches += 1
+                seen_tools |= cand_tools
+                seen_paths |= cand_paths
+                if matches >= min_repeats:
+                    return True
+    return False
+
+
+def find_cognitive_loops(
+    events: list[dict[str, Any]] | None,
+    *,
+    now: float | None = None,
+    window_seconds: int = COGNITIVE_LOOP_WINDOW_SECONDS,
+    similarity_threshold: float = COGNITIVE_LOOP_SIMILARITY_THRESHOLD,
+    min_repeats: int = COGNITIVE_LOOP_MIN_REPEATS,
+) -> list[str]:
+    """Return session_ids that exhibit a cognitive loop.
+
+    A cognitive loop = ``min_repeats`` near-identical assistant messages
+    inside ``window_seconds`` AND no new tool name AND no new file path
+    invoked between them. Caps at 200 sessions scanned per call so it
+    never blows up on large DuckDB exports.
+
+    ``now`` is accepted for API symmetry with ``classify_session`` (and
+    leaves room for a future "only loops in the last N hours" filter); it
+    is currently unused because the detection is purely intra-session.
+    """
+    del now  # reserved for future windowing
+    by_session: dict[str, list[dict[str, Any]]] = {}
+    for ev in events or []:
+        sid = ev.get("session_id") or ""
+        if not sid:
+            continue
+        if sid not in by_session and len(by_session) >= 200:
+            continue  # cap fan-out
+        by_session.setdefault(sid, []).append(ev)
+    flagged: list[str] = []
+    for sid, sess_events in by_session.items():
+        if _session_has_cognitive_loop(
+            sess_events,
+            window_seconds=window_seconds,
+            similarity_threshold=similarity_threshold,
+            min_repeats=min_repeats,
+        ):
+            flagged.append(sid)
+    return flagged
+
+
 def classify_session(
     events: list[dict[str, Any]] | None,
     session_meta: dict[str, Any] | None = None,
@@ -224,6 +408,7 @@ def classify_session(
       * 0.95  — escalated (approval row exists)
       * 0.9   — tool.result error on the tail
       * 0.85  — session.ended terminal marker present
+      * 0.8   — cognitive loop detected (issue #1706)
       * 0.75  — last-turn text matched a failure pattern
       * 0.6   — ongoing (recent activity, no terminal event)
       * 0.5   — fell through to "success" default (conservative)
@@ -259,6 +444,19 @@ def classify_session(
         for a in approvals:
             if a:  # ignore None / empty
                 return OUTCOME_ESCALATED, 0.95
+
+    # ── 2.5. Cognitive loop — recursive self-validation (issue #1706) ─
+    # Runs BEFORE ongoing because a still-chattering session whose
+    # assistant keeps emitting the same text is no longer healthy ongoing.
+    # When #1671 (tool_call_stuck) lands it will slot just above this one;
+    # ordering is preserved naturally by the rebase.
+    if _session_has_cognitive_loop(
+        evs,
+        window_seconds=COGNITIVE_LOOP_WINDOW_SECONDS,
+        similarity_threshold=COGNITIVE_LOOP_SIMILARITY_THRESHOLD,
+        min_repeats=COGNITIVE_LOOP_MIN_REPEATS,
+    ):
+        return OUTCOME_COGNITIVE_LOOP, 0.8
 
     # ── 3. Ongoing — no terminal marker AND recent activity ─────────
     terminal = _has_terminal_event(evs) or bool(meta.get("ended_at"))
@@ -301,24 +499,28 @@ def aggregate_outcomes(rows: list[dict[str, Any]]) -> dict[str, Any]:
     Output matches the ``/api/outcomes`` contract:
 
         {
-            "total":         247,
-            "success":       220,
-            "failed":         18,
-            "escalated":       9,
-            "ongoing":         0,
-            "success_rate":  0.890,    # success / (success + failed)
+            "total":           247,
+            "success":         220,
+            "failed":           18,
+            "escalated":         9,
+            "cognitive_loop":    0,
+            "ongoing":           0,
+            "success_rate":   0.880,   # success / (success + failed + loop)
             "needed_human_rate": 0.036,  # escalated / total
         }
 
     ``success_rate`` deliberately excludes ``ongoing`` (still in flight) and
     ``escalated`` (different category — a successful human-in-the-loop run
-    isn't a failure of the agent). Matches industry convention for
-    autonomous-task success metrics.
+    isn't a failure of the agent). ``cognitive_loop`` IS in the denominator
+    because it's a terminal failure mode (the agent wasted budget without
+    making progress). Matches industry convention for autonomous-task
+    success metrics.
     """
     counts = {
         OUTCOME_SUCCESS: 0,
         OUTCOME_FAILED: 0,
         OUTCOME_ESCALATED: 0,
+        OUTCOME_COGNITIVE_LOOP: 0,
         OUTCOME_ONGOING: 0,
     }
     for r in rows or []:
@@ -328,7 +530,11 @@ def aggregate_outcomes(rows: list[dict[str, Any]]) -> dict[str, Any]:
         else:
             counts[OUTCOME_SUCCESS] += 1
     total = sum(counts.values())
-    finished = counts[OUTCOME_SUCCESS] + counts[OUTCOME_FAILED]
+    finished = (
+        counts[OUTCOME_SUCCESS]
+        + counts[OUTCOME_FAILED]
+        + counts[OUTCOME_COGNITIVE_LOOP]
+    )
     success_rate = (counts[OUTCOME_SUCCESS] / finished) if finished else 0.0
     needed_human = (counts[OUTCOME_ESCALATED] / total) if total else 0.0
     return {
@@ -336,6 +542,7 @@ def aggregate_outcomes(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "success": counts[OUTCOME_SUCCESS],
         "failed": counts[OUTCOME_FAILED],
         "escalated": counts[OUTCOME_ESCALATED],
+        "cognitive_loop": counts[OUTCOME_COGNITIVE_LOOP],
         "ongoing": counts[OUTCOME_ONGOING],
         "success_rate": round(success_rate, 4),
         "needed_human_rate": round(needed_human, 4),

--- a/tests/test_outcome_classifier.py
+++ b/tests/test_outcome_classifier.py
@@ -354,7 +354,91 @@ def test_reclassify_after_new_error_event(isolated_store):
     assert by_id2[sid]["outcome"] == "failed"
 
 
-# ── 6. Bug-class gate (memory: synthetic vs real event shape) ──────────────
+# ── 7. Cognitive loop detection (issue #1706) ──────────────────────────────
+
+
+def _assistant_msg(ts_iso, text, *, session_id="loop-sess", tool_uses=()):
+    """Build a real ``message`` envelope event matching v3 ingest shape."""
+    content = [{"type": "text", "text": text}]
+    for name, file_path in tool_uses:
+        content.append({
+            "type": "tool_use",
+            "name": name,
+            "input": {"file_path": file_path} if file_path else {},
+        })
+    return {
+        "event_type": "message",
+        "ts": ts_iso,
+        "session_id": session_id,
+        "data": {"message": {"role": "assistant", "content": content}},
+    }
+
+
+def test_classify_cognitive_loop_when_assistant_repeats_self():
+    """5 near-identical 'validate the results' messages 60s apart -> loop."""
+    from clawmetry.outcome_classifier import (
+        classify_session,
+        OUTCOME_COGNITIVE_LOOP,
+    )
+    from datetime import datetime, timezone
+
+    now = time.time()
+    events = []
+    for i in range(5):
+        ts = datetime.fromtimestamp(now - (300 - 60 * i), tz=timezone.utc).isoformat()
+        events.append(_assistant_msg(
+            ts, "I should validate the results again to be sure."
+        ))
+    outcome, conf = classify_session(events, {}, now=now)
+    assert outcome == OUTCOME_COGNITIVE_LOOP
+    assert 0.5 < conf <= 1.0
+
+
+def test_classify_distinct_messages_is_ongoing_not_loop():
+    """5 different assistant messages in window -> ongoing, not a loop."""
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_ONGOING
+    from datetime import datetime, timezone
+
+    now = time.time()
+    distinct = [
+        "Let me read the file.",
+        "Now I'll check the database schema.",
+        "Running the test suite next.",
+        "Inspecting the failed assertion.",
+        "Drafting a patch for the bug.",
+    ]
+    events = []
+    for i, txt in enumerate(distinct):
+        ts = datetime.fromtimestamp(now - (300 - 60 * i), tz=timezone.utc).isoformat()
+        events.append(_assistant_msg(ts, txt))
+    outcome, _ = classify_session(events, {}, now=now)
+    assert outcome == OUTCOME_ONGOING
+
+
+def test_classify_repeated_text_with_new_tools_each_time_is_ongoing():
+    """5 identical assistant texts, each invoking a NEW tool/file -> ongoing.
+
+    Forward progress (new tool name OR new file path) shields the session
+    from the cognitive-loop label even if the prose is verbatim repeated.
+    """
+    from clawmetry.outcome_classifier import classify_session, OUTCOME_ONGOING
+    from datetime import datetime, timezone
+
+    now = time.time()
+    tools = ["bash", "read_file", "grep", "edit_file", "write_file"]
+    events = []
+    for i, tn in enumerate(tools):
+        ts = datetime.fromtimestamp(now - (300 - 60 * i), tz=timezone.utc).isoformat()
+        events.append(_assistant_msg(
+            ts,
+            "I should validate the results again to be sure.",
+            tool_uses=[(tn, f"file_{i}.py")],
+        ))
+    outcome, _ = classify_session(events, {}, now=now)
+    assert outcome == OUTCOME_ONGOING
+
+
+# ── 8. Bug-class gate (memory: synthetic vs real event shape) ──────────────
 
 
 def test_classifier_does_not_filter_on_legacy_event_shape_only():


### PR DESCRIPTION
## Summary
- Adds `cognitive_loop` as a new outcome class in `clawmetry/outcome_classifier.py`. Fires when an agent emits N>=3 near-identical assistant messages inside a 10-minute window with no new tool name and no new file path between them.
- Pure-Python detection (token-level Jaccard on normalised last-200-chars of each turn, threshold 0.85). No new deps, no DuckDB schema change, caps at 200 sessions per batch call.
- Slots into `classify_session` between `escalated` and `ongoing` so a still-chattering session that isn't making forward progress is no longer mislabelled as healthy ongoing. `aggregate_outcomes` includes `cognitive_loop` in the success-rate denominator (it's a terminal failure mode: agent burned tokens with zero progress).
- Public helper `find_cognitive_loops(events, *, now, ...)` returns the flagged session_ids for batch use (e.g. backfill jobs). Internal `_session_has_cognitive_loop` is what `classify_session` calls per single session.

## Implementation notes
- `_normalize_for_similarity`: lowercase, strip digits + hex/UUID runs (so timestamps and request IDs don't disrupt matching), collapse whitespace, take last 200 chars.
- `_token_jaccard`: cheap intersection-over-union on whitespace-split tokens.
- `_tool_uses_in_event`: extracts `(tool_name, file_path)` from `data.message.content[*].type == "tool_use"` blocks (Anthropic shape).
- Forward-progress check: the moment a NEW tool name or NEW file path appears in the window, the anchor bails. Same prose plus a fresh tool == working, not stuck.
- When #1671 (`tool_call_stuck`) rebases later it slots naturally above `cognitive_loop` since both fire BEFORE `ongoing` and `tool_call_stuck` takes precedence per the issue spec.

## Test plan
- [x] `python3 -m pytest tests/test_outcome_classifier.py::test_classify_cognitive_loop_when_assistant_repeats_self` — 5 near-identical messages 60s apart returns `cognitive_loop`
- [x] `python3 -m pytest tests/test_outcome_classifier.py::test_classify_distinct_messages_is_ongoing_not_loop` — 5 different messages stays `ongoing`
- [x] `python3 -m pytest tests/test_outcome_classifier.py::test_classify_repeated_text_with_new_tools_each_time_is_ongoing` — 5 identical messages each invoking a NEW tool/file stays `ongoing` (forward progress)
- [x] `python3 -c 'import dashboard'` clean
- [x] All 17 other classifier tests still pass (the one pre-existing failure `test_api_outcomes_endpoint_returns_aggregate` is unrelated and reproduces on `origin/main` without this PR)

Closes #1706

Generated with [Claude Code](https://claude.com/claude-code)