### PR TITLE
[RELEASE] chore: bump to v0.12.247 (cognitive_loop + forward-progress + auto-deploy paths fix)

### DIFF
--- a/.github/workflows/auto-deploy-cloud.yml
+++ b/.github/workflows/auto-deploy-cloud.yml
@@ -7,6 +7,7 @@ on:
       - 'dashboard.py'
       - 'clawmetry/**'
       - 'setup.py'
+      - 'CHANGELOG.md'
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -503,3 +503,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fix(cloud-nav): Version impact hidden in cloud mode (#1700)
 - fix(advisor): Self-Evolve auto-detects Anthropic key from OpenClaw config; no more blocking takeover panel (#1703)
 - fix(skills): Skills tab now discovers ~/.openclaw/plugin-skills/ (was returning 0 even with installed skills) (#1703)
+
+## v0.12.247
+- feat(classifier): cognitive_loop 6th outcome class. Catches recursive self-validation, the Wolfgang's burnout case) (#1709)
+- feat(brain): forward-progress signal (tokens per state delta) + Pro alert + DuckDB query (#1710)
+- fix(ci): auto-deploy-cloud workflow now watches CHANGELOG.md so [RELEASE] PRs auto-fire cloud pin


### PR DESCRIPTION
Bundles Wolfgang-burnout fixes (#1709 + #1710) plus repairs the auto-deploy-cloud paths filter that's been silently skipping [RELEASE] PRs.