### PR TITLE
feat(proxy): structured BUDGET_EXCEEDED abort signal (closes G3 of #1708)

### DIFF
--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -22,6 +22,30 @@ Config in ~/.clawmetry/proxy.json:
             "openai": { "api_key_env": "OPENAI_API_KEY", "base_url": "https://api.openai.com" }
         }
     }
+
+BUDGET_EXCEEDED abort contract (G3 of #1708):
+    When ``budget.action == "block"`` and the daily/monthly cap is hit,
+    the proxy returns HTTP 429 with a structured abort envelope so the
+    agent runtime can hard-stop instead of retrying forever:
+
+        Status: 429
+        Header: X-Clawmetry-Budget-Status: exceeded
+        Body  : {
+            "type":  "error",
+            "error": {"type": "budget_exceeded", "message": "<reason>"},
+            "code":  "BUDGET_EXCEEDED",
+            "should_abort":        true,
+            "retry_after_seconds": null,
+            "spent_today":         <float>,
+            "budget_today":        <float>,
+            "message":             "Daily budget reached. Halting agent. ..."
+        }
+
+    Agent runtimes SHOULD check for ``code == "BUDGET_EXCEEDED"`` (or
+    the ``X-Clawmetry-Budget-Status`` header) and stop their loop.
+    Runtimes that ignore these fields fall back to the legacy 429
+    retry path, preserving backward compatibility with non-budget
+    rate-limit semantics.
 """
 
 from __future__ import annotations
@@ -791,9 +815,21 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
     _stats_lock = threading.Lock()
 
     def _error_response(
-        status_code: int, error_type: str, message: str, provider: str = "anthropic"
+        status_code: int,
+        error_type: str,
+        message: str,
+        provider: str = "anthropic",
+        extra: Optional[dict] = None,
+        extra_headers: Optional[dict] = None,
     ) -> Response:
-        """Return an error response in the provider's expected format."""
+        """Return an error response in the provider's expected format.
+
+        ``extra``: top-level fields merged into the JSON body (used to surface
+        the structured ``BUDGET_EXCEEDED`` abort envelope per G3 of #1708).
+        ``extra_headers``: additional response headers (e.g.
+        ``X-Clawmetry-Budget-Status: exceeded`` so HTTP clients that respect
+        headers can short-circuit retries without parsing the body).
+        """
         if provider == "openai":
             body = {
                 "error": {
@@ -810,10 +846,50 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
                     "message": message,
                 },
             }
-        return Response(
+        if extra:
+            body.update(extra)
+        resp = Response(
             json.dumps(body),
             status=status_code,
             content_type="application/json",
+        )
+        if extra_headers:
+            for k, v in extra_headers.items():
+                resp.headers[k] = v
+        return resp
+
+    def _budget_abort_response(reason: str, provider: str) -> Response:
+        """Structured BUDGET_EXCEEDED abort signal (G3 of #1708).
+
+        Agent runtimes that wrap the proxy should branch on either
+        ``code == "BUDGET_EXCEEDED"`` in the JSON body or the
+        ``X-Clawmetry-Budget-Status: exceeded`` response header and STOP
+        their retry loop. Plain 429 retry behaviour is preserved for
+        runtimes that do not read these fields, so the contract is
+        backward compatible with non-budget rate limits.
+        """
+        status = budget.get_status()
+        spent = status.get("daily_spent", 0.0)
+        limit = status.get("daily_limit", 0.0)
+        message = (
+            "Daily budget reached. Halting agent. "
+            "Raise the budget in ClawMetry Cloud settings to resume."
+        )
+        extra = {
+            "code":                "BUDGET_EXCEEDED",
+            "should_abort":        True,
+            "retry_after_seconds": None,
+            "spent_today":         spent,
+            "budget_today":        limit,
+            "message":             message,
+        }
+        return _error_response(
+            429,
+            "budget_exceeded",
+            reason,
+            provider,
+            extra=extra,
+            extra_headers={"X-Clawmetry-Budget-Status": "exceeded"},
         )
 
     def _get_upstream_url(provider: str, path: str) -> str:
@@ -1070,7 +1146,7 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
             elif config.budget.action == "warn":
                 pass  # Allow through with warning
             else:
-                return _error_response(429, "budget_exceeded", reason, provider)
+                return _budget_abort_response(reason, provider)
 
         # ── Loop detection ─────────────────────────────────────────────
         req_hash = compute_request_hash(body)

--- a/routes/alerts.py
+++ b/routes/alerts.py
@@ -112,6 +112,30 @@ DEFAULT_ALERT_RULES = [
             "Catches genuine spinning, not just busy productive burn."
         ),
     },
+    # G3 of #1708 (Wolfgang burnout): the proxy now emits a structured
+    # BUDGET_EXCEEDED abort signal when the daily cap is hit. This seed
+    # rule surfaces those aborts in the alerts UI as an opt-in template
+    # so a user who configured a budget sees a one-click way to be
+    # notified when their agent actually got halted. NOT default-enabled
+    # because most users don't run the proxy yet.
+    {
+        "id":           "agent_halted_budget_default",
+        "type":         "budget_abort",
+        "event_type":   "budget_blocked",
+        "window_hours": 24,
+        "threshold":    1,
+        "channels":     ["banner", "telegram"],
+        "cooldown_min": 60,
+        "enabled":      False,
+        "pro_only":     True,
+        "label":        "Agent halted by budget",
+        "description": (
+            "Fires when the Pro proxy emits at least one BUDGET_EXCEEDED "
+            "abort in the last 24 hours. Use this to confirm the daily "
+            "cap actually stopped a runaway agent, not just logged a "
+            "warning."
+        ),
+    },
 ]
 
 

--- a/tests/test_proxy_budget_abort.py
+++ b/tests/test_proxy_budget_abort.py
@@ -1,0 +1,105 @@
+"""Tests for the structured BUDGET_EXCEEDED abort signal (G3 of #1708).
+
+Pins three guarantees:
+  1. Healthy budget: no abort header leaks onto normal responses.
+  2. Exhausted budget: JSON body carries ``code: BUDGET_EXCEEDED`` +
+     ``should_abort: true``.
+  3. Exhausted budget: response header carries
+     ``X-Clawmetry-Budget-Status: exceeded``.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def client(tmp_path):
+    import clawmetry.proxy
+    from clawmetry.proxy import (
+        create_proxy_app,
+        ProxyConfig,
+        BudgetConfig,
+        LoopDetectionConfig,
+        ProxyDB,
+    )
+
+    config = ProxyConfig(
+        port=14101,
+        budget=BudgetConfig(daily_usd=5.0, monthly_usd=100.0, action="block"),
+        loop_detection=LoopDetectionConfig(enabled=False, max_similar=3, window_seconds=300),
+    )
+    db_path = tmp_path / "abort.db"
+    original_init = ProxyDB.__init__
+
+    def patched_init(self, db_path=None):
+        original_init(self, db_path or clawmetry.proxy.PROXY_DB_FILE)
+
+    with (
+        patch.object(clawmetry.proxy, "PROXY_DB_FILE", db_path),
+        patch.object(ProxyDB, "__init__", patched_init),
+    ):
+        app = create_proxy_app(config)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    c._db_path = db_path
+    return c
+
+
+def _exhaust_budget(db_path):
+    from clawmetry.proxy import ProxyDB
+    ProxyDB(db_path=db_path).record_usage(
+        provider="anthropic",
+        model="claude-3-5-sonnet-20241022",
+        input_tokens=1000,
+        output_tokens=500,
+        cost_usd=10.0,
+    )
+
+
+def _post_messages(client):
+    return client.post(
+        "/v1/messages",
+        data=json.dumps({
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        }),
+        content_type="application/json",
+        headers={"x-api-key": "test-key"},
+    )
+
+
+class TestBudgetAbort:
+    def test_budget_not_exhausted_no_abort_envelope(self, client):
+        # /proxy/status shares the BudgetEnforcer with the proxy path;
+        # an empty exceeded flag here proves the abort path was NOT taken.
+        resp = client.get("/proxy/status")
+        assert resp.status_code == 200
+        assert resp.get_json()["budget"]["daily_remaining"] == 5.0
+        assert resp.headers.get("X-Clawmetry-Budget-Status") != "exceeded"
+
+    def test_budget_exhausted_response_body_carries_abort_code(self, client):
+        _exhaust_budget(client._db_path)
+        resp = _post_messages(client)
+        assert resp.status_code == 429
+        body = resp.get_json()
+        # Legacy 429 envelope preserved (don't break non-budget rate limits).
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "budget_exceeded"
+        # New abort envelope (G3 of #1708).
+        assert body["code"] == "BUDGET_EXCEEDED"
+        assert body["should_abort"] is True
+        assert body["retry_after_seconds"] is None
+        assert body["spent_today"] >= 5.0
+        assert body["budget_today"] == 5.0
+        assert "Halting agent" in body["message"]
+        # No em-dashes in user-facing copy.
+        assert "—" not in body["message"]
+
+    def test_budget_exhausted_response_header_carries_abort_flag(self, client):
+        _exhaust_budget(client._db_path)
+        resp = _post_messages(client)
+        assert resp.status_code == 429
+        assert resp.headers.get("X-Clawmetry-Budget-Status") == "exceeded"


### PR DESCRIPTION
## Summary

Closes G3 of epic #1708 (Wolfgang burnout).

Pro proxy on port 4100 currently returns a generic 429 when the daily budget is exhausted. Agent runtimes see the 429 and just retry, so the agent keeps spinning past the limit. This PR adds a structured abort envelope so runtimes can hard-stop the loop on a single response.

### Before

```http
HTTP/1.1 429 Too Many Requests
Content-Type: application/json

{
  "type": "error",
  "error": {
    "type": "budget_exceeded",
    "message": "Daily budget exceeded: $10.00 / $5.00"
  }
}
```

### After

```http
HTTP/1.1 429 Too Many Requests
Content-Type: application/json
X-Clawmetry-Budget-Status: exceeded

{
  "type":  "error",
  "error": {"type": "budget_exceeded", "message": "Daily budget exceeded: $10.00 / $5.00"},
  "code":  "BUDGET_EXCEEDED",
  "should_abort":        true,
  "retry_after_seconds": null,
  "spent_today":         10.0,
  "budget_today":        5.0,
  "message":             "Daily budget reached. Halting agent. Raise the budget in ClawMetry Cloud settings to resume."
}
```

Runtimes branch on either `code == "BUDGET_EXCEEDED"` (body) or `X-Clawmetry-Budget-Status: exceeded` (header) and stop their retry loop. Runtimes that ignore the new fields fall back to the legacy 429 retry path, so the non-budget rate-limit contract (per-plan 60/min on free, loop-detected 429s, etc.) is unchanged.

## Why option A and not "POST abort to a daemon endpoint"

Option A (this PR) is unilateral. The proxy already owns the response. Cooperating runtimes opt in for free; non-cooperating runtimes keep retrying, same as today. Option B (proxy POSTs `/api/agent-runtime/abort?...`) requires every agent runtime to expose and trust that endpoint, which is a separate negotiation per harness.

## Also in this PR

- New optional Pro alert template `"Agent halted by budget"` in `routes/alerts.py` `DEFAULT_ALERT_RULES`. NOT default-enabled (`enabled: false`); shows up in the one-click templates list so users who configure a daily cap can opt in to be notified the first time it actually halts an agent.

## Test plan

- [x] 3 new cases in `tests/test_proxy_budget_abort.py`:
  - Healthy budget: abort header does NOT leak onto normal responses.
  - Exhausted budget: 429 body carries `code: BUDGET_EXCEEDED` + `should_abort: true`.
  - Exhausted budget: response header carries `X-Clawmetry-Budget-Status: exceeded`.
- [x] All 58 existing `tests/test_proxy.py` cases still pass (no regression on `budget_exceeded`/`loop_detected`/`authentication_error` 429s).
- [x] `python3 -c 'import dashboard'` clean.
- [x] No em-dashes in the user-facing `message` field (banned in copy that integrations may read out loud).
- [x] Diff ~209 LOC (proxy 84, alerts 24, tests 105).

NO `[RELEASE]` tag. Will not be merged from this PR.