### PR TITLE
[RELEASE] fix: alerts modal centers in viewport (closes #1717)

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -306,8 +306,24 @@
 
   // ── Paywall modal ─────────────────────────────────────────────────────────
 
+  // Issue #1717: the alerts modal nodes are templated inside #zoom-wrapper,
+  // which gets `transform: scale(currentZoom)` applied unconditionally by
+  // app.js applyZoom() at boot — even when currentZoom === 1. Any non-`none`
+  // transform creates a containing block for descendants with `position:
+  // fixed`, so `inset: 0` no longer means viewport — it means the wrapper.
+  // Result: the modal renders pinned to the wrapper's top-left (which
+  // scrolls with the page) instead of centered in the viewport. Reparent
+  // the modal to <body> on first open to escape the transform.
+  function detachModalToBody(modalId) {
+    const modal = document.getElementById(modalId);
+    if (modal && modal.parentNode !== document.body) {
+      document.body.appendChild(modal);
+    }
+    return modal;
+  }
+
   function openPaywall() {
-    const modal = document.getElementById('alerts-paywall-modal');
+    const modal = detachModalToBody('alerts-paywall-modal');
     const title = document.getElementById('alerts-paywall-title');
     const body  = document.getElementById('alerts-paywall-body');
     const cta   = document.getElementById('alerts-paywall-cta');
@@ -343,7 +359,10 @@
   // ── Editor modal (Pro tier) ───────────────────────────────────────────────
 
   function openEditor() {
-    document.getElementById('alerts-editor-modal').style.display = 'flex';
+    // See detachModalToBody() above re: #zoom-wrapper transform / issue #1717.
+    const modal = detachModalToBody('alerts-editor-modal');
+    if (!modal) return; // editor markup only renders for Pro (is_pro)
+    modal.style.display = 'flex';
     document.getElementById('alerts-editor-title').textContent =
       alertsState.editorRule ? 'Edit alert rule' : 'New alert rule';
     setActiveType(alertsState.editorType);


### PR DESCRIPTION
## Summary

- Alerts "Enable" / paywall modal rendered far down the page (or off-screen if scrolled) instead of centered in the viewport.
- Root cause: `#zoom-wrapper` gets `transform: scale(currentZoom)` applied at boot by `app.js applyZoom()` regardless of zoom level. Any non-`none` transform creates a containing block for `position: fixed` descendants, so the modal's `inset: 0` overlay sized to the wrapper bounding box (full document height) instead of the viewport and pinned to the wrapper's top-left.
- Fix: reparent both alerts modals (`alerts-paywall-modal` + `alerts-editor-modal`) to `<body>` on first open via a tiny `detachModalToBody()` helper. Idempotent, no DOM churn on subsequent opens.

## Evidence

Playwright repro before fix (overlay positioned relative to wrapper):
```
overlayRect: { top: -600, left: 0, width: 1280, height: 1725 }
cardRect:    { top: 86.5, left: 410, width: 460, height: 352 }
viewport:    { w: 1280, h: 800 }
scrollY:     600
parent:      MAIN.app-shell-content
```

After fix (overlay properly fixed to viewport):
```
overlayRect: { top: 0, left: 0, width: 1280, height: 800 }
cardRect:    { top: 224, left: 410, width: 460, height: 352 }  // center y = 400 = viewport/2
viewport:    { w: 1280, h: 800 }
scrollY:     0
parent:      BODY
```

## Test plan

- [x] Repro the bug locally on port 8911, click Enable on a canned example rule while scrolled down -> modal pinned at the top of the wrapper, not viewport-centered.
- [x] Apply fix, re-run the same flow -> modal is fixed full-viewport with card centered at y=400 (== viewport height / 2).
- [x] `pytest tests/test_tier_pro_paywall_no_flash.py` -> 7/7 pass (initial server-side HTML markers unaffected).
- [x] Click-outside dismissal still works (modal id unchanged, so `alertsClosePaywall` / `alertsCloseEditor` event-target check still matches).
- [x] Cloud reuses OSS `alerts.js` verbatim per `clawmetry-cloud/dashboard.py` line ~11985 comment, so the fix applies on cloud too. No cloud-side override exists for these handlers.

Closes #1717

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>