### PR TITLE
[RELEASE] fix: self-evolve auto-detects gateway token (closes #1721)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5040,17 +5040,48 @@ async function selfevolveProbe() {
     var empty = document.getElementById('selfevolve-empty');
     var runBtn = document.getElementById('selfevolve-run-btn');
     if (!s || !s.available) {
-      // Inline hint stays at the top of the page; the Analyze button
-      // stays enabled so the user sees the 412 error inline if they
-      // click it. Don't block the rest of the surface.
+      // Issue #1721: zero-config principle — render the same OpenClaw-
+      // setup CTA other panels use instead of a "paste your key" prompt.
+      // /status now ships a setup_hint payload listing the paths the
+      // backend probed so the operator can see exactly where to drop a
+      // credential; the Analyze button is disabled to prevent the 412
+      // round-trip (the inline CTA is the actionable surface here).
       if (hint) hint.style.display = 'none';
-      if (noauth) noauth.style.display = '';
-      if (empty) empty.style.display = '';
-      if (runBtn) runBtn.disabled = false;
+      if (noauth) {
+        noauth.style.display = '';
+        var sh = s && s.setup_hint;
+        if (sh) {
+          var hl = document.getElementById('selfevolve-noauth-headline');
+          if (hl && sh.headline) hl.textContent = sh.headline;
+          var sub = document.getElementById('selfevolve-noauth-subhead');
+          if (sub && sh.subhead) sub.textContent = sh.subhead;
+          var probed = document.getElementById('selfevolve-noauth-probed');
+          if (probed && Array.isArray(sh.probed)) {
+            probed.innerHTML = sh.probed.map(function (p) {
+              return '<li>' + String(p).replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</li>';
+            }).join('');
+          }
+        }
+      }
+      if (empty) empty.style.display = 'none';
+      if (runBtn) {
+        runBtn.disabled = true;
+        runBtn.style.opacity = '0.5';
+        runBtn.style.cursor = 'not-allowed';
+        runBtn.title = 'Sign in with claude or export ANTHROPIC_API_KEY first';
+      }
       return;
     }
     if (hint) hint.style.display = '';
     if (noauth) noauth.style.display = 'none';
+    // Re-enable the Analyze button in case a prior probe disabled it
+    // (e.g. credentials added between page loads without a full refresh).
+    if (runBtn) {
+      runBtn.disabled = false;
+      runBtn.style.opacity = '';
+      runBtn.style.cursor = '';
+      runBtn.title = '';
+    }
     if (s.has_cached) {
       try {
         var cached = await fetchJsonWithTimeout('/api/selfevolve/latest', 3000);

--- a/clawmetry/templates/tabs/selfevolve.html
+++ b/clawmetry/templates/tabs/selfevolve.html
@@ -31,21 +31,34 @@
       </button>
     </div>
 
-    <!-- Inline no-auth hint (single line, non-blocking). Resolution
-         order is documented at the top of the file. -->
+    <!-- Issue #1721: when auto-detect comes up empty, render the same
+         OpenClaw-setup CTA other panels use (no raw input box, no "paste
+         a key" prompt). Populated by selfevolveProbe() from /status's
+         setup_hint payload. -->
     <div id="selfevolve-noauth" style="
       display:none;
       background:var(--bg-secondary);
       border:1px solid var(--border);
-      border-radius:6px;
-      padding:10px 14px;
+      border-radius:8px;
+      padding:14px 16px;
       color:var(--text-muted);
-      font-size:12px;
+      font-size:12.5px;
+      line-height:1.55;
       margin-bottom:12px;
       ">
-      Self-Evolve needs an Anthropic key. Set
-      <code style="background:var(--bg-primary);padding:1px 5px;border-radius:3px;">ANTHROPIC_API_KEY</code>
-      in your shell, or paste one in Settings.
+      <div id="selfevolve-noauth-headline" style="font-weight:600;color:var(--text-primary);margin-bottom:4px;">
+        Self-Evolve needs an Anthropic credential.
+      </div>
+      <div id="selfevolve-noauth-subhead">
+        Run <code style="background:var(--bg-primary);padding:1px 5px;border-radius:3px;">claude</code>
+        once to sign in with OAuth (free, recommended), or export
+        <code style="background:var(--bg-primary);padding:1px 5px;border-radius:3px;">ANTHROPIC_API_KEY</code>
+        in your shell. We auto-detect, no copy/paste here.
+      </div>
+      <details style="margin-top:8px;">
+        <summary style="cursor:pointer;font-size:11px;color:var(--text-muted);">Where we looked</summary>
+        <ul id="selfevolve-noauth-probed" style="margin:6px 0 0 0;padding-left:18px;font-size:11px;color:var(--text-muted);font-family:ui-monospace,Menlo,monospace;"></ul>
+      </details>
     </div>
 
     <!-- Status line (analyzed at, model, event count) -->

--- a/routes/advisor.py
+++ b/routes/advisor.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -56,13 +57,12 @@ def _read_anthropic_key_from_openclaw_config() -> str | None:
     The key never leaves the process via /api/* responses (the only
     caller is the LLM dispatcher).
     """
+    home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
     candidates: list[str] = []
 
     # 1. Insights config -- the user may have pasted a key here already.
     try:
-        ins_path = os.path.expanduser(
-            "~/.openclaw/.clawmetry/insights_config.json"
-        )
+        ins_path = os.path.join(home, ".clawmetry", "insights_config.json")
         if os.path.isfile(ins_path):
             with open(ins_path) as f:
                 cfg = json.load(f)
@@ -77,7 +77,7 @@ def _read_anthropic_key_from_openclaw_config() -> str | None:
     # rather than walking the whole tree; new ones can be added as we
     # discover them across installs.
     try:
-        oc_path = os.path.expanduser("~/.openclaw/openclaw.json")
+        oc_path = os.path.join(home, "openclaw.json")
         if os.path.isfile(oc_path):
             with open(oc_path) as f:
                 oc = json.load(f)
@@ -93,6 +93,28 @@ def _read_anthropic_key_from_openclaw_config() -> str | None:
                     v = blob.get(field)
                     if isinstance(v, str) and v.strip().startswith("sk-"):
                         candidates.append(v.strip())
+    except Exception:
+        pass
+
+    # 3. Gateway service-env shell file -- launchd / systemd installs put
+    # provider creds here so the gateway sees them. Issue #1721: zero-config
+    # principle says any key on disk should "just work" -- we already
+    # auto-detect the gateway token here, the Anthropic key sits in the
+    # same file family. Parse with a strict regex so we never execute the
+    # shell or pick up unrelated lines.
+    try:
+        env_path = os.path.join(home, "service-env", "ai.openclaw.gateway.env")
+        if os.path.isfile(env_path):
+            with open(env_path) as f:
+                txt = f.read()
+            for name in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_API_KEY"):
+                m = re.search(
+                    r"^\s*(?:export\s+)?" + re.escape(name) + r"\s*=\s*['\"]?(sk-[A-Za-z0-9\-_]+)",
+                    txt,
+                    re.MULTILINE,
+                )
+                if m:
+                    candidates.append(m.group(1))
     except Exception:
         pass
 
@@ -113,9 +135,13 @@ def _load_anthropic_auth() -> tuple[str | None, str | None]:
                         instead of a blocking modal
     """
     # 1. Explicit env var wins -- operator-controlled, easy to override.
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
-    if api_key:
-        return "api_key", api_key
+    # Issue #1721: also honour the alternate names Claude CLI / Anthropic
+    # SDKs read so users who exported one of the well-known aliases don't
+    # have to set a second env var to make Self-Evolve work.
+    for env_name in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_API_KEY"):
+        api_key = os.environ.get(env_name, "").strip()
+        if api_key:
+            return "api_key", api_key
 
     # 2. Auto-detect a key the user already configured in OpenClaw / the
     # dashboard's Insights tab. This is the "show some magic" path: a

--- a/routes/selfevolve.py
+++ b/routes/selfevolve.py
@@ -327,12 +327,38 @@ def _extract_findings(raw_text: str) -> tuple[list[dict], dict]:
 def api_selfevolve_status():
     mode, credential = _load_anthropic_auth()
     cached = _load_cached()
+
+    # Issue #1721: when auto-detect comes up empty, give the UI enough info
+    # to render the same OpenClaw-setup CTA the rest of the dashboard uses
+    # (not a "paste your API key here" input box). The hint surfaces what
+    # paths were probed so a curious operator can see exactly where to drop
+    # the credential -- zero-config first, then opt-in env var, never a
+    # blocking modal.
+    home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+    setup_hint = None
+    if not credential:
+        setup_hint = {
+            "headline": "Self-Evolve needs an Anthropic credential.",
+            "subhead": (
+                "Run `claude` once to sign in with OAuth (free, recommended), "
+                "or export ANTHROPIC_API_KEY in your shell."
+            ),
+            "probed": [
+                "$ANTHROPIC_API_KEY / $ANTHROPIC_AUTH_TOKEN / $CLAUDE_API_KEY",
+                os.path.join(home, ".clawmetry", "insights_config.json"),
+                os.path.join(home, "openclaw.json"),
+                os.path.join(home, "service-env", "ai.openclaw.gateway.env"),
+                os.path.join(home, "agents", "main", "agent", "auth-profiles.json"),
+            ],
+            "claude_cli_url": "https://docs.anthropic.com/en/docs/claude-code",
+        }
     return jsonify(
         {
             "available": bool(credential),
             "auth_mode": mode or "none",
             "has_cached": bool(cached),
             "cached_at": (cached or {}).get("generated_at"),
+            "setup_hint": setup_hint,
         }
     )
 


### PR DESCRIPTION
## Summary
- Drop Self-Evolve's "paste your API key in Settings" prompt — violates the zero-config principle every other surface honours.
- Widen `_load_anthropic_auth` to also pick up `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_API_KEY` env aliases and to scan the launchd / systemd `service-env/ai.openclaw.gateway.env` file where provider creds are injected on managed installs.
- `/api/selfevolve/status` now returns a structured `setup_hint` payload (headline, subhead, list of paths probed); the no-auth banner renders that as a friendly OpenClaw-setup CTA with a collapsible "Where we looked" section. Analyze button is disabled while no-auth so clicks don't produce a vague 412.

## Closes
- #1721

## Test plan
- [x] `python3 -m py_compile routes/advisor.py routes/selfevolve.py` — syntax clean.
- [x] Local `python3 dashboard.py` with real user creds (`claude-cli` OAuth profile) → `/api/selfevolve/status` returns `available: true`, `setup_hint: null` (unchanged behaviour for the happy path).
- [x] Local dashboard with `env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u CLAUDE_API_KEY OPENCLAW_HOME=/tmp/empty` → `/api/selfevolve/status` returns `available: false` with full `setup_hint.probed` list naming every path we tried.
- [x] Cloud passthrough confirmed: `cloud_route_policy/policy.py` line 1815 classifies `/api/selfevolve/status` as `oss-passthrough`; the new `setup_hint` field passes through transparently and the JS handles a missing hint defensively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)