### PR TITLE
[RELEASE] perf: migrate service-status + flow/runs to DuckDB daemon-proxy (MOAT Tier-1 sweep)

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -1927,14 +1927,32 @@ def _try_local_store_service_status():
     Returns ``None`` when no recent heartbeat exists — the legacy handler
     will then live-probe the gateway port + run pgrep, which is the right
     behaviour for a node that has never written to the local store.
+
+    MOAT Tier-1 sweep (refs #1565): route through the daemon HTTP proxy
+    first. The previous direct ``local_store.get_store(read_only=True)``
+    open silently failed on multi-process installs (DuckDB exclusive lock
+    blocks even RO opens — see memory ``reference_duckdb_process_lock.md``),
+    forcing /api/service-status to fall through to a live gateway probe
+    + pgrep on every poll for every standard launchd / systemd user.
     """
-    try:
-        from clawmetry import local_store
-        # CRITICAL: read_only=True — see #1228.
-        store = local_store.get_store(read_only=True)
-        hb_rows = store.query_heartbeats(limit=1)
-    except Exception:
-        return None
+    from routes.local_query import local_store_via_daemon
+
+    def _query(method, **kwargs):
+        """Daemon proxy first, single-process direct open as fallback."""
+        try:
+            rows = local_store_via_daemon(method, **kwargs)
+            if rows is not None:
+                return rows
+        except Exception:
+            pass
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            return getattr(store, method)(**kwargs)
+        except Exception:
+            return None
+
+    hb_rows = _query("query_heartbeats", limit=1)
     if not hb_rows:
         return None
     hb = hb_rows[0]
@@ -1956,13 +1974,10 @@ def _try_local_store_service_status():
     node_id = hb.get("node_id")
 
     def _latest_snapshot(kind: str):
-        try:
-            rows = store.query_system_snapshots(node_id=node_id, kind=kind, limit=1)
-            if not rows:
-                rows = store.query_system_snapshots(kind=kind, limit=1)
-            return rows[0] if rows else None
-        except Exception:
-            return None
+        rows = _query("query_system_snapshots", node_id=node_id, kind=kind, limit=1)
+        if not rows:
+            rows = _query("query_system_snapshots", kind=kind, limit=1)
+        return rows[0] if rows else None
 
     gw_snap = _latest_snapshot("gateway")
     if gw_snap and isinstance(gw_snap.get("data"), dict):

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -626,19 +626,43 @@ def api_flow_runs():
             since = cap_iso
             capped_at_24h = True
 
-    runs: list = []
+    # MOAT Tier-1 sweep (refs #1565): route through the daemon HTTP proxy
+    # first. The previous direct ``local_store.get_store(read_only=True)``
+    # open silently failed on multi-process installs (DuckDB exclusive lock
+    # blocks even RO opens — see memory
+    # ``reference_duckdb_process_lock.md``), so every standard launchd /
+    # systemd user saw an empty Past-flow-runs list. The daemon owns the
+    # writer connection and serves reads via HTTP from the same process.
+    runs: list | None = None
     source = "empty"
     try:
-        from clawmetry import local_store
-        store = local_store.get_store(read_only=True)
-        runs = store.query_flow_runs(
+        from routes.local_query import local_store_via_daemon
+        runs = local_store_via_daemon(
+            "query_flow_runs",
             agent_id=agent_id, since=since, until=until, limit=limit,
-        ) or []
-        if runs:
-            source = "local_store"
+        )
     except Exception:
-        runs = []
-        source = "empty"
+        runs = None
+    if runs is None:
+        # Single-process fallback (tests / dev mode with no sync daemon).
+        # NB: this path WILL fail on a multi-process install because of the
+        # DuckDB process lock — but in that scenario the daemon proxy above
+        # should always succeed. Logging here surfaces drift if it doesn't.
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            runs = store.query_flow_runs(
+                agent_id=agent_id, since=since, until=until, limit=limit,
+            ) or []
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning(
+                "api_flow_runs: daemon proxy AND direct DuckDB open both "
+                "failed — returning empty list (%s)", exc,
+            )
+            runs = []
+    if runs:
+        source = "local_store"
 
     return jsonify({
         "runs": runs,

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -349,6 +349,13 @@ _DAEMON_METHODS = frozenset({
     "query_daily_usage_splits",
     "query_heartbeats",
     "query_channels",
+    # MOAT Tier-1 sweep (refs #1565): /api/flow/runs was opening DuckDB
+    # directly via ``local_store.get_store(read_only=True)`` — fails on
+    # multi-process installs because DuckDB's exclusive lock blocks even
+    # read-only opens (per memory ``reference_duckdb_process_lock.md``).
+    # Routed through the daemon proxy so the Flow tab "Past flow runs"
+    # list serves fast on the standard launchd / systemd install.
+    "query_flow_runs",
     # Issue #1256 follow-up: alert_rules + channel_config_status. PR #1258
     # routed /api/alerts/rules and /api/channels/status through the daemon
     # proxy but missed adding the methods to the allowlist — every call

--- a/tests/test_moat_tier1_daemon_proxy_sweep.py
+++ b/tests/test_moat_tier1_daemon_proxy_sweep.py
@@ -1,0 +1,272 @@
+"""MOAT Tier-1 sweep (2026-05-19 mandate) — daemon-proxy migration for
+the last two routes that opened DuckDB directly.
+
+Both endpoints used to call ``local_store.get_store(read_only=True)`` from
+the dashboard process. On the standard launchd / systemd install where
+the sync daemon owns the writer connection, DuckDB's exclusive file lock
+blocked even read-only opens (per memory ``reference_duckdb_process_lock
+.md``), so the routes silently degraded:
+
+* ``/api/flow/runs`` — returned an empty list (``_source: 'empty'``) for
+  every standard install. The Flow tab "Past flow runs" panel painted
+  blank.
+* ``/api/service-status`` — returned ``None`` from the fast path, forced
+  fall-through to a live gateway port probe + ``pgrep`` on every poll.
+
+The fix routes both through ``routes.local_query.local_store_via_daemon``
+first, with a single-process direct-open fallback for tests / dev mode.
+These tests pin BOTH behaviours so we don't regress:
+
+1. With the daemon proxy mocked to return rows, the endpoint serves
+   those rows (proves the daemon-proxy path is wired).
+2. With the daemon proxy mocked to fail, the single-process fallback
+   still answers from a tmp DuckDB (proves graceful degradation).
+"""
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+
+def _wait_flush(store, t: float = 2.0) -> None:
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+# ── /api/flow/runs ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def flow_runs_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.infra as infra_mod
+    importlib.reload(infra_mod)
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)  # bypass 24h cap
+
+    a = Flask(__name__)
+    a.register_blueprint(infra_mod.bp_logs)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_flow_runs_uses_daemon_proxy_when_available(flow_runs_app):
+    """When ``local_store_via_daemon`` returns rows, /api/flow/runs
+    surfaces them verbatim — proves the daemon-proxy code path is wired.
+    """
+    a, _ls = flow_runs_app
+    fake_rows = [
+        {
+            "session_id":       "sess-via-daemon",
+            "agent_id":         "main",
+            "started_at":       "2026-05-19T10:00:00Z",
+            "duration_seconds": 60.0,
+            "event_count":      4,
+            "tools_called":     2,
+            "models_invoked":   1,
+            "models":           ["claude-opus-4-7"],
+            "total_cost":       0.45,
+            "channels_touched": 1,
+            "channel":          "telegram",
+            "status":           "completed",
+        }
+    ]
+    with patch(
+        "routes.local_query.local_store_via_daemon",
+        return_value=fake_rows,
+    ) as mock:
+        r = a.test_client().get("/api/flow/runs?limit=10")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    assert body["count"] == 1
+    assert body["runs"][0]["session_id"] == "sess-via-daemon"
+    # The daemon proxy MUST have been called with the right method name.
+    assert mock.called
+    assert mock.call_args.args[0] == "query_flow_runs"
+
+
+def test_flow_runs_falls_back_to_direct_open_when_daemon_unreachable(
+    flow_runs_app,
+):
+    """When the daemon proxy returns None (unreachable in tests), the
+    single-process direct-open fallback still answers from the tmp DuckDB.
+    """
+    a, ls = flow_runs_app
+    store = ls.get_store()
+    now = datetime.now(timezone.utc)
+    store.ingest({
+        "id":         "fb-1",
+        "node_id":    "n1",
+        "agent_id":   "main",
+        "session_id": "sess-fallback",
+        "event_type": "message",
+        "ts":         (now - timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "data":       {"role": "user"},
+        "cost_usd":   0.01,
+        "token_count": 10,
+        "model":      "claude-opus-4-7",
+    })
+    _wait_flush(store)
+
+    with patch(
+        "routes.local_query.local_store_via_daemon",
+        return_value=None,  # Simulate daemon unreachable
+    ):
+        r = a.test_client().get("/api/flow/runs?limit=10")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    sids = {row["session_id"] for row in body["runs"]}
+    assert "sess-fallback" in sids
+
+
+# ── /api/service-status ───────────────────────────────────────────────────
+
+
+@pytest.fixture
+def health_app(tmp_path, monkeypatch):
+    """Isolated Flask app with the health blueprint and a tmp DuckDB."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "clawmetry.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    # Match the existing fixture's dashboard stubbing.
+    import sys
+    import types
+    mod = sys.modules.get("dashboard")
+    if mod is None:
+        mod = types.ModuleType("dashboard")
+        sys.modules["dashboard"] = mod
+    monkeypatch.setattr(mod, "SESSIONS_DIR", "/nonexistent/clawmetry-test-sessions", raising=False)
+    monkeypatch.setattr(mod, "_load_gw_config", lambda: {}, raising=False)
+    monkeypatch.setattr(mod, "_detect_gateway_port", lambda: 18789, raising=False)
+    monkeypatch.setattr(mod, "_gw_invoke", lambda *a, **kw: None, raising=False)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as hp
+    importlib.reload(hp)
+
+    a = Flask(__name__)
+    a.register_blueprint(hp.bp_health)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_service_status_uses_daemon_proxy_for_heartbeats(health_app):
+    """When the daemon proxy returns a heartbeat row, /api/service-status
+    composes the response from it — proves the daemon-proxy path is wired
+    for the heartbeats query.
+    """
+    a, _ls = health_app
+    now = datetime.now(timezone.utc)
+    fake_hb = [{
+        "node_id": "agent+via-daemon",
+        "ts":      _iso(now),
+        "data":    {
+            "gateway_up": True,
+            "channels":   [
+                {"name": "telegram", "connected": True},
+            ],
+        },
+    }]
+
+    # Track method names hit so we can assert query_heartbeats fires.
+    calls: list = []
+
+    def _fake_proxy(method, **kwargs):
+        calls.append(method)
+        if method == "query_heartbeats":
+            return fake_hb
+        if method == "query_system_snapshots":
+            return []  # No snapshots → fall back to heartbeat data
+        return None
+
+    with patch(
+        "routes.local_query.local_store_via_daemon",
+        side_effect=_fake_proxy,
+    ):
+        r = a.test_client().get("/api/service-status")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    ss = body["service_status"]
+    assert ss["sync"] is True
+    assert ss["gateway"] is True
+    names = {c["name"] for c in ss["channels"]}
+    assert "telegram" in names
+    # The heartbeats query MUST be served via the daemon proxy.
+    assert "query_heartbeats" in calls
+
+
+def test_service_status_falls_back_when_daemon_unreachable(health_app):
+    """When daemon proxy returns None (unreachable), single-process
+    direct-open fallback still composes the response from the tmp store.
+    """
+    a, ls = health_app
+    store = ls.get_store()
+    now = datetime.now(timezone.utc)
+    store.ingest_heartbeat({
+        "node_id":    "agent+local-fallback",
+        "ts":         _iso(now),
+        "version":    "0.12.247",
+        "channels":   [{"name": "discord", "connected": True}],
+        "gateway_up": True,
+    })
+    _wait_flush(store)
+
+    with patch(
+        "routes.local_query.local_store_via_daemon",
+        return_value=None,  # Force fallback
+    ):
+        r = a.test_client().get("/api/service-status")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    names = {c["name"] for c in body["service_status"]["channels"]}
+    assert "discord" in names
+
+
+# ── Daemon allowlist regression guard ────────────────────────────────────
+
+
+def test_query_flow_runs_is_in_daemon_allowlist():
+    """Lock the daemon allowlist entry in place. PR #1258 → #1260 → #1266
+    cascade burned us when a new route called ``local_store_via_daemon``
+    for a method the allowlist didn't carry, and the daemon returned 400
+    silently. The MOAT linter (``scripts/lint_daemon_allowlist.py``) is
+    the primary gate, but a unit test surfaces the breakage faster in
+    the test loop.
+    """
+    from routes.local_query import _DAEMON_METHODS
+    assert "query_flow_runs" in _DAEMON_METHODS, (
+        "query_flow_runs missing from _DAEMON_METHODS — /api/flow/runs "
+        "will silently return empty results on multi-process installs."
+    )


### PR DESCRIPTION
## Summary

Final two routes that still opened DuckDB directly via `local_store.get_store(read_only=True)`. On the standard launchd / systemd install where the sync daemon owns the writer connection, DuckDB's exclusive process-level file lock blocks even read-only opens (per memory `reference_duckdb_process_lock.md`) — so both endpoints silently degraded for every multi-process user.

| Endpoint | Before (live, my dashboard) | After |
|---|---|---|
| `GET /api/flow/runs` | `_source: 'empty'`, 0 runs even with data in daemon DuckDB | `_source: 'local_store'`, served via daemon proxy |
| `GET /api/service-status` | No `_source` field, fell through to live gateway probe + pgrep | `_source: 'local_store'`, composed from DuckDB heartbeats + snapshots |

Pattern mirrors PR #1294's shim playbook + the `_try_local_store_autonomy` helper at `routes/autonomy.py:296`.

## Changes

- `routes/local_query.py` — add `query_flow_runs` to `_DAEMON_METHODS` allowlist (was missing — daemon would have 400'd the proxy call per the PR #1258 → #1260 → #1266 cascade lesson).
- `routes/infra.py:api_flow_runs` — daemon-proxy first, fallback to `local_store.get_store(read_only=True)`; logs a warning when both paths fail so drift surfaces in production logs.
- `routes/health.py:_try_local_store_service_status` — wrap heartbeat + 3× snapshot queries in a shared `_query()` helper that does daemon-proxy first, direct-open fallback.
- `tests/test_moat_tier1_daemon_proxy_sweep.py` (NEW) — 5 tests pinning both the proxy path AND the fallback degradation path for both endpoints, plus an allowlist regression guard.

## MOAT impact

Carries the Tier-1 audit list to **0 remaining real candidates**. Both endpoints flagged in the 2026-05-19 mandate sweep are migrated; the 2 outstanding 2026-05-17 candidates (`channel/bluebubbles`, `channel/tui`) were already fixed in #1586 and #1657.

Refs #1565.

## Test plan

- [x] `make lint-daemon-allowlist` — 23 distinct query_* methods all in `_DAEMON_METHODS`
- [x] `pytest tests/test_moat_tier1_daemon_proxy_sweep.py` — 5/5 green
- [x] `pytest tests/test_flow_runs_endpoint.py` — 8/8 green (no regression)
- [ ] Post-deploy: browser devtools on `/api/flow/runs` + `/api/service-status` must show `_source: local_store` in the response body
- [ ] Post-deploy: `tail ~/.clawmetry/sync.log | grep "POST /__local_query__/query_flow_runs"` shows traffic — proves daemon-proxy is hot

🤖 Generated with [Claude Code](https://claude.com/claude-code)