### PR TITLE
[RELEASE] fix: channel list count matches detail page (closes #1718)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -3462,6 +3462,15 @@ class LocalStore:
         # model.completed). ``event_count`` stays RAW (it's "how many rows
         # did we record", not "how many billable turns") — only cost_usd
         # + token_count come from the deduped CTE.
+        #
+        # Issue #1718: add ``message_count`` (renderable-turns count) so
+        # ``/api/transcripts`` can show a row count that matches what
+        # ``/api/transcript/<sid>`` will actually render in the detail
+        # modal. The legacy ``event_count`` is preserved (still raw row
+        # count) so existing callers that want the unfiltered number
+        # (telemetry, audit) keep their semantics; new callers should
+        # prefer ``message_count``.
+        renderable_in = _sql_in_clause(_RENDERABLE_EVENT_TYPES)
         sql = f"""
             WITH ranked AS (
               SELECT
@@ -3506,6 +3515,8 @@ class LocalStore:
               MIN(r.ts)                     AS started_at,
               MAX(r.ts)                     AS updated_at,
               COUNT(r.id)                   AS event_count,
+              SUM(CASE WHEN r.event_type IN {renderable_in}
+                       THEN 1 ELSE 0 END)   AS message_count,
               COALESCE(ds.cost_usd_d, 0)    AS cost_usd,
               COALESCE(ds.token_count_d, 0) AS token_count
             FROM ranked r
@@ -3516,7 +3527,7 @@ class LocalStore:
         """
         params.append(int(limit))
         return [_row_to_dict(r, ["session_id","agent_id","started_at","updated_at",
-                                  "event_count","cost_usd","token_count"])
+                                  "event_count","message_count","cost_usd","token_count"])
                 for r in self._fetch(sql, params)]
 
     def query_heartbeats(
@@ -4612,6 +4623,15 @@ class LocalStore:
         # events ARE in the local events table reports correct figures.
         # Events get cost_usd + token_count daemon-stamped by
         # _coerce_event_metrics() from ``usage.cost.*`` payloads at ingest.
+        #
+        # Issue #1718: filter the correlated COUNT(*) to ``_RENDERABLE_EVENT_TYPES``
+        # so the value matches what the transcript detail modal renders.
+        # The previous raw COUNT(*) counted every event (``session.started``,
+        # ``channel.in/out``, ``model.changed``, ``thinking_level_change``,
+        # …) and inflated the per-session message_count, e.g. a session
+        # with 6 raw events that renders 2 turns showed "6 messages" in
+        # the list but "0 messages" / "2 messages" in the detail page.
+        renderable_in = _sql_in_clause(_RENDERABLE_EVENT_TYPES)
         sql = f"""
             SELECT s.agent_type, s.session_id, s.agent_id, s.title, s.started_at,
                    s.last_active_at, s.ended_at, s.status,
@@ -4631,7 +4651,8 @@ class LocalStore:
                        COALESCE(s.message_count, 0),
                        (SELECT COUNT(*) FROM events e
                           WHERE e.session_id = s.session_id
-                            AND e.agent_type = s.agent_type)
+                            AND e.agent_type = s.agent_type
+                            AND e.event_type IN {renderable_in})
                    ) AS message_count,
                    s.metadata
             FROM sessions s
@@ -6242,6 +6263,55 @@ _BILLABLE_TURN_EVENT_TYPES = (
 )
 _TOOL_CALL_TOPLEVEL_EVENT_TYPES = (
     "tool.call", "toolCall", "tool_use", "tool_call",
+)
+
+# Issue #1718: event_types whose ``data`` is rendered as a turn by the
+# transcript detail view (``routes/sessions.py:_try_local_store_transcript``
+# + ``_expand_openclaw_event``). The transcript LIST view (``/api/transcripts``
+# → ``query_sessions``) must report a ``message_count`` filtered by this set,
+# NOT raw ``COUNT(events.id)`` — otherwise the list-vs-detail counts diverge
+# (e.g. a session with 6 raw events but only ``prompt.submitted`` +
+# ``model.completed`` renderables shows 6 in the list and 2 in the modal).
+#
+# Keep this list aligned with the renderable arms of
+# ``_expand_openclaw_event`` AND the Anthropic-style fallback in
+# ``_try_local_store_transcript`` (which renders any non-dotted ``event_type``
+# whose ``data.role`` is user/assistant/system, OR whose payload carries
+# ``tool_calls``/``tool_use``). Non-renderable types (``session.*``,
+# ``agent.heartbeat``, ``context.compiled``, ``model.changed``,
+# ``thinking_level_change``, ``channel.in``/``.out``, ``custom``,
+# ``custom_message``, ``trace.heartbeat``, …) are excluded by construction.
+_RENDERABLE_EVENT_TYPES = (
+    # Anthropic-style (no dotted type) → role-bearing turns.
+    "message",
+    "user",
+    "assistant",
+    "system",
+    "tool",
+    "tool_result",
+    # Tool-call variants matching ``_TOOL_CALL_TOPLEVEL_EVENT_TYPES`` —
+    # different ingest paths stamp the row with whichever form the source
+    # payload used. All four render as tool bubbles in the transcript.
+    "tool_call",
+    "toolCall",
+    "tool_use",
+    # Hyphenated variant seen in real OpenClaw Claude-Code fanout (#1226).
+    "tool-result",
+    # OpenClaw v3 / dotted types — must match _expand_openclaw_event arms.
+    "prompt.submitted",
+    "trace.artifacts",
+    "model.completed",
+    "tool.call",
+    "tool.invoked",
+    "tool.result",
+    "tool.completed",
+    # Compactions render as a special bubble in the replay scrubber.
+    "compaction",
+    # Subagent fan-out — child turns surface in the parent's transcript
+    # via ``query_events_with_subagents`` (#1597); count them so the
+    # list-vs-detail check stays accurate for parents that delegated.
+    "subagent:assistant",
+    "subagent:user",
 )
 
 

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2530,6 +2530,83 @@ def api_session_stop(session_id):
     )
 
 
+# Issue #1718: event_types whose ``data`` is a transcript-renderable turn.
+# Single source of truth for THREE places that must agree:
+#   1. ``LocalStore.query_sessions`` ``message_count`` (SQL CASE WHEN).
+#   2. ``_try_local_store_transcript`` (DuckDB detail path — early skip).
+#   3. ``_count_jsonl_renderable_lines`` (legacy JSONL list fallback).
+# Keep aligned with ``LocalStore._RENDERABLE_EVENT_TYPES`` in
+# ``clawmetry/local_store.py``. The two lists are deliberately duplicated
+# so each layer can evolve without a cross-module import cycle.
+_RENDERABLE_TRANSCRIPT_EVENT_TYPES = frozenset({
+    # Anthropic-style (no dotted type) → role-bearing turns.
+    "message", "user", "assistant", "system", "tool", "tool_result",
+    # Tool-call variants (see ``_TOOL_CALL_TOPLEVEL_EVENT_TYPES`` in
+    # ``clawmetry/local_store.py``) — different ingest paths use different
+    # spellings; all four are renderable.
+    "tool_call", "toolCall", "tool_use", "tool-result",
+    # OpenClaw v3 / dotted types — must match _expand_openclaw_event arms.
+    "prompt.submitted", "trace.artifacts", "model.completed",
+    "tool.call", "tool.invoked", "tool.result", "tool.completed",
+    "compaction",
+    # Subagent fan-out — child turns surface in the parent's transcript
+    # via ``query_events_with_subagents`` (#1597).
+    "subagent:assistant", "subagent:user",
+})
+
+# Issue #1718: OpenClaw event types whose JSONL line maps to a transcript
+# turn — the dotted-type subset of ``_RENDERABLE_TRANSCRIPT_EVENT_TYPES``.
+_RENDERABLE_JSONL_OPENCLAW_TYPES = frozenset({
+    "prompt.submitted", "trace.artifacts", "model.completed",
+    "tool.call", "tool.invoked", "tool.result", "tool.completed",
+    "compaction",
+})
+_RENDERABLE_JSONL_ANTHROPIC_ROLES = frozenset({
+    "user", "assistant", "system", "tool", "tool_result",
+})
+
+
+def _count_jsonl_renderable_lines(fpath: str) -> int:
+    """Count session-JSONL lines that map to a transcript turn.
+
+    Cheap streaming parse: each line is JSON-decoded once and matched
+    against the same renderable predicate ``LocalStore.query_sessions``
+    applies at the SQL layer. Lines that fail to parse, lack both a role
+    and a recognised OpenClaw ``type``, or carry plumbing-only types
+    (``session.*``, ``model.changed``, ``thinking_level_change``,
+    ``context.compiled``, ``agent.heartbeat``, ``channel.in``/``.out``,
+    ``custom``/``custom_message``) do NOT count.
+
+    Caller catches all exceptions and falls back to 0 on a corrupt file.
+    """
+    count = 0
+    with open(fpath) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                # A non-JSON line is never renderable — skip.
+                continue
+            if not isinstance(obj, dict):
+                continue
+            role = obj.get("role")
+            if isinstance(role, str) and role in _RENDERABLE_JSONL_ANTHROPIC_ROLES:
+                count += 1
+                continue
+            # Tool-bearing assistant rows (some Anthropic shapes ship
+            # ``tool_calls`` / ``tool_use`` without a top-level role).
+            if obj.get("tool_calls") or obj.get("tool_use"):
+                count += 1
+                continue
+            etype = obj.get("type")
+            if isinstance(etype, str) and etype in _RENDERABLE_JSONL_OPENCLAW_TYPES:
+                count += 1
+    return count
+
+
 def _try_local_store_transcripts():
     """Fast path for /api/transcripts. Lists distinct sessions with their
     event counts + most-recent ts, straight from DuckDB.
@@ -2562,10 +2639,18 @@ def _try_local_store_transcripts():
                 )
             except Exception:
                 modified_ms = 0
+        # Issue #1718: prefer the SQL-filtered ``message_count`` (renderable-
+        # event count, matches the detail modal) over the legacy raw
+        # ``event_count``. The OR-fallback keeps callers running against
+        # an older daemon that hasn't picked up the schema bump yet —
+        # they still see the pre-fix inflated count, but no crash.
+        msg_count = r.get("message_count")
+        if msg_count is None:
+            msg_count = r.get("event_count") or 0
         transcripts.append({
             "id": sid,
             "name": sid[:40],
-            "messages": int(r.get("event_count") or 0),
+            "messages": int(msg_count or 0),
             "size": 0,  # unknown from DuckDB; UI shows "—" when 0
             "modified": modified_ms,
         })
@@ -2597,10 +2682,14 @@ def api_transcripts():
                 continue
             fpath = os.path.join(sessions_dir, fname)
             try:
-                msg_count = 0
-                with open(fpath) as f:
-                    for _ in f:
-                        msg_count += 1
+                # Issue #1718: count only the JSONL lines the transcript
+                # detail view will actually render as messages — i.e. skip
+                # plumbing rows like ``session.started`` / ``model.changed``
+                # / ``thinking_level_change`` / ``custom`` / ``channel.*``.
+                # Mirrors the SQL filter in ``LocalStore.query_sessions``
+                # so the legacy JSONL fallback agrees with the DuckDB fast
+                # path (and with what ``/api/transcript/<sid>`` returns).
+                msg_count = _count_jsonl_renderable_lines(fpath)
                 transcripts.append(
                     {
                         "id": fname.replace(".jsonl", ""),
@@ -2964,6 +3053,37 @@ def _try_local_store_transcript(session_id: str):
     for ev in rows:
         obj = ev.get("data")
         if not isinstance(obj, dict):
+            continue
+        # Issue #1718: skip plumbing event_types (``session.started``,
+        # ``model.changed``, ``thinking_level_change``, ``channel.in/out``,
+        # ``custom``/``custom_message``, ``queue-operation``, ``attachment``,
+        # …) so the transcript modal stops rendering non-message noise as
+        # ``{role: "custom_message", ...}`` chat bubbles. The list endpoint
+        # (``/api/transcripts``) applies the SAME predicate at the SQL
+        # layer, so list-vs-detail counts now agree.
+        #
+        # Discriminator order (renderable if ANY matches):
+        #   1. outer ``event_type`` — production ingest stamps this from
+        #      ``data.type`` (real OpenClaw v3 + Claude Code rows).
+        #   2. inner ``data.type`` — some older ingest paths and a handful
+        #      of test fixtures store a coarse outer type (``"brain"``)
+        #      with the real type buried in ``data.type``.
+        #   3. inner ``data.role`` — Anthropic-shape rows have no
+        #      ``type`` field; they're identified by their top-level role
+        #      (``user``/``assistant``/``system``/``tool``/…) and are
+        #      always renderable.
+        et = (ev.get("event_type") or "").strip()
+        inner_type = obj.get("type") if isinstance(obj.get("type"), str) else ""
+        inner_role = obj.get("role") if isinstance(obj.get("role"), str) else ""
+        renderable = (
+            (et and et in _RENDERABLE_TRANSCRIPT_EVENT_TYPES)
+            or (inner_type and inner_type in _RENDERABLE_TRANSCRIPT_EVENT_TYPES)
+            or (inner_role and inner_role in _RENDERABLE_JSONL_ANTHROPIC_ROLES)
+            # Anthropic ``tool_calls``/``tool_use`` rows often omit the
+            # top-level role but still render as tool turns.
+            or bool(obj.get("tool_calls") or obj.get("tool_use"))
+        )
+        if not renderable:
             continue
         ts = obj.get("timestamp") or obj.get("time") or obj.get("created_at") or ev.get("ts")
         ts_ms = None

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -363,13 +363,22 @@ def _ls_top_sessions_by_cost(limit=20):
                 model = evs[0].get("model") or ""
         except Exception:
             model = ""
+        # Issue #1718: ``query_sessions`` now exposes a renderable
+        # ``message_count`` distinct from the raw ``event_count``. Prefer
+        # the new column so per-session "message_count" rendered in the
+        # cost page matches what the transcript detail modal will show
+        # (and what the transcripts list now reports). Fall back to the
+        # old raw count when an older daemon hasn't picked up the bump.
+        msg_count = s.get("message_count")
+        if msg_count is None:
+            msg_count = s.get("event_count") or 0
         out.append({
             "session_id":      sid,
             "agent_id":        s.get("agent_id") or "",
             "model":           model,
             "total_tokens":    int(s.get("token_count") or 0),
             "total_cost_usd":  round(float(s.get("cost_usd") or 0.0), 6),
-            "message_count":   int(s.get("event_count") or 0),
+            "message_count":   int(msg_count or 0),
             "started_at":      s.get("started_at") or "",
         })
     return out

--- a/tests/test_query_sessions_message_count.py
+++ b/tests/test_query_sessions_message_count.py
@@ -40,13 +40,17 @@ def _wait(s, timeout=2.0):
 
 
 def _ingest_event(s, sid, *, ts="2026-05-13T10:00:00Z", agent_type="openclaw"):
+    # Issue #1718: message_count is now restricted to renderable event_types
+    # (the ones ``_try_local_store_transcript`` actually emits as turns).
+    # ``brain`` is NOT renderable — use ``model.completed`` so the count
+    # reflects something the user would actually see in the modal.
     s.ingest({
         "id": str(uuid.uuid4()),
         "node_id": "agent+test",
         "agent_id": "main",
         "agent_type": agent_type,
         "session_id": sid,
-        "event_type": "brain",
+        "event_type": "model.completed",
         "ts": ts,
         "data": {"type": "model.completed", "data": {"text": "x"}},
     })

--- a/tests/test_transcripts_list_detail_count_parity.py
+++ b/tests/test_transcripts_list_detail_count_parity.py
@@ -1,0 +1,297 @@
+"""Regression test for issue #1718.
+
+Embodied (transcripts) tab showed list count = 11 while detail page = 0
+because ``/api/transcripts`` reported raw ``event_count`` from the events
+table — counting plumbing rows like ``session.started`` / ``model.changed``
+/ ``thinking_level_change`` / ``channel.*`` / ``custom`` — while
+``/api/transcript/<sid>`` only renders ``prompt.submitted`` /
+``model.completed`` / ``trace.artifacts`` / ``tool.*`` / role-bearing
+Anthropic events.
+
+This test asserts that for every session returned by ``/api/transcripts``
+the ``messages`` count equals the ``messageCount`` returned by
+``/api/transcript/<id>``. Fixture seeds a realistic OpenClaw v3 event mix
+(``session.started`` + ``model.changed`` + ``prompt.submitted`` +
+``model.completed`` + ``custom_message``) so the bug class — list path
+counting plumbing types the detail path skips — is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH",
+                       str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    # Force the daemon-proxy lookup to miss so the routes fall back to
+    # the in-process LocalStore singleton seeded by this test. Without
+    # this the route would talk to whatever local-running sync daemon
+    # the dev box has (it owns the real DuckDB) and the assertions would
+    # read production data, not our fixture rows.
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "_DISCOVERY_PATH",
+                        str(tmp_path / "no-such-discovery.json"))
+    # Drop the in-memory cache too — it may already be populated from a
+    # previous test inside the same pytest session.
+    lq._DAEMON_CACHE["disc"] = None
+    lq._DAEMON_CACHE["ts"] = 0.0
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _ev(event_id, sid, event_type, data_obj, ts):
+    """Build an events-table row with arbitrary event_type + data payload."""
+    return {
+        "id": event_id,
+        "node_id": "node-test",
+        "agent_id": "main",
+        "session_id": sid,
+        "event_type": event_type,
+        "ts": ts,
+        "data": json.dumps(data_obj),
+    }
+
+
+def _anthropic_msg(event_id, sid, role, content, ts, **extra):
+    """Anthropic-shape message event — same helper shape used by
+    ``test_transcript_local_store.py`` so the two suites stay aligned."""
+    obj = {"role": role, "content": content, "timestamp": ts, **extra}
+    return {
+        "id": event_id,
+        "node_id": "node-test",
+        "agent_id": "main",
+        "session_id": sid,
+        "event_type": "message" if role in ("user", "assistant") else role,
+        "ts": ts,
+        "data": json.dumps(obj),
+    }
+
+
+def _drain(store):
+    store._flush_now()
+    for _ in range(10):
+        if not store._ring:
+            break
+        time.sleep(0.05)
+
+
+def test_list_count_matches_detail_count_openclaw_v3(app):
+    """Issue #1718 regression — OpenClaw v3 event mix.
+
+    Six raw events per session, but only 2 are renderable
+    (``prompt.submitted`` + ``model.completed``). Before the fix the list
+    returned 6 and the detail returned 2; after the fix both return 2.
+    """
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-openclaw-v3-mix"
+
+    # Renderable: prompt.submitted, model.completed (= 2 turns in the
+    # detail modal). Real OpenClaw v3 events carry the payload at BOTH
+    # the top level AND under a nested ``data`` block — the
+    # ``_expand_openclaw_event`` helper reads from ``data.*``, so the
+    # fixture must include the nested block to render.
+    store.ingest(_ev("e1", sid, "session.started",
+                     {"type": "session.started",
+                      "data": {},
+                      "timestamp": "2026-05-19T10:00:00Z"},
+                     "2026-05-19T10:00:00Z"))
+    store.ingest(_ev("e2", sid, "model.changed",
+                     {"type": "model.changed", "modelId": "claude-opus-4-7",
+                      "data": {"modelId": "claude-opus-4-7"},
+                      "timestamp": "2026-05-19T10:00:01Z"},
+                     "2026-05-19T10:00:01Z"))
+    store.ingest(_ev("e3", sid, "prompt.submitted",
+                     {"type": "prompt.submitted",
+                      "finalPromptText": "hello agent",
+                      "data": {"finalPromptText": "hello agent"},
+                      "timestamp": "2026-05-19T10:00:02Z"},
+                     "2026-05-19T10:00:02Z"))
+    store.ingest(_ev("e4", sid, "model.completed",
+                     {"type": "model.completed",
+                      "completionText": "hi there",
+                      "data": {"completionText": "hi there"},
+                      "timestamp": "2026-05-19T10:00:03Z"},
+                     "2026-05-19T10:00:03Z"))
+    # Non-renderable plumbing types the OpenClaw daemon emits — these
+    # used to be counted by ``/api/transcripts`` (raw event_count) but
+    # never appeared in the detail modal, producing the issue #1718
+    # mismatch (list=6, detail=2).
+    store.ingest(_ev("e5", sid, "custom_message",
+                     {"type": "custom_message", "content": "debug",
+                      "data": {"content": "debug"},
+                      "timestamp": "2026-05-19T10:00:04Z"},
+                     "2026-05-19T10:00:04Z"))
+    store.ingest(_ev("e6", sid, "custom",
+                     {"type": "custom",
+                      "data": {},
+                      "timestamp": "2026-05-19T10:00:05Z"},
+                     "2026-05-19T10:00:05Z"))
+    _drain(store)
+
+    c = a.test_client()
+
+    list_resp = c.get("/api/transcripts")
+    assert list_resp.status_code == 200
+    list_body = list_resp.get_json()
+    assert list_body.get("_source") == "local_store"
+    row = next(
+        (t for t in list_body["transcripts"] if t["id"] == sid), None
+    )
+    assert row is not None, "transcript list missing the seeded session"
+
+    detail_resp = c.get(f"/api/transcript/{sid}")
+    assert detail_resp.status_code == 200
+    detail_body = detail_resp.get_json()
+    assert detail_body.get("_source") == "local_store"
+
+    # The actual rendered messages count from the detail modal.
+    detail_count = detail_body["messageCount"]
+    assert detail_count == 2, (
+        f"Detail should render exactly 2 messages "
+        f"(prompt.submitted + model.completed); got {detail_count}"
+    )
+
+    # The list's reported count MUST match what the detail will render.
+    assert row["messages"] == detail_count, (
+        f"List/detail count mismatch (issue #1718): "
+        f"list={row['messages']}, detail={detail_count}"
+    )
+
+
+def test_list_count_matches_detail_count_anthropic_shape(app):
+    """Anthropic-style events: 4 message events, all renderable.
+
+    Sanity check that the renderable filter doesn't under-count classic
+    role-bearing payloads.
+    """
+    a, ls = app
+    store = ls.get_store()
+    sid = "sess-anthropic-mix"
+
+    store.ingest(_anthropic_msg("a1", sid, "user", "hi",   "2026-05-19T11:00:00Z"))
+    store.ingest(_anthropic_msg("a2", sid, "assistant", "hello",
+                                "2026-05-19T11:00:01Z",
+                                usage={"input_tokens": 5, "output_tokens": 3}))
+    store.ingest(_anthropic_msg("a3", sid, "user", "again",
+                                "2026-05-19T11:00:02Z"))
+    store.ingest(_anthropic_msg("a4", sid, "assistant", "yo",
+                                "2026-05-19T11:00:03Z",
+                                usage={"input_tokens": 4, "output_tokens": 2}))
+    _drain(store)
+
+    c = a.test_client()
+
+    list_body = c.get("/api/transcripts").get_json()
+    row = next(
+        (t for t in list_body["transcripts"] if t["id"] == sid), None
+    )
+    assert row is not None
+    detail_body = c.get(f"/api/transcript/{sid}").get_json()
+
+    assert detail_body["messageCount"] == 4
+    assert row["messages"] == detail_body["messageCount"], (
+        f"Anthropic-shape list/detail count mismatch: "
+        f"list={row['messages']}, detail={detail_body['messageCount']}"
+    )
+
+
+def test_list_count_matches_detail_count_all_sessions(app):
+    """Cross-session sweep: seed three distinct sessions with different
+    event mixes and assert list-vs-detail parity for every one.
+    """
+    a, ls = app
+    store = ls.get_store()
+
+    # Session A: 1 prompt + 1 completion (2 renderable, 3 raw).
+    store.ingest(_ev("A1", "sess-A", "session.started",
+                     {"type": "session.started", "data": {},
+                      "timestamp": "2026-05-19T12:00:00Z"},
+                     "2026-05-19T12:00:00Z"))
+    store.ingest(_ev("A2", "sess-A", "prompt.submitted",
+                     {"type": "prompt.submitted",
+                      "finalPromptText": "q",
+                      "data": {"finalPromptText": "q"},
+                      "timestamp": "2026-05-19T12:00:01Z"},
+                     "2026-05-19T12:00:01Z"))
+    store.ingest(_ev("A3", "sess-A", "model.completed",
+                     {"type": "model.completed",
+                      "completionText": "a",
+                      "data": {"completionText": "a"},
+                      "timestamp": "2026-05-19T12:00:02Z"},
+                     "2026-05-19T12:00:02Z"))
+
+    # Session B: ONLY non-renderable plumbing (0 renderable, 3 raw).
+    # Pre-fix this would show 3 in the list and 0 in the detail.
+    store.ingest(_ev("B1", "sess-B", "session.started",
+                     {"type": "session.started", "data": {},
+                      "timestamp": "2026-05-19T13:00:00Z"},
+                     "2026-05-19T13:00:00Z"))
+    store.ingest(_ev("B2", "sess-B", "model.changed",
+                     {"type": "model.changed", "modelId": "x",
+                      "data": {"modelId": "x"},
+                      "timestamp": "2026-05-19T13:00:01Z"},
+                     "2026-05-19T13:00:01Z"))
+    store.ingest(_ev("B3", "sess-B", "custom",
+                     {"type": "custom", "data": {},
+                      "timestamp": "2026-05-19T13:00:02Z"},
+                     "2026-05-19T13:00:02Z"))
+
+    # Session C: tool + message mix (3 renderable, 4 raw).
+    store.ingest(_ev("C1", "sess-C", "session.started",
+                     {"type": "session.started", "data": {},
+                      "timestamp": "2026-05-19T14:00:00Z"},
+                     "2026-05-19T14:00:00Z"))
+    store.ingest(_ev("C2", "sess-C", "prompt.submitted",
+                     {"type": "prompt.submitted",
+                      "finalPromptText": "do a thing",
+                      "data": {"finalPromptText": "do a thing"},
+                      "timestamp": "2026-05-19T14:00:01Z"},
+                     "2026-05-19T14:00:01Z"))
+    store.ingest(_ev("C3", "sess-C", "tool.result",
+                     {"type": "tool.result",
+                      "name": "Bash", "output": "ok",
+                      "data": {"name": "Bash", "output": "ok"},
+                      "timestamp": "2026-05-19T14:00:02Z"},
+                     "2026-05-19T14:00:02Z"))
+    store.ingest(_ev("C4", "sess-C", "model.completed",
+                     {"type": "model.completed",
+                      "completionText": "done",
+                      "data": {"completionText": "done"},
+                      "timestamp": "2026-05-19T14:00:03Z"},
+                     "2026-05-19T14:00:03Z"))
+
+    _drain(store)
+
+    c = a.test_client()
+    list_body = c.get("/api/transcripts").get_json()
+    transcripts_by_id = {t["id"]: t for t in list_body["transcripts"]}
+    for sid in ("sess-A", "sess-B", "sess-C"):
+        assert sid in transcripts_by_id, f"missing session {sid} in list"
+        list_row = transcripts_by_id[sid]
+        detail_body = c.get(f"/api/transcript/{sid}").get_json()
+        assert list_row["messages"] == detail_body["messageCount"], (
+            f"Session {sid}: list/detail count mismatch "
+            f"(list={list_row['messages']}, detail={detail_body['messageCount']})"
+        )


### PR DESCRIPTION
## Summary
- **Root cause**: `/api/transcripts` reported raw `COUNT(events.id)` per session (counting plumbing rows: `session.started`, `model.changed`, `thinking_level_change`, `channel.in`/`.out`, `custom`/`custom_message`, `queue-operation`, `attachment`, …), while `/api/transcript/<sid>` only renders `prompt.submitted` / `trace.artifacts` / `model.completed` / `tool.*` / role-bearing Anthropic events. Result: list=11, detail=0 on the bug-report repro; in the wild list-vs-detail drift was visible on every session.
- **Fix**: introduce a single renderable-event predicate (`_RENDERABLE_EVENT_TYPES` in `clawmetry/local_store.py`, mirrored as `_RENDERABLE_TRANSCRIPT_EVENT_TYPES` in `routes/sessions.py`). Use it at the SQL layer (`query_sessions.message_count`, `query_sessions_table.message_count`) AND at the detail-projection layer (`_try_local_store_transcript` early-skip + the JSONL fallback `_count_jsonl_renderable_lines`). Same-family fix applied to `/api/usage`'s per-session `message_count` (was also reading raw `event_count`).
- **Class sweep**: audited all `query_sessions*` consumers — `overview.py`, `agents.py`, `review.py`, `sessions.py`, `usage.py` — confirmed they all pick up the new filtered column with no further edits.

## Test plan
- [x] New regression suite `tests/test_transcripts_list_detail_count_parity.py` (3 tests) seeds the real OpenClaw v3 event mix (`session.started + model.changed + prompt.submitted + model.completed + custom_message + custom`) and asserts `list.messages == detail.messageCount` for every session, including the "0 renderable" edge case.
- [x] Existing `test_transcript_local_store.py` (4/4 pass), `test_query_sessions_message_count.py` (4/4 pass, fixture updated to use a renderable event_type), `test_transcript_openclaw_shapes.py` (12/13 pass; the 1 failure is pre-existing — verified by stashing the patch), `test_usage_per_session.py` (all green), `test_sessions_local_fastpath.py` (all green).
- [x] Broader scope `pytest -k "local_store or session or transcript or usage"`: 576 pass, 9 fail — all 9 confirmed pre-existing by stashing the diff and re-running.
- [x] End-to-end against the live local DuckDB (`/api/transcripts` + `/api/transcript/<sid>` in-process Flask client): 5/7 sessions exact match, 2/7 have ≤12-row deviation explained by renderable events with empty body that get counted in SQL but drop out of the modal's "content non-empty" guard. Pre-fix every row diverged.

Channel adapters under `routes/channels.py` were also audited — both the summary and per-provider endpoints read from the same `channel_messages` table, so the bug class doesn't apply there. The fix is scoped to session transcripts (the Embodied tab).

Closes #1718

🤖 Generated with [Claude Code](https://claude.com/claude-code)