### PR TITLE
fix(local_store): total_tokens fallback from events in query_sessions_table

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -4584,9 +4584,23 @@ class LocalStore:
         # correlated subquery against ``events`` and fall back to the stored
         # column for agents that DO populate it (e.g. ingest from sync.py
         # where the events table may be empty).
+        #
+        # ``sessions.total_tokens`` has the same problem (#1725): sessions
+        # ingested via the gateway path (e.g. in-memory Telegram sessions)
+        # arrive with ``total_tokens=0`` because the gateway doesn't always
+        # return token counts in the session metadata. Apply the same
+        # GREATEST(stored, computed-from-events) fallback so sessions whose
+        # events ARE in the local events table report correct token totals.
         sql = f"""
             SELECT s.agent_type, s.session_id, s.agent_id, s.title, s.started_at,
-                   s.last_active_at, s.ended_at, s.status, s.total_tokens, s.cost_usd,
+                   s.last_active_at, s.ended_at, s.status,
+                   GREATEST(
+                       COALESCE(s.total_tokens, 0),
+                       COALESCE((SELECT SUM(e.token_count) FROM events e
+                                  WHERE e.session_id = s.session_id
+                                    AND e.agent_type  = s.agent_type), 0)
+                   ) AS total_tokens,
+                   s.cost_usd,
                    GREATEST(
                        COALESCE(s.message_count, 0),
                        (SELECT COUNT(*) FROM events e


### PR DESCRIPTION
Closes #1725

## Summary

- `query_sessions_table` read `s.total_tokens` directly with no fallback. Sessions ingested via the gateway path (e.g. in-memory Telegram sessions) arrive with `total_tokens=0` because gateway metadata doesn't always include token counts.
- Applied the same `GREATEST(stored, computed-from-events)` pattern already used for `message_count` (#1129 bug 4): when `s.total_tokens=0`, fall back to `SUM(events.token_count)` for that session.
- Sessions with a correctly-populated `total_tokens` are unaffected — `GREATEST` picks the stored value when it's ≥ the events-derived sum.

## Test plan

- [ ] Sessions with `total_tokens=0` in the `sessions` table but matching events in the `events` table now show a non-zero token count on the Sessions list and Overview.
- [ ] Sessions with existing correct `total_tokens` are unchanged.
- [ ] `make lint` passes (pre-existing failures only, none introduced by this change).
- [ ] `python3 -m py_compile clawmetry/local_store.py` passes.

https://claude.ai/code/session_016Am8qN8ttuNbzubexMC9gk

---
_Generated by [Claude Code](https://claude.ai/code/session_016Am8qN8ttuNbzubexMC9gk)_