### PR TITLE
fix(brain): flush stale SSE cache on reconnect

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2999,6 +2999,7 @@ var _brainFilter = 'all';
 var _brainTypeFilter = 'all';
 var _brainChannelFilter = 'all';
 var _brainAllEvents = [];
+var _brainSSEEverConnected = false;
 
 // Provider → emoji + display name. Mirrors routes/brain.py `_CHANNEL_ICON`
 // and clawmetry/sync.py `_CHANNEL_DIRS` (the canonical 21-adapter list).
@@ -4673,6 +4674,16 @@ function _startBrainSSE() {
       _updateBrainLiveIndicator(true);
       // Issue #1596 — successful reconnect clears banner + retry state.
       _resetBrainSSEReconnectState();
+      // Issue #1606 — on reconnect (not first connect), the server may have
+      // restarted with a changed event shape. Flush the stale cache and
+      // reload so chip filters don't compute against a mixed old+new array.
+      if (_brainSSEEverConnected) {
+        _brainAllEvents = [];
+        _brainFilter = 'all';
+        _brainTypeFilter = 'all';
+        loadBrainPage(true);
+      }
+      _brainSSEEverConnected = true;
     });
 
     es.onmessage = function(e) {


### PR DESCRIPTION
Closes #1606

## What

When the backend restarts (deploy, daemon restart) mid-session, the Brain SSE connection drops and reconnects. Before this fix, new events from the reconnected stream were prepended into `_brainAllEvents` which still held old-shape rows. The chip filters (`renderBrainFilterChips`, `renderBrainTypeChips`) computed from that mixed array and showed wrong source/type counts indefinitely — the 5-second polling fallback is suspended while SSE is connected, so the stale cache never self-healed.

## How

- Add `var _brainSSEEverConnected = false` alongside the other brain globals.
- In the existing `'connected'` SSE event handler inside `_startBrainSSE`: if `_brainSSEEverConnected` is already `true` (this is a *re*-connect, not the first connect), flush `_brainAllEvents`, reset `_brainFilter`/`_brainTypeFilter` to `'all'`, and call `loadBrainPage(true)` to pull a clean batch from the server.
- Set `_brainSSEEverConnected = true` so every subsequent reconnect also gets the flush.

No backend changes. One extra `/api/brain-history` fetch per server restart — negligible.

## Test plan

- `node --check clawmetry/static/js/app.js` — syntax clean
- `node tests/test_appjs_units.js` — 163/163 pass
- Manual: open Brain tab, restart the dashboard server, observe SSE reconnect — chip filters should reset to "All" and reload cleanly rather than showing stale source counts

---
_Generated by [Claude Code](https://claude.ai/code/session_017UyMxyachDovfZX9v3cvKP)_