### PR TITLE
feat(dives): prompt template + schema descriptor builder (#1001)

### DIFF
--- a/clawmetry/dives_prompt.py
+++ b/clawmetry/dives_prompt.py
@@ -1,0 +1,372 @@
+"""clawmetry/dives_prompt.py — prompt template + schema descriptor for Dives.
+
+Dives lets users ask plain-English questions; an LLM generates a SQL query
+against the local DuckDB store; the result is rendered as a chart.
+
+This module owns:
+  - ``PROMPT_VERSION`` — bump when the template changes incompatibly.
+  - ``_COL_DOCS`` — human descriptions for every column in the 9 allowlisted
+    tables. Column names + types come from ``PRAGMA table_info`` at runtime;
+    this dict is the knowledge layer the LLM can't infer from names alone.
+  - ``build_schema_descriptor(store)`` — combines runtime PRAGMA output with
+    the static column docs into a plain-text schema block.
+  - ``build_dives_prompt(question, store)`` — returns
+    ``{"system": <system prompt + schema + few-shots>, "user": <question>}``
+    ready for the Anthropic messages API (or any OpenAI-compat API).
+
+Safety: the LLM output is always run through
+``clawmetry.dives_sql_safety.validate_sql`` before execution.  The prompt
+reinforces the same constraints so the model learns to self-police (belt +
+suspenders).
+
+Sub-issue: https://github.com/vivekchand/clawmetry/issues/1001
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from clawmetry.local_store import LocalStore
+
+# ---------------------------------------------------------------------------
+# Version
+# ---------------------------------------------------------------------------
+
+# Bump when the template changes in a backward-incompatible way so callers
+# can detect that cached prompts need regeneration.
+PROMPT_VERSION = 1
+
+# ---------------------------------------------------------------------------
+# Allowlisted tables (mirrors dives_sql_safety.ALLOWED_TABLES)
+# ---------------------------------------------------------------------------
+
+# Kept here as an ordered tuple so the schema descriptor has a stable,
+# human-friendly ordering.  Kept in sync with dives_sql_safety.ALLOWED_TABLES
+# by the test suite (test_dives_tables_match_allowlist).
+_DIVES_TABLES: tuple[str, ...] = (
+    "events",
+    "sessions",
+    "daily_aggregates",
+    "memory_blobs",
+    "heartbeats",
+    "system_snapshots",
+    "openclaw_channels",
+    "crons",
+    "subagents",
+)
+
+# ---------------------------------------------------------------------------
+# Column documentation
+# ---------------------------------------------------------------------------
+
+# Human descriptions for each column in each allowlisted table.  Column names
+# and SQL types come from PRAGMA table_info at runtime; these strings are the
+# extra semantic layer the LLM can't infer from column names alone.
+_COL_DOCS: dict[str, dict[str, str]] = {
+    "events": {
+        "id":           "unique event ID",
+        "agent_type":   "agent runtime (openclaw, hermes, ...)",
+        "node_id":      "machine / container ID",
+        "agent_id":     "agent instance (usually 'main')",
+        "session_id":   "conversation session this event belongs to",
+        "workspace_id": "workspace / project ID",
+        "event_type":   "category (tool_call, llm_turn, error, ...)",
+        "ts":           "ISO-8601 timestamp of the event",
+        "data":         "BLOB - JSON payload; use json_extract_string() to query fields",
+        "cost_usd":     "LLM cost in USD (NULL for non-LLM events)",
+        "token_count":  "tokens consumed in this event",
+        "model":        "LLM model ID (e.g. claude-3-5-sonnet-20241022)",
+        "created_at":   "Unix milliseconds when the row was written",
+    },
+    "sessions": {
+        "agent_type":            "agent runtime",
+        "session_id":            "unique session identifier",
+        "node_id":               "machine / container ID",
+        "agent_id":              "agent instance (usually 'main')",
+        "workspace_id":          "workspace / project ID",
+        "title":                 "short session title (often the first user message)",
+        "started_at":            "ISO-8601 session start time",
+        "last_active_at":        "ISO-8601 most recent activity",
+        "ended_at":              "ISO-8601 session end time (NULL if still running)",
+        "status":                "running | completed | error | ...",
+        "total_tokens":          "cumulative token usage for the session",
+        "cost_usd":              "cumulative LLM cost in USD for the session",
+        "message_count":         "number of turns in the session",
+        "metadata":              "BLOB - extra metadata",
+        "updated_at":            "Unix milliseconds of last row update",
+        "outcome":               "success | failure | ambiguous (set by outcome classifier)",
+        "outcome_confidence":    "classifier confidence 0-1",
+        "outcome_classified_at": "Unix milliseconds when outcome was set",
+        "eval_score":            "LLM-as-judge score 0-5",
+        "eval_reason":           "judge's reasoning text",
+        "eval_judge_model":      "model used for evaluation",
+        "eval_scored_at":        "Unix milliseconds when eval was run",
+        "eval_rubric":           "rubric used for evaluation",
+    },
+    "daily_aggregates": {
+        "agent_type":   "agent runtime",
+        "agent_id":     "agent instance",
+        "workspace_id": "workspace / project ID",
+        "day":          "ISO date string (YYYY-MM-DD)",
+        "cost_usd":     "total LLM cost for this agent on this day",
+        "token_count":  "total tokens consumed on this day",
+        "event_count":  "number of events on this day",
+        "error_count":  "number of error events on this day",
+    },
+    "memory_blobs": {
+        "agent_type": "agent runtime",
+        "agent_id":   "agent instance",
+        "path":       "file path of the memory file (e.g. SOUL.md, MEMORY.md)",
+        "ts":         "ISO-8601 last-modified time",
+        "blob":       "BLOB - raw file contents (do not SELECT; use size_bytes instead)",
+        "sha256":     "SHA-256 content hash",
+        "size_bytes": "file size in bytes",
+        "updated_at": "Unix milliseconds when the row was written",
+    },
+    "heartbeats": {
+        "agent_type":   "agent runtime",
+        "node_id":      "machine / container ID",
+        "ts":           "ISO-8601 heartbeat timestamp",
+        "version":      "ClawMetry version string",
+        "e2e":          "TRUE if end-to-end health check passed",
+        "size_mb":      "local DuckDB file size in MB at heartbeat time",
+        "events_total": "total events in the local store at heartbeat time",
+        "data":         "BLOB - additional node metadata",
+    },
+    "system_snapshots": {
+        "agent_type": "agent runtime",
+        "node_id":    "machine / container ID",
+        "ts":         "ISO-8601 snapshot timestamp",
+        "kind":       "snapshot type (disk, cpu, ram, gpu, ...)",
+        "data":       "BLOB - JSON snapshot payload; use json_extract_string() to query",
+    },
+    "openclaw_channels": {
+        "session_id":   "session this channel metadata belongs to",
+        "channel":      "channel adapter (telegram, slack, discord, signal, ...)",
+        "chat_type":    "private | group | channel",
+        "subject":      "chat title or topic",
+        "origin_label": "human-readable source label",
+    },
+    "crons": {
+        "agent_type":  "agent runtime",
+        "cron_id":     "unique cron job ID",
+        "agent_id":    "agent instance",
+        "name":        "human-readable cron name",
+        "schedule":    "cron schedule expression (e.g. '0 9 * * 1')",
+        "enabled":     "TRUE if the cron is active",
+        "last_run_at": "ISO-8601 last execution time",
+        "last_status": "ok | error | skipped",
+        "next_run_at": "ISO-8601 next scheduled run",
+        "data":        "BLOB - extra cron metadata",
+        "updated_at":  "Unix milliseconds of last row update",
+    },
+    "subagents": {
+        "agent_type":        "agent runtime",
+        "subagent_id":       "unique sub-agent ID",
+        "parent_session_id": "session that spawned this sub-agent",
+        "spawned_at":        "ISO-8601 spawn time",
+        "ended_at":          "ISO-8601 completion time (NULL if still running)",
+        "task":              "task description given to the sub-agent",
+        "status":            "running | completed | error | ...",
+        "cost_usd":          "LLM cost incurred by this sub-agent in USD",
+        "token_count":       "tokens consumed by this sub-agent",
+        "data":              "BLOB - additional sub-agent metadata",
+        "updated_at":        "Unix milliseconds of last row update",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Chart types
+# ---------------------------------------------------------------------------
+
+SUPPORTED_CHART_TYPES: tuple[str, ...] = ("bar", "line", "pie", "table", "number")
+
+# ---------------------------------------------------------------------------
+# Few-shot examples
+# ---------------------------------------------------------------------------
+
+# Three question shapes: aggregation-over-time, ranking, group-by-count.
+# Each SQL is validated by the test suite via dives_sql_safety.validate_sql.
+_FEW_SHOT_EXAMPLES: list[dict] = [
+    {
+        "question": "Total cost per agent today",
+        "answer": {
+            "sql": (
+                "SELECT agent_type, SUM(cost_usd) AS cost "
+                "FROM events "
+                "WHERE DATE(ts) = CURRENT_DATE "
+                "  AND cost_usd IS NOT NULL "
+                "GROUP BY agent_type "
+                "ORDER BY cost DESC "
+                "LIMIT 50"
+            ),
+            "chart_type": "bar",
+            "x": "agent_type",
+            "y": "cost",
+            "title": "Total cost per agent today",
+            "description": "Cumulative LLM cost grouped by agent runtime for today.",
+        },
+    },
+    {
+        "question": "Top 10 most-used tools this week",
+        "answer": {
+            "sql": (
+                "SELECT json_extract_string(data, '$.tool_name') AS tool, "
+                "       COUNT(*) AS calls "
+                "FROM events "
+                "WHERE event_type = 'tool_call' "
+                "  AND ts >= CAST(DATE_TRUNC('week', CURRENT_DATE) AS VARCHAR) "
+                "  AND json_extract_string(data, '$.tool_name') IS NOT NULL "
+                "GROUP BY tool "
+                "ORDER BY calls DESC "
+                "LIMIT 10"
+            ),
+            "chart_type": "bar",
+            "x": "tool",
+            "y": "calls",
+            "title": "Top 10 tools this week",
+            "description": "Tool call frequency ranked highest to lowest for the current week.",
+        },
+    },
+    {
+        "question": "Sessions started in the last 24h, by status",
+        "answer": {
+            "sql": (
+                "SELECT status, COUNT(*) AS n "
+                "FROM sessions "
+                "WHERE started_at >= CAST(NOW() - INTERVAL '24 hours' AS VARCHAR) "
+                "GROUP BY status "
+                "ORDER BY n DESC "
+                "LIMIT 20"
+            ),
+            "chart_type": "pie",
+            "x": "status",
+            "y": "n",
+            "title": "Session status in last 24h",
+            "description": "Distribution of session outcomes started in the last 24 hours.",
+        },
+    },
+]
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT_HEADER = f"""\
+You are an expert SQL author for ClawMetry, a real-time AI agent observability \
+dashboard. You write SELECT queries against a local DuckDB database and return a \
+JSON envelope that the dashboard uses to render a chart.
+
+## Hard constraints
+- Only SELECT (or WITH ... SELECT) is allowed. Never INSERT, UPDATE, DELETE, DROP,
+  CREATE, ATTACH, PRAGMA, or any write/DDL statement.
+- Only query tables listed in the schema below. Never reference other tables.
+- Always add LIMIT (max 500) when the result set could be large.
+- Never use file-read functions (read_csv, read_parquet, glob, httpfs, etc.).
+- BLOB columns must not be SELECTed raw; use json_extract_string() for JSON payloads.
+- Return JSON only. No markdown fences, no explanation text outside the JSON object.
+
+## Response format (JSON, exactly these six keys)
+{{
+  "sql":         "<your SELECT query>",
+  "chart_type":  "bar | line | pie | table | number",
+  "x":           "<column name for x-axis or label>",
+  "y":           "<column name for y-axis or value>",
+  "title":       "<short chart title>",
+  "description": "<one sentence explaining what the chart shows>"
+}}
+
+chart_type guide:
+  bar    -- ranked or grouped comparisons
+  line   -- time series and trends
+  pie    -- proportions (max 8 slices; prefer bar for > 8)
+  table  -- multi-column results with no natural chart shape
+  number -- single scalar answer (COUNT, SUM, AVG, ...)
+
+## Prompt version
+PROMPT_VERSION={PROMPT_VERSION}
+""".strip()
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_schema_descriptor(store: "LocalStore | None" = None) -> str:
+    """Return a plain-text schema block for the 9 allowlisted tables.
+
+    When *store* is provided, column names and SQL types are fetched via
+    ``store.dives_table_columns(table)`` so the descriptor reflects any
+    migrations applied since this module was written.  When *store* is
+    ``None`` (tests, import-time checks) the static column list from
+    ``_COL_DOCS`` is used as the fallback.
+    """
+    lines: list[str] = ["Allowlisted tables and their columns:\n"]
+
+    for table in _DIVES_TABLES:
+        col_docs = _COL_DOCS.get(table, {})
+
+        if store is not None:
+            try:
+                pragma_rows = store.dives_table_columns(table)
+                cols = [(r["name"], r["ctype"]) for r in pragma_rows]
+            except Exception:
+                cols = [(name, "") for name in col_docs]
+        else:
+            cols = [(name, "") for name in col_docs]
+
+        lines.append(f"Table: {table}")
+        for name, ctype in cols:
+            doc = col_docs.get(name, "")
+            type_part = f" ({ctype})" if ctype else ""
+            doc_part = f"  -- {doc}" if doc else ""
+            lines.append(f"  {name}{type_part}{doc_part}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_dives_prompt(
+    question: str,
+    store: "LocalStore | None" = None,
+) -> dict[str, str]:
+    """Build the system + user messages for a Dives LLM call.
+
+    Args:
+        question: The plain-English question from the user.
+        store:    Open ``LocalStore`` instance.  When provided the schema
+                  descriptor is generated from ``PRAGMA table_info`` so it
+                  reflects any live migrations; otherwise a static descriptor
+                  is used (sufficient for unit tests).
+
+    Returns:
+        ``{"system": ..., "user": ...}`` — pass ``system`` as the Anthropic
+        ``system`` parameter and wrap ``user`` in a ``messages`` list with
+        ``role="user"``.
+
+    Raises:
+        ValueError: if *question* is empty or whitespace-only.
+    """
+    if not question or not question.strip():
+        raise ValueError("question must be a non-empty string")
+
+    schema = build_schema_descriptor(store)
+    few_shot_json = json.dumps(_FEW_SHOT_EXAMPLES, indent=2)
+
+    system = "\n\n".join([
+        _SYSTEM_PROMPT_HEADER,
+        "## Schema\n" + schema,
+        "## Few-shot examples\n" + few_shot_json,
+    ])
+
+    return {"system": system, "user": question.strip()}
+
+
+__all__ = [
+    "PROMPT_VERSION",
+    "SUPPORTED_CHART_TYPES",
+    "build_schema_descriptor",
+    "build_dives_prompt",
+]

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5864,6 +5864,25 @@ class LocalStore:
             out.append({c: _coerce_value(v) for c, v in zip(cols, r)})
         return out
 
+    def dives_table_columns(self, table: str) -> list[dict]:
+        """Return column metadata for *table* via ``PRAGMA table_info``.
+
+        Used by ``clawmetry.dives_prompt.build_schema_descriptor`` to build an
+        accurate schema block for the Dives LLM prompt.  Only column names and
+        SQL types are returned — never data values.
+
+        Raises:
+            ValueError: if *table* is not in the Dives allowlist.
+        """
+        from clawmetry.dives_sql_safety import ALLOWED_TABLES
+        if table not in ALLOWED_TABLES:
+            raise ValueError(
+                f"dives_table_columns: {table!r} is not an allowlisted Dives table"
+            )
+        rows = self._fetch(f"PRAGMA table_info('{table}')", [])
+        # PRAGMA table_info columns: cid, name, type, notnull, dflt_value, pk
+        return [{"name": r[1], "ctype": r[2]} for r in rows]
+
     # ── internals ───────────────────────────────────────────────────────
 
     def _fetch(self, sql: str, params: list[Any]) -> list[tuple]:

--- a/tests/test_dives_prompt.py
+++ b/tests/test_dives_prompt.py
@@ -1,0 +1,179 @@
+"""Tests for ``clawmetry.dives_prompt``.
+
+Covers the Dives prompt template and schema descriptor (issue #1001).  All
+tests run without a live DuckDB connection or Anthropic API key.
+
+Test groups:
+  - Constants — PROMPT_VERSION, _DIVES_TABLES alignment with ALLOWED_TABLES
+  - Few-shot examples — SQL validity, chart type validity
+  - build_schema_descriptor — static mode (no store)
+  - build_dives_prompt — shape, content, edge cases
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from clawmetry.dives_prompt import (  # noqa: E402
+    PROMPT_VERSION,
+    SUPPORTED_CHART_TYPES,
+    _DIVES_TABLES,
+    _FEW_SHOT_EXAMPLES,
+    build_dives_prompt,
+    build_schema_descriptor,
+)
+from clawmetry.dives_sql_safety import ALLOWED_TABLES, validate_sql  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_version_is_int():
+    assert isinstance(PROMPT_VERSION, int)
+    assert PROMPT_VERSION >= 1
+
+
+def test_dives_tables_match_allowlist():
+    """_DIVES_TABLES must be exactly the same set as ALLOWED_TABLES."""
+    assert set(_DIVES_TABLES) == ALLOWED_TABLES
+
+
+def test_supported_chart_types_non_empty():
+    assert len(SUPPORTED_CHART_TYPES) >= 5
+    assert "bar" in SUPPORTED_CHART_TYPES
+    assert "line" in SUPPORTED_CHART_TYPES
+    assert "number" in SUPPORTED_CHART_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Few-shot examples
+# ---------------------------------------------------------------------------
+
+
+def test_few_shot_count():
+    assert len(_FEW_SHOT_EXAMPLES) == 3
+
+
+@pytest.mark.parametrize("ex", _FEW_SHOT_EXAMPLES)
+def test_few_shot_sql_passes_validator(ex):
+    sql = ex["answer"]["sql"]
+    ok, reason = validate_sql(sql)
+    assert ok, f"Few-shot SQL failed validator: {reason!r}\nSQL:\n{sql}"
+
+
+@pytest.mark.parametrize("ex", _FEW_SHOT_EXAMPLES)
+def test_few_shot_chart_type_supported(ex):
+    ct = ex["answer"]["chart_type"]
+    assert ct in SUPPORTED_CHART_TYPES, f"Unsupported chart_type {ct!r}"
+
+
+@pytest.mark.parametrize("ex", _FEW_SHOT_EXAMPLES)
+def test_few_shot_required_keys(ex):
+    required = {"sql", "chart_type", "x", "y", "title", "description"}
+    assert required.issubset(ex["answer"].keys()), (
+        f"Missing keys: {required - ex['answer'].keys()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_schema_descriptor (static mode — no store)
+# ---------------------------------------------------------------------------
+
+
+def test_schema_descriptor_contains_all_tables():
+    desc = build_schema_descriptor(store=None)
+    for table in _DIVES_TABLES:
+        assert table in desc, f"Table {table!r} missing from descriptor"
+
+
+def test_schema_descriptor_contains_key_columns():
+    desc = build_schema_descriptor(store=None)
+    # Spot-check a handful of column names across different tables.
+    for col in ("cost_usd", "session_id", "event_type", "agent_type", "ts"):
+        assert col in desc, f"Column {col!r} missing from descriptor"
+
+
+def test_schema_descriptor_documents_blob_columns():
+    desc = build_schema_descriptor(store=None)
+    # BLOB columns must be mentioned (not silently dropped) so the LLM
+    # knows to use json_extract_string() rather than selecting them raw.
+    assert "BLOB" in desc
+
+
+def test_schema_descriptor_is_string():
+    assert isinstance(build_schema_descriptor(store=None), str)
+
+
+# ---------------------------------------------------------------------------
+# build_dives_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_dives_prompt_returns_dict():
+    result = build_dives_prompt("Total cost per agent today")
+    assert isinstance(result, dict)
+    assert "system" in result and "user" in result
+
+
+def test_build_dives_prompt_user_equals_question():
+    q = "How many sessions started in the last 7 days?"
+    result = build_dives_prompt(q)
+    assert result["user"] == q
+
+
+def test_build_dives_prompt_strips_whitespace():
+    q = "  What is the average cost per session?  "
+    result = build_dives_prompt(q)
+    assert result["user"] == q.strip()
+
+
+def test_build_dives_prompt_system_contains_prompt_version():
+    result = build_dives_prompt("anything")
+    assert "PROMPT_VERSION" in result["system"]
+
+
+def test_build_dives_prompt_system_contains_select_constraint():
+    result = build_dives_prompt("anything")
+    assert "SELECT" in result["system"]
+
+
+def test_build_dives_prompt_system_contains_chart_types():
+    result = build_dives_prompt("anything")
+    for ct in SUPPORTED_CHART_TYPES:
+        assert ct in result["system"], f"chart_type {ct!r} missing from system prompt"
+
+
+def test_build_dives_prompt_system_contains_all_tables():
+    result = build_dives_prompt("anything")
+    for table in _DIVES_TABLES:
+        assert table in result["system"], f"Table {table!r} missing from system prompt"
+
+
+def test_build_dives_prompt_system_contains_few_shots():
+    result = build_dives_prompt("anything")
+    # Each few-shot question should appear in the system prompt.
+    for ex in _FEW_SHOT_EXAMPLES:
+        assert ex["question"] in result["system"]
+
+
+def test_build_dives_prompt_empty_question_raises():
+    with pytest.raises(ValueError, match="non-empty"):
+        build_dives_prompt("")
+
+
+def test_build_dives_prompt_whitespace_only_raises():
+    with pytest.raises(ValueError, match="non-empty"):
+        build_dives_prompt("   \t\n")
+
+
+def test_build_dives_prompt_store_none_works():
+    result = build_dives_prompt("How many events today?", store=None)
+    assert result["user"] == "How many events today?"


### PR DESCRIPTION
## Summary

Implements the Dives prompt template and schema descriptor builder (issue #1001). Introduces `clawmetry/dives_prompt.py` as the single source of truth for how ClawMetry constructs the LLM prompt that turns a plain-English question into a safe DuckDB SELECT query. All 28 unit tests pass with zero live dependencies (no DuckDB connection, no Anthropic API key required).

## Changes

- **`clawmetry/dives_prompt.py`** (new) — `PROMPT_VERSION = 1`, `_COL_DOCS` with human descriptions for every column in the 9 allowlisted tables, `build_schema_descriptor(store=None)` generating the schema block from `PRAGMA table_info` at runtime (static fallback for tests), `build_dives_prompt(question, store=None)` returning `{"system": ..., "user": ...}` with hard SQL constraints + 3 few-shot examples (aggregation-over-time, ranking, group-by-count), and `SUPPORTED_CHART_TYPES`.
- **`clawmetry/local_store.py`** — adds `LocalStore.dives_table_columns(table)` that validates against the allowlist then fetches `PRAGMA table_info` via `_fetch`, keeping the raw DuckDB connection out of `dives_prompt.py`.
- **`tests/test_dives_prompt.py`** (new) — 28 tests covering constants alignment (`_DIVES_TABLES == ALLOWED_TABLES`), few-shot SQL validity via `validate_sql`, chart type validity, schema descriptor content, `build_dives_prompt` shape and content, and edge-case error handling.

## Test plan

- [ ] `python3 -m pytest tests/test_dives_prompt.py -v` — 28 passed
- [ ] `python3 -m pytest tests/test_dives_sql_safety.py -q` — 58 passed, no regression
- [ ] `python3 -c 'import ast; ast.parse(open("clawmetry/dives_prompt.py").read())'` — clean

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #1001. Marked draft for human review -- mark Ready for Review once happy.

Closes #1001

---
_Generated by [Claude Code](https://claude.ai/code/session_014DFrmRZEK8hz28jTZPNydf)_