### PR TITLE
fix: alerts modal renders at viewport center, not bottom of page

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -322,6 +322,10 @@
       cta.textContent   = 'Start 7-day free trial';
       cta.dataset.action = 'upgrade';
     }
+    // #zoom-wrapper can have CSS transform (boot animation, zoom feature).
+    // position:fixed inside a transformed ancestor is fixed to that ancestor,
+    // not the viewport. Move to body so inset:0 anchors to the viewport. (#1717)
+    if (modal.parentElement !== document.body) document.body.appendChild(modal);
     modal.style.display = 'flex';
   }
 
@@ -343,7 +347,11 @@
   // ── Editor modal (Pro tier) ───────────────────────────────────────────────
 
   function openEditor() {
-    document.getElementById('alerts-editor-modal').style.display = 'flex';
+    const modal = document.getElementById('alerts-editor-modal');
+    if (!modal) return; // server-side gated to Pro users
+    // Same viewport-escape as openPaywall (#1717).
+    if (modal.parentElement !== document.body) document.body.appendChild(modal);
+    modal.style.display = 'flex';
     document.getElementById('alerts-editor-title').textContent =
       alertsState.editorRule ? 'Edit alert rule' : 'New alert rule';
     setActiveType(alertsState.editorType);
@@ -494,4 +502,13 @@
       return iso;
     }
   }
+
+  // ESC closes whichever alerts modal is open (#1717).
+  document.addEventListener('keydown', function (e) {
+    if (e.key !== 'Escape') return;
+    const editor  = document.getElementById('alerts-editor-modal');
+    const paywall = document.getElementById('alerts-paywall-modal');
+    if (editor  && editor.style.display  !== 'none') window.alertsCloseEditor();
+    else if (paywall && paywall.style.display !== 'none') window.alertsClosePaywall();
+  });
 })();


### PR DESCRIPTION
Closes #1717

## Root cause

CSS `position: fixed` inside a transformed ancestor is fixed relative to **that ancestor**, not the viewport. `#zoom-wrapper` has two sources of CSS `transform`: the boot animation (`translateY(4px)`) and the zoom feature (`scale(X)`). When either is active, the alerts paywall/editor modals render at their natural DOM position (bottom of the document) instead of viewport-centered.

## Fix (alerts.js only, 18 lines)

- In `openPaywall()` and `openEditor()`: call `document.body.appendChild(modal)` before setting `display: flex`. Moving the element to `<body>` (which has no transform) lets `position: fixed; inset: 0` anchor to the viewport as intended. The move is idempotent — repeated opens are a no-op.
- Added a module-level `keydown` ESC handler that closes whichever alerts modal is open (third acceptance criterion).

## Test plan

- [ ] Open ClawMetry as OSS user (no cloud token) → go to Alerts tab → click **Enable** on any example rule → paywall modal opens **centered in viewport** with full backdrop
- [ ] Scroll down on the Alerts tab, then click Enable → modal still centers (scroll-position independent)
- [ ] Press **ESC** → modal closes
- [ ] Click outside the modal card → modal closes
- [ ] Open page with zoom set (if zoom feature active) → modal still centers correctly
- [ ] Pro user: click **Edit** on a rule → editor modal also centers correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01447deKoZs8QPVeuYGnZNAk)_