### PR TITLE
[RELEASE] chore(refire): v0.12.249 carries PR #1730 + #1732 (race-loss recovery, closes #1746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### MOAT EOD refire: PyPI 0.12.249 carries PR #1730 + PR #1732 (issue #1746, 2026-05-19)
+- **Why.** PRs #1723, #1730, #1732 all merged within 35s tonight. All three release-on-merge runs computed `NEW=0.12.248` from the same starting main, then each tried `twine upload --skip-existing`. PyPI accepted #1723's wheel first; the other two were silently skipped. Net result: PyPI 0.12.248 only carried #1723's alerts-modal centering fix, while main moved to v0.12.248 with the #1732 commit.
+- **What this release does.** No code change beyond this CHANGELOG entry — exists purely to re-fire `release-on-merge.yml` so v0.12.249 picks up the missing #1730 (DuckDB daemon-proxy for service-status + flow/runs) and #1732 (gateway WS `client.id="openclaw-control-ui"` so crons/sessions/messages reads return scopes) commits that already landed in main.
+- **Follow-up.** Issue #1746 tracks the underlying release workflow race; `release-on-merge.yml` needs a `concurrency` group so only one publish runs at a time, plus a hard-fail (not `--skip-existing`) on duplicate uploads.
+
 ### Gateway-tap opt-in nudge for users impacted by PR #1228 default-OFF flip (issue #1233, 2026-05-17)
 - **Why.** PR #1228 flipped the live WS gateway tap (`clawmetry/gateway_tap.py`) from default-ON to default-OFF for the OpenClaw `operator.read` scope-grant transition. Users who previously relied on the tap for inbound channel-message bodies (Telegram, Signal, Discord, etc.) silently lost capture; the fix landed but no upgrade prompt told them how to re-enable.
 - **Detection (DuckDB, cached 5m).** New `_compute_gateway_tap_comms()` in `routes/overview.py`: tap env unset + 1+ `channel_messages` rows in prior 7d + 0 rows in last 24h. Three predicates so we never nag fresh installs or users who already opted back in.


### PR DESCRIPTION
## Summary

Three [RELEASE] PRs (#1723, #1730, #1732) merged within ~35s of each other tonight. All three \`release-on-merge.yml\` runs raced, each computed \`NEW=0.12.248\`, then each ran \`twine upload --skip-existing\`. PyPI accepted PR #1723's wheel; the other two were silently skipped:

\`\`\`
WARNING  Skipping clawmetry-0.12.248-py3-none-any.whl because it appears to already exist
WARNING  Skipping clawmetry-0.12.248.tar.gz because it appears to already exist
\`\`\`

Net effect:
- \`main\` is at v0.12.248 with PR #1732's commit
- PyPI 0.12.248 = PR #1723's content ONLY (alerts modal centering)
- PR #1730 (DuckDB daemon-proxy for service-status + flow/runs) and PR #1732 (gateway WS client.id fix unblocking crons + sessions reads) are in main but NOT in any pip-installable wheel

This is doc-only — exists solely to re-fire \`release-on-merge.yml\` so v0.12.249 picks up everything currently in main. Issue #1746 tracks the underlying workflow race fix (needs \`concurrency: release-\${{ github.repository }}\` group + hard-fail on duplicate upload).

## Test plan

- [ ] release-on-merge.yml runs on merge, publishes v0.12.249 to PyPI
- [ ] \`pip install clawmetry==0.12.249\` then \`clawmetry --help\` shows v0.12.249
- [ ] Confirm 0.12.249 wheel contains both \`helpers/gateway.py\` client.id fix (from #1732) and \`routes/local_query.py\` daemon-proxy additions (from #1730)

🤖 Generated with [Claude Code](https://claude.com/claude-code)