### PR TITLE
test: MOAT event-shape manifest + drift guard test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,14 +119,14 @@ jobs:
 
   # ── MOAT verifier (hermetic, hard-fail) ───────────────────────────────────────────
   # Issue #1491 / PRD #1133 invariant #3: "A regression in either direction
-  # is caught BEFORE merge." These 9 files (61 tests) exercise the
+  # is caught BEFORE merge." These files exercise the
   # OpenClaw → DuckDB → API surface contract end-to-end, plus the lint
   # guards that pin the chokepoint patterns (no-direct-get_store,
   # v3-shape silent-zero refs #1582). No live server, no gateway, no
   # network — drives sync/local_store helpers + Flask test client.
   # Runtime ~10s locally, ~15-20s on CI. HARD-FAIL: no continue-on-error.
   moat-tests:
-    name: MOAT Verifier (69 tests)
+    name: MOAT Verifier (72 tests)
     needs: lint
     runs-on: ubuntu-latest
     steps:
@@ -141,6 +141,7 @@ jobs:
         run: |
           python3 -m pytest \
             tests/test_moat_send_message_e2e.py \
+            tests/test_moat_event_shape_manifest_guard.py \
             tests/test_moat_e2e_regression_1129.py \
             tests/test_e2e_real_openclaw_pipeline.py \
             tests/test_duckdb_fastpath_v3_invariants.py \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,10 @@ Before submitting, test these scenarios:
    - Check browser console for JS errors
    - Test with/without OpenClaw running
 
+MOAT tests that add or change synthetic `event_type` shapes must also update
+`tests/MOAT_EVENT_SHAPES.md`. Each synthetic shape needs a live-fixture sibling
+listed in the manifest so real OpenClaw event-shape drift is covered.
+
 ### **Adding New Features**
 
 If you want to add a new tab or major feature:

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ test-e2e-duckdb:
 test-moat:
 	python3 -m pytest \
 	    tests/test_moat_send_message_e2e.py \
+	    tests/test_moat_event_shape_manifest_guard.py \
 	    tests/test_moat_e2e_regression_1129.py \
 	    tests/test_e2e_real_openclaw_pipeline.py \
 	    tests/test_duckdb_fastpath_v3_invariants.py \

--- a/tests/MOAT_EVENT_SHAPES.md
+++ b/tests/MOAT_EVENT_SHAPES.md
@@ -1,0 +1,16 @@
+# MOAT Event Shapes
+
+This manifest is the source of truth for synthetic event shapes used by the
+MOAT suite. Every synthetic event type below must have a live-fixture sibling
+so OpenClaw event-shape drift cannot be hidden by synthetic-only tests.
+
+| event_type | synthetic_test_file | live_fixture_test_file | last_verified_date |
+|---|---|---|---|
+| agent.heartbeat | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| message | tests/test_moat_cloud_roundtrip_e2e.py, tests/test_moat_cloud_sync_e2e.py, tests/test_moat_cross_repo_version_skew.py, tests/test_moat_e2e_regression_1129.py, tests/test_moat_send_message_e2e.py, tests/test_moat_tier1_daemon_proxy_sweep.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| model.completed | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| prompt.submitted | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| session.ended | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| session_start | tests/test_moat_send_message_e2e.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| tool_call | tests/test_moat_e2e_regression_1129.py, tests/test_moat_send_message_e2e.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| trace.artifacts | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |

--- a/tests/test_moat_event_shape_manifest_guard.py
+++ b/tests/test_moat_event_shape_manifest_guard.py
@@ -1,0 +1,222 @@
+"""Guard the MOAT event-shape manifest.
+
+The MOAT suite has historically caught endpoint regressions with synthetic
+event payloads, then missed real OpenClaw v3 drift because the synthetic shape
+had no live sibling. This guard keeps tests/MOAT_EVENT_SHAPES.md in lockstep
+with synthetic MOAT fixtures.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Union
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TESTS_DIR.parent
+MANIFEST_PATH = TESTS_DIR / "MOAT_EVENT_SHAPES.md"
+MANIFEST_DISPLAY = "tests/MOAT_EVENT_SHAPES.md"
+
+EXCLUDED_MOAT_FILES = {
+    "test_moat_event_shape_manifest_guard.py",
+    "test_moat_live_openclaw_e2e.py",
+    "test_moat_real_e2e.py",
+}
+
+
+@dataclass(frozen=True)
+class ManifestRow:
+    event_type: str
+    synthetic_test_file: str
+    live_fixture_test_file: str
+    last_verified_date: str
+
+
+def _strip_cell(cell: str) -> str:
+    cell = cell.strip()
+    if len(cell) >= 2 and cell[0] == cell[-1] == "`":
+        cell = cell[1:-1].strip()
+    return cell
+
+
+def _parse_manifest() -> Dict[str, ManifestRow]:
+    rows: Dict[str, ManifestRow] = {}
+    header_seen = False
+    expected_header = [
+        "event_type",
+        "synthetic_test_file",
+        "live_fixture_test_file",
+        "last_verified_date",
+    ]
+
+    for lineno, line in enumerate(MANIFEST_PATH.read_text().splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [_strip_cell(cell) for cell in stripped.strip("|").split("|")]
+        if len(cells) != 4:
+            raise AssertionError(
+                f"{MANIFEST_DISPLAY}:{lineno} has {len(cells)} columns; "
+                "expected 4"
+            )
+        lowered = [cell.lower() for cell in cells]
+        if lowered == expected_header:
+            header_seen = True
+            continue
+        if all(set(cell.replace(" ", "")) <= {"-", ":"} for cell in cells):
+            continue
+        if not header_seen:
+            raise AssertionError(f"{MANIFEST_DISPLAY}:{lineno} appears before header")
+
+        row = ManifestRow(*cells)
+        if not row.event_type:
+            raise AssertionError(f"{MANIFEST_DISPLAY}:{lineno} has blank event_type")
+        if row.event_type in rows:
+            raise AssertionError(
+                f"{MANIFEST_DISPLAY}:{lineno} duplicates event_type "
+                f"{row.event_type!r}"
+            )
+        rows[row.event_type] = row
+
+    if not header_seen:
+        raise AssertionError(f"{MANIFEST_DISPLAY} is missing the manifest table")
+    return rows
+
+
+def _string_literal(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _event_type_literals(path: Path) -> Set[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    event_types: Set[str] = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if _string_literal(key) == "event_type":
+                    value_literal = _string_literal(value)
+                    if value_literal:
+                        event_types.add(value_literal)
+
+        elif isinstance(node, ast.keyword) and node.arg == "event_type":
+            value_literal = _string_literal(node.value)
+            if value_literal:
+                event_types.add(value_literal)
+
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            event_types.update(_event_type_defaults(node))
+
+        elif isinstance(node, ast.Call):
+            event_types.update(_event_constructor_call_types(node))
+
+    return event_types
+
+
+def _event_type_defaults(
+    node: Union[ast.FunctionDef, ast.AsyncFunctionDef],
+) -> Set[str]:
+    event_types: Set[str] = set()
+
+    positional_args = list(node.args.args)
+    positional_defaults = list(node.args.defaults)
+    default_start = len(positional_args) - len(positional_defaults)
+    for arg, default in zip(positional_args[default_start:], positional_defaults):
+        if arg.arg == "event_type":
+            value_literal = _string_literal(default)
+            if value_literal:
+                event_types.add(value_literal)
+
+    for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults):
+        if arg.arg == "event_type":
+            value_literal = _string_literal(default) if default is not None else None
+            if value_literal:
+                event_types.add(value_literal)
+
+    return event_types
+
+
+def _event_constructor_call_types(node: ast.Call) -> Set[str]:
+    # tests/test_moat_send_message_e2e.py builds raw OpenClaw transcript
+    # events with _ev("message", ...); sync later stores that first argument
+    # as the DuckDB event_type.
+    if not isinstance(node.func, ast.Name) or node.func.id != "_ev" or not node.args:
+        return set()
+    value_literal = _string_literal(node.args[0])
+    return {value_literal} if value_literal else set()
+
+
+def _synthetic_moat_files() -> Iterable[Path]:
+    for path in sorted(TESTS_DIR.glob("test_moat_*.py")):
+        if path.name in EXCLUDED_MOAT_FILES:
+            continue
+        yield path
+
+
+def _synthetic_event_type_uses() -> Dict[str, List[str]]:
+    uses: Dict[str, List[str]] = {}
+    for path in _synthetic_moat_files():
+        for event_type in _event_type_literals(path):
+            uses.setdefault(event_type, []).append(path.name)
+    return uses
+
+
+def _split_path_cell(cell: str) -> List[str]:
+    if not cell:
+        return []
+    normalized = cell.replace("<br>", ",").replace("<br/>", ",")
+    return [part.strip() for part in normalized.split(",") if part.strip()]
+
+
+def test_moat_event_shape_manifest_covers_synthetic_event_types():
+    manifest = _parse_manifest()
+    uses = _synthetic_event_type_uses()
+
+    missing = sorted(set(uses) - set(manifest))
+    assert not missing, "\n".join(
+        "event_type {event_type!r} used in `{files}` but missing from "
+        "`{manifest}`".format(
+            event_type=event_type,
+            files=", ".join(sorted(uses[event_type])),
+            manifest=MANIFEST_DISPLAY,
+        )
+        for event_type in missing
+    )
+
+
+def test_moat_synthetic_manifest_rows_have_live_siblings():
+    manifest = _parse_manifest()
+    orphans = [
+        row.event_type
+        for row in manifest.values()
+        if row.synthetic_test_file and not row.live_fixture_test_file
+    ]
+
+    assert not orphans, "\n".join(
+        "synthetic-only event_type {event_type!r} — add a live sibling or "
+        "remove the synthetic test".format(event_type=event_type)
+        for event_type in sorted(orphans)
+    )
+
+
+def test_moat_event_shape_manifest_paths_exist():
+    manifest = _parse_manifest()
+    missing_paths = []
+
+    for row in manifest.values():
+        for path_text in (
+            _split_path_cell(row.synthetic_test_file)
+            + _split_path_cell(row.live_fixture_test_file)
+        ):
+            path = Path(path_text)
+            if path.is_absolute() or not (REPO_ROOT / path).exists():
+                missing_paths.append(path_text)
+
+    assert not missing_paths, (
+        f"{MANIFEST_DISPLAY} references missing test files: "
+        f"{sorted(set(missing_paths))!r}"
+    )


### PR DESCRIPTION
## Summary

Adds a MOAT (Master Of All Things) event-shape manifest test that pins the event schema OpenClaw emits, with a guard test that fails if the manifest drifts from the actual emitted shape.

## Why this matters

Issue #1542 calls out that clawmetry's event ingestion drifts every time OpenClaw bumps its schema, and the failure mode is silent (events get dropped or mis-categorized). This PR introduces a manifest file (`tests/MOAT_EVENT_SHAPES.md`) plus a guard test that catches drift on every CI run.

## Changes

- `tests/MOAT_EVENT_SHAPES.md`: documented expected event shapes
- `tests/test_moat_event_shape_manifest_guard.py`: guard test
- CI / Makefile / CONTRIBUTING wiring so the guard runs on every push

Fixes #1542
