### PR TITLE
fix(tests): skip Live OpenClaw E2E gracefully when LLM key unavailable

### DIFF
--- a/tests/test_moat_live_openclaw_e2e.py
+++ b/tests/test_moat_live_openclaw_e2e.py
@@ -63,13 +63,48 @@ def _find_openclaw_binary() -> str | None:
 
 OPENCLAW_BIN = _find_openclaw_binary()
 
-pytestmark = pytest.mark.skipif(
-    OPENCLAW_BIN is None,
-    reason=(
-        "openclaw binary not on PATH; install via `npm install -g openclaw` "
-        "or use the `setup-openclaw` composite action in CI"
+
+# Real LLM credentials required: the canonical ``<sid>.jsonl`` is only
+# flushed AFTER the model call completes. With a fake key OpenClaw 401s
+# before that flush, and ``_find_session_jsonl`` then has nothing to read.
+# GitHub Actions does not expose repo secrets to PRs from forks, so an
+# external contributor's PR cannot reach this code path. Skip the whole
+# module with a clear reason instead of failing the run.
+REQUIRED_LLM_ENV = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_API_KEY")
+_FAKE_LLM_KEY_MARKERS = ("fake-clawmetry", "sk-ant-fake", "sk-fake")
+
+
+def _have_real_llm_key() -> bool:
+    """True iff env has a non-empty, non-fake LLM key on any accepted alias.
+    Fake markers are filtered so the module's own ``_send_message`` default
+    keys don't accidentally satisfy this gate."""
+    for name in REQUIRED_LLM_ENV:
+        v = os.environ.get(name, "")
+        if v and not any(m in v for m in _FAKE_LLM_KEY_MARKERS):
+            return True
+    return False
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        OPENCLAW_BIN is None,
+        reason=(
+            "openclaw binary not on PATH; install via `npm install -g openclaw` "
+            "or use the `setup-openclaw` composite action in CI"
+        ),
     ),
-)
+    pytest.mark.skipif(
+        not _have_real_llm_key(),
+        reason=(
+            "Live OpenClaw E2E needs a real LLM key (ANTHROPIC_API_KEY, "
+            "ANTHROPIC_AUTH_TOKEN, or CLAUDE_API_KEY). GitHub Actions does not "
+            "expose repo secrets to PRs from forks, so this is expected on "
+            "contributor PRs. It runs on push to main and on PRs from the main "
+            "repo where the secret is available. Set ANTHROPIC_API_KEY locally "
+            "to run it during development."
+        ),
+    ),
+]
 
 NODE_ID = "agent+moat-live-e2e"
 # Layout note: when ``OPENCLAW_STATE_DIR=<X>`` is set, OpenClaw v3 (verified

--- a/tests/test_moat_real_e2e.py
+++ b/tests/test_moat_real_e2e.py
@@ -73,13 +73,45 @@ def _find_openclaw_binary() -> str | None:
 
 OPENCLAW_BIN = _find_openclaw_binary()
 
-pytestmark = pytest.mark.skipif(
-    OPENCLAW_BIN is None,
-    reason=(
-        "openclaw binary not on PATH; install via `brew install openclaw` "
-        "or `npm install -g openclaw`. CI: use .github/actions/setup-openclaw."
+
+# Real LLM credentials required: the canonical ``<sid>.jsonl`` only flushes
+# after the model call returns. Fake key -> 401 -> no file -> fixture asserts
+# explode. GitHub Actions does not expose repo secrets to PRs from forks,
+# so external-contributor PRs cannot satisfy this. Skip the whole module
+# with a clear reason so contributor CI stays green.
+REQUIRED_LLM_ENV = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_API_KEY")
+_FAKE_LLM_KEY_MARKERS = ("fake-clawmetry", "sk-ant-fake", "sk-fake")
+
+
+def _have_real_llm_key() -> bool:
+    """True iff env has a non-empty, non-fake LLM key on any accepted alias."""
+    for name in REQUIRED_LLM_ENV:
+        v = os.environ.get(name, "")
+        if v and not any(m in v for m in _FAKE_LLM_KEY_MARKERS):
+            return True
+    return False
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        OPENCLAW_BIN is None,
+        reason=(
+            "openclaw binary not on PATH; install via `brew install openclaw` "
+            "or `npm install -g openclaw`. CI: use .github/actions/setup-openclaw."
+        ),
     ),
-)
+    pytest.mark.skipif(
+        not _have_real_llm_key(),
+        reason=(
+            "Real MOAT E2E needs a real LLM key (ANTHROPIC_API_KEY, "
+            "ANTHROPIC_AUTH_TOKEN, or CLAUDE_API_KEY). GitHub Actions does not "
+            "expose repo secrets to PRs from forks, so this is expected on "
+            "contributor PRs. It runs on push to main and on PRs from the main "
+            "repo where the secret is available. Set ANTHROPIC_API_KEY locally "
+            "to run it during development."
+        ),
+    ),
+]
 
 
 # ── Constants ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

External-contributor PRs all fail the **Live OpenClaw E2E** job. GitHub Actions does not expose repo secrets (including `ANTHROPIC_API_KEY`) to PRs from forks for security reasons, so the test that requires a real LLM round-trip 401s and the fixture explodes when it can't find the canonical session JSONL.

Evidence: PR #1750, run `26080457994` job `76683825499` — 5 errors, all from the `live` fixture, all with:

```
FailoverError: No API key found for provider "anthropic". Auth store: /tmp/pytest-of-runner/pytest-0/.../auth-profiles.json
Likely causes: (a) no real LLM key in env - set ANTHROPIC_API_KEY...
```

This blocks open-source contributor onboarding (mvanhorn just shipped 3 PRs and saw red CI).

## Fix

Module-level `pytest.mark.skipif` on both live-MOAT test files, checking for any of `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_API_KEY` (filtering known fake-key markers so the module's own fake fallbacks don't accidentally satisfy the gate). Skip reason is explicit about contributor-PR expectations and the path to run it locally.

Files touched:
- `tests/test_moat_live_openclaw_e2e.py`
- `tests/test_moat_real_e2e.py`

## What is NOT changed

- No assertion logic weakened. Tests run exactly as before when a real key is present (push to main, repo-internal PRs, nightly).
- `test_real_openclaw_binary_e2e.py` left alone (asserts on JSONL existence, works with fake keys).
- `test_eval_runner.py` left alone (already gated on `CI_ANTHROPIC_API_KEY`).
- `test_insights.py` left alone (uses `monkeypatch.setenv/delenv` for full env control).

## Test plan

- [x] Unset all LLM env vars and run pytest -> 17 skipped with the new reason
- [x] Set `ANTHROPIC_API_KEY=sk-ant-api03-...` and run pytest -> 5 passed + 1 pre-existing tool-call skip
- [x] Skip reason is visible via `-rs` and points contributors at the cause + the local-run instruction
- [ ] Watch the post-merge `Live OpenClaw E2E` job stay green on main (where the secret IS available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)