### PR TITLE
fix(sync): publish local_query.json on foreground startup so API Latency Smoke gate doesn't time out

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8610,6 +8610,34 @@ def run_daemon() -> None:
         else:
             log.warning("local_store writer warm-up failed (continuing): %s", _ws_e)
 
+    # ── Local query HTTP server (cross-process DuckDB read fix) ────────
+    # Daemon owns the DuckDB writer lock; the dashboard process can't
+    # open the same file (DuckDB exclusive lock blocks RO too). We host
+    # the same routes/local_query.py shapes on a localhost port; the
+    # dashboard's /api/local/* proxies through. Discovery+auth via
+    # ~/.clawmetry/local_query.json. Failure here is non-fatal — the
+    # dashboard falls back to direct DuckDB access (works in
+    # single-process mode).
+    #
+    # MUST run BEFORE send_heartbeat(). The initial heartbeat is a
+    # synchronous HTTP POST with `timeout=45` and up to 3 retries
+    # (1s + 2s backoff) — i.e. ~135s worst-case when the ingest URL
+    # is unreachable (offline laptop, CI smoke gate pointing at
+    # 127.0.0.1:9, cloud cold start, PgBouncer flap). API Latency
+    # Smoke gates on `~/.clawmetry/local_query.json` appearing
+    # within 30s, and the cross-process dashboard's /api/local/*
+    # proxy needs the discovery file too. Bringing the local query
+    # server up FIRST decouples local-dashboard usability from any
+    # cloud-side hiccup. Same class of "publish discovery before
+    # blocking I/O" bug as PR #1762, just on the sister code path.
+    try:
+        from clawmetry import local_server as _local_server
+        _ls_port = _local_server.start()
+        if _ls_port:
+            log.info("local query server: listening on 127.0.0.1:%d", _ls_port)
+    except Exception as _e:
+        log.warning("local query server: failed to start: %s", _e)
+
     # ── Startup sync: recent-first so Brain feed shows current activity ──
     send_heartbeat(config)
     log.info("Initial heartbeat sent")
@@ -8625,22 +8653,6 @@ def run_daemon() -> None:
     # the heartbeat response and answered via /ingest/cache (issue #1053).
     # `clawmetry/relay.py` is retained as a stub so any third-party
     # importers don't crash, but `start_relay_thread` is no longer called.
-
-    # ── Local query HTTP server (cross-process DuckDB read fix) ────────
-    # Daemon owns the DuckDB writer lock; the dashboard process can't
-    # open the same file (DuckDB exclusive lock blocks RO too). We host
-    # the same routes/local_query.py shapes on a localhost port; the
-    # dashboard's /api/local/* proxies through. Discovery+auth via
-    # ~/.clawmetry/local_query.json. Failure here is non-fatal — the
-    # dashboard falls back to direct DuckDB access (works in
-    # single-process mode).
-    try:
-        from clawmetry import local_server as _local_server
-        _ls_port = _local_server.start()
-        if _ls_port:
-            log.info("local query server: listening on 127.0.0.1:%d", _ls_port)
-    except Exception as _e:
-        log.warning("local query server: failed to start: %s", _e)
 
     # ── Live gateway WS tap (capture in-memory channel messages) ────────
     # OpenClaw stores Telegram + sibling-channel chats entirely in


### PR DESCRIPTION
## Summary
- `clawmetry sync --foreground` was calling `local_server.start()` AFTER `send_heartbeat()`, so when the ingest URL is unreachable the initial heartbeat blocked ~135s (timeout=45 x 3 retries) before the daemon ever wrote `~/.clawmetry/local_query.json`.
- API Latency Smoke / PR build is **100% deterministic failing today** (5/5 main runs + every open PR). Setup step polls for `local_query.json` with a 30s budget and times out, mislabeled "[setup-flake]" but it's a real bug.
- Same class of bug as PR #1762 (which fixed the keystone `local_server.start()` path on fresh install). This PR fixes the sister sync-daemon code path.

## Fix
Hoist the `local_server.start()` block to run BEFORE `send_heartbeat()` in `run_daemon()`. The local server has zero coupling to the cloud heartbeat — it only needs the DuckDB writer lock, which was already taken in the warm-up step immediately above.

## Repro (before)
```
HOME=$(mktemp -d) <seed minimal config.json pointing ingest at 127.0.0.1:9>
python -m clawmetry sync --foreground &
# 35s later: local_query.json still missing
```

## Verify (after)
```
[VERIFY] local_query.json appeared at 3s
{"port": 49699, "token": "...", "pid": 38932}
---- daemon log tail ----
INFO local_store writer warm-up: owned ...
INFO local query server: listening on 127.0.0.1:49699
```
3s wall clock, well under the 30s smoke-gate budget.

## Why not bump the 30s timeout?
- 30s is plenty for the real work (writer lock + thread spawn + bind-to-zero + JSON write = ~3s on my laptop). The 30s budget is correct; the daemon was simply doing 100+s of UNRELATED blocking I/O first.
- Also a separate workflow change (OAuth scope concern) and would paper over the actual bug (daemon publishing late hurts every real-world install too — cross-process dashboard reads waste up to 2 min on first fetch after restart).

## Test plan
- [x] Local repro on macOS: pre-fix → never appears, post-fix → 3s
- [x] `pytest tests/test_local_server_proxy.py clawmetry/tests/integration/test_fast_paths_cross_process.py` 8/8 PASS (the 1 flake re-runs green)
- [x] Syntax check on `clawmetry/sync.py`
- [ ] CI: API Latency Smoke + MOAT Keystone go green on this PR