### PR TITLE
fix(routes): stable JSON shape for /api/flow + /api/memory-files (closes #1763)

### DIFF
--- a/routes/infra.py
+++ b/routes/infra.py
@@ -399,7 +399,12 @@ def api_flow_events():
     # E2E health checks and non-SSE clients get a lightweight JSON response
     accept = request.headers.get("Accept", "")
     if request.method == "HEAD" or "text/event-stream" not in accept:
-        envelope = {"ok": True, "type": "flow-events", "streaming": True}
+        # Always include `events` (default empty list) so the JSON envelope
+        # shape is stable for non-SSE callers — including the keystone E2E
+        # verifier. Without this, an empty/disabled local store would emit
+        # `{ok, streaming, type}` and the verifier's shape probe would fail
+        # on the missing `.events` key (refs #1763).
+        envelope = {"ok": True, "type": "flow-events", "streaming": True, "events": []}
         # DuckDB fast path (refs #1565). Hydrate the JSON envelope with a
         # snapshot of recent flow events so callers that can't (or don't
         # want to) hold an SSE connection still see real data. SSE is the
@@ -1009,7 +1014,12 @@ def api_memory_files():
         fast = _try_local_store_memory_files()
         if fast is not None:
             return jsonify({"files": fast, "_source": "local_store"})
-    return jsonify(_d._get_memory_files())
+    # Wrap the workspace-scan fallback in the same `{files: [...]}` envelope
+    # the fast path returns, so the on-the-wire shape is stable regardless
+    # of whether the local store is enabled. The bare-list fallback used to
+    # break the keystone E2E verifier's shape probe (refs #1763) and any
+    # caller that already correctly handled the local_store shape.
+    return jsonify({"files": _d._get_memory_files()})
 
 
 @bp_memory.route("/api/file", methods=["GET"])

--- a/tests/test_flow_events_local_store_v3.py
+++ b/tests/test_flow_events_local_store_v3.py
@@ -90,7 +90,11 @@ def _row(event_id, sid, event_type, ts, data, **extra):
 def test_empty_local_store_returns_legacy_envelope(app):
     """When DuckDB has zero flow-relevant rows the helper returns None and
     the route falls back to the static envelope. Critical: this keeps the
-    legacy SSE-only behaviour intact for fresh installs."""
+    legacy SSE-only behaviour intact for fresh installs.
+
+    The envelope still includes ``events: []`` so the on-the-wire shape is
+    stable for non-SSE callers (refs #1763 — keystone E2E verifier expects
+    ``.events`` / ``.ok`` keys regardless of local-store state)."""
     a, _ls = app
     r = a.test_client().get("/api/flow-events", headers={"Accept": "application/json"})
     assert r.status_code == 200, r.get_data(as_text=True)
@@ -98,9 +102,9 @@ def test_empty_local_store_returns_legacy_envelope(app):
     assert body.get("ok") is True
     assert body.get("type") == "flow-events"
     assert body.get("streaming") is True
-    # No DuckDB rows → no _source tag, no events list.
+    # No DuckDB rows → no _source tag, but events is always present (empty).
     assert "_source" not in body
-    assert "events" not in body
+    assert body.get("events") == []
 
 
 def test_populated_local_store_hydrates_envelope(app):

--- a/tests/test_memory_local_store.py
+++ b/tests/test_memory_local_store.py
@@ -119,15 +119,15 @@ def test_memory_alias_route_also_fast_paths(app):
 
 def test_memory_files_disabled_without_flag(app_no_flag):
     """Flag unset → no fast path even if writes would land in the store.
-    Falls through to the filesystem helper which returns a bare list (no
-    `_source` tag)."""
+    Falls through to the filesystem helper, but the response is still
+    wrapped in the ``{files: [...]}`` envelope so the on-the-wire shape is
+    stable across both paths (refs #1763 — keystone E2E verifier expects
+    a dict, not the bare list the legacy helper used to return)."""
     a, _ls = app_no_flag
     body = a.test_client().get("/api/memory-files").get_json()
-    if isinstance(body, dict):
-        assert body.get("_source") != "local_store"
-    else:
-        # bare list = legacy filesystem return shape
-        assert isinstance(body, list)
+    assert isinstance(body, dict), f"expected dict envelope, got {type(body).__name__}"
+    assert body.get("_source") != "local_store"
+    assert isinstance(body.get("files"), list)
 
 
 # ── /api/file (GET) ────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1763

## What

Two real shape bugs the keystone E2E verifier was catching before PR #1762's empty-DB skip gate silenced them:

1. **`/api/flow`** — the non-SSE JSON envelope only included `events` when the local store was enabled AND returned rows. Otherwise the envelope was `{ok, streaming, type}`, missing the `.events` key the verifier expects.

2. **`/api/memory-files`** — the local-store fast path returned `{files: [...], _source: "local_store"}` but the workspace-scan fallback returned the bare list. The verifier expects a dict with `.files` regardless.

## How

- `routes/infra.py:api_flow_events` — always seed `events: []` in the envelope; local-store hydration still overwrites it with real rows when available.
- `routes/infra.py:api_memory_files` — wrap the legacy fallback in `{files: [...]}` so callers see the same shape on both paths.
- Frontend already handles both shapes (`Array.isArray(rawFiles) ? rawFiles : rawFiles.files`), so this is pure shape-narrowing.

## Tests

- Updated `test_empty_local_store_returns_legacy_envelope` to assert `events == []` (was asserting "events key absent").
- Updated `test_memory_files_disabled_without_flag` to assert the unified dict shape (was defensively accepting both shapes).

Where this will resurface, per #1763:
- Nightly drive mode (`moat-keystone-drive-nightly.yml`) seeds events first and runs without `--no-drive`; skip gate doesn't fire and these would have failed loud.
- Any real install with events would hit the silent-zeros today.

## Out of scope

The keystone "no memory files (silent zero)" failure when `files` is empty is a separate concern (real data needed) — this PR only fixes the shape, not population.