### PR TITLE
fix(ci): retry pr-screenshots push when concurrent PRs race for the shared ref

### DIFF
--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -232,7 +232,32 @@ jobs:
           cp "${GITHUB_WORKSPACE}/screenshots/manifest.json" "$DEST_DIR/manifest.json"
           git add -A
           git commit -m "visual diff: PR #${PR_NUMBER} @ ${SHORT_SHA}" || { echo "no changes"; exit 0; }
-          git push "$REMOTE" "HEAD:pr-screenshots"
+          # Concurrent PR builds race to push to the shared pr-screenshots
+          # ref. Each PR writes to its own pr/<N>/<sha>/ subdir, so rebase
+          # is always conflict-free. Retry with rebase up to 6 attempts +
+          # jittered backoff. If we still lose the race the screenshots are
+          # uploaded as a workflow artifact (step 12), so don't fail the job.
+          for attempt in 1 2 3 4 5 6; do
+            if git push "$REMOTE" "HEAD:pr-screenshots" 2>push.err; then
+              echo "pushed pr-screenshots on attempt ${attempt}"
+              exit 0
+            fi
+            cat push.err
+            if ! grep -qE "rejected|non-fast-forward|fetch first" push.err; then
+              echo "push failed for a non-race reason; bailing"
+              exit 1
+            fi
+            echo "race lost (attempt ${attempt}/6) — fetching remote tip and rebasing"
+            git fetch --depth=50 "$REMOTE" pr-screenshots
+            if ! git rebase FETCH_HEAD; then
+              git rebase --abort || true
+              echo "::warning::pr-screenshots rebase conflict (unexpected since dirs are per-PR); skipping publish"
+              exit 0
+            fi
+            sleep $(( attempt * 3 + RANDOM % 4 ))
+          done
+          echo "::warning::pr-screenshots push lost the race after 6 attempts; screenshots are still available as a workflow artifact"
+          exit 0
 
       # ── 11. Render and post the comment ─────────────────────────────────
       - name: Render comment body


### PR DESCRIPTION
## Summary
- Wrap the `git push HEAD:pr-screenshots` step in a 6-attempt retry loop with fetch+rebase+jitter-sleep between attempts.
- On exhausted retries: exit 0 with a `::warning::` instead of failing the whole workflow (screenshots are still uploaded as a workflow artifact in step 12, so consumers can fall back).
- No behaviour change on the happy path — single push, first attempt wins, exits immediately.

## Root cause (today's incident)

After I ran `gh pr update-branch` across 14 OSS PRs at 18:01Z to pick up #1764, all 14 visual-diff jobs reached the push step inside ~30s of each other. The shared `pr-screenshots` ref can only fast-forward one of them at a time; the rest got `! [rejected] HEAD -> pr-screenshots (fetch first)` and went red. User flagged this with screenshot of run 26115648501 on PR #1761.

Each PR writes to its own `pr/<N>/<sha>/` subdir, so the conflict is purely on the git ref. Rebase onto the new remote tip is always conflict-free.

## Why retry-with-rebase (not per-PR refs)

Per-PR refs (`pr-screenshots/<N>`) would be cleaner long-term but require the consumer (`.github/scripts/post-visual-diff.mjs`, PR comment renderer) to know which ref to read. Retry-with-rebase is a 26-line localised fix and downstream consumers don't move.

## Test plan
- [ ] After merge: rebase a couple of open PRs and watch their visual-diff jobs go green simultaneously instead of one-at-a-time
- [ ] No regression on the single-PR happy path (first push wins, loop exits on attempt 1)