### PR TITLE
fix(e2e): zero-click test matches new .left-nav-item.active class from IA v2

### DIFF
--- a/tests/e2e/zero-click-auth.mjs
+++ b/tests/e2e/zero-click-auth.mjs
@@ -173,10 +173,12 @@ async function testZeroClickAutoLogin() {
   );
 
   // Dashboard root rendered. The Overview tab is the canonical landing
-  // tab. The codebase uses `.nav-tab` with `onclick="switchTab('overview')"`,
-  // so match by text rather than the spec's `[data-tab="overview"]` (no
-  // such attribute exists in the embedded frontend).
-  const overviewTab = page.locator('.nav-tab.active', { hasText: /Overview/i }).first();
+  // tab. IA refactor v2 (PR #1662) introduced a sidebar `.left-nav-item`
+  // alongside the legacy top `.nav-tab`. Both classes get `.active` toggled
+  // by switchTab() — match either so this test survives nav restructures.
+  const overviewTab = page
+    .locator('.nav-tab.active, .left-nav-item.active', { hasText: /Overview/i })
+    .first();
   let overviewVisible = false;
   try {
     await overviewTab.waitFor({ state: 'visible', timeout: 5000 });
@@ -185,7 +187,7 @@ async function testZeroClickAutoLogin() {
   check(
     'Overview tab is visible — dashboard root rendered',
     overviewVisible,
-    overviewVisible ? '' : 'no .nav-tab.active with "Overview" text found'
+    overviewVisible ? '' : 'no .nav-tab.active or .left-nav-item.active with "Overview" text found'
   );
 
   // Token must be in localStorage — that's how every later /api/* call


### PR DESCRIPTION
## Summary

Zero-click Playwright E2E was looking for `.nav-tab.active` containing "Overview" to confirm the dashboard rendered. After PR #1662 (IA refactor v2) the rendered active-nav element became `.left-nav-item.active` instead. Test now matches either class.

## Why this kept biting every PR

Every PR in the last 24h had `Zero-click localhost auto-login` show `7 passed, 1 failed — no .nav-tab.active with "Overview" text found`. Pre-existing regression from when IA v2 merged. PR #1654 (whose own purpose was fixing e2e overlay assertions) couldn't unblock its own CI because the failure was upstream of its scope.

## What changed

- `tests/e2e/zero-click-auth.mjs:179` — selector goes from `.nav-tab.active` to `.nav-tab.active, .left-nav-item.active`. Both classes get `.active` toggled by `switchTab()` (see `clawmetry/static/js/app.js:852-860`), so either matching is correct.

## Verification plan

- [ ] CI green after rebase of #1654, #1661, #1715, #1726, #1729, #1664 onto main with this fix
- [ ] No regression on the other 7 zero-click assertions (XFF refuse, localStorage check, token presence)

## Out of scope

- Deleting the legacy top `.nav-tab` markup entirely. That's a follow-up cleanup once we're sure no consumer depends on it.