### PR TITLE
fix(local_store): evict cached RO handle on writer request (closes #1771)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -948,11 +948,21 @@ def get_store(read_only: bool = False) -> "LocalStore":
         with _store_lock:
             if _store_rw is None:
                 if _store_ro is not None:
-                    raise RuntimeError(
-                        "local_store: cannot open writer — read-only handle "
-                        "already exists in this process. Get a fresh process "
-                        "to write."
-                    )
+                    # Evict the cached RO handle so we can open the writer.
+                    # DuckDB forbids RW+RO on the same file in the same
+                    # process; without this eviction the daemon brick-locks
+                    # itself the moment any startup code path opens read-only
+                    # before the writer (see #1771: 21h silent ingest outage
+                    # on dev because a non-critical read cached _store_ro,
+                    # then every subsequent write attempt raised and the
+                    # daemon logged 37,728 warnings without recovering).
+                    # Future RO callers fall through to the _store_rw branch
+                    # below — the writer connection serves reads fine.
+                    try:
+                        _store_ro.stop(flush=False)
+                    except Exception:
+                        pass
+                    _store_ro = None
                 _store_rw = LocalStore(read_only=False)
                 _store_rw.start()
             return _store_rw


### PR DESCRIPTION
## Summary

Daemon bricks itself if any startup code path opens read-only before the writer is established. Once \`_store_ro\` is cached, \`get_store(read_only=False)\` raised forever and every write silently dropped.

Live ground truth from 2026-05-19 (issue #1771):
- Dev daemon logged **37,728** \"cannot open writer\" warnings over **21 hours**
- 0 events landed in DuckDB during that window
- Every dashboard read served stale JSONL fallback without flagging it
- Detail endpoints returned empty data silently (see #1772, #1773 for the envelope-correctness siblings)

## Fix

When a writer is requested and \`_store_ro\` is already cached, close the RO handle and proceed to open the writer. RO callers fall through to the \`_store_rw\` branch below — the writer connection serves reads fine. No behavior change in the happy path (writer-first or writer-only daemons).

## Verified locally

After applying the same patch to the installed wheel and killing two stale \`clawmetry --port 8906\` squatters that had held the writer lock for 21+ hours:

\`\`\`
--- new lock holder ---
COMMAND   PID  USER   FD   TYPE
python3.1 844 vivek    3u   REG   <- daemon RW

Synced 0 events, 0 log lines, 0 memory files, 0 crons, 0 cron-runs,
0 session rows, 47 telegram-out (E2E encrypted)
\`\`\`

47 backlogged Telegram messages ingested on first sync tick. Dashboard /api/system-health now serves with \`_source: daemon_proxy\`.

## Test plan

- [x] \`python3 -c 'import clawmetry.local_store'\` clean
- [x] \`tests/test_local_store_missing_writers.py\` — 14 pass, 1 pre-existing unrelated failure (\`test_existing_ingest_paths_unaffected\` — millis-epoch ts cast issue, reproduces on main without this PR; same one Eng 2/3 saw on PRs #1774/#1775)
- [x] Hot-patch verified live: daemon claimed writer, 47 messages ingested, dashboard serves daemon_proxy
- [ ] Suggest follow-up: \`_store_ro\` should never be cached in the daemon process at all — but that requires auditing every startup callsite. This PR is the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)