### PR TITLE
fix(sessions): honest _source marker when filesystem fallback fires (closes #1773)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -253,6 +253,14 @@ def api_sessions():
             _merge_unregistered_jsonls(fast["sessions"])
             capped = _apply_24h_retention_cap(fast["sessions"])
             fast["capped_at_24h"] = capped
+            # Issue #1773: honest envelope marker. The fast path tags itself
+            # local_store, but _merge_unregistered_jsonls may have appended
+            # filesystem_unregistered rows. Recompute from the row markers so
+            # operators see the actual data path (vs. a misleading
+            # "local_store" envelope that hides an ingest outage).
+            fast["_source"] = _derive_envelope_source(
+                fast["sessions"], fallback="local_store"
+            )
             return jsonify(fast)
     gw_data = _d._gw_invoke("sessions_list", {"limit": 20, "messageLimit": 0})
     if gw_data and "sessions" in gw_data:
@@ -277,6 +285,39 @@ def api_sessions():
     _merge_unregistered_jsonls(sessions)
     capped = _apply_24h_retention_cap(sessions)
     return jsonify({"sessions": sessions, "capped_at_24h": capped})
+
+
+def _derive_envelope_source(rows: list, fallback: str = "local_store") -> str:
+    """Compute an honest envelope ``_source`` from per-row markers.
+
+    Issue #1773: ``/api/sessions`` (and any other route that unions multiple
+    backends) used to hard-code ``_source: "local_store"`` at the envelope
+    while individual rows might carry a different per-row marker
+    (e.g. ``filesystem_unregistered`` from the JSONL fallback). That misled
+    operators into thinking DuckDB was the source of truth when an ingest
+    outage had silently demoted the response to a filesystem scan.
+
+    Returns:
+      - ``fallback`` when ``rows`` is empty (nothing to derive from).
+      - The single source string when every row agrees.
+      - ``"mixed:a,b,..."`` (sources sorted alphabetically) when rows disagree.
+
+    Rows without a ``_source`` key are treated as ``fallback`` so we don't
+    over-claim purity for rows that simply forgot to tag themselves.
+    """
+    if not rows:
+        return fallback
+    sources = set()
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        src = r.get("_source") or fallback
+        sources.add(src)
+    if not sources:
+        return fallback
+    if len(sources) == 1:
+        return next(iter(sources))
+    return "mixed:" + ",".join(sorted(sources))
 
 
 def _merge_unregistered_jsonls(sessions: list) -> None:

--- a/tests/test_sessions_local_fastpath.py
+++ b/tests/test_sessions_local_fastpath.py
@@ -232,3 +232,105 @@ def test_sessions_api_does_not_duplicate_registered(tmp_path, monkeypatch):
     ]
     assert len(matches) == 1, f"expected 1 row for {sid}, got {len(matches)}"
     assert matches[0]["displayName"] == "Real Session"
+
+
+def test_derive_envelope_source_unit():
+    """Issue #1773: envelope marker must reflect per-row sources honestly.
+
+    Pure unit test for ``_derive_envelope_source`` — exercises the all-same,
+    mixed, empty, and missing-marker branches without spinning up a route.
+    """
+    import routes.sessions as sessions_mod
+    derive = sessions_mod._derive_envelope_source
+
+    # Empty input falls back to the supplied default.
+    assert derive([], fallback="local_store") == "local_store"
+
+    # Homogeneous rows surface the single source unchanged.
+    assert derive([{"_source": "local_store"}, {"_source": "local_store"}]) == "local_store"
+
+    # Mixed sources emit a deterministic, alphabetically sorted "mixed:" tag.
+    mixed = derive([
+        {"_source": "local_store"},
+        {"_source": "filesystem_unregistered"},
+    ])
+    assert mixed == "mixed:filesystem_unregistered,local_store"
+
+    # Rows without a marker inherit the fallback (and merge with markers).
+    inherited = derive([
+        {"_source": "filesystem_unregistered"},
+        {"no_source_key": True},
+    ], fallback="local_store")
+    assert inherited == "mixed:filesystem_unregistered,local_store"
+
+
+def test_sessions_envelope_source_mixed_when_unregistered_present(tmp_path, monkeypatch):
+    """Issue #1773: when ``/api/sessions`` unions DuckDB rows with on-disk
+    JSONL fallbacks, the envelope ``_source`` must NOT lie. It used to
+    hard-code ``"local_store"`` even though appended rows carried
+    ``"filesystem_unregistered"``, masking ingest outages.
+    """
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    # Sessions dir with one orphan JSONL — simulates a session that wrote
+    # to disk but daemon ingest never registered it.
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    orphan_sid = "moat-eod-1773-orphan"
+    (sessions_dir / f"{orphan_sid}.jsonl").write_text("{}\n")
+    monkeypatch.setenv("OPENCLAW_SESSIONS_DIR", str(sessions_dir))
+
+    import dashboard as _d
+    monkeypatch.setattr(_d, "SESSIONS_DIR", str(sessions_dir), raising=False)
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Neutralise any real local-query daemon on the dev machine so the
+    # fast path opens our hermetic DuckDB instead of the real one. Reload
+    # the module FIRST, then patch + invalidate the cache (same dance as
+    # tests/test_moat_send_message_e2e.py — reloading after the patch
+    # would restore the production default).
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(
+        lq, "_DISCOVERY_PATH", str(tmp_path / "no-such-discovery.json"),
+        raising=True,
+    )
+    lq._invalidate_daemon_cache()
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    # Seed one DuckDB-backed session so the fast path returns non-None.
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": "sess-ingested",
+        "agent_type": "openclaw",
+        "title": "Ingested OK",
+        "started_at": "2026-05-11T10:00:00Z",
+        "last_active_at": "2026-05-11T10:30:00Z",
+    })
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    r = a.test_client().get("/api/sessions")
+    assert r.status_code == 200
+    body = r.get_json() or {}
+
+    # Both rows must be present.
+    sids = {s.get("session_id") or s.get("sessionId") for s in body.get("sessions", [])}
+    assert "sess-ingested" in sids
+    assert orphan_sid in sids
+
+    # Envelope must reflect the hybrid reality, not silently claim
+    # "local_store" purity.
+    assert body.get("_source") == "mixed:filesystem_unregistered,local_store", (
+        f"expected mixed envelope marker, got {body.get('_source')!r}"
+    )
+
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary

`/api/sessions` hard-coded `_source: "local_store"` at the envelope even when `_merge_unregistered_jsonls` had appended rows tagged `_source: "filesystem_unregistered"`. Per #1773 (found during MOAT EOD 2026-05-19 live verification, #1722), that silently masks a daemon ingestion outage: the dashboard claims DuckDB truth while the actual data path is a JSONL filesystem scan.

## Fix

Add `_derive_envelope_source(rows, fallback)` in `routes/sessions.py`:
- empty rows -> the supplied fallback
- all rows agree -> that single source
- rows disagree -> `mixed:a,b,...` (alphabetically sorted, deterministic)

`/api/sessions` now recomputes its envelope `_source` after the unregistered-JSONL merge. So when ingest is broken, the operator sees `mixed:filesystem_unregistered,local_store` instead of a misleading pure `local_store`.

Picked option 1 from the issue (degrade marker) rather than option 2 (drop the fallback) so we keep header-only recovery during ingest outages — dropping it would make the outage worse, not better.

## Tests

- `test_derive_envelope_source_unit` — pure unit test for the helper covering empty, homogeneous, mixed, and missing-marker branches.
- `test_sessions_envelope_source_mixed_when_unregistered_present` — route-level regression: seeds one DuckDB session + one orphan JSONL, asserts envelope reads `mixed:filesystem_unregistered,local_store` and both rows are present.

Existing `tests/test_oss_routes_source_canary.py` keeps passing (its hermetic env has an empty sessions dir, so no unregistered rows append and envelope stays `local_store`).

## Out of scope (future work)

Grepped `_source.*local_store` and found 6 other route files that hard-code an envelope `_source: "local_store"`:
- `routes/nemoclaw.py:112`
- `routes/meta.py:949`, `:1072`
- `routes/bootstrap.py:97`, `:127`
- `routes/sessions.py:535` (by-type — does not currently union non-local rows, so envelope is honest)

None of those currently union rows from a different backend, so they aren't lying today. If a future PR adds a fallback-merge to any of them, route them through `_derive_envelope_source` (or lift it into a shared helper). Logged here so the next person doesn't have to re-grep.

## Closes

closes #1773