### PR TITLE
feat(usage): /api/usage/cache-trends DuckDB fast path (Tier-1 from #1778)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5527,6 +5527,195 @@ class LocalStore:
 
         return sorted(day_bucket.values(), key=lambda r: r["day"], reverse=True)
 
+    def query_cache_metrics(
+        self,
+        *,
+        days: int = 14,
+        agent_id: str | None = None,
+        limit_events: int = 50000,
+    ) -> list[dict[str, Any]]:
+        """Per-(day, model) prompt-cache + cost split for /api/usage/cache-trends.
+
+        Tier-1 surface from the 2026-05-19 DuckDB coverage audit (issue
+        #1778). The JSONL walker in ``routes/usage.py:api_usage_cache_trends``
+        re-parses every session file on every call; this helper streams the
+        same numbers off the events table in one SQL pass + a single Python
+        bucketing pass, with the same v3 sibling-pair dedupe as
+        ``query_daily_usage_splits``.
+
+        Returns ``[{day:'YYYY-MM-DD', model, input_tokens, output_tokens,
+        cache_read_tokens, cache_write_tokens, input_cost, output_cost,
+        cache_read_cost, cache_write_cost, total_cost}]`` sorted by day
+        desc, model asc. Empty list when no billable-turn events fall in
+        the window (caller falls back to the legacy walker).
+
+        Dedup: real OpenClaw v3 emits BOTH an ``assistant`` (Anthropic-SDK
+        envelope, carries cache splits) AND a sibling ``model.completed``
+        (slim, no cache) for the SAME LLM turn ~100-300 ms apart. Counting
+        both doubles input/output and inflates total_cost. Mirrors the
+        bucket-and-pick-richest logic in ``query_daily_usage_splits`` so
+        the two surfaces report consistent splits.
+        """
+        from datetime import datetime as _dt, timedelta as _td, timezone as _tz
+
+        try:
+            window_days = max(1, min(int(days), 365))
+        except (TypeError, ValueError):
+            window_days = 14
+        since_iso = (
+            _dt.now(_tz.utc) - _td(days=window_days)
+        ).isoformat()
+
+        clauses: list[str] = [f"event_type IN {_sql_in_clause(_BILLABLE_TURN_EVENT_TYPES)}"]
+        params: list[Any] = []
+        if agent_id:
+            clauses.append("agent_id = ?")
+            params.append(agent_id)
+        clauses.append("ts >= ?")
+        params.append(since_iso)
+        where = "WHERE " + " AND ".join(clauses)
+        sql = f"""
+            SELECT id, ts, session_id, event_type, data, cost_usd, model
+            FROM events
+            {where}
+            ORDER BY ts ASC, id ASC
+            LIMIT ?
+        """
+        params.append(int(max(1, limit_events)))
+        rows = self._fetch(sql, params)
+
+        DEDUP_WINDOW_S = 1
+
+        def _priority(et: str | None) -> int:
+            et = (et or "").lower()
+            if et in ("assistant", "subagent:assistant", "message"):
+                return 2
+            if et == "model.completed":
+                return 1
+            return 0
+
+        def _ts_to_epoch_s(ts_str: str) -> int | None:
+            if not ts_str:
+                return None
+            try:
+                s = ts_str.replace("Z", "+00:00") if ts_str.endswith("Z") else ts_str
+                return int(_dt.fromisoformat(s).timestamp())
+            except (TypeError, ValueError):
+                return None
+
+        chosen: dict[tuple[str, int], dict[str, Any]] = {}
+        loose: list[dict[str, Any]] = []
+
+        for ev_id, ts, sid, etype, raw, col_cost, model_col in rows:
+            data: dict[str, Any] = {}
+            if raw is not None:
+                try:
+                    text = (
+                        raw.decode("utf-8")
+                        if isinstance(raw, (bytes, bytearray))
+                        else raw
+                    )
+                    parsed = json.loads(text) if text else {}
+                    if isinstance(parsed, dict):
+                        data = parsed
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    continue
+            splits = _extract_usage_splits(data)
+            if splits["input_tokens"] <= 0 and splits["output_tokens"] <= 0:
+                continue
+            day = (ts or "")[:10]
+            if not day:
+                continue
+
+            cost_split = _extract_usage_cost_split(data)
+            try:
+                col_cost_f = float(col_cost or 0.0)
+            except (TypeError, ValueError):
+                col_cost_f = 0.0
+            # Prefer the per-component cost block from the data blob. Fall
+            # back to the daemon-stamped ``cost_usd`` column when no split
+            # is available (UI still gets a sensible total bar).
+            if cost_split["total"] <= 0 and col_cost_f > 0:
+                cost_split = {
+                    "input": 0.0, "output": 0.0,
+                    "cache_read": 0.0, "cache_write": 0.0,
+                    "total": col_cost_f,
+                }
+
+            # Resolve a model label. Prefer the dedicated ``model`` column
+            # (stamped by sync.py at ingest), fall back to data.message.model
+            # for older daemons that didn't populate the column.
+            model = (model_col or "").strip()
+            if not model:
+                msg = data.get("message") if isinstance(data, dict) else None
+                if isinstance(msg, dict):
+                    model = (msg.get("model") or "").strip()
+            if not model:
+                model = "unknown"
+
+            payload = {
+                "priority":   _priority(etype),
+                "splits":     splits,
+                "cost_split": cost_split,
+                "day":        day,
+                "model":      model,
+                "etype":      etype,
+                "ts":         ts,
+            }
+
+            epoch_s = _ts_to_epoch_s(ts)
+            if epoch_s is None or not sid:
+                loose.append(payload)
+                continue
+
+            collision_key: tuple[str, int] | None = None
+            for delta in range(-DEDUP_WINDOW_S, DEDUP_WINDOW_S + 1):
+                k = (sid, epoch_s + delta)
+                if k in chosen:
+                    collision_key = k
+                    break
+
+            if collision_key is None:
+                chosen[(sid, epoch_s)] = payload
+                continue
+
+            existing = chosen[collision_key]
+            if payload["priority"] > existing["priority"]:
+                chosen[collision_key] = payload
+
+        # Aggregate into (day, model) buckets.
+        bucket: dict[tuple[str, str], dict[str, Any]] = {}
+        for p in list(chosen.values()) + loose:
+            key = (p["day"], p["model"])
+            row = bucket.setdefault(key, {
+                "day": p["day"],
+                "model": p["model"],
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "input_cost": 0.0,
+                "output_cost": 0.0,
+                "cache_read_cost": 0.0,
+                "cache_write_cost": 0.0,
+                "total_cost": 0.0,
+            })
+            row["input_tokens"]       += p["splits"]["input_tokens"]
+            row["output_tokens"]      += p["splits"]["output_tokens"]
+            row["cache_read_tokens"]  += p["splits"]["cache_read_tokens"]
+            row["cache_write_tokens"] += p["splits"]["cache_write_tokens"]
+            row["input_cost"]         += p["cost_split"]["input"]
+            row["output_cost"]        += p["cost_split"]["output"]
+            row["cache_read_cost"]    += p["cost_split"]["cache_read"]
+            row["cache_write_cost"]   += p["cost_split"]["cache_write"]
+            row["total_cost"]         += p["cost_split"]["total"]
+
+        return sorted(
+            bucket.values(),
+            key=lambda r: (r["day"], r["model"]),
+            reverse=False,
+        )
+
     def query_aggregates(
         self,
         *,
@@ -6589,6 +6778,72 @@ def _extract_usage_cost(data: dict) -> float:
         elif isinstance(cost, (int, float)) and cost > 0:
             return float(cost)
     return 0.0
+
+
+def _extract_usage_cost_split(data: dict) -> dict[str, float]:
+    """Per-component cost breakdown ({input, output, cache_read, cache_write,
+    total}) extracted from an event ``data`` blob.
+
+    Companion to ``_extract_usage_cost`` — the JSONL walker in
+    ``api_usage_cache_trends`` needs the four sub-costs (not just the
+    total) so the cache-savings line can compute ``cache_read_cost`` vs.
+    ``input_cost``. Walks the same shape priority list:
+    ``data.message.usage.cost``, ``data.usage.cost``,
+    ``data.promptCache.lastCallUsage.cost``. First envelope whose
+    ``total`` (or sum of sub-keys) is > 0 wins.
+
+    Returns all-zero floats on absence so the caller can simply ``+=``.
+    """
+    out = {
+        "input": 0.0,
+        "output": 0.0,
+        "cache_read": 0.0,
+        "cache_write": 0.0,
+        "total": 0.0,
+    }
+    if not isinstance(data, dict):
+        return out
+
+    candidates: list[Any] = []
+    msg = data.get("message")
+    if isinstance(msg, dict):
+        u = msg.get("usage")
+        if isinstance(u, dict):
+            candidates.append(u.get("cost"))
+    u2 = data.get("usage")
+    if isinstance(u2, dict):
+        candidates.append(u2.get("cost"))
+    pc = data.get("promptCache")
+    if isinstance(pc, dict):
+        lcu = pc.get("lastCallUsage")
+        if isinstance(lcu, dict):
+            candidates.append(lcu.get("cost"))
+
+    def _f(v: Any) -> float:
+        try:
+            return float(v or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    for cost in candidates:
+        if not isinstance(cost, dict):
+            continue
+        in_c   = _f(cost.get("input"))
+        out_c  = _f(cost.get("output"))
+        cr_c   = _f(cost.get("cacheRead"))
+        cw_c   = _f(cost.get("cacheWrite"))
+        tot_c  = _f(cost.get("total"))
+        if tot_c <= 0:
+            tot_c = in_c + out_c + cr_c + cw_c
+        if tot_c > 0:
+            return {
+                "input": in_c,
+                "output": out_c,
+                "cache_read": cr_c,
+                "cache_write": cw_c,
+                "total": tot_c,
+            }
+    return out
 
 
 _READ_TOOL_NAMES = frozenset({"read", "readfile", "read_file"})

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -3156,6 +3156,78 @@ def _summarise_cache_bucket(label, b, key):
     }
 
 
+def _try_local_store_cache_trends(days: int):
+    """Fast path for /api/usage/cache-trends (issue #1778, Tier-1 #1).
+
+    Mirrors the JSONL walker shape exactly: ``{days, daily[], by_model[],
+    totals, recommendations}`` where every bucket carries the same
+    ``input_tokens / output_tokens / cache_read_tokens / cache_write_tokens
+    + per-component cost + cache_hit_ratio_pct + est_savings`` columns the
+    legacy path emits. Backed by ``LocalStore.query_cache_metrics`` which
+    runs one SQL pass and applies the same v3 sibling-pair dedupe
+    (``assistant`` + ``model.completed`` 100-300 ms apart) as
+    ``query_daily_usage_splits`` — without dedupe the cache-hit ratio
+    silently lies by 2×.
+
+    Returns ``None`` to defer to the legacy walker when the store is
+    unreachable. Returns the full envelope (with ``_source: 'local_store'``
+    canary) when the store IS reachable, even if no events match — that
+    keeps the audit grep at ``reference_duckdb_coverage_audit.md`` from
+    re-categorising the surface as ``JSONL_FALLBACK_ONLY``.
+    """
+    rows = _ls_call("query_cache_metrics", days=int(days))
+    if rows is None:
+        return None
+
+    daily: dict = {}
+    by_model: dict = {}
+    for r in rows:
+        d_key = r.get("day", "")
+        m_key = r.get("model", "unknown")
+        for bucket in (
+            daily.setdefault(d_key, _empty_cache_bucket()),
+            by_model.setdefault(m_key, _empty_cache_bucket()),
+        ):
+            bucket["input_tokens"]       += int(r.get("input_tokens") or 0)
+            bucket["output_tokens"]      += int(r.get("output_tokens") or 0)
+            bucket["cache_read_tokens"]  += int(r.get("cache_read_tokens") or 0)
+            bucket["cache_write_tokens"] += int(r.get("cache_write_tokens") or 0)
+            bucket["input_cost"]         += float(r.get("input_cost") or 0.0)
+            bucket["output_cost"]        += float(r.get("output_cost") or 0.0)
+            bucket["cache_read_cost"]    += float(r.get("cache_read_cost") or 0.0)
+            bucket["cache_write_cost"]   += float(r.get("cache_write_cost") or 0.0)
+            bucket["total_cost"]         += float(r.get("total_cost") or 0.0)
+
+    today = datetime.now()
+    daily_out = []
+    for i in range(days - 1, -1, -1):
+        d = today - timedelta(days=i)
+        ds = d.strftime("%Y-%m-%d")
+        daily_out.append(
+            _summarise_cache_bucket(ds, daily.get(ds, _empty_cache_bucket()), key="date")
+        )
+
+    by_model_out = [
+        _summarise_cache_bucket(m, b, key="model")
+        for m, b in sorted(by_model.items(), key=lambda kv: -kv[1]["total_cost"])
+    ]
+
+    totals_bucket = _empty_cache_bucket()
+    for b in daily.values():
+        for k in totals_bucket:
+            totals_bucket[k] += b[k]
+    totals_out = _summarise_cache_bucket("totals", totals_bucket, key="label")
+
+    return {
+        "days": days,
+        "daily": daily_out,
+        "by_model": by_model_out,
+        "totals": totals_out,
+        "recommendations": _cache_recommendations(totals_out, by_model_out),
+        "_source": "local_store",
+    }
+
+
 def _cache_recommendations(totals, by_model):
     tips = []
     hit = totals.get("cache_hit_ratio_pct", 0.0)
@@ -3230,6 +3302,16 @@ def api_usage_cache_trends():
         days = max(1, min(int(request.args.get("days", "14")), 90))
     except ValueError:
         days = 14
+
+    # Tier-1 DuckDB fast path (issue #1778 audit #1). Same dedupe shape as
+    # ``_try_local_store_usage_forecast`` — one SQL pass + sibling-pair
+    # collapse, vs. the JSONL walker below which re-parses every session
+    # file on every call. Returns ``None`` to defer when the store is
+    # unreachable.
+    if is_local_store_read_enabled():
+        fast = _try_local_store_cache_trends(days)
+        if fast is not None:
+            return jsonify(fast)
 
     sessions_dir = _d._get_sessions_dir()
     cutoff_ts = time.time() - (days * 86400)

--- a/tests/test_usage_cache_trends_local_store.py
+++ b/tests/test_usage_cache_trends_local_store.py
@@ -1,0 +1,257 @@
+"""Synthetic safety net for /api/usage/cache-trends DuckDB fast path.
+
+Tier-1 surface #1 in the 2026-05-19 DuckDB coverage audit (issue #1778).
+``_try_local_store_cache_trends`` aggregates per-(day, model) cache
+hit-ratio + cost-split off the DuckDB ``events`` table — this file
+pins the v3 event shape it must accept and guards the two failure
+modes most likely to silently inflate the numbers:
+
+  1. Real v3 ``assistant`` + ``model.completed`` sibling pairs (every
+     billable turn emits both) must not double cache_read_tokens or
+     total_cost.
+  2. The full envelope shape must round-trip — daily[] bucket per day,
+     by_model[] bucket per model, totals + recommendations.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+def _iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _today_iso() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _wait_flush(store, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _build_app(tmp_path, monkeypatch, *, enable_fast_path: bool = True):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_READ", "1" if enable_fast_path else "0"
+    )
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Steer the daemon-proxy discovery away from a contributor's locally
+    # running clawmetry daemon (same trick as test_usage_forecast_...).
+    import routes.local_query as lq
+    monkeypatch.setattr(
+        lq, "_DISCOVERY_PATH", str(tmp_path / "no-such-discovery.json")
+    )
+    lq._invalidate_daemon_cache()
+
+    import routes.usage as usage_mod
+    importlib.reload(usage_mod)
+
+    a = Flask(__name__)
+    a.register_blueprint(usage_mod.bp_usage)
+    return a, ls, usage_mod
+
+
+@pytest.fixture
+def fast_path_app(tmp_path, monkeypatch):
+    a, ls, u = _build_app(tmp_path, monkeypatch, enable_fast_path=True)
+    yield a, ls, u
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _ingest_v3_assistant(
+    store, *, sid, ts, ev_id, model="claude-opus-4-7",
+    input_tokens=100, output_tokens=50,
+    cache_read=200, cache_write=80,
+    cost_total=0.02,
+):
+    """Real v3 ``assistant`` Anthropic-SDK envelope — carries every
+    usage split + per-component cost breakdown. The richer of the
+    sibling pair, so the dedupe MUST keep this one."""
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "assistant",
+        "ts":         ts,
+        "data": {
+            "type":    "assistant",
+            "version": 3,
+            "message": {
+                "role":  "assistant",
+                "model": model,
+                "type":  "message",
+                "usage": {
+                    "input_tokens":                input_tokens,
+                    "output_tokens":               output_tokens,
+                    "cache_read_input_tokens":     cache_read,
+                    "cache_creation_input_tokens": cache_write,
+                    "cost": {
+                        "input":      cost_total * 0.4,
+                        "output":     cost_total * 0.3,
+                        "cacheRead":  cost_total * 0.2,
+                        "cacheWrite": cost_total * 0.1,
+                        "total":      cost_total,
+                    },
+                },
+            },
+        },
+        "cost_usd":    cost_total,
+        "token_count": input_tokens + output_tokens,
+        "model":       model,
+    })
+
+
+def _ingest_v3_model_completed(
+    store, *, sid, ts, ev_id, model="claude-opus-4-7",
+    input_tokens=100, output_tokens=50, cost_total=0.02,
+):
+    """Slim ``model.completed`` sibling that races the ``assistant`` row
+    by ~150 ms. Same cost stamped. Cache splits NOT carried — so if the
+    dedupe accidentally picks this one, the cache_hit_ratio collapses
+    to 0 (a useful failure-mode canary)."""
+    store.ingest({
+        "id":         ev_id,
+        "node_id":    "agent+test",
+        "agent_id":   "main",
+        "session_id": sid,
+        "event_type": "model.completed",
+        "ts":         ts,
+        "data": {
+            "type":     "model.completed",
+            "modelId":  model,
+            "provider": "claude-cli",
+            "promptCache": {
+                "lastCallUsage": {
+                    "input":  input_tokens,
+                    "output": output_tokens,
+                    "total":  input_tokens + output_tokens,
+                },
+            },
+        },
+        "cost_usd":    cost_total,
+        "token_count": input_tokens + output_tokens,
+        "model":       model,
+    })
+
+
+# ── happy path: single assistant event lands in today's bucket ─────────────
+
+def test_cache_trends_single_assistant_event(fast_path_app):
+    """One assistant turn with 100 in / 50 out / 200 cache_read / 80
+    cache_write — confirm the envelope round-trips and the values land
+    in today's daily bucket + by-model bucket."""
+    a, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    _ingest_v3_assistant(
+        store,
+        sid="sess-single",
+        ts=_iso(time.time()),
+        ev_id="asst-single",
+    )
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/usage/cache-trends?days=7").get_json()
+    assert body["_source"] == "local_store", body
+    assert body["days"] == 7
+    assert len(body["daily"]) == 7
+    today = _today_iso()
+    todays = [d for d in body["daily"] if d["date"] == today]
+    assert len(todays) == 1, body["daily"]
+    t = todays[0]
+    assert t["input_tokens"] == 100, t
+    assert t["output_tokens"] == 50, t
+    assert t["cache_read_tokens"] == 200, t
+    assert t["cache_write_tokens"] == 80, t
+    # cache_hit_ratio_pct = 200 / (100 + 200) * 100 = 66.7
+    assert abs(t["cache_hit_ratio_pct"] - 66.7) < 0.1, t
+
+    assert len(body["by_model"]) == 1
+    assert body["by_model"][0]["model"] == "claude-opus-4-7"
+    assert body["by_model"][0]["cache_read_tokens"] == 200
+
+    assert body["totals"]["label"] == "totals"
+    assert body["totals"]["cache_read_tokens"] == 200
+    assert isinstance(body["recommendations"], list)
+
+
+# ── dedupe-pattern regression (feedback_usage_dedupe_pattern.md) ──────────
+
+def test_cache_trends_dedupes_v3_sibling_pairs(fast_path_app):
+    """Every real v3 LLM turn writes BOTH an ``assistant`` row AND a
+    sibling ``model.completed`` row ~150 ms apart. Counting both:
+      * doubles input/output tokens,
+      * doubles total_cost,
+      * silently drops the cache split (slim sibling has none).
+
+    The dedupe must pick the richer ``assistant`` envelope and emit
+    single-counted numbers."""
+    a, ls, _u = fast_path_app
+    store = ls.get_store()
+
+    ts = _iso(time.time())
+    _ingest_v3_assistant(
+        store, sid="sess-pair", ts=ts, ev_id="a-1",
+        input_tokens=100, output_tokens=50,
+        cache_read=200, cache_write=80, cost_total=0.02,
+    )
+    _ingest_v3_model_completed(
+        store, sid="sess-pair", ts=ts, ev_id="mc-1",
+        input_tokens=100, output_tokens=50, cost_total=0.02,
+    )
+    _wait_flush(store)
+
+    body = a.test_client().get("/api/usage/cache-trends?days=2").get_json()
+    assert body["_source"] == "local_store"
+
+    today = _today_iso()
+    todays = [d for d in body["daily"] if d["date"] == today]
+    assert len(todays) == 1
+    t = todays[0]
+    # Single-counted: 100/50/200/80. Double-counted (sibling bug) would
+    # be 200/100/200/80 with cache_hit collapsing — both canaries.
+    assert t["input_tokens"] == 100, (
+        f"sibling-pair double-count: input_tokens={t['input_tokens']}"
+    )
+    assert t["output_tokens"] == 50, t
+    assert t["cache_read_tokens"] == 200, t
+    assert t["cache_write_tokens"] == 80, t
+    # Cache hit ratio survives the dedupe (would collapse to 33% under
+    # the bug if the slim sibling won and replaced the splits with 0).
+    assert abs(t["cache_hit_ratio_pct"] - 66.7) < 0.1, t
+
+
+# ── gate: env flag OFF ────────────────────────────────────────────────────
+
+def test_cache_trends_falls_through_when_local_store_disabled(tmp_path, monkeypatch):
+    """With ``CLAWMETRY_LOCAL_STORE_READ=0``, the fast path must be
+    skipped entirely — the response is the legacy JSONL-walker shape
+    WITHOUT the ``_source: local_store`` canary."""
+    a, _ls, _u = _build_app(tmp_path, monkeypatch, enable_fast_path=False)
+
+    body = a.test_client().get("/api/usage/cache-trends").get_json()
+    assert body.get("_source") != "local_store", (
+        f"gate honoured? body keys={list(body.keys())}"
+    )
+    # Legacy shape still has the core keys
+    assert "daily" in body
+    assert "by_model" in body
+    assert "totals" in body


### PR DESCRIPTION
## Summary
- Closes #1778 - Tier-1 item #1: `/api/usage/cache-trends` migrates from JSONL walker to a DuckDB fast path backed by a new `LocalStore.query_cache_metrics(days=N)` method.
- Same v3 sibling-pair dedupe pattern as `query_daily_usage_splits` so `assistant` + `model.completed` rows do not double-count cache reads/writes or total cost.
- Canonical fast-path wiring (`_try_local_store_cache_trends` -> `is_local_store_read_enabled` gate -> return-or-defer), modelled on PR #1571 (`_try_local_store_usage_forecast`).
- Adds `_extract_usage_cost_split` so we can carry per-component cost (input/output/cacheRead/cacheWrite) not just `total`.

## Files
- `clawmetry/local_store.py` (+255): new `query_cache_metrics` + `_extract_usage_cost_split` helper.
- `routes/usage.py` (+82): new `_try_local_store_cache_trends` + 8-line wiring into the existing handler. Legacy JSONL walker untouched and remains the fallback.
- `tests/test_usage_cache_trends_local_store.py` (+253): 3 cases.

## Test plan
- [x] `python3 -c "import dashboard"` clean
- [x] `python3 -m pytest tests/test_usage_cache_trends_local_store.py -q` (3/3 pass)
- [x] `python3 -m pytest tests/test_usage*.py -q` (46/46 pass, no regressions in forecast/usage)
- [ ] CI green
- [ ] Manual smoke against live OpenClaw DuckDB before any release that ships this

## Audit notes
Verified the line 3209 handler was a genuine JSONL walker (no DuckDB code path), so this is a real Tier-1 migration. No audit miss to document.

Refs #1778