### PR TITLE
docs: add networked plugin observability smoke test

### DIFF
--- a/OBSERVABILITY.md
+++ b/OBSERVABILITY.md
@@ -286,6 +286,40 @@ weather       unused    35 tok    0 times             --
 old-plugin    dead      120 tok   0 times             never (30d+)
 ```
 
+### Networked Plugin Smoke Test
+
+A networked plugin gives you a quick way to verify skill detection, tool-call
+visibility, approval policy, and alert routing without changing ClawMetry code.
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) is a useful example because
+it has read-only X/Twitter data tools and approval-sensitive write tools in the
+same OpenClaw plugin.
+
+1. Install the plugin:
+
+   ```bash
+   openclaw plugins install @xquik/tweetclaw
+   ```
+
+2. Configure the Xquik API key in OpenClaw's private runtime configuration.
+   Do not paste it into prompts, chats, issue bodies, or ClawMetry notes.
+
+3. Start with a read-only request, such as asking the agent to search tweets or
+   search tweet replies for a small query. ClawMetry should show the plugin
+   call in the Brain and Flow tabs.
+
+4. Before trying write-capable actions such as post tweets, post tweet replies,
+   media upload, or direct messages, add an approval rule that requires manual
+   confirmation. The approval record should show the action and reviewed text,
+   not credentials.
+
+| Surface | What to check |
+|---------|---------------|
+| Brain | `tool.call` and `tool.result` rows identify the TweetClaw action. |
+| Flow | The tool-call edge appears in the current session path. |
+| Skills | TweetClaw appears as used only after the agent loads the plugin guidance. |
+| Approvals | Write-capable actions pause for a decision before execution. |
+| Alerts | Error-rate or stuck-tool rules can be scoped to the plugin name. |
+
 
 ## Agent Runtime Timeline
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Opens at **http://localhost:8900** and you're done.
 - **Alerts** — Budget caps, error-rate triggers, agent-offline detection; routes to Slack, Discord, PagerDuty, Telegram, Email
 - **Approvals** — Gate destructive deletes, force pushes, DB mutations, sudo, package installs, network calls behind one-click sign-off
 
+For a concrete networked-plugin trace, see the [Agent Observability guide](./OBSERVABILITY.md#networked-plugin-smoke-test).
+
 ## Screenshots
 
 ### 🧠 Brain — Live agent event stream


### PR DESCRIPTION
## What This PR Does

Adds a small networked-plugin smoke test to the observability guide, using TweetClaw as a concrete OpenClaw plugin example for checking Brain, Flow, Skills, Approvals, and Alerts.

Also adds one README pointer to the new guide section.

## Why

ClawMetry already explains tool and skill telemetry in the abstract. A bounded example helps users verify that networked plugin calls and approval-sensitive write actions are visible without changing ClawMetry code.

## Validation

- Read README, CONTRIBUTING, SECURITY, AGENTS, OBSERVABILITY, adapter docs, plugin README, repo metadata, open and closed issues, open and closed PRs.
- Checked duplicate TweetClaw/Xquik/x-twitter-scraper issues and PRs. No duplicates found.
- Verified fork is kriptoburak/clawmetry, not an organization fork.
- Ran git diff --check.
- Ran added-line dash and sensitive-string scans.
- Ran touched-file link sweep for README.md and OBSERVABILITY.md: 27 links, 25 external, 2 local; new TweetClaw link and local anchor OK; existing Product Hunt page returned 403 while its badge image returned 200.
- Confirmed npm metadata: @xquik/tweetclaw@1.6.31.

No NHS badge was added because the README badges describe ClawMetry itself, not one optional plugin smoke-test example.