### PR TITLE
feat(sessions): /api/delegation-tree DuckDB fast path (Tier-1 from #1778)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2234,14 +2234,167 @@ def api_subagents():
     return jsonify(payload)
 
 
+def _try_local_store_delegation_tree():
+    """Fast path for /api/delegation-tree (Tier-1 from #1778 punch list).
+
+    Reads the pre-aggregated ``subagents`` table (same source as
+    ``_try_local_store_subagents``) and groups by ``parent_session_id``
+    to produce the per-chain token + cost totals. Skips the JSONL spawn
+    walker + sessions.json index read entirely — the daemon's snapshot
+    pass already computed both ``cost_usd`` and ``token_count`` per
+    subagent row, so chain totals are a server-side sum.
+
+    Returns ``None`` when the ``subagents`` table is empty so the
+    legacy ``sessions.json`` fallback fires for installs whose daemon
+    hasn't snapshotted yet. Returns a populated empty shell only when
+    the store is reachable AND no subagents have been spawned, which
+    is the right answer (the legacy path would also return empty).
+    """
+    import dashboard as _d
+    rows = _ls_call("query_subagents", limit=500)
+    if rows is None:
+        # Store unreachable. Defer to legacy so older installs keep working.
+        return None
+    if not rows:
+        # Store reachable, just empty. Serve the empty shell directly so
+        # we don't trigger an unnecessary sessions.json open + walk.
+        return {
+            "chains": [],
+            "total_subagents": 0,
+            "total_chain_cost_usd": 0.0,
+            "_source": "local_store",
+        }
+
+    # Fall back to the OSS pricing estimator only when the row lacks a
+    # daemon-computed ``cost_usd``. Cloud's dashboard.py doesn't export
+    # this helper; guard with getattr so we degrade to zero rather than 500.
+    _estimate_usd_per_token = getattr(_d, "_estimate_usd_per_token", None)
+    usd_per_tok = _estimate_usd_per_token() if _estimate_usd_per_token else 3.0 / 1_000_000.0
+    now_ms = time.time() * 1000
+
+    chains_map: dict = {}
+    parent_display_map: dict = {}
+
+    for r in rows:
+        sid = r.get("subagent_id") or ""
+        if not sid:
+            continue
+        extra = r.get("data") if isinstance(r.get("data"), dict) else {}
+        # The daemon stores parent_session_id as a bare session id; the
+        # legacy route grouped by ``spawnedBy`` (a full canonical key). Prefer
+        # the full key from the ``data`` blob when present so the response
+        # shape stays byte-compatible with the legacy walker.
+        parent_key = (extra.get("spawnedBy")
+                      or r.get("parent_session_id")
+                      or "unknown")
+        token_count = int(r.get("token_count") or 0)
+        # The daemon's cost_usd column is already deduped (issue #1460
+        # sibling-pair fix landed in query_sessions); prefer it verbatim and
+        # fall back to the token-based estimator only when the daemon
+        # snapshotted a row without cost (older sync.py builds).
+        cost_usd = r.get("cost_usd")
+        if cost_usd is None or cost_usd == 0:
+            cost_usd = round(token_count * usd_per_tok, 6)
+        else:
+            cost_usd = float(cost_usd)
+
+        # Status: prefer daemon classification, fall back to age bucket.
+        status = (r.get("status") or "").strip().lower()
+        if not status:
+            updated_ms = extra.get("updated_at_ms") or 0
+            try:
+                if not updated_ms and r.get("updated_at"):
+                    updated_ms = int(datetime.fromisoformat(
+                        str(r["updated_at"]).replace("Z", "+00:00")
+                    ).timestamp() * 1000)
+            except Exception:
+                updated_ms = 0
+            age_ms = now_ms - (updated_ms or 0)
+            if age_ms < 120000:
+                status = "active"
+            elif age_ms < 600000:
+                status = "idle"
+            else:
+                status = "stale"
+
+        key = extra.get("key") or f"agent:main:subagent:{sid}"
+        label = extra.get("label") or extra.get("displayName") or key.split(":")[-1]
+        model = extra.get("model") or "unknown"
+        try:
+            updated_iso = r.get("updated_at")
+            updated_at = (int(datetime.fromisoformat(
+                str(updated_iso).replace("Z", "+00:00")
+            ).timestamp() * 1000)
+                          if updated_iso else (extra.get("updated_at_ms") or 0))
+        except Exception:
+            updated_at = extra.get("updated_at_ms") or 0
+
+        chains_map.setdefault(parent_key, []).append({
+            "key":               key,
+            "label":             label,
+            "model":             model,
+            "prov_agent_type":   "subagent",
+            "prov_session_turn": 2,
+            "prov_parent_key":   parent_key,
+            "prov_total_tokens": token_count,
+            "input_tokens":      int(extra.get("tokensIn") or extra.get("inputTokens") or 0),
+            "output_tokens":     int(extra.get("tokensOut") or extra.get("outputTokens") or 0),
+            "total_tokens":      token_count,
+            "cost_usd":          round(float(cost_usd), 6),
+            "status":            status,
+            "updated_at":        updated_at,
+        })
+        if "displayName" in extra or "subject" in extra:
+            parent_display_map.setdefault(parent_key,
+                                          extra.get("displayName") or extra.get("subject"))
+
+    chains = []
+    total_chain_cost = 0.0
+    for parent_key, children in chains_map.items():
+        parts = parent_key.split(":")
+        channel = parts[2] if len(parts) > 2 else "unknown"
+        display = parts[-1] if parts else parent_key
+        chain_tokens = sum(c["total_tokens"] for c in children)
+        chain_cost = round(sum(c["cost_usd"] for c in children), 6)
+        total_chain_cost += chain_cost
+        chains.append({
+            "parent_key":      parent_key,
+            "parent_display":  parent_display_map.get(parent_key) or display,
+            "parent_channel":  channel,
+            "children":        sorted(children, key=lambda x: x["total_tokens"], reverse=True),
+            "chain_tokens":    chain_tokens,
+            "chain_cost_usd":  chain_cost,
+            "child_count":     len(children),
+        })
+
+    chains.sort(key=lambda x: x["chain_tokens"], reverse=True)
+    return {
+        "chains":               chains,
+        "total_subagents":      len(rows),
+        "total_chain_cost_usd": round(total_chain_cost, 4),
+        "_source":              "local_store",
+    }
+
+
 @bp_sessions.route("/api/delegation-tree")
 def api_delegation_tree():
     """Agent delegation chains -- inspired by AgentWeave provenance tracing.
 
-    Reads sessions.json, groups subagents by their spawnedBy parent key,
-    and returns per-chain token totals and estimated cost.
+    Source 0 (DuckDB fast path): groups the ``subagents`` table by
+    ``parent_session_id``; per-chain token + cost totals come from the
+    daemon-aggregated columns (no JSONL re-walk).
+
+    Source 1 (legacy fallback): reads sessions.json, groups subagents
+    by their ``spawnedBy`` parent key. Kept so older OpenClaw installs
+    without the local store keep rendering this view.
     """
     import dashboard as _d
+    # Source 0: DuckDB fast path. Skips sessions.json entirely.
+    if is_local_store_read_enabled():
+        fast = _try_local_store_delegation_tree()
+        if fast is not None:
+            return jsonify(fast)
+
     # Cloud's dashboard.py is a different module than OSS's; some helpers
     # (e.g. _get_sessions_dir, _estimate_usd_per_token) only exist in OSS.
     # Guard with getattr so we degrade to an empty response instead of 500.

--- a/tests/test_delegation_tree_local_store.py
+++ b/tests/test_delegation_tree_local_store.py
@@ -1,0 +1,174 @@
+"""Regression guard for /api/delegation-tree DuckDB fast path (Tier-1 #1778).
+
+``routes/sessions.py:_try_local_store_delegation_tree`` reads the
+pre-aggregated ``subagents`` table (same source as
+``_try_local_store_subagents``) instead of opening + walking
+``sessions.json``. Groups by ``parent_session_id`` (or ``spawnedBy``
+when the full canonical key is in the row's data blob), then sums
+each chain's token + cost totals server-side.
+
+Tests:
+
+1. Two children for one parent surface with the correct chain
+   rollups and ``_source='local_store'``.
+2. Empty store returns the empty shell directly (no legacy fallback
+   trigger) since reaching the daemon and finding zero subagents is
+   the right answer.
+3. Per-row ``cost_usd`` from the daemon (already deduped at the
+   ``query_sessions`` SQL layer for v3 sibling pairs) is honored
+   verbatim — we do NOT re-estimate from tokens when the daemon
+   already wrote a cost.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.local_query as lq
+    importlib.reload(lq)
+    import routes.sessions as sessions_mod
+    importlib.reload(sessions_mod)
+
+    # Isolate the fixture from a contributor's locally running daemon
+    # (same shim as ``test_subagents_local_store_v3``).
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    yield a, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def test_delegation_tree_local_store_groups_by_parent(app):
+    """Two children sharing one parent -> one chain with token + cost
+    rollups, tagged ``_source='local_store'``."""
+    a, ls = app
+    store = ls.get_store()
+    parent_sid = "parent-session-xyz"
+
+    store.ingest_subagent({
+        "subagent_id":       "child-a",
+        "agent_type":        "openclaw",
+        "parent_session_id": parent_sid,
+        "spawned_at":        "2026-05-17T10:00:00Z",
+        "task":              "refactor auth.py",
+        "status":            "active",
+        "cost_usd":          0.0234,
+        "token_count":       4200,
+        "model":             "claude-opus-4-7",
+        "label":             "auth-refactor",
+        "tokensIn":          3000,
+        "tokensOut":         1200,
+        "updated_at_ms":     int(time.time() * 1000),
+    })
+    store.ingest_subagent({
+        "subagent_id":       "child-b",
+        "agent_type":        "openclaw",
+        "parent_session_id": parent_sid,
+        "spawned_at":        "2026-05-17T10:01:00Z",
+        "task":              "summarise transcripts",
+        "status":            "completed",
+        "cost_usd":          0.0089,
+        "token_count":       1800,
+        "model":             "claude-opus-4-7",
+        "label":             "summariser",
+        "updated_at_ms":     int(time.time() * 1000),
+    })
+
+    r = a.test_client().get("/api/delegation-tree")
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body.get("_source") == "local_store", body
+    assert body.get("total_subagents") == 2
+    chains = body.get("chains") or []
+    assert len(chains) == 1, f"expected one chain, got {chains!r}"
+    chain = chains[0]
+    assert chain["parent_key"] == parent_sid
+    assert chain["child_count"] == 2
+    assert chain["chain_tokens"] == 6000  # 4200 + 1800
+    # Per-row cost_usd from the daemon is honored verbatim (no token-based
+    # re-estimation). 0.0234 + 0.0089 = 0.0323.
+    assert abs(chain["chain_cost_usd"] - 0.0323) < 1e-6, chain
+    # total_chain_cost_usd is rounded to 4 dp (legacy parity).
+    assert abs(body["total_chain_cost_usd"] - 0.0323) < 1e-4
+
+    # Children sorted by total_tokens DESC.
+    child_ids = [c["key"].rsplit(":", 1)[-1] for c in chain["children"]]
+    assert child_ids == ["child-a", "child-b"], child_ids
+    first = chain["children"][0]
+    assert first["total_tokens"] == 4200
+    assert first["input_tokens"] == 3000
+    assert first["output_tokens"] == 1200
+    assert first["status"] == "active"
+    assert first["model"] == "claude-opus-4-7"
+    assert first["prov_agent_type"] == "subagent"
+    assert first["prov_session_turn"] == 2
+
+
+def test_delegation_tree_local_store_empty_returns_shell(app):
+    """Empty subagents table -> reachable-but-empty shell with
+    ``_source='local_store'``. Avoids triggering the sessions.json
+    fallback on installs where the daemon is healthy but no subagents
+    have been spawned yet."""
+    a, ls = app
+    assert ls.get_store().query_subagents(limit=10) == []
+
+    import routes.sessions as sessions_mod
+    fast = sessions_mod._try_local_store_delegation_tree()
+    assert fast is not None, "reachable empty store must return shell, not None"
+    assert fast["_source"] == "local_store"
+    assert fast["chains"] == []
+    assert fast["total_subagents"] == 0
+    assert fast["total_chain_cost_usd"] == 0.0
+
+
+def test_delegation_tree_local_store_honors_spawned_by_full_key(app):
+    """When the row's data blob carries ``spawnedBy`` (the OpenClaw
+    canonical parent key), the fast path groups by it instead of the
+    bare ``parent_session_id`` column. Keeps the response shape
+    byte-compatible with the legacy walker (which grouped by full key)."""
+    a, ls = app
+    store = ls.get_store()
+    full_parent_key = "agent:main:session:abc123"
+
+    store.ingest_subagent({
+        "subagent_id":       "child-fk",
+        "agent_type":        "openclaw",
+        "parent_session_id": "abc123",
+        "spawnedBy":         full_parent_key,
+        "spawned_at":        "2026-05-17T10:00:00Z",
+        "task":              "lookup",
+        "status":            "active",
+        "cost_usd":          0.001,
+        "token_count":       500,
+        "model":             "claude-haiku-4-5",
+        "displayName":       "user inbox triage",
+        "updated_at_ms":     int(time.time() * 1000),
+    })
+
+    r = a.test_client().get("/api/delegation-tree")
+    body = r.get_json()
+    assert body["_source"] == "local_store"
+    chains = body["chains"]
+    assert len(chains) == 1
+    ch = chains[0]
+    assert ch["parent_key"] == full_parent_key
+    assert ch["parent_channel"] == "session"  # parts[2] of canonical key
+    assert ch["parent_display"] == "user inbox triage"
+    assert ch["children"][0]["prov_parent_key"] == full_parent_key


### PR DESCRIPTION
## Summary

Migrates `/api/delegation-tree` (item #8 from #1778 punch list) off the
`sessions.json` index file walker onto a DuckDB fast path that reads
the pre-aggregated `subagents` table (same source as
`_try_local_store_subagents`).

- `_try_local_store_delegation_tree` groups by `parent_session_id` (or
  `spawnedBy` full key when the row's data blob carries one, preserving
  legacy walker shape) and sums per-chain token + cost totals from the
  daemon-computed columns.
- `cost_usd` is honored verbatim since the daemon snapshot already
  applies the issue #1460 v3 sibling-pair dedupe at the
  `query_sessions` SQL layer. Falls back to the OSS token-estimator
  only when the row was written by an older `sync.py` build with no
  cost column populated.
- Legacy `sessions.json` walker stays as fallback for installs whose
  daemon hasn't snapshotted yet, so older OpenClaw users keep
  rendering this view.
- Reachable-but-empty store returns the empty shell directly
  (`_source='local_store'`) so we don't trigger a needless
  `sessions.json` open on healthy installs that simply haven't spawned
  any subagents.

False-positive check passed: `routes/sessions.py:2255` (pre-patch)
does call `open(index_path)` on `sessions.json`, so this is a real
fast-path migration, not an audit miss.

## Test plan

- [x] `tests/test_delegation_tree_local_store.py` (3 cases): two
  children one parent chain rollup with daemon-computed cost; reachable
  empty store returns shell not None; `spawnedBy` full-key grouping
  path preserves legacy response shape.
- [x] `python3 -c "import dashboard"` clean.
- [x] `python3 -m pytest tests/test_subagents_local_store_v3.py
  tests/test_subagent_attribution_v3.py
  tests/test_delegation_tree_local_store.py -q` -> 10 passed.
- [x] Diff under 250 LOC (155 LOC in `routes/sessions.py`).
- [ ] Smoke against live `/api/delegation-tree` on a daemon-backed
  install pre-merge.

## Notes

- Part of #1778 tracking issue; do not auto-close.
- Coordination note: `routes/sessions.py:_try_local_store_subagents`
  (PR #1774 area) and `is_writer_alive()` patches (PR #1779) edit
  adjacent code in this file. This PR touches only the
  `delegation-tree` handler + its new helper, no shared-helper
  refactors, so the merge surface stays narrow. Will rebase if main
  moves before merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>