### PR TITLE
fix: remove Fleet Sonar (dead tab, loadClusters never defined)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -103,7 +103,7 @@ from routes.overview import bp_overview
 from routes.components import bp_components
 from routes.fleet_history import bp_fleet, bp_history
 from routes.infra import bp_logs, bp_memory, bp_security, bp_config
-from routes.meta import bp_auth, bp_cloud_relay, bp_gateway, bp_otel, bp_version, bp_version_impact, bp_clusters
+from routes.meta import bp_auth, bp_cloud_relay, bp_gateway, bp_otel, bp_version, bp_version_impact
 from routes.nemoclaw import bp_nemoclaw
 from routes.skills import bp_skills
 from routes.heartbeat import bp_heartbeat
@@ -4890,17 +4890,6 @@ function clawmetryLogout(){
   </div>
 </div>
 
-<!-- SESSION CLUSTERS -->
-<div class="page" id="page-clusters">
-  <div class="refresh-bar">
-    <h2 style="font-size:16px;font-weight:700;color:var(--text-primary);margin:0;flex:1;">&#129492; Session Clusters</h2>
-    <button class="refresh-btn" onclick="loadClusters()">&#8635; Refresh</button>
-  </div>
-  <div id="clusters-content" style="padding:8px 0;">
-    <div style="color:var(--text-muted);font-size:13px;">Loading...</div>
-  </div>
-</div>
-
 <!-- HISTORY -->
 
 <!-- RATE LIMITS -->
@@ -6271,7 +6260,7 @@ function switchTab(name) {
   if (name === 'memory') loadMemory();
   if (name === 'transcripts') loadTranscripts();
   if (name === 'version-impact') loadVersionImpact();
-  if (name === 'clusters') loadClusters();
+
   if (name === 'limits') loadRateLimits();
   if (name === 'flow') initFlow();
   if (name === 'history') loadHistory();
@@ -10486,7 +10475,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_usage)
     app.register_blueprint(bp_version)
     app.register_blueprint(bp_version_impact)
-    app.register_blueprint(bp_clusters)
+
     app.register_blueprint(bp_cloud_relay)
     app.register_blueprint(bp_nemoclaw)
     app.register_blueprint(bp_skills)
@@ -10888,10 +10877,7 @@ DASHBOARD_HTML = r"""
           <span class="left-nav-label">LLM Context</span>
         </div>
       </div>
-      <div class="left-nav-item" data-tab="clusters" onclick="switchTab('clusters')" title="Multi-node fleet overview">
-        <span class="left-nav-icon" aria-hidden="true">&#9678;</span>
-        <span class="left-nav-label">Fleet sonar</span>
-      </div>
+
       <div class="left-nav-item" data-tab="approvals" onclick="switchTab('approvals')" title="Cloud-mediated approval queue">
         <span class="left-nav-icon" aria-hidden="true">&#10003;</span>
         <span class="left-nav-label">Approvals</span>
@@ -11221,7 +11207,7 @@ from flask import Blueprint as _Blueprint
 # bp_usage moved to routes/usage.py
 # bp_version moved to routes/meta.py
 # bp_version_impact moved to routes/meta.py
-# bp_clusters moved to routes/meta.py
+
 # bp_nemoclaw moved to routes/nemoclaw.py
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -14814,225 +14800,6 @@ _CLUSTER_TOOL_GROUPS = {
     "pdf": {"pdf", "image"},
     "files": {"Read", "Write", "Edit"},
 }
-
-_CLUSTER_PATTERNS = [
-    # (cluster_label, dominant_tools_required, min_fraction)
-    ("browsing-heavy", {"browser", "web_fetch", "web_search"}, 0.4),
-    ("code-heavy", {"exec", "Read", "Write", "Edit"}, 0.4),
-    ("messaging", {"message", "tts"}, 0.3),
-    ("doc-analysis", {"pdf", "image"}, 0.2),
-    ("mixed-research", {"web_search", "exec", "Read"}, 0.15),
-    ("cron-light", set(), 0.0),  # fallback for very short sessions
-]
-
-
-def _extract_session_fingerprint(fpath):
-    """Extract tool call sequence, cost, tokens, error presence from a session JSONL file."""
-    tools_seq = []
-    cost = 0.0
-    tokens = 0
-    has_error = False
-    first_ts = None
-    last_ts = None
-
-    try:
-        with open(fpath, "r", errors="replace") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    ev = json.loads(line)
-                except Exception:
-                    continue
-
-                ts_str = ev.get("timestamp", "")
-                if ts_str:
-                    try:
-                        ts_f = datetime.fromisoformat(
-                            ts_str.replace("Z", "+00:00")
-                        ).timestamp()
-                        if first_ts is None or ts_f < first_ts:
-                            first_ts = ts_f
-                        if last_ts is None or ts_f > last_ts:
-                            last_ts = ts_f
-                    except Exception:
-                        pass
-
-                ev_type = ev.get("type", "")
-                if ev_type == "error":
-                    has_error = True
-                elif ev_type == "message":
-                    msg = ev.get("message", {})
-                    if msg.get("role") == "assistant":
-                        usage = msg.get("usage", {})
-                        if isinstance(usage, dict):
-                            cost_obj = usage.get("cost", {})
-                            if isinstance(cost_obj, dict):
-                                cost += float(cost_obj.get("total", 0))
-                            tok_in = (
-                                usage.get("input", 0)
-                                or usage.get("inputTokens", 0)
-                                or 0
-                            )
-                            tok_out = (
-                                usage.get("output", 0)
-                                or usage.get("outputTokens", 0)
-                                or 0
-                            )
-                            tokens += int(tok_in) + int(tok_out)
-                        if isinstance(msg.get("content"), list):
-                            for part in msg["content"]:
-                                if (
-                                    isinstance(part, dict)
-                                    and part.get("type") == "toolCall"
-                                ):
-                                    tn = part.get("name", "")
-                                    if tn:
-                                        tools_seq.append(tn)
-    except Exception:
-        pass
-
-    duration_ms = (
-        int((last_ts - first_ts) * 1000)
-        if (first_ts and last_ts and last_ts > first_ts)
-        else 0
-    )
-
-    # Cost bucket (calibrated to typical agent session costs)
-    if cost < 0.10:
-        cost_bucket = "low"
-    elif cost < 1.0:
-        cost_bucket = "medium"
-    else:
-        cost_bucket = "high"
-
-    return {
-        "tools_seq": tools_seq,
-        "tool_set": list(set(tools_seq)),
-        "cost": round(cost, 6),
-        "tokens": tokens,
-        "has_error": has_error,
-        "cost_bucket": cost_bucket,
-        "duration_ms": duration_ms,
-        "tool_count": len(tools_seq),
-    }
-
-
-def _assign_cluster_label(fp):
-    """Assign a cluster label to a session based on its fingerprint."""
-    tools = set(fp["tool_set"])
-    n = fp["tool_count"]
-    cost = fp["cost"]
-    has_error = fp["has_error"]
-
-    if n == 0:
-        return "cron-light"
-
-    # Score each cluster pattern by fraction of required tools present in session tool set
-    best_label = "general"
-    best_score = 0.0
-
-    for label, required_tools, min_frac in _CLUSTER_PATTERNS:
-        if not required_tools:
-            continue
-        # Fraction of required_tools that appear in the session (0..1)
-        overlap = len(tools & required_tools)
-        frac = overlap / len(required_tools) if required_tools else 0.0
-        if frac >= min_frac and frac > best_score:
-            best_score = frac
-            best_label = label
-
-    # Override only truly extreme outliers (cost > $5 or pure exec-only)
-    if cost > 5.0:
-        best_label = "expensive-outlier"
-
-    # Suffix for error-heavy sessions
-    if has_error and best_label not in ("expensive-outlier",):
-        best_label += "+errors"
-
-    return best_label
-
-
-def _build_clusters(sessions_dir, limit=200):
-    """Analyze recent sessions and return cluster groups."""
-    if not sessions_dir or not os.path.isdir(sessions_dir):
-        return {}
-
-    files = sorted(
-        [
-            f
-            for f in os.listdir(sessions_dir)
-            if f.endswith(".jsonl") and "deleted" not in f
-        ],
-        key=lambda f: os.path.getmtime(os.path.join(sessions_dir, f)),
-        reverse=True,
-    )[:limit]
-
-    clusters = {}  # label -> {sessions, total_cost, total_tokens, error_count, rep_session}
-
-    for fname in files:
-        fpath = os.path.join(sessions_dir, fname)
-        sid = fname.replace(".jsonl", "")
-        fp = _extract_session_fingerprint(fpath)
-        label = _assign_cluster_label(fp)
-
-        if label not in clusters:
-            clusters[label] = {
-                "label": label,
-                "sessions": [],
-                "total_cost": 0.0,
-                "total_tokens": 0,
-                "error_count": 0,
-                "rep_session": None,
-            }
-
-        c = clusters[label]
-        c["sessions"].append(
-            {
-                "id": sid,
-                "cost": fp["cost"],
-                "tokens": fp["tokens"],
-                "tools": fp["tool_set"][:8],
-                "has_error": fp["has_error"],
-                "cost_bucket": fp["cost_bucket"],
-                "duration_ms": fp["duration_ms"],
-            }
-        )
-        c["total_cost"] += fp["cost"]
-        c["total_tokens"] += fp["tokens"]
-        if fp["has_error"]:
-            c["error_count"] += 1
-        # Representative session: highest cost/complexity
-        if c["rep_session"] is None or fp["cost"] > c["rep_session"].get("cost", 0):
-            c["rep_session"] = {
-                "id": sid,
-                "cost": fp["cost"],
-                "tools": fp["tool_set"][:8],
-            }
-
-    # Compute summaries
-    result = []
-    for label, c in sorted(
-        clusters.items(), key=lambda x: len(x[1]["sessions"]), reverse=True
-    ):
-        n = len(c["sessions"])
-        result.append(
-            {
-                "label": label,
-                "session_count": n,
-                "avg_cost": round(c["total_cost"] / n, 6),
-                "avg_tokens": int(c["total_tokens"] / n),
-                "error_rate": round(c["error_count"] / n, 3),
-                "rep_session": c["rep_session"],
-                "sessions": c["sessions"][:20],  # cap for response size
-            }
-        )
-
-    return result
-
-
-# (bp_clusters handler moved to routes/meta.py: /api/clusters)
 
 
 def _build_context_inspector_data():

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -10,6 +10,7 @@ and they are all auth/meta/observability plumbing:
   bp_auth           (3)  — /api/auth/check, /auth, /  (main page)
   bp_otel           (3)  — /v1/metrics, /v1/traces, /api/otel-status
   bp_version_impact (1)  — /api/version-impact
+  bp_cloud_relay    (1)  — /api/cloud/subscribe
 
 Module-level helpers (``_auto_discover_gateway``, ``_gw_invoke_docker``,
 ``_gw_invoke``, ``_gw_ws_rpc``, ``_load_gw_config``, ``_ext_emit``,

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -1,5 +1,5 @@
 """
-routes/meta.py — Auth / gateway / OTLP / version / clusters / version-impact.
+routes/meta.py — Auth / gateway / OTLP / version / version-impact.
 
 Extracted from dashboard.py as Phase 5.12 of the incremental modularisation.
 Six small Blueprints bundled into one file because each is tiny (1-3 routes)
@@ -10,14 +10,13 @@ and they are all auth/meta/observability plumbing:
   bp_auth           (3)  — /api/auth/check, /auth, /  (main page)
   bp_otel           (3)  — /v1/metrics, /v1/traces, /api/otel-status
   bp_version_impact (1)  — /api/version-impact
-  bp_clusters       (1)  — /api/clusters
 
 Module-level helpers (``_auto_discover_gateway``, ``_gw_invoke_docker``,
 ``_gw_invoke``, ``_gw_ws_rpc``, ``_load_gw_config``, ``_ext_emit``,
 ``_process_otlp_metrics``, ``_process_otlp_traces``, ``_has_otel_data``,
 ``_get_openclaw_version``, ``_record_version_if_changed``,
 ``_version_impact_db``, ``_compute_session_stats_in_range``,
-``_stats_to_summary``, ``_compute_diff``, ``_build_clusters``) and module
+``_stats_to_summary``, ``_compute_diff``) and module
 state (``GATEWAY_URL``, ``GATEWAY_TOKEN``, ``_ws_client``, ``_ws_connected``,
 ``_GW_CONFIG_FILE``, ``_CURRENT_PLATFORM``, ``__version__``, ``_pypi_cache``,
 ``_budget_paused``, ``_HAS_OTEL_PROTO``, ``_metrics_lock``, ``metrics_store``,
@@ -50,7 +49,6 @@ bp_gateway = Blueprint('gateway', __name__)
 bp_auth = Blueprint('auth', __name__)
 bp_otel = Blueprint('otel', __name__)
 bp_version_impact = Blueprint('version_impact', __name__)
-bp_clusters = Blueprint('clusters', __name__)
 bp_cloud_relay = Blueprint('cloud_relay', __name__)
 
 
@@ -1045,55 +1043,6 @@ def api_version_impact():
             "transitions": transitions,
         }
     )
-
-
-# ── Trace clustering ──────────────────────────────────────────────────────────
-
-
-@bp_clusters.route("/api/clusters")
-def api_clusters():
-    """Return session clusters grouped by tool call pattern, cost, and error types."""
-    import dashboard as _d
-    sessions_dir = getattr(_d, "SESSIONS_DIR", None) or os.path.expanduser(
-        "~/.openclaw/agents/main/sessions"
-    )
-    # Issue #1088: opt-in DuckDB fast path. Delegates to the same DuckDB-driven
-    # clustering used by /api/sessions/clusters and exposes a thinner shape
-    # (clusters + total_clusters) — _source: "local_store" for tests.
-    if is_local_store_read_enabled():
-        try:
-            from routes.usage import _try_local_store_sessions_clusters
-            fast = _try_local_store_sessions_clusters(30)
-            if fast is not None:
-                return jsonify({
-                    "clusters": fast.get("clusters", []),
-                    "total_clusters": len(fast.get("clusters", [])),
-                    "sessions_dir": sessions_dir,
-                    "_source": "local_store",
-                })
-        except Exception:
-            pass
-    # Cloud's dashboard.py doesn't ship _build_clusters; fall through to an
-    # empty 200 instead of leaking a 500 with an AttributeError body into the
-    # user's console. (When cloud_route_policy is loaded, this endpoint is
-    # normally returned as 410 by the policy enforcer; this guard is the
-    # defence-in-depth path for environments where the policy isn't active.)
-    build_clusters = getattr(_d, "_build_clusters", None)
-    if build_clusters is None:
-        return jsonify(
-            {"clusters": [], "total_clusters": 0, "sessions_dir": sessions_dir}
-        )
-    try:
-        clusters = build_clusters(sessions_dir)
-        return jsonify(
-            {
-                "clusters": clusters,
-                "total_clusters": len(clusters),
-                "sessions_dir": sessions_dir,
-            }
-        )
-    except Exception as e:
-        return jsonify({"error": str(e), "clusters": []}), 500
 
 
 # ── Heartbeat-piggyback subscribe queue (issue #1595) ────────────────────────


### PR DESCRIPTION
Closes #1716

## Summary

- **Root cause**: The Fleet Sonar left-nav entry switched to `data-tab="clusters"`, but `loadClusters()` was called twice in the tab-switch handler and never defined anywhere — so the tab permanently showed "Loading..." with no data ever rendered.
- **Removed** the nav entry, `page-clusters` tab panel, and the dead `loadClusters()` call from the tab-switch block (`dashboard.py`).
- **Removed** the now-dead backend: `bp_clusters` Blueprint + `/api/clusters` route (`routes/meta.py`) and the JSONL-scan helpers `_CLUSTER_PATTERNS` / `_extract_session_fingerprint` / `_assign_cluster_label` / `_build_clusters` (`dashboard.py`, ~220 lines).

**Not touched:** `/api/sessions/clusters` in `routes/usage.py` — that's a separate, live DuckDB-backed endpoint used by the Usage tab's behavioural clustering panel.

Net change: **−291 lines** across 2 files.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — passes (syntax OK)
- [ ] `python3 -c "import ast; ast.parse(open('routes/meta.py').read())"` — passes
- [ ] Start dev server, confirm "Fleet sonar" entry no longer appears in the left nav
- [ ] Confirm all other nav items (Approvals, Alerts, Cost, etc.) still render correctly
- [ ] `GET /api/sessions/clusters` still returns cluster data (Usage tab unaffected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gw56pcp5GR4hkuW7x3PKsy)_