### PR TITLE
fix(channels): DuckDB fast-path for /api/channel-delivery-health

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -4102,6 +4102,70 @@ class LocalStore:
                 "last_test_error", "updated_at"]
         return [_row_to_dict(r, cols) for r in self._fetch(sql, params)]
 
+    def query_channel_delivery_health(
+        self,
+        since_hours: int = 48,
+    ) -> list[dict[str, Any]]:
+        """Per-channel delivery counts from DuckDB (issue #1757 fast-path).
+
+        Queries events rows with event_type in ('delivery.ok',
+        'delivery.failed', 'delivery.intent'), grouped by the ``provider``
+        field inside the ``data`` BLOB.  Returns an empty list when no such
+        events exist in the window — the caller (api_channel_delivery_health)
+        should fall back to log-file scanning in that case.
+
+        This method is the DuckDB-first counterpart to the log-scan path that
+        PR #1740 introduced.  It becomes the primary data source once channel
+        adapters emit delivery events; until then it returns [] and the
+        legacy fallback fires.
+        """
+        from datetime import datetime, timedelta, timezone
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(hours=int(since_hours))
+        ).isoformat()
+        rows = self._fetch(
+            "SELECT event_type, data FROM events "
+            "WHERE event_type IN ('delivery.ok','delivery.failed','delivery.intent') "
+            "AND ts >= ?",
+            [cutoff],
+        )
+        decoded = _decode_data_blob_rows(rows, ["event_type", "data"])
+
+        counts: dict[str, dict[str, int]] = {}
+        for row in decoded:
+            data = row.get("data") or {}
+            if not isinstance(data, dict):
+                continue
+            provider = str(
+                data.get("provider") or data.get("channel") or ""
+            ).lower().strip()
+            if not provider:
+                continue
+            if provider not in counts:
+                counts[provider] = {"ok": 0, "failed": 0, "intents": 0}
+            et = row["event_type"]
+            if et == "delivery.ok":
+                counts[provider]["ok"] += 1
+            elif et == "delivery.failed":
+                counts[provider]["failed"] += 1
+            elif et == "delivery.intent":
+                counts[provider]["intents"] += 1
+
+        result = []
+        for ch, c in sorted(counts.items()):
+            total_sends = c["ok"] + c["failed"]
+            result.append({
+                "channel": ch,
+                "intents": c["intents"],
+                "ok": c["ok"],
+                "failed": c["failed"],
+                "unconfirmed": max(0, c["intents"] - total_sends),
+                "success_rate": (
+                    round(c["ok"] / total_sends, 3) if total_sends else None
+                ),
+            })
+        return result
+
     def query_alert_rules(
         self,
         *,

--- a/routes/channels.py
+++ b/routes/channels.py
@@ -806,18 +806,31 @@ def api_channels_summary():
 def api_channel_delivery_health():
     """Aggregate outbound message delivery integrity across all channels.
 
-    Scans the past 48 h of log files for send-success, send-failure, and
-    run-start events grouped by channel.  Returns per-channel counts:
+    DuckDB fast-path (issue #1757): tries ``query_channel_delivery_health``
+    first. Falls back to log-file scanning when DuckDB has no delivery events
+    yet (i.e. before adapter instrumentation ships).
 
-    - ``intents``     — detected run-starts (agent began handling a channel msg)
+    Returns per-channel counts:
+    - ``intents``     — run-starts (agent began handling a channel msg)
     - ``ok``          — confirmed outbound deliveries
-    - ``failed``      — explicit send failures logged by the adapter
-    - ``unconfirmed`` — intents with no matching ok/failed entry (the gap)
+    - ``failed``      — explicit send failures
+    - ``unconfirmed`` — intents with no matching ok/failed entry
     - ``success_rate`` — ok / (ok + failed), null when no sends recorded
 
     Addresses issue #978: channel delivery failures were logged per-adapter
     but never surfaced in an aggregate view.
     """
+    # ── DuckDB fast-path ──────────────────────────────────────────────────
+    store_rows = _ls_call("query_channel_delivery_health", since_hours=48)
+    if store_rows:
+        return jsonify({
+            "channels":          store_rows,
+            "log_files_scanned": 0,
+            "_source":           "local_store",
+            "ts":                datetime.now().isoformat(),
+        })
+
+    # ── DEPRECATED FALLBACK — delete after adapters emit delivery events ──
     import re
     import dashboard as _d
 


### PR DESCRIPTION
Closes #1757

## Summary

- Adds `query_channel_delivery_health(since_hours=48)` to `LocalStore` (`clawmetry/local_store.py`): queries `events` rows with `event_type IN ('delivery.ok', 'delivery.failed', 'delivery.intent')`, decodes the `data` BLOB in Python, groups by provider, and returns the same per-channel shape (`channel`, `ok`, `failed`, `intents`, `unconfirmed`, `success_rate`) the endpoint already emits.
- Rewrites `api_channel_delivery_health()` (`routes/channels.py`) to call the DuckDB fast-path first via `_ls_call()`; if it returns non-empty rows the response is served from DuckDB tagged `_source: "local_store"`. The existing log-file regex scan is kept as a `# DEPRECATED FALLBACK` that fires only when DuckDB has no delivery events yet.

**No user-visible change until channel adapters emit `delivery.ok`/`delivery.failed` events** — at that point the log-scan path is bypassed automatically. The fallback deprecation marker is in place for removal in the follow-up PR that instruments the adapters.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('clawmetry/local_store.py').read())"` — syntax OK
- [x] `python3 -c "import ast; ast.parse(open('routes/channels.py').read())"` — syntax OK
- [x] `pytest tests/test_schema_migration_failure_integrity.py tests/test_local_store.py -x -q` — 36 passed
- [x] Smoke test: empty store returns `[]` (fallback fires); after ingesting `delivery.ok`/`delivery.failed` events the fast-path returns correct per-channel counts and success rates

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3wXsRNqtetQqJBvgU93QW)_