### PR TITLE
fix(cloud): sync detected-config diagnostics (kills 'local-only' dead-end)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7275,6 +7275,58 @@ def _build_runtime_info():
         return {"items": []}
 
 
+def _build_diagnostics(workspace=None):
+    """Build the Diagnostics snapshot (detected config) for the cloud panel.
+
+    Mirrors the OSS ``/api/diagnostics`` endpoint (routes/health.py) so cloud
+    users see the same detected-config view the host shows, instead of the old
+    "Diagnostics are local-only" dead-end. The auth-token VALUE is never
+    included — only whether one is present. Best-effort: any failure yields an
+    empty dict and the cloud falls back to its hint copy. Late-imports
+    ``dashboard`` (the daemon can already import it for capture_gateway_metric).
+    """
+    try:
+        import dashboard as _d
+
+        gw_port = _d._detect_gateway_port()
+        gw_url = _d.GATEWAY_URL or f"http://localhost:{gw_port}"
+        auto_detected = []
+        if not _d.GATEWAY_URL:
+            auto_detected.append("gateway_port")
+        ws = _d.WORKSPACE or workspace or os.getcwd()
+        if _d.WORKSPACE or workspace:
+            auto_detected.append("workspace")
+        token = _d.GATEWAY_TOKEN or os.environ.get("OPENCLAW_GATEWAY_TOKEN", "").strip()
+        auth_token_status = "present" if token else "missing"
+        openclaw_flags = {}
+        flag_map = {
+            "OPENCLAW_MODEL": "model",
+            "OPENCLAW_REASONING": "reasoning",
+            "OPENCLAW_THINKING": "thinking",
+            "OPENCLAW_MAX_TOKENS": "max_tokens",
+        }
+        for env_key, flag_name in flag_map.items():
+            val = os.environ.get(env_key, "").strip()
+            if val:
+                openclaw_flags[flag_name] = val
+        try:
+            warnings_list, _tips = _d.validate_configuration()
+        except Exception:
+            warnings_list = []
+        return {
+            "gateway_url": gw_url,
+            "gateway_port": gw_port,
+            "workspace_path": ws,
+            "auth_token_status": auth_token_status,
+            "openclaw_flags": openclaw_flags,
+            "warnings": warnings_list,
+            "auto_detected": auto_detected,
+        }
+    except Exception as _e:
+        log.debug("diagnostics snapshot build failed: %s", _e)
+        return {}
+
+
 def _build_memory_files(workspace):
     """Build memory file list for the Memory popup."""
     if not workspace or not os.path.isdir(workspace):
@@ -8174,6 +8226,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "machineInfo": _build_machine_info(),
         "channelList": _build_channel_list(config),
         "ollamaInfo": _detect_ollama_for_heartbeat(),
+        "diagnostics": _build_diagnostics(paths.get("workspace")),
     }
 
     # ── NemoClaw / sandbox enrichment ────────────────────────────────────────


### PR DESCRIPTION
## Problem
On a paid cloud node, the **Diagnostics** panel shows a dead-end:

> Diagnostics are local-only — open the dashboard on the host to inspect detected config.

The data was simply never synced, so cloud users (who pay precisely so they don't have to be on the host) get nothing. Meanwhile **Security** (which also inspects local config) syncs fine and renders an A-grade posture — proving config inspection can ride the snapshot.

## Fix (OSS side)
Add a `diagnostics` block to the E2E-encrypted system snapshot in `sync_system_snapshot`, mirroring the OSS `/api/diagnostics` shape:
- `gateway_url` / `gateway_port`
- `workspace_path` (from the daemon's detected paths)
- `auth_token_status` — `present`/`missing` only, **never the token value**
- `openclaw_flags` (OPENCLAW_* env)
- `warnings` (from `validate_configuration()`)

The cloud renders this client-side from the decrypted snapshot (separate clawmetry-cloud PR), replacing the dead-end.

## Verification
Ran live against `app.clawmetry.com`: pulled the node's encrypted `system_snapshot` from Cloud SQL, decrypted with the node key, and confirmed the new `diagnostics` block is present and well-formed.

## Rollout
This is the OSS half. After merge + `[RELEASE]`, clawmetry-cloud pins the new version and ships the matching render script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)