### PR TITLE
fix(ci): auto-deploy-cloud pin push force + idempotent PR (red pipeline)

### DIFF
--- a/.github/workflows/auto-deploy-cloud.yml
+++ b/.github/workflows/auto-deploy-cloud.yml
@@ -50,13 +50,24 @@ jobs:
           git add Dockerfile
           git diff --staged --quiet && echo "No change needed" && exit 0
           git commit -m "chore: auto-pin clawmetry==${{ steps.oss_version.outputs.version }} from OSS"
-          git push origin "$BRANCH"
-          gh pr create \
-            --repo vivekchand/clawmetry-cloud \
-            --title "chore: auto-pin clawmetry==${{ steps.oss_version.outputs.version }}" \
-            --body "Automated version pin from OSS release ${{ steps.oss_version.outputs.version }}. Merge to deploy." \
-            --base main \
-            --head "$BRANCH"
-          echo "✅ PR opened to pin clawmetry==${{ steps.oss_version.outputs.version }}"
+          # Force-push: this automation-owned branch may already exist from a
+          # prior run for the same version (re-fired release, retried merge).
+          # A plain push is rejected ("fetch first") and the whole job goes red,
+          # which is why the cloud pin silently drifted. Overwrite is safe.
+          git push -f origin "$BRANCH"
+          # Idempotent PR create: gh pr create errors if a PR is already open
+          # for this head. Skip in that case (the force-push already refreshed
+          # the branch, so the existing PR now carries the latest pin).
+          if [ -n "$(gh pr list --repo vivekchand/clawmetry-cloud --head "$BRANCH" --state open --json number -q '.[0].number')" ]; then
+            echo "PR already open for $BRANCH; refreshed via force-push."
+          else
+            gh pr create \
+              --repo vivekchand/clawmetry-cloud \
+              --title "chore: auto-pin clawmetry==${{ steps.oss_version.outputs.version }}" \
+              --body "Automated version pin from OSS release ${{ steps.oss_version.outputs.version }}. Merge to deploy." \
+              --base main \
+              --head "$BRANCH"
+            echo "✅ PR opened to pin clawmetry==${{ steps.oss_version.outputs.version }}"
+          fi
         env:
           GH_TOKEN: ${{ secrets.CLOUD_REPO_PAT }}


### PR DESCRIPTION
## Problem
The **Auto-deploy Cloud on OSS update** job fails on every OSS merge:

```
! [rejected]  auto/pin-clawmetry-0.12.253 -> auto/pin-clawmetry-0.12.253 (fetch first)
error: failed to push some refs
##[error]Process completed with exit code 1
```

It `git push`es the `auto/pin-clawmetry-<ver>` branch without force. When that branch already exists remotely (re-fired release, retried merge, or a same-version re-run) the push is rejected and the whole job goes red. Net effect: the cloud pin PR never opens, so the cloud Dockerfile silently drifts behind OSS (it was stuck at `clawmetry==0.12.247` while OSS shipped 0.12.253).

## Fix
- `git push -f` the automation-owned branch (safe to overwrite).
- Skip `gh pr create` when a PR is already open for that head (the force-push refreshes the existing PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)