### PR TITLE
fix(overview): System Health overflow no longer collides with 'Is your agent alive?' panel

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -634,8 +634,12 @@
   .zoom-wrapper { transform-origin: top left; transition: transform 0.3s ease; }
 
   /* === Split-Screen Overview === */
-  .overview-split { display: grid; grid-template-columns: 60fr 1px 40fr; gap: 0; margin-bottom: 0; height: calc(100vh - 175px); }
-  .overview-flow-pane { position: relative; border: 1px solid var(--border-primary); border-radius: 8px 0 0 8px; overflow: hidden; background: var(--bg-secondary); padding: 4px; }
+  /* height:auto + min-height (not fixed): when the left column's System Health
+     panel is tall it grows the grid instead of overflowing it and colliding
+     with #heartbeat-panel below. flow-pane keeps a min-height so flex:3 can't
+     collapse it in an auto-height grid (mobile @media overrides below). */
+  .overview-split { display: grid; grid-template-columns: 60fr 1px 40fr; gap: 0; margin-bottom: 0; height: auto; min-height: calc(100vh - 175px); }
+  .overview-flow-pane { position: relative; border: 1px solid var(--border-primary); border-radius: 8px 0 0 8px; overflow: hidden; background: var(--bg-secondary); padding: 4px; min-height: 55vh; }
   .overview-flow-pane .flow-container { height: 100%; }
   .overview-flow-pane svg { width: 100%; height: 100%; min-width: 0 !important; }
   .overview-divider { background: var(--border-primary); width: 1px; }

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -122,7 +122,7 @@
   <div class="overview-split">
     <!-- LEFT: Flow + System Health stacked -->
     <div style="display:flex;flex-direction:column;">
-      <div class="overview-flow-pane" style="border-radius:8px 0 0 0;flex:3;min-height:0;">
+      <div class="overview-flow-pane" style="border-radius:8px 0 0 0;flex:3;">
         <div class="grid-overlay"></div>
         <div class="scanline-overlay"></div>
         <div class="flow-container" id="overview-flow-container">

--- a/dashboard.py
+++ b/dashboard.py
@@ -3615,8 +3615,12 @@ DASHBOARD_HTML = r"""
   .zoom-wrapper { transform-origin: top left; transition: transform 0.3s ease; }
 
   /* === Split-Screen Overview === */
-  .overview-split { display: grid; grid-template-columns: 60fr 1px 40fr; gap: 0; margin-bottom: 0; height: calc(100vh - 175px); }
-  .overview-flow-pane { position: relative; border: 1px solid var(--border-primary); border-radius: 8px 0 0 8px; overflow: hidden; background: var(--bg-secondary); padding: 4px; }
+  /* height:auto + min-height (not a fixed height): when the left column's
+     System Health panel is tall it must grow the grid, not overflow it and
+     collide with #heartbeat-panel below (the flow-pane keeps its own
+     min-height so flex:3 can't collapse it in an auto-height grid). */
+  .overview-split { display: grid; grid-template-columns: 60fr 1px 40fr; gap: 0; margin-bottom: 0; height: auto; min-height: calc(100vh - 175px); }
+  .overview-flow-pane { position: relative; border: 1px solid var(--border-primary); border-radius: 8px 0 0 8px; overflow: hidden; background: var(--bg-secondary); padding: 4px; min-height: 55vh; }
   .overview-flow-pane .flow-container { height: 100%; }
   .overview-flow-pane svg { width: 100%; height: 100%; min-width: 0 !important; }
   .overview-divider { background: var(--border-primary); width: 1px; }


### PR DESCRIPTION
## Problem
On the local/OSS dashboard, the **System Health** section overlapped the **❤️ Is your agent alive?** heartbeat panel and the section labels (CHANNELS / DISK USAGE / CRON JOBS / …).

DOM-verified root cause: `.overview-split` is a **fixed-height grid** (`height: calc(100vh - 175px)` = 573px) with `overflow:visible`, but the left column's `#system-health-panel` is ~1450px tall, so it spilled ~880px past the grid onto `#heartbeat-panel` below. (The cloud had a separate `cm-ov-layout` band-aid, so this only manifested locally.)

## Fix
- `.overview-split`: `height: auto; min-height: calc(100vh - 175px)` — grows to fit instead of overflowing.
- `.overview-flow-pane`: `min-height: 55vh` so its `flex:3` can't collapse in the now auto-height grid (the naive `overflow-y:auto` fix collapsed the flow diagram to 10px).
- Removed inline `min-height:0` on the flow pane so the CSS min-height applies. Mobile `@media` still overrides.
- Live CSS is `clawmetry/static/css/dashboard.css`; the dashboard.py inline copy is the dead first `DASHBOARD_HTML` (patched too for consistency).

## Verify
Ran repo HEAD (0.12.254) on `:8950`: grid grows, flow pane stays 436px, heartbeat panel sits cleanly below System Health, **no overlap**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)