### PR TITLE
chore(ui): remove the Logs tab (no value; cloud dead-end + local dup)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6074,7 +6074,7 @@ function openDetailView(type) {
   } else if (type === 'sessions') {
     showSessionsModal();
   } else if (type === 'tools') {
-    switchTab('logs');
+    switchTab('brain');
   } else {
     // For thinking feed and models, stay on overview but could expand in future
     alert('Detail view for ' + type + ' coming soon!');

--- a/dashboard.py
+++ b/dashboard.py
@@ -10813,9 +10813,6 @@ DASHBOARD_HTML = r"""
         <div class="left-nav-item left-nav-item-sub" data-tab="brain" onclick="switchTab('brain')">
           <span class="left-nav-label">Brain</span>
         </div>
-        <div class="left-nav-item left-nav-item-sub" data-tab="logs" onclick="switchTab('logs')">
-          <span class="left-nav-label">Logs</span>
-        </div>
         <div class="left-nav-item left-nav-item-sub" data-tab="models" onclick="switchTab('models')">
           <span class="left-nav-label">Models</span>
         </div>
@@ -10952,7 +10949,6 @@ DASHBOARD_HTML = r"""
 <!-- SKILLS FIDELITY (#687) -->
 {% include 'tabs/skills.html' %}
 
-{% include 'tabs/logs.html' %}
 
 {% if not legacy_nav %}
   </main>


### PR DESCRIPTION
Per product call: the Logs tab adds no value. In cloud it was a hard dead-end ('Full logs are not available in cloud view'); locally it duplicated the live stream on Flow/Brain. Removes the nav item + page include + repoints the overview 'tools' KPI to Brain. Verified on :8950: page renders, Logs nav + page gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)