### PR TITLE
fix(embodied): sync per-session transcripts to cloud via snapshot

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7386,6 +7386,53 @@ def _build_model_attribution():
         return {}
 
 
+def _build_transcripts(limit_sessions=8, msg_cap=80):
+    """Recent per-session transcripts for the cloud Embodied tab.
+
+    Built on the daemon's OWN store handle (a read-only re-open deadlocks the
+    write lock — same trap as model attribution). Returns ``{session_id:
+    <transcript dict>}`` for the most-recent sessions, message-capped to bound
+    the encrypted snapshot size. The transcript dict matches what
+    ``/api/transcript/<id>`` returns, so the cloud just hands it to the
+    existing Embodied renderer. Best-effort -> {}.
+    """
+    try:
+        from clawmetry import local_store as _ls
+        import routes.sessions as _s
+
+        store = _ls.get_store()
+        if store is None:
+            return {}
+        evs = store.query_events(limit=5000)  # DESC by ts (most recent first)
+        if not evs:
+            return {}
+        recent_sids = []
+        for e in evs:
+            sid = (e.get("session_id") or "").strip()
+            if sid and sid not in recent_sids:
+                recent_sids.append(sid)
+            if len(recent_sids) >= limit_sessions:
+                break
+        out = {}
+        for sid in recent_sids:
+            try:
+                rows = store.query_events(session_id=sid, limit=10000)
+                t = _s._try_local_store_transcript(sid, _events=rows)
+            except Exception:
+                t = None
+            if t and t.get("messages"):
+                msgs = t["messages"]
+                if len(msgs) > msg_cap:
+                    t = dict(t)
+                    t["messages"] = msgs[-msg_cap:]
+                    t["_truncated"] = True
+                out[sid] = t
+        return out
+    except Exception as _e:
+        log.debug("transcripts snapshot build failed: %s", _e)
+        return {}
+
+
 def _build_memory_files(workspace):
     """Build memory file list for the Memory popup."""
     if not workspace or not os.path.isdir(workspace):
@@ -8287,6 +8334,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "ollamaInfo": _detect_ollama_for_heartbeat(),
         "diagnostics": _build_diagnostics(paths.get("workspace")),
         "modelAttribution": _build_model_attribution(),
+        "transcripts": _build_transcripts(),
     }
 
     # ── NemoClaw / sandbox enrichment ────────────────────────────────────────

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -3189,7 +3189,7 @@ def _extract_decoding_params(obj):
     return out
 
 
-def _try_local_store_transcript(session_id: str):
+def _try_local_store_transcript(session_id: str, _events=None):
     """Read a session transcript directly from the DuckDB events table.
 
     Returns the same response shape as the JSONL parser. Returns ``None``
@@ -3209,13 +3209,14 @@ def _try_local_store_transcript(session_id: str):
     # `reference_duckdb_process_lock.md`), forced fall-through to the JSONL
     # walker → 5.5s p95 the latency probe (#1287) surfaced for
     # ``sessions.api_transcript``.
-    rows = None
-    try:
-        from routes.local_query import local_store_via_daemon
-        rows = local_store_via_daemon(
-            "query_events", session_id=session_id, limit=10000)
-    except Exception:
-        rows = None
+    rows = _events
+    if rows is None:
+        try:
+            from routes.local_query import local_store_via_daemon
+            rows = local_store_via_daemon(
+                "query_events", session_id=session_id, limit=10000)
+        except Exception:
+            rows = None
     if rows is None:
         # Single-process fallback (tests/dev with no sync daemon).
         try:


### PR DESCRIPTION
Cloud Embodied tab showed 'No messages in this transcript' — /api/transcript/<id> read the cloud's empty filesystem; transcripts live only in local DuckDB. Daemon now puts recent per-session transcripts (capped 80 msgs, ~8 sessions) in the encrypted snapshot, built on its own store handle (read-only re-open deadlocks the write lock). `_try_local_store_transcript` refactored to accept pre-fetched events so the daemon reuses the full message builder. clawmetry-cloud intercepts /api/transcript/<id> (separate PR). Verified: cloud snapshot decrypts to 8 sessions with real messages; IDs match the Embodied list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)