### PR TITLE
feat: sub-agents via DuckDB + agent ways-of-working doc

### DIFF
--- a/agents-ways-of-working.md
+++ b/agents-ways-of-working.md
@@ -1,0 +1,102 @@
+# Agents — Ways of Working (ClawMetry OSS)
+
+How an autonomous agent should ship a change in this repo **end to end**: code → PR → green CI → merge → `[RELEASE]` → PyPI → promote to clawmetry-cloud → verify live. Read this with `CLAUDE.md` (architecture) and the cloud repo's `agents-ways-of-working.md` (the other half of the loop).
+
+The north star: **don't stop at "code compiles." Stop at "verified working in production, by me, with evidence."** Use `/goal` and keep iterating until that's true.
+
+---
+
+## 0. Before you touch anything
+
+1. **Scan open issues/PRs for human claims.** If a human said "picking this up" / "working on" / "I'll take" in the last 7 days, do NOT open a competing PR. Automation is the night-shift janitor, not the day-shift engineer.
+2. **Scan the user's recent comments** on open PRs/issues and address them first.
+3. **Re-read the goal.** If invoked via `/goal`, the goal persists until the *outcome* is achieved and verified — not until the code is written.
+
+## 1. The data-flow rule (this is the one that bites)
+
+ClawMetry is **read-only** and **DuckDB-first**:
+
+- Every feature persists to and reads from the local **DuckDB** store. Reading raw JSONL, log files, `sessions.json`, or process stats *inside a request handler* is a violation — it works locally and silently returns empty in cloud (the cloud container has no `~/.openclaw` filesystem). Most "works locally, broken in cloud" bugs are exactly this.
+- The blessed path for anything the cloud needs to display:
+  ```
+  jsonl/gateway  →  daemon ingest  →  DuckDB  →  (sync_system_snapshot)  →  encrypted snapshot  →  Redis  →  cloud decrypts client-side & renders
+  ```
+- The daemon **owns the DuckDB writer lock**. Build snapshot data on the daemon's **own** store handle (`local_store.get_store()`), never a `read_only=True` re-open — that deadlocks the writer (the `#1771` brick-lock: a cached RO handle blocks every subsequent write; symptom is `cannot open writer — read-only handle already exists`). When you need a read in a separate process, go through the daemon's `/__local_query__/<method>` HTTP proxy (`local_store_via_daemon`), not a direct open.
+- If the agent runtime's **model** is needed (e.g. Self-Evolve), don't try to make ClawMetry call an LLM or get gateway write scope — it's read-only by design and its gateway token is `operator.read` only. Shell out to **`openclaw agent --session-id <stable> --message <prompt> --json`**: OpenClaw runs the turn on its own credentials, the transcript lands on disk → DuckDB, and you parse the result. (`openclaw` is a Node script — under the daemon's launchd PATH `node` isn't found, so pass an augmented `PATH` to the subprocess.)
+
+## 2. Make the change
+
+- New HTTP endpoints go in `routes/<feature>.py` on that feature's Blueprint, not in `dashboard.py`. Shared helpers reach back via late `import dashboard as _d`.
+- Embedded frontend lives in `dashboard.py` template strings AND in `clawmetry/static/` + `clawmetry/templates/`. Note: `dashboard.py` defines `DASHBOARD_HTML` twice — the **second** wins and loads `static/css/dashboard.css` + `templates/tabs/*.html`. The inline `<style>`/HTML earlier in the file is dead. Edit the static/template files.
+- Match surrounding style: `snake_case` funcs, minimal deps (Flask + waitress + cryptography), never crash on bad input (graceful fallbacks + a logged warning).
+- No em-dashes / double-dashes in user-facing copy (banners, marketing). Code comments + PR text are fine.
+
+## 3. Verify locally BEFORE the PR (the loop that actually catches bugs)
+
+The daemon does **not** run the repo — it runs a copy in `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (a venv with no pip). Editing the repo + restarting does nothing. To test daemon code:
+
+```bash
+SP=~/.clawmetry/lib/python3.11/site-packages/clawmetry
+cp clawmetry/sync.py "$SP/sync.py"          # copy EACH changed file
+rm -f "$SP/__pycache__/sync"*.pyc           # clear stale bytecode (it can shadow your .py)
+launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync   # restart the sync daemon
+```
+
+Then prove the data actually flows by **decrypting the live cloud snapshot** (this is the real E2E check, not a synthetic test):
+
+```python
+# reads ~/.clawmetry/config.json for node_id + api_key + encryption_key,
+# GETs https://app.clawmetry.com/api/cloud/system-snapshot, AES-256-GCM decrypts
+# (nonce = first 12 bytes), and asserts your new key is present + correct.
+```
+
+Gotchas that have burned us:
+- **Synthetic tests pass while real data flunks.** OpenClaw v3 normalises event types (`message`→`prompt.submitted`/`model.completed`, etc.). Always smoke against the live DuckDB, not hand-crafted fixtures.
+- **DuckDB writer-lock contention.** If the daemon logs `ANOTHER PROCESS HOLDS THE DUCKDB WRITER LOCK`, a stray `dashboard.py --port 89xx` dev server grabbed it. Kill the strays, then restart the daemon so it reclaims the writer.
+- **Restart BOTH** the dashboard and the sync daemon after an upgrade — the daemon keeps the old wheel in memory otherwise.
+- When you claim "works locally," confirm you're testing **repo HEAD on a known port**, not a stale long-running server.
+
+## 4. PR → green CI → merge
+
+```bash
+git checkout -B feat/<slug> origin/main      # branch off origin/main, never a stale release branch
+gh pr create --title "feat: …" --body "…"    # explain WHY + the verification you did
+```
+
+- End commit messages with the `Co-Authored-By` trailer; end PR bodies with the Claude Code footer.
+- **CI must be 100% green before merge — red means it will not deploy.** The matrix includes: Syntax & Lint, API Tests (3 OS), E2E Browser Tests, **Live OpenClaw E2E (real gateway)**, MOAT Verifier + Keystone, Eval Suite Gate, Sync matrix (3 OS × 3 Py), Install/boot/health, wheel/asset presence, pip install.
+- A red check is a real signal. **Fix the cause — code or test — never skip or `xfail` to get green.** If a test encodes the wrong expectation (e.g. an IA-v2 rename), fix the test to match reality; read the *rendered* HTML before "fixing" a selector so you don't fix half of it.
+- Merge with `gh pr merge <n> --squash --delete-branch`.
+- After any cross-cutting fix on main, **rebase every open PR** (`gh pr update-branch`) — "main green" ≠ "PRs green."
+
+## 5. Release to PyPI (`[RELEASE]`)
+
+A feature PR merging to main does **not** publish. Publishing is triggered by merging a **separate PR whose title starts with `[RELEASE]`** — `release-on-merge.yml` then bumps the patch version and uploads to PyPI.
+
+```bash
+git checkout -b release/<slug> origin/main
+# add a CHANGELOG.md entry under [Unreleased]: why / what / verified
+gh pr create --title "[RELEASE] <summary> (carries #<feature-pr>)" --body "…"
+```
+
+- **Never** hand-edit `__version__` or push a `v*` tag — the workflow does it.
+- `gh pr merge --squash` defaults the commit subject to the *last commit*, dropping the PR title. Pass `--subject "[RELEASE] … (#<n>)"` and **verify** `git log origin/main -1` still starts with `[RELEASE]`, or the release won't fire.
+- Wait for `release-on-merge.yml` to finish AND for the new version to appear on PyPI before bumping the cloud pin — there's a propagation race where the cloud Docker build pulls a stale index. Poll `https://pypi.org/pypi/clawmetry/json` for the new version.
+
+## 6. Promote to clawmetry-cloud
+
+Hand off to the cloud repo's `agents-ways-of-working.md`. In short: bump `clawmetry==<new>` in the cloud `Dockerfile` *only when the daemon code changed* (a cloud-only render fix that reads an already-shipped snapshot key needs no bump), add the matching `cm-cloud-*` interceptor + route-policy entry, get cloud CI green, and verify the deploy.
+
+## 7. Verify in production (the part that's non-negotiable)
+
+- Decrypt the live cloud snapshot again post-deploy and confirm your data is present.
+- Open the actual tab in a browser, confirm it renders, and **attach a screenshot** within ~5 min of merge (especially for any cloud UI surface). The screenshot catches stale-rebase regressions as a bonus.
+- Only then say it's done — plainly, with the evidence. If something is partial, say which part and why.
+
+## 8. Judgment
+
+- Decide ship-vs-hold trade-offs yourself; state a one-line rationale and act. Don't bounce routine decisions back to the user.
+- When a finding contradicts the premise of a request (e.g. "spawn a gateway session" turns out to need write scope ClawMetry can't have), surface it with evidence and propose the path that actually works.
+- Save durable, non-obvious learnings to memory so the next agent doesn't re-burn them.
+
+🤖 Maintained by Claude Code agents. If you discover a new gotcha, add it here.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7386,7 +7386,7 @@ def _build_model_attribution():
         return {}
 
 
-def _build_transcripts(limit_sessions=8, msg_cap=80):
+def _build_transcripts(limit_sessions=8, msg_cap=80, extra_sids=None):
     """Recent per-session transcripts for the cloud Embodied tab.
 
     Built on the daemon's OWN store handle (a read-only re-open deadlocks the
@@ -7394,7 +7394,12 @@ def _build_transcripts(limit_sessions=8, msg_cap=80):
     <transcript dict>}`` for the most-recent sessions, message-capped to bound
     the encrypted snapshot size. The transcript dict matches what
     ``/api/transcript/<id>`` returns, so the cloud just hands it to the
-    existing Embodied renderer. Best-effort -> {}.
+    existing Embodied renderer.
+
+    ``extra_sids`` are session ids that MUST be included even if they fall
+    outside the most-recent-N window — e.g. ACTIVE sub-agents, so the cloud
+    Active Tasks click-through ("see what this sub-agent is doing") has a
+    transcript to render. Best-effort -> {}.
     """
     try:
         from clawmetry import local_store as _ls
@@ -7404,15 +7409,20 @@ def _build_transcripts(limit_sessions=8, msg_cap=80):
         if store is None:
             return {}
         evs = store.query_events(limit=5000)  # DESC by ts (most recent first)
-        if not evs:
-            return {}
         recent_sids = []
-        for e in evs:
+        for e in (evs or []):
             sid = (e.get("session_id") or "").strip()
             if sid and sid not in recent_sids:
                 recent_sids.append(sid)
             if len(recent_sids) >= limit_sessions:
                 break
+        # Always include explicitly-requested sessions (active sub-agents).
+        for sid in (extra_sids or []):
+            sid = (sid or "").strip()
+            if sid and sid not in recent_sids:
+                recent_sids.append(sid)
+        if not recent_sids:
+            return {}
         out = {}
         for sid in recent_sids:
             try:
@@ -8494,6 +8504,55 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         except Exception as e:
             log.debug(f"Session index read error: {e}")
 
+    # jsonl -> DuckDB -> snapshot. Write each sub-agent into the local store,
+    # then read them BACK from DuckDB so the cloud snapshot and the OSS
+    # /api/subagents fast path share ONE source (query_subagents). Previously
+    # the snapshot shipped the filesystem-built list directly, bypassing
+    # DuckDB — the data path is now jsonl -> duckdb -> redis -> cloud,
+    # identical in OSS and cloud.
+    try:
+        from clawmetry import local_store as _ls_sa
+
+        _sa_store = _ls_sa.get_store()
+        for _sa in subagents_list:
+            _sid = _sa.get("sessionId") or _sa.get("key")
+            if not _sid:
+                continue
+            _sa_store.ingest_subagent(
+                {
+                    "subagent_id": _sid,
+                    "agent_type": "openclaw",
+                    "task": _sa.get("task", ""),
+                    "status": _sa.get("status", ""),
+                    "token_count": _sa.get("tokens", 0),
+                    "model": _sa.get("model", ""),
+                    "label": _sa.get("label", ""),
+                    "displayName": _sa.get("displayName", ""),
+                    "session_file": _sa.get("sessionFile", ""),
+                    "updated_at_ms": _sa.get("updatedAt", 0),
+                    "runtime_ms": _sa.get("runtimeMs", 0),
+                }
+            )
+    except Exception as _e:
+        log.debug("local_store: subagent ingest failed: %s", _e)
+    try:
+        import routes.sessions as _sa_routes
+        from clawmetry import local_store as _ls_rb
+
+        # Pass rows from the daemon's OWN store handle — the cross-process
+        # _ls_call proxy is unreliable when called from inside the daemon.
+        _duck_rows = _ls_rb.get_store().query_subagents(limit=500)
+        _duck = _sa_routes._try_local_store_subagents(_rows=_duck_rows)
+        if _duck and isinstance(_duck.get("subagents"), list):
+            # Keep the filesystem list only if the DuckDB read came back empty
+            # while the FS had rows (defensive — never blank a live workforce).
+            if _duck["subagents"] or not subagents_list:
+                subagents_list = _duck["subagents"]
+                _dc = _duck.get("counts") or {}
+                active_count = _dc.get("active", active_count)
+    except Exception as _e:
+        log.debug("subagents read-back from DuckDB failed: %s", _e)
+
     # Crons
     cron_enabled = 0
     cron_disabled = 0
@@ -8561,7 +8620,13 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "ollamaInfo": _detect_ollama_for_heartbeat(),
         "diagnostics": _build_diagnostics(paths.get("workspace")),
         "modelAttribution": _build_model_attribution(),
-        "transcripts": _build_transcripts(),
+        "transcripts": _build_transcripts(
+            extra_sids=[
+                s["sessionId"]
+                for s in subagents_list
+                if s.get("status") in ("active", "idle") and s.get("sessionId")
+            ]
+        ),
         "selfEvolve": _build_selfevolve(paths.get("workspace")),
     }
 
@@ -8636,23 +8701,10 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
             "active_subagents":  active_count,
         })
 
-        for sa in subagents_list:
-            sid = sa.get("sessionId") or sa.get("key")
-            if not sid:
-                continue
-            _store.ingest_subagent({
-                "subagent_id":       sid,
-                "agent_type":        "openclaw",
-                "task":              sa.get("task", ""),
-                "status":            sa.get("status", ""),
-                "token_count":       sa.get("tokens", 0),
-                "model":             sa.get("model", ""),
-                "label":             sa.get("label", ""),
-                "displayName":       sa.get("displayName", ""),
-                "session_file":      sa.get("sessionFile", ""),
-                "updated_at_ms":     sa.get("updatedAt", 0),
-                "runtime_ms":        sa.get("runtimeMs", 0),
-            })
+        # Sub-agent ingest moved EARLIER (right after the session-index read)
+        # so the snapshot reads sub-agents back from DuckDB. Re-ingesting here
+        # would corrupt the rows — subagents_list now carries the DuckDB shape
+        # (displayName/totalTokens), not the filesystem shape (label/tokens).
     except Exception as _e:
         log.debug("local_store: snapshot/subagent write-through failed: %s", _e)
 

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -1874,13 +1874,18 @@ def _scan_spawn_events_from_jsonl(sessions_dir, max_files=None, tail_bytes=None)
     return subs
 
 
-def _try_local_store_subagents():
+def _try_local_store_subagents(_rows=None):
     """Fast path for /api/subagents. Reads the pre-aggregated ``subagents``
     table that the sync daemon write-throughs from each system-snapshot
     pass (see ``clawmetry/sync.py`` ``ingest_subagent`` call site). Each
     row carries the same fields the JSONL-walking legacy path derives, so
     we can serve the dashboard's Subagent Tracker tab without re-scanning
     every session JSONL on every request.
+
+    ``_rows`` lets a caller pass ``query_subagents`` rows it already has
+    (e.g. the sync daemon building the snapshot on its OWN store handle,
+    where the cross-process ``_ls_call`` proxy is the wrong tool). When
+    omitted we fetch via the daemon proxy as usual.
 
     Returns ``None`` when the table is empty so the legacy gateway-RPC +
     JSONL fallback fires for older OpenClaw versions / installs whose
@@ -1889,7 +1894,7 @@ def _try_local_store_subagents():
     spawned — keeps the route off the 100-file JSONL walker for the
     common empty case.
     """
-    rows = _ls_call("query_subagents", limit=500)
+    rows = _rows if _rows is not None else _ls_call("query_subagents", limit=500)
     # Distinguish "store missing entirely" (rows is None) from "store is
     # there but no subagent rows yet" (rows == []). Both return None so
     # the legacy gateway-RPC + JSONL fallback fires — older OpenClaw


### PR DESCRIPTION
## What
Active Tasks / sub-agent workforce now flows through DuckDB end to end, and clicking a sub-agent shows its transcript.

## Why
The cloud Active Tasks panel showed "No active tasks" while sub-agents ran (cloud `/api/subagents` read the local FS → empty on the container). And the snapshot shipped the sub-agent list straight from `sessions.json` (filesystem), bypassing DuckDB.

## How (jsonl → DuckDB → redis → cloud)
- Daemon ingests sub-agents into DuckDB, then reads them BACK via `query_subagents` for the snapshot. `_try_local_store_subagents(_rows=...)` lets the daemon pass rows from its own store handle (the cross-process `_ls_call` proxy is unreliable in-daemon). OSS `/api/subagents` and the cloud snapshot now share one source.
- `_build_transcripts(extra_sids=...)` always includes active/idle sub-agents' transcripts (keyed by sessionId via `query_events`) so the cloud click-through has data.

## Verified live
Spawned 5 parallel sub-agents (`IN-Pol-1…5`); the node's encrypted snapshot decrypts to `subagents` (DuckDB shape) + per-sub-agent transcripts; OSS local `/api/subagents` returns all 5 with status + names.

Also adds `agents-ways-of-working.md` (the full ship loop + gotchas). Cloud render side: clawmetry-cloud PR #1016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)