### PR TITLE
fix(cli): set CLAWMETRY_ROLE before dashboard import (completes the writer-steal fix)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2376,6 +2376,13 @@ def main() -> None:
             "v2 preview at http://localhost:8900/v2 · back to v1 at /",
             flush=True,
         )
+    # Tag this process as the dashboard BEFORE importing dashboard, so every
+    # get_store() in dashboard.py (module-level + handlers) is barred from the
+    # DuckDB writer — only the sync daemon writes. Set before the import or a
+    # module-level open would race in before the gate is active. The daemon
+    # (-m clawmetry.sync) never takes this path and calls mark_writer_owner(),
+    # which overrides the gate.
+    os.environ["CLAWMETRY_ROLE"] = "dashboard"
     from dashboard import main as dashboard_main
 
     # Anonymous, opt-out, once-per-install ping. See clawmetry/telemetry.py


### PR DESCRIPTION
Follow-up to #1810: the role gate must be set **before** `from dashboard import main` or a module-level/handler `get_store()` races in before the gate is active and the dashboard steals the DuckDB writer. Verified live: daemon keeps the writer across restarts, Models + Cost-history populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)