### PR TITLE
fix(approvals): make approvals fire AND surface in the cloud inbox (e2e)

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -235,6 +235,33 @@ def _fetch_cloud_policies(api_key: str) -> list[dict]:
 
 # ── Match engine ──────────────────────────────────────────────────────────
 
+# Harness-agnostic tool categories. Approval policies are authored against
+# OpenClaw's tool names (``exec``, ``read``, …), but other harnesses emit the
+# SAME semantic tool under a different name — claude-cli/Claude Code calls the
+# shell ``Bash``, Codex ``shell``, etc. Without this map a policy with
+# ``tool: exec`` silently never matches a ``Bash`` toolCall, so no approval
+# ever fires (the recurring "I toggled rules but never see a pending
+# approval" bug). Map both sides to a canonical category before comparing.
+_TOOL_CANON = {}
+for _canon, _aliases in {
+    "exec": ["exec", "bash", "sh", "shell", "zsh", "fish", "powershell", "pwsh",
+             "cmd", "command", "run", "run_command", "run_terminal_cmd",
+             "terminal", "execute", "shell_command", "bashtool"],
+    "read": ["read", "cat", "view", "open", "read_file", "get_file", "fs_read"],
+    "write": ["write", "edit", "multiedit", "str_replace", "str_replace_editor",
+              "create", "apply_patch", "write_file", "fs_write"],
+    "web": ["web_fetch", "webfetch", "fetch", "curl", "wget", "http",
+            "web_search", "websearch", "browser", "browse"],
+    "search": ["grep", "glob", "ls", "find", "search", "memory_search"],
+}.items():
+    for _a in _aliases:
+        _TOOL_CANON[_a] = _canon
+
+
+def _canonical_tool(name: str) -> str:
+    """Map a harness-specific tool name to its canonical category (or itself)."""
+    return _TOOL_CANON.get((name or "").strip().lower(), (name or "").strip().lower())
+
 
 def _extract_command(tool_name: str, args: dict) -> str:
     """Best-effort: derive the human-readable 'command' string from toolCall args.
@@ -269,7 +296,10 @@ def match_policy(policies: list[dict], tool_name: str, args: dict):
     except Exception:
         pass
     for p in policies:
-        if p.get("tool") and tool_name.lower() != p["tool"].lower():
+        # Harness-agnostic tool match: a policy authored for ``exec`` matches a
+        # ``Bash`` / ``shell`` toolCall (see _canonical_tool). Falls back to a
+        # plain case-insensitive compare when neither side maps to a category.
+        if p.get("tool") and _canonical_tool(tool_name) != _canonical_tool(p["tool"]):
             continue
         if p.get("command_regex") and not p["command_regex"].search(cmd):
             continue

--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -454,6 +454,26 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
         "policy_name": policy["name"],
         "timeout": policy["timeout"],
     }
+    # Persist to local DuckDB so the daemon's heartbeat cache_push surfaces
+    # this in the cloud Approvals inbox — which reads the
+    # approvals:{owner_hash}:queue Redis key, NOT the legacy
+    # _post_approval_request endpoint. Without this the watcher fired but the
+    # inbox stayed empty ("toggled rules but never see a pending approval").
+    try:
+        import hashlib as _hl
+        from clawmetry import local_store as _lsa
+        _lsa.get_store().ingest_approval({
+            "id": approval_id,
+            "owner_hash": _hl.sha256((api_key or "").encode()).hexdigest(),
+            "requestor_session_id": session_id,
+            "action": f"{tool_name}: {cmd_preview}",
+            "args": args,
+            "status": "pending",
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        })
+    except Exception as _ae:
+        log.debug("approval DuckDB persist failed: %s", _ae)
+
     resp = _post_approval_request(api_key, req)
     if not resp:
         # Cloud unreachable — fail-open by default (don't block the agent)
@@ -469,6 +489,14 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
     killed = False
     if decision == "denied":
         killed = _kill_session(session_id)
+    # Mirror the resolution into DuckDB so the approval leaves the cloud
+    # pending queue (the next cache_push won't re-surface it as pending).
+    try:
+        from clawmetry import local_store as _lsa2
+        _lsa2.get_store().update_approval_decision(
+            approval_id, decision, "cloud", None)
+    except Exception as _ue:
+        log.debug("approval decision update failed: %s", _ue)
     result = {"decision": decision, "policy": policy["name"], "killed": killed,
               "approval_id": approval_id}
     log.info(f"[approval] {approval_id} → {decision}, killed={killed}")


### PR DESCRIPTION
## The bug
"Protection rules toggled, but I've never seen a pending approval." Three stacked bugs, all fixed + verified e2e on a live node.

## Root causes & fixes
1. **Watcher never matched** — policies are authored for OpenClaw's tool name `exec`, but claude-cli emits `Bash`; the exact-name compare skipped every shell policy. Fix: `_canonical_tool()` maps harness tool names to a category (exec/read/write/web/search).
2. **Ingestion could stall** — a dashboard process holding the DuckDB writer starves the daemon, so no events reach DuckDB and the watcher sees nothing. (Mitigated by the role-gate writer fix; surfaced here as the reason the watcher looked dead.)
3. **Fired approvals never reached the cloud** — `process_tool_call` only POSTed via the legacy `_post_approval_request` endpoint and never wrote the DuckDB `approvals` table, but the cloud inbox reads the `approvals:{owner_hash}:queue` Redis key populated by the heartbeat cache_push FROM that table. Fix: `ingest_approval(pending)` on match + `update_approval_decision()` on resolve.

## Verified e2e (live)
Agent runs `rm -rf` → watcher matches `Block destructive deletes` → DuckDB `pending` → heartbeat cache_push → `/api/cloud/approvals` returns the encrypted `approvals_blob` → **decrypts client-side to a visible PENDING approval (count=1)**. On timeout it resolves to `denied` and leaves the queue.

NOTE: this is the **detection + surface** layer (you chose "both"). The OpenClaw-native **pre-execution** gate (`tools.exec.ask` + gateway `exec.approval.*`) is the enforcement layer — blocked on an `operator.approvals` scope grant for ClawMetry's token; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)