### PR TITLE
fix(alerts): Enable works e2e + stop dashboard locking the DuckDB writer

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -961,6 +961,41 @@ def _daemon_registered() -> bool:
         return False
 
 
+# Cached proxy singleton (the dashboard's stand-in for the writer-owning daemon).
+_store_proxy = None
+
+
+class _ProxyStore:
+    """Stand-in returned by ``get_store()`` in a NON-writer process (the
+    dashboard) when a daemon owns the DuckDB writer.
+
+    DuckDB locks at the PROCESS level: opening *any* handle here — even
+    read-only — takes a file lock that blocks the daemon's writer, which
+    starves ingestion and silently breaks Models/Embodied/Cost/alerts.
+    Downgrading to read_only is NOT enough (that's the recurring bug). So
+    instead of opening DuckDB we forward every method call to the daemon's
+    HTTP query proxy. Read methods (``query_*``) work; the dashboard must not
+    write, so write methods just no-op via the proxy (returns None)."""
+
+    _read_only = True
+
+    def __getattr__(self, name):
+        def _forward(*args, **kwargs):
+            try:
+                from routes.local_query import local_store_via_daemon
+                return local_store_via_daemon(name, **kwargs)
+            except Exception:
+                return None
+        return _forward
+
+    def health(self):
+        try:
+            from routes.local_query import local_store_via_daemon
+            return local_store_via_daemon("health") or {"ok": False, "_via": "proxy"}
+        except Exception:
+            return {"ok": False, "_via": "proxy"}
+
+
 def get_store(read_only: bool = False) -> "LocalStore":
     """Lazy-init the process-wide singleton. Cheap to call repeatedly.
 
@@ -974,27 +1009,26 @@ def get_store(read_only: bool = False) -> "LocalStore":
     handle to the same file in the same process). All read-paths on
     LocalStore work the same regardless of mode; ingest() raises in RO mode.
     """
-    global _store_rw, _store_ro
+    global _store_rw, _store_ro, _store_proxy
+    # Writer-owner (daemon) or single-process boot already holds the writer.
+    if _store_rw is not None:
+        return _store_rw
+    # NON-writer process with a daemon present (or tagged as the dashboard):
+    # NEVER open a DuckDB handle — even a read-only handle takes a
+    # process-level lock that blocks the daemon's writer (the recurring
+    # ingest-stall / Models / Embodied / alerts breakage; downgrading to
+    # read_only was not enough). Return a proxy that forwards to the daemon's
+    # HTTP query server. The daemon itself called mark_writer_owner() so
+    # _writer_owner short-circuits this and it opens the real writer below.
+    if not _writer_owner and (
+        os.environ.get("CLAWMETRY_ROLE") == "dashboard"
+        or _daemon_registered()
+    ):
+        if _store_proxy is None:
+            _store_proxy = _ProxyStore()
+        return _store_proxy
     if not read_only:
-        if _store_rw is not None:
-            return _store_rw
-        # Never steal the writer from a live daemon. A non-owner process (the
-        # dashboard) that opens the writer during a daemon-restart window
-        # starves the daemon's ingest and blanks every snapshot read. Downgrade
-        # to read_only — in the daemon this branch is skipped (it called
-        # mark_writer_owner()), and in single-process boots no live owner is
-        # registered so the writer still opens.
-        if not _writer_owner and (
-            os.environ.get("CLAWMETRY_ROLE") == "dashboard"
-            or _daemon_registered()
-        ):
-            # The dashboard process is structurally barred from the writer
-            # (CLAWMETRY_ROLE), which also closes the cold-start race where
-            # local_query.json is briefly absent. The daemon is unaffected: it
-            # calls mark_writer_owner() so _writer_owner short-circuits this.
-            read_only = True
-        else:
-          with _store_lock:
+        with _store_lock:
             if _store_rw is None:
                 if _store_ro is not None:
                     # Evict the cached RO handle so we can open the writer.
@@ -1034,7 +1068,7 @@ def get_store(read_only: bool = False) -> "LocalStore":
 def _reset_singleton_for_tests() -> None:
     """Test-only helper. Drops the cached stores so the next get_store() picks
     up new env vars (DB path, flush knobs)."""
-    global _store_rw, _store_ro
+    global _store_rw, _store_ro, _store_proxy
     with _store_lock:
         for name in ("_store_rw", "_store_ro"):
             store = globals().get(name)
@@ -1045,6 +1079,7 @@ def _reset_singleton_for_tests() -> None:
                     pass
         _store_rw = None
         _store_ro = None
+        _store_proxy = None
 
 
 class LocalStore:

--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -288,11 +288,34 @@
       return openPaywall();
     }
     try {
-      const resp = await fetch('/api/cloud-proxy/api/alerts/' + ruleId, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ enabled: newEnabled }),
-      });
+      // Enabling a canned EXAMPLE creates a real rule from the template.
+      // The old code PUT '/api/alerts/example_cost' which 404s ("unknown
+      // example id"), caught + swallowed -> "Enable does nothing". A real
+      // (already-saved) rule still goes through the PUT toggle path.
+      const ex = EXAMPLE_RULES.find(r => r.id === ruleId);
+      const isExample = !!ex && !alertsState.rules.find(r => r.id === ruleId);
+      let resp;
+      if (isExample && newEnabled) {
+        resp = await fetch('/api/cloud-proxy/api/alerts', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            alert_type: ex.alert_type,
+            name: ex.name,
+            threshold_value: ex.threshold_value,
+            threshold_unit: ex.threshold_unit || '',
+            enabled: true,
+            channel_ids: [],
+            re_alert_policy: 'once',
+          }),
+        });
+      } else {
+        resp = await fetch('/api/cloud-proxy/api/alerts/' + ruleId, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled: newEnabled }),
+        });
+      }
       if (resp.status === 402) {
         // Hit the Free-tier cap server-side
         return openPaywall();

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5793,7 +5793,14 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
         _action_channel_test(config, action)
         return
     if atype in ("alert_rule_upsert", "alert_rule_delete"):
-        _apply_pending_write(atype, action)
+        # Stamp THIS node's owner_hash: the cloud relay body carries no
+        # owner_hash, so without this the rule lands with owner_hash=NULL and
+        # _build_alert_rules_cache_pushes' owner_hash filter silently drops it
+        # (the cloud Alerts tab then never shows the rule the user just saved).
+        _apply_pending_write(
+            atype, action,
+            owner_hash=_owner_hash_for_token(config.get("api_key", "")),
+        )
         return
     if atype == "approval_decision":
         _apply_approval_decision(action)
@@ -6161,7 +6168,7 @@ def _dispatch_pending_queries(config: dict, pending: list) -> None:
 # (clawmetry-cloud/routes/alerts.py:_enqueue_alert_rule_change).
 
 
-def _apply_pending_write(qtype: str, q: dict) -> None:
+def _apply_pending_write(qtype: str, q: dict, owner_hash: str | None = None) -> None:
     """Apply one cloud-authored write to the local DuckDB.
 
     Routed by ``type``:
@@ -6183,7 +6190,7 @@ def _apply_pending_write(qtype: str, q: dict) -> None:
         # the evaluator + dashboard get everything without a follow-up fetch.
         rule = {
             "id":            body.get("id") or q.get("id"),
-            "owner_hash":    body.get("owner_hash"),
+            "owner_hash":    body.get("owner_hash") or owner_hash,
             "name":          body.get("name"),
             "condition_json": body,
             "enabled":       body.get("enabled", True),


### PR DESCRIPTION
Three bugs behind "Enable does nothing":
1. **Writer-lock (recurring root cause):** the dashboard's `get_store()` opened a DuckDB handle; even read-only locks block the daemon's writer (downgrading to read_only wasn't enough). Now returns a `_ProxyStore` forwarding to the daemon HTTP proxy — opens NO handle. Verified: daemon keeps the writer across restarts; dashboard reads work via proxy.
2. **owner_hash:** relay `alert_rule_upsert` body lacks owner_hash → rules stored NULL → cache_push filter dropped them. Daemon now stamps its own.
3. **alerts.js:** Enable on an example PUT a non-existent id (404 → silent). Now POSTs to create from the template.

Verified e2e: POST → daemon upsert (owner stamped) → cache_push → cloud GET returns the rule (rules_blob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)