### PR TITLE
feat(update): one-click 'Update now' button on update banner + daemon kickstart

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -15291,3 +15291,102 @@ function _ncEsc(s) {
     }).catch(function(){});
   } catch(e) {}
 })();
+
+// ── Update banner (PyPI version check + one-click upgrade) ─────────────
+// Functions are referenced from clawmetry/templates/partials/banners.html.
+// /api/update-check/status decides visibility; /api/update runs pip install.
+async function checkUpdateStatus() {
+  try {
+    var data = await fetch('/api/update-check/status').then(function(r){return r.json();});
+    var banner = document.getElementById('update-banner');
+    var msg = document.getElementById('update-banner-msg');
+    if (data.show_banner && banner && msg) {
+      var latest = (data.latest_check && data.latest_check.latest) || 'newer';
+      var current = (data.latest_check && data.latest_check.current) || '';
+      msg.textContent = 'Update available: v' + latest + ' is out. You are on v' + current + '.';
+      banner.style.display = 'flex';
+    }
+  } catch(e) {}
+}
+
+async function dismissUpdateBanner() {
+  try {
+    var data = await fetch('/api/update-check/status').then(function(r){return r.json();});
+    if (data.latest_check && data.latest_check.latest) {
+      await fetch('/api/update-check/dismiss', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({version: data.latest_check.latest})
+      });
+    }
+    var banner = document.getElementById('update-banner');
+    if (banner) banner.style.display = 'none';
+  } catch(e) {}
+}
+
+async function updateFromBanner() {
+  var btn = document.getElementById('update-banner-update-btn');
+  var msg = document.getElementById('update-banner-msg');
+  var changelog = document.getElementById('update-banner-changelog');
+  if (!btn) return;
+  var target = '';
+  try {
+    var s = await fetch('/api/update-check/status').then(function(r){return r.json();});
+    target = (s && s.latest_check && s.latest_check.latest) || '';
+  } catch(e) {}
+  if (!confirm('Update ClawMetry' + (target ? ' to v' + target : '') + ' now?\n\nThe dashboard and sync daemon will restart. In-flight requests may be interrupted.')) return;
+  btn.disabled = true;
+  btn.textContent = 'Updating...';
+  btn.style.cursor = 'wait';
+  btn.style.opacity = '0.7';
+  if (changelog) changelog.style.display = 'none';
+  if (msg) msg.textContent = 'Running pip install -U clawmetry. This usually takes 10-30 seconds...';
+  try {
+    var resp = await fetch('/api/update', {method: 'POST'});
+    var d = await resp.json().catch(function(){return {};});
+    if (resp.ok && d.ok) {
+      if (msg) msg.textContent = 'Updated to v' + (d.new_version || target) + '. Restarting dashboard...';
+      var reloaded = false;
+      var attempts = 0;
+      var poll = setInterval(function(){
+        attempts++;
+        fetch('/api/version', {cache: 'no-store'}).then(function(r){
+          if (!r.ok) throw new Error('not-ok');
+          return r.json();
+        }).then(function(v){
+          if (reloaded) return;
+          if (v && v.current && (!target || v.current === target)) {
+            reloaded = true;
+            clearInterval(poll);
+            window.location.reload();
+          }
+        }).catch(function(){});
+        if (attempts > 60) {
+          clearInterval(poll);
+          if (msg) msg.textContent = 'Restart taking longer than expected. Refresh the page manually.';
+          btn.disabled = false;
+          btn.textContent = 'Update now';
+          btn.style.cursor = 'pointer';
+          btn.style.opacity = '1';
+        }
+      }, 1000);
+    } else {
+      if (msg) msg.textContent = 'Update failed: ' + ((d && d.error) || ('HTTP ' + resp.status));
+      btn.disabled = false;
+      btn.textContent = 'Update now';
+      btn.style.cursor = 'pointer';
+      btn.style.opacity = '1';
+      if (changelog) changelog.style.display = '';
+    }
+  } catch(e) {
+    if (msg) msg.textContent = 'Update failed: ' + (e && e.message ? e.message : 'network error');
+    btn.disabled = false;
+    btn.textContent = 'Update now';
+    btn.style.cursor = 'pointer';
+    btn.style.opacity = '1';
+    if (changelog) changelog.style.display = '';
+  }
+}
+
+setInterval(checkUpdateStatus, 3600000);
+setTimeout(checkUpdateStatus, 5000);

--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -2,7 +2,7 @@
 <div id="update-banner" style="display:none; padding:10px 16px; background:linear-gradient(90deg,#0f3d0f 0%,#1a1a2e 100%); border-bottom:2px solid #22c55e; color:#86efac; font-size:13px; font-weight:600; align-items:center; gap:10px;">
   <span style="font-size:18px;">&#128640;</span>
   <span id="update-banner-msg" style="flex:1;"></span>
-  <a id="update-banner-changelog" href="https://github.com/vivekchand/clawmetry/blob/main/CHANGELOG.md" target="_blank" style="
+  <button id="update-banner-update-btn" onclick="updateFromBanner()" style="
     background:#16a34a;
     color:#fff;
     border:none;
@@ -11,8 +11,18 @@
     font-size:12px;
     cursor:pointer;
     font-weight:600;
+    ">Update now</button>
+  <a id="update-banner-changelog" href="https://github.com/vivekchand/clawmetry/blob/main/CHANGELOG.md" target="_blank" style="
+    background:transparent;
+    color:#86efac;
+    border:1px solid #22c55e80;
+    border-radius:6px;
+    padding:4px 12px;
+    font-size:12px;
+    cursor:pointer;
+    font-weight:600;
     text-decoration:none;
-    ">View Changelog</a>
+    ">Changelog</a>
   <button onclick="dismissUpdateBanner()" style="
     background:transparent;
     color:#86efac;

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -127,10 +127,27 @@ def api_update():
     except Exception:
         pass
 
-    # Schedule restart after response is sent
+    # Schedule restart after response is sent.
+    # CRITICAL: kick the sync daemon FIRST. Otherwise it keeps the OLD wheel in
+    # memory until launchctl restarts it on next boot (see
+    # ``feedback_restart_both_processes_after_upgrade.md``).
     def _restart():
         import os as _os
+        import platform as _pl
 
+        if _pl.system() == "Darwin":
+            try:
+                uid = _os.getuid()
+                _sp.run(
+                    ["launchctl", "kickstart", "-k",
+                     f"gui/{uid}/com.clawmetry.sync"],
+                    timeout=5,
+                    stdout=_sp.DEVNULL,
+                    stderr=_sp.DEVNULL,
+                    check=False,
+                )
+            except Exception:
+                pass  # daemon may not be running; dashboard restart is enough
         _os._exit(0)
 
     _thr.Timer(2.0, _restart).start()


### PR DESCRIPTION
## Summary

User asked for a clear banner that actually updates ClawMetry when clicked, end-to-end. Previously the banner only said 'update available' and pointed at the changelog. Now it does the upgrade itself.

## What changed

- **`clawmetry/templates/partials/banners.html`**: add green 'Update now' button next to the dismissible message; demote 'View Changelog' to a secondary outline button.
- **`clawmetry/static/js/app.js`** (+99 lines): add `checkUpdateStatus` / `dismissUpdateBanner` / `updateFromBanner` handlers + the polling/init pair. *Note: `dismissUpdateBanner` was previously referenced from banners.html but had no live definition — the original lived in a long-orphaned `DASHBOARD_HTML` block in dashboard.py that's overridden by the live template at line 10779. This PR fixes that latent bug too.*
- **`routes/meta.py` `/api/update`** (+19 lines): before `_os._exit(0)`, kickstart the launchctl `com.clawmetry.sync` daemon on macOS. Without this the daemon kept the OLD wheel in memory after upgrade (see `feedback_restart_both_processes_after_upgrade.md` in memory). Darwin-only; other OSes get the dashboard restart only.

## Upgrade flow

1. User clicks **Update now** on banner.
2. Confirm dialog: 'Update ClawMetry to vX.Y.Z now? The dashboard and sync daemon will restart. In-flight requests may be interrupted.'
3. `POST /api/update` runs `pip install -U clawmetry` (~10-30s).
4. Server returns `{ok: true, new_version: 'X.Y.Z'}`, then launchctl-kickstarts the sync daemon and self-exits 2s later.
5. Browser polls `GET /api/version` every 1s; reloads the page once the new process answers (or shows a manual-refresh message after 60s ceiling).

## E2E verified locally

- Stubbed `__version__` down to `0.12.250` (PyPI is at `0.12.264`).
- `POST /api/update-check/check-now` → 200, `latest=0.12.264`.
- `GET /api/update-check/status` → `show_banner=true`, `latest_check.{current,latest}` correct.
- `GET /` served the banner partial with the `update-banner-update-btn` button.
- `GET /static/js/app.js` exported all 3 handler functions.
- Browser confirmed banner renders with all 3 buttons (`Update now`, `Changelog`, `Dismiss`).

## Out of scope (follow-ups)

- The dead-code `DASHBOARD_HTML` block at `dashboard.py:2988-8080` should be deleted in a separate cleanup PR — out of scope here.
- The 4h release-stagger + rollback button discussed in the earlier auto-update conversation will land in a follow-up PR.
- Linux/Windows sync-daemon restart paths (this PR is Darwin-only).

## Test plan

- [ ] Upgrade banner shows when an older version is installed.
- [ ] 'Update now' button opens confirm dialog with target version.
- [ ] On confirm, `pip install -U clawmetry` runs, dashboard restarts, browser auto-reloads.
- [ ] After reload, banner is gone (new version matches latest).
- [ ] Sync daemon also picks up the new wheel (no stale-method 400s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)