### PR TITLE
fix(alerts): restore status dot for the 5-col grid row layout

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -198,6 +198,7 @@
       const badge = real ? '' : '<span class="alerts-rule-example-badge">example</span>';
       return `
         <div class="alerts-rule-row${real ? '' : ' alerts-rule-example'}" data-rule-id="${id}">
+          <div class="alerts-rule-dot ${on ? 'on' : 'off'}" title="${on ? 'Enabled' : 'Disabled'}"></div>
           <div class="alerts-rule-main">
             <div class="alerts-rule-title">${meta.icon} ${escape(name)} ${badge}</div>
             <div class="alerts-rule-meta">${metaLine}</div>


### PR DESCRIPTION
Merge-render dropped the dot; the row grid is 5 cols so the title collapsed + wrapped. Re-add the dot as a status indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)