### PR TITLE
fix(sync): daemon detects gateway token (snapshot auth_token_status was false 'missing')

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7304,6 +7304,16 @@ def _build_diagnostics(workspace=None):
         if _d.WORKSPACE or workspace:
             auto_detected.append("workspace")
         token = _d.GATEWAY_TOKEN or os.environ.get("OPENCLAW_GATEWAY_TOKEN", "").strip()
+        # The daemon process never runs the dashboard's startup token detection,
+        # so _d.GATEWAY_TOKEN is None here and (under launchd) the env var is
+        # unset — auth_token_status was wrongly "missing" in the snapshot even
+        # when openclaw.json has a gateway token. Fall back to the same detector
+        # the dashboard and security posture use (reads gateway.auth.token).
+        if not token:
+            try:
+                token = _d._detect_gateway_token() or ""
+            except Exception:
+                token = ""
         auth_token_status = "present" if token else "missing"
         openclaw_flags = {}
         flag_map = {


### PR DESCRIPTION
## Problem
On `app.clawmetry.com` the node Diagnostics panel showed **"Auth token: missing"**, and Self-Evolve generated ~23h of **false HIGH-severity findings** ("Auth token still missing… Self-Evolve keeps spending Opus") — burning Opus turns against a non-issue. Meanwhile the **Security** tab and the **localhost** dashboard both correctly report the gateway token as **present (48 chars)** from `~/.openclaw/openclaw.json`.

## Root cause
`_build_diagnostics()` runs in the **sync daemon** process and computes:
```python
token = _d.GATEWAY_TOKEN or os.environ.get("OPENCLAW_GATEWAY_TOKEN", "").strip()
auth_token_status = "present" if token else "missing"
```
This is identical to the dashboard's `/api/config-diagnostics` — but the daemon process **never runs the dashboard's startup token detection**, so `_d.GATEWAY_TOKEN` is `None` there, and under launchd `OPENCLAW_GATEWAY_TOKEN` is unset. Result: `token=""` → `"missing"`, even though `openclaw.json` has a token.

Verified in the actual daemon runtime:
```
GATEWAY_TOKEN global: None
_detect_gateway_token() len: 48
env OPENCLAW_GATEWAY_TOKEN set: False
```

## Fix
Fall back to `_d._detect_gateway_token()` (the same detector the dashboard and Security posture use — reads `gateway.auth.token` from `openclaw.json`) when the global and env are empty.

## Verification
With the patch, `_build_diagnostics()` returns `auth_token_status="present"` (was `"missing"`) against the real config. After this ships and the daemon upgrades, the cloud Diagnostics panel will read "present" and the false Self-Evolve "auth token missing" findings stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)