### PR TITLE
feat(selfevolve): "Fix with AI" button — apply a finding via openclaw agent (Phase 1: local)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Self-Evolve: "Fix with AI" button on findings (2026-05-21)
+- Each Self-Evolve finding now has a "✨ Fix with AI" button. Clicking it (after a confirm) dispatches the finding's suggestion to your local agent via `openclaw agent` (OpenClaw's own creds — ClawMetry's gateway token is read-only), which actually applies the change. Status shows Queued → Agent working → ✅ <summary>. Local dashboard for now; the cloud relay is a follow-up. New endpoints: `POST /api/selfevolve/fix`, `GET /api/selfevolve/fix/status`.
+
 ### Fix: daemon detects gateway token (snapshot auth_token_status was false "missing") (2026-05-21)
 - `_build_diagnostics()` runs in the sync daemon, where `dashboard.GATEWAY_TOKEN` is never populated (the daemon doesn't run the dashboard's startup detection) and `OPENCLAW_GATEWAY_TOKEN` is unset under launchd — so the snapshot reported `auth_token_status="missing"` even when `openclaw.json` has a gateway token. Cloud showed "Auth token: missing" and Self-Evolve generated false HIGH-severity findings. Now falls back to `_detect_gateway_token()` (the same detector the dashboard + Security posture use).
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5129,7 +5129,8 @@ function selfevolveRenderFindings(payload) {
     container.innerHTML = '<div style="padding:10px 12px;color:var(--text-muted);font-size:12px;">' +
       'No findings yet. Click Analyze to review recent activity.</div>';
   } else {
-    findings.forEach(function (f) {
+    window._seFindings = findings;
+    findings.forEach(function (f, _fidx) {
       var col = selfevolveSeverityColor(f.severity);
       var card = document.createElement('div');
       card.style.cssText =
@@ -5148,8 +5149,16 @@ function selfevolveRenderFindings(payload) {
         (f.evidence ? '<div style="font-size:12px;color:var(--text-muted);margin-bottom:6px;line-height:1.5;">' +
           '<strong style="color:var(--text-secondary);">Evidence:</strong> ' + escapeHtml(f.evidence) + '</div>' : '') +
         (f.suggestion ? '<div style="font-size:12px;color:var(--text-primary);line-height:1.5;">' +
-          '<strong style="color:#60a5fa;">Try:</strong> ' + escapeHtml(f.suggestion) + '</div>' : '');
+          '<strong style="color:#60a5fa;">Try:</strong> ' + escapeHtml(f.suggestion) + '</div>' : '') +
+        ((f.suggestion && !window.CLOUD_MODE) ?
+          '<div style="margin-top:10px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;">' +
+            '<button class="se-fix-btn" data-fidx="' + _fidx + '" style="display:inline-flex;align-items:center;gap:6px;font-size:12px;font-weight:600;cursor:pointer;background:#2563eb;color:#fff;border:none;border-radius:6px;padding:6px 12px;">✨ Fix with AI</button>' +
+            '<span class="se-fix-status" style="font-size:12px;color:var(--text-muted);"></span>' +
+          '</div>' : '');
       container.appendChild(card);
+    });
+    container.querySelectorAll('.se-fix-btn').forEach(function (btn) {
+      btn.addEventListener('click', function () { selfevolveFixClick(parseInt(btn.dataset.fidx, 10), btn); });
     });
   }
   if (status) {
@@ -5159,6 +5168,78 @@ function selfevolveRenderFindings(payload) {
     if (payload.model) meta.push(payload.model);
     status.textContent = meta.join(' · ');
   }
+}
+
+// ── "Fix with AI": dispatch a finding's suggestion to the local agent ──────────
+// Confirms first (the agent makes a real change), POSTs to /api/selfevolve/fix,
+// then polls /api/selfevolve/fix/status until done/error. Local-only for now;
+// the cloud relay routes the same intent through a node command.
+function selfevolveFixClick(idx, btn) {
+  var f = (window._seFindings || [])[idx];
+  if (!f) return;
+  _seFixConfirm(f, function () { _seFixRun(f, btn); });
+}
+function _seFixConfirm(f, onYes) {
+  var ov = document.createElement('div');
+  ov.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:10000;display:flex;align-items:center;justify-content:center;padding:20px;';
+  var box = document.createElement('div');
+  box.style.cssText = 'max-width:460px;width:100%;background:var(--bg-secondary,#161b22);border:1px solid var(--border-primary,#30363d);border-radius:10px;padding:20px;';
+  box.innerHTML =
+    '<div style="font-size:15px;font-weight:700;color:var(--text-primary,#e6edf3);margin-bottom:8px;">✨ Send this fix to your agent?</div>' +
+    '<div style="font-size:12px;color:var(--text-muted,#8b949e);margin-bottom:6px;">Your OpenClaw agent will apply this change on your machine:</div>' +
+    '<div style="font-size:13px;color:var(--text-primary,#e6edf3);background:var(--bg-primary,#0d1117);border:1px solid var(--border-primary,#30363d);border-radius:6px;padding:10px 12px;margin-bottom:16px;line-height:1.5;">' + escapeHtml(f.suggestion || '') + '</div>' +
+    '<div style="display:flex;justify-content:flex-end;gap:8px;">' +
+      '<button id="se-fix-cancel" style="font-size:13px;padding:7px 14px;border-radius:6px;border:1px solid var(--border-primary,#30363d);background:transparent;color:var(--text-secondary,#9ca3af);cursor:pointer;">Cancel</button>' +
+      '<button id="se-fix-go" style="font-size:13px;font-weight:600;padding:7px 16px;border-radius:6px;border:none;background:#2563eb;color:#fff;cursor:pointer;">Send to agent</button>' +
+    '</div>';
+  ov.appendChild(box);
+  document.body.appendChild(ov);
+  function close() { ov.remove(); }
+  ov.addEventListener('click', function (e) { if (e.target === ov) close(); });
+  box.querySelector('#se-fix-cancel').addEventListener('click', close);
+  box.querySelector('#se-fix-go').addEventListener('click', function () { close(); onYes(); });
+}
+function _seFixRun(f, btn) {
+  var statusEl = btn.parentElement.querySelector('.se-fix-status');
+  btn.disabled = true; btn.style.opacity = '0.6';
+  if (statusEl) { statusEl.textContent = '⏳ Queued…'; statusEl.style.color = 'var(--text-muted)'; }
+  fetch('/api/selfevolve/fix', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: f.title, suggestion: f.suggestion, category: f.category, evidence: f.evidence }) })
+    .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+    .then(function (res) {
+      if (!res.ok || !res.j.job_id) {
+        if (statusEl) { statusEl.textContent = '⚠️ ' + (res.j.message || 'Could not start'); statusEl.style.color = '#f59e0b'; }
+        btn.disabled = false; btn.style.opacity = '1'; return;
+      }
+      _seFixPoll(res.j.job_id, statusEl, btn);
+    })
+    .catch(function () {
+      if (statusEl) { statusEl.textContent = '⚠️ Network error'; statusEl.style.color = '#ef4444'; }
+      btn.disabled = false; btn.style.opacity = '1';
+    });
+}
+function _seFixPoll(jobId, statusEl, btn) {
+  var tries = 0;
+  var iv = setInterval(function () {
+    tries++;
+    fetch('/api/selfevolve/fix/status?job_id=' + encodeURIComponent(jobId))
+      .then(function (r) { return r.json(); })
+      .then(function (j) {
+        if (j.status === 'running') {
+          if (statusEl) { statusEl.textContent = '⚙️ Agent working…'; statusEl.style.color = '#60a5fa'; }
+        } else if (j.status === 'done') {
+          clearInterval(iv);
+          if (statusEl) { statusEl.textContent = '✅ ' + (j.summary || 'Done'); statusEl.style.color = '#22c55e'; }
+          if (btn) { btn.textContent = '✅ Fixed'; }
+        } else if (j.status === 'error') {
+          clearInterval(iv);
+          if (statusEl) { statusEl.textContent = '⚠️ ' + (j.error || 'Failed'); statusEl.style.color = '#ef4444'; }
+          if (btn) { btn.disabled = false; btn.style.opacity = '1'; }
+        }
+      })
+      .catch(function () {});
+    if (tries > 200) { clearInterval(iv); }  // ~10 min cap
+  }, 3000);
 }
 // Self-Evolve is intentionally NOT in the top nav (option C: discoverable via
 // a contextual link on the Brain tab + deep-link). The probe's job here is

--- a/routes/selfevolve.py
+++ b/routes/selfevolve.py
@@ -434,3 +434,189 @@ def api_selfevolve_analyze():
     }
     _save_cached(payload)
     return jsonify(payload)
+
+
+# ── "Fix with AI": apply a finding by dispatching it to the local agent ────────
+# A finding's suggestion is sent to `openclaw agent` (OpenClaw's own creds —
+# ClawMetry's gateway token is read-only), the same mechanism Self-Evolve uses
+# to *generate* findings. The agent actually makes the change. Jobs run in a
+# background thread; the UI polls /api/selfevolve/fix/status. Local-only: on a
+# host with no `openclaw` CLI (e.g. the cloud server) this returns 412 and the
+# cloud relay path (queue a node command) takes over instead.
+
+import threading as _threading
+import subprocess as _subprocess
+
+_FIX_JOBS: dict = {}  # job_id -> {status, summary, error, started_at}
+_FIX_LOCK = _threading.Lock()
+_FIX_MAX = 50
+_FIX_SESSION_ID = "clawmetry-fix"
+
+
+def _resolve_openclaw_bin_local():
+    import shutil
+
+    found = shutil.which("openclaw")
+    if found:
+        return found
+    for cand in (
+        "/opt/homebrew/bin/openclaw",
+        "/usr/local/bin/openclaw",
+        os.path.expanduser("~/.local/bin/openclaw"),
+        "/usr/bin/openclaw",
+    ):
+        if os.path.isfile(cand) and os.access(cand, os.X_OK):
+            return cand
+    return None
+
+
+def _build_fix_message(title, suggestion, category, evidence):
+    return (
+        "You are ClawMetry Self-Evolve in FIX mode. A review of your own agent "
+        "telemetry surfaced the finding below. Apply the recommended change to "
+        "your OpenClaw setup now, using your tools (edit config files, adjust "
+        "model routing, set values, etc.).\n\n"
+        "Finding (" + (category or "general") + "): " + (title or "") + "\n"
+        "Evidence: " + (evidence or "(none)") + "\n"
+        "Recommended action: " + (suggestion or "") + "\n\n"
+        "Make the concrete change. If a step needs a human decision you cannot "
+        "safely make on your own, do what you safely can and clearly state what "
+        "remains for the operator. Keep it tight. End with a one-line summary "
+        "that starts with 'DONE:' describing exactly what you changed."
+    )
+
+
+def _extract_fix_summary(stdout):
+    """Pull a human summary from the `openclaw agent --json` envelope."""
+    try:
+        out = json.loads(stdout)
+    except Exception:
+        return ((stdout or "").strip()[:600]) or "Done."
+    result = out.get("result") or {}
+    txt = ""
+    for p in result.get("payloads") or []:
+        if isinstance(p, dict) and p.get("text"):
+            txt = p["text"]
+    txt = txt or result.get("text") or out.get("text") or ""
+    m = re.search(r"DONE:.*", txt or "")
+    if m:
+        return m.group(0).strip()[:600]
+    return ((txt or "Done.").strip()[:600]) or "Done."
+
+
+def _run_fix_job(job_id, message, timeout=300):
+    binp = _resolve_openclaw_bin_local()
+    if not binp:
+        with _FIX_LOCK:
+            _FIX_JOBS[job_id].update(
+                status="error", error="openclaw CLI not found on this machine"
+            )
+        return
+    # `openclaw` is a Node script; under launchd's minimal PATH `node` isn't
+    # found (rc 127). Prepend the bin dir + the usual Node locations.
+    env = dict(os.environ)
+    node_dirs = [
+        os.path.dirname(binp),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        os.path.expanduser("~/.local/bin"),
+    ]
+    env["PATH"] = os.pathsep.join(node_dirs + [env.get("PATH", "/usr/bin:/bin")])
+    with _FIX_LOCK:
+        _FIX_JOBS[job_id].update(status="running")
+    try:
+        proc = _subprocess.run(
+            [
+                binp,
+                "agent",
+                "--session-id",
+                _FIX_SESSION_ID,
+                "--message",
+                message,
+                "--json",
+                "--timeout",
+                str(timeout),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout + 30,
+            env=env,
+        )
+        if proc.returncode != 0:
+            with _FIX_LOCK:
+                _FIX_JOBS[job_id].update(
+                    status="error",
+                    error=(proc.stderr or ("agent exited %d" % proc.returncode))[:400],
+                )
+            return
+        summary = _extract_fix_summary(proc.stdout)
+        with _FIX_LOCK:
+            _FIX_JOBS[job_id].update(status="done", summary=summary)
+    except _subprocess.TimeoutExpired:
+        with _FIX_LOCK:
+            _FIX_JOBS[job_id].update(status="error", error="agent timed out")
+    except Exception as e:  # never crash the worker thread
+        with _FIX_LOCK:
+            _FIX_JOBS[job_id].update(status="error", error=str(e)[:400])
+
+
+@bp_selfevolve.route("/api/selfevolve/fix", methods=["POST"])
+def api_selfevolve_fix():
+    """Dispatch a finding's suggestion to the local agent to apply it."""
+    if _resolve_openclaw_bin_local() is None:
+        return (
+            jsonify(
+                {
+                    "error": "no_agent",
+                    "message": (
+                        "OpenClaw CLI not found on this machine. Run the fix from "
+                        "the host where your agent lives."
+                    ),
+                }
+            ),
+            412,
+        )
+    body = request.get_json(silent=True) or {}
+    suggestion = (body.get("suggestion") or "").strip()
+    if not suggestion:
+        return jsonify({"error": "bad_request", "message": "suggestion is required"}), 400
+    import secrets as _secrets
+
+    job_id = _secrets.token_hex(8)
+    message = _build_fix_message(
+        (body.get("title") or "").strip(),
+        suggestion,
+        (body.get("category") or "").strip(),
+        (body.get("evidence") or "").strip(),
+    )
+    with _FIX_LOCK:
+        if len(_FIX_JOBS) >= _FIX_MAX:
+            stale = sorted(_FIX_JOBS, key=lambda j: _FIX_JOBS[j].get("started_at", 0))
+            for k in stale[: len(_FIX_JOBS) - _FIX_MAX + 1]:
+                _FIX_JOBS.pop(k, None)
+        _FIX_JOBS[job_id] = {
+            "status": "queued",
+            "summary": "",
+            "error": "",
+            "started_at": time.time(),
+        }
+    _threading.Thread(
+        target=_run_fix_job, args=(job_id, message), daemon=True
+    ).start()
+    return jsonify({"job_id": job_id, "status": "queued"})
+
+
+@bp_selfevolve.route("/api/selfevolve/fix/status")
+def api_selfevolve_fix_status():
+    job_id = request.args.get("job_id", "")
+    with _FIX_LOCK:
+        job = _FIX_JOBS.get(job_id)
+    if not job:
+        return jsonify({"error": "not_found"}), 404
+    return jsonify(
+        {
+            "status": job["status"],
+            "summary": job.get("summary", ""),
+            "error": job.get("error", ""),
+        }
+    )


### PR DESCRIPTION
## What
Adds a **✨ Fix with AI** button to each Self-Evolve finding. Clicking it (after a confirm modal) dispatches the finding's suggestion to your **local agent** via `openclaw agent`, which actually applies the change. The UI shows **Queued → ⚙️ Agent working → ✅ \<summary\>**.

This is **Phase 1 (local)** per the agreed plan (local first, cloud relay next).

## How
- **Backend** (`routes/selfevolve.py`): `POST /api/selfevolve/fix` validates the finding, spawns a background thread running `openclaw agent --session-id clawmetry-fix --message "<fix prompt>" --json --timeout 300` (PATH-augmented for launchd, same pattern Self-Evolve already uses to *generate* findings — OpenClaw's own creds, since ClawMetry's gateway token is read-only). `GET /api/selfevolve/fix/status?job_id=` returns `queued|running|done|error` + the agent's `DONE:` summary. On a host with no `openclaw` CLI (e.g. the cloud server) it returns **412** gracefully.
- **Frontend** (`app.js`): button per finding (gated `!CLOUD_MODE` for now), a confirm modal showing the exact change, then status polling.

## Verification (live, local dashboard)
- `POST /api/selfevolve/fix` (no-op self-test) → `queued` → `running` → `done`, summary `"DONE: live endpoint ok"` — agent ran, **nothing changed**.
- Modal renders with Send/Cancel + the suggestion, user text HTML-escaped (no XSS), POST returns a `job_id`.
- `node --check app.js` clean.

## Next (Phase 2, separate PR)
Cloud relay: cm-cloud interceptor for `/api/selfevolve/fix` → queue a node command (`self_evolve_fix`) the local daemon polls + executes + acks; remove the `!CLOUD_MODE` gate; add route-policy entries. Then the button works on app.clawmetry.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)