### PR TITLE
fix(brain): hide gateway.metric as plumbing so the activity stream isn't buried

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3520,17 +3520,25 @@ function sessionHasHighRisk(events, sessionId) {
   return false;
 }
 
-// Plumbing event types: internal queue housekeeping that's noise to anyone
-// debugging an actual conversation. Hidden by default; toggle in the Brain
-// header reveals them. Match is case-insensitive on type AND detail to
-// catch QUEUE-OPERATION / queue_operation / "queue-operation" alike.
+// Plumbing event types: internal queue housekeeping + gateway CPU/RAM metrics
+// that are noise to anyone debugging an actual conversation. Hidden by default;
+// toggle in the Brain header reveals them. Match is case-insensitive and
+// separator-insensitive on type AND role to catch QUEUE-OPERATION /
+// queue_operation and GATEWAY.METRIC / gateway_metric alike.
 function _isPlumbingEvent(ev) {
   if (!ev) return false;
-  var t = String(ev.type || '').toLowerCase().replace(/[_-]/g, '');
-  if (t === 'queueoperation') return true;
-  // Belt-and-suspenders: some ingests stuff "queue-operation" into role/detail
-  var role = String(ev.role || '').toLowerCase().replace(/[_-]/g, '');
-  if (role === 'queueoperation') return true;
+  // Infra/plumbing event types: machine noise, not agent content, so they're
+  // hidden by default behind "Show plumbing". gateway.metric is a CPU/RAM ping
+  // emitted ~every 40s — left unfiltered it floods the stream and buries real
+  // activity (the Brain tab looked broken when the agent was idle).
+  // Normalise (lowercase, drop . _ -) so "gateway.metric", "GATEWAY.METRIC"
+  // and "queue-operation" all collapse to one comparable token.
+  var PLUMBING = { queueoperation: 1, gatewaymetric: 1 };
+  var t = String(ev.type || '').toLowerCase().replace(/[._-]/g, '');
+  if (PLUMBING[t]) return true;
+  // Belt-and-suspenders: some ingests stuff the type into role/detail.
+  var role = String(ev.role || '').toLowerCase().replace(/[._-]/g, '');
+  if (PLUMBING[role]) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary
The Brain **Unified Activity Stream** only treated `queue-operation` events as plumbing. `gateway.metric` (a CPU/RAM ping emitted ~every 40s) stayed visible, so when the agent is idle the stream fills with metric rows and looks broken — real `ASSISTANT`/`USER`/`EXEC` activity gets buried. This was the "localhost Brain tab looks much worse than cloud" symptom.

`_isPlumbingEvent` now also matches `gateway.metric`, folding it into the existing **Show plumbing** toggle. Normalisation is made separator-insensitive (drops `.` `_` `-`) so `gateway.metric` / `GATEWAY.METRIC` / `gateway_metric` and `queue-operation` / `queueoperation` all collapse to one comparable token.

## Why
- Read-only frontend change, no new deps, consistent with the existing `queue-operation` treatment (still surfaceable via Show plumbing).
- The cloud already looks clean; this brings the OSS/localhost stream to parity.

## Verification
- Pure-logic unit check: `gateway.metric` (all separator variants) + `queue-operation` → plumbing; `assistant`/`user`/`exec`/`agent`/`attachment` → kept.
- Live node `/api/brain-history` (300 events): **85 hidden** (45 `gateway.metric` + 40 `queue-operation`), **215 shown** (123 `ASSISTANT`, 77 `USER`, 15 `ATTACHMENT`).

## Test plan
- [ ] Open Brain tab while agent is idle → stream shows last real activity, not gateway pings
- [ ] "Show plumbing (N hidden)" count includes gateway.metric; toggling reveals them
- [ ] Type-filter chips still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)