### PR TITLE
feat(selfevolve): cloud relay for "Fix with AI" (Phase 2 — daemon action + ungate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Self-Evolve: "Fix with AI" cloud relay (2026-05-21)
+- The Fix button now works from app.clawmetry.com: the cloud queues an authenticated, owner-scoped `selfevolve_fix` action on the heartbeat-piggyback relay; the local daemon runs `openclaw agent` in a background thread and posts the E2E-encrypted result to the cloud cache, which the browser polls + decrypts. Button is no longer gated to the local dashboard.
+
 ### Self-Evolve: "Fix with AI" button on findings (2026-05-21)
 - Each Self-Evolve finding now has a "✨ Fix with AI" button. Clicking it (after a confirm) dispatches the finding's suggestion to your local agent via `openclaw agent` (OpenClaw's own creds — ClawMetry's gateway token is read-only), which actually applies the change. Status shows Queued → Agent working → ✅ <summary>. Local dashboard for now; the cloud relay is a follow-up. New endpoints: `POST /api/selfevolve/fix`, `GET /api/selfevolve/fix/status`.
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -5150,7 +5150,7 @@ function selfevolveRenderFindings(payload) {
           '<strong style="color:var(--text-secondary);">Evidence:</strong> ' + escapeHtml(f.evidence) + '</div>' : '') +
         (f.suggestion ? '<div style="font-size:12px;color:var(--text-primary);line-height:1.5;">' +
           '<strong style="color:#60a5fa;">Try:</strong> ' + escapeHtml(f.suggestion) + '</div>' : '') +
-        ((f.suggestion && !window.CLOUD_MODE) ?
+        (f.suggestion ?
           '<div style="margin-top:10px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;">' +
             '<button class="se-fix-btn" data-fidx="' + _fidx + '" style="display:inline-flex;align-items:center;gap:6px;font-size:12px;font-weight:600;cursor:pointer;background:#2563eb;color:#fff;border:none;border-radius:6px;padding:6px 12px;">✨ Fix with AI</button>' +
             '<span class="se-fix-status" style="font-size:12px;color:var(--text-muted);"></span>' +

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5620,6 +5620,7 @@ _PENDING_ACTIONS = frozenset({
     "alert_rule_upsert",
     "alert_rule_delete",
     "approval_decision",
+    "selfevolve_fix",
 })
 
 
@@ -5805,6 +5806,117 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
     if atype == "approval_decision":
         _apply_approval_decision(action)
         return
+    if atype == "selfevolve_fix":
+        _action_selfevolve_fix(config, action)
+        return
+
+
+def _selfevolve_fix_summary(stdout: str) -> str:
+    """Pull a human summary from the `openclaw agent --json` envelope."""
+    import re as _re
+
+    try:
+        out = json.loads(stdout)
+    except Exception:
+        return ((stdout or "").strip()[:600]) or "Done."
+    result = out.get("result") or {}
+    txt = ""
+    for p in result.get("payloads") or []:
+        if isinstance(p, dict) and p.get("text"):
+            txt = p["text"]
+    txt = txt or result.get("text") or out.get("text") or ""
+    m = _re.search(r"DONE:.*", txt or "")
+    return (m.group(0).strip()[:600] if m else (txt or "Done.").strip()[:600]) or "Done."
+
+
+def _action_selfevolve_fix(config: dict, action: dict) -> None:
+    """Cloud-relayed Self-Evolve "Fix with AI": run a finding's suggestion via
+    ``openclaw agent`` (OpenClaw's own creds — the gateway token is read-only)
+    and post the E2E-encrypted result to ``/ingest/cache`` under the action's
+    ``cache_key`` so the cloud dashboard can poll + decrypt it. Runs in a
+    background thread so a ~15s agent turn never blocks the heartbeat loop.
+
+    Wire shape (queued cloud-side by /api/cloud/selfevolve-fix):
+        {type:"selfevolve_fix", id, cache_key, suggestion, title, category, evidence}
+    """
+    cache_key = action.get("cache_key")
+    suggestion = (action.get("suggestion") or "").strip()
+    enc_key = config.get("encryption_key")
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not (cache_key and suggestion and enc_key and api_key):
+        return
+    title = (action.get("title") or "").strip()
+    category = (action.get("category") or "").strip()
+    evidence = (action.get("evidence") or "").strip()
+    aid = action.get("id")
+
+    def _run():
+        status, summary = "error", ""
+        try:
+            binp = _resolve_openclaw_bin()
+            if not binp:
+                summary = "openclaw CLI not found on this machine"
+            else:
+                message = (
+                    "You are ClawMetry Self-Evolve in FIX mode. Apply the "
+                    "recommended change to your OpenClaw setup now, using your "
+                    "tools (edit config, adjust model routing, set values).\n\n"
+                    "Finding (" + (category or "general") + "): " + title + "\n"
+                    "Evidence: " + (evidence or "(none)") + "\n"
+                    "Recommended action: " + suggestion + "\n\n"
+                    "Make the concrete change. If a step needs a human decision "
+                    "you cannot safely make on your own, do what you safely can "
+                    "and state what remains. End with a one-line summary that "
+                    "starts with 'DONE:' describing exactly what you changed."
+                )
+                env = dict(os.environ)
+                node_dirs = [
+                    os.path.dirname(binp),
+                    "/opt/homebrew/bin",
+                    "/usr/local/bin",
+                    os.path.expanduser("~/.local/bin"),
+                ]
+                env["PATH"] = os.pathsep.join(
+                    node_dirs + [env.get("PATH", "/usr/bin:/bin")]
+                )
+                proc = subprocess.run(
+                    [
+                        binp, "agent", "--session-id", "clawmetry-fix",
+                        "--message", message, "--json", "--timeout", "300",
+                    ],
+                    capture_output=True, text=True, timeout=330, env=env,
+                )
+                if proc.returncode != 0:
+                    summary = (
+                        proc.stderr or ("agent exited %d" % proc.returncode)
+                    )[:400]
+                else:
+                    status = "done"
+                    summary = _selfevolve_fix_summary(proc.stdout)
+        except Exception as e:  # never raise from the worker thread
+            summary = str(e)[:400]
+        try:
+            blob = encrypt_payload(
+                {"status": status, "summary": summary, "_shape": "selfevolve_fix"},
+                enc_key,
+            )
+            _post(
+                "/ingest/cache",
+                {
+                    "node_id": node_id,
+                    "id": aid,
+                    "cache_key": cache_key,
+                    "blob": blob,
+                    "shape": "selfevolve_fix",
+                    "ttl": 3600,
+                },
+                api_key,
+            )
+        except Exception as e:
+            log.warning("selfevolve_fix cache post failed: %s", e)
+
+    threading.Thread(target=_run, daemon=True).start()
 
 
 def _action_channel_config_upsert(config: dict, action: dict) -> None:


### PR DESCRIPTION
## What
Phase 2 of the Self-Evolve **Fix with AI** button: make it work from **app.clawmetry.com** (Phase 1 #1876 was local-only).

## How (reuses the existing heartbeat-piggyback relay — no new poller, no new RCE channel)
- **Daemon** (`sync.py`): new `selfevolve_fix` pending-**action**. The cloud queues it (owner-scoped, authenticated) on the same relay that already carries alert-rule/approval/channel actions. The daemon runs `openclaw agent --session-id clawmetry-fix` in a **background thread** (a ~15s turn never blocks heartbeats) and posts the **E2E-encrypted** `{status,summary}` to `/ingest/cache` under the action's `cache_key`. ClawMetry's gateway token stays read-only — the agent runs on OpenClaw's own creds.
- **Frontend** (`app.js`): drop the `!CLOUD_MODE` gate so the button shows on cloud. It calls the same `/api/selfevolve/fix(+/status)` endpoints; the cloud cm-cloud interceptor (separate cloud PR) routes them through the relay + decrypts the cached result.

## Security
Owner-scoped + authenticated (the relay binds every cache entry to `sha256(token)`; the cloud enqueue validates the cm_token and that the node belongs to the caller). The browser confirm modal gates every dispatch. The daemon's `_PENDING_ACTIONS` allowlist is the execution gate.

## Verification
Daemon `_action_selfevolve_fix` unit-tested with a no-op suggestion: ran the agent, posted `shape=selfevolve_fix` + encrypted blob to `/ingest/cache` with the correct `cache_key` (nothing changed). py + `node --check` clean. Full cross-system E2E (click on cloud → relay → result) verified after this releases + the cloud PR deploys.

Pairs with clawmetry-cloud PR (enqueue endpoint + interceptor + pin bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)