### PR TITLE
[RELEASE] Self-Evolve "Fix with AI" (local + cloud relay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Release: Self-Evolve "Fix with AI" (local + cloud relay) (2026-05-21)
+- Publishes the Fix-button feature (#1876 local, #1878 cloud relay + daemon `selfevolve_fix` action) and the daemon gateway-token detection fix.
+
 ### Self-Evolve: "Fix with AI" cloud relay (2026-05-21)
 - The Fix button now works from app.clawmetry.com: the cloud queues an authenticated, owner-scoped `selfevolve_fix` action on the heartbeat-piggyback relay; the local daemon runs `openclaw agent` in a background thread and posts the E2E-encrypted result to the cloud cache, which the browser polls + decrypts. Button is no longer gated to the local dashboard.
 


### PR DESCRIPTION
Publishes the Fix button feature to PyPI: Phase 1 local (#1876) + Phase 2 daemon `selfevolve_fix` action & button ungate (#1878). Required before the clawmetry-cloud pin can bump to light up the cloud Fix button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)