### PR TITLE
feat(usage): spend optimization recommender tile (#1415)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10322,6 +10322,8 @@ async function loadUsage() {
     loadCacheAnalytics();
     // Load cost forecast (issue #1413)
     loadCostForecast();
+    // Load spend optimization recommendations (issue #1415)
+    loadSpendOptimization();
     // NeMo daily-cap banner (issue #1170) — only visible when a free-tier
     // user has tripped the 1000-events/day ceiling.
     _refreshNemoCapBanner('usage-chart');
@@ -10626,6 +10628,55 @@ function renderCostComparison(data) {
   });
   html += '</div>';
   html += '<div style="margin-top:10px;font-size:11px;color:var(--text-muted);line-height:1.5;">Estimates based on 60/40 input/output split for ' + tokStr + ' tokens. Actual costs vary by prompt structure and API tier.</div>';
+  el.innerHTML = html;
+}
+
+// ===== Spend Optimization Recommendations (issue #1415) =====
+async function loadSpendOptimization() {
+  var card = document.getElementById('spend-optimization-card');
+  var el = document.getElementById('spend-optimization-content');
+  if (!card || !el) return;
+  try {
+    var data = await fetch('/api/usage/optimization-recommendations').then(function(r){return r.json();});
+    if (!data || !data.recommendations || data.recommendations.length === 0) return;
+    card.style.display = 'block';
+    renderSpendOptimization(data);
+  } catch(e) {
+    // silently skip if unavailable
+  }
+}
+
+function renderSpendOptimization(data) {
+  var el = document.getElementById('spend-optimization-content');
+  if (!el) return;
+  var recs = data.recommendations || [];
+  if (recs.length === 0) {
+    el.innerHTML = '<span style="color:var(--text-muted)">No optimization suggestions yet — run more agents with span data enabled to see recommendations.</span>';
+    return;
+  }
+  var totalSave = data.total_projected_savings_usd_30d || 0;
+  var saveFmt = totalSave >= 0.01 ? '$' + totalSave.toFixed(2) : totalSave > 0 ? '<$0.01' : '$0.00';
+  var html = '<div style="margin-bottom:14px;padding:10px 14px;background:rgba(34,197,94,0.08);border:1px solid rgba(34,197,94,0.25);border-radius:8px;">';
+  html += '<div style="font-size:12px;color:#86efac;margin-bottom:4px;">Projected 30-day savings</div>';
+  html += '<div style="font-size:22px;font-weight:700;color:#22c55e;">' + saveFmt + '</div>';
+  html += '<div style="font-size:11px;color:var(--text-muted);margin-top:2px;">by routing simple tools to a cheaper model tier</div>';
+  html += '</div>';
+  html += '<div style="display:flex;flex-direction:column;gap:8px;">';
+  recs.forEach(function(rec) {
+    var savStr = rec.projected_savings_usd_30d >= 0.01 ? '$' + rec.projected_savings_usd_30d.toFixed(2) : '<$0.01';
+    var curStr = rec.current_cost_usd_30d >= 0.01 ? '$' + rec.current_cost_usd_30d.toFixed(2) : rec.current_cost_usd_30d > 0 ? '<$0.01' : '$0.00';
+    html += '<div style="background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.07);border-radius:8px;padding:10px 14px;display:flex;align-items:center;gap:12px;">';
+    html += '<div style="flex:1;min-width:0;">';
+    html += '<div style="font-size:13px;font-weight:600;color:var(--text-primary);">' + escHtml(rec.tool) + '</div>';
+    html += '<div style="font-size:11px;color:var(--text-muted);">' + escHtml(rec.current_model) + ' → ' + escHtml(rec.suggested_model_tier) + ' &middot; ' + rec.call_count + ' calls</div>';
+    html += '</div>';
+    html += '<div style="text-align:right;flex-shrink:0;">';
+    html += '<div style="font-size:14px;font-weight:700;color:#22c55e;">save ' + savStr + '</div>';
+    html += '<div style="font-size:11px;color:var(--text-muted);">' + curStr + ' now &middot; ' + rec.savings_pct + '% off</div>';
+    html += '</div></div>';
+  });
+  html += '</div>';
+  html += '<div style="margin-top:10px;font-size:11px;color:var(--text-muted);line-height:1.5;">Based on a static heuristic: deterministic tools (bash, read, ls) rarely need heavy reasoning. Validate quality before applying routing rules.</div>';
   el.innerHTML = html;
 }
 

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -107,6 +107,8 @@
   "usage.otlp_data_source": "Data source: OpenTelemetry OTLP - real-time metrics from OpenClaw",
   "usage.cost_comparison": "Cost Comparison",
   "usage.cost_comparison_hint": "what same workload costs elsewhere · 30 days",
+  "usage.spend_optimization": "Spend Optimization",
+  "usage.spend_optimization_hint": "model downgrade suggestions · 30 days",
   "usage.trace_clusters": "Trace Clusters",
   "usage.trace_clusters_hint": "auto-group sessions by behavior pattern",
   "usage.activity_heatmap": "Activity Heatmap",

--- a/clawmetry/templates/tabs/usage.html
+++ b/clawmetry/templates/tabs/usage.html
@@ -110,6 +110,11 @@
   <div class="card" id="cost-comparison-card" style="display:none;">
     <div id="cost-comparison-content" style="min-height:60px;color:var(--text-muted);">Loading...</div>
   </div>
+  <!-- Spend Optimization Recommendations (issue #1415) -->
+  <div class="section-title" id="spend-optimization-section" style="display:flex;align-items:center;">💡 <span data-i18n="usage.spend_optimization">Spend Optimization</span> <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;" data-i18n="usage.spend_optimization_hint">model downgrade suggestions · 30 days</span></div>
+  <div class="card" id="spend-optimization-card" style="display:none;">
+    <div id="spend-optimization-content" style="min-height:60px;color:var(--text-muted);">Loading...</div>
+  </div>
     <div class="section-title">🔮 <span data-i18n="usage.trace_clusters">Trace Clusters</span> <span style="
       font-size:11px;
       font-weight:400;

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -3825,3 +3825,132 @@ def api_nemo_cap_status():
             "cap_hit": False,
             "date": "",
         })
+
+
+# ── Spend Optimization Recommendations (issue #1415) ────────────────────────
+#
+# Reads spans for the last 30 days and applies a static heuristic to rank
+# tools by potential savings from routing to a cheaper model tier.
+# Pure read-path: no writes, no LLM calls, no new dependencies.
+
+# Tools whose outputs are deterministic / structural — cheaper models
+# produce equivalent results and can safely replace heavier ones.
+_SPEND_OPT_TOOL_DOWNGRADE: dict = {
+    "bash":               "haiku",
+    "read":               "haiku",
+    "ls":                 "haiku",
+    "list_files":         "haiku",
+    "ls_files":           "haiku",
+    "find_files":         "haiku",
+    "glob":               "haiku",
+    "search_files":       "haiku",
+    "computer":           "haiku",
+    "write":              "sonnet",
+    "edit":               "sonnet",
+    "str_replace_editor": "sonnet",
+    "create_file":        "sonnet",
+    "multiedit":          "sonnet",
+}
+
+# Relative input-token price ratios: haiku = 1.0 baseline.
+_SPEND_OPT_MODEL_RATIO: dict = {
+    "haiku":  1.0,
+    "sonnet": 12.0,
+    "opus":   60.0,
+}
+
+
+def _spend_opt_model_tier(model: str) -> str:
+    """Map a raw model string to haiku / sonnet / opus (or unknown)."""
+    m = (model or "").lower()
+    if "haiku" in m:
+        return "haiku"
+    if "sonnet" in m:
+        return "sonnet"
+    if "opus" in m:
+        return "opus"
+    return "unknown"
+
+
+def _try_local_store_spend_optimization():
+    """Fast-path: aggregate spans → ranked model-downgrade recommendations."""
+    import time as _time
+    from collections import defaultdict
+
+    since = _time.time() - 30 * 86400  # 30-day look-back (unix seconds)
+    spans = _ls_call("query_recent_spans", since=since, limit=5000)
+    if not spans:
+        return None
+
+    agg: dict = defaultdict(lambda: {"calls": 0, "cost_usd": 0.0})
+    for s in spans:
+        tool = (s.get("tool_name") or "").strip()
+        model = (s.get("model") or "").strip()
+        cost = s.get("cost_usd") or 0.0
+        if not tool or not model or cost <= 0:
+            continue
+        key = (tool, model)
+        agg[key]["calls"] += 1
+        agg[key]["cost_usd"] += cost
+
+    if not agg:
+        return None
+
+    recs: list = []
+    for (tool, model), stats in agg.items():
+        target_tier = _SPEND_OPT_TOOL_DOWNGRADE.get(tool)
+        if not target_tier:
+            continue
+        cur_tier = _spend_opt_model_tier(model)
+        if cur_tier == "unknown" or cur_tier == target_tier:
+            continue
+        cur_ratio = _SPEND_OPT_MODEL_RATIO.get(cur_tier, 1.0)
+        tgt_ratio = _SPEND_OPT_MODEL_RATIO.get(target_tier, 1.0)
+        if cur_ratio <= tgt_ratio:
+            continue  # already on a cheaper or equivalent tier
+        savings_frac = 1.0 - tgt_ratio / cur_ratio
+        projected_save = stats["cost_usd"] * savings_frac
+        if projected_save < 0.005:
+            continue  # skip sub-cent savings
+        recs.append({
+            "tool":                      tool,
+            "current_model":             model,
+            "suggested_model_tier":      target_tier,
+            "call_count":                stats["calls"],
+            "current_cost_usd_30d":      round(stats["cost_usd"], 4),
+            "projected_savings_usd_30d": round(projected_save, 4),
+            "savings_pct":               round(savings_frac * 100, 1),
+        })
+
+    recs.sort(key=lambda r: -r["projected_savings_usd_30d"])
+    recs = recs[:5]
+    total_save = sum(r["projected_savings_usd_30d"] for r in recs)
+    total_cost = sum(r["current_cost_usd_30d"] for r in recs)
+    return {
+        "recommendations":               recs,
+        "total_projected_savings_usd_30d": round(total_save, 4),
+        "total_analyzed_cost_usd_30d":   round(total_cost, 4),
+        "window_days":                   30,
+        "_source":                       "local_store",
+    }
+
+
+@bp_usage.route("/api/usage/optimization-recommendations")
+def api_usage_optimization_recommendations():
+    """Spend-optimization tile: per-tool model-downgrade suggestions.
+
+    Reads spans for the last 30 days (no writes, no LLM calls) and applies
+    a static heuristic to surface tools that can safely be routed to a
+    cheaper model tier with the projected monthly savings.  Issue #1415.
+    """
+    if is_local_store_read_enabled():
+        fast = _try_local_store_spend_optimization()
+        if fast is not None:
+            return jsonify(fast)
+    return jsonify({
+        "recommendations":               [],
+        "total_projected_savings_usd_30d": 0,
+        "total_analyzed_cost_usd_30d":   0,
+        "window_days":                   30,
+        "note": "Enable clawmetry connect to see recommendations.",
+    })


### PR DESCRIPTION
## Summary

Implements the read-only v1 of the Spend Optimization Recommender from #1415. Queries the last 30 days of OTel spans (tool_name + model + cost_usd), applies a static heuristic to rank tools that can safely be routed to a cheaper model tier, and renders a 💡 Spend Optimization section on the Tokens tab showing projected monthly savings.

No writes, no LLM calls, no new dependencies.

## Changes

- **`routes/usage.py`** — adds `_SPEND_OPT_TOOL_DOWNGRADE` heuristic map, `_SPEND_OPT_MODEL_RATIO` price-ratio table, `_spend_opt_model_tier()`, `_try_local_store_spend_optimization()` (calls `query_recent_spans` via daemon proxy, groups by `(tool_name, model)`), and `GET /api/usage/optimization-recommendations` endpoint
- **`clawmetry/templates/tabs/usage.html`** — inserts a `spend-optimization-card` section (hidden until data arrives) between Cost Comparison and Trace Clusters
- **`clawmetry/static/js/app.js`** — adds `loadSpendOptimization()` + `renderSpendOptimization(data)` following the same pattern as `loadCostComparison`; wires the call into `loadUsage()`

## What's deferred (needs human call)

- **"Apply rule" button** (step 4 in the issue): writes to OpenClaw routing config — left as a follow-up so a human can review the write-path design.
- **v2 embedding-similarity confidence**: out of scope per the issue itself.

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("routes/usage.py").read())'` → syntax OK
- [ ] `curl http://localhost:8900/api/usage/optimization-recommendations` → `{"recommendations":[...],"total_projected_savings_usd_30d":X,...}`
- [ ] Load Tokens tab with span data present → 💡 Spend Optimization section appears with green savings header and per-tool rows
- [ ] Load Tokens tab with no span data → section stays hidden (card `display:none` is not overridden)
- [ ] No regressions on existing `/api/usage`, `/api/usage/cost-comparison`, `/api/model-attribution` endpoints

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #1415. Marked draft for human review — mark Ready for Review once happy.

Closes #1415

---
_Generated by [Claude Code](https://claude.ai/code/session_012LxFv2DsbWTykfz36rXUyd)_