### PR TITLE
fix: remove redundant variable assignments in dashboard.py (#1566)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -208,8 +208,6 @@ _budget_alert_cooldowns = {}  # rule_id -> last_fired_timestamp
 _AGENT_DOWN_SECONDS = 300  # 5 min with no OTLP data = agent down alert
 _ALERTS_CONFIG_FILE = os.path.expanduser("~/.openclaw/clawmetry-alerts.json")
 _security_posture_hash = ""
-_ALERTS_CONFIG_FILE = os.path.expanduser("~/.openclaw/clawmetry-alerts.json")
-_security_posture_hash = ""
 # Token velocity alert thresholds (GH#313)
 _VELOCITY_TOKENS_PER_2MIN = 10000  # tokens in any 2-minute window
 _VELOCITY_CONSECUTIVE_TOOLS = 20  # consecutive tool calls without human turn
@@ -12037,8 +12035,6 @@ _usage_cache = {"data": None, "ts": 0}
 _USAGE_CACHE_TTL = 60  # seconds
 _sessions_cache = {"data": None, "ts": 0}
 _SESSIONS_CACHE_TTL = 10  # seconds
-_transcript_analytics_cache = {"data": None, "ts": 0}
-_TRANSCRIPT_ANALYTICS_TTL = 60  # seconds
 
 
 def _get_sessions_dir():


### PR DESCRIPTION
Closes #1566

## Summary

- Removes `_ALERTS_CONFIG_FILE` and `_security_posture_hash` that were assigned twice back-to-back at lines 209–212 (second pair was an identical no-op — finding #5 from the audit).
- Removes the first definition of `_transcript_analytics_cache` and `_TRANSCRIPT_ANALYTICS_TTL` from the duplicated module-copy region; the definitive second definition ~370 lines later remains (finding #6 from the audit).
- Confirms finding #2 (alert webhook config UI) is already live in `clawmetry/templates/partials/budget-modal.html` and `static/js/app.js` — no porting needed.

**No behaviour change** — all four deleted lines were no-ops (same value, immediately overridden or redundantly set).

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('dashboard.py').read()); print('OK')"` — passes (syntax clean)
- [ ] `make lint` — no new errors introduced (163 pre-existing errors unchanged)
- [ ] Confirm `grep -c '_ALERTS_CONFIG_FILE = ' dashboard.py` returns 1
- [ ] Confirm `grep -c '_transcript_analytics_cache = ' dashboard.py` returns 1

## Remaining findings from #1566

Findings #3 (Self-Config Diff Viewer tab), #4 (Quick Actions panel), and #7 (full module-prelude de-duplication, ~2000 LOC) remain. Each should be a separate PR after human review of the dead-vs-live boundary on a fresh checkout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDSdMYfsFiKXgzD4xnp8yo)_