### PR TITLE
e2e(c7): failure quarantine mechanism

### DIFF
--- a/.github/workflows/quarantine-sweep.yml
+++ b/.github/workflows/quarantine-sweep.yml
@@ -1,0 +1,132 @@
+name: Quarantine Sweep
+
+# C7 gate: daily sweep of quarantined tests.
+# "Flaky failures are quarantined within 24h, not silently retried forever."
+# Tracking: vivekchand/clawmetry#1646
+#
+# How it works:
+#   Tests in tests/quarantine.txt are marked with pytest.mark.quarantine
+#   (via tests/conftest.py) and skipped in the main PR gate with
+#   -m 'not quarantine'. This workflow runs them daily (up to 3 attempts).
+#   It exits 0 if ANY attempt passes -- the test is still flaky but not
+#   broken. It hard-fails only when ALL 3 attempts fail, which means the
+#   test is now permanently broken and must be investigated within 24h.
+#
+# Non-blocking on PRs. Alerting is via GitHub job failure + email.
+# Remove continue-on-error once the team is comfortable with the signal.
+
+on:
+  schedule:
+    - cron: "23 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  quarantine-sweep:
+    name: Quarantine sweep (daily)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: |
+          pip install flask pytest pytest-playwright requests \
+            duckdb waitress cryptography
+
+      - name: Install Playwright browsers
+        run: python3 -m playwright install chromium --with-deps
+
+      - name: Check quarantine list
+        id: check
+        run: |
+          count=$(grep -cEv '^\s*(#|$)' tests/quarantine.txt 2>/dev/null || echo 0)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Quarantined tests: $count"
+          if [ "$count" -eq 0 ]; then
+            echo "No quarantined tests -- nothing to sweep."
+          else
+            grep -v '^\s*#' tests/quarantine.txt | grep -v '^\s*$' | while read -r t; do
+              echo "  - $t"
+            done
+          fi
+
+      - name: Start dashboard
+        if: steps.check.outputs.count != '0'
+        run: |
+          OPENCLAW_GATEWAY_TOKEN=ci-quarantine-token \
+            python3 dashboard.py --port 8900 --no-debug \
+            > /tmp/dashboard.log 2>&1 &
+          for i in $(seq 1 30); do
+            curl -sf -H "Authorization: Bearer ci-quarantine-token" \
+              http://localhost:8900/api/health && break
+            sleep 1
+          done
+
+      - name: Run quarantined tests (attempt 1 of 3)
+        if: steps.check.outputs.count != '0'
+        id: run1
+        continue-on-error: true
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+          CLAWMETRY_TOKEN: ci-quarantine-token
+        run: |
+          python3 -m pytest -m quarantine -v --tb=short 2>&1 | tee /tmp/sweep-run1.txt
+
+      - name: Run quarantined tests (attempt 2 of 3)
+        if: steps.check.outputs.count != '0' && steps.run1.outcome == 'failure'
+        id: run2
+        continue-on-error: true
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+          CLAWMETRY_TOKEN: ci-quarantine-token
+        run: |
+          python3 -m pytest -m quarantine -v --tb=short 2>&1 | tee /tmp/sweep-run2.txt
+
+      - name: Run quarantined tests (attempt 3 of 3)
+        if: |
+          steps.check.outputs.count != '0' &&
+          steps.run1.outcome == 'failure' &&
+          steps.run2.outcome == 'failure'
+        id: run3
+        env:
+          CLAWMETRY_URL: http://localhost:8900
+          CLAWMETRY_TOKEN: ci-quarantine-token
+        run: |
+          echo "::error::Quarantined test(s) failed all 3 attempts."
+          echo "::error::They are BROKEN (not just flaky). Investigate and fix within 24h."
+          echo "::error::See tests/quarantine.txt for the test list."
+          python3 -m pytest -m quarantine -v --tb=long 2>&1 | tee /tmp/sweep-run3.txt
+          exit 1
+
+      - name: Sweep summary
+        if: always() && steps.check.outputs.count != '0'
+        run: |
+          r1="${{ steps.run1.outcome }}"
+          r2="${{ steps.run2.outcome }}"
+          r3="${{ steps.run3.outcome }}"
+          if [ "$r1" = "success" ]; then
+            echo "All quarantined tests passed on attempt 1 (flakiness resolved? consider un-quarantining)."
+          elif [ "$r2" = "success" ]; then
+            echo "Quarantined tests passed on attempt 2 -- still flaky but not broken."
+          elif [ "$r3" = "success" ]; then
+            echo "Quarantined tests passed on attempt 3 -- still flaky."
+          else
+            echo "ALERT: quarantined test(s) BROKEN (all 3 attempts failed). See run3 log."
+          fi
+
+      - name: Upload sweep logs
+        if: always() && steps.check.outputs.count != '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: quarantine-sweep-logs-${{ github.run_number }}
+          path: |
+            /tmp/sweep-run*.txt
+            /tmp/dashboard.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import sys
 import json
 import subprocess
 import time
+from pathlib import Path
 import pytest
 import requests
 
@@ -23,6 +24,38 @@ def _shared_chromium():
         browser = p.chromium.launch(headless=True)
         yield browser
         browser.close()
+
+
+def pytest_configure(config):
+    """Register the 'quarantine' mark so -m 'not quarantine' works cleanly."""
+    config.addinivalue_line(
+        "markers",
+        "quarantine: test quarantined from main PR gate due to known flakiness; "
+        "see tests/quarantine.txt",
+    )
+
+
+def pytest_collection_modifyitems(items):
+    """Apply 'quarantine' mark to tests listed in tests/quarantine.txt.
+
+    Quarantined tests are excluded from the main PR gate via
+    -m 'not quarantine'. They still run daily in quarantine-sweep.yml,
+    which hard-fails if they go from flaky to permanently broken.
+    """
+    quarantine_path = Path(__file__).parent / "quarantine.txt"
+    if not quarantine_path.exists():
+        return
+    quarantined = {
+        line.strip()
+        for line in quarantine_path.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+    if not quarantined:
+        return
+    quarantine_mark = pytest.mark.quarantine
+    for item in items:
+        if item.nodeid in quarantined:
+            item.add_marker(quarantine_mark)
 
 
 def pytest_addoption(parser):
@@ -102,7 +135,7 @@ def server(base_url, token):
         yield base_url
         return
 
-    # No gateway token available — we're probably running hermetic MOAT /
+    # No gateway token available -- we're probably running hermetic MOAT /
     # unit tests (e.g. the MOAT Verifier CI job) that use their own Flask
     # test clients and don't need a live dashboard server at all. Yield None
     # so those tests proceed; any test that actually needs a running server

--- a/tests/quarantine.txt
+++ b/tests/quarantine.txt
@@ -1,0 +1,23 @@
+# Quarantine register: tests excluded from the main PR gate due to known flakiness.
+#
+# Format: one pytest node id per line.
+# Example: tests/test_e2e.py::TestFlowDiagram::test_flow_svg_renders
+#
+# To quarantine a test:
+#   1. Add its node id here (one per line).
+#   2. Open a PR so the change is code-reviewed.
+#
+# To un-quarantine:
+#   Remove the line once the root cause of the flakiness is fixed and
+#   the test has a clean run history (>= 3 consecutive green runs).
+#
+# Quarantined tests still run daily in .github/workflows/quarantine-sweep.yml.
+# That workflow retries each test up to 3 times. If ALL 3 attempts fail,
+# the sweep job hard-fails to alert the team that the test is now permanently
+# broken (not just intermittent) and needs investigation within 24h.
+#
+# The CI main-gate jobs pass -m 'not quarantine' so quarantined tests are
+# skipped in the per-PR runs. This prevents one flaky test from blocking
+# all PRs while still surfacing it daily.
+#
+# Last triage: 2026-05-22. No tests currently quarantined.


### PR DESCRIPTION
## Problem (C7: no quarantine mechanism -- RED)

Tracking issue #1646 criterion C7: "flaky failures are quarantined within 24h, not silently retried forever."

Currently there is no mechanism to:
- Prevent one flaky E2E test from blocking all PRs
- Alert the team when a quarantined test stops being flaky and becomes permanently broken
- Give engineers a standard process for handling flaky tests

## Changes (3 files, ~110 LOC)

### `tests/quarantine.txt` (new)

Empty register. One pytest node id per line. Comment lines and blank lines are ignored. Starts empty -- no tests are currently quarantined.

```
tests/test_e2e.py::TestFlowDiagram::test_flow_svg_renders   # example
```

### `tests/conftest.py` (+2 hooks, +1 import)

- `from pathlib import Path` -- needed by the new hook.
- `pytest_configure` -- registers the `quarantine` mark so `-m 'not quarantine'` works without `UnknownMarkWarning`.
- `pytest_collection_modifyitems` -- reads `quarantine.txt` at collection time and stamps matching test items with `pytest.mark.quarantine`. No other test is affected.

### `.github/workflows/quarantine-sweep.yml` (new)

Daily cron at 02:23 UTC. Runs `pytest -m quarantine` up to 3 times:

| Result | Meaning | Job outcome |
|---|---|---|
| Attempt 1 passes | Test healed itself; consider un-quarantining | green |
| Attempt 2 passes | Still flaky but not broken | green |
| Attempt 3 passes | Still flaky | green |
| All 3 fail | Test is BROKEN (not just intermittent) | **red -- alert** |

The job has `continue-on-error: true` so it never blocks PRs. It fails loudly (job failure, GitHub email) when a quarantined test goes from flaky to permanently broken, giving a 24h detection window.

## How to quarantine a test

```bash
echo "tests/test_e2e.py::TestFlowDiagram::test_flow_svg_renders" >> tests/quarantine.txt
git add tests/quarantine.txt && git commit -m "quarantine: test_flow_svg_renders (tracking #NNN)"
```

Then update the CI run commands to add `-m 'not quarantine'` if the quarantined test is in a hard-gate job. (The current `e2e-critical` job names tests explicitly, so `-m 'not quarantine'` is only needed if a quarantined test is added to an explicit list.)

## Acceptance test

```bash
# Verify mark is registered (no UnknownMarkWarning)
pytest --co -q tests/test_e2e.py -m quarantine 2>&1 | grep -v "UnknownMarkWarning"

# Add a test to quarantine.txt, verify it gets the mark
echo "tests/test_e2e.py::TestTabsLoad::test_overview_tab_loads" >> tests/quarantine.txt
pytest --co -q tests/test_e2e.py::TestTabsLoad -m quarantine
# Expected output: 1 test collected with quarantine marker
git checkout tests/quarantine.txt  # restore
```

## Tracking

Closes C7 in vivekchand/clawmetry#1646 (E2E Robustness Epic).

## Test plan

- [ ] CI passes on this PR (conftest.py change must not break any existing test collection)
- [ ] `pytest --co -q -m quarantine tests/` exits 0 with 0 tests collected (empty quarantine list)
- [ ] No `PytestUnknownMarkWarning` in CI output

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpSiaXsUjMQSVNv9FCnEAX)_