### PR TITLE
feat(selfevolve): on-demand only — stop the hourly Opus auto-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Self-Evolve: on-demand only (no more hourly auto-run) (2026-05-22)
+- Self-Evolve no longer runs on a timer — it was spending Opus turns on a schedule (the job flagged itself for it) and re-ran on every daemon restart (in-memory clock). It now runs ONLY when you click Analyze/Re-analyze. Local uses /api/selfevolve/analyze; cloud uses a new `selfevolve_analyze` heartbeat-relay action so the Re-analyze button triggers a fresh run on the daemon. Opt back into periodic refresh with CLAWMETRY_SELFEVOLVE_AUTO=1.
+
 ### Release: Self-Evolve "Fix with AI" (local + cloud relay) (2026-05-21)
 - Publishes the Fix-button feature (#1876 local, #1878 cloud relay + daemon `selfevolve_fix` action) and the daemon gateway-token detection fix.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5621,6 +5621,7 @@ _PENDING_ACTIONS = frozenset({
     "alert_rule_delete",
     "approval_decision",
     "selfevolve_fix",
+    "selfevolve_analyze",
 })
 
 
@@ -5809,6 +5810,9 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
     if atype == "selfevolve_fix":
         _action_selfevolve_fix(config, action)
         return
+    if atype == "selfevolve_analyze":
+        _action_selfevolve_analyze(config, action)
+        return
 
 
 def _selfevolve_fix_summary(stdout: str) -> str:
@@ -5915,6 +5919,60 @@ def _action_selfevolve_fix(config: dict, action: dict) -> None:
             )
         except Exception as e:
             log.warning("selfevolve_fix cache post failed: %s", e)
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def _action_selfevolve_analyze(config: dict, action: dict) -> None:
+    """Cloud-relayed on-demand Self-Evolve re-analyze (the Re-analyze button).
+
+    Self-Evolve no longer runs on a timer (see _build_selfevolve) — this is the
+    only thing that triggers a fresh review on cloud. Context is built on THIS
+    (heartbeat) thread because DuckDB isn't thread-safe; the agent runs in a
+    background thread (so a ~15s turn never blocks heartbeats), updates _SE_STATE
+    so the next snapshot carries the fresh findings, and posts the E2E-encrypted
+    findings to the action's cache_key for immediate cloud feedback.
+    """
+    cache_key = action.get("cache_key")
+    enc_key = config.get("encryption_key")
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not (cache_key and enc_key and api_key):
+        return
+    try:
+        ctx = _selfevolve_build_context()
+    except Exception:
+        ctx = {}
+    aid = action.get("id")
+
+    def _run():
+        payload = None
+        try:
+            payload = _selfevolve_compute_via_openclaw(ctx)
+        except Exception as e:
+            log.warning("selfevolve_analyze compute failed: %s", e)
+        if payload:
+            with _SE_LOCK:
+                _SE_STATE["payload"] = payload
+                _SE_STATE["computed_at"] = time.time()
+        out = payload or {"findings": [], "insufficient": True,
+                          "reason": "analysis failed — check the agent / gateway"}
+        try:
+            blob = encrypt_payload(out, enc_key)
+            _post(
+                "/ingest/cache",
+                {
+                    "node_id": node_id,
+                    "id": aid,
+                    "cache_key": cache_key,
+                    "blob": blob,
+                    "shape": "selfevolve_analyze",
+                    "ttl": 3600,
+                },
+                api_key,
+            )
+        except Exception as e:
+            log.warning("selfevolve_analyze cache post failed: %s", e)
 
     threading.Thread(target=_run, daemon=True).start()
 
@@ -7778,7 +7836,15 @@ def _build_selfevolve(workspace=None):
             except Exception:
                 payload = None
         can_run = bool(_resolve_openclaw_bin())
-        if can_run and (time.time() - computed_at > _SE_REFRESH_SEC):
+        # Self-Evolve no longer auto-runs on a timer. It spends Opus turns on a
+        # schedule (the job repeatedly flagged itself for exactly that), and the
+        # in-memory _SE_STATE meant every daemon restart reset the clock and
+        # triggered an immediate run. It now runs ONLY on demand — the
+        # Analyze/Re-analyze button (local: /api/selfevolve/analyze; cloud: the
+        # `selfevolve_analyze` relay action). Opt back into the periodic refresh
+        # with CLAWMETRY_SELFEVOLVE_AUTO=1 (interval CLAWMETRY_SELFEVOLVE_INTERVAL_SEC).
+        _auto = os.environ.get("CLAWMETRY_SELFEVOLVE_AUTO", "").strip().lower() in ("1", "true", "yes", "on")
+        if can_run and _auto and (time.time() - computed_at > _SE_REFRESH_SEC):
             # Build the context HERE, in the snapshot thread, before handing it
             # to the background runner — DuckDB connections aren't thread-safe,
             # so querying the store from the worker thread races this thread and


### PR DESCRIPTION
## Why
You asked: *"why do we keep running self-evolve every hour? it should be run only on demand of clicking analyse button."* Exactly right — and Self-Evolve had been flagging *itself* for it (*"the recurring job keeps adding Opus turns"*).

## Root cause
`_build_selfevolve` (daemon) auto-ran the review via `openclaw agent` on a 6h timer. `_SE_STATE` is **in-memory**, so every daemon restart reset `computed_at=0` → an immediate re-run. In practice it fired far more than every 6h and kept burning Opus.

## Fix — on-demand only
- **Gate the timer** behind `CLAWMETRY_SELFEVOLVE_AUTO` (default **OFF**). No more scheduled runs.
- **New `selfevolve_analyze` relay action**: the cloud Re-analyze button queues it; the daemon builds context on the heartbeat thread (DuckDB is single-thread), runs the review in a background thread, updates `_SE_STATE`, and posts the **E2E-encrypted** findings to the action's `cache_key`.
- **Local** Analyze (`/api/selfevolve/analyze`, Anthropic path) is unchanged — already on-demand.

## Verification
`_action_selfevolve_analyze` unit-tested: ran a real review, posted `shape=selfevolve_analyze` findings to the cache, updated `_SE_STATE`. Your **local daemon is already patched + restarted with auto-run OFF** — the hourly runs have stopped (and the restart did not trigger a run). Pairs with a cloud PR (enqueue endpoint + Re-analyze interceptor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)