### PR TITLE
feat(transcript): raw ↔ pretty toggle for the exact upstream payload (#1895)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -9643,9 +9643,60 @@ function _buildReplayEvent(m, idx) {
     timestamp: m.timestamp,
     tokens: m.tokens || null,
     params: m.params || null,
+    // Issue #1895: verbatim event payload for the Raw/Pretty toggle.
+    raw: (m.raw !== undefined ? m.raw : null),
     originalIndex: idx,
     extra: extra
   };
+}
+
+// ── Raw payload toggle (issue #1895) ───────────────────────────────────────
+// Lets users flip the whole transcript between the beautified turns and the
+// exact JSON payload OpenClaw recorded/sent upstream. Requested by users who
+// want to study OpenClaw's behavior, not just read a cleaned-up conversation.
+window._transcriptRawMode = false;
+
+function toggleTranscriptRaw() {
+  window._transcriptRawMode = !window._transcriptRawMode;
+  var btn = document.getElementById('replay-raw-toggle');
+  if (btn) {
+    var on = window._transcriptRawMode;
+    btn.style.background = on ? '#6366f1' : 'var(--button-bg)';
+    btn.style.color = on ? '#fff' : 'var(--text-secondary)';
+    btn.style.borderColor = on ? '#6366f1' : 'var(--border-secondary)';
+    btn.textContent = on ? '{ } Raw ✓' : '{ } Raw';
+  }
+  if (typeof _replayRenderCurrent === 'function') _replayRenderCurrent();
+}
+
+// Render the verbatim JSON body for a turn (raw mode). Returns '' when the
+// turn carries no captured payload so the caller can fall back to pretty.
+function _renderRawPayload(ev) {
+  var raw = ev && ev.raw;
+  if (raw == null) return '';
+  if (raw && typeof raw === 'object' && raw._raw_truncated) {
+    return '<div style="font-size:11px;color:var(--text-muted);font-style:italic;">'
+      + 'Raw payload too large to show inline (' + (raw._raw_bytes || 0)
+      + ' bytes). Open this transcript locally to view the full payload.</div>';
+  }
+  var pretty;
+  try { pretty = JSON.stringify(raw, null, 2); }
+  catch (e) { pretty = String(raw); }
+  var html = '<button type="button" onclick="copyTranscriptRaw(this)" style="float:right;background:none;border:1px solid var(--border-secondary);color:var(--text-muted);border-radius:5px;padding:1px 7px;font-size:10px;cursor:pointer;">Copy</button>';
+  html += '<pre style="white-space:pre-wrap;word-break:break-word;font-size:11px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--text-secondary);margin:0;overflow-x:auto;max-height:420px;">' + escHtml(pretty) + '</pre>';
+  return html;
+}
+
+function copyTranscriptRaw(btn) {
+  try {
+    var pre = btn.parentElement.querySelector('pre');
+    if (pre && navigator.clipboard) {
+      navigator.clipboard.writeText(pre.textContent);
+      var orig = btn.textContent;
+      btn.textContent = 'Copied';
+      setTimeout(function () { btn.textContent = orig; }, 1200);
+    }
+  } catch (e) {}
 }
 
 // Format the decoding-params dict into a compact inline pill. Returns ''
@@ -9669,6 +9720,22 @@ function _renderReplayEvent(ev, highlighted) {
   // Handle compaction events specially
   if (role === 'compaction') {
     return _renderCompactionEvent(ev, highlighted);
+  }
+  // Raw mode (#1895): show the verbatim payload bubble when this turn has one.
+  // Compaction markers carry no captured payload, so they fall through above.
+  if (window._transcriptRawMode && ev.raw != null) {
+    var rawBody = _renderRawPayload(ev);
+    if (rawBody) {
+      var rRing = highlighted ? 'box-shadow:0 0 0 2px #6366f1;' : '';
+      var rTs = ev.timestamp ? new Date(ev.timestamp).toLocaleString() : '';
+      var rCls = role === 'user' ? 'user' : role === 'assistant' ? 'assistant'
+               : role === 'system' ? 'system' : 'tool';
+      return '<div class="chat-msg ' + rCls + '" id="replay-msg-' + ev.originalIndex + '" style="' + rRing + '">'
+        + '<div class="chat-role">' + escHtml(role) + ' · raw</div>'
+        + rawBody
+        + (rTs ? '<div class="chat-ts">' + rTs + '</div>' : '')
+        + '</div>';
+    }
   }
   // Tool turns (assistant tool_use / user tool_result) carry no prose, so they
   // used to render as blank bubbles with just a role + timestamp — looking

--- a/clawmetry/templates/tabs/transcripts.html
+++ b/clawmetry/templates/tabs/transcripts.html
@@ -45,6 +45,17 @@
           min-width:120px;
           accent-color:#6366f1;
           ">
+        <button id="replay-raw-toggle" onclick="toggleTranscriptRaw()" title="Toggle between the beautified turn and the exact JSON payload OpenClaw recorded" style="
+          padding:5px 12px;
+          border-radius:6px;
+          border:1px solid var(--border-secondary);
+          background:var(--button-bg);
+          color:var(--text-secondary);
+          cursor:pointer;
+          font-size:12px;
+          font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+          white-space:nowrap;
+          ">{ } Raw</button>
       </div>
       <div style="display:flex;gap:6px;flex-wrap:wrap;">
         <button class="replay-filter active-filter" data-type="all" onclick="replayFilter('all')" style="

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2968,6 +2968,26 @@ def _stringify_content(content) -> str:
     return str(content) if content else ""
 
 
+# Issue #1895: expose the verbatim event payload so the transcript viewer can
+# toggle between the beautified turn and the exact JSON OpenClaw recorded/sent
+# upstream (requested by users studying OpenClaw's behavior). Capped per-message
+# so attaching it to every turn never bloats the response or the cloud snapshot
+# it rides into.
+_RAW_PAYLOAD_CAP = 12000
+
+
+def _bounded_raw_payload(obj, cap: int = _RAW_PAYLOAD_CAP):
+    """Return ``obj`` for inline raw-payload display, or a small truncation
+    marker when its serialized form exceeds ``cap`` bytes. Never raises."""
+    try:
+        serialized = json.dumps(obj, default=str)
+    except Exception:
+        return None
+    if len(serialized) > cap:
+        return {"_raw_truncated": True, "_raw_bytes": len(serialized)}
+    return obj
+
+
 def _expand_openclaw_event(obj: dict, ts_ms):
     """Map one OpenClaw event into zero or more transcript turns.
 
@@ -3308,17 +3328,21 @@ def _try_local_store_transcript(session_id: str, _events=None):
             # Issue #564: surface decoding params on assistant turns so the UI
             # can show the "T=… top_p=… max=…" pill inline with the reply.
             decoding = _extract_decoding_params(obj)
+            raw_payload = _bounded_raw_payload(obj)
             for turn in _expand_openclaw_event(obj, ts_ms):
                 if not turn.get("content", "").strip():
                     continue
                 if decoding and turn.get("role") == "assistant":
                     turn["params"] = decoding
+                if raw_payload is not None:
+                    turn["raw"] = raw_payload
                 messages.append(turn)
             continue
 
         # Anthropic-style fallback (existing logic).
         role = obj.get("role", obj.get("type", "unknown"))
         content = _stringify_content(obj.get("content", ""))
+        raw_payload = _bounded_raw_payload(obj)
         if obj.get("tool_calls") or obj.get("tool_use"):
             tools = obj.get("tool_calls") or obj.get("tool_use") or []
             if isinstance(tools, list):
@@ -3328,6 +3352,7 @@ def _try_local_store_transcript(session_id: str, _events=None):
                         "role": "tool",
                         "content": f"[Tool Call: {tname}]\n{json.dumps(tc.get('input', tc.get('arguments', {})), indent=2)[:500]}",
                         "timestamp": ts_ms,
+                        "raw": _bounded_raw_payload(tc),
                     })
         if role == "tool_result":
             role = "tool"
@@ -3344,6 +3369,8 @@ def _try_local_store_transcript(session_id: str, _events=None):
                 decoding = _extract_decoding_params(obj)
                 if decoding:
                     msg_entry["params"] = decoding
+            if raw_payload is not None:
+                msg_entry["raw"] = raw_payload
             messages.append(msg_entry)
     duration = None
     if first_ts and last_ts and last_ts > first_ts:
@@ -3420,6 +3447,7 @@ def api_transcript(session_id):
                                         "content": f"[Tool Call: {tname}]\n{json.dumps(tc.get('input', tc.get('arguments', {})), indent=2)[:500]}",
                                         "timestamp": obj.get("timestamp")
                                         or obj.get("time"),
+                                        "raw": _bounded_raw_payload(tc),
                                     }
                                 )
                     if role == "tool_result":
@@ -3467,6 +3495,10 @@ def api_transcript(session_id):
                             decoding = _extract_decoding_params(obj)
                             if decoding:
                                 msg_entry["params"] = decoding
+                        # Issue #1895: verbatim payload for the raw/pretty toggle.
+                        raw_payload = _bounded_raw_payload(obj)
+                        if raw_payload is not None:
+                            msg_entry["raw"] = raw_payload
                         messages.append(msg_entry)
                 except (json.JSONDecodeError, ValueError):
                     pass


### PR DESCRIPTION
## What
Adds a **`{ } Raw`** toggle to the transcript viewer that flips the whole conversation between the beautified turns and the **verbatim JSON payload** OpenClaw recorded for each turn.

Closes #1895.

## Why
Users who want to study OpenClaw's exact behavior need to see the raw payload, not only the cleaned-up conversation. ClawMetry had no way to expose the exact wire payload — this adds the raw ↔ pretty toggle they asked for.

## How
**Backend (`routes/sessions.py`)**
- New `_bounded_raw_payload()` helper returns the verbatim event dict, or a small `{_raw_truncated, _raw_bytes}` marker when it exceeds 12 KB — so `raw` never bloats the response or the cloud snapshot it rides into (FLYWHEEL: performance is a feature).
- Attaches `raw` to each turn in **both** the DuckDB fast-path (`_try_local_store_transcript`) and the JSONL fallback (`api_transcript`): OpenClaw events, Anthropic-style messages, and tool calls.
- **DuckDB-first:** the raw event `data` is already ingested; no new filesystem reads in the handler.

**Frontend (`app.js` + `transcripts.html`)**
- `{ } Raw` toggle button in the replay control bar.
- Raw mode renders each turn as verbatim JSON with a **Copy** button; falls back to the pretty turn when a turn has no captured payload (e.g. compaction markers) and shows a note for truncated payloads.

## Verification (local, repo HEAD on :8901)
- Backend against **live DuckDB**: every turn carries `raw`; sample is a real 6.2 KB OpenClaw event (`cwd`/`gitBranch`/`message`/`type`/...).
- Truncation branch returns the `_raw_truncated` marker for >12 KB payloads.
- Browser: toggle flips to `{ } Raw ✓`, each bubble shows the verbatim JSON + Copy button (screenshot below). No DuckDB writer-lock contention.

![raw toggle](.claude/screenshots/issue1895-raw-toggle-local.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
