### PR TITLE
feat(memory): access log — when memory was read + which conversation triggered it (#1896)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7821,8 +7821,10 @@ async function loadMemoryAnalytics() {
 function memorySwitchView(view) {
   var summary = document.getElementById('memory-summary-view');
   var all = document.getElementById('memory-all-view');
+  var access = document.getElementById('memory-access-view');
   if (summary) summary.style.display = view === 'summary' ? 'block' : 'none';
   if (all) all.style.display = view === 'all' ? 'block' : 'none';
+  if (access) access.style.display = view === 'access' ? 'block' : 'none';
   document.querySelectorAll('.mem-view-tab').forEach(function(t) {
     var active = t.getAttribute('data-view') === view;
     t.style.background = active ? 'var(--bg-secondary)' : 'transparent';
@@ -7831,9 +7833,65 @@ function memorySwitchView(view) {
   });
   if (view === 'summary') {
     if (typeof loadSelfConfig === 'function') loadSelfConfig();
+  } else if (view === 'access') {
+    loadMemoryAccess();
   } else {
     _loadMemoryAllFiles();
   }
+}
+
+// ── Memory access log (issue #1896) ────────────────────────────────────────
+// Shows when OpenClaw read memory (memory_search / memory_get) and lets the
+// user click through to the conversation that triggered each access.
+async function loadMemoryAccess() {
+  var el = document.getElementById('memory-access-list');
+  if (!el) return;
+  el.innerHTML = '<div style="padding:18px;color:var(--text-muted);">Loading memory accesses…</div>';
+  var data;
+  try {
+    data = await fetch('/api/memory-access?limit=300').then(function(r){ return r.json(); });
+  } catch (e) {
+    el.innerHTML = '<div style="padding:18px;color:var(--text-muted);">Could not load memory accesses.</div>';
+    return;
+  }
+  if (!data || data.available === false) {
+    el.innerHTML = '<div style="padding:24px;text-align:center;color:var(--text-secondary);font-size:13px;">Memory access history reads from the local event store, which is not available here.</div>';
+    return;
+  }
+  var rows = data.accesses || [];
+  if (!rows.length) {
+    el.innerHTML = '<div style="padding:24px;text-align:center;color:var(--text-secondary);font-size:13px;">No memory accesses recorded yet. They appear here once your agent reads its memory.</div>';
+    return;
+  }
+  var html = '<div style="display:flex;flex-direction:column;">';
+  rows.forEach(function(a) {
+    var op = a.op || 'access';
+    var opColor = op === 'search' ? '#6366f1' : op === 'get' ? '#10b981' : '#6b7280';
+    var opLabel = op === 'search' ? '🔍 search' : op === 'get' ? '📄 get' : op;
+    var when = a.ts ? new Date(a.ts).toLocaleString() : '';
+    var sid = a.session_id || '';
+    var sidShort = sid ? escHtml(sid.slice(0, 12)) : '(unknown session)';
+    var canOpen = !!sid;
+    html += '<div onclick="' + (canOpen ? "memoryOpenAccessConversation('" + escHtml(sid) + "')" : '') + '" '
+      + 'style="display:flex;align-items:center;gap:12px;padding:10px 14px;border-bottom:1px solid var(--border-secondary);'
+      + (canOpen ? 'cursor:pointer;' : '') + '" '
+      + (canOpen ? 'onmouseover="this.style.background=\'var(--bg-tertiary,#1e293b)\'" onmouseout="this.style.background=\'\'"' : '') + '>'
+      + '<span style="flex-shrink:0;background:' + opColor + '22;color:' + opColor + ';border-radius:6px;padding:2px 8px;font-size:11px;font-weight:600;white-space:nowrap;">' + opLabel + '</span>'
+      + '<span style="flex:1;color:var(--text-primary);font-size:13px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="' + escHtml(a.target || '') + '">' + (a.target ? escHtml(a.target) : '<span style="color:var(--text-muted);">(no query)</span>') + '</span>'
+      + '<span style="flex-shrink:0;color:var(--text-muted);font-size:11px;white-space:nowrap;">' + escHtml(when) + '</span>'
+      + '<span style="flex-shrink:0;color:var(--text-secondary);font-size:11px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;white-space:nowrap;">' + sidShort + (canOpen ? ' ›' : '') + '</span>'
+      + '</div>';
+  });
+  html += '</div>';
+  el.style.cssText = 'padding:0;overflow:hidden;';
+  el.innerHTML = html;
+}
+
+// Deep-link from a memory access to the conversation that triggered it.
+function memoryOpenAccessConversation(sessionId) {
+  if (!sessionId) return;
+  if (typeof switchTab === 'function') switchTab('transcripts');
+  setTimeout(function(){ if (typeof viewTranscript === 'function') viewTranscript(sessionId); }, 60);
 }
 
 // Entry point called by nav switchTab + loadAll bootstrap.

--- a/clawmetry/templates/tabs/memory.html
+++ b/clawmetry/templates/tabs/memory.html
@@ -7,6 +7,7 @@
     <div style="display:flex;gap:6px;align-items:center;">
       <div class="mem-view-tab" data-view="summary" onclick="memorySwitchView('summary')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:var(--bg-secondary);border:1px solid var(--border-primary);color:var(--text-primary);">Summary</div>
       <div class="mem-view-tab" data-view="all" onclick="memorySwitchView('all')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:transparent;border:1px solid transparent;color:var(--text-muted);">All files</div>
+      <div class="mem-view-tab" data-view="access" onclick="memorySwitchView('access')" style="padding:6px 14px;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer;background:transparent;border:1px solid transparent;color:var(--text-muted);">Access log</div>
       <button class="refresh-btn" onclick="loadMemory()" style="margin-left:8px;">&#8635;</button>
     </div>
   </div>
@@ -83,6 +84,12 @@
 
       </div>
     </div>
+  </div>
+
+  <!-- ACCESS LOG VIEW (issue #1896) -->
+  <div id="memory-access-view" style="display:none;">
+    <div style="font-size:12px;color:var(--text-muted);margin-bottom:10px;">When OpenClaw read its memory (via memory_search / memory_get), and which conversation triggered it. Click a row to open that conversation.</div>
+    <div class="card" id="memory-access-list" style="color:var(--text-muted);font-size:13px;">Loading memory accesses…</div>
   </div>
 
   <!-- ALL FILES VIEW -->

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -1240,6 +1240,111 @@ def api_memory_rag_search():
         conn.close()
 
 
+# ── Memory access history (issue #1896) ────────────────────────────────────
+# OpenClaw reads memory via the MCP tools mcp__openclaw__memory_get /
+# memory_search. Each call shows up as a `tool_use` block in the assistant
+# turn that triggered it, carrying the search query (or fetched key) plus the
+# session id + timestamp. We surface those as an access timeline so users can
+# see when a memory was accessed and click through to the conversation that
+# triggered it (verified against real events 2026-05-22).
+_MEMORY_TOOL_PREFIX = "mcp__openclaw__memory_"
+
+
+def _walk_tool_uses(node):
+    """Yield every dict in ``node`` whose type is 'tool_use' (depth-first).
+    Handles the nested message/content shapes OpenClaw v3 + claude-cli use."""
+    if isinstance(node, dict):
+        if node.get("type") == "tool_use" and node.get("name"):
+            yield node
+        for v in node.values():
+            yield from _walk_tool_uses(v)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk_tool_uses(item)
+
+
+def _extract_memory_accesses(rows, limit=200):
+    """Pull memory tool calls out of raw events into access records.
+
+    Returns a recent-first list of
+    ``{op, target, session_id, ts, tool_use_id}``. ``op`` is "search"/"get",
+    ``target`` is the search query or fetched key. Never raises.
+    """
+    accesses = []
+    for ev in rows or []:
+        data = ev.get("data")
+        if not isinstance(data, dict):
+            continue
+        try:
+            tool_uses = list(_walk_tool_uses(data))
+        except Exception:
+            tool_uses = []
+        for tu in tool_uses:
+            name = tu.get("name") or ""
+            if not name.startswith(_MEMORY_TOOL_PREFIX):
+                continue
+            op = name[len(_MEMORY_TOOL_PREFIX):] or "access"  # "search" / "get"
+            inp = tu.get("input") if isinstance(tu.get("input"), dict) else {}
+            target = (
+                inp.get("query") or inp.get("key") or inp.get("id")
+                or inp.get("name") or inp.get("path") or ""
+            )
+            if not target and inp:
+                try:
+                    target = json.dumps(inp)[:200]
+                except Exception:
+                    target = ""
+            accesses.append({
+                "op": op,
+                "target": str(target)[:300],
+                "session_id": ev.get("session_id") or "",
+                "ts": ev.get("ts"),
+                "tool_use_id": tu.get("id") or "",
+            })
+    # Recent-first. ``ts`` is an ISO-8601 string for v3 events; sort as string
+    # which is chronologically correct for that format, defensive for others.
+    accesses.sort(key=lambda a: str(a.get("ts") or ""), reverse=True)
+    return accesses[:limit]
+
+
+@bp_memory.route("/api/memory-access")
+def api_memory_access():
+    """Timeline of memory tool accesses (memory_get / memory_search).
+
+    DuckDB-first: reads already-ingested events via the daemon proxy and
+    extracts memory tool calls. Returns HTTP 200 with ``available: false``
+    when the store can't be read so the UI degrades gracefully.
+
+    Query params:
+      limit — max records (default 200, max 1000)
+    """
+    try:
+        limit = min(int(request.args.get("limit", 200)), 1000)
+    except (ValueError, TypeError):
+        limit = 200
+
+    rows = None
+    try:
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_events", limit=12000)
+    except Exception:
+        rows = None
+    if rows is None and is_local_store_read_enabled():
+        # Single-process fallback (tests/dev with no sync daemon), mirroring
+        # routes.sessions._try_local_store_transcript.
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_events(limit=12000)
+        except Exception:
+            rows = None
+    if rows is None:
+        return jsonify({"available": False, "accesses": [], "total": 0})
+
+    accesses = _extract_memory_accesses(rows, limit=limit)
+    return jsonify({"available": True, "accesses": accesses, "total": len(accesses)})
+
+
 # ── Security ───────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What
Adds an **"Access log"** view to the Memory tab showing every memory tool access (`mcp__openclaw__memory_search` / `memory_get`) with its query/key, timestamp, and originating session. Clicking a row opens the conversation that triggered the access.

Closes #1896.

## Why
Users want to see **when** a memory was accessed and **which conversation triggered it**. The Memory tab's existing "History" is file-version history (edits), not access tracking — this fills that gap.

## How
**Backend (`routes/infra.py`)**
- New `GET /api/memory-access` on `bp_memory`. **DuckDB-first:** reads already-ingested events via the daemon proxy (`local_store_via_daemon`), with the same single-process RO fallback `routes.sessions` uses.
- `_walk_tool_uses()` + `_extract_memory_accesses()` pull `tool_use` blocks whose name starts with `mcp__openclaw__memory_` into `{op, target, session_id, ts, tool_use_id}`, recent-first.
- Returns `available:false` (HTTP 200) when the store can't be read, so the UI degrades gracefully (oss-passthrough safe, no 410).

**Frontend (`app.js` + `memory.html`)**
- Third Memory view tab **"Access log"**; `loadMemoryAccess()` renders the timeline (search/get badge, query, time, session).
- `memoryOpenAccessConversation()` deep-links a row to `viewTranscript()`.

## Verification (against REAL data, per FLYWHEEL)
The store had no real memory-tool calls, so I generated one: ran a real `memory_search` turn via `openclaw agent` (OpenClaw's own creds), which landed real `mcp__openclaw__memory_search` events in DuckDB. Then confirmed:
- `/api/memory-access` extracts the 3 real searches (`OpenInfer` / `ClawMetry` / `ClawMetry OpenInfer`) with session + ts.
- The Access log view renders them (screenshot).
- Clicking a row deep-links to the triggering conversation in the transcript viewer.

![access log](.claude/screenshots/issue1896-memory-access-log.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
