### PR TITLE
feat: hide ClawMetry's own helper sessions from user-facing views

### DIFF
--- a/clawmetry/config.py
+++ b/clawmetry/config.py
@@ -40,6 +40,33 @@ def is_local_store_read_enabled() -> bool:
         not in _LOCAL_STORE_DISABLE_VALUES
 
 
+# ── ClawMetry-internal session filter ──────────────────────────────────────
+# Sessions ClawMetry itself spawns to drive OpenClaw (Self-Evolve, Fix-with-AI,
+# memory probes, …) all use a "clawmetry-" session-id prefix. They are our own
+# plumbing, not the user's agent activity, so user-facing views (transcripts,
+# brain feed, stuck-session alerts) hide them by default. Set
+# CLAWMETRY_SHOW_INTERNAL_SESSIONS=1 to surface them (debugging ClawMetry itself).
+CLAWMETRY_INTERNAL_SESSION_PREFIX = "clawmetry-"
+_SHOW_INTERNAL_ENABLE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def is_clawmetry_internal_session(session_id) -> bool:
+    """True for sessions ClawMetry spawns to invoke OpenClaw (clawmetry-fix,
+    clawmetry-selfevolve, clawmetry-mem-probe, …)."""
+    return bool(session_id) and str(session_id).startswith(
+        CLAWMETRY_INTERNAL_SESSION_PREFIX
+    )
+
+
+def hide_clawmetry_session(session_id) -> bool:
+    """Whether to hide ``session_id`` from user-facing views because it's
+    ClawMetry's own plumbing. Override with CLAWMETRY_SHOW_INTERNAL_SESSIONS=1."""
+    if not is_clawmetry_internal_session(session_id):
+        return False
+    return os.environ.get("CLAWMETRY_SHOW_INTERNAL_SESSIONS", "").strip().lower() \
+        not in _SHOW_INTERNAL_ENABLE_VALUES
+
+
 @dataclass
 class ClawMetryConfig:
     """

--- a/dashboard.py
+++ b/dashboard.py
@@ -8685,6 +8685,12 @@ def _check_stuck_sessions() -> None:
         sid = s.get("sessionId", "")
         if not sid:
             continue
+        # Don't alert on ClawMetry's own helper sessions (clawmetry-fix /
+        # clawmetry-selfevolve / clawmetry-mem-probe …) — they're our plumbing,
+        # not the user's agent activity. Override: CLAWMETRY_SHOW_INTERNAL_SESSIONS=1.
+        from clawmetry.config import hide_clawmetry_session
+        if hide_clawmetry_session(sid):
+            continue
         updated_ms = s.get("updatedAt") or 0
         if not updated_ms:
             continue

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -21,7 +21,7 @@ import time
 from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, jsonify, request
-from clawmetry.config import is_local_store_read_enabled
+from clawmetry.config import is_local_store_read_enabled, hide_clawmetry_session
 from clawmetry.risk import compute_hallucination_risk, is_llm_event
 from clawmetry.token_confidence import annotate_events as _annotate_token_confidence
 from clawmetry.token_confidence import annotate_tool_alternatives as _annotate_tool_alternatives
@@ -279,6 +279,10 @@ def _try_local_store_brain(limit, include_artifacts, since=None):
     # the dashboard JS expects (time/type/detail/src/sessionId/...).
     out = []
     for r in rows:
+        # Hide ClawMetry's own helper sessions (clawmetry-fix / -selfevolve /
+        # -mem-probe …) so our plumbing doesn't show up in the Brain feed.
+        if hide_clawmetry_session(r.get("session_id")):
+            continue
         # P0 regression fix (#1143): the v3 sync mapper nests content under
         # ``data.data`` and the legacy trajectory parser nests it under
         # ``data.message.content`` — neither exposes the flat ``input/summary/
@@ -1003,6 +1007,16 @@ def api_brain_history():
         m = _skill_pat.search(detail)
         if m:
             ev["skill"] = m.group(1)
+
+    # Hide ClawMetry's own helper sessions (clawmetry-fix / -selfevolve /
+    # -mem-probe …) from the Brain feed — plumbing, not the user's activity.
+    # (The local-store fast path above already excludes them at the source.)
+    events = [
+        ev for ev in events
+        if not hide_clawmetry_session(
+            ev.get("sessionId") or ev.get("source") or ev.get("src")
+        )
+    ]
 
     # OSS 24h cap (issue #1448): drop any JSONL-sourced event older than
     # the cap before we count + ship. CONTEXT pseudo-events have no

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -33,7 +33,7 @@ import time
 from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, Response, jsonify, request
-from clawmetry.config import is_local_store_read_enabled
+from clawmetry.config import is_local_store_read_enabled, hide_clawmetry_session
 
 bp_logs = Blueprint('logs', __name__)
 bp_memory = Blueprint('memory', __name__)
@@ -1272,6 +1272,11 @@ def _extract_memory_accesses(rows, limit=200):
     """
     accesses = []
     for ev in rows or []:
+        # Hide ClawMetry's own helper sessions (clawmetry-selfevolve /
+        # clawmetry-mem-probe …) — their memory reads are plumbing, not the
+        # user's activity. Override: CLAWMETRY_SHOW_INTERNAL_SESSIONS=1.
+        if hide_clawmetry_session(ev.get("session_id")):
+            continue
         data = ev.get("data")
         if not isinstance(data, dict):
             continue

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -25,7 +25,7 @@ from datetime import datetime
 import csv
 from datetime import timezone
 from flask import Blueprint, jsonify, request, Response
-from clawmetry.config import is_local_store_read_enabled
+from clawmetry.config import is_local_store_read_enabled, hide_clawmetry_session
 from routes._dedupe import build_sibling_bucket_max, is_sibling_dup
 
 bp_sessions = Blueprint('sessions', __name__)
@@ -261,6 +261,7 @@ def api_sessions():
             fast["_source"] = _derive_envelope_source(
                 fast["sessions"], fallback="local_store"
             )
+            fast["sessions"] = _filter_internal_sessions(fast["sessions"])
             return jsonify(fast)
     gw_data = _d._gw_invoke("sessions_list", {"limit": 20, "messageLimit": 0})
     if gw_data and "sessions" in gw_data:
@@ -283,8 +284,27 @@ def api_sessions():
     # registrar runs). Without this merge those sessions stay invisible until
     # the registrar catches up — see MOAT_E2E_REPORT_2026-05-13 root-cause #3.
     _merge_unregistered_jsonls(sessions)
+    sessions = _filter_internal_sessions(sessions)
     capped = _apply_24h_retention_cap(sessions)
     return jsonify({"sessions": sessions, "capped_at_24h": capped})
+
+
+def _filter_internal_sessions(rows: list) -> list:
+    """Drop ClawMetry's own helper sessions (clawmetry-fix / -selfevolve /
+    -mem-probe …) from a session-row list so our plumbing doesn't mix with the
+    user's agent activity. Honors CLAWMETRY_SHOW_INTERNAL_SESSIONS=1."""
+    out = []
+    for s in rows or []:
+        if not isinstance(s, dict):
+            out.append(s)
+            continue
+        sid = (
+            s.get("sessionId") or s.get("id") or s.get("session_id") or s.get("key")
+        )
+        if hide_clawmetry_session(sid):
+            continue
+        out.append(s)
+    return out
 
 
 def _derive_envelope_source(rows: list, fallback: str = "local_store") -> str:
@@ -2826,6 +2846,11 @@ def _try_local_store_transcripts():
         sid = r.get("session_id") or ""
         if not sid:
             continue
+        # Issue #1896 follow-up: hide ClawMetry's own helper sessions
+        # (clawmetry-fix / clawmetry-selfevolve / clawmetry-mem-probe …) so
+        # our plumbing doesn't mix with the user's agent activity.
+        if hide_clawmetry_session(sid):
+            continue
         # Coerce ts (ISO string) to ms-since-epoch for parity with the
         # legacy ``int(os.path.getmtime(fpath) * 1000)`` shape.
         modified_ms = 0
@@ -2878,6 +2903,9 @@ def api_transcripts():
             reverse=True,
         ):
             if not fname.endswith(".jsonl") or "deleted" in fname:
+                continue
+            # Hide ClawMetry's own helper sessions (see _try_local_store_transcripts).
+            if hide_clawmetry_session(fname.replace(".jsonl", "")):
                 continue
             fpath = os.path.join(sessions_dir, fname)
             try:


### PR DESCRIPTION
## Why
ClawMetry spawns OpenClaw sessions to do its own work (Self-Evolve, Fix-with-AI, memory probes), all named with a `clawmetry-` session-id prefix. These were leaking into user-facing views and mixing with the user's real agent activity: a stuck-session alert fired on `clawmetry-fix`, and `clawmetry-mem-probe` showed in the transcripts list and Brain feed.

## How
Centralizes the convention in `clawmetry/config.py` (`is_clawmetry_internal_session` / `hide_clawmetry_session`) and hides these sessions **by default** from every user-facing surface:
- Stuck-session alerts (`dashboard.py`)
- Transcripts list — DuckDB + JSONL paths (`routes/sessions.py`)
- Active sessions list — both paths (`routes/sessions.py`)
- Brain feed — fast path + legacy (`routes/brain.py`)
- Memory access log (`routes/infra.py`)

Escape hatch for debugging ClawMetry itself: `CLAWMETRY_SHOW_INTERNAL_SESSIONS=1`.

There was already precedent for this filter in `sync.py` ("skip the ClawMetry helper sessions so we score the user's real agent"); this makes it consistent across the user-facing read paths.

## Verification
Against live DuckDB: `clawmetry-mem-probe` / `clawmetry-fix` / `clawmetry-selfevolve` no longer appear in transcripts, sessions, brain, or the memory access log; real UUID sessions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)