### PR TITLE
fix(crons): render real schedule (not {}) + stop run-history 502 from erroring

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7392,9 +7392,14 @@ async function loadCronRuns(jobId) {
     var timelinePromise = fetch('/api/crons/' + encodeURIComponent(jobId) + '/runs?limit=30')
       .then(function(r) { return r.ok ? r.json() : {runs:[]}; })
       .catch(function() { return {runs:[]}; });
-    var resp = await fetch('/api/cron/' + encodeURIComponent(jobId) + '/runs');
-    if (!resp.ok) throw new Error('HTTP ' + resp.status);
-    var data = await resp.json();
+    // The legacy gateway-derived endpoint is BEST-EFFORT only -- it 502s in
+    // cloud (no gateway reachable) and may be offline locally. Never let its
+    // failure surface an error: the DuckDB-backed timeline endpoint above is
+    // the real source. Falling through to {runs:[]} yields the friendly
+    // "No run history yet" empty state instead of a scary 502.
+    var data = await fetch('/api/cron/' + encodeURIComponent(jobId) + '/runs')
+      .then(function(r) { return r.ok ? r.json() : {runs:[]}; })
+      .catch(function() { return {runs:[]}; });
     var timelineData = await timelinePromise;
     var timelineRuns = (timelineData && timelineData.runs) || [];
     var el = document.getElementById('cron-runs-' + jobId);
@@ -7676,21 +7681,39 @@ function showCronToast(msg) {
 }
 
 function formatSchedule(s) {
+  // Defensive: never render a raw `{}` or JSON blob. Schedules can arrive as
+  // a structured dict (the blessed shape), a bare cron-expr string (legacy
+  // store rows), or empty (data not yet synced). Handle all three.
+  if (s == null) return 'no schedule';
+  if (typeof s === 'string') {
+    if (!s.trim()) return 'no schedule';
+    var hs = cronToHuman(s);
+    return hs ? ('cron: ' + s + ' \u00b7 ' + hs) : ('cron: ' + s);
+  }
+  if (typeof s !== 'object') return String(s);
   if (s.kind === 'cron') {
-    var expr = s.expr;
+    var expr = s.expr || s.cron || '';
+    if (!expr) return 'cron (no expression)';
     var human = cronToHuman(expr);
     var label = 'cron: ' + expr;
-    if (human) label += ' \u2014 ' + human;
+    if (human) label += ' \u00b7 ' + human;
     if (s.tz) label += ' (' + s.tz + ')';
     return label;
   }
-  if (s.kind === 'every') {
-    var mins = s.everyMs / 60000;
-    if (mins >= 60) return 'every ' + (mins/60).toFixed(0) + 'h';
-    return 'every ' + mins + ' min';
+  if (s.kind === 'every' || s.kind === 'interval') {
+    var ms = (typeof s.everyMs === 'number') ? s.everyMs : null;
+    if (ms != null) {
+      var mins = ms / 60000;
+      if (mins >= 60) return 'every ' + (mins/60).toFixed(0) + 'h';
+      return 'every ' + mins + ' min';
+    }
+    if (s.interval) return 'every ' + s.interval;
   }
-  if (s.kind === 'at') return 'once at ' + formatTime(s.atMs);
-  return JSON.stringify(s);
+  if (s.kind === 'at') return 'once at ' + formatTime(s.atMs || s.at);
+  // Last-ditch: surface any expr-ish field rather than the raw object.
+  if (s.expr || s.cron) return 'cron: ' + (s.expr || s.cron);
+  if (s.interval) return 'every ' + s.interval;
+  return Object.keys(s).length ? 'custom schedule' : 'no schedule';
 }
 
 function cronToHuman(expr) {
@@ -7712,6 +7735,11 @@ function cronToHuman(expr) {
   if (evHr && dom === '*' && mon === '*' && dow === '*') {
     if (min === '0') return 'every ' + evHr[1] + ' hours';
     return 'every ' + evHr[1] + ' hours at :' + min.padStart(2,'0');
+  }
+  // Minute X past every hour within an hour range (e.g. "37 9-21 * * *")
+  var hrRange = hr.match(/^(\d{1,2})-(\d{1,2})$/);
+  if (hrRange && dom === '*' && mon === '*' && dow === '*' && /^\d+$/.test(min)) {
+    return 'at :' + min.padStart(2,'0') + ' hourly, ' + hrRange[1].padStart(2,'0') + ':00 to ' + hrRange[2].padStart(2,'0') + ':00';
   }
   // Daily
   if (dom === '*' && mon === '*' && dow === '*' && /^\d+$/.test(hr) && /^\d+$/.test(min)) {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6491,19 +6491,22 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
         events = []
         emitted_job_ids: list = []
         for j in jobs:
-            sched = j.get("schedule", {})
+            sched = j.get("schedule", {}) or {}
             kind = sched.get("kind", "")
-            expr = (
-                sched.get("interval", "")
-                if kind == "interval"
-                else (
-                    f"at {sched.get('at', '')}"
-                    if kind == "at"
-                    else sched.get("cron", "")
-                    if kind == "cron"
-                    else ""
-                )
-            )
+            # OpenClaw's on-disk schedule shapes:
+            #   {"kind":"cron","expr":"37 9-21 * * *","tz":"..."}
+            #   {"kind":"every","everyMs":3600000} | {"kind":"interval","interval":"1h"}
+            #   {"kind":"at","atMs":...} | {"kind":"at","at":"..."}
+            # The cron field is `expr`, NOT `cron` -- reading the wrong name
+            # produced an empty string that collapsed to `{}` in the UI.
+            if kind == "cron":
+                expr = sched.get("expr") or sched.get("cron") or ""
+            elif kind in ("interval", "every"):
+                expr = str(sched.get("interval") or sched.get("everyMs") or "")
+            elif kind == "at":
+                expr = f"at {sched.get('at') or sched.get('atMs') or ''}"
+            else:
+                expr = ""
             job_state = j.get("state", {})
             job_id = j.get("id", "")
             event_data = {
@@ -6556,7 +6559,13 @@ def sync_crons(config: dict, state: dict, paths: dict) -> int:
                     "cron_id":     job_id,
                     "agent_type":  "openclaw",
                     "name":        j.get("name", ""),
-                    "schedule":    expr,
+                    # Persist the FULL structured schedule (not the lossy
+                    # flattened expr) so the dashboard's formatSchedule +
+                    # next-fire predictor get {kind,expr,tz} back. Readers
+                    # (_row_to_cron_job / _build_crons_cache_pushes) json.loads
+                    # it to a dict. A bare expr string here is what made the
+                    # schedule render as `{}`.
+                    "schedule":    json.dumps(sched) if sched else "",
                     "enabled":     bool(j.get("enabled", True)),
                     "last_run_at": str(job_state.get("lastRunAtMs") or ""),
                     "last_status": str(job_state.get("lastStatus") or ""),
@@ -8833,19 +8842,6 @@ def _build_cron_jobs(paths):
         jobs = data.get("jobs", []) if isinstance(data, dict) else data
         result = []
         for j in jobs:
-            sched = j.get("schedule", {})
-            kind = sched.get("kind", "")
-            expr = (
-                sched.get("interval", "")
-                if kind == "interval"
-                else (
-                    f"at {sched.get('at', '')}"
-                    if kind == "at"
-                    else sched.get("cron", "")
-                    if kind == "cron"
-                    else ""
-                )
-            )
             sched_obj = j.get("schedule", {})
             result.append(
                 {


### PR DESCRIPTION
## What

Two cron-tab bugs visible on the **cloud** Crons screen (reported with screenshots):

### Bug 1 — schedule renders as a literal `{}`
The "Hourly water reminder" cron showed `{}` as its schedule.

**Root cause:** the sync daemon flattens OpenClaw's structured schedule into a single `expr` string before storing it, AND reads the **wrong field name** for cron jobs. OpenClaw's on-disk shape is:
```json
{"kind":"cron","expr":"37 9-21 * * *","tz":"Europe/Berlin"}
```
but the ingest did `sched.get("cron")` (should be `"expr"`), so `expr=""`. That empty string hit `"" or {}` in `_row_to_cron_job` / `_build_crons_cache_pushes` and became `{}`, which `formatSchedule()` printed via `JSON.stringify`.

**Fix:**
- `sync.py`: persist the **full structured schedule dict** (`json.dumps(sched)`) into the `crons` table, so readers decode it back to `{kind,expr,tz}`.
- `sync.py`: correct the `expr` derivation to read `expr` (and handle `every`/`interval`/`at` field aliases).
- `app.js` `formatSchedule()`: harden so it **never** renders a raw `{}`/JSON — handles string, dict, alternate field names, and empty.
- `app.js` `cronToHuman()`: teach it the hour-range form, e.g. `37 9-21 * * *` -> `at :37 hourly, 09:00 to 21:00`.

### Bug 2 — clicking a cron row shows "Could not load run history (HTTP 502)"
The row click races a DuckDB-backed timeline endpoint (`/api/crons/<id>/runs`, returns 200) against the legacy gateway-RPC endpoint (`/api/cron/<id>/runs`). `loadCronRuns` **threw** on the legacy non-OK response, which **always 502s in cloud** (no gateway reachable), defeating the timeline race.

**Fix:** make the legacy fetch best-effort (fall through to `{runs:[]}`) so the timeline drives rendering and the empty state shows "No run history yet" instead of a scary 502. (The matching cloud-side `502 -> graceful 200` change ships in the cloud repo.)

## Verification
Redeployed `sync.py` to the running daemon, restarted it, and `/api/crons` now returns:
```json
"schedule": {"kind":"cron","expr":"37 9-21 * * *","tz":"Europe/Berlin"}
```
for the live "Hourly water reminder" job (was `{}`). UI now renders `cron: 37 9-21 * * * · at :37 hourly, 09:00 to 21:00 (Europe/Berlin)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)