### PR TITLE
fix(replay): deep-dive tool turns — name + args + result, not nameless chips (#1911)

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -562,6 +562,13 @@
   .chat-tool-chip.tc-user { border-left: 3px solid #2a4a7a; }
   .chat-tool-chip-label { font-weight: 600; letter-spacing: 0.3px; color: #b8c0cc; }
   .chat-tool-chip-meta { opacity: 0.55; font-size: 10px; color: #888; font-variant-numeric: tabular-nums; }
+  /* #1911: expandable tool deep-dive chip — name in the header, exact
+     args/result in the collapsible body. */
+  .chat-tool-dive { display: flex; flex-direction: column; align-items: stretch; gap: 0; max-width: 90%; }
+  .chat-tool-dive .ctd-head { display: flex; align-items: center; gap: 10px; }
+  .chat-tool-dive .ctd-head[onclick] { cursor: pointer; }
+  .ctd-caret { margin-left: auto; opacity: 0.5; font-size: 10px; }
+  .ctd-body { margin: 8px 0 0; padding: 8px 10px; background: rgba(0,0,0,0.28); border: 1px solid #242433; border-radius: 7px; font-size: 11px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--text-secondary); white-space: pre-wrap; word-break: break-word; max-height: 360px; overflow: auto; }
   .chat-ts { font-size: 10px; color: #555; margin-top: 6px; text-align: right; }
   .chat-expand { display: inline-block; color: #f0c040; font-size: 11px; cursor: pointer; margin-top: 4px; }
   .chat-expand:hover { text-decoration: underline; }

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -9940,7 +9940,10 @@ window._replayFilter = 'all';
 function _buildReplayEvent(m, idx) {
   var role = m.role || 'unknown';
   // Determine event type for filtering
-  var type = role;
+  var type = m.type || role;
+  // #1911: tool turns carry a structured `tool` object (name + input/output);
+  // classify them as tool_use so the "Tools" filter and deep-dive chip pick up.
+  if (m.tool) type = 'tool_use';
   if (role === 'assistant' && m.content && m.content.indexOf('[tool_use]') !== -1) type = 'tool_use';
   if (role === 'assistant' && m.content && m.content.indexOf('<antml_thinking>') !== -1) type = 'thinking';
   if (role === 'compaction') type = 'compaction';
@@ -9962,6 +9965,8 @@ function _buildReplayEvent(m, idx) {
     timestamp: m.timestamp,
     tokens: m.tokens || null,
     params: m.params || null,
+    // #1911: structured tool call/result detail for the deep-dive chip.
+    tool: m.tool || null,
     // Issue #1895: verbatim event payload for the Raw/Pretty toggle.
     raw: (m.raw !== undefined ? m.raw : null),
     originalIndex: idx,
@@ -10034,6 +10039,45 @@ function _fmtDecodingParams(p) {
   return '⚙ ' + parts.join(' · ');
 }
 
+// #1911: render a tool call/result as a named, expandable deep-dive chip.
+// The header shows the tool name (and an error badge for failed results); the
+// body — the exact input args or result output — toggles open on click.
+function _renderToolDiveChip(ev, highlighted) {
+  var t = ev.tool || {};
+  var isResult = t.kind === 'result';
+  var name = escHtml(t.name || 'tool');
+  var icon = isResult ? '↩' : '🔧';
+  var side = isResult ? 'flex-end' : 'flex-start';
+  var ring = highlighted ? 'box-shadow:0 0 0 2px #6366f1;' : '';
+  var ts = ev.timestamp ? new Date(ev.timestamp).toLocaleTimeString() : '';
+  var body = isResult ? (t.output || '') : (t.input || '');
+  var hasBody = !!(body && String(body).trim());
+  var did = 'tooldive-' + ev.originalIndex;
+  var labelText = isResult ? (name + ' · result') : name;
+  var html = '<div class="chat-tool-chip chat-tool-dive ' + (isResult ? 'tc-user' : 'tc-asst') + '"'
+    + ' id="replay-msg-' + ev.originalIndex + '" style="align-self:' + side + ';' + ring + '">';
+  html += '<div class="ctd-head"' + (hasBody ? ' onclick="toggleToolDive(\'' + did + '\')"' : '') + '>';
+  html += '<span class="chat-tool-chip-label">' + icon + ' ' + labelText + '</span>';
+  if (isResult && t.is_error) html += '<span class="chat-tool-chip-meta" style="color:#e0625a;">error</span>';
+  if (hasBody) html += '<span class="ctd-caret" id="' + did + '-caret">▸</span>';
+  if (ts) html += '<span class="chat-tool-chip-meta">' + ts + '</span>';
+  html += '</div>';
+  if (hasBody) {
+    html += '<pre class="ctd-body" id="' + did + '" style="display:none;">' + escHtml(String(body)) + '</pre>';
+  }
+  html += '</div>';
+  return html;
+}
+
+function toggleToolDive(id) {
+  var pre = document.getElementById(id);
+  var caret = document.getElementById(id + '-caret');
+  if (!pre) return;
+  var open = pre.style.display !== 'none';
+  pre.style.display = open ? 'none' : 'block';
+  if (caret) caret.textContent = open ? '▸' : '▾';
+}
+
 function _renderReplayEvent(ev, highlighted) {
   var role = ev.role;
   // Handle compaction events specially
@@ -10055,6 +10099,12 @@ function _renderReplayEvent(ev, highlighted) {
         + (rTs ? '<div class="chat-ts">' + rTs + '</div>' : '')
         + '</div>';
     }
+  }
+  // #1911: a tool turn carries a structured `tool` object (name + input or
+  // output). Render an expandable deep-dive chip — the tool name up front, the
+  // exact args/result one click away — instead of a nameless "Tool call".
+  if (ev.tool) {
+    return _renderToolDiveChip(ev, highlighted);
   }
   // Tool turns (assistant tool_use / user tool_result) carry no prose, so they
   // used to render as blank bubbles with just a role + timestamp — looking

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7582,6 +7582,45 @@ def _build_model_attribution():
         return {}
 
 
+# #1911: bound the tool deep-dive detail before it rides the shared ~170 KB
+# encrypted snapshot. The local dashboard keeps the full input/output
+# (``_TOOL_DETAIL_CAP`` in routes/sessions.py); the cloud Embodied tab gets a
+# preview within a per-transcript budget and an "open locally" hint.
+_SNAP_TOOL_FIELD_CAP = 600   # per tool input/output preview
+_SNAP_TOOL_BUDGET = 8000     # per-transcript total tool-detail budget
+
+
+def _project_snapshot_messages(msgs):
+    """Strip the raw payload (#1895, ~12 KB each) and trim each tool turn's
+    input/output to a budgeted preview so the Embodied transcripts stay small in
+    the shared snapshot. Tool *names* are always kept — they're the headline of
+    the deep-dive and cost nothing."""
+    out = []
+    spent = 0
+    for m in msgs:
+        if not isinstance(m, dict):
+            out.append(m)
+            continue
+        m = {k: v for k, v in m.items() if k != "raw"}
+        tool = m.get("tool")
+        if isinstance(tool, dict):
+            tool = dict(tool)
+            for fld in ("input", "output"):
+                v = tool.get(fld)
+                if not isinstance(v, str) or not v:
+                    continue
+                if spent >= _SNAP_TOOL_BUDGET:
+                    tool[fld] = "… (open locally for full tool detail)"
+                    continue
+                cap = min(_SNAP_TOOL_FIELD_CAP, _SNAP_TOOL_BUDGET - spent)
+                if len(v) > cap:
+                    tool[fld] = v[:cap] + f"\n… (truncated, {len(v)} chars; open locally)"
+                spent += min(len(v), cap)
+            m["tool"] = tool
+        out.append(m)
+    return out
+
+
 def _build_transcripts(limit_sessions=8, msg_cap=80, extra_sids=None):
     """Recent per-session transcripts for the cloud Embodied tab.
 
@@ -7636,15 +7675,13 @@ def _build_transcripts(limit_sessions=8, msg_cap=80, extra_sids=None):
                     msgs = msgs[-msg_cap:]
                     t["messages"] = msgs
                     t["_truncated"] = True
-                # Perf: the per-message `raw` payload (#1895) can be ~12 KB each.
-                # Shipping it for 8 sessions × 80 msgs would bloat the shared
-                # snapshot from ~170 KB to multiple MB. The raw toggle is a
-                # local-dashboard feature; strip raw from the cloud snapshot and
-                # let the cloud toggle degrade gracefully.
-                t["messages"] = [
-                    {k: v for k, v in m.items() if k != "raw"} if isinstance(m, dict) else m
-                    for m in msgs
-                ]
+                # Perf: the per-message `raw` payload (#1895) can be ~12 KB each
+                # and the tool deep-dive (#1911) carries input/output; shipping
+                # them in full for 8 sessions × 80 msgs would bloat the shared
+                # snapshot from ~170 KB to multiple MB. Strip raw and trim tool
+                # detail to a budgeted preview; the full detail stays on the
+                # local dashboard.
+                t["messages"] = _project_snapshot_messages(msgs)
                 out[sid] = t
         return out
     except Exception as _e:

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -3016,6 +3016,91 @@ def _bounded_raw_payload(obj, cap: int = _RAW_PAYLOAD_CAP):
     return obj
 
 
+# Issue #1911: Anthropic Messages content-block tools. Claude-Code rows nest the
+# real message under ``data.message`` and record each tool as a *content block*
+# (``{"type":"tool_use","name","input"}`` / ``{"type":"tool_result",
+# "tool_use_id","content"}``) rather than a top-level ``tool_calls`` key. The
+# flat transcript path missed these entirely, so tool-heavy sessions replayed as
+# a wall of nameless "Tool call"/"Tool result" chips. We lift each block into a
+# real turn carrying the tool name + input/output so the replay can deep-dive
+# into what actually happened.
+_TOOL_DETAIL_CAP = 4000
+
+
+def _cap_text(s, cap: int = _TOOL_DETAIL_CAP) -> str:
+    """Truncate a string to ``cap`` chars with a visible marker. Never raises."""
+    s = s if isinstance(s, str) else str(s)
+    if len(s) > cap:
+        return s[:cap] + f"\n… (truncated, {len(s)} chars total)"
+    return s
+
+
+def _pretty_json(x, cap: int = _TOOL_DETAIL_CAP) -> str:
+    """Pretty-print a tool input/output payload to a capped string for inline
+    display. Falls back to ``str()`` for anything not JSON-serializable."""
+    try:
+        s = json.dumps(x, indent=2, default=str)
+    except (TypeError, ValueError):
+        s = str(x)
+    return _cap_text(s, cap)
+
+
+def _anthropic_tool_turns(blocks, ts_ms, name_by_id):
+    """Map an Anthropic message ``content`` block list to ``(tool_turns, text)``.
+
+    ``tool_turns`` is one turn per ``tool_use`` / ``tool_result`` block, each
+    carrying a ``tool`` dict (``{kind, name, input|output}``) the replay renders
+    as an expandable deep-dive. ``text`` is the joined text blocks, used only
+    when the session has no v3 prose event (pure Claude Code) so we never double
+    the assistant reply. ``name_by_id`` maps a ``tool_use`` id to its name so
+    the matching ``tool_result`` (which only references the id) can show which
+    tool it came from.
+    """
+    tool_turns: list[dict] = []
+    texts: list[str] = []
+    if not isinstance(blocks, list):
+        return tool_turns, ""
+    for b in blocks:
+        if not isinstance(b, dict):
+            continue
+        bt = b.get("type")
+        if bt == "text":
+            t = b.get("text")
+            if t:
+                texts.append(t if isinstance(t, str) else str(t))
+        elif bt == "tool_use":
+            name = b.get("name") or "tool"
+            tid = b.get("id")
+            if tid:
+                name_by_id[tid] = name
+            tool_turns.append({
+                "role": "assistant",
+                "content": "",
+                "timestamp": ts_ms,
+                "type": "tool_use",
+                "tool": {
+                    "kind": "call",
+                    "name": name,
+                    "input": _pretty_json(b.get("input") or {}),
+                },
+            })
+        elif bt == "tool_result":
+            name = name_by_id.get(b.get("tool_use_id"), "")
+            tool_turns.append({
+                "role": "tool",
+                "content": "",
+                "timestamp": ts_ms,
+                "type": "tool_use",
+                "tool": {
+                    "kind": "result",
+                    "name": name,
+                    "output": _cap_text(_stringify_content(b.get("content"))),
+                    "is_error": bool(b.get("is_error")),
+                },
+            })
+    return tool_turns, "\n".join(texts)
+
+
 def _expand_openclaw_event(obj: dict, ts_ms):
     """Map one OpenClaw event into zero or more transcript turns.
 
@@ -3293,6 +3378,18 @@ def _try_local_store_transcript(session_id: str, _events=None):
     total_tokens = 0
     first_ts = None
     last_ts = None
+    # Anthropic ``tool_result`` blocks reference their call by id only; map
+    # id→name as we see ``tool_use`` blocks so results show which tool ran.
+    tool_name_by_id: dict = {}
+    # When v3 (``model.completed`` / ``prompt.submitted``) events are present
+    # they already supply the prose for Claude-Code sessions, so we take *tools*
+    # from the raw ``message`` rows but skip their text to avoid doubling the
+    # reply. Pure Claude-Code sessions (no v3 events) keep their message text.
+    has_v3_messages = any(
+        isinstance(r.get("data"), dict)
+        and r["data"].get("_v3_type") == "message"
+        for r in rows
+    )
     for ev in rows:
         obj = ev.get("data")
         if not isinstance(obj, dict):
@@ -3365,6 +3462,38 @@ def _try_local_store_transcript(session_id: str, _events=None):
                 if raw_payload is not None:
                     turn["raw"] = raw_payload
                 messages.append(turn)
+            continue
+
+        # Claude-Code shape (#1911): the real Anthropic message is nested under
+        # ``data.message`` and tools are content blocks, not top-level keys.
+        # Lift each tool_use/tool_result block into a named, deep-divable turn;
+        # emit prose only when no v3 event already covered it.
+        msg_obj = obj.get("message") if isinstance(obj.get("message"), dict) else None
+        if msg_obj is not None:
+            raw_payload = _bounded_raw_payload(obj)
+            role = msg_obj.get("role") or obj.get("type") or "assistant"
+            if not model:
+                model = msg_obj.get("model") or obj.get("model") or ev.get("model")
+            usage = msg_obj.get("usage")
+            if isinstance(usage, dict):
+                total_tokens += usage.get("total_tokens", 0) or (
+                    (usage.get("input_tokens", 0) or 0)
+                    + (usage.get("output_tokens", 0) or 0)
+                )
+            tool_turns, block_text = _anthropic_tool_turns(
+                msg_obj.get("content"), ts_ms, tool_name_by_id)
+            for tt in tool_turns:
+                if raw_payload is not None:
+                    tt["raw"] = raw_payload
+                messages.append(tt)
+            if block_text.strip() and not has_v3_messages:
+                entry = {"role": role, "content": block_text, "timestamp": ts_ms}
+                decoding = _extract_decoding_params(obj)
+                if decoding and role == "assistant":
+                    entry["params"] = decoding
+                if raw_payload is not None:
+                    entry["raw"] = raw_payload
+                messages.append(entry)
             continue
 
         # Anthropic-style fallback (existing logic).


### PR DESCRIPTION
## What & why
The Embodied/replay tab rendered every tool turn as a generic **"🔧 Tool call"** / **"↩ Tool result"** chip — no tool name, no input args, no result output. The replay is meant to deep-dive into what happened; instead tool-heavy sessions were a wall of nameless chips. Closes #1911.

This turned out to be a **data bug**, not cosmetics. Claude-Code rows nest the Anthropic message under `data.message` and record tools as *content blocks*:
- assistant: `message.content[] = {type:"tool_use", name, input}`
- user: `message.content[] = {type:"tool_result", tool_use_id, content}`

`_try_local_store_transcript` only read top-level `obj["content"]` (absent here) and only pulled tools from a top-level `obj["tool_calls"]`/`obj["tool_use"]` key (also absent — they're nested blocks). So it emitted `{role, content:""}` for every tool turn and dropped the name/args/result entirely. The frontend then showed a role-only fallback chip because there was nothing to render.

**Verified on the live cloud snapshot + local `/api/transcript`:** 13/15 turns of `clawmetry-mem-probe` reach the browser blank; `clawmetry-selfevolve` was 118/178 blank.

## The fix
- **`routes/sessions.py`** — parse Anthropic content blocks; emit one named turn per `tool_use`/`tool_result` carrying `{kind, name, input|output}`. v3 `model.completed`/`prompt.submitted` stay authoritative for prose (no double prose); pure Claude-Code sessions (no v3 events) keep their message text. This also removes the **duplicate empty-noise turns** those rows used to produce.
- **`app.js` + `dashboard.css`** — render an expandable deep-dive chip: tool name in the header, exact input/result one click away (error badge for failed results).
- **`sync.py`** — bound per-tool input/output in the cloud snapshot (600-char preview, 8 KB/transcript budget) so it doesn't bloat the shared ~170 KB blob; names always kept, full detail stays on the local dashboard.

## Verification (local, real OpenClaw data)
| session | before | after |
|---|---|---|
| clawmetry-mem-probe | 15 msgs, 13 blank | 10 msgs, **8 named tools** + 2 prose, 0 noise |
| clawmetry-selfevolve | 178 msgs, 118 blank | **20 named tools** + 60 prose, 0 noise |
| 625c0ad9 (1334-msg) | mostly blank | **384 named tools** + 115 prose |

- Render functions checked headlessly: chip contains tool name, expandable body, toggle, HTML-escaped.
- Snapshot projection measured: net add bounded to ~8 KB/transcript; names preserved.
- Note: snapshot path uses the **same** `_try_local_store_transcript`, so this lights up the cloud Embodied tab once released + the cloud pin is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)