### PR TITLE
fix(tracing): gate the Tracing tab behind a flag until the span tree is polished

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -15584,7 +15584,23 @@ document.addEventListener('DOMContentLoaded', function() {
   // Issue #950: multi-profile workspace switcher
   try { initWorkspaceSwitcher(); } catch (e) { /* non-fatal */ }
   try { _hideCloudIrrelevantNav(); } catch (e) { /* non-fatal */ }
+  try { _applyTracingFlag(); } catch (e) { /* non-fatal */ }
 });
+
+// The Tracing tab is gated behind a flag while the span tree is being polished
+// (the parentId chain renders as a deep diagonal staircase today). Hidden from
+// the nav by default; reveal it with ?tracing=1 (persisted to localStorage) or
+// when landing directly on ?tab=tracing. Disable again with ?tracing=0.
+function _applyTracingFlag() {
+  var p = new URLSearchParams(window.location.search);
+  if (p.get('tracing') === '1') { try { localStorage.setItem('cm-ff-tracing', '1'); } catch (e) {} }
+  if (p.get('tracing') === '0') { try { localStorage.removeItem('cm-ff-tracing'); } catch (e) {} }
+  var on = false;
+  try { on = localStorage.getItem('cm-ff-tracing') === '1'; } catch (e) {}
+  if (p.get('tab') === 'tracing') on = true;
+  var el = document.getElementById('left-nav-tracing');
+  if (el) el.style.display = on ? '' : 'none';
+}
 
 // ── Workspace switcher (issue #950) ───────────────────────────────────
 // Discovers all OpenClaw workspaces on this machine and lets power users

--- a/dashboard.py
+++ b/dashboard.py
@@ -10831,7 +10831,7 @@ DASHBOARD_HTML = r"""
         <div class="left-nav-item left-nav-item-sub" data-tab="context" onclick="switchTab('context')" title="What the LLM sees on each turn">
           <span class="left-nav-label">LLM Context</span>
         </div>
-        <div class="left-nav-item left-nav-item-sub" data-tab="tracing" onclick="switchTab('tracing')" title="Every trace: span waterfall, tree, and agent graph">
+        <div class="left-nav-item left-nav-item-sub" id="left-nav-tracing" data-tab="tracing" onclick="switchTab('tracing')" title="Every trace: span waterfall, tree, and agent graph" style="display:none;">
           <span class="left-nav-label">Tracing</span>
         </div>
       </div>


### PR DESCRIPTION
The Tracing tab shipped **visible** in 0.12.279, but the span-tree view renders the parentId chain as a deep diagonal staircase (not a real tree). Hiding the nav item by default until it's reworked.

- Nav item hidden by default; reveal with **`?tracing=1`** (persisted to localStorage) or `?tab=tracing`. Disable with `?tracing=0`.
- Backend endpoints + waterfall/agent-graph unchanged; only the nav entry point is gated.

Verified locally: hidden by default (`display:none`), shown with the flag (`display:flex`), flag persists across navigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)