### PR TITLE
fix(local-query): retry daemon proxy on timeout (kills transient empty reads) + re-gate Tracing

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -15665,7 +15665,23 @@ document.addEventListener('DOMContentLoaded', function() {
   // Issue #950: multi-profile workspace switcher
   try { initWorkspaceSwitcher(); } catch (e) { /* non-fatal */ }
   try { _hideCloudIrrelevantNav(); } catch (e) { /* non-fatal */ }
+  try { _applyTracingFlag(); } catch (e) { /* non-fatal */ }
 });
+
+// The Tracing tab stays gated while it's being polished (PRD-tracing.md phases
+// 3-4 + the daemon-proxy reliability fix). Hidden from the nav by default;
+// reveal it with ?tracing=1 (persisted to localStorage) or ?tab=tracing.
+// Disable again with ?tracing=0.
+function _applyTracingFlag() {
+  var p = new URLSearchParams(window.location.search);
+  if (p.get('tracing') === '1') { try { localStorage.setItem('cm-ff-tracing', '1'); } catch (e) {} }
+  if (p.get('tracing') === '0') { try { localStorage.removeItem('cm-ff-tracing'); } catch (e) {} }
+  var on = false;
+  try { on = localStorage.getItem('cm-ff-tracing') === '1'; } catch (e) {}
+  if (p.get('tab') === 'tracing') on = true;
+  var el = document.getElementById('left-nav-tracing');
+  if (el) el.style.display = on ? '' : 'none';
+}
 
 // ── Workspace switcher (issue #950) ───────────────────────────────────
 // Discovers all OpenClaw workspaces on this machine and lets power users

--- a/dashboard.py
+++ b/dashboard.py
@@ -10831,7 +10831,7 @@ DASHBOARD_HTML = r"""
         <div class="left-nav-item left-nav-item-sub" data-tab="context" onclick="switchTab('context')" title="What the LLM sees on each turn">
           <span class="left-nav-label">LLM Context</span>
         </div>
-        <div class="left-nav-item left-nav-item-sub" id="left-nav-tracing" data-tab="tracing" onclick="switchTab('tracing')" title="Every trace: span waterfall, tree, and agent graph">
+        <div class="left-nav-item left-nav-item-sub" id="left-nav-tracing" data-tab="tracing" onclick="switchTab('tracing')" title="Every trace: span waterfall, tree, and agent graph" style="display:none;">
           <span class="left-nav-label">Tracing</span>
         </div>
       </div>

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -70,6 +70,40 @@ import os as _os
 
 _DISCOVERY_PATH = _os.path.expanduser("~/.clawmetry/local_query.json")
 _PROXY_TIMEOUT_SECS = 5.0
+# The daemon's local_server is threaded, but DuckDB serializes queries on its
+# single connection — so heavy reads (e.g. query_events) under a page-load
+# fan-out can queue past the timeout and surface as a transient EMPTY result
+# (urlopen raises → caller returns None → blank tab). Retry on TIMEOUTS only
+# (contended DuckDB) with backoff + a longer per-attempt timeout; fail fast on
+# connection errors (daemon down → fall through to direct open).
+_PROXY_TIMEOUTS = (5.0, 9.0)  # per-attempt seconds; len() == max attempts
+
+
+def _is_timeout_err(e):
+    import socket as _socket
+    if isinstance(e, (_socket.timeout, TimeoutError)):
+        return True
+    return isinstance(getattr(e, "reason", None), (_socket.timeout, TimeoutError))
+
+
+def _urlopen_retry(req):
+    """POST to the daemon with timeout-aware retry. Returns the parsed JSON
+    body or raises the last exception. Retries only on timeouts (contended
+    DuckDB), not connection errors (which mean the daemon is down)."""
+    import urllib.request
+    last = None
+    n = len(_PROXY_TIMEOUTS)
+    for i, t in enumerate(_PROXY_TIMEOUTS):
+        try:
+            with urllib.request.urlopen(req, timeout=t) as resp:
+                return _json.loads(resp.read().decode("utf-8"))
+        except Exception as e:  # noqa: BLE001 — re-raised below
+            last = e
+            if _is_timeout_err(e) and i < n - 1:
+                time.sleep(0.2 * (i + 1))
+                continue
+            raise
+    raise last
 
 
 def _read_discovery():
@@ -120,8 +154,7 @@ def _proxy_dispatch(shape: str, args: dict):
         },
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=_PROXY_TIMEOUT_SECS) as resp:
-        return _json.loads(resp.read().decode("utf-8"))
+    return _urlopen_retry(req)
 
 
 def _coerce_args(shape: str, raw: dict) -> dict:
@@ -560,11 +593,10 @@ def local_store_via_daemon(method_name: str, **kwargs):
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=_PROXY_TIMEOUT_SECS) as resp:
-            body = _json.loads(resp.read().decode("utf-8"))
+        body = _urlopen_retry(req)
     except (urllib.error.URLError, OSError, ValueError):
-        # Stale port / daemon restarted / network gremlin — drop the cache
-        # so the next call re-reads the discovery file.
+        # Stale port / daemon restarted / network gremlin (after retrying
+        # timeouts) — drop the cache so the next call re-reads discovery.
         _invalidate_daemon_cache()
         return None
     if "error" in body:

--- a/routes/tracing.py
+++ b/routes/tracing.py
@@ -210,7 +210,11 @@ def api_traces():
     except (ValueError, TypeError):
         limit = 100
 
-    rows = _events_for(limit=14000)
+    # Scan a bounded window of recent events to group into the trace list.
+    # 14000 was needlessly heavy on the shared DuckDB connection (it's the
+    # main contributor to proxy-timeout empties); 6000 still covers far more
+    # than the ``limit`` traces we return, most-recent first.
+    rows = _events_for(limit=6000)
     if rows is None:
         return jsonify({"available": False, "traces": [], "total": 0})
 


### PR DESCRIPTION
## Daemon-proxy flakiness (root cause)
The daemon's `local_server` is threaded, but **DuckDB serializes queries on its single connection** — so heavy reads (`query_events`) under a page-load fan-out queue past the **5s timeout** → `urlopen` raises → `local_store_via_daemon` returns `None` → blank tab / empty list. It was intermittent (~2/3 of concurrent calls returned empty under load), affecting **all** DuckDB-read endpoints, not just tracing.

## Fix
- **`_urlopen_retry()`**: retry on **timeouts only** (contended DuckDB) with backoff + a longer per-attempt timeout (5s → 9s); **fail fast on connection errors** (daemon down → fall through to direct open, unchanged). Applied to both proxy call sites, so every `_try_local_store_*` fast path benefits.
- **`routes/tracing.py`**: trace-list scan cut **14000 → 6000** events (the heaviest contributor; still far more than the traces we return).

## Verified
**5 concurrent `/api/traces` calls now all return data (total=20), zero empties** — was ~2/3 empty before.

## Also
Re-gates the Tracing tab behind `?tracing=1` (per request — keep gated while PRD phases 3-4 land), reverting the un-gate from #1919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)