### PR TITLE
feat(skills): ship skills in the cloud snapshot (was local-only)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1860,15 +1860,10 @@ async function loadSkills() {
   var summaryEl = document.getElementById('skills-summary-row');
   var listEl = document.getElementById('skills-list');
   if (!summaryEl || !listEl) return;
-  // Cloud iframes don't have access to the local skills filesystem — the
-  // cloud server returns 410 Gone for /api/skills, which the browser logs
-  // as a console error every time the user opens the Skills tab. Render
-  // an inline empty-state instead so the network call never fires.
-  if (window.CLOUD_MODE) {
-    listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Skills inspector is local-only. Open the dashboard on the host running OpenClaw to view installed skills.</div>';
-    summaryEl.innerHTML = '';
-    return;
-  }
+  // Cloud serves skills from the encrypted snapshot via the cm-cloud-skills
+  // interceptor (the daemon ships snapshot.skills). When the snapshot is cold
+  // the route is oss-passthrough and returns an empty list (graceful), so the
+  // fetch is safe in cloud too — no more "local-only" dead end.
   listEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading...</div>';
   try {
     var data = await fetch('/api/skills').then(function(r) { return r.json(); });

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7709,6 +7709,74 @@ def _build_memory_access(limit=200):
         return []
 
 
+def _build_skills(file_cap=40000, total_cap=400000):
+    """Skills list + per-skill file contents for the cloud Skills tab.
+
+    Reuses routes.skills.compute_skills_payload() (single source of truth) for
+    the list/summary, then attaches a file tree + capped file contents per skill
+    so the cloud cm-cloud-skills interceptor can render the browser. Built in the
+    daemon, where get_store(read_only=True) returns the writer handle (no
+    brick-lock). Best-effort -> {}.
+    """
+    try:
+        import routes.skills as _sk
+        payload = _sk.compute_skills_payload()
+    except Exception as _e:
+        log.debug("skills snapshot build failed: %s", _e)
+        return {}
+    _lang = {"py": "python", "sh": "bash", "js": "javascript", "ts": "typescript",
+             "json": "json", "yaml": "yaml", "yml": "yaml", "md": "markdown",
+             "toml": "toml"}
+    detail = {}
+    total = 0
+    for s in (payload.get("skills") or []):
+        name = s.get("name")
+        if not name:
+            continue
+        try:
+            sdir = _sk._find_skill_dir(name)
+        except Exception:
+            sdir = None
+        if not sdir:
+            continue
+        files, contents = [], {}
+        try:
+            for root, _dirs, fnames in os.walk(sdir):
+                rel = os.path.relpath(root, sdir)
+                depth = 0 if rel == "." else rel.count(os.sep) + 1
+                for fn in sorted(fnames):
+                    fp = os.path.join(root, fn)
+                    frel = os.path.relpath(fp, sdir)
+                    try:
+                        fsize = os.path.getsize(fp)
+                    except OSError:
+                        fsize = 0
+                    files.append({"path": frel, "size": fsize, "depth": depth})
+                    if total < total_cap and 0 < fsize <= file_cap:
+                        try:
+                            with open(fp, "r", errors="replace") as fh:
+                                txt = fh.read(file_cap)
+                            ext = os.path.splitext(frel)[1].lstrip(".").lower()
+                            contents[frel] = {"path": frel, "content": txt,
+                                              "language": _lang.get(ext, "text"),
+                                              "size": len(txt)}
+                            total += len(txt)
+                        except OSError:
+                            pass
+        except Exception:
+            pass
+        detail[name] = {
+            "name": name, "description": s.get("description", ""),
+            "skill_dir": sdir, "header_tokens": s.get("header_tokens", 0),
+            "has_body": s.get("has_body"), "has_linked_files": s.get("has_linked_files"),
+            "body_fetch_count_7d": s.get("body_fetch_count_7d", 0),
+            "linked_file_read_count_7d": s.get("linked_file_read_count_7d", 0),
+            "last_used_ts": s.get("last_used_ts"), "status": s.get("status"),
+            "files": files, "fileContents": contents,
+        }
+    return {"list": payload, "detail": detail}
+
+
 def _build_traces(limit_traces=5, span_cap=100):
     """Trace list + capped per-trace details for the cloud Tracing tab (#1903).
 
@@ -9243,6 +9311,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "reliability": _build_reliability(),
         "memoryAccess": _build_memory_access(),
         "traces": _build_traces(),
+        "skills": _build_skills(),
     }
 
     # ── NemoClaw / sandbox enrichment ────────────────────────────────────────

--- a/routes/skills.py
+++ b/routes/skills.py
@@ -367,9 +367,13 @@ def _scan_fidelity_events(sessions_dir, skill_dirs_map, cutoff_ts):
     return stats
 
 
-@bp_skills.route("/api/skills")
-def api_skills():
-    """List all installed skills with fidelity stats.
+def compute_skills_payload():
+    """Plain (no-Flask) skills list + summary.
+
+    Single source of truth shared by the ``/api/skills`` route AND the cloud
+    snapshot builder (``sync._build_skills``), so cloud renders the same shape
+    the local dashboard does. Reads the filesystem + DuckDB; never raises out
+    of the route (callers wrap).
 
     Returns:
         {
@@ -392,7 +396,7 @@ def api_skills():
 
     skills_dirs = _get_skills_dirs()
     if not skills_dirs:
-        return jsonify({"skills": [], "summary": empty_summary})
+        return {"skills": [], "summary": empty_summary}
 
     # Discover installed skills across every candidate directory. First
     # match wins on name collisions so the user-installed copy in
@@ -415,7 +419,7 @@ def api_skills():
                 skill_dirs_map[entry] = entry_path
 
     if not skill_dirs_map:
-        return jsonify({"skills": [], "summary": empty_summary})
+        return {"skills": [], "summary": empty_summary}
 
     now_ts = time.time()
     cutoff_7d = now_ts - 7 * 86400
@@ -523,7 +527,13 @@ def api_skills():
         "wasted_header_tokens": wasted_header_tokens,
     }
 
-    return jsonify({"skills": skills_out, "summary": summary})
+    return {"skills": skills_out, "summary": summary}
+
+
+@bp_skills.route("/api/skills")
+def api_skills():
+    """List all installed skills with fidelity stats."""
+    return jsonify(compute_skills_payload())
 
 
 @bp_skills.route("/api/skills/<skill_name>")


### PR DESCRIPTION
Skills showed **"Skills inspector is local-only"** in cloud while working fine on localhost. Promote it via the standard snapshot path (same as Tracing/Memory-access).

## OSS half (this PR)
- **`routes/skills.py`**: extract `compute_skills_payload()` (plain, no-Flask) as the single source of truth; `api_skills` wraps it.
- **`sync.py _build_skills()`**: ship `snapshot.skills = {list, detail{name:{files, fileContents}}}`. Built on the daemon's own handle (`get_store(read_only=True)` returns the writer there — no brick-lock). File contents capped (40 KB/file, 400 KB total); **measured 5.1 KB** for the real 1-skill install.
- **`app.js`**: drop the `CLOUD_MODE` "local-only" early-return in `loadSkills` so cloud fetches `/api/skills` (interceptor fills from snapshot; cold fall-through = graceful empty list, not 410). Detail/file loaders already fetch unconditionally.

## Verified
`_build_skills()` against live data: 1 skill (browser-automation), SKILL.md content present, 5.1 KB blob.

## Cloud half (follows)
`cm-cloud-skills` interceptor + route-policy `oss-passthrough` + pin bump in clawmetry-cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)