### PR TITLE
fix(nav): remove the dead Classic nav (legacy top-nav) link

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -10891,10 +10891,6 @@ DASHBOARD_HTML = r"""
         <span class="left-nav-label">NemoClaw</span>
       </div>
     </div>
-
-    <div class="left-nav-footer">
-      <a href="?legacy_nav=1" class="left-nav-legacy-link" title="Switch back to the classic top-nav layout">Classic nav</a>
-    </div>
   </aside>
   <main class="app-shell-content">
 {% endif %}


### PR DESCRIPTION
The left-nav footer offered a **"Classic nav"** link (`?legacy_nav=1`) to switch back to the old top-nav, but the classic nav is gone — the link led to a dead layout. Removes the footer link.

Cloud has no own copy (it serves the OSS shell via the pinned `clawmetry` package), so the cloud pin bump removes it there too — covers OSS & cloud.

Verified: rendered shell no longer contains "Classic nav" or `legacy_nav=1`; the left-nav is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)