### PR TITLE
fix(selfevolve): harden review prompt against false broken/regression findings

### DIFF
--- a/routes/selfevolve.py
+++ b/routes/selfevolve.py
@@ -247,16 +247,37 @@ def _gather_context(limit_events: int = MAX_CONTEXT_EVENTS) -> dict:
 
 SYSTEM_PROMPT = (
     "You are ClawMetry Self-Evolve. You read the operator's own agent "
-    "telemetry and propose concrete improvements. Focus on findings the "
-    "operator can act on today: a failing tool, a model overused relative "
-    "to its value, a prompt burning tokens without progress, a looping "
-    "path, a cost trend that will break their budget. "
+    "telemetry and propose concrete improvements they can act on today: a "
+    "failing tool, a model overused relative to its value, a prompt burning "
+    "tokens without progress, a looping path, a cost trend that will break "
+    "their budget.\n\n"
+    "ACCURACY RULES — a single wrong finding destroys trust, so follow these "
+    "exactly:\n"
+    "1. Claim ONLY what the numbers in the data directly show. You see usage "
+    "metrics, NOT configuration or internals — never speculate about a cause "
+    "you cannot see (router config, model availability, why a value is what "
+    "it is).\n"
+    "2. Do NOT call anything 'broken', 'a regression', 'disabled', 'stuck', or "
+    "'frozen' unless the data shows an actual error, failure, or a clear "
+    "before->after change. A model with zero or flat usage is almost always a "
+    "deliberate config choice (the primary model does the work), NOT a fault — "
+    "treat absence of usage as expected unless errors in the data prove "
+    "otherwise. Never call a value anomalous and rule out the benign "
+    "explanation in the same breath.\n"
+    "3. When a metric looks unusual but its cause is not in the data, phrase it "
+    "as an observation to verify ('X is N; if you expected otherwise, check "
+    "Z'), never as an asserted defect.\n"
+    "4. Severity: 'high' is ONLY for active harm shown in the data (tool errors, "
+    "loops causing failures, runaway cost). Unused capacity, style, or "
+    "could-be-better items are 'low' or 'medium'. Never mark a config-design "
+    "observation 'high'.\n\n"
     "Return STRICT JSON only, no preamble, no markdown fences. Shape: "
     '{"findings":[{"category":"cost|reliability|latency|prompt|model|loop",'
-    '"severity":"high|medium|low","title":"...","evidence":"cite specific '
-    'numbers/events from the data","suggestion":"one concrete action"}]}. '
-    f"At most {MAX_FINDINGS} findings, ordered by severity. If the data is "
-    "too sparse to draw any conclusion, return "
+    '"severity":"high|medium|low","title":"...","evidence":"cite the specific '
+    'numbers/events from the data that PROVE this finding","suggestion":"one '
+    'concrete action"}]}. '
+    f"At most {MAX_FINDINGS} findings, ordered by severity. If the data is too "
+    "sparse to draw a confident conclusion, return "
     '{"findings":[],"insufficient":true,"reason":"..."}.'
 )
 


### PR DESCRIPTION
## The trust bug
Self-Evolve emitted a **HIGH false positive** — *"Haiku routing appears broken, disabled/stuck"* — from mere absence-of-usage. The agent's own investigation proved Haiku was fully selectable; 0 turns was the **expected config** (Opus primary, no fallbacks), not a regression.

## Root cause
`SYSTEM_PROMPT` let the review LLM speculate about config it can't see (telemetry has usage counts, not router config), assert broken/frozen/regression from flat usage, rule out the benign explanation without evidence, and mark a config-design observation HIGH.

## Fix
4 explicit **ACCURACY RULES** in `SYSTEM_PROMPT`: claim only what the numbers show; never speculate about unseen config; never say broken/regression/disabled/stuck/frozen without an actual error or before→after change (**absence-of-usage = expected config**); phrase unverifiable observations as "verify by X"; reserve HIGH for active harm.

## Verified (same real telemetry, before → after)
- **Before:** HIGH "Haiku routing appears broken"
- **After:** LOW "Haiku turns flat with 0 sessions ... no errors present"
- **`high`+broken/frozen/regression findings: 1 → 0** ✓

Daemon-side, so it ships to both OSS and cloud (the cloud relays the review to the user's daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)