### PR TITLE
feat(trace): reconstruct OTel spans from OpenClaw JSONL (Trace 4 / #1010)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -12,8 +12,11 @@ identical to the pre-refactor dashboard.
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
+import time as _time
 from typing import List, Optional, Set
 
 from .base import AgentAdapter, Capability, DetectResult, Event, Session
@@ -129,6 +132,142 @@ class OpenClawAdapter(AgentAdapter):
             Capability.GATEWAY_RPC,
             Capability.CHANNELS,
         }
+
+    # ── Span reconstruction (issue #1010 / Trace 4) ────────────────────────
+
+    @staticmethod
+    def _span_id(*parts: str) -> str:
+        return hashlib.sha256(":".join(parts).encode()).hexdigest()[:16]
+
+    @staticmethod
+    def _trace_id(session_id: str) -> str:
+        return hashlib.sha256(session_id.encode()).hexdigest()[:32]
+
+    @staticmethod
+    def _build_spans_from_events(events: list, session_id: str) -> list:
+        """Map raw JSONL objects to OTel-shaped span dicts.
+
+        Mapping per issue #1010:
+        - ``session`` (version set)   → root span (INTERNAL)
+        - ``message`` (role=assistant) → llm.call span (CLIENT, child of root)
+          - each tool_use block       → tool.<name> span (CLIENT, child of llm)
+        - ``subagent_spawn``          → agent.spawn span (INTERNAL, link to child trace)
+
+        Span IDs are deterministic SHA-256 prefixes so re-ingesting is idempotent.
+        """
+        _sid = OpenClawAdapter._span_id
+        trace_id = OpenClawAdapter._trace_id(session_id)
+        session_span_id = _sid("session", session_id)
+        now = _time.time()
+        spans: list = []
+
+        for obj in events:
+            if not isinstance(obj, dict):
+                continue
+            t = obj.get("type")
+            raw_ts = obj.get("timestamp") or obj.get("ts") or now
+            try:
+                ts = float(raw_ts)
+            except (TypeError, ValueError):
+                ts = now
+
+            if t == "session" and obj.get("version") is not None:
+                spans.append({
+                    "span_id": session_span_id,
+                    "trace_id": trace_id,
+                    "name": "session",
+                    "kind": "INTERNAL",
+                    "start_ts": ts,
+                    "session_id": session_id,
+                    "agent_type": "openclaw",
+                    "attributes": {"session.version": obj.get("version"), "session.id": session_id},
+                })
+
+            elif t == "message" and isinstance(obj.get("message"), dict):
+                msg = obj["message"]
+                if msg.get("role") != "assistant":
+                    continue
+                model = msg.get("model") or ""
+                usage = msg.get("usage") or {}
+                tok_in = int(usage.get("input_tokens") or usage.get("inputTokens") or 0)
+                tok_out = int(usage.get("output_tokens") or usage.get("outputTokens") or 0)
+                llm_sid = _sid("llm", session_id, str(raw_ts))
+                spans.append({
+                    "span_id": llm_sid,
+                    "trace_id": trace_id,
+                    "parent_span_id": session_span_id,
+                    "name": f"llm.call {model}".strip() if model else "llm.call",
+                    "kind": "CLIENT",
+                    "start_ts": ts,
+                    "session_id": session_id,
+                    "agent_type": "openclaw",
+                    "model": model or None,
+                    "tokens_input": tok_in or None,
+                    "tokens_output": tok_out or None,
+                    "token_count": (tok_in + tok_out) or None,
+                })
+                content = msg.get("content") or []
+                if isinstance(content, list):
+                    for block in content:
+                        if not isinstance(block, dict) or block.get("type") != "tool_use":
+                            continue
+                        tool_name = block.get("name") or "tool"
+                        tool_id = block.get("id") or ""
+                        spans.append({
+                            "span_id": _sid("tool", session_id, str(raw_ts), tool_id, tool_name),
+                            "trace_id": trace_id,
+                            "parent_span_id": llm_sid,
+                            "name": f"tool.{tool_name}",
+                            "kind": "CLIENT",
+                            "start_ts": ts,
+                            "session_id": session_id,
+                            "agent_type": "openclaw",
+                            "tool_name": tool_name,
+                            "input": block.get("input"),
+                        })
+
+            elif t in ("subagent_spawn", "agent_spawn"):
+                sub_id = (
+                    obj.get("subagent_id") or obj.get("agentId") or obj.get("agent_id") or ""
+                )
+                child_trace = hashlib.sha256(sub_id.encode()).hexdigest()[:32] if sub_id else ""
+                spans.append({
+                    "span_id": _sid("spawn", session_id, str(raw_ts), sub_id),
+                    "trace_id": trace_id,
+                    "parent_span_id": session_span_id,
+                    "name": "agent.spawn",
+                    "kind": "INTERNAL",
+                    "start_ts": ts,
+                    "session_id": session_id,
+                    "agent_type": "openclaw",
+                    "links": [{"trace_id": child_trace, "span_id": "0" * 16}] if child_trace else None,
+                    "attributes": {"subagent_id": sub_id} if sub_id else None,
+                })
+
+        return spans
+
+    def reconstruct_spans(self, jsonl_path: str) -> list:
+        """Read an OpenClaw JSONL transcript and return OTel-shaped span dicts.
+
+        The returned list can be fed directly to ``local_store.ingest_span()``.
+        Returns an empty list and logs a warning on I/O errors.
+        """
+        session_id = os.path.basename(jsonl_path).split(".jsonl", 1)[0]
+        try:
+            with open(jsonl_path, encoding="utf-8", errors="replace") as fh:
+                events = []
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        events.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError as exc:
+            logger.warning("reconstruct_spans: cannot read %s: %s", jsonl_path, exc)
+            return []
+        return self._build_spans_from_events(events, session_id)
 
     def running(self) -> bool:
         try:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2613,6 +2613,14 @@ def _local_ingest_session_batch(
         })
     if rows:
         store.ingest_many(rows)
+    # Reconstruct OTel-compatible spans from this batch (issue #1010 / Trace 4).
+    # Non-fatal: span failures never block event ingest.
+    try:
+        from clawmetry.adapters.openclaw import OpenClawAdapter
+        for sp in OpenClawAdapter._build_spans_from_events(batch, session_id):
+            store.ingest_span(sp)
+    except Exception as _e:
+        log.debug("span reconstruction skipped (non-fatal): %s", _e)
 
 
 def _local_ingest_sessions_batch(rows: list, node_id: str) -> None:


### PR DESCRIPTION
Closes #1010

## Summary

- Adds `OpenClawAdapter._build_spans_from_events(events, session_id)` — static method that maps raw JSONL objects to OTel-shaped span dicts without file I/O, so the sync batch path can call it directly.
- Adds `OpenClawAdapter.reconstruct_spans(jsonl_path)` — reads a full transcript file and delegates to the static method; useful for standalone analysis or backfill.
- Wires span ingest into `_local_ingest_session_batch` in `sync.py`: after each event batch lands in DuckDB, spans are reconstructed and ingested via `store.ingest_span()`. Failure is caught at DEBUG — span reconstruction never blocks event ingest.

**Mapping** (per issue spec):
| JSONL event | Span |
|---|---|
| `session` (version set) | root span, `kind=INTERNAL` |
| `message` (role=assistant) | `llm.call <model>`, `kind=CLIENT`, child of root, carries `tokens_input`/`tokens_output`/`model` |
| `tool_use` block in content | `tool.<name>`, `kind=CLIENT`, child of the enclosing `llm.call` |
| `subagent_spawn` / `agent_spawn` | `agent.spawn`, `kind=INTERNAL`, `links` → child session's `trace_id` |

Span IDs are deterministic `SHA-256(type:session_id:ts:...)[:16]` — re-ingesting the same batch is idempotent via `ingest_span`'s `INSERT OR REPLACE`.

## Test plan

- [ ] Syntax check: `python3 -m py_compile clawmetry/adapters/openclaw.py clawmetry/sync.py` → both OK
- [ ] Unit test: construct a synthetic 4-event batch (session + assistant message with 2 tool_use blocks + subagent_spawn) → `_build_spans_from_events` returns 5 spans with correct kinds, parent links, and subagent trace link
- [ ] Idempotency: same batch processed twice yields identical span_ids
- [ ] File path: `reconstruct_spans(path)` on the same events written to a temp `.jsonl` returns the same 5 spans
- [ ] Verified locally: all 4 checks pass

https://claude.ai/code/session_01CjhX4vHcPRRVLaVCcoFB5Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjhX4vHcPRRVLaVCcoFB5Z)_