### PR TITLE
feat(onboard): explicit local-only option + --local flag (closes #1937)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1657,7 +1657,8 @@ def _cmd_onboard(args) -> None:
     if already_connected:
         print(f"\n  {GREEN(BOLD('Already connected to ClawMetry Cloud'))}")
         _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
-        print(f"  {DIM('Run  clawmetry status  to check sync health.')}\n")
+        print(f"  {DIM('Run')} {CYAN('clawmetry status')} {DIM('to check sync health.')}")
+        print(f"  {DIM('Run')} {CYAN('clawmetry disconnect')} {DIM('to stop cloud sync and go local-only.')}\n")
         return
 
     # Get version for banner
@@ -1670,18 +1671,49 @@ def _cmd_onboard(args) -> None:
 
     print(f"\n  {BOLD(f'ClawMetry{_ver_str} installed!')}")
     print()
-    print(f"  Monitor your AI agents from anywhere with ClawMetry Cloud.")
-    print()
 
-    try:
-        choice = _input("  Do you have a ClawMetry account? [y/N]: ").strip().lower() or "n"
-    except (EOFError, KeyboardInterrupt):
-        choice = "n"
+    if getattr(args, "local_only", False):
+        # Non-interactive opt-out via `clawmetry onboard --local`.
+        choice = "l"
+    else:
+        print(f"  Set up your dashboard:")
+        print()
+        print(f"    {BOLD('c')} - Cloud dashboard (free, E2E encrypted, recommended)")
+        print(f"    {BOLD('e')} - Connect existing account")
+        print(f"    {BOLD('l')} - Local only (no cloud sync)")
         print()
 
+        try:
+            choice = _input("  Choice [C/e/l]: ").strip().lower() or "c"
+        except (EOFError, KeyboardInterrupt):
+            choice = "c"
+            print()
+
+    # Back-compat: legacy "y" mapped to existing account, "n"/no input meant
+    # "create a new cloud account". Honour those replies so install.sh users
+    # who answered the old prompt still get the same outcome.
+    if choice in ("y", "yes"):
+        choice = "e"
+    elif choice in ("n", "no"):
+        choice = "c"
+
     print()
 
-    if choice in ("y", "yes"):
+    if choice in ("l", "local"):
+        # Local-only mode: skip cloud entirely.
+        print(f"  {GREEN(BOLD('Installed'))} (local mode)")
+        print()
+        print(f"  Start your dashboard:")
+        print(
+            f"    {CYAN('clawmetry --host 0.0.0.0 --port 8900')}          {DIM('# foreground (LAN)')}"
+        )
+        print()
+        print(f"  {DIM('Connect to cloud later: clawmetry setup')}")
+        print()
+        _print_nemoclaw_preset_hint(BOLD, CYAN, DIM)
+        return
+
+    if choice in ("e", "existing"):
         # Existing user: email -> OTP -> connect
         import argparse as _ap
 
@@ -1694,7 +1726,7 @@ def _cmd_onboard(args) -> None:
         print()
         _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
     else:
-        # New user: instant registration (no OTP)
+        # Default ("c"): instant registration (no OTP)
         print(f"  Setting up your cloud dashboard...")
         print()
 
@@ -2452,6 +2484,12 @@ def main() -> None:
         metavar="NAME",
         dest="custom_node_id",
         help="Custom node name (default: hostname)",
+    )
+    p_onboard.add_argument(
+        "--local",
+        action="store_true",
+        dest="local_only",
+        help="Skip the cloud prompt and install in local-only mode",
     )
 
     # connect

--- a/install.sh
+++ b/install.sh
@@ -725,6 +725,9 @@ fi
 
 if [ "${CLAWMETRY_SKIP_ONBOARD:-}" = "1" ] || [ "$NEMOCLAW_DETECTED" = "1" ]; then
   [ "$NEMOCLAW_DETECTED" = "1" ] || echo -e "  ${DIM}Skipping onboard (CLAWMETRY_SKIP_ONBOARD=1)${NC}"
+elif [ "${CLAWMETRY_LOCAL_ONLY:-}" = "1" ]; then
+  echo -e "  ${DIM}Installing in local-only mode (CLAWMETRY_LOCAL_ONLY=1)${NC}"
+  "$CLAWMETRY_BIN" onboard --local || true
 elif (exec </dev/tty) 2>/dev/null; then
   "$CLAWMETRY_BIN" onboard </dev/tty || true
 else

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,3 +139,38 @@ def test_post_json_handles_non_json_body():
     assert status == 500
     assert "oh no" in result["error"]
     assert result["retry_after"] is None
+
+
+def test_onboard_local_only_skips_cloud_setup(monkeypatch, tmp_path, capsys):
+    """`clawmetry onboard --local` must not call cloud setup or prompt the user."""
+    import argparse
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAWMETRY_API_KEY", raising=False)
+    monkeypatch.delenv("CLAWMETRY_NODE_ID", raising=False)
+
+    def _boom_register(*_a, **_kw):
+        raise AssertionError("cloud registration must not run in local mode")
+
+    def _boom_connect(*_a, **_kw):
+        raise AssertionError("cloud connect must not run in local mode")
+
+    def _boom_input(_prompt):
+        raise AssertionError("local-only path must not prompt the user")
+
+    monkeypatch.setattr(cli, "_instant_register", _boom_register)
+    monkeypatch.setattr(cli, "_cmd_connect", _boom_connect)
+    monkeypatch.setattr("builtins.input", _boom_input)
+
+    args = argparse.Namespace(
+        key=None,
+        foreground=False,
+        custom_node_id=None,
+        local_only=True,
+    )
+
+    cli._cmd_onboard(args)
+
+    out = capsys.readouterr().out
+    assert "local mode" in out.lower()
+    assert "clawmetry --host" in out


### PR DESCRIPTION
Closes #1937

## What

User reported (in #1937): _"I recently updated Clawmetry and it automatically connected to the cloud and asked for my email address. How can I disable this?"_

The onboarding wizard asked **"Do you have a ClawMetry account? [y/N]:"** and treated the default `n` as _"create a new cloud account for me"_. There was no explicit local-only path, and anyone who hit `Enter` thinking they were declining cloud was silently enrolled.

## How

- **Three-way prompt** in `clawmetry onboard`:
  - `c` — Cloud dashboard (free, E2E encrypted, recommended) — default
  - `e` — Connect existing account
  - `l` — Local only (no cloud sync)
- **Back-compat shim**: legacy `y`/`n` replies still resolve to the same behaviour (existing account / new cloud account), so any scripted install.sh callers keep working.
- **`--local` flag** on `clawmetry onboard` for non-interactive opt-out.
- **`CLAWMETRY_LOCAL_ONLY=1`** env var honoured by `install.sh` (forwards `--local` to onboard).
- **Already-connected branch** now surfaces `clawmetry disconnect` so users in #1937's exact state can drop cloud sync without digging through docs.

## Test plan

- [x] New unit test `test_onboard_local_only_skips_cloud_setup` — asserts `--local` does not invoke `_instant_register`, `_cmd_connect`, or prompt the user, and prints the local-mode confirmation.
- [x] `pytest tests/test_cli.py` — all 7 tests pass.
- [ ] Manual: `clawmetry onboard --local` on a fresh box, confirm no cloud calls + no prompt.
- [ ] Manual: `CLAWMETRY_LOCAL_ONLY=1 curl -fsSL .../install.sh | bash` — confirm local install path.
- [ ] Manual: legacy interactive flow — pressing `y` connects, `n`/Enter creates cloud account (same as before).