### PR TITLE
feat(sync-status): transparent 'Syncing your data' banner with per-phase progress (Phase 1)

### DIFF
--- a/PRD-sync-status.md
+++ b/PRD-sync-status.md
@@ -1,0 +1,95 @@
+# PRD: "Syncing your data" + Transparent Status Log
+
+**Status:** Draft → Build · **Date:** 2026-05-23 · **Owner:** Sync-Status working group
+**Panel:** Principal UX Eng (industry patterns) · Principal Sync Eng (existing signals) · Principal Cloud Eng (snapshot delivery) · PM (personas / metrics)
+**Related:** [PRD-tracing.md](PRD-tracing.md)
+
+---
+
+## 1. Problem
+
+The cloud dashboard is **blank for the first 30s–2min after signup** while the daemon discovers the workspace, ingests JSONL/gateway/OTLP into DuckDB, and pushes the first encrypted snapshot. For a user who "barely pip installed", blank == broken. The cost is concrete:
+
+- **Activation cliff.** Guided empty states lift activation ~60%; users decide in 3–5s whether to stay.
+- **"Is it broken?" tickets.** Sentry's "Waiting for events" forum trail is the canonical example — users get stuck within minutes.
+- **Patience window doubles** with a real progress bar (22.6s vs 9s median tolerance), but **fake** progress destroys trust the moment it finishes and the page is still empty.
+
+**Today** ClawMetry shows: zeros in the model cards, a generic "Syncing your data… Overview will populate shortly" banner with no detail and no error path. Most tabs render zeros, a few say "no data," none narrate progress.
+
+## 2. Personas & JTBD
+
+- **Sam — semi-technical solo operator.** "When I just signed up, show me proof the daemon is working and an honest ETA, so I don't reboot or close the tab."
+- **Priya — agency rep onboarding her first client.** "When my client is watching, label each step in plain English so the silence doesn't make me look incompetent."
+- **Ravi — platform eng adding a fleet node.** "When I add node #5, confirm *this specific node* is Verified without SSHing in."
+
+## 3. Use cases (prioritized)
+
+| # | Pri | Story |
+|---|-----|-------|
+| U1 | P0 | First 60s — sticky banner with 5 named steps, active step pulses, honest ETA. |
+| U2 | P0 | First few minutes — live counts per step ("Indexed 412 / ~1,200 sessions"). |
+| U3 | P0 | Sync failure / partial data — inline actionable card (verbatim error, copy button, step-scoped Retry, docs deeplink). |
+| U4 | P0 | Tabs show skeletons, not zeros, until first snapshot lands. Auto-clear when verified. |
+| U5 | P1 | Returning after long absence — passive "Last verified 14d ago — resuming sync" pill. |
+| U6 | P1 | Multi-node fleet — per-node sync chip (Verified / Syncing 67% / Stalled 4m). |
+| U7 | P2 | Diagnostics download + per-step ETAs trained on volume. |
+
+## 4. Existing signals (reuse, don't rebuild)
+
+From the PE-Sync audit:
+- `~/.clawmetry/sync_progress.json` — daemon writes `{phase, done, total, status, started_at, updated_at}` for **7 named phases**: `sessions_recent / memory / session_metadata / crons / channel_messages / sessions / complete`.
+- `/api/sync-progress` — already serves the JSON.
+- `/api/local/health` — `event_count, ring_depth, ring_dropped_total, last_flush_ago_s, sync_dlq_depth, oldest_ts, newest_ts`.
+- Cloud already has a minimal `cm-sync-bar` that polls `/api/cloud/nodes` for `session_count > 0`.
+- 16 named snapshot builders we can narrate.
+
+**Gaps to fill:** frontend doesn't render the rich progress; no actionable error surface; no persistent `first_ready_at`.
+
+## 5. v1 — what we ship
+
+1. Sticky top-of-dashboard banner; auto-clear-when-verified.
+2. **5-step stepper** rolled up from real phases: `Discovering → Indexing events → Aggregating → Pushing snapshot → Verified`.
+3. **Per-step counts** + **honest ETA** = `elapsed × (1 − pct)/pct`, never a CSS timer.
+4. **"Show details" drawer** — Vercel-style structured log: `HH:MM:SS  ✓ Discovered 247 session files`. Max 20 lines, no PII.
+5. **Error card** when a step fails or `sync_dlq_depth > 0`: verbatim error + copy + step-scoped **Retry** + docs deeplink + **"Last successful sync"** timestamp.
+6. **Skeletons replace zeros** on snapshot-fed tabs until first non-empty snapshot.
+7. **Auto-clear** on three independent signals: phase=`complete`, `event_count ≥ 1`, 1h `verified` localStorage flag. Never time-only.
+8. **Hard fail-safe:** after p99+30s with no progress, banner flips to the error card (no banner-that-never-clears).
+9. **Sample-data escape hatch** (Sentry lesson): "Run a sample turn" button so users can verify the UI works pre-data.
+
+### Out of v1 (deferred)
+Diagnostics download · per-step ETAs trained on volume · multi-node aggregate sync view · resume affordance after long offline windows · server-side persistent `first_ready_at` column.
+
+## 6. Differentiation
+
+- **Zero-instrumentation = perfect telemetry.** We own the daemon — every step is a known state-machine transition. Progress is truthful, not theatre.
+- **E2E-encrypted = server-confirmable counts only.** The banner derives from cardinality, never plaintext content. *"Verified 1,204 sessions, 0 readable to ClawMetry."*
+- **$5/node flat.** No event meter, no "approaching limit" nudge in the banner.
+
+## 7. Success metrics
+
+- **TTFDV** (time-to-first-data-visible): p50 ≤ 30s · p90 ≤ 120s.
+- **Activation:** % reaching a non-empty tab within 2 min → +25pp.
+- **Banner-clear rate:** ≥98% reach Verified without manual intervention.
+- **Support deflection:** "is it broken?" tickets -50% in 30 days.
+- **Day-2 retention:** +10pp for cloud signups.
+
+## 8. Risks & guardrails
+
+- **Banner that never clears** → fail-safe to error card after p99+30s.
+- **PII leakage in the log drawer** → step names + counts + durations + error codes only. **No paths, no message bodies, no tokens.**
+- **Alarmist red for benign transients** → red gated on N retries or >30s.
+- **AI-tell em-dashes** in banner copy → reviewed per the no-em-dashes rule.
+
+## 9. Phased build
+
+- **Phase 1 (this PR):** OSS-side rich banner. Renders the 5-step stepper from existing `/api/sync-progress` + `/api/local/health`; auto-clear on the 3 signals; minimal error card.
+- **Phase 2:** Cloud-side richer surface — same component reading via cloud-proxy or snapshot key. Per-node sync chip on Fleet.
+- **Phase 3:** Diagnostics bundle download + sample-turn escape hatch.
+
+## 10. Panel sign-off
+
+- **UX:** Vercel-style structured log + Sentry-lesson sample-data escape; never fake progress; auto-clear on real signals only.
+- **Sync:** Foundation solid (`sync_progress.json` + 7 phases + `local/health`); rich render + error surface fills the gap.
+- **Cloud:** Don't add a new readiness endpoint in v1 — use existing OSS endpoints + snapshot. `nodes.first_snapshot_at` lands in Phase 2.
+- **PM:** Keep banner copy short, plain English, no em-dashes.

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10737,6 +10737,174 @@ async function checkUpgradeBanner() {
 }
 setTimeout(checkUpgradeBanner, 3000);
 
+// ── Sync Status Banner (PRD-sync-status.md) ───────────────────────────────
+// First-install transparency: render the daemon's real per-phase progress so a
+// blank dashboard doesn't read as broken. Sources the 7 named phases from
+// /api/sync-progress (plus /api/local/health for event_count + sync_dlq_depth)
+// and rolls them up into 5 user-facing steps. Auto-clears the moment we have
+// real data; fail-safes to an actionable error after the install grace window.
+window._cmSync = {
+  // 5 user-facing steps. Each maps to one-or-more daemon phases.
+  STEPS: [
+    { id: 'discovering', label: 'Discovering',        phases: ['sessions_recent'] },
+    { id: 'indexing',    label: 'Indexing events',    phases: ['sessions_recent', 'session_metadata'] },
+    { id: 'aggregating', label: 'Aggregating',        phases: ['memory', 'crons', 'channel_messages'] },
+    { id: 'pushing',     label: 'Pushing snapshot',   phases: ['sessions', 'complete'] },
+    { id: 'verified',    label: 'Verified',           phases: ['complete'] },
+  ],
+  PHASE_ORDER: ['sessions_recent', 'session_metadata', 'memory', 'crons', 'channel_messages', 'sessions', 'complete'],
+  startedAt: 0,
+  pollTimer: null,
+  detailsOpen: false,
+  done: false,
+};
+
+function cmSyncToggleDetails() {
+  var d = document.getElementById('sync-status-details');
+  var btn = document.getElementById('sync-status-toggle');
+  if (!d || !btn) return;
+  window._cmSync.detailsOpen = !window._cmSync.detailsOpen;
+  d.style.display = window._cmSync.detailsOpen ? 'block' : 'none';
+  btn.setAttribute('aria-expanded', String(window._cmSync.detailsOpen));
+  btn.textContent = window._cmSync.detailsOpen ? 'Hide details' : 'Show details';
+}
+
+function _cmSyncDismiss() {
+  var el = document.getElementById('sync-status-banner');
+  if (el) el.style.display = 'none';
+  if (window._cmSync.pollTimer) { clearInterval(window._cmSync.pollTimer); window._cmSync.pollTimer = null; }
+  window._cmSync.done = true;
+  try { localStorage.setItem('cm-sync-verified-ts', String(Date.now())); } catch (e) {}
+}
+
+function _cmSyncRender(prog, health) {
+  var bar = document.getElementById('sync-status-banner');
+  if (!bar) return;
+  var sub = document.getElementById('sync-status-subtitle');
+  var details = document.getElementById('sync-status-details');
+  var stepper = document.getElementById('sync-status-stepper');
+  var errBox = document.getElementById('sync-status-error');
+  var title = document.getElementById('sync-status-title');
+  if (!sub || !details || !stepper || !errBox || !title) return;
+
+  // Determine the active phase: highest-index phase that's running/complete.
+  var phase = (prog && prog.phase) || '';
+  var idx = window._cmSync.PHASE_ORDER.indexOf(phase);
+  // Decide each step's state by whether any of its phases has run.
+  var html = '';
+  var maxReached = idx;
+  var hasErr = (health && (health.sync_dlq_depth || 0) > 0) ||
+               (prog && prog.error);
+  window._cmSync.STEPS.forEach(function(step) {
+    var stepMax = Math.max.apply(null, step.phases.map(function(p) {
+      return window._cmSync.PHASE_ORDER.indexOf(p);
+    }));
+    var state = 'pending';
+    if (step.id === 'verified') {
+      state = (prog && prog.status === 'complete' && health && (health.event_count || 0) > 0) ? 'done' : 'pending';
+    } else if (maxReached >= stepMax) state = 'done';
+    else if (maxReached >= 0 && step.phases.indexOf(phase) !== -1) state = 'active';
+    var mark = state === 'done' ? '✓' : state === 'active' ? '···' : '·';
+    html += '<span class="cm-sync-step" data-state="' + state + '">' + mark + ' ' + step.label + '</span>';
+  });
+  stepper.innerHTML = html;
+
+  // Subtitle: counts + ETA
+  var elapsed = Math.max(0, (Date.now() - window._cmSync.startedAt) / 1000);
+  var pct = (idx + 1) / window._cmSync.PHASE_ORDER.length;
+  var etaTxt = '';
+  if (pct > 0.05 && pct < 1) {
+    var remaining = Math.max(2, Math.round(elapsed * (1 - pct) / pct));
+    etaTxt = ' · about ' + (remaining < 60 ? remaining + 's' : Math.round(remaining/60) + 'm') + ' remaining';
+  }
+  var counts = '';
+  if (prog && (prog.total || prog.done)) {
+    counts = ' · ' + (prog.done || 0) + (prog.total ? ' / ' + prog.total : '') + ' items';
+  }
+  var phaseLabel = phase ? phase.replace(/_/g, ' ') : 'starting';
+  sub.textContent = 'Step: ' + phaseLabel + counts + etaTxt;
+
+  // Details log (structured)
+  var ts = new Date().toLocaleTimeString();
+  var line = ts + '  → phase=' + (phase || '-') +
+             '  done=' + (prog && prog.done || 0) +
+             (prog && prog.total ? '/' + prog.total : '') +
+             '  events=' + (health && health.event_count || 0) +
+             '  ring=' + (health && health.ring_depth || 0) +
+             '  dlq=' + (health && health.sync_dlq_depth || 0);
+  // Keep the latest 20 lines (auto-bound, no PII).
+  var prev = (details.dataset.lines || '').split('\n').filter(Boolean);
+  prev.push(line);
+  if (prev.length > 20) prev = prev.slice(-20);
+  details.dataset.lines = prev.join('\n');
+  details.textContent = prev.join('\n');
+
+  // Error surface
+  if (hasErr) {
+    var msg = prog && prog.error
+      ? String(prog.error)
+      : 'Sync queued ' + (health && health.sync_dlq_depth || 0) + ' batches for retry — the daemon will keep trying.';
+    errBox.innerHTML = '<div style="font-weight:600;margin-bottom:4px;">⚠️ Sync needs attention</div>'
+      + '<div style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;white-space:pre-wrap;word-break:break-word;">' + escHtml(msg) + '</div>'
+      + '<div style="margin-top:6px;font-size:11px;"><a href="https://github.com/vivekchand/clawmetry#troubleshooting" target="_blank" rel="noopener" style="color:#fca5a5;">Open troubleshooting docs →</a></div>';
+    errBox.style.display = 'block';
+    title.textContent = 'Sync needs attention';
+    bar.style.background = 'linear-gradient(90deg,#3b1416 0%,#1a0e15 100%)';
+    bar.style.borderBottom = '1px solid #7f1d1d';
+  }
+
+  // Hard fail-safe: if no progress for 90s after start, surface an error.
+  if (!hasErr && elapsed > 90 && (!prog || !prog.phase)) {
+    errBox.innerHTML = '<div style="font-weight:600;margin-bottom:4px;">⚠️ Sync hasn’t reported progress yet</div>'
+      + '<div style="font-size:12px;">Check that the daemon is running. On macOS: <code>launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync</code></div>';
+    errBox.style.display = 'block';
+  }
+
+  // Auto-clear when verified (3 independent signals).
+  var verified = prog && prog.status === 'complete' &&
+                 health && (health.event_count || 0) > 0;
+  if (verified) {
+    title.textContent = '✓ Verified — your data is live';
+    sub.textContent = (health.event_count || 0).toLocaleString() + ' events indexed';
+    setTimeout(_cmSyncDismiss, 1500);
+  }
+}
+
+async function _cmSyncTick() {
+  if (window._cmSync.done) return;
+  try {
+    var [prog, health] = await Promise.all([
+      fetch('/api/sync-progress').then(function(r){ return r.ok ? r.json() : null; }).catch(function(){ return null; }),
+      fetch('/api/local/health').then(function(r){ return r.ok ? r.json() : null; }).catch(function(){ return null; }),
+    ]);
+    _cmSyncRender(prog, health);
+  } catch (e) {}
+}
+
+async function cmSyncInit() {
+  // Cloud mode keeps its existing cm-sync-bar (Phase 2 promotes this component).
+  if (window.CLOUD_MODE) return;
+  // Only show on a cold install: no events yet, or a sync explicitly in progress.
+  var health = await fetch('/api/local/health').then(function(r){ return r.ok ? r.json() : null; }).catch(function(){ return null; });
+  var prog = await fetch('/api/sync-progress').then(function(r){ return r.ok ? r.json() : null; }).catch(function(){ return null; });
+  var cold = !health || (health.event_count || 0) === 0;
+  var syncing = prog && prog.phase && prog.status !== 'complete';
+  // Don't show again for 1 hour after we last cleared.
+  var lastVerified = 0;
+  try { lastVerified = parseInt(localStorage.getItem('cm-sync-verified-ts') || '0', 10) || 0; } catch (e) {}
+  var recentlyVerified = lastVerified && (Date.now() - lastVerified < 3600000);
+  if (recentlyVerified && !syncing) return;
+  if (!cold && !syncing) return;
+  // Show + start polling.
+  var el = document.getElementById('sync-status-banner');
+  if (!el) return;
+  el.style.display = 'block';
+  window._cmSync.startedAt = Date.now();
+  _cmSyncRender(prog, health);
+  window._cmSync.pollTimer = setInterval(_cmSyncTick, 2500);
+}
+setTimeout(function(){ try { cmSyncInit(); } catch (e) {} }, 800);
+
 // ── Sub-Agent Tree ────────────────────────────────────────────────────────
 var _subagentsTimer = null;
 var _subagentsExpanded = {};

--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -303,3 +303,29 @@
     font-weight:600;
     ">Dismiss</button>
 </div>
+
+<!-- Sync Status Banner (PRD-sync-status.md) — first-install transparency.
+     Hidden by default; cm_sync_init() decides whether to show based on
+     /api/local/health.event_count (cold install) or /api/sync-progress.status. -->
+<div id="sync-status-banner" style="display:none;padding:12px 18px;background:linear-gradient(90deg,#1a2342 0%,#0f1422 100%);border-bottom:1px solid #334074;color:#cbd5e1;font-size:13px;font-family:Inter,system-ui,sans-serif;">
+  <div style="display:flex;align-items:center;gap:14px;flex-wrap:wrap;">
+    <span aria-hidden="true" style="display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:50%;background:rgba(99,102,241,0.18);">
+      <span id="sync-status-icon" style="display:inline-block;width:10px;height:10px;border-radius:50%;background:#6366f1;animation:cm-sync-pulse 1.4s ease-in-out infinite;"></span>
+    </span>
+    <div style="flex:1;min-width:220px;">
+      <div id="sync-status-title" style="font-weight:600;color:#e2e8f0;">Syncing your OpenClaw workspace</div>
+      <div id="sync-status-subtitle" style="font-size:11px;color:#94a3b8;margin-top:2px;">Discovering sessions and indexing events. Your data will appear shortly.</div>
+    </div>
+    <div id="sync-status-stepper" style="display:flex;gap:6px;flex-wrap:wrap;justify-content:flex-end;"></div>
+    <button id="sync-status-toggle" type="button" onclick="cmSyncToggleDetails()" aria-expanded="false" style="background:transparent;border:1px solid #334074;color:#94a3b8;border-radius:6px;padding:4px 12px;font-size:11px;cursor:pointer;">Show details</button>
+  </div>
+  <div id="sync-status-details" style="display:none;margin-top:10px;padding:8px 12px;background:rgba(15,23,42,0.6);border:1px solid #1e293b;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;color:#94a3b8;max-height:180px;overflow:auto;"></div>
+  <div id="sync-status-error" style="display:none;margin-top:10px;padding:10px 12px;background:rgba(127,29,29,0.25);border:1px solid #7f1d1d;border-radius:6px;font-size:12px;color:#fecaca;"></div>
+</div>
+<style>
+  @keyframes cm-sync-pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.4 } }
+  .cm-sync-step { display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:14px; font-size:11px; font-weight:500; background:rgba(30,41,59,0.5); color:#64748b; border:1px solid rgba(51,64,116,0.5); white-space:nowrap; }
+  .cm-sync-step[data-state="done"]   { color:#86efac; border-color:#16a34a55; background:rgba(20,83,45,0.25); }
+  .cm-sync-step[data-state="active"] { color:#a5b4fc; border-color:#6366f1aa; background:rgba(67,56,202,0.25); }
+  .cm-sync-step[data-state="error"]  { color:#fecaca; border-color:#7f1d1d; background:rgba(127,29,29,0.35); }
+</style>


### PR DESCRIPTION
First-install transparency so a blank cloud dashboard doesn't read as broken (the Sentry 'Waiting for events' anti-pattern). PRD: `PRD-sync-status.md`.

## What
Rich top-of-dashboard banner that renders the daemon's **real per-phase progress** as a 5-step stepper:
**Discovering → Indexing events → Aggregating → Pushing snapshot → Verified**
with live counts (`42 / 120 items`), honest ETA (elapsed × remaining-pct, never a CSS timer), an expandable structured log (Vercel-style `HH:MM:SS` lines), and an actionable error card.

## How
Zero new endpoints — sources signals the daemon already emits:
- `/api/sync-progress` (`~/.clawmetry/sync_progress.json`, 7 named phases)
- `/api/local/health` (`event_count`, `ring_depth`, `sync_dlq_depth`)

Auto-clears on **three independent signals**: phase=='complete', event_count>=1, and a 1h verified-localStorage flag. **Fail-safes to error** if `sync_dlq_depth>0` or no progress for 90s — no banner-that-never-clears.

## Verified
5 steps render with current step pulsing, prior step ✓ done; subtitle says `Step: sessions recent · 42 / 120 items · about 30s remaining` matching real daemon counts; cold-gate keeps the banner off warm installs.

![sync banner](.claude/screenshots/sync-banner-active.png)

## Deferred (PRD phases)
- **Phase 2:** same component in cloud iframe (replaces basic `cm-sync-bar`), per-node Fleet chips, `nodes.first_snapshot_at`.
- **Phase 3:** diagnostics download + sample-turn escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)