### PR TITLE
fix(alerts): restore Approvals-style all-toggles UI (#1885 wiped 4 prior PRs)

### DIFF
--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -48,116 +48,154 @@
       };
       const ck = await crypto.subtle.importKey('raw', b64u(nk), { name: 'AES-GCM' }, false, ['decrypt']);
       const raw = new Uint8Array(b64u(blobB64));
-      const iv = raw.slice(0, 12);
-      const ct = raw.slice(12);
-      const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, ck, ct);
-      return JSON.parse(new TextDecoder().decode(pt));
-    } catch { return []; }
-  }
-
-  // ── Paywall helpers ───────────────────────────────────────────────────────
-
-  function openPaywall() {
-    var m = document.getElementById('alerts-paywall-modal');
-    if (m) m.style.display = 'flex';
-  }
-
-  window.alertsClosePaywall = function (e) {
-    if (e && e.target !== document.getElementById('alerts-paywall-modal')) return;
-    var m = document.getElementById('alerts-paywall-modal');
-    if (m) m.style.display = 'none';
-  };
-
-  window.alertsCtaClick = function () {
-    window.open('https://app.clawmetry.com/?ref=alerts-cta', '_blank');
-  };
-
-  // ── Pro editor helpers ────────────────────────────────────────────────────
-
-  function openEditor() {
-    var m = document.getElementById('alerts-editor-modal');
-    if (m) m.style.display = 'flex';
-    alertsRenderTypeForm(alertsState.editorType);
-    alertsRenderEditorChannels();
-    var title = document.getElementById('alerts-editor-title');
-    if (title) title.textContent = alertsState.editorRule && alertsState.editorRule.id ? 'Edit alert rule' : 'New alert rule';
-  }
-
-  window.alertsCloseEditor = function (e) {
-    if (e && e.target !== document.getElementById('alerts-editor-modal')) return;
-    var m = document.getElementById('alerts-editor-modal');
-    if (m) m.style.display = 'none';
-  };
-
-  // ── Rule type form ────────────────────────────────────────────────────────
-
-  function alertsRenderTypeForm(type) {
-    var form = document.getElementById('alerts-editor-form');
-    if (!form) return;
-    var rule = alertsState.editorRule || {};
-    var fields = {
-      daily_spend:      [['Threshold ($)', 'number', 'threshold', rule.threshold || 10]],
-      node_offline:     [['Offline for (min)', 'number', 'threshold', rule.threshold || 5]],
-      session_cost:     [['Session cost ($)', 'number', 'threshold', rule.threshold || 2]],
-      session_duration: [['Duration (min)', 'number', 'threshold', rule.threshold || 30]],
-      token_velocity:   [['Tokens/min', 'number', 'threshold', rule.threshold || 5000]],
-      subagent_depth:   [['Max depth', 'number', 'threshold', rule.threshold || 5]],
-      cron_failure:     [],
-      error_rate:       [['Error rate (%)', 'number', 'threshold', rule.threshold || 20]],
-    };
-    var rows = (fields[type] || []).map(function(f) {
-      return '<label style="font-size:13px;color:var(--text-secondary);display:flex;gap:8px;align-items:center;">' +
-        f[0] + ': <input type="' + f[1] + '" id="ae-' + f[2] + '" value="' + f[3] +
-        '" style="width:80px;padding:4px 8px;border:1px solid var(--border-primary);border-radius:6px;background:var(--bg-tertiary);color:var(--text-primary);"></label>';
-    }).join('');
-    form.innerHTML = rows || '<div style="color:var(--text-muted);font-size:12px;">Triggers on any occurrence.</div>';
-  }
-
-  window.alertsPickType = function (type) {
-    alertsState.editorType = type;
-    document.querySelectorAll('#alerts-type-seg button').forEach(function(b) {
-      b.classList.toggle('active', b.dataset.type === type);
-    });
-    alertsRenderTypeForm(type);
-  };
-
-  // ── Channel picker (inside editor) ────────────────────────────────────────
-
-  async function alertsRenderEditorChannels() {
-    var el = document.getElementById('alerts-editor-channels');
-    if (!el) return;
-    // Load channels from cloud proxy
-    try {
-      var data = await fetch('/api/cloud-proxy/channels').then(function(r) { return r.json(); });
-      var channels = Array.isArray(data) ? data : (data.channels || []);
-      if (!channels.length) {
-        el.innerHTML = '<div style="color:var(--text-muted);font-size:12px;">No channels configured yet. Add one below.</div>';
-        return;
-      }
-      var selectedIds = (alertsState.editorRule && alertsState.editorRule.channel_ids) || [];
-      el.innerHTML = channels.map(function(ch) {
-        var checked = selectedIds.includes(ch.id) ? ' checked' : '';
-        return '<label style="font-size:13px;display:flex;gap:8px;align-items:center;">' +
-          '<input type="checkbox" value="' + ch.id + '"' + checked + '> ' + ch.name + '</label>';
-      }).join('');
-    } catch(e) {
-      el.innerHTML = '<div style="color:var(--text-muted);font-size:12px;">Could not load channels.</div>';
+      const txt = new TextDecoder().decode(
+        await crypto.subtle.decrypt({ name: 'AES-GCM', iv: raw.slice(0, 12) }, ck, raw.slice(12)));
+      const payload = JSON.parse(txt);
+      const rules = payload.rules || payload.alerts || [];
+      // The daemon stores the full cloud rule body inside ``condition_json``
+      // (the top level only has id/name/enabled), so alert_type / threshold /
+      // channel_ids live one level down. Flatten it up — otherwise the
+      // merge-render's ``find(r.alert_type === ...)`` never matches and the
+      // toggle stays OFF even though the rule exists. Top-level id/name/enabled
+      // win (they're the authoritative live state).
+      return rules.map(r => Object.assign({}, r.condition_json || {}, r));
+    } catch (e) {
+      return [];
     }
   }
 
-  // ── Render helpers ────────────────────────────────────────────────────────
-
+  // Canned example rules shown to OSS-only / no-cloud users. Users can edit
+  // these (change threshold, channels, name) before being asked to sign up --
+  // investing in configuration first improves conversion.
   const EXAMPLE_RULES = [
-    { id: 'example_cost',      alert_type: 'daily_spend',  threshold: 10,   enabled: false, name: 'Daily cost spike',      description: 'Alert when daily spend exceeds $10' },
-    { id: 'example_agent',     alert_type: 'node_offline', threshold: 5,    enabled: false, name: 'Agent offline',         description: 'Alert when agent is offline for > 5 min' },
-    { id: 'example_session',   alert_type: 'session_cost', threshold: 2,    enabled: false, name: 'Session cost',          description: 'Alert when session cost exceeds $2' },
-    { id: 'example_velocity',  alert_type: 'token_velocity', threshold: 5000, enabled: false, name: 'Token velocity',      description: 'Alert on token spike > 5000/min' },
-    { id: 'example_cron',      alert_type: 'cron_failure', threshold: 1,    enabled: false, name: 'Cron failure',          description: 'Alert on any cron job failure' },
-    { id: 'example_error',     alert_type: 'error_rate',   threshold: 20,   enabled: false, name: 'Tool error rate',       description: 'Alert when tool error rate > 20%' },
+    { id: 'example_cost',  alert_type: 'daily_spend',  name: 'Daily spend > $50',
+      threshold_value: 50, threshold_unit: 'USD',
+      _exampleChannels: '💬 Slack · ✉️ Email' },
+    { id: 'example_agent', alert_type: 'node_offline', name: 'Agent offline > 10 min',
+      threshold_value: 10, threshold_unit: 'min',
+      _exampleChannels: '📟 PagerDuty' },
+    { id: 'example_session', alert_type: 'session_cost', name: 'Session cost > $5',
+      threshold_value: 5, threshold_unit: 'USD',
+      _exampleChannels: '✉️ Email' },
+    { id: 'example_velocity', alert_type: 'token_velocity', name: 'Token velocity > 10k/min',
+      threshold_value: 10000, threshold_unit: 'tokens/min',
+      _exampleChannels: '✈️ Telegram · ✉️ Email' },
+    { id: 'example_cron', alert_type: 'cron_failure', name: 'Cron failed 3× in a row',
+      threshold_value: 3, threshold_unit: 'fails',
+      _exampleChannels: '💬 Slack · ✈️ Telegram' },
+    { id: 'example_tool', alert_type: 'error_rate', name: 'Tool failures > 5/hr',
+      threshold_value: 5, threshold_unit: '%',
+      _exampleChannels: '✉️ Email' },
   ];
 
-  const ALERT_META = {
-    daily_spend:      { icon: '💰', verb: 'Daily cost exceeds' },
+  // ── Tier resolution ───────────────────────────────────────────────────────
+
+  async function resolveTier() {
+    try {
+      const status = await fetch('/api/cloud-cta/status').then(r => r.json());
+      if (!status.connected) return { tier: 'none' };
+      const acct = await fetch('/api/cloud-proxy/api/cloud/account').then(r => r.json());
+      const plan = (acct.plan || 'free').toLowerCase();
+      if (plan === 'cloud_pro' || plan === 'pro') return { tier: 'pro' };
+      if (plan === 'trial') {
+        const days = parseInt(acct.trial_days_left || 0, 10);
+        return { tier: days > 0 ? 'trial' : 'free', trialDaysLeft: days };
+      }
+      return { tier: 'free' };
+    } catch (e) {
+      console.warn('[alerts] tier resolution failed', e);
+      return { tier: 'none' };
+    }
+  }
+
+  // ── Page entry point ──────────────────────────────────────────────────────
+
+  window.loadAlertsPage = async function () {
+    document.getElementById('alerts-rules-list').innerHTML =
+      '<div class="alerts-loading">Loading alerts…</div>';
+
+    const t = await resolveTier();
+    alertsState.tier = t.tier;
+    alertsState.trialDaysLeft = t.trialDaysLeft || null;
+    // Trial banner removed in PR #791 — paywall fires on action (click
+    // + New alert rule / Enable) for Free users instead. Trial/Pro users
+    // have full access and see no upgrade prompt unless they hit a cap.
+
+    // For all tiers: try to load rules. If unauthenticated, fall back to
+    // canned examples so the user still sees the value.
+    if (t.tier === 'none') {
+      renderCannedExamples();
+      renderHistoryEmpty('Sign up for Cloud to start collecting alert history.');
+      return;
+    }
+
+    try {
+      const data = await fetch('/api/cloud-proxy/api/alerts').then(r => r.json());
+      // Cache hit returns an E2E-encrypted ``rules_blob`` ({rules:[...]}) that
+      // only the browser can decrypt; cache miss returns plaintext
+      // ``{alerts:[]}``. Reading data.alerts alone meant a saved rule (which
+      // arrives encrypted) never rendered — the tab stayed on canned examples
+      // forever. Decrypt the blob when present.
+      let serverRules;
+      if (data.rules_blob) {
+        serverRules = await alertsDecryptRulesBlob(data.rules_blob);
+      } else {
+        serverRules = data.alerts || data.rules || [];
+      }
+      // Preserve optimistic ``pending-`` rules until the cloud cache catches
+      // up (the daemon cache_push lags the write by ~2 heartbeats). Without
+      // this the toggle visibly flips back OFF on the reconcile reload before
+      // the rule appears — looking exactly like "Enable does nothing".
+      const pending = (alertsState.rules || []).filter(r =>
+        String(r.id).startsWith('pending-') &&
+        !serverRules.find(s => s.alert_type === r.alert_type));
+      alertsState.rules = serverRules.concat(pending);
+    } catch {
+      // keep existing (incl. optimistic) rules on a transient fetch error
+    }
+    renderRules();
+
+    // Bug #1127: Badge counted local OSS fires while page only checked cloud
+    // history -> badge "20" with page saying "no alerts fired". Fall back to
+    // the same local /api/alerts/history the nav badge uses when cloud has
+    // nothing (or errors), so the two stay consistent.
+    try {
+      const hist = await fetch('/api/cloud-proxy/api/alerts/history?limit=20')
+        .then(r => r.json());
+      alertsState.history = hist.history || [];
+    } catch {
+      alertsState.history = [];
+    }
+    if (!alertsState.history.length) {
+      try {
+        const local = await fetch('/api/alerts/history?limit=20').then(r => r.json());
+        const localFires = (local.alerts || []).map(a => ({
+          id: a.id,
+          fired_at: a.fired_at,
+          resolved_at: a.acknowledged ? a.ack_at : null,
+          alert_id: a.rule_id,
+          payload: { name: a.type, actual_value: a.message, threshold_unit: '' },
+        }));
+        alertsState.history = localFires;
+      } catch {
+        // keep empty
+      }
+    }
+    renderHistory();
+
+    try {
+      const ch = await fetch('/api/cloud-proxy/api/channels').then(r => r.json());
+      alertsState.channels = ch.channels || [];
+      renderChannelsSummary();
+    } catch {
+      alertsState.channels = [];
+    }
+  };
+
+  // ── Renderers ─────────────────────────────────────────────────────────────
+
+  const RULE_TYPE_LABELS = {
+    daily_spend:      { icon: '💰', verb: 'Daily spend exceeds' },
     session_cost:     { icon: '🧵', verb: 'Session cost exceeds' },
     node_offline:     { icon: '🤖', verb: 'Agent offline >' },
     session_duration: { icon: '⏱',  verb: 'Session duration >' },
@@ -167,172 +205,125 @@
     error_rate:       { icon: '🛠', verb: 'Tool error rate >' },
   };
 
+  // On/off slider that matches the Approvals protection-rule toggle. Clicking
+  // it flips the rule: OFF (example/disabled) -> creates+enables the rule;
+  // ON -> disables it. ``alertsToggleRule`` handles create-from-example.
+  function toggleSwitch(ruleId, on) {
+    return '<div class="alerts-toggle-switch" onclick="event.stopPropagation();alertsToggleRule(\'' + ruleId + '\', ' + (on ? 'false' : 'true') + ')"'
+      + ' title="' + (on ? 'Enabled — click to disable' : 'Disabled — click to enable') + '"'
+      + ' style="position:relative;width:42px;height:24px;cursor:pointer;flex-shrink:0;">'
+      + '<div style="position:absolute;inset:0;background:' + (on ? '#3b82f6' : '#374151') + ';border-radius:12px;transition:background 0.2s;"></div>'
+      + '<div style="position:absolute;top:3px;left:' + (on ? '21px' : '3px') + ';width:18px;height:18px;background:#fff;border-radius:50%;transition:left 0.2s;box-shadow:0 1px 3px rgba(0,0,0,0.3);"></div>'
+      + '</div>';
+  }
+
   function renderRules() {
-    var el = document.getElementById('alerts-rules-list');
-    if (!el) return;
-    var rules = alertsState.rules;
-    var html = '';
+    const wrap = document.getElementById('alerts-rules-list');
+    // Approvals-style: ALWAYS show the canonical alert types as on/off
+    // toggles (default OFF). Each maps to a matching saved rule by
+    // alert_type so the toggle reflects its real state; an OFF row uses the
+    // example template and creates the rule on toggle-on. This keeps all
+    // types visible after you enable one (the old render hid the rest).
+    wrap.innerHTML = EXAMPLE_RULES.map(ex => {
+      const real = alertsState.rules.find(r => r.alert_type === ex.alert_type);
+      const on = !!(real && real.enabled);
+      const id = real ? real.id : ex.id;
+      const meta = RULE_TYPE_LABELS[ex.alert_type] || { icon: '🔔', verb: ex.alert_type };
+      const name = real ? real.name : ex.name;
+      const threshold = real ? real.threshold_value : ex.threshold_value;
+      const unit = (real ? real.threshold_unit : ex.threshold_unit) || '';
+      let metaLine;
+      if (real && real.last_triggered_at) {
+        metaLine = `Last: ${formatTimeAgo(real.last_triggered_at)} · ${real.trigger_count}× total`;
+      } else {
+        metaLine = `${meta.verb} ${threshold}${unit ? ' ' + escape(unit) : ''}`
+          + (real ? ' · never triggered' : '');
+      }
+      const channelPills = real
+        ? (real.channel_ids || []).map(cid => {
+            const ch = alertsState.channels.find(c => c.id === cid);
+            return ch ? `<span class="alerts-chan-pill">${chTypeIcon(ch.channel_type)} ${escape(ch.name)}</span>` : '';
+          }).join('')
+        : `<span class="alerts-chan-pill off">${ex._exampleChannels}</span>`;
+      const badge = real ? '' : '<span class="alerts-rule-example-badge">example</span>';
+      return `
+        <div class="alerts-rule-row${real ? '' : ' alerts-rule-example'}" data-rule-id="${id}">
+          <div class="alerts-rule-dot ${on ? 'on' : 'off'}" title="${on ? 'Enabled' : 'Disabled'}"></div>
+          <div class="alerts-rule-main">
+            <div class="alerts-rule-title">${meta.icon} ${escape(name)} ${badge}</div>
+            <div class="alerts-rule-meta">${metaLine}</div>
+          </div>
+          <div class="alerts-rule-chan">${channelPills || '<span class="alerts-chan-pill off">no channels</span>'}</div>
+          ${toggleSwitch(id, on)}
+          <button class="alerts-btn-ghost" onclick="alertsHandleEdit('${id}')">Edit</button>
+        </div>
+      `;
+    }).join('');
+  }
 
-    if (!rules.length && (alertsState.tier !== 'pro' && alertsState.tier !== 'trial')) {
-      // Show canned example teaser for non-Pro (one rule only)
-      var ex = EXAMPLE_RULES[0];
-      var meta = ALERT_META[ex.alert_type] || { icon: '🔔', verb: '' };
-      html += '<div class="alerts-rule-row" style="opacity:0.6">';
-      html += '<div class="alerts-rule-icon">' + meta.icon + '</div>';
-      html += '<div class="alerts-rule-body">';
-      html += '<div class="alerts-rule-name">' + ex.name + '</div>';
-      html += '<div class="alerts-rule-desc">' + ex.description + '</div>';
-      html += '</div>';
-      html += '<label class="alerts-toggle"><input type="checkbox" onchange="alertsToggleRule(\'' + ex.id + '\', this.checked)" ' + (ex.enabled ? 'checked' : '') + '><span class="alerts-toggle-slider"></span></label>';
-      html += '</div>';
-      el.innerHTML = html;
-      return;
-    }
-
-    if (!rules.length) {
-      el.innerHTML = '<div class="alerts-empty">No alert rules yet. Click \'+ New alert rule\' to add one.</div>';
-      return;
-    }
-
-    rules.forEach(function(rule) {
-      var meta = ALERT_META[rule.alert_type] || { icon: '🔔', verb: '' };
-      html += '<div class="alerts-rule-row">';
-      html += '<div class="alerts-rule-icon">' + meta.icon + '</div>';
-      html += '<div class="alerts-rule-body">';
-      html += '<div class="alerts-rule-name">' + (rule.name || rule.alert_type) + '</div>';
-      html += '<div class="alerts-rule-desc">' + meta.verb + ' ' + (rule.threshold || '') + '</div>';
-      html += '</div>';
-      html += '<div style="display:flex;gap:8px;align-items:center;">';
-      html += '<button class="alerts-rule-edit" onclick="alertsHandleEditRule(\'' + rule.id + '\')">✏️</button>';
-      html += '<button class="alerts-rule-del" onclick="alertsDeleteRule(\'' + rule.id + '\')">🗑️</button>';
-      html += '<label class="alerts-toggle"><input type="checkbox" onchange="alertsToggleRule(\'' + rule.id + '\', this.checked)" ' + (rule.enabled ? 'checked' : '') + '><span class="alerts-toggle-slider"></span></label>';
-      html += '</div>';
-      html += '</div>';
-    });
-    el.innerHTML = html;
+  function renderCannedExamples() {
+    const wrap = document.getElementById('alerts-rules-list');
+    wrap.innerHTML = EXAMPLE_RULES.map(ex => {
+      const meta = RULE_TYPE_LABELS[ex.alert_type];
+      return `
+        <div class="alerts-rule-row alerts-rule-example" onclick="alertsHandleEdit('${ex.id}')">
+          <div class="alerts-rule-dot off"></div>
+          <div class="alerts-rule-main">
+            <div class="alerts-rule-title">${meta.icon} ${escape(ex.name)}
+              <span class="alerts-rule-example-badge">example</span>
+            </div>
+            <div class="alerts-rule-meta">Tap to customize — saves require Cloud Pro</div>
+          </div>
+          <div class="alerts-rule-chan"><span class="alerts-chan-pill off">${ex._exampleChannels}</span></div>
+          ${toggleSwitch(ex.id, false)}
+          <button class="alerts-btn-ghost" onclick="event.stopPropagation();alertsHandleEdit('${ex.id}')">Edit</button>
+        </div>
+      `;
+    }).join('');
   }
 
   function renderHistory() {
-    var el = document.getElementById('alerts-history-list');
-    if (!el) return;
-    var history = alertsState.history;
-    if (!history.length) {
-      el.innerHTML = '<div class="alerts-empty">No alerts triggered yet.</div>';
+    const wrap = document.getElementById('alerts-history-list');
+    if (!alertsState.history.length) {
+      return renderHistoryEmpty('No alerts have fired yet.');
+    }
+    wrap.innerHTML = alertsState.history.map(h => {
+      const sev = h.resolved_at ? 'sev-green' : 'sev-red';
+      const dot = h.resolved_at ? '●' : '●';
+      const payload = h.payload || {};
+      return `
+        <div class="alerts-hist-row">
+          <span class="${sev}">${dot}</span>
+          <span class="alerts-hist-time">${formatTimeAgo(h.fired_at)}</span>
+          <span class="alerts-hist-text"><b>${escape(payload.name || h.alert_id)}</b>
+            → ${escape(String(payload.actual_value ?? ''))} ${escape(payload.threshold_unit || '')}</span>
+        </div>
+      `;
+    }).join('');
+  }
+
+  function renderHistoryEmpty(msg) {
+    document.getElementById('alerts-history-list').innerHTML =
+      `<div class="alerts-loading">${escape(msg)}</div>`;
+  }
+
+  function renderChannelsSummary() {
+    const wrap = document.getElementById('alerts-channels-summary');
+    if (!alertsState.channels.length) {
+      wrap.textContent = 'No channels configured yet';
       return;
     }
-    var html = history.map(function(ev) {
-      var d = new Date(ev.triggered_at * 1000);
-      var ts = d.toLocaleString();
-      return '<div class="alerts-history-row"><span class="alerts-history-ts">' + ts + '</span>' +
-        '<span class="alerts-history-msg">' + (ev.message || ev.alert_type || '') + '</span></div>';
-    }).join('');
-    el.innerHTML = html;
+    const types = [...new Set(alertsState.channels.map(c => chTypeLabel(c.channel_type)))];
+    wrap.textContent = types.join(' · ');
   }
 
-  // ── API calls ─────────────────────────────────────────────────────────────
-
-  async function fetchTier() {
-    try {
-      // Check OSS status endpoint first
-      var oss = await fetch('/api/cloud-cta/status').then(function(r) { return r.json(); });
-      if (oss && oss.cloud_connected === false) {
-        alertsState.tier = 'none';
-        return;
-      }
-      // Check Pro account
-      var acct = await fetch('/api/cloud-proxy/account').then(function(r) { return r.json(); });
-      if (acct && (acct.plan === 'cloud_pro' || acct.plan === 'pro')) {
-        alertsState.tier = 'pro';
-      } else if (acct && acct.plan === 'trial' && acct.trial_days_left > 0) {
-        alertsState.tier = 'trial';
-        alertsState.trialDaysLeft = acct.trial_days_left;
-      } else {
-        alertsState.tier = 'free';
-      }
-    } catch {
-      alertsState.tier = 'none';
-    }
-  }
-
-  async function fetchRules() {
-    if (alertsState.tier !== 'pro' && alertsState.tier !== 'trial') return;
-    try {
-      // Try cloud proxy first (has E2E-encrypted rules_blob on cache hit)
-      var data = await fetch('/api/cloud-proxy/alert-rules').then(function(r) { return r.json(); });
-      var rules = [];
-      if (data && data.rules_blob) {
-        rules = await alertsDecryptRulesBlob(data.rules_blob);
-      }
-      if (!rules.length && data && Array.isArray(data.rules)) {
-        rules = data.rules;
-      }
-      // Fall back to local rules endpoint if proxy returns nothing
-      if (!rules.length) {
-        var local = await fetch('/api/alerts/rules').then(function(r) { return r.json(); });
-        rules = Array.isArray(local) ? local : (local.rules || []);
-      }
-      alertsState.rules = rules;
-    } catch {
-      alertsState.rules = [];
-    }
-  }
-
-  async function fetchHistory() {
-    if (alertsState.tier !== 'pro' && alertsState.tier !== 'trial') return;
-    try {
-      var data = await fetch('/api/alerts/history').then(function(r) { return r.json(); });
-      alertsState.history = Array.isArray(data) ? data : (data.history || []);
-    } catch {
-      alertsState.history = [];
-    }
-  }
-
-  // ── Init ──────────────────────────────────────────────────────────────────
-
-  async function init() {
-    await fetchTier();
-    applyTierUI();
-    await Promise.all([fetchRules(), fetchHistory()]);
-    renderRules();
-    renderHistory();
-    updateChannelsSummary();
-  }
-
-  function applyTierUI() {
-    var t = alertsState.tier;
-    var paywallTitle = document.getElementById('alerts-paywall-title');
-    var paywallBody  = document.getElementById('alerts-paywall-body');
-    var paywallCta   = document.getElementById('alerts-paywall-cta');
-    if (t === 'none') {
-      if (paywallTitle) paywallTitle.textContent = 'Sign up for ClawMetry Cloud';
-      if (paywallBody)  paywallBody.textContent  = 'Alerts need the cloud to deliver Slack / PagerDuty / Telegram / Email messages. Sign up — your data stays encrypted, Pro features include a 7-day free trial.';
-      if (paywallCta)   paywallCta.textContent   = 'Sign up for Cloud';
-    } else if (t === 'free') {
-      if (paywallTitle) paywallTitle.textContent = 'Upgrade to Pro';
-      if (paywallBody)  paywallBody.textContent  = 'Your free plan includes 1 example rule. Upgrade to Pro to create unlimited rules with Slack, PagerDuty, and email delivery.';
-      if (paywallCta)   paywallCta.textContent   = 'Upgrade to Pro';
-    }
-  }
-
-  async function updateChannelsSummary() {
-    var el = document.getElementById('alerts-channels-summary');
-    if (!el) return;
-    if (alertsState.tier === 'pro' || alertsState.tier === 'trial') {
-      try {
-        var data = await fetch('/api/cloud-proxy/channels').then(function(r) { return r.json(); });
-        var channels = Array.isArray(data) ? data : (data.channels || []);
-        el.textContent = channels.length ? channels.map(function(c) { return c.name; }).join(' · ') : 'None configured';
-      } catch {
-        el.textContent = 'Slack · Email · PagerDuty · Telegram';
-      }
-    } else {
-      el.textContent = 'Slack · Discord · Webhook (direct)';
-    }
-  }
-
-  // ── Public API ────────────────────────────────────────────────────────────
+  // ── Action handlers (paywall-aware) ───────────────────────────────────────
 
   window.alertsHandleNewRule = function () {
+    // Gate on click (not on Save): the banner that used to explain the trial
+    // is gone, so Free / no-cloud users need an explicit prompt that this is
+    // a Pro feature before they start filling out a form they can't save.
+    // Trial + Pro users skip the paywall and get the editor directly.
     if (alertsState.tier !== 'pro' && alertsState.tier !== 'trial') {
       return openPaywall();
     }
@@ -341,12 +332,19 @@
     openEditor();
   };
 
-  window.alertsHandleEditRule = function (ruleId) {
+  window.alertsHandleEdit = function (ruleId) {
+    // Look up either a real rule (Pro tier) or a canned example (Free/OSS).
+    let rule = alertsState.rules.find(r => r.id === ruleId);
+    if (!rule) {
+      rule = EXAMPLE_RULES.find(r => r.id === ruleId);
+    }
+    if (!rule) return;
+    // Issue #1603: the editor modal DOM is server-side gated to Pro users
+    // so Free users get the upsell here instead of a null-deref on
+    // ``alerts-editor-modal``. Matches the alertsHandleNewRule gate above.
     if (alertsState.tier !== 'pro' && alertsState.tier !== 'trial') {
       return openPaywall();
     }
-    var rule = alertsState.rules.find(function(r) { return r.id === ruleId; });
-    if (!rule) return;
     alertsState.editorRule = rule;
     alertsState.editorType = rule.alert_type;
     openEditor();
@@ -357,9 +355,9 @@
       // Pro/trial: full cloud channel management (PagerDuty, email, on-call)
       window.open('https://app.clawmetry.com/cloud#channels', '_blank');
     } else {
-      // OSS/free: open the Budget & Alerts modal on the "Alert Rules" tab where
-      // Slack/Discord direct-webhook config lives. Cloud-routed channels
-      // (PagerDuty, email, on-call) remain Pro-only.
+      // OSS/free (#1885, closes #590): open the Budget & Alerts modal on the
+      // "Alert Rules" tab where Slack/Discord direct-webhook config lives.
+      // Cloud-routed channels (PagerDuty, email, on-call) remain Pro-only.
       openBudgetModal();
       var alertsTab = document.querySelector('#budget-modal-tabs .modal-tab:nth-child(2)');
       switchBudgetTab('alerts', alertsTab);
@@ -399,102 +397,260 @@
       }
       let resp;
       if (isExample && newEnabled) {
-        // POST to /api/alerts/rules to create a real rule from the example template
-        const body = {
-          name: ex.name,
-          alert_type: ex.alert_type,
-          threshold: ex.threshold,
-          enabled: true,
-        };
-        resp = await fetch('/api/alerts/rules', {
+        resp = await fetch('/api/cloud-proxy/api/alerts', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
+          body: JSON.stringify({
+            alert_type: ex.alert_type,
+            name: ex.name,
+            threshold_value: ex.threshold_value,
+            threshold_unit: ex.threshold_unit || '',
+            enabled: true,
+            channel_ids: [],
+            re_alert_policy: 'once',
+          }),
         });
-        if (resp.ok) {
-          const created = await resp.json();
-          const newRule = {
-            id: 'pending-' + Date.now(),
-            ...body,
-            ...created,
-          };
-          alertsState.rules = [...alertsState.rules, newRule];
-          renderRules();
-          // Reload after short delay to get real server id
-          setTimeout(function() {
-            fetchRules().then(renderRules);
-          }, 800);
-        }
-        return;
+      } else {
+        resp = await fetch('/api/cloud-proxy/api/alerts/' + ruleId, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled: newEnabled }),
+        });
       }
-      resp = await fetch('/api/alerts/rules/' + ruleId, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ enabled: newEnabled }),
-      });
-      if (resp.ok) {
-        var rule = alertsState.rules.find(function(r) { return r.id === ruleId; });
-        if (rule) rule.enabled = newEnabled;
-        renderRules();
+      if (resp.status === 402) {
+        // Hit the Free-tier cap server-side
+        return openPaywall();
       }
-    } catch(e) {
-      console.error('alertsToggleRule error', e);
-    }
-  };
-
-  window.alertsDeleteRule = async function (ruleId) {
-    if (!confirm('Delete this alert rule?')) return;
-    try {
-      await fetch('/api/alerts/rules/' + ruleId, { method: 'DELETE' });
-      alertsState.rules = alertsState.rules.filter(function(r) { return r.id !== ruleId; });
+      if (!resp.ok) throw new Error('toggle failed: HTTP ' + resp.status);
+      // Optimistic update: the cloud cache warms a few seconds behind the
+      // write (daemon heartbeat cache_push), so reflect the new state locally
+      // and re-render NOW so the switch flips instantly; the delayed reloads
+      // then reconcile against the warmed cache.
+      if (ex && newEnabled && !alertsState.rules.find(r => r.alert_type === ex.alert_type)) {
+        alertsState.rules.push({
+          id: 'pending-' + ruleId, alert_type: ex.alert_type, name: ex.name,
+          threshold_value: ex.threshold_value, threshold_unit: ex.threshold_unit || '',
+          enabled: true, channel_ids: [],
+        });
+      } else {
+        const r = alertsState.rules.find(x => x.id === ruleId);
+        if (r) r.enabled = newEnabled;
+      }
       renderRules();
-    } catch(e) {
-      console.error('alertsDeleteRule error', e);
+      setTimeout(function () { window.loadAlertsPage(); }, 2500);
+      setTimeout(function () { window.loadAlertsPage(); }, 6000);
+    } catch (e) {
+      console.warn(e);
     }
   };
 
-  window.alertsSaveRule = async function () {
-    if (alertsState.tier !== 'pro' && alertsState.tier !== 'trial') return;
-    var type = alertsState.editorType;
-    var thresholdEl = document.getElementById('ae-threshold');
-    var threshold = thresholdEl ? parseFloat(thresholdEl.value) : null;
-    var channelEls = document.querySelectorAll('#alerts-editor-channels input[type="checkbox"]:checked');
-    var channelIds = Array.from(channelEls).map(function(el) { return el.value; });
-    var rule = alertsState.editorRule;
-    var reEl = document.querySelector('input[name="alerts-re"]:checked');
-    var reAlert = reEl ? reEl.value : 'once';
-    var body = {
-      alert_type: type,
-      threshold: threshold,
-      channel_ids: channelIds,
-      re_alert: reAlert,
-      enabled: true,
-    };
-    if (rule && rule.id) body.id = rule.id;
-    try {
-      var method = (rule && rule.id) ? 'PUT' : 'POST';
-      var url = (rule && rule.id) ? ('/api/alerts/rules/' + rule.id) : '/api/alerts/rules';
-      var resp = await fetch(url, {
-        method: method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      if (resp.ok) {
-        window.alertsCloseEditor();
-        await fetchRules();
-        renderRules();
-      }
-    } catch(e) {
-      console.error('alertsSaveRule error', e);
-    }
-  };
+  // ── Paywall modal ─────────────────────────────────────────────────────────
 
-  // ── Boot ──────────────────────────────────────────────────────────────────
-  // Defer until DOMContentLoaded so the template elements exist.
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
+  // Issue #1717: the alerts modal nodes are templated inside #zoom-wrapper,
+  // which gets `transform: scale(currentZoom)` applied unconditionally by
+  // app.js applyZoom() at boot — even when currentZoom === 1. Any non-`none`
+  // transform creates a containing block for descendants with `position:
+  // fixed`, so `inset: 0` no longer means viewport — it means the wrapper.
+  // Result: the modal renders pinned to the wrapper's top-left (which
+  // scrolls with the page) instead of centered in the viewport. Reparent
+  // the modal to <body> on first open to escape the transform.
+  function detachModalToBody(modalId) {
+    const modal = document.getElementById(modalId);
+    if (modal && modal.parentNode !== document.body) {
+      document.body.appendChild(modal);
+    }
+    return modal;
   }
 
-}());
+  function openPaywall() {
+    const modal = detachModalToBody('alerts-paywall-modal');
+    const title = document.getElementById('alerts-paywall-title');
+    const body  = document.getElementById('alerts-paywall-body');
+    const cta   = document.getElementById('alerts-paywall-cta');
+    if (alertsState.tier === 'none') {
+      title.textContent = 'Sign up for ClawMetry Cloud';
+      body.textContent  = 'Alerts need the cloud to deliver Slack / PagerDuty / Telegram / Email messages. Sign up — your data stays encrypted, Pro features include a 7-day free trial.';
+      cta.textContent   = 'Sign up for Cloud';
+      cta.dataset.action = 'signup';
+    } else {
+      title.textContent = 'Upgrade to ClawMetry Pro';
+      body.textContent  = 'Free plan allows 1 enabled alert. Upgrade to Pro for unlimited alerts, multi-channel delivery to Slack / PagerDuty / Telegram / Email, and 90-day alert history.';
+      cta.textContent   = 'Start 7-day free trial';
+      cta.dataset.action = 'upgrade';
+    }
+    modal.style.display = 'flex';
+  }
+
+  window.alertsClosePaywall = function (e) {
+    if (e && e.target.id !== 'alerts-paywall-modal') return;
+    document.getElementById('alerts-paywall-modal').style.display = 'none';
+  };
+
+  window.alertsCtaClick = function () {
+    const cta = document.getElementById('alerts-paywall-cta');
+    if (cta.dataset.action === 'signup' && typeof openCloudModal === 'function') {
+      window.alertsClosePaywall();
+      openCloudModal();
+    } else {
+      window.open('https://app.clawmetry.com/pricing', '_blank');
+    }
+  };
+
+  // ── Editor modal (Pro tier) ───────────────────────────────────────────────
+
+  function openEditor() {
+    // See detachModalToBody() above re: #zoom-wrapper transform / issue #1717.
+    const modal = detachModalToBody('alerts-editor-modal');
+    if (!modal) return; // editor markup only renders for Pro (is_pro)
+    modal.style.display = 'flex';
+    document.getElementById('alerts-editor-title').textContent =
+      alertsState.editorRule ? 'Edit alert rule' : 'New alert rule';
+    setActiveType(alertsState.editorType);
+    renderEditorForm();
+    renderEditorChannels();
+    setEditorReAlert(alertsState.editorRule?.re_alert_policy || 'once');
+  }
+
+  window.alertsCloseEditor = function (e) {
+    if (e && e.target.id !== 'alerts-editor-modal') return;
+    document.getElementById('alerts-editor-modal').style.display = 'none';
+  };
+
+  window.alertsPickType = function (type) {
+    alertsState.editorType = type;
+    setActiveType(type);
+    renderEditorForm();
+  };
+
+  function setActiveType(type) {
+    document.querySelectorAll('#alerts-type-seg button').forEach(b => {
+      b.classList.toggle('active', b.dataset.type === type);
+    });
+  }
+
+  function renderEditorForm() {
+    const t = alertsState.editorType;
+    const r = alertsState.editorRule || {};
+    const presets = {
+      daily_spend:    { unit: 'USD',         placeholder: 50,    label: 'Daily spend exceeds', name: 'Daily spend cap' },
+      session_cost:   { unit: 'USD',         placeholder: 5,     label: 'Single session cost exceeds', name: 'Session cost cap' },
+      node_offline:   { unit: 'min',         placeholder: 10,    label: 'Agent has been offline for more than', name: 'Agent offline' },
+      token_velocity: { unit: 'tokens/min',  placeholder: 10000, label: 'Token velocity exceeds', name: 'Runaway session' },
+      cron_failure:   { unit: 'fails',       placeholder: 3,     label: 'Cron has failed in a row at least', name: 'Cron failure streak' },
+      error_rate:     { unit: '%',           placeholder: 20,    label: 'Tool failure rate exceeds', name: 'Tool failures' },
+    };
+    const p = presets[t] || { unit: '', placeholder: 0, label: 'Threshold', name: 'Custom alert' };
+    const val = r.threshold_value ?? p.placeholder;
+    document.getElementById('alerts-editor-form').innerHTML = `
+      <div class="alerts-form-row">
+        <label>Name</label>
+        <input type="text" id="alerts-rule-name" value="${escape(r.name || p.name)}" />
+      </div>
+      <div class="alerts-form-row">
+        <label>${p.label}</label>
+        <input type="number" id="alerts-rule-threshold" value="${val}" step="any" style="width:120px;" />
+        <span class="alerts-form-unit">${p.unit}</span>
+      </div>
+    `;
+  }
+
+  function renderEditorChannels() {
+    const wrap = document.getElementById('alerts-editor-channels');
+    if (!alertsState.channels.length) {
+      wrap.innerHTML = '<div class="alerts-loading">No channels yet — add one below.</div>';
+      return;
+    }
+    const selected = new Set(alertsState.editorRule?.channel_ids || []);
+    wrap.innerHTML = alertsState.channels.map(ch => `
+      <label class="alerts-chan-check">
+        <input type="checkbox" data-channel-id="${ch.id}" ${selected.has(ch.id) ? 'checked' : ''} />
+        <span class="name">${chTypeIcon(ch.channel_type)} ${chTypeLabel(ch.channel_type)}</span>
+        <span class="dest">${escape(ch.name)}</span>
+      </label>
+    `).join('');
+  }
+
+  function setEditorReAlert(policy) {
+    document.querySelectorAll('input[name="alerts-re"]').forEach(r => {
+      r.checked = (r.value === policy);
+    });
+  }
+
+  window.alertsSaveRule = async function () {
+    const name = document.getElementById('alerts-rule-name').value.trim();
+    const threshold = parseFloat(document.getElementById('alerts-rule-threshold').value);
+    if (!name || isNaN(threshold)) return;
+    const channelIds = [...document.querySelectorAll('#alerts-editor-channels input:checked')]
+      .map(i => i.dataset.channelId);
+    const policy = document.querySelector('input[name="alerts-re"]:checked')?.value || 'once';
+
+    // Editing a canned example or saving on a non-Pro tier: fire the paywall
+    // here, AFTER the user has configured the rule. They're more invested by
+    // this point -- better conversion than gating on first click.
+    const editingExample = alertsState.editorRule
+      && String(alertsState.editorRule.id || '').startsWith('example_');
+    if (editingExample || (alertsState.tier !== 'pro' && alertsState.tier !== 'trial')) {
+      window.alertsCloseEditor();
+      return openPaywall();
+    }
+
+    const body = {
+      alert_type: alertsState.editorType,
+      name,
+      threshold_value: threshold,
+      enabled: true,
+      channel_ids: channelIds,
+      re_alert_policy: policy,
+    };
+
+    const isEdit = !!alertsState.editorRule;
+    const url = isEdit
+      ? '/api/cloud-proxy/api/alerts/' + alertsState.editorRule.id
+      : '/api/cloud-proxy/api/alerts';
+    const method = isEdit ? 'PUT' : 'POST';
+
+    const resp = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (resp.status === 402) {
+      window.alertsCloseEditor();
+      return openPaywall();
+    }
+    if (!resp.ok) {
+      console.warn('save failed', resp.status, await resp.text());
+      return;
+    }
+    window.alertsCloseEditor();
+    window.loadAlertsPage();
+  };
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  function chTypeIcon(type) {
+    return ({ slack: '💬', email: '✉️', pagerduty: '📟', telegram: '✈️', phone: '📞' })[type] || '🔔';
+  }
+  function chTypeLabel(type) {
+    return ({ slack: 'Slack', email: 'Email', pagerduty: 'PagerDuty', telegram: 'Telegram', phone: 'Phone' })[type] || type;
+  }
+  function escape(s) {
+    if (s == null) return '';
+    return String(s).replace(/[&<>"']/g, c =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]
+    );
+  }
+  function formatTimeAgo(iso) {
+    if (!iso) return '';
+    try {
+      const ts = new Date(iso);
+      const sec = Math.floor((Date.now() - ts.getTime()) / 1000);
+      if (sec < 60) return 'just now';
+      if (sec < 3600) return Math.floor(sec / 60) + 'm ago';
+      if (sec < 86400) return Math.floor(sec / 3600) + 'h ago';
+      return Math.floor(sec / 86400) + 'd ago';
+    } catch {
+      return iso;
+    }
+  }
+})();


### PR DESCRIPTION
## Symptom

OSS Alerts tab on v0.12.286 shows a single greyed-out "Daily cost spike" teaser instead of the canonical 6 alert types as on/off toggles (Approvals pattern). Reported live by @vivekchand with screenshot.

## Root cause

PR **#1885** ("fix: open OSS webhook config from Alerts tab 'Manage channels' for non-Pro users") had a *one-block* stated scope — change one branch of `alertsHandleManageChannels` to open the Budget modal instead of the paywall. But the diff was actually **+333/-484**, rewriting `clawmetry/static/js/alerts.js` end-to-end and silently reverting 4 prior fixes:

| Reverted PR | What it shipped | What #1885 lost |
|---|---|---|
| **#1840** | "always show all alert types as toggles (Approvals pattern)" | Replaced with `EXAMPLE_RULES[0]` teaser — what the user is seeing |
| **#1847** | optimistic toggle preserves `pending-*` rules through cache lag | reconcile logic dropped |
| **#1851** | decrypt `rules_blob` with the real key | path simplified, robustness gone |
| **#1854** | flatten `condition_json` so toggle reflects saved rules | `Object.assign({}, r.condition_json \|\| {}, r)` dropped |

This is the "scope ≠ diff" pattern @vivekchand has called out before — sibling of the worktree-leak class (PR #270).

## Fix

Restore `alerts.js` to its pre-#1885 state (commit `7fac8c24`, which had all 4 fixes in) and **re-apply only #1885's intended one-block change**: the non-Pro branch of `alertsHandleManageChannels` opens `openBudgetModal()` + `switchBudgetTab('alerts', …)` instead of `openPaywall()`. Pro/trial branch unchanged.

## Verification

- `node -c clawmetry/static/js/alerts.js` ✅
- `Approvals-style` marker count = 1 (was 0 on broken HEAD).
- `one rule only` marker count = 0 (was 1 on broken HEAD).
- `openBudgetModal` reference present (intended #1885 patch in).
- Live alerts.js also copied to both `~/Library/Python/3.9/.../` AND `~/.clawmetry/lib/python3.11/.../` so a hard-refresh in @vivekchand's browser exercises the new code immediately.
- Post-merge: needs a `[RELEASE]` PR so the fix hits PyPI for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)