### PR TITLE
[RELEASE] restore Approvals-style alerts UI (carries #1944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- **Fixed:** Alerts tab on OSS shows the Approvals-style 6-toggle list again. PR #1885 had silently rewritten `alerts.js` end-to-end (+333/-484) while claiming a one-block scope, reverting #1840 / #1847 / #1851 / #1854. Restored the pre-#1885 file and re-applied only the intended Manage-channels patch. (#1944)
 
 ### Release: Self-Evolve accuracy fix + backlog (2026-05-23)
 - Publishes the Self-Evolve accuracy hardening (#1929 — no more false "broken/regression" findings from absence-of-usage) plus a merged backlog: OTel spans from JSONL (#1931), tabbed span-detail panel (#1936), /api/dives (#1932), config-drift badge (#1826), /api/component/mcp (#1827), runtime DuckDB fast-path (#1887), outcomes impact API (#1824), 503-banner wiring (#1825), alerts manage-channels (#1885), and CI/e2e hardening (#1850/#1886/#1888/#1889/#1891).


### PR DESCRIPTION
Bug-fix release carrying #1944.

**Why a release matters:** the alerts.js regression went out in v0.12.286 via PR #1885 — every OSS user on the current PyPI is seeing the broken single-teaser UI right now. Cutting v0.12.287 propagates the fix.

**Carries:** #1944 — restore alerts.js to pre-#1885 (which had #1840 / #1847 / #1851 / #1854 stacked in) and re-apply only #1885's intended Manage-channels block.

**Verified:** all 20/20 CI checks green on #1944; the live alerts.js was also copied to my install paths and confirmed mechanically correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)