### PR TITLE
fix(update): in-app 'Update now' was failing with 'No module named pip' on uv-provisioned venvs

### DIFF
--- a/routes/meta.py
+++ b/routes/meta.py
@@ -104,13 +104,39 @@ def api_update():
     import threading as _thr
 
     old_version = _d.__version__
+    py = sys.executable
+    # Bootstrap pip via the stdlib's ensurepip first. The daemon's venv at
+    # ~/.clawmetry/bin/python3 is provisioned WITHOUT pip by uv-style
+    # installers (uv venv defaults to --no-pip), so `python -m pip ...`
+    # exits 1 with "No module named pip" — which the banner used to surface
+    # as just "Command [...] returned non-zero exit status 1." with no
+    # actionable detail (stderr was piped to DEVNULL). ensurepip is in the
+    # stdlib, idempotent if pip already exists, and cheap. Burned 2026-05-23.
     try:
-        _sp.check_call(
-            [sys.executable, "-m", "pip", "install", "--upgrade", "clawmetry"],
-            timeout=120,
-            stdout=_sp.DEVNULL,
-            stderr=_sp.STDOUT,
+        _sp.run(
+            [py, "-m", "ensurepip", "--upgrade", "--default-pip"],
+            timeout=60, capture_output=True,
         )
+    except Exception:
+        # If ensurepip itself isn't available the pip call below will surface
+        # a real error message via capture_output, which we now return verbatim.
+        pass
+    try:
+        proc = _sp.run(
+            # --no-cache-dir dodges the uv-cache-stale-after-[RELEASE] race
+            # (see feedback_uv_cache_stale_after_release.md): a fresh PyPI
+            # publish is sometimes shadowed by uv's "already at latest" cache.
+            [py, "-m", "pip", "install", "--upgrade", "--no-cache-dir", "clawmetry"],
+            timeout=180, capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            # Surface pip's actual last lines so the banner is actionable —
+            # the old code swallowed everything into DEVNULL.
+            tail = ((proc.stdout or "") + (proc.stderr or "")).strip()[-800:]
+            return {"ok": False,
+                    "error": f"pip exit {proc.returncode}: {tail or '(no output)'}"}, 500
+    except _sp.TimeoutExpired:
+        return {"ok": False, "error": "pip install timed out after 180s"}, 500
     except Exception as exc:
         return {"ok": False, "error": str(exc)}, 500
     # Re-read new version from pip metadata


### PR DESCRIPTION
## Symptom

The in-app "Update now" banner on v0.12.286→v0.12.287 (and any prior release) showed:

> Update failed: Command '[/Users/vivek/.clawmetry/bin/python3, -m, pip, install, --upgrade, clawmetry]' returned non-zero exit status 1.

…with no further detail. Reproduced live by @vivekchand.

## Root cause

Two bugs in `routes/meta.py::api_update`:

1. **`No module named pip` in the daemon venv.** The daemon's venv at `~/.clawmetry/bin/python3` is provisioned **without** pip by uv-style installers (`uv venv` defaults to `--no-pip`). The handler ran `python -m pip install --upgrade clawmetry` against that venv → exit 1 with `No module named pip`. Every user with the uv-bootstrapped install hits this.
2. **Real error was swallowed.** `subprocess.check_call(..., stdout=DEVNULL, stderr=STDOUT)` piped both streams to `DEVNULL`, so the user-visible message was just the bare `CalledProcessError` repr. No way to tell whether it was missing pip, network, PyPI propagation, or something else.

## Fix

- **Bootstrap pip via stdlib `ensurepip --upgrade --default-pip` first.** Idempotent; cheap if pip is already there; doesn't require network if the bundled wheel is present (it is).
- **Switch to `subprocess.run(... capture_output=True, text=True)`** and return the last ~800 chars of pip's combined output on failure, so the banner becomes actionable.
- **Add `--no-cache-dir`** to dodge the uv-cache-stale race right after a `[RELEASE]` merge (see `feedback_uv_cache_stale_after_release.md`).
- Tighten timeout handling with an explicit `TimeoutExpired` branch.

## Verification (live, on the actual failing machine)

```
$ /Users/vivek/.clawmetry/bin/python3 -m pip --version
# BEFORE FIX:
/Users/vivek/.clawmetry/bin/python3: No module named pip

$ /Users/vivek/.clawmetry/bin/python3 -m ensurepip --upgrade --default-pip
Successfully installed pip-24.0 setuptools-79.0.1

$ /Users/vivek/.clawmetry/bin/python3 -m pip install --upgrade --no-cache-dir clawmetry
Successfully installed clawmetry-0.12.287
```

`py_compile` ✅. Live fix-file copied to `~/.clawmetry/lib/python3.11/.../routes/meta.py` and `~/Library/Python/3.9/.../routes/meta.py` so the user's next click of "Update now" exercises the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)