### PR TITLE
fix(alerts): kill alert fatigue — '20576d ago', dup rows, internal helpers (#1954)

### DIFF
--- a/clawmetry/config.py
+++ b/clawmetry/config.py
@@ -52,10 +52,22 @@ _SHOW_INTERNAL_ENABLE_VALUES = frozenset({"1", "true", "yes", "on"})
 
 def is_clawmetry_internal_session(session_id) -> bool:
     """True for sessions ClawMetry spawns to invoke OpenClaw (clawmetry-fix,
-    clawmetry-selfevolve, clawmetry-mem-probe, …)."""
-    return bool(session_id) and str(session_id).startswith(
-        CLAWMETRY_INTERNAL_SESSION_PREFIX
-    )
+    clawmetry-selfevolve, clawmetry-mem-probe, …).
+
+    Matches both the bare id (``clawmetry-fix``) and the full OpenClaw
+    session-id form (``agent:main:explicit:clawmetry-fix``), where the base id
+    is the last ``:``-delimited segment. Without the segment check the full
+    form leaked into user-facing views: the cloud Embodied list showed it as a
+    ghost session with an empty transcript (cloud-side fix landed in #1063),
+    and ``_check_stuck_sessions`` fired nuisance stuck-session alerts for the
+    helpers themselves (#1954).
+    """
+    if not session_id:
+        return False
+    sid = str(session_id)
+    return sid.startswith(CLAWMETRY_INTERNAL_SESSION_PREFIX) or (
+        ":" + CLAWMETRY_INTERNAL_SESSION_PREFIX
+    ) in sid
 
 
 def hide_clawmetry_session(session_id) -> bool:

--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -1165,7 +1165,15 @@
   border-bottom: 1px solid var(--border-secondary); font-size: 13px;
 }
 .alerts-hist-row:last-child { border-bottom: 0; }
+.alerts-hist-row[title] { cursor: help; }
 .alerts-hist-time { color: var(--text-muted); font-size: 12px; }
+/* #1954: "× N" badge on consecutive identical alerts (dedupe collapse). */
+.alerts-hist-count {
+  display: inline-block; margin-left: 4px; padding: 1px 7px;
+  font-size: 11px; font-weight: 600; color: var(--text-muted);
+  background: rgba(255,255,255,0.06); border-radius: 9px;
+  font-variant-numeric: tabular-nums;
+}
 .sev-red   { color: var(--text-error); }
 .sev-amber { color: var(--text-warning); }
 .sev-green { color: var(--text-success); }

--- a/clawmetry/static/js/alerts.js
+++ b/clawmetry/static/js/alerts.js
@@ -282,20 +282,66 @@
     }).join('');
   }
 
+  // #1954: short one-line explanations for each alert type, shown as a hover
+  // tooltip on the history row so "what does stuck_session even mean" stops
+  // being a user question. Keys match the `type` / `payload.name` strings the
+  // evaluator writes.
+  const ALERT_TYPE_HINTS = {
+    stuck_session:    'A session went silent past the timeout — the agent likely stalled (no new events).',
+    token_velocity:   'Runaway-loop guard — tokens/min crossed your threshold (agent burning tokens in a loop).',
+    daily_spend:      'Daily spend crossed your budget.',
+    session_cost:     'A single session’s cost crossed your threshold.',
+    session_duration: 'A session ran longer than your threshold.',
+    node_offline:     'An agent node hasn’t pinged in longer than your threshold.',
+    cron_failure:     'A cron job failed more times than your threshold.',
+    error_rate:       'Tool error rate crossed your threshold.',
+    subagent_depth:   'Sub-agent nesting depth crossed your threshold.',
+  };
+  // Hide alerts older than this from the history view. Stops the list from
+  // accumulating forever; the user only cares about recent activity.
+  const ALERTS_HISTORY_MAX_AGE_MS = 3 * 86400 * 1000;
+
   function renderHistory() {
     const wrap = document.getElementById('alerts-history-list');
-    if (!alertsState.history.length) {
-      return renderHistoryEmpty('No alerts have fired yet.');
+    // #1954: filter ancient entries (>3d) so the list stays useful, then
+    // collapse runs of consecutive identical alerts (same type + same message)
+    // into a single row with a "× N" counter — kills the "5 identical
+    // token_velocity rows" fatigue without losing the signal that it fired.
+    const now = Date.now();
+    const fresh = (alertsState.history || []).filter(h => {
+      const ms = new Date(_alertsTsMs(h.fired_at)).getTime();
+      return !isFinite(ms) || (now - ms) <= ALERTS_HISTORY_MAX_AGE_MS;
+    });
+    if (!fresh.length) {
+      return renderHistoryEmpty('No alerts in the last 3 days.');
     }
-    wrap.innerHTML = alertsState.history.map(h => {
+    const grouped = [];
+    for (const h of fresh) {
+      const p = h.payload || {};
+      const key = (p.name || h.alert_id || '') + '|' + String(p.actual_value ?? '');
+      const last = grouped[grouped.length - 1];
+      if (last && last._key === key) {
+        last._count += 1;
+        last._latestFiredAt = h.fired_at;
+      } else {
+        grouped.push({ ...h, _key: key, _count: 1, _latestFiredAt: h.fired_at });
+      }
+    }
+    wrap.innerHTML = grouped.map(h => {
       const sev = h.resolved_at ? 'sev-green' : 'sev-red';
-      const dot = h.resolved_at ? '●' : '●';
+      const dot = '●';
       const payload = h.payload || {};
+      const typeName = payload.name || h.alert_id || '';
+      const hint = ALERT_TYPE_HINTS[typeName] || '';
+      const countBadge = h._count > 1
+        ? ` <span class="alerts-hist-count" title="Fired ${h._count} times in a row">× ${h._count}</span>`
+        : '';
+      const rowTitle = hint ? ` title="${escape(hint)}"` : '';
       return `
-        <div class="alerts-hist-row">
+        <div class="alerts-hist-row"${rowTitle}>
           <span class="${sev}">${dot}</span>
-          <span class="alerts-hist-time">${formatTimeAgo(h.fired_at)}</span>
-          <span class="alerts-hist-text"><b>${escape(payload.name || h.alert_id)}</b>
+          <span class="alerts-hist-time">${formatTimeAgo(h._latestFiredAt)}</span>
+          <span class="alerts-hist-text"><b>${escape(typeName)}</b>${countBadge}
             → ${escape(String(payload.actual_value ?? ''))} ${escape(payload.threshold_unit || '')}</span>
         </div>
       `;
@@ -640,17 +686,31 @@
       ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]
     );
   }
+  // #1954: `fired_at` from /api/alerts/history is epoch SECONDS (REAL column
+  // written by time.time()), but JS Date() treats a bare number as ms. Without
+  // this normalization every row rendered as "20576d ago" (epoch zero → now).
+  // Treat numbers below ~year 33658 as seconds and scale to ms. ISO strings
+  // and ms-scale numbers pass through unchanged.
+  function _alertsTsMs(v) {
+    if (typeof v === 'number') return v < 1e12 ? v * 1000 : v;
+    if (typeof v === 'string' && /^-?\d+(\.\d+)?$/.test(v)) {
+      const n = Number(v);
+      return n < 1e12 ? n * 1000 : n;
+    }
+    return v;
+  }
   function formatTimeAgo(iso) {
     if (!iso) return '';
     try {
-      const ts = new Date(iso);
-      const sec = Math.floor((Date.now() - ts.getTime()) / 1000);
+      const ms = new Date(_alertsTsMs(iso)).getTime();
+      if (!isFinite(ms)) return '';
+      const sec = Math.floor((Date.now() - ms) / 1000);
       if (sec < 60) return 'just now';
       if (sec < 3600) return Math.floor(sec / 60) + 'm ago';
       if (sec < 86400) return Math.floor(sec / 3600) + 'h ago';
       return Math.floor(sec / 86400) + 'd ago';
     } catch {
-      return iso;
+      return '';
     }
   }
 })();


### PR DESCRIPTION
Closes #1954. The Alerts tab's *Recent alert history* was unusable for a trial user — every row read \`20576d ago\`, runs of identical alerts stacked as separate rows, ClawMetry's own internal helper sessions fired stuck-session alerts they should never reach the user for, and there was no max age or explanation of what each alert type meant.

## Root causes
1. **\`20576d ago\`** — \`alerts.js#formatTimeAgo\` passes \`fired_at\` straight to \`new Date()\`, but \`fired_at\` from \`/api/alerts/history\` is **epoch SECONDS** (REAL column written by \`time.time()\`). \`new Date(<small number>)\` treats it as ms → year 1970 → ~20576 days from now. (The OSS legacy renderer in \`app.js#loadAlertHistory\` already multiplied by 1000; \`alerts.js\` didn't.)
2. **Internal helpers firing alerts** — \`_check_stuck_sessions\` calls \`hide_clawmetry_session(sid)\`, but \`is_clawmetry_internal_session\` only does \`startswith(\"clawmetry-\")\`. Gateway returns the session as \`agent:main:explicit:clawmetry-fix\` (full OpenClaw form) → prefix check misses it → alert fires for our own plumbing. Same root-cause class as the cloud Embodied ghost bug fixed in cloud#1063.
3. **No dedupe, no TTL, no tooltips.**

## Changes
- **\`config.py\`** — broaden \`is_clawmetry_internal_session\` to match the \`:clawmetry-\` segment in addition to the bare prefix. Now catches both forms uniformly across every caller (snapshot transcripts, stuck-session evaluator, brain feed, …).
- **\`alerts.js#formatTimeAgo\`** — detect epoch-seconds-as-number (\`n < 1e12\`) and scale to ms; ISO strings and ms-scale numbers pass through; falsy inputs return \`''\`.
- **\`alerts.js#renderHistory\`** — filter rows >3 days old; collapse runs of consecutive identical alerts into a single row with a "× N" badge; \`title\` tooltip on each row with a one-line explanation of \`stuck_session\` / \`token_velocity\` / \`daily_spend\` / etc.
- **\`dashboard.css\`** — small "× N" badge + \`cursor:help\` on tooltipped row.

## Verification
- 8 matcher cases: bare \`clawmetry-fix\` ✓, full \`agent:main:explicit:clawmetry-fix\` ✓, UUID ✓, empty/None ✓.
- 7 formatter cases: epoch-seconds → "just now"/"1m ago"/"2h ago"/"5d ago"; \`0\`/\`null\` → \`''\` (not "20576d ago"); ISO strings ✓.
- Carries through the daemon, so once released + cloud pin bumped the same fixes light up on app.clawmetry.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)