### PR TITLE
feat(transcripts): ChatGPT-style derived titles + UUID-as-sub-line renderer

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10324,12 +10324,25 @@ async function loadTranscripts() {
   try {
     var data = await fetch('/api/transcripts').then(r => r.json());
     var html = '';
+    // ChatGPT-style row: derived title on top (first user prompt, when the
+    // daemon shipped one in the snapshot), with the full session id demoted
+    // to a small muted sub-line. Falls back to t.name/"Untitled session" so
+    // older snapshots (before #1959) don't go blank. Looks-like-an-id detector
+    // catches the "name === sid" / "name === sid[:40]" cases the legacy
+    // endpoint emits.
+    var UUIDISH = /^[0-9a-f]{6,}([-_][0-9a-f]+)*$/i;
     data.transcripts.forEach(function(t) {
-      html += '<div class="transcript-item" onclick="viewTranscript(\'' + escHtml(t.id) + '\')">';
-      html += '<div><div class="transcript-name">' + escHtml(t.name) + '</div>';
-      html += '<div class="transcript-meta-row">';
+      var raw = String(t.id || '');
+      var titleSrc = (t.title && String(t.title).trim()) || (t.name && String(t.name).trim()) || '';
+      var looksLikeId = !titleSrc || titleSrc === raw || UUIDISH.test(titleSrc) || raw.indexOf(titleSrc) === 0;
+      var title = looksLikeId ? 'Untitled session' : titleSrc;
+      html += '<div class="transcript-item" onclick="viewTranscript(\'' + escHtml(raw) + '\')">';
+      html += '<div style="min-width:0;flex:1;">';
+      html += '<div class="transcript-name" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(title) + '</div>';
+      html += '<div class="transcript-meta-row" style="gap:10px;">';
+      html += '<span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--text-muted,#888);font-size:11px;" title="' + escHtml(raw) + '">' + escHtml(raw.slice(0, 8)) + '</span>';
       html += '<span>' + t.messages + ' messages</span>';
-      html += '<span>' + (t.size > 1024 ? (t.size/1024).toFixed(1) + ' KB' : t.size + ' B') + '</span>';
+      if (t.size > 0) html += '<span>' + (t.size > 1024 ? (t.size/1024).toFixed(1) + ' KB' : t.size + ' B') + '</span>';
       html += '<span>' + timeAgo(t.modified) + '</span>';
       html += '</div></div>';
       html += '<span style="color:#444;font-size:18px;">▸</span>';

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7652,6 +7652,58 @@ def _project_snapshot_messages(msgs):
     return out
 
 
+_TITLE_MAX_CHARS = 80
+
+
+def _derive_transcript_title(msgs):
+    """Return a ChatGPT-style title for the session from the first user message.
+
+    The transcript dict produced by ``_try_local_store_transcript`` normalises
+    both Anthropic-shape (``role: user``, ``content`` str or block list) and
+    OpenClaw v3 (``prompt.submitted`` events surfaced with ``role: user``).
+    We just need the first text we can extract from those user turns; anything
+    else (system/assistant/tool/error) is skipped. Stripped of leading/trailing
+    whitespace, collapsed-newlines, capped to ``_TITLE_MAX_CHARS`` with an
+    ellipsis when truncated. Returns ``""`` when nothing usable is found — the
+    renderer falls back to the legacy display label.
+    """
+    if not isinstance(msgs, (list, tuple)):
+        return ""
+    for m in msgs:
+        if not isinstance(m, dict):
+            continue
+        if m.get("role") != "user":
+            continue
+        c = m.get("content")
+        text = ""
+        if isinstance(c, str):
+            text = c
+        elif isinstance(c, list):
+            for block in c:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    t = block.get("text")
+                    if isinstance(t, str) and t.strip():
+                        text = t
+                        break
+                elif isinstance(block, str) and block.strip():
+                    text = block
+                    break
+        if not text:
+            # Some adapters write the prompt under a sibling key.
+            for fld in ("text", "prompt", "finalPromptText"):
+                v = m.get(fld)
+                if isinstance(v, str) and v.strip():
+                    text = v
+                    break
+        text = " ".join((text or "").split())  # collapse all whitespace runs
+        if not text:
+            continue
+        if len(text) > _TITLE_MAX_CHARS:
+            return text[: _TITLE_MAX_CHARS - 1].rstrip() + "…"
+        return text
+    return ""
+
+
 def _build_transcripts(limit_sessions=8, msg_cap=80, extra_sids=None):
     """Recent per-session transcripts for the cloud Embodied tab.
 
@@ -7701,6 +7753,17 @@ def _build_transcripts(limit_sessions=8, msg_cap=80, extra_sids=None):
                 t = None
             if t and t.get("messages"):
                 msgs = t["messages"]
+                # ChatGPT-style title: derive from the first user message on the
+                # FULL message list (before we cap to the last msg_cap turns —
+                # otherwise long sessions lose their title because the opening
+                # prompt got dropped). +~60 bytes per session in the snapshot;
+                # well under the field-bloat budget, see
+                # feedback_snapshot_transcript_field_bloat.md. Frontend falls
+                # back to t.name/sid when absent (old daemons / old snapshots).
+                try:
+                    title = _derive_transcript_title(msgs)
+                except Exception:
+                    title = ""
                 if len(msgs) > msg_cap:
                     t = dict(t)
                     msgs = msgs[-msg_cap:]
@@ -7713,6 +7776,8 @@ def _build_transcripts(limit_sessions=8, msg_cap=80, extra_sids=None):
                 # detail to a budgeted preview; the full detail stays on the
                 # local dashboard.
                 t["messages"] = _project_snapshot_messages(msgs)
+                if title:
+                    t["title"] = title
                 out[sid] = t
         return out
     except Exception as _e:


### PR DESCRIPTION
## What

The Session-replay (formerly Embodied) list rendered each row as just a raw UUID. Reported live by @vivekchand:

> can we have the name of the session or some context of the session to better understand what it is … ideally the session title if available like how chatgpt shows in left after full chat

Before / after row:

```
BEFORE                                       AFTER
─────────────────────────                    ─────────────────────────
6288f40a-f82c-47f4-90c3-3f1bfdc06e88         Refactor the embedding pipeline so we batch the calls
2 messages · 3.1 KB · 20h ago                6288f40a · 2 messages · 3.1 KB · 20h ago
```

## Changes

### `clawmetry/sync.py` — snapshot
`_build_transcripts` now derives a per-session **title** from the first user message and ships it on the transcript dict as `t["title"]`. Derived on the FULL message list (before `msg_cap` truncation — otherwise long sessions lose their opening prompt and title goes blank).

New module helper `_derive_transcript_title` handles:
- Anthropic-shape string `content` → use as-is
- Block-list `content` (`[{type:"text", text:"..."}]`) → first text block
- OpenClaw v3 aliases (`text`, `prompt`, `finalPromptText`)
- Skips non-user roles, collapses whitespace, caps at 80 chars with ellipsis, returns `""` on anything weird so the renderer can fall back gracefully.

**Snapshot-bloat safety:** ~60 bytes/session × 8 sessions ≈ 480 bytes total — well under the field-bloat budget (`feedback_snapshot_transcript_field_bloat.md` warns against per-MESSAGE bloat, per-SESSION metadata is fine).

### `clawmetry/static/js/app.js` — renderer
`loadTranscripts` now:
- Shows the derived title as the primary row text (`transcript-name`).
- Demotes the UUID to a muted short prefix (`<first-8-chars>`) on the meta line, full id in the tooltip.
- Falls back through `t.title → t.name → "Untitled session"`, detecting the legacy `name === sid[:40]` shape via uuid-ish regex + prefix-of-sid check, so old snapshots and old endpoints don't render as a hex blob.

## Out of scope (deferred)

The OSS `/api/transcripts` list endpoint (`_try_local_store_transcripts` + the JSONL fallback in `api_transcripts`) still emits `name = sid[:40]`. Doing per-session first-message lookups would be a 50-row N+1 hit on the local dashboard. Left as a follow-up — needs either a SQL CTE that extracts first-user-text per session, or a small batch helper. The renderer already handles the legacy shape gracefully so OSS users see "Untitled session" + a short id, not the raw UUID.

## Verification

- `py_compile sync.py` ✅ · `node -c app.js` ✅
- 8/8 unit cases pass for `_derive_transcript_title` (string content, block-list, skip-assistant, truncation, empty, OpenClaw "text" alias, None, non-list).
- Cloud follow-up will: update `cm-cloud-transcript` interceptor to prefer `t.title` and bump `clawmetry==<this-release>` in the cloud Dockerfile so app.clawmetry.com starts rendering titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)