### PR TITLE
perf(polling): gate background pollers + coalesce loadAll fan-out (#1969)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -719,9 +719,13 @@ async function checkOnboardingStatus() {
   }
 }
 
-// Poll every 5s while the banner is active. First check is fast (300ms)
-// so a returning user with an already-warm daemon barely sees the banner.
-_cmOnboardingTimer = setInterval(checkOnboardingStatus, 5000);
+// Poll every 15s while the banner is active (#1969: was 5s + ungated, which
+// kept hitting /api/heartbeat-status every 5s on every tab and while the
+// browser tab was hidden). First check is fast (300ms) so a returning user
+// with an already-warm daemon barely sees the banner; thereafter the gated
+// wrapper suspends the poll when the tab is hidden and the in-function
+// dismiss-on-first-heartbeat keeps the on-tab pollage short.
+_cmOnboardingTimer = visibilitySetInterval(checkOnboardingStatus, 15000);
 setTimeout(checkOnboardingStatus, 300);
 
 // === No-Agent-Detected Empty-State Banner ===================================
@@ -2285,7 +2289,18 @@ function renderOauthBanner(overview) {
   }
 }
 
+// #1969: coalesce concurrent + back-to-back loadAll() callers. Heartbeat-
+// landed handlers, connection-restored, switchTab('overview'), and the
+// periodic refresh interval can all fire within the same second; pre-fix
+// each one independently ran the /api/overview + 8 secondary fetch
+// fan-out, producing the "3× /api/overview in 1 second" burst.
+var _loadAllInFlight = null;
+var _loadAllLastFinishedMs = 0;
+var _LOADALL_COALESCE_MS = 2000;
 async function loadAll() {
+  if (_loadAllInFlight) return _loadAllInFlight;
+  if (Date.now() - _loadAllLastFinishedMs < _LOADALL_COALESCE_MS) return;
+  _loadAllInFlight = (async function () {
   try {
     // Render overview quickly; do not block on heavy usage aggregation.
     var overview = await fetchJsonWithTimeout('/api/overview', 3000);
@@ -2343,6 +2358,12 @@ async function loadAll() {
     document.getElementById('refresh-time').textContent = 'Load failed - retrying...';
     return false;
   }
+  })();
+  _loadAllInFlight.finally(function () {
+    _loadAllLastFinishedMs = Date.now();
+    _loadAllInFlight = null;
+  });
+  return _loadAllInFlight;
 }
 
 async function loadMiniWidgets(overview, usage) {
@@ -11017,7 +11038,14 @@ async function cmSyncInit() {
   el.style.display = 'block';
   window._cmSync.startedAt = Date.now();
   _cmSyncRender(prog, health);
-  window._cmSync.pollTimer = setInterval(_cmSyncTick, 2500);
+  // #1969: was setInterval(.., 2500) ungated -> fired /api/sync-progress AND
+  // /api/local/health every 2.5s on every tab and while hidden (24 reqs in a
+  // 25s window). Route through the visibility wrapper and slow to 15s; the
+  // banner self-dismisses via _cmSyncDismiss when sync verifies, so this
+  // bounds the cost to ~1 request-pair / 15s when active and 0 when hidden.
+  window._cmSync.pollTimer = (typeof visibilitySetInterval === 'function'
+    ? visibilitySetInterval
+    : setInterval)(_cmSyncTick, 15000);
 }
 setTimeout(function(){ try { cmSyncInit(); } catch (e) {} }, 800);
 

--- a/clawmetry/templates/tabs/approvals.html
+++ b/clawmetry/templates/tabs/approvals.html
@@ -741,8 +741,13 @@
     }
   });
 
-  /* ── Background badge poll ── */
+  /* ── Background badge poll ──
+     #1969: gate on document visibility too. Pre-fix, this fetched
+     /api/cloud/approvals every 10s on every tab AND while the browser tab
+     was hidden — pointless noise in the access log for a nav-badge count
+     nobody is watching when the window isn't focused. */
   setInterval(function(){
+    if (typeof document !== 'undefined' && document.hidden) return;
     var pg = document.getElementById('page-approvals');
     if (pg && pg.classList.contains('active')) return;
     fetchJsonWithTimeout('/api/cloud/approvals?status=pending&limit=10' + _q(), 4000)


### PR DESCRIPTION
Closes #1969.

Your dashboard's port-8900 access log captured a 25-second window with **/api/local/health × 13, /api/sync-progress × 12, /api/cloud/approvals × 5, /api/overview × 3 in a single second, /api/budget/status × 3** — all firing regardless of the active tab and while the browser tab was hidden. Exactly the request-storm the FLYWHEEL "Performance is a feature — and a cost" rule bans.

## Root causes (4 ungated/uncoalesced pollers, all predate PRD #1252)

| Poller | Pre-fix | Issue |
|---|---|---|
| \`_cmSyncTick\` (\`app.js#11020\`) | \`setInterval(.., 2500)\` ungated, **two endpoints/tick** | sync-progress + local/health every 2.5 s on every tab + while hidden = 24 reqs / 25 s |
| \`_cmOnboardingTimer\` (\`app.js#724\`) | \`setInterval(.., 5000)\` ungated | /api/heartbeat-status every 5 s on every tab + while hidden |
| Approvals badge poll (\`approvals.html#745\`) | \`setInterval(.., 10000)\` ungated | /api/cloud/approvals nav-badge every 10 s while hidden |
| \`loadAll()\` (\`app.js#2300\`) | No in-flight / recently-completed guard | Heartbeat-landed + connection-restored + switchTab + periodic interval stampede simultaneously → 3 × /api/overview in 1 s |

## Fix
- Route \`_cmSyncTick\` and \`_cmOnboardingTimer\` through the existing \`visibilitySetInterval\` wrapper (PRD #1252) and bump to 15 s. State doesn't change every 2.5 s; the banners still self-dismiss on the verified/heartbeat-landed state so on-tab time-to-clear is unchanged.
- Approvals badge poll: add \`document.hidden\` early-return.
- \`loadAll()\`: in-flight Promise reuse + 2 s recently-completed coalesce window. Concurrent callers share one Promise; immediate back-to-back callers within 2 s no-op.

## Verified
- Headless test: 3 concurrent \`loadAll()\` → **1 dispatch**; +1 immediate within 2 s → **0 new dispatch**; after 2 s → **1 new dispatch**. (Each dispatch = 2 fetches: /api/overview + /api/usage.)
- JS syntax clean.

## Expected effect (same 25 s window)
| Endpoint | Before | After (tab visible) | After (tab hidden) |
|---|---|---|---|
| /api/local/health | 13 | ≈ 2 | 0 |
| /api/sync-progress | 12 | ≈ 2 | 0 |
| /api/cloud/approvals | 5 | ≈ 2 | 0 |
| /api/overview | 3 (in 1 s burst) | 1 | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)