### PR TITLE
fix(llm-context): filter clawmetry-* sessions + OSS↔cloud parity for /api/overview

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5216,6 +5216,7 @@ class LocalStore:
         self,
         *,
         scan_sessions: int = 5,
+        exclude_clawmetry: bool = True,
     ) -> dict[str, Any]:
         """Peak context-window measurement for the latest active session.
 
@@ -5256,6 +5257,16 @@ class LocalStore:
         Args:
             scan_sessions: How many most-recent sessions to walk before
                 giving up. Matches the legacy file-scan budget of 5.
+            exclude_clawmetry: Skip sessions whose id starts with
+                ``clawmetry-`` (Self-Evolve, Fix-with-AI, memory probes,
+                …). Default True so the "Context Window Usage" gauge
+                reflects the *user's* agent, not ClawMetry's own
+                plumbing. Bug surfaced 2026-05-23: OSS showed a 204K
+                SelfEvolve context while cloud showed 38K for the user's
+                actual session, because OSS scanned whichever
+                clawmetry-* session ran most recently first. Pass False
+                to keep the legacy include-everything behaviour
+                (debug tooling).
         """
         # Step 1: most-recent N sessions ordered by last activity. The
         # session table has updated_at; we use events for the same answer
@@ -5267,6 +5278,10 @@ class LocalStore:
         # returned ``input_tokens=0`` and the dashboard's
         # /api/context-anatomy "Session history" bucket vanished.
         ev_in = _sql_in_clause(_ASSISTANT_EVENT_TYPES)
+        # Over-fetch when filtering so a burst of clawmetry-* plumbing
+        # sessions can't crowd the user's real session out of the scan
+        # budget. The post-filter still respects the caller's cap.
+        sql_limit = int(scan_sessions) * (4 if exclude_clawmetry else 1)
         recent_sessions = self._fetch(
             f"""
             SELECT session_id, MAX(ts) AS last_ts
@@ -5277,8 +5292,17 @@ class LocalStore:
             ORDER BY last_ts DESC
             LIMIT ?
             """,
-            [int(scan_sessions)],
+            [sql_limit],
         )
+        if exclude_clawmetry:
+            # Imported here to keep clawmetry.config off this module's
+            # import critical path (local_store is imported in the cloud
+            # too, where the env-var override semantics still apply).
+            from clawmetry.config import hide_clawmetry_session
+            recent_sessions = [
+                r for r in recent_sessions
+                if not hide_clawmetry_session(r[0])
+            ][: int(scan_sessions)]
         for sid_row in recent_sessions:
             sid, _last_ts = sid_row[0], sid_row[1]
             if not sid:

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -1903,7 +1903,7 @@ def api_automation_analysis():
         })
 
 
-def _try_local_store_session_history_tokens():
+def _try_local_store_session_history_tokens(exclude_clawmetry: bool = True):
     """Tier-1 DuckDB fast path for /api/context-anatomy session-history bucket.
 
     Replaces a 5-file × N-line JSONL scan (the single hottest blocking
@@ -1913,11 +1913,20 @@ def _try_local_store_session_history_tokens():
     behaviour exactly. Returns ``None`` to defer to the JSONL scanner if:
       * the daemon proxy isn't reachable AND direct open fails
       * the events table has no message events with non-zero usage yet
+
+    Args:
+        exclude_clawmetry: filter out ClawMetry-internal plumbing
+            sessions (clawmetry-selfevolve, clawmetry-fix, …). Default
+            True so the value drives a user-facing "context window
+            usage" gauge — see ``query_context_window_peek``.
     """
+    kwargs = {"scan_sessions": 5}
+    if not exclude_clawmetry:
+        kwargs["exclude_clawmetry"] = False
     result = None
     try:
         from routes.local_query import local_store_via_daemon
-        result = local_store_via_daemon("query_context_window_peek", scan_sessions=5)
+        result = local_store_via_daemon("query_context_window_peek", **kwargs)
     except Exception:
         result = None
     if result is None:
@@ -1926,7 +1935,7 @@ def _try_local_store_session_history_tokens():
         try:
             from clawmetry import local_store
             store = local_store.get_store(read_only=True)
-            result = store.query_context_window_peek(scan_sessions=5)
+            result = store.query_context_window_peek(**kwargs)
         except Exception:
             return None
     if not isinstance(result, dict):

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -780,6 +780,50 @@ def _compute_gateway_tap_comms() -> dict:
     return out
 
 
+# ── LLM Context Inspector parity helpers (issue: OSS↔cloud mismatch) ──────
+# The Context tab on OSS and on app.clawmetry.com used to disagree because
+# they computed Context Window Usage and Skills from different sources
+# (OSS hit /api/overview.mainTokens + /api/skills; cloud read the snapshot's
+# top-level mainTokens and had no /api/skills route → 410 Gone).
+# These two helpers compute the new shared fields (currentContextTokens,
+# skillHeaderTokens) that both /api/overview and the daemon snapshot now
+# expose so the Context tab reads one value on both sides.
+
+def _try_local_store_current_context_tokens():
+    """Live prompt size for the user's most-recent assistant turn.
+
+    Wraps ``routes.infra._try_local_store_session_history_tokens`` (which
+    in turn calls ``LocalStore.query_context_window_peek``) and pins
+    ``exclude_clawmetry=True`` so the gauge tracks the user's agent,
+    not ClawMetry-internal plumbing. Returns 0 when the local store is
+    cold or the daemon proxy can't be reached — the frontend then falls
+    back to mainTokens for backwards compatibility.
+    """
+    try:
+        from routes.infra import _try_local_store_session_history_tokens
+        v = _try_local_store_session_history_tokens(exclude_clawmetry=True)
+        return int(v or 0)
+    except Exception:
+        return 0
+
+
+def _compute_skill_header_tokens():
+    """Sum of header tokens for all installed skills.
+
+    Reuses ``routes.skills.compute_skills_payload`` (the same source
+    /api/skills serves) so OSS and the daemon snapshot agree on the
+    number rendered by the LLM Context Inspector's ``## Skills`` bar.
+    Returns 0 if the helper raises — we never fail the overview render
+    on a missing skill catalogue.
+    """
+    try:
+        from routes.skills import compute_skills_payload
+        payload = compute_skills_payload() or {}
+        return int((payload.get("summary") or {}).get("total_header_tokens") or 0)
+    except Exception:
+        return 0
+
+
 def _try_local_store_overview():
     """Epic #964: opt-in local-store fast path for /api/overview.
 
@@ -838,11 +882,25 @@ def _try_local_store_overview():
             "model": meta.get("model"),
         })
 
-    # Pick the most recent non-subagent session as the "main" session.
+    # Pick the user's main session — first non-subagent, non-ClawMetry-
+    # internal session in the most-recently-active-first order from
+    # query_sessions_table (`ORDER BY last_active_at DESC`).
+    #
+    # Without the ClawMetry filter OSS surfaced clawmetry-selfevolve /
+    # clawmetry-fix plumbing sessions as "main" — e.g. it reported the
+    # 204K cumulative tokens of a SelfEvolve run as the user's main
+    # session while the cloud snapshot (which already filters them at
+    # clawmetry/sync.py:9167) reported the real ~38K. Bug surfaced
+    # 2026-05-23.
+    from clawmetry.config import hide_clawmetry_session
     def _is_subagent(s):
         sid = (s.get("session_id") or "").lower()
         return "subagent" in sid or "sub-agent" in sid
-    main = next((s for s in sessions if not _is_subagent(s)), sessions[0])
+    def _is_user_main(s):
+        sid = s.get("session_id") or ""
+        return not _is_subagent(s) and not hide_clawmetry_session(sid)
+    user_sessions = [s for s in sessions if _is_user_main(s)]
+    main = user_sessions[0] if user_sessions else sessions[0]
 
     # Active = status=='active' (DuckDB persists status as a free-form string;
     # 'active' is what sync.py writes for in-progress sessions).
@@ -970,14 +1028,34 @@ def _try_local_store_overview():
     except Exception:
         infra["storage"] = "Disk"
 
+    # OSS/cloud parity: user-visible session count excludes sub-agents and
+    # ClawMetry-internal plumbing sessions so the OSS Overview matches the
+    # cloud snapshot's `sessionCount` (clawmetry/sync.py builds the same way).
+    user_session_count = len(user_sessions) if user_sessions else len(sessions)
+
+    # `currentContextTokens` is the right "Context Window Usage" gauge —
+    # the most recent assistant turn's input_tokens (i.e. live prompt
+    # size), filtered to exclude clawmetry-* plumbing sessions. Falls
+    # back to 0 so the frontend can degrade to mainTokens for backwards
+    # compatibility (older daemons without the snapshot field).
+    current_context_tokens = _try_local_store_current_context_tokens()
+
+    # `skillHeaderTokens` lets the LLM Context Inspector render the
+    # "## Skills" bar from the snapshot/overview without a separate
+    # /api/skills fetch (which is 410 Gone in cloud mode). Same source
+    # of truth on OSS and cloud.
+    skill_header_tokens = _compute_skill_header_tokens()
+
     return {
         "model": model_name,
         "provider": _d._infer_provider_from_model(model_name),
-        "sessionCount": len(sessions),
-        "sessions": len(sessions),  # alias for E2E compatibility
+        "sessionCount": user_session_count,
+        "sessions": user_session_count,  # alias for E2E compatibility
         "activeSessions": active_count,
         "mainSessionUpdated": main.get("last_active_at") or main.get("started_at"),
         "mainTokens": main.get("total_tokens", 0),
+        "currentContextTokens": current_context_tokens or 0,
+        "skillHeaderTokens": skill_header_tokens or 0,
         "contextWindow": 200000,
         "cronCount": len(crons),
         "cronEnabled": enabled,

--- a/tests/test_overview_local_store.py
+++ b/tests/test_overview_local_store.py
@@ -38,8 +38,23 @@ def overview_app(tmp_path, monkeypatch):
 
     import clawmetry.local_store as ls
     importlib.reload(ls)
+    # Hermetic isolation: on a dev machine the running sync daemon
+    # publishes ~/.clawmetry/local_query.json which trips
+    # `_daemon_registered()` and steers `get_store()` to a
+    # `_ProxyStore` that forwards into the *real* DuckDB. Force the
+    # writer-owner path so the fixture's tmp_path store gets opened
+    # in this process (matches the single-process boot semantics CI
+    # already runs under).
+    ls.mark_writer_owner()
     import routes.overview as ov
     importlib.reload(ov)
+    # Same fix on the routes side: the fast-path call goes through
+    # `local_store_via_daemon`, which would also hit the real
+    # daemon's HTTP proxy. Stub both discovery hooks so it falls
+    # through to the direct open via `get_store(read_only=True)`.
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    monkeypatch.setattr(lq, "_cached_discovery", lambda: None)
 
     a = Flask(__name__)
     a.register_blueprint(ov.bp_overview)
@@ -119,6 +134,7 @@ def test_overview_fast_path_returns_local_store_data(overview_app):
         "cost_usd": 1.7,
         "message_count": 30,
     })
+    _wait_flush(store)
 
     c = a.test_client()
     r = c.get("/api/overview")
@@ -159,6 +175,66 @@ def test_overview_fast_path_falls_back_when_store_empty(overview_app):
     # Fast path returned None → fell through to legacy gateway path, which
     # does NOT add the _source tag.
     assert body.get("_source") != "local_store"
+
+
+def test_overview_excludes_clawmetry_internal_sessions(overview_app):
+    """OSS↔cloud parity regression (2026-05-23).
+
+    Before the fix, /api/overview picked the most-recently-active
+    non-subagent session as ``main`` — but ClawMetry's own plumbing
+    sessions (``clawmetry-selfevolve``, ``clawmetry-fix``, …) qualified
+    and would crowd out the user's real agent. A ``clawmetry-selfevolve``
+    run with 204K cumulative tokens then flowed through ``mainTokens``
+    and the LLM Context Inspector showed "204K / 200K (100%)" even
+    though the user's actual session was idle. The cloud snapshot
+    already filtered them (clawmetry/sync.py:9167), so the two
+    dashboards disagreed.
+
+    This test pins the new filter: ``hide_clawmetry_session`` excludes
+    ``clawmetry-*`` sessions from both the main-session pick and the
+    user-facing ``sessionCount``.
+    """
+    a, ls = overview_app
+    store = ls.get_store()
+
+    # Plumbing session: most recent, biggest token count. MUST NOT win.
+    store.ingest_session({
+        "session_id": "clawmetry-selfevolve",
+        "agent_type": "openclaw",
+        "title": "SelfEvolve plumbing run",
+        "started_at": "2026-05-23T10:00:00+00:00",
+        "last_active_at": "2026-05-23T11:00:00+00:00",
+        "status": "active",
+        "total_tokens": 204476,
+        "metadata": {"model": "claude-opus-4-7"},
+    })
+    # User's real session: older, smaller. SHOULD win.
+    store.ingest_session({
+        "session_id": "sess-user-real",
+        "agent_type": "openclaw",
+        "title": "User's actual agent",
+        "started_at": "2026-05-23T08:00:00+00:00",
+        "last_active_at": "2026-05-23T09:00:00+00:00",
+        "status": "active",
+        "total_tokens": 37763,
+        "metadata": {"model": "claude-opus-4-7"},
+    })
+
+    body = a.test_client().get("/api/overview").get_json()
+    assert body.get("_source") == "local_store"
+    # mainTokens reflects the user's session, NOT the plumbing one.
+    assert body["mainTokens"] == 37763, (
+        f"clawmetry-* session leaked into mainTokens: {body['mainTokens']}"
+    )
+    # User-facing session count also excludes the plumbing entry.
+    assert body["sessionCount"] == 1, (
+        f"clawmetry-* session leaked into sessionCount: {body['sessionCount']}"
+    )
+    # New OSS↔cloud parity fields are always present (default 0).
+    assert "currentContextTokens" in body
+    assert "skillHeaderTokens" in body
+    assert isinstance(body["currentContextTokens"], int)
+    assert isinstance(body["skillHeaderTokens"], int)
 
 
 def test_overview_fast_path_disabled_without_flag(tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

Live bug from a user dashboard screenshot today: the LLM Context Inspector showed wildly different numbers on OSS vs cloud for the same node.

| Field | OSS `localhost:8900` | Cloud `app.clawmetry.com` |
|---|---|---|
| Context Window Usage | **204.5K / 200K (100%)** | 37.8K / 200K (19%) |
| Total Turns | 2 | 3 |
| ## Skills | 62 | 1.6K |
| Conversation history | 188.5K | 21.8K |

Reproduced live:
- `curl :8900/api/overview` → `mainTokens: 204476`, `sessionCount: 37`
- decrypted cloud system-snapshot → `mainTokens: 37763`, `sessionCount: 12`, `currentContextTokens: 0`, `skillHeaderTokens: 62` (new fields from #1956 — empty because of bug #1).

## Three root causes

1. **OSS `_try_local_store_overview` picked the wrong main session.** The picker excluded sub-agents but NOT ClawMetry's own plumbing sessions (`clawmetry-selfevolve`, `clawmetry-fix`, …). A 204K SelfEvolve run was the most-recently-active non-subagent session on the user's box, so it became "main" and its cumulative tokens flowed into `mainTokens`. The cloud snapshot already filtered them at `clawmetry/sync.py:9167` — that's why the two disagreed.
2. **`query_context_window_peek` didn't filter clawmetry-* either**, so the `currentContextTokens` snapshot field (added in #1956) reported a SelfEvolve reading too. Cloud showed `currentContextTokens: 0` only because the scan budget got crowded out by `clawmetry-*` sessions.
3. **`/api/overview.sessionCount` was unfiltered** (37) while the cloud snapshot already filtered (12) — minor but contributed to the "they don't match" feel.

## Changes

- **`clawmetry/local_store.py`**: `query_context_window_peek` gains `exclude_clawmetry=True` default. Over-fetches `scan_sessions*4` so a burst of plumbing rows can't crowd the user's real session out of the scan window, then post-filters via `hide_clawmetry_session()`. Pass `exclude_clawmetry=False` for debug tooling that wants the legacy behaviour.
- **`routes/overview.py:_try_local_store_overview`**:
  - filter `clawmetry-*` from the main-session pick (uses `hide_clawmetry_session`) and from `sessionCount`.
  - new response field **`currentContextTokens`** — live `input_tokens` from the latest assistant turn (the right value for "Context Window Usage", capped naturally at the model window; `mainTokens` was cumulative and exceeded 200K as soon as a session ran a couple of turns).
  - new response field **`skillHeaderTokens`** — sum of header tokens for installed skills, sourced from `compute_skills_payload()` so OSS and cloud match the same number.
- **`routes/infra.py`**: `_try_local_store_session_history_tokens` forwards the new `exclude_clawmetry` kwarg.
- **`tests/test_overview_local_store.py`**: regression test pins the filter (a 204K `clawmetry-selfevolve` session must NOT win as `main`) and asserts the two new response keys are always present.

The cloud snapshot/sync.py + frontend `app.js` halves of this fix landed earlier (#1956 carried them as a side dish in cloud-opt-out). This PR completes the OSS half so `/api/overview` and the cloud snapshot serve the same numbers for the Context Inspector.

## Verification done

- Reproduced the divergence by hitting `/api/overview` on `localhost:8900` and decrypting the live `app.clawmetry.com/api/cloud/system-snapshot` simultaneously.
- After the fix, the cloud snapshot (built by the daemon with new sync.py from #1956) already publishes `skillHeaderTokens: 62` matching OSS's `/api/skills`, confirming the snapshot side.
- The new regression test pins the filter in CI.
- Once merged + released + cloud-deployed, the OSS dashboard at `localhost:8900` will show the same `currentContextTokens` value as the cloud snapshot at `app.clawmetry.com`, both reflecting the user's actual agent rather than ClawMetry's plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)