### PR TITLE
feat(v2): add /v2/ops page — unified Overview + Crons + Logs

### DIFF
--- a/clawmetry/v2/routes.py
+++ b/clawmetry/v2/routes.py
@@ -15,7 +15,7 @@ Flask's static_folder dispatch automatically.
 
 from __future__ import annotations
 import os
-from flask import Blueprint, send_from_directory, abort
+from flask import Blueprint, send_from_directory, abort, jsonify
 
 # `static_folder` is resolved relative to this file. After `npm run build`
 # in `frontend/`, the bundle lives at `clawmetry/static/v2/dist/`.
@@ -72,3 +72,30 @@ def v2_catchall(path: str):
     if ".." in path.split("/"):
         abort(404)
     return _serve_index()
+
+@bp_v2.route("/api/v2/ops", methods=["GET"])
+def get_ops():
+    return jsonify({
+        "services": [
+            {"name": "Gateway controller", "status": "ok", "uptime": "14d", "bpm": 84, "latency": "44ms"},
+            {"name": "Session DB", "status": "ok", "uptime": "14d", "bpm": 62, "latency": "2ms"},
+            {"name": "Memory store", "status": "ok", "uptime": "14d", "bpm": 71, "latency": "1ms"},
+            {"name": "Telegram connector", "status": "ok", "uptime": "8d", "bpm": 92, "latency": "180ms"},
+            {"name": "WhatsApp connector", "status": "warn", "uptime": "32m", "bpm": 110, "latency": "440ms"},
+            {"name": "Discord connector", "status": "ok", "uptime": "8d", "bpm": 78, "latency": "92ms"},
+            {"name": "Cron manager", "status": "ok", "uptime": "14d", "bpm": 68, "latency": "—"},
+            {"name": "ClawMetry agent (NemoClaw)", "status": "ok", "uptime": "8d", "bpm": 56, "latency": "12ms"},
+        ],
+        "crons": [
+            {"id": "cron-1", "name": "morning-digest", "schedule": "0 8 * * *", "last_run": "ok · today 08:00", "next_run": "tomorrow 08:00", "status": "ok", "miss_count": 0},
+            {"id": "cron-2", "name": "weekly-rollup", "schedule": "0 17 * * fri", "last_run": "ok · fri 17:00", "next_run": "fri 17:00", "status": "ok", "miss_count": 0},
+            {"id": "cron-3", "name": "purge-old-sessions", "schedule": "0 3 * * *", "last_run": "missed · 6h ago", "next_run": "in 18h", "status": "miss", "miss_count": 1},
+            {"id": "cron-4", "name": "embed-docs", "schedule": "*/15 * * * *", "last_run": "ok · 4m ago", "next_run": "in 11m", "status": "ok", "miss_count": 0},
+            {"id": "cron-5", "name": "standup-poll", "schedule": "30 9 * * 1-5", "last_run": "ok · today 09:30", "next_run": "tomorrow 09:30", "status": "ok", "miss_count": 0},
+            {"id": "cron-6", "name": "billing-cron", "schedule": "0 0 1 * *", "last_run": "ok · Oct 1", "next_run": "Nov 1", "status": "ok", "miss_count": 0},
+            {"id": "cron-7", "name": "memory-compact", "schedule": "0 4 * * *", "last_run": "fail · today 04:00", "next_run": "in 20h", "status": "fail", "miss_count": 0},
+        ],
+        "incidents": [
+            {"service": "WhatsApp connector", "summary": "Reconnect storm · 7 retries in 32 min", "detail": "Last good message · 32m ago\nLikely cause · upstream rate limit", "severity": "warn"},
+        ],
+    })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,8 @@ import { Routes, Route } from "react-router-dom";
 import { Layout } from "./components/Layout";
 import { WelcomePage } from "./pages/WelcomePage";
 import { StubPage } from "./pages/StubPage";
-import { NAV_ITEMS } from "./components/nav";
+import { NAV_ITEMS } from "./components/nav"; 
+import { OpsPage } from "./pages/OpsPage";
 
 // All v2 routes live inside <Layout>, which renders the sidebar + topbar
 // chrome and an <Outlet /> for route content. Every NAV_ITEMS entry maps
@@ -13,7 +14,8 @@ export default function App() {
     <Routes>
       <Route path="/" element={<Layout />}>
         <Route index element={<WelcomePage />} />
-        {NAV_ITEMS.map((it) => (
+        <Route path="ops" element={<OpsPage />} />
+        {NAV_ITEMS.filter((it) => it.id !== "ops").map((it) => (
           <Route key={it.id} path={it.id} element={<StubPage slug={it.id} />} />
         ))}
         {/* SPA catch-all — unknown deep links land on the welcome page rather

--- a/frontend/src/pages/OpsPage.tsx
+++ b/frontend/src/pages/OpsPage.tsx
@@ -1,0 +1,225 @@
+import { useState, useEffect } from "react";
+
+interface Service {
+  name: string;
+  status: "ok" | "warn" | "fail";
+  uptime: string;
+  bpm: number;
+  latency: string;
+}
+
+interface CronJob {
+  id: string;
+  name: string;
+  schedule: string;
+  last_run: string;
+  next_run: string;
+  status: "ok" | "miss" | "fail";
+  miss_count: number;
+}
+
+interface Incident {
+  service: string;
+  summary: string;
+  detail: string;
+  severity: "warn" | "critical";
+}
+
+interface OpsData {
+  services: Service[];
+  crons: CronJob[];
+  incidents: Incident[];
+}
+
+const ECG_PATH =
+  "M0 14 L20 14 L24 6 L28 22 L32 14 L60 14 L64 8 L68 20 L72 14 L100 14 L104 4 L108 24 L112 14 L120 14";
+
+const UPCOMING = [
+  { t: "+11m", l: "embed-docs", c: "var(--moss)" },
+  { t: "+26m", l: "embed-docs", c: "var(--moss)" },
+  { t: "+1h 41m", l: "embed-docs", c: "var(--moss)" },
+  { t: "+3h 22m", l: "purge-old-sessions · retry", c: "var(--amber)" },
+  { t: "+5h 18m", l: "morning-digest", c: "var(--moss)" },
+];
+
+function statusColor(s: string): string {
+  if (s === "ok") return "var(--moss)";
+  if (s === "warn" || s === "miss") return "var(--amber)";
+  return "var(--claw-red)";
+}
+
+export function OpsPage() {
+  const [data, setData] = useState<OpsData | null>(null);
+
+  useEffect(() => {
+    fetch("/api/v2/ops")
+      .then((r) => r.json())
+      .then(setData)
+      .catch(console.error);
+  }, []);
+
+  if (!data) {
+    return (
+      <div style={{ padding: 40, color: "var(--ink-4)" }} className="mono">
+        Loading ops…
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+      <div style={{ flex: 1, display: "grid", gridTemplateRows: "auto 1fr", minHeight: 0 }}>
+
+        {/* ── Heartbeats — top row ── */}
+        <div style={{ padding: "20px 22px", borderBottom: "1px dashed var(--line)" }}>
+          <div className="caps" style={{ color: "var(--ink-4)", marginBottom: 10 }}>
+            Heartbeats · live · 1.4s sweep
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12 }}>
+            {data.services.map((s, i) => {
+              const c = statusColor(s.status);
+              return (
+                <div
+                  key={i}
+                  className="cm-card"
+                  style={{ padding: 12, borderLeftWidth: 3, borderLeftStyle: "solid", borderLeftColor: c }}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span style={{ fontSize: 12, fontWeight: 500, color: "var(--ink-2)" }}>{s.name}</span>
+                    <span className="cm-tag" style={{ color: c, borderColor: c, fontSize: 9 }}>
+                      {s.status.toUpperCase()}
+                    </span>
+                  </div>
+                  <svg className="cm-ecg" viewBox="0 0 120 28" style={{ width: "100%", height: 28, marginTop: 6 }}>
+                    <path d={ECG_PATH} fill="none" stroke={c} strokeWidth="1.4" />
+                  </svg>
+                  <div
+                    className="mono"
+                    style={{ fontSize: 10, color: "var(--ink-4)", display: "flex", justifyContent: "space-between", marginTop: 4 }}
+                  >
+                    <span>up {s.uptime}</span>
+                    <span>{s.bpm} bpm · {s.latency}</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* ── Cron board — bottom row, two columns ── */}
+        <div style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", minHeight: 0 }}>
+
+          {/* Left: Cron registry table */}
+          <div style={{ padding: 22, overflow: "auto" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 12 }}>
+              <div className="caps" style={{ color: "var(--ink-4)" }}>
+                Cron registry · {data.crons.length} jobs
+              </div>
+              <button className="cm-btn tiny">+ schedule</button>
+            </div>
+            <div className="cm-card" style={{ padding: 0, overflow: "hidden" }}>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1.4fr 1fr 1.4fr 1fr 60px",
+                  padding: "8px 14px",
+                  background: "var(--panel-2)",
+                  fontFamily: "var(--f-mono)",
+                  fontSize: 9,
+                  color: "var(--ink-4)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                }}
+              >
+                <span>name</span>
+                <span>cron</span>
+                <span>last run</span>
+                <span>next</span>
+                <span />
+              </div>
+              {data.crons.map((cr) => {
+                const c = statusColor(cr.status);
+                return (
+                  <div
+                    key={cr.id}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1.4fr 1fr 1.4fr 1fr 60px",
+                      padding: "10px 14px",
+                      borderTop: "1px dashed var(--line)",
+                      fontSize: 12,
+                      alignItems: "center",
+                      background: cr.status !== "ok" ? "var(--panel-2)" : "transparent",
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span style={{ width: 6, height: 6, borderRadius: "50%", background: c }} />
+                      <span style={{ color: "var(--ink-2)" }}>{cr.name}</span>
+                    </div>
+                    <span className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>{cr.schedule}</span>
+                    <span className="mono" style={{ fontSize: 11, color: c }}>{cr.last_run}</span>
+                    <span className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>{cr.next_run}</span>
+                    <button className="cm-btn tiny" style={{ padding: "2px 8px" }}>run</button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Right: Incident watch + upcoming + SSE stub */}
+          <div
+            style={{
+              borderLeft: "1px solid var(--line)",
+              padding: 22,
+              background: "var(--paper-deep)",
+              overflow: "auto",
+              display: "flex",
+              flexDirection: "column",
+              gap: 12,
+            }}
+          >
+            {data.incidents.map((inc, i) => (
+              <div key={i} className="cm-card" style={{ padding: 14, borderColor: statusColor(inc.severity) }}>
+                <div className="caps" style={{ color: statusColor(inc.severity) }}>
+                  Watch · {inc.service}
+                </div>
+                <div style={{ fontSize: 13, fontWeight: 500, marginTop: 2 }}>{inc.summary}</div>
+                <div className="mono" style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 6, lineHeight: 1.5 }}>
+                  {inc.detail.split("\n").map((line, j) => (
+                    <span key={j}>
+                      {line}
+                      {j < inc.detail.split("\n").length - 1 && <br />}
+                    </span>
+                  ))}
+                </div>
+                <button className="cm-btn tiny" style={{ marginTop: 10 }}>open runbook →</button>
+              </div>
+            ))}
+
+            <div className="cm-card" style={{ padding: 14 }}>
+              <div className="caps" style={{ color: "var(--ink-4)", marginBottom: 8 }}>
+                Upcoming · next 6h
+              </div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                {UPCOMING.map((u, i) => (
+                  <div key={i} style={{ display: "flex", alignItems: "center", gap: 10, padding: "4px 0", fontSize: 11 }}>
+                    <span className="mono" style={{ width: 60, color: "var(--ink-4)" }}>{u.t}</span>
+                    <span style={{ width: 6, height: 6, borderRadius: "50%", background: u.c }} />
+                    <span style={{ color: "var(--ink-2)" }}>{u.l}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="cm-card" style={{ padding: 14, background: "var(--panel-2)" }}>
+              <div className="mono" style={{ fontSize: 11, color: "var(--ink-3)" }}>
+                Live logs — connecting...
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -280,7 +280,13 @@
 @keyframes cm-trail { 0%{stroke-dashoffset:200} 100%{stroke-dashoffset:0} }
 
 .cm-blink { animation: cm-blink 1.4s infinite; }
-.cm-pulse { animation: cm-pulse 1.8s ease-in-out infinite; }
+.cm-pulse { animation: cm-pulse 1.8s ease-in-out infinite; } 
+
+.cm-ecg path {
+  stroke-dasharray: 200;
+  stroke-dashoffset: 200;
+  animation: cm-trail 1.4s linear infinite;
+}
 
 /* metaphor frame variants — wraps the featured dashboard */
 .metaphor-hood {


### PR DESCRIPTION
Closes #1510

## What

Ports the DashOps design handoff into the first v2 tab page — merging v1's Overview, Crons, and Logs into a single `/v2/ops` page.

## Changes

- **`clawmetry/v2/routes.py`** — added `GET /api/v2/ops` endpoint returning hardcoded sample data matching the Stage B typed contract (`services`, `crons`, `incidents`). Real data wiring is a follow-up.
- **`frontend/src/pages/OpsPage.tsx`** — new page component with:
  - Heartbeat grid (4-column, ECG sparklines with 1.4s `cm-trail` animation)
  - Cron registry table (miss/fail row highlighting)
  - Incident watch card + upcoming schedule sidebar
  - SSE log strip stub
- **`frontend/src/App.tsx`** — wired `/v2/ops` route to `OpsPage`
- **`frontend/src/styles.css`** — added `.cm-ecg` utility class for sparkline animation

All styling uses design tokens (`--moss`, `--amber`, `--claw-red`) and existing CSS classes (`cm-card`, `cm-btn`, `cm-tag`) — no inline magic colors.

## Verified locally

- `/api/v2/ops` returns valid JSON (8 services, 7 crons, 1 incident)
- `/v2/ops` renders all three sections correctly
- ECG sparklines animate at 1.4s
- Miss/fail cron rows highlighted
- Theme switching (light/mid/dark) works across all components

## Follow-ups

- Wire real data from `/api/health` + `/api/crons`
- Connect SSE log strip to `/sse/logs`
- Wire cron CRUD actions (+ schedule, run buttons)
- Derive upcoming schedule from live cron data