### PR TITLE
fix(brain): keep ClawMetry plumbing out of the cloud Brain feed (hide Self-Evolve + collapse stacked provenance)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3009,22 +3009,42 @@ function _provenancePillHtml(meta, bodyHtml) {
 // Detects the "Sender (untrusted metadata)" / "Conversation info ..." JSON
 // prefix that channel adapters prepend to user messages. Returns
 // { meta:{...}, body:"<remaining text>" } or null.
+//
+// Adapters STACK more than one such block — a Telegram user message arrives as
+//
+//     Conversation info (untrusted metadata):
+//     ```json { "chat_id": "telegram:…", "sender": "Vivek Chand", … } ```
+//     Sender (untrusted metadata):
+//     ```json { "label": "Vivek Chand (…)", "id": "…", "name": "Vivek Chand" } ```
+//     <real message body>
+//
+// We strip EVERY leading provenance block (not just the first) so the same
+// identity isn't echoed 2-3× under the pill. The pill summarises the first
+// (richest) block; later blocks are redundant with it and dropped entirely.
 function _parseProvenancePrefix(s) {
   if (!s || typeof s !== 'string') return null;
-  // Match: optional "<label> (untrusted metadata):" header, then a ```json
-  // block, then the rest is the real body. Header is optional because some
-  // payloads ship just the json fence at the top.
-  var m = s.match(/^(?:[^\n]*\(untrusted metadata\)[^\n]*\n)?\s*```json\s*([\s\S]*?)```\s*([\s\S]*)$/);
-  if (!m) return null;
-  try {
-    var meta = JSON.parse(m[1]);
-    if (!meta || typeof meta !== 'object') return null;
-    // Require at least one provenance-y key so we don't eat unrelated json.
-    if (meta.chat_id == null && meta.sender == null && meta.message_id == null) {
-      return null;
-    }
-    return { meta: meta, body: (m[2] || '').trim() };
-  } catch(e) { return null; }
+  var rest = s;
+  var firstMeta = null;
+  // One leading block: optional "<label> (untrusted metadata):" header, then a
+  // ```json fence. ``\n?`` swallows the newline between stacked blocks.
+  var blockRe = /^\s*([^\n]*\(untrusted metadata\)[^\n]*\n)?[ \t]*```json\s*([\s\S]*?)```[ \t]*\n?/;
+  while (true) {
+    var m = rest.match(blockRe);
+    if (!m) break;
+    var hadHeader = !!m[1];
+    var meta;
+    try { meta = JSON.parse(m[2]); } catch(e) { break; }
+    if (!meta || typeof meta !== 'object') break;
+    var looksProv = (meta.chat_id != null || meta.sender != null || meta.message_id != null);
+    // Without the "(untrusted metadata)" header we only strip a block that is
+    // clearly provenance, so a real ```json code block in the message body is
+    // never eaten. With the header the adapter already declared it plumbing.
+    if (!hadHeader && !looksProv) break;
+    if (firstMeta === null) firstMeta = meta;
+    rest = rest.slice(m[0].length);
+  }
+  if (firstMeta === null) return null;
+  return { meta: firstMeta, body: rest.trim() };
 }
 
 function renderBrainDetail(detail) {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5282,10 +5282,24 @@ def _rows_to_brain_events(rows: list) -> list:
 
     The OSS-local Brain tab uses ``routes/brain.py:_try_local_store_brain``
     which builds the display shape directly — that path is unchanged.
+
+    Helper-session filtering: ClawMetry's own sessions (``clawmetry-selfevolve``,
+    ``clawmetry-fix``, ``clawmetry-mem-probe`` …) are plumbing, not agent
+    activity. The OSS-local path drops them via ``hide_clawmetry_session``
+    (``routes/brain.py``); for a long time this cache-push path did NOT, so
+    Self-Evolve findings leaked into the cloud Brain feed even though they
+    were hidden locally. We mirror the local filter here so both surfaces
+    agree. (The user explicitly asked to keep Self-Evolve out of the feed.)
     """
+    try:
+        from clawmetry.config import hide_clawmetry_session
+    except Exception:
+        hide_clawmetry_session = lambda _sid: False  # noqa: E731 — never break the push
     out = []
     for r in rows or []:
         if not isinstance(r, dict):
+            continue
+        if hide_clawmetry_session(r.get("session_id")):
             continue
         data = r.get("data")
         enrich = _channel_enrichment_from_row(r)
@@ -5369,15 +5383,19 @@ def _build_brain_cache_pushes(config: dict) -> list:
         return []
     try:
         store = local_store.get_store(read_only=True)
-        rows = store.query_events(limit=BRAIN_CACHE_LIMIT)
+        # Fetch headroom: _rows_to_brain_events drops ClawMetry's own helper
+        # sessions (selfevolve/fix/…), so query extra rows to still land
+        # ~BRAIN_CACHE_LIMIT real events after filtering.
+        rows = store.query_events(limit=BRAIN_CACHE_LIMIT * 3)
     except Exception:
         return []
     if not rows:
         return []
-    # Same translation as routes/brain.py:_try_local_store_brain so the
-    # browser sees an identical event shape regardless of which path served
-    # the data (cache hit vs. relay subscribe vs. JSONL fallback).
-    events = _rows_to_brain_events(rows)
+    # Same translation as routes/brain.py:_try_local_store_brain (incl. the
+    # hide_clawmetry_session filter) so the browser sees an identical event
+    # shape AND set regardless of which path served the data (cache hit vs.
+    # relay subscribe vs. JSONL fallback).
+    events = _rows_to_brain_events(rows)[:BRAIN_CACHE_LIMIT]
     payload = {
         "events":  events,
         "count":   len(events),


### PR DESCRIPTION
## Why
After Diya (an OpenClaw node) went deaf for ~37h, the operator opened the cloud Brain feed expecting to see what happened — and instead got **Self-Evolve cost findings** ("most turns run on Opus, expected") plus **redundant sender JSON** buried under each message. Two distinct leaks, both fixed here.

### 1. Self-Evolve leaks into the *cloud* Brain feed (#3)
`_build_brain_cache_pushes` pushed `query_events()` straight to the cloud cache via `_rows_to_brain_events` **without** the `hide_clawmetry_session()` filter that the OSS-local path (`routes/brain.py:_try_local_store_brain`) applies. So `clawmetry-selfevolve` / `clawmetry-fix` helper sessions were hidden on the local dashboard but **leaked to cloud**. (The function's own comment even claimed "Same translation as routes/brain.py" — it wasn't.)

**Fix:** apply `hide_clawmetry_session` at the `_rows_to_brain_events` chokepoint (covers every caller) and fetch `3×` headroom in the cache-push query so the post-filter feed still lands ~50 events.

### 2. Stacked provenance blocks echo the sender as raw JSON (#5)
Channel adapters prepend **two** `(untrusted metadata)` JSON blocks to a user message: `Conversation info {chat_id, sender, timestamp, …}` then `Sender {label, id, name}`. `_parseProvenancePrefix` stripped only the **first**, so the second rendered as raw JSON in the body — echoing the sender that's *already shown in the provenance pill*.

**Fix:** strip **every** leading provenance block; the pill summarises the first (richest) one. A real ` ```json ` message body (no `untrusted metadata` header) is still never eaten.

## Verification (local)
- Provenance parser unit-tested over 4 shapes: stacked (real Telegram) → body `"how are you?"`, single block (back-comat), **real `{findings}` json body → NOT eaten**, plain text → null.
- `node --check app.js`, `py_compile sync.py`, `python -c "import dashboard"` all clean.

## Follow-ups (separate PRs, same incident)
- Connector-liveness alarm so ClawMetry actually *catches* a dead inbound poller (the keystone).
- Fix ClawMetry's own gateway WS-tap auth spam (44 MB of `token_mismatch` in `gateway.err.log`).

Both fixes ship in the OSS package; the cloud serves the new `app.js` via a pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)