### PR TITLE
feat(health): connector-liveness alarm — catch a channel going deaf

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -4363,6 +4363,95 @@ class LocalStore:
             })
         return result
 
+    # ── Connector liveness ("agent went deaf and nobody noticed") ────────
+    # An OpenClaw channel provider (Telegram/Signal/Slack/…) runs an inbound
+    # long-poll. When that poll wedges — a network stall, an aborted restart
+    # that times out — the agent silently stops RECEIVING messages while it
+    # keeps SENDING (scheduled crons fire fine), so from the outside nothing
+    # looks broken. That exact failure left a node deaf for ~37h with no
+    # alarm. The only on-disk evidence is diagnostic lines in gateway.log /
+    # gateway.err.log; the daemon (sync.sync_connector_health_from_logs)
+    # tails them and records each signal here so health.py and the cloud
+    # snapshot can raise a real "inbound silent for Nh" alert.
+    def ingest_connector_health(
+        self,
+        *,
+        node_id: str,
+        provider: str,
+        kind: str,
+        ts_iso: str,
+        raw: str = "",
+    ) -> None:
+        """Idempotently record one connector-health signal in ``events``.
+
+        ``kind`` is one of the healthy markers (``started`` / ``recovered``)
+        or the unhealthy ones (``stall`` / ``disconnect`` / ``wedged``).
+        Idempotent on a stable id derived from provider+kind+ts so re-tailing
+        the log (after a rotation/truncation rescan) never double-counts.
+        """
+        import hashlib
+        prov = (provider or "").lower().strip()
+        if not prov or not kind or not ts_iso:
+            return
+        ev_id = "connhealth-" + hashlib.sha1(
+            f"{prov}|{kind}|{ts_iso}|{(raw or '')[:80]}".encode("utf-8")
+        ).hexdigest()[:24]
+        payload = json.dumps({
+            "provider": prov,
+            "kind": kind,
+            "raw": (raw or "")[:300],
+        }).encode("utf-8")
+        with self._write_lock:
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO events
+                  (id, agent_type, node_id, agent_id, session_id, workspace_id,
+                   event_type, ts, data, cost_usd, token_count, model, created_at)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                [
+                    ev_id, "openclaw", node_id or "local", "main", None, None,
+                    "connector.health", ts_iso, payload, None, None, None,
+                    int(time.time() * 1000),
+                ],
+            )
+
+    def query_connector_health(self, since_hours: int = 24) -> list[dict[str, Any]]:
+        """Recent ``connector.health`` signals, newest first.
+
+        Returns ``[{provider, kind, ts, raw}, ...]`` over the last
+        ``since_hours``. Empty on any failure — callers degrade to an
+        'unknown' state and never crash. The classifier
+        (``routes/health.py:_connector_liveness``) turns this stream into a
+        per-channel ok/degraded/down verdict.
+        """
+        from datetime import datetime, timedelta, timezone
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(hours=int(since_hours))
+        ).isoformat()
+        rows = self._fetch(
+            "SELECT ts, data FROM events "
+            "WHERE event_type = 'connector.health' AND ts >= ? "
+            "ORDER BY ts DESC",
+            [cutoff],
+        )
+        decoded = _decode_data_blob_rows(rows, ["ts", "data"])
+        out: list[dict[str, Any]] = []
+        for r in decoded:
+            data = r.get("data") or {}
+            if not isinstance(data, dict):
+                continue
+            prov = str(data.get("provider") or "").lower().strip()
+            if not prov:
+                continue
+            out.append({
+                "provider": prov,
+                "kind": data.get("kind") or "",
+                "ts": r.get("ts") or "",
+                "raw": data.get("raw") or "",
+            })
+        return out
+
     def query_alert_rules(
         self,
         *,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10304,6 +10304,14 @@ def run_daemon() -> None:
                 )
                 tg = 0
 
+            # ── Connector liveness (incident: node deaf ~37h, no alarm) ──
+            # Tail both gateway logs for inbound-poll stall/disconnect/wedge
+            # signals so health.py can flag a channel that stopped receiving.
+            try:
+                sync_connector_health_from_logs(config, state, paths)
+            except Exception as _e_ch:
+                log.debug("connector-health tick error (non-fatal): %s", _e_ch)
+
             state["last_sync"] = datetime.now(timezone.utc).isoformat()
             # Audit fix (2026-05-17): force a synchronous local-store flush
             # BEFORE persisting the cursor state. Belt-and-suspenders to
@@ -10722,6 +10730,161 @@ def sync_telegram_from_gateway_log(
         return ingested
     except Exception as e:
         log.warning("telegram-gw-log: cycle failed: %s", e)
+        return 0
+
+
+# ── Connector liveness: detect a channel going deaf ──────────────────────────
+# Incident 2026-05-24: a Telegram inbound long-poll wedged (network stall →
+# aborted shutdown that timed out) and never restarted. The agent kept SENDING
+# (scheduled crons fired fine) but silently stopped RECEIVING for ~37h, and
+# nothing flagged it. The evidence was always there, split across two logs:
+#   gateway.log      [telegram] [default] starting provider            (healthy)
+#                    [health-monitor] [telegram:default] … (reason: disconnected)
+#   gateway.err.log  [telegram] Polling stall detected …               (unhealthy)
+#                    [telegram] [default] channel stop exceeded … abort (wedged)
+# We tail both and record each signal as a connector.health event so
+# routes/health.py can raise a real "inbound silent for Nh" alarm.
+_CONNECTOR_PROVIDERS = {
+    "telegram", "signal", "whatsapp", "discord", "slack", "irc", "imessage",
+    "webchat", "googlechat", "msteams", "matrix", "mattermost", "line",
+    "nostr", "twitch", "bluebubbles",
+}
+
+
+def parse_connector_health_line(line: str):
+    """Map one gateway-log line to ``(provider, kind, ts_utc_iso)`` or None.
+
+    ``kind`` ∈ healthy {``started``} / unhealthy {``stall``, ``wedged``,
+    ``disconnect``}. Cheap substring pre-filter first — only a handful of
+    lines per day match, so we skip the regex/parse for the other 99.99%.
+    """
+    if not line:
+        return None
+    if (
+        "starting provider" not in line
+        and "Polling stall detected" not in line
+        and "channel stop exceeded" not in line
+        and "(reason: disconnected)" not in line
+    ):
+        return None
+    import re as _re
+    mts = _re.match(r"(\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:?\d{2}))", line)
+    if not mts:
+        return None
+    try:
+        from datetime import datetime as _dt, timezone as _tz
+        ts_utc = (
+            _dt.fromisoformat(mts.group(1).replace("Z", "+00:00"))
+            .astimezone(_tz.utc)
+            .isoformat()
+        )
+    except Exception:
+        return None
+    # Provider lives in a bracket token: [telegram] or [telegram:default] or
+    # (for health-monitor lines) the SECOND bracket [telegram:default].
+    prov = None
+    for tok in _re.findall(r"\[([a-z0-9_]+)(?::[^\]]*)?\]", line.lower()):
+        if tok in _CONNECTOR_PROVIDERS:
+            prov = tok
+            break
+    if not prov:
+        return None
+    if "Polling stall detected" in line:
+        kind = "stall"
+    elif "channel stop exceeded" in line:
+        kind = "wedged"
+    elif "(reason: disconnected)" in line:
+        kind = "disconnect"
+    elif "starting provider" in line:
+        kind = "started"
+    else:
+        return None
+    return (prov, kind, ts_utc)
+
+
+def _connector_health_offset_key(log_path: str) -> str:
+    return f"connector_health::{os.path.abspath(log_path)}"
+
+
+def sync_connector_health_from_logs(
+    config: dict | None,
+    state: dict,
+    paths: dict | None = None,
+) -> int:
+    """Tail gateway.log + gateway.err.log for channel inbound-poll lifecycle
+    signals and ingest them as connector.health events. Byte-offset resume
+    per file (mirrors sync_telegram_from_gateway_log); idempotent ingest.
+    Best-effort — returns the number of signals ingested this cycle, 0 on any
+    failure (the daemon must never crash on telemetry plumbing).
+    """
+    try:
+        if paths and isinstance(paths, dict) and paths.get("logs_dir"):
+            logs_dir = str(paths["logs_dir"])
+        else:
+            logs_dir = os.path.join(_get_openclaw_dir(), "logs")
+        log_paths = [
+            os.path.join(logs_dir, "gateway.log"),
+            os.path.join(logs_dir, "gateway.err.log"),
+        ]
+        try:
+            from clawmetry import local_store as _ls
+            store = _ls.get_store()
+        except Exception as e:
+            log.warning("connector-health: local_store unavailable: %s", e)
+            return 0
+        node_id = (
+            (config or {}).get("node_id")
+            or os.environ.get("CLAWMETRY_NODE_ID")
+            or "local"
+        )
+        offsets = state.setdefault("last_log_offsets", {})
+        total = 0
+        for log_path in log_paths:
+            if not os.path.exists(log_path):
+                continue
+            key = _connector_health_offset_key(log_path)
+            prev_offset = int(offsets.get(key, 0) or 0)
+            try:
+                size = os.path.getsize(log_path)
+            except OSError:
+                continue
+            if size < prev_offset:
+                prev_offset = 0  # rotated/truncated — rescan (ingest idempotent)
+            if size == prev_offset:
+                continue
+            try:
+                with open(log_path, "rb") as fh:
+                    fh.seek(prev_offset)
+                    buf = fh.read()
+            except OSError as e:
+                log.warning("connector-health: read failed (%s): %s", log_path, e)
+                continue
+            text = buf.decode("utf-8", errors="ignore")
+            last_nl = text.rfind("\n")
+            if last_nl < 0:
+                continue
+            complete = text[: last_nl + 1]
+            new_offset = prev_offset + len(complete.encode("utf-8", errors="ignore"))
+            for raw_line in complete.splitlines():
+                parsed = parse_connector_health_line(raw_line)
+                if not parsed:
+                    continue
+                prov, kind, ts_utc = parsed
+                try:
+                    store.ingest_connector_health(
+                        node_id=node_id, provider=prov, kind=kind,
+                        ts_iso=ts_utc, raw=raw_line.strip(),
+                    )
+                except Exception as e:
+                    log.debug("connector-health: ingest failed: %s", e)
+                    continue
+                total += 1
+            offsets[key] = new_offset
+        if total:
+            log.info("connector-health: ingested %d signal(s)", total)
+        return total
+    except Exception as e:
+        log.warning("connector-health: cycle failed: %s", e)
         return 0
 
 

--- a/routes/health.py
+++ b/routes/health.py
@@ -1332,6 +1332,10 @@ def api_system_health():
             # so operators see whether the gateway WS tap is actually
             # writing Telegram/Signal/Slack/etc. messages to DuckDB.
             "channel_ingest": _channel_ingest_recent(),
+            # Connector liveness (incident 2026-05-24: a node went deaf for
+            # ~37h with no alarm). Per enabled channel: is the inbound poll
+            # alive? 'down' = stopped receiving messages — the one that bites.
+            "connector_liveness": _connector_liveness(),
             "_source": top_source,
         }
     )
@@ -1552,6 +1556,133 @@ def _channel_ingest_recent():
         })
     # Most-recently-active provider first.
     out.sort(key=lambda r: r.get("mins_ago") if r.get("mins_ago") is not None else 1e9)
+    return out
+
+
+# ── Connector liveness ("agent went deaf and nobody noticed") ───────────────
+# A channel went deaf for ~37h with no alarm (2026-05-24): the inbound
+# long-poll wedged but outbound (crons) kept working, so health stayed green.
+# The daemon now records connector.health signals (sync.sync_connector_health
+# _from_logs); here we turn them into a per-channel ok/degraded/down verdict.
+# 'down' is the verdict that would have caught it: most-recent signal is a
+# stall/disconnect/wedge, no recovery since, older than the grace window.
+_CONNECTOR_DOWN_MIN = 15          # unhealthy + no recovery this long ⇒ down
+_CONNECTOR_FLAP_WINDOW_MIN = 60   # window for counting repeated disconnects
+_CONNECTOR_FLAP_COUNT = 3         # this many disconnects/hr ⇒ degraded
+_CONNECTOR_HEALTHY = {"started", "recovered"}
+_CONNECTOR_UNHEALTHY = {"stall", "disconnect", "wedged"}
+
+
+def _enabled_channels_from_config():
+    """Channel providers explicitly enabled in openclaw.json
+    (``channels.<provider>.enabled == true``).
+
+    Empty on cloud or when no config is present — the cloud surface reads
+    liveness from the encrypted snapshot (built daemon-side where the config
+    lives), not from this local-filesystem read. Never raises.
+    """
+    import os as _os
+    import json as _json
+    candidates = []
+    env = _os.environ.get("CLAWMETRY_OPENCLAW_DIR") or _os.environ.get("OPENCLAW_HOME")
+    if env:
+        candidates.append(_os.path.join(env, "openclaw.json"))
+    candidates.append(_os.path.join(_os.path.expanduser("~"), ".openclaw", "openclaw.json"))
+    for p in candidates:
+        try:
+            if not _os.path.exists(p):
+                continue
+            with open(p, errors="ignore") as f:
+                cfg = _json.load(f)
+            chans = (cfg or {}).get("channels") or {}
+            return [
+                str(name).lower()
+                for name, c in chans.items()
+                if isinstance(c, dict) and c.get("enabled")
+            ]
+        except Exception:
+            continue
+    return []
+
+
+def _connector_liveness():
+    """Per-enabled-channel inbound-poll verdict for the System Health UI.
+
+    Returns ``[{provider, state, reason, mins_ago, last_kind}, ...]`` with
+    ``state`` ∈ ``down`` | ``degraded`` | ``unknown`` | ``ok`` (worst first).
+    Reads connector.health signals via the daemon proxy (DuckDB-first);
+    returns ``[]`` on any failure — never blocks /api/system-health.
+    """
+    enabled = _enabled_channels_from_config()
+    if not enabled:
+        return []
+    rows = None
+    try:
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_connector_health", since_hours=24)
+    except Exception:
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = store.query_connector_health(since_hours=24)
+        except Exception:
+            rows = []
+
+    by_prov: dict[str, list] = {}
+    for r in (rows or []):
+        if isinstance(r, dict) and r.get("provider"):
+            by_prov.setdefault(str(r["provider"]).lower(), []).append(r)
+
+    def _mins_since(ts):
+        try:
+            t = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+            return max(0, int((datetime.now(timezone.utc) - t).total_seconds() / 60))
+        except Exception:
+            return None
+
+    out = []
+    for prov in enabled:
+        sigs = by_prov.get(prov, [])  # newest-first (query orders DESC)
+        if not sigs:
+            out.append({
+                "provider": prov, "state": "unknown",
+                "reason": "no inbound-poll signals seen in the last 24h",
+                "mins_ago": None, "last_kind": None,
+            })
+            continue
+        latest = sigs[0]
+        latest_kind = latest.get("kind")
+        mins_ago = _mins_since(latest.get("ts"))
+        recent_bad = sum(
+            1 for s in sigs
+            if s.get("kind") in _CONNECTOR_UNHEALTHY
+            and (_mins_since(s.get("ts")) or 1e9) <= _CONNECTOR_FLAP_WINDOW_MIN
+        )
+        if latest_kind in _CONNECTOR_UNHEALTHY and (
+            mins_ago is None or mins_ago >= _CONNECTOR_DOWN_MIN
+        ):
+            state = "down"
+            reason = (
+                f"inbound poll {latest_kind} {mins_ago}m ago with no recovery "
+                f"since — this channel can no longer receive messages"
+            )
+        elif latest_kind in _CONNECTOR_UNHEALTHY:
+            state = "degraded"
+            reason = f"inbound poll {latest_kind} {mins_ago}m ago (watching for recovery)"
+        elif recent_bad >= _CONNECTOR_FLAP_COUNT:
+            state = "degraded"
+            reason = f"inbound poll flapping ({recent_bad} disconnects in the last hour)"
+        else:
+            state = "ok"
+            reason = f"inbound poll healthy (last signal: {latest_kind} {mins_ago}m ago)"
+        out.append({
+            "provider": prov, "state": state, "reason": reason,
+            "mins_ago": mins_ago, "last_kind": latest_kind,
+        })
+    order = {"down": 0, "degraded": 1, "unknown": 2, "ok": 3}
+    out.sort(key=lambda r: order.get(r["state"], 9))
     return out
 
 

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -446,6 +446,10 @@ _DAEMON_METHODS = frozenset({
     "query_channel_messages",
     "query_channel_threads",
     "query_channel_summary",
+    # Connector liveness (incident: node deaf ~37h, no alarm). health.py
+    # reads connector.health signals via the proxy to classify each enabled
+    # channel ok/degraded/down. Read-only; daemon owns the writer.
+    "query_connector_health",
     # Issue #1282: NeMoClaw approvals fast-path was opening DuckDB writable
     # in routes/nemoclaw.py — collided with the daemon's writer lock.
     # Routed through proxy so /api/nemoclaw/pending-approvals stays fast.

--- a/tests/test_connector_health.py
+++ b/tests/test_connector_health.py
@@ -1,0 +1,174 @@
+"""Tests for connector-liveness detection (incident 2026-05-24).
+
+Why this exists
+---------------
+A Telegram inbound long-poll wedged (network stall → aborted shutdown that
+timed out) and never restarted. The agent kept SENDING (scheduled crons
+fired) but silently stopped RECEIVING for ~37h, and ClawMetry showed green
+the whole time. The only evidence was diagnostic lines split across
+``gateway.log`` (``starting provider`` / ``health-monitor … reason:
+disconnected``) and ``gateway.err.log`` (``Polling stall detected`` /
+``channel stop exceeded … abort``).
+
+This module pins:
+  1. ``sync.parse_connector_health_line`` against the REAL production log
+     shapes captured from the user's machine.
+  2. ``ingest_connector_health`` / ``query_connector_health`` round-trip +
+     idempotency on re-tail.
+  3. ``routes/health.py:_connector_liveness`` verdict — especially the
+     ``down`` verdict that would have caught the deaf node.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # On a dev box with the daemon running, get_store() returns a proxy to the
+    # LIVE DuckDB (see get_store: _daemon_registered branch). Force a local
+    # writer at the tmp path so this test is hermetic — a different file means
+    # no contention with the real daemon's writer lock.
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    s = ls.get_store()
+    yield s
+    try:
+        s.stop(flush=True)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def parse():
+    from clawmetry import sync
+    return sync.parse_connector_health_line
+
+
+# ── parser: real production log shapes (captured 2026-05-23/24) ──────────
+
+@pytest.mark.parametrize("line,provider,kind", [
+    (
+        "2026-05-23T07:44:04.115+02:00 [health-monitor] [telegram:default] "
+        "health-monitor: restarting (reason: disconnected)",
+        "telegram", "disconnect",
+    ),
+    (
+        "2026-05-24T20:50:14.548+02:00 [telegram] [default] "
+        "starting provider (@diya_vivek_bot)",
+        "telegram", "started",
+    ),
+    (
+        "2026-05-23T07:44:03.631+02:00 [telegram] Polling stall detected "
+        "(no completed getUpdates for 880.28s); forcing restart.",
+        "telegram", "stall",
+    ),
+    (
+        "2026-05-23T07:44:09.204+02:00 [telegram] [default] channel stop "
+        "exceeded 5000ms after abort; continuing shutdown",
+        "telegram", "wedged",
+    ),
+])
+def test_parses_real_connector_health_lines(parse, line, provider, kind):
+    out = parse(line)
+    assert out is not None, f"expected a match for: {line!r}"
+    prov, k, ts = out
+    assert prov == provider
+    assert k == kind
+    # Timestamp is normalised to UTC (CEST +02:00 → −2h).
+    assert ts.endswith("+00:00")
+
+
+@pytest.mark.parametrize("line", [
+    "2026-05-24T20:29:21.392+02:00 [ws] unauthorized conn=e36a client=openclaw-control-ui",
+    "2026-05-24T20:50:14.401+02:00 [gateway] ready",
+    "2026-05-24T20:50:14.760+02:00 [telegram] menu text exceeded the budget",  # noise
+    "not a log line at all",
+    "",
+])
+def test_ignores_non_health_lines(parse, line):
+    assert parse(line) is None
+
+
+# ── store round-trip + idempotency ──────────────────────────────────────
+
+def test_ingest_and_query_roundtrip(store):
+    ts = datetime.now(timezone.utc).isoformat()
+    store.ingest_connector_health(
+        node_id="n1", provider="telegram", kind="disconnect", ts_iso=ts,
+        raw="reason: disconnected",
+    )
+    store.flush()
+    rows = store.query_connector_health(since_hours=24)
+    assert len(rows) == 1
+    assert rows[0]["provider"] == "telegram"
+    assert rows[0]["kind"] == "disconnect"
+
+
+def test_ingest_is_idempotent_on_retail(store):
+    ts = datetime.now(timezone.utc).isoformat()
+    for _ in range(3):  # a log rotation rescan re-feeds the same line
+        store.ingest_connector_health(
+            node_id="n1", provider="telegram", kind="stall", ts_iso=ts, raw="x",
+        )
+    store.flush()
+    assert len(store.query_connector_health(since_hours=24)) == 1
+
+
+# ── classifier verdict ───────────────────────────────────────────────────
+
+def _verdict(monkeypatch, rows):
+    """Run _connector_liveness with telegram enabled + crafted signals."""
+    import routes.health as h
+    import routes.local_query as lq
+    monkeypatch.setattr(h, "_enabled_channels_from_config", lambda: ["telegram"])
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda method, **kw: rows)
+    out = h._connector_liveness()
+    return out[0] if out else {}
+
+
+def _ago(mins):
+    return (datetime.now(timezone.utc) - timedelta(minutes=mins)).isoformat()
+
+
+def test_down_when_deaf_with_no_recovery(monkeypatch):
+    """The Diya incident: most-recent signal is a wedge/disconnect 37h ago,
+    no recovery since → DOWN (this is the alarm that was missing)."""
+    rows = [
+        {"provider": "telegram", "kind": "wedged", "ts": _ago(37 * 60), "raw": ""},
+        {"provider": "telegram", "kind": "disconnect", "ts": _ago(37 * 60 + 1), "raw": ""},
+    ]
+    v = _verdict(monkeypatch, rows)
+    assert v["state"] == "down"
+    assert "receive messages" in v["reason"]
+
+
+def test_ok_after_recovery(monkeypatch):
+    """A fresh 'starting provider' after an old disconnect → OK."""
+    rows = [
+        {"provider": "telegram", "kind": "started", "ts": _ago(3), "raw": ""},
+        {"provider": "telegram", "kind": "disconnect", "ts": _ago(40), "raw": ""},
+    ]
+    assert _verdict(monkeypatch, rows)["state"] == "ok"
+
+
+def test_degraded_when_flapping(monkeypatch):
+    rows = [
+        {"provider": "telegram", "kind": "started", "ts": _ago(2), "raw": ""},
+        {"provider": "telegram", "kind": "disconnect", "ts": _ago(10), "raw": ""},
+        {"provider": "telegram", "kind": "disconnect", "ts": _ago(25), "raw": ""},
+        {"provider": "telegram", "kind": "disconnect", "ts": _ago(40), "raw": ""},
+    ]
+    assert _verdict(monkeypatch, rows)["state"] == "degraded"
+
+
+def test_unknown_when_no_signals(monkeypatch):
+    assert _verdict(monkeypatch, [])["state"] == "unknown"


### PR DESCRIPTION
## The incident this prevents
On 2026-05-24 a Telegram inbound long-poll **wedged** (network stall → an aborted shutdown that timed out) and never restarted. The agent kept **sending** (scheduled crons fired fine) but silently stopped **receiving** messages for **~37 hours** — and ClawMetry showed green the entire time.

**Why we were blind** (all confirmed in-tree):
- Gateway health is **process-level** (`compute_gateway_health` / RSS + port) — the process was alive, so green.
- The one channel signal we had, `_channel_ingest_recent`'s `mins_ago`, **can't distinguish** "dead poller" from "no traffic" from "tap off" (its own docstring says so) and is tagged "decorative; never alarm."
- The daemon's gateway-log parser explicitly treated `Polling stall detected` as *"nothing to parse"* (sync.py comment) rather than an alarm.

## What this adds
A real per-channel inbound-liveness detector, DuckDB-first end to end.

**Producer (daemon):** `sync_connector_health_from_logs` tails **both** `gateway.log` and `gateway.err.log` (the diagnostics are split across them) with byte-offset resume. `parse_connector_health_line` maps each lifecycle line to a `connector.health` event — `kind ∈ started / stall / disconnect / wedged`, timestamp normalised to UTC. Idempotent ingest (re-tail after a rotation is a no-op).

**Classifier (dashboard):** `_connector_liveness` reads the channels **enabled in `openclaw.json`** and the `connector.health` stream (via the daemon proxy) and returns a verdict per channel, worst-first, in `/api/system-health.connector_liveness`:
- **down** — most-recent signal is unhealthy, no recovery since, ≥15 min → *"this channel can no longer receive messages"* (the verdict that was missing)
- **degraded** — recent stall inside the grace window, or flapping (≥3 disconnects/hr)
- **ok** / **unknown**

## Verification
- **Parser** pinned against the **real** May 23/24 production log lines (incl. CEST→UTC normalisation).
- **Classifier** unit-tested: deaf-37h → `down`, recovery → `ok`, flapping → `degraded`, grace-window stall → `degraded`, no signals → `unknown`. **15/15 pass.**
- **Live E2E** on the dev box: daemon ingested **93** `connector.health` signals from the real logs; `/api/system-health.connector_liveness` returned `telegram=ok (last signal: started 16m ago)` after the node recovered.

```json
{ "provider": "telegram", "state": "ok", "last_kind": "started", "mins_ago": 16,
  "reason": "inbound poll healthy (last signal: started 16m ago)" }
```

## Follow-up (separate PR, #2)
Surface a `down` verdict **prominently** (top-of-dashboard banner / Alerts) and ship `connector_liveness` in the encrypted snapshot so the **cloud** dashboard flags it too. This PR is the detection + local surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)