### PR TITLE
ci(c4): skip cross-repo handoff on fork PRs instead of failing

### DIFF
--- a/.github/workflows/cross-repo-handoff.yml
+++ b/.github/workflows/cross-repo-handoff.yml
@@ -25,8 +25,27 @@ jobs:
         with:
           path: oss
 
+      # CLOUD_REPO_PAT is NOT exposed to pull_request runs from a fork (GitHub
+      # withholds repo secrets from fork PRs to prevent exfiltration). Without it
+      # the private clawmetry-cloud checkout below cannot authenticate, so this
+      # cross-repo test can only run on same-repo PRs and on push to main. Detect
+      # that here and skip the cloud-dependent steps (job still goes green) so a
+      # fork contributor's PR is not blocked by an inaccessible private repo.
+      - name: Detect cloud-repo access
+        id: access
+        env:
+          CLOUD_REPO_PAT: ${{ secrets.CLOUD_REPO_PAT }}
+        run: |
+          if [ -n "$CLOUD_REPO_PAT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=C4 skipped (fork PR)::CLOUD_REPO_PAT is not available to PRs from forks, so the private clawmetry-cloud repo cannot be checked out. The cross-repo handoff test is skipped on this run; it still runs on same-repo PRs and on push to main."
+          fi
+
       # Cloud repo provides run_cloud.py stub + DaemonSim wire-format simulator.
       - name: Checkout clawmetry-cloud
+        if: steps.access.outputs.available == 'true'
         uses: actions/checkout@v6
         with:
           repository: vivekchand/clawmetry-cloud
@@ -34,6 +53,7 @@ jobs:
           path: cloud
 
       - name: Patch run_cloud.py throttle stub (node_id kwarg compat)
+        if: steps.access.outputs.available == 'true'
         run: |
           python - <<'EOF'
           import pathlib
@@ -58,6 +78,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install deps
+        if: steps.access.outputs.available == 'true'
         run: |
           python -m pip install --upgrade pip
           # Install only what the test needs (avoids duckdb version-pin in requirements.txt)
@@ -69,6 +90,7 @@ jobs:
           pip install waitress
 
       - name: Run C4 cross-repo handoff
+        if: steps.access.outputs.available == 'true'
         env:
           CLAWMETRY_E2E_STUB_AUTH: "1"
         run: |


### PR DESCRIPTION
## Problem

The **Cross-repo handoff (C4)** check is permanently red on every external contributor's fork PR — currently blocking #1984 and #1985 (both from `JaiCodes77`'s fork). Every other open PR (all same-repo branches) is green.

Root cause is **not** the contributor's code. The C4 job checks out the **private** `clawmetry-cloud` repo using `secrets.CLOUD_REPO_PAT`:

```yaml
- name: Checkout clawmetry-cloud
  uses: actions/checkout@v6
  with:
    repository: vivekchand/clawmetry-cloud
    token: ${{ secrets.CLOUD_REPO_PAT }}
```

GitHub **withholds repo secrets from `pull_request` runs triggered by a fork** (security: prevents a malicious PR from exfiltrating secrets). So on a fork PR the token resolves to empty and checkout dies with:

```
##[error]Input required and not supplied: token
```

The C4 test genuinely requires the private repo (`run_cloud.py` + `DaemonSim` at `$GITHUB_WORKSPACE/cloud/`), so there is no way to run T2–T4 on a fork. `pull_request_target` would expose secrets but is unsafe here (the job installs and runs PR code).

## Fix

Detect whether `CLOUD_REPO_PAT` is available and **skip the cloud-dependent steps** (checkout + patch + install + run) when it is not. The job then reports green on fork PRs, while the cross-repo handoff test still runs **in full** on:
- same-repo PRs (secret present — verified: #1983, #1982 pass C4), and
- push to `main` (the event that actually gates the merged result).

This is the secure design for a job that depends on a private repo, not a skip-to-green hack — the gate is preserved exactly where the secret exists.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML OK.
- After merge: re-trigger C4 on #1984 / #1985 and confirm the check goes green (cloud steps skipped, job succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)