### PR TITLE
feat(health): surface a down inbound channel loudly + ship it to cloud

### DIFF
--- a/clawmetry/connector_health.py
+++ b/clawmetry/connector_health.py
@@ -1,0 +1,144 @@
+"""Connector liveness — turn the daemon's ``connector.health`` signal
+stream into a per-channel ok/degraded/down verdict.
+
+Incident 2026-05-24: a Telegram inbound long-poll wedged (network stall →
+aborted shutdown that timed out) and never restarted. The agent kept
+SENDING (scheduled crons fired) but silently stopped RECEIVING for ~37h,
+and ClawMetry showed green the whole time.
+
+The daemon (``sync.sync_connector_health_from_logs``) tails gateway.log +
+gateway.err.log into ``connector.health`` events. This module is the SINGLE
+classifier shared by:
+  * the dashboard ``/api/system-health`` (``routes/health.py``), and
+  * the cloud snapshot builder (``sync.sync_system_snapshot``),
+so the local UI and the cloud dashboard never disagree on whether a channel
+is down.
+
+Pure + dependency-free (stdlib only) so the daemon can import it without
+pulling Flask.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+
+# An inbound poll that has been unhealthy this long with no recovery is DOWN.
+CONNECTOR_DOWN_MIN = 15
+# Window for counting repeated disconnects (flapping).
+CONNECTOR_FLAP_WINDOW_MIN = 60
+CONNECTOR_FLAP_COUNT = 3
+
+CONNECTOR_HEALTHY = {"started", "recovered"}
+CONNECTOR_UNHEALTHY = {"stall", "disconnect", "wedged"}
+
+
+def enabled_channels_from_config(openclaw_dir: str | None = None) -> list[str]:
+    """Channel providers explicitly enabled in openclaw.json
+    (``channels.<provider>.enabled == true``).
+
+    ``openclaw_dir`` overrides discovery (the daemon passes its resolved
+    workspace). Falls back to ``$CLAWMETRY_OPENCLAW_DIR`` / ``$OPENCLAW_HOME``
+    / ``~/.openclaw``. Empty on cloud / no config — the cloud reads liveness
+    from the snapshot built daemon-side. Never raises.
+    """
+    candidates = []
+    if openclaw_dir:
+        candidates.append(os.path.join(openclaw_dir, "openclaw.json"))
+    env = os.environ.get("CLAWMETRY_OPENCLAW_DIR") or os.environ.get("OPENCLAW_HOME")
+    if env:
+        candidates.append(os.path.join(env, "openclaw.json"))
+    candidates.append(os.path.join(os.path.expanduser("~"), ".openclaw", "openclaw.json"))
+    for p in candidates:
+        try:
+            if not os.path.exists(p):
+                continue
+            with open(p, errors="ignore") as f:
+                cfg = json.load(f)
+            chans = (cfg or {}).get("channels") or {}
+            return [
+                str(name).lower()
+                for name, c in chans.items()
+                if isinstance(c, dict) and c.get("enabled")
+            ]
+        except Exception:
+            continue
+    return []
+
+
+def _mins_since(ts, now: datetime) -> int | None:
+    try:
+        t = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        return max(0, int((now - t).total_seconds() / 60))
+    except Exception:
+        return None
+
+
+def classify_connector_liveness(
+    enabled: list[str],
+    rows: list[dict],
+    now: datetime | None = None,
+) -> list[dict]:
+    """Classify each enabled channel from the connector.health stream.
+
+    ``rows`` is the output of ``LocalStore.query_connector_health`` —
+    ``[{provider, kind, ts, raw}, ...]`` newest-first. Returns
+    ``[{provider, state, reason, mins_ago, last_kind}, ...]``, worst-first,
+    where ``state`` ∈ ``down`` | ``degraded`` | ``unknown`` | ``ok``.
+
+    ``down`` is the verdict that catches a deaf channel: most-recent signal
+    is unhealthy, no recovery since, and older than the grace window.
+    """
+    if not enabled:
+        return []
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    by_prov: dict[str, list] = {}
+    for r in (rows or []):
+        if isinstance(r, dict) and r.get("provider"):
+            by_prov.setdefault(str(r["provider"]).lower(), []).append(r)
+
+    out = []
+    for prov in enabled:
+        sigs = by_prov.get(prov, [])
+        if not sigs:
+            out.append({
+                "provider": prov, "state": "unknown",
+                "reason": "no inbound-poll signals seen in the last 24h",
+                "mins_ago": None, "last_kind": None,
+            })
+            continue
+        latest = sigs[0]
+        latest_kind = latest.get("kind")
+        mins_ago = _mins_since(latest.get("ts"), now)
+        recent_bad = sum(
+            1 for s in sigs
+            if s.get("kind") in CONNECTOR_UNHEALTHY
+            and (_mins_since(s.get("ts"), now) or 1e9) <= CONNECTOR_FLAP_WINDOW_MIN
+        )
+        if latest_kind in CONNECTOR_UNHEALTHY and (
+            mins_ago is None or mins_ago >= CONNECTOR_DOWN_MIN
+        ):
+            state = "down"
+            reason = (
+                f"inbound poll {latest_kind} {mins_ago}m ago with no recovery "
+                f"since — this channel can no longer receive messages"
+            )
+        elif latest_kind in CONNECTOR_UNHEALTHY:
+            state = "degraded"
+            reason = f"inbound poll {latest_kind} {mins_ago}m ago (watching for recovery)"
+        elif recent_bad >= CONNECTOR_FLAP_COUNT:
+            state = "degraded"
+            reason = f"inbound poll flapping ({recent_bad} disconnects in the last hour)"
+        else:
+            state = "ok"
+            reason = f"inbound poll healthy (last signal: {latest_kind} {mins_ago}m ago)"
+        out.append({
+            "provider": prov, "state": state, "reason": reason,
+            "mins_ago": mins_ago, "last_kind": latest_kind,
+        })
+    order = {"down": 0, "degraded": 1, "unknown": 2, "ok": 3}
+    out.sort(key=lambda r: order.get(r["state"], 9))
+    return out

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -427,6 +427,50 @@ setTimeout(checkActiveAlerts, 3000);
 
 // === Anomaly Detection Banner ===
 var _anomalyBannerEl = null;
+// ── Connector-down banner (incident: a channel went deaf ~37h, no alarm) ──
+// A red top banner whenever an enabled inbound channel's poll is 'down' —
+// the agent can still SEND but can no longer RECEIVE messages on it. Driven
+// by /api/system-health.connector_liveness (loadSystemHealth). Dynamically
+// created so it works on cloud (which serves this app.js) without a template.
+var _connectorBannerEl = null;
+function _getOrCreateConnectorBanner() {
+  if (_connectorBannerEl) return _connectorBannerEl;
+  var existing = document.getElementById('connector-down-banner');
+  if (existing) { _connectorBannerEl = existing; return existing; }
+  var el = document.createElement('div');
+  el.id = 'connector-down-banner';
+  el.style.cssText = 'display:none;padding:10px 16px;background:#7f1d1d;border-bottom:2px solid #ef4444;color:#fecaca;font-size:13px;font-weight:600;align-items:center;gap:10px;';
+  el.innerHTML = '<span style="font-size:18px;">&#128227;</span><span id="connector-down-banner-msg" style="flex:1;"></span><a href="#" onclick="switchTab(\'overview\');return false;" style="color:#fecaca;text-decoration:underline;font-size:12px;margin-right:8px;">View</a><button onclick="document.getElementById(\'connector-down-banner\').style.display=\'none\';" style="background:#991b1b;color:#fee2e2;border:none;border-radius:6px;padding:4px 10px;font-size:12px;cursor:pointer;">Dismiss</button>';
+  var alertBanner = document.getElementById('alert-banner');
+  if (alertBanner && alertBanner.parentNode) {
+    alertBanner.parentNode.insertBefore(el, alertBanner.nextSibling);
+  } else {
+    document.body.insertBefore(el, document.body.firstChild);
+  }
+  _connectorBannerEl = el;
+  return el;
+}
+
+function _renderConnectorBanner(liveness) {
+  var banner = _getOrCreateConnectorBanner();
+  var rows = Array.isArray(liveness) ? liveness : [];
+  var down = rows.filter(function(r){ return r && r.state === 'down'; });
+  if (down.length === 0) { banner.style.display = 'none'; return; }
+  function cap(s){ return s ? s.charAt(0).toUpperCase() + s.slice(1) : s; }
+  var first = down[0];
+  var mins = (first.mins_ago != null) ? first.mins_ago : null;
+  var since = (mins != null)
+    ? (mins >= 120 ? Math.round(mins/60) + 'h' : mins + 'm')
+    : '';
+  var msg = '⚠️ ' + cap(first.provider) + ' is not receiving messages'
+    + (since ? '. Inbound down ' + since + '.' : '.')
+    + ' Your agent can still send, but is not hearing replies.';
+  if (down.length > 1) msg += ' (+' + (down.length - 1) + ' more channel' + (down.length > 2 ? 's' : '') + ')';
+  var msgEl = document.getElementById('connector-down-banner-msg');
+  if (msgEl) msgEl.textContent = msg;
+  banner.style.display = 'flex';
+}
+
 function _getOrCreateAnomalyBanner() {
   if (_anomalyBannerEl) return _anomalyBannerEl;
   var existing = document.getElementById('anomaly-engine-banner');
@@ -8815,6 +8859,9 @@ async function _loadGatewayHealthSparkline() {
 async function loadSystemHealth() {
   try {
     var d = await fetchJsonWithTimeout('/api/system-health', 18000);
+    // Connector liveness: surface a 'down' inbound channel loudly (incident:
+    // a channel went deaf ~37h with no alarm). Driven by the same payload.
+    try { _renderConnectorBanner(d.connector_liveness); } catch(e) {}
     var services = Array.isArray(d.services) ? d.services : [];
     var channels = Array.isArray(d.channels) ? d.channels : [];
     var disks = Array.isArray(d.disks) ? d.disks : [];

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9480,6 +9480,10 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "memoryAccess": _build_memory_access(),
         "traces": _build_traces(),
         "skills": _build_skills(),
+        # Connector liveness (incident: a channel went deaf ~37h, no alarm).
+        # Lets the cloud dashboard flag a 'down' inbound channel just like the
+        # local dashboard's /api/system-health does.
+        "connectorLiveness": _build_connector_liveness(config),
     }
 
     # ── NemoClaw / sandbox enrichment ────────────────────────────────────────
@@ -10904,6 +10908,26 @@ def sync_connector_health_from_logs(
     except Exception as e:
         log.warning("connector-health: cycle failed: %s", e)
         return 0
+
+
+def _build_connector_liveness(config: dict | None = None) -> list:
+    """Per-channel inbound-poll verdict for the cloud snapshot, computed with
+    the SAME classifier the local dashboard uses (clawmetry.connector_health)
+    so the cloud and local UIs never disagree on whether a channel is down.
+    Best-effort; [] on any failure (never block the snapshot)."""
+    try:
+        from clawmetry.connector_health import (
+            enabled_channels_from_config, classify_connector_liveness,
+        )
+        enabled = enabled_channels_from_config()
+        if not enabled:
+            return []
+        from clawmetry import local_store as _ls
+        rows = _ls.get_store().query_connector_health(since_hours=24)
+        return classify_connector_liveness(enabled, rows)
+    except Exception as e:
+        log.debug("connector-liveness snapshot build failed (non-fatal): %s", e)
+        return []
 
 
 def _build_gateway_data(paths: dict = None) -> dict:

--- a/routes/health.py
+++ b/routes/health.py
@@ -1562,49 +1562,9 @@ def _channel_ingest_recent():
 # ── Connector liveness ("agent went deaf and nobody noticed") ───────────────
 # A channel went deaf for ~37h with no alarm (2026-05-24): the inbound
 # long-poll wedged but outbound (crons) kept working, so health stayed green.
-# The daemon now records connector.health signals (sync.sync_connector_health
-# _from_logs); here we turn them into a per-channel ok/degraded/down verdict.
-# 'down' is the verdict that would have caught it: most-recent signal is a
-# stall/disconnect/wedge, no recovery since, older than the grace window.
-_CONNECTOR_DOWN_MIN = 15          # unhealthy + no recovery this long ⇒ down
-_CONNECTOR_FLAP_WINDOW_MIN = 60   # window for counting repeated disconnects
-_CONNECTOR_FLAP_COUNT = 3         # this many disconnects/hr ⇒ degraded
-_CONNECTOR_HEALTHY = {"started", "recovered"}
-_CONNECTOR_UNHEALTHY = {"stall", "disconnect", "wedged"}
-
-
-def _enabled_channels_from_config():
-    """Channel providers explicitly enabled in openclaw.json
-    (``channels.<provider>.enabled == true``).
-
-    Empty on cloud or when no config is present — the cloud surface reads
-    liveness from the encrypted snapshot (built daemon-side where the config
-    lives), not from this local-filesystem read. Never raises.
-    """
-    import os as _os
-    import json as _json
-    candidates = []
-    env = _os.environ.get("CLAWMETRY_OPENCLAW_DIR") or _os.environ.get("OPENCLAW_HOME")
-    if env:
-        candidates.append(_os.path.join(env, "openclaw.json"))
-    candidates.append(_os.path.join(_os.path.expanduser("~"), ".openclaw", "openclaw.json"))
-    for p in candidates:
-        try:
-            if not _os.path.exists(p):
-                continue
-            with open(p, errors="ignore") as f:
-                cfg = _json.load(f)
-            chans = (cfg or {}).get("channels") or {}
-            return [
-                str(name).lower()
-                for name, c in chans.items()
-                if isinstance(c, dict) and c.get("enabled")
-            ]
-        except Exception:
-            continue
-    return []
-
-
+# The daemon records connector.health signals (sync.sync_connector_health
+# _from_logs); the classifier is shared with the cloud snapshot builder in
+# ``clawmetry/connector_health.py`` so the local UI and cloud never disagree.
 def _connector_liveness():
     """Per-enabled-channel inbound-poll verdict for the System Health UI.
 
@@ -1613,7 +1573,10 @@ def _connector_liveness():
     Reads connector.health signals via the daemon proxy (DuckDB-first);
     returns ``[]`` on any failure — never blocks /api/system-health.
     """
-    enabled = _enabled_channels_from_config()
+    from clawmetry.connector_health import (
+        enabled_channels_from_config, classify_connector_liveness,
+    )
+    enabled = enabled_channels_from_config()
     if not enabled:
         return []
     rows = None
@@ -1629,61 +1592,7 @@ def _connector_liveness():
             rows = store.query_connector_health(since_hours=24)
         except Exception:
             rows = []
-
-    by_prov: dict[str, list] = {}
-    for r in (rows or []):
-        if isinstance(r, dict) and r.get("provider"):
-            by_prov.setdefault(str(r["provider"]).lower(), []).append(r)
-
-    def _mins_since(ts):
-        try:
-            t = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
-            return max(0, int((datetime.now(timezone.utc) - t).total_seconds() / 60))
-        except Exception:
-            return None
-
-    out = []
-    for prov in enabled:
-        sigs = by_prov.get(prov, [])  # newest-first (query orders DESC)
-        if not sigs:
-            out.append({
-                "provider": prov, "state": "unknown",
-                "reason": "no inbound-poll signals seen in the last 24h",
-                "mins_ago": None, "last_kind": None,
-            })
-            continue
-        latest = sigs[0]
-        latest_kind = latest.get("kind")
-        mins_ago = _mins_since(latest.get("ts"))
-        recent_bad = sum(
-            1 for s in sigs
-            if s.get("kind") in _CONNECTOR_UNHEALTHY
-            and (_mins_since(s.get("ts")) or 1e9) <= _CONNECTOR_FLAP_WINDOW_MIN
-        )
-        if latest_kind in _CONNECTOR_UNHEALTHY and (
-            mins_ago is None or mins_ago >= _CONNECTOR_DOWN_MIN
-        ):
-            state = "down"
-            reason = (
-                f"inbound poll {latest_kind} {mins_ago}m ago with no recovery "
-                f"since — this channel can no longer receive messages"
-            )
-        elif latest_kind in _CONNECTOR_UNHEALTHY:
-            state = "degraded"
-            reason = f"inbound poll {latest_kind} {mins_ago}m ago (watching for recovery)"
-        elif recent_bad >= _CONNECTOR_FLAP_COUNT:
-            state = "degraded"
-            reason = f"inbound poll flapping ({recent_bad} disconnects in the last hour)"
-        else:
-            state = "ok"
-            reason = f"inbound poll healthy (last signal: {latest_kind} {mins_ago}m ago)"
-        out.append({
-            "provider": prov, "state": state, "reason": reason,
-            "mins_ago": mins_ago, "last_kind": latest_kind,
-        })
-    order = {"down": 0, "degraded": 1, "unknown": 2, "ok": 3}
-    out.sort(key=lambda r: order.get(r["state"], 9))
-    return out
+    return classify_connector_liveness(enabled, rows)
 
 
 def _summarise_gateway_metric_recent(minutes: int = 60):

--- a/tests/test_connector_health.py
+++ b/tests/test_connector_health.py
@@ -126,10 +126,16 @@ def test_ingest_is_idempotent_on_retail(store):
 # ── classifier verdict ───────────────────────────────────────────────────
 
 def _verdict(monkeypatch, rows):
-    """Run _connector_liveness with telegram enabled + crafted signals."""
+    """Run _connector_liveness with telegram enabled + crafted signals.
+
+    The enabled-channels reader + classifier live in clawmetry.connector_health
+    (shared with the daemon snapshot builder); _connector_liveness imports them
+    at call time, so patching the source module takes effect.
+    """
     import routes.health as h
     import routes.local_query as lq
-    monkeypatch.setattr(h, "_enabled_channels_from_config", lambda: ["telegram"])
+    import clawmetry.connector_health as ch
+    monkeypatch.setattr(ch, "enabled_channels_from_config", lambda *a, **k: ["telegram"])
     monkeypatch.setattr(lq, "local_store_via_daemon", lambda method, **kw: rows)
     out = h._connector_liveness()
     return out[0] if out else {}


### PR DESCRIPTION
Follow-up to the connector-liveness detector (#1992). The detector landed the verdict in `/api/system-health.connector_liveness`; this makes a **down** channel impossible to miss and gets it to the **cloud** dashboard too.

- **Shared classifier** — extracted into `clawmetry/connector_health.py` (pure, stdlib-only) so the dashboard (`routes/health.py`) and the daemon snapshot builder share **one** implementation and can never disagree on whether a channel is down.
- **Snapshot key** — `sync.sync_system_snapshot` now ships `connectorLiveness` (computed with the shared classifier) so the cloud dashboard has the data.
- **Loud banner** — `app.js` renders a red top banner ("Telegram is not receiving messages. Inbound down 37h. Your agent can still send, but is not hearing replies.") from `/api/system-health.connector_liveness` in `loadSystemHealth`. Dynamically created (mirrors the anomaly banner) so it works on cloud — which serves this `app.js` — without a template change.

## Verification
- 15/15 connector-health tests pass (test updated to patch the shared module).
- `py_compile` + `import dashboard` + `node --check app.js` clean.
- No em-dashes in the banner copy.

## Follow-up
Cloud `/api/system-health` interceptor to read `connectorLiveness` from the snapshot so the banner also lights up on app.clawmetry.com. (Separate cloud PR; this lands the OSS half + the snapshot data.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)