### PR TITLE
fix(local_store): v3 event-type aliases in query_session_model_journey

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5606,19 +5606,33 @@ class LocalStore:
           * thinking rows:     ``{kind:'thinking_level_change', level, ts}``
 
         Single-session helper — caller passes ``session_id``. Uses the
-        existing events table; no new schema required."""
+        existing events table; no new schema required.
+
+        Accepts both v2 event names (``model_change``, ``message``) and v3
+        namespaced names (``model.changed``, ``model.completed``,
+        ``prompt.submitted``) so sessions ingested via OpenClaw v3 return a
+        non-empty journey.  ``cost_usd`` and ``token_count`` are read directly
+        from the typed columns — both v2 and v3 ingest paths populate them —
+        and used as a fallback when the nested ``data.message.usage`` block
+        is absent (v3 shape)."""
         if not session_id:
             return []
         sql = """
-            SELECT event_type, ts, data, model
+            SELECT event_type, ts, data, model, cost_usd, token_count
             FROM events
             WHERE session_id = ?
-              AND event_type IN ('model_change', 'message', 'thinking_level_change')
+              AND event_type IN (
+                'model_change',   'model.changed',
+                'message',        'model.completed', 'prompt.submitted',
+                'thinking_level_change'
+              )
             ORDER BY ts ASC, id ASC
             LIMIT ?
         """
         out: list[dict[str, Any]] = []
-        for et, ts, raw, ev_model in self._fetch(sql, [session_id, int(limit)]):
+        for et, ts, raw, ev_model, ev_cost_usd, ev_token_count in self._fetch(
+            sql, [session_id, int(limit)]
+        ):
             data: dict[str, Any] = {}
             if raw is not None:
                 try:
@@ -5628,7 +5642,7 @@ class LocalStore:
                         data = parsed
                 except (ValueError, TypeError, UnicodeDecodeError):
                     data = {}
-            if et == "model_change":
+            if et in ("model_change", "model.changed"):
                 out.append({
                     "kind":      "model_change",
                     "model":     data.get("modelId") or data.get("model") or ev_model or "",
@@ -5641,16 +5655,20 @@ class LocalStore:
                     "level": data.get("thinkingLevel") or data.get("level") or "",
                     "ts":    ts,
                 })
-            else:  # message
+            else:  # message / model.completed / prompt.submitted
+                # v2 path: cost + tokens nested under data["message"]["usage"]
                 msg = data.get("message") if isinstance(data.get("message"), dict) else {}
                 usage = msg.get("usage") if isinstance(msg.get("usage"), dict) else {}
                 cost_obj = usage.get("cost") if isinstance(usage.get("cost"), dict) else {}
+                # Prefer nested v2 values; fall back to typed columns for v3.
+                total_tokens = int(usage.get("totalTokens", 0) or 0) or int(ev_token_count or 0)
+                total_cost = float(cost_obj.get("total", 0) or 0) or float(ev_cost_usd or 0)
                 out.append({
                     "kind":         "message",
-                    "model":        msg.get("model") or ev_model or "",
-                    "provider":     msg.get("provider") or "",
-                    "total_tokens": int(usage.get("totalTokens", 0) or 0),
-                    "total_cost":   float(cost_obj.get("total", 0) or 0),
+                    "model":        msg.get("model") or data.get("modelId") or ev_model or "",
+                    "provider":     msg.get("provider") or data.get("provider") or "",
+                    "total_tokens": total_tokens,
+                    "total_cost":   total_cost,
                     "ts":           ts,
                 })
         return out

--- a/tests/test_duckdb_fastpath_v3_invariants.py
+++ b/tests/test_duckdb_fastpath_v3_invariants.py
@@ -99,6 +99,11 @@ def _model_completed_data(*, input_t: int, output_t: int) -> dict:
     }
 
 
+def _model_changed_data(*, model: str) -> dict:
+    """v3 ``model.changed`` envelope — emitted when agent switches models."""
+    return {"modelId": model, "provider": PROVIDER}
+
+
 def _build_v3_events() -> list[dict]:
     """Mixed v3 transcript.
 
@@ -121,6 +126,9 @@ def _build_v3_events() -> list[dict]:
         # session_start
         _base("ev-session-start", "session_start", 600,
               data={"title": "v3-invariants fixture"}),
+        # 1× model.changed — agent selects Opus at session start
+        _base("ev-model-changed", "model.changed", 550,
+              data=_model_changed_data(model=MODEL), model=MODEL),
         # 2× assistant (different seconds so dedupe keeps both)
         _base("ev-assistant-1", "assistant", 500,
               data=_assistant_data(model=MODEL, input_t=10000, output_t=500,
@@ -161,7 +169,7 @@ def _build_v3_events() -> list[dict]:
     ]
 
 
-EXPECTED_RAW_EVENT_COUNT  = 8
+EXPECTED_RAW_EVENT_COUNT  = 9
 EXPECTED_INPUT_TOKENS_MIN = 21000   # 10000 + 11000 (subagent extras OK)
 EXPECTED_OUTPUT_TOKENS_MIN = 1100   # 500 + 600
 
@@ -319,7 +327,30 @@ def test_query_events_returns_full_v3_transcript(store):
         )
 
 
-# NOTE: ``query_cost_split`` and ``query_session_model_journey`` still filter
-# ``event_type='message'`` exclusively. Known v3 zeros (not patched as part
-# of #1385) — re-listed in #1393's bug class but out of scope for this PR.
-# When they get migrated, add tests here mirroring the four above.
+def test_query_session_model_journey_returns_v3_model_completed_rows(store):
+    """Pre-fix: only ``message`` was in the IN-clause so ``model.completed``
+    events were invisible — the journey returned [] for every v3 session."""
+    rows = store.query_session_model_journey(session_id=SESSION_ID)
+    assert rows, (
+        "query_session_model_journey returned [] for v3 session — "
+        "model.completed event_type is missing from the IN-clause predicate"
+    )
+    total = sum(int(r.get("total_tokens") or 0) for r in rows if r.get("kind") == "message")
+    assert total > 0, (
+        f"query_session_model_journey summed 0 total_tokens on v3 fixture; "
+        f"typed cost_usd/token_count columns not being read. rows={rows!r}"
+    )
+
+
+def test_query_session_model_journey_tracks_v3_model_change(store):
+    """``model.changed`` events must produce ``kind='model_change'`` rows so
+    segment boundaries are computed for v3 sessions that switch models."""
+    rows = store.query_session_model_journey(session_id=SESSION_ID)
+    change_rows = [r for r in rows if r.get("kind") == "model_change"]
+    assert change_rows, (
+        f"query_session_model_journey returned no model_change rows from "
+        f"v3 model.changed event. all rows: {rows!r}"
+    )
+    assert any(r.get("model") == MODEL for r in change_rows), (
+        f"model_change row missing expected model {MODEL!r}: {change_rows!r}"
+    )


### PR DESCRIPTION
## Summary

Closes #1582

- **Root cause**: `query_session_model_journey` filtered `event_type IN ('model_change', 'message', 'thinking_level_change')` — v2-only names. OpenClaw v3 daemon stores model-change events as `'model.changed'` and assistant turns as `'model.completed'`, so `/api/session-model-journey` returned an empty segment list (blank chart) for every v3 session.
- **Fix**: extend the `IN` clause to include `'model.changed'`, `'model.completed'`, and `'prompt.submitted'`; also `SELECT cost_usd, token_count` typed columns as a fallback for v3's different data shape.
- **Tests**: replaces the long-standing `# NOTE: … TODO` in `test_duckdb_fastpath_v3_invariants.py` with two passing assertions; adds a `model.changed` fixture event so both the model-switch and cost-accumulation paths are covered.

## Test plan

- [x] `python3 -c "import dashboard"` — clean
- [x] `pytest tests/test_duckdb_fastpath_v3_invariants.py -v` — 10/10 pass (8 pre-existing + 2 new)
- [x] `pytest tests/test_local_store.py -k "journey"` — 1/1 pass (v2 path unchanged)
- [x] `pytest tests/test_class_bug_parent_sid_drain.py -k "model_journey"` — 1/1 pass
- [x] `pytest tests/test_duckdb_coverage_phase3_2026_05_13.py -k "model_journey"` — 1/1 pass
- [x] `pytest tests/test_moat_bug_class_v3_event_shape_gate.py` — 3/3 pass

**Note**: `query_cost_split` has the same v2-only filter; left for a focused follow-up since fixing it requires normalising the per-component cost split (input/output/cache) across v2 and v3 shapes.

https://claude.ai/code/session_011SiVBYL3nPRHoEwbFzK8AK

---
_Generated by [Claude Code](https://claude.ai/code/session_011SiVBYL3nPRHoEwbFzK8AK)_