### PR TITLE
feat(compat): surface PicoClaw/NanoClaw runtime label in the cloud (phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
             tests/test_moat_perf_benchmark.py \
             tests/test_picoclaw_adapter.py \
             tests/test_nanoclaw_adapter.py \
+            tests/test_runtime_detection_snapshot.py \
             -q
 
   # ── MOAT keystone (DuckDB-first invariant, 13-endpoint bar) ──────────────

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: test-api test-e2e test-e2e-duckdb test-workflow test-compat
 # (per-session SQLite). Hermetic, ~1s — no live server, no gateway, no
 # network. Mirror in .github/workflows/ci.yml (moat-tests job).
 test-compat:
-	python3 -m pytest tests/test_picoclaw_adapter.py tests/test_nanoclaw_adapter.py -v
+	python3 -m pytest tests/test_picoclaw_adapter.py tests/test_nanoclaw_adapter.py tests/test_runtime_detection_snapshot.py -v
 
 test-fast:
 	CLAWMETRY_URL=http://localhost:8900 CLAWMETRY_TOKEN=dev-token python3 -m pytest tests/test_api.py -v

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ ClawMetry observes the OpenClaw runtime family. Some members share OpenClaw's se
 | **PicoClaw** | Beta adapter | Reads PicoClaw's native flat JSONL (`~/.picoclaw/workspace/sessions`). Transcripts, model, and tool calls. Tokens/cost are not written to disk by PicoClaw. |
 | **NanoClaw** | Beta adapter | Reads NanoClaw's native per-session SQLite (`data/v2-sessions`). Transcripts and message counts. Model/tokens/cost are not written to those tables. |
 
-"Beta adapter" means ClawMetry ships a reader for that runtime's real on-disk format, validated against a session captured from a real install (we installed and ran both; see `tests/fixtures/runtimes/<rt>/REAL/` and the per-runtime PRDs) with fixture-backed CI tests. A full "Verified" badge is reserved for once the live cloud end-to-end path is also confirmed.
+"Beta adapter" means ClawMetry ships a reader for that runtime's real on-disk format, validated against a session captured from a real install (we installed and ran both; see `tests/fixtures/runtimes/<rt>/REAL/` and the per-runtime PRDs) with fixture-backed CI tests. Runtime detection is also live-verified end to end in the cloud: a node running PicoClaw or NanoClaw is labeled with its runtime in the cloud Runtime panel alongside OpenClaw. Full ingest of each runtime's individual sessions into the cloud is the next phase.
 
 ## Configuration
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7442,6 +7442,43 @@ def _build_machine_info():
         return {"items": []}
 
 
+def _detect_family_runtimes():
+    """Detect OpenClaw-family runtimes installed alongside (PicoClaw, NanoClaw).
+
+    These runtimes use their OWN native session format (not OpenClaw's v3
+    JSONL), so ClawMetry ships dedicated reader adapters for them
+    (clawmetry/adapters/{picoclaw,nanoclaw}.py). Here we run each adapter's
+    cheap, never-raising ``detect()`` so the cloud can label which runtime a
+    node is actually running. Pure detection: no DuckDB access, no writes, no
+    writer lock involved.
+
+    Returns a list of ``{name, displayName, sessionCount, workspace}`` for the
+    runtimes whose data is present on this host. Empty list if none / on error.
+    """
+    out = []
+    try:
+        from clawmetry.adapters.picoclaw import PicoClawAdapter
+        from clawmetry.adapters.nanoclaw import NanoClawAdapter
+    except Exception as exc:  # adapters unavailable (old wheel) — degrade quietly
+        log.debug(f"family-runtime adapters unavailable: {exc}")
+        return out
+    for cls in (PicoClawAdapter, NanoClawAdapter):
+        try:
+            d = cls().detect()
+            if d.detected:
+                out.append(
+                    {
+                        "name": d.name,
+                        "displayName": d.display_name,
+                        "sessionCount": int(d.session_count or 0),
+                        "workspace": d.workspace or "",
+                    }
+                )
+        except Exception as exc:  # one bad adapter never blocks the others
+            log.debug(f"family-runtime detect failed for {cls.__name__}: {exc}")
+    return out
+
+
 def _build_runtime_info():
     """Build runtime environment info for the Runtime popup."""
     try:
@@ -7504,6 +7541,18 @@ def _build_runtime_info():
             items.append({"label": "Node.js", "value": nv, "status": "ok"})
         except Exception:
             pass
+        # OpenClaw-family runtimes detected on this host (PicoClaw, NanoClaw).
+        # Surfaced as Runtime popup rows so the cloud shows what a node runs,
+        # with no cloud-side code change (the popup renders runtimeInfo.items).
+        for rt in _detect_family_runtimes():
+            n = rt.get("sessionCount") or 0
+            items.append(
+                {
+                    "label": rt.get("displayName") or rt.get("name") or "Runtime",
+                    "value": f"detected ({n} session{'s' if n != 1 else ''})",
+                    "status": "ok",
+                }
+            )
         return {"items": items}
     except Exception as e:
         log.warning(f"Runtime info error: {e}")
@@ -9462,6 +9511,10 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "brainData": _build_brain_data(),
         "gateway": {},
         "runtimeInfo": _build_runtime_info(),
+        # OpenClaw-family runtimes (PicoClaw, NanoClaw) detected on this host,
+        # tiny by design ({name, displayName, sessionCount, workspace}) so the
+        # cloud can show a runtime chip without bloating the snapshot.
+        "detectedRuntimes": _detect_family_runtimes(),
         "machineInfo": _build_machine_info(),
         "channelList": _build_channel_list(config),
         "ollamaInfo": _detect_ollama_for_heartbeat(),

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -46,6 +46,17 @@ A "Verified" badge will be restored per runtime only after a session captured
 from a **real install** of that runtime passes its adapter test, and the live
 end-to-end path (dashboard + cloud snapshot) is confirmed.
 
+### Cloud runtime label (live-verified)
+
+The sync daemon detects PicoClaw / NanoClaw installs (via each adapter's
+`detect()`) and ships a runtime label in the encrypted snapshot, both as
+`runtimeInfo.items[]` rows and a small top-level `detectedRuntimes` summary
+(`{name, displayName, sessionCount, workspace}`). The cloud Runtime panel
+renders these alongside OpenClaw with no cloud code change. This was verified by
+decrypting the live cloud snapshot of a real node, which showed
+`PicoClaw: detected (1 session)` and `NanoClaw: detected (2 sessions)`. Pure
+detection only: no DuckDB access and no writer lock are involved.
+
 ## Pointing ClawMetry at PicoClaw or NanoClaw
 
 When a runtime's home directory exists, its adapter registers automatically and

--- a/tests/test_runtime_detection_snapshot.py
+++ b/tests/test_runtime_detection_snapshot.py
@@ -1,0 +1,67 @@
+"""Phase-3 daemon tests: family-runtime detection in the cloud snapshot.
+
+The sync daemon labels which OpenClaw-family runtime (PicoClaw / NanoClaw) a
+node is running so the cloud can show it. This is pure detection via the
+adapters (no DuckDB, no writer lock). These tests point the adapters at the
+committed fixtures via env overrides and assert the snapshot carries the
+runtime label + the tiny `detectedRuntimes` summary.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import clawmetry.sync as sync
+
+_FIX = os.path.join(os.path.dirname(__file__), "fixtures", "runtimes")
+_PICO_HOME = os.path.join(_FIX, "picoclaw")  # has workspace/sessions/*.jsonl
+_NANO_DIR = os.path.join(_FIX, "nanoclaw", "REAL")  # has <group>/<session>/*.db
+
+
+def test_no_family_runtimes_when_absent(monkeypatch, tmp_path):
+    """No PicoClaw/NanoClaw on the host -> empty list, never raises."""
+    monkeypatch.setenv("PICOCLAW_HOME", str(tmp_path / "nope-pico"))
+    monkeypatch.setenv("CLAWMETRY_NANOCLAW_DIR", str(tmp_path / "nope-nano"))
+    # Also keep discovery from finding a real checkout under $HOME.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert sync._detect_family_runtimes() == []
+
+
+def test_detects_picoclaw(monkeypatch):
+    monkeypatch.setenv("PICOCLAW_HOME", _PICO_HOME)
+    monkeypatch.delenv("CLAWMETRY_NANOCLAW_DIR", raising=False)
+    rts = {r["name"]: r for r in sync._detect_family_runtimes()}
+    assert "picoclaw" in rts
+    assert rts["picoclaw"]["displayName"] == "PicoClaw"
+    # The synthetic fixture has two sessions under workspace/sessions/.
+    assert rts["picoclaw"]["sessionCount"] == 2
+
+
+def test_detects_nanoclaw(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_NANOCLAW_DIR", _NANO_DIR)
+    rts = {r["name"]: r for r in sync._detect_family_runtimes()}
+    assert "nanoclaw" in rts
+    assert rts["nanoclaw"]["displayName"] == "NanoClaw"
+    assert rts["nanoclaw"]["sessionCount"] == 2
+
+
+def test_runtime_info_includes_runtime_rows(monkeypatch):
+    monkeypatch.setenv("PICOCLAW_HOME", _PICO_HOME)
+    monkeypatch.setenv("CLAWMETRY_NANOCLAW_DIR", _NANO_DIR)
+    info = sync._build_runtime_info()
+    labels = {i["label"]: i["value"] for i in info["items"]}
+    assert "PicoClaw" in labels
+    assert "NanoClaw" in labels
+    assert "session" in labels["PicoClaw"]
+
+
+def test_runtime_info_never_raises_and_has_base_items(monkeypatch, tmp_path):
+    """Base runtime rows (Python/OS) survive even with no family runtimes."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PICOCLAW_HOME", str(tmp_path / "nope"))
+    monkeypatch.setenv("CLAWMETRY_NANOCLAW_DIR", str(tmp_path / "nope2"))
+    info = sync._build_runtime_info()
+    labels = [i["label"] for i in info["items"]]
+    assert "Python" in labels
+    assert "PicoClaw" not in labels


### PR DESCRIPTION
Builds on #2013. Phase 3 of NanoClaw/PicoClaw support: make a node's runtime visible in the cloud, shown the same way OpenClaw is.

## What

The sync daemon detects OpenClaw-family runtimes (PicoClaw, NanoClaw) via their adapters' cheap, never-raising `detect()` and ships the result in the encrypted snapshot:

- `_detect_family_runtimes()` returns `[{name, displayName, sessionCount, workspace}]` for runtimes present on the host. **Pure detection** - no DuckDB access, no writes, no writer lock.
- `_build_runtime_info()` appends a Runtime-panel row per detected runtime (e.g. `PicoClaw: detected (1 session)`), so the cloud Runtime panel shows it next to the OpenClaw row with **zero cloud code change** (the renderer is a generic `{label,value,status}` loop served from the OSS wheel).
- `sync_system_snapshot` adds a tiny top-level `detectedRuntimes` key for a future cloud chip.

## Verified live, end to end

Placed the real captured PicoClaw session at `~/.picoclaw/workspace/sessions` and the real NanoClaw SQLite at `~/nanoclaw-v2/data/v2-sessions`, ran the daemon, and **decrypted this node's live cloud snapshot**:

```
node: agent+Macbook-Pro-2-local
detectedRuntimes: [PicoClaw (1 session, ~/.picoclaw), NanoClaw (2 sessions, ~/nanoclaw-v2)]
runtimeInfo rows:  "PicoClaw: detected (1 session)", "NanoClaw: detected (2 sessions)"
```

A cloud-side audit (in `clawmetry-cloud`) confirmed:
- The Runtime panel renderer (`app.js:13547`, served from the OSS wheel) is a generic loop, so the new rows auto-render. **No cloud code, route, or policy change needed.**
- The E2E-encryption invariant holds: the cloud only stores/serves the opaque AES-256-GCM blob; the browser decrypts. No server-side compute on the runtime data.

## Tests

`tests/test_runtime_detection_snapshot.py` (5 tests) wired into the `moat-tests` CI job and `make test-compat`. 41 compat tests pass on Python 3.9.

```
$ make test-compat
41 passed
```

## Notes / next phase

- This surfaces the runtime **label + session count**. Ingesting each runtime's individual sessions into the cloud sessions list (so you can open a PicoClaw/NanoClaw transcript in the cloud) is the next phase; it requires adapter-driven DuckDB ingest and is tracked in the PRDs.
- No cloud `Dockerfile` pin bump is required (the Runtime renderer already exists in the pinned wheel; the new data rides the snapshot the daemon produces). A PyPI release of the OSS daemon ships the detection to all users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)