### PR TITLE
fix(audit): full clawmetry-session match in reliability scoring + gate overview self-poll (#2019)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8430,9 +8430,15 @@ def _build_reliability(limit_sessions=25, min_sessions=4):
         # score the user's real agent, not our own selfevolve/probe runs).
         order = []
         by_sid = {}
+        from clawmetry.config import is_clawmetry_internal_session
         for e in evs:
             sid = (e.get("session_id") or "").strip()
-            if not sid or sid.startswith("clawmetry-"):
+            # #2019: skip ClawMetry's own helper sessions from reliability
+            # scoring. is_clawmetry_internal_session matches both the bare id
+            # and the full OpenClaw form (agent:main:explicit:clawmetry-*);
+            # the old startswith("clawmetry-") missed the latter and let our
+            # selfevolve/probe runs pollute the user's real-agent score.
+            if not sid or is_clawmetry_internal_session(sid):
                 continue
             if sid not in by_sid:
                 by_sid[sid] = []

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -512,6 +512,11 @@
       // app.js. The backend caches the heartbeat block for 30s so this is
       // cheap; we still poll every 60s to keep the gap counter ticking.
       function pollOnce(){
+        // #2019: skip the poll when the browser tab is hidden. This is a
+        // second, independent /api/overview poller (decoupled from app.js's
+        // loadAll on purpose), so it can't ride loadAll's coalesce window —
+        // gate it directly so it doesn't fetch every 60s while backgrounded.
+        if (typeof document !== 'undefined' && document.hidden) return;
         fetch('/api/overview', {credentials: 'same-origin'})
           .then(function(r){ return r.ok ? r.json() : null; })
           .then(function(d){


### PR DESCRIPTION
Closes #2019. Proactive sweep for siblings of #1954 (prefix-only `clawmetry-` matcher) and #1969 (ungated pollers).

- **`sync.py`** reliability/score builder skipped helper sessions via `sid.startswith("clawmetry-")`, missing the full OpenClaw form `agent:main:explicit:clawmetry-*` — our own selfevolve/probe runs could pollute the user's real-agent reliability score. Now uses `is_clawmetry_internal_session` (matches both forms, central matcher fixed in #1954).
- **`overview.html`** had a *second*, independent `/api/overview` poller (`pollOnce`, every 60s) decoupled from app.js `loadAll` on purpose — so #1969's coalesce window can't reach it, and it fetched every 60s even while the tab was hidden. Added a `document.hidden` gate.

Daemon change (sync matcher) → lights up cloud reliability scoring once the pin advances; the overview poll gate ships via the served template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)