### PR TITLE
feat(compat): PicoClaw + NanoClaw sessions in the sessions list + transcripts (phase 3b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
             tests/test_picoclaw_adapter.py \
             tests/test_nanoclaw_adapter.py \
             tests/test_runtime_detection_snapshot.py \
+            tests/test_family_runtime_ingest.py \
             -q
 
   # ── MOAT keystone (DuckDB-first invariant, 13-endpoint bar) ──────────────

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: test-api test-e2e test-e2e-duckdb test-workflow test-compat
 # (per-session SQLite). Hermetic, ~1s — no live server, no gateway, no
 # network. Mirror in .github/workflows/ci.yml (moat-tests job).
 test-compat:
-	python3 -m pytest tests/test_picoclaw_adapter.py tests/test_nanoclaw_adapter.py tests/test_runtime_detection_snapshot.py -v
+	python3 -m pytest tests/test_picoclaw_adapter.py tests/test_nanoclaw_adapter.py tests/test_runtime_detection_snapshot.py tests/test_family_runtime_ingest.py -v
 
 test-fast:
 	CLAWMETRY_URL=http://localhost:8900 CLAWMETRY_TOKEN=dev-token python3 -m pytest tests/test_api.py -v

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7479,6 +7479,180 @@ def _detect_family_runtimes():
     return out
 
 
+def _epoch_to_iso(epoch) -> str | None:
+    """Convert a float/int epoch-seconds timestamp to an ISO-8601 UTC string.
+
+    The family adapters return ``started_at`` / ``ended_at`` / event ``ts`` as
+    float epoch seconds, but every DuckDB ``ts`` / ``started_at`` column is an
+    ISO string (OpenClaw stamps ISO, and ``query_sessions`` does
+    ``CAST(ts AS TIMESTAMP)`` + string ``ts >= ?`` comparisons). Returns None on
+    anything unparseable so a bad timestamp never crashes ingest or breaks sort.
+    """
+    if not epoch:
+        return None
+    try:
+        return datetime.fromtimestamp(float(epoch), tz=timezone.utc).isoformat()
+    except (ValueError, OSError, OverflowError, TypeError):
+        return None
+
+
+def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
+    """Ingest PicoClaw + NanoClaw sessions into DuckDB (and the cloud) so they
+    appear in the sessions list + transcripts the same way OpenClaw does.
+
+    These runtimes store sessions in their OWN native formats (PicoClaw: flat
+    ``providers.Message`` JSONL; NanoClaw: per-session SQLite), so we read them
+    through the reader adapters (which translate to the unified Session/Event
+    shapes) and map those onto the SAME DuckDB rows OpenClaw uses:
+
+    - ``agent_type='openclaw'`` so every existing read path (``/api/sessions``,
+      transcripts, ``query_sessions_table``'s events-join) returns them with no
+      filter changes; the runtime is carried in ``metadata.runtime`` (session)
+      and ``data._runtime`` (events) as the discriminator.
+    - session ids are namespaced (``picoclaw:<key>`` / ``nanoclaw:<id>``) so a
+      runtime UUID can never collide with an OpenClaw one in the shared
+      ``(agent_type, session_id)`` PK.
+    - event types stay ``message`` / ``tool_call`` / ``tool_result`` (the
+      renderable set) so transcripts render and ``message_count`` counts.
+
+    Writes go through the daemon's OWN writer handle (``local_store.get_store()``),
+    never a ``read_only=True`` re-open (the #1771 brick-lock). Gated by
+    ``_sync_allowed()`` exactly like ``sync_sessions`` / ``sync_session_metadata``.
+    Returns the number of events ingested.
+    """
+    if not _sync_allowed():
+        return 0
+    try:
+        from clawmetry.adapters.picoclaw import PicoClawAdapter
+        from clawmetry.adapters.nanoclaw import NanoClawAdapter
+        from clawmetry import local_store
+    except Exception as exc:  # adapters unavailable (old wheel) — degrade quietly
+        log.debug(f"family-runtime adapters unavailable for ingest: {exc}")
+        return 0
+
+    node_id = config.get("node_id") or ""
+    api_key = config.get("api_key")
+    store = local_store.get_store()
+    total_events = 0
+    cloud_session_rows: list = []
+
+    for cls in (PicoClawAdapter, NanoClawAdapter):
+        try:
+            adapter = cls()  # construct once (NanoClaw discovery globs are not free)
+            if not adapter.detect().detected:
+                continue
+            runtime = adapter.name
+            for s in adapter.list_sessions(limit=50):
+                ns_id = f"{runtime}:{s.id}"
+                started = _epoch_to_iso(s.started_at)
+                ended = _epoch_to_iso(s.ended_at)
+                metadata = {
+                    "runtime": runtime,
+                    "displayName": s.display_name or "",
+                    "model": s.model or "",
+                    # recent_model is the key the sessions list reads to label
+                    # the model column (OpenClaw rows use the same key).
+                    "recent_model": s.model or "",
+                    "source": s.source or "",
+                }
+                if isinstance(s.extra, dict):
+                    metadata.update(
+                        {k: v for k, v in s.extra.items() if k not in metadata}
+                    )
+                # Local upsert (the sessions list reads this).
+                try:
+                    store.ingest_session({
+                        "agent_type": "openclaw",
+                        "session_id": ns_id,
+                        "node_id": node_id,
+                        "agent_id": "main",
+                        "title": s.display_name or s.title or s.id,
+                        "started_at": started,
+                        "last_active_at": ended or started,
+                        "ended_at": ended,
+                        "status": "ended",
+                        "total_tokens": int(s.total_tokens or 0),
+                        "cost_usd": s.cost_usd,
+                        "message_count": int(s.message_count or 0),
+                        "metadata": metadata,
+                    })
+                except Exception as _se:
+                    log.warning("family session upsert failed (%s): %s", ns_id, _se)
+                    continue
+                # Carry the same row to cloud so the cloud Sessions list shows it.
+                cloud_session_rows.append({
+                    "agent_type": "openclaw",
+                    "session_id": ns_id,
+                    "node_id": node_id,
+                    "agent_id": "main",
+                    "title": s.display_name or s.title or s.id,
+                    "started_at": started,
+                    "last_active_at": ended or started,
+                    "ended_at": ended,
+                    "status": "ended",
+                    "total_tokens": int(s.total_tokens or 0),
+                    "cost_usd": s.cost_usd,
+                    "message_count": int(s.message_count or 0),
+                    "runtime": runtime,
+                    "model": s.model or "",
+                })
+                # Events → transcript (rides the existing _build_transcripts path).
+                rows = []
+                for e in adapter.list_events(s.id, limit=2000):
+                    ets = _epoch_to_iso(e.ts)
+                    if not ets:
+                        continue
+                    data = {"role": e.role, "content": e.content, "_runtime": runtime}
+                    if e.tool_calls:
+                        data["tool_calls"] = e.tool_calls
+                    if e.tool_name:
+                        data["tool_name"] = e.tool_name
+                    if isinstance(e.extra, dict) and e.extra:
+                        data["extra"] = e.extra
+                    rows.append({
+                        "id": f"{runtime}:{e.id}",
+                        "node_id": node_id,
+                        "agent_id": "main",
+                        "session_id": ns_id,
+                        "workspace_id": None,
+                        "event_type": e.type or "message",
+                        "ts": ets,
+                        "data": data,
+                        "cost_usd": None,
+                        "token_count": int(e.tokens or 0),
+                        "model": s.model or None,
+                    })
+                if rows:
+                    try:
+                        store.ingest_many(rows)
+                        total_events += len(rows)
+                    except Exception as _ee:
+                        log.warning("family event ingest failed (%s): %s", ns_id, _ee)
+        except Exception as exc:
+            log.warning(
+                "family runtime ingest failed for %s: %s",
+                getattr(cls, "name", cls.__name__), exc,
+            )
+
+    if total_events or cloud_session_rows:
+        try:
+            store.flush()
+        except Exception as _fe:
+            log.debug("family ingest flush failed (continuing): %s", _fe)
+    # Push session rows to cloud so the cloud Sessions list shows them. Mirrors
+    # sync_session_metadata's cloud push; best-effort and never blocks.
+    if cloud_session_rows and api_key:
+        try:
+            _post(
+                "/ingest/sessions",
+                {"node_id": node_id, "sessions": cloud_session_rows},
+                api_key,
+            )
+        except Exception as _pe:
+            log.debug("family sessions cloud push failed (continuing): %s", _pe)
+    return total_events
+
+
 def _build_runtime_info():
     """Build runtime environment info for the Runtime popup."""
     try:
@@ -10066,6 +10240,12 @@ def run_daemon() -> None:
     except Exception as e:
         log.warning(f"  Session metadata error: {e}")
     try:
+        fr = sync_family_runtimes(config, state, paths)
+        if fr:
+            log.info(f"  Family-runtime sessions (PicoClaw/NanoClaw): {fr} events synced")
+    except Exception as e:
+        log.warning(f"  Family-runtime sync error: {e}")
+    try:
         cr = sync_crons(config, state, paths)
         if cr:
             log.info(f"  Crons: {cr} synced")
@@ -10245,6 +10425,8 @@ def run_daemon() -> None:
     heartbeat_interval = _pick_heartbeat_interval(_LAST_HEARTBEAT_RESPONSE)
     snapshot_interval = 60  # system snapshot (subagents, flow metrics) every 60s
     log_sync_interval = 60  # log lines are low-priority; streamer covers real-time
+    family_interval = 60  # PicoClaw/NanoClaw ingest; cheap when absent, throttled when present
+    last_family = 0  # force first family-runtime ingest immediately
     last_heartbeat = time.time()
     last_snapshot = 0  # force first snapshot immediately
     last_log_sync = (
@@ -10305,6 +10487,17 @@ def run_daemon() -> None:
 
             ev = sync_sessions(config, state, paths)
             ev += sync_claude_cli_sessions(config, state, paths)
+            # OpenClaw-family runtimes (PicoClaw/NanoClaw) sessions -> DuckDB +
+            # cloud, throttled. Cheap no-op when neither runtime is present
+            # (detect() short-circuits), so the gate is just to bound the
+            # per-session file/SQLite reads when one IS present.
+            now_fam = time.time()
+            if now_fam - last_family > family_interval:
+                try:
+                    ev += sync_family_runtimes(config, state, paths)
+                except Exception as _fam_e:
+                    log.warning("family-runtime ingest failed (continuing): %s", _fam_e)
+                last_family = now_fam
             # PRIMARY: walk OpenClaw's sessions.json → ``cliSessionIds.claude-cli``
             # → ``~/.claude/projects/<encoded-cwd>/<id>.jsonl`` plus subagents/
             # and tool-results/. Tags events under the OpenClaw session UUID

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -455,10 +455,12 @@ def _try_local_store_sessions():
             "total_tokens":   int(r.get("total_tokens") or 0),
             "total_cost":     float(r.get("cost_usd") or 0.0),
             "message_count":  int(r.get("message_count") or 0),
+            "model":          meta.get("recent_model") or meta.get("model") or "",
             "channel":        meta.get("channel", ""),
             "chat_type":      meta.get("chat_type", ""),
             "subject":        title or meta.get("subject", ""),
             "session_type":   meta.get("session_type", "main"),
+            "runtime":        meta.get("runtime", ""),
             "_source":        "local_store",
         })
     # Decorate with channel context from the typed openclaw_channels table.

--- a/tests/test_family_runtime_ingest.py
+++ b/tests/test_family_runtime_ingest.py
@@ -1,0 +1,162 @@
+"""Phase-3b: sync_family_runtimes ingests PicoClaw + NanoClaw sessions into DuckDB.
+
+Verifies the daemon maps the reader adapters' unified Session/Event objects onto
+the same DuckDB rows OpenClaw uses, so the runtimes appear in the sessions list +
+transcripts. Tagged agent_type='openclaw' + data._runtime, namespaced session ids,
+ISO timestamps. Cloud push (_post) is mocked; the assertions are about the local
+store (the source of truth the sessions list + snapshot read from).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+_FIX = os.path.join(os.path.dirname(__file__), "fixtures", "runtimes")
+_PICO_HOME = os.path.join(_FIX, "picoclaw")          # <home>/workspace/sessions/*.jsonl
+_NANO_DIR = os.path.join(_FIX, "nanoclaw", "REAL")   # <group>/<session>/{inbound,outbound}.db
+
+
+@pytest.fixture
+def sync_with_isolated_store(tmp_path, monkeypatch):
+    """Reload sync + local_store with an isolated DB, pointed at the fixtures."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    # Point the family adapters at the committed real-capture fixtures.
+    monkeypatch.setenv("PICOCLAW_HOME", _PICO_HOME)
+    monkeypatch.setenv("CLAWMETRY_NANOCLAW_DIR", _NANO_DIR)
+    import clawmetry.local_store as ls
+    import clawmetry.sync as sync
+    importlib.reload(ls)
+    importlib.reload(sync)
+    # Force the in-process writer on the isolated tmp DB. Without this, when a
+    # real ClawMetry daemon happens to be running on the dev box, get_store()
+    # returns a proxy to that daemon's PROD store and the test would read/write
+    # the wrong database. In CI no daemon runs, so this is a harmless no-op.
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    yield sync, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait_for_flush(store, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+    raise AssertionError("flusher did not drain in time")
+
+
+def test_family_runtimes_ingest_sessions_and_events(sync_with_isolated_store):
+    sync, ls = sync_with_isolated_store
+    # api_key truthy so the cloud-push path runs (_post is mocked below).
+    config = {"node_id": "test-node", "api_key": "test-key"}
+
+    with patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}) as mock_post:
+        n_events = sync.sync_family_runtimes(config, {}, {})
+
+    assert n_events > 0, "expected family-runtime events to be ingested"
+    store = ls.get_store()
+    _wait_for_flush(store)
+
+    # Sessions landed under namespaced ids, tagged agent_type='openclaw'.
+    rows = store._fetch(
+        "SELECT agent_type, session_id, title, message_count, metadata "
+        "FROM sessions WHERE session_id LIKE 'picoclaw:%' OR session_id LIKE 'nanoclaw:%'",
+        [],
+    )
+    sids = {r[1] for r in rows}
+    assert any(s.startswith("picoclaw:") for s in sids), f"no picoclaw session: {sids}"
+    assert any(s.startswith("nanoclaw:") for s in sids), f"no nanoclaw session: {sids}"
+    for agent_type, sid, _title, mcount, meta in rows:
+        assert agent_type == "openclaw", f"{sid} should be tagged openclaw, got {agent_type}"
+        # runtime discriminator is preserved in metadata
+        md = json.loads(meta) if isinstance(meta, (str, bytes)) else (meta or {})
+        assert md.get("runtime") in ("picoclaw", "nanoclaw")
+
+    # Events landed with renderable types + the _runtime discriminator.
+    evrows = store._fetch(
+        "SELECT session_id, event_type, data FROM events "
+        "WHERE session_id LIKE 'picoclaw:%' OR session_id LIKE 'nanoclaw:%'",
+        [],
+    )
+    assert evrows, "expected family-runtime events in the events table"
+    types = {r[1] for r in evrows}
+    assert "message" in types
+    for _sid, etype, data in evrows:
+        d = json.loads(data) if isinstance(data, (str, bytes)) else (data or {})
+        assert d.get("_runtime") in ("picoclaw", "nanoclaw")
+    # PicoClaw real capture has an exec tool call -> tool_call event present.
+    assert "tool_call" in types
+
+    # Cloud push was attempted with the namespaced session rows.
+    assert mock_post.called
+    _path, payload, _key = mock_post.call_args[0]
+    assert _path == "/ingest/sessions"
+    assert any(
+        s["session_id"].startswith(("picoclaw:", "nanoclaw:"))
+        for s in payload["sessions"]
+    )
+
+
+def test_family_runtimes_transcript_renders(sync_with_isolated_store):
+    """Ingested events render as a transcript (the renderable event-type path)."""
+    sync, ls = sync_with_isolated_store
+    config = {"node_id": "test-node", "api_key": None}
+    with patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}):
+        sync.sync_family_runtimes(config, {}, {})
+    store = ls.get_store()
+    _wait_for_flush(store)
+
+    # Find a picoclaw session and pull its events back in ts order (what the
+    # transcript builder does). query_events applies no agent_type filter.
+    sess = store._fetch(
+        "SELECT session_id FROM sessions WHERE session_id LIKE 'picoclaw:%' LIMIT 1", []
+    )
+    assert sess, "no picoclaw session to render"
+    sid = sess[0][0]
+    evs = store.query_events(session_id=sid, limit=1000)
+    assert evs, "transcript events should be returned by query_events (no agent_type filter)"
+    roles = {(json.loads(e["data"]) if isinstance(e.get("data"), (str, bytes)) else e.get("data", {})).get("role")
+             for e in evs}
+    assert "user" in roles and "assistant" in roles
+
+
+def test_family_runtimes_gated_by_sync_allowed(sync_with_isolated_store):
+    sync, _ls = sync_with_isolated_store
+    with patch.object(sync, "_sync_allowed", return_value=False):
+        assert sync.sync_family_runtimes({"node_id": "n"}, {}, {}) == 0
+
+
+def test_family_runtimes_noop_when_absent(tmp_path, monkeypatch):
+    """No PicoClaw/NanoClaw on the host -> zero events, never raises."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("PICOCLAW_HOME", str(tmp_path / "nope-pico"))
+    monkeypatch.setenv("CLAWMETRY_NANOCLAW_DIR", str(tmp_path / "nope-nano"))
+    monkeypatch.setenv("HOME", str(tmp_path))  # keep nano discovery from finding a real checkout
+    import clawmetry.local_store as ls
+    import clawmetry.sync as sync
+    importlib.reload(ls)
+    importlib.reload(sync)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    try:
+        with patch.object(sync, "_sync_allowed", return_value=True), \
+             patch.object(sync, "_post", return_value={}) as mock_post:
+            assert sync.sync_family_runtimes({"node_id": "n", "api_key": "k"}, {}, {}) == 0
+        assert not mock_post.called
+    finally:
+        try:
+            ls.get_store().stop(flush=True)
+        except Exception:
+            pass


### PR DESCRIPTION
Builds on #2013 (adapters) and #2014 (cloud runtime label). Phase 3b makes PicoClaw + NanoClaw sessions **fully observable like OpenClaw**: they show up in the sessions list and render as transcripts, locally and in the cloud.

## What

New daemon function `sync_family_runtimes()` (`clawmetry/sync.py`). For each detected family runtime it reads sessions + events through the existing reader adapters (which translate the native formats to unified `Session`/`Event`) and maps them onto the **same DuckDB rows OpenClaw uses**, through the daemon's own writer handle (`local_store.get_store()`, never a `read_only` re-open):

- `agent_type='openclaw'` so every existing read path returns them with no filter changes; the runtime rides in `metadata.runtime` + `data._runtime`.
- session ids namespaced (`picoclaw:<key>` / `nanoclaw:<id>`) to avoid PK collision with OpenClaw UUIDs.
- event types `message` / `tool_call` / `tool_result` (the renderable set) so transcripts render and `message_count` counts with zero filter edits.
- `_epoch_to_iso()` converts the adapters' float-epoch timestamps to the ISO strings every DuckDB `ts` column expects.
- session rows pushed to `/ingest/sessions` so the cloud sessions list shows them. Gated by `_sync_allowed()`, throttled 60s.

Transcripts ride the existing `_build_transcripts` (reads `query_events`, no `agent_type` filter), so the cloud snapshot includes them with no extra snapshot work.

`routes/sessions.py`: `_try_local_store_sessions` now surfaces `model` (`metadata.recent_model`) + `runtime` — fills the model column for family sessions (and OpenClaw sessions on the local-store path).

**No `local_store.py` changes** (by design — keeps the change off a concurrently-edited file and needs no read-filter widening).

## Verified live, end to end (real node)

Ran the ingest against the real `~/.picoclaw` + `~/nanoclaw-v2` captures from the earlier installs:
- `/api/sessions` → `picoclaw:…` (model `llama3`, runtime `picoclaw`, 10 msgs) + 2 `nanoclaw:…` sessions.
- `/api/transcript/<picoclaw session>` → renders in full: user → assistant → **exec tool call with args** → tool result `hello-from-picoclaw` → summary.
- Decrypted the **live cloud snapshot**: all 3 family transcripts present (`picoclaw:…` 12 msgs + both `nanoclaw:…`), plus `detectedRuntimes`.

## Tests

`tests/test_family_runtime_ingest.py` (4 tests: ingest→DuckDB with namespaced ids + `_runtime` tags, transcript render via `query_events`, `_sync_allowed` gate, absent no-op). Wired into the `moat-tests` CI job + `make test-compat`. 45 compat tests pass on Python 3.9.

```
$ make test-compat
45 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)