### PR TITLE
ci(release): build v2 frontend before packaging (stop shipping stale dist to PyPI)

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -155,6 +155,21 @@ jobs:
           echo "new=$NEW" >> $GITHUB_OUTPUT
           echo "Bumped $OLD → $NEW"
 
+      # Rebuild the v2 React bundle from source so the wheel never ships a
+      # stale committed clawmetry/static/v2/dist/. publish.yml already does
+      # this; this path (the actual [RELEASE] publish) did not, so PyPI shipped
+      # whatever dist happened to be committed — which lags source whenever a
+      # v2 PR lands without rebuilding the bundle.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Build v2 React bundle (fresh)
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+
       - name: Build package
         run: python3 -m build
 


### PR DESCRIPTION
## Problem

The OSS release path — **`release-on-merge.yml`** (fires on a `[RELEASE]` merge and `twine upload`s directly to PyPI) — ran `python3 -m build` against the **committed** `clawmetry/static/v2/dist/` **without rebuilding it**.

That bundle is Vite hash-named and chronically lags source: nobody re-runs `npm run build` when a v2 PR merges, so the committed dist drifts. Verified on current `main` — the committed bundle (`index-DOOhBMLZ.js`) contains **none** of the `/api/v2/ops`, `/api/v2/brain`, `/api/v2/context`, `/api/v2/cost` pages whose source already merged. So **every PyPI release shipped a stale v2 UI**.

`publish.yml` (the tag-triggered path) already builds the frontend first — but `release-on-merge.yml`, the path that actually publishes, did not.

## Fix

Add `setup-node` + `cd frontend && npm ci && npm run build` **before** `python3 -m build` in `release-on-merge.yml`, mirroring `publish.yml` exactly. Every release now packages a bundle built from current source.

Purely additive — no change to the committed-dist convention (source/dev installs still use it) or the cloud Dockerfile.

## Verification
- `yaml.safe_load` → OK.
- Build order confirmed: `setup-node` → `npm run build` → `python3 -m build` → `twine upload`.
- The next `[RELEASE]` will rebuild the bundle; the wheel's `static/v2/dist/` will reflect current source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)