### PR TITLE
feat(sync-banner): add a Hide button to the "Syncing your OpenClaw" banner

### DIFF
--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -318,6 +318,7 @@
     </div>
     <div id="sync-status-stepper" style="display:flex;gap:6px;flex-wrap:wrap;justify-content:flex-end;"></div>
     <button id="sync-status-toggle" type="button" onclick="cmSyncToggleDetails()" aria-expanded="false" style="background:transparent;border:1px solid #334074;color:#94a3b8;border-radius:6px;padding:4px 12px;font-size:11px;cursor:pointer;">Show details</button>
+    <button id="sync-status-hide" type="button" onclick="_cmSyncDismiss()" title="Hide this banner" aria-label="Hide sync banner" style="background:transparent;border:1px solid #334074;color:#94a3b8;border-radius:6px;padding:4px 10px;font-size:11px;cursor:pointer;">Hide</button>
   </div>
   <div id="sync-status-details" style="display:none;margin-top:10px;padding:8px 12px;background:rgba(15,23,42,0.6);border:1px solid #1e293b;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;color:#94a3b8;max-height:180px;overflow:auto;"></div>
   <div id="sync-status-error" style="display:none;margin-top:10px;padding:10px 12px;background:rgba(127,29,29,0.25);border:1px solid #7f1d1d;border-radius:6px;font-size:12px;color:#fecaca;"></div>


### PR DESCRIPTION
## What
The first-install **"Syncing your OpenClaw workspace"** banner (`PRD-sync-status.md`) had a "Show details" toggle but **no way to dismiss it**. When sync is slow or stuck — e.g. the daemon isn't running and it shows *"Sync hasn't reported progress yet"* — it stays pinned to the top of every tab with no escape.

## Change
Adds a **"Hide"** button next to "Show details" that calls the existing `_cmSyncDismiss()`:
- hides the banner, stops the poll timer, records `cm-sync-verified-ts`
- `cmSyncInit()` already honors that timestamp, so it stays hidden for the next hour (and indefinitely while the daemon is down, since `/api/sync-progress` returns null)

No new logic — just wires the existing dismiss path to a user control. One-line addition to `clawmetry/templates/partials/banners.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)