### PR TITLE
fix(context-window): model-aware window so the LLM Context gauge never reads >100%

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import threading
 import time
@@ -5435,10 +5436,24 @@ class LocalStore:
                     + int(splits.get("cache_write_tokens", 0))
                 )
                 if tok > 0:
+                    # Carry the turn's model so callers can size the context
+                    # window correctly (e.g. 1M for the [1m] Opus variant).
+                    # Without it, currentContextTokens=323K rendered against
+                    # a hardcoded 200K window read ">100%". Probed across the
+                    # same shapes _extract_usage_splits handles.
+                    msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+                    model = (
+                        msg.get("model")
+                        or data.get("model")
+                        or data.get("modelId")
+                        or ""
+                    )
                     return {
                         "session_id":   sid,
                         "input_tokens": tok,
                         "ts":           ts,
+                        "model":        model,
+                        "context_window": context_window_for_model(model, tok),
                     }
         return {"input_tokens": 0}
 
@@ -6979,6 +6994,50 @@ def _sql_in_clause(values: tuple[str, ...]) -> str:
     so it's safe to interpolate them directly. Centralised so the four
     fast-path methods can keep their predicates in sync."""
     return "(" + ", ".join("'" + v.replace("'", "''") + "'" for v in values) + ")"
+
+
+# Standard Claude context window. Most models are 200K; the [1m] Opus/Sonnet
+# variants are 1M. Other providers/local models vary, but 200K is a safe
+# default that the observed-tokens guard below corrects upward when wrong.
+_DEFAULT_CONTEXT_WINDOW = 200_000
+_LARGE_CONTEXT_WINDOW = 1_000_000
+
+
+def context_window_for_model(model: str, observed_tokens: int = 0) -> int:
+    """Best-effort context-window size (in tokens) for ``model``.
+
+    Used to size the LLM Context Inspector gauge so currentContextTokens /
+    contextWindow is coherent. Before this, contextWindow was hardcoded to
+    200K everywhere, so a Claude Code turn on the 1M Opus variant
+    (currentContextTokens ≈ 323K) rendered as ">100%". (Surfaced
+    2026-05-25.)
+
+    Two signals, in order:
+      1. **Model string** — a ``1m`` marker (``claude-opus-4-7[1m]``,
+         ``...-1m``) means the 1M variant.
+      2. **Observed tokens** — a measured prompt can never exceed the
+         model's window, so if we saw MORE than the string-derived base we
+         must be on a larger variant whose marker we didn't recognise (the
+         beta 1M header isn't always echoed into the model string). Bump to
+         the next standard tier so the gauge never reads >100%.
+
+    Args:
+        model: the model string from the turn (may be empty).
+        observed_tokens: the measured live context size, if known. Acts as
+            a floor for the returned window.
+    """
+    m = (model or "").lower()
+    if "1m" in m:  # matches [1m], -1m, _1m, "1m"
+        base = _LARGE_CONTEXT_WINDOW
+    else:
+        base = _DEFAULT_CONTEXT_WINDOW
+    obs = int(observed_tokens or 0)
+    if obs > base:
+        if obs <= _LARGE_CONTEXT_WINDOW:
+            return _LARGE_CONTEXT_WINDOW
+        # Round up to the next whole-million tier for >1M contexts.
+        return int(math.ceil(obs / _LARGE_CONTEXT_WINDOW) * _LARGE_CONTEXT_WINDOW)
+    return base
 
 
 def _extract_input_tokens(data: dict) -> int:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9654,6 +9654,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     # cloud. Both built on the daemon's OWN store handle (no read-only
     # re-open → no writer-lock brick; see FLYWHEEL.md §1).
     current_context_tokens = 0
+    context_window = 200000
     try:
         from clawmetry import local_store as _ls_ctx
         _ctx_store = _ls_ctx.get_store()
@@ -9662,6 +9663,9 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
                 scan_sessions=5, exclude_clawmetry=True,
             ) or {}
             current_context_tokens = int(_peek.get("input_tokens") or 0)
+            # Size the window from the peeked turn's model + observed size so
+            # the gauge stays coherent (1M for [1m]/large-context sessions).
+            context_window = int(_peek.get("context_window") or 0) or 200000
     except Exception as _e:
         log.debug("snapshot: query_context_window_peek failed: %s", _e)
 
@@ -9684,7 +9688,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "mainTokens": main_tokens,
         "currentContextTokens": current_context_tokens,
         "skillHeaderTokens": skill_header_tokens,
-        "contextWindow": 200000,
+        "contextWindow": context_window,
         "cronCount": cron_enabled + cron_disabled,
         "cronEnabled": cron_enabled,
         "cronDisabled": cron_disabled,

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -789,20 +789,44 @@ def _compute_gateway_tap_comms() -> dict:
 # skillHeaderTokens) that both /api/overview and the daemon snapshot now
 # expose so the Context tab reads one value on both sides.
 
-def _try_local_store_current_context_tokens():
-    """Live prompt size for the user's most-recent assistant turn.
+def _try_local_store_context_peek():
+    """Full context-window peek for the user's most-recent assistant turn.
 
-    Wraps ``routes.infra._try_local_store_session_history_tokens`` (which
-    in turn calls ``LocalStore.query_context_window_peek``) and pins
-    ``exclude_clawmetry=True`` so the gauge tracks the user's agent,
-    not ClawMetry-internal plumbing. Returns 0 when the local store is
-    cold or the daemon proxy can't be reached — the frontend then falls
-    back to mainTokens for backwards compatibility.
+    Returns ``{"input_tokens": int, "context_window": int}`` (other keys
+    from ``query_context_window_peek`` may be present). ``exclude_clawmetry``
+    is pinned True so the gauge tracks the user's agent, not ClawMetry's own
+    plumbing. ``context_window`` is sized from the turn's model + observed
+    size so a 1M-context session (≈323K live) reads against a 1M window
+    instead of the old hardcoded 200K (which showed ">100%"). Returns an
+    empty dict on any miss so callers fall back to defaults.
     """
     try:
-        from routes.infra import _try_local_store_session_history_tokens
-        v = _try_local_store_session_history_tokens(exclude_clawmetry=True)
-        return int(v or 0)
+        from routes.local_query import local_store_via_daemon
+        peek = local_store_via_daemon(
+            "query_context_window_peek", scan_sessions=5, exclude_clawmetry=True,
+        )
+    except Exception:
+        peek = None
+    if peek is None:
+        try:
+            from clawmetry import local_store
+            peek = local_store.get_store(read_only=True).query_context_window_peek(
+                scan_sessions=5, exclude_clawmetry=True,
+            )
+        except Exception:
+            return {}
+    return peek if isinstance(peek, dict) else {}
+
+
+def _try_local_store_current_context_tokens():
+    """Live prompt size (int) for the user's most-recent assistant turn.
+
+    Thin wrapper over :func:`_try_local_store_context_peek` kept for
+    backwards compatibility. Returns 0 on any miss — the frontend then
+    falls back to mainTokens.
+    """
+    try:
+        return int((_try_local_store_context_peek() or {}).get("input_tokens") or 0)
     except Exception:
         return 0
 
@@ -1034,11 +1058,16 @@ def _try_local_store_overview():
     user_session_count = len(user_sessions) if user_sessions else len(sessions)
 
     # `currentContextTokens` is the right "Context Window Usage" gauge —
-    # the most recent assistant turn's input_tokens (i.e. live prompt
-    # size), filtered to exclude clawmetry-* plumbing sessions. Falls
-    # back to 0 so the frontend can degrade to mainTokens for backwards
-    # compatibility (older daemons without the snapshot field).
-    current_context_tokens = _try_local_store_current_context_tokens()
+    # the most recent assistant turn's live prompt size (input + cache),
+    # filtered to exclude clawmetry-* plumbing sessions. `contextWindow`
+    # is sized from THAT turn's model + observed size so the gauge stays
+    # coherent: a 1M-context session (≈323K live) reads against a 1M
+    # window instead of the old hardcoded 200K (which showed ">100%").
+    # Falls back to 0 / 200K so the frontend can degrade to mainTokens
+    # for daemons without these fields.
+    _ctx_peek = _try_local_store_context_peek()
+    current_context_tokens = int(_ctx_peek.get("input_tokens") or 0)
+    context_window = int(_ctx_peek.get("context_window") or 0) or 200000
 
     # `skillHeaderTokens` lets the LLM Context Inspector render the
     # "## Skills" bar from the snapshot/overview without a separate
@@ -1056,7 +1085,7 @@ def _try_local_store_overview():
         "mainTokens": main.get("total_tokens", 0),
         "currentContextTokens": current_context_tokens or 0,
         "skillHeaderTokens": skill_header_tokens or 0,
-        "contextWindow": 200000,
+        "contextWindow": context_window,
         "cronCount": len(crons),
         "cronEnabled": enabled,
         "cronDisabled": disabled,

--- a/tests/test_context_window_model_aware.py
+++ b/tests/test_context_window_model_aware.py
@@ -1,0 +1,97 @@
+"""Model-aware context window sizing (surfaced 2026-05-25).
+
+currentContextTokens (the live prompt size) was rendered against a
+hardcoded 200K window everywhere. A Claude Code turn on the 1M Opus
+variant has ≈323K of live context, so the LLM Context Inspector gauge
+read ">100%". ``context_window_for_model`` sizes the denominator from the
+turn's model string and, defensively, from the observed token count (a
+measured prompt can never exceed the model's window).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ls():
+    import clawmetry.local_store as _ls
+    importlib.reload(_ls)
+    return _ls
+
+
+def test_default_window_is_200k(ls):
+    assert ls.context_window_for_model("claude-opus-4-7") == 200_000
+    assert ls.context_window_for_model("claude-sonnet-4-6") == 200_000
+    assert ls.context_window_for_model("") == 200_000
+    assert ls.context_window_for_model(None) == 200_000
+
+
+def test_1m_marker_gives_1m_window(ls):
+    assert ls.context_window_for_model("claude-opus-4-7[1m]") == 1_000_000
+    assert ls.context_window_for_model("claude-opus-4-7-1m") == 1_000_000
+    assert ls.context_window_for_model("CLAUDE-OPUS-4-7[1M]") == 1_000_000
+
+
+def test_observed_over_base_bumps_to_1m(ls):
+    # No 1m marker in the string, but the measured prompt exceeds 200K →
+    # the session must be on a larger-window variant. Bump so the gauge
+    # never reads >100%. This is the exact 323K Claude Code case.
+    assert ls.context_window_for_model("claude-opus-4-7", 323_485) == 1_000_000
+
+
+def test_observed_under_base_keeps_200k(ls):
+    # The user's normal OpenClaw agent: 200K window, compacts at 160K.
+    assert ls.context_window_for_model("claude-opus-4-7", 150_000) == 200_000
+
+
+def test_observed_over_1m_rounds_up(ls):
+    assert ls.context_window_for_model("claude-opus-4-7", 1_300_000) == 2_000_000
+
+
+def test_peek_returns_model_aware_window(ls, tmp_path, monkeypatch):
+    """End-to-end: a 1M-context turn (≈323K live) yields context_window=1M
+    in the peek result, not the hardcoded 200K."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    importlib.reload(ls)
+    ls.mark_writer_owner()
+    store = ls.get_store()
+    store.ingest({
+        "id": "ctxwin-1",
+        "node_id": "agent+Macbook-Pro-2-local",
+        "agent_id": "main",
+        "session_id": "625c0ad9-71af-4a56-9a3b-cab396860a85",
+        "event_type": "assistant",
+        "ts": "2026-05-25T18:50:51.723Z",
+        "data": {
+            "type": "assistant", "version": 3,
+            "message": {
+                "role": "assistant", "model": "claude-opus-4-7",
+                "usage": {
+                    "input_tokens": 2,
+                    "output_tokens": 140,
+                    "cache_read_input_tokens": 320_000,
+                    "cache_creation_input_tokens": 3_483,
+                },
+            },
+        },
+        "model": "claude-opus-4-7",
+    })
+    # flush
+    import time
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and store.health().get("ring_depth", 0):
+        time.sleep(0.02)
+
+    peek = store.query_context_window_peek(scan_sessions=5)
+    assert peek["input_tokens"] == 2 + 320_000 + 3_483  # 323485
+    assert peek["context_window"] == 1_000_000, (
+        f"window not model/observed-aware; got {peek.get('context_window')}"
+    )
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass


### PR DESCRIPTION
Follow-up to the LLM Context Inspector parity work (#1983 + the cache-sum fix).

## Why
`currentContextTokens` (live prompt size = input + cache_read + cache_write) was rendered against a **hardcoded 200K** `contextWindow` everywhere. A Claude Code turn on the **1M Opus** variant has ≈323K of live context, so the gauge read `323K / 200K` (clamped to 100%) — it looked maxed-out when the window was only **32% full**.

## Fix — size the window from the turn's model + observed size
- **`local_store.context_window_for_model(model, observed)`**: 1M for a `1m` marker (`claude-opus-4-7[1m]`, `…-1m`); defensively bumps to the next tier when the observed prompt exceeds the string-derived base. The beta 1M header isn't always echoed into the model string, so the observed token count is the reliable signal — a measured prompt can't exceed its own window.
- **`query_context_window_peek`** now returns the turn's `model` + `context_window`.
- **`/api/overview`** and the **daemon snapshot** set `contextWindow` from the peek (was `200000`). The cloud `cm-cloud-overview` interceptor already passes `snap.contextWindow` through, so cloud renders correctly with **no cloud-side code change** (just the OSS pin bump).

## Verified live (before merge)
Patched the local daemon, restarted, and checked both surfaces for the same node:

| | currentContextTokens | contextWindow | gauge |
|---|---|---|---|
| OSS `/api/overview` | 323485 | **1000000** | **32.3%** |
| decrypted cloud snapshot | 323485 | **1000000** | **32.3%** |

Previously both showed `323485 / 200000` (>100%, clamped).

For the user's normal OpenClaw agent (200K window, compacts at 160K) the window stays 200K — `context_window_for_model("claude-opus-4-7", 150000) == 200000`.

## Tests
`tests/test_context_window_model_aware.py`: the window matrix (default 200K, `1m` marker → 1M, observed-over-base bump, >1M round-up) + an end-to-end peek assertion (323485 live → 1M window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
