### PR TITLE
feat(cost): derive cost from tokens×model pricing at ingest + backfill (#2049)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -3497,6 +3497,76 @@ class LocalStore:
         params.append(int(limit))
         return [_row_to_event(r, _EVENT_COLS) for r in self._fetch(sql, params)]
 
+    def backfill_event_costs(self, *, batch: int = 5000) -> int:
+        """#2049: populate ``cost_usd`` for events that arrived without it.
+
+        OpenClaw / OAuth events carry tokens + model but no provider-reported
+        cost, so ``cost_usd`` was NULL/0 and the Cost tab showed ~$0 for heavy
+        usage (1.5M tokens -> $0.008). Recompute the API-equivalent cost from
+        each event's own token split x model pricing (cache-aware) and store
+        it. One bounded batch per call. Idempotent: only rows whose cost_usd
+        is NULL/0 AND whose derived cost is > 0 are written, so re-runs and
+        genuinely-free local-model rows are no-ops. Returns rows updated.
+        Daemon-only (needs the writer connection)."""
+        try:
+            from clawmetry.providers_pricing import estimate_event_cost_usd
+        except Exception:
+            return 0
+        try:
+            rows = self._conn.execute(
+                "SELECT id, data, model FROM events "
+                "WHERE (cost_usd IS NULL OR cost_usd = 0) "
+                "AND token_count > 0 AND model IS NOT NULL "
+                "LIMIT ?",
+                [int(batch)],
+            ).fetchall()
+        except Exception:
+            return 0
+
+        def _tok(u, *keys):
+            for k in keys:
+                v = u.get(k)
+                if v is not None:
+                    try:
+                        return int(v)
+                    except (TypeError, ValueError):
+                        pass
+            return 0
+
+        updates: list[tuple] = []
+        for (eid, data, model) in rows:
+            try:
+                if isinstance(data, (bytes, bytearray)):
+                    data = bytes(data).decode("utf-8", "replace")
+                obj = json.loads(data) if isinstance(data, str) else data
+            except Exception:
+                continue
+            if not isinstance(obj, dict):
+                continue
+            msg = obj.get("message") if isinstance(obj.get("message"), dict) else None
+            src = msg or obj
+            u = src.get("usage") if isinstance(src.get("usage"), dict) else {}
+            if not u:
+                continue
+            cost = estimate_event_cost_usd(
+                model,
+                _tok(u, "input_tokens", "inputTokens", "prompt_tokens"),
+                _tok(u, "output_tokens", "outputTokens", "completion_tokens"),
+                _tok(u, "cache_read_input_tokens", "cacheReadInputTokens"),
+                _tok(u, "cache_creation_input_tokens", "cacheCreationInputTokens"),
+            )
+            if cost and cost > 0:
+                updates.append((float(cost), eid))
+        if not updates:
+            return 0
+        try:
+            self._conn.executemany(
+                "UPDATE events SET cost_usd = ? WHERE id = ?", updates
+            )
+        except Exception:
+            return 0
+        return len(updates)
+
     def query_events_with_subagents(
         self,
         *,

--- a/clawmetry/providers_pricing.py
+++ b/clawmetry/providers_pricing.py
@@ -149,3 +149,78 @@ def _get_rates(provider: str, model: str) -> tuple[float, float]:
             return info["input_per_1m"], info["output_per_1m"]
 
     return 1.0, 3.0  # unknown provider — conservative default
+
+
+# #2049: self-hosted / local model name hints. Routed to the "local" provider
+# so _get_rates returns 0 (the user pays for hardware, not per token) instead
+# of the conservative unknown-provider default.
+_LOCAL_MODEL_HINTS = (
+    "llama", "qwen", "mistral", "mixtral", "deepseek", "phi", "gemma", "codellama",
+)
+
+# Anthropic prompt-cache multipliers, relative to the input rate:
+# cache reads are ~0.1x input; 5-minute cache writes are ~1.25x input.
+_CACHE_READ_MULT = 0.1
+_CACHE_WRITE_MULT = 1.25
+
+
+def provider_for_model(model: str) -> str:
+    """Best-effort provider id for pricing from a model name (self-contained,
+    daemon-safe — no dashboard import). Mirrors dashboard._provider_from_model
+    and additionally routes self-hosted models to "local" (zero cost).
+
+    Returns "" when nothing matches so callers can decide whether to fall back.
+    """
+    m = (model or "").lower()
+    if not m:
+        return ""
+    for prov in ("openai", "anthropic", "google", "openrouter", "xai"):
+        if m.startswith(prov + "/"):
+            return prov
+    if any(m.startswith(p + "/") for p in _LOCAL_PROVIDERS) or any(
+        h in m for h in _LOCAL_MODEL_HINTS
+    ):
+        return "local"
+    if "gpt" in m or "codex" in m or m.startswith(("o1", "o3", "o4")):
+        return "openai"
+    if "claude" in m:
+        return "anthropic"
+    if "gemini" in m:
+        return "google"
+    if "grok" in m:
+        return "xai"
+    return ""
+
+
+def estimate_event_cost_usd(
+    model: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    provider: str = "",
+) -> float:
+    """Cache-aware per-event cost in USD (#2049).
+
+    Infers the provider from the model when not supplied — important because
+    ``_get_rates`` needs the right provider (an empty provider falls through to
+    the conservative unknown default and mis-prices). Prices prompt-cache read
+    and write on top of input+output using Anthropic's documented multipliers
+    (only applied for the anthropic provider, where the split is well-defined).
+    Local / self-hosted models resolve to 0. Never raises.
+    """
+    try:
+        prov = provider or provider_for_model(model)
+        input_rate, output_rate = _get_rates(prov, model)
+        if input_rate == 0 and output_rate == 0:
+            return 0.0
+        cost = (
+            (max(0, int(input_tokens)) / 1_000_000) * input_rate
+            + (max(0, int(output_tokens)) / 1_000_000) * output_rate
+        )
+        if prov == "anthropic":
+            cost += (max(0, int(cache_read_tokens)) / 1_000_000) * input_rate * _CACHE_READ_MULT
+            cost += (max(0, int(cache_write_tokens)) / 1_000_000) * input_rate * _CACHE_WRITE_MULT
+        return round(cost, 8)
+    except Exception:
+        return 0.0

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2066,6 +2066,42 @@ def _extract_cost_tokens_model(obj: dict) -> tuple:
                         cost_usd = float(cv)
                     except (TypeError, ValueError):
                         cost_usd = None
+
+    # #2049: derive cost when the provider didn't report it. OpenClaw / OAuth
+    # events carry tokens + model but no cost_usd, so the Cost tab showed ~$0
+    # for heavy usage (1.5M tokens -> $0.008). Compute the API-equivalent cost
+    # from this event's own token split x model pricing (cache-aware) and store
+    # it — chosen semantics: derive-at-ingest, store-as-cost, so aggregates,
+    # budgets and per-session costs all see a real number. Local/self-hosted
+    # models resolve to 0 (no per-token charge). Best-effort, never raises.
+    if cost_usd is None and model:
+        u = usage if (isinstance(msg, dict) and isinstance(usage, dict)) else {}
+        if not u and isinstance(obj.get("usage"), dict):
+            u = obj["usage"]
+
+        def _utok(*keys):
+            for _k in keys:
+                _v = u.get(_k)
+                if _v is not None:
+                    try:
+                        return int(_v)
+                    except (TypeError, ValueError):
+                        pass
+            return 0
+
+        _in = _utok("input_tokens", "inputTokens", "prompt_tokens", "promptTokens")
+        _out = _utok("output_tokens", "outputTokens", "completion_tokens", "completionTokens")
+        _cr = _utok("cache_read_input_tokens", "cacheReadInputTokens", "cache_read_tokens")
+        _cw = _utok("cache_creation_input_tokens", "cacheCreationInputTokens", "cache_write_tokens")
+        if _in or _out or _cr or _cw:
+            try:
+                from clawmetry.providers_pricing import estimate_event_cost_usd
+                _derived = estimate_event_cost_usd(model, _in, _out, _cr, _cw)
+                if _derived and _derived > 0:
+                    cost_usd = _derived
+            except Exception:
+                pass
+
     return cost_usd, token_count, model
 
 
@@ -8421,6 +8457,31 @@ def _build_selfevolve(workspace=None):
         return {}
 
 
+_cost_backfill_done = False
+
+
+def _backfill_event_costs_once(store) -> None:
+    """#2049: drain the cost_usd backfill once per daemon process. Bounded
+    batches with a hard iteration cap so a huge store can't stall the snapshot
+    build; remaining rows get picked up on the next process start. Never
+    raises."""
+    global _cost_backfill_done
+    if _cost_backfill_done:
+        return
+    _cost_backfill_done = True  # set first: a failure shouldn't retry-loop
+    try:
+        total = 0
+        for _ in range(40):  # cap: 40 x 5000 = up to 200k rows / process
+            n = store.backfill_event_costs(batch=5000)
+            total += n
+            if n < 5000:
+                break
+        if total:
+            log.info("cost backfill: populated cost_usd for %d events (#2049)", total)
+    except Exception as _e:
+        log.debug("cost backfill failed: %s", _e)
+
+
 def _build_daily_usage(days=14):
     """14-day token/cost history for the cloud Cost tab.
 
@@ -8439,6 +8500,11 @@ def _build_daily_usage(days=14):
         store = _ls.get_store()
         if store is None:
             return {}
+        # #2049: one-time backfill of cost_usd for events ingested before the
+        # derive-at-ingest fix (they carry tokens+model but no provider cost,
+        # so the Cost tab showed ~$0). Runs once per process, on the daemon's
+        # writer handle, draining in bounded batches before we read costs.
+        _backfill_event_costs_once(store)
         daily_tok: dict = {}
         daily_cost: dict = {}
         for r in (store.query_aggregates() or []):


### PR DESCRIPTION
Closes #2049. ClawMetry showed **~\$0 for 1.53M tokens** (\$0.0081) because cost came only from a provider-reported `cost_usd` that OpenClaw/OAuth events don't carry — nothing derived cost from tokens × model pricing. For a cost-observability product that's the worst trust signal, and it's the highest-value accuracy fix from the snapshot audit.

**Semantics (you confirmed):** derive at ingest, store as cost — so aggregates, budgets, and per-session costs all reflect API-equivalent spend.

## Changes
- **`providers_pricing.py`**: `provider_for_model()` (self-contained, daemon-safe; self-hosted → `local`/\$0) + `estimate_event_cost_usd()` — cache-aware per-event estimator (Anthropic cache read 0.1×, write 1.25× of input rate). Passing the inferred provider is essential — empty provider mis-prices (\$4 vs \$90 for 1M+1M opus).
- **`sync.py` `_extract_cost_tokens_model`**: derive + store cost when the event has tokens+model but no `cost_usd`.
- **`local_store.backfill_event_costs()`**: bounded, idempotent batch recomputing `cost_usd` for pre-fix rows from their own usage blob (only writes derived > 0 → local/already-priced rows are no-ops).
- **`sync.py` `_backfill_event_costs_once`**: drains the backfill once per daemon process before the snapshot reads costs.

## Verified (every layer, against real data)
- Provider inference: claude→anthropic, gpt→openai, gemini→google, llama→local.
- Cache pricing: 1M in+out opus = \$90; +1M cache_read = \$91.5; llama → \$0.
- **Real events derive to \$443.64** (vs stored \$0.0081).
- Backfill E2E on a temp DuckDB: opus+cache row → \$12.62, local row stays \$0, already-priced row untouched, idempotent.

Daemon change → corrects cloud Cost tab once the pin advances; I'll verify the live snapshot shows real cost post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)