### PR TITLE
fix(update-check): update banner must show the LIVE version, not the recorded one

### DIFF
--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -29,6 +29,28 @@ _update_check_stop_event = threading.Event()
 CHANGELOG_URL = "https://github.com/vivekchand/clawmetry/blob/main/CHANGELOG.md"
 
 
+def _live_current_version() -> str:
+    """The version actually running right now (not the version recorded at the
+    last PyPI check). Reading this live is what keeps the update banner honest
+    immediately after an upgrade — before the next background check runs."""
+    try:
+        import dashboard as _d
+        return str(_d.__version__)
+    except Exception:
+        return ""
+
+
+def _version_gt(a: str, b: str) -> bool:
+    """True if version ``a`` is strictly newer than ``b`` (numeric tuple
+    compare; falls back to string inequality on non-numeric versions)."""
+    if not a or not b:
+        return False
+    try:
+        return [int(x) for x in a.split(".")] > [int(x) for x in b.split(".")]
+    except Exception:
+        return a != b
+
+
 def _get_fleet_db():
     """Get fleet database connection."""
     import dashboard as _d
@@ -137,10 +159,19 @@ def _get_latest_update_check():
             ).fetchone()
             db.close()
         if row:
+            latest = row["latest_version"]
+            # Always report the LIVE installed version, not the version recorded
+            # at check time — otherwise the banner lies right after an upgrade
+            # (e.g. "you are on v0.12.306" while actually on v0.12.309) until the
+            # next background check runs (which is delayed 60s on startup).
+            # Recompute availability against the live version too, so a stale
+            # recorded `latest` that's <= the current build never shows a banner.
+            current = _live_current_version() or row["current_version"]
+            update_available = _version_gt(latest, current)
             return {
-                "current": row["current_version"],
-                "latest": row["latest_version"],
-                "update_available": bool(row["update_available"]),
+                "current": current,
+                "latest": latest,
+                "update_available": update_available,
                 "changelog_url": row["changelog_url"] or "",
                 "checked_at": row["check_at"],
             }
@@ -184,14 +215,7 @@ def _check_for_update():
         log.debug("Update check failed: %s", exc)
         return None
 
-    # Compare version tuples
-    if latest != current:
-        try:
-            cur_parts = [int(x) for x in current.split(".")]
-            lat_parts = [int(x) for x in latest.split(".")]
-            update_available = lat_parts > cur_parts
-        except Exception:
-            update_available = True
+    update_available = _version_gt(latest, current)
 
     _record_update_check(current, latest, update_available, CHANGELOG_URL)
 

--- a/tests/test_update_banner_live_version.py
+++ b/tests/test_update_banner_live_version.py
@@ -1,0 +1,75 @@
+"""The update banner must reflect the LIVE installed version, never the
+version recorded at the last PyPI check.
+
+Regression: after upgrading 0.12.306 → 0.12.309, the banner still showed
+"Update available: v0.12.308 is out. You are on v0.12.306." for ~60s (until
+the delayed on-startup recheck ran), because `_get_latest_update_check`
+returned the recorded `current_version` from the DB. Fix overlays the live
+version and recomputes availability against it.
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib
+
+
+def _uc():
+    import routes.update_check as uc
+    return importlib.reload(uc)
+
+
+def test_version_gt_numeric_tuple():
+    uc = _uc()
+    assert uc._version_gt("0.12.309", "0.12.308") is True
+    assert uc._version_gt("0.12.309", "0.12.309") is False
+    assert uc._version_gt("0.12.308", "0.12.309") is False
+    # numeric, not lexicographic: 310 > 9
+    assert uc._version_gt("0.12.310", "0.12.9") is True
+    assert uc._version_gt("", "0.1") is False
+
+
+class _FakeRow(dict):
+    pass
+
+
+def _patch_db(monkeypatch, uc, row):
+    class _FakeDB:
+        def execute(self, *a, **k):
+            class _C:
+                def fetchone(_self):
+                    return row
+            return _C()
+        def close(self):
+            pass
+    monkeypatch.setattr(uc, "_get_fleet_db", lambda: _FakeDB())
+    monkeypatch.setattr(uc, "_get_fleet_db_lock", lambda: contextlib.nullcontext())
+
+
+def test_latest_check_overlays_live_version(monkeypatch):
+    """DB recorded current=.306/latest=.308, but we're actually on .309 now."""
+    uc = _uc()
+    monkeypatch.setattr(uc, "_live_current_version", lambda: "0.12.309")
+    _patch_db(monkeypatch, uc, _FakeRow(
+        current_version="0.12.306", latest_version="0.12.308",
+        update_available=1, changelog_url="", check_at=123,
+    ))
+    res = uc._get_latest_update_check()
+    assert res["current"] == "0.12.309"          # live, not the stale .306
+    assert res["update_available"] is False        # .308 is NOT > .309
+    # → banner stays hidden
+    assert uc._should_show_update_banner({"enabled": True}, res) is False
+
+
+def test_latest_check_still_flags_real_update(monkeypatch):
+    """A genuinely newer latest still shows the banner, with live current."""
+    uc = _uc()
+    monkeypatch.setattr(uc, "_live_current_version", lambda: "0.12.309")
+    _patch_db(monkeypatch, uc, _FakeRow(
+        current_version="0.12.309", latest_version="0.12.312",
+        update_available=1, changelog_url="", check_at=123,
+    ))
+    res = uc._get_latest_update_check()
+    assert res["current"] == "0.12.309"
+    assert res["latest"] == "0.12.312"
+    assert res["update_available"] is True
+    assert uc._should_show_update_banner({"enabled": True}, res) is True


### PR DESCRIPTION
## Symptom
Right after upgrading a node (e.g. 0.12.306 → 0.12.309), the green update banner kept claiming:

> Update available: v0.12.308 is out. **You are on v0.12.306.**

…even though the version badge and `/api/version` both correctly said `0.12.309` / `update_available:false`. Caught live in a post-upgrade screenshot.

## Root cause
`_get_latest_update_check` returned `current_version` **as recorded at the last PyPI check**, which goes stale the moment you update. `_should_show_update_banner` then trusted the recorded `update_available`. The on-startup recheck sleeps 60s before running, so for ~1 min after every restart the banner serves the stale recorded check.

## Fix
`_get_latest_update_check` now overlays the **live** installed version (`dashboard.__version__`) as `current` and recomputes `update_available` against it, via a shared `_version_gt` numeric-tuple compare (also de-dupes the identical logic in `_check_for_update`). A stale recorded `latest` that's ≤ the running build can no longer show a banner; a genuinely newer `latest` still does. No more 60s lying window.

## Verification
- 3/3 new unit tests: stale `.306/.308` row + live `.309` → `current:.309`, `update_available:false`, banner hidden; real newer `latest` → banner shown; `_version_gt` numeric tuples (310 > 9).
- `py_compile` + `import dashboard` clean.
- The node in question is already on 0.12.309 with the banner correctly gone; this prevents the transient on future updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)