### PR TITLE
fix(overview): 'Finished N ago' showed '0s ago' for old subagents (use end time, not runtime)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -13205,10 +13205,22 @@ function _ovTimeLabel(agent) {
     if (min < 60) return 'Running (' + min + ' min)';
     return 'Running (' + hr + 'h ' + (min % 60) + 'm)';
   }
-  if (sec < 60) return 'Finished ' + sec + 's ago';
-  if (min < 60) return 'Finished ' + min + ' min ago';
-  if (hr < 24) return 'Finished ' + hr + 'h ago';
-  return 'Finished ' + Math.floor(hr / 24) + 'd ago';
+  // "Finished N ago" is time since the spawn ENDED — not the run duration.
+  // Using runtimeMs here made stale spawns whose runtime was frozen to 0
+  // (the dead-subagent freeze) read "Finished 0s ago" even when they ended
+  // days ago. Prefer completionTs, then updatedAt (last activity), then
+  // startedAt+runtime; blank if the end time is genuinely unknown.
+  var endedMs = 0;
+  if (agent.completionTs) { var ct = Date.parse(agent.completionTs); if (!isNaN(ct)) endedMs = ct; }
+  if (!endedMs && agent.updatedAt) endedMs = agent.updatedAt;
+  if (!endedMs && agent.startedAt && ms) endedMs = agent.startedAt + ms;
+  if (!endedMs) return '';
+  var ago = Math.max(0, Date.now() - endedMs);
+  var asec = Math.floor(ago / 1000), amin = Math.floor(asec / 60), ahr = Math.floor(amin / 60);
+  if (asec < 60) return 'Finished ' + asec + 's ago';
+  if (amin < 60) return 'Finished ' + amin + ' min ago';
+  if (ahr < 24) return 'Finished ' + ahr + 'h ago';
+  return 'Finished ' + Math.floor(ahr / 24) + 'd ago';
 }
 
 function _ovRenderCard(agent, idx) {


### PR DESCRIPTION
## Symptom
Overview Tasks cards show **"Finished 0s ago"** for subagents that actually ran days ago (seen alongside the Brain-Events report: the "Research-A" et al. spawns are from May 20, ~5 days old, yet every card reads "Finished 0s ago").

## Root cause
`_ovTimeLabel` (app.js) builds "Finished N ago" from **`agent.runtimeMs`** — a *run duration*, not an end timestamp. The dead-subagent freeze (#2038) forces `runtimeMs = 0` for stale spawns, so `sec = 0` → **"Finished 0s ago"**. (The `active` branch correctly uses runtimeMs as elapsed runtime; only the finished branch was wrong.)

## Fix
Compute time-since-end from the real end timestamp: `completionTs` → else `updatedAt` (last activity) → else `startedAt + runtime`; return blank if the end time is genuinely unknown (better than a wrong "0s ago").

## Verification
- `node --check clawmetry/static/js/app.js` → OK.
- Simulated against the live `/api/subagents` feed (the reporting node): all 8 stale spawns go **"Finished 0s ago" → "Finished 4d ago"** (correct — May-20 spawns).

Frontend-only; ships in the next OSS release and reaches the cloud via the Dockerfile pin bump. (The dead `humanTimeDone` helper has the same latent bug but has no callers; left untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)