### PR TITLE
feat(crons): full cloud cron management (delete/toggle/run/edit via relay)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6834,6 +6834,7 @@ var _cronJobs = [];
 var _cronExpanded = {};
 var _cronAutoRefreshTimer = null;
 var _cronActionsAvailable = false;
+var _cronWritesAvailable = false;  // single-job writes (relay-backed in cloud)
 var _cronView = 'active'; // 'active' | 'paused' | 'calendar'
 
 // Cache of recent runs per job, populated lazily when Calendar is opened.
@@ -7092,14 +7093,18 @@ async function loadCrons() {
     // copy says to click it. Cloud-iframe stays false so we don't dangle
     // controls that 410 when used.
     _cronActionsAvailable = !window.CLOUD_MODE;
-    // Show/hide cron action buttons based on gateway availability
+    // Single-job writes (create/run/toggle/delete/edit) now work in cloud too:
+    // the cm-cloud-cron-create + cm-cloud-cron-actions interceptors relay them
+    // to the daemon, which runs `openclaw cron <subcmd>` locally. So per-row
+    // management is available in cloud. Bulk/dangerous ops (Emergency Stop All)
+    // and the AI "Fix" button stay local-only until they get their own relay.
+    _cronWritesAvailable = _cronActionsAvailable || !!window.CLOUD_MODE;
+    // Show/hide the bulk cron-action buttons (.cron-action-btn = New Job +
+    // Emergency Stop All) — local-only by default.
     document.querySelectorAll('.cron-action-btn').forEach(function(btn) {
       btn.style.display = _cronActionsAvailable ? '' : 'none';
     });
-    // "+ New Job" works in cloud too: the cm-cloud-cron-create interceptor
-    // relays the POST to the daemon, which runs `openclaw cron add` locally.
-    // (Per-row write buttons — Pause/Run/Delete/Fix — stay local-only until
-    // they get their own relay actions.) Un-gate just New Job in cloud.
+    // "+ New Job" is relay-backed, so show it in cloud too.
     var _newJobBtn = document.getElementById('cron-new-job-btn');
     if (_newJobBtn) _newJobBtn.style.display = '';
     renderCrons();
@@ -7182,7 +7187,7 @@ async function loadCronHealth() {
         html += anomalyBadges;
         if (j.consecutiveFailures > 1) html += '<span style="font-size:11px;background:#ef444422;color:#ef4444;border-radius:4px;padding:1px 5px;">'+j.consecutiveFailures+' fails</span>';
         html += '<span style="font-size:11px;color:var(--text-muted);white-space:nowrap;">'+projStr+'</span>';
-        if (_cronActionsAvailable) html += '<button onclick="event.stopPropagation();cronPauseJob(\''+escHtml(j.id)+'\')" title="Pause this job" style="font-size:11px;padding:2px 7px;border-radius:5px;border:1px solid var(--border-secondary);background:var(--bg-tertiary);color:var(--text-secondary);cursor:pointer;">&#x23F8; Pause</button>';
+        if (_cronWritesAvailable) html += '<button onclick="event.stopPropagation();cronPauseJob(\''+escHtml(j.id)+'\')" title="Pause this job" style="font-size:11px;padding:2px 7px;border-radius:5px;border:1px solid var(--border-secondary);background:var(--bg-tertiary);color:var(--text-secondary);cursor:pointer;">&#x23F8; Pause</button>';
         html += '</div>';
       });
       html += '</div>';
@@ -7372,8 +7377,9 @@ function renderCronList(jobs) {
     }
     if (badges) html += '<div style="display:inline;">' + badges + '</div>';
 
-    // Action buttons (hidden unless gateway supports cron invocation)
-    if (_cronActionsAvailable) {
+    // Action buttons. Relay-backed in cloud (cm-cloud-cron-actions), so show
+    // them whenever single-job writes are available (local OR cloud).
+    if (_cronWritesAvailable) {
     html += '<div class="cron-actions" onclick="event.stopPropagation()">';
     html += '<button class="cron-btn-run" onclick="cronRunNow(\'' + escHtml(j.id) + '\')">&#x25B6; Run Now</button>';
     html += '<button class="cron-btn-toggle" onclick="cronToggle(\'' + escHtml(j.id) + '\',' + !isEnabled + ')">' + (isEnabled ? '&#x23F8; Disable' : '&#x25B6; Enable') + '</button>';

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5722,6 +5722,7 @@ _PENDING_ACTIONS = frozenset({
     "selfevolve_fix",
     "selfevolve_analyze",
     "cron_create",
+    "cron_action",
 })
 
 
@@ -5915,6 +5916,9 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
         return
     if atype == "cron_create":
         _action_cron_create(config, action)
+        return
+    if atype == "cron_action":
+        _action_cron_op(config, action)
         return
 
 
@@ -6156,6 +6160,100 @@ def _action_cron_create(config: dict, action: dict) -> None:
             )
         except Exception as e:
             log.warning("cron_create cache post failed: %s", e)
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def _action_cron_op(config: dict, action: dict) -> None:
+    """Cloud-relayed cron management op (delete / toggle / run / update).
+
+    Completes cloud cron management alongside _action_cron_create: the cloud
+    "Run / Disable / Edit / Delete" per-row buttons relay a `cron_action` here
+    and the daemon runs the matching `openclaw cron` subcommand locally
+    (OpenClaw's own creds; v3 dropped the gateway cron tool). E2E-encrypted
+    result -> cache_key, browser polls + decrypts. Runs in a background thread.
+
+    Wire shape (queued cloud-side by /api/cloud/cron-action):
+        {type:"cron_action", id, cache_key, action, jobId, enabled?, patch?}
+      action ∈ {delete, toggle, run, update}
+    """
+    cache_key = action.get("cache_key")
+    op = (action.get("action") or "").strip()
+    job_id = (action.get("jobId") or "").strip()
+    enc_key = config.get("encryption_key")
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not (cache_key and op and job_id and enc_key and api_key):
+        return
+    aid = action.get("id")
+    enabled = action.get("enabled", True)
+    patch = action.get("patch") if isinstance(action.get("patch"), dict) else {}
+
+    def _run():
+        status, message, scope_pending = "error", "", False
+        try:
+            if op == "delete":
+                res = run_openclaw_cron("rm", [job_id], timeout=40)
+                ok_msg = "Job deleted"
+            elif op == "run":
+                res = run_openclaw_cron("run", [job_id], timeout=45)
+                ok_msg = "Job triggered"
+            elif op == "toggle":
+                res = run_openclaw_cron(
+                    "enable" if enabled else "disable", [job_id], timeout=40)
+                ok_msg = "Job enabled" if enabled else "Job disabled"
+            elif op == "update":
+                eargs = [job_id]
+                if patch.get("name"):
+                    eargs += ["--name", str(patch["name"])]
+                if patch.get("description"):
+                    eargs += ["--description", str(patch["description"])]
+                if patch.get("prompt") or patch.get("message"):
+                    eargs += ["--message",
+                              str(patch.get("prompt") or patch.get("message"))]
+                if patch.get("model"):
+                    eargs += ["--model", str(patch["model"])]
+                if patch.get("channel"):
+                    eargs += ["--channel", str(patch["channel"])]
+                if isinstance(patch.get("schedule"), dict):
+                    sargs, serr = cron_schedule_to_cli_args(patch["schedule"])
+                    if serr:
+                        raise ValueError(serr)
+                    eargs += sargs
+                if "enabled" in patch:
+                    eargs += ["--enable"] if patch["enabled"] else ["--disable"]
+                res = run_openclaw_cron("edit", eargs, timeout=40)
+                ok_msg = "Job updated"
+            else:
+                res = {"ok": False, "error": "unsupported action: %s" % op}
+                ok_msg = ""
+            scope_pending = bool(res.get("scope_pending"))
+            if res.get("ok"):
+                status, message = "done", ok_msg
+            else:
+                message = res.get("error") or ("cron %s failed" % op)
+        except Exception as e:  # never raise from the worker thread
+            message = str(e)[:400]
+        try:
+            blob = encrypt_payload(
+                {"status": status, "message": message,
+                 "scope_pending": scope_pending, "_shape": "cron_action"},
+                enc_key,
+            )
+            _post(
+                "/ingest/cache",
+                {
+                    "node_id": node_id,
+                    "id": aid,
+                    "cache_key": cache_key,
+                    "blob": blob,
+                    "shape": "cron_action",
+                    "ttl": 3600,
+                },
+                api_key,
+            )
+        except Exception as e:
+            log.warning("cron_action cache post failed: %s", e)
 
     threading.Thread(target=_run, daemon=True).start()
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8549,7 +8549,13 @@ def run_openclaw_cron(subcmd, extra_args=None, timeout=40):
         os.path.expanduser("~/.local/bin"),
     ]
     env["PATH"] = os.pathsep.join(node_dirs + [env.get("PATH", "/usr/bin:/bin")])
-    cmd = [binp, "cron", subcmd] + list(extra_args or []) + ["--json"]
+    # Only some subcommands accept --json (add/rm + the read commands); enable/
+    # disable/run/edit reject it with "unknown option '--json'". Append it only
+    # where supported so writes don't fail on an unrecognised flag.
+    _JSON_OK = {"add", "create", "rm", "list", "status", "runs", "show"}
+    cmd = [binp, "cron", subcmd] + list(extra_args or [])
+    if subcmd in _JSON_OK:
+        cmd.append("--json")
     try:
         proc = subprocess.run(
             cmd, capture_output=True, text=True, timeout=timeout, env=env,


### PR DESCRIPTION
## What
Completes cloud cron management on top of create (#2053). The per-row **Run / Disable-Enable / Edit / Delete** buttons (and the health-panel Pause) now work from app.clawmetry.com, via the same heartbeat relay.

- `clawmetry/sync.py`: generic `cron_action` relay action (`_action_cron_op`) — maps `action ∈ {delete,toggle,run,update}` to the matching `openclaw cron` subcommand via `run_openclaw_cron`, runs it in a daemon thread, posts the E2E-encrypted result. `update` rebuilds `cron edit` flags from the patch.
- `app.js`: new `_cronWritesAvailable` (= local OR CLOUD_MODE) gates the per-row write block + Pause, now that they're relay-backed in cloud. Bulk **Emergency Stop All** and the AI **Fix** button stay local-only.

Cloud half (route + `cm-cloud-cron-actions` interceptor): clawmetry-cloud PR.

## Verification
- `cron_action` registered in `_PENDING_ACTIONS`; `_action_cron_op` callable; `node --check` + `py_compile` pass.
- Full E2E (delete/toggle/run from cloud → daemon CLI → decrypt result → confirm local effect) verified post-deploy — see PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)