### PR TITLE
feat(update): opt-in auto-update — install new releases automatically

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -16797,8 +16797,49 @@ async function checkUpdateStatus() {
       var current = (data.latest_check && data.latest_check.current) || '';
       msg.textContent = 'Update available: v' + latest + ' is out. You are on v' + current + '.';
       banner.style.display = 'flex';
+      _renderAutoUpdateToggle(!!(data.config && data.config.auto_update));
     }
   } catch(e) {}
+}
+
+// Reflect the persisted auto_update preference in the banner toggle. On the
+// hosted cloud (CLOUD_MODE) the local pip-updater doesn't apply — the cloud
+// stays current centrally — so show that instead of a functional switch.
+function _renderAutoUpdateToggle(isOn) {
+  var wrap = document.getElementById('update-banner-auto');
+  var box = document.getElementById('update-banner-auto-toggle');
+  var label = document.getElementById('update-banner-auto-label');
+  if (!wrap) return;
+  if (window.CLOUD_MODE) {
+    wrap.style.display = 'flex';
+    wrap.style.cursor = 'default';
+    wrap.title = 'ClawMetry Cloud is kept on the latest release automatically.';
+    if (box) box.style.display = 'none';
+    if (label) label.textContent = '☁ Auto-updates on Cloud';
+    return;
+  }
+  wrap.style.display = 'flex';
+  if (box) { box.style.display = ''; box.checked = !!isOn; }
+  if (label) label.textContent = isOn ? 'Auto-update on' : 'Auto-update';
+}
+
+// Persist the toggle; if turning it ON while an update is already pending,
+// kick the upgrade right away instead of waiting for the next daily check.
+async function toggleAutoUpdate(on) {
+  var label = document.getElementById('update-banner-auto-label');
+  try {
+    await fetch('/api/update-check/config', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({auto_update: !!on})
+    });
+  } catch(e) {}
+  if (label) label.textContent = on ? 'Auto-update on' : 'Auto-update';
+  if (on) {
+    // An update is showing (this toggle only renders inside the update banner),
+    // so apply it now — reuse the same vetted path as the Update now button.
+    updateFromBanner();
+  }
 }
 
 async function dismissUpdateBanner() {

--- a/clawmetry/templates/partials/banners.html
+++ b/clawmetry/templates/partials/banners.html
@@ -2,6 +2,10 @@
 <div id="update-banner" style="display:none; padding:10px 16px; background:linear-gradient(90deg,#0f3d0f 0%,#1a1a2e 100%); border-bottom:2px solid #22c55e; color:#86efac; font-size:13px; font-weight:600; align-items:center; gap:10px;">
   <span style="font-size:18px;">&#128640;</span>
   <span id="update-banner-msg" style="flex:1;"></span>
+  <label id="update-banner-auto" title="When on, future releases install automatically as soon as they're published." style="display:none; align-items:center; gap:6px; font-size:12px; color:#86efac; cursor:pointer; user-select:none; white-space:nowrap;">
+    <input type="checkbox" id="update-banner-auto-toggle" onchange="toggleAutoUpdate(this.checked)" style="cursor:pointer; accent-color:#16a34a; width:14px; height:14px;">
+    <span id="update-banner-auto-label">Auto-update</span>
+  </label>
   <button id="update-banner-update-btn" onclick="updateFromBanner()" style="
     background:#16a34a;
     color:#fff;

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -96,14 +96,23 @@ def api_version():
     return {"current": current, "latest": latest, "update_available": update_available}
 
 
-@bp_version.route("/api/update", methods=["POST"])
-def api_update():
-    """Self-update clawmetry via pip, then schedule process restart."""
+def perform_self_update(reason: str = "manual"):
+    """Core self-update: ``pip install -U clawmetry`` then schedule a process
+    restart. Returns ``(payload_dict, http_status)``.
+
+    Shared by the manual ``/api/update`` route and the background auto-updater
+    (``routes/update_check.py``) so both use one vetted upgrade+restart path.
+    Safe to call from a worker thread — the restart is scheduled on a Timer
+    that exits the process (launchd/systemd respawns it on the new wheel).
+    """
     import dashboard as _d
     import subprocess as _sp
     import threading as _thr
+    import logging as _log
 
+    _ulog = _log.getLogger(__name__)
     old_version = _d.__version__
+    _ulog.info("self-update (%s): pip install -U clawmetry from v%s", reason, old_version)
     py = sys.executable
     # Bootstrap pip via the stdlib's ensurepip first. The daemon's venv at
     # ~/.clawmetry/bin/python3 is provisioned WITHOUT pip by uv-style
@@ -176,8 +185,17 @@ def api_update():
                 pass  # daemon may not be running; dashboard restart is enough
         _os._exit(0)
 
+    _ulog.info("self-update (%s): upgraded v%s -> v%s; restarting in 2s",
+               reason, old_version, new_version)
     _thr.Timer(2.0, _restart).start()
-    return {"ok": True, "old_version": old_version, "new_version": new_version}
+    return {"ok": True, "old_version": old_version, "new_version": new_version}, 200
+
+
+@bp_version.route("/api/update", methods=["POST"])
+def api_update():
+    """Self-update clawmetry via pip, then schedule process restart."""
+    payload, status = perform_self_update(reason="manual")
+    return payload, status
 
 
 @bp_version.route("/api/install-age")

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -93,6 +93,10 @@ def _get_update_check_config():
         "enabled": True,
         "check_on_startup": True,
         "check_daily": True,
+        # Opt-in: when on, a detected newer release is installed automatically
+        # by the background worker (no click needed). Off by default — auto
+        # pip-install + restart is something the user explicitly turns on.
+        "auto_update": False,
         "dismissed_version": "",
         "last_check_at": 0,
     }
@@ -219,12 +223,48 @@ def _check_for_update():
 
     _record_update_check(current, latest, update_available, CHANGELOG_URL)
 
+    # Auto-update: if the user opted in, install the newer release now (no
+    # click). Runs in the always-on dashboard server process, so it works
+    # with no browser open. Guarded so a pending restart isn't re-triggered.
+    if update_available:
+        try:
+            _maybe_auto_update(current, latest)
+        except Exception as exc:
+            log.warning("auto-update trigger failed: %s", exc)
+
     return {
         "current": current,
         "latest": latest,
         "update_available": update_available,
         "changelog_url": CHANGELOG_URL,
     }
+
+
+# Set once an auto-update upgrade has been kicked off (the process is about to
+# restart). Prevents re-triggering pip on every subsequent check in the gap
+# before the restart lands. Reset on failure so the next check can retry.
+_auto_update_in_progress = False
+
+
+def _maybe_auto_update(current, latest):
+    """Install a newer release automatically when ``auto_update`` is enabled."""
+    global _auto_update_in_progress
+    if _auto_update_in_progress:
+        return
+    cfg = _get_update_check_config()
+    if not cfg.get("auto_update"):
+        return
+    _auto_update_in_progress = True
+    log.info("auto-update: opted in — upgrading clawmetry v%s -> v%s", current, latest)
+    try:
+        from routes.meta import perform_self_update
+        payload, _status = perform_self_update(reason="auto")
+        if not (isinstance(payload, dict) and payload.get("ok")):
+            log.warning("auto-update: upgrade failed, will retry next check: %s", payload)
+            _auto_update_in_progress = False  # allow retry; no restart was scheduled
+    except Exception as exc:
+        log.warning("auto-update: error during upgrade: %s", exc)
+        _auto_update_in_progress = False
 
 
 def _update_check_worker(stop_event):
@@ -296,7 +336,7 @@ def api_update_check_config():
 def api_update_check_config_post():
     """Update update check configuration."""
     data = request.get_json(silent=True) or {}
-    allowed_keys = ["enabled", "check_on_startup", "check_daily", "dismissed_version"]
+    allowed_keys = ["enabled", "check_on_startup", "check_daily", "auto_update", "dismissed_version"]
     updates = {k: v for k, v in data.items() if k in allowed_keys}
     _set_update_check_config(updates)
     return jsonify({"ok": True})

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -1,0 +1,72 @@
+"""Opt-in auto-update: the background update-check worker installs a newer
+release automatically only when the `auto_update` config is on, and never
+re-triggers pip once a restart is already pending.
+
+The upgrade itself goes through the same vetted path as the manual "Update
+now" button (routes.meta.perform_self_update), which is mocked here — these
+tests are about the *gating*, not the pip/restart mechanics.
+"""
+from __future__ import annotations
+
+import importlib
+
+
+def _uc():
+    import routes.update_check as uc
+    return importlib.reload(uc)
+
+
+def _mock_self_update(monkeypatch, calls, ok=True):
+    import routes.meta as meta
+
+    def _fake(reason="manual"):
+        calls.append(reason)
+        return ({"ok": ok, "old_version": "0.12.1", "new_version": "0.12.2"},
+                200 if ok else 500)
+
+    monkeypatch.setattr(meta, "perform_self_update", _fake)
+
+
+def test_auto_update_off_does_not_upgrade(monkeypatch):
+    uc = _uc()
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": False})
+    calls = []
+    _mock_self_update(monkeypatch, calls)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert calls == [], "must not upgrade when auto_update is off"
+
+
+def test_auto_update_on_upgrades_once(monkeypatch):
+    uc = _uc()
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+    calls = []
+    _mock_self_update(monkeypatch, calls)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert calls == ["auto"], "must upgrade once when auto_update is on"
+    # Guard: a second check before the restart lands must NOT re-trigger pip.
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert calls == ["auto"], "must not re-trigger while a restart is pending"
+
+
+def test_auto_update_failure_allows_retry(monkeypatch):
+    uc = _uc()
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+    calls = []
+    _mock_self_update(monkeypatch, calls, ok=False)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert calls == ["auto"]
+    # The upgrade failed (no restart scheduled) → the next check may retry.
+    uc._maybe_auto_update("0.12.1", "0.12.2")
+    assert calls == ["auto", "auto"], "a failed auto-update must be retryable"
+
+
+def test_auto_update_in_allowed_config_keys(monkeypatch):
+    """The config setter must accept `auto_update` (else the toggle is a no-op)."""
+    from flask import Flask
+    uc = _uc()
+    captured = {}
+    monkeypatch.setattr(uc, "_set_update_check_config", lambda u: captured.update(u))
+    app = Flask(__name__)
+    with app.test_request_context(json={"auto_update": True, "bogus": "x"}):
+        uc.api_update_check_config_post()
+    assert captured == {"auto_update": True}, "auto_update must pass the allow-list, bogus keys filtered"


### PR DESCRIPTION
## What
Adds an **Auto-update** toggle to the update banner. Once enabled, ClawMetry installs each newly published release automatically — no clicking "Update now" each time. Requested by @vivekchand.

## How (OSS, daemon-style/always-on)
The existing `routes/update_check.py` already runs a background PyPI checker in the **dashboard server process** (always on, independent of any open browser). This builds on it:

- **`routes/meta.py`** — factored the proven `pip install -U` + restart out of `api_update` into **`perform_self_update(reason)`**; `api_update` is now a thin wrapper. One vetted upgrade path for both manual and auto.
- **`routes/update_check.py`** — new opt-in **`auto_update`** config (off by default). When a check finds a newer release and `auto_update` is on, `_maybe_auto_update` calls `perform_self_update(reason="auto")`. Guarded so a pending restart is never re-triggered; a failed upgrade is retryable next check.
- **Banner toggle** (`banners.html` + `app.js`) — an Auto-update checkbox reflecting the persisted preference. Enabling it while an update is pending applies it immediately (same confirm + restart as Update now). On the hosted cloud (`CLOUD_MODE`) it shows **"Auto-updates on Cloud"** instead, since the cloud is kept current centrally (Dockerfile pin), not via local pip.

Off by default — auto pip-install + restart is something the user explicitly turns on.

## Cloud half
"Same for cloud" is handled in a companion clawmetry-cloud PR: the auto-pin PR will auto-merge when CI is green, so the cloud deploys each OSS release automatically (the existing candidate smoke-gate still protects prod before traffic flips).

## Tests
`tests/test_auto_update.py` — 4 passing: off → no upgrade; on → one upgrade; guard blocks re-trigger before restart; failed upgrade is retryable; `auto_update` passes the config allow-list. Plus `node --check` on app.js, `py_compile` on the routes, and `import dashboard` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)