### PR TITLE
fix(multi-agent): don't double-count OpenClaw-spawned Claude Code sessions

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7757,6 +7757,39 @@ def _family_adapter_classes():
     return classes
 
 
+def _openclaw_spawned_claude_ids() -> set:
+    """Claude Code session ids that OpenClaw spawned (and already ingests).
+
+    OpenClaw's sessions.json index records the Claude CLI session id it spawned
+    under ``cliSessionIds.claude-cli`` (or ``claude_code`` / ``claude``).
+    sync_openclaw_claude_sessions_via_index already ingests those under the
+    OpenClaw session UUID, so the standalone ClaudeCode adapter must skip them to
+    avoid double-counting the same session. Cheap (one JSON read); never raises.
+    """
+    out: set = set()
+    idx = os.path.join(_get_openclaw_dir(), "agents", "main", "sessions", "sessions.json")
+    try:
+        if not os.path.isfile(idx):
+            return out
+        with open(idx) as fh:
+            data = json.load(fh)
+        for _k, meta in (data.items() if isinstance(data, dict) else []):
+            if not isinstance(meta, dict):
+                continue
+            cli = meta.get("cliSessionIds") or {}
+            if not isinstance(cli, dict):
+                continue
+            cc = cli.get("claude-cli") or cli.get("claude_code") or cli.get("claude")
+            if not cc:
+                continue
+            for v in (cc if isinstance(cc, list) else [cc]):
+                if v:
+                    out.add(str(v))
+    except Exception as exc:  # never block ingest on a bad/locked index
+        log.debug(f"openclaw spawned-claude index read failed: {exc}")
+    return out
+
+
 def _detect_family_runtimes():
     """Detect non-OpenClaw runtimes present on this host (Hermes, Claude Code,
     Codex, Cursor, PicoClaw, NanoClaw, ...).
@@ -7841,6 +7874,13 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
     total_events = 0
     cloud_session_rows: list = []
 
+    # Claude Code sessions that OpenClaw SPAWNED are already ingested under the
+    # OpenClaw session UUID by sync_openclaw_claude_sessions_via_index. Skip them
+    # in the claude_code adapter ingest so an orchestrated session shows once
+    # (under OpenClaw, which owns it), not twice. Verified on a real machine:
+    # 29 of 387 ~/.claude sessions were OpenClaw-spawned.
+    openclaw_spawned_claude = _openclaw_spawned_claude_ids()
+
     for cls in _family_adapter_classes():
         try:
             adapter = cls()  # construct once (discovery globs/DB opens are not free)
@@ -7848,6 +7888,8 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 continue
             runtime = adapter.name
             for s in adapter.list_sessions(limit=50):
+                if runtime == "claude_code" and s.id in openclaw_spawned_claude:
+                    continue  # owned by OpenClaw; avoid the double-count
                 ns_id = f"{runtime}:{s.id}"
                 started = _epoch_to_iso(s.started_at)
                 ended = _epoch_to_iso(s.ended_at)

--- a/tests/test_family_runtime_ingest.py
+++ b/tests/test_family_runtime_ingest.py
@@ -160,3 +160,54 @@ def test_family_runtimes_noop_when_absent(tmp_path, monkeypatch):
             ls.get_store().stop(flush=True)
         except Exception:
             pass
+
+
+# ── Claude Code / OpenClaw spawn dedup (verified vs real data: 29/387) ────────
+
+def test_openclaw_spawned_claude_skipped(tmp_path, monkeypatch):
+    """A Claude session OpenClaw spawned (in sessions.json cliSessionIds) is NOT
+    re-ingested as a claude_code:<id> session (OpenClaw already owns it)."""
+    import importlib, json as _json, time
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    # Build a fake OpenClaw home whose index marks one claude id as spawned.
+    oc = tmp_path / ".openclaw" / "agents" / "main" / "sessions"
+    oc.mkdir(parents=True)
+    spawned_id = "spawned-1111-2222-3333-444444444444"
+    (oc / "sessions.json").write_text(_json.dumps({
+        "agent:main:explicit:x": {"cliSessionIds": {"claude-cli": spawned_id}}
+    }))
+    monkeypatch.setenv("CLAWMETRY_OPENCLAW_DIR", str(tmp_path / ".openclaw"))
+    import clawmetry.local_store as ls
+    import clawmetry.sync as sync
+    importlib.reload(ls); importlib.reload(sync)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    # The index helper must see the spawned id.
+    assert spawned_id in sync._openclaw_spawned_claude_ids()
+
+    # Stub a ClaudeCode adapter that returns one spawned + one standalone session.
+    from clawmetry.adapters.base import AgentAdapter, DetectResult, Session, Event, Capability
+    class _FakeCC(AgentAdapter):
+        name = "claude_code"; display_name = "Claude Code"
+        def detect(self): return DetectResult(name=self.name, display_name=self.display_name, detected=True, session_count=2)
+        def list_sessions(self, limit=100):
+            return [Session(agent=self.name, id=spawned_id, started_at=1.0, message_count=1),
+                    Session(agent=self.name, id="standalone-xyz", started_at=2.0, message_count=1)]
+        def list_events(self, session_id, limit=500):
+            return [Event(agent=self.name, session_id=session_id, id=session_id+":1", type="message", ts=1.0, role="user", content="hi")]
+        def capabilities(self): return {Capability.SESSIONS, Capability.EVENTS}
+    monkeypatch.setattr(sync, "_family_adapter_classes", lambda: [_FakeCC])
+
+    from unittest.mock import patch
+    with patch.object(sync, "_sync_allowed", return_value=True), patch.object(sync, "_post", return_value={}):
+        sync.sync_family_runtimes({"node_id": "n", "api_key": None}, {}, {})
+    store = ls.get_store()
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline and store.health()["ring_depth"] != 0:
+        time.sleep(0.02)
+    rows = store._fetch("SELECT session_id FROM sessions WHERE session_id LIKE 'claude_code:%'", [])
+    sids = {r[0] for r in rows}
+    assert "claude_code:standalone-xyz" in sids, "standalone session must be ingested"
+    assert f"claude_code:{spawned_id}" not in sids, "OpenClaw-spawned session must be skipped (dedup)"
+    try: store.stop(flush=True)
+    except Exception: pass


### PR DESCRIPTION
Follow-up correctness fix on the multi-agent work (#2060). A Claude Code session that OpenClaw **spawned** was counted twice: once as `openclaw` (via `sync_openclaw_claude_sessions_via_index`, which ingests it under the OpenClaw UUID) and once as `claude_code:<id>` (the new ClaudeCodeAdapter ingested every `~/.claude` session).

## Fix
`_openclaw_spawned_claude_ids()` reads OpenClaw's `sessions.json` index (`cliSessionIds.claude-cli`/`claude_code`/`claude`); `sync_family_runtimes` skips those ids for the `claude_code` runtime. Orchestrated sessions show once (under OpenClaw, which owns them); standalone Claude Code sessions ingest normally.

## Verified against real data
On a real machine: **29 of 387** `~/.claude` sessions were OpenClaw-spawned and would have double-counted. After the fix they ingest only via the OpenClaw path. New regression test (`test_openclaw_spawned_claude_skipped`) asserts the spawned id is skipped and the standalone id kept. **95 compat tests green** on Python 3.9.

Found by auditing the shipped multi-agent pipeline against real data, not synthetic fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)