### PR TITLE
ci(cloud): widen auto-merge poll budget to ~45 min

### DIFF
--- a/.github/workflows/auto-deploy-cloud.yml
+++ b/.github/workflows/auto-deploy-cloud.yml
@@ -111,7 +111,11 @@ jobs:
             echo "::warning::PR #$PR touches more than Dockerfile ($FILES) — leaving for manual review."; exit 0
           fi
           # Poll the rollup until every check concludes (or budget runs out).
-          for i in $(seq 1 40); do
+          # ~45 min budget: the cloud golden-path E2E + MOAT roundtrip checks
+          # routinely run 15-20 min, and the earlier 20 min budget timed out
+          # before they finished (the pin PR was left open, merged later by
+          # hand) — defeating hands-off auto-merge.
+          for i in $(seq 1 90); do
             ROLL=$(gh pr view "$PR" --repo "$REPO" --json statusCheckRollup \
                      -q '.statusCheckRollup')
             FAIL=$(echo "$ROLL" | python3 -c "import json,sys; r=json.load(sys.stdin); print(sum(1 for c in r if (c.get('conclusion') or '') in ('FAILURE','CANCELLED','TIMED_OUT','ACTION_REQUIRED')))")


### PR DESCRIPTION
Follow-up to #2075. The pin-PR auto-merge polled cloud CI for only 20 min, but the cloud golden-path E2E + MOAT roundtrip checks routinely take 15-20 min — so the first release (0.12.313) timed out and the pin PR was merged by hand instead. Bumps the poll to ~45 min (90×30s) so hands-off auto-merge actually completes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)