### PR TITLE
feat(robustness): daemon self-heals DuckDB index corruption from kill-during-write (#2073)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1097,6 +1097,90 @@ def _reset_singleton_for_tests() -> None:
         _store_proxy = None
 
 
+# #2073: DuckDB ART-index corruption recovery. A SIGKILL / OOM / reboot during
+# a write (especially a bulk UPDATE — e.g. the cost backfill #2049) can leave
+# an explicit ``idx_%`` out of sync with its table, so the next DELETE/UPSERT
+# touching it raises one of these markers and DuckDB invalidates the whole
+# database for that session — every subsequent op fails and the daemon
+# crash-loops until manual recovery. Detection + heal lets the daemon self-heal
+# on the next cycle instead. (Burned 2026-05-25;
+# [[feedback_no_sigkill_daemon_duckdb_writes]].)
+_INDEX_CORRUPTION_MARKERS = (
+    "Failed to delete all rows from index",
+    "database has been invalidated",
+)
+
+
+def is_index_corruption_error(err: BaseException) -> bool:
+    """True if ``err``'s message matches a DuckDB index-invalidation FATAL.
+    Used by the daemon main loop to trigger ``heal_index_corruption()``."""
+    s = str(err)
+    return any(m in s for m in _INDEX_CORRUPTION_MARKERS)
+
+
+def heal_index_corruption() -> int:
+    """Repair DuckDB ART-index corruption on the daemon's writer DB. Drops
+    every explicit ``idx_%`` on a fresh connection, ``CHECKPOINT``s, then
+    re-runs the schema DDL (idempotent ``CREATE INDEX IF NOT EXISTS``) to
+    rebuild them clean from the table data. Data is intact — only the
+    indexes are rebuilt.
+
+    Closes and clears the singleton so the next ``get_store()`` reopens on
+    the healed DB. Returns the number of indexes rebuilt, or -1 on failure.
+    Never raises."""
+    global _store_rw, _store_ro, _store_proxy
+    try:
+        with _store_lock:
+            # The cached writer connection is invalidated post-corruption — drop
+            # it so the next get_store() opens fresh on the healed DB.
+            for name in ("_store_rw", "_store_ro"):
+                _st = globals().get(name)
+                if _st is None:
+                    continue
+                try:
+                    _st.stop(flush=False)
+                except Exception:
+                    pass
+            _store_rw = None
+            _store_ro = None
+            _store_proxy = None
+            # Open a fresh connection just for the repair.
+            conn = _open_connection(read_only=False)
+            n_dropped = 0
+            try:
+                try: conn.execute("CHECKPOINT")
+                except Exception: pass
+                try:
+                    rows = conn.execute(
+                        "SELECT index_name FROM duckdb_indexes() "
+                        "WHERE index_name LIKE 'idx_%'"
+                    ).fetchall()
+                except Exception:
+                    rows = []
+                for (idx_name,) in rows:
+                    try:
+                        conn.execute(f'DROP INDEX IF EXISTS "{idx_name}"')
+                        n_dropped += 1
+                    except Exception:
+                        pass
+                try: conn.execute("CHECKPOINT")
+                except Exception: pass
+                # Re-apply schema DDL — CREATE INDEX IF NOT EXISTS is
+                # idempotent for tables and recreates the dropped indexes
+                # from the table data, clean.
+                for stmt in _DDL:
+                    try: conn.execute(stmt)
+                    except Exception: pass
+                try: conn.execute("CHECKPOINT")
+                except Exception: pass
+            finally:
+                try: conn.close()
+                except Exception: pass
+        return n_dropped
+    except Exception:
+        return -1
+
+
 class LocalStore:
     """Thread-safe local event store with a background batched flusher.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11122,7 +11122,30 @@ def run_daemon() -> None:
                     heartbeat_interval = HEARTBEAT_INTERVAL_SLOW
 
         except Exception as e:
-            log.error(f"Sync cycle error: {e}")
+            # #2073: self-heal DuckDB ART-index corruption from a prior
+            # kill-during-write (SIGKILL / OOM / reboot). The whole DB is
+            # invalidated for this connection — every subsequent op fails
+            # and the daemon crash-loops without this. Drop+recreate the
+            # explicit indexes on a fresh connection and continue; the next
+            # cycle runs on the healed DB. Data is intact (#2073;
+            # [[feedback_no_sigkill_daemon_duckdb_writes]]).
+            try:
+                from clawmetry import local_store as _ls
+                if _ls.is_index_corruption_error(e):
+                    n = _ls.heal_index_corruption()
+                    if n >= 0:
+                        log.warning(
+                            "Sync cycle hit DuckDB index corruption — "
+                            "self-healed (%d indexes rebuilt); next cycle "
+                            "will run on the recovered store.", n,
+                        )
+                    else:
+                        log.error("Sync cycle hit DuckDB index corruption "
+                                  "and self-heal failed; will retry next cycle")
+                else:
+                    log.error(f"Sync cycle error: {e}")
+            except Exception:
+                log.error(f"Sync cycle error: {e}")
 
         # Adaptive cycle sleep (P0 real-time MOAT, 2026-05-13). The
         # original `time.sleep(POLL_INTERVAL=15)` floored the heartbeat


### PR DESCRIPTION
Closes #2073. Today (after the cost backfill rolled out and I SIGKILL'd the daemon mid-write while debugging), a DuckDB ART index went out of sync with its table → \`FATAL: database has been invalidated... Failed to delete all rows from index. Only deleted 0 out of 1 rows\` → every \`query_*\` returned 0 rows and the daemon crash-looped until I manually dropped+recreated the indexes. Data was intact (1.4 GB file fine); only the index was bad.

SIGKILL-during-write is a real-world hazard (OOM, reboot, \`kill -9\`, laptop sleep) — not just my debugging. Today a single such event would brick a user's local store until manual recovery. This PR makes the daemon self-heal instead.

## Implementation
- **\`local_store.py\`**
  - \`is_index_corruption_error(e)\` — matches both FATAL markers ("Failed to delete all rows from index", "database has been invalidated").
  - \`heal_index_corruption()\` — drops the cached writer singleton (so the post-corruption invalidated connection is gone), opens a **fresh** connection, \`DROP INDEX IF EXISTS\` every \`idx_%\` from \`duckdb_indexes()\`, \`CHECKPOINT\`, **re-runs the schema DDL** (\`CREATE INDEX IF NOT EXISTS\` is idempotent → recreates them clean from the table data), \`CHECKPOINT\` again, closes. Returns count rebuilt; never raises. Next \`get_store()\` opens a fresh writer on the healed DB.
- **\`sync.py\`** (\`run_daemon\` main cycle) — in the existing \`except Exception as e:\`, check \`is_index_corruption_error(e)\` first → call \`heal_index_corruption()\` → log and continue. Falls through to the existing handler when it's a different error.

## Verified end-to-end on the live 1.4 GB DB
- Before: 34 \`idx_%\` indexes, 929 events.
- \`heal_index_corruption()\` → dropped 34, recreated 34.
- After: 34 indexes (restored), 929 events (preserved).
- Daemon \`bootstrap\` post-heal: clean boot, \`query_events\` returns rows.
- Unit: \`is_index_corruption_error\` matches the FATAL strings (3/3) and rejects unrelated errors.

Mirrors the manual recovery I validated during the 2026-05-25 incident — the daemon now does it automatically on the next cycle instead of crash-looping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)