### PR TITLE
feat(dashboard): fold Subagent + skill-bootstrap sessions under "Show plumbing"

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10490,10 +10490,15 @@ function loadAllSkills() {
 // toggle (same treatment the Brain tab gives queue/metric rows).
 window._transcriptShowPlumbing = window._transcriptShowPlumbing || false;
 function _isPlumbingTranscript(titleSrc) {
-  // Match the Self-Evolve system prompt anywhere in the derived title — the
-  // title often carries a "[Wed 2026-05-20 22:30 GMT+2] …" timestamp prefix
+  // Internal/machine sessions that bury real work in the list — hidden by
+  // default behind "Show plumbing". Matched anywhere in the derived title,
+  // which often carries a "[Wed 2026-05-20 22:30 GMT+2] …" timestamp prefix
   // ahead of the prompt text, so we can't anchor at the start.
-  return String(titleSrc || '').toLowerCase().indexOf('you are clawmetry self-evolve') !== -1;
+  var s = String(titleSrc || '').toLowerCase();
+  return s.indexOf('you are clawmetry self-evolve') !== -1     // Self-Evolve runs (FIX + re-analyze)
+      || s.indexOf('[subagent context]') !== -1                 // spawned subagents
+      || s.indexOf('you are running as a subagent') !== -1      // subagent prompt (belt-and-suspenders)
+      || s.indexOf('base directory for this skill:') !== -1;    // skill-bootstrap sessions
 }
 window.toggleTranscriptPlumbing = function() {
   window._transcriptShowPlumbing = !window._transcriptShowPlumbing;


### PR DESCRIPTION
## What
Extends the "Show plumbing" filter (shipped in #2001) to also fold **`[Subagent Context]`** and **skill-bootstrap** sessions — not just Self-Evolve.

## Why
With only Self-Evolve hidden, the live Session replay list was still flooded with `[Subagent Context]` rows (8+), burying the actual user sessions. Folding the subagent + skill noise leaves just real work visible by default; one click on "Show plumbing" reveals everything (dimmed).

## Change
One-function change to `_isPlumbingTranscript` — adds title matches for `[subagent context]` / `you are running as a subagent` and `base directory for this skill:`.

Unit-tested against real session titles: Self-Evolve + Subagent + skill hidden; real + "Untitled" sessions stay visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)