### PR TITLE
feat(otel): first-class, vendor-neutral OpenTelemetry framing (--otel-export + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,29 @@ ClawMetry observes many AI-agent runtimes, not just OpenClaw. Each non-OpenClaw 
 
 "Beta adapter" means ClawMetry ships a reader for that runtime's real on-disk format, each built + verified against a real install on a real machine (see `tests/fixtures/runtimes/<rt>/`). Adapters are read-only; each is honest about what its runtime actually stores (e.g. PicoClaw/NanoClaw/Cursor don't write token cost to disk). When several runtimes run on one node, the runtime switcher scopes the sessions view to one for a clean deep-dive.
 
+## OpenTelemetry — vendor-neutral, send your traces anywhere
+
+ClawMetry speaks **OpenTelemetry** in both directions, using the **GenAI semantic conventions**, so your agent traces are never locked into one tool.
+
+**Export** every session — LLM calls, tools, sub-agents, tokens, cost — as OTLP/HTTP GenAI spans to any collector (Datadog, Grafana, Honeycomb, **MLflow**, or your own OTel Collector):
+
+```bash
+clawmetry --otel-export http://localhost:4318/v1/traces
+# equivalently:
+CLAWMETRY_OTEL_EXPORT_ENDPOINT=http://localhost:4318/v1/traces clawmetry
+```
+
+Auth headers and poll interval are optional env vars:
+
+```bash
+CLAWMETRY_OTEL_EXPORT_HEADERS='{"X-API-Key":"…"}'   # extra HTTP headers
+CLAWMETRY_OTEL_EXPORT_INTERVAL=60                    # seconds (default 60)
+```
+
+**Ingest** — the built-in OTLP receiver accepts traces and metrics from anything else at `/v1/traces` and `/v1/metrics` (`pip install clawmetry[otel]` for protobuf ingest).
+
+You get the zero-config, local-first ClawMetry dashboard **and** your data in whatever backend your team already runs — no lock-in, no second agent to install.
+
 ## Configuration
 
 Most people don't need any config. ClawMetry auto-detects your workspace, logs, sessions, and crons.

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2493,6 +2493,24 @@ def main() -> None:
             "v2 preview at http://localhost:8900/v2 · back to v1 at /",
             flush=True,
         )
+    # --otel-export <url>: stream agent traces as OpenTelemetry GenAI spans to
+    # any OTLP/HTTP collector (Datadog, Grafana, Honeycomb, MLflow, your own).
+    # Sets the env var clawmetry/otel_exporter.py reads at boot. Strip from argv
+    # so dashboard.main's argparse doesn't choke on it. Accepts both
+    # `--otel-export URL` and `--otel-export=URL`.
+    _otel_ep = None
+    for _i, _a in enumerate(list(sys.argv)):
+        if _a == "--otel-export" and _i + 1 < len(sys.argv):
+            _otel_ep = sys.argv[_i + 1]
+            del sys.argv[_i:_i + 2]
+            break
+        if _a.startswith("--otel-export="):
+            _otel_ep = _a.split("=", 1)[1]
+            sys.argv.remove(_a)
+            break
+    if _otel_ep:
+        os.environ["CLAWMETRY_OTEL_EXPORT_ENDPOINT"] = _otel_ep
+        print(f"OpenTelemetry export ON → {_otel_ep} (GenAI semconv)", flush=True)
     # Tag this process as the dashboard BEFORE importing dashboard, so every
     # get_store() in dashboard.py (module-level + handlers) is barred from the
     # DuckDB writer — only the sync daemon writes. Set before the import or a


### PR DESCRIPTION
## Why
MLflow (and others) lead their OpenClaw/agent-observability pitch with **"vendor-neutral OpenTelemetry, no lock-in."** ClawMetry already has the plumbing — an OTLP **receiver** (`/v1/metrics`, `/v1/traces`) and an outbound **GenAI-semconv exporter** (#1978) — but it was env-var-only and undocumented. This makes it a **first-class, one-flag** feature and leads with it.

## What
- **`--otel-export <url>` CLI flag** (`clawmetry/cli.py`) — `clawmetry --otel-export http://localhost:4318/v1/traces` streams every session (LLM calls, tools, sub-agents, tokens, cost) as OTLP/HTTP GenAI spans to **Datadog, Grafana, Honeycomb, MLflow, or your own collector**. Accepts `URL` and `=URL`; strips itself from argv before argparse; sets `CLAWMETRY_OTEL_EXPORT_ENDPOINT` (the exporter's existing switch).
- **README** — a prominent "OpenTelemetry — vendor-neutral, send your traces anywhere" section: export + the built-in receiver for ingest, with auth-header / interval env vars.

No change to the export/receiver mechanism — just discoverability + positioning.

## Verification
- `py_compile clawmetry/cli.py` OK.
- Flag parsing simulated for both forms + absent: endpoint captured, env set, **argv left clean** so `dashboard.main`'s argparse doesn't choke.

## Follow-up
Mirror the framing on the landing page (separate `clawmetry-landing` repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)