### PR TITLE
feat(otel): ingest OTel GenAI semconv v1.37 spans + derive cost

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -2209,16 +2209,32 @@ def _otel_to_row(span, resource_attrs):
       * ``gen_ai.usage.output_tokens`` / ``llm.usage.completion_tokens`` →
         ``tokens_output``
       * ``gen_ai.usage.total_tokens`` → ``token_count``
-      * ``gen_ai.usage.cost_usd`` / ``llm.usage.cost`` → ``cost_usd``
-      * ``tool.name`` / ``code.function`` → ``tool_name``
-      * ``session.id`` / ``openclaw.session_id`` → ``session_id``
-      * ``agent.id`` / ``openclaw.agent_id`` (also from resource) → ``agent_id``
+      * ``gen_ai.usage.cost_usd`` / ``llm.usage.cost`` → ``cost_usd``; when the
+        exporter ships no cost (the OTel GenAI norm — cost is not a standard
+        span attribute, so MLflow's OpenClaw plugin et al. emit token-only
+        spans), it is derived from tokens × model pricing, cache-aware, with
+        the provider resolved from ``gen_ai.provider.name`` / ``gen_ai.system``
+        or inferred from the model — same as the #2049 event path.
+      * ``gen_ai.tool.name`` / ``tool.name`` / ``code.function`` → ``tool_name``
+      * ``gen_ai.conversation.id`` / ``session.id`` / ``openclaw.session_id`` →
+        ``session_id``
+      * ``gen_ai.agent.id`` / ``agent.id`` / ``openclaw.agent_id`` (also from
+        resource) → ``agent_id``
       * ``agent.type`` (also from resource) → ``agent_type``
+      * ``gen_ai.input.messages`` / ``gen_ai.output.messages`` (current semconv)
+        and the legacy ``gen_ai.prompt`` / ``gen_ai.completion`` → ``input`` /
+        ``output``
       * Resource ``service.name`` → ``service_name``
+
+    Targets the OpenTelemetry GenAI semantic conventions (v1.37) so spans from
+    any conforming emitter — including MLflow's ``@mlflow/mlflow-openclaw``
+    tracer — light up ClawMetry's trace tree and cost views without a bespoke
+    per-SDK translator.
 
     Everything not projected lands in the ``attributes`` JSON blob so the
     span-detail panel can render any custom attributes the SDK exporter
-    set. Span events / links are passed through as JSON arrays.
+    set (e.g. ``gen_ai.operation.name``, ``gen_ai.agent.name``). Span events /
+    links are passed through as JSON arrays.
     """
     attrs = {}
     for attr in span.attributes:
@@ -2279,10 +2295,40 @@ def _otel_to_row(span, resource_attrs):
     token_count = _pick_int("gen_ai.usage.total_tokens", "llm.usage.total_tokens", "total_tokens")
     if token_count is None and (tokens_input or tokens_output):
         token_count = (tokens_input or 0) + (tokens_output or 0)
+    # Prompt-cache tokens (OTel GenAI semconv + Anthropic convention). Not
+    # stored as typed columns — they ride the attributes blob — but read here
+    # so the derived cost below is cache-aware (matches the #2049 event path).
+    cache_read = _pick_int("gen_ai.usage.cache_read_input_tokens", "cache_read_input_tokens") or 0
+    cache_write = _pick_int("gen_ai.usage.cache_creation_input_tokens", "cache_creation_input_tokens") or 0
+    # Provider: OTel GenAI semconv renamed gen_ai.system -> gen_ai.provider.name.
+    provider = _pick("gen_ai.provider.name", "gen_ai.system", "llm.provider", "provider") or ""
     cost_usd = _pick_float("gen_ai.usage.cost_usd", "llm.usage.cost", "cost_usd")
-    tool_name = _pick("tool.name", "code.function")
-    session_id = _pick("session.id", "openclaw.session_id", "session_id")
-    agent_id = _pick("agent.id", "openclaw.agent_id", "agent_id") or "main"
+    # Cost is NOT an OTel-standard span attribute, so GenAI emitters (MLflow's
+    # OpenClaw plugin, raw OpenAI/Anthropic auto-trace, …) ship token-only spans
+    # that would read as $0 in our usage/cost views. Derive it the same way the
+    # event ingest does (#2049): tokens x model pricing, cache-aware, provider
+    # resolved from the model when the span omits it. Only fill when the exporter
+    # supplied no cost at all, so an explicit cost (even 0 for a local model) wins.
+    if cost_usd is None and model and (tokens_input or tokens_output or cache_read or cache_write):
+        try:
+            from clawmetry.providers_pricing import estimate_event_cost_usd
+            derived = estimate_event_cost_usd(
+                model,
+                input_tokens=tokens_input or 0,
+                output_tokens=tokens_output or 0,
+                cache_read_tokens=cache_read,
+                cache_write_tokens=cache_write,
+                provider=provider,
+            )
+            if derived:
+                cost_usd = derived
+        except Exception:
+            pass
+    # tool.name: OTel GenAI semconv uses gen_ai.tool.name on execute_tool spans.
+    tool_name = _pick("gen_ai.tool.name", "tool.name", "code.function")
+    # session/conversation: semconv uses gen_ai.conversation.id.
+    session_id = _pick("gen_ai.conversation.id", "session.id", "openclaw.session_id", "session_id")
+    agent_id = _pick("gen_ai.agent.id", "agent.id", "openclaw.agent_id", "agent_id") or "main"
     agent_type = _pick("agent.type", "openclaw.agent_type", "agent_type") or "openclaw"
     service_name = resource_attrs.get("service.name") or attrs.get("service.name")
     node_id = _pick("node.id", "openclaw.node_id", "host.name")
@@ -2335,8 +2381,10 @@ def _otel_to_row(span, resource_attrs):
         "token_count": token_count,
         "tokens_input": tokens_input,
         "tokens_output": tokens_output,
-        "input": attrs.get("gen_ai.prompt") or attrs.get("llm.prompts") or attrs.get("input"),
-        "output": attrs.get("gen_ai.completion") or attrs.get("llm.completions") or attrs.get("output"),
+        "input": (attrs.get("gen_ai.input.messages") or attrs.get("gen_ai.prompt")
+                  or attrs.get("llm.prompts") or attrs.get("input")),
+        "output": (attrs.get("gen_ai.output.messages") or attrs.get("gen_ai.completion")
+                   or attrs.get("llm.completions") or attrs.get("output")),
         "attributes": attrs,
         "events": events,
         "links": links,
@@ -9953,16 +10001,32 @@ def _otel_to_row(span, resource_attrs):
       * ``gen_ai.usage.output_tokens`` / ``llm.usage.completion_tokens`` →
         ``tokens_output``
       * ``gen_ai.usage.total_tokens`` → ``token_count``
-      * ``gen_ai.usage.cost_usd`` / ``llm.usage.cost`` → ``cost_usd``
-      * ``tool.name`` / ``code.function`` → ``tool_name``
-      * ``session.id`` / ``openclaw.session_id`` → ``session_id``
-      * ``agent.id`` / ``openclaw.agent_id`` (also from resource) → ``agent_id``
+      * ``gen_ai.usage.cost_usd`` / ``llm.usage.cost`` → ``cost_usd``; when the
+        exporter ships no cost (the OTel GenAI norm — cost is not a standard
+        span attribute, so MLflow's OpenClaw plugin et al. emit token-only
+        spans), it is derived from tokens × model pricing, cache-aware, with
+        the provider resolved from ``gen_ai.provider.name`` / ``gen_ai.system``
+        or inferred from the model — same as the #2049 event path.
+      * ``gen_ai.tool.name`` / ``tool.name`` / ``code.function`` → ``tool_name``
+      * ``gen_ai.conversation.id`` / ``session.id`` / ``openclaw.session_id`` →
+        ``session_id``
+      * ``gen_ai.agent.id`` / ``agent.id`` / ``openclaw.agent_id`` (also from
+        resource) → ``agent_id``
       * ``agent.type`` (also from resource) → ``agent_type``
+      * ``gen_ai.input.messages`` / ``gen_ai.output.messages`` (current semconv)
+        and the legacy ``gen_ai.prompt`` / ``gen_ai.completion`` → ``input`` /
+        ``output``
       * Resource ``service.name`` → ``service_name``
+
+    Targets the OpenTelemetry GenAI semantic conventions (v1.37) so spans from
+    any conforming emitter — including MLflow's ``@mlflow/mlflow-openclaw``
+    tracer — light up ClawMetry's trace tree and cost views without a bespoke
+    per-SDK translator.
 
     Everything not projected lands in the ``attributes`` JSON blob so the
     span-detail panel can render any custom attributes the SDK exporter
-    set. Span events / links are passed through as JSON arrays.
+    set (e.g. ``gen_ai.operation.name``, ``gen_ai.agent.name``). Span events /
+    links are passed through as JSON arrays.
     """
     attrs = {}
     for attr in span.attributes:
@@ -10023,10 +10087,40 @@ def _otel_to_row(span, resource_attrs):
     token_count = _pick_int("gen_ai.usage.total_tokens", "llm.usage.total_tokens", "total_tokens")
     if token_count is None and (tokens_input or tokens_output):
         token_count = (tokens_input or 0) + (tokens_output or 0)
+    # Prompt-cache tokens (OTel GenAI semconv + Anthropic convention). Not
+    # stored as typed columns — they ride the attributes blob — but read here
+    # so the derived cost below is cache-aware (matches the #2049 event path).
+    cache_read = _pick_int("gen_ai.usage.cache_read_input_tokens", "cache_read_input_tokens") or 0
+    cache_write = _pick_int("gen_ai.usage.cache_creation_input_tokens", "cache_creation_input_tokens") or 0
+    # Provider: OTel GenAI semconv renamed gen_ai.system -> gen_ai.provider.name.
+    provider = _pick("gen_ai.provider.name", "gen_ai.system", "llm.provider", "provider") or ""
     cost_usd = _pick_float("gen_ai.usage.cost_usd", "llm.usage.cost", "cost_usd")
-    tool_name = _pick("tool.name", "code.function")
-    session_id = _pick("session.id", "openclaw.session_id", "session_id")
-    agent_id = _pick("agent.id", "openclaw.agent_id", "agent_id") or "main"
+    # Cost is NOT an OTel-standard span attribute, so GenAI emitters (MLflow's
+    # OpenClaw plugin, raw OpenAI/Anthropic auto-trace, …) ship token-only spans
+    # that would read as $0 in our usage/cost views. Derive it the same way the
+    # event ingest does (#2049): tokens x model pricing, cache-aware, provider
+    # resolved from the model when the span omits it. Only fill when the exporter
+    # supplied no cost at all, so an explicit cost (even 0 for a local model) wins.
+    if cost_usd is None and model and (tokens_input or tokens_output or cache_read or cache_write):
+        try:
+            from clawmetry.providers_pricing import estimate_event_cost_usd
+            derived = estimate_event_cost_usd(
+                model,
+                input_tokens=tokens_input or 0,
+                output_tokens=tokens_output or 0,
+                cache_read_tokens=cache_read,
+                cache_write_tokens=cache_write,
+                provider=provider,
+            )
+            if derived:
+                cost_usd = derived
+        except Exception:
+            pass
+    # tool.name: OTel GenAI semconv uses gen_ai.tool.name on execute_tool spans.
+    tool_name = _pick("gen_ai.tool.name", "tool.name", "code.function")
+    # session/conversation: semconv uses gen_ai.conversation.id.
+    session_id = _pick("gen_ai.conversation.id", "session.id", "openclaw.session_id", "session_id")
+    agent_id = _pick("gen_ai.agent.id", "agent.id", "openclaw.agent_id", "agent_id") or "main"
     agent_type = _pick("agent.type", "openclaw.agent_type", "agent_type") or "openclaw"
     service_name = resource_attrs.get("service.name") or attrs.get("service.name")
     node_id = _pick("node.id", "openclaw.node_id", "host.name")
@@ -10079,8 +10173,10 @@ def _otel_to_row(span, resource_attrs):
         "token_count": token_count,
         "tokens_input": tokens_input,
         "tokens_output": tokens_output,
-        "input": attrs.get("gen_ai.prompt") or attrs.get("llm.prompts") or attrs.get("input"),
-        "output": attrs.get("gen_ai.completion") or attrs.get("llm.completions") or attrs.get("output"),
+        "input": (attrs.get("gen_ai.input.messages") or attrs.get("gen_ai.prompt")
+                  or attrs.get("llm.prompts") or attrs.get("input")),
+        "output": (attrs.get("gen_ai.output.messages") or attrs.get("gen_ai.completion")
+                   or attrs.get("llm.completions") or attrs.get("output")),
         "attributes": attrs,
         "events": events,
         "links": links,

--- a/tests/test_spans_ingest.py
+++ b/tests/test_spans_ingest.py
@@ -340,6 +340,106 @@ def test_otlp_traces_write_through_persists_span(store, monkeypatch):
 
 @pytest.mark.skipif(not _HAS_OTEL_PROTO,
                     reason="opentelemetry-proto not installed (pip install clawmetry[otel])")
+def test_otlp_genai_semconv_v137_mlflow_shape(store, monkeypatch):
+    """Spans in the current OTel GenAI semantic conventions (v1.37) — the shape
+    MLflow's @mlflow/mlflow-openclaw plugin emits — must populate the typed
+    columns. These keys (gen_ai.tool.name, gen_ai.conversation.id,
+    gen_ai.agent.id, gen_ai.provider.name) were NOT mapped before, so an
+    MLflow/OTel tool or sub-agent span landed with empty session/tool/agent."""
+    import dashboard as _d
+    import clawmetry.local_store as ls
+    monkeypatch.setattr(_d, "_HAS_OTEL_PROTO", True, raising=False)
+    monkeypatch.setattr(_d, "trace_service_pb2", trace_service_pb2, raising=False)
+
+    trace_id_hex = "11112222333344445555666677778888"
+    chat_id = "aaaa000000000001"
+    tool_id = "aaaa000000000002"
+    pb = _build_export_request([
+        {   # invoke_agent → chat span (LLM call), token-only, NO cost attr
+            "trace_id": trace_id_hex,
+            "span_id":  chat_id,
+            "name":     "chat claude-opus-4-7",
+            "start_ns": 1_715_000_000_000_000_000,
+            "end_ns":   1_715_000_001_000_000_000,
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "anthropic",
+                "gen_ai.request.model": "claude-opus-4-7",
+                "gen_ai.conversation.id": "conv-mlflow-1",
+                "gen_ai.agent.id": "researcher",
+                "gen_ai.usage.input_tokens": 1000,
+                "gen_ai.usage.output_tokens": 200,
+            },
+        },
+        {   # execute_tool span — semconv uses gen_ai.tool.name
+            "trace_id": trace_id_hex,
+            "span_id":  tool_id,
+            "parent_span_id": chat_id,
+            "name":     "execute_tool bash",
+            "start_ns": 1_715_000_000_200_000_000,
+            "end_ns":   1_715_000_000_400_000_000,
+            "attributes": {
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": "bash",
+                "gen_ai.conversation.id": "conv-mlflow-1",
+            },
+        },
+    ])
+
+    _d._process_otlp_traces(pb)
+    rows = {r["span_id"]: r for r in ls.get_store().query_spans(trace_id=trace_id_hex)}
+    assert set(rows) == {chat_id, tool_id}
+
+    chat = rows[chat_id]
+    assert chat["model"] == "claude-opus-4-7"
+    assert chat["session_id"] == "conv-mlflow-1"      # gen_ai.conversation.id
+    assert chat["agent_id"] == "researcher"            # gen_ai.agent.id
+    assert chat["tokens_input"] == 1000
+    assert chat["tokens_output"] == 200
+    # Cost is NOT an OTel-standard attribute — must be derived from tokens.
+    from clawmetry.providers_pricing import estimate_event_cost_usd
+    expected = estimate_event_cost_usd("claude-opus-4-7", input_tokens=1000,
+                                       output_tokens=200, provider="anthropic")
+    assert expected > 0, "fixture pricing assumption broke"
+    assert chat["cost_usd"] == pytest.approx(expected)
+
+    tool = rows[tool_id]
+    assert tool["tool_name"] == "bash"                 # gen_ai.tool.name
+    assert tool["session_id"] == "conv-mlflow-1"
+    assert tool["parent_span_id"] == chat_id
+
+
+@pytest.mark.skipif(not _HAS_OTEL_PROTO,
+                    reason="opentelemetry-proto not installed (pip install clawmetry[otel])")
+def test_otlp_explicit_cost_is_not_overridden(store, monkeypatch):
+    """When the exporter DID ship a cost, we keep it verbatim and never
+    re-derive (an explicit 0 for a local model must survive)."""
+    import dashboard as _d
+    import clawmetry.local_store as ls
+    monkeypatch.setattr(_d, "_HAS_OTEL_PROTO", True, raising=False)
+    monkeypatch.setattr(_d, "trace_service_pb2", trace_service_pb2, raising=False)
+
+    trace_id_hex = "99998888777766665555444433332222"
+    pb = _build_export_request([{
+        "trace_id": trace_id_hex,
+        "span_id":  "cccc000000000001",
+        "name":     "chat",
+        "start_ns": 1_715_000_000_000_000_000,
+        "end_ns":   1_715_000_000_500_000_000,
+        "attributes": {
+            "gen_ai.request.model": "claude-opus-4-7",
+            "gen_ai.usage.input_tokens": 1000,
+            "gen_ai.usage.output_tokens": 200,
+            "gen_ai.usage.cost_usd": 0.0,   # explicit zero must win
+        },
+    }])
+    _d._process_otlp_traces(pb)
+    row = ls.get_store().query_spans(trace_id=trace_id_hex)[0]
+    assert row["cost_usd"] == pytest.approx(0.0)
+
+
+@pytest.mark.skipif(not _HAS_OTEL_PROTO,
+                    reason="opentelemetry-proto not installed (pip install clawmetry[otel])")
 def test_otlp_retry_does_not_duplicate(store, monkeypatch):
     """OTel exporters retry on 5xx — same span_id must NOT duplicate in DuckDB."""
     import dashboard as _d


### PR DESCRIPTION
## Why

MLflow just shipped an **OpenClaw tracing plugin** (`@mlflow/mlflow-openclaw`, blog: *From Black Box to Observability*). It traces OpenClaw agents into a local MLflow UI using the **OpenTelemetry GenAI semantic conventions (v1.37)**. Our full competitive analysis is in `docs/MLFLOW_VS_CLAWMETRY.md`; the #1 strategic move it identified was:

> Adopt OTel GenAI semconv so we **ingest** MLflow-grade spans instead of fighting on the wire format. Interop beats a format war.

Our OTLP `/v1/traces` receiver already existed (issue #1007), but `_otel_to_row` only mapped the **older** `gen_ai.*` keys. Spans in the current semconv — the exact shape MLflow's plugin and other GenAI auto-tracers emit — landed with **empty session/tool/agent** and **$0 cost**. The $0 is the same problem #2049 fixed for events: cost is not an OTel-standard attribute, so GenAI emitters ship token-only spans.

## What

`_otel_to_row` now maps the current OTel GenAI semconv v1.37 keys:

| semconv key | column |
|---|---|
| `gen_ai.tool.name` | `tool_name` (execute_tool spans) |
| `gen_ai.conversation.id` | `session_id` |
| `gen_ai.agent.id` | `agent_id` |
| `gen_ai.provider.name` / `gen_ai.system` | provider (for cost resolution) |
| `gen_ai.input.messages` / `gen_ai.output.messages` | `input` / `output` |
| `gen_ai.usage.cache_{read,creation}_input_tokens` | cache-aware cost input |

And **derives cost** for token-only spans the same way the event ingest does (#2049): tokens × model pricing, cache-aware, provider inferred from the model when absent — via `providers_pricing.estimate_event_cost_usd`. Only fills when the exporter gave **no** cost at all, so an explicit value (including `0` for a local model) still wins.

All older keys (`gen_ai.request.model`, `llm.usage.*`, `tool.name`, `session.id`, …) remain mapped — this is purely additive.

## Verification

- 2 new tests in `tests/test_spans_ingest.py`:
  - `test_otlp_genai_semconv_v137_mlflow_shape` — a chat + execute_tool trace in MLflow/semconv shape; asserts tool/conversation/agent mapping **and** derived cost.
  - `test_otlp_explicit_cost_is_not_overridden` — explicit `0.0` cost survives.
- **17/17** span tests green locally (`test_spans_ingest.py` + `test_spans_e2e.py`).
- Pure-function change (`_otel_to_row`) — no DuckDB writer-lock interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)