### PR TITLE
docs(otel): drop MLflow from export examples (don't name a competitor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ ClawMetry observes many AI-agent runtimes, not just OpenClaw. Each non-OpenClaw 
 
 ClawMetry speaks **OpenTelemetry** in both directions, using the **GenAI semantic conventions**, so your agent traces are never locked into one tool.
 
-**Export** every session — LLM calls, tools, sub-agents, tokens, cost — as OTLP/HTTP GenAI spans to any collector (Datadog, Grafana, Honeycomb, **MLflow**, or your own OTel Collector):
+**Export** every session — LLM calls, tools, sub-agents, tokens, cost — as OTLP/HTTP GenAI spans to any collector (Datadog, Grafana, Honeycomb, or your own OTel Collector):
 
 ```bash
 clawmetry --otel-export http://localhost:4318/v1/traces

--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2494,7 +2494,7 @@ def main() -> None:
             flush=True,
         )
     # --otel-export <url>: stream agent traces as OpenTelemetry GenAI spans to
-    # any OTLP/HTTP collector (Datadog, Grafana, Honeycomb, MLflow, your own).
+    # any OTLP/HTTP collector (Datadog, Grafana, Honeycomb, your own).
     # Sets the env var clawmetry/otel_exporter.py reads at boot. Strip from argv
     # so dashboard.main's argparse doesn't choke on it. Accepts both
     # `--otel-export URL` and `--otel-export=URL`.


### PR DESCRIPTION
Follow-up to #2086. The OTel 'send anywhere' copy named **MLflow** as an example export target — but MLflow is a direct competitor in agent observability, so there's no reason to give them a free mention in our own README/CLI. Removed it; the neutral backends (Datadog, Grafana, Honeycomb, your own collector) make the vendor-neutral / no-lock-in point just as well. 🤖 Generated with [Claude Code](https://claude.com/claude-code)