### PR TITLE
feat(tracing): make the Tracing tab GA (out of the ?tracing=1 flag)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -16533,16 +16533,18 @@ document.addEventListener('DOMContentLoaded', function() {
   try { _applyTracingFlag(); } catch (e) { /* non-fatal */ }
 });
 
-// The Tracing tab stays gated while it's being polished (PRD-tracing.md phases
-// 3-4 + the daemon-proxy reliability fix). Hidden from the nav by default;
-// reveal it with ?tracing=1 (persisted to localStorage) or ?tab=tracing.
-// Disable again with ?tracing=0.
+// The Tracing tab (Phoenix/Arize-style span waterfall + tree + agent graph) is
+// now GA: shown in the nav by default for every install. The phases-3-4 polish
+// and the daemon-proxy reliability fixes that kept it behind a flag have landed,
+// and it's verified against real traces (event-derived + OTel/OTLP spans).
+// Power users can still hide it with ?tracing=0 (persisted to localStorage);
+// ?tracing=1 clears the opt-out.
 function _applyTracingFlag() {
   var p = new URLSearchParams(window.location.search);
-  if (p.get('tracing') === '1') { try { localStorage.setItem('cm-ff-tracing', '1'); } catch (e) {} }
-  if (p.get('tracing') === '0') { try { localStorage.removeItem('cm-ff-tracing'); } catch (e) {} }
-  var on = false;
-  try { on = localStorage.getItem('cm-ff-tracing') === '1'; } catch (e) {}
+  if (p.get('tracing') === '0') { try { localStorage.setItem('cm-ff-tracing-off', '1'); } catch (e) {} }
+  if (p.get('tracing') === '1') { try { localStorage.removeItem('cm-ff-tracing-off'); } catch (e) {} }
+  var on = true;
+  try { if (localStorage.getItem('cm-ff-tracing-off') === '1') on = false; } catch (e) {}
   if (p.get('tab') === 'tracing') on = true;
   var el = document.getElementById('left-nav-tracing');
   if (el) el.style.display = on ? '' : 'none';

--- a/dashboard.py
+++ b/dashboard.py
@@ -11066,7 +11066,7 @@ DASHBOARD_HTML = r"""
         <div class="left-nav-item left-nav-item-sub" data-tab="context" onclick="switchTab('context')" data-i18n-title="nav.llm_context_tooltip" title="What the LLM sees on each turn">
           <span class="left-nav-label" data-i18n="nav.llm_context">LLM Context</span>
         </div>
-        <div class="left-nav-item left-nav-item-sub" id="left-nav-tracing" data-tab="tracing" onclick="switchTab('tracing')" data-i18n-title="nav.tracing_tooltip" title="Every trace: span waterfall, tree, and agent graph" style="display:none;">
+        <div class="left-nav-item left-nav-item-sub" id="left-nav-tracing" data-tab="tracing" onclick="switchTab('tracing')" data-i18n-title="nav.tracing_tooltip" title="Every trace: span waterfall, tree, and agent graph">
           <span class="left-nav-label" data-i18n="nav.tracing">Tracing</span>
         </div>
       </div>


### PR DESCRIPTION
## Why

The Phoenix/Arize-style **Tracing tab** (per-session trace list → span **waterfall** + span **tree** + **agent graph** + span-detail drawer) has been hidden behind a `?tracing=1` feature flag since it was "being polished (phases 3-4 + the daemon-proxy reliability fix)". Those preconditions have landed:
- daemon-proxy read path is reliable (retry-on-timeout shipped);
- the span-detail drawer is built;
- the tab is verified against real traces.

This is the **#1 MLflow-parity gap** from `docs/MLFLOW_VS_CLAWMETRY.md`: a first-class span tree for every user. It was already built; it was just gated.

## What

- Remove the inline `style="display:none;"` from the `left-nav-tracing` nav item so it shows by default (no flash-of-hidden).
- `_applyTracingFlag()` now defaults **ON**; power users can opt **out** with `?tracing=0` (persisted as `cm-ff-tracing-off`), and `?tracing=1` clears the opt-out.

2-line HTML change + the gate function. No backend changes.

## Verification (live, real data)

Ran repo HEAD on `:8901` with `CLAWMETRY_ROLE=dashboard` (reads via the daemon proxy, never grabs the DuckDB writer), then in a browser with a **fresh origin and no `?tracing` flag**:
- ✅ "Tracing" appears in the nav by default.
- ✅ The tab lists **19 real traces** (span counts, durations, tokens).
- ✅ A 361-span trace renders its **waterfall** and **span tree** with per-span tokens/durations and 🤖/🔧 icons.
- ✅ Daemon (PID unchanged, exit 0) + DuckDB data unaffected afterwards.

(Screenshots captured locally: `docs/screenshots/tracing-tab-ungated-default-nav.png`, `tracing-tab-waterfall-live.png`.)

No test depends on the gate (`grep` for `cm-ff-tracing` / `?tab=tracing` in `tests/` is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)