### PR TITLE
feat(observability): ingest OpenClaw run ledger (subagent/cron/cli lanes)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -396,6 +396,52 @@ _DDL = [
         PRIMARY KEY (agent_type, subagent_id)
     )
     """,
+    # OpenClaw 2026.5.x moved its background-run bookkeeping out of the old
+    # ``~/.openclaw/subagents/runs.json`` (now usually empty) into a unified
+    # SQLite ledger at ``~/.openclaw/tasks/runs.sqlite``. That ledger is the
+    # authoritative record of EVERY background run — sub-agents
+    # (``runtime='subagent'``), cron jobs (``runtime='cron'``), and inline
+    # CLI/agent turns (``runtime='cli'``) — with status, delivery, timing,
+    # parent/child linkage and terminal outcome. We mirror it verbatim into
+    # ``run_ledger`` so three observability surfaces share one source of
+    # truth: the Scheduler/lane monitor (group by ``runtime``/``status``),
+    # the sub-agent fan-out tree (``parent_task_id``/``child_session_key``),
+    # and the cron run log. ``runtime`` IS the OpenClaw queue lane.
+    """
+    CREATE TABLE IF NOT EXISTS run_ledger (
+        task_id               VARCHAR PRIMARY KEY,
+        node_id               VARCHAR,
+        runtime               VARCHAR,
+        task_kind             VARCHAR,
+        source_id             VARCHAR,
+        requester_session_key VARCHAR,
+        owner_key             VARCHAR,
+        scope_kind            VARCHAR,
+        child_session_key     VARCHAR,
+        parent_flow_id        VARCHAR,
+        parent_task_id        VARCHAR,
+        agent_id              VARCHAR,
+        run_id                VARCHAR,
+        label                 VARCHAR,
+        task                  VARCHAR,
+        status                VARCHAR,
+        delivery_status       VARCHAR,
+        notify_policy         VARCHAR,
+        created_at            BIGINT,
+        started_at            BIGINT,
+        ended_at              BIGINT,
+        last_event_at         BIGINT,
+        cleanup_after         BIGINT,
+        error                 VARCHAR,
+        progress_summary      VARCHAR,
+        terminal_summary      VARCHAR,
+        terminal_outcome      VARCHAR,
+        updated_at            BIGINT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_run_ledger_runtime_status ON run_ledger(runtime, status)",
+    "CREATE INDEX IF NOT EXISTS idx_run_ledger_parent ON run_ledger(parent_task_id)",
+    "CREATE INDEX IF NOT EXISTS idx_run_ledger_last_event ON run_ledger(last_event_at)",
     # Epic #1032 Phase 4 — approval queue. Authored locally when the policy
     # watcher fires on a tool-call, mirrored to the cloud cache via heartbeat
     # cache_push so the cloud Approvals inbox paints from cache, and resolved
@@ -2063,6 +2109,74 @@ class LocalStore:
                   float(sa.get("cost_usd") or 0),
                   int(sa.get("token_count") or 0),
                   data_blob, now_ms])
+
+    # Columns mirrored 1:1 from OpenClaw's tasks/runs.sqlite ``task_runs`` row.
+    _RUN_LEDGER_COLS = (
+        "task_id", "node_id", "runtime", "task_kind", "source_id",
+        "requester_session_key", "owner_key", "scope_kind", "child_session_key",
+        "parent_flow_id", "parent_task_id", "agent_id", "run_id", "label",
+        "task", "status", "delivery_status", "notify_policy", "created_at",
+        "started_at", "ended_at", "last_event_at", "cleanup_after", "error",
+        "progress_summary", "terminal_summary", "terminal_outcome",
+    )
+
+    def ingest_run_ledger_row(self, r: dict[str, Any], *, node_id: str = "") -> None:
+        """Upsert one OpenClaw run-ledger row (from ``tasks/runs.sqlite``).
+
+        Required: ``task_id``. Re-ingesting a row whose ``status`` /
+        ``last_event_at`` advanced overwrites the prior copy (runs go
+        ``running`` -> ``succeeded``/``failed``), so the daemon can keep a
+        watermark on ``last_event_at`` and only re-read changed rows. Long
+        free-text fields are truncated so a runaway ``task`` description
+        can't bloat the row (and, downstream, the shared snapshot)."""
+        tid = r.get("task_id")
+        if not tid:
+            raise ValueError("run-ledger row must include 'task_id'")
+
+        def _txt(v: Any, n: int = 2000) -> Any:
+            if v is None:
+                return None
+            s = str(v)
+            return s[:n] if len(s) > n else s
+
+        def _int(v: Any) -> Any:
+            if v is None:
+                return None
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return None
+
+        vals = [
+            str(tid), node_id or None, _txt(r.get("runtime"), 64),
+            _txt(r.get("task_kind"), 64), _txt(r.get("source_id"), 256),
+            _txt(r.get("requester_session_key"), 256), _txt(r.get("owner_key"), 256),
+            _txt(r.get("scope_kind"), 64), _txt(r.get("child_session_key"), 256),
+            _txt(r.get("parent_flow_id"), 256), _txt(r.get("parent_task_id"), 256),
+            _txt(r.get("agent_id"), 128), _txt(r.get("run_id"), 256),
+            _txt(r.get("label"), 512), _txt(r.get("task"), 2000),
+            _txt(r.get("status"), 64), _txt(r.get("delivery_status"), 64),
+            _txt(r.get("notify_policy"), 64), _int(r.get("created_at")),
+            _int(r.get("started_at")), _int(r.get("ended_at")),
+            _int(r.get("last_event_at")), _int(r.get("cleanup_after")),
+            _txt(r.get("error"), 2000), _txt(r.get("progress_summary"), 2000),
+            _txt(r.get("terminal_summary"), 2000), _txt(r.get("terminal_outcome"), 256),
+        ]
+        now_ms = int(time.time() * 1000)
+        cols = ", ".join(self._RUN_LEDGER_COLS)
+        ph = ", ".join("?" for _ in self._RUN_LEDGER_COLS)
+        # Overwrite every non-key column on conflict — the source row is the
+        # source of truth and only ever moves forward (status/timing fill in).
+        upd = ", ".join(
+            f"{c} = excluded.{c}" for c in self._RUN_LEDGER_COLS if c != "task_id"
+        )
+        with self._write_lock:
+            self._conn.execute(
+                f"INSERT INTO run_ledger ({cols}, updated_at) "
+                f"VALUES ({ph}, ?) "
+                f"ON CONFLICT (task_id) DO UPDATE SET {upd}, updated_at = excluded.updated_at",
+                [*vals, now_ms],
+            )
 
     def ingest_loop_signal(
         self,
@@ -4389,6 +4503,63 @@ class LocalStore:
                 "ended_at", "task", "status", "cost_usd", "token_count",
                 "data", "updated_at"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
+
+    def query_run_ledger(
+        self,
+        *,
+        runtime: str | None = None,
+        scope_kind: str | None = None,
+        status: str | None = None,
+        since_ms: int | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """OpenClaw background-run ledger rows (sub-agents, crons, CLI turns).
+
+        ``runtime`` is the OpenClaw queue lane (``cli``/``cron``/``subagent``).
+        Newest first by ``last_event_at`` (falling back to ``created_at``)."""
+        where: list[str] = []
+        params: list[Any] = []
+        if runtime:
+            where.append("runtime = ?"); params.append(runtime)
+        if scope_kind:
+            where.append("scope_kind = ?"); params.append(scope_kind)
+        if status:
+            where.append("status = ?"); params.append(status)
+        if since_ms is not None:
+            where.append("COALESCE(last_event_at, created_at, 0) >= ?")
+            params.append(int(since_ms))
+        clause = ("WHERE " + " AND ".join(where)) if where else ""
+        cols = list(self._RUN_LEDGER_COLS) + ["updated_at"]
+        sql = (
+            f"SELECT {', '.join(cols)} FROM run_ledger {clause} "
+            f"ORDER BY COALESCE(last_event_at, created_at, 0) DESC LIMIT ?"
+        )
+        params.append(int(limit))
+        return [dict(zip(cols, row)) for row in self._fetch(sql, params)]
+
+    def query_run_ledger_lanes(self) -> list[dict[str, Any]]:
+        """Per-lane occupancy rollup for the Scheduler/queue monitor.
+
+        One row per ``runtime`` lane with running / queued / done counts so
+        the UI can render lane-saturation bars without pulling every row.
+        ``running`` approximates live lane occupancy; ``queued`` is anything
+        accepted-but-not-started; ``failed_recent`` flags lanes with trouble."""
+        sql = """
+            SELECT
+                COALESCE(runtime, 'unknown')                                   AS lane,
+                COUNT(*)                                                       AS total,
+                COUNT(*) FILTER (WHERE status IN ('running', 'in_progress', 'active'))   AS running,
+                COUNT(*) FILTER (WHERE status IN ('queued', 'accepted', 'pending'))      AS queued,
+                COUNT(*) FILTER (WHERE status IN ('succeeded', 'success', 'ok', 'done')) AS succeeded,
+                COUNT(*) FILTER (WHERE status IN ('failed', 'error', 'timeout'))         AS failed,
+                MAX(COALESCE(last_event_at, created_at, 0))                     AS last_event_at
+            FROM run_ledger
+            GROUP BY 1
+            ORDER BY running DESC, total DESC
+        """
+        cols = ["lane", "total", "running", "queued", "succeeded",
+                "failed", "last_event_at"]
+        return [dict(zip(cols, row)) for row in self._fetch(sql, [])]
 
     def query_channel_configs(
         self,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7149,6 +7149,108 @@ def sync_cron_runs(config: dict, state: dict, paths: dict) -> int:
     return n_ingested
 
 
+_RUN_LEDGER_SRC_COLS = (
+    "task_id", "runtime", "task_kind", "source_id", "requester_session_key",
+    "owner_key", "scope_kind", "child_session_key", "parent_flow_id",
+    "parent_task_id", "agent_id", "run_id", "label", "task", "status",
+    "delivery_status", "notify_policy", "created_at", "started_at", "ended_at",
+    "last_event_at", "cleanup_after", "error", "progress_summary",
+    "terminal_summary", "terminal_outcome",
+)
+
+
+def _openclaw_task_ledger_paths() -> list[Path]:
+    """Candidate locations of OpenClaw's run ledger SQLite, newest layout
+    first. OpenClaw 2026.5.x writes ``~/.openclaw/tasks/runs.sqlite``."""
+    oc = Path(_get_openclaw_dir())
+    return [
+        oc / "tasks" / "runs.sqlite",
+        Path("/root/.openclaw/tasks/runs.sqlite"),
+        Path("/sandbox/.openclaw/tasks/runs.sqlite"),
+    ]
+
+
+def sync_run_ledger(config: dict, state: dict, paths: dict) -> int:
+    """Mirror OpenClaw's background-run ledger (``tasks/runs.sqlite``) into
+    the local DuckDB ``run_ledger`` table.
+
+    This is the authoritative record of every background run — sub-agents
+    (``runtime='subagent'``), cron jobs (``runtime='cron'``) and inline
+    CLI/agent turns (``runtime='cli'``) — and is the shared source for the
+    Scheduler lane monitor, the sub-agent fan-out tree and the cron run log.
+
+    Idempotent + incremental: we keep a ``last_event_at`` watermark in
+    ``state['run_ledger_watermark']`` and only re-read rows that advanced
+    since the last cycle (status moves ``running`` -> terminal, so the
+    watermark catches updates as well as inserts). Returns rows ingested.
+
+    Degrades silently: missing ledger, locked DB, or malformed row each
+    return 0 / skip rather than raising (read-only-by-default contract).
+    """
+    try:
+        from clawmetry import local_store as _ls
+    except Exception as e:  # noqa: BLE001
+        log.debug("sync_run_ledger: local_store unavailable: %s", e)
+        return 0
+
+    src = next((p for p in _openclaw_task_ledger_paths() if p.exists()), None)
+    if src is None:
+        return 0
+
+    node_id = config.get("node_id", "") if isinstance(config, dict) else ""
+    watermark = int(state.get("run_ledger_watermark", 0) or 0)
+
+    import sqlite3
+    rows: list[dict] = []
+    try:
+        # Read-only URI open so we never contend with OpenClaw's writer.
+        conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True, timeout=2.0)
+        try:
+            conn.row_factory = sqlite3.Row
+            cur = conn.execute(
+                f"SELECT {', '.join(_RUN_LEDGER_SRC_COLS)} FROM task_runs "
+                "WHERE COALESCE(last_event_at, ended_at, created_at, 0) >= ? "
+                "ORDER BY COALESCE(last_event_at, ended_at, created_at, 0) ASC "
+                "LIMIT 5000",
+                [watermark],
+            )
+            rows = [dict(r) for r in cur.fetchall()]
+        finally:
+            conn.close()
+    except Exception as e:  # noqa: BLE001 — locked / corrupt / schema drift
+        log.debug("sync_run_ledger: read failed (%s)", e)
+        return 0
+
+    if not rows:
+        return 0
+
+    try:
+        store = _ls.get_store()
+    except Exception as e:  # noqa: BLE001
+        log.debug("sync_run_ledger: get_store failed: %s", e)
+        return 0
+
+    n = 0
+    new_watermark = watermark
+    for r in rows:
+        try:
+            store.ingest_run_ledger_row(r, node_id=node_id)
+            n += 1
+            wm = r.get("last_event_at") or r.get("ended_at") or r.get("created_at") or 0
+            try:
+                new_watermark = max(new_watermark, int(wm))
+            except (TypeError, ValueError):
+                pass
+        except Exception as e_in:  # noqa: BLE001
+            log.debug("sync_run_ledger: ingest skipped for %s: %s",
+                      r.get("task_id"), e_in)
+    state["run_ledger_watermark"] = new_watermark
+    if n:
+        log.debug("sync_run_ledger: ingested %d rows (watermark=%d)",
+                  n, new_watermark)
+    return n
+
+
 def sync_session_metadata(config: dict, state: dict = None) -> int:
     """Sync OpenClaw session metadata rows to cloud sessions table.
 
@@ -10128,6 +10230,37 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     except Exception as _e:
         log.debug("snapshot: compute_skills_payload failed: %s", _e)
 
+    # OpenClaw run ledger (tasks/runs.sqlite mirror) → bounded snapshot slice
+    # for the cloud Scheduler lane monitor + sub-agent fan-out tree. We ship
+    # the lane rollup (tiny) plus the most-recent runs only, and trim the
+    # free-text fields to short prefixes so a long task description can't
+    # bloat the shared snapshot (the #1895 / 0.12.278 bloat lesson).
+    run_ledger_slice = {"lanes": [], "runs": []}
+    try:
+        from clawmetry import local_store as _ls_rl
+        _rl_store = _ls_rl.get_store()
+        if _rl_store is not None:
+            run_ledger_slice["lanes"] = _rl_store.query_run_ledger_lanes() or []
+            _RL_KEEP = (
+                "task_id", "runtime", "task_kind", "scope_kind", "agent_id",
+                "run_id", "label", "status", "delivery_status",
+                "terminal_outcome", "child_session_key", "parent_task_id",
+                "requester_session_key", "created_at", "started_at",
+                "ended_at", "last_event_at",
+            )
+            _runs = _rl_store.query_run_ledger(limit=120) or []
+            run_ledger_slice["runs"] = [
+                {
+                    **{k: r.get(k) for k in _RL_KEEP},
+                    # short prefixes only — never the full task/error body
+                    "label": (str(r.get("label") or r.get("task") or "")[:80]),
+                    "error": (str(r.get("error"))[:160] if r.get("error") else None),
+                }
+                for r in _runs
+            ]
+    except Exception as _e_rl:
+        log.debug("snapshot: run_ledger slice failed: %s", _e_rl)
+
     payload = {
         "system": system,
         "infra": infra,
@@ -10152,6 +10285,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
             "total": len(subagents_list),
         },
         "totalActive": active_count,
+        "runLedger": run_ledger_slice,
         "spending": spending,
         "cronJobs": _build_cron_jobs(paths),
         "channels": _build_channel_data(config),
@@ -10728,6 +10862,14 @@ def run_daemon() -> None:
             log.info(f"  Cron runs: {crr} rows ingested")
     except Exception as e:
         log.warning(f"  Cron-run ingest error: {e}")
+    # OpenClaw 2026.5.x run ledger (tasks/runs.sqlite) → DuckDB run_ledger.
+    # Feeds the Scheduler lane monitor + sub-agent fan-out tree.
+    try:
+        rl = sync_run_ledger(config, state, paths)
+        if rl:
+            log.info(f"  Run ledger: {rl} rows ingested")
+    except Exception as e:
+        log.warning(f"  Run-ledger ingest error: {e}")
     # Sync today's log lines immediately so Brain tab shows the most recent
     # activity right away — older log history is backfilled later
     try:
@@ -11023,6 +11165,11 @@ def run_daemon() -> None:
             except Exception as _e_cr:
                 log.debug("sync_cron_runs error (non-fatal): %s", _e_cr)
                 cron_runs = 0
+            # OpenClaw run ledger (tasks/runs.sqlite) → DuckDB run_ledger.
+            try:
+                sync_run_ledger(config, state, paths)
+            except Exception as _e_rl:
+                log.debug("sync_run_ledger error (non-fatal): %s", _e_rl)
 
             # ── Low-priority: log lines (real-time covered by streamer) ──
             lg = 0

--- a/dashboard.py
+++ b/dashboard.py
@@ -121,6 +121,7 @@ from routes.insights import bp_insights
 from routes.review import bp_review
 from routes.evals import bp_evals
 from routes.dives import bp_dives
+from routes.scheduler import bp_scheduler
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -10617,6 +10618,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_plugins)
     app.register_blueprint(bp_local_query)
     app.register_blueprint(bp_dives)
+    app.register_blueprint(bp_scheduler)
 
     # Register built-in agent adapters. External plugins can register more
     # via clawmetry.extensions entry points — see clawmetry/adapters/.

--- a/docs/PRD_OPENCLAW_OBSERVABILITY_GAPS.md
+++ b/docs/PRD_OPENCLAW_OBSERVABILITY_GAPS.md
@@ -1,0 +1,189 @@
+# PRD — Closing ClawMetry's OpenClaw Observability Gaps
+
+> **Status:** Draft for review · **Author:** Claude Code agent · **Date:** 2026-05-25
+> **Source of truth:** [OpenClaw architecture docs](https://docs.openclaw.ai/concepts/architecture) crawled in depth (architecture, agent-loop, queue, gateway/protocol, multi-agent, subagents, memory, skills, tools, compaction, sandbox/tool-policy/elevated, presence) cross-referenced against the current ClawMetry codebase (`routes/`, `clawmetry/sync.py`, `clawmetry/local_store.py`, `frontend/`).
+
+## TL;DR
+
+ClawMetry observes OpenClaw's **outputs** well (sessions, transcripts, tokens, cost, channel messages, crons, health) but is largely blind to OpenClaw's **runtime control plane** — the parts that explain *why* the agent is doing what it's doing and *whether it's healthy right now*. The gateway exposes a protocol-v4 RPC surface of ~150 methods and ~30 event types; we ingest a thin slice. The biggest leverage is in five areas OpenClaw emits rich signals for and we surface ~nothing:
+
+1. **Queue & lane concurrency** — the FIFO lane scheduler (`main`/`subagent`/`cron`/`nested`) that decides what runs and what waits. **Zero observability today.**
+2. **Sub-agent live fan-out** — `sessions_spawn` depth tree, the task ledger (`tasks.*`), artifacts, the announce chain. **Tab is a "Coming soon" stub; task ledger not ingested.**
+3. **Agent-turn lifecycle as a span waterfall** — `lifecycle`/`tool`/`compaction` streams, hook decision points, and the `session.long_running`/`stalled`/`stuck` diagnostics. **Brain feed shows events, not a turn anatomy; diagnostics not tapped.**
+4. **Governance: tool-policy + exec-approval audit** — which tools were filtered and *why*, the `exec.approval.*` lifecycle, sandbox mode per agent, elevation events. **Not modeled (this is our moat vs. offline trace tools).**
+5. **Context economics** — context-window utilization over time, compaction triggers (proactive vs. overflow), tokens reclaimed, pruning. **We list compaction events but not the economics.**
+
+Every proposal below respects the three hard constraints: **DuckDB-first** (daemon ingests → DuckDB → encrypted snapshot → cloud renders client-side), **E2E encryption** (cloud computes nothing on OpenClaw data), and the **per-node cost/perf budget** (share one snapshot fetch, no request storms).
+
+---
+
+## 1. Method
+
+For each OpenClaw subsystem I extracted (a) the exact observable signals OpenClaw emits — RPC methods, event names, stream phases, log lines, diagnostic states — and (b) what ClawMetry surfaces today, verified by grep against `routes/*.py`, `sync.py`, `local_store.py`, and `frontend/`. The gap is the delta. Proposals are scoped to signals OpenClaw *actually exposes* (no speculative instrumentation of OpenClaw internals), reachable via the gateway WS tap (`clawmetry/gateway_tap.py`), JSON-RPC polling, JSONL/log ingest, or OTLP.
+
+---
+
+## 2. Coverage scorecard
+
+| OpenClaw subsystem | Signals OpenClaw exposes | ClawMetry today | Grade |
+|---|---|---|---|
+| Sessions & transcripts | `sessions.*`, `chat.history`, JSONL | Sessions list, transcript, cost-split, compaction list | 🟢 Strong |
+| Token usage & cost | `usage.cost`, `usage.status`, `sessions.usage.*` | Usage tab, cost breakdown, model/skill attribution, anomalies | 🟢 Strong |
+| Channels (messages) | `channels.status`, per-channel JSONL | 21 adapters, messages, delivery-health | 🟢 Strong |
+| Crons | `cron.*` (CLI writes) | Cron CRUD, runs, health | 🟢 Strong |
+| System health | `health`, `status`, OTLP | system-health, reliability, heatmap | 🟢 Strong |
+| **Queue / lane concurrency** | lane scheduler, `/queue` modes, depth, `drop` policy, "waited >2s" | Only static `maxConcurrent` config echo (`components.py:1225`) | 🔴 **Blind** |
+| **Sub-agent fan-out** | `sessions_spawn`, depth 0/1/2, `tasks.*`, `artifacts.*`, announce chain | subagents table + delegation tree; **task ledger not ingested; tab is stub** | 🟠 Partial |
+| **Agent-turn lifecycle** | `lifecycle`(start/end/error), `tool`(start/update/end), hook points, `deliveryStatus` | Brain feed (flat event list), llm-call-timeline | 🟠 Partial |
+| **Stuck/stalled diagnostics** | `session.long_running` / `stalled` / `stuck`, `diagnostics.stability` | ClawMetry's own heuristic alerts only; `diagnostics.stability` **not tapped** | 🔴 **Blind** |
+| **Tool policy & provenance** | `tools.catalog` (provenance), `tools.effective`, `agents/tool-policy` audit logs | Tool call counts + flow lanes; **no provenance, no policy audit** | 🟠 Partial |
+| **Exec approvals / sandbox / elevated** | `exec.approval.*`, `plugin.approval.*`, `sandbox explain`, `/elevated` | approvals table; Nemoclaw approvals stub; sandbox **inferred** | 🟠 Partial |
+| **Context / compaction economics** | `compaction` stream, overflow-error patterns, `Compactions:<n>`, pruning | `/api/compactions` event list only | 🟠 Partial |
+| **Memory subsystem** | `doctor.memory.status`, backends (SQLite/QMD/Honcho/LanceDB), dreaming, index status | memory_blobs + memory-access timeline (as a tool) | 🟠 Partial |
+| **Skills runtime** | `skills.status` eligibility, ClawHub scan state, per-session snapshot, token cost | skill attribution; **tab is stub; no eligibility/why-not-loaded** | 🟠 Partial |
+| **Channel routing / bindings** | binding rules (peer/guildId/teamId/accountId), `deliveryStatus` | message lists per channel; **no routing explainer** | 🟠 Partial |
+| **Nodes / presence topology** | `system-presence` (modes, Active/Idle/Stale), `node.*`, caps, `node.invoke` | heartbeat gauge, fleet nodes | 🟠 Partial |
+| **Config / update / secrets** | `config.*` + `reloadKind`, `update.*`, `secrets.reload` | config snapshot, version/update check | 🟠 Partial |
+| **Talk / TTS / voice** | large `talk.*` surface (realtime/transcription/managed-room/telephony) | — | 🔴 **Blind** |
+| **Payload/transport diagnostics** | `payload.large` events (oversized frames, slow buffers) | — | 🔴 **Blind** |
+
+---
+
+## 3. Cross-cutting foundation (do this first — it unblocks everything)
+
+Most gaps share a root cause: **we only tap a thin slice of the gateway WS protocol and don't persist the control-plane events.** Before building tabs, widen the pipe.
+
+### F1. Subscribe to the full gateway event family in `gateway_tap.py`
+OpenClaw broadcasts these events to any client with `operator.read`: `session.operation`, `session.tool`, `sessions.changed`, `exec.approval.requested|resolved`, `plugin.approval.*`, `cron`, `payload.large`, `node.pair.*`, `device.pair.*`, plus `presence`/`health`/`heartbeat`/`tick`. We currently consume a subset. **Action:** subscribe to the full allowlist, normalize each into a typed DuckDB row (`control_events` table with `kind`, `seq`, `state_version`, `payload_json`, `ts_ms`), and respect per-connection `seq` to detect dropped frames.
+
+### F2. Poll the read-only diagnostic RPCs on the daemon's existing tick
+These need a single `operator.read` call each and are pure gold:
+- `diagnostics.stability` — OpenClaw's own bounded diagnostic recorder.
+- `tasks.list` / `tasks.get` — the **sub-agent/background task ledger** (filter by `status`, `agentId`, `sessionKey`).
+- `tools.catalog` — runtime tool catalog **with provenance** (builtin vs. plugin vs. MCP).
+- `skills.status` — skill inventory with eligibility/config checks.
+- `usage.status` — provider quota windows (rate-limit headroom).
+- `system-presence` — client/node presence with mode + recency.
+
+**Action:** add a `_poll_gateway_diagnostics()` pass (cheap, ~6 RPCs, 30–60s cadence, gated like other pollers) writing to new DuckDB tables. All of it rides the existing snapshot → Redis → client-render path.
+
+### F3. New snapshot keys
+Add top-level snapshot keys so cloud interceptors can light up tabs without server compute: `laneState`, `taskLedger`, `turnSpans`, `toolPolicy`, `execApprovals`, `contextEconomics`, `memoryHealth`, `skillEligibility`, `routingTrace`, `presenceTopology`. Each must be **bounded** (cap rows, strip heavy fields per the snapshot-bloat lesson) and reuse `window.__cmSnap` on the cloud side.
+
+---
+
+## 4. Prioritized initiatives
+
+Each initiative: **Gap → Signals available → Proposed visualization → Data path → Effort → Success metric.**
+
+### 🔴 P0 — "What is OpenClaw doing right now"
+
+#### P0-1. Lane & Queue Monitor *(new tab: "Scheduler")*
+- **Gap:** We show static `maxConcurrent`/`maxSubagents` config but nothing about live scheduling. Users can't see *why a reply is slow* or *that a lane is saturated*.
+- **Signals:** Lane model — `session:<key>` serialized, global lanes `main`(cap 4)/`subagent`(cap 8)/`cron`/`cron-nested`/`nested`; `/queue` modes `steer|followup|collect|interrupt`; `drop` policy `summarize|old|new`; `debounceMs`(500), `cap`(20); verbose "queued run waited >2s" notices; `session.operation` events for in-flight ops.
+- **Visualization:** Live lane-saturation bars (running / cap per lane), a queue-depth-over-time sparkline per lane, a "waiting" list with wait-time-so-far, and a per-session badge showing active `/queue` mode. Highlight backpressure when a lane is at cap with a growing queue.
+- **Data path:** `session.operation` + lane state from `diagnostics.stability` → `lane_state` table → `laneState` snapshot key → client renders.
+- **Effort:** M (ingest + one tab). **Metric:** user can answer "is my agent queue-bound and which lane?" in <5s; backpressure visible before the user notices lag.
+
+#### P0-2. Live Sub-agent Fan-out Tree *(complete the stubbed "Sub agents" tab)*
+- **Gap:** `subagents` table + a delegation tree exist, but the v2 tab is a "Coming soon" stub and **the task ledger (`tasks.*`) and artifacts are not ingested at all.** No live depth, no lane-8-cap saturation, no announce-chain, no orphan/tombstone recovery.
+- **Signals:** `sessions_spawn` → `{runId, childSessionKey}`; session-key depth shape `agent:<id>:main` → `:subagent:<uuid>` → `:subagent:<uuid>:subagent:<uuid>` (max `maxSpawnDepth` 1–5); `maxChildrenPerAgent`(5), subagent lane cap (8); announce status `success|error|timeout|unknown` with runtime + I/O/total tokens + est. cost; `context: isolated|fork`; `tasks.list/get/cancel`; `artifacts.list/get/download`; `archiveAfterMinutes`(60); orphan recovery tombstones; `ANNOUNCE_SKIP`/`NO_REPLY` suppression.
+- **Visualization:** Live tree (depth 0→2) with per-node status pill, runtime, tokens, cost; a "subagent lane: 6/8" saturation header; the announce chain as upward edges; an artifacts drawer per run; a "stuck/orphaned" filter. Cost rolls up to the parent turn.
+- **Data path:** `tasks.*` poll + spawn/announce events → extend `subagents` table + new `task_ledger`/`artifacts_index` tables → `taskLedger` snapshot key.
+- **Effort:** M–L. **Metric:** every active spawn visible within one snapshot cycle with correct depth, status, and cost rollup; verified against `/subagents list`.
+
+#### P0-3. Turn Anatomy waterfall + stuck/stalled detector *(upgrade Brain → "Live trace")*
+- **Gap:** Brain renders a flat event feed. OpenClaw's turn is a structured lifecycle with streams and hook decision points, and it emits explicit stuck/stalled diagnostics we ignore.
+- **Signals:** Streams `lifecycle`(phase start/end/error), `assistant`(deltas), `tool`(start/update/end), `compaction`; hook points `before_model_resolve`, `before_prompt_build`, `before_agent_reply`, `before_tool_call`(can `block:true`), `after_tool_call`, `before/after_compaction`, `tool_result_persist`; diagnostics `session.long_running`/`stalled`/`stuck` (`diagnostics.stuckSessionWarnMs`); reply `deliveryStatus` = `sent|suppressed|partial_failed|failed`; `agent.wait` terminal `{status, startedAt, endedAt}`.
+- **Visualization:** Per-turn waterfall — prompt-assembly → model-resolve (with hook overrides flagged) → model stream → each tool call as a span (start→end, latency, sanitized result size) → compaction (if any) → reply (with `deliveryStatus`). A red marker where a hook **blocked** a tool call (governance signal). A persistent "Stalled/Stuck" strip listing sessions OpenClaw flagged.
+- **Data path:** `lifecycle`/`tool`/`session.tool` events + `diagnostics.stability` → `turn_spans` table → `turnSpans` snapshot key.
+- **Effort:** L. **Metric:** a turn's wall-clock decomposes into visible spans summing to total; stalled sessions surface within `stuckSessionWarnMs`; hook-block events are countable.
+
+### 🟠 P1 — Governance & economics (the moat)
+
+#### P1-1. Tool-policy & Exec-approval audit *(complete "Approvals" + new "Policy" panel)*
+- **Gap:** Approvals exist as a table but the rich lifecycle + the *reason* tools were filtered isn't surfaced. This is exactly the enforcement/governance story that differentiates us from offline trace+eval tools.
+- **Signals:** `exec.approval.requested|resolved`, `plugin.approval.requested|resolved`, `exec.approval.waitDecision`, `systemRunPlan` (canonical argv/cwd/rawCommand); three controls — sandbox (`off|non-main|all`), tool policy (allow/deny, `group:*`, "deny wins", "non-empty allow blocks rest"), elevated (`/elevated on`, `tools.elevated.allowFrom.<provider>`); audit logs `agents/tool-policy` (rule label, config key, affected tool); `sandbox explain` effective mode/scope/source.
+- **Visualization:** Approval timeline (requested → decided, who/scope/latency-to-decision); a "tools filtered this turn and why" panel (rule label + config key, sourced from tool-policy audit); a per-agent sandbox-mode matrix; elevation-event log. Tie each blocked exec to its `systemRunPlan`.
+- **Data path:** approval events + tool-policy audit log lines → extend `approvals` table + new `tool_policy_audit` table → `toolPolicy`/`execApprovals` snapshot keys. Keep cloud route `oss-passthrough`.
+- **Effort:** M. **Metric:** every approval decision and every policy-blocked tool is attributable to a rule + config key; verified against `openclaw logs`.
+
+#### P1-2. Context Economics *(upgrade Context tab)*
+- **Gap:** We list compaction *events* but not the economics that drive cost and quality.
+- **Signals:** auto-compaction proactive (near limit) vs. reactive (overflow patterns: `request_too_large`, `context length exceeded`, `input is too long`, …); `compaction` stream start/complete; `Compactions:<count>`; `maxActiveTranscriptBytes`, `keepRecentTokens`, `identifierPolicy`, `truncateAfterCompaction`; compaction-vs-pruning distinction; memory-flush turn before compaction.
+- **Visualization:** Context-window utilization gauge over the turn timeline (% of model limit), compaction markers tagged proactive/overflow, tokens-before/after (reclaimed), and a pruning-vs-compaction split. Flag sessions that overflow-then-retry repeatedly (a cost/quality smell).
+- **Data path:** compaction stream events + token deltas from `model.completed` → `context_economics` table → snapshot key.
+- **Effort:** M. **Metric:** each compaction is classified proactive/overflow with reclaimed-token delta; repeated-overflow sessions are flagged.
+
+#### P1-3. Tool Catalog & Provenance + per-tool latency
+- **Gap:** We count tool calls but can't answer "where did this tool come from?" or "which tools are even available in this session?" or "what's the p95 latency of `exec`?"
+- **Signals:** `tools.catalog` (provenance: builtin/plugin/MCP, provider-prefixed names like `outlook__send_mail`), `tools.effective` (per-`sessionKey`), tool groups (`group:runtime|fs|web|memory|sessions|automation|plugins`), deferred/dynamic tools (Codex), `tool` stream start→end timing.
+- **Visualization:** A tool catalog grouped by provenance with enabled/filtered state per session; per-tool latency p50/p95 and error rate; "effective tools for this session" inspector.
+- **Data path:** `tools.catalog`/`tools.effective` poll + tool-stream timing → `tool_catalog` + `tool_latency` tables → snapshot key.
+- **Effort:** M. **Metric:** every tool the agent calls maps to a provenance source; p95 latency available per tool.
+
+### 🟡 P2 — Depth & coverage
+
+#### P2-1. Memory subsystem health *(complete "Memory" tab)*
+- **Signals:** `doctor.memory.status` (embedding/vector readiness, `probe`/`deep`), `doctor.memory.remHarness`; backends builtin-SQLite/QMD/Honcho/LanceDB; hybrid search (vector + keyword); `memory_search`/`memory_get` (we already track as tools); dreaming (cron consolidation, `DREAMS.md`, score/recall/diversity gates); index status (`openclaw memory status/index`); `MEMORY.md` truncation when over bootstrap budget; memory-flush before compaction.
+- **Visualization:** Embedding-provider readiness badge, backend identity, search hit/miss + retrieval latency, dreaming activity (items promoted), index freshness, and a **truncation warning** when `MEMORY.md` exceeds budget.
+- **Data path:** `doctor.memory.status` poll + memory-tool timing → `memory_health` table → snapshot key. **Effort:** M.
+
+#### P2-2. Skill eligibility & cost *(complete "Skills" tab)*
+- **Signals:** `skills.status` (eligibility/config checks); gates `requires.bins|anyBins|env|config`, `os`, `always`; precedence (workspace > project-agent > personal > managed > bundled > extraDirs); per-agent allowlist (non-empty list is final); per-session skill snapshot + watcher refresh; token cost (~24 tokens/skill, 195-char base + 97/skill); ClawHub security scan state (VirusTotal/ClawScan); install/update tracking.
+- **Visualization:** Per-session loaded-skills list with **"why not loaded"** (failed gate: missing bin/env/config/os); skill token-cost contribution to the system prompt; ClawHub scan state per installed skill.
+- **Data path:** `skills.status` poll → `skill_eligibility` table → snapshot key. **Effort:** M.
+
+#### P2-3. Channel routing / binding explainer + delivery status
+- **Signals:** binding rules in priority order (peer → parentPeer → guildId+roles → guildId → teamId → accountId → channel `*` → default agent), AND semantics, multi-account `accountId`/`defaultAccount`; `agent` `deliveryStatus` = `sent|suppressed|partial_failed|failed`.
+- **Visualization:** Per inbound message, "routed to agent X because binding rule Y matched"; a multi-account map; delivery-status breakdown per channel.
+- **Data path:** message metadata + routing events → extend `channel_messages` → `routingTrace` snapshot key. **Effort:** M.
+
+#### P2-4. Node topology & presence
+- **Signals:** `system-presence` (modes ui/webchat/cli/backend/probe/test/node; Active/Idle/Stale; 5-min TTL; `lastInputSeconds`); `node.list/describe`, caps (camera/canvas/screen/location/voice/talk), `commands`, `node.invoke`/`node.invoke.result`, `node.presence.alive` triggers (background/silent_push/significant_location/bg_app_refresh/manual/connect).
+- **Visualization:** Node/operator topology with capability chips, Active/Idle/Stale state, last-input recency, and a `node.invoke` activity log. Extends the existing fleet view from "list" to "topology + capabilities."
+- **Data path:** `system-presence` + `node.*` poll/events → `presence_topology` table → snapshot key. **Effort:** M.
+
+#### P2-5. Config-change audit trail
+- **Signals:** `config.set/patch/apply`, `config.schema.lookup` `reloadKind` (`restart|hot|none`), `update.run/status`, `secrets.reload`. **Visualization:** timeline of config changes with hot-vs-restart classification and config-hash diffs; update-restart events. **Data path:** `config.get` hash polling + config events → `config_audit` table. **Effort:** S–M.
+
+#### P2-6 (stretch). Voice/Talk observability
+- The `talk.*` surface (realtime/transcription/STT-TTS/managed-room/telephony/meeting) is entirely unobserved. Lower priority unless a node user runs voice. Track turn lifecycle, barge-in, TTS provider/fallback, tool-results-in-voice. **Effort:** L. **Note:** revisit only if usage data shows voice adoption.
+
+---
+
+## 5. Sequencing
+
+```
+Phase 0 (foundation):  F1 widen WS tap  →  F2 diagnostic RPC poll  →  F3 snapshot keys
+Phase 1 (ship the "now"):  P0-1 Scheduler  ·  P0-2 Sub-agent tree  ·  P0-3 Turn anatomy
+Phase 2 (moat):  P1-1 Policy/Approvals audit  ·  P1-2 Context economics  ·  P1-3 Tool provenance
+Phase 3 (depth):  P2-1 Memory  ·  P2-2 Skills  ·  P2-3 Routing  ·  P2-4 Topology  ·  P2-5 Config
+Phase 4 (stretch):  P2-6 Voice
+```
+
+Phase 0 is the unlock — once the daemon taps the full event family + diagnostic RPCs and writes typed DuckDB tables, each tab is mostly a snapshot key + a `cm-cloud-*` interceptor mirroring `cm-cloud-models`.
+
+---
+
+## 6. Constraints & risks (carry into every PR)
+
+- **DuckDB-first.** No handler reads `~/.openclaw`/JSONL/process stats directly — daemon ingests → DuckDB → snapshot. Build on the daemon's own writer handle, never a `read_only=True` re-open (the #1771 brick-lock).
+- **E2E encryption.** Cloud computes nothing on OpenClaw data; all new tabs render client-side from the decrypted snapshot via `window.__cmSnap`. New routes default to `oss-passthrough` (never a 410 the OSS JS calls).
+- **Cost/perf budget.** New diagnostic polls share one cadence and one snapshot fetch — no per-tab pollers, no per-interceptor snapshot fetches. Gate heavy polls on the active tab. Bound every new snapshot key and strip heavy fields (the snapshot-bloat lesson).
+- **Read-only.** ClawMetry observes; it must not change scheduling, approvals, or policy (cron writes via the CLI remain the sole exception). Approval/policy tabs are *views*, not controls — unless we deliberately add the relay-backed write path later, gated behind `operator.approvals`.
+- **Gateway token scope.** Our token is `operator.read`. Every RPC in F2 (`diagnostics.stability`, `tasks.list`, `tools.catalog`, `skills.status`, `usage.status`, `system-presence`) is read-scoped — confirmed against the protocol scope table. Anything needing `operator.admin`/`approvals` is out of scope for observation.
+- **Verify against live data, not fixtures.** OpenClaw v3 normalizes event types; smoke every ingest against live DuckDB + decrypt the cloud snapshot before claiming done.
+
+---
+
+## 7. Open questions
+
+1. **Tap vs. poll for the control plane** — does subscribing to the full WS event family (F1) give us enough, or do we still need the periodic diagnostic RPCs (F2)? Likely both: events for real-time, RPCs for snapshot/state. Validate WS volume against the cost budget first.
+2. **One "Scheduler"/"Control plane" tab vs. enriching existing tabs?** Lane+queue is genuinely new (P0-1 new tab); sub-agent/turn/context map onto existing surfaces. Lean toward enriching where a home exists.
+3. **How much of the v2 React rebuild do we target?** Several proposals (Sub-agents, Approvals, Skills, Fleet sonar) are already stubbed-out nav entries in `frontend/` — confirm whether v2 ships before building these, or whether to land them in the live v1 template/static frontend first.
+4. **Voice (P2-6) — is there any real-world usage to justify it?** Defer until node telemetry shows voice/talk sessions in the wild.
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -416,6 +416,11 @@ _DAEMON_METHODS = frozenset({
     # ``routes/crons.py:_cron_runs_from_duckdb`` via the daemon proxy.
     "query_cron_runs",
     "query_subagents",
+    # OpenClaw run ledger (tasks/runs.sqlite mirror): sub-agents + crons +
+    # CLI turns with status/timing/parent-child. Powers the Scheduler lane
+    # monitor + sub-agent fan-out tree + cron run log off one source.
+    "query_run_ledger",
+    "query_run_ledger_lanes",
     # Issue #1597: parent session tool-timeline rollup needs to merge in
     # events from every child sub-agent session (the events table has no
     # parent_session_id column; the link lives on the subagents table). The

--- a/routes/scheduler.py
+++ b/routes/scheduler.py
@@ -1,0 +1,143 @@
+"""routes/scheduler.py — OpenClaw run-ledger + queue-lane endpoints.
+
+OpenClaw 2026.5.x records every background run — sub-agents
+(``runtime='subagent'``), cron jobs (``runtime='cron'``) and inline
+CLI/agent turns (``runtime='cli'``) — in a unified SQLite ledger at
+``~/.openclaw/tasks/runs.sqlite``. The sync daemon mirrors it into the
+DuckDB ``run_ledger`` table (``clawmetry/sync.py:sync_run_ledger``).
+
+This module exposes that ledger so three observability surfaces share
+one source of truth:
+
+  GET /api/run-ledger          — lanes rollup + recent runs (Scheduler tab)
+  GET /api/run-ledger/tree     — sub-agent fan-out tree (parent -> children)
+
+``runtime`` IS the OpenClaw queue lane, so the lanes rollup is the live
+queue/concurrency monitor (P0-1) and the sub-agent slice is the fan-out
+tree (P0-2). Reads go through the daemon proxy (the daemon owns the
+DuckDB writer lock) with a single-process direct-read fallback — the
+same pattern as ``routes/agents.py``.
+"""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+bp_scheduler = Blueprint("scheduler", __name__)
+
+
+def _ls_call(method_name: str, **kwargs):
+    """Cross-process LocalStore call with single-process fallback (issue #1088)."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+def _coerce_runs(rows) -> list[dict]:
+    """``local_store_via_daemon`` returns the raw method result (a list) or a
+    ``{"result": [...]}`` envelope depending on transport — normalise both."""
+    if isinstance(rows, dict):
+        rows = rows.get("result") or rows.get("rows") or []
+    return rows if isinstance(rows, list) else []
+
+
+@bp_scheduler.route("/api/run-ledger")
+def api_run_ledger():
+    """Lane rollup + recent runs.
+
+    Query params: ``runtime`` (lane filter), ``status``, ``limit`` (<=1000).
+    Returns ``{lanes, runs, _source}``. Never 500s — an empty ledger (fresh
+    sync, OpenClaw < 2026.5, or daemon mid-restart) returns empty lists so
+    the tab renders an honest "no background runs yet" state.
+    """
+    try:
+        limit = max(1, min(1000, int(request.args.get("limit", 200))))
+    except (TypeError, ValueError):
+        limit = 200
+    runtime = (request.args.get("runtime") or "").strip() or None
+    status = (request.args.get("status") or "").strip() or None
+
+    lanes = _coerce_runs(_ls_call("query_run_ledger_lanes"))
+    runs = _coerce_runs(
+        _ls_call("query_run_ledger", runtime=runtime, status=status, limit=limit)
+    )
+    return jsonify({
+        "lanes": lanes,
+        "runs": runs,
+        "_source": "local_store",
+    })
+
+
+@bp_scheduler.route("/api/run-ledger/tree")
+def api_run_ledger_tree():
+    """Sub-agent fan-out tree.
+
+    Groups ``runtime='subagent'`` runs under the session that requested them
+    (``requester_session_key``), with explicit ``parent_task_id`` edges where
+    OpenClaw set them (nested orchestrators). Each node carries status +
+    timing so the UI can render depth, lane saturation and per-run outcome.
+    """
+    try:
+        limit = max(1, min(1000, int(request.args.get("limit", 300))))
+    except (TypeError, ValueError):
+        limit = 300
+
+    subs = _coerce_runs(_ls_call("query_run_ledger", runtime="subagent", limit=limit))
+
+    # Group by requesting session; nest explicit parent_task_id children.
+    by_parent_task: dict[str, list] = {}
+    roots_by_session: dict[str, list] = {}
+    for r in subs:
+        node = {
+            "task_id": r.get("task_id"),
+            "run_id": r.get("run_id"),
+            "label": r.get("label") or (str(r.get("task") or "")[:60]),
+            "task": str(r.get("task") or "")[:200],
+            "status": r.get("status"),
+            "delivery_status": r.get("delivery_status"),
+            "terminal_outcome": r.get("terminal_outcome"),
+            "child_session_key": r.get("child_session_key"),
+            "agent_id": r.get("agent_id"),
+            "created_at": r.get("created_at"),
+            "started_at": r.get("started_at"),
+            "ended_at": r.get("ended_at"),
+            "error": r.get("error"),
+            "children": [],
+        }
+        pt = r.get("parent_task_id")
+        if pt:
+            by_parent_task.setdefault(str(pt), []).append(node)
+        else:
+            sess = r.get("requester_session_key") or "unknown"
+            roots_by_session.setdefault(str(sess), []).append(node)
+
+    # Attach explicit nested children to their parent node where present.
+    def _attach(nodes: list):
+        for n in nodes:
+            kids = by_parent_task.get(str(n["task_id"]))
+            if kids:
+                n["children"] = kids
+                _attach(kids)
+
+    for nodes in roots_by_session.values():
+        _attach(nodes)
+
+    tree = [
+        {"session_key": sess, "runs": nodes}
+        for sess, nodes in roots_by_session.items()
+    ]
+    # Newest session group first.
+    tree.sort(
+        key=lambda g: max((n.get("created_at") or 0) for n in g["runs"]),
+        reverse=True,
+    )
+    return jsonify({"tree": tree, "count": len(subs), "_source": "local_store"})


### PR DESCRIPTION
## What

OpenClaw **2026.5.x** moved background-run bookkeeping out of the old `~/.openclaw/subagents/runs.json` (now empty) into a **unified SQLite run ledger** at `~/.openclaw/tasks/runs.sqlite`. ClawMetry still read the dead file, so the **sub-agent** surface went **stale** (live `subagents` table = status `stale`, bogus multi-day runtimes) and the OpenClaw **queue/lane scheduler** was never observed.

This mirrors that ledger into DuckDB as the shared foundation for three PRD surfaces (`docs/PRD_OPENCLAW_OBSERVABILITY_GAPS.md`): **Scheduler/lane monitor (P0-1)**, **sub-agent fan-out tree (P0-2)**, cron run log. `runtime` *is* the OpenClaw queue lane (`cli`/`cron`/`subagent`).

## Why on-disk, not the gateway RPCs the PRD assumed

The PRD's Phase-0 assumed polling `diagnostics.stability`/`tasks.list`/`tools.catalog` over the gateway WS. **Verified live: the gateway token grants ZERO scopes on a stock install** — every `operator.read` RPC is rejected. So the WS-RPC path is blocked for most users. Reading the SQLite **read-only** needs no scope and stays DuckDB-first. (Future scoped surfaces will shell the `openclaw` CLI on OpenClaw's own creds — the proven Self-Evolve pattern.)

## Changes

- **`local_store`**: `run_ledger` table (additive `CREATE … IF NOT EXISTS`, no version bump), `ingest_run_ledger_row` (capped upsert), `query_run_ledger`, `query_run_ledger_lanes` (per-lane running/queued/succeeded/failed rollup).
- **`sync`**: `sync_run_ledger` — read-only URI open of `tasks/runs.sqlite`, `last_event_at` watermark (incremental + idempotent, catches status transitions), wired into both daemon-loop sites; bounded **`runLedger` snapshot key** (lanes + last 120 runs, free-text trimmed per the snapshot-bloat lesson).
- **`routes/local_query`**: both query methods added to the daemon-proxy allowlist.
- **`routes/scheduler`** (new): `GET /api/run-ledger` (lanes + runs) and `GET /api/run-ledger/tree` (sub-agent fan-out grouped by requester session, explicit `parent_task_id` edges). Mirrors the `agents.py` proxy + direct-fallback pattern; never 500s on an empty ledger.
- **docs**: the PRD this implements.

## Verification

E2E against **147 live run-ledger rows**, read-only on the source — the production DuckDB writer was never touched (**zero corruption risk**, relevant given two index corruptions today from `kickstart -k` mid-write):

- Lanes: `cli` 85 · `cron` 52✓ / 2✗ / 1 running · `subagent` 8
- 8 sub-agent runs with correct `child_session_key` tree linkage (`agent:main:subagent:<uuid>`), grouped into 2 session groups
- Watermark incremental re-read (re-run ingests only advanced rows)
- Both routes `200` with correct shape via a Flask test client backed by the temp store

UI (v1 + v2 tabs + `cm-cloud-scheduler` interceptor) lands in the follow-up PR consuming these endpoints + the `runLedger` snapshot key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)