### PR TITLE
fix(cost): price family-runtime events (Tracing/Cost showed $0 on heavy Opus)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -3630,6 +3630,17 @@ class LocalStore:
             msg = obj.get("message") if isinstance(obj.get("message"), dict) else None
             src = msg or obj
             u = src.get("usage") if isinstance(src.get("usage"), dict) else {}
+            # Family-runtime events (claude_code/cursor/…, ingested by
+            # sync_family_runtimes) carry the token split under
+            # ``data.extra.{inputTokens,outputTokens}`` rather than
+            # ``data.usage``. Without this fallback their cost stayed $0 even
+            # for heavy Opus sessions (the Tracing + Cost tabs showed $0 on
+            # hundreds of thousands of tokens). _tok() already accepts the
+            # camelCase keys, so the same estimate path then prices them.
+            if not u:
+                ex = obj.get("extra") if isinstance(obj.get("extra"), dict) else {}
+                if ex.get("inputTokens") is not None or ex.get("outputTokens") is not None:
+                    u = ex
             if not u:
                 continue
             cost = estimate_event_cost_usd(

--- a/tests/test_backfill_family_cost.py
+++ b/tests/test_backfill_family_cost.py
@@ -1,0 +1,88 @@
+"""backfill_event_costs must price family-runtime events.
+
+Family runtimes (claude_code, cursor, …) are ingested by sync_family_runtimes
+with cost_usd=None and the token split under ``data.extra.{inputTokens,
+outputTokens}`` (not ``data.usage``). The #2049 backfill only read
+``data.usage``, so these events stayed $0 — a heavy Opus session showed $0
+in the Tracing + Cost tabs. The fix adds ``data.extra`` as a fallback usage
+source; the existing _tok() already accepts the camelCase keys.
+"""
+from __future__ import annotations
+
+import importlib
+import time
+
+
+def _wait_flush(store, t=3.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "ev.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "2")
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)  # in-process writer
+    return ls, ls.get_store()
+
+
+def _cost(store, eid):
+    rows = store._fetch("SELECT cost_usd FROM events WHERE id = ?", [eid])
+    return rows[0][0] if rows else None
+
+
+def test_backfill_prices_family_event_via_extra(tmp_path, monkeypatch):
+    ls, store = _store(tmp_path, monkeypatch)
+    try:
+        store.ingest({
+            "id": "claude_code:ev-1",
+            "node_id": "n", "agent_id": "main",
+            "session_id": "claude_code:sess-1",
+            "event_type": "message",
+            "ts": "2026-05-25T12:00:00Z",
+            # family shape: split under data.extra (camelCase), no data.usage
+            "data": {"role": "assistant", "_runtime": "claude_code",
+                     "extra": {"inputTokens": 100000, "outputTokens": 20000}},
+            "cost_usd": None,
+            "token_count": 120000,
+            "model": "claude-opus-4-7",
+        })
+        _wait_flush(store)
+        assert (_cost(store, "claude_code:ev-1") or 0) == 0, "starts uncosted"
+
+        n = store.backfill_event_costs(batch=100)
+        assert n >= 1, "backfill must price the family event"
+        c = _cost(store, "claude_code:ev-1")
+        assert c and c > 0, f"family event must be priced, got {c}"
+        # sanity: 100k in + 20k out Opus is a few dollars, not cents and not absurd
+        assert 0.5 < c < 50, f"cost out of sane range: {c}"
+    finally:
+        store.stop(flush=True)
+
+
+def test_backfill_skips_event_with_no_token_split(tmp_path, monkeypatch):
+    """No usage and no extra split -> left uncosted (honest, not a crash)."""
+    ls, store = _store(tmp_path, monkeypatch)
+    try:
+        store.ingest({
+            "id": "cursor:ev-1",
+            "node_id": "n", "agent_id": "main",
+            "session_id": "cursor:sess-1",
+            "event_type": "message",
+            "ts": "2026-05-25T12:00:00Z",
+            "data": {"role": "assistant", "_runtime": "cursor"},  # no split anywhere
+            "cost_usd": None,
+            "token_count": 5000,
+            "model": "claude-opus-4-7",
+        })
+        _wait_flush(store)
+        store.backfill_event_costs(batch=100)
+        assert (_cost(store, "cursor:ev-1") or 0) == 0, "no split -> stays uncosted"
+    finally:
+        store.stop(flush=True)


### PR DESCRIPTION
## Symptom
The **Tracing tab** showed `$0.00` cost on claude_code sessions with hundreds of thousands of Opus tokens (e.g. a 492K-token trace at $0.00). Same on **/api/usage** (today/week/month all $0). Reported via "is the tracing tab accurate?"

## Root cause (systemic, not tracing-specific)
The #2049 cost backfill (`local_store.backfill_event_costs`) estimates `cost_usd` for events that arrived without it — but it only read the token split from `data.usage` / `data.message.usage`. **Family-runtime events (claude_code, cursor, …, ingested by `sync_family_runtimes`) carry the split under `data.extra.{inputTokens,outputTokens}`**, so `if not u: continue` skipped them and their cost stayed $0 everywhere (tracing, usage, sessions). The span tree itself is healthy (no staircase) and span counts are consistent — the tab was faithfully showing bad upstream cost data.

## Fix
Fall back to `data.extra` as the usage source when `data.usage` is absent. `_tok()` already accepts the camelCase `inputTokens`/`outputTokens` keys, so the existing estimate path then prices them. It's a backfill (`UPDATE`), so it corrects **existing** events on the daemon's next startup pass.

## Verified live on a real node (claude_code sessions)
- `/api/traces`: **5/5 traces** went `$0.00` → `$0.05–$33.33` (308K-tok session = **$19.30**, 492K-tok = **$33.33**).
- `/api/usage`: today `$0.00` → **$501.58**, month **$1352.97**.

## Tests
`tests/test_backfill_family_cost.py` — family event priced via the `extra` fallback (sane range), and the honest no-split case (Cursor records no split → stays uncosted, not guessed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)