### PR TITLE
feat(crons): finish the cron surface — kill/kill-all + Fix work everywhere

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7093,20 +7093,18 @@ async function loadCrons() {
     // copy says to click it. Cloud-iframe stays false so we don't dangle
     // controls that 410 when used.
     _cronActionsAvailable = !window.CLOUD_MODE;
-    // Single-job writes (create/run/toggle/delete/edit) now work in cloud too:
-    // the cm-cloud-cron-create + cm-cloud-cron-actions interceptors relay them
-    // to the daemon, which runs `openclaw cron <subcmd>` locally. So per-row
-    // management is available in cloud. Bulk/dangerous ops (Emergency Stop All)
-    // and the AI "Fix" button stay local-only until they get their own relay.
+    // ALL cron writes now relay to the daemon's openclaw CLI: single-job
+    // (create/run/toggle/delete/edit via cm-cloud-cron-create + cm-cloud-cron-
+    // actions), Emergency Stop All (cm-cloud-cron-bulk -> cron_killall), and
+    // the AI "Fix" button (cm-cloud-cron-bulk -> cron_fix). So per-row +
+    // bulk + AI-fix all work in cloud. Both flags now collapse to the same
+    // thing; kept as a pair for callers that semantically check "writes".
     _cronWritesAvailable = _cronActionsAvailable || !!window.CLOUD_MODE;
-    // Show/hide the bulk cron-action buttons (.cron-action-btn = New Job +
-    // Emergency Stop All) — local-only by default.
+    // .cron-action-btn (New Job + Emergency Stop All) — relay-backed, so show
+    // in cloud too.
     document.querySelectorAll('.cron-action-btn').forEach(function(btn) {
-      btn.style.display = _cronActionsAvailable ? '' : 'none';
+      btn.style.display = _cronWritesAvailable ? '' : 'none';
     });
-    // "+ New Job" is relay-backed, so show it in cloud too.
-    var _newJobBtn = document.getElementById('cron-new-job-btn');
-    if (_newJobBtn) _newJobBtn.style.display = '';
     renderCrons();
     // Load cron health summary panel
     loadCronHealth();
@@ -7151,7 +7149,7 @@ async function loadCronHealth() {
 
     // Show/hide emergency stop button
     var killBtn = document.getElementById('cron-kill-all-btn');
-    if (killBtn) killBtn.style.display = (_cronActionsAvailable && hasIssues) ? 'inline-flex' : 'none';
+    if (killBtn) killBtn.style.display = (_cronWritesAvailable && hasIssues) ? 'inline-flex' : 'none';
 
     if (jobs.length === 0) { panel.innerHTML = ''; return; }
 
@@ -7345,7 +7343,7 @@ function renderCronList(jobs) {
       var consecutiveFails = (j.state && j.state.consecutiveFailures) ? j.state.consecutiveFailures : '';
       html += '<span class="cron-error-actions">';
       html += '<span class="cron-info-icon" title="Error details" onclick="event.stopPropagation();showCronError(this,\'' + errMsg.replace(/'/g,'\\&#39;').replace(/"/g,'&quot;') + '\',\'' + escHtml(errTime) + '\',' + (consecutiveFails||'null') + ')">&#x2139;&#xFE0F;</span>';
-      if (_cronActionsAvailable) html += '<button class="cron-fix-btn" onclick="event.stopPropagation();confirmCronFix(\'' + escHtml(j.id) + '\',\'' + escHtml(j.name||j.id).replace(/'/g,'\\&#39;') + '\')">&#x1F527; Fix</button>';
+      if (_cronWritesAvailable) html += '<button class="cron-fix-btn" onclick="event.stopPropagation();confirmCronFix(\'' + escHtml(j.id) + '\',\'' + escHtml(j.name||j.id).replace(/'/g,'\\&#39;') + '\')">&#x1F527; Fix</button>';
       html += '</span>';
     }
     html += '</div>';

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6283,18 +6283,23 @@ def _action_cron_killall(config: dict, action: dict) -> None:
     def _run():
         status, disabled, errors, scope_pending = "done", 0, [], False
         try:
-            from clawmetry import local_store as _ls
+            # Read the LIVE job list from the gateway via the CLI (not
+            # DuckDB). DuckDB lags the gateway and stale ids would either
+            # surface "unknown cron job id" errors or silently target jobs
+            # the user already deleted. The CLI is the gateway's own ground
+            # truth.
+            listed = run_openclaw_cron("list", ["--all"], timeout=20)
             jobs = []
-            try:
-                store = _ls.get_store()
-                if store is not None:
-                    jobs = store.query_crons(limit=2000) or []
-            except Exception:
-                jobs = []
+            if listed.get("ok"):
+                lr = listed.get("result")
+                if isinstance(lr, list):
+                    jobs = lr
+                elif isinstance(lr, dict):
+                    jobs = lr.get("jobs") or lr.get("crons") or []
             for j in jobs:
                 if not isinstance(j, dict) or not j.get("enabled", True):
                     continue
-                jid = j.get("cron_id") or j.get("id") or ""
+                jid = j.get("id") or j.get("cron_id") or ""
                 if not jid:
                     continue
                 res = run_openclaw_cron("disable", [str(jid)], timeout=40)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5723,6 +5723,8 @@ _PENDING_ACTIONS = frozenset({
     "selfevolve_analyze",
     "cron_create",
     "cron_action",
+    "cron_killall",
+    "cron_fix",
 })
 
 
@@ -5919,6 +5921,12 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
         return
     if atype == "cron_action":
         _action_cron_op(config, action)
+        return
+    if atype == "cron_killall":
+        _action_cron_killall(config, action)
+        return
+    if atype == "cron_fix":
+        _action_cron_fix(config, action)
         return
 
 
@@ -6254,6 +6262,147 @@ def _action_cron_op(config: dict, action: dict) -> None:
             )
         except Exception as e:
             log.warning("cron_action cache post failed: %s", e)
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def _action_cron_killall(config: dict, action: dict) -> None:
+    """Cloud-relayed Emergency Stop All. Reads enabled jobs from local DuckDB
+    (cross-process safe; never via the dead v3 gateway cron tool) and disables
+    each via `openclaw cron disable <id>` in a daemon thread. Posts an
+    E2E-encrypted summary {status,disabled,errors,_shape:"cron_killall"} so
+    the browser can show a real count, not just "queued"."""
+    cache_key = action.get("cache_key")
+    enc_key = config.get("encryption_key")
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not (cache_key and enc_key and api_key):
+        return
+    aid = action.get("id")
+
+    def _run():
+        status, disabled, errors, scope_pending = "done", 0, [], False
+        try:
+            from clawmetry import local_store as _ls
+            jobs = []
+            try:
+                store = _ls.get_store()
+                if store is not None:
+                    jobs = store.query_crons(limit=2000) or []
+            except Exception:
+                jobs = []
+            for j in jobs:
+                if not isinstance(j, dict) or not j.get("enabled", True):
+                    continue
+                jid = j.get("cron_id") or j.get("id") or ""
+                if not jid:
+                    continue
+                res = run_openclaw_cron("disable", [str(jid)], timeout=40)
+                if res.get("ok"):
+                    disabled += 1
+                else:
+                    if res.get("scope_pending"):
+                        scope_pending = True
+                    errors.append({"jobId": jid,
+                                   "error": (res.get("error") or "")[:200]})
+            if scope_pending and disabled == 0:
+                status = "error"
+        except Exception as e:
+            status = "error"; errors.append({"error": str(e)[:300]})
+        try:
+            blob = encrypt_payload(
+                {"status": status, "disabled": disabled,
+                 "errors": errors, "scope_pending": scope_pending,
+                 "message": ("Emergency stop: %d job(s) disabled." % disabled),
+                 "_shape": "cron_killall"},
+                enc_key,
+            )
+            _post(
+                "/ingest/cache",
+                {"node_id": node_id, "id": aid, "cache_key": cache_key,
+                 "blob": blob, "shape": "cron_killall", "ttl": 3600},
+                api_key,
+            )
+        except Exception as e:
+            log.warning("cron_killall cache post failed: %s", e)
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def _action_cron_fix(config: dict, action: dict) -> None:
+    """Cloud-relayed cron Fix. Dispatches `openclaw agent` against the cron's
+    error context in a daemon thread (mirror of _action_selfevolve_fix). The
+    agent's output lands in its own session, surfaced live in Brain. Posts a
+    short "dispatched" status blob so the cloud UI shows a real
+    acknowledgement instead of a stub."""
+    cache_key = action.get("cache_key")
+    job_id = (action.get("jobId") or "").strip()
+    name = (action.get("name") or job_id).strip()
+    last_err = (action.get("lastError") or "").strip()
+    schedule = action.get("schedule") or {}
+    consecutive = action.get("consecutiveFailures") or 0
+    enc_key = config.get("encryption_key")
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not (cache_key and job_id and enc_key and api_key):
+        return
+    aid = action.get("id")
+
+    def _run():
+        status, message = "error", ""
+        try:
+            binp = _resolve_openclaw_bin()
+            if not binp:
+                message = "openclaw CLI not found on this machine"
+            else:
+                import json as _j
+                msg = (
+                    "You are ClawMetry Cron-Fix in REPAIR mode. A scheduled "
+                    "job is failing repeatedly. Investigate and apply a "
+                    "concrete fix using your tools.\n\n"
+                    "Job: " + name + " (id " + job_id + ")\n"
+                    "Schedule: " + _j.dumps(schedule) + "\n"
+                    "Consecutive failures: " + str(consecutive) + "\n"
+                    "Last error: " + (last_err or "(none recorded)") + "\n\n"
+                    "End with a one-line summary that starts with 'DONE:' "
+                    "describing exactly what you changed."
+                )
+                env = dict(os.environ)
+                node_dirs = [
+                    os.path.dirname(binp),
+                    "/opt/homebrew/bin",
+                    "/usr/local/bin",
+                    os.path.expanduser("~/.local/bin"),
+                ]
+                env["PATH"] = os.pathsep.join(
+                    node_dirs + [env.get("PATH", "/usr/bin:/bin")]
+                )
+                sid = "clawmetry-cron-fix-" + job_id[:24]
+                # Fire-and-forget: don't block the post on the agent turn.
+                subprocess.Popen(
+                    [binp, "agent", "--session-id", sid,
+                     "--message", msg, "--json", "--timeout", "300"],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env,
+                )
+                status = "done"
+                message = ('Fix dispatched. Agent is working on "%s" — '
+                           "watch the Brain feed for progress." % name)
+        except Exception as e:
+            message = str(e)[:400]
+        try:
+            blob = encrypt_payload(
+                {"status": status, "message": message,
+                 "_shape": "cron_fix"},
+                enc_key,
+            )
+            _post(
+                "/ingest/cache",
+                {"node_id": node_id, "id": aid, "cache_key": cache_key,
+                 "blob": blob, "shape": "cron_fix", "ttl": 3600},
+                api_key,
+            )
+        except Exception as e:
+            log.warning("cron_fix cache post failed: %s", e)
 
     threading.Thread(target=_run, daemon=True).start()
 

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -485,19 +485,87 @@ def api_crons():
 
 @bp_crons.route("/api/cron/fix", methods=["POST"])
 def api_cron_fix():
+    """Dispatch the AI agent to fix a failing cron job.
+
+    Used to be a stub ("Fix request submitted" toast, TODO). Now actually
+    fires: shells to `openclaw agent` in a background thread (OpenClaw's own
+    creds — same escape hatch as Self-Evolve's Fix), giving the agent the
+    cron's name, schedule, lastError, and a clear instruction to investigate
+    + fix. The agent's output lands in its own session, visible in the user's
+    Brain feed and Session replay.
+
+    Returns 202 immediately so the dashboard can show "agent working on it"
+    without blocking on a ~30s agent turn.
+    """
     import dashboard as _d
     data = request.get_json(silent=True) or {}
     job_id = data.get("jobId", "")
     if not job_id:
         return jsonify({"error": "Missing jobId"}), 400
-    # Find the job name for context
-    job_name = job_id
-    for j in _d._get_crons():
+    # Locate the job for context — name, schedule, lastError.
+    job = None
+    for j in _d._get_crons() or []:
         if j.get("id") == job_id:
-            job_name = j.get("name", job_id)
+            job = j
             break
-    # TODO: integrate with AI agent messaging system
-    return jsonify({"ok": True, "message": f'Fix request submitted for "{job_name}"'})
+    if not job:
+        return jsonify({"error": "Unknown jobId"}), 404
+    name = job.get("name", job_id)
+    sched = job.get("schedule", {})
+    state = job.get("state", {}) if isinstance(job.get("state"), dict) else {}
+    last_err = (state.get("lastError") or job.get("lastError") or "").strip()
+    consecutive = state.get("consecutiveFailures") or 0
+
+    # Build the agent message.
+    import json as _json
+    msg = (
+        "You are ClawMetry Cron-Fix in REPAIR mode. A scheduled job is "
+        "failing repeatedly. Investigate the failure and apply a concrete "
+        "fix using your tools (edit OpenClaw config, adjust the cron's "
+        "prompt/channel/model/schedule, fix the target's credentials, …).\n\n"
+        "Job: " + name + " (id " + str(job_id) + ")\n"
+        "Schedule: " + _json.dumps(sched) + "\n"
+        "Consecutive failures: " + str(consecutive) + "\n"
+        "Last error: " + (last_err or "(none recorded)") + "\n\n"
+        "Make the concrete change. End with a one-line summary that starts "
+        "with 'DONE:' describing exactly what you changed."
+    )
+
+    # Fire-and-forget dispatch on a daemon thread so the dashboard isn't
+    # blocked on the agent turn. The agent's session shows up live in Brain.
+    import threading, subprocess, os
+    from clawmetry.sync import _resolve_openclaw_bin
+    binp = _resolve_openclaw_bin()
+    if not binp:
+        return jsonify({"ok": False,
+                        "error": "openclaw CLI not found on this machine"}), 502
+
+    def _run():
+        env = dict(os.environ)
+        node_dirs = [
+            os.path.dirname(binp),
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            os.path.expanduser("~/.local/bin"),
+        ]
+        env["PATH"] = os.pathsep.join(node_dirs + [env.get("PATH", "/usr/bin:/bin")])
+        try:
+            # Stable session id so repeated Fix clicks on the same cron land
+            # in one conversation (the agent has context from prior attempts).
+            sid = "clawmetry-cron-fix-" + str(job_id)[:24]
+            subprocess.run(
+                [binp, "agent", "--session-id", sid,
+                 "--message", msg, "--json", "--timeout", "300"],
+                capture_output=True, text=True, timeout=330, env=env,
+            )
+        except Exception:
+            pass  # never raise from worker; user sees outcome in Brain feed
+    threading.Thread(target=_run, daemon=True).start()
+    return jsonify({
+        "ok": True,
+        "message": 'Fix dispatched. Agent is working on "%s" — '
+                   "watch the Brain feed for progress." % name,
+    }), 202
 
 
 @bp_crons.route("/api/cron/run", methods=["POST"])
@@ -901,21 +969,20 @@ def api_crons_job_runs(job_id):
 def api_cron_kill(job_id):
     """Kill switch: disable a single cron job by ID.
 
-    Sends update via gateway WebSocket RPC to disable the job immediately.
-    Returns the updated job state or an error.
+    v3: gateway cron tool gone; use the CLI (same path as the rest of cron
+    writes). Returns 409 + scope_pending guidance if the device scope is
+    pending approval.
     """
-    import dashboard as _d
-    result = _d._gw_invoke(
-        "cron", {"action": "update", "jobId": job_id, "patch": {"enabled": False}}
-    )
-    if result is None:
-        return jsonify(
-            {
-                "ok": False,
-                "error": "Gateway unavailable — cannot disable cron remotely. Try restarting the gateway.",
-            }
-        ), 502
-    return jsonify({"ok": True, "jobId": job_id, "enabled": False, "result": result})
+    from clawmetry.sync import run_openclaw_cron
+    res = run_openclaw_cron("disable", [str(job_id)])
+    if res.get("ok"):
+        return jsonify({"ok": True, "jobId": job_id, "enabled": False,
+                        "result": res.get("result")})
+    if res.get("scope_pending"):
+        return jsonify({"ok": False, "scope_pending": True,
+                        "error": res.get("error", "")}), 409
+    return jsonify({"ok": False, "jobId": job_id,
+                    "error": res.get("error") or "cron disable failed"}), 502
 
 
 def _try_local_store_cron_run_log(session_id: str):
@@ -1153,15 +1220,25 @@ def api_cron_health_summary():
 
 @bp_crons.route("/api/cron/kill-all", methods=["POST"])
 def api_cron_kill_all():
-    """Emergency: disable all enabled cron jobs. Returns count disabled."""
-    import dashboard as _d
-    gw_data = _d._gw_invoke("cron", {"action": "list", "includeDisabled": False}) or {}
-    jobs = gw_data.get("jobs", []) or _d._get_crons()
+    """Emergency: disable all enabled cron jobs. Returns count disabled.
+
+    v3 migration: reads the job list from DuckDB (fast path, always works) +
+    falls back to dashboard._get_crons; per-job disable via the openclaw cron
+    CLI (the legacy `_gw_invoke("cron", ...)` is dead on v3). If the device
+    scope is pending approval, returns 409 with actionable guidance instead
+    of silently 502-ing every job.
+    """
+    from clawmetry.sync import run_openclaw_cron
+    jobs = _try_local_store_crons()  # DuckDB fast path
+    if jobs is None:
+        import dashboard as _d
+        jobs = _d._get_crons() or []
     if not isinstance(jobs, list):
         jobs = []
 
     disabled_count = 0
     errors = []
+    scope_pending_hit = False
     for job in jobs:
         if not isinstance(job, dict):
             continue
@@ -1170,22 +1247,28 @@ def api_cron_kill_all():
         job_id = job.get("id", "")
         if not job_id:
             continue
-        result = _d._gw_invoke(
-            "cron", {"action": "update", "jobId": job_id, "patch": {"enabled": False}}
-        )
-        if result is not None:
+        res = run_openclaw_cron("disable", [str(job_id)])
+        if res.get("ok"):
             disabled_count += 1
         else:
-            errors.append(job_id)
+            if res.get("scope_pending"):
+                scope_pending_hit = True
+            errors.append({"jobId": job_id, "error": res.get("error", "")[:200]})
 
-    return jsonify(
-        {
-            "ok": True,
-            "disabled": disabled_count,
+    if scope_pending_hit and disabled_count == 0:
+        return jsonify({
+            "ok": False, "scope_pending": True, "disabled": 0,
             "errors": errors,
-            "message": f"Emergency stop: {disabled_count} cron job(s) disabled.",
-        }
-    )
+            "error": ("Cron disable needs a one-time gateway approval. "
+                      "Run `openclaw devices list` then `openclaw devices "
+                      "approve <id>`, then retry."),
+        }), 409
+    return jsonify({
+        "ok": True,
+        "disabled": disabled_count,
+        "errors": errors,
+        "message": "Emergency stop: %d cron job(s) disabled." % disabled_count,
+    })
 
 
 def _project_intentions(jobs, days: int, include_disabled: bool, max_events: int):

--- a/routes/crons.py
+++ b/routes/crons.py
@@ -1228,11 +1228,21 @@ def api_cron_kill_all():
     scope is pending approval, returns 409 with actionable guidance instead
     of silently 502-ing every job.
     """
+    # CRITICAL: read the LIVE job list from the gateway via the CLI, not
+    # DuckDB. DuckDB lags the gateway (ingest is periodic) and can carry
+    # stale ids from deleted-but-not-yet-resynced jobs. Using a stale list
+    # risks (a) "unknown cron job id" errors for ids that no longer exist
+    # and (b) silently disabling jobs that have already been deleted.
+    # The CLI's `cron list --all --json` is the gateway's own ground truth.
     from clawmetry.sync import run_openclaw_cron
-    jobs = _try_local_store_crons()  # DuckDB fast path
-    if jobs is None:
-        import dashboard as _d
-        jobs = _d._get_crons() or []
+    listed = run_openclaw_cron("list", ["--all"], timeout=20)
+    jobs = []
+    if listed.get("ok"):
+        res = listed.get("result")
+        if isinstance(res, list):
+            jobs = res
+        elif isinstance(res, dict):
+            jobs = res.get("jobs") or res.get("crons") or []
     if not isinstance(jobs, list):
         jobs = []
 


### PR DESCRIPTION
## Why
The last three cron controls were broken or stubbed. Closes them out:

1. **`api_cron_kill` + `api_cron_kill_all`** used the dead v3 `_gw_invoke("cron",{action:"update"/"list"})` path — 502'd locally on v3 too, not just in cloud.
2. **`api_cron_fix`** was a stub: `# TODO: integrate with AI agent messaging system` returning a fake "Fix request submitted" toast.
3. **Emergency Stop All + Fix buttons** were hidden in cloud (no relay).

## What

### Local fixes (also repairs everyone on v3)
- `api_cron_kill` + `api_cron_kill_all` → `run_openclaw_cron("disable", [id])`. kill_all reads the **gateway's own job list via the CLI** (`openclaw cron list --all --json`) — DuckDB lags ingest and risks operating on stale ids (silently disabling deleted-but-not-yet-resynced jobs). 409 + actionable guidance on scope_pending.
- `api_cron_fix` properly dispatches `openclaw agent --session-id clawmetry-cron-fix-<id> --message <ctx> --json` in a daemon thread (mirror of Self-Evolve Fix). Context = name/schedule/lastError/consecutiveFailures. Returns 202 immediately; the agent's session shows up live in the Brain feed.

### Relay (cloud)
- `clawmetry/sync.py`: `cron_killall` + `cron_fix` daemon actions (mirror of `cron_create`/`cron_action`).
- `app.js`: every cron-write button now gates on `_cronWritesAvailable` (true in cloud too); Emergency Stop All + Fix are un-gated.

Cloud route + interceptor in the paired clawmetry-cloud PR.

## Verification
- **Live local E2E (twice):** created 2 enabled probes → kill-all → `{disabled:2, errors:[]}` → both probes disabled in the gateway, real `Hourly water reminder` untouched, clean cleanup.
- **Caught and fixed a near-miss**: first iteration read DuckDB, which silently disabled stale ids — repaired to read the CLI's authoritative list. The user's real cron got disabled by the bad version; immediately re-enabled, then re-verified the CLI-list fix.
- compile + node --check clean across both files.

Closes the cron surface: every button (create/run/toggle/edit/delete/kill-all/Fix) now works in both local and cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)