### PR TITLE
fix(tracing,cost): derive cost + label spans for Claude Code / adapter runtimes

### DIFF
--- a/clawmetry/adapters/claude_code.py
+++ b/clawmetry/adapters/claude_code.py
@@ -298,6 +298,11 @@ class ClaudeCodeAdapter(AgentAdapter):
             usage = msg.get("usage") if isinstance(msg.get("usage"), dict) else {}
             tokens_in = int(usage.get("input_tokens") or 0)
             tokens_out = int(usage.get("output_tokens") or 0)
+            # Prompt-cache tokens dominate cost on Claude Code turns (a cached
+            # 100k-token context re-read every turn). Carry them so the store's
+            # cost derivation is cache-aware instead of input/output-only.
+            cache_read = int(usage.get("cache_read_input_tokens") or 0)
+            cache_write = int(usage.get("cache_creation_input_tokens") or 0)
             model = msg.get("model") or ""
             usage_attached = False  # carry usage onto the first event of the turn
 
@@ -310,9 +315,13 @@ class ClaudeCodeAdapter(AgentAdapter):
                 btype = block.get("type")
                 tokens = 0
                 extra: dict[str, Any] = {}
-                if not usage_attached and (tokens_in or tokens_out):
+                if not usage_attached and (tokens_in or tokens_out or cache_read or cache_write):
                     tokens = tokens_in + tokens_out
                     extra = {"inputTokens": tokens_in, "outputTokens": tokens_out}
+                    if cache_read:
+                        extra["cacheReadInputTokens"] = cache_read
+                    if cache_write:
+                        extra["cacheCreationInputTokens"] = cache_write
 
                 if btype == "text" and isinstance(block.get("text"), str):
                     seq += 1

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -6928,17 +6928,53 @@ def _extract_event_metrics(
                     except (TypeError, ValueError):
                         pass
 
-    # Derive cost only when input/output split + provider + model are all known.
-    # estimate_cost_usd uses asymmetric input/output rates; a single ``total``
-    # can't be priced correctly, so leave cost=None and let read-side compute.
-    if cost is None and provider and model and (tokens_in or tokens_out):
+    # Adapter shapes (Claude Code, Codex, …) pre-set ``token_count`` (the lumped
+    # total) and stash the input/output/cache split under ``data.extra`` — so
+    # the ``if tokens is None`` blocks above were skipped and the split is still
+    # unknown, leaving cost NULL ($0 in the Cost tab for sessions that clearly
+    # cost money). Recover the split + cache tokens here, from ``data.extra``
+    # then ``data.usage``, regardless of whether the total was pre-set, so the
+    # #2049 derivation below can run.
+    cache_read = cache_write = 0
+    for src in (d.get("extra"), d.get("usage")):
+        if not isinstance(src, dict):
+            continue
+        if tokens_in is None:
+            i = src.get("inputTokens") or src.get("input_tokens")
+            if i:
+                try:
+                    tokens_in = int(i)
+                except (TypeError, ValueError):
+                    pass
+        if tokens_out is None:
+            o = src.get("outputTokens") or src.get("output_tokens")
+            if o:
+                try:
+                    tokens_out = int(o)
+                except (TypeError, ValueError):
+                    pass
+        if not cache_read:
+            cache_read = int(src.get("cacheReadInputTokens")
+                             or src.get("cache_read_input_tokens") or 0)
+        if not cache_write:
+            cache_write = int(src.get("cacheCreationInputTokens")
+                              or src.get("cache_creation_input_tokens") or 0)
+
+    # Derive cost from tokens × model pricing (#2049), cache-aware, with the
+    # provider resolved from the model when the event didn't carry one (adapter
+    # events don't). ``estimate_event_cost_usd`` infers the provider and applies
+    # the Anthropic cache multipliers; an explicit/already-priced cost still
+    # wins (we only derive when ``cost is None``).
+    if cost is None and model and (tokens_in or tokens_out or cache_read or cache_write):
         try:
-            from clawmetry.providers_pricing import estimate_cost_usd
-            est = estimate_cost_usd(
-                provider=str(provider),
-                tokens_in=int(tokens_in or 0),
-                tokens_out=int(tokens_out or 0),
-                model=str(model),
+            from clawmetry.providers_pricing import estimate_event_cost_usd
+            est = estimate_event_cost_usd(
+                str(model),
+                input_tokens=int(tokens_in or 0),
+                output_tokens=int(tokens_out or 0),
+                cache_read_tokens=int(cache_read or 0),
+                cache_write_tokens=int(cache_write or 0),
+                provider=str(provider or ""),
             )
             if est:
                 cost = float(est)

--- a/routes/tracing.py
+++ b/routes/tracing.py
@@ -60,6 +60,58 @@ def _events_for(session_id=None, limit=12000):
     return rows
 
 
+def _event_cost(e):
+    """Best-effort USD cost for one event, derived when the stored value is 0/None.
+
+    Multi-runtime adapters (Claude Code, Codex, …) pre-set ``token_count`` (the
+    lumped total) and stash the input/output/cache split under ``data.extra`` —
+    a shape the #2049 ingest derivation skipped, so these events land with
+    ``cost_usd`` NULL and the Cost column reads ``$0`` for sessions that clearly
+    cost money. Derive it here (read-side) from the split × model pricing,
+    cache-aware, with the provider inferred from the model. Honour an explicit
+    stored cost first so OpenClaw's already-priced events are never re-derived.
+    """
+    try:
+        c = e.get("cost_usd")
+        if c:
+            return float(c)
+    except (TypeError, ValueError):
+        pass
+    d = e.get("data") if isinstance(e.get("data"), dict) else {}
+    model = e.get("model") or d.get("model") or ""
+    if not model:
+        return 0.0
+    ex = d.get("extra") if isinstance(d.get("extra"), dict) else {}
+    u = d.get("usage") if isinstance(d.get("usage"), dict) else {}
+
+    def _pick(*keys):
+        for src in (ex, u):
+            if not isinstance(src, dict):
+                continue
+            for k in keys:
+                v = src.get(k)
+                if v:
+                    try:
+                        return int(v)
+                    except (TypeError, ValueError):
+                        return 0
+        return 0
+
+    ti = _pick("inputTokens", "input_tokens")
+    to = _pick("outputTokens", "output_tokens")
+    cr = _pick("cacheReadInputTokens", "cache_read_input_tokens")
+    cw = _pick("cacheCreationInputTokens", "cache_creation_input_tokens")
+    if not (ti or to or cr or cw):
+        return 0.0
+    try:
+        from clawmetry.providers_pricing import estimate_event_cost_usd
+        return float(estimate_event_cost_usd(
+            str(model), input_tokens=ti, output_tokens=to,
+            cache_read_tokens=cr, cache_write_tokens=cw) or 0.0)
+    except Exception:
+        return 0.0
+
+
 def _ts_ms(ts):
     """Coerce an event ts (ISO-8601 string or epoch s/ms) to ms-since-epoch."""
     if ts is None:
@@ -171,10 +223,7 @@ def _summarize_trace(session_id, rows):
         if ms:
             starts.append(ms)
         total_tokens += int(e.get("token_count") or 0)
-        try:
-            total_cost += float(e.get("cost_usd") or 0.0)
-        except (TypeError, ValueError):
-            pass
+        total_cost += _event_cost(e)
         if not model and e.get("model"):
             model = e.get("model")
         d = e.get("data") if isinstance(e.get("data"), dict) else {}
@@ -297,14 +346,29 @@ def _build_spans(rows):
             text = msg["content"]
         elif isinstance(d.get("finalPromptText"), str):
             text = d["finalPromptText"]
+        elif isinstance(d.get("content"), str):
+            # Multi-runtime adapters (Claude Code, …) put the turn text on
+            # ``data.content`` directly — without this the user prompt is empty
+            # and falls through to a generic ``message`` span instead of a
+            # ``prompt`` span.
+            text = d["content"]
 
         if is_sub and sub_root is None:
             sub_root = _mk("agent-sub", main_root["span_id"],
                            "invoke_agent sub-agent", "agent", start, t1, is_sub=True)
         agent_parent = (sub_root or main_root)["span_id"] if is_sub else main_root["span_id"]
 
-        is_assistant = ("assistant" in low) or ("model.completed" in low)
-        is_user = low.endswith("user") or low == "user" or "prompt" in low
+        # Multi-runtime adapters (Claude Code, Codex, …) emit event_type
+        # ``message`` for BOTH turns and carry the speaker in ``data.role`` —
+        # so classify on the role too, or every adapter LLM turn renders as a
+        # generic ``event`` span instead of a ``chat`` (llm) span. Gate the
+        # role path to text turns so a ``tool_call`` row (also role=assistant)
+        # still becomes an execute_tool span, not an empty chat.
+        role = (d.get("role") or "").lower()
+        is_assistant = ("assistant" in low) or ("model.completed" in low) \
+            or (role == "assistant" and low in ("message", "text"))
+        is_user = low.endswith("user") or low == "user" or "prompt" in low \
+            or (role == "user" and low == "message")
 
         # Close execute_tool spans whose result just arrived (the join).
         results = list(_walk_tool_results(d))
@@ -322,7 +386,7 @@ def _build_spans(rows):
             chat = _mk(eid, agent_parent,
                        ("chat " + (e.get("model") or "")).strip() or "chat",
                        "llm", start, nxt, is_sub=is_sub, model=e.get("model") or "",
-                       tokens=e.get("token_count"), cost=e.get("cost_usd"),
+                       tokens=e.get("token_count"), cost=_event_cost(e),
                        status="error" if (d.get("isError") or d.get("is_error")) else "ok",
                        detail=text, event_type=et)
             for j, tu in enumerate(_walk_tool_uses(d)):
@@ -342,7 +406,7 @@ def _build_spans(rows):
         # Fallback: any other renderable event as a child of its agent root.
         _mk(eid, agent_parent, (et or "event"), _span_kind(et, is_sub), start, nxt,
             is_sub=is_sub, model=e.get("model") or "", tokens=e.get("token_count"),
-            cost=e.get("cost_usd"), detail=text, event_type=et)
+            cost=_event_cost(e), detail=text, event_type=et)
 
     # Roll cost/tokens/duration child→parent; propagate error to agent parents.
     children = {}

--- a/tests/test_event_metrics_extraction.py
+++ b/tests/test_event_metrics_extraction.py
@@ -85,8 +85,64 @@ def test_anthropic_shape_sums_input_and_output_tokens():
     cost, tokens, model = _extract_event_metrics(ev)
     assert model == "claude-3-5-sonnet-latest"
     assert tokens == 150
-    # No provider in payload → cost stays None even though tokens are split.
-    assert cost is None
+    # Provider is now inferred from the model (no explicit provider needed) so
+    # the split IS priced — previously this left cost None, which surfaced as
+    # $0 for real spend. The provider-required gate was the bug, not a feature.
+    from clawmetry.providers_pricing import estimate_event_cost_usd
+    expect = estimate_event_cost_usd(
+        "claude-3-5-sonnet-latest", input_tokens=100, output_tokens=50)
+    assert expect > 0
+    assert cost is not None and abs(cost - expect) < 1e-9
+
+
+def test_claude_code_extra_split_derives_cost_with_inferred_provider():
+    """Claude Code / Codex shape: ``token_count`` pre-set (the lumped total)
+    with the input/output split under ``data.extra`` and NO provider. This
+    used to leave cost NULL — the ``$0 for a 100k-token session`` bug — because
+    the split-extraction blocks were gated on ``tokens is None`` and the cost
+    derivation required an explicit provider. Now the split is recovered from
+    ``data.extra`` and the provider is inferred from the model."""
+    ev = {
+        "id": "cc1",
+        "node_id": "n",
+        "event_type": "message",
+        "ts": "2026-05-25T00:00:00Z",
+        "model": "claude-opus-4-7",
+        "token_count": 3212,
+        "data": {"role": "assistant",
+                 "extra": {"inputTokens": 3166, "outputTokens": 46}},
+    }
+    cost, tokens, model = _extract_event_metrics(ev)
+    assert tokens == 3212
+    assert model == "claude-opus-4-7"
+    from clawmetry.providers_pricing import estimate_event_cost_usd
+    expect = estimate_event_cost_usd(
+        "claude-opus-4-7", input_tokens=3166, output_tokens=46)
+    assert expect > 0, "pricing assumption broke"
+    assert cost is not None and abs(cost - expect) < 1e-9
+
+
+def test_claude_code_extra_cache_tokens_are_priced():
+    """Prompt-cache tokens under ``data.extra`` are priced (Anthropic cache
+    multipliers) so a cache-heavy Claude Code turn isn't undercounted — cache
+    creation dominates cost on these turns."""
+    base = {
+        "id": "cc2", "node_id": "n", "event_type": "message",
+        "ts": "2026-05-25T00:00:00Z",
+        "model": "claude-opus-4-7", "token_count": 3212,
+    }
+    no_cache = dict(base, data={
+        "role": "assistant",
+        "extra": {"inputTokens": 3166, "outputTokens": 46}})
+    with_cache = dict(base, data={
+        "role": "assistant",
+        "extra": {"inputTokens": 3166, "outputTokens": 46,
+                  "cacheReadInputTokens": 10319,
+                  "cacheCreationInputTokens": 12078}})
+    c0, _, _ = _extract_event_metrics(no_cache)
+    c1, _, _ = _extract_event_metrics(with_cache)
+    assert c0 is not None and c1 is not None
+    assert c1 > c0, "cache tokens must add cost"
 
 
 def test_top_level_already_extracted_values_are_preserved():

--- a/tests/test_tracing_accuracy.py
+++ b/tests/test_tracing_accuracy.py
@@ -1,0 +1,99 @@
+"""Accuracy regression tests for the Tracing tab's span builder.
+
+These pin two bugs surfaced by checking /api/trace against the raw Claude Code
+session JSONL on a real machine:
+
+  1. **$0 cost for real spend.** Multi-runtime adapters (Claude Code, Codex, …)
+     emit ``event_type='message'`` with the input/output split under
+     ``data.extra`` and no top-level ``cost_usd``. The trace builder read
+     ``e['cost_usd']`` directly → every span cost was 0 → a 100k-token session
+     showed ``$0``. ``_event_cost`` now derives it (cache-aware, provider
+     inferred from the model), honouring an explicit stored cost first.
+
+  2. **LLM turns mislabelled.** Those adapters carry the speaker in
+     ``data.role`` (event_type is just ``message`` for both turns), so
+     ``_build_spans`` rendered every assistant turn as a generic ``event``
+     span instead of a ``chat`` (llm) span, and the user prompt never became a
+     ``prompt`` span. Classification now also keys on ``data.role``.
+"""
+
+from __future__ import annotations
+
+from clawmetry.providers_pricing import estimate_event_cost_usd
+from routes.tracing import _build_spans, _event_cost, _summarize_trace
+
+
+def _cc_event(eid, role, *, et="message", text="", tok=0, extra=None,
+              ts="2026-05-25T18:37:00Z", model="claude-opus-4-7"):
+    """A Claude Code-shaped event row as ``query_events`` returns it."""
+    data = {"role": role, "content": text}
+    if extra:
+        data["extra"] = extra
+    return {
+        "id": eid, "session_id": "claude_code:s1", "event_type": et,
+        "ts": ts, "model": model, "token_count": tok, "cost_usd": None,
+        "data": data,
+    }
+
+
+# ── _event_cost ───────────────────────────────────────────────────────────
+
+
+def test_event_cost_derives_from_extra_split():
+    e = _cc_event("a", "assistant", text="hi", tok=3212,
+                  extra={"inputTokens": 3166, "outputTokens": 46})
+    expect = estimate_event_cost_usd("claude-opus-4-7", input_tokens=3166, output_tokens=46)
+    assert expect > 0
+    assert abs(_event_cost(e) - expect) < 1e-9
+
+
+def test_event_cost_is_cache_aware():
+    no_cache = _cc_event("a", "assistant", tok=3212,
+                         extra={"inputTokens": 3166, "outputTokens": 46})
+    with_cache = _cc_event("b", "assistant", tok=3212,
+                           extra={"inputTokens": 3166, "outputTokens": 46,
+                                  "cacheReadInputTokens": 10319,
+                                  "cacheCreationInputTokens": 12078})
+    assert _event_cost(with_cache) > _event_cost(no_cache) > 0
+
+
+def test_event_cost_honours_explicit_stored_cost():
+    e = _cc_event("a", "assistant", tok=100, extra={"inputTokens": 100, "outputTokens": 0})
+    e["cost_usd"] = 0.42
+    assert _event_cost(e) == 0.42  # never re-derive when the value is real
+
+
+def test_event_cost_zero_without_model_or_tokens():
+    assert _event_cost(_cc_event("a", "assistant", model="", tok=0)) == 0.0
+
+
+# ── _build_spans classification ─────────────────────────────────────────────
+
+
+def test_build_spans_labels_claude_code_roles_and_cost():
+    rows = [
+        _cc_event("u", "user", text="do a thing", ts="2026-05-25T18:37:00Z"),
+        _cc_event("a", "assistant", text="done", tok=3212,
+                  extra={"inputTokens": 3166, "outputTokens": 46},
+                  ts="2026-05-25T18:37:02Z"),
+    ]
+    spans, roots = _build_spans(rows)
+    kinds = {s["kind"] for s in spans}
+    # assistant 'message' → chat/llm span (was generic 'event'); user → 'prompt'
+    assert "llm" in kinds, f"assistant turn not classified as llm: {[(s['name'], s['kind']) for s in spans]}"
+    assert "prompt" in kinds, f"user turn not classified as prompt: {[(s['name'], s['kind']) for s in spans]}"
+    chat = next(s for s in spans if s["kind"] == "llm")
+    assert chat["name"].startswith("chat")
+    assert chat["cost"] > 0, "chat span cost not derived from the extra split"
+    prompt = next(s for s in spans if s["kind"] == "prompt")
+    assert "do a thing" in (prompt.get("detail") or "")
+
+
+def test_summarize_trace_derives_total_cost():
+    rows = [
+        _cc_event("a", "assistant", tok=3212,
+                  extra={"inputTokens": 3166, "outputTokens": 46}),
+    ]
+    summ = _summarize_trace("claude_code:s1", rows)
+    assert summ["total_cost_usd"] > 0, "trace total cost still $0 for a priced turn"
+    assert summ["total_tokens"] == 3212


### PR DESCRIPTION
## Why

@vivekchand asked the right question after the Tracing tab went GA: **is it actually accurate?** I tested `/api/traces` + `/api/trace/<id>` against the **raw `~/.claude` session JSONL** on a real machine and found two accuracy bugs — both pre-existing, exposed by the multi-runtime adapters (Claude Code / Codex / …) whose event shape differs from OpenClaw's:

### Bug 1 — $0 cost for real spend
Adapter events pre-set `token_count` (lumped total) and stash the input/output/cache split under `data.extra`, with **no provider**. `_extract_event_metrics` gated split-extraction on `tokens is None` (skipped when the total was already set) **and** required an explicit `provider` — so cost landed `NULL`. A **430k-token, $29.58 session showed $0** everywhere (Cost tab, Overview, budgets, Tracing).

**Fix:** recover the input/output **and cache** split from `data.extra`/`data.usage` regardless of whether the total was pre-set; derive cost via `estimate_event_cost_usd` (#2049, cache-aware) with the **provider inferred from the model**. The `claude_code` adapter now also carries `cache_read`/`cache_creation` tokens so new events price cache-accurately (cache dominates these turns).

### Bug 2 — LLM turns mislabelled
Those adapters use `event_type='message'` for both turns and carry the speaker in `data.role`, so `_build_spans` rendered every assistant turn as a generic `event` span (not `chat`/llm) and never built a `prompt` span.

**Fix:** classify on `data.role` too (gated to text turns so `tool_call` rows stay execute_tool), read prompt text from `data.content`, and add a read-side `_event_cost()` so the tab is accurate even before re-ingest.

## Verification (real data, exact match)

| | before | after |
|---|---|---|
| 430,291-tok Claude Code trace | **$0.00** | **$29.578365** |
| ground truth (raw JSONL, 44,891 in + 385,400 out) | — | **$29.5784** ✅ exact |
| small 2-event session assistant turn | `message` / `event` / $0 | `chat claude-opus-4-7` / **llm** / **$0.05094** |
| small session user turn | `message` / `event` | **`prompt`** span with text |

(Old events lack cache tokens on disk → read-side stays input/output-correct; new events are fully cache-accurate. The true cache-inclusive cost of that trace is ~$105.81 — a follow-up backfill can recover cache for historical events, deferred to avoid a bulk UPDATE on the live 1.4 GB DuckDB.)

## Tests
5 new cases (extra-split derivation, cache-aware pricing, role classification, trace-cost rollup) + updated the anthropic-shape test that previously asserted the provider-required-gate bug. **32 trace/metrics tests green.** Read-path verified live against the real daemon (repo HEAD on `:8901`, `role=dashboard`, no writer-lock touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)