### PR TITLE
feat(observability): per-turn anatomy waterfall + stalled detector (P0-3)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -964,6 +964,7 @@ function switchTab(name) {
   if (name === 'flow') initFlow();
   if (name === 'context') loadContextInspector();
   if (name === 'tracing') loadTracing();
+  if (name === 'turn-anatomy') loadTurnAnatomy();
   if (name === 'brain') loadBrainPage();
   if (name === 'selfevolve') loadSelfEvolvePage();
   if (name === 'notifications') { if (typeof loadNotificationsPage === 'function') loadNotificationsPage(); }
@@ -8349,6 +8350,171 @@ function _traceFmtDur(ms) {
 window._allTraces = [];
 window._traceListFilter = 'recent';
 window._traceListSearch = '';
+
+// ── Turn anatomy (P0-3): per-turn waterfall + stalled detector ──────────────
+// Reuses the trace list (one row per session) for picking a session, then
+// /api/turn-anatomy decomposes that session into turns of ordered spans.
+var _TA_KIND_COLORS = {
+  prompt: '#a78bfa', model: '#22d3ee', tool: '#f59e0b',
+  compaction: '#f472b6', reply: '#34d399'
+};
+var _TA_KIND_ICONS = {
+  prompt: '💬', model: '🧠', tool: '🔧', compaction: '🗜️', reply: '✅'
+};
+function _taColor(kind) { return _TA_KIND_COLORS[kind] || '#94a3b8'; }
+function _taIcon(kind) { return _TA_KIND_ICONS[kind] || '•'; }
+
+window._taSession = null;
+
+async function loadTurnAnatomy() {
+  turnAnatomyShowList();
+  _taLoadStalled();
+  var el = document.getElementById('ta-list');
+  if (!el) return;
+  el.style.cssText = '';
+  el.innerHTML = '<div style="padding:18px;color:var(--text-muted);">Loading sessions&hellip;</div>';
+  var data;
+  try {
+    data = await fetch('/api/traces?limit=200').then(function(r){ return r.json(); });
+  } catch (e) {
+    el.innerHTML = '<div style="padding:18px;color:var(--text-muted);">Could not load sessions.</div>';
+    return;
+  }
+  if (!data || data.available === false) {
+    el.innerHTML = '<div style="padding:24px;text-align:center;color:var(--text-secondary);font-size:13px;">Turn anatomy reads from the local event store, which is not available here.</div>';
+    return;
+  }
+  var traces = (data.traces || []).slice().sort(function(a, b){ return (b.start_ms || 0) - (a.start_ms || 0); });
+  if (!traces.length) {
+    el.innerHTML = '<div style="padding:24px;text-align:center;color:var(--text-secondary);font-size:13px;">No sessions yet. They appear here once your agent runs.</div>';
+    return;
+  }
+  el.style.cssText = 'padding:0;overflow:hidden;';
+  var html = '<div style="display:flex;gap:12px;padding:8px 14px;border-bottom:1px solid var(--border-primary);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:0.6px;color:var(--text-muted);">'
+    + '<span style="flex:1;">Session</span><span style="width:74px;text-align:right;">Duration</span><span style="width:64px;text-align:right;">Spans</span><span style="width:130px;">Model</span></div>';
+  traces.forEach(function(t) {
+    var when = t.start_ms ? new Date(t.start_ms).toLocaleString() : '';
+    var statusDot = t.status === 'error' ? '#ef4444' : '#22c55e';
+    html += '<div onclick="viewTurnAnatomy(\'' + escHtml(t.trace_id) + '\')" '
+      + 'style="display:flex;gap:12px;align-items:center;padding:10px 14px;border-bottom:1px solid var(--border-secondary);cursor:pointer;" '
+      + 'onmouseover="this.style.background=\'var(--bg-tertiary,#1e293b)\'" onmouseout="this.style.background=\'\'">'
+      + '<span style="flex:1;min-width:0;">'
+        + '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + statusDot + ';margin-right:8px;"></span>'
+        + '<span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;color:var(--text-primary);">' + escHtml((t.name || t.trace_id).slice(0, 30)) + '</span>'
+        + '<span style="margin-left:8px;color:var(--text-muted);font-size:11px;">' + escHtml(when) + '</span>'
+      + '</span>'
+      + '<span style="width:74px;text-align:right;color:var(--text-secondary);font-size:12px;">' + _traceFmtDur(t.duration_ms) + '</span>'
+      + '<span style="width:64px;text-align:right;color:var(--text-secondary);font-size:12px;">' + (t.span_count || 0) + '</span>'
+      + '<span style="width:130px;color:var(--text-muted);font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escHtml(t.model || '') + '</span>'
+      + '</div>';
+  });
+  el.innerHTML = html;
+}
+
+function turnAnatomyShowList() {
+  var list = document.getElementById('ta-list');
+  var detail = document.getElementById('ta-detail');
+  var back = document.getElementById('ta-back-btn');
+  if (list) list.style.display = '';
+  if (detail) detail.style.display = 'none';
+  if (back) back.style.display = 'none';
+}
+
+async function _taLoadStalled() {
+  var el = document.getElementById('ta-stalled');
+  if (!el) return;
+  var data;
+  try {
+    data = await fetch('/api/turn-anatomy/stalled?min=5').then(function(r){ return r.json(); });
+  } catch (e) { el.style.display = 'none'; return; }
+  var stalled = (data && data.stalled) || [];
+  if (!stalled.length) { el.style.display = 'none'; return; }
+  el.style.display = '';
+  var rows = stalled.slice(0, 6).map(function(s) {
+    return '<div onclick="viewTurnAnatomy(\'' + escHtml(s.session_id) + '\')" style="display:flex;align-items:center;gap:10px;padding:6px 0;cursor:pointer;font-size:12px;">'
+      + '<span style="width:8px;height:8px;border-radius:50%;background:#f59e0b;flex-shrink:0;"></span>'
+      + '<span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--text-primary);flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escHtml(s.session_id) + '</span>'
+      + '<span style="color:#fbbf24;">idle ' + (s.idle_min || 0) + 'm</span>'
+      + '<span style="color:var(--text-muted);">' + escHtml(s.last_kind || '') + (s.pending_tool ? ' · tool pending' : '') + '</span>'
+      + '</div>';
+  }).join('');
+  el.innerHTML = '<div style="background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.35);border-radius:8px;padding:12px 14px;">'
+    + '<div style="font-size:12px;font-weight:700;color:#f59e0b;margin-bottom:4px;">&#9888; ' + stalled.length + ' session' + (stalled.length === 1 ? '' : 's') + ' stalled / long-running</div>'
+    + '<div style="font-size:11px;color:var(--text-muted);margin-bottom:6px;">Latest turn has had no new event for &gt; ' + (data.threshold_min || 5) + ' min and never reached a reply.</div>'
+    + rows + '</div>';
+}
+
+async function viewTurnAnatomy(sessionId) {
+  window._taSession = sessionId;
+  var list = document.getElementById('ta-list');
+  var detail = document.getElementById('ta-detail');
+  var back = document.getElementById('ta-back-btn');
+  if (list) list.style.display = 'none';
+  if (detail) detail.style.display = '';
+  if (back) back.style.display = '';
+  var meta = document.getElementById('ta-detail-meta');
+  var turnsEl = document.getElementById('ta-turns');
+  if (meta) meta.innerHTML = '<div style="color:var(--text-muted);font-size:13px;">Loading turns&hellip;</div>';
+  if (turnsEl) turnsEl.innerHTML = '';
+  var data;
+  try {
+    data = await fetch('/api/turn-anatomy?session_id=' + encodeURIComponent(sessionId)).then(function(r){ return r.json(); });
+  } catch (e) {
+    if (meta) meta.innerHTML = '<div style="color:var(--text-muted);font-size:13px;">Could not load turns.</div>';
+    return;
+  }
+  if (!data || data.available === false) {
+    if (meta) meta.innerHTML = '<div style="color:var(--text-secondary);font-size:13px;">Event store not available here.</div>';
+    return;
+  }
+  var turns = data.turns || [];
+  if (meta) {
+    meta.innerHTML = '<div style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:14px;color:var(--text-primary);">' + escHtml(sessionId) + '</div>'
+      + '<div style="font-size:12px;color:var(--text-muted);margin-top:4px;">' + turns.length + ' turn' + (turns.length === 1 ? '' : 's') + '</div>';
+  }
+  if (!turns.length) {
+    if (turnsEl) turnsEl.innerHTML = '<div class="card" style="padding:18px;color:var(--text-muted);">No turns in this session.</div>';
+    return;
+  }
+  if (turnsEl) turnsEl.innerHTML = turns.map(_taRenderTurn).join('');
+}
+
+function _taRenderTurn(t) {
+  var spans = (t.spans || []).slice().sort(function(a, b){ return (a.started_ms || 0) - (b.started_ms || 0); });
+  var t0 = spans.length ? (spans[0].started_ms || 0) : 0;
+  var t1 = 0;
+  spans.forEach(function(s){ t1 = Math.max(t1, (s.started_ms || 0) + (s.duration_ms || 0)); });
+  var total = Math.max(1, t1 - t0);
+  var isErr = t.status === 'error';
+  var head = '<div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;">'
+    + '<span style="font-size:13px;font-weight:700;color:var(--text-primary);">Turn ' + t.turn + '</span>'
+    + (isErr ? '<span style="background:rgba(239,68,68,0.15);color:#f87171;border-radius:6px;padding:1px 7px;font-size:10px;font-weight:600;">error</span>' : '')
+    + '<span style="font-size:11px;color:var(--text-muted);">' + _traceFmtDur(t.duration_ms) + ' &middot; ' + (t.tool_count || 0) + ' tool' + (t.tool_count === 1 ? '' : 's') + ' &middot; ' + ((t.total_tokens || 0) / 1000).toFixed(1) + 'K tok</span>'
+    + '</div>';
+  var prompt = t.prompt ? '<div style="font-size:12px;color:var(--text-secondary);margin-bottom:10px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="' + escHtml(t.prompt) + '">&#128172; ' + escHtml(t.prompt) + '</div>' : '';
+  var bars = '<div style="min-width:560px;">';
+  if (!spans.length) {
+    bars += '<div style="padding:8px;color:var(--text-muted);font-size:12px;">No spans.</div>';
+  }
+  spans.forEach(function(s) {
+    var left = ((s.started_ms - t0) / total) * 100;
+    var width = Math.max(0.6, ((s.duration_ms || 0) / total) * 100);
+    if (left + width > 100) width = Math.max(0.6, 100 - left);
+    var color = _taColor(s.kind);
+    var spanErr = s.status === 'error';
+    var label = (s.label || s.kind || '');
+    bars += '<div style="display:flex;align-items:center;gap:8px;padding:2px 0;" title="' + escHtml(label) + ' · ' + _traceFmtDur(s.duration_ms) + (spanErr ? ' · error' : '') + '">'
+      + '<span style="width:18px;flex-shrink:0;text-align:center;font-size:11px;">' + _taIcon(s.kind) + '</span>'
+      + '<span style="width:170px;flex-shrink:0;font-size:11px;color:' + (spanErr ? '#f87171' : 'var(--text-secondary)') + ';white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escHtml(label) + (spanErr ? ' &#9888;' : '') + '</span>'
+      + '<span style="flex:1;position:relative;height:14px;background:var(--bg-primary);border-radius:3px;">'
+        + '<span style="position:absolute;left:' + left.toFixed(2) + '%;width:' + width.toFixed(2) + '%;top:2px;height:10px;background:' + (spanErr ? '#ef4444' : color) + ';border-radius:3px;min-width:2px;"></span>'
+      + '</span>'
+      + '<span style="width:58px;flex-shrink:0;text-align:right;font-size:11px;color:var(--text-muted);">' + _traceFmtDur(s.duration_ms) + '</span>'
+      + '</div>';
+  });
+  bars += '</div>';
+  return '<div class="card" style="margin-bottom:10px;overflow-x:auto;' + (isErr ? 'border-color:rgba(239,68,68,0.35);' : '') + '">' + head + prompt + bars + '</div>';
+}
 
 async function loadTracing() {
   tracingShowList();

--- a/clawmetry/templates/tabs/turn-anatomy.html
+++ b/clawmetry/templates/tabs/turn-anatomy.html
@@ -1,0 +1,24 @@
+<div class="page" id="page-turn-anatomy">
+  <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:14px;gap:16px;flex-wrap:wrap;">
+    <div>
+      <div style="font-size:18px;font-weight:700;color:var(--text-primary);">Turn anatomy</div>
+      <div style="font-size:12px;color:var(--text-muted);margin-top:4px;">Decompose one agent turn into a waterfall: prompt &rarr; model call(s) &rarr; each tool (start&rarr;end) &rarr; compaction &rarr; reply. Bar width is proportional to wall-clock duration.</div>
+    </div>
+    <div style="display:flex;gap:6px;align-items:center;">
+      <button class="refresh-btn" id="ta-back-btn" style="display:none;" onclick="turnAnatomyShowList()">&larr; Back to sessions</button>
+      <button class="refresh-btn" onclick="loadTurnAnatomy()">&#8635;</button>
+    </div>
+  </div>
+
+  <!-- Stalled / long-running indicator (persistent across both views) -->
+  <div id="ta-stalled" style="display:none;margin-bottom:12px;"></div>
+
+  <!-- SESSION LIST -->
+  <div class="card" id="ta-list" style="color:var(--text-muted);font-size:13px;">Loading sessions&hellip;</div>
+
+  <!-- TURN DETAIL -->
+  <div id="ta-detail" style="display:none;">
+    <div class="card" id="ta-detail-meta" style="margin-bottom:10px;"></div>
+    <div id="ta-turns"></div>
+  </div>
+</div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -123,6 +123,7 @@ from routes.evals import bp_evals
 from routes.dives import bp_dives
 from routes.scheduler import bp_scheduler
 from routes.policy import bp_policy
+from routes.turn_anatomy import bp_turn_anatomy
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -10621,6 +10622,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_dives)
     app.register_blueprint(bp_scheduler)
     app.register_blueprint(bp_policy)
+    app.register_blueprint(bp_turn_anatomy)
 
     # Register built-in agent adapters. External plugins can register more
     # via clawmetry.extensions entry points — see clawmetry/adapters/.
@@ -11073,6 +11075,9 @@ DASHBOARD_HTML = r"""
         <div class="left-nav-item left-nav-item-sub" id="left-nav-tracing" data-tab="tracing" onclick="switchTab('tracing')" data-i18n-title="nav.tracing_tooltip" title="Every trace: span waterfall, tree, and agent graph">
           <span class="left-nav-label" data-i18n="nav.tracing">Tracing</span>
         </div>
+        <div class="left-nav-item left-nav-item-sub" id="left-nav-turn-anatomy" data-tab="turn-anatomy" onclick="switchTab('turn-anatomy')" title="Decompose a turn into prompt, model, tools, compaction and reply">
+          <span class="left-nav-label">Turn anatomy</span>
+        </div>
       </div>
 
       <div class="left-nav-item" data-tab="approvals" onclick="switchTab('approvals')" data-i18n-title="nav.approvals_tooltip" title="Cloud-mediated approval queue">
@@ -11196,6 +11201,9 @@ DASHBOARD_HTML = r"""
 
 <!-- TRACING (Phoenix/Arize-style: span waterfall + tree + agent graph) -->
 {% include 'tabs/tracing.html' %}
+
+<!-- TURN ANATOMY (per-turn waterfall + stalled detector, P0-3) -->
+{% include 'tabs/turn-anatomy.html' %}
 
 <!-- SECURITY -->
 {% include 'tabs/security.html' %}

--- a/routes/turn_anatomy.py
+++ b/routes/turn_anatomy.py
@@ -1,0 +1,421 @@
+"""routes/turn_anatomy.py — per-turn anatomy waterfall (PRD P0-3).
+
+A *turn* is one round of agent work: the events between two consecutive
+``prompt.submitted`` boundaries within a session (the human/scheduler prompt,
+the model call(s) it triggered, every tool the model invoked with its
+start→end duration, any context compaction, and the final reply).
+
+This decomposes a session into those turns and emits, per turn, an ordered
+list of *spans* laid out on the wall-clock timeline so the UI can draw a
+horizontal waterfall (bar width ∝ duration). It also exposes a *stalled*
+detector: sessions whose most recent turn has been running with no new event
+for longer than a threshold (a long-running / stuck agent indicator).
+
+Events-first by design: reads the OpenClaw events ClawMetry already ingests
+into DuckDB (no OTLP exporter needed), via the daemon read proxy
+(``local_store_via_daemon``) with a single-process read-only fallback — the
+same DuckDB-first pattern as ``routes/tracing.py`` / ``routes/scheduler.py``.
+Never 500s on empty data.
+
+Endpoints (bp_turn_anatomy):
+  GET /api/turn-anatomy?session_id=...  — ordered spans grouped per turn
+  GET /api/turn-anatomy/stalled         — sessions whose latest turn is stalled
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify, request
+
+bp_turn_anatomy = Blueprint("turn_anatomy", __name__)
+
+# Pure-plumbing event types that never become a span of their own.
+_PLUMBING_TYPES = frozenset({
+    "session.started", "session.ended", "session.created",
+    "model.changed", "thinking_level_change", "context.compiled",
+    "agent.heartbeat", "queue-operation",
+})
+
+# How long (minutes) a session's latest turn may sit with no new event before
+# we flag it as stalled / long-running.
+_DEFAULT_STALL_MIN = 5
+
+
+def _events_for(session_id=None, limit=14000):
+    """Read events via the daemon proxy with a single-process RO fallback."""
+    rows = None
+    try:
+        from routes.local_query import local_store_via_daemon
+        if session_id:
+            rows = local_store_via_daemon(
+                "query_events", session_id=session_id, limit=limit)
+        else:
+            rows = local_store_via_daemon("query_events", limit=limit)
+    except Exception:
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry.config import is_local_store_read_enabled
+            if not is_local_store_read_enabled():
+                return None
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            rows = (store.query_events(session_id=session_id, limit=limit)
+                    if session_id else store.query_events(limit=limit))
+        except Exception:
+            rows = None
+    # The proxy may wrap the list in an envelope depending on transport.
+    if isinstance(rows, dict):
+        rows = rows.get("result") or rows.get("rows") or []
+    return rows
+
+
+def _ts_ms(ts):
+    """Coerce an event ts (ISO-8601 string or epoch s/ms) to ms-since-epoch."""
+    if ts is None:
+        return None
+    if isinstance(ts, (int, float)):
+        return int(ts * 1000) if ts < 1e12 else int(ts)
+    try:
+        return int(datetime.fromisoformat(
+            str(ts).replace("Z", "+00:00")).timestamp() * 1000)
+    except Exception:
+        return None
+
+
+def _now_ms():
+    return int(datetime.now(timezone.utc).timestamp() * 1000)
+
+
+def _data(e):
+    d = e.get("data")
+    return d if isinstance(d, dict) else {}
+
+
+def _classify(e):
+    """Classify an event into a turn-anatomy kind.
+
+    Handles BOTH OpenClaw v3 normalized types (prompt.submitted /
+    model.completed / tool_call / tool_result) AND the multi-runtime adapter
+    shapes (Claude Code, Codex, …) that emit ``message`` rows carrying the
+    speaker in ``data.role``. This is a display classifier, not a row-dropping
+    filter, so it never silent-zeros on either shape.
+
+    Returns one of: 'prompt', 'model', 'tool_call', 'tool_result',
+    'compaction', or '' (skip / plumbing).
+    """
+    et = (e.get("event_type") or "").lower()
+    if et in _PLUMBING_TYPES:
+        return ""
+    if "compact" in et:
+        return "compaction"
+    d = _data(e)
+    role = (d.get("role") or "").lower()
+
+    # Tool plumbing first (a tool_call row may also have role=assistant).
+    if "tool_result" in et or "tool_use_result" in et or role == "tool":
+        return "tool_result"
+    if "tool_call" in et or "tool.call" in et or d.get("tool_name") or d.get("tool_calls"):
+        return "tool_call"
+
+    # Prompt / user boundary.
+    if "prompt.submitted" in et or et.endswith("user") or et == "user" \
+            or (role == "user" and et in ("message", "text")):
+        return "prompt"
+
+    # Model call / assistant reply.
+    if "model.completed" in et or "assistant" in et \
+            or (role == "assistant" and et in ("message", "text")):
+        return "model"
+
+    if et == "thinking":
+        return "model"
+    return ""
+
+
+def _tool_name(e):
+    d = _data(e)
+    name = d.get("tool_name")
+    if name:
+        return str(name).replace("mcp__openclaw__", "")
+    tcs = d.get("tool_calls")
+    if isinstance(tcs, list) and tcs and isinstance(tcs[0], dict):
+        n = tcs[0].get("name") or (tcs[0].get("function") or {}).get("name")
+        if n:
+            return str(n).replace("mcp__openclaw__", "")
+    return "tool"
+
+
+def _tool_use_ids(e):
+    """tool_use ids this event opens (a tool_call) — for start→end matching."""
+    d = _data(e)
+    ids = []
+    tcs = d.get("tool_calls")
+    if isinstance(tcs, list):
+        for tc in tcs:
+            if isinstance(tc, dict) and tc.get("id"):
+                ids.append(str(tc["id"]))
+    return ids
+
+
+def _tool_result_id(e):
+    """tool_use id this tool_result closes (the join key)."""
+    d = _data(e)
+    ex = d.get("extra") if isinstance(d.get("extra"), dict) else {}
+    return ex.get("toolUseId") or ex.get("tool_use_id") or d.get("tool_use_id")
+
+
+def _is_error(e):
+    d = _data(e)
+    ex = d.get("extra") if isinstance(d.get("extra"), dict) else {}
+    return bool(ex.get("isError") or d.get("isError") or d.get("is_error")
+                or (e.get("event_type") or "").endswith("error"))
+
+
+def _prompt_text(e):
+    d = _data(e)
+    for k in ("finalPromptText", "content"):
+        v = d.get(k)
+        if isinstance(v, str) and v.strip():
+            return v
+    msg = d.get("message")
+    if isinstance(msg, dict) and isinstance(msg.get("content"), str):
+        return msg["content"]
+    return ""
+
+
+def _build_turns(rows):
+    """Decompose a session's events into ordered turns of waterfall spans.
+
+    A turn starts at each ``prompt`` boundary (the first turn also absorbs any
+    pre-prompt events). Within a turn we emit spans in wall-clock order:
+    prompt → model call(s) → each tool (start at its tool_call, end at the
+    matching tool_result) → compaction → reply. Each span's ``ended_ms`` is the
+    next event's ts (so a bar's width is the wall-clock gap until the next
+    activity); a tool span instead ends at its matched result.
+    """
+    evs = sorted(
+        (e for e in rows if _classify(e)),
+        key=lambda e: _ts_ms(e.get("ts")) or 0,
+    )
+    if not evs:
+        return []
+    start_ms = [(_ts_ms(e.get("ts")) or 0) for e in evs]
+
+    # Partition into turns on each prompt boundary.
+    turns = []
+    cur = None
+    for i, e in enumerate(evs):
+        kind = _classify(e)
+        if kind == "prompt" or cur is None:
+            if kind == "prompt" or not turns:
+                cur = {"events": [], "idx": []}
+                turns.append(cur)
+        cur["events"].append(e)
+        cur["idx"].append(i)
+
+    out = []
+    for tn, turn in enumerate(turns):
+        spans = []
+        tool_open = {}  # tool_use_id -> span (awaiting its result)
+        t_starts = [start_ms[i] for i in turn["idx"]]
+        turn_start = min(t_starts) if t_starts else None
+        turn_end = max(t_starts) if t_starts else None
+        n = len(turn["events"])
+        for j, e in enumerate(turn["events"]):
+            gi = turn["idx"][j]
+            kind = _classify(e)
+            s_ms = start_ms[gi]
+            # Default end = next event's start within the WHOLE session.
+            nxt = start_ms[gi + 1] if gi + 1 < len(start_ms) else s_ms
+            tokens = int(e.get("token_count") or 0)
+            model = e.get("model") or _data(e).get("model") or ""
+
+            if kind == "tool_result":
+                # Close the matching open tool span; this row is not its own span.
+                rid = _tool_result_id(e)
+                sp = tool_open.pop(rid, None) if rid else None
+                if sp is not None:
+                    sp["ended_ms"] = s_ms
+                    sp["duration_ms"] = max(0, s_ms - sp["started_ms"])
+                    if _is_error(e):
+                        sp["status"] = "error"
+                else:
+                    # Orphan result (no matching open tool_call captured) — show
+                    # it as a zero-width tool span so nothing is silently lost.
+                    spans.append({
+                        "kind": "tool", "label": _tool_name(e) + " result",
+                        "started_ms": s_ms, "ended_ms": s_ms, "duration_ms": 0,
+                        "status": "error" if _is_error(e) else "ok",
+                    })
+                continue
+
+            if kind == "tool_call":
+                sp = {
+                    "kind": "tool", "label": _tool_name(e),
+                    "started_ms": s_ms, "ended_ms": nxt,
+                    "duration_ms": max(0, nxt - s_ms),
+                    "tokens": tokens or None,
+                    "status": "error" if _is_error(e) else "ok",
+                }
+                spans.append(sp)
+                # Register every tool_use id this call opened so its result closes it.
+                for tuid in _tool_use_ids(e):
+                    tool_open[tuid] = sp
+                continue
+
+            if kind == "compaction":
+                spans.append({
+                    "kind": "compaction", "label": "context compaction",
+                    "started_ms": s_ms, "ended_ms": nxt,
+                    "duration_ms": max(0, nxt - s_ms), "status": "ok",
+                })
+                continue
+
+            if kind == "prompt":
+                txt = _prompt_text(e)
+                spans.append({
+                    "kind": "prompt",
+                    "label": (txt[:80] or "prompt").replace("\n", " "),
+                    "started_ms": s_ms, "ended_ms": nxt,
+                    "duration_ms": max(0, nxt - s_ms), "status": "ok",
+                })
+                continue
+
+            # model: the last model event of the turn is the reply.
+            is_last = (j == n - 1)
+            spans.append({
+                "kind": "reply" if is_last else "model",
+                "label": ("reply" if is_last else "model call")
+                         + (" " + model if model else ""),
+                "started_ms": s_ms, "ended_ms": nxt,
+                "duration_ms": max(0, nxt - s_ms),
+                "tokens": tokens or None, "model": model or None,
+                "status": "error" if _is_error(e) else "ok",
+            })
+
+        # Any tool still open at turn end never got a result → leave it ending
+        # at the turn boundary (best-effort) so its bar is still drawn.
+        for sp in tool_open.values():
+            if sp.get("ended_ms") in (None, sp["started_ms"]) and turn_end:
+                sp["ended_ms"] = turn_end
+                sp["duration_ms"] = max(0, turn_end - sp["started_ms"])
+
+        prompt_label = next(
+            (s["label"] for s in spans if s["kind"] == "prompt"), "")
+        tool_count = sum(1 for s in spans if s["kind"] == "tool")
+        total_tokens = sum(int(s.get("tokens") or 0) for s in spans)
+        has_error = any(s.get("status") == "error" for s in spans)
+        out.append({
+            "turn": tn + 1,
+            "started_ms": turn_start,
+            "ended_ms": turn_end,
+            "duration_ms": (turn_end - turn_start) if (turn_start and turn_end) else 0,
+            "prompt": prompt_label,
+            "tool_count": tool_count,
+            "total_tokens": total_tokens,
+            "span_count": len(spans),
+            "status": "error" if has_error else "ok",
+            "spans": spans,
+        })
+    return out
+
+
+@bp_turn_anatomy.route("/api/turn-anatomy")
+def api_turn_anatomy():
+    """Per-turn anatomy for one session.
+
+    Query: ``session_id`` (required). Returns ``{session_id, turns, _source}``
+    where each turn carries ordered ``spans``. Never 500s — a missing session
+    or unreadable store returns an empty ``turns`` list (HTTP 200).
+    """
+    session_id = (request.args.get("session_id") or "").strip()
+    if not session_id:
+        return jsonify({"error": "session_id required", "turns": []}), 400
+    try:
+        limit = max(1, min(20000, int(request.args.get("limit", 14000))))
+    except (TypeError, ValueError):
+        limit = 14000
+
+    rows = _events_for(session_id=session_id, limit=limit)
+    if rows is None:
+        return jsonify({"available": False, "session_id": session_id, "turns": []})
+
+    turns = _build_turns(rows)
+    return jsonify({
+        "available": True,
+        "session_id": session_id,
+        "turns": turns,
+        "turn_count": len(turns),
+        "_source": "local_store",
+    })
+
+
+@bp_turn_anatomy.route("/api/turn-anatomy/stalled")
+def api_turn_anatomy_stalled():
+    """Sessions whose most recent turn is stalled / long-running.
+
+    A session is stalled when its latest event is older than ``min`` minutes
+    (default 5) but the latest turn never reached a terminal reply — i.e. the
+    agent appears stuck mid-turn. Scans a bounded recent window of events.
+    Returns ``{stalled:[...], threshold_min, _source}``; never 500s.
+    """
+    try:
+        stall_min = max(1, min(1440, int(request.args.get("min", _DEFAULT_STALL_MIN))))
+    except (TypeError, ValueError):
+        stall_min = _DEFAULT_STALL_MIN
+    threshold_ms = stall_min * 60 * 1000
+    now = _now_ms()
+
+    rows = _events_for(limit=6000)
+    if rows is None:
+        return jsonify({"available": False, "stalled": [], "threshold_min": stall_min})
+
+    by_sid = {}
+    for e in rows:
+        sid = (e.get("session_id") or "").strip()
+        if not sid:
+            continue
+        by_sid.setdefault(sid, []).append(e)
+
+    stalled = []
+    for sid, evs in by_sid.items():
+        kinds = [(k, _ts_ms(e.get("ts"))) for e in evs for k in (_classify(e),) if k]
+        if not kinds:
+            continue
+        last_ms = max((ms for _, ms in kinds if ms), default=None)
+        if last_ms is None:
+            continue
+        idle_ms = now - last_ms
+        if idle_ms < threshold_ms:
+            continue
+        # Terminal if the latest classified event is a reply/model with no
+        # tool still pending. We approximate "running" as: the last event in
+        # the turn is a prompt or an unresolved tool_call (waiting).
+        kinds_only = [k for k, _ in sorted(
+            ((k, ms or 0) for k, ms in kinds), key=lambda x: x[1])]
+        last_kind = kinds_only[-1] if kinds_only else ""
+        # Count tool_call vs tool_result to detect an unresolved tool.
+        opened = sum(1 for k in kinds_only if k == "tool_call")
+        closed = sum(1 for k in kinds_only if k == "tool_result")
+        pending_tool = opened > closed
+        running = last_kind in ("prompt", "tool_call", "model") or pending_tool
+        if not running:
+            continue
+        stalled.append({
+            "session_id": sid,
+            "last_event_ms": last_ms,
+            "idle_ms": idle_ms,
+            "idle_min": round(idle_ms / 60000, 1),
+            "last_kind": last_kind,
+            "pending_tool": pending_tool,
+            "event_count": len(evs),
+        })
+
+    stalled.sort(key=lambda s: s["idle_ms"], reverse=True)
+    return jsonify({
+        "available": True,
+        "stalled": stalled,
+        "threshold_min": stall_min,
+        "_source": "local_store",
+    })

--- a/routes/turn_anatomy.py
+++ b/routes/turn_anatomy.py
@@ -118,8 +118,10 @@ def _classify(e):
     if "tool_call" in et or "tool.call" in et or d.get("tool_name") or d.get("tool_calls"):
         return "tool_call"
 
-    # Prompt / user boundary.
-    if "prompt.submitted" in et or et.endswith("user") or et == "user" \
+    # Prompt / user boundary. (``et.endswith("user")`` already covers an
+    # exact ``"user"`` as well as v3-adjacent ``*user`` spellings; the v3
+    # name ``prompt.submitted`` is matched first, so this never silent-zeros.)
+    if "prompt.submitted" in et or et.endswith("user") \
             or (role == "user" and et in ("message", "text")):
         return "prompt"
 


### PR DESCRIPTION
## What

A new **Turn anatomy** dashboard surface (PRD P0-3) that decomposes a single agent **turn** into a waterfall of spans:

`prompt → model call(s) → each tool (start→end duration) → compaction → reply`

plus a persistent **stalled / long-running** indicator for sessions whose latest turn is stuck.

A *turn* = the events between consecutive `prompt.submitted` boundaries within a session.

## How

- **DuckDB-first, no new ingest.** Reads the OpenClaw events ClawMetry already ingests into the `events` table via the daemon read proxy (`local_store_via_daemon("query_events", ...)`) with a single-process read-only fallback — the same pattern as `routes/tracing.py` / `routes/scheduler.py`. No new daemon allowlist method (`query_events` is already allowlisted).
- **Both event shapes handled.** v3-normalized (`prompt.submitted` / `model.completed` / `tool_call` / `tool_result`) and the multi-runtime adapter shape (Claude Code / Codex `message` rows carrying the speaker in `data.role`). It's a display classifier, never a row-dropping filter, so it doesn't silent-zero on either shape.
- **Real tool durations.** Tool spans are reconstructed by joining a `tool_call`'s `tool_calls[].id` to the later `tool_result`'s `data.extra.toolUseId`, so a bar's width is the true tool wall-clock duration. Mixed ISO `ts` formats coerced to ms.
- **Never 500s.** Empty / unreadable store returns `available:false` or empty lists (HTTP 200).

### Endpoints (`routes/turn_anatomy.py`, `bp_turn_anatomy`)
- `GET /api/turn-anatomy?session_id=...` — ordered spans grouped per turn: `[{turn, duration_ms, prompt, tool_count, total_tokens, status, spans:[{kind, label, started_ms, ended_ms, duration_ms, tokens?, model?, status}]}]`
- `GET /api/turn-anatomy/stalled?min=N` — sessions whose latest turn has had no new event for > N min (default 5) and never reached a reply.

### UI
New **Turn anatomy** sub-item under the Live trace nav group. A session picker (reuses `/api/traces`) drills into a per-turn horizontal waterfall (bar width ∝ duration), with error highlighting and a persistent stalled banner. Inline styles + `var(--...)` theme tokens, no new deps.

## Verification (against real local DuckDB, no writer lock taken)

Read real events through the daemon read proxy (`~/.clawmetry/local_query.json`) and ran the span builder + routes against them:

- **Tool-heavy Claude Code session** (235 events) → 3 turns. Turn 1 spans: `prompt → model → tool(Read 9ms) → tool(Read 6ms) → model → reply`. Turn 2: 21 tools incl. a sub-agent `Agent` tool measured at 243.7s. Tool durations resolve correctly via the tool_use_id join.
- **v3-shape cron-fix session** (48 events, `prompt.submitted`/`model.completed`) → 11 turns with `prompt → model → reply` decomposition.
- **Stalled detector**: correctly flagged the cron-fix session (latest event was a mid-turn `model`, no reply) while the resolved tool-heavy session did not flag.
- Flask test-client checks (proxy monkeypatched to real captured events): missing `session_id` → 400; unreadable store → `available:false` HTTP 200; nonexistent session → empty turns HTTP 200.
- `python3 -m py_compile` and `python3 -m ruff check` clean on the new module; `node --check clawmetry/static/js/app.js` OK; `make lint-js` OK. (The `lint-daemon-allowlist` failures for `query_cache_metrics` / `query_channel_delivery_health` are pre-existing on `main` in `routes/usage.py` / `routes/channels.py`, untouched here.)

## Files
- `routes/turn_anatomy.py` (new) — `bp_turn_anatomy`, span/turn builder + stalled detector
- `dashboard.py` — blueprint import + registration, nav item, tab include
- `clawmetry/templates/tabs/turn-anatomy.html` (new) — tab markup
- `clawmetry/static/js/app.js` — `loadTurnAnatomy()`, session picker, per-turn waterfall renderer, stalled banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)