### PR TITLE
feat(observability): tool-policy + sandbox + exec-approval audit (P1-1)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -442,6 +442,38 @@ _DDL = [
     "CREATE INDEX IF NOT EXISTS idx_run_ledger_runtime_status ON run_ledger(runtime, status)",
     "CREATE INDEX IF NOT EXISTS idx_run_ledger_parent ON run_ledger(parent_task_id)",
     "CREATE INDEX IF NOT EXISTS idx_run_ledger_last_event ON run_ledger(last_event_at)",
+    # PRD P1-1 (governance) — effective sandbox + tool-policy per agent.
+    # Mirrors `openclaw sandbox explain --json` (one row per agent_id): the
+    # sandbox mode (off/non-main/all), scope, workspace access, and the
+    # effective tool allow/deny lists. This is the authoritative answer to
+    # "which tools can this agent run, and where do they run." The daemon
+    # re-ingests on a slow cadence (config is near-static), upserting on
+    # agent_id. allow_json/deny_json are JSON-encoded string arrays so we
+    # don't drag a list type through DuckDB; sources_json keeps the
+    # provenance (which config key set each list) for the "why" column.
+    """
+    CREATE TABLE IF NOT EXISTS tool_policy (
+        agent_id              VARCHAR PRIMARY KEY,
+        node_id               VARCHAR,
+        session_key           VARCHAR,
+        sandbox_mode          VARCHAR,
+        sandbox_scope         VARCHAR,
+        workspace_access      VARCHAR,
+        workspace_root        VARCHAR,
+        session_is_sandboxed  BOOLEAN,
+        allow_json            VARCHAR,
+        deny_json             VARCHAR,
+        allow_count           INTEGER,
+        deny_count            INTEGER,
+        sources_json          VARCHAR,
+        elevated_enabled      BOOLEAN,
+        elevated_channel      VARCHAR,
+        elevated_allowed      BOOLEAN,
+        observed_at           BIGINT,
+        updated_at            BIGINT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_tool_policy_observed ON tool_policy(observed_at)",
     # Epic #1032 Phase 4 — approval queue. Authored locally when the policy
     # watcher fires on a tool-call, mirrored to the cloud cache via heartbeat
     # cache_push so the cloud Approvals inbox paints from cache, and resolved
@@ -2175,6 +2207,77 @@ class LocalStore:
                 f"INSERT INTO run_ledger ({cols}, updated_at) "
                 f"VALUES ({ph}, ?) "
                 f"ON CONFLICT (task_id) DO UPDATE SET {upd}, updated_at = excluded.updated_at",
+                [*vals, now_ms],
+            )
+
+    _TOOL_POLICY_COLS = (
+        "agent_id", "node_id", "session_key", "sandbox_mode", "sandbox_scope",
+        "workspace_access", "workspace_root", "session_is_sandboxed",
+        "allow_json", "deny_json", "allow_count", "deny_count", "sources_json",
+        "elevated_enabled", "elevated_channel", "elevated_allowed", "observed_at",
+    )
+
+    def ingest_tool_policy_row(self, r: dict[str, Any], *, node_id: str = "") -> None:
+        """Upsert one effective sandbox/tool-policy row (PRD P1-1 governance).
+
+        ``r`` is the (already flattened) shape produced from one
+        ``openclaw sandbox explain --json`` invocation — see
+        ``clawmetry/sync.py:_flatten_sandbox_explain``. Required: ``agent_id``.
+        Re-ingest overwrites the prior copy on ``agent_id`` (config is
+        near-static; the newest read is the source of truth). The tool
+        allow/deny lists arrive as Python lists and are JSON-encoded so we
+        don't drag a list type through DuckDB.
+
+        Never raises on a malformed list/dict — degrades to ``[]``/``{}`` so
+        the read-only-by-default contract holds (the daemon must not crash on
+        an unexpected CLI shape)."""
+        aid = r.get("agent_id")
+        if not aid:
+            raise ValueError("tool-policy row must include 'agent_id'")
+
+        def _txt(v: Any, n: int = 512) -> Any:
+            if v is None:
+                return None
+            s = str(v)
+            return s[:n] if len(s) > n else s
+
+        def _json_list(v: Any) -> tuple[str, int]:
+            items = v if isinstance(v, list) else []
+            try:
+                return json.dumps(items)[:60000], len(items)
+            except (TypeError, ValueError):
+                return "[]", 0
+
+        def _bool(v: Any) -> Any:
+            return bool(v) if v is not None else None
+
+        allow_json, allow_n = _json_list(r.get("allow"))
+        deny_json, deny_n = _json_list(r.get("deny"))
+        try:
+            sources_json = json.dumps(r.get("sources") or {})[:8000]
+        except (TypeError, ValueError):
+            sources_json = "{}"
+
+        vals = [
+            str(aid), node_id or None, _txt(r.get("session_key"), 256),
+            _txt(r.get("sandbox_mode"), 32), _txt(r.get("sandbox_scope"), 32),
+            _txt(r.get("workspace_access"), 64), _txt(r.get("workspace_root"), 1024),
+            _bool(r.get("session_is_sandboxed")), allow_json, deny_json,
+            allow_n, deny_n, sources_json, _bool(r.get("elevated_enabled")),
+            _txt(r.get("elevated_channel"), 64), _bool(r.get("elevated_allowed")),
+            int(r.get("observed_at") or int(time.time() * 1000)),
+        ]
+        now_ms = int(time.time() * 1000)
+        cols = ", ".join(self._TOOL_POLICY_COLS)
+        ph = ", ".join("?" for _ in self._TOOL_POLICY_COLS)
+        upd = ", ".join(
+            f"{c} = excluded.{c}" for c in self._TOOL_POLICY_COLS if c != "agent_id"
+        )
+        with self._write_lock:
+            self._conn.execute(
+                f"INSERT INTO tool_policy ({cols}, updated_at) "
+                f"VALUES ({ph}, ?) "
+                f"ON CONFLICT (agent_id) DO UPDATE SET {upd}, updated_at = excluded.updated_at",
                 [*vals, now_ms],
             )
 
@@ -4571,6 +4674,48 @@ class LocalStore:
         cols = ["lane", "total", "running", "queued", "succeeded",
                 "failed", "last_event_at"]
         return [dict(zip(cols, row)) for row in self._fetch(sql, [])]
+
+    def query_tool_policy(
+        self,
+        *,
+        agent_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Effective sandbox + tool-policy rows, one per agent (PRD P1-1).
+
+        Returns the per-agent sandbox mode, scope, workspace access and the
+        decoded tool ``allow`` / ``deny`` lists (parsed back from JSON so the
+        caller hands them straight to the API). ``sources`` provenance is
+        decoded the same way. Newest-observed first. Empty list (fresh sync /
+        OpenClaw without ``sandbox explain``) is a normal, non-error state."""
+        where: list[str] = []
+        params: list[Any] = []
+        if agent_id:
+            where.append("agent_id = ?")
+            params.append(agent_id)
+        clause = ("WHERE " + " AND ".join(where)) if where else ""
+        cols = list(self._TOOL_POLICY_COLS) + ["updated_at"]
+        sql = (
+            f"SELECT {', '.join(cols)} FROM tool_policy {clause} "
+            f"ORDER BY COALESCE(observed_at, 0) DESC, agent_id LIMIT ?"
+        )
+        params.append(int(limit))
+        out: list[dict[str, Any]] = []
+        for row in self._fetch(sql, params):
+            d = dict(zip(cols, row))
+            for jk, outk in (("allow_json", "allow"), ("deny_json", "deny")):
+                try:
+                    d[outk] = json.loads(d.get(jk) or "[]")
+                except (ValueError, TypeError):
+                    d[outk] = []
+                d.pop(jk, None)
+            try:
+                d["sources"] = json.loads(d.get("sources_json") or "{}")
+            except (ValueError, TypeError):
+                d["sources"] = {}
+            d.pop("sources_json", None)
+            out.append(d)
+        return out
 
     def query_channel_configs(
         self,

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -968,6 +968,7 @@ function switchTab(name) {
   if (name === 'selfevolve') loadSelfEvolvePage();
   if (name === 'notifications') { if (typeof loadNotificationsPage === 'function') loadNotificationsPage(); }
   if (name === 'security') { loadSecurityPage(); loadSecurityPosture(); }
+  if (name === 'policy') { if (typeof loadToolPolicy === 'function') loadToolPolicy(); }
   if (name === 'approvals') { if (typeof loadApprovalsTab === 'function') loadApprovalsTab(); }
   if (name === 'alerts') { if (typeof loadAlertsPage === 'function') loadAlertsPage(); }
   if (name === 'dives') { if (typeof loadDivesPage === 'function') loadDivesPage(); }
@@ -11467,6 +11468,118 @@ async function loadRunLedger() {
     el.innerHTML = laneHtml + runHtml;
   } catch(e) {
     el.innerHTML = '<div style="color:#e74c3c;font-size:13px;padding:16px;">Failed to load run ledger: '+escHtml(String(e))+'</div>';
+  }
+}
+
+// ── Tool Policy + Sandbox + exec-approval audit (governance, PRD P1-1) ──────
+// Renders per-agent effective sandbox mode + tool allow/deny (from
+// /api/tool-policy, mirrored from `openclaw sandbox explain --json`) plus the
+// exec-approval decision audit (from /api/approvals-audit). Answers: which
+// tools can run, where they run, and what got blocked/approved and why.
+async function loadToolPolicy() {
+  var sumEl = document.getElementById('tool-policy-summary');
+  var agEl = document.getElementById('tool-policy-agents');
+  var apEl = document.getElementById('approvals-audit-panel');
+  if (!agEl) return;
+  // ── Per-agent sandbox + tool policy ──
+  try {
+    var data = await fetch('/api/tool-policy?limit=50').then(function(r){ return r.json(); });
+    var agents = data.agents || [];
+    var s = data.summary || {};
+    if (sumEl) {
+      if (agents.length === 0) {
+        sumEl.innerHTML = '';
+      } else {
+        function chip(label, val, color){
+          return '<div style="border:1px solid var(--border-primary);border-radius:10px;padding:10px 14px;min-width:96px;">'
+            + '<div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">'+escHtml(label)+'</div>'
+            + '<div style="font-size:18px;font-weight:700;color:'+(color||'var(--text-primary)')+';margin-top:2px;">'+escHtml(String(val))+'</div></div>';
+        }
+        var modeColor = (s.strongest_mode && s.strongest_mode !== 'off') ? '#16a34a' : 'var(--text-muted)';
+        sumEl.innerHTML = '<div style="display:flex;gap:10px;flex-wrap:wrap;">'
+          + chip('Agents', s.agent_count || 0)
+          + chip('Sandboxed', (s.sandboxed_agents||0) + '/' + (s.agent_count||0), modeColor)
+          + chip('Strongest mode', s.strongest_mode || 'off', modeColor)
+          + chip('Tools allowed', s.total_allowed_tools || 0)
+          + chip('Tools denied', s.total_denied_tools || 0, '#ef4444')
+          + '</div>';
+      }
+    }
+    if (agents.length === 0) {
+      agEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;border:1px solid var(--border-primary);border-radius:10px;">No tool policy recorded yet. Per-agent sandbox mode and tool allow/deny lists appear here once the sync daemon reads OpenClaw’s effective policy.</div>';
+    } else {
+      function modePill(mode){
+        var m = {off:['#6b7280','var(--bg-secondary)'],'non-main':['#d97706','rgba(217,119,6,.12)'],nonmain:['#d97706','rgba(217,119,6,.12)'],all:['#16a34a','rgba(22,163,74,.12)']};
+        var c = m[mode] || ['#6b7280','var(--bg-secondary)'];
+        return '<span style="font-size:11px;font-weight:700;color:'+c[0]+';background:'+c[1]+';border-radius:5px;padding:2px 8px;">sandbox: '+escHtml(String(mode||'off'))+'</span>';
+      }
+      function toolTags(list, color, bg){
+        list = list || [];
+        if (list.length === 0) return '<span style="font-size:11px;color:var(--text-faint);">(none)</span>';
+        return list.map(function(t){
+          return '<span style="font-size:11px;color:'+color+';background:'+bg+';border-radius:4px;padding:1px 7px;margin:0 4px 4px 0;display:inline-block;">'+escHtml(String(t))+'</span>';
+        }).join('');
+      }
+      var html = '';
+      agents.forEach(function(a){
+        html += '<div style="border:1px solid var(--border-primary);border-radius:10px;padding:14px;margin-bottom:12px;">';
+        html += '<div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px;">';
+        html += '<span style="font-size:14px;font-weight:700;color:var(--text-primary);">' + escHtml(a.agent_id || 'main') + '</span>';
+        html += modePill(a.sandbox_mode);
+        if (a.sandbox_scope) html += '<span style="font-size:11px;color:var(--text-muted);">scope: '+escHtml(String(a.sandbox_scope))+'</span>';
+        if (a.workspace_access) html += '<span style="font-size:11px;color:var(--text-muted);">workspace: '+escHtml(String(a.workspace_access))+'</span>';
+        if (a.elevated_enabled) html += '<span style="font-size:11px;color:'+(a.elevated_allowed?'#16a34a':'var(--text-muted)')+';">elevated: '+(a.elevated_allowed?'allowed':'gated')+(a.elevated_channel?(' ('+escHtml(String(a.elevated_channel))+')'):'')+'</span>';
+        html += '</div>';
+        html += '<div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;">';
+        html += '<div><div style="font-size:11px;font-weight:700;color:#16a34a;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px;">Allowed ('+(a.allow_count!=null?a.allow_count:(a.allow||[]).length)+')</div>'+toolTags(a.allow,'#16a34a','rgba(22,163,74,.10)')+'</div>';
+        html += '<div><div style="font-size:11px;font-weight:700;color:#ef4444;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px;">Denied ('+(a.deny_count!=null?a.deny_count:(a.deny||[]).length)+')</div>'+toolTags(a.deny,'#ef4444','rgba(239,68,68,.10)')+'</div>';
+        html += '</div></div>';
+      });
+      agEl.innerHTML = html;
+    }
+  } catch(e) {
+    if (sumEl) sumEl.innerHTML = '';
+    agEl.innerHTML = '<div style="color:#e74c3c;font-size:13px;padding:16px;">Failed to load tool policy: '+escHtml(String(e))+'</div>';
+  }
+  // ── Exec-approval audit ──
+  if (!apEl) return;
+  try {
+    var ad = await fetch('/api/approvals-audit?limit=80').then(function(r){ return r.json(); });
+    var decisions = ad.decisions || [];
+    var as = ad.summary || {};
+    var head = '<div style="border:1px solid var(--border-primary);border-radius:10px;overflow:hidden;">';
+    head += '<div style="display:flex;align-items:center;gap:12px;font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;padding:12px 14px;border-bottom:1px solid var(--border-primary);">';
+    head += '<span style="flex:1;">Exec-approval audit</span>';
+    head += '<span style="color:#d97706;">'+(as.pending||0)+' pending</span>';
+    head += '<span style="color:#16a34a;">'+(as.approved||0)+' approved</span>';
+    head += '<span style="color:#ef4444;">'+(as.denied||0)+' denied</span>';
+    head += '</div>';
+    if (decisions.length === 0) {
+      apEl.innerHTML = head + '<div style="color:var(--text-muted);font-size:13px;padding:16px;">No exec-approval decisions recorded yet. When a tool-call hits a policy gate it appears here with its decision and reason.</div></div>';
+    } else {
+      function decPill(st){
+        var m = {pending:['#d97706','rgba(217,119,6,.12)'],approved:['#16a34a','rgba(22,163,74,.12)'],allowed:['#16a34a','rgba(22,163,74,.12)'],denied:['#ef4444','rgba(239,68,68,.12)'],blocked:['#ef4444','rgba(239,68,68,.12)']};
+        var c = m[st] || ['#6b7280','var(--bg-secondary)'];
+        return '<span style="font-size:10px;font-weight:700;color:'+c[0]+';background:'+c[1]+';border-radius:4px;padding:1px 6px;">'+escHtml(String(st||'?'))+'</span>';
+      }
+      var rows = head;
+      decisions.forEach(function(d){
+        rows += '<div style="padding:9px 14px;border-bottom:1px solid var(--border-secondary);font-size:12px;">';
+        rows += '<div style="display:flex;align-items:center;gap:10px;">';
+        rows += decPill(d.status);
+        rows += '<span style="font-weight:600;color:var(--text-primary);">'+escHtml(String(d.action||'tool-call'))+'</span>';
+        if (d.args_preview) rows += '<span style="flex:1;color:var(--text-muted);font-family:monospace;font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="'+escHtml(String(d.args_preview))+'">'+escHtml(String(d.args_preview))+'</span>';
+        else rows += '<span style="flex:1;"></span>';
+        if (d.resolver) rows += '<span style="font-size:11px;color:var(--text-faint);">by '+escHtml(String(d.resolver))+'</span>';
+        rows += '</div>';
+        if (d.decision_reason) rows += '<div style="margin-top:3px;color:var(--text-muted);font-size:11px;">'+escHtml(String(d.decision_reason))+'</div>';
+        rows += '</div>';
+      });
+      rows += '</div>';
+      apEl.innerHTML = rows;
+    }
+  } catch(e) {
+    apEl.innerHTML = '<div style="color:#e74c3c;font-size:13px;padding:16px;">Failed to load approval audit: '+escHtml(String(e))+'</div>';
   }
 }
 

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -26,6 +26,7 @@
   "nav.advanced": "Advanced",
   "nav.notifications": "Notifications",
   "nav.security": "Security",
+  "nav.tool_policy": "Tool Policy",
   "nav.skills": "Skills",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "Version impact",

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7405,6 +7405,136 @@ def sync_run_ledger(config: dict, state: dict, paths: dict) -> int:
     return n
 
 
+def _openclaw_agent_ids() -> list[str]:
+    """Enumerate OpenClaw agent ids to inspect for tool policy.
+
+    Each agent has a dir under ``~/.openclaw/agents/<id>/``. ``main`` always
+    exists; we read the directory so multi-agent installs are covered. Falls
+    back to ``["main"]`` if the dir is missing/unreadable (read-only contract:
+    never crash, always return at least the default agent)."""
+    ids: list[str] = []
+    try:
+        agents_dir = Path(_get_openclaw_dir()) / "agents"
+        if agents_dir.is_dir():
+            for p in sorted(agents_dir.iterdir()):
+                if p.is_dir() and not p.name.startswith("."):
+                    ids.append(p.name)
+    except Exception as e:  # noqa: BLE001
+        log.debug("_openclaw_agent_ids: enumerate failed: %s", e)
+    if "main" not in ids:
+        ids.insert(0, "main")
+    return ids[:25]  # bound the fan-out — pathological installs only
+
+
+def _flatten_sandbox_explain(d: dict, agent_id: str) -> dict | None:
+    """Flatten one ``openclaw sandbox explain --json`` payload into the row
+    shape ``LocalStore.ingest_tool_policy_row`` expects. Returns None if the
+    payload has no ``sandbox`` block (nothing useful to store)."""
+    if not isinstance(d, dict):
+        return None
+    sb = d.get("sandbox")
+    if not isinstance(sb, dict):
+        return None
+    tools = sb.get("tools") if isinstance(sb.get("tools"), dict) else {}
+    elev = d.get("elevated") if isinstance(d.get("elevated"), dict) else {}
+    allow = tools.get("allow") if isinstance(tools.get("allow"), list) else []
+    deny = tools.get("deny") if isinstance(tools.get("deny"), list) else []
+    return {
+        "agent_id": d.get("agentId") or agent_id,
+        "session_key": d.get("sessionKey"),
+        "sandbox_mode": sb.get("mode"),
+        "sandbox_scope": sb.get("scope"),
+        "workspace_access": sb.get("workspaceAccess"),
+        "workspace_root": sb.get("workspaceRoot"),
+        "session_is_sandboxed": sb.get("sessionIsSandboxed"),
+        "allow": allow,
+        "deny": deny,
+        "sources": tools.get("sources") if isinstance(tools.get("sources"), dict) else {},
+        "elevated_enabled": elev.get("enabled"),
+        "elevated_channel": elev.get("channel"),
+        "elevated_allowed": elev.get("allowedByConfig"),
+        "observed_at": int(time.time() * 1000),
+    }
+
+
+def sync_tool_policy(config: dict, state: dict, paths: dict) -> int:
+    """Mirror OpenClaw's effective sandbox + tool policy into the DuckDB
+    ``tool_policy`` table (PRD P1-1 governance).
+
+    For each agent we shell out to ``openclaw sandbox explain --agent <id>
+    --json`` — OpenClaw's own CLI, which works on its OWN credentials and so
+    does NOT need the (scope-less) ClawMetry gateway token. The daemon's
+    launchd PATH lacks ``node``, so we augment PATH with the usual Homebrew /
+    local install dirs (same escape hatch as ``run_openclaw_cron`` /
+    Self-Evolve). One row per agent, upserted on ``agent_id``.
+
+    Degrades silently: CLI missing, timeout, non-zero exit, or malformed JSON
+    each skip that agent rather than raising (read-only-by-default). Returns
+    the number of agent rows ingested."""
+    binp = _resolve_openclaw_bin()
+    if not binp:
+        log.debug("sync_tool_policy: openclaw CLI not found; skipping")
+        return 0
+    try:
+        from clawmetry import local_store as _ls
+    except Exception as e:  # noqa: BLE001
+        log.debug("sync_tool_policy: local_store unavailable: %s", e)
+        return 0
+
+    env = dict(os.environ)
+    env["PATH"] = os.pathsep.join([
+        os.path.dirname(binp), "/opt/homebrew/bin", "/usr/local/bin",
+        os.path.expanduser("~/.local/bin"),
+        env.get("PATH", "/usr/bin:/bin"),
+    ])
+    node_id = config.get("node_id", "") if isinstance(config, dict) else ""
+
+    try:
+        store = _ls.get_store()
+    except Exception as e:  # noqa: BLE001
+        log.debug("sync_tool_policy: get_store failed: %s", e)
+        return 0
+
+    n = 0
+    for aid in _openclaw_agent_ids():
+        try:
+            proc = subprocess.run(
+                [binp, "sandbox", "explain", "--agent", aid, "--json"],
+                capture_output=True, text=True, timeout=20, env=env,
+            )
+        except subprocess.TimeoutExpired:
+            log.debug("sync_tool_policy: explain %s timed out", aid)
+            continue
+        except Exception as e:  # noqa: BLE001
+            log.debug("sync_tool_policy: explain %s failed: %s", aid, e)
+            continue
+        if proc.returncode != 0:
+            log.debug("sync_tool_policy: explain %s rc=%s", aid, proc.returncode)
+            continue
+        try:
+            payload = json.loads(proc.stdout.strip())
+        except Exception:
+            import re as _re
+            m = _re.search(r"\{.*\}", proc.stdout, _re.DOTALL)
+            if not m:
+                continue
+            try:
+                payload = json.loads(m.group(0))
+            except Exception:
+                continue
+        row = _flatten_sandbox_explain(payload, aid)
+        if not row:
+            continue
+        try:
+            store.ingest_tool_policy_row(row, node_id=node_id)
+            n += 1
+        except Exception as e_in:  # noqa: BLE001
+            log.debug("sync_tool_policy: ingest skipped for %s: %s", aid, e_in)
+    if n:
+        log.debug("sync_tool_policy: ingested %d agent rows", n)
+    return n
+
+
 def sync_session_metadata(config: dict, state: dict = None) -> int:
     """Sync OpenClaw session metadata rows to cloud sessions table.
 
@@ -10419,6 +10549,36 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     except Exception as _e_rl:
         log.debug("snapshot: run_ledger slice failed: %s", _e_rl)
 
+    # Effective sandbox + tool policy per agent (PRD P1-1 governance) →
+    # bounded snapshot slice for the cloud Tool Policy tab. One small row per
+    # agent (allow/deny lists are short tool-name arrays, capped here so a
+    # pathological config can't bloat the shared snapshot).
+    tool_policy_slice: list[dict] = []
+    try:
+        from clawmetry import local_store as _ls_tp
+        _tp_store = _ls_tp.get_store()
+        if _tp_store is not None:
+            for r in (_tp_store.query_tool_policy(limit=25) or []):
+                allow = r.get("allow") if isinstance(r.get("allow"), list) else []
+                deny = r.get("deny") if isinstance(r.get("deny"), list) else []
+                tool_policy_slice.append({
+                    "agent_id": r.get("agent_id"),
+                    "sandbox_mode": r.get("sandbox_mode"),
+                    "sandbox_scope": r.get("sandbox_scope"),
+                    "workspace_access": r.get("workspace_access"),
+                    "session_is_sandboxed": r.get("session_is_sandboxed"),
+                    "allow": allow[:80],
+                    "deny": deny[:80],
+                    "allow_count": r.get("allow_count"),
+                    "deny_count": r.get("deny_count"),
+                    "elevated_enabled": r.get("elevated_enabled"),
+                    "elevated_channel": r.get("elevated_channel"),
+                    "elevated_allowed": r.get("elevated_allowed"),
+                    "observed_at": r.get("observed_at"),
+                })
+    except Exception as _e_tp:
+        log.debug("snapshot: tool_policy slice failed: %s", _e_tp)
+
     payload = {
         "system": system,
         "infra": infra,
@@ -10444,6 +10604,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         },
         "totalActive": active_count,
         "runLedger": run_ledger_slice,
+        "toolPolicy": tool_policy_slice,
         "spending": spending,
         "cronJobs": _build_cron_jobs(paths),
         "channels": _build_channel_data(config),
@@ -11028,6 +11189,15 @@ def run_daemon() -> None:
             log.info(f"  Run ledger: {rl} rows ingested")
     except Exception as e:
         log.warning(f"  Run-ledger ingest error: {e}")
+    # Effective sandbox + tool policy per agent (PRD P1-1 governance) →
+    # DuckDB tool_policy. Feeds the Tool Policy tab. Near-static config;
+    # re-synced on a slow cadence in the steady-state loop below.
+    try:
+        tp = sync_tool_policy(config, state, paths)
+        if tp:
+            log.info(f"  Tool policy: {tp} agent rows ingested")
+    except Exception as e:
+        log.warning(f"  Tool-policy ingest error: {e}")
     # Sync today's log lines immediately so Brain tab shows the most recent
     # activity right away — older log history is backfilled later
     try:
@@ -11193,6 +11363,10 @@ def run_daemon() -> None:
     heartbeat_interval = _pick_heartbeat_interval(_LAST_HEARTBEAT_RESPONSE)
     snapshot_interval = 60  # system snapshot (subagents, flow metrics) every 60s
     log_sync_interval = 60  # log lines are low-priority; streamer covers real-time
+    tool_policy_interval = 300  # sandbox/tool policy is near-static; refresh slowly
+    last_tool_policy = (
+        time.time()
+    )  # already synced at startup; next run after tool_policy_interval
     family_interval = 60  # PicoClaw/NanoClaw ingest; cheap when absent, throttled when present
     last_family = 0  # force first family-runtime ingest immediately
     last_heartbeat = time.time()
@@ -11328,6 +11502,18 @@ def run_daemon() -> None:
                 sync_run_ledger(config, state, paths)
             except Exception as _e_rl:
                 log.debug("sync_run_ledger error (non-fatal): %s", _e_rl)
+
+            # Effective sandbox + tool policy per agent (PRD P1-1) → DuckDB
+            # tool_policy. Throttled — config is near-static and each agent is
+            # a CLI shell-out, so we refresh every tool_policy_interval, not
+            # every loop tick.
+            now_tp = time.time()
+            if now_tp - last_tool_policy > tool_policy_interval:
+                try:
+                    sync_tool_policy(config, state, paths)
+                except Exception as _e_tp:
+                    log.debug("sync_tool_policy error (non-fatal): %s", _e_tp)
+                last_tool_policy = now_tp
 
             # ── Low-priority: log lines (real-time covered by streamer) ──
             lg = 0

--- a/clawmetry/templates/tabs/policy.html
+++ b/clawmetry/templates/tabs/policy.html
@@ -1,0 +1,18 @@
+<div class="page" id="page-policy">
+  <div class="refresh-bar">
+    <h2 style="font-size:16px;font-weight:700;color:var(--text-primary);margin:0;flex:1;">&#128274; Tool Policy &amp; Sandbox</h2>
+    <button class="refresh-btn" onclick="loadToolPolicy()">&#8635; Refresh</button>
+  </div>
+  <!-- Governance surface (PRD P1-1): which tools each agent can run, where
+       they run (sandbox mode + workspace access), and what got approved or
+       blocked. Per-agent policy comes from /api/tool-policy (mirrored from
+       `openclaw sandbox explain --json`); the exec-approval audit comes from
+       /api/approvals-audit. Both render via loadToolPolicy(). -->
+  <div id="tool-policy-summary" style="margin-bottom:14px;"></div>
+  <div id="tool-policy-agents">
+    <div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading tool policy&hellip;</div>
+  </div>
+  <div id="approvals-audit-panel" style="margin-top:18px;">
+    <div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading approval audit&hellip;</div>
+  </div>
+</div><!-- end page-policy -->

--- a/dashboard.py
+++ b/dashboard.py
@@ -122,6 +122,7 @@ from routes.review import bp_review
 from routes.evals import bp_evals
 from routes.dives import bp_dives
 from routes.scheduler import bp_scheduler
+from routes.policy import bp_policy
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -10619,6 +10620,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_local_query)
     app.register_blueprint(bp_dives)
     app.register_blueprint(bp_scheduler)
+    app.register_blueprint(bp_policy)
 
     # Register built-in agent adapters. External plugins can register more
     # via clawmetry.extensions entry points — see clawmetry/adapters/.
@@ -11116,6 +11118,9 @@ DASHBOARD_HTML = r"""
       <div class="left-nav-item left-nav-item-sub" data-tab="security" onclick="switchTab('security')">
         <span class="left-nav-label" data-i18n="nav.security">Security</span>
       </div>
+      <div class="left-nav-item left-nav-item-sub" data-tab="policy" onclick="switchTab('policy')" title="Which tools each agent can run, where they run, and what got approved or blocked">
+        <span class="left-nav-label" data-i18n="nav.tool_policy">Tool Policy</span>
+      </div>
       <div class="left-nav-item left-nav-item-sub" data-tab="skills" onclick="switchTab('skills')">
         <span class="left-nav-label" data-i18n="nav.skills">Skills</span>
       </div>
@@ -11194,6 +11199,9 @@ DASHBOARD_HTML = r"""
 
 <!-- SECURITY -->
 {% include 'tabs/security.html' %}
+
+<!-- TOOL POLICY + SANDBOX + EXEC-APPROVAL AUDIT (governance, PRD P1-1) -->
+{% include 'tabs/policy.html' %}
 
 <!-- APPROVALS — cloud-mediated approval queue (#667) -->
 {% include 'tabs/approvals.html' %}

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -421,6 +421,10 @@ _DAEMON_METHODS = frozenset({
     # monitor + sub-agent fan-out tree + cron run log off one source.
     "query_run_ledger",
     "query_run_ledger_lanes",
+    # PRD P1-1 (governance): effective sandbox + tool policy per agent,
+    # mirrored from `openclaw sandbox explain --json`. Powers the Tool Policy
+    # tab (routes/policy.py:/api/tool-policy). Read-only; daemon owns writer.
+    "query_tool_policy",
     # Issue #1597: parent session tool-timeline rollup needs to merge in
     # events from every child sub-agent session (the events table has no
     # parent_session_id column; the link lives on the subagents table). The

--- a/routes/policy.py
+++ b/routes/policy.py
@@ -1,0 +1,174 @@
+"""routes/policy.py — tool-policy + sandbox + exec-approval audit (PRD P1-1).
+
+This is the governance surface (our moat): "which tools can run, where they
+run, and what got blocked/approved and why."
+
+Two read-only endpoints, both backed by DuckDB through the daemon proxy
+(the daemon owns the writer lock) with a single-process direct-read fallback
+— the same ``_ls_call`` pattern as ``routes/agents.py`` / ``routes/scheduler.py``:
+
+  GET /api/tool-policy      — per-agent effective sandbox mode + tool
+                              allow/deny, mirrored from
+                              ``openclaw sandbox explain --json``
+                              (``clawmetry/sync.py:sync_tool_policy``).
+  GET /api/approvals-audit  — exec-approval decisions (approved / denied /
+                              pending) from the approvals table, summarised
+                              into a decision rollup + recent decisions feed.
+
+Neither endpoint ever 500s on empty data: a fresh sync, an OpenClaw build
+without ``sandbox explain``, or a daemon mid-restart all return empty lists so
+the tab paints an honest "nothing recorded yet" state.
+"""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+bp_policy = Blueprint("policy", __name__)
+
+
+def _ls_call(method_name: str, **kwargs):
+    """Cross-process LocalStore call with single-process fallback (issue #1088)."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+def _coerce_rows(rows) -> list[dict]:
+    """``local_store_via_daemon`` returns the raw method result (a list) or a
+    ``{"result": [...]}`` / ``{"rows": [...]}`` envelope depending on transport
+    — normalise both to a plain list."""
+    if isinstance(rows, dict):
+        rows = rows.get("result") or rows.get("rows") or []
+    return rows if isinstance(rows, list) else []
+
+
+@bp_policy.route("/api/tool-policy")
+def api_tool_policy():
+    """Per-agent effective sandbox mode + tool allow/deny.
+
+    Returns ``{agents:[...], summary:{...}, _source}``. Each agent row carries
+    the sandbox mode (``off`` / ``non-main`` / ``all``), scope, workspace
+    access, and the effective tool ``allow`` / ``deny`` lists with their
+    config provenance (``sources``). The summary rolls up how many agents are
+    sandboxed and the most-restricted mode seen, so the UI can show a
+    one-glance governance posture chip.
+
+    Query params: ``agent_id`` (filter to one agent), ``limit`` (<=100).
+    """
+    try:
+        limit = max(1, min(100, int(request.args.get("limit", 50))))
+    except (TypeError, ValueError):
+        limit = 50
+    agent_id = (request.args.get("agent_id") or "").strip() or None
+
+    agents = _coerce_rows(_ls_call("query_tool_policy", agent_id=agent_id, limit=limit))
+
+    # Governance posture rollup. ``mode`` ordering: all > non-main > off
+    # (most → least restrictive). We surface the most-restrictive mode in use
+    # plus how many agents run with a non-off sandbox.
+    _MODE_RANK = {"all": 3, "non-main": 2, "nonmain": 2, "off": 1}
+    sandboxed = 0
+    strongest = None
+    strongest_rank = 0
+    total_allow = 0
+    total_deny = 0
+    for a in agents:
+        mode = (a.get("sandbox_mode") or "off")
+        if mode and mode != "off":
+            sandboxed += 1
+        rank = _MODE_RANK.get(str(mode), 0)
+        if rank > strongest_rank:
+            strongest_rank = rank
+            strongest = mode
+        total_allow += int(a.get("allow_count") or 0)
+        total_deny += int(a.get("deny_count") or 0)
+
+    summary = {
+        "agent_count": len(agents),
+        "sandboxed_agents": sandboxed,
+        "strongest_mode": strongest or ("off" if agents else None),
+        "total_allowed_tools": total_allow,
+        "total_denied_tools": total_deny,
+    }
+    return jsonify({"agents": agents, "summary": summary, "_source": "local_store"})
+
+
+@bp_policy.route("/api/approvals-audit")
+def api_approvals_audit():
+    """Exec-approval decision audit — what got approved / denied / is pending.
+
+    Returns ``{decisions:[...], summary:{...}, _source}``. Each decision row is
+    a normalised slice of an approvals-table row (the heavy ``args`` BLOB is
+    reduced to a short preview so the audit feed can't bloat). The summary
+    counts pending / approved / denied so the UI can render a posture bar.
+
+    Query params: ``status`` (filter), ``limit`` (<=300).
+    """
+    try:
+        limit = max(1, min(300, int(request.args.get("limit", 100))))
+    except (TypeError, ValueError):
+        limit = 100
+    status = (request.args.get("status") or "").strip() or None
+
+    rows = _coerce_rows(_ls_call("query_approvals", status=status, limit=limit))
+
+    def _arg_preview(args) -> str:
+        """A short, single-line preview of the tool-call arguments — never the
+        full body (avoids snapshot/response bloat)."""
+        if args is None:
+            return ""
+        if isinstance(args, dict):
+            # exec-style calls usually carry a command; surface it first.
+            for k in ("command", "cmd", "tool", "path", "url"):
+                v = args.get(k)
+                if v:
+                    return str(v)[:160]
+            try:
+                import json as _json
+                return _json.dumps(args, separators=(",", ":"))[:160]
+            except Exception:
+                return str(args)[:160]
+        return str(args)[:160]
+
+    decisions = []
+    pending = approved = denied = 0
+    for r in rows:
+        st = (r.get("status") or "pending")
+        dec = (r.get("decision") or "")
+        if st == "pending":
+            pending += 1
+        elif st in ("approved", "allow", "allowed") or dec in ("approve", "allow"):
+            approved += 1
+        elif st in ("denied", "deny", "blocked", "rejected") or dec in ("deny", "block"):
+            denied += 1
+        decisions.append({
+            "id": r.get("id"),
+            "action": r.get("action"),
+            "args_preview": _arg_preview(r.get("args")),
+            "status": st,
+            "decision": dec or None,
+            "decision_reason": (str(r.get("decision_reason"))[:300]
+                                if r.get("decision_reason") else None),
+            "resolver": r.get("resolver"),
+            "requestor_session_id": r.get("requestor_session_id"),
+            "created_at": r.get("created_at"),
+            "resolved_at": r.get("resolved_at"),
+        })
+
+    summary = {
+        "total": len(decisions),
+        "pending": pending,
+        "approved": approved,
+        "denied": denied,
+    }
+    return jsonify({"decisions": decisions, "summary": summary, "_source": "local_store"})


### PR DESCRIPTION
## What

Adds a v1 **governance** surface (PRD P1-1, our moat): visualise OpenClaw's
**sandbox + tool policy + exec-approvals** — *which tools each agent can run,
where they run, and what got blocked/approved and why.*

A new **Tool Policy** tab (under the Advanced drawer) shows:
- **Per-agent sandbox posture** — sandbox mode (`off` / `non-main` / `all`),
  scope, workspace access, elevated-tool gating, and a one-glance summary
  (sandboxed agents, strongest mode in use, total allowed/denied tools).
- **Effective tool allow/deny** per agent, rendered as colour-coded tag lists.
- **Exec-approval audit** — recent approval decisions (approved / denied /
  pending) with the tool action, a short args preview, resolver, and the
  decision reason.

## Data path (no-scope, DuckDB-first)

The ClawMetry gateway WS token grants **zero scopes**, so gateway RPCs are
blocked. This reads OpenClaw's own CLI instead:

- The sync daemon shells out to `openclaw sandbox explain --agent <id> --json`
  (works on OpenClaw's **own** creds; PATH augmented for the launchd `node`
  lookup, the same escape hatch Self-Evolve and cron writes use) and mirrors
  the effective sandbox mode + tool allow/deny into a new DuckDB `tool_policy`
  table.
- The exec-approval audit reads the existing `approvals` table.

## How (mirrors the shipped run-ledger slice exactly)

- **Store** (`clawmetry/local_store.py`): additive `tool_policy` DDL (no
  version bump), `ingest_tool_policy_row`, `query_tool_policy`.
- **Sync** (`clawmetry/sync.py`): `sync_tool_policy` + `_flatten_sandbox_explain`,
  wired into the daemon initial pass + a throttled (5 min) steady-state call
  (config is near-static).
- **Snapshot**: bounded `toolPolicy` slice (allow/deny capped) in
  `sync_system_snapshot`.
- **Route** (`routes/policy.py`, `bp_policy`): `GET /api/tool-policy` +
  `GET /api/approvals-audit` via the `_ls_call` daemon-proxy + direct-read
  fallback pattern. Neither endpoint ever 500s on empty data.
- **Allowlist**: `query_tool_policy` added to `_DAEMON_METHODS`.
- **UI**: `tabs/policy.html` + `loadToolPolicy()` + nav entry + `switchTab`
  wiring + `nav.tool_policy` English i18n key.

## Verification (no prod-DuckDB risk)

All against a temp `LocalStore(read_only=False)` on an isolated path — the
production writer was never touched.

- **Live source**: `openclaw sandbox explain --agent main --json` returns
  `sandbox.mode=off`, 14 allowed tools, 29 denied — ingested live via
  `sync_tool_policy` and read back correctly.
- **Store**: ingest + query proved shape, multi-agent, upsert-on-`agent_id`,
  JSON allow/deny/sources decode, `agent_id` filter.
- **Routes** (Flask test client, proxy monkeypatched to the temp store):
  `/api/tool-policy` and `/api/approvals-audit` return correct rollups;
  empty-data returns **200** with empty lists (no 500); proxy-down falls back
  cleanly.
- `python3 -m py_compile` (all changed `.py`) + `node --check app.js` green.

## Files

- `clawmetry/local_store.py`, `clawmetry/sync.py`, `routes/local_query.py`,
  `routes/policy.py` (new), `dashboard.py`, `clawmetry/static/js/app.js`,
  `clawmetry/static/locales/en.json`, `clawmetry/templates/tabs/policy.html` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
