### PR TITLE
fix(install): upgrade in place — never `rm -rf ~/.clawmetry` (data-loss + crash)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -184,7 +184,9 @@ fi
 
 # ── Install into venv ────────────────────────────────────────────────────────
 
-# Preserve config before wiping venv (contains node_id, encryption_key)
+# Back up config (node_id, encryption_key) as a belt-and-suspenders guard —
+# the in-place upgrade below preserves it, but keep a copy in case a future
+# change reintroduces a venv rebuild.
 _CM_CFG_BAK=""
 if [ -f "$INSTALL_DIR/config.json" ]; then
   _CM_CFG_BAK=$(mktemp)
@@ -193,7 +195,34 @@ elif [ -f "$HOME/.clawmetry/config.json" ] && [ "$INSTALL_DIR" = "$HOME/.clawmet
   _CM_CFG_BAK=$(mktemp)
   cp "$HOME/.clawmetry/config.json" "$_CM_CFG_BAK"
 fi
-$USE_SUDO rm -rf "$INSTALL_DIR"
+
+# Upgrade in place when a venv already exists — do NOT `rm -rf "$INSTALL_DIR"`.
+# That directory also holds the user's DuckDB store (~/.clawmetry/clawmetry.duckdb),
+# config.json, sync.pid and the LIVE sync daemon's working files. A blanket wipe
+# (a) silently destroys local history on every upgrade, and (b) races the running
+# daemon, which keeps recreating DuckDB WAL/tmp files mid-delete so the final
+# rmdir fails with "Directory not empty" and `set -e` aborts the whole install.
+# Reported 2026-05-25 (curl … | bash on a machine with an active daemon: pid 9316).
+_venv_exists=0
+_CM_STASH=""
+if [ -x "$INSTALL_DIR/bin/python3" ] && [ -f "$INSTALL_DIR/pyvenv.cfg" ]; then
+  _venv_exists=1
+elif [ -d "$INSTALL_DIR" ] && [ -n "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
+  # Dir present but no valid venv (stale/partial — e.g. a previous installer
+  # interrupted mid-wipe). We must recreate the venv WITHOUT destroying the
+  # co-located data (config.json, the DuckDB store, sync-state.json, logs) that
+  # shares INSTALL_DIR. `uv venv` refuses a non-empty target, so stash the
+  # non-venv files aside, create the venv into a now-clean dir, and restore them
+  # below. Stale venv subdirs are dropped, not stashed.
+  _CM_STASH=$(mktemp -d)
+  ( shopt -s dotglob nullglob
+    for _e in "$INSTALL_DIR"/*; do
+      case "$(basename "$_e")" in
+        bin|lib|lib64|include|share|pyvenv.cfg) $USE_SUDO rm -rf "$_e" 2>/dev/null || true ;;
+        *) $USE_SUDO mv "$_e" "$_CM_STASH/" 2>/dev/null || true ;;
+      esac
+    done )
+fi
 
 # Try `uv` (Astral's Rust-based pip replacement) for ~5x faster installs.
 # Bootstrap a copy if missing; on any failure, silently fall back to pip so
@@ -214,8 +243,10 @@ if command -v uv >/dev/null 2>&1; then
   # Estimates from observed timings on PyPI cold-cache + Apple Silicon /
   # mid-range Linux. uv handles the heavy lifting; --quiet suppresses uv's
   # native progress bar so OUR spinner is the only thing on screen.
-  _step "Creating virtual environment (uv)" 2 \
-    $USE_SUDO "$_UV_BIN" venv "$INSTALL_DIR" --quiet
+  if [ "$_venv_exists" = "0" ]; then
+    _step "Creating virtual environment (uv)" 2 \
+      $USE_SUDO "$_UV_BIN" venv "$INSTALL_DIR" --quiet
+  fi
   # --refresh forces uv to re-fetch the PyPI index even if a cached copy
   # exists. Without this, running install.sh seconds after a [RELEASE]
   # auto-publish silently no-ops ("already at latest" against a stale
@@ -227,12 +258,22 @@ if command -v uv >/dev/null 2>&1; then
 else
   # pip path is much slower (~30s for the install alone) — make sure the
   # spinner conveys that so users don't think the script is wedged.
-  _step "Bootstrapping pip fallback venv" 5 \
-    $USE_SUDO python3 -m venv "$INSTALL_DIR"
+  if [ "$_venv_exists" = "0" ]; then
+    _step "Bootstrapping pip fallback venv" 5 \
+      $USE_SUDO python3 -m venv "$INSTALL_DIR"
+  fi
   _step "Upgrading pip" 5 \
     $USE_SUDO "$INSTALL_DIR/bin/pip" install --upgrade pip
   _step "Installing clawmetry from PyPI (pip)" 30 \
     $USE_SUDO "$INSTALL_DIR/bin/pip" install --no-cache-dir --upgrade clawmetry
+fi
+
+# Restore data files stashed aside for the venv rebuild (DuckDB store, config,
+# sync-state, logs) back into the freshly-created venv dir. (See stash above.)
+if [ -n "$_CM_STASH" ] && [ -d "$_CM_STASH" ]; then
+  ( shopt -s dotglob nullglob
+    for _e in "$_CM_STASH"/*; do $USE_SUDO mv "$_e" "$INSTALL_DIR/" 2>/dev/null || true; done )
+  rmdir "$_CM_STASH" 2>/dev/null || $USE_SUDO rm -rf "$_CM_STASH" 2>/dev/null || true
 fi
 
 # Restore config if it was backed up


### PR DESCRIPTION
## The bug

A user ran `curl -fsSL https://clawmetry.com/install.sh | bash` and it **failed**:

```
↻ Detected 1 existing clawmetry process(es) — will restart after upgrade:
    pid 9316: /Users/vivek/.clawmetry/bin/python3 -m clawmetry.sync
→ Detected macOS
rm: /Users/vivek/.clawmetry: Directory not empty
```

`set -e` then aborted the whole script, leaving a half-wiped install (no venv, dashboard down).

## Root cause

`~/.clawmetry` is **both the venv and the data dir** — it holds the DuckDB store (`clawmetry.duckdb`, the user's entire local history) and `config.json` (node_id + E2E `encryption_key`). The installer ran an unconditional `rm -rf "$INSTALL_DIR"` before recreating the venv. Two failures:

1. **Silent data loss on every upgrade.** Only `config.json` was backed up/restored; `clawmetry.duckdb` (was 423 MB on the reporting machine) was destroyed every time.
2. **The crash is a race.** The pre-flight *detects* the running daemon but only signals the kill at the **end** of the script. So `rm -rf` runs while the daemon is still writing `clawmetry.duckdb.wal` into that dir → rm deletes contents, daemon recreates the WAL, final `rmdir` finds a non-empty dir → `Directory not empty` → `set -e` aborts.

On the reporting machine the `rm` got far enough to unlink the 423 MB DuckDB **and** `config.json` (node_id + encryption key) before dying — the daemon survived only on deleted-but-open inodes.

## The fix

Update in place; never wipe the data dir:

- **Valid venv present** → skip venv creation, just `uv/pip install --upgrade` (DuckDB + config untouched). *This is the "it should just update if already installed" path.*
- **Venv missing/partial but data present** → stash the non-venv files aside, recreate the venv into a clean dir (keeps uv's Python 3.11), then restore the data. No data loss even on a full rebuild.
- **Fresh install** (empty/absent dir) → unchanged fast `uv venv` path.

## Verification

Reproduced and repaired the exact failing machine end to end:
- Recovered `config.json` from the pre-`rm` `mktemp` backup (the restore step never ran because the script aborted), so node_id + encryption_key were preserved.
- Ran the fixed installer → it exercised the new stash/rebuild path, rebuilt the venv (Python 3.11.15), restored all data.
- Daemon back up under launchd, DuckDB actively re-ingesting, dashboard `HTTP 200`, **same node_id + encryption_key** (cloud history still decryptable).
- `bash -n` + `shellcheck -S error` clean.

## Deploy note

`clawmetry.com/install.sh` live-fetches this file from `main` (no-cache), so **merging to `main` deploys immediately**. Not a `[RELEASE]` (install.sh isn't in the PyPI wheel). The landing repo's fallback copy (used only on a raw-fetch timeout) has the same bug and will be fixed in a separate landing PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)