### PR TITLE
feat(dives): cloud Dives via heartbeat relay + graceful local fallback

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5725,6 +5725,7 @@ _PENDING_ACTIONS = frozenset({
     "cron_action",
     "cron_killall",
     "cron_fix",
+    "dives_query",
 })
 
 
@@ -5927,6 +5928,9 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
         return
     if atype == "cron_fix":
         _action_cron_fix(config, action)
+        return
+    if atype == "dives_query":
+        _action_dives_query(config, action)
         return
 
 
@@ -6168,6 +6172,88 @@ def _action_cron_create(config: dict, action: dict) -> None:
             )
         except Exception as e:
             log.warning("cron_create cache post failed: %s", e)
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def _action_dives_query(config: dict, action: dict) -> None:
+    """Cloud-relayed Dives NL-to-SQL query (the cloud Dives "Run" button).
+
+    The cloud server has no DuckDB and cannot decrypt the snapshot, so it can't
+    run arbitrary SQL. It enqueues a ``dives_query`` action on the
+    heartbeat-piggyback relay; this daemon runs the NL->SQL + query LOCALLY on
+    its OWN DuckDB writer handle (``local_store.get_store()`` — never a
+    ``read_only=True`` re-open, which would brick the writer lock, flywheel
+    #1771) and posts the E2E-encrypted ``{sql, chart_spec, rows}`` result to
+    ``/ingest/cache`` under the action's ``cache_key`` for the browser to poll +
+    decrypt. Runs in a background thread so the LLM + query latency never blocks
+    the heartbeat loop.
+
+    Wire shape (queued cloud-side by /api/cloud/dives-query):
+        {type:"dives_query", id, cache_key, question}
+
+    Result shape mirrors routes/dives.py::api_dives_query so the same Dives
+    frontend renders it: {sql, chart_spec, rows, error?} (or {error:"no_auth"}).
+    """
+    cache_key = action.get("cache_key")
+    question = (action.get("question") or "").strip()
+    enc_key = config.get("encryption_key")
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not (cache_key and question and enc_key and api_key):
+        return
+    aid = action.get("id")
+
+    def _run():
+        result: dict = {"_shape": "dives_query"}
+        try:
+            from clawmetry import local_store as _ls
+            from routes import dives as _dives
+            store = _ls.get_store()  # daemon's own writer handle, never read_only
+            spec = _dives._call_llm_for_sql(question, store)
+            sql = spec["sql"]
+            rows, sql_error = _dives._execute(sql, store)
+            result.update({
+                "sql": sql,
+                "chart_spec": {
+                    "chart_type":  spec.get("chart_type", "table"),
+                    "x":           spec.get("x"),
+                    "y":           spec.get("y"),
+                    "title":       spec.get("title", question[:60]),
+                    "description": spec.get("description", ""),
+                },
+                "rows": rows,
+            })
+            if sql_error:
+                result["error"] = sql_error
+        except ValueError as e:
+            # Mirror api_dives_query's error mapping so the frontend reacts the
+            # same way (no-auth banner vs upstream error).
+            msg = str(e)
+            if msg.startswith("no_auth"):
+                result["error"] = "no_auth"
+                result["message"] = msg[len("no_auth"):].strip(": ").strip()
+            else:
+                result["error"] = "upstream_error"
+                result["detail"] = msg[:200]
+        except Exception as e:  # never raise from the worker thread
+            result["error"] = str(e)[:200]
+        try:
+            blob = encrypt_payload(result, enc_key)
+            _post(
+                "/ingest/cache",
+                {
+                    "node_id": node_id,
+                    "id": aid,
+                    "cache_key": cache_key,
+                    "blob": blob,
+                    "shape": "dives_query",
+                    "ttl": 3600,
+                },
+                api_key,
+            )
+        except Exception as e:
+            log.warning("dives_query cache post failed: %s", e)
 
     threading.Thread(target=_run, daemon=True).start()
 

--- a/routes/dives.py
+++ b/routes/dives.py
@@ -191,8 +191,20 @@ def api_dives_query():
 
     try:
         store = _get_store()
-    except Exception as e:
-        return jsonify({"error": f"Local store unavailable: {e}"}), 503
+    except Exception:
+        # Cold/cloud fall-through: there's no local DuckDB to query here (the
+        # cloud container has no ~/.clawmetry, and a keyless browser hasn't
+        # rerouted through the cm-cloud-dives relay yet). Return a clean,
+        # graceful message instead of leaking the raw DuckDB IO error — the
+        # frontend renders `error` verbatim in its result box. When the cloud
+        # interceptor IS active it reroutes POST /api/dives/query to the
+        # heartbeat relay and this handler is never reached. (#2124)
+        return jsonify({
+            "error": "Dives runs SQL against your local data store, which isn't "
+                     "reachable from here. Open your local dashboard at "
+                     "http://localhost:8900 to run Dives — your raw event data "
+                     "stays on your machine.",
+        }), 200
 
     t0 = time.monotonic()
     try:


### PR DESCRIPTION
## The bug
Cloud Dives (the "Run" button) showed a raw DuckDB error:
```
Local store unavailable: IO Error: Cannot open database
"/root/.clawmetry/clawmetry.duckdb" in read-only mode: database does not exist
```
The cloud server has no `~/.clawmetry` and can't decrypt the E2E snapshot, so it cannot run Dives' arbitrary SQL server-side.

## The fix (OSS half)
Relay Dives to the user's local daemon — local compute, cloud display, exactly like cron:

- **`clawmetry/sync.py`** — new `dives_query` pending-action. `_action_dives_query` runs the NL→SQL + query on the daemon's **own writer handle** (`local_store.get_store()`, never a `read_only=True` re-open — flywheel #1771), reusing `routes/dives.py::_call_llm_for_sql` + `_execute`, then AES-256-GCM-encrypts the `{sql,chart_spec,rows}` result and POSTs it to `/ingest/cache` under the action's `cache_key`. Mirrors `_action_cron_create`; runs in a daemon thread so LLM latency never blocks the heartbeat.
- **`routes/dives.py`** — `api_dives_query` now degrades gracefully when the local store is unreachable (cloud cold / keyless fall-through): a clean "run Dives on your local dashboard" message instead of the raw IO error (the flywheel's "cold fall-through returns a graceful 200" rule).

## Verification
Daemon relay wiring tested locally end to end: dispatch → run → AES-256-GCM encrypt → `/ingest/cache` post → decrypt round-trips with the correct `{sql,chart_spec,rows}` shape. The NL→SQL + `raw_select_safe` paths reuse the already-working `api_dives_query` code.

## Follow-on
The cloud half (the `/api/cloud/dives-query` enqueue endpoint, the `cm-cloud-dives` browser interceptor that reroutes + polls + decrypts, and the route-policy note) ships in clawmetry-cloud once this is released to PyPI and the Dockerfile pin is bumped. Requires the user's local daemon to have an Anthropic credential for the NL→SQL step (otherwise the relay returns `no_auth`, surfaced as the existing no-auth banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)