### PR TITLE
fix: derive snapshot provider from model name (was always '')

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10913,11 +10913,12 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     except Exception as _e_ce:
         log.debug("snapshot: context_economics slice failed: %s", _e_ce)
 
+    from clawmetry.providers_pricing import provider_for_model as _pfm
     payload = {
         "system": system,
         "infra": infra,
         "model": model_name or "unknown",
-        "provider": "",
+        "provider": _pfm(model_name or ""),
         "sessionCount": session_count,
         "mainTokens": main_tokens,
         "currentContextTokens": current_context_tokens,


### PR DESCRIPTION
Closes #2033

## What

`sync_system_snapshot()` in `clawmetry/sync.py` was hardcoding `"provider": ""` in the outgoing payload even when `model_name` (e.g. `"claude-sonnet-4-6"`) was already known. The cloud dashboard falls back to `'—'` and the provider column shows blank for every node.

## Fix

- Call `provider_for_model(model_name or "")` from the existing `providers_pricing` module (the function was already written for exactly this purpose — see `providers_pricing.py:167`)
- Returns `""` on no match, so unknown model names are unchanged from current behavior

**1 file changed, 2 lines** — just `clawmetry/sync.py`.

## Test plan

- [ ] Confirm `provider_for_model("claude-sonnet-4-6")` → `"anthropic"` (verified locally ✓)
- [ ] Confirm `provider_for_model("")` → `""` so nodes without a session don't emit a wrong provider (verified ✓)
- [ ] After deploy, check snapshot payload in cloud: `provider` field should now show `"anthropic"` / `"openai"` / etc. instead of `""`
- [ ] Items #2–#4 from #2033 (channels dict, gateway, memoryAccess) are deliberately not touched here per the triage note

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwG5VLX84hkHeUiaop6npS)_