### PR TITLE
fix: wire /api/v2/context to real DuckDB data (Stage A)

### DIFF
--- a/clawmetry/v2/routes.py
+++ b/clawmetry/v2/routes.py
@@ -144,29 +144,86 @@ def get_ops():
 
 @bp_v2.route("/api/v2/context", methods=["GET"])
 def get_context():
+    from datetime import datetime, timezone, timedelta
+
+    # ── Token gauge ───────────────────────────────────────────────────────
+    peek: dict = {}
+    try:
+        from routes.local_query import local_store_via_daemon
+        peek = local_store_via_daemon("query_context_window_peek") or {}
+    except Exception:
+        pass
+
+    input_toks = int(peek.get("input_tokens") or 0)
+    # context_window is already model-aware (1M Opus, etc.) — falls back to 200K.
+    context_window = int(peek.get("context_window") or 200_000)
+    compaction_threshold = int(context_window * 0.8)
+
+    # ── Compaction history (last 6 h) ─────────────────────────────────────
+    history: list[dict] = []
+    try:
+        from routes.local_query import local_store_via_daemon as _lsd
+        raw = _lsd("query_compactions", limit=100) or []
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=6)
+        for c in raw:
+            ts_str = str(c.get("timestamp") or c.get("ts") or "")
+            if not ts_str:
+                continue
+            try:
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts < cutoff:
+                    continue
+                history.append({
+                    "ts": ts.strftime("%H:%M"),
+                    "used": round(int(c.get("tokens_before") or 0) / 1000, 2),
+                    "event": "compaction",
+                })
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    # Append current reading as the trailing data point.
+    if input_toks > 0:
+        history.append({
+            "ts": datetime.now(timezone.utc).strftime("%H:%M"),
+            "used": round(input_toks / 1000, 2),
+        })
+
+    # ── Memory files ──────────────────────────────────────────────────────
+    memory_files: list[dict] = []
+    try:
+        from routes.local_query import local_store_via_daemon as _lsd2
+        rows = _lsd2("query_memory_blobs", limit=20) or []
+        seen: set[str] = set()
+        for r in rows:
+            path = r.get("path") or ""
+            if not path or path in seen:
+                continue
+            seen.add(path)
+            blob = r.get("blob") or ""
+            preview = (blob if isinstance(blob, str) else "")[:200]
+            size = r.get("size_bytes")
+            if size is None:
+                size = len(blob.encode("utf-8") if isinstance(blob, str) else b"")
+            memory_files.append({
+                "path": path,
+                "size_bytes": int(size or 0),
+                "preview": preview,
+            })
+    except Exception:
+        pass
+
     return jsonify({
-        "tokens": {"used": 51.95, "total": 200, "compaction_threshold": 160},
-        "segments": [
-            {"name": "System prompt", "tokens": 1.2, "color": "ink-3", "note": "boilerplate · ClawMetry default"},
-            {"name": "Tooling overhead", "tokens": 3.0, "color": "sea", "note": "framework scaffolding"},
-            {"name": "Skill headers", "tokens": 1.5, "color": "amber", "note": "7 skills loaded"},
-            {"name": "Bootstrap · SOUL.md", "tokens": 0.75, "color": "plum", "note": "agent persona"},
-            {"name": "Bootstrap · MEMORY.md", "tokens": 1.0, "color": "plum", "note": "long-term memory"},
-            {"name": "Tool schemas (JSON)", "tokens": 7.0, "color": "sea", "note": "12 tools, full JSON-schema"},
-            {"name": "Conversation history", "tokens": 38.5, "color": "claw-red", "note": "current session · 84 turns"},
-        ],
-        "history": [
-            {"ts": "08:00", "used": 50, "event": "compaction"},
-            {"ts": "10:00", "used": 42},
-            {"ts": "12:00", "used": 22, "event": "compaction"},
-            {"ts": "14:00", "used": 56},
-            {"ts": "16:00", "used": 30, "event": "compaction"},
-            {"ts": "18:00", "used": 51.95},
-        ],
-        "memory_files": [
-            {"path": "SOUL.md", "size_bytes": 1200, "preview": "You are agent-vega-04. You're patient,\ndirect, and never deploy on Fridays."},
-            {"path": "MEMORY.md", "size_bytes": 1024, "preview": "- prod cluster: us-west-2\n- on-call: @vivek (oct rotation)\n- last incident: 2026-04-12 db lag"},
-        ],
+        "tokens": {
+            "used": round(input_toks / 1000, 2),
+            "total": context_window // 1000,
+            "compaction_threshold": compaction_threshold // 1000,
+        },
+        "history": history,
+        "memory_files": memory_files,
     })
 
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded mock data in `/api/v2/context` with live readings from three allowlisted DuckDB methods
- Token gauge (`used/total/compaction_threshold` in K-tokens) now reflects the real active session's context window, including model-aware sizing for 1M Opus variants
- Compaction history is built from the last 6 hours of real compaction events, plus a trailing point for the current reading
- Memory file list returns actual `{path, size_bytes, preview}` rows from DuckDB instead of placeholder strings

## Test plan

- [ ] Start `make dev` + sync daemon; open `/api/v2/context` — verify `tokens.used` matches the context bar on the Brain tab
- [ ] Run an agent session that triggers a compaction; verify `history` array includes a `{"event":"compaction"}` entry with correct `tokens_before` value
- [ ] Confirm fresh install (no DuckDB data) returns `{used:0, total:200, compaction_threshold:160}` with empty `history` and `memory_files` — no 500
- [ ] `ruff check clawmetry/v2/routes.py` passes clean

Closes #1513

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSjaMmMV9c9hNg6bio6NUq)_