### PR TITLE
feat(observability): interactive tool catalog — provenance + p50/p95 latency (P1-3)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -965,6 +965,7 @@ function switchTab(name) {
   if (name === 'context') loadContextInspector();
   if (name === 'tracing') loadTracing();
   if (name === 'turn-anatomy') loadTurnAnatomy();
+  if (name === 'tool-catalog') { if (typeof loadToolCatalog === 'function') loadToolCatalog(); }
   if (name === 'brain') loadBrainPage();
   if (name === 'selfevolve') loadSelfEvolvePage();
   if (name === 'notifications') { if (typeof loadNotificationsPage === 'function') loadNotificationsPage(); }
@@ -11634,6 +11635,165 @@ async function loadRunLedger() {
     el.innerHTML = laneHtml + runHtml;
   } catch(e) {
     el.innerHTML = '<div style="color:#e74c3c;font-size:13px;padding:16px;">Failed to load run ledger: '+escHtml(String(e))+'</div>';
+  }
+}
+
+// ── Tool catalog: provenance + p50/p95 latency (PRD P1-3) ───────────────────
+// Interactive catalog of every tool the agent invoked, grouped by provenance
+// (builtin / MCP / plugin) with call count + p50/p95 latency + error rate.
+// Rows are clickable → expand to the tool's recent individual calls (each
+// linking to its session transcript). Sortable + provenance-filterable.
+// Reads /api/tool-catalog (derived from DuckDB tool_call/tool_result pairs).
+var _toolCatalogData = null;       // last /api/tool-catalog payload
+var _tcExpanded = {};              // tool name -> bool (row expanded)
+var _tcCallsCache = {};            // tool name -> recent-calls payload
+
+function _tcProvBadge(prov, provider) {
+  var map = {
+    builtin: ['#0ea5e9', 'rgba(14,165,233,.12)', 'builtin'],
+    mcp:     ['#8b5cf6', 'rgba(139,92,246,.12)', 'MCP' + (provider ? (' · ' + provider) : '')],
+    plugin:  ['#d97706', 'rgba(217,119,6,.12)', 'plugin']
+  };
+  var c = map[prov] || ['#6b7280', 'var(--bg-secondary)', prov || 'unknown'];
+  var tip = prov === 'builtin' ? 'In the OpenClaw sandbox tool allow-list'
+          : prov === 'mcp' ? ('MCP-namespaced tool' + (provider ? (' from provider "' + provider + '"') : ''))
+          : 'Not a sandbox builtin and not MCP-namespaced (plugin / custom / unknown)';
+  return '<span title="' + escHtml(tip) + '" style="font-size:10px;font-weight:700;color:' + c[0] + ';background:' + c[1] + ';border-radius:4px;padding:1px 7px;white-space:nowrap;">' + escHtml(c[2]) + '</span>';
+}
+
+function _tcFmtMs(ms) {
+  if (ms === null || ms === undefined) return '<span style="color:var(--text-faint);" title="No matching tool_result captured for these calls">&mdash;</span>';
+  if (ms < 1000) return ms + 'ms';
+  if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+  return Math.round(ms / 60000) + 'm';
+}
+
+function _tcSortTools(tools) {
+  var sel = document.getElementById('tc-sort');
+  var mode = sel ? sel.value : 'calls';
+  var arr = tools.slice();
+  if (mode === 'name') arr.sort(function(a, b) { return a.name.localeCompare(b.name); });
+  else if (mode === 'p95') arr.sort(function(a, b) { return (b.p95_ms || 0) - (a.p95_ms || 0); });
+  else if (mode === 'p50') arr.sort(function(a, b) { return (b.p50_ms || 0) - (a.p50_ms || 0); });
+  else if (mode === 'errors') arr.sort(function(a, b) { return (b.error_rate || 0) - (a.error_rate || 0) || (b.calls - a.calls); });
+  else arr.sort(function(a, b) { return (b.calls - a.calls) || ((b.p95_ms || 0) - (a.p95_ms || 0)); });
+  return arr;
+}
+
+async function loadToolCatalog() {
+  var tableEl = document.getElementById('tc-table');
+  var sumEl = document.getElementById('tc-summary');
+  if (!tableEl) return;
+  var provSel = document.getElementById('tc-prov-filter');
+  var provQ = provSel && provSel.value ? ('?provenance=' + encodeURIComponent(provSel.value)) : '';
+  try {
+    var data = await fetch('/api/tool-catalog' + provQ).then(function(r) { return r.json(); });
+    _toolCatalogData = data;
+    _tcCallsCache = {};  // catalog refreshed → drop stale per-call caches
+    // Provenance summary chips.
+    if (sumEl) {
+      var g = data.groups || {}, t = data.totals || {};
+      var chips = '';
+      function chip(label, val, color) {
+        return '<span style="font-size:12px;color:var(--text-muted);background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:8px;padding:5px 11px;"><strong style="color:' + color + ';">' + val + '</strong> ' + label + '</span>';
+      }
+      chips += chip('tools', t.tool_count || 0, 'var(--text-primary)');
+      chips += chip('calls', t.total_calls || 0, 'var(--text-primary)');
+      chips += chip('builtin', g.builtin || 0, '#0ea5e9');
+      chips += chip('MCP', g.mcp || 0, '#8b5cf6');
+      chips += chip('plugin', g.plugin || 0, '#d97706');
+      sumEl.innerHTML = chips;
+    }
+    renderToolCatalog();
+  } catch (e) {
+    tableEl.innerHTML = '<div style="color:#e74c3c;font-size:13px;padding:16px;">Failed to load tool catalog: ' + escHtml(String(e)) + '</div>';
+  }
+}
+
+function renderToolCatalog() {
+  var tableEl = document.getElementById('tc-table');
+  if (!tableEl || !_toolCatalogData) return;
+  var tools = _tcSortTools(_toolCatalogData.tools || []);
+  if (tools.length === 0) {
+    tableEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:24px;text-align:center;">No tool calls recorded yet. Tools appear here as the agent invokes them (derived from tool_call &rarr; tool_result event pairs).</div>';
+    return;
+  }
+  var html = '';
+  // Header row.
+  html += '<div style="display:flex;align-items:center;gap:10px;padding:9px 14px;background:var(--bg-secondary);border-bottom:1px solid var(--border-primary);font-size:11px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;">';
+  html += '<span style="width:14px;"></span>';
+  html += '<span style="flex:1;">Tool</span>';
+  html += '<span style="width:96px;">Provenance</span>';
+  html += '<span style="width:54px;text-align:right;" title="Number of times this tool was called">Calls</span>';
+  html += '<span style="width:62px;text-align:right;" title="Median (50th percentile) call duration">p50</span>';
+  html += '<span style="width:62px;text-align:right;" title="95th percentile call duration">p95</span>';
+  html += '<span style="width:64px;text-align:right;" title="Share of calls that returned an error">Errors</span>';
+  html += '</div>';
+  tools.forEach(function(tool) {
+    var expanded = !!_tcExpanded[tool.name];
+    var errPct = (tool.error_rate || 0) * 100;
+    var errColor = errPct > 0 ? '#ef4444' : 'var(--text-muted)';
+    var nameEsc = tool.name.replace(/'/g, "\\'");
+    html += '<div onclick="_tcToggle(\'' + nameEsc + '\')" title="Click to expand recent calls for ' + escHtml(tool.name) + '" style="display:flex;align-items:center;gap:10px;padding:9px 14px;border-bottom:1px solid var(--border-secondary);font-size:13px;cursor:pointer;transition:background 0.1s;" onmouseover="this.style.background=\'var(--bg-hover)\'" onmouseout="this.style.background=\'\'">';
+    html += '<span style="width:14px;color:var(--text-muted);font-size:11px;">' + (expanded ? '&#9660;' : '&#9654;') + '</span>';
+    html += '<span style="flex:1;font-weight:600;color:var(--text-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:var(--font-mono,monospace);" title="' + escHtml(tool.name) + '">' + escHtml(tool.name) + '</span>';
+    html += '<span style="width:96px;">' + _tcProvBadge(tool.provenance, tool.provider) + '</span>';
+    html += '<span style="width:54px;text-align:right;color:var(--text-primary);font-variant-numeric:tabular-nums;">' + tool.calls + '</span>';
+    html += '<span style="width:62px;text-align:right;color:var(--text-muted);font-variant-numeric:tabular-nums;">' + _tcFmtMs(tool.p50_ms) + '</span>';
+    html += '<span style="width:62px;text-align:right;color:var(--text-muted);font-variant-numeric:tabular-nums;">' + _tcFmtMs(tool.p95_ms) + '</span>';
+    html += '<span style="width:64px;text-align:right;color:' + errColor + ';font-variant-numeric:tabular-nums;" title="' + (tool.errors || 0) + ' of ' + tool.calls + ' calls errored">' + errPct.toFixed(errPct > 0 && errPct < 1 ? 1 : 0) + '%</span>';
+    html += '</div>';
+    if (expanded) {
+      html += '<div id="tc-calls-' + encodeURIComponent(tool.name) + '" style="background:var(--bg-secondary);border-bottom:1px solid var(--border-secondary);padding:6px 14px 10px 38px;font-size:12px;color:var(--text-muted);">Loading recent calls&hellip;</div>';
+    }
+  });
+  tableEl.innerHTML = html;
+  // Lazy-load the per-call drill-down for any expanded row.
+  tools.forEach(function(tool) {
+    if (_tcExpanded[tool.name]) _tcLoadCalls(tool.name);
+  });
+}
+
+function _tcToggle(name) {
+  _tcExpanded[name] = !_tcExpanded[name];
+  renderToolCatalog();
+}
+
+async function _tcLoadCalls(name) {
+  var el = document.getElementById('tc-calls-' + encodeURIComponent(name));
+  if (!el) return;
+  try {
+    var data = _tcCallsCache[name];
+    if (!data) {
+      data = await fetch('/api/tool-catalog/' + encodeURIComponent(name) + '/calls').then(function(r) { return r.json(); });
+      _tcCallsCache[name] = data;
+    }
+    var calls = data.calls || [];
+    if (calls.length === 0) {
+      el.innerHTML = '<div style="padding:4px 0;">No individual calls captured in the recent event window.</div>';
+      return;
+    }
+    var rows = '';
+    calls.forEach(function(c) {
+      var when = c.ts_ms ? new Date(c.ts_ms).toLocaleString() : '';
+      var statusColor = c.status === 'error' ? '#ef4444' : '#16a34a';
+      var statusLabel = c.status === 'error' ? 'error' : 'ok';
+      rows += '<div style="display:flex;align-items:center;gap:10px;padding:4px 0;border-top:1px solid var(--border-secondary);">';
+      rows += '<span style="display:inline-block;width:7px;height:7px;border-radius:50%;background:' + statusColor + ';flex-shrink:0;" title="' + statusLabel + '"></span>';
+      rows += '<span style="width:140px;color:var(--text-faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="' + escHtml(when) + '">' + escHtml(when) + '</span>';
+      rows += '<span style="width:64px;color:var(--text-primary);font-variant-numeric:tabular-nums;">' + _tcFmtMs(c.duration_ms) + '</span>';
+      rows += '<span style="width:48px;font-size:10px;font-weight:700;color:' + statusColor + ';">' + statusLabel + '</span>';
+      if (c.session_id) {
+        var sidEsc = String(c.session_id).replace(/'/g, "\\'");
+        rows += '<span onclick="event.stopPropagation();viewTranscript(\'' + sidEsc + '\')" title="Open this session\'s transcript" style="flex:1;color:var(--accent,#3b82f6);cursor:pointer;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-decoration:underline;">' + escHtml(String(c.session_id).slice(0, 32)) + '</span>';
+      } else {
+        rows += '<span style="flex:1;color:var(--text-faint);">(no session)</span>';
+      }
+      rows += '</div>';
+    });
+    el.innerHTML = '<div style="font-size:11px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;padding:2px 0 4px;">' + calls.length + ' recent call' + (calls.length === 1 ? '' : 's') + '</div>' + rows;
+  } catch (e) {
+    el.innerHTML = '<div style="color:#e74c3c;padding:4px 0;">Failed to load calls: ' + escHtml(String(e)) + '</div>';
   }
 }
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9864,6 +9864,178 @@ def _build_brain_data():
         return {"stats": {}, "calls": [], "total": 0}
 
 
+def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
+    """Per-tool call count + p50/p95 latency + error rate grouped by provenance
+    (PRD P1-3), derived from the DuckDB ``events`` table.
+
+    Mirrors the OSS ``routes/tool_catalog.py`` aggregation so the cloud Tool
+    Catalog tab shows the same rollup: each ``tool_call`` event is matched to
+    its closing ``tool_result`` by tool_use id (the ``turn_anatomy`` join),
+    duration = ``result_ts - call_ts``. Provenance: a name with ``__`` is MCP,
+    a name in the sandbox ``tool_policy`` allow set is builtin, else plugin.
+
+    Bounded to the ``top`` busiest tools so the slice stays tiny in the shared
+    snapshot. Returns ``{"tools": [...], "groups": {...}}``; degrades to an
+    empty catalog (never raises) when the store is unavailable."""
+    out = {"tools": [], "groups": {"builtin": 0, "mcp": 0, "plugin": 0}}
+    try:
+        from clawmetry import local_store as _ls_tc
+        store = _ls_tc.get_store()
+    except Exception:
+        return out
+    if store is None:
+        return out
+
+    try:
+        rows = store.query_events(limit=int(limit)) or []
+    except Exception:
+        return out
+
+    # Builtin universe from the mirrored sandbox tool policy.
+    builtin: set = set()
+    try:
+        for r in (store.query_tool_policy(limit=25) or []):
+            allow = r.get("allow")
+            if isinstance(allow, list):
+                for n in allow:
+                    if n:
+                        builtin.add(str(n).replace("mcp__openclaw__", ""))
+    except Exception:
+        pass
+
+    def _d(e):
+        d = e.get("data")
+        return d if isinstance(d, dict) else {}
+
+    def _ms(ts):
+        if ts is None:
+            return None
+        if isinstance(ts, (int, float)):
+            return int(ts * 1000) if ts < 1e12 else int(ts)
+        try:
+            return int(datetime.fromisoformat(
+                str(ts).replace("Z", "+00:00")).timestamp() * 1000)
+        except Exception:
+            return None
+
+    def _name(e):
+        d = _d(e)
+        n = d.get("tool_name")
+        if n:
+            return str(n).replace("mcp__openclaw__", "")
+        tcs = d.get("tool_calls")
+        if isinstance(tcs, list) and tcs and isinstance(tcs[0], dict):
+            nn = tcs[0].get("name") or (tcs[0].get("function") or {}).get("name")
+            if nn:
+                return str(nn).replace("mcp__openclaw__", "")
+        return ""
+
+    def _err(e):
+        d = _d(e)
+        ex = d.get("extra") if isinstance(d.get("extra"), dict) else {}
+        return bool(ex.get("isError") or d.get("isError") or d.get("is_error")
+                    or (e.get("event_type") or "").endswith("error"))
+
+    def _is_result(e):
+        et = (e.get("event_type") or "").lower()
+        if "tool_result" in et or "tool_use_result" in et:
+            return True
+        return (_d(e).get("role") or "").lower() == "tool"
+
+    def _is_call(e):
+        et = (e.get("event_type") or "").lower()
+        if "tool_result" in et or "tool_use_result" in et:
+            return False
+        d = _d(e)
+        if (d.get("role") or "").lower() == "tool":
+            return False
+        return bool("tool_call" in et or "tool.call" in et
+                    or d.get("tool_name") or d.get("tool_calls"))
+
+    # Index results by the tool_use id they close.
+    res_idx: dict = {}
+    for e in rows:
+        if not _is_result(e):
+            continue
+        d = _d(e)
+        ex = d.get("extra") if isinstance(d.get("extra"), dict) else {}
+        rid = ex.get("toolUseId") or ex.get("tool_use_id") or d.get("tool_use_id")
+        if rid is not None:
+            res_idx[str(rid)] = {"ts": _ms(e.get("ts")), "error": _err(e)}
+
+    agg: dict = {}
+    for e in rows:
+        if not _is_call(e):
+            continue
+        name = _name(e)
+        if not name:
+            continue
+        start = _ms(e.get("ts"))
+        dur = None
+        err = _err(e)
+        d = _d(e)
+        tcs = d.get("tool_calls")
+        ids = [str(tc["id"]) for tc in tcs
+               if isinstance(tc, dict) and tc.get("id")] if isinstance(tcs, list) else []
+        for tuid in ids:
+            m = res_idx.get(tuid)
+            if m:
+                if m["error"]:
+                    err = True
+                if m["ts"] is not None and start is not None:
+                    dur = max(0, m["ts"] - start)
+                break
+        a = agg.setdefault(name, {"calls": 0, "durs": [], "errs": 0})
+        a["calls"] += 1
+        if dur is not None:
+            a["durs"].append(dur)
+        if err:
+            a["errs"] += 1
+
+    def _pct(vals, p):
+        if not vals:
+            return None
+        if len(vals) == 1:
+            return int(vals[0])
+        k = (len(vals) - 1) * (p / 100.0)
+        f = int(k)
+        if f + 1 < len(vals):
+            return int(vals[f] + (vals[f + 1] - vals[f]) * (k - f))
+        return int(vals[f])
+
+    def _classify(name):
+        if "__" in name:
+            parts = [p for p in name.split("__") if p]
+            if name.startswith("mcp__"):
+                provider = parts[1] if len(parts) > 1 else "mcp"
+            else:
+                provider = parts[0] if parts else "mcp"
+            return ("mcp", provider)
+        if name in builtin:
+            return ("builtin", "")
+        return ("plugin", "")
+
+    tools = []
+    for name, a in agg.items():
+        prov, provider = _classify(name)
+        durs = sorted(a["durs"])
+        calls = a["calls"]
+        tools.append({
+            "name": name,
+            "provenance": prov,
+            "provider": provider or None,
+            "calls": calls,
+            "p50_ms": _pct(durs, 50),
+            "p95_ms": _pct(durs, 95),
+            "error_rate": round(a["errs"] / calls, 4) if calls else 0.0,
+            "errors": a["errs"],
+        })
+        out["groups"][prov] = out["groups"].get(prov, 0) + 1
+    tools.sort(key=lambda t: (-t["calls"], -(t["p95_ms"] or 0), t["name"]))
+    out["tools"] = tools[:int(top)]
+    return out
+
+
 def _build_tool_stats():
     """Build tool usage stats from recent session logs."""
     try:
@@ -10665,6 +10837,17 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     except Exception as _e_tp:
         log.debug("snapshot: tool_policy slice failed: %s", _e_tp)
 
+    # Tool catalog (PRD P1-3): per-tool call count + p50/p95 latency + error
+    # rate grouped by provenance, derived from the DuckDB events table
+    # (tool_call → tool_result join). Bounded to the top tools by call count so
+    # the slice stays tiny in the shared snapshot. Mirrors the OSS
+    # ``/api/tool-catalog`` aggregation so the cloud tab shows the same rollup.
+    tool_catalog_slice: dict = {"tools": [], "groups": {}}
+    try:
+        tool_catalog_slice = _build_tool_catalog_slice()
+    except Exception as _e_tc:
+        log.debug("snapshot: tool_catalog slice failed: %s", _e_tc)
+
     payload = {
         "system": system,
         "infra": infra,
@@ -10691,6 +10874,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "totalActive": active_count,
         "runLedger": run_ledger_slice,
         "toolPolicy": tool_policy_slice,
+        "toolCatalog": tool_catalog_slice,
         "spending": spending,
         "cronJobs": _build_cron_jobs(paths),
         "channels": _build_channel_data(config),

--- a/clawmetry/templates/tabs/tool-catalog.html
+++ b/clawmetry/templates/tabs/tool-catalog.html
@@ -1,0 +1,30 @@
+<div class="page" id="page-tool-catalog">
+  <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:14px;gap:16px;flex-wrap:wrap;">
+    <div>
+      <div style="font-size:18px;font-weight:700;color:var(--text-primary);">Tool catalog</div>
+      <div style="font-size:12px;color:var(--text-muted);margin-top:4px;">Every tool the agent actually invoked, grouped by provenance (builtin / MCP / plugin), with call count, p50/p95 latency and error rate. Click a tool to expand its recent calls.</div>
+    </div>
+    <div style="display:flex;gap:6px;align-items:center;">
+      <select id="tc-prov-filter" onchange="loadToolCatalog()" title="Filter by provenance group" style="font-size:12px;padding:5px 8px;border:1px solid var(--border-primary);border-radius:7px;background:var(--bg-secondary);color:var(--text-primary);">
+        <option value="">All provenance</option>
+        <option value="builtin">Builtin only</option>
+        <option value="mcp">MCP only</option>
+        <option value="plugin">Plugin only</option>
+      </select>
+      <select id="tc-sort" onchange="renderToolCatalog()" title="Sort tool rows" style="font-size:12px;padding:5px 8px;border:1px solid var(--border-primary);border-radius:7px;background:var(--bg-secondary);color:var(--text-primary);">
+        <option value="calls">Most calls</option>
+        <option value="p95">Slowest p95</option>
+        <option value="p50">Slowest p50</option>
+        <option value="errors">Highest error rate</option>
+        <option value="name">Name (A&ndash;Z)</option>
+      </select>
+      <button class="refresh-btn" onclick="loadToolCatalog()">&#8635;</button>
+    </div>
+  </div>
+
+  <!-- Provenance summary chips -->
+  <div id="tc-summary" style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:12px;"></div>
+
+  <!-- Tool table -->
+  <div class="card" id="tc-table" style="color:var(--text-muted);font-size:13px;padding:0;overflow:hidden;">Loading tool catalog&hellip;</div>
+</div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -124,6 +124,7 @@ from routes.dives import bp_dives
 from routes.scheduler import bp_scheduler
 from routes.policy import bp_policy
 from routes.turn_anatomy import bp_turn_anatomy
+from routes.tool_catalog import bp_tool_catalog
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -10623,6 +10624,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_scheduler)
     app.register_blueprint(bp_policy)
     app.register_blueprint(bp_turn_anatomy)
+    app.register_blueprint(bp_tool_catalog)
 
     # Register built-in agent adapters. External plugins can register more
     # via clawmetry.extensions entry points — see clawmetry/adapters/.
@@ -11078,6 +11080,9 @@ DASHBOARD_HTML = r"""
         <div class="left-nav-item left-nav-item-sub" id="left-nav-turn-anatomy" data-tab="turn-anatomy" onclick="switchTab('turn-anatomy')" title="Decompose a turn into prompt, model, tools, compaction and reply">
           <span class="left-nav-label">Turn anatomy</span>
         </div>
+        <div class="left-nav-item left-nav-item-sub" id="left-nav-tool-catalog" data-tab="tool-catalog" onclick="switchTab('tool-catalog')" title="Every tool the agent uses by provenance, with call count and p50/p95 latency">
+          <span class="left-nav-label">Tool catalog</span>
+        </div>
       </div>
 
       <div class="left-nav-item" data-tab="approvals" onclick="switchTab('approvals')" data-i18n-title="nav.approvals_tooltip" title="Cloud-mediated approval queue">
@@ -11204,6 +11209,9 @@ DASHBOARD_HTML = r"""
 
 <!-- TURN ANATOMY (per-turn waterfall + stalled detector, P0-3) -->
 {% include 'tabs/turn-anatomy.html' %}
+
+<!-- TOOL CATALOG (provenance + p50/p95 latency + error rate, P1-3) -->
+{% include 'tabs/tool-catalog.html' %}
 
 <!-- SECURITY -->
 {% include 'tabs/security.html' %}

--- a/routes/tool_catalog.py
+++ b/routes/tool_catalog.py
@@ -1,0 +1,369 @@
+"""routes/tool_catalog.py — interactive tool catalog + provenance (PRD P1-3).
+
+Every tool the agent actually invoked, grouped by **provenance** (builtin /
+MCP / plugin), with per-tool **call count, p50/p95 latency, and error rate** —
+plus a drill-down into the individual recent calls behind each tool row.
+
+Where the numbers come from
+===========================
+Latency + counts + errors are derived from the DuckDB ``events`` table (the
+same rows ClawMetry already ingests — no OTLP exporter, no gateway RPC). Each
+``tool_call`` event is matched to its closing ``tool_result`` by the tool_use
+id, exactly the join ``routes/turn_anatomy.py`` uses for its waterfall
+(``_tool_use_ids`` open the span; ``_tool_result_id`` closes it). Duration is
+``result_ts - call_ts``; an unmatched call contributes to the count but not the
+latency percentiles. Aggregated per tool name → ``calls``, ``p50_ms``,
+``p95_ms``, ``error_rate``.
+
+Provenance is classified from two inputs:
+  1. The OpenClaw sandbox tool universe, already mirrored into DuckDB by
+     ``clawmetry/sync.py:sync_tool_policy`` (``openclaw sandbox explain
+     --json`` → ``tool_policy.allow``) and read here via ``query_tool_policy``.
+     A tool name in that allow set is **builtin**.
+  2. Name shape: a name containing ``__`` / ``mcp__`` is an **MCP** tool (the
+     provider is the prefix before ``__``). Anything left over is **plugin**.
+If the sandbox universe is unavailable (fresh sync / OpenClaw build without
+``sandbox explain``) we degrade to name-based classification only — never an
+error.
+
+Endpoints (bp_tool_catalog):
+  GET /api/tool-catalog              — per-tool rollup grouped by provenance
+  GET /api/tool-catalog/<name>/calls — recent individual calls for one tool
+
+Reads go through the daemon proxy (the daemon owns the DuckDB writer lock)
+with a single-process direct-read fallback — the same ``_ls_call`` pattern as
+``routes/scheduler.py`` / ``routes/policy.py``. Neither endpoint ever 500s on
+empty data.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify, request
+
+bp_tool_catalog = Blueprint("tool_catalog", __name__)
+
+
+# ── DuckDB access (daemon proxy + single-process fallback) ──────────────────
+
+def _ls_call(method_name: str, **kwargs):
+    """Cross-process LocalStore call with single-process fallback (issue #1088)."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+def _coerce_rows(rows) -> list:
+    """``local_store_via_daemon`` returns the raw method result (a list) or a
+    ``{"result": [...]}`` / ``{"rows": [...]}`` envelope depending on transport
+    — normalise both to a plain list."""
+    if isinstance(rows, dict):
+        rows = rows.get("result") or rows.get("rows") or []
+    return rows if isinstance(rows, list) else []
+
+
+# ── Event helpers (mirror routes/turn_anatomy.py tool-timing join) ──────────
+
+def _data(e):
+    d = e.get("data")
+    return d if isinstance(d, dict) else {}
+
+
+def _ts_ms(ts):
+    """Coerce an event ts (ISO-8601 string or epoch s/ms) to ms-since-epoch."""
+    if ts is None:
+        return None
+    if isinstance(ts, (int, float)):
+        return int(ts * 1000) if ts < 1e12 else int(ts)
+    try:
+        return int(datetime.fromisoformat(
+            str(ts).replace("Z", "+00:00")).timestamp() * 1000)
+    except Exception:
+        return None
+
+
+def _tool_name(e):
+    """The tool name a ``tool_call`` event invokes. Strips the OpenClaw-native
+    ``mcp__openclaw__`` wrapper so a builtin reads as its plain name."""
+    d = _data(e)
+    name = d.get("tool_name")
+    if name:
+        return str(name).replace("mcp__openclaw__", "")
+    tcs = d.get("tool_calls")
+    if isinstance(tcs, list) and tcs and isinstance(tcs[0], dict):
+        n = tcs[0].get("name") or (tcs[0].get("function") or {}).get("name")
+        if n:
+            return str(n).replace("mcp__openclaw__", "")
+    return ""
+
+
+def _tool_use_ids(e):
+    """tool_use ids this event opens (a tool_call) — for start→end matching."""
+    d = _data(e)
+    ids = []
+    tcs = d.get("tool_calls")
+    if isinstance(tcs, list):
+        for tc in tcs:
+            if isinstance(tc, dict) and tc.get("id"):
+                ids.append(str(tc["id"]))
+    return ids
+
+
+def _tool_result_id(e):
+    """tool_use id this tool_result closes (the join key)."""
+    d = _data(e)
+    ex = d.get("extra") if isinstance(d.get("extra"), dict) else {}
+    return ex.get("toolUseId") or ex.get("tool_use_id") or d.get("tool_use_id")
+
+
+def _is_error(e):
+    d = _data(e)
+    ex = d.get("extra") if isinstance(d.get("extra"), dict) else {}
+    return bool(ex.get("isError") or d.get("isError") or d.get("is_error")
+                or (e.get("event_type") or "").endswith("error"))
+
+
+def _is_tool_call(e):
+    """True for a tool-invocation event (NOT its result).
+
+    Substring match on the v3 ``tool_call`` / ``tool.call`` names plus the
+    multi-runtime ``data.tool_name`` / ``data.tool_calls`` shape — never an
+    equality check against pre-v3 envelope names, so this can't silent-zero
+    on a real v3 install (MOAT v3-shape gate)."""
+    et = (e.get("event_type") or "").lower()
+    if "tool_result" in et or "tool_use_result" in et:
+        return False
+    d = _data(e)
+    if (d.get("role") or "").lower() == "tool":
+        return False
+    return bool("tool_call" in et or "tool.call" in et
+                or d.get("tool_name") or d.get("tool_calls"))
+
+
+def _is_tool_result(e):
+    """True for a tool-result event (the closing half of the join)."""
+    et = (e.get("event_type") or "").lower()
+    if "tool_result" in et or "tool_use_result" in et:
+        return True
+    return (_data(e).get("role") or "").lower() == "tool"
+
+
+# ── Provenance classification ───────────────────────────────────────────────
+
+def _builtin_tool_set() -> set:
+    """The OpenClaw sandbox builtin-tool universe, read from the DuckDB
+    ``tool_policy`` table (mirrored from ``openclaw sandbox explain --json`` by
+    the sync daemon). The union of every agent's ``allow`` list. Empty set when
+    the policy hasn't been synced yet — callers then fall back to name shape
+    only."""
+    builtin: set = set()
+    for r in _coerce_rows(_ls_call("query_tool_policy", limit=25)):
+        allow = r.get("allow")
+        if isinstance(allow, list):
+            for n in allow:
+                if n:
+                    builtin.add(str(n).replace("mcp__openclaw__", ""))
+    return builtin
+
+
+def _classify(name: str, builtin: set):
+    """Return ``(provenance, provider)`` for a tool name.
+
+    ``mcp__<provider>__<tool>`` or any ``a__b`` → MCP (provider = the segment
+    before ``__``); a name in the sandbox builtin universe → builtin; anything
+    else → plugin/unknown. Name shape wins for MCP even when the policy lists
+    it, because an ``__``-bearing name is unambiguously an MCP-namespaced tool.
+    """
+    if not name:
+        return ("plugin", "")
+    if "__" in name:
+        parts = [p for p in name.split("__") if p]
+        if name.startswith("mcp__"):
+            provider = parts[1] if len(parts) > 1 else "mcp"
+        else:
+            provider = parts[0] if parts else "mcp"
+        return ("mcp", provider)
+    if name in builtin:
+        return ("builtin", "")
+    return ("plugin", "")
+
+
+# ── Aggregation ─────────────────────────────────────────────────────────────
+
+def _percentile(sorted_vals: list, p: float):
+    """Linear-interpolated percentile (p in 0..100) over a SORTED list."""
+    if not sorted_vals:
+        return None
+    if len(sorted_vals) == 1:
+        return int(sorted_vals[0])
+    k = (len(sorted_vals) - 1) * (p / 100.0)
+    f = int(k)
+    if f + 1 < len(sorted_vals):
+        return int(sorted_vals[f] + (sorted_vals[f + 1] - sorted_vals[f]) * (k - f))
+    return int(sorted_vals[f])
+
+
+def _result_index(rows: list) -> dict:
+    """Index every tool_result by the tool_use id it closes → {ts_ms, error}."""
+    idx: dict = {}
+    for e in rows:
+        if not _is_tool_result(e):
+            continue
+        rid = _tool_result_id(e)
+        if rid is None:
+            continue
+        idx[str(rid)] = {"ts": _ts_ms(e.get("ts")), "error": _is_error(e)}
+    return idx
+
+
+def _iter_tool_calls(rows: list, res_idx: dict):
+    """Yield ``(name, ts_ms, duration_ms_or_None, is_error, session_id)`` for
+    every tool_call, matching its result by tool_use id where present."""
+    for e in rows:
+        if not _is_tool_call(e):
+            continue
+        name = _tool_name(e)
+        if not name:
+            continue
+        start = _ts_ms(e.get("ts"))
+        ids = _tool_use_ids(e)
+        dur = None
+        err = _is_error(e)
+        for tuid in ids:
+            m = res_idx.get(str(tuid))
+            if m:
+                if m["error"]:
+                    err = True
+                if m["ts"] is not None and start is not None:
+                    dur = max(0, m["ts"] - start)
+                break
+        yield (name, start, dur, err, (e.get("session_id") or ""))
+
+
+# ── Endpoints ───────────────────────────────────────────────────────────────
+
+@bp_tool_catalog.route("/api/tool-catalog")
+def api_tool_catalog():
+    """Per-tool rollup grouped by provenance.
+
+    Returns ``{tools:[...], groups:{builtin,mcp,plugin}, totals, _source}``.
+    Each tool row: ``{name, provenance, provider, calls, p50_ms, p95_ms,
+    error_rate}``. Never 500s — an empty/unreadable store returns empty lists
+    (HTTP 200) so the tab paints an honest "no tool calls recorded yet" state.
+
+    Query params: ``limit`` (event scan window, <=5000), ``provenance``
+    (filter to one of builtin/mcp/plugin).
+    """
+    try:
+        limit = max(1, min(5000, int(request.args.get("limit", 5000))))
+    except (TypeError, ValueError):
+        limit = 5000
+    prov_filter = (request.args.get("provenance") or "").strip().lower() or None
+
+    rows = _coerce_rows(_ls_call("query_events", limit=limit))
+    builtin = _builtin_tool_set()
+    res_idx = _result_index(rows)
+
+    agg: dict = {}
+    for name, _start, dur, err, _sid in _iter_tool_calls(rows, res_idx):
+        a = agg.setdefault(name, {"calls": 0, "durs": [], "errs": 0})
+        a["calls"] += 1
+        if dur is not None:
+            a["durs"].append(dur)
+        if err:
+            a["errs"] += 1
+
+    tools = []
+    groups = {"builtin": 0, "mcp": 0, "plugin": 0}
+    for name, a in agg.items():
+        prov, provider = _classify(name, builtin)
+        if prov_filter and prov != prov_filter:
+            continue
+        durs = sorted(a["durs"])
+        calls = a["calls"]
+        tools.append({
+            "name": name,
+            "provenance": prov,
+            "provider": provider or None,
+            "calls": calls,
+            "p50_ms": _percentile(durs, 50),
+            "p95_ms": _percentile(durs, 95),
+            "error_rate": round(a["errs"] / calls, 4) if calls else 0.0,
+            "errors": a["errs"],
+            "timed_calls": len(durs),
+        })
+        if prov in groups:
+            groups[prov] += 1
+
+    # Busiest tool first; ties broken by slowest p95 then name (stable, useful).
+    tools.sort(key=lambda t: (-t["calls"], -(t["p95_ms"] or 0), t["name"]))
+
+    return jsonify({
+        "tools": tools,
+        "groups": groups,
+        "totals": {
+            "tool_count": len(tools),
+            "total_calls": sum(t["calls"] for t in tools),
+            "builtin_universe": len(builtin),
+        },
+        "_source": "local_store",
+    })
+
+
+@bp_tool_catalog.route("/api/tool-catalog/<path:name>/calls")
+def api_tool_catalog_calls(name):
+    """Recent individual calls for one tool (the drill-down).
+
+    Returns ``{name, provenance, provider, calls:[...], _source}`` where each
+    call is ``{ts_ms, duration_ms, status, session_id}`` — newest first — so
+    the UI can expand a tool row into its per-call detail and link each call to
+    its session transcript. Never 500s.
+
+    Query params: ``limit`` (event scan window, <=5000); the call list is
+    capped to the 100 most-recent invocations of this tool.
+    """
+    name = (name or "").strip().replace("mcp__openclaw__", "")
+    if not name:
+        return jsonify({"name": "", "calls": []}), 400
+    try:
+        limit = max(1, min(5000, int(request.args.get("limit", 5000))))
+    except (TypeError, ValueError):
+        limit = 5000
+
+    rows = _coerce_rows(_ls_call("query_events", limit=limit))
+    builtin = _builtin_tool_set()
+    res_idx = _result_index(rows)
+
+    calls = []
+    for tname, start, dur, err, sid in _iter_tool_calls(rows, res_idx):
+        if tname != name:
+            continue
+        calls.append({
+            "ts_ms": start,
+            "duration_ms": dur,
+            "status": "error" if err else "ok",
+            "session_id": sid or None,
+        })
+    # Newest first; cap so a hot tool can't return an unbounded list.
+    calls.sort(key=lambda c: c["ts_ms"] or 0, reverse=True)
+    calls = calls[:100]
+
+    prov, provider = _classify(name, builtin)
+    return jsonify({
+        "name": name,
+        "provenance": prov,
+        "provider": provider or None,
+        "calls": calls,
+        "call_count": len(calls),
+        "_source": "local_store",
+    })


### PR DESCRIPTION
## What

A v1 **Tool Catalog** dashboard surface (PRD P1-3) that shows **every tool the agent actually invoked**, grouped by **provenance** (builtin / MCP / plugin), with per-tool **call count, p50/p95 latency, and error rate** — and it's fully **interactive**: click a tool to drill into its recent individual calls.

New tab lives under **Live trace** in the left nav (next to Tracing + Turn anatomy).

## Endpoints (`routes/tool_catalog.py`, `bp_tool_catalog`)

- `GET /api/tool-catalog` → `{tools:[{name, provenance, provider, calls, p50_ms, p95_ms, error_rate, errors}], groups, totals, _source}` (sortable/filterable server-side via `?provenance=`)
- `GET /api/tool-catalog/<name>/calls` → per-tool recent calls `{ts_ms, duration_ms, status, session_id}` (newest-first, capped at 100)

Neither endpoint ever 500s on empty data.

## How the numbers are derived (DuckDB-first, no gateway RPC)

- **Latency / counts / errors:** `tool_call` events are joined to their closing `tool_result` by tool_use id — the **same join `routes/turn_anatomy.py` uses** (`_tool_use_ids` open, `_tool_result_id` close). Duration = `result_ts - call_ts`, aggregated per tool name into count / p50 / p95 / error rate. Reads via `local_store_via_daemon("query_events")` (the daemon owns the writer lock) with a single-process RO fallback — the shipped `_ls_call` pattern from `routes/scheduler.py` / `routes/policy.py`.
- **Provenance:** name with `__` / `mcp__` → MCP (provider = prefix); name in the OpenClaw sandbox allow-set → builtin; else plugin. The sandbox universe is read from the DuckDB `tool_policy.allow` rows already mirrored by `sync_tool_policy` (`openclaw sandbox explain --json`) — no request-time shell-out. Degrades to name-based classification only when the policy is unsynced.

## Interactive UI (`tabs/tool-catalog.html` + `app.js`)

- Tool rows **clickable** → expand to that tool's recent calls, each with duration + ok/error + session id linking to `viewTranscript(sessionId)`
- **Sortable** (calls / slowest p95 / slowest p50 / error rate / name) and **provenance-filterable**
- Provenance summary chips + hover tooltips throughout
- Reuses existing globals (`viewTranscript`, `switchTab`, `escHtml`); no new deps, no build step

## Cloud

Bounded `toolCatalog` slice (top 60 tools by call count) added to `sync_system_snapshot` in `clawmetry/sync.py`, mirroring the OSS aggregation so the cloud tab shows the same rollup.

## Verification (against real live data)

Run through the daemon read proxy on a real DuckDB store:

```
LIVE /api/tool-catalog (route logic, real events):
  Read    prov=plugin calls=5 p50=9ms  p95=255ms  err=0.2
  Bash    prov=plugin calls=3 p50=2325 p95=70758  err=0.0
  drill-down Read → 5 calls, real session ids (claude_code:beb46e78-...), per-call ms + ok/error

_build_tool_catalog_slice (full store, snapshot path): 24 tools / 8 MCP / 1 builtin / 15 plugin
  Bash  calls=654 p50=1027ms p95=120150ms err=0.012
  Edit  calls=139 p50=31ms   p95=76ms     err=0.122
  mcp__plugin_chrome-devtools-mcp_chrome-devtools__navigate_page  prov=mcp provider=plugin_chrome-devtools-mcp_chrome-devtools  calls=25  err=0.24
```

MCP provenance + provider extraction confirmed on real `mcp__...` names; builtin/plugin classification correct.

Also verified:
- `python3 -m py_compile routes/tool_catalog.py clawmetry/sync.py dashboard.py` — OK
- `node --check clawmetry/static/js/app.js` — OK
- `tests/test_moat_bug_class_v3_event_shape_gate.py` — 3 passed (uses substring matching on `tool_call`/`tool_result`, no pre-v3 `event_type ==` filters)
- `tests/test_no_direct_get_store_in_routes.py` — 2 passed
- Flask test-client: provenance filter, drill-down ordering, and empty-store (returns 200 + empty lists, never 500) all pass

Note: `tests/test_oss_routes_source_canary.py` fails identically on clean `origin/main` (a pre-existing `ring_depth` fixture `KeyError` shared with `test_moat_send_message_e2e.py`); unrelated to this change. The new endpoint reports `_source: local_store` as the canary expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)