### PR TITLE
feat(observability): interactive context-economics tab — utilization + compaction triggers + reclaimed (P1-2)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5938,6 +5938,252 @@ class LocalStore:
                     }
         return {"input_tokens": 0}
 
+    # Overflow-trigger signal strings. A compaction whose own summary/error
+    # text (or an error event adjacent to it) carries one of these was forced
+    # by the model rejecting an over-long prompt — i.e. the agent hit the wall
+    # rather than compacting proactively. Lower-cased substring match.
+    _OVERFLOW_MARKERS = (
+        "request_too_large",
+        "context length exceeded",
+        "context_length_exceeded",
+        "input is too long",
+        "input length and `max_tokens`",
+        "prompt is too long",
+        "maximum context length",
+        "too many tokens",
+        "exceeds the maximum",
+    )
+
+    def query_context_economics(
+        self,
+        *,
+        session_id: str | None = None,
+        util_limit: int = 400,
+        compaction_limit: int = 200,
+    ) -> dict[str, Any]:
+        """Context-window economics for the Context Economics tab (PRD P1-2).
+
+        Bundles three views off the ``events`` table so the dashboard reads
+        one round-trip:
+
+          * ``utilization`` — per-turn live context size over time. For each
+            assistant turn (``_ASSISTANT_EVENT_TYPES`` — v3-safe) we sum the
+            prompt-side tokens the model actually saw on that turn
+            (``input + cache_read + cache_write``, matching
+            ``query_context_window_peek``) and divide by the model's context
+            window. This is the gauge-over-time the PRD asks for.
+          * ``compactions`` — every ``compaction`` event tagged
+            ``proactive`` vs ``overflow``. ``tokens_before`` comes from the
+            event blob; ``tokens_after`` is the first post-compaction
+            assistant-turn context reading for that session (what the window
+            actually shrank to); ``reclaimed = before - after``.
+          * ``overflow_sessions`` — sessions that overflowed then kept going
+            (>=2 compactions with at least one ``overflow`` trigger), i.e. the
+            repeatedly-overflow-then-retry flag.
+
+        ``session_id`` scopes utilization to one conversation (the session
+        picker / clickable chips in the UI). Compactions + overflow flags are
+        always computed workspace-wide so the summary chips stay meaningful;
+        the route filters them client-side when a session is picked.
+
+        Never raises — an empty / fresh DB returns empty lists. Reads only;
+        the daemon owns the writer lock.
+        """
+        try:
+            util_limit = max(1, min(2000, int(util_limit)))
+        except (TypeError, ValueError):
+            util_limit = 400
+        try:
+            compaction_limit = max(1, min(1000, int(compaction_limit)))
+        except (TypeError, ValueError):
+            compaction_limit = 200
+
+        def _ctx_tokens(data: dict) -> int:
+            """Prompt-side token total the model saw this turn. Mirrors
+            query_context_window_peek, plus a ``data.extra`` fallback for the
+            Claude Code SDK echo shape (inputTokens / cacheReadInputTokens /
+            cacheCreationInputTokens live under ``extra``, which
+            ``_extract_usage_splits`` doesn't walk)."""
+            splits = _extract_usage_splits(data)
+            tok = (
+                int(splits.get("input_tokens", 0))
+                + int(splits.get("cache_read_tokens", 0))
+                + int(splits.get("cache_write_tokens", 0))
+            )
+            if tok > 0:
+                return tok
+            extra = data.get("extra") if isinstance(data.get("extra"), dict) else {}
+            if extra:
+                return (
+                    _read_usage_int(extra, _USAGE_KEYS_INPUT)
+                    + _read_usage_int(extra, _USAGE_KEYS_CACHE_READ)
+                    + _read_usage_int(extra, _USAGE_KEYS_CACHE_WRITE)
+                )
+            return 0
+
+        def _model_of(data: dict, fallback: str) -> str:
+            msg = data.get("message") if isinstance(data.get("message"), dict) else {}
+            extra = data.get("extra") if isinstance(data.get("extra"), dict) else {}
+            return (
+                msg.get("model")
+                or data.get("model")
+                or data.get("modelId")
+                or extra.get("model")
+                or fallback
+                or ""
+            )
+
+        def _parse(raw) -> dict:
+            if raw is None:
+                return {}
+            try:
+                text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                parsed = json.loads(text) if text else {}
+                return parsed if isinstance(parsed, dict) else {}
+            except (ValueError, TypeError, UnicodeDecodeError):
+                return {}
+
+        # ── utilization series (assistant turns, chronological) ──
+        ev_in = _sql_in_clause(_ASSISTANT_EVENT_TYPES)
+        util_clauses = [f"event_type IN {ev_in}"]
+        util_params: list[Any] = []
+        if session_id:
+            util_clauses.append("session_id = ?")
+            util_params.append(session_id)
+        util_where = "WHERE " + " AND ".join(util_clauses)
+        util_params.append(int(util_limit))
+        util_rows = self._fetch(
+            f"""
+            SELECT session_id, ts, data, model
+            FROM events
+            {util_where}
+            ORDER BY ts DESC, id DESC
+            LIMIT ?
+            """,
+            util_params,
+        )
+        utilization: list[dict[str, Any]] = []
+        for sid, ts, raw, model_col in util_rows:
+            data = _parse(raw)
+            tok = _ctx_tokens(data)
+            if tok <= 0:
+                continue
+            model = _model_of(data, model_col or "")
+            window = context_window_for_model(model, tok)
+            pct = round(100.0 * tok / window, 2) if window else 0.0
+            utilization.append({
+                "session_id": sid,
+                "ts":         ts,
+                "tokens":     tok,
+                "window":     window,
+                "model":      model,
+                "pct":        pct,
+            })
+        # Oldest-first so the gauge reads left-to-right as a timeline.
+        utilization.sort(key=lambda u: str(u.get("ts") or ""))
+
+        # ── compactions (workspace-wide) ──
+        comp_rows = self._fetch(
+            f"""
+            SELECT session_id, ts, data
+            FROM events
+            WHERE event_type = 'compaction'
+            ORDER BY ts DESC
+            LIMIT ?
+            """,
+            [int(compaction_limit)],
+        )
+        # First post-compaction context reading per session, so we can derive
+        # tokens_after. Build a per-session sorted list of (ts, tokens) once.
+        by_session_util: dict[str, list[tuple[str, int]]] = {}
+        for u in utilization:
+            by_session_util.setdefault(str(u["session_id"]), []).append(
+                (str(u["ts"] or ""), int(u["tokens"]))
+            )
+        # utilization is session-scoped when session_id is set; for the
+        # tokens_after lookup we want all sessions, so re-scan if scoped.
+        if session_id:
+            after_rows = self._fetch(
+                f"""
+                SELECT session_id, ts, data
+                FROM events
+                WHERE event_type IN {ev_in}
+                ORDER BY ts ASC, id ASC
+                LIMIT 4000
+                """,
+                [],
+            )
+            by_session_util = {}
+            for sid, ts, raw in after_rows:
+                tok = _ctx_tokens(_parse(raw))
+                if tok > 0:
+                    by_session_util.setdefault(str(sid), []).append((str(ts or ""), tok))
+
+        def _first_after(sid: str, comp_ts: str) -> int:
+            pts = by_session_util.get(str(sid)) or []
+            for ts, tok in sorted(pts):
+                if ts > (comp_ts or ""):
+                    return tok
+            return 0
+
+        compactions: list[dict[str, Any]] = []
+        overflow_counts: dict[str, dict[str, int]] = {}
+        for sid, ts, raw in comp_rows:
+            data = _parse(raw)
+            summary = str(data.get("summary") or "")
+            tokens_before = int(
+                data.get("tokensBefore") or data.get("tokens_before") or 0
+            )
+            from_hook = bool(data.get("fromHook") or data.get("from_hook") or False)
+            comp_ts = data.get("timestamp") or ts or ""
+            # Trigger inference: scan the compaction blob's own text for an
+            # overflow marker. ``fromHook`` (OpenClaw's proactive
+            # auto-compaction hook) is a strong proactive signal; an error /
+            # reason field carrying a too-large marker flips it to overflow.
+            blob_text = json.dumps(data, default=str).lower()
+            err_text = str(
+                data.get("error") or data.get("reason") or data.get("trigger") or ""
+            ).lower()
+            is_overflow = any(
+                m in blob_text or m in err_text for m in self._OVERFLOW_MARKERS
+            )
+            trigger = "overflow" if is_overflow else ("proactive" if from_hook else "proactive")
+            tokens_after = _first_after(str(sid), str(comp_ts))
+            reclaimed = max(0, tokens_before - tokens_after) if tokens_before else 0
+            compactions.append({
+                "session_id":    sid,
+                "ts":            comp_ts,
+                "trigger":       trigger,
+                "tokens_before": tokens_before,
+                "tokens_after":  tokens_after,
+                "reclaimed":     reclaimed,
+                "from_hook":     from_hook,
+                "summary":       summary,
+            })
+            oc = overflow_counts.setdefault(str(sid), {"total": 0, "overflow": 0})
+            oc["total"] += 1
+            if is_overflow:
+                oc["overflow"] += 1
+
+        # ── repeatedly-overflow-then-retry flag ──
+        # A session that overflowed at least once AND compacted >= 2 times is
+        # thrashing the context wall instead of staying under it.
+        overflow_sessions: list[dict[str, Any]] = []
+        for sid, c in overflow_counts.items():
+            if c["overflow"] >= 1 and c["total"] >= 2:
+                overflow_sessions.append({
+                    "session_id":       sid,
+                    "compaction_count": c["total"],
+                    "overflow_count":   c["overflow"],
+                })
+        overflow_sessions.sort(key=lambda s: s["overflow_count"], reverse=True)
+
+        return {
+            "utilization":       utilization,
+            "compactions":       compactions,
+            "overflow_sessions": overflow_sessions,
+        }
+
     def query_model_fallbacks(
         self,
         *,

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -930,6 +930,192 @@ function cancelAllPendingSSEDwell() {
   });
 }
 
+// ── Context Economics (PRD P1-2) ───────────────────────────────────────────
+// Interactive context-window economics: a utilization gauge over time, the
+// compaction log tagged proactive/overflow with tokens reclaimed, and the
+// repeatedly-overflow-then-retry flag. Reads /api/context-economics.
+//   - Click a session chip to scope the gauge to one conversation.
+//   - Hover a gauge bar for the per-turn ctx tokens / window / %.
+//   - Click a compaction row to expand its before/after + summary, with a
+//     "View transcript" deep-link into the global viewTranscript(sessionId).
+var _ceSessionId = null;          // active session scope (null = all)
+var _ceCompactionsCache = [];     // last-rendered compactions (for expand)
+
+function _ceShortSid(sid) {
+  sid = String(sid || '');
+  // claude_code:UUID -> UUID head; otherwise tail. Keep it short + stable.
+  var parts = sid.split(':');
+  var tail = parts[parts.length - 1] || sid;
+  return tail.slice(0, 8);
+}
+
+function _ceFmtTokens(n) {
+  n = Number(n || 0);
+  if (n >= 1000) return (n / 1000).toFixed(n >= 100000 ? 0 : 1) + 'K';
+  return String(n);
+}
+
+function _ceSelectSession(sid) {
+  _ceSessionId = (_ceSessionId === sid) ? null : sid;  // toggle off if same
+  loadContextEconomics();
+}
+
+function _ceToggleCompaction(idx) {
+  var row = document.getElementById('ce-comp-detail-' + idx);
+  if (!row) return;
+  row.style.display = (row.style.display === 'none' || !row.style.display) ? 'block' : 'none';
+}
+
+async function loadContextEconomics() {
+  var gaugeEl = document.getElementById('ce-gauge-panel');
+  var sumEl = document.getElementById('ce-summary');
+  var chipsEl = document.getElementById('ce-session-chips');
+  var compEl = document.getElementById('ce-compactions-panel');
+  var ovEl = document.getElementById('ce-overflow-panel');
+  if (!gaugeEl) return;
+  var url = '/api/context-economics?limit=400' + (_ceSessionId ? ('&session_id=' + encodeURIComponent(_ceSessionId)) : '');
+  var data;
+  try {
+    data = await fetch(url).then(function(r){ return r.json(); });
+  } catch (e) {
+    gaugeEl.innerHTML = '<div style="color:#e74c3c;font-size:13px;padding:16px;">Failed to load context economics: ' + escHtml(String(e)) + '</div>';
+    return;
+  }
+  var util = data.utilization || [];
+  var comps = data.compactions || [];
+  var overflow = data.overflow_sessions || [];
+  var chips = data.session_chips || [];
+  var s = data.summary || {};
+  _ceCompactionsCache = comps;
+
+  // ── Summary chips ──
+  if (sumEl) {
+    function chip(label, val, color) {
+      return '<div style="border:1px solid var(--border-primary);border-radius:10px;padding:10px 14px;min-width:96px;">'
+        + '<div style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;">' + escHtml(label) + '</div>'
+        + '<div style="font-size:18px;font-weight:700;color:' + (color || 'var(--text-primary)') + ';margin-top:2px;">' + escHtml(String(val)) + '</div></div>';
+    }
+    var peakColor = (s.peak_pct || 0) >= 90 ? '#ef4444' : ((s.peak_pct || 0) >= 70 ? '#d97706' : 'var(--text-primary)');
+    sumEl.innerHTML = '<div style="display:flex;gap:10px;flex-wrap:wrap;">'
+      + chip('Peak window', (s.peak_pct || 0) + '%', peakColor)
+      + chip('Compactions', s.compaction_count || 0)
+      + chip('Overflow', s.overflow_count || 0, (s.overflow_count || 0) > 0 ? '#ef4444' : 'var(--text-muted)')
+      + chip('Proactive', s.proactive_count || 0, '#16a34a')
+      + chip('Tokens reclaimed', _ceFmtTokens(s.total_reclaimed || 0), '#16a34a')
+      + chip('Overflow sessions', s.overflow_sessions || 0, (s.overflow_sessions || 0) > 0 ? '#ef4444' : 'var(--text-muted)')
+      + '</div>';
+  }
+
+  // ── Session picker chips ──
+  if (chipsEl) {
+    if (chips.length === 0) {
+      chipsEl.innerHTML = '';
+    } else {
+      var ch = '<div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;">';
+      ch += '<span style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;margin-right:4px;">Scope:</span>';
+      ch += '<span onclick="_ceSelectSession(null)" style="cursor:pointer;font-size:12px;font-weight:600;border-radius:14px;padding:4px 12px;border:1px solid ' + (!_ceSessionId ? '#3b82f6' : 'var(--border-primary)') + ';background:' + (!_ceSessionId ? 'rgba(59,130,246,.12)' : 'transparent') + ';color:var(--text-primary);">All sessions</span>';
+      chips.slice(0, 12).forEach(function(c) {
+        var active = (_ceSessionId === c.session_id);
+        var pk = Number(c.peak_pct || 0);
+        var dot = pk >= 90 ? '#ef4444' : (pk >= 70 ? '#d97706' : '#16a34a');
+        ch += '<span onclick="_ceSelectSession(' + JSON.stringify(c.session_id) + ')" title="' + escHtml(c.session_id) + ' · peak ' + pk + '%" style="cursor:pointer;font-size:12px;font-weight:600;border-radius:14px;padding:4px 12px;border:1px solid ' + (active ? '#3b82f6' : 'var(--border-primary)') + ';background:' + (active ? 'rgba(59,130,246,.12)' : 'transparent') + ';color:var(--text-primary);">'
+          + '<span style="display:inline-block;width:7px;height:7px;border-radius:50%;background:' + dot + ';margin-right:5px;"></span>'
+          + escHtml(_ceShortSid(c.session_id)) + ' <span style="color:var(--text-muted);font-weight:500;">' + pk + '%</span></span>';
+      });
+      ch += '</div>';
+      chipsEl.innerHTML = ch;
+    }
+  }
+
+  // ── Utilization gauge over time (sparkline-style bars) ──
+  if (util.length === 0) {
+    gaugeEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;border:1px solid var(--border-primary);border-radius:10px;">No context-window readings yet. Once your agents take a few turns, per-turn utilization appears here.</div>';
+  } else {
+    var maxPct = Math.max(100, util.reduce(function(m, u){ return Math.max(m, Number(u.pct || 0)); }, 0));
+    var g = '<div style="border:1px solid var(--border-primary);border-radius:10px;padding:14px;">';
+    g += '<div style="display:flex;align-items:baseline;gap:8px;margin-bottom:10px;">';
+    g += '<div style="font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;">Context-window utilization over time</div>';
+    g += '<span style="font-size:11px;color:var(--text-muted);">' + util.length + ' turns' + (_ceSessionId ? (' · ' + escHtml(_ceShortSid(_ceSessionId))) : '') + '</span></div>';
+    // Threshold guide lines (70% warn / 90% danger) behind the bars.
+    g += '<div style="position:relative;height:120px;display:flex;align-items:flex-end;gap:1px;border-bottom:1px solid var(--border-secondary);">';
+    g += '<div style="position:absolute;left:0;right:0;bottom:' + (90 / maxPct * 100) + '%;border-top:1px dashed rgba(239,68,68,.5);"></div>';
+    g += '<div style="position:absolute;left:0;right:0;bottom:' + (70 / maxPct * 100) + '%;border-top:1px dashed rgba(217,119,6,.4);"></div>';
+    util.forEach(function(u) {
+      var pct = Number(u.pct || 0);
+      var h = Math.max(2, pct / maxPct * 100);
+      var color = pct >= 90 ? '#ef4444' : (pct >= 70 ? '#d97706' : '#3b82f6');
+      var tip = (u.ts || '') + ' · ' + _ceFmtTokens(u.tokens) + ' / ' + _ceFmtTokens(u.window) + ' ctx tokens (' + pct + '%)' + (u.model ? (' · ' + u.model) : '');
+      g += '<div title="' + escHtml(tip) + '" style="flex:1;min-width:2px;height:' + h + '%;background:' + color + ';border-radius:2px 2px 0 0;cursor:crosshair;"></div>';
+    });
+    g += '</div>';
+    g += '<div style="display:flex;justify-content:space-between;font-size:10px;color:var(--text-faint);margin-top:5px;">'
+      + '<span>oldest</span><span style="color:#d97706;">- - 70%</span><span style="color:#ef4444;">- - 90%</span><span>newest</span></div>';
+    g += '</div>';
+    gaugeEl.innerHTML = g;
+  }
+
+  // ── Compaction log (clickable rows -> before/after + summary) ──
+  if (compEl) {
+    if (comps.length === 0) {
+      compEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;border:1px solid var(--border-primary);border-radius:10px;">No compactions recorded' + (_ceSessionId ? ' for this session' : '') + '. OpenClaw compacts the transcript when the window fills; events appear here as they happen.</div>';
+    } else {
+      var c = '<div style="border:1px solid var(--border-primary);border-radius:10px;overflow:hidden;">';
+      c += '<div style="font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;padding:12px 14px;border-bottom:1px solid var(--border-primary);">Compaction events <span style="color:var(--text-faint);font-weight:500;text-transform:none;">— click a row to expand</span></div>';
+      comps.forEach(function(cp, idx) {
+        var isOverflow = cp.trigger === 'overflow';
+        var trigColor = isOverflow ? '#ef4444' : '#16a34a';
+        var trigBg = isOverflow ? 'rgba(239,68,68,.12)' : 'rgba(22,163,74,.12)';
+        var reclaimed = Number(cp.reclaimed || 0);
+        c += '<div onclick="_ceToggleCompaction(' + idx + ')" style="cursor:pointer;display:flex;align-items:center;gap:10px;padding:9px 14px;border-bottom:1px solid var(--border-secondary);font-size:12px;">';
+        c += '<span style="font-size:10px;font-weight:700;color:' + trigColor + ';background:' + trigBg + ';border-radius:4px;padding:1px 7px;text-transform:uppercase;">' + escHtml(cp.trigger || 'proactive') + '</span>';
+        c += '<span style="color:var(--text-faint);background:var(--bg-secondary);border-radius:4px;padding:1px 6px;font-size:10px;" title="' + escHtml(cp.session_id || '') + '">' + escHtml(_ceShortSid(cp.session_id)) + '</span>';
+        c += '<span style="flex:1;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(String(cp.ts || '')) + '</span>';
+        c += '<span style="color:var(--text-primary);white-space:nowrap;">' + _ceFmtTokens(cp.tokens_before) + ' &#8594; ' + _ceFmtTokens(cp.tokens_after) + '</span>';
+        if (reclaimed > 0) c += '<span style="color:#16a34a;font-weight:600;white-space:nowrap;">&#8722;' + _ceFmtTokens(reclaimed) + '</span>';
+        c += '<span style="color:var(--text-faint);">&#9662;</span>';
+        c += '</div>';
+        // Expandable detail.
+        c += '<div id="ce-comp-detail-' + idx + '" style="display:none;padding:12px 16px;background:var(--bg-secondary);border-bottom:1px solid var(--border-secondary);font-size:12px;">';
+        c += '<div style="display:flex;gap:18px;flex-wrap:wrap;margin-bottom:10px;">';
+        c += '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;">Tokens before</div><div style="font-size:15px;font-weight:700;color:var(--text-primary);">' + Number(cp.tokens_before || 0).toLocaleString() + '</div></div>';
+        c += '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;">Tokens after</div><div style="font-size:15px;font-weight:700;color:var(--text-primary);">' + Number(cp.tokens_after || 0).toLocaleString() + '</div></div>';
+        c += '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;">Reclaimed</div><div style="font-size:15px;font-weight:700;color:#16a34a;">' + reclaimed.toLocaleString() + '</div></div>';
+        c += '<div><div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;">Trigger</div><div style="font-size:13px;font-weight:600;color:' + trigColor + ';">' + escHtml(cp.trigger || 'proactive') + (cp.from_hook ? ' (auto-hook)' : '') + '</div></div>';
+        c += '</div>';
+        if (cp.summary) {
+          c += '<div style="font-size:10px;color:var(--text-muted);text-transform:uppercase;margin-bottom:4px;">Compaction summary</div>';
+          c += '<div style="max-height:160px;overflow:auto;white-space:pre-wrap;color:var(--text-secondary);line-height:1.5;border:1px solid var(--border-secondary);border-radius:6px;padding:8px;background:var(--bg-primary);">' + escHtml(String(cp.summary).slice(0, 4000)) + '</div>';
+        }
+        c += '<div style="margin-top:10px;"><a href="#" onclick="event.stopPropagation();viewTranscript(' + JSON.stringify(cp.session_id) + ');return false;" style="color:#7eb8f7;text-decoration:underline;font-weight:600;">View session transcript &#8594;</a></div>';
+        c += '</div>';
+      });
+      c += '</div>';
+      compEl.innerHTML = c;
+    }
+  }
+
+  // ── Repeatedly-overflow-then-retry flag ──
+  if (ovEl) {
+    if (overflow.length === 0) {
+      ovEl.innerHTML = '';
+    } else {
+      var o = '<div style="border:1px solid rgba(239,68,68,.4);border-radius:10px;overflow:hidden;margin-top:4px;">';
+      o += '<div style="font-size:12px;font-weight:700;color:#ef4444;text-transform:uppercase;letter-spacing:0.5px;padding:12px 14px;border-bottom:1px solid var(--border-secondary);background:rgba(239,68,68,.06);">&#9888; Sessions overflowing then retrying</div>';
+      overflow.forEach(function(os) {
+        o += '<div style="display:flex;align-items:center;gap:10px;padding:9px 14px;border-bottom:1px solid var(--border-secondary);font-size:12px;">';
+        o += '<span style="color:var(--text-faint);background:var(--bg-secondary);border-radius:4px;padding:1px 6px;font-size:10px;" title="' + escHtml(os.session_id || '') + '">' + escHtml(_ceShortSid(os.session_id)) + '</span>';
+        o += '<span style="flex:1;color:var(--text-muted);">' + (os.compaction_count || 0) + ' compactions · ' + (os.overflow_count || 0) + ' overflow</span>';
+        o += '<a href="#" onclick="_ceSelectSession(' + JSON.stringify(os.session_id) + ');return false;" style="color:#7eb8f7;text-decoration:underline;">Scope gauge</a>';
+        o += '<a href="#" onclick="viewTranscript(' + JSON.stringify(os.session_id) + ');return false;" style="color:#7eb8f7;text-decoration:underline;">Transcript &#8594;</a>';
+        o += '</div>';
+      });
+      o += '</div>';
+      ovEl.innerHTML = o;
+    }
+  }
+}
+
+
 function switchTab(name) {
   // Track the active tab so tab-scoped pollers (Overview loadAll, etc.) only
   // run on their own screen instead of on every tab.
@@ -966,6 +1152,7 @@ function switchTab(name) {
   if (name === 'tracing') loadTracing();
   if (name === 'turn-anatomy') loadTurnAnatomy();
   if (name === 'tool-catalog') { if (typeof loadToolCatalog === 'function') loadToolCatalog(); }
+  if (name === 'context-economics') { if (typeof loadContextEconomics === 'function') loadContextEconomics(); }
   if (name === 'brain') loadBrainPage();
   if (name === 'selfevolve') loadSelfEvolvePage();
   if (name === 'notifications') { if (typeof loadNotificationsPage === 'function') loadNotificationsPage(); }

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10847,6 +10847,59 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         tool_catalog_slice = _build_tool_catalog_slice()
     except Exception as _e_tc:
         log.debug("snapshot: tool_catalog slice failed: %s", _e_tc)
+    # Context-window economics (PRD P1-2) → bounded snapshot slice for the
+    # cloud Context Economics tab. Ships the compaction log (trigger + before/
+    # after + reclaimed) and the overflow-session flags, plus a small summary,
+    # but caps rows and truncates the free-text compaction summary so a long
+    # transcript summary can't bloat the shared snapshot (#1895 / 0.12.278
+    # bloat lesson). The full per-turn utilization series is intentionally
+    # NOT shipped — it can be hundreds of points per session; the cloud can
+    # re-derive a coarse view from the summary + compactions, and the OSS tab
+    # reads the live series directly.
+    context_economics_slice: dict = {
+        "compactions": [], "overflow_sessions": [], "summary": {},
+    }
+    try:
+        from clawmetry import local_store as _ls_ce
+        _ce_store = _ls_ce.get_store()
+        if _ce_store is not None:
+            _ce = _ce_store.query_context_economics(
+                util_limit=400, compaction_limit=80,
+            ) or {}
+            _ce_comps = _ce.get("compactions") or []
+            context_economics_slice["compactions"] = [
+                {
+                    "session_id":    c.get("session_id"),
+                    "ts":            c.get("ts"),
+                    "trigger":       c.get("trigger"),
+                    "tokens_before": c.get("tokens_before"),
+                    "tokens_after":  c.get("tokens_after"),
+                    "reclaimed":     c.get("reclaimed"),
+                    "from_hook":     c.get("from_hook"),
+                    # short prefix only — never the full compaction summary
+                    "summary":       (str(c.get("summary") or "")[:280]),
+                }
+                for c in _ce_comps[:80]
+            ]
+            context_economics_slice["overflow_sessions"] = (
+                _ce.get("overflow_sessions") or []
+            )[:50]
+            _ce_util = _ce.get("utilization") or []
+            _peak = max((float(u.get("pct") or 0) for u in _ce_util), default=0.0)
+            _overflow_n = sum(
+                1 for c in _ce_comps if c.get("trigger") == "overflow"
+            )
+            context_economics_slice["summary"] = {
+                "compaction_count":   len(_ce_comps),
+                "overflow_count":     _overflow_n,
+                "proactive_count":    len(_ce_comps) - _overflow_n,
+                "total_reclaimed":    sum(int(c.get("reclaimed") or 0) for c in _ce_comps),
+                "peak_pct":           round(_peak, 2),
+                "overflow_sessions":  len(_ce.get("overflow_sessions") or []),
+                "utilization_points": len(_ce_util),
+            }
+    except Exception as _e_ce:
+        log.debug("snapshot: context_economics slice failed: %s", _e_ce)
 
     payload = {
         "system": system,
@@ -10875,6 +10928,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "runLedger": run_ledger_slice,
         "toolPolicy": tool_policy_slice,
         "toolCatalog": tool_catalog_slice,
+        "contextEconomics": context_economics_slice,
         "spending": spending,
         "cronJobs": _build_cron_jobs(paths),
         "channels": _build_channel_data(config),

--- a/clawmetry/templates/tabs/context-economics.html
+++ b/clawmetry/templates/tabs/context-economics.html
@@ -1,0 +1,22 @@
+<div class="page" id="page-context-economics">
+  <div class="refresh-bar">
+    <h2 style="font-size:16px;font-weight:700;color:var(--text-primary);margin:0;flex:1;">&#128202; Context Economics</h2>
+    <button class="refresh-btn" onclick="loadContextEconomics()">&#8635; Refresh</button>
+  </div>
+  <p style="color:var(--text-muted);font-size:13px;margin:2px 0 14px;max-width:760px;">
+    How full your agents&#8217; context windows get, when OpenClaw compacted (proactively vs forced by an overflow),
+    how many tokens each compaction reclaimed, and which sessions keep slamming into the wall.
+  </p>
+  <!-- Summary chips -->
+  <div id="ce-summary" style="margin-bottom:14px;"></div>
+  <!-- Session picker chips (scope the gauge to one conversation) -->
+  <div id="ce-session-chips" style="margin-bottom:14px;"></div>
+  <!-- Context-window utilization gauge over time -->
+  <div id="ce-gauge-panel" style="margin-bottom:18px;">
+    <div style="color:var(--text-muted);font-size:13px;padding:16px;">Loading utilization&#8230;</div>
+  </div>
+  <!-- Compaction events (clickable rows -> before/after + summary) -->
+  <div id="ce-compactions-panel" style="margin-bottom:18px;"></div>
+  <!-- Repeatedly-overflow-then-retry sessions -->
+  <div id="ce-overflow-panel"></div>
+</div><!-- end page-context-economics -->

--- a/dashboard.py
+++ b/dashboard.py
@@ -125,6 +125,7 @@ from routes.scheduler import bp_scheduler
 from routes.policy import bp_policy
 from routes.turn_anatomy import bp_turn_anatomy
 from routes.tool_catalog import bp_tool_catalog
+from routes.context_economics import bp_context_economics
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -10625,6 +10626,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_policy)
     app.register_blueprint(bp_turn_anatomy)
     app.register_blueprint(bp_tool_catalog)
+    app.register_blueprint(bp_context_economics)
 
     # Register built-in agent adapters. External plugins can register more
     # via clawmetry.extensions entry points — see clawmetry/adapters/.
@@ -11082,6 +11084,8 @@ DASHBOARD_HTML = r"""
         </div>
         <div class="left-nav-item left-nav-item-sub" id="left-nav-tool-catalog" data-tab="tool-catalog" onclick="switchTab('tool-catalog')" title="Every tool the agent uses by provenance, with call count and p50/p95 latency">
           <span class="left-nav-label">Tool catalog</span>
+        <div class="left-nav-item left-nav-item-sub" id="left-nav-context-economics" data-tab="context-economics" onclick="switchTab('context-economics')" title="Context-window utilization over time, compaction triggers and tokens reclaimed">
+          <span class="left-nav-label">Context economics</span>
         </div>
       </div>
 
@@ -11212,6 +11216,7 @@ DASHBOARD_HTML = r"""
 
 <!-- TOOL CATALOG (provenance + p50/p95 latency + error rate, P1-3) -->
 {% include 'tabs/tool-catalog.html' %}
+{% include 'tabs/context-economics.html' %}
 
 <!-- SECURITY -->
 {% include 'tabs/security.html' %}

--- a/routes/context_economics.py
+++ b/routes/context_economics.py
@@ -1,0 +1,123 @@
+"""routes/context_economics.py — context-window economics (PRD P1-2).
+
+Surfaces the cost of the context window itself: how full each agent turn's
+prompt got, when OpenClaw compacted (proactively vs forced by an overflow
+error), how many tokens each compaction reclaimed, and which sessions keep
+slamming into the wall (overflow-then-retry).
+
+  GET /api/context-economics?session_id=...
+
+Returns ``{utilization, compactions, overflow_sessions, summary, _source}``.
+Reads go through the daemon proxy (the daemon owns the DuckDB writer lock)
+with a single-process direct-read fallback — the same pattern as
+``routes/scheduler.py`` / ``routes/agents.py``. NEVER 500s on empty data: a
+fresh sync (no compactions yet, or OpenClaw running under its context limit)
+returns empty lists so the tab renders an honest "no compactions yet" state.
+"""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+bp_context_economics = Blueprint("context_economics", __name__)
+
+
+def _ls_call(method_name: str, **kwargs):
+    """Cross-process LocalStore call with single-process fallback (issue #1088)."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+def _coerce(payload):
+    """``local_store_via_daemon`` returns the raw method result (a dict) or a
+    ``{"result": {...}}`` envelope depending on transport — normalise both."""
+    if isinstance(payload, dict) and "result" in payload and isinstance(payload["result"], dict):
+        return payload["result"]
+    return payload if isinstance(payload, dict) else {}
+
+
+@bp_context_economics.route("/api/context-economics")
+def api_context_economics():
+    """Context-window economics bundle.
+
+    Query params:
+      * ``session_id`` — scope the utilization gauge to one conversation
+        (the UI session picker / clickable chips). Compactions + overflow
+        flags are computed workspace-wide; the route filters them to the
+        picked session here so the chips/list stay coherent with the gauge.
+      * ``limit`` — max utilization points (<=2000, default 400).
+
+    The ``summary`` block is a small derived rollup the tab paints as chips:
+    compaction count, overflow count, total tokens reclaimed, peak window %.
+    """
+    session_id = (request.args.get("session_id") or "").strip() or None
+    try:
+        limit = max(1, min(2000, int(request.args.get("limit", 400))))
+    except (TypeError, ValueError):
+        limit = 400
+
+    data = _coerce(_ls_call(
+        "query_context_economics",
+        session_id=session_id,
+        util_limit=limit,
+    ))
+    utilization = data.get("utilization") or []
+    compactions = data.get("compactions") or []
+    overflow_sessions = data.get("overflow_sessions") or []
+
+    # When a session is picked, scope compactions to it so the list matches
+    # the gauge. (query_context_economics returns compactions workspace-wide
+    # so the cross-session overflow flag stays meaningful.)
+    if session_id:
+        compactions = [
+            c for c in compactions if str(c.get("session_id")) == session_id
+        ]
+
+    # Session chips for the picker: distinct sessions seen in the gauge,
+    # most-recent first, with their peak utilization %.
+    chips: dict[str, dict] = {}
+    for u in utilization:
+        sid = str(u.get("session_id") or "")
+        if not sid:
+            continue
+        entry = chips.setdefault(sid, {"session_id": sid, "peak_pct": 0.0, "ts": ""})
+        try:
+            entry["peak_pct"] = max(entry["peak_pct"], float(u.get("pct") or 0))
+        except (TypeError, ValueError):
+            pass
+        ts = str(u.get("ts") or "")
+        if ts > entry["ts"]:
+            entry["ts"] = ts
+    session_chips = sorted(chips.values(), key=lambda c: c["ts"], reverse=True)
+
+    total_reclaimed = sum(int(c.get("reclaimed") or 0) for c in compactions)
+    overflow_count = sum(1 for c in compactions if c.get("trigger") == "overflow")
+    peak_pct = max((float(u.get("pct") or 0) for u in utilization), default=0.0)
+    summary = {
+        "compaction_count":     len(compactions),
+        "overflow_count":       overflow_count,
+        "proactive_count":      len(compactions) - overflow_count,
+        "total_reclaimed":      total_reclaimed,
+        "peak_pct":             round(peak_pct, 2),
+        "overflow_sessions":    len(overflow_sessions),
+        "utilization_points":   len(utilization),
+    }
+
+    return jsonify({
+        "utilization":       utilization,
+        "compactions":       compactions,
+        "overflow_sessions": overflow_sessions,
+        "session_chips":     session_chips,
+        "summary":           summary,
+        "_source":           "local_store",
+    })

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -449,6 +449,11 @@ _DAEMON_METHODS = frozenset({
     # off the JSONL scanner. Returns last non-zero usage.input_tokens
     # from the most-recent active session.
     "query_context_window_peek",
+    # PRD P1-2 (Context Economics): per-turn context utilization over time +
+    # compaction events tagged proactive/overflow + reclaimed tokens +
+    # repeatedly-overflow-then-retry session flag. Powers the Context
+    # Economics tab (routes/context_economics.py:/api/context-economics).
+    "query_context_economics",
     # Phase 4 (issue #1088 follow-up, 2026-05-13): channel-message
     # foundation. Three helpers proved out the schema; the remaining 18
     # per-provider channel routes follow once these go green.


### PR DESCRIPTION
## What

A v1 **Context Economics** dashboard surface that visualizes OpenClaw context-window economics (PRD P1-2). It answers: how full does each agent turn's prompt get, when did OpenClaw compact and why, how many tokens did each compaction reclaim, and which sessions keep slamming into the wall.

### The four PRD asks
- **Utilization gauge over time** — per-turn live prompt size (`input + cache_read + cache_write`, matching `query_context_window_peek`) vs the model's context window, with 70%/90% threshold guides.
- **Compaction events tagged proactive vs overflow** — overflow inferred from the compaction blob's own text (`request_too_large`, `context length exceeded`, `input is too long`, ...); `fromHook` auto-compaction reads as proactive.
- **Tokens reclaimed per compaction** — `tokens_before` (from the event) minus the first post-compaction context reading for that session.
- **Overflow-then-retry flag** — sessions with >=2 compactions and >=1 overflow trigger.

### Interactive (hard requirement)
- **Clickable session chips** scope the gauge to one conversation (toggle off to go back to all sessions).
- **Clickable compaction rows** expand in place to show before/after token counts + reclaimed + the compaction summary, plus a "View session transcript" deep-link into the global `viewTranscript(sessionId)`.
- **Hover tooltips** on every gauge bar (ts, ctx tokens / window, %, model).
- Reuses the existing global `escHtml` / `viewTranscript` / `switchTab` helpers; no reinvention.

## How (mirrors the shipped `routes/scheduler.py` slice)
- `LocalStore.query_context_economics` — DuckDB-first. v3-safe event filter via `_ASSISTANT_EVENT_TYPES`, plus a `data.extra` fallback for the Claude Code SDK echo shape that `_extract_usage_splits` doesn't walk.
- `routes/context_economics.py` (`bp_context_economics`) with the `_ls_call` daemon-proxy + single-process fallback. **Never 500s on empty data.**
- Method added to `_DAEMON_METHODS` in `routes/local_query.py`.
- New tab template + nav item under the **Live trace** group + `switchTab` wiring + `loadContextEconomics()` in `static/js/app.js` (inline-style `var(--...)` theme tokens, no new deps).
- Bounded `contextEconomics` slice in `sync_system_snapshot` (compaction summary truncated to 280 chars, rows capped) so the cloud can render it later.

## Verification
- Real daemon-proxy utilization sample: 156 live turns, one session peaking at **89.46%** of its 200K window.
- Seeded isolated temp DuckDB (`CLAWMETRY_LOCAL_STORE_PATH`, never the prod writer) exercising trigger/reclaimed/overflow via the Flask test client:
  - `request_too_large` / `input is too long` -> `overflow`; `fromHook` -> `proactive`.
  - reclaimed = 156998 / 144998 / 119998; overflow-then-retry flag correctly fired for the 2x-overflow session.
  - route returns 200, session scope filter works, empty/unknown-session is empty-safe (no 500).
- `python3 -m py_compile` (all 5 changed .py) ✓ · `node --check app.js` ✓ · `tests/test_moat_bug_class_v3_event_shape_gate.py` 3 passed ✓ · blueprint registers on the app ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)