### PR TITLE
e2e(c5): explicit auth probe + server startup gate in e2e-critical CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           done
           echo "✅ JS Syntax OK"
 
-  # ── API tests across all 3 platforms ───────────────────────────────────────────
+  # ── API tests across all 3 platforms ─────────────────────────────────────────────
   api-tests:
     name: API Tests (${{ matrix.os }})
     needs: lint
@@ -117,7 +117,7 @@ jobs:
           CLAWMETRY_TOKEN: ci-test-token
         run: python3 -m pytest tests/test_api.py -v --tb=short
 
-  # ── MOAT verifier (hermetic, hard-fail) ───────────────────────────────────────────
+  # ── MOAT verifier (hermetic, hard-fail) ────────────────────────────────────────────────────
   # Issue #1491 / PRD #1133 invariant #3: "A regression in either direction
   # is caught BEFORE merge." These files exercise the
   # OpenClaw → DuckDB → API surface contract end-to-end, plus the lint
@@ -263,12 +263,12 @@ jobs:
           echo "── local_server.log tail ──"
           tail -200 /tmp/local_server.log || true
 
-  # ── E2E Playwright tests — critical subset (hard-gate, blocks merge) ──────
+  # ── E2E Playwright tests — critical subset (hard-gate, blocks merge) ────
   # Per issue #1528: the prior `e2e-tests` job carried `continue-on-error: true`
   # which silently masked Playwright regressions. We split the suite into:
   #   1. `e2e-critical` (this job) — TestTabsLoad: page-load + tab-nav smoke
   #      tests that have been stable. Hard-fails on regression.
-  #      TestAllTabsPostAuth: C5 auth-overlay gate (issue #1646).
+  #      TestAllTabsPostAuth: C5 auth-overlay gate (issue #1646, #2146).
   #   2. `e2e-nightly`  (.github/workflows/e2e-nightly.yml) — the broader
   #      TestFlowDiagram suite, which depends on SVG rendering of live data
   #      and is still flaky. Runs on schedule, not per-PR.
@@ -285,16 +285,44 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: pip install flask pytest pytest-playwright requests
+        # duckdb is in requirements.txt and used by the dashboard's local
+        # event store; without it the server crashes on import and the
+        # health check silently times out.
+        run: pip install flask pytest pytest-playwright requests duckdb
       - name: Install Playwright browsers
         run: python3 -m playwright install chromium --with-deps
       - name: Start server
         run: |
           OPENCLAW_GATEWAY_TOKEN=ci-test-token python3 dashboard.py --port 8900 --no-debug &
+          ok=0
           for i in $(seq 1 30); do
-            curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health && break
+            curl -sf -H "Authorization: Bearer ci-test-token" http://localhost:8900/api/health \
+              && echo "Dashboard ready after ${i}s" && ok=1 && break
             sleep 1
           done
+          if [ "$ok" != "1" ]; then
+            echo "::error::Dashboard failed to start on port 8900. Check for import errors or port conflicts."
+            exit 1
+          fi
+      - name: Probe gateway-token auth (C5 gate)
+        # Explicit pre-flight: verify /api/auth/check accepts the token
+        # BEFORE Playwright runs. Without this a token mismatch produces
+        # 19 identical overlay-visible assertion failures instead of one
+        # actionable message. Routes/meta.py:api_auth_check compares the
+        # bearer token directly to OPENCLAW_GATEWAY_TOKEN (no gateway
+        # process needed), so this probe is purely env-var correctness.
+        run: |
+          resp=$(curl -sf -H "Authorization: Bearer ci-test-token" \
+            "http://localhost:8900/api/auth/check" 2>/dev/null || echo '{"valid":false}')
+          valid=$(echo "$resp" | python3 -c \
+            "import sys,json; d=json.load(sys.stdin); print(d.get('valid',False))" \
+            2>/dev/null || echo "False")
+          if [ "$valid" != "True" ]; then
+            echo "::error::/api/auth/check returned valid!=true (C5 gate). Response: $resp"
+            echo "::error::Token plumbing broken: OPENCLAW_GATEWAY_TOKEN=ci-test-token not accepted."
+            exit 1
+          fi
+          echo "C5 auth probe OK: /api/auth/check returned valid=true"
       - name: Run E2E tests (critical subset only -- hard gate)
         env:
           CLAWMETRY_URL: http://localhost:8900
@@ -305,7 +333,7 @@ jobs:
             tests/test_e2e_oss_all_tabs.py::TestAllTabsPostAuth \
             -v --tb=short
 
-  # ── pip install smoke test across platforms ──────────────────────────────
+  # ── pip install smoke test across platforms ─────────────────────────────────────────
   pip-install:
     name: pip install (${{ matrix.os }})
     needs: lint
@@ -381,7 +409,7 @@ jobs:
           fi
           echo "✅ /static/js/app.js served from installed wheel"
 
-  # ── Eval suite gate (Phase 2 evals, refs #1619 / PR #1626) ─────────────
+  # ── Eval suite gate (Phase 2 evals, refs #1619 / PR #1626) ──────────────
   # Runs ClawMetry's own golden suite (tests/data/golden_ci.yaml) through
   # the `clawmetry eval` CLI on every PR. Catches regressions in:
   #   * eval_suite_runner.py YAML parsing / runner loop


### PR DESCRIPTION
## Summary

Closes the C5 visual-diff gateway-token gap in the `e2e-critical` CI job. Three targeted changes, all in `.github/workflows/ci.yml`:

- **Add `duckdb` to the install step.** `duckdb` is declared in `requirements.txt` but was absent from `e2e-critical`'s dep list. Dashboard startup fails silently without it on some import paths, causing the health check to time out and producing cryptic downstream errors.

- **Make the server startup check fail explicitly.** The previous loop ran 30 iterations and silently completed even if the server never responded. A crash during dashboard startup now immediately surfaces as `::error::Dashboard failed to start` with `exit 1` instead of reaching Playwright with a dead server.

- **Add an explicit gateway-token auth probe (C5 gate).** A `curl` call to `/api/auth/check` runs before Playwright. `routes/meta.py:api_auth_check` is a pure env-var comparison (`OPENCLAW_GATEWAY_TOKEN` vs bearer token) -- no gateway process needed. Without this probe, a token mismatch produces 19 identical "overlay visible" assertion failures that all point at the wrong place. With it, a mismatch gives one clear message: "Token plumbing broken: OPENCLAW_GATEWAY_TOKEN=ci-test-token not accepted."

## Acceptance test

After merge, the following is verifiable in CI: if `OPENCLAW_GATEWAY_TOKEN` is not set or mismatched, the job fails at the "Probe gateway-token auth (C5 gate)" step with a `::error::` annotation, not at the Playwright assertions.

## Test plan

- [ ] `e2e-critical` job green on this PR's own CI run
- [ ] Verify "Probe gateway-token auth" step appears in the job log and prints "C5 auth probe OK"
- [ ] Verify if either the server or the token is wrong, the new steps fail before Playwright

Tracking: vivekchand/clawmetry#2146 (C5)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAb8UjkJQ56MGVwL8iCuPw)_