### PR TITLE
[RELEASE] dashboard tab i18n — 16 languages complete (carries #2130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Release: dashboard tab i18n (16 languages, coverage model) (2026-05-26)
+- Completes the dashboard string extraction (last i18n surface): ~350 tab/panel strings across all tabs are now translatable. 16 languages fully translated (bn/es/fr/gu/hi/ja/kn/ko/ml/mr/pa/pt-BR/ta/te/zh-CN/zh-TW); the rest fall back to English (no blanks) and backfill via the autotranslate bot. Publishes #2130.
+
 ### Fixed: cloud Dives via heartbeat relay (was a raw DuckDB error) (2026-05-26)
 - The cloud **Dives** tab (NL-to-SQL exploration) showed a raw `Local store unavailable: IO Error: Cannot open database "/root/.clawmetry/clawmetry.duckdb" in read-only mode: database does not exist`. The cloud server has no DuckDB and cannot decrypt the E2E snapshot, so it can't run Dives' arbitrary SQL server-side. Dives now rides the heartbeat-piggyback relay like cron does (local compute, cloud display): the daemon gets a `dives_query` action, runs the NL-to-SQL + query on its **own** DuckDB writer handle (never a `read_only=True` re-open), and posts the AES-256-GCM-encrypted `{sql, chart_spec, rows}` result to `/ingest/cache` for the browser to poll + decrypt client-side. The cloud never sees plaintext. The local `/api/dives/query` handler also degrades gracefully now — a keyless/cold cloud fall-through returns a clean "run Dives on your local dashboard" message instead of the raw IO error. The NL-to-SQL step runs on the node, so it needs an Anthropic credential (env var or `claude` CLI OAuth) locally; without one the relay returns the existing no-auth banner. (#2127 + cloud)
 

--- a/clawmetry/static/locales/bn.json
+++ b/clawmetry/static/locales/bn.json
@@ -26,6 +26,7 @@
   "nav.advanced": "অ্যাডভান্সড",
   "nav.notifications": "নোটিফিকেশন",
   "nav.security": "নিরাপত্তা",
+  "nav.tool_policy": "টুল নীতি",
   "nav.skills": "স্কিল",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "ভার্সন ইম্প্যাক্ট",

--- a/clawmetry/static/locales/es.json
+++ b/clawmetry/static/locales/es.json
@@ -26,6 +26,7 @@
   "nav.advanced": "Avanzado",
   "nav.notifications": "Notificaciones",
   "nav.security": "Seguridad",
+  "nav.tool_policy": "Política de herramientas",
   "nav.skills": "Habilidades",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "Impacto de versión",

--- a/clawmetry/static/locales/fr.json
+++ b/clawmetry/static/locales/fr.json
@@ -26,6 +26,7 @@
   "nav.advanced": "Avancé",
   "nav.notifications": "Notifications",
   "nav.security": "Sécurité",
+  "nav.tool_policy": "Politique des outils",
   "nav.skills": "Compétences",
   "nav.self_evolve": "Auto-évolution",
   "nav.version_impact": "Impact de version",

--- a/clawmetry/static/locales/gu.json
+++ b/clawmetry/static/locales/gu.json
@@ -26,6 +26,7 @@
   "nav.advanced": "ઍડ્વાન્સ્ડ",
   "nav.notifications": "સૂચનાઓ",
   "nav.security": "સુરક્ષા",
+  "nav.tool_policy": "ટૂલ નીતિ",
   "nav.skills": "કૌશલ્યો",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "વર્ઝન અસર",

--- a/clawmetry/static/locales/hi.json
+++ b/clawmetry/static/locales/hi.json
@@ -26,6 +26,7 @@
   "nav.advanced": "उन्नत",
   "nav.notifications": "सूचनाएं",
   "nav.security": "सुरक्षा",
+  "nav.tool_policy": "टूल नीति",
   "nav.skills": "कौशल",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "वर्शन प्रभाव",

--- a/clawmetry/static/locales/ja.json
+++ b/clawmetry/static/locales/ja.json
@@ -26,6 +26,7 @@
   "nav.advanced": "詳細設定",
   "nav.notifications": "通知",
   "nav.security": "セキュリティ",
+  "nav.tool_policy": "ツールポリシー",
   "nav.skills": "スキル",
   "nav.self_evolve": "自己進化",
   "nav.version_impact": "バージョン影響",

--- a/clawmetry/static/locales/kn.json
+++ b/clawmetry/static/locales/kn.json
@@ -26,6 +26,7 @@
   "nav.advanced": "ಸುಧಾರಿತ",
   "nav.notifications": "ಅಧಿಸೂಚನೆಗಳು",
   "nav.security": "ಸುರಕ್ಷತೆ",
+  "nav.tool_policy": "ಟೂಲ್ ನೀತಿ",
   "nav.skills": "ಕೌಶಲ್ಯಗಳು",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "ಆವೃತ್ತಿ ಪ್ರಭಾವ",

--- a/clawmetry/static/locales/ko.json
+++ b/clawmetry/static/locales/ko.json
@@ -26,6 +26,7 @@
   "nav.advanced": "고급",
   "nav.notifications": "통지",
   "nav.security": "보안",
+  "nav.tool_policy": "도구 정책",
   "nav.skills": "스킬",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "버전 영향",

--- a/clawmetry/static/locales/ml.json
+++ b/clawmetry/static/locales/ml.json
@@ -26,6 +26,7 @@
   "nav.advanced": "വിപുലമായത്",
   "nav.notifications": "അറിയിപ്പുകൾ",
   "nav.security": "സുരക്ഷ",
+  "nav.tool_policy": "ടൂൾ നയം",
   "nav.skills": "സ്കില്ലുകൾ",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "പതിപ്പ് സ്വാധീനം",

--- a/clawmetry/static/locales/mr.json
+++ b/clawmetry/static/locales/mr.json
@@ -26,6 +26,7 @@
   "nav.advanced": "प्रगत",
   "nav.notifications": "सूचना",
   "nav.security": "सुरक्षा",
+  "nav.tool_policy": "टूल धोरण",
   "nav.skills": "कौशल्ये",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "आवृत्ती परिणाम",

--- a/clawmetry/static/locales/pa.json
+++ b/clawmetry/static/locales/pa.json
@@ -26,6 +26,7 @@
   "nav.advanced": "ਐਡਵਾਂਸਡ",
   "nav.notifications": "ਸੂਚਨਾਵਾਂ",
   "nav.security": "ਸੁਰੱਖਿਆ",
+  "nav.tool_policy": "ਟੂਲ ਨੀਤੀ",
   "nav.skills": "ਹੁਨਰ",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "ਵਰਜਨ ਪ੍ਰਭਾਵ",

--- a/clawmetry/static/locales/pt-BR.json
+++ b/clawmetry/static/locales/pt-BR.json
@@ -26,6 +26,7 @@
   "nav.advanced": "Avançado",
   "nav.notifications": "Notificações",
   "nav.security": "Segurança",
+  "nav.tool_policy": "Política de ferramentas",
   "nav.skills": "Skills",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "Impacto da versão",

--- a/clawmetry/static/locales/ta.json
+++ b/clawmetry/static/locales/ta.json
@@ -26,6 +26,7 @@
   "nav.advanced": "மேம்பட்டது",
   "nav.notifications": "அறிவிப்புகள்",
   "nav.security": "பாதுகாப்பு",
+  "nav.tool_policy": "கருவிக் கொள்கை",
   "nav.skills": "திறன்கள்",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "பதிப்பு தாக்கம்",

--- a/clawmetry/static/locales/te.json
+++ b/clawmetry/static/locales/te.json
@@ -26,6 +26,7 @@
   "nav.advanced": "అధునాతనం",
   "nav.notifications": "నోటిఫికేషన్‌లు",
   "nav.security": "భద్రత",
+  "nav.tool_policy": "టూల్ విధానం",
   "nav.skills": "స్కిల్స్",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "వెర్షన్ ప్రభావం",

--- a/clawmetry/static/locales/zh-CN.json
+++ b/clawmetry/static/locales/zh-CN.json
@@ -26,6 +26,7 @@
   "nav.advanced": "高级",
   "nav.notifications": "通知",
   "nav.security": "安全",
+  "nav.tool_policy": "工具策略",
   "nav.skills": "技能",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "版本影响",

--- a/clawmetry/static/locales/zh-TW.json
+++ b/clawmetry/static/locales/zh-TW.json
@@ -26,6 +26,7 @@
   "nav.advanced": "進階",
   "nav.notifications": "通知",
   "nav.security": "安全性",
+  "nav.tool_policy": "工具策略",
   "nav.skills": "技能",
   "nav.self_evolve": "Self-Evolve",
   "nav.version_impact": "版本影響",


### PR DESCRIPTION
Publishes the dashboard tab extraction (#2130): 16 languages fully translated, the rest English-fallback (coverage model) + backfilling. Triggers release-on-merge -> PyPI; cloud re-pin to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)