### PR TITLE
docs: refresh agent canon (AGENTS.md rewrite + read FLYWHEEL.md first)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,30 @@
 # AGENTS.md — For AI Coding Agents
 
-## Quick Context
-ClawMetry = open-source observability dashboard for OpenClaw AI agents. Single Python file, zero config, auto-detects everything.
+> **Read [`FLYWHEEL.md`](./FLYWHEEL.md) first.** It is how you ship a change end to end in this repo (code → PR → green CI → `[RELEASE]` → PyPI → cloud → verified live) and the non-negotiable "done" bar. Then [`CLAUDE.md`](./CLAUDE.md) for the architecture deep-dive. This file is the short "what to do"; those two carry the detail.
 
-## Rules
-- **Don't split dashboard.py** — the single-file architecture is a feature, not a bug
-- **Don't add heavy dependencies** — Flask is the only required dependency
-- **Don't add a build step** — frontend is embedded in Python, no npm/webpack/vite
-- **Keep auto-detection working** — if you add a feature, it should work without config
-- **Performance matters** — this runs on Raspberry Pis. Keep it light (<100MB RAM)
-- **Read-only principle** — ClawMetry observes agents, it doesn't control them
+## Quick context
+ClawMetry is an open-source, real-time observability dashboard for OpenClaw (and other) AI agents. `pip install clawmetry && clawmetry` — zero config, read-only by default. It's a Flask app with an embedded, no-build vanilla-JS frontend; a sync daemon ingests filesystem/gateway/OTLP data into a local **DuckDB** store, and the app reads from DuckDB to serve the UI.
 
-## Common Tasks
-- **Add a new API endpoint**: Add `@app.route` in dashboard.py, follow existing patterns
-- **Update the UI**: Edit HTML template strings in dashboard.py (search for the route's `render_template_string`)
-- **Add a new dashboard view**: Add route + template + navigation link
-- **Bump version**: Update `__version__` in dashboard.py and `setup.py`
+## The rules that bite
+- **DuckDB-first.** Every feature persists to and reads from the local DuckDB store (`clawmetry/local_store.py`; the daemon owns the writer lock). Reading raw JSONL / logs / `sessions.json` / process stats *inside a request handler* works locally but silently returns empty in cloud — that's a bug, not a shortcut. (FLYWHEEL.md §1.)
+- **Per-feature route modules.** New HTTP endpoints go in `routes/<feature>.py` on that feature's Blueprint, not in `dashboard.py`. The old "single file" rule is dead — it broke down at ~33K lines and caused constant PR conflicts. Shared helpers still in `dashboard.py` are reached via late `import dashboard as _d`.
+- **No build step, no npm.** The live frontend is `clawmetry/static/css|js/*` + `clawmetry/templates/tabs/*.html`, vanilla JS only. (`dashboard.py` defines `DASHBOARD_HTML` twice; the second wins and loads the static/template files — the inline `<style>`/HTML earlier is dead code.) No React/Vue/webpack/vite.
+- **Minimal dependencies.** Flask + waitress + cryptography + duckdb. Don't add heavy libraries.
+- **Read-only by default.** ClawMetry observes; it doesn't modify agent behavior (the exceptions are cron management and enforcement, which go through the gateway RPC or OpenClaw's own credentials, never a new write path).
+- **Auto-detect everything.** Users should never have to configure anything manually.
+- **Never crash on bad input.** Graceful fallbacks plus a logged warning, always.
+- **Performance is a cost.** At $5/node/mo, every poller and fetch is money — cache + dedup shared fetches, scope pollers to the active tab. (FLYWHEEL.md ⚡.)
 
-## Publishing to PyPI
-See `PUBLISH.md` in `packages/clawmetry/`
+## Common tasks
+- **Add an API endpoint:** add it to `routes/<feature>.py` on the feature Blueprint; reach shared helpers via late `import dashboard as _d`.
+- **Change the UI:** edit `clawmetry/static/css/dashboard.css`, `clawmetry/static/js/app.js`, or `clawmetry/templates/tabs/*.html` — never the dead inline HTML in `dashboard.py`.
+- **Light up a cloud surface:** the OSS daemon adds the data to `sync_system_snapshot`; the cloud renders it with a client-side `cm-cloud-*` interceptor (the cloud server can't decrypt — data is E2E-encrypted). See the cloud repo's `FLYWHEEL.md`.
 
-## Don't
-- Don't introduce React/Vue/Angular — vanilla JS only
-- Don't require a database for core functionality (history.py is optional)
-- Don't make external network calls from the dashboard
-- Don't store user data outside the local machine
-- Don't break backward compatibility with older OpenClaw versions
+## Releasing
+- **Never hand-edit `__version__` or push a `v*` tag.** Publishing is triggered by merging a separate PR whose title starts with `[RELEASE]`; the workflow then bumps the patch version and uploads to PyPI. Full procedure in FLYWHEEL.md §5.
+
+## Conventions
+- `snake_case` functions, `PascalCase` classes, `SCREAMING_SNAKE_CASE` constants.
+- No em-dashes / double-dashes in user-facing copy (banners, marketing). Code comments + PR text are fine.
+- Don't store user data outside the local machine; cloud sync is E2E-encrypted and the cloud only ever holds opaque blobs.
+- Keep business/revenue/funnel/pricing docs out of this public repo — they go in the private `clawmetry-cloud` repo. (FLYWHEEL.md §2.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md — ClawMetry
 
+> **Read [`FLYWHEEL.md`](./FLYWHEEL.md) first.** It is how you ship a change end to end here (code → PR → green CI → `[RELEASE]` → PyPI → cloud → verified live) and the non-negotiable "done" bar. This file is the architecture reference; FLYWHEEL.md is the shipping loop.
+
 ## What is this?
 ClawMetry is an open-source, real-time observability dashboard for [OpenClaw](https://github.com/openclaw/openclaw) AI agents. `pip install clawmetry && clawmetry` — that's it. Zero config, read-only by default.
 

--- a/FLYWHEEL.md
+++ b/FLYWHEEL.md
@@ -43,6 +43,7 @@ ClawMetry is **read-only** and **DuckDB-first**:
 - Embedded frontend lives in `dashboard.py` template strings AND in `clawmetry/static/` + `clawmetry/templates/`. Note: `dashboard.py` defines `DASHBOARD_HTML` twice — the **second** wins and loads `static/css/dashboard.css` + `templates/tabs/*.html`. The inline `<style>`/HTML earlier in the file is dead. Edit the static/template files.
 - Match surrounding style: `snake_case` funcs, minimal deps (Flask + waitress + cryptography), never crash on bad input (graceful fallbacks + a logged warning).
 - No em-dashes / double-dashes in user-facing copy (banners, marketing). Code comments + PR text are fine.
+- **Keep business internals out of this public repo.** This repo is public — investors, competitors, and prospective hires browse it. Any doc with live revenue/MRR/funnel/conversion numbers or monetization/pricing strategy (conversion roadmaps, conversion PRDs, pricing analysis) goes in **`clawmetry-cloud/docs/` (private), NEVER `clawmetry/docs/`**. Same rule as `[intel/*]` issues. Before creating any doc, ask: would this leak positioning, lead pipeline, or revenue if a competitor read it? If yes → private repo. (Burned 2026-05-26: a conversion roadmap + PRDs with the real paying-customer/MRR funnel were written into public `docs/` and had to be relocated.)
 
 ## 3. Verify locally BEFORE the PR (the loop that actually catches bugs)
 


### PR DESCRIPTION
## Why

`AGENTS.md` was last meaningfully updated in #1545 and had drifted badly out of sync with the codebase — in a few places it actively contradicted current conventions:

| AGENTS.md said | Reality |
|---|---|
| "Single Python file" / "Don't split dashboard.py" | 38 modules in `routes/`; the single-file rule was killed (broke at ~33K lines) |
| "Add `@app.route` in dashboard.py" | Endpoints live on feature Blueprints in `routes/<feature>.py` |
| "Edit HTML template strings in dashboard.py" | Live frontend is `clawmetry/static/` + `clawmetry/templates/`; inline HTML is dead code |
| "Bump `__version__` in dashboard.py and setup.py" | **Contradicts the release process** — never hand-edit; a `[RELEASE]` PR + workflow does it |
| "Flask is the only dependency" | flask + waitress + cryptography + duckdb |
| "Don't require a database" | DuckDB (`local_store.py`) is now the core data layer (DuckDB-first) |
| `packages/clawmetry/PUBLISH.md` | path doesn't exist |

## What

- **AGENTS.md rewritten** to match reality: `routes/` modules, DuckDB-first, static+template no-build frontend, the `[RELEASE]` flow, real deps, and the read-only/auto-detect/never-crash rules that still hold.
- **AGENTS.md + CLAUDE.md now open with "read FLYWHEEL.md first"** so an agent hits the shipping loop and the non-negotiable done-bar before touching anything. Aligns the three-file canon: AGENTS.md (what to do) → CLAUDE.md (architecture) → FLYWHEEL.md (how to ship).
- **FLYWHEEL.md §2**: added the rule that business/revenue/funnel/pricing docs stay in the private `clawmetry-cloud` repo, never public OSS.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)