### PR TITLE
feat: per-MCP-server cost & latency rollup (#2007)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -12249,6 +12249,59 @@ async function loadToolCatalog() {
   } catch (e) {
     tableEl.innerHTML = '<div style="color:#e74c3c;font-size:13px;padding:16px;">Failed to load tool catalog: ' + escHtml(String(e)) + '</div>';
   }
+  // Per-MCP-server rollup (#2007) — independent of the provenance filter.
+  loadMcpServers();
+}
+
+// ── Per-MCP-server rollup (#2007) ───────────────────────────────────────────
+// Reads /api/mcp-servers (same DuckDB tool_call/tool_result join as the
+// catalog, re-aggregated by MCP server) and renders a compact per-server card:
+// call volume, p50/p95 latency, error rate, top tools, and the model spend of
+// the turns that called the server. Hidden when no MCP servers were used.
+function _mcpFmtMs(ms) {
+  if (ms === null || ms === undefined) return '<span style="color:var(--text-faint);">&mdash;</span>';
+  if (ms < 1000) return ms + 'ms';
+  if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+  return Math.round(ms / 60000) + 'm';
+}
+
+async function loadMcpServers() {
+  var section = document.getElementById('mcp-servers-section');
+  var card = document.getElementById('mcp-servers-card');
+  if (!section || !card) return;
+  try {
+    var data = await fetch('/api/mcp-servers').then(function(r) { return r.json(); });
+    var servers = (data && data.servers) || [];
+    if (servers.length === 0) { section.style.display = 'none'; return; }
+    section.style.display = 'block';
+    var maxCalls = servers.reduce(function(m, s) { return Math.max(m, s.calls || 0); }, 1);
+    var html = '';
+    servers.forEach(function(s, i) {
+      var errPct = Math.round((s.error_rate || 0) * 100);
+      var errColor = errPct >= 20 ? '#dc2626' : errPct > 0 ? '#d97706' : 'var(--text-muted)';
+      var barW = Math.round(((s.calls || 0) / maxCalls) * 100);
+      var topTools = (s.top_tools || []).map(function(t) {
+        return '<span style="font-size:10px;color:var(--text-muted);background:var(--bg-secondary);border-radius:4px;padding:1px 6px;">' + escHtml(t.name) + ' &middot; ' + t.calls + '</span>';
+      }).join(' ');
+      html += '<div style="padding:11px 14px;' + (i > 0 ? 'border-top:1px solid var(--border-primary);' : '') + '">';
+      html += '<div style="display:flex;align-items:center;gap:12px;">';
+      html += '<div style="flex:1;min-width:0;">';
+      html += '<div style="font-size:13px;font-weight:600;color:var(--text-primary);">' + escHtml(s.display_name || s.server) + '</div>';
+      html += '<div style="height:4px;background:var(--bg-secondary);border-radius:3px;margin-top:5px;max-width:220px;"><div style="width:' + barW + '%;height:100%;background:#8b5cf6;border-radius:3px;"></div></div>';
+      html += '</div>';
+      html += '<div style="display:flex;gap:18px;font-size:12px;text-align:right;flex-shrink:0;">';
+      html += '<div><div style="font-weight:700;color:var(--text-primary);">' + (s.calls || 0) + '</div><div style="font-size:10px;color:var(--text-muted);">calls</div></div>';
+      html += '<div title="median / 95th-percentile call duration"><div style="font-weight:700;color:var(--text-primary);">' + _mcpFmtMs(s.p50_ms) + ' / ' + _mcpFmtMs(s.p95_ms) + '</div><div style="font-size:10px;color:var(--text-muted);">p50 / p95</div></div>';
+      html += '<div><div style="font-weight:700;color:' + errColor + ';">' + errPct + '%</div><div style="font-size:10px;color:var(--text-muted);">errors</div></div>';
+      html += '<div title="Model spend on the turns that called this server (cache-aware). Not the MCP execution cost."><div style="font-weight:700;color:var(--text-primary);">$' + (s.cost_usd >= 0.01 ? Number(s.cost_usd).toFixed(2) : (s.cost_usd > 0 ? '&lt;0.01' : '0.00')) + '</div><div style="font-size:10px;color:var(--text-muted);">turn spend</div></div>';
+      html += '</div></div>';
+      if (topTools) html += '<div style="margin-top:7px;display:flex;gap:5px;flex-wrap:wrap;">' + topTools + '</div>';
+      html += '</div>';
+    });
+    card.innerHTML = html;
+  } catch (e) {
+    section.style.display = 'none';
+  }
 }
 
 function renderToolCatalog() {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10859,6 +10859,34 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         tool_catalog_slice = _build_tool_catalog_slice()
     except Exception as _e_tc:
         log.debug("snapshot: tool_catalog slice failed: %s", _e_tc)
+    # Per-MCP-server cost & latency rollup (#2007): the same tool_call→tool_result
+    # join as the tool catalog, re-aggregated by MCP server (the provider segment
+    # of mcp__<server>__<tool>). Built on the daemon's OWN store handle (never a
+    # read_only=True re-open — #1771) and bounded to the top servers so the slice
+    # stays tiny in the shared snapshot. Reuses the OSS route's rollup so the
+    # cloud MCP-servers card shows the identical numbers.
+    mcp_servers_slice: dict = {"servers": [], "totals": {}}
+    try:
+        from clawmetry import local_store as _ls_mcp
+        _mcp_store = _ls_mcp.get_store()
+        if _mcp_store is not None:
+            _mcp_rows = _mcp_store.query_events(limit=5000) or []
+            _mcp_builtin: set = set()
+            try:
+                for _r in (_mcp_store.query_tool_policy(limit=25) or []):
+                    _allow = _r.get("allow")
+                    if isinstance(_allow, list):
+                        for _n in _allow:
+                            if _n:
+                                _mcp_builtin.add(str(_n).replace("mcp__openclaw__", ""))
+            except Exception:
+                pass
+            from routes.tool_catalog import _mcp_servers_rollup as _mcp_roll
+            mcp_servers_slice = _mcp_roll(_mcp_rows, builtin=_mcp_builtin)
+            # Bound to the 12 busiest servers; trim each server's top_tools to 5.
+            mcp_servers_slice["servers"] = mcp_servers_slice.get("servers", [])[:12]
+    except Exception as _e_mcp:
+        log.debug("snapshot: mcp_servers slice failed: %s", _e_mcp)
     # Context-window economics (PRD P1-2) → bounded snapshot slice for the
     # cloud Context Economics tab. Ships the compaction log (trigger + before/
     # after + reclaimed) and the overflow-session flags, plus a small summary,
@@ -10941,6 +10969,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "runLedger": run_ledger_slice,
         "toolPolicy": tool_policy_slice,
         "toolCatalog": tool_catalog_slice,
+        "mcpServers": mcp_servers_slice,
         "contextEconomics": context_economics_slice,
         "spending": spending,
         "cronJobs": _build_cron_jobs(paths),

--- a/clawmetry/templates/tabs/tool-catalog.html
+++ b/clawmetry/templates/tabs/tool-catalog.html
@@ -25,6 +25,13 @@
   <!-- Provenance summary chips -->
   <div id="tc-summary" style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:12px;"></div>
 
+  <!-- Per-MCP-server rollup (#2007): which MCP server is hot / slow / failing. -->
+  <div id="mcp-servers-section" style="display:none;margin-bottom:16px;">
+    <div style="font-size:13px;font-weight:700;color:var(--text-primary);margin-bottom:2px;">🧩 MCP servers</div>
+    <div style="font-size:11px;color:var(--text-muted);margin-bottom:8px;">Tool calls grouped by MCP server &mdash; volume, p50/p95 latency, error rate. Model spend is the cost of the turns that called each server.</div>
+    <div class="card" id="mcp-servers-card" style="padding:0;overflow:hidden;"></div>
+  </div>
+
   <!-- Tool table -->
   <div class="card" id="tc-table" style="color:var(--text-muted);font-size:13px;padding:0;overflow:hidden;">Loading tool catalog&hellip;</div>
 </div>

--- a/routes/tool_catalog.py
+++ b/routes/tool_catalog.py
@@ -198,6 +198,28 @@ def _classify(name: str, builtin: set):
     return ("plugin", "")
 
 
+def _mcp_tool_short(name: str, provider: str) -> str:
+    """Strip the ``mcp__<provider>__`` namespace off a tool name for display.
+
+    ``mcp__plugin_x_y__list_pages`` → ``list_pages``. Falls back to the full
+    name if the expected prefix isn't present.
+    """
+    if not name:
+        return ""
+    prefix = f"mcp__{provider}__"
+    if provider and name.startswith(prefix):
+        return name[len(prefix):]
+    parts = [p for p in name.split("__") if p]
+    return "__".join(parts[2:]) if len(parts) > 2 else name
+
+
+def _mcp_server_display(provider: str) -> str:
+    """Human-friendly server label. OpenClaw namespaces plugin-hosted MCP
+    servers as ``plugin_<name>`` — drop that prefix for the UI."""
+    p = provider or "mcp"
+    return p[len("plugin_"):] if p.startswith("plugin_") else p
+
+
 # ── Aggregation ─────────────────────────────────────────────────────────────
 
 def _percentile(sorted_vals: list, p: float):
@@ -367,3 +389,117 @@ def api_tool_catalog_calls(name):
         "call_count": len(calls),
         "_source": "local_store",
     })
+
+
+def _mcp_servers_rollup(rows: list, builtin: set | None = None) -> dict:
+    """Aggregate MCP tool calls by server (issue #2007).
+
+    Reuses the same tool_call->tool_result join + provenance classification as
+    the tool catalog, then rolls up by MCP server (the ``provider`` segment of
+    ``mcp__<provider>__<tool>``):
+      * ``calls`` / ``p50_ms`` / ``p95_ms`` / ``error_rate`` — exact, derived
+        from the event join (a call with no matching result counts toward
+        ``calls`` but not the latency percentiles).
+      * ``tokens`` / ``cost_usd`` — best-effort, summed from the ``tool_call``
+        event's own ``token_count`` / ``cost_usd`` (the LLM turn that issued the
+        call). Reflects the hop that drove the MCP call; may be 0 on runtimes
+        that don't price per event.
+      * ``top_tools`` — the busiest tools that server exposed.
+    Transport (stdio/sse/http) and cold-start are not yet ingested, so they're
+    deliberately omitted rather than faked.
+
+    ``builtin`` lets the daemon pass its own sandbox tool set (read from its own
+    store handle) so the snapshot builder never goes through the daemon proxy or
+    a ``read_only=True`` re-open; the HTTP route passes ``None`` and we resolve
+    it via ``_builtin_tool_set()``.
+    """
+    if builtin is None:
+        builtin = _builtin_tool_set()
+    res_idx = _result_index(rows)
+
+    servers: dict = {}
+    for name, start, dur, err, _sid in _iter_tool_calls(rows, res_idx):
+        prov, provider = _classify(name, builtin)
+        if prov != "mcp":
+            continue
+        s = servers.setdefault(provider, {
+            "calls": 0, "durs": [], "errs": 0, "tools": {}, "last_ts": None,
+            "tokens": 0, "cost": 0.0,
+        })
+        s["calls"] += 1
+        if dur is not None:
+            s["durs"].append(dur)
+        if err:
+            s["errs"] += 1
+        short = _mcp_tool_short(name, provider)
+        s["tools"][short] = s["tools"].get(short, 0) + 1
+        if start is not None and (s["last_ts"] is None or start > s["last_ts"]):
+            s["last_ts"] = start
+
+    # Token/cost attribution: a separate pass over the raw tool_call events so we
+    # don't have to thread cost through the shared _iter_tool_calls helper.
+    for e in rows:
+        if not _is_tool_call(e):
+            continue
+        prov, provider = _classify(_tool_name(e), builtin)
+        if prov != "mcp" or provider not in servers:
+            continue
+        servers[provider]["tokens"] += int(e.get("token_count") or 0)
+        try:
+            servers[provider]["cost"] += float(e.get("cost_usd") or 0.0)
+        except (TypeError, ValueError):
+            pass
+
+    out = []
+    for provider, s in servers.items():
+        durs = sorted(s["durs"])
+        calls = s["calls"]
+        top_tools = sorted(s["tools"].items(), key=lambda kv: -kv[1])[:5]
+        out.append({
+            "server": provider,
+            "display_name": _mcp_server_display(provider),
+            "calls": calls,
+            "p50_ms": _percentile(durs, 50),
+            "p95_ms": _percentile(durs, 95),
+            "error_rate": round(s["errs"] / calls, 4) if calls else 0.0,
+            "errors": s["errs"],
+            "timed_calls": len(durs),
+            "tool_count": len(s["tools"]),
+            "top_tools": [{"name": n, "calls": c} for n, c in top_tools],
+            "tokens": s["tokens"],
+            "cost_usd": round(s["cost"], 4),
+            "last_active_ms": s["last_ts"],
+        })
+    # Busiest server first; ties broken by slowest p95 then name.
+    out.sort(key=lambda r: (-r["calls"], -(r["p95_ms"] or 0), r["server"]))
+    return {
+        "servers": out,
+        "totals": {
+            "server_count": len(out),
+            "total_calls": sum(r["calls"] for r in out),
+            "total_tokens": sum(r["tokens"] for r in out),
+            "total_cost_usd": round(sum(r["cost_usd"] for r in out), 4),
+        },
+        "_source": "local_store",
+    }
+
+
+@bp_tool_catalog.route("/api/mcp-servers")
+def api_mcp_servers():
+    """Per-MCP-server cost & latency rollup (issue #2007).
+
+    Groups the agent's MCP tool calls by server so you can see which MCP server
+    is hot, slow, or error-prone — call volume, p50/p95 latency, error rate, the
+    tools each server exposes, and best-effort token/cost attributed from the
+    issuing turn. Reads the DuckDB ``events`` table through the daemon proxy
+    (same source + join as ``/api/tool-catalog``). Never 500s — an empty/cold
+    store returns ``{servers:[], totals:{...}}`` (HTTP 200).
+
+    Query param: ``limit`` (event scan window, <=5000).
+    """
+    try:
+        limit = max(1, min(5000, int(request.args.get("limit", 5000))))
+    except (TypeError, ValueError):
+        limit = 5000
+    rows = _coerce_rows(_ls_call("query_events", limit=limit))
+    return jsonify(_mcp_servers_rollup(rows))


### PR DESCRIPTION
## What

Adds a **per-MCP-server rollup** so you can see which MCP server is hot, slow, or error-prone instead of having every MCP tool call lumped into the parent span. Closes #2007.

- **`GET /api/mcp-servers`** (`routes/tool_catalog.py`) — reuses the tool catalog's `tool_call`→`tool_result` join + provenance classification (the `mcp__<server>__<tool>` prefix), re-aggregated **by server**: call volume, p50/p95 latency, error rate, the tools each server exposes, and best-effort model spend. Never 500s; graceful empty (`{servers:[]}`, HTTP 200) on a cold store.
- **`mcpServers` snapshot slice** (`clawmetry/sync.py`) — built on the daemon's **own** store handle (no `read_only=True` re-open, per the #1771 brick-lock), bounded to the 12 busiest servers, reusing the same `_mcp_servers_rollup` so the eventual cloud card matches the OSS numbers exactly.
- **"MCP servers" card** on the Tool Catalog tab (above the tool table): volume bar, p50/p95, error rate, top tools, turn spend.

## Honest scoping
- **Latency + volume + error rate are exact** (derived from the event join). A call with no matching result counts toward volume but not the percentiles.
- **Cost is best-effort**: the *calling turn's* model spend (cache-aware), summed per server and labelled "turn spend" in the UI — **not** MCP execution cost (MCP exec is typically free; the spend is the LLM reasoning around it). I deliberately did not imply otherwise.
- **Transport (stdio/sse/http) and cold-start are not yet ingested**, so they're omitted rather than faked (the issue lists them; they need new ingest).

## Verification
- **Real-data, in-browser:** the card renders my live MCP traffic — `chrome-devtools-mcp` · 26 calls · 229ms/2.9s p50/p95 · 23% errors · 6 tools · \$30.69 turn spend, with the top-tools breakdown. Endpoint returns the same over HTTP.
- **Snapshot slice:** `_mcp_servers_rollup` is verified on real events using the daemon's own Python; the slice builder uses the identical `get_store()`/`query_events()`/`query_tool_policy()` pattern as the shipping `_build_tool_catalog_slice`. I did **not** restart the live daemon to decrypt the snapshot — `kickstart -k` mid-write on this reporting machine is what corrupted a DuckDB index before; CI's sync matrix exercises the snapshot build, and the live-snapshot decrypt happens at cloud-pin-bump time.

## Cloud follow-up
When the cloud pin reaches the release carrying this, add an `oss-passthrough` `cloud_route_policy` entry for `/api/mcp-servers` (cold response is a clean 200 → smoke-gate-safe). A `cm-cloud-mcpservers` interceptor reading the `mcpServers` snapshot key would light up the cloud card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)