### PR TITLE
feat(subagents): per-agent pause/resume/stop controls

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -12053,9 +12053,10 @@ async function loadSubagents() {
       }
     });
     function statusDot(status) {
-      var colors = { active: '#16a34a', idle: '#d97706', stale: '#6b7280', failed: '#ef4444' };
+      var colors = { active: '#16a34a', idle: '#d97706', stale: '#6b7280', failed: '#ef4444', paused: '#7c3aed' };
       var glow = status === 'active' ? 'box-shadow:0 0 6px rgba(22,163,74,0.6);'
-               : status === 'failed' ? 'box-shadow:0 0 6px rgba(239,68,68,0.5);' : '';
+               : status === 'failed' ? 'box-shadow:0 0 6px rgba(239,68,68,0.5);'
+               : status === 'paused' ? 'box-shadow:0 0 6px rgba(124,58,237,0.5);' : '';
       return '<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + (colors[status] || '#6b7280') + ';' + glow + 'flex-shrink:0;margin-right:4px;"></span>';
     }
     function renderAgent(a, depth) {
@@ -12086,6 +12087,18 @@ async function loadSubagents() {
       html += '<span style="font-size:11px;color:var(--text-muted);white-space:nowrap;margin-left:8px;">' + escHtml(a.model || '') + '</span>';
       html += '<span style="font-size:11px;color:var(--text-muted);white-space:nowrap;margin-left:8px;">' + tokens + ' tok</span>';
       html += '<span style="font-size:11px;color:var(--text-faint);white-space:nowrap;margin-left:8px;">' + escHtml(a.runtime || '') + '</span>';
+      if (a.status !== 'failed' && a.status !== 'stale' && a.status !== 'stopped') {
+        var keyBtn = (a.key || a.sessionId || '').replace(/\\/g,'\\\\').replace(/'/g,"\\'");
+        var isPaused = a.status === 'paused';
+        html += '<span onclick="event.stopPropagation();" style="margin-left:8px;display:inline-flex;gap:4px;flex-shrink:0;">';
+        if (isPaused) {
+          html += '<button onclick="event.stopPropagation();controlAgent(\'' + keyBtn + '\',\'resume\')" style="font-size:10px;padding:2px 6px;border-radius:4px;border:1px solid #16a34a;background:transparent;color:#16a34a;cursor:pointer;">Resume</button>';
+        } else {
+          html += '<button onclick="event.stopPropagation();controlAgent(\'' + keyBtn + '\',\'pause\')" style="font-size:10px;padding:2px 6px;border-radius:4px;border:1px solid var(--border-primary);background:transparent;color:var(--text-muted);cursor:pointer;">Pause</button>';
+        }
+        html += '<button onclick="event.stopPropagation();controlAgent(\'' + keyBtn + '\',\'stop\')" style="font-size:10px;padding:2px 6px;border-radius:4px;border:1px solid rgba(239,68,68,0.5);background:transparent;color:#ef4444;cursor:pointer;">Stop</button>';
+        html += '</span>';
+      }
       html += '</div>';
       if (hasChildren && isExpanded) {
         childrenOf[sid].forEach(function(child) { html += renderAgent(child, depth + 1); });
@@ -12111,6 +12124,28 @@ async function loadSubagents() {
 function _saToggle(sid) {
   _subagentsExpanded[sid] = (_subagentsExpanded[sid] === false) ? true : false;
   loadSubagents();
+}
+
+async function controlAgent(key, action) {
+  if (action === 'stop') {
+    if (!confirm('Stop agent ' + key + '? This will attempt to terminate it via the gateway and cannot be undone.')) return;
+  }
+  try {
+    var body = action === 'stop' ? {confirm: true} : {};
+    var r = await fetch('/api/agents/' + encodeURIComponent(key) + '/' + action, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(body),
+    });
+    var d = await r.json();
+    if (d.ok) {
+      loadSubagents();
+    } else {
+      alert('Agent ' + action + ' failed: ' + (d.error || 'unknown error'));
+    }
+  } catch(e) {
+    alert('Request failed: ' + e);
+  }
 }
 
 // OpenClaw queue-lane defaults (docs.openclaw.ai/concepts/queue): the

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -16,6 +16,7 @@ Pure mechanical move — zero behaviour change from the previous in-file
 definitions.
 """
 
+import collections
 import json
 import os
 import re
@@ -39,6 +40,12 @@ _SUBAGENTS_SCAN_TAIL_BYTES = int(os.environ.get("CLAWMETRY_SUBAGENTS_SCAN_TAIL_B
 
 # Channels that don't identify a user-initiated session (generic/internal)
 _GENERIC_CHANNELS = frozenset({"unknown", "direct", "", "main", "internal"})
+
+# Per-agent pause tracking — in-memory only, resets on dashboard restart.
+# Actual pause/resume/stop is delegated to the gateway RPC; this set is the
+# dashboard's local view of which agent keys have been soft-paused.
+_paused_agents: set = set()
+_agent_control_audit: collections.deque = collections.deque(maxlen=200)
 
 
 def _ls_call(method_name, **kwargs):
@@ -2078,6 +2085,10 @@ def api_subagents():
     if not full_scan and is_local_store_read_enabled():
         fast = _try_local_store_subagents()
         if fast is not None:
+            if _paused_agents:
+                for _sa in fast.get("subagents", []):
+                    if (_sa.get("key") or _sa.get("sessionId") or "") in _paused_agents:
+                        _sa["status"] = "paused"
             _SUBAGENTS_CACHE["data"] = fast
             _SUBAGENTS_CACHE["ts"] = time.time()
             return jsonify(fast)
@@ -2274,7 +2285,11 @@ def api_subagents():
             "runId":     s.get("runId") or sp_match.get("runId") or "",
         })
 
-    _status_rank = {"active": 0, "idle": 1, "stale": 2, "failed": 3}
+    if _paused_agents:
+        for _sa in subagents:
+            if (_sa.get("key") or _sa.get("sessionId") or "") in _paused_agents:
+                _sa["status"] = "paused"
+    _status_rank = {"active": 0, "idle": 1, "stale": 2, "paused": 3, "failed": 4}
     subagents.sort(key=lambda x: (_status_rank.get(x["status"], 9), x["depth"]))
     payload = {"subagents": subagents, "counts": counts}
     if not full_scan:
@@ -2927,6 +2942,57 @@ def api_session_stop(session_id):
             "errors": errors,
         }
     )
+
+
+@bp_sessions.route("/api/agents/<path:agent_key>/pause", methods=["POST"])
+def api_agent_pause(agent_key):
+    """Pause a single agent via gateway RPC; tracks state in _paused_agents."""
+    import dashboard as _d
+    result = _d._gw_invoke("subagents", {"action": "pause", "key": agent_key})
+    _paused_agents.add(agent_key)
+    _agent_control_audit.append({
+        "ts": time.time(), "action": "pause", "key": agent_key,
+        "gw_ok": result is not None, "source": request.remote_addr,
+    })
+    return jsonify({"ok": True, "key": agent_key, "status": "paused",
+                    "gw_ok": result is not None})
+
+
+@bp_sessions.route("/api/agents/<path:agent_key>/resume", methods=["POST"])
+def api_agent_resume(agent_key):
+    """Resume a paused agent via gateway RPC; clears the key from _paused_agents."""
+    import dashboard as _d
+    result = _d._gw_invoke("subagents", {"action": "resume", "key": agent_key})
+    _paused_agents.discard(agent_key)
+    _agent_control_audit.append({
+        "ts": time.time(), "action": "resume", "key": agent_key,
+        "gw_ok": result is not None, "source": request.remote_addr,
+    })
+    return jsonify({"ok": True, "key": agent_key, "status": "active",
+                    "gw_ok": result is not None})
+
+
+@bp_sessions.route("/api/agents/<path:agent_key>/stop", methods=["POST"])
+def api_agent_stop(agent_key):
+    """Stop a single agent via gateway RPC. Requires {\"confirm\": true} in body."""
+    import dashboard as _d
+    body = request.get_json(silent=True) or {}
+    if not body.get("confirm"):
+        return jsonify({"ok": False, "error": "confirm:true required to stop an agent"}), 400
+    result = _d._gw_invoke("subagents", {"action": "stop", "key": agent_key})
+    _paused_agents.discard(agent_key)
+    _agent_control_audit.append({
+        "ts": time.time(), "action": "stop", "key": agent_key,
+        "gw_ok": result is not None, "source": request.remote_addr,
+    })
+    return jsonify({"ok": True, "key": agent_key, "status": "stopped",
+                    "gw_ok": result is not None})
+
+
+@bp_sessions.route("/api/agents/audit")
+def api_agents_audit():
+    """Return the last 50 agent control actions (pause/resume/stop)."""
+    return jsonify({"entries": list(_agent_control_audit)[-50:]})
 
 
 # Issue #1718: event_types whose ``data`` is a transcript-renderable turn.


### PR DESCRIPTION
Closes #955

## Summary

- **`routes/sessions.py`**: Adds `_paused_agents` set + `_agent_control_audit` deque (maxlen=200) at module level. Four new endpoints: `POST /api/agents/<key>/pause`, `POST /api/agents/<key>/resume`, `POST /api/agents/<key>/stop` (requires `{"confirm": true}`), and `GET /api/agents/audit` (last 50 actions). Each action calls `_d._gw_invoke("subagents", {"action": "...", "key": key})`; `gw_ok: false` in the response signals the gateway didn't support the RPC (soft-pause tracked locally). The `/api/subagents` response overlays `"paused"` status for tracked keys in both the DuckDB fast path and the legacy JSONL path.
- **`clawmetry/static/js/app.js`**: Pause/Resume/Stop buttons on each active/idle subagent row; purple status dot for `paused` state; `controlAgent(key, action)` async helper — stop shows a `confirm()` dialog before POSTing.

## Test plan

- [ ] Start dashboard, open Sub-Agents tab — Pause and Stop buttons appear on active/idle agent rows
- [ ] Click Pause on an agent row → row status dot turns purple, button changes to Resume
- [ ] Click Resume → status dot returns to original color
- [ ] Click Stop → confirm dialog appears; on confirm the agent row transitions to stopped
- [ ] `GET /api/agents/audit` returns last actions with `ts`, `action`, `key`, `gw_ok`
- [ ] With no running gateway: actions return `{"ok": true, "gw_ok": false}` (graceful soft-pause)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jodux9DfdkzDSN3aHyeS8L)_