### PR TITLE
feat: NemoClaw guardrail events + metrics tab panels

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -500,6 +500,24 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_approvals_owner_status ON approvals(owner_hash, status, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_approvals_session ON approvals(requestor_session_id, created_at)",
+    # Issue #876 — NemoClaw guardrail enforcement events. The sync daemon
+    # writes via ingest_guardrail_event(); the dashboard reads via
+    # query_guardrail_events() through the daemon proxy. Additive; no
+    # schema-version bump required (CREATE TABLE IF NOT EXISTS is idempotent).
+    """
+    CREATE TABLE IF NOT EXISTS guardrail_events (
+        id         VARCHAR PRIMARY KEY,
+        owner_hash VARCHAR,
+        ts         VARCHAR NOT NULL,
+        rule_name  VARCHAR,
+        verdict    VARCHAR,
+        session_id VARCHAR,
+        action     VARCHAR,
+        latency_ms DOUBLE
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_guardrail_events_ts      ON guardrail_events(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_guardrail_events_session ON guardrail_events(session_id, ts)",
     # Issue #1088 Phase 4 (2026-05-13) — channel-message foundation. Replaces
     # the per-provider log-grep + JSONL-scan path that the 21 routes in
     # ``routes/channels.py`` use today. Each row is one inbound or outbound
@@ -5035,6 +5053,121 @@ class LocalStore:
                     d["args"] = None
             out.append(d)
         return out
+
+    def ingest_guardrail_event(self, event: dict[str, Any]) -> None:
+        """Upsert one NemoClaw guardrail-enforcement row. Required: ``id``, ``ts``."""
+        eid = event.get("id")
+        if not eid:
+            raise ValueError("guardrail event must include 'id'")
+        ts = event.get("ts") or datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO guardrail_events (
+                    id, owner_hash, ts, rule_name, verdict, session_id, action, latency_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO UPDATE SET
+                    rule_name  = COALESCE(excluded.rule_name,  guardrail_events.rule_name),
+                    verdict    = COALESCE(excluded.verdict,    guardrail_events.verdict),
+                    session_id = COALESCE(excluded.session_id, guardrail_events.session_id),
+                    action     = COALESCE(excluded.action,     guardrail_events.action),
+                    latency_ms = COALESCE(excluded.latency_ms, guardrail_events.latency_ms)
+            """, [
+                str(eid),
+                event.get("owner_hash"),
+                ts,
+                event.get("rule_name"),
+                event.get("verdict"),
+                event.get("session_id"),
+                event.get("action"),
+                event.get("latency_ms"),
+            ])
+
+    def query_guardrail_events(
+        self,
+        *,
+        owner_hash: str | None = None,
+        since: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Read guardrail-event rows, most-recent first."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if owner_hash:
+            clauses.append("owner_hash = ?")
+            params.append(owner_hash)
+        if since:
+            clauses.append("ts >= ?")
+            params.append(since)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT id, owner_hash, ts, rule_name, verdict, session_id, action, latency_ms
+            FROM guardrail_events
+            {where}
+            ORDER BY ts DESC, id
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = ["id", "owner_hash", "ts", "rule_name", "verdict",
+                "session_id", "action", "latency_ms"]
+        return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
+
+    def query_nemoclaw_metrics(
+        self,
+        *,
+        owner_hash: str | None = None,
+    ) -> dict[str, Any]:
+        """Aggregate NemoClaw metrics from ``approvals`` and ``guardrail_events``.
+
+        Returns total approvals, approval/denial rates, average latency, and
+        last-24h guardrail-trigger count."""
+        params_a: list[Any] = []
+        where_a = ""
+        if owner_hash:
+            where_a = "WHERE owner_hash = ?"
+            params_a.append(owner_hash)
+        row = self._fetch(f"""
+            SELECT
+                COUNT(*)                                                       AS total,
+                SUM(CASE WHEN status='approved' THEN 1 ELSE 0 END)            AS approved_count,
+                SUM(CASE WHEN status='denied'   THEN 1 ELSE 0 END)            AS denied_count,
+                AVG(
+                    CASE WHEN resolved_at IS NOT NULL AND created_at IS NOT NULL
+                         THEN datediff('second',
+                                       created_at::TIMESTAMP,
+                                       resolved_at::TIMESTAMP)
+                         ELSE NULL END
+                )                                                              AS avg_latency_secs
+            FROM approvals
+            {where_a}
+        """, params_a)
+        agg = row[0] if row else (0, 0, 0, None)
+        total = int(agg[0] or 0)
+        approved = int(agg[1] or 0)
+        denied = int(agg[2] or 0)
+        avg_latency = round(float(agg[3]), 1) if agg[3] is not None else None
+
+        since_24h = datetime.utcnow().replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ).strftime("%Y-%m-%dT%H:%M:%S")
+        params_g: list[Any] = [since_24h]
+        where_g = "WHERE ts >= ? AND verdict = 'triggered'"
+        if owner_hash:
+            where_g += " AND owner_hash = ?"
+            params_g.append(owner_hash)
+        trig = self._fetch(
+            f"SELECT COUNT(*) FROM guardrail_events {where_g}",
+            params_g,
+        )
+        triggers_24h = int((trig[0][0] if trig else 0) or 0)
+
+        return {
+            "total_approvals": total,
+            "approved_count": approved,
+            "denied_count": denied,
+            "approval_rate_pct": round(approved / total * 100, 1) if total else None,
+            "avg_latency_secs": avg_latency,
+            "triggers_24h": triggers_24h,
+        }
 
     def query_memory_blobs(
         self,

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6283,8 +6283,10 @@ async function loadNemoClaw() {
     if (tab) tab.style.display = 'none';
     console.warn('NemoClaw governance load failed:', e);
   }
-  // Also load approvals
+  // Also load approvals, events and metrics
   loadNemoClawApprovals();
+  loadNemoClawEvents();
+  loadNemoClawMetrics();
 }
 
 // Auto-refresh approvals every 15 seconds when NemoClaw tab is active
@@ -6377,6 +6379,66 @@ async function loadNemoClawApprovals() {
     listEl.innerHTML = html;
   } catch(e) {
     listEl.innerHTML = '<div style="color:var(--text-muted);font-size:12px;">Failed to load approvals</div>';
+  }
+}
+
+// Issue #876 — Guardrail events list
+async function loadNemoClawEvents() {
+  var listEl = document.getElementById('nc-events-list');
+  var countEl = document.getElementById('nc-events-count');
+  if (!listEl) return;
+  try {
+    var data = await fetchJsonWithTimeout('/api/nemoclaw/events', 8000);
+    var events = data.events || [];
+    if (countEl) {
+      if (events.length > 0) {
+        countEl.textContent = events.length;
+        countEl.style.display = '';
+      } else {
+        countEl.style.display = 'none';
+      }
+    }
+    if (events.length === 0) {
+      listEl.innerHTML = '<div style="color:var(--text-muted);font-size:12px;padding:8px 0;text-align:center;">No guardrail events recorded yet</div>';
+      return;
+    }
+    var verdictColor = function(v) { return v === 'triggered' ? '#ef4444' : '#76b900'; };
+    var html = '<div style="display:grid;grid-template-columns:140px 1fr 90px 80px;gap:4px 8px;font-size:11px;">';
+    html += '<div style="color:var(--text-muted);padding-bottom:4px;border-bottom:1px solid var(--border);">TIME</div>';
+    html += '<div style="color:var(--text-muted);padding-bottom:4px;border-bottom:1px solid var(--border);">RULE</div>';
+    html += '<div style="color:var(--text-muted);padding-bottom:4px;border-bottom:1px solid var(--border);">VERDICT</div>';
+    html += '<div style="color:var(--text-muted);padding-bottom:4px;border-bottom:1px solid var(--border);">LATENCY</div>';
+    events.slice(0, 50).forEach(function(ev) {
+      var ts = (ev.ts || '').substring(0, 19).replace('T', ' ');
+      var latency = ev.latency_ms != null ? ev.latency_ms.toFixed(0) + ' ms' : '—';
+      var vc = verdictColor(ev.verdict);
+      html += '<div style="color:var(--text-muted);padding:3px 0;border-bottom:1px solid var(--border);">' + escHtml(ts) + '</div>';
+      html += '<div style="padding:3px 0;border-bottom:1px solid var(--border);word-break:break-all;">' + escHtml(ev.rule_name || '—') + '</div>';
+      html += '<div style="padding:3px 0;border-bottom:1px solid var(--border);"><span style="color:' + vc + ';font-weight:600;">' + escHtml(ev.verdict || '—') + '</span></div>';
+      html += '<div style="color:var(--text-muted);padding:3px 0;border-bottom:1px solid var(--border);">' + escHtml(latency) + '</div>';
+    });
+    html += '</div>';
+    listEl.innerHTML = html;
+  } catch(e) {
+    listEl.innerHTML = '<div style="color:var(--text-muted);font-size:12px;">Failed to load guardrail events</div>';
+  }
+}
+
+// Issue #876 — NemoClaw aggregate metrics
+async function loadNemoClawMetrics() {
+  try {
+    var data = await fetchJsonWithTimeout('/api/nemoclaw/metrics', 8000);
+    var m = data.metrics || {};
+    var trigEl = document.getElementById('nc-metric-triggers');
+    var rateEl = document.getElementById('nc-metric-approval-rate');
+    var latEl  = document.getElementById('nc-metric-latency');
+    var totEl  = document.getElementById('nc-metric-total');
+    if (trigEl) trigEl.textContent = m.triggers_24h != null ? m.triggers_24h : '—';
+    if (rateEl) rateEl.textContent = m.approval_rate_pct != null ? m.approval_rate_pct + '%' : '—';
+    if (latEl)  latEl.textContent  = m.avg_latency_secs  != null ? m.avg_latency_secs + 's'  : '—';
+    if (totEl)  totEl.textContent  = m.total_approvals   != null ? m.total_approvals           : '—';
+  } catch(e) {
+    console.warn('NemoClaw metrics load failed:', e);
   }
 }
 

--- a/clawmetry/templates/tabs/nemoclaw.html
+++ b/clawmetry/templates/tabs/nemoclaw.html
@@ -161,6 +161,62 @@
         <div style="color:var(--text-muted);font-size:12px;padding:8px 0;">Loading...</div>
       </div>
     </div>
+    <!-- Guardrail Events Panel (issue #876) -->
+    <div style="
+      background:var(--bg-secondary);
+      border:1px solid rgba(118,185,0,0.35);
+      border-radius:8px;
+      padding:14px;
+      margin-top:12px;
+      " id="nc-events-panel">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">
+        <div style="display:flex;align-items:center;gap:8px;">
+          <span style="font-size:11px;font-weight:700;color:#76b900;letter-spacing:1px;">GUARDRAIL EVENTS</span>
+          <span id="nc-events-count" style="
+            display:none;
+            font-size:11px;
+            font-weight:700;
+            background:rgba(118,185,0,0.12);
+            color:#76b900;
+            border:1px solid rgba(118,185,0,0.3);
+            border-radius:10px;
+            padding:1px 8px;
+            "></span>
+        </div>
+        <button class="refresh-btn" onclick="loadNemoClawEvents()" style="font-size:11px;">&#8635; <span data-i18n="common.refresh">Refresh</span></button>
+      </div>
+      <div id="nc-events-list">
+        <div style="color:var(--text-muted);font-size:12px;padding:8px 0;">Loading...</div>
+      </div>
+    </div>
+    <!-- NemoClaw Metrics Panel (issue #876) -->
+    <div style="
+      background:var(--bg-secondary);
+      border:1px solid rgba(118,185,0,0.35);
+      border-radius:8px;
+      padding:14px;
+      margin-top:12px;
+      " id="nc-metrics-panel">
+      <div style="font-size:11px;font-weight:700;color:#76b900;letter-spacing:1px;margin-bottom:10px;">METRICS</div>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:10px;">
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;padding:10px 12px;">
+          <div style="font-size:10px;color:var(--text-muted);margin-bottom:4px;">TRIGGERS (24h)</div>
+          <div id="nc-metric-triggers" style="font-size:20px;font-weight:700;color:#76b900;">—</div>
+        </div>
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;padding:10px 12px;">
+          <div style="font-size:10px;color:var(--text-muted);margin-bottom:4px;">APPROVAL RATE</div>
+          <div id="nc-metric-approval-rate" style="font-size:20px;font-weight:700;color:#76b900;">—</div>
+        </div>
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;padding:10px 12px;">
+          <div style="font-size:10px;color:var(--text-muted);margin-bottom:4px;">AVG LATENCY</div>
+          <div id="nc-metric-latency" style="font-size:20px;font-weight:700;color:#76b900;">—</div>
+        </div>
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;padding:10px 12px;">
+          <div style="font-size:10px;color:var(--text-muted);margin-bottom:4px;">TOTAL APPROVALS</div>
+          <div id="nc-metric-total" style="font-size:20px;font-weight:700;color:#76b900;">—</div>
+        </div>
+      </div>
+    </div>
   </div>
 </div><!-- end page-nemoclaw (theme 2) -->
 {% endif %}

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -527,6 +527,13 @@ _DAEMON_METHODS = frozenset({
     "query_eval_summary",
     "persist_eval_score",
     "health",
+    # Issue #876 — NemoClaw guardrail enforcement events + metrics.
+    # Routed through the daemon proxy so /api/nemoclaw/events and
+    # /api/nemoclaw/metrics never open DuckDB writable in the dashboard
+    # process (same pattern as query_approvals above).
+    "query_guardrail_events",
+    "ingest_guardrail_event",
+    "query_nemoclaw_metrics",
 })
 
 

--- a/routes/nemoclaw.py
+++ b/routes/nemoclaw.py
@@ -427,3 +427,82 @@ def api_nemoclaw_pending_approvals():
         return jsonify(_annotate_pro_upsell({'installed': True, 'approvals': approvals}))
     except Exception as e:
         return jsonify(_annotate_pro_upsell({'installed': True, 'approvals': [], 'error': str(e)}))
+
+
+# ── NemoClaw guardrail events + metrics (issue #876) ─────────────────────────
+
+def _try_local_store_guardrail_events(since=None, limit=100):
+    """Return guardrail events from DuckDB via daemon proxy, or None on failure."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        kwargs = {"limit": limit}
+        if since:
+            kwargs["since"] = since
+        rows = local_store_via_daemon("query_guardrail_events", **kwargs)
+    except Exception:
+        rows = None
+    if rows is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            kwargs = {"limit": limit}
+            if since:
+                kwargs["since"] = since
+            rows = store.query_guardrail_events(**kwargs)
+        except Exception:
+            return None
+    return rows if rows is not None else []
+
+
+@bp_nemoclaw.route('/api/nemoclaw/events')
+def api_nemoclaw_events():
+    """Return recent NemoClaw guardrail enforcement events from local DuckDB."""
+    import dashboard as _d
+    installed = _d._detect_nemoclaw() is not None
+    since = request.args.get('since')
+    try:
+        limit = max(1, min(500, int(request.args.get('limit', 100))))
+    except (TypeError, ValueError):
+        limit = 100
+    events = _try_local_store_guardrail_events(since=since, limit=limit) or []
+    return jsonify({
+        'installed': installed,
+        'events': events,
+        'total': len(events),
+    })
+
+
+def _try_local_store_nemoclaw_metrics():
+    """Return NemoClaw metrics from DuckDB via daemon proxy, or None on failure."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon("query_nemoclaw_metrics")
+    except Exception:
+        result = None
+    if result is None:
+        try:
+            from clawmetry import local_store
+            store = local_store.get_store(read_only=True)
+            result = store.query_nemoclaw_metrics()
+        except Exception:
+            return None
+    return result
+
+
+@bp_nemoclaw.route('/api/nemoclaw/metrics')
+def api_nemoclaw_metrics():
+    """Return aggregate NemoClaw metrics (approval rates, latency, trigger count)."""
+    import dashboard as _d
+    installed = _d._detect_nemoclaw() is not None
+    metrics = _try_local_store_nemoclaw_metrics() or {
+        "total_approvals": 0,
+        "approved_count": 0,
+        "denied_count": 0,
+        "approval_rate_pct": None,
+        "avg_latency_secs": None,
+        "triggers_24h": 0,
+    }
+    return jsonify({
+        'installed': installed,
+        'metrics': metrics,
+    })

--- a/tests/test_nemoclaw_events_metrics.py
+++ b/tests/test_nemoclaw_events_metrics.py
@@ -1,0 +1,211 @@
+"""Tests for /api/nemoclaw/events and /api/nemoclaw/metrics (GH #876)."""
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+os.environ["CLAWMETRY_NO_INTERCEPT"] = "1"
+os.environ["CLAWMETRY_DASHBOARD"] = "1"
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def _make_app():
+    """Build a minimal Flask app with only the NemoClaw blueprint registered."""
+    from flask import Flask
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    # Stub out dashboard helpers used by the routes
+    import types
+    dashboard_stub = types.ModuleType("dashboard")
+    dashboard_stub._detect_nemoclaw = lambda: None  # NemoClaw not installed
+    sys.modules.setdefault("dashboard", dashboard_stub)
+
+    from routes.nemoclaw import bp_nemoclaw
+    app.register_blueprint(bp_nemoclaw)
+    return app
+
+
+class TestNemoClawEventsEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        self.app = _make_app()
+        self.client = self.app.test_client()
+
+    def _get(self, url):
+        with patch("routes.local_query.local_store_via_daemon", side_effect=Exception("no daemon")):
+            with patch("clawmetry.local_store.get_store", side_effect=Exception("no store")):
+                return self.client.get(url)
+
+    def test_events_returns_200(self):
+        resp = self._get("/api/nemoclaw/events")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_events_has_required_keys(self):
+        resp = self._get("/api/nemoclaw/events")
+        data = json.loads(resp.data)
+        self.assertIn("installed", data)
+        self.assertIn("events", data)
+        self.assertIn("total", data)
+
+    def test_events_not_installed_when_nemoclaw_absent(self):
+        resp = self._get("/api/nemoclaw/events")
+        data = json.loads(resp.data)
+        self.assertFalse(data["installed"])
+
+    def test_events_list_is_list(self):
+        resp = self._get("/api/nemoclaw/events")
+        data = json.loads(resp.data)
+        self.assertIsInstance(data["events"], list)
+
+    def test_events_total_matches_list(self):
+        resp = self._get("/api/nemoclaw/events")
+        data = json.loads(resp.data)
+        self.assertEqual(data["total"], len(data["events"]))
+
+    def test_events_empty_on_no_store(self):
+        resp = self._get("/api/nemoclaw/events")
+        data = json.loads(resp.data)
+        self.assertEqual(data["events"], [])
+
+
+class TestNemoClawMetricsEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        self.app = _make_app()
+        self.client = self.app.test_client()
+
+    def _get(self, url):
+        with patch("routes.local_query.local_store_via_daemon", side_effect=Exception("no daemon")):
+            with patch("clawmetry.local_store.get_store", side_effect=Exception("no store")):
+                return self.client.get(url)
+
+    def test_metrics_returns_200(self):
+        resp = self._get("/api/nemoclaw/metrics")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_metrics_has_required_keys(self):
+        resp = self._get("/api/nemoclaw/metrics")
+        data = json.loads(resp.data)
+        self.assertIn("installed", data)
+        self.assertIn("metrics", data)
+
+    def test_metrics_not_installed_when_nemoclaw_absent(self):
+        resp = self._get("/api/nemoclaw/metrics")
+        data = json.loads(resp.data)
+        self.assertFalse(data["installed"])
+
+    def test_metrics_object_has_expected_fields(self):
+        resp = self._get("/api/nemoclaw/metrics")
+        data = json.loads(resp.data)
+        m = data["metrics"]
+        self.assertIn("total_approvals", m)
+        self.assertIn("approved_count", m)
+        self.assertIn("denied_count", m)
+        self.assertIn("triggers_24h", m)
+
+    def test_metrics_defaults_to_zeros_on_no_store(self):
+        resp = self._get("/api/nemoclaw/metrics")
+        data = json.loads(resp.data)
+        m = data["metrics"]
+        self.assertEqual(m["total_approvals"], 0)
+        self.assertEqual(m["triggers_24h"], 0)
+
+
+class TestLocalStoreGuardrailMethods(unittest.TestCase):
+    """Unit tests for ingest_guardrail_event and query_guardrail_events."""
+
+    def _make_store(self):
+        from clawmetry.local_store import LocalStore
+        import tempfile, pathlib
+        tmp = pathlib.Path(tempfile.mkdtemp()) / "test.duckdb"
+        store = LocalStore.__new__(LocalStore)
+        import duckdb, threading
+        store._conn = duckdb.connect(str(tmp))
+        store._write_lock = threading.Lock()
+        store._path = tmp
+        # Run only the DDL we need
+        store._conn.execute("""
+            CREATE TABLE IF NOT EXISTS guardrail_events (
+                id VARCHAR PRIMARY KEY,
+                owner_hash VARCHAR,
+                ts VARCHAR NOT NULL,
+                rule_name VARCHAR,
+                verdict VARCHAR,
+                session_id VARCHAR,
+                action VARCHAR,
+                latency_ms DOUBLE
+            )
+        """)
+        store._conn.execute("""
+            CREATE TABLE IF NOT EXISTS approvals (
+                id VARCHAR PRIMARY KEY,
+                owner_hash VARCHAR,
+                requestor_session_id VARCHAR,
+                action VARCHAR,
+                args BLOB,
+                status VARCHAR NOT NULL DEFAULT 'pending',
+                created_at VARCHAR,
+                resolved_at VARCHAR,
+                resolver VARCHAR,
+                decision VARCHAR,
+                decision_reason VARCHAR
+            )
+        """)
+        return store
+
+    def _fetch(self, store, sql, params=None):
+        cur = store._conn.cursor()
+        if params:
+            cur.execute(sql, params)
+        else:
+            cur.execute(sql)
+        return cur.fetchall()
+
+    # Monkey-patch _fetch on the store instance
+    def _attach_fetch(self, store):
+        store._fetch = lambda sql, params=None: self._fetch(store, sql, params)
+
+    def test_ingest_and_query_guardrail_event(self):
+        store = self._make_store()
+        self._attach_fetch(store)
+        store.ingest_guardrail_event({
+            "id": "evt-1",
+            "ts": "2026-05-27T10:00:00",
+            "rule_name": "no-exfil",
+            "verdict": "triggered",
+            "session_id": "sess-abc",
+            "action": "write_file",
+            "latency_ms": 12.5,
+        })
+        rows = store.query_guardrail_events()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], "evt-1")
+        self.assertEqual(rows[0]["verdict"], "triggered")
+        self.assertAlmostEqual(rows[0]["latency_ms"], 12.5)
+
+    def test_ingest_guardrail_event_requires_id(self):
+        store = self._make_store()
+        self._attach_fetch(store)
+        with self.assertRaises(ValueError):
+            store.ingest_guardrail_event({"ts": "2026-05-27T10:00:00"})
+
+    def test_query_guardrail_events_empty(self):
+        store = self._make_store()
+        self._attach_fetch(store)
+        self.assertEqual(store.query_guardrail_events(), [])
+
+    def test_query_nemoclaw_metrics_empty_store(self):
+        store = self._make_store()
+        self._attach_fetch(store)
+        m = store.query_nemoclaw_metrics()
+        self.assertEqual(m["total_approvals"], 0)
+        self.assertEqual(m["triggers_24h"], 0)
+        self.assertIsNone(m["approval_rate_pct"])
+        self.assertIsNone(m["avg_latency_secs"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #876

## Summary

- **`clawmetry/local_store.py`** — additive `guardrail_events` DuckDB table (`CREATE TABLE IF NOT EXISTS`, no schema version bump) + `ingest_guardrail_event()`, `query_guardrail_events()`, `query_nemoclaw_metrics()` (approval rate / avg latency / 24h trigger count from existing `approvals` + new table)
- **`routes/nemoclaw.py`** — `GET /api/nemoclaw/events` and `GET /api/nemoclaw/metrics`, both using the daemon-proxy fast-path (same `_try_local_store_*` pattern as `pending-approvals`)
- **`routes/local_query.py`** — three new entries in `_DAEMON_METHODS` allowlist so the dashboard process never opens DuckDB writable
- **`clawmetry/templates/tabs/nemoclaw.html`** — GUARDRAIL EVENTS scrollable table panel + METRICS four-stat-card panel appended after the existing Egress Approvals panel
- **`clawmetry/static/js/app.js`** — `loadNemoClawEvents()` + `loadNemoClawMetrics()`, called from `loadNemoClaw()` on tab load
- **`tests/test_nemoclaw_events_metrics.py`** — 15 tests (route 200/shape, not-installed empty state, LocalStore unit tests for ingest/query/metrics)

## Test plan

- [ ] `python3 -m pytest tests/test_nemoclaw_events_metrics.py -v` → 15 passed (green locally)
- [ ] `GET /api/nemoclaw/events` on a host without NemoClaw → `{"installed": false, "events": [], "total": 0}`
- [ ] `GET /api/nemoclaw/metrics` on a host without NemoClaw → `{"installed": false, "metrics": {"total_approvals": 0, "triggers_24h": 0, ...}}`
- [ ] NemoClaw tab shows two new panels in empty state on a fresh install

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ej2CZ5sMHMuvuBULHb2hrU)_