### PR TITLE
feat: Tracing runtime filter + clearer switcher session counts

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8839,6 +8839,13 @@ function _renderTraceRows() {
   var box = document.getElementById('trace-rows');
   if (!box) return;
   var traces = (window._allTraces || []).slice();
+  // Global runtime switcher (header): scope traces to one runtime. Each
+  // event-derived trace's `trace_id` IS its session_id, whose prefix is the
+  // runtime discriminator (OTLP traces with hex ids fall through to OpenClaw).
+  var _trRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  if (_trRt && _trRt !== 'all') {
+    traces = traces.filter(function(t) { return _cmRuntimeOf({ id: t.trace_id }) === _trRt; });
+  }
   var f = window._traceListFilter, q = window._traceListSearch;
   if (q) traces = traces.filter(function(t) {
     return (((t.trace_id || '') + ' ' + (t.model || '')).toLowerCase().indexOf(q) !== -1);

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6782,9 +6782,13 @@ function _cmPopulateGlobalRuntime(counts) {
   var active = _cmRuntimeFilter();
   if (active !== 'all' && !counts[active]) active = 'all';
   var total = order.reduce(function(a, k) { return a + counts[k]; }, 0);
-  var html = '<option value="all">All runtimes (' + total + ')</option>';
+  // The count is the number of SESSIONS for that runtime — spell it out so the
+  // chip doesn't read as "22 Claude Code runtimes" (there's one runtime, many
+  // sessions). Singular/plural for the "1 session" case.
+  function _sessLabel(n) { return n + (n === 1 ? ' session' : ' sessions'); }
+  var html = '<option value="all">All runtimes · ' + _sessLabel(total) + '</option>';
   order.forEach(function(k) {
-    html += '<option value="' + k + '">' + escHtml(_CM_RT_LABEL[k] || k) + ' (' + counts[k] + ')</option>';
+    html += '<option value="' + k + '">' + escHtml(_CM_RT_LABEL[k] || k) + ' · ' + _sessLabel(counts[k]) + '</option>';
   });
   sel.innerHTML = html;
   sel.value = active;


### PR DESCRIPTION
Two runtime-switcher improvements, continuing the de-merge:

### 1. Tracing tab honours the runtime filter
`_renderTraceRows()` now filters by the global runtime switcher. Event-derived traces set `trace_id = session_id` (prefix = runtime), so the same `_cmRuntimeOf` filter that scopes Brain/Transcripts works (OTLP hex-id traces fall through to OpenClaw). Verified on a mixed dataset: All=30 → Claude Code=21, Qwen=2, opencode=3, goose=3, OpenClaw=1.

### 2. Switcher counts now read as "N sessions"
`Claude Code (22)` read as "22 Claude Code runtimes" — confusing, since there's **one** runtime running many sessions. Now: `Claude Code · 22 sessions` / `OpenClaw · 1 session` / `All runtimes · 23 sessions` (singular/plural handled). Verified in-browser.

After this, **Brain + Transcripts + Tracing** all de-merge by runtime. Cost/Overview/Usage (DuckDB aggregates) still need a server-side `runtime=` filter — next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)