### PR TITLE
fix: Active Tasks showed week-old runs as "Recently Completed"

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -14589,14 +14589,33 @@ async function loadOverviewTasks() {
       else if (isRealFailure) failed.push(a);
       else done.push(a);
     });
-    // Filter old completed/failed (2h)
-    done = done.filter(function(a) { return a.runtimeMs < 2 * 60 * 60 * 1000; });
-    failed = failed.filter(function(a) { return a.runtimeMs < 2 * 60 * 60 * 1000; });
+    // "Recently Completed/Failed" must mean RECENT — bound by how long ago the
+    // task FINISHED, not its run duration. The old `runtimeMs < 2h` check used
+    // duration, so a 5-minute task that finished 6 days ago still passed and
+    // showed as "recent" (an idle node looked busy). Derive the end time the
+    // same way _ovRenderCard's "Finished N ago" does (completionTs → updatedAt
+    // → startedAt+runtime); unknown end time → not recent.
+    var RECENT_DONE_MS = 60 * 60 * 1000; // 1h
+    var _nowMs = Date.now();
+    function _ovEndedMs(a) {
+      var e = 0;
+      if (a.completionTs) { var ct = Date.parse(a.completionTs); if (!isNaN(ct)) e = ct; }
+      if (!e && a.updatedAt) e = a.updatedAt;
+      if (!e && a.startedAt && a.runtimeMs) e = a.startedAt + a.runtimeMs;
+      return e;
+    }
+    function _ovRecentlyFinished(a) {
+      var e = _ovEndedMs(a);
+      return e > 0 && (_nowMs - e) < RECENT_DONE_MS;
+    }
+    done = done.filter(_ovRecentlyFinished);
+    failed = failed.filter(_ovRecentlyFinished);
 
     if (countBadge) countBadge.textContent = running.length > 0 ? '(' + running.length + ' running)' : '(' + (done.length + failed.length) + ' recent)';
 
     var totalShown = running.length + done.length + failed.length;
     if (totalShown === 0) {
+      if (countBadge) countBadge.textContent = '';
       el.innerHTML = '<div style="text-align:center;padding:40px 20px;color:var(--text-muted);">'
         + '<div style="font-size:32px;margin-bottom:12px;" class="tasks-empty-icon">😴</div>'
         + '<div style="font-size:14px;font-weight:600;color:var(--text-tertiary);margin-bottom:4px;">No active tasks</div>'


### PR DESCRIPTION
## The bug (from a screenshot of an idle node)

The overview **Active Tasks** panel showed tasks that finished **6 days ago** under "✅ Recently Completed", so an idle node looked busy.

Root cause (`loadOverviewTasks`, app.js):
```js
done = done.filter(function(a) { return a.runtimeMs < 2 * 60 * 60 * 1000; });
```
`runtimeMs` is the run **duration**, not **how long ago the task finished**. A 5-minute task that ended 6 days ago has `runtimeMs = 300000`, which passes `< 2h` — so it lingered as "recent" forever. The card's own "Finished N ago" label already computed finish-age correctly; only the filter was wrong.

## Fix

Bound "Recently Completed/Failed" by **finish age (1h)**, derived the same way the card does (`completionTs → updatedAt → startedAt+runtime`); unknown end time → not recent. Running tasks still always show. Idle nodes now show "😴 No active tasks — The AI is idle" and the count badge clears.

## Verified locally (mocked /api/subagents)
- Mix (1 active, 1 done-5min-ago, 1 done-6d-ago, 1 idle-6d-ago) → renders **Running (1) + Recently Completed (1)**; both 6-day-old entries filtered out.
- All-stale (everything 6d old) → **"No active tasks — The AI is idle"**, badge cleared.

Frontend-only (no new routes); needs a release + cloud pin bump to reach `app.clawmetry.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)