### PR TITLE
chore: bump to v0.12.334 [skip ci]

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -153,7 +153,7 @@ except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
 
-__version__ = "0.12.333"
+__version__ = "0.12.334"
 
 # Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
 try:


### PR DESCRIPTION
Reconciles `main` with the already-published PyPI **0.12.334** wheel. The release-on-merge auto-bump (#2175) published 0.12.334 successfully but its final push failed on a transient GitHub `commit_refs` error, leaving main at 0.12.333 — which would collide on the next release. No functional change, no `[RELEASE]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)