### PR TITLE
fix(tool-catalog): cross-runtime builtin provenance + drill-down calls in snapshot

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9891,8 +9891,14 @@ def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
     except Exception:
         return out
 
-    # Builtin universe from the mirrored sandbox tool policy.
-    builtin: set = set()
+    # Builtin universe: the mirrored OpenClaw sandbox tool policy unioned with
+    # the cross-runtime builtin names (Claude Code / Codex have no sandbox
+    # policy on disk, so without this their builtins mislabel as "plugin").
+    try:
+        from routes.tool_catalog import RUNTIME_BUILTINS as _rt_builtins
+        builtin: set = set(_rt_builtins)
+    except Exception:
+        builtin = set()
     try:
         for r in (store.query_tool_policy(limit=25) or []):
             allow = r.get("allow")
@@ -9985,12 +9991,23 @@ def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
                 if m["ts"] is not None and start is not None:
                     dur = max(0, m["ts"] - start)
                 break
-        a = agg.setdefault(name, {"calls": 0, "durs": [], "errs": 0})
+        a = agg.setdefault(name, {"calls": 0, "durs": [], "errs": 0, "recent": []})
         a["calls"] += 1
         if dur is not None:
             a["durs"].append(dur)
         if err:
             a["errs"] += 1
+        # Per-call detail for the cloud drill-down (#tool-catalog calls). The
+        # OSS /api/tool-catalog/<name>/calls reads DuckDB live; the cloud
+        # container has none, so the cm-cloud-tool-catalog interceptor reads
+        # toolCatalog.calls[name] from the snapshot instead. Mirror its field
+        # shape: {ts_ms, duration_ms, status, session_id}.
+        a["recent"].append({
+            "ts_ms": start,
+            "duration_ms": dur,
+            "status": "error" if err else "ok",
+            "session_id": (e.get("session_id") or None),
+        })
 
     def _pct(vals, p):
         if not vals:
@@ -10033,6 +10050,18 @@ def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
         out["groups"][prov] = out["groups"].get(prov, 0) + 1
     tools.sort(key=lambda t: (-t["calls"], -(t["p95_ms"] or 0), t["name"]))
     out["tools"] = tools[:int(top)]
+
+    # Per-tool recent calls for the cloud drill-down — only for the tools we
+    # actually ship (top N), newest first, capped per tool so a hot tool can't
+    # bloat the shared snapshot (#1895 lesson). Keyed by tool name to match the
+    # cloud interceptor's toolCatalog.calls[name] lookup.
+    recent_cap = 15
+    calls_map: dict = {}
+    for t in out["tools"]:
+        recent = agg.get(t["name"], {}).get("recent", [])
+        recent.sort(key=lambda c: c.get("ts_ms") or 0, reverse=True)
+        calls_map[t["name"]] = recent[:recent_cap]
+    out["calls"] = calls_map
     return out
 
 

--- a/routes/tool_catalog.py
+++ b/routes/tool_catalog.py
@@ -37,7 +37,7 @@ empty data.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 
 from flask import Blueprint, jsonify, request
 
@@ -160,13 +160,41 @@ def _is_tool_result(e):
 
 # ── Provenance classification ───────────────────────────────────────────────
 
+# Well-known builtin tool names for the non-OpenClaw runtimes ClawMetry now
+# observes (Claude Code, Codex, …). The OpenClaw builtin universe is discovered
+# from the synced sandbox ``tool_policy``; other runtimes ship no such policy to
+# disk, so without this set their core tools (Bash/Read/Edit/Write/Task*…) fall
+# through to "plugin" and the whole provenance breakdown is wrong on, e.g., a
+# Claude Code node. Names are runtime-distinct (PascalCase Claude Code vs Codex
+# snake_case vs ``mcp__`` MCP) so a flat union can't collide across runtimes.
+RUNTIME_BUILTINS = frozenset({
+    # Claude Code core file/shell/search tools
+    "Bash", "BashOutput", "KillShell", "KillBash",
+    "Read", "Edit", "MultiEdit", "Write", "NotebookEdit",
+    "Glob", "Grep", "LS",
+    # Claude Code agent / planning / meta tools
+    "Task", "Agent", "TodoWrite", "WebFetch", "WebSearch",
+    "ExitPlanMode", "EnterPlanMode", "SlashCommand", "Skill",
+    "AskUserQuestion", "ToolSearch",
+    # Claude Code / FleetView task, cron, worktree & scheduling tools
+    "TaskCreate", "TaskUpdate", "TaskGet", "TaskList", "TaskOutput", "TaskStop",
+    "CronCreate", "CronDelete", "CronList",
+    "EnterWorktree", "ExitWorktree",
+    "Monitor", "PushNotification", "RemoteTrigger", "ScheduleWakeup",
+    # Codex CLI distinctive builtins (snake_case, unambiguous)
+    "apply_patch", "update_plan",
+})
+
+
 def _builtin_tool_set() -> set:
-    """The OpenClaw sandbox builtin-tool universe, read from the DuckDB
-    ``tool_policy`` table (mirrored from ``openclaw sandbox explain --json`` by
-    the sync daemon). The union of every agent's ``allow`` list. Empty set when
-    the policy hasn't been synced yet — callers then fall back to name shape
-    only."""
-    builtin: set = set()
+    """The builtin-tool universe. Unions the OpenClaw sandbox allow set (read
+    from the DuckDB ``tool_policy`` table, mirrored from ``openclaw sandbox
+    explain --json`` by the sync daemon) with ``RUNTIME_BUILTINS`` so non-
+    OpenClaw runtimes (Claude Code, Codex) classify their builtins correctly
+    even though they have no sandbox policy on disk. Falls back to just
+    ``RUNTIME_BUILTINS`` when the policy hasn't been synced yet — never empty,
+    so a Claude Code node no longer mislabels Bash/Read/Edit as plugin."""
+    builtin: set = set(RUNTIME_BUILTINS)
     for r in _coerce_rows(_ls_call("query_tool_policy", limit=25)):
         allow = r.get("allow")
         if isinstance(allow, list):

--- a/tests/test_tool_catalog_provenance_and_calls.py
+++ b/tests/test_tool_catalog_provenance_and_calls.py
@@ -1,0 +1,170 @@
+"""Regression tests for the Tool Catalog provenance + drill-down fixes.
+
+Two bugs this guards (both surfaced on a live Claude Code node,
+``agent+Macbook-Pro-2-local``):
+
+1. **Cross-runtime provenance.** ``builtin`` was decided *only* from the
+   OpenClaw sandbox ``tool_policy`` allow set. A Claude Code / Codex node ships
+   no such policy, so its core tools (Bash/Read/Edit/Write/Task*…) fell through
+   to ``plugin`` and the whole provenance breakdown was wrong. The fix unions a
+   ``RUNTIME_BUILTINS`` set into the builtin universe.
+
+2. **Cloud drill-down always empty.** The cloud ``cm-cloud-tool-catalog``
+   interceptor reads ``snapshot.toolCatalog.calls[name]`` for the per-call
+   drill-down, but the daemon's ``_build_tool_catalog_slice`` only ever shipped
+   ``{tools, groups}`` — so the expand showed "No individual calls captured"
+   for every tool on cloud. The fix ships a bounded per-tool ``calls`` map.
+
+Events are ingested in the real Claude Code tool_call/tool_result shape so a
+synthetic-but-wrong fixture can't pass while real data flunks.
+"""
+
+from __future__ import annotations
+
+import importlib
+import time
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+def _iso(s: float) -> str:
+    return datetime.fromtimestamp(s, tz=timezone.utc).isoformat()
+
+
+def _wait_flush(store, t=2.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+@pytest.fixture
+def catalog_app(tmp_path, monkeypatch):
+    """Flask app + tmp DuckDB with the daemon proxy short-circuited so the
+    route's ``_ls_call`` falls through to the in-process store."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Own the writer in-process so get_store() opens the tmp DuckDB directly
+    # instead of proxying to a live daemon (CI has none; a dev box does).
+    ls.mark_writer_owner()
+    import routes.local_query as lq
+    importlib.reload(lq)
+    monkeypatch.setattr(lq, "local_store_via_daemon", lambda *a, **k: None)
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
+    monkeypatch.setattr(lq, "_cached_discovery", lambda: None)
+    import routes.tool_catalog as tc
+    importlib.reload(tc)
+    a = Flask(__name__)
+    a.register_blueprint(tc.bp_tool_catalog)
+    yield a, ls, tc
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _call(store, *, eid, sid, ts, name, tuid):
+    """A Claude Code tool-invocation event."""
+    store.ingest({
+        "id": eid, "node_id": "agent+test", "agent_id": "main",
+        "session_id": sid, "event_type": "tool_call", "ts": _iso(ts),
+        "data": {"tool_name": name, "tool_calls": [{"id": tuid, "name": name}]},
+        "cost_usd": None, "token_count": None, "model": None,
+    })
+
+
+def _result(store, *, eid, sid, ts, tuid, error=False):
+    """The closing tool_result for ``tuid`` (Claude Code role='tool' shape)."""
+    store.ingest({
+        "id": eid, "node_id": "agent+test", "agent_id": "main",
+        "session_id": sid, "event_type": "tool_result", "ts": _iso(ts),
+        "data": {"role": "tool", "extra": {"toolUseId": tuid, "isError": error}},
+        "cost_usd": None, "token_count": None, "model": None,
+    })
+
+
+def _seed_claude_code_tools(store):
+    """One call+result for each of: two builtins, an MCP tool, a real plugin,
+    plus a second Bash call that errored (so error_rate > 0)."""
+    now = time.time()
+    rows = [
+        ("Bash", "t1", False),
+        ("Read", "t2", False),
+        ("TaskCreate", "t3", False),
+        ("mcp__chrome-devtools__click", "t4", False),
+        ("some_vendor_tool", "t5", False),
+        ("Bash", "t6", True),   # second Bash call, errored
+    ]
+    for i, (name, tuid, err) in enumerate(rows):
+        ts = now - 600 + i * 10
+        _call(store, eid=f"c-{i}", sid=f"sess-{i % 2}", ts=ts, name=name, tuid=tuid)
+        _result(store, eid=f"r-{i}", sid=f"sess-{i % 2}", ts=ts + 0.05,
+                 tuid=tuid, error=err)
+    _wait_flush(store)
+
+
+def test_provenance_classifies_claude_code_builtins(catalog_app):
+    """Bash/Read/TaskCreate are builtin even with no OpenClaw sandbox policy."""
+    a, ls, _tc = catalog_app
+    _seed_claude_code_tools(ls.get_store())
+    body = a.test_client().get("/api/tool-catalog").get_json() or {}
+    prov = {t["name"]: t["provenance"] for t in body["tools"]}
+    assert prov.get("Bash") == "builtin", prov
+    assert prov.get("Read") == "builtin", prov
+    assert prov.get("TaskCreate") == "builtin", prov
+    assert prov.get("mcp__chrome-devtools__click") == "mcp", prov
+    # A genuinely unknown name is still plugin — the fix must not over-classify.
+    assert prov.get("some_vendor_tool") == "plugin", prov
+    g = body["groups"]
+    assert g["builtin"] >= 3 and g["mcp"] >= 1 and g["plugin"] >= 1, g
+
+
+def test_mcp_provider_extracted(catalog_app):
+    """``mcp__<provider>__<tool>`` → provider segment for the MCP rollup."""
+    a, ls, _tc = catalog_app
+    _seed_claude_code_tools(ls.get_store())
+    body = a.test_client().get("/api/tool-catalog").get_json() or {}
+    row = next(t for t in body["tools"] if t["name"] == "mcp__chrome-devtools__click")
+    assert row["provider"] == "chrome-devtools", row
+
+
+def test_drilldown_returns_individual_calls(catalog_app):
+    """The live /calls endpoint returns per-call rows (status + session)."""
+    a, ls, _tc = catalog_app
+    _seed_claude_code_tools(ls.get_store())
+    body = a.test_client().get("/api/tool-catalog/Bash/calls").get_json() or {}
+    assert body["provenance"] == "builtin", body
+    calls = body["calls"]
+    assert len(calls) == 2, body            # two Bash invocations
+    assert {c["status"] for c in calls} == {"ok", "error"}, calls
+    assert all(c.get("session_id") for c in calls), calls
+
+
+def test_snapshot_slice_ships_calls_map(catalog_app):
+    """The cloud drill-down reads toolCatalog.calls[name] — the daemon slice
+    must ship it (was the always-empty-in-cloud bug)."""
+    a, ls, _tc = catalog_app
+    _seed_claude_code_tools(ls.get_store())
+    from clawmetry.sync import _build_tool_catalog_slice
+    slice_ = _build_tool_catalog_slice()
+    assert "calls" in slice_, slice_.keys()
+    calls = slice_["calls"]
+    # Every shipped tool row has a (non-empty) recent-calls list keyed by name.
+    shipped = {t["name"] for t in slice_["tools"]}
+    assert shipped, slice_
+    for name in shipped:
+        assert name in calls, (name, list(calls))
+    bash = calls["Bash"]
+    assert len(bash) == 2, bash
+    sample = bash[0]
+    assert set(sample) == {"ts_ms", "duration_ms", "status", "session_id"}, sample
+    # Provenance is fixed in the slice too (cloud renders this verbatim).
+    prov = {t["name"]: t["provenance"] for t in slice_["tools"]}
+    assert prov.get("Bash") == "builtin", prov


### PR DESCRIPTION
## What & why

The cloud **Tool catalog** tab was misbehaving on a live Claude Code node (`agent+Macbook-Pro-2-local`), spotted in the dashboard:

**1. Every builtin was labeled `plugin`.** Bash, Read, Edit, Write, TaskCreate, TaskUpdate all showed `plugin`; the header read "1 builtin / 7 MCP / 14 plugin". Root cause: `builtin` was decided *only* from the OpenClaw sandbox `tool_policy.allow` set (`openclaw sandbox explain --json`). A Claude Code / Codex runtime ships no such policy, so every PascalCase builtin fell through to `plugin`. The whole provenance breakdown was meaningless off OpenClaw.

**2. The per-tool drill-down was always empty in cloud** — "No individual calls captured in the recent event window" under every tool. The summary table is real (it rides `snapshot.toolCatalog`), but the cloud `cm-cloud-tool-catalog` interceptor reads `snapshot.toolCatalog.calls[name]` for the expand, and `_build_tool_catalog_slice()` only ever shipped `{tools, groups}`. The cold fall-through then hit the cloud server's `/api/tool-catalog/<name>/calls` route, which reads DuckDB — empty on the cloud container. So the drill-down was structurally always empty in cloud.

## The fix

- **Provenance:** new `RUNTIME_BUILTINS` set (Claude Code + Codex core tool names) unioned into the builtin universe in both the live route (`routes/tool_catalog.py`) and the snapshot slice builder (`clawmetry/sync.py`). Names are runtime-distinct (PascalCase vs snake_case vs `mcp__`) so a flat union can't collide. A genuinely unknown name is still `plugin` (no over-classification).
- **Drill-down:** `_build_tool_catalog_slice()` now ships a bounded per-tool `calls` map — the 15 newest calls of each shipped tool as `{ts_ms, duration_ms, status, session_id}` — keyed by tool name to match the interceptor's lookup. No cloud code change needed (the interceptor already reads `calls[name]`).

## Cost

`+22.8 KB` (4.7% of the snapshot) for the calls map, served behind the existing `system-snapshot` ETag/304 so unchanged blobs aren't re-sent.

## Verification

Copied both files into the daemon venv, restarted the daemon, and **decrypted the live cloud snapshot** for the node:
- `groups: {builtin: 12, mcp: 7, plugin: 2}` (was 1 / 7 / 14)
- Bash/Read/Edit/TaskUpdate/Write/TaskCreate/ToolSearch/Agent/AskUserQuestion → `builtin`; chrome-devtools tools → `mcp`; only `glob` + `list_directory` (1 call each) remain `plugin`
- `toolCatalog.calls` present, 21 keyed tools, 15 recent each, correct field shape

New regression test `tests/test_tool_catalog_provenance_and_calls.py` (4 tests, all green) ingests real Claude Code `tool_call`/`tool_result` shapes and asserts both fixes, including the slice's `calls` map.

Daemon change → will need a `[RELEASE]` + cloud pin bump to light up in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)