### PR TITLE
feat(runtime): Models tab filters by selected runtime (real per-runtime aggregation)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6811,7 +6811,7 @@ function _cmRuntimeLabel(rt) { return _CM_RT_LABEL[rt] || rt; }
 // shows an honest "all runtimes" note rather than pretending the numbers are
 // runtime-specific. (Per-runtime aggregation is a follow-up.)
 var _CM_RT_AGGREGATE = {
-  models: 1, usage: 1, 'tool-catalog': 1, 'context-economics': 1, context: 1
+  usage: 1, 'tool-catalog': 1, 'context-economics': 1, context: 1
 };
 // Tabs that are NODE-WIDE concepts, not per-runtime: crons run on the gateway,
 // memory/skills are workspace-level, security is machine posture, self-evolve is
@@ -11215,7 +11215,12 @@ function exportUsageData() {
 // ===== Model Attribution =====
 async function loadModelAttribution() {
   try {
-    var data = await fetch('/api/model-attribution').then(function(r) { return r.json(); });
+    // Scope to the selected runtime (the server route + cloud interceptor both
+    // honour ?runtime=<prefix> and return that runtime's attribution, or an
+    // honest empty set — never the merged view).
+    var _maRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+    var _maQ = (_maRt && _maRt !== 'all') ? ('?runtime=' + encodeURIComponent(_maRt)) : '';
+    var data = await fetch('/api/model-attribution' + _maQ).then(function(r) { return r.json(); });
     var models = data.models || [];
     var switches = data.switches || [];
     var totalTurns = data.total_turns || 0;
@@ -11248,7 +11253,10 @@ async function loadModelAttribution() {
       chartHtml += '<div style="min-width:55px;text-align:right;font-size:12px;color:var(--text-secondary);">' + m.turns.toLocaleString() + ' turns</div>';
       chartHtml += '</div>';
     });
-    document.getElementById('model-mix-chart').innerHTML = chartHtml || '<div style="color:#666;">No model data found in sessions.</div>';
+    var _maEmpty = (_maRt && _maRt !== 'all')
+      ? 'No model activity for <strong>' + escHtml(_cmRuntimeLabel(_maRt)) + '</strong> yet.'
+      : 'No model data found in sessions.';
+    document.getElementById('model-mix-chart').innerHTML = chartHtml || '<div style="color:#666;">' + _maEmpty + '</div>';
 
     // Per-model session table
     var tbodyHtml = '';

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8677,6 +8677,106 @@ def _build_model_attribution():
         return {}
 
 
+# Cross-runtime builtin/runtime prefixes — mirrors the frontend `_cmRuntimeOf`
+# and `_CM_RT_LABEL` keys (agent_type is always "openclaw"; the runtime is the
+# session-id prefix). Keep in sync with clawmetry/static/js/app.js.
+_RUNTIME_PREFIXES = frozenset({
+    "picoclaw", "nanoclaw", "hermes", "claude_code", "codex", "cursor",
+    "aider", "goose", "opencode", "qwen_code",
+})
+
+
+def _runtime_of_session(sid: str) -> str:
+    """Runtime for a session id = its prefix before ':' if it's a known
+    non-OpenClaw runtime, else 'openclaw'. Mirrors frontend `_cmRuntimeOf`."""
+    sid = sid or ""
+    i = sid.find(":")
+    if i > 0:
+        p = sid[:i].lower()
+        if p in _RUNTIME_PREFIXES:
+            return p
+    return "openclaw"
+
+
+def _build_runtime_summary(limit: int = 20000):
+    """Per-runtime rollup so the cloud Models / Cost / Overview tabs can scope
+    aggregates to the selected runtime for real (not just show a note).
+
+    Buckets the DuckDB events by runtime (session-id prefix) on the daemon's
+    OWN store handle. Each runtime gets a per-turn model-attribution block in
+    the SAME shape as ``_build_model_attribution`` (``models``/``total_turns``/
+    ``primary_model``) plus ``tokens``/``cost_usd``/``sessions``, so the cloud
+    Models interceptor can return ``runtimeSummary[rt]`` verbatim and the
+    Overview headline can read the per-runtime totals. Bounded (≈10 runtimes ×
+    a 15-model list) so it stays tiny in the shared snapshot. Best-effort: any
+    failure yields ``{}``.
+    """
+    try:
+        from collections import defaultdict
+        from clawmetry import local_store as _ls
+
+        store = _ls.get_store()
+        if store is None:
+            return {}
+        evs = store.query_events(limit=int(limit))
+        if not evs:
+            return {}
+        agg: dict = {}
+        sess_models = defaultdict(list)  # (rt, sid) -> ordered model list
+        for ev in sorted(evs, key=lambda e: (e.get("session_id") or "", e.get("ts") or "")):
+            sid = ev.get("session_id") or ""
+            rt = _runtime_of_session(sid)
+            a = agg.setdefault(rt, {"turns": 0, "tokens": 0, "cost": 0.0,
+                                    "models": {}, "sessions": set()})
+            if sid:
+                a["sessions"].add(sid)
+            try:
+                a["tokens"] += int(ev.get("token_count") or 0)
+            except (TypeError, ValueError):
+                pass
+            try:
+                a["cost"] += float(ev.get("cost_usd") or 0.0)
+            except (TypeError, ValueError):
+                pass
+            m = (ev.get("model") or "").strip()
+            if not m:
+                continue
+            a["turns"] += 1
+            a["models"][m] = a["models"].get(m, 0) + 1
+            key = (rt, sid)
+            if sid and (not sess_models[key] or sess_models[key][-1] != m):
+                sess_models[key].append(m)
+        rt_model_sessions = defaultdict(lambda: defaultdict(int))
+        rt_switches = defaultdict(int)
+        for (rt, _sid), mlist in sess_models.items():
+            if mlist:
+                rt_model_sessions[rt][mlist[0]] += 1
+            rt_switches[rt] += max(0, len(mlist) - 1)
+        out: dict = {}
+        for rt, a in agg.items():
+            total = sum(a["models"].values())
+            sorted_models = sorted(a["models"].items(), key=lambda x: -x[1])
+            models_out = [{
+                "model": m, "turns": t,
+                "sessions": rt_model_sessions[rt].get(m, 0),
+                "share_pct": round(t / total * 100, 2) if total else 0,
+            } for m, t in sorted_models[:15]]
+            out[rt] = {
+                "sessions": len(a["sessions"]),
+                "turns": a["turns"],
+                "tokens": a["tokens"],
+                "cost_usd": round(a["cost"], 4),
+                "primary_model": sorted_models[0][0] if sorted_models else "",
+                "total_turns": total,
+                "models": models_out,
+                "switch_count": rt_switches[rt],
+            }
+        return out
+    except Exception as _e:
+        log.debug("runtime summary snapshot build failed: %s", _e)
+        return {}
+
+
 # #1911: bound the tool deep-dive detail before it rides the shared ~170 KB
 # encrypted snapshot. The local dashboard keeps the full input/output
 # (``_TOOL_DETAIL_CAP`` in routes/sessions.py); the cloud Embodied tab gets a
@@ -11016,6 +11116,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "ollamaInfo": _detect_ollama_for_heartbeat(),
         "diagnostics": _build_diagnostics(paths.get("workspace")),
         "modelAttribution": _build_model_attribution(),
+        "runtimeSummary": _build_runtime_summary(),
         "transcripts": _build_transcripts(
             extra_sids=[
                 s["sessionId"]

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -842,10 +842,30 @@ def _try_local_store_usage_forecast():
     }
 
 
-def _try_local_store_model_attribution():
+# Known non-OpenClaw runtime prefixes (session-id prefix = runtime; agent_type
+# is always "openclaw"). Mirrors the frontend `_cmRuntimeOf` / `_CM_RT_LABEL`.
+_RUNTIME_PREFIXES = frozenset({
+    "picoclaw", "nanoclaw", "hermes", "claude_code", "codex", "cursor",
+    "aider", "goose", "opencode", "qwen_code",
+})
+
+
+def _runtime_of(sid):
+    sid = sid or ""
+    i = sid.find(":")
+    if i > 0:
+        p = sid[:i].lower()
+        if p in _RUNTIME_PREFIXES:
+            return p
+    return "openclaw"
+
+
+def _try_local_store_model_attribution(runtime=None):
     """Fast path for /api/model-attribution. Per-model assistant turn count,
     session count, provider tag, and share %. Switches list is best-effort
-    — derived from per-session model variation."""
+    — derived from per-session model variation. When ``runtime`` is set (a
+    session-id prefix like ``qwen_code``), only that runtime's events count, so
+    the Models tab scopes to the runtime switcher selection."""
     store = _ls_get_store()
     if store is None:
         return None
@@ -855,6 +875,13 @@ def _try_local_store_model_attribution():
         return None
     if not evs:
         return None
+    if runtime and runtime != "all":
+        evs = [e for e in evs if _runtime_of(e.get("session_id")) == runtime]
+        if not evs:
+            # Honest empty — the runtime exists in the switcher but has no
+            # model-bearing turns; don't fall back to the merged view.
+            return {"models": [], "switches": [], "total_turns": 0,
+                    "primary_model": "", "runtime": runtime, "_source": "local_store"}
     try:
         import dashboard as _d
         provider_fn = getattr(_d, "_provider_from_model", None)
@@ -2683,12 +2710,16 @@ def api_usage_export():
 
 @bp_usage.route('/api/model-attribution')
 def api_model_attribution():
-    """Per-model turn/session breakdown and switch history (GH #300)."""
+    """Per-model turn/session breakdown and switch history (GH #300).
+
+    ``?runtime=<prefix>`` scopes the breakdown to one runtime (session-id
+    prefix) so the Models tab honours the runtime switcher."""
     import dashboard as _d
+    runtime = (request.args.get('runtime') or '').strip() or None
 
     # Epic #964 — local-store fast path.
     if is_local_store_read_enabled():
-        fast = _try_local_store_model_attribution()
+        fast = _try_local_store_model_attribution(runtime=runtime)
         if fast is not None:
             return jsonify(fast)
 

--- a/tests/test_appjs_units.js
+++ b/tests/test_appjs_units.js
@@ -1148,11 +1148,16 @@ console.log('_cmApplyRuntimeScopeNote (honest note on aggregate / node-wide tabs
   vm.createContext(sandbox);
   vm.runInContext(maps + '\n' + fnSrc + '\nthis._note = _cmApplyRuntimeScopeNote;', sandbox);
 
-  // aggregate tab (models) → "all runtimes" note mentioning the runtime
-  thePage = null; sandbox.document.getElementById = function(id) { return id === 'page-models' ? (thePage = thePage || makePage()) : null; };
-  sandbox._note('models');
+  // aggregate tab (usage/Cost) → "all runtimes" note mentioning the runtime
+  thePage = null; sandbox.document.getElementById = function(id) { return id === 'page-usage' ? (thePage = thePage || makePage()) : null; };
+  sandbox._note('usage');
   truthy(thePage && thePage._html.indexOf('all runtimes') !== -1, 'aggregate tab → "all runtimes" note');
   truthy(thePage._html.indexOf('Qwen Code') !== -1, 'aggregate note names the selected runtime');
+
+  // models is NO LONGER aggregate (it filters for real now) → no note
+  thePage = null; sandbox.document.getElementById = function(id) { return id === 'page-models' ? (thePage = thePage || makePage()) : null; };
+  sandbox._note('models');
+  truthy(thePage && thePage._html === '', 'models tab → no note (filters for real now)');
 
   // node-wide tab (crons) → "node-wide" note
   thePage = null; sandbox.document.getElementById = function(id) { return id === 'page-crons' ? (thePage = thePage || makePage()) : null; };


### PR DESCRIPTION
Follow-up to #2180. The Models tab merged every runtime, so picking **Qwen Code** still showed `claude-opus-4-7` / 19,802 turns (it only got an honest "all runtimes" note). Now it filters for real.

### How
- **Daemon** ships a compact `runtimeSummary` snapshot slice: per-runtime (session-id prefix) `tokens / turns / cost_usd / sessions` + a model-attribution block (`models / total_turns / primary_model`). Bucketed on the daemon's own store handle; ~10 runtimes × a 15-model list so it stays tiny.
- **`/api/model-attribution?runtime=<prefix>`** filters events to that runtime before aggregating — honest empty set when the runtime has no model turns, never a silent merge.
- **app.js** appends `?runtime=` from the switcher and drops `models` from the scope-note map (it filters for real now); empty state is runtime-aware.
- The matching **cloud `cm-cloud-models` interceptor** reads `runtimeSummary[rt]` (shipping in the paired cloud PR + pin bump).

### Verified on the live snapshot
```
runtimeSummary.qwen_code   = { turns: 9,     primary_model: 'qwen3:8b' }
runtimeSummary.claude_code = { turns: 19859, primary_model: 'claude-opus-4-7' }
```
So selecting Qwen Code on Models will correctly show **qwen3:8b / 9 turns** — the true answer to "are we really using Qwen / claude-opus-4-7?".

Overview headline + Cost tab can reuse the same `runtimeSummary` slice next.

178 app.js unit tests pass; `node --check` + `ast.parse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)