### PR TITLE
feat(runtime): scope the Overview MODEL card to the selected runtime

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2581,6 +2581,19 @@ async function loadAll() {
     if (overview.model && overview.model !== 'unknown') {
       applyBrainModelToAll(overview.model);
     }
+    // Scope the Overview MODEL card to the selected runtime — the flagged
+    // "MODEL claude-opus-4-7 while Qwen Code is selected" confusion. Uses the
+    // per-runtime primary model from /api/runtime-summary (cloud serves the
+    // runtimeSummary snapshot slice). Cost/tokens stay node totals: they're
+    // today/week/month windows the all-time runtimeSummary can't decompose.
+    try {
+      var _ovRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+      if (_ovRt && _ovRt !== 'all') {
+        var _rsd = await fetchJsonWithTimeout('/api/runtime-summary', 4000);
+        var _rs = _rsd && _rsd.runtimes && _rsd.runtimes[_ovRt];
+        applyBrainModelToAll((_rs && _rs.primary_model) ? _rs.primary_model : '—');
+      }
+    } catch (e) { /* non-fatal — leave the node-wide model */ }
 
     // Usage may be slow on first run; keep trying in background with timeout.
     try {

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -2708,6 +2708,53 @@ def api_usage_export():
         return jsonify({'error': str(e)}), 500
 
 
+@bp_usage.route('/api/runtime-summary')
+def api_runtime_summary():
+    """Per-runtime rollup (tokens / cost / turns / sessions / primary model),
+    keyed by session-id prefix, so the Overview headline can scope to the
+    runtime switcher. Mirrors the daemon ``runtimeSummary`` snapshot slice; the
+    cloud serves that slice via an interceptor instead of this route. Reads the
+    local store (fast path); never 500s — empty store yields ``{}``."""
+    store = _ls_get_store() if is_local_store_read_enabled() else None
+    out = {}
+    if store is not None:
+        try:
+            evs = store.query_events(limit=20000) or []
+            agg = {}
+            for ev in evs:
+                rt = _runtime_of(ev.get("session_id"))
+                a = agg.setdefault(rt, {"turns": 0, "tokens": 0, "cost": 0.0,
+                                        "models": {}, "sessions": set()})
+                sid = ev.get("session_id") or ""
+                if sid:
+                    a["sessions"].add(sid)
+                try:
+                    a["tokens"] += int(ev.get("token_count") or 0)
+                except (TypeError, ValueError):
+                    pass
+                try:
+                    a["cost"] += float(ev.get("cost_usd") or 0.0)
+                except (TypeError, ValueError):
+                    pass
+                m = (ev.get("model") or "").strip()
+                if m:
+                    a["turns"] += 1
+                    a["models"][m] = a["models"].get(m, 0) + 1
+            for rt, a in agg.items():
+                sorted_models = sorted(a["models"].items(), key=lambda x: -x[1])
+                out[rt] = {
+                    "sessions": len(a["sessions"]),
+                    "turns": a["turns"],
+                    "tokens": a["tokens"],
+                    "cost_usd": round(a["cost"], 4),
+                    "primary_model": sorted_models[0][0] if sorted_models else "",
+                    "total_turns": sum(a["models"].values()),
+                }
+        except Exception:
+            out = {}
+    return jsonify({"runtimes": out, "_source": "local_store"})
+
+
 @bp_usage.route('/api/model-attribution')
 def api_model_attribution():
     """Per-model turn/session breakdown and switch history (GH #300).


### PR DESCRIPTION
Closes the last runtime-switcher gap (image #3): the Overview headline MODEL card showed the node-dominant model (claude-opus-4-7) even with Qwen Code selected. Now it shows the selected runtime's primary model (qwen3:8b for Qwen Code), matching the Models tab.

- New `GET /api/runtime-summary` (per-runtime tokens/cost/turns/sessions/primary_model by session-id prefix; mirrors the daemon `runtimeSummary` slice). Never 500s.
- `loadAll` overrides the model card from `runtime-summary[<runtime>]` when a runtime is selected ('—' if no model turns). Cost/tokens stay node totals (today/week/month windows the all-time slice can't decompose).

Cloud interceptor for `/api/runtime-summary` + pin bump ship in the paired cloud PR. 177 app.js unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)