### PR TITLE
feat: Ed25519 self-hosted license client (clawmetry activate)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2481,6 +2481,45 @@ def _cmd_update() -> None:
         sys.exit(1)
 
 
+def _cmd_activate(args) -> None:
+    """clawmetry activate <KEY> — install a self-hosted Pro/Enterprise license."""
+    from clawmetry import license as _lic
+
+    ok, msg = _lic.activate(args.key, node_id=_lic._node_id())
+    if ok:
+        print(f"✅  {msg}")
+        print("    Run `clawmetry license` to see status. Restart the daemon to load Pro features.")
+    else:
+        print(f"❌  {msg}")
+        print("    Need a key? Buy a self-hosted license at https://clawmetry.com/pricing")
+        sys.exit(1)
+
+
+def _cmd_license(args) -> None:
+    """clawmetry license — show the current self-hosted license status."""
+    from clawmetry import license as _lic
+
+    info = _lic.current_license_info()
+    print("ClawMetry License\n" + "─" * 40)
+    if not info:
+        print("  Plan:        OSS (free)")
+        print("  License:     none installed")
+        print("  Unlocks:     OpenClaw runtime + NeMo governance + core observability")
+        print("\n  Upgrade for all runtimes + advanced features:")
+        print("    self-hosted key  →  clawmetry activate <KEY>   (https://clawmetry.com/pricing)")
+        return
+    if not info.get("valid"):
+        status = info.get("status", "invalid")
+        print(f"  License:     ⚠️  {status} (run `clawmetry activate <KEY>` with a current key)")
+        return
+    tier = str(info.get("tier", "pro")).capitalize()
+    print(f"  Plan:        {tier} (self-hosted)")
+    print(f"  Nodes:       {info.get('nodes', 1)}")
+    if info.get("days_left") is not None:
+        print(f"  Expires:     in {info['days_left']} day(s)")
+    print("  E2E:         🔒 verified offline")
+
+
 def main() -> None:
     import argparse
     # --v2 opt-in flag for the React SPA scaffold (see clawmetry/v2/routes.py).
@@ -2797,6 +2836,15 @@ def main() -> None:
         "uninstall", help="Fully uninstall clawmetry (stop daemons, remove all files)"
     )
 
+    # activate — install a self-hosted Pro/Enterprise license key
+    p_activate = sub.add_parser(
+        "activate", help="Activate a self-hosted Pro/Enterprise license key"
+    )
+    p_activate.add_argument("key", help="License key (CLAW1.…)")
+
+    # license — show the current license status
+    sub.add_parser("license", help="Show the current self-hosted license status")
+
     # Parse just the first token to decide if it's a sub-command or dashboard flag
     _subcmds = (
         "onboard",
@@ -2810,6 +2858,8 @@ def main() -> None:
         "eval",
         "update",
         "uninstall",
+        "activate",
+        "license",
         "nemoclaw-daemons",
     )
     if len(sys.argv) > 1 and sys.argv[1] in _subcmds:
@@ -2838,6 +2888,10 @@ def main() -> None:
             _cmd_update()
         elif args.cmd == "uninstall":
             _cmd_uninstall()
+        elif args.cmd == "activate":
+            _cmd_activate(args)
+        elif args.cmd == "license":
+            _cmd_license(args)
         elif args.cmd == "nemoclaw-daemons":
             _register_nemoclaw_sandbox_daemons()
     else:

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -245,18 +245,15 @@ def _oss_free() -> Entitlement:
 
 
 def _read_local_license() -> Entitlement | None:
-    """Resolve a self-hosted entitlement from ``~/.clawmetry/license.key``.
-
-    Stub: signature verification + payload parsing land with the Ed25519
-    license client (Phase 2). Until then a present file is ignored (returns
-    None) so an unverified file can never grant access. Never raises."""
+    """Resolve a self-hosted entitlement from ``~/.clawmetry/license.key`` via
+    the Ed25519 license client. An absent/forged/expired key yields None, so an
+    unverified file can never grant access. Never raises."""
     try:
         if not os.path.isfile(_LICENSE_PATH):
             return None
-        # Phase 2: verify Ed25519 signature against the embedded public key,
-        # parse {tier, nodes, exp, features}, and _build(...) from it.
-        logger.debug("license.key present but verification not yet wired (Phase 2)")
-        return None
+        from clawmetry import license as _lic  # late import avoids import cycle
+
+        return _lic.load_license(_LICENSE_PATH)
     except Exception as exc:  # never crash on a bad/locked file
         logger.warning("entitlements: license read failed: %s", exc)
         return None

--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -1,0 +1,222 @@
+"""
+clawmetry/license.py — self-hosted Pro/Enterprise license client.
+
+A ClawMetry Pro/Enterprise license is a signed token issued by
+``license.clawmetry.com``. It unlocks the closed-source ``clawmetry-pro``
+package (the paid runtimes + advanced features) on self-hosted installs, for N
+nodes, for one year.
+
+Trust model
+-----------
+The license server holds the Ed25519 PRIVATE key and signs licenses. This OSS
+package embeds only the matching PUBLIC key, so a license verifies fully
+OFFLINE — no phone-home needed to keep a paid feature working once activated.
+``clawmetry activate`` does one online call to register this node against the
+key's node count and fetch the clawmetry-pro wheel; after that the node runs
+offline until the license expires.
+
+Token format
+------------
+``CLAW1.<b64url(payload_json)>.<b64url(ed25519_sig)>`` where the signature
+covers the exact payload-json bytes. Payload::
+
+    {"sub": "<account>", "tier": "pro"|"enterprise", "nodes": N,
+     "iat": <epoch>, "exp": <epoch>, "features": [...]}
+
+Nothing here ever raises to the caller — a bad/expired/forged token resolves to
+"no license" (OSS free), logged at warning level.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+
+logger = logging.getLogger("clawmetry.license")
+
+# Ed25519 PUBLIC verification key. The matching PRIVATE key lives only on the
+# license server (clawmetry-cloud, never shipped). Rotating the server key
+# means bumping this constant + an OSS release.
+_PUBLIC_KEY_PEM = b"""-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEA1xcY0kmz1Ns+SVWTzJ/8BtLWDIS+OGquGxtk3FIaDzA=
+-----END PUBLIC KEY-----
+"""
+
+_TOKEN_PREFIX = "CLAW1"
+LICENSE_PATH = os.path.expanduser("~/.clawmetry/license.key")
+_CONFIG_PATH = os.path.expanduser("~/.clawmetry/config.json")
+
+
+def _b64u_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64u_decode(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+def _load_public_key():
+    from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+    return load_pem_public_key(_PUBLIC_KEY_PEM)
+
+
+def _encode_token(payload: dict, private_key) -> str:
+    """Mint a license token. Needs the Ed25519 PRIVATE key — used by the
+    license server and tests, never with a key shipped in this package."""
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    sig = private_key.sign(raw)
+    return f"{_TOKEN_PREFIX}.{_b64u_encode(raw)}.{_b64u_encode(sig)}"
+
+
+def verify_token(token: str) -> dict | None:
+    """Verify a license token against the embedded public key. Returns the
+    payload dict if the signature is valid, else None. Never raises."""
+    try:
+        from cryptography.exceptions import InvalidSignature
+
+        parts = (token or "").strip().split(".")
+        if len(parts) != 3 or parts[0] != _TOKEN_PREFIX:
+            return None
+        raw = _b64u_decode(parts[1])
+        sig = _b64u_decode(parts[2])
+        try:
+            _load_public_key().verify(sig, raw)
+        except InvalidSignature:
+            logger.warning("license: signature verification failed")
+            return None
+        payload = json.loads(raw.decode("utf-8"))
+        if not isinstance(payload, dict):
+            return None
+        return payload
+    except Exception as exc:
+        logger.warning("license: token parse failed: %s", exc)
+        return None
+
+
+def parse_license(token: str):
+    """Verify ``token`` and build an Entitlement, or None if invalid."""
+    payload = verify_token(token)
+    if payload is None:
+        return None
+    try:
+        from clawmetry import entitlements as _ent
+
+        tier_in = str(payload.get("tier", "")).strip().lower()
+        tier = _ent.TIER_ENTERPRISE if tier_in == "enterprise" else _ent.TIER_PRO
+        return _ent._build(
+            tier,
+            "license",
+            node_limit=int(payload.get("nodes", 1) or 1),
+            expiry=payload.get("exp"),
+        )
+    except Exception as exc:
+        logger.warning("license: entitlement build failed: %s", exc)
+        return None
+
+
+def load_license(path: str = LICENSE_PATH):
+    """Load + verify the on-disk license, returning an Entitlement or None.
+    This is the hook :mod:`clawmetry.entitlements` calls."""
+    try:
+        if not os.path.isfile(path):
+            return None
+        with open(path, "r", encoding="utf-8") as fh:
+            token = fh.read().strip()
+        return parse_license(token)
+    except Exception as exc:
+        logger.warning("license: load failed: %s", exc)
+        return None
+
+
+def _node_id() -> str | None:
+    try:
+        with open(_CONFIG_PATH, "r", encoding="utf-8") as fh:
+            return json.load(fh).get("node_id")
+    except Exception:
+        return None
+
+
+def _download_and_install_pro(payload: dict) -> str:
+    """Register this node with the license server and install ``clawmetry-pro``.
+
+    Gated on ``CLAWMETRY_LICENSE_SERVER`` — when unset (e.g. before the license
+    server exists) this is a graceful no-op so offline activation still saves a
+    verified license. Returns a human status string. Never raises."""
+    server = os.environ.get("CLAWMETRY_LICENSE_SERVER", "").strip()
+    if not server:
+        return "clawmetry-pro install deferred (no license server configured)"
+    try:
+        # Phase 3: POST {key, node_id} to <server>/activate, receive a scoped
+        # wheel/index URL bounded by the key's node count, pip-install it into
+        # the daemon venv; extensions.load_plugins() then discovers it.
+        logger.info("license: would activate node %s against %s", _node_id(), server)
+        return f"node registration + clawmetry-pro install via {server} (pending Phase 3)"
+    except Exception as exc:
+        logger.warning("license: pro install failed: %s", exc)
+        return f"clawmetry-pro install failed: {exc}"
+
+
+def activate(key: str, node_id: str | None = None) -> tuple[bool, str]:
+    """Verify ``key`` offline, persist it, and (best-effort) register the node
+    + install clawmetry-pro. Returns (ok, message). Never raises."""
+    payload = verify_token(key)
+    if payload is None:
+        return False, "Invalid or unrecognized license key."
+    import time as _t
+
+    exp = payload.get("exp")
+    if isinstance(exp, (int, float)) and _t.time() > exp:
+        return False, "This license key has expired."
+    try:
+        os.makedirs(os.path.dirname(LICENSE_PATH), exist_ok=True)
+        with open(LICENSE_PATH, "w", encoding="utf-8") as fh:
+            fh.write(key.strip() + "\n")
+    except Exception as exc:
+        return False, f"Could not write license file: {exc}"
+    # Refresh the entitlement cache so the new license takes effect immediately.
+    try:
+        from clawmetry import entitlements as _ent
+
+        _ent.invalidate()
+    except Exception:
+        pass
+    install_status = _download_and_install_pro(payload)
+    tier = str(payload.get("tier", "pro")).lower()
+    nodes = payload.get("nodes", 1)
+    return True, f"Activated {tier} license for {nodes} node(s). {install_status}"
+
+
+def current_license_info() -> dict | None:
+    """Human-readable summary of the installed license, or None if there is no
+    valid one. Never raises."""
+    import time as _t
+
+    try:
+        if not os.path.isfile(LICENSE_PATH):
+            return None
+        with open(LICENSE_PATH, "r", encoding="utf-8") as fh:
+            payload = verify_token(fh.read().strip())
+        if payload is None:
+            return {"valid": False, "status": "invalid"}
+        exp = payload.get("exp")
+        days_left = None
+        expired = False
+        if isinstance(exp, (int, float)):
+            days_left = int((exp - _t.time()) // 86400)
+            expired = _t.time() > exp
+        return {
+            "valid": not expired,
+            "status": "expired" if expired else "active",
+            "tier": payload.get("tier", "pro"),
+            "nodes": payload.get("nodes", 1),
+            "sub": payload.get("sub", ""),
+            "exp": exp,
+            "days_left": days_left,
+        }
+    except Exception as exc:
+        logger.warning("license: info read failed: %s", exc)
+        return None

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,0 +1,179 @@
+"""Tests for clawmetry/license.py — Ed25519 self-hosted license client.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key, so nothing depends on the real
+production signing key. Covers signature verification (valid/forged/tampered),
+expiry, entitlement mapping, file load, the activate flow, and the integration
+back into clawmetry.entitlements.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=10, exp_delta=365 * 86400):
+    now = int(time.time())
+    return {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes", "alerts", "fleet"],
+    }
+
+
+@pytest.fixture
+def lic(monkeypatch, tmp_path):
+    import clawmetry.license as L
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(L, "_PUBLIC_KEY_PEM", pub_pem)
+    monkeypatch.setattr(L, "LICENSE_PATH", str(tmp_path / "license.key"))
+    monkeypatch.setattr(L, "_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    return SimpleNamespace(L=L, priv=priv, pub_pem=pub_pem)
+
+
+# ── signature verification ────────────────────────────────────────────────────
+
+
+def test_valid_token_verifies(lic):
+    tok = lic.L._encode_token(_payload(), lic.priv)
+    payload = lic.L.verify_token(tok)
+    assert payload is not None
+    assert payload["tier"] == "pro"
+    assert payload["nodes"] == 10
+
+
+def test_forged_token_rejected(lic):
+    other_priv, _ = _keypair()  # signed by a DIFFERENT key
+    tok = lic.L._encode_token(_payload(), other_priv)
+    assert lic.L.verify_token(tok) is None
+
+
+def test_tampered_payload_rejected(lic):
+    tok = lic.L._encode_token(_payload(nodes=1), lic.priv)
+    prefix, body, sig = tok.split(".")
+    # swap in a different (validly-signed-elsewhere) body but keep the old sig
+    forged_body = lic.L._b64u_encode(b'{"tier":"enterprise","nodes":9999}')
+    assert lic.L.verify_token(f"{prefix}.{forged_body}.{sig}") is None
+
+
+@pytest.mark.parametrize("bad", ["", "garbage", "NOPE.a.b", "CLAW1.only-two"])
+def test_malformed_tokens_rejected(lic, bad):
+    assert lic.L.verify_token(bad) is None
+
+
+# ── entitlement mapping ────────────────────────────────────────────────────────
+
+
+def test_parse_license_pro(lic):
+    import clawmetry.entitlements as e
+
+    tok = lic.L._encode_token(_payload("pro", nodes=42), lic.priv)
+    en = lic.L.parse_license(tok)
+    assert en is not None
+    assert en.tier == e.TIER_PRO
+    assert en.source == "license"
+    assert en.node_limit == 42
+    assert en.is_paid is True
+
+
+def test_parse_license_enterprise(lic):
+    import clawmetry.entitlements as e
+
+    tok = lic.L._encode_token(_payload("enterprise", nodes=5), lic.priv)
+    en = lic.L.parse_license(tok)
+    assert en.tier == e.TIER_ENTERPRISE
+
+
+def test_invalid_token_parses_to_none(lic):
+    assert lic.L.parse_license("CLAW1.bogus.bogus") is None
+
+
+# ── file load + activate ───────────────────────────────────────────────────────
+
+
+def test_load_license_from_file(lic):
+    tok = lic.L._encode_token(_payload(), lic.priv)
+    with open(lic.L.LICENSE_PATH, "w") as fh:
+        fh.write(tok)
+    en = lic.L.load_license(lic.L.LICENSE_PATH)
+    assert en is not None and en.is_paid
+
+
+def test_load_missing_file_returns_none(lic):
+    assert lic.L.load_license(lic.L.LICENSE_PATH) is None
+
+
+def test_activate_valid_key(lic):
+    import os
+
+    tok = lic.L._encode_token(_payload("pro", nodes=7), lic.priv)
+    ok, msg = lic.L.activate(tok)
+    assert ok is True
+    assert "pro" in msg.lower()
+    assert os.path.isfile(lic.L.LICENSE_PATH)
+    # deferred install message when no server configured
+    assert "deferred" in msg.lower()
+
+
+def test_activate_invalid_key(lic):
+    ok, msg = lic.L.activate("CLAW1.not.real")
+    assert ok is False
+    assert not __import__("os").path.isfile(lic.L.LICENSE_PATH)
+
+
+def test_activate_expired_key(lic):
+    tok = lic.L._encode_token(_payload(exp_delta=-3600), lic.priv)  # already expired
+    ok, msg = lic.L.activate(tok)
+    assert ok is False
+    assert "expired" in msg.lower()
+
+
+def test_current_license_info(lic):
+    tok = lic.L._encode_token(_payload("pro", nodes=3), lic.priv)
+    lic.L.activate(tok)
+    info = lic.L.current_license_info()
+    assert info["valid"] is True
+    assert info["tier"] == "pro"
+    assert info["nodes"] == 3
+    assert info["days_left"] > 300
+
+
+# ── integration with entitlements ──────────────────────────────────────────────
+
+
+def test_activate_then_entitlement_resolves_pro(lic, monkeypatch):
+    import clawmetry.entitlements as e
+
+    monkeypatch.setattr(e, "_LICENSE_PATH", lic.L.LICENSE_PATH)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")  # enforce so grace can't mask it
+    e.invalidate()
+
+    tok = lic.L._encode_token(_payload("pro", nodes=42), lic.priv)
+    ok, _ = lic.L.activate(tok)
+    assert ok
+
+    en = e.get_entitlement(force=True)
+    assert en.tier == e.TIER_PRO
+    assert en.node_limit == 42
+    assert en.allows_runtime("claude_code") is True  # paid runtime unlocked
+    assert en.grace is False


### PR DESCRIPTION
## What

Phase 2 of the open-core restructure: the offline license **verifier** + activation CLI that sits on top of the Phase 1 entitlement plumbing (#2186).

- **`clawmetry/license.py`** — verifies a `CLAW1.<payload>.<sig>` token against an **embedded Ed25519 public key**. The private signing key lives only on the license server (never shipped here), so a license verifies **fully offline** — no phone-home to keep a paid feature working once activated.
  - `verify_token` / `parse_license` → `Entitlement`, `load_license` reads `~/.clawmetry/license.key`.
  - `activate(key)` verifies offline, persists the key, and — behind `CLAWMETRY_LICENSE_SERVER` — registers the node against the key's node count and installs `clawmetry-pro` (graceful no-op until the server exists, Phase 3).
  - Never raises: a forged / expired / garbage key resolves to OSS free.
- **`entitlements._read_local_license()`** now calls the verifier (was a stub in #2186).
- **`cli.py`** — `clawmetry activate <KEY>` and `clawmetry license` subcommands.
- **`tests/test_license.py`** — 17 hermetic tests (ephemeral keypair, no dependency on the real signing key): valid/forged/tampered/expired tokens, tier mapping, file load, the activate flow, and the integration back into `entitlements`.

## Why

A self-hosted Pro/Enterprise license is a per-N-nodes, 1-year signed token. This lands the client that verifies it and flips the install's entitlement — the second half of the self-hosted revenue path.

## Safety

Still **GRACE by default**: this changes behaviour only once a real key is activated **and** `CLAWMETRY_ENFORCE=1`. No current user is affected.

## Verification

- `python3 -m pytest tests/test_license.py tests/test_entitlements.py` → 29 passed.
- A token minted with the real signing key verifies against the embedded public key (trust chain confirmed).
- `clawmetry activate <KEY>` → `clawmetry license` shows `Pro (self-hosted) / 100 nodes / 364 days / verified offline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)