### PR TITLE
fix(extensions): load entry-point plugins on Python 3.9

### DIFF
--- a/clawmetry/extensions.py
+++ b/clawmetry/extensions.py
@@ -66,6 +66,22 @@ def emit(event: str, payload: Dict[str, Any] | None = None) -> None:
             )
 
 
+def _select_entry_points(group: str):
+    """Return entry points for ``group`` across Python versions.
+
+    The ``entry_points(group=...)`` keyword form is Python 3.10+. On 3.9
+    ``entry_points()`` returns a dict keyed by group, and passing ``group=``
+    raises ``TypeError`` — which previously made ``load_plugins`` silently load
+    nothing on 3.9 (still a supported runtime + CI matrix row), so no extension
+    package (e.g. clawmetry-pro) ever registered there.
+    """
+    eps = importlib.metadata.entry_points()
+    select = getattr(eps, "select", None)
+    if select is not None:  # 3.10+ SelectableGroups / EntryPoints
+        return list(select(group=group))
+    return list(eps.get(group, []))  # 3.9 dict form
+
+
 def load_plugins() -> None:
     """
     Auto-discover and load extension plugins via entry points.
@@ -84,7 +100,7 @@ def load_plugins() -> None:
     _loaded = True
 
     try:
-        eps = importlib.metadata.entry_points(group="clawmetry.extensions")
+        eps = _select_entry_points("clawmetry.extensions")
     except Exception:
         return
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,42 @@
+"""Tests for clawmetry/extensions.py — plugin entry-point loading.
+
+Regression focus: ``_select_entry_points`` must work on Python 3.9 (where
+``entry_points(group=...)`` raises TypeError) as well as 3.10+, so the
+closed-source clawmetry-pro package actually loads on every supported runtime.
+"""
+from __future__ import annotations
+
+import clawmetry.extensions as ext
+
+
+def test_select_entry_points_returns_list():
+    # Never raises on any Python version; returns a list of EntryPoint.
+    eps = ext._select_entry_points("clawmetry.extensions")
+    assert isinstance(eps, list)
+
+
+def test_select_unknown_group_is_empty():
+    assert ext._select_entry_points("no.such.group.xyz123") == []
+
+
+def test_load_plugins_idempotent_and_safe(monkeypatch):
+    # Reset the once-guard, then load twice — must never raise regardless of
+    # whether any extension package is installed.
+    monkeypatch.setattr(ext, "_loaded", False)
+    ext.load_plugins()
+    ext.load_plugins()  # second call is a no-op via the guard
+
+
+def test_register_emit_roundtrip():
+    seen = []
+    ext.register("test.evt.roundtrip", lambda p: seen.append(p))
+    ext.emit("test.evt.roundtrip", {"x": 1})
+    assert seen == [{"x": 1}]
+
+
+def test_emit_swallows_handler_errors():
+    def boom(_payload):
+        raise ValueError("boom")
+
+    ext.register("test.evt.boom", boom)
+    ext.emit("test.evt.boom", {})  # must not propagate


### PR DESCRIPTION
## Bug

`extensions.load_plugins()` called `importlib.metadata.entry_points(group="clawmetry.extensions")`. The `group=` keyword is **Python 3.10+**. On **3.9** (a supported runtime and a CI matrix row) it raises `TypeError`, which the surrounding bare `except` swallows — so `load_plugins()` silently loaded **nothing** on 3.9.

Consequence: any package that registers via the `clawmetry.extensions` entry point (notably the closed-source `clawmetry-pro` paid layer) would never load on a 3.9 install.

## Fix

`_select_entry_points(group)` uses the `.select(group=...)` API on 3.10+ and the dict form (`entry_points().get(group, [])`) on 3.9. No behaviour change on 3.10+.

## Verification

- `pytest tests/test_extensions.py` → 5 passed (incl. unknown-group, idempotency, emit error-swallowing).
- With `clawmetry-pro` installed locally on **Python 3.9.6**, `load_plugins()` now discovers and runs its `register_all` (registered event `clawmetry.pro.loaded`, `is_loaded() == True`). It was a silent no-op before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)