### PR TITLE
feat: defer to clawmetry-pro adapters when a plugin provides them

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -10674,6 +10674,13 @@ def detect_config(args=None):
         for _family_cls in _fam_classes():
             try:
                 _inst = _family_cls()
+                # A licensed install's clawmetry-pro plugin registers its own
+                # (closed) adapter for some runtimes at import time, before this
+                # loop runs. Don't clobber it — the registry intentionally lets
+                # plugins override the bundled adapter. Free installs have no
+                # plugin, so this is a no-op and OSS registers its own.
+                if _adapter_registry.get(_inst.name) is not None:
+                    continue
                 if _inst.detect().detected:
                     _adapter_registry.register(_inst)
             except Exception as _fam_err:  # pragma: no cover - defensive

--- a/tests/test_adapter_registry_override.py
+++ b/tests/test_adapter_registry_override.py
@@ -1,0 +1,42 @@
+"""Tests for the adapter-registry override contract.
+
+The open-core plugin model depends on this: a clawmetry-pro plugin registers
+its closed adapter at import time, and OSS must let it win rather than clobber
+it with the bundled adapter. These lock the two behaviours that guarantee that:
+later-registration-wins (override by name) and get()-after-register.
+"""
+from __future__ import annotations
+
+from clawmetry.adapters import base, registry
+
+
+class _FakeAdapter(base.AgentAdapter):
+    def __init__(self, name, tag):
+        self.name = name
+        self.display_name = name
+        self.tag = tag
+
+    def detect(self):
+        return base.DetectResult(name=self.name, display_name=self.display_name, detected=True)
+
+    def list_sessions(self, limit: int = 100):
+        return []
+
+    def capabilities(self):
+        return set()
+
+
+def test_later_registration_overrides_by_name():
+    name = "test_runtime_override"
+    registry.register(_FakeAdapter(name, "bundled"))
+    assert registry.get(name).tag == "bundled"
+    # a plugin registering the same name later must win (closed adapter override)
+    registry.register(_FakeAdapter(name, "plugin"))
+    assert registry.get(name).tag == "plugin"
+    registry.unregister(name)
+
+
+def test_get_absent_is_none_so_oss_knows_to_register():
+    # OSS's skip-if-present guard relies on get() being None when no plugin
+    # has claimed the runtime.
+    assert registry.get("definitely_not_registered_xyz") is None


### PR DESCRIPTION
## What

The seam that lets gated runtimes live in the closed `clawmetry-pro` package for licensed installs while staying bundled in OSS during the grace period.

When `clawmetry-pro` is installed, its `register_all` registers closed adapters into the registry at import time (`load_plugins()`). The OSS family-adapter loop ran *after* and clobbered them. This guards the loop: **skip the bundled adapter when the registry already has one for that name** — the registry's documented "plugins override the built-in adapter" behaviour.

## Safety

Free installs have no plugin → registry empty for those names → OSS registers its own adapters exactly as before. **Zero behaviour change** for OSS users.

## Verification

- With `clawmetry-pro` installed locally: `registry.get('claude_code')` resolves to `clawmetry_pro.adapters.claude_code` (`provider="clawmetry-pro"`); the OSS loop no longer clobbers it.
- `pytest tests/test_adapter_registry_override.py` → 2 passed (locks the override-by-name contract the closed layer depends on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)