### PR TITLE
feat(errors): filter benign tool results from error counts (#2196)

### DIFF
--- a/clawmetry/error_signal.py
+++ b/clawmetry/error_signal.py
@@ -1,0 +1,99 @@
+"""Shared tool-result error classification.
+
+A number of tool results carry an ``isError`` / ``is_error`` flag (or an
+``error``-suffixed event type) for outcomes that are not real failures: a
+runtime read-guard telling the agent to re-read a file, a transient gateway
+timeout that succeeded on retry, and similar control-flow nudges. Counting
+these as errors inflated error rates across the Tracing / Health / Self-Evolve
+surfaces and the snapshot (measured live: two read-guard signatures alone were
+~two thirds of all flagged tool errors).
+
+This module is the single source of truth for "is this flagged error actually
+benign?". It is a dependency-free leaf module so both the daemon ingest path
+(``clawmetry.sync``) and the request handlers (``routes/*``) can import it
+without circular-import risk. Nothing here raises.
+
+The signatures are intentionally conservative and easy to tune: each entry is a
+plain substring matched (case-insensitively) against the tool result's text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Substrings that mark a flagged tool result as benign (not a real failure).
+# Matched case-insensitively against the result text. Keep this list tight and
+# evidence-backed — every entry suppresses a real ``isError`` flag, so a
+# too-broad signature would hide genuine failures.
+BENIGN_TOOL_ERROR_SIGNATURES: tuple[str, ...] = (
+    # Claude Code Edit/Write read-guards: the runtime asks the agent to read
+    # (or re-read) the file first, the agent complies, and the turn proceeds.
+    # Control-flow nudges, not task failures.
+    "file has not been read yet",
+    "file has been modified since read",
+    # Transient gateway timeout that the runtime retries; surfaces as a flagged
+    # result even when the retry succeeds.
+    "gateway timeout after",
+)
+
+
+def is_benign_tool_error(text: Any) -> bool:
+    """True if ``text`` (a tool result body) matches a known-benign signature.
+
+    Defensive: non-string / empty input is treated as not-benign so we never
+    suppress an error we couldn't actually read.
+    """
+    if not text:
+        return False
+    try:
+        low = str(text).lower()
+    except Exception:
+        return False
+    return any(sig in low for sig in BENIGN_TOOL_ERROR_SIGNATURES)
+
+
+def extract_tool_result_text(data: Any) -> str:
+    """Best-effort plain text of a tool result, across runtime shapes.
+
+    Handles the OpenClaw v3 shape (``data.output`` / ``data.result`` strings)
+    and the Claude Code family shape (``data.content`` as a string or a list of
+    ``{type, text|content}`` blocks, including the ``<tool_use_error>`` wrapper).
+    Returns ``""`` on anything unrecognised. Never raises.
+    """
+    if not isinstance(data, dict):
+        return ""
+    try:
+        # v3 / flattened string fields first.
+        for key in ("output", "result", "preview", "full", "detail"):
+            v = data.get(key)
+            if isinstance(v, str) and v:
+                return v
+        # Claude Code family: content is a string or a list of blocks.
+        content = data.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for blk in content:
+                if isinstance(blk, dict):
+                    t = blk.get("text") or blk.get("content")
+                    if isinstance(t, str):
+                        parts.append(t)
+                elif isinstance(blk, str):
+                    parts.append(blk)
+            return " ".join(parts)
+    except Exception:
+        return ""
+    return ""
+
+
+def corrected_is_error(raw_is_error: Any, result_text: Any) -> bool:
+    """Return the error flag with benign results filtered out.
+
+    ``raw_is_error and not is_benign_tool_error(result_text)``, coerced to a
+    plain bool. Use at ingest so the stored flag (and therefore every reader and
+    the snapshot) reflects the corrected value.
+    """
+    if not raw_is_error:
+        return False
+    return not is_benign_tool_error(result_text)

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -3897,6 +3897,85 @@ class LocalStore:
             return 0
         return len(updates)
 
+    def backfill_benign_errors(self, *, after_id: str = "", batch: int = 5000):
+        """#2196: clear the error flag on historical tool results whose body
+        matches a known-benign signature (see ``clawmetry.error_signal``).
+
+        Runtime read-guards ("File has been modified since read", …) and
+        transient gateway timeouts carry ``isError`` but are not real failures,
+        and were inflating error counts across Tracing / Health / Self-Evolve
+        and the snapshot (measured: ~two thirds of all flagged tool errors).
+        New events are corrected at ingest; this heals the history.
+
+        Pages tool-result events by the ``id`` primary key (forward-only
+        cursor, so progress is guaranteed regardless of how sparse the matches
+        are) and rewrites only rows that still carry a truthy error flag AND are
+        not already stamped — idempotent. Returns ``(max_id, updated,
+        scanned)``. Daemon-only (needs the writer connection)."""
+        try:
+            from clawmetry import error_signal as _es
+        except Exception:
+            return (after_id, 0, 0)
+        try:
+            rows = self._conn.execute(
+                "SELECT id, data FROM events "
+                "WHERE id > ? AND event_type LIKE '%result%' "
+                "ORDER BY id LIMIT ?",
+                [after_id, int(batch)],
+            ).fetchall()
+        except Exception:
+            return (after_id, 0, 0)
+        if not rows:
+            return (after_id, 0, 0)
+
+        max_id = after_id
+        updates: list[tuple] = []
+        for (eid, data) in rows:
+            if eid is not None and str(eid) > str(max_id):
+                max_id = eid
+            try:
+                if isinstance(data, (bytes, bytearray)):
+                    data = bytes(data).decode("utf-8", "replace")
+                obj = json.loads(data) if isinstance(data, str) else data
+            except Exception:
+                continue
+            if not isinstance(obj, dict) or obj.get("benign_error"):
+                continue
+            extra = obj.get("extra") if isinstance(obj.get("extra"), dict) else {}
+            raw = bool(
+                extra.get("isError")
+                or extra.get("is_error")
+                or obj.get("isError")
+                or obj.get("is_error")
+            )
+            if not raw:
+                continue
+            if not _es.is_benign_tool_error(_es.extract_tool_result_text(obj)):
+                continue
+            if extra:
+                extra["isError"] = False
+                extra["is_error"] = False
+                obj["extra"] = extra
+            if "is_error" in obj:
+                obj["is_error"] = False
+            if "isError" in obj:
+                obj["isError"] = False
+            obj["benign_error"] = True
+            try:
+                blob = json.dumps(obj, separators=(",", ":"), default=str).encode("utf-8")
+            except Exception:
+                continue
+            updates.append((blob, eid))
+
+        if updates:
+            try:
+                self._conn.executemany(
+                    "UPDATE events SET data = ? WHERE id = ?", updates
+                )
+            except Exception:
+                return (max_id, 0, len(rows))
+        return (max_id, len(updates), len(rows))
+
     def query_events_with_subagents(
         self,
         *,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -26,6 +26,9 @@ from pathlib import Path
 from datetime import datetime, timezone
 from itertools import islice
 
+# Leaf module (typing-only deps) — safe to import at package load, no cycle.
+from clawmetry import error_signal as _error_signal
+
 
 def _get_openclaw_dir():
     """Return the OpenClaw config directory, respecting CLAWMETRY_OPENCLAW_DIR env var."""
@@ -2526,19 +2529,27 @@ def _parse_v3_event(
         # or a plain string; flatten so PR #1132's expander finds it under
         # ``data.output`` / ``data.result``.
         result_text = _v3_content_to_text(obj.get("content"))
+        # Filter benign read-guards / transient timeouts so they don't inflate
+        # error counts everywhere downstream (readers + snapshot read this
+        # stored flag). See clawmetry.error_signal.
+        raw_is_error = obj.get("is_error")
+        is_error = _error_signal.corrected_is_error(raw_is_error, result_text)
         data.update({
             "tool_use_id": obj.get("tool_use_id"),
             "output": result_text,
             "result": result_text,
-            "is_error": obj.get("is_error"),
+            "is_error": is_error,
             "timestamp": ts,
         })
         inner.update({
             "tool_use_id": obj.get("tool_use_id"),
             "output": result_text,
             "result": result_text,
-            "is_error": obj.get("is_error"),
+            "is_error": is_error,
         })
+        if raw_is_error and not is_error:
+            data["benign_error"] = True
+            inner["benign_error"] = True
 
     else:
         # Unknown v3 event — log + drop so future schema additions don't
@@ -8431,7 +8442,17 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     if e.tool_name:
                         data["tool_name"] = e.tool_name
                     if isinstance(e.extra, dict) and e.extra:
-                        data["extra"] = e.extra
+                        extra = e.extra
+                        # Filter benign read-guards (the family error flag lives
+                        # in extra.isError) so they don't inflate error counts.
+                        if extra.get("isError") or extra.get("is_error"):
+                            txt = _error_signal.extract_tool_result_text(data) or (e.content or "")
+                            if _error_signal.is_benign_tool_error(txt):
+                                extra = dict(extra)
+                                extra["isError"] = False
+                                extra["is_error"] = False
+                                data["benign_error"] = True
+                        data["extra"] = extra
                     rows.append({
                         "id": f"{runtime}:{e.id}",
                         "node_id": node_id,
@@ -9441,6 +9462,32 @@ def _backfill_event_costs_once(store) -> None:
         log.debug("cost backfill failed: %s", _e)
 
 
+_benign_backfill_done = False
+
+
+def _backfill_benign_errors_once(store) -> None:
+    """#2196: drain the benign-error backfill once per daemon process. Pages
+    tool-result events by an ``id`` cursor (forward progress guaranteed), with a
+    hard iteration cap so a huge store can't stall the snapshot build; remaining
+    rows get picked up on the next process start. Never raises."""
+    global _benign_backfill_done
+    if _benign_backfill_done:
+        return
+    _benign_backfill_done = True  # set first: a failure shouldn't retry-loop
+    try:
+        after, total = "", 0
+        for _ in range(200):  # cap: 200 x 5000 = up to 1M tool-result rows
+            max_id, updated, scanned = store.backfill_benign_errors(after_id=after, batch=5000)
+            total += updated
+            if scanned == 0:
+                break
+            after = max_id
+        if total:
+            log.info("benign-error backfill: cleared %d flagged-but-benign tool errors (#2196)", total)
+    except Exception as _e:
+        log.debug("benign-error backfill failed: %s", _e)
+
+
 def _build_daily_usage(days=14):
     """14-day token/cost history for the cloud Cost tab.
 
@@ -9464,6 +9511,10 @@ def _build_daily_usage(days=14):
         # so the Cost tab showed ~$0). Runs once per process, on the daemon's
         # writer handle, draining in bounded batches before we read costs.
         _backfill_event_costs_once(store)
+        # #2196: one-time backfill to clear flagged-but-benign tool errors
+        # (read-guards / transient timeouts) on history, so error counts match
+        # the at-ingest correction. Same writer handle, bounded batches.
+        _backfill_benign_errors_once(store)
         daily_tok: dict = {}
         daily_cost: dict = {}
         for r in (store.query_aggregates() or []):

--- a/routes/selfevolve.py
+++ b/routes/selfevolve.py
@@ -25,6 +25,7 @@ from collections import Counter, defaultdict
 
 from flask import Blueprint, jsonify, request
 
+from clawmetry import error_signal as _error_signal
 from routes.advisor import (
     _call_anthropic_api,
     _call_via_claude_cli,
@@ -74,13 +75,18 @@ def _save_cached(payload: dict) -> None:
 def _classify_event(ev: dict) -> tuple[str, bool]:
     """Return (bucket, is_error). Buckets: exec | tool | llm | context | agent | user | other."""
     typ = (ev.get("type") or "").lower()
-    detail = str(ev.get("detail") or "").lower()
+    detail_raw = str(ev.get("detail") or "")
+    detail = detail_raw.lower()
     is_error = (
         "error" in detail
         or "failed" in detail
         or "timeout" in detail
         or typ == "error"
     )
+    # Don't count benign read-guards / transient timeouts as errors — they were
+    # inflating the Self-Evolve error buckets (see clawmetry.error_signal).
+    if is_error and _error_signal.is_benign_tool_error(detail_raw):
+        is_error = False
     if typ in ("exec", "execution"):
         return "exec", is_error
     if typ in ("tool", "tool_use", "tool_result"):

--- a/tests/test_error_signal.py
+++ b/tests/test_error_signal.py
@@ -1,0 +1,144 @@
+"""Benign tool-error filtering (#2196).
+
+A number of tool results carry an ``isError`` flag for outcomes that are not
+real failures (runtime read-guards, transient gateway timeouts). They were
+inflating error counts across Tracing / Health / Self-Evolve and the snapshot.
+``clawmetry.error_signal`` is the single classifier; new events are corrected at
+ingest and ``backfill_benign_errors`` heals the history.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+from clawmetry import error_signal as es
+
+
+# ── pure classifier ────────────────────────────────────────────────────────
+
+def test_benign_signatures_match_case_insensitively():
+    assert es.is_benign_tool_error("File has not been read yet")
+    assert es.is_benign_tool_error(
+        "<tool_use_error>File has been modified since read, either by the user "
+        "or by a linter. Read it again.</tool_use_error>"
+    )
+    assert es.is_benign_tool_error("Gateway TIMEOUT after 30000ms")  # mixed case
+
+
+def test_real_errors_are_not_benign():
+    for txt in (
+        "Exit code 1\nTraceback (most recent call last): ...",
+        "fatal: not a git repository",
+        '{"status":"error","message":"permission denied"}',
+        "",
+        None,
+        12345,  # non-string input must not raise
+    ):
+        assert not es.is_benign_tool_error(txt)
+
+
+def test_extract_tool_result_text_across_shapes():
+    # v3 flattened string fields
+    assert "modified since read" in es.extract_tool_result_text(
+        {"output": "File has been modified since read"}
+    )
+    # Claude Code content as a plain string
+    assert es.extract_tool_result_text({"content": "hello"}) == "hello"
+    # Claude Code content as a list of blocks
+    assert "guard" in es.extract_tool_result_text(
+        {"content": [{"type": "text", "text": "guard"}]}
+    )
+    # garbage in -> "" out, never raises
+    assert es.extract_tool_result_text("not a dict") == ""
+    assert es.extract_tool_result_text(None) == ""
+
+
+def test_corrected_is_error_truth_table():
+    assert es.corrected_is_error(True, "File has been modified since read") is False
+    assert es.corrected_is_error(True, "Exit code 1: traceback") is True
+    assert es.corrected_is_error(False, "anything") is False
+    assert es.corrected_is_error(None, "File has not been read yet") is False
+
+
+# ── backfill integration ────────────────────────────────────────────────────
+
+def _wait_flush(store, t=3.0):
+    deadline = time.monotonic() + t
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def _store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "ev.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "2")
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)  # in-process writer
+    return ls, ls.get_store()
+
+
+def _data(store, eid):
+    rows = store._fetch("SELECT data FROM events WHERE id = ?", [eid])
+    if not rows:
+        return None
+    blob = rows[0][0]
+    if isinstance(blob, (bytes, bytearray)):
+        blob = bytes(blob).decode("utf-8", "replace")
+    return json.loads(blob)
+
+
+def test_backfill_clears_benign_keeps_real(tmp_path, monkeypatch):
+    ls, store = _store(tmp_path, monkeypatch)
+    try:
+        # Benign read-guard flagged as error (Claude Code family shape).
+        store.ingest({
+            "id": "claude_code:benign-1",
+            "node_id": "n", "agent_id": "main",
+            "session_id": "claude_code:s1",
+            "event_type": "tool_result",
+            "ts": "2026-05-26T12:00:00Z",
+            "data": {
+                "role": "tool", "_runtime": "claude_code",
+                "content": "<tool_use_error>File has been modified since read</tool_use_error>",
+                "extra": {"isError": True},
+            },
+            "cost_usd": None, "token_count": 0, "model": None,
+        })
+        # A genuine failure that must stay an error.
+        store.ingest({
+            "id": "claude_code:real-1",
+            "node_id": "n", "agent_id": "main",
+            "session_id": "claude_code:s1",
+            "event_type": "tool_result",
+            "ts": "2026-05-26T12:01:00Z",
+            "data": {
+                "role": "tool", "_runtime": "claude_code",
+                "content": "Exit code 1\nTraceback (most recent call last): ...",
+                "extra": {"isError": True},
+            },
+            "cost_usd": None, "token_count": 0, "model": None,
+        })
+        _wait_flush(store)
+
+        _, updated, scanned = store.backfill_benign_errors(after_id="", batch=100)
+        assert scanned == 2
+        assert updated == 1, f"only the benign row should be rewritten, got {updated}"
+
+        benign = _data(store, "claude_code:benign-1")
+        assert benign["extra"]["isError"] is False
+        assert benign.get("benign_error") is True
+
+        real = _data(store, "claude_code:real-1")
+        assert real["extra"]["isError"] is True
+        assert not real.get("benign_error")
+
+        # Idempotent: a second pass rewrites nothing.
+        _, updated2, _ = store.backfill_benign_errors(after_id="", batch=100)
+        assert updated2 == 0
+    finally:
+        store.stop(flush=True)


### PR DESCRIPTION
## What

Stop counting benign tool results as errors. A number of tool results carry an `isError` / `is_error` flag for outcomes that are **not** real failures:

- Claude Code's `File has not been read yet` / `File has been modified since read` read-guards (the runtime nudges the agent to re-read; the agent complies and proceeds).
- Transient `gateway timeout after ...` retries.

Counting these inflated error rates across **Tracing, Health, Self-Evolve, and the snapshot**.

Implements item #1 of #2196.

## Evidence (measured on a live store)

Paged 20,000 recent `tool_result` events through the daemon query proxy:

- **120 flagged as errors → 80 (66.7%) were the `File has been modified since read` read-guard**, not real failures.
- The genuine ones (exit-code-1 tracebacks, etc.) are correctly left alone.

## Approach

The readers each read the stored flag independently (there's no single read-side chokepoint), so the fix is applied at **ingest** — correct the stored flag once and every reader **and the snapshot** inherit it.

- **`clawmetry/error_signal.py`** (new) — one dependency-free, never-raise classifier: `is_benign_tool_error()`, `extract_tool_result_text()` (handles the v3 `output`/`result` and Claude Code `content` shapes), `corrected_is_error()`. Signatures are a tight, evidence-backed, easy-to-tune constant.
- **`sync.py`** — corrects the stored flag at both ingest points (v3 `tool_use_result` and the Claude Code family adapter) and stamps `data.benign_error = true` for transparency.
- **`local_store.backfill_benign_errors()`** — bounded, idempotent, `id`-cursor-paged backfill (mirrors the `backfill_event_costs` pattern) to heal history; drained once per daemon process in `_build_daily_usage`.
- **`routes/selfevolve.py`** — `_classify_event` consults the same helper (it derives `is_error` from `detail` text, not the stored flag).

Tool result **text is preserved** in all cases — only the error flag is corrected, so transcripts still show what happened.

## Verification

- `tests/test_error_signal.py` — 5 tests: classifier truth table, text extraction across runtime shapes, and a backfill integration test (clears benign, preserves real, idempotent). All green.
- Syntax/lint: my new module is ruff-clean; my edits add **zero** new ruff errors vs `origin/main`.
- **Live E2E** (daemon restarted on the patched wheel, real production DuckDB):
  - Backfill log: `benign-error backfill: cleared 96 flagged-but-benign tool errors (#2196)`.
  - Recent-20k window: **80 → 40** flagged tool errors; the 40 benign read-guards now excluded and stamped, genuine errors preserved.

## Cloud

Daemon-side change → ships via PyPI. The cloud snapshot inherits the corrected counts (the snapshot's `_err()` predicate reads the same stored flag), so no cloud-repo code change is required — only a pin bump once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
