### PR TITLE
feat(open-core): /api/runtimes catalog + locked-but-visible switcher hook

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -87,6 +87,25 @@ PAID_RUNTIMES = frozenset(
 
 ALL_RUNTIMES = FREE_RUNTIMES | PAID_RUNTIMES
 
+# Display labels for every known runtime. Mirrors ``_CM_RT_LABEL`` in
+# ``clawmetry/static/js/app.js`` so the dashboard and the API agree on what to
+# call each runtime in human-readable copy. The frontend falls back to the
+# runtime id when a label is missing, so adding a runtime to ``PAID_RUNTIMES``
+# without a label here is safe — but please add one.
+RUNTIME_LABELS = {
+    "openclaw": "OpenClaw",
+    "claude_code": "Claude Code",
+    "codex": "Codex",
+    "cursor": "Cursor",
+    "aider": "Aider",
+    "goose": "Goose",
+    "opencode": "opencode",
+    "qwen_code": "Qwen Code",
+    "hermes": "Hermes",
+    "picoclaw": "PicoClaw",
+    "nanoclaw": "NanoClaw",
+}
+
 # ── Feature catalogue ───────────────────────────────────────────────────────
 # Core observability — always free. Keys are stable identifiers the route /
 # UI layer checks via Entitlement.allows_feature(...).
@@ -329,3 +348,62 @@ def available_runtimes() -> list[str]:
     if ent.grace:
         return sorted(ALL_RUNTIMES)
     return sorted(ent.runtimes)
+
+
+def runtime_label(runtime: str) -> str:
+    """Human-readable label for ``runtime``. Falls back to the id when unknown
+    so unknown plugin runtimes still render with *something*."""
+    rt = (runtime or "").strip().lower()
+    return RUNTIME_LABELS.get(rt, rt)
+
+
+def runtime_catalog() -> list[dict]:
+    """The full runtime catalog with the entitlement-derived availability for
+    each entry. Single source of truth the UI uses to render *every* known
+    runtime — including paid ones with zero local sessions — so the locked-
+    but-visible upgrade affordance has data to render against.
+
+    Each entry:
+        {
+          "id":       "<runtime>",         # canonical key
+          "label":    "<Display Name>",    # falls back to id
+          "free":     True | False,        # FREE_RUNTIMES membership
+          "allowed":  True | False,        # entitlement allows observing it
+          "locked":   True | False,        # paid + not allowed (UI shows 🔒)
+        }
+
+    Ordering: free runtimes first (alphabetical), then paid runtimes
+    (alphabetical) — stable so the UI dropdown is deterministic.
+
+    Never raises; on any resolution error every paid runtime is reported as
+    ``locked=False`` (grace) to match the OSS-free fallback in
+    :func:`get_entitlement`.
+    """
+    try:
+        ent = get_entitlement()
+    except Exception as exc:  # never crash a catalog read
+        logger.warning("entitlements: runtime_catalog falling back to grace: %s", exc)
+        ent = _oss_free()
+    out: list[dict] = []
+    for rt in sorted(FREE_RUNTIMES):
+        out.append(
+            {
+                "id": rt,
+                "label": runtime_label(rt),
+                "free": True,
+                "allowed": True,
+                "locked": False,
+            }
+        )
+    for rt in sorted(PAID_RUNTIMES):
+        allowed = ent.allows_runtime(rt)
+        out.append(
+            {
+                "id": rt,
+                "label": runtime_label(rt),
+                "free": False,
+                "allowed": allowed,
+                "locked": not allowed,
+            }
+        )
+    return out

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6909,6 +6909,12 @@ function _cmRenderRuntimeSwitcher(counts, anchor, reload) {
 // unchanged). Changing it reloads the current tab so any runtime-aware view
 // re-filters against the new scope.
 var _cmGlobalRtCounts = {};
+// Catalog of locked runtimes from /api/runtimes (Phase 5 open-core).
+// Stays empty in grace mode (the default), so the switcher renders unchanged
+// from before this endpoint existed. Populated only once enforcement is on
+// AND the install lacks the paid entitlement — then locked runtimes appear in
+// the dropdown with a 🔒 affordance regardless of session count.
+var _cmLockedRuntimes = {};
 
 function _cmPopulateGlobalRuntime(counts) {
   // Merge-MAX into the running set, never replace. Per-tab loaders pass their
@@ -6926,18 +6932,32 @@ function _cmPopulateGlobalRuntime(counts) {
   var wrap = document.getElementById('cm-global-runtime-wrap');
   var sel = document.getElementById('cm-global-runtime');
   if (!wrap || !sel) return;
-  var order = Object.keys(_CM_RT_LABEL).filter(function(k) { return counts[k]; });
+  // Observed runtimes (have local sessions) ∪ locked-but-visible runtimes.
+  // _cmLockedRuntimes is empty in grace mode, so this collapses to the
+  // previous behaviour (observed-only) by default.
+  var observed = Object.keys(_CM_RT_LABEL).filter(function(k) { return counts[k]; });
+  var seen = {};
+  observed.forEach(function(k) { seen[k] = 1; });
+  var locked = Object.keys(_cmLockedRuntimes).filter(function(k) { return !seen[k]; });
+  var order = observed.concat(locked);
   if (order.length < 2) { wrap.style.display = 'none'; return; }
   var active = _cmRuntimeFilter();
-  if (active !== 'all' && !counts[active]) active = 'all';
-  var total = order.reduce(function(a, k) { return a + counts[k]; }, 0);
+  if (active !== 'all' && !counts[active] && !_cmLockedRuntimes[active]) active = 'all';
+  var total = observed.reduce(function(a, k) { return a + counts[k]; }, 0);
   // The count is the number of SESSIONS for that runtime — spell it out so the
   // chip doesn't read as "22 Claude Code runtimes" (there's one runtime, many
   // sessions). Singular/plural for the "1 session" case.
   function _sessLabel(n) { return n + (n === 1 ? ' session' : ' sessions'); }
   var html = '<option value="all">All runtimes · ' + _sessLabel(total) + '</option>';
   order.forEach(function(k) {
-    html += '<option value="' + k + '">' + escHtml(_CM_RT_LABEL[k] || k) + ' · ' + _sessLabel(counts[k]) + '</option>';
+    var lbl = _CM_RT_LABEL[k] || k;
+    if (_cmLockedRuntimes[k]) {
+      // Padlock + "Upgrade" hint; the option stays selectable so users can see
+      // the empty-runtime state (and the upgrade CTA the tab will render).
+      html += '<option value="' + k + '">🔒 ' + escHtml(lbl) + ' · Upgrade</option>';
+    } else {
+      html += '<option value="' + k + '">' + escHtml(lbl) + ' · ' + _sessLabel(counts[k]) + '</option>';
+    }
   });
   sel.innerHTML = html;
   sel.value = active;
@@ -6953,10 +6973,30 @@ function _cmOnGlobalRuntimeChange(sel) {
   if (typeof switchTab === 'function' && _cmCurrentTab) switchTab(_cmCurrentTab);
 }
 
+async function _cmLoadRuntimeCatalog() {
+  // Read the entitlement-aware runtime catalog (Phase 5 open-core). In grace
+  // mode (the default) nothing is locked, so _cmLockedRuntimes stays {} and
+  // the switcher behaves exactly as it did before this endpoint existed.
+  // Once enforcement is on, the locked paid runtimes appear in the dropdown
+  // with a 🔒 affordance regardless of session count.
+  try {
+    var cat = await fetch('/api/runtimes', { credentials: 'same-origin' }).then(function(r) { return r.json(); });
+    if (!cat || !cat.enforced || !Array.isArray(cat.runtimes)) return;
+    var locked = {};
+    cat.runtimes.forEach(function(r) { if (r && r.locked && r.id) locked[r.id] = 1; });
+    _cmLockedRuntimes = locked;
+  } catch (e) { /* non-fatal — grace mode keeps the previous behaviour */ }
+}
+
 async function _cmInitGlobalRuntimeSwitcher() {
   // Derive the runtimes present from the session list (the session-id prefix is
   // the runtime discriminator — agent_type is always "openclaw"). One cheap
   // fetch on load; the Transcripts loader refreshes the counts as it runs.
+  // Also pull the locked-but-visible catalog so paid runtimes show up in the
+  // switcher (with a 🔒) when enforcement is on — no-op in grace mode.
+  try {
+    await _cmLoadRuntimeCatalog();
+  } catch (e) { /* non-fatal */ }
   try {
     var data = await fetch('/api/sessions', { credentials: 'same-origin' }).then(function(r) { return r.json(); });
     var counts = {};

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -7,6 +7,7 @@ locked behind an upgrade CTA). Backed by :mod:`clawmetry.entitlements`, which
 is the single source of truth — handlers never re-derive tier logic here.
 
   GET /api/entitlement — the current Entitlement as JSON.
+  GET /api/runtimes    — the full runtime catalog with locked/free flags.
 
 Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
 on the cloud side: when no license/cloud plan is present it returns a graceful
@@ -46,5 +47,58 @@ def api_entitlement():
                 "enforced": False,
                 "runtimes": ["openclaw"],
                 "features": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/runtimes")
+def api_runtimes():
+    """Return the full runtime catalog with per-runtime ``free``/``allowed``/
+    ``locked`` flags so the dashboard can render *every* known runtime in the
+    switcher — including paid ones with zero local sessions — and overlay a
+    lock affordance on the locked rows once enforcement is on.
+
+    Shape::
+
+        {
+          "runtimes": [
+            {"id": "openclaw", "label": "OpenClaw",
+             "free": true, "allowed": true, "locked": false},
+            ...
+          ],
+          "grace":    true | false,   # mirrors /api/entitlement.grace
+          "enforced": true | false
+        }
+
+    Side-effect-free and never-raise: any resolution error falls back to a
+    grace OSS-free shape with the OpenClaw row, so the UI still has something
+    safe to render.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "runtimes": _ent.runtime_catalog(),
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_runtimes: falling back to OSS-free: %s", exc)
+        return jsonify(
+            {
+                "runtimes": [
+                    {
+                        "id": "openclaw",
+                        "label": "OpenClaw",
+                        "free": True,
+                        "allowed": True,
+                        "locked": False,
+                    }
+                ],
+                "grace": True,
+                "enforced": False,
             }
         )

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -141,3 +141,56 @@ def test_to_dict_shape(ent):
         assert key in d
     assert d["enforced"] == (not d["grace"])
     assert isinstance(d["runtimes"], list)
+
+
+# ── runtime_catalog (Phase 5: locked-but-visible foundation) ────────────────
+
+
+def test_runtime_catalog_grace_locks_nothing(ent):
+    cat = ent.runtime_catalog()
+    # Every known runtime is present exactly once.
+    ids = [r["id"] for r in cat]
+    assert set(ids) == set(ent.ALL_RUNTIMES)
+    assert len(ids) == len(set(ids))
+    # Free runtimes first, paid runtimes after — stable ordering.
+    free_count = len(ent.FREE_RUNTIMES)
+    assert set(ids[:free_count]) == set(ent.FREE_RUNTIMES)
+    assert set(ids[free_count:]) == set(ent.PAID_RUNTIMES)
+    # Grace mode: nothing is locked, everything is allowed.
+    for row in cat:
+        assert row["allowed"] is True
+        assert row["locked"] is False
+        assert isinstance(row["label"], str) and row["label"]
+        # `free` matches FREE_RUNTIMES membership.
+        assert row["free"] == (row["id"] in ent.FREE_RUNTIMES)
+
+
+def test_runtime_catalog_enforced_oss_locks_paid(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cat = {r["id"]: r for r in ent.runtime_catalog()}
+    # Free stays free + allowed.
+    for rt in ent.FREE_RUNTIMES:
+        assert cat[rt]["allowed"] is True
+        assert cat[rt]["locked"] is False
+    # Every paid runtime is locked when enforced + no entitlement.
+    for rt in ent.PAID_RUNTIMES:
+        assert cat[rt]["allowed"] is False, rt
+        assert cat[rt]["locked"] is True, rt
+
+
+def test_runtime_catalog_labels_match_paid_runtimes(ent):
+    # Every paid runtime has a human-readable label (not just the id) so the
+    # UI never has to guess. Catches "added a runtime but forgot the label".
+    for rt in ent.PAID_RUNTIMES | ent.FREE_RUNTIMES:
+        assert rt in ent.RUNTIME_LABELS, rt
+        assert ent.RUNTIME_LABELS[rt], rt
+
+
+def test_runtime_label_falls_back_to_id(ent):
+    assert ent.runtime_label("openclaw") == "OpenClaw"
+    # Unknown runtime → graceful fallback to the id so plugin runtimes still
+    # render with *something* in the UI.
+    assert ent.runtime_label("brand_new_plugin_runtime") == "brand_new_plugin_runtime"
+    assert ent.runtime_label("") == ""
+    assert ent.runtime_label(None) == ""

--- a/tests/test_routes_runtimes.py
+++ b/tests/test_routes_runtimes.py
@@ -1,0 +1,97 @@
+"""Tests for the ``/api/runtimes`` endpoint (``routes/entitlement.py``).
+
+The endpoint feeds the locked-but-visible runtime affordance in the global
+runtime switcher — every paid runtime appears in the catalog even when the
+local install has zero sessions for it, with ``locked`` set from the resolved
+entitlement.
+
+The headline invariant: in GRACE mode (the default), every catalog row reports
+``locked=False`` so the UI behaves exactly as it did before this endpoint
+existed. ``CLAWMETRY_ENFORCE=1`` flips the paid rows to ``locked=True`` for an
+OSS install.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client wired with bp_entitlement against a clean HOME."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def test_runtimes_grace_locks_nothing(client):
+    resp = client.get("/api/runtimes")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["grace"] is True
+    assert data["enforced"] is False
+    runtimes = {r["id"]: r for r in data["runtimes"]}
+    # OpenClaw is always free.
+    assert runtimes["openclaw"]["free"] is True
+    assert runtimes["openclaw"]["locked"] is False
+    # Every paid runtime is present and not locked in grace mode.
+    for rt in ("claude_code", "codex", "cursor", "aider", "goose",
+               "opencode", "qwen_code", "hermes", "picoclaw", "nanoclaw"):
+        assert rt in runtimes, rt
+        assert runtimes[rt]["free"] is False, rt
+        assert runtimes[rt]["locked"] is False, rt
+        assert runtimes[rt]["label"], rt  # never blank
+
+
+def test_runtimes_enforced_oss_locks_paid(monkeypatch, tmp_path):
+    """When CLAWMETRY_ENFORCE=1 and no license/cloud plan is present every
+    paid runtime is reported locked — the UI uses this to render the 🔒
+    affordance in the switcher even for runtimes with zero local sessions."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    c = app.test_client()
+    data = c.get("/api/runtimes").get_json()
+    assert data["enforced"] is True
+    assert data["grace"] is False
+    runtimes = {r["id"]: r for r in data["runtimes"]}
+    assert runtimes["openclaw"]["locked"] is False  # free stays free
+    assert runtimes["claude_code"]["locked"] is True
+    assert runtimes["picoclaw"]["locked"] is True
+
+
+def test_runtimes_shape_is_stable(client):
+    """Each row carries the keys the frontend reads — defends against an
+    accidental rename breaking the dropdown."""
+    data = client.get("/api/runtimes").get_json()
+    assert isinstance(data["runtimes"], list)
+    for row in data["runtimes"]:
+        for key in ("id", "label", "free", "allowed", "locked"):
+            assert key in row, row
+        assert isinstance(row["id"], str)
+        assert isinstance(row["label"], str)
+        assert isinstance(row["free"], bool)
+        assert isinstance(row["allowed"], bool)
+        assert isinstance(row["locked"], bool)
+        # locked = paid-and-not-allowed; mutually exclusive with free=True.
+        if row["free"]:
+            assert row["locked"] is False, row


### PR DESCRIPTION
## Summary

Phase 5 foundation on top of the open-core entitlement plumbing landed in #2186 / #2189: expose every known runtime — including paid ones with zero local sessions — through a stable `GET /api/runtimes` catalog so the global runtime switcher can render an upgrade affordance against the runtimes this install isn't entitled to observe.

**Headline invariant: no behaviour change in grace mode (the default).** The catalog reports `locked=False` for every row, the frontend's locked set stays empty, and the dropdown renders exactly as it did before this endpoint existed. The locked-but-visible affordance only activates once `CLAWMETRY_ENFORCE=1` flips the resolver out of grace.

## Changes

- **`clawmetry/entitlements.py`**: add `RUNTIME_LABELS` (single source of truth shared with `_CM_RT_LABEL` in `app.js`), `runtime_label()`, and `runtime_catalog()` returning `[{id, label, free, allowed, locked}]` for every known runtime. Stable ordering: free first, paid after, both alphabetical. Never raises — any resolution error falls back to a grace catalog.
- **`routes/entitlement.py`**: register `GET /api/runtimes` on `bp_entitlement`, returning `{runtimes, grace, enforced}`. Never-raise; any error falls back to the OpenClaw-only grace shape so the UI always has something safe to render.
- **`clawmetry/static/js/app.js`**: `_cmInitGlobalRuntimeSwitcher()` now also fetches `/api/runtimes` and folds locked runtimes into `_cmLockedRuntimes` **only when `enforced=true`**, so grace-mode installs see no change. When enforcement is on, locked runtimes appear in the dropdown as `🔒 <Label> · Upgrade` alongside the observed ones.
- **Tests** (19 passing):
  - `tests/test_entitlements.py` — 4 new tests: grace-locks-nothing, enforced-locks-paid, label coverage for every paid runtime, unknown-runtime label fallback.
  - `tests/test_routes_runtimes.py` — 3 Flask-test-client tests for the new endpoint: grace shape, enforced shape, key stability (defends against an accidental rename breaking the dropdown).

```
$ python3 -m pytest tests/test_entitlements.py tests/test_routes_runtimes.py -q
...................                                                      [100%]
19 passed in 0.22s
```

```
$ ruff check clawmetry/entitlements.py routes/entitlement.py
All checks passed!

$ node --check clawmetry/static/js/app.js
(syntax ok)
```

Smoke test against the live endpoint:

```
# grace (default)
GET /api/runtimes → {"enforced": false, "grace": true, "runtimes": [
  {"id": "openclaw", "label": "OpenClaw", "free": true, "locked": false}, ...
  {"id": "claude_code", "label": "Claude Code", "free": false, "locked": false}, ...
]}

# CLAWMETRY_ENFORCE=1
GET /api/runtimes → {"enforced": true, "grace": false, "runtimes": [
  {"id": "openclaw", "free": true, "locked": false},
  {"id": "claude_code", "free": false, "locked": true}, ...10 paid runtimes locked
]}
```

## Why a draft

The open-core rollout is in grace mode until the announced enforce date — this PR is the next foundational layer (Phase 5 in `entitlements.py:327`). Keeping it draft so the local operator handles the daemon-side verification + cloud-snapshot decrypt before this lands.

## Local operator verification checklist

I cannot reach the live daemon, `~/.openclaw`, or the cloud snapshot from this sandbox — please run the steps below before flipping to ready-for-review:

- [ ] Copy changed files into the daemon venv:
  ```
  cp clawmetry/entitlements.py routes/entitlement.py clawmetry/static/js/app.js \
      ~/.clawmetry/lib/python*/site-packages/clawmetry/ # adjust for your tree
  ```
- [ ] Clear `__pycache__` under the venv and `kickstart` the daemon:
  ```
  find ~/.clawmetry -name __pycache__ -exec rm -rf {} +
  launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
  ```
- [ ] Hit the new endpoint locally:
  ```
  curl -s localhost:8900/api/runtimes | jq .
  ```
  Expect `grace=true`, `enforced=false`, every paid runtime present with `locked=false`.
- [ ] Set `CLAWMETRY_ENFORCE=1` and re-hit it: expect `locked=true` on the 10 paid runtimes, `openclaw` still free; then unset.
- [ ] Decrypt the live cloud snapshot and browser-check the dashboard: the runtime switcher renders unchanged in grace mode (no padlocks). With `CLAWMETRY_ENFORCE=1` set, paid runtimes appear as `🔒 <Label> · Upgrade` even when they have zero sessions.
- [ ] CI green on this draft before flipping out of grace.

## Out of scope

- Per-runtime "this runtime is locked behind Pro" empty-state copy on each tab (separate UI follow-up; this PR is the data layer + switcher hook only).
- License-key flow + clawmetry-pro download (handled by #2189; this PR doesn't touch `license.py`).
- Any pricing / monetization copy — kept entirely out of this repo by policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BimKBmQzkwyYf3vERriUC1)_