### PR TITLE
feat(integrity): tamper-evident hash chain for event audit log (#2200)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2520,6 +2520,48 @@ def _cmd_license(args) -> None:
     print("  E2E:         🔒 verified offline")
 
 
+def _cmd_verify_integrity(args) -> None:
+    """clawmetry verify-integrity — walk the hash chain and report validity."""
+    from clawmetry.local_store import get_store
+
+    node_id = getattr(args, "node_id", None) or None
+    print("ClawMetry Integrity Verify\n" + "─" * 40)
+
+    try:
+        store = get_store(read_only=True)
+    except Exception as exc:
+        print(f"  Error: cannot open local store — {exc}")
+        raise SystemExit(1) from exc
+
+    try:
+        result = store.verify_integrity(node_id=node_id)
+    except Exception as exc:
+        print(f"  Error: verification failed — {exc}")
+        raise SystemExit(1) from exc
+
+    status = result["status"]
+    checked = result["checked"]
+    pre_chain = result["pre_chain"]
+    scope = result["node_id"]
+
+    print(f"  Scope:       {scope}")
+    print(f"  Checked:     {checked} stamped event(s)")
+    if pre_chain:
+        print(f"  Pre-chain:   {pre_chain} event(s) without hash (before integrity was enabled)")
+
+    if status == "empty":
+        print("  Result:      ○  No stamped events found")
+        print("               (set CLAWMETRY_INTEGRITY=1 to enable stamping)")
+    elif status == "valid":
+        print(f"  Result:      ✅  VALID — chain intact across {checked} event(s)")
+    else:
+        broken_at = result["broken_at"]
+        error = result["error"]
+        print(f"  Result:      ❌  INVALID — {error}")
+        print(f"  First break: {broken_at}")
+        raise SystemExit(1)
+
+
 def main() -> None:
     import argparse
     # --v2 opt-in flag for the React SPA scaffold (see clawmetry/v2/routes.py).
@@ -2845,6 +2887,18 @@ def main() -> None:
     # license — show the current license status
     sub.add_parser("license", help="Show the current self-hosted license status")
 
+    # verify-integrity — walk hash chain and report validity (Issue #2200)
+    p_verify = sub.add_parser(
+        "verify-integrity",
+        help="Verify the tamper-evident hash chain for local events",
+    )
+    p_verify.add_argument(
+        "--node-id",
+        dest="node_id",
+        default=None,
+        help="Limit verification to a single node (default: all nodes)",
+    )
+
     # Parse just the first token to decide if it's a sub-command or dashboard flag
     _subcmds = (
         "onboard",
@@ -2860,6 +2914,7 @@ def main() -> None:
         "uninstall",
         "activate",
         "license",
+        "verify-integrity",
         "nemoclaw-daemons",
     )
     if len(sys.argv) > 1 and sys.argv[1] in _subcmds:
@@ -2892,6 +2947,8 @@ def main() -> None:
             _cmd_activate(args)
         elif args.cmd == "license":
             _cmd_license(args)
+        elif args.cmd == "verify-integrity":
+            _cmd_verify_integrity(args)
         elif args.cmd == "nemoclaw-daemons":
             _register_nemoclaw_sandbox_daemons()
     else:

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -36,6 +36,7 @@ Concurrency model:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
@@ -194,19 +195,21 @@ _DDL = [
     # ── Layer 1: shared core ─────────────────────────────────────────────────
     """
     CREATE TABLE IF NOT EXISTS events (
-        id            VARCHAR PRIMARY KEY,
-        agent_type    VARCHAR NOT NULL DEFAULT 'openclaw',
-        node_id       VARCHAR NOT NULL,
-        agent_id      VARCHAR NOT NULL DEFAULT 'main',
-        session_id    VARCHAR,
-        workspace_id  VARCHAR,
-        event_type    VARCHAR NOT NULL,
-        ts            VARCHAR NOT NULL,
-        data          BLOB,
-        cost_usd      DOUBLE,
-        token_count   INTEGER,
-        model         VARCHAR,
-        created_at    BIGINT NOT NULL
+        id              VARCHAR PRIMARY KEY,
+        agent_type      VARCHAR NOT NULL DEFAULT 'openclaw',
+        node_id         VARCHAR NOT NULL,
+        agent_id        VARCHAR NOT NULL DEFAULT 'main',
+        session_id      VARCHAR,
+        workspace_id    VARCHAR,
+        event_type      VARCHAR NOT NULL,
+        ts              VARCHAR NOT NULL,
+        data            BLOB,
+        cost_usd        DOUBLE,
+        token_count     INTEGER,
+        model           VARCHAR,
+        created_at      BIGINT NOT NULL,
+        chain_prev_hash VARCHAR,
+        chain_hash      VARCHAR
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_events_ts          ON events(ts)",
@@ -827,6 +830,16 @@ _DDL = [
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_sync_dlq_created ON sync_dlq(created_at)",
+    # Issue #2200 — tamper-evident hash chain. chain_heads tracks the current
+    # head hash per node; events.chain_prev_hash/chain_hash carry the per-row
+    # links. Added via _MIGRATIONS_V2 for existing stores.
+    """
+    CREATE TABLE IF NOT EXISTS chain_heads (
+        node_id     VARCHAR PRIMARY KEY,
+        chain_hash  VARCHAR NOT NULL,
+        updated_at  BIGINT NOT NULL
+    )
+    """,
 ]
 
 
@@ -862,7 +875,40 @@ _MIGRATIONS_V2 = [
     ("sessions", "eval_judge_model",  "VARCHAR"),
     ("sessions", "eval_scored_at",    "BIGINT"),
     ("sessions", "eval_rubric",       "VARCHAR"),
+    # Issue #2200 — hash-chain columns. chain_prev_hash/chain_hash are NULL on
+    # existing rows and populated on new events when CLAWMETRY_INTEGRITY=1.
+    ("events",   "chain_prev_hash",   "VARCHAR"),
+    ("events",   "chain_hash",        "VARCHAR"),
 ]
+
+# ── Integrity / hash-chain (Issue #2200) ────────────────────────────────────
+#
+# Off by default. Set CLAWMETRY_INTEGRITY=1 to enable stamping new events with
+# a per-node SHA-256 chain. Existing rows keep chain_prev_hash/chain_hash=NULL
+# and are skipped by verify-integrity (reported as "pre-chain" events).
+_INTEGRITY_ENABLED = os.environ.get("CLAWMETRY_INTEGRITY", "0").strip().lower() not in (
+    "0", "false", "no", ""
+)
+
+def _integrity_hash(prev_hash: str, event: dict) -> str:
+    """Compute SHA-256(prev_hash + '|' + canonical JSON of immutable fields).
+
+    Applies the same field-level normalizations as _event_to_row so that
+    stamp-time hashes (using raw event dicts) and verify-time hashes (using
+    DB rows, already normalized) agree.
+    """
+    payload = {
+        "id":           str(event.get("id") or ""),
+        "agent_type":   str(event.get("agent_type") or "openclaw"),
+        "node_id":      str(event.get("node_id") or ""),
+        "agent_id":     str(event.get("agent_id") or "main"),
+        "session_id":   event.get("session_id"),
+        "workspace_id": event.get("workspace_id"),
+        "event_type":   str(event.get("event_type") or ""),
+        "ts":           str(event.get("ts") or ""),
+    }
+    canon = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(f"{prev_hash}|{canon}".encode()).hexdigest()
 
 
 def _apply_migrations(conn) -> None:
@@ -1306,6 +1352,9 @@ class LocalStore:
         self._flush_lock = threading.Lock()
         self._dropped = 0
         self._flusher_stop = threading.Event()
+        # Issue #2200 — in-memory chain-head cache (node_id -> current head hash).
+        # Populated lazily from chain_heads table on first flush for each node.
+        self._chain_heads: dict[str, str] = {}
         self._flusher_thread: threading.Thread | None = None
         self._last_flush_ts = time.monotonic()
         # Issue #1594 — auto-vacuum bookkeeping. ``_bytes_since_vacuum_check``
@@ -3689,6 +3738,7 @@ class LocalStore:
                             """,
                             rows,
                         )
+                        self._stamp_integrity(batch, self._conn)
                 last_exc = None
                 break
             except Exception as exc:  # noqa: BLE001 — surface any DuckDB error
@@ -3815,6 +3865,151 @@ class LocalStore:
         """
         params.append(int(limit))
         return [_row_to_event(r, _EVENT_COLS) for r in self._fetch(sql, params)]
+
+    # ── Issue #2200: integrity hash chain ────────────────────────────────────
+
+    def _stamp_integrity(self, batch: list[dict], conn) -> None:
+        """Compute and store chain_prev_hash/chain_hash for a flushed batch.
+
+        Called inside _flush_now_locked's _txn so hashes land atomically with
+        the events. No-op when _INTEGRITY_ENABLED is false or when an event was
+        already stamped (INSERT OR IGNORE skipped it, so we skip the UPDATE too).
+        """
+        if not _INTEGRITY_ENABLED:
+            return
+        from collections import defaultdict
+        by_node: dict[str, list[dict]] = defaultdict(list)
+        for e in batch:
+            node = str(e.get("node_id") or "unknown")
+            by_node[node].append(e)
+
+        for node_id, events in by_node.items():
+            if node_id not in self._chain_heads:
+                row = conn.execute(
+                    "SELECT chain_hash FROM chain_heads WHERE node_id = ?", [node_id]
+                ).fetchone()
+                self._chain_heads[node_id] = row[0] if row else "0" * 64
+
+            head = self._chain_heads[node_id]
+            # Sort by id so stamp order within a created_at bucket is deterministic
+            # and matches the ORDER BY id ASC used in verify_integrity.
+            events.sort(key=lambda e: str(e.get("id") or ""))
+            updates: list[tuple[str, str, str]] = []
+            for e in events:
+                eid = str(e.get("id") or "")
+                if not eid:
+                    continue
+                # Only stamp events that were actually inserted (not duplicates).
+                already = conn.execute(
+                    "SELECT chain_hash FROM events WHERE id = ? AND chain_hash IS NOT NULL",
+                    [eid],
+                ).fetchone()
+                if already:
+                    head = already[0]
+                    continue
+                new_hash = _integrity_hash(head, e)
+                updates.append((head, new_hash, eid))
+                head = new_hash
+
+            if updates:
+                conn.executemany(
+                    "UPDATE events SET chain_prev_hash = ?, chain_hash = ? WHERE id = ?",
+                    updates,
+                )
+            conn.execute(
+                """
+                INSERT INTO chain_heads (node_id, chain_hash, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT (node_id) DO UPDATE SET
+                    chain_hash = excluded.chain_hash,
+                    updated_at = excluded.updated_at
+                """,
+                [node_id, head, int(time.time() * 1000)],
+            )
+            self._chain_heads[node_id] = head
+
+    def verify_integrity(self, node_id: str | None = None) -> dict:
+        """Walk the hash chain and verify every stamped event in order.
+
+        Returns a dict with keys:
+          - status: 'valid' | 'invalid' | 'empty'
+          - node_id: the node checked (or 'all')
+          - checked: number of events verified
+          - pre_chain: events with no hash (inserted before integrity was enabled)
+          - broken_at: first event id where the chain breaks (or None)
+          - error: description of the break (or None)
+        """
+        where = "WHERE chain_hash IS NOT NULL"
+        params: list = []
+        if node_id:
+            where += " AND node_id = ?"
+            params.append(node_id)
+
+        rows = self._fetch(
+            f"""
+            SELECT id, node_id, chain_prev_hash, chain_hash,
+                   agent_type, agent_id, session_id, workspace_id, event_type, ts
+            FROM events
+            {where}
+            ORDER BY node_id, created_at ASC, id ASC
+            """,
+            params,
+        )
+
+        pre_chain_count = self._fetch(
+            "SELECT COUNT(*) FROM events WHERE chain_hash IS NULL"
+            + (" AND node_id = ?" if node_id else ""),
+            [node_id] if node_id else [],
+        )
+        pre_chain = pre_chain_count[0][0] if pre_chain_count else 0
+
+        if not rows:
+            return {
+                "status": "empty",
+                "node_id": node_id or "all",
+                "checked": 0,
+                "pre_chain": pre_chain,
+                "broken_at": None,
+                "error": None,
+            }
+
+        # Verify per node, in the order rows are sorted (node_id, created_at).
+        current_node: str | None = None
+        expected_prev = "0" * 64
+        checked = 0
+        for row in rows:
+            rid, rnid, prev_h, h, *rest_fields = row
+            # rest_fields = [agent_type, agent_id, session_id, workspace_id, event_type, ts]
+            event_dict = dict(zip(
+                ("id", "node_id", "agent_type", "agent_id", "session_id", "workspace_id", "event_type", "ts"),
+                (rid, rnid) + tuple(rest_fields),
+            ))
+            if rnid != current_node:
+                current_node = rnid
+                # Re-anchor expected_prev to the stored prev of the first row for this node
+                expected_prev = prev_h or "0" * 64
+
+            expected_hash = _integrity_hash(expected_prev, event_dict)
+            if h != expected_hash or prev_h != expected_prev:
+                return {
+                    "status": "invalid",
+                    "node_id": node_id or "all",
+                    "checked": checked,
+                    "pre_chain": pre_chain,
+                    "broken_at": rid,
+                    "error": f"chain break at event {rid} (node {rnid})",
+                }
+            expected_prev = h
+            checked += 1
+
+        return {
+            "status": "valid",
+            "node_id": node_id or "all",
+            "checked": checked,
+            "pre_chain": pre_chain,
+            "broken_at": None,
+            "error": None,
+        }
 
     def backfill_event_costs(self, *, batch: int = 5000) -> int:
         """#2049: populate ``cost_usd`` for events that arrived without it.

--- a/tests/test_integrity_hash_chain.py
+++ b/tests/test_integrity_hash_chain.py
@@ -1,0 +1,164 @@
+"""Unit tests for the tamper-evident hash chain (Issue #2200)."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import time
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def store_with_integrity(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_INTEGRITY", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.LocalStore()
+    s.start()
+    yield s
+    s.stop(flush=True)
+
+
+@pytest.fixture
+def store_no_integrity(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_INTEGRITY", "0")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.LocalStore()
+    s.start()
+    yield s
+    s.stop(flush=True)
+
+
+def _ev(node_id="node-a", **kw):
+    return {
+        "id": str(uuid.uuid4()),
+        "node_id": node_id,
+        "agent_id": "main",
+        "event_type": "tool_call",
+        "ts": "2026-01-01T00:00:00Z",
+        **kw,
+    }
+
+
+def _flush(store):
+    store._flush_now()
+    time.sleep(0.1)
+
+
+class TestIntegrityDisabled:
+    def test_verify_returns_empty_when_no_hashes(self, store_no_integrity):
+        s = store_no_integrity
+        s.ingest(_ev())
+        _flush(s)
+        result = s.verify_integrity()
+        assert result["status"] == "empty"
+        assert result["checked"] == 0
+
+    def test_events_have_no_hash_columns(self, store_no_integrity):
+        s = store_no_integrity
+        s.ingest(_ev())
+        _flush(s)
+        rows = s._fetch("SELECT chain_hash FROM events WHERE chain_hash IS NOT NULL", [])
+        assert rows == []
+
+
+class TestIntegrityEnabled:
+    def test_single_event_chain_is_valid(self, store_with_integrity):
+        s = store_with_integrity
+        s.ingest(_ev())
+        _flush(s)
+        result = s.verify_integrity()
+        assert result["status"] == "valid"
+        assert result["checked"] == 1
+        assert result["broken_at"] is None
+
+    def test_multiple_events_chain_is_valid(self, store_with_integrity):
+        s = store_with_integrity
+        for _ in range(5):
+            s.ingest(_ev())
+        _flush(s)
+        result = s.verify_integrity()
+        assert result["status"] == "valid"
+        assert result["checked"] == 5
+
+    def test_genesis_prev_hash_is_zeros(self, store_with_integrity):
+        s = store_with_integrity
+        s.ingest(_ev())
+        _flush(s)
+        rows = s._fetch(
+            "SELECT chain_prev_hash FROM events WHERE chain_hash IS NOT NULL ORDER BY created_at ASC LIMIT 1",
+            [],
+        )
+        assert rows[0][0] == "0" * 64
+
+    def test_chain_links_are_sequential(self, store_with_integrity):
+        s = store_with_integrity
+        for _ in range(3):
+            s.ingest(_ev())
+        _flush(s)
+        rows = s._fetch(
+            "SELECT chain_prev_hash, chain_hash FROM events WHERE chain_hash IS NOT NULL ORDER BY created_at ASC, id ASC",
+            [],
+        )
+        # Each row's prev_hash must equal the previous row's hash
+        for i in range(1, len(rows)):
+            assert rows[i][0] == rows[i - 1][1], f"Link broken between row {i-1} and {i}"
+
+    def test_cost_backfill_does_not_break_chain(self, store_with_integrity):
+        s = store_with_integrity
+        s.ingest(_ev())
+        _flush(s)
+        # Simulate a cost backfill: update cost_usd on the event
+        with s._write_lock:
+            s._conn.execute("UPDATE events SET cost_usd = 0.042 WHERE cost_usd IS NULL")
+        result = s.verify_integrity()
+        assert result["status"] == "valid", "Cost backfill must not break the chain"
+
+    def test_verify_detects_tampered_immutable_field(self, store_with_integrity):
+        import clawmetry.local_store as ls
+        s = store_with_integrity
+        s.ingest(_ev())
+        _flush(s)
+        # Tamper with event_type — this is an immutable field in the hash
+        with s._write_lock:
+            s._conn.execute("UPDATE events SET event_type = 'tampered' WHERE event_type = 'tool_call'")
+        result = s.verify_integrity()
+        assert result["status"] == "invalid"
+        assert result["broken_at"] is not None
+
+    def test_verify_node_id_filter(self, store_with_integrity):
+        s = store_with_integrity
+        for _ in range(2):
+            s.ingest(_ev(node_id="node-a"))
+        for _ in range(2):
+            s.ingest(_ev(node_id="node-b"))
+        _flush(s)
+        r_a = s.verify_integrity(node_id="node-a")
+        r_b = s.verify_integrity(node_id="node-b")
+        assert r_a["status"] == "valid"
+        assert r_b["status"] == "valid"
+        assert r_a["checked"] == 2
+        assert r_b["checked"] == 2
+
+    def test_pre_chain_count_reported(self, store_with_integrity, store_no_integrity):
+        # Events inserted without integrity have chain_hash=NULL → pre_chain
+        s = store_with_integrity
+        # Directly insert a row without hashes to simulate pre-chain events
+        with s._write_lock:
+            s._conn.execute(
+                "INSERT INTO events (id, agent_type, node_id, agent_id, event_type, ts, created_at) "
+                "VALUES ('pre-chain-id', 'openclaw', 'node-x', 'main', 'message', '2025-01-01', 0)"
+            )
+        s.ingest(_ev())
+        _flush(s)
+        result = s.verify_integrity()
+        assert result["pre_chain"] >= 1


### PR DESCRIPTION
Closes #2200

## What

Adds a per-node SHA-256 hash chain over the immutable identity fields of every event stored in the local DuckDB store. Each event gets `chain_prev_hash` and `chain_hash` stamped atomically with the insert; a new `chain_heads` table tracks the current head per node.

## Changes

- **`clawmetry/local_store.py`** — new `chain_prev_hash`/`chain_hash` columns added to the `events` DDL and via `_MIGRATIONS_V2` (safe for existing stores); `chain_heads` tracking table; `_stamp_integrity()` called inside the flush transaction so hashes land atomically; `verify_integrity(node_id=None)` reader method that walks the chain and returns `VALID` or the first broken link.
- **`clawmetry/cli.py`** — `clawmetry verify-integrity [--node-id ID]` subcommand opens the store read-only and prints the result.
- **`tests/test_integrity_hash_chain.py`** — 10 unit tests covering: genesis hash (`prev_hash = "0"*64`), sequential chain links, cost-backfill safety (the critical acceptance criterion), tamper detection on immutable fields, per-node scoping, and pre-chain event counting.

## Key design choices

- **Hash only immutable fields** (`id`, `agent_type`, `node_id`, `agent_id`, `session_id`, `workspace_id`, `event_type`, `ts`) so cost backfills writing `cost_usd`/`token_count`/`model` don't invalidate the chain.
- **Off by default** — set `CLAWMETRY_INTEGRITY=1` to enable stamping. Zero overhead when disabled; `verify-integrity` works on any store regardless.
- **Consistent normalization** — `_integrity_hash` applies the same field defaults as `_event_to_row` (`agent_type → 'openclaw'`, `agent_id → 'main'`) so stamp-time and verify-time hashes always agree.
- **Atomic with INSERT** — `_stamp_integrity` runs inside the same `_txn` as the flush, so a crash mid-batch leaves no partial stamps.

## Test plan

- `python3 -m pytest tests/test_integrity_hash_chain.py -v` → 10 passed
- `python3 -m pytest tests/test_local_store.py tests/test_error_signal.py tests/test_entitlements.py tests/test_integrity_hash_chain.py -q` → 60 passed
- Lint: same 188 pre-existing errors, 0 new ones introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRKmNDppf8T1saMVwmS9pa)_