### PR TITLE
feat(waste-flags): per-run waste heuristics in the snapshot (#2196 item #3)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9132,6 +9132,45 @@ _SE_LOCK = threading.Lock()
 _SE_STATE = {"payload": None, "computed_at": 0.0, "running": False}
 
 
+def _build_waste_flags(session_limit: int = 60, events_per_session: int = 500):
+    """Per-session waste flags (#2196 item #3).
+
+    Returns ``{session_id: [{type, severity, msg}, …]}`` for the most recent
+    sessions that have any flags. Sessions with no flags are omitted so the
+    snapshot only carries the signal (saves bytes; "no entry" is read as
+    "clean run"). Built on the daemon's own store handle, bounded so a busy
+    store can't bloat the encrypted snapshot. Never raises."""
+    try:
+        from clawmetry import local_store as _ls
+        from clawmetry import waste_flags as _wf
+    except Exception:
+        return {}
+    try:
+        store = _ls.get_store()
+        if store is None:
+            return {}
+        sessions = store.query_sessions(limit=int(session_limit))
+    except Exception:
+        return {}
+    out: dict[str, list] = {}
+    for s in sessions:
+        sid = s.get("session_id")
+        if not sid:
+            continue
+        try:
+            events = store.query_events(session_id=sid, limit=int(events_per_session))
+        except Exception:
+            continue
+        try:
+            signals = _wf.compute_signals_from_events(events)
+            flags = _wf.compute_flags(signals)
+        except Exception:
+            continue
+        if flags:
+            out[str(sid)] = flags
+    return out
+
+
 def _resolve_openclaw_bin():
     """Find the ``openclaw`` binary. The daemon runs under launchd with a
     minimal PATH, so ``shutil.which`` alone often misses Homebrew installs."""
@@ -11185,6 +11224,10 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         # Lets the cloud dashboard flag a 'down' inbound channel just like the
         # local dashboard's /api/system-health does.
         "connectorLiveness": _build_connector_liveness(config),
+        # Per-session waste flags (#2196 item #3): runaway / cold-cache /
+        # unscoped-result / bloated-context. Sessions without flags are
+        # omitted so this slice stays tiny — empty == clean.
+        "wasteFlags": _build_waste_flags(),
     }
 
     # ── NemoClaw / sandbox enrichment ────────────────────────────────────────

--- a/clawmetry/waste_flags.py
+++ b/clawmetry/waste_flags.py
@@ -1,0 +1,254 @@
+"""Per-run "waste" heuristics.
+
+A small set of cheap, derived flags that turn an anomalous run from
+"something is unusual" into "here is the lever to pull". The thresholds are
+deliberately tunable; each flag has a stable ``type`` so consumers can render
+distinct chips/colours, plus a plain-English ``msg`` for the dashboard.
+
+Pure-function and dependency-free so both the daemon snapshot builder
+(``clawmetry.sync``) and the request handlers can call it without a circular
+import.
+
+Flag types (round-1 set):
+
+- ``runaway``         — too many tool steps in one run (likely a loop)
+- ``cold_cache``      — cache hit rate is low and the run has enough steps to
+                         have warmed up, so context is being re-paid
+- ``unscoped_result`` — a single tool result is huge (probably an unscoped
+                         file/snapshot read)
+- ``bloated_context`` — a single step's context tokens are very large
+
+Each input field on the signals dict is optional and ``None``-safe; flags are
+emitted only when the relevant signal is present, so a partial signal set (for
+runtimes that don't expose cache numbers, for example) gracefully degrades.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Iterable
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an int from env, falling back to default on any parse error."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+# Thresholds — overridable via env (no install-time config file needed).
+RUNAWAY_STEPS = _env_int("CLAWMETRY_WASTE_RUNAWAY_STEPS", 30)
+COLD_CACHE_HIT_RATIO = _env_float("CLAWMETRY_WASTE_COLD_CACHE_HIT", 0.5)
+COLD_CACHE_MIN_STEPS = _env_int("CLAWMETRY_WASTE_COLD_CACHE_MIN_STEPS", 5)
+UNSCOPED_RESULT_BYTES = _env_int("CLAWMETRY_WASTE_UNSCOPED_RESULT_BYTES", 10_000)
+BLOATED_CONTEXT_TOKENS = _env_int("CLAWMETRY_WASTE_BLOATED_CONTEXT_TOKENS", 50_000)
+
+
+def _fmt_bytes(n: int) -> str:
+    """Human-readable byte count used in flag messages."""
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    return f"{n / (1024 * 1024):.1f} MB"
+
+
+def compute_flags(signals: Any) -> list[dict]:
+    """Derive waste flags from a per-run signals dict. Never raises.
+
+    Recognised signal keys (all optional, ``None``-safe):
+
+    - ``step_count``                   : int — number of tool-step events
+    - ``cache_read_tokens``            : int — total cache-read tokens this run
+    - ``input_tokens``                 : int — non-cached input tokens this run
+    - ``max_tool_result_bytes``        : int — biggest tool-result body (bytes)
+    - ``max_event_token_count``        : int — biggest single-event token count
+    """
+    out: list[dict] = []
+    if not isinstance(signals, dict):
+        return out
+
+    def _int(key: str) -> int | None:
+        v = signals.get(key)
+        if v is None:
+            return None
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return None
+
+    steps = _int("step_count")
+    if steps is not None and steps > RUNAWAY_STEPS:
+        out.append({
+            "type": "runaway",
+            "severity": "red",
+            "msg": f"{steps} steps (likely runaway loop)",
+        })
+
+    cache_read = _int("cache_read_tokens")
+    inp = _int("input_tokens")
+    if (
+        steps is not None and steps > COLD_CACHE_MIN_STEPS
+        and cache_read is not None and inp is not None
+    ):
+        total = cache_read + inp
+        if total > 0:
+            ratio = cache_read / total
+            if ratio < COLD_CACHE_HIT_RATIO:
+                out.append({
+                    "type": "cold_cache",
+                    "severity": "yellow",
+                    "msg": f"{round(ratio * 100)}% cache hit (cold start or drift)",
+                })
+
+    rb = _int("max_tool_result_bytes")
+    if rb is not None and rb > UNSCOPED_RESULT_BYTES:
+        out.append({
+            "type": "unscoped_result",
+            "severity": "yellow",
+            "msg": f"Step returned {_fmt_bytes(rb)} (unscoped snapshot?)",
+        })
+
+    tc = _int("max_event_token_count")
+    if tc is not None and tc > BLOATED_CONTEXT_TOKENS:
+        out.append({
+            "type": "bloated_context",
+            "severity": "yellow",
+            "msg": f"Step with {tc:,} context (bloated)",
+        })
+
+    return out
+
+
+# ── Per-session signal aggregation ────────────────────────────────────────────
+# Kept here (rather than in local_store) because it must work on event rows
+# from any source — the SQL fast path, a snapshot iterator, or a fixture in
+# a test. The shape matches ``local_store.query_events`` rows:
+#   {event_type: str, data: dict|bytes|str (JSON), token_count: int|None, ...}
+
+
+_TOOL_CALL_ET_HINTS = ("tool_call", "tool_use", "tool.call")
+_TOOL_RESULT_ET_HINTS = ("tool_result", "tool.result", "tool_use_result")
+
+
+def _ev_is_tool_call(event_type: str) -> bool:
+    et = event_type.lower()
+    return any(h in et for h in _TOOL_CALL_ET_HINTS) and "result" not in et
+
+
+def _ev_is_tool_result(event_type: str) -> bool:
+    et = event_type.lower()
+    return any(h in et for h in _TOOL_RESULT_ET_HINTS)
+
+
+def _coerce_data(data: Any) -> dict:
+    """Return a dict for ``data``, parsing JSON bytes/str when needed."""
+    if isinstance(data, dict):
+        return data
+    if isinstance(data, (bytes, bytearray)):
+        try:
+            data = bytes(data).decode("utf-8", "replace")
+        except Exception:
+            return {}
+    if isinstance(data, str):
+        try:
+            obj = json.loads(data)
+        except Exception:
+            return {}
+        return obj if isinstance(obj, dict) else {}
+    return {}
+
+
+def _i(d: dict, *keys: str) -> int:
+    """First parseable int from any of ``keys``, else 0."""
+    for k in keys:
+        v = d.get(k)
+        if v is None:
+            continue
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
+def compute_signals_from_events(events: Iterable[dict]) -> dict:
+    """Aggregate per-run waste signals from an iterable of event rows.
+
+    Pure-function, never raises. The output shape matches the input contract
+    of :func:`compute_flags` — call ``compute_flags(compute_signals_from_events(rows))``
+    end to end for a single run's flags.
+    """
+    step_count = 0
+    max_result_bytes = 0
+    max_event_tokens = 0
+    cache_read = 0
+    input_tokens = 0
+
+    for e in events or []:
+        et = str(e.get("event_type") or "")
+
+        if _ev_is_tool_call(et):
+            step_count += 1
+
+        try:
+            tc = int(e.get("token_count") or 0)
+        except (TypeError, ValueError):
+            tc = 0
+        if tc > max_event_tokens:
+            max_event_tokens = tc
+
+        data = _coerce_data(e.get("data"))
+
+        if _ev_is_tool_result(et) and data:
+            try:
+                blob = json.dumps(data, separators=(",", ":"), default=str)
+                sz = len(blob.encode("utf-8"))
+            except Exception:
+                sz = 0
+            if sz > max_result_bytes:
+                max_result_bytes = sz
+
+        if not data:
+            continue
+        usage = data.get("usage") if isinstance(data.get("usage"), dict) else {}
+        extra = data.get("extra") if isinstance(data.get("extra"), dict) else {}
+        cache_read += _i(
+            usage,
+            "cacheRead", "cacheReadInputTokens",
+            "cache_read_input_tokens", "cache_read_tokens",
+        )
+        cache_read += _i(
+            extra,
+            "cacheRead", "cacheReadInputTokens",
+            "cache_read_input_tokens", "cache_read_tokens",
+        )
+        input_tokens += _i(
+            usage, "input", "inputTokens", "input_tokens", "prompt_tokens",
+        )
+        input_tokens += _i(
+            extra, "input", "inputTokens", "input_tokens", "prompt_tokens",
+        )
+
+    return {
+        "step_count": step_count,
+        "max_tool_result_bytes": max_result_bytes,
+        "max_event_token_count": max_event_tokens,
+        "cache_read_tokens": cache_read,
+        "input_tokens": input_tokens,
+    }

--- a/tests/test_waste_flags.py
+++ b/tests/test_waste_flags.py
@@ -1,0 +1,177 @@
+"""Per-run waste-flag heuristics (#2196 item #3)."""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+from clawmetry import waste_flags as wf
+
+
+# ── compute_flags ──────────────────────────────────────────────────────────
+
+def test_empty_or_partial_signals_emit_nothing():
+    assert wf.compute_flags({}) == []
+    assert wf.compute_flags(None) == []
+    assert wf.compute_flags("not a dict") == []
+    # Partial: step_count only, no waste
+    assert wf.compute_flags({"step_count": 3}) == []
+
+
+def test_runaway_flag():
+    out = wf.compute_flags({"step_count": 99})
+    assert any(f["type"] == "runaway" for f in out)
+    assert "99 steps" in next(f for f in out if f["type"] == "runaway")["msg"]
+
+
+def test_cold_cache_requires_min_steps_and_low_ratio():
+    # 2 steps -> below COLD_CACHE_MIN_STEPS, no flag
+    assert not any(f["type"] == "cold_cache" for f in wf.compute_flags({
+        "step_count": 2, "cache_read_tokens": 0, "input_tokens": 1000,
+    }))
+    # Enough steps + low hit ratio -> flagged
+    out = wf.compute_flags({
+        "step_count": 20, "cache_read_tokens": 1000, "input_tokens": 9000,
+    })
+    cold = [f for f in out if f["type"] == "cold_cache"]
+    assert cold and "10%" in cold[0]["msg"]
+    # Healthy cache + plenty of steps -> no flag
+    assert not any(f["type"] == "cold_cache" for f in wf.compute_flags({
+        "step_count": 20, "cache_read_tokens": 9500, "input_tokens": 500,
+    }))
+
+
+def test_unscoped_result_and_bloated_context():
+    out = wf.compute_flags({
+        "max_tool_result_bytes": 50_000,
+        "max_event_token_count": 120_000,
+    })
+    types = {f["type"] for f in out}
+    assert "unscoped_result" in types
+    assert "bloated_context" in types
+
+
+def test_threshold_env_overrides(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_WASTE_RUNAWAY_STEPS", "3")
+    importlib.reload(wf)
+    assert any(f["type"] == "runaway" for f in wf.compute_flags({"step_count": 4}))
+
+
+# ── compute_signals_from_events ────────────────────────────────────────────
+
+def test_signals_aggregate_tool_calls_and_results():
+    # Reload module so any env-tweaks from above don't leak into this test
+    importlib.reload(wf)
+    rows = [
+        # Two tool calls -> step_count=2
+        {"event_type": "tool_call", "data": {}, "token_count": 0},
+        {"event_type": "tool.call", "data": None, "token_count": 0},
+        # Tool result with a big body -> max_tool_result_bytes
+        {"event_type": "tool_result", "token_count": 0,
+         "data": {"content": "x" * 20_000, "role": "tool"}},
+        # Assistant turn carrying token split via data.usage
+        {"event_type": "assistant", "token_count": 80_000,
+         "data": {"role": "assistant",
+                  "usage": {"input": 1000, "cacheRead": 9000}}},
+        # Same shape but via data.extra (claude_code family)
+        {"event_type": "assistant", "token_count": 4000,
+         "data": {"_runtime": "claude_code",
+                  "extra": {"inputTokens": 500, "cacheReadInputTokens": 4500}}},
+        # Bytes-encoded data must be parsed back
+        {"event_type": "tool_call", "token_count": 0,
+         "data": json.dumps({"foo": "bar"}).encode("utf-8")},
+    ]
+    s = wf.compute_signals_from_events(rows)
+    assert s["step_count"] == 3  # 2 tool_call + 1 byte-encoded tool_call
+    assert s["max_tool_result_bytes"] > 20_000
+    assert s["max_event_token_count"] == 80_000
+    assert s["cache_read_tokens"] == 13_500  # 9000 + 4500
+    assert s["input_tokens"] == 1_500       # 1000 + 500
+
+
+def test_signals_then_flags_end_to_end():
+    importlib.reload(wf)
+    # Build a synthetic runaway run: 31 tool calls + a bloated step.
+    rows = []
+    for _ in range(31):
+        rows.append({"event_type": "tool_call", "data": {}, "token_count": 0})
+    rows.append({"event_type": "assistant", "token_count": 60_000,
+                 "data": {"usage": {"input": 60_000}}})
+    flags = wf.compute_flags(wf.compute_signals_from_events(rows))
+    types = {f["type"] for f in flags}
+    assert {"runaway", "bloated_context"}.issubset(types)
+
+
+def test_signals_never_raises_on_garbage():
+    importlib.reload(wf)
+    rows = [
+        {"event_type": None, "data": object()},
+        {"event_type": 12345, "data": "not json"},
+        {},
+        {"event_type": "tool_call", "token_count": "not-a-number", "data": b"not-json"},
+    ]
+    s = wf.compute_signals_from_events(rows)
+    # Only the last row's event_type matches tool_call -> step_count=1
+    assert s["step_count"] == 1
+    # Everything else stays at zero rather than crashing
+    assert s["max_tool_result_bytes"] == 0
+    assert s["max_event_token_count"] == 0
+
+
+# ── snapshot integration ───────────────────────────────────────────────────
+
+
+def test_build_waste_flags_in_snapshot(tmp_path, monkeypatch):
+    """Integrate-test the daemon's _build_waste_flags(): ingest synthetic
+    sessions and assert flagged ones land in the map and clean ones don't."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "ev.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "2")
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    store = ls.get_store()
+    # Patch the sync module's get_store() lookup to return ours.
+    from clawmetry import sync as syncmod
+    monkeypatch.setattr(syncmod, "_resolve_openclaw_bin", lambda: None, raising=False)
+
+    # Runaway session: 35 tool_call events.
+    for i in range(35):
+        store.ingest({
+            "id": f"runaway:ev-{i}",
+            "node_id": "n", "agent_id": "main", "session_id": "sess-runaway",
+            "event_type": "tool_call",
+            "ts": f"2026-05-28T12:00:{i:02d}Z",
+            "data": {"name": "Bash"},
+            "cost_usd": None, "token_count": 0, "model": None,
+        })
+    # Clean session: 3 tool_call events, nothing unusual.
+    for i in range(3):
+        store.ingest({
+            "id": f"clean:ev-{i}",
+            "node_id": "n", "agent_id": "main", "session_id": "sess-clean",
+            "event_type": "tool_call",
+            "ts": f"2026-05-28T13:00:{i:02d}Z",
+            "data": {"name": "Read"},
+            "cost_usd": None, "token_count": 0, "model": None,
+        })
+    # Flush ring -> events table.
+    deadline_helper = lambda: store.health()["ring_depth"] == 0
+    import time as _t
+    end = _t.monotonic() + 3
+    while _t.monotonic() < end and not deadline_helper():
+        _t.sleep(0.02)
+
+    try:
+        out = syncmod._build_waste_flags()
+        assert "sess-runaway" in out, f"runaway should be flagged: keys={list(out)}"
+        assert any(f["type"] == "runaway" for f in out["sess-runaway"])
+        assert "sess-clean" not in out, "clean sessions must be omitted (empty == clean)"
+    finally:
+        store.stop(flush=True)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Implements item #3 of #2196 — per-run **waste flags** that turn "something is unusual" into "here's the lever to pull":

| Flag | Heuristic (env-tunable) | Severity |
|---|---|---|
| `runaway` | `step_count > 30` | red |
| `cold_cache` | cache hit `< 50%` AND `> 5` steps | yellow |
| `unscoped_result` | any tool result `> 10 KB` | yellow |
| `bloated_context` | any single step `> 50 k` tokens | yellow |

Thresholds override via env (`CLAWMETRY_WASTE_*`).

## Approach

The chokepoint is the **snapshot** — every reader inherits flags by reading the same slice.

- `clawmetry/waste_flags.py` (new) — one dependency-free, pure-function module with the threshold constants, `compute_flags(signals)` (classifier), and `compute_signals_from_events(rows)` (per-session aggregator). Importable by snapshot, route, fixture — no circular risk.
- `sync.py._build_waste_flags()` walks recent sessions on the daemon's own store handle, computes signals, and ships `wasteFlags: {session_id -> [flags]}` as a new top-level snapshot slice. Sessions with no flags are **omitted** so the slice stays tiny ("empty == clean run").
- Daemon-side only — cloud renders the slice client-side. No cloud code change required, just a pin bump once released.

The local dashboard route + UI surface ship in the timeline PR (item #4 of #2196), which is the natural visual consumer of these flags. This PR ships the data primitive.

## Verification

- `tests/test_waste_flags.py` — 9 tests: classifier truth table, env-override of thresholds, the cross-runtime aggregator (Anthropic `data.usage` + Claude Code `data.extra`, byte-encoded data, garbage-in safety), end-to-end `events → signals → flags`, and an integration test that ingests synthetic runaway/clean sessions into a temp DuckDB and asserts the snapshot builder includes the runaway one and omits the clean one. All green.
- New module ruff-clean; my edits add **zero** new ruff errors vs `origin/main`.
- Live E2E verification (decrypt the live cloud snapshot for `wasteFlags`) included in the comment after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
