### PR TITLE
feat(enterprise): OTel/OTLP export endpoint for recent events

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -127,6 +127,7 @@ from routes.turn_anatomy import bp_turn_anatomy
 from routes.tool_catalog import bp_tool_catalog
 from routes.context_economics import bp_context_economics
 from routes.entitlement import bp_entitlement
+from routes.otel_export import bp_otel_export
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -10629,6 +10630,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_tool_catalog)
     app.register_blueprint(bp_context_economics)
     app.register_blueprint(bp_entitlement)
+    app.register_blueprint(bp_otel_export)
 
     # Register built-in agent adapters. External plugins can register more
     # via clawmetry.extensions entry points — see clawmetry/adapters/.

--- a/routes/otel_export.py
+++ b/routes/otel_export.py
@@ -1,0 +1,137 @@
+"""
+routes/otel_export.py — Enterprise OTel/OTLP export.
+
+Streams recent ClawMetry events as OTLP-JSON ``logRecords`` so a customer's
+Datadog / Grafana / Honeycomb / OTel collector can poll us and pipe agent
+activity into their existing observability stack. This is the first
+Enterprise-only feature (entitlement gate ``otel_export``); while the
+open-core rollout is in GRACE mode the gate is permissive, so the endpoint is
+reachable today for evaluation.
+
+  GET /api/otel/export[?limit=N]
+    -> {"resourceLogs": [{"resource": ..., "scopeLogs": [...]}]}
+
+The mapping is intentionally simple: one ``LogRecord`` per event, body = a
+short label, attributes = session_id / event_type / role / tool_name / model.
+Trace-tree export (events as Spans) is the next refinement.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, jsonify, request
+
+logger = logging.getLogger("clawmetry.routes.otel_export")
+
+bp_otel_export = Blueprint("otel_export", __name__)
+
+
+def _entitlement_allows() -> tuple[bool, dict]:
+    """Whether this install may use OTel export. Grace lets everyone through;
+    after enforce, only Enterprise-tier installs do. Never raises."""
+    try:
+        from clawmetry import entitlements as _ent
+
+        en = _ent.get_entitlement()
+        return en.allows_feature("otel_export"), en.to_dict()
+    except Exception as exc:  # pragma: no cover
+        logger.warning("otel_export: entitlement read failed, defaulting open: %s", exc)
+        return True, {"tier": "oss", "grace": True}
+
+
+def _event_to_log_record(ev: dict) -> dict:
+    """Map a ClawMetry event row to an OTLP LogRecord (JSON)."""
+    ts = ev.get("ts") or ev.get("timestamp") or 0
+    try:
+        ts_ns = str(int(float(ts) * 1_000_000_000))
+    except Exception:
+        ts_ns = "0"
+    event_type = str(ev.get("event_type") or ev.get("type") or "event")
+    body = event_type
+    role = ev.get("role") or ev.get("data", {}).get("role") if isinstance(ev.get("data"), dict) else ev.get("role")
+
+    attrs: list[dict] = []
+    def _add(k: str, v):
+        if v is None or v == "":
+            return
+        if isinstance(v, bool):
+            attrs.append({"key": k, "value": {"boolValue": v}})
+        elif isinstance(v, (int,)):
+            attrs.append({"key": k, "value": {"intValue": str(v)}})
+        elif isinstance(v, float):
+            attrs.append({"key": k, "value": {"doubleValue": v}})
+        else:
+            attrs.append({"key": k, "value": {"stringValue": str(v)[:512]}})
+
+    _add("session_id", ev.get("session_id"))
+    _add("event_type", event_type)
+    _add("role", role)
+    _add("tool_name", ev.get("tool_name") or ev.get("toolName"))
+    _add("model", ev.get("model"))
+    _add("agent_type", ev.get("agent_type") or "openclaw")
+
+    return {
+        "timeUnixNano": ts_ns,
+        "severityNumber": 9,           # INFO
+        "severityText": "INFO",
+        "body": {"stringValue": body},
+        "attributes": attrs,
+    }
+
+
+def _build_otlp_envelope(events: list[dict]) -> dict:
+    """Wrap LogRecords in the OTLP/JSON resourceLogs/scopeLogs envelope."""
+    return {
+        "resourceLogs": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "clawmetry"}},
+                        {"key": "telemetry.sdk.name", "value": {"stringValue": "clawmetry-otel-export"}},
+                    ]
+                },
+                "scopeLogs": [
+                    {
+                        "scope": {"name": "clawmetry.events", "version": "1"},
+                        "logRecords": [_event_to_log_record(e) for e in events],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _fetch_events(limit: int) -> list[dict]:
+    """Pull recent events via the daemon-proxy local-query path. Falls back to
+    an empty list on any failure (cloud / no-daemon environments)."""
+    try:
+        from routes.local_query import _dispatch
+
+        body = _dispatch("events", {"limit": limit})
+        evs = body.get("events") if isinstance(body, dict) else None
+        return evs if isinstance(evs, list) else []
+    except Exception as exc:
+        logger.warning("otel_export: event fetch failed: %s", exc)
+        return []
+
+
+@bp_otel_export.route("/api/otel/export", methods=["GET"])
+def api_otel_export():
+    """OTLP/JSON export of recent events. Enterprise-gated; permissive during
+    the open-core grace period. Never raises."""
+    allowed, ent = _entitlement_allows()
+    if not allowed:
+        return jsonify({
+            "error": "upgrade_required",
+            "feature": "otel_export",
+            "tier": ent.get("tier"),
+            "hint": "OTel export is an Enterprise feature. Contact sales at https://clawmetry.com/pricing",
+        }), 402
+
+    try:
+        limit = max(1, min(int(request.args.get("limit", 200) or 200), 5000))
+    except Exception:
+        limit = 200
+    events = _fetch_events(limit)
+    return jsonify(_build_otlp_envelope(events))

--- a/tests/test_otel_export.py
+++ b/tests/test_otel_export.py
@@ -1,0 +1,74 @@
+"""Tests for routes/otel_export.py — Enterprise OTLP/JSON export.
+
+Validates the envelope shape, event→LogRecord mapping, attribute encoding, and
+the entitlement gate (allowed in grace, blocked + 402 once enforced).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import routes.otel_export as O
+
+
+def test_envelope_shape_and_scope():
+    env = O._build_otlp_envelope([])
+    assert "resourceLogs" in env and isinstance(env["resourceLogs"], list)
+    rl = env["resourceLogs"][0]
+    res_attrs = {a["key"]: a["value"]["stringValue"] for a in rl["resource"]["attributes"]}
+    assert res_attrs["service.name"] == "clawmetry"
+    scope = rl["scopeLogs"][0]["scope"]
+    assert scope["name"] == "clawmetry.events"
+
+
+def test_event_to_log_record_basic():
+    rec = O._event_to_log_record({
+        "ts": 1717000000.5, "event_type": "model.completed",
+        "session_id": "abc", "role": "assistant", "model": "claude-opus-4-7",
+    })
+    assert rec["severityText"] == "INFO"
+    assert rec["body"]["stringValue"] == "model.completed"
+    attrs = {a["key"]: a["value"] for a in rec["attributes"]}
+    assert attrs["session_id"]["stringValue"] == "abc"
+    assert attrs["event_type"]["stringValue"] == "model.completed"
+    assert attrs["model"]["stringValue"] == "claude-opus-4-7"
+    # nanosecond conversion
+    assert rec["timeUnixNano"] == str(1717000000_500_000_000)
+
+
+def test_attribute_type_encoding():
+    rec = O._event_to_log_record({"ts": 0, "event_type": "x", "model": 42})
+    attrs = {a["key"]: a["value"] for a in rec["attributes"]}
+    assert "intValue" in attrs["model"]
+
+
+def test_missing_fields_dont_raise():
+    # Defensive: a sparse event row must never crash mapping.
+    rec = O._event_to_log_record({})
+    assert rec["body"]["stringValue"] == "event"
+    assert rec["timeUnixNano"] == "0"
+
+
+def test_entitlement_allows_in_grace(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+    allowed, ent = O._entitlement_allows()
+    assert allowed is True
+    assert ent["grace"] is True
+
+
+def test_entitlement_blocks_otel_for_oss_when_enforced(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+    allowed, ent = O._entitlement_allows()
+    assert allowed is False
+    assert ent["grace"] is False
+    # cleanup so other tests aren't poisoned
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    importlib.reload(e)
+    e.invalidate()


### PR DESCRIPTION
## What

First Enterprise-only feature in OSS: `GET /api/otel/export` returns recent events as **OTLP/JSON logRecords** so a customer's Datadog / Grafana / Honeycomb / OTel collector can poll us.

Mapping: one `LogRecord` per event, body = event_type, attributes = session_id, event_type, role, tool_name, model, agent_type.

## Gating

`entitlements.allows_feature('otel_export')`. **Grace = permissive** today; once enforce flips, non-Enterprise installs get HTTP 402 `{error: upgrade_required, feature: otel_export}`.

## Verification

`pytest tests/test_otel_export.py` → 6 passed (envelope shape, attribute encoding, sparse-event resilience, grace/enforce gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)