### PR TITLE
feat(assets): evidence-based asset registry (first slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+### Added: evidence-based asset registry — first slice (2026-05-28)
+- New DuckDB-backed asset registry that converts individual agent discoveries (Self-Evolve findings, useful prompts, improved skills) into **reviewable, reusable assets with provenance** — without auto-promoting unreviewed local changes to team/company defaults (#2201). Lifecycle `pending → approved/rejected → deprecated`; every asset traces to a source `session_id`/`run_id`. Types: `skill`, `prompt`, `workflow`, `playbook`, `memory_snippet`, `tool_config`, `evaluation_case`. The daemon owns writes; reads ride the daemon proxy so the cloud can paint from a snapshot the same way (added to the `_DAEMON_METHODS` allowlist next to `ingest_approval` / `update_approval_decision`).
+- HTTP surface (`routes/assets.py`): `GET /api/assets` (filter by `status` / `asset_type` / `source_run_id` / `source_session_id` / `limit`), `GET /api/assets/<id>`, `POST /api/assets` (create candidate), `POST /api/assets/<id>/review` (`approve` / `reject` / `deprecate`).
+- Self-Evolve hook: `POST /api/selfevolve/findings/save-as-asset` packages a finding into a `pending` candidate asset with its source `session_id` attached and a `self-evolve` provenance tag — one-click promotion from a finding card to the registry. Approval still requires an explicit reviewer action.
+- Foundation lives in OSS (DuckDB-first); the richer review/promote console with reviewer identity + auto-recommendation is the planned Pro surface. 19 unit + HTTP tests; daemon-side only, no cloud pin bump.
+
+### Added: agents must work in an isolated git worktree (FLYWHEEL.md §0) (2026-05-28)
+- Documented hard rule: multiple Claude Code agents and crons run against this repo concurrently — editing the main checkout is unsafe because another process can switch branches mid-edit and clobber uncommitted changes. Future agents must start with `EnterWorktree` (or `git worktree add .claude/worktrees/<slug> -b feat/<slug> origin/main`). Burned 2026-05-28 when an autonomous process checked out a different branch in the shared working tree and wiped the in-progress asset-registry edits.
+
 ### Release: tamper-evident hash chain for event audit log (carries #2210) (2026-05-28)
 - Per-node SHA-256 chain over events now ships on PyPI, plus the new `clawmetry verify-integrity` CLI. Off by default (set `CLAWMETRY_INTEGRITY=1` to enable stamping; existing stores migrate cleanly and pre-chain rows are reported separately by the verifier). See the detailed Added entry below for the design and the cost-backfill-safety guarantee. No cloud pin bump.
 

--- a/FLYWHEEL.md
+++ b/FLYWHEEL.md
@@ -24,6 +24,7 @@ The north star: **don't stop at "code compiles." Stop at "verified working in pr
 1. **Scan open issues/PRs for human claims.** If a human said "picking this up" / "working on" / "I'll take" in the last 7 days, do NOT open a competing PR. Automation is the night-shift janitor, not the day-shift engineer.
 2. **Scan the user's recent comments** on open PRs/issues and address them first.
 3. **Re-read the goal.** If invoked via `/goal`, the goal persists until the *outcome* is achieved and verified — not until the code is written.
+4. **Work in an isolated worktree.** Multiple Claude Code agents and crons run against this repo at the same time. Editing the main checkout is unsafe: another process can switch branches mid-edit and clobber uncommitted changes (burned 2026-05-28 — `feat/asset-registry` working-tree wiped when a concurrent agent checked out `release/hash-chain-2210` in the same checkout). Always start with `EnterWorktree`, or `git worktree add .claude/worktrees/<slug> -b feat/<slug> origin/main`. The worktree gives you your own branch + working tree; the shared checkout is for the human, not for parallel automation. Use `ExitWorktree` (or `git worktree remove`) once the PR is merged.
 
 ## 1. The data-flow rule (this is the one that bites)
 

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -521,6 +521,39 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_guardrail_events_ts      ON guardrail_events(ts)",
     "CREATE INDEX IF NOT EXISTS idx_guardrail_events_session ON guardrail_events(session_id, ts)",
+    # Issue #2201 — asset registry. Evidence + review layer that turns
+    # individual agent discoveries (Self-Evolve findings, useful prompts,
+    # improved skills) into reviewable, reusable assets without auto-promoting
+    # unreviewed local changes to team/company defaults. Lifecycle:
+    # pending → approved/rejected → deprecated. Every asset references a
+    # source ``run_id``/``session_id`` (evidence over claims). Tags + content
+    # are JSON-encoded into BLOB via ``_to_blob`` and decoded back via
+    # ``_decode_data_blob_rows``.
+    """
+    CREATE TABLE IF NOT EXISTS assets (
+        id                VARCHAR PRIMARY KEY,
+        asset_type        VARCHAR NOT NULL,
+        name              VARCHAR NOT NULL,
+        description       VARCHAR NOT NULL DEFAULT '',
+        source_run_id     VARCHAR NOT NULL DEFAULT '',
+        source_session_id VARCHAR NOT NULL DEFAULT '',
+        node_id           VARCHAR NOT NULL DEFAULT '',
+        author            VARCHAR NOT NULL DEFAULT '',
+        team_id           VARCHAR NOT NULL DEFAULT '',
+        version           VARCHAR NOT NULL DEFAULT '0.1.0',
+        status            VARCHAR NOT NULL DEFAULT 'pending',
+        tags              BLOB,
+        content           BLOB,
+        reviewer          VARCHAR NOT NULL DEFAULT '',
+        review_reason     VARCHAR NOT NULL DEFAULT '',
+        created_at        VARCHAR NOT NULL,
+        updated_at        BIGINT NOT NULL,
+        reviewed_at       VARCHAR
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_assets_status ON assets(status, updated_at)",
+    "CREATE INDEX IF NOT EXISTS idx_assets_type   ON assets(asset_type, updated_at)",
+    "CREATE INDEX IF NOT EXISTS idx_assets_run    ON assets(source_run_id)",
     # Issue #1088 Phase 4 (2026-05-13) — channel-message foundation. Replaces
     # the per-provider log-grep + JSONL-scan path that the 21 routes in
     # ``routes/channels.py`` use today. Each row is one inbound or outbound
@@ -3051,6 +3084,183 @@ class LocalStore:
             },
             "per_agent": per_agent,
         }
+
+    # ── Asset registry (#2201) ─────────────────────────────────────────────
+    # Evidence + review layer that turns individual agent discoveries
+    # (Self-Evolve findings, useful prompts, improved skills) into reviewable,
+    # reusable assets. Daemon owns writes; reads ride the local_query proxy
+    # so the cloud can paint from the snapshot the same way.
+
+    _ASSET_TYPES = frozenset({
+        "skill", "prompt", "workflow", "playbook",
+        "memory_snippet", "tool_config", "evaluation_case",
+    })
+    _ASSET_STATUSES = frozenset({"pending", "approved", "rejected", "deprecated"})
+
+    _ASSET_COLS = [
+        "id", "asset_type", "name", "description", "source_run_id",
+        "source_session_id", "node_id", "author", "team_id", "version",
+        "status", "tags", "content", "reviewer", "review_reason",
+        "created_at", "updated_at", "reviewed_at",
+    ]
+
+    def ingest_asset(self, asset: dict[str, Any]) -> None:
+        """Upsert one asset. Required: ``id``, ``asset_type``, ``name``.
+        Re-ingesting the same id refreshes name/description/content/tags but
+        preserves the existing status + reviewer (those move via
+        ``update_asset_status``). Tags/content are stored as ``_to_blob``-
+        encoded BLOBs and decoded back via ``_decode_data_blob_rows`` on read."""
+        from datetime import datetime, timezone
+
+        aid = asset.get("id")
+        if not aid:
+            raise ValueError("asset must include 'id'")
+        atype = asset.get("asset_type") or ""
+        if atype not in self._ASSET_TYPES:
+            raise ValueError(
+                f"asset_type {atype!r} not in {sorted(self._ASSET_TYPES)}"
+            )
+        name = asset.get("name") or ""
+        if not name:
+            raise ValueError("asset must include non-empty 'name'")
+        status = asset.get("status") or "pending"
+        if status not in self._ASSET_STATUSES:
+            raise ValueError(
+                f"status {status!r} not in {sorted(self._ASSET_STATUSES)}"
+            )
+        created_at = asset.get("created_at") or datetime.now(timezone.utc).isoformat()
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO assets (
+                    id, asset_type, name, description, source_run_id,
+                    source_session_id, node_id, author, team_id, version,
+                    status, tags, content, reviewer, review_reason,
+                    created_at, updated_at, reviewed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO UPDATE SET
+                    name              = excluded.name,
+                    description       = excluded.description,
+                    source_run_id     = COALESCE(NULLIF(excluded.source_run_id, ''), assets.source_run_id),
+                    source_session_id = COALESCE(NULLIF(excluded.source_session_id, ''), assets.source_session_id),
+                    node_id           = COALESCE(NULLIF(excluded.node_id, ''), assets.node_id),
+                    author            = COALESCE(NULLIF(excluded.author, ''), assets.author),
+                    team_id           = COALESCE(NULLIF(excluded.team_id, ''), assets.team_id),
+                    version           = COALESCE(NULLIF(excluded.version, ''), assets.version),
+                    tags              = COALESCE(excluded.tags, assets.tags),
+                    content           = COALESCE(excluded.content, assets.content),
+                    updated_at        = excluded.updated_at
+            """, [
+                str(aid), atype, name,
+                asset.get("description") or "",
+                asset.get("source_run_id") or "",
+                asset.get("source_session_id") or "",
+                asset.get("node_id") or "",
+                asset.get("author") or "",
+                asset.get("team_id") or "",
+                asset.get("version") or "0.1.0",
+                status,
+                _to_blob(asset.get("tags")),
+                _to_blob(asset.get("content")),
+                asset.get("reviewer") or "",
+                asset.get("review_reason") or "",
+                created_at,
+                int(time.time() * 1000),
+                asset.get("reviewed_at"),
+            ])
+
+    def update_asset_status(
+        self, asset_id: str, *, status: str, reviewer: str = "",
+        reason: str = "",
+    ) -> bool:
+        """Move an asset to a new status (the review action). Returns True if
+        a row with ``asset_id`` existed and was updated, False otherwise."""
+        from datetime import datetime, timezone
+
+        if status not in self._ASSET_STATUSES:
+            raise ValueError(
+                f"status {status!r} not in {sorted(self._ASSET_STATUSES)}"
+            )
+        now_iso = datetime.now(timezone.utc).isoformat()
+        now_ms = int(time.time() * 1000)
+        with self._write_lock:
+            # DuckDB UPDATE doesn't return a useful affected-row count via the
+            # cursor; check existence first, then update.
+            row = self._conn.execute(
+                "SELECT 1 FROM assets WHERE id = ?", [str(asset_id)]
+            ).fetchone()
+            if not row:
+                return False
+            self._conn.execute("""
+                UPDATE assets SET
+                    status        = ?,
+                    reviewer      = COALESCE(NULLIF(?, ''), reviewer),
+                    review_reason = COALESCE(NULLIF(?, ''), review_reason),
+                    reviewed_at   = ?,
+                    updated_at    = ?
+                WHERE id = ?
+            """, [status, reviewer, reason, now_iso, now_ms, str(asset_id)])
+            return True
+
+    def query_assets(
+        self,
+        *,
+        status: str | None = None,
+        asset_type: str | None = None,
+        source_run_id: str | None = None,
+        source_session_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """List assets newest-first with optional filters."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if status:
+            clauses.append("status = ?"); params.append(status)
+        if asset_type:
+            clauses.append("asset_type = ?"); params.append(asset_type)
+        if source_run_id:
+            clauses.append("source_run_id = ?"); params.append(source_run_id)
+        if source_session_id:
+            clauses.append("source_session_id = ?"); params.append(source_session_id)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT {", ".join(self._ASSET_COLS)}
+            FROM assets
+            {where}
+            ORDER BY updated_at DESC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        return self._decode_asset_rows(self._fetch(sql, params))
+
+    def get_asset(self, asset_id: str) -> dict[str, Any] | None:
+        """Return one asset detail by id, or None."""
+        if not asset_id:
+            return None
+        sql = f"SELECT {', '.join(self._ASSET_COLS)} FROM assets WHERE id = ?"
+        out = self._decode_asset_rows(self._fetch(sql, [str(asset_id)]))
+        return out[0] if out else None
+
+    def _decode_asset_rows(self, rows: Iterable[tuple]) -> list[dict[str, Any]]:
+        """tuple→dict for ``assets``. Mirrors ``_decode_data_blob_rows`` but
+        decodes BOTH BLOB columns (``tags`` + ``content``) — the shared helper
+        only handles a single ``data`` column."""
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            d = dict(zip(self._ASSET_COLS, r))
+            for k in ("tags", "content"):
+                raw = d.get(k)
+                if raw is None:
+                    continue
+                try:
+                    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+                    try:
+                        d[k] = json.loads(text)
+                    except (ValueError, TypeError):
+                        d[k] = text
+                except (UnicodeDecodeError, AttributeError):
+                    d[k] = None
+            out.append(d)
+        return out
 
     def ingest_system_snapshot(self, snap: dict[str, Any]) -> None:
         """Insert one system-snapshot row. Append-only;

--- a/dashboard.py
+++ b/dashboard.py
@@ -111,6 +111,7 @@ from routes.heartbeat import bp_heartbeat
 from routes.autonomy import bp_autonomy
 from routes.selfconfig import bp_selfconfig
 from routes.agents import bp_agents
+from routes.assets import bp_assets
 from routes.reasoning import bp_reasoning
 from routes.plugins import bp_plugins
 from routes.local_query import bp_local_query
@@ -10619,6 +10620,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_heartbeat)
     app.register_blueprint(bp_selfconfig)
     app.register_blueprint(bp_agents)
+    app.register_blueprint(bp_assets)
     app.register_blueprint(bp_reasoning)
     app.register_blueprint(bp_plugins)
     app.register_blueprint(bp_local_query)

--- a/routes/assets.py
+++ b/routes/assets.py
@@ -1,0 +1,147 @@
+"""routes/assets.py — Asset registry HTTP surface.
+
+Evidence + review layer that turns individual agent discoveries (Self-Evolve
+findings, useful prompts, improved skills) into reviewable, reusable assets
+without auto-promoting unreviewed local changes to team/company defaults
+(see issue #2201 + ``spec/asset-registry`` in the evotown adoption thread).
+
+Endpoints (first slice):
+
+  GET  /api/assets                  — list, newest first; ``status``,
+                                       ``asset_type``, ``source_run_id``,
+                                       ``source_session_id``, ``limit`` query
+                                       params
+  GET  /api/assets/<asset_id>       — single asset detail
+  POST /api/assets                  — create / upsert a candidate asset
+                                       (``id``, ``asset_type``, ``name``
+                                       required; ``source_run_id``,
+                                       ``source_session_id``, ``description``,
+                                       ``content``, ``tags``, ``author``,
+                                       ``team_id`` optional)
+  POST /api/assets/<asset_id>/review — move status (`approve`/`reject`/
+                                       `deprecate`); body: ``reviewer``,
+                                       ``reason``
+
+All reads + writes go through the daemon proxy (``local_store_via_daemon``)
+so the dashboard process never opens DuckDB writable — same pattern as
+``query_approvals`` / ``ingest_approval``. Auth is intentionally not enforced
+in this first slice; the dashboard binds to localhost and the richer
+review/promote console (with reviewer identity + audit) is the planned Pro
+surface.
+"""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+bp_assets = Blueprint("assets", __name__)
+
+
+# Mirrors the lifecycle in the LocalStore (kept in sync — the daemon validates
+# again, this is just a friendlier 400 at the API edge).
+_VALID_TYPES = frozenset({
+    "skill", "prompt", "workflow", "playbook",
+    "memory_snippet", "tool_config", "evaluation_case",
+})
+_REVIEW_ACTIONS = {
+    "approve": "approved",
+    "approved": "approved",
+    "reject": "rejected",
+    "rejected": "rejected",
+    "deprecate": "deprecated",
+    "deprecated": "deprecated",
+}
+
+
+def _ls_call(method_name, **kwargs):
+    """Cross-process LocalStore call with single-process fallback. Mirrors the
+    helper used by routes/agents.py / routes/components.py."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+def _int_arg(name: str, default: int, *, lo: int, hi: int) -> int:
+    try:
+        v = int(request.args.get(name, default))
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, v))
+
+
+@bp_assets.route("/api/assets", methods=["GET"])
+def list_assets():
+    kwargs = {"limit": _int_arg("limit", 100, lo=1, hi=1000)}
+    for key in ("status", "asset_type", "source_run_id", "source_session_id"):
+        val = (request.args.get(key) or "").strip()
+        if val:
+            kwargs[key] = val
+    rows = _ls_call("query_assets", **kwargs) or []
+    return jsonify({"assets": rows, "count": len(rows)})
+
+
+@bp_assets.route("/api/assets/<asset_id>", methods=["GET"])
+def get_asset_detail(asset_id: str):
+    row = _ls_call("get_asset", asset_id=asset_id)
+    if not row:
+        return jsonify({"error": f"asset {asset_id!r} not found"}), 404
+    return jsonify(row)
+
+
+@bp_assets.route("/api/assets", methods=["POST"])
+def create_asset():
+    data = request.get_json(silent=True) or {}
+    aid = (data.get("id") or "").strip()
+    atype = (data.get("asset_type") or "").strip()
+    name = (data.get("name") or "").strip()
+    if not aid:
+        return jsonify({"error": "'id' is required"}), 400
+    if atype not in _VALID_TYPES:
+        return jsonify({
+            "error": f"'asset_type' must be one of {sorted(_VALID_TYPES)}",
+        }), 400
+    if not name:
+        return jsonify({"error": "'name' is required"}), 400
+    # Whitelist — refuse silently-ignored extras so callers learn the schema.
+    allowed = {
+        "id", "asset_type", "name", "description", "source_run_id",
+        "source_session_id", "node_id", "author", "team_id", "version",
+        "status", "tags", "content", "reviewer", "review_reason",
+        "created_at",
+    }
+    payload = {k: v for k, v in data.items() if k in allowed}
+    result = _ls_call("ingest_asset", asset=payload)
+    if result is None and not _ls_call("get_asset", asset_id=aid):
+        return jsonify({"error": "asset store unavailable"}), 503
+    row = _ls_call("get_asset", asset_id=aid)
+    return jsonify(row or {"id": aid, "status": "pending"}), 201
+
+
+@bp_assets.route("/api/assets/<asset_id>/review", methods=["POST"])
+def review_asset(asset_id: str):
+    data = request.get_json(silent=True) or {}
+    action = (data.get("action") or data.get("status") or "").strip().lower()
+    status = _REVIEW_ACTIONS.get(action)
+    if not status:
+        return jsonify({
+            "error": f"'action' must be one of {sorted(set(_REVIEW_ACTIONS))}",
+        }), 400
+    reviewer = (data.get("reviewer") or "").strip()
+    reason = (data.get("reason") or "").strip()
+    ok = _ls_call(
+        "update_asset_status",
+        asset_id=asset_id, status=status, reviewer=reviewer, reason=reason,
+    )
+    if not ok:
+        return jsonify({"error": f"asset {asset_id!r} not found"}), 404
+    row = _ls_call("get_asset", asset_id=asset_id)
+    return jsonify(row or {"id": asset_id, "status": status})

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -476,6 +476,13 @@ _DAEMON_METHODS = frozenset({
     # decisions stay serialized.
     "ingest_approval",
     "update_approval_decision",
+    # Issue #2201: asset registry (Self-Evolve findings → reviewable assets).
+    # query_/get_ are reads; ingest_asset + update_asset_status are read-then-
+    # write under the daemon's _write_lock — same pattern as approvals above.
+    "query_assets",
+    "get_asset",
+    "ingest_asset",
+    "update_asset_status",
     # Issue #1364: surface clawmetry/proxy.py LoopDetector signals on the
     # dashboard. Read by routes/health.py:/api/loop-signals via the daemon
     # proxy so the dashboard process never opens DuckDB writable.

--- a/routes/selfevolve.py
+++ b/routes/selfevolve.py
@@ -647,3 +647,72 @@ def api_selfevolve_fix_status():
             "error": job.get("error", ""),
         }
     )
+
+
+# ── #2201: file a Self-Evolve finding as a candidate asset ─────────────────
+# Thin wrapper so the dashboard / cloud UI can promote a finding into the
+# asset registry with one click — generates the asset id, packages the
+# finding body as the asset content, and ties it to its source session_id.
+# The reviewer still has to approve via POST /api/assets/<id>/review before
+# the asset becomes searchable / recommendable.
+
+@bp_selfevolve.route(
+    "/api/selfevolve/findings/save-as-asset", methods=["POST"]
+)
+def api_selfevolve_save_as_asset():
+    from datetime import datetime, timezone
+    import secrets as _secrets
+
+    data = request.get_json(silent=True) or {}
+    finding_id = (data.get("finding_id") or "").strip()
+    session_id = (data.get("session_id") or "").strip()
+    summary = (data.get("summary") or data.get("name") or "").strip()
+    body = data.get("body") or data.get("content") or ""
+    if not summary:
+        return jsonify({"error": "'summary' is required"}), 400
+    valid_types = {
+        "skill", "prompt", "workflow", "playbook",
+        "memory_snippet", "tool_config", "evaluation_case",
+    }
+    asset_type = (data.get("asset_type") or "prompt").strip()
+    if asset_type not in valid_types:
+        return jsonify({
+            "error": f"'asset_type' must be one of {sorted(valid_types)}",
+        }), 400
+
+    asset_id = data.get("id") or f"selfevolve:{finding_id or _secrets.token_hex(6)}"
+    payload = {
+        "id": asset_id,
+        "asset_type": asset_type,
+        "name": summary,
+        "description": data.get("description") or "",
+        "source_session_id": session_id,
+        "source_run_id": data.get("source_run_id") or "",
+        "author": data.get("author") or "self-evolve",
+        "team_id": data.get("team_id") or "",
+        "tags": (data.get("tags") or []) + ["self-evolve"],
+        "content": {
+            "finding_id": finding_id,
+            "summary": summary,
+            "body": body,
+            "filed_at": datetime.now(timezone.utc).isoformat(),
+        },
+        "status": "pending",
+    }
+
+    try:
+        from routes.local_query import local_store_via_daemon
+        local_store_via_daemon("ingest_asset", asset=payload)
+    except Exception:
+        try:
+            from clawmetry import local_store
+            local_store.get_store().ingest_asset(payload)
+        except Exception as exc:
+            return jsonify({"error": f"asset store unavailable: {exc}"}), 503
+
+    try:
+        from routes.local_query import local_store_via_daemon
+        row = local_store_via_daemon("get_asset", asset_id=asset_id)
+    except Exception:
+        row = None
+    return jsonify(row or {"id": asset_id, "status": "pending"}), 201

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -1,0 +1,225 @@
+"""Tests for the asset registry first slice — issue #2201.
+
+Covers:
+- LocalStore methods (ingest_asset / update_asset_status / query_assets /
+  get_asset) using a raw LocalStore (not get_store(), which may return a
+  daemon proxy on a dev box with the sync daemon running).
+- The HTTP surface in routes/assets.py and the Self-Evolve "save as asset"
+  hook in routes/selfevolve.py — both exercised through Flask's test client
+  with the LocalStore daemon-proxy short-circuited to a single in-process
+  raw store.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+# ── LocalStore-level tests ─────────────────────────────────────────────────
+
+@pytest.fixture
+def raw_store(tmp_path, monkeypatch):
+    """A fresh LocalStore writing to a temp DuckDB. Use the raw class so
+    ``_ring`` / ``_conn`` access works (``get_store()`` may proxy)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.LocalStore()
+    yield store
+    try:
+        store.stop(flush=False)
+    except Exception:
+        pass
+
+
+def _mk(asset_id="a1", **overrides):
+    base = {
+        "id": asset_id,
+        "asset_type": "prompt",
+        "name": "Better refactor prompt",
+        "description": "from a real session",
+        "source_session_id": "sess-1",
+        "tags": ["self-evolve", "prompt-quality"],
+        "content": {"body": "...prompt body..."},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestLocalStoreAssets:
+    def test_ingest_and_get(self, raw_store):
+        raw_store.ingest_asset(_mk())
+        row = raw_store.get_asset("a1")
+        assert row is not None
+        assert row["id"] == "a1"
+        assert row["asset_type"] == "prompt"
+        assert row["status"] == "pending"
+        assert row["tags"] == ["self-evolve", "prompt-quality"]
+        assert row["content"] == {"body": "...prompt body..."}
+        assert row["source_session_id"] == "sess-1"
+
+    def test_get_unknown_returns_none(self, raw_store):
+        assert raw_store.get_asset("does-not-exist") is None
+        assert raw_store.get_asset("") is None
+
+    def test_invalid_type_rejected(self, raw_store):
+        with pytest.raises(ValueError):
+            raw_store.ingest_asset(_mk(asset_type="nope"))
+
+    def test_invalid_status_rejected(self, raw_store):
+        with pytest.raises(ValueError):
+            raw_store.ingest_asset(_mk(status="weird"))
+
+    def test_id_required(self, raw_store):
+        with pytest.raises(ValueError):
+            raw_store.ingest_asset(_mk(asset_id=""))
+
+    def test_upsert_preserves_status_and_reviewer(self, raw_store):
+        raw_store.ingest_asset(_mk())
+        raw_store.update_asset_status(
+            "a1", status="approved", reviewer="vivek", reason="looks good"
+        )
+        # Re-ingest the same id with new name/content; status must stick.
+        raw_store.ingest_asset(_mk(name="Renamed", content={"body": "v2"}))
+        row = raw_store.get_asset("a1")
+        assert row["status"] == "approved"
+        assert row["reviewer"] == "vivek"
+        assert row["name"] == "Renamed"
+        assert row["content"] == {"body": "v2"}
+
+    def test_update_status_unknown_returns_false(self, raw_store):
+        assert raw_store.update_asset_status("missing", status="approved") is False
+
+    def test_query_filters(self, raw_store):
+        raw_store.ingest_asset(_mk("a1", asset_type="prompt", source_run_id="r1"))
+        raw_store.ingest_asset(_mk("a2", asset_type="skill", source_run_id="r1"))
+        raw_store.ingest_asset(_mk("a3", asset_type="prompt", source_run_id="r2"))
+        raw_store.update_asset_status("a2", status="approved")
+        all_rows = raw_store.query_assets()
+        assert {r["id"] for r in all_rows} == {"a1", "a2", "a3"}
+        prompts = raw_store.query_assets(asset_type="prompt")
+        assert {r["id"] for r in prompts} == {"a1", "a3"}
+        approved = raw_store.query_assets(status="approved")
+        assert {r["id"] for r in approved} == {"a2"}
+        run_r1 = raw_store.query_assets(source_run_id="r1")
+        assert {r["id"] for r in run_r1} == {"a1", "a2"}
+
+    def test_query_ordered_newest_first(self, raw_store):
+        import time as _t
+        raw_store.ingest_asset(_mk("a1"))
+        _t.sleep(0.01)
+        raw_store.ingest_asset(_mk("a2"))
+        _t.sleep(0.01)
+        raw_store.update_asset_status("a1", status="approved")  # bumps updated_at
+        rows = raw_store.query_assets()
+        assert [r["id"] for r in rows][:2] == ["a1", "a2"]
+
+
+# ── HTTP-surface tests ─────────────────────────────────────────────────────
+
+@pytest.fixture
+def client(raw_store, monkeypatch):
+    """Flask test client with the daemon-proxy short-circuited to the
+    in-process raw store. Avoids spinning up the daemon for unit tests."""
+    def _fake_via_daemon(method_name, **kwargs):
+        return getattr(raw_store, method_name)(**kwargs)
+    import routes.local_query as lq
+    monkeypatch.setattr(lq, "local_store_via_daemon", _fake_via_daemon, raising=False)
+    # Also short-circuit the in-package fallback get_store() that the routes
+    # reach for if the daemon proxy returns None. The fixture-loaded raw
+    # store is the truth here.
+    import clawmetry.local_store as ls
+    monkeypatch.setattr(ls, "get_store", lambda read_only=False: raw_store)
+    from flask import Flask
+    from routes.assets import bp_assets
+    from routes.selfevolve import bp_selfevolve
+    app = Flask(__name__)
+    app.register_blueprint(bp_assets)
+    app.register_blueprint(bp_selfevolve)
+    return app.test_client()
+
+
+class TestAssetsHTTP:
+    def test_post_creates_asset(self, client):
+        r = client.post("/api/assets", json={
+            "id": "h1", "asset_type": "prompt", "name": "API-created",
+            "source_session_id": "sess-9",
+            "content": {"body": "..."},
+        })
+        assert r.status_code == 201, r.get_json()
+        assert r.get_json()["id"] == "h1"
+
+    def test_post_rejects_bad_type(self, client):
+        r = client.post("/api/assets", json={
+            "id": "x", "asset_type": "bogus", "name": "n",
+        })
+        assert r.status_code == 400
+
+    def test_post_requires_id_and_name(self, client):
+        assert client.post("/api/assets", json={"asset_type": "prompt", "name": "x"}).status_code == 400
+        assert client.post("/api/assets", json={"id": "x", "asset_type": "prompt"}).status_code == 400
+
+    def test_get_list_and_detail(self, client):
+        client.post("/api/assets", json={
+            "id": "h1", "asset_type": "skill", "name": "n1",
+        })
+        r = client.get("/api/assets")
+        body = r.get_json()
+        assert r.status_code == 200
+        assert body["count"] >= 1
+        assert any(a["id"] == "h1" for a in body["assets"])
+        detail = client.get("/api/assets/h1").get_json()
+        assert detail["id"] == "h1"
+
+    def test_get_detail_404(self, client):
+        assert client.get("/api/assets/nope").status_code == 404
+
+    def test_review_approve(self, client):
+        client.post("/api/assets", json={
+            "id": "h1", "asset_type": "prompt", "name": "n",
+        })
+        r = client.post("/api/assets/h1/review", json={
+            "action": "approve", "reviewer": "vivek", "reason": "ok",
+        })
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body["status"] == "approved"
+        assert body["reviewer"] == "vivek"
+
+    def test_review_unknown_action(self, client):
+        client.post("/api/assets", json={
+            "id": "h1", "asset_type": "prompt", "name": "n",
+        })
+        r = client.post("/api/assets/h1/review", json={"action": "yolo"})
+        assert r.status_code == 400
+
+    def test_review_missing_asset(self, client):
+        r = client.post("/api/assets/nope/review", json={"action": "approve"})
+        assert r.status_code == 404
+
+    def test_selfevolve_save_as_asset(self, client):
+        r = client.post("/api/selfevolve/findings/save-as-asset", json={
+            "finding_id": "f-abc",
+            "session_id": "sess-42",
+            "summary": "Drop the redundant retry",
+            "body": "...details...",
+            "asset_type": "prompt",
+        })
+        assert r.status_code == 201, r.get_json()
+        body = r.get_json()
+        assert body["status"] == "pending"
+        assert body["source_session_id"] == "sess-42"
+        # Self-evolve provenance recorded in tags + content.
+        assert "self-evolve" in body["tags"]
+        assert body["content"]["finding_id"] == "f-abc"
+
+    def test_selfevolve_save_requires_summary(self, client):
+        r = client.post("/api/selfevolve/findings/save-as-asset", json={
+            "finding_id": "f-abc",
+        })
+        assert r.status_code == 400


### PR DESCRIPTION
Closes the first slice of #2201.

## What this ships

A DuckDB-backed **asset registry** that converts individual agent discoveries (Self-Evolve findings, useful prompts, improved skills) into **reviewable, reusable assets with provenance** — without auto-promoting unreviewed local changes to team/company defaults.

- **Lifecycle:** `pending → approved/rejected → deprecated`
- **Asset types:** `skill`, `prompt`, `workflow`, `playbook`, `memory_snippet`, `tool_config`, `evaluation_case`
- **Evidence required:** every asset traces to a source `session_id`/`run_id`

## Implementation

- **DuckDB schema** (`clawmetry/local_store.py`) — new `assets` table + 3 indexes (`status`/`type`/`source_run_id`). Tags + content are JSON-encoded BLOBs.
- **LocalStore methods** — `ingest_asset` / `update_asset_status` / `query_assets` / `get_asset`, all under `_write_lock`. Re-ingesting an existing id preserves status + reviewer (those move via `update_asset_status`).
- **Daemon proxy** — `query_assets` / `get_asset` / `ingest_asset` / `update_asset_status` added to `_DAEMON_METHODS` (`routes/local_query.py`). Reads + writes never open DuckDB writable from the dashboard — same pattern as approvals.
- **HTTP surface** (`routes/assets.py`):
  - `GET  /api/assets` — list, with `status`/`asset_type`/`source_run_id`/`source_session_id`/`limit` filters
  - `GET  /api/assets/<id>` — detail (404 on miss)
  - `POST /api/assets` — create/upsert candidate (id + type + name required)
  - `POST /api/assets/<id>/review` — `approve` / `reject` / `deprecate` (reviewer + reason recorded)
- **Self-Evolve hook** (`routes/selfevolve.py`) — `POST /api/selfevolve/findings/save-as-asset` packages a finding into a `pending` candidate asset with its source `session_id` attached and a `self-evolve` provenance tag. One-click from a finding card to the registry; approval still requires an explicit reviewer action.

## FLYWHEEL.md update

Documented the new hard rule that future agents must work in an **isolated `git worktree`**. Multiple Claude Code agents and crons run against this repo concurrently; editing the main checkout is unsafe because another process can switch branches mid-edit and clobber uncommitted changes. (Burned in this exact session — a concurrent autonomous process switched branches in the shared checkout and wiped the first attempt at this slice. Worktree fixed it.)

## Tests

19 tests in `tests/test_asset_registry.py` — LocalStore CRUD + lifecycle + validation + filter/order, the full HTTP surface, and the Self-Evolve hook. All green locally.

## Scope

- Foundation is OSS and DuckDB-first (per the project's "DuckDB-first" rule); the richer review/promote console with reviewer identity + auto-recommendation is the planned **Pro** governance surface.
- Daemon-side only — no cloud pin bump.

## Out of scope (follow-ups)
- Auto-promotion + recommendation engine.
- Signed skill packages + private distribution handoff.
- Cross-runtime candidate ingest from non-OpenClaw engines.
- Cloud dashboard surface that paints from a snapshot slice (the daemon proxy is already wired; the snapshot slice + interceptor is the next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)