### PR TITLE
fix(integrity): verify-integrity CLI crashed against running daemon (allowlist + graceful-None)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2539,6 +2539,16 @@ def _cmd_verify_integrity(args) -> None:
         print(f"  Error: verification failed — {exc}")
         raise SystemExit(1) from exc
 
+    # When a sync daemon is running, ``get_store(read_only=True)`` returns a
+    # proxy that forwards through HTTP. Older daemons (< 0.12.343) do not
+    # have ``verify_integrity`` in their method allowlist and return None.
+    # Degrade gracefully instead of crashing on ``result["status"]``.
+    if result is None:
+        print("  Result:      ?  Could not reach the running daemon's verifier.")
+        print("               This usually means the daemon is older than the CLI.")
+        print("               Restart the sync daemon to pick up the new wheel, then re-run.")
+        raise SystemExit(2)
+
     status = result["status"]
     checked = result["checked"]
     pre_chain = result["pre_chain"]

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -534,6 +534,13 @@ _DAEMON_METHODS = frozenset({
     "query_guardrail_events",
     "ingest_guardrail_event",
     "query_nemoclaw_metrics",
+    # Issue #2200 — tamper-evident hash chain verifier. `clawmetry
+    # verify-integrity` calls this through the daemon proxy when a daemon
+    # is running (the daemon holds DuckDB's process-level writer lock so
+    # the CLI cannot open the file directly, even read-only). Without
+    # this entry the proxy returns None and the CLI crashed on
+    # `result["status"]`. Read-only walk over the events table.
+    "verify_integrity",
 })
 
 

--- a/tests/test_verify_integrity_cli_proxy.py
+++ b/tests/test_verify_integrity_cli_proxy.py
@@ -1,0 +1,90 @@
+"""Regression coverage for the verify-integrity CLI → daemon-proxy path.
+
+The integrity hash chain ships in 0.12.342 (#2200 / #2210). Live verification
+caught a crash: ``clawmetry verify-integrity`` calls
+``get_store(read_only=True)`` which returns the proxy when a daemon is running,
+the proxy forwards the call through HTTP, and the HTTP dispatch allowlist did
+not include ``verify_integrity`` — so the proxy returned ``None`` and the CLI
+crashed on ``result["status"]``.
+
+This file pins both halves of the fix so it cannot regress:
+
+1. ``verify_integrity`` is in the daemon-side ``_DAEMON_METHODS`` allowlist.
+2. The CLI prints a clear message and exits 2 instead of crashing when the
+   proxy returns ``None`` (older daemon, daemon unreachable, etc.).
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+
+def test_verify_integrity_is_in_daemon_method_allowlist():
+    from routes.local_query import _DAEMON_METHODS
+    assert "verify_integrity" in _DAEMON_METHODS, (
+        "verify_integrity must be allowlisted so `clawmetry verify-integrity`"
+        " works when the dashboard/CLI talks to the daemon over HTTP (the"
+        " daemon holds DuckDB's process-level writer lock and any direct"
+        " read-only open from another process is rejected)."
+    )
+
+
+def test_cli_handles_proxy_returning_none_without_crashing(monkeypatch, capsys):
+    """Old-daemon scenario: ``store.verify_integrity()`` returns None
+    (because the running daemon predates this fix). The CLI must not raise
+    ``TypeError: 'NoneType' object is not subscriptable``."""
+    from clawmetry import cli
+
+    class _NoneStore:
+        def verify_integrity(self, node_id=None):  # noqa: ARG002
+            return None
+
+    monkeypatch.setattr(cli, "_cmd_verify_integrity",
+                        cli._cmd_verify_integrity)  # ensure name exists
+    monkeypatch.setattr("clawmetry.local_store.get_store",
+                        lambda read_only=True: _NoneStore())
+
+    class _Args:
+        node_id = None
+
+    with pytest.raises(SystemExit) as ei:
+        cli._cmd_verify_integrity(_Args())
+    # Exit code 2 (specific signal for "could not verify, environment
+    # problem"), not 1 (chain invalid) and not 0 (success).
+    assert ei.value.code == 2
+    captured = capsys.readouterr()
+    assert "Could not reach" in captured.out
+    assert "Restart the sync daemon" in captured.out
+
+
+def test_cli_still_reports_invalid_when_real_break_detected(monkeypatch, capsys):
+    """Make sure the graceful-None path didn't break the normal invalid-chain
+    branch."""
+    from clawmetry import cli
+
+    class _BrokenStore:
+        def verify_integrity(self, node_id=None):  # noqa: ARG002
+            return {
+                "status": "invalid",
+                "node_id": "all",
+                "checked": 3,
+                "pre_chain": 0,
+                "broken_at": "evt-3",
+                "error": "chain break at event evt-3",
+            }
+
+    monkeypatch.setattr("clawmetry.local_store.get_store",
+                        lambda read_only=True: _BrokenStore())
+
+    class _Args:
+        node_id = None
+
+    with pytest.raises(SystemExit) as ei:
+        cli._cmd_verify_integrity(_Args())
+    assert ei.value.code == 1
+    captured = capsys.readouterr()
+    assert "INVALID" in captured.out
+    assert "evt-3" in captured.out


### PR DESCRIPTION
## Caught by FLYWHEEL §7 live verification

Immediately after `[RELEASE]` of #2210 (the tamper-evident hash chain) hit PyPI as 0.12.342, I installed the fresh wheel and ran the new CLI against the running sync daemon (the live-verify step that the FLYWHEEL done-bar requires). It crashed:

```
$ clawmetry verify-integrity
ClawMetry Integrity Verify
────────────────────────────────────────
Traceback (most recent call last):
  File ".../clawmetry/cli.py", line 2542, in _cmd_verify_integrity
    status = result["status"]
TypeError: 'NoneType' object is not subscriptable
```

## Root cause

`_cmd_verify_integrity` does `store = get_store(read_only=True)`. When a sync daemon is running (the standard install) `get_store()` returns the `_ProxyStore` proxy because DuckDB locks at the **process level** — see memory `reference_duckdb_process_lock` and PR #1253 — and any other process opening the file (even read-only) gets rejected by the daemon's writer lock.

The proxy forwards every method call through HTTP to `/__local_query__/<method>` on the daemon. That endpoint enforces a per-method allowlist (`_DAEMON_METHODS`) so a stolen bearer token cannot call arbitrary `LocalStore.<method>`. `verify_integrity` was not in the allowlist → the daemon returned a 400 → the proxy swallowed it as `None` → CLI crashed.

## Fix (defense in depth)

1. **`routes/local_query.py`** — add `"verify_integrity"` to `_DAEMON_METHODS`. The proxy now succeeds against the running daemon.
2. **`clawmetry/cli.py`** — explicit `if result is None` branch that prints a clear message ("could not reach the running daemon's verifier — restart the sync daemon to pick up the new wheel") and exits 2. So even if a *future* method is added to the CLI without being allowlisted, the CLI prints a human error instead of crashing on subscript.

## Tests

`tests/test_verify_integrity_cli_proxy.py` — 3 new tests:
- `verify_integrity` is in `_DAEMON_METHODS` (prevents drift).
- CLI graceful-None branch exits 2 with the help message.
- CLI invalid-chain branch still exits 1 with the broken-event id.

All 13 integrity-cluster tests pass locally (3 new + 10 existing in `test_integrity_hash_chain.py`).

## Audit the class of bug, not just the instance

Per memory `feedback_audit_class_of_bug_not_just_instance` — checked whether any other recently added `LocalStore.<method>` is invoked from the CLI and missing from the allowlist. None found in the current CLI; the SIEM exporter (#2199 in flight) does not depend on the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)