### PR TITLE
feat(health-timeline): per-runtime sparkline of recent runs (#2196 item #4)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2527,6 +2527,63 @@ function renderOauthBanner(overview) {
   }
 }
 
+// Per-runtime sparkline of recent runs (#2196 item #4). Hides the card
+// when no runtime has dots, so a clean install never shows an empty box.
+async function loadHealthTimeline() {
+  var card = document.getElementById('health-timeline-card');
+  var body = document.getElementById('health-timeline-body');
+  if (!card || !body) return;
+  var data;
+  try {
+    var resp = await fetch('/api/health-timeline');
+    if (!resp.ok) { card.style.display = 'none'; return; }
+    data = await resp.json();
+  } catch (e) { card.style.display = 'none'; return; }
+  var runtimes = (data && data.runtimes) || [];
+  if (!runtimes.length || !runtimes.some(function(r){ return (r.dots||[]).length; })) {
+    card.style.display = 'none';
+    return;
+  }
+  var sevColor = {
+    red:    'var(--err, #ef4444)',
+    yellow: 'var(--warn, #eab308)',
+    green:  'var(--ok, #22c55e)'
+  };
+  var html = '';
+  runtimes.forEach(function (r) {
+    var dots = r.dots || [];
+    if (!dots.length) return;
+    var dotsHtml = dots.map(function (d) {
+      var bits = [];
+      if (d.error_count) bits.push(d.error_count + ' err');
+      if (d.flag_count)  bits.push(d.flag_count + ' flag');
+      if (d.cost_usd)    bits.push('$' + (d.cost_usd < 0.01 ? d.cost_usd.toFixed(4) : d.cost_usd.toFixed(2)));
+      var when = d.started_at ? new Date(d.started_at).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}) : '?';
+      var tip = when + (bits.length ? ' · ' + bits.join(' · ') : ' · ok');
+      var fill = sevColor[d.severity] || sevColor.green;
+      return '<span title="' + tip.replace(/"/g,'&quot;') + '" style="display:inline-block;width:10px;height:10px;border-radius:50%;background:' + fill + ';margin-right:3px;"></span>';
+    }).join('');
+    var summary = dots.length + ' runs';
+    var reds = dots.filter(function (d) { return d.severity === 'red'; }).length;
+    if (reds) summary += ', ' + reds + ' err';
+    html += '<div style="display:grid;grid-template-columns:140px 1fr auto;align-items:center;gap:10px;padding:4px 0;">'
+         +    '<div style="font-size:12px;color:var(--text-primary);font-weight:600;">' + escapeHtmlSafe(r.runtime) + '</div>'
+         +    '<div style="line-height:1;">' + dotsHtml + '</div>'
+         +    '<div style="font-size:11px;color:var(--text-muted);">' + summary + '</div>'
+         +  '</div>';
+  });
+  body.innerHTML = html;
+  card.style.display = '';
+}
+
+// Minimal HTML escape for the runtime label; the rest of the values are
+// hand-built from numbers/timestamps so they're safe without escaping.
+function escapeHtmlSafe(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
 // #1969: coalesce concurrent + back-to-back loadAll() callers. Heartbeat-
 // landed handlers, connection-restored, switchTab('overview'), and the
 // periodic refresh interval can all fire within the same second; pre-fix
@@ -2590,6 +2647,9 @@ async function loadAll() {
       // Keep UI responsive with placeholder values until next refresh.
       loadMiniWidgets(overview, {todayCost:0, weekCost:0, monthCost:0, month:0, today:0});
     }
+    // Health timeline (#2196 item #4) — fire-and-forget; renderer hides the
+    // card if there's nothing to show.
+    try { loadHealthTimeline(); } catch (e) {}
     return true;
   } catch (e) {
     console.error('Initial load failed', e);

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9171,6 +9171,82 @@ def _build_waste_flags(session_limit: int = 60, events_per_session: int = 500):
     return out
 
 
+def _build_health_timeline(session_limit: int = 60, events_per_session: int = 500,
+                           dots_per_runtime: int = 30):
+    """Per-runtime sparkline of recent runs (#2196 item #4).
+
+    Returns ``{"runtimes": [{"runtime": str, "dots": [...]}, …]}`` where each
+    dot summarises one session — severity is ``red`` for any real error
+    (post #2202 benign-error filtering), ``yellow`` for any waste flag
+    (#2215), ``green`` otherwise. Runtimes are derived from the session-id
+    prefix (cf. ``waste_flags.runtime_from_session_id``); openclaw sessions
+    (raw UUIDs) bucket under ``"openclaw"``.
+
+    Daemon-only (uses the writer-owned store handle). Best-effort + bounded
+    so a busy store can't bloat the encrypted snapshot.
+    """
+    try:
+        from clawmetry import local_store as _ls
+        from clawmetry import waste_flags as _wf
+    except Exception:
+        return {"runtimes": []}
+    try:
+        store = _ls.get_store()
+        if store is None:
+            return {"runtimes": []}
+        sessions = store.query_sessions(limit=int(session_limit))
+    except Exception:
+        return {"runtimes": []}
+
+    buckets: dict[str, list] = {}
+    for s in sessions:
+        sid = s.get("session_id")
+        if not sid:
+            continue
+        try:
+            events = store.query_events(session_id=sid, limit=int(events_per_session))
+        except Exception:
+            continue
+        try:
+            signals = _wf.compute_signals_from_events(events)
+            flags = _wf.compute_flags(signals)
+            error_count = sum(1 for e in events if _wf.event_is_real_error(e))
+        except Exception:
+            continue
+        try:
+            cost = float(s.get("cost_usd") or 0.0)
+        except (TypeError, ValueError):
+            cost = 0.0
+        runtime = _wf.runtime_from_session_id(sid)
+        buckets.setdefault(runtime, []).append({
+            "session_id": str(sid),
+            "started_at": s.get("started_at"),
+            "updated_at": s.get("updated_at"),
+            "severity": _wf.severity_from_counts(error_count, len(flags)),
+            "error_count": error_count,
+            "flag_count": len(flags),
+            "flag_types": [f.get("type") for f in flags],
+            "cost_usd": cost,
+        })
+
+    runtimes_out = []
+    for runtime, dots in buckets.items():
+        # most-recent-first within each runtime, then cap so the slice stays
+        # small enough to fit comfortably in the encrypted snapshot.
+        dots.sort(key=lambda d: (d.get("started_at") or ""), reverse=True)
+        runtimes_out.append({"runtime": runtime, "dots": dots[: int(dots_per_runtime)]})
+    # Sort runtimes by their freshest dot so the dashboard shows active ones
+    # first (deterministic for empty buckets via runtime name fallback).
+    runtimes_out.sort(
+        key=lambda r: (
+            (r["dots"][0].get("started_at") if r["dots"] else "") or "",
+            r["runtime"],
+        ),
+        reverse=True,
+    )
+    return {"runtimes": runtimes_out}
+
+
 def _resolve_openclaw_bin():
     """Find the ``openclaw`` binary. The daemon runs under launchd with a
     minimal PATH, so ``shutil.which`` alone often misses Homebrew installs."""
@@ -11228,6 +11304,10 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         # unscoped-result / bloated-context. Sessions without flags are
         # omitted so this slice stays tiny — empty == clean.
         "wasteFlags": _build_waste_flags(),
+        # Per-runtime sparkline of recent runs (#2196 item #4). Each dot is
+        # a session summary; severity = red (real error, post #2202 benign
+        # filter), yellow (waste flag, #2215), green (clean).
+        "healthTimeline": _build_health_timeline(),
     }
 
     # ── NemoClaw / sandbox enrichment ────────────────────────────────────────

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -19,6 +19,16 @@
     </div>
   </div>
 
+  <!-- Per-runtime sparkline of recent runs (#2196 item #4). Severity: red=real
+       error, yellow=waste flag, green=clean. Empty when no runtime has data. -->
+  <div id="health-timeline-card" style="display:none;background:var(--bg-secondary);border:2px solid var(--border-primary);border-radius:12px;padding:14px 22px;margin-bottom:14px;box-shadow:var(--card-shadow);">
+    <div style="display:flex;align-items:baseline;justify-content:space-between;margin-bottom:10px;">
+      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.5px;">&#129488; <span data-i18n="overview.run_health_title">Run health</span></div>
+      <div style="font-size:11px;color:var(--text-muted);" data-i18n="overview.run_health_legend">red = error · yellow = waste · green = clean</div>
+    </div>
+    <div id="health-timeline-body"></div>
+  </div>
+
   <div class="refresh-bar" style="margin-bottom:6px;">
     <button class="refresh-btn" onclick="loadAll()" style="padding:4px 12px;font-size:12px;">↻</button>
     <span class="pulse"></span>

--- a/clawmetry/waste_flags.py
+++ b/clawmetry/waste_flags.py
@@ -252,3 +252,66 @@ def compute_signals_from_events(events: Iterable[dict]) -> dict:
         "cache_read_tokens": cache_read,
         "input_tokens": input_tokens,
     }
+
+
+# ── Health-timeline derivation ────────────────────────────────────────────────
+# Tiny derived primitives shared by the snapshot builder and the dashboard
+# route, so the read path doesn't have to re-derive runtime/severity from
+# scratch.
+
+
+def runtime_from_session_id(session_id: Any) -> str:
+    """Map a session id back to its runtime label.
+
+    Family-runtime sessions are namespaced with a ``<runtime>:`` prefix
+    (``claude_code:``, ``cursor:``, ``goose:``, …); OpenClaw sessions are raw
+    UUIDs without a prefix. Returns ``"openclaw"`` as the default so the
+    timeline always has *some* bucket for a session.
+    """
+    if not isinstance(session_id, str) or not session_id:
+        return "openclaw"
+    head, sep, _ = session_id.partition(":")
+    if not sep or not head:
+        return "openclaw"
+    return head.lower()
+
+
+def severity_from_counts(error_count: Any, flag_count: Any) -> str:
+    """Map (errors, flags) -> a dot colour.
+
+    - ``red``    — at least one real error (post benign-error filtering, #2202).
+    - ``yellow`` — no errors but at least one waste flag (#2215).
+    - ``green``  — clean run.
+    """
+    try:
+        ec = int(error_count or 0)
+    except (TypeError, ValueError):
+        ec = 0
+    try:
+        fc = int(flag_count or 0)
+    except (TypeError, ValueError):
+        fc = 0
+    if ec > 0:
+        return "red"
+    if fc > 0:
+        return "yellow"
+    return "green"
+
+
+def event_is_real_error(event: Any) -> bool:
+    """True when an event row carries the corrected error flag (after #2202).
+
+    Reads ``data.is_error`` / ``data.isError`` and ``data.extra.isError`` — the
+    union of what the snapshot's ``_err()`` predicate checks. Never raises.
+    """
+    if not isinstance(event, dict):
+        return False
+    data = _coerce_data(event.get("data"))
+    if not data:
+        return False
+    if data.get("is_error") or data.get("isError"):
+        return True
+    extra = data.get("extra") if isinstance(data.get("extra"), dict) else {}
+    if extra.get("isError") or extra.get("is_error"):
+        return True
+    return False

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -1470,6 +1470,110 @@ def _try_local_store_prompt_errors(since_iso):
     return {"errors": errors, "count": len(errors), "_source": "local_store"}
 
 
+# ── Health timeline (#2196 item #4) ──────────────────────────────────────────
+# 30s cache: a dashboard widget polls this; recomputing it iterates events
+# across ~60 sessions, which is cheap but not free.
+
+_HEALTH_TIMELINE_CACHE_TTL = 30.0
+_health_timeline_cache: dict = {"ts": 0.0, "value": None}
+_health_timeline_cache_lock = threading.Lock()
+
+
+@bp_overview.route("/api/health-timeline")
+def api_health_timeline():
+    """Per-runtime sparkline of recent sessions, severity by health (#2196 item #4).
+
+    Each "dot" summarises one session: severity is ``red`` for any real
+    error (post #2202 benign-error filtering), ``yellow`` for any waste flag
+    (#2215), ``green`` otherwise. Runtimes come from the session-id prefix
+    (cf. ``waste_flags.runtime_from_session_id``). Same shape as the cloud
+    snapshot's ``healthTimeline`` slice.
+
+    Query params:
+
+    - ``session_limit`` (default 60, clamped 1-200) — newest sessions to scan
+    - ``events_per_session`` (default 500, clamped 1-500)
+    - ``dots_per_runtime``  (default 30, clamped 1-200)
+    """
+    try:
+        from clawmetry import waste_flags as _wf
+        from routes.local_query import local_store_via_daemon
+    except Exception as exc:
+        return jsonify({"runtimes": [], "error": f"unavailable: {exc}"}), 503
+
+    session_limit = max(1, min(int(request.args.get("session_limit") or 60), 200))
+    events_per_session = max(1, min(int(request.args.get("events_per_session") or 500), 500))
+    dots_per_runtime = max(1, min(int(request.args.get("dots_per_runtime") or 30), 200))
+
+    cache_key = (session_limit, events_per_session, dots_per_runtime)
+    with _health_timeline_cache_lock:
+        cached = _health_timeline_cache.get("value")
+        cached_key = _health_timeline_cache.get("key")
+        if (
+            cached is not None
+            and cached_key == cache_key
+            and (_time.time() - _health_timeline_cache["ts"]) < _HEALTH_TIMELINE_CACHE_TTL
+        ):
+            return jsonify(cached)
+
+    try:
+        sessions = local_store_via_daemon("query_sessions", limit=session_limit) or []
+    except Exception as exc:
+        return jsonify({"runtimes": [], "error": f"sessions unavailable: {exc}"}), 503
+
+    buckets: dict = {}
+    for s in sessions:
+        sid = s.get("session_id")
+        if not sid:
+            continue
+        try:
+            events = local_store_via_daemon(
+                "query_events", session_id=sid, limit=events_per_session,
+            ) or []
+        except Exception:
+            continue
+        try:
+            signals = _wf.compute_signals_from_events(events)
+            flags = _wf.compute_flags(signals)
+            error_count = sum(1 for e in events if _wf.event_is_real_error(e))
+        except Exception:
+            continue
+        try:
+            cost = float(s.get("cost_usd") or 0.0)
+        except (TypeError, ValueError):
+            cost = 0.0
+        runtime = _wf.runtime_from_session_id(sid)
+        buckets.setdefault(runtime, []).append({
+            "session_id": str(sid),
+            "started_at": s.get("started_at"),
+            "updated_at": s.get("updated_at"),
+            "severity": _wf.severity_from_counts(error_count, len(flags)),
+            "error_count": error_count,
+            "flag_count": len(flags),
+            "flag_types": [f.get("type") for f in flags],
+            "cost_usd": cost,
+        })
+
+    runtimes_out = []
+    for runtime, dots in buckets.items():
+        dots.sort(key=lambda d: (d.get("started_at") or ""), reverse=True)
+        runtimes_out.append({"runtime": runtime, "dots": dots[:dots_per_runtime]})
+    runtimes_out.sort(
+        key=lambda r: (
+            (r["dots"][0].get("started_at") if r["dots"] else "") or "",
+            r["runtime"],
+        ),
+        reverse=True,
+    )
+
+    payload = {"runtimes": runtimes_out, "generated_at": _time.time()}
+    with _health_timeline_cache_lock:
+        _health_timeline_cache["ts"] = _time.time()
+        _health_timeline_cache["key"] = cache_key
+        _health_timeline_cache["value"] = payload
+    return jsonify(payload)
+
+
 @bp_overview.route("/api/prompt-errors")
 def api_prompt_errors():
     """Return recent openclaw:prompt-error events from session JSONL files.

--- a/tests/test_waste_flags.py
+++ b/tests/test_waste_flags.py
@@ -173,5 +173,117 @@ def test_build_waste_flags_in_snapshot(tmp_path, monkeypatch):
         store.stop(flush=True)
 
 
+# ── Health-timeline helpers + snapshot builder (#2196 item #4) ──────────────
+
+
+def test_runtime_from_session_id():
+    importlib.reload(wf)
+    assert wf.runtime_from_session_id("claude_code:abc-def") == "claude_code"
+    assert wf.runtime_from_session_id("Cursor:xyz") == "cursor"  # lower-cased
+    # OpenClaw sessions are bare UUIDs -> default bucket
+    assert wf.runtime_from_session_id("12345678-1234-1234-1234-1234567890ab") == "openclaw"
+    # garbage in -> default bucket, never raises
+    assert wf.runtime_from_session_id(None) == "openclaw"
+    assert wf.runtime_from_session_id("") == "openclaw"
+    assert wf.runtime_from_session_id(":no-head") == "openclaw"
+
+
+def test_severity_from_counts():
+    importlib.reload(wf)
+    assert wf.severity_from_counts(0, 0) == "green"
+    assert wf.severity_from_counts(0, 3) == "yellow"
+    assert wf.severity_from_counts(1, 0) == "red"
+    assert wf.severity_from_counts(2, 5) == "red"  # error wins
+    # garbage-safe
+    assert wf.severity_from_counts(None, "bad") == "green"
+
+
+def test_event_is_real_error_reads_corrected_flag():
+    importlib.reload(wf)
+    # Anthropic / v3 shape: top-level is_error
+    assert wf.event_is_real_error({"data": {"is_error": True}})
+    # Claude Code shape: nested in extra
+    assert wf.event_is_real_error({"data": {"extra": {"isError": True}}})
+    # Stored data may be encoded as JSON bytes
+    assert wf.event_is_real_error({"data": json.dumps({"is_error": True}).encode("utf-8")})
+    # Cleared (corrected) flag -> not an error
+    assert not wf.event_is_real_error({"data": {"is_error": False, "benign_error": True}})
+    # Garbage / no data -> not an error, no exception
+    assert not wf.event_is_real_error({})
+    assert not wf.event_is_real_error(None)
+    assert not wf.event_is_real_error({"data": "not json"})
+
+
+def test_build_health_timeline_bucketed_by_runtime(tmp_path, monkeypatch):
+    """End-to-end snapshot builder: real + clean + flagged sessions across two
+    runtimes; assert dots land in the right bucket with the right severity."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "ev.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "2")
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    store = ls.get_store()
+
+    # Claude Code session — one tool_call (clean) + one real tool error
+    store.ingest({
+        "id": "cc:1", "node_id": "n", "agent_id": "main",
+        "session_id": "claude_code:sess-red",
+        "event_type": "tool_call", "ts": "2026-05-28T10:00:00Z",
+        "data": {"name": "Bash"}, "cost_usd": None, "token_count": 0,
+        "model": None,
+    })
+    store.ingest({
+        "id": "cc:2", "node_id": "n", "agent_id": "main",
+        "session_id": "claude_code:sess-red",
+        "event_type": "tool_result", "ts": "2026-05-28T10:00:01Z",
+        "data": {"role": "tool", "_runtime": "claude_code",
+                 "content": "Exit code 1\nTraceback ...",
+                 "extra": {"isError": True}},
+        "cost_usd": None, "token_count": 0, "model": None,
+    })
+    # OpenClaw session — runaway (35 tool_call events), no errors
+    for i in range(35):
+        store.ingest({
+            "id": f"oc:{i}", "node_id": "n", "agent_id": "main",
+            "session_id": "11111111-2222-3333-4444-555555555555",
+            "event_type": "tool_call", "ts": f"2026-05-28T11:00:{i:02d}Z",
+            "data": {"name": "Bash"}, "cost_usd": None, "token_count": 0,
+            "model": None,
+        })
+    # Goose session — clean
+    store.ingest({
+        "id": "g:1", "node_id": "n", "agent_id": "main",
+        "session_id": "goose:happy", "event_type": "tool_call",
+        "ts": "2026-05-28T12:00:00Z", "data": {"name": "Read"},
+        "cost_usd": None, "token_count": 0, "model": None,
+    })
+
+    import time as _t
+    end = _t.monotonic() + 3
+    while _t.monotonic() < end and store.health()["ring_depth"] > 0:
+        _t.sleep(0.02)
+
+    try:
+        from clawmetry import sync as syncmod
+        out = syncmod._build_health_timeline()
+        runtimes = {r["runtime"]: r["dots"] for r in out.get("runtimes", [])}
+        # All three runtimes represented
+        assert {"claude_code", "openclaw", "goose"}.issubset(set(runtimes.keys())), \
+            f"runtimes={list(runtimes.keys())}"
+        # Severity per session
+        cc_dot = next(d for d in runtimes["claude_code"] if "sess-red" in d["session_id"])
+        assert cc_dot["severity"] == "red", cc_dot
+        oc_dot = next(d for d in runtimes["openclaw"]
+                       if d["session_id"].startswith("11111111"))
+        assert oc_dot["severity"] == "yellow", oc_dot
+        assert oc_dot["flag_count"] >= 1 and "runaway" in oc_dot["flag_types"]
+        g_dot = next(d for d in runtimes["goose"] if d["session_id"] == "goose:happy")
+        assert g_dot["severity"] == "green", g_dot
+    finally:
+        store.stop(flush=True)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Implements item #4 of #2196 — a per-runtime **health timeline** sparkline of recent sessions on the Overview tab. Each dot summarises one session; severity:

- **red** — at least one real error (post #2202 benign-error filtering)
- **yellow** — at least one waste flag (#2215)
- **green** — clean run

Hovering a dot shows time, error/flag count, and cost.

## Approach

Three layers, all reusing primitives from #2202 + #2215:

- **Helpers in `clawmetry/waste_flags.py`** — `runtime_from_session_id` (session-id prefix → runtime label), `severity_from_counts(errors, flags)`, `event_is_real_error` (reads the corrected stored flag).
- **Snapshot slice** — `sync.py._build_health_timeline()` walks recent sessions on the daemon's own store handle, buckets by runtime, sorts most-recent-first and caps to 30 dots per runtime. Shipped as a new top-level `healthTimeline` key. Cloud renders directly from this slice client-side.
- **Local dashboard** — `/api/health-timeline` route (30 s cache) returns the same shape from a fresh DuckDB read via the daemon proxy; `overview.html` gets a tiny `health-timeline-card` and `app.js` renders the dot strips, hiding the card when no runtime has any dots.

## Verification

- `tests/test_waste_flags.py` — 13 tests including a cross-runtime integration test that ingests claude_code + openclaw + goose sessions (real error / runaway / clean) into a temp DuckDB and asserts each lands in the correct runtime bucket with the correct severity. All green.
- New module ruff-clean; my edits add **zero** new ruff errors vs `origin/main`.
- **Live E2E** (decrypt the live cloud snapshot for `healthTimeline`):
  - 5 runtimes represented (`claude_code`: 30 dots, `openclaw`: 2, `qwen_code`: 2, `opencode`: 3, `goose`: 3).
  - Severity mix: 10 red / 1 yellow / 29 green.
  - Sample dot carries `severity`, `error_count`, `flag_count`, `flag_types`, `cost_usd`, `started_at`, `updated_at` — exactly the shape the UI consumes.

## Cloud

Daemon-side change. The cloud inherits the snapshot slice with no cloud code change required (just a pin bump once released). The local dashboard route + UI are also OSS-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
