### PR TITLE
feat(run-compare): /api/run-compare endpoint (#2196 item #2) [stacked on #2225]

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -6477,3 +6477,137 @@ def api_session_intent_divergence(session_id):
     result = _detect_intent_divergence(path)
     result["sessionId"] = session_id
     return jsonify(result)
+
+
+# ── Per-run A/B compare (#2196 item #2) ───────────────────────────────────────
+# Pick two runs, get the side-by-side stats + signed deltas. Stats are
+# computed from the same primitives the snapshot uses (#2215 waste-flags
+# signals + #2202 corrected error flag), so a Compare view reads the same
+# truth the Overview health timeline + cost numbers do.
+
+_RUN_COMPARE_LOWER_BETTER = (
+    "cost_usd",
+    "total_tokens",
+    "step_count",
+    "max_event_token_count",
+    "max_tool_result_bytes",
+    "error_count",
+    "flag_count",
+)
+_RUN_COMPARE_HIGHER_BETTER = ("cache_hit_rate",)
+
+
+def _run_compare_stats(sid):
+    """Compute the per-session stats panel used by /api/run-compare. Returns a
+    dict (with ``missing: True`` when the session id has no events / summary)."""
+    from clawmetry import waste_flags as _wf
+    from routes.local_query import local_store_via_daemon
+
+    # Session summary: best-effort lookup in a bounded recent window.
+    try:
+        sessions = local_store_via_daemon("query_sessions", limit=500) or []
+    except Exception:
+        sessions = []
+    meta = next((s for s in sessions if s.get("session_id") == sid), None)
+
+    try:
+        events = local_store_via_daemon("query_events", session_id=sid, limit=500) or []
+    except Exception:
+        events = []
+
+    signals = _wf.compute_signals_from_events(events)
+    flags = _wf.compute_flags(signals)
+    error_count = sum(1 for e in events if _wf.event_is_real_error(e))
+
+    cache_read = int(signals.get("cache_read_tokens") or 0)
+    input_tokens = int(signals.get("input_tokens") or 0)
+    cache_total = cache_read + input_tokens
+    cache_hit_rate = (cache_read / cache_total) if cache_total > 0 else None
+
+    try:
+        cost_usd = float((meta or {}).get("cost_usd") or 0.0)
+    except (TypeError, ValueError):
+        cost_usd = 0.0
+    try:
+        total_tokens = int((meta or {}).get("token_count") or 0)
+    except (TypeError, ValueError):
+        total_tokens = 0
+
+    return {
+        "session_id": sid,
+        "runtime": _wf.runtime_from_session_id(sid),
+        "started_at": (meta or {}).get("started_at"),
+        "updated_at": (meta or {}).get("updated_at"),
+        "cost_usd": cost_usd,
+        "total_tokens": total_tokens,
+        "message_count": int((meta or {}).get("message_count") or 0),
+        "event_count": int((meta or {}).get("event_count") or 0),
+        "step_count": int(signals.get("step_count") or 0),
+        "max_event_token_count": int(signals.get("max_event_token_count") or 0),
+        "max_tool_result_bytes": int(signals.get("max_tool_result_bytes") or 0),
+        "cache_read_tokens": cache_read,
+        "input_tokens": input_tokens,
+        "cache_hit_rate": cache_hit_rate,
+        "error_count": error_count,
+        "flag_count": len(flags),
+        "flags": flags,
+        "severity": _wf.severity_from_counts(error_count, len(flags)),
+        "missing": meta is None and not events,
+    }
+
+
+def _run_compare_deltas(a, b):
+    """Signed deltas for every numeric metric in both stats panels. Each entry
+    carries ``favorable`` so the UI can colour improvements green and
+    regressions red without re-applying the rule."""
+    out = {}
+    for key in (_RUN_COMPARE_LOWER_BETTER + _RUN_COMPARE_HIGHER_BETTER):
+        va = a.get(key)
+        vb = b.get(key)
+        if va is None or vb is None:
+            continue
+        try:
+            absd = vb - va
+        except TypeError:
+            continue
+        # percent change relative to A; None when A is zero (avoid /0).
+        pct = (absd / va * 100.0) if va not in (0, 0.0) else None
+        if key in _RUN_COMPARE_LOWER_BETTER:
+            favorable = absd < 0  # decreased -> improvement
+        else:
+            favorable = absd > 0
+        out[key] = {
+            "a": va, "b": vb, "abs": absd, "pct": pct,
+            "favorable": favorable, "favorable_lower": key in _RUN_COMPARE_LOWER_BETTER,
+        }
+    return out
+
+
+@bp_sessions.route("/api/run-compare")
+def api_run_compare():
+    """Side-by-side stats + signed deltas for two runs (#2196 item #2).
+
+    Query params:
+
+    - ``a`` (required) — session id of the baseline run
+    - ``b`` (required) — session id of the candidate run
+
+    Stats per side: cost, tokens, step count, context, cache hit, errors,
+    waste flags, severity. Each numeric metric appears in ``deltas`` with
+    ``abs``, ``pct`` (None when A is zero), and ``favorable`` (lower-is-better
+    for cost/steps/errors/flags/etc.; higher-is-better for cache hit). The UI
+    colours improvements green, regressions red, off this flag.
+    """
+    a = (request.args.get("a") or "").strip()
+    b = (request.args.get("b") or "").strip()
+    if not a or not b:
+        return jsonify({"error": "missing 'a' or 'b' query parameter"}), 400
+    if a == b:
+        return jsonify({"error": "'a' and 'b' must be different session ids"}), 400
+    stats_a = _run_compare_stats(a)
+    stats_b = _run_compare_stats(b)
+    return jsonify({
+        "a": stats_a,
+        "b": stats_b,
+        "deltas": _run_compare_deltas(stats_a, stats_b),
+    })

--- a/tests/test_run_compare.py
+++ b/tests/test_run_compare.py
@@ -1,0 +1,173 @@
+"""Per-run A/B compare with deltas (#2196 item #2)."""
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+
+
+def _store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "ev.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "2")
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    return ls, ls.get_store()
+
+
+def _wait_flush(store, t=3.0):
+    end = time.monotonic() + t
+    while time.monotonic() < end and store.health()["ring_depth"] > 0:
+        time.sleep(0.02)
+
+
+def _patch_daemon_proxy(monkeypatch, store):
+    """Make routes.local_query.local_store_via_daemon read straight from the
+    in-process store, so the route handler runs end-to-end without needing the
+    real daemon HTTP server."""
+    import routes.sessions as sessions_mod
+
+    def fake_proxy(method, **kwargs):
+        fn = getattr(store, method)
+        return fn(**kwargs)
+
+    # The route imports lazily inside the function — patch the module it pulls
+    # from so both call sites resolve to our fake.
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon", fake_proxy, raising=False,
+    )
+    return sessions_mod
+
+
+def test_run_compare_stats_basic(tmp_path, monkeypatch):
+    ls, store = _store(tmp_path, monkeypatch)
+    try:
+        # Baseline run "a": 3 tool calls, no errors, no flags (clean).
+        for i in range(3):
+            store.ingest({
+                "id": f"a:{i}", "node_id": "n", "agent_id": "main",
+                "session_id": "claude_code:run-a",
+                "event_type": "tool_call",
+                "ts": f"2026-05-28T10:00:{i:02d}Z",
+                "data": {"name": "Read"},
+                "cost_usd": 0.10, "token_count": 100, "model": None,
+            })
+        # Candidate run "b": 35 tool calls (runaway) + a real error.
+        for i in range(35):
+            store.ingest({
+                "id": f"b:{i}", "node_id": "n", "agent_id": "main",
+                "session_id": "claude_code:run-b",
+                "event_type": "tool_call",
+                "ts": f"2026-05-28T11:00:{i:02d}Z",
+                "data": {"name": "Bash"},
+                "cost_usd": 0.10, "token_count": 100, "model": None,
+            })
+        store.ingest({
+            "id": "b:result-err", "node_id": "n", "agent_id": "main",
+            "session_id": "claude_code:run-b",
+            "event_type": "tool_result",
+            "ts": "2026-05-28T11:01:00Z",
+            "data": {"role": "tool", "_runtime": "claude_code",
+                     "content": "Exit code 1\nTraceback ...",
+                     "extra": {"isError": True}},
+            "cost_usd": 0.0, "token_count": 0, "model": None,
+        })
+        _wait_flush(store)
+
+        sessions_mod = _patch_daemon_proxy(monkeypatch, store)
+        a = sessions_mod._run_compare_stats("claude_code:run-a")
+        b = sessions_mod._run_compare_stats("claude_code:run-b")
+
+        # Baseline: clean (3 steps, no errors, no flags).
+        assert a["runtime"] == "claude_code"
+        assert a["step_count"] == 3
+        assert a["error_count"] == 0
+        assert a["flag_count"] == 0
+        assert a["severity"] == "green"
+        assert a["missing"] is False
+        # Candidate: runaway flag + 1 real error.
+        assert b["step_count"] == 35
+        assert b["error_count"] == 1
+        assert any(f["type"] == "runaway" for f in b["flags"])
+        assert b["severity"] == "red"
+
+        deltas = sessions_mod._run_compare_deltas(a, b)
+        # Step count went up — that's a regression (favorable=False for
+        # lower-is-better metrics).
+        assert deltas["step_count"]["abs"] == 32
+        assert deltas["step_count"]["favorable"] is False
+        # Error count went up too.
+        assert deltas["error_count"]["a"] == 0
+        assert deltas["error_count"]["b"] == 1
+        assert deltas["error_count"]["favorable"] is False
+        # When A is zero, pct is None (no /0).
+        assert deltas["error_count"]["pct"] is None
+    finally:
+        store.stop(flush=True)
+
+
+def _client_with_route():
+    """Mount bp_sessions on a fresh Flask app — dashboard.py only registers
+    blueprints inside main(), so plain ``import dashboard`` leaves them off.
+    This mirrors the pattern in tests/test_channels_local_store.py."""
+    from flask import Flask
+    import routes.sessions as sessions_mod
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    return a.test_client()
+
+
+def test_run_compare_route_missing_params():
+    """The HTTP route returns a clean 400 when either id is missing or both
+    refer to the same session — sanity test for the API contract."""
+    client = _client_with_route()
+    resp = client.get("/api/run-compare?a=x")
+    assert resp.status_code == 400, resp.get_data(as_text=True)
+
+    resp = client.get("/api/run-compare?a=same&b=same")
+    assert resp.status_code == 400
+
+
+def test_run_compare_route_end_to_end(tmp_path, monkeypatch):
+    ls, store = _store(tmp_path, monkeypatch)
+    try:
+        # Two clean sessions, different cost.
+        store.ingest({
+            "id": "cheap:1", "node_id": "n", "agent_id": "main",
+            "session_id": "openclaw-cheap", "event_type": "tool_call",
+            "ts": "2026-05-28T08:00:00Z", "data": {"name": "Read"},
+            "cost_usd": 0.05, "token_count": 100, "model": None,
+        })
+        store.ingest({
+            "id": "spendy:1", "node_id": "n", "agent_id": "main",
+            "session_id": "openclaw-spendy", "event_type": "tool_call",
+            "ts": "2026-05-28T09:00:00Z", "data": {"name": "Read"},
+            # cost up, but under the bloated-context token threshold so the
+            # severity stays green — we're only asserting the cost delta here.
+            "cost_usd": 5.00, "token_count": 1_000, "model": None,
+        })
+        _wait_flush(store)
+
+        _patch_daemon_proxy(monkeypatch, store)
+        client = _client_with_route()
+        resp = client.get(
+            "/api/run-compare?a=openclaw-cheap&b=openclaw-spendy"
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        body = resp.get_json()
+        assert body["a"]["session_id"] == "openclaw-cheap"
+        assert body["b"]["session_id"] == "openclaw-spendy"
+        # B is more expensive -> regression on cost.
+        assert body["deltas"]["cost_usd"]["abs"] > 4.0
+        assert body["deltas"]["cost_usd"]["favorable"] is False
+        # Both clean -> green severity.
+        assert body["a"]["severity"] == body["b"]["severity"] == "green"
+    finally:
+        store.stop(flush=True)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Implements item #2 of #2196 — **per-run A/B compare** with side-by-side stats and signed deltas:

- `cost_usd`, `total_tokens`, `message_count`, `event_count`
- `step_count`, `max_event_token_count`, `max_tool_result_bytes`
- `cache_read_tokens`, `input_tokens`, `cache_hit_rate`
- `error_count`, `flag_count`, `flags`, `severity`

Stats are computed from the same primitives the snapshot uses — #2202 corrected error flag + #2215 waste-flag signals — so a Compare view reads the same truth the Overview health timeline + cost numbers do.

**Stacked on #2225** (per-agent health timeline) — uses the helpers `event_is_real_error`, `runtime_from_session_id`, `severity_from_counts` added there. Will rebase the base to `main` once #2225 lands.

## API

```
GET /api/run-compare?a=<session_id>&b=<session_id>
```

Returns `{a: stats, b: stats, deltas}`. Each delta carries `abs`, `pct` (None when A is zero — no /0), and `favorable` (lower-is-better for cost/steps/errors/flags; higher-is-better for cache hit). 400 on missing/equal ids.

The UI consumer (Compare modal) ships in a follow-up — this PR is the data primitive.

## Verification

- `tests/test_run_compare.py` — 3 tests: helper-level (baseline vs runaway-with-error → correct delta direction + favorable), HTTP error contract (missing/equal params → 400), and an end-to-end test that builds a Flask app, registers `bp_sessions`, ingests two synthetic sessions into a temp DuckDB, and asserts the response shape + delta direction. All green.
- Daemon-side primitive only (the route reads via the proxy); no cloud code change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
