### PR TITLE
feat(error-triage): mark known/expected errors as resolved (#2196 item #5)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -840,6 +840,17 @@ _DDL = [
         updated_at  BIGINT NOT NULL
     )
     """,
+    # Issue #2196 item #5 — per-event "resolved" markers. Lets a user mute a
+    # known/expected error so it stops inflating counts on Tracing / Health /
+    # the run-compare deltas. Keyed by event_id (the unique error-bearing
+    # tool_result row id) so the relation joins cleanly back to events.
+    """
+    CREATE TABLE IF NOT EXISTS resolved_errors (
+        event_id     VARCHAR PRIMARY KEY,
+        resolved_at  BIGINT NOT NULL,
+        note         VARCHAR
+    )
+    """,
 ]
 
 
@@ -4186,6 +4197,75 @@ class LocalStore:
             except Exception:
                 return (max_id, 0, len(rows))
         return (max_id, len(updates), len(rows))
+
+    # ── Error triage (#2196 item #5) ────────────────────────────────────────
+    # Mark a known/expected error as resolved so it stops inflating counts.
+    # Idempotent — re-marking refreshes the timestamp + note; un-marking is a
+    # plain DELETE. Reads go through ``query_resolved_errors`` (returns a
+    # dict for cheap membership checks).
+
+    def mark_error_resolved(self, event_id: str, note: str | None = None) -> bool:
+        """Mark ``event_id`` as resolved. Returns True if a row was written,
+        False on bad input or write failure. Idempotent: re-marking the same
+        event refreshes its timestamp + note."""
+        if not isinstance(event_id, str) or not event_id.strip():
+            return False
+        eid = event_id.strip()
+        now_ms = int(time.time() * 1000)
+        n = None if note is None else str(note)[:1000]
+        try:
+            self._conn.execute(
+                "INSERT INTO resolved_errors (event_id, resolved_at, note) "
+                "VALUES (?, ?, ?) "
+                "ON CONFLICT (event_id) DO UPDATE SET "
+                "  resolved_at = excluded.resolved_at, note = excluded.note",
+                [eid, now_ms, n],
+            )
+            return True
+        except Exception:
+            return False
+
+    def unmark_error_resolved(self, event_id: str) -> bool:
+        """Remove the resolved marker for ``event_id``. Returns True if a row
+        was deleted, False if it didn't exist or on write failure.
+
+        DuckDB's Python binding returns -1 from ``cursor.rowcount`` for DELETE,
+        so the existence check has to be a pre-delete SELECT — there's no way
+        to recover it from the deletion call itself."""
+        if not isinstance(event_id, str) or not event_id.strip():
+            return False
+        eid = event_id.strip()
+        try:
+            row = self._conn.execute(
+                "SELECT 1 FROM resolved_errors WHERE event_id = ?", [eid],
+            ).fetchone()
+            existed = row is not None
+            if existed:
+                self._conn.execute(
+                    "DELETE FROM resolved_errors WHERE event_id = ?", [eid],
+                )
+            return existed
+        except Exception:
+            return False
+
+    def query_resolved_errors(self, *, limit: int = 5000) -> dict[str, dict]:
+        """Return ``{event_id: {resolved_at, note}}`` for all current resolved
+        markers (most-recent-first up to ``limit``). Map shape keeps consumer
+        membership checks O(1)."""
+        try:
+            rows = self._conn.execute(
+                "SELECT event_id, resolved_at, note FROM resolved_errors "
+                "ORDER BY resolved_at DESC LIMIT ?",
+                [int(limit)],
+            ).fetchall()
+        except Exception:
+            return {}
+        out: dict[str, dict] = {}
+        for (eid, ts_ms, note) in rows:
+            if not eid:
+                continue
+            out[str(eid)] = {"resolved_at": int(ts_ms or 0), "note": note}
+        return out
 
     def query_events_with_subagents(
         self,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9247,6 +9247,23 @@ def _build_health_timeline(session_limit: int = 60, events_per_session: int = 50
     return {"runtimes": runtimes_out}
 
 
+def _build_resolved_errors(limit: int = 5000):
+    """Per-event resolved-error markers (#2196 item #5).
+
+    Returns ``{event_id: {resolved_at, note}}`` for every entry currently in
+    the ``resolved_errors`` table. Built on the daemon's own store handle.
+    Best-effort; an empty map is returned on any failure or when the table is
+    empty (== nothing resolved)."""
+    try:
+        from clawmetry import local_store as _ls
+        store = _ls.get_store()
+        if store is None:
+            return {}
+        return store.query_resolved_errors(limit=int(limit)) or {}
+    except Exception:
+        return {}
+
+
 def _resolve_openclaw_bin():
     """Find the ``openclaw`` binary. The daemon runs under launchd with a
     minimal PATH, so ``shutil.which`` alone often misses Homebrew installs."""
@@ -11308,6 +11325,10 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         # a session summary; severity = red (real error, post #2202 benign
         # filter), yellow (waste flag, #2215), green (clean).
         "healthTimeline": _build_health_timeline(),
+        # Per-event resolved-error markers (#2196 item #5). UIs render the
+        # corresponding rows in a muted state and may exclude them from
+        # error counts. Map keyed by event_id; empty == nothing resolved.
+        "resolvedErrors": _build_resolved_errors(),
     }
 
     # ── NemoClaw / sandbox enrichment ────────────────────────────────────────

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -541,6 +541,13 @@ _DAEMON_METHODS = frozenset({
     # this entry the proxy returns None and the CLI crashed on
     # `result["status"]`. Read-only walk over the events table.
     "verify_integrity",
+    # Issue #2196 item #5 — per-event resolved-error triage. Writes need the
+    # daemon's writer connection; the read returns a {event_id: {...}} map
+    # used by /api/error-triage/resolved + future "exclude resolved from
+    # error counts" filtering.
+    "mark_error_resolved",
+    "unmark_error_resolved",
+    "query_resolved_errors",
 })
 
 

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -6611,3 +6611,84 @@ def api_run_compare():
         "b": stats_b,
         "deltas": _run_compare_deltas(stats_a, stats_b),
     })
+
+
+# ── Error triage: mark known/expected errors as resolved (#2196 item #5) ─────
+# Persists the resolved-set in DuckDB (the source-tool kept it in localStorage,
+# which would not survive our E2E-encrypted cloud model). Each entry is keyed
+# by the unique event_id of the error-bearing tool_result row so the relation
+# joins cleanly back to ``events``.
+
+def _err_triage_event_id():
+    """Pull ``event_id`` from JSON body or query string. Returns "" on miss."""
+    if request.method == "POST":
+        body = request.get_json(silent=True) or {}
+        eid = body.get("event_id") or body.get("eventId")
+    else:
+        eid = request.args.get("event_id") or request.args.get("eventId")
+    return (eid or "").strip() if isinstance(eid, str) else ""
+
+
+@bp_sessions.route("/api/error-triage/resolve", methods=["POST"])
+def api_error_triage_resolve():
+    """Mark an error as resolved (idempotent — re-POST refreshes the note).
+
+    Body: ``{"event_id": "<id>", "note": "<optional>"}``. Returns
+    ``{"ok": true, "event_id": ...}`` on success.
+    """
+    from routes.local_query import local_store_via_daemon
+
+    eid = _err_triage_event_id()
+    if not eid:
+        return jsonify({"ok": False, "error": "missing event_id"}), 400
+    body = request.get_json(silent=True) or {}
+    note = body.get("note")
+    if note is not None and not isinstance(note, str):
+        return jsonify({"ok": False, "error": "note must be a string"}), 400
+    try:
+        ok = bool(local_store_via_daemon("mark_error_resolved", event_id=eid, note=note))
+    except Exception as exc:
+        return jsonify({"ok": False, "error": f"daemon unavailable: {exc}"}), 503
+    if not ok:
+        return jsonify({"ok": False, "error": "write failed"}), 500
+    return jsonify({"ok": True, "event_id": eid})
+
+
+@bp_sessions.route("/api/error-triage/resolve", methods=["DELETE"])
+def api_error_triage_unresolve():
+    """Remove the resolved marker for an error.
+
+    Query: ``?event_id=<id>``. ``{"ok": true, "removed": bool}`` on success;
+    ``removed`` is False when the id had no marker (idempotent).
+    """
+    from routes.local_query import local_store_via_daemon
+
+    eid = _err_triage_event_id()
+    if not eid:
+        return jsonify({"ok": False, "error": "missing event_id"}), 400
+    try:
+        removed = bool(local_store_via_daemon("unmark_error_resolved", event_id=eid))
+    except Exception as exc:
+        return jsonify({"ok": False, "error": f"daemon unavailable: {exc}"}), 503
+    return jsonify({"ok": True, "removed": removed, "event_id": eid})
+
+
+@bp_sessions.route("/api/error-triage/resolved")
+def api_error_triage_resolved():
+    """Return the current resolved-set as ``{event_id: {resolved_at, note}}``.
+
+    Query: ``?limit=<N>`` (default 5000, clamped 1-5000).
+    """
+    from routes.local_query import local_store_via_daemon
+
+    try:
+        limit = max(1, min(int(request.args.get("limit") or 5000), 5000))
+    except (TypeError, ValueError):
+        limit = 5000
+    try:
+        out = local_store_via_daemon("query_resolved_errors", limit=limit) or {}
+    except Exception as exc:
+        return jsonify({"resolved": {}, "error": f"daemon unavailable: {exc}"}), 503
+    if not isinstance(out, dict):
+        out = {}
+    return jsonify({"resolved": out, "count": len(out)})

--- a/tests/test_error_triage.py
+++ b/tests/test_error_triage.py
@@ -1,0 +1,152 @@
+"""Per-event resolved-error triage (#2196 item #5)."""
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+
+
+def _store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "ev.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "2")
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    return ls, ls.get_store()
+
+
+def _patch_daemon_proxy(monkeypatch, store):
+    def fake(method, **kwargs):
+        return getattr(store, method)(**kwargs)
+    monkeypatch.setattr(
+        "routes.local_query.local_store_via_daemon", fake, raising=False,
+    )
+
+
+def _client_with_route():
+    from flask import Flask
+    import routes.sessions as sessions_mod
+    a = Flask(__name__)
+    a.register_blueprint(sessions_mod.bp_sessions)
+    return a.test_client()
+
+
+# ── store layer ────────────────────────────────────────────────────────────
+
+def test_mark_and_query_roundtrip(tmp_path, monkeypatch):
+    _, store = _store(tmp_path, monkeypatch)
+    try:
+        assert store.mark_error_resolved("ev:abc", note="known flaky test") is True
+        assert store.mark_error_resolved("ev:def") is True
+        m = store.query_resolved_errors()
+        assert "ev:abc" in m and "ev:def" in m
+        assert m["ev:abc"]["note"] == "known flaky test"
+        assert m["ev:def"]["note"] is None
+        assert m["ev:abc"]["resolved_at"] > 0
+    finally:
+        store.stop(flush=True)
+
+
+def test_mark_is_idempotent_and_refreshes_note(tmp_path, monkeypatch):
+    _, store = _store(tmp_path, monkeypatch)
+    try:
+        store.mark_error_resolved("ev:1", note="first")
+        first_ts = store.query_resolved_errors()["ev:1"]["resolved_at"]
+        time.sleep(0.01)
+        store.mark_error_resolved("ev:1", note="second")
+        m = store.query_resolved_errors()
+        assert m["ev:1"]["note"] == "second"
+        assert m["ev:1"]["resolved_at"] >= first_ts  # refreshed (or equal-on-fast-clock)
+    finally:
+        store.stop(flush=True)
+
+
+def test_unmark_removes_row(tmp_path, monkeypatch):
+    _, store = _store(tmp_path, monkeypatch)
+    try:
+        store.mark_error_resolved("ev:x")
+        assert "ev:x" in store.query_resolved_errors()
+        assert store.unmark_error_resolved("ev:x") is True
+        assert "ev:x" not in store.query_resolved_errors()
+        # idempotent: removing a non-existent key returns False rather than raising
+        assert store.unmark_error_resolved("ev:not-there") is False
+    finally:
+        store.stop(flush=True)
+
+
+def test_bad_input_never_raises(tmp_path, monkeypatch):
+    _, store = _store(tmp_path, monkeypatch)
+    try:
+        assert store.mark_error_resolved("") is False
+        assert store.mark_error_resolved(None) is False  # type: ignore[arg-type]
+        assert store.unmark_error_resolved("") is False
+        assert store.unmark_error_resolved(None) is False  # type: ignore[arg-type]
+        assert store.query_resolved_errors() == {}
+    finally:
+        store.stop(flush=True)
+
+
+# ── route layer ─────────────────────────────────────────────────────────────
+
+
+def test_routes_full_lifecycle(tmp_path, monkeypatch):
+    _, store = _store(tmp_path, monkeypatch)
+    try:
+        _patch_daemon_proxy(monkeypatch, store)
+        client = _client_with_route()
+
+        # Empty to start
+        body = client.get("/api/error-triage/resolved").get_json()
+        assert body == {"resolved": {}, "count": 0}
+
+        # POST resolves
+        r = client.post(
+            "/api/error-triage/resolve",
+            json={"event_id": "ev:rt", "note": "flaky"},
+        )
+        assert r.status_code == 200, r.get_data(as_text=True)
+        assert r.get_json()["ok"] is True
+
+        # GET sees it
+        listing = client.get("/api/error-triage/resolved").get_json()
+        assert "ev:rt" in listing["resolved"]
+        assert listing["resolved"]["ev:rt"]["note"] == "flaky"
+        assert listing["count"] == 1
+
+        # DELETE removes it
+        r = client.delete("/api/error-triage/resolve?event_id=ev:rt")
+        assert r.status_code == 200
+        assert r.get_json() == {"ok": True, "removed": True, "event_id": "ev:rt"}
+
+        # GET is empty again
+        assert client.get("/api/error-triage/resolved").get_json()["count"] == 0
+
+        # Bad input -> 400, never 500
+        r = client.post("/api/error-triage/resolve", json={})
+        assert r.status_code == 400
+        r = client.delete("/api/error-triage/resolve")
+        assert r.status_code == 400
+    finally:
+        store.stop(flush=True)
+
+
+def test_snapshot_inclusion_via_build_resolved_errors(tmp_path, monkeypatch):
+    """The snapshot's resolvedErrors slice mirrors query_resolved_errors —
+    test the daemon-side builder directly."""
+    ls, store = _store(tmp_path, monkeypatch)
+    try:
+        store.mark_error_resolved("ev:snap-1", note="snapshot test")
+        from clawmetry import sync as syncmod
+        out = syncmod._build_resolved_errors()
+        assert isinstance(out, dict)
+        assert "ev:snap-1" in out
+        assert out["ev:snap-1"]["note"] == "snapshot test"
+    finally:
+        store.stop(flush=True)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Implements item #5 of #2196 — let a user **mark an error as resolved** so it stops inflating counts on Tracing / Health / the run-compare deltas. Useful for known/expected failures (a flaky integration test, an upstream outage) where you want the dashboard to focus on *new* signal.

The source tool kept this state in `localStorage`, which wouldn't survive our E2E-encrypted cloud model — every device would see different counts, and the cloud snapshot couldn't be authoritative. This version persists in **DuckDB** so it transits to the cloud via the snapshot and is consistent across devices.

## Approach

- **`local_store.resolved_errors`** — new table (`event_id` PK + `resolved_at` + optional `note`) added via the existing CREATE-IF-NOT-EXISTS pattern. `mark_error_resolved` is an upsert (idempotent — re-marking refreshes timestamp + note); `unmark_error_resolved` returns a truthful "removed" bool (pre-delete SELECT, because DuckDB's `cursor.rowcount` is -1 for DELETEs); `query_resolved_errors` returns a `{event_id: {resolved_at, note}}` map for O(1) membership checks.
- **Daemon-proxy allowlist** — `mark_error_resolved` / `unmark_error_resolved` / `query_resolved_errors` added to `_DAEMON_METHODS` so the three new routes can call them.
- **Routes** on `bp_sessions`:
  - `POST /api/error-triage/resolve` — body `{event_id, note?}`, returns `{ok, event_id}`. 400 on missing id.
  - `DELETE /api/error-triage/resolve?event_id=...` — returns `{ok, removed, event_id}`. `removed=False` is the idempotent "wasn't there" case.
  - `GET /api/error-triage/resolved?limit=N` — returns the map + count.
- **Snapshot slice** — new `resolvedErrors` top-level key (the same map), so the cloud renders the muted state without a separate fetch.

The UI consumer (a "Resolve" button next to error rows, plus a "Show resolved" toggle) ships in a follow-up — this PR is the foundation.

## Scope / non-goals

- This PR does **not** subtract resolved errors from the existing `error_count` / `severity` computations in `_build_waste_flags` / `_build_health_timeline` / `/api/run-compare`. That's a layer-spanning change worth its own PR — it changes existing numbers and needs careful verification. For now: callers can join the `resolvedErrors` map themselves when rendering.

## Verification

- `tests/test_error_triage.py` — 6 tests: store-layer roundtrip, idempotent re-mark refresh, unmark returns truthful `removed` bool, bad-input safety (empty / None never raises), full HTTP lifecycle through a Flask test client (resolve / list / delete / 400 contract), and the snapshot-slice builder returns the same map. All green.
- Daemon-side change → cloud inherits the slice with no cloud code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
