### PR TITLE
[RELEASE] evidence-based asset registry first slice (carries #2231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Release: evidence-based asset registry — first slice (carries #2231) (2026-05-28)
+- DuckDB-backed asset registry now ships on PyPI: turns Self-Evolve findings (and any other agent discovery) into reviewable, reusable assets with provenance — `pending → approved/rejected → deprecated`, every asset tied to a source `session_id`/`run_id`, daemon-proxied reads + writes, full `/api/assets` surface, and a one-click "save as asset" hook on the Self-Evolve route. See the detailed Added entry below for design + scope. No cloud pin bump.
+
 ### Added: evidence-based asset registry — first slice (2026-05-28)
 - New DuckDB-backed asset registry that converts individual agent discoveries (Self-Evolve findings, useful prompts, improved skills) into **reviewable, reusable assets with provenance** — without auto-promoting unreviewed local changes to team/company defaults (#2201). Lifecycle `pending → approved/rejected → deprecated`; every asset traces to a source `session_id`/`run_id`. Types: `skill`, `prompt`, `workflow`, `playbook`, `memory_snippet`, `tool_config`, `evaluation_case`. The daemon owns writes; reads ride the daemon proxy so the cloud can paint from a snapshot the same way (added to the `_DAEMON_METHODS` allowlist next to `ingest_approval` / `update_approval_decision`).
 - HTTP surface (`routes/assets.py`): `GET /api/assets` (filter by `status` / `asset_type` / `source_run_id` / `source_session_id` / `limit`), `GET /api/assets/<id>`, `POST /api/assets` (create candidate), `POST /api/assets/<id>/review` (`approve` / `reject` / `deprecate`).


### PR DESCRIPTION
Publishes #2231 to PyPI.

**What ships**
DuckDB-backed asset registry that turns Self-Evolve findings (and any other agent discovery) into **reviewable, reusable assets with provenance** — without auto-promoting unreviewed local changes to team/company defaults. Lifecycle `pending → approved/rejected → deprecated`; every asset traces to a source `session_id`/`run_id`. Daemon owns writes; reads + writes ride the daemon proxy (added to `_DAEMON_METHODS` next to `ingest_approval` / `update_approval_decision`).

- `GET /api/assets` / `GET /api/assets/<id>` / `POST /api/assets` / `POST /api/assets/<id>/review`
- `POST /api/selfevolve/findings/save-as-asset` (one-click candidate from a finding)

Foundation OSS + DuckDB-first; the richer review/promote console with reviewer identity + auto-recommendation is the planned Pro surface.

**Why this ships separately**
Pure additive primitive (new table + new endpoints; no existing surface changed). Full CI green on #2231: 25 checks across API tests (3 OS), Live OpenClaw E2E, MOAT Verifier (72), Eval Suite Gate, OSS golden path, pip install (3 OS), browser E2E.

**Scope**
Daemon-side only — cloud doesn't read assets yet (the snapshot slice + cloud interceptor is the next PR). **No cloud pin bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)