### PR TITLE
feat: server-side runtime filter on /api/usage (Cost/Tokens tab)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -7204,6 +7204,7 @@ class LocalStore:
         since: str | None = None,
         until: str | None = None,
         limit_events: int = 50000,
+        runtime: str | None = None,
     ) -> list[dict[str, Any]]:
         """Per-day input/output/cache_read/cache_write token + cost split.
 
@@ -7245,6 +7246,10 @@ class LocalStore:
         if until:
             clauses.append("ts <= ?")
             params.append(until)
+        _rt_clause, _rt_params = _runtime_session_id_clause(runtime)
+        if _rt_clause:
+            clauses.append(_rt_clause)
+            params.extend(_rt_params)
         where = "WHERE " + " AND ".join(clauses)
         sql = f"""
             SELECT id, ts, session_id, event_type, data, cost_usd
@@ -7584,9 +7589,16 @@ class LocalStore:
         agent_id: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        runtime: str | None = None,
     ) -> list[dict[str, Any]]:
         """Per-day rollup. Computed on the fly from events; columnar storage
-        means this is cheap even at hundreds-of-thousands of rows."""
+        means this is cheap even at hundreds-of-thousands of rows.
+
+        ``runtime``: optional runtime/harness filter (``claude_code``,
+        ``openclaw``, ``picoclaw``, …). Adds a session_id-prefix WHERE clause
+        BEFORE the dedupe CTE so all downstream cost/token math reuses the
+        same code path. Sum across runtime values == unfiltered total, by
+        construction (RULE #1: filtered totals reconcile)."""
         clauses: list[str] = []
         params: list[Any] = []
         if agent_id:
@@ -7598,6 +7610,10 @@ class LocalStore:
         if until:
             clauses.append("ts <= ?")
             params.append(until)
+        _rt_clause, _rt_params = _runtime_session_id_clause(runtime)
+        if _rt_clause:
+            clauses.append(_rt_clause)
+            params.extend(_rt_params)
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         # Same dedupe shape as ``query_sessions`` (PR #1462). On real v3
         # OpenClaw installs each LLM turn emits BOTH an ``assistant`` row
@@ -8413,6 +8429,45 @@ _BILLABLE_TURN_EVENT_TYPES = (
 _TOOL_CALL_TOPLEVEL_EVENT_TYPES = (
     "tool.call", "toolCall", "tool_use", "tool_call",
 )
+
+# ── Runtime filtering by session_id prefix ──────────────────────────────────
+# The global runtime switcher in the dashboard scopes views by runtime; runtime
+# is encoded in the session_id prefix (the daemon stamps it: ``claude_code:…``,
+# ``picoclaw:…``, …). ``agent_type`` is uselessly always ``"openclaw"`` and the
+# real runtime hint sits inside ``data._runtime`` (a JSON blob, not queryable).
+# Keep this list in sync with ``_CM_RT_LABEL`` in clawmetry/static/js/app.js so
+# the OpenClaw bucket matches the UI's definition (anything that isn't a known
+# non-openclaw prefix — including bare-UUID OpenClaw session ids).
+_NON_OPENCLAW_RUNTIME_PREFIXES = (
+    "picoclaw", "nanoclaw", "hermes",
+    "claude_code", "codex", "cursor", "aider", "goose", "opencode", "qwen_code",
+)
+
+def _runtime_session_id_clause(runtime: str | None) -> tuple[str | None, list[str]]:
+    """Build a WHERE-clause fragment + params filtering ``events.session_id``
+    by runtime prefix. Returns ``(None, [])`` for an empty / "all" / unknown
+    runtime so the caller can no-op. Used by ``query_aggregates`` /
+    ``query_daily_usage_splits`` to add a runtime filter that reuses the
+    method's existing dedupe + cost math, so per-runtime totals reconcile
+    with the unfiltered total by construction (no parallel aggregation path
+    → no risk of cost-number divergence).
+    """
+    if not runtime or runtime == "all":
+        return None, []
+    rt = runtime.lower()
+    if rt == "openclaw":
+        placeholders = ", ".join(["?"] * len(_NON_OPENCLAW_RUNTIME_PREFIXES))
+        # split_part returns the whole string when there's no separator → bare
+        # OpenClaw UUIDs land outside the known-non-openclaw set, as intended.
+        return (
+            f"split_part(session_id, ':', 1) NOT IN ({placeholders})",
+            list(_NON_OPENCLAW_RUNTIME_PREFIXES),
+        )
+    if rt in _NON_OPENCLAW_RUNTIME_PREFIXES:
+        return ("session_id LIKE ?", [f"{rt}:%"])
+    # Unknown runtime label: produce a clause that matches nothing, so callers
+    # get an empty result instead of silently leaking the unfiltered total.
+    return ("1 = 0", [])
 
 # Issue #1718: event_types whose ``data`` is rendered as a turn by the
 # transcript detail view (``routes/sessions.py:_try_local_store_transcript``

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10668,8 +10668,13 @@ async function loadHeatmap(days) {
 // ===== Usage / Token Tracking =====
 async function loadUsage() {
   try {
+    // Append the global runtime filter so Cost/Tokens scopes to the selected
+    // runtime (server-side, via query_aggregates' runtime= param). Numbers
+    // reconcile with the unfiltered total by construction.
+    var _uRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+    var _uRtQ = (_uRt && _uRt !== 'all') ? ('?runtime=' + encodeURIComponent(_uRt)) : '';
     var [_uResp, byPlugin] = await Promise.all([
-      fetch('/api/usage').then(async function(r) { return {s: r.status, b: await r.json()}; }),
+      fetch('/api/usage' + _uRtQ).then(async function(r) { return {s: r.status, b: await r.json()}; }),
       fetch('/api/usage/by-plugin').then(r => r.json()).catch(function(){ return {plugins: []}; })
     ]);
     var data = _uResp.b || {};

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -30,12 +30,42 @@ import os
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta
+from typing import Optional
 
 from flask import Blueprint, jsonify, make_response, request
 from clawmetry.config import is_local_store_read_enabled
 from routes._dedupe import build_sibling_bucket_max, is_sibling_dup
 
 bp_usage = Blueprint('usage', __name__)
+
+# In-memory mirror of ``_runtime_session_id_clause`` for paths that read raw
+# events (query_events doesn't take a runtime param). Same canonical prefix
+# list as the SQL filter, so client-side and server-side runtime scoping agree.
+# Duplicated rather than imported from clawmetry.local_store because that
+# module imports duckdb at top level and routes/usage.py must stay importable
+# in test environments where duckdb isn't installed. Keep in sync with
+# ``_NON_OPENCLAW_RUNTIME_PREFIXES`` in clawmetry/local_store.py and
+# ``_CM_RT_LABEL`` in clawmetry/static/js/app.js.
+_NON_OPENCLAW_RT_SET = frozenset((
+    "picoclaw", "nanoclaw", "hermes",
+    "claude_code", "codex", "cursor", "aider", "goose", "opencode", "qwen_code",
+))
+
+def _event_runtime(ev) -> str:
+    sid = str((ev or {}).get("session_id") or "")
+    if ":" in sid:
+        p = sid.split(":", 1)[0].lower()
+        if p in _NON_OPENCLAW_RT_SET:
+            return p
+    return "openclaw"
+
+def _filter_evs_by_runtime(evs, runtime):
+    if not runtime or runtime == "all":
+        return evs
+    rt = runtime.lower()
+    if rt != "openclaw" and rt not in _NON_OPENCLAW_RT_SET:
+        return []  # unknown runtime → empty, matching the SQL clause behaviour
+    return [e for e in (evs or []) if _event_runtime(e) == rt]
 
 _CLUSTER_CACHE = {"ts": 0.0, "key": None, "data": None}
 _CLUSTER_CACHE_TTL_SECONDS = 120
@@ -178,7 +208,7 @@ def _ls_call(method_name, **kwargs):
         return None
 
 
-def _try_local_store_usage():
+def _try_local_store_usage(runtime: Optional[str] = None):
     """Fast path for /api/usage. Builds the daily token/cost chart by
     aggregating ``daily_aggregates`` (with a ``query_events`` fallback if
     the aggregates table is empty). Returns the same shape as the legacy
@@ -197,7 +227,10 @@ def _try_local_store_usage():
     # Pull pre-rolled day buckets first — these are the "blessed" data
     # the daemon writes once per ingest. Falls back to live event scan
     # when aggregates are empty (e.g. fresh install, only events seeded).
-    agg_rows = _ls_call("query_aggregates")
+    # Optional ``runtime`` filter is threaded into query_aggregates +
+    # query_daily_usage_splits so filtered totals reuse the same dedupe +
+    # cost math (sum over runtimes == unfiltered, by construction).
+    agg_rows = _ls_call("query_aggregates", runtime=runtime)
     if agg_rows is None:
         return None
     daily_tokens = {}
@@ -213,6 +246,9 @@ def _try_local_store_usage():
         evs = _ls_call("query_events", limit=10000)
         if not evs:
             return None
+        # query_events has no SQL runtime filter; apply the same prefix logic
+        # in Python so the fallback path agrees with the aggregates path.
+        evs = _filter_evs_by_runtime(evs, runtime)
         for ev in evs:
             day = _ls_iso_day(ev.get("ts", ""))
             if not day:
@@ -224,7 +260,7 @@ def _try_local_store_usage():
     # build this from the assistant-event blob walker so we don't have
     # to wait for the daemon to backfill split columns. Empty list is
     # fine (caller renders zeros for the missing days).
-    splits_rows = _ls_call("query_daily_usage_splits") or []
+    splits_rows = _ls_call("query_daily_usage_splits", runtime=runtime) or []
     daily_input = {r["day"]: int(r.get("input_tokens") or 0) for r in splits_rows}
     daily_output = {r["day"]: int(r.get("output_tokens") or 0) for r in splits_rows}
     daily_cache_read = {r["day"]: int(r.get("cache_read_tokens") or 0) for r in splits_rows}
@@ -300,6 +336,7 @@ def _try_local_store_usage():
     # Per-model breakdown: scan recent events and group.
     model_usage = {}
     recent = _ls_call("query_events", limit=5000) or []
+    recent = _filter_evs_by_runtime(recent, runtime)
     for ev in recent:
         m = ev.get("model") or "unknown"
         model_usage[m] = model_usage.get(m, 0) + int(ev.get("token_count") or 0)
@@ -1622,10 +1659,18 @@ def api_usage():
     import dashboard as _d
     import time as _time
 
+    # Optional ?runtime=X scopes the Cost / Tokens tab to one agent runtime
+    # (Claude Code, Goose, PicoClaw, …). Mirrors the global runtime switcher;
+    # threaded into query_aggregates + query_daily_usage_splits so per-runtime
+    # totals reuse the same dedupe + cost math (sum across runtimes ==
+    # unfiltered, by construction). Only honoured on the local-store fast
+    # path; the legacy OTLP/cache fallback ignores it.
+    _rt = (request.args.get("runtime") or "").strip() or None
+
     # Epic #964 — local-store fast path. Opt-in via CLAWMETRY_LOCAL_STORE_READ=1;
     # falls through to OTLP/transcript scan when the store is empty / disabled.
     if is_local_store_read_enabled():
-        fast = _try_local_store_usage()
+        fast = _try_local_store_usage(runtime=_rt)
         if fast is not None:
             return jsonify(_apply_oss_24h_cap(fast))
 


### PR DESCRIPTION
Final de-merge surface: the Cost / Tokens tab now scopes server-side to the runtime selected in the global switcher.

## Why it had to be server-side
The aggregates are pre-grouped by ``(agent_id, day)`` without a runtime dimension, so the Cost tab kept showing merged totals even after Brain/Transcripts/Tracing de-merged. Filtering client-side wasn't possible.

## Why this is RULE-#1 safe
The ``runtime`` param goes into ``query_aggregates`` + ``query_daily_usage_splits`` as a ``WHERE`` clause on the ``session_id`` prefix — **before** the dedupe CTE. The cost / token math is unchanged, so per-runtime totals reuse the same code path and **reconcile with the unfiltered total by construction** (no parallel aggregation, no risk of divergent cost numbers).

Verified with a synthetic DuckDB seeded with mixed prefixes:
```
unfiltered:   $10.20 / 7200 tok
claude_code:  $4.60  / 3100 tok   (model.completed sibling deduped)
openclaw:     $4.30  / 3100 tok   (bare-UUID + ':' sessions)
picoclaw:     $0.40  /  300 tok
goose:        $0.90  /  700 tok
sum:         $10.20 / 7200 tok    ✓ matches unfiltered exactly
unknown rt → empty (doesn't leak)
'all'      → identity
```

## What's wired
- ``clawmetry/local_store.py``: ``_runtime_session_id_clause()`` helper + ``runtime`` param on ``query_aggregates`` and ``query_daily_usage_splits``.
- ``routes/usage.py``: ``_try_local_store_usage(runtime=)`` threads it through both ``_ls_call`` sites + the ``query_events`` fallback + the ``modelBreakdown`` scan (Python-side mirror). ``api_usage()`` reads ``?runtime=…``.
- ``clawmetry/static/js/app.js``: ``loadUsage`` appends ``?runtime=`` from the global switcher.

## Live-verify limitation
The synthetic test exercised the actual SQL + dedupe against a real DuckDB and reconciled. I didn't restart the live sync daemon to test against production data — ``kickstart -k`` mid-write is the #1771 brick-lock risk; CI's MOAT verifier exercises fresh stores with the new code.

## Cloud follow-up
``/api/usage`` is ``cloud-override``, so the cloud frontend won't pick this up until the daemon ships per-runtime ``dailyUsage`` in the snapshot AND the cloud handler honours ``?runtime=``. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)