### PR TITLE
[RELEASE] fix: /api/export/traces silently dropped — Blueprint name collision

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -104,7 +104,7 @@ from routes.overview import bp_overview
 from routes.components import bp_components
 from routes.fleet_history import bp_fleet
 from routes.infra import bp_logs, bp_memory, bp_security, bp_config
-from routes.meta import bp_auth, bp_cloud_relay, bp_gateway, bp_otel, bp_otel_export, bp_version, bp_version_impact
+from routes.meta import bp_auth, bp_cloud_relay, bp_gateway, bp_otel, bp_otlp_traces, bp_version, bp_version_impact
 from routes.nemoclaw import bp_nemoclaw
 from routes.skills import bp_skills
 from routes.heartbeat import bp_heartbeat
@@ -10609,6 +10609,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_memory)
     app.register_blueprint(bp_otel)
     app.register_blueprint(bp_otel_export)
+    app.register_blueprint(bp_otlp_traces)
     app.register_blueprint(bp_overview)
     app.register_blueprint(bp_security)
     app.register_blueprint(bp_sessions)

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -51,7 +51,14 @@ bp_auth = Blueprint('auth', __name__)
 bp_otel = Blueprint('otel', __name__)
 bp_version_impact = Blueprint('version_impact', __name__)
 bp_cloud_relay = Blueprint('cloud_relay', __name__)
-bp_otel_export = Blueprint('otel_export', __name__)
+# NOTE: This blueprint owns /api/export/traces (outbound OTLP traces export,
+# shipped in #2206). It must NOT share its name with routes/otel_export.py's
+# bp_otel_export (which owns /api/otel/export, the older Enterprise OTLP/JSON
+# export). Pre-0.12.353 both blueprints were named 'otel_export' -> Flask
+# refused the second registration -> /api/export/traces was silently dropped
+# at runtime. Distinct name 'otlp_traces' fixes the collision; keep the
+# variable name as bp_otlp_traces and update dashboard.py's import + register.
+bp_otlp_traces = Blueprint('otlp_traces', __name__)
 
 
 # ── OTLP trace export ──────────────────────────────────────────────────────────────
@@ -243,7 +250,7 @@ def _sessions_to_otlp_fallback(sessions: list, version: str) -> dict:
     }
 
 
-@bp_otel_export.route("/api/export/traces", methods=["GET"])
+@bp_otlp_traces.route("/api/export/traces", methods=["GET"])
 def export_otlp_traces():
     """Export agent traces as OTLP JSON.
 


### PR DESCRIPTION
## Bug
The new `/api/export/traces` endpoint shipped in #2206 (OTLP outbound trace export) was **unreachable at runtime in 0.12.350-0.12.352** despite the code shipping. Surfaced by cloud's route-policy audit ([cloud #1181](https://github.com/vivekchand/clawmetry-cloud/pull/1181)) which tries to register all OSS blueprints and got back:

> `The name 'otel_export' is already registered for a different blueprint.`

## Root cause
`routes/meta.py` and `routes/otel_export.py` both defined a `Blueprint` with the name `'otel_export'`:

```python
# routes/meta.py:54
bp_otel_export = Blueprint('otel_export', __name__)  # owns /api/export/traces

# routes/otel_export.py:27
bp_otel_export = Blueprint("otel_export", __name__)  # owns /api/otel/export
```

`dashboard.py` imported BOTH (lines 107 and 131) into the same local name `bp_otel_export`. The second import shadowed the first → only `routes.otel_export.bp_otel_export` was registered → `/api/export/traces` never appeared in the URL map. Wheel had the file; app didn't expose the route.

## Fix
Rename `routes/meta.py`'s blueprint to `bp_otlp_traces` with the distinct name `'otlp_traces'` (semantic: it owns the new OTLP traces export, distinct from the older Enterprise OTLP/JSON export on `/api/otel/export`). Add a separate `register_blueprint(bp_otlp_traces)` call so both blueprints register without collision.

## Verification
- Standalone register-both Flask test: both `/api/export/traces` and `/api/otel/export` now reachable.
- `tests/test_otel_export.py`: 6 passed.
- `tests/test_i18n_catalog.py`: 40 passed.
- `dashboard.py` imports clean.

## Files
| File | Change |
|------|--------|
| `routes/meta.py` | `bp_otel_export` → `bp_otlp_traces` (name + variable) + explanatory comment |
| `dashboard.py` | Update import + add separate `register_blueprint` call |

🤖 Generated with [Claude Code](https://claude.com/claude-code)