### PR TITLE
feat(heartbeat): ship plaintext node_meta so cloud Flow Machine modal renders (closes cloud#956)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5014,6 +5014,78 @@ def _pick_heartbeat_interval(resp_json: dict | None) -> int:
     )
 
 
+def _build_node_meta() -> dict:
+    """Plaintext machine metadata for the cloud Flow Machine modal (cloud#956).
+
+    Mirrors the fields cloud's /ingest/heartbeat extracts from body.node_meta:
+    os, arch, ram_gb, cpu_count, local_ips. The encrypted snapshot already
+    carries the richer machineInfo blob; this duplicates the trust-safe subset
+    so the keyless fallback in cm-cloud-machine fires with real data instead
+    of an empty {hostname, platform} shell.
+
+    Best-effort: any subcomponent failure yields an empty value rather than
+    raising — the heartbeat MUST keep flowing even on weird platforms.
+    """
+    import platform as _pm
+    import socket as _sk
+    meta = {
+        "os": "",
+        "arch": "",
+        "ram_gb": "",
+        "cpu_count": "",
+        "local_ips": [],
+    }
+    try:
+        meta["os"] = _pm.system()
+    except Exception:
+        pass
+    try:
+        meta["arch"] = _pm.machine()
+    except Exception:
+        pass
+    try:
+        import multiprocessing as _mp
+        meta["cpu_count"] = str(_mp.cpu_count())
+    except Exception:
+        pass
+    try:
+        # /proc/meminfo on Linux, sysctl on Mac. Skip silently when neither.
+        if _pm.system() == "Linux":
+            with open("/proc/meminfo") as _mf:
+                for _line in _mf:
+                    if _line.startswith("MemTotal:"):
+                        _kb = int(_line.split()[1])
+                        meta["ram_gb"] = str(round(_kb / 1024 / 1024, 1))
+                        break
+        elif _pm.system() == "Darwin":
+            import subprocess as _sp
+            _out = _sp.check_output(["sysctl", "-n", "hw.memsize"], timeout=2)
+            meta["ram_gb"] = str(round(int(_out.strip()) / 1024 / 1024 / 1024, 1))
+    except Exception:
+        pass
+    try:
+        # All non-loopback IPv4 addresses on the host. Bounded list, no PII.
+        _ips = set()
+        try:
+            for _info in _sk.getaddrinfo(_sk.gethostname(), None, _sk.AF_INET):
+                _ip = _info[4][0]
+                if _ip and not _ip.startswith("127."):
+                    _ips.add(_ip)
+        except Exception:
+            pass
+        try:
+            _s = _sk.socket(_sk.AF_INET, _sk.SOCK_DGRAM)
+            _s.connect(("8.8.8.8", 80))
+            _ips.add(_s.getsockname()[0])
+            _s.close()
+        except Exception:
+            pass
+        meta["local_ips"] = sorted(_ips)[:8]
+    except Exception:
+        pass
+    return meta
+
+
 def send_heartbeat(config: dict) -> bool:
     """Send heartbeat to cloud. Returns True on success, False on failure.
 
@@ -5039,6 +5111,7 @@ def send_heartbeat(config: dict) -> bool:
         "version": _get_version(),
         "e2e": bool(config.get("encryption_key")),
         "ollama": _detect_ollama_for_heartbeat(),
+        "node_meta": _build_node_meta(),
     }
     # Agent-install self-report (cloud bug fix 2026-05-18). Cloud Run pods
     # can't stat the user's home directory, so the daemon tells cloud what


### PR DESCRIPTION
## Closes vivekchand/clawmetry-cloud#956 (P1 user-reported)

### The bug
Cloud Flow Machine modal renders only "Hostname" + "Platform" on a fresh install. User expected CPU model / RAM / cores / arch / kernel.

### Where the gap is
Cloud is already wired:
- `routes/api.py:1101-1107` (cloud) extracts `os`, `arch`, `ram_gb`, `cpu_count`, `local_ips` from `body.node_meta` and persists them to `nodes.metadata`
- `dashboard.py:~10883` (cloud) intercepts `/api/component/machine`; when the snapshot is locked it falls through to `comp.machine` from `cloud_node_components`, which builds `items[]` from those exact fields

The daemon side was the missing half. Heartbeat payload only carried:
```py
payload = {
    "node_id": ...,
    "ts": ...,
    "platform": platform.system(),   # this is why Platform renders
    "version": ...,
    "e2e": ...,
    "ollama": ...,
}
```
No `node_meta`. So every field cloud's fallback expected to find was empty.

### What this PR does
1. Adds `_build_node_meta()` helper — best-effort plaintext subset of the existing `_build_machine_info()`: `os`, `arch`, `ram_gb`, `cpu_count`, `local_ips`. Each subcomponent guarded by `try/except` so any quirky platform (containers without `/proc`, restricted sandboxes, etc.) yields an empty string rather than crashing the heartbeat.
2. Adds `"node_meta": _build_node_meta()` to the heartbeat payload alongside the existing `ollama` / `security_posture` siblings.

### Trust model
Same fields that already ship plaintext via the Mac sister app's heartbeat (existing precedent). The rich encrypted-snapshot `machineInfo` (load average, GPU, kernel) stays E2E-encrypted; this is the unlock-free subset only — exactly what the modal shows when the user has not pasted their secret key yet.

### Verified locally
```
$ python3 -c "from clawmetry.sync import _build_node_meta; import json; print(json.dumps(_build_node_meta(), indent=2))"
{
  "os": "Linux",
  "arch": "x86_64",
  "ram_gb": "47.0",
  "cpu_count": "8",
  "local_ips": ["192.168.178.57"]
}
```

### After PyPI release + cloud pin bump
The next heartbeat from each upgraded node will carry `node_meta`. Cloud will UPSERT `nodes.metadata` and the Flow Machine modal will paint the richer fields automatically — no cloud-side code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
