### PR TITLE
feat(ingest): OSS-side stub for /api/v1/runs/* and /api/v1/engines/*

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -136,6 +136,7 @@ PAID_FEATURES = frozenset(
         "anomaly_detection",
         "self_evolve",
         "cost_optimizer",
+        "custom_runtime_ingest",
     }
 )
 

--- a/clawmetry/extensions.py
+++ b/clawmetry/extensions.py
@@ -66,6 +66,30 @@ def emit(event: str, payload: Dict[str, Any] | None = None) -> None:
             )
 
 
+def dispatch(event: str, payload: Dict[str, Any] | None = None) -> Any:
+    """Call handlers for *event* in order and return the first non-None result.
+
+    Unlike :func:`emit`, this is a request/response pattern: the first handler
+    that returns a non-None value wins and subsequent handlers are skipped.
+    If no handler is registered or every handler returns None, returns None.
+    Exceptions in handlers are caught and logged — never propagated.
+    """
+    if payload is None:
+        payload = {}
+    with _lock:
+        handlers = list(_registry.get(event, []))
+    for handler in handlers:
+        try:
+            result = handler(payload)
+            if result is not None:
+                return result
+        except Exception as exc:
+            logger.warning(
+                f"Extension handler {handler.__name__!r} raised on event {event!r}: {exc}"
+            )
+    return None
+
+
 def _select_entry_points(group: str):
     """Return entry points for ``group`` across Python versions.
 

--- a/dashboard.py
+++ b/dashboard.py
@@ -130,6 +130,7 @@ from routes.context_economics import bp_context_economics
 from routes.entitlement import bp_entitlement
 from routes.otel_export import bp_otel_export
 from routes.audit import bp_audit
+from routes.runtime_ingest import bp_runtime_ingest
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -10636,6 +10637,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_context_economics)
     app.register_blueprint(bp_entitlement)
     app.register_blueprint(bp_audit)
+    app.register_blueprint(bp_runtime_ingest)
 
     # Register built-in agent adapters. External plugins can register more
     # via clawmetry.extensions entry points — see clawmetry/adapters/.

--- a/routes/runtime_ingest.py
+++ b/routes/runtime_ingest.py
@@ -1,0 +1,105 @@
+"""
+routes/runtime_ingest.py — Custom runtime HTTP ingest API stub.
+
+Reserves the /api/v1/runs/* and /api/v1/engines/* namespaces so the paid
+plugin (clawmetry-pro) can attach a real handler at startup. OSS installs
+without the plugin get a graceful 402 with an upgrade hint rather than a
+confusing 404.
+
+  POST /api/v1/runs/<path>     — create / update a run record
+  GET  /api/v1/runs/<path>     — read a run record (discovery)
+  POST /api/v1/engines/<path>  — engine-side ingest (reserved)
+  GET  /api/v1/engines/<path>  — engine catalog (discovery)
+  (PUT, PATCH, DELETE also forwarded for completeness)
+
+Extension hook: register a callable under event "runtime_ingest.request" via
+clawmetry.extensions.register(). The handler receives:
+  {"path": str, "method": str, "body": dict | None, "args": dict}
+and must return a Flask response object / tuple, or None to fall through to
+the 402 stub.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, jsonify, request
+
+logger = logging.getLogger("clawmetry.routes.runtime_ingest")
+
+bp_runtime_ingest = Blueprint("runtime_ingest", __name__)
+
+_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
+
+
+def _try_plugin(path: str):
+    """Delegate to a paid-plugin handler registered under 'runtime_ingest.request'.
+
+    Returns the handler's Flask response tuple/object, or None if no handler
+    is registered or every handler returns None.
+    """
+    try:
+        from clawmetry.extensions import dispatch
+
+        return dispatch(
+            "runtime_ingest.request",
+            {
+                "path": path,
+                "method": request.method,
+                "body": request.get_json(silent=True),
+                "args": dict(request.args),
+            },
+        )
+    except Exception as exc:
+        logger.warning("runtime_ingest: plugin dispatch error: %s", exc)
+        return None
+
+
+def _stub_402():
+    """Return the standard 402 upgrade hint for this feature."""
+    try:
+        from clawmetry import entitlements as _ent
+
+        tier = _ent.get_entitlement().to_dict().get("tier", "oss")
+    except Exception:
+        tier = "oss"
+    return (
+        jsonify(
+            {
+                "error": "upgrade_required",
+                "feature": "custom_runtime_ingest",
+                "tier": tier,
+                "hint": (
+                    "Custom runtime HTTP ingest is a Pro+ feature. "
+                    "https://clawmetry.com/pricing"
+                ),
+            }
+        ),
+        402,
+    )
+
+
+@bp_runtime_ingest.route(
+    "/api/v1/runs/",
+    defaults={"run_path": ""},
+    methods=_METHODS,
+)
+@bp_runtime_ingest.route("/api/v1/runs/<path:run_path>", methods=_METHODS)
+def api_v1_runs(run_path: str):
+    result = _try_plugin(f"runs/{run_path}" if run_path else "runs/")
+    if result is not None:
+        return result
+    return _stub_402()
+
+
+@bp_runtime_ingest.route(
+    "/api/v1/engines/",
+    defaults={"engine_path": ""},
+    methods=_METHODS,
+)
+@bp_runtime_ingest.route("/api/v1/engines/<path:engine_path>", methods=_METHODS)
+def api_v1_engines(engine_path: str):
+    result = _try_plugin(f"engines/{engine_path}" if engine_path else "engines/")
+    if result is not None:
+        return result
+    return _stub_402()

--- a/tests/test_runtime_ingest_stub.py
+++ b/tests/test_runtime_ingest_stub.py
@@ -1,0 +1,156 @@
+"""Tests for routes/runtime_ingest.py — /api/v1/runs/* and /api/v1/engines/*.
+
+All tests are hermetic (no live server, no gateway, no DuckDB on disk).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask, jsonify
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Minimal Flask test client with only bp_runtime_ingest registered."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Reload entitlements so no stale license cache is carried over.
+    import clawmetry.entitlements as _ent
+    importlib.reload(_ent)
+    _ent.invalidate()
+
+    # Clear the extensions registry so no leftover handlers bleed between tests.
+    import clawmetry.extensions as _ext
+    importlib.reload(_ext)
+
+    from routes.runtime_ingest import bp_runtime_ingest
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_runtime_ingest)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+# ── 402 stub behaviour ────────────────────────────────────────────────────────
+
+def test_post_runs_returns_402(client):
+    r = client.post("/api/v1/runs/my-run", json={"data": 1})
+    assert r.status_code == 402
+    body = r.get_json()
+    assert body["error"] == "upgrade_required"
+    assert body["feature"] == "custom_runtime_ingest"
+    assert "hint" in body
+
+
+def test_get_runs_returns_402(client):
+    r = client.get("/api/v1/runs/some/nested/path")
+    assert r.status_code == 402
+
+
+def test_post_engines_returns_402(client):
+    r = client.post("/api/v1/engines/my-engine")
+    assert r.status_code == 402
+    assert r.get_json()["feature"] == "custom_runtime_ingest"
+
+
+def test_get_engines_root_returns_402(client):
+    r = client.get("/api/v1/engines/")
+    assert r.status_code == 402
+
+
+# ── Plugin delegation ─────────────────────────────────────────────────────────
+
+def test_runs_delegates_to_registered_plugin(client, monkeypatch, tmp_path):
+    """A registered 'runtime_ingest.request' handler gets the call and its
+    response is forwarded to the HTTP client."""
+    import clawmetry.extensions as ext
+
+    captured = {}
+
+    def my_handler(payload):
+        captured.update(payload)
+        return jsonify({"accepted": True, "path": payload["path"]}), 201
+
+    ext.register("runtime_ingest.request", my_handler)
+
+    r = client.post("/api/v1/runs/run-xyz", json={"foo": "bar"})
+    assert r.status_code == 201
+    body = r.get_json()
+    assert body["accepted"] is True
+    assert body["path"] == "runs/run-xyz"
+    assert captured["method"] == "POST"
+    assert captured["body"] == {"foo": "bar"}
+
+
+def test_engines_delegates_to_registered_plugin(client, monkeypatch, tmp_path):
+    import clawmetry.extensions as ext
+
+    def engine_handler(payload):
+        return jsonify({"engine": payload["path"]}), 200
+
+    ext.register("runtime_ingest.request", engine_handler)
+
+    r = client.get("/api/v1/engines/my-engine")
+    assert r.status_code == 200
+    assert r.get_json()["engine"] == "engines/my-engine"
+
+
+def test_none_returning_plugin_falls_through_to_402(client, monkeypatch, tmp_path):
+    """A handler that returns None should not block the 402 fallback."""
+    import clawmetry.extensions as ext
+
+    def passive_handler(payload):
+        return None  # explicitly declines
+
+    ext.register("runtime_ingest.request", passive_handler)
+
+    r = client.post("/api/v1/runs/declined")
+    assert r.status_code == 402
+
+
+# ── Entitlement key present ───────────────────────────────────────────────────
+
+def test_custom_runtime_ingest_in_paid_features():
+    """The feature key must exist in PAID_FEATURES so allows_feature() is
+    consistent and the entitlement system has a stable string to gate on."""
+    from clawmetry.entitlements import PAID_FEATURES
+    assert "custom_runtime_ingest" in PAID_FEATURES
+
+
+# ── extensions.dispatch present ───────────────────────────────────────────────
+
+def test_dispatch_returns_first_non_none():
+    from clawmetry.extensions import register, dispatch, _registry
+
+    _registry.pop("test_dispatch_event", None)
+    try:
+        calls = []
+
+        def h1(p):
+            calls.append("h1")
+            return None
+
+        def h2(p):
+            calls.append("h2")
+            return "result-from-h2"
+
+        def h3(p):
+            calls.append("h3")
+            return "should-not-reach"
+
+        register("test_dispatch_event", h1)
+        register("test_dispatch_event", h2)
+        register("test_dispatch_event", h3)
+
+        result = dispatch("test_dispatch_event", {})
+        assert result == "result-from-h2"
+        assert calls == ["h1", "h2"]  # h3 never called
+    finally:
+        _registry.pop("test_dispatch_event", None)
+
+
+def test_dispatch_returns_none_when_no_handlers():
+    from clawmetry.extensions import dispatch, _registry
+
+    _registry.pop("unregistered_event_xyz", None)
+    assert dispatch("unregistered_event_xyz") is None


### PR DESCRIPTION
## Summary

Closes #2269

- Reserves `/api/v1/runs/<path>` and `/api/v1/engines/<path>` so clients get a helpful `402 upgrade_required` (feature: `custom_runtime_ingest`) instead of a confusing 404
- Adds `extensions.dispatch()` — a request/response variant of `emit()` that returns the first non-None handler result, letting the paid plugin attach a real ingest handler without duplicate Flask route registration
- Adds `"custom_runtime_ingest"` to `PAID_FEATURES` so `allows_feature()` has a stable key

## Test plan

- `python3 -m pytest tests/test_runtime_ingest_stub.py -v` — 10 hermetic tests: 402 stub for both namespaces, plugin delegation (handler returns response), None-returning handler falls through to 402, `dispatch()` unit tests, feature key in `PAID_FEATURES`
- `python3 -m pytest tests/test_blueprint_uniqueness.py -v` — confirms `runtime_ingest` blueprint name is unique
- `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — syntax check
- `ruff check clawmetry/extensions.py clawmetry/entitlements.py routes/runtime_ingest.py` — all clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTibzhsZhMWgyCPRA8SGBU)_