### PR TITLE
feat(open-core): load_plugins() in sync daemon startup

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11765,6 +11765,22 @@ def run_daemon() -> None:
     # racing supervisor restart sees the lock held until the flush is
     # done, instead of starting a second daemon mid-drain.
     _install_shutdown_handlers()
+
+    # Open-core plugin discovery. dashboard.py runs this at import time so the
+    # dashboard process picks up entry-point plugins (clawmetry-pro adapters,
+    # event handlers, etc.). The sync daemon is a SEPARATE process — started
+    # via `python -m clawmetry.sync` from launchd/systemd, so it never imports
+    # dashboard — and was therefore the only ClawMetry process where paid
+    # plugins did not register. Without this call, the ingest path (the
+    # daemon's primary job) cannot be extended by clawmetry-pro. The
+    # ``_loaded`` guard makes this safe even if the process somehow imports
+    # dashboard later. Never raises.
+    try:
+        from clawmetry.extensions import load_plugins as _ext_load
+        _ext_load()
+    except Exception as _ext_e:
+        log.warning("extensions load_plugins failed: %s", _ext_e)
+
     config = load_config()
     # If node_id looks like email prefix (contains + or @), use hostname instead
     nid = config.get("node_id", "")

--- a/tests/test_sync_loads_plugins.py
+++ b/tests/test_sync_loads_plugins.py
@@ -1,0 +1,117 @@
+"""Tests for the open-core plugin wiring in the sync daemon.
+
+Regression focus: ``run_daemon()`` is the entry point for the long-running
+ClawMetry sync/ingest process — started as ``python -m clawmetry.sync`` from
+launchd / systemd. ``dashboard.py`` runs ``load_plugins()`` at import time so
+plugins (e.g. clawmetry-pro adapters) register in the dashboard process;
+without the matching call in ``run_daemon()`` the sync daemon would silently
+skip entry-point plugins, and clawmetry-pro could never hook the ingest path
+that is the daemon's primary job.
+
+The full daemon does heavy setup (PID lock, DuckDB warm-up, gateway WS tap,
+heartbeat HTTP). To test the wiring in isolation we patch the modules
+``run_daemon`` reaches BEFORE it touches any of that, and assert that
+``load_plugins`` is called. The test never actually runs the daemon loop.
+"""
+from __future__ import annotations
+
+
+def _stub_call_counter():
+    """Return a (counter_dict, fn) pair. ``fn`` increments ``counter['n']``."""
+    counter = {"n": 0}
+
+    def fn(*_a, **_kw):
+        counter["n"] += 1
+
+    return counter, fn
+
+
+def test_run_daemon_calls_load_plugins(monkeypatch):
+    """``sync.run_daemon`` must invoke ``clawmetry.extensions.load_plugins``
+    before any ingest setup. We short-circuit ``load_config`` to raise
+    immediately after the call, so we observe the plugin call without running
+    the rest of the daemon."""
+    from clawmetry import extensions as ext
+    from clawmetry import sync as sync_mod
+
+    counter, fake_load = _stub_call_counter()
+    monkeypatch.setattr(ext, "load_plugins", fake_load)
+    # The sync module imports the function lazily inside run_daemon
+    # (`from clawmetry.extensions import load_plugins as _ext_load`), so the
+    # monkeypatch on ``ext.load_plugins`` is what the daemon picks up.
+
+    # Make _acquire_pid_lock pass so we reach the load_plugins call.
+    monkeypatch.setattr(sync_mod, "_acquire_pid_lock", lambda: True)
+    monkeypatch.setattr(sync_mod, "_install_shutdown_handlers", lambda: None)
+
+    # Stop the daemon hard right after load_plugins by raising in load_config.
+    class _Stop(RuntimeError):
+        pass
+
+    def _boom():
+        raise _Stop("stop after load_plugins")
+
+    monkeypatch.setattr(sync_mod, "load_config", _boom)
+
+    try:
+        sync_mod.run_daemon()
+    except _Stop:
+        pass
+
+    assert counter["n"] == 1, (
+        "sync.run_daemon must call clawmetry.extensions.load_plugins exactly "
+        "once at startup so paid-plugin entry points register in the daemon "
+        "process, not only in the dashboard process."
+    )
+
+
+def test_run_daemon_swallows_plugin_load_errors(monkeypatch):
+    """A broken plugin must NOT crash the sync daemon. The daemon's ingest
+    job is the OSS install's only data source — losing it because one paid
+    plugin's ``register_all`` raised would silently break every dashboard."""
+    from clawmetry import extensions as ext
+    from clawmetry import sync as sync_mod
+
+    def _raise(*_a, **_kw):
+        raise RuntimeError("simulated broken plugin")
+
+    monkeypatch.setattr(ext, "load_plugins", _raise)
+    monkeypatch.setattr(sync_mod, "_acquire_pid_lock", lambda: True)
+    monkeypatch.setattr(sync_mod, "_install_shutdown_handlers", lambda: None)
+
+    class _Stop(RuntimeError):
+        pass
+
+    monkeypatch.setattr(
+        sync_mod, "load_config", lambda: (_ for _ in ()).throw(_Stop("stop"))
+    )
+
+    # If the plugin error were not swallowed, this would surface RuntimeError
+    # instead of _Stop. The assertion is the absence of RuntimeError leaking.
+    try:
+        sync_mod.run_daemon()
+    except _Stop:
+        pass
+    except RuntimeError as exc:
+        if "simulated broken plugin" in str(exc):
+            raise AssertionError(
+                "sync.run_daemon must swallow load_plugins errors, not "
+                "propagate them — a broken plugin must never take down the "
+                "ingest daemon."
+            )
+        raise
+
+
+def test_dashboard_module_still_loads_plugins():
+    """Sanity check: the dashboard's import-time call to load_plugins remains
+    in place. Sync-daemon wiring is *additive*; it does not replace the
+    dashboard's own startup hook."""
+    import dashboard  # noqa: F401 — import triggers load_plugins side-effect
+
+    # The dashboard imports ``load_plugins`` and calls it inside a try/except.
+    # Re-importing here proves the module loaded cleanly (no ImportError) on
+    # the open-core OSS install.
+    assert hasattr(dashboard, "_ext_emit"), (
+        "dashboard.py must keep the extensions wiring (emit + load_plugins) "
+        "alive at module top so the dashboard process registers plugins."
+    )


### PR DESCRIPTION
## Summary

Wires the `clawmetry.extensions` entry-point plugin loader into the **sync
daemon** so paid plugins (clawmetry-pro adapters / event handlers / ingest
hooks) register in that process too — not only in the dashboard process.

### Why
`dashboard.py` calls `load_plugins()` at module import time, so the dashboard
process picks up `clawmetry.extensions` entry-point plugins for HTTP routes
and `emit()` events. But the sync daemon is a **separate process** — started
as `python -m clawmetry.sync` from launchd / systemd — and never imports
`dashboard`. Until now, that meant the sync daemon was the *only* ClawMetry
process where paid plugins were silently skipped, even though the daemon is
the long-running data-ingestion process (the natural extension point for a
paid runtime adapter / ingest sink).

### What

- **`clawmetry/sync.py`** — call `load_plugins()` at the top of `run_daemon()`,
  right after the PID lock and shutdown handlers, before any heavy ingest
  setup (DuckDB writer warm-up, local query server, heartbeat). The
  extensions module's `_loaded` guard makes the call safe even if the
  process later transitively imports `dashboard.py`. Errors are swallowed
  with a warning — a broken plugin must never take down the ingest daemon
  (it is the OSS install's only data source).

- **`tests/test_sync_loads_plugins.py`** — 3 hermetic tests:
  1. `run_daemon()` calls `extensions.load_plugins` exactly once at startup
  2. A raising `load_plugins` is swallowed (no `RuntimeError` propagates)
  3. The dashboard's own import-time hook is left intact

Default behaviour unchanged — the OSS install has zero registered entry-point
plugins, so `load_plugins()` is a fast no-op for free users. Stays in GRACE.

## Test plan

- [x] `python3 -m pytest tests/test_sync_loads_plugins.py -v` → 3 passed
- [x] `python3 -m pytest tests/test_extensions.py tests/test_entitlements.py tests/test_license.py tests/test_sync_loads_plugins.py` → 41 passed, 0 failed (no regressions)
- [x] `python3 -m ruff check clawmetry/sync.py tests/test_sync_loads_plugins.py` (only pre-existing sync.py findings — my hunk is clean)
- [x] `python3 -c "import ast; ast.parse(open('clawmetry/sync.py').read())"` syntax OK

## Local operator verification checklist

Since I cannot reach the user's machine, ~/.openclaw, the running daemon, the
live cloud snapshot, or a browser:

- [ ] Copy `clawmetry/sync.py` + `tests/test_sync_loads_plugins.py` into
      `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and the test into
      the daemon's test path if you run tests in-place)
- [ ] Clear `__pycache__` under that site-packages tree
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or
      `systemctl --user restart clawmetry-sync` (Linux)
- [ ] Tail the daemon log and confirm no new ERROR lines at startup
      (`tail -F ~/Library/Logs/clawmetry-sync.log` on macOS)
- [ ] Hit `http://localhost:8900/api/entitlement` — should still resolve as
      `tier: "oss"`, `grace: true` on the OSS install (no behaviour change)
- [ ] Decrypt the live cloud snapshot in the browser — sessions, brain feed,
      flow tab still render
- [ ] Once clawmetry-pro is installed against this build, confirm the daemon
      log shows `Loaded ClawMetry extension plugin: <plugin-name>` from the
      daemon process (previously only the dashboard process printed this)

Phases 3, 4, 6 (cloud entitlement push, closed-source clawmetry-pro wheel
publish, enterprise/SSO/RBAC) require the private `clawmetry-cloud` and
not-yet-existing `clawmetry-pro` repos that this autonomous run does not
have access to — left for the local operator.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TstWdXgmLkuHc1HHP5gtMf)_