### PR TITLE
fix(usage): per-runtime Cost/Usage tab scoping (#2254)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7030,7 +7030,7 @@ function _cmRuntimeLabel(rt) { return _CM_RT_LABEL[rt] || rt; }
 // shows an honest "all runtimes" note rather than pretending the numbers are
 // runtime-specific. (Per-runtime aggregation is a follow-up.)
 var _CM_RT_AGGREGATE = {
-  usage: 1, 'tool-catalog': 1, 'context-economics': 1, context: 1
+  'tool-catalog': 1, 'context-economics': 1, context: 1
 };
 // Tabs that are NODE-WIDE concepts, not per-runtime: crons run on the gateway,
 // memory/skills are workspace-level, security is machine posture, self-evolve is
@@ -10715,7 +10715,7 @@ async function loadUsage() {
     var _uRtQ = (_uRt && _uRt !== 'all') ? ('?runtime=' + encodeURIComponent(_uRt)) : '';
     var [_uResp, byPlugin] = await Promise.all([
       fetch('/api/usage' + _uRtQ).then(async function(r) { return {s: r.status, b: await r.json()}; }),
-      fetch('/api/usage/by-plugin').then(r => r.json()).catch(function(){ return {plugins: []}; })
+      fetch('/api/usage/by-plugin' + _uRtQ).then(r => r.json()).catch(function(){ return {plugins: []}; })
     ]);
     var data = _uResp.b || {};
     // Issue #1804: show outage banner when ingest is offline (503 envelope).
@@ -10732,6 +10732,17 @@ async function loadUsage() {
     document.getElementById('usage-week-cost').textContent = '≈ ' + fmtCost(data.weekCost);
     document.getElementById('usage-month').textContent = fmtTokens(data.month);
     document.getElementById('usage-month-cost').textContent = '≈ ' + fmtCost(data.monthCost);
+    // Runtime-scoped empty state: when a specific runtime is selected but has
+    // no cost data in any window, surface a clear note rather than showing all zeros.
+    var _uEmptyEl = document.getElementById('usage-runtime-empty-note');
+    if (_uRt && _uRt !== 'all' && !data.today && !data.week && !data.month) {
+      var _uRtLabel = _cmRuntimeLabel(_uRt);
+      var _uEmptyHtml = '<div id="usage-runtime-empty-note" style="margin:8px 0 12px;padding:9px 13px;border-radius:8px;background:rgba(99,102,241,0.07);border:1px solid rgba(99,102,241,0.25);font-size:12px;color:var(--text-secondary);">No cost data recorded for <strong>' + escHtml(_uRtLabel) + '</strong> yet.</div>';
+      var _uChart = document.getElementById('usage-chart');
+      if (!_uEmptyEl && _uChart) _uChart.insertAdjacentHTML('beforebegin', _uEmptyHtml);
+    } else {
+      if (_uEmptyEl) _uEmptyEl.remove();
+    }
 
     // Display cost warnings
     displayCostWarnings(data.warnings || []);

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -545,7 +545,7 @@ def _try_local_store_anomalies():
     }
 
 
-def _try_local_store_usage_by_plugin(threshold_pct):
+def _try_local_store_usage_by_plugin(threshold_pct, runtime=None):
     """Fast path for /api/usage/by-plugin. Groups events by plugin/tool
     name, splits each event's tokens/cost across the plugins implicated.
     Returns shape: {plugins: [...], warnings: [...]}."""
@@ -558,6 +558,7 @@ def _try_local_store_usage_by_plugin(threshold_pct):
         return None
     if not evs:
         return None
+    evs = _filter_evs_by_runtime(evs, runtime)
     # Issue #1451: sibling-dedupe so v3 assistant + model.completed pairs
     # don't double-count per-plugin tokens.
     bucket_max = build_sibling_bucket_max(evs)
@@ -1913,10 +1914,11 @@ def api_usage_by_plugin():
         threshold_pct_arg = float(request.args.get("threshold", 50.0))
     except (ValueError, TypeError):
         threshold_pct_arg = 50.0
+    _rt = (request.args.get("runtime") or "").strip() or None
 
     # Epic #964 — local-store fast path.
     if is_local_store_read_enabled():
-        fast = _try_local_store_usage_by_plugin(threshold_pct_arg)
+        fast = _try_local_store_usage_by_plugin(threshold_pct_arg, runtime=_rt)
         if fast is not None:
             return jsonify(fast)
 

--- a/tests/test_runtime_filter_no_leak.py
+++ b/tests/test_runtime_filter_no_leak.py
@@ -203,3 +203,47 @@ def test_runtime_summary_buckets_each_session_into_one_runtime(app_and_store):
     # Sanity: claude_code's primary is claude-opus, qwen's is qwen3:8b.
     assert runtimes["claude_code"]["primary_model"] == "claude-opus-4-7"
     assert runtimes["qwen_code"]["primary_model"] == "qwen3:8b"
+
+
+# ── 4. /api/usage?runtime= scopes with zero leakage ────────────────────────
+
+
+def test_usage_api_per_runtime_no_leak(app_and_store):
+    """Seeding distinct token counts per runtime and querying /api/usage?runtime=
+    must return exactly that runtime's tokens — no cross-adapter leak or loss."""
+    a, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    seeds = {
+        "claude_code:c1": ("claude-opus-4-7", 500),
+        "qwen_code:q1":   ("qwen3:8b",        300),
+        "bareuuid-z1":    ("claude-opus-4-7", 200),  # → openclaw bucket
+    }
+    for i, (sid, (model, toks)) in enumerate(seeds.items()):
+        store.ingest({
+            "id": f"{sid}-{i}",
+            "node_id": "test",
+            "agent_id": "main",
+            "session_id": sid,
+            "event_type": "tool_call",
+            "ts": _iso(now - 3600 + i),
+            "data": {},
+            "cost_usd": 0.01,
+            "token_count": toks,
+            "model": model,
+        })
+    _wait_flush(store)
+    cli = a.test_client()
+
+    expected_tokens = {"claude_code": 500, "qwen_code": 300, "openclaw": 200}
+    for rt, exp in expected_tokens.items():
+        body = cli.get(f"/api/usage?runtime={rt}").get_json() or {}
+        # today = tokens from events in the last 24 h for this runtime only.
+        actual = body.get("today") or 0
+        assert actual == exp, (
+            f"{rt}: expected {exp} tokens today, got {actual}. Body keys={list(body)}")
+
+    # Unfiltered total must equal the sum of all seeded tokens.
+    body_all = cli.get("/api/usage").get_json() or {}
+    assert (body_all.get("today") or 0) == sum(t for _, t in seeds.values()), (
+        f"unfiltered today mismatch: {body_all.get('today')}")


### PR DESCRIPTION
Closes #2254

## Summary
- Remove `usage` from `_CM_RT_AGGREGATE` in `app.js` — eliminates the deceptive amber "Showing all runtimes" note; the main `/api/usage?runtime=` call was already filtering correctly end-to-end
- Thread `?runtime=` through to `/api/usage/by-plugin` (fast-path helper + route handler) so the plugin attribution pie also scopes to the selected runtime
- Add runtime-aware empty state: when a specific runtime is selected but has zero tokens in all windows, surfaces a clear "No cost data recorded for [Runtime] yet" note instead of all-zero stats

## Test plan
- [ ] `python -m pytest tests/test_runtime_filter_no_leak.py -v` — 4 tests pass (new `test_usage_api_per_runtime_no_leak` seeds three runtimes with distinct token counts and asserts zero cross-adapter leak/loss for each `?runtime=` call)
- [ ] Select a runtime in the switcher → Cost tab: amber note is gone, today/week/month numbers reflect only that runtime's events
- [ ] Select a runtime with no events → "No cost data recorded for…" note appears above the chart
- [ ] `/api/usage/by-plugin?runtime=claude_code` returns only plugins used in claude_code sessions

---
_Generated by [Claude Code](https://claude.ai/code/session_01CErnGQQrfdnDD6HP8972T9)_