### PR TITLE
feat(local-query): expose spans + traces shapes in relay allowlist

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -3596,6 +3596,67 @@ class LocalStore:
             out.append(d)
         return out
 
+    def query_traces(
+        self,
+        *,
+        session_id: str | None = None,
+        agent_type: str | None = None,
+        since: float | None = None,
+        until: float | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """One row per distinct trace_id with aggregate stats.
+
+        Aggregates MIN(start_ts), MAX(end_ts), span_count, cost_usd,
+        tokens_input, tokens_output, and has_error across all spans
+        that share a trace_id. Returns [] gracefully when the spans
+        table is empty or not yet populated.
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        if session_id:
+            clauses.append("session_id = ?")
+            params.append(str(session_id))
+        if agent_type:
+            clauses.append("agent_type = ?")
+            params.append(str(agent_type))
+        if since is not None:
+            clauses.append("start_ts >= ?")
+            params.append(float(since))
+        if until is not None:
+            clauses.append("start_ts <= ?")
+            params.append(float(until))
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT
+                trace_id,
+                MAX(session_id)    AS session_id,
+                MAX(agent_type)    AS agent_type,
+                MIN(start_ts)      AS start_ts,
+                MAX(end_ts)        AS end_ts,
+                CAST((MAX(end_ts) - MIN(start_ts)) * 1000 AS DOUBLE) AS duration_ms,
+                COUNT(*)           AS span_count,
+                SUM(cost_usd)      AS cost_usd,
+                SUM(tokens_input)  AS tokens_input,
+                SUM(tokens_output) AS tokens_output,
+                MAX(CASE WHEN status = 'ERROR' THEN 1 ELSE 0 END) AS has_error
+            FROM spans
+            {where}
+            GROUP BY trace_id
+            ORDER BY MIN(start_ts) DESC
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = [
+            "trace_id", "session_id", "agent_type",
+            "start_ts", "end_ts", "duration_ms", "span_count",
+            "cost_usd", "tokens_input", "tokens_output", "has_error",
+        ]
+        try:
+            return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
+        except Exception:
+            return []
+
     def query_recent_spans(
         self,
         *,

--- a/clawmetry/relay.py
+++ b/clawmetry/relay.py
@@ -47,6 +47,8 @@ _CAPABILITIES = [
     "query.aggregates",
     "query.transcript",
     "query.health",
+    "query.spans",    # Issue #1013
+    "query.traces",   # Issue #1013
 ]
 
 

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -44,6 +44,8 @@ _SHAPES = {
     "aggregates": "query_aggregates",
     "health":     None,                 # special: no args
     "transcript": "query_events",       # alias with session_id required
+    "spans":      "query_spans",        # Issue #1013: full-filter span list
+    "traces":     "query_traces",       # Issue #1013: one row per trace_id
 }
 
 
@@ -192,6 +194,23 @@ def _coerce_args(shape: str, raw: dict) -> dict:
         }
     if shape == "health":
         return {}
+    if shape == "spans":
+        return {
+            "trace_id":   raw.get("trace_id"),
+            "session_id": raw.get("session_id"),
+            "agent_type": raw.get("agent_type"),
+            "since":      raw.get("since"),
+            "until":      raw.get("until"),
+            "limit":      _safe_int(raw.get("limit"), default=200, lo=1, hi=2000),
+        }
+    if shape == "traces":
+        return {
+            "session_id": raw.get("session_id"),
+            "agent_type": raw.get("agent_type"),
+            "since":      raw.get("since"),
+            "until":      raw.get("until"),
+            "limit":      _safe_int(raw.get("limit"), default=100, lo=1, hi=1000),
+        }
     raise ValueError(f"unknown shape: {shape}")
 
 
@@ -348,6 +367,26 @@ def http_span_detail(span_id: str):
     return jsonify({"available": True, "span": rows[0]})
 
 
+@bp_local_query.route("/api/local/spans", methods=["GET"])
+def http_spans():
+    """List spans. Filters: trace_id, session_id, agent_type, since, until, limit."""
+    try:
+        args = _coerce_args("spans", request.args.to_dict())
+        return jsonify(_dispatch("spans", args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
+@bp_local_query.route("/api/local/traces", methods=["GET"])
+def http_traces():
+    """List traces (one row per trace_id). Filters: session_id, agent_type, since, until, limit."""
+    try:
+        args = _coerce_args("traces", request.args.to_dict())
+        return jsonify(_dispatch("traces", args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
 @bp_local_query.route("/api/local/query", methods=["POST"])
 def http_query():
     """Generic shape-dispatched endpoint. Mirrors the WS relay frame format,
@@ -493,6 +532,9 @@ _DAEMON_METHODS = frozenset({
     # Issue #853: OTLP trace export. Full-filter variant used by
     # /api/export/traces when session_id / since / until are supplied.
     "query_spans",
+    # Issue #1013: Trace 7 — one row per trace_id with aggregate stats.
+    # Powers /api/local/traces + the cloud relay query.traces shape.
+    "query_traces",
     # Issue #1364 (Tier-1 2026-05-15): /api/fallbacks model/provider
     # transition aggregator. Replaces a JSONL walker that opened up to 100
     # transcript files per request — multi-second on a busy workspace.


### PR DESCRIPTION
Closes #1013

## Summary

- Add `"spans"` and `"traces"` to `_SHAPES` in `routes/local_query.py` so `/api/local/query` (and the cloud relay heartbeat-piggyback path) can dispatch these shapes to the node's DuckDB. The spans table and `query_spans` method were already fully landed from Trace 1 work; this PR wires them into the public contract.
- Add `query_traces()` to `LocalStore`: one row per `trace_id` aggregating `MIN(start_ts)`, `MAX(end_ts)`, `duration_ms`, `span_count`, `SUM(cost_usd)`, `SUM(tokens_input/output)`, and `has_error`. Returns `[]` gracefully on an empty store.
- Add `GET /api/local/spans` (list) and `GET /api/local/traces` endpoints alongside the existing `/api/local/spans/<span_id>` detail route.
- Add `"query.spans"` and `"query.traces"` to `relay._CAPABILITIES` to keep the doc/test snapshot in sync with `_SHAPES`.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('routes/local_query.py').read())"` — syntax clean (verified)
- [ ] `POST /api/local/query {"shape": "spans", "args": {}}` → `{"rows": [], "count": 0, "_shape": "spans"}` on empty store
- [ ] `POST /api/local/query {"shape": "traces", "args": {}}` → `{"rows": [], "count": 0, "_shape": "traces"}` on empty store
- [ ] `GET /api/local/spans` → 200 with `rows` key
- [ ] `GET /api/local/traces` → 200 with `rows` key
- [ ] Existing shapes (`events`, `sessions`, etc.) unaffected — shapes are additive

**Note:** Cloud-side `node_relay.py` (in `clawmetry-cloud`) needs a paired PR to add `spans` and `traces` to its routing allowlist before the end-to-end cloud relay path works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvfFknwaXzuhBPmpb4nvHZ)_