### PR TITLE
feat(runtime): custom-runtime HTTP ingest API (Pro)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -129,6 +129,7 @@ from routes.tool_catalog import bp_tool_catalog
 from routes.context_economics import bp_context_economics
 from routes.entitlement import bp_entitlement
 from routes.otel_export import bp_otel_export
+from routes.runtime_ingest import bp_runtime_ingest
 from routes.audit import bp_audit
 from helpers.openapi import bp_openapi
 
@@ -10609,6 +10610,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_memory)
     app.register_blueprint(bp_otel)
     app.register_blueprint(bp_otel_export)
+    app.register_blueprint(bp_runtime_ingest)
     app.register_blueprint(bp_otlp_traces)
     app.register_blueprint(bp_overview)
     app.register_blueprint(bp_security)

--- a/docs/CUSTOM_RUNTIME_INGEST.md
+++ b/docs/CUSTOM_RUNTIME_INGEST.md
@@ -1,0 +1,122 @@
+# Custom runtime HTTP ingest API
+
+Push events from any agent runtime into ClawMetry without writing to the
+OpenClaw / Claude Code filesystem layout. Designed for in-house agents,
+eval harnesses, and web agents that already produce structured run/step
+records.
+
+**Tier:** Pro (entitlement key `custom_runtime_ingest`). Free in grace mode
+until the enforce rollout flips on.
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET`  | `/api/v1/runtimes` | List runtimes ClawMetry knows about. Free. |
+| `POST` | `/api/v1/runs` | Open a run; returns `run_id`. |
+| `POST` | `/api/v1/runs/<id>/events` | Append one or many events. |
+| `POST` | `/api/v1/runs/<id>/end` | Mark the run ended. Optional. |
+| `GET`  | `/api/v1/runs/<id>` | Read-back: was the run persisted? |
+
+## Auth
+
+Two modes; the dashboard picks based on env:
+
+1. **Localhost-only (default):** if `CLAWMETRY_INGEST_TOKEN` is unset,
+   only loopback requests are accepted. Zero-config but local-only.
+2. **Token header:** set `CLAWMETRY_INGEST_TOKEN=<secret>` on the
+   dashboard; clients must send `X-ClawMetry-Token: <secret>`. The check
+   is constant-time.
+
+Non-localhost without a matching token returns `401 unauthorized`.
+
+## Quickstart
+
+```bash
+# Start a run
+curl -s http://localhost:8900/api/v1/runs \
+  -H 'content-type: application/json' \
+  -d '{"runtime": "my_engine", "metadata": {"build": "abc123"}}'
+# -> {"ok": true, "run_id": "run_a1b2c3d4...", "runtime": "my_engine"}
+
+# Push an event
+curl -s http://localhost:8900/api/v1/runs/run_a1b2c3d4/events \
+  -H 'content-type: application/json' \
+  -d '{"event": {
+        "id":         "evt_1",
+        "ts":         '"$(date +%s.%N)"',
+        "event_type": "model.completed",
+        "model":      "claude-3.5-sonnet",
+        "data":       {"input_tokens": 1240, "output_tokens": 312}
+      }}'
+# -> {"ok": true, "accepted": 1, "ids": ["evt_1"]}
+
+# Close it
+curl -s http://localhost:8900/api/v1/runs/run_a1b2c3d4/end \
+  -H 'content-type: application/json' -d '{}'
+```
+
+## Event payload
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | no | Dedupe key; server fills `evt_<hex>` if missing. Re-ingesting the same id is a no-op. |
+| `ts` | no | Epoch seconds (float). Server uses `time.time()` if missing. |
+| `event_type` | no | Free-form. Conventional values: `prompt.submitted`, `model.completed`, `tool.invoked`, `session.started`. |
+| `session_id` | no | Defaults to the `run_id`. |
+| `tool_name` | no | If the event represents a tool call. |
+| `model` | no | LLM model id. |
+| `role` | no | `user`, `assistant`, `system`, `tool`. |
+| `data` | no | Opaque dict; the daemon adds `data.extra.runtime = <runtime>`. |
+
+Batch shape: `{"events": [event, event, ...]}`. Cap is 1000 events per
+request. Split larger batches and retry.
+
+## Where the data goes
+
+Events go through `local_store.ingest`, which means:
+
+* Secret redaction (#2197) scrubs API-key-shaped values before they rest
+  in DuckDB.
+* Optional SIEM forwarding (#2199) sends to your Splunk / QRadar /
+  Elastic collector if `CLAWMETRY_SIEM_HOST` is set.
+* The Overview / Tracing / Brain / Usage tabs pick the run up
+  automatically; the runtime switcher shows it under whatever string you
+  passed in `runtime`.
+
+## Client recipes
+
+A minimal Python client (no extra dependencies):
+
+```python
+import os, time, uuid, requests
+
+API = os.environ.get("CLAWMETRY_URL", "http://localhost:8900")
+HEAD = {"content-type": "application/json"}
+tok = os.environ.get("CLAWMETRY_INGEST_TOKEN")
+if tok:
+    HEAD["X-ClawMetry-Token"] = tok
+
+def start_run(runtime="my_engine", **meta):
+    r = requests.post(f"{API}/api/v1/runs", json={"runtime": runtime, "metadata": meta}, headers=HEAD)
+    r.raise_for_status()
+    return r.json()["run_id"]
+
+def event(run_id, **fields):
+    fields.setdefault("id", f"evt_{uuid.uuid4().hex[:16]}")
+    fields.setdefault("ts", time.time())
+    requests.post(f"{API}/api/v1/runs/{run_id}/events", json={"event": fields}, headers=HEAD).raise_for_status()
+
+def end(run_id):
+    requests.post(f"{API}/api/v1/runs/{run_id}/end", json={}, headers=HEAD).raise_for_status()
+```
+
+## Error responses
+
+| Code | Body | Cause |
+|---|---|---|
+| 400 | `{"error":"bad_request","detail":"..."}` | Malformed event, batch >1000, ts not a number. |
+| 401 | `{"error":"unauthorized","hint":"..."}` | Token header missing or wrong, non-localhost without token. |
+| 402 | `{"error":"upgrade_required","feature":"custom_runtime_ingest",...}` | Enforce mode, tier doesn't unlock it. |
+| 503 | `{"error":"daemon_unavailable"}` | LocalStore writer not reachable. |
+| 500 | `{"error":"ingest_failed","detail":"..."}` | Anything else; bug or DuckDB error. Logged with traceback. |

--- a/routes/runtime_ingest.py
+++ b/routes/runtime_ingest.py
@@ -1,0 +1,313 @@
+"""routes/runtime_ingest.py — custom-runtime HTTP ingest API (Pro feature).
+
+Lets a customer-built agent runtime push events into ClawMetry without
+touching the filesystem layout that the OpenClaw/Claude-Code adapters watch.
+Useful for in-house frameworks, web agents, evaluation harnesses, anything
+that already produces structured run/step records.
+
+Endpoints (all gated on the ``custom_runtime_ingest`` entitlement):
+
+  POST /api/v1/runs                       — start a run; returns ``run_id``
+  POST /api/v1/runs/<run_id>/events       — append one or many events
+  POST /api/v1/runs/<run_id>/end          — close the run (optional)
+  GET  /api/v1/runtimes                   — list known runtimes (free)
+  GET  /api/v1/runs/<run_id>              — fetch metadata for a run
+
+Auth:
+* If ``CLAWMETRY_INGEST_TOKEN`` is set, requests must present an
+  ``X-ClawMetry-Token: <token>`` header (constant-time compared).
+* If unset, requests are accepted only from localhost (the same trust
+  surface the dashboard already runs on).
+
+Payload shape (single event)::
+
+    {
+      "id":           "evt_…",          # required, dedupe key
+      "ts":           1.234e9,          # required, epoch seconds
+      "event_type":   "model.completed",# required
+      "session_id":   "run_…",          # optional, defaults to run_id
+      "tool_name":    "Bash",           # optional
+      "model":        "claude-…",       # optional
+      "role":         "assistant",      # optional
+      "data":         {…}               # optional, opaque dict
+    }
+
+Bulk shape: ``{"events": [event, event, …]}``.
+
+Everything goes through ``local_store.ingest`` so secret redaction (#2197)
+and SIEM forwarding (#2199) still apply.
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+import time
+import uuid
+
+from flask import Blueprint, jsonify, request
+
+from clawmetry._gate import gate
+
+logger = logging.getLogger("clawmetry.routes.runtime_ingest")
+
+bp_runtime_ingest = Blueprint("runtime_ingest", __name__)
+
+
+# ── auth ───────────────────────────────────────────────────────────────────────
+
+
+def _is_localhost(req) -> bool:
+    """True when the request's remote_addr is loopback."""
+    addr = (req.remote_addr or "").strip()
+    return addr in ("127.0.0.1", "::1", "localhost", "")
+
+
+def _auth_ok(req) -> bool:
+    """Either localhost (zero-config) or a matching ingest-token header."""
+    expected = (os.environ.get("CLAWMETRY_INGEST_TOKEN") or "").strip()
+    if not expected:
+        return _is_localhost(req)
+    presented = (req.headers.get("X-ClawMetry-Token") or "").strip()
+    if not presented:
+        return False
+    return hmac.compare_digest(expected, presented)
+
+
+def _unauthorized():
+    return jsonify({
+        "error": "unauthorized",
+        "hint": (
+            "Set CLAWMETRY_INGEST_TOKEN on the dashboard and send the same "
+            "value in the X-ClawMetry-Token header, or call from localhost."
+        ),
+    }), 401
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _node_id() -> str:
+    """Stable node id (matches what the rest of clawmetry uses)."""
+    try:
+        import dashboard as _d
+
+        node = getattr(_d, "NODE_ID", None) or os.environ.get("CLAWMETRY_NODE_ID")
+        if node:
+            return str(node)
+    except Exception:
+        pass
+    return os.environ.get("HOSTNAME") or "node-local"
+
+
+def _store():
+    """Return the daemon's LocalStore writer (or None if not available)."""
+    try:
+        from clawmetry import local_store as _ls
+
+        return _ls.get_store()
+    except Exception as exc:
+        logger.warning("runtime_ingest: local_store unavailable: %s", exc)
+        return None
+
+
+def _normalise_event(ev: dict, run_id: str, runtime: str, node_id: str) -> dict:
+    """Fill required keys + default the optionals."""
+    out = dict(ev) if isinstance(ev, dict) else {}
+    out.setdefault("id", f"evt_{uuid.uuid4().hex[:16]}")
+    out.setdefault("ts", time.time())
+    out.setdefault("event_type", "event")
+    out.setdefault("session_id", run_id)
+    out["node_id"] = node_id
+    out["agent_type"] = runtime
+    # Stash the runtime label in data.extra too so existing analytics that
+    # group by runtime see it.
+    data = out.get("data") if isinstance(out.get("data"), dict) else {}
+    extra = data.get("extra") if isinstance(data.get("extra"), dict) else {}
+    extra.setdefault("runtime", runtime)
+    data["extra"] = extra
+    out["data"] = data
+    return out
+
+
+def _validate_event(ev: dict) -> tuple[bool, str]:
+    """Quick shape check on a single event payload."""
+    if not isinstance(ev, dict):
+        return False, "event must be an object"
+    et = ev.get("event_type") or ev.get("type")
+    if et is not None and not isinstance(et, str):
+        return False, "event_type must be a string"
+    ts = ev.get("ts") or ev.get("timestamp")
+    if ts is not None:
+        try:
+            float(ts)
+        except Exception:
+            return False, "ts must be a number"
+    sid = ev.get("session_id")
+    if sid is not None and not isinstance(sid, str):
+        return False, "session_id must be a string"
+    return True, ""
+
+
+# ── endpoints ──────────────────────────────────────────────────────────────────
+
+
+@bp_runtime_ingest.route("/api/v1/runtimes", methods=["GET"])
+def list_runtimes():
+    """List of runtimes we've seen events for. Free — same data the
+    runtime switcher in the header already reads. Useful for client SDKs
+    that want to introspect before pushing."""
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.runtime_catalog() if hasattr(_ent, "runtime_catalog") else []
+    except Exception as exc:
+        logger.warning("runtime_ingest: runtime catalog read failed: %s", exc)
+        rows = []
+    return jsonify({"runtimes": rows})
+
+
+@bp_runtime_ingest.route("/api/v1/runs", methods=["POST"])
+@gate("custom_runtime_ingest")
+def start_run():
+    """Open a new run. Returns ``run_id`` the client uses for subsequent
+    /events + /end calls. Accepts a client-supplied id if you'd rather
+    keep your own scheme; the server will accept and trust it.
+
+    Body (all optional)::
+
+        {
+          "run_id":   "client-provided id",
+          "runtime":  "my_engine",      # default "custom"
+          "metadata": {...}             # opaque, stored on the session
+        }
+    """
+    if not _auth_ok(request):
+        return _unauthorized()
+    body = request.get_json(silent=True) or {}
+    run_id = (body.get("run_id") or f"run_{uuid.uuid4().hex[:16]}").strip()
+    runtime = (body.get("runtime") or "custom").strip() or "custom"
+    metadata = body.get("metadata") if isinstance(body.get("metadata"), dict) else {}
+
+    store = _store()
+    if store is None:
+        return jsonify({"error": "daemon_unavailable"}), 503
+    node_id = _node_id()
+    try:
+        store.ingest_session({
+            "session_id": run_id,
+            "agent_type": runtime,
+            "node_id": node_id,
+            "metadata": metadata,
+            "started_at_ms": int(time.time() * 1000),
+        })
+    except Exception as exc:
+        logger.exception("runtime_ingest: ingest_session failed: %s", exc)
+        return jsonify({"error": "ingest_failed", "detail": str(exc)}), 500
+    return jsonify({"ok": True, "run_id": run_id, "runtime": runtime})
+
+
+@bp_runtime_ingest.route("/api/v1/runs/<run_id>/events", methods=["POST"])
+@gate("custom_runtime_ingest")
+def append_events(run_id: str):
+    """Append one or many events to a run.
+
+    Body either ``{"event": {...}}``, ``{"events": [...]}``, or a bare
+    event object. Returns ``accepted`` (the count) and the assigned ids
+    so the client can dedupe its own retry path.
+    """
+    if not _auth_ok(request):
+        return _unauthorized()
+    body = request.get_json(silent=True) or {}
+    if isinstance(body, dict) and "events" in body:
+        events = body.get("events") or []
+    elif isinstance(body, dict) and "event" in body:
+        events = [body["event"]]
+    elif isinstance(body, dict):
+        # Bare event object (id/ts/event_type at the top level).
+        events = [body]
+    else:
+        return jsonify({"error": "bad_request", "detail": "expected JSON object"}), 400
+    if not isinstance(events, list):
+        return jsonify({"error": "bad_request", "detail": "events must be an array"}), 400
+    if not events:
+        return jsonify({"ok": True, "accepted": 0, "ids": []})
+    if len(events) > 1000:
+        return jsonify({
+            "error": "bad_request",
+            "detail": "batch is capped at 1000 events; split and retry",
+        }), 400
+
+    store = _store()
+    if store is None:
+        return jsonify({"error": "daemon_unavailable"}), 503
+    node_id = _node_id()
+    runtime = (request.args.get("runtime") or "custom").strip() or "custom"
+    ids: list[str] = []
+    for raw in events:
+        ok, msg = _validate_event(raw)
+        if not ok:
+            return jsonify({"error": "bad_request", "detail": msg}), 400
+        norm = _normalise_event(raw, run_id=run_id, runtime=runtime, node_id=node_id)
+        try:
+            store.ingest(norm)
+            ids.append(norm["id"])
+        except Exception as exc:
+            logger.exception("runtime_ingest: ingest failed for %s: %s", norm.get("id"), exc)
+            return jsonify({
+                "error": "ingest_failed",
+                "accepted": len(ids),
+                "ids": ids,
+                "detail": str(exc),
+            }), 500
+    return jsonify({"ok": True, "accepted": len(ids), "ids": ids})
+
+
+@bp_runtime_ingest.route("/api/v1/runs/<run_id>/end", methods=["POST"])
+@gate("custom_runtime_ingest")
+def end_run(run_id: str):
+    """Mark a run as ended. Optional — long-lived runs work fine without
+    this; calling it just stamps ``ended_at_ms`` on the session row so
+    the Overview surfaces the right "active vs done" count."""
+    if not _auth_ok(request):
+        return _unauthorized()
+    body = request.get_json(silent=True) or {}
+    store = _store()
+    if store is None:
+        return jsonify({"error": "daemon_unavailable"}), 503
+    try:
+        # Use ingest_session as an upsert: pass session_id + ended_at_ms.
+        # local_store stamps the field on top of whatever started_at_ms /
+        # metadata is already there.
+        store.ingest_session({
+            "session_id": run_id,
+            "ended_at_ms": int(time.time() * 1000),
+            "metadata": body.get("metadata") if isinstance(body.get("metadata"), dict) else None,
+        })
+    except Exception as exc:
+        logger.exception("runtime_ingest: end_run failed: %s", exc)
+        return jsonify({"error": "ingest_failed", "detail": str(exc)}), 500
+    return jsonify({"ok": True, "run_id": run_id})
+
+
+@bp_runtime_ingest.route("/api/v1/runs/<run_id>", methods=["GET"])
+@gate("custom_runtime_ingest")
+def get_run(run_id: str):
+    """Read-back the run + its event count. Useful for clients that want
+    to confirm the daemon has persisted what they pushed."""
+    if not _auth_ok(request):
+        return _unauthorized()
+    try:
+        from routes.local_query import _dispatch
+
+        sessions = _dispatch("sessions", {"session_id": run_id}) or {}
+        events = _dispatch("events", {"session_id": run_id, "limit": 1}) or {}
+    except Exception as exc:
+        logger.warning("runtime_ingest: get_run dispatch failed: %s", exc)
+        return jsonify({"error": "read_failed", "detail": str(exc)}), 500
+    rows = sessions.get("sessions") if isinstance(sessions, dict) else None
+    return jsonify({
+        "run_id": run_id,
+        "session": (rows or [None])[0],
+        "has_events": bool(events.get("events") if isinstance(events, dict) else False),
+    })

--- a/tests/test_runtime_ingest.py
+++ b/tests/test_runtime_ingest.py
@@ -1,0 +1,198 @@
+"""Tests for routes/runtime_ingest.py — the Pro custom-runtime HTTP API.
+
+Pins the auth contract (localhost or token header), the entitlement gate
+(402 in enforce mode), the run-then-events happy path, and the basic
+shape validation. Uses a stub LocalStore so we don't need a daemon.
+"""
+from __future__ import annotations
+
+import importlib
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+
+class _StubStore:
+    def __init__(self):
+        self.events: list[dict] = []
+        self.sessions: list[dict] = []
+
+    def ingest(self, ev: dict):
+        self.events.append(ev)
+
+    def ingest_session(self, sess: dict):
+        self.sessions.append(sess)
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    """Flask app with the runtime_ingest blueprint + a stub store. Auth
+    defaults to localhost mode (no token configured)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_TOKEN", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as _ent
+    importlib.reload(_ent)
+    _ent.invalidate()
+
+    from routes import runtime_ingest as _ri
+    importlib.reload(_ri)
+
+    stub = _StubStore()
+    monkeypatch.setattr(_ri, "_store", lambda: stub)
+
+    app = Flask(__name__)
+    app.register_blueprint(_ri.bp_runtime_ingest)
+    app.config["TESTING"] = True
+    app._ri_store = stub  # type: ignore[attr-defined]
+    return app
+
+
+def test_runtimes_list_is_public_and_lists_known(app):
+    with app.test_client() as c:
+        r = c.get("/api/v1/runtimes")
+        assert r.status_code == 200
+        body = r.get_json()
+        assert isinstance(body["runtimes"], list)
+        # openclaw is in the catalog under the FREE bucket.
+        ids = [row["id"] for row in body["runtimes"]]
+        assert "openclaw" in ids
+
+
+def test_start_run_happy_path(app):
+    with app.test_client() as c:
+        r = c.post("/api/v1/runs", json={"runtime": "my_engine", "metadata": {"k": "v"}})
+        assert r.status_code == 200, r.get_data(as_text=True)
+        body = r.get_json()
+        assert body["ok"] is True
+        assert body["run_id"].startswith("run_")
+        assert body["runtime"] == "my_engine"
+    sessions = app._ri_store.sessions  # type: ignore[attr-defined]
+    assert len(sessions) == 1
+    assert sessions[0]["agent_type"] == "my_engine"
+
+
+def test_start_run_accepts_client_supplied_id(app):
+    with app.test_client() as c:
+        r = c.post("/api/v1/runs", json={"run_id": "my-run-42"})
+        assert r.status_code == 200
+        assert r.get_json()["run_id"] == "my-run-42"
+
+
+def test_append_events_single(app):
+    with app.test_client() as c:
+        c.post("/api/v1/runs", json={"run_id": "r1"})
+        r = c.post("/api/v1/runs/r1/events", json={
+            "event": {
+                "id": "evt_1", "ts": time.time(),
+                "event_type": "model.completed", "model": "claude-3.5",
+            }
+        })
+        assert r.status_code == 200, r.get_data(as_text=True)
+        body = r.get_json()
+        assert body["accepted"] == 1
+        assert body["ids"] == ["evt_1"]
+    evs = app._ri_store.events  # type: ignore[attr-defined]
+    assert len(evs) == 1
+    assert evs[0]["event_type"] == "model.completed"
+    assert evs[0]["session_id"] == "r1"
+
+
+def test_append_events_bulk_and_fills_required_keys(app):
+    with app.test_client() as c:
+        c.post("/api/v1/runs", json={"run_id": "r2"})
+        r = c.post("/api/v1/runs/r2/events", json={
+            "events": [
+                {"event_type": "prompt.submitted"},  # id + ts filled in
+                {"event_type": "model.completed", "model": "gpt-5"},
+            ],
+        })
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body["accepted"] == 2
+        assert len(body["ids"]) == 2
+    evs = app._ri_store.events  # type: ignore[attr-defined]
+    assert {e["event_type"] for e in evs} == {"prompt.submitted", "model.completed"}
+    # Each event should have an id, ts, node_id, agent_type filled in.
+    for e in evs:
+        assert e["id"]
+        assert e["ts"]
+        assert e["node_id"]
+        assert e["agent_type"]
+
+
+def test_append_events_rejects_oversized_batch(app):
+    with app.test_client() as c:
+        c.post("/api/v1/runs", json={"run_id": "r3"})
+        events = [{"event_type": "x"} for _ in range(1001)]
+        r = c.post("/api/v1/runs/r3/events", json={"events": events})
+        assert r.status_code == 400
+        assert r.get_json()["error"] == "bad_request"
+
+
+def test_append_events_validates_event_shape(app):
+    with app.test_client() as c:
+        c.post("/api/v1/runs", json={"run_id": "r4"})
+        # ts that isn't a number
+        r = c.post("/api/v1/runs/r4/events", json={
+            "event": {"event_type": "x", "ts": "not-a-number"},
+        })
+        assert r.status_code == 400
+        assert "ts" in r.get_json()["detail"]
+
+
+def test_end_run_stamps_ended_at(app):
+    with app.test_client() as c:
+        c.post("/api/v1/runs", json={"run_id": "r5"})
+        r = c.post("/api/v1/runs/r5/end", json={})
+        assert r.status_code == 200
+    # ingest_session was called twice: once for start, once for end.
+    sessions = app._ri_store.sessions  # type: ignore[attr-defined]
+    end_calls = [s for s in sessions if s.get("ended_at_ms")]
+    assert len(end_calls) == 1
+    assert end_calls[0]["session_id"] == "r5"
+
+
+# ── auth ───────────────────────────────────────────────────────────────────────
+
+
+def test_token_required_when_configured(app, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_INGEST_TOKEN", "secret-token")
+    # The route reads the env var at request time, not module load, so just
+    # set it and call.
+    with app.test_client() as c:
+        # No header → 401
+        r = c.post("/api/v1/runs", json={})
+        assert r.status_code == 401
+        # Wrong header → 401
+        r = c.post("/api/v1/runs", json={}, headers={"X-ClawMetry-Token": "wrong"})
+        assert r.status_code == 401
+        # Right header → 200
+        r = c.post("/api/v1/runs", json={}, headers={"X-ClawMetry-Token": "secret-token"})
+        assert r.status_code == 200
+
+
+# ── entitlement gate ──────────────────────────────────────────────────────────
+
+
+def test_gate_returns_402_when_enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as _ent
+    importlib.reload(_ent)
+    _ent.invalidate()
+
+    from routes import runtime_ingest as _ri
+    importlib.reload(_ri)
+
+    app = Flask(__name__)
+    app.register_blueprint(_ri.bp_runtime_ingest)
+
+    with app.test_client() as c:
+        r = c.post("/api/v1/runs", json={})
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["feature"] == "custom_runtime_ingest"


### PR DESCRIPTION
## What
HTTP API that lets a customer-built agent runtime push events into ClawMetry without touching the OpenClaw / Claude Code filesystem layout. Closes the /pricing Pro promise "Custom runtime ingest API".

## Endpoints

| Method | Path | Tier | Description |
|---|---|---|---|
| GET  | `/api/v1/runtimes` | Free | List known runtimes |
| POST | `/api/v1/runs` | Pro | Open a run; returns `run_id` |
| POST | `/api/v1/runs/<id>/events` | Pro | Append one or many events |
| POST | `/api/v1/runs/<id>/end` | Pro | Close a run (optional) |
| GET  | `/api/v1/runs/<id>` | Pro | Read-back a run |

Every write route is gated on `@gate("custom_runtime_ingest")` so enforce mode returns `402 upgrade_required` for tiers that don't unlock it.

## Auth
- `CLAWMETRY_INGEST_TOKEN` env var. If set, `X-ClawMetry-Token` header must match (constant-time compare).
- If unset, only loopback is accepted (zero-config local dev).

## Quickstart
```bash
curl -s http://localhost:8900/api/v1/runs \
  -H 'content-type: application/json' \
  -d '{"runtime": "my_engine"}'
# -> {"ok": true, "run_id": "run_a1b2c3d4..."}

curl -s http://localhost:8900/api/v1/runs/run_a1b2c3d4/events \
  -H 'content-type: application/json' \
  -d '{"event": {"event_type": "model.completed", "model": "claude-3.5-sonnet"}}'
# -> {"ok": true, "accepted": 1, "ids": ["evt_..."]}
```

## Tests
`tests/test_runtime_ingest.py` - 10 tests covering happy path, bulk append, oversized-batch rejection (>1000), ts validation, end-run stamping, token auth modes, and the 402 enforce-mode gate. Uses a stub LocalStore so no daemon required.

```
tests/test_runtime_ingest.py ..........  [100%]  10 passed
```

## Where the data goes
All events flow through `local_store.ingest`, so:
- Secret redaction (#2197) scrubs API-key-shaped values before they rest in DuckDB
- SIEM forwarding (#2199) sends to your Splunk/QRadar/Elastic if configured
- Overview / Tracing / Brain / Usage tabs surface the run automatically; runtime switcher shows whatever string you passed as `runtime`

## Docs
`docs/CUSTOM_RUNTIME_INGEST.md` - quickstart curl, payload schema, Python client snippet, error response table.

## Closes
Part of #2262 (open-core pricing audit). Closes the "Custom runtime ingest API" Pro gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)