### PR TITLE
feat(otel): OTLP/HTTP push exporter (Datadog / Grafana / Honeycomb) (Pro)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1636,6 +1636,14 @@ class LocalStore:
             _siem.forward_event(event)
         except Exception:
             pass  # never let the SIEM hook block ingest
+        # Optional OTLP/HTTP push forward (Pro feature; #2262 catalogue).
+        # Off unless CLAWMETRY_OTLP_ENDPOINT is set + tier unlocks
+        # otel_export. Same non-blocking-enqueue contract as SIEM.
+        try:
+            from clawmetry import otel_push as _otelp
+            _otelp.forward_event(event)
+        except Exception:
+            pass  # never let the OTLP push hook block ingest
         with self._ring_lock:
             if len(self._ring) >= RING_MAX:
                 self._dropped += 1

--- a/clawmetry/otel_push.py
+++ b/clawmetry/otel_push.py
@@ -1,0 +1,373 @@
+"""clawmetry/otel_push.py - OTLP/HTTP push exporter (Pro feature).
+
+Periodically POSTs recent ClawMetry events as OTLP/JSON logRecords to a
+customer-configured OpenTelemetry collector (Datadog, Grafana, Honeycomb,
+or any OTel-compatible endpoint). Companion to ``routes/otel_export.py``
+which is the *pull* shape (collector polls us).
+
+Why push as well as pull?
+* Push fits the Datadog / Honeycomb / Grafana Cloud model (their agents
+  read from sources, they don't host pull endpoints).
+* It works behind NAT / firewalls without exposing the dashboard.
+
+Wiring: ``LocalStore.ingest()`` forwards each event to ``forward_event()``
+(non-blocking enqueue). A background thread batches up to N events or
+waits up to flush_interval seconds, then POSTs the OTLP envelope.
+
+Defense-in-depth: by the time an event reaches us it has already been
+scrubbed by ``redact_event``, so no secret values leave the box even if
+the collector is hostile.
+
+Config (env vars; all optional, exporter is off by default):
+
+    CLAWMETRY_OTLP_ENDPOINT      collector URL, e.g.
+                                 https://api.honeycomb.io/v1/logs
+                                 https://http-intake.logs.datadoghq.com/api/v2/logs
+                                 http://localhost:4318/v1/logs
+    CLAWMETRY_OTLP_HEADERS       comma-separated "Key: Value" pairs
+                                 e.g. "x-honeycomb-team: abc123,x-honeycomb-dataset: clawmetry"
+    CLAWMETRY_OTLP_BATCH_MAX     max events per flush (default 200)
+    CLAWMETRY_OTLP_FLUSH_SECS    flush cadence in seconds (default 10)
+    CLAWMETRY_OTLP_TIMEOUT_SECS  HTTP timeout (default 5)
+    CLAWMETRY_OTLP_QUEUE_MAX     bounded queue size (default 10000)
+
+Entitlement: ``otel_export`` (Pro tier; see clawmetry.com/pricing). When
+``CLAWMETRY_OTLP_ENDPOINT`` is set but the tier doesn't unlock the key,
+the exporter logs a clear warning and refuses to start.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from typing import Any, Optional
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+_log = logging.getLogger("clawmetry.otel_push")
+
+
+# ── envelope helpers (mirror routes/otel_export.py) ───────────────────────────
+
+
+def _event_to_log_record(ev: dict) -> dict:
+    """Map a ClawMetry event row to an OTLP LogRecord (JSON)."""
+    ts = ev.get("ts") or ev.get("timestamp") or 0
+    try:
+        ts_ns = str(int(float(ts) * 1_000_000_000))
+    except Exception:
+        ts_ns = "0"
+    event_type = str(ev.get("event_type") or ev.get("type") or "event")
+    body = event_type
+    role = ev.get("role")
+    if not role and isinstance(ev.get("data"), dict):
+        role = ev["data"].get("role")
+
+    attrs: list[dict] = []
+
+    def _add(k: str, v):
+        if v is None or v == "":
+            return
+        if isinstance(v, bool):
+            attrs.append({"key": k, "value": {"boolValue": v}})
+        elif isinstance(v, int):
+            attrs.append({"key": k, "value": {"intValue": str(v)}})
+        elif isinstance(v, float):
+            attrs.append({"key": k, "value": {"doubleValue": v}})
+        else:
+            attrs.append({"key": k, "value": {"stringValue": str(v)[:512]}})
+
+    _add("session_id", ev.get("session_id"))
+    _add("event_type", event_type)
+    _add("role", role)
+    _add("tool_name", ev.get("tool_name") or ev.get("toolName"))
+    _add("model", ev.get("model"))
+    _add("agent_type", ev.get("agent_type") or "openclaw")
+    _add("node_id", ev.get("node_id"))
+
+    return {
+        "timeUnixNano": ts_ns,
+        "severityNumber": 9,
+        "severityText": "INFO",
+        "body": {"stringValue": body},
+        "attributes": attrs,
+    }
+
+
+def _build_otlp_envelope(events: list[dict]) -> dict:
+    """Wrap LogRecords in the OTLP/JSON resourceLogs/scopeLogs envelope."""
+    return {
+        "resourceLogs": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "clawmetry"}},
+                        {"key": "telemetry.sdk.name", "value": {"stringValue": "clawmetry-otel-push"}},
+                    ]
+                },
+                "scopeLogs": [
+                    {
+                        "scope": {"name": "clawmetry.events", "version": "1"},
+                        "logRecords": [_event_to_log_record(e) for e in events],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _parse_headers(raw: str) -> dict[str, str]:
+    """Parse a ``"K1: V1, K2: V2"`` string into a dict. Tolerant of bad
+    pieces (drops a malformed pair, keeps going)."""
+    out: dict[str, str] = {}
+    if not raw:
+        return out
+    for piece in raw.split(","):
+        piece = piece.strip()
+        if not piece or ":" not in piece:
+            continue
+        k, _, v = piece.partition(":")
+        k = k.strip()
+        v = v.strip()
+        if k and v:
+            out[k] = v
+    return out
+
+
+# ── HTTP writer ───────────────────────────────────────────────────────────────
+
+
+class _HTTPWriter:
+    """Tiny OTLP/HTTP poster using urllib (no requests dep)."""
+
+    def __init__(self, endpoint: str, headers: dict[str, str], timeout: float) -> None:
+        self._endpoint = endpoint
+        self._headers = dict(headers)
+        self._headers.setdefault("content-type", "application/json")
+        self._timeout = timeout
+
+    def send(self, envelope: dict) -> None:
+        """POST an OTLP envelope. Raises on transport error or non-2xx."""
+        body = json.dumps(envelope).encode("utf-8")
+        req = urlrequest.Request(self._endpoint, data=body, method="POST")
+        for k, v in self._headers.items():
+            req.add_header(k, v)
+        try:
+            with urlrequest.urlopen(req, timeout=self._timeout) as resp:
+                code = getattr(resp, "status", 200)
+                if not (200 <= int(code) < 300):
+                    raise RuntimeError(f"otel-collector returned {code}")
+        except urlerror.HTTPError as exc:
+            raise RuntimeError(f"otel-collector {exc.code} {exc.reason}") from exc
+
+    def close(self) -> None:
+        # urllib has no persistent connection to close.
+        pass
+
+
+# ── Exporter ──────────────────────────────────────────────────────────────────
+
+
+class OTLPPushExporter:
+    """Bounded-queue, single-thread batching exporter.
+
+    Designed to never block ingest: ``send()`` is a non-blocking enqueue;
+    the worker drains in the background. When the queue is full or the
+    collector is unreachable, events are dropped and counted rather than
+    back-pressuring the daemon.
+    """
+
+    def __init__(
+        self,
+        writer: _HTTPWriter,
+        *,
+        batch_max: int = 200,
+        flush_secs: float = 10.0,
+        queue_size: int = 10_000,
+    ) -> None:
+        self._writer = writer
+        self._batch_max = int(batch_max)
+        self._flush_secs = float(flush_secs)
+        self._q: queue.Queue[Optional[dict[str, Any]]] = queue.Queue(maxsize=queue_size)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="otel-push-exporter", daemon=True)
+        self._thread.start()
+        self.sent_count = 0
+        self.dropped_count = 0
+        self.error_count = 0
+        self.flush_count = 0
+
+    def send(self, event: dict[str, Any]) -> None:
+        try:
+            self._q.put_nowait(event)
+        except queue.Full:
+            self.dropped_count += 1
+
+    def close(self, timeout: float = 2.0) -> None:
+        self._stop.set()
+        try:
+            self._q.put_nowait(None)
+        except queue.Full:
+            pass
+        self._thread.join(timeout=timeout)
+        try:
+            self._writer.close()
+        except Exception:
+            pass
+
+    def _drain_batch(self, max_wait: float) -> list[dict[str, Any]]:
+        """Pull up to ``batch_max`` events; return early when ``max_wait``
+        seconds have elapsed since the first event was pulled."""
+        batch: list[dict[str, Any]] = []
+        deadline: float | None = None
+        while len(batch) < self._batch_max:
+            timeout = max_wait if not batch else max(0.0, (deadline or 0.0) - time.monotonic())
+            if not batch and self._stop.is_set():
+                break
+            try:
+                ev = self._q.get(timeout=timeout)
+            except queue.Empty:
+                break
+            if ev is None:
+                self._stop.set()
+                break
+            batch.append(ev)
+            if deadline is None:
+                deadline = time.monotonic() + max_wait
+        return batch
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            batch = self._drain_batch(self._flush_secs)
+            if not batch:
+                continue
+            envelope = _build_otlp_envelope(batch)
+            try:
+                self._writer.send(envelope)
+                self.sent_count += len(batch)
+                self.flush_count += 1
+            except Exception as exc:
+                self.error_count += 1
+                self.dropped_count += len(batch)
+                _log.debug("otel-push: flush failed (%s); dropped %d", exc, len(batch))
+
+    def stats(self) -> dict:
+        return {
+            "sent": self.sent_count,
+            "dropped": self.dropped_count,
+            "errors": self.error_count,
+            "flushes": self.flush_count,
+            "queue_size": self._q.qsize(),
+        }
+
+
+# ── Singleton wiring ──────────────────────────────────────────────────────────
+
+
+_singleton: Optional[OTLPPushExporter] = None
+_singleton_lock = threading.Lock()
+
+
+def _otel_push_entitled() -> bool:
+    """Whether this install may run the OTLP push exporter. Grace mode
+    lets everyone through; after enforce, only Pro+ installs do."""
+    try:
+        from clawmetry import entitlements as _ent
+        return _ent.get_entitlement().allows_feature("otel_export")
+    except Exception:  # pragma: no cover
+        return True
+
+
+def _build_default_writer() -> Optional[_HTTPWriter]:
+    endpoint = os.environ.get("CLAWMETRY_OTLP_ENDPOINT", "").strip()
+    if not endpoint:
+        return None
+    headers = _parse_headers(os.environ.get("CLAWMETRY_OTLP_HEADERS", ""))
+    try:
+        timeout = float(os.environ.get("CLAWMETRY_OTLP_TIMEOUT_SECS", "5") or "5")
+    except ValueError:
+        timeout = 5.0
+    return _HTTPWriter(endpoint, headers, timeout=timeout)
+
+
+def get_default_exporter() -> Optional[OTLPPushExporter]:
+    """Return the process-wide exporter, building it from env vars on
+    first call. Returns ``None`` when ``CLAWMETRY_OTLP_ENDPOINT`` is
+    unset OR the install's tier doesn't unlock ``otel_export``."""
+    global _singleton
+    if _singleton is not None:
+        return _singleton
+    with _singleton_lock:
+        if _singleton is not None:
+            return _singleton
+        writer = _build_default_writer()
+        if writer is None:
+            return None
+        if not _otel_push_entitled():
+            _log.warning(
+                "otel-push: CLAWMETRY_OTLP_ENDPOINT is set but the current tier "
+                "does not unlock 'otel_export' (Pro feature on clawmetry.com/pricing). "
+                "Exporter will not start. Set CLAWMETRY_ENFORCE=0 to bypass."
+            )
+            return None
+        try:
+            batch_max = int(os.environ.get("CLAWMETRY_OTLP_BATCH_MAX", "200") or "200")
+        except ValueError:
+            batch_max = 200
+        try:
+            flush_secs = float(os.environ.get("CLAWMETRY_OTLP_FLUSH_SECS", "10") or "10")
+        except ValueError:
+            flush_secs = 10.0
+        try:
+            queue_max = int(os.environ.get("CLAWMETRY_OTLP_QUEUE_MAX", "10000") or "10000")
+        except ValueError:
+            queue_max = 10_000
+        _singleton = OTLPPushExporter(
+            writer,
+            batch_max=batch_max,
+            flush_secs=flush_secs,
+            queue_size=queue_max,
+        )
+        _log.info(
+            "otel-push: exporter active (endpoint=%s batch_max=%d flush_secs=%.1f)",
+            os.environ.get("CLAWMETRY_OTLP_ENDPOINT"),
+            batch_max,
+            flush_secs,
+        )
+    return _singleton
+
+
+def forward_event(event: dict[str, Any]) -> None:
+    """Daemon-side hook called from ``LocalStore.ingest`` after redaction.
+    Cheap when disabled (single env-var check via the singleton getter)."""
+    exp = get_default_exporter()
+    if exp is None:
+        return
+    exp.send(event)
+
+
+def reset_for_tests() -> None:
+    """Test-only helper. Closes the singleton so a fresh one is built
+    next call (the next call may again return None if env vars are cleared)."""
+    global _singleton
+    with _singleton_lock:
+        if _singleton is not None:
+            try:
+                _singleton.close(timeout=0.5)
+            except Exception:
+                pass
+        _singleton = None
+
+
+def stats() -> dict:
+    """Return a snapshot of the exporter's counters, or an empty dict
+    when the exporter isn't running. Useful for the status endpoint."""
+    exp = _singleton
+    if exp is None:
+        return {"running": False}
+    s = exp.stats()
+    s["running"] = True
+    return s

--- a/docs/OTEL_PUSH_EXPORTER.md
+++ b/docs/OTEL_PUSH_EXPORTER.md
@@ -1,0 +1,99 @@
+# OTLP/HTTP push exporter
+
+Periodically POSTs ClawMetry events as OTLP/JSON `logRecords` to a customer
+OpenTelemetry collector. Works with Datadog, Grafana Cloud, Honeycomb, or
+any OTel collector that accepts OTLP/HTTP logs on a `/v1/logs` endpoint.
+
+**Tier:** Pro (entitlement key `otel_export`).
+
+## Why push as well as pull?
+
+The existing `GET /api/otel/export` endpoint is the *pull* shape: a collector
+polls ClawMetry. That works for in-cluster OTel collectors, but Datadog,
+Grafana Cloud, and Honeycomb all read from sources rather than hosting pull
+endpoints. The push exporter posts to them on a flush cadence.
+
+It also works behind NAT or a firewall without exposing the dashboard.
+
+## Enable
+
+Set two env vars on the dashboard (or sync daemon) and restart:
+
+```bash
+export CLAWMETRY_OTLP_ENDPOINT="https://api.honeycomb.io/v1/logs"
+export CLAWMETRY_OTLP_HEADERS="x-honeycomb-team: YOUR_KEY, x-honeycomb-dataset: clawmetry"
+```
+
+That's it. Every event that lands in DuckDB after redaction is enqueued and
+flushed every 10 seconds (default).
+
+Confirm it's running:
+
+```bash
+curl http://localhost:8900/api/otel/push/status
+# -> {"running": true, "sent": 1240, "dropped": 0, "errors": 0,
+#     "flushes": 31, "queue_size": 12, "endpoint": "...", "tier_allows": true}
+```
+
+To verify the endpoint + headers without waiting for the next flush:
+
+```bash
+curl -XPOST http://localhost:8900/api/otel/push/flush?limit=5
+# -> {"ok": true, "sent": 5}
+```
+
+## Endpoint recipes
+
+| Vendor | Endpoint | Headers |
+|---|---|---|
+| Honeycomb | `https://api.honeycomb.io/v1/logs` | `x-honeycomb-team: KEY, x-honeycomb-dataset: clawmetry` |
+| Datadog | `https://http-intake.logs.datadoghq.com/api/v2/logs` | `DD-API-KEY: KEY, content-type: application/json` |
+| Grafana Cloud (OTLP) | `https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/logs` | `Authorization: Basic BASE64(user:token)` |
+| Local OTel collector | `http://localhost:4318/v1/logs` | (none) |
+
+For Datadog specifically, the OTLP-JSON envelope is accepted but you may
+prefer to point at an in-cluster collector configured for the Datadog
+exporter to get full feature parity.
+
+## Tuning
+
+| Env var | Default | Description |
+|---|---|---|
+| `CLAWMETRY_OTLP_BATCH_MAX` | 200 | Max events per flush |
+| `CLAWMETRY_OTLP_FLUSH_SECS` | 10 | Seconds between flushes |
+| `CLAWMETRY_OTLP_TIMEOUT_SECS` | 5 | HTTP request timeout |
+| `CLAWMETRY_OTLP_QUEUE_MAX` | 10000 | Bounded queue size; older drop on overflow |
+
+The exporter is bounded by design. When the queue is full or the collector
+is unreachable, events are dropped and counted (`stats().dropped`) rather
+than back-pressuring ingest.
+
+## Data shape
+
+Each event becomes one OTLP `LogRecord`:
+
+```json
+{
+  "timeUnixNano": "1700000000500000000",
+  "severityNumber": 9,
+  "severityText": "INFO",
+  "body":   {"stringValue": "model.completed"},
+  "attributes": [
+    {"key": "session_id", "value": {"stringValue": "sess_…"}},
+    {"key": "event_type", "value": {"stringValue": "model.completed"}},
+    {"key": "model",      "value": {"stringValue": "claude-3.5-sonnet"}},
+    {"key": "node_id",    "value": {"stringValue": "node-1"}},
+    {"key": "agent_type", "value": {"stringValue": "openclaw"}}
+  ]
+}
+```
+
+Wrapped in the standard `resourceLogs/scopeLogs/logRecords` envelope with
+`service.name = clawmetry`.
+
+## Security
+
+By the time an event reaches the push exporter it has already been scrubbed
+by `redact_event` (see `clawmetry/redaction.py`), so API keys, OAuth tokens,
+and the other tracked patterns will not leave the box even if the collector
+is hostile.

--- a/routes/otel_export.py
+++ b/routes/otel_export.py
@@ -138,3 +138,69 @@ def api_otel_export():
         limit = 200
     events = _fetch_events(limit)
     return jsonify(_build_otlp_envelope(events))
+
+
+@bp_otel_export.route("/api/otel/push/status", methods=["GET"])
+def api_otel_push_status():
+    """Counters for the OTLP/HTTP push exporter (clawmetry/otel_push.py).
+
+    Returns ``{running: bool, sent, dropped, errors, flushes, queue_size,
+    endpoint, tier_allows}`` so operators can verify their
+    ``CLAWMETRY_OTLP_ENDPOINT`` is configured + the Pro tier unlocks the
+    feature. Free to call (no auth, no entitlement)."""
+    out: dict = {}
+    try:
+        from clawmetry import otel_push as _otelp
+        out.update(_otelp.stats())
+    except Exception as exc:
+        out["error"] = str(exc)
+    try:
+        import os as _os
+        out["endpoint"] = _os.environ.get("CLAWMETRY_OTLP_ENDPOINT", "") or None
+    except Exception:
+        out["endpoint"] = None
+    try:
+        from clawmetry import entitlements as _ent
+        en = _ent.get_entitlement()
+        out["tier"] = en.tier
+        out["tier_allows"] = en.allows_feature("otel_export")
+    except Exception:
+        out["tier_allows"] = None
+    return jsonify(out)
+
+
+@bp_otel_export.route("/api/otel/push/flush", methods=["POST"])
+def api_otel_push_flush():
+    """Sample the most recent events and synchronously POST them through
+    the push exporter's writer once. Useful for verifying a customer's
+    OTLP collector URL + headers without waiting for the next flush
+    tick. Pro+ gated."""
+    allowed, ent = _entitlement_allows()
+    if not allowed:
+        return jsonify({
+            "error": "upgrade_required",
+            "feature": "otel_export",
+            "tier": ent.get("tier"),
+            "hint": "OTel push is a Pro feature on clawmetry.com/pricing",
+        }), 402
+    try:
+        limit = max(1, min(int(request.args.get("limit", 50) or 50), 500))
+    except Exception:
+        limit = 50
+    events = _fetch_events(limit)
+    if not events:
+        return jsonify({"ok": True, "sent": 0, "detail": "no events to flush"})
+    try:
+        from clawmetry import otel_push as _otelp
+        writer = _otelp._build_default_writer()
+        if writer is None:
+            return jsonify({
+                "error": "not_configured",
+                "hint": "Set CLAWMETRY_OTLP_ENDPOINT (and optional CLAWMETRY_OTLP_HEADERS).",
+            }), 400
+        envelope = _otelp._build_otlp_envelope(events)
+        writer.send(envelope)
+    except Exception as exc:
+        logger.warning("otel_push: manual flush failed: %s", exc)
+        return jsonify({"error": "flush_failed", "detail": str(exc)}), 502
+    return jsonify({"ok": True, "sent": len(events)})

--- a/tests/test_otel_push.py
+++ b/tests/test_otel_push.py
@@ -1,0 +1,195 @@
+"""Tests for clawmetry/otel_push.py (Pro OTLP/HTTP push exporter).
+
+Covers:
+* Envelope shape (OTLP/JSON logRecords with attributes)
+* Header parser tolerance
+* Disabled-by-default contract (no env -> no exporter)
+* Entitlement gate (env set but tier doesn't unlock -> still no exporter)
+* Batching + flush
+* Bounded-queue drop behaviour
+* Stub HTTP transport (no live network)
+"""
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+
+
+@pytest.fixture
+def fresh(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.delenv("CLAWMETRY_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("CLAWMETRY_OTLP_HEADERS", raising=False)
+    monkeypatch.delenv("CLAWMETRY_OTLP_BATCH_MAX", raising=False)
+    monkeypatch.delenv("CLAWMETRY_OTLP_FLUSH_SECS", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as _ent
+    importlib.reload(_ent)
+    _ent.invalidate()
+
+    import clawmetry.otel_push as _otelp
+    importlib.reload(_otelp)
+    _otelp.reset_for_tests()
+    yield _otelp
+    _otelp.reset_for_tests()
+
+
+class _StubWriter:
+    def __init__(self):
+        self.sent: list[dict] = []
+        self.fail = False
+
+    def send(self, envelope):
+        if self.fail:
+            raise RuntimeError("collector down")
+        self.sent.append(envelope)
+
+    def close(self):
+        pass
+
+
+# ── envelope ───────────────────────────────────────────────────────────────────
+
+
+def test_envelope_shape_is_otlp_logs(fresh):
+    env = fresh._build_otlp_envelope([
+        {
+            "id": "e1", "ts": 1700000000.5, "event_type": "model.completed",
+            "session_id": "s1", "model": "claude-3.5", "node_id": "n1",
+        }
+    ])
+    assert "resourceLogs" in env
+    rl = env["resourceLogs"][0]
+    assert rl["scopeLogs"][0]["scope"]["name"] == "clawmetry.events"
+    rec = rl["scopeLogs"][0]["logRecords"][0]
+    # ts in nanoseconds.
+    assert rec["timeUnixNano"] == "1700000000500000000"
+    assert rec["body"]["stringValue"] == "model.completed"
+    keys = {a["key"] for a in rec["attributes"]}
+    assert {"session_id", "event_type", "model", "node_id"}.issubset(keys)
+
+
+def test_envelope_handles_missing_ts(fresh):
+    env = fresh._build_otlp_envelope([{"id": "e1", "event_type": "x"}])
+    rec = env["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]
+    assert rec["timeUnixNano"] == "0"
+
+
+# ── header parser ──────────────────────────────────────────────────────────────
+
+
+def test_parse_headers_handles_real_world_pairs(fresh):
+    raw = "x-honeycomb-team: abc123, x-honeycomb-dataset: clawmetry"
+    parsed = fresh._parse_headers(raw)
+    assert parsed == {"x-honeycomb-team": "abc123", "x-honeycomb-dataset": "clawmetry"}
+
+
+def test_parse_headers_drops_malformed_pieces(fresh):
+    parsed = fresh._parse_headers("good: yes, malformed, also-bad: , : value, key: val2")
+    assert parsed == {"good": "yes", "key": "val2"}
+
+
+def test_parse_headers_empty(fresh):
+    assert fresh._parse_headers("") == {}
+    assert fresh._parse_headers("   ") == {}
+
+
+# ── singleton gate ─────────────────────────────────────────────────────────────
+
+
+def test_no_endpoint_means_no_exporter(fresh):
+    assert fresh.get_default_exporter() is None
+
+
+def test_endpoint_set_in_grace_starts_exporter(fresh, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_OTLP_ENDPOINT", "http://localhost:4318/v1/logs")
+    exp = fresh.get_default_exporter()
+    assert exp is not None
+    # Idempotent.
+    assert fresh.get_default_exporter() is exp
+
+
+def test_endpoint_set_but_enforced_oss_refuses(fresh, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_OTLP_ENDPOINT", "http://localhost:4318/v1/logs")
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as _ent
+    importlib.reload(_ent)
+    _ent.invalidate()
+    importlib.reload(fresh)
+    fresh.reset_for_tests()
+
+    assert fresh.get_default_exporter() is None
+
+
+# ── batching + flush ───────────────────────────────────────────────────────────
+
+
+def test_exporter_batches_and_flushes(fresh):
+    stub = _StubWriter()
+    exp = fresh.OTLPPushExporter(stub, batch_max=3, flush_secs=0.05, queue_size=100)
+    try:
+        for i in range(5):
+            exp.send({"id": f"e{i}", "ts": time.time(), "event_type": "x"})
+        # Wait for at least 2 flushes (3 + 2).
+        deadline = time.time() + 3.0
+        while time.time() < deadline and exp.sent_count < 5:
+            time.sleep(0.05)
+        assert exp.sent_count == 5
+        # First flush has 3 records.
+        first = stub.sent[0]["resourceLogs"][0]["scopeLogs"][0]["logRecords"]
+        assert len(first) == 3
+    finally:
+        exp.close(timeout=1.0)
+
+
+def test_writer_failure_drops_batch_and_counts(fresh):
+    stub = _StubWriter()
+    stub.fail = True
+    exp = fresh.OTLPPushExporter(stub, batch_max=2, flush_secs=0.05, queue_size=100)
+    try:
+        for i in range(4):
+            exp.send({"id": f"e{i}", "ts": time.time(), "event_type": "x"})
+        deadline = time.time() + 3.0
+        while time.time() < deadline and exp.error_count < 2:
+            time.sleep(0.05)
+        assert exp.sent_count == 0
+        assert exp.dropped_count >= 2
+        assert exp.error_count >= 2
+    finally:
+        exp.close(timeout=1.0)
+
+
+def test_bounded_queue_drops_when_full(fresh):
+    stub = _StubWriter()
+    exp = fresh.OTLPPushExporter(stub, batch_max=10, flush_secs=10.0, queue_size=3)
+    # Don't run the worker; fill the queue beyond capacity.
+    exp._stop.set()
+    exp._thread.join(timeout=0.5)
+    for i in range(10):
+        exp.send({"id": f"e{i}", "ts": 0, "event_type": "x"})
+    assert exp.dropped_count >= 7
+    exp.close(timeout=0.5)
+
+
+# ── forward_event passthrough ──────────────────────────────────────────────────
+
+
+def test_forward_event_no_op_when_disabled(fresh):
+    # No env, no exporter -> forward_event is a cheap no-op.
+    fresh.forward_event({"id": "e1", "event_type": "x"})
+
+
+def test_forward_event_enqueues_when_active(fresh, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_OTLP_ENDPOINT", "http://localhost:4318/v1/logs")
+    exp = fresh.get_default_exporter()
+    assert exp is not None
+    qsize_before = exp._q.qsize()
+    fresh.forward_event({"id": "e1", "event_type": "x"})
+    # Worker may have already drained it; either way, send() did not raise.
+    qsize_after = exp._q.qsize()
+    assert qsize_after >= qsize_before  # never negative


### PR DESCRIPTION
## What
Bounded-queue, single-thread background exporter that periodically POSTs ClawMetry events to a customer-configured OpenTelemetry collector in the OTLP/JSON logRecords shape. Closes the /pricing Pro promise "OTel export to Datadog / Grafana / Honeycomb".

## Why push as well as pull?
The existing `GET /api/otel/export` is the *pull* shape (collector polls us). Datadog, Grafana Cloud, and Honeycomb all read from sources rather than hosting pull endpoints. Push also works behind NAT / firewalls without exposing the dashboard.

## Architecture (mirrors `clawmetry/siem.py`)
- `OTLPPushExporter` class — bounded queue, background thread, batches up to `CLAWMETRY_OTLP_BATCH_MAX` events or waits `CLAWMETRY_OTLP_FLUSH_SECS` seconds, then POSTs.
- `_HTTPWriter` — uses `urllib` (no `requests` dep added).
- `forward_event()` wired into `LocalStore.ingest` AFTER `redact_event`, so API keys / tokens never leave the box via OTLP either.
- Singleton `get_default_exporter()` refuses to start when `CLAWMETRY_OTLP_ENDPOINT` is set but the install's tier doesn't unlock `otel_export` (same shape as `siem_export`).

## Endpoints
| Method | Path | Tier | Description |
|---|---|---|---|
| GET  | `/api/otel/push/status` | Free | sent / dropped / errors / flushes / queue_size + endpoint + tier_allows |
| POST | `/api/otel/push/flush` | Pro | Manual flush (verify a customer's collector URL + headers without waiting) |

## Vendor recipes (full table in [docs/OTEL_PUSH_EXPORTER.md](docs/OTEL_PUSH_EXPORTER.md))
| Vendor | Endpoint | Headers |
|---|---|---|
| Honeycomb | `https://api.honeycomb.io/v1/logs` | `x-honeycomb-team: KEY, x-honeycomb-dataset: clawmetry` |
| Datadog | `https://http-intake.logs.datadoghq.com/api/v2/logs` | `DD-API-KEY: KEY` |
| Grafana Cloud | `https://otlp-gateway-…grafana.net/otlp/v1/logs` | `Authorization: Basic …` |
| Local OTel | `http://localhost:4318/v1/logs` | (none) |

## Quickstart
```bash
export CLAWMETRY_OTLP_ENDPOINT="https://api.honeycomb.io/v1/logs"
export CLAWMETRY_OTLP_HEADERS="x-honeycomb-team: YOUR_KEY, x-honeycomb-dataset: clawmetry"
# restart the dashboard
curl http://localhost:8900/api/otel/push/status
# -> {"running": true, "sent": 1240, "flushes": 31, "queue_size": 12, ...}
```

## Tests
`tests/test_otel_push.py` — 13 tests:
- OTLP envelope shape + missing-ts handling
- Header parser tolerance (drops malformed pieces)
- Disabled-by-default + grace-mode startup
- Entitlement gate (env set but enforced OSS tier returns `None`)
- Batching + flush with stub HTTP writer
- Writer failure increments `error_count` + `dropped_count`
- Bounded-queue drop accounting
- `forward_event` no-op when disabled

```
tests/test_otel_push.py .............              [100%]  13 passed
tests/test_entitlements*.py + test_route_gates.py  [100%]  40 passed (no regressions)
```

## Closes
Part of #2262 (open-core pricing audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)