### PR TITLE
feat(entitlements): move NemoClaw to FREE_RUNTIMES alongside OpenClaw

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -7,16 +7,18 @@ nothing should gate on a hardcoded plan check scattered across routes.
 
 Open-core model
 ---------------
-* **FREE** (this OSS package): the OpenClaw runtime + NeMo governance + the
-  core observability surface. Always available — no key, no network call.
+* **FREE** (this OSS package): the OpenClaw + NVIDIA NemoClaw runtimes +
+  NeMo governance + the core observability surface. Always available — no
+  key, no network call.
 * **PAID** (the closed-source ``clawmetry-pro`` package, fetched only with
   a valid license key or a cloud entitlement — it is *not* shipped in this
   repo): the other agent runtimes (Claude Code, Codex, Cursor, …), the
   advanced features (custom alerts, multi-node fleet, anomaly detection, …),
   and paid CLI capabilities.
 
-  NeMo is a *governance feature*, not an agent runtime, so it stays FREE.
-  The free runtime set is therefore ``{"openclaw"}``.
+  NeMo governance (policy enforcement on top of any runtime) remains a free
+  *feature* (``nemo_governance``). The ``nemoclaw`` agent runtime is also
+  free and sits alongside ``openclaw`` in ``FREE_RUNTIMES``.
 
 Resolution order (first hit wins), all cached
 ---------------------------------------------
@@ -64,8 +66,10 @@ _PAID_TIERS = frozenset(
 )
 
 # ── Runtime catalogue ───────────────────────────────────────────────────────
-# FREE: the OpenClaw runtime only. NeMo is governance, not a runtime.
-FREE_RUNTIMES = frozenset({"openclaw"})
+# FREE: the OpenClaw and NVIDIA NemoClaw runtimes. NeMo *governance* (policy
+# enforcement) is a separate free feature; ``nemoclaw`` here is the agent
+# runtime itself, which is part of the free tier alongside ``openclaw``.
+FREE_RUNTIMES = frozenset({"openclaw", "nemoclaw"})
 
 # PAID: every other agent runtime ClawMetry can observe. These ship in the
 # closed-source ``clawmetry-pro`` package, not here — listed so the UI can
@@ -94,6 +98,7 @@ ALL_RUNTIMES = FREE_RUNTIMES | PAID_RUNTIMES
 # without a label here is safe — but please add one.
 RUNTIME_LABELS = {
     "openclaw": "OpenClaw",
+    "nemoclaw": "NemoClaw",
     "claude_code": "Claude Code",
     "codex": "Codex",
     "cursor": "Cursor",

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -45,7 +45,7 @@ def api_entitlement():
                 "is_paid": False,
                 "grace": True,
                 "enforced": False,
-                "runtimes": ["openclaw"],
+                "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
             }
         )
@@ -91,12 +91,19 @@ def api_runtimes():
             {
                 "runtimes": [
                     {
+                        "id": "nemoclaw",
+                        "label": "NemoClaw",
+                        "free": True,
+                        "allowed": True,
+                        "locked": False,
+                    },
+                    {
                         "id": "openclaw",
                         "label": "OpenClaw",
                         "free": True,
                         "allowed": True,
                         "locked": False,
-                    }
+                    },
                 ],
                 "grace": True,
                 "enforced": False,

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -89,10 +89,12 @@ def test_is_enforced_env_parsing(ent, monkeypatch):
 # ── catalogue invariants ────────────────────────────────────────────────────────
 
 
-def test_free_runtimes_is_openclaw_only(ent):
-    assert ent.FREE_RUNTIMES == frozenset({"openclaw"})
+def test_free_runtimes_is_openclaw_and_nemoclaw(ent):
+    # NVIDIA NemoClaw is a free-tier agent runtime alongside OpenClaw
+    # (issue #2289). NeMo *governance* is a separate free feature.
+    assert ent.FREE_RUNTIMES == frozenset({"openclaw", "nemoclaw"})
     assert "claude_code" in ent.PAID_RUNTIMES
-    assert "nemoclaw" not in ent.PAID_RUNTIMES  # NeMo is governance, not a runtime
+    assert "nemoclaw" not in ent.PAID_RUNTIMES
     assert ent.FREE_RUNTIMES.isdisjoint(ent.PAID_RUNTIMES)
 
 


### PR DESCRIPTION
Closes #2289

## What

Move the `nemoclaw` agent runtime into `FREE_RUNTIMES` so it sits alongside `openclaw` on the free tier, both in grace and once enforcement flips on.

Until now `FREE_RUNTIMES` held only `{"openclaw"}` and NeMo was treated purely as a free governance *feature* (`nemo_governance`). Per the open-core pricing model in #2288, the `nemoclaw` runtime itself is also free — only the other harnesses (Claude Code, Codex, Cursor, etc.) are gated.

## How

- `clawmetry/entitlements.py`
  - `FREE_RUNTIMES = frozenset({"openclaw", "nemoclaw"})`
  - Added `"nemoclaw": "NemoClaw"` to `RUNTIME_LABELS` so the dashboard switcher and `/api/runtimes` catalog render a proper label.
  - Refreshed the open-core docstring to distinguish `nemo_governance` (feature) from the `nemoclaw` runtime.
- `routes/entitlement.py`
  - Updated the never-raise fallback shapes for `/api/entitlement` and `/api/runtimes` to include the `nemoclaw` row, so the UI keeps rendering it even when entitlement resolution errors out.
- `tests/test_entitlements.py`
  - Pinned `FREE_RUNTIMES == frozenset({"openclaw", "nemoclaw"})` exactly and renamed the membership test. The existing assertions about `runtime_catalog` ordering, label coverage, and the enforced-OSS path already key off `FREE_RUNTIMES`, so they exercise the new runtime without further edits.

## Verification

```
$ python3 -m pytest tests/test_entitlements.py tests/test_nemo_adapter_pro_gate.py \
                   tests/test_nemoclaw_events_metrics.py tests/test_nemoclaw_governance.py \
                   tests/test_tier_pro_paywall_no_flash.py -q
52 passed, 5 skipped in 2.22s
```

Acceptance criteria from the issue:

- [x] `Entitlement(tier=TIER_OSS, grace=False).allows_runtime("nemoclaw")` → `True`
- [x] `/api/entitlement` returns `"nemoclaw"` in `runtimes` for OSS
- [x] NemoClaw adapter instantiates without a license or cloud plan (no changes were needed in `clawmetry/adapters/nemo.py`; it never read entitlement-runtime membership, only `_is_pro` for the daily cap)
- [x] All affected tests updated and green