### PR TITLE
feat(sync): add firstRun snapshot key (foundation for #1189 activation UX)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -776,6 +776,55 @@ def _record_sync_progress(
         log.debug(f"Could not record sync progress ({phase}): {e}")
 
 
+def _build_first_run() -> dict:
+    """Snapshot key for the activation first-run UX (#1189 P0.1).
+
+    Pure passthrough of ``sync_progress.json`` + the in-process
+    ``_sync_progress_done`` flag. The cloud ``cm-cloud-firstrun``
+    interceptor derives the 4-state UI from this:
+
+      0  Connecting     no progress file yet
+      1  Syncing        progress file exists, ``done`` is false
+      2  First value    first session present in the snapshot
+      3  Activated      done AND at least one session
+
+    Keeping the state machine client-side avoids coupling the daemon
+    to UI semantics — the cloud can adjust state derivation without an
+    OSS release.
+
+    Safe to call frequently: just a file read and a couple of in-process
+    globals. Never raises (graceful fallbacks per CLAUDE.md).
+    """
+    out = {
+        "done": bool(_sync_progress_done),
+        "started_at": _sync_progress_started_at,
+        "phase": None,
+        "phase_done": 0,
+        "phase_total": 0,
+        "status": None,
+        "updated_at": None,
+    }
+    try:
+        if SYNC_PROGRESS_FILE.exists():
+            p = json.loads(SYNC_PROGRESS_FILE.read_text())
+            out["phase"] = p.get("phase")
+            try:
+                out["phase_done"] = int(p.get("done") or 0)
+            except (TypeError, ValueError):
+                pass
+            try:
+                out["phase_total"] = int(p.get("total") or 0)
+            except (TypeError, ValueError):
+                pass
+            out["status"] = p.get("status")
+            out["updated_at"] = p.get("updated_at")
+            if p.get("started_at"):
+                out["started_at"] = p["started_at"]
+    except Exception as e:
+        log.debug(f"_build_first_run: progress read failed: {e}")
+    return out
+
+
 # ── HTTP ──────────────────────────────────────────────────────────────────────
 
 
@@ -11370,6 +11419,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "machineInfo": _build_machine_info(),
         "channelList": _build_channel_list(config),
         "ollamaInfo": _detect_ollama_for_heartbeat(),
+        "firstRun": _build_first_run(),
         "diagnostics": _build_diagnostics(paths.get("workspace")),
         "modelAttribution": _build_model_attribution(),
         "runtimeSummary": _build_runtime_summary(),


### PR DESCRIPTION
> First OSS slice of cloud issue **vivekchand/clawmetry-cloud#1189** (P0.1 activation — fix the empty-dashboard first impression that's killing the connect→7d-active funnel).

## Why

The biggest leak in the activation funnel is the first 60 seconds after \`pip install clawmetry && clawmetry\`. The daemon already records initial-sync phase progress to \`sync_progress.json\` (from #748), but **nothing in the snapshot exposes that to the cloud renderer** — so the cloud dashboard renders empty for a freshly-installed node until ingest finishes, and the user assumes the product is broken and closes the tab.

This PR ships the **data** the cloud needs. The cloud's \`cm-cloud-firstrun\` interceptor + UX (separate PR in clawmetry-cloud) will read it.

## What

Adds a \`firstRun\` top-level key to \`sync_system_snapshot\`:

\`\`\`json
{
  "done": false,
  "started_at": "2026-05-29T08:00:00Z",
  "phase": "sessions",
  "phase_done": 1204,
  "phase_total": 5000,
  "status": "in_progress",
  "updated_at": "2026-05-29T08:00:15Z"
}
\`\`\`

Pure passthrough of \`sync_progress.json\` + the in-process \`_sync_progress_done\` flag. The cloud interceptor derives the 4-state UI:

| State | Meaning |
|---|---|
| 0 Connecting | progress file absent |
| 1 Syncing | progress file present, \`done=false\` |
| 2 First value | first session present in the snapshot |
| 3 Activated | \`done=true\` AND at least one session |

State derivation lives client-side on purpose — the cloud can tweak the state machine without an OSS release.

## Cost

Just a file read + a couple of globals per snapshot build. Never raises (file read wrapped in try/except per CLAUDE.md graceful-fallback rule). No DuckDB query in the hot path; \`first_session_id\` is derivable client-side from the existing \`transcripts\` / \`sessions\` snapshot keys.

## Sequencing

1. **This PR** — daemon ships \`firstRun\` in snapshot.
2. \`[RELEASE]\` PR — publish to PyPI.
3. Cloud — bump pin + ship \`cm-cloud-firstrun\` interceptor that renders the 4-state UX client-side (\`window.__cmSnap\` reuse — no new fetch per FLYWHEEL ⚡).
4. Cloud — emit \`firstrun.state\` events via \`window.cmTrack\` (the #1206 beacon, already live) so #1189's activation funnel populates in the admin Funnel v2 (#1218).

🤖 Generated with [Claude Code](https://claude.com/claude-code)