### PR TITLE
docs(prd): trial drops to 7 days in plan matrix (closes #2290)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -30,7 +30,7 @@ Three product pillars: **zero config**, **read-only by default** (we observe age
 |---|---|---|---|---|---|---|---|---|---|
 | **OSS only** | $0 | ✓ | — | — | local only | — | — | local only | n/a |
 | **Cloud Free** | $0 | ✓ | ✓ (heartbeat only) | heartbeat only | 1 alert visible | empty queue | — | — | `free` |
-| **Cloud Trial** | $0 / 14 d | ✓ | ✓ | full | unlimited | full | unlimited | full | `trial` |
+| **Cloud Trial** | $0 / 7 d | ✓ | ✓ | full | unlimited | full | unlimited | full | `trial` |
 | **Cloud Pro** | paid | ✓ | ✓ | full | unlimited | full | unlimited | full | `cloud_pro` |
 | **Trial-Expired** | $0 | ✓ | dashboard frozen at last sync | paused | view only | view only | view only | partial | `trial_expired` |
 


### PR DESCRIPTION
Closes #2290 · Part of #2288

## What

`PRD.md:33` was the last place still listing `Cloud Trial | $0 / 14 d`. The rest of the OSS surface (dashboard upgrade CTAs, CLI welcome prompt, paywall partial, sync-side trial copy) already says **7-day free trial**, so the PRD plan matrix was the only drift.

## How

One-line edit in `PRD.md:33`:

```diff
- | **Cloud Trial** | $0 / 14 d | ✓ | ✓ | ... | `trial` |
+ | **Cloud Trial** | $0 / 7 d  | ✓ | ✓ | ... | `trial` |
```

## Audit (acceptance criteria from the issue)

- `grep -rIn '14[- ]day'` → zero hits in trial contexts (remaining `14d` references are token-usage charts, perf fixtures, and the prompt-cache window — not trial)
- `grep -rIn '7[- ]day'` → covers all trial mentions (`dashboard.py:1289/1339/5892/17618`, CLI `build/lib/clawmetry/cli.py:552`, paywall test `tests/test_tier_pro_paywall_no_flash.py:51`)
- PRD matrix reflects 7-day trial ✓

## Out of scope for this PR

- Cloud-side `TRIAL_DAYS` constant + Stripe `trial_period_days` — tracked in `vivekchand/clawmetry-cloud#1210`
- Annual SKU, self-hosted Pro SKU, NemoClaw-free rollout — `#2288` epic + sibling issue `#2289` (PR #2299) + `#2294` (copy)

🤖 Auto-implemented by Dhriti (cron: clawmetry-gh-issues → MC → PR). Vivek reviews and merges.