### PR TITLE
feat(extensions): thread Flask app through load_plugins so plugins can register blueprints

### DIFF
--- a/clawmetry/extensions.py
+++ b/clawmetry/extensions.py
@@ -82,7 +82,7 @@ def _select_entry_points(group: str):
     return list(eps.get(group, []))  # 3.9 dict form
 
 
-def load_plugins() -> None:
+def load_plugins(app=None) -> None:
     """
     Auto-discover and load extension plugins via entry points.
     Called once at dashboard startup.
@@ -91,8 +91,19 @@ def load_plugins() -> None:
         [project.entry-points."clawmetry.extensions"]
         myplugin = "mypkg.ext:register_all"
 
-    The entry point value must be a callable that takes no arguments
-    and calls register() for each event it handles.
+    The entry point value is a callable. Backward-compatible signatures:
+
+    * ``register_all()`` (no args) — receives only the event-bus handle via
+      :func:`register`. Plugins that only subscribe to events can stay this
+      shape; calling them with no args is what shipped pre-2026-05-29.
+    * ``register_all(app)`` — receives the Flask app so the plugin can
+      register Blueprints on it. Required for plugins that ship routes
+      (e.g., ``clawmetry-pro`` ships the runtime-ingest + OTel push
+      blueprints).
+
+    Detection is via :func:`inspect.signature`. A plugin that declares an
+    ``app`` parameter gets it; one that does not is still called with no
+    args. This way old plugins keep working without bumping their pin.
     """
     global _loaded
     if _loaded:
@@ -104,10 +115,24 @@ def load_plugins() -> None:
     except Exception:
         return
 
+    import inspect
+
     for ep in eps:
         try:
             fn = ep.load()
-            fn()
+            # Pass ``app`` only when the plugin accepts it. Older plugins
+            # with ``register_all()`` (no args) keep working unchanged.
+            accepts_app = False
+            if app is not None:
+                try:
+                    sig = inspect.signature(fn)
+                    accepts_app = len(sig.parameters) >= 1
+                except (TypeError, ValueError):
+                    accepts_app = False
+            if accepts_app:
+                fn(app)
+            else:
+                fn()
             logger.info(f"Loaded ClawMetry extension plugin: {ep.name!r}")
         except Exception as exc:
             logger.warning(f"Failed to load extension plugin {ep.name!r}: {exc}")

--- a/dashboard.py
+++ b/dashboard.py
@@ -160,14 +160,18 @@ except ImportError:
 
 __version__ = "0.12.367"
 
-# Extensions (Phase 2) — load plugins at import time; safe no-op if package not installed
+# Extensions (Phase 2): import the plugin host now, but defer the actual
+# load_plugins() call until after the Flask app is created below so we can
+# hand each plugin the app and let it register blueprints. The host falls
+# back to a no-op when the package itself is unavailable.
 try:
     from clawmetry.extensions import emit as _ext_emit, load_plugins as _ext_load
-
-    _ext_load()
 except ImportError:
 
     def _ext_emit(event, payload=None):
+        pass  # noqa
+
+    def _ext_load(app=None):
         pass  # noqa
 
 
@@ -176,6 +180,11 @@ app = Flask(
     static_folder=os.path.join(os.path.dirname(__file__), 'clawmetry', 'static'),
     template_folder=os.path.join(os.path.dirname(__file__), 'clawmetry', 'templates'),
 )
+
+# Plugins (e.g. ``clawmetry-pro``) can now register Blueprints on ``app``.
+# Older plugins with ``register_all()`` (no args) keep working unchanged:
+# the loader inspects the signature and only passes ``app`` when accepted.
+_ext_load(app)
 
 # ── Cross-platform helpers ──────────────────────────────────────────────
 import re as _re

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -40,3 +40,100 @@ def test_emit_swallows_handler_errors():
 
     ext.register("test.evt.boom", boom)
     ext.emit("test.evt.boom", {})  # must not propagate
+
+
+# ── load_plugins(app) signature introspection (Phase 1.2) ────────────────────
+
+
+class _FakeEntryPoint:
+    """Stub entry point that returns ``fn`` from ``.load()`` and has ``.name``."""
+
+    def __init__(self, fn, name="fake"):
+        self._fn = fn
+        self.name = name
+
+    def load(self):
+        return self._fn
+
+
+def _fake_eps(*fns_with_names):
+    return [_FakeEntryPoint(fn, name=n) for fn, n in fns_with_names]
+
+
+def test_load_plugins_calls_old_style_with_no_args(monkeypatch):
+    """A plugin that declares ``register_all()`` is still called no-args
+    even when ``load_plugins(app)`` is invoked. Backward-compat."""
+    monkeypatch.setattr(ext, "_loaded", False)
+    calls = []
+
+    def register_all():
+        calls.append("no-args")
+
+    monkeypatch.setattr(ext, "_select_entry_points",
+                        lambda group: _fake_eps((register_all, "old")))
+    ext.load_plugins(app=object())  # passes app, plugin ignores it
+    assert calls == ["no-args"]
+
+
+def test_load_plugins_passes_app_when_plugin_accepts_it(monkeypatch):
+    monkeypatch.setattr(ext, "_loaded", False)
+    received = []
+
+    def register_all(app):
+        received.append(app)
+
+    sentinel = {"flask-app": True}
+    monkeypatch.setattr(ext, "_select_entry_points",
+                        lambda group: _fake_eps((register_all, "new")))
+    ext.load_plugins(app=sentinel)
+    assert received == [sentinel]
+
+
+def test_load_plugins_with_no_app_never_passes_app(monkeypatch):
+    """Calling ``load_plugins()`` (no args) never invokes a plugin with an
+    arg, even when the plugin accepts one. Lets older OSS dashboards that
+    haven't been updated keep working."""
+    monkeypatch.setattr(ext, "_loaded", False)
+    calls = []
+
+    def register_all(app=None):
+        calls.append(app)
+
+    monkeypatch.setattr(ext, "_select_entry_points",
+                        lambda group: _fake_eps((register_all, "new")))
+    ext.load_plugins()  # no app
+    assert calls == [None] or calls == []  # depending on Python signature handling
+
+
+def test_load_plugins_swallows_plugin_exceptions(monkeypatch):
+    """One bad plugin must not break the others."""
+    monkeypatch.setattr(ext, "_loaded", False)
+    other_called = []
+
+    def boom(app):
+        raise RuntimeError("boom")
+
+    def good(app):
+        other_called.append(app)
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((boom, "boom"), (good, "good")),
+    )
+    sentinel = object()
+    ext.load_plugins(app=sentinel)  # must not raise
+    assert other_called == [sentinel]
+
+
+def test_load_plugins_handles_unintrospectable_callable(monkeypatch):
+    """Built-in callables with no inspectable signature must not crash the
+    loader; we fall back to no-args invocation for them."""
+    monkeypatch.setattr(ext, "_loaded", False)
+    # ``min`` is a builtin whose signature() may raise on some Python
+    # versions / contexts. We just need any callable that takes args and
+    # could raise during signature introspection.
+    monkeypatch.setattr(ext, "_select_entry_points",
+                        lambda group: _fake_eps((min, "builtin")))
+    # Must not raise; ``min()`` with no args would error, but we wrap the
+    # call in try/except in the loader, so it gets logged + swallowed.
+    ext.load_plugins(app=object())


### PR DESCRIPTION
## What
Tightens the plugin entry point so closed-source extension packages (starting with clawmetry-pro) can register Flask Blueprints on the OSS dashboard's app, not just subscribe to events on the in-process bus.

## Why
Phase 1 of the open-core move ships paid feature routes (custom-runtime HTTP ingest, OTel push, ...) inside clawmetry-pro. To install those routes on the dashboard at startup the plugin needs the Flask app. Before this PR \`load_plugins()\` took no args, so plugins could only register event-bus handlers; Blueprint registration was impossible.

## What changes
- \`clawmetry/extensions.py\`: \`load_plugins(app=None)\`. Loader inspects each plugin's \`register_all\` signature: passes \`app\` if it accepts one, calls no-args otherwise. Backward compatible.
- \`dashboard.py\`: move \`_ext_load()\` from module-import time to after \`app = Flask(...)\` is created, and pass \`app\` to it.

## Tests
\`tests/test_extensions.py\` gains 5 new tests:
- Old-style \`register_all()\` still called no-args even when \`load_plugins(app)\`
- New-style \`register_all(app)\` receives the app
- \`load_plugins()\` (no args) never passes app
- One bad plugin doesn't break the others
- Unintrospectable callables (built-ins) don't crash the loader

\`\`\`
tests/test_extensions.py ..........  [100%]  10 passed (5 existing + 5 new)
\`\`\`

## Phase 1 sequence
1. clawmetry-pro PR #12 (private): import the moved Pro features
2. **this PR**: extend \`load_plugins\` to pass app
3. follow-up OSS PR: replace OSS implementations with 402 \`upgrade_required\` stubs at the same URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)