### PR TITLE
docs(PRD): reduce trial from 14d to 7d in plan matrix

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -30,7 +30,7 @@ Three product pillars: **zero config**, **read-only by default** (we observe age
 |---|---|---|---|---|---|---|---|---|---|
 | **OSS only** | $0 | ✓ | — | — | local only | — | — | local only | n/a |
 | **Cloud Free** | $0 | ✓ | ✓ (heartbeat only) | heartbeat only | 1 alert visible | empty queue | — | — | `free` |
-| **Cloud Trial** | $0 / 14 d | ✓ | ✓ | full | unlimited | full | unlimited | full | `trial` |
+| **Cloud Trial** | $0 / 7 d | ✓ | ✓ | full | unlimited | full | unlimited | full | `trial` |
 | **Cloud Pro** | paid | ✓ | ✓ | full | unlimited | full | unlimited | full | `cloud_pro` |
 | **Trial-Expired** | $0 | ✓ | dashboard frozen at last sync | paused | view only | view only | view only | partial | `trial_expired` |
 


### PR DESCRIPTION
Closes #2290

## What

PRD.md plan matrix line for **Cloud Trial** still showed `$0 / 14 d`. Flipped to `$0 / 7 d` to match the rest of the codebase.

## How

Audited the repo for stale 14-day trial references with:

```
grep -rIn '14[- ]day' --include='*.py' --include='*.md' --include='*.tsx' --include='*.ts' --include='*.html'
```

Findings:
- All other `14[- ]day` hits are unrelated to trials — they cover the **14-day chart window** in `/api/usage`, prompt-cache analytics, and trend windows in `routes/overview.py`. None of those are scoped by this issue.
- Trial-related copy is already `7-day` everywhere it appears:
  - `dashboard.py:1298, 1348, 5901, 17637` (paywall CTAs + CLI welcome)
  - `clawmetry/templates/tabs/approvals.html:151` (trial note)
  - `tests/test_tier_pro_paywall_no_flash.py:51` (paywall marker)
- `PRD.md:33` was the last stale reference.

The companion change in `clawmetry-cloud#1210` flips the runtime `TRIAL_DAYS` constant + Stripe `trial_period_days`; OSS just renders what the cloud heartbeat reports, so nothing else here needs to change.

## Acceptance criteria

- [x] `grep -rIn '14[- ]day'` returns zero hits in trial contexts
- [x] `grep -rIn '7[- ]day'` covers all trial mentions
- [x] PRD matrix reflects 7-day trial
- [x] Cross-references companion cloud issue (clawmetry-cloud#1210)