### PR TITLE
fix(nemo): expose NeMo as read-side AgentAdapter so it appears in /api/agents

### DIFF
--- a/clawmetry/adapters/nemo.py
+++ b/clawmetry/adapters/nemo.py
@@ -630,8 +630,138 @@ class NeMoAdapter:
         return row
 
 
+# ── Read-side AgentAdapter facade ──────────────────────────────────────────
+#
+# The NeMoAdapter above is push-mode (callback receiver). For the multi-agent
+# UI (chip bar, runtime switcher, /api/agents) the dashboard expects every
+# observed runtime to be an :class:`AgentAdapter` subclass it can detect +
+# query for sessions/events. This thin facade exposes NeMo's ingested data
+# through the same shape as OpenClawAdapter, reading from DuckDB rather than
+# the filesystem.
+#
+# Without this, /api/agents never reports nemo, the runtime switcher cannot
+# filter to NeMo, and the homepage tooltip ("OpenClaw · NVIDIA NemoClaw ·
+# Claude Code · ...") promises a runtime the UI cannot select. Verified
+# during the 2026-05-29 runtime-coverage audit.
+from .base import AgentAdapter, Capability, DetectResult, Event, Session
+
+
+class NeMoReaderAdapter(AgentAdapter):
+    """Read-side facade so NeMo appears in /api/agents alongside the other
+    runtimes. NeMo events are ingested by the push-side ``NeMoAdapter``
+    above; this class only reads them back out of DuckDB."""
+
+    name = "nemo"
+    display_name = "NeMo"
+
+    def detect(self) -> DetectResult:
+        """Detect by checking whether DuckDB has any nemo-tagged events."""
+        n = 0
+        try:
+            from clawmetry import local_store as _ls
+            store = _ls.get_store(read_only=True)
+            rows = store._fetch(
+                "SELECT COUNT(*) FROM events WHERE agent_type = ?",
+                ["nemo"],
+            )
+            if rows:
+                n = int(rows[0][0])
+        except Exception as exc:
+            logger.debug("nemo detect read failed: %s", exc)
+        return DetectResult(
+            name=self.name,
+            display_name=self.display_name,
+            detected=n > 0,
+            running=False,
+            workspace="(push-mode receiver)",
+            session_count=0,
+            capabilities=[c.value for c in self.capabilities()],
+            meta={"event_count": n, "cap_per_day": NEMO_FREE_DAILY_CAP},
+        )
+
+    def list_sessions(self, limit: int = 100) -> list[Session]:
+        """List sessions for NeMo runtime by querying DuckDB."""
+        sessions: list[Session] = []
+        try:
+            from clawmetry import local_store as _ls
+            store = _ls.get_store(read_only=True)
+            rows = store._fetch(
+                "SELECT session_id, MIN(ts) AS started, MAX(ts) AS ended, "
+                "COUNT(*) AS n_events, SUM(token_count) AS tokens, "
+                "SUM(cost_usd) AS cost FROM events "
+                "WHERE agent_type = ? AND session_id IS NOT NULL "
+                "GROUP BY session_id ORDER BY started DESC LIMIT ?",
+                ["nemo", int(limit)],
+            )
+            for r in rows or []:
+                sid = r[0]
+                started = r[1] or 0.0
+                ended = r[2] or 0.0
+                # ts column is VARCHAR (ISO string or epoch-as-string);
+                # coerce to float for the dataclass typed fields.
+                try:
+                    started_f = float(started) if started not in ("", None) else 0.0
+                except (TypeError, ValueError):
+                    started_f = 0.0
+                try:
+                    ended_f = float(ended) if ended not in ("", None) else None
+                except (TypeError, ValueError):
+                    ended_f = None
+                n_ev = int(r[3] or 0)
+                tokens = int(r[4] or 0)
+                cost = float(r[5] or 0.0)
+                sessions.append(Session(
+                    agent=self.name,
+                    id=str(sid),
+                    title=f"NeMo session {str(sid)[:8]}",
+                    started_at=started_f,
+                    ended_at=ended_f,
+                    message_count=n_ev,
+                    total_tokens=tokens,
+                    cost_usd=cost,
+                ))
+        except Exception as exc:
+            logger.debug("nemo list_sessions read failed: %s", exc)
+        return sessions
+
+    def list_events(self, session_id: str, limit: int = 500) -> list[Event]:
+        """List events for one NeMo session by querying DuckDB."""
+        events: list[Event] = []
+        try:
+            from clawmetry import local_store as _ls
+            store = _ls.get_store(read_only=True)
+            rows = store._fetch(
+                "SELECT id, event_type, ts, model, token_count "
+                "FROM events WHERE agent_type = ? AND session_id = ? "
+                "ORDER BY ts ASC LIMIT ?",
+                ["nemo", str(session_id), int(limit)],
+            )
+            for r in rows or []:
+                events.append(Event(
+                    agent=self.name,
+                    session_id=str(session_id),
+                    id=str(r[0]),
+                    type=str(r[1] or "event"),
+                    ts=float(r[2]) if isinstance(r[2], (int, float)) else 0.0,
+                    tokens=int(r[4] or 0),
+                    extra={"model": r[3]} if r[3] else {},
+                ))
+        except Exception as exc:
+            logger.debug("nemo list_events read failed: %s", exc)
+        return events
+
+    def capabilities(self) -> set[Capability]:
+        return {
+            Capability.SESSIONS,
+            Capability.EVENTS,
+            Capability.BRAIN,
+            Capability.COST,
+        }
+
+
 __all__ = [
     "NeMoAdapter",
+    "NeMoReaderAdapter",
     "MAPPED_EVENT_TYPES",
     "NEMO_FREE_DAILY_CAP",
     "get_nemo_cap_state",

--- a/dashboard.py
+++ b/dashboard.py
@@ -10856,6 +10856,21 @@ def detect_config(args=None):
     from clawmetry.adapters.openclaw import OpenClawAdapter
     _adapter_registry.register(OpenClawAdapter())
 
+    # NeMo is a Free observed runtime alongside OpenClaw (homepage hero
+    # promises "OpenClaw + NeMo"). The push-side NeMoAdapter ingests into
+    # DuckDB; this read-side facade lets /api/agents + the runtime switcher
+    # filter to nemo. Only registers when detect() finds nemo-tagged events
+    # already in the store, so an OSS install with no NeMo data does not
+    # clutter the multi-agent view.
+    try:
+        from clawmetry.adapters.nemo import NeMoReaderAdapter
+        _nemo_reader = NeMoReaderAdapter()
+        if _nemo_reader.detect().detected:
+            _adapter_registry.register(_nemo_reader)
+    except Exception as _nemo_err:  # pragma: no cover - defensive
+        import logging as _logging
+        _logging.getLogger(__name__).debug("Skipped NeMo reader registration: %s", _nemo_err)
+
     # Non-OpenClaw runtimes ClawMetry can observe via a dedicated reader adapter
     # (Hermes, Claude Code, Codex, Cursor, PicoClaw, NanoClaw, ...). Each uses
     # its own native session format. Register each only when its own cheap,

--- a/tests/test_nemo_reader_adapter.py
+++ b/tests/test_nemo_reader_adapter.py
@@ -1,0 +1,151 @@
+"""Tests for ``NeMoReaderAdapter`` (Phase 4.5 read-side facade).
+
+The push-side ``NeMoAdapter`` keeps ingesting events into DuckDB; the
+new facade makes those events queryable through the standard
+:class:`AgentAdapter` shape so:
+
+* /api/agents lists "nemo" alongside openclaw + paid runtimes
+* The header runtime switcher can filter to NeMo
+* The homepage tooltip "OpenClaw + NeMo" stops being a lie
+
+These pin the facade contract: detect/list_sessions/list_events query
+DuckDB by ``agent_type='nemo'`` and return the shapes the dashboard
+expects.
+"""
+from __future__ import annotations
+
+import importlib
+import time
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def isolated_store(tmp_path, monkeypatch):
+    """Fresh LocalStore at a tmp path so tests don't read the dev DuckDB.
+
+    The adapter calls ``local_store.get_store(read_only=True)`` to fetch
+    the singleton; we patch it to return our test instance so the read
+    path sees the events we ingest in tests."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))  # daemon-detection shield
+    import clawmetry.local_store as _ls
+    importlib.reload(_ls)
+    s = _ls.LocalStore()
+    s.start()
+    monkeypatch.setattr(_ls, "get_store", lambda *a, **kw: s)
+    yield s
+    s.stop(flush=True)
+
+
+def _seed_nemo_event(store, *, session_id="nemo-sess-1", event_type="model.completed"):
+    event_id = str(uuid.uuid4())
+    store.ingest({
+        "id": event_id,
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "nemo",
+        "session_id": session_id,
+        "event_type": event_type,
+        "ts": time.time(),
+        "model": "nv/llama3-70b",
+        "data": {"role": "assistant", "content": "hi"},
+        "token_count": 42,
+        "cost_usd": 0.001,
+    })
+
+
+def _wait_flush(store, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+# ── detect ────────────────────────────────────────────────────────────────────
+
+
+def test_nemo_reader_detect_false_when_no_events(isolated_store):
+    """Empty store -> detected=False so we don't clutter /api/agents."""
+    from clawmetry.adapters.nemo import NeMoReaderAdapter
+    res = NeMoReaderAdapter().detect()
+    assert res.detected is False
+    assert res.name == "nemo"
+    assert res.display_name == "NeMo"
+
+
+def test_nemo_reader_detect_true_after_ingest(isolated_store):
+    _seed_nemo_event(isolated_store)
+    _wait_flush(isolated_store)
+    from clawmetry.adapters.nemo import NeMoReaderAdapter
+    res = NeMoReaderAdapter().detect()
+    assert res.detected is True
+    assert res.meta["event_count"] == 1
+
+
+# ── list_sessions ────────────────────────────────────────────────────────────
+
+
+def test_nemo_reader_list_sessions_groups_by_session_id(isolated_store):
+    _seed_nemo_event(isolated_store, session_id="sess-a")
+    _seed_nemo_event(isolated_store, session_id="sess-a", event_type="model.completed")
+    _seed_nemo_event(isolated_store, session_id="sess-b")
+    _wait_flush(isolated_store)
+    from clawmetry.adapters.nemo import NeMoReaderAdapter
+    sessions = NeMoReaderAdapter().list_sessions()
+    ids = {s.id for s in sessions}
+    assert ids == {"sess-a", "sess-b"}
+    sess_a = next(s for s in sessions if s.id == "sess-a")
+    assert sess_a.message_count == 2
+    assert sess_a.total_tokens == 84  # 42 + 42
+
+
+# ── list_events ──────────────────────────────────────────────────────────────
+
+
+def test_nemo_reader_list_events_for_session(isolated_store):
+    _seed_nemo_event(isolated_store, session_id="sess-c", event_type="prompt.submitted")
+    _seed_nemo_event(isolated_store, session_id="sess-c", event_type="model.completed")
+    _wait_flush(isolated_store)
+    from clawmetry.adapters.nemo import NeMoReaderAdapter
+    events = NeMoReaderAdapter().list_events("sess-c")
+    types = [e.type for e in events]
+    assert set(types) == {"prompt.submitted", "model.completed"}
+    assert all(e.agent == "nemo" for e in events)
+
+
+# ── capabilities ─────────────────────────────────────────────────────────────
+
+
+def test_nemo_reader_capabilities():
+    from clawmetry.adapters.nemo import NeMoReaderAdapter
+    from clawmetry.adapters.base import Capability
+    caps = NeMoReaderAdapter().capabilities()
+    assert Capability.SESSIONS in caps
+    assert Capability.EVENTS in caps
+    assert Capability.BRAIN in caps
+    assert Capability.COST in caps
+
+
+# ── isolation: doesn't pick up non-nemo runtimes ────────────────────────────
+
+
+def test_nemo_reader_ignores_non_nemo_events(isolated_store):
+    """A claude_code event seeded into the same store must NOT make NeMo
+    detect True. agent_type is the discriminator."""
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "claude_code",
+        "session_id": "cc-sess",
+        "event_type": "model.completed",
+        "ts": time.time(),
+    })
+    _wait_flush(isolated_store)
+    from clawmetry.adapters.nemo import NeMoReaderAdapter
+    assert NeMoReaderAdapter().detect().detected is False


### PR DESCRIPTION
NeMo is sold on the homepage hero ("OpenClaw + NeMo + ...") but the runtime switcher could never filter to it because:

- NeMoAdapter (existing) is push-mode and does not subclass AgentAdapter
- No facade existed to read NeMo events back out of DuckDB
- /api/agents iteration only registered OpenClawAdapter + family paid adapters; NeMo was invisible

## What changes
`NeMoReaderAdapter(AgentAdapter)` in `clawmetry/adapters/nemo.py`:
- `detect()` queries DuckDB for any events with `agent_type='nemo'`
- `list_sessions()` groups events by session_id
- `list_events(session_id)` filters by agent_type='nemo'
- `capabilities()` returns `{SESSIONS, EVENTS, BRAIN, COST}`

dashboard.py registers `NeMoReaderAdapter` alongside `OpenClawAdapter`, gated on detect() so OSS installs with no NeMo data don't clutter the chip bar.

## Tests
`tests/test_nemo_reader_adapter.py` — 6 tests covering empty/full detect, group-by-session-id, event filtering, capability set, non-nemo isolation. All pass.

## Closes
The homepage 'NeMo runtime' promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)