### PR TITLE
docs: update PRD pricing matrix to canonical tier model

### DIFF
--- a/PRD-cloud-pro-agent-reliability.md
+++ b/PRD-cloud-pro-agent-reliability.md
@@ -1,6 +1,6 @@
 # PRD — Cloud Pro: Agent Reliability (ClawBench on your real traffic) + Pipelines (CrawlBar)
 
-Status: Draft · Owner: ClawMetry · Date: 2026-05-20 · Tier: **Cloud Pro** ($5/node/mo)
+Status: Draft · Owner: ClawMetry · Date: 2026-05-20 · Tier: **Cloud Pro** ($5/node/mo or $50/node/year, saves $10)
 
 > TL;DR. ClawMetry already *observes* agents and *scores completed sessions* with an LLM judge (eval Phases 1–3). The natural next step — and the strongest paid differentiator we have — is to score **how reliably the agent works**, on the user's **own production traces**, using [ClawBench](https://github.com/openclaw/clawbench)'s trace-based methodology. Everyone else benchmarks models on synthetic tasks; we grade *your* agent on *your* traffic and tell you the one config change that buys the most reliability. A second, lighter surface borrows [CrawlBar](https://github.com/openclaw/crawlbar)'s manifest control-plane idea to give crawler/cron **data pipelines** a freshness + last-run view.
 

--- a/PRD.md
+++ b/PRD.md
@@ -19,22 +19,35 @@ Three product pillars: **zero config**, **read-only by default** (we observe age
 ## 2. Target users and plans
 
 ### Personas
-- **Solo OSS dev** — runs one agent on one laptop. Pip-installs, opens dashboard, never touches cloud. Free forever.
-- **Cloud Free** — same as above but signed up for an account. Gets remote-view at `app.clawmetry.com` for the dashboard but no team features.
-- **Cloud Pro (paid)** — multi-node fleets, team alerts, human-approval workflows, longer retention, channel integrations.
-- **NemoClaw operator** — runs N sandboxed OpenClaw boxes; each registers as a separate node automatically.
+- **Solo OSS dev** — runs one agent on one laptop. Pip-installs, opens dashboard, never touches cloud. Free forever for OpenClaw + NemoClaw.
+- **Cloud Free** — same as above but signed up for an account. Gets remote-view at `app.clawmetry.com` for the dashboard but no team features. Free for OpenClaw + NemoClaw, 1 node.
+- **Local Pro** — self-hosts every harness (Claude Code, Codex, Cursor, etc.) without cloud sync. Activates a `$50 / node / year` Ed25519 license key.
+- **Cloud Pro (paid)** — multi-node fleets, team alerts, human-approval workflows, longer retention, channel integrations. Monthly or annual SKU.
+- **NemoClaw operator** — runs N sandboxed OpenClaw boxes; each registers as a separate node automatically. NemoClaw is free alongside OpenClaw.
 
-### Plan matrix
+### Pricing matrix (canonical)
+
+| Tier | Local (self-hosted) | Cloud monthly | Cloud annual |
+|---|---|---|---|
+| **Free** | OpenClaw + NemoClaw, all features | OpenClaw + NemoClaw, 1 node | — |
+| **Pro** | **$50 / node / year** (Ed25519 license key) | **$5 / node / month** | **$50 / node / year** (saves $10 vs monthly) |
+| **Trial** | — | **7 days**, all Pro features, no card | — |
+
+All non-free harnesses (Claude Code, Codex, Cursor, Aider, Goose, Opencode, QwenCode, NanoClaw, PicoClaw, Hermes) require Pro on any tier. See `vivekchand/clawmetry#2288` for the rationale.
+
+### Plan matrix (runtime gates)
 
 | Plan | Cost | Local dashboard | Remote dashboard | Cloud sync | Alerts | Approvals | Notifications | Multi-node | Trial-flag |
 |---|---|---|---|---|---|---|---|---|---|
-| **OSS only** | $0 | ✓ | — | — | local only | — | — | local only | n/a |
-| **Cloud Free** | $0 | ✓ | ✓ (heartbeat only) | heartbeat only | 1 alert visible | empty queue | — | — | `free` |
-| **Cloud Trial** | $0 / 14 d | ✓ | ✓ | full | unlimited | full | unlimited | full | `trial` |
-| **Cloud Pro** | paid | ✓ | ✓ | full | unlimited | full | unlimited | full | `cloud_pro` |
+| **OSS only (Free)** | $0 | ✓ (OpenClaw + NemoClaw) | — | — | local only | — | — | local only | n/a |
+| **Local Pro** | $50/node/year | ✓ (all harnesses) | — | — | local only | — | — | local only | `pro` |
+| **Cloud Free** | $0 | ✓ (OpenClaw + NemoClaw) | ✓ (heartbeat only) | heartbeat only | 1 alert visible | empty queue | — | — | `free` |
+| **Cloud Trial** | $0 / 7 d | ✓ | ✓ | full | unlimited | full | unlimited | full | `trial` |
+| **Cloud Pro (monthly)** | $5/node/mo | ✓ | ✓ | full | unlimited | full | unlimited | full | `cloud_pro` |
+| **Cloud Pro (annual)** | $50/node/year | ✓ | ✓ | full | unlimited | full | unlimited | full | `cloud_pro` |
 | **Trial-Expired** | $0 | ✓ | dashboard frozen at last sync | paused | view only | view only | view only | partial | `trial_expired` |
 
-Plan transitions are driven by Stripe webhooks and the `users.plan` column in Cloud SQL. Trial auto-starts on first signup, no card required.
+Cloud plan transitions are driven by Stripe webhooks and the `users.plan` column in Cloud SQL. Trial auto-starts on first signup, no card required. Local Pro is activated by dropping an Ed25519 license key at `~/.clawmetry/license.key` (see `clawmetry/license.py`).
 
 ---
 


### PR DESCRIPTION
Closes #2294

## What

Update PRD docs to match the canonical pricing table from #2288 (the Pro-tier harness gating epic).

## How

`PRD.md` — section 2 "Target users and plans":
- **Personas**: explicit free designation for OpenClaw + NemoClaw; new **Local Pro** persona for self-hosted users who unlock all harnesses via Ed25519 license key
- **New "Pricing matrix (canonical)"** table copied verbatim from #2288: Free / Pro / Trial rows with Local, Cloud monthly, Cloud annual columns
- **Plan matrix (runtime gates)**: trial drops 14d → 7d; new **Local Pro** row; **Cloud Pro** split into monthly ($5/node/mo) and annual ($50/node/year)
- Footer note: paid harnesses list (Claude Code, Codex, Cursor, Aider, Goose, Opencode, QwenCode, NanoClaw, PicoClaw, Hermes) and pointer to local license storage

`PRD-cloud-pro-agent-reliability.md` — front-matter Tier line now reads `Cloud Pro ($5/node/mo or $50/node/year, saves $10)` so the annual SKU is reflected wherever Cloud Pro is stamped.

## Acceptance criteria (from #2294)

- [x] `grep -rIn '\$5/node'` returns hits only in monthly/Cloud-Pro contexts (verified — PRD-sync-status, AGENTS, PRD-tracing, FLYWHEEL, PRD-cloud-pro, PRD all monthly)
- [x] `grep -rIn '14[- ]day'` returns zero hits in trial contexts (remaining hits in CHANGELOG.md are historical "14-day Cost history rollup" — not trial copy)
- [x] PRD plan matrix matches #2288 verbatim
- [x] Marketing copy lists NemoClaw as free alongside OpenClaw (personas + pricing matrix + plan matrix all updated)

## Not in scope

- README.md has no pricing snippet (verified — only NemoClaw detection content). Nothing to update.
- SKILL_TEMPLATES.md, blog/ posts: untouched in this PR (scan returned no pricing references in docs/markdown). If they exist in cloud-only repos, they belong on `vivekchand/clawmetry-cloud#1210`.
- CHANGELOG.md "14-day" hits are historical post-mortem text about the Cost-tab history rollup — not trial copy.
- In-app "Upgrade to Pro" CTAs and trial-length copy are tracked separately on #2291 (runtime switcher UI) and `clawmetry-cloud#1210` (cloud upgrade copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)