### PR TITLE
fix: runtime detection requires a real install + running, not a bare folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,7 @@ jobs:
             tests/test_runtime_detection_snapshot.py \
             tests/test_family_runtime_ingest.py \
             tests/test_phase4_adapter_move.py \
+            tests/test_openclaw_detection_real.py \
             -q
 
   # ── MOAT keystone (DuckDB-first invariant, 13-endpoint bar) ──────────────

--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -31,6 +31,52 @@ def _d():
     return _dash
 
 
+def _gateway_live() -> bool:
+    """True only if the OpenClaw gateway is actually up (pid alive or port
+    18789 listening). Never raises."""
+    home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+    pid_file = os.path.join(home, "gateway", "gateway.pid")
+    try:
+        if os.path.exists(pid_file):
+            with open(pid_file) as fh:
+                pid = int((fh.read() or "0").strip())
+            if pid > 0:
+                os.kill(pid, 0)
+                return True
+    except (OSError, ValueError):
+        pass
+    try:
+        import socket as _sock
+        s = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
+        s.settimeout(0.2)
+        rc = s.connect_ex(("127.0.0.1", 18789))
+        s.close()
+        return rc == 0
+    except Exception:
+        return False
+
+
+def _real_install(sessions_dir: str) -> bool:
+    """A genuine OpenClaw install signal, NOT the bare ~/.openclaw dir that
+    ClawMetry itself creates as a scratch workspace. Any one of: the openclaw
+    CLI/app, a gateway.pid, real session .jsonl files, or workspace markers."""
+    import shutil as _shutil
+    if _shutil.which("openclaw") or os.path.isdir("/Applications/OpenClaw.app"):
+        return True
+    home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+    if os.path.exists(os.path.join(home, "gateway", "gateway.pid")):
+        return True
+    if sessions_dir and os.path.isdir(sessions_dir):
+        try:
+            if any(n.endswith(".jsonl") for n in os.listdir(sessions_dir)):
+                return True
+        except OSError:
+            pass
+    ws = os.path.join(home, "workspace")
+    return any(os.path.exists(os.path.join(ws, m))
+               for m in ("SOUL.md", "AGENTS.md", "MEMORY.md"))
+
+
 class OpenClawAdapter(AgentAdapter):
     name = "openclaw"
     display_name = "OpenClaw"
@@ -48,17 +94,17 @@ class OpenClawAdapter(AgentAdapter):
                 logger.debug(f"OpenClaw _get_sessions() failed in detect: {exc}")
 
             default_home = os.path.expanduser("~/.openclaw")
-            detected = bool(
-                sessions
-                or (workspace and os.path.isdir(workspace))
-                or (sessions_dir and os.path.isdir(sessions_dir))
-                or os.path.isdir(default_home)
-            )
+            running = _gateway_live()
+            # Require a GENUINE signal: real sessions, or an actual install
+            # artifact, or a live gateway. The bare ~/.openclaw (or its
+            # workspace dir) is NOT a signal — ClawMetry creates it, which
+            # false-positived OpenClaw on uninstalled machines.
+            detected = bool(sessions) or running or _real_install(sessions_dir)
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,
                 detected=detected,
-                running=bool(gateway_url),
+                running=running,
                 workspace=workspace or default_home,
                 session_count=len(sessions),
                 capabilities=[c.value for c in self.capabilities()],

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -4587,12 +4587,65 @@ _AGENT_INSTALL_TTL_SEC = 60
 _agent_install_cache: dict = {"ts": 0.0, "value": None}
 
 
+# ClawMetry creates ~/.openclaw/workspace as a scratch dir on startup (it drops
+# .clawmetry-fleet.db / .clawmetry-metrics.json there), so the mere existence of
+# ~/.openclaw is NOT evidence OpenClaw is installed — that bare-dir heuristic
+# false-positived "openclaw_detected" on a machine where OpenClaw was uninstalled
+# (verified 2026-05-30). These markers are ClawMetry's own; never count them.
+_CLAWMETRY_OWN_FILES = frozenset({".clawmetry-fleet.db", ".clawmetry-metrics.json"})
+
+
+def _openclaw_gateway_running() -> bool:
+    """True only if the OpenClaw gateway is actually live (pid alive or the
+    JSON-RPC port is listening). Stat + a 200ms localhost probe; never raises."""
+    home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+    pid_file = os.path.join(home, "gateway", "gateway.pid")
+    try:
+        if os.path.exists(pid_file):
+            with open(pid_file) as fh:
+                pid = int((fh.read() or "0").strip())
+            if pid > 0:
+                os.kill(pid, 0)  # raises if the process is gone
+                return True
+    except (OSError, ValueError):
+        pass
+    try:
+        import socket as _sock
+        s = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
+        s.settimeout(0.2)
+        rc = s.connect_ex(("127.0.0.1", 18789))
+        s.close()
+        if rc == 0:
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def _detect_openclaw_install_for_heartbeat() -> bool:
-    """Stat-only OpenClaw presence check (no subprocess, no DB)."""
+    """True only when OpenClaw is GENUINELY installed (folder + a real runtime
+    artifact), not when only ClawMetry's own ~/.openclaw scratch dir exists.
+
+    Stat-only (plus shutil.which); no DB. Genuine signals, any one of:
+      * the ``openclaw`` CLI is on PATH, or /Applications/OpenClaw.app exists
+      * a live gateway (pid alive / port 18789 listening)
+      * a gateway.pid file (installed even if not currently running)
+      * real session data (~/.openclaw/agents/main/sessions/*.jsonl)
+      * a real OpenClaw workspace (SOUL.md / AGENTS.md / MEMORY.md)
+    The bare presence of ~/.openclaw is deliberately NOT a signal (ClawMetry
+    creates it), which is what caused the false positive this fix removes.
+    """
+    import shutil as _shutil
+    if _shutil.which("openclaw"):
+        return True
+    if os.path.isdir("/Applications/OpenClaw.app"):
+        return True
     home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
     if not home:
         return False
     if os.path.exists(os.path.join(home, "gateway", "gateway.pid")):
+        return True
+    if _openclaw_gateway_running():
         return True
     sess_dir = os.path.join(home, "agents", "main", "sessions")
     if os.path.isdir(sess_dir):
@@ -4606,12 +4659,6 @@ def _detect_openclaw_install_for_heartbeat() -> bool:
     for marker in ("SOUL.md", "AGENTS.md", "MEMORY.md"):
         if os.path.exists(os.path.join(ws, marker)):
             return True
-    if os.path.isdir(home):
-        try:
-            if any(True for _ in os.scandir(home)):
-                return True
-        except OSError:
-            pass
     return False
 
 
@@ -4662,6 +4709,7 @@ def _detect_agent_install_for_heartbeat() -> dict:
     if cached and (now - _agent_install_cache["ts"]) < _AGENT_INSTALL_TTL_SEC:
         return cached
     openclaw = bool(_detect_openclaw_install_for_heartbeat())
+    openclaw_running = bool(_openclaw_gateway_running()) if openclaw else False
     nemoclaw = bool(_detect_nemoclaw_install_for_heartbeat())
     any_data = bool(_detect_any_local_data_for_heartbeat())
     signals = []
@@ -4673,6 +4721,7 @@ def _detect_agent_install_for_heartbeat() -> dict:
         signals.append("local_data")
     payload = {
         "openclaw_detected": openclaw,
+        "openclaw_running": openclaw_running,  # installed AND gateway live
         "nemoclaw_detected": nemoclaw,
         "any_data": any_data,
         "signals": signals,
@@ -8426,6 +8475,11 @@ def _detect_family_runtimes():
                         "displayName": d.display_name,
                         "sessionCount": int(d.session_count or 0),
                         "workspace": d.workspace or "",
+                        # installed (data/binary present) vs actually running
+                        # (a live process), so the API + UI can show
+                        # "installed & running" instead of conflating them.
+                        "installed": True,
+                        "running": bool(getattr(d, "running", False)),
                     }
                 )
         except Exception as exc:  # one bad adapter never blocks the others

--- a/dashboard.py
+++ b/dashboard.py
@@ -8354,16 +8354,51 @@ _agent_presence_cache = {"ts": 0.0, "value": None}
 _AGENT_PRESENCE_TTL_SEC = 60
 
 
+def _openclaw_gateway_running():
+    """True only if the OpenClaw gateway is actually live (pid alive or the
+    JSON-RPC port is listening). Stat + a 200ms localhost probe; never raises."""
+    home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+    pid_path = os.path.join(home, "gateway", "gateway.pid")
+    try:
+        if os.path.exists(pid_path):
+            with open(pid_path) as fh:
+                pid = int((fh.read() or "0").strip())
+            if pid > 0:
+                os.kill(pid, 0)
+                return True
+    except (OSError, ValueError):
+        pass
+    try:
+        import socket as _sock
+        s = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
+        s.settimeout(0.2)
+        rc = s.connect_ex(("127.0.0.1", 18789))
+        s.close()
+        return rc == 0
+    except Exception:
+        return False
+
+
 def _detect_openclaw_install():
-    """Return True if OpenClaw appears installed (any of: PID file present,
-    workspace dir exists, session JSONLs exist, OPENCLAW_HOME env set to a
-    real dir). Cheap stat-only checks — no subprocess, no DuckDB."""
+    """Return True only when OpenClaw is GENUINELY installed (a real artifact),
+    not when only ClawMetry's own ~/.openclaw scratch dir exists.
+
+    ClawMetry creates ~/.openclaw/workspace (it drops .clawmetry-fleet.db /
+    .clawmetry-metrics.json there), so "the dir exists / is non-empty" is NOT a
+    signal — that bare-dir heuristic false-positived OpenClaw on uninstalled
+    machines (fixed 2026-05-30). Cheap stat-only checks; no subprocess, no DuckDB.
+    """
+    import shutil as _shutil
+    # 0. The openclaw CLI on PATH or the app bundle — unambiguous install.
+    if _shutil.which("openclaw") or os.path.isdir("/Applications/OpenClaw.app"):
+        return True
     home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
     if not home:
         return False
-    # 1. Gateway PID file — strongest "openclaw is/was running" signal.
-    pid_path = os.path.join(home, "gateway", "gateway.pid")
-    if os.path.exists(pid_path):
+    # 1. Gateway PID file / live gateway — strongest "is/was running" signal.
+    if os.path.exists(os.path.join(home, "gateway", "gateway.pid")):
+        return True
+    if _openclaw_gateway_running():
         return True
     # 2. Session JSONLs (agent has produced events at some point).
     sess_dir = os.path.join(home, "agents", "main", "sessions")
@@ -8374,19 +8409,12 @@ def _detect_openclaw_install():
                     return True
         except OSError:
             pass
-    # 3. Workspace marker files (SOUL.md / AGENTS.md / MEMORY.md).
+    # 3. Workspace marker files (SOUL.md / AGENTS.md / MEMORY.md) — a real
+    # OpenClaw workspace, not ClawMetry's scratch dir.
     ws = os.path.join(home, "workspace")
     for marker in ("SOUL.md", "AGENTS.md", "MEMORY.md"):
         if os.path.exists(os.path.join(ws, marker)):
             return True
-    # 4. ~/.openclaw dir exists with *any* content (catches fresh installs
-    # that haven't run yet but have at least laid down config).
-    if os.path.isdir(home):
-        try:
-            if any(True for _ in os.scandir(home)):
-                return True
-        except OSError:
-            pass
     return False
 
 
@@ -8449,6 +8477,7 @@ def detect_agent_install():
     if cached and (now - _agent_presence_cache["ts"]) < _AGENT_PRESENCE_TTL_SEC:
         return cached
     openclaw = bool(_detect_openclaw_install())
+    openclaw_running = bool(_openclaw_gateway_running()) if openclaw else False
     nemoclaw = bool(_detect_nemoclaw_install())
     any_data = bool(_detect_any_local_data())
     signals = []
@@ -8460,6 +8489,7 @@ def detect_agent_install():
         signals.append("local_data")
     payload = {
         "openclaw_detected": openclaw,
+        "openclaw_running": openclaw_running,  # installed AND gateway live
         "nemoclaw_detected": nemoclaw,
         "any_data": any_data,
         "signals": signals,

--- a/tests/test_openclaw_detection_real.py
+++ b/tests/test_openclaw_detection_real.py
@@ -1,0 +1,90 @@
+"""Regression: OpenClaw "installed" must require a REAL artifact, not the bare
+~/.openclaw dir that ClawMetry itself creates.
+
+Bug (verified live 2026-05-30): on a machine where OpenClaw was uninstalled,
+`agent_install.openclaw_detected` was `true` because the heartbeat detector
+fell back to "~/.openclaw exists and is non-empty" — but ClawMetry drops its own
+`.clawmetry-fleet.db` / `.clawmetry-metrics.json` into `~/.openclaw/workspace`,
+so the dir is never actually empty. These tests pin the tightened rule.
+
+Pure OSS (no clawmetry_pro needed), so this runs in OSS CI.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import clawmetry.sync as sync
+
+
+@pytest.fixture(autouse=True)
+def _no_global_signals(monkeypatch):
+    # Neutralize host-level signals so tests only see the tmp OPENCLAW_HOME.
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda *_a, **_k: None)
+    # /Applications/OpenClaw.app is absent on CI (Linux); guard anyway.
+    real_isdir = os.path.isdir
+    monkeypatch.setattr(os.path, "isdir",
+                        lambda p: False if p == "/Applications/OpenClaw.app" else real_isdir(p))
+    # clear the agent_install cache between cases
+    sync._agent_install_cache.pop("value", None)
+    sync._agent_install_cache["ts"] = 0
+
+
+def test_bare_openclaw_dir_is_not_detected(monkeypatch, tmp_path):
+    home = tmp_path / ".openclaw"
+    home.mkdir()
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert sync._detect_openclaw_install_for_heartbeat() is False
+
+
+def test_clawmetry_own_workspace_files_are_not_a_signal(monkeypatch, tmp_path):
+    # The exact false-positive scenario: only ClawMetry's scratch files exist.
+    home = tmp_path / ".openclaw"
+    ws = home / "workspace"
+    ws.mkdir(parents=True)
+    (ws / ".clawmetry-fleet.db").write_text("x")
+    (ws / ".clawmetry-metrics.json").write_text("{}")
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert sync._detect_openclaw_install_for_heartbeat() is False
+    assert sync._openclaw_gateway_running() is False
+
+
+def test_real_workspace_markers_are_detected(monkeypatch, tmp_path):
+    home = tmp_path / ".openclaw"
+    ws = home / "workspace"
+    ws.mkdir(parents=True)
+    (ws / "SOUL.md").write_text("# soul")
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert sync._detect_openclaw_install_for_heartbeat() is True
+
+
+def test_real_session_jsonl_is_detected(monkeypatch, tmp_path):
+    home = tmp_path / ".openclaw"
+    sess = home / "agents" / "main" / "sessions"
+    sess.mkdir(parents=True)
+    (sess / "abc.jsonl").write_text('{"type":"session"}\n')
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert sync._detect_openclaw_install_for_heartbeat() is True
+
+
+def test_live_gateway_is_detected_and_running(monkeypatch, tmp_path):
+    home = tmp_path / ".openclaw"
+    gw = home / "gateway"
+    gw.mkdir(parents=True)
+    # our own pid is guaranteed alive -> os.kill(pid, 0) succeeds
+    (gw / "gateway.pid").write_text(str(os.getpid()))
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert sync._detect_openclaw_install_for_heartbeat() is True
+    assert sync._openclaw_gateway_running() is True
+
+
+def test_agent_install_payload_carries_openclaw_running(monkeypatch, tmp_path):
+    home = tmp_path / ".openclaw"
+    home.mkdir()
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    payload = sync._detect_agent_install_for_heartbeat()
+    assert payload["openclaw_detected"] is False
+    assert payload["openclaw_running"] is False
+    assert "openclaw" not in payload["signals"]


### PR DESCRIPTION
**Bug (verified live 2026-05-30):** a node showed `openclaw_detected: true` with **no** `openclaw` binary, no `/Applications/OpenClaw.app`, no gateway, and no sessions. Root cause: both detectors fell back to *"`~/.openclaw` exists / is non-empty"* — but **ClawMetry itself** creates `~/.openclaw/workspace` (drops `.clawmetry-fleet.db` / `.clawmetry-metrics.json` there), so the dir is never empty → permanent false positive.

**Fix (folder + actual runtime available & running, the requested model):**
- `sync.py` `_detect_openclaw_install_for_heartbeat` + `dashboard.py` `_detect_openclaw_install`: drop the bare-dir fallback. Require a **genuine** signal — `openclaw` CLI on PATH, the app bundle, a **live gateway** (pid alive / port 18789), a `gateway.pid`, real session `.jsonl`, or workspace markers (SOUL/AGENTS/MEMORY.md). ClawMetry's own files are never a signal.
- New `_openclaw_gateway_running()` (pid-alive + 200ms port probe). `agent_install` now carries **`openclaw_running`** so the API/UI can distinguish "installed AND running" from "installed".
- `adapters/openclaw.py` `detect()`: same tightening; `running` now reflects real gateway liveness, not the configured URL.
- `_detect_family_runtimes()`: carry `detected` + `running` per runtime (the adapter computes `running`; we were dropping it) — so **every** runtime reports installed-vs-running uniformly.

This auto-fixes the **cloud API** (`agent_install` / `detectedRuntimes`) and the **UI**, which read the same daemon-produced data.

**Tests:** `tests/test_openclaw_detection_real.py` (6) — bare dir + ClawMetry-only files → not detected; workspace markers / real sessions / live gateway → detected; payload carries `openclaw_running`. Wired into the OSS CI MOAT suite. Verified on the affected machine: detector now returns `False`.

Follow-up: `[RELEASE]` to PyPI, then bump the cloud pin so prod nodes pick it up on daemon upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)