### PR TITLE
fix: license activate/status/deactivate CLI + /api/license/* endpoints

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2496,28 +2496,59 @@ def _cmd_activate(args) -> None:
 
 
 def _cmd_license(args) -> None:
-    """clawmetry license — show the current self-hosted license status."""
-    from clawmetry import license as _lic
+    """clawmetry license [activate|status|deactivate] — manage the self-hosted license."""
+    action = getattr(args, "license_action", None) or "status"
 
-    info = _lic.current_license_info()
-    print("ClawMetry License\n" + "─" * 40)
-    if not info:
-        print("  Plan:        OSS (free)")
-        print("  License:     none installed")
-        print("  Unlocks:     OpenClaw runtime + NeMo governance + core observability")
-        print("\n  Upgrade for all runtimes + advanced features:")
-        print("    self-hosted key  →  clawmetry activate <KEY>   (https://clawmetry.com/pricing)")
-        return
-    if not info.get("valid"):
-        status = info.get("status", "invalid")
-        print(f"  License:     ⚠️  {status} (run `clawmetry activate <KEY>` with a current key)")
-        return
-    tier = str(info.get("tier", "pro")).capitalize()
-    print(f"  Plan:        {tier} (self-hosted)")
-    print(f"  Nodes:       {info.get('nodes', 1)}")
-    if info.get("days_left") is not None:
-        print(f"  Expires:     in {info['days_left']} day(s)")
-    print("  E2E:         🔒 verified offline")
+    if action == "activate":
+        key = getattr(args, "license_key", None) or ""
+        if not key:
+            print("❌  Usage: clawmetry license activate <KEY>")
+            sys.exit(1)
+        from clawmetry import license as _lic
+        ok, msg = _lic.activate(key.strip(), node_id=_lic._node_id())
+        if ok:
+            print(f"✅  {msg}")
+            print("    Run `clawmetry license status` to verify. Restart the daemon to load Pro features.")
+        else:
+            print(f"❌  {msg}")
+            print("    Need a key? Buy a self-hosted license at https://clawmetry.com/pricing")
+            sys.exit(1)
+
+    elif action == "deactivate":
+        import os
+        from clawmetry import license as _lic
+        try:
+            from clawmetry import entitlements as _ent
+            _ent.invalidate()
+        except Exception:
+            pass
+        if os.path.isfile(_lic.LICENSE_PATH):
+            os.remove(_lic.LICENSE_PATH)
+            print("✅  License removed. ClawMetry will revert to OSS tier on next restart.")
+        else:
+            print("ℹ️  No license key installed — nothing to deactivate.")
+
+    else:
+        from clawmetry import license as _lic
+        info = _lic.current_license_info()
+        print("ClawMetry License\n" + "─" * 40)
+        if not info:
+            print("  Plan:        OSS (free)")
+            print("  License:     none installed")
+            print("  Unlocks:     OpenClaw runtime + NeMo governance + core observability")
+            print("\n  Upgrade for all runtimes + advanced features:")
+            print("    self-hosted key  →  clawmetry license activate <KEY>   (https://clawmetry.com/pricing)")
+            return
+        if not info.get("valid"):
+            status = info.get("status", "invalid")
+            print(f"  License:     ⚠️  {status} (run `clawmetry license activate <KEY>` with a current key)")
+            return
+        tier = str(info.get("tier", "pro")).capitalize()
+        print(f"  Plan:        {tier} (self-hosted)")
+        print(f"  Nodes:       {info.get('nodes', 1)}")
+        if info.get("days_left") is not None:
+            print(f"  Expires:     in {info['days_left']} day(s)")
+        print("  E2E:         🔒 verified offline")
 
 
 def _cmd_verify_integrity(args) -> None:
@@ -2894,8 +2925,21 @@ def main() -> None:
     )
     p_activate.add_argument("key", help="License key (CLAW1.…)")
 
-    # license — show the current license status
-    sub.add_parser("license", help="Show the current self-hosted license status")
+    # license — manage the self-hosted Pro/Enterprise license
+    p_license = sub.add_parser("license", help="Manage the self-hosted Pro/Enterprise license")
+    p_license.add_argument(
+        "license_action",
+        nargs="?",
+        default="status",
+        choices=["status", "activate", "deactivate"],
+        help="status (default) | activate <KEY> | deactivate",
+    )
+    p_license.add_argument(
+        "license_key",
+        nargs="?",
+        default=None,
+        help="License key (CLAW1.…) — required for 'activate'",
+    )
 
     # verify-integrity — walk hash chain and report validity (Issue #2200)
     p_verify = sub.add_parser(

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import logging
 
-from flask import Blueprint, jsonify
+import os
+
+from flask import Blueprint, jsonify, request
 
 logger = logging.getLogger("clawmetry.routes.entitlement")
 
@@ -109,3 +111,67 @@ def api_runtimes():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/license/status")
+def api_license_status():
+    """Return the current self-hosted license info as JSON.
+    Returns ``{plan: 'oss', status: 'no_license'}`` when nothing is installed."""
+    try:
+        from clawmetry import license as _lic
+
+        info = _lic.current_license_info()
+        if info is None:
+            return jsonify({"plan": "oss", "status": "no_license", "valid": False})
+        return jsonify(info)
+    except Exception as exc:
+        logger.warning("api_license_status: error: %s", exc)
+        return jsonify({"error": str(exc)}), 500
+
+
+@bp_entitlement.route("/api/license/activate", methods=["POST"])
+def api_license_activate():
+    """Activate a self-hosted Pro/Enterprise license key.
+
+    Body: ``{"key": "CLAW1.…"}``.
+    Returns ``{"ok": true, "message": "…"}`` on success or 400 on failure.
+    """
+    try:
+        body = request.get_json(silent=True) or {}
+        key = str(body.get("key", "")).strip()
+        if not key:
+            return jsonify({"ok": False, "error": "key is required"}), 400
+        from clawmetry import license as _lic
+
+        ok, msg = _lic.activate(key)
+        status_code = 200 if ok else 400
+        return jsonify({"ok": ok, "message": msg}), status_code
+    except Exception as exc:
+        logger.warning("api_license_activate: error: %s", exc)
+        return jsonify({"ok": False, "error": str(exc)}), 500
+
+
+@bp_entitlement.route("/api/license/deactivate", methods=["POST"])
+def api_license_deactivate():
+    """Remove the installed license key and revert to OSS tier.
+
+    Idempotent — returns ``{"ok": true, "removed": false}`` when no key was
+    installed.
+    """
+    try:
+        from clawmetry import license as _lic
+
+        removed = False
+        if os.path.isfile(_lic.LICENSE_PATH):
+            os.remove(_lic.LICENSE_PATH)
+            removed = True
+        try:
+            from clawmetry import entitlements as _ent
+
+            _ent.invalidate()
+        except Exception:
+            pass
+        return jsonify({"ok": True, "removed": removed})
+    except Exception as exc:
+        logger.warning("api_license_deactivate: error: %s", exc)
+        return jsonify({"ok": False, "error": str(exc)}), 500

--- a/tests/test_license_api.py
+++ b/tests/test_license_api.py
@@ -1,0 +1,170 @@
+"""Tests for the /api/license/* endpoints added in routes/entitlement.py.
+
+Uses an ephemeral Ed25519 keypair (never the production key) and a tmp_path
+license file so no real file system state is touched.
+"""
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+
+# ── shared helpers (mirrors test_license.py) ──────────────────────────────────
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=3, exp_delta=365 * 86400):
+    now = int(time.time())
+    return {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import clawmetry.license as _lic
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(_lic, "_PUBLIC_KEY_PEM", pub_pem)
+    license_path = str(tmp_path / "license.key")
+    monkeypatch.setattr(_lic, "LICENSE_PATH", license_path)
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+
+    from routes.entitlement import bp_entitlement
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp_entitlement)
+    flask_app.config["TESTING"] = True
+
+    return SimpleNamespace(
+        app=flask_app,
+        lic=_lic,
+        priv=priv,
+        license_path=license_path,
+    )
+
+
+# ── /api/license/status ───────────────────────────────────────────────────────
+
+
+def test_status_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/status")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["status"] == "no_license"
+
+
+def test_status_active_license(app):
+    tok = app.lic._encode_token(_payload("pro", nodes=5), app.priv)
+    app.lic.activate(tok)
+    with app.app.test_client() as c:
+        resp = c.get("/api/license/status")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is True
+    assert data["tier"] == "pro"
+    assert data["nodes"] == 5
+
+
+# ── /api/license/activate ─────────────────────────────────────────────────────
+
+
+def test_activate_valid_key(app):
+    tok = app.lic._encode_token(_payload("pro", nodes=2), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/activate",
+            data=json.dumps({"key": tok}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert "pro" in data["message"].lower()
+
+
+def test_activate_invalid_key(app):
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/activate",
+            data=json.dumps({"key": "CLAW1.not.real"}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 400
+    assert resp.get_json()["ok"] is False
+
+
+def test_activate_missing_key_body(app):
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/activate",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 400
+
+
+def test_activate_expired_key(app):
+    tok = app.lic._encode_token(_payload(exp_delta=-3600), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/activate",
+            data=json.dumps({"key": tok}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 400
+    assert resp.get_json()["ok"] is False
+
+
+# ── /api/license/deactivate ───────────────────────────────────────────────────
+
+
+def test_deactivate_removes_file(app):
+    import os
+
+    tok = app.lic._encode_token(_payload(), app.priv)
+    app.lic.activate(tok)
+    assert os.path.isfile(app.license_path)
+
+    with app.app.test_client() as c:
+        resp = c.post("/api/license/deactivate")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["removed"] is True
+    assert not os.path.isfile(app.license_path)
+
+
+def test_deactivate_idempotent_when_no_license(app):
+    with app.app.test_client() as c:
+        resp = c.post("/api/license/deactivate")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["removed"] is False


### PR DESCRIPTION
Closes #2292

## Summary

- **`clawmetry license activate <KEY>`** — calls `license.activate()`, prints result; keeps `clawmetry activate` as a backward-compat alias.
- **`clawmetry license status`** — shows tier/nodes/expiry; same output as the existing `clawmetry license` (which still works).
- **`clawmetry license deactivate`** — removes `~/.clawmetry/license.key` and invalidates the entitlement cache. New functionality not previously available.
- **`GET /api/license/status`**, **`POST /api/license/activate`**, **`POST /api/license/deactivate`** — three endpoints on the existing `bp_entitlement` blueprint in `routes/entitlement.py`; all reuse `clawmetry/license.py` helpers and never crash the dashboard.

Out of scope for this PR: the `LicensePanel.tsx` React component (requires a frontend build pass).

## Test plan

- `python -m pytest tests/test_license_api.py -v` → 8 new tests, all green (status/activate/deactivate endpoints, happy path + invalid/expired key + idempotent deactivate).
- `python -m pytest tests/test_license.py -v` → 17 existing tests, all still green (no regression to `license.py` logic).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXWJK7mdFym6816HPjVWPL)_