### PR TITLE
test: parametrize entitlement tests across all paid runtimes + /api/entitlement coverage

### DIFF
--- a/tests/test_entitlement_api.py
+++ b/tests/test_entitlement_api.py
@@ -1,0 +1,125 @@
+"""Tests for the ``/api/entitlement`` endpoint (``routes/entitlement.py``).
+
+Validates the JSON shape, grace/enforced flag round-trip, per-tier runtime
+list, and the ``is_paid`` flag under each representative paid tier — so the
+dashboard's entitlement consumer never receives a surprise null or stale shape.
+
+Complements ``tests/test_routes_runtimes.py`` which covers ``/api/runtimes``.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client wired with bp_entitlement and a clean HOME."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client(), tmp_path
+
+
+# ── shape invariants ──────────────────────────────────────────────────────────
+
+
+def test_api_entitlement_shape_grace(client):
+    c, _ = client
+    resp = c.get("/api/entitlement")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    for key in ("tier", "source", "grace", "enforced", "is_paid",
+                "runtimes", "features", "all_runtimes"):
+        assert key in d, key
+    assert isinstance(d["runtimes"], list)
+    assert isinstance(d["features"], list)
+    assert isinstance(d["all_runtimes"], list)
+
+
+def test_api_entitlement_grace_defaults(client):
+    c, _ = client
+    d = c.get("/api/entitlement").get_json()
+    assert d["grace"] is True
+    assert d["enforced"] is False
+    assert d["is_paid"] is False
+    assert d["tier"] == "oss"
+    # OSS tier: runtimes lists the entitled set (FREE_RUNTIMES); all_runtimes
+    # is the full catalog.  In grace mode every runtime is *allowed* (via
+    # allows_runtime), but the runtimes field reflects the tier's grant.
+    import clawmetry.entitlements as e
+    assert set(d["runtimes"]) == set(e.FREE_RUNTIMES)
+    assert set(d["all_runtimes"]) == set(e.ALL_RUNTIMES)
+
+
+def test_api_entitlement_grace_enforced_are_inverse(client):
+    """grace and enforced must always be exact inverses — the frontend uses
+    both and breaking this causes half the UI to show the wrong lock state."""
+    c, _ = client
+    d = c.get("/api/entitlement").get_json()
+    assert d["grace"] == (not d["enforced"])
+
+
+# ── enforce mode ─────────────────────────────────────────────────────────────
+
+
+def test_api_entitlement_enforced_oss_grace_false(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement").get_json()
+
+    assert d["grace"] is False
+    assert d["enforced"] is True
+    assert d["is_paid"] is False
+    # In enforced OSS, only free runtimes are available.
+    assert set(d["runtimes"]) == set(e.FREE_RUNTIMES)
+    assert d["grace"] == (not d["enforced"])
+
+
+# ── paid tiers ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("tier", ["trial", "pro", "cloud_pro"])
+def test_api_entitlement_paid_tier_grants_all_runtimes(monkeypatch, tmp_path, tier):
+    """Subscribers on trial / pro / cloud_pro get is_paid=True and all runtimes
+    in the runtimes list even with enforcement on."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": tier, "node_limit": 1, "expiry": None}))
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement").get_json()
+
+    assert d["tier"] == tier
+    assert d["is_paid"] is True
+    assert d["grace"] is False
+    assert d["grace"] == (not d["enforced"])
+    # All paid runtimes must be present.
+    for rt in e.PAID_RUNTIMES:
+        assert rt in d["runtimes"], f"{tier}: {rt} missing from runtimes"

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -196,3 +196,56 @@ def test_runtime_label_falls_back_to_id(ent):
     assert ent.runtime_label("brand_new_plugin_runtime") == "brand_new_plugin_runtime"
     assert ent.runtime_label("") == ""
     assert ent.runtime_label(None) == ""
+
+
+# ── paid-tier coverage (issue #2293) ─────────────────────────────────────────
+
+
+def test_paid_runtimes_exact_membership(ent):
+    # Asserts the exact 10-entry PAID_RUNTIMES set so any accidental add/remove
+    # breaks loudly instead of silently skipping gate coverage.
+    expected = frozenset(
+        {
+            "claude_code",
+            "codex",
+            "cursor",
+            "aider",
+            "goose",
+            "opencode",
+            "qwen_code",
+            "hermes",
+            "picoclaw",
+            "nanoclaw",
+        }
+    )
+    assert ent.PAID_RUNTIMES == expected
+    assert len(ent.PAID_RUNTIMES) == 10
+
+
+def test_all_paid_runtimes_blocked_on_oss_enforced(ent, monkeypatch):
+    """Every entry in PAID_RUNTIMES is denied for an OSS install once enforced."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.grace is False
+    for rt in ent.PAID_RUNTIMES:
+        assert en.allows_runtime(rt) is False, rt
+    # Free runtimes are never blocked regardless of enforcement.
+    for rt in ent.FREE_RUNTIMES:
+        assert en.allows_runtime(rt) is True, rt
+
+
+def test_paid_runtimes_allowed_on_paid_tiers_enforced(ent, monkeypatch, tmp_path):
+    """Every paid runtime is allowed on trial / pro / cloud_pro even with
+    CLAWMETRY_ENFORCE=1 — the gate must pass for legitimate subscribers."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    for tier in (ent.TIER_TRIAL, ent.TIER_PRO, ent.TIER_CLOUD_PRO):
+        cache.write_text(json.dumps({"plan": tier, "node_limit": 1, "expiry": None}))
+        en = ent.get_entitlement(force=True)
+        assert en.tier == tier, tier
+        assert en.grace is False, tier
+        for rt in ent.PAID_RUNTIMES:
+            assert en.allows_runtime(rt) is True, f"{tier}/{rt}"
+        for rt in ent.FREE_RUNTIMES:
+            assert en.allows_runtime(rt) is True, f"{tier}/{rt}"


### PR DESCRIPTION
Closes #2293

## Summary

- **`tests/test_entitlements.py`** — three new tests:
  - `test_paid_runtimes_exact_membership`: asserts the exact 10-entry `PAID_RUNTIMES` frozenset so an accidental add/remove breaks loudly
  - `test_all_paid_runtimes_blocked_on_oss_enforced`: iterates every paid runtime and asserts `allows_runtime` is `False` on `TIER_OSS` + enforce on, `True` for free runtimes
  - `test_paid_runtimes_allowed_on_paid_tiers_enforced`: for each of `trial` / `pro` / `cloud_pro`, stubs `cloud_plan.json` and verifies every paid runtime returns `allows_runtime=True` with enforcement on

- **`tests/test_entitlement_api.py`** (new file) — Flask test client for `/api/entitlement`:
  - shape check (all required keys present)
  - grace defaults (`tier=oss`, `is_paid=False`, `runtimes=FREE_RUNTIMES`, `all_runtimes=ALL_RUNTIMES`)
  - `grace == !enforced` invariant test
  - enforced OSS: `grace=False`, `enforced=True`, runtimes clamped to `FREE_RUNTIMES`
  - parametrized over `trial` / `pro` / `cloud_pro`: `is_paid=True`, all paid runtimes present

No production code touched. 26 tests, all passing.

## Test plan

```
pytest tests/test_entitlements.py tests/test_entitlement_api.py -v
# 26 passed in 0.24s
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcdriLJcsECxNj9iAJMzCK)_