### PR TITLE
feat(open-core): load_plugins() in enforcement proxy startup

### DIFF
--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -943,6 +943,23 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
     app = Flask(__name__)
     app.config["MAX_CONTENT_LENGTH"] = 50 * 1024 * 1024  # 50MB max
 
+    # Open-core plugin host: the enforcement proxy is a SEPARATE long-running
+    # process (``python -m clawmetry.proxy``) from the dashboard and the sync
+    # daemon, so its Flask app needs its own ``load_plugins(app)`` call.
+    # Without this, a clawmetry-pro plugin that ships custom policy / routing
+    # blueprints (e.g. budget overrides, tool-policy enforcement endpoints)
+    # would register on the dashboard process but be missing here — the proxy
+    # would silently fall back to OSS behaviour. The extensions module's
+    # ``_loaded`` guard makes the call safe across processes (it is per-process
+    # state). Errors are swallowed with a warning: a broken plugin must never
+    # take the proxy down — it is the LLM-egress chokepoint.
+    try:
+        from clawmetry.extensions import load_plugins as _ext_load
+
+        _ext_load(app)
+    except Exception as _ext_e:
+        logger.warning("extensions load_plugins failed: %s", _ext_e)
+
     db = ProxyDB()
     budget = BudgetEnforcer(config.budget, db)
     loop_detector = LoopDetector(config.loop_detection, db)

--- a/tests/test_proxy_loads_plugins.py
+++ b/tests/test_proxy_loads_plugins.py
@@ -1,0 +1,110 @@
+"""Tests for ``clawmetry/proxy.py`` plugin host wiring.
+
+The enforcement proxy runs as a separate process (``python -m clawmetry.proxy``)
+and was the only ClawMetry process besides the sync daemon where paid plugins
+were silently skipped. ``create_proxy_app`` now calls
+:func:`clawmetry.extensions.load_plugins(app)` right after the Flask app is
+constructed so a clawmetry-pro plugin can register policy / routing blueprints
+on the proxy. Errors must never take the proxy down — the proxy is the LLM
+egress chokepoint.
+
+These tests are hermetic — they monkey-patch ``load_plugins`` so no real entry
+points are touched, and they avoid spawning a server.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def reset_extensions_state():
+    """Reset the once-guard so each test exercises ``load_plugins`` fresh."""
+    import clawmetry.extensions as ext
+
+    saved = ext._loaded
+    ext._loaded = False
+    yield ext
+    ext._loaded = saved
+
+
+def _build_app(monkeypatch, fake_load):
+    """Patch ``load_plugins`` on the extensions module and build the proxy app.
+
+    The proxy imports the symbol at call time inside ``create_proxy_app`` —
+    we patch the source module so the late import resolves to ``fake_load``.
+    """
+    import clawmetry.extensions as ext
+
+    monkeypatch.setattr(ext, "load_plugins", fake_load)
+
+    from clawmetry.proxy import create_proxy_app, ProxyConfig
+
+    return create_proxy_app(ProxyConfig())
+
+
+def test_create_proxy_app_calls_load_plugins_once(monkeypatch, reset_extensions_state):
+    """The proxy invokes ``load_plugins(app)`` exactly once at construction
+    so paid plugins can register Blueprints on the enforcement Flask app."""
+    calls = []
+
+    def fake_load(app=None):
+        calls.append(app)
+
+    app = _build_app(monkeypatch, fake_load)
+
+    assert len(calls) == 1, "load_plugins must be called exactly once"
+    assert calls[0] is app, "the proxy Flask app must be handed to the plugin"
+
+
+def test_create_proxy_app_swallows_load_plugins_errors(
+    monkeypatch, reset_extensions_state
+):
+    """A broken plugin must never take the proxy down — the proxy is the LLM
+    egress chokepoint, so we log and continue rather than propagate."""
+
+    def fake_load(app=None):
+        raise RuntimeError("simulated plugin crash")
+
+    # Must not raise.
+    app = _build_app(monkeypatch, fake_load)
+
+    # Sanity check: app is still a usable Flask app.
+    from flask import Flask
+
+    assert isinstance(app, Flask)
+
+
+def test_create_proxy_app_logs_warning_on_plugin_error(
+    monkeypatch, reset_extensions_state, caplog
+):
+    """When a plugin raises, the proxy logs a warning so the operator can see
+    the failure without the process dying."""
+    import logging
+
+    def fake_load(app=None):
+        raise RuntimeError("simulated plugin crash")
+
+    with caplog.at_level(logging.WARNING, logger="clawmetry.proxy"):
+        _build_app(monkeypatch, fake_load)
+
+    assert any(
+        "load_plugins" in rec.message and "simulated plugin crash" in rec.message
+        for rec in caplog.records
+    ), "expected a warning mentioning the failed load_plugins call"
+
+
+def test_create_proxy_app_does_not_call_dashboard_load(
+    monkeypatch, reset_extensions_state
+):
+    """The proxy must call its own ``load_plugins(app)`` — not rely on the
+    dashboard process having loaded plugins, because the proxy runs in a
+    separate process under ``python -m clawmetry.proxy``."""
+    calls = []
+
+    def fake_load(app=None):
+        calls.append(("called", app is not None))
+
+    _build_app(monkeypatch, fake_load)
+
+    assert calls == [("called", True)]


### PR DESCRIPTION
## Summary

Wires the `clawmetry.extensions` entry-point plugin loader into the
**enforcement proxy** so paid plugins (clawmetry-pro custom policy
endpoints, routing blueprints, budget overrides) register on the proxy's
Flask app too — not only on the dashboard process.

### Why

`dashboard.py` already calls `load_plugins(app)` at import time
(`dashboard.py:187`), so the dashboard process picks up
`clawmetry.extensions` entry-point plugins for HTTP routes and `emit()`
events. The sync daemon load is in flight (#2277).

The **enforcement proxy** (`clawmetry/proxy.py`) is a *third*
long-running process — launched as `python -m clawmetry.proxy` by
`clawmetry proxy start` (`cli.py:2114`) — that never imports
`dashboard`. The `extensions._loaded` guard is per-process state, so
until now the proxy was the last ClawMetry process where paid plugins
were silently skipped. A clawmetry-pro plugin that ships custom policy /
routing blueprints (e.g. tool-policy enforcement endpoints, model-route
overrides) would register on the dashboard process but be missing on
the proxy — the proxy would silently fall back to OSS behaviour, which
is the *opposite* of what a paid policy plugin is for.

### What

- **`clawmetry/proxy.py`** — call `load_plugins(app)` inside
  `create_proxy_app()` right after `app = Flask(__name__)` is
  constructed, so plugins can register Blueprints on it. Mirrors the
  pattern already in `dashboard.py`. Errors are swallowed with a logged
  warning — a broken plugin must never take down the proxy (it sits in
  the LLM-egress path and is the budget / loop-detection chokepoint).
  Late import of the symbol keeps the proxy importable even on installs
  where `clawmetry.extensions` somehow isn't available.

- **`tests/test_proxy_loads_plugins.py`** — 4 hermetic tests:
  1. `create_proxy_app` calls `extensions.load_plugins` exactly once
     and hands it the Flask app
  2. A raising `load_plugins` is swallowed (no `RuntimeError`
     propagates) — proxy stays up
  3. The swallow path logs a warning at `clawmetry.proxy`
  4. The call is unconditional — the proxy never relies on the
     dashboard process having loaded plugins

Default behaviour unchanged — the OSS install has zero registered
entry-point plugins, so `load_plugins()` is a fast no-op for free users.
Stays in **GRACE**: no gate is enforced, no behaviour flips.

## Test plan

- [x] `python3 -m pytest tests/test_proxy_loads_plugins.py -v` → 4 passed
- [x] `python3 -m pytest tests/test_extensions.py tests/test_entitlements.py tests/test_license.py tests/test_proxy.py tests/test_proxy_loads_plugins.py` → 107 passed, 1 pre-existing failure in `test_proxy.py::TestLoopDetector::test_loop_emits_alert_event` (missing `duckdb` dep — fails identically on `origin/main`, not caused by this PR)
- [x] `python3 -m py_compile clawmetry/proxy.py tests/test_proxy_loads_plugins.py` → syntax OK

## Local operator verification checklist

Since this autonomous run cannot reach the user's machine, `~/.openclaw`,
the running daemon, the live cloud snapshot, or a browser:

- [ ] Copy `clawmetry/proxy.py` + `tests/test_proxy_loads_plugins.py` into
      `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and the test
      into the daemon's test path if you run tests in-place)
- [ ] Clear `__pycache__` under that site-packages tree
- [ ] Restart the proxy: `clawmetry proxy stop && clawmetry proxy start`
      (or `launchctl kickstart -k gui/$(id -u)/com.clawmetry.proxy` if
      managed by launchd)
- [ ] Tail the proxy log and confirm no new ERROR lines at startup
      (`tail -F ~/.clawmetry/proxy.log`)
- [ ] Hit `http://localhost:8900/api/entitlement` — still resolves as
      `tier: "oss"`, `grace: true` on the OSS install (no behaviour
      change)
- [ ] Decrypt the live cloud snapshot in the browser — sessions, brain
      feed, flow tab still render
- [ ] Once `clawmetry-pro` is installed against this build, confirm the
      proxy log shows `Loaded ClawMetry extension plugin: <name>` from
      the proxy process (previously only the dashboard process printed
      this)

## Roadmap status

Open-core phases 1 and 2 (entitlements, license, CLI subcommands,
`/api/entitlement`, dashboard plugin host) are already on `main`. The
remaining places where `load_plugins()` should fire in their own
processes are:

- ✅ `dashboard.py` — on `main`
- ⏳ `clawmetry/sync.py` — in flight in #2277 (sync daemon)
- ✅ `clawmetry/proxy.py` — this PR

Phases 3, 4, 6 (cloud entitlement push, closed-source `clawmetry-pro`
wheel publish, enterprise/SSO/RBAC) require the private
`clawmetry-cloud` and not-yet-existing `clawmetry-pro` repos that this
autonomous run does not have access to — left for the local operator.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012hnpuk5bmTda7xCcpn6Vu1)_