### PR TITLE
fix(entitlement): intercept locked-runtime selection, show paywall modal

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7169,11 +7169,85 @@ function _cmPopulateGlobalRuntime(counts) {
 
 function _cmOnGlobalRuntimeChange(sel) {
   if (!sel) return;
-  _cmSetRuntimeFilter(sel.value);
+  var val = sel.value;
+  // If the chosen runtime is locked (paid, enforcement on) revert the
+  // selection and show the upgrade modal instead of switching.
+  if (val !== 'all' && _cmLockedRuntimes[val]) {
+    sel.value = _cmRuntimeFilter() || 'all';
+    _cmShowRuntimePaywall(val, _CM_RT_LABEL[val] || val);
+    return;
+  }
+  _cmSetRuntimeFilter(val);
   // Swap the Flow + Overview diagram to the selected runtime's topology.
-  try { if (typeof _applyRuntimeFlowDiagram === 'function') _applyRuntimeFlowDiagram(sel.value); } catch (e) {}
+  try { if (typeof _applyRuntimeFlowDiagram === 'function') _applyRuntimeFlowDiagram(val); } catch (e) {}
   // Reload the current tab so any runtime-aware view re-filters in place.
   if (typeof switchTab === 'function' && _cmCurrentTab) switchTab(_cmCurrentTab);
+}
+
+function _cmShowRuntimePaywall(harness, label) {
+  // Emit paywall_view telemetry (fire-and-forget).
+  try {
+    fetch('/api/paywall/event', {method:'POST', headers:{'Content-Type':'application/json'},
+      credentials:'same-origin',
+      body: JSON.stringify({event:'paywall_view', feature: harness + '_observability',
+        harness: harness, source:'runtime-switcher'})});
+  } catch(e) {}
+
+  var existing = document.getElementById('_cmRtPaywallOverlay');
+  if (existing) existing.remove();
+
+  var overlay = document.createElement('div');
+  overlay.id = '_cmRtPaywallOverlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.style.cssText = 'position:fixed;inset:0;z-index:9999;background:rgba(26,24,22,.45);'
+    + 'display:flex;align-items:center;justify-content:center;padding:24px;';
+
+  var upgradeUrl = 'https://app.clawmetry.com/upgrade?source=runtime-switcher&harness='
+    + encodeURIComponent(harness);
+
+  overlay.innerHTML = '<div style="max-width:420px;width:100%;padding:24px;'
+    + 'background:var(--bg-primary,#1a1a2e);border:1px solid var(--border-color,rgba(255,255,255,.15));'
+    + 'border-radius:12px;">'
+    + '<div style="font-size:10px;text-transform:uppercase;letter-spacing:1.5px;color:#a78bfa;'
+    + 'margin-bottom:8px;font-weight:600;">Cloud Pro</div>'
+    + '<h2 style="margin:0 0 10px;font-size:20px;font-weight:500;color:var(--text-primary,#e2e8f0);">'
+    + escHtml(label) + ' is a Pro runtime</h2>'
+    + '<p style="margin:0 0 18px;font-size:13px;color:var(--text-muted,#94a3b8);line-height:1.5;">'
+    + 'OSS + Free tiers include OpenClaw and NemoClaw. Upgrade to Pro to observe '
+    + escHtml(label) + ', plus Claude Code, Codex, Cursor, Aider, Goose, and more.</p>'
+    + '<div style="display:flex;gap:8px;justify-content:flex-end;">'
+    + '<button type="button" id="_cmRtPaywallCancel" style="padding:8px 16px;'
+    + 'border:1px solid var(--border-color,rgba(255,255,255,.2));border-radius:6px;'
+    + 'background:transparent;color:var(--text-secondary,#cbd5e1);cursor:pointer;font-size:13px;">Not now</button>'
+    + '<a href="' + upgradeUrl + '" target="_blank" rel="noopener noreferrer" id="_cmRtPaywallCTA"'
+    + ' style="padding:8px 16px;background:#7c3aed;color:#fff;border-radius:6px;'
+    + 'text-decoration:none;font-size:13px;font-weight:500;">Start free trial</a>'
+    + '</div></div>';
+
+  document.body.appendChild(overlay);
+  overlay.addEventListener('click', function(e) { if (e.target === overlay) _cmDismissRtPaywall(); });
+  document.getElementById('_cmRtPaywallCancel').addEventListener('click', _cmDismissRtPaywall);
+  var ctaEl = document.getElementById('_cmRtPaywallCTA');
+  if (ctaEl) {
+    ctaEl.addEventListener('click', function() {
+      try {
+        fetch('/api/paywall/event', {method:'POST', headers:{'Content-Type':'application/json'},
+          credentials:'same-origin',
+          body: JSON.stringify({event:'paywall_cta_click', harness: harness,
+            source:'runtime-switcher', plan_chosen:'pro'})});
+      } catch(e) {}
+    });
+  }
+  overlay._cmEscHandler = function(e) { if (e.key === 'Escape') _cmDismissRtPaywall(); };
+  document.addEventListener('keydown', overlay._cmEscHandler);
+}
+
+function _cmDismissRtPaywall() {
+  var overlay = document.getElementById('_cmRtPaywallOverlay');
+  if (!overlay) return;
+  if (overlay._cmEscHandler) document.removeEventListener('keydown', overlay._cmEscHandler);
+  overlay.remove();
 }
 
 async function _cmLoadRuntimeCatalog() {

--- a/frontend/src/components/ProPaywallModal.tsx
+++ b/frontend/src/components/ProPaywallModal.tsx
@@ -2,10 +2,20 @@ interface ProPaywallModalProps {
   open: boolean;
   onClose: () => void;
   feature?: string;
+  harness?: string;
 }
 
-export function ProPaywallModal({ open, onClose, feature = "auto-promote rules" }: ProPaywallModalProps) {
+export function ProPaywallModal({ open, onClose, feature = "auto-promote rules", harness }: ProPaywallModalProps) {
   if (!open) return null;
+
+  const upgradeUrl = harness
+    ? `https://app.clawmetry.com/upgrade?source=runtime-switcher&harness=${encodeURIComponent(harness)}`
+    : "https://app.clawmetry.com/upgrade?source=v2-approvals";
+
+  const title = harness ? `${feature} is a Pro runtime` : `${feature} is a Pro feature`;
+  const description = harness
+    ? `OSS + Free tiers include OpenClaw and NemoClaw. Upgrade to Pro to observe ${feature}, plus Claude Code, Codex, Cursor, Aider, Goose, and more.`
+    : "On OSS/Free, you can review and approve actions manually. Cloud Pro unlocks auto-promote rules, notification dispatch, and one-click rule creation from the approval inbox.";
 
   return (
     <div
@@ -33,18 +43,17 @@ export function ProPaywallModal({ open, onClose, feature = "auto-promote rules" 
           Cloud Pro
         </div>
         <h2 id="pro-paywall-title" style={{ margin: "0 0 10px", fontSize: 20, fontWeight: 500, color: "var(--ink)" }}>
-          {feature} is a Pro feature
+          {title}
         </h2>
         <p style={{ margin: "0 0 18px", fontSize: 13, color: "var(--ink-3)", lineHeight: 1.5 }}>
-          On OSS/Free, you can review and approve actions manually. Cloud Pro unlocks auto-promote rules,
-          notification dispatch, and one-click rule creation from the approval inbox.
+          {description}
         </p>
         <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
           <button type="button" className="cm-btn" onClick={onClose}>
             Not now
           </button>
           <a
-            href="https://app.clawmetry.com/upgrade?source=v2-approvals"
+            href={upgradeUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="cm-btn primary"

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -129,6 +129,29 @@ def api_license_status():
         return jsonify({"error": str(exc)}), 500
 
 
+@bp_entitlement.route("/api/paywall/event", methods=["POST"])
+def api_paywall_event():
+    """Accept a client-side paywall telemetry ping (fire-and-forget).
+
+    Body: ``{"event": "paywall_view"|"paywall_cta_click",
+             "feature": "...", "harness": "...", "source": "..."}``
+    Always returns 204 — callers never need the response.
+    """
+    try:
+        body = request.get_json(silent=True) or {}
+        event = str(body.get("event", ""))[:64]
+        harness = str(body.get("harness", ""))[:64]
+        source = str(body.get("source", ""))[:64]
+        feature = str(body.get("feature", ""))[:128]
+        logger.info(
+            "paywall: event=%s harness=%s feature=%s source=%s",
+            event, harness, feature, source,
+        )
+    except Exception as exc:
+        logger.debug("api_paywall_event: ignored error: %s", exc)
+    return "", 204
+
+
 @bp_entitlement.route("/api/license/activate", methods=["POST"])
 def api_license_activate():
     """Activate a self-hosted Pro/Enterprise license key.


### PR DESCRIPTION
Closes #2291

## Summary

- **Intercept locked selection** — `_cmOnGlobalRuntimeChange` now checks `_cmLockedRuntimes[val]`; if the chosen runtime is locked (enforcement on, OSS/Free tier), it reverts the `<select>` to the current filter and opens a paywall overlay. Runtime does not change.
- **Paywall overlay** — `_cmShowRuntimePaywall` / `_cmDismissRtPaywall` build a lightweight vanilla-JS modal (CSS-variable-aware, Escape-dismissible) with harness-specific copy and an upgrade CTA to `https://app.clawmetry.com/upgrade?source=runtime-switcher&harness=<id>`. Fires `paywall_view` and `paywall_cta_click` telemetry pings.
- **Telemetry endpoint** — `POST /api/paywall/event` added to `routes/entitlement.py`; accepts `{event, feature, harness, source}`, logs server-side, returns 204. Callers are fire-and-forget.
- **`ProPaywallModal.tsx`** — optional `harness` prop added; generates harness-specific title/description and appends `?harness=` to the upgrade URL for attribution.

Grace mode (default, `CLAWMETRY_ENFORCE` unset) is a no-op: `_cmLockedRuntimes` stays `{}` and the change handler never fires the intercept path.

## Test plan

- Set `CLAWMETRY_ENFORCE=1` and `TIER_OSS` (default, no license). Open the dashboard with ≥2 runtimes. The dropdown shows 🔒 next to `claude_code`, `codex`, etc.
- Click a locked option → selection reverts, paywall overlay appears with correct harness name and upgrade URL.
- Click "Not now" or press Escape → overlay dismisses, selection stays on previous value.
- Click "Start free trial" → opens `app.clawmetry.com/upgrade?source=runtime-switcher&harness=<id>` in new tab.
- Unset `CLAWMETRY_ENFORCE` (grace mode) → no locks, selecting any runtime works as before.
- `POST /api/paywall/event` with `{"event":"paywall_view","harness":"claude_code","source":"runtime-switcher"}` → 204 response.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXKQyvmVErgJoEWbiZpNbV)_