### PR TITLE
fix(c6): correct landing job name + add workflow_dispatch runner

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -1,0 +1,46 @@
+name: Apply required E2E status checks (C6 -- one-shot)
+
+# Runs scripts/apply_required_status_checks.py from the GitHub Actions UI
+# so the admin does not need a local Python environment.
+#
+# Prerequisite: add repo secret E2E_ADMIN_PAT containing a fine-grained PAT
+# with Administration (read + write) on all three repos:
+#   vivekchand/clawmetry, vivekchand/clawmetry-cloud, vivekchand/clawmetry-landing
+#
+# First run with confirm=dry-run to preview, then confirm=APPLY to apply.
+# Running multiple times is safe: the underlying script is idempotent.
+#
+# Tracking: vivekchand/clawmetry#2146 (C6)
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type APPLY to configure all 3 repos (anything else = dry run)"
+        required: true
+        default: "dry-run"
+
+jobs:
+  apply-required-checks:
+    name: Apply required E2E status checks (C6)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preview checks (dry run)
+        if: github.event.inputs.confirm != 'APPLY'
+        run: |
+          echo "=== DRY RUN -- checks that will be added when confirm=APPLY ==="
+          echo ""
+          echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
+          echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
+          echo "  clawmetry-cloud   : cross-repo handoff golden path"
+          echo "  clawmetry-landing : Landing golden path (C3)"
+          echo ""
+          echo "Re-run with confirm=APPLY to apply."
+
+      - name: Apply required status checks
+        if: github.event.inputs.confirm == 'APPLY'
+        env:
+          GITHUB_TOKEN: ${{ secrets.E2E_ADMIN_PAT }}
+        run: python3 scripts/apply_required_status_checks.py

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -31,11 +31,13 @@ import urllib.request
 OWNER = "vivekchand"
 
 # Each tuple: (repo, exact job name as it appears in the workflow's `name:` field)
+# Landing job name: from landing-golden-path.yml job `name: Landing golden path (C3)`
+# (PR #279 merged 2026-05-29 -- superseded #325 which had a different name).
 REQUIRED_CHECKS: list[tuple[str, str]] = [
     ("clawmetry",         "OSS golden path (wheel + OpenClaw + 9 tabs)"),
     ("clawmetry-cloud",   "Cloud golden-path browser E2E"),
     ("clawmetry-cloud",   "cross-repo handoff golden path"),
-    ("clawmetry-landing", "Landing golden path (hero + CTA + subscribe + cloud handoff)"),
+    ("clawmetry-landing", "Landing golden path (C3)"),
 ]
 
 
@@ -129,7 +131,7 @@ def main() -> None:
     print("=== All 4 E2E checks are now required on main ===")
     print()
     print("Verify at:")
-    for repo, _ in dict.fromkeys((r for r, _ in REQUIRED_CHECKS)):
+    for repo in dict.fromkeys(r for r, _ in REQUIRED_CHECKS):
         print(f"  https://github.com/{OWNER}/{repo}/settings/branches")
 
 


### PR DESCRIPTION
## Summary

`scripts/apply_required_status_checks.py` (merged via PR #2311) has the wrong job name for clawmetry-landing. It was written expecting PR #325 to merge, but PR #279 merged instead. The two PRs used different `name:` values in their `landing-golden-path.yml` jobs:

- PR #325 (superseded, closed without merging): `Landing golden path (hero + CTA + subscribe + cloud handoff)`
- PR #279 (merged 2026-05-29, currently on main): `Landing golden path (C3)`

**If the old script is run, the wrong check name gets configured.** PRs would block on a required check (`Landing golden path (hero + CTA + subscribe + cloud handoff)`) that never runs, because the actual workflow job is named differently.

### Changes

- **`scripts/apply_required_status_checks.py`**: single-line fix -- landing job name corrected to `Landing golden path (C3)`. All other check names are unchanged and verified against actual workflow `name:` fields.

- **`.github/workflows/apply-required-checks.yml`**: new `workflow_dispatch` runner so the admin can trigger the script from the GitHub Actions UI without needing a local Python environment or a terminal. First run with `confirm=dry-run` (default) to preview; re-run with `confirm=APPLY` to apply.

### Correct check names (all four)

| Repo | Job name | Source workflow |
|------|----------|-----------------|
| clawmetry | `OSS golden path (wheel + OpenClaw + 9 tabs)` | `oss-golden-path.yml` |
| clawmetry-cloud | `Cloud golden-path browser E2E` | `e2e.yml` |
| clawmetry-cloud | `cross-repo handoff golden path` | `e2e-cross-repo.yml` |
| clawmetry-landing | `Landing golden path (C3)` | `landing-golden-path.yml` |

### To close C6 after merging

1. Add repo secret `E2E_ADMIN_PAT`: fine-grained PAT with **Administration (read + write)** on clawmetry, clawmetry-cloud, clawmetry-landing.
2. Go to Actions -> "Apply required E2E status checks (C6 -- one-shot)" -> Run workflow -> confirm=`APPLY`.
3. Verify in each repo: Settings -> Branches -> main -> Branch protection rules.

### Acceptance test

`python3 scripts/apply_required_status_checks.py` (with a valid PAT) prints:

```
[clawmetry-landing] added required check: 'Landing golden path (C3)'
```

not the old superseded name.

Tracking: vivekchand/clawmetry#2146 (C6)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPdR7UY9DtUwyS5FbeoeiE)_