### PR TITLE
feat(open-core): load_plugins() in dashboard_claudecode create_app

### DIFF
--- a/dashboard_claudecode.py
+++ b/dashboard_claudecode.py
@@ -1295,6 +1295,23 @@ def create_app(claude_home: Optional[str] = None) -> Flask:
         )
 
     app = Flask(__name__)
+
+    # Open-core plugin host: when this module is run standalone (or its
+    # ``create_app()`` is called from a sibling entry point), it never imports
+    # ``dashboard.py`` — so the import-time ``load_plugins()`` there never
+    # fires for this process. Wire it explicitly so paid plugins (e.g.
+    # ``clawmetry-pro`` Blueprints scoped to the Claude Code surface) get a
+    # chance to register on this app too. Errors are swallowed with a logged
+    # warning — a broken plugin must never take down the claudecode dashboard.
+    try:
+        from clawmetry.extensions import load_plugins as _ext_load
+
+        _ext_load(app)
+    except Exception as _ext_exc:  # pragma: no cover - defensive
+        logger.warning(
+            "claudecode: extension plugin load failed: %s", _ext_exc
+        )
+
     app.register_blueprint(bp_claudecode, url_prefix="/")
     return app
 

--- a/tests/test_claudecode_loads_plugins.py
+++ b/tests/test_claudecode_loads_plugins.py
@@ -1,0 +1,87 @@
+"""Tests for the ``load_plugins(app)`` wire-up in
+``dashboard_claudecode.create_app``.
+
+The Claude Code dashboard variant is a *standalone* Flask app — its
+``main()`` builds the app via ``create_app()`` and never imports the main
+``dashboard`` module. dashboard.py's import-time ``load_plugins()`` call
+therefore never fires for this process. Without an explicit wire-up here,
+``clawmetry-pro`` plugins that ship Blueprints scoped to the Claude Code
+surface would silently be skipped when a user runs
+
+    python3 dashboard_claudecode.py --port 8901
+
+even though they register correctly on the main dashboard process. These
+tests pin down the wire-up so it can't regress.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import dashboard_claudecode
+from clawmetry import extensions as _ext
+
+
+@pytest.fixture(autouse=True)
+def _reset_extensions_guard():
+    """Each test gets a clean ``_loaded`` guard so ``load_plugins`` actually
+    runs; otherwise the first test that imports anything plugin-adjacent
+    would short-circuit later tests."""
+    prev = _ext._loaded
+    _ext._loaded = False
+    try:
+        yield
+    finally:
+        _ext._loaded = prev
+
+
+def test_create_app_invokes_load_plugins(monkeypatch):
+    """``create_app()`` must call ``extensions.load_plugins`` exactly once and
+    hand it the Flask app — that is the contract paid plugins rely on to
+    register Blueprints scoped to the Claude Code dashboard."""
+    calls: list[object] = []
+
+    def _fake_load(app=None):
+        calls.append(app)
+
+    monkeypatch.setattr(_ext, "load_plugins", _fake_load)
+
+    app = dashboard_claudecode.create_app()
+
+    assert len(calls) == 1, "load_plugins must be invoked exactly once"
+    assert calls[0] is app, "load_plugins must receive the Flask app"
+
+
+def test_create_app_swallows_plugin_load_errors(monkeypatch, caplog):
+    """A raising ``load_plugins`` must not propagate — the standalone
+    claudecode dashboard must come up even when a paid plugin is broken."""
+
+    def _boom(app=None):
+        raise RuntimeError("plugin install corrupt")
+
+    monkeypatch.setattr(_ext, "load_plugins", _boom)
+
+    with caplog.at_level(logging.WARNING, logger="clawmetry.claudecode"):
+        app = dashboard_claudecode.create_app()
+
+    assert app is not None, "create_app must still return a Flask app"
+    assert any(
+        "extension plugin load failed" in rec.getMessage().lower()
+        for rec in caplog.records
+    ), "broken plugin path must be logged at WARNING"
+
+
+def test_create_app_returns_flask_app_with_blueprint(monkeypatch):
+    """The plugin hook must not regress the existing app shape: the
+    ``claudecode`` Blueprint still has to register on ``/``."""
+    monkeypatch.setattr(_ext, "load_plugins", lambda app=None: None)
+
+    app = dashboard_claudecode.create_app()
+
+    # Flask app + blueprint still registered after the wire-up.
+    assert hasattr(app, "register_blueprint")
+    assert "claudecode" in app.blueprints, (
+        "the bp_claudecode blueprint must still be registered after the "
+        "load_plugins() call is added"
+    )


### PR DESCRIPTION
## Summary

Wires the `clawmetry.extensions` entry-point plugin loader into the
**standalone Claude Code dashboard** so paid plugins (clawmetry-pro
Blueprints scoped to that surface) register on its Flask app too — not
only on the main dashboard process.

### Why

`dashboard.py` calls `load_plugins(app)` at module import time
(`dashboard.py:168`), so the main dashboard process picks up
`clawmetry.extensions` entry-point plugins for HTTP routes and `emit()`
events. The sync daemon hook is in flight in #2277 and the proxy hook
in #2347.

The **Claude Code dashboard variant** (`dashboard_claudecode.py`) is a
*fourth* long-running Flask process — launched as
`python3 dashboard_claudecode.py --port 8901` or via its own
`create_app()` factory — that never imports `dashboard`. The
`extensions._loaded` guard is per-process state, so until now the
standalone claudecode dashboard was the last ClawMetry Flask process
where paid plugins were silently skipped. A `clawmetry-pro` plugin that
ships a Blueprint targeting the Claude Code surface (e.g. a Pro-only
session detail view, an asset-registry promotion endpoint) would
register on the main dashboard process but be missing here — the
standalone claudecode dashboard would silently fall back to OSS-only
endpoints, which is the *opposite* of what a paid plugin is for.

### What

- **`dashboard_claudecode.py`** — call `load_plugins(app)` inside
  `create_app()` right after `app = Flask(__name__)` is constructed and
  *before* `bp_claudecode` is registered, so a plugin Blueprint can
  land alongside it. Mirrors the pattern already in `dashboard.py`.
  Errors are swallowed with a logged warning — a broken plugin must
  never take down the claudecode dashboard. Late import of the symbol
  keeps the standalone module importable even on installs where
  `clawmetry.extensions` somehow isn't available.

- **`tests/test_claudecode_loads_plugins.py`** — 3 hermetic tests:
  1. `create_app` calls `extensions.load_plugins` exactly once and
     hands it the Flask app
  2. A raising `load_plugins` is swallowed (no `RuntimeError`
     propagates) — the standalone dashboard still comes up
  3. The `bp_claudecode` Blueprint is still registered on the app
     after the wire-up (no shape regression)

Default behaviour unchanged — the OSS install has zero registered
entry-point plugins, so `load_plugins()` is a fast no-op for free
users. Stays in **GRACE**: no gate is enforced, no behaviour flips.

## Test plan

- [x] `python3 -m pytest tests/test_claudecode_loads_plugins.py -v` → 3 passed
- [x] `python3 -m pytest tests/test_extensions.py tests/test_entitlements.py tests/test_claudecode_loads_plugins.py` → 32 passed, 0 failed (only `test_license.py` errors out in this sandbox due to a pre-existing `_cffi_backend` issue — identical on `origin/main`, not caused by this PR)
- [x] `python3 -m py_compile dashboard_claudecode.py tests/test_claudecode_loads_plugins.py` → syntax OK
- [x] `make lint` — no new findings in `dashboard_claudecode.py`; the 195 errors reported are all pre-existing on `main`

## Local operator verification checklist

Since this autonomous run cannot reach the user's machine, `~/.openclaw`,
the running daemon, the live cloud snapshot, or a browser:

- [ ] Copy `dashboard_claudecode.py` + `tests/test_claudecode_loads_plugins.py`
      into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and the
      test into the daemon's test path if you run tests in-place)
- [ ] Clear `__pycache__` under that site-packages tree
- [ ] If the claudecode dashboard runs as its own launchd / systemd
      service, kick it: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.claudecode`
      (otherwise restart however you normally do it)
- [ ] Tail the claudecode dashboard log and confirm no new ERROR lines
      at startup
- [ ] Hit `http://localhost:8900/api/entitlement` — still resolves as
      `tier: "oss"`, `grace: true` on the OSS install (no behaviour
      change)
- [ ] Decrypt the live cloud snapshot in the browser — sessions, brain
      feed, flow tab still render
- [ ] Once `clawmetry-pro` is installed against this build, confirm the
      claudecode dashboard log shows
      `Loaded ClawMetry extension plugin: <name>` from the standalone
      claudecode process (previously only the main dashboard process
      printed this)

## Roadmap status

Open-core phases 1 and 2 (entitlements, license, CLI subcommands,
`/api/entitlement`, dashboard plugin host) are already on `main`. The
remaining places where `load_plugins()` should fire in their own
processes are:

- ✅ `dashboard.py` — on `main`
- ⏳ `clawmetry/sync.py` — in flight in #2277 (sync daemon)
- ⏳ `clawmetry/proxy.py` — in flight in #2347 (enforcement proxy)
- ⏳ `dashboard_claudecode.py` — this PR

Phases 3, 4, 6 (cloud entitlement push, closed-source `clawmetry-pro`
wheel publish, enterprise/SSO/RBAC) require the private
`clawmetry-cloud` and not-yet-existing `clawmetry-pro` repos that this
autonomous run does not have access to — left for the local operator.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013foCUYvPjBd4NMxHBJ8gCo)_