### PR TITLE
test(e2e): cheapest Anthropic model for the real billed OpenClaw turns

### DIFF
--- a/tests/test_moat_live_openclaw_e2e.py
+++ b/tests/test_moat_live_openclaw_e2e.py
@@ -257,7 +257,12 @@ def _send_message(home: str, message: str) -> subprocess.CompletedProcess:
         [
             OPENCLAW_BIN, "agent", "--local",
             "--message", message, "--to", RECIPIENT,
-            "--model", "anthropic/claude-opus-4-7",
+            # Cheapest Anthropic model: this is a real billed turn in CI and we
+            # only assert the canonical <sid>.jsonl SHAPE (session + user +
+            # assistant rows with provider/model populated), which Haiku writes
+            # identically to Opus. The anthropic/ prefix drives harness
+            # selection (see note above); the specific model is free to be cheap.
+            "--model", "anthropic/claude-3-5-haiku-20241022",
             "--json", "--timeout", "30",
         ],
         env=env, capture_output=True, text=True, timeout=60,

--- a/tests/test_moat_real_e2e.py
+++ b/tests/test_moat_real_e2e.py
@@ -225,7 +225,11 @@ def _send_message(home: str, message: str) -> subprocess.CompletedProcess:
         [
             OPENCLAW_BIN, "agent", "--local",
             "--message", message, "--to", RECIPIENT,
-            "--model", "anthropic/claude-opus-4-7",
+            # Cheapest Anthropic model: real billed turn in CI, and we assert
+            # only the JSONL shape (provider/model rows), which Haiku writes
+            # identically to Opus. The anthropic/ prefix drives harness
+            # selection; the specific model is free to be cheap.
+            "--model", "anthropic/claude-3-5-haiku-20241022",
             "--json", "--timeout", "30",
         ],
         env=env, capture_output=True, text=True, timeout=60,


### PR DESCRIPTION
## What
Switches the two **real billed** OpenClaw turns in CI from `anthropic/claude-opus-4-7` to the cheapest model `anthropic/claude-3-5-haiku-20241022`:
- `tests/test_moat_live_openclaw_e2e.py:260`
- `tests/test_moat_real_e2e.py:228`

## Why it's safe
Both tests assert only the **canonical `<sid>.jsonl` shape** — session + user + assistant rows with `provider`/`model` populated (the "gateway bubble" signature). Haiku writes the identical shape. OpenClaw v3 harness selection is driven by the `anthropic/` prefix (not the specific model), so routing is unchanged.

## Scope (the "everywhere" audit)
- `test_real_openclaw_binary_e2e.py` — passes **no `--model`** + a bogus key (401s before billing), so it's already free; unchanged.
- The cloud "real-browser Brain E2E" runs against seeded snapshot data with no LLM creds — not a billed turn.
- clawmetry-pro conformance turns already use the cheap tier (Haiku / gpt-4o-mini).
- The `claude-opus-4-7` strings elsewhere (golden-path, unit tests) are **synthetic seeded event labels with hardcoded `cost_usd`** — no LLM call, and several feed exact cost-math assertions, so they are intentionally left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)