### PR TITLE
feat(ingest): add /api/v1/engines/* OSS 402-stubs (#2269)

### DIFF
--- a/routes/runtime_ingest.py
+++ b/routes/runtime_ingest.py
@@ -68,3 +68,16 @@ def end_run_stub(run_id: str):
 @bp_runtime_ingest.route("/api/v1/runs/<run_id>", methods=["GET"])
 def get_run_stub(run_id: str):
     return jsonify(_UPGRADE), 402
+
+
+@bp_runtime_ingest.route("/api/v1/engines", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+def engines_stub():
+    return jsonify(_UPGRADE), 402
+
+
+@bp_runtime_ingest.route(
+    "/api/v1/engines/<path:subpath>",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+)
+def engines_subpath_stub(subpath: str):
+    return jsonify(_UPGRADE), 402

--- a/tests/test_oss_stubs_after_pro_move.py
+++ b/tests/test_oss_stubs_after_pro_move.py
@@ -13,6 +13,8 @@ What this file covers:
   - POST /api/v1/runs/<id>/events returns 402
   - POST /api/v1/runs/<id>/end returns 402
   - GET  /api/v1/runs/<id> returns 402
+  - GET/POST /api/v1/engines returns 402 upgrade_required
+  - GET/POST /api/v1/engines/<path> returns 402 upgrade_required
 
 * ``clawmetry/otel_push.py`` (OSS delegating shim):
   - forward_event() is a no-op when pro is unavailable
@@ -34,7 +36,7 @@ import pytest
 from flask import Flask
 
 
-# ── runtime_ingest stub ───────────────────────────────────────────────────────
+# ── runtime_ingest stub ─────────────────────────────────────────────────
 
 
 @pytest.fixture
@@ -87,7 +89,22 @@ def test_get_run_returns_402(app_with_stub):
         assert r.status_code == 402
 
 
-# ── otel_push delegating shim ────────────────────────────────────────────────
+def test_engines_root_returns_402(app_with_stub):
+    with app_with_stub.test_client() as c:
+        r = c.get("/api/v1/engines")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["feature"] == "custom_runtime_ingest"
+
+
+def test_engines_subpath_returns_402(app_with_stub):
+    with app_with_stub.test_client() as c:
+        r = c.post("/api/v1/engines/my-engine/runs", json={})
+        assert r.status_code == 402
+
+
+# ── otel_push delegating shim ──────────────────────────────────────────────
 
 
 def _hide_pro(monkeypatch):
@@ -121,7 +138,7 @@ def test_otel_push_reset_is_safe(monkeypatch):
     _otelp.reset_for_tests()  # no-op, no raise
 
 
-# ── PD/OG dashboard helpers delegate ──────────────────────────────────────────
+# ── PD/OG dashboard helpers delegate ────────────────────────────────────────────
 
 
 def test_build_pagerduty_payload_returns_empty_when_pro_absent(monkeypatch):


### PR DESCRIPTION
## Summary

The `/api/v1/runs/*` stubs and the `custom_runtime_ingest` entitlement key were already on `main`, but the issue also called for reserving `/api/v1/engines/*` — those URLs were returning 404 instead of the expected `upgrade_required` 402. This PR fills that gap.

## Changes

- **`routes/runtime_ingest.py`** — two new route handlers that catch all HTTP methods on `/api/v1/engines` and `/api/v1/engines/<path:subpath>`, returning the same `upgrade_required` 402 body the runs-stubs already emit. Uses a `<path:subpath>` catch-all so any depth (e.g. `/api/v1/engines/my-engine/runs`) is reserved without assuming a specific URL shape.
- **`tests/test_oss_stubs_after_pro_move.py`** — two new tests (`test_engines_root_returns_402`, `test_engines_subpath_returns_402`) pinning the 402 shape for engine routes, plus docstring updated to list them.

## Test plan

- [ ] `python3 -m pytest tests/test_oss_stubs_after_pro_move.py -v` — all existing + 2 new engine tests pass
- [ ] `python3 -c "import ast; ast.parse(open('routes/runtime_ingest.py').read())"` — no syntax errors

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #2269. Marked draft for human review — mark Ready for Review once happy.

Closes #2269

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcvH5Wtcx5qcw4wMpyBDSP)_