### PR TITLE
test(e2e): drive test_spans_e2e through the REAL OTLP path (no put_span shortcut)

### DIFF
--- a/tests/test_spans_e2e.py
+++ b/tests/test_spans_e2e.py
@@ -1,15 +1,23 @@
 """E2E test for /api/spans — MOAT issue #1364.
 
-Confirms the read-side surface for OTel spans we already persist:
+Confirms the read-side surface for OTel spans we already persist, driven by
+the REAL ingest path end to end (no synthetic ``put_span`` shortcut):
 
-  inject 3 spans via LocalStore.ingest_span()  →
-  GET /api/spans                                →
-  assert all 3 returned, ordered by start_time DESC.
+  build OTLP ExportTraceServiceRequest  →
+  POST protobuf to /v1/traces (the real production receiver)  →
+  GET /api/spans                                               →
+  assert the spans surface, ordered by start_time DESC.
 
-The ingest path under test is the same one routes/meta.py /v1/traces uses
-in production: dashboard._process_otlp_traces → LocalStore.put_span (which
-is an alias for ingest_span). Calling ingest_span directly here keeps the
-test independent of opentelemetry-proto being installed.
+This is a true e2e: the same path production traffic takes —
+``POST /v1/traces`` → ``dashboard._process_otlp_traces`` → ``_otel_to_row``
+→ ``LocalStore.put_span`` → ``GET /api/spans`` → read. Earlier this file
+called ``store.put_span()`` directly, which skipped the OTLP receiver + the
+attribute-projection layer — an ingest regression there would not have been
+caught. Now both ingest and read run over HTTP for real.
+
+Gated on ``opentelemetry-proto`` (``pip install clawmetry[otel]``); the OTLP
+receiver returns 501 without it, so a real POST is only meaningful when it's
+installed. Skips loudly otherwise rather than silently degrading.
 """
 
 from __future__ import annotations
@@ -20,14 +28,28 @@ import time
 import pytest
 from flask import Flask
 
+try:
+    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2 as _ts_pb2
+    from opentelemetry.proto.trace.v1 import trace_pb2 as _trace_pb2
+    _HAS_OTEL_PROTO = True
+except Exception:  # pragma: no cover - exercised only on minimal installs
+    _HAS_OTEL_PROTO = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_OTEL_PROTO,
+    reason="opentelemetry-proto not installed (pip install clawmetry[otel]); "
+           "the /v1/traces receiver returns 501, so a real OTLP POST is moot",
+)
+
 
 @pytest.fixture
 def app(tmp_path, monkeypatch):
-    """Fresh DuckDB store + Flask app with the sessions blueprint mounted.
+    """Fresh DuckDB store + Flask app with the OTLP receiver AND the read
+    surface mounted, so one test client can POST a real trace and read it back.
 
-    Uses single-process mode (the dashboard owns the writer lock since no
-    sync daemon is running) so _ls_call's daemon-proxy path falls through
-    to the direct-open fallback — exactly what we want to exercise here.
+    Single-process mode (the dashboard owns the writer lock, no sync daemon)
+    so ``_ls_call``'s daemon-proxy path falls through to the direct-open
+    fallback — exactly what we want to exercise here.
     """
     monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
     monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
@@ -36,13 +58,27 @@ def app(tmp_path, monkeypatch):
 
     import clawmetry.local_store as ls
     importlib.reload(ls)
+    # Force a hermetic direct store: if a real ClawMetry daemon happens to be
+    # running on the test host, get_store() would otherwise return a proxy to
+    # the daemon's DuckDB (the writer-lock guard) and our tmp_path store would
+    # never see the spans. CI has no daemon; this makes local runs match CI.
+    monkeypatch.setattr(ls, "_daemon_registered", lambda *a, **k: False)
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
     import routes.local_query as lq
     importlib.reload(lq)
+    # Read path: force the local-query dispatch to the direct-open store too.
+    # _read_discovery() returning None makes _proxy_dispatch raise, so reads
+    # fall through to the in-process DuckDB (same hermetic store the OTLP
+    # ingest writes to). Mirrors test_e2e_real_openclaw_pipeline.
+    monkeypatch.setattr(lq, "_read_discovery", lambda: None)
     import routes.sessions as ses
     importlib.reload(ses)
+    import routes.meta as meta
+    importlib.reload(meta)
 
     a = Flask(__name__)
     a.register_blueprint(ses.bp_sessions)
+    a.register_blueprint(meta.bp_otel)  # /v1/traces — the real receiver
     yield a, ls
     try:
         ls.get_store().stop(flush=True)
@@ -50,29 +86,83 @@ def app(tmp_path, monkeypatch):
         pass
 
 
-def _span(span_id, start_ts, *, session_id="sess-spans-e2e", name="llm.call"):
-    """Minimal valid span dict (matches ingest_span's required keys)."""
-    return {
-        "span_id":      span_id,
-        "trace_id":     "trace-e2e",
-        "name":         name,
-        "kind":         "CLIENT",
-        "start_ts":     float(start_ts),
-        "end_ts":       float(start_ts) + 0.5,
-        "status":       "OK",
-        "service_name": "openclaw",
-        "agent_id":     "main",
-        "agent_type":   "openclaw",
-        "session_id":   session_id,
-        "model":        "claude-opus-4-7",
-        "tokens_input":  10,
-        "tokens_output": 5,
-        "attributes":   {"gen_ai.system": "anthropic"},
-    }
+# ── Real OTLP ingest helpers ────────────────────────────────────────────────
+#
+# Span IDs are 8-byte / trace IDs 16-byte per OTLP, so we use hex ids (not
+# arbitrary strings). ``/api/spans`` returns the hex span_id, which the
+# ordering/filter assertions key off.
+
+
+def _hex_span(n: int) -> str:
+    return f"{n:016x}"
+
+
+def _build_traces_pb(specs):
+    """Build a serialized OTLP ExportTraceServiceRequest from span specs.
+
+    Each spec: {span_id_hex, start_ts (unix sec), name, session_id,
+                duration_s (default 0.5)}. Attributes use the GenAI semconv
+    keys ``_otel_to_row`` projects (session.id, gen_ai.request.model,
+    gen_ai.usage.*) so the typed columns the UI reads get populated.
+    """
+    req = _ts_pb2.ExportTraceServiceRequest()
+    rs = req.resource_spans.add()
+    res_attr = rs.resource.attributes.add()
+    res_attr.key = "service.name"
+    res_attr.value.string_value = "openclaw"
+    scope_spans = rs.scope_spans.add()
+    for spec in specs:
+        sp = scope_spans.spans.add()
+        sp.trace_id = bytes.fromhex("0123456789abcdef0123456789abcdef")
+        sp.span_id = bytes.fromhex(spec["span_id_hex"])
+        sp.name = spec["name"]
+        sp.kind = _trace_pb2.Span.SPAN_KIND_CLIENT
+        start_ns = int(spec["start_ts"] * 1e9)
+        sp.start_time_unix_nano = start_ns
+        sp.end_time_unix_nano = start_ns + int(spec.get("duration_s", 0.5) * 1e9)
+        sp.status.code = _trace_pb2.Status.STATUS_CODE_OK
+        for k, v in (
+            ("session.id", spec.get("session_id", "sess-spans-e2e")),
+            ("gen_ai.request.model", "claude-3-5-haiku-20241022"),
+            ("agent.type", "openclaw"),
+            ("agent.id", "main"),
+        ):
+            a = sp.attributes.add()
+            a.key = k
+            a.value.string_value = v
+        for k, iv in (
+            ("gen_ai.usage.input_tokens", 10),
+            ("gen_ai.usage.output_tokens", 5),
+        ):
+            a = sp.attributes.add()
+            a.key = k
+            a.value.int_value = iv
+    return req.SerializeToString()
+
+
+def _post_traces(client, ls, specs):
+    """POST a real OTLP protobuf to /v1/traces, assert 2xx, then wait for the
+    async flusher to drain the ring so the spans are queryable from DuckDB
+    (put_span enqueues; the read path reads flushed rows)."""
+    r = client.post(
+        "/v1/traces",
+        data=_build_traces_pb(specs),
+        content_type="application/x-protobuf",
+    )
+    assert r.status_code == 200, (
+        f"/v1/traces rejected the OTLP payload: {r.status_code} "
+        f"{r.get_data(as_text=True)[:300]}"
+    )
+    store = ls.get_store()
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if store.health().get("ring_depth", 0) == 0:
+            return
+        time.sleep(0.02)
 
 
 def test_api_spans_returns_ingested_spans_ordered_desc(app):
-    """Synthetic event → DuckDB → /api/spans round-trip.
+    """Real OTLP POST → DuckDB → /api/spans round-trip.
 
     Asserts:
       * All 3 ingested spans surface in the response.
@@ -80,15 +170,15 @@ def test_api_spans_returns_ingested_spans_ordered_desc(app):
       * Each row carries the contract fields the UI renders
         (name, duration_ms, session_id, kind, start_time).
     """
-    a, ls = app
-    store = ls.get_store()
-    # Use distinct, increasing start_ts so the DESC sort is unambiguous.
-    base = time.time() - 60
-    store.put_span(_span("span-e2e-1", base + 1.0, name="llm.call"))
-    store.put_span(_span("span-e2e-2", base + 2.0, name="tool.call"))
-    store.put_span(_span("span-e2e-3", base + 3.0, name="agent.step"))
-
+    a, _ls = app
     c = a.test_client()
+    base = time.time() - 60
+    _post_traces(c, _ls, [
+        {"span_id_hex": _hex_span(1), "start_ts": base + 1.0, "name": "llm.call"},
+        {"span_id_hex": _hex_span(2), "start_ts": base + 2.0, "name": "tool.call"},
+        {"span_id_hex": _hex_span(3), "start_ts": base + 3.0, "name": "agent.step"},
+    ])
+
     r = c.get("/api/spans?limit=10")
     assert r.status_code == 200, r.get_data(as_text=True)[:300]
     body = r.get_json()
@@ -96,7 +186,7 @@ def test_api_spans_returns_ingested_spans_ordered_desc(app):
     assert body["count"] == 3
     spans = body["spans"]
     # Newest first.
-    assert [s["span_id"] for s in spans] == ["span-e2e-3", "span-e2e-2", "span-e2e-1"]
+    assert [s["span_id"] for s in spans] == [_hex_span(3), _hex_span(2), _hex_span(1)]
     # Contract fields the UI renders.
     for s in spans:
         assert s["name"]
@@ -109,19 +199,20 @@ def test_api_spans_returns_ingested_spans_ordered_desc(app):
 
 def test_api_spans_session_filter(app):
     """`session_id` query param scopes the result set."""
-    a, ls = app
-    store = ls.get_store()
-    base = time.time() - 60
-    store.put_span(_span("span-a", base + 1.0, session_id="sess-A"))
-    store.put_span(_span("span-b", base + 2.0, session_id="sess-B"))
-    store.put_span(_span("span-c", base + 3.0, session_id="sess-A"))
-
+    a, _ls = app
     c = a.test_client()
+    base = time.time() - 60
+    _post_traces(c, _ls, [
+        {"span_id_hex": _hex_span(0xA), "start_ts": base + 1.0, "name": "a", "session_id": "sess-A"},
+        {"span_id_hex": _hex_span(0xB), "start_ts": base + 2.0, "name": "b", "session_id": "sess-B"},
+        {"span_id_hex": _hex_span(0xC), "start_ts": base + 3.0, "name": "c", "session_id": "sess-A"},
+    ])
+
     r = c.get("/api/spans?session_id=sess-A")
     assert r.status_code == 200
     body = r.get_json()
     assert body["count"] == 2
-    assert {s["span_id"] for s in body["spans"]} == {"span-a", "span-c"}
+    assert {s["span_id"] for s in body["spans"]} == {_hex_span(0xA), _hex_span(0xC)}
 
 
 def test_api_spans_empty_store(app):
@@ -137,13 +228,14 @@ def test_api_spans_empty_store(app):
 
 def test_api_spans_limit_clamped(app):
     """`limit` is clamped 1-500 to prevent runaway scans."""
-    a, ls = app
-    store = ls.get_store()
-    base = time.time() - 60
-    for i in range(5):
-        store.put_span(_span(f"span-l-{i}", base + i))
-
+    a, _ls = app
     c = a.test_client()
+    base = time.time() - 60
+    _post_traces(c, _ls, [
+        {"span_id_hex": _hex_span(0x10 + i), "start_ts": base + i, "name": f"s{i}"}
+        for i in range(5)
+    ])
+
     # Out-of-range values should fall back to safe defaults rather than 400.
     r = c.get("/api/spans?limit=99999")
     assert r.status_code == 200
@@ -162,38 +254,42 @@ def test_api_spans_limit_clamped(app):
 # can render the upgrade CTA when the cap kicks in.
 
 
-def _seed_old_and_recent_spans(store):
-    """One ancient span (8 days old) + one fresh span (5 min ago)."""
+def _post_old_and_recent_spans(client, ls):
+    """One ancient span (8 days old) + one fresh span (5 min ago), via OTLP."""
     now = time.time()
-    store.put_span(_span("span-old", now - 8 * 86400, name="ancient"))
-    store.put_span(_span("span-new", now - 300, name="fresh"))
+    _post_traces(client, ls, [
+        {"span_id_hex": _hex_span(0x0100), "start_ts": now - 8 * 86400, "name": "ancient"},
+        {"span_id_hex": _hex_span(0x0200), "start_ts": now - 300, "name": "fresh"},
+    ])
 
 
 def test_api_spans_oss_capped_to_24h(app, monkeypatch):
     """Non-Pro users see only spans newer than now-24h; flag set."""
-    a, ls = app
-    _seed_old_and_recent_spans(ls.get_store())
+    a, _ls = app
+    c = a.test_client()
+    _post_old_and_recent_spans(c, _ls)
     import dashboard as _d
     monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
 
-    r = a.test_client().get("/api/spans?limit=10")
+    r = c.get("/api/spans?limit=10")
     assert r.status_code == 200, r.get_data(as_text=True)[:300]
     body = r.get_json()
     assert body["capped_at_24h"] is True
     sids = {s["span_id"] for s in body["spans"]}
     # The 8-day-old span must be excluded; only the fresh one shows.
-    assert sids == {"span-new"}
+    assert sids == {_hex_span(0x0200)}
 
 
 def test_api_spans_pro_bypasses_cap(app, monkeypatch):
     """Pro users get the full history, unflagged."""
-    a, ls = app
-    _seed_old_and_recent_spans(ls.get_store())
+    a, _ls = app
+    c = a.test_client()
+    _post_old_and_recent_spans(c, _ls)
     import dashboard as _d
     monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
 
-    r = a.test_client().get("/api/spans?limit=10")
+    r = c.get("/api/spans?limit=10")
     body = r.get_json()
     assert body["capped_at_24h"] is False
     sids = {s["span_id"] for s in body["spans"]}
-    assert sids == {"span-old", "span-new"}
+    assert sids == {_hex_span(0x0100), _hex_span(0x0200)}


### PR DESCRIPTION
First conversion in the **"real e2e, no synthetic seeds"** initiative.

## Before
`test_spans_e2e` set up data by calling `LocalStore.put_span()` directly — a synthetic shortcut that **skipped the OTLP receiver and the attribute-projection layer** (`/v1/traces` → `_process_otlp_traces` → `_otel_to_row`). A regression in that ingest path would have left this "e2e" green.

## After
Builds a real OTLP `ExportTraceServiceRequest`, **POSTs the protobuf to `/v1/traces`** (the actual production receiver), and reads it back via **`GET /api/spans`** — ingest *and* read over HTTP for real. Every read assertion is preserved (DESC order, session filter, limit clamp, 24h retention cap + Pro bypass).

## Hermetic on any host
Forces the direct in-process DuckDB on both sides — ingest (`ls._daemon_registered → False`) and read (`lq._read_discovery → None`) — so it passes whether or not a real ClawMetry daemon is running on the test host (CI has none; a dev machine with a live daemon would otherwise proxy to the daemon's DB). Gated on `opentelemetry-proto` (the receiver 501s without it).

**Verified locally: 6 passed.**

## Initiative context
Per the directive that e2e tests must exercise the real pipeline (synthetic data only for unit tests). This is the cleanest case (deterministic + real + zero LLM cost). The remaining ~14 e2e-named tests are heterogeneous (some are deterministic transform/integration tests whose exact-invariant value is lost under a non-deterministic real LLM turn; some channel-ingest tests need live bot infra that can't run in CI) — I'm cataloguing those with a per-test plan rather than mechanically converting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)