### PR TITLE
fix(fleet): surface local-node DuckDB scope on Usage and History tabs

### DIFF
--- a/clawmetry/templates/tabs/history.html
+++ b/clawmetry/templates/tabs/history.html
@@ -1,4 +1,7 @@
 <div class="page" id="page-history">
+  <div id="history-node-scope-banner" style="background:var(--bg-secondary,#f1f5f9);border:1px solid var(--border-primary,#e2e8f0);border-left:3px solid #3b82f6;padding:10px 14px;border-radius:4px;margin-bottom:12px;font-size:13px;color:var(--text-secondary,#64748b);">
+    ℹ️ <strong>Local node only.</strong> These figures reflect only this node's DuckDB. See the <a href="#" onclick="showTab('fleet');return false" style="color:#3b82f6;text-decoration:none;">Fleet</a> tab for cross-node totals.
+  </div>
   <div style="display:flex;align-items:center;gap:16px;margin-bottom:16px;flex-wrap:wrap;">
     <h2 style="font-size:18px;font-weight:700;color:var(--text-primary);margin:0;">&#128202; <span data-i18n="history.title">History</span></h2>
     <div style="display:flex;gap:4px;flex-wrap:wrap;" id="time-range-picker">

--- a/clawmetry/templates/tabs/usage.html
+++ b/clawmetry/templates/tabs/usage.html
@@ -1,4 +1,7 @@
 <div class="page" id="page-usage">
+  <div id="usage-node-scope-banner" style="background:var(--bg-secondary,#f1f5f9);border:1px solid var(--border-primary,#e2e8f0);border-left:3px solid #3b82f6;padding:10px 14px;border-radius:4px;margin-bottom:12px;font-size:13px;color:var(--text-secondary,#64748b);">
+    ℹ️ <strong>Local node only.</strong> These figures reflect only this node's DuckDB. See the <a href="#" onclick="showTab('fleet');return false" style="color:#3b82f6;text-decoration:none;">Fleet</a> tab for cross-node totals.
+  </div>
   <div class="refresh-bar">
     <button class="refresh-btn" onclick="loadUsage()">↻ <span data-i18n="common.refresh">Refresh</span></button>
     <button class="refresh-btn" onclick="exportUsageData()" style="margin-left: 8px;">📥 <span data-i18n="usage.export_csv">Export CSV</span></button>

--- a/routes/fleet_history.py
+++ b/routes/fleet_history.py
@@ -16,6 +16,7 @@ Module-level helpers (``_fleet_db``, ``_fleet_db_lock``, ``_fleet_check_key``,
 ``dashboard.py`` and are reached via late ``import dashboard as _d``.
 """
 
+import datetime
 import json
 import time
 
@@ -146,6 +147,33 @@ def api_nodes_list():
 
         db.close()
 
+    # Enrich the local node's entry with accurate DuckDB-derived totals so
+    # the fleet view can show real cost/token data without relying on the
+    # heartbeat payload (which doesn't include these fields today).
+    try:
+        from clawmetry.local_store import get_store
+        today = datetime.date.today().isoformat()
+        store = get_store()
+        if store is not None:
+            agg_rows = store.query_aggregates(since=today)
+            cost_today = round(sum(r.get("cost_usd", 0) or 0 for r in agg_rows), 4)
+            tokens_today = int(sum(r.get("token_count", 0) or 0 for r in agg_rows))
+            local_node_id = getattr(store, "node_id", None)
+            for n in result:
+                if local_node_id and n["node_id"] == local_node_id:
+                    n["duckdb_summary"] = {
+                        "cost_today_usd": cost_today,
+                        "token_count_today": tokens_today,
+                        "source": "local_duckdb",
+                    }
+                    n["is_local"] = True
+                    # Use DuckDB-sourced cost as the authoritative value for
+                    # fleet_summary rather than the (often empty) heartbeat figure.
+                    total_cost = max(total_cost, cost_today)
+                    break
+    except Exception:
+        pass
+
     return jsonify(
         {
             "nodes": result,
@@ -155,6 +183,10 @@ def api_nodes_list():
                 "offline": offline_count,
                 "total_cost_today": round(total_cost, 2),
                 "total_sessions_today": total_sessions,
+                # data_scope signals to callers that analytics tabs show
+                # local-node data only; multi_node_partial means remote nodes
+                # rely on heartbeat payloads which may lack DuckDB summaries.
+                "data_scope": "single_node" if len(result) <= 1 else "multi_node_partial",
             },
         }
     )


### PR DESCRIPTION
Closes #1607

## Summary

- **Usage and History tabs** now show an info banner ("Local node only — see Fleet for cross-node totals") so multi-node fleet users know the analytics scope at a glance.
- **`/api/nodes` response** enriches the local node's entry with DuckDB-derived `duckdb_summary` (`cost_today_usd`, `token_count_today`) queried directly via `local_store.query_aggregates`, bypassing the heartbeat payload which doesn't include these fields today.
- **`fleet_summary.data_scope`** is now `"single_node"` or `"multi_node_partial"` so API callers can detect partial aggregation without parsing node counts.

## Test plan

- [ ] Start ClawMetry with one node — Usage and History tabs show the info banner; Fleet tab shows `data_scope: "single_node"`.
- [ ] Register a second node — Fleet tab shows `data_scope: "multi_node_partial"`; local node entry includes `duckdb_summary` with accurate cost/token figures.
- [ ] Verify `GET /api/nodes` returns `duckdb_summary` for the local node (non-empty DuckDB) without error.
- [ ] Confirm no regression: Usage/History data still loads correctly, banner links to Fleet tab.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wmoo2PB71KtuXPyJvR1H8T)_