### PR TITLE
test: rename test_moat_e2e_regression_1129 → test_moat_regression_1129 (it's not an e2e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           python3 -m pytest \
             tests/test_moat_send_message_e2e.py \
             tests/test_moat_event_shape_manifest_guard.py \
-            tests/test_moat_e2e_regression_1129.py \
+            tests/test_moat_regression_1129.py \
             tests/test_e2e_real_openclaw_pipeline.py \
             tests/test_duckdb_fastpath_v3_invariants.py \
             tests/test_moat_cloud_roundtrip_e2e.py \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-moat:
 	    tests/test_moat_send_message_e2e.py \
 	    tests/test_moat_event_shape_manifest_guard.py \
 	    tests/test_oss_routes_source_canary.py \
-	    tests/test_moat_e2e_regression_1129.py \
+	    tests/test_moat_regression_1129.py \
 	    tests/test_e2e_real_openclaw_pipeline.py \
 	    tests/test_duckdb_fastpath_v3_invariants.py \
 	    tests/test_moat_cloud_roundtrip_e2e.py \

--- a/tests/MOAT_EVENT_SHAPES.md
+++ b/tests/MOAT_EVENT_SHAPES.md
@@ -6,12 +6,12 @@ so OpenClaw event-shape drift cannot be hidden by synthetic-only tests.
 
 | event_type | synthetic_test_file | live_fixture_test_file | last_verified_date |
 |---|---|---|---|
-| agent.heartbeat | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
-| message | tests/test_moat_cloud_roundtrip_e2e.py, tests/test_moat_cloud_sync_e2e.py, tests/test_moat_cross_repo_version_skew.py, tests/test_moat_e2e_regression_1129.py, tests/test_moat_send_message_e2e.py, tests/test_moat_tier1_daemon_proxy_sweep.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
-| model.completed | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
-| prompt.submitted | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
-| session.ended | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| agent.heartbeat | tests/test_moat_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| message | tests/test_moat_cloud_roundtrip_e2e.py, tests/test_moat_cloud_sync_e2e.py, tests/test_moat_cross_repo_version_skew.py, tests/test_moat_regression_1129.py, tests/test_moat_send_message_e2e.py, tests/test_moat_tier1_daemon_proxy_sweep.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| model.completed | tests/test_moat_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| prompt.submitted | tests/test_moat_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| session.ended | tests/test_moat_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
 | session_start | tests/test_moat_send_message_e2e.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
-| tool_call | tests/test_moat_e2e_regression_1129.py, tests/test_moat_send_message_e2e.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| tool_call | tests/test_moat_regression_1129.py, tests/test_moat_send_message_e2e.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
 | test.crash_recovery | tests/test_moat_daemon_crash_recovery.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-20 |
-| trace.artifacts | tests/test_moat_e2e_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |
+| trace.artifacts | tests/test_moat_regression_1129.py | tests/test_moat_live_openclaw_e2e.py | 2026-05-18 |

--- a/tests/test_moat_regression_1129.py
+++ b/tests/test_moat_regression_1129.py
@@ -1,5 +1,15 @@
-"""End-to-end MOAT regression gauntlet for the 4 read-path bugs filed in
+"""Deterministic read-path regression gauntlet for the 4 bugs filed in
 issue #1129.
+
+NOTE ON NAMING (2026-05-31): renamed from ``test_moat_e2e_regression_1129``.
+Despite the old name this is NOT an end-to-end test and intentionally does NOT
+spawn the real OpenClaw binary — as the note below says, the 4 failure modes
+are 100% determined by the exact event field SHAPE, which a non-deterministic
+real LLM turn cannot reproduce. Per the "real e2e, no synthetic seeds"
+initiative, synthetic data is fine for a deterministic regression/integration
+test like this; the "e2e" label was the only thing wrong, so it was dropped.
+The genuine end-to-end coverage for these event shapes lives in
+``tests/test_moat_live_openclaw_e2e.py`` (real turn).
 
 Each of the 4 fixes is queued in its own PR (#1130, #1131, #1132 — #1128 is
 unrelated dead-code in sync.py) but **none are merged yet**. This file


### PR DESCRIPTION
Part of the **"real e2e, no synthetic seeds"** initiative — the *rename* half of the pattern (complement to the *convert* half in #2363 / #2367).

## Why rename, not convert
This file is a **deterministic read-path regression gauntlet**, not an end-to-end test. Its own docstring: *"the 4 failure modes are 100% determined by the field shape — which we can pin down here with a hand-written payload"*, and it deliberately does **not** spawn the real OpenClaw binary. A non-deterministic real LLM turn cannot reproduce 4 exact bug-triggering field shapes, so converting it would **delete the regression coverage that is its entire purpose**.

Per the initiative's rule (synthetic data is fine for non-e2e tests), the only thing wrong was the misleading `e2e` in the name. Genuine end-to-end coverage of these event shapes already lives in `test_moat_live_openclaw_e2e.py` (real turn).

## Change
Pure rename: filename + docstring note + the 9 references in `ci.yml`, `Makefile`, `tests/MOAT_EVENT_SHAPES.md`. **Test logic is byte-identical** — collects cleanly (5 tests); CI runs it exactly as before (it's in the same MOAT pytest list). (Local pass/fail can't be checked through my dev-box ClawMetry daemon's store-proxy, a known artifact; logic is unchanged so CI is authoritative.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)