### PR TITLE
feat(security): content-policy scanner — PII, prompt-injection, credential-leak

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6834,6 +6834,46 @@ async function loadSecurityPage(silent) {
       if (el) el.innerHTML = '<div style="color:var(--text-error);padding:20px">' + t("app.scan_failed", null, "Scan failed") + ': ' + escHtml(String(e)) + '</div>';
     }
   }
+  // Policy events (PII / injection / credential leak)
+  try {
+    var pd = await fetchJsonWithTimeout('/api/security/policy-events', 10000);
+    var pc = pd.counts || {};
+    var piiEl = document.getElementById('pol-pii-count');
+    var injEl = document.getElementById('pol-inject-count');
+    var lkEl  = document.getElementById('pol-leak-count');
+    if (piiEl) piiEl.textContent = pc.PII || 0;
+    if (injEl) injEl.textContent = pc.INJECT || 0;
+    if (lkEl)  lkEl.textContent  = pc.LEAK || 0;
+    var stEl = document.getElementById('policy-events-scan-time');
+    if (stEl) stEl.textContent = new Date().toLocaleTimeString();
+    var listEl = document.getElementById('policy-events-list');
+    if (listEl) {
+      var hits = pd.hits || [];
+      if (!hits.length) {
+        listEl.innerHTML = '<div style="color:var(--text-muted);padding:12px;" data-i18n="security.no_policy_events">No policy events detected in recent activity.</div>';
+      } else {
+        var _polSevColor = {critical:'#dc2626', high:'#ef4444', medium:'#f59e0b', low:'#64748b'};
+        var _polTypeIcon = {PII:'&#128100;', INJECT:'&#128680;', LEAK:'&#128273;'};
+        var html = '';
+        hits.slice(0, 30).forEach(function(h) {
+          var col = _polSevColor[h.severity] || '#64748b';
+          var icon = _polTypeIcon[h.type] || '&#9888;';
+          html += '<div style="display:flex;align-items:flex-start;gap:8px;padding:6px 0;border-bottom:1px solid var(--border);">';
+          html += '<span style="font-size:13px;flex-shrink:0;">' + icon + '</span>';
+          html += '<div style="flex:1;min-width:0;">';
+          html += '<span style="font-size:11px;font-weight:600;color:' + col + ';">' + escHtml(h.type) + ' · ' + escHtml(h.severity) + '</span>';
+          html += ' <span style="font-size:11px;color:var(--text-muted);">' + escHtml(h.description) + '</span>';
+          if (h.matched) html += ' <code style="font-size:10px;background:var(--bg-primary);padding:1px 4px;border-radius:3px;color:#a78bfa;">' + escHtml(h.matched) + '</code>';
+          if (h.time) html += '<div style="font-size:10px;color:var(--text-muted);margin-top:2px;">' + escHtml(String(h.time).slice(0, 19)) + (h.session ? ' · ' + escHtml(String(h.session).slice(0, 20)) : '') + '</div>';
+          html += '</div></div>';
+        });
+        listEl.innerHTML = html;
+      }
+    }
+  } catch(e) {
+    var pel = document.getElementById('policy-events-list');
+    if (pel && !silent) pel.innerHTML = '<div style="color:var(--text-muted);padding:12px;font-size:11px;">Policy scan unavailable.</div>';
+  }
   if (_securityRefreshTimer) clearTimeout(_securityRefreshTimer);
   if (document.getElementById('page-security') && document.getElementById('page-security').classList.contains('active')) {
     _securityRefreshTimer = setTimeout(function() { loadSecurityPage(true); }, 30000);
@@ -12226,12 +12266,13 @@ async function viewTranscript(sessionId) {
   window._replayIndex = 0;
   window._replayFilter = 'all';
   try {
-    // Fetch transcript, compaction markers, config-drift, and lexical drift in parallel
-    var [data, compactionsData, driftData, lexicalDriftData] = await Promise.all([
+    // Fetch transcript, compaction markers, config-drift, lexical drift, and policy events in parallel
+    var [data, compactionsData, driftData, lexicalDriftData, policyData] = await Promise.all([
       fetch('/api/transcript/' + encodeURIComponent(sessionId)).then(r => r.json()),
       fetch('/api/compactions?session_id=' + encodeURIComponent(sessionId) + '&summary_chars=5000').then(r => r.json()).catch(() => ({compactions: []})),
       fetch('/api/sessions/' + encodeURIComponent(sessionId) + '/config-drift').then(r => r.json()).catch(() => ({has_drift: false})),
-      fetch('/api/sessions/' + encodeURIComponent(sessionId) + '/lexical-drift').then(r => r.json()).catch(() => null)
+      fetch('/api/sessions/' + encodeURIComponent(sessionId) + '/lexical-drift').then(r => r.json()).catch(() => null),
+      fetch('/api/security/policy-events?session_id=' + encodeURIComponent(sessionId)).then(r => r.json()).catch(() => null)
     ]);
     var compactions = compactionsData.compactions || [];
     // Metadata
@@ -12261,6 +12302,22 @@ async function viewTranscript(sessionId) {
     if (lexicalDriftData && lexicalDriftData.has_drift) {
       metaHtml += '<div class="stat-row" style="margin-top:8px;padding-top:8px;border-top:1px solid var(--border-secondary);">';
       metaHtml += '<span class="stat-label">⚠ Lexical Drift</span><span class="stat-val" title="TF-IDF cosine similarity vs turn 0 (lexical vocabulary overlap)">avg ' + lexicalDriftData.avg_similarity + ' · min ' + lexicalDriftData.min_similarity + ' at turn ' + lexicalDriftData.min_turn + '</span>';
+      metaHtml += '</div>';
+    }
+    // Policy events badge — shown when PII, injection, or credential-leak patterns fire
+    if (policyData && policyData.counts && policyData.counts.total > 0) {
+      var pc = policyData.counts;
+      var hasLeak = (pc.LEAK || 0) > 0;
+      var hasInj  = (pc.INJECT || 0) > 0;
+      var bgCol   = hasLeak ? 'rgba(220,38,38,0.12)' : 'rgba(245,158,11,0.12)';
+      var bdCol   = hasLeak ? 'rgba(220,38,38,0.4)'  : 'rgba(245,158,11,0.4)';
+      var txCol   = hasLeak ? '#fca5a5' : '#fde68a';
+      var parts   = [];
+      if (pc.LEAK)   parts.push('🔑 ' + pc.LEAK + ' cred-leak');
+      if (pc.INJECT) parts.push('⚠ ' + pc.INJECT + ' injection');
+      if (pc.PII)    parts.push('👤 ' + pc.PII + ' PII');
+      metaHtml += '<div style="margin-top:10px;padding:7px 10px;background:' + bgCol + ';border:1px solid ' + bdCol + ';border-radius:6px;font-size:11px;color:' + txCol + ';line-height:1.4;" title="Open the Security tab to view full policy event details">';
+      metaHtml += '🔒 <strong>Policy events:</strong> ' + parts.join(' · ') + '. <a href="#" onclick="switchTab(\'security\');return false;" style="color:inherit;text-decoration:underline;">View in Security tab</a>';
       metaHtml += '</div>';
     }
     document.getElementById('transcript-meta').innerHTML = metaHtml;

--- a/clawmetry/templates/tabs/security.html
+++ b/clawmetry/templates/tabs/security.html
@@ -173,6 +173,30 @@
         <div style="color:var(--text-muted);padding:20px" data-i18n="security.scanning">Scanning...</div>
       </div>
     </div>
+    <!-- Policy Events (PII / Injection / Credential-Leak) -->
+    <div style="margin-top:14px;background:var(--bg-secondary);border:1px solid var(--border);border-radius:8px;padding:10px 14px;" id="policy-events-panel">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">
+        <span style="font-size:12px;font-weight:700;color:var(--text-primary);">&#128274; <span data-i18n="security.policy_events">Policy Events</span> <span style="font-size:11px;font-weight:400;color:var(--text-muted);" data-i18n="security.policy_events_sub">(PII · Injection · Credential Leak)</span></span>
+        <span id="policy-events-scan-time" style="font-size:11px;color:var(--text-muted);"></span>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-bottom:10px;" id="policy-counts">
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;padding:10px;text-align:center;">
+          <div style="font-size:20px;font-weight:700;color:#f59e0b;" id="pol-pii-count">-</div>
+          <div style="font-size:10px;color:var(--text-muted);" data-i18n="security.pol_pii">PII</div>
+        </div>
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;padding:10px;text-align:center;">
+          <div style="font-size:20px;font-weight:700;color:#ef4444;" id="pol-inject-count">-</div>
+          <div style="font-size:10px;color:var(--text-muted);" data-i18n="security.pol_inject">Injection</div>
+        </div>
+        <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:6px;padding:10px;text-align:center;">
+          <div style="font-size:20px;font-weight:700;color:#dc2626;" id="pol-leak-count">-</div>
+          <div style="font-size:10px;color:var(--text-muted);" data-i18n="security.pol_leak">Cred Leak</div>
+        </div>
+      </div>
+      <div id="policy-events-list" style="max-height:300px;overflow-y:auto;font-size:12px;">
+        <div style="color:var(--text-muted);padding:12px;" data-i18n="security.scanning">Scanning...</div>
+      </div>
+    </div>
     <div style="
       margin-top:14px;
       background:var(--bg-secondary);

--- a/dashboard.py
+++ b/dashboard.py
@@ -14791,6 +14791,116 @@ def _scan_security_posture():
 # (bp_security /api/security/posture moved to routes/infra.py)
 
 
+# ── Content-policy scanners (PII / prompt-injection / credential-leak) ──────
+# Complement to _scan_events_for_threats: that checks WHAT the agent DID
+# (exec/read actions); these scan WHAT DATA flows through agent content
+# (prompts, completions, tool results) for data-policy violations.
+
+_POLICY_SIGNATURES = [
+    # PII ─────────────────────────────────────────────────────────────────
+    {
+        "id": "POL-PII-001", "type": "PII", "severity": "medium",
+        "description": "Email address in agent content",
+        "pattern": r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}",
+    },
+    {
+        "id": "POL-PII-002", "type": "PII", "severity": "high",
+        "description": "US Social Security Number in agent content",
+        "pattern": r"\b\d{3}-\d{2}-\d{4}\b",
+    },
+    {
+        "id": "POL-PII-003", "type": "PII", "severity": "medium",
+        "description": "Phone number in agent content",
+        "pattern": r"\b(?:\+\d{1,3}\s?)?\(?\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b",
+    },
+    # Prompt injection ────────────────────────────────────────────────────
+    {
+        "id": "POL-INJECT-001", "type": "INJECT", "severity": "high",
+        "description": "Prompt injection: ignore-instructions override attempt",
+        "pattern": r"(?:ignore|disregard|forget|override)\s+(?:(?:all|your|my|the|those|any)\s+)?(?:previous|prior|above|original|earlier|current)?\s*(?:instructions?|prompts?|guidelines?|rules?|constraints?|system)",
+    },
+    {
+        "id": "POL-INJECT-002", "type": "INJECT", "severity": "high",
+        "description": "Prompt injection: role/persona override attempt",
+        "pattern": r"(?:you\s+are\s+now|act\s+as|pretend\s+(?:to\s+be|you\s+are)|your\s+new\s+(?:role|persona|instructions?|task|objective))",
+    },
+    {
+        "id": "POL-INJECT-003", "type": "INJECT", "severity": "medium",
+        "description": "Prompt injection: hidden system-prompt injection marker",
+        "pattern": r"(?:<\s*(?:system|sys|SYSTEM)\s*>|\[SYSTEM\s*PROMPT\]|#\s*SYSTEM\s*:)",
+    },
+    # Credential leak ─────────────────────────────────────────────────────
+    {
+        "id": "POL-LEAK-001", "type": "LEAK", "severity": "critical",
+        "description": "AWS access key in agent content",
+        "pattern": r"(?:AKIA|ABIA|ACCA|ASIA)[0-9A-Z]{16}",
+    },
+    {
+        "id": "POL-LEAK-002", "type": "LEAK", "severity": "critical",
+        "description": "Anthropic API key in agent content",
+        "pattern": r"sk-ant-(?:api\d{2}-)?[A-Za-z0-9\-_]{86,}",
+    },
+    {
+        "id": "POL-LEAK-003", "type": "LEAK", "severity": "critical",
+        "description": "OpenAI API key in agent content",
+        "pattern": r"sk-(?:proj-)?[A-Za-z0-9]{48,}",
+    },
+    {
+        "id": "POL-LEAK-004", "type": "LEAK", "severity": "critical",
+        "description": "GitHub personal access token in agent content",
+        "pattern": r"(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{36,}",
+    },
+    {
+        "id": "POL-LEAK-005", "type": "LEAK", "severity": "high",
+        "description": "Generic API key/secret assignment in agent content",
+        "pattern": r"(?:api[_\-]?key|api[_\-]?secret|secret[_\-]?key|access[_\-]?token)\s*[=:]\s*['\"]?[A-Za-z0-9\-_]{16,}",
+    },
+]
+
+for _pol in _POLICY_SIGNATURES:
+    _pol["_compiled"] = _sec_re.compile(_pol["pattern"], _sec_re.IGNORECASE)
+
+
+def _scan_content_for_policy_events(events):
+    """Scan brain-feed events for PII, prompt-injection, and credential-leak.
+
+    Unlike _scan_events_for_threats (action-based), this inspects the text
+    *content* in event detail fields — useful for finding data that should
+    not appear in prompts or completions (PII leaking out, credentials leaking
+    in/out, injection attempts arriving via tool results or user messages).
+
+    Returns (hits, counts) with the same shape as _scan_events_for_threats.
+    """
+    hits = []
+    for ev in events:
+        detail = ev.get("detail") or ""
+        if len(detail) < 8:
+            continue
+        for sig in _POLICY_SIGNATURES:
+            m = sig["_compiled"].search(detail)
+            if m:
+                raw = m.group(0)
+                redacted = (raw[:3] + "…" + raw[-2:]) if len(raw) > 6 else "***"
+                hits.append({
+                    "rule_id":     sig["id"],
+                    "type":        sig["type"],
+                    "severity":    sig["severity"],
+                    "description": sig["description"],
+                    "matched":     redacted,
+                    "time":        ev.get("time", ""),
+                    "session":     ev.get("source", ""),
+                    "event_type":  ev.get("type", ""),
+                })
+                break  # one match per signature family per event
+    counts = {
+        "PII":    sum(1 for h in hits if h["type"] == "PII"),
+        "INJECT": sum(1 for h in hits if h["type"] == "INJECT"),
+        "LEAK":   sum(1 for h in hits if h["type"] == "LEAK"),
+        "total":  len(hits),
+    }
+    return hits, counts
+
+
 def _detect_channel_status():
     """Return list of configured channels with live connectivity status.
 

--- a/routes/infra.py
+++ b/routes/infra.py
@@ -1469,6 +1469,31 @@ def api_security_posture():
         return jsonify({"error": str(e), "score": "U", "checks": []}), 500
 
 
+@bp_security.route("/api/security/policy-events")
+def api_security_policy_events():
+    """Scan agent event content for PII, prompt-injection, and credential-leak patterns.
+
+    Optional query param: session_id — narrows scan to one session.
+    Returns {hits, counts{PII,INJECT,LEAK,total}, scanned_events}.
+    """
+    import dashboard as _d
+    session_id = (request.args.get("session_id") or "").strip()
+    events = []
+    try:
+        if session_id:
+            from routes.brain import _fetch_session_chain
+            events = _fetch_session_chain(session_id, limit=500)
+        else:
+            from routes.brain import api_brain_history
+            brain_resp = api_brain_history()
+            brain_data = brain_resp.get_json()
+            events = brain_data.get("events", [])
+    except Exception:
+        events = []
+    hits, counts = _d._scan_content_for_policy_events(events)
+    return jsonify({"hits": hits[:200], "counts": counts, "scanned_events": len(events)})
+
+
 # ── Config / Cost optimization ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #2010

## Summary

- **`dashboard.py`** — `_POLICY_SIGNATURES` (11 regex patterns: 3 PII, 3 injection, 5 credential-leak) + `_scan_content_for_policy_events(events)` helper. Reuses the existing `_sec_re` import and the same brain-feed event shape as `_scan_events_for_threats`, so it slots into the existing security infrastructure with no new dependencies.
- **`routes/infra.py`** — new `GET /api/security/policy-events?session_id=<opt>` endpoint on `bp_security`. Narrows to one session via `_fetch_session_chain` when `session_id` is given; falls back to global brain history otherwise. Returns `{hits, counts{PII,INJECT,LEAK,total}, scanned_events}`.
- **`security.html`** — Policy Events card inserted between Threat Detection and Signature Catalog: three count tiles (PII / Injection / Cred Leak) and a recent-hits list with per-type icon and partial redaction of matched text.
- **`app.js`** — `loadSecurityPage` fetches and renders the new card on page load (auto-refreshes every 30 s alongside existing threat scan). `viewTranscript` adds the endpoint to its parallel fetch set and injects a `🔒 n policy events` warning badge into the session metadata panel when any events fire, with a link straight to the Security tab.

## Test plan

- [ ] Open Security tab → Policy Events card appears; shows `0` for PII/INJECT/LEAK on a clean session.
- [ ] Open a session transcript that contains an email address or phone number → `🔒 1 PII` badge appears in the metadata panel.
- [ ] Craft a message containing `AKIAIOSFODNN7EXAMPLE` → Cred Leak count increments and badge shows `🔑 1 cred-leak`.
- [ ] Content with `"ignore your previous instructions"` → Injection count fires.
- [ ] `/api/security/policy-events?session_id=<id>` returns `200` with correct shape.
- [ ] Clean content (no patterns) → no badge shown in transcript, all counts `0`.

> **Note:** Alert-template and OTel integrations are blocked on other open issues (#885-cloud, #1651) — left as follow-up PRs once this endpoint contract is stable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gq2aNqTM3DRHQVZZsypmcc)_