### PR TITLE
feat: "Sessions at risk" card on Brain tab (issue #2008)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6010,6 +6010,48 @@ async function loadBrainPage(silent) {
   }
   // Loop-signals badge (#1364) — fire-and-forget; never blocks the Brain tab.
   loadLoopSignals();
+  // At-risk impact summary (issue #2008) — fire-and-forget; never blocks.
+  loadBrainAtRisk();
+}
+
+
+// Fetch /api/outcomes/impact?window=1h and render the "Sessions at risk"
+// card on the Brain tab (issue #2008). Called fire-and-forget from
+// loadBrainPage(). Hides the card when all impact counts are zero.
+async function loadBrainAtRisk() {
+  var card = document.getElementById('brain-at-risk-card');
+  var chips = document.getElementById('brain-at-risk-chips');
+  if (!card || !chips) return;
+  try {
+    var r = await fetch('/api/outcomes/impact?window=1h');
+    if (!r.ok) return;
+    var d = await r.json();
+    var counts = (d && d.impacts) || {};
+    var _IMPACT_META = {
+      'crash-loop':    {icon: '🔁', label: 'Crash loop'},
+      'message-loss':  {icon: '📨', label: 'Message loss'},
+      'session-state': {icon: '💾', label: 'Session state'},
+      'auth-provider': {icon: '🔑', label: 'Auth error'},
+      'security':      {icon: '🛡️', label: 'Security'},
+    };
+    var anyNonZero = Object.keys(counts).some(function(k) { return counts[k] > 0; });
+    card.style.display = anyNonZero ? '' : 'none';
+    if (!anyNonZero) return;
+    var win = document.getElementById('brain-at-risk-window');
+    if (win) win.textContent = '· last ' + (d.window || '1h');
+    chips.innerHTML = '';
+    Object.keys(_IMPACT_META).forEach(function(k) {
+      if (!counts[k]) return;
+      var m = _IMPACT_META[k];
+      var chip = document.createElement('span');
+      chip.style.cssText = 'display:inline-flex;align-items:center;gap:4px;padding:3px 10px;' +
+        'border-radius:12px;background:rgba(245,158,11,0.12);' +
+        'border:1px solid rgba(245,158,11,0.3);font-size:11px;color:#f59e0b;cursor:default;';
+      chip.title = escHtml(m.label) + ': ' + counts[k] + ' session' + (counts[k] !== 1 ? 's' : '');
+      chip.innerHTML = m.icon + ' ' + escHtml(m.label) + ' <strong>' + counts[k] + '</strong>';
+      chips.appendChild(chip);
+    });
+  } catch(e) { /* never block brain load */ }
 }
 
 

--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -119,6 +119,21 @@
         " data-i18n="brain.activity_density">Activity density · last 60 min (30s buckets)</div>
       <canvas id="brain-density-chart" height="60" style="width:100%;display:block;"></canvas>
     </div>
+    <!-- Sessions-at-risk card (issue #2008): surfaces the existing
+         /api/outcomes/impact endpoint in a visible UI summary. Hidden when
+         all impact counts are zero; rendered by loadBrainAtRisk() in app.js. -->
+    <div id="brain-at-risk-card" style="display:none;
+      background:var(--bg-secondary);
+      border:1px solid #f59e0b;
+      border-radius:8px;
+      padding:10px 14px;
+      margin-bottom:12px;">
+      <div style="display:flex;align-items:center;gap:6px;margin-bottom:8px;">
+        <span style="font-size:13px;font-weight:700;color:#f59e0b;">⚠ <span data-i18n="brain.at_risk_title">Sessions at risk</span></span>
+        <span id="brain-at-risk-window" style="font-size:11px;color:var(--text-muted);"></span>
+      </div>
+      <div id="brain-at-risk-chips" style="display:flex;flex-wrap:wrap;gap:6px;"></div>
+    </div>
     <div class="brain-view-toggle" data-i18n-title="brain.view_toggle_tooltip" title="Switch between list view and neural-network view">
       <button class="brain-view-btn active" data-view="list" onclick="setBrainViewMode('list', this)" data-i18n="brain.view_list">List</button>
       <button class="brain-view-btn" data-view="graph" onclick="setBrainViewMode('graph', this)" data-i18n-title="brain.view_graph_tooltip" title="Neural-network visualization of agent activity (closes #53)" data-i18n="brain.view_graph">Graph</button>


### PR DESCRIPTION
Closes #2008

## Summary

- `outcome_classifier.py` already implements `classify_session_impact()` and `/api/outcomes/impact` was already exposed in `routes/sessions.py` (landed as part of #1649) — but no UI ever consumed that endpoint.
- This PR wires the endpoint to a visible surface: an amber "⚠ Sessions at risk" card on the Brain tab that lists non-zero impact categories (crash-loop, message-loss, session-state, auth-provider, security) with per-category counts.
- Card is hidden when all counts are zero. `loadBrainAtRisk()` fires-and-forgets at the end of `loadBrainPage()` — same pattern as the existing `loadLoopSignals()` call — so it never blocks the Brain stream from loading.

**Files changed (57 lines):**
- `clawmetry/templates/tabs/brain.html` — amber at-risk card HTML (15 lines, inserted between activity density chart and view-mode toggle)
- `clawmetry/static/js/app.js` — `loadBrainAtRisk()` async function + call site in `loadBrainPage` (42 lines)

No schema migration. No new backend endpoints. No sync.py changes.

## Test plan

- [ ] Load the Brain tab with at least one non-success session in the last hour → amber "Sessions at risk" card appears above the event stream with correct category chips
- [ ] Load the Brain tab with zero at-risk sessions → card is hidden, Brain stream renders normally
- [ ] Confirm `loadBrainPage()` completes even if `/api/outcomes/impact` returns an error (try/catch swallows it)
- [ ] Check that each chip's `title` tooltip shows the correct count + singular/plural label

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7cYVY6XSd9aEjzEU5pYii)_