### PR TITLE
fix: unlock approval rule editor for OSS installs

### DIFF
--- a/clawmetry/templates/tabs/approvals.html
+++ b/clawmetry/templates/tabs/approvals.html
@@ -204,6 +204,14 @@
     return true;
   }
 
+  // True when running as a plain OSS install (no cloud cm_ token).
+  // Rule creation is OSS-free per #1343; notification channels stay Pro-gated.
+  function _isOssMode() {
+    if (window.CLOUD_MODE || window.CLOUD_TOKEN) return false;
+    var t = localStorage.getItem('clawmetry_token') || '';
+    return !(t && t.startsWith('cm_'));
+  }
+
   window.showUpgradeModal = function() {
     var m = document.getElementById('approvals-upgrade-modal');
     if (m) m.style.display = 'flex';
@@ -475,14 +483,23 @@
   /* ── Main loader ── */
   window.loadApprovalsTab = async function() {
     try {
+      var ossMode = _isOssMode();
       var [pending, history, policies, integrations] = await Promise.all([
-        fetchJsonWithTimeout('/api/cloud/approvals?status=pending&limit=50' + _q(), 6000).catch(function(){return {approvals:[]};}),
-        fetchJsonWithTimeout('/api/cloud/approvals?limit=50' + _q(), 6000).catch(function(){return {approvals:[]};}),
-        fetchJsonWithTimeout('/api/cloud/policies?' + _q().replace(/^&/,''), 6000).catch(function(){return {policies:[]};}),
-        fetchJsonWithTimeout('/api/cloud/integrations?' + _q().replace(/^&/,''), 6000).catch(function(){return {integrations:[]};})
+        fetchJsonWithTimeout(
+          ossMode ? '/api/nemoclaw/pending-approvals'
+                  : '/api/cloud/approvals?status=pending&limit=50' + _q(),
+          6000).catch(function(){return {approvals:[]};}),
+        ossMode ? Promise.resolve({approvals:[]})
+                : fetchJsonWithTimeout('/api/cloud/approvals?limit=50' + _q(), 6000).catch(function(){return {approvals:[]};}),
+        fetchJsonWithTimeout(
+          ossMode ? '/api/nemoclaw/rules'
+                  : '/api/cloud/policies?' + _q().replace(/^&/,''),
+          6000).catch(function(){return {policies:[]};}),
+        ossMode ? Promise.resolve({integrations:[]})
+                : fetchJsonWithTimeout('/api/cloud/integrations?' + _q().replace(/^&/,''), 6000).catch(function(){return {integrations:[]};})
       ]);
       var p = (pending.approvals || []).filter(function(r){return r.status==='pending';});
-      var h = (history.approvals || []).filter(function(r){return r.status!=='pending';});
+      var h = ossMode ? [] : (history.approvals || []).filter(function(r){return r.status!=='pending';});
 
       // Pending
       var pe = document.getElementById('approvals-pending-list');
@@ -537,7 +554,9 @@
   var _toggleBusy = {};
   window.togglePresetPolicy = async function(presetKey, enabled) {
     if (_toggleBusy[presetKey]) return;
-    if (_showUpgradeIfNeeded()) return;
+    var ossMode = _isOssMode();
+    // OSS users can toggle preset rules (rule creation is free, per #1343).
+    if (!ossMode && _showUpgradeIfNeeded()) return;
     _toggleBusy[presetKey] = true;
     var preset = PRESETS.find(function(p){return p.key === presetKey;});
     if (!preset) { delete _toggleBusy[presetKey]; return; }
@@ -551,22 +570,40 @@
       card.style.borderColor = enabled ? preset.color + '55' : 'var(--border)';
     }
     try {
-      var r = await fetch('/api/cloud/policies', {
-        method: 'POST', headers: _authHeaders(),
-        body: JSON.stringify({
-          name: preset.name,
-          tool: preset.tool,
-          pattern_type: 'command_regex',
-          pattern: preset.pattern,
-          action: 'require_approval',
-          timeout: preset.timeout,
-          on_timeout: preset.on_timeout,
-          enabled: enabled,
-          preset_key: preset.key
-        })
-      });
+      var r;
+      if (ossMode) {
+        if (enabled) {
+          // Enable: upsert into ~/.clawmetry/policies.yml
+          r = await fetch('/api/nemoclaw/rules', {
+            method: 'POST', headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+              name: preset.name, tool: preset.tool,
+              pattern_type: 'command_regex', pattern: preset.pattern,
+              action: 'require_approval', timeout: preset.timeout,
+              on_timeout: preset.on_timeout, preset_key: preset.key
+            })
+          });
+        } else {
+          // Disable: remove from YAML so the local daemon stops enforcing it.
+          // (The daemon enforces all YAML entries regardless of enabled flag.)
+          r = await fetch('/api/nemoclaw/rules/' + encodeURIComponent(presetKey), {
+            method: 'DELETE', headers: {'Content-Type': 'application/json'}
+          });
+        }
+      } else {
+        r = await fetch('/api/cloud/policies', {
+          method: 'POST', headers: _authHeaders(),
+          body: JSON.stringify({
+            name: preset.name, tool: preset.tool,
+            pattern_type: 'command_regex', pattern: preset.pattern,
+            action: 'require_approval', timeout: preset.timeout,
+            on_timeout: preset.on_timeout, enabled: enabled,
+            preset_key: preset.key
+          })
+        });
+        if (!r.ok && r.status === 402) { showUpgradeModal(); loadApprovalsTab(); return; }
+      }
       if (!r.ok) {
-        if (r.status === 402) { showUpgradeModal(); loadApprovalsTab(); return; }
         var d = await r.json().catch(function(){return {};});
         throw new Error(d.error || ('HTTP ' + r.status));
       }
@@ -581,7 +618,8 @@
 
   /* ── Save custom rule ── */
   window.saveCustomRule = async function() {
-    if (_showUpgradeIfNeeded()) return;
+    var ossMode = _isOssMode();
+    if (!ossMode && _showUpgradeIfNeeded()) return;
     var name = (document.getElementById('rule-name').value || '').trim();
     var tool = document.getElementById('rule-tool').value;
     var patternRaw = (document.getElementById('rule-pattern').value || '').trim();
@@ -592,12 +630,14 @@
     // Convert comma-separated keywords to regex alternation
     var pattern = patternRaw.split(',').map(function(s){return s.trim();}).filter(Boolean).join('|');
     try {
-      var r = await fetch('/api/cloud/policies', {
-        method: 'POST', headers: _authHeaders(),
+      var url = ossMode ? '/api/nemoclaw/rules' : '/api/cloud/policies';
+      var headers = ossMode ? {'Content-Type': 'application/json'} : _authHeaders();
+      var r = await fetch(url, {
+        method: 'POST', headers: headers,
         body: JSON.stringify({
           name: name, tool: tool, pattern_type: 'command_regex',
           pattern: pattern, action: 'require_approval',
-          timeout: timeout, on_timeout: onTimeout, enabled: true
+          timeout: timeout, on_timeout: onTimeout
         })
       });
       if (!r.ok) {
@@ -614,7 +654,7 @@
   };
 
   window.toggleCreateRuleForm = function() {
-    if (_showUpgradeIfNeeded()) return;
+    if (!_isOssMode() && _showUpgradeIfNeeded()) return;
     var f = document.getElementById('create-rule-form');
     f.style.display = f.style.display === 'none' ? '' : 'none';
   };

--- a/routes/nemoclaw.py
+++ b/routes/nemoclaw.py
@@ -511,3 +511,118 @@ def api_nemoclaw_metrics():
         'installed': installed,
         'metrics': metrics,
     })
+
+
+# ── Approval policy rule CRUD (OSS YAML-backed, issue #1343) ─────────────────
+#
+# Cloud users manage rules at /api/cloud/policies (Pro-gated, Postgres-backed).
+# OSS users get equivalent local capability: rules live in
+# ~/.clawmetry/policies.yml, already watched by clawmetry/approvals.py for
+# enforcement. Notification channels (Slack / PagerDuty / email / phone) stay
+# Cloud-Pro gated — this layer is rule-definition only.
+#
+# Tier boundary (per issue #1343): "Approvals queue + basic rule editor: OSS
+# free (already user-asked). Slack/PagerDuty/email notifications: Cloud-Pro."
+
+def _load_local_policies() -> list:
+    """Read ~/.clawmetry/policies.yml; return [] on any error."""
+    from clawmetry.approvals import POLICIES_PATH, _load_yaml
+    try:
+        if POLICIES_PATH.exists():
+            return _load_yaml(POLICIES_PATH.read_text(errors='replace')) or []
+    except Exception:
+        pass
+    return []
+
+
+def _write_local_policies(policies: list) -> None:
+    """Atomically write policies list to ~/.clawmetry/policies.yml."""
+    from clawmetry.approvals import POLICIES_PATH
+    import tempfile
+    POLICIES_PATH.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import yaml as _yaml  # type: ignore
+        text = _yaml.dump(policies, default_flow_style=False, allow_unicode=True)
+    except ImportError:
+        # Hand-roll for the documented flat-dict format (no PyYAML dep).
+        lines = []
+        for p in policies:
+            first = True
+            for k, v in p.items():
+                if v is None:
+                    vs = 'null'
+                elif isinstance(v, bool):
+                    vs = 'true' if v else 'false'
+                elif isinstance(v, (int, float)):
+                    vs = str(v)
+                else:
+                    s = str(v)
+                    # Quote strings containing YAML special characters.
+                    if any(c in s for c in ':#{}[]|>&!\'",%@`'):
+                        s = "'" + s.replace("'", "''") + "'"
+                    vs = s
+                lines.append(('- ' if first else '  ') + k + ': ' + vs)
+                first = False
+            lines.append('')
+        text = '\n'.join(lines)
+    with tempfile.NamedTemporaryFile('w', dir=POLICIES_PATH.parent,
+                                     delete=False, suffix='.tmp') as f:
+        f.write(text)
+        tmp_path = f.name
+    os.replace(tmp_path, POLICIES_PATH)
+
+
+@bp_nemoclaw.route('/api/nemoclaw/rules', methods=['GET'])
+def api_nemoclaw_rules_list():
+    """Return all approval rules from ~/.clawmetry/policies.yml."""
+    return jsonify({'policies': _load_local_policies()})
+
+
+@bp_nemoclaw.route('/api/nemoclaw/rules', methods=['POST'])
+def api_nemoclaw_rules_create():
+    """Create or update a rule in ~/.clawmetry/policies.yml.
+
+    Upserts by preset_key (for preset-card toggles) or by name (for custom
+    rules). The local daemon enforces every entry in policies.yml regardless
+    of an ``enabled`` field, so callers should DELETE rather than set
+    enabled=false to disable a rule.
+    """
+    data = request.get_json(silent=True) or {}
+    name = (data.get('name') or '').strip()
+    if not name:
+        return jsonify({'error': 'name is required'}), 400
+    rule = {k: v for k, v in data.items() if v is not None and k != 'id'}
+    rule['name'] = name
+    policies = _load_local_policies()
+    preset_key = data.get('preset_key')
+    updated = False
+    for i, p in enumerate(policies):
+        if not isinstance(p, dict):
+            continue
+        if preset_key and p.get('preset_key') == preset_key:
+            policies[i] = rule
+            updated = True
+            break
+        if not preset_key and p.get('name') == name:
+            policies[i] = rule
+            updated = True
+            break
+    if not updated:
+        policies.append(rule)
+    _write_local_policies(policies)
+    return jsonify({'ok': True, 'updated': updated})
+
+
+@bp_nemoclaw.route('/api/nemoclaw/rules/<path:rule_key>', methods=['DELETE'])
+def api_nemoclaw_rules_delete(rule_key):
+    """Remove a rule from ~/.clawmetry/policies.yml by preset_key or name."""
+    policies = _load_local_policies()
+    before = len(policies)
+    policies = [
+        p for p in policies
+        if isinstance(p, dict)
+        and p.get('preset_key') != rule_key
+        and p.get('name') != rule_key
+    ]
+    _write_local_policies(policies)
+    return jsonify({'ok': True, 'deleted': before - len(policies)})


### PR DESCRIPTION
Closes #1343

## Summary

- **`routes/nemoclaw.py`**: Add `GET/POST /api/nemoclaw/rules` + `DELETE /api/nemoclaw/rules/<key>` backed by `~/.clawmetry/policies.yml`. Upserts by `preset_key` (preset-card toggles) or `name` (custom rules). Disabling a preset uses DELETE rather than `enabled=false` because the local daemon enforces every YAML entry regardless of that field.
- **`clawmetry/templates/tabs/approvals.html`**: Add `_isOssMode()` helper. Route `togglePresetPolicy`, `saveCustomRule`, and `toggleCreateRuleForm` to the new OSS endpoints when no `cm_` token is present. Notification channels (Slack/PagerDuty/email/phone) remain Cloud-Pro gated. `loadApprovalsTab` fetches from `/api/nemoclaw/rules` + `/api/nemoclaw/pending-approvals` in OSS mode.

## Test plan

- OSS install (no `CLAWMETRY_CLOUD_TOKEN`): enable a preset → `~/.clawmetry/policies.yml` gets the entry; reload shows it still enabled
- Disable the same preset → YAML entry removed; daemon stops enforcing it on next reload
- Save a custom rule → YAML entry appears; `GET /api/nemoclaw/rules` returns it
- With a `cm_` token (cloud): full cloud path is unchanged — preset toggle still hits `/api/cloud/policies`, notification channels still gate with upgrade modal
- `python3 -m py_compile routes/nemoclaw.py` → OK (passes)
- Backend roundtrip: write rules → read back → upsert → delete all verified in isolation tests

https://claude.ai/code/session_01TxoxeF5GtL1WiyLDFqe7Z1

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxoxeF5GtL1WiyLDFqe7Z1)_