### PR TITLE
feat(sync): persist cloud heartbeat plan into entitlement cache file

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1010,11 +1010,74 @@ _TRIAL_STATE = {
     "last_log_day": "",     # YYYY-MM-DD of the last "sync paused" log
 }
 
+# Cloud-plan cache file the entitlements resolver reads. The daemon writes it
+# from heartbeat responses so a separate process (the Flask dashboard) can pick
+# up a cloud Pro plan without re-running auth itself. Kept in sync with
+# ``clawmetry.entitlements._CLOUD_PLAN_CACHE``.
+_CLOUD_PLAN_CACHE_PATH = os.path.expanduser("~/.clawmetry/cloud_plan.json")
+
+# Heartbeat ``plan`` strings → entitlement tier codes. Anything not in this map
+# (incl. ``trial_expired`` / None / "") clears the cache so the resolver falls
+# back to OSS-free instead of mistakenly granting an expired Pro plan.
+_HEARTBEAT_PLAN_TO_TIER = {
+    "free": "cloud_free",
+    "cloud_free": "cloud_free",
+    "trial": "trial",
+    "cloud_trial": "trial",
+    "starter": "cloud_starter",
+    "cloud_starter": "cloud_starter",
+    "pro": "cloud_pro",
+    "cloud_pro": "cloud_pro",
+    "enterprise": "enterprise",
+}
+
+
+def _persist_cloud_plan_to_disk(plan: str | None, trial_days_left=None) -> None:
+    """Mirror the heartbeat plan into ``~/.clawmetry/cloud_plan.json`` so the
+    dashboard process (which runs ``clawmetry.entitlements.get_entitlement``)
+    can resolve a cloud entitlement.
+
+    Best-effort: any IO error logs at debug and is swallowed — the cache is an
+    optimisation, the daemon still works without it. When ``plan`` is unknown
+    or signals an inactive state (``trial_expired``, ``None``) the cache file
+    is removed instead of written, so the resolver falls back to OSS-free
+    rather than granting a dead plan."""
+    tier = _HEARTBEAT_PLAN_TO_TIER.get(str(plan or "").strip().lower())
+    try:
+        if tier is None:
+            if os.path.isfile(_CLOUD_PLAN_CACHE_PATH):
+                try:
+                    os.remove(_CLOUD_PLAN_CACHE_PATH)
+                except OSError as exc:
+                    log.debug("cloud_plan: could not remove cache: %s", exc)
+        else:
+            expiry = None
+            try:
+                if tier == "trial" and isinstance(trial_days_left, (int, float)) and trial_days_left > 0:
+                    expiry = time.time() + float(trial_days_left) * 86400.0
+            except Exception:
+                expiry = None
+            payload = {"plan": tier, "node_limit": 1, "expiry": expiry}
+            os.makedirs(os.path.dirname(_CLOUD_PLAN_CACHE_PATH), exist_ok=True)
+            tmp = _CLOUD_PLAN_CACHE_PATH + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh)
+            os.replace(tmp, _CLOUD_PLAN_CACHE_PATH)
+        try:
+            from clawmetry import entitlements as _ent
+            _ent.invalidate()
+        except Exception:
+            pass
+    except Exception as exc:
+        log.debug("cloud_plan: persist failed: %s", exc)
+
 
 def _update_trial_state(resp: dict) -> None:
     """Mirror plan info from a cloud response into the local cache + log
     a one-line "upgrade to resume" message once per UTC day on transition."""
     prev_allowed = _TRIAL_STATE["sync_allowed"]
+    prev_plan = _TRIAL_STATE.get("plan")
+    prev_days = _TRIAL_STATE.get("trial_days_left")
     new_allowed = bool(resp.get("sync_allowed", True))
     _TRIAL_STATE["sync_allowed"] = new_allowed
     if "plan" in resp:
@@ -1023,6 +1086,10 @@ def _update_trial_state(resp: dict) -> None:
         _TRIAL_STATE["trial_days_left"] = resp.get("trial_days_left")
     if resp.get("upgrade_url"):
         _TRIAL_STATE["upgrade_url"] = resp["upgrade_url"]
+    if _TRIAL_STATE.get("plan") != prev_plan or _TRIAL_STATE.get("trial_days_left") != prev_days:
+        _persist_cloud_plan_to_disk(
+            _TRIAL_STATE.get("plan"), _TRIAL_STATE.get("trial_days_left")
+        )
     reason = (resp.get("reason") or "").strip()
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     if not new_allowed and _TRIAL_STATE["last_log_day"] != today:

--- a/tests/test_sync_cloud_plan_cache.py
+++ b/tests/test_sync_cloud_plan_cache.py
@@ -1,0 +1,180 @@
+"""Tests for the daemon -> dashboard cloud-plan bridge.
+
+The Flask dashboard process resolves entitlements via
+``clawmetry.entitlements.get_entitlement`` which reads
+``~/.clawmetry/cloud_plan.json``. Until now the daemon mirrored the heartbeat
+``plan`` only into in-process ``_TRIAL_STATE``, so a cloud Pro plan never made
+it across the process boundary and ``/api/entitlement`` reported ``tier=oss``
+on real Pro installs.
+
+These tests pin the new behaviour: whenever ``_update_trial_state`` learns of
+a plan change, ``_persist_cloud_plan_to_disk`` writes a mapped tier code to
+the cache file (or removes it on inactive plans), and the entitlements module
+picks the new plan up on its next resolution.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def sync(monkeypatch, tmp_path):
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as s
+
+    cache_path = str(tmp_path / ".clawmetry" / "cloud_plan.json")
+    monkeypatch.setattr(s, "_CLOUD_PLAN_CACHE_PATH", cache_path)
+    s._TRIAL_STATE["sync_allowed"] = True
+    s._TRIAL_STATE["plan"] = None
+    s._TRIAL_STATE["trial_days_left"] = None
+    s._TRIAL_STATE["last_log_day"] = ""
+
+    import clawmetry.entitlements as e
+    monkeypatch.setattr(e, "_CLOUD_PLAN_CACHE", cache_path)
+    monkeypatch.setattr(e, "_LICENSE_PATH", str(tmp_path / "license.key"))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    e.invalidate()
+    return s
+
+
+# ── _persist_cloud_plan_to_disk ───────────────────────────────────────────────
+
+
+def test_persist_writes_cloud_pro_for_pro_plan(sync):
+    sync._persist_cloud_plan_to_disk("pro")
+    assert os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
+    payload = json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())
+    assert payload["plan"] == "cloud_pro"
+
+
+@pytest.mark.parametrize(
+    "heartbeat_plan,expected_tier",
+    [
+        ("pro", "cloud_pro"),
+        ("cloud_pro", "cloud_pro"),
+        ("starter", "cloud_starter"),
+        ("cloud_starter", "cloud_starter"),
+        ("trial", "trial"),
+        ("cloud_trial", "trial"),
+        ("free", "cloud_free"),
+        ("cloud_free", "cloud_free"),
+        ("enterprise", "enterprise"),
+        ("PRO", "cloud_pro"),  # case-insensitive
+        (" pro ", "cloud_pro"),  # whitespace-tolerant
+    ],
+)
+def test_persist_maps_known_plan_codes(sync, heartbeat_plan, expected_tier):
+    sync._persist_cloud_plan_to_disk(heartbeat_plan)
+    payload = json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())
+    assert payload["plan"] == expected_tier
+
+
+@pytest.mark.parametrize("dead_plan", ["trial_expired", "", None, "unknown_plan"])
+def test_persist_removes_cache_for_inactive_plans(sync, dead_plan):
+    # Seed an existing cache so the removal path is exercised.
+    os.makedirs(os.path.dirname(sync._CLOUD_PLAN_CACHE_PATH), exist_ok=True)
+    with open(sync._CLOUD_PLAN_CACHE_PATH, "w") as fh:
+        json.dump({"plan": "cloud_pro"}, fh)
+    sync._persist_cloud_plan_to_disk(dead_plan)
+    assert not os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
+
+
+def test_persist_trial_writes_expiry_from_days_left(sync):
+    before = time.time()
+    sync._persist_cloud_plan_to_disk("trial", trial_days_left=7)
+    payload = json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())
+    assert payload["plan"] == "trial"
+    # 7d ± slack for test timing.
+    assert payload["expiry"] is not None
+    assert (payload["expiry"] - before) > 6 * 86400
+    assert (payload["expiry"] - before) < 8 * 86400
+
+
+def test_persist_pro_has_no_expiry(sync):
+    sync._persist_cloud_plan_to_disk("pro", trial_days_left=99)
+    payload = json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())
+    # Only trials get a derived expiry from trial_days_left.
+    assert payload["expiry"] is None
+
+
+def test_persist_is_atomic_no_partial_file(sync):
+    sync._persist_cloud_plan_to_disk("pro")
+    # The tmp file used for the atomic rename must not be left behind.
+    assert not os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH + ".tmp")
+
+
+def test_persist_swallows_filesystem_errors(sync, monkeypatch):
+    # Point the cache at a path inside a non-existent root that cannot be
+    # mkdired. Persist must not raise.
+    monkeypatch.setattr(sync, "_CLOUD_PLAN_CACHE_PATH", "/nonexistent/root/x/cloud_plan.json")
+    sync._persist_cloud_plan_to_disk("pro")  # no exception
+
+
+# ── _update_trial_state writes through to the cache ──────────────────────────
+
+
+def test_update_trial_state_persists_pro(sync):
+    sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
+    payload = json.loads(open(sync._CLOUD_PLAN_CACHE_PATH).read())
+    assert payload["plan"] == "cloud_pro"
+
+
+def test_update_trial_state_clears_cache_on_expiry(sync):
+    sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
+    assert os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
+    sync._update_trial_state({"sync_allowed": False, "plan": "trial_expired"})
+    assert not os.path.isfile(sync._CLOUD_PLAN_CACHE_PATH)
+
+
+def test_update_trial_state_skips_persist_when_plan_unchanged(sync, monkeypatch):
+    calls = {"n": 0}
+
+    def _spy(plan, trial_days_left=None):
+        calls["n"] += 1
+
+    sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
+    monkeypatch.setattr(sync, "_persist_cloud_plan_to_disk", _spy)
+    # Same plan repeated → no extra disk writes.
+    sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
+    sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
+    assert calls["n"] == 0
+
+
+# ── integration: dashboard sees the cloud plan after persist ────────────────
+
+
+def test_entitlements_sees_cloud_pro_after_heartbeat(sync, monkeypatch):
+    import clawmetry.entitlements as e
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")  # bypass grace so tier shows
+    e.invalidate()
+
+    sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
+    en = e.get_entitlement(force=True)
+    assert en.tier == e.TIER_CLOUD_PRO
+    assert en.source == "cloud"
+    assert en.allows_runtime("claude_code") is True
+
+
+def test_entitlements_falls_back_to_oss_after_trial_expiry(sync, monkeypatch):
+    import clawmetry.entitlements as e
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    e.invalidate()
+
+    sync._update_trial_state({"sync_allowed": True, "plan": "pro"})
+    assert e.get_entitlement(force=True).tier == e.TIER_CLOUD_PRO
+
+    sync._update_trial_state({"sync_allowed": False, "plan": "trial_expired"})
+    en = e.get_entitlement(force=True)
+    assert en.tier == e.TIER_OSS
+    assert en.allows_runtime("claude_code") is False


### PR DESCRIPTION
## Summary

Closes the daemon → dashboard gap in the entitlements stack: the daemon already mirrors heartbeat `plan` into in-process `_TRIAL_STATE`, but the Flask dashboard runs in a **separate process** and resolves entitlements via `clawmetry.entitlements.get_entitlement()`, which reads `~/.clawmetry/cloud_plan.json`. Until now nothing wrote that file, so `/api/entitlement` reported `tier=oss` on real cloud Pro installs even with all the read-side scaffolding (`tests/test_entitlements.py::test_cloud_plan_cache_grants_tier`) already in place.

## Changes

- **`clawmetry/sync.py`**
  - New `_CLOUD_PLAN_CACHE_PATH = ~/.clawmetry/cloud_plan.json` mirroring `clawmetry.entitlements._CLOUD_PLAN_CACHE`.
  - New `_HEARTBEAT_PLAN_TO_TIER` map: `pro`/`cloud_pro` → `cloud_pro`, `starter`/`cloud_starter` → `cloud_starter`, `trial`/`cloud_trial` → `trial`, `free`/`cloud_free` → `cloud_free`, `enterprise` → `enterprise`. Case-insensitive, whitespace-tolerant.
  - New `_persist_cloud_plan_to_disk(plan, trial_days_left=None)`:
    - Inactive/unknown plans (`trial_expired`, `None`, `""`, anything not in the map) **remove** the cache so the resolver falls back to OSS-free rather than granting a dead plan.
    - Active plans are written atomically (`*.tmp` + `os.replace`) with `{plan, node_limit:1, expiry}` where `expiry` is derived from `trial_days_left` for trials only.
    - Calls `clawmetry.entitlements.invalidate()` so the in-process 60s cache rebuilds on next read.
    - Best-effort: any IO error logs at debug and is swallowed — the cache is an optimisation, never a daemon-crashing path.
  - `_update_trial_state` now persists when the plan or `trial_days_left` changes (skips disk IO on identical-heartbeat repeats).
- **`tests/test_sync_cloud_plan_cache.py`** (new, 25 tests):
  - Plan-code mapping (parametrized over every known heartbeat code + case/whitespace variants).
  - Inactive plans remove the cache (parametrized over `trial_expired`/`""`/`None`/unknown).
  - Atomic write (no `.tmp` residue).
  - Trial expiry is derived from `trial_days_left`; non-trials have `expiry=None`.
  - IO error in `_persist_cloud_plan_to_disk` is swallowed.
  - `_update_trial_state` skips persist when plan is unchanged.
  - Integration: enforced `get_entitlement()` picks up `cloud_pro` after a heartbeat, falls back to OSS when the plan drops to `trial_expired`.

## Grace-mode safety

Behaviour is unchanged in grace mode (the default). `Entitlement.allows_runtime` / `allows_feature` still return `True` regardless of tier; the only user-visible effect is that `/api/entitlement` now reports the correct tier for cloud subscribers — which the dashboard already uses to suppress the upgrade CTA.

## Test plan

- [x] `python3 -m pytest tests/test_sync_cloud_plan_cache.py` — 25 passed
- [x] `python3 -m pytest tests/test_sync_trial_gating.py tests/test_entitlements.py tests/test_license.py tests/test_entitlements_catalogue.py tests/test_adaptive_heartbeat.py tests/test_moat_cloud_robustness.py` — 86 passed, no regressions
- [x] `ruff check clawmetry/sync.py` — same 23 pre-existing errors, no new ones introduced
- [x] `python3 -m py_compile clawmetry/sync.py tests/test_sync_cloud_plan_cache.py` — OK

## Local operator verification checklist

Because the bot cannot reach the running daemon, the live cloud snapshot, or a browser, please run these after merge:

1. **Copy changed files into the live daemon venv** (replace the version path as appropriate):
   ```sh
   cp clawmetry/sync.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/sync.py
   find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null
   ```
2. **Restart the daemon** so it picks up the new module:
   ```sh
   launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
   ```
3. **Wait one heartbeat (≤60 s)** then inspect the cache file:
   ```sh
   cat ~/.clawmetry/cloud_plan.json
   ```
   Should show `{"plan": "cloud_pro", "node_limit": 1, "expiry": null}` (or whatever tier this account is on).
4. **Hit `/api/entitlement`** and confirm `tier` matches the cache (instead of `oss`):
   ```sh
   curl -s http://localhost:8900/api/entitlement | python3 -m json.tool | head -20
   ```
5. **Decrypt the live snapshot** and open the dashboard in a browser; the upgrade CTA should disappear for Pro tiers (grace mode still allows everything, so no other UI change).
6. **Smoke-check downgrade**: temporarily revoke the plan (or wait for trial expiry), confirm the cache file is removed on the next heartbeat and `/api/entitlement` flips back to `tier=oss`.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_017W5yKVpbD96dEvFuqamaip)_