### PR TITLE
feat(brain): forward-progress badge on Brain tab

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -6012,6 +6012,8 @@ async function loadBrainPage(silent) {
   loadLoopSignals();
   // At-risk impact summary (issue #2008) — fire-and-forget; never blocks.
   loadBrainAtRisk();
+  // Forward-progress badge (issue #1707) — fire-and-forget; never blocks.
+  loadBrainProgress();
 }
 
 
@@ -6049,6 +6051,47 @@ async function loadBrainAtRisk() {
         'border:1px solid rgba(245,158,11,0.3);font-size:11px;color:#f59e0b;cursor:default;';
       chip.title = escHtml(m.label) + ': ' + counts[k] + ' session' + (counts[k] !== 1 ? 's' : '');
       chip.innerHTML = m.icon + ' ' + escHtml(m.label) + ' <strong>' + counts[k] + '</strong>';
+      chips.appendChild(chip);
+    });
+  } catch(e) { /* never block brain load */ }
+}
+
+
+// Forward-progress badge (issue #1707) — per-session token-to-delta ratio
+// pills on the Brain tab. Called fire-and-forget from loadBrainPage().
+// Shows only yellow/red sessions; hides the card when all are green.
+async function loadBrainProgress() {
+  var card  = document.getElementById('brain-progress-card');
+  var chips = document.getElementById('brain-progress-chips');
+  if (!card || !chips) return;
+  try {
+    var since1h = new Date(Date.now() - 3600000).toISOString().slice(0, 19) + 'Z';
+    var r = await fetch('/api/forward-progress?since=' + encodeURIComponent(since1h));
+    if (!r.ok) return;
+    var d = await r.json();
+    var rows = (d && d.rows) || [];
+    var concerning = rows.filter(function(row) {
+      return row.badge === 'yellow' || row.badge === 'red';
+    });
+    card.style.display = concerning.length ? '' : 'none';
+    if (!concerning.length) return;
+    var win = document.getElementById('brain-progress-window');
+    if (win) win.textContent = '· last 1h';
+    chips.innerHTML = '';
+    concerning.forEach(function(row) {
+      var isRed = row.badge === 'red';
+      var color = isRed ? '#ef4444' : '#f59e0b';
+      var bg    = isRed ? 'rgba(239,68,68,0.12)'  : 'rgba(245,158,11,0.12)';
+      var bdr   = isRed ? 'rgba(239,68,68,0.3)'   : 'rgba(245,158,11,0.3)';
+      var icon  = isRed ? '🔴' : '🟡';
+      var sid   = (row.session_id || '').slice(0, 8);
+      var ratio = Math.round(row.ratio || 0).toLocaleString();
+      var chip  = document.createElement('span');
+      chip.style.cssText = 'display:inline-flex;align-items:center;gap:4px;padding:3px 10px;' +
+        'border-radius:12px;background:' + bg + ';border:1px solid ' + bdr + ';' +
+        'font-size:11px;color:' + color + ';cursor:default;';
+      chip.title = 'Session ' + escHtml(row.session_id || '') + ' — ' + ratio + ' tok/Δ';
+      chip.innerHTML = icon + ' ' + escHtml(sid) + '… <strong>' + ratio + '</strong> tok/Δ';
       chips.appendChild(chip);
     });
   } catch(e) { /* never block brain load */ }

--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -134,6 +134,21 @@
       </div>
       <div id="brain-at-risk-chips" style="display:flex;flex-wrap:wrap;gap:6px;"></div>
     </div>
+    <!-- Forward-progress card (issue #1707): per-session token-to-delta ratio
+         badges. Hidden when all sessions are green (healthy). Populated by
+         loadBrainProgress() in app.js. -->
+    <div id="brain-progress-card" style="display:none;
+      background:var(--bg-secondary);
+      border:1px solid #6366f1;
+      border-radius:8px;
+      padding:10px 14px;
+      margin-bottom:12px;">
+      <div style="display:flex;align-items:center;gap:6px;margin-bottom:8px;">
+        <span style="font-size:13px;font-weight:700;color:#818cf8;">&#128260; <span data-i18n="brain.progress_title">Unproductive burn detected</span></span>
+        <span id="brain-progress-window" style="font-size:11px;color:var(--text-muted);"></span>
+      </div>
+      <div id="brain-progress-chips" style="display:flex;flex-wrap:wrap;gap:6px;"></div>
+    </div>
     <div class="brain-view-toggle" data-i18n-title="brain.view_toggle_tooltip" title="Switch between list view and neural-network view">
       <button class="brain-view-btn active" data-view="list" onclick="setBrainViewMode('list', this)" data-i18n="brain.view_list">List</button>
       <button class="brain-view-btn" data-view="graph" onclick="setBrainViewMode('graph', this)" data-i18n-title="brain.view_graph_tooltip" title="Neural-network visualization of agent activity (closes #53)" data-i18n="brain.view_graph">Graph</button>


### PR DESCRIPTION
## Summary

- Adds `#brain-progress-card` to `clawmetry/templates/tabs/brain.html` — a card that surfaces per-session token-to-delta ratio badges (🟡 yellow = 5k–50k tok/Δ, 🔴 red = > 50k tok/Δ); hidden when all sessions are green
- Adds `loadBrainProgress()` async function to `clawmetry/static/js/app.js` — fetches `/api/forward-progress?since=1h` and renders chips for concerning sessions; follows the exact pattern of the existing `loadBrainAtRisk()` card
- Wires the new function into `loadBrainPage()` as a fire-and-forget call (never blocks the Brain tab render)

The `/api/forward-progress` endpoint was shipped in #1707 and returns `{session_id, ratio, badge: "green"|"yellow"|"red"}` — this PR adds the missing UI wire-up.

Closes #1708

## Test plan

- [ ] Open Brain tab with an active session → card hidden when all sessions are green
- [ ] Simulate a session with high tok/Δ ratio → yellow or red chip appears with session prefix and ratio
- [ ] Toggle refresh — card re-renders correctly without duplicate chips
- [ ] Focus mode (`⛶ Focus`) — card remains visible (intentional, matches `#brain-at-risk-card` behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVZMd85TUFaYZmYuP6qdYi)_