### PR TITLE
test: rename loop_signals/duckdb_relay e2e → *_integration (deterministic, not e2e)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test-e2e:
 # Self-contained: drives the daemon ingest helper + relay shapes against an
 # isolated DuckDB file. No live server, no gateway, no network. ~5s.
 test-e2e-duckdb:
-	python3 -m pytest tests/test_e2e_duckdb_relay.py -v
+	python3 -m pytest tests/test_duckdb_relay_integration.py -v
 
 test-workflow:
 	python3 -m pytest tests/test_e2e_nightly_workflow.py -v

--- a/tests/test_duckdb_relay_integration.py
+++ b/tests/test_duckdb_relay_integration.py
@@ -1,5 +1,14 @@
-"""End-to-end test for the DuckDB + relay-shape pipeline (Engineer B,
-2026-05-12).
+"""Deterministic integration test for the DuckDB + relay-shape data path.
+
+Renamed 2026-05-31 from test_e2e_duckdb_relay: it is explicitly "fully
+self-contained: no live daemon, no real WebSocket, no network" and drives the
+in-process ingest+relay helpers with controlled synthetic events to prove
+cross-layer row/content EQUALITY. That determinism is the point, so synthetic
+input is appropriate (the "real e2e, no synthetic seeds" rule applies to e2e
+tests, not deterministic integration tests). Genuine real-turn coverage of the
+same relay layer lives in tests/test_e2e_real_openclaw_pipeline.py.
+
+Original note (Engineer B, 2026-05-12):
 
 Proves the full local data path:
 
@@ -30,7 +39,7 @@ Why drive the helpers in-process instead of spawning a real daemon:
 Run as:
     make test-e2e-duckdb
 or:
-    pytest -v tests/test_e2e_duckdb_relay.py
+    pytest -v tests/test_duckdb_relay_integration.py
 """
 
 from __future__ import annotations

--- a/tests/test_loop_signals_integration.py
+++ b/tests/test_loop_signals_integration.py
@@ -1,4 +1,13 @@
-"""E2E tests for the LoopDetector → DuckDB → /api/loop-signals path (#1364).
+"""Integration tests for the loop-signal storage+read contract
+(LocalStore.ingest_loop_signal → DuckDB → /api/loop-signals), #1364.
+
+Renamed 2026-05-31 from test_loop_signals_e2e: this pins the deterministic
+STORAGE+READ contract (schema round-trip, upsert, query filters) with
+controlled synthetic loop-signal rows — not an end-to-end run of the proxy
+LoopDetector. Synthetic input is appropriate for a deterministic contract
+test (the no-synthetic-seeds rule targets e2e tests).
+
+Original note: E2E tests for the LoopDetector → DuckDB → /api/loop-signals path (#1364).
 
 Three surfaces:
   1. Schema round-trip — ``LocalStore.ingest_loop_signal`` writes a row


### PR DESCRIPTION
Part of the **"real e2e, no synthetic seeds"** initiative — more *rename* (not convert), because both are deterministic integration tests whose synthetic input is load-bearing.

- **`test_e2e_duckdb_relay` → `test_duckdb_relay_integration`**: its own docstring says *"fully self-contained: no live daemon, no real WebSocket, no network"*; it asserts cross-layer row/content **equality** — determinism is the point. Real-turn coverage of the relay layer now lives in `test_e2e_real_openclaw_pipeline.py` (#2367).
- **`test_loop_signals_e2e` → `test_loop_signals_integration`**: pins the loop-signal **storage+read contract** (schema round-trip, upsert, query filters) with controlled synthetic rows — not a real proxy LoopDetector run.

Per the initiative's rule, synthetic data is fine for non-e2e tests; only the misleading `e2e` label was wrong. Pure renames (logic byte-identical) + Makefile ref updates + classification docstrings. 29 tests collect cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)