### PR TITLE
fix(tracing): show the agent reply in the invoke_agent Chat tab

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -9931,6 +9931,31 @@ function _traceExtractMessages(s, full) {
     if (val.messages)                    { walk(val.messages, role); return; }
   }
   if (full) { walk(full.input, 'user'); walk(full.output, 'assistant'); }
+  // Agent-root spans (invoke_agent) are CONTAINERS with empty own detail — the
+  // user prompt lives on a child `prompt` span and the assistant reply on a
+  // child `chat`/llm span's detail. Aggregate the whole subtree so the Chat
+  // tab shows the full user -> assistant(+tools) conversation. (Bug: clicking
+  // "invoke_agent main" showed only the user prompt, never the reply.)
+  if (!out.length && s && s.kind === 'agent'
+      && window._traceData && Array.isArray(window._traceData.spans)) {
+    var _kids = {};
+    window._traceData.spans.forEach(function(x) {
+      if (x.parent_span_id) (_kids[x.parent_span_id] = _kids[x.parent_span_id] || []).push(x);
+    });
+    (function _collect(id) {
+      (_kids[id] || []).slice()
+        .sort(function(a, b) { return (a.start_ms || 0) - (b.start_ms || 0); })
+        .forEach(function(c) {
+          if (c.kind === 'prompt') add('user', c.detail);
+          else if (c.kind === 'llm') add('assistant', c.detail);
+          else if (c.kind === 'tool') {
+            if (c.detail) add('tool', (c.tool ? c.tool + ': ' : '') + c.detail);
+            if (c.output) add('tool_result', c.output);
+          }
+          _collect(c.span_id);
+        });
+    })(s.span_id);
+  }
   // Span-level captured detail + output (set by _build_spans). For tool
   // spans, detail is the tool input and output is the tool_result content.
   if (!out.length && s) {


### PR DESCRIPTION
User-reported (Image #5): clicking **invoke_agent main** in Tracing showed the USER prompt but **not the agent reply** ('pong').

**Root cause:** the agent-root span is a container with empty own `detail`; `_build_spans` puts the user prompt on a child `prompt` span and the assistant reply on a child `chat`/llm span's `detail`. `_traceExtractMessages` only read the clicked span's own detail (empty for an agent span) then fell back to the trace title (the user prompt) — so the reply never rendered.

**Fix:** for an agent-kind span, aggregate the whole descendant subtree into the Chat view (`prompt`→user, `llm`→assistant, `tool`→tool/result, in start-time order). The agent-root Chat tab now shows the full user → assistant(+tools) conversation. Frontend-only; aggregation logic verified to emit both the prompt and the reply.

Part of the UI/UX pass (bug #5 of the user's screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)