### PR TITLE
fix(tracing): show agent reply in CLOUD — keep truncated span text in snapshot + aggregate-first

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -9930,13 +9930,14 @@ function _traceExtractMessages(s, full) {
     if (val.message)                     { walk(val.message, role); return; }
     if (val.messages)                    { walk(val.messages, role); return; }
   }
-  if (full) { walk(full.input, 'user'); walk(full.output, 'assistant'); }
   // Agent-root spans (invoke_agent) are CONTAINERS with empty own detail — the
   // user prompt lives on a child `prompt` span and the assistant reply on a
-  // child `chat`/llm span's detail. Aggregate the whole subtree so the Chat
-  // tab shows the full user -> assistant(+tools) conversation. (Bug: clicking
-  // "invoke_agent main" showed only the user prompt, never the reply.)
-  if (!out.length && s && s.kind === 'agent'
+  // child `chat`/llm span's detail. Aggregate the whole subtree FIRST so the
+  // Chat tab shows the full user -> assistant(+tools) conversation. (Bug:
+  // clicking "invoke_agent main" showed only the user prompt, never the reply
+  // — the trace-title fallback added the prompt before this could run, so it
+  // must come before the full/title fallbacks and win when it yields content.)
+  if (s && s.kind === 'agent'
       && window._traceData && Array.isArray(window._traceData.spans)) {
     var _kids = {};
     window._traceData.spans.forEach(function(x) {
@@ -9955,7 +9956,9 @@ function _traceExtractMessages(s, full) {
           _collect(c.span_id);
         });
     })(s.span_id);
+    if (out.length) return out;  // aggregated conversation wins for agent spans
   }
+  if (full) { walk(full.input, 'user'); walk(full.output, 'assistant'); }
   // Span-level captured detail + output (set by _build_spans). For tool
   // spans, detail is the tool input and output is the tool_result content.
   if (!out.length && s) {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9371,6 +9371,51 @@ def _build_traces(limit_traces=5, span_cap=100):
         return {"list": [], "detail": {}}
 
 
+def _build_turn_anatomy(limit_sessions=8, turn_cap=60):
+    """Per-session turn-anatomy 'turns' for the cloud Turn-anatomy detail view.
+
+    The cloud container has no local event store, so /api/turn-anatomy?session_id
+    returns ``available: false`` there and the detail view showed "Event store
+    not available here" (user-reported 2026-05-31). Ship a compact per-session
+    ``turns`` slice the cm-cloud-turn-anatomy interceptor serves — built daemon
+    -side from the same events as the trace slice, via the real
+    ``routes.turn_anatomy._build_turns`` so the shape matches the OSS endpoint.
+    Bounded: turns are short label/duration rows; limit_sessions × turn_cap.
+    Returns {"detail": {session_id: {available, session_id, turns}}}.
+    """
+    try:
+        from clawmetry import local_store as _ls
+        from clawmetry.config import hide_clawmetry_session
+        import routes.turn_anatomy as _ta
+        store = _ls.get_store()
+        if store is None:
+            return {"detail": {}}
+        rows = store.query_events(limit=14000)
+        by_sid = {}
+        for e in (rows or []):
+            sid = (e.get("session_id") or "").strip()
+            if not sid or hide_clawmetry_session(sid):
+                continue
+            by_sid.setdefault(sid, []).append(e)
+        # Most-recent sessions first (by latest event ms), bounded.
+        def _latest(evs):
+            ms = [_ta._ts_ms(_ta._data(x).get("timestamp") or x.get("ts"))
+                  for x in evs]
+            return max((m for m in ms if m is not None), default=0)
+        ordered = sorted(by_sid.items(), key=lambda kv: _latest(kv[1]), reverse=True)
+        detail = {}
+        for sid, evs in ordered[:limit_sessions]:
+            turns = _ta._build_turns(evs)
+            if not turns:
+                continue
+            detail[sid] = {"available": True, "session_id": sid,
+                           "turns": turns[:turn_cap]}
+        return {"detail": detail}
+    except Exception as _e:
+        log.debug("turn-anatomy snapshot build failed: %s", _e)
+        return {"detail": {}}
+
+
 # ── Self-Evolve: delegate the review to OpenClaw itself ──────────────────────
 # The cloud server has no model credential, and ClawMetry's gateway token is
 # read-only (operator.read) — so neither can run the Self-Evolve LLM review.
@@ -11569,6 +11614,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "reliability": _build_reliability(),
         "memoryAccess": _build_memory_access(),
         "traces": _build_traces(),
+        "turnAnatomy": _build_turn_anatomy(),
         "skills": _build_skills(),
         # Connector liveness (incident: a channel went deaf ~37h, no alarm).
         # Lets the cloud dashboard flag a 'down' inbound channel just like the

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9344,11 +9344,19 @@ def _build_traces(limit_traces=5, span_cap=100):
                     if s["parent_span_id"] and s["parent_span_id"] not in ids:
                         s["parent_span_id"] = None
                 roots = [s["span_id"] for s in spans if not s["parent_span_id"]]
-            # Perf: drop the per-span free-text payload from the snapshot — it's
-            # the bulk of the size. Cloud renders the waterfall/tree/graph from
-            # the metadata; the full text is a local-dashboard detail.
+            # Keep a TRUNCATED per-span text in the snapshot so the cloud
+            # Tracing Chat tab can show the conversation (user prompt +
+            # assistant reply), not just the waterfall metadata. Previously we
+            # popped `detail` entirely to save size, which left the cloud Chat
+            # tab showing only the trace-title prompt and never the reply
+            # (user-reported 2026-05-31). Cap each field so the bulk-text bloat
+            # the pop was guarding against stays bounded: 400 chars/span ×
+            # span_cap(100) × limit_traces(5) ≈ 200KB worst case.
             for s in spans:
-                s.pop("detail", None)
+                if s.get("detail"):
+                    s["detail"] = s["detail"][:400]
+                if s.get("output"):
+                    s["output"] = s["output"][:400]
             detail[sid] = {
                 "trace_id": sid,
                 "summary": t,


### PR DESCRIPTION
**Found via live visual verification** (logged into app.clawmetry.com): #2381's frontend fix was loaded (`hasFix:true`) but the agent reply still didn't render in cloud. Inspecting the live data showed every trace span had **empty `detail`** — because the snapshot builder (`sync.py:_build_traces`) did `s.pop("detail", None)` to save size. So the cloud Chat tab had no conversation text; the "USER" line was just the trace-title fallback, and the reply was nowhere in the cloud trace data.

## Fix (two parts)
1. **`sync.py` `_build_traces`**: keep a **truncated** `detail`/`output` (400 chars/span) in the snapshot instead of dropping it. Bounded: 400 × span_cap(100) × limit_traces(5) ≈ 200KB worst case — the bulk-text bloat the pop guarded against stays small, but the cloud Chat tab now has the user prompt + assistant reply.
2. **`app.js` `_traceExtractMessages`**: run the agent-subtree aggregation **first** and return when it yields content — so the trace-title/full fallbacks can't pre-populate `out` and block it (the reason #2381 looked applied but the reply still didn't show).

Daemon-side (1) reaches cloud when the node's daemon upgrades to this wheel; (2) ships via the pinned wheel. `node --check` + `sync.py` AST clean. Will re-verify on live (logged-in browser) after release + daemon upgrade.

Completes bug #5 for cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)