### PR TITLE
feat(ui): runtime switcher flags Pro runtimes actually detected on this machine

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7243,6 +7243,29 @@ var _cmGlobalRtCounts = {};
 // AND the install lacks the paid entitlement — then locked runtimes appear in
 // the dropdown with a 🔒 affordance regardless of session count.
 var _cmLockedRuntimes = {};
+// Runtimes actually DETECTED on this machine (from the daemon's
+// `detectedRuntimes` snapshot slice / overview): id -> {running:bool}. Lets the
+// switcher flag a locked runtime the user is genuinely running ("detected here
+// — upgrade to observe") vs a generic locked catalog row. Empty by default.
+var _cmRunningRuntimes = {};
+async function _cmLoadDetectedRuntimes() {
+  try {
+    var det = null;
+    if (window.CLOUD_MODE && typeof window.__cmSnap === 'function') {
+      var sp = await window.__cmSnap();
+      det = sp && sp.detectedRuntimes;            // daemon-detected, server-blind
+    } else {
+      var ov = await fetch('/api/overview', { credentials: 'same-origin' })
+        .then(function(r) { return r.json(); }).catch(function() { return null; });
+      det = ov && (ov.detectedRuntimes || ov.detected_runtimes);
+    }
+    var run = {};
+    (det || []).forEach(function(d) {
+      if (d && d.name) run[d.name] = { running: !!d.running };
+    });
+    _cmRunningRuntimes = run;
+  } catch (e) { /* non-fatal — switcher just omits the "detected here" hint */ }
+}
 
 function _cmPopulateGlobalRuntime(counts) {
   // Merge-MAX into the running set, never replace. Per-tab loaders pass their
@@ -7276,17 +7299,39 @@ function _cmPopulateGlobalRuntime(counts) {
   // chip doesn't read as "22 Claude Code runtimes" (there's one runtime, many
   // sessions). Singular/plural for the "1 session" case.
   function _sessLabel(n) { return n + (n === 1 ? ' session' : ' sessions'); }
-  var html = '<option value="all">All runtimes · ' + _sessLabel(total) + '</option>';
-  order.forEach(function(k) {
+  function _opt(k) {
     var lbl = _CM_RT_LABEL[k] || k;
     if (_cmLockedRuntimes[k]) {
-      // Padlock + "Upgrade" hint; the option stays selectable so users can see
-      // the empty-runtime state (and the upgrade CTA the tab will render).
-      html += '<option value="' + k + '">🔒 ' + escHtml(lbl) + ' · Upgrade</option>';
-    } else {
-      html += '<option value="' + k + '">' + escHtml(lbl) + ' · ' + _sessLabel(counts[k]) + '</option>';
+      // A locked (Pro) runtime that is ACTUALLY DETECTED on this machine is the
+      // strongest upgrade signal — "you're using it here, upgrade to observe
+      // it" — so call it out, distinct from a generic catalog row the user
+      // doesn't run. Both stay selectable so the tab can render its empty-state
+      // + upgrade CTA.
+      var det = _cmRunningRuntimes[k];
+      if (det) {
+        var tag = det.running ? '▶ running here' : 'detected here';
+        return '<option value="' + k + '">🔒 ' + escHtml(lbl) + ' · ' + tag + ' · Upgrade</option>';
+      }
+      return '<option value="' + k + '">🔒 ' + escHtml(lbl) + ' · Upgrade</option>';
     }
-  });
+    return '<option value="' + k + '">' + escHtml(lbl) + ' · ' + _sessLabel(counts[k]) + '</option>';
+  }
+  var lockedRunning = locked.filter(function(k) { return _cmRunningRuntimes[k]; });
+  var lockedOther = locked.filter(function(k) { return !_cmRunningRuntimes[k]; });
+  var html = '<option value="all">All runtimes · ' + _sessLabel(total) + '</option>';
+  observed.forEach(function(k) { html += _opt(k); });
+  // Group the detected-but-locked runtimes under their own header so the
+  // "running here, needs Pro" distinction is unmistakable in the dropdown.
+  if (lockedRunning.length) {
+    html += '<optgroup label="▶ Detected on this machine — upgrade to observe">';
+    lockedRunning.forEach(function(k) { html += _opt(k); });
+    html += '</optgroup>';
+  }
+  if (lockedOther.length) {
+    html += '<optgroup label="Available with Pro">';
+    lockedOther.forEach(function(k) { html += _opt(k); });
+    html += '</optgroup>';
+  }
   sel.innerHTML = html;
   sel.value = active;
   wrap.style.display = 'flex';
@@ -7409,6 +7454,9 @@ async function _cmInitGlobalRuntimeSwitcher() {
   // switcher (with a 🔒) when enforcement is on — no-op in grace mode.
   try {
     await _cmLoadRuntimeCatalog();
+  } catch (e) { /* non-fatal */ }
+  try {
+    await _cmLoadDetectedRuntimes();
   } catch (e) { /* non-fatal */ }
   try {
     var data = await fetch('/api/sessions', { credentials: 'same-origin' }).then(function(r) { return r.json(); });


### PR DESCRIPTION
**User request:** the runtime switcher should clearly show which locked (Pro) runtimes are **actually detected running on this machine** vs generic locked catalog rows — "Claude Code is running here → upgrade to observe it" is a much stronger signal than a runtime the user doesn't have.

The daemon already ships a `detectedRuntimes` snapshot slice (`_detect_family_runtimes` runs each adapter's `detect()` with `installed`/`running`). The header switcher now consumes it (cloud: snapshot; local: `/api/overview`) into `_cmRunningRuntimes` and:
- groups **locked-but-detected** runtimes under **"▶ Detected on this machine — upgrade to observe"** with a per-row tag (`▶ running here` when running, `detected here` when installed);
- keeps undetected locked runtimes under **"Available with Pro"**.

Empty detection is a graceful no-op (everything stays "Available with Pro" — exactly today's behavior). Frontend-only → cloud via the pinned wheel. `node --check` clean; option-building verified with test data (1 observed + 1 running-locked + 1 plain-locked → the correct two-group dropdown). It lights up live the moment a Pro runtime is detected on the node (currently `detectedRuntimes` is empty on the test node, so the dropdown is unchanged there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)