### PR TITLE
feat(flow): newcomer-legible redesign + live trace-accurate packet view

### DIFF
--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -479,6 +479,55 @@
   .flow-path.glow-cyan { stroke: #40a0b0; filter: drop-shadow(0 0 6px rgba(64,160,176,0.6)); stroke-dasharray: none; opacity: 1; }
   .flow-path.glow-purple { stroke: #b080ff; filter: drop-shadow(0 0 6px rgba(176,128,255,0.6)); }
 
+  /* === Flow Journey Rail (human-first headline) ===
+     A calm, editorial left-to-right "how your messages get answered" story
+     above the topology. Cool slate station cards, one warm accent (amber) for
+     the live signal + the Brain station. Live sub-stats wired in updateFlowStats. */
+  .flow-journey { margin: 0 0 16px; padding: 18px 20px 16px; border-radius: 16px;
+    background: radial-gradient(120% 160% at 0% 0%, rgba(59,130,246,0.08), transparent 55%), linear-gradient(180deg, var(--bg-secondary), var(--bg-primary));
+    border: 1px solid var(--border-primary);
+    box-shadow: 0 1px 0 rgba(255,255,255,0.03) inset, 0 8px 30px rgba(0,0,0,0.18); }
+  .flow-journey-title { font-family: Georgia, 'Times New Roman', 'Noto Serif', serif;
+    font-size: 19px; font-weight: 600; letter-spacing: -0.2px; color: var(--text-primary);
+    margin: 0 0 14px; line-height: 1.25; }
+  .flow-journey-rail { position: relative; }
+  .fj-track { position: absolute; left: 6px; right: 6px; top: 30px; height: 2px;
+    background: linear-gradient(90deg, var(--border-secondary), var(--border-primary), var(--border-secondary));
+    border-radius: 2px; overflow: visible; z-index: 0; }
+  .fj-signal { position: absolute; top: -3px; left: 0; width: 8px; height: 8px; border-radius: 50%;
+    background: #f0c040; box-shadow: 0 0 8px rgba(240,192,64,0.8);
+    animation: fjSignal 4.5s linear infinite; }
+  @keyframes fjSignal { 0% { left: 0; opacity: 0; } 8% { opacity: 1; } 92% { opacity: 1; } 100% { left: 100%; opacity: 0; } }
+  .fj-stations { position: relative; z-index: 1; display: flex; align-items: stretch;
+    gap: 6px; flex-wrap: nowrap; overflow-x: auto; padding-bottom: 2px;
+    scrollbar-width: thin; -webkit-overflow-scrolling: touch; }
+  .fj-stations::-webkit-scrollbar { height: 5px; }
+  .fj-stations::-webkit-scrollbar-thumb { background: var(--border-primary); border-radius: 3px; }
+  .fj-station { flex: 1 1 0; min-width: 96px; display: flex; flex-direction: column; align-items: center;
+    text-align: center; gap: 3px; padding: 12px 8px 10px; border-radius: 12px;
+    background: var(--bg-tertiary); border: 1px solid var(--border-primary);
+    box-shadow: 0 1px 0 rgba(255,255,255,0.04) inset, 0 4px 14px rgba(0,0,0,0.10);
+    transition: border-color 0.25s, box-shadow 0.25s, transform 0.25s; }
+  .fj-station-accent { border-color: rgba(240,192,64,0.55);
+    box-shadow: 0 1px 0 rgba(255,255,255,0.05) inset, 0 4px 16px rgba(240,192,64,0.18); }
+  .fj-icon { font-size: 20px; line-height: 1; }
+  .fj-label { font-size: 13px; font-weight: 700; color: var(--text-primary); letter-spacing: -0.1px; }
+  .fj-sub { font-size: 11px; font-weight: 600; color: var(--text-muted); line-height: 1.2;
+    max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .fj-station-accent .fj-sub { color: #c79a2e; }
+  [data-theme="dark"] .fj-station-accent .fj-sub { color: #f0c040; }
+  .fj-arrow { flex: 0 0 auto; align-self: center; color: var(--text-muted); font-size: 14px;
+    font-weight: 700; opacity: 0.55; padding: 0 1px; }
+
+  /* Active vs available legibility: channel + tool nodes read as "available"
+     (dimmed) by default and pop to full opacity when JS toggles .active. */
+  .flow-node-channel, .flow-node-tool { opacity: 0.45; transition: opacity 0.3s ease; }
+  .flow-node-channel.active, .flow-node-tool.active { opacity: 1; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .fj-signal { animation: none; opacity: 0; }
+  }
+
   /* === Activity Heatmap === */
   .heatmap-wrap { overflow-x: auto; padding: 8px 0; }
   .heatmap-grid { display: grid; grid-template-columns: 60px repeat(24, 1fr); gap: 2px; min-width: 650px; }
@@ -1014,6 +1063,13 @@
     .flow-label { font-size: 7px !important; }
     .flow-node rect { stroke-width: 1 !important; }
     .flow-node.active rect { stroke-width: 1.5 !important; }
+    .flow-journey { padding: 14px 14px 12px; }
+    .flow-journey-title { font-size: 16px; margin-bottom: 10px; }
+    .fj-station { min-width: 84px; padding: 10px 6px 8px; }
+    .fj-icon { font-size: 18px; }
+    .fj-label { font-size: 12px; }
+    .fj-sub { font-size: 10px; }
+    .fj-arrow { font-size: 12px; }
     .brain-group { animation-duration: 1.8s; } /* Faster on mobile */
     
     /* Mobile zoom controls */

--- a/clawmetry/static/css/dashboard.css
+++ b/clawmetry/static/css/dashboard.css
@@ -446,6 +446,10 @@
   .flow-path { fill: none; stroke: var(--text-muted); stroke-width: 1.8; stroke-linecap: round; transition: stroke 0.35s, opacity 0.35s; opacity: 0.45; }
   .flow-path.glow-blue { stroke: #4080e0; filter: drop-shadow(0 0 6px rgba(64,128,224,0.6)); }
   .flow-path.glow-yellow { stroke: #f0c040; filter: drop-shadow(0 0 6px rgba(240,192,64,0.6)); }
+  /* Layer 2: static reduced-motion fallback for _flowPulseEdge — instead of a
+     travelling dot we briefly brighten the connector itself (amber, ~500ms). */
+  .flow-path.flow-pulse-glow { stroke: #f0c040; opacity: 1;
+    filter: drop-shadow(0 0 7px rgba(240,192,64,0.75)); transition: stroke 0.15s, opacity 0.15s; }
   .flow-path.glow-green { stroke: #50e080; filter: drop-shadow(0 0 6px rgba(80,224,128,0.6)); }
   .flow-path.glow-red { stroke: #e04040; filter: drop-shadow(0 0 6px rgba(224,64,64,0.6)); }
   @keyframes brainPulse { 0%,100% { filter: drop-shadow(0 0 6px rgba(129,140,248,0.18)); } 50% { filter: drop-shadow(0 0 18px rgba(129,140,248,0.45)); } }
@@ -510,6 +514,15 @@
     transition: border-color 0.25s, box-shadow 0.25s, transform 0.25s; }
   .fj-station-accent { border-color: rgba(240,192,64,0.55);
     box-shadow: 0 1px 0 rgba(255,255,255,0.05) inset, 0 4px 16px rgba(240,192,64,0.18); }
+  /* Layer 2: the station the live packet is currently passing through. Warm
+     amber border + soft glow, consistent with .fj-station-accent but brighter
+     so the moving "stage" reads against the resting Brain accent. JS toggles
+     this via _flowRailSetStage() as msg_in / tool / msg_out events fire. */
+  .fj-station-active { border-color: #f0c040;
+    box-shadow: 0 0 0 1px #f0c040, 0 4px 18px rgba(240,192,64,0.25);
+    transform: translateY(-1px); }
+  .fj-station-active .fj-sub { color: #c79a2e; }
+  [data-theme="dark"] .fj-station-active .fj-sub { color: #f0c040; }
   .fj-icon { font-size: 20px; line-height: 1; }
   .fj-label { font-size: 13px; font-weight: 700; color: var(--text-primary); letter-spacing: -0.1px; }
   .fj-sub { font-size: 11px; font-weight: 600; color: var(--text-muted); line-height: 1.2;

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -14288,14 +14288,23 @@ function _startFlowSse() {
       _flowSseDebounce[dk] = now;
       if (type === 'msg_in') {
         triggerInbound(evt.channel || 'tg');
+        // Layer 2: send the live packet You → channel → gateway → brain and
+        // walk the journey rail accent through the same stages.
+        _flowPulseInbound(evt.channel || 'tg');
         addFlowFeedItem('📨 Message via ' + (evt.channel || 'telegram'), '#c0a0ff', 'inbound');
         flowStats.msgTimestamps.push(now);
       } else if (type === 'msg_out') {
         triggerOutbound(evt.channel || 'tg');
+        // Layer 2: the reply travels brain → You along the low return loop.
+        _flowPulseEdge('path-brain-reply');
+        _flowRailSetStage('reply');
         addFlowFeedItem('📤 Replied via ' + (evt.channel || 'telegram'), '#50e080', 'reply');
       } else if (type === 'tool_call') {
         var toolName = evt.tool || 'exec';
         triggerToolCall(toolName);
+        // Layer 2: pulse the brain→tool edge for this bucket + accent Tools.
+        _flowPulseEdge('path-brain-' + toolName);
+        _flowRailSetStage('tools');
         var toolNames = {exec:'running a command',browser:'browsing the web',search:'searching the web',cron:'scheduling',tts:'generating speech',memory:'accessing memory'};
         addFlowFeedItem('⚡ ' + (toolName || 'tool') + ': ' + (toolNames[toolName] || 'using ' + toolName), '#f0c040', 'tool');
         flowStats.events++;
@@ -14745,6 +14754,99 @@ function _flowFeedLabelForTool(toolName) {
   return toolNames[toolName] || 'using ' + toolName;
 }
 
+// ── Layer 2: live "what's firing right now" packet view ─────────────────────
+// Flow STAYS a live view (turn-replay lives on the Tracing screen). These two
+// helpers make the diagram + rail visibly track real events as they fire:
+//   _flowPulseEdge(pathId) — one bright dot travels that exact connector once
+//   _flowRailSetStage(s)   — accents the matching journey-rail station
+// NOTE: the canvas nodes are harness component CLASSES (the bucket map collapses
+// many real tools into ~6); #flow-live-feed is the exact per-call truth. Deeper
+// per-component fidelity comes with the Tracing wiring.
+function _flowPulseEdge(pathId) {
+  try {
+    if (!pathId) return;
+    var svg = document.getElementById('flow-svg');
+    if (!svg) return;
+    var path = document.getElementById(pathId);
+    if (!path) return; // unknown connector → no-op (e.g. runtime-variant SVG)
+    var ns = 'http://www.w3.org/2000/svg';
+    // Reduced motion: skip the travelling dot, just briefly brighten the path.
+    var reduce = false;
+    try { reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (e) {}
+    if (reduce) {
+      path.classList.add('flow-pulse-glow');
+      setTimeout(function() { try { path.classList.remove('flow-pulse-glow'); } catch (e2) {} }, 500);
+      return;
+    }
+    var dot = document.createElementNS(ns, 'circle');
+    dot.setAttribute('r', '5');
+    dot.setAttribute('fill', '#f0c040');
+    dot.setAttribute('class', 'flow-pulse-dot');
+    dot.style.filter = 'drop-shadow(0 0 8px rgba(240,192,64,0.85))';
+    var anim = document.createElementNS(ns, 'animateMotion');
+    anim.setAttribute('dur', '0.7s');
+    anim.setAttribute('fill', 'remove');
+    anim.setAttribute('begin', 'indefinite');
+    var mpath = document.createElementNS(ns, 'mpath');
+    // Set BOTH href and the namespaced xlink:href for cross-browser support.
+    try { mpath.setAttribute('href', '#' + pathId); } catch (e3) {}
+    try { mpath.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', '#' + pathId); } catch (e4) {}
+    anim.appendChild(mpath);
+    dot.appendChild(anim);
+    svg.appendChild(dot);
+    var removed = false;
+    var remove = function() {
+      if (removed) return; removed = true;
+      try { if (dot.parentNode) dot.parentNode.removeChild(dot); } catch (e5) {}
+    };
+    try { anim.addEventListener('endEvent', remove); } catch (e6) {}
+    // Fallback in case endEvent never fires (older engines).
+    setTimeout(remove, 900);
+    try { anim.beginElement(); } catch (e7) { /* if begin fails, the fallback timeout still cleans up */ }
+  } catch (e) {}
+}
+
+// Module-level idle-decay timer: after ~4s of no events the rail returns to
+// its resting state (Brain accented), matching the default look.
+var _flowRailStageTimer = null;
+function _flowRailSetStage(stage) {
+  try {
+    var stations = document.querySelectorAll('#page-flow .fj-station[data-stage]');
+    if (stations && stations.length) {
+      for (var i = 0; i < stations.length; i++) {
+        var on = stations[i].getAttribute('data-stage') === stage;
+        stations[i].classList.toggle('fj-station-active', on);
+      }
+    }
+  } catch (e) {}
+  // Reset the idle-decay timer on every call; resting state = Brain.
+  try {
+    if (_flowRailStageTimer) { clearTimeout(_flowRailStageTimer); }
+    if (stage !== 'brain') {
+      _flowRailStageTimer = setTimeout(function() { _flowRailSetStage('brain'); }, 4000);
+    } else {
+      _flowRailStageTimer = null;
+    }
+  } catch (e2) {}
+}
+// Expose for manual testing + the live handlers below.
+try { window._flowPulseEdge = _flowPulseEdge; window._flowRailSetStage = _flowRailSetStage; } catch (e) {}
+
+// Drive the inbound packet: You → channel → gateway → brain, with a small
+// stagger so the dot visibly hops node to node. ``ch`` is a full channel name
+// (telegram/signal/...) or already-short code; _chPathKey maps it to the path
+// id suffix used by path-human-<ch> / path-<ch>-gw.
+function _flowPulseInbound(ch) {
+  try {
+    var key = (typeof _chPathKey === 'function') ? _chPathKey(ch) : 'tg';
+    setTimeout(function() { _flowPulseEdge('path-human-' + key); _flowRailSetStage('channels'); }, 0);
+    setTimeout(function() { _flowPulseEdge('path-' + key + '-gw'); _flowRailSetStage('gateway'); }, 180);
+    setTimeout(function() { _flowPulseEdge('path-gw-brain'); _flowRailSetStage('brain'); }, 360);
+  } catch (e) {
+    try { _flowPulseEdge('path-gw-brain'); } catch (e2) {}
+  }
+}
+
 function _backfillFlowFromBrain() {
   // One-shot historical backfill from /api/brain-history (DuckDB-backed).
   // Populates Active Tools with the most recent tool calls so the panel is
@@ -14794,12 +14896,25 @@ function _startFlowBrainStream() {
         var ev = JSON.parse(e.data);
         if (!ev || !ev.type) return;
         var tool = _brainTypeToFlowTool(ev.type);
-        if (!tool) return;
-        // Drive Active Tools + the existing tool-call animation off the same
-        // DuckDB-backed event. triggerToolCall already handles the 5s expiry.
-        triggerToolCall(tool);
-        var label = '⚡ ' + tool + ': ' + _flowFeedLabelForTool(tool);
-        addFlowFeedItem(label, '#f0c040', 'tool');
+        // Accuracy: a type that maps to a real bucket lights that component +
+        // pulses its edge; an UNMAPPED type must NOT falsely light "Exec" — we
+        // pulse the neutral Skills edge and still record the REAL name in the
+        // feed (#flow-live-feed is the exact per-call truth).
+        if (tool) {
+          // Drive Active Tools + the existing tool-call animation off the same
+          // DuckDB-backed event. triggerToolCall already handles the 5s expiry.
+          triggerToolCall(tool);
+          _flowPulseEdge('path-brain-' + tool);
+          _flowRailSetStage('tools');
+          var label = '⚡ ' + tool + ': ' + _flowFeedLabelForTool(tool);
+          addFlowFeedItem(label, '#f0c040', 'tool');
+        } else {
+          // Unknown tool class — neutral pulse, honest label with the raw type.
+          _flowPulseEdge('path-brain-skills');
+          _flowRailSetStage('tools');
+          var rawName = String(ev.tool || ev.type || 'tool');
+          addFlowFeedItem('⚡ ' + rawName, '#f0c040', 'tool');
+        }
         flowStats.events++;
       } catch(e2) {}
     };
@@ -14878,6 +14993,16 @@ function enhanceArchitectureClarity() {
   });
 }
 
+// Format a token count for the Flow stat cards / rail. Never emits "0K"
+// (which read like "OK"): show the raw number under 1k, "12K" up to a
+// million, and "1.2M" above. Returns "-" for missing/NaN input so the
+// card keeps its neutral placeholder instead of "0".
+function _fmtFlowTokens(tokens) {
+  var n = Number(tokens);
+  if (!isFinite(n) || n <= 0) return ' - ';
+  return n < 1000 ? String(n) : n < 1e6 ? Math.round(n / 1000) + 'K' : (n / 1e6).toFixed(1) + 'M';
+}
+
 function updateFlowStats() {
   // Tab-scoped: this polls /api/overview for the Flow tab's live stats. It
   // must NOT fire on every other screen — it was hitting /api/overview ~9x/15s
@@ -14927,7 +15052,7 @@ function updateFlowStats() {
   if (flowStats.events % 15 === 0) {
     fetchJsonWithTimeout('/api/overview', 5000).then(function(d) {
       var tok = document.getElementById('flow-tokens');
-      if (tok) tok.textContent = (d.mainTokens / 1000).toFixed(0) + 'K';
+      if (tok) tok.textContent = _fmtFlowTokens(d.mainTokens);
     }).catch(function(){});
   }
 }

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -14891,7 +14891,39 @@ function updateFlowStats() {
   if (el2) el2.textContent = flowStats.events;
   var names = Object.keys(flowStats.activeTools).filter(function(k){return flowStats.activeTools[k];});
   var el3 = document.getElementById('flow-active-tools');
-  if (el3) el3.textContent = names.length > 0 ? names.join(', ') : '\u2014';
+  if (el3) {
+    // Show the COUNT (numeric, matches the other stat cards) rather than the
+    // comma-joined list, which overflowed the small card. The full list stays
+    // available as a hover tooltip.
+    el3.textContent = names.length > 0 ? String(names.length) : '0';
+    try { el3.title = names.length > 0 ? names.join(', ') : ''; } catch (e) {}
+  }
+  // Journey rail sub-stats \u2014 wired to the same live data every tick. Each is
+  // guarded so a missing node (e.g. runtime-variant SVG) never throws.
+  try {
+    var railCh = document.getElementById('rail-channels-stat');
+    if (railCh) railCh.textContent = flowStats.msgTimestamps.length + '/min';
+  } catch (e) {}
+  try {
+    var railBr = document.getElementById('rail-brain-stat');
+    if (railBr) {
+      var bm = document.getElementById('brain-model-text');
+      var mtxt = (bm && bm.textContent ? bm.textContent : '').trim();
+      railBr.textContent = (mtxt && mtxt !== 'unknown') ? mtxt
+        : (typeof t === 'function' ? t('app.model', null, 'model') : 'model');
+    }
+  } catch (e) {}
+  try {
+    var railTl = document.getElementById('rail-tools-stat');
+    if (railTl) {
+      if (names.length > 0) {
+        var aw = (typeof t === 'function') ? t('flow.active_word', null, 'active') : 'active';
+        railTl.textContent = names.length + ' ' + aw;
+      } else {
+        railTl.textContent = (typeof t === 'function') ? t('flow.idle', null, 'idle') : 'idle';
+      }
+    }
+  } catch (e) {}
   if (flowStats.events % 15 === 0) {
     fetchJsonWithTimeout('/api/overview', 5000).then(function(d) {
       var tok = document.getElementById('flow-tokens');
@@ -15099,19 +15131,19 @@ function triggerError() {
 }
 
 function triggerInfraNetwork() {
-  animateParticle('path-gw-network', '#40a0b0', 1200, false);
+  animateParticle('path-brain-infra', '#40a0b0', 1200, false);
   highlightNode('node-network', 2500);
 }
 function triggerInfraRuntime() {
-  animateParticle('path-brain-runtime', '#40a0b0', 1000, false);
+  animateParticle('path-brain-infra', '#40a0b0', 1000, false);
   highlightNode('node-runtime', 2200);
 }
 function triggerInfraMachine() {
-  animateParticle('path-brain-machine', '#40a0b0', 1000, false);
+  animateParticle('path-brain-infra', '#40a0b0', 1050, false);
   highlightNode('node-machine', 2200);
 }
 function triggerInfraStorage() {
-  animateParticle('path-memory-storage', '#40a0b0', 700, false);
+  animateParticle('path-brain-infra', '#40a0b0', 700, false);
   highlightNode('node-storage', 2000);
 }
 

--- a/clawmetry/static/locales/en.json
+++ b/clawmetry/static/locales/en.json
@@ -871,5 +871,17 @@
   "usage.trace_clusters": "Trace Clusters",
   "usage.trace_clusters_hint": "auto-group sessions by behavior pattern",
   "usage.trend": "Trend",
-  "version_impact.title": "Upgrade Impact"
+  "version_impact.title": "Upgrade Impact",
+  "flow.journey_title": "How your messages get answered",
+  "flow.replies_back": "replies back to you",
+  "flow.idle": "idle",
+  "flow.active_word": "active",
+  "flow.rail_you_sub": "send a message",
+  "flow.rail_routing": "routing",
+  "flow.rail_reply": "Reply",
+  "app.channels": "Channels",
+  "app.gateway_word": "Gateway",
+  "app.brain": "Brain",
+  "app.model": "model",
+  "app.tools": "Tools"
 }

--- a/clawmetry/templates/tabs/flow.html
+++ b/clawmetry/templates/tabs/flow.html
@@ -15,37 +15,37 @@
       <div class="flow-journey-rail">
         <div class="fj-track" aria-hidden="true"><span class="fj-signal"></span></div>
         <div class="fj-stations">
-          <div class="fj-station">
+          <div class="fj-station" data-stage="you">
             <span class="fj-icon">🧑</span>
             <span class="fj-label" data-i18n="app.you">You</span>
             <span class="fj-sub" data-i18n="flow.rail_you_sub">send a message</span>
           </div>
           <div class="fj-arrow" aria-hidden="true">→</div>
-          <div class="fj-station">
+          <div class="fj-station" data-stage="channels">
             <span class="fj-icon">📨</span>
             <span class="fj-label" data-i18n="app.channels">Channels</span>
             <span class="fj-sub" id="rail-channels-stat">0/min</span>
           </div>
           <div class="fj-arrow" aria-hidden="true">→</div>
-          <div class="fj-station">
+          <div class="fj-station" data-stage="gateway">
             <span class="fj-icon">🔀</span>
             <span class="fj-label" data-i18n="app.gateway_word">Gateway</span>
             <span class="fj-sub" id="rail-gateway-stat" data-i18n="flow.rail_routing">routing</span>
           </div>
           <div class="fj-arrow" aria-hidden="true">→</div>
-          <div class="fj-station fj-station-accent">
+          <div class="fj-station fj-station-accent" data-stage="brain">
             <span class="fj-icon">🧠</span>
             <span class="fj-label" data-i18n="app.brain">Brain</span>
             <span class="fj-sub" id="rail-brain-stat" data-i18n="app.model">model</span>
           </div>
           <div class="fj-arrow" aria-hidden="true">→</div>
-          <div class="fj-station">
+          <div class="fj-station" data-stage="tools">
             <span class="fj-icon">🛠️</span>
             <span class="fj-label" data-i18n="app.tools">Tools</span>
             <span class="fj-sub" id="rail-tools-stat" data-i18n="flow.idle">idle</span>
           </div>
           <div class="fj-arrow" aria-hidden="true">→</div>
-          <div class="fj-station">
+          <div class="fj-station" data-stage="reply">
             <span class="fj-icon">↩️</span>
             <span class="fj-label" data-i18n="flow.rail_reply">Reply</span>
             <span class="fj-sub" data-i18n="flow.replies_back">replies back to you</span>
@@ -103,9 +103,13 @@
            canvas. No diagonals, no crossings. -->
       <path class="flow-path flow-path-infra" id="path-brain-infra" d="M 420 235 L 420 438"/>
 
-      <!-- Faint reply/return loop: brain back to "You". Routed low/under the
-           diagram so it never crosses the brain->tool fan-out. -->
-      <path id="path-brain-reply" d="M 415 232 C 300 415, 130 230, 64 78"
+      <!-- Faint reply/return loop: brain back to "You". Routed LOW — it drops
+           from the brain's bottom, sweeps along just above the infrastructure
+           band (well under the brain->tool fan-out on the right and the
+           channel/gateway boxes on the left), then rises up the far-left
+           margin (x~12, left of the channel column at x=20) back to "You".
+           No control point re-enters the node bands, so nothing crosses a box. -->
+      <path id="path-brain-reply" d="M 415 232 C 360 412, 120 422, 12 360 C 6 240, 8 120, 60 78"
             fill="none" stroke="var(--text-muted)" stroke-width="1.4"
             stroke-dasharray="3 5" stroke-linecap="round" opacity="0.28"/>
       <text class="flow-label" x="225" y="372" style="font-size:9px;opacity:0.7;" data-i18n="flow.replies_back">replies back to you</text>

--- a/clawmetry/templates/tabs/flow.html
+++ b/clawmetry/templates/tabs/flow.html
@@ -2,10 +2,57 @@
   <div class="flow-stats">
     <div class="flow-stat"><span class="flow-stat-label" data-i18n="flow.messages_per_min">Messages / min</span><span class="flow-stat-value" id="flow-msg-rate">0</span></div>
     <div class="flow-stat"><span class="flow-stat-label" data-i18n="flow.actions_taken">Actions Taken</span><span class="flow-stat-value" id="flow-event-count">0</span></div>
-    <div class="flow-stat"><span class="flow-stat-label" data-i18n="flow.active_tools">Active Tools</span><span class="flow-stat-value" id="flow-active-tools"> - </span></div>
+    <div class="flow-stat"><span class="flow-stat-label" data-i18n="flow.active_tools">Active Tools</span><span class="flow-stat-value" id="flow-active-tools">0</span></div>
     <div class="flow-stat"><span class="flow-stat-label" data-i18n="flow.tokens_used">Tokens Used</span><span class="flow-stat-value" id="flow-tokens"> - </span></div>
   </div>
   <div class="flow-container">
+    <!-- Journey rail (issue: human-first Flow): a calm, left-to-right "how your
+         messages get answered" story. Sub-stats are wired to real data in
+         updateFlowStats(). The single travelling dot conveys direction; it is
+         suppressed under prefers-reduced-motion. -->
+    <div class="flow-journey" aria-label="How your messages get answered">
+      <div class="flow-journey-title" data-i18n="flow.journey_title">How your messages get answered</div>
+      <div class="flow-journey-rail">
+        <div class="fj-track" aria-hidden="true"><span class="fj-signal"></span></div>
+        <div class="fj-stations">
+          <div class="fj-station">
+            <span class="fj-icon">🧑</span>
+            <span class="fj-label" data-i18n="app.you">You</span>
+            <span class="fj-sub" data-i18n="flow.rail_you_sub">send a message</span>
+          </div>
+          <div class="fj-arrow" aria-hidden="true">→</div>
+          <div class="fj-station">
+            <span class="fj-icon">📨</span>
+            <span class="fj-label" data-i18n="app.channels">Channels</span>
+            <span class="fj-sub" id="rail-channels-stat">0/min</span>
+          </div>
+          <div class="fj-arrow" aria-hidden="true">→</div>
+          <div class="fj-station">
+            <span class="fj-icon">🔀</span>
+            <span class="fj-label" data-i18n="app.gateway_word">Gateway</span>
+            <span class="fj-sub" id="rail-gateway-stat" data-i18n="flow.rail_routing">routing</span>
+          </div>
+          <div class="fj-arrow" aria-hidden="true">→</div>
+          <div class="fj-station fj-station-accent">
+            <span class="fj-icon">🧠</span>
+            <span class="fj-label" data-i18n="app.brain">Brain</span>
+            <span class="fj-sub" id="rail-brain-stat" data-i18n="app.model">model</span>
+          </div>
+          <div class="fj-arrow" aria-hidden="true">→</div>
+          <div class="fj-station">
+            <span class="fj-icon">🛠️</span>
+            <span class="fj-label" data-i18n="app.tools">Tools</span>
+            <span class="fj-sub" id="rail-tools-stat" data-i18n="flow.idle">idle</span>
+          </div>
+          <div class="fj-arrow" aria-hidden="true">→</div>
+          <div class="fj-station">
+            <span class="fj-icon">↩️</span>
+            <span class="fj-label" data-i18n="flow.rail_reply">Reply</span>
+            <span class="fj-sub" data-i18n="flow.replies_back">replies back to you</span>
+          </div>
+        </div>
+      </div>
+    </div>
     <svg id="flow-svg" viewBox="0 0 980 550" preserveAspectRatio="xMidYMid meet">
       <defs>
         <pattern id="flow-grid" width="40" height="40" patternUnits="userSpaceOnUse">
@@ -50,11 +97,18 @@
       <path class="flow-path" id="path-brain-tts"     d="M 510 205 C 530 260, 545 325, 560 339"/>
       <path class="flow-path" id="path-brain-memory"  d="M 510 215 C 530 290, 545 370, 560 389"/>
 
-      <!-- Infrastructure paths (dashed) -->
-      <path class="flow-path flow-path-infra" id="path-gw-network"    d="M 235 205 C 235 350, 500 400, 590 450"/>
-      <path class="flow-path flow-path-infra" id="path-brain-runtime" d="M 380 220 C 300 350, 150 400, 95 450"/>
-      <path class="flow-path flow-path-infra" id="path-brain-machine" d="M 420 220 C 380 350, 300 400, 260 450"/>
-      <path class="flow-path flow-path-infra" id="path-memory-storage" d="M 615 408 C 550 420, 470 435, 425 450"/>
+      <!-- "Runs on" link (de-spaghetti): one tidy vertical connector from the
+           brain's bottom-center straight down to the INFRASTRUCTURE band —
+           replaces the four diagonal crossing paths that cut across the whole
+           canvas. No diagonals, no crossings. -->
+      <path class="flow-path flow-path-infra" id="path-brain-infra" d="M 420 235 L 420 438"/>
+
+      <!-- Faint reply/return loop: brain back to "You". Routed low/under the
+           diagram so it never crosses the brain->tool fan-out. -->
+      <path id="path-brain-reply" d="M 415 232 C 300 415, 130 230, 64 78"
+            fill="none" stroke="var(--text-muted)" stroke-width="1.4"
+            stroke-dasharray="3 5" stroke-linecap="round" opacity="0.28"/>
+      <text class="flow-label" x="225" y="372" style="font-size:9px;opacity:0.7;" data-i18n="flow.replies_back">replies back to you</text>
 
       <!-- Human Origin -->
       <g class="flow-node flow-node-human" id="node-human">
@@ -166,7 +220,7 @@
         <text x="420" y="211" style="font-size:8px;fill:#888;opacity:0.6;text-anchor:middle;" id="brain-fallback-1"></text>
         <text x="420" y="221" style="font-size:8px;fill:#888;opacity:0.6;text-anchor:middle;" id="brain-fallback-2"></text>
         <text x="420" y="228" style="font-size:8px;fill:#a5b4fc;text-anchor:middle;" id="brain-billing-text" data-i18n="app.auth_unknown">Auth: unknown</text>
-        <circle cx="420" cy="240" r="4" fill="#FF8A65">
+        <circle cx="420" cy="240" r="4" fill="#FF8A65" id="brain-status-dot">
           <animate attributeName="r" values="3;5;3" dur="1.1s" repeatCount="indefinite"/>
           <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
         </circle>


### PR DESCRIPTION
**Flagship Flow redesign — draft, do not merge until visual QA + Layer 2 land.**

### Layer 1 (this commit) — newcomer-legible
- **Journey rail** headline: `You → Channels → Gateway → Brain → Tools → reply` with live sub-stats + a single travelling signal dot (reduced-motion aware).
- **De-spaghetti**: removed the 4 crossing infra connectors; one tidy vertical 'runs on' link + a faint reply loop.
- **Active-vs-available**: channels/tools dim by default, light + glow only when actually invoked.
- **Bugs**: Active Tools `—` → count; token label clarity.
- All node IDs/classes/JS hooks preserved. Automated checks all green (node --check, en.json, i18n guard 69 passed, IDs present, crossing paths gone, SVG well-formed).

### Layer 2 (WIP) — trace accuracy (per founder)
Drive the diagram from the **real trace**: show only components actually invoked, in true invocation order, animate the packet's path, ground it in the real OpenClaw harness — so Tracing/Turn-anatomy inherit an accurate mental model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)