### PR TITLE
feat: 30-day session activity heatmap on Overview tab

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2819,6 +2819,7 @@ async function loadAll() {
     if (typeof loadHeartbeat === 'function') loadHeartbeat().catch(function(e){console.warn('heartbeat panel failed',e)});
     if (typeof loadAutonomy === 'function') setTimeout(function(){ loadAutonomy().catch(function(e){console.warn('autonomy failed',e)}); }, 2600);
     if (typeof loadAnomalyPanel === 'function') setTimeout(function(){ loadAnomalyPanel().catch(function(e){console.warn('anomaly panel failed',e)}); }, 3600);
+    if (typeof loadActivityHeatmap === 'function') setTimeout(function(){ loadActivityHeatmap().catch(function(e){console.warn('activity heatmap failed',e)}); }, 4500);
     // Issue #1614 — outcome tile (Today: N tasks, X% success).
     if (typeof loadOutcomeTile === 'function') setTimeout(function(){ loadOutcomeTile().catch(function(e){console.warn('outcome tile failed',e)}); }, 800);
     document.getElementById('refresh-time').textContent = t("app.updated", null, "Updated ") + new Date().toLocaleTimeString();
@@ -11055,6 +11056,32 @@ async function loadSandboxStatus() {
   } catch(e) {
     console.warn('loadSandboxStatus failed', e);
   }
+}
+
+// ===== 30-day Session Activity Heatmap (#875) =====
+async function loadActivityHeatmap() {
+  var card = document.getElementById('activity-heatmap-card');
+  var grid = document.getElementById('activity-heatmap-grid');
+  if (!card || !grid) return;
+  var data;
+  try { data = await fetchJsonWithTimeout('/api/activity-heatmap', 5000); } catch(e) { return; }
+  var days = (data && data.days) || [];
+  if (!days.length) return;
+  var maxSessions = Math.max.apply(null, days.map(function(d){ return d.sessions || 0; }));
+  var shades = ['#12122a','#1a3a2a','#2a6a3a','#4a9a2a','#6adb3a'];
+  var html = '';
+  days.forEach(function(day) {
+    var s = day.sessions || 0;
+    var idx = (maxSessions > 0 && s > 0) ? Math.min(4, Math.ceil(s / maxSessions * 4)) : 0;
+    var tooltip = day.label + ': ' + s + ' session' + (s !== 1 ? 's' : '')
+      + ', ' + (day.tokens || 0).toLocaleString() + ' tokens'
+      + (day.cost > 0 ? ', $' + day.cost.toFixed(4) : '');
+    html += '<div class="heatmap-cell" style="background:' + shades[idx] + ';" title="' + tooltip + '"></div>';
+  });
+  grid.innerHTML = html;
+  var legend = document.getElementById('activity-heatmap-legend');
+  if (legend) legend.innerHTML = 'Less <div class="heatmap-legend-cell" style="background:#12122a"></div><div class="heatmap-legend-cell" style="background:#1a3a2a"></div><div class="heatmap-legend-cell" style="background:#2a6a3a"></div><div class="heatmap-legend-cell" style="background:#4a9a2a"></div><div class="heatmap-legend-cell" style="background:#6adb3a"></div> More';
+  card.style.display = '';
 }
 
 // ===== Activity Heatmap =====

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -497,6 +497,13 @@
     </style>
   </div>
 
+  <!-- 30-day session activity heatmap (#875) -->
+  <div id="activity-heatmap-card" style="background:var(--bg-secondary);border:2px solid var(--border-primary);border-radius:12px;padding:14px 22px;margin-bottom:14px;box-shadow:var(--card-shadow);display:none;">
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:10px;">&#128197; 30-day Activity</div>
+    <div id="activity-heatmap-grid" style="display:grid;grid-template-columns:repeat(30,1fr);gap:3px;"></div>
+    <div class="heatmap-legend" id="activity-heatmap-legend"></div>
+  </div>
+
   <!-- Renderer for the overview heartbeat card (#686). Reads the `heartbeat`
        block injected by /api/overview and updates the inline panel. Lives in
        the template (not app.js) so the card is fully self-contained. -->

--- a/routes/overview.py
+++ b/routes/overview.py
@@ -1670,6 +1670,40 @@ def api_prompt_errors():
     return jsonify({"errors": errors, "count": len(errors)})
 
 
+@bp_overview.route("/api/activity-heatmap")
+def api_activity_heatmap():
+    """30-day session activity heatmap data (#875)."""
+    from datetime import datetime, timedelta
+
+    now = datetime.now()
+    cutoff = (now - timedelta(days=29)).strftime("%Y-%m-%d") + "T00:00:00"
+    rows = _ls_call("query_sessions", since=cutoff, limit=10000) or []
+
+    day_sessions: dict = {}
+    day_tokens: dict = {}
+    day_cost: dict = {}
+    for row in rows:
+        started = (row.get("started_at") or "")[:10]
+        if not started:
+            continue
+        day_sessions[started] = day_sessions.get(started, 0) + 1
+        day_tokens[started] = day_tokens.get(started, 0) + int(row.get("token_count") or 0)
+        day_cost[started] = day_cost.get(started, 0) + float(row.get("cost_usd") or 0)
+
+    days = []
+    for i in range(29, -1, -1):
+        d = now - timedelta(days=i)
+        ds = d.strftime("%Y-%m-%d")
+        days.append({
+            "date": ds,
+            "label": d.strftime("%b ") + str(d.day),
+            "sessions": day_sessions.get(ds, 0),
+            "tokens": day_tokens.get(ds, 0),
+            "cost": round(day_cost.get(ds, 0), 4),
+        })
+    return jsonify({"days": days})
+
+
 @bp_overview.route("/api/cloud-cta/status")
 def cloud_cta_status():
     import dashboard as _d


### PR DESCRIPTION
Closes #875

## Summary

- **`routes/overview.py`** — new `GET /api/activity-heatmap` endpoint: reads sessions from DuckDB via `_ls_call("query_sessions", since=cutoff, limit=10000)`, groups by calendar day (`started_at[:10]`), returns `[{date, label, sessions, tokens, cost}]` for the last 30 days. No schema changes, no new deps.
- **`clawmetry/templates/tabs/overview.html`** — new "📅 30-day Activity" card appended before the heartbeat script block; reuses existing `.heatmap-cell` and `.heatmap-legend-cell` CSS classes from `dashboard.css`.
- **`clawmetry/static/js/app.js`** — new `loadActivityHeatmap()` async function: 5-shade green intensity scale (darkest = no sessions, brightest = busiest day), hover tooltip showing date / session count / tokens / cost. Wired into `loadAll()` as a non-blocking secondary panel at 4.5s delay (same pattern as `loadAnomalyPanel`).

## Test plan

- [ ] `GET /api/activity-heatmap` returns `{"days": [...30 items...]}`, each with `date` (YYYY-MM-DD), `label` (e.g. "May 5"), `sessions` (int ≥ 0), `tokens` (int), `cost` (float)
- [ ] Overview tab shows a row of 30 coloured squares — darkest on empty days, progressively greener on busier days
- [ ] Tooltip on each cell shows correct date, session count, tokens, and cost
- [ ] Workspace with no sessions: all cells rendered dark, no JS console errors
- [ ] `python3 -c 'import ast; ast.parse(open("routes/overview.py").read())'` passes

https://claude.ai/code/session_01K1PAXmvtsbjJ6PeVXpug6c

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1PAXmvtsbjJ6PeVXpug6c)_