### PR TITLE
feat(health): expose daemon_error_rate_per_min on /api/system-health (#1133)

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -1327,6 +1327,9 @@ def api_system_health():
             "security": _d._detect_security_metadata(),
             "service_status": service_status,
             "daemon": daemon_health,
+            "daemon_error_rate_per_min": round(
+                daemon_health.get("errors_last_5min", 0) / 5.0, 2
+            ),
             "gateway": gateway_health,
             # Issue #1310 follow-up — per-provider channel ingest summary
             # so operators see whether the gateway WS tap is actually

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -471,6 +471,22 @@ class TestHeartbeatStatus:
         assert "resources" in ss
         assert ss["resources"] in ("ok", "warn", "critical")
 
+    def test_system_health_includes_daemon_error_rate_per_min(self, api, base_url):
+        """system-health returns daemon_error_rate_per_min (PRD #1133 layer 4)."""
+        d = assert_ok(get(api, base_url, "/api/system-health"))
+        assert "daemon_error_rate_per_min" in d, (
+            "system-health must include daemon_error_rate_per_min"
+        )
+        rate = d["daemon_error_rate_per_min"]
+        assert isinstance(rate, (int, float)), "daemon_error_rate_per_min must be numeric"
+        assert rate >= 0, "daemon_error_rate_per_min must be non-negative"
+        # Must equal daemon.errors_last_5min / 5 (the source window)
+        daemon = d.get("daemon", {})
+        expected = round(daemon.get("errors_last_5min", 0) / 5.0, 2)
+        assert rate == expected, (
+            f"daemon_error_rate_per_min {rate} != daemon.errors_last_5min/5 {expected}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Heartbeat Liveness Panel (#686)


### PR DESCRIPTION
## Summary

PRD #1133 Layer 4 specified that `/api/system-health` should expose a `daemon_error_rate_per_min` top-level field so operators and monitoring scripts can read the daemon error rate at a glance. The underlying `compute_daemon_health()` already collects `errors_last_5min` via DuckDB (with sync.log fallback) — this PR adds the convenience rate field alongside the existing `daemon` block.

## Changes

- `routes/health.py` — add `"daemon_error_rate_per_min": round(daemon_health.get("errors_last_5min", 0) / 5.0, 2)` to the `return jsonify(...)` dict in `api_system_health` (~3 lines)
- `tests/test_api.py` — add `test_system_health_includes_daemon_error_rate_per_min` to `TestHeartbeatStatus`, asserting the field is present, is a non-negative float, and equals `daemon.errors_last_5min / 5` (~15 lines)

## Test plan

- [ ] `python3 -m pytest tests/test_daemon_health_endpoint.py tests/test_api.py::TestHeartbeatStatus -q` — all pass (20 daemon health unit tests green locally)
- [ ] Verify `curl http://localhost:8900/api/system-health | python3 -m json.tool | grep daemon_error_rate_per_min` returns the field
- [ ] Confirm field is `0.0` on a clean install (no daemon errors expected)

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #1133. Marked draft for human review — mark Ready for Review once happy.

Closes #1133

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfCYiHYsG7HuUFPTm2yPew)_