### PR TITLE
C6: apply required checks via GITHUB_TOKEN (no PAT needed for clawmetry)

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -3,9 +3,12 @@ name: Apply required E2E status checks (C6 -- one-shot)
 # Runs scripts/apply_required_status_checks.py from the GitHub Actions UI
 # so the admin does not need a local Python environment.
 #
-# Prerequisite: add repo secret E2E_ADMIN_PAT containing a fine-grained PAT
-# with Administration (read + write) on all three repos:
-#   vivekchand/clawmetry, vivekchand/clawmetry-cloud, vivekchand/clawmetry-landing
+# When E2E_ADMIN_PAT is set: applies required checks across all three repos
+#   (vivekchand/clawmetry, vivekchand/clawmetry-cloud, vivekchand/clawmetry-landing).
+# When E2E_ADMIN_PAT is NOT set: falls back to GITHUB_TOKEN, which has
+#   Administration write access on THIS repo only (vivekchand/clawmetry).
+#   For clawmetry-cloud and clawmetry-landing, run the equivalent workflow
+#   in each of those repos.
 #
 # First run with confirm=dry-run to preview, then confirm=APPLY to apply.
 # Running multiple times is safe: the underlying script is idempotent.
@@ -16,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type APPLY to configure all 3 repos (anything else = dry run)"
+        description: "Type APPLY to configure repos (anything else = dry run)"
         required: true
         default: "dry-run"
 
@@ -24,6 +27,8 @@ jobs:
   apply-required-checks:
     name: Apply required E2E status checks (C6)
     runs-on: ubuntu-latest
+    permissions:
+      administration: write
     steps:
       - uses: actions/checkout@v4
 
@@ -32,15 +37,26 @@ jobs:
         run: |
           echo "=== DRY RUN -- checks that will be added when confirm=APPLY ==="
           echo ""
-          echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
-          echo "  clawmetry         : Cross-repo handoff (C4)"
-          echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
-          echo "  clawmetry-landing : Landing golden path (C3)"
+          if [ -z "${{ secrets.E2E_ADMIN_PAT }}" ]; then
+            echo "  Using GITHUB_TOKEN (no E2E_ADMIN_PAT set) -- clawmetry only:"
+            echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
+            echo "  clawmetry         : Cross-repo handoff (C4)"
+            echo ""
+            echo "  For the remaining repos, run the equivalent workflow in each:"
+            echo "  clawmetry-cloud   : Cloud golden-path browser E2E  (needs E2E_ADMIN_PAT or own workflow)"
+            echo "  clawmetry-landing : Landing golden path (C3)        (needs E2E_ADMIN_PAT or own workflow)"
+          else
+            echo "  Using E2E_ADMIN_PAT -- applying to all 3 repos:"
+            echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
+            echo "  clawmetry         : Cross-repo handoff (C4)"
+            echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
+            echo "  clawmetry-landing : Landing golden path (C3)"
+          fi
           echo ""
           echo "Re-run with confirm=APPLY to apply."
 
       - name: Apply required status checks
         if: github.event.inputs.confirm == 'APPLY'
         env:
-          GITHUB_TOKEN: ${{ secrets.E2E_ADMIN_PAT }}
+          GITHUB_TOKEN: ${{ secrets.E2E_ADMIN_PAT || github.token }}
         run: python3 scripts/apply_required_status_checks.py

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -9,6 +9,14 @@ Usage
 -----
   GITHUB_TOKEN=ghp_xxx python3 scripts/apply_required_status_checks.py
 
+When run inside GitHub Actions, GITHUB_REPOSITORY is set automatically
+(e.g. "vivekchand/clawmetry"). The script restricts the checks it applies
+to only the matching repo so that a GITHUB_TOKEN with single-repo
+Administration write access is sufficient.
+
+When run locally (GITHUB_REPOSITORY not set), the script applies all 4
+checks and requires a token with cross-repo Administration access.
+
 Requirements
 ------------
 A fine-grained PAT (or classic token) with:
@@ -115,6 +123,39 @@ def add_required_check(repo: str, context: str, token: str) -> None:
     print(f"  [{repo}] added required check ({len(existing)} total): {context!r}")
 
 
+def _checks_to_apply() -> list[tuple[str, str]]:
+    """Return the subset of REQUIRED_CHECKS applicable to the current context.
+
+    Inside GitHub Actions, GITHUB_REPOSITORY is set to "owner/repo". When it
+    matches one of the repos in REQUIRED_CHECKS, only that repo's checks are
+    returned so that a single-repo GITHUB_TOKEN is sufficient.
+
+    When GITHUB_REPOSITORY is not set (local run with a cross-repo PAT),
+    all checks are returned.
+    """
+    github_repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if not github_repository:
+        return REQUIRED_CHECKS
+
+    # Extract the repo name (strip owner prefix if present)
+    current_repo = github_repository.split("/", 1)[-1]
+    filtered = [(repo, ctx) for repo, ctx in REQUIRED_CHECKS if repo == current_repo]
+    if filtered:
+        print(
+            f"  Scope: GITHUB_REPOSITORY={github_repository!r} -- "
+            f"applying {len(filtered)} check(s) for {current_repo!r} only"
+        )
+        return filtered
+
+    # GITHUB_REPOSITORY is set but doesn't match any entry -- apply all and
+    # let the API calls fail with a clear error if the token lacks access.
+    print(
+        f"  Warning: GITHUB_REPOSITORY={github_repository!r} did not match any "
+        "entry in REQUIRED_CHECKS; applying all checks."
+    )
+    return REQUIRED_CHECKS
+
+
 def main() -> None:
     token = os.environ.get("GITHUB_TOKEN", "").strip()
     if not token:
@@ -123,8 +164,10 @@ def main() -> None:
             "Usage: GITHUB_TOKEN=ghp_xxx python3 scripts/apply_required_status_checks.py"
         )
 
-    print("=== E2E Robustness C6: applying required status checks ===")
-    for repo, context in REQUIRED_CHECKS:
+    checks = _checks_to_apply()
+    total = len(checks)
+    print(f"=== E2E Robustness C6: applying {total} required status check(s) ===")
+    for repo, context in checks:
         try:
             add_required_check(repo, context, token)
         except RuntimeError as exc:
@@ -132,10 +175,18 @@ def main() -> None:
             sys.exit(1)
 
     print()
-    print("=== All 4 E2E checks are now required on main ===")
+    print(f"=== {total} E2E check(s) are now required on main ===")
+
+    if total < len(REQUIRED_CHECKS):
+        print()
+        print(
+            "Note: to apply checks in other repos, run the equivalent workflow "
+            "in clawmetry-cloud and clawmetry-landing."
+        )
+
     print()
     print("Verify at:")
-    for repo in dict.fromkeys(r for r, _ in REQUIRED_CHECKS):
+    for repo in dict.fromkeys(r for r, _ in checks):
         print(f"  https://github.com/{OWNER}/{repo}/settings/branches")
 
 


### PR DESCRIPTION
## Summary

- Fixes the RED C6 criterion (vivekchand/clawmetry#2146) for the clawmetry repo without requiring a cross-repo admin PAT.
- Adds `permissions: administration: write` at the job level so `GITHUB_TOKEN` can modify branch protection on this same repo.
- Changes the token expression to `${{ secrets.E2E_ADMIN_PAT || github.token }}` -- when the PAT is absent, the built-in token is used and the script automatically scopes itself to clawmetry-only checks.
- Updates the dry-run step to clearly explain which checks will be applied depending on whether `E2E_ADMIN_PAT` is set or not.
- Adds `_checks_to_apply()` to `scripts/apply_required_status_checks.py`: reads `GITHUB_REPOSITORY` (set automatically by GitHub Actions) and filters `REQUIRED_CHECKS` to only the current repo when running in CI; local runs with a full PAT continue to apply all 4 checks unchanged.
- Prints a note after a partial apply reminding the operator to run the equivalent workflow in clawmetry-cloud and clawmetry-landing.

## Test plan

- [ ] Trigger the workflow with `confirm=dry-run` and no `E2E_ADMIN_PAT` secret -- verify the dry-run echo lists only clawmetry checks and mentions the other repos.
- [ ] Trigger with `confirm=APPLY` and no `E2E_ADMIN_PAT` -- verify the two clawmetry checks (OSS golden path + Cross-repo handoff) are added to branch protection on main using GITHUB_TOKEN.
- [ ] Verify no error about missing token permissions (the `administration: write` permission grants access).
- [ ] Run `GITHUB_TOKEN=ghp_xxx python3 scripts/apply_required_status_checks.py` locally (no `GITHUB_REPOSITORY` set) -- verify all 4 checks are attempted as before.
- [ ] Confirm the script is idempotent: a second APPLY run reports "already required" for each check.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01WAGE59GgfescMmjrjM4oZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAGE59GgfescMmjrjM4oZo)_