### PR TITLE
fix: external API call tracing (interceptor → DuckDB → /api/local/external-calls)

### DIFF
--- a/clawmetry/interceptor.py
+++ b/clawmetry/interceptor.py
@@ -38,6 +38,24 @@ _LLM_URL_PATTERNS = [
     "openrouter.ai",
 ]
 
+# Hosts to exclude from external-API capture (noise / internal traffic).
+# User can extend via CLAWMETRY_INTERCEPT_HOSTS_EXCLUDE=host1,host2 (substring).
+_EXCLUDED_HOST_DEFAULTS = frozenset([
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "169.254.",        # link-local / AWS metadata
+    "::1",
+    # LLM providers already tracked as llm_call
+    "api.anthropic.com",
+    "api.openai.com",
+    "generativelanguage.googleapis.com",
+    "openrouter.ai",
+    # ClawMetry infra — don't capture our own sync calls
+    "ingest.clawmetry.com",
+    "app.clawmetry.com",
+])
+
 
 # Output file — in OpenClaw dir so ClawMetry sync picks it up
 def _get_output_file() -> Path:
@@ -110,6 +128,43 @@ def _is_llm_url(url: str) -> bool:
         return False
     url_lower = url.lower()
     return any(pattern in url_lower for pattern in _LLM_URL_PATTERNS)
+
+
+def _is_excluded_host(url: str) -> bool:
+    """Return True if the URL should be silently skipped for external-call capture."""
+    if not url:
+        return True
+    url_lower = url.lower()
+    if any(h in url_lower for h in _EXCLUDED_HOST_DEFAULTS):
+        return True
+    extra = os.environ.get("CLAWMETRY_INTERCEPT_HOSTS_EXCLUDE", "").strip()
+    if extra:
+        for part in extra.split(","):
+            part = part.strip().lower()
+            if part and part in url_lower:
+                return True
+    return False
+
+
+def _build_external_event(
+    url: str, method: str, status_code: int, latency_ms: float, library: str
+) -> dict[str, Any]:
+    """Build an external_api_call event dict."""
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(url).netloc or url.split("/")[2]
+    except Exception:
+        host = ""
+    return {
+        "type": "external_api_call",
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "url": url,
+        "host": host,
+        "method": (method or "").upper(),
+        "status_code": status_code,
+        "latency_ms": round(latency_ms, 1),
+        "library": library,
+    }
 
 
 def _detect_provider(url: str) -> str:
@@ -257,6 +312,16 @@ def _patch_httpx() -> bool:
         ) -> httpx.Response:
             url = str(request.url)
             if not _is_llm_url(url):
+                if not _is_excluded_host(url):
+                    t0 = time.monotonic()
+                    response = _original_send(self, request, **kwargs)
+                    _write_event(_build_external_event(
+                        url, str(getattr(request, "method", "")),
+                        response.status_code,
+                        (time.monotonic() - t0) * 1000,
+                        "httpx",
+                    ))
+                    return response
                 return _original_send(self, request, **kwargs)
 
             provider = _detect_provider(url)
@@ -311,6 +376,16 @@ def _patch_httpx() -> bool:
             ) -> httpx.Response:
                 url = str(request.url)
                 if not _is_llm_url(url):
+                    if not _is_excluded_host(url):
+                        t0 = time.monotonic()
+                        response = await _original_async_send(self, request, **kwargs)
+                        _write_event(_build_external_event(
+                            url, str(getattr(request, "method", "")),
+                            response.status_code,
+                            (time.monotonic() - t0) * 1000,
+                            "httpx.async",
+                        ))
+                        return response
                     return await _original_async_send(self, request, **kwargs)
 
                 provider = _detect_provider(url)
@@ -383,6 +458,16 @@ def _patch_requests() -> bool:
         ) -> requests.Response:
             url = str(request.url or "")
             if not _is_llm_url(url):
+                if not _is_excluded_host(url):
+                    t0 = time.monotonic()
+                    response = _original_session_send(self, request, **kwargs)
+                    _write_event(_build_external_event(
+                        url, str(getattr(request, "method", "")),
+                        response.status_code,
+                        (time.monotonic() - t0) * 1000,
+                        "requests",
+                    ))
+                    return response
                 return _original_session_send(self, request, **kwargs)
 
             provider = _detect_provider(url)

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -884,6 +884,26 @@ _DDL = [
         note         VARCHAR
     )
     """,
+    # Issue #883 — external API tracing. Captures outbound HTTP calls that are
+    # NOT LLM provider calls (those go through events as llm_call). Written by
+    # clawmetry/interceptor.py when CLAWMETRY_INTERCEPT=1; ingested by sync.py
+    # via sync_intercepted_events(). Session attribution is time-window based:
+    # query_external_calls(session_id=X) joins on session start/end timestamps.
+    """
+    CREATE TABLE IF NOT EXISTS external_api_calls (
+        id          VARCHAR PRIMARY KEY,
+        node_id     VARCHAR,
+        ts          VARCHAR NOT NULL,
+        host        VARCHAR,
+        url         VARCHAR,
+        method      VARCHAR,
+        status_code INTEGER,
+        latency_ms  DOUBLE,
+        library     VARCHAR
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_ext_api_calls_ts   ON external_api_calls(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_ext_api_calls_host ON external_api_calls(host, ts)",
 ]
 
 
@@ -8214,6 +8234,81 @@ class LocalStore:
         rows = self._fetch(f"PRAGMA table_info('{table}')", [])
         # PRAGMA table_info columns: cid, name, type, notnull, dflt_value, pk
         return [{"name": r[1], "ctype": r[2]} for r in rows]
+
+    # ── External API call tracing (issue #883) ──────────────────────────
+
+    def ingest_external_call(self, ev: dict[str, Any], node_id: str = "") -> None:
+        """Insert one external_api_call row. Idempotent via ON CONFLICT IGNORE."""
+        import hashlib as _hashlib
+        raw_id = ev.get("ts", "") + ev.get("url", "") + ev.get("library", "")
+        row_id = _hashlib.sha256(raw_id.encode()).hexdigest()[:32]
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO external_api_calls
+                    (id, node_id, ts, host, url, method, status_code, latency_ms, library)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (id) DO NOTHING
+            """, [
+                row_id,
+                node_id or "",
+                ev.get("ts") or "",
+                ev.get("host") or "",
+                ev.get("url") or "",
+                (ev.get("method") or "").upper(),
+                ev.get("status_code"),
+                ev.get("latency_ms"),
+                ev.get("library") or "",
+            ])
+
+    def query_external_calls(
+        self,
+        *,
+        session_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Query external API call rows, optionally scoped to a session by time-window.
+
+        When ``session_id`` is given, only calls whose ``ts`` falls between the
+        session's ``started_at`` and ``updated_at`` are returned (time-window
+        attribution — no ABI changes to the interceptor required)."""
+        cols = ["id", "node_id", "ts", "host", "url", "method",
+                "status_code", "latency_ms", "library"]
+        if session_id:
+            sql = """
+                SELECT e.id, e.node_id, e.ts, e.host, e.url, e.method,
+                       e.status_code, e.latency_ms, e.library
+                FROM external_api_calls e
+                JOIN sessions s ON (
+                    e.ts >= s.started_at
+                    AND (s.updated_at IS NULL
+                         OR epoch_ms(CAST(s.updated_at AS BIGINT) * 1000)::VARCHAR >= e.ts)
+                )
+                WHERE s.session_id = ?
+                ORDER BY e.ts DESC
+                LIMIT ?
+            """
+            rows = self._fetch(sql, [session_id, int(limit)])
+        else:
+            clauses: list[str] = []
+            params: list[Any] = []
+            if since:
+                clauses.append("ts >= ?")
+                params.append(since)
+            if until:
+                clauses.append("ts <= ?")
+                params.append(until)
+            where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+            sql = f"""
+                SELECT id, node_id, ts, host, url, method,
+                       status_code, latency_ms, library
+                FROM external_api_calls {where}
+                ORDER BY ts DESC LIMIT ?
+            """
+            params.append(int(limit))
+            rows = self._fetch(sql, params)
+        return [dict(zip(cols, r)) for r in rows]
 
     # ── internals ───────────────────────────────────────────────────────
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -4615,6 +4615,47 @@ def sync_logs(config: dict, state: dict, paths: dict) -> int:
     return total
 
 
+def sync_intercepted_events(config: dict, state: dict, paths: dict) -> int:
+    """Tail ~/.openclaw/clawmetry-intercepted.jsonl and ingest external_api_call
+    rows into the local DuckDB store. Uses a byte-offset cursor in state so
+    only new lines are read each tick. Returns the number of rows ingested."""
+    openclaw_dir = paths.get("openclaw_dir", str(Path.home() / ".openclaw"))
+    fpath = Path(openclaw_dir) / "clawmetry-intercepted.jsonl"
+    if not fpath.exists():
+        return 0
+    node_id = config.get("node_id", "")
+    offset_key = "last_intercepted_offset"
+    offset = state.get(offset_key, 0)
+    ingested = 0
+    try:
+        from clawmetry import local_store as _ls
+        store = _ls.get_store()
+        with open(fpath, "r", errors="replace") as f:
+            f.seek(0, 2)
+            size = f.tell()
+            if offset > size:
+                offset = 0
+            f.seek(offset)
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    ev = json.loads(raw)
+                except Exception:
+                    continue
+                if ev.get("type") == "external_api_call":
+                    try:
+                        store.ingest_external_call(ev, node_id)
+                        ingested += 1
+                    except Exception as _ie:
+                        log.debug("ingest_external_call failed: %s", _ie)
+            state[offset_key] = f.tell()
+    except Exception as e:
+        log.warning("sync_intercepted_events error: %s", e)
+    return ingested
+
+
 def _flush_log_batch(
     entries: list, fname: str, api_key: str, enc_key: str | None, node_id: str
 ) -> None:
@@ -12216,6 +12257,12 @@ def run_daemon() -> None:
             log.info(f"  Recent logs: {lg} lines synced")
     except Exception as e:
         log.warning(f"  Recent log sync error: {e}")
+    try:
+        ie = sync_intercepted_events(config, state, paths)
+        if ie:
+            log.info(f"  External API calls: {ie} rows ingested")
+    except Exception as e:
+        log.warning(f"  Intercepted-events sync error: {e}")
 
     state["last_sync"] = datetime.now(timezone.utc).isoformat()
     # Force a sync local-store flush before persisting the startup cursor.
@@ -12602,6 +12649,12 @@ def run_daemon() -> None:
             if now_log - last_log_sync > log_sync_interval:
                 lg = sync_logs(config, state, paths)
                 last_log_sync = now_log
+
+            # ── External API call tracing (issue #883) ──────────────────
+            try:
+                sync_intercepted_events(config, state, paths)
+            except Exception as _ie:
+                log.debug("sync_intercepted_events tick error (non-fatal): %s", _ie)
 
             # ── Telegram outbound from gateway.log (#1192 follow-up) ──
             # OpenClaw stores Telegram chats in memory only — no JSONL is

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -39,13 +39,14 @@ bp_local_query = Blueprint("local_query", __name__)
 # arbitrary SELECT against the user's local DuckDB — only what we've
 # whitelisted here.
 _SHAPES = {
-    "events":     "query_events",
-    "sessions":   "query_sessions",
-    "aggregates": "query_aggregates",
-    "health":     None,                 # special: no args
-    "transcript": "query_events",       # alias with session_id required
-    "spans":      "query_spans",        # Issue #1013: full-filter span list
-    "traces":     "query_traces",       # Issue #1013: one row per trace_id
+    "events":          "query_events",
+    "sessions":        "query_sessions",
+    "aggregates":      "query_aggregates",
+    "health":          None,                      # special: no args
+    "transcript":      "query_events",            # alias with session_id required
+    "spans":           "query_spans",             # Issue #1013: full-filter span list
+    "traces":          "query_traces",            # Issue #1013: one row per trace_id
+    "external_calls":  "query_external_calls",   # Issue #883: external API tracing
 }
 
 
@@ -210,6 +211,13 @@ def _coerce_args(shape: str, raw: dict) -> dict:
             "since":      raw.get("since"),
             "until":      raw.get("until"),
             "limit":      _safe_int(raw.get("limit"), default=100, lo=1, hi=1000),
+        }
+    if shape == "external_calls":
+        return {
+            "session_id": raw.get("session_id"),
+            "since":      raw.get("since"),
+            "until":      raw.get("until"),
+            "limit":      _safe_int(raw.get("limit"), default=200, lo=1, hi=2000),
         }
     raise ValueError(f"unknown shape: {shape}")
 
@@ -383,6 +391,20 @@ def http_traces():
     try:
         args = _coerce_args("traces", request.args.to_dict())
         return jsonify(_dispatch("traces", args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
+@bp_local_query.route("/api/local/external-calls", methods=["GET"])
+def http_external_calls():
+    """List external (non-LLM) API calls captured by the interceptor.
+
+    Optional query params: session_id, since (ISO), until (ISO), limit (int).
+    When session_id is given, results are filtered to calls whose timestamp
+    falls within that session's start/end window."""
+    try:
+        args = _coerce_args("external_calls", request.args.to_dict())
+        return jsonify(_dispatch("external_calls", args))
     except Exception as e:
         return jsonify({"error": str(e)[:300]}), 500
 
@@ -600,6 +622,9 @@ _DAEMON_METHODS = frozenset({
     "mark_error_resolved",
     "unmark_error_resolved",
     "query_resolved_errors",
+    # Issue #883: external API tracing. Read-only; the daemon owns the writer
+    # connection so the proxy is required for multi-process installs.
+    "query_external_calls",
 })
 
 


### PR DESCRIPTION
Closes #883

## Summary

- **`clawmetry/interceptor.py`** — after the existing LLM-URL early-return, capture any non-excluded outbound HTTP call as an `external_api_call` event written to `clawmetry-intercepted.jsonl`. Built-in exclude list covers localhost/loopback, link-local, LLM provider hosts (already tracked as `llm_call`), and ClawMetry ingest/app hosts. User-extensible via `CLAWMETRY_INTERCEPT_HOSTS_EXCLUDE=host1,host2` (comma-separated substring match).
- **`clawmetry/local_store.py`** — adds `external_api_calls` DDL + `ingest_external_call()` (idempotent, SHA-256 row ID) + `query_external_calls()` with optional time-window session attribution (JOIN sessions on `started_at ≤ call_ts ≤ updated_at`).
- **`clawmetry/sync.py`** — adds `sync_intercepted_events()` that tails `clawmetry-intercepted.jsonl` by byte offset (same pattern as `sync_logs`); called at daemon startup and each 15 s main-loop tick.
- **`routes/local_query.py`** — adds `external_calls` shape + `GET /api/local/external-calls?session_id=&since=&until=&limit=` endpoint + daemon-proxy allowlist entry for `query_external_calls`.

## Design decisions made

- **Session attribution**: time-window JOIN at query time — no changes to the capture path. Approximate for concurrent sessions but zero overhead per call.
- **Noise control**: opt-out by default (active when `CLAWMETRY_INTERCEPT=1`); LLM providers and ClawMetry infra excluded automatically.

## Test plan

- `python3 -m py_compile clawmetry/interceptor.py clawmetry/local_store.py clawmetry/sync.py routes/local_query.py` → all clean
- Unit: `_is_excluded_host('https://api.anthropic.com/...')` → True; `_is_excluded_host('https://api.github.com/repos')` → False
- Unit: `ingest_external_call()` idempotent (same SHA-256 row ID on re-ingest)
- Unit: `query_external_calls(session_id='no-such-id')` → empty list
- Unit: `query_external_calls(since='future')` → empty list
- Integration: set `CLAWMETRY_INTERCEPT=1`, make a `requests.get('https://api.github.com/...')` → row appears in `clawmetry-intercepted.jsonl` with `type=external_api_call`; after daemon tick, `GET /api/local/external-calls` returns the row

https://claude.ai/code/session_01TRarbSTBv53KEccrcKcqee

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRarbSTBv53KEccrcKcqee)_