### PR TITLE
feat(v2): add route_map.py — canonical V1↔V2 tab-name mapping (#1494)

### DIFF
--- a/clawmetry/v2/__init__.py
+++ b/clawmetry/v2/__init__.py
@@ -1,0 +1,5 @@
+"""ClawMetry v2 package — React SPA + parallel-rails Flask blueprint."""
+
+from clawmetry.v2.route_map import V1_TO_V2, V2_TO_V1
+
+__all__ = ["V1_TO_V2", "V2_TO_V1"]

--- a/clawmetry/v2/route_map.py
+++ b/clawmetry/v2/route_map.py
@@ -1,0 +1,27 @@
+"""Canonical tab-name mapping between v1 and v2 URL schemes.
+
+V1_TO_V2 maps the short tab identifiers used in v1 URL fragments /
+query params to the corresponding v2 React Router path segments.
+V2_TO_V1 is the reverse.
+
+Usage::
+
+    from clawmetry.v2.route_map import V1_TO_V2, V2_TO_V1
+    v2_tab = V1_TO_V2.get(v1_tab, v1_tab)  # graceful passthrough for unmapped tabs
+    v1_tab = V2_TO_V1.get(v2_tab, v2_tab)
+"""
+
+V1_TO_V2: dict[str, str] = {
+    "flow": "trace",
+    "sessions": "brain",
+    "memory": "context",
+    "usage": "cost",
+    "crons": "ops",
+    "logs": "ops",
+}
+
+# Reverse mapping. "crons" and "logs" both map to "ops" in V1_TO_V2,
+# so V2_TO_V1["ops"] resolves to "logs" (last writer wins in dict
+# comprehension). Callers that need to distinguish should consult
+# V1_TO_V2 directly rather than relying on V2_TO_V1["ops"].
+V2_TO_V1: dict[str, str] = {v: k for k, v in V1_TO_V2.items()}


### PR DESCRIPTION
## Summary

The parallel-rails routing infrastructure from RFC-v2-002 is already wired (CLI `--v2`/`--v2-default` flags, `clawmetry/v2/routes.py` blueprint, registration in `dashboard.py`, "✨ Try v2 (beta)" link in the v1 sidebar). The one remaining Python-side piece specified in the RFC is the tab-name mapping table — without it, any code that needs to translate between v1 tab identifiers and v2 React Router paths has no canonical source of truth.

## Changes

- **`clawmetry/v2/route_map.py`** (new, ~25 LOC): `V1_TO_V2` and `V2_TO_V1` dicts exactly as specified in the RFC. Documents the `ops` ambiguity (both `crons` and `logs` map to `ops`; reverse resolves to `logs`).
- **`clawmetry/v2/__init__.py`** (updated from empty): exports `V1_TO_V2` and `V2_TO_V1` so callers can do `from clawmetry.v2 import V1_TO_V2`.

## Test plan

- [ ] `python3 -c "from clawmetry.v2.route_map import V1_TO_V2, V2_TO_V1; assert V2_TO_V1[V1_TO_V2['flow']] == 'flow'; assert V1_TO_V2.get('sessions') == 'brain'; print('ok')"` — roundtrip + spot-check
- [ ] `python3 -m py_compile clawmetry/v2/route_map.py clawmetry/v2/__init__.py` — syntax clean
- [ ] No change to `routes.py`, `cli.py`, or `dashboard.py` — v1 dashboard is unaffected

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #1494. Marked draft for human review — mark Ready for Review once happy.

Closes #1494

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6mc2eXjYzJZLzUxPGTJgY)_