### PR TITLE
feat(v2): Fleet Sonar page at /v2/fleet

### DIFF
--- a/clawmetry/v2/routes.py
+++ b/clawmetry/v2/routes.py
@@ -646,6 +646,63 @@ def get_subagents():
     })
 
 
+# ── Fleet API ─────────────────────────────────────────────────────────────
+
+@bp_v2.route("/api/v2/fleet", methods=["GET"])
+def get_fleet():
+    """Radar data for the /v2/fleet page (issue #1518).
+
+    Wire shape: {nodes: [{id, label, status, r, theta, last_seen_ts}],
+                 is_single_node: bool}
+
+    ``r`` is 0..1 (fraction of radar radius); ``theta`` is radians.
+    OSS installs with no registered remote nodes return a single synthetic
+    local-node record so the radar always has something to render.
+    """
+    import math
+    import time
+
+    nodes: list = []
+    try:
+        import dashboard as _d
+        with _d._fleet_db_lock:
+            db = _d._fleet_db()
+            rows = db.execute(
+                "SELECT node_id, name, status, last_seen_at"
+                " FROM nodes ORDER BY registered_at ASC"
+            ).fetchall()
+        count = len(rows)
+        for i, row in enumerate(rows):
+            node_id, name, status, last_seen_at = row
+            if count == 1:
+                r, theta = 0.35, 0.0
+            else:
+                theta = 2 * math.pi * i / count
+                r = 0.55 + 0.15 * (i % 2)
+            nodes.append({
+                "id": node_id or f"node-{i}",
+                "label": name or node_id or f"Node {i + 1}",
+                "status": status or "await",
+                "r": round(r, 3),
+                "theta": round(theta, 4),
+                "last_seen_ts": int(last_seen_at) if last_seen_at else 0,
+            })
+    except Exception:
+        pass
+
+    if not nodes:
+        nodes = [{
+            "id": "local",
+            "label": "This node",
+            "status": "live",
+            "r": 0.35,
+            "theta": 0.0,
+            "last_seen_ts": int(time.time()),
+        }]
+
+    return jsonify({"nodes": nodes, "is_single_node": len(nodes) <= 1})
+
+
 # ── SPA serving ───────────────────────────────────────────────────────────
 # Registered after the API routes. Flask matches by rule specificity, so the
 # explicit /api/v2/* rules still win over the catch-all even in default mode.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { ContextEconomicsPage } from "./pages/ContextEconomicsPage";
 import { ToolCatalogPage } from "./pages/ToolCatalogPage";
 import { CostPage } from "./pages/CostPage";
 import { ApprovalsPage } from "./pages/ApprovalsPage";
+import { FleetSonarPage } from "./pages/FleetSonarPage";
 
 // Nav slugs that now have a real React page (so the stub fallback skips them).
 const REAL_PAGES = new Set([
@@ -28,6 +29,7 @@ const REAL_PAGES = new Set([
   "tools",
   "cost",
   "approvals",
+  "fleet",
 ]);
 
 // All v2 routes live inside <Layout>, which renders the sidebar + topbar
@@ -54,6 +56,7 @@ export default function App() {
         <Route path="tools" element={<ToolCatalogPage />} />
         <Route path="cost" element={<CostPage />} />
         <Route path="approvals" element={<ApprovalsPage />} />
+        <Route path="fleet" element={<FleetSonarPage />} />
         {NAV_ITEMS.filter((it) => !REAL_PAGES.has(it.id)).map((it) => (
           <Route key={it.id} path={it.id} element={<StubPage slug={it.id} />} />
         ))}

--- a/frontend/src/pages/FleetSonarPage.tsx
+++ b/frontend/src/pages/FleetSonarPage.tsx
@@ -1,0 +1,317 @@
+import { useState, useEffect } from "react";
+import { ProPaywallModal } from "../components/ProPaywallModal";
+
+interface FleetNode {
+  id: string;
+  label: string;
+  status: "live" | "await" | "alert";
+  r: number;
+  theta: number;
+  last_seen_ts: number;
+}
+
+interface FleetData {
+  nodes: FleetNode[];
+  is_single_node: boolean;
+}
+
+// Radar geometry
+const R = 155;
+const CX = 180;
+const CY = 180;
+
+function nodeColor(status: string): string {
+  if (status === "live") return "var(--moss)";
+  if (status === "await") return "var(--amber)";
+  return "var(--claw-red)";
+}
+
+function nodeX(n: FleetNode): number {
+  return CX + n.r * R * Math.cos(n.theta - Math.PI / 2);
+}
+
+function nodeY(n: FleetNode): number {
+  return CY + n.r * R * Math.sin(n.theta - Math.PI / 2);
+}
+
+function tsAgo(ts: number): string {
+  if (!ts) return "—";
+  const delta = Math.floor(Date.now() / 1000 - ts);
+  if (delta < 60) return `${delta}s ago`;
+  if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
+  return `${Math.floor(delta / 3600)}h ago`;
+}
+
+// Sweep glow wedge endpoint (20° arc ahead of the beam)
+const GLOW_ANGLE = 0.35; // radians
+const sweepGlowX = CX + R * Math.sin(GLOW_ANGLE);
+const sweepGlowY = CY - R * Math.cos(GLOW_ANGLE);
+
+export function FleetSonarPage() {
+  const [data, setData] = useState<FleetData | null>(null);
+  const [paywallOpen, setPaywallOpen] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/v2/fleet")
+      .then((r) => r.json())
+      .then(setData)
+      .catch(console.error);
+  }, []);
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        padding: "20px 22px",
+        display: "flex",
+        flexDirection: "column",
+        minHeight: 0,
+        overflowY: "auto",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 10,
+          marginBottom: 20,
+        }}
+      >
+        <span className="caps" style={{ color: "var(--ink-4)" }}>
+          Fleet sonar
+        </span>
+        {data && (
+          <span style={{ fontSize: 11, color: "var(--ink-4)" }}>
+            {data.nodes.length} node{data.nodes.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          gap: 28,
+          alignItems: "flex-start",
+          flexWrap: "wrap",
+        }}
+      >
+        {/* ── Radar ─────────────────────────────────────────────────── */}
+        <svg
+          width={CX * 2}
+          height={CY * 2}
+          style={{ flexShrink: 0, display: "block" }}
+          aria-label="Fleet radar"
+        >
+          {/* Rings */}
+          <circle
+            cx={CX}
+            cy={CY}
+            r={R}
+            fill="none"
+            stroke="var(--line)"
+            strokeWidth={1}
+          />
+          {[0.5, 0.75].map((f) => (
+            <circle
+              key={f}
+              cx={CX}
+              cy={CY}
+              r={f * R}
+              fill="none"
+              stroke="var(--line)"
+              strokeWidth={1}
+              strokeDasharray="3 6"
+            />
+          ))}
+
+          {/* Cross-hairs */}
+          <line
+            x1={CX}
+            y1={CY - R}
+            x2={CX}
+            y2={CY + R}
+            stroke="var(--line)"
+            strokeWidth={1}
+          />
+          <line
+            x1={CX - R}
+            y1={CY}
+            x2={CX + R}
+            y2={CY}
+            stroke="var(--line)"
+            strokeWidth={1}
+          />
+
+          {/* Sweep beam — 4s linear via CSS cm-sweep keyframe */}
+          <g
+            style={{
+              transformOrigin: `${CX}px ${CY}px`,
+              animation: "cm-sweep 4s linear infinite",
+            }}
+          >
+            {/* Glow wedge ahead of beam */}
+            <path
+              d={`M ${CX} ${CY} L ${CX} ${CY - R} A ${R} ${R} 0 0 1 ${sweepGlowX} ${sweepGlowY} Z`}
+              fill="var(--moss)"
+              opacity={0.06}
+            />
+            {/* Beam line */}
+            <line
+              x1={CX}
+              y1={CY}
+              x2={CX}
+              y2={CY - R}
+              stroke="var(--moss)"
+              strokeWidth={2}
+              opacity={0.9}
+            />
+          </g>
+
+          {/* Node pins */}
+          {(data?.nodes ?? []).map((node) => {
+            const nx = nodeX(node);
+            const ny = nodeY(node);
+            const col = nodeColor(node.status);
+            return (
+              <g
+                key={node.id}
+                style={{ cursor: "pointer" }}
+                onClick={() => setPaywallOpen(true)}
+                role="button"
+                aria-label={`Node ${node.label}`}
+              >
+                {/* Pulse ring — 1.4s heartbeat */}
+                <circle
+                  cx={nx}
+                  cy={ny}
+                  r={9}
+                  fill="none"
+                  stroke={col}
+                  strokeWidth={1}
+                  style={{ animation: "pin-pulse 1.4s ease-in-out infinite" }}
+                />
+                {/* Core dot */}
+                <circle
+                  cx={nx}
+                  cy={ny}
+                  r={5}
+                  fill={col}
+                  stroke="var(--paper)"
+                  strokeWidth={1.5}
+                />
+                {/* Label */}
+                <text
+                  x={nx + 10}
+                  y={ny + 4}
+                  fontSize={11}
+                  fill="var(--ink-3)"
+                  style={{ fontFamily: "inherit", userSelect: "none" }}
+                >
+                  {node.label}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+
+        {/* ── Right panel ───────────────────────────────────────────── */}
+        <div
+          style={{ flex: 1, minWidth: 220, display: "flex", flexDirection: "column", gap: 10 }}
+        >
+          {/* Node status rows */}
+          {(data?.nodes ?? []).map((node) => {
+            const col = nodeColor(node.status);
+            return (
+              <div
+                key={node.id}
+                className="cm-card"
+                style={{
+                  padding: "10px 14px",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                }}
+              >
+                <div
+                  style={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: "50%",
+                    background: col,
+                    flexShrink: 0,
+                  }}
+                />
+                <span
+                  style={{ flex: 1, fontSize: 13, color: "var(--ink)" }}
+                >
+                  {node.label}
+                </span>
+                <span
+                  className="mono"
+                  style={{ fontSize: 11, color: "var(--ink-4)" }}
+                >
+                  {tsAgo(node.last_seen_ts)}
+                </span>
+              </div>
+            );
+          })}
+
+          {/* Upgrade CTA for single-node OSS */}
+          {data?.is_single_node && (
+            <div
+              className="cm-card"
+              style={{
+                padding: "16px",
+                borderColor: "var(--line)",
+                marginTop: 6,
+              }}
+            >
+              <div
+                className="caps"
+                style={{ color: "var(--claw-red)", marginBottom: 6 }}
+              >
+                Fleet · Cloud Pro
+              </div>
+              <p
+                style={{
+                  margin: "0 0 12px",
+                  fontSize: 13,
+                  color: "var(--ink-3)",
+                  lineHeight: 1.5,
+                }}
+              >
+                You are running a single node. Connect additional machines to
+                see your full fleet on this radar.
+              </p>
+              <button
+                type="button"
+                className="cm-btn primary"
+                onClick={() => setPaywallOpen(true)}
+              >
+                Add nodes via Cloud
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <ProPaywallModal
+        open={paywallOpen}
+        onClose={() => setPaywallOpen(false)}
+        feature="Fleet sonar"
+      />
+
+      <style>{`
+        @keyframes cm-sweep {
+          from { transform: rotate(0deg); }
+          to   { transform: rotate(360deg); }
+        }
+        @keyframes pin-pulse {
+          0%, 100% { opacity: 0.45; r: 9px; }
+          50%       { opacity: 0.08; r: 14px; }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1518

## Summary

- **`FleetSonarPage.tsx`** — new React page replacing the `/v2/fleet` stub. Renders an SVG radar with a 4 s linear CSS sweep beam (`cm-sweep` keyframe), node pins with a 1.4 s heartbeat pulse, and a right-side status list. OSS single-node installs see an upgrade CTA card ("Add nodes via Cloud") that opens the existing `ProPaywallModal`.
- **`GET /api/v2/fleet`** — new endpoint in `clawmetry/v2/routes.py`. Reads the fleet `nodes` table, assigns polar coordinates `(r, θ)` so the server controls radar placement. Falls back to a synthetic local-node entry when no nodes are registered, so the radar always renders something useful.
- **`App.tsx`** — promotes `"fleet"` from the `StubPage` fallback to `<FleetSonarPage />`.

## Out of scope

Embodied world map (`/v2/embodied`) and per-node drill-down navigation — both need their own API surface and design reference. The click-pin handler shows the Pro paywall for OSS users as a placeholder.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/v2/routes.py').read())"` → no syntax errors
- [ ] `CLAWMETRY_V2=1 python3 dashboard.py --port 8900` → open `/v2/fleet` → radar renders with sweep animation and single local-node pin
- [ ] Node pin pulse animates at ~1.4 s; sweep completes one full rotation every 4 s
- [ ] "Add nodes via Cloud" button opens the Pro paywall modal
- [ ] `GET /api/v2/fleet` with empty fleet DB → returns `{"nodes": [{"id": "local", ...}], "is_single_node": true}`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdM1EaFStFCLxqLuh6wbnH)_