### PR TITLE
fix(c6): add visual-diff to required status checks (5th missing check)

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -41,6 +41,7 @@ jobs:
             echo "  Using GITHUB_TOKEN (no E2E_ADMIN_PAT set) -- clawmetry only:"
             echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
             echo "  clawmetry         : Cross-repo handoff (C4)"
+            echo "  clawmetry         : visual-diff"
             echo ""
             echo "  For the remaining repos, run the equivalent workflow in each:"
             echo "  clawmetry-cloud   : Cloud golden-path browser E2E  (needs E2E_ADMIN_PAT or own workflow)"
@@ -49,6 +50,7 @@ jobs:
             echo "  Using E2E_ADMIN_PAT -- applying to all 3 repos:"
             echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
             echo "  clawmetry         : Cross-repo handoff (C4)"
+            echo "  clawmetry         : visual-diff"
             echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
             echo "  clawmetry-landing : Landing golden path (C3)"
           fi

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -14,7 +14,7 @@ When run inside GitHub Actions, GITHUB_REPOSITORY is set automatically
 to only the matching repo so that a GITHUB_TOKEN with single-repo
 Administration write access is sufficient.
 
-When run locally (GITHUB_REPOSITORY not set), the script applies all 4
+When run locally (GITHUB_REPOSITORY not set), the script applies all 5
 checks and requires a token with cross-repo Administration access.
 
 Requirements
@@ -43,11 +43,15 @@ OWNER = "vivekchand"
 # Job names verified against workflow files 2026-06-01:
 #   clawmetry/.github/workflows/oss-golden-path.yml      -> "OSS golden path (wheel + OpenClaw + 9 tabs)"
 #   clawmetry/.github/workflows/cross-repo-handoff.yml   -> "Cross-repo handoff (C4)"
+#   clawmetry/.github/workflows/pr-screenshots.yml       -> "visual-diff"
+#     (no `name:` on the job -- GitHub uses the job key; continue-on-error: true
+#      means the check always reports success, ensuring screenshots run on every PR)
 #   clawmetry-cloud/.github/workflows/e2e.yml            -> "Cloud golden-path browser E2E"
 #   clawmetry-landing/.github/workflows/landing-golden-path.yml -> "Landing golden path (C3)"
 REQUIRED_CHECKS: list[tuple[str, str]] = [
     ("clawmetry",         "OSS golden path (wheel + OpenClaw + 9 tabs)"),
     ("clawmetry",         "Cross-repo handoff (C4)"),
+    ("clawmetry",         "visual-diff"),
     ("clawmetry-cloud",   "Cloud golden-path browser E2E"),
     ("clawmetry-landing", "Landing golden path (C3)"),
 ]


### PR DESCRIPTION
## Summary

Fixes a gap in C6 (Required-status-checks) where `visual-diff` was documented as required in the tracking issue (#2146) but was absent from `REQUIRED_CHECKS` in `scripts/apply_required_status_checks.py`. Without this fix, triggering `apply-required-checks.yml` with `confirm=APPLY` would configure only 2 checks on clawmetry (OSS golden path + Cross-repo handoff) instead of the full 3, leaving `visual-diff` permanently unconfigured.

### Changes

- `scripts/apply_required_status_checks.py`: Added `("clawmetry", "visual-diff")` to `REQUIRED_CHECKS`. Updated docstring to say "all 5 checks" instead of "all 4". Added inline note explaining `continue-on-error: true` behavior.
- `.github/workflows/apply-required-checks.yml`: Added `visual-diff` to the dry-run preview output in both the PAT and no-PAT branches so the operator sees all 3 clawmetry checks before confirming APPLY.

### Why visual-diff is safe as a required check

`pr-screenshots.yml` job `visual-diff` has `continue-on-error: true`. GitHub reports this check as success even when the job fails internally. Adding it as required means: every PR triggers the screenshot job (screenshots always run), but pixel-diff regressions do NOT block merges. This is the intended non-blocking but always-runs behavior.

### Context

All 3 C6 self-apply workflows were merged this morning (#2407 for clawmetry, cloud#1273, landing#390). The admin can now trigger `workflow_dispatch` with `confirm=APPLY` in each repo. This PR ensures the clawmetry run configures the correct 3 checks (not 2).

### Test plan

- [ ] Trigger `Apply required E2E status checks (C6 -- one-shot)` with `confirm=dry-run` -- dry-run output should list all 3 clawmetry checks including `visual-diff`
- [ ] Trigger with `confirm=APPLY` -- verify Settings > Branches > main shows `OSS golden path (wheel + OpenClaw + 9 tabs)`, `Cross-repo handoff (C4)`, and `visual-diff` as required
- [ ] Script is idempotent: second APPLY run reports "already required" for each check

Tracking: #2146 (C6)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXHtyyGhf57u45qB9oBeay)_