### PR TITLE
feat(dives): chat history + context-aware follow-up queries (#1411)

### DIFF
--- a/clawmetry/dives_prompt.py
+++ b/clawmetry/dives_prompt.py
@@ -491,6 +491,7 @@ def build_schema_descriptor(store: "LocalStore | None" = None) -> str:
 def build_dives_prompt(
     question: str,
     store: "LocalStore | None" = None,
+    history: "list[dict] | None" = None,
 ) -> dict[str, str]:
     """Build the system + user messages for a Dives LLM call.
 
@@ -500,6 +501,11 @@ def build_dives_prompt(
                   descriptor is generated from ``PRAGMA table_info`` so it
                   reflects any live migrations; otherwise a static descriptor
                   is used (sufficient for unit tests).
+        history:  Optional list of prior Q+SQL turns (most recent last).
+                  Each entry should have ``question`` and ``sql`` keys.
+                  When provided, the last up to 3 turns are injected into the
+                  system prompt so the model can resolve follow-up references
+                  like "show me the same broken down by hour".
 
     Returns:
         ``{"system": ..., "user": ...}`` — pass ``system`` as the Anthropic
@@ -515,11 +521,25 @@ def build_dives_prompt(
     schema = build_schema_descriptor(store)
     few_shot_json = json.dumps(_FEW_SHOT_EXAMPLES, indent=2)
 
-    system = "\n\n".join([
+    parts = [
         _SYSTEM_PROMPT_HEADER,
         "## Schema\n" + schema,
         "## Few-shot examples\n" + few_shot_json,
-    ])
+    ]
+
+    if history:
+        recent = history[-3:]
+        ctx_lines = ["## Prior conversation context (most recent last)"]
+        for i, turn in enumerate(recent, 1):
+            q = (turn.get("question") or "").strip()
+            sql = (turn.get("sql") or "").strip()
+            if q and sql:
+                ctx_lines.append(f"Turn {i} — question: {q}")
+                ctx_lines.append(f"Turn {i} — SQL you generated: {sql}")
+        if len(ctx_lines) > 1:
+            parts.append("\n".join(ctx_lines))
+
+    system = "\n\n".join(parts)
 
     return {"system": system, "user": question.strip()}
 

--- a/routes/dives.py
+++ b/routes/dives.py
@@ -29,6 +29,8 @@ bp_dives = Blueprint("dives", __name__)
 _MAX_QUESTION_LEN = 1_000
 _MAX_NAME_LEN = 200
 _QUERY_TIMEOUT_SEC = 30
+_MAX_HISTORY_ENTRIES = 200
+_HISTORY_CONTEXT_TURNS = 3
 
 
 # ── Storage helpers ────────────────────────────────────────────────────────────
@@ -38,6 +40,34 @@ def _dives_dir() -> str:
     d = os.path.expanduser("~/.clawmetry/dives")
     os.makedirs(d, exist_ok=True)
     return d
+
+
+def _history_path() -> str:
+    return os.path.join(_dives_dir(), "_history.json")
+
+
+def _read_history() -> list:
+    path = _history_path()
+    if not os.path.isfile(path):
+        return []
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+def _append_history(entry: dict) -> None:
+    history = _read_history()
+    history.append(entry)
+    if len(history) > _MAX_HISTORY_ENTRIES:
+        history = history[-_MAX_HISTORY_ENTRIES:]
+    try:
+        with open(_history_path(), "w") as f:
+            json.dump(history, f)
+    except OSError:
+        pass
 
 
 def _safe_slug(raw: str) -> str:
@@ -95,7 +125,7 @@ def _list_dives() -> list[dict]:
 # ── LLM dispatch ──────────────────────────────────────────────────────────────
 
 
-def _call_llm_for_sql(question: str, store) -> dict:
+def _call_llm_for_sql(question: str, store, history: list | None = None) -> dict:
     """Return the LLM-generated {sql, chart_type, x, y, title, description} spec."""
     import shutil
     from routes.advisor import (
@@ -112,7 +142,7 @@ def _call_llm_for_sql(question: str, store) -> dict:
             "Export ANTHROPIC_API_KEY or run `claude` CLI to set up OAuth."
         )
 
-    msgs = build_dives_prompt(question, store)
+    msgs = build_dives_prompt(question, store, history=history)
 
     if mode == "claude_cli":
         claude_bin = shutil.which("claude") or "claude"
@@ -179,9 +209,21 @@ def _execute(sql: str, store) -> tuple[list[dict], str | None]:
 # ── Endpoints ──────────────────────────────────────────────────────────────────
 
 
+@bp_dives.route("/api/dives/history")
+def api_dives_history():
+    """GET → {history: [{ts, question, sql, chart_spec}]} most-recent-first."""
+    try:
+        limit = max(1, min(200, int(request.args.get("limit", "50"))))
+    except (TypeError, ValueError):
+        limit = 50
+    history = _read_history()
+    recent = list(reversed(history[-limit:]))
+    return jsonify({"history": recent})
+
+
 @bp_dives.route("/api/dives/query", methods=["POST"])
 def api_dives_query():
-    """POST {question} → {sql, chart_spec, rows, ms, error?}"""
+    """POST {question, history?} → {sql, chart_spec, rows, ms, error?}"""
     payload = request.get_json(silent=True) or {}
     question = (payload.get("question") or "").strip()
     if not question:
@@ -206,9 +248,16 @@ def api_dives_query():
                      "stays on your machine.",
         }), 200
 
+    # Client may pass explicit history; fall back to last N turns from disk.
+    client_history = payload.get("history")
+    if isinstance(client_history, list):
+        ctx_history = client_history[-_HISTORY_CONTEXT_TURNS:]
+    else:
+        ctx_history = _read_history()[-_HISTORY_CONTEXT_TURNS:]
+
     t0 = time.monotonic()
     try:
-        spec = _call_llm_for_sql(question, store)
+        spec = _call_llm_for_sql(question, store, history=ctx_history or None)
     except ValueError as e:
         msg = str(e)
         if msg.startswith("no_auth"):
@@ -229,6 +278,16 @@ def api_dives_query():
     body: dict = {"sql": sql, "chart_spec": chart_spec, "rows": rows, "ms": ms}
     if sql_error:
         body["error"] = sql_error
+
+    # Persist to history only on non-error queries so history stays meaningful.
+    if not sql_error:
+        _append_history({
+            "ts":         time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "question":   question,
+            "sql":        sql,
+            "chart_spec": chart_spec,
+        })
+
     return jsonify(body)
 
 


### PR DESCRIPTION
Closes #1411

## Summary

- Each successful Dives query is persisted to `~/.clawmetry/dives/_history.json` (capped at 200 entries, same directory as saved dives — no DuckDB migration needed).
- The last 3 turns are injected into the LLM system prompt as **"Prior conversation context"**, enabling follow-up references like *"show me the same broken down by hour"* to generate correct SQL.
- New `GET /api/dives/history?limit=` endpoint returns recent queries most-recent-first (consistent with `/api/brain-history` and `/api/evals/recent` patterns).
- `build_dives_prompt()` gains an optional `history` parameter; existing callers are unaffected (backward-compatible default of `None`).

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('routes/dives.py').read())"` — syntax clean
- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/dives_prompt.py').read())"` — syntax clean
- [ ] `pytest tests/test_dives_prompt.py` — all 54 tests pass (verified locally)
- [ ] `GET /api/dives/history` with no prior queries → `{"history": []}`
- [ ] `POST /api/dives/query` succeeds → `GET /api/dives/history` returns that entry
- [ ] Follow-up query ("break it down by hour") with history populated → system prompt contains prior Q+SQL context

https://claude.ai/code/session_015rVAUMKh4Urb3JS7FmrioR

---
_Generated by [Claude Code](https://claude.ai/code/session_015rVAUMKh4Urb3JS7FmrioR)_