### PR TITLE
e2e(C6): auto-apply required status checks on push to main

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -1,17 +1,21 @@
 name: Apply required E2E status checks (C6 -- one-shot)
 
-# Runs scripts/apply_required_status_checks.py from the GitHub Actions UI
-# so the admin does not need a local Python environment.
+# Runs scripts/apply_required_status_checks.py to configure required
+# status checks on main across all three repos.
 #
-# When E2E_ADMIN_PAT is set: applies required checks across all three repos
-#   (vivekchand/clawmetry, vivekchand/clawmetry-cloud, vivekchand/clawmetry-landing).
-# When E2E_ADMIN_PAT is NOT set: falls back to GITHUB_TOKEN, which has
-#   Administration write access on THIS repo only (vivekchand/clawmetry).
-#   For clawmetry-cloud and clawmetry-landing, run the equivalent workflow
-#   in each of those repos.
+# Triggers:
+#   push to main: automatically re-applies required checks on every merge
+#     so the configuration is self-healing. No manual action needed after
+#     this PR is merged.
+#   workflow_dispatch: manual trigger from the Actions UI. Use confirm=APPLY
+#     to apply immediately; anything else previews what would change.
 #
-# First run with confirm=dry-run to preview, then confirm=APPLY to apply.
-# Running multiple times is safe: the underlying script is idempotent.
+# When E2E_ADMIN_PAT is set: applies checks across all 3 repos in one run.
+# When E2E_ADMIN_PAT is NOT set: falls back to GITHUB_TOKEN (administration:
+#   write) for this repo only. The equivalent push-triggered workflow in
+#   clawmetry-cloud and clawmetry-landing handles those repos automatically.
+#
+# Idempotent: running multiple times is safe.
 #
 # Tracking: vivekchand/clawmetry#2146 (C6)
 
@@ -22,6 +26,8 @@ on:
         description: "Type APPLY to configure repos (anything else = dry run)"
         required: true
         default: "dry-run"
+  push:
+    branches: [main]
 
 jobs:
   apply-required-checks:
@@ -33,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Preview checks (dry run)
-        if: github.event.inputs.confirm != 'APPLY'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.confirm != 'APPLY'
         run: |
           echo "=== DRY RUN -- checks that will be added when confirm=APPLY ==="
           echo ""
@@ -42,9 +48,8 @@ jobs:
             echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
             echo "  clawmetry         : Cross-repo handoff (C4)"
             echo ""
-            echo "  For the remaining repos, run the equivalent workflow in each:"
-            echo "  clawmetry-cloud   : Cloud golden-path browser E2E  (needs E2E_ADMIN_PAT or own workflow)"
-            echo "  clawmetry-landing : Landing golden path (C3)        (needs E2E_ADMIN_PAT or own workflow)"
+            echo "  For the remaining repos, the push-triggered workflow in each"
+            echo "  repo handles those repos automatically on next merge."
           else
             echo "  Using E2E_ADMIN_PAT -- applying to all 3 repos:"
             echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
@@ -56,7 +61,7 @@ jobs:
           echo "Re-run with confirm=APPLY to apply."
 
       - name: Apply required status checks
-        if: github.event.inputs.confirm == 'APPLY'
+        if: github.event_name == 'push' || github.event.inputs.confirm == 'APPLY'
         env:
           GITHUB_TOKEN: ${{ secrets.E2E_ADMIN_PAT || github.token }}
         run: python3 scripts/apply_required_status_checks.py


### PR DESCRIPTION
## Problem

`apply-required-checks.yml` exists but only had a `workflow_dispatch` trigger and was never run. Today 4 PRs (#2408, #2410, #2416, #2418) merged without any E2E gate blocking them. C6 is the only remaining RED criterion blocking the 7-day countdown.

## Fix

Add `push: branches: [main]` trigger to `apply-required-checks.yml`. On every merge to main, the workflow now calls `scripts/apply_required_status_checks.py` automatically using `GITHUB_TOKEN` with `administration: write`. The required checks are idempotently re-applied, making the configuration self-healing.

Changes:
- Added `push: branches: [main]` to `on:` block
- Preview (dry-run) step now guards on `event_name == 'workflow_dispatch'` so it does not fire on push
- Apply step fires on `push` OR on manual `APPLY` confirmation

The `workflow_dispatch` dry-run / APPLY path is unchanged for manual use.

## Acceptance test

After merge, the "Apply required E2E status checks (C6)" job runs and exits 0. Then:

```bash
gh api repos/vivekchand/clawmetry/branches/main/protection/required_status_checks \
  --jq '.contexts[]'
# expected output includes both:
# OSS golden path (wheel + OpenClaw + 9 tabs)
# Cross-repo handoff (C4)
```

Same acceptance check applies to the companion PRs in clawmetry-cloud and clawmetry-landing.

## Notes

If `GITHUB_TOKEN` does not have `administration: write` privilege (blocked by repo settings), the Apply step will fail with a 403. In that case, set `E2E_ADMIN_PAT` as a repo secret and re-run, or use the UI path in the tracking issue.

Tracking: #2146 (C6)
Part of: clawmetry-cloud e2e/c6-auto-apply-on-push, clawmetry-landing e2e/c6-auto-apply-on-push

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdPdc8vekyxu8y9LNib5o1)_