### PR TITLE
feat(cli): add `clawmetry entitlement` subcommand mirroring /api/entitlement

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2848,6 +2848,87 @@ def _cmd_license(args) -> None:
         print("  E2E:         🔒 verified offline")
 
 
+def _cmd_entitlement(args) -> None:
+    """clawmetry entitlement [--json] — show the resolved open-core entitlement.
+
+    Mirrors the GET /api/entitlement endpoint as a command-line tool so an
+    operator can verify what the install thinks it has (tier, source, grace
+    flag, runtimes, features) on a real machine without curling the dashboard.
+
+    Complements ``clawmetry license`` (which only reports the on-disk license
+    file): this command shows the FULL resolution — license -> cloud cache ->
+    OSS fallback — so a wrong-tier puzzle ("my Pro key is installed but the
+    UI still shows OSS") has a single command to diagnose.
+
+    Never raises: any resolution error falls back to the OSS-free shape that
+    ``routes/entitlement.py`` already returns to the dashboard.
+    """
+    import json as _json
+
+    as_json = bool(getattr(args, "as_json", False))
+    try:
+        from clawmetry import entitlements as _ent
+
+        en = _ent.get_entitlement(force=True)
+        data = en.to_dict()
+    except Exception as exc:
+        # Mirror the OSS-free fallback the HTTP route uses, so operator
+        # tooling can rely on a stable shape even on a misconfigured install.
+        data = {
+            "tier": "oss",
+            "source": "oss",
+            "node_limit": 1,
+            "expiry": None,
+            "expired": False,
+            "is_paid": False,
+            "grace": True,
+            "enforced": False,
+            "runtimes": ["nemoclaw", "openclaw"],
+            "features": [],
+            "error": str(exc),
+        }
+
+    if as_json:
+        print(_json.dumps(data, sort_keys=True, indent=2))
+        return
+
+    print("ClawMetry Entitlement\n" + "─" * 40)
+    print(f"  Tier:        {data.get('tier', 'oss')}")
+    print(f"  Source:      {data.get('source', 'oss')}")
+    print(f"  Paid:        {'yes' if data.get('is_paid') else 'no'}")
+    print(f"  Node limit:  {data.get('node_limit', 1)}")
+    grace = bool(data.get("grace", True))
+    enforced = bool(data.get("enforced", False))
+    print(f"  Grace:       {'on' if grace else 'off'}")
+    print(f"  Enforced:    {'yes' if enforced else 'no'}")
+    expiry = data.get("expiry")
+    if expiry:
+        import time as _t
+
+        days = int((float(expiry) - _t.time()) // 86400)
+        suffix = " (EXPIRED)" if data.get("expired") else f" (~{days} day(s) left)"
+        print(f"  Expiry:      {int(expiry)}{suffix}")
+    runtimes = data.get("runtimes") or []
+    features = data.get("features") or []
+    print(f"  Runtimes:    {', '.join(runtimes) if runtimes else '(none)'}")
+    if features:
+        # Wrap so a wide feature list doesn't run off a narrow terminal.
+        line = "  Features:    "
+        indent = " " * len(line)
+        wrapped = [line + features[0]]
+        for f in features[1:]:
+            if len(wrapped[-1]) + 2 + len(f) > 78:
+                wrapped.append(indent + f)
+            else:
+                wrapped[-1] = wrapped[-1] + ", " + f
+        for w in wrapped:
+            print(w)
+    else:
+        print("  Features:    (none — gates inert in grace)")
+    if "error" in data:
+        print(f"  Note:        resolution error fell back to OSS-free: {data['error']}")
+
+
 def _cmd_verify_integrity(args) -> None:
     """clawmetry verify-integrity — walk the hash chain and report validity."""
     from clawmetry.local_store import get_store
@@ -3255,6 +3336,18 @@ def main() -> None:
         help="License key (CLAW1.…) — required for 'activate'",
     )
 
+    # entitlement — show the resolved open-core entitlement (mirrors /api/entitlement)
+    p_entitlement = sub.add_parser(
+        "entitlement",
+        help="Show the resolved open-core entitlement (tier, runtimes, features)",
+    )
+    p_entitlement.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Emit the entitlement as JSON for scripting",
+    )
+
     # verify-integrity — walk hash chain and report validity (Issue #2200)
     p_verify = sub.add_parser(
         "verify-integrity",
@@ -3283,6 +3376,7 @@ def main() -> None:
         "uninstall",
         "activate",
         "license",
+        "entitlement",
         "verify-integrity",
         "nemoclaw-daemons",
     )
@@ -3318,6 +3412,8 @@ def main() -> None:
             _cmd_activate(args)
         elif args.cmd == "license":
             _cmd_license(args)
+        elif args.cmd == "entitlement":
+            _cmd_entitlement(args)
         elif args.cmd == "verify-integrity":
             _cmd_verify_integrity(args)
         elif args.cmd == "nemoclaw-daemons":

--- a/tests/test_cli_entitlement.py
+++ b/tests/test_cli_entitlement.py
@@ -1,0 +1,166 @@
+"""Tests for the ``clawmetry entitlement`` CLI subcommand.
+
+Mirrors the assertions in ``tests/test_entitlements.py`` for the HTTP route, but
+exercises the operator-facing CLI surface that prints the resolved entitlement
+to stdout. Headline invariants:
+
+* No license + no cloud cache + no ``CLAWMETRY_ENFORCE`` => OSS-free in grace,
+  human-readable output mentions ``Tier: oss`` and ``Grace: on``.
+* ``--json`` emits a parseable object whose keys match the
+  :func:`clawmetry.entitlements.Entitlement.to_dict` shape served at
+  ``GET /api/entitlement``, so scripts and the HTTP route are
+  interchangeable for operator tooling.
+* The handler never raises: a broken entitlements module still produces an
+  OSS-free fallback (matching the route's behaviour) plus a ``Note:`` line
+  in the human-readable rendering.
+"""
+from __future__ import annotations
+
+import importlib
+import io
+import json
+from contextlib import redirect_stdout
+
+import pytest
+
+import clawmetry.cli as cli
+
+
+@pytest.fixture
+def fresh_entitlements(monkeypatch, tmp_path):
+    """Re-import :mod:`clawmetry.entitlements` against an empty HOME so no real
+    ``~/.clawmetry/license.key`` or ``cloud_plan.json`` leaks into the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as ent
+
+    importlib.reload(ent)
+    ent.invalidate()
+    yield ent
+    ent.invalidate()
+
+
+class _Args:
+    """Minimal stand-in for the argparse Namespace the dispatcher passes."""
+
+    def __init__(self, as_json: bool = False):
+        self.as_json = as_json
+
+
+def _run(as_json: bool = False) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        cli._cmd_entitlement(_Args(as_json=as_json))
+    return buf.getvalue()
+
+
+# ── human-readable output ────────────────────────────────────────────────────
+
+
+def test_oss_free_default(fresh_entitlements):
+    out = _run()
+    assert "ClawMetry Entitlement" in out
+    assert "Tier:        oss" in out
+    assert "Source:      oss" in out
+    assert "Paid:        no" in out
+    assert "Grace:       on" in out
+    assert "Enforced:    no" in out
+
+
+def test_lists_free_runtimes(fresh_entitlements):
+    out = _run()
+    # OpenClaw + NemoClaw are the two free agent runtimes.
+    assert "openclaw" in out
+    assert "nemoclaw" in out
+    # Paid runtimes must not appear in the free entitlement runtime list.
+    assert "claude_code" not in out
+    assert "codex" not in out
+
+
+def test_lists_free_features(fresh_entitlements):
+    out = _run()
+    # A representative slice from FREE_FEATURES — the wrap logic might split
+    # the list across lines, so we just check membership.
+    for feat in ("sessions", "transcripts", "usage", "brain", "flow"):
+        assert feat in out
+
+
+# ── --json mode ──────────────────────────────────────────────────────────────
+
+
+def test_json_mode_emits_valid_json(fresh_entitlements):
+    out = _run(as_json=True)
+    data = json.loads(out)  # raises on garbage
+    assert isinstance(data, dict)
+
+
+def test_json_shape_matches_route(fresh_entitlements):
+    """The CLI's JSON object must be a superset of what /api/entitlement
+    returns — operator tooling that consumes one should work with the other."""
+    data = json.loads(_run(as_json=True))
+    for key in (
+        "tier", "source", "node_limit", "expiry", "expired", "is_paid",
+        "grace", "enforced", "runtimes", "features",
+    ):
+        assert key in data, f"missing key {key!r}"
+    assert data["tier"] == "oss"
+    assert data["source"] == "oss"
+    assert data["grace"] is True
+    assert data["enforced"] is False
+    assert data["is_paid"] is False
+    assert "openclaw" in data["runtimes"]
+    assert "nemoclaw" in data["runtimes"]
+
+
+# ── enforce-flag observability ───────────────────────────────────────────────
+
+
+def test_enforce_flips_human_output(fresh_entitlements, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    fresh_entitlements.invalidate()
+    out = _run()
+    assert "Grace:       off" in out
+    assert "Enforced:    yes" in out
+
+
+def test_enforce_flips_json_output(fresh_entitlements, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    fresh_entitlements.invalidate()
+    data = json.loads(_run(as_json=True))
+    assert data["grace"] is False
+    assert data["enforced"] is True
+
+
+# ── never-raise contract ─────────────────────────────────────────────────────
+
+
+def test_fallback_on_resolution_error(monkeypatch):
+    """If :mod:`clawmetry.entitlements` somehow blows up, the handler must
+    still print an OSS-free entitlement (matching the HTTP route fallback) and
+    surface the error via a ``Note:`` line — never raise to the operator."""
+    import clawmetry.entitlements as ent
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("simulated breakage")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    out = _run()
+    assert "Tier:        oss" in out
+    assert "Grace:       on" in out
+    assert "Note:" in out
+    assert "simulated breakage" in out
+
+
+def test_fallback_on_resolution_error_json(monkeypatch):
+    import clawmetry.entitlements as ent
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("simulated breakage")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    data = json.loads(_run(as_json=True))
+    assert data["tier"] == "oss"
+    assert data["grace"] is True
+    assert data["enforced"] is False
+    assert "openclaw" in data["runtimes"]
+    assert data.get("error") == "simulated breakage"


### PR DESCRIPTION
## Summary

Adds an operator-facing CLI surface for the resolved open-core entitlement. `clawmetry entitlement` prints a human-readable summary; `clawmetry entitlement --json` emits the same shape as `GET /api/entitlement` so scripts and the HTTP route are interchangeable.

## Why

`clawmetry license` already reports the on-disk license file. The full resolution — local license -> cloud plan cache -> OSS fallback — is only visible through the dashboard's `/api/entitlement` endpoint today, which means "my Pro key is installed but the UI still shows OSS" needs a curl loop to diagnose. This command closes the gap with a one-line operator check.

Complements the existing CLI surface:
- `clawmetry license` — what license file is installed and how much time is left
- `clawmetry entitlement` (new) — what tier/runtimes/features did the resolver actually pick

The entitlement-shaped APIs and CLI commands are now fully symmetric:

| Question | HTTP | CLI |
|----------|------|-----|
| "What does this install have access to?" | `GET /api/entitlement` | `clawmetry entitlement` |
| "What runtimes exist + which are locked?" | `GET /api/runtimes` | (dashboard-only) |
| "What license file is installed?" | `GET /api/license/status` | `clawmetry license` |

## Scope

- `clawmetry/cli.py`: `_cmd_entitlement(args)` handler + `entitlement` subparser + dispatch wiring + `_subcmds` entry. Never raises: any resolution error falls back to the same OSS-free shape that `routes/entitlement.py` returns to the dashboard, with the error surfaced via a `Note:` line (human) or `error` key (JSON).
- `tests/test_cli_entitlement.py` (new, 9 tests): OSS-free defaults, free runtimes (`openclaw`, `nemoclaw`) listed, paid runtimes absent, free features visible, `--json` shape is a superset of `/api/entitlement`, `CLAWMETRY_ENFORCE=1` flips both human + JSON output, and the never-raise fallback fires on a simulated module breakage.

No behaviour change for the dashboard or daemon — purely additive CLI. Grace mode is preserved end-to-end; no enforcement is added.

## Sample output

```text
$ clawmetry entitlement
ClawMetry Entitlement
────────────────────────────────────────
  Tier:        oss
  Source:      oss
  Paid:        no
  Node limit:  1
  Grace:       on
  Enforced:    no
  Runtimes:    nemoclaw, openclaw
  Features:    brain, channels, crons, flow, health, logs, nemo_governance
               overview, sessions, tracing, transcripts, usage

$ clawmetry entitlement --json | jq '.tier, .grace, .source'
"oss"
true
"oss"
```

## Test plan

- [x] `python3 -m pytest tests/test_cli_entitlement.py -v` — 9/9 pass
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_license.py tests/test_license_api.py tests/test_extensions.py tests/test_entitlements_catalogue.py tests/test_cli.py -q` — 82/82 pass (no regression in adjacent surfaces)
- [x] `python3 -m py_compile clawmetry/cli.py tests/test_cli_entitlement.py` — syntax clean
- [x] `ruff check tests/test_cli_entitlement.py` — clean (the 162 pre-existing findings in `clawmetry/cli.py` are unchanged; the lines this PR adds introduce zero new findings)
- [x] `python3 -m clawmetry.cli entitlement --help` — argparse renders the subcommand and `--json` flag
- [x] `python3 -m clawmetry.cli entitlement` — human-readable OSS-free summary
- [x] `python3 -m clawmetry.cli entitlement --json | python3 -m json.tool` — valid JSON parses
- [x] `CLAWMETRY_ENFORCE=1 python3 -m clawmetry.cli entitlement` — `Grace: off` / `Enforced: yes`

## Local operator verification checklist

I cannot reach the user's local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please complete on a real install:

1. `cp clawmetry/cli.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/cli.py`
2. `rm -f ~/.clawmetry/lib/python3.11/site-packages/clawmetry/__pycache__/cli*.pyc`
3. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (no daemon code changed, but restart to pick up the new CLI module)
4. `~/.clawmetry/bin/clawmetry entitlement` — should print the human summary; verify it agrees with `curl -s http://localhost:8900/api/entitlement` from the running dashboard
5. `~/.clawmetry/bin/clawmetry entitlement --json | jq .` — should parse as JSON and contain `tier`, `source`, `runtimes`, `features`, `grace`, `enforced`
6. After `clawmetry activate <KEY>` with a real Pro key, re-run `clawmetry entitlement` and confirm `Tier: pro` / `Source: license` / appropriate `Runtimes` and `Features`
7. Decrypt the live cloud snapshot to confirm no daemon-side regression (this PR is CLI-only; the snapshot shape is unchanged)
8. Browser check: load the dashboard and confirm `/api/entitlement` still returns the same shape the CLI prints

This PR is **draft-only**: I am not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Grace mode stays on. Once you have run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0179bAQJtCvLJMU8LcBd5hg3)_