### PR TITLE
feat(v2): wire i18next foundation into v2 SPA

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,8 +13,12 @@
         "@visx/scale": "^3.12.0",
         "@visx/shape": "^3.12.0",
         "framer-motion": "^12.40.0",
+        "i18next": "^23.0.0",
+        "i18next-browser-languagedetector": "^8.0.0",
+        "i18next-http-backend": "^2.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-i18next": "^14.0.0",
         "react-router-dom": "^6.27.0",
         "zustand": "^5.0.13"
       },
@@ -258,6 +262,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1481,6 +1494,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1743,6 +1765,56 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-http-backend": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.7.3.tgz",
+      "integrity": "sha512-FgZxrXdRA5u44xfYsJlEBL4/KH3f2IluBpgV/7riW0YW2VEyM8FzVt2XHAOi6id0Ppj7vZvCZVpp5LrGXnc8Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "4.0.0"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -1853,6 +1925,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.44",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
@@ -1939,6 +2031,28 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.3.tgz",
+      "integrity": "sha512-wZnpfunU6UIAiJ+bxwOiTmBOAaB14ha97MjOEnLGac2RJ+h/maIYXZuTHlmyqQVX1UVHmU1YDTQ5vxLmwfXTjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -2069,6 +2183,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2178,6 +2298,31 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,12 @@
     "@visx/scale": "^3.12.0",
     "@visx/shape": "^3.12.0",
     "framer-motion": "^12.40.0",
+    "i18next": "^23.0.0",
+    "i18next-browser-languagedetector": "^8.0.0",
+    "i18next-http-backend": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-i18next": "^14.0.0",
     "react-router-dom": "^6.27.0",
     "zustand": "^5.0.13"
   },

--- a/frontend/src/components/Topbar.tsx
+++ b/frontend/src/components/Topbar.tsx
@@ -7,7 +7,10 @@
 //   - LIVE / AWAIT / ALERT status pill (defaults to LIVE)
 //   - Pill-link "✨ You're on v2 (beta) · Back to v1 ↩" pointing at "/"
 //     (the cross-version link required by the README "What to communicate" rule)
+//   - Language picker (i18n foundation, issue #1986)
 
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 import { getNavItemBySlug } from "./nav";
 
@@ -41,6 +44,53 @@ function metaForPath(pathname: string): RouteMeta {
     title: getNavItemBySlug(slug)?.label ?? "ClawMetry v2",
     subtitle: "preview build",
   };
+}
+
+interface LangMeta {
+  code: string;
+  endonym: string;
+  enabled: boolean;
+}
+
+// Language picker that loads the shared _meta.json catalog and calls
+// i18n.changeLanguage() on selection.  Renders nothing until the catalog
+// arrives so there's no layout shift on fast connections.
+function LanguagePicker() {
+  const { i18n } = useTranslation();
+  const [langs, setLangs] = useState<LangMeta[]>([]);
+
+  useEffect(() => {
+    fetch("/static/locales/_meta.json")
+      .then((r) => r.json())
+      .then((data: LangMeta[]) => setLangs(data.filter((l) => l.enabled)))
+      .catch(() => {/* silently degrade when locales endpoint is unreachable */});
+  }, []);
+
+  if (langs.length === 0) return null;
+
+  return (
+    <select
+      aria-label="Language"
+      value={i18n.language}
+      onChange={(e) => void i18n.changeLanguage(e.target.value)}
+      style={{
+        fontSize: 11,
+        padding: "3px 6px",
+        borderRadius: 6,
+        border: "1px solid var(--line)",
+        background: "var(--paper)",
+        color: "var(--ink-3)",
+        cursor: "pointer",
+        fontFamily: "inherit",
+      }}
+    >
+      {langs.map((l) => (
+        <option key={l.code} value={l.code}>
+          {l.endonym}
+        </option>
+      ))}
+    </select>
+  );
 }
 
 export function Topbar() {
@@ -103,6 +153,9 @@ export function Topbar() {
         >
           share ↗
         </button>
+
+        {/* Language picker — loads _meta.json, calls i18n.changeLanguage() */}
+        <LanguagePicker />
 
         {/* Default LIVE pill — per-tab overrides land in week 2+ */}
         <span

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,0 +1,69 @@
+/**
+ * i18n.ts — i18next initialisation for the v2 SPA.
+ *
+ * Shares the same locale catalog as v1 (`clawmetry/static/locales/*.json`)
+ * via the HTTP backend; no duplicate translation files.
+ *
+ * Detection order (matches v1 PRD §3.4):
+ *   querystring ?lng=  →  cm-lang cookie  →  navigator.language  →  "en"
+ *
+ * RTL: on every language change the <html dir> attribute is updated so CSS
+ * logical properties take effect without a page reload.  The RTL set is
+ * pre-computed from _meta.json (ar, fa, he, ur).
+ *
+ * refs: issue #1986
+ */
+
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import Backend from "i18next-http-backend";
+
+// Languages whose base script runs right-to-left.
+// Derived from clawmetry/static/locales/_meta.json where dir === "rtl".
+const RTL_LANGS = new Set(["ar", "fa", "he", "ur"]);
+
+function applyDocumentDir(lng: string) {
+  const base = lng.split("-")[0];
+  document.documentElement.setAttribute(
+    "dir",
+    RTL_LANGS.has(base) ? "rtl" : "ltr",
+  );
+}
+
+i18n
+  .use(Backend)
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: "en",
+    // Allow any code listed in _meta.json; explicit list not needed because
+    // the HTTP backend will 404 on unknown codes and fall back to "en".
+    supportedLngs: false,
+    load: "currentOnly",
+    detection: {
+      order: ["querystring", "cookie", "navigator"],
+      lookupQuerystring: "lng",
+      lookupCookie: "cm-lang",
+      caches: ["cookie"],
+      cookieOptions: { sameSite: "strict", domain: ".clawmetry.com" },
+    },
+    backend: {
+      // Locale files served by Flask at /static/locales/<lng>.json.
+      // In dev, vite.config.ts proxies /static → Flask on :8900.
+      loadPath: "/static/locales/{{lng}}.json",
+    },
+    interpolation: {
+      escapeValue: false, // React already escapes output
+    },
+    react: {
+      useSuspense: true,
+    },
+  });
+
+i18n.on("languageChanged", applyDocumentDir);
+
+// Apply direction on init (fires after the first language is resolved).
+i18n.on("initialized", () => applyDocumentDir(i18n.language));
+
+export default i18n;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,6 @@
+// i18n must initialise before the React tree mounts so that the language
+// detector has resolved and the first render uses the correct locale.
+import "./i18n";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api": "http://localhost:8900",
+      "/static": "http://localhost:8900",
     },
   },
 });


### PR DESCRIPTION
Closes #1986

## Summary

- **`frontend/src/i18n.ts`** (new) — configures i18next with the HTTP backend loading `/static/locales/{{lng}}.json` (the same 37-language catalog v1 already serves), browser language detector (querystring `?lng=` → `cm-lang` cookie → `navigator.language` → `en`), and RTL `<html dir>` switching for ar/fa/he/ur on every language change
- **`frontend/src/main.tsx`** — imports `./i18n` before the React tree mounts so the detector resolves before the first render
- **`frontend/src/components/Topbar.tsx`** — adds `<LanguagePicker>`: fetches `_meta.json` on mount, renders a compact `<select>` with all 37 enabled languages by endonym, calls `i18n.changeLanguage()` on selection; degrades silently if the locales endpoint is unreachable
- **`frontend/vite.config.ts`** — proxies `/static → Flask :8900` in the dev server so locale JSON files are reachable at the same path as production without CORS plumbing
- **`frontend/package.json` + lockfile** — adds `i18next`, `react-i18next`, `i18next-browser-languagedetector`, `i18next-http-backend`

## Test plan

- [ ] `npx tsc --noEmit` in `frontend/` — passes clean (verified locally)
- [ ] `npm run dev` with Flask running on :8900 → navigate to `/v2/`, language picker appears in topbar, selecting a language applies `dir` attribute on `<html>` for RTL languages
- [ ] `?lng=ja` in the URL resolves to Japanese (querystring detection)
- [ ] Selecting a language sets the `cm-lang` cookie and persists on reload
- [ ] When Flask is not running, picker renders nothing (graceful degrade)

**Out of scope** (deferred per-tab):
- String extraction across existing page components (each tab PR will wrap its own strings)
- `i18next/no-literal-string` ESLint rule (enable once a tab completes its first extraction pass)
- Noto font subsets (design tokens already load Google Fonts)

https://claude.ai/code/session_012bhQdCFzKseYHFWpePqZgx

---
_Generated by [Claude Code](https://claude.ai/code/session_012bhQdCFzKseYHFWpePqZgx)_