### PR TITLE
feat(hitl): human-in-the-loop session pause API

### DIFF
--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -75,6 +75,15 @@ PROXY_CONFIG_FILE = CONFIG_DIR / "proxy.json"
 PROXY_DB_FILE = CONFIG_DIR / "proxy.db"
 PROXY_PID_FILE = CONFIG_DIR / "proxy.pid"
 PROXY_LOG_FILE = CONFIG_DIR / "proxy.log"
+_HITL_DIR = CONFIG_DIR / "hitl"
+
+
+def _is_session_hitl_paused(session_id: str) -> bool:
+    """Return True if an operator has flagged this session for HITL review."""
+    if not session_id:
+        return False
+    return (_HITL_DIR / f"pause_{session_id}").exists()
+
 
 # Model pricing per 1M tokens (input, output) — kept in sync with dashboard.py
 MODEL_PRICING = {
@@ -1359,6 +1368,25 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
             )
             logger.warning(f"Velocity exceeded: {spike_reason}")
             return _error_response(429, "velocity_exceeded", spike_reason, provider)
+
+        # ── HITL pause check ───────────────────────────────────────────
+        if _is_session_hitl_paused(session_id):
+            with _stats_lock:
+                _stats["blocked"] += 1
+            db.record_event(
+                "hitl_paused",
+                f"Session '{session_id}' paused for human review",
+                severity="warning",
+                details={"model": model, "session_id": session_id},
+            )
+            logger.warning("HITL: session '%s' blocked pending operator decision", session_id)
+            return _error_response(
+                503,
+                "session_paused",
+                f"Session '{session_id}' is paused for human-in-the-loop review. "
+                "Approve or reject via POST /api/hitl/decide.",
+                provider,
+            )
 
         # ── Model routing ──────────────────────────────────────────────
         new_model, new_provider = router.route(model, session_id)

--- a/dashboard.py
+++ b/dashboard.py
@@ -132,6 +132,7 @@ from routes.otel_export import bp_otel_export
 from routes.runtime_ingest import bp_runtime_ingest
 from routes.audit import bp_audit
 from routes.sla import bp_sla
+from routes.hitl import bp_hitl
 from helpers.openapi import bp_openapi
 
 # History / time-series module
@@ -10867,6 +10868,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_insights)
     app.register_blueprint(bp_review)
     app.register_blueprint(bp_evals)
+    app.register_blueprint(bp_hitl)
 
     # ── v2 React SPA (opt-in) ───────────────────────────────────────────────
     # Default OFF so existing v1 users notice nothing. Enabled when the user

--- a/routes/hitl.py
+++ b/routes/hitl.py
@@ -1,0 +1,166 @@
+"""routes/hitl.py — Human-in-the-loop (HITL) pause API.
+
+Implements issue #878: operator-initiated session pause mechanism that works
+without NemoClaw installed and without any cloud dependency.
+
+Pause state lives in ``~/.clawmetry/hitl/pause_<session_id>`` flag files.
+The proxy reads these files on every LLM API call (cheap ``Path.exists()``
+check) and returns 503 while a session is paused. Decisions are also written
+to the ``approvals`` DuckDB table so they appear in the audit log.
+
+Routes:
+  POST /api/hitl/flag              — flag a session for human review
+  GET  /api/hitl/pending           — list currently paused sessions
+  POST /api/hitl/decide            — approve or reject a flagged session
+  GET  /api/hitl/status/<sid>      — check pause state for one session
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import logging
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request
+
+log = logging.getLogger("clawmetry-hitl")
+
+bp_hitl = Blueprint("hitl", __name__)
+
+_HITL_DIR = Path.home() / ".clawmetry" / "hitl"
+
+
+def _flag_path(session_id: str) -> Path:
+    return _HITL_DIR / f"pause_{session_id}"
+
+
+def _ensure_dir() -> None:
+    _HITL_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _try_store_call(method_name: str, **kwargs):
+    """Best-effort LocalStore call: daemon proxy first, direct open as fallback."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=(method_name.startswith("query")))
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@bp_hitl.route("/api/hitl/flag", methods=["POST"])
+def hitl_flag():
+    """Flag a session for human review. Proxy will block its next LLM call."""
+    data = request.get_json(force=True, silent=True) or {}
+    session_id = (data.get("session_id") or "").strip()
+    reason = (data.get("reason") or "").strip()
+    operator = (data.get("operator") or "unknown").strip()
+
+    if not session_id:
+        return jsonify({"error": "session_id required"}), 400
+
+    _ensure_dir()
+    record = {
+        "session_id": session_id,
+        "reason": reason,
+        "operator": operator,
+        "flagged_at": time.time(),
+        "status": "pending",
+    }
+    _flag_path(session_id).write_text(json.dumps(record))
+    log.info("HITL flag: session=%s operator=%s reason=%r", session_id, operator, reason)
+
+    # Mirror into DuckDB approvals table for audit log visibility.
+    _try_store_call(
+        "ingest_approval",
+        approval={
+            "id": f"hitl_{session_id}",
+            "requestor_session_id": session_id,
+            "action": "hitl_review",
+            "status": "pending",
+            "resolver": operator,
+            "decision_reason": reason,
+            "created_at": str(int(time.time() * 1000)),
+        },
+    )
+
+    return jsonify({"flagged": True, "session_id": session_id, "operator": operator})
+
+
+@bp_hitl.route("/api/hitl/pending", methods=["GET"])
+def hitl_pending():
+    """Return all sessions currently paused for HITL."""
+    _ensure_dir()
+    sessions: list[dict] = []
+    for f in sorted(_HITL_DIR.glob("pause_*"), key=lambda p: p.stat().st_mtime):
+        try:
+            sessions.append(json.loads(f.read_text()))
+        except Exception:
+            sessions.append({"session_id": f.name.removeprefix("pause_"), "status": "pending"})
+    return jsonify({"sessions": sessions, "count": len(sessions)})
+
+
+@bp_hitl.route("/api/hitl/decide", methods=["POST"])
+def hitl_decide():
+    """Approve or reject a flagged session. Removes the pause flag so the proxy unblocks it."""
+    data = request.get_json(force=True, silent=True) or {}
+    session_id = (data.get("session_id") or "").strip()
+    decision = (data.get("decision") or "").strip().lower()
+    reason = (data.get("reason") or "").strip()
+    operator = (data.get("operator") or "unknown").strip()
+
+    if not session_id:
+        return jsonify({"error": "session_id required"}), 400
+    if decision not in ("approve", "reject"):
+        return jsonify({"error": "decision must be 'approve' or 'reject'"}), 400
+
+    flag = _flag_path(session_id)
+    if not flag.exists():
+        return jsonify({"error": "session not flagged for HITL"}), 404
+
+    flag.unlink()
+    log.info(
+        "HITL decision: session=%s decision=%s operator=%s reason=%r",
+        session_id, decision, operator, reason,
+    )
+
+    # Map to the approvals table vocabulary ("approve" → "approved", "reject" → "deny").
+    store_decision = "approve" if decision == "approve" else "deny"
+    _try_store_call(
+        "update_approval_decision",
+        approval_id=f"hitl_{session_id}",
+        decision=store_decision,
+        resolver=operator,
+        reason=reason,
+    )
+
+    return jsonify({
+        "decided": True,
+        "session_id": session_id,
+        "decision": decision,
+        "operator": operator,
+    })
+
+
+@bp_hitl.route("/api/hitl/status/<session_id>", methods=["GET"])
+def hitl_status(session_id: str):
+    """Return the current pause state for a single session."""
+    flag = _flag_path(session_id)
+    if not flag.exists():
+        return jsonify({"paused": False, "session_id": session_id})
+    try:
+        record = json.loads(flag.read_text())
+        return jsonify({"paused": True, **record})
+    except Exception:
+        return jsonify({"paused": True, "session_id": session_id})


### PR DESCRIPTION
Closes #878

## Summary

- **`routes/hitl.py`** (new, 166 LOC): Blueprint with 4 endpoints — `POST /api/hitl/flag`, `GET /api/hitl/pending`, `POST /api/hitl/decide`, `GET /api/hitl/status/<session_id>`
- **`clawmetry/proxy.py`** (+28 LOC): `_is_session_hitl_paused()` + pause check inserted after velocity check — returns 503 while a session is flagged, blocking any further LLM calls
- **`dashboard.py`** (+2 LOC): import and register `bp_hitl`

Pause state lives in flag files under `~/.clawmetry/hitl/pause_<session_id>` — a `Path.exists()` check is cheap enough for the proxy hot path and survives daemon restarts without needing DuckDB on the proxy side. Decisions are also mirrored to the `approvals` DuckDB table for audit log visibility.

Works in OSS-only mode (no NemoClaw, no cloud dependency required).

## Test plan

- [ ] `POST /api/hitl/flag` with `{"session_id": "test-123", "operator": "alice"}` → returns `{"flagged": true, ...}`, flag file created at `~/.clawmetry/hitl/pause_test-123`
- [ ] `GET /api/hitl/pending` → returns the flagged session
- [ ] `GET /api/hitl/status/test-123` → `{"paused": true, ...}`
- [ ] Start proxy on port 4100; send a request with header `X-Session-Id: test-123` → receives 503 `session_paused`
- [ ] `POST /api/hitl/decide` with `{"session_id": "test-123", "decision": "approve", "operator": "alice"}` → flag file deleted, proxy unblocks subsequent requests
- [ ] `GET /api/hitl/status/test-123` → `{"paused": false, ...}`
- [ ] 64 proxy unit tests still pass (`pytest tests/test_proxy.py tests/test_proxy_budget_abort.py`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SGs8pS8WUhyFJo97rP8iwy)_