### PR TITLE
fix(c6): remove visual-diff from required checks (path filter blocks non-UI PRs)

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -41,7 +41,6 @@ jobs:
             echo "  Using GITHUB_TOKEN (no E2E_ADMIN_PAT set) -- clawmetry only:"
             echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
             echo "  clawmetry         : Cross-repo handoff (C4)"
-            echo "  clawmetry         : visual-diff"
             echo ""
             echo "  For the remaining repos, run the equivalent workflow in each:"
             echo "  clawmetry-cloud   : Cloud golden-path browser E2E  (needs E2E_ADMIN_PAT or own workflow)"
@@ -50,10 +49,13 @@ jobs:
             echo "  Using E2E_ADMIN_PAT -- applying to all 3 repos:"
             echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
             echo "  clawmetry         : Cross-repo handoff (C4)"
-            echo "  clawmetry         : visual-diff"
             echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
             echo "  clawmetry-landing : Landing golden path (C3)"
           fi
+          echo ""
+          echo "  NOTE: visual-diff is not in this list -- pr-screenshots.yml has a"
+          echo "  paths: filter so it only runs on UI-touching PRs. Adding it as"
+          echo "  required would permanently block non-UI PRs."
           echo ""
           echo "Re-run with confirm=APPLY to apply."
 

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -14,7 +14,7 @@ When run inside GitHub Actions, GITHUB_REPOSITORY is set automatically
 to only the matching repo so that a GITHUB_TOKEN with single-repo
 Administration write access is sufficient.
 
-When run locally (GITHUB_REPOSITORY not set), the script applies all 5
+When run locally (GITHUB_REPOSITORY not set), the script applies all 4
 checks and requires a token with cross-repo Administration access.
 
 Requirements
@@ -43,15 +43,17 @@ OWNER = "vivekchand"
 # Job names verified against workflow files 2026-06-01:
 #   clawmetry/.github/workflows/oss-golden-path.yml      -> "OSS golden path (wheel + OpenClaw + 9 tabs)"
 #   clawmetry/.github/workflows/cross-repo-handoff.yml   -> "Cross-repo handoff (C4)"
-#   clawmetry/.github/workflows/pr-screenshots.yml       -> "visual-diff"
-#     (no `name:` on the job -- GitHub uses the job key; continue-on-error: true
-#      means the check always reports success, ensuring screenshots run on every PR)
 #   clawmetry-cloud/.github/workflows/e2e.yml            -> "Cloud golden-path browser E2E"
 #   clawmetry-landing/.github/workflows/landing-golden-path.yml -> "Landing golden path (C3)"
+#
+# visual-diff (pr-screenshots.yml) is intentionally excluded: that workflow
+# has a `paths:` filter so it only runs on PRs touching UI files. Adding it
+# as a required check would permanently stall non-UI PRs waiting for a check
+# that never fires. C5 (visual-diff covers all tabs) is already GREEN;
+# C6 only requires that the golden-path gates are required.
 REQUIRED_CHECKS: list[tuple[str, str]] = [
     ("clawmetry",         "OSS golden path (wheel + OpenClaw + 9 tabs)"),
     ("clawmetry",         "Cross-repo handoff (C4)"),
-    ("clawmetry",         "visual-diff"),
     ("clawmetry-cloud",   "Cloud golden-path browser E2E"),
     ("clawmetry-landing", "Landing golden path (C3)"),
 ]


### PR DESCRIPTION
## Problem

PR #2412 (merged 2026-06-01T09:09Z) added `("clawmetry", "visual-diff")` to `REQUIRED_CHECKS` in `scripts/apply_required_status_checks.py`. This is incorrect.

`pr-screenshots.yml` has a `paths:` filter:

```yaml
on:
  pull_request:
    paths:
      - "dashboard.py"
      - "routes/**"
      - "clawmetry/static/**"
      - "clawmetry/templates/**"
      - ...
```

The `visual-diff` job only runs on PRs that touch those paths. If `visual-diff` is registered as a required status check, every PR that does NOT touch UI files will stall permanently on "Expected -- Waiting for status to be reported." The check never fires on non-UI PRs, so those PRs can never be merged.

## Why this is urgent

PR #2420 is open (`mergeable_state: clean`) and adds `push: branches: [main]` to `apply-required-checks.yml`. When #2420 merges, the workflow fires automatically and runs `scripts/apply_required_status_checks.py` -- which still has `visual-diff` in `REQUIRED_CHECKS`. That call would add `visual-diff` as required and immediately break all non-UI PRs.

**This PR must merge before #2420 to prevent that.**

## Fix

- `scripts/apply_required_status_checks.py`: Remove `("clawmetry", "visual-diff")` from `REQUIRED_CHECKS`. Add explanatory comment. Update docstring count from 5 to 4.
- `.github/workflows/apply-required-checks.yml`: Remove `visual-diff` from dry-run output. Add a NOTE explaining why it is excluded.

## The correct 4 required checks

| Repo | Job name | Workflow | Path filter? |
|------|----------|----------|-------------|
| clawmetry | `OSS golden path (wheel + OpenClaw + 9 tabs)` | `oss-golden-path.yml` | No |
| clawmetry | `Cross-repo handoff (C4)` | `cross-repo-handoff.yml` | No |
| clawmetry-cloud | `Cloud golden-path browser E2E` | `e2e.yml` | No |
| clawmetry-landing | `Landing golden path (C3)` | `landing-golden-path.yml` | No |

All 4 run on every PR. `visual-diff` is intentionally excluded.

## C5 status

C5 (visual-diff covers all tabs post-auth) is already GREEN since 2026-05-23. The gateway token fix and all-tabs sweep are working correctly. C6 does not require `visual-diff` to be a hard gate -- it requires the **golden path** checks to be required.

## Merge order

1. Merge this PR first
2. Then merge #2420 (push trigger)

After both land, the push-triggered workflow fires and adds the correct 4 checks. C6 flips GREEN.

Tracking: #2146 (C6)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01URw6s6tNmHKtyyTym3RPQ8)_