### PR TITLE
feat(entitlement): add feature_catalog() + GET /api/features mirroring /api/runtimes

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -111,6 +111,12 @@ RUNTIME_LABELS = {
     "nanoclaw": "NanoClaw",
 }
 
+# ── Tier identifiers for feature_tier() ─────────────────────────────────────
+TIER_LABEL_FREE = "free"
+TIER_LABEL_STARTER = "starter"
+TIER_LABEL_PRO = "pro"
+TIER_LABEL_ENTERPRISE = "enterprise"
+
 # ── Feature catalogue ───────────────────────────────────────────────────────
 # Core observability — always free. Keys are stable identifiers the route /
 # UI layer checks via Entitlement.allows_feature(...).
@@ -184,6 +190,58 @@ ENTERPRISE_FEATURES = frozenset(
 )
 
 ALL_FEATURES = FREE_FEATURES | PAID_FEATURES | ENTERPRISE_FEATURES
+
+# Display labels for every known feature. Mirrors the copy /pricing on
+# clawmetry.com uses so the dashboard, the API and the marketing page agree on
+# what to call each feature. Missing labels fall back to a humanised
+# ``snake_case`` -> ``Snake Case`` derivation in :func:`feature_label`, so a
+# newly added feature key still renders with *something* readable while a
+# proper label gets reviewed.
+FEATURE_LABELS = {
+    # Free / core observability
+    "sessions": "Sessions",
+    "transcripts": "Transcripts",
+    "usage": "Token & cost usage",
+    "brain": "Reasoning brain feed",
+    "flow": "Message flow",
+    "tracing": "Tracing",
+    "health": "System health",
+    "logs": "Logs",
+    "crons": "Cron jobs",
+    "channels": "Chat channels",
+    "nemo_governance": "NeMo governance",
+    "overview": "Overview dashboard",
+    # Starter
+    "multi_runtime": "Multi-runtime support",
+    "fleet": "Multi-node fleet",
+    "cloud_sync": "Cloud sync",
+    "all_channels": "All chat channel adapters",
+    "approval_queue": "Approval queue",
+    "budget_limits": "Budget limits",
+    "per_runtime_health_timeline": "Per-runtime health timeline",
+    # Pro-only
+    "per_run_waste_flags": "Per-run waste flags",
+    "per_run_compare": "Per-run compare (A vs B)",
+    "error_triage": "Error triage",
+    "self_evolve": "Self-Evolve",
+    "asset_registry": "Asset registry",
+    "eval_suite": "Eval suite",
+    "tool_policy": "Tool policy",
+    "otel_export": "OpenTelemetry export",
+    "custom_webhooks": "Custom webhooks",
+    "custom_runtime_ingest": "Custom runtime ingest",
+    "custom_alerts": "Custom alerts",
+    "alert_webhooks": "Alert webhooks",
+    "anomaly_detection": "Anomaly detection",
+    "cost_optimizer": "Cost optimizer",
+    # Enterprise
+    "siem_export": "SIEM export",
+    "sso": "SSO (SAML / OIDC)",
+    "audit_logs": "Audit logs",
+    "rbac": "Role-based access control",
+    "air_gapped_license": "Air-gapped licensing",
+    "custom_data_residency": "Custom data residency",
+}
 
 # Per-tier paid feature grants (free features are always included on top).
 _TIER_FEATURES = {
@@ -481,4 +539,88 @@ def runtime_catalog() -> list[dict]:
                 "entitled": ent.entitled_runtime(rt),
             }
         )
+    return out
+
+
+def feature_label(feature: str) -> str:
+    """Human-readable label for ``feature``. Falls back to a humanised version
+    of the feature id when no explicit label is registered, so an unknown or
+    newly-added feature still renders with *something* readable."""
+    fid = (feature or "").strip()
+    if not fid:
+        return ""
+    if fid in FEATURE_LABELS:
+        return FEATURE_LABELS[fid]
+    return fid.replace("_", " ").strip().capitalize()
+
+
+def feature_tier(feature: str) -> str:
+    """Which tier bucket ``feature`` belongs to.
+
+    Returns one of ``"free"``, ``"starter"``, ``"pro"``, ``"enterprise"``.
+    Unknown features default to ``"pro"`` so the UI errs on the safe side
+    (showing a locked affordance) rather than silently leaking access.
+    """
+    fid = (feature or "").strip()
+    if fid in FREE_FEATURES:
+        return TIER_LABEL_FREE
+    if fid in STARTER_FEATURES:
+        return TIER_LABEL_STARTER
+    if fid in PRO_ONLY_FEATURES:
+        return TIER_LABEL_PRO
+    if fid in ENTERPRISE_FEATURES:
+        return TIER_LABEL_ENTERPRISE
+    return TIER_LABEL_PRO
+
+
+def feature_catalog() -> list[dict]:
+    """The full feature catalog with the entitlement-derived availability for
+    each entry. Companion to :func:`runtime_catalog` — single source of truth
+    the UI uses to render *every* known feature (free / starter / pro /
+    enterprise) so the locked-but-visible upgrade affordance and the
+    /pricing-style comparison table have data to render against.
+
+    Each entry::
+
+        {
+          "id":      "<feature>",           # canonical key
+          "label":   "<Display Name>",      # falls back to a humanised id
+          "tier":    "free"|"starter"|"pro"|"enterprise",
+          "free":    True | False,          # FREE_FEATURES membership
+          "allowed": True | False,          # entitlement allows the feature
+          "locked":  True | False,          # paid + not allowed (UI shows 🔒)
+        }
+
+    Ordering: free first, then starter, pro, enterprise — each bucket sorted
+    alphabetically — so the UI list is deterministic.
+
+    Never raises; on any resolution error every paid feature is reported as
+    ``locked=False`` (grace) to match the OSS-free fallback in
+    :func:`get_entitlement`.
+    """
+    try:
+        ent = get_entitlement()
+    except Exception as exc:  # never crash a catalog read
+        logger.warning("entitlements: feature_catalog falling back to grace: %s", exc)
+        ent = _oss_free()
+    buckets = (
+        (TIER_LABEL_FREE, sorted(FREE_FEATURES), True),
+        (TIER_LABEL_STARTER, sorted(STARTER_FEATURES), False),
+        (TIER_LABEL_PRO, sorted(PRO_ONLY_FEATURES), False),
+        (TIER_LABEL_ENTERPRISE, sorted(ENTERPRISE_FEATURES), False),
+    )
+    out: list[dict] = []
+    for tier_name, feats, is_free in buckets:
+        for fid in feats:
+            allowed = True if is_free else ent.allows_feature(fid)
+            out.append(
+                {
+                    "id": fid,
+                    "label": feature_label(fid),
+                    "tier": tier_name,
+                    "free": is_free,
+                    "allowed": allowed,
+                    "locked": (not is_free) and (not allowed),
+                }
+            )
     return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8,6 +8,7 @@ is the single source of truth — handlers never re-derive tier logic here.
 
   GET /api/entitlement — the current Entitlement as JSON.
   GET /api/runtimes    — the full runtime catalog with locked/free flags.
+  GET /api/features    — the full feature catalog with locked/free flags.
 
 Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
 on the cloud side: when no license/cloud plan is present it returns a graceful
@@ -107,6 +108,71 @@ def api_runtimes():
                         "locked": False,
                     },
                 ],
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/features")
+def api_features():
+    """Return the full feature catalog with per-feature ``tier``/``free``/
+    ``allowed``/``locked`` flags so the dashboard can render *every* known
+    feature in a paywall / upgrade table — including paid ones the install
+    cannot currently use — and overlay a lock affordance on the locked rows
+    once enforcement is on.
+
+    Shape::
+
+        {
+          "features": [
+            {"id": "sessions", "label": "Sessions", "tier": "free",
+             "free": true, "allowed": true, "locked": false},
+            {"id": "multi_runtime", "label": "Multi-runtime support",
+             "tier": "starter", "free": false, "allowed": true,
+             "locked": false},
+            ...
+          ],
+          "grace":    true | false,   # mirrors /api/entitlement.grace
+          "enforced": true | false
+        }
+
+    Side-effect-free and never-raise: any resolution error falls back to a
+    grace OSS-free shape with just the free features unlocked, so the UI
+    still has something safe to render.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "features": _ent.feature_catalog(),
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_features: falling back to OSS-free: %s", exc)
+        try:
+            from clawmetry import entitlements as _ent
+
+            free_only = [
+                {
+                    "id": fid,
+                    "label": _ent.feature_label(fid),
+                    "tier": "free",
+                    "free": True,
+                    "allowed": True,
+                    "locked": False,
+                }
+                for fid in sorted(_ent.FREE_FEATURES)
+            ]
+        except Exception:
+            free_only = []
+        return jsonify(
+            {
+                "features": free_only,
                 "grace": True,
                 "enforced": False,
             }

--- a/tests/test_features_catalogue.py
+++ b/tests/test_features_catalogue.py
@@ -1,0 +1,322 @@
+"""Tests for the feature catalogue helpers + ``/api/features`` endpoint.
+
+Companion to ``tests/test_entitlements_catalogue.py`` (which pins the
+per-tier feature sets) and ``tests/test_routes_runtimes.py`` (which covers
+the runtime catalog endpoint). Where those tests guard the upstream catalogue
+and the runtime API surface, this file guards the *feature* catalogue helpers
+and the new ``/api/features`` route that the dashboard reads to render a
+paywall/upgrade table for every known feature.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module + clean HOME, no enforce flag set."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client wired with bp_entitlement against a clean HOME."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── feature_label() ──────────────────────────────────────────────────────────
+
+
+def test_feature_label_known_keys(ent):
+    """Every known feature in the catalogue has a non-blank label."""
+    for fid in ent.ALL_FEATURES:
+        label = ent.feature_label(fid)
+        assert isinstance(label, str)
+        assert label.strip(), f"label for {fid!r} is blank"
+
+
+def test_feature_label_falls_back_to_humanised_id(ent):
+    """Unknown feature ids degrade gracefully into a humanised label."""
+    assert ent.feature_label("brand_new_thing") == "Brand new thing"
+
+
+def test_feature_label_handles_empty_and_none(ent):
+    assert ent.feature_label("") == ""
+    assert ent.feature_label(None) == ""
+
+
+# ── feature_tier() ───────────────────────────────────────────────────────────
+
+
+def test_feature_tier_classifies_free(ent):
+    for fid in ent.FREE_FEATURES:
+        assert ent.feature_tier(fid) == "free", fid
+
+
+def test_feature_tier_classifies_starter(ent):
+    for fid in ent.STARTER_FEATURES:
+        assert ent.feature_tier(fid) == "starter", fid
+
+
+def test_feature_tier_classifies_pro(ent):
+    for fid in ent.PRO_ONLY_FEATURES:
+        assert ent.feature_tier(fid) == "pro", fid
+
+
+def test_feature_tier_classifies_enterprise(ent):
+    for fid in ent.ENTERPRISE_FEATURES:
+        assert ent.feature_tier(fid) == "enterprise", fid
+
+
+def test_feature_tier_unknown_defaults_to_pro(ent):
+    """Unknown feature ids default to ``pro`` so the UI errs on the side of
+    showing a lock affordance rather than silently leaking access."""
+    assert ent.feature_tier("never_heard_of_this") == "pro"
+
+
+# ── feature_catalog() ────────────────────────────────────────────────────────
+
+
+def test_feature_catalog_includes_every_known_feature(ent):
+    """Catalog must cover every key in ALL_FEATURES exactly once."""
+    cat = ent.feature_catalog()
+    ids = [row["id"] for row in cat]
+    assert sorted(ids) == sorted(ent.ALL_FEATURES)
+    assert len(ids) == len(set(ids)), "duplicate feature ids in catalog"
+
+
+def test_feature_catalog_row_shape_is_stable(ent):
+    """Each row carries the keys the frontend reads — defends against an
+    accidental rename breaking the paywall table."""
+    cat = ent.feature_catalog()
+    for row in cat:
+        for key in ("id", "label", "tier", "free", "allowed", "locked"):
+            assert key in row, row
+        assert isinstance(row["id"], str)
+        assert isinstance(row["label"], str)
+        assert row["tier"] in ("free", "starter", "pro", "enterprise"), row
+        assert isinstance(row["free"], bool)
+        assert isinstance(row["allowed"], bool)
+        assert isinstance(row["locked"], bool)
+        # locked = paid-and-not-allowed; mutually exclusive with free=True.
+        if row["free"]:
+            assert row["locked"] is False, row
+            assert row["allowed"] is True, row
+
+
+def test_feature_catalog_ordering_is_deterministic(ent):
+    """Ordering: free -> starter -> pro -> enterprise, each alphabetical."""
+    cat = ent.feature_catalog()
+    # Tier appearance order must match the spec.
+    tier_seen = []
+    for row in cat:
+        if not tier_seen or tier_seen[-1] != row["tier"]:
+            tier_seen.append(row["tier"])
+    assert tier_seen == ["free", "starter", "pro", "enterprise"]
+    # Within each tier, ids must be sorted alphabetically.
+    by_tier: dict[str, list[str]] = {}
+    for row in cat:
+        by_tier.setdefault(row["tier"], []).append(row["id"])
+    for tier, ids in by_tier.items():
+        assert ids == sorted(ids), f"{tier} not alpha-sorted: {ids}"
+
+
+def test_feature_catalog_grace_locks_nothing(ent):
+    """Default grace mode: every paid feature reports locked=False so the UI
+    behaves exactly as it did before the catalog existed."""
+    cat = ent.feature_catalog()
+    for row in cat:
+        assert row["locked"] is False, row
+        assert row["allowed"] is True, row
+
+
+def test_feature_catalog_enforced_oss_locks_paid(monkeypatch, tmp_path):
+    """CLAWMETRY_ENFORCE=1 with no license: free stays unlocked, paid locks."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    cat = e.feature_catalog()
+    rows = {row["id"]: row for row in cat}
+    # Spot-check the headline free feature.
+    assert rows["sessions"]["locked"] is False
+    assert rows["sessions"]["allowed"] is True
+    # Starter / Pro / Enterprise representatives all lock in OSS-enforced.
+    for fid in ("multi_runtime", "self_evolve", "siem_export"):
+        assert rows[fid]["locked"] is True, fid
+        assert rows[fid]["allowed"] is False, fid
+
+
+def test_feature_catalog_cloud_starter_unlocks_starter_only(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_starter"}))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    rows = {row["id"]: row for row in e.feature_catalog()}
+    # Starter unlocks.
+    assert rows["multi_runtime"]["locked"] is False
+    assert rows["budget_limits"]["locked"] is False
+    # Pro and Enterprise stay locked.
+    assert rows["self_evolve"]["locked"] is True
+    assert rows["siem_export"]["locked"] is True
+
+
+def test_feature_catalog_cloud_pro_unlocks_starter_plus_pro(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    rows = {row["id"]: row for row in e.feature_catalog()}
+    assert rows["multi_runtime"]["locked"] is False
+    assert rows["self_evolve"]["locked"] is False
+    assert rows["otel_export"]["locked"] is False
+    # Enterprise still locked under cloud_pro.
+    assert rows["siem_export"]["locked"] is True
+    assert rows["sso"]["locked"] is True
+
+
+def test_feature_catalog_enterprise_unlocks_everything(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "enterprise"}))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    cat = e.feature_catalog()
+    for row in cat:
+        assert row["locked"] is False, row
+        assert row["allowed"] is True, row
+
+
+# ── /api/features endpoint ───────────────────────────────────────────────────
+
+
+def test_api_features_shape_grace(client):
+    resp = client.get("/api/features")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert "features" in d
+    assert "grace" in d
+    assert "enforced" in d
+    assert d["grace"] is True
+    assert d["enforced"] is False
+    assert isinstance(d["features"], list)
+    assert len(d["features"]) >= 1
+    # Grace defaults: every row reports locked=False.
+    for row in d["features"]:
+        assert row["locked"] is False, row
+
+
+def test_api_features_grace_enforced_are_inverse(client):
+    """grace and enforced must always be exact inverses."""
+    d = client.get("/api/features").get_json()
+    assert d["grace"] == (not d["enforced"])
+
+
+def test_api_features_enforced_oss_locks_paid(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/features").get_json()
+
+    assert d["grace"] is False
+    assert d["enforced"] is True
+    rows = {row["id"]: row for row in d["features"]}
+    assert rows["sessions"]["locked"] is False
+    assert rows["multi_runtime"]["locked"] is True
+    assert rows["siem_export"]["locked"] is True
+
+
+def test_api_features_paid_tier_unlocks_paid_features(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/features").get_json()
+
+    rows = {row["id"]: row for row in d["features"]}
+    assert rows["self_evolve"]["locked"] is False
+    assert rows["multi_runtime"]["locked"] is False
+    # Enterprise still locked.
+    assert rows["siem_export"]["locked"] is True
+
+
+def test_api_features_never_raises_on_broken_module(monkeypatch, client):
+    """A resolution error must degrade to a graceful free-only response,
+    never a 5xx — the dashboard reads this endpoint on every page load."""
+    import clawmetry.entitlements as e
+
+    def _boom():
+        raise RuntimeError("simulated catalog breakage")
+
+    monkeypatch.setattr(e, "feature_catalog", _boom)
+    resp = client.get("/api/features")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["grace"] is True
+    assert d["enforced"] is False
+    # Fallback still emits the free features so the UI has something to show.
+    ids = {row["id"] for row in d["features"]}
+    for fid in ("sessions", "overview", "channels"):
+        assert fid in ids
+    for row in d["features"]:
+        assert row["tier"] == "free"
+        assert row["locked"] is False


### PR DESCRIPTION
## Summary

Adds a feature catalog that mirrors the existing `runtime_catalog()` / `GET /api/runtimes` pattern for *features*. The dashboard already has a single source of truth for which runtimes to render free vs locked; until now it had no equivalent for the feature columns the upgrade table needs. This PR closes that gap with a side-effect-free, never-raise endpoint and the helpers behind it.

The three entitlement-shaped endpoints are now fully symmetric:

| Question | HTTP | Helper |
|----------|------|--------|
| "What does this install have access to?" | `GET /api/entitlement` | `get_entitlement()` |
| "What runtimes exist + which are locked?" | `GET /api/runtimes` | `runtime_catalog()` |
| "What features exist + which are locked?" (new) | `GET /api/features` | `feature_catalog()` |

No enforcement is added. Grace mode is preserved end-to-end — every paid row reports `locked=False` until `CLAWMETRY_ENFORCE=1` flips it on. Catalog is purely additive.

## Changes

- `clawmetry/entitlements.py`:
  - `FEATURE_LABELS` dict with copy that matches `/pricing`
  - `feature_label(fid)` helper, humanised id fallback for unknown keys
  - `feature_tier(fid)` helper returning `free|starter|pro|enterprise`, defaulting to `pro` for unknown ids so the UI errs on the locked side rather than silently leaking access
  - `feature_catalog()` returning `{id, label, tier, free, allowed, locked}` rows, deterministically ordered free → starter → pro → enterprise with each bucket alphabetical. Never-raises; on any resolution error falls back to the OSS-free shape via `_oss_free()`.

- `routes/entitlement.py`:
  - `GET /api/features` returning `{features, grace, enforced}`
  - Never-raise fallback emits the free features so the UI always has something safe to render — never a 5xx, the dashboard reads this on every page load.

- `tests/test_features_catalogue.py` (new, 21 tests):
  - Shape invariants: every `ALL_FEATURES` entry appears exactly once, no duplicates, all required keys present with correct types
  - Label fallback: known keys carry a non-blank label; unknown keys degrade to a humanised id; empty/`None` return `""`
  - Tier classification: free / starter / pro / enterprise buckets resolve correctly; unknown ids default to `pro`
  - Deterministic ordering: tiers appear `free → starter → pro → enterprise`, each alphabetical within
  - Grace locks nothing: default mode has `locked=False` for every row
  - Enforced OSS locks paid: with `CLAWMETRY_ENFORCE=1` and no license, paid representatives (`multi_runtime`, `self_evolve`, `siem_export`) lock
  - Per-tier unlock checks: `cloud_starter` unlocks Starter only; `cloud_pro` unlocks Starter + Pro but leaves Enterprise locked; `enterprise` unlocks everything
  - API endpoint: shape, `grace == not enforced` invariant, paid-tier unlocks
  - Never-raise simulation: monkey-patches `feature_catalog` to raise; the endpoint still returns 200 with the free features so the UI degrades gracefully

## Response shapes

```jsonc
// Default (grace) — every row unlocked
{
  "features": [
    {"id": "sessions", "label": "Sessions", "tier": "free",
     "free": true, "allowed": true, "locked": false},
    {"id": "multi_runtime", "label": "Multi-runtime support",
     "tier": "starter", "free": false, "allowed": true, "locked": false},
    {"id": "self_evolve", "label": "Self-Evolve",
     "tier": "pro", "free": false, "allowed": true, "locked": false},
    {"id": "siem_export", "label": "SIEM export",
     "tier": "enterprise", "free": false, "allowed": true, "locked": false}
  ],
  "grace": true,
  "enforced": false
}

// CLAWMETRY_ENFORCE=1 with no license — paid rows lock
{"features": [..., {"id": "self_evolve", ..., "allowed": false, "locked": true}, ...],
 "grace": false, "enforced": true}

// Resolution error fallback (never-raise)
{"features": [<free features only>], "grace": true, "enforced": false}
```

## Test plan

- [x] `python3 -m pytest tests/test_features_catalogue.py -v` — 21/21 pass
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_routes_runtimes.py tests/test_entitlements_catalogue.py tests/test_license.py tests/test_license_api.py tests/test_extensions.py -q` — 79/79 pass (no regression in adjacent surfaces)
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_features_catalogue.py` — syntax clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_features_catalogue.py` — clean
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — clean

## Local operator verification checklist

I cannot reach the user's local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please complete on a real install:

1. `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/entitlements.py`
2. `cp routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/routes/entitlement.py`
3. `rm -f ~/.clawmetry/lib/python3.11/site-packages/clawmetry/__pycache__/entitlements*.pyc ~/.clawmetry/lib/python3.11/site-packages/routes/__pycache__/entitlement*.pyc`
4. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (and restart the dashboard if running)
5. `curl -s http://localhost:8900/api/features | python3 -m json.tool` — should print a non-empty `features` array, `grace: true`, `enforced: false`, and every `locked: false`
6. `curl -s http://localhost:8900/api/features | python3 -c "import json,sys; d=json.load(sys.stdin); print({r['tier'] for r in d['features']})"` — should be exactly `{'free', 'starter', 'pro', 'enterprise'}`
7. `CLAWMETRY_ENFORCE=1 ~/.clawmetry/bin/clawmetry` (in a side terminal) → `curl -s http://localhost:8900/api/features | jq '.features[] | select(.id=="self_evolve")'` — should show `allowed: false`, `locked: true`
8. After `clawmetry activate <KEY>` with a real Pro key, re-curl `/api/features` and confirm Pro features now report `locked: false`
9. Decrypt the live cloud snapshot to confirm no daemon-side regression (this PR is dashboard-only, no daemon code changed, so the snapshot shape is unchanged)
10. Browser check: load the dashboard and confirm `/api/features` is reachable via the network panel; no UI is wired up in this PR so there is nothing visual to verify yet

This PR is **draft-only**: I am not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Grace mode stays on. Once you have run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDN8WEVm85ghrjWWm1jxTm)_