### PR TITLE
fix(c6): remove visual-diff from required checks + clean up if already applied

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -5,8 +5,8 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #
 # Triggers:
 #   push to main: automatically re-applies required checks on every merge
-#     so the configuration is self-healing. No manual action needed after
-#     this PR is merged.
+#     so the configuration is self-healing. Also removes any deprecated
+#     checks (e.g. visual-diff) if they were previously added in error.
 #   workflow_dispatch: manual trigger from the Actions UI. Use confirm=APPLY
 #     to apply immediately; anything else previews what would change.
 #
@@ -47,7 +47,10 @@ jobs:
             echo "  Using GITHUB_TOKEN (no E2E_ADMIN_PAT set) -- clawmetry only:"
             echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
             echo "  clawmetry         : Cross-repo handoff (C4)"
-            echo "  clawmetry         : visual-diff"
+            echo ""
+            echo "  NOTE: visual-diff is excluded -- pr-screenshots.yml has a paths:"
+            echo "  filter so it only runs on UI-touching PRs. Requiring it would"
+            echo "  permanently stall non-UI PRs."
             echo ""
             echo "  For the remaining repos, the push-triggered workflow in each"
             echo "  repo handles those repos automatically on next merge."
@@ -55,10 +58,16 @@ jobs:
             echo "  Using E2E_ADMIN_PAT -- applying to all 3 repos:"
             echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
             echo "  clawmetry         : Cross-repo handoff (C4)"
-            echo "  clawmetry         : visual-diff"
             echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
             echo "  clawmetry-landing : Landing golden path (C3)"
+            echo ""
+            echo "  NOTE: visual-diff is excluded -- pr-screenshots.yml has a paths:"
+            echo "  filter so it only runs on UI-touching PRs. Requiring it would"
+            echo "  permanently stall non-UI PRs."
           fi
+          echo ""
+          echo "  Also removes visual-diff from required checks if it was previously"
+          echo "  added in error (self-healing DEPRECATED_CHECKS cleanup)."
           echo ""
           echo "Re-run with confirm=APPLY to apply."
 

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -158,6 +158,43 @@ def remove_required_check(repo: str, context: str, token: str) -> None:
     print(f"  [{repo}] removed deprecated check ({len(updated)} remaining): {context!r}")
 
 
+def verify_required_checks(
+    checks: list[tuple[str, str]],
+    deprecated: list[tuple[str, str]],
+    token: str,
+) -> bool:
+    """Read back branch protection state and assert it matches intent.
+
+    Returns True if all required checks are present and no deprecated checks
+    remain. Prints a FAIL line for each discrepancy so CI logs are actionable.
+    Catches silent 403 / administration:write failures before they go unnoticed.
+    """
+    repos = dict.fromkeys([r for r, _ in checks + deprecated])
+    ok = True
+    for repo in repos:
+        path = f"/repos/{OWNER}/{repo}/branches/main/protection/required_status_checks"
+        try:
+            current = _api("GET", path, token=token)
+            actual: set[str] = set(current.get("contexts", []))
+        except RuntimeError as exc:
+            print(f"  [{repo}] FAIL: could not read required checks: {exc}")
+            ok = False
+            continue
+        required = {ctx for r, ctx in checks if r == repo}
+        blocked = {ctx for r, ctx in deprecated if r == repo}
+        missing = required - actual
+        stale = blocked & actual
+        if missing:
+            print(f"  [{repo}] FAIL: check not yet required: {sorted(missing)}")
+            ok = False
+        if stale:
+            print(f"  [{repo}] FAIL: deprecated check still present: {sorted(stale)}")
+            ok = False
+        if not missing and not stale:
+            print(f"  [{repo}] OK: {sorted(actual)}")
+    return ok
+
+
 def _checks_to_apply() -> list[tuple[str, str]]:
     """Return the subset of REQUIRED_CHECKS applicable to the current context.
 
@@ -245,6 +282,19 @@ def main() -> None:
     print("Verify at:")
     for repo in dict.fromkeys(r for r, _ in checks):
         print(f"  https://github.com/{OWNER}/{repo}/settings/branches")
+
+    print()
+    print("=== Verification: reading back branch protection state ===")
+    if not verify_required_checks(checks, deprecated, token):
+        print()
+        print(
+            "ERROR: branch protection state does not match expected config (see above).\n"
+            "If this is a 403, GITHUB_TOKEN may not have administration:write on this "
+            "repo. Set E2E_ADMIN_PAT as a repo secret (fine-grained PAT, "
+            "Administration read+write) and re-run."
+        )
+        sys.exit(2)
+    print("=== Verification passed: C6 branch protection is correctly configured ===")
 
 
 if __name__ == "__main__":

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -2,8 +2,8 @@
 """Apply required status checks for E2E Robustness criterion C6.
 
 This script is idempotent: running it multiple times is safe.
-It adds the named E2E job checks without removing any existing
-required status checks on main.
+It adds checks listed in REQUIRED_CHECKS and removes any in DEPRECATED_CHECKS
+from the main branch protection of each repo.
 
 Usage
 -----
@@ -14,7 +14,7 @@ When run inside GitHub Actions, GITHUB_REPOSITORY is set automatically
 to only the matching repo so that a GITHUB_TOKEN with single-repo
 Administration write access is sufficient.
 
-When run locally (GITHUB_REPOSITORY not set), the script applies all 5
+When run locally (GITHUB_REPOSITORY not set), the script applies all 4
 checks and requires a token with cross-repo Administration access.
 
 Requirements
@@ -43,17 +43,29 @@ OWNER = "vivekchand"
 # Job names verified against workflow files 2026-06-01:
 #   clawmetry/.github/workflows/oss-golden-path.yml      -> "OSS golden path (wheel + OpenClaw + 9 tabs)"
 #   clawmetry/.github/workflows/cross-repo-handoff.yml   -> "Cross-repo handoff (C4)"
-#   clawmetry/.github/workflows/pr-screenshots.yml       -> "visual-diff"
-#     (no `name:` on the job -- GitHub uses the job key; continue-on-error: true
-#      means the check always reports success, ensuring screenshots run on every PR)
 #   clawmetry-cloud/.github/workflows/e2e.yml            -> "Cloud golden-path browser E2E"
 #   clawmetry-landing/.github/workflows/landing-golden-path.yml -> "Landing golden path (C3)"
+#
+# visual-diff (pr-screenshots.yml) is intentionally excluded: that workflow has
+# a paths: filter so the job only runs on PRs that touch UI files. Adding it as
+# a required check would permanently stall non-UI PRs on "Expected -- Waiting
+# for status to be reported."
 REQUIRED_CHECKS: list[tuple[str, str]] = [
     ("clawmetry",         "OSS golden path (wheel + OpenClaw + 9 tabs)"),
     ("clawmetry",         "Cross-repo handoff (C4)"),
-    ("clawmetry",         "visual-diff"),
     ("clawmetry-cloud",   "Cloud golden-path browser E2E"),
     ("clawmetry-landing", "Landing golden path (C3)"),
+]
+
+# Checks previously added as required that must be actively removed.
+# This list is processed on every run so the script is self-healing:
+# if a deprecated check re-appears (e.g. via a manual UI edit) it is
+# removed on the next push-triggered run.
+DEPRECATED_CHECKS: list[tuple[str, str]] = [
+    # Added in error before 2026-06-02: pr-screenshots.yml has a paths: filter
+    # so visual-diff only fires on UI-touching PRs. As a required check it
+    # permanently stalls non-UI PRs waiting for a status that never arrives.
+    ("clawmetry", "visual-diff"),
 ]
 
 
@@ -127,6 +139,25 @@ def add_required_check(repo: str, context: str, token: str) -> None:
     print(f"  [{repo}] added required check ({len(existing)} total): {context!r}")
 
 
+def remove_required_check(repo: str, context: str, token: str) -> None:
+    """Idempotently remove context from required status checks on repo/main."""
+    path = f"/repos/{OWNER}/{repo}/branches/main/protection/required_status_checks"
+    try:
+        current = _api("GET", path, token=token)
+        existing: list[str] = current.get("contexts", [])
+    except RuntimeError:
+        print(f"  [{repo}] no branch protection found, skipping removal of: {context!r}")
+        return
+
+    if context not in existing:
+        print(f"  [{repo}] not present (clean), nothing to remove: {context!r}")
+        return
+
+    updated = [c for c in existing if c != context]
+    _api("PATCH", path, body={"strict": False, "contexts": updated}, token=token)
+    print(f"  [{repo}] removed deprecated check ({len(updated)} remaining): {context!r}")
+
+
 def _checks_to_apply() -> list[tuple[str, str]]:
     """Return the subset of REQUIRED_CHECKS applicable to the current context.
 
@@ -160,6 +191,15 @@ def _checks_to_apply() -> list[tuple[str, str]]:
     return REQUIRED_CHECKS
 
 
+def _deprecated_to_remove() -> list[tuple[str, str]]:
+    """Return the DEPRECATED_CHECKS subset applicable to the current repo context."""
+    github_repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if not github_repository:
+        return DEPRECATED_CHECKS
+    current_repo = github_repository.split("/", 1)[-1]
+    return [(repo, ctx) for repo, ctx in DEPRECATED_CHECKS if repo == current_repo]
+
+
 def main() -> None:
     token = os.environ.get("GITHUB_TOKEN", "").strip()
     if not token:
@@ -169,6 +209,8 @@ def main() -> None:
         )
 
     checks = _checks_to_apply()
+    deprecated = _deprecated_to_remove()
+
     total = len(checks)
     print(f"=== E2E Robustness C6: applying {total} required status check(s) ===")
     for repo, context in checks:
@@ -177,6 +219,17 @@ def main() -> None:
         except RuntimeError as exc:
             print(f"  ERROR [{repo}]: {exc}")
             sys.exit(1)
+
+    if deprecated:
+        print()
+        print(f"=== Removing {len(deprecated)} deprecated check(s) ===")
+        for repo, context in deprecated:
+            try:
+                remove_required_check(repo, context, token)
+            except RuntimeError as exc:
+                # Removal failure is non-fatal: log a warning and continue.
+                # The check will be retried on the next push-triggered run.
+                print(f"  WARNING [{repo}]: could not remove {context!r}: {exc}")
 
     print()
     print(f"=== {total} E2E check(s) are now required on main ===")


### PR DESCRIPTION
## Problem

`scripts/apply_required_status_checks.py` on current main still lists `("clawmetry", "visual-diff")` in `REQUIRED_CHECKS`. The `apply-required-checks.yml` workflow already has a `push: branches: [main]` trigger (merged with #2420), so the script fires on every merge to main.

`pr-screenshots.yml` has a `paths:` filter -- `visual-diff` only runs on PRs that touch UI files. If registered as a required status check, every non-UI PR stalls permanently on \"Expected -- Waiting for status to be reported\" and can never merge.

**Because the push trigger has been live since #2420 merged, `visual-diff` may already be set as a required check on clawmetry/main.** Simply removing it from `REQUIRED_CHECKS` is not enough -- the script also needs to actively remove it if present.

This PR supersedes #2425 (same removal, but #2425 does not add the cleanup step).

## Changes

**`scripts/apply_required_status_checks.py`:**
- Remove `("clawmetry", "visual-diff")` from `REQUIRED_CHECKS`
- Add `DEPRECATED_CHECKS` list containing `("clawmetry", "visual-diff")`
- Add `remove_required_check()` function
- Add `_deprecated_to_remove()` function (repo-scoped, same pattern as `_checks_to_apply`)
- Call cleanup loop in `main()` after the add loop (non-fatal: logs WARNING, does not `sys.exit`)
- Update docstring count from \"all 5\" to \"all 4\"
- Update comment block: remove visual-diff entry, add exclusion note

**`.github/workflows/apply-required-checks.yml`:**
- Remove `visual-diff` from both dry-run echo branches (with-PAT and without-PAT)
- Add NOTE explaining the exclusion in the dry-run output
- Add note about DEPRECATED_CHECKS self-healing cleanup in dry-run output

## Correct 4 required checks (all path-filter safe)

| Repo | Job name | Path filter? |
|------|----------|-------------|
| clawmetry | `OSS golden path (wheel + OpenClaw + 9 tabs)` | No |
| clawmetry | `Cross-repo handoff (C4)` | No |
| clawmetry-cloud | `Cloud golden-path browser E2E` | No |
| clawmetry-landing | `Landing golden path (C3)` | No |

## What happens after this PR merges

1. The merge to main triggers `apply-required-checks.yml` (push trigger already active)
2. Script runs with `GITHUB_TOKEN` + `administration: write`
3. **Adds** the 2 correct clawmetry checks (OSS golden path + Cross-repo handoff)
4. **Removes** `visual-diff` from required checks if it was previously applied
5. C6 flips GREEN for clawmetry; cloud and landing self-apply on their next push

## Acceptance test

```bash
gh api repos/vivekchand/clawmetry/branches/main/protection/required_status_checks \
  --jq '.contexts[]'
# Expected output (after merge + workflow run):
# OSS golden path (wheel + OpenClaw + 9 tabs)
# Cross-repo handoff (C4)
# (visual-diff must NOT appear)
```

Tracking: #2146 (C6)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3Eh2a1Gw34Crz8SB1nCUr)_