### PR TITLE
feat(cli): clawmetry connect starts sync by default

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -688,17 +688,21 @@ def _cmd_connect(args) -> None:
         print()
         return
 
-    # Default: defer the sync daemon until the user runs `clawmetry sync`.
-    # --start-sync-now restores the historical auto-spawn behavior.
-    _start_now = getattr(args, "start_sync_now", False)
-
-    if _start_now:
-        _start_daemon(config, args)
-    else:
-        print("  Sync is paused. Start it whenever you're ready:")
+    # Default (2026-06-01): start the sync daemon immediately on connect, so
+    # the dashboard populates without an extra step. A user who runs
+    # `clawmetry connect` wants their observability now; the previous deferred
+    # default ("Sync is paused") was a confusing trap where the node never
+    # heartbeated and the dashboard stayed empty. Pass `--defer-sync` to keep
+    # the old behavior (e.g. provisioning a node you do not want syncing yet).
+    # `--start-sync-now` is retained as a no-op alias for back-compat (it is
+    # now the default), so existing scripts and the cloud dashboard's copy of
+    # the connect command keep working.
+    if getattr(args, "defer_sync", False):
+        print("  Sync is paused (--defer-sync). Start it whenever you're ready:")
         print("    clawmetry sync")
-        print("  (or run `clawmetry connect --start-sync-now` to keep today's auto-start)")
         print()
+    else:
+        _start_daemon(config, args)
 
     # Open browser with encryption key in URL fragment (never sent to server)
     # The #key=... fragment stays client-side — true E2E encryption
@@ -2742,7 +2746,13 @@ def main() -> None:
         "--start-sync-now",
         action="store_true",
         dest="start_sync_now",
-        help="Start the sync daemon immediately after connect (default: defer until `clawmetry sync`)",
+        help="No-op (now the default). Retained for back-compat.",
+    )
+    p_connect.add_argument(
+        "--defer-sync",
+        action="store_true",
+        dest="defer_sync",
+        help="Connect but leave sync paused; start it later with `clawmetry sync`",
     )
     p_connect.add_argument(
         "--foreground", action="store_true", help="Run daemon in foreground"


### PR DESCRIPTION
## Why

Founder decision (2026-06-01), prompted by hitting this live: the previous default **deferred** the sync daemon. `clawmetry connect` printed *"Sync is paused"* and did not start the daemon, so the node never heartbeated and the cloud dashboard stayed empty until the user discovered `clawmetry sync` / `--start-sync-now`. A user who runs `clawmetry connect` wants their observability now.

## Change (`clawmetry/cli.py`)

- **Default flips to start sync** on connect (`_start_daemon` runs).
- New **`--defer-sync`** flag preserves the old paused behavior (for provisioning a node you don't want syncing yet, or external/supervisord management alongside `--no-daemon`).
- **`--start-sync-now`** is kept as a no-op alias (it's now the default) so existing scripts and the cloud dashboard's connect command (`... --start-sync-now`) keep working.

## Safety

The **server-side** deferred-sync gate for auto-provisioned KiloClaw nodes (`sync_allowed=false` until intent) is untouched, so the cost/privacy reason the deferral existed is unaffected. This only changes the interactive CLI default.

## Verification

`py_compile` + `ast.parse` clean. No existing test pinned the old default. This is a CLI-behavior change, the real check is a live run: `clawmetry connect --key cm_…` now starts sync immediately; `clawmetry connect --defer-sync` keeps it paused. Will follow with a `[RELEASE]` PR to publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)