### PR TITLE
fix(ui): runtime-neutral copy for compaction empty-state and Context Economics

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1057,7 +1057,7 @@ async function loadContextEconomics() {
   // ── Compaction log (clickable rows -> before/after + summary) ──
   if (compEl) {
     if (comps.length === 0) {
-      compEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;border:1px solid var(--border-primary);border-radius:10px;">' + t("app.no_compactions_recorded", null, "No compactions recorded") + '' + (_ceSessionId ? ' for this session' : '') + '. OpenClaw compacts the transcript when the window fills; events appear here as they happen.</div>';
+      compEl.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;border:1px solid var(--border-primary);border-radius:10px;">' + t("app.no_compactions_recorded", null, "No compactions recorded") + '' + (_ceSessionId ? ' for this session' : '') + '. Your agent compacts the transcript when the window fills; events appear here as they happen.</div>';
     } else {
       var c = '<div style="border:1px solid var(--border-primary);border-radius:10px;overflow:hidden;">';
       c += '<div style="font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;padding:12px 14px;border-bottom:1px solid var(--border-primary);">Compaction events <span style="color:var(--text-faint);font-weight:500;text-transform:none;">— click a row to expand</span></div>';

--- a/clawmetry/templates/tabs/context-economics.html
+++ b/clawmetry/templates/tabs/context-economics.html
@@ -3,7 +3,7 @@
     <h2 style="font-size:16px;font-weight:700;color:var(--text-primary);margin:0;flex:1;" data-i18n="app.context_economics">📊 Context Economics</h2>
     <button class="refresh-btn" onclick="loadContextEconomics()" data-i18n="app.refresh">↻ Refresh</button>
   </div>
-  <p style="color:var(--text-muted);font-size:13px;margin:2px 0 14px;max-width:760px;" data-i18n="app.how_full_your_agents_context_windows_get_when_open">How full your agents’ context windows get, when OpenClaw compacted (proactively vs forced by an overflow),
+  <p style="color:var(--text-muted);font-size:13px;margin:2px 0 14px;max-width:760px;" data-i18n="app.how_full_your_agents_context_windows_get_when_open">How full your agents’ context windows get, when your agent compacted (proactively vs forced by an overflow),
     how many tokens each compaction reclaimed, and which sessions keep slamming into the wall.</p>
   <!-- Summary chips -->
   <div id="ce-summary" style="margin-bottom:14px;"></div>


### PR DESCRIPTION
## What

Two user-visible strings named only OpenClaw as the agent that compacts the transcript, even though transcript compaction is a multi-runtime concept. Claude Code and the other supported runtimes also compact, so naming OpenClaw alone implied ClawMetry only tracks OpenClaw agents. Both are now runtime-neutral.

## Reframed

1. **Compactions empty-state** (`clawmetry/static/js/app.js`): "OpenClaw compacts the transcript when the window fills" becomes "Your agent compacts the transcript when the window fills".
2. **Context Economics tab description** (`clawmetry/templates/tabs/context-economics.html`): "when OpenClaw compacted (proactively vs forced by an overflow)" becomes "when your agent compacted (proactively vs forced by an overflow)". The sentence already opened runtime-neutrally ("your agents' context windows"), so this makes the whole line consistent.

Both keep the original meaning and reflect the 12 supported runtimes. No code logic changed, copy only.

## Skipped

None. Both findings applied as proposed.

## Checks

- `node --check` on app.js: clean
- No `.py` files edited (no `py_compile` needed); no inline-JS-in-py lint trap script present; no clawmetry-landing dir in this repo.
- Verified no em dash or double hyphen in the authored copy.