### PR TITLE
refactor(nemoclaw): 402 upgrade_required stub (real impl moves to clawmetry-pro)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -10837,7 +10837,14 @@ def detect_config(args=None):
     app.register_blueprint(bp_version_impact)
 
     app.register_blueprint(bp_cloud_relay)
-    app.register_blueprint(bp_nemoclaw)
+    # NeMo governance + approval queue is a Pro feature; the impl lives in
+    # clawmetry-pro. When that package is installed, its blueprint was
+    # already registered by ``_ext_load(app)`` above and won the URL
+    # routes; skip the OSS 402-stub registration here to avoid a Flask
+    # blueprint-name collision. When the closed package is NOT installed
+    # the OSS stub registers and returns HTTP 402 ``upgrade_required``.
+    if not _pro_loaded:
+        app.register_blueprint(bp_nemoclaw)
     app.register_blueprint(bp_skills)
     app.register_blueprint(bp_heartbeat)
     app.register_blueprint(bp_selfconfig)

--- a/routes/nemoclaw.py
+++ b/routes/nemoclaw.py
@@ -1,628 +1,125 @@
+"""routes/nemoclaw.py: OSS stub after the impl moved to clawmetry-pro.
+
+The real NeMo Guardrails governance + approval-queue implementation ships
+in the closed-source ``clawmetry-pro`` package as
+``clawmetry_pro/routes/nemoclaw.py``. When that package is installed
+(license key or cloud Pro plan), its blueprint registers via
+``clawmetry_pro.register_all()`` -> ``_register_blueprints(app)`` at app
+startup and wins the URL routes.
+
+When clawmetry-pro is NOT installed (vanilla OSS), this stub blueprint
+registers in its place and returns HTTP 402 ``upgrade_required`` on every
+governance endpoint (governance summary, drift ack, daemon status, policy,
+approve, reject, pending-approvals, rule CRUD, guardrail events, metrics).
+
+dashboard.py decides which blueprint to register by inspecting
+``clawmetry_pro.is_loaded()`` so the two never coexist on the URL map.
+
+Mirrors the precedent set by ``routes/runtime_ingest.py`` (custom-runtime
+ingest), ``routes/otel_export.py`` (OTel push), ``routes/selfevolve.py``
+and ``routes/assets.py`` (asset registry) — all OSS 402-stubs whose real
+impls live in clawmetry-pro.
+
+Import-light and never-raise: the blueprint object name (``bp_nemoclaw``)
+and every URL rule match the real impl so swapping the two is transparent.
 """
-routes/nemoclaw.py — NemoClaw governance + approval endpoints.
+from __future__ import annotations
 
-Extracted from dashboard.py as Phase 5.13 (FINAL) of the incremental
-modularisation. Owns the 7 routes registered on ``bp_nemoclaw``:
+import logging
 
-  /api/nemoclaw/governance                     — governance summary
-  /api/nemoclaw/governance/acknowledge-drift   — POST ack
-  /api/nemoclaw/status                         — daemon status
-  /api/nemoclaw/policy                         — active policy
-  /api/nemoclaw/approve                        — approve pending action
-  /api/nemoclaw/reject                         — reject pending action
-  /api/nemoclaw/pending-approvals              — list queue
+from flask import Blueprint, jsonify
 
-Module-level helpers (``_detect_nemoclaw``, ``_parse_network_policies``)
-and module state (``_nemoclaw_policy_hash``, ``_nemoclaw_drift_info``)
-stay in ``dashboard.py`` and are reached via late ``import dashboard as _d``.
+logger = logging.getLogger("clawmetry.routes.nemoclaw")
 
-Pure mechanical move — zero behaviour change.
-
-Phase 4 of epic #1032 adds an opt-in DuckDB fast path
-(``CLAWMETRY_LOCAL_STORE_READ=1``) to ``/api/nemoclaw/pending-approvals``:
-when local DuckDB has rows in the ``approvals`` table, we serve the
-queue from there (tagged ``_source: "local_store"``) instead of shelling
-out to ``openshell draft get``. Sits in front of the legacy CLI path —
-fresh installs or non-NemoClaw users degrade to the same response as
-before.
-"""
-import os
-
-from datetime import datetime, timezone
-
-from flask import Blueprint, jsonify, request
-from clawmetry.config import is_local_store_read_enabled
-
-bp_nemoclaw = Blueprint('nemoclaw', __name__)
-
-from clawmetry._gate import gate
+bp_nemoclaw = Blueprint("nemoclaw", __name__)
 
 
-# ── Local DuckDB fast path (epic #1032 Phase 4 — approvals queue) ───────────
-#
-# Opt-in via CLAWMETRY_LOCAL_STORE_READ=1. Mirrors routes/crons.py: a dedicated
-# helper attempts a DuckDB read and returns ``None`` on any error / empty
-# table so the legacy ``openshell draft get`` path runs untouched. The fast
-# path NEVER replaces the legacy code — it sits in front of it, so a fresh
-# install with no local store (or a non-NemoClaw user) sees the same data
-# as before.
-#
-# The local ``approvals`` table is populated by the policy watcher in
-# clawmetry/approvals.py via LocalStore.ingest_approval (Phase 4). Schema:
-#
-#   approvals (
-#     id, owner_hash, requestor_session_id, action, args BLOB, status,
-#     created_at, resolved_at, resolver, decision, decision_reason
-#   )
-#
-# Response shape mirrors the legacy ``/api/nemoclaw/pending-approvals``
-# contract (``{installed, approvals}``) — only adding ``_source:
-# "local_store"`` so tests can assert which path served the response.
+# Shared 402 body so the wire format is identical across every governance
+# route (and matches the ``@gate`` enforce-mode shape used elsewhere).
+_UPGRADE = {
+    "error": "upgrade_required",
+    "feature": "nemo_governance",
+    "hint": (
+        "NeMo governance is a paid feature. Install clawmetry-pro with a "
+        "license key, or use Cloud at clawmetry.com/pricing."
+    ),
+}
 
 
-def _try_local_store_approvals():
-    """Return pending-approvals dict shaped like ``/api/nemoclaw/pending-
-    approvals`` from the local DuckDB.
-
-    Returns ``None`` to defer to the legacy openshell CLI fallback if:
-      - the ``local_store`` module isn't importable
-      - the ``approvals`` table is empty (fresh install / no pending rows)
-      - any unexpected error happens (we'd rather degrade than 500)
-    """
-    # Issue #1282 / memory `feedback_daemon_proxy_pattern.md`: writable
-    # ``get_store`` raced the sync daemon's exclusive DuckDB writer lock
-    # on multi-process installs (launchd/systemd). Try the daemon HTTP
-    # proxy first; fall back to a direct read-only open for single-process
-    # boots (tests, dev mode).
-    try:
-        from routes.local_query import local_store_via_daemon
-        rows = local_store_via_daemon("query_approvals", status="pending", limit=500)
-    except Exception:
-        rows = None
-    if rows is None:
-        try:
-            from clawmetry import local_store
-            store = local_store.get_store(read_only=True)
-            rows = store.query_approvals(status="pending", limit=500)
-        except Exception:
-            return None
-    if not rows:
-        return None
-    approvals = []
-    for r in rows:
-        args = r.get("args") if isinstance(r.get("args"), dict) else {}
-        approvals.append({
-            # Preserve the column names so the cloud + dashboard can address
-            # rows directly by id without translation.
-            "id":                   r.get("id"),
-            # Legacy fields the dashboard JS still reads — derived from the
-            # row when present, kept as None otherwise so the renderer's
-            # `||` fallbacks behave unchanged.
-            "chunk_id":             r.get("id"),
-            "session_id":           r.get("requestor_session_id"),
-            "requestor_session_id": r.get("requestor_session_id"),
-            "action":               r.get("action"),
-            "tool_name":            r.get("action"),
-            "args":                 args,
-            "status":               r.get("status", "pending"),
-            "ts":                   r.get("created_at"),
-            "created_at":           r.get("created_at"),
-        })
-    return {
-        "installed": True,
-        "approvals": approvals,
-        "_source":   "local_store",
-    }
+def _upgrade():
+    return jsonify(_UPGRADE), 402
 
 
-# ── NemoClaw Governance API ───────────────────────────────────────────────────
+# ── NeMo governance summary + drift ─────────────────────────────────────────
 
 
 @bp_nemoclaw.route('/api/nemoclaw/governance')
 def api_nemoclaw_governance():
-    """Return NemoClaw governance status: policy, sandbox state, drift detection."""
-    import dashboard as _d
-    info = _d._detect_nemoclaw()
-    if info is None:
-        return jsonify({'installed': False})
-
-    result = {
-        'installed': True,
-        'sandboxes': [],
-        'policy': None,
-        'network_policies': [],
-        'presets': info.get('presets', []),
-        'drift': None,
-        'config': {},
-    }
-
-    # Config summary (sanitise - remove tokens/keys)
-    cfg = info.get('config', {})
-    if cfg:
-        safe_cfg = {k: v for k, v in cfg.items() if 'token' not in k.lower() and 'key' not in k.lower() and 'secret' not in k.lower()}
-        result['config'] = safe_cfg
-
-    # Sandbox state
-    state = info.get('state', {})
-    if isinstance(state, dict):
-        sandboxes_raw = state.get('sandboxes') or state.get('shells') or {}
-        if isinstance(sandboxes_raw, dict):
-            for name, sb in sandboxes_raw.items():
-                if isinstance(sb, dict):
-                    result['sandboxes'].append({
-                        'name': name,
-                        'status': sb.get('status', 'unknown'),
-                        'pid': sb.get('pid'),
-                        'created': sb.get('created') or sb.get('createdAt'),
-                        'preset': sb.get('preset') or sb.get('policy_preset'),
-                    })
-        elif isinstance(sandboxes_raw, list):
-            for sb in sandboxes_raw:
-                if isinstance(sb, dict):
-                    result['sandboxes'].append({
-                        'name': sb.get('name', 'unknown'),
-                        'status': sb.get('status', 'unknown'),
-                        'pid': sb.get('pid'),
-                        'created': sb.get('created') or sb.get('createdAt'),
-                        'preset': sb.get('preset') or sb.get('policy_preset'),
-                    })
-
-    # Parse sandbox list from CLI output if state didn't give sandboxes
-    if not result['sandboxes'] and info.get('sandbox_list_raw'):
-        for line in info['sandbox_list_raw'].splitlines():
-            line = line.strip()
-            if not line or line.startswith('#') or line.lower().startswith('name'):
-                continue
-            parts = line.split()
-            if parts:
-                status = parts[1] if len(parts) > 1 else 'unknown'
-                result['sandboxes'].append({'name': parts[0], 'status': status, 'pid': None, 'created': None, 'preset': None})
-
-    # Policy summary
-    policy_yaml = info.get('policy_yaml')
-    policy_hash = info.get('policy_hash')
-    if policy_yaml:
-        result['network_policies'] = _d._parse_network_policies(policy_yaml)
-        result['policy'] = {
-            'hash': policy_hash,
-            'lines': len(policy_yaml.splitlines()),
-            'size_bytes': len(policy_yaml.encode()),
-        }
-
-    # Drift detection: compare policy hash vs last seen
-    if policy_hash:
-        if _d._nemoclaw_policy_hash is None:
-            _d._nemoclaw_policy_hash = policy_hash
-        elif _d._nemoclaw_policy_hash != policy_hash:
-            _d._nemoclaw_drift_info = {
-                'detected_at': datetime.utcnow().isoformat() + 'Z',
-                'previous_hash': _d._nemoclaw_policy_hash,
-                'current_hash': policy_hash,
-            }
-            _d._nemoclaw_policy_hash = policy_hash
-
-        if _d._nemoclaw_drift_info:
-            result['drift'] = _d._nemoclaw_drift_info
-
-    return jsonify(result)
+    return _upgrade()
 
 
 @bp_nemoclaw.route('/api/nemoclaw/governance/acknowledge-drift', methods=['POST'])
 def api_nemoclaw_acknowledge_drift():
-    """Clear the drift alert (user acknowledged the policy change)."""
-    import dashboard as _d
-    _d._nemoclaw_drift_info = {}
-    return jsonify({'ok': True})
+    return _upgrade()
 
 
-# ── NemoClaw Governance Routes ───────────────────────────────────────────────
+# ── NeMo status + policy ────────────────────────────────────────────────────
 
 
 @bp_nemoclaw.route('/api/nemoclaw/status')
 def api_nemoclaw_status():
-    """Detect NemoClaw installation and return full status."""
-    import dashboard as _d
-    data = _d._detect_nemoclaw()
-    if not data:
-        return jsonify({"installed": False})
-    # Policy drift detection
-    current_hash = data.get("policy_hash")
-    if current_hash:
-        if _d._nemoclaw_policy_hash is None:
-            _d._nemoclaw_policy_hash = current_hash
-        elif _d._nemoclaw_policy_hash != current_hash:
-            _d._nemoclaw_drift_info = {
-                "old_hash": _d._nemoclaw_policy_hash,
-                "new_hash": current_hash,
-                "detected_at": datetime.now(timezone.utc).isoformat(),
-            }
-            _d._nemoclaw_policy_hash = current_hash
-            data["policy_drifted"] = True
-            data["drift_info"] = _d._nemoclaw_drift_info
-        else:
-            data["policy_drifted"] = False
-    # Parse network policies for structured display
-    if data.get("policy_yaml"):
-        data["network_policies"] = _d._parse_network_policies(data["policy_yaml"])
-    return jsonify(data)
+    return _upgrade()
 
 
 @bp_nemoclaw.route('/api/nemoclaw/policy')
 def api_nemoclaw_policy():
-    """Return full policy YAML + hash + drift status."""
-    import dashboard as _d
-    data = _d._detect_nemoclaw()
-    if not data:
-        return jsonify({"installed": False, "policy_yaml": None})
-    result = {
-        "installed": True,
-        "policy_yaml": data.get("policy_yaml"),
-        "policy_hash": data.get("policy_hash"),
-        "policy_drifted": False,
-        "drift_info": None,
-    }
-    current_hash = data.get("policy_hash")
-    if current_hash:
-        if _d._nemoclaw_policy_hash and _d._nemoclaw_policy_hash != current_hash:
-            result["policy_drifted"] = True
-            result["drift_info"] = _d._nemoclaw_drift_info
-        elif _d._nemoclaw_policy_hash is None:
-            _d._nemoclaw_policy_hash = current_hash
-    if data.get("policy_yaml"):
-        result["network_policies"] = _d._parse_network_policies(data["policy_yaml"])
-    return jsonify(result)
+    return _upgrade()
+
+
+# ── Approval queue actions ──────────────────────────────────────────────────
 
 
 @bp_nemoclaw.route('/api/nemoclaw/approve', methods=['POST'])
-@gate("approval_queue")
 def api_nemoclaw_approve():
-    """Approve a pending NemoClaw egress chunk."""
-    data = request.get_json() or {}
-    sandbox = data.get('sandbox')
-    chunk_id = data.get('chunk_id')
-    if not sandbox or not chunk_id:
-        return jsonify({'error': 'missing sandbox or chunk_id'}), 400
-    import subprocess as _sp
-    r = _sp.run(
-        ['openshell', 'draft', 'approve', sandbox, chunk_id],
-        capture_output=True, text=True, timeout=10
-    )
-    return jsonify({'ok': r.returncode == 0, 'output': r.stdout or r.stderr})
+    return _upgrade()
 
 
 @bp_nemoclaw.route('/api/nemoclaw/reject', methods=['POST'])
-@gate("approval_queue")
 def api_nemoclaw_reject():
-    """Reject a pending NemoClaw egress chunk."""
-    data = request.get_json() or {}
-    sandbox = data.get('sandbox')
-    chunk_id = data.get('chunk_id')
-    reason = data.get('reason', '')
-    if not sandbox or not chunk_id:
-        return jsonify({'error': 'missing sandbox or chunk_id'}), 400
-    import subprocess as _sp
-    cmd = ['openshell', 'draft', 'reject', sandbox, chunk_id]
-    if reason:
-        cmd += ['--reason', reason]
-    r = _sp.run(cmd, capture_output=True, text=True, timeout=10)
-    return jsonify({'ok': r.returncode == 0, 'output': r.stdout or r.stderr})
-
-
-# ── Cloud-Pro upsell flag (issue #1328) ────────────────────────────────────
-#
-# OSS users can SEE the approvals queue grow but get zero notification surface
-# (Slack / PagerDuty / email dispatch lives in Cloud-Pro per memory
-# ``project_alerts_pro_feature.md``). The dashboard JS renders an inline CTA
-# above the queue table whenever this flag is true: queue has >=1 pending row
-# AND the caller is NOT a Cloud-Pro user. Pro users never see the CTA.
-#
-# Same pattern as ``capped_pro_gated`` on /api/loop-signals (issue #1376):
-# decision lives on the server so the dashboard does not have to re-implement
-# the Pro check. Fails closed (treats any error as "not pro") so we never
-# accidentally suppress the upsell on a free node.
-def _annotate_pro_upsell(payload):
-    """Stamp ``pro_gated_upsell`` + ``pending_count`` on the response when the
-    queue has rows and the caller is NOT Cloud-Pro. No-op on empty queues so
-    the empty-state stays clean."""
-    try:
-        approvals = payload.get("approvals") or []
-        pending_count = len(approvals)
-        payload["pending_count"] = pending_count
-        if pending_count <= 0:
-            payload["pro_gated_upsell"] = False
-            return payload
-        try:
-            import dashboard as _d
-            is_pro = bool(_d._is_pro_user())
-        except Exception:
-            is_pro = False
-        payload["pro_gated_upsell"] = (not is_pro)
-    except Exception:
-        # Never let the CTA flag-stamping break the response — the queue
-        # itself is the load-bearing thing here.
-        payload.setdefault("pro_gated_upsell", False)
-        payload.setdefault("pending_count", 0)
-    return payload
+    return _upgrade()
 
 
 @bp_nemoclaw.route('/api/nemoclaw/pending-approvals')
-@gate("approval_queue")
 def api_nemoclaw_pending_approvals():
-    """Return pending egress approval requests from openshell.
-
-    Phase 4 of epic #1032: when ``CLAWMETRY_LOCAL_STORE_READ=1`` AND the
-    local DuckDB ``approvals`` table has pending rows, serve from there
-    and tag ``_source: "local_store"``. Otherwise fall through to the
-    legacy ``openshell draft get`` CLI path (response is unchanged).
-
-    Issue #1328: every return path is annotated with ``pro_gated_upsell``
-    + ``pending_count`` so the dashboard JS can render the Cloud-Pro
-    notifications upsell CTA without re-deriving tier on the client.
-    """
-    if is_local_store_read_enabled():
-        fast = _try_local_store_approvals()
-        if fast is not None:
-            return jsonify(_annotate_pro_upsell(fast))
-    import shutil as _shutil
-    if not _shutil.which('openshell'):
-        return jsonify(_annotate_pro_upsell({'installed': False, 'approvals': []}))
-    try:
-        # Get sandbox names
-        import subprocess as _sp
-        r = _sp.run(['nemoclaw', 'list'], capture_output=True, text=True, timeout=5)
-        approvals = []
-        sandboxes = []
-        for line in r.stdout.splitlines():
-            line = line.strip()
-            if not line or line.startswith('#') or line.lower().startswith('name') or line.startswith('-'):
-                continue
-            parts = line.split()
-            if parts:
-                sandboxes.append(parts[0])
-        for sandbox in sandboxes:
-            # Try JSON output first
-            r2 = _sp.run(
-                ['openshell', 'draft', 'get', sandbox, '--status', 'pending', '--json'],
-                capture_output=True, text=True, timeout=5
-            )
-            if r2.returncode == 0 and r2.stdout.strip():
-                try:
-                    import json as _j
-                    chunks = _j.loads(r2.stdout)
-                    if not isinstance(chunks, list):
-                        chunks = [chunks] if isinstance(chunks, dict) else []
-                    for chunk in chunks:
-                        endpoints = chunk.get('proposed_rule', {}).get('endpoints', [{}])
-                        first_ep = endpoints[0] if endpoints else {}
-                        approvals.append({
-                            'sandbox': sandbox,
-                            'chunk_id': chunk.get('id'),
-                            'rule_name': chunk.get('rule_name'),
-                            'host': first_ep.get('host'),
-                            'port': first_ep.get('port'),
-                            'protocol': first_ep.get('protocol'),
-                            'status': 'pending',
-                            'ts': chunk.get('created_at'),
-                        })
-                    continue
-                except (ValueError, KeyError):
-                    pass
-            # Fallback: plain text
-            r3 = _sp.run(
-                ['openshell', 'draft', 'get', sandbox, '--status', 'pending'],
-                capture_output=True, text=True, timeout=5
-            )
-            if r3.returncode == 0:
-                for line in r3.stdout.splitlines():
-                    line = line.strip()
-                    if not line or line.startswith('#') or line.lower().startswith('id'):
-                        continue
-                    parts = line.split()
-                    if len(parts) >= 2:
-                        approvals.append({
-                            'sandbox': sandbox,
-                            'chunk_id': parts[0],
-                            'rule_name': parts[1] if len(parts) > 1 else None,
-                            'host': parts[2] if len(parts) > 2 else None,
-                            'port': parts[3] if len(parts) > 3 else None,
-                            'protocol': None,
-                            'status': 'pending',
-                            'ts': None,
-                        })
-        return jsonify(_annotate_pro_upsell({'installed': True, 'approvals': approvals}))
-    except Exception as e:
-        return jsonify(_annotate_pro_upsell({'installed': True, 'approvals': [], 'error': str(e)}))
+    return _upgrade()
 
 
-# ── NemoClaw guardrail events + metrics (issue #876) ─────────────────────────
-
-def _try_local_store_guardrail_events(since=None, limit=100):
-    """Return guardrail events from DuckDB via daemon proxy, or None on failure."""
-    try:
-        from routes.local_query import local_store_via_daemon
-        kwargs = {"limit": limit}
-        if since:
-            kwargs["since"] = since
-        rows = local_store_via_daemon("query_guardrail_events", **kwargs)
-    except Exception:
-        rows = None
-    if rows is None:
-        try:
-            from clawmetry import local_store
-            store = local_store.get_store(read_only=True)
-            kwargs = {"limit": limit}
-            if since:
-                kwargs["since"] = since
-            rows = store.query_guardrail_events(**kwargs)
-        except Exception:
-            return None
-    return rows if rows is not None else []
+# ── Guardrail events + metrics ──────────────────────────────────────────────
 
 
 @bp_nemoclaw.route('/api/nemoclaw/events')
 def api_nemoclaw_events():
-    """Return recent NemoClaw guardrail enforcement events from local DuckDB."""
-    import dashboard as _d
-    installed = _d._detect_nemoclaw() is not None
-    since = request.args.get('since')
-    try:
-        limit = max(1, min(500, int(request.args.get('limit', 100))))
-    except (TypeError, ValueError):
-        limit = 100
-    events = _try_local_store_guardrail_events(since=since, limit=limit) or []
-    return jsonify({
-        'installed': installed,
-        'events': events,
-        'total': len(events),
-    })
-
-
-def _try_local_store_nemoclaw_metrics():
-    """Return NemoClaw metrics from DuckDB via daemon proxy, or None on failure."""
-    try:
-        from routes.local_query import local_store_via_daemon
-        result = local_store_via_daemon("query_nemoclaw_metrics")
-    except Exception:
-        result = None
-    if result is None:
-        try:
-            from clawmetry import local_store
-            store = local_store.get_store(read_only=True)
-            result = store.query_nemoclaw_metrics()
-        except Exception:
-            return None
-    return result
+    return _upgrade()
 
 
 @bp_nemoclaw.route('/api/nemoclaw/metrics')
 def api_nemoclaw_metrics():
-    """Return aggregate NemoClaw metrics (approval rates, latency, trigger count)."""
-    import dashboard as _d
-    installed = _d._detect_nemoclaw() is not None
-    metrics = _try_local_store_nemoclaw_metrics() or {
-        "total_approvals": 0,
-        "approved_count": 0,
-        "denied_count": 0,
-        "approval_rate_pct": None,
-        "avg_latency_secs": None,
-        "triggers_24h": 0,
-    }
-    return jsonify({
-        'installed': installed,
-        'metrics': metrics,
-    })
+    return _upgrade()
 
 
-# ── Approval policy rule CRUD (OSS YAML-backed, issue #1343) ─────────────────
-#
-# Cloud users manage rules at /api/cloud/policies (Pro-gated, Postgres-backed).
-# OSS users get equivalent local capability: rules live in
-# ~/.clawmetry/policies.yml, already watched by clawmetry/approvals.py for
-# enforcement. Notification channels (Slack / PagerDuty / email / phone) stay
-# Cloud-Pro gated — this layer is rule-definition only.
-#
-# Tier boundary (per issue #1343): "Approvals queue + basic rule editor: OSS
-# free (already user-asked). Slack/PagerDuty/email notifications: Cloud-Pro."
-
-def _load_local_policies() -> list:
-    """Read ~/.clawmetry/policies.yml; return [] on any error."""
-    from clawmetry.approvals import POLICIES_PATH, _load_yaml
-    try:
-        if POLICIES_PATH.exists():
-            return _load_yaml(POLICIES_PATH.read_text(errors='replace')) or []
-    except Exception:
-        pass
-    return []
-
-
-def _write_local_policies(policies: list) -> None:
-    """Atomically write policies list to ~/.clawmetry/policies.yml."""
-    from clawmetry.approvals import POLICIES_PATH
-    import tempfile
-    POLICIES_PATH.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        import yaml as _yaml  # type: ignore
-        text = _yaml.dump(policies, default_flow_style=False, allow_unicode=True)
-    except ImportError:
-        # Hand-roll for the documented flat-dict format (no PyYAML dep).
-        lines = []
-        for p in policies:
-            first = True
-            for k, v in p.items():
-                if v is None:
-                    vs = 'null'
-                elif isinstance(v, bool):
-                    vs = 'true' if v else 'false'
-                elif isinstance(v, (int, float)):
-                    vs = str(v)
-                else:
-                    s = str(v)
-                    # Quote strings containing YAML special characters.
-                    if any(c in s for c in ':#{}[]|>&!\'",%@`'):
-                        s = "'" + s.replace("'", "''") + "'"
-                    vs = s
-                lines.append(('- ' if first else '  ') + k + ': ' + vs)
-                first = False
-            lines.append('')
-        text = '\n'.join(lines)
-    with tempfile.NamedTemporaryFile('w', dir=POLICIES_PATH.parent,
-                                     delete=False, suffix='.tmp') as f:
-        f.write(text)
-        tmp_path = f.name
-    os.replace(tmp_path, POLICIES_PATH)
+# ── Approval policy rule CRUD ───────────────────────────────────────────────
 
 
 @bp_nemoclaw.route('/api/nemoclaw/rules', methods=['GET'])
 def api_nemoclaw_rules_list():
-    """Return all approval rules from ~/.clawmetry/policies.yml."""
-    return jsonify({'policies': _load_local_policies()})
+    return _upgrade()
 
 
 @bp_nemoclaw.route('/api/nemoclaw/rules', methods=['POST'])
 def api_nemoclaw_rules_create():
-    """Create or update a rule in ~/.clawmetry/policies.yml.
-
-    Upserts by preset_key (for preset-card toggles) or by name (for custom
-    rules). The local daemon enforces every entry in policies.yml regardless
-    of an ``enabled`` field, so callers should DELETE rather than set
-    enabled=false to disable a rule.
-    """
-    data = request.get_json(silent=True) or {}
-    name = (data.get('name') or '').strip()
-    if not name:
-        return jsonify({'error': 'name is required'}), 400
-    rule = {k: v for k, v in data.items() if v is not None and k != 'id'}
-    rule['name'] = name
-    policies = _load_local_policies()
-    preset_key = data.get('preset_key')
-    updated = False
-    for i, p in enumerate(policies):
-        if not isinstance(p, dict):
-            continue
-        if preset_key and p.get('preset_key') == preset_key:
-            policies[i] = rule
-            updated = True
-            break
-        if not preset_key and p.get('name') == name:
-            policies[i] = rule
-            updated = True
-            break
-    if not updated:
-        policies.append(rule)
-    _write_local_policies(policies)
-    return jsonify({'ok': True, 'updated': updated})
+    return _upgrade()
 
 
 @bp_nemoclaw.route('/api/nemoclaw/rules/<path:rule_key>', methods=['DELETE'])
 def api_nemoclaw_rules_delete(rule_key):
-    """Remove a rule from ~/.clawmetry/policies.yml by preset_key or name."""
-    policies = _load_local_policies()
-    before = len(policies)
-    policies = [
-        p for p in policies
-        if isinstance(p, dict)
-        and p.get('preset_key') != rule_key
-        and p.get('name') != rule_key
-    ]
-    _write_local_policies(policies)
-    return jsonify({'ok': True, 'deleted': before - len(policies)})
+    return _upgrade()

--- a/tests/test_approvals_local_store.py
+++ b/tests/test_approvals_local_store.py
@@ -132,57 +132,57 @@ def test_query_approvals_returns_seeded_rows(fast_path_app):
     assert other == []
 
 
-# ── 2. route fast-path: flag on + rows present → _source=local_store ───────
+# ── 2. route: pending-approvals is now a Pro 402 stub ──────────────────────
+#
+# The HTTP endpoint moved to clawmetry-pro; vanilla OSS serves the 402
+# upgrade stub regardless of the local-store fast-path flag or seeded rows.
+# The LocalStore + sync helpers that fed the old route (query_approvals,
+# update_approval_decision, _build_approvals_cache_pushes,
+# _dispatch_pending_queries) stay in OSS and keep their coverage below — the
+# cloud relay still drives the queue through those, the dashboard HTTP route
+# is what's gated.
 
 
-def test_pending_approvals_fast_path_serves_from_duckdb(fast_path_app):
+def _assert_upgrade_required(resp_json):
+    assert resp_json.get("error") == "upgrade_required"
+    assert resp_json.get("feature") == "nemo_governance"
+    assert "hint" in resp_json
+
+
+def test_pending_approvals_returns_402_with_rows(fast_path_app):
     _app, ls, _nm = fast_path_app
     _seed_two_pending(ls.get_store())
 
-    body = _app.test_client().get("/api/nemoclaw/pending-approvals").get_json()
-    assert body.get("_source") == "local_store"
-    assert body.get("installed") is True
-    approvals = body.get("approvals") or []
-    assert len(approvals) == 2
-
-    by_id = {a["id"]: a for a in approvals}
-    assert set(by_id) == {"app-1", "app-2"}
-    # Legacy fields the dashboard JS reads — present + populated.
-    assert by_id["app-1"]["status"] == "pending"
-    assert by_id["app-1"]["action"] == "bash"
-    assert by_id["app-1"]["chunk_id"] == "app-1"
-    assert by_id["app-1"]["session_id"] == "sess-A"
-    assert by_id["app-1"]["args"] == {"cmd": "rm -rf /tmp/x"}
+    resp = _app.test_client().get("/api/nemoclaw/pending-approvals")
+    assert resp.status_code == 402
+    body = resp.get_json()
+    _assert_upgrade_required(body)
+    # The stub never leaks the local-store fast-path tag or the queue rows.
+    assert body.get("_source") != "local_store"
+    assert "approvals" not in body
 
 
-# ── 3. route fast-path: flag off → fast path skipped ───────────────────────
+# ── 3. route: 402 regardless of the local-store read flag ──────────────────
 
 
-def test_pending_approvals_flag_off_skips_fast_path(no_flag_app):
-    """CLAWMETRY_LOCAL_STORE_READ unset: even with DuckDB rows present, the
-    fast path is skipped and the legacy openshell CLI path runs. On a system
-    without `openshell` on PATH the legacy path returns
-    ``{installed: False, approvals: []}`` — and crucially, NO ``_source``."""
+def test_pending_approvals_returns_402_flag_off(no_flag_app):
+    """CLAWMETRY_LOCAL_STORE_READ unset: the route is a Pro stub either way."""
     _app, ls, _nm = no_flag_app
     _seed_two_pending(ls.get_store())
 
-    body = _app.test_client().get("/api/nemoclaw/pending-approvals").get_json()
-    assert body.get("_source") != "local_store"
-    # The legacy path may return installed=False (no openshell binary in CI)
-    # or installed=True with an empty list (binary present but no sandbox).
-    # Either way the response must NOT carry the fast-path tag.
+    resp = _app.test_client().get("/api/nemoclaw/pending-approvals")
+    assert resp.status_code == 402
+    _assert_upgrade_required(resp.get_json())
 
 
-# ── 4. route fast-path: empty store → fast path returns None → legacy ──────
+# ── 4. route: 402 even with an empty store ─────────────────────────────────
 
 
-def test_pending_approvals_empty_store_falls_through(fast_path_app):
-    """Flag on but no rows in DuckDB: ``_try_local_store_approvals`` returns
-    None and the legacy CLI path runs (and degrades to installed=False on a
-    bare CI image)."""
+def test_pending_approvals_returns_402_empty_store(fast_path_app):
     _app, _ls, _nm = fast_path_app
-    body = _app.test_client().get("/api/nemoclaw/pending-approvals").get_json()
-    assert body.get("_source") != "local_store"
+    resp = _app.test_client().get("/api/nemoclaw/pending-approvals")
+    assert resp.status_code == 402
+    _assert_upgrade_required(resp.get_json())
 
 
 # ── 5. update_approval_decision flips status idempotently ──────────────────
@@ -348,58 +348,12 @@ def test_dispatch_pending_queries_applies_approval_decision(fast_path_app):
 
 # ── 9. issue #1328: Cloud-Pro upsell CTA flag on the queue response ────────
 #
-# OSS / Cloud-Free callers with >=1 pending approval get
-# ``pro_gated_upsell=true`` so the dashboard renders the Slack/PagerDuty/email
-# notifications CTA. Cloud-Pro callers never see the flag. Empty queue never
-# triggers the CTA (we don't want to pollute the clean empty state).
-
-
-def test_pending_approvals_pro_gated_upsell_for_oss_user(fast_path_app, monkeypatch):
-    """OSS / Cloud-Free user with pending approvals: response includes
-    ``pro_gated_upsell=true`` + ``pending_count`` so the JS can render the
-    upsell CTA above the queue table."""
-    _app, ls, _nm = fast_path_app
-    _seed_two_pending(ls.get_store())
-
-    import dashboard as _d
-    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
-
-    body = _app.test_client().get("/api/nemoclaw/pending-approvals").get_json()
-    assert body.get("pro_gated_upsell") is True
-    assert body.get("pending_count") == 2
-    # The queue itself is still served — gating only adds the CTA flag.
-    assert len(body.get("approvals") or []) == 2
-
-
-def test_pending_approvals_no_upsell_for_pro_user(fast_path_app, monkeypatch):
-    """Cloud-Pro user with pending approvals: ``pro_gated_upsell`` is False
-    so the upsell CTA never renders. Count still surfaces (harmless metadata).
-    """
-    _app, ls, _nm = fast_path_app
-    _seed_two_pending(ls.get_store())
-
-    import dashboard as _d
-    monkeypatch.setattr(_d, "_is_pro_user", lambda: True)
-
-    body = _app.test_client().get("/api/nemoclaw/pending-approvals").get_json()
-    assert body.get("pro_gated_upsell") is False
-    assert body.get("pending_count") == 2
-    assert len(body.get("approvals") or []) == 2
-
-
-def test_pending_approvals_empty_queue_never_upsells(no_flag_app, monkeypatch):
-    """Empty queue must NOT trigger the CTA — issue #1328 ask #2 explicitly
-    says don't pollute the empty state."""
-    _app, _ls, _nm = no_flag_app
-
-    import dashboard as _d
-    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
-
-    body = _app.test_client().get("/api/nemoclaw/pending-approvals").get_json()
-    # Legacy path with no openshell binary returns installed=False, [].
-    # Either way, the upsell must be off when the queue is empty.
-    assert body.get("pro_gated_upsell") is False
-    assert body.get("pending_count") == 0
+# The ``pro_gated_upsell`` / ``pending_count`` CTA annotation lived on the
+# ``/api/nemoclaw/pending-approvals`` HTTP route, which moved to clawmetry-pro
+# alongside the rest of NeMo governance. In vanilla OSS the route is a 402
+# stub (covered by sections 2-4 above), so the route-level upsell assertions
+# no longer apply here — they live in clawmetry-pro's test suite. The
+# LocalStore + sync queue-relay coverage (sections 1, 5-8) is unaffected.
 
 
 def test_dispatch_pending_queries_approval_decision_missing_id_is_noop(fast_path_app):

--- a/tests/test_nemoclaw_events_metrics.py
+++ b/tests/test_nemoclaw_events_metrics.py
@@ -28,90 +28,39 @@ def _make_app():
     return app
 
 
-class TestNemoClawEventsEndpoint(unittest.TestCase):
+# The /api/nemoclaw/events + /metrics endpoints moved to clawmetry-pro;
+# vanilla OSS now serves the 402 upgrade stub on both. The real impl
+# (DuckDB-backed events + aggregate metrics) is covered by clawmetry-pro's
+# own suite. The LocalStore guardrail helpers below stay in OSS and keep
+# their direct unit coverage.
+
+
+def _assert_upgrade_required(test, resp):
+    test.assertEqual(resp.status_code, 402)
+    data = json.loads(resp.data)
+    test.assertEqual(data.get("error"), "upgrade_required")
+    test.assertEqual(data.get("feature"), "nemo_governance")
+    test.assertIn("hint", data)
+
+
+class TestNemoClawEventsEndpointStub(unittest.TestCase):
 
     def setUp(self):
         self.app = _make_app()
         self.client = self.app.test_client()
 
-    def _get(self, url):
-        with patch("routes.local_query.local_store_via_daemon", side_effect=Exception("no daemon")):
-            with patch("clawmetry.local_store.get_store", side_effect=Exception("no store")):
-                return self.client.get(url)
-
-    def test_events_returns_200(self):
-        resp = self._get("/api/nemoclaw/events")
-        self.assertEqual(resp.status_code, 200)
-
-    def test_events_has_required_keys(self):
-        resp = self._get("/api/nemoclaw/events")
-        data = json.loads(resp.data)
-        self.assertIn("installed", data)
-        self.assertIn("events", data)
-        self.assertIn("total", data)
-
-    def test_events_not_installed_when_nemoclaw_absent(self):
-        resp = self._get("/api/nemoclaw/events")
-        data = json.loads(resp.data)
-        self.assertFalse(data["installed"])
-
-    def test_events_list_is_list(self):
-        resp = self._get("/api/nemoclaw/events")
-        data = json.loads(resp.data)
-        self.assertIsInstance(data["events"], list)
-
-    def test_events_total_matches_list(self):
-        resp = self._get("/api/nemoclaw/events")
-        data = json.loads(resp.data)
-        self.assertEqual(data["total"], len(data["events"]))
-
-    def test_events_empty_on_no_store(self):
-        resp = self._get("/api/nemoclaw/events")
-        data = json.loads(resp.data)
-        self.assertEqual(data["events"], [])
+    def test_events_returns_402(self):
+        _assert_upgrade_required(self, self.client.get("/api/nemoclaw/events"))
 
 
-class TestNemoClawMetricsEndpoint(unittest.TestCase):
+class TestNemoClawMetricsEndpointStub(unittest.TestCase):
 
     def setUp(self):
         self.app = _make_app()
         self.client = self.app.test_client()
 
-    def _get(self, url):
-        with patch("routes.local_query.local_store_via_daemon", side_effect=Exception("no daemon")):
-            with patch("clawmetry.local_store.get_store", side_effect=Exception("no store")):
-                return self.client.get(url)
-
-    def test_metrics_returns_200(self):
-        resp = self._get("/api/nemoclaw/metrics")
-        self.assertEqual(resp.status_code, 200)
-
-    def test_metrics_has_required_keys(self):
-        resp = self._get("/api/nemoclaw/metrics")
-        data = json.loads(resp.data)
-        self.assertIn("installed", data)
-        self.assertIn("metrics", data)
-
-    def test_metrics_not_installed_when_nemoclaw_absent(self):
-        resp = self._get("/api/nemoclaw/metrics")
-        data = json.loads(resp.data)
-        self.assertFalse(data["installed"])
-
-    def test_metrics_object_has_expected_fields(self):
-        resp = self._get("/api/nemoclaw/metrics")
-        data = json.loads(resp.data)
-        m = data["metrics"]
-        self.assertIn("total_approvals", m)
-        self.assertIn("approved_count", m)
-        self.assertIn("denied_count", m)
-        self.assertIn("triggers_24h", m)
-
-    def test_metrics_defaults_to_zeros_on_no_store(self):
-        resp = self._get("/api/nemoclaw/metrics")
-        data = json.loads(resp.data)
-        m = data["metrics"]
-        self.assertEqual(m["total_approvals"], 0)
-        self.assertEqual(m["triggers_24h"], 0)
+    def test_metrics_returns_402(self):
+        _assert_upgrade_required(self, self.client.get("/api/nemoclaw/metrics"))
 
 
 class TestLocalStoreGuardrailMethods(unittest.TestCase):

--- a/tests/test_nemoclaw_governance.py
+++ b/tests/test_nemoclaw_governance.py
@@ -117,122 +117,51 @@ class TestDetectNemoclaw(unittest.TestCase):
             self.assertEqual(loaded_cfg.get('provider'), 'anthropic')
 
 
-class TestGovernanceEndpoint(unittest.TestCase):
-    """Integration-style tests for /api/nemoclaw/governance Flask endpoint."""
+class TestGovernanceEndpointStub(unittest.TestCase):
+    """In vanilla OSS the NeMo governance impl is gone — it moved to the
+    closed-source ``clawmetry-pro`` package. The OSS ``bp_nemoclaw`` stub
+    now returns HTTP 402 ``upgrade_required`` on every governance endpoint.
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a minimal Flask test client from dashboard."""
-        try:
-            import dashboard as _d
-            cls.app = _d.create_app()
-            cls.client = cls.app.test_client()
-            cls.app_available = True
-        except Exception as e:
-            cls.app_available = False
-            cls.skip_reason = str(e)
+    These tests register the OSS stub blueprint directly (the same blueprint
+    dashboard.py registers when ``clawmetry_pro.is_loaded()`` is False) and
+    assert the 402 upgrade contract. The real behaviour is covered by
+    clawmetry-pro's own test suite."""
 
-    def _skip_if_unavailable(self):
-        if not self.app_available:
-            self.skipTest(f"Dashboard app not available: {self.skip_reason}")
+    def setUp(self):
+        from flask import Flask
+        from routes.nemoclaw import bp_nemoclaw
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.register_blueprint(bp_nemoclaw)
+        self.client = app.test_client()
 
-    def test_not_installed_returns_200(self):
-        self._skip_if_unavailable()
-        import dashboard as _d
-        with self.app.test_request_context():
-            with patch.object(_d, '_detect_nemoclaw', return_value=None):
-                resp = self.client.get('/api/nemoclaw/governance')
-        self.assertEqual(resp.status_code, 200)
+    def _assert_upgrade_required(self, resp):
+        self.assertEqual(resp.status_code, 402)
         data = json.loads(resp.data)
-        self.assertFalse(data['installed'])
+        self.assertEqual(data.get("error"), "upgrade_required")
+        self.assertEqual(data.get("feature"), "nemo_governance")
+        self.assertIn("hint", data)
 
-    def test_installed_returns_expected_keys(self):
-        self._skip_if_unavailable()
-        import dashboard as _d
-        mock_info = {
-            'installed': True,
-            'config': {'version': '1.0', 'provider': 'anthropic'},
-            'state': {'sandboxes': {}},
-            'policy_yaml': 'network_policies:\n  allow_api:\n    - api.anthropic.com\n',
-            'policy_hash': 'abc123def456',
-            'presets': ['clawmetry'],
-        }
-        with self.app.test_request_context():
-            with patch.object(_d, '_detect_nemoclaw', return_value=mock_info):
-                resp = self.client.get('/api/nemoclaw/governance')
-        self.assertEqual(resp.status_code, 200)
-        data = json.loads(resp.data)
-        self.assertTrue(data['installed'])
-        self.assertIn('sandboxes', data)
-        self.assertIn('network_policies', data)
-        self.assertIn('presets', data)
-        self.assertIn('config', data)
+    def test_governance_returns_402(self):
+        self._assert_upgrade_required(self.client.get('/api/nemoclaw/governance'))
 
-    def test_sensitive_config_keys_filtered(self):
-        """API keys and tokens should be stripped from config."""
-        self._skip_if_unavailable()
-        import dashboard as _d
-        mock_info = {
-            'installed': True,
-            'config': {
-                'version': '1.0',
-                'apiKey': 'sk-secret-12345',
-                'token': 'tok-secret',
-                'provider': 'anthropic',
-            },
-            'state': {},
-        }
-        with self.app.test_request_context():
-            with patch.object(_d, '_detect_nemoclaw', return_value=mock_info):
-                resp = self.client.get('/api/nemoclaw/governance')
-        data = json.loads(resp.data)
-        cfg = data.get('config', {})
-        self.assertNotIn('apiKey', cfg)
-        self.assertNotIn('token', cfg)
-        self.assertIn('provider', cfg)  # non-sensitive key preserved
+    def test_acknowledge_drift_returns_402(self):
+        self._assert_upgrade_required(
+            self.client.post('/api/nemoclaw/governance/acknowledge-drift'))
 
-    def test_drift_detection_triggers(self):
-        """Second call with different policy hash sets drift info."""
-        self._skip_if_unavailable()
-        import dashboard as _d
+    def test_status_returns_402(self):
+        self._assert_upgrade_required(self.client.get('/api/nemoclaw/status'))
 
-        # Reset module-level drift state
-        _d._nemoclaw_policy_hash = None
-        _d._nemoclaw_drift_info = {}
+    def test_policy_returns_402(self):
+        self._assert_upgrade_required(self.client.get('/api/nemoclaw/policy'))
 
-        def make_info(h):
-            return {
-                'installed': True,
-                'config': {},
-                'state': {},
-                'policy_yaml': '# hash ' + h,
-                'policy_hash': h,
-            }
+    def test_approve_returns_402(self):
+        self._assert_upgrade_required(
+            self.client.post('/api/nemoclaw/approve', json={}))
 
-        with self.app.test_request_context():
-            with patch.object(_d, '_detect_nemoclaw', return_value=make_info('aaa111')):
-                self.client.get('/api/nemoclaw/governance')  # sets baseline
-            with patch.object(_d, '_detect_nemoclaw', return_value=make_info('bbb222')):
-                resp = self.client.get('/api/nemoclaw/governance')  # should trigger drift
-
-        data = json.loads(resp.data)
-        self.assertIsNotNone(data.get('drift'))
-        drift = data['drift']
-        self.assertIn('previous_hash', drift)
-        self.assertEqual(drift['previous_hash'], 'aaa111')
-        self.assertEqual(drift['current_hash'], 'bbb222')
-
-    def test_acknowledge_drift_clears_it(self):
-        """POST /acknowledge-drift clears the drift dict."""
-        self._skip_if_unavailable()
-        import dashboard as _d
-        _d._nemoclaw_drift_info = {'previous_hash': 'x', 'current_hash': 'y', 'detected_at': '2026-01-01T00:00:00Z'}
-        with self.app.test_request_context():
-            resp = self.client.post('/api/nemoclaw/governance/acknowledge-drift')
-        self.assertEqual(resp.status_code, 200)
-        data = json.loads(resp.data)
-        self.assertTrue(data['ok'])
-        self.assertEqual(_d._nemoclaw_drift_info, {})
+    def test_reject_returns_402(self):
+        self._assert_upgrade_required(
+            self.client.post('/api/nemoclaw/reject', json={}))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

Replaces the OSS NeMo Guardrails governance + approval-queue implementation in `routes/nemoclaw.py` with a **402 `upgrade_required` stub**. The real implementation moves to the closed-source `clawmetry-pro` package (`clawmetry_pro/routes/nemoclaw.py`), per the open-core plan.

This mirrors the precedent already shipped for `runtime_ingest`, `otel_export`, `selfevolve`, and `assets`:
- Same blueprint object (`bp_nemoclaw`, `Blueprint("nemoclaw", ...)`) and the same 12 URL rules.
- Every governance endpoint now returns a shared body:
  ```json
  {"error":"upgrade_required","feature":"nemo_governance","hint":"NeMo governance is a paid feature. Install clawmetry-pro with a license key, or use Cloud at clawmetry.com/pricing."}
  ```
  Routes covered: `governance`, `governance/acknowledge-drift`, `status`, `policy`, `approve`, `reject`, `pending-approvals`, `rules` GET/POST/DELETE, `events`, `metrics`. Import-light and never-raise.

## Registration

`dashboard.py` registers the OSS stub **only when `clawmetry_pro.is_loaded()` is False**, exactly like `bp_runtime_ingest`. When clawmetry-pro is installed, its blueprint registers via `register_all()` -> `_register_blueprints(app)` and wins the URL routes; the OSS stub skips registration so the two never collide on the URL map.

## Tests

Updated OSS-side assertions to expect the 402 stub contract. No coverage was deleted:
- The dashboard helpers (`_detect_nemoclaw`, `_parse_network_policies`) stay in `dashboard.py` and keep their tests.
- The LocalStore / sync queue-relay helpers (`query_approvals`, `update_approval_decision`, `_build_approvals_cache_pushes`, `_dispatch_pending_queries`, guardrail-event store methods) stay in OSS and keep their direct unit coverage. The cloud approval relay still drives the queue through those; only the dashboard HTTP route is gated.
- The route-level upsell-CTA assertions (issue #1328) moved out with the route — they live in clawmetry-pro's suite now.

## Verification

- `python3 -m py_compile routes/nemoclaw.py dashboard.py` passes.
- All 12 stub routes verified returning 402 with the shared body.
- Updated stub + retained unit tests pass (24 passed). (4 pre-existing `test_approvals_local_store.py` LocalStore failures reproduce on `origin/main` unchanged and are unrelated to this change — a local DuckDB env issue.)

## Sequencing — IMPORTANT

This depends on the clawmetry-pro PR shipping FIRST (pro-first sequence) so that paying / Pro users never see a 402. Until the clawmetry-pro `routes/nemoclaw.py` impl is live and the cloud/Pro deploy pins it, this OSS stub must NOT be merged-and-deployed in isolation, or Pro users would hit the upgrade wall on a feature they already pay for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)