### PR TITLE
feat(brain): "Why?" button — LLM narration for agent turns

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -4496,6 +4496,13 @@ function renderBrainStream(events) {
             _altContainerId = 'toolalt-' + ((te.eventId || (te.time || '') + (te.source || '')) + '').replace(/[^a-z0-9-]/gi, '').slice(0, 24);
             turnTimeline += '<button onclick="event.stopPropagation();toggleToolAlternatives(this,\'' + escHtml(_altContainerId) + '\')" data-ta=\'' + escHtml(JSON.stringify(te.tool_alternatives || null)) + '\' style="flex-shrink:0;padding:1px 7px;border-radius:10px;border:1px solid #a78bfa;background:transparent;color:#a78bfa;font-size:10px;cursor:pointer;white-space:nowrap;" title="What other tools did the model consider before picking this one?">&#9879; Alternatives</button>';
           }
+          // Issue #1414: "Why did this happen?" — LLM-narrated explanation for AGENT turns.
+          var _whyContainerId = null;
+          if (te.type === 'AGENT' && te.eventId) {
+            var _whySid = te.sessionId || '';
+            _whyContainerId = 'why-' + te.eventId.replace(/[^a-z0-9-]/gi, '').slice(0, 24);
+            turnTimeline += '<button onclick="event.stopPropagation();loadBrainWhy(\'' + escHtml(_whySid) + '\',\'' + escHtml(te.eventId) + '\',\'' + escHtml(_whyContainerId) + '\')" style="flex-shrink:0;padding:1px 7px;border-radius:10px;border:1px solid #f43f5e;background:transparent;color:#fb7185;font-size:10px;cursor:pointer;white-space:nowrap;" title="Why did this happen? (AI narration)">&#128269; Why?</button>';
+          }
           turnTimeline += '</div>';
           if (_rcContainerId) {
             turnTimeline += '<div id="' + escHtml(_rcContainerId) + '" style="margin:2px 0 4px 56px;"></div>';
@@ -4508,6 +4515,9 @@ function renderBrainStream(events) {
           }
           if (_altContainerId) {
             turnTimeline += '<div id="' + escHtml(_altContainerId) + '" class="tool-alternatives-host" style="margin:2px 0 4px 56px;"></div>';
+          }
+          if (_whyContainerId) {
+            turnTimeline += '<div id="' + escHtml(_whyContainerId) + '" class="brain-why-host" style="margin:2px 0 4px 56px;"></div>';
           }
         });
         if (currentSubagent) turnTimeline += '</div>'; // close last sub-agent group
@@ -4676,6 +4686,39 @@ function loadReasoningChain(sessionId, containerId) {
     })
     .catch(function(err) {
       container.innerHTML = '<span style="color:#ef4444;font-size:10px;">' + t("app.error_loading_reasoning_chain", null, "Error loading reasoning chain.") + '</span>';
+    });
+}
+
+// Issue #1414: "Why did this happen?" — fetch LLM narration for one AGENT turn.
+function loadBrainWhy(sessionId, eventId, containerId) {
+  var container = document.getElementById(containerId);
+  if (!container) return;
+  // Toggle: second click clears the panel.
+  if (container.dataset.loaded === '1') {
+    container.innerHTML = '';
+    container.dataset.loaded = '0';
+    return;
+  }
+  container.innerHTML = '<span style="color:var(--text-muted);font-size:10px;">Asking AI…</span>';
+  fetch('/api/brain/why/' + encodeURIComponent(sessionId) + '/' + encodeURIComponent(eventId))
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      container.dataset.loaded = '1';
+      var narration = data.narration || '(no narration)';
+      var anomaly = data.anomaly || false;
+      var html = '<div style="padding:6px 10px;background:rgba(244,63,94,0.08);border:1px solid rgba(244,63,94,0.2);border-radius:6px;font-size:11px;line-height:1.5;">';
+      if (anomaly) {
+        html += '<div style="color:#f43f5e;font-weight:700;margin-bottom:4px;">⚠ Anomaly detected</div>';
+      }
+      html += '<div style="color:var(--text-secondary);">🔍 ' + escHtml(narration) + '</div>';
+      if (data.model && data.model !== 'none') {
+        html += '<div style="color:var(--text-faint);font-size:9px;margin-top:4px;">via ' + escHtml(data.model) + '</div>';
+      }
+      html += '</div>';
+      container.innerHTML = html;
+    })
+    .catch(function() {
+      container.innerHTML = '<span style="color:#ef4444;font-size:10px;">Error loading explanation.</span>';
     });
 }
 

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -1862,3 +1862,79 @@ def api_brain_clusters():
         "_source": "unavailable",
         "_shape": "brain_clusters",
     })
+
+
+_WHY_HINT = (
+    "These rows are events from an AI agent session (oldest first). "
+    "The last row is the target assistant turn. "
+    "Explain in exactly 3 sentences why that assistant output happened. "
+    "Lead with the most direct cause (which user message or tool result triggered it). "
+    "If the same tool or query appears 3+ times (loop / anomaly), say so first."
+)
+
+
+@bp_brain.route("/api/brain/why/<session_id>/<event_id>")
+def api_brain_why(session_id, event_id):
+    """Return an LLM-narrated explanation of why a specific assistant turn happened.
+
+    Reads up to 10 preceding events from DuckDB as context, then calls the
+    same synthesis path used by the weekly digest (insights.py). Falls back
+    to a stub message when no LLM key is configured — never a 500.
+
+    Query params: none required (session_id and event_id are path params).
+    """
+    rows = _fetch_session_chain(session_id)
+    if rows is None:
+        return jsonify({"error": "local store unavailable", "event_id": event_id}), 503
+
+    # Find the target event; rows are oldest-first from _fetch_session_chain.
+    target_idx = None
+    for i, r in enumerate(rows):
+        if str(r.get("id") or "") == str(event_id):
+            target_idx = i
+            break
+
+    if target_idx is None:
+        return jsonify({"error": "event not found", "event_id": event_id}), 404
+
+    # Context window: up to 10 preceding events + the target event itself.
+    context = rows[max(0, target_idx - 10): target_idx + 1]
+
+    # Anomaly: any non-conversation event_type that repeats 3+ times in context.
+    from collections import Counter
+    type_counts = Counter(r.get("event_type", "") for r in context)
+    anomaly = any(
+        count >= 3 and et not in ("assistant", "user", "message", "")
+        for et, count in type_counts.items()
+    )
+
+    from clawmetry.insights import _resolve_synthesis_credential, _synthesize_narrative
+    from clawmetry.config import load_config
+
+    cfg = load_config()
+    mode, secret = _resolve_synthesis_credential(cfg)
+
+    if mode == "none":
+        narration = (
+            f"{len(context)} context events. "
+            "Connect to Cloud for AI narration — no key required."
+        )
+        used_model = "none"
+    else:
+        narration, _ = _synthesize_narrative(
+            secret,
+            "Why did this agent turn happen?",
+            _WHY_HINT,
+            context,
+            mode=mode,
+        )
+        used_model = "claude-sonnet-4-6"
+
+    return jsonify({
+        "session_id": session_id,
+        "event_id": event_id,
+        "narration": narration,
+        "anomaly": anomaly,
+        "model": used_model,
+        "_source": "local_store",
+    })


### PR DESCRIPTION
Closes #1414

## Summary

- **New endpoint** `GET /api/brain/why/<session_id>/<event_id>` in `routes/brain.py`: loads up to 10 preceding DuckDB events as context, calls the existing `_synthesize_narrative` path from `clawmetry/insights.py`, returns a 3-sentence explanation of why the assistant turn happened. Anomaly flag fires when any non-conversation `event_type` repeats 3+ times. Graceful stub when no LLM key is configured (never a 500).
- **"🔍 Why?" button** added to AGENT events in the Brain tab turn timeline (`clawmetry/static/js/app.js`), same pattern as the existing Timeline/Confidence buttons. Click fetches the endpoint and renders narration inline; second click toggles the panel off. Yellow ⚠ banner shown when `anomaly=true`.
- Reuses Feature B's synthesis infrastructure (`insights.py`) — no new LLM plumbing. Step 5 ("Compare to similar turns") left for a follow-up.

## Test plan

- [ ] `curl http://localhost:8900/api/brain/why/<session_id>/<event_id>` returns 200 with `narration` and `anomaly` fields
- [ ] Without `ANTHROPIC_API_KEY` / cloud pairing: endpoint returns stub narration, not a 500
- [ ] Open Brain tab → expand a USER turn → click "🔍 Why?" on an AGENT chip → narration appears within a few seconds
- [ ] Click "🔍 Why?" again → panel clears (toggle)
- [ ] Session with a repeated tool call (3+ same event_type) → `anomaly: true` → ⚠ banner shown in UI

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9G6LRBDF2Qcn9vfYRybrH)_