### PR TITLE
fix(ui): add nemoclaw to JS _CM_RT_LABEL + CI guard for Python↔JS drift

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7336,7 +7336,8 @@ function closeFileViewer() {
 // `<name>:<id>` session-id prefix the daemon stamps). Order here drives the
 // switcher chip order (OpenClaw always first). To add a runtime, add a label.
 var _CM_RT_LABEL = {
-  openclaw: 'OpenClaw', picoclaw: 'PicoClaw', nanoclaw: 'NanoClaw',
+  openclaw: 'OpenClaw', nemoclaw: 'NemoClaw',
+  picoclaw: 'PicoClaw', nanoclaw: 'NanoClaw',
   hermes: 'Hermes', claude_code: 'Claude Code', codex: 'Codex', cursor: 'Cursor',
   aider: 'Aider', goose: 'Goose', opencode: 'opencode', qwen_code: 'Qwen Code'
 };

--- a/tests/test_runtime_labels_js_python_parity.py
+++ b/tests/test_runtime_labels_js_python_parity.py
@@ -1,0 +1,110 @@
+"""CI guard: Python ``RUNTIME_LABELS`` must match the JS ``_CM_RT_LABEL``
+runtime-switcher dictionary.
+
+``clawmetry/entitlements.py`` advertises a label for every known runtime; the
+dashboard frontend hard-codes the same map in ``clawmetry/static/js/app.js``
+as ``_CM_RT_LABEL``. The JS dict is the source of truth for:
+
+* the runtime chip switcher (``_cmRenderRuntimeSwitcher`` only renders keys
+  that exist in ``_CM_RT_LABEL``),
+* the session-id-prefix runtime detector (``_cmRuntimeOf`` only recognises
+  prefixes that exist in ``_CM_RT_LABEL`` — anything else falls back to
+  ``openclaw``),
+* the global header switcher's display labels.
+
+If a runtime is in the Python catalogue but missing from the JS dict, sessions
+for that runtime are silently classified as OpenClaw and never get their own
+chip. Burned 2026-06-02: ``nemoclaw`` was in ``RUNTIME_LABELS`` (Free tier)
+but absent from ``_CM_RT_LABEL`` — NemoClaw sessions vanished from the
+switcher. This guard pins the two sides together so the next runtime can't
+drift the same way.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_APP_JS = os.path.join(_REPO_ROOT, "clawmetry", "static", "js", "app.js")
+
+
+def _parse_js_label_dict() -> dict[str, str]:
+    """Pull the ``_CM_RT_LABEL = { ... }`` dict out of ``app.js`` and parse it
+    into a Python dict. Tolerant of trailing commas and any whitespace/line
+    layout; rejects entries that are not a simple ``ident: 'string'`` pair so
+    the test fails loudly on malformed JS rather than silently passing."""
+    with open(_APP_JS, "r", encoding="utf-8") as fh:
+        src = fh.read()
+    m = re.search(r"var\s+_CM_RT_LABEL\s*=\s*\{([^}]*)\}", src)
+    assert m, f"_CM_RT_LABEL declaration not found in {_APP_JS}"
+    body = m.group(1)
+    out: dict[str, str] = {}
+    for pair in re.finditer(
+        r"([A-Za-z_][A-Za-z0-9_]*)\s*:\s*'([^']*)'", body
+    ):
+        out[pair.group(1)] = pair.group(2)
+    assert out, "_CM_RT_LABEL parsed empty — JS layout changed, update the test"
+    return out
+
+
+@pytest.fixture(scope="module")
+def js_labels() -> dict[str, str]:
+    return _parse_js_label_dict()
+
+
+def test_every_python_runtime_has_js_label(js_labels):
+    """Every key in ``RUNTIME_LABELS`` must appear in ``_CM_RT_LABEL``."""
+    from clawmetry.entitlements import RUNTIME_LABELS
+
+    missing = sorted(set(RUNTIME_LABELS) - set(js_labels))
+    assert not missing, (
+        f"_CM_RT_LABEL (clawmetry/static/js/app.js) is missing runtime(s) "
+        f"present in Python RUNTIME_LABELS: {missing}. Add them to the JS "
+        f"dict or the runtime chip switcher will silently drop those sessions."
+    )
+
+
+def test_every_js_runtime_has_python_label(js_labels):
+    """Every key in ``_CM_RT_LABEL`` must appear in ``RUNTIME_LABELS`` — a JS
+    entry without a Python counterpart means the catalogue side does not know
+    about the runtime and ``/api/runtimes`` will not advertise it."""
+    from clawmetry.entitlements import RUNTIME_LABELS
+
+    extra = sorted(set(js_labels) - set(RUNTIME_LABELS))
+    assert not extra, (
+        f"_CM_RT_LABEL has runtime(s) not in Python RUNTIME_LABELS: {extra}. "
+        f"Add them to clawmetry/entitlements.py RUNTIME_LABELS (and the "
+        f"FREE_RUNTIMES / PAID_RUNTIMES sets) or remove them from the JS dict."
+    )
+
+
+def test_label_strings_match_between_python_and_js(js_labels):
+    """The display labels must agree — a mismatch means the dashboard shows a
+    different name than the API response and the chip will look inconsistent
+    next to the tab title."""
+    from clawmetry.entitlements import RUNTIME_LABELS
+
+    mismatches = sorted(
+        (rt, RUNTIME_LABELS[rt], js_labels[rt])
+        for rt in RUNTIME_LABELS
+        if rt in js_labels and RUNTIME_LABELS[rt] != js_labels[rt]
+    )
+    assert not mismatches, (
+        f"Display-label drift between Python RUNTIME_LABELS and JS "
+        f"_CM_RT_LABEL (id, py, js): {mismatches}"
+    )
+
+
+def test_free_runtimes_all_present_in_js(js_labels):
+    """Free-tier runtimes must always render in the switcher — they are the
+    OSS install's actual runtimes. A missing one means the user can't filter
+    to it and its sessions get bucketed under openclaw."""
+    from clawmetry.entitlements import FREE_RUNTIMES
+
+    missing = sorted(set(FREE_RUNTIMES) - set(js_labels))
+    assert not missing, (
+        f"_CM_RT_LABEL missing FREE_RUNTIMES: {missing}. The runtime switcher "
+        f"will silently classify these sessions as openclaw."
+    )


### PR DESCRIPTION
## Summary

`nemoclaw` is in `FREE_RUNTIMES` and `clawmetry/entitlements.py::RUNTIME_LABELS`, but the JS `_CM_RT_LABEL` dict in `clawmetry/static/js/app.js` was missing it. That dict is the single source of truth on the frontend for:

- the runtime chip switcher (`_cmRenderRuntimeSwitcher` at `app.js:7427` filters its order by `Object.keys(_CM_RT_LABEL)`)
- the session-id prefix detector (`_cmRuntimeOf` at `app.js:7347` only recognises prefixes that exist in `_CM_RT_LABEL`)
- the global header switcher's display labels

A missing key means NemoClaw sessions were silently bucketed under `openclaw` and never got their own chip — the user could not filter to NemoClaw at all. This PR adds the entry and pins Python↔JS parity with a CI guard so the next runtime can't drift the same way.

## Changes

- **`clawmetry/static/js/app.js`** — added `nemoclaw: 'NemoClaw'` to `_CM_RT_LABEL` (right after `openclaw`, since both are Free).
- **`tests/test_runtime_labels_js_python_parity.py`** (new, 4 tests) — parses the JS `_CM_RT_LABEL = { … }` block out of `app.js` with a regex (no build step, no node dependency) and asserts:
  1. every key in Python `RUNTIME_LABELS` appears in JS `_CM_RT_LABEL`
  2. every key in JS `_CM_RT_LABEL` appears in Python `RUNTIME_LABELS`
  3. display strings agree on both sides for every shared key
  4. every member of `FREE_RUNTIMES` is present in JS (the strongest invariant — Free runtimes are always observable on an OSS install, so a missing one is a guaranteed user-visible bug)

The parser tolerates trailing commas and arbitrary whitespace; if the JS layout changes in a way that makes the dict unparseable the test fails loudly with a clear message rather than silently passing.

## No behaviour change beyond the fix

Grace mode is preserved. No `__version__` bump. No `[RELEASE]` PR. No enforcement gate. The only user-visible change is that NemoClaw sessions now render with the correct label and get a chip in the runtime switcher.

## Test plan

- [x] `python3 -m pytest tests/test_runtime_labels_js_python_parity.py -v` — 4/4 pass
- [x] `python3 -m pytest tests/test_advertised_runtimes_match_catalogue.py tests/test_entitlements.py tests/test_entitlements_catalogue.py -q` — 41/41 pass (no regression in adjacent runtime/catalogue guards)
- [x] Regression sanity check: temporarily removed the new JS entry → 2 of 4 parity tests fail with the expected drift message; restored → all 4 pass
- [x] `node -e "new Function(fs.readFileSync('clawmetry/static/js/app.js','utf8'))"` — JS parses cleanly
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_runtime_labels_js_python_parity.py` — clean
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — clean

## Local operator verification checklist

I cannot reach the user's local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please complete on a real install:

1. `cp clawmetry/static/js/app.js ~/.clawmetry/lib/python3.11/site-packages/clawmetry/static/js/app.js`
2. `rm -f ~/.clawmetry/lib/python3.11/site-packages/clawmetry/__pycache__/*.pyc`
3. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (no daemon code changed; restart picks up the new static asset)
4. Hard-reload the dashboard in the browser (Cmd+Shift+R) so the cached `app.js` is replaced.
5. With a node that has NemoClaw sessions present (or a synthesised `nemoclaw:` session-id prefix in the snapshot), confirm:
   - the runtime chip switcher renders a "NemoClaw" chip alongside "OpenClaw" — not a raw `nemoclaw` string
   - selecting the NemoClaw chip filters sessions to that runtime only
   - the global header switcher (top of the dashboard) shows "NemoClaw" with the right label
6. Decrypt the live cloud snapshot to confirm no daemon-side regression (this PR is frontend-only; the snapshot shape is unchanged).
7. `curl -s http://localhost:8900/api/runtimes | jq '.runtimes[] | select(.id=="nemoclaw")'` — should still show `free: true, allowed: true, locked: false` (no API change, just verifying parity holds).

This PR is **draft-only**: I am not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Once you have run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsxoDdccg9moBNM3oA4nkx)_