### PR TITLE
feat(connect): GitHub/Google browser sign-in for 'clawmetry connect'

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -283,8 +283,70 @@ def _stop_existing_daemon() -> None:
         LOG_FILE.write_text("")
 
 
+def _oauth_browser_login(provider: str) -> str:
+    """Browser-bridge OAuth for `clawmetry connect`.
+
+    Spins up a one-shot loopback server on 127.0.0.1, opens the cloud OAuth flow
+    with cli_port=<our port>, and captures the cm_ key that the callback redirects
+    back to loopback. Returns "" on timeout/error so the caller falls back to email
+    OTP. The key only ever travels over 127.0.0.1 — nothing is exposed off-host.
+    """
+    import http.server
+    import urllib.parse
+    import webbrowser
+    import time as _time
+
+    app_base = os.environ.get("CLAWMETRY_APP_BASE", "https://app.clawmetry.com").rstrip("/")
+    captured = {}
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            captured["token"] = (params.get("token") or [""])[0]
+            ok = captured["token"].startswith("cm_")
+            msg = ("You're connected — return to your terminal."
+                   if ok else "Sign-in failed. Return to your terminal and use email instead.")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(
+                ("<!DOCTYPE html><html><head><meta charset='utf-8'><title>ClawMetry</title></head>"
+                 "<body style='font-family:sans-serif;background:#0b0f1a;color:#e2e8f0;display:flex;"
+                 "align-items:center;justify-content:center;height:100vh;margin:0'>"
+                 "<div style='text-align:center'><div style='font-size:40px'>\U0001F99E</div>"
+                 "<h2 style='font-weight:700'>" + msg + "</h2></div></body></html>").encode("utf-8")
+            )
+
+        def log_message(self, *args):  # silence default stderr request logging
+            pass
+
+    try:
+        srv = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    except OSError:
+        return ""
+    port = srv.server_address[1]
+    url = f"{app_base}/api/oauth/{provider}/start?cli_port={port}"
+    print(f"\n  🌐 Opening your browser to sign in with {provider.title()}…")
+    print(f"  If it doesn't open, paste this into your browser:\n  {url}\n")
+    try:
+        webbrowser.open(url)
+    except Exception:
+        pass
+
+    srv.timeout = 1
+    deadline = _time.time() + 180
+    try:
+        while "token" not in captured and _time.time() < deadline:
+            srv.handle_request()
+    finally:
+        srv.server_close()
+
+    tok = captured.get("token", "")
+    return tok if tok.startswith("cm_") else ""
+
+
 def _get_api_key_interactive() -> str:
-    """Interactive API key acquisition: email OTP or direct paste."""
+    """Interactive API key acquisition: GitHub/Google OAuth, email OTP, or paste."""
     import getpass
     import urllib.request
     import urllib.error
@@ -316,7 +378,19 @@ def _get_api_key_interactive() -> str:
         return result
 
     print()
-    entry = _input("  📧 Enter your email: ").strip()
+    print("  Sign in with:")
+    print("    [1] GitHub      [2] Google      (opens your browser)")
+    print("    …or type your email to get a 6-digit code.")
+    entry = _input("  > ").strip()
+
+    # Browser-bridge OAuth (GitHub / Google). Falls back to email on failure.
+    _provider = {"1": "github", "github": "github", "2": "google", "google": "google"}.get(entry.lower())
+    if _provider:
+        _key = _oauth_browser_login(_provider)
+        if _key:
+            return _key
+        print("  Couldn't complete browser sign-in. Let's use email instead.")
+        entry = _input("  📧 Enter your email: ").strip()
 
     # If it's already an API key, return it directly
     if entry.startswith("cm_"):


### PR DESCRIPTION
`clawmetry connect` was email+OTP only. This adds **GitHub/Google browser sign-in** to the terminal linking flow.

## How
`_oauth_browser_login(provider)` spins up a one-shot **loopback** server on `127.0.0.1:0`, opens the cloud OAuth flow with `cli_port=<our port>`, and captures the `cm_` key the callback redirects back to loopback (same pattern as `gh`/`gcloud`). Falls back to email OTP on timeout/failure. The key only ever travels over loopback.

The prompt now leads with `[1] GitHub  [2] Google`, or type your email for a code. The `cm_` paste and email-OTP paths are unchanged.

## Verified
- `py_compile` clean.
- Loopback capture unit-tested: a mocked browser hitting `127.0.0.1:<port>/?token=cm_…` is captured and returned; a non-`cm_` token is rejected (returns "" → email fallback).

Pairs with cloud PR (oauth_start/oauth_callback `cli_port` support) which must deploy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)