### PR TITLE
feat(cost): spread derived family-runtime session cost across events (Cost-tab totals)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8756,6 +8756,18 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                         "model": s.model or None,
                     })
                 if rows:
+                    # Per-event USD isn't on disk for family runtimes (the
+                    # adapter derives one accurate cost at the SESSION level).
+                    # Spread that real cost across the session's events in
+                    # proportion to each event's token_count so the event-based
+                    # Cost tab sums to the true session cost instead of $0.
+                    if s.cost_usd is not None:
+                        _tot_tok = sum(r["token_count"] for r in rows)
+                        if _tot_tok > 0:
+                            for r in rows:
+                                r["cost_usd"] = round(s.cost_usd * r["token_count"] / _tot_tok, 8)
+                        else:
+                            rows[-1]["cost_usd"] = s.cost_usd
                     try:
                         store.ingest_many(rows)
                         total_events += len(rows)


### PR DESCRIPTION
Completes the cost gem on the **aggregate Cost tab** for family runtimes. Pro 0.3.1 derives a real per-session cost; the family ingest carries it onto the session row, but per-event rows were `cost_usd=None` → an event-based Cost-tab total still read $0. This distributes the session's derived cost across its events by token share (sums to the true session cost; last-event fallback when no token split). Verified: distribution sums exactly to the session cost; py_compile clean.