### PR TITLE
feat(cost-intel): persist per-session split + reasoning-tax $ / cache-hit % (the foundation)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7842,6 +7842,16 @@ async function loadSessions() {
     if (sessCost && sessCost.cost_usd > 0) {
       html += '<span style="font-size:11px;color:var(--text-success);font-weight:600;">💰 $' + Number(sessCost.cost_usd||0).toFixed(4) + ' total</span>';
     }
+    // Cost-intelligence chips (foundation): reasoning-tax $ + cache-hit %, shown
+    // only for runtimes whose adapter reports the field (others omit it).
+    if (sessCost && sessCost.reasoning_cost_usd != null && Number(sessCost.reasoning_cost_usd) > 0) {
+      html += '<span title="Reasoning tokens billed at the output rate — spend that produces no visible deliverable" style="font-size:11px;color:#a78bfa;font-weight:600;">🧠 $' + Number(sessCost.reasoning_cost_usd).toFixed(4) + ' reasoning</span>';
+    }
+    if (sessCost && sessCost.cache_hit_pct != null) {
+      var _chp = Number(sessCost.cache_hit_pct);
+      var _chc = _chp >= 70 ? '#22c55e' : (_chp >= 40 ? '#f59e0b' : '#ef4444');
+      html += '<span title="Share of input context served from prompt cache (far cheaper). Low = re-sending context at full price every turn." style="font-size:11px;color:' + _chc + ';font-weight:600;">⚡ ' + _chp.toFixed(0) + '% cache</span>';
+    }
     // Issue #1619 Phase 1 — Score pill. Color band matches the overview
     // tile (4+ green, 3-4 yellow, <3 red). Hover shows the judge's reason.
     var evalRow = evalMap[sid];

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8612,6 +8612,47 @@ def _epoch_to_iso(epoch) -> str | None:
         return None
 
 
+def _session_cost_intel(s) -> dict:
+    """Per-session cost-intelligence foundation: the token split + the derived
+    reasoning-tax $ and cache-hit %, computed from the adapter Session.
+
+    The split (input/output/cache/reasoning) is dropped at event ingest (family
+    events carry only a total) and the ``sessions`` table doesn't store it — so
+    this is the single place every adapter's authoritative split is available.
+    We stash it on the session metadata here so the cost-intelligence chip and
+    the context graph can read it. Reasoning bills at the OUTPUT rate (there is
+    no separate reasoning rate). Best-effort: a field is OMITTED (honest
+    "unknown") when its source data is absent. Never raises.
+    """
+    out: dict = {}
+    try:
+        in_t = int(getattr(s, "input_tokens", 0) or 0)
+        out_t = int(getattr(s, "output_tokens", 0) or 0)
+        cr = int(getattr(s, "cache_read_tokens", 0) or 0)
+        cw = int(getattr(s, "cache_write_tokens", 0) or 0)
+        rt = int(getattr(s, "reasoning_tokens", 0) or 0)
+        model = getattr(s, "model", "") or ""
+        out["tokenSplit"] = {
+            "input": in_t, "output": out_t,
+            "cacheRead": cr, "cacheWrite": cw, "reasoning": rt,
+        }
+        # Cache-hit %: share of read context served from cache (cheaper).
+        if (in_t + cr) > 0:
+            out["cacheHitPct"] = round(cr / (in_t + cr) * 100, 1)
+        # Reasoning-tax $: reasoning tokens priced at the model's output rate.
+        if model and rt > 0:
+            try:
+                from clawmetry.providers_pricing import estimate_event_cost_usd
+                _rc = estimate_event_cost_usd(model, output_tokens=rt)
+                if _rc is not None:
+                    out["reasoningCostUsd"] = round(float(_rc), 6)
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return out
+
+
 def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
     """Ingest PicoClaw + NanoClaw sessions into DuckDB (and the cloud) so they
     appear in the sessions list + transcripts the same way OpenClaw does.
@@ -8682,6 +8723,11 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     metadata.update(
                         {k: v for k, v in s.extra.items() if k not in metadata}
                     )
+                # Cost-intelligence foundation: stash the per-session token split
+                # + derived reasoning-tax $ / cache-hit % onto the metadata (the
+                # only place the adapter's authoritative split survives).
+                _intel = _session_cost_intel(s)
+                metadata.update(_intel)
                 # Local upsert (the sessions list reads this).
                 try:
                     store.ingest_session({
@@ -8718,6 +8764,11 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     "message_count": int(s.message_count or 0),
                     "runtime": runtime,
                     "model": s.model or "",
+                    # Cost-intelligence (foundation): carried to the cloud so the
+                    # chip renders from the snapshot, not just the local store.
+                    "reasoning_cost_usd": _intel.get("reasoningCostUsd"),
+                    "cache_hit_pct": _intel.get("cacheHitPct"),
+                    "token_split": _intel.get("tokenSplit"),
                 })
                 # Events → transcript (rides the existing _build_transcripts path).
                 rows = []

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2846,6 +2846,28 @@ def _try_local_store_cost_breakdown():
             "day": day,
             "start_ts": start_ts,
         })
+    # Merge per-session cost-intelligence (reasoning-tax $, cache-hit %) that the
+    # daemon stashed on the sessions-table metadata. query_sessions (above)
+    # aggregates events and can't see the per-session token split, so we read it
+    # from the sessions table here and graft it onto the matching rows.
+    try:
+        meta_rows = _ls_call("query_sessions_table", limit=1000) or []
+        intel = {}
+        for mr in meta_rows:
+            md = mr.get("metadata") or {}
+            if isinstance(md, dict) and (md.get("reasoningCostUsd") is not None or md.get("cacheHitPct") is not None):
+                intel[mr.get("session_id") or ""] = md
+        if intel:
+            for row in result:
+                md = intel.get(row["session_id"])
+                if not md:
+                    continue
+                if md.get("reasoningCostUsd") is not None:
+                    row["reasoning_cost_usd"] = md["reasoningCostUsd"]
+                if md.get("cacheHitPct") is not None:
+                    row["cache_hit_pct"] = md["cacheHitPct"]
+    except Exception:
+        pass
     result.sort(key=lambda x: x["cost_usd"], reverse=True)
     top10 = result[:10]
     total_cost = sum(r["cost_usd"] for r in result)

--- a/tests/test_session_cost_intel.py
+++ b/tests/test_session_cost_intel.py
@@ -1,0 +1,59 @@
+"""Unit tests for the cost-intelligence foundation (_session_cost_intel).
+
+Verifies the per-session token split + derived reasoning-tax $ and cache-hit %
+that the family ingest stashes on the session metadata.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from clawmetry.sync import _session_cost_intel
+
+
+class _FakeSession:
+    def __init__(self, **k):
+        self.input_tokens = k.get("input", 0)
+        self.output_tokens = k.get("output", 0)
+        self.cache_read_tokens = k.get("cache_read", 0)
+        self.cache_write_tokens = k.get("cache_write", 0)
+        self.reasoning_tokens = k.get("reasoning", 0)
+        self.model = k.get("model", "")
+
+
+def test_cloud_model_reasoning_and_cache():
+    intel = _session_cost_intel(
+        _FakeSession(input=100000, output=20000, cache_read=80000, reasoning=5000, model="gpt-5.4")
+    )
+    assert intel["tokenSplit"]["reasoning"] == 5000
+    assert intel["reasoningCostUsd"] > 0  # reasoning billed at the output rate
+    assert intel["cacheHitPct"] == round(80000 / 180000 * 100, 1)
+
+
+def test_local_model_reasoning_is_real_zero():
+    intel = _session_cost_intel(
+        _FakeSession(input=1000, output=500, reasoning=200, model="qwen3:8b")
+    )
+    # Local model: reasoning is real $0.00 (not "unknown").
+    assert intel["reasoningCostUsd"] == 0.0
+
+
+def test_no_model_omits_reasoning_keeps_cache():
+    intel = _session_cost_intel(_FakeSession(input=1000, cache_read=1000))
+    assert "reasoningCostUsd" not in intel  # honest "unknown" -> omitted
+    assert intel["cacheHitPct"] == 50.0
+
+
+def test_no_tokens_omits_cache():
+    intel = _session_cost_intel(_FakeSession(model="gpt-5.4"))
+    assert "cacheHitPct" not in intel  # nothing to ratio against
+    assert "reasoningCostUsd" not in intel
+    assert intel["tokenSplit"]["input"] == 0
+
+
+def test_never_raises_on_garbage():
+    class Bad:
+        input_tokens = "x"
+        model = None
+    # Must not raise; returns at worst an empty-ish dict.
+    assert isinstance(_session_cost_intel(Bad()), dict)


### PR DESCRIPTION
The foundation the cost-intelligence gems need. The per-session token **split** (input/output/cache/reasoning) was dropped at event ingest and never stored — so reasoning-tax / cache-efficiency / model-mix had no queryable data.

- `_session_cost_intel(s)`: stash the `tokenSplit` + derive **reasoning-tax $** (reasoning billed at the OUTPUT rate via OSS `providers_pricing`) + **cache-hit %** onto the session metadata. Honest — omits a field when absent; real $0.00 for local models.
- Family ingest carries it onto the session metadata **and** the cloud session rows (snapshot).
- `/api/sessions/cost-breakdown` grafts `reasoning_cost_usd` + `cache_hit_pct` onto each row from the sessions-table metadata.
- app.js session chip renders **🧠 $X reasoning** + **⚡ N% cache** (color-coded) next to 💰 total — only for runtimes whose adapter reports the field.

Lights up reasoning for codex/qwen/opencode/hermes(/nemo), cache for those + claude_code. Also the data layer the **context graph** needs. OSS compute; closed adapters provide the paid-runtime data.

Verified: 5 new unit tests (cloud reasoning>0 + cache%; local reasoning=real $0; no-model omits reasoning; never-raises); py_compile + node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)