### PR TITLE
feat(cost-intel): silent model-fallback flag + cache-% chip for OpenClaw/Claude Code

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -6509,9 +6509,13 @@ class LocalStore:
         out: list[dict[str, Any]] = []
         for agg in per_session.values():
             mt = agg.pop("_model_tokens", {})
-            agg["primary_model"] = (
-                max(mt.items(), key=lambda kv: kv[1])[0] if mt else ""
-            )
+            _ranked = sorted(mt.items(), key=lambda kv: kv[1], reverse=True)
+            agg["primary_model"] = _ranked[0][0] if _ranked else ""
+            # Silent model-mix / fallback: a session that ran on >1 model the
+            # user never chose (a downgrade/fallback no CLI flags). Expose the
+            # count + the secondary (fallback) model so the UI can flag it.
+            agg["model_count"] = len([m for m, t in mt.items() if t > 0])
+            agg["secondary_model"] = _ranked[1][0] if len(_ranked) > 1 else ""
             agg["total_tokens"] = (
                 agg["input_tokens"] + agg["output_tokens"]
                 + agg["cache_read_tokens"] + agg["cache_write_tokens"]

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7852,6 +7852,11 @@ async function loadSessions() {
       var _chc = _chp >= 70 ? '#22c55e' : (_chp >= 40 ? '#f59e0b' : '#ef4444');
       html += '<span title="Share of input context served from prompt cache (far cheaper). Low = re-sending context at full price every turn." style="font-size:11px;color:' + _chc + ';font-weight:600;">⚡ ' + _chp.toFixed(0) + '% cache</span>';
     }
+    if (sessCost && sessCost.model_mix) {
+      var _mmt = 'This session silently ran on more than one model — a fallback/downgrade you did not choose';
+      if (sessCost.primary_model) _mmt += ' (' + escHtml(sessCost.primary_model) + (sessCost.secondary_model ? ' + ' + escHtml(sessCost.secondary_model) : '') + ')';
+      html += '<span title="' + _mmt + '" style="font-size:11px;color:#f59e0b;font-weight:600;">🔀 model fallback</span>';
+    }
     // Issue #1619 Phase 1 — Score pill. Color band matches the overview
     // tile (4+ green, 3-4 yellow, <3 red). Hover shows the judge's reason.
     var evalRow = evalMap[sid];

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2868,6 +2868,24 @@ def _try_local_store_cost_breakdown():
                     row["cache_hit_pct"] = md["cacheHitPct"]
     except Exception:
         pass
+    # Cache-hit % (for the event-usage runtimes: OpenClaw / Claude Code) + the
+    # silent model-mix flag, from the existing per-session cost-split aggregator.
+    # Family runtimes get cache % from the metadata above; this covers the rest
+    # and adds the >1-model fallback flag for any session.
+    try:
+        by_id = {r["session_id"]: r for r in result}
+        for sr in (_ls_call("query_cost_split", limit=1000) or []):
+            row = by_id.get(sr.get("session_id") or "")
+            if not row:
+                continue
+            if row.get("cache_hit_pct") is None and sr.get("cache_hit_ratio_pct") is not None:
+                row["cache_hit_pct"] = sr["cache_hit_ratio_pct"]
+            if int(sr.get("model_count") or 0) > 1:
+                row["model_mix"] = True
+                row["primary_model"] = sr.get("primary_model") or ""
+                row["secondary_model"] = sr.get("secondary_model") or ""
+    except Exception:
+        pass
     result.sort(key=lambda x: x["cost_usd"], reverse=True)
     top10 = result[:10]
     total_cost = sum(r["cost_usd"] for r in result)

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -523,6 +523,12 @@ def test_query_cost_split_aggregates_per_session(store):
     assert aggregated["total_cost_usd"] == pytest.approx(0.063, abs=1e-6)
     # Cache hit ratio = cache_read / (input + cache_read) = 4000 / 6000 = 66.7%
     assert aggregated["cache_hit_ratio_pct"] == pytest.approx(66.7, abs=0.1)
+    # Model-mix fields (silent-fallback flag): a count of distinct billed models
+    # + the secondary model. When >1 model, secondary is real and != primary.
+    assert aggregated["model_count"] >= 1
+    assert isinstance(aggregated["secondary_model"], str)
+    if aggregated["model_count"] > 1:
+        assert aggregated["secondary_model"] and aggregated["secondary_model"] != aggregated["primary_model"]
     # Single-session lookup ignores aggregations from other sessions.
     only = store.query_cost_split(session_id="sess-cs")
     assert len(only) == 1


### PR DESCRIPTION
Builds on the cost-intel foundation:
- `query_cost_split` now returns **model_count + secondary_model** per session (it already bucketed `_model_tokens`). >1 model = a silent fallback/downgrade no CLI flags.
- `/api/sessions/cost-breakdown` grafts **cache_hit_pct** from query_cost_split for the event-usage runtimes (OpenClaw / Claude Code; family runtimes already get it from the metadata foundation) and sets **model_mix** (+ primary/secondary model) when model_count>1.
- The session chip renders **🔀 model fallback** (amber) next to 💰/🧠/⚡, models in the tooltip.

Verified: extended `test_local_store` cost_split test (model_count + secondary), py_compile + node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)