### PR TITLE
feat(cost-intel): per-session tool failure-rate chip

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7857,6 +7857,11 @@ async function loadSessions() {
       if (sessCost.primary_model) _mmt += ' (' + escHtml(sessCost.primary_model) + (sessCost.secondary_model ? ' + ' + escHtml(sessCost.secondary_model) : '') + ')';
       html += '<span title="' + _mmt + '" style="font-size:11px;color:#f59e0b;font-weight:600;">🔀 model fallback</span>';
     }
+    if (sessCost && sessCost.tool_error_pct != null && Number(sessCost.tool_error_pct) > 0) {
+      var _tep = Number(sessCost.tool_error_pct);
+      var _tec = _tep >= 30 ? '#ef4444' : '#f59e0b';
+      html += '<span title="Share of this session\'s tool calls that came back a real (non-benign) error — a failing tool you only ever see as the agent \'thinking\'." style="font-size:11px;color:' + _tec + ';font-weight:600;">⚠ ' + _tep.toFixed(0) + '% tools failing</span>';
+    }
     // Issue #1619 Phase 1 — Score pill. Color band matches the overview
     // tile (4+ green, 3-4 yellow, <3 red). Hover shows the judge's reason.
     var evalRow = evalMap[sid];

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8653,6 +8653,51 @@ def _session_cost_intel(s) -> dict:
     return out
 
 
+def _session_tool_health(events) -> dict:
+    """Per-session tool failure-rate from the adapter events: how many tool
+    results came back as a REAL (non-benign) error. A tool that keeps failing
+    (e.g. "browser fails 40%") is invisible to the user, who just sees the agent
+    "thinking". Benign read-guards / transient gateway timeouts are filtered out
+    (mirrors the transcript-ingest benign filter) so the rate is actionable, not
+    alarmist. Returns {} when there are no tool results. Never raises.
+    """
+    try:
+        from clawmetry import error_signal as _es
+    except Exception:
+        _es = None
+    results = 0
+    errors = 0
+    try:
+        for e in events:
+            et = (getattr(e, "type", "") or "").lower()
+            if "result" not in et and not getattr(e, "tool_name", ""):
+                continue
+            results += 1
+            extra = getattr(e, "extra", None)
+            extra = extra if isinstance(extra, dict) else {}
+            if not (extra.get("isError") or extra.get("is_error")):
+                continue
+            if _es is not None:
+                try:
+                    txt = _es.extract_tool_result_text(
+                        {"content": getattr(e, "content", ""), "extra": extra}
+                    ) or (getattr(e, "content", "") or "")
+                except Exception:
+                    txt = getattr(e, "content", "") or ""
+                if _es.is_benign_tool_error(txt):
+                    continue
+            errors += 1
+    except Exception:
+        return {}
+    if results <= 0:
+        return {}
+    return {
+        "toolResults": results,
+        "toolErrors": errors,
+        "toolErrorPct": round(errors / results * 100, 1),
+    }
+
+
 def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
     """Ingest PicoClaw + NanoClaw sessions into DuckDB (and the cloud) so they
     appear in the sessions list + transcripts the same way OpenClaw does.
@@ -8728,6 +8773,11 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 # only place the adapter's authoritative split survives).
                 _intel = _session_cost_intel(s)
                 metadata.update(_intel)
+                # Pre-fetch the events once (the transcript loop below reuses
+                # them) so we can also derive the per-session tool failure-rate.
+                _events = list(adapter.list_events(s.id, limit=2000))
+                _thealth = _session_tool_health(_events)
+                metadata.update(_thealth)
                 # Local upsert (the sessions list reads this).
                 try:
                     store.ingest_session({
@@ -8769,10 +8819,11 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     "reasoning_cost_usd": _intel.get("reasoningCostUsd"),
                     "cache_hit_pct": _intel.get("cacheHitPct"),
                     "token_split": _intel.get("tokenSplit"),
+                    "tool_error_pct": _thealth.get("toolErrorPct"),
                 })
                 # Events → transcript (rides the existing _build_transcripts path).
                 rows = []
-                for e in adapter.list_events(s.id, limit=2000):
+                for e in _events:
                     ets = _epoch_to_iso(e.ts)
                     if not ets:
                         continue

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2855,7 +2855,7 @@ def _try_local_store_cost_breakdown():
         intel = {}
         for mr in meta_rows:
             md = mr.get("metadata") or {}
-            if isinstance(md, dict) and (md.get("reasoningCostUsd") is not None or md.get("cacheHitPct") is not None):
+            if isinstance(md, dict) and (md.get("reasoningCostUsd") is not None or md.get("cacheHitPct") is not None or md.get("toolErrorPct") is not None):
                 intel[mr.get("session_id") or ""] = md
         if intel:
             for row in result:
@@ -2866,6 +2866,8 @@ def _try_local_store_cost_breakdown():
                     row["reasoning_cost_usd"] = md["reasoningCostUsd"]
                 if md.get("cacheHitPct") is not None:
                     row["cache_hit_pct"] = md["cacheHitPct"]
+                if md.get("toolErrorPct") is not None:
+                    row["tool_error_pct"] = md["toolErrorPct"]
     except Exception:
         pass
     # Cache-hit % (for the event-usage runtimes: OpenClaw / Claude Code) + the

--- a/tests/test_session_cost_intel.py
+++ b/tests/test_session_cost_intel.py
@@ -57,3 +57,37 @@ def test_never_raises_on_garbage():
         model = None
     # Must not raise; returns at worst an empty-ish dict.
     assert isinstance(_session_cost_intel(Bad()), dict)
+
+
+from clawmetry.sync import _session_tool_health
+
+
+class _FakeEvent:
+    def __init__(self, type="", tool_name="", content="", extra=None):
+        self.type = type
+        self.tool_name = tool_name
+        self.content = content
+        self.extra = extra or {}
+
+
+def test_tool_health_counts_real_errors():
+    evs = [
+        _FakeEvent(type="tool.result", tool_name="browser", extra={"isError": True}, content="Connection refused: fatal"),
+        _FakeEvent(type="tool.result", tool_name="browser"),
+        _FakeEvent(type="tool.result", tool_name="bash"),
+        _FakeEvent(type="message", content="hi"),  # not a tool result -> ignored
+    ]
+    h = _session_tool_health(evs)
+    assert h["toolResults"] == 3
+    assert h["toolErrors"] >= 1
+    assert 0 < h["toolErrorPct"] <= 100
+
+
+def test_tool_health_empty_when_no_tools():
+    assert _session_tool_health([_FakeEvent(type="message")]) == {}
+
+
+def test_tool_health_clean_session_zero_errors():
+    evs = [_FakeEvent(type="tool.result", tool_name="read"), _FakeEvent(type="tool.result", tool_name="bash")]
+    h = _session_tool_health(evs)
+    assert h["toolResults"] == 2 and h["toolErrors"] == 0 and h["toolErrorPct"] == 0.0


### PR DESCRIPTION
A tool that keeps failing (browser 40%, a flaky MCP) is invisible — the user just sees 'thinking'. `_session_tool_health(events)` counts tool-result events + the share that came back a **real (non-benign)** error (reuses `error_signal`'s benign filter so it's actionable, not alarmist). The family ingest fetches events **once** (the transcript loop reuses them), stashes `toolErrorPct` onto the session metadata + cloud rows; `/api/sessions/cost-breakdown` surfaces it; the chip renders **⚠ N% tools failing** (amber, red ≥30%) next to 💰/🧠/⚡/🔀.

Verified: 3 new unit tests; py_compile + node --check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)