### PR TITLE
feat(cost-intel): per-session compaction-count chip (♻ context thrash)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7862,6 +7862,10 @@ async function loadSessions() {
       var _tec = _tep >= 30 ? '#ef4444' : '#f59e0b';
       html += '<span title="Share of this session\'s tool calls that came back a real (non-benign) error — a failing tool you only ever see as the agent \'thinking\'." style="font-size:11px;color:' + _tec + ';font-weight:600;">⚠ ' + _tep.toFixed(0) + '% tools failing</span>';
     }
+    if (sessCost && sessCost.compaction_count != null && Number(sessCost.compaction_count) > 0) {
+      var _cc = Number(sessCost.compaction_count);
+      html += '<span title="Times this session auto-compacted — each one silently re-summarises (and re-bills) the context window. Frequent compaction = context thrash / wasted tokens." style="font-size:11px;color:#f59e0b;font-weight:600;">♻ compacted ' + _cc + '×</span>';
+    }
     // Issue #1619 Phase 1 — Score pill. Color band matches the overview
     // tile (4+ green, 3-4 yellow, <3 red). Hover shows the judge's reason.
     var evalRow = evalMap[sid];

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8778,6 +8778,15 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 _events = list(adapter.list_events(s.id, limit=2000))
                 _thealth = _session_tool_health(_events)
                 metadata.update(_thealth)
+                # Compaction count: each auto-compaction silently re-summarises
+                # (and re-bills) the context. A session that compacted N times
+                # is thrashing its context window — a glanceable waste signal.
+                _compactions = sum(
+                    1 for e in _events
+                    if "compact" in ((getattr(e, "type", "") or "").lower())
+                )
+                if _compactions:
+                    metadata["compactionCount"] = _compactions
                 # Local upsert (the sessions list reads this).
                 try:
                     store.ingest_session({
@@ -8820,6 +8829,7 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     "cache_hit_pct": _intel.get("cacheHitPct"),
                     "token_split": _intel.get("tokenSplit"),
                     "tool_error_pct": _thealth.get("toolErrorPct"),
+                    "compaction_count": _compactions or None,
                 })
                 # Events → transcript (rides the existing _build_transcripts path).
                 rows = []

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2855,7 +2855,7 @@ def _try_local_store_cost_breakdown():
         intel = {}
         for mr in meta_rows:
             md = mr.get("metadata") or {}
-            if isinstance(md, dict) and (md.get("reasoningCostUsd") is not None or md.get("cacheHitPct") is not None or md.get("toolErrorPct") is not None):
+            if isinstance(md, dict) and any(md.get(k) is not None for k in ("reasoningCostUsd", "cacheHitPct", "toolErrorPct", "compactionCount")):
                 intel[mr.get("session_id") or ""] = md
         if intel:
             for row in result:
@@ -2868,6 +2868,8 @@ def _try_local_store_cost_breakdown():
                     row["cache_hit_pct"] = md["cacheHitPct"]
                 if md.get("toolErrorPct") is not None:
                     row["tool_error_pct"] = md["toolErrorPct"]
+                if md.get("compactionCount") is not None:
+                    row["compaction_count"] = md["compactionCount"]
     except Exception:
         pass
     # Cache-hit % (for the event-usage runtimes: OpenClaw / Claude Code) + the


### PR DESCRIPTION
Each auto-compaction silently re-summarises (and re-bills) the context. Counts compaction events from the events already fetched once per family session, stashes `compactionCount` onto the metadata + cloud rows; `/api/sessions/cost-breakdown` surfaces it; the chip renders **♻ compacted N×** next to 💰/🧠/⚡/🔀/⚠. Completes the per-session cost-intel chip cluster. py_compile + node --check clean.