### PR TITLE
feat(context-graph): session decision-lineage traversal — the first graph view

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5199,6 +5199,58 @@ class LocalStore:
                 "data", "created_at"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
 
+    def query_session_lineage(self, session_id: str, *, max_depth: int = 25) -> list[dict[str, Any]]:
+        """Context-graph traversal — the decision-lineage tree rooted at a session.
+
+        Walks the parent->subagent edges (``subagents.parent_session_id`` ->
+        ``subagent_id``) with a DuckDB ``WITH RECURSIVE`` CTE and returns every
+        node in the fan-out with its own cost/outcome, so one ask's full
+        delegation tree + the cost it incurred downstream is a single
+        round-trip. This is the first materialized projection of the context
+        graph (no new tables — edges are JOINs over existing rows). Read-only,
+        best-effort -> []. The ``max_depth`` guard makes cyclic data safe.
+        """
+        if not session_id:
+            return []
+        sql = """
+        WITH RECURSIVE tree(node_id, parent_id, depth) AS (
+            SELECT CAST(? AS VARCHAR), CAST(NULL AS VARCHAR), 0
+          UNION ALL
+            SELECT s.subagent_id, s.parent_session_id, t.depth + 1
+            FROM subagents s
+            JOIN tree t ON s.parent_session_id = t.node_id
+            WHERE t.depth < ?
+        )
+        SELECT t.node_id, t.parent_id, t.depth,
+               sub.task, sub.status, sub.cost_usd, sub.token_count,
+               ses.cost_usd, ses.outcome, ses.agent_type, ses.total_tokens
+        FROM tree t
+        LEFT JOIN subagents sub ON sub.subagent_id = t.node_id
+        LEFT JOIN sessions ses ON ses.session_id = t.node_id
+        ORDER BY t.depth, t.node_id
+        """
+        try:
+            rows = self._fetch(sql, [str(session_id), int(max_depth)])
+        except Exception:
+            return []
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            node_id, parent_id, depth, task, status, sub_cost, sub_tok, ses_cost, outcome, agent_type, ses_tok = r
+            cost = ses_cost if ses_cost is not None else (sub_cost or 0.0)
+            tok = ses_tok if ses_tok is not None else (sub_tok or 0)
+            out.append({
+                "session_id": node_id,
+                "parent_id": parent_id,
+                "depth": int(depth or 0),
+                "task": task or "",
+                "status": status or "",
+                "cost_usd": round(float(cost or 0.0), 6),
+                "token_count": int(tok or 0),
+                "outcome": outcome or "",
+                "runtime": agent_type or "",
+            })
+        return out
+
     def query_subagents(
         self,
         *,

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -477,6 +477,8 @@ _DAEMON_METHODS = frozenset({
     # ``routes/crons.py:_cron_runs_from_duckdb`` via the daemon proxy.
     "query_cron_runs",
     "query_subagents",
+    # Context graph: decision-lineage tree (recursive subagent fan-out) for a session.
+    "query_session_lineage",
     # OpenClaw run ledger (tasks/runs.sqlite mirror): sub-agents + crons +
     # CLI turns with status/timing/parent-child. Powers the Scheduler lane
     # monitor + sub-agent fan-out tree + cron run log off one source.

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2596,6 +2596,30 @@ def _try_local_store_delegation_tree():
     }
 
 
+@bp_sessions.route("/api/session-lineage/<path:session_id>")
+def api_session_lineage(session_id):
+    """Context graph — first view: the decision-lineage tree rooted at a session.
+
+    The full subagent fan-out of one ask + the cost each branch incurred,
+    traversed recursively over the existing subagent edges (no new tables). The
+    seed of the temporal decision graph that unifies Brain/Tracing/Subagents.
+    """
+    try:
+        nodes = _ls_call("query_session_lineage", session_id=session_id) or []
+    except Exception:
+        nodes = []
+    root_cost = next((n.get("cost_usd", 0.0) for n in nodes if n.get("depth") == 0), 0.0)
+    downstream = round(sum(n.get("cost_usd", 0.0) for n in nodes if (n.get("depth") or 0) > 0), 6)
+    return jsonify({
+        "session_id": session_id,
+        "nodes": nodes,
+        "node_count": len(nodes),
+        "root_cost_usd": round(float(root_cost or 0.0), 6),
+        "downstream_cost_usd": downstream,
+        "total_cost_usd": round(float(root_cost or 0.0) + downstream, 6),
+    })
+
+
 @bp_sessions.route("/api/delegation-tree")
 def api_delegation_tree():
     """Agent delegation chains -- inspired by AgentWeave provenance tracing.

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -757,3 +757,31 @@ def test_query_channel_summary_groups_across_providers(store):
     sl = by_prov["slack"]
     assert sl["msg_in"] == 1
     assert sl["distinct_channels"] == 1
+
+
+def test_query_session_lineage_recursive_tree(store):
+    """Context-graph first view: the recursive CTE walks the parent->subagent
+    tree and returns every node with depth + cost (downstream cost rollup)."""
+    store.ingest_session({
+        "agent_type": "openclaw", "session_id": "lin-root", "node_id": "n",
+        "cost_usd": 0.10, "total_tokens": 1000, "outcome": "success",
+    })
+    store.ingest_subagent({"subagent_id": "lin-a", "parent_session_id": "lin-root",
+                           "task": "child A", "status": "ended", "cost_usd": 0.20})
+    store.ingest_subagent({"subagent_id": "lin-b", "parent_session_id": "lin-a",
+                           "task": "grandchild B", "status": "ended", "cost_usd": 0.05})
+    nodes = store.query_session_lineage("lin-root")
+    by_id = {n["session_id"]: n for n in nodes}
+    assert set(by_id) == {"lin-root", "lin-a", "lin-b"}
+    assert by_id["lin-root"]["depth"] == 0
+    assert by_id["lin-a"]["depth"] == 1 and by_id["lin-a"]["parent_id"] == "lin-root"
+    assert by_id["lin-b"]["depth"] == 2 and by_id["lin-b"]["parent_id"] == "lin-a"
+    downstream = sum(n["cost_usd"] for n in nodes if n["depth"] > 0)
+    assert downstream == pytest.approx(0.25, abs=1e-6)
+
+
+def test_query_session_lineage_root_only_and_empty(store):
+    assert store.query_session_lineage("") == []
+    # An unknown root still returns itself (depth 0), just with empty attrs.
+    only = store.query_session_lineage("nope")
+    assert len(only) == 1 and only[0]["session_id"] == "nope" and only[0]["depth"] == 0


### PR DESCRIPTION
The first materialized projection of the **context graph** (your direction). `query_session_lineage(session_id)` walks the `parent->subagent` edges with a DuckDB `WITH RECURSIVE` CTE and returns every node in the fan-out with depth + cost + outcome — one ask's full delegation tree and the cost each branch incurred downstream, one round-trip. **No new tables** — edges are JOINs over existing rows (the grounding's key finding: the graph is materialized on read). Exposed at `GET /api/session-lineage/<id>` with a root/downstream/total cost rollup; added to the daemon allowlist.

This is the seed that unifies Brain/Tracing/Subagents into one queryable graph; richer decision-insight views (memory-as-of-turn, approval/guardrail lineage, the Pro analysis + viz) build on this traversal. The cost-intel cluster shipped this run is exactly the per-session node signal it carries.

Verified: 2 new unit tests (recursive tree depth + downstream cost rollup; root-only/empty) — these exercise the real DuckDB recursive CTE. py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)