### PR TITLE
feat(context-graph): unified per-session decision insight (true cost + waste flags)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2596,6 +2596,66 @@ def _try_local_store_delegation_tree():
     }
 
 
+def _derive_session_insight(sess: dict, lineage: list) -> dict:
+    """Unify the per-session cost-intel + the lineage fan-out into ONE decision
+    insight: the TRUE cost of an ask (its own spend + everything its sub-agents
+    spent) plus the waste flags that fired. The context graph's per-session
+    answer — no single flat tab gives it. Pure function (so it's testable).
+    """
+    sess = sess or {}
+    lineage = lineage or []
+    cost = float(sess.get("cost_usd") or 0.0)
+    children = [n for n in lineage if (n.get("depth") or 0) > 0]
+    downstream = round(sum(float(n.get("cost_usd") or 0.0) for n in children), 6)
+    flags: list[str] = []
+    rc = sess.get("reasoning_cost_usd")
+    if rc and cost and (rc / cost) > 0.25:
+        flags.append("reasoning_heavy")
+    chp = sess.get("cache_hit_pct")
+    if chp is not None and chp < 40:
+        flags.append("cache_poor")
+    if (sess.get("tool_error_pct") or 0) >= 20:
+        flags.append("tools_failing")
+    if (sess.get("compaction_count") or 0) >= 2:
+        flags.append("compaction_thrash")
+    if sess.get("model_mix"):
+        flags.append("model_fallback")
+    if children:
+        flags.append("fanned_out")
+    return {
+        "cost_usd": round(cost, 6),
+        "reasoning_cost_usd": sess.get("reasoning_cost_usd"),
+        "cache_hit_pct": sess.get("cache_hit_pct"),
+        "tool_error_pct": sess.get("tool_error_pct"),
+        "compaction_count": sess.get("compaction_count"),
+        "model_mix": bool(sess.get("model_mix")),
+        "subagent_count": len(children),
+        "downstream_cost_usd": downstream,
+        "true_cost_usd": round(cost + downstream, 6),
+        "waste_flags": flags,
+    }
+
+
+@bp_sessions.route("/api/session-insight/<path:session_id>")
+def api_session_insight(session_id):
+    """Context graph — the unified per-session decision insight: true cost
+    (own + sub-agent fan-out) + the waste flags that fired, joining the
+    cost-intel cluster with the lineage traversal in one answer.
+    """
+    try:
+        cb = _try_local_store_cost_breakdown() or {"sessions": []}
+        sess = next((s for s in cb.get("sessions", []) if s.get("session_id") == session_id), {})
+    except Exception:
+        sess = {}
+    try:
+        lineage = _ls_call("query_session_lineage", session_id=session_id) or []
+    except Exception:
+        lineage = []
+    out = _derive_session_insight(sess, lineage)
+    out["session_id"] = session_id
+    return jsonify(out)
+
+
 @bp_sessions.route("/api/session-lineage/<path:session_id>")
 def api_session_lineage(session_id):
     """Context graph — first view: the decision-lineage tree rooted at a session.

--- a/tests/test_session_insight.py
+++ b/tests/test_session_insight.py
@@ -1,0 +1,33 @@
+"""Unit tests for the context-graph per-session decision insight helper."""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from routes.sessions import _derive_session_insight
+
+
+def test_true_cost_includes_fanout_and_all_flags():
+    sess = {"cost_usd": 1.00, "reasoning_cost_usd": 0.40, "cache_hit_pct": 11.0,
+            "tool_error_pct": 40.0, "compaction_count": 3, "model_mix": True}
+    lineage = [{"depth": 0, "cost_usd": 1.00}, {"depth": 1, "cost_usd": 0.50}, {"depth": 2, "cost_usd": 0.20}]
+    ins = _derive_session_insight(sess, lineage)
+    assert ins["true_cost_usd"] == 1.70        # own 1.00 + downstream 0.70
+    assert ins["downstream_cost_usd"] == 0.70
+    assert ins["subagent_count"] == 2
+    assert set(ins["waste_flags"]) == {
+        "reasoning_heavy", "cache_poor", "tools_failing",
+        "compaction_thrash", "model_fallback", "fanned_out",
+    }
+
+
+def test_clean_session_has_no_flags():
+    ins = _derive_session_insight(
+        {"cost_usd": 0.10, "cache_hit_pct": 85.0, "tool_error_pct": 0, "compaction_count": 0},
+        [{"depth": 0, "cost_usd": 0.10}],
+    )
+    assert ins["waste_flags"] == []
+    assert ins["true_cost_usd"] == 0.10
+    assert ins["subagent_count"] == 0
+
+
+def test_empty_is_safe():
+    ins = _derive_session_insight({}, [])
+    assert ins["true_cost_usd"] == 0.0 and ins["waste_flags"] == []


### PR DESCRIPTION
The second context-graph projection. Joins the cost-intel cluster with the lineage traversal into one answer no flat tab gives: the **true cost** of an ask (own spend + sub-agent fan-out) + the **waste flags** that fired. `_derive_session_insight()` is a pure, unit-tested helper; `GET /api/session-insight/<id>` wires it over cost-breakdown + query_session_lineage. 3 new tests (all-flags + true-cost-incl-fanout; clean=none; empty-safe). py_compile clean.