### PR TITLE
feat(context-graph): true-cost fan-out chip (↳ +$X · N agents)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5199,6 +5199,32 @@ class LocalStore:
                 "data", "created_at"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
 
+    def query_subagent_cost_rollup(self, *, limit: int = 2000) -> list[dict[str, Any]]:
+        """Per-parent sub-agent cost rollup in ONE pass: for each session that
+        spawned sub-agents, the total $ + count its children spent. Lets the
+        session chip show the TRUE cost of an ask (its own spend + the fan-out
+        it caused) without an N-query recursive walk per row. One level deep —
+        the common, glanceable case. Read-only, best-effort -> [].
+        """
+        sql = """
+            SELECT parent_session_id,
+                   ROUND(SUM(COALESCE(cost_usd, 0)), 6) AS child_cost,
+                   COUNT(*) AS child_count
+            FROM subagents
+            WHERE parent_session_id IS NOT NULL AND parent_session_id != ''
+            GROUP BY parent_session_id
+            ORDER BY child_cost DESC
+            LIMIT ?
+        """
+        try:
+            rows = self._fetch(sql, [int(limit)])
+        except Exception:
+            return []
+        return [
+            {"parent_session_id": p, "child_cost_usd": float(c or 0.0), "child_count": int(n or 0)}
+            for (p, c, n) in rows
+        ]
+
     def query_session_lineage(self, session_id: str, *, max_depth: int = 25) -> list[dict[str, Any]]:
         """Context-graph traversal — the decision-lineage tree rooted at a session.
 

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7866,6 +7866,10 @@ async function loadSessions() {
       var _cc = Number(sessCost.compaction_count);
       html += '<span title="Times this session auto-compacted — each one silently re-summarises (and re-bills) the context window. Frequent compaction = context thrash / wasted tokens." style="font-size:11px;color:#f59e0b;font-weight:600;">♻ compacted ' + _cc + '×</span>';
     }
+    if (sessCost && sessCost.downstream_cost_usd != null && Number(sessCost.downstream_cost_usd) > 0) {
+      var _dc = Number(sessCost.downstream_cost_usd), _sa = Number(sessCost.subagent_count || 0);
+      html += '<span title="The TRUE cost of this ask: it spawned ' + _sa + ' sub-agent(s) that spent this much downstream — billed under their own keys but caused by this session. (Context graph)" style="font-size:11px;color:#60a5fa;font-weight:600;">&#8627; +$' + _dc.toFixed(4) + (_sa ? ' · ' + _sa + ' agents' : '') + '</span>';
+    }
     // Issue #1619 Phase 1 — Score pill. Color band matches the overview
     // tile (4+ green, 3-4 yellow, <3 red). Hover shows the judge's reason.
     var evalRow = evalMap[sid];

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -479,6 +479,8 @@ _DAEMON_METHODS = frozenset({
     "query_subagents",
     # Context graph: decision-lineage tree (recursive subagent fan-out) for a session.
     "query_session_lineage",
+    # Context graph: per-parent sub-agent cost rollup (true-cost-of-an-ask chip).
+    "query_subagent_cost_rollup",
     # OpenClaw run ledger (tasks/runs.sqlite mirror): sub-agents + crons +
     # CLI turns with status/timing/parent-child. Powers the Scheduler lane
     # monitor + sub-agent fan-out tree + cron run log off one source.

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2974,6 +2974,17 @@ def _try_local_store_cost_breakdown():
                 row["secondary_model"] = sr.get("secondary_model") or ""
     except Exception:
         pass
+    # Sub-agent fan-out cost — the TRUE cost of an ask = its own cost + what its
+    # children spent (one GROUP BY, not an N-query recursive walk). Context graph.
+    try:
+        roll = {r["parent_session_id"]: r for r in (_ls_call("query_subagent_cost_rollup", limit=2000) or [])}
+        for row in result:
+            rr = roll.get(row["session_id"])
+            if rr and rr.get("child_cost_usd", 0) > 0:
+                row["downstream_cost_usd"] = rr["child_cost_usd"]
+                row["subagent_count"] = rr.get("child_count") or 0
+    except Exception:
+        pass
     result.sort(key=lambda x: x["cost_usd"], reverse=True)
     top10 = result[:10]
     total_cost = sum(r["cost_usd"] for r in result)

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -785,3 +785,14 @@ def test_query_session_lineage_root_only_and_empty(store):
     # An unknown root still returns itself (depth 0), just with empty attrs.
     only = store.query_session_lineage("nope")
     assert len(only) == 1 and only[0]["session_id"] == "nope" and only[0]["depth"] == 0
+
+
+def test_query_subagent_cost_rollup(store):
+    """True-cost chip: one GROUP BY rolls up each parent's sub-agent spend."""
+    store.ingest_subagent({"subagent_id": "c1", "parent_session_id": "root-x", "cost_usd": 0.20})
+    store.ingest_subagent({"subagent_id": "c2", "parent_session_id": "root-x", "cost_usd": 0.05})
+    store.ingest_subagent({"subagent_id": "c3", "parent_session_id": "root-y", "cost_usd": 0.10})
+    roll = {r["parent_session_id"]: r for r in store.query_subagent_cost_rollup()}
+    assert roll["root-x"]["child_cost_usd"] == pytest.approx(0.25, abs=1e-6)
+    assert roll["root-x"]["child_count"] == 2
+    assert roll["root-y"]["child_count"] == 1


### PR DESCRIPTION
Makes the context graph **visible** in the session list: the **true cost of an ask** = its own spend + what its sub-agents spent (billed under their own keys but caused by it). `query_subagent_cost_rollup()` rolls that up in **one GROUP BY** (not an N-query recursive walk); cost-breakdown grafts `downstream_cost_usd` + `subagent_count` per root; the chip renders **↳ +$X · N agents** (blue) next to the cost-intel chips. 1 new test (GROUP BY rollup); py_compile + node --check clean.