### PR TITLE
feat(context-graph): governance lineage edge (decision->approval/guardrail)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2691,6 +2691,52 @@ def _derive_session_insight(sess: dict, lineage: list) -> dict:
     }
 
 
+def _session_governance(approvals: list, guardrails: list, session_id: str) -> dict:
+    """Context graph — the decision->approval / decision->guardrail edges for one
+    session: which tool calls were gated, and how they were decided. Joins the
+    approval queue (by requestor_session_id) with NeMo guardrail verdicts (by
+    session_id) into the session's governance lineage. Pure (testable).
+    """
+    _DENY = {"deny", "denied", "reject", "rejected", "block", "blocked"}
+    appr = [
+        {"kind": "approval", "action": a.get("action"),
+         "decision": a.get("decision") or a.get("status") or "", "reason": a.get("decision_reason") or "",
+         "status": a.get("status") or ""}
+        for a in (approvals or []) if a.get("requestor_session_id") == session_id
+    ]
+    grd = [
+        {"kind": "guardrail", "action": g.get("action"), "rule": g.get("rule_name"),
+         "verdict": g.get("verdict") or ""}
+        for g in (guardrails or []) if g.get("session_id") == session_id
+    ]
+    denied = sum(1 for a in appr if str(a.get("decision", "")).lower() in _DENY) \
+        + sum(1 for g in grd if str(g.get("verdict", "")).lower() in _DENY)
+    return {
+        "approvals": appr,
+        "guardrails": grd,
+        "decision_count": len(appr) + len(grd),
+        "denied_count": denied,
+    }
+
+
+@bp_sessions.route("/api/session-governance/<path:session_id>")
+def api_session_governance(session_id):
+    """Context graph — a session's governance lineage: its approval decisions +
+    NeMo guardrail verdicts (decision->approval / decision->guardrail edges).
+    """
+    try:
+        approvals = _ls_call("query_approvals", limit=500) or []
+    except Exception:
+        approvals = []
+    try:
+        guardrails = _ls_call("query_guardrail_events", limit=500) or []
+    except Exception:
+        guardrails = []
+    out = _session_governance(approvals, guardrails, session_id)
+    out["session_id"] = session_id
+    return jsonify(out)
+
+
 @bp_sessions.route("/api/session-insight/<path:session_id>")
 def api_session_insight(session_id):
     """Context graph — the unified per-session decision insight: true cost

--- a/tests/test_session_insight.py
+++ b/tests/test_session_insight.py
@@ -56,3 +56,27 @@ def test_waste_summary_aggregates_recoverable_spend():
 def test_waste_summary_empty_is_safe():
     w = _derive_waste_summary([])
     assert w["total_cost_usd"] == 0.0 and w["flagged_session_count"] == 0
+
+
+from routes.sessions import _session_governance
+
+
+def test_session_governance_joins_approvals_and_guardrails():
+    approvals = [
+        {"requestor_session_id": "s1", "action": "bash", "decision": "approve", "status": "resolved"},
+        {"requestor_session_id": "s1", "action": "write", "decision": "deny", "decision_reason": "outside scope", "status": "resolved"},
+        {"requestor_session_id": "s2", "action": "bash", "decision": "approve"},
+    ]
+    guardrails = [
+        {"session_id": "s1", "action": "curl", "rule_name": "egress", "verdict": "block"},
+        {"session_id": "s1", "action": "read", "rule_name": "fs", "verdict": "allow"},
+        {"session_id": "s2", "action": "x", "verdict": "allow"},
+    ]
+    g = _session_governance(approvals, guardrails, "s1")
+    assert len(g["approvals"]) == 2 and len(g["guardrails"]) == 2
+    assert g["decision_count"] == 4
+    assert g["denied_count"] == 2          # 1 deny + 1 block
+
+
+def test_session_governance_empty_is_safe():
+    assert _session_governance([], [], "x")["decision_count"] == 0


### PR DESCRIPTION
The next context-graph edge. `_session_governance()` joins the approval queue (by `requestor_session_id`) with NeMo guardrail verdicts (by `session_id`) into a session's governance lineage — which tool calls were gated and how they were decided, with a denied-count. Pure unit-tested helper; `GET /api/session-governance/<id>` wires it over the existing `query_approvals` + `query_guardrail_events`. 2 new tests; py_compile clean.