### PR TITLE
feat(context-graph): governance chip (🛡 N gated · M denied) per session

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7904,6 +7904,11 @@ async function loadSessions() {
       var _dc = Number(sessCost.downstream_cost_usd), _sa = Number(sessCost.subagent_count || 0);
       html += '<span title="The TRUE cost of this ask: it spawned ' + _sa + ' sub-agent(s) that spent this much downstream — billed under their own keys but caused by this session. (Context graph)" style="font-size:11px;color:#60a5fa;font-weight:600;">&#8627; +$' + _dc.toFixed(4) + (_sa ? ' · ' + _sa + ' agents' : '') + '</span>';
     }
+    if (sessCost && Number(sessCost.governance_count) > 0) {
+      var _gn = Number(sessCost.governance_count), _gd = Number(sessCost.governance_denied || 0);
+      var _gc = _gd > 0 ? '#ef4444' : '#22c55e';
+      html += '<span title="Tool calls this session put through governance (NeMo guardrails + the approval queue): ' + _gn + ' gated, ' + _gd + ' denied/blocked. (Context graph)" style="font-size:11px;color:' + _gc + ';font-weight:600;">&#128737; ' + _gn + ' gated' + (_gd ? ' · ' + _gd + ' denied' : '') + '</span>';
+    }
     // Issue #1619 Phase 1 — Score pill. Color band matches the overview
     // tile (4+ green, 3-4 yellow, <3 red). Hover shows the judge's reason.
     var evalRow = evalMap[sid];

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -3086,6 +3086,32 @@ def _try_local_store_cost_breakdown():
                 row["subagent_count"] = rr.get("child_count") or 0
     except Exception:
         pass
+    # Governance lineage counts per session — tool calls gated by the approval
+    # queue + NeMo guardrails, and how many were denied/blocked. Context graph.
+    try:
+        _DENY = {"deny", "denied", "reject", "rejected", "block", "blocked"}
+        gov: dict = {}
+        for a in (_ls_call("query_approvals", limit=1000) or []):
+            sid = a.get("requestor_session_id")
+            if not sid:
+                continue
+            d = gov.setdefault(sid, {"n": 0, "deny": 0}); d["n"] += 1
+            if str(a.get("decision", "")).lower() in _DENY:
+                d["deny"] += 1
+        for g in (_ls_call("query_guardrail_events", limit=1000) or []):
+            sid = g.get("session_id")
+            if not sid:
+                continue
+            d = gov.setdefault(sid, {"n": 0, "deny": 0}); d["n"] += 1
+            if str(g.get("verdict", "")).lower() in _DENY:
+                d["deny"] += 1
+        for row in result:
+            gv = gov.get(row["session_id"])
+            if gv and gv["n"] > 0:
+                row["governance_count"] = gv["n"]
+                row["governance_denied"] = gv["deny"]
+    except Exception:
+        pass
     result.sort(key=lambda x: x["cost_usd"], reverse=True)
     top10 = result[:10]
     total_cost = sum(r["cost_usd"] for r in result)


### PR DESCRIPTION
Makes the governance edge **visible**: cost-breakdown aggregates the approval queue + NeMo guardrail verdicts per session (one pass each); the chip renders **🛡 N gated · M denied** (green / red if anything denied) next to the cost-intel + fan-out chips. The context graph's policy lineage, glanceable. py_compile + node --check clean.