### PR TITLE
[RELEASE] actionable recommendations on the decision insight (carries #2483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Release: actionable recommendations on the decision insight (carries #2483) (2026-06-02)
+- **What:** /api/session-insight now turns each waste flag into advice — what to DO, not just what happened (reasoning-heavy -> lower effort/cheaper model; cache-poor -> warm the cache; tools-failing -> fix the tool; compaction -> smaller context; model-fallback -> pin the model; fanned-out -> true cost incl children; policy-denied -> review). Returns a `recommendations` list; a guard test asserts every flag the insight can emit has advice.
+- **Verified:** py_compile clean; insight + recommendations unit tests green; full OSS CI matrix green.
+
+
 ### Release: /api/session-insight is now the complete per-session context-graph answer (carries #2479) (2026-06-02)
 - **What:** the session-insight endpoint now folds in the governance lineage, so one call returns cost + waste flags + sub-agent fan-out + governance (approval/guardrail decision + denied counts, with a `policy_denied` flag when blocked) — the single endpoint that will power the decision-insight card.
 - **Verified:** py_compile clean; insight unit tests green; full OSS CI matrix green.


### PR DESCRIPTION
Cuts 0.12.397. session-insight now returns actionable recommendations per waste flag.