### PR TITLE
feat(context-graph): error->cause edge (failed spans + their parent)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5199,6 +5199,39 @@ class LocalStore:
                 "data", "created_at"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
 
+    def query_session_errors(self, session_id: str, *, limit: int = 200) -> list[dict[str, Any]]:
+        """Context graph — the error->cause edge for a session: the spans that
+        ended in an error (OTel status ERROR or a failed tool), each with its
+        parent span so the upstream decision that led to the failure is one hop
+        away. Read-only, best-effort -> []. (Spans come from OTel-instrumented
+        runs; the per-session tool-failure rate covers the non-OTel case.)
+        """
+        if not session_id:
+            return []
+        sql = """
+            SELECT span_id, parent_span_id, tool_name, status, status_code, status_message
+            FROM spans
+            WHERE session_id = ?
+              AND (UPPER(COALESCE(status_code, '')) = 'ERROR'
+                   OR LOWER(COALESCE(status, '')) IN ('error', 'failed', 'failure'))
+            ORDER BY start_ts DESC
+            LIMIT ?
+        """
+        try:
+            rows = self._fetch(sql, [str(session_id), int(limit)])
+        except Exception:
+            return []
+        out: list[dict[str, Any]] = []
+        for sp, parent, tool, status, scode, smsg in rows:
+            out.append({
+                "span_id": sp,
+                "parent_span_id": parent,
+                "tool_name": tool or "",
+                "status": status or scode or "error",
+                "message": (smsg or "")[:300],
+            })
+        return out
+
     def query_subagent_cost_rollup(self, *, limit: int = 2000) -> list[dict[str, Any]]:
         """Per-parent sub-agent cost rollup in ONE pass: for each session that
         spawned sub-agents, the total $ + count its children spent. Lets the

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -481,6 +481,8 @@ _DAEMON_METHODS = frozenset({
     "query_session_lineage",
     # Context graph: per-parent sub-agent cost rollup (true-cost-of-an-ask chip).
     "query_subagent_cost_rollup",
+    # Context graph: the error->cause edge (failed spans + their parent).
+    "query_session_errors",
     # OpenClaw run ledger (tasks/runs.sqlite mirror): sub-agents + crons +
     # CLI turns with status/timing/parent-child. Powers the Scheduler lane
     # monitor + sub-agent fan-out tree + cron run log off one source.

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2787,6 +2787,17 @@ def api_session_insight(session_id):
     return jsonify(out)
 
 
+@bp_sessions.route("/api/session-errors/<path:session_id>")
+def api_session_errors(session_id):
+    """Context graph — the error->cause edge: this session's failed spans, each
+    with its parent span (the upstream decision one hop away)."""
+    try:
+        errors = _ls_call("query_session_errors", session_id=session_id) or []
+    except Exception:
+        errors = []
+    return jsonify({"session_id": session_id, "errors": errors, "error_count": len(errors)})
+
+
 @bp_sessions.route("/api/session-lineage/<path:session_id>")
 def api_session_lineage(session_id):
     """Context graph — first view: the decision-lineage tree rooted at a session.

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -796,3 +796,22 @@ def test_query_subagent_cost_rollup(store):
     assert roll["root-x"]["child_cost_usd"] == pytest.approx(0.25, abs=1e-6)
     assert roll["root-x"]["child_count"] == 2
     assert roll["root-y"]["child_count"] == 1
+
+
+def test_query_session_errors_edge(store):
+    """Context-graph error->cause edge: only failed spans, with their parent."""
+    store.ingest_span({"span_id": "e1", "trace_id": "t1", "name": "browser", "start_ts": 100.0,
+                       "session_id": "err-s", "parent_span_id": "p1", "tool_name": "browser",
+                       "status_code": "ERROR", "status_message": "Connection refused"})
+    store.ingest_span({"span_id": "e2", "trace_id": "t1", "name": "bash", "start_ts": 101.0,
+                       "session_id": "err-s", "parent_span_id": "p1", "tool_name": "bash",
+                       "status": "failed"})
+    store.ingest_span({"span_id": "ok1", "trace_id": "t1", "name": "read", "start_ts": 102.0,
+                       "session_id": "err-s", "parent_span_id": "p1", "tool_name": "read",
+                       "status_code": "OK"})
+    errs = store.query_session_errors("err-s")
+    ids = {e["span_id"] for e in errs}
+    assert ids == {"e1", "e2"}                      # ok1 excluded
+    e1 = next(e for e in errs if e["span_id"] == "e1")
+    assert e1["parent_span_id"] == "p1" and e1["tool_name"] == "browser"
+    assert store.query_session_errors("") == []


### PR DESCRIPTION
`query_session_errors(session_id)` returns a session's failed spans (OTel status ERROR or a failed tool) each with its `parent_span_id` — the upstream decision that led to the failure, one hop away. `GET /api/session-errors/<id>`; added to the daemon allowlist. Completes the graph's core edge set (session→tool, parent→subagent, decision→approval/guardrail, cost→decision, **error→cause**). Spans are OTel-only; the per-session tool-failure rate covers the non-OTel case. 1 new test.