### PR TITLE
feat(cli): 'clawmetry status --live' — in-terminal live status bar

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1517,8 +1517,64 @@ def _cmd_uninstall() -> None:
     print()
 
 
+def _status_live_line(rows, prev, now):
+    """Build the one-line live status from session rows. ``prev`` is the last
+    ``(total_tokens, time)`` sample (or None); ``now`` is the current time.
+    Returns ``(line, (total_tokens, now))``. Pure so it's unit-testable — the
+    refresh loop is the only impure part. Live tokens/sec is the total-token
+    delta over wall time (so it's ~0 when idle, and climbs while an agent works).
+    """
+    rows = rows or []
+    tot_tok = sum(int(r.get("total_tokens") or 0) for r in rows)
+    tot_cost = sum(float(r.get("cost_usd") or 0) for r in rows)
+    cur, best = {}, ""
+    for r in rows:
+        k = r.get("last_active_at") or r.get("updated_at") or r.get("started_at") or ""
+        if k >= best:
+            best, cur = k, r
+    _md = cur.get("metadata") if isinstance(cur.get("metadata"), dict) else {}
+    model = cur.get("model") or _md.get("model") or "—"
+    tps = 0.0
+    if prev is not None and now > prev[1]:
+        tps = max(0.0, (tot_tok - prev[0]) / (now - prev[1]))
+    line = f"\U0001F99E {len(rows)} sessions · {tot_tok:,} tokens · ${tot_cost:,.4f} · {model} · {tps:,.0f} tok/s"
+    return line, (tot_tok, now)
+
+
+def _status_live() -> None:
+    """clawmetry status --live — a refreshing one-line terminal status bar
+    (sessions · tokens · cost · model · live tokens/sec), read from the running
+    daemon's local store via the read-only proxy. Ctrl-C to exit."""
+    import sys as _sys
+    import time as _t
+    from clawmetry.local_store import get_store
+    try:
+        store = get_store(read_only=True)
+    except Exception as exc:
+        print(f"  Cannot open the local store (is the sync daemon running?): {exc}")
+        return
+    print("ClawMetry live  ·  Ctrl-C to exit\n")
+    prev = None
+    try:
+        while True:
+            try:
+                rows = store.query_sessions_table(limit=300) or []
+            except Exception:
+                rows = []
+            line, prev = _status_live_line(rows, prev, _t.time())
+            _sys.stdout.write("\r\033[2K" + line)
+            _sys.stdout.flush()
+            _t.sleep(2)
+    except KeyboardInterrupt:
+        _sys.stdout.write("\n")
+        _sys.stdout.flush()
+
+
 def _cmd_status(args) -> None:
     """clawmetry status — show local + cloud sync status."""
+    if getattr(args, "live", False):
+        _status_live()
+        return
     import platform
     from clawmetry.sync import CONFIG_FILE, STATE_FILE, LOG_FILE
 
@@ -2901,6 +2957,7 @@ def main() -> None:
     # status
     p_status = sub.add_parser("status", help="Show local + cloud sync status")
     p_status.add_argument("--show-key", action="store_true", help="Reveal secret key")
+    p_status.add_argument("--live", action="store_true", help="Live one-line status bar (sessions · tokens · cost · model · tok/s); Ctrl-C to exit")
 
     # proxy
     p_proxy = sub.add_parser(

--- a/tests/test_status_live.py
+++ b/tests/test_status_live.py
@@ -1,0 +1,31 @@
+"""Unit tests for the `clawmetry status --live` line builder (pure part)."""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from clawmetry.cli import _status_live_line
+
+
+def test_aggregates_sessions_tokens_cost_and_recent_model():
+    rows = [
+        {"session_id": "a", "total_tokens": 1000, "cost_usd": 0.50, "model": "claude-opus", "updated_at": "2026-06-02T10:00:00"},
+        {"session_id": "b", "total_tokens": 500, "cost_usd": 0.20, "model": "gpt-5", "updated_at": "2026-06-02T11:00:00"},
+    ]
+    line, prev = _status_live_line(rows, None, 100.0)
+    assert "2 sessions" in line and "1,500 tokens" in line and "$0.7000" in line
+    assert "gpt-5" in line          # most-recently-updated session's model
+    assert "0 tok/s" in line        # first sample has no rate
+    assert prev == (1500, 100.0)
+
+
+def test_tps_from_token_delta_over_time():
+    prev = (1500, 100.0)
+    rows = [
+        {"session_id": "a", "total_tokens": 1000, "cost_usd": 0.5, "model": "gpt-5", "updated_at": "2026-06-02T10:00:00"},
+        {"session_id": "b", "total_tokens": 700, "cost_usd": 0.3, "model": "gpt-5", "updated_at": "2026-06-02T11:00:05"},
+    ]
+    line, _ = _status_live_line(rows, prev, 110.0)   # +200 tokens in 10s
+    assert "20 tok/s" in line
+
+
+def test_empty_is_safe():
+    line, prev = _status_live_line([], None, 1.0)
+    assert "0 sessions" in line and prev == (0, 1.0)


### PR DESCRIPTION
A refreshing one-line terminal status — **sessions · tokens · cost · running model · live tokens/sec** — read from the daemon's local store via the read-only proxy. Pi-parity for the terminal-native crowd without leaving the shell. Live TPS = total-token delta over wall time (~0 idle, climbs while an agent works). The line builder `_status_live_line()` is a **pure, unit-tested** helper; the refresh loop (Ctrl-C to exit) is the only impure part. 3 new tests; py_compile clean.