### PR TITLE
feat(track): named source for out-loop / production agents

### DIFF
--- a/clawmetry/interceptor.py
+++ b/clawmetry/interceptor.py
@@ -291,7 +291,31 @@ def _build_event(
         event["model"] = model
     if cost is not None:
         event["cost_usd"] = cost
+    src = _get_source()
+    if src:
+        event["source"] = src
     return event
+
+
+# ── Named source (out-loop / production agents) ────────────────────────────────
+# A production agent built on an SDK (OpenAI Agents, LangChain, Vercel AI SDK,
+# E2B, …) is auto-tracked by `import clawmetry.track`. Tagging it with a name
+# makes it a first-class *source* in the dashboard (e.g. "support-agent",
+# "investment-agent") instead of an anonymous script, so you can attribute cost
+# per product. Set via CLAWMETRY_SOURCE=<name> or clawmetry.track.set_source().
+_source: str = ""
+
+
+def set_source(name: str) -> None:
+    """Tag every subsequently-intercepted LLM call with a named source."""
+    global _source
+    _source = (str(name or "").strip())[:120]
+
+
+def _get_source() -> str:
+    if _source:
+        return _source
+    return (os.environ.get("CLAWMETRY_SOURCE", "") or "").strip()[:120]
 
 
 # ── httpx patching ─────────────────────────────────────────────────────────────

--- a/clawmetry/track.py
+++ b/clawmetry/track.py
@@ -36,4 +36,23 @@ def get_stats() -> dict:
         return {}
 
 
-__all__ = ["get_stats"]
+def set_source(name: str) -> None:
+    """Tag every intercepted LLM call with a named source — your production
+    agent's name (e.g. "support-agent"). Makes an out-loop agent built on any
+    SDK (OpenAI Agents, LangChain, Vercel AI SDK, E2B, …) a first-class source
+    in ClawMetry, so you can attribute cost per product. Equivalent to setting
+    the ``CLAWMETRY_SOURCE`` env var.
+
+    Usage::
+
+        import clawmetry.track
+        clawmetry.track.set_source("support-agent")
+    """
+    try:
+        from clawmetry.interceptor import set_source as _set
+        _set(name)
+    except Exception:
+        pass
+
+
+__all__ = ["get_stats", "set_source"]

--- a/tests/test_track_source.py
+++ b/tests/test_track_source.py
@@ -1,0 +1,33 @@
+"""Out-loop source tagging: a production agent built on any SDK can name itself
+so it becomes a first-class source in ClawMetry (clawmetry.track.set_source)."""
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import clawmetry.interceptor as I
+import clawmetry.track as T
+
+
+def test_default_no_source():
+    I.set_source("")
+    os.environ.pop("CLAWMETRY_SOURCE", None)
+    assert I._get_source() == ""
+
+
+def test_set_source_tags_calls():
+    T.set_source("support-agent")
+    assert I._get_source() == "support-agent"
+    I.set_source("")
+
+
+def test_env_var_fallback():
+    I.set_source("")
+    os.environ["CLAWMETRY_SOURCE"] = "investment-agent"
+    try:
+        assert I._get_source() == "investment-agent"
+    finally:
+        os.environ.pop("CLAWMETRY_SOURCE", None)
+
+
+def test_source_is_bounded_and_stripped():
+    I.set_source("  " + "x" * 500 + "  ")
+    assert len(I._get_source()) <= 120
+    I.set_source("")


### PR DESCRIPTION
`import clawmetry.track` already auto-tracks any Python agent's LLM calls (it patches httpx/requests → OpenAI Agents SDK / LangChain / Vercel AI SDK / E2B all flow through). This adds **`clawmetry.track.set_source('my-agent')`** (and a `CLAWMETRY_SOURCE` env var) to **tag** those calls with a name, so a production agent becomes a first-class **source** in ClawMetry — attribute cost per product, not an anonymous script. Each intercepted `llm_call` event now carries a `source` field. The first step toward **out-loop SDK products as a source class** (the report's biggest TAM gap). 4 new tests; py_compile clean.