### PR TITLE
[RELEASE] persist named source through to the external-calls store

### DIFF
--- a/clawmetry/interceptor.py
+++ b/clawmetry/interceptor.py
@@ -155,7 +155,7 @@ def _build_external_event(
         host = urlparse(url).netloc or url.split("/")[2]
     except Exception:
         host = ""
-    return {
+    ev: dict[str, Any] = {
         "type": "external_api_call",
         "ts": datetime.now(timezone.utc).isoformat(),
         "url": url,
@@ -165,6 +165,10 @@ def _build_external_event(
         "latency_ms": round(latency_ms, 1),
         "library": library,
     }
+    src = _get_source()
+    if src:
+        ev["source"] = src
+    return ev
 
 
 def _detect_provider(url: str) -> str:

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -904,6 +904,8 @@ _DDL = [
     """,
     "CREATE INDEX IF NOT EXISTS idx_ext_api_calls_ts   ON external_api_calls(ts)",
     "CREATE INDEX IF NOT EXISTS idx_ext_api_calls_host ON external_api_calls(host, ts)",
+    # Named source for out-loop / production agents (clawmetry.track.set_source).
+    "ALTER TABLE external_api_calls ADD COLUMN IF NOT EXISTS source VARCHAR",
 ]
 
 
@@ -8360,8 +8362,8 @@ class LocalStore:
         with self._write_lock:
             self._conn.execute("""
                 INSERT INTO external_api_calls
-                    (id, node_id, ts, host, url, method, status_code, latency_ms, library)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (id, node_id, ts, host, url, method, status_code, latency_ms, library, source)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (id) DO NOTHING
             """, [
                 row_id,
@@ -8373,6 +8375,7 @@ class LocalStore:
                 ev.get("status_code"),
                 ev.get("latency_ms"),
                 ev.get("library") or "",
+                ev.get("source") or "",
             ])
 
     def query_external_calls(
@@ -8389,11 +8392,11 @@ class LocalStore:
         session's ``started_at`` and ``updated_at`` are returned (time-window
         attribution — no ABI changes to the interceptor required)."""
         cols = ["id", "node_id", "ts", "host", "url", "method",
-                "status_code", "latency_ms", "library"]
+                "status_code", "latency_ms", "library", "source"]
         if session_id:
             sql = """
                 SELECT e.id, e.node_id, e.ts, e.host, e.url, e.method,
-                       e.status_code, e.latency_ms, e.library
+                       e.status_code, e.latency_ms, e.library, e.source
                 FROM external_api_calls e
                 JOIN sessions s ON (
                     e.ts >= s.started_at
@@ -8417,7 +8420,7 @@ class LocalStore:
             where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
             sql = f"""
                 SELECT id, node_id, ts, host, url, method,
-                       status_code, latency_ms, library
+                       status_code, latency_ms, library, source
                 FROM external_api_calls {where}
                 ORDER BY ts DESC LIMIT ?
             """


### PR DESCRIPTION
## What

Completes the **out-loop named-source** flow end-to-end. `set_source()` / `CLAWMETRY_SOURCE` already tagged the intercepted event; this makes the daemon actually **store and serve** it, so an out-loop agent built on any SDK (OpenAI Agents, LangChain, Vercel AI SDK, E2B, …) becomes a first-class, cost-attributable source in ClawMetry.

## Changes
- `external_api_calls` gains an idempotent `source` column (`ALTER ... ADD COLUMN IF NOT EXISTS`, applied on every store open → existing installs upgrade in place, no migration step).
- `ingest_external_call` writes `ev["source"]`; `query_external_calls` SELECTs + returns it (both the session-scoped and general query).
- `_build_external_event` already carries `source` (the daemon-flowing builder).

Source now reaches `/api/local/external-calls` automatically (`query_external_calls` is already in the daemon allowlist).

## Test
Idempotent-ALTER (runs twice cleanly) + round-trip smoke test: source persisted & returned; back-compat when the field is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)