### PR TITLE
docs(readme): document out-loop SDK tracking (set_source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,25 @@ ClawMetry observes many AI-agent runtimes, not just OpenClaw. Each non-OpenClaw 
 
 "Beta adapter" means ClawMetry ships a reader for that runtime's real on-disk format, each built + verified against a real install on a real machine (see `tests/fixtures/runtimes/<rt>/`). Adapters are read-only; each is honest about what its runtime actually stores (e.g. PicoClaw/NanoClaw/Cursor don't write token cost to disk). When several runtimes run on one node, the runtime switcher scopes the sessions view to one for a clean deep-dive.
 
+## Track any SDK agent — out-loop cost attribution
+
+The runtimes above all write sessions to disk. Your own **production agent** — the one you built on the OpenAI Agents SDK, LangChain, the Vercel AI SDK, LlamaIndex, E2B, or a plain `httpx` loop — doesn't. ClawMetry's zero-config interceptor still captures its LLM calls (cost, tokens, latency, errors) by monkey-patching `httpx`/`requests`:
+
+```python
+import clawmetry.track            # activate the interceptor
+clawmetry.track.set_source("support-agent")   # name this product
+
+# ...your agent runs as normal; every LLM call is now tracked + attributed.
+```
+
+`set_source()` (or the `CLAWMETRY_SOURCE=support-agent` env var) tags each call with a **named source**, so every product you run shows up as its own first-class, cost-attributable line in the dashboard's **🔌 Out-loop sources** card on Overview — calls, providers, latency, error rate per agent. No source set? The calls are still tracked; the card just stays hidden.
+
+```bash
+CLAWMETRY_SOURCE=billing-agent python my_agent.py
+```
+
+This is the same data layer the runtime adapters feed (DuckDB → cloud snapshot), so out-loop sources sync to the cloud dashboard the same as everything else, E2E-encrypted.
+
 ## OpenTelemetry — vendor-neutral, send your traces anywhere
 
 ClawMetry speaks **OpenTelemetry** in both directions, using the **GenAI semantic conventions**, so your agent traces are never locked into one tool.


### PR DESCRIPTION
## What
Makes the out-loop named-source feature (0.12.402→405) **discoverable**. A feature nobody knows about captures no TAM.

Adds a **"Track any SDK agent — out-loop cost attribution"** README section between Runtime Compatibility and OpenTelemetry: `import clawmetry.track` + `set_source()` / `CLAWMETRY_SOURCE` turns a production agent built on any SDK (OpenAI Agents, LangChain, Vercel AI SDK, LlamaIndex, E2B, plain `httpx`) into a first-class, cost-attributable line in the **🔌 Out-loop sources** card — synced to cloud E2E like every other runtime.

Doc-only; no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)