### PR TITLE
[RELEASE] per-source cost in the out-loop sources card

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -906,6 +906,11 @@ _DDL = [
     "CREATE INDEX IF NOT EXISTS idx_ext_api_calls_host ON external_api_calls(host, ts)",
     # Named source for out-loop / production agents (clawmetry.track.set_source).
     "ALTER TABLE external_api_calls ADD COLUMN IF NOT EXISTS source VARCHAR",
+    # Cost attribution for out-loop LLM calls (interceptor llm_call events).
+    "ALTER TABLE external_api_calls ADD COLUMN IF NOT EXISTS cost_usd DOUBLE",
+    "ALTER TABLE external_api_calls ADD COLUMN IF NOT EXISTS input_tokens INTEGER",
+    "ALTER TABLE external_api_calls ADD COLUMN IF NOT EXISTS output_tokens INTEGER",
+    "ALTER TABLE external_api_calls ADD COLUMN IF NOT EXISTS model VARCHAR",
 ]
 
 
@@ -8362,8 +8367,9 @@ class LocalStore:
         with self._write_lock:
             self._conn.execute("""
                 INSERT INTO external_api_calls
-                    (id, node_id, ts, host, url, method, status_code, latency_ms, library, source)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (id, node_id, ts, host, url, method, status_code, latency_ms,
+                     library, source, cost_usd, input_tokens, output_tokens, model)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (id) DO NOTHING
             """, [
                 row_id,
@@ -8376,6 +8382,10 @@ class LocalStore:
                 ev.get("latency_ms"),
                 ev.get("library") or "",
                 ev.get("source") or "",
+                float(ev.get("cost_usd") or 0.0),
+                int(ev.get("input_tokens") or 0),
+                int(ev.get("output_tokens") or 0),
+                ev.get("model") or "",
             ])
 
     def query_external_calls(
@@ -8392,11 +8402,13 @@ class LocalStore:
         session's ``started_at`` and ``updated_at`` are returned (time-window
         attribution — no ABI changes to the interceptor required)."""
         cols = ["id", "node_id", "ts", "host", "url", "method",
-                "status_code", "latency_ms", "library", "source"]
+                "status_code", "latency_ms", "library", "source",
+                "cost_usd", "input_tokens", "output_tokens", "model"]
         if session_id:
             sql = """
                 SELECT e.id, e.node_id, e.ts, e.host, e.url, e.method,
-                       e.status_code, e.latency_ms, e.library, e.source
+                       e.status_code, e.latency_ms, e.library, e.source,
+                       e.cost_usd, e.input_tokens, e.output_tokens, e.model
                 FROM external_api_calls e
                 JOIN sessions s ON (
                     e.ts >= s.started_at
@@ -8420,7 +8432,8 @@ class LocalStore:
             where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
             sql = f"""
                 SELECT id, node_id, ts, host, url, method,
-                       status_code, latency_ms, library, source
+                       status_code, latency_ms, library, source,
+                       cost_usd, input_tokens, output_tokens, model
                 FROM external_api_calls {where}
                 ORDER BY ts DESC LIMIT ?
             """

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2841,29 +2841,40 @@ function _renderOutLoopSources() {
     var by = {};
     named.forEach(function(c){
       var k = String(c.source);
-      var g = by[k] || (by[k] = { calls: 0, errors: 0, lat: 0, hosts: {} });
+      var g = by[k] || (by[k] = { calls: 0, errors: 0, lat: 0, cost: 0, tokens: 0, hosts: {}, models: {} });
       g.calls += 1;
       if (Number(c.status_code) >= 400) g.errors += 1;
       g.lat += Number(c.latency_ms) || 0;
+      g.cost += Number(c.cost_usd) || 0;
+      g.tokens += (Number(c.input_tokens) || 0) + (Number(c.output_tokens) || 0);
       if (c.host) g.hosts[c.host] = 1;
+      if (c.model) g.models[c.model] = 1;
     });
-    var keys = Object.keys(by).sort(function(a, b){ return by[b].calls - by[a].calls; });
+    var keys = Object.keys(by).sort(function(a, b){ return by[b].cost - by[a].cost || by[b].calls - by[a].calls; });
+    var fleetCost = keys.reduce(function(s, k){ return s + by[k].cost; }, 0);
+    function _fmtCost(v){ return v >= 1 ? ('$' + v.toFixed(2)) : ('$' + v.toFixed(4)); }
+    function _fmtTok(n){ return n >= 1000 ? (Math.round(n / 100) / 10) + 'k' : String(n); }
     var inner = keys.map(function(k){
       var g = by[k];
       var hosts = Object.keys(g.hosts);
+      var models = Object.keys(g.models);
       var avg = g.calls ? Math.round(g.lat / g.calls) : 0;
       var errPct = g.calls ? Math.round((g.errors / g.calls) * 100) : 0;
       var meta = g.calls + ' call' + (g.calls == 1 ? '' : 's')
-        + ' · ' + hosts.length + ' provider' + (hosts.length == 1 ? '' : 's')
+        + (g.tokens ? ' · ' + _fmtTok(g.tokens) + ' tok' : '')
+        + ' · ' + (models.length === 1 ? models[0] : hosts.length + ' provider' + (hosts.length == 1 ? '' : 's'))
         + ' · ~' + avg + 'ms'
         + (g.errors ? ' · ' + errPct + '% errors' : '');
+      var costStr = g.cost > 0 ? _fmtCost(g.cost) : '';
       return '<div style="display:flex;gap:8px;align-items:baseline;font-size:13px;color:var(--text-secondary);padding:4px 0;">'
         + '<span>🔌</span><strong style="color:var(--text-primary);">' + escHtml(k) + '</strong>'
+        + (costStr ? '<strong style="color:#8b5cf6;">' + escHtml(costStr) + '</strong>' : '')
         + '<span style="color:var(--text-muted);">' + escHtml(meta) + '</span></div>';
     }).join('');
+    var fleetStr = fleetCost > 0 ? (' · ' + _fmtCost(fleetCost) + ' total') : '';
     var html = '<div id="cm-outloop-sources" style="background:var(--bg-secondary,#161b22);border:1px solid var(--border-primary,#30363d);border-left:3px solid #8b5cf6;border-radius:10px;padding:14px 18px;margin:0 0 16px;">'
       + '<div style="font-size:13px;font-weight:700;color:var(--text-primary,#e6edf3);margin-bottom:8px;">🔌 Out-loop sources '
-      + '<span style="font-weight:500;color:var(--text-muted,#6b7280);">— ' + keys.length + ' production agent' + (keys.length == 1 ? '' : 's') + ' reporting via the SDK</span></div>'
+      + '<span style="font-weight:500;color:var(--text-muted,#6b7280);">— ' + keys.length + ' production agent' + (keys.length == 1 ? '' : 's') + ' reporting via the SDK' + fleetStr + '</span></div>'
       + inner
       + '<div style="font-size:12px;color:var(--text-muted,#6b7280);margin-top:8px;">Tag any SDK agent with <code style="background:rgba(139,92,246,0.12);padding:1px 5px;border-radius:4px;">clawmetry.track.set_source("name")</code> to attribute its cost here.</div>'
       + '</div>';

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -4644,7 +4644,13 @@ def sync_intercepted_events(config: dict, state: dict, paths: dict) -> int:
                     ev = json.loads(raw)
                 except Exception:
                     continue
-                if ev.get("type") == "external_api_call":
+                _evt = ev.get("type")
+                if _evt in ("external_api_call", "llm_call"):
+                    # llm_call carries cost/tokens/model + provider; normalise
+                    # provider→host so both event types share external_api_calls
+                    # (the out-loop card then shows real per-source $ spend).
+                    if _evt == "llm_call" and not ev.get("host"):
+                        ev["host"] = ev.get("provider") or ""
                     try:
                         store.ingest_external_call(ev, node_id)
                         ingested += 1
@@ -10882,6 +10888,10 @@ def _build_external_calls():
                 "method":      (c.get("method") or "")[:10],
                 "status_code": c.get("status_code"),
                 "latency_ms":  c.get("latency_ms"),
+                "cost_usd":    c.get("cost_usd") or 0,
+                "input_tokens":  c.get("input_tokens") or 0,
+                "output_tokens": c.get("output_tokens") or 0,
+                "model":       (c.get("model") or "")[:60],
             })
             if len(out) >= 500:
                 break

--- a/tests/test_track_source.py
+++ b/tests/test_track_source.py
@@ -116,6 +116,23 @@ def test_external_call_source_round_trips(fresh_store):
     assert len(tagged) == 1
 
 
+def test_external_call_cost_round_trips(fresh_store):
+    # llm_call events carry cost/tokens/model — the out-loop card's per-source
+    # $ spend depends on these surviving ingest+query.
+    _ls, store = fresh_store
+    ev = _ev("2026-06-02T00:00:05Z", "billing-agent")
+    ev.update({"cost_usd": 0.0123, "input_tokens": 400, "output_tokens": 120,
+               "model": "claude-opus-4-8"})
+    store.ingest_external_call(ev)
+    row = next((r for r in store.query_external_calls(limit=10)
+                if r.get("source") == "billing-agent"), None)
+    assert row is not None
+    assert abs(float(row.get("cost_usd") or 0) - 0.0123) < 1e-9
+    assert int(row.get("input_tokens") or 0) == 400
+    assert int(row.get("output_tokens") or 0) == 120
+    assert row.get("model") == "claude-opus-4-8"
+
+
 def test_external_calls_migration_is_idempotent(fresh_store):
     # Re-running the migration set (as happens on every store open) must not
     # fail on the ALTER ... ADD COLUMN IF NOT EXISTS source.


### PR DESCRIPTION
## What
Delivers the actual promise of out-loop tracking — **cost attribution per product**. The 🔌 Out-loop sources card showed calls/latency/errors but **no cost**, because the daemon ingested only `external_api_call` events and **dropped the cost-bearing `llm_call` events** the interceptor writes for real LLM calls.

## The fix (full chain)
- **daemon** — `sync_intercepted_events` now ingests `llm_call` too (provider→host), so actual LLM spend lands in `external_api_calls`.
- **store** — `external_api_calls` gains `cost_usd` / `input_tokens` / `output_tokens` / `model` columns (idempotent `ADD COLUMN IF NOT EXISTS`); ingest + both queries wired.
- **snapshot** — `_build_external_calls` carries the new fields → the **cloud** card shows $ too, no cloud change needed (it reads the same `externalCalls` slice).
- **card** — aggregates per-source $ spend + tokens + model, sorts by cost, shows a fleet total in the header.

## Test
Cost/tokens/model round-trip added to `tests/test_track_source.py` — 10 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)