### PR TITLE
[RELEASE] interceptor cost falls back to the canonical pricing table

### DIFF
--- a/clawmetry/interceptor.py
+++ b/clawmetry/interceptor.py
@@ -116,7 +116,16 @@ def _estimate_cost(
                 input_tokens * prices["input"] + output_tokens * prices["output"]
             ) / 1_000_000
             return round(cost, 8)
-    return None
+    # Fall back to the canonical multi-provider table so a real out-loop call is
+    # never silently $0 just because this small table predates the model
+    # (gpt-4.1/5, o3/o4, gemini-2.5, grok, …). providers_pricing infers the
+    # provider from the model and returns a conservative non-zero estimate.
+    try:
+        from clawmetry.providers_pricing import estimate_event_cost_usd as _pp_cost
+        c = _pp_cost(model, input_tokens, output_tokens)
+        return round(c, 8) if c and c > 0 else None
+    except Exception:
+        return None
 
 
 # ── URL detection ──────────────────────────────────────────────────────────────

--- a/tests/test_track_source.py
+++ b/tests/test_track_source.py
@@ -116,6 +116,17 @@ def test_external_call_source_round_trips(fresh_store):
     assert len(tagged) == 1
 
 
+def test_cost_fallback_prices_models_outside_local_table():
+    # The interceptor's small _PRICING table predates models like o3 / grok /
+    # gemini-2.5; out-loop cost must NOT silently read $0 for them — the
+    # providers_pricing fallback returns a conservative non-zero estimate.
+    for m in ("o3", "grok-2", "gemini-2.5-pro", "gpt-5"):
+        c = I._estimate_cost(m, 1000, 500)
+        assert c and c > 0, (m, c)
+    # but a call with no tokens is still None (nothing to price)
+    assert I._estimate_cost("o3", 0, 0) is None
+
+
 def test_external_call_cost_round_trips(fresh_store):
     # llm_call events carry cost/tokens/model — the out-loop card's per-source
     # $ spend depends on these surviving ingest+query.


### PR DESCRIPTION
## What
Accuracy fix for out-loop cost (and the interceptor's `get_session_stats`). The interceptor's small `_PRICING` table returned `None` → **\$0** for any model it predated, so per-source cost silently read \$0 for current models (gpt-4.1/5, o3/o4, gemini-2.5, grok).

On a miss, `_estimate_cost` now falls back to `providers_pricing.estimate_event_cost_usd` — the canonical multi-provider table that infers the provider from the model and returns a **conservative non-zero estimate** (with the unknown-provider default as a floor).

The local table stays as the fast path; this only adds the fallback so a real LLM call is never silently free in the 🔌 Out-loop sources cost figure.

## Test
`test_cost_fallback_prices_models_outside_local_table` asserts o3 / grok-2 / gemini-2.5-pro / gpt-5 price non-zero, and a zero-token call is still `None`. 11 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)