### PR TITLE
[RELEASE] price the most-specific model, not the first substring match

### DIFF
--- a/clawmetry/interceptor.py
+++ b/clawmetry/interceptor.py
@@ -108,14 +108,21 @@ def _estimate_cost(
     """Estimate cost in USD for given model and token counts."""
     if not model or (input_tokens == 0 and output_tokens == 0):
         return None
-    # Find best match (model names can have version suffixes like -20240229)
+    # Find the MOST SPECIFIC match (model names have version suffixes like
+    # -20240229). First-substring would let "gpt-4o" swallow "gpt-4o-mini" (a
+    # 16x over-charge) or "o1" swallow "o1-mini" — so pick the longest matching
+    # key, which is the more specific model.
     model_lower = model.lower()
+    best_key = None
+    best_prices = None
     for key, prices in _PRICING.items():
-        if key in model_lower:
-            cost = (
-                input_tokens * prices["input"] + output_tokens * prices["output"]
-            ) / 1_000_000
-            return round(cost, 8)
+        if key in model_lower and (best_key is None or len(key) > len(best_key)):
+            best_key, best_prices = key, prices
+    if best_prices is not None:
+        cost = (
+            input_tokens * best_prices["input"] + output_tokens * best_prices["output"]
+        ) / 1_000_000
+        return round(cost, 8)
     # Fall back to the canonical multi-provider table so a real out-loop call is
     # never silently $0 just because this small table predates the model
     # (gpt-4.1/5, o3/o4, gemini-2.5, grok, …). providers_pricing infers the

--- a/tests/test_track_source.py
+++ b/tests/test_track_source.py
@@ -116,6 +116,16 @@ def test_external_call_source_round_trips(fresh_store):
     assert len(tagged) == 1
 
 
+def test_cost_picks_most_specific_model_match():
+    # First-substring matching let "gpt-4o" swallow "gpt-4o-mini" (16x over) and
+    # "o1" swallow "o1-mini" (5x over). Longest-match must price the specific one.
+    assert abs(I._estimate_cost("gpt-4o-mini", 1_000_000, 0) - 0.15) < 1e-6
+    assert abs(I._estimate_cost("o1-mini", 1_000_000, 0) - 3.0) < 1e-6
+    assert abs(I._estimate_cost("gpt-4o", 1_000_000, 0) - 2.5) < 1e-6
+    # and the more-specific claude haiku key isn't swallowed by the shorter one
+    assert abs(I._estimate_cost("claude-3-5-haiku", 1_000_000, 0) - 0.8) < 1e-6
+
+
 def test_cost_fallback_prices_models_outside_local_table():
     # The interceptor's small _PRICING table predates models like o3 / grok /
     # gemini-2.5; out-loop cost must NOT silently read $0 for them — the


### PR DESCRIPTION
## What
`_estimate_cost` matched the **first** `_PRICING` key that was a substring of the model name — but `gpt-4o` is listed before `gpt-4o-mini`, so **`gpt-4o-mini` got `gpt-4o`'s rate (a 16× over-charge: $2.50 vs the real $0.15 input)**, and `o1` swallowed `o1-mini` (5×).

## Fix
Pick the **longest** matching key (the more specific model). `claude-3-5-haiku` no longer collapses to `claude-3-haiku` either.

## Verify
```
gpt-4o-mini $/1M-in: 2.5 → 0.15
o1-mini     $/1M-in: 15  → 3.0
gpt-4o, claude-3-5-haiku, … : unchanged/correct
```
`test_cost_picks_most_specific_model_match` — 12 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)