### PR TITLE
[RELEASE] version-boundary on model match (gpt-4 must not price gpt-4.1)

### DIFF
--- a/clawmetry/interceptor.py
+++ b/clawmetry/interceptor.py
@@ -116,7 +116,18 @@ def _estimate_cost(
     best_key = None
     best_prices = None
     for key, prices in _PRICING.items():
-        if key in model_lower and (best_key is None or len(key) > len(best_key)):
+        idx = model_lower.find(key)
+        if idx == -1:
+            continue
+        # Reject a match immediately followed by a digit or "." — that's a
+        # different version (e.g. "gpt-4" must NOT price "gpt-4.1"/"gpt-4.5";
+        # let those fall through to the canonical table instead of classic
+        # gpt-4's $30/$60). "-"/letter suffixes (gpt-4-turbo, claude-opus-4-8)
+        # are still valid matches.
+        after = model_lower[idx + len(key): idx + len(key) + 1]
+        if after.isdigit() or after == ".":
+            continue
+        if best_key is None or len(key) > len(best_key):
             best_key, best_prices = key, prices
     if best_prices is not None:
         cost = (

--- a/tests/test_track_source.py
+++ b/tests/test_track_source.py
@@ -126,6 +126,15 @@ def test_cost_picks_most_specific_model_match():
     assert abs(I._estimate_cost("claude-3-5-haiku", 1_000_000, 0) - 0.8) < 1e-6
 
 
+def test_cost_version_boundary_no_false_match():
+    # "gpt-4" must NOT price "gpt-4.1"/"gpt-4.5" (different versions) as classic
+    # gpt-4 ($30/$60); they fall through to the canonical table instead.
+    assert abs(I._estimate_cost("gpt-4.1", 1_000_000, 0) - 2.5) < 1e-6   # openai baseline, not 30
+    assert abs(I._estimate_cost("gpt-4", 1_000_000, 0) - 30.0) < 1e-6    # classic still 30
+    assert abs(I._estimate_cost("gpt-4-turbo", 1_000_000, 0) - 10.0) < 1e-6
+    assert abs(I._estimate_cost("claude-opus-4-8", 1_000_000, 0) - 15.0) < 1e-6
+
+
 def test_cost_fallback_prices_models_outside_local_table():
     # The interceptor's small _PRICING table predates models like o3 / grok /
     # gemini-2.5; out-loop cost must NOT silently read $0 for them — the


### PR DESCRIPTION
## What
Even after the longest-match fix, the bare `gpt-4` key is a substring of `gpt-4.1` / `gpt-4.5`, so those newer models were still priced as **classic gpt-4 ($30/$60)** — ~10× too high.

## Fix
Reject a key match immediately followed by a **digit or `.`** (a different version). `-`/letter suffixes still match (`gpt-4-turbo`, `claude-opus-4-8`). `gpt-4.1` now falls through to the canonical `providers_pricing` table ($2.5/$10 openai baseline); classic `gpt-4` stays $30/$60.

## Test
`test_cost_version_boundary_no_false_match` — 13 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)