### PR TITLE
[RELEASE] roll the re-read tax up to the fleet recoverable-spend card

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -2790,6 +2790,7 @@ function _renderWasteSummary() {
     var rows = [];
     if (Number(w.reasoning_cost_usd) > 0) rows.push(['🧠', '$' + Number(w.reasoning_cost_usd).toFixed(2) + ' on reasoning', '(' + (w.reasoning_pct_of_cost || 0) + '% of spend — billed, no deliverable)']);
     if (Number(w.low_cache_sessions) > 0) rows.push(['⚡', w.low_cache_sessions + ' session' + (w.low_cache_sessions == 1 ? '' : 's'), 'with low cache hit (context re-sent at full price)']);
+    if (Number(w.reread_tax_usd) > 0) rows.push(['⏱', '$' + Number(w.reread_tax_usd).toFixed(2) + ' re-read tax', 'rebuilding the prompt cache after its 5-min TTL expired (' + w.reread_tax_sessions + ' session' + (w.reread_tax_sessions == 1 ? '' : 's') + ')']);
     if (Number(w.tool_failing_sessions) > 0) rows.push(['⚠', w.tool_failing_sessions + ' session' + (w.tool_failing_sessions == 1 ? '' : 's'), 'with a tool failing (tokens burned on retries)']);
     if (Number(w.compaction_heavy_sessions) > 0) rows.push(['♻', w.compaction_heavy_sessions + ' session' + (w.compaction_heavy_sessions == 1 ? '' : 's'), 'thrashing context (re-summarised repeatedly)']);
     if (Number(w.model_fallback_sessions) > 0) rows.push(['🔀', w.model_fallback_sessions + ' session' + (w.model_fallback_sessions == 1 ? '' : 's'), 'on a silent model fallback']);
@@ -2808,6 +2809,8 @@ function _renderWasteSummary() {
       _opps.push([Number(w.tool_failing_sessions) * 1.5, 'Fix the failing tool in ' + w.tool_failing_sessions + ' session' + (w.tool_failing_sessions == 1 ? '' : 's') + ' — you\'re paying tokens on the retries.']);
     if (Number(w.low_cache_sessions) > 0)
       _opps.push([Number(w.low_cache_sessions), w.low_cache_sessions + ' session' + (w.low_cache_sessions == 1 ? '' : 's') + ' re-send context at full price — keep the prompt stable to warm the cache.']);
+    if (Number(w.reread_tax_usd) > 0)
+      _opps.push([Number(w.reread_tax_usd) * 2, '$' + Number(w.reread_tax_usd).toFixed(2) + ' went to rebuilding the prompt cache after its 5-min TTL expired — keep sessions warm (a heartbeat or batched turns) so context is read at ~0.1x instead of re-written at full price.']);
     if (Number(w.compaction_heavy_sessions) > 0)
       _opps.push([Number(w.compaction_heavy_sessions) * 0.8, w.compaction_heavy_sessions + ' session' + (w.compaction_heavy_sessions == 1 ? '' : 's') + ' thrash context with repeated compaction — work in a smaller window.']);
     _opps.sort(function(a, b){ return b[0] - a[0]; });

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2610,11 +2610,16 @@ def _derive_waste_summary(sessions: list) -> dict:
     total_cost = sum(float(s.get("cost_usd") or 0.0) for s in sessions)
     reasoning = round(sum(float(s.get("reasoning_cost_usd") or 0.0) for s in sessions), 4)
     low_cache, failing, compacting, mixed, flagged = [], [], [], [], set()
+    reread, reread_usd = [], 0.0
     for s in sessions:
         sid = s.get("session_id")
         chp = s.get("cache_hit_pct")
         if chp is not None and chp < 40 and (s.get("cost_usd") or 0) > 0:
             low_cache.append(sid); flagged.add(sid)
+        # Re-read tax: paid more to rebuild the prompt cache than reuse saved.
+        cwc = s.get("cache_write_cost_usd")
+        if cwc and float(cwc) > 0.005 and float(cwc) > float(s.get("cache_saved_usd") or 0.0):
+            reread.append(sid); reread_usd += float(cwc); flagged.add(sid)
         if (s.get("tool_error_pct") or 0) >= 20:
             failing.append(sid); flagged.add(sid)
         if (s.get("compaction_count") or 0) >= 2:
@@ -2630,6 +2635,8 @@ def _derive_waste_summary(sessions: list) -> dict:
         "reasoning_cost_usd": reasoning,
         "reasoning_pct_of_cost": round(reasoning / total_cost * 100, 1) if total_cost else 0.0,
         "low_cache_sessions": len(low_cache),
+        "reread_tax_sessions": len(reread),
+        "reread_tax_usd": round(reread_usd, 4),
         "tool_failing_sessions": len(failing),
         "compaction_heavy_sessions": len(compacting),
         "model_fallback_sessions": len(mixed),

--- a/tests/test_session_cost_intel.py
+++ b/tests/test_session_cost_intel.py
@@ -127,3 +127,16 @@ def test_reread_tax_waste_flag():
     healthy = {"cost_usd": 1.0, "cache_hit_pct": 85,
                "cache_write_cost_usd": 0.01, "cache_saved_usd": 0.50}
     assert "reread_tax" not in _derive_session_insight(healthy, [])["waste_flags"]
+
+
+def test_waste_summary_rolls_up_reread_tax():
+    from routes.sessions import _derive_waste_summary
+    sessions = [
+        {"session_id": "a", "cost_usd": 1.0, "cache_write_cost_usd": 0.15,
+         "cache_saved_usd": 0.0027, "cache_hit_pct": 9},   # churn → counted
+        {"session_id": "b", "cost_usd": 2.0, "cache_write_cost_usd": 0.01,
+         "cache_saved_usd": 0.50, "cache_hit_pct": 85},      # healthy → not
+    ]
+    w = _derive_waste_summary(sessions)
+    assert w["reread_tax_sessions"] == 1
+    assert abs(w["reread_tax_usd"] - 0.15) < 1e-9


### PR DESCRIPTION
## What
Builds on the per-session re-read tax (#2517 / 0.12.410): the Overview **recoverable spend** card now sums the cache-rebuild cost across churny sessions into a headline **"$X re-read tax"** line + session count, and offers it as a **"Start here"** fix (keep sessions warm so context is read at ~0.1× instead of re-written at full price).

This is the number that *proves* the tax Diakonov described — the thing no other tool shows.

- `_derive_waste_summary`: `reread_tax_usd` + `reread_tax_sessions`.
- `_renderWasteSummary`: ⏱ row + ranked opportunity (`$value × 2` weight so a real-dollar tax surfaces near the top).

## Test
Fleet rollup counts only churny sessions (write cost > savings), not healthy reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)