### PR TITLE
[RELEASE] per-turn idle-gap detection sharpens the re-read tax

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -8724,6 +8724,48 @@ def _session_tool_health(events) -> dict:
     }
 
 
+def _session_idle_gaps(events, ttl_sec: int = 300) -> dict:
+    """Count idle gaps that crossed the prompt-cache TTL. Anthropic's cache
+    expires after ~5 minutes, so every consecutive-event gap longer than that
+    forced the next call to RE-READ (re-derive) context it already had — a
+    direct, timestamp-only count of the re-read tax events (no per-event cache
+    split needed, which family events drop at ingest). Returns {} for <2 events.
+    Never raises."""
+    ts: list[float] = []
+    try:
+        for e in events or []:
+            t = getattr(e, "ts", None)
+            if t is None:
+                continue
+            try:
+                ts.append(float(t))
+            except (TypeError, ValueError):
+                try:
+                    ts.append(datetime.fromisoformat(
+                        str(t).replace("Z", "+00:00")).timestamp())
+                except Exception:
+                    continue
+    except Exception:
+        return {}
+    if len(ts) < 2:
+        return {}
+    ts.sort()
+    expiries = 0
+    max_gap = 0.0
+    for a, b in zip(ts, ts[1:]):
+        gap = b - a
+        if gap > max_gap:
+            max_gap = gap
+        if gap > ttl_sec:
+            expiries += 1
+    out: dict = {}
+    if expiries:
+        out["cacheExpiryCount"] = expiries
+    if max_gap > 0:
+        out["maxIdleGapSec"] = round(max_gap, 1)
+    return out
+
+
 def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
     """Ingest PicoClaw + NanoClaw sessions into DuckDB (and the cloud) so they
     appear in the sessions list + transcripts the same way OpenClaw does.
@@ -8804,6 +8846,8 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 _events = list(adapter.list_events(s.id, limit=2000))
                 _thealth = _session_tool_health(_events)
                 metadata.update(_thealth)
+                _idle = _session_idle_gaps(_events)
+                metadata.update(_idle)
                 # Compaction count: each auto-compaction silently re-summarises
                 # (and re-bills) the context. A session that compacted N times
                 # is thrashing its context window — a glanceable waste signal.
@@ -8856,6 +8900,7 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     "token_split": _intel.get("tokenSplit"),
                     "cache_write_cost_usd": _intel.get("cacheWriteCostUsd"),
                     "cache_saved_usd": _intel.get("cacheSavedUsd"),
+                    "cache_expiry_count": _idle.get("cacheExpiryCount"),
                     "tool_error_pct": _thealth.get("toolErrorPct"),
                     "compaction_count": _compactions or None,
                 })

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2690,10 +2690,12 @@ def _derive_session_insight(sess: dict, lineage: list) -> dict:
         flags.append("cache_poor")
     # Cache re-read tax (sharper than cache_poor): you paid MORE to rebuild the
     # cache than reuse saved — the 5-min TTL expired between turns and the
-    # context was re-derived. Material write cost that dwarfs the savings.
+    # context was re-derived. Fires on the cost heuristic (write cost dwarfs
+    # savings) OR on direct evidence: turns that idled past the TTL (≥2).
     cwc = sess.get("cache_write_cost_usd")
     csv = float(sess.get("cache_saved_usd") or 0.0)
-    if cwc and float(cwc) > 0.005 and float(cwc) > csv:
+    expiry = int(sess.get("cache_expiry_count") or 0)
+    if (cwc and float(cwc) > 0.005 and float(cwc) > csv) or expiry >= 2:
         flags.append("reread_tax")
     if (sess.get("tool_error_pct") or 0) >= 20:
         flags.append("tools_failing")
@@ -2709,6 +2711,7 @@ def _derive_session_insight(sess: dict, lineage: list) -> dict:
         "cache_hit_pct": sess.get("cache_hit_pct"),
         "cache_write_cost_usd": sess.get("cache_write_cost_usd"),
         "cache_saved_usd": sess.get("cache_saved_usd"),
+        "cache_expiry_count": sess.get("cache_expiry_count"),
         "tool_error_pct": sess.get("tool_error_pct"),
         "compaction_count": sess.get("compaction_count"),
         "model_mix": bool(sess.get("model_mix")),
@@ -3098,7 +3101,7 @@ def _try_local_store_cost_breakdown():
         intel = {}
         for mr in meta_rows:
             md = mr.get("metadata") or {}
-            if isinstance(md, dict) and any(md.get(k) is not None for k in ("reasoningCostUsd", "cacheHitPct", "toolErrorPct", "compactionCount")):
+            if isinstance(md, dict) and any(md.get(k) is not None for k in ("reasoningCostUsd", "cacheHitPct", "toolErrorPct", "compactionCount", "cacheExpiryCount")):
                 intel[mr.get("session_id") or ""] = md
         if intel:
             for row in result:
@@ -3113,6 +3116,8 @@ def _try_local_store_cost_breakdown():
                     row["tool_error_pct"] = md["toolErrorPct"]
                 if md.get("compactionCount") is not None:
                     row["compaction_count"] = md["compactionCount"]
+                if md.get("cacheExpiryCount") is not None:
+                    row["cache_expiry_count"] = md["cacheExpiryCount"]
     except Exception:
         pass
     # Cache-hit % (for the event-usage runtimes: OpenClaw / Claude Code) + the

--- a/tests/test_session_cost_intel.py
+++ b/tests/test_session_cost_intel.py
@@ -140,3 +140,30 @@ def test_waste_summary_rolls_up_reread_tax():
     w = _derive_waste_summary(sessions)
     assert w["reread_tax_sessions"] == 1
     assert abs(w["reread_tax_usd"] - 0.15) < 1e-9
+
+
+def test_idle_gap_cache_expiry_count():
+    from clawmetry.sync import _session_idle_gaps
+    class _E:
+        def __init__(self, ts): self.ts = ts
+    # gaps: 100s (ok), 500s (>300 → expiry), 700s (expiry)
+    evs = [_E(1000.0), _E(1100.0), _E(1600.0), _E(2300.0)]
+    out = _session_idle_gaps(evs)
+    assert out["cacheExpiryCount"] == 2
+    assert out["maxIdleGapSec"] == 700.0
+    # ISO timestamps also parse
+    iso = [_E("2026-06-02T00:00:00Z"), _E("2026-06-02T00:10:00Z")]  # 600s gap
+    assert _session_idle_gaps(iso)["cacheExpiryCount"] == 1
+    # fewer than 2 events → empty
+    assert _session_idle_gaps([_E(1.0)]) == {}
+
+
+def test_reread_tax_flag_on_idle_evidence():
+    from routes.sessions import _derive_session_insight
+    # direct idle evidence (>=2 expiries) flags even without the cost heuristic
+    out = _derive_session_insight({"cost_usd": 1.0, "cache_expiry_count": 2}, [])
+    assert "reread_tax" in out["waste_flags"]
+    assert out["cache_expiry_count"] == 2
+    # a single brief idle does not
+    assert "reread_tax" not in _derive_session_insight(
+        {"cost_usd": 1.0, "cache_expiry_count": 1}, [])["waste_flags"]


### PR DESCRIPTION
## What
Follow-up to the re-read tax (0.12.410-412). The session-aggregate heuristic *infers* churn (cache write cost > savings); this adds **direct evidence from timestamps alone**: `_session_idle_gaps` counts consecutive-event gaps that crossed the **5-minute prompt-cache TTL** — each one forced the next call to re-read context it already had.

**Key property: it needs no per-event cache split** (which family adapters drop at ingest), so it works across all runtimes from timestamps we always have.

## Changes
- `cacheExpiryCount` + `maxIdleGapSec` on the session cost-intel metadata.
- `_derive_session_insight`: `reread_tax` now fires on the cost heuristic **OR** ≥2 idle expiries; `cache_expiry_count` in the output.
- Threaded through the metadata camel→snake mapping + the cloud upload row.

## Test
Gap counting (epoch + ISO timestamps) + the flag reinforcement (≥2 expiries flags; a single brief idle doesn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)