### PR TITLE
[RELEASE] run the opt-in auto-update worker in the daemon (headless nodes)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -12761,6 +12761,21 @@ def run_daemon() -> None:
     except Exception as _e:
         log.warning(f"pro-entitlement watcher failed to start: {_e}")
 
+    # ── Opt-in auto-update worker ────────────────────────────────────────
+    # routes/update_check.py runs a background checker that self-updates ONLY
+    # when the `auto_update` config is on (default OFF → no behaviour change
+    # for anyone who hasn't opted in), via the same vetted pip+restart path as
+    # the manual "Update now". It was started only in the DASHBOARD process —
+    # but a headless / cloud-synced node runs only this daemon, so auto-update
+    # never fired where it's most needed. Start it here too (idempotent: the
+    # module guards against a double-started thread). Never blocks/raises.
+    try:
+        from routes.update_check import start_update_check_thread as _start_uc
+        _start_uc()
+        log.info("update-check thread started (auto-update honours the opt-in flag)")
+    except Exception as _e:
+        log.warning(f"update-check thread failed to start: {_e}")
+
     # ── Per-tier event retention prune (#2262 catalogue) ─────────────────
     # Hourly tick that reads ``Entitlement.event_retention_days()`` and
     # calls ``LocalStore.prune_events_by_age`` so the events table never


### PR DESCRIPTION
## What
The opt-in auto-update checker (`routes/update_check.py`) self-updates **only when the `auto_update` config is on** (default **OFF** — zero behaviour change for anyone who hasn't opted in), via the same vetted pip+restart path as the manual "Update now". It was started **only in the dashboard process** (`dashboard.py`) — but a **headless / cloud-synced node runs only the sync daemon**, so the opt-in feature never fired where it's most needed (exactly the nodes that fall behind, like the founder's 0.12.385).

## Fix
`run_daemon()` now also calls `start_update_check_thread()`:
- **idempotent** — the module guards against a double-started thread, so it's safe when the dashboard runs alongside the daemon;
- still **gated on `auto_update`** (default off) — no forced updates, no blast radius.

This makes "keep this node current automatically" actually work on daemon-only nodes. **Flipping the default to on, or auto-enabling it per entitlement, stays a deliberate product decision** (auto-`pip`-upgrading users' machines is high-blast-radius) — this PR only makes the existing opt-in reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)