### PR TITLE
feat: multi-agent orchestration status board in Subagents tab

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1178,7 +1178,7 @@ function switchTab(name) {
   if (name === 'models') loadModelAttribution();
   if (name === 'nemoclaw') { loadNemoClaw(); _startNcApprovalsAutoRefresh(); }
   if (name !== 'nemoclaw') _stopNcApprovalsAutoRefresh();
-  if (name === 'subagents') { loadRunLedger(); loadSubagents(); if (!_subagentsTimer) _subagentsTimer = visibilitySetInterval(function(){ loadRunLedger(); loadSubagents(); }, 5000); }
+  if (name === 'subagents') { loadOrchestration(); loadRunLedger(); loadSubagents(); if (!_subagentsTimer) _subagentsTimer = visibilitySetInterval(function(){ loadOrchestration(); loadRunLedger(); loadSubagents(); }, 5000); }
   if (name !== 'subagents' && _subagentsTimer) { clearInterval(_subagentsTimer); _subagentsTimer = null; }
   if (name === 'swimlane') { loadSwimlane(); if (!_swimlaneTimer) _swimlaneTimer = visibilitySetInterval(loadSwimlane, 3000); }
   if (name !== 'swimlane' && _swimlaneTimer) { clearInterval(_swimlaneTimer); _swimlaneTimer = null; }
@@ -13381,6 +13381,59 @@ async function loadSubagents() {
 function _saToggle(sid) {
   _subagentsExpanded[sid] = (_subagentsExpanded[sid] === false) ? true : false;
   loadSubagents();
+}
+
+async function loadOrchestration() {
+  var el = document.getElementById('orchestration-board');
+  if (!el) return;
+  try {
+    var data = await fetch('/api/orchestration').then(function(r) { return r.json(); });
+    var agents = data.agents || [];
+    var summary = data.summary || {};
+    if (agents.length === 0) { el.innerHTML = ''; return; }
+    var statusColors = {
+      active: '#16a34a', running: '#16a34a', idle: '#d97706',
+      stale: '#6b7280', failed: '#ef4444', paused: '#7c3aed', completed: '#3b82f6'
+    };
+    var html = '<div style="border:1px solid var(--border-primary);border-radius:10px;overflow:hidden;margin-bottom:4px;">';
+    html += '<div style="display:flex;align-items:center;gap:16px;padding:8px 14px;background:var(--bg-secondary);border-bottom:1px solid var(--border-primary);font-size:12px;flex-wrap:wrap;">';
+    html += '<span style="font-weight:700;color:var(--text-primary);font-size:13px;">🤖 Orchestration</span>';
+    html += '<span style="color:var(--text-muted);"><strong style="color:var(--text-primary);">' + (summary.total || 0) + '</strong> agents</span>';
+    if (summary.active) html += '<span style="color:#16a34a;"><strong>' + summary.active + '</strong> active</span>';
+    if (summary.total_cost_usd) {
+      html += '<span style="color:var(--text-muted);">$<strong style="color:var(--text-primary);">' + summary.total_cost_usd.toFixed(4) + '</strong> total cost</span>';
+    }
+    html += '</div>';
+    html += '<div style="display:flex;flex-wrap:wrap;gap:8px;padding:10px;">';
+    agents.forEach(function(a) {
+      var color = statusColors[a.status] || '#6b7280';
+      var glow = (a.status === 'active' || a.status === 'running') ? 'box-shadow:0 0 0 1px ' + color + '40;' : '';
+      var costStr = (a.costUsd > 0) ? '$' + a.costUsd.toFixed(4) : '';
+      var tokens = a.totalTokens >= 1000 ? (a.totalTokens / 1000).toFixed(1) + 'K tok' : (a.totalTokens > 0 ? a.totalTokens + ' tok' : '');
+      var depthBadge = (a.depth > 1) ? '<span style="font-size:9px;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:3px;padding:0 4px;color:var(--text-muted);margin-left:4px;">d' + a.depth + '</span>' : '';
+      html += '<div style="flex:0 0 auto;min-width:155px;max-width:215px;border:1px solid var(--border-primary);border-radius:8px;padding:8px 10px;background:var(--bg-card);' + glow + '">';
+      html += '<div style="display:flex;align-items:center;gap:5px;margin-bottom:4px;">';
+      html += '<span style="width:8px;height:8px;border-radius:50%;background:' + color + ';display:inline-block;flex-shrink:0;"></span>';
+      html += '<span style="font-size:12px;font-weight:600;color:var(--text-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;" title="' + escHtml(a.displayName) + '">' + escHtml(a.displayName) + '</span>';
+      html += depthBadge;
+      html += '</div>';
+      if (a.model && a.model !== 'unknown') {
+        html += '<div style="font-size:10px;color:var(--text-muted);margin-bottom:2px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(a.model) + '</div>';
+      }
+      if (costStr || tokens) {
+        html += '<div style="display:flex;gap:8px;font-size:10px;color:var(--text-faint);">';
+        if (costStr) html += '<span style="color:#16a34a;">' + escHtml(costStr) + '</span>';
+        if (tokens) html += '<span>' + escHtml(tokens) + '</span>';
+        html += '</div>';
+      }
+      html += '</div>';
+    });
+    html += '</div></div>';
+    el.innerHTML = html;
+  } catch(e) {
+    var board = document.getElementById('orchestration-board');
+    if (board) board.innerHTML = '';
+  }
 }
 
 async function controlAgent(key, action) {

--- a/clawmetry/templates/tabs/subagents.html
+++ b/clawmetry/templates/tabs/subagents.html
@@ -1,8 +1,12 @@
 <div class="page" id="page-subagents">
   <div class="refresh-bar">
     <h2 style="font-size:16px;font-weight:700;color:var(--text-primary);margin:0;flex:1;" data-i18n="app.sub_agents_queue_lanes">🤖 Sub-Agents &amp; Queue Lanes</h2>
-    <button class="refresh-btn" onclick="loadRunLedger();loadSubagents()" data-i18n="app.refresh">↻ Refresh</button>
+    <button class="refresh-btn" onclick="loadOrchestration();loadRunLedger();loadSubagents()" data-i18n="app.refresh">↻ Refresh</button>
   </div>
+  <!-- Orchestration status board: one card per agent with status badge, cost,
+       model tag. Populated by loadOrchestration() from /api/orchestration.
+       Hidden automatically when no agents exist. -->
+  <div id="orchestration-board" style="margin-bottom:12px;"></div>
   <!-- OpenClaw run-ledger lane monitor (cli / cron / subagent) + recent runs.
        Populated by loadRunLedger() from /api/run-ledger. `runtime` is the
        OpenClaw queue lane, so this is the live queue/concurrency view. -->

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -2027,6 +2027,7 @@ def _try_local_store_subagents(_rows=None):
             "depth":            int(extra.get("depth") or 1),
             "parent":           r.get("parent_session_id") or extra.get("spawnedBy"),
             "totalTokens":      token_count,
+            "costUsd":          round(float(r.get("cost_usd") or 0.0), 4),
             "runtime":          runtime,
             "runtimeMs":        runtime_ms,
             "startedAt":        spawned_at_ms or updated_at_ms,
@@ -2415,6 +2416,29 @@ def _check_integrity(subagents):
             _dfs(key, [])
 
     return violations
+
+
+@bp_sessions.route("/api/orchestration")
+def api_orchestration():
+    """Compact orchestration status board — agent cards with cost and model tags.
+
+    Wraps the subagents DuckDB fast-path (same source as /api/subagents) and
+    adds a per-agent ``costUsd`` field for the status-board panel rendered
+    above the subagent tree. Returns an empty board when the local store is
+    unavailable so the existing tree view still works via its own fallback.
+    """
+    fast = _try_local_store_subagents()
+    agents = (fast or {}).get("subagents", [])
+    counts = (fast or {}).get("counts", {})
+    total_cost_usd = round(sum(a.get("costUsd", 0.0) for a in agents), 4)
+    return jsonify({
+        "agents": agents,
+        "summary": {
+            "total":          counts.get("total", 0),
+            "active":         counts.get("active", 0),
+            "total_cost_usd": total_cost_usd,
+        },
+    })
 
 
 @bp_sessions.route("/api/subagents/integrity")


### PR DESCRIPTION
Closes #591

## Summary

- **New `/api/orchestration` endpoint** (`routes/sessions.py`) — thin wrapper around the existing `_try_local_store_subagents` DuckDB fast-path. Returns `{agents[], summary}` with per-agent status, model, token count, and cost in USD. Also exposes `costUsd` in the existing `/api/subagents` response (the `cost_usd` column from `query_subagents` was already computed via events-join but was previously discarded).
- **Orchestration status board panel** (`templates/tabs/subagents.html` + `static/js/app.js`) — renders one card per agent (coloured status badge, model tag, cost chip, depth badge) above the existing queue-lanes + tree view. Auto-hides when no agents exist so the tree view remains the primary UI at idle. Polled every 5 s on the same interval as the subagent tree.

## Test plan

- [ ] Open Subagents tab with active agents → board renders above the run-ledger panel with one card per agent showing status colour, model, cost
- [ ] Open Subagents tab with no agents → board is empty (no ghost div), tree view loads normally
- [ ] Click ↻ Refresh → board, lanes, and tree all refresh
- [ ] `python3 -c "import ast; ast.parse(open('routes/sessions.py').read())"` — syntax clean
- [ ] `GET /api/orchestration` returns `{agents: [...], summary: {total, active, total_cost_usd}}`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vobu1vv7HiVAVupdLDQRch)_