### PR TITLE
feat(license): add `check_license` dry-run verify + `/api/license/check` + `clawmetry license check`

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2713,8 +2713,46 @@ def _cmd_activate(args) -> None:
 
 
 def _cmd_license(args) -> None:
-    """clawmetry license [activate|status|deactivate] — manage the self-hosted license."""
+    """clawmetry license [activate|status|deactivate|check] — manage the self-hosted license."""
     action = getattr(args, "license_action", None) or "status"
+
+    if action == "check":
+        key = getattr(args, "license_key", None) or ""
+        if not key:
+            print("❌  Usage: clawmetry license check <KEY>")
+            sys.exit(1)
+        from clawmetry import license as _lic
+        info = _lic.check_license(key.strip())
+        status = info.get("status", "error")
+        print("ClawMetry License Check\n" + "─" * 40)
+        if status == "missing":
+            print("  Result:      ❌  no key provided")
+            sys.exit(1)
+        if status == "invalid":
+            print("  Result:      ❌  signature invalid or key unparseable")
+            print("               (the key did not verify against the embedded public key)")
+            sys.exit(1)
+        if status == "error":
+            print("  Result:      ❌  could not verify (see logs)")
+            sys.exit(1)
+        # active or expired — print the parsed metadata either way
+        tier = str(info.get("tier", "pro")).capitalize()
+        print(f"  Plan:        {tier} (self-hosted)")
+        print(f"  Nodes:       {info.get('nodes', 1)}")
+        if info.get("sub"):
+            print(f"  Account:     {info['sub']}")
+        if info.get("days_left") is not None:
+            if status == "expired":
+                print(f"  Expires:     {abs(info['days_left'])} day(s) ago")
+            else:
+                print(f"  Expires:     in {info['days_left']} day(s)")
+        if status == "active":
+            print("  Result:      ✅  VALID — signature verified, not expired")
+            print("               (no changes made — run `clawmetry license activate <KEY>` to install)")
+        else:
+            print("  Result:      ⚠️   EXPIRED — signature verified but past its `exp`")
+            sys.exit(1)
+        return
 
     if action == "activate":
         key = getattr(args, "license_key", None) or ""
@@ -3159,14 +3197,14 @@ def main() -> None:
         "license_action",
         nargs="?",
         default="status",
-        choices=["status", "activate", "deactivate"],
-        help="status (default) | activate <KEY> | deactivate",
+        choices=["status", "activate", "deactivate", "check"],
+        help="status (default) | activate <KEY> | deactivate | check <KEY>",
     )
     p_license.add_argument(
         "license_key",
         nargs="?",
         default=None,
-        help="License key (CLAW1.…) — required for 'activate'",
+        help="License key (CLAW1.…) — required for 'activate' and 'check'",
     )
 
     # verify-integrity — walk hash chain and report validity (Issue #2200)

--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -472,6 +472,56 @@ def activate(key: str, node_id: str | None = None) -> tuple[bool, str]:
     return True, f"Activated {tier} license for {nodes} node(s). {install_status}"
 
 
+def check_license(token: str) -> dict:
+    """Dry-run verify ``token`` and return its would-be license info.
+
+    Pure read-only: never writes the key to disk, never registers a node,
+    never downloads/installs the clawmetry-pro wheel, never invalidates the
+    entitlement cache. Useful for confirming a key parses + verifies before
+    committing it with :func:`activate`, and for support flows that want to
+    inspect a key the operator was sent without storing it.
+
+    Returns a dict with the same shape ``current_license_info()`` uses for an
+    installed license, plus a ``status`` that is one of:
+
+      * ``"missing"`` — token was empty/None
+      * ``"invalid"`` — signature failed, malformed, or unparseable
+      * ``"expired"`` — signature OK but the ``exp`` claim has passed
+      * ``"active"``  — signature OK and not expired
+      * ``"error"``   — something else went wrong (never crashes; falls here)
+
+    Never raises.
+    """
+    import time as _t
+
+    try:
+        tok = (token or "").strip()
+        if not tok:
+            return {"valid": False, "status": "missing"}
+        payload = verify_token(tok)
+        if payload is None:
+            return {"valid": False, "status": "invalid"}
+        exp = payload.get("exp")
+        days_left: int | None = None
+        expired = False
+        if isinstance(exp, (int, float)):
+            days_left = int((exp - _t.time()) // 86400)
+            expired = _t.time() > exp
+        return {
+            "valid": not expired,
+            "status": "expired" if expired else "active",
+            "tier": str(payload.get("tier", "pro")).lower(),
+            "nodes": int(payload.get("nodes", 1) or 1),
+            "sub": payload.get("sub", ""),
+            "exp": exp,
+            "iat": payload.get("iat"),
+            "days_left": days_left,
+        }
+    except Exception as exc:
+        logger.warning("license: check failed: %s", exc)
+        return {"valid": False, "status": "error"}
+
+
 def current_license_info() -> dict | None:
     """Human-readable summary of the installed license, or None if there is no
     valid one. Never raises."""

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -152,6 +152,30 @@ def api_paywall_event():
     return "", 204
 
 
+@bp_entitlement.route("/api/license/check", methods=["POST"])
+def api_license_check():
+    """Dry-run verify a license key WITHOUT writing it to disk.
+
+    Body: ``{"key": "CLAW1.…"}``. Returns the would-be license info — the
+    same shape ``/api/license/status`` reports for an installed license, so
+    a UI can show "this key is valid: Pro, N nodes, expires …" before the
+    user commits it with ``/api/license/activate``.
+
+    Side-effect-free: no license file is created, no node is registered,
+    no wheel is fetched, the entitlement cache is left alone. Always
+    returns 200 — the verification *result* is in the body.
+    """
+    try:
+        body = request.get_json(silent=True) or {}
+        key = str(body.get("key", "")).strip()
+        from clawmetry import license as _lic
+
+        return jsonify(_lic.check_license(key))
+    except Exception as exc:
+        logger.warning("api_license_check: error: %s", exc)
+        return jsonify({"valid": False, "status": "error"})
+
+
 @bp_entitlement.route("/api/license/activate", methods=["POST"])
 def api_license_activate():
     """Activate a self-hosted Pro/Enterprise license key.

--- a/tests/test_cli_license_check.py
+++ b/tests/test_cli_license_check.py
@@ -1,0 +1,176 @@
+"""Tests for the ``clawmetry license check`` subcommand — dry-run license
+verify with no side effects on disk or on the entitlement cache.
+
+Hermetic: each test mints tokens with its own ephemeral keypair and
+monkeypatches the module's embedded public key, so nothing depends on the
+real production signing key.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=10, exp_delta=365 * 86400):
+    now = int(time.time())
+    return {
+        "sub": "acct_test",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes", "alerts", "fleet"],
+    }
+
+
+@pytest.fixture
+def cli_ctx(monkeypatch, tmp_path):
+    import clawmetry.license as L
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(L, "_PUBLIC_KEY_PEM", pub_pem)
+    monkeypatch.setattr(L, "LICENSE_PATH", str(tmp_path / "license.key"))
+    monkeypatch.setattr(L, "_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    return SimpleNamespace(L=L, priv=priv)
+
+
+# ── happy path ────────────────────────────────────────────────────────────────
+
+
+def test_check_valid_pro_key_prints_summary(cli_ctx, capsys):
+    from clawmetry import cli
+
+    tok = cli_ctx.L._encode_token(_payload("pro", nodes=8), cli_ctx.priv)
+    args = SimpleNamespace(license_action="check", license_key=tok)
+    cli._cmd_license(args)
+    out = capsys.readouterr().out
+    assert "Pro" in out
+    assert "8" in out  # nodes
+    assert "VALID" in out
+    assert "no changes made" in out
+
+
+def test_check_valid_enterprise_key(cli_ctx, capsys):
+    from clawmetry import cli
+
+    tok = cli_ctx.L._encode_token(_payload("enterprise", nodes=50), cli_ctx.priv)
+    args = SimpleNamespace(license_action="check", license_key=tok)
+    cli._cmd_license(args)
+    out = capsys.readouterr().out
+    assert "Enterprise" in out
+    assert "50" in out
+    assert "VALID" in out
+
+
+def test_check_surfaces_account_subject(cli_ctx, capsys):
+    from clawmetry import cli
+
+    tok = cli_ctx.L._encode_token(_payload("pro"), cli_ctx.priv)
+    args = SimpleNamespace(license_action="check", license_key=tok)
+    cli._cmd_license(args)
+    out = capsys.readouterr().out
+    assert "acct_test" in out  # subject claim is printed for support flows
+
+
+# ── failure paths ────────────────────────────────────────────────────────────
+
+
+def test_check_with_no_key_exits_nonzero(cli_ctx, capsys):
+    from clawmetry import cli
+
+    args = SimpleNamespace(license_action="check", license_key=None)
+    with pytest.raises(SystemExit) as excinfo:
+        cli._cmd_license(args)
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "Usage" in out
+
+
+def test_check_invalid_signature_exits_nonzero(cli_ctx, capsys):
+    from clawmetry import cli
+
+    args = SimpleNamespace(license_action="check", license_key="CLAW1.not.real")
+    with pytest.raises(SystemExit) as excinfo:
+        cli._cmd_license(args)
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "invalid" in out.lower()
+
+
+def test_check_forged_signature_exits_nonzero(cli_ctx, capsys):
+    from clawmetry import cli
+
+    other_priv, _ = _keypair()
+    tok = cli_ctx.L._encode_token(_payload("pro"), other_priv)
+    args = SimpleNamespace(license_action="check", license_key=tok)
+    with pytest.raises(SystemExit) as excinfo:
+        cli._cmd_license(args)
+    assert excinfo.value.code == 1
+
+
+def test_check_expired_key_exits_nonzero(cli_ctx, capsys):
+    from clawmetry import cli
+
+    tok = cli_ctx.L._encode_token(_payload("pro", exp_delta=-86400), cli_ctx.priv)
+    args = SimpleNamespace(license_action="check", license_key=tok)
+    with pytest.raises(SystemExit) as excinfo:
+        cli._cmd_license(args)
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "EXPIRED" in out
+    # tier is still shown so the operator sees WHICH key expired:
+    assert "Pro" in out
+
+
+# ── no side effects on disk or on the entitlement cache ──────────────────────
+
+
+def test_check_does_not_create_license_file(cli_ctx, capsys):
+    import os
+    from clawmetry import cli
+
+    tok = cli_ctx.L._encode_token(_payload("pro", nodes=3), cli_ctx.priv)
+    args = SimpleNamespace(license_action="check", license_key=tok)
+    cli._cmd_license(args)
+    assert not os.path.isfile(cli_ctx.L.LICENSE_PATH)
+    capsys.readouterr()  # drain
+
+
+def test_check_does_not_flip_resolved_entitlement(cli_ctx, monkeypatch, capsys, tmp_path):
+    """A dry-run check must not move the resolver off OSS-free, even under
+    enforce mode."""
+    import clawmetry.entitlements as e
+    from clawmetry import cli
+
+    monkeypatch.setattr(e, "_LICENSE_PATH", cli_ctx.L.LICENSE_PATH)
+    # Pin the cloud-plan cache to an empty tmp path so a sibling test that
+    # reloaded entitlements with a patched HOME cannot leak a cached plan in.
+    monkeypatch.setattr(e, "_CLOUD_PLAN_CACHE", str(tmp_path / "cloud_plan.json"))
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    e.invalidate()
+    assert e.get_entitlement(force=True).tier == e.TIER_OSS
+
+    tok = cli_ctx.L._encode_token(_payload("pro", nodes=2), cli_ctx.priv)
+    args = SimpleNamespace(license_action="check", license_key=tok)
+    cli._cmd_license(args)
+    capsys.readouterr()
+
+    after = e.get_entitlement(force=True)
+    assert after.tier == e.TIER_OSS  # unchanged

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -353,3 +353,97 @@ def test_pip_install_prefers_pip_when_available(prov, tmp_path, monkeypatch):
     ok, detail = L._pip_install_wheel(str(tmp_path / "any.whl"))
     assert ok and detail == "installed"
     assert called["unzip"] is False  # never fell back
+
+
+# ── check_license (dry-run verify) ─────────────────────────────────────────────
+
+
+def test_check_license_active(lic):
+    tok = lic.L._encode_token(_payload("pro", nodes=7), lic.priv)
+    info = lic.L.check_license(tok)
+    assert info["valid"] is True
+    assert info["status"] == "active"
+    assert info["tier"] == "pro"
+    assert info["nodes"] == 7
+    assert info["sub"] == "acct_test"
+    assert info["days_left"] > 300
+    assert isinstance(info["iat"], int)
+
+
+def test_check_license_enterprise_tier_preserved(lic):
+    tok = lic.L._encode_token(_payload("enterprise", nodes=20), lic.priv)
+    info = lic.L.check_license(tok)
+    assert info["valid"] is True
+    assert info["tier"] == "enterprise"
+    assert info["nodes"] == 20
+
+
+def test_check_license_expired(lic):
+    tok = lic.L._encode_token(_payload("pro", exp_delta=-86400), lic.priv)  # 1 day ago
+    info = lic.L.check_license(tok)
+    assert info["valid"] is False
+    assert info["status"] == "expired"
+    # Metadata is still surfaced so the operator can see WHICH key expired:
+    assert info["tier"] == "pro"
+    assert info["days_left"] < 0
+
+
+def test_check_license_invalid_signature(lic):
+    other_priv, _ = _keypair()
+    tok = lic.L._encode_token(_payload(), other_priv)
+    info = lic.L.check_license(tok)
+    assert info["valid"] is False
+    assert info["status"] == "invalid"
+
+
+@pytest.mark.parametrize("bad", ["", None, "   ", "garbage", "CLAW1.only-two", "NOPE.x.y"])
+def test_check_license_malformed(lic, bad):
+    info = lic.L.check_license(bad)
+    assert info["valid"] is False
+    assert info["status"] in ("missing", "invalid")
+
+
+def test_check_license_no_side_effects(lic):
+    """check_license must NEVER write the license file or trigger the wheel
+    install path, even on a fully valid key."""
+    import os
+
+    tok = lic.L._encode_token(_payload("pro", nodes=5), lic.priv)
+    assert not os.path.isfile(lic.L.LICENSE_PATH)
+    info = lic.L.check_license(tok)
+    assert info["valid"] is True
+    # No file should be written:
+    assert not os.path.isfile(lic.L.LICENSE_PATH)
+
+
+def test_check_license_never_raises(lic, monkeypatch):
+    """Even if the underlying verifier blows up, check_license returns the
+    error shape rather than propagating."""
+    def _boom(_tok):
+        raise RuntimeError("simulated parser failure")
+
+    monkeypatch.setattr(lic.L, "verify_token", _boom)
+    info = lic.L.check_license("CLAW1.anything.here")
+    assert info == {"valid": False, "status": "error"}
+
+
+def test_check_license_does_not_change_entitlement_cache(lic, monkeypatch, tmp_path):
+    """A dry-run check on a valid Pro key must not flip the resolved
+    entitlement — only activate() does that."""
+    import clawmetry.entitlements as e
+
+    monkeypatch.setattr(e, "_LICENSE_PATH", lic.L.LICENSE_PATH)
+    # Pin the cloud-plan cache to an empty tmp path so a sibling test that
+    # reloaded entitlements with a patched HOME cannot leak a cached plan in.
+    monkeypatch.setattr(e, "_CLOUD_PLAN_CACHE", str(tmp_path / "cloud_plan.json"))
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    e.invalidate()
+    before = e.get_entitlement(force=True)
+    assert before.tier == e.TIER_OSS  # no license on disk
+
+    tok = lic.L._encode_token(_payload("pro", nodes=11), lic.priv)
+    info = lic.L.check_license(tok)
+    assert info["valid"] is True
+
+    after = e.get_entitlement(force=True)
+    assert after.tier == e.TIER_OSS  # unchanged

--- a/tests/test_license_api.py
+++ b/tests/test_license_api.py
@@ -168,3 +168,105 @@ def test_deactivate_idempotent_when_no_license(app):
     data = resp.get_json()
     assert data["ok"] is True
     assert data["removed"] is False
+
+
+# ── /api/license/check — dry-run verify, no side effects ──────────────────────
+
+
+def test_check_valid_key(app):
+    import os
+
+    tok = app.lic._encode_token(_payload("pro", nodes=4), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/check",
+            data=json.dumps({"key": tok}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is True
+    assert data["status"] == "active"
+    assert data["tier"] == "pro"
+    assert data["nodes"] == 4
+    # Must NOT have written the license file:
+    assert not os.path.isfile(app.license_path)
+
+
+def test_check_invalid_key(app):
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/check",
+            data=json.dumps({"key": "CLAW1.not.real"}),
+            content_type="application/json",
+        )
+    # Verification result is in the body — not a 4xx:
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["status"] == "invalid"
+
+
+def test_check_expired_key(app):
+    tok = app.lic._encode_token(_payload(exp_delta=-3600), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/check",
+            data=json.dumps({"key": tok}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["status"] == "expired"
+    # Metadata still surfaced so the operator can see WHICH key expired:
+    assert data["tier"] == "pro"
+
+
+def test_check_missing_body(app):
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/check",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["status"] == "missing"
+
+
+def test_check_no_body_at_all(app):
+    """POST with no body must still return 200 + a missing-key shape."""
+    with app.app.test_client() as c:
+        resp = c.post("/api/license/check")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["status"] == "missing"
+
+
+def test_check_does_not_overwrite_installed_license(app):
+    """If a valid license is already installed, /check on a DIFFERENT key must
+    not disturb it."""
+    import os
+
+    installed = app.lic._encode_token(_payload("pro", nodes=2), app.priv)
+    app.lic.activate(installed)
+    assert os.path.isfile(app.license_path)
+    with open(app.license_path) as fh:
+        before = fh.read()
+
+    other = app.lic._encode_token(_payload("enterprise", nodes=99), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/check",
+            data=json.dumps({"key": other}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    assert resp.get_json()["tier"] == "enterprise"
+
+    with open(app.license_path) as fh:
+        after = fh.read()
+    assert before == after  # file untouched


### PR DESCRIPTION
## Summary

Adds a side-effect-free **preview** for license keys: confirm a key parses + verifies + isn't expired *without* committing it. Complements the existing `activate` (which writes the key, registers the node, downloads the wheel) and `status` (which inspects the *installed* key) surfaces.

The three license-shaped surfaces are now symmetric:

| Question | Function | HTTP | CLI |
|----------|----------|------|-----|
| "Is this key I was sent actually valid?" (new) | `check_license(token)` | `POST /api/license/check` | `clawmetry license check <KEY>` |
| "What did the key I installed unlock?" | `current_license_info()` | `GET /api/license/status` | `clawmetry license` |
| "Install this key." | `activate(key)` | `POST /api/license/activate` | `clawmetry license activate <KEY>` / `clawmetry activate <KEY>` |

`check` is the read-only sibling — useful for:
- Support: paste a key into a sandbox to confirm it parses against the embedded public key before sending it to the operator.
- Pre-flight: confirm a key from CI secrets verifies before a job tries to `activate` it.
- Audit: inspect a `CLAW1.…` blob's claims (tier, nodes, sub, exp) without writing it anywhere.

## Changes

- **`clawmetry/license.py`** — `check_license(token: str) -> dict`. Runs `verify_token` + payload extraction. Returns `{valid, status, tier, nodes, sub, exp, iat, days_left}` where `status` ∈ `{missing, invalid, expired, active, error}`. Never raises; never writes; never triggers the wheel install path; never touches the entitlement cache.

- **`routes/entitlement.py`** — `POST /api/license/check`. Reads `{"key": "CLAW1.…"}`, calls `check_license`, returns the dict. Always 200 — the verification *result* is the body, never a 4xx. Per-route never-raise fallback returns `{valid: false, status: "error"}`.

- **`clawmetry/cli.py`** — extends `_cmd_license` with the `check` action. Adds `check` to `license_action` argparse choices. Prints a human-readable summary; exits 1 on `missing` / `invalid` / `expired` / `error` so shell scripts can branch on the result.

- **`tests/test_license.py`** — 8 new unit tests covering the active/expired/invalid/forged/malformed/empty paths, the no-side-effects invariant (no file written), the never-raise contract (monkeypatched `verify_token` that throws), and that a `check` on a valid Pro key does NOT flip the resolved entitlement off OSS-free.

- **`tests/test_license_api.py`** — 6 new route tests: valid key, invalid key, expired key, missing body, no body at all (still 200), and that `check` on a different key does NOT overwrite the currently-installed license file.

- **`tests/test_cli_license_check.py`** (new) — 9 CLI tests covering the happy path (Pro + Enterprise), subject claim surfaced for support, no-key/usage error, invalid signature, forged signature, expired key (exits 1, prints `EXPIRED`), and the two no-side-effect invariants (no file written, no entitlement flip).

## Response shapes

```jsonc
// Valid Pro key
{"valid": true, "status": "active", "tier": "pro", "nodes": 5,
 "sub": "acct_abc", "exp": 1781234567, "iat": 1749698567,
 "days_left": 320}

// Expired but signature-valid — metadata still surfaced so the operator can
// see WHICH key expired
{"valid": false, "status": "expired", "tier": "pro", "nodes": 5,
 "sub": "acct_abc", "exp": 1700000000, "iat": ..., "days_left": -120}

// Signature failed / malformed / tampered
{"valid": false, "status": "invalid"}

// Empty body
{"valid": false, "status": "missing"}

// Unexpected error (never-crash fallback)
{"valid": false, "status": "error"}
```

## Sample CLI output

```text
$ clawmetry license check CLAW1.eyJzdWI...
ClawMetry License Check
────────────────────────────────────────
  Plan:        Pro (self-hosted)
  Nodes:       5
  Account:     acct_abc
  Expires:     in 320 day(s)
  Result:      ✅  VALID — signature verified, not expired
               (no changes made — run `clawmetry license activate <KEY>` to install)
```

```text
$ clawmetry license check CLAW1.bogus
ClawMetry License Check
────────────────────────────────────────
  Result:      ❌  signature invalid or key unparseable
               (the key did not verify against the embedded public key)
$ echo $?
1
```

## No behavior change

This PR is purely additive. No `__version__` bump. No `[RELEASE]` PR. No enforcement gate. Grace mode is preserved end-to-end. The existing `activate` / `status` / `deactivate` flows are unchanged.

## Test plan

- [x] `python3 -m pytest tests/test_license.py tests/test_license_api.py tests/test_cli_license_check.py -q` — **59/59 pass**
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_extensions.py tests/test_license.py tests/test_license_api.py tests/test_cli_license_check.py -q` — **110/110 pass** (no regression in adjacent surfaces)
- [x] Filtered `pytest -k "license or entitle or extension"` across the repo (excluding DuckDB-dependent collections) — **117/117 pass**, the one error is an unrelated DuckDB import in `test_retention_prune.py`
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py clawmetry/cli.py tests/test_license.py tests/test_license_api.py tests/test_cli_license_check.py` — clean
- [x] Confirmed the cross-test-file pollution path (a sibling test that reloads `entitlements` with a patched HOME leaves `_CLOUD_PLAN_CACHE` pointing at a stale tmp_path) is handled by also pinning `_CLOUD_PLAN_CACHE` in the two no-flip tests.

## Local operator verification checklist

I cannot reach your local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please complete on a real install:

1. `cp clawmetry/license.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/license.py`
2. `cp clawmetry/cli.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/cli.py`
3. `cp routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/routes/entitlement.py`
4. `rm -f ~/.clawmetry/lib/python3.11/site-packages/clawmetry/__pycache__/license*.pyc ~/.clawmetry/lib/python3.11/site-packages/clawmetry/__pycache__/cli*.pyc ~/.clawmetry/lib/python3.11/site-packages/routes/__pycache__/entitlement*.pyc`
5. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` and restart the dashboard if it's running
6. `~/.clawmetry/bin/clawmetry license check` (no key) — should print "Usage" and exit 1
7. `~/.clawmetry/bin/clawmetry license check CLAW1.bogus.bogus` — should print "signature invalid" and exit 1
8. `~/.clawmetry/bin/clawmetry license check $(cat ~/.clawmetry/license.key)` — with a real installed key, should print the parsed metadata + ✅ VALID
9. Confirm `ls -l ~/.clawmetry/license.key` mtime is unchanged after step 8 — `check` MUST NOT touch the file
10. Confirm `curl -s http://localhost:8900/api/entitlement | jq .tier` is unchanged after step 8 — `check` MUST NOT flip the resolved entitlement
11. `curl -s -X POST http://localhost:8900/api/license/check -H "Content-Type: application/json" -d '{"key":"CLAW1.bogus"}' | jq` — should return `{"valid": false, "status": "invalid"}` with HTTP 200
12. `curl -s -X POST http://localhost:8900/api/license/check -H "Content-Type: application/json" -d "{\"key\":\"$(cat ~/.clawmetry/license.key | tr -d '\n')\"}" | jq` — should return `{"valid": true, "status": "active", ...}` with the parsed metadata
13. Decrypt the live cloud snapshot to confirm no daemon-side regression — this PR is dashboard + CLI only; no daemon code is touched; snapshot shape is unchanged
14. Browser check: load the dashboard, confirm `/api/license/check` is reachable from the network panel; no UI is wired up in this PR so there is nothing visual to verify yet

This PR is **draft-only**: I am not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Grace mode stays on. Once you have run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3c4FD7uC2dSqMFLzohBaS)_