### PR TITLE
[RELEASE] entitled accounts keep the node current automatically

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1032,6 +1032,39 @@ _HEARTBEAT_PLAN_TO_TIER = {
 }
 
 
+def _sync_auto_update_with_plan(tier: str | None) -> None:
+    """Entitled accounts (Trial / Starter / Pro / Enterprise) keep the node
+    current automatically: enable the opt-in ``auto_update`` flag so the
+    daemon's update-check worker installs new releases (riding the 48h
+    staleness rail). This is what makes "I'm on Pro, the node should just stay
+    current" real without a manual ``pip install -U``.
+
+    Safety: respects an explicit opt-out (``CLAWMETRY_AUTO_UPDATE`` in
+    0/false/no/off), only ever ENABLES (never auto-disables, so a user's manual
+    choice survives a downgrade), and no-ops for free / inactive plans. Best
+    effort — never raises."""
+    try:
+        if not tier or tier == "cloud_free":
+            return
+        _ov = os.environ.get("CLAWMETRY_AUTO_UPDATE", "").strip().lower()
+        if _ov in ("0", "false", "no", "off"):
+            return
+        from routes.update_check import (
+            _get_update_check_config as _gucc,
+            _set_update_check_config as _succ,
+        )
+        cfg = _gucc() or {}
+        if not cfg.get("auto_update"):
+            _succ({"auto_update": True})
+            log.info(
+                "auto-update enabled for entitled plan (%s) — this node will keep "
+                "itself current (48h stability window). Opt out any time with "
+                "CLAWMETRY_AUTO_UPDATE=0.", tier,
+            )
+    except Exception as exc:
+        log.debug("auto-update plan sync skipped: %s", exc)
+
+
 def _persist_cloud_plan_to_disk(plan: str | None, trial_days_left=None) -> None:
     """Mirror the heartbeat plan into ``~/.clawmetry/cloud_plan.json`` so the
     dashboard process (which runs ``clawmetry.entitlements.get_entitlement``)
@@ -1043,6 +1076,8 @@ def _persist_cloud_plan_to_disk(plan: str | None, trial_days_left=None) -> None:
     is removed instead of written, so the resolver falls back to OSS-free
     rather than granting a dead plan."""
     tier = _HEARTBEAT_PLAN_TO_TIER.get(str(plan or "").strip().lower())
+    # Entitled plan → keep this node current automatically (opt-out + 48h rail).
+    _sync_auto_update_with_plan(tier)
     try:
         if tier is None:
             if os.path.isfile(_CLOUD_PLAN_CACHE_PATH):

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -93,3 +93,32 @@ def test_auto_update_unknown_age_does_not_block(monkeypatch):
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=None)
     assert calls == ["auto"], "unknown age must not block (back-compat)"
+
+
+def test_entitled_plan_enables_auto_update(monkeypatch):
+    import clawmetry.sync as S
+    import routes.update_check as uc
+    state = {"auto_update": False}
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: dict(state))
+    monkeypatch.setattr(uc, "_set_update_check_config", lambda upd: state.update(upd))
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    # free / inactive → unchanged
+    S._sync_auto_update_with_plan("cloud_free"); assert state["auto_update"] is False
+    S._sync_auto_update_with_plan(None);         assert state["auto_update"] is False
+    # entitled → enabled
+    S._sync_auto_update_with_plan("trial");      assert state["auto_update"] is True
+    S._sync_auto_update_with_plan("cloud_pro");  assert state["auto_update"] is True
+
+
+def test_entitled_plan_respects_optout_and_never_disables(monkeypatch):
+    import clawmetry.sync as S
+    import routes.update_check as uc
+    state = {"auto_update": False}
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: dict(state))
+    monkeypatch.setattr(uc, "_set_update_check_config", lambda upd: state.update(upd))
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "0")
+    S._sync_auto_update_with_plan("cloud_pro");  assert state["auto_update"] is False  # opt-out
+    # never auto-DISABLES a user's manual choice on downgrade
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    state["auto_update"] = True
+    S._sync_auto_update_with_plan("cloud_free"); assert state["auto_update"] is True


### PR DESCRIPTION
## What
Closes the loop on *"when the user is on Trial/Starter/Pro, the node should just stay current."* When the cloud heartbeat reports an **entitled** plan, the daemon now enables the opt-in `auto_update` flag, so the node keeps the `clawmetry` package current on its own — no manual `pip install -U`.

Fires from the existing plan-change path (`_persist_cloud_plan_to_disk` ← `_update_trial_state` ← heartbeat), so **no cloud change is needed**.

## Fully de-risked + reversible
- **48h staleness rail** (0.12.416) — never installs a brand-new (possibly broken) release unattended;
- runs through the **daemon update-worker** (0.12.415) so it works on headless nodes;
- **only ever ENABLES** — never auto-disables, so a user's manual choice survives a downgrade; free/inactive plans no-op;
- **opt out any time** with `CLAWMETRY_AUTO_UPDATE=0`.

Together with pro auto-provision (0.12.414): an entitled node self-installs `clawmetry-pro` **and** stays current — Claude Code / Codex / … just show up. Pairs with the Fleet per-runtime cards (#1333) and the update hint (#1335).

## Test
`test_auto_update.py`: entitled enables; free/none/opt-out don't; never disables on downgrade — 8 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)