### PR TITLE
[RELEASE] report pro_version + auto_update in node heartbeat

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5330,6 +5330,21 @@ def _build_node_meta() -> dict:
         meta["local_ips"] = sorted(_ips)[:8]
     except Exception:
         pass
+    # Pro-adapter + auto-update status so the cloud Fleet can show whether an
+    # entitled node is actually running clawmetry-pro (the paid runtime
+    # adapters) and keeping itself current — turning the "I'm on Pro but Claude
+    # Code isn't showing" guesswork into a visible state on the node card.
+    try:
+        from clawmetry.license import _pro_installed_version as _pv
+        _pver = _pv()
+        meta["pro_version"] = str(_pver) if _pver else ""
+    except Exception:
+        pass
+    try:
+        from routes.update_check import _get_update_check_config as _gucc
+        meta["auto_update"] = bool((_gucc() or {}).get("auto_update"))
+    except Exception:
+        pass
     return meta
 
 


### PR DESCRIPTION
Adds `pro_version` (installed clawmetry-pro version, `""` when absent) + `auto_update` (the opt-in flag) to `_build_node_meta`, so the cloud Fleet can show whether an entitled node is actually running the Pro adapters and staying current — the precise version of the #1335 update hint. Best-effort, never blocks the heartbeat. Cloud extract + Fleet-card display lands in a follow-up cloud PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)