### PR TITLE
feat(runtime): tab-local ?runtime= URL pin (enables per-runtime tabs)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7523,11 +7523,36 @@ function _cmRuntimeOf(o) {
   }
   return 'openclaw';
 }
+// The active runtime filter. A `?runtime=<id>` URL param takes precedence over
+// the localStorage value and is TAB-LOCAL: localStorage is shared across all
+// tabs of an origin, so without this a Fleet "open <runtime> in a new tab" would
+// have every tab fight over one shared key. Pinning via the URL lets you open
+// Claude Code in one tab and Codex in another, each independent.
+function _cmRuntimeFilterUrlPin() {
+  try {
+    var p = new URLSearchParams(window.location.search);
+    if (p.has('runtime')) { var v = p.get('runtime'); if (v) return v; }
+  } catch (e) {}
+  return null;
+}
 function _cmRuntimeFilter() {
+  var pin = _cmRuntimeFilterUrlPin();
+  if (pin) return pin;
   try { return localStorage.getItem('cm-runtime-filter') || 'all'; } catch (e) { return 'all'; }
 }
 function _cmSetRuntimeFilter(v, reload) {
-  try { localStorage.setItem('cm-runtime-filter', v); } catch (e) {}
+  // If this tab is URL-pinned to a runtime, keep the selection tab-local by
+  // updating the URL param (not the shared localStorage key) so sibling tabs
+  // stay on their own runtime.
+  if (_cmRuntimeFilterUrlPin() !== null) {
+    try {
+      var u = new URL(window.location.href);
+      u.searchParams.set('runtime', v);
+      window.history.replaceState(null, '', u.toString());
+    } catch (e) {}
+  } else {
+    try { localStorage.setItem('cm-runtime-filter', v); } catch (e) {}
+  }
   if (typeof reload === 'function') reload();
 }
 function _cmRuntimeLabel(rt) { return _CM_RT_LABEL[rt] || rt; }


### PR DESCRIPTION
## Why
The global runtime filter lived only in `localStorage['cm-runtime-filter']` — **shared across every tab** of the origin. That makes "open `<runtime>` in its own tab" impossible: opening Claude Code in one tab and Codex in another fights over one shared key (last-write-wins), so both tabs show the same runtime.

## What
A `?runtime=<id>` URL param that takes precedence over localStorage and is **tab-local**:
- `_cmRuntimeFilter()` prefers the URL pin.
- `_cmSetRuntimeFilter()` updates the URL param (`history.replaceState`) instead of localStorage when the tab is pinned, so switching runtime in a pinned tab stays in that tab; sibling tabs keep their own runtime.
- Tabs with no `?runtime=` behave exactly as before.

The switcher dropdown already renders `sel.value` from `_cmRuntimeFilter()`, so a pinned tab shows the right runtime selected with no extra wiring.

This is the primitive behind the cloud Fleet **per-runtime cards** (clawmetry-cloud PR): click a synced runtime chip → opens the node view scoped to that runtime in a new tab. One tab per runtime, each independent.

## Verified
7 assertions (node): url-pin beats localStorage; pinned switch updates URL not localStorage; unpinned tab reads+writes localStorage and never touches the URL. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)