### PR TITLE
[RELEASE] per-runtime tabs + pip-less pro provisioning + release-flake fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Release: per-runtime Fleet tabs + pip-less pro provisioning (carries #2548, #2551) + release-flake fix (2026-06-03)
+- **Per-runtime tabs:** the global runtime filter now honours a tab-local `?runtime=<id>` URL param (overrides the shared `localStorage` key). This lets the cloud Fleet open each synced runtime in its own browser tab — Claude Code in one, Codex in another — each independent. `_cmRuntimeFilter()` prefers the URL pin; `_cmSetRuntimeFilter()` updates the URL (not localStorage) in a pinned tab. (#2551)
+- **Pip-less pro provisioning:** the daemon venv (`~/.clawmetry/bin/python3`) often has no `pip`, so `auto_provision_pro` failed forever with `No module named pip` and paid runtimes never installed on entitled accounts. The installer now does `pip → ensurepip → unzip the (pure-Python --no-deps) wheel into site-packages`, so it always succeeds. Also fixed the wrong `clawmetry status` hint (it suggested `pip install clawmetry-pro`, which is closed-source + needs no pip). (#2548)
+- **Release-flake fix:** a third-party DoubleClick/Google-Ads pixel returning 400 false-failed the cloud-contract release gate (`zero unexpected JS errors`). Added ad/measurement domains to `isHarmlessConsoleError` so third-party beacons we don't control can't block a publish.
+- **Verified:** OSS CI matrix green; pip-less install proven live on a real pip-less daemon venv (synced 10 runtimes / 45945 events to the Fleet); 7 URL-pin assertions + 3 install-fallback unit tests.
+
+
 ### Release: provision clawmetry-pro into pip-less daemon venvs (carries #2548) (2026-06-03)
 - **Why:** the cloud sync daemon runs from `~/.clawmetry/bin/python3`, a venv that on many installs has no `pip` (sometimes no `ensurepip`). `auto_provision_pro` shelled to `python -m pip install <wheel>` and failed every cycle with `No module named pip` — so on entitled (Trial/Pro) accounts the paid runtime adapters (Claude Code, Codex, Cursor, Aider, Goose, opencode, Qwen, …) downloaded but never installed and stayed locked in the Fleet despite a valid entitlement.
 - **What:** `clawmetry-pro` is a pure-Python `--no-deps` wheel (a zip), so the installer is now resilient: `pip install → ensurepip+retry → unzip wheel into site-packages`. The unzip fallback writes the `.dist-info` so both `import` and `importlib.metadata.version` resolve it on the daemon's next start. Also fixed the `clawmetry status` hint that wrongly suggested `pip install clawmetry-pro` (closed-source, served via `/api/license/download`, not PyPI).

--- a/tests/e2e/cloud-contract.mjs
+++ b/tests/e2e/cloud-contract.mjs
@@ -68,6 +68,12 @@ function isHarmlessConsoleError(e) {
     /Unexpected string/.test(e) ||
     (/\/api\/skills/.test(e) && /\b410\b/.test(e)) ||
     /posthog|clarity|analytics|gtag/i.test(e) ||
+    // Third-party ad/measurement pixels we don't control: Google Tag Manager
+    // fires DoubleClick / Google Ads conversion beacons that intermittently
+    // 4xx (ad blockers, consent state, Google-side throttling). These are not
+    // ClawMetry resources and must not gate a release. (A DoubleClick 400
+    // false-failed the 0.12.423 release — 59 passed, 1 failed on an ad pixel.)
+    /doubleclick\.net|googletagmanager\.com|google-analytics\.com|googleadservices|googlesyndication|\/ccm\/|\/collect\b/i.test(e) ||
     // TEMPORARY (revert after cloud is on clawmetry==0.12.167+):
     // Live cloud still serves OSS 0.12.166's broken app.js (PR #753
     // shipped a missing `}`, fixed in PR #1019). Until cloud's


### PR DESCRIPTION
Cuts a PyPI release carrying changes already merged to main, plus a release-gate hardening so the publish actually succeeds this time.

## Carries
- **#2548** — pip-less clawmetry-pro provisioning (`pip → ensurepip → unzip wheel`). Verified live: a real pip-less daemon venv now installs the pack and synced 10 runtimes / 45945 events to the Fleet.
- **#2551** — tab-local `?runtime=` URL pin (enables per-runtime Fleet tabs; pairs with clawmetry-cloud #1350).

## Also fixes the release flake that blocked 0.12.423
The previous release failed the cloud-contract gate on `zero unexpected JS errors` — caused by a **third-party DoubleClick/Google-Ads pixel returning 400** (`ad.doubleclick.net/ccm/s/collect`), not a ClawMetry error (59 passed, 1 failed on an ad beacon). Added ad/measurement domains (`doubleclick.net`, `googletagmanager.com`, `google-analytics.com`, `/ccm/`, `/collect`) to `isHarmlessConsoleError`. Verified: the exact failing string is now filtered, while a real app.js error is still flagged (not over-filtered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)