### PR TITLE
feat(sync): CLAWMETRY_FAMILY_SESSION_LIMIT — configurable family-runtime ingest depth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ OPENCLAW_GATEWAY_TOKEN=token           # Gateway auth token
 CLAWMETRY_PROVIDER=local|turso         # Data backend (default: local)
 CLAWMETRY_INTERCEPT=1                  # Enable HTTP interceptor
 CLAWMETRY_FLEET_KEY=...               # Multi-node fleet auth key
+CLAWMETRY_FAMILY_SESSION_LIMIT=50      # Max sessions/runtime to ingest for Claude Code/Codex/Cursor/… (most-recent N; raise for deeper history)
 DEBUG=1                                # Enable debug logging
 ```
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -294,6 +294,17 @@ BATCH_SIZE = (
 MAX_EVENTS_PER_CYCLE = (
     5000  # cap per sync cycle so initial sync doesn't block the main loop
 )
+# How many sessions per family runtime (Claude Code / Codex / Cursor / …) to
+# ingest — the MOST-RECENT N. Default 50 keeps storage + initial-sync payload
+# bounded (a machine with 1000s of historical Claude Code sessions would
+# otherwise push a huge one-time ingest). Power users who want deeper history
+# can raise it via CLAWMETRY_FAMILY_SESSION_LIMIT. Floored at 1, never crashes
+# on a bad value.
+def _family_session_limit() -> int:
+    try:
+        return max(1, int(os.environ.get("CLAWMETRY_FAMILY_SESSION_LIMIT", "50")))
+    except (TypeError, ValueError):
+        return 50
 
 CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 log = logging.getLogger("clawmetry-sync")
@@ -8975,7 +8986,7 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
             if not adapter.detect().detected:
                 continue
             runtime = adapter.name
-            for s in adapter.list_sessions(limit=50):
+            for s in adapter.list_sessions(limit=_family_session_limit()):
                 if runtime == "claude_code" and s.id in openclaw_spawned_claude:
                     continue  # owned by OpenClaw; avoid the double-count
                 ns_id = f"{runtime}:{s.id}"

--- a/tests/test_sync_family_session_limit.py
+++ b/tests/test_sync_family_session_limit.py
@@ -1,0 +1,39 @@
+"""Regression test for the configurable family-runtime session-ingest cap.
+
+Family runtimes (Claude Code / Codex / Cursor / …) ingest the N most-recent
+sessions per runtime. The default is 50 to bound storage + initial-sync payload
+on machines with thousands of historical sessions; CLAWMETRY_FAMILY_SESSION_LIMIT
+lets power users raise it. The parse must floor at 1 and never crash on a bad
+value (the daemon must not die on a typo'd env var).
+"""
+
+import importlib
+
+import clawmetry.sync as sync
+
+
+def _limit(monkeypatch, value):
+    if value is None:
+        monkeypatch.delenv("CLAWMETRY_FAMILY_SESSION_LIMIT", raising=False)
+    else:
+        monkeypatch.setenv("CLAWMETRY_FAMILY_SESSION_LIMIT", value)
+    return sync._family_session_limit()
+
+
+def test_default_is_50(monkeypatch):
+    assert _limit(monkeypatch, None) == 50
+
+
+def test_env_override(monkeypatch):
+    assert _limit(monkeypatch, "300") == 300
+
+
+def test_floored_at_one(monkeypatch):
+    # 0 / negative would ingest nothing or break the adapter — floor at 1.
+    assert _limit(monkeypatch, "0") == 1
+    assert _limit(monkeypatch, "-5") == 1
+
+
+def test_bad_value_falls_back_to_default(monkeypatch):
+    assert _limit(monkeypatch, "abc") == 50
+    assert _limit(monkeypatch, "") == 50


### PR DESCRIPTION
Family runtimes ingested a hardcoded 50 most-recent sessions per runtime, so a machine with e.g. 1250 Claude Code sessions only surfaced 50. Adds `CLAWMETRY_FAMILY_SESSION_LIMIT` (default **unchanged at 50** — storage/payload stay bounded by default; opt in to deeper history). Floors at 1, never crashes on a bad value. 4 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)