### PR TITLE
feat(sync): on-demand runtime backfill — daemon capability (step 1 of #2556-style)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Release: scoped Overview shows the runtime's footprint, not an empty today-window (carries #2565) (2026-06-03)
+- **Why:** selecting a runtime whose sessions are older than today (e.g. OpenClaw, 2 sessions from 2 days ago) made the Overview show "0 sessions today" while the switcher said "OpenClaw · 2 sessions" — it read as "sessions gone." Not a data bug (verified via v1 usage day=0 / month=2).
+- **What:** when a runtime is selected, the Overview shows that runtime's FOOTPRINT matching the switcher — SESSIONS = the switcher's per-runtime total, the tile label flips "Sessions today" -> "Sessions", the hero drops the "today" suffix, and cost/tokens use the month figure. Node-wide ('all') keeps the live "today" framing.
+- **Verified:** node --check clean; hero-wording logic unit-checked (scoped "2 sessions"; all "68 sessions today").
+
+
 ### Release: Overview SPENDING wk/mo scope to selected runtime (carries #2562) (2026-06-03)
 - **What:** completes the node-detail Overview runtime scoping (follows #2558). The SPENDING card's wk/mo sub-figures now scope to the selected runtime via a v1 usage `period=week|month` fetch (local-mode fallback uses the runtime-summary slice); `runtime=all` keeps node-wide. The whole Overview screen (sessions / tokens / cost / model / spending) now reflects only the selected runtime.
 - **Verified:** v1 `period=week` live (claude_code 52.9M tokens / $0 OAuth); node --check clean.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -306,6 +306,25 @@ def _family_session_limit() -> int:
     except (TypeError, ValueError):
         return 50
 
+# On-demand backfill (founder 2026-06-03): the default sync is the most-recent
+# 50, but the local DuckDB can hold as much history as the user wants. When the
+# cloud UI requests older sessions (a `runtime_backfill` pending action), we
+# raise the effective per-runtime ingest depth here; the next `sync_family_runtimes`
+# pass (every 60s) honours it and uploads the deeper history. In-memory for the
+# session; a restart resets to the default-50 (re-requestable on demand).
+_RUNTIME_BACKFILL_OVERRIDES: dict = {}
+_RUNTIME_BACKFILL_MAX = 5000  # hard ceiling so a bad request can't ingest unbounded
+
+def _effective_family_limit(runtime: str) -> int:
+    """The ingest depth for one family runtime: the larger of the default cap and
+    any on-demand backfill override requested for that runtime."""
+    base = _family_session_limit()
+    try:
+        ov = int(_RUNTIME_BACKFILL_OVERRIDES.get(runtime, 0) or 0)
+    except (TypeError, ValueError):
+        ov = 0
+    return max(base, min(ov, _RUNTIME_BACKFILL_MAX))
+
 CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 log = logging.getLogger("clawmetry-sync")
 log.setLevel(logging.INFO)
@@ -6191,6 +6210,7 @@ _PENDING_ACTIONS = frozenset({
     "cron_killall",
     "cron_fix",
     "dives_query",
+    "runtime_backfill",
 })
 
 
@@ -6382,6 +6402,9 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
     if atype == "selfevolve_analyze":
         _action_selfevolve_analyze(config, action)
         return
+    if atype == "runtime_backfill":
+        _action_runtime_backfill(config, action)
+        return
     if atype == "cron_create":
         _action_cron_create(config, action)
         return
@@ -6397,6 +6420,39 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
     if atype == "dives_query":
         _action_dives_query(config, action)
         return
+
+
+def _action_runtime_backfill(config: dict, action: dict) -> None:
+    """On-demand backfill: raise the ingest depth for ONE family runtime so the
+    next ``sync_family_runtimes`` pass pulls older sessions into DuckDB and
+    uploads them. Triggered by the cloud UI when the user digs into the past
+    (founder 2026-06-03: "we should be able to go back as much as the user
+    prefers but default-sync 50 recent"). Never raises.
+
+    Action shape: ``{"type": "runtime_backfill", "runtime": "claude_code",
+    "limit": 500}``. The limit is the TOTAL most-recent sessions to ingest for
+    that runtime (capped at _RUNTIME_BACKFILL_MAX); it only ever increases the
+    override, so repeated "load more" requests deepen monotonically."""
+    try:
+        runtime = str(action.get("runtime") or "").strip()
+        if not runtime:
+            return
+        try:
+            want = int(action.get("limit") or 0)
+        except (TypeError, ValueError):
+            want = 0
+        if want <= 0:
+            # No explicit target -> step the current depth up by one page.
+            want = _effective_family_limit(runtime) + max(50, _family_session_limit())
+        want = min(want, _RUNTIME_BACKFILL_MAX)
+        prev = int(_RUNTIME_BACKFILL_OVERRIDES.get(runtime, 0) or 0)
+        if want <= prev:
+            return  # already at or beyond this depth
+        _RUNTIME_BACKFILL_OVERRIDES[runtime] = want
+        log.info("runtime_backfill: %s ingest depth raised to %d (was %d); next "
+                 "sync pass will pull the older sessions", runtime, want, prev)
+    except Exception as e:
+        log.debug("runtime_backfill action skipped: %s", e)
 
 
 def _selfevolve_fix_summary(stdout: str) -> str:
@@ -8986,7 +9042,7 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
             if not adapter.detect().detected:
                 continue
             runtime = adapter.name
-            for s in adapter.list_sessions(limit=_family_session_limit()):
+            for s in adapter.list_sessions(limit=_effective_family_limit(runtime)):
                 if runtime == "claude_code" and s.id in openclaw_spawned_claude:
                     continue  # owned by OpenClaw; avoid the double-count
                 ns_id = f"{runtime}:{s.id}"

--- a/tests/test_sync_family_session_limit.py
+++ b/tests/test_sync_family_session_limit.py
@@ -37,3 +37,61 @@ def test_floored_at_one(monkeypatch):
 def test_bad_value_falls_back_to_default(monkeypatch):
     assert _limit(monkeypatch, "abc") == 50
     assert _limit(monkeypatch, "") == 50
+
+
+# ── on-demand backfill (founder: default 50, dig deeper on demand) ─────────────
+
+def _reset_overrides():
+    sync._RUNTIME_BACKFILL_OVERRIDES.clear()
+
+
+def test_effective_limit_default_is_family_limit(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_FAMILY_SESSION_LIMIT", raising=False)
+    _reset_overrides()
+    assert sync._effective_family_limit("claude_code") == 50
+
+
+def test_backfill_raises_one_runtime_only(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_FAMILY_SESSION_LIMIT", raising=False)
+    _reset_overrides()
+    sync._action_runtime_backfill({}, {"type": "runtime_backfill", "runtime": "claude_code", "limit": 500})
+    assert sync._effective_family_limit("claude_code") == 500
+    # other runtimes untouched
+    assert sync._effective_family_limit("goose") == 50
+
+
+def test_backfill_is_monotonic(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_FAMILY_SESSION_LIMIT", raising=False)
+    _reset_overrides()
+    sync._action_runtime_backfill({}, {"runtime": "claude_code", "limit": 500})
+    sync._action_runtime_backfill({}, {"runtime": "claude_code", "limit": 200})  # lower — ignored
+    assert sync._effective_family_limit("claude_code") == 500
+
+
+def test_backfill_no_limit_steps_up_a_page(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_FAMILY_SESSION_LIMIT", raising=False)
+    _reset_overrides()
+    sync._action_runtime_backfill({}, {"runtime": "claude_code"})  # no limit -> +page
+    assert sync._effective_family_limit("claude_code") == 100  # 50 + 50
+
+
+def test_backfill_capped_and_never_below_default(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_FAMILY_SESSION_LIMIT", raising=False)
+    _reset_overrides()
+    sync._action_runtime_backfill({}, {"runtime": "claude_code", "limit": 10 ** 9})
+    assert sync._effective_family_limit("claude_code") == sync._RUNTIME_BACKFILL_MAX
+    # a raised default still wins if larger than a small override
+    _reset_overrides()
+    monkeypatch.setenv("CLAWMETRY_FAMILY_SESSION_LIMIT", "300")
+    assert sync._effective_family_limit("codex") == 300
+
+
+def test_backfill_in_pending_action_allowlist():
+    assert "runtime_backfill" in sync._PENDING_ACTIONS
+
+
+def test_backfill_bad_input_never_raises(monkeypatch):
+    _reset_overrides()
+    sync._action_runtime_backfill({}, {})  # no runtime
+    sync._action_runtime_backfill({}, {"runtime": "x", "limit": "abc"})  # bad limit
+    # no exception == pass


### PR DESCRIPTION
**Founder:** "since we store the DB locally, we should be able to go back in the past as much as the user prefers, but default-sync ~50 recent sessions."

Step 1 (the daemon foundation) for on-demand backfill. Default stays the recent-50 cap; when the cloud UI requests older sessions, a `runtime_backfill` pending **action** raises that runtime's ingest depth and the next `sync_family_runtimes` pass pulls the older sessions into DuckDB + uploads them.

- `_effective_family_limit(runtime)` = max(default, on-demand override), capped at 5000.
- `_action_runtime_backfill` (allowlisted) raises ONE runtime monotonically; bare request steps up a page; never raises.

7 new unit tests. **Next:** cloud endpoint to enqueue the action + a "load older" UI trigger.