### PR TITLE
feat(node-view): per-runtime tab visibility (grounded, replaces blanket hide)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7648,26 +7648,48 @@ var _CM_RT_NODEWIDE = {
   alerts: 1, policy: 1, nemoclaw: 1, notifications: 1, dives: 1,
   'version-impact': 1, clusters: 1, logs: 1, actions: 1
 };
-// Tabs ONLY meaningful for the OpenClaw runtime family (OpenClaw + NemoClaw).
-// Memory reads ~/.openclaw/workspace/*.md; Skills/Self-Evolve/Crons/Tool-Policy/
-// NeMo are OpenClaw-gateway concepts. For a non-OpenClaw runtime (Claude Code,
-// Codex, …) they show OpenClaw's data, not that runtime's — pure cognitive load.
-// HIDE them when such a runtime is selected, instead of an "it's node-wide"
-// apology banner (founder 2026-06-03: "why have tabs not relevant to a runtime").
-var _CM_RT_OPENCLAW_ONLY = {
-  memory: 1, skills: 1, selfevolve: 1, crons: 1, policy: 1, nemoclaw: 1
+// Per-runtime sidebar tab visibility — HIDE the tabs a runtime can't populate,
+// so each runtime gets the leanest sensible sidebar (founder 2026-06-03: "have
+// minimal tabs for each runtime that make sense"). Derived from a per-runtime
+// adapter-capability analysis (which fields each adapter emits: tool_call /
+// reasoning / cron / memory / skill / cache-tokens), corrected from the raw
+// workflow output (which over-hid models/cost/brain for some). Values = data-tab
+// names to HIDE. A tab NOT listed is shown. Unknown runtime / 'all' => show
+// everything (never silently drop a tab on an unmapped runtime). overview /
+// models / cost / context / alerts / notifications / security stay everywhere
+// (universal: every runtime has tokens+cost+model; alerts/notifications/security
+// are node/account-level).
+var _CM_RT_TAB_VISIBILITY = {
+  // OpenClaw = reference (full); NeMo tab + context-economics (no cache fields) hidden.
+  openclaw:    ['nemoclaw', 'context-economics'],
+  // NemoClaw = light NeMo-toolkit wrapper, NOT full OpenClaw: no gateway/crons/memory/skills/policy.
+  nemoclaw:    ['flow','tracing','context-economics','approvals','dives','crons','memory','policy','skills','selfevolve'],
+  claude_code: ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
+  codex:       ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
+  cursor:      ['flow','approvals','context-economics','memory','policy','skills','selfevolve','nemoclaw'], // keeps crons (cursor has a cron signal)
+  aider:       ['flow','brain','tracing','turn-anatomy','context-economics','approvals','dives','crons','memory','policy','skills','selfevolve','nemoclaw'], // light: no tool stream
+  goose:       ['flow','approvals','context-economics','crons','memory','policy','skills','selfevolve','nemoclaw'],
+  opencode:    ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
+  qwen_code:   ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
+  hermes:      ['flow','approvals','policy','selfevolve','nemoclaw'], // keeps crons + memory + skills (Hermes adapter has them)
+  picoclaw:    ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
+  nanoclaw:    ['flow','brain','tracing','turn-anatomy','context-economics','approvals','dives','memory','policy','skills','selfevolve','nemoclaw'] // light; keeps crons (has cron)
 };
-function _cmIsOpenClawFamily(rt) {
-  return !rt || rt === 'all' || rt === 'openclaw' || rt === 'nemoclaw';
-}
+// Every togglable sidebar tab — so switching runtimes RE-SHOWS tabs a prior
+// runtime hid. overview is never togglable (always visible).
+var _CM_RT_ALL_TABS = ['flow','brain','models','context','tracing','turn-anatomy',
+  'context-economics','approvals','alerts','cost','dives','crons','memory',
+  'notifications','security','policy','skills','selfevolve','nemoclaw'];
 function _cmApplyRuntimeTabVisibility() {
   var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
-  var show = _cmIsOpenClawFamily(rt);
-  Object.keys(_CM_RT_OPENCLAW_ONLY).forEach(function (tab) {
-    var sel = '[data-tab="' + tab + '"]';
-    Array.prototype.forEach.call(document.querySelectorAll('.left-nav-item' + sel + ', .nav-tab' + sel), function (el) {
+  var hide = (rt && rt !== 'all') ? (_CM_RT_TAB_VISIBILITY[rt] || []) : [];
+  var hideSet = {}; hide.forEach(function (t) { hideSet[t] = 1; });
+  _CM_RT_ALL_TABS.forEach(function (tab) {
+    var show = !hideSet[tab];
+    Array.prototype.forEach.call(document.querySelectorAll('.left-nav-item[data-tab="' + tab + '"], .nav-tab[data-tab="' + tab + '"]'), function (el) {
       el.style.display = show ? '' : 'none';
     });
+    // On a now-hidden tab? fall back to Overview.
     if (!show && _cmCurrentTab === tab && typeof switchTab === 'function') {
       try { switchTab('overview'); } catch (e) {}
     }


### PR DESCRIPTION
From your `/workflows` request — a per-runtime minimal sidebar, grounded in each adapter's real capabilities. Replaces the coarse blanket rule (#2571), which wrongly hid crons/memory/skills for runtimes that have them.

I ran a 12-agent analysis, then **corrected** its output (it over-hid `models`/`cost`/`brain` for some runtimes). Final per-runtime sidebars:

| Runtime | Tabs shown |
|---|---|
| openclaw | 18 (full reference) |
| hermes | 15 (+ crons, memory, skills) |
| claude_code / codex / opencode / qwen / picoclaw | 12 (brain, models, context, tracing, turn-anatomy, context-economics, cost, dives, …) |
| cursor | 12 (+ crons, − context-economics) |
| goose | 11 |
| nemoclaw | 10 (light NeMo wrapper) |
| nanoclaw | 8 (+ crons; light, no tool stream) |
| aider | 7 (overview, models, context, alerts, cost, notifications, security) |

`overview / models / cost / context / alerts / notifications / security` stay everywhere. Switching runtimes re-shows tabs a prior runtime hid; unknown/'all' shows everything. `node --check` clean.

Adjust any runtime's set by editing `_CM_RT_TAB_VISIBILITY`.