### PR TITLE
fix(node-view): derive tab visibility from DECLARED capabilities + CI parity guard

### DIFF
--- a/FLYWHEEL.md
+++ b/FLYWHEEL.md
@@ -91,6 +91,14 @@ When the global runtime switcher is set to a runtime, **every view must show ONL
 - **Two-renderer mirror.** If the same data has two renderers (e.g. a list and a chart), BOTH must apply the runtime filter or the chart fills while the list empties. CI guard: `tests/test_runtime_filter_no_leak.py` (server-side no-leak) + assert both render functions reference the filter.
 - **Verify per runtime, not just one.** Picking one runtime and eyeballing it is not enough — a filter that hard-codes the first runtime passes that check. For each runtime in `/api/v1/nodes/<id>/runtimes`, hit the v1 endpoints with `runtime=<id>` and assert the response scopes (counts match the runtimes list; `claude_code` ≠ `picoclaw`; an absent runtime returns zero, not the node total). The helper `scripts/verify_runtime_filtering.py` does this sweep — run it before claiming a runtime-aware view works, and wire it into the per-runtime E2E matrix (see [`feedback_workflows_all_runtimes_e2e`]).
 
+## 1d. Don't let an LLM analyze a fact the code declares — extract it, then judge
+
+When a decision depends on a fact the codebase **declares** (a `Capability` enum, a config constant, a route-policy entry, a DB schema, a pinned version, the pricing table), **EXTRACT it deterministically** — never ask an LLM (or a workflow agent) to "analyse" it from prose. LLMs hallucinate facts. Burned 2026-06-03: a `/workflows` agent called NemoClaw a "NeMo toolkit" when it is **sandboxed OpenClaw** (runs the OpenClaw adapter); the derived per-runtime tab config inherited the error and reached `main` before the founder caught it.
+
+- **Derive from the contract.** The per-runtime sidebar tabs DERIVE from each adapter's declared `Capability` enum (`_CM_RT_CAPS` ← `grep Capability. <adapter>`), so a new runtime/capability flows automatically and nothing can drift it. Prefer "derive from the declared source" over "hand-maintain a list."
+- **LLM-as-judge is for JUDGMENT, not facts.** When the question is genuinely judgmental (not extractable), the pattern is: extract the ground-truth facts → the LLM proposes → an **independent judge verifies the proposal against those facts and rejects on contradiction** (e.g. "agent says NemoClaw lacks CRONS, but it runs the OpenClaw adapter which declares `CRONS` → contradiction → reject"). A workflow that fans out analysis MUST add this verify/judge phase; never let an agent's prose be the source of truth for an extractable fact.
+- **Guard with an eval.** Add a CI test that re-extracts the fact and asserts the derived artifact matches (`tests/test_runtime_tab_capability_parity.py`), so correctness is mechanical, not "trust me."
+
 ## 2. Make the change
 
 - New HTTP endpoints go in `routes/<feature>.py` on that feature's Blueprint, not in `dashboard.py`. Shared helpers reach back via late `import dashboard as _d`.

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7648,48 +7648,70 @@ var _CM_RT_NODEWIDE = {
   alerts: 1, policy: 1, nemoclaw: 1, notifications: 1, dives: 1,
   'version-impact': 1, clusters: 1, logs: 1, actions: 1
 };
-// Per-runtime sidebar tab visibility — HIDE the tabs a runtime can't populate,
-// so each runtime gets the leanest sensible sidebar (founder 2026-06-03: "have
-// minimal tabs for each runtime that make sense"). Derived from a per-runtime
-// adapter-capability analysis (which fields each adapter emits: tool_call /
-// reasoning / cron / memory / skill / cache-tokens), corrected from the raw
-// workflow output (which over-hid models/cost/brain for some). Values = data-tab
-// names to HIDE. A tab NOT listed is shown. Unknown runtime / 'all' => show
-// everything (never silently drop a tab on an unmapped runtime). overview /
-// models / cost / context / alerts / notifications / security stay everywhere
-// (universal: every runtime has tokens+cost+model; alerts/notifications/security
-// are node/account-level).
-var _CM_RT_TAB_VISIBILITY = {
-  // OpenClaw = reference (full); NeMo tab + context-economics (no cache fields) hidden.
-  openclaw:    ['nemoclaw', 'context-economics'],
-  // NemoClaw = light NeMo-toolkit wrapper, NOT full OpenClaw: no gateway/crons/memory/skills/policy.
-  nemoclaw:    ['flow','tracing','context-economics','approvals','dives','crons','memory','policy','skills','selfevolve'],
-  claude_code: ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
-  codex:       ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
-  cursor:      ['flow','approvals','context-economics','memory','policy','skills','selfevolve','nemoclaw'], // keeps crons (cursor has a cron signal)
-  aider:       ['flow','brain','tracing','turn-anatomy','context-economics','approvals','dives','crons','memory','policy','skills','selfevolve','nemoclaw'], // light: no tool stream
-  goose:       ['flow','approvals','context-economics','crons','memory','policy','skills','selfevolve','nemoclaw'],
-  opencode:    ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
-  qwen_code:   ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
-  hermes:      ['flow','approvals','policy','selfevolve','nemoclaw'], // keeps crons + memory + skills (Hermes adapter has them)
-  picoclaw:    ['flow','approvals','crons','memory','policy','skills','selfevolve','nemoclaw'],
-  nanoclaw:    ['flow','brain','tracing','turn-anatomy','context-economics','approvals','dives','memory','policy','skills','selfevolve','nemoclaw'] // light; keeps crons (has cron)
+// Per-runtime sidebar tab visibility, DERIVED from each adapter's DECLARED
+// Capability enum — the authoritative contract, not an LLM "analysis" (founder
+// 2026-06-03: a workflow agent hallucinated NemoClaw as a "NeMo toolkit" when
+// it is sandboxed OpenClaw; deriving from declared capabilities makes the config
+// hallucination-proof and self-maintaining). Source of truth:
+//   - pro adapters: clawmetry_pro/adapters/<rt>.py `capabilities()` return.
+//   - openclaw: clawmetry/adapters/openclaw.py. nemoclaw runs the OpenClaw
+//     adapter (sandboxed: `clawmetry exec ... kubectl exec nemoclaw-sandbox`),
+//     so it shares OpenClaw's capabilities.
+// Verify/regenerate: grep `Capability.` in each adapter. Guarded by
+// tests/test_runtime_tab_capability_parity.py (OSS) against openclaw.
+var _CM_RT_CAPS = {
+  openclaw:    ['SESSIONS','EVENTS','COST','SUBAGENTS','CRONS','SKILLS','MEMORY','BRAIN','LOGS','GATEWAY_RPC','CHANNELS'],
+  nemoclaw:    ['SESSIONS','EVENTS','COST','SUBAGENTS','CRONS','SKILLS','MEMORY','BRAIN','LOGS','GATEWAY_RPC','CHANNELS'], // sandboxed OpenClaw
+  claude_code: ['SESSIONS','EVENTS','COST'],
+  codex:       ['SESSIONS','EVENTS','COST'],
+  aider:       ['SESSIONS','EVENTS','COST'],
+  goose:       ['SESSIONS','EVENTS','COST'],
+  opencode:    ['SESSIONS','EVENTS','COST'],
+  qwen_code:   ['SESSIONS','EVENTS','COST'],
+  hermes:      ['SESSIONS','EVENTS','COST','SUBAGENTS'],
+  cursor:      ['SESSIONS','EVENTS'],   // no COST
+  picoclaw:    ['SESSIONS','EVENTS'],   // no COST
+  nanoclaw:    ['SESSIONS','EVENTS']    // no COST
 };
-// Every togglable sidebar tab — so switching runtimes RE-SHOWS tabs a prior
-// runtime hid. overview is never togglable (always visible).
+// Capability -> the sidebar tabs it enables. A tab shows iff the runtime
+// declares (at least) one capability that enables it.
+var _CM_CAP_TABS = {
+  SESSIONS:    ['overview','dives'],
+  EVENTS:      ['brain','models','context','tracing','turn-anatomy'],
+  COST:        ['cost','context-economics'],
+  SUBAGENTS:   ['subagents'],
+  CRONS:       ['crons'],
+  SKILLS:      ['skills'],
+  MEMORY:      ['memory'],
+  GATEWAY_RPC: ['approvals','policy','selfevolve'],
+  CHANNELS:    ['flow']
+};
+// Node/account-level tabs — not capability-gated, shown for every runtime.
+var _CM_NODE_TABS = ['alerts','notifications','security'];
+// Every togglable sidebar tab (so switching runtimes RE-SHOWS what a prior one
+// hid). overview is never togglable.
 var _CM_RT_ALL_TABS = ['flow','brain','models','context','tracing','turn-anatomy',
   'context-economics','approvals','alerts','cost','dives','crons','memory',
-  'notifications','security','policy','skills','selfevolve','nemoclaw'];
+  'notifications','security','policy','skills','selfevolve','subagents','nemoclaw'];
+function _cmShownTabsForRuntime(rt) {
+  var show = {};
+  _CM_NODE_TABS.forEach(function (t) { show[t] = 1; });
+  (_CM_RT_CAPS[rt] || []).forEach(function (cap) {
+    (_CM_CAP_TABS[cap] || []).forEach(function (t) { show[t] = 1; });
+  });
+  if (rt === 'nemoclaw') show['nemoclaw'] = 1;
+  return show;
+}
 function _cmApplyRuntimeTabVisibility() {
   var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
-  var hide = (rt && rt !== 'all') ? (_CM_RT_TAB_VISIBILITY[rt] || []) : [];
-  var hideSet = {}; hide.forEach(function (t) { hideSet[t] = 1; });
+  // 'all' or an unknown/unmapped runtime => show everything (never silently drop).
+  var showAll = !rt || rt === 'all' || !_CM_RT_CAPS[rt];
+  var shown = showAll ? null : _cmShownTabsForRuntime(rt);
   _CM_RT_ALL_TABS.forEach(function (tab) {
-    var show = !hideSet[tab];
+    var show = showAll || !!shown[tab];
     Array.prototype.forEach.call(document.querySelectorAll('.left-nav-item[data-tab="' + tab + '"], .nav-tab[data-tab="' + tab + '"]'), function (el) {
       el.style.display = show ? '' : 'none';
     });
-    // On a now-hidden tab? fall back to Overview.
     if (!show && _cmCurrentTab === tab && typeof switchTab === 'function') {
       try { switchTab('overview'); } catch (e) {}
     }

--- a/tests/test_runtime_tab_capability_parity.py
+++ b/tests/test_runtime_tab_capability_parity.py
@@ -1,0 +1,80 @@
+"""Anti-hallucination guard: the per-runtime sidebar tab visibility must DERIVE
+from each adapter's DECLARED ``Capability`` enum, never from an LLM's prose.
+
+Burned 2026-06-03: a workflow agent hallucinated NemoClaw as a "NeMo toolkit"
+(it is sandboxed OpenClaw running the OpenClaw adapter); the tab config inherited
+the error. Fix = derive the frontend's ``_CM_RT_CAPS`` from the contract. This
+test re-extracts the contract and asserts the frontend matches, so the guarantee
+is mechanical, not "trust me".
+
+Scope: the OSS adapter (openclaw) — its declared capabilities must equal the
+frontend's ``_CM_RT_CAPS.openclaw``. The closed pro adapters are guarded by the
+parallel test in clawmetry-pro. Also checks internal consistency (every cap used
+in ``_CM_RT_CAPS`` is mapped in ``_CM_CAP_TABS``).
+"""
+from __future__ import annotations
+
+import os
+import re
+
+_HERE = os.path.dirname(__file__)
+_APP_JS = os.path.join(_HERE, "..", "clawmetry", "static", "js", "app.js")
+_OPENCLAW = os.path.join(_HERE, "..", "clawmetry", "adapters", "openclaw.py")
+
+
+def _declared_caps_openclaw() -> set:
+    """Extract the Capability.* names returned by openclaw.py's capabilities()."""
+    src = open(_OPENCLAW, encoding="utf-8").read()
+    m = re.search(r"def capabilities\(self\).*?\{(.*?)\}", src, re.S)
+    assert m, "openclaw.py capabilities() not found"
+    return set(re.findall(r"Capability\.([A-Z_]+)", m.group(1)))
+
+
+def _frontend_caps() -> dict:
+    """Parse the _CM_RT_CAPS map from app.js -> {runtime: set(caps)}."""
+    src = open(_APP_JS, encoding="utf-8").read()
+    m = re.search(r"var _CM_RT_CAPS = \{(.*?)\n\};", src, re.S)
+    assert m, "_CM_RT_CAPS not found in app.js"
+    out = {}
+    for line in m.group(1).splitlines():
+        lm = re.match(r"\s*(\w+):\s*\[(.*?)\]", line)
+        if lm:
+            caps = set(re.findall(r"'([A-Z_]+)'", lm.group(2)))
+            out[lm.group(1)] = caps
+    return out
+
+
+def _cap_tabs_keys() -> set:
+    src = open(_APP_JS, encoding="utf-8").read()
+    m = re.search(r"var _CM_CAP_TABS = \{(.*?)\n\};", src, re.S)
+    assert m, "_CM_CAP_TABS not found in app.js"
+    return set(re.findall(r"\n\s*([A-Z_]+):", m.group(1)))
+
+
+def test_openclaw_frontend_caps_match_declared():
+    declared = _declared_caps_openclaw()
+    fe = _frontend_caps()
+    assert "openclaw" in fe, "openclaw missing from _CM_RT_CAPS"
+    assert fe["openclaw"] == declared, (
+        f"_CM_RT_CAPS.openclaw drifted from openclaw.py capabilities(): "
+        f"frontend-only={fe['openclaw'] - declared}, declared-only={declared - fe['openclaw']}"
+    )
+
+
+def test_nemoclaw_inherits_openclaw_caps():
+    # NemoClaw = sandboxed OpenClaw (runs the OpenClaw adapter) -> identical caps.
+    fe = _frontend_caps()
+    assert fe.get("nemoclaw") == fe.get("openclaw"), (
+        "nemoclaw must share OpenClaw's capabilities (it is sandboxed OpenClaw)"
+    )
+
+
+def test_every_used_capability_is_mapped_to_tabs():
+    fe = _frontend_caps()
+    mapped = _cap_tabs_keys()
+    used = set().union(*fe.values()) if fe else set()
+    # LOGS = a node-wide tab outside this sidebar set; BRAIN = the brain tab is
+    # already enabled by EVENTS (every adapter with the live stream). Both are
+    # intentionally not unique keys in _CM_CAP_TABS.
+    unmapped = used - mapped - {"LOGS", "BRAIN"}
+    assert not unmapped, f"capabilities used in _CM_RT_CAPS but not mapped in _CM_CAP_TABS: {unmapped}"


### PR DESCRIPTION
**#2574 merged the hallucinated config** (the auto-merge landed before my correction). This corrects main: per-runtime tab visibility now DERIVES from each adapter's declared `Capability` enum, and a CI test guards it so it can't drift.

- NemoClaw = sandboxed OpenClaw → full (21 tabs, was wrongly 10). Hermes has `SUBAGENTS` (not memory/skills/crons). cursor/picoclaw/nanoclaw lack `COST` → no Cost tab.
- `tests/test_runtime_tab_capability_parity.py` re-extracts `openclaw.py`'s `capabilities()` and asserts `_CM_RT_CAPS.openclaw` matches — mechanical anti-hallucination guard.

3 parity tests + `node --check` green.