### PR TITLE
[RELEASE] Fleet: drop 0-session runtime phantoms (Cursor 'detected here' never syncs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Release: Fleet shows only runtimes with REAL sessions (drop 0-session phantoms) (2026-06-03)
+- **Why:** the Fleet rendered a "Cursor — detected here / appears shortly / Syncing…" card that never resolved. The lite detector flags a runtime from directory/config presence alone — the Cursor *IDE* being installed makes `~/Library/Application Support/Cursor` exist even when the Cursor *agent* was never used — so the daemon reported it with `sessions=0` and the cloud showed a stuck phantom (founder report).
+- **What:** `_detect_runtimes_for_heartbeat()` now drops any runtime with 0 sessions. "Installed & running" for observability means there is real data; a runtime with zero sessions isn't advertised until it produces one. Verified on the founder's machine: Cursor (0) dropped; Claude Code/Codex/Qwen/Goose/opencode/Hermes/PicoClaw (all >0, all real) kept.
+- **Guard:** `tests/test_detected_runtimes_no_phantom.py` asserts 0-session runtimes never leak.
+
 ### Release: per-runtime sidebars derive from DECLARED capabilities (#2575) (2026-06-03)
 - **Why:** the first pass (#2571/#2572) hid tabs from a hand-written list that an LLM helper had hallucinated parts of (NemoClaw mislabeled a "NeMo toolkit"; Hermes/Cursor/NanoClaw credited with crons/memory/skills they don't have). Founder caught it — "should I even trust you?".
 - **What:** tab visibility now derives mechanically from each adapter's declared `Capability` enum (`_CM_RT_CAPS` → `_CM_CAP_TABS`), not prose. OpenClaw + NemoClaw (sandboxed OpenClaw, identical caps) show the full set; cost runtimes (Claude Code, Codex, Aider, Goose, opencode, Qwen) show Sessions/Events/Cost tabs; Cursor/PicoClaw/NanoClaw (no COST) show less. A CI parity guard (`test_runtime_tab_capability_parity.py`) re-extracts the contract and fails on drift, so this can't silently rot again.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5459,7 +5459,17 @@ def _detect_runtimes_lite() -> list:
 def _detect_runtimes_for_heartbeat() -> list:
     """Detected runtimes to report to the cloud Fleet. Merges the authoritative
     clawmetry-pro adapter counts (when installed) with the free lite detector,
-    preferring the higher session count per runtime. Never raises."""
+    preferring the higher session count per runtime. Never raises.
+
+    Only runtimes with **real sessions on disk** (sessions > 0) are reported.
+    The lite detector flags a runtime from its directory/config presence alone —
+    e.g. the Cursor *IDE* being installed makes ``~/Library/Application Support/
+    Cursor`` exist even when the Cursor *agent* was never used. Reporting such a
+    0-session runtime makes the Fleet render a "detected here / appears shortly"
+    card that never resolves (nothing to sync), which reads as a stuck phantom.
+    "Installed & running" for observability means there is actual data — so a
+    runtime with zero sessions is not shown until it produces one.
+    """
     merged: dict = {}
     try:
         for r in (_detect_runtimes_lite() or []):
@@ -5478,7 +5488,8 @@ def _detect_runtimes_for_heartbeat() -> list:
                 merged[rid] = {"id": rid, "label": label, "sessions": n}
     except Exception:
         pass
-    return list(merged.values())
+    # Drop 0-session phantoms (directory/config detected but no real data).
+    return [r for r in merged.values() if int(r.get("sessions") or 0) > 0]
 
 
 def send_heartbeat(config: dict) -> bool:

--- a/tests/test_detected_runtimes_no_phantom.py
+++ b/tests/test_detected_runtimes_no_phantom.py
@@ -1,0 +1,51 @@
+"""Guard: the Fleet must only advertise runtimes with REAL sessions.
+
+Burned 2026-06-03 (founder): the Fleet showed a "Cursor — detected here /
+appears shortly / Syncing…" card that never resolved. Root cause: the lite
+detector flags a runtime from directory/config presence alone — the Cursor
+*IDE* being installed makes ``~/Library/Application Support/Cursor`` exist even
+when the Cursor *agent* was never used — so ``_detect_runtimes_for_heartbeat``
+reported it with sessions=0 and the cloud rendered a stuck phantom card.
+
+Contract: a runtime with zero sessions is NOT reported (nothing to observe).
+Runtimes with real sessions (even one) ARE reported.
+"""
+from __future__ import annotations
+
+import clawmetry.sync as sync
+
+
+def test_zero_session_runtime_is_dropped(monkeypatch):
+    monkeypatch.setattr(sync, "_detect_runtimes_lite", lambda: [
+        {"id": "claude_code", "label": "Claude Code", "sessions": 1251},
+        {"id": "cursor", "label": "Cursor", "sessions": 0},      # IDE installed, agent unused
+        {"id": "picoclaw", "label": "PicoClaw", "sessions": 0},  # filled in by family below
+    ])
+    monkeypatch.setattr(sync, "_detect_family_runtimes", lambda: [
+        {"name": "picoclaw", "displayName": "PicoClaw", "sessionCount": 1},
+        {"name": "goose", "displayName": "Goose", "sessionCount": 4},
+    ])
+    out = sync._detect_runtimes_for_heartbeat()
+    ids = {r["id"] for r in out}
+
+    assert "cursor" not in ids, "0-session cursor phantom must not be reported"
+    assert ids == {"claude_code", "picoclaw", "goose"}
+    assert all(int(r.get("sessions") or 0) > 0 for r in out), "no 0-session runtime may leak"
+    # the family count must win where it's higher (picoclaw 0 -> 1)
+    assert next(r for r in out if r["id"] == "picoclaw")["sessions"] == 1
+
+
+def test_all_real_runtimes_kept(monkeypatch):
+    monkeypatch.setattr(sync, "_detect_runtimes_lite", lambda: [])
+    monkeypatch.setattr(sync, "_detect_family_runtimes", lambda: [
+        {"name": rid, "displayName": rid, "sessionCount": n}
+        for rid, n in [("claude_code", 1251), ("codex", 1), ("hermes", 2)]
+    ])
+    out = sync._detect_runtimes_for_heartbeat()
+    assert {r["id"] for r in out} == {"claude_code", "codex", "hermes"}
+
+
+def test_never_raises_on_bad_detectors(monkeypatch):
+    monkeypatch.setattr(sync, "_detect_runtimes_lite", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(sync, "_detect_family_runtimes", lambda: None)
+    assert sync._detect_runtimes_for_heartbeat() == []


### PR DESCRIPTION
## Founder report
The Fleet showed a **Cursor** card stuck on *"detected here / appears shortly / Syncing…"* that never resolved — "do we really have cursor on this machine?"

## Verified root cause
`_detect_runtimes_for_heartbeat()` reported every detected runtime **including 0-session ones**. The lite detector flags a runtime from directory presence alone — the Cursor **IDE** creates `~/Library/Application Support/Cursor` even when the Cursor **agent** was never used. So the daemon sent `cursor: sessions=0`, and the cloud rendered a card that can never sync (no data) → stuck phantom.

Ground truth from the founder's daemon (0.12.429):
```
claude_code 1251 · codex 1 · qwen 2 · goose 4 · opencode 3 · hermes 2 · picoclaw 1   ← all real
cursor 0   ← phantom (IDE installed, agent unused)
```
(PicoClaw/Hermes are real — founder ran/runs them; only Cursor was a phantom.)

## Fix
Report only runtimes with `sessions > 0`. "Installed & running" for an observability tool means real data exists. Verified: Cursor dropped, all 7 real runtimes kept. Guard test `test_detected_runtimes_no_phantom.py` added.

Daemon-side, so it reaches existing nodes on auto-update (and the next heartbeat drops the Cursor card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)