### PR TITLE
[RELEASE] fix(nav): Context economics double-indent (missing </div> on Tool catalog)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -11354,6 +11354,7 @@ DASHBOARD_HTML = r"""
         </div>
         <div class="left-nav-item left-nav-item-sub" id="left-nav-tool-catalog" data-tab="tool-catalog" onclick="switchTab('tool-catalog')" title="Every tool the agent uses by provenance, with call count and p50/p95 latency">
           <span class="left-nav-label">Tool catalog</span>
+        </div>
         <div class="left-nav-item left-nav-item-sub" id="left-nav-context-economics" data-tab="context-economics" onclick="switchTab('context-economics')" title="Context-window utilization over time, compaction triggers and tokens reclaimed">
           <span class="left-nav-label">Context economics</span>
         </div>


### PR DESCRIPTION
Founder report: the **Context economics** sidebar item had extra left space and looked weird.

**Cause:** the `Tool catalog` `left-nav-item` `<div>` was never closed, so Context economics *and* Swimlane were nested **inside** it — inheriting Tool catalog's indent plus their own. One missing `</div>`.

**Fix:** close the Tool catalog item so the three are proper siblings at the same indent.

Ships via release → cloud pin (the node-page sidebar is the OSS dashboard HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)