### PR TITLE
[RELEASE] feat(tool-catalog): per-runtime filtering (opencode/codex showed Claude Code's tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Release: Tool catalog filters per-runtime (snapshot byRuntime slice) (2026-06-03)
+- **Why:** selecting opencode/codex on the node page showed Claude Code's tools (Bash/Read/Edit/chrome-devtools) — the all-runtimes aggregate (founder report). The Tool-catalog snapshot slice was a single aggregate.
+- **What:** `_build_tool_catalog_slice` now also emits `byRuntime` (runtime -> {tools, groups, totals}), derived from each tool_call event's session_id prefix. The cloud interceptor serves the selected runtime's catalog (empty for a runtime that never invoked a tool). Verified on a real node: claude_code 26 tools / 1425 calls, opencode/codex absent (correctly empty). Removed tool-catalog from `_CM_RT_AGGREGATE` so its 'not yet filtered' banner no longer shows.
+- **Guard:** `tests/test_tool_catalog_per_runtime.py` (per-runtime split + sum reconciles to the aggregate).
+
 ### Release: Fleet shows only runtimes with REAL sessions (drop 0-session phantoms) (2026-06-03)
 - **Why:** the Fleet rendered a "Cursor — detected here / appears shortly / Syncing…" card that never resolved. The lite detector flags a runtime from directory/config presence alone — the Cursor *IDE* being installed makes `~/Library/Application Support/Cursor` exist even when the Cursor *agent* was never used — so the daemon reported it with `sessions=0` and the cloud showed a stuck phantom (founder report).
 - **What:** `_detect_runtimes_for_heartbeat()` now drops any runtime with 0 sessions. "Installed & running" for observability means there is real data; a runtime with zero sessions isn't advertised until it produces one. Verified on the founder's machine: Cursor (0) dropped; Claude Code/Codex/Qwen/Goose/opencode/Hermes/PicoClaw (all >0, all real) kept.

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7637,8 +7637,11 @@ function _cmRuntimeLabel(rt) { return _CM_RT_LABEL[rt] || rt; }
 // the switcher can't scope them client-side yet, so picking a specific runtime
 // shows an honest "all runtimes" note rather than pretending the numbers are
 // runtime-specific. (Per-runtime aggregation is a follow-up.)
+// Tool catalog now filters per-runtime (snapshot byRuntime slice + cloud
+// interceptor), so it's no longer an aggregate-only tab. context-economics +
+// context (LLM Context) still pending per-runtime slicing.
 var _CM_RT_AGGREGATE = {
-  'tool-catalog': 1, 'context-economics': 1, context: 1
+  'context-economics': 1, context: 1
 };
 // Tabs that are NODE-WIDE concepts, not per-runtime: crons run on the gateway,
 // memory/skills are workspace-level, security is machine posture, self-evolve is

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11074,7 +11074,20 @@ def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
         if rid is not None:
             res_idx[str(rid)] = {"ts": _ms(e.get("ts")), "error": _err(e)}
 
+    def _accum(store, name, dur, err, detail):
+        a = store.setdefault(name, {"calls": 0, "durs": [], "errs": 0, "recent": []})
+        a["calls"] += 1
+        if dur is not None:
+            a["durs"].append(dur)
+        if err:
+            a["errs"] += 1
+        a["recent"].append(detail)
+
     agg: dict = {}
+    # Per-runtime aggregation so the Tool-catalog tab can scope to the selected
+    # runtime (founder 2026-06-03: opencode/codex showed Claude Code's tools).
+    # runtime -> name -> counts; the cloud interceptor picks byRuntime[<rt>].
+    agg_rt: dict = {}
     for e in rows:
         if not _is_call(e):
             continue
@@ -11096,23 +11109,20 @@ def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
                 if m["ts"] is not None and start is not None:
                     dur = max(0, m["ts"] - start)
                 break
-        a = agg.setdefault(name, {"calls": 0, "durs": [], "errs": 0, "recent": []})
-        a["calls"] += 1
-        if dur is not None:
-            a["durs"].append(dur)
-        if err:
-            a["errs"] += 1
         # Per-call detail for the cloud drill-down (#tool-catalog calls). The
         # OSS /api/tool-catalog/<name>/calls reads DuckDB live; the cloud
         # container has none, so the cm-cloud-tool-catalog interceptor reads
         # toolCatalog.calls[name] from the snapshot instead. Mirror its field
         # shape: {ts_ms, duration_ms, status, session_id}.
-        a["recent"].append({
+        detail = {
             "ts_ms": start,
             "duration_ms": dur,
             "status": "error" if err else "ok",
             "session_id": (e.get("session_id") or None),
-        })
+        }
+        _accum(agg, name, dur, err, detail)
+        _rt = _runtime_of_session(e.get("session_id") or "")
+        _accum(agg_rt.setdefault(_rt, {}), name, dur, err, detail)
 
     def _pct(vals, p):
         if not vals:
@@ -11137,24 +11147,39 @@ def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
             return ("builtin", "")
         return ("plugin", "")
 
-    tools = []
-    for name, a in agg.items():
-        prov, provider = _classify(name)
-        durs = sorted(a["durs"])
-        calls = a["calls"]
-        tools.append({
-            "name": name,
-            "provenance": prov,
-            "provider": provider or None,
-            "calls": calls,
-            "p50_ms": _pct(durs, 50),
-            "p95_ms": _pct(durs, 95),
-            "error_rate": round(a["errs"] / calls, 4) if calls else 0.0,
-            "errors": a["errs"],
-        })
-        out["groups"][prov] = out["groups"].get(prov, 0) + 1
-    tools.sort(key=lambda t: (-t["calls"], -(t["p95_ms"] or 0), t["name"]))
-    out["tools"] = tools[:int(top)]
+    def _tools_from_agg(a_dict, n):
+        groups = {"builtin": 0, "mcp": 0, "plugin": 0}
+        tl = []
+        for name, a in a_dict.items():
+            prov, provider = _classify(name)
+            durs = sorted(a["durs"])
+            calls = a["calls"]
+            tl.append({
+                "name": name,
+                "provenance": prov,
+                "provider": provider or None,
+                "calls": calls,
+                "p50_ms": _pct(durs, 50),
+                "p95_ms": _pct(durs, 95),
+                "error_rate": round(a["errs"] / calls, 4) if calls else 0.0,
+                "errors": a["errs"],
+            })
+            groups[prov] = groups.get(prov, 0) + 1
+        tl.sort(key=lambda t: (-t["calls"], -(t["p95_ms"] or 0), t["name"]))
+        return tl[:int(n)], groups
+
+    out["tools"], out["groups"] = _tools_from_agg(agg, top)
+    # Per-runtime catalogs for the runtime filter. Only runtimes that actually
+    # invoked a tool appear; the cloud interceptor falls back to the aggregate
+    # for the all-runtimes view. Tiny for a single-runtime user.
+    out["byRuntime"] = {}
+    for _rt, _a in agg_rt.items():
+        _tl, _gr = _tools_from_agg(_a, top)
+        out["byRuntime"][_rt] = {
+            "tools": _tl,
+            "groups": _gr,
+            "totals": {"tool_count": len(_tl), "total_calls": sum(t["calls"] for t in _tl)},
+        }
 
     # Per-tool recent calls for the cloud drill-down — only for the tools we
     # actually ship (top N), newest first, capped per tool so a hot tool can't

--- a/tests/test_tool_catalog_per_runtime.py
+++ b/tests/test_tool_catalog_per_runtime.py
@@ -1,0 +1,62 @@
+"""The Tool-catalog snapshot slice must split tools per-runtime.
+
+Founder report 2026-06-03: selecting opencode/codex on the node page showed
+Claude Code's tools (Bash/Read/Edit/chrome-devtools) — the all-runtimes
+aggregate. Fix: `_build_tool_catalog_slice` emits a `byRuntime` map (runtime ->
+{tools, groups, totals}) derived from each tool_call event's session_id prefix,
+so the cloud interceptor can serve the selected runtime's catalog (and an
+empty one for a runtime that never invoked a tool).
+"""
+import clawmetry.sync as sync
+
+
+class _FakeStore:
+    def __init__(self, events):
+        self._events = events
+
+    def query_events(self, limit=5000):
+        return self._events
+
+    def query_tool_policy(self, limit=25):
+        return []
+
+
+def _call(session_id, tool, tuid):
+    return {
+        "event_type": "tool_call",
+        "ts": 1000,
+        "session_id": session_id,
+        "data": {"tool_name": tool, "tool_calls": [{"id": tuid, "name": tool}]},
+    }
+
+
+def test_by_runtime_splits_tools(monkeypatch):
+    events = [
+        _call("claude_code:s1", "Bash", "a"),
+        _call("claude_code:s1", "Bash", "b"),
+        _call("claude_code:s1", "Read", "c"),
+        _call("goose:s2", "extensionmanager__list", "d"),
+        _call("625c0ad9-bare-uuid", "openclaw_tool", "e"),  # bare uuid -> openclaw
+    ]
+    monkeypatch.setattr(sync, "_runtime_of_session", lambda sid: (
+        sid.split(":")[0] if ":" in sid else "openclaw"))
+
+    import clawmetry.local_store as ls
+    monkeypatch.setattr(ls, "get_store", lambda *a, **k: _FakeStore(events))
+
+    slice_ = sync._build_tool_catalog_slice()
+    br = slice_.get("byRuntime", {})
+
+    # claude_code, goose, openclaw each get their own catalog; codex/opencode absent
+    assert set(br.keys()) == {"claude_code", "goose", "openclaw"}
+    assert "codex" not in br and "opencode" not in br
+
+    cc = {t["name"]: t["calls"] for t in br["claude_code"]["tools"]}
+    assert cc == {"Bash": 2, "Read": 1}
+    assert br["goose"]["totals"]["total_calls"] == 1
+    assert br["openclaw"]["totals"]["total_calls"] == 1
+
+    # reconciliation: per-runtime call counts sum to the aggregate
+    agg_calls = sum(t["calls"] for t in slice_["tools"])
+    rt_calls = sum(d["totals"]["total_calls"] for d in br.values())
+    assert agg_calls == rt_calls == 5


### PR DESCRIPTION
First complete vertical of the per-runtime snapshot-slice work (founder: 'fix similar issues for all the other tabs').

**Problem:** the Tool catalog (and other snapshot-served tabs) showed the all-runtimes aggregate on every runtime tab — opencode/codex displayed Claude Code's Bash/Read/Edit/chrome-devtools.

**Fix (daemon side):** `_build_tool_catalog_slice` emits `byRuntime` (runtime -> {tools, groups, totals}) derived from each tool_call event's `session_id` prefix. Verified on a real node:
```
aggregate:   28 tools / 1427 calls
claude_code: 26 tools / 1425 calls  (Bash, Read, Edit, ...)
goose:        2 tools / 2 calls
opencode/codex: absent -> correctly empty
```
The companion cloud interceptor (separate PR) picks `byRuntime[<rt>]`. Old daemons (no byRuntime) fall back to the aggregate — clean transition. Removed tool-catalog from `_CM_RT_AGGREGATE` so the 'not yet filtered' banner stops showing once filtered. Guard test reconciles per-runtime sums to the aggregate.

This is the template; Context economics / LLM Context follow the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)