### PR TITLE
docs: position ClawMetry beyond OpenClaw — 12 agent runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <a href="https://www.producthunt.com/products/clawmetry?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-clawmetry-for-openclaw" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1081207&theme=light&period=daily&t=1771491508782" alt="ClawMetry - #5 Product of the Day on Product Hunt" width="250" height="54" /></a>
 
-**See your agent think.** Real-time observability for [OpenClaw](https://github.com/openclaw/openclaw) AI agents.
+**See your agent think.** Real-time observability for **12 AI agent runtimes** — [OpenClaw](https://github.com/openclaw/openclaw), [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw), Claude Code, OpenAI Codex & 8 more. One dashboard for your whole agent fleet.
 
 > 🌐 **Read this in:** [English](README.md) · [简体中文](docs/i18n/zh-CN/README.md) · [日本語](docs/i18n/ja/README.md) · [한국어](docs/i18n/ko/README.md) · [Español](docs/i18n/es/README.md) · [Português (BR)](docs/i18n/pt-BR/README.md) · [Français](docs/i18n/fr/README.md) · [Deutsch](docs/i18n/de/README.md) · [हिन्दी](docs/i18n/hi/README.md) · [العربية](docs/i18n/ar/README.md) · [Русский](docs/i18n/ru/README.md) · [more →](docs/i18n/)
 
@@ -21,6 +21,14 @@ pip install clawmetry && clawmetry
 Opens at **http://localhost:8900** and you're done.
 
 ![Flow Visualization](https://clawmetry.com/screenshots/flow.png)
+
+## Works with 12 agent runtimes
+
+ClawMetry started as observability for OpenClaw — it now meters your **whole agent fleet** in one dashboard, auto-detecting each runtime on your machine:
+
+🦞 **OpenClaw** · 🟩 **NVIDIA NemoClaw** · ◆ **Claude Code** · ⬡ **OpenAI Codex** · **Cursor** · 🪿 **Goose** · ⚡ **Hermes** · **opencode** · ◈ **Qwen Code** · **Aider** · **NanoClaw** · **PicoClaw**
+
+OpenClaw and NemoClaw are free in the open-source app; the other runtimes light up with ClawMetry Cloud or a self-hosted Pro license. Switch runtimes from the header and every tab — cost, tokens, tools, traces — re-scopes to that runtime.
 
 ## What You Get
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("dashboard.py", "r", encoding="utf-8") as f:
 setup(
     name="clawmetry",
     version=version,
-    description="ClawMetry - Real-time observability dashboard for OpenClaw AI agents",
+    description="ClawMetry - Real-time observability for 12 AI agent runtimes (OpenClaw, NVIDIA NemoClaw, Claude Code, Codex & more)",
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Vivek Chand",


### PR DESCRIPTION
Founder ask: the about/title still said *'observability for OpenClaw AI agents'* — but ClawMetry now supports **12 runtimes**.

**Updated:**
- **README tagline** → *'Real-time observability for 12 AI agent runtimes — OpenClaw, NVIDIA NemoClaw, Claude Code, OpenAI Codex & 8 more.'*
- **New README section** *'Works with 12 agent runtimes'* listing all 12 (OpenClaw + NemoClaw free; the other 10 via Cloud/Pro), with the runtime-switcher note.
- **setup.py** PyPI summary → multi-runtime.
- **GitHub repo 'About'** → updated live (already applied).

Verified the 12 from the actual adapters: OpenClaw, NVIDIA NemoClaw (free) + Aider, Claude Code, Codex, Cursor, Goose, Hermes, NanoClaw, opencode, PicoClaw, Qwen Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)