### PR TITLE
[RELEASE] feat(context-economics): per-runtime filtering (byRuntime slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Release: Context economics filters per-runtime (snapshot byRuntime slice) (2026-06-03)
+- **Why:** like Tool catalog, the Context-economics tab showed the all-runtimes aggregate on every runtime tab (founder report). Compactions from every runtime were lumped together.
+- **What:** the contextEconomics snapshot slice now carries `byRuntime` (runtime -> {compactions, overflow_sessions, summary}) via `_context_econ_by_runtime`, grouped by each compaction's session_id prefix. The cloud interceptor serves the selected runtime's view (empty for a runtime that never compacted). Removed context-economics from `_CM_RT_AGGREGATE` so its 'not yet filtered' banner no longer shows.
+- **Guard:** `tests/test_context_econ_per_runtime.py` (per-runtime split + reconciliation).
+
 ### Release: Tool catalog filters per-runtime (snapshot byRuntime slice) (2026-06-03)
 - **Why:** selecting opencode/codex on the node page showed Claude Code's tools (Bash/Read/Edit/chrome-devtools) — the all-runtimes aggregate (founder report). The Tool-catalog snapshot slice was a single aggregate.
 - **What:** `_build_tool_catalog_slice` now also emits `byRuntime` (runtime -> {tools, groups, totals}), derived from each tool_call event's session_id prefix. The cloud interceptor serves the selected runtime's catalog (empty for a runtime that never invoked a tool). Verified on a real node: claude_code 26 tools / 1425 calls, opencode/codex absent (correctly empty). Removed tool-catalog from `_CM_RT_AGGREGATE` so its 'not yet filtered' banner no longer shows.

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7637,11 +7637,11 @@ function _cmRuntimeLabel(rt) { return _CM_RT_LABEL[rt] || rt; }
 // the switcher can't scope them client-side yet, so picking a specific runtime
 // shows an honest "all runtimes" note rather than pretending the numbers are
 // runtime-specific. (Per-runtime aggregation is a follow-up.)
-// Tool catalog now filters per-runtime (snapshot byRuntime slice + cloud
-// interceptor), so it's no longer an aggregate-only tab. context-economics +
+// Tool catalog + Context economics now filter per-runtime (snapshot byRuntime
+// slice + cloud interceptor), so they're no longer aggregate-only tabs.
 // context (LLM Context) still pending per-runtime slicing.
 var _CM_RT_AGGREGATE = {
-  'context-economics': 1, context: 1
+  context: 1
 };
 // Tabs that are NODE-WIDE concepts, not per-runtime: crons run on the gateway,
 // memory/skills are workspace-level, security is machine posture, self-evolve is

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11195,6 +11195,40 @@ def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
     return out
 
 
+def _context_econ_by_runtime(compactions, overflow_sessions, base_summary):
+    """Group context-economics compactions + overflow sessions per runtime
+    (session_id prefix) for the Context-economics runtime filter. Returns
+    ``{runtime: {compactions, overflow_sessions, summary}}``; a runtime that
+    never compacted is absent (the cloud interceptor then serves an empty
+    slice). ``peak_pct``/``utilization_points`` inherit the node-wide value —
+    utilization points are not per-session, so they aren't split."""
+    by: dict = {}
+    for c in (compactions or []):
+        rt = _runtime_of_session((c or {}).get("session_id") or "")
+        by.setdefault(rt, []).append(c)
+    base = base_summary or {}
+    out: dict = {}
+    for rt, comps in by.items():
+        ovn = sum(1 for c in comps if c.get("trigger") == "overflow")
+        rt_ovf = [s for s in (overflow_sessions or [])
+                  if _runtime_of_session(
+                      (s.get("session_id") if isinstance(s, dict) else s) or "") == rt]
+        out[rt] = {
+            "compactions": comps,
+            "overflow_sessions": rt_ovf,
+            "summary": {
+                "compaction_count": len(comps),
+                "overflow_count": ovn,
+                "proactive_count": len(comps) - ovn,
+                "total_reclaimed": sum(int(c.get("reclaimed") or 0) for c in comps),
+                "peak_pct": base.get("peak_pct", 0),
+                "overflow_sessions": len(rt_ovf),
+                "utilization_points": base.get("utilization_points", 0),
+            },
+        }
+    return out
+
+
 def _build_external_calls():
     """Snapshot slice for the out-loop sources card — source-tagged external
     API calls only (clawmetry.track.set_source()). Capped + field-trimmed so
@@ -12131,6 +12165,15 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
                 "overflow_sessions":  len(_ce.get("overflow_sessions") or []),
                 "utilization_points": len(_ce_util),
             }
+            # Per-runtime context-economics for the runtime filter (founder
+            # 2026-06-03: opencode/codex showed Claude Code's compactions). The
+            # cloud interceptor picks byRuntime[<rt>]; empty for a runtime that
+            # never compacted.
+            context_economics_slice["byRuntime"] = _context_econ_by_runtime(
+                context_economics_slice["compactions"],
+                context_economics_slice["overflow_sessions"],
+                context_economics_slice["summary"],
+            )
     except Exception as _e_ce:
         log.debug("snapshot: context_economics slice failed: %s", _e_ce)
 

--- a/tests/test_context_econ_per_runtime.py
+++ b/tests/test_context_econ_per_runtime.py
@@ -1,0 +1,47 @@
+"""Context-economics snapshot slice must split compactions per-runtime.
+
+Founder report 2026-06-03: selecting opencode/codex showed Claude Code's
+compactions (the all-runtimes aggregate). `_context_econ_by_runtime` groups
+compactions + overflow sessions by each compaction's session_id prefix so the
+cloud interceptor can serve the selected runtime's view (empty for a runtime
+that never compacted).
+"""
+import clawmetry.sync as sync
+
+
+def _comp(sid, trigger="proactive", reclaimed=100):
+    return {"session_id": sid, "trigger": trigger, "reclaimed": reclaimed}
+
+
+def test_compactions_split_by_runtime(monkeypatch):
+    monkeypatch.setattr(sync, "_runtime_of_session", lambda s: (
+        s.split(":")[0] if ":" in s else "openclaw"))
+    comps = [
+        _comp("claude_code:a", "overflow", 500),
+        _comp("claude_code:b", "proactive", 200),
+        _comp("goose:c", "proactive", 50),
+        _comp("bare-uuid", "proactive", 10),  # -> openclaw
+    ]
+    ovf = [{"session_id": "claude_code:a"}, {"session_id": "goose:c"}]
+    base = {"peak_pct": 87.5, "utilization_points": 400}
+
+    out = sync._context_econ_by_runtime(comps, ovf, base)
+
+    assert set(out.keys()) == {"claude_code", "goose", "openclaw"}
+    assert "opencode" not in out and "codex" not in out
+
+    cc = out["claude_code"]
+    assert cc["summary"]["compaction_count"] == 2
+    assert cc["summary"]["overflow_count"] == 1
+    assert cc["summary"]["proactive_count"] == 1
+    assert cc["summary"]["total_reclaimed"] == 700
+    assert cc["summary"]["peak_pct"] == 87.5            # inherits node-wide
+    assert [s["session_id"] for s in cc["overflow_sessions"]] == ["claude_code:a"]
+
+    # reconciliation: per-runtime compaction counts sum to the total
+    assert sum(d["summary"]["compaction_count"] for d in out.values()) == 4
+
+
+def test_empty_input_yields_empty(monkeypatch):
+    monkeypatch.setattr(sync, "_runtime_of_session", lambda s: "openclaw")
+    assert sync._context_econ_by_runtime([], [], {}) == {}


### PR DESCRIPTION
Second vertical of the per-runtime snapshot work (after Tool catalog #2583).

The `contextEconomics` snapshot slice now carries `byRuntime` (runtime -> {compactions, overflow_sessions, summary}) via `_context_econ_by_runtime`, grouped by each compaction's `session_id` prefix. The companion cloud interceptor (separate PR) serves `byRuntime[<rt>]` — empty for a runtime that never compacted. Removed context-economics from `_CM_RT_AGGREGATE` so the 'not yet filtered' banner stops showing.

Guard test reconciles per-runtime compaction counts to the total. (The founder's node has 0 compactions, so it's correctly empty for them either way — but the split is proven by the unit test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)