### PR TITLE
feat(harness): daily observability-coverage audit (sync 12 runtimes, file gap issues)

### DIFF
--- a/.github/workflows/harness-observability-audit.yml
+++ b/.github/workflows/harness-observability-audit.yml
@@ -1,0 +1,86 @@
+name: Harness observability audit (daily)
+
+# Every day: sync the upstream source of every agent runtime ClawMetry monitors
+# (scripts/harness/manifest.json), then have Claude compare what each harness
+# EXPOSES against what our adapter CAPTURES, and file a GitHub issue for each gap
+# so it can be picked up. This is how we keep up as the harnesses evolve — new
+# fields, new telemetry, new features to observe.
+#
+# Safe to merge before the secret exists: with no CLAUDE_CODE_OAUTH_TOKEN the
+# model pass is skipped (clones + dry-run still run, logged as a warning), exactly
+# like i18n-autotranslate.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"   # daily 06:00 UTC (before the runtime-conformance nightly)
+  workflow_dispatch:
+    inputs:
+      runtime:
+        description: "Audit a single runtime (blank = all)"
+        required: false
+        default: ""
+      file_issues:
+        description: "Actually open issues (false = dry-run)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: harness-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+      HARNESS_DIR: ${{ github.workspace }}/.harness
+      CLAWMETRY_PRO_DIR: ${{ github.workspace }}/clawmetry-pro
+    steps:
+      - name: Checkout clawmetry (OSS)
+        uses: actions/checkout@v4
+
+      # Closed adapters live in clawmetry-pro — best-effort so the audit still
+      # runs (with reduced context) if the cross-repo token is absent.
+      - name: Checkout clawmetry-pro (adapter context, optional)
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: vivekchand/clawmetry-pro
+          token: ${{ secrets.CLOUD_REPO_PAT }}
+          path: clawmetry-pro
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Token visibility (presence only)
+        run: |
+          [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && echo "CLAUDE_CODE_OAUTH_TOKEN: set" || echo "::warning::CLAUDE_CODE_OAUTH_TOKEN not set — clones run, model audit skipped. Add it with 'claude setup-token'."
+          [ -d "$CLAWMETRY_PRO_DIR/clawmetry_pro" ] && echo "clawmetry-pro: checked out" || echo "::warning::clawmetry-pro not checked out (set CLOUD_REPO_PAT) — auditing harness surface with reduced adapter context."
+
+      - name: Sync harness sources
+        run: bash scripts/harness/sync.sh
+
+      - name: Audit observability coverage + file gap issues
+        run: |
+          ARGS=""
+          [ -n "${{ github.event.inputs.runtime }}" ] && ARGS="--runtime ${{ github.event.inputs.runtime }}"
+          # default to filing issues on schedule; honor the dispatch toggle
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.file_issues }}" = "false" ]; then
+            echo "dry-run (no issues)"; python3 scripts/harness/audit.py $ARGS
+          else
+            python3 scripts/harness/audit.py --file-issues $ARGS
+          fi

--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -1,0 +1,38 @@
+# Harness observability audit
+
+Keeps ClawMetry's coverage current as the agent runtimes it monitors evolve. Every
+day it syncs each harness's upstream source, asks Claude to compare what the
+harness **exposes** (sessions, events, tool calls, cost/tokens, cache, telemetry,
+new features) against what our adapter **captures**, and files a GitHub issue for
+each gap — so "new things to observe" get picked up instead of silently drifting.
+
+## Pieces
+- **`manifest.json`** — single source of truth: each monitored runtime → its
+  upstream repo + the ClawMetry adapter that observes it. `repo: null` = no public
+  source (audited from on-disk format instead).
+- **`sync.sh`** — clones/pulls every harness with a repo into `../harness/<runtime>`
+  (override with `HARNESS_DIR`). Idempotent, shallow by default.
+- **`audit.py`** — for each runtime, builds the harness's observable surface +
+  the adapter source + the `Capability` enum, asks Claude for grounded gaps, and
+  files deduplicated issues (`harness-gap`, `runtime:<rt>`, `severity:<s>`).
+  Dry-run by default; `--file-issues` to open them. `--runtime <rt>` for one.
+- **`.github/workflows/harness-observability-audit.yml`** — runs it daily
+  (06:00 UTC) + on demand. Needs `CLAUDE_CODE_OAUTH_TOKEN` (model pass) and
+  optionally `CLOUD_REPO_PAT` (to read the closed `clawmetry-pro` adapters).
+
+## Monitored runtimes (12)
+Public source synced: **openclaw, nemoclaw, claude_code, codex, goose, aider,
+opencode, qwen_code, hermes, nanoclaw, cursor** (cursor = its `agent-trace` format).
+Needs a repo URL: **picoclaw** (set `repo` in `manifest.json` when known).
+
+## Add / fix a runtime
+Edit `manifest.json` — set `repo` to the verified GitHub URL (HTTP-check it; never
+guess), `adapter` to the ClawMetry adapter path, `adapter_repo` to `clawmetry` or
+`clawmetry-pro`. The sync + audit pick it up automatically next run.
+
+## Run locally
+```bash
+scripts/harness/sync.sh                                  # clone/pull all
+python3 scripts/harness/audit.py --runtime goose         # dry-run one
+CLAUDE_CODE_OAUTH_TOKEN=… python3 scripts/harness/audit.py --file-issues   # all, file issues
+```

--- a/scripts/harness/audit.py
+++ b/scripts/harness/audit.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Daily harness-observability audit: for every monitored runtime, compare what
+its upstream harness EXPOSES (sessions, events, tool calls, cost/tokens, cache,
+telemetry, new features) against what ClawMetry's adapter actually CAPTURES, and
+file a GitHub issue for each gap so it can be picked up.
+
+Runs locally or in CI (.github/workflows/harness-observability-audit.yml). The
+comparison is done by Claude (the `claude` CLI, same as i18n-autotranslate) so it
+keeps up as harnesses evolve. Every step degrades gracefully — a missing clone,
+a missing token, or a bad model response skips that runtime, never crashes the
+run (so the workflow is safe to schedule before secrets exist).
+
+Anti-hallucination (FLYWHEEL §1d): the model is given the REAL adapter source +
+the REAL harness files + the declared Capability enum, and asked to ground every
+gap in a concrete file/path it can point to. Gaps with no `where` are dropped.
+Issues are deduplicated by a stable fingerprint so a daily run doesn't spam.
+
+Usage:
+  python3 scripts/harness/audit.py                 # audit all, DRY-RUN (print)
+  python3 scripts/harness/audit.py --file-issues   # actually open/refresh issues
+  python3 scripts/harness/audit.py --runtime goose # one runtime
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.normpath(os.path.join(HERE, "..", ".."))
+MANIFEST = os.path.join(HERE, "manifest.json")
+
+# Keyword groups that flag a harness file as part of its OBSERVABLE surface — what
+# a monitoring tool would want to read. Used to pull the most relevant files into
+# the audit context (a shallow clone can be large; we never feed the whole tree).
+_OBS_KEYWORDS = (
+    "session", "transcript", "rollout", "event", "telemetry", "otel",
+    "opentelemetry", "trace", "span", "usage", "token", "cost", "price",
+    "cache", "model", "tool_call", "tool_use", "log", "metric", "history",
+)
+_ISSUE_LABELS = ["harness-gap", "automated", "observability"]
+
+
+def _load_manifest() -> dict:
+    with open(MANIFEST, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _clone_dir(manifest: dict) -> str:
+    env = os.environ.get("HARNESS_DIR")
+    if env:
+        return env
+    return os.path.normpath(os.path.join(REPO_ROOT, manifest.get("clone_dir", "../harness")))
+
+
+def _read(path: str, limit: int = 16000) -> str:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return f.read(limit)
+    except Exception:
+        return ""
+
+
+def _git(cwd: str, *args: str) -> str:
+    try:
+        return subprocess.check_output(["git", *args], cwd=cwd, text=True,
+                                       stderr=subprocess.DEVNULL, timeout=30)
+    except Exception:
+        return ""
+
+
+def _harness_surface(clone: str) -> str:
+    """A compact view of the harness's observable surface: recent commit subjects
+    + the top files whose names hint at session/telemetry/cost data, trimmed."""
+    if not os.path.isdir(clone):
+        return ""
+    out = []
+    log = _git(clone, "log", "--oneline", "-30")
+    if log:
+        out.append("RECENT COMMITS (last 30):\n" + log.strip())
+    hits = []
+    for root, dirs, files in os.walk(clone):
+        if ".git" in dirs:
+            dirs.remove(".git")
+        # don't descend into vendored deps
+        dirs[:] = [d for d in dirs if d not in ("node_modules", "target", "dist", "build", ".venv")]
+        for fn in files:
+            low = fn.lower()
+            if any(k in low for k in _OBS_KEYWORDS) and low.rsplit(".", 1)[-1] in (
+                    "py", "rs", "ts", "tsx", "js", "go", "md", "json", "toml"):
+                hits.append(os.path.join(root, fn))
+    # rank: prefer shorter paths (closer to root) and dedupe; cap to keep prompt small
+    hits = sorted(set(hits), key=lambda p: (p.count(os.sep), len(p)))[:6]
+    for p in hits:
+        rel = os.path.relpath(p, clone)
+        out.append(f"\n--- {rel} (excerpt) ---\n" + _read(p, 4000))
+    return "\n".join(out)[:32000]
+
+
+def _adapter_source(h: dict) -> str:
+    """Read the ClawMetry adapter for this runtime (from clawmetry or, if present,
+    a sibling clawmetry-pro checkout). Missing pro checkout => note it."""
+    rel = h["adapter"]
+    if h.get("adapter_repo") == "clawmetry-pro":
+        for base in (os.path.join(REPO_ROOT, "..", "clawmetry-pro"),
+                     os.environ.get("CLAWMETRY_PRO_DIR", "")):
+            if base and os.path.exists(os.path.join(base, rel)):
+                return _read(os.path.join(base, rel))
+        return "(clawmetry-pro adapter not checked out in this run — audit the harness surface alone)"
+    return _read(os.path.join(REPO_ROOT, rel))
+
+
+def _capabilities_enum() -> str:
+    return _read(os.path.join(REPO_ROOT, "clawmetry", "adapters", "base.py"), 6000)
+
+
+def _build_prompt(h: dict, surface: str, adapter: str, caps: str) -> str:
+    return f"""You audit observability coverage for ClawMetry, which monitors AI agent runtimes.
+
+RUNTIME: {h['runtime']} ({h.get('display', h['runtime'])})
+{('NOTE: ' + h['note']) if h.get('note') else ''}
+
+ClawMetry's Capability contract (the things an adapter can declare it observes):
+```
+{caps}
+```
+
+ClawMetry's adapter that observes this runtime (what it ACTUALLY captures today):
+```
+{adapter}
+```
+
+The upstream harness — its observable surface (recent commits + data/telemetry files):
+```
+{surface or '(no public source available — reason for that is in NOTE above)'}
+```
+
+TASK: List concrete OBSERVABLE signals the harness EXPOSES that the ClawMetry
+adapter does NOT capture today — e.g. a new session field, a cost/token/cache
+counter, an OTel/telemetry stream, tool-call metadata, error/retry signals, a new
+storage format, a new feature that emits data. Ground EVERY gap in a real file or
+path you can point to in the harness; if you can't point to where the harness
+exposes it, DO NOT include it (no speculation).
+
+Output ONLY a JSON array (no prose). Each element:
+{{"title": "<short, runtime-prefixed>", "exposes": "<what the harness emits>",
+  "missing": "<what ClawMetry doesn't capture>", "where": "<harness file/path>",
+  "severity": "high|medium|low", "capability": "<closest Capability enum name or 'new'>"}}
+If coverage looks complete, output []."""
+
+
+def _run_claude(prompt: str) -> str:
+    """Call the `claude` CLI (CLAUDE_CODE_OAUTH_TOKEN in env). Returns raw text or ''."""
+    if not (os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY")):
+        print("  [skip] no CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY — analysis skipped")
+        return ""
+    try:
+        p = subprocess.run(["claude", "-p", prompt], capture_output=True, text=True, timeout=300)
+        return p.stdout or ""
+    except FileNotFoundError:
+        print("  [skip] `claude` CLI not on PATH")
+        return ""
+    except Exception as e:
+        print(f"  [skip] claude call failed: {e}")
+        return ""
+
+
+def _extract_json_array(text: str) -> list:
+    if not text:
+        return []
+    # tolerate ```json fences / surrounding prose: grab the first [...] block
+    i, j = text.find("["), text.rfind("]")
+    if i == -1 or j == -1 or j < i:
+        return []
+    try:
+        data = json.loads(text[i:j + 1])
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+def _fingerprint(runtime: str, gap: dict) -> str:
+    key = f"{runtime}:{gap.get('title', '')}:{gap.get('where', '')}".lower()
+    return "hgap-" + hashlib.sha1(key.encode()).hexdigest()[:10]
+
+
+def _existing_fingerprints() -> set:
+    """Fingerprints of already-filed gaps (from issue bodies), so a daily run
+    never re-files the same gap. Matches the `hgap-<10hex>` token we embed."""
+    import re
+    try:
+        out = subprocess.check_output(
+            ["gh", "issue", "list", "--label", "harness-gap", "--state", "all",
+             "--limit", "500", "--json", "body"], text=True, stderr=subprocess.DEVNULL)
+        fps: set = set()
+        for it in json.loads(out):
+            fps.update(re.findall(r"hgap-[0-9a-f]{10}", it.get("body") or ""))
+        return fps
+    except Exception:
+        return set()
+
+
+def _file_issue(runtime: str, gap: dict, fp: str, dry: bool) -> None:
+    title = f"[obs-gap:{runtime}] " + str(gap.get("title", "observability gap"))[:140]
+    sev = gap.get("severity", "medium")
+    body = (
+        f"Automated harness-observability audit found a gap for **{runtime}**.\n\n"
+        f"- **Harness exposes:** {gap.get('exposes', '')}\n"
+        f"- **ClawMetry misses:** {gap.get('missing', '')}\n"
+        f"- **Where (harness):** `{gap.get('where', '')}`\n"
+        f"- **Severity:** {sev}\n"
+        f"- **Closest capability:** {gap.get('capability', 'new')}\n\n"
+        f"_Filed by `scripts/harness/audit.py`. Fingerprint: {fp} (used to dedupe — keep it in the body)._"
+    )
+    labels = _ISSUE_LABELS + [f"runtime:{runtime}", f"severity:{sev}"]
+    if dry:
+        print(f"  [dry-run] would file: {title}  ({fp})")
+        return
+    try:
+        subprocess.run(["gh", "issue", "create", "--title", title, "--body", body,
+                        "--label", ",".join(labels)], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+        print(f"  [filed] {title}")
+    except Exception as e:
+        # label may not exist yet; retry without labels rather than lose the issue
+        try:
+            subprocess.run(["gh", "issue", "create", "--title", title, "--body", body],
+                           check=True, stdout=subprocess.DEVNULL)
+            print(f"  [filed, no labels] {title}")
+        except Exception as e2:
+            print(f"  [error] could not file issue: {e2}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--file-issues", action="store_true", help="actually open issues (default: dry-run)")
+    ap.add_argument("--runtime", help="audit a single runtime")
+    args = ap.parse_args()
+
+    manifest = _load_manifest()
+    clone_base = _clone_dir(manifest)
+    caps = _capabilities_enum()
+    existing = _existing_fingerprints() if args.file_issues else set()
+    total_gaps = 0
+
+    for h in manifest["harnesses"]:
+        rt = h["runtime"]
+        if args.runtime and rt != args.runtime:
+            continue
+        print(f"== {rt} ==")
+        clone = os.path.join(clone_base, rt)
+        surface = _harness_surface(clone)
+        if not surface and not h.get("repo"):
+            print("  (no public source — covered by on-disk-format audit, skipping model pass)")
+            continue
+        if not surface:
+            print(f"  [skip] no clone at {clone} — run scripts/harness/sync.sh first")
+            continue
+        adapter = _adapter_source(h)
+        raw = _run_claude(_build_prompt(h, surface, adapter, caps))
+        gaps = _extract_json_array(raw)
+        print(f"  {len(gaps)} gap(s) reported")
+        for gap in gaps:
+            if not gap.get("where"):  # ungrounded -> drop (anti-hallucination)
+                continue
+            fp = _fingerprint(rt, gap)
+            if fp in existing:
+                print(f"  [dup] {gap.get('title')} ({fp}) — already filed")
+                continue
+            total_gaps += 1
+            _file_issue(rt, gap, fp, dry=not args.file_issues)
+
+    print(f"\nDone. {total_gaps} new gap(s) "
+          + ("filed." if args.file_issues else "(dry-run; pass --file-issues to open them)."))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/harness/manifest.json
+++ b/scripts/harness/manifest.json
@@ -1,0 +1,109 @@
+{
+  "_comment": "Single source of truth for the harness-observability audit. Each entry maps an agent runtime ClawMetry monitors to its upstream source repo + the ClawMetry adapter that observes it. The daily audit (.github/workflows/harness-observability-audit.yml) clones/pulls each repo, reviews what the harness exposes that's observable, and files a GH issue for anything ClawMetry's adapter doesn't yet capture. repo=null => no public source to clone (closed, or URL not yet known); those are audited from on-disk format + docs instead.",
+  "_verified": "2026-06-04 — repo URLs HTTP-checked; closed/unknown left null on purpose (no guessing).",
+  "clone_dir": "../harness",
+  "harnesses": [
+    {
+      "runtime": "openclaw",
+      "display": "OpenClaw",
+      "repo": "https://github.com/openclaw/openclaw",
+      "adapter": "clawmetry/adapters/openclaw.py",
+      "adapter_repo": "clawmetry",
+      "tier": "free"
+    },
+    {
+      "runtime": "nemoclaw",
+      "display": "NVIDIA NemoClaw",
+      "repo": "https://github.com/NVIDIA/NemoClaw",
+      "adapter": "clawmetry/adapters/openclaw.py",
+      "adapter_repo": "clawmetry",
+      "tier": "free",
+      "note": "Sandboxed OpenClaw — runs the OpenClaw adapter; audit NeMo-specific guardrail/sandbox telemetry."
+    },
+    {
+      "runtime": "claude_code",
+      "display": "Claude Code",
+      "repo": "https://github.com/yasasbanukaofficial/claude-code",
+      "adapter": "clawmetry_pro/adapters/claude_code.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro",
+      "note": "Full Claude Code source (founder-provided mirror)."
+    },
+    {
+      "runtime": "codex",
+      "display": "OpenAI Codex",
+      "repo": "https://github.com/openai/codex",
+      "adapter": "clawmetry_pro/adapters/codex.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro"
+    },
+    {
+      "runtime": "goose",
+      "display": "Goose",
+      "repo": "https://github.com/aaif-goose/goose",
+      "adapter": "clawmetry_pro/adapters/goose.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro"
+    },
+    {
+      "runtime": "aider",
+      "display": "Aider",
+      "repo": "https://github.com/Aider-AI/aider",
+      "adapter": "clawmetry_pro/adapters/aider.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro"
+    },
+    {
+      "runtime": "opencode",
+      "display": "opencode",
+      "repo": "https://github.com/anomalyco/opencode",
+      "adapter": "clawmetry_pro/adapters/opencode.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro"
+    },
+    {
+      "runtime": "qwen_code",
+      "display": "Qwen Code",
+      "repo": "https://github.com/QwenLM/qwen-code",
+      "adapter": "clawmetry_pro/adapters/qwen_code.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro"
+    },
+    {
+      "runtime": "cursor",
+      "display": "Cursor",
+      "repo": "https://github.com/cursor/agent-trace",
+      "adapter": "clawmetry_pro/adapters/cursor.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro",
+      "note": "Cursor is a closed IDE; agent-trace is its agent trace/telemetry format — audit that against our state.vscdb reader."
+    },
+    {
+      "runtime": "hermes",
+      "display": "Hermes",
+      "repo": "https://github.com/NousResearch/hermes-agent",
+      "adapter": "clawmetry_pro/adapters/hermes.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro",
+      "note": "Nous Research Hermes agent. Binary `tirith`, ~/.hermes/state.db."
+    },
+    {
+      "runtime": "picoclaw",
+      "display": "PicoClaw",
+      "repo": null,
+      "adapter": "clawmetry_pro/adapters/picoclaw.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro",
+      "note": "Repo URL not yet known — needs founder. OpenClaw-family, JSONL provider Messages."
+    },
+    {
+      "runtime": "nanoclaw",
+      "display": "NanoClaw",
+      "repo": "https://github.com/nanocoai/nanoclaw",
+      "adapter": "clawmetry_pro/adapters/nanoclaw.py",
+      "adapter_repo": "clawmetry-pro",
+      "tier": "pro",
+      "note": "Per-session inbound.db/outbound.db SQLite."
+    }
+  ]
+}

--- a/scripts/harness/sync.sh
+++ b/scripts/harness/sync.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Sync every monitored agent-harness source into a local checkout so we can audit
+# what each exposes vs what ClawMetry observes. Reads scripts/harness/manifest.json.
+#
+# Idempotent: first run clones (shallow), later runs fast-forward pull. repo=null
+# entries (closed source / URL unknown) are skipped with a note.
+#
+#   scripts/harness/sync.sh                 # clone/pull into ../harness (manifest default)
+#   HARNESS_DIR=/tmp/h scripts/harness/sync.sh   # override target dir
+#   DEPTH=50 scripts/harness/sync.sh        # deeper history (default: shallow depth=1)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$HERE/manifest.json"
+[ -f "$MANIFEST" ] || { echo "manifest not found: $MANIFEST" >&2; exit 1; }
+
+# Resolve clone dir: env override > manifest clone_dir (relative to repo root) > ../harness
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+DEFAULT_DIR="$(python3 -c "import json,os;m=json.load(open('$MANIFEST'));print(os.path.normpath(os.path.join('$REPO_ROOT', m.get('clone_dir','../harness'))))")"
+HARNESS_DIR="${HARNESS_DIR:-$DEFAULT_DIR}"
+DEPTH="${DEPTH:-1}"
+mkdir -p "$HARNESS_DIR"
+echo "[harness-sync] target: $HARNESS_DIR (depth=$DEPTH)"
+
+# Emit "runtime<TAB>repo" for entries that have a repo.
+python3 - "$MANIFEST" <<'PY' | while IFS=$'\t' read -r rt repo; do
+import json, sys
+m = json.load(open(sys.argv[1]))
+for h in m["harnesses"]:
+    if h.get("repo"):
+        print(f"{h['runtime']}\t{h['repo']}")
+PY
+  dest="$HARNESS_DIR/$rt"
+  if [ -d "$dest/.git" ]; then
+    echo "[harness-sync] $rt: pull"
+    git -C "$dest" remote set-url origin "$repo" 2>/dev/null || true
+    git -C "$dest" fetch --depth "$DEPTH" origin >/dev/null 2>&1 \
+      && git -C "$dest" reset --hard "@{upstream}" >/dev/null 2>&1 \
+      && echo "[harness-sync] $rt: up to date @ $(git -C "$dest" rev-parse --short HEAD)" \
+      || echo "[harness-sync] $rt: pull FAILED (kept existing checkout)"
+  else
+    echo "[harness-sync] $rt: clone $repo"
+    rm -rf "$dest"
+    if git clone --depth "$DEPTH" "$repo" "$dest" >/dev/null 2>&1; then
+      echo "[harness-sync] $rt: cloned @ $(git -C "$dest" rev-parse --short HEAD)"
+    else
+      echo "[harness-sync] $rt: clone FAILED ($repo)"
+    fi
+  fi
+done
+
+# Report the skipped (closed / unknown) harnesses so the gap is visible, not silent.
+python3 - "$MANIFEST" <<'PY'
+import json, sys
+m = json.load(open(sys.argv[1]))
+skipped = [h for h in m["harnesses"] if not h.get("repo")]
+if skipped:
+    print("[harness-sync] no public source (audited from on-disk format instead): "
+          + ", ".join(f"{h['runtime']} ({h.get('note','')[:40]})" for h in skipped))
+PY
+echo "[harness-sync] done."

--- a/tests/test_harness_manifest.py
+++ b/tests/test_harness_manifest.py
@@ -1,0 +1,59 @@
+"""Guard: the harness-observability manifest stays well-formed and complete.
+
+scripts/harness/manifest.json drives the daily audit that keeps ClawMetry's
+coverage current as the runtimes evolve. If it drifts (a runtime dropped, a bad
+repo URL, a wrong adapter path), the audit silently skips that runtime — so we
+pin the shape here.
+"""
+import json
+import os
+import re
+
+HERE = os.path.dirname(__file__)
+MANIFEST = os.path.join(HERE, "..", "scripts", "harness", "manifest.json")
+
+# The 12 runtimes ClawMetry monitors (matches the v1 API _RUNTIME_PREFIXES +
+# openclaw/nemoclaw). The manifest must cover exactly these.
+_RUNTIMES = {
+    "openclaw", "nemoclaw", "claude_code", "codex", "goose", "aider",
+    "opencode", "qwen_code", "cursor", "hermes", "picoclaw", "nanoclaw",
+}
+
+
+def _load():
+    with open(MANIFEST, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_manifest_is_valid_json_and_covers_all_runtimes():
+    m = _load()
+    runtimes = {h["runtime"] for h in m["harnesses"]}
+    assert runtimes == _RUNTIMES, (
+        f"manifest runtimes drifted: missing={_RUNTIMES - runtimes}, "
+        f"extra={runtimes - _RUNTIMES}"
+    )
+
+
+def test_every_entry_is_well_formed():
+    m = _load()
+    for h in m["harnesses"]:
+        rt = h.get("runtime")
+        assert rt, f"entry missing runtime: {h}"
+        assert h.get("adapter"), f"{rt}: missing adapter path"
+        assert h.get("adapter_repo") in ("clawmetry", "clawmetry-pro"), f"{rt}: bad adapter_repo"
+        repo = h.get("repo")
+        # repo is either null (closed/unknown, with a note) or a real https GitHub URL
+        if repo is None:
+            assert h.get("note"), f"{rt}: repo=null must carry a note explaining why"
+        else:
+            assert re.match(r"^https://github\.com/[\w.-]+/[\w.-]+$", repo), \
+                f"{rt}: repo is not a github https URL: {repo}"
+
+
+def test_openclaw_and_nemoclaw_are_free_tier():
+    m = _load()
+    by = {h["runtime"]: h for h in m["harnesses"]}
+    assert by["openclaw"]["tier"] == "free"
+    assert by["nemoclaw"]["tier"] == "free"
+    # nemoclaw is sandboxed openclaw -> shares the openclaw adapter
+    assert by["nemoclaw"]["adapter"] == by["openclaw"]["adapter"]


### PR DESCRIPTION
Founder request: *"clone all the harnesses we monitor, a cron to fetch their latest code daily, a cron to review what each can observe + check if ClawMetry observes every aspect, fully automated, file GH issues to bridge the gaps."*

## What this does
A daily GitHub Action (`harness-observability-audit.yml`, 06:00 UTC + on-demand) that:
1. **Syncs** every monitored runtime's upstream source (`scripts/harness/sync.sh` → `../harness/<rt>`).
2. **Audits** each: feeds Claude the harness's observable surface (recent commits + session/telemetry/cost files) + our adapter + the `Capability` enum, and asks for **grounded** gaps — every gap must point to a real harness file (ungrounded = dropped, per the anti-hallucination rule).
3. **Files deduplicated GH issues** (`harness-gap`, `runtime:<rt>`, `severity:<s>`) so gaps get picked up.

## Coverage (12 runtimes)
Verified public repos (HTTP-checked, **no guessing**): openclaw, nemoclaw, claude_code, codex, goose, aider, opencode, qwen_code, hermes, nanoclaw, cursor (its `agent-trace` format). **picoclaw** repo URL still needed — set it in `manifest.json` and it's auto-picked-up.

Verified locally: all 10 public repos cloned clean into `~/projects/harness/`.

## Safety
- Degrades gracefully: no `CLAUDE_CODE_OAUTH_TOKEN` → clones + dry-run only (warns, never fails), like i18n-autotranslate. `clawmetry-pro` checkout is best-effort (reduced adapter context if absent).
- Dedup by a `hgap-` fingerprint in issue bodies → daily runs don't spam.
- `tests/test_harness_manifest.py` guards the manifest covers all 12 runtimes + every entry is well-formed.

## To activate the model pass
Add repo secret `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) and optionally `CLOUD_REPO_PAT` (to read closed pro adapters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)