### PR TITLE
fix(harness): full adapter context + verify capabilities() (cut false-positive gaps)

### DIFF
--- a/scripts/harness/audit.py
+++ b/scripts/harness/audit.py
@@ -238,6 +238,10 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--file-issues", action="store_true", help="actually open issues (default: dry-run)")
     ap.add_argument("--runtime", help="audit a single runtime")
+    ap.add_argument("--max-per-runtime", type=int, default=5,
+                    help="cap issues filed per runtime (highest-severity first); 0 = no cap")
+    ap.add_argument("--include-low", action="store_true",
+                    help="also file low-severity gaps (default: skip them)")
     args = ap.parse_args()
 
     manifest = _load_manifest()
@@ -263,9 +267,20 @@ def main() -> int:
         raw = _run_claude(_build_prompt(h, surface, adapter, caps))
         gaps = _extract_json_array(raw)
         print(f"  {len(gaps)} gap(s) reported")
-        for gap in gaps:
-            if not gap.get("where"):  # ungrounded -> drop (anti-hallucination)
-                continue
+        # Ground (anti-hallucination), severity-sort, drop low, cap per runtime so a
+        # daily run produces a focused, high-value stream — not 100+ noisy issues.
+        # The cap is LOGGED (no silent truncation, FLYWHEEL "no silent caps").
+        _sev = {"high": 0, "medium": 1, "low": 2}
+        grounded = [g for g in gaps if g.get("where")]
+        grounded.sort(key=lambda g: _sev.get(str(g.get("severity", "medium")).lower(), 1))
+        keep = grounded if args.include_low else [
+            g for g in grounded if str(g.get("severity", "medium")).lower() != "low"]
+        capped = keep if args.max_per_runtime <= 0 else keep[:args.max_per_runtime]
+        deferred = len(grounded) - len(capped)
+        if deferred:
+            print(f"  filing {len(capped)} of {len(grounded)} grounded gap(s); "
+                  f"{deferred} lower-priority deferred (raise --max-per-runtime / --include-low)")
+        for gap in capped:
             fp = _fingerprint(rt, gap)
             if fp in existing:
                 print(f"  [dup] {gap.get('title')} ({fp}) — already filed")

--- a/scripts/harness/audit.py
+++ b/scripts/harness/audit.py
@@ -101,16 +101,19 @@ def _harness_surface(clone: str) -> str:
 
 
 def _adapter_source(h: dict) -> str:
-    """Read the ClawMetry adapter for this runtime (from clawmetry or, if present,
-    a sibling clawmetry-pro checkout). Missing pro checkout => note it."""
+    """Read the FULL ClawMetry adapter for this runtime (from clawmetry or a
+    sibling clawmetry-pro checkout). Read the whole file (up to 60k) — truncating
+    drops the tail, and capabilities()/cost-derivation often live at the BOTTOM
+    of the adapter, which caused false-positive gaps (e.g. aider's conditional
+    COST at line ~527 was cut, so the audit wrongly flagged 'no COST')."""
     rel = h["adapter"]
     if h.get("adapter_repo") == "clawmetry-pro":
         for base in (os.path.join(REPO_ROOT, "..", "clawmetry-pro"),
                      os.environ.get("CLAWMETRY_PRO_DIR", "")):
             if base and os.path.exists(os.path.join(base, rel)):
-                return _read(os.path.join(base, rel))
+                return _read(os.path.join(base, rel), 60000)
         return "(clawmetry-pro adapter not checked out in this run — audit the harness surface alone)"
-    return _read(os.path.join(REPO_ROOT, rel))
+    return _read(os.path.join(REPO_ROOT, rel), 60000)
 
 
 def _capabilities_enum() -> str:
@@ -144,6 +147,12 @@ counter, an OTel/telemetry stream, tool-call metadata, error/retry signals, a ne
 storage format, a new feature that emits data. Ground EVERY gap in a real file or
 path you can point to in the harness; if you can't point to where the harness
 exposes it, DO NOT include it (no speculation).
+
+CRITICAL — verify against the FULL adapter above before reporting (it is provided
+in full): do NOT flag something the adapter already handles. In particular check
+``capabilities()`` (capabilities are often added CONDITIONALLY at the bottom of
+the file), any ``derive_cost_usd`` / cost-derivation, and the field mapping. If
+the adapter already captures or derives it, it is NOT a gap.
 
 Output ONLY a JSON array (no prose). Each element:
 {{"title": "<short, runtime-prefixed>", "exposes": "<what the harness emits>",


### PR DESCRIPTION
Found a false positive in the seeded backlog (closed #2595: aider 'no COST' — the adapter actually derives cost + adds COST **conditionally** at line ~527). Root cause: the audit read only the first 16k chars of each adapter, **truncating the tail** where capabilities()/cost-derivation live. The model's auto-filed gaps share this blind spot.

Fix: feed the **full** adapter (up to 60k) + an explicit instruction to verify against `capabilities()` / `derive_cost_usd` before reporting. Future daily runs are higher-signal. (Existing backlog still needs human triage — #2595 is the worked example of how.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)