### PR TITLE
[RELEASE] feat(otlp): /v1/logs receiver — ingest Claude Code/Codex OTel events (#2596)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Release: OTLP /v1/logs receiver — ingest Claude Code / Codex OTel event stream (#2596) (2026-06-04)
+- **Why:** the OTLP receiver had /v1/metrics + /v1/traces but no /v1/logs. Claude Code (and Codex) export their per-turn EVENT stream as OTel *logs* (event_name like `claude_code.api_request` with cost/token/model attributes), so OTel-configured installs gave signal we dropped. Surfaced by the harness-observability audit.
+- **What:** add `POST /v1/logs` (mirrors /v1/traces; 501 without the `clawmetry[otel]` extra) + `_process_otlp_logs`, which maps any OTLP LogRecord carrying cost/token/duration attributes into the cost / tokens / runs metric tiles. Point an agent at it with `OTEL_LOGS_EXPORTER=otlp`, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:8900`.
+- **Test:** `tests/test_otlp_logs.py` builds a synthetic ExportLogsServiceRequest and asserts a claude_code.api_request lands in cost+tokens+runs; a non-cost event is ignored.
+
 ### Release: Context economics filters per-runtime (snapshot byRuntime slice) (2026-06-03)
 - **Why:** like Tool catalog, the Context-economics tab showed the all-runtimes aggregate on every runtime tab (founder report). Compactions from every runtime were lumped together.
 - **What:** the contextEconomics snapshot slice now carries `byRuntime` (runtime -> {compactions, overflow_sessions, summary}) via `_context_econ_by_runtime`, grouped by each compaction's session_id prefix. The cloud interceptor serves the selected runtime's view (empty for a runtime that never compacted). Removed context-economics from `_CM_RT_AGGREGATE` so its 'not yet filtered' banner no longer shows.

--- a/dashboard.py
+++ b/dashboard.py
@@ -154,11 +154,13 @@ _HAS_OTEL_PROTO = False
 try:
     from opentelemetry.proto.collector.metrics.v1 import metrics_service_pb2
     from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+    from opentelemetry.proto.collector.logs.v1 import logs_service_pb2
 
     _HAS_OTEL_PROTO = True
 except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
+    logs_service_pb2 = None
 
 __version__ = "0.12.434"
 
@@ -2494,6 +2496,76 @@ def _process_otlp_traces(pb_data):
                             )
                         except Exception:
                             pass
+
+
+def _process_otlp_logs(pb_data):
+    """Decode OTLP logs protobuf and ingest agent EVENT records (#2596).
+
+    Claude Code (and other runtimes) export their per-turn event stream as OTel
+    *logs* — ``event_name`` like ``claude_code.api_request`` / ``tool_decision``
+    with cost/token/model attributes — not just metrics/traces, so an OTel-
+    configured install gives signal we previously dropped. We map any log record
+    carrying cost or token attributes into the same metrics cache categories as
+    /v1/metrics (cost / tokens / runs), so the cost + usage tiles light up.
+    Best-effort: a bad record never breaks the batch.
+    """
+    req = logs_service_pb2.ExportLogsServiceRequest()
+    req.ParseFromString(pb_data)
+
+    def _f(attrs, *keys):
+        for k in keys:
+            if k in attrs and attrs[k] not in (None, ""):
+                return attrs[k]
+        return None
+
+    for resource_logs in req.resource_logs:
+        resource_attrs = {}
+        if resource_logs.resource:
+            for attr in resource_logs.resource.attributes:
+                resource_attrs[attr.key] = _otel_attr_value(attr.value)
+
+        for scope_logs in resource_logs.scope_logs:
+            for rec in scope_logs.log_records:
+                attrs = {}
+                for attr in rec.attributes:
+                    attrs[attr.key] = _otel_attr_value(attr.value)
+                ts = time.time()
+                model = _f(attrs, "model") or resource_attrs.get("model", "")
+                channel = _f(attrs, "channel") or resource_attrs.get("channel", "")
+                provider = _f(attrs, "provider") or resource_attrs.get("provider", "")
+
+                cost = _f(attrs, "cost_usd", "cost.usd", "cost")
+                if cost is not None:
+                    try:
+                        _add_metric("cost", {
+                            "timestamp": ts, "usd": float(cost),
+                            "model": model, "channel": channel, "provider": provider,
+                        })
+                    except (TypeError, ValueError):
+                        pass
+
+                itok = _f(attrs, "input_tokens", "tokens.input", "prompt_tokens")
+                otok = _f(attrs, "output_tokens", "tokens.output", "completion_tokens")
+                if itok is not None or otok is not None:
+                    try:
+                        i, o = int(itok or 0), int(otok or 0)
+                        _add_metric("tokens", {
+                            "timestamp": ts, "input": i, "output": o, "total": i + o,
+                            "model": model, "channel": channel, "provider": provider,
+                        })
+                    except (TypeError, ValueError):
+                        pass
+
+                dur = _f(attrs, "duration_ms", "duration.ms")
+                ev = (getattr(rec, "event_name", "") or "").lower()
+                if dur is not None and any(k in ev for k in ("request", "run", "completion")):
+                    try:
+                        _add_metric("runs", {
+                            "timestamp": ts, "duration_ms": float(dur),
+                            "model": model, "channel": channel,
+                        })
+                    except (TypeError, ValueError):
+                        pass
 
 
 def _get_otel_usage_data():
@@ -8119,11 +8191,13 @@ _HAS_OTEL_PROTO = False
 try:
     from opentelemetry.proto.collector.metrics.v1 import metrics_service_pb2
     from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+    from opentelemetry.proto.collector.logs.v1 import logs_service_pb2
 
     _HAS_OTEL_PROTO = True
 except ImportError:
     metrics_service_pb2 = None
     trace_service_pb2 = None
+    logs_service_pb2 = None
 
 
 app = Flask(
@@ -10465,6 +10539,76 @@ def _process_otlp_traces(pb_data):
                             )
                         except Exception:
                             pass
+
+
+def _process_otlp_logs(pb_data):
+    """Decode OTLP logs protobuf and ingest agent EVENT records (#2596).
+
+    Claude Code (and other runtimes) export their per-turn event stream as OTel
+    *logs* — ``event_name`` like ``claude_code.api_request`` / ``tool_decision``
+    with cost/token/model attributes — not just metrics/traces, so an OTel-
+    configured install gives signal we previously dropped. We map any log record
+    carrying cost or token attributes into the same metrics cache categories as
+    /v1/metrics (cost / tokens / runs), so the cost + usage tiles light up.
+    Best-effort: a bad record never breaks the batch.
+    """
+    req = logs_service_pb2.ExportLogsServiceRequest()
+    req.ParseFromString(pb_data)
+
+    def _f(attrs, *keys):
+        for k in keys:
+            if k in attrs and attrs[k] not in (None, ""):
+                return attrs[k]
+        return None
+
+    for resource_logs in req.resource_logs:
+        resource_attrs = {}
+        if resource_logs.resource:
+            for attr in resource_logs.resource.attributes:
+                resource_attrs[attr.key] = _otel_attr_value(attr.value)
+
+        for scope_logs in resource_logs.scope_logs:
+            for rec in scope_logs.log_records:
+                attrs = {}
+                for attr in rec.attributes:
+                    attrs[attr.key] = _otel_attr_value(attr.value)
+                ts = time.time()
+                model = _f(attrs, "model") or resource_attrs.get("model", "")
+                channel = _f(attrs, "channel") or resource_attrs.get("channel", "")
+                provider = _f(attrs, "provider") or resource_attrs.get("provider", "")
+
+                cost = _f(attrs, "cost_usd", "cost.usd", "cost")
+                if cost is not None:
+                    try:
+                        _add_metric("cost", {
+                            "timestamp": ts, "usd": float(cost),
+                            "model": model, "channel": channel, "provider": provider,
+                        })
+                    except (TypeError, ValueError):
+                        pass
+
+                itok = _f(attrs, "input_tokens", "tokens.input", "prompt_tokens")
+                otok = _f(attrs, "output_tokens", "tokens.output", "completion_tokens")
+                if itok is not None or otok is not None:
+                    try:
+                        i, o = int(itok or 0), int(otok or 0)
+                        _add_metric("tokens", {
+                            "timestamp": ts, "input": i, "output": o, "total": i + o,
+                            "model": model, "channel": channel, "provider": provider,
+                        })
+                    except (TypeError, ValueError):
+                        pass
+
+                dur = _f(attrs, "duration_ms", "duration.ms")
+                ev = (getattr(rec, "event_name", "") or "").lower()
+                if dur is not None and any(k in ev for k in ("request", "run", "completion")):
+                    try:
+                        _add_metric("runs", {
+                            "timestamp": ts, "duration_ms": float(dur),
+                            "model": model, "channel": channel,
+                        })
+                    except (TypeError, ValueError):
+                        pass
 
 
 def _get_otel_usage_data():

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -1062,6 +1062,33 @@ def otlp_traces():
         return jsonify({"error": str(e)}), 400
 
 
+@bp_otel.route("/v1/logs", methods=["POST"])
+def otlp_logs():
+    """OTLP/HTTP receiver for logs (protobuf). Ingests the agent EVENT stream
+    that Claude Code / Codex export as OTel logs (cost/token/model per record),
+    mapping them into the cost + usage tiles. Closes obs-gap #2596."""
+    import dashboard as _d
+    if _d._budget_paused:
+        return jsonify(
+            {"error": "Budget limit exceeded - intake paused", "paused": True}
+        ), 429
+    if not _d._HAS_OTEL_PROTO:
+        return jsonify(
+            {
+                "error": "opentelemetry-proto not installed",
+                "message": "Install OTLP support: pip install clawmetry[otel]  "
+                "or: pip install opentelemetry-proto protobuf",
+            }
+        ), 501
+
+    try:
+        pb_data = request.get_data()
+        _d._process_otlp_logs(pb_data)
+        return "{}", 200, {"Content-Type": "application/json"}
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
 @bp_otel.route("/api/otel-status")
 def api_otel_status():
     """Return OTLP receiver + exporter status."""

--- a/tests/test_otlp_logs.py
+++ b/tests/test_otlp_logs.py
@@ -1,0 +1,76 @@
+"""obs-gap #2596: the /v1/logs OTLP receiver must ingest agent event records.
+
+Claude Code / Codex export their per-turn EVENT stream as OTel *logs* (event_name
+like ``claude_code.api_request`` with cost/token/model attributes). We had
+/v1/metrics + /v1/traces but no /v1/logs, so those events were dropped.
+``_process_otlp_logs`` maps any log record carrying cost/token attributes into
+the cost + tokens metric tiles. Skips cleanly when opentelemetry-proto is absent
+(same as the other OTLP tests).
+"""
+import time
+
+import pytest
+
+pytest.importorskip("opentelemetry.proto.collector.logs.v1.logs_service_pb2",
+                    reason="opentelemetry-proto not installed (pip install clawmetry[otel])")
+
+from opentelemetry.proto.collector.logs.v1 import logs_service_pb2  # noqa: E402
+from opentelemetry.proto.logs.v1 import logs_pb2  # noqa: E402
+from opentelemetry.proto.common.v1 import common_pb2  # noqa: E402
+
+import dashboard as _d  # noqa: E402
+
+
+def _kv(key, s=None, i=None, d=None):
+    v = common_pb2.AnyValue()
+    if s is not None:
+        v.string_value = s
+    elif i is not None:
+        v.int_value = i
+    elif d is not None:
+        v.double_value = d
+    return common_pb2.KeyValue(key=key, value=v)
+
+
+def _request_with_api_event():
+    rec = logs_pb2.LogRecord(time_unix_nano=int(time.time() * 1e9))
+    rec.event_name = "claude_code.api_request"
+    rec.attributes.extend([
+        _kv("model", s="claude-opus-4-8"),
+        _kv("cost_usd", d=0.1234),
+        _kv("input_tokens", i=1500),
+        _kv("output_tokens", i=300),
+        _kv("duration_ms", d=820.0),
+    ])
+    scope = logs_pb2.ScopeLogs(log_records=[rec])
+    res = logs_pb2.ResourceLogs(scope_logs=[scope])
+    return logs_service_pb2.ExportLogsServiceRequest(resource_logs=[res])
+
+
+def test_otlp_log_event_lands_in_cost_and_tokens(monkeypatch):
+    captured = []
+    monkeypatch.setattr(_d, "_add_metric", lambda cat, e: captured.append((cat, e)))
+
+    _d._process_otlp_logs(_request_with_api_event().SerializeToString())
+
+    cats = {c for c, _ in captured}
+    assert "cost" in cats and "tokens" in cats and "runs" in cats, f"got {cats}"
+    cost = next(e for c, e in captured if c == "cost")
+    assert abs(cost["usd"] - 0.1234) < 1e-9
+    assert cost["model"] == "claude-opus-4-8"
+    toks = next(e for c, e in captured if c == "tokens")
+    assert toks["input"] == 1500 and toks["output"] == 300 and toks["total"] == 1800
+    runs = next(e for c, e in captured if c == "runs")
+    assert abs(runs["duration_ms"] - 820.0) < 1e-6
+
+
+def test_record_without_cost_or_tokens_is_ignored(monkeypatch):
+    captured = []
+    monkeypatch.setattr(_d, "_add_metric", lambda cat, e: captured.append((cat, e)))
+    rec = logs_pb2.LogRecord(time_unix_nano=int(time.time() * 1e9))
+    rec.event_name = "claude_code.tool_decision"
+    rec.attributes.extend([_kv("tool_name", s="Bash"), _kv("decision", s="allow")])
+    req = logs_service_pb2.ExportLogsServiceRequest(
+        resource_logs=[logs_pb2.ResourceLogs(scope_logs=[logs_pb2.ScopeLogs(log_records=[rec])])])
+    _d._process_otlp_logs(req.SerializeToString())
+    assert captured == [], "a non-cost/token event must not add metrics"


### PR DESCRIPTION
Closes the highest-value harness-gap (#2596). Our OTLP receiver had `/v1/metrics` + `/v1/traces` but **no `/v1/logs`** — and Claude Code/Codex export their per-turn **event** stream as OTel *logs* (`claude_code.api_request` with cost/token/model attrs), so we dropped that signal.

**Added:** `POST /v1/logs` (parallel to `/v1/traces`, 501 without `clawmetry[otel]`) + `_process_otlp_logs` mapping any LogRecord carrying cost/token/duration attributes into the cost / tokens / runs tiles.

**Built + tested properly** (I installed the otel proto in a temp venv to verify, not a rushed untested parser): `tests/test_otlp_logs.py` asserts a `claude_code.api_request` lands in cost+tokens+runs and a `tool_decision` is ignored. `importorskip` when the extra is absent.

**Enable:** `OTEL_LOGS_EXPORTER=otlp OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:8900`

Follow-ups (separate): persist each LogRecord as a DuckDB event row; Codex span enablement doc (#2591).

🤖 Generated with [Claude Code](https://claude.com/claude-code)