### PR TITLE
[RELEASE] feat(otlp): map cost/token span attributes — Codex telemetry (#2591)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -2481,6 +2481,40 @@ def _process_otlp_traces(pb_data):
                         },
                     )
 
+                # Generic cost/token mapping from span ATTRIBUTES. Codex (and
+                # OTel-instrumented agents) emit cost/token telemetry on spans
+                # like ``codex.api_request`` — without this they persist to the
+                # spans table but never light the cost/usage tiles. OpenClaw cost
+                # arrives via the /v1/metrics path (openclaw.cost.usd), not span
+                # attrs, so this doesn't double-count. Same shape as /v1/logs
+                # (#2591).
+                _sc = attrs.get("cost_usd") or attrs.get("cost.usd") or attrs.get("cost")
+                if _sc is not None:
+                    try:
+                        _add_metric("cost", {
+                            "timestamp": ts, "usd": float(_sc),
+                            "model": attrs.get("model", resource_attrs.get("model", "")),
+                            "channel": attrs.get("channel", resource_attrs.get("channel", "")),
+                            "provider": attrs.get("provider", resource_attrs.get("provider", "")),
+                        })
+                    except (TypeError, ValueError):
+                        pass
+                _si = (attrs.get("input_tokens") or attrs.get("tokens.input")
+                       or attrs.get("prompt_tokens"))
+                _so = (attrs.get("output_tokens") or attrs.get("tokens.output")
+                       or attrs.get("completion_tokens"))
+                if _si is not None or _so is not None:
+                    try:
+                        _i, _o = int(_si or 0), int(_so or 0)
+                        _add_metric("tokens", {
+                            "timestamp": ts, "input": _i, "output": _o, "total": _i + _o,
+                            "model": attrs.get("model", resource_attrs.get("model", "")),
+                            "channel": attrs.get("channel", resource_attrs.get("channel", "")),
+                            "provider": attrs.get("provider", resource_attrs.get("provider", "")),
+                        })
+                    except (TypeError, ValueError):
+                        pass
+
                 # DuckDB write-through. Failures here are logged but do not
                 # break the metrics cache path above (which is what the
                 # live tiles read from). Idempotent on span_id — OTLP
@@ -10523,6 +10557,40 @@ def _process_otlp_traces(pb_data):
                             "duration_ms": duration_ms,
                         },
                     )
+
+                # Generic cost/token mapping from span ATTRIBUTES. Codex (and
+                # OTel-instrumented agents) emit cost/token telemetry on spans
+                # like ``codex.api_request`` — without this they persist to the
+                # spans table but never light the cost/usage tiles. OpenClaw cost
+                # arrives via the /v1/metrics path (openclaw.cost.usd), not span
+                # attrs, so this doesn't double-count. Same shape as /v1/logs
+                # (#2591).
+                _sc = attrs.get("cost_usd") or attrs.get("cost.usd") or attrs.get("cost")
+                if _sc is not None:
+                    try:
+                        _add_metric("cost", {
+                            "timestamp": ts, "usd": float(_sc),
+                            "model": attrs.get("model", resource_attrs.get("model", "")),
+                            "channel": attrs.get("channel", resource_attrs.get("channel", "")),
+                            "provider": attrs.get("provider", resource_attrs.get("provider", "")),
+                        })
+                    except (TypeError, ValueError):
+                        pass
+                _si = (attrs.get("input_tokens") or attrs.get("tokens.input")
+                       or attrs.get("prompt_tokens"))
+                _so = (attrs.get("output_tokens") or attrs.get("tokens.output")
+                       or attrs.get("completion_tokens"))
+                if _si is not None or _so is not None:
+                    try:
+                        _i, _o = int(_si or 0), int(_so or 0)
+                        _add_metric("tokens", {
+                            "timestamp": ts, "input": _i, "output": _o, "total": _i + _o,
+                            "model": attrs.get("model", resource_attrs.get("model", "")),
+                            "channel": attrs.get("channel", resource_attrs.get("channel", "")),
+                            "provider": attrs.get("provider", resource_attrs.get("provider", "")),
+                        })
+                    except (TypeError, ValueError):
+                        pass
 
                 # DuckDB write-through. Failures here are logged but do not
                 # break the metrics cache path above (which is what the

--- a/tests/test_otlp_traces_cost.py
+++ b/tests/test_otlp_traces_cost.py
@@ -1,0 +1,58 @@
+"""obs-gap #2591: /v1/traces must map cost/token SPAN ATTRIBUTES into the tiles.
+
+Codex emits cost/token telemetry on spans (e.g. ``codex.api_request``), not as
+metrics. The /v1/traces handler previously mapped only span *names*
+(run/message) into the metrics cache, so a Codex cost/token span persisted to
+the spans table but never lit the cost/usage tiles. ``_process_otlp_traces`` now
+also maps any span carrying cost/token attributes.
+"""
+import time
+
+import pytest
+
+pytest.importorskip("opentelemetry.proto.collector.trace.v1.trace_service_pb2",
+                    reason="opentelemetry-proto not installed (pip install clawmetry[otel])")
+
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2  # noqa: E402
+from opentelemetry.proto.trace.v1 import trace_pb2  # noqa: E402
+from opentelemetry.proto.common.v1 import common_pb2  # noqa: E402
+
+import dashboard as _d  # noqa: E402
+
+
+def _kv(key, s=None, i=None, d=None):
+    v = common_pb2.AnyValue()
+    if s is not None:
+        v.string_value = s
+    elif i is not None:
+        v.int_value = i
+    elif d is not None:
+        v.double_value = d
+    return common_pb2.KeyValue(key=key, value=v)
+
+
+def test_codex_cost_token_span_lands_in_tiles(monkeypatch):
+    captured = []
+    monkeypatch.setattr(_d, "_add_metric", lambda cat, e: captured.append((cat, e)))
+
+    now = int(time.time() * 1e9)
+    span = trace_pb2.Span(name="codex.api_request",
+                          start_time_unix_nano=now, end_time_unix_nano=now + 500_000_000)
+    span.attributes.extend([
+        _kv("model", s="gpt-5.4"),
+        _kv("cost_usd", d=0.0312),
+        _kv("input_tokens", i=1200),
+        _kv("output_tokens", i=300),
+    ])
+    req = trace_service_pb2.ExportTraceServiceRequest(resource_spans=[
+        trace_pb2.ResourceSpans(scope_spans=[trace_pb2.ScopeSpans(spans=[span])])])
+
+    # store may be unavailable in this env; the metrics path must still run
+    _d._process_otlp_traces(req.SerializeToString())
+
+    cats = {c for c, _ in captured}
+    assert "cost" in cats and "tokens" in cats, f"got {cats}"
+    cost = next(e for c, e in captured if c == "cost")
+    assert abs(cost["usd"] - 0.0312) < 1e-9 and cost["model"] == "gpt-5.4"
+    toks = next(e for c, e in captured if c == "tokens")
+    assert toks["input"] == 1200 and toks["output"] == 300 and toks["total"] == 1500


### PR DESCRIPTION
Twin of #2657 (/v1/logs). Codex emits cost/token telemetry on **spans** (`codex.api_request`), but `_process_otlp_traces` only mapped span *names* (run/message) into the metrics cache — so Codex cost/token spans persisted to the spans table but never lit the cost/usage tiles. Now it maps any span with `cost_usd`/`input_tokens`/`output_tokens` attributes → cost + tokens tiles. No double-count (OpenClaw cost comes via /v1/metrics, not span attrs).

Built + tested vs the real OTLP trace proto (`tests/test_otlp_traces_cost.py`). Together with #2657, ClawMetry now ingests cost/token signal from **both** OTel logs (Claude Code) and OTel spans (Codex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)