### PR TITLE
fix(openclaw): populate session token breakdown from gateway response

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -141,6 +141,10 @@ class OpenClawAdapter(AgentAdapter):
                     source=s.get("channel") or "",
                     started_at=started_at,
                     total_tokens=int(s.get("totalTokens") or 0),
+                    input_tokens=int(s.get("inputTokens") or 0),
+                    output_tokens=int(s.get("outputTokens") or 0),
+                    cache_read_tokens=int(s.get("cacheReadTokens") or 0),
+                    cache_write_tokens=int(s.get("cacheWriteTokens") or 0),
                     extra={
                         "kind": s.get("kind") or "direct",
                         "contextTokens": s.get("contextTokens"),

--- a/dashboard.py
+++ b/dashboard.py
@@ -15902,6 +15902,10 @@ def _get_sessions():
                     "model": s.get("model", s.get("modelRef", "unknown")),
                     "channel": s.get("channel", "unknown"),
                     "totalTokens": s.get("totalTokens", 0),
+                    "inputTokens": s.get("inputTokens", 0),
+                    "outputTokens": s.get("outputTokens", 0),
+                    "cacheReadTokens": s.get("cacheReadInputTokens", s.get("cacheReadTokens", 0)),
+                    "cacheWriteTokens": s.get("cacheCreationInputTokens", s.get("cacheWriteTokens", 0)),
                     "contextTokens": api_data.get("defaults", {}).get(
                         "contextTokens", 200000
                     ),


### PR DESCRIPTION
Closes #2601

## Summary

- `dashboard.py` `_get_sessions()`: pass through `inputTokens`, `outputTokens`, `cacheReadTokens` (mapping `cacheReadInputTokens` / `cacheReadTokens` key variants), and `cacheWriteTokens` (mapping `cacheCreationInputTokens` / `cacheWriteTokens`) from the gateway WebSocket RPC response — these were already in the raw session data but silently dropped when building the normalized dict
- `clawmetry/adapters/openclaw.py` `list_sessions()`: map the four new dict fields onto `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens` in the `Session` constructor — these were zero for every OpenClaw session before this fix

## Test plan

- [ ] Start a session via the OpenClaw gateway; confirm `/api/sessions` (or the Sessions list) now shows non-zero `input_tokens` / `output_tokens` / `cache_read_tokens` / `cache_write_tokens` in session metadata
- [ ] Verify the cache-efficiency panel and cost breakdown panels now reflect the real token split instead of all-zero values
- [ ] File-fallback path (`_get_sessions_from_files`) is unchanged — `total_tokens` still works correctly for sessions read from JSONL files

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUPvPepA6iAFmMKSbuwRbv)_