### PR TITLE
fix(ingest): local-model events store cost=0.0 instead of None

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -8646,7 +8646,7 @@ def _extract_event_metrics(
                 cache_write_tokens=int(cache_write or 0),
                 provider=str(provider or ""),
             )
-            if est:
+            if est is not None:
                 cost = float(est)
         except Exception:
             pass

--- a/tests/test_event_metrics_extraction.py
+++ b/tests/test_event_metrics_extraction.py
@@ -223,3 +223,47 @@ def test_openclaw_message_shape_with_priced_cost():
     assert tokens == 280
     # The pre-priced value wins, not the re-derivation.
     assert cost == 0.0123
+
+
+def test_local_model_event_cost_is_zero_not_none():
+    """Local/self-hosted model (e.g. ollama) with real token counts must produce
+    cost=0.0, NOT None. None renders as 'no data' in the Cost tab; 0.0 renders
+    as '$0 — local model, no API cost'. The derivation gate was `if est:` which
+    silently dropped 0.0; it must be `if est is not None:` (#2576)."""
+    ev = {
+        "id": "local1",
+        "node_id": "n",
+        "event_type": "message",
+        "ts": "2026-06-04T00:00:00Z",
+        "model": "ollama/llama3.2:3b",
+        "data": {"extra": {"inputTokens": 100, "outputTokens": 50}},
+    }
+    cost, tokens, model = _extract_event_metrics(ev)
+    assert model == "ollama/llama3.2:3b"
+    assert cost == 0.0, (
+        "local model cost must be 0.0 (not None) so the UI can label it "
+        "'local model — no API cost' rather than 'no data'"
+    )
+
+
+def test_unknown_provider_event_derives_conservative_nonzero_cost():
+    """Events whose model is completely unknown must get a non-zero conservative
+    cost (1.0/3.0 per-1M default), not None. This guards the 'Hermes drops
+    unknown-priced models' regression claim from #2576."""
+    ev = {
+        "id": "unk1",
+        "node_id": "n",
+        "event_type": "message",
+        "ts": "2026-06-04T00:00:00Z",
+        "data": {
+            "modelId": "totally-unknown-model-xyz",
+            "provider": "nobody",
+            "promptCache": {"lastCallUsage": {"input": 500, "output": 100}},
+        },
+    }
+    cost, tokens, model = _extract_event_metrics(ev)
+    assert model == "totally-unknown-model-xyz"
+    assert tokens == 600
+    assert cost is not None and cost > 0, (
+        "unknown provider must use conservative non-zero default, not be dropped"
+    )


### PR DESCRIPTION
Closes #2576

## Summary

- **Bug fix** (`local_store.py`): `_extract_event_metrics` used `if est:` to gate the derived cost, which silently dropped `0.0` for local models (ollama, llamacpp, vllm). These events landed in DuckDB with `cost_usd = NULL` and rendered in the Cost tab as "no data" instead of "$0 — local model, no API cost". Changed to `if est is not None:`.
- **New tests** (`test_event_metrics_extraction.py`): two conformance guards per the issue acceptance criteria — local-model event → `cost == 0.0` (not None), and unknown-provider event → `cost > 0` (conservative 1.0/3.0 default, not dropped).

## Test plan

- `python -m pytest tests/test_event_metrics_extraction.py -v` — all 11 tests pass (9 existing + 2 new)
- `python -m pytest tests/test_providers_pricing.py -v` — all 5 pass, no regression

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXWJf6VFumoPVtTu2Mjdds)_