### PR TITLE
fix(sync): propagate agent_id from log events into DuckDB (#2605)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2780,7 +2780,7 @@ def _parse_v3_event(
         "id": str(eid),
         "agent_type": "openclaw",
         "node_id": node_id,
-        "agent_id": "main",
+        "agent_id": obj.get("agent_id") or "main",
         "session_id": session_id,
         "workspace_id": None,
         "event_type": event_type,
@@ -2881,7 +2881,7 @@ def _local_ingest_session_batch(
         rows.append({
             "id": str(eid),
             "node_id": node_id,
-            "agent_id": "main",  # OpenClaw harness; Claude Code adapter will use 'claude-code'
+            "agent_id": obj.get("agent_id") or "main",
             "session_id": session_id,
             "workspace_id": obj.get("workspace") or obj.get("workspace_id"),
             "event_type": str(obj.get("type") or obj.get("event_type") or "unknown"),


### PR DESCRIPTION
## Summary

OpenClaw JSONL transcript events carry a top-level `agent_id` field when emitted in a subagent context, but both event-ingest paths hardcoded `"main"` and silently discarded it. This meant every event row in DuckDB had `agent_id = "main"`, breaking per-agent log filtering and the cross-reference from a log entry back to its originating agent.

The `events.agent_id` column already exists with a `DEFAULT 'main'` — no schema change is needed. Reading the field matches how `_local_ingest_sessions_batch` already handles session rows.

## Changes

- `clawmetry/sync.py` (`_parse_v3_event`): `"agent_id": "main"` → `"agent_id": obj.get("agent_id") or "main"`
- `clawmetry/sync.py` (`_local_ingest_session_batch`): same change in the legacy trajectory path

## Test plan

- [x] `python3 -c 'import ast; ast.parse(open("clawmetry/sync.py").read())'` — passes
- [ ] Run daemon against a workspace with subagent sessions; verify `SELECT DISTINCT agent_id FROM events` returns non-`"main"` values for subagent-originated events
- [ ] CI matrix (Ubuntu/macOS/Windows × Python 3.9/3.11)

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #2605. Marked draft for human review — mark Ready for Review once happy.

Closes #2605

---
_Generated by [Claude Code](https://claude.ai/code/session_013jFyh1sJmopTyLN4kTcebV)_