### PR TITLE
fix(openclaw): surface per-type token split in list_events() extra

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -192,6 +192,33 @@ class OpenClawAdapter(AgentAdapter):
                 extra: dict = {}
                 if r[3]:
                     extra["model"] = r[3]
+                # r[5] = data BLOB — decode and surface per-type token split
+                # (input/output/cache_read/cache_write) so callers can measure
+                # per-turn cache efficiency without re-reading the raw file.
+                raw_data = r[5]
+                if raw_data is not None:
+                    try:
+                        if isinstance(raw_data, (bytes, bytearray)):
+                            raw_data = bytes(raw_data).decode("utf-8", "replace")
+                        obj = json.loads(raw_data) if isinstance(raw_data, str) else raw_data
+                        if isinstance(obj, dict):
+                            msg = obj.get("message")
+                            src = msg if isinstance(msg, dict) else obj
+                            usage = src.get("usage") if isinstance(src.get("usage"), dict) else {}
+                            if usage:
+                                for dst, *keys in [
+                                    ("inputTokens", "input_tokens", "inputTokens"),
+                                    ("outputTokens", "output_tokens", "outputTokens"),
+                                    ("cacheReadTokens", "cache_read_input_tokens", "cacheReadInputTokens"),
+                                    ("cacheWriteTokens", "cache_creation_input_tokens", "cacheCreationInputTokens"),
+                                ]:
+                                    for k in keys:
+                                        v = usage.get(k)
+                                        if v is not None:
+                                            extra[dst] = int(v)
+                                            break
+                    except Exception:
+                        pass
                 events.append(Event(
                     agent=self.name,
                     session_id=str(session_id),

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -116,3 +116,46 @@ def test_list_events_respects_limit(isolated_store):
 def test_list_events_unknown_session_returns_empty(isolated_store):
     from clawmetry.adapters.openclaw import OpenClawAdapter
     assert OpenClawAdapter().list_events("no-such-session") == []
+
+
+def test_list_events_surfaces_cache_token_split(isolated_store):
+    """Per-type token fields from the data blob land in event.extra (#2603).
+
+    Seed an assistant event whose data contains message.usage with input,
+    output, and cache_read token counts; verify list_events() populates
+    the corresponding extra keys so per-turn cache efficiency is measurable.
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-E",
+        "event_type": "model.completed",
+        "ts": _t.time(),
+        "model": "claude-opus-4-7",
+        "token_count": 150,
+        "data": {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-7",
+                "usage": {
+                    "input_tokens": 30,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 80,
+                    "cache_creation_input_tokens": 10,
+                },
+            },
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-E")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("inputTokens") == 30
+    assert ex.get("outputTokens") == 20
+    assert ex.get("cacheReadTokens") == 80
+    assert ex.get("cacheWriteTokens") == 10


### PR DESCRIPTION
Closes #2603

## Summary
- `list_events()` in `OpenClawAdapter` already SELECTs the `data` BLOB (column r[5]) but never decoded it, so `input_tokens`, `output_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` from `message.usage` were silently ignored — every event showed zero for cache efficiency
- Decode the blob with the same `bytes→JSON` pattern used elsewhere in `local_store.py` and populate `extra` with `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`
- Added `test_list_events_surfaces_cache_token_split` covering the `message.usage` path

## Test plan
- [ ] `python -m pytest tests/test_openclaw_list_events.py -v` — all 6 tests pass (confirmed locally)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKyPWvwMSjfS8DQrbmEYwt)_