### PR TITLE
chore(harness-audit): scope OSS audit to free runtimes only

### DIFF
--- a/.github/workflows/harness-observability-audit.yml
+++ b/.github/workflows/harness-observability-audit.yml
@@ -1,10 +1,14 @@
 name: Harness observability audit (daily)
 
-# Every day: sync the upstream source of every agent runtime ClawMetry monitors
-# (scripts/harness/manifest.json), then have Claude compare what each harness
-# EXPOSES against what our adapter CAPTURES, and file a GitHub issue for each gap
-# so it can be picked up. This is how we keep up as the harnesses evolve — new
-# fields, new telemetry, new features to observe.
+# Every day: sync the upstream source of every FREE agent runtime ClawMetry
+# monitors (scripts/harness/manifest.json = openclaw + nemoclaw), then have Claude
+# compare what each harness EXPOSES against what our OSS adapter CAPTURES, and file
+# a GitHub issue for each gap so it can be picked up. This is how we keep up as the
+# harnesses evolve — new fields, new telemetry, new features to observe.
+#
+# The 10 closed PRO runtimes are audited by clawmetry-pro's own private workflow
+# (its adapters + manifest live there) so no closed adapter path is referenced from
+# this public repo.
 #
 # Safe to merge before the secret exists: with no CLAUDE_CODE_OAUTH_TOKEN the
 # model pass is skipped (clones + dry-run still run, logged as a warning), exactly
@@ -40,20 +44,9 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       GH_TOKEN: ${{ github.token }}
       HARNESS_DIR: ${{ github.workspace }}/.harness
-      CLAWMETRY_PRO_DIR: ${{ github.workspace }}/clawmetry-pro
     steps:
       - name: Checkout clawmetry (OSS)
         uses: actions/checkout@v4
-
-      # Closed adapters live in clawmetry-pro — best-effort so the audit still
-      # runs (with reduced context) if the cross-repo token is absent.
-      - name: Checkout clawmetry-pro (adapter context, optional)
-        continue-on-error: true
-        uses: actions/checkout@v4
-        with:
-          repository: vivekchand/clawmetry-pro
-          token: ${{ secrets.CLOUD_REPO_PAT }}
-          path: clawmetry-pro
 
       - uses: actions/setup-python@v5
         with:
@@ -69,7 +62,6 @@ jobs:
       - name: Token visibility (presence only)
         run: |
           [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] && echo "CLAUDE_CODE_OAUTH_TOKEN: set" || echo "::warning::CLAUDE_CODE_OAUTH_TOKEN not set — clones run, model audit skipped. Add it with 'claude setup-token'."
-          [ -d "$CLAWMETRY_PRO_DIR/clawmetry_pro" ] && echo "clawmetry-pro: checked out" || echo "::warning::clawmetry-pro not checked out (set CLOUD_REPO_PAT) — auditing harness surface with reduced adapter context."
 
       - name: Sync harness sources
         run: bash scripts/harness/sync.sh

--- a/scripts/harness/audit.py
+++ b/scripts/harness/audit.py
@@ -101,19 +101,16 @@ def _harness_surface(clone: str) -> str:
 
 
 def _adapter_source(h: dict) -> str:
-    """Read the FULL ClawMetry adapter for this runtime (from clawmetry or a
-    sibling clawmetry-pro checkout). Read the whole file (up to 60k) — truncating
-    drops the tail, and capabilities()/cost-derivation often live at the BOTTOM
-    of the adapter, which caused false-positive gaps (e.g. aider's conditional
-    COST at line ~527 was cut, so the audit wrongly flagged 'no COST')."""
-    rel = h["adapter"]
-    if h.get("adapter_repo") == "clawmetry-pro":
-        for base in (os.path.join(REPO_ROOT, "..", "clawmetry-pro"),
-                     os.environ.get("CLAWMETRY_PRO_DIR", "")):
-            if base and os.path.exists(os.path.join(base, rel)):
-                return _read(os.path.join(base, rel), 60000)
-        return "(clawmetry-pro adapter not checked out in this run — audit the harness surface alone)"
-    return _read(os.path.join(REPO_ROOT, rel), 60000)
+    """Read the FULL ClawMetry adapter for this runtime. Read the whole file (up
+    to 60k) — truncating drops the tail, and capabilities()/cost-derivation often
+    live at the BOTTOM of the adapter, which caused false-positive gaps (e.g.
+    aider's conditional COST at line ~527 was cut, so the audit wrongly flagged
+    'no COST').
+
+    OSS audits only the FREE runtimes (openclaw + nemoclaw), whose adapters are in
+    this repo. The 10 closed pro adapters are audited by clawmetry-pro's own
+    private copy of this script, so no closed adapter path is referenced here."""
+    return _read(os.path.join(REPO_ROOT, h["adapter"]), 60000)
 
 
 def _capabilities_enum() -> str:

--- a/scripts/harness/manifest.json
+++ b/scripts/harness/manifest.json
@@ -1,6 +1,6 @@
 {
-  "_comment": "Single source of truth for the harness-observability audit. Each entry maps an agent runtime ClawMetry monitors to its upstream source repo + the ClawMetry adapter that observes it. The daily audit (.github/workflows/harness-observability-audit.yml) clones/pulls each repo, reviews what the harness exposes that's observable, and files a GH issue for anything ClawMetry's adapter doesn't yet capture. repo=null => no public source to clone (closed, or URL not yet known); those are audited from on-disk format + docs instead.",
-  "_verified": "2026-06-04 — repo URLs HTTP-checked; closed/unknown left null on purpose (no guessing).",
+  "_comment": "Single source of truth for the OSS harness-observability audit. Each entry maps a FREE agent runtime ClawMetry monitors to its upstream source repo + the OSS adapter that observes it. The daily audit (.github/workflows/harness-observability-audit.yml) clones/pulls each repo, reviews what the harness exposes that's observable, and files a GH issue for anything ClawMetry's adapter doesn't yet capture. Only the free runtimes (openclaw + nemoclaw) live here; the 10 closed pro runtimes are audited by clawmetry-pro's own private manifest + workflow.",
+  "_verified": "2026-06-04 — free-only; pro runtime entries moved to clawmetry-pro to keep closed adapter paths out of the public repo.",
   "clone_dir": "../harness",
   "harnesses": [
     {
@@ -19,91 +19,6 @@
       "adapter_repo": "clawmetry",
       "tier": "free",
       "note": "Sandboxed OpenClaw — runs the OpenClaw adapter; audit NeMo-specific guardrail/sandbox telemetry."
-    },
-    {
-      "runtime": "claude_code",
-      "display": "Claude Code",
-      "repo": "https://github.com/yasasbanukaofficial/claude-code",
-      "adapter": "clawmetry_pro/adapters/claude_code.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro",
-      "note": "Full Claude Code source (founder-provided mirror)."
-    },
-    {
-      "runtime": "codex",
-      "display": "OpenAI Codex",
-      "repo": "https://github.com/openai/codex",
-      "adapter": "clawmetry_pro/adapters/codex.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro"
-    },
-    {
-      "runtime": "goose",
-      "display": "Goose",
-      "repo": "https://github.com/aaif-goose/goose",
-      "adapter": "clawmetry_pro/adapters/goose.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro"
-    },
-    {
-      "runtime": "aider",
-      "display": "Aider",
-      "repo": "https://github.com/Aider-AI/aider",
-      "adapter": "clawmetry_pro/adapters/aider.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro"
-    },
-    {
-      "runtime": "opencode",
-      "display": "opencode",
-      "repo": "https://github.com/anomalyco/opencode",
-      "adapter": "clawmetry_pro/adapters/opencode.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro"
-    },
-    {
-      "runtime": "qwen_code",
-      "display": "Qwen Code",
-      "repo": "https://github.com/QwenLM/qwen-code",
-      "adapter": "clawmetry_pro/adapters/qwen_code.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro"
-    },
-    {
-      "runtime": "cursor",
-      "display": "Cursor",
-      "repo": "https://github.com/cursor/agent-trace",
-      "adapter": "clawmetry_pro/adapters/cursor.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro",
-      "note": "Cursor is a closed IDE; agent-trace is its agent trace/telemetry format — audit that against our state.vscdb reader."
-    },
-    {
-      "runtime": "hermes",
-      "display": "Hermes",
-      "repo": "https://github.com/NousResearch/hermes-agent",
-      "adapter": "clawmetry_pro/adapters/hermes.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro",
-      "note": "Nous Research Hermes agent. Binary `tirith`, ~/.hermes/state.db."
-    },
-    {
-      "runtime": "picoclaw",
-      "display": "PicoClaw",
-      "repo": "https://github.com/sipeed/picoclaw",
-      "adapter": "clawmetry_pro/adapters/picoclaw.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro",
-      "note": "Sipeed PicoClaw — OpenClaw-family, JSONL provider Messages (no on-disk token/cost)."
-    },
-    {
-      "runtime": "nanoclaw",
-      "display": "NanoClaw",
-      "repo": "https://github.com/nanocoai/nanoclaw",
-      "adapter": "clawmetry_pro/adapters/nanoclaw.py",
-      "adapter_repo": "clawmetry-pro",
-      "tier": "pro",
-      "note": "Per-session inbound.db/outbound.db SQLite."
     }
   ]
 }


### PR DESCRIPTION
## What
The OSS harness-observability audit (`scripts/harness/manifest.json` + `audit.py` + the daily workflow) listed **all 12** runtimes, including the 10 **closed PRO** runtimes whose adapters live in `clawmetry-pro`. That referenced closed adapter paths (`clawmetry_pro/adapters/*.py`) from this public repo and made the OSS workflow depend on `CLOUD_REPO_PAT` to read closed source.

## Change
- Manifest → **openclaw + nemoclaw only** (the free runtimes; their adapter is OSS `clawmetry/adapters/openclaw.py`).
- `audit.py` → drop the dead `clawmetry-pro` adapter-read branch.
- Workflow → drop the `clawmetry-pro` checkout + `CLAWMETRY_PRO_DIR`.

The 10 pro runtimes are now audited by **clawmetry-pro's own private** manifest + workflow (it has the closed adapters + reads `base.py` from the installed OSS `clawmetry` package — the same companion relationship as at runtime). The 46 pro gap issues were migrated out of this public repo; only the 8 free-runtime gaps (#2603–#2610) remain here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)