### PR TITLE
fix(nemoclaw): tag catalog meta-tool spans in trace view

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -23,6 +23,16 @@ from .base import AgentAdapter, Capability, DetectResult, Event, Session
 
 logger = logging.getLogger("clawmetry.adapters.openclaw")
 
+# NeMo Guardrails compact tool-catalog injects these three meta-tool names into
+# the JSONL transcript when NEMOCLAW_TOOL_CATALOG is active. They are guardrail
+# dispatches, not real agent actions; tag them so consumers can filter/style
+# them separately from ordinary tool calls.
+_NEMOCLAW_CATALOG_TOOLS: frozenset = frozenset({
+    "tool_search",
+    "tool_describe",
+    "tool_call",
+})
+
 
 def _d():
     """Late import to avoid circular init with dashboard module."""
@@ -327,7 +337,7 @@ class OpenClawAdapter(AgentAdapter):
                             continue
                         tool_name = block.get("name") or "tool"
                         tool_id = block.get("id") or ""
-                        spans.append({
+                        tool_span: dict = {
                             "span_id": _sid("tool", session_id, str(raw_ts), tool_id, tool_name),
                             "trace_id": trace_id,
                             "parent_span_id": llm_sid,
@@ -338,7 +348,10 @@ class OpenClawAdapter(AgentAdapter):
                             "agent_type": "openclaw",
                             "tool_name": tool_name,
                             "input": block.get("input"),
-                        })
+                        }
+                        if tool_name in _NEMOCLAW_CATALOG_TOOLS:
+                            tool_span["attributes"] = {"nemoclaw.catalog_guardrail": True}
+                        spans.append(tool_span)
 
             elif t in ("subagent_spawn", "agent_spawn"):
                 sub_id = (

--- a/routes/tracing.py
+++ b/routes/tracing.py
@@ -36,6 +36,16 @@ _TRACE_PLUMBING_TYPES = frozenset({
     "agent.heartbeat", "queue-operation", "custom", "custom_message",
 })
 
+# NeMo Guardrails compact tool-catalog meta-tools. When NEMOCLAW_TOOL_CATALOG
+# is active these names appear as tool_use blocks in the JSONL transcript; they
+# are guardrail dispatches, not real agent actions. Spans for these names get
+# nemoclaw_meta=True so the frontend can filter/style them separately.
+_NEMOCLAW_CATALOG_TOOLS: frozenset = frozenset({
+    "tool_search",
+    "tool_describe",
+    "tool_call",
+})
+
 
 def _events_for(session_id=None, limit=12000):
     """Read events via the daemon proxy, RO-fallback for single-process boots."""
@@ -504,6 +514,8 @@ def _build_spans(rows):
                 ts = _mk(tuid, chat["span_id"], "execute_tool " + tname, "tool",
                          start, nxt, is_sub=is_sub, tool=tname,
                          detail=_short_input(tu.get("input")), event_type=et)
+                if (tu.get("name") or "") in _NEMOCLAW_CATALOG_TOOLS:
+                    ts["nemoclaw_meta"] = True
                 tool_spans[tu.get("id") or tuid] = ts
             continue
 

--- a/tests/test_tracing_accuracy.py
+++ b/tests/test_tracing_accuracy.py
@@ -97,3 +97,39 @@ def test_summarize_trace_derives_total_cost():
     summ = _summarize_trace("claude_code:s1", rows)
     assert summ["total_cost_usd"] > 0, "trace total cost still $0 for a priced turn"
     assert summ["total_tokens"] == 3212
+
+
+# ── NeMo catalog meta-tool tagging (issue #2607) ────────────────────────────
+
+
+def _oc_tool_event(eid, tool_names, *, ts="2026-06-03T10:00:00Z"):
+    """An OpenClaw v3 assistant message event with tool_use blocks in content."""
+    content = [{"type": "text", "text": "searching"}]
+    for i, name in enumerate(tool_names):
+        content.append({"type": "tool_use", "id": f"tu{i}", "name": name, "input": {}})
+    return {
+        "id": eid, "session_id": "oc:s1", "event_type": "model.completed",
+        "ts": ts, "model": "claude-sonnet-4-6", "token_count": 50, "cost_usd": None,
+        "data": {"role": "assistant", "message": {"role": "assistant", "content": content}},
+    }
+
+
+def test_nemoclaw_catalog_tools_tagged():
+    rows = [_oc_tool_event("e1", ["tool_search", "Bash"])]
+    spans, _ = _build_spans(rows)
+    tool_spans = [s for s in spans if s["kind"] == "tool"]
+    assert tool_spans, "expected tool spans"
+    by_name = {s["tool"]: s for s in tool_spans}
+    assert by_name.get("tool_search", {}).get("nemoclaw_meta") is True, \
+        "tool_search span should have nemoclaw_meta=True"
+    assert "nemoclaw_meta" not in by_name.get("Bash", {}), \
+        "regular tool span should not have nemoclaw_meta"
+
+
+def test_nemoclaw_all_three_meta_tools_tagged():
+    rows = [_oc_tool_event("e2", ["tool_search", "tool_describe", "tool_call"])]
+    spans, _ = _build_spans(rows)
+    tool_spans = [s for s in spans if s["kind"] == "tool"]
+    assert len(tool_spans) == 3
+    for s in tool_spans:
+        assert s.get("nemoclaw_meta") is True, f"{s['tool']} should be tagged as nemoclaw_meta"


### PR DESCRIPTION
## Summary

Closes #2607

When NeMo Guardrails' compact tool-catalog is active (`NEMOCLAW_TOOL_CATALOG`), OpenClaw injects three meta-tool calls — `tool_search`, `tool_describe`, `tool_call` — into the JSONL transcript. These are guardrail dispatches, not real agent actions, but both span-builders treated them identically to regular tool calls, inflating tool-call counts and muddying attribution in the NeMo governance tab.

- **`clawmetry/adapters/openclaw.py`** — adds `_NEMOCLAW_CATALOG_TOOLS` frozenset; `_build_spans_from_events` now sets `attributes={"nemoclaw.catalog_guardrail": True}` on matching tool spans so stored OTel spans carry the flag.
- **`routes/tracing.py`** — same constant; `_build_spans` now sets `nemoclaw_meta=True` on matching `execute_tool` spans so the trace API response lets the frontend filter/style them separately from real tool calls.
- **`tests/test_tracing_accuracy.py`** — two new tests verify that `tool_search` gets tagged and that ordinary tools like `Bash` do not.

## Test plan

- [ ] `PYTHONPATH=. python3 -m pytest tests/test_tracing_accuracy.py -v` — all 8 tests pass (6 pre-existing + 2 new)
- [ ] Verify a session transcript containing `tool_search` in the trace view shows `nemoclaw_meta: true` on that span in `/api/trace/<sid>`
- [ ] Confirm regular tools (`Bash`, `Read`, etc.) in the same session have no `nemoclaw_meta` key

---
_Generated by [Claude Code](https://claude.ai/code/session_011LFKpeQ2ZS41uFF6GggvpW)_