### PR TITLE
[RELEASE] feat(harness): declarative per-harness custom-tab framework (#2667)

### DIFF
--- a/clawmetry/harness_templates.py
+++ b/clawmetry/harness_templates.py
@@ -1,0 +1,242 @@
+"""Per-harness custom-tab template registry.
+
+Every agent runtime ClawMetry monitors exposes a *unique* observable surface
+(goose recipes + schedules, cursor edit-ranges, opencode todos, …) that has no
+home in the generic, runtime-agnostic tabs (Cost, Brain, Tracing). A **harness
+template** is a small declarative JSON object that describes a custom panel for
+one runtime: ordered sections, each with a title, a data ``source`` (a path into
+the per-runtime data blob the dashboard fetches), and a ``render`` hint the
+generic client-side renderer understands. The "Harness" tab renders the selected
+runtime's template; the renderer never hard-codes a harness.
+
+Open-core split (mirrors the adapter registry exactly):
+
+* This module + the renderer + the Harness tab shell + the **free** templates
+  (openclaw, nemoclaw) ship in OSS clawmetry.
+* The **10 closed pro** templates live in ``clawmetry-pro`` and register
+  themselves through the ``clawmetry.extensions`` plugin seam at startup
+  (``register_all`` calls :func:`register` for each), the same way the closed
+  adapters do. A FREE node only ever sees the openclaw/nemoclaw panels; a
+  licensed node lights up the rest.
+
+The template ``source`` mini-DSL (resolved client-side against the fetched data):
+
+* ``summary.cost_usd``        → ``data.summary.cost_usd`` (a scalar)
+* ``sessions[]``              → ``data.sessions`` (the whole list, for tables)
+* ``sessions[].extra.recipe`` → for each session, pluck ``extra.recipe``
+* ``extra.recipe``            → ``data.extra.recipe`` (a runtime-wide aggregate)
+
+Render types the client renderer supports: ``count`` (single stat), ``kv``
+(key/value), ``table`` (columns), ``badge-list``, ``timeline`` (ts + label),
+``bar`` (label + value), ``json`` (collapsible raw). Adding a render type is a
+client-only change; templates declaring an unknown type degrade to ``json``.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, List
+
+logger = logging.getLogger("clawmetry.harness_templates")
+
+SCHEMA_VERSION = 1
+
+# Render hints the client renderer knows how to draw. Kept here (not just in JS)
+# so the guard test + :func:`validate` can reject typo'd templates at registration.
+RENDER_TYPES = frozenset(
+    {"count", "kv", "table", "badge-list", "timeline", "bar", "json"}
+)
+
+_templates: Dict[str, Dict[str, Any]] = {}
+_lock = threading.Lock()
+
+
+def validate(template: Dict[str, Any]) -> List[str]:
+    """Return a list of human-readable problems with ``template`` (empty = OK).
+
+    Never raises — a malformed pro template must not take down startup; the
+    caller logs the problems and skips the template instead.
+    """
+    errs: List[str] = []
+    if not isinstance(template, dict):
+        return ["template is not an object"]
+    rt = template.get("runtime")
+    if not rt or not isinstance(rt, str):
+        errs.append("missing/!str 'runtime'")
+    if not template.get("title"):
+        errs.append("missing 'title'")
+    sv = template.get("schema", SCHEMA_VERSION)
+    if not isinstance(sv, int):
+        errs.append("'schema' must be an int")
+    sections = template.get("sections")
+    if not isinstance(sections, list) or not sections:
+        errs.append("'sections' must be a non-empty list")
+        return errs
+    seen_ids: set = set()
+    for i, s in enumerate(sections):
+        if not isinstance(s, dict):
+            errs.append(f"section[{i}] is not an object")
+            continue
+        sid = s.get("id")
+        if not sid:
+            errs.append(f"section[{i}] missing 'id'")
+        elif sid in seen_ids:
+            errs.append(f"section[{i}] duplicate id {sid!r}")
+        else:
+            seen_ids.add(sid)
+        if not s.get("title"):
+            errs.append(f"section[{i}] ({sid}) missing 'title'")
+        if not s.get("source"):
+            errs.append(f"section[{i}] ({sid}) missing 'source'")
+        render = s.get("render")
+        if render not in RENDER_TYPES:
+            errs.append(
+                f"section[{i}] ({sid}) render {render!r} not in {sorted(RENDER_TYPES)}"
+            )
+        if render == "table" and not isinstance(s.get("columns"), list):
+            errs.append(f"section[{i}] ({sid}) render=table needs 'columns' list")
+    return errs
+
+
+def register(template: Dict[str, Any]) -> bool:
+    """Register (or replace, by ``runtime``) one harness template.
+
+    Idempotent on ``runtime`` — a later registration overrides, so a pro package
+    can override a built-in if it wants. Invalid templates are rejected (logged,
+    not raised) so one bad pro template never blocks the others or startup.
+    Returns ``True`` if the template was accepted.
+    """
+    problems = validate(template)
+    rt = template.get("runtime", "?")
+    if problems:
+        logger.warning("harness template %r rejected: %s", rt, "; ".join(problems))
+        return False
+    tmpl = dict(template)
+    tmpl.setdefault("schema", SCHEMA_VERSION)
+    with _lock:
+        _templates[rt] = tmpl
+    logger.debug("registered harness template %r (%d sections)", rt, len(tmpl["sections"]))
+    return True
+
+
+def unregister(runtime: str) -> None:
+    with _lock:
+        _templates.pop(runtime, None)
+
+
+def get(runtime: str) -> Dict[str, Any] | None:
+    with _lock:
+        t = _templates.get(runtime)
+        return dict(t) if t else None
+
+
+def all_templates() -> Dict[str, Dict[str, Any]]:
+    """Snapshot of ``{runtime: template}`` — safe to serialize without the lock."""
+    with _lock:
+        return {k: dict(v) for k, v in _templates.items()}
+
+
+def runtimes() -> List[str]:
+    with _lock:
+        return sorted(_templates.keys())
+
+
+# --------------------------------------------------------------------------- #
+# Built-in FREE templates (openclaw + nemoclaw). Pro templates register from
+# clawmetry-pro via the plugin seam. These only reference data the dashboard
+# serves today (summary + sessions); richer sections sourced from adapter
+# ``extra.*`` fields are added as the harness-observability gap issues land
+# (fix a gap -> a new extra key appears -> add its template section).
+# --------------------------------------------------------------------------- #
+_OPENCLAW_TEMPLATE: Dict[str, Any] = {
+    "schema": SCHEMA_VERSION,
+    "runtime": "openclaw",
+    "title": "OpenClaw specifics",
+    "icon": "\U0001F43E",  # paw prints
+    "tier": "free",
+    "sections": [
+        {
+            "id": "sessions_count",
+            "title": "Sessions observed",
+            "source": "summary.sessions",
+            "render": "count",
+            "unit": "sessions",
+        },
+        {
+            "id": "spend",
+            "title": "Spend (API-equivalent)",
+            "source": "summary.cost_usd",
+            "render": "count",
+            "format": "money",
+        },
+        {
+            "id": "recent",
+            "title": "Recent sessions",
+            "source": "sessions[]",
+            "render": "table",
+            "columns": ["session_id", "session_type", "cost_usd", "ended_at"],
+            "empty": "No sessions yet",
+        },
+        {
+            "id": "channels",
+            "title": "Active channels",
+            "source": "extra.channels",
+            "render": "badge-list",
+            "empty": "No chat channels detected",
+        },
+        {
+            "id": "skills",
+            "title": "Skills invoked",
+            "source": "extra.skills",
+            "render": "badge-list",
+            "empty": "No skills invoked",
+        },
+    ],
+}
+
+_NEMOCLAW_TEMPLATE: Dict[str, Any] = {
+    "schema": SCHEMA_VERSION,
+    "runtime": "nemoclaw",
+    "title": "NeMo Guardrails specifics",
+    "icon": "\U0001F6E1️",  # shield
+    "tier": "free",
+    "sections": [
+        {
+            "id": "sessions_count",
+            "title": "Sandboxed sessions",
+            "source": "summary.sessions",
+            "render": "count",
+            "unit": "sessions",
+        },
+        {
+            "id": "spend",
+            "title": "Spend (API-equivalent)",
+            "source": "summary.cost_usd",
+            "render": "count",
+            "format": "money",
+        },
+        {
+            "id": "recent",
+            "title": "Recent sandboxed runs",
+            "source": "sessions[]",
+            "render": "table",
+            "columns": ["session_id", "session_type", "cost_usd", "ended_at"],
+            "empty": "No sandboxed runs yet",
+        },
+        {
+            "id": "guardrails",
+            "title": "Guardrail actions",
+            "source": "extra.guardrails",
+            "render": "badge-list",
+            "empty": "No guardrail activity observed",
+        },
+    ],
+}
+
+
+def _register_builtins() -> None:
+    register(_OPENCLAW_TEMPLATE)
+    register(_NEMOCLAW_TEMPLATE)
+
+
+_register_builtins()

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1156,6 +1156,7 @@ function switchTab(name) {
   if (name === 'tracing') loadTracing();
   if (name === 'turn-anatomy') loadTurnAnatomy();
   if (name === 'tool-catalog') { if (typeof loadToolCatalog === 'function') loadToolCatalog(); }
+  if (name === 'harness') { if (typeof loadHarness === 'function') loadHarness(); }
   if (name === 'context-economics') { if (typeof loadContextEconomics === 'function') loadContextEconomics(); }
   if (name === 'brain') loadBrainPage();
   if (name === 'selfevolve') loadSelfEvolvePage();
@@ -13982,6 +13983,197 @@ function renderToolCatalog() {
   tools.forEach(function(tool) {
     if (_tcExpanded[tool.name]) _tcLoadCalls(tool.name);
   });
+}
+
+// ── Harness tab: declarative per-runtime custom panels ────────────────────
+// A "harness template" (served by /api/harness/templates; OSS ships openclaw +
+// nemoclaw, clawmetry-pro registers its 10 closed ones) declares ordered
+// sections, each with a data `source` path and a `render` hint. This renderer is
+// generic — it never hard-codes a harness; it just interprets the template.
+var _cmHarnessTemplates = null;   // {runtime: template}, fetched once
+var _cmHarnessData = null;
+
+async function loadHarness() {
+  var el = document.getElementById('harness-container');
+  if (!el) return;
+  var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  if (!rt || rt === 'all') rt = 'openclaw';
+  try {
+    if (!_cmHarnessTemplates) {
+      var t = await fetch('/api/harness/templates').then(function (r) { return r.json(); });
+      _cmHarnessTemplates = (t && t.templates) || {};
+    }
+    var tmpl = _cmHarnessTemplates[rt];
+    if (!tmpl) { el.innerHTML = _cmHarnessNoTemplate(rt); return; }
+    var data = await fetch('/api/harness/data?runtime=' + encodeURIComponent(rt))
+                 .then(function (r) { return r.json(); });
+    _cmHarnessData = data;
+    el.innerHTML = renderHarnessPanel(tmpl, data);
+  } catch (e) {
+    el.innerHTML = '<div style="color:var(--muted,#888);">Failed to load harness view: '
+      + escapeHtml(String((e && e.message) || e)) + '</div>';
+  }
+}
+
+function _cmHarnessNoTemplate(rt) {
+  return '<div style="color:var(--muted,#888);line-height:1.5;">No harness panel for <b>'
+    + escapeHtml(rt) + '</b> yet.<br>Pro runtimes light up their panels when '
+    + 'clawmetry-pro is installed (Cloud Pro or a self-hosted license).</div>';
+}
+
+// Resolve a template `source` path against the data blob:
+//   "summary.cost_usd"        -> data.summary.cost_usd  (scalar)
+//   "sessions[]"              -> data.sessions          (array, for tables)
+//   "sessions[].extra.recipe" -> [s.extra.recipe ...]   (plucked, non-empty)
+//   "extra.skills"            -> data.extra.skills
+function _cmHarnessResolve(source, data) {
+  if (!source) return undefined;
+  var m = String(source).match(/^([a-zA-Z0-9_]+)\[\](?:\.(.+))?$/);
+  if (m) {
+    var arr = data && data[m[1]];
+    if (!Array.isArray(arr)) return [];
+    if (!m[2]) return arr;
+    return arr.map(function (it) { return _cmHarnessGet(it, m[2]); })
+              .filter(function (v) { return v !== undefined && v !== null && v !== ''; });
+  }
+  return _cmHarnessGet(data, source);
+}
+
+function _cmHarnessGet(obj, path) {
+  var parts = String(path).split('.'), cur = obj;
+  for (var i = 0; i < parts.length; i++) {
+    if (cur == null) return undefined;
+    cur = cur[parts[i]];
+  }
+  return cur;
+}
+
+function renderHarnessPanel(tmpl, data) {
+  var pro = tmpl.tier === 'pro'
+    ? '<span style="background:#3a2f00;color:#ffd24a;border:1px solid #6b5600;border-radius:10px;padding:2px 8px;font-size:11px;font-weight:700;">PRO</span>'
+    : '';
+  var html = '<div style="display:flex;align-items:center;gap:8px;margin-bottom:14px;">'
+    + '<span style="font-size:22px;">' + escapeHtml(tmpl.icon || '🧩') + '</span>'
+    + '<span style="font-size:17px;font-weight:700;">' + escapeHtml(tmpl.title || tmpl.runtime) + '</span>'
+    + pro + '</div>';
+  html += '<div style="display:flex;flex-wrap:wrap;gap:14px;">';
+  (tmpl.sections || []).forEach(function (sec) { html += renderHarnessSection(sec, data); });
+  html += '</div>';
+  return html;
+}
+
+function renderHarnessSection(sec, data) {
+  var val = _cmHarnessResolve(sec.source, data);
+  var body;
+  switch (sec.render) {
+    case 'count':      body = _hrCount(sec, val); break;
+    case 'kv':         body = _hrKv(sec, val); break;
+    case 'table':      body = _hrTable(sec, val); break;
+    case 'badge-list': body = _hrBadges(sec, val); break;
+    case 'timeline':   body = _hrTimeline(sec, val); break;
+    case 'bar':        body = _hrBar(sec, val); break;
+    default:           body = _hrJson(sec, val); break;   // json + unknown render
+  }
+  var empty = (val === undefined || val === null || val === ''
+               || (Array.isArray(val) && val.length === 0));
+  if (empty && sec.render !== 'count') {
+    body = '<div style="color:var(--muted,#888);font-size:13px;">'
+      + escapeHtml(sec.empty || 'No data') + '</div>';
+  }
+  var wide = (sec.render === 'table' || sec.render === 'timeline' || sec.render === 'json');
+  return '<div class="card" style="padding:12px 14px;flex:' + (wide ? '1 1 100%' : '1 1 200px')
+    + ';min-width:180px;">'
+    + '<div style="font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted,#888);margin-bottom:8px;">'
+    + escapeHtml(sec.title || sec.id) + '</div>' + body + '</div>';
+}
+
+function _hrFmtVal(sec, v) {
+  if (sec.format === 'money') {
+    var n = Number(v) || 0;
+    return '$' + (n > 0 && n < 0.01 ? n.toFixed(4) : n.toFixed(2));
+  }
+  return escapeHtml(String(v == null ? '0' : v));
+}
+
+function _hrCount(sec, v) {
+  return '<div style="font-size:26px;font-weight:700;">' + _hrFmtVal(sec, v == null ? 0 : v)
+    + (sec.unit ? ' <span style="font-size:13px;font-weight:400;color:var(--muted,#888);">'
+                  + escapeHtml(sec.unit) + '</span>' : '')
+    + '</div>';
+}
+
+function _hrKv(sec, v) {
+  if (v == null) return '';
+  if (typeof v !== 'object') return '<div>' + escapeHtml(String(v)) + '</div>';
+  return Object.keys(v).map(function (k) {
+    return '<div style="display:flex;justify-content:space-between;gap:12px;padding:3px 0;border-bottom:1px solid var(--border,#222);">'
+      + '<span style="color:var(--muted,#888);">' + escapeHtml(k) + '</span>'
+      + '<span>' + escapeHtml(String(v[k])) + '</span></div>';
+  }).join('');
+}
+
+function _hrTable(sec, rows) {
+  if (!Array.isArray(rows) || !rows.length) return '';
+  var cols = sec.columns || Object.keys(rows[0] || {});
+  var head = cols.map(function (c) {
+    return '<th style="text-align:left;padding:6px 10px;color:var(--muted,#888);font-weight:600;font-size:12px;">'
+      + escapeHtml(c) + '</th>';
+  }).join('');
+  var body = rows.map(function (r) {
+    return '<tr>' + cols.map(function (c) {
+      var cell = (r && typeof r === 'object') ? r[c] : '';
+      if (c === 'cost_usd') { var n = Number(cell) || 0; cell = '$' + (n > 0 && n < 0.01 ? n.toFixed(4) : n.toFixed(2)); }
+      return '<td style="padding:6px 10px;border-top:1px solid var(--border,#222);font-size:13px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:280px;">'
+        + escapeHtml(String(cell == null ? '' : cell)) + '</td>';
+    }).join('') + '</tr>';
+  }).join('');
+  return '<div style="overflow-x:auto;"><table style="border-collapse:collapse;width:100%;">'
+    + '<thead><tr>' + head + '</tr></thead><tbody>' + body + '</tbody></table></div>';
+}
+
+function _hrBadges(sec, v) {
+  var items = Array.isArray(v) ? v : (v == null ? [] : [v]);
+  var counts = {};
+  items.forEach(function (it) { var k = String(it); counts[k] = (counts[k] || 0) + 1; });
+  var keys = Object.keys(counts);
+  if (!keys.length) return '';
+  return '<div style="display:flex;flex-wrap:wrap;gap:6px;">' + keys.map(function (k) {
+    var c = counts[k];
+    return '<span style="background:var(--chip,#1c1c1c);border:1px solid var(--border,#333);border-radius:12px;padding:3px 10px;font-size:12px;">'
+      + escapeHtml(k) + (c > 1 ? ' <b>×' + c + '</b>' : '') + '</span>';
+  }).join('') + '</div>';
+}
+
+function _hrTimeline(sec, rows) {
+  if (!Array.isArray(rows) || !rows.length) return '';
+  return rows.slice(0, 50).map(function (r) {
+    var ts = (r && (r.ts || r.time || r.ended_at)) || '';
+    var label = (r && (r.label || r.title || r.name)) || (typeof r === 'string' ? r : JSON.stringify(r));
+    return '<div style="display:flex;gap:10px;padding:4px 0;border-bottom:1px solid var(--border,#222);font-size:13px;">'
+      + '<span style="color:var(--muted,#888);white-space:nowrap;">' + escapeHtml(String(ts)) + '</span>'
+      + '<span>' + escapeHtml(String(label)) + '</span></div>';
+  }).join('');
+}
+
+function _hrBar(sec, rows) {
+  var pairs = [];
+  if (Array.isArray(rows)) pairs = rows.map(function (r) { return [r.label || r.name || '', Number(r.value) || 0]; });
+  else if (rows && typeof rows === 'object') pairs = Object.keys(rows).map(function (k) { return [k, Number(rows[k]) || 0]; });
+  if (!pairs.length) return '';
+  var max = Math.max.apply(null, pairs.map(function (p) { return p[1]; })) || 1;
+  return pairs.map(function (p) {
+    var pct = Math.round(p[1] / max * 100);
+    return '<div style="margin:4px 0;font-size:12px;"><div style="display:flex;justify-content:space-between;">'
+      + '<span>' + escapeHtml(String(p[0])) + '</span><span>' + escapeHtml(String(p[1])) + '</span></div>'
+      + '<div style="height:6px;background:var(--border,#222);border-radius:3px;overflow:hidden;">'
+      + '<div style="height:100%;width:' + pct + '%;background:var(--accent,#5b8def);"></div></div></div>';
+  }).join('');
+}
+
+function _hrJson(sec, v) {
+  if (v === undefined || v === null) return '';
+  return '<pre style="white-space:pre-wrap;word-break:break-word;font-size:12px;margin:0;max-height:300px;overflow:auto;">'
+    + escapeHtml(JSON.stringify(v, null, 2)) + '</pre>';
 }
 
 function _tcToggle(name) {

--- a/clawmetry/templates/tabs/harness.html
+++ b/clawmetry/templates/tabs/harness.html
@@ -1,0 +1,11 @@
+<div class="page" id="page-harness">
+  <div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;margin-bottom:6px;">
+    <div style="font-size:20px;font-weight:700;" id="harness-title">Harness</div>
+    <div style="font-size:13px;color:var(--muted,#888);">
+      What this runtime uniquely exposes — beyond the generic tabs.
+    </div>
+    <button onclick="loadHarness()" style="margin-left:auto;" class="btn-ghost" title="Refresh">&#8635;</button>
+  </div>
+  <!-- renderHarnessPanel() fills this from the selected runtime's template -->
+  <div id="harness-container" class="card" style="padding:16px;">Loading harness view…</div>
+</div>

--- a/dashboard.py
+++ b/dashboard.py
@@ -97,6 +97,7 @@ from helpers.gateway import (  # noqa: F401 — re-export for routes/
 )
 from routes.usage import bp_usage
 from routes.crons import bp_crons
+from routes.harness import bp_harness
 from routes.health import bp_health
 from routes.alerts import bp_alerts, bp_budget
 from routes.channels import bp_channels
@@ -11020,6 +11021,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_crons)
     app.register_blueprint(bp_fleet)
     app.register_blueprint(bp_gateway)
+    app.register_blueprint(bp_harness)
     app.register_blueprint(bp_health)
     app.register_blueprint(bp_logs)
     app.register_blueprint(bp_memory)
@@ -11570,6 +11572,9 @@ DASHBOARD_HTML = r"""
         <div class="left-nav-item left-nav-item-sub" id="left-nav-context-economics" data-tab="context-economics" onclick="switchTab('context-economics')" title="Context-window utilization over time, compaction triggers and tokens reclaimed">
           <span class="left-nav-label">Context economics</span>
         </div>
+        <div class="left-nav-item left-nav-item-sub" id="left-nav-harness" data-tab="harness" onclick="switchTab('harness')" title="What the selected runtime uniquely exposes — beyond the generic tabs">
+          <span class="left-nav-label">Harness</span>
+        </div>
         <div class="left-nav-item left-nav-item-sub" id="left-nav-swimlane" data-tab="swimlane" onclick="switchTab('swimlane')" title="Compare up to 4 sessions or runtimes side by side as parallel live lanes">
           <span class="left-nav-label">Swimlane</span>
         </div>
@@ -11703,6 +11708,9 @@ DASHBOARD_HTML = r"""
 <!-- TOOL CATALOG (provenance + p50/p95 latency + error rate, P1-3) -->
 {% include 'tabs/tool-catalog.html' %}
 {% include 'tabs/context-economics.html' %}
+
+<!-- HARNESS (declarative per-runtime custom panel; #2667) -->
+{% include 'tabs/harness.html' %}
 
 <!-- SWIMLANE COMPARE — N parallel live lanes (sessions / runtimes) -->
 {% include 'tabs/swimlane.html' %}

--- a/routes/harness.py
+++ b/routes/harness.py
@@ -1,0 +1,115 @@
+"""``bp_harness`` — the per-harness custom-tab API.
+
+Two read-only endpoints back the "Harness" tab:
+
+* ``GET /api/harness/templates`` — the registered harness templates
+  (``{runtime: template}``). OSS ships openclaw + nemoclaw; clawmetry-pro
+  registers its 10 closed templates through the plugin seam, so this endpoint
+  returns exactly what the running node is entitled to render.
+* ``GET /api/harness/data?runtime=<rt>`` — the per-runtime data blob the
+  template's ``source`` paths resolve against (summary + recent sessions, plus
+  room for adapter-``extra`` aggregates as the gap issues land). Cloud-safe:
+  reads DuckDB through ``routes.local_query._dispatch`` (the daemon proxy), not
+  raw files, so it works in the cloud container too.
+"""
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, jsonify, request
+
+logger = logging.getLogger("clawmetry.routes.harness")
+
+bp_harness = Blueprint("harness", __name__)
+
+# Session-id prefix → runtime. Mirrors ``_NON_OPENCLAW_RUNTIME_PREFIXES`` in
+# clawmetry/local_store.py (agent_type is always "openclaw"; the runtime is the
+# session_id prefix). nemoclaw is a free OpenClaw wrapper that tags its sessions
+# with a ``nemoclaw:`` prefix; everything without a known prefix is OpenClaw.
+_NON_OPENCLAW_PREFIXES = frozenset({
+    "picoclaw", "nanoclaw", "hermes", "nemoclaw",
+    "claude_code", "codex", "cursor", "aider", "goose", "opencode", "qwen_code",
+})
+
+
+def _prefix_of(session_id: str) -> str:
+    if not session_id or ":" not in session_id:
+        return "openclaw"
+    head = session_id.split(":", 1)[0]
+    return head if head in _NON_OPENCLAW_PREFIXES else "openclaw"
+
+
+def _runtime_match(session_id: str, runtime: str) -> bool:
+    """Does ``session_id`` belong to ``runtime``? openclaw = anything without a
+    known non-openclaw prefix; otherwise an exact prefix match."""
+    return _prefix_of(session_id) == (runtime or "openclaw").lower()
+
+
+def _num(v) -> float:
+    try:
+        return float(v or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+@bp_harness.route("/api/harness/templates", methods=["GET"])
+def http_harness_templates():
+    """Registered harness templates the node is entitled to render."""
+    try:
+        from clawmetry import harness_templates as _ht
+        tmpls = _ht.all_templates()
+        return jsonify({"templates": tmpls, "runtimes": sorted(tmpls.keys())})
+    except Exception as exc:  # never crash the tab
+        logger.warning("harness templates failed: %s", exc)
+        return jsonify({"templates": {}, "runtimes": []})
+
+
+@bp_harness.route("/api/harness/data", methods=["GET"])
+def http_harness_data():
+    """Per-runtime data blob the template ``source`` paths resolve against.
+
+    Shape (the source mini-DSL maps onto this):
+        {
+          "runtime": "goose",
+          "summary": {"sessions": N, "cost_usd": X, "tokens": T},
+          "sessions": [{session_id, session_type, started_at, ended_at,
+                        cost_usd, tokens}, ...],   # newest first, capped
+          "extra": { ... }   # runtime-wide adapter-extra aggregates (grows as
+                             # the harness-observability gap issues land)
+        }
+    """
+    runtime = (request.args.get("runtime") or "openclaw").strip().lower()
+    blob = {"runtime": runtime, "summary": {"sessions": 0, "cost_usd": 0.0, "tokens": 0},
+            "sessions": [], "extra": {}}
+    try:
+        from routes.local_query import _dispatch
+        body = _dispatch("sessions", {"limit": 500})
+        rows = body.get("rows") or body.get("sessions") or []
+    except Exception as exc:
+        logger.warning("harness data dispatch failed: %s", exc)
+        return jsonify(blob)
+
+    mine = [r for r in rows if _runtime_match(r.get("session_id", ""), runtime)]
+    total_cost = sum(_num(r.get("cost_usd")) for r in mine)
+    total_tok = sum(_num(r.get("token_count", r.get("tokens"))) for r in mine)
+
+    def _sort_key(r):
+        return r.get("updated_at") or r.get("ended_at") or r.get("started_at") or ""
+
+    mine.sort(key=_sort_key, reverse=True)
+    sessions = [{
+        "session_id": r.get("session_id", ""),
+        "session_type": r.get("session_type") or r.get("agent_id") or "",
+        "started_at": r.get("started_at", ""),
+        "ended_at": r.get("updated_at") or r.get("ended_at") or "",
+        "cost_usd": round(_num(r.get("cost_usd")), 4),
+        "tokens": int(_num(r.get("token_count", r.get("tokens")))),
+    } for r in mine[:50]]
+
+    blob["summary"] = {
+        "sessions": len(mine),
+        "cost_usd": round(total_cost, 4),
+        "tokens": int(total_tok),
+    }
+    blob["sessions"] = sessions
+    return jsonify(blob)

--- a/tests/test_harness_templates.py
+++ b/tests/test_harness_templates.py
@@ -1,0 +1,94 @@
+"""Guard tests for the per-harness template framework (#2667).
+
+Covers the registry/schema contract, the built-in free templates, the
+Python<->JS render-type contract (the JS renderer must handle every render type
+the Python registry allows), and the /api/harness/* endpoints.
+"""
+import os
+import re
+
+import pytest
+
+from clawmetry import harness_templates as ht
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_JS = os.path.join(REPO, "clawmetry", "static", "js", "app.js")
+
+
+def test_builtins_registered():
+    rts = ht.runtimes()
+    assert "openclaw" in rts and "nemoclaw" in rts, rts
+
+
+def test_builtin_templates_validate():
+    for rt in ("openclaw", "nemoclaw"):
+        tmpl = ht.get(rt)
+        assert tmpl, f"{rt} template missing"
+        assert ht.validate(tmpl) == [], f"{rt}: {ht.validate(tmpl)}"
+
+
+def test_register_rejects_malformed_without_raising():
+    # bad render type
+    assert ht.register({"runtime": "z1", "title": "Z", "sections": [
+        {"id": "a", "title": "A", "source": "s", "render": "bogus"}]}) is False
+    # missing sections
+    assert ht.register({"runtime": "z2", "title": "Z"}) is False
+    # table without columns
+    assert ht.register({"runtime": "z3", "title": "Z", "sections": [
+        {"id": "a", "title": "A", "source": "s", "render": "table"}]}) is False
+    # duplicate section id
+    assert ht.register({"runtime": "z4", "title": "Z", "sections": [
+        {"id": "a", "title": "A", "source": "s", "render": "count"},
+        {"id": "a", "title": "B", "source": "s2", "render": "count"}]}) is False
+    for z in ("z1", "z2", "z3", "z4"):
+        assert ht.get(z) is None
+
+
+def test_register_accepts_and_overrides_by_runtime():
+    t1 = {"runtime": "tmprt", "title": "One", "sections": [
+        {"id": "a", "title": "A", "source": "summary.x", "render": "count"}]}
+    t2 = {"runtime": "tmprt", "title": "Two", "sections": [
+        {"id": "b", "title": "B", "source": "summary.y", "render": "count"}]}
+    try:
+        assert ht.register(t1) is True
+        assert ht.get("tmprt")["title"] == "One"
+        assert ht.register(t2) is True   # override by runtime
+        assert ht.get("tmprt")["title"] == "Two"
+    finally:
+        ht.unregister("tmprt")
+
+
+def test_js_renderer_handles_every_render_type():
+    """The JS renderer's switch must cover every render type the Python
+    registry permits — otherwise a template validates server-side but the
+    client silently drops the section."""
+    js = open(APP_JS, encoding="utf-8").read()
+    # the dispatch switch is in renderHarnessSection
+    assert "function renderHarnessSection" in js
+    for rtype in ht.RENDER_TYPES:
+        if rtype == "json":
+            # json is the default arm, not an explicit case
+            assert "_hrJson(" in js
+            continue
+        assert f"case '{rtype}':" in js, f"JS renderer missing case for render type {rtype!r}"
+
+
+def test_harness_endpoints_smoke():
+    """/api/harness/templates returns the registry; /api/harness/data never 500s."""
+    from flask import Flask
+    from routes.harness import bp_harness
+    app = Flask(__name__)
+    app.register_blueprint(bp_harness)
+    client = app.test_client()
+
+    r = client.get("/api/harness/templates")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "openclaw" in body["templates"]
+
+    r2 = client.get("/api/harness/data?runtime=openclaw")
+    assert r2.status_code == 200
+    d = r2.get_json()
+    assert d["runtime"] == "openclaw"
+    assert set(d["summary"].keys()) >= {"sessions", "cost_usd", "tokens"}
+    assert isinstance(d["sessions"], list)


### PR DESCRIPTION
## Why
Every runtime ClawMetry monitors exposes a **unique** observable surface — goose recipes + cron schedules, cursor edit-ranges, opencode todos, codex turn-failures — that has no home in the generic, runtime-agnostic tabs (Cost, Brain, Tracing). The harness-observability audit backlog is, in effect, a catalog of exactly this. This PR is **Phase 0** of the per-harness template system (closes the framework half of #2667).

## What
A declarative **template** (JSON) describes a custom panel for one runtime: ordered sections, each with a data `source` path and a `render` hint. A generic renderer interprets it — it never hard-codes a harness. A new **Harness** tab renders the selected runtime's template.

- **`clawmetry/harness_templates.py`** — process-wide registry mirroring `clawmetry.adapters.registry` (`register`/`get`/`all_templates` + `validate`). Ships the FREE **openclaw + nemoclaw** templates. clawmetry-pro registers its 10 closed templates through the **`clawmetry.extensions` plugin seam** at startup — the same seam as the closed adapters, so a FREE node sees only openclaw/nemoclaw and a licensed node lights up the rest. **No pro template JSON in the public repo.**
- **`routes/harness.py`** (`bp_harness`) — `GET /api/harness/templates` (the entitled registry) + `GET /api/harness/data?runtime=<rt>` (the per-runtime data blob). Cloud-safe: reads DuckDB via `routes.local_query._dispatch`, not raw files.
- **`static/js/app.js`** — `renderHarnessPanel(template, data)` + a `source`-path resolver + 7 render types (`count`/`kv`/`table`/`badge-list`/`timeline`/`bar`/`json`); `loadHarness()` wired into `switchTab` + the runtime switcher re-render.
- **`templates/tabs/harness.html`** + the **Harness** sidebar nav item.
- **`tests/test_harness_templates.py`** — schema/registry contract, malformed rejection, the **Python↔JS render-type contract** (the JS switch must cover every render type the registry permits), and endpoint smoke tests.

## Source mini-DSL
`summary.cost_usd` · `sessions[]` · `sessions[].extra.recipe` · `extra.skills` — so as the harness-observability gap issues land (each surfacing a new adapter `extra.*` field), **adding a template section lights up the panel**. The backlog becomes the template worklist.

## Verification
- 6/6 guard tests pass.
- `node --check app.js` + `py_compile` clean.
- Live on a throwaway instance: `/api/harness/templates` returns openclaw+nemoclaw; `/api/harness/data?runtime=openclaw` returns real data (2 sessions, \$8.31, 20.7k tokens); nav item + page container + tab all render.

## Follow-ups
- Pro templates (clawmetry-pro #37) register via the seam — Phase 1.
- Each gap fix adds its template section — Phase 2.
- Design doc: clawmetry-cloud/docs/PER_HARNESS_TEMPLATES.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)