### PR TITLE
feat(harness): surface per-session adapter extra + models in /api/harness/data

### DIFF
--- a/routes/harness.py
+++ b/routes/harness.py
@@ -97,6 +97,14 @@ def http_harness_data():
         return r.get("updated_at") or r.get("ended_at") or r.get("started_at") or ""
 
     mine.sort(key=_sort_key, reverse=True)
+
+    # Per-session adapter `extra` + runtime-wide aggregates, harvested from the
+    # events stream (the adapters stash their unique surface in event/session
+    # `data.extra` — goose scheduleId/recipe, codex cliVersion/rolloutFile,
+    # claude_code cache-token splits, …). Reusing the cloud-safe `events`
+    # dispatch means no new store code and this works in the cloud container.
+    per_session_extra, models = _harvest_event_extra(runtime)
+
     sessions = [{
         "session_id": r.get("session_id", ""),
         "session_type": r.get("session_type") or r.get("agent_id") or "",
@@ -104,6 +112,7 @@ def http_harness_data():
         "ended_at": r.get("updated_at") or r.get("ended_at") or "",
         "cost_usd": round(_num(r.get("cost_usd")), 4),
         "tokens": int(_num(r.get("token_count", r.get("tokens")))),
+        "extra": per_session_extra.get(r.get("session_id", ""), {}),
     } for r in mine[:50]]
 
     blob["summary"] = {
@@ -112,4 +121,49 @@ def http_harness_data():
         "tokens": int(total_tok),
     }
     blob["sessions"] = sessions
+    if models:
+        blob["extra"]["models"] = models
     return jsonify(blob)
+
+
+def _harvest_event_extra(runtime: str):
+    """Aggregate per-session ``data.extra`` (last value wins per key) and the
+    distinct models seen, from the runtime's recent events. Returns
+    ``({session_id: extra_dict}, [models])``. Never raises — returns empties."""
+    import json
+    per_session: dict = {}
+    models: list = []
+    seen_models: set = set()
+    try:
+        from routes.local_query import _dispatch
+        body = _dispatch("events", {"limit": 2000})
+        rows = body.get("rows") or []
+    except Exception as exc:
+        logger.warning("harness extra harvest failed: %s", exc)
+        return per_session, models
+    for r in rows:
+        sid = r.get("session_id", "")
+        if not _runtime_match(sid, runtime):
+            continue
+        m = r.get("model")
+        if m and m not in seen_models:
+            seen_models.add(m)
+            models.append(m)
+        d = r.get("data")
+        if isinstance(d, str):
+            try:
+                d = json.loads(d)
+            except Exception:
+                d = None
+        ex = d.get("extra") if isinstance(d, dict) else None
+        if isinstance(ex, dict) and ex:
+            bucket = per_session.setdefault(sid, {})
+            for k, v in ex.items():
+                # keep concise, JSON-friendly scalars; skip the noisy token
+                # split keys that already have first-class tiles
+                if k in ("inputTokens", "outputTokens", "cacheReadInputTokens",
+                         "cacheCreationInputTokens"):
+                    continue
+                if isinstance(v, (str, int, float, bool)) or v is None:
+                    bucket[k] = v
+    return per_session, models

--- a/tests/test_harness_templates.py
+++ b/tests/test_harness_templates.py
@@ -92,3 +92,7 @@ def test_harness_endpoints_smoke():
     assert d["runtime"] == "openclaw"
     assert set(d["summary"].keys()) >= {"sessions", "cost_usd", "tokens"}
     assert isinstance(d["sessions"], list)
+    assert isinstance(d.get("extra"), dict)
+    # every session carries an `extra` dict so `sessions[].extra.*` always resolves
+    for s in d["sessions"]:
+        assert isinstance(s.get("extra"), dict)


### PR DESCRIPTION
Follow-up to the per-harness template framework (#2670).

## Why
The template `source` DSL supports `sessions[].extra.recipe` / `extra.models`, but `/api/harness/data` only returned `summary` + bare session rows — so every extra-sourced template section rendered empty.

## What
Harvest per-session `data.extra` (last value wins per key) + the distinct models seen, from the runtime's recent events via the **cloud-safe `events` dispatch** (no new store code; works in the cloud container). This is what lights up each harness's unique panel sections — goose `scheduleId`/`recipe`, codex `cliVersion`/`rolloutFile`, claude_code per-turn metadata — as the data exists. Token-split keys that already have first-class tiles are skipped to keep the blob concise.

## Verified
- 6/6 guard tests pass (now asserts every session carries an `extra` dict).
- Live: `claude_code` sessions surface `model`/`toolUseId`/`isError`; `goose` surfaces `extension`/`status`/`toolCallId`; `extra.models` populated per runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)