### PR TITLE
feat(_gate): include required_tier in 402 upgrade_required body

### DIFF
--- a/clawmetry/_gate.py
+++ b/clawmetry/_gate.py
@@ -21,12 +21,39 @@ Example::
 
 The error shape matches what ``routes/audit.py`` and ``routes/otel_export.py``
 have been returning by hand for months, so existing front-ends that already
-handle 402 continue to work.
+handle 402 continue to work. ``required_tier`` is included so the UI can
+route users to the *correct* upgrade CTA (Starter vs Pro vs Enterprise)
+instead of a generic one.
 """
 from __future__ import annotations
 
 from functools import wraps
 from typing import Callable
+
+
+def _required_tier(feature_key: str) -> str | None:
+    """Minimum tier identifier that unlocks ``feature_key``.
+
+    Returns a tier id from :mod:`clawmetry.entitlements` (e.g.
+    ``"cloud_starter"``, ``"cloud_pro"``, ``"enterprise"``) or ``None`` for
+    free features and unknown keys. Used to enrich the 402 body so the UI
+    can render the right upgrade CTA without re-deriving tier logic in JS.
+    Never raises: any lookup error returns ``None``.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        if feature_key in _ent.FREE_FEATURES:
+            return None
+        if feature_key in _ent.STARTER_FEATURES:
+            return _ent.TIER_CLOUD_STARTER
+        if feature_key in _ent.PRO_ONLY_FEATURES:
+            return _ent.TIER_CLOUD_PRO
+        if feature_key in _ent.ENTERPRISE_FEATURES:
+            return _ent.TIER_ENTERPRISE
+    except Exception:
+        return None
+    return None
 
 
 def gate(feature_key: str) -> Callable:
@@ -47,6 +74,7 @@ def gate(feature_key: str) -> Callable:
                         "error": "upgrade_required",
                         "feature": feature_key,
                         "tier": en.tier,
+                        "required_tier": _required_tier(feature_key),
                         "hint": (
                             "This is a paid feature on clawmetry.com/pricing. "
                             "Upgrade or set CLAWMETRY_ENFORCE=0 to disable enforcement."

--- a/tests/test_route_gates.py
+++ b/tests/test_route_gates.py
@@ -58,6 +58,76 @@ def test_gate_decorator_blocks_in_enforce_mode(enforce):
         assert body["feature"] == "self_evolve"
         assert "tier" in body
         assert "hint" in body
+        # required_tier lets the UI route to the right upgrade CTA.
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
+
+
+# ── required_tier mapping ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "feature_key,expected_tier_attr",
+    [
+        ("multi_runtime", "TIER_CLOUD_STARTER"),       # Starter feature
+        ("budget_limits", "TIER_CLOUD_STARTER"),       # Starter feature
+        ("self_evolve", "TIER_CLOUD_PRO"),             # Pro-only feature
+        ("otel_export", "TIER_CLOUD_PRO"),             # Pro-only (moved off Enterprise)
+        ("siem_export", "TIER_ENTERPRISE"),            # Enterprise-only feature
+        ("sso", "TIER_ENTERPRISE"),                    # Enterprise-only feature
+    ],
+)
+def test_gate_required_tier_routes_to_correct_upgrade(
+    enforce, feature_key, expected_tier_attr
+):
+    """The 402 response carries ``required_tier`` so the UI can render the
+    right upgrade CTA (Starter vs Pro vs Enterprise) without re-deriving
+    tier logic in JavaScript."""
+    from clawmetry._gate import gate
+
+    app = Flask(__name__)
+
+    @app.route("/test")
+    @gate(feature_key)
+    def view():
+        return {"ok": True}
+
+    with app.test_client() as c:
+        r = c.get("/test")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["required_tier"] == getattr(enforce, expected_tier_attr)
+
+
+def test_gate_required_tier_is_none_for_free_feature(enforce):
+    """Free features never produce a 402, but if a caller asks the helper
+    directly for one it returns None (no upgrade required)."""
+    from clawmetry._gate import _required_tier
+
+    assert _required_tier("sessions") is None
+    assert _required_tier("usage") is None
+
+
+def test_gate_required_tier_is_none_for_unknown_feature(enforce):
+    """Unknown / typo'd feature keys resolve to ``None`` rather than raising.
+    Keeps the 402 path graceful when a route uses a key not yet in the
+    catalogue (e.g. a clawmetry-pro plugin's private feature)."""
+    from clawmetry._gate import _required_tier
+
+    assert _required_tier("totally_unknown_feature_xyz") is None
+
+
+def test_gate_required_tier_swallows_entitlement_lookup_errors(monkeypatch):
+    """If a catalogue read itself raises the helper returns ``None`` rather
+    than propagating — the 402 body still serializes and the request path
+    stays defensive."""
+    from clawmetry import _gate
+
+    class _Boom:
+        def __contains__(self, _key):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.FREE_FEATURES", _Boom())
+    assert _gate._required_tier("self_evolve") is None
 
 
 def test_gate_decorator_passes_in_grace_mode(grace):


### PR DESCRIPTION
## Summary

Enrich the `@gate` 402 `upgrade_required` body with `required_tier` so the frontend can render the correct upgrade CTA (Starter vs Pro vs Enterprise) without re-deriving tier logic in JavaScript.

### What changes
- `clawmetry/_gate.py`: new private `_required_tier(feature_key)` helper that maps a feature onto the minimum tier identifier exported by `clawmetry/entitlements.py`:
  - `FREE_FEATURES`       → `None` (no upgrade required)
  - `STARTER_FEATURES`    → `TIER_CLOUD_STARTER`
  - `PRO_ONLY_FEATURES`   → `TIER_CLOUD_PRO`
  - `ENTERPRISE_FEATURES` → `TIER_ENTERPRISE`
- `gate()` now includes `required_tier` in the JSON response alongside the existing `error`, `feature`, `tier`, and `hint` fields.

### Shape

```jsonc
// before
{ "error": "upgrade_required", "feature": "self_evolve",
  "tier": "oss", "hint": "..." }

// after
{ "error": "upgrade_required", "feature": "self_evolve",
  "tier": "oss", "required_tier": "cloud_pro",
  "hint": "..." }
```

### Tests
- `tests/test_route_gates.py`:
  - Parameterized test pins the catalogue mapping for 6 representative feature keys (Starter / Pro / Enterprise).
  - Helper-level tests for free / unknown keys → `None`.
  - Helper swallows catalogue-read errors and returns `None` (never-crash contract).
  - Extends the existing blocked-in-enforce test to assert `required_tier`.

### Grace / enforce
Pure addition. Grace mode is unchanged (the decorator is still a no-op when `CLAWMETRY_ENFORCE` is unset), and the existing `tier` / `feature` / `hint` fields keep their shapes so any existing 402 consumer continues to work.

### Why this isn't in PR #2426
PR #2426 (`feature_catalog` + `/api/features`) adds a public `feature_tier()` helper in `entitlements.py`. This PR is independent: `_required_tier` is a private helper inside `_gate.py` scoped to the decorator and depends only on the already-exported `*_FEATURES` / `TIER_*` constants, so the two PRs can land in either order. If #2426 lands first, `_required_tier` can later be a one-line forward to `entitlements.feature_tier()`.

### Test plan

- [x] `python3 -m py_compile clawmetry/_gate.py tests/test_route_gates.py` clean
- [x] `python3 -m pytest tests/test_route_gates.py tests/test_entitlements.py tests/test_entitlements_catalogue.py tests/test_entitlement_api.py` → 58 passed (1 pre-existing `test_gated_route_passes_in_grace_mode` failure also fails on `origin/main`, unrelated)
- [x] `make lint` clean for changed files (198 pre-existing repo-wide errors, none in `_gate.py` / `tests/test_route_gates.py`)
- [ ] Frontend update to surface `required_tier` in the upgrade CTA (separate PR — out of scope here)

### Local operator verification checklist

Since this agent runs in CI and has no access to the local daemon / live snapshot / browser, the local operator should:

- [ ] Pull the branch: `git fetch origin feat/gate-required-tier && git checkout feat/gate-required-tier`
- [ ] Copy changed files into the live install:
  - `cp clawmetry/_gate.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/_gate.py`
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] In grace mode (default), exercise a gated route (e.g. `curl -s http://localhost:8900/api/assets`) — should still return its normal response (200 / empty list / 5xx), **not** 402. The decorator is a no-op without `CLAWMETRY_ENFORCE=1`.
- [ ] Flip enforce briefly (`CLAWMETRY_ENFORCE=1 python3 -c "from clawmetry._gate import _required_tier; print(_required_tier('self_evolve'))"`) → expect `cloud_pro`.
- [ ] Decrypt the live cloud snapshot and confirm `/api/entitlement` still returns the same OSS-free shape (this PR does not change `/api/entitlement`).
- [ ] Browser-check the dashboard — no UI surface consumes `required_tier` yet (frontend wiring is a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvMFkvFRqviA3oW87G2SUw)_