### PR TITLE
feat(device): emit encrypted deviceSummary slice in cloud snapshot (WiFi transport)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11647,6 +11647,69 @@ def _build_cron_jobs(paths):
         return []
 
 
+def _build_device_summary(spending, daily_usage):
+    """Compact, all-runtime payload for a WiFi hardware companion.
+
+    Mirrors ``routes/device.py``'s ``/api/device/snapshot`` but built on the
+    daemon's OWN store handle (never a ``read_only`` re-open — FLYWHEEL §1) so
+    it rides the E2E-encrypted snapshot to cloud. The device GETs the snapshot,
+    decrypts with the user's key, and reads this one small slice — the cloud
+    never sees plaintext (E2E invariant preserved). Approve/Deny is wired (the
+    daemon owns the approvals queue); ``alert`` is sourced LAN-side for now
+    (the alert history lives in the dashboard process, not the daemon), so the
+    cloud summary leaves it ``null`` until that store is daemon-readable.
+
+    Never raises — every read degrades to a safe default so the device always
+    gets a valid shape.
+    """
+    summary = {
+        "schema": 1,
+        "cost_today_usd": round(float((spending or {}).get("today") or 0.0), 4),
+        "tokens_today": int((daily_usage or {}).get("today") or 0),
+        "active_sessions": 0,
+        "runtimes_active": [],
+        "health": "green",
+        "alert": None,
+        "approval": None,
+    }
+    try:
+        from clawmetry import local_store as _ls
+        store = _ls.get_store()
+    except Exception:
+        return summary
+    try:
+        from clawmetry import waste_flags as _wf
+        rows = store.query_sessions_table(limit=300) or []
+        active = [s for s in rows
+                  if isinstance(s, dict) and s.get("status") == "active"]
+        summary["active_sessions"] = len(active)
+        summary["runtimes_active"] = sorted({
+            (_wf.runtime_from_session_id(s.get("session_id") or "") or "openclaw")
+            for s in active
+        })
+    except Exception:
+        pass
+    try:
+        from clawmetry import waste_flags as _wf
+        ap = [r for r in (store.query_approvals(status="pending", limit=200) or [])
+              if isinstance(r, dict)]
+        if ap:
+            oldest = min(ap, key=lambda r: (r.get("created_at") or ""))
+            sid = oldest.get("requestor_session_id") or ""
+            summary["approval"] = {
+                "id": oldest.get("id"),
+                "action": oldest.get("action") or "tool call",
+                "runtime": _wf.runtime_from_session_id(sid) or "openclaw",
+                "session_id": sid,
+            }
+    except Exception:
+        pass
+    # A waiting approval is the one thing on this slice that needs a human.
+    if summary["approval"]:
+        summary["health"] = "amber"
+    return summary
+
+
 def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     """Push system info + subagent data as encrypted snapshot.
 
@@ -12208,6 +12271,10 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "mcpServers": mcp_servers_slice,
         "contextEconomics": context_economics_slice,
         "spending": spending,
+        # Compact all-runtime slice a WiFi hardware companion decrypts + renders
+        # (the device GETs the snapshot, decrypts with the user's key, reads
+        # this). Cloud stays blind; E2E preserved.
+        "deviceSummary": _build_device_summary(spending, _du),
         "cronJobs": _build_cron_jobs(paths),
         "channels": _build_channel_data(config),
         "toolStats": _build_tool_stats(),

--- a/tests/test_device_summary_snapshot.py
+++ b/tests/test_device_summary_snapshot.py
@@ -1,0 +1,105 @@
+"""Tests for the snapshot `deviceSummary` slice (clawmetry/sync.py).
+
+The WiFi hardware companion decrypts the cloud snapshot and reads this one
+small slice. It must:
+  1. Always be a well-formed shape (never crash — the device must always get a
+     valid payload), carrying cost/tokens straight from the spending inputs.
+  2. Count active sessions across runtimes and surface the OLDEST pending
+     approval (the Approve/Deny button's source).
+  3. Flip health to amber while an approval is waiting.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def sync_with_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    ls.mark_writer_owner()  # own the writer so the tmp store opens in-process
+
+    import clawmetry.sync as sync
+    importlib.reload(sync)
+    yield sync, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _keys():
+    return ("schema", "cost_today_usd", "tokens_today", "active_sessions",
+            "runtimes_active", "health", "alert", "approval")
+
+
+def test_shape_and_cost_tokens_passthrough(sync_with_store):
+    sync, _ls = sync_with_store
+    s = sync._build_device_summary({"today": 4.2}, {"today": 1000})
+    for k in _keys():
+        assert k in s, f"missing key: {k}"
+    assert s["schema"] == 1
+    assert s["cost_today_usd"] == 4.2
+    assert s["tokens_today"] == 1000
+    assert s["active_sessions"] == 0
+    assert s["runtimes_active"] == []
+    assert s["health"] == "green"
+    assert s["approval"] is None
+
+
+def test_never_raises_on_missing_inputs(sync_with_store):
+    sync, _ls = sync_with_store
+    s = sync._build_device_summary(None, None)
+    assert s["cost_today_usd"] == 0.0
+    assert s["tokens_today"] == 0
+    assert s["health"] == "green"
+
+
+def test_active_sessions_and_oldest_approval(sync_with_store):
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": "sess-active",
+        "agent_type": "openclaw",
+        "status": "active",
+        "started_at": "2026-06-04T10:00:00+00:00",
+        "last_active_at": "2026-06-04T11:00:00+00:00",
+    })
+    store.ingest_session({
+        "session_id": "sess-ended",
+        "agent_type": "openclaw",
+        "status": "ended",
+        "started_at": "2026-06-03T09:00:00+00:00",
+        "last_active_at": "2026-06-03T10:00:00+00:00",
+    })
+    store.ingest_approval({
+        "id": "app-new", "requestor_session_id": "sess-active",
+        "action": "write_file", "status": "pending",
+        "created_at": "2026-06-04T10:05:00+00:00",
+    })
+    store.ingest_approval({
+        "id": "app-old", "requestor_session_id": "sess-active",
+        "action": "bash", "status": "pending",
+        "created_at": "2026-06-04T10:00:00+00:00",  # older
+    })
+    # drain ring so the SELECTs see the rows
+    import time
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and store.health()["ring_depth"] != 0:
+        time.sleep(0.02)
+
+    s = sync._build_device_summary({"today": 0}, {"today": 0})
+    assert s["active_sessions"] == 1
+    assert s["runtimes_active"] == ["openclaw"]
+    assert s["approval"] is not None
+    assert s["approval"]["id"] == "app-old"  # oldest pending, not newest
+    assert s["approval"]["action"] == "bash"
+    assert s["approval"]["runtime"] == "openclaw"
+    assert s["health"] == "amber"  # a human is needed


### PR DESCRIPTION
## Why

Step 2 of the hardware-companion initiative. We chose **WiFi-to-cloud** as the device transport (works for the whole fleet from anywhere, unlike a BLE-to-one-machine buddy). The constraint is ClawMetry's E2E invariant: the cloud cannot read your data. So the device must hold the key and decrypt a slice itself.

This PR makes the daemon emit a tiny `deviceSummary` slice into the existing E2E-encrypted snapshot. A WiFi device GETs the snapshot from cloud, decrypts with the user's key, and renders just this slice. The cloud stays blind. "Local compute, cloud display" extended to hardware.

## What

- `clawmetry/sync.py` `_build_device_summary(spending, daily_usage)`: mirrors the `/api/device/snapshot` payload (`cost_today_usd`, `tokens_today`, `active_sessions`, `runtimes_active`, `health`, `approval`, `alert`). Built on the daemon's **own** store handle (local `local_store` import, never a `read_only` re-open, per FLYWHEEL §1), reusing the already-computed `spending` + `dailyUsage`. Added as the `deviceSummary` key on the snapshot payload. Never raises.
- The Approve/Deny path (the killer button) is wired since the daemon owns the approvals queue. `alert` is left `null` in the cloud summary for now (the alert history lives in the dashboard process, not the daemon) — a tracked follow-up.
- `tests/test_device_summary_snapshot.py`: shape + cost/token passthrough, never-raise on missing inputs, active-session counting + oldest-pending-approval surfacing + amber health.

## Verification

Unit tests green (3 passed). Helper returns live data against a seeded store. Post-release I'll upgrade the local daemon and decrypt the live cloud snapshot to confirm `deviceSummary` is present (the real E2E check).

## Note on cloud

No cloud pin needed for this increment: `deviceSummary` is data the daemon pushes into the snapshot; the cloud relays it opaquely and the device decrypts client-side. A cloud-served device endpoint/page is a later step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)