### PR TITLE
fix(c6): remove invalid administration:write permission that caused 0-job workflow failures

### DIFF
--- a/.github/workflows/apply-required-checks.yml
+++ b/.github/workflows/apply-required-checks.yml
@@ -7,29 +7,37 @@ name: Apply required E2E status checks (C6 -- one-shot)
 #   workflow_dispatch -- manual trigger with confirm=APPLY to apply;
 #     confirm=dry-run (default) to preview without making changes.
 #   push to main -- self-healing: re-applies checks on every merge.
-#     On 403 (Workflow permissions not yet set to Read+Write), the
-#     Apply step exits 0 with an INFO message so main never acquires
-#     a failing check. Once Workflow permissions are set the VERY NEXT
-#     merge to main applies branch protection automatically.
+#     The script detects GITHUB_TOKEN vs PAT and behaves accordingly:
+#       - PAT (E2E_ADMIN_PAT set): applies and verifies branch protection.
+#       - GITHUB_TOKEN (no PAT): read-only verify + print instructions.
+#     Push runs always exit 0 -- they are informational, never blocking.
 #
 # HISTORY:
 #   push trigger added     2026-06-01 (PR #2420): push: branches: [main]
 #   push trigger removed   2026-06-02 (PR #2449): job-level permissions
 #     caused 0-job failures. Fix: moved permissions to workflow level.
-#   push trigger re-added  2026-06-03 (this PR): bug fixed, self-healing
-#     restored. Apply step exits 0 on 403 so push never blocks main.
+#   push trigger re-added  2026-06-03 (PR #2468): permissions moved to
+#     workflow level. But administration:write is still invalid for
+#     GITHUB_TOKEN -- all 283 runs failed with 0 jobs.
+#   ROOT CAUSE FIX        2026-06-04 (this PR): removed administration:write
+#     from permissions block. It is NOT a valid GITHUB_TOKEN permission in
+#     Actions; requesting it causes GitHub to reject the workflow run before
+#     any jobs are queued. Script now handles GITHUB_TOKEN path gracefully.
 #
-# REQUIREMENTS (choose one before admin wants to apply):
-#   A) Settings > Actions > General > Workflow permissions =
-#      "Read and write permissions". Built-in GITHUB_TOKEN then has
-#      administration:write. Push trigger will apply checks on next merge.
-#   B) Set repo secret E2E_ADMIN_PAT to a fine-grained PAT with
-#      Administration (read+write) on clawmetry, clawmetry-cloud,
-#      clawmetry-landing. Applies all 3 repos in one run.
+# REQUIREMENTS:
+#   To automatically apply required checks on every push to main:
+#     Set repo secret E2E_ADMIN_PAT to a fine-grained PAT with
+#     Administration (read+write) on clawmetry, clawmetry-cloud,
+#     clawmetry-landing. The GITHUB_TOKEN in Actions cannot write branch
+#     protection rules -- administration:write is not a valid permission
+#     for GITHUB_TOKEN and requesting it caused 0-job workflow failures.
 #
-# When only Option A is used: trigger the equivalent workflow in
-#   clawmetry-cloud and clawmetry-landing separately (or wait for next
-#   push to main there).
+#   Manual alternative (no PAT needed):
+#     Settings > Branches > main > Required status checks > add:
+#       clawmetry         : "OSS golden path (wheel + OpenClaw + 9 tabs)"
+#       clawmetry         : "Cross-repo handoff (C4)"
+#       clawmetry-cloud   : "Cloud golden-path browser E2E"
+#       clawmetry-landing : "Landing golden path (C3)"
 #
 # Idempotent: running multiple times is safe.
 # Tracking: vivekchand/clawmetry#2146 (C6)
@@ -44,11 +52,12 @@ on:
   push:
     branches: [main]
 
-# Workflow-level permissions: provisioned at run start, not job setup.
-# administration:write is required to modify branch protection rules.
 # contents:read is required for actions/checkout.
+# administration:write is intentionally absent: it is NOT a valid GITHUB_TOKEN
+# permission in Actions. Requesting it caused GitHub to reject all workflow
+# runs before any jobs were queued (0-job failure, conclusion: failure).
+# Branch-protection writes require a PAT (see REQUIREMENTS above).
 permissions:
-  administration: write
   contents: read
 
 jobs:
@@ -64,19 +73,17 @@ jobs:
           echo "=== DRY RUN -- checks that will be added when confirm=APPLY ==="
           echo ""
           if [ -z "${{ secrets.E2E_ADMIN_PAT }}" ]; then
-            echo "  Using GITHUB_TOKEN (E2E_ADMIN_PAT not set) -- clawmetry only:"
-            echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
-            echo "  clawmetry         : Cross-repo handoff (C4)"
+            echo "  E2E_ADMIN_PAT is not set. Without it, the Apply step runs"
+            echo "  in read-only mode: it verifies current state but cannot"
+            echo "  write branch protection rules (GITHUB_TOKEN lacks admin"
+            echo "  rights -- administration:write is not a valid GITHUB_TOKEN"
+            echo "  permission in Actions)."
             echo ""
-            echo "  REQUIREMENT: ensure Settings > Actions > General > Workflow"
-            echo "  permissions is set to 'Read and write permissions' before"
-            echo "  triggering with confirm=APPLY. Otherwise the PATCH to branch"
-            echo "  protection will return 403 even with administration:write here."
-            echo ""
-            echo "  For clawmetry-cloud and clawmetry-landing: trigger the"
-            echo "  equivalent workflow in each repo separately."
+            echo "  To enable auto-apply: set E2E_ADMIN_PAT as a repo secret"
+            echo "  (fine-grained PAT, Administration read+write on:"
+            echo "    clawmetry, clawmetry-cloud, clawmetry-landing)"
           else
-            echo "  Using E2E_ADMIN_PAT -- applying to all 3 repos:"
+            echo "  Using E2E_ADMIN_PAT -- will apply to all 3 repos:"
             echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
             echo "  clawmetry         : Cross-repo handoff (C4)"
             echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
@@ -92,10 +99,4 @@ jobs:
         if: github.event_name == 'push' || github.event.inputs.confirm == 'APPLY'
         env:
           GITHUB_TOKEN: ${{ secrets.E2E_ADMIN_PAT || github.token }}
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            python3 scripts/apply_required_status_checks.py \
-              || echo "INFO: branch protection not applied (Workflow permissions may be read-only). Enable Settings > Actions > General > Workflow permissions = Read and write, then this step succeeds on next push to main."
-          else
-            python3 scripts/apply_required_status_checks.py
-          fi
+        run: python3 scripts/apply_required_status_checks.py

--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -9,24 +9,27 @@ Usage
 -----
   GITHUB_TOKEN=ghp_xxx python3 scripts/apply_required_status_checks.py
 
+Token types
+-----------
+GITHUB_TOKEN from Actions (prefix ghs_):
+  Can read branch protection state but CANNOT write it. The script detects
+  this automatically: it verifies current state (read-only) and exits 0 with
+  actionable instructions. Push-triggered runs are always informational.
+  Note: requesting administration:write in the workflow permissions block is
+  invalid for GITHUB_TOKEN and causes 0-job workflow failures -- do not add it.
+
+Fine-grained PAT (prefix ghp_ or github_pat_, set as E2E_ADMIN_PAT secret):
+  Required to write branch protection rules. Needs Administration (read+write)
+  on clawmetry, clawmetry-cloud, clawmetry-landing. Full apply + verify.
+
 When run inside GitHub Actions, GITHUB_REPOSITORY is set automatically
 (e.g. "vivekchand/clawmetry"). The script restricts the checks it applies
-to only the matching repo so that a GITHUB_TOKEN with single-repo
-Administration write access is sufficient.
+to only the matching repo so that a single-repo token is sufficient.
 
 When run locally (GITHUB_REPOSITORY not set), the script applies all 4
 checks and requires a token with cross-repo Administration access.
 
-Requirements
-------------
-A fine-grained PAT (or classic token) with:
-  - Repository access: clawmetry, clawmetry-cloud, clawmetry-landing
-  - Permissions: Administration (read + write) on each repo
-    (required to modify branch protection rules)
-
-If branch protection does not yet exist on main, the script creates a
-minimal protection rule first (no push restrictions, no required reviews)
-before adding the status checks. Existing protection rules are preserved.
+Tracking: vivekchand/clawmetry#2146 (C6)
 """
 from __future__ import annotations
 
@@ -58,9 +61,6 @@ REQUIRED_CHECKS: list[tuple[str, str]] = [
 ]
 
 # Checks previously added as required that must be actively removed.
-# This list is processed on every run so the script is self-healing:
-# if a deprecated check re-appears (e.g. via a manual UI edit) it is
-# removed on the next push-triggered run.
 DEPRECATED_CHECKS: list[tuple[str, str]] = [
     # Added in error before 2026-06-02: pr-screenshots.yml has a paths: filter
     # so visual-diff only fires on UI-touching PRs. As a required check it
@@ -167,7 +167,6 @@ def verify_required_checks(
 
     Returns True if all required checks are present and no deprecated checks
     remain. Prints a FAIL line for each discrepancy so CI logs are actionable.
-    Catches silent 403 / administration:write failures before they go unnoticed.
     """
     repos = dict.fromkeys([r for r, _ in checks + deprecated])
     ok = True
@@ -196,20 +195,11 @@ def verify_required_checks(
 
 
 def _checks_to_apply() -> list[tuple[str, str]]:
-    """Return the subset of REQUIRED_CHECKS applicable to the current context.
-
-    Inside GitHub Actions, GITHUB_REPOSITORY is set to "owner/repo". When it
-    matches one of the repos in REQUIRED_CHECKS, only that repo's checks are
-    returned so that a single-repo GITHUB_TOKEN is sufficient.
-
-    When GITHUB_REPOSITORY is not set (local run with a cross-repo PAT),
-    all checks are returned.
-    """
+    """Return the subset of REQUIRED_CHECKS applicable to the current context."""
     github_repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
     if not github_repository:
         return REQUIRED_CHECKS
 
-    # Extract the repo name (strip owner prefix if present)
     current_repo = github_repository.split("/", 1)[-1]
     filtered = [(repo, ctx) for repo, ctx in REQUIRED_CHECKS if repo == current_repo]
     if filtered:
@@ -219,8 +209,6 @@ def _checks_to_apply() -> list[tuple[str, str]]:
         )
         return filtered
 
-    # GITHUB_REPOSITORY is set but doesn't match any entry -- apply all and
-    # let the API calls fail with a clear error if the token lacks access.
     print(
         f"  Warning: GITHUB_REPOSITORY={github_repository!r} did not match any "
         "entry in REQUIRED_CHECKS; applying all checks."
@@ -245,10 +233,47 @@ def main() -> None:
             "Usage: GITHUB_TOKEN=ghp_xxx python3 scripts/apply_required_status_checks.py"
         )
 
+    # Token type detection:
+    #   ghs_ prefix  = GITHUB_TOKEN from Actions (scoped to current repo only).
+    #                  Cannot write branch protection rules. Read-only path.
+    #   ghp_ or github_pat_ = Personal Access Token. Can write branch protection
+    #                  when it has Administration (read+write) on target repos.
+    is_pat = not token.startswith("ghs_")
+
     checks = _checks_to_apply()
     deprecated = _deprecated_to_remove()
-
     total = len(checks)
+
+    if not is_pat:
+        # Read-only path: GITHUB_TOKEN cannot write branch protection.
+        # Verify current state so push runs detect if checks were already
+        # configured by a prior PAT run or via the GitHub Settings UI.
+        print("=== E2E Robustness C6: read-only verify (GITHUB_TOKEN, no write access) ===")
+        print()
+        print("INFO: GITHUB_TOKEN cannot write branch protection rules.")
+        print("INFO: To auto-apply on every push to main, set E2E_ADMIN_PAT as a")
+        print("  repo secret (fine-grained PAT, Administration read+write on")
+        print("  clawmetry, clawmetry-cloud, clawmetry-landing).")
+        print("INFO: Manual alternative -- Settings > Branches > main >")
+        print("  Required status checks > add:")
+        for repo, ctx in REQUIRED_CHECKS:
+            print(f"    [{repo}] {ctx!r}")
+        print()
+        print("=== Reading current required status checks ===")
+        if verify_required_checks(checks, deprecated, token):
+            print()
+            print("=== C6: checks already correctly configured ===")
+            print("=== (Set by manual Settings UI action or a prior PAT run.) ===")
+        else:
+            print()
+            print("INFO: Required checks not yet configured. Next steps:")
+            print("  A) Set E2E_ADMIN_PAT repo secret (see above) -- auto-applies on")
+            print("     next push to main.")
+            print("  B) Settings > Branches > main > Required status checks (manual).")
+        # Always exit 0: push-triggered runs are informational, never blocking.
+        return
+
+    # PAT path: full apply + verify.
     print(f"=== E2E Robustness C6: applying {total} required status check(s) ===")
     for repo, context in checks:
         try:
@@ -264,8 +289,7 @@ def main() -> None:
             try:
                 remove_required_check(repo, context, token)
             except RuntimeError as exc:
-                # Removal failure is non-fatal: log a warning and continue.
-                # The check will be retried on the next push-triggered run.
+                # Removal failure is non-fatal: log and continue.
                 print(f"  WARNING [{repo}]: could not remove {context!r}: {exc}")
 
     print()
@@ -289,9 +313,8 @@ def main() -> None:
         print()
         print(
             "ERROR: branch protection state does not match expected config (see above).\n"
-            "If this is a 403, GITHUB_TOKEN may not have administration:write on this "
-            "repo. Set E2E_ADMIN_PAT as a repo secret (fine-grained PAT, "
-            "Administration read+write) and re-run."
+            "If this is a 403, E2E_ADMIN_PAT may lack Administration (read+write) on "
+            "this repo. Check the PAT permissions and re-run."
         )
         sys.exit(2)
     print("=== Verification passed: C6 branch protection is correctly configured ===")


### PR DESCRIPTION
## Root cause

`administration:write` is **not a valid `GITHUB_TOKEN` permission** in GitHub Actions. Requesting it at the workflow `permissions:` level caused GitHub to reject all 283 `apply-required-checks.yml` runs before any jobs were queued. Every run showed `conclusion: failure, total_jobs: 0`. The self-healing push trigger fired on every merge to main but the workflow was dead on arrival -- C6 has never actually applied required status checks.

Confirmed by checking run IDs `26936957636` (main push, 07:17Z today) and `26943044088` (latest): both `list_workflow_jobs` calls returned `total_count: 0`.

## What this PR changes

### `.github/workflows/apply-required-checks.yml`
- **Remove `administration: write`** from the `permissions:` block (was the only cause of 0-job failures)
- Keep `contents: read` (still needed for `actions/checkout`)
- Simplify the Apply step: the script now handles GITHUB_TOKEN vs PAT routing internally, so the bash wrapper `|| echo "INFO..."` is no longer needed
- Add history note explaining the root cause

### `scripts/apply_required_status_checks.py`
- **Detect token type** at start of `main()`: `ghs_` prefix = GITHUB_TOKEN, `ghp_`/`github_pat_` = PAT
- **GITHUB_TOKEN path** (no PAT set): skip write, run read-only `verify_required_checks`, exit 0 with actionable instructions. This means push-triggered runs will now:
  - Show the current branch protection state (detects if user already configured it manually)
  - Print exact instructions for setting `E2E_ADMIN_PAT` or using the Settings UI
  - Never block CI
- **PAT path** (E2E_ADMIN_PAT set): full apply + verify as before, `sys.exit(2)` on verification failure

## Behavior after merge

| Token available | Trigger | Outcome |
|---|---|---|
| GITHUB_TOKEN only | push to main | Jobs run, read-only verify, exit 0. Prints current branch protection state + instructions. |
| E2E_ADMIN_PAT set | push to main | Jobs run, applies checks to clawmetry (scoped by GITHUB_REPOSITORY), exits 0/2. |
| E2E_ADMIN_PAT set | workflow_dispatch confirm=APPLY | Full apply to all 3 repos, verification, exits 2 on mismatch. |

## To flip C6 green

**Option A (recommended):** Set `E2E_ADMIN_PAT` as a repo secret: fine-grained PAT with Administration (read+write) on `clawmetry`, `clawmetry-cloud`, `clawmetry-landing`. After merge, the next push to main auto-applies all required checks.

**Option B:** GitHub Settings > Branches > main > Required status checks > add:
- `clawmetry`: `OSS golden path (wheel + OpenClaw + 9 tabs)`
- `clawmetry`: `Cross-repo handoff (C4)`
- `clawmetry-cloud`: `Cloud golden-path browser E2E`
- `clawmetry-landing`: `Landing golden path (C3)`

## Acceptance test

After merge: check the next push-triggered `apply-required-checks.yml` run on main. It must show `total_jobs: 1` (not 0) and `conclusion: success`. The job log will show either "checks already configured" or the instructions to add `E2E_ADMIN_PAT`.

Tracking: vivekchand/clawmetry#2146 (C6)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_0116NFXH2ur65J1VPpRku1Em)_