### PR TITLE
fix: surface structured log context fields in Event.extra (#2680)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -187,7 +187,7 @@ class OpenClawAdapter(AgentAdapter):
             from clawmetry import local_store as _ls
             store = _ls.get_store(read_only=True)
             rows = store._fetch(
-                "SELECT id, event_type, ts, model, token_count, data "
+                "SELECT id, event_type, ts, model, token_count, data, agent_id, node_id "
                 "FROM events WHERE agent_type = ? AND session_id = ? "
                 "ORDER BY ts ASC LIMIT ?",
                 ["openclaw", str(session_id), int(limit)],
@@ -202,9 +202,17 @@ class OpenClawAdapter(AgentAdapter):
                 extra: dict = {}
                 if r[3]:
                     extra["model"] = r[3]
+                # r[6] = agent_id, r[7] = node_id — surface structured log
+                # context fields so callers can correlate events by agent and node.
+                if r[6]:
+                    extra["agent_id"] = r[6]
+                if r[7]:
+                    extra["node_id"] = r[7]
                 # r[5] = data BLOB — decode and surface per-type token split
                 # (input/output/cache_read/cache_write) so callers can measure
                 # per-turn cache efficiency without re-reading the raw file.
+                # Also extract channel/hostname from gateway log record top-level
+                # fields when present (no dedicated DB columns for these).
                 raw_data = r[5]
                 if raw_data is not None:
                     try:
@@ -212,6 +220,10 @@ class OpenClawAdapter(AgentAdapter):
                             raw_data = bytes(raw_data).decode("utf-8", "replace")
                         obj = json.loads(raw_data) if isinstance(raw_data, str) else raw_data
                         if isinstance(obj, dict):
+                            for _field in ("channel", "hostname"):
+                                _val = obj.get(_field)
+                                if _val:
+                                    extra[_field] = _val
                             msg = obj.get("message")
                             src = msg if isinstance(msg, dict) else obj
                             usage = src.get("usage") if isinstance(src.get("usage"), dict) else {}

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2780,7 +2780,7 @@ def _parse_v3_event(
         "id": str(eid),
         "agent_type": "openclaw",
         "node_id": node_id,
-        "agent_id": "main",
+        "agent_id": obj.get("agent_id") or "main",
         "session_id": session_id,
         "workspace_id": None,
         "event_type": event_type,
@@ -2881,7 +2881,7 @@ def _local_ingest_session_batch(
         rows.append({
             "id": str(eid),
             "node_id": node_id,
-            "agent_id": "main",  # OpenClaw harness; Claude Code adapter will use 'claude-code'
+            "agent_id": obj.get("agent_id") or "main",
             "session_id": session_id,
             "workspace_id": obj.get("workspace") or obj.get("workspace_id"),
             "event_type": str(obj.get("type") or obj.get("event_type") or "unknown"),


### PR DESCRIPTION
Closes #2680

## Summary

- **Ingest fix** (`sync.py`): Both the v3-schema and legacy ingest paths hardcoded `agent_id="main"`, silently discarding the real agent_id from gateway JSONL log records. Now uses `obj.get("agent_id") or "main"` so the actual value is stored in DuckDB.
- **Query fix** (`adapters/openclaw.py`): `list_events()` SELECT only fetched 6 columns, omitting `agent_id` and `node_id` that are already in the events table schema. Expanded to 8 columns; both fields now appear in `Event.extra`. Also extracts `channel` and `hostname` from the data BLOB when present (reuses the existing BLOB-parse path, no new overhead class).

## Test plan

- `tests/test_openclaw_list_events.py` — all 6 tests pass (covers `list_events()` SELECT shape, field filtering, limit, cache token split)
- `tests/test_local_store.py` — all 76 tests pass (covers ingest, read-back, schema integrity)
- `tests/test_event_metrics_extraction.py` + `tests/test_v3_schema_parser.py` — all pass
- Syntax validated on both changed files via `ast.parse`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WukPRU8xhL4cSThLmj3Cv6)_