### PR TITLE
feat(entitlement): add tier_catalog() + tier_label() + GET /api/tiers

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -111,6 +111,34 @@ RUNTIME_LABELS = {
     "nanoclaw": "NanoClaw",
 }
 
+# Display labels for every tier identifier. Mirrors the runtime/feature label
+# pattern so the dashboard never has to hardcode a tier display name — the
+# upgrade-ladder UI reads :func:`tier_catalog` and trusts these. Falls back to
+# the tier id when a label is missing so an unknown tier still renders with
+# *something*. Plain tier names only — no pricing strings live in this file.
+TIER_LABELS = {
+    TIER_OSS: "OSS",
+    TIER_CLOUD_FREE: "Free",
+    TIER_TRIAL: "Trial",
+    TIER_CLOUD_STARTER: "Starter",
+    TIER_CLOUD_PRO: "Pro",
+    TIER_PRO: "Pro (Self-hosted)",
+    TIER_ENTERPRISE: "Enterprise",
+}
+
+# Stable display order for the upgrade ladder: cheapest → most capable. The
+# self-hosted Pro tier sits next to cloud Pro because it grants the same paid
+# feature set. The UI iterates :func:`tier_catalog` in this order.
+_TIER_ORDER = (
+    TIER_OSS,
+    TIER_CLOUD_FREE,
+    TIER_TRIAL,
+    TIER_CLOUD_STARTER,
+    TIER_CLOUD_PRO,
+    TIER_PRO,
+    TIER_ENTERPRISE,
+)
+
 # ── Feature catalogue ───────────────────────────────────────────────────────
 # Core observability — always free. Keys are stable identifiers the route /
 # UI layer checks via Entitlement.allows_feature(...).
@@ -464,6 +492,67 @@ def runtime_catalog() -> list[dict]:
                 "free": False,
                 "allowed": allowed,
                 "locked": not allowed,
+            }
+        )
+    return out
+
+
+def tier_label(tier: str) -> str:
+    """Human-readable label for ``tier``. Falls back to the id when unknown so
+    an unrecognised tier (e.g. a future plan code) still renders with
+    *something*."""
+    t = (tier or "").strip().lower()
+    return TIER_LABELS.get(t, t)
+
+
+def tier_catalog() -> list[dict]:
+    """The full tier ladder with the per-tier feature/runtime/retention
+    metadata the dashboard needs to render an upgrade affordance.
+
+    Mirrors :func:`runtime_catalog` (and the in-flight ``feature_catalog``) so
+    every catalogue the UI consumes has the same shape and ordering contract.
+    Returned in :data:`_TIER_ORDER` (cheapest → most capable) so the upgrade
+    ladder is deterministic across reloads.
+
+    Each entry::
+
+        {
+          "id":               "<tier>",        # canonical key (TIER_*)
+          "label":            "<Display>",     # falls back to id
+          "is_paid":          True | False,    # is in _PAID_TIERS
+          "is_current":       True | False,    # matches the resolved tier
+          "rank":             0..n,            # position in the ladder
+          "unlocks_paid_runtimes": True|False, # tier grants paid runtimes
+          "retention_days":   int | None,      # event retention cap (None = unlimited)
+          "features":         [...],           # paid feature keys this tier grants
+                                               # (free features are always included
+                                               # on top — they're not listed here so
+                                               # the upgrade copy stays scoped to the
+                                               # paid delta)
+        }
+
+    Never raises; on any resolution error the ``is_current`` flag falls back to
+    the OSS tier so the UI still has a safe row highlighted.
+    """
+    try:
+        ent = get_entitlement()
+        current = ent.tier
+    except Exception as exc:  # never crash a catalog read
+        logger.warning("entitlements: tier_catalog falling back to OSS-free: %s", exc)
+        current = TIER_OSS
+    out: list[dict] = []
+    for rank, tier in enumerate(_TIER_ORDER):
+        paid_feats = _TIER_FEATURES.get(tier, frozenset())
+        out.append(
+            {
+                "id": tier,
+                "label": tier_label(tier),
+                "is_paid": tier in _PAID_TIERS,
+                "is_current": tier == current,
+                "rank": rank,
+                "unlocks_paid_runtimes": tier in _TIER_PAID_RUNTIMES,
+                "retention_days": _TIER_RETENTION_DAYS.get(tier, 7),
+                "features": sorted(paid_feats),
             }
         )
     return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8,6 +8,7 @@ is the single source of truth — handlers never re-derive tier logic here.
 
   GET /api/entitlement — the current Entitlement as JSON.
   GET /api/runtimes    — the full runtime catalog with locked/free flags.
+  GET /api/tiers       — the full tier ladder with per-tier metadata.
 
 Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
 on the cloud side: when no license/cloud plan is present it returns a graceful
@@ -107,6 +108,54 @@ def api_runtimes():
                         "locked": False,
                     },
                 ],
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/tiers")
+def api_tiers():
+    """Return the full tier ladder with per-tier metadata so the dashboard can
+    render an upgrade affordance without re-deriving tier identifiers in
+    JavaScript.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"id": "oss", "label": "OSS", "is_paid": false,
+             "is_current": true, "rank": 0,
+             "unlocks_paid_runtimes": false,
+             "retention_days": 7, "features": []},
+            ...
+          ],
+          "current":  "oss",
+          "grace":    true | false,   # mirrors /api/entitlement.grace
+          "enforced": true | false
+        }
+
+    Side-effect-free and never-raise: any resolution error falls back to a
+    grace OSS-free shape so the UI still has something safe to render.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": _ent.tier_catalog(),
+                "current": ent.tier,
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_tiers: falling back to OSS-free: %s", exc)
+        return jsonify(
+            {
+                "tiers": [],
+                "current": "oss",
                 "grace": True,
                 "enforced": False,
             }

--- a/tests/test_tier_catalog.py
+++ b/tests/test_tier_catalog.py
@@ -1,0 +1,254 @@
+"""Tests for the tier catalogue helpers in clawmetry/entitlements.py.
+
+Pins:
+
+* :data:`TIER_LABELS` covers every tier id ``Entitlement.tier`` can take.
+* :func:`tier_label` returns the label for known ids and the raw id for unknown
+  ones (never-crash contract).
+* :func:`tier_catalog` returns one row per tier in the published ladder order,
+  marks exactly one row ``is_current``, never raises, and is internally
+  consistent with the per-tier feature / runtime / retention maps.
+
+Plus an integration test for :func:`routes.entitlement.api_tiers` that confirms
+the wire shape and the never-raise fallback.
+
+Companion to ``tests/test_entitlements.py`` (grace/enforce mechanics) and
+``tests/test_entitlements_catalogue.py`` (feature / retention buckets).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement off
+    by default (grace mode)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── tier_label ─────────────────────────────────────────────────────────────────
+
+
+def test_tier_label_known_tier_ids_return_their_label(ent):
+    assert ent.tier_label(ent.TIER_OSS) == "OSS"
+    assert ent.tier_label(ent.TIER_CLOUD_FREE) == "Free"
+    assert ent.tier_label(ent.TIER_TRIAL) == "Trial"
+    assert ent.tier_label(ent.TIER_CLOUD_STARTER) == "Starter"
+    assert ent.tier_label(ent.TIER_CLOUD_PRO) == "Pro"
+    assert ent.tier_label(ent.TIER_PRO) == "Pro (Self-hosted)"
+    assert ent.tier_label(ent.TIER_ENTERPRISE) == "Enterprise"
+
+
+def test_tier_label_unknown_tier_falls_back_to_id(ent):
+    assert ent.tier_label("not_a_real_tier") == "not_a_real_tier"
+
+
+def test_tier_label_handles_empty_and_none(ent):
+    # Never raises — empty / None should round-trip to an empty string so a
+    # missing field in the UI still renders as ``""`` rather than blowing up.
+    assert ent.tier_label("") == ""
+    assert ent.tier_label(None) == ""
+
+
+def test_tier_label_is_case_insensitive(ent):
+    assert ent.tier_label("CLOUD_PRO") == "Pro"
+    assert ent.tier_label(" Cloud_Starter ") == "Starter"
+
+
+def test_tier_labels_cover_every_known_tier(ent):
+    """Every TIER_* constant exported by entitlements.py must have a label so
+    the upgrade-ladder UI never has to fall back to a raw tier id for a tier
+    we already know about. New tiers MUST add a TIER_LABELS entry to keep this
+    test green."""
+    known = {
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    assert known.issubset(set(ent.TIER_LABELS.keys()))
+
+
+# ── tier_catalog ───────────────────────────────────────────────────────────────
+
+
+def test_tier_catalog_returns_one_row_per_known_tier(ent):
+    rows = ent.tier_catalog()
+    ids = [row["id"] for row in rows]
+    expected_known = {
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    assert expected_known.issubset(set(ids))
+    # No duplicates — the UI iterates the catalog as a ladder.
+    assert len(ids) == len(set(ids))
+
+
+def test_tier_catalog_order_is_oss_first_enterprise_last(ent):
+    rows = ent.tier_catalog()
+    assert rows[0]["id"] == ent.TIER_OSS
+    assert rows[-1]["id"] == ent.TIER_ENTERPRISE
+    # Ranks are 0..n-1, monotonic.
+    ranks = [row["rank"] for row in rows]
+    assert ranks == list(range(len(rows)))
+
+
+def test_tier_catalog_marks_exactly_one_current_in_grace(ent):
+    rows = ent.tier_catalog()
+    current = [row for row in rows if row["is_current"]]
+    assert len(current) == 1
+    # Grace mode + no license + no cloud plan → OSS is current.
+    assert current[0]["id"] == ent.TIER_OSS
+
+
+def test_tier_catalog_is_paid_matches_paid_tiers(ent):
+    rows = ent.tier_catalog()
+    paid_ids = {row["id"] for row in rows if row["is_paid"]}
+    # Strict equality: every paid tier shows up, no free tier slips in.
+    assert paid_ids == {
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+
+
+def test_tier_catalog_unlocks_paid_runtimes_matches_is_paid(ent):
+    """A paid tier always unlocks the paid runtime bundle (the open-core
+    invariant). A free tier never does."""
+    for row in ent.tier_catalog():
+        assert row["unlocks_paid_runtimes"] == row["is_paid"]
+
+
+def test_tier_catalog_retention_days_match_published_caps(ent):
+    rows_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    assert rows_by_id[ent.TIER_OSS]["retention_days"] == 7
+    assert rows_by_id[ent.TIER_CLOUD_FREE]["retention_days"] == 7
+    assert rows_by_id[ent.TIER_TRIAL]["retention_days"] == 30
+    assert rows_by_id[ent.TIER_CLOUD_STARTER]["retention_days"] == 30
+    assert rows_by_id[ent.TIER_CLOUD_PRO]["retention_days"] == 90
+    assert rows_by_id[ent.TIER_PRO]["retention_days"] == 90
+    assert rows_by_id[ent.TIER_ENTERPRISE]["retention_days"] is None
+
+
+def test_tier_catalog_features_are_paid_only_no_free_leakage(ent):
+    """The ``features`` list per row is the paid delta — free features are
+    always included on top and aren't repeated per-tier so the upgrade copy
+    stays scoped."""
+    for row in ent.tier_catalog():
+        assert set(row["features"]).isdisjoint(ent.FREE_FEATURES)
+
+
+def test_tier_catalog_starter_features_match_starter_bucket(ent):
+    rows_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    assert set(rows_by_id[ent.TIER_CLOUD_STARTER]["features"]) == set(ent.STARTER_FEATURES)
+
+
+def test_tier_catalog_pro_features_are_starter_plus_pro_only(ent):
+    rows_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    assert set(rows_by_id[ent.TIER_CLOUD_PRO]["features"]) == set(ent.PAID_FEATURES)
+    assert set(rows_by_id[ent.TIER_PRO]["features"]) == set(ent.PAID_FEATURES)
+
+
+def test_tier_catalog_enterprise_features_include_enterprise_bucket(ent):
+    rows_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    enterprise_feats = set(rows_by_id[ent.TIER_ENTERPRISE]["features"])
+    assert enterprise_feats == set(ent.PAID_FEATURES | ent.ENTERPRISE_FEATURES)
+
+
+def test_tier_catalog_marks_active_paid_tier_when_license_resolves(ent, monkeypatch, tmp_path):
+    """A cloud-plan cache file lights up the matching tier as current."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro", "node_limit": 3}))
+    ent.invalidate()
+    rows = ent.tier_catalog()
+    current = [row for row in rows if row["is_current"]]
+    assert len(current) == 1
+    assert current[0]["id"] == ent.TIER_CLOUD_PRO
+
+
+def test_tier_catalog_never_raises_on_resolution_failure(ent, monkeypatch):
+    """If get_entitlement explodes, tier_catalog still returns the ladder with
+    OSS as the (default) current row — never propagates an exception."""
+
+    def boom(*_a, **_kw):  # noqa
+        raise RuntimeError("simulated entitlement failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.tier_catalog()
+    assert any(row["id"] == ent.TIER_OSS for row in rows)
+    current = [row for row in rows if row["is_current"]]
+    # Fallback path marks OSS as current.
+    assert len(current) == 1
+    assert current[0]["id"] == ent.TIER_OSS
+
+
+# ── /api/tiers endpoint ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client(ent):
+    """Flask test client wired only to bp_entitlement so the test stays
+    independent of the full dashboard app and its imports."""
+    from flask import Flask
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def test_api_tiers_returns_ladder_shape(client, ent):
+    resp = client.get("/api/tiers")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "tiers" in body and isinstance(body["tiers"], list) and body["tiers"]
+    assert body["current"] == ent.TIER_OSS
+    # In grace mode (default fixture) enforcement is off.
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    # Spot-check the first/last rows match the catalog order.
+    assert body["tiers"][0]["id"] == ent.TIER_OSS
+    assert body["tiers"][-1]["id"] == ent.TIER_ENTERPRISE
+
+
+def test_api_tiers_falls_back_on_internal_error(client, ent, monkeypatch):
+    """If both ``get_entitlement`` AND ``tier_catalog`` explode the route still
+    returns 200 with the safe OSS-free fallback (never 5xx)."""
+
+    def boom(*_a, **_kw):  # noqa
+        raise RuntimeError("simulated catalog failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    monkeypatch.setattr(ent, "tier_catalog", boom)
+    resp = client.get("/api/tiers")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["current"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    assert body["tiers"] == []


### PR DESCRIPTION
## Summary

Mirror `runtime_catalog` / `runtime_label` (and the in-flight `feature_catalog` in #2426) for the **tier dimension** so the dashboard can render an upgrade ladder without re-deriving tier identifiers in JavaScript.

The three catalogue surfaces converge on a uniform shape:

| Dimension | Helper             | Endpoint        | Status |
|-----------|--------------------|-----------------|--------|
| Runtime   | `runtime_catalog()`| `GET /api/runtimes` | on main |
| Feature   | `feature_catalog()`| `GET /api/features` | in flight (#2426) |
| Tier      | `tier_catalog()`   | `GET /api/tiers`    | **this PR** |

## What changes

### `clawmetry/entitlements.py`
- `TIER_LABELS` — one display label per `TIER_*` constant (`OSS`, `Free`, `Trial`, `Starter`, `Pro`, `Pro (Self-hosted)`, `Enterprise`). Plain tier names — no pricing strings in this file.
- `_TIER_ORDER` — stable ladder order (cheapest → most capable) so the UI is deterministic across reloads.
- `tier_label(tier)` — case-insensitive lookup; falls back to the raw id so unknown tiers still render with *something*.
- `tier_catalog()` — one row per tier with this exact shape:

```jsonc
{
  "id":                    "cloud_pro",
  "label":                 "Pro",
  "is_paid":               true,
  "is_current":            false,
  "rank":                  4,
  "unlocks_paid_runtimes": true,
  "retention_days":        90,
  "features":              ["...", "..."]   // paid delta only — free features
                                            // are always included on top and
                                            // aren't repeated per row
}
```

### `routes/entitlement.py`
- `GET /api/tiers` on `bp_entitlement`, returning `{tiers, current, grace, enforced}`. Side-effect-free and never-raise: any resolution error falls back to a safe OSS-free shape (200 + empty list, never 5xx).

### `tests/test_tier_catalog.py`
19 tests pinning:
- `TIER_LABELS` covers every known tier id.
- `tier_label` handles known / unknown / empty / `None` / whitespace / mixed-case inputs without raising.
- Ladder ordering: OSS first, Enterprise last, ranks `0..n-1`.
- Exactly one row is `is_current` (OSS in grace; matches the resolved tier when a cloud-plan cache is present).
- Invariant: `is_paid` ↔ `unlocks_paid_runtimes` for every row.
- Per-tier retention caps match the published values (7 / 30 / 90 / `None`).
- Starter / Pro / Enterprise feature slices match `STARTER_FEATURES` / `PAID_FEATURES` / `PAID_FEATURES | ENTERPRISE_FEATURES`.
- No free-feature leakage into the per-row `features` list.
- Never-raise: a simulated `get_entitlement` failure still produces the ladder with OSS as the current row.
- `/api/tiers` wire shape, including the safe fallback when both `get_entitlement` and `tier_catalog` blow up.

## Grace / enforce

Pure addition. Grace mode behaviour is unchanged: `tier_catalog()` calls `get_entitlement()` once and surfaces the resolved tier id — no `allows_*` check is invoked and the `@gate` decorator path is not touched. Wiring this in changes **no current behaviour**.

## Why this doesn't conflict with the in-flight PRs

- **#2426 (`feature_catalog` + `/api/features`)** — independent dimension. Both PRs add additive helpers on `entitlements.py` and a new route on `bp_entitlement`. Edit windows are non-overlapping (this PR touches the constants block + tail of the file; #2426 lives in its own section).
- **#2674 (`required_tier` in 402 body)** — touches `_gate.py` only; this PR doesn't.
- **#2411 (`/api/license`) / #2534 (`/api/license/check`)** — license routes; this PR doesn't touch them.
- **#2421 (`clawmetry entitlement` CLI)** — CLI surface; this PR is HTTP / catalogue only.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_tier_catalog.py` → clean.
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_tier_catalog.py` → all checks passed.
- [x] `python3 -m pytest tests/test_tier_catalog.py` → **19/19 passed**.
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlements_catalogue.py tests/test_entitlement_api.py tests/test_tier_catalog.py` → **60/60 passed** — no regression in the entitlement suite.
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` → `dashboard.py` still parses.
- [x] Smoke import: `from routes.entitlement import bp_entitlement; from clawmetry import entitlements as e; e.tier_catalog()` → returns 7 rows; `e.tier_label('cloud_pro')` → `"Pro"`.
- [ ] Frontend rendering of the tier ladder (consumes `/api/tiers`) — separate PR, out of scope.

The pre-existing `make lint-daemon-allowlist` failure (`query_cache_metrics` in `routes/usage.py:3404`, `query_channel_delivery_health` in `routes/channels.py:824`) reproduces on `origin/main` and is unrelated to this PR — neither file is touched here.

## Local operator verification checklist

Since this agent runs in CI and has no access to the local daemon, the live cloud snapshot, or a browser, the local operator should:

- [ ] Pull the branch: `git fetch origin feat/tier-catalog && git checkout feat/tier-catalog`.
- [ ] Copy the three changed files into the live install:
  ```bash
  cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/entitlements.py
  cp routes/entitlement.py    ~/.clawmetry/lib/python3.*/site-packages/routes/entitlement.py
  ```
- [ ] Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`.
- [ ] Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] Hit the new endpoint:
  ```bash
  curl -s http://localhost:8900/api/tiers | python3 -m json.tool
  ```
  Expect 7 tier rows, `current: "oss"`, `grace: true`, `enforced: false`. `cloud_pro.retention_days` should be `90`; `enterprise.retention_days` should be `null`.
- [ ] Confirm `/api/entitlement` and `/api/runtimes` still return their existing shapes (this PR does not modify them).
- [ ] Decrypt the live cloud snapshot and confirm no behavioural drift in any existing surface.
- [ ] Browser-check the dashboard — no UI surface consumes `/api/tiers` yet (frontend wiring is a follow-up).

---
Generated by Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMogc3Lj1JK3ZpKpWQi2HS)_