### PR TITLE
fix(nemoclaw): capture NEMOCLAW_TOOL_CATALOG state in detect + snapshot

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1434,7 +1434,13 @@ def _detect_nemoclaw() -> dict:
         result["inference_provider"] = ""
         result["inference_model"] = ""
 
-    # 4. Try `openshell sandbox list` as alternative discovery
+    # 4. Capture tool-catalog mode (NEMOCLAW_TOOL_CATALOG env var).
+    # Harness logic: enabled = (env !== '0'). Absent means default-on.
+    _tc_env = os.environ.get("NEMOCLAW_TOOL_CATALOG")
+    result["tool_catalog_enabled"] = _tc_env != "0"
+    result["tool_catalog_env"] = _tc_env or ""
+
+    # 5. Try `openshell sandbox list` as alternative discovery
     openshell_bin = _find_openshell_bin()
     if openshell_bin and not result.get("sandbox_name"):
         try:
@@ -12340,6 +12346,8 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
             "inference.model": nemo.get("inference_model", ""),
             "security.sandbox_enabled": nemo.get("security_sandbox_enabled", True),
             "security.network_policy": nemo.get("security_network_policy", True),
+            "nemoclaw.tool_catalog_enabled": nemo.get("tool_catalog_enabled", True),
+            "nemoclaw.tool_catalog_env": nemo.get("tool_catalog_env", ""),
         }
         payload["sandbox"] = sandbox_meta
         log.info(


### PR DESCRIPTION
Closes #2606

## Summary

- **`_detect_nemoclaw()`** now reads `NEMOCLAW_TOOL_CATALOG` and emits `tool_catalog_enabled` (bool — False only when env is `"0"`, matching harness semantics) and `tool_catalog_env` (raw value for diagnostics).
- **`sync_system_snapshot()`** surfaces both as `nemoclaw.tool_catalog_enabled` and `nemoclaw.tool_catalog_env` in the `sandbox_meta` dict alongside the existing sandbox / inference / security fields.

## Test plan

- [ ] With `NEMOCLAW_TOOL_CATALOG` unset: snapshot `sandbox.nemoclaw.tool_catalog_enabled` is `true`.
- [ ] With `NEMOCLAW_TOOL_CATALOG=0`: snapshot `sandbox.nemoclaw.tool_catalog_enabled` is `false`.
- [ ] With `NEMOCLAW_TOOL_CATALOG=1`: snapshot value is `true`.
- [ ] Without NemoClaw installed (`_detect_nemoclaw()` returns `detected: false`): no `sandbox` key added (existing behaviour, unchanged).
- [ ] `python3 -m py_compile clawmetry/sync.py` passes (no syntax errors).

---
_Generated by [Claude Code](https://claude.ai/code/session_014CVz6Ahw58X1dK6vCKjtdi)_