### PR TITLE
feat(harness): hide Harness nav unless runtime selected + has template (#2667)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -7771,6 +7771,7 @@ function _cmApplyRuntimeTabVisibility() {
       try { switchTab('overview'); } catch (e) {}
     }
   });
+  try { _cmRefreshHarnessNav(); } catch (e) {}
 }
 // Insert/update/remove the runtime-scope note at the top of a tab's page.
 // Called from switchTab. Only shows when a specific (non-'all') runtime is
@@ -7982,6 +7983,7 @@ function _cmOnGlobalRuntimeChange(sel) {
   try { if (typeof _applyRuntimeFlowDiagram === 'function') _applyRuntimeFlowDiagram(val); } catch (e) {}
   // Reload the current tab so any runtime-aware view re-filters in place.
   if (typeof switchTab === 'function' && _cmCurrentTab) switchTab(_cmCurrentTab);
+  try { _cmRefreshHarnessNav(); } catch (e) {}
 }
 
 function _cmShowRuntimePaywall(harness, label) {
@@ -13993,6 +13995,26 @@ function renderToolCatalog() {
 var _cmHarnessTemplates = null;   // {runtime: template}, fetched once
 var _cmHarnessData = null;
 
+// Show the Harness nav iff a specific runtime is selected AND it has a template.
+function _cmRefreshHarnessNav() {
+  var nav = document.getElementById('left-nav-harness');
+  if (!nav) return;
+  var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  if (!rt || rt === 'all') { nav.style.display = 'none'; return; }
+  nav.style.display = (_cmHarnessTemplates && _cmHarnessTemplates[rt]) ? '' : 'none';
+}
+
+// Eagerly fetch templates at page-init so the nav can appear without waiting
+// for the user to visit the Harness tab.
+async function _cmInitHarnessNav() {
+  if (_cmHarnessTemplates) { _cmRefreshHarnessNav(); return; }
+  try {
+    var t = await fetch('/api/harness/templates').then(function (r) { return r.json(); });
+    _cmHarnessTemplates = (t && t.templates) || {};
+  } catch (e) { /* non-fatal — nav stays hidden */ }
+  _cmRefreshHarnessNav();
+}
+
 async function loadHarness() {
   var el = document.getElementById('harness-container');
   if (!el) return;
@@ -14002,6 +14024,7 @@ async function loadHarness() {
     if (!_cmHarnessTemplates) {
       var t = await fetch('/api/harness/templates').then(function (r) { return r.json(); });
       _cmHarnessTemplates = (t && t.templates) || {};
+      _cmRefreshHarnessNav();
     }
     var tmpl = _cmHarnessTemplates[rt];
     if (!tmpl) { el.innerHTML = _cmHarnessNoTemplate(rt); return; }
@@ -18868,6 +18891,9 @@ function closeCompModal() {
 }
 document.addEventListener('keydown', function(e) { if (e.key === 'Escape') closeCompModal(); });
 document.addEventListener('DOMContentLoaded', initCompClickHandlers);
+// Eagerly resolve harness template availability so the nav item appears
+// (or stays hidden) at first paint rather than waiting for the tab visit.
+document.addEventListener('DOMContentLoaded', function () { setTimeout(_cmInitHarnessNav, 300); });
 
 // Pre-fetch tool data so modals open instantly
 function _prefetchToolData() {

--- a/dashboard.py
+++ b/dashboard.py
@@ -11574,7 +11574,7 @@ DASHBOARD_HTML = r"""
         <div class="left-nav-item left-nav-item-sub" id="left-nav-context-economics" data-tab="context-economics" onclick="switchTab('context-economics')" title="Context-window utilization over time, compaction triggers and tokens reclaimed">
           <span class="left-nav-label">Context economics</span>
         </div>
-        <div class="left-nav-item left-nav-item-sub" id="left-nav-harness" data-tab="harness" onclick="switchTab('harness')" title="What the selected runtime uniquely exposes — beyond the generic tabs">
+        <div class="left-nav-item left-nav-item-sub" id="left-nav-harness" data-tab="harness" onclick="switchTab('harness')" title="What the selected runtime uniquely exposes — beyond the generic tabs" style="display:none">
           <span class="left-nav-label">Harness</span>
         </div>
         <div class="left-nav-item left-nav-item-sub" id="left-nav-swimlane" data-tab="swimlane" onclick="switchTab('swimlane')" title="Compare up to 4 sessions or runtimes side by side as parallel live lanes">


### PR DESCRIPTION
## Summary

Phase 0 of #2667 shipped the harness template registry, renderer, and backend endpoints — but the Harness sidebar nav item was unconditionally visible. The spec calls for it to be hidden unless a specific runtime is selected **and** that runtime has a registered template.

This PR closes that gap with ~27 lines across two files.

## Changes

- **`dashboard.py`**: add `style="display:none"` to `left-nav-harness` so the item is hidden from first paint (previously always visible).
- **`clawmetry/static/js/app.js`**:
  - `_cmRefreshHarnessNav()` — reads `_cmRuntimeFilter()` and `_cmHarnessTemplates`; shows the nav iff `rt !== 'all'` and the runtime has a registered template.
  - `_cmInitHarnessNav()` — async; pre-fetches `/api/harness/templates` on page init (~200-byte response) so the nav can appear on the first load without waiting for the user to click the tab.
  - `_cmRefreshHarnessNav()` wired into `_cmApplyRuntimeTabVisibility()`, `_cmOnGlobalRuntimeChange()`, and `loadHarness()` (when templates are first fetched).
  - A `DOMContentLoaded` handler calls `_cmInitHarnessNav()` 300 ms after page load (after the runtime filter is restored from localStorage).

## Test plan

- [ ] `python3 -m pytest tests/test_harness_templates.py -v` — all 5 registry/validation tests pass (6th needs Flask; smoke passes in a full env).
- [ ] `node --check clawmetry/static/js/app.js` — passes.
- [ ] `python3 -c 'import ast; ast.parse(open("dashboard.py").read())'` — passes.
- [ ] Manual: select **openclaw** in the runtime switcher → Harness tab appears in sidebar.
- [ ] Manual: switch to **All runtimes** → Harness tab hides.
- [ ] Manual: select **cursor** (no template) → Harness tab hides.
- [ ] Manual: page reload with openclaw pre-selected in localStorage → tab appears within ~300 ms without visiting the Harness tab.

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #2667. Marked draft for human review — mark Ready for Review once happy.

Closes #2667

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAYxRpP7MNhiot362AuNEv)_