### PR TITLE
feat(_gate): add gate_runtime() decorator + require_runtime() inline helper

### DIFF
--- a/clawmetry/_gate.py
+++ b/clawmetry/_gate.py
@@ -22,6 +22,16 @@ Example::
 The error shape matches what ``routes/audit.py`` and ``routes/otel_export.py``
 have been returning by hand for months, so existing front-ends that already
 handle 402 continue to work.
+
+Runtime gating
+--------------
+Some routes are scoped to a single runtime (e.g. the Claude Code dashboard)
+or accept a runtime in a path/body parameter (e.g. the runtime ingest API).
+For those, use :func:`gate_runtime` as a decorator when the runtime is known
+at import time, or :func:`require_runtime` inline when it comes from the
+request. Both share the same defensive contract as :func:`gate`: grace mode
++ free runtimes (``openclaw``, ``nemoclaw``) always pass through; any error
+inside the entitlement lookup is swallowed and the request proceeds.
 """
 from __future__ import annotations
 
@@ -57,6 +67,74 @@ def gate(feature_key: str) -> Callable:
                 # The audit chain still records the call; the worst that
                 # happens is a paid feature briefly runs on a Free tier.
                 pass
+            return fn(*args, **kwargs)
+        return wrapper
+    return deco
+
+
+def require_runtime(runtime: str):
+    """Inline gate for runtime-scoped routes that pick the runtime out of a
+    path or body parameter at request time.
+
+    Returns a Flask 402 ``upgrade_required`` response tuple when the install
+    is not entitled to ``runtime``; returns ``None`` (let the request through)
+    in grace mode, for free runtimes, or for any tier that already unlocks
+    ``runtime``. Defensive: any error inside the entitlement read swallows
+    to ``None`` so a flaky lookup never blocks a request that would otherwise
+    succeed.
+
+    Typical usage::
+
+        from clawmetry._gate import require_runtime
+
+        @bp.route("/api/runtimes/<rt>/sessions")
+        def list_sessions(rt: str):
+            blocked = require_runtime(rt)
+            if blocked is not None:
+                return blocked
+            ...
+    """
+    try:
+        from flask import jsonify
+        from clawmetry import entitlements as _ent
+
+        rt = (runtime or "").strip().lower()
+        en = _ent.get_entitlement()
+        if en.allows_runtime(rt):
+            return None
+        return jsonify({
+            "error": "upgrade_required",
+            "runtime": rt,
+            "tier": en.tier,
+            "hint": (
+                "This runtime ships in the closed-source clawmetry-pro "
+                "package. Install it with a license key or use Cloud Pro at "
+                "clawmetry.com/pricing."
+            ),
+        }), 402
+    except Exception:
+        # A flaky entitlement read must never block the request path.
+        return None
+
+
+def gate_runtime(runtime_key: str) -> Callable:
+    """Decorator factory: gate a Flask view on a specific runtime being
+    entitled.
+
+    Use when the runtime is known at decoration time (a route that only
+    serves Claude Code data, say). For runtime-from-request routes, prefer
+    :func:`require_runtime` inline so the gated value can vary per call.
+
+    Mirrors :func:`gate` semantically: grace mode + free runtimes pass
+    through; any entitlement-lookup error is swallowed and the request
+    proceeds (the audit chain still records the call).
+    """
+    def deco(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            blocked = require_runtime(runtime_key)
+            if blocked is not None:
+                return blocked
             return fn(*args, **kwargs)
         return wrapper
     return deco

--- a/tests/test_gate_runtime.py
+++ b/tests/test_gate_runtime.py
@@ -1,0 +1,212 @@
+"""Tests for the runtime-level gate decorator + inline helper.
+
+Pins the 402 ``upgrade_required`` contract for routes that gate on a
+specific runtime (``claude_code``, ``codex``, ...) rather than a feature
+key. Companion to ``tests/test_route_gates.py`` (feature gating) and
+``tests/test_entitlements_catalogue.py`` (catalogue invariants).
+
+Grace mode (default) always passes through, including for paid runtimes,
+so wiring a runtime gate into a route changes no current behaviour. Once
+``CLAWMETRY_ENFORCE=1`` flips on, paid runtimes return the structured
+402 body the dashboard already knows how to render.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def enforce(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def grace(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── @gate_runtime decorator contract ─────────────────────────────────────────
+
+
+def test_gate_runtime_blocks_paid_runtime_in_enforce_mode(enforce):
+    """A paid runtime on an OSS-free install returns 402 with the runtime
+    id, current tier, and an upgrade hint."""
+    from clawmetry._gate import gate_runtime
+
+    app = Flask(__name__)
+
+    @app.route("/test")
+    @gate_runtime("claude_code")
+    def view():
+        return {"ok": True}
+
+    with app.test_client() as c:
+        r = c.get("/test")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["runtime"] == "claude_code"
+        assert "tier" in body
+        assert "hint" in body
+
+
+@pytest.mark.parametrize("free_rt", ["openclaw", "nemoclaw"])
+def test_gate_runtime_passes_free_runtimes_even_when_enforced(enforce, free_rt):
+    """The free-tier runtimes always pass through, regardless of enforce
+    mode — they're free in every plan including OSS."""
+    from clawmetry._gate import gate_runtime
+
+    app = Flask(__name__)
+
+    @app.route("/test")
+    @gate_runtime(free_rt)
+    def view():
+        return {"ok": True}
+
+    with app.test_client() as c:
+        r = c.get("/test")
+        assert r.status_code == 200
+        assert r.get_json() == {"ok": True}
+
+
+@pytest.mark.parametrize(
+    "paid_rt",
+    ["claude_code", "codex", "cursor", "aider", "goose"],
+)
+def test_gate_runtime_passes_paid_runtimes_in_grace_mode(grace, paid_rt):
+    """Grace mode (default) lets every known runtime through so wiring the
+    gate in changes no current behaviour. Enforcement is opt-in via
+    ``CLAWMETRY_ENFORCE=1``."""
+    from clawmetry._gate import gate_runtime
+
+    app = Flask(__name__)
+
+    @app.route("/test")
+    @gate_runtime(paid_rt)
+    def view():
+        return {"ok": True}
+
+    with app.test_client() as c:
+        r = c.get("/test")
+        assert r.status_code == 200
+        assert r.get_json() == {"ok": True}
+
+
+def test_gate_runtime_never_raises_when_entitlement_lookup_fails(
+    enforce, monkeypatch
+):
+    """If the entitlement read itself throws, the request still goes
+    through (mirrors the ``@gate`` defensive fallback). A flaky entitlement
+    check must never break the request path."""
+    from clawmetry._gate import gate_runtime
+
+    def explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", explode)
+
+    app = Flask(__name__)
+
+    @app.route("/test")
+    @gate_runtime("claude_code")
+    def view():
+        return {"ok": True}
+
+    with app.test_client() as c:
+        r = c.get("/test")
+        assert r.status_code == 200  # graceful fallthrough
+
+
+# ── require_runtime() inline helper contract ─────────────────────────────────
+
+
+def test_require_runtime_returns_none_for_free_runtime(enforce):
+    """Free runtimes return ``None`` so the caller falls through to its
+    normal logic."""
+    from clawmetry._gate import require_runtime
+
+    assert require_runtime("openclaw") is None
+    assert require_runtime("nemoclaw") is None
+
+
+def test_require_runtime_returns_402_for_paid_runtime_when_enforced(enforce):
+    """Inline form returns a Flask response tuple (body, status) for the
+    caller to ``return`` directly."""
+    from clawmetry._gate import require_runtime
+
+    app = Flask(__name__)
+    with app.test_request_context("/test"):
+        result = require_runtime("claude_code")
+        assert result is not None
+        resp, status = result
+        assert status == 402
+        body = resp.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["runtime"] == "claude_code"
+
+
+def test_require_runtime_normalises_case_and_whitespace(enforce):
+    """Runtime ids are matched case-insensitively after trimming so a
+    request that sends ``"Claude_Code"`` or ``" codex "`` still hits the
+    gate."""
+    from clawmetry._gate import require_runtime
+
+    app = Flask(__name__)
+    with app.test_request_context("/test"):
+        # Paid runtime with messy casing still gated.
+        blocked = require_runtime("  Claude_Code  ")
+        assert blocked is not None
+        assert blocked[1] == 402
+        # Free runtime with messy casing still passes.
+        assert require_runtime("  OpenClaw  ") is None
+
+
+def test_require_runtime_passes_in_grace_mode(grace):
+    """Grace mode (default) returns ``None`` for every runtime so existing
+    request paths see no change until enforcement is on."""
+    from clawmetry._gate import require_runtime
+
+    for rt in ("openclaw", "nemoclaw", "claude_code", "codex", "totally_unknown"):
+        assert require_runtime(rt) is None
+
+
+def test_require_runtime_swallows_lookup_errors(enforce, monkeypatch):
+    """A failing entitlement read returns ``None`` rather than propagating
+    — the request path keeps working even on a partially-broken install."""
+    from clawmetry._gate import require_runtime
+
+    def explode():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", explode)
+    assert require_runtime("claude_code") is None
+
+
+def test_require_runtime_unknown_runtime_returns_402_when_enforced(enforce):
+    """Unknown runtime ids (typo, future runtime, plugin) are NOT in
+    ``FREE_RUNTIMES`` so enforce mode rejects them — opt-in only via the
+    entitled set, the same posture as the catalogue contract."""
+    from clawmetry._gate import require_runtime
+
+    app = Flask(__name__)
+    with app.test_request_context("/test"):
+        result = require_runtime("totally_unknown_xyz")
+        assert result is not None
+        assert result[1] == 402


### PR DESCRIPTION
## Summary

`clawmetry/_gate.py` already exposes `@gate("feature_key")` for feature-level entitlement checks, but the **runtime** axis was unaddressed: every route that needs to block a paid runtime currently either hand-rolls a 402 body (see `routes/runtime_ingest.py`, `routes/nemoclaw.py`) or omits the check entirely. This PR adds the missing pair so the wire format and grace contract are shared across both axes.

- `gate_runtime(runtime_key)` — decorator factory, mirrors `gate()`. Use when the gated runtime is known at decoration time.
- `require_runtime(runtime)` — inline helper that returns a Flask `(response, 402)` tuple or `None`. Use when the runtime comes from a path/body parameter at request time.

Both follow the existing `@gate` semantic posture:
- Grace mode (`CLAWMETRY_ENFORCE` unset / != 1) — pass through. **No current behaviour changes** by this PR.
- Free runtimes (`openclaw`, `nemoclaw`) — always pass.
- Any entitlement-lookup error is swallowed so a flaky read never blocks a request path.

No call sites are migrated in this PR — that's a separate, behaviour-neutral cleanup once the helper lands and the operator has verified locally.

## Changes

- `clawmetry/_gate.py` — adds `require_runtime()` + `gate_runtime()`; updates the module docstring with a "Runtime gating" section.
- `tests/test_gate_runtime.py` — 15 tests pinning:
  - 402 body shape (`error`, `runtime`, `tier`, `hint`).
  - Grace-mode pass-through for every runtime (free + paid + unknown).
  - Free runtimes always pass even when `CLAWMETRY_ENFORCE=1`.
  - Case/whitespace normalisation (`"  Claude_Code  "` still hits the gate).
  - Defensive fallback when `get_entitlement()` raises.
  - Unknown runtime ids return 402 under enforce (opt-in posture: entitled set only).

## Test plan

- [x] `python -m pytest tests/test_gate_runtime.py -q` → 15 passed.
- [x] `python -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_license.py tests/test_license_api.py -q` → 75 passed (no regressions).
- [x] `python -m ruff check clawmetry/_gate.py tests/test_gate_runtime.py` → All checks passed.
- [x] `python -m py_compile clawmetry/_gate.py tests/test_gate_runtime.py` → clean.

Note: there is one pre-existing failure in `tests/test_route_gates.py::test_gated_route_passes_in_grace_mode` on `main` (independent of this PR) — not addressed here.

## Local operator verification checklist

Because this agent has no access to your machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and `tests/` for the new test file).
- [ ] Clear `__pycache__` under the install path.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon.
- [ ] Hit `/api/entitlement` and confirm the existing shape is unchanged (this PR adds helpers; no endpoint was modified).
- [ ] Decrypt the live snapshot and confirm no behavioural drift in grace mode.
- [ ] Browser-check the dashboard: every paid-runtime UI surface should still render exactly as before (grace pass-through).
- [ ] Optionally `CLAWMETRY_ENFORCE=1 python -m pytest tests/test_gate_runtime.py` in your dev env to see the 402 shape live.

This PR is **DRAFT** — leave it for the operator to mark ready / merge / cut the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeKPg76khdMPGWByEt9kBP)_