### PR TITLE
e2e(c6): add close-c6.sh -- one-command C6 closer via gh CLI

### DIFF
--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -7,6 +7,10 @@ from the main branch protection of each repo.
 
 Usage
 -----
+  # Quickest path (no PAT needed -- uses your existing gh CLI session):
+  bash scripts/close-c6.sh
+
+  # Or directly with a token:
   GITHUB_TOKEN=ghp_xxx python3 scripts/apply_required_status_checks.py
 
 Token types
@@ -18,16 +22,22 @@ GITHUB_TOKEN from Actions (prefix ghs_):
   Note: requesting administration:write in the workflow permissions block is
   invalid for GITHUB_TOKEN and causes 0-job workflow failures -- do not add it.
 
-Fine-grained PAT (prefix ghp_ or github_pat_, set as E2E_ADMIN_PAT secret):
+Fine-grained PAT (prefix ghp_ or github_pat_), classic OAuth (gho_), or
+any non-ghs_ token:
   Required to write branch protection rules. Needs Administration (read+write)
-  on clawmetry, clawmetry-cloud, clawmetry-landing. Full apply + verify.
+  or repo ownership on clawmetry, clawmetry-cloud, clawmetry-landing.
+  Full apply + verify.
+
+  Easiest way to get one: gh auth token (uses your gh CLI session, which
+  already has admin rights if you own the repos -- run close-c6.sh instead
+  of calling this script directly).
 
 When run inside GitHub Actions, GITHUB_REPOSITORY is set automatically
 (e.g. "vivekchand/clawmetry"). The script restricts the checks it applies
 to only the matching repo so that a single-repo token is sufficient.
 
 When run locally (GITHUB_REPOSITORY not set), the script applies all 4
-checks and requires a token with cross-repo Administration access.
+checks and requires a token with cross-repo admin access.
 
 Tracking: vivekchand/clawmetry#2146 (C6)
 """
@@ -230,14 +240,15 @@ def main() -> None:
     if not token:
         sys.exit(
             "Error: GITHUB_TOKEN is not set.\n"
-            "Usage: GITHUB_TOKEN=ghp_xxx python3 scripts/apply_required_status_checks.py"
+            "Quickest path: bash scripts/close-c6.sh (uses gh CLI session)\n"
+            "Or: GITHUB_TOKEN=ghp_xxx python3 scripts/apply_required_status_checks.py"
         )
 
     # Token type detection:
     #   ghs_ prefix  = GITHUB_TOKEN from Actions (scoped to current repo only).
     #                  Cannot write branch protection rules. Read-only path.
-    #   ghp_ or github_pat_ = Personal Access Token. Can write branch protection
-    #                  when it has Administration (read+write) on target repos.
+    #   Anything else = PAT or OAuth token (gho_, ghp_, github_pat_, etc.).
+    #                  Full apply when token has admin/owner rights.
     is_pat = not token.startswith("ghs_")
 
     checks = _checks_to_apply()
@@ -246,14 +257,18 @@ def main() -> None:
 
     if not is_pat:
         # Read-only path: GITHUB_TOKEN cannot write branch protection.
-        # Verify current state so push runs detect if checks were already
-        # configured by a prior PAT run or via the GitHub Settings UI.
         print("=== E2E Robustness C6: read-only verify (GITHUB_TOKEN, no write access) ===")
         print()
         print("INFO: GITHUB_TOKEN cannot write branch protection rules.")
-        print("INFO: To auto-apply on every push to main, set E2E_ADMIN_PAT as a")
-        print("  repo secret (fine-grained PAT, Administration read+write on")
-        print("  clawmetry, clawmetry-cloud, clawmetry-landing).")
+        print()
+        print("INFO: Quickest path to close C6 (no PAT needed):")
+        print("  bash scripts/close-c6.sh")
+        print("  (Requires: gh CLI installed and 'gh auth login' run as repo admin.)")
+        print()
+        print("INFO: Alternative -- set E2E_ADMIN_PAT repo secret (fine-grained PAT,")
+        print("  Administration read+write on clawmetry, clawmetry-cloud,")
+        print("  clawmetry-landing). Next push to main auto-applies checks.")
+        print()
         print("INFO: Manual alternative -- Settings > Branches > main >")
         print("  Required status checks > add:")
         for repo, ctx in REQUIRED_CHECKS:
@@ -263,17 +278,14 @@ def main() -> None:
         if verify_required_checks(checks, deprecated, token):
             print()
             print("=== C6: checks already correctly configured ===")
-            print("=== (Set by manual Settings UI action or a prior PAT run.) ===")
+            print("=== (Set by manual Settings UI action or a prior admin run.) ===")
         else:
             print()
-            print("INFO: Required checks not yet configured. Next steps:")
-            print("  A) Set E2E_ADMIN_PAT repo secret (see above) -- auto-applies on")
-            print("     next push to main.")
-            print("  B) Settings > Branches > main > Required status checks (manual).")
+            print("INFO: Required checks not yet configured. Run: bash scripts/close-c6.sh")
         # Always exit 0: push-triggered runs are informational, never blocking.
         return
 
-    # PAT path: full apply + verify.
+    # PAT / OAuth path: full apply + verify.
     print(f"=== E2E Robustness C6: applying {total} required status check(s) ===")
     for repo, context in checks:
         try:
@@ -313,8 +325,9 @@ def main() -> None:
         print()
         print(
             "ERROR: branch protection state does not match expected config (see above).\n"
-            "If this is a 403, E2E_ADMIN_PAT may lack Administration (read+write) on "
-            "this repo. Check the PAT permissions and re-run."
+            "If this is a 403, your token may lack admin rights on this repo.\n"
+            "Run 'gh auth status' to verify your gh CLI session has the repo scope,\n"
+            "then re-run: bash scripts/close-c6.sh"
         )
         sys.exit(2)
     print("=== Verification passed: C6 branch protection is correctly configured ===")

--- a/scripts/close-c6.sh
+++ b/scripts/close-c6.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# close-c6.sh: Apply required E2E status checks across all 3 repos in one shot.
+#
+# Prerequisites: gh CLI installed and authenticated as repo admin. ~30 seconds.
+# No PAT creation, no repo secret setup, no Actions UI needed.
+#
+# Usage:
+#   bash scripts/close-c6.sh
+#
+# What this does:
+#   Adds 4 required status checks to main branch protection across 3 repos:
+#     clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)
+#     clawmetry         : Cross-repo handoff (C4)
+#     clawmetry-cloud   : Cloud golden-path browser E2E
+#     clawmetry-landing : Landing golden path (C3)
+#
+# After running: every PR in those 3 repos must pass the E2E suite to merge.
+# This closes criterion C6 of the E2E Robustness epic.
+#
+# Tracking: vivekchand/clawmetry#2146
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo ""
+echo "=== C6: applying required E2E status checks ==="
+echo ""
+echo "Target repos and checks:"
+echo "  clawmetry         : OSS golden path (wheel + OpenClaw + 9 tabs)"
+echo "  clawmetry         : Cross-repo handoff (C4)"
+echo "  clawmetry-cloud   : Cloud golden-path browser E2E"
+echo "  clawmetry-landing : Landing golden path (C3)"
+echo ""
+
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: gh CLI not found."
+  echo "Install from https://cli.github.com then run: gh auth login"
+  exit 1
+fi
+
+if ! gh auth status --active 2>/dev/null; then
+  echo ""
+  echo "ERROR: gh CLI is not authenticated. Run: gh auth login"
+  exit 1
+fi
+
+TOKEN=$(gh auth token)
+if [ -z "${TOKEN}" ]; then
+  echo "ERROR: could not read token from gh CLI."
+  exit 1
+fi
+
+echo "Got token from gh CLI."
+echo ""
+
+# Unset GITHUB_REPOSITORY so apply_required_status_checks.py applies
+# all 4 checks across all 3 repos (not just the current repo).
+unset GITHUB_REPOSITORY 2>/dev/null || true
+
+GITHUB_TOKEN="${TOKEN}" python3 "${SCRIPT_DIR}/apply_required_status_checks.py"


### PR DESCRIPTION
## What this PR adds

`scripts/close-c6.sh` -- a single bash command that closes C6 in ~30 seconds using your existing `gh` CLI session. No PAT creation, no repo secret, no Actions UI.

```bash
# From the clawmetry repo root, run once:
bash scripts/close-c6.sh
```

That's it. After running, all 4 required status checks are configured across all 3 repos and every future PR must pass E2E to merge.

---

## Why previous automation attempts didn't work

`administration:write` is not a valid `GITHUB_TOKEN` permission in GitHub Actions (fixed in PR #2687 for the workflow YAML). But even with that fix, `GITHUB_TOKEN` cannot write branch protection rules at all -- only read-only verification is possible. The `apply-required-checks.yml` workflow has been printing instructions on every push to main since 2026-06-04, but requires user action to complete.

`close-c6.sh` bypasses this entirely: it runs `gh auth token` to get a token from your existing `gh` login (which has admin rights on repos you own), then calls `scripts/apply_required_status_checks.py` with that token.

---

## What `close-c6.sh` does

1. Checks `gh` CLI is installed and authenticated (`gh auth status --active`)
2. Reads your token via `gh auth token`
3. Calls `apply_required_status_checks.py` with `GITHUB_REPOSITORY` unset so it applies all 4 checks across all 3 repos
4. Prints verification (reads back branch protection state, fails with details if anything is wrong)

Checks configured (idempotent, already-configured checks are skipped):

| Repo | Required check |
|------|----------------|
| clawmetry | `OSS golden path (wheel + OpenClaw + 9 tabs)` |
| clawmetry | `Cross-repo handoff (C4)` |
| clawmetry-cloud | `Cloud golden-path browser E2E` |
| clawmetry-landing | `Landing golden path (C3)` |

Also removes deprecated `visual-diff` from required checks if it was previously applied (it has a `paths:` filter that would stall non-UI PRs forever).

---

## Also in this PR

`scripts/apply_required_status_checks.py`: updated GITHUB_TOKEN path output to lead with `bash scripts/close-c6.sh` as the quickest path (instead of burying it after the PAT instructions).

---

## Companion PRs (also awaiting merge)

- clawmetry-cloud: fix `administration:write` in `apply-required-checks.yml` (same 0-job bug as clawmetry had before #2687)
- clawmetry-landing: same fix

Those two PRs fix the cloud and landing self-apply workflows so they run correctly on every push. But `close-c6.sh` works RIGHT NOW without needing those to merge first.

---

## After merging and running

1. Merge this PR
2. Run `bash scripts/close-c6.sh` from your terminal (takes ~30 seconds)
3. C6 flips GREEN. 7/7 criteria green. 7-consecutive-day countdown begins (estimated completion: 2026-06-12).

Tracking: vivekchand/clawmetry#2146

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_011U4y96hrmFRgpaXHfbq16v)_