### PR TITLE
fix(license): install clawmetry-pro into a HOME fallback when site-packages is read-only

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -87,6 +87,102 @@ def _real_install(sessions_dir: str) -> bool:
                for m in ("SOUL.md", "AGENTS.md", "MEMORY.md"))
 
 
+def _model_router_fingerprint() -> dict:
+    """Read the NemoClaw model-router source fingerprint (``git:<sha>``)
+    written by harness onboarding to ``<venv>/.nemoclaw-source-fingerprint``
+    (model-router.ts writeModelRouterInstalledFingerprint). Surfaces the
+    install-provenance / version-drift signal on DetectResult.meta (#2608).
+
+    Read-only and never raises. Returns ``{}`` when the file/venv is absent
+    (plain OpenClaw or old NemoClaw installs), so the meta dict is unchanged.
+    """
+    venv = os.environ.get("NEMOCLAW_MODEL_ROUTER_VENV") or os.path.expanduser(
+        os.path.join("~", ".nemoclaw", "model-router-venv"))
+    fp_path = os.path.join(venv, ".nemoclaw-source-fingerprint")
+    try:
+        with open(fp_path, encoding="utf-8") as fh:
+            raw = (fh.read() or "").strip()
+        if not raw:
+            return {}
+        out = {"modelRouterFingerprint": raw}
+        # raw looks like "git:<40hex>" / "gitlink:<40hex>" / "files:<hex>"
+        if ":" in raw:
+            kind, _, val = raw.partition(":")
+            out["modelRouterFingerprintKind"] = kind
+            if kind in ("git", "gitlink") and val:
+                out["modelRouterSourceSha"] = val[:12]
+        return out
+    except (OSError, ValueError):
+        return {}
+
+
+# NOTE (#2610, deferred): NemoClaw's skill-catalog version/provenance lives in
+# ``skills/catalog-metadata.json`` (min/tested NemoClaw version, content shas),
+# but that file is a SOURCE-repo build artifact — it is not shipped in the npm
+# ``files`` list and no install/Docker step copies it to any host-readable path,
+# and the NemoClaw skills bundle lives inside the sandbox container, not the host
+# ``~/.openclaw`` ClawMetry reads. So there is no reliable on-disk location to
+# read it from today. Deferred rather than ship a dead read; revisit if NemoClaw
+# starts exporting the catalog to the host (e.g. ~/.nemoclaw/skills/).
+
+
+def _nemoclaw_tool_catalog_state() -> Optional[bool]:
+    """Whether the NemoClaw compact tool-catalog wrapper is active for this
+    runtime (#2683).
+
+    The harness patch (scripts/patch-openclaw-tool-catalog.js) injects
+    ``NEMOCLAW_TOOL_CATALOG !== "0"`` into every agent turn, after rewriting
+    the pinned OpenClaw ``selection-*.js`` and stamping the marker
+    ``/* nemoclaw compact tool catalog (#2600) */``. We surface a defensive
+    session-level boolean so the dashboard can tell a guardrail-wrapped
+    session from one where the catalog was disabled.
+
+    Returns ``True``/``False`` ONLY when there is positive NemoClaw signal
+    (the patch marker is present in the openclaw dist, or the env var is
+    explicitly set); returns ``None`` on plain OpenClaw so we never assert a
+    catalog state that doesn't exist. Never raises.
+    """
+    env = os.environ.get("NEMOCLAW_TOOL_CATALOG")
+    # Look for the applied patch marker in the openclaw dist selection runtime.
+    patched = False
+    try:
+        home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+        dist_dirs = [
+            os.path.join(home, "node_modules", "openclaw", "dist"),
+            "/usr/local/lib/node_modules/openclaw/dist",
+        ]
+        marker = b"/* nemoclaw compact tool catalog (#2600) */"
+        for dist in dist_dirs:
+            if not os.path.isdir(dist):
+                continue
+            try:
+                names = os.listdir(dist)
+            except OSError:
+                continue
+            for n in names:
+                if not (n.startswith("selection-") and n.endswith(".js")):
+                    continue
+                fp = os.path.join(dist, n)
+                try:
+                    with open(fp, "rb") as fh:
+                        # Marker sits early in the rewritten module; cap the read.
+                        if marker in fh.read(2_000_000):
+                            patched = True
+                            break
+                except OSError:
+                    continue
+            if patched:
+                break
+    except Exception:
+        patched = False
+
+    if not patched and env is None:
+        # No NemoClaw signal at all → don't claim a catalog state.
+        return None
+    # Mirror the harness gate exactly: enabled unless explicitly "0".
+    return env != "0"
+
+
 class OpenClawAdapter(AgentAdapter):
     name = "openclaw"
     display_name = "OpenClaw"
@@ -110,6 +206,17 @@ class OpenClawAdapter(AgentAdapter):
             # workspace dir) is NOT a signal — ClawMetry creates it, which
             # false-positived OpenClaw on uninstalled machines.
             detected = bool(sessions) or running or _real_install(sessions_dir)
+            meta = {
+                "gatewayUrl": gateway_url,
+                "sessionsDir": sessions_dir,
+            }
+            # NemoClaw install-provenance signal (#2608). Returns {} on plain
+            # OpenClaw, so meta is unchanged there. (#2610 skill-catalog deferred
+            # — see note above: no host-readable on-disk location.)
+            meta.update(_model_router_fingerprint())
+            _tc_enabled = _nemoclaw_tool_catalog_state()
+            if _tc_enabled is not None:
+                meta["nemoclawToolCatalogEnabled"] = _tc_enabled
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,
@@ -118,10 +225,7 @@ class OpenClawAdapter(AgentAdapter):
                 workspace=workspace or default_home,
                 session_count=len(sessions),
                 capabilities=[c.value for c in self.capabilities()],
-                meta={
-                    "gatewayUrl": gateway_url,
-                    "sessionsDir": sessions_dir,
-                },
+                meta=meta,
             )
         except Exception as exc:
             logger.warning(f"OpenClaw detect() raised: {exc}")
@@ -138,10 +242,21 @@ class OpenClawAdapter(AgentAdapter):
         except Exception as exc:
             logger.warning(f"OpenClaw list_sessions() failed: {exc}")
             return []
+        # Runtime-level NemoClaw tool-catalog state (#2683): whether the
+        # compact tool-catalog wrapper is active for this install. None on
+        # plain OpenClaw (no NemoClaw signal) — we don't stamp a state then.
+        _tc_enabled = _nemoclaw_tool_catalog_state()
         out: List[Session] = []
         for s in raw[:limit]:
             updated_ms = s.get("updatedAt") or 0
             started_at = (updated_ms / 1000.0) if updated_ms else 0.0
+            extra = {
+                "kind": s.get("kind") or "direct",
+                "contextTokens": s.get("contextTokens"),
+                "agentId": s.get("agent") or "main",
+            }
+            if _tc_enabled is not None:
+                extra["nemoclawToolCatalogEnabled"] = _tc_enabled
             out.append(
                 Session(
                     agent=self.name,
@@ -156,11 +271,7 @@ class OpenClawAdapter(AgentAdapter):
                     cache_read_tokens=int(s.get("cacheReadTokens") or 0),
                     cache_write_tokens=int(s.get("cacheWriteTokens") or 0),
                     cost_usd=float(s["costUsd"]) if s.get("costUsd") is not None else None,
-                    extra={
-                        "kind": s.get("kind") or "direct",
-                        "contextTokens": s.get("contextTokens"),
-                        "agentId": s.get("agent") or "main",
-                    },
+                    extra=extra,
                 )
             )
         return out
@@ -347,8 +458,34 @@ class OpenClawAdapter(AgentAdapter):
                     for block in content:
                         if not isinstance(block, dict) or block.get("type") != "tool_use":
                             continue
-                        tool_name = block.get("name") or "tool"
+                        orig_name = block.get("name") or "tool"
+                        tool_name = orig_name
                         tool_id = block.get("id") or ""
+                        blk_input = block.get("input")
+                        # NemoClaw compact tool-catalog dispatch (#2682): the
+                        # injected meta-tool is named "tool_call" and carries the
+                        # REAL dispatched tool in input.name (the wrapper
+                        # dispatches via catalog.get(name)). Unwrap it so the
+                        # Tracing tab shows the real tool, not a generic
+                        # "tool_call" span. Falls back to the literal name on
+                        # old/missing data so it never crashes.
+                        attrs: dict = {}
+                        if tool_name == "tool_call" and isinstance(blk_input, dict):
+                            real = blk_input.get("name")
+                            if isinstance(real, str) and real.strip():
+                                real = real.strip()
+                                attrs.update({
+                                    "nemoclaw.catalog_dispatch": True,
+                                    "nemoclaw.meta_tool": "tool_call",
+                                    "nemoclaw.dispatched_tool": real,
+                                })
+                                tool_name = real
+                        # Catalog meta-tools (tool_search/tool_describe/tool_call)
+                        # are guardrail dispatches, not real agent actions — tag
+                        # by the ORIGINAL name (tool_name may now be the unwrapped
+                        # real tool).
+                        if orig_name in _NEMOCLAW_CATALOG_TOOLS:
+                            attrs["nemoclaw.catalog_guardrail"] = True
                         tool_span: dict = {
                             "span_id": _sid("tool", session_id, str(raw_ts), tool_id, tool_name),
                             "trace_id": trace_id,
@@ -359,10 +496,9 @@ class OpenClawAdapter(AgentAdapter):
                             "session_id": session_id,
                             "agent_type": "openclaw",
                             "tool_name": tool_name,
-                            "input": block.get("input"),
+                            "input": blk_input,
+                            "attributes": attrs or None,
                         }
-                        if tool_name in _NEMOCLAW_CATALOG_TOOLS:
-                            tool_span["attributes"] = {"nemoclaw.catalog_guardrail": True}
                         spans.append(tool_span)
 
             elif t in ("subagent_spawn", "agent_spawn"):

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5703,6 +5703,68 @@ class LocalStore:
                 ],
             )
 
+    def ingest_talk_lifecycle(
+        self,
+        *,
+        node_id: str,
+        session_id: str = "",
+        event_type: str,
+        mode: str = "",
+        transport: str = "",
+        brain: str = "",
+        provider: str = "",
+        final: Any = None,
+        duration_ms: Any = None,
+        byte_length: Any = None,
+        ts_iso: str,
+        raw: str = "",
+    ) -> None:
+        """Idempotently record one Talk/voice lifecycle signal in ``events``.
+
+        Gap #2604. OpenClaw's realtime Talk subsystem emits structured JSONL
+        log records (subsystem="talk") carrying flattened attributes
+        (``talkEventType`` / ``talkMode`` / ``talkTransport`` / ``talkBrain``
+        / ``talkProvider`` / ``talkFinal`` / ``talkDurationMs`` /
+        ``talkByteLength``). The daemon
+        (``sync.sync_talk_lifecycle_from_logs``) tails the file logs and
+        records each one here as a ``talk.lifecycle`` event so the dashboard /
+        cloud snapshot can surface per-session voice activity.
+
+        Modeled byte-for-byte on ``ingest_connector_health``: idempotent on a
+        stable id derived from session+event_type+ts so re-tailing the log
+        (after a rotation/truncation rescan) never double-counts. Never raises.
+        """
+        if not event_type or not ts_iso:
+            return
+        ev_id = "talk-" + hashlib.sha1(
+            f"{session_id or ''}|{event_type}|{ts_iso}|{(raw or '')[:80]}".encode("utf-8")
+        ).hexdigest()[:24]
+        payload = json.dumps({
+            "talkEventType": event_type,
+            "talkMode": mode or "",
+            "talkTransport": transport or "",
+            "talkBrain": brain or "",
+            "talkProvider": provider or "",
+            "talkFinal": final,
+            "talkDurationMs": duration_ms,
+            "talkByteLength": byte_length,
+        }).encode("utf-8")
+        with self._write_lock:
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO events
+                  (id, agent_type, node_id, agent_id, session_id, workspace_id,
+                   event_type, ts, data, cost_usd, token_count, model, created_at)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                [
+                    ev_id, "openclaw", node_id or "local", "main",
+                    (session_id or None), None,
+                    "talk.lifecycle", ts_iso, payload, None, None, None,
+                    int(time.time() * 1000),
+                ],
+            )
+
     def query_connector_health(self, since_hours: int = 24) -> list[dict[str, Any]]:
         """Recent ``connector.health`` signals, newest first.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1355,6 +1355,83 @@ def _is_running_in_container() -> bool:
     return False
 
 
+def _read_nemoclaw_sandbox_routing() -> list:
+    """Read ``~/.nemoclaw/sandboxes.json`` and derive per-sandbox model routing.
+
+    Gap #2684. The NemoClaw registry persists ``{sandboxes: {<name>: entry},
+    defaultSandbox}`` (harness/nemoclaw/src/lib/state/registry.ts); each entry
+    carries the raw ``provider`` + ``model``. This mirrors
+    ``getSandboxInferenceConfig()``
+    (harness/nemoclaw/src/lib/inference/config.ts) to derive the effective
+    providerKey / primaryModelRef / inferenceBaseUrl / inferenceApi for each
+    sandbox. Never raises — returns [] on missing/old/malformed registry files
+    so the daemon never crashes.
+    """
+    import json as _j
+
+    home = os.environ.get("HOME") or os.path.expanduser("~")
+    reg = os.path.join(home, ".nemoclaw", "sandboxes.json")
+    out: list = []
+    try:
+        with open(reg, "r", encoding="utf-8") as fh:
+            data = _j.load(fh)
+    except Exception:
+        return out
+    if not isinstance(data, dict):
+        return out
+    default_sb = data.get("defaultSandbox")
+    sandboxes = data.get("sandboxes")
+    if not isinstance(sandboxes, dict):
+        return out
+    MANAGED = "inference"
+    INFERENCE_ROUTE_URL = "https://inference.local/v1"
+    for name, entry in sandboxes.items():
+        try:
+            if not isinstance(entry, dict):
+                continue
+            provider = entry.get("provider") or ""
+            model = entry.get("model") or ""
+            # inferenceApi defaults to "openai-completions" unless the sandbox
+            # pins preferredInferenceApi (harness config.ts:188).
+            api = entry.get("preferredInferenceApi") or "openai-completions"
+            base_url = INFERENCE_ROUTE_URL
+            # Derive providerKey/primaryModelRef per the harness switch
+            # (getSandboxInferenceConfig, nemoclaw/src/lib/inference/config.ts).
+            # Default = managed "inference" provider for any unknown/cloud route.
+            if provider == "openai-api":
+                provider_key = "openai"
+                primary = f"openai/{model}" if model else ""
+            elif provider == "anthropic-prod" or (
+                provider == "compatible-anthropic-endpoint"
+                and api != "openai-completions"
+            ):
+                # Real anthropic route only when NOT the openai-completions
+                # default; a compatible-anthropic-endpoint with the default api
+                # is served by the MANAGED provider (config.ts:196-203).
+                provider_key = "anthropic"
+                primary = f"anthropic/{model}" if model else ""
+                base_url = "https://inference.local"
+                api = "anthropic-messages"
+            else:
+                # Includes compatible-anthropic-endpoint + openai-completions
+                # (the common default) → managed "inference" provider.
+                provider_key = MANAGED
+                primary = f"{MANAGED}/{model}" if model else ""
+            out.append({
+                "sandbox": name,
+                "isDefault": bool(default_sb and name == default_sb),
+                "provider": provider,
+                "model": model,
+                "providerKey": provider_key,
+                "primaryModelRef": primary,
+                "inferenceBaseUrl": base_url,
+                "inferenceApi": api,
+            })
+        except Exception:
+            continue
+    return out
+
+
 def _detect_nemoclaw() -> dict:
     """Detect NemoClaw (NVIDIA's OpenClaw wrapper) presence on the host.
 
@@ -1462,6 +1539,26 @@ def _detect_nemoclaw() -> dict:
                     break
         except Exception:
             pass
+
+    # 5. Per-sandbox model routing from ~/.nemoclaw/sandboxes.json (gap #2684).
+    # Defensive: returns [] on any failure so detection never crashes.
+    try:
+        routing = _read_nemoclaw_sandbox_routing()
+    except Exception:
+        routing = []
+    if routing:
+        result["sandboxes"] = routing
+        # Backfill coarse fields from the default sandbox when `nemoclaw
+        # status --json` didn't yield them (env-only / status unavailable).
+        default_route = next(
+            (r for r in routing if r.get("isDefault")), routing[0]
+        )
+        if not result.get("inference_provider"):
+            result["inference_provider"] = default_route.get("provider") or ""
+        if not result.get("inference_model"):
+            result["inference_model"] = default_route.get("model") or ""
+        if not result.get("sandbox_name"):
+            result["sandbox_name"] = default_route.get("sandbox") or ""
 
     return result
 
@@ -4692,9 +4789,63 @@ def sync_logs(config: dict, state: dict, paths: dict) -> int:
                     if not raw:
                         continue
                     try:
-                        entries.append(json.loads(raw))
+                        obj = json.loads(raw)
                     except Exception:
-                        entries.append({"raw": raw})
+                        obj = {"raw": raw}
+                    entries.append(obj)
+                    # Gap #2680: project session-correlatable gateway LOG
+                    # records into the local DuckDB events table so the
+                    # structured log fields (hostname / agent_id / channel)
+                    # are queryable per-session. This is OPPORTUNISTIC and
+                    # MUST NOT change the cloud-stream path below (entries /
+                    # _flush_log_batch stay as-is) and MUST never raise — the
+                    # store may be read-only / _ProxyStore in some daemon
+                    # states, hence the broad try/except.
+                    try:
+                        sid = (
+                            obj.get("session_id")
+                            if isinstance(obj, dict)
+                            else None
+                        )
+                        if sid:
+                            from clawmetry import local_store as _ls
+                            store = _ls.get_store()
+                            ev_ts = (
+                                obj.get("time")
+                                or obj.get("ts")
+                                or datetime.now(timezone.utc).isoformat()
+                            )
+                            meta = obj.get("_meta")
+                            level = (
+                                meta.get("logLevelName")
+                                if isinstance(meta, dict)
+                                else None
+                            )
+                            eid = "openclaw-log:%s:%s:%s" % (
+                                fname, offset, len(entries),
+                            )
+                            store.ingest({
+                                "id": eid,
+                                "node_id": node_id,
+                                "agent_type": "openclaw",
+                                "agent_id": obj.get("agent_id") or "main",
+                                "session_id": str(sid),
+                                "event_type": "log",
+                                "ts": str(ev_ts),
+                                "data": {
+                                    "kind": "gateway_log",
+                                    "hostname": obj.get("hostname"),
+                                    "agent_id": obj.get("agent_id"),
+                                    "channel": obj.get("channel"),
+                                    "message": obj.get("message"),
+                                    "level": level,
+                                },
+                            })
+                    except Exception as _le:
+                        log.debug(
+                            "sync_logs local event ingest (non-fatal): %s",
+                            _le,
+                        )
                     if len(entries) >= BATCH_SIZE:
                         _flush_log_batch(entries, fname, api_key, enc_key, node_id)
                         total += len(entries)
@@ -13545,6 +13696,15 @@ def run_daemon() -> None:
             except Exception as _e_ch:
                 log.debug("connector-health tick error (non-fatal): %s", _e_ch)
 
+            # ── Talk / realtime voice lifecycle (gap #2604) ──
+            # Tail the file logs for subsystem="talk" lifecycle records and
+            # ingest them as talk.lifecycle events so the dashboard can
+            # surface per-session voice activity. Best-effort, never fatal.
+            try:
+                sync_talk_lifecycle_from_logs(config, state, paths)
+            except Exception as _e_tk:
+                log.debug("talk-lifecycle tick error (non-fatal): %s", _e_tk)
+
             state["last_sync"] = datetime.now(timezone.utc).isoformat()
             # Audit fix (2026-05-17): force a synchronous local-store flush
             # BEFORE persisting the cursor state. Belt-and-suspenders to
@@ -14141,6 +14301,202 @@ def sync_connector_health_from_logs(
         return total
     except Exception as e:
         log.warning("connector-health: cycle failed: %s", e)
+        return 0
+
+
+def parse_talk_lifecycle_line(raw_line: str) -> dict | None:
+    """Parse one structured JSONL log line and return a Talk/voice lifecycle
+    record dict, or None when the line is not a Talk record.
+
+    Gap #2604. OpenClaw's Talk subsystem
+    (harness/openclaw/src/talk/logging.ts ``recordTalkLogEvent``) logs an
+    attributes object ``{sessionId, talkEventType, talkMode, talkTransport,
+    talkBrain, talkProvider, talkFinal, talkDurationMs, talkByteLength}`` via a
+    child logger bound with ``subsystem:"talk"``. tslog does NOT flatten that
+    object to the top level of the file-log record — it lands as a *positional*
+    argument under a numeric string key (``o["1"]``; ``o["0"]`` is the binding
+    prefix), the same way ``buildStructuredFileLogFields`` reads ``args[0]``
+    (logger.ts). So we scan the numeric-keyed positional args (and decode any
+    that are JSON strings) for the dict carrying ``talkEventType`` — robust to
+    whichever position tslog uses. Detection also accepts ``subsystem == "talk"``
+    in ``_meta.name`` / a positional binding. Best-effort: returns None on any
+    malformed/non-Talk line, never raises.
+    """
+    try:
+        line = (raw_line or "").strip()
+        if not line or not line.startswith("{"):
+            return None
+        # Cheap pre-filter to avoid json.loads on every gateway log line.
+        if "talk" not in line:
+            return None
+        o = json.loads(line)
+        if not isinstance(o, dict):
+            return None
+
+        # Collect candidate attribute dicts: the record itself + every
+        # positional numeric-keyed value (dict, or a JSON-string that decodes
+        # to a dict). tslog nests the logged attributes object here.
+        candidates: list[dict] = [o]
+        for k, v in o.items():
+            if not (isinstance(k, str) and k.isdigit()):
+                continue
+            if isinstance(v, dict):
+                candidates.append(v)
+            elif isinstance(v, str) and v.startswith("{"):
+                try:
+                    dv = json.loads(v)
+                    if isinstance(dv, dict):
+                        candidates.append(dv)
+                except (ValueError, TypeError):
+                    pass
+
+        attrs = next((c for c in candidates if c.get("talkEventType")), None)
+        if attrs is None:
+            # No talk attrs found — only ingest if it's clearly a talk-subsystem
+            # record (avoids dropping a future shape), else skip.
+            sub = None
+            meta = o.get("_meta")
+            if isinstance(meta, dict) and isinstance(meta.get("name"), str):
+                nm = meta["name"]
+                if nm.startswith("{"):
+                    try:
+                        sub = json.loads(nm).get("subsystem")
+                    except (ValueError, TypeError):
+                        sub = None
+                elif nm == "talk":
+                    sub = "talk"
+            if not (isinstance(sub, str) and sub == "talk"):
+                sub = next((c.get("subsystem") for c in candidates
+                            if c.get("subsystem") == "talk"), None)
+            if not (isinstance(sub, str) and sub == "talk"):
+                return None
+            return None  # talk-subsystem but no parseable attrs → nothing to ingest
+
+        event_type = attrs.get("talkEventType") or ""
+        if not event_type:
+            return None
+        ts = (o.get("time") or o.get("ts")
+              or (o.get("_meta") or {}).get("date") if isinstance(o.get("_meta"), dict) else "") or ""
+        return {
+            "session_id": attrs.get("sessionId") or attrs.get("session_id")
+            or o.get("session_id") or o.get("sessionId") or "",
+            "event_type": str(event_type),
+            "mode": attrs.get("talkMode") or "",
+            "transport": attrs.get("talkTransport") or "",
+            "brain": attrs.get("talkBrain") or "",
+            "provider": attrs.get("talkProvider") or "",
+            "final": attrs.get("talkFinal"),
+            "duration_ms": attrs.get("talkDurationMs"),
+            "byte_length": attrs.get("talkByteLength"),
+            "ts": str(ts),
+        }
+    except Exception:
+        return None
+
+
+def _talk_lifecycle_offset_key(log_path: str) -> str:
+    return f"talk_lifecycle::{os.path.abspath(log_path)}"
+
+
+def sync_talk_lifecycle_from_logs(
+    config: dict | None,
+    state: dict,
+    paths: dict | None = None,
+) -> int:
+    """Tail the OpenClaw file logs for Talk/voice lifecycle records and ingest
+    them as talk.lifecycle events. Byte-offset resume per file (mirrors
+    sync_connector_health_from_logs); idempotent ingest. Best-effort — returns
+    the number of signals ingested this cycle, 0 on any failure (the daemon
+    must never crash on telemetry plumbing).
+
+    Gap #2604.
+    """
+    try:
+        # Talk records ride both the gateway logs and the structured
+        # ~/.openclaw/logs/openclaw-*.log file logs, so tail both candidate
+        # sets (same resolution the cloud log-stream already uses).
+        if paths and isinstance(paths, dict) and paths.get("logs_dir"):
+            logs_dir = str(paths["logs_dir"])
+        else:
+            logs_dir = os.path.join(_get_openclaw_dir(), "logs")
+        log_paths = [
+            os.path.join(logs_dir, "gateway.log"),
+            os.path.join(logs_dir, "gateway.err.log"),
+        ]
+        try:
+            log_paths += sorted(
+                glob.glob(os.path.join(logs_dir, "openclaw-*.log"))
+            )[-5:]
+        except Exception:
+            pass
+        try:
+            from clawmetry import local_store as _ls
+            store = _ls.get_store()
+        except Exception as e:
+            log.warning("talk-lifecycle: local_store unavailable: %s", e)
+            return 0
+        node_id = (
+            (config or {}).get("node_id")
+            or os.environ.get("CLAWMETRY_NODE_ID")
+            or "local"
+        )
+        offsets = state.setdefault("last_log_offsets", {})
+        total = 0
+        for log_path in log_paths:
+            if not os.path.exists(log_path):
+                continue
+            key = _talk_lifecycle_offset_key(log_path)
+            prev_offset = int(offsets.get(key, 0) or 0)
+            try:
+                size = os.path.getsize(log_path)
+            except OSError:
+                continue
+            if size < prev_offset:
+                prev_offset = 0  # rotated/truncated — rescan (idempotent)
+            if size == prev_offset:
+                continue
+            try:
+                with open(log_path, "rb") as fh:
+                    fh.seek(prev_offset)
+                    buf = fh.read()
+            except OSError as e:
+                log.warning("talk-lifecycle: read failed (%s): %s", log_path, e)
+                continue
+            text = buf.decode("utf-8", errors="ignore")
+            last_nl = text.rfind("\n")
+            if last_nl < 0:
+                continue
+            complete = text[: last_nl + 1]
+            new_offset = prev_offset + len(complete.encode("utf-8", errors="ignore"))
+            for raw_line in complete.splitlines():
+                rec = parse_talk_lifecycle_line(raw_line)
+                if not rec:
+                    continue
+                try:
+                    store.ingest_talk_lifecycle(
+                        node_id=node_id,
+                        session_id=rec.get("session_id") or "",
+                        event_type=rec["event_type"],
+                        mode=rec.get("mode") or "",
+                        transport=rec.get("transport") or "",
+                        brain=rec.get("brain") or "",
+                        provider=rec.get("provider") or "",
+                        final=rec.get("final"),
+                        duration_ms=rec.get("duration_ms"),
+                        byte_length=rec.get("byte_length"),
+                        ts_iso=rec.get("ts") or "",
+                        raw=raw_line.strip(),
+                    )
+                except Exception as e:
+                    log.debug("talk-lifecycle: ingest failed: %s", e)
+                    continue
+                total += 1
+            offsets[key] = new_offset
+        if total:
+            log.info("talk-lifecycle: ingested %d signal(s)", total)
+        return total
+    except Exception as e:
+        log.warning("talk-lifecycle: cycle failed: %s", e)
         return 0
 
 

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -1,0 +1,151 @@
+"""Unit tests for the openclaw/nemoclaw observability-gap fixes that are pure
+filesystem/parse functions (no DuckDB, so they run anywhere — the store-backed
+ingest paths are exercised by the existing sync/ingest suites).
+
+Covers:
+- #2604 parse_talk_lifecycle_line — talk attrs live in a NESTED positional arg
+  (tslog), not top-level; the parser must find them wherever tslog put them.
+- #2684 _read_nemoclaw_sandbox_routing — per-sandbox model routing must match
+  the harness getSandboxInferenceConfig switch (compatible-anthropic-endpoint
+  with the default api routes to the MANAGED 'inference' provider).
+- #2608 _model_router_fingerprint — parse git:<sha> from the fingerprint file.
+"""
+import json
+import os
+
+import pytest
+
+from clawmetry.sync import parse_talk_lifecycle_line, _read_nemoclaw_sandbox_routing
+from clawmetry.adapters.openclaw import _model_router_fingerprint
+
+
+# -- #2604 talk parser -------------------------------------------------------
+
+def test_talk_parser_reads_nested_positional_attrs():
+    # tslog: o["0"] is the binding prefix, o["1"] is the logged attrs object.
+    rec = json.dumps({
+        "0": {"subsystem": "talk"},
+        "1": {"sessionId": "s1", "talkEventType": "session.start",
+              "talkMode": "voice", "talkTransport": "webrtc",
+              "talkBrain": "gpt-realtime", "talkProvider": "openai",
+              "talkFinal": True, "talkDurationMs": 1200, "talkByteLength": 4096},
+        "_meta": {"name": "{\"subsystem\":\"talk\"}", "date": "2026-06-05T00:00:00Z"},
+        "message": "talk event session.start",
+    })
+    r = parse_talk_lifecycle_line(rec)
+    assert r is not None
+    assert r["event_type"] == "session.start"
+    assert r["session_id"] == "s1"
+    assert r["mode"] == "voice" and r["transport"] == "webrtc"
+    assert r["duration_ms"] == 1200 and r["byte_length"] == 4096
+    assert r["final"] is True
+
+
+def test_talk_parser_handles_json_string_positional():
+    rec = json.dumps({"0": "{\"subsystem\":\"talk\"}",
+                      "1": "{\"sessionId\":\"s2\",\"talkEventType\":\"tool.error\"}"})
+    r = parse_talk_lifecycle_line(rec)
+    assert r and r["session_id"] == "s2" and r["event_type"] == "tool.error"
+
+
+def test_talk_parser_back_compatible_with_top_level():
+    r = parse_talk_lifecycle_line(json.dumps(
+        {"talkEventType": "session.end", "sessionId": "s3", "time": "t"}))
+    assert r and r["session_id"] == "s3" and r["event_type"] == "session.end"
+
+
+def test_talk_parser_rejects_non_talk_and_garbage():
+    assert parse_talk_lifecycle_line(json.dumps({"message": "hi"})) is None
+    assert parse_talk_lifecycle_line(json.dumps({"message": "talkative user"})) is None
+    assert parse_talk_lifecycle_line("not json") is None
+    assert parse_talk_lifecycle_line("") is None
+
+
+# -- #2684 sandbox routing ---------------------------------------------------
+
+@pytest.fixture
+def nemoclaw_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".nemoclaw").mkdir()
+    return tmp_path
+
+
+def _write_sandboxes(home, sandboxes, default=None):
+    payload = {"sandboxes": sandboxes}
+    if default:
+        payload["defaultSandbox"] = default
+    (home / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(payload))
+
+
+def test_sandbox_routing_matches_harness_switch(nemoclaw_home):
+    _write_sandboxes(nemoclaw_home, {
+        "a": {"provider": "openai-api", "model": "gpt-5"},
+        "b": {"provider": "compatible-anthropic-endpoint", "model": "claude-x"},
+        "c": {"provider": "compatible-anthropic-endpoint", "model": "claude-y",
+              "preferredInferenceApi": "anthropic-messages"},
+        "d": {"provider": "anthropic-prod", "model": "claude-z"},
+        "e": {"provider": "some-future-provider", "model": "m"},
+    }, default="a")
+    by = {r["sandbox"]: r for r in _read_nemoclaw_sandbox_routing()}
+    assert by["a"]["providerKey"] == "openai"
+    # compatible-anthropic-endpoint + default api -> MANAGED inference (not anthropic)
+    assert by["b"]["providerKey"] == "inference"
+    # only an explicit non-default api makes it a real anthropic route
+    assert by["c"]["providerKey"] == "anthropic"
+    assert by["d"]["providerKey"] == "anthropic"
+    assert by["e"]["providerKey"] == "inference"  # unknown -> managed default
+    assert by["a"]["isDefault"] is True and by["b"]["isDefault"] is False
+
+
+def test_sandbox_routing_missing_file_returns_empty(nemoclaw_home):
+    assert _read_nemoclaw_sandbox_routing() == []
+
+
+def test_sandbox_routing_malformed_is_skipped(nemoclaw_home):
+    (nemoclaw_home / ".nemoclaw" / "sandboxes.json").write_text("{ not json")
+    assert _read_nemoclaw_sandbox_routing() == []
+
+
+# -- #2608 model-router fingerprint ------------------------------------------
+
+def test_model_router_fingerprint_parses_git_sha(tmp_path, monkeypatch):
+    venv = tmp_path / "mrv"
+    venv.mkdir()
+    (venv / ".nemoclaw-source-fingerprint").write_text(
+        "git:0123456789abcdef0123456789abcdef01234567\n")
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(venv))
+    out = _model_router_fingerprint()
+    assert out["modelRouterFingerprintKind"] == "git"
+    assert out["modelRouterSourceSha"] == "0123456789ab"
+    assert out["modelRouterFingerprint"].startswith("git:")
+
+
+def test_model_router_fingerprint_absent_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(tmp_path / "nope"))
+    assert _model_router_fingerprint() == {}
+
+
+# -- #2682 nemoclaw catalog dispatch span unwrap -----------------------------
+
+def test_catalog_dispatch_span_unwraps_real_tool():
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [{"type": "message", "timestamp": "2026-06-05T00:00:00Z",
+               "message": {"role": "assistant", "content": [
+                   {"type": "tool_use", "id": "t1", "name": "tool_call",
+                    "input": {"name": "Read", "arguments": {"path": "/x"}}},
+                   {"type": "tool_use", "id": "t2", "name": "Bash",
+                    "input": {"command": "ls"}},
+                   {"type": "tool_use", "id": "t3", "name": "tool_search",
+                    "input": {"q": "grep"}},
+               ]}}]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    by = {s["tool_name"]: s for s in spans if s.get("tool_name")}
+    # tool_call -> real dispatched tool (Read), tagged both dispatch + guardrail
+    assert "Read" in by, "tool_call should be unwrapped to its real dispatched tool"
+    assert by["Read"]["attributes"]["nemoclaw.dispatched_tool"] == "Read"
+    assert by["Read"]["attributes"]["nemoclaw.catalog_guardrail"] is True
+    assert by["Read"]["name"] == "tool.Read"
+    # ordinary tool -> no nemoclaw attributes
+    assert by["Bash"]["attributes"] is None
+    # other catalog meta-tools -> guardrail tag only (not a dispatcher)
+    assert by["tool_search"]["attributes"] == {"nemoclaw.catalog_guardrail": True}


### PR DESCRIPTION
## Bug (found on a real self-hosted box, 2026-06-05)

A system-wide install (e.g. `/opt/clawmetry` owned by `root`) run by a **non-root daemon** (`systemctl --user`) cannot write the Pro wheel into the interpreter site-packages. Both the pip path and the pip-less unzip fallback targeted `sysconfig.get_path("purelib")`, so the auto-provisioner failed with:

```
license: clawmetry-pro install failed: unzip install failed:
[Errno 13] Permission denied: '/opt/clawmetry/lib/python3.10/site-packages/clawmetry_pro'
```

Net: the paid runtime adapters (Claude Code, Codex, Cursor, ...) **silently never loaded** even though the account was entitled (Trial/Pro). The only workaround was a manual `sudo chown` of the install dir, which no normal user will discover.

## Fix (general, no sudo/chown needed)

- `_site_packages_target()` reports whether the interpreter site-packages is actually writable by us (`os.access(..., W_OK)`).
- When it is **not** writable, the wheel is extracted into a HOME-owned fallback dir `~/.clawmetry/pro-packages` and that dir is added to `sys.path` so the adapters import. `_pip_install_wheel` short-circuits to this path too (pip would fail on read-only site-packages anyway).
- `ensure_pro_on_path()` adds the fallback dir to `sys.path`; called at daemon startup **before** plugin discovery (`sync.py`) and at the start of `_provision_pro_wheel` (so an already fallback-installed pro is detected as present and the install stays idempotent).

This covers **any** read-only-install layout, not just `/opt`.

## Tests
- New `tests/test_pro_install_fallback.py`: read-only site-packages -> extract into fallback + put on `sys.path`; `_pip_install_wheel` short-circuits (pip never runs); writable site-packages -> normal path; `ensure_pro_on_path` idempotent.
- Updated `test_license.py::test_pip_install_prefers_pip_when_available` to pin site-packages writable (pip is now used only when writable). 30 license tests pass.

## Follow-up
Optionally harden `install.sh` to make a system-wide install dir writable by the daemon user at install time. The provisioner fallback in this PR already makes that unnecessary for correctness.