### PR TITLE
fix(license): install clawmetry-pro into a HOME fallback when site-packages is read-only

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -47,6 +47,16 @@ _DEFAULT_CLOUD_BASE = "https://ingest.clawmetry.com"
 # activate are idempotent (don't re-download an already-current wheel).
 _PRO_MARKER_PATH = os.path.expanduser("~/.clawmetry/pro_installed.json")
 
+# User-writable fallback for the clawmetry-pro install. The provisioner normally
+# extracts the wheel into the interpreter's site-packages, but a SYSTEM-WIDE
+# install (e.g. /opt/clawmetry owned by root) is NOT writable by a non-root
+# daemon (systemd --user). Installing there fails with PermissionError and the
+# paid runtimes silently never load. When site-packages is read-only we install
+# into this HOME-owned dir instead and put it on sys.path. Always writable by the
+# daemon user, no sudo/chown needed. (Founder hit this on a root-owned /opt
+# install with a --user systemd daemon, 2026-06-05.)
+_PRO_FALLBACK_DIR = os.path.expanduser("~/.clawmetry/pro-packages")
+
 # Ed25519 PUBLIC verification key. The matching PRIVATE key lives only on the
 # license server (clawmetry-cloud, never shipped). Rotating the server key
 # means bumping this constant + an OSS release.
@@ -240,24 +250,74 @@ def _pip_run(args: list) -> tuple[bool, str]:
     return False, (tail[-1] if tail else f"pip exited {proc.returncode}")
 
 
-def _unzip_wheel_into_site(wheel_path: str) -> tuple[bool, str]:
-    """pip-less fallback: a wheel is a zip of pure-Python packages, so for a
-    ``--no-deps`` pure-Python wheel (clawmetry-pro) we can simply extract it into
-    this interpreter's site-packages and it becomes importable. This is the path
-    that rescues a daemon venv created WITHOUT pip (``~/.clawmetry/bin/python3``
-    on some installs has no pip / no ensurepip), where ``python -m pip`` fails
-    with ``No module named pip``. Never raises."""
+def _site_packages_target() -> tuple[str, bool]:
+    """Return (interpreter site-packages dir, is_writable_by_us)."""
     try:
         import sysconfig
+        target = sysconfig.get_path("purelib") or sysconfig.get_path("platlib") or ""
+        writable = bool(target) and os.path.isdir(target) and os.access(target, os.W_OK)
+        return target, writable
+    except Exception:
+        return "", False
+
+
+def ensure_pro_on_path() -> None:
+    """Put the user-writable fallback dir on ``sys.path`` if it exists, so a
+    clawmetry-pro installed there (because site-packages was read-only) is
+    importable. Idempotent, never raises. Call this at daemon/dashboard startup
+    BEFORE plugin discovery, and before each provision attempt so an already-
+    fallback-installed pro is detected as present."""
+    try:
+        import sys
+        d = _PRO_FALLBACK_DIR
+        if os.path.isdir(d) and d not in sys.path:
+            sys.path.insert(0, d)
+            try:
+                import importlib
+                importlib.invalidate_caches()
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+def _unzip_wheel_into_site(wheel_path: str) -> tuple[bool, str]:
+    """pip-less fallback: a wheel is a zip of pure-Python packages, so for a
+    ``--no-deps`` pure-Python wheel (clawmetry-pro) we can simply extract it and
+    it becomes importable. Rescues a daemon venv created WITHOUT pip
+    (``~/.clawmetry/bin/python3`` with no pip/ensurepip) AND a read-only
+    interpreter site-packages (root-owned ``/opt`` install run by a non-root
+    --user daemon): when site-packages is not writable we extract into the
+    HOME-owned ``_PRO_FALLBACK_DIR`` and add it to ``sys.path`` so the adapters
+    still load with no sudo/chown. Never raises."""
+    try:
+        import sys
         import zipfile
 
-        target = sysconfig.get_path("purelib") or sysconfig.get_path("platlib")
+        target, writable = _site_packages_target()
+        if not writable:
+            # Interpreter site-packages is read-only (e.g. root-owned /opt
+            # install, non-root daemon). Use the HOME-owned fallback dir.
+            target = _PRO_FALLBACK_DIR
+            try:
+                os.makedirs(target, exist_ok=True)
+            except Exception as _me:
+                return False, f"no writable install target ({target!r}): {_me}"
         if not target or not os.path.isdir(target):
-            return False, f"no writable site-packages ({target!r})"
+            return False, f"no writable install target ({target!r})"
         with zipfile.ZipFile(wheel_path) as zf:
-            # Skip RECORD-only metadata noise; extract packages + dist-info so the
-            # import system (and _pro_installed_version's importlib.metadata) work.
+            # Extract packages + dist-info so the import system (and
+            # _pro_installed_version's importlib.metadata) work.
             zf.extractall(target)
+        if target == _PRO_FALLBACK_DIR:
+            if target not in sys.path:
+                sys.path.insert(0, target)
+            try:
+                import importlib
+                importlib.invalidate_caches()
+            except Exception:
+                pass
+            return True, f"installed (unzip -> fallback {target})"
         return True, "installed (unzip)"
     except Exception as exc:
         return False, f"unzip install failed: {exc}"
@@ -275,6 +335,14 @@ def _pip_install_wheel(wheel_path: str) -> tuple[bool, str]:
     site-packages. Never raises."""
     import subprocess
     import sys
+
+    # If the interpreter's site-packages is READ-ONLY (root-owned /opt install
+    # run by a non-root daemon), pip can't write it either -> go straight to the
+    # HOME-owned fallback unzip. This is the path that makes a system-wide
+    # install work for a --user daemon without sudo/chown.
+    _, _writable = _site_packages_target()
+    if not _writable:
+        return _unzip_wheel_into_site(wheel_path)
 
     args = ["install", "--upgrade", "--no-deps",
             "--disable-pip-version-check", wheel_path]
@@ -312,6 +380,9 @@ def _provision_pro_wheel(download_url: str, *, headers: dict | None = None,
     Returns a human status string. NEVER raises and NEVER blocks the caller —
     on any failure it logs a warning and returns a message; the node keeps
     running on the free runtimes."""
+    # Make a prior fallback-dir install importable before the idempotency check,
+    # so we don't re-download when pro is already present in the HOME fallback.
+    ensure_pro_on_path()
     # Idempotent: if pro is already importable, don't re-download. A version
     # bump still re-installs because the marker is rewritten on every success
     # and the server serves the current wheel.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -12960,6 +12960,15 @@ def run_daemon() -> None:
     # daemon's primary job) cannot be extended by clawmetry-pro. The
     # ``_loaded`` guard makes this safe even if the process somehow imports
     # dashboard later. Never raises.
+    # If clawmetry-pro was installed into the HOME-owned fallback dir (because
+    # the interpreter site-packages is read-only, e.g. a root-owned /opt
+    # install run by a --user daemon), put that dir on sys.path BEFORE plugin
+    # discovery so the paid adapters import on this start.
+    try:
+        from clawmetry.license import ensure_pro_on_path as _ensure_pro_path
+        _ensure_pro_path()
+    except Exception:
+        pass
     try:
         from clawmetry.extensions import load_plugins as _ext_load
         _ext_load()

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -344,8 +344,11 @@ def test_pip_install_falls_back_to_unzip_when_pip_missing(prov, tmp_path, monkey
 
 
 def test_pip_install_prefers_pip_when_available(prov, tmp_path, monkeypatch):
-    """When pip works, we use it and DON'T touch site-packages directly."""
+    """When pip works AND site-packages is writable, we use it and DON'T touch
+    site-packages directly (pip is skipped only when site-packages is read-only,
+    where it would fail anyway -> HOME fallback)."""
     L = prov.L
+    monkeypatch.setattr(L, "_site_packages_target", lambda: ("/writable/site", True))
     monkeypatch.setattr(L, "_pip_run", lambda args: (True, "installed"))
     called = {"unzip": False}
     monkeypatch.setattr(L, "_unzip_wheel_into_site",

--- a/tests/test_pro_install_fallback.py
+++ b/tests/test_pro_install_fallback.py
@@ -1,0 +1,97 @@
+"""Guards the clawmetry-pro install fallback for read-only site-packages.
+
+Burned 2026-06-05: a system-wide install at /opt/clawmetry owned by root, run
+by a non-root --user systemd daemon, could not write the Pro wheel into the
+interpreter site-packages ("[Errno 13] Permission denied") so the paid runtime
+adapters (Claude Code/Codex/...) silently never loaded. The provisioner now
+falls back to a HOME-owned dir and puts it on sys.path.
+
+Invariants:
+  1. When site-packages is NOT writable, the wheel extracts into
+     _PRO_FALLBACK_DIR (not the read-only interpreter dir) and that dir is put
+     on sys.path so the adapters import.
+  2. _pip_install_wheel short-circuits to the fallback when site-packages is
+     read-only (pip would fail there too).
+  3. When site-packages IS writable, the normal path is used (no fallback).
+"""
+import os
+import sys
+import zipfile
+
+import pytest
+
+from clawmetry import license as lic
+
+
+def _make_fake_wheel(path):
+    """A minimal pure-Python wheel: a package + dist-info so importlib.metadata
+    can see it."""
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("clawmetry_pro/__init__.py", "VERSION = '9.9.9'\n")
+        zf.writestr("clawmetry_pro-9.9.9.dist-info/METADATA",
+                    "Metadata-Version: 2.1\nName: clawmetry-pro\nVersion: 9.9.9\n")
+        zf.writestr("clawmetry_pro-9.9.9.dist-info/RECORD", "")
+
+
+def test_unzip_falls_back_when_site_packages_readonly(tmp_path, monkeypatch):
+    fallback = tmp_path / "pro-packages"
+    monkeypatch.setattr(lic, "_PRO_FALLBACK_DIR", str(fallback))
+    # Pretend the interpreter site-packages is read-only.
+    monkeypatch.setattr(lic, "_site_packages_target",
+                        lambda: ("/read/only/site-packages", False))
+    wheel = tmp_path / "clawmetry_pro-9.9.9.whl"
+    _make_fake_wheel(str(wheel))
+
+    ok, detail = lic._unzip_wheel_into_site(str(wheel))
+
+    assert ok, detail
+    # Extracted into the fallback, NOT the read-only site-packages.
+    assert (fallback / "clawmetry_pro" / "__init__.py").exists()
+    assert (fallback / "clawmetry_pro-9.9.9.dist-info").exists()
+    assert str(fallback) in sys.path
+    assert "fallback" in detail
+
+
+def test_pip_install_short_circuits_to_fallback_when_readonly(tmp_path, monkeypatch):
+    fallback = tmp_path / "pro-packages"
+    monkeypatch.setattr(lic, "_PRO_FALLBACK_DIR", str(fallback))
+    monkeypatch.setattr(lic, "_site_packages_target",
+                        lambda: ("/read/only", False))
+
+    # If pip were invoked it would explode; assert it is NOT called.
+    def _boom(*a, **k):
+        raise AssertionError("pip must not run when site-packages is read-only")
+    monkeypatch.setattr(lic, "_pip_run", _boom)
+
+    wheel = tmp_path / "w.whl"
+    _make_fake_wheel(str(wheel))
+    ok, detail = lic._pip_install_wheel(str(wheel))
+    assert ok, detail
+    assert (fallback / "clawmetry_pro" / "__init__.py").exists()
+
+
+def test_writable_site_packages_uses_normal_path(tmp_path, monkeypatch):
+    site = tmp_path / "site-packages"
+    site.mkdir()
+    monkeypatch.setattr(lic, "_site_packages_target", lambda: (str(site), True))
+    wheel = tmp_path / "w.whl"
+    _make_fake_wheel(str(wheel))
+    ok, detail = lic._unzip_wheel_into_site(str(wheel))
+    assert ok, detail
+    # Extracted into the (writable) interpreter site-packages, not the fallback.
+    assert (site / "clawmetry_pro" / "__init__.py").exists()
+    assert "fallback" not in detail
+
+
+def test_ensure_pro_on_path_idempotent(tmp_path, monkeypatch):
+    d = tmp_path / "pro-packages"
+    d.mkdir()
+    monkeypatch.setattr(lic, "_PRO_FALLBACK_DIR", str(d))
+    before = list(sys.path)
+    lic.ensure_pro_on_path()
+    lic.ensure_pro_on_path()
+    assert sys.path.count(str(d)) == 1
+    # cleanup
+    while str(d) in sys.path:
+        sys.path.remove(str(d))
+    monkeypatch.setattr(sys, "path", before, raising=False)


### PR DESCRIPTION
## Bug (found on a real self-hosted box, 2026-06-05)

A system-wide install (e.g. `/opt/clawmetry` owned by `root`) run by a **non-root daemon** (`systemctl --user`) cannot write the Pro wheel into the interpreter site-packages. Both the pip path and the pip-less unzip fallback targeted `sysconfig.get_path("purelib")`, so the auto-provisioner failed with:

```
license: clawmetry-pro install failed: unzip install failed:
[Errno 13] Permission denied: '/opt/clawmetry/lib/python3.10/site-packages/clawmetry_pro'
```

Net: the paid runtime adapters (Claude Code, Codex, Cursor, ...) **silently never loaded** even though the account was entitled. The only workaround was a manual `sudo chown`, which no normal user will discover.

## Fix (general, no sudo/chown needed)

- `_site_packages_target()` reports whether the interpreter site-packages is actually writable by us (`os.access(..., W_OK)`).
- When it is **not** writable, the wheel extracts into a HOME-owned fallback dir `~/.clawmetry/pro-packages` and that dir is added to `sys.path` so the adapters import. `_pip_install_wheel` short-circuits to this path too (pip would fail on read-only site-packages anyway).
- `ensure_pro_on_path()` adds the fallback dir to `sys.path`; called at daemon startup before plugin discovery (`sync.py`) and at the start of `_provision_pro_wheel` (so an already fallback-installed pro is detected and the install stays idempotent).

Covers any read-only-install layout, not just `/opt`.

## Tests
- New `tests/test_pro_install_fallback.py` (read-only -> fallback + on path; pip short-circuit; writable -> normal path; `ensure_pro_on_path` idempotent).
- Updated `test_license.py::test_pip_install_prefers_pip_when_available` to pin site-packages writable. 30 license tests pass.