### PR TITLE
feat(detect): classify detected runtimes by activity (last_active + status + source)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5671,6 +5671,111 @@ _LITE_RT_LABELS = {
     "nanoclaw": "NanoClaw",
 }
 
+# Activity thresholds (seconds) for classifying a detected runtime. Detecting a
+# runtime by its on-disk data dir does NOT mean it is actively in use: a Cursor
+# IDE state.vscdb or an opencode.db can sit untouched for months. Reporting such
+# a runtime as "syncing" alongside a runtime you used five minutes ago is the
+# conflation founders flagged (a 10-month-old Cursor history shown like a live
+# node). We attach last_active + status so the Fleet can render honestly.
+_RT_ACTIVE_SECS = 7 * 86400     # used within a week -> active
+_RT_IDLE_SECS = 30 * 86400      # used within a month -> idle
+
+
+def _runtime_data_paths(rid: str) -> list:
+    """Native on-disk data location(s) for a runtime, used to compute recency.
+    Mirrors the per-adapter stores (the same dirs the lite/pro detectors read).
+    Returns file or dir paths; non-existent ones are ignored by the caller."""
+    home = os.path.expanduser("~")
+    if rid == "cursor":
+        import sys as _sys
+        roots = {
+            "darwin": os.path.join(home, "Library", "Application Support", "Cursor"),
+            "linux": os.path.join(home, ".config", "Cursor"),
+            "win32": os.path.join(home, "AppData", "Roaming", "Cursor"),
+        }
+        base = roots.get(_sys.platform, os.path.join(home, ".config", "Cursor"))
+        return [os.path.join(base, "User", "globalStorage", "state.vscdb")]
+    _M = {
+        "claude_code": [os.path.join(home, ".claude", "projects")],
+        "codex": [os.path.join(home, ".codex", "sessions")],
+        "qwen_code": [os.path.join(home, ".qwen")],
+        "opencode": [os.path.join(home, ".local", "share", "opencode", "opencode.db")],
+        "goose": [os.path.join(home, ".local", "share", "goose")],
+        "hermes": [os.path.join(home, ".hermes", "state.db")],
+        "aider": [os.path.join(home, ".aider")],
+        "picoclaw": [os.path.join(home, ".picoclaw")],
+        "nanoclaw": [os.path.join(home, ".nanoclaw")],
+    }
+    return _M.get(rid, [])
+
+
+def _newest_mtime(paths: list, cap: int = 4000):
+    """Newest mtime (epoch float) across the given files/dirs, or None. Bounded
+    walk (cap files) so a huge ~/.claude/projects tree can't make the heartbeat
+    expensive. Never raises."""
+    newest = 0.0
+    seen = 0
+    for p in (paths or []):
+        try:
+            if os.path.isfile(p):
+                m = os.path.getmtime(p)
+                if m > newest:
+                    newest = m
+            elif os.path.isdir(p):
+                for root, _dirs, files in os.walk(p):
+                    for f in files:
+                        seen += 1
+                        if seen > cap:
+                            return newest or None
+                        try:
+                            m = os.path.getmtime(os.path.join(root, f))
+                            if m > newest:
+                                newest = m
+                        except OSError:
+                            pass
+        except OSError:
+            pass
+    return newest or None
+
+
+def _openclaw_subagent_mtime(rid: str):
+    """Newest mtime of this runtime's sessions when run AS an OpenClaw sub-agent
+    (``~/.openclaw/agents/<alias>/sessions``). Used to classify a runtime whose
+    only activity is via OpenClaw (so we don't present it as a standalone tool).
+    None when there is no such sub-agent data. Never raises."""
+    home = os.path.expanduser("~")
+    aliases = {rid, rid.replace("_code", ""), rid.replace("_", "-"), rid.replace("_", "")}
+    if rid == "claude_code":
+        aliases |= {"claude", "claude-code"}
+    paths = [os.path.join(home, ".openclaw", "agents", a, "sessions") for a in aliases]
+    return _newest_mtime([p for p in paths if os.path.isdir(p)])
+
+
+def _classify_runtime(rid: str) -> dict:
+    """Return {last_active, status, source} for a detected runtime.
+
+    status: 'active' (used <7d), 'idle' (<30d), 'stale' (older), 'unknown'.
+    source: 'standalone' (its own native store has the most recent activity) or
+            'openclaw_subagent' (only/most-recent activity is via OpenClaw).
+    Never raises."""
+    try:
+        native = _newest_mtime(_runtime_data_paths(rid))
+        sub = _openclaw_subagent_mtime(rid)
+        last = max([t for t in (native, sub) if t], default=None)
+        source = "standalone"
+        if sub and (not native or sub >= native):
+            source = "openclaw_subagent"
+        if last:
+            age = time.time() - last
+            status = ("active" if age < _RT_ACTIVE_SECS
+                      else "idle" if age < _RT_IDLE_SECS else "stale")
+        else:
+            status = "unknown"
+        return {"last_active": int(last) if last else None,
+                "status": status, "source": source}
+    except Exception:
+        return {"last_active": None, "status": "unknown", "source": "standalone"}
+
 
 def _detect_runtimes_lite() -> list:
     """FREE, dependency-free detection of which paid runtimes have data on this
@@ -5749,8 +5854,21 @@ def _detect_runtimes_for_heartbeat() -> list:
                 merged[rid] = {"id": rid, "label": label, "sessions": n}
     except Exception:
         pass
-    # Drop 0-session phantoms (directory/config detected but no real data).
-    return [r for r in merged.values() if int(r.get("sessions") or 0) > 0]
+    # Drop 0-session phantoms (directory/config detected but no real data),
+    # then enrich each with activity classification (last_active + status +
+    # source) so the Fleet stops presenting a months-old Cursor history or an
+    # OpenClaw sub-agent as a live standalone runtime. Back-compat: consumers
+    # that don't read the new keys are unaffected.
+    out = []
+    for r in merged.values():
+        if int(r.get("sessions") or 0) <= 0:
+            continue
+        try:
+            r.update(_classify_runtime(r["id"]))
+        except Exception:
+            pass
+        out.append(r)
+    return out
 
 
 def send_heartbeat(config: dict) -> bool:

--- a/tests/test_runtime_activity_status.py
+++ b/tests/test_runtime_activity_status.py
@@ -1,0 +1,85 @@
+"""Guards runtime activity classification (last_active + status + source).
+
+Detecting a runtime by its on-disk data dir does NOT mean it is active: a
+Cursor state.vscdb or opencode.db can sit untouched for months. The Fleet must
+not present a 10-month-old Cursor history as a live "syncing" runtime, nor an
+OpenClaw sub-agent as a standalone tool. `_classify_runtime` attaches:
+  - last_active (epoch) from the runtime's newest data mtime
+  - status: active (<7d) / idle (<30d) / stale (older) / unknown
+  - source: standalone vs openclaw_subagent
+"""
+import os
+import time
+
+import clawmetry.sync as s
+
+
+def _touch(path, age_days):
+    open(path, "w").close()
+    t = time.time() - age_days * 86400
+    os.utime(path, (t, t))
+
+
+def test_recent_native_data_is_active_standalone(tmp_path, monkeypatch):
+    f = tmp_path / "claude.jsonl"
+    _touch(str(f), age_days=1)
+    monkeypatch.setattr(s, "_runtime_data_paths", lambda rid: [str(tmp_path)])
+    monkeypatch.setattr(s, "_openclaw_subagent_mtime", lambda rid: None)
+    c = s._classify_runtime("claude_code")
+    assert c["status"] == "active"
+    assert c["source"] == "standalone"
+    assert c["last_active"] and abs(c["last_active"] - os.path.getmtime(f)) < 2
+
+
+def test_old_cursor_history_is_stale(tmp_path, monkeypatch):
+    db = tmp_path / "state.vscdb"
+    _touch(str(db), age_days=300)  # ~10 months, the real Cursor case
+    monkeypatch.setattr(s, "_runtime_data_paths", lambda rid: [str(db)])
+    monkeypatch.setattr(s, "_openclaw_subagent_mtime", lambda rid: None)
+    c = s._classify_runtime("cursor")
+    assert c["status"] == "stale", c
+
+
+def test_mid_age_is_idle(tmp_path, monkeypatch):
+    f = tmp_path / "opencode.db"
+    _touch(str(f), age_days=14)
+    monkeypatch.setattr(s, "_runtime_data_paths", lambda rid: [str(f)])
+    monkeypatch.setattr(s, "_openclaw_subagent_mtime", lambda rid: None)
+    assert s._classify_runtime("opencode")["status"] == "idle"
+
+
+def test_subagent_only_is_classified_as_openclaw_subagent(tmp_path, monkeypatch):
+    # No native data; activity exists only via OpenClaw sub-agent.
+    monkeypatch.setattr(s, "_runtime_data_paths", lambda rid: [])
+    monkeypatch.setattr(s, "_openclaw_subagent_mtime",
+                        lambda rid: time.time() - 2 * 86400)
+    c = s._classify_runtime("opencode")
+    assert c["source"] == "openclaw_subagent"
+    assert c["status"] == "active"  # 2 days
+
+
+def test_standalone_wins_when_newer_than_subagent(tmp_path, monkeypatch):
+    f = tmp_path / "n.jsonl"
+    _touch(str(f), age_days=1)
+    monkeypatch.setattr(s, "_runtime_data_paths", lambda rid: [str(tmp_path)])
+    monkeypatch.setattr(s, "_openclaw_subagent_mtime",
+                        lambda rid: time.time() - 100 * 86400)
+    assert s._classify_runtime("claude_code")["source"] == "standalone"
+
+
+def test_no_data_is_unknown(monkeypatch):
+    monkeypatch.setattr(s, "_runtime_data_paths", lambda rid: [])
+    monkeypatch.setattr(s, "_openclaw_subagent_mtime", lambda rid: None)
+    c = s._classify_runtime("aider")
+    assert c["status"] == "unknown" and c["last_active"] is None
+
+
+def test_heartbeat_runtimes_carry_status(monkeypatch):
+    # End to end: the heartbeat detector enriches each kept runtime.
+    monkeypatch.setattr(s, "_detect_runtimes_lite",
+                        lambda: [{"id": "cursor", "label": "Cursor", "sessions": 5}])
+    monkeypatch.setattr(s, "_detect_family_runtimes", lambda: [])
+    monkeypatch.setattr(s, "_classify_runtime",
+                        lambda rid: {"last_active": 123, "status": "stale", "source": "standalone"})
+    out = s._detect_runtimes_for_heartbeat()
+    assert out and out[0]["status"] == "stale" and out[0]["last_active"] == 123


### PR DESCRIPTION
## Problem (real box, founder report)

Detecting a runtime by its on-disk data dir does **not** mean it is in active use. A Cursor `state.vscdb` or an `opencode.db` can sit untouched for months, yet the Fleet showed every detected runtime as "syncing" alongside the one you used minutes ago:

| Runtime | Sessions | Last active |
|---|---|---|
| Claude Code | 1450 | recent (real) |
| Codex | 26 | ~6 weeks |
| opencode | 2 | ~7 weeks |
| **Cursor** | 5 | **2025-07-30 (10 months)** |

A 10-month-old Cursor chat history rendered like a live node; an OpenClaw sub-agent looked like a standalone install.

## Change

`_detect_runtimes_for_heartbeat` now enriches each reported runtime with:
- **`last_active`** (epoch): newest mtime of the runtime's native store (`~/.claude/projects`, `~/.codex`, `opencode.db`, Cursor `state.vscdb`, ...). Bounded walk (cap 4000 files) so a huge tree can't slow the heartbeat.
- **`status`**: `active` (used <7d) / `idle` (<30d) / `stale` (older) / `unknown`.
- **`source`**: `standalone` vs `openclaw_subagent` (activity is only/most-recent via `~/.openclaw/agents/<runtime>/sessions`), so the cloud can stop presenting an OpenClaw sub-agent or stale data as a first-class live runtime.

Additive and back-compat: consumers that ignore the new keys are unaffected. **Cloud Fleet rendering of the badge ships in a separate PR** that reads these fields.

## Tests
`tests/test_runtime_activity_status.py` (7 cases): active/idle/stale/unknown, standalone-vs-subagent precedence, newest-mtime picks the recent file, and the heartbeat detector carries the status through.