### PR TITLE
feat(cli): show the linked account email in clawmetry status

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -1575,6 +1575,30 @@ def _status_live() -> None:
         _sys.stdout.flush()
 
 
+def _resolve_account_email(api_key: str):
+    """Best-effort: ask the cloud which ACCOUNT this node's api_key is linked to,
+    so `clawmetry status` can show the email (and plan). This is the fastest way
+    to catch the "my node is on the wrong account" trap. Short timeout + never
+    raises, so status stays fast and works offline (returns (None, None) then)."""
+    try:
+        if not api_key or not str(api_key).startswith("cm_"):
+            return None, None
+        import json as _json
+        import os as _os
+        import urllib.parse as _up
+        import urllib.request as _ur
+
+        base = _os.environ.get("CLAWMETRY_APP_BASE", "https://app.clawmetry.com").rstrip("/")
+        url = base + "/api/cloud/account?token=" + _up.quote(api_key)
+        with _ur.urlopen(url, timeout=2.5) as resp:
+            data = _json.loads(resp.read() or b"{}")
+        email = (data.get("email") or "").strip()
+        plan = (data.get("plan") or "").strip()
+        return (email or None), (plan or None)
+    except Exception:
+        return None, None
+
+
 def _cmd_status(args) -> None:
     """clawmetry status — show local + cloud sync status."""
     if getattr(args, "live", False):
@@ -1598,6 +1622,10 @@ def _cmd_status(args) -> None:
             )
             print("  Cloud sync:  ✅  Connected")
             print(f"  API key:     {masked_api}")
+            _acct_email, _acct_plan = _resolve_account_email(api_key)
+            if _acct_email:
+                _plan_suffix = f"  ({_acct_plan})" if _acct_plan else ""
+                print(f"  Account:     {_acct_email}{_plan_suffix}")
             print(f"  Node ID:     {cfg.get('node_id', '?')}")
             print(f"  Connected:   {cfg.get('connected_at', '?')[:19]}")
             if enc_key:
@@ -1820,6 +1848,10 @@ def _print_nemoclaw_nodes(args) -> None:
             )
             print("  Cloud sync:  ✅  Connected")
             print(f"  API key:     {masked_api}")
+            _acct_email, _acct_plan = _resolve_account_email(api_key)
+            if _acct_email:
+                _plan_suffix = f"  ({_acct_plan})" if _acct_plan else ""
+                print(f"  Account:     {_acct_email}{_plan_suffix}")
             print(f"  Node ID:     {node_id}")
             if enc_key:
                 if getattr(args, "show_key", False):

--- a/tests/test_status_account_email.py
+++ b/tests/test_status_account_email.py
@@ -1,0 +1,61 @@
+"""`clawmetry status` resolves and shows the linked account email.
+
+Fastest way to catch the "my node is on the wrong account" trap: see which
+account the node's api_key is linked to. Best-effort + offline-safe.
+"""
+import json
+
+import clawmetry.cli as cli
+
+
+class _Resp:
+    def __init__(self, body):
+        self._b = body
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_resolves_email_and_plan(monkeypatch):
+    import urllib.request as ur
+    monkeypatch.setattr(ur, "urlopen", lambda url, timeout=0: _Resp(
+        json.dumps({"email": "vivekchand.kd@gmail.com", "plan": "cloud_pro"}).encode()))
+    email, plan = cli._resolve_account_email("cm_abcdef0123456789")
+    assert email == "vivekchand.kd@gmail.com"
+    assert plan == "cloud_pro"
+
+
+def test_non_cm_key_is_skipped_no_network(monkeypatch):
+    import urllib.request as ur
+
+    def _boom(*a, **k):
+        raise AssertionError("must not hit the network for a non-cm_ key")
+    monkeypatch.setattr(ur, "urlopen", _boom)
+    assert cli._resolve_account_email("not-a-key") == (None, None)
+    assert cli._resolve_account_email("") == (None, None)
+
+
+def test_offline_is_graceful(monkeypatch):
+    import urllib.request as ur
+    monkeypatch.setattr(ur, "urlopen",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("offline")))
+    assert cli._resolve_account_email("cm_xyz0123456789") == (None, None)
+
+
+def test_respects_app_base_env(monkeypatch):
+    import urllib.request as ur
+    seen = {}
+
+    def _cap(url, timeout=0):
+        seen["url"] = url
+        return _Resp(b"{}")
+    monkeypatch.setenv("CLAWMETRY_APP_BASE", "https://staging.example.com")
+    monkeypatch.setattr(ur, "urlopen", _cap)
+    cli._resolve_account_email("cm_abc0123456789")
+    assert seen["url"].startswith("https://staging.example.com/api/cloud/account?token=")


### PR DESCRIPTION
## What

`clawmetry status` showed the `api_key` but not **which account** the node is linked to. So a node connected to the wrong account (the two-account trap that bit a founder) was invisible from the box. This adds an **`Account:`** line:

```
  API key:     cm_55d…86ca
  Account:     vivekchand.kd@gmail.com  (cloud_pro)
  Node ID:     agent+vivek-System-Product-Name
```

## How

`_resolve_account_email(api_key)` resolves the email + plan from the cloud via `/api/cloud/account?token=`. Best-effort:
- a non-`cm_` key skips the call (no network),
- a short 2.5s timeout + never-raise keeps `status` fast and **offline-safe** (the line is simply omitted when the lookup fails),
- honours `CLAWMETRY_APP_BASE`.

Wired into both status output paths (config-file + env-based).

## Tests
`tests/test_status_account_email.py` (4 cases): resolves email+plan, non-`cm_` key skips the network, offline is graceful, honours `CLAWMETRY_APP_BASE`.