### PR TITLE
fix(openclaw): populate Event.content from log-record message text (#2700)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -311,6 +311,7 @@ class OpenClawAdapter(AgentAdapter):
                 except (TypeError, ValueError):
                     ts_f = 0.0
                 extra: dict = {}
+                content_text = ""
                 if r[3]:
                     extra["model"] = r[3]
                 # r[6] = agent_id, r[7] = node_id — surface structured log
@@ -336,6 +337,8 @@ class OpenClawAdapter(AgentAdapter):
                                 if _val:
                                     extra[_field] = _val
                             msg = obj.get("message")
+                            if isinstance(msg, str):
+                                content_text = msg
                             src = msg if isinstance(msg, dict) else obj
                             usage = src.get("usage") if isinstance(src.get("usage"), dict) else {}
                             if usage:
@@ -358,6 +361,7 @@ class OpenClawAdapter(AgentAdapter):
                     id=str(r[0]),
                     type=str(r[1] or "event"),
                     ts=ts_f,
+                    content=content_text,
                     tokens=int(r[4] or 0),
                     extra=extra,
                 ))

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -159,3 +159,72 @@ def test_list_events_surfaces_cache_token_split(isolated_store):
     assert ex.get("outputTokens") == 20
     assert ex.get("cacheReadTokens") == 80
     assert ex.get("cacheWriteTokens") == 10
+
+
+def test_list_events_populates_content_from_log_message_text(isolated_store):
+    """Log records with a string ``message`` populate Event.content (#2700).
+
+    OpenClaw gateway log records (per docs/logging.md) put the flattened
+    log text in a top-level string ``message`` field for full-text search.
+    Previously list_events read obj["message"] only to choose a usage
+    source (dict vs. string branch) and discarded the string, so log
+    events came back with empty content. Pin the new behavior so the
+    unified event stream stays searchable.
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-LOG",
+        "event_type": "log",
+        "ts": _t.time(),
+        "data": {
+            "channel": "gateway",
+            "hostname": "Dhriti-1",
+            "level": "info",
+            "message": "tool dispatched: bash exit=0",
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-LOG")
+    assert len(events) == 1
+    e = events[0]
+    assert e.content == "tool dispatched: bash exit=0"
+    # channel/hostname still come through extra.
+    assert e.extra.get("channel") == "gateway"
+    assert e.extra.get("hostname") == "Dhriti-1"
+
+
+def test_list_events_dict_message_does_not_set_content(isolated_store):
+    """Sanity guard: when ``message`` is a dict (assistant turn shape),
+    Event.content stays empty — only string ``message`` values are
+    treated as flattened log text. Keeps the dict branch — which is
+    the usage source — unchanged.
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-DICT",
+        "event_type": "model.completed",
+        "ts": _t.time(),
+        "data": {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-7",
+                "usage": {"input_tokens": 1, "output_tokens": 2},
+            },
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-DICT")
+    assert len(events) == 1
+    assert events[0].content == ""


### PR DESCRIPTION
## Why
Closes #2700 (automated harness-obs audit, severity:medium, capability:LOGS).

OpenClaw gateway log records (per harness docs/logging.md, "File-log JSONL records" section) include a top-level string field **message** containing the flattened log message text, intended for full-text search across the unified event stream.

In **clawmetry/adapters/openclaw.py::OpenClawAdapter.list_events**, the code read obj.get("message") only to decide a usage source (dict branch = assistant-turn shape with message.usage, else fall back to obj itself). When msg was a string (log record format), the string was discarded and **Event.content** was never populated. Result: log events came back through the unified API with empty content, so any full-text search built on the Event shape silently saw nothing for OpenClaw logs.

## Data flow
- Gateway writes JSONL log records with {channel, hostname, level, message: "...flat text...", ...}.
- sync_logs() (added by #2698 / #2680) projects those records into the local DuckDB **events** table with event_type="log" and data={hostname, agent_id, channel, message, level}.
- list_events(session_id) reads each row, JSON-decodes data, currently extracts channel/hostname into extra, picks usage from either message (dict) or obj (string-message branch), and constructs an Event.
- The Event dataclass (clawmetry/adapters/base.py) already has a content field defaulting to empty string, exposed via to_dict() as content. Nothing to add at the contract layer.

## Fix
4-line surgical change in list_events:
1. Initialize content_text per row (alongside the existing extra dict).
2. When obj["message"] is a string, copy it into content_text.
3. Pass content=content_text into the Event constructor.

The dict branch is untouched, so the assistant-turn usage extraction (input_tokens / output_tokens / cache_read_input_tokens / cache_creation_input_tokens) keeps working. The existing test_list_events_surfaces_cache_token_split regression covers that path and still passes.

## Verification
- python3 -m py_compile on the adapter file: clean.
- python3 -m pytest tests/test_openclaw_list_events.py: 8 passed (6 pre-existing + 2 new).
  - test_list_events_populates_content_from_log_message_text: seeds a log record with string message, asserts Event.content matches and extra.channel / extra.hostname still come through.
  - test_list_events_dict_message_does_not_set_content: sanity guard, dict-shaped message (assistant turn) leaves content empty.

## Backwards compat
Event.content already defaulted to the empty string. Callers that previously saw empty content for log events now get the flat log text. No serialized field shape change (to_dict already exposed content). Cloud display path and dashboard.py rich transcript route are untouched.

## Out of scope (deferred)
Sibling obs-gap #2699 (openclaw/cache-token-sdk-fieldnames) lives in the same list_events usage extractor but is a different fix (add cacheRead / cacheWrite keys to the fallback chains). Keeping this PR single-purpose; #2699 will be its own one-line PR next flywheel run.

closes #2700

Generated with Claude Code (https://claude.com/claude-code)
