### PR TITLE
fix(openclaw): accept SDK-normalized cacheRead/cacheWrite usage keys (#2699)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -345,8 +345,8 @@ class OpenClawAdapter(AgentAdapter):
                                 for dst, *keys in [
                                     ("inputTokens", "input_tokens", "inputTokens"),
                                     ("outputTokens", "output_tokens", "outputTokens"),
-                                    ("cacheReadTokens", "cache_read_input_tokens", "cacheReadInputTokens"),
-                                    ("cacheWriteTokens", "cache_creation_input_tokens", "cacheCreationInputTokens"),
+                                    ("cacheReadTokens", "cache_read_input_tokens", "cacheReadInputTokens", "cacheRead"),
+                                    ("cacheWriteTokens", "cache_creation_input_tokens", "cacheCreationInputTokens", "cacheWrite"),
                                 ]:
                                     for k in keys:
                                         v = usage.get(k)

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -228,3 +228,49 @@ def test_list_events_dict_message_does_not_set_content(isolated_store):
     events = OpenClawAdapter().list_events("sess-DICT")
     assert len(events) == 1
     assert events[0].content == ""
+
+
+def test_list_events_surfaces_cache_token_split_sdk_keys(isolated_store):
+    """SDK-normalized cacheRead/cacheWrite usage keys are read by list_events.
+
+    The OpenClaw plugin SDK completeSimple() returns Usage with the
+    normalized keys ``cacheRead`` / ``cacheWrite`` (instead of the raw
+    Anthropic-style ``cache_read_input_tokens`` /
+    ``cache_creation_input_tokens``). Sessions recorded via that SDK
+    path should still surface the per-turn cache split through
+    Event.extra. Regression for #2699.
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-SDK",
+        "event_type": "model.completed",
+        "ts": _t.time(),
+        "model": "claude-opus-4-7",
+        "token_count": 150,
+        "data": {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-7",
+                "usage": {
+                    "input_tokens": 30,
+                    "output_tokens": 20,
+                    "cacheRead": 80,
+                    "cacheWrite": 10,
+                },
+            },
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-SDK")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("inputTokens") == 30
+    assert ex.get("outputTokens") == 20
+    assert ex.get("cacheReadTokens") == 80
+    assert ex.get("cacheWriteTokens") == 10


### PR DESCRIPTION
## Why

OSS observability-audit issue #2699 (severity: medium, capability: COST) flagged that `clawmetry/adapters/openclaw.py::list_events` extracts per-turn cache token counts using only the raw Anthropic-style field names (`cache_read_input_tokens` / `cacheReadInputTokens` for reads, `cache_creation_input_tokens` / `cacheCreationInputTokens` for writes). It never tries the **SDK-normalized** key names `cacheRead` / `cacheWrite` that the OpenClaw plugin SDK's `completeSimple()` Usage object returns.

Result: sessions recorded through the plugin SDK path showed zero cache-read / cache-write token counts in Event.extra, breaking per-turn cache-efficiency display for those sessions.

## Data flow

DuckDB events.data BLOB -> `json.loads` -> `obj["message"]["usage"]` (or `obj["usage"]` if log-shaped) -> per-key fallback walk into `Event.extra` for `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`.

Before this PR the walk was:

```
("cacheReadTokens", "cache_read_input_tokens", "cacheReadInputTokens"),
("cacheWriteTokens", "cache_creation_input_tokens", "cacheCreationInputTokens"),
```

After:

```
("cacheReadTokens", "cache_read_input_tokens", "cacheReadInputTokens", "cacheRead"),
("cacheWriteTokens", "cache_creation_input_tokens", "cacheCreationInputTokens", "cacheWrite"),
```

The SDK-normalized keys are appended as the final fallback so they only kick in when the raw Anthropic-style fields are absent. Behavior for any session that already populated correctly is byte-identical.

## Backwards compatibility

The match loop is order-sensitive: it picks the first non-None value and breaks. Existing producers (which emit `cache_read_input_tokens` etc.) still hit the earlier tuple entries unchanged. Only sessions that previously yielded **no** value for those tokens (because they only had the SDK keys) now get a non-zero number.

No API surface change. No schema change. No new dependency.

## Verification

- Read existing test pattern at `tests/test_openclaw_list_events.py::test_list_events_surfaces_cache_token_split` (snake_case case, already green).
- Added `test_list_events_surfaces_cache_token_split_sdk_keys` mirroring it with `cacheRead: 80` / `cacheWrite: 10` instead. Asserts the same `extra` keys land.
- `python3 -m pytest tests/test_openclaw_list_events.py -x -q` -> 7 passed in 3.99s on Dhriti against this branch.
- `python3 -m py_compile` clean on both touched files.

closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
