### PR TITLE
fix(evals): judge works without httpx (stdlib urllib fallback)

### DIFF
--- a/clawmetry/eval_runner.py
+++ b/clawmetry/eval_runner.py
@@ -607,6 +607,40 @@ class EvalRunner:
 # ── Judge LLM call ─────────────────────────────────────────────────────────────
 
 
+def _judge_http_post_json(url: str, payload: dict, headers: dict, timeout: float) -> dict:
+    """POST JSON to ``url`` and return the parsed response dict.
+
+    Prefers ``httpx`` when installed (so ``clawmetry/interceptor.py`` cost
+    tracking picks up eval spend), but FALLS BACK to the stdlib ``urllib`` when
+    httpx is absent. httpx is NOT a clawmetry dependency (deps stay minimal:
+    flask + waitress + cryptography), so on the daemon's own venv the judge used
+    to die with ``No module named 'httpx'`` and no session ever got scored.
+    Raises on HTTP / network / JSON error; the caller catches and degrades."""
+    try:
+        import httpx  # noqa: F401
+        _have_httpx = True
+    except Exception:
+        _have_httpx = False
+    if _have_httpx:
+        import httpx
+        with httpx.Client(timeout=timeout) as client:
+            r = client.post(url, json=payload, headers=headers)
+            r.raise_for_status()
+            return r.json()
+    # stdlib fallback (always available). urlopen raises HTTPError on 4xx/5xx,
+    # mirroring httpx's raise_for_status so the caller's error handling is uniform.
+    import json as _json
+    import urllib.request as _ur
+
+    body = _json.dumps(payload).encode("utf-8")
+    req = _ur.Request(
+        url, data=body, method="POST",
+        headers={**(headers or {}), "Content-Type": "application/json"},
+    )
+    with _ur.urlopen(req, timeout=timeout) as resp:
+        return _json.loads(resp.read() or b"{}")
+
+
 def _call_judge(model: str, prompt: str, *, timeout: float = 30.0) -> str:
     """Call the Anthropic Messages API with the user's existing API key.
 
@@ -623,8 +657,6 @@ def _call_judge(model: str, prompt: str, *, timeout: float = 30.0) -> str:
     Anything else falls back to Anthropic — Phase 1 is Haiku-by-default,
     so the long tail of providers can wait for Phase 2.
     """
-    import httpx
-
     model_lower = model.lower()
     if model_lower.startswith(("gpt-", "o1-", "o3-", "o4-")):
         api_key = os.environ.get("OPENAI_API_KEY", "")
@@ -641,10 +673,7 @@ def _call_judge(model: str, prompt: str, *, timeout: float = 30.0) -> str:
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }
-        with httpx.Client(timeout=timeout) as client:
-            r = client.post(url, json=payload, headers=headers)
-            r.raise_for_status()
-            data = r.json()
+        data = _judge_http_post_json(url, payload, headers, timeout)
         choices = data.get("choices") or []
         if not choices:
             return ""
@@ -665,10 +694,7 @@ def _call_judge(model: str, prompt: str, *, timeout: float = 30.0) -> str:
         "anthropic-version": "2023-06-01",
         "Content-Type": "application/json",
     }
-    with httpx.Client(timeout=timeout) as client:
-        r = client.post(url, json=payload, headers=headers)
-        r.raise_for_status()
-        data = r.json()
+    data = _judge_http_post_json(url, payload, headers, timeout)
     blocks = data.get("content") or []
     parts: list[str] = []
     for blk in blocks:

--- a/tests/test_eval_judge_httpx_fallback.py
+++ b/tests/test_eval_judge_httpx_fallback.py
@@ -1,0 +1,68 @@
+"""The evals judge must work without httpx (a non-dependency).
+
+Burned 2026-06-06: `_call_judge` hard-imported `httpx` to route through the
+cost interceptor, but httpx is NOT a clawmetry dependency, so on the daemon's
+own venv every judge call died with "No module named 'httpx'" and no session
+was ever scored. The judge now prefers httpx (cost tracking) and falls back to
+stdlib urllib.
+"""
+import json
+import sys
+
+import clawmetry.eval_runner as er
+
+
+class _Resp:
+    def __init__(self, body):
+        self._b = body
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_post_json_urllib_fallback_when_httpx_absent(monkeypatch):
+    # Simulate httpx not installed: `import httpx` raises ImportError.
+    monkeypatch.setitem(sys.modules, "httpx", None)
+    import urllib.request as ur
+    captured = {}
+
+    def _fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["data"] = req.data
+        return _Resp(json.dumps({"content": [{"text": "ok"}]}).encode())
+
+    monkeypatch.setattr(ur, "urlopen", _fake_urlopen)
+    out = er._judge_http_post_json("https://api.anthropic.com/v1/messages",
+                                   {"model": "claude-haiku-4-5"}, {"x-api-key": "k"}, 5.0)
+    assert out == {"content": [{"text": "ok"}]}
+    assert captured["url"].startswith("https://api.anthropic.com")
+    assert b"claude-haiku" in captured["data"]  # payload was JSON-encoded
+
+
+def test_call_judge_anthropic_parses_text(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setattr(er, "_judge_http_post_json",
+                        lambda url, payload, headers, timeout: {"content": [{"text": "Score: 8"}]})
+    assert er._call_judge("claude-haiku-4-5", "rate this") == "Score: 8"
+
+
+def test_call_judge_openai_parses_text(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(er, "_judge_http_post_json",
+                        lambda url, payload, headers, timeout: {"choices": [{"message": {"content": "Score: 7"}}]})
+    assert er._call_judge("gpt-4o-mini", "rate this") == "Score: 7"
+
+
+def test_call_judge_missing_key_raises(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    try:
+        er._call_judge("claude-haiku-4-5", "x")
+        assert False, "expected RuntimeError for missing key"
+    except RuntimeError as e:
+        assert "ANTHROPIC_API_KEY" in str(e)


### PR DESCRIPTION
## Bug (founder's sync.log)

```
evals: judge call failed for claude_code:1162e0b6-…: No module named 'httpx'
evals: judge call failed for claude_code:3e7d29d7-…: No module named 'httpx'
```

`eval_runner._call_judge` hard-imported `httpx` to route the judge LLM call through `clawmetry/interceptor.py` for cost tracking. But **httpx is not a clawmetry dependency** (deps stay minimal: flask + waitress + cryptography), so on the daemon's own venv every judge call died with `No module named 'httpx'` and **no session was ever scored**.

## Fix

New `_judge_http_post_json(url, payload, headers, timeout)`:
- **prefers `httpx`** when installed (keeps interceptor cost tracking for eval spend),
- **falls back to stdlib `urllib`** when it isn't, so the judge works on a minimal install.

Both provider branches (Anthropic + OpenAI) route through it. `urlopen` raises `HTTPError` on 4xx/5xx, mirroring httpx's `raise_for_status`, so the caller's error handling is uniform.

## Tests
`tests/test_eval_judge_httpx_fallback.py` (4 cases): urllib fallback when httpx is absent, Anthropic + OpenAI parse paths, missing-key raises.