### PR TITLE
fix(evals): skip quietly when no judge API key is configured

### DIFF
--- a/clawmetry/eval_runner.py
+++ b/clawmetry/eval_runner.py
@@ -513,6 +513,31 @@ class EvalRunner:
         judge_model = str(rubric.get("judge_model") or DEFAULT_RUBRIC["judge_model"])
         scored_at = int(time.time() * 1000)
 
+        # Judge-key guard. Evals are default-on, but the judge calls a real LLM
+        # (Anthropic/OpenAI) that needs an API key in the env. With no key,
+        # return a quiet SKIP (not a per-session WARNING) so we (a) never spam
+        # sync.log every scheduler tick when the feature simply isn't configured,
+        # and (b) never spend silently. The user opts in implicitly by setting
+        # ANTHROPIC_API_KEY / OPENAI_API_KEY. Logged once per process.
+        if not _judge_key_present(judge_model):
+            global _NO_KEY_LOGGED
+            if not _NO_KEY_LOGGED:
+                log.info(
+                    "evals: no judge API key in env (set ANTHROPIC_API_KEY or "
+                    "OPENAI_API_KEY to enable session scoring) — skipping until then"
+                )
+                _NO_KEY_LOGGED = True
+            return EvalResult(
+                session_id=session_id,
+                score=None,
+                reason=None,
+                judge_model=judge_model,
+                rubric_name=self.rubric_name,
+                scored_at=scored_at,
+                skipped=True,
+                skip_reason="no judge API key configured",
+            )
+
         transcript, total_tokens = self._collect_transcript(session_id)
 
         # Trivial-session guard. The threshold is intentionally low —
@@ -605,6 +630,21 @@ class EvalRunner:
 
 
 # ── Judge LLM call ─────────────────────────────────────────────────────────────
+
+
+# Logged once per process when evals are on but no judge key is configured, so
+# we don't repeat the notice on every scheduler tick.
+_NO_KEY_LOGGED = False
+
+
+def _judge_key_present(model: str) -> bool:
+    """True if the API key for this judge model's provider is set in the env.
+    Mirrors the provider routing in ``_call_judge`` (gpt/o* -> OpenAI, else
+    Anthropic)."""
+    m = (model or "").lower()
+    if m.startswith(("gpt-", "o1-", "o3-", "o4-")):
+        return bool(os.environ.get("OPENAI_API_KEY", "").strip())
+    return bool(os.environ.get("ANTHROPIC_API_KEY", "").strip())
 
 
 def _judge_http_post_json(url: str, payload: dict, headers: dict, timeout: float) -> dict:

--- a/tests/test_eval_skip_without_key.py
+++ b/tests/test_eval_skip_without_key.py
@@ -1,0 +1,52 @@
+"""Evals must skip QUIETLY when no judge API key is configured.
+
+Evals are default-on, but the judge calls a real LLM (Anthropic/OpenAI) that
+needs an API key. With no key the scheduler used to attempt every session and
+log a WARNING each ("judge call failed ... ANTHROPIC_API_KEY not set"), spamming
+sync.log and implying the feature is broken. Now it returns a quiet SKIP and
+never invokes the judge, so nothing spams and nothing spends.
+"""
+import clawmetry.eval_runner as er
+
+
+def test_score_session_skips_when_no_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(er, "_NO_KEY_LOGGED", False, raising=False)
+
+    called = {"judge": False}
+
+    def _spy(model, prompt, *, timeout=0):
+        called["judge"] = True
+        return "Score: 9"
+
+    runner = er.EvalRunner()
+    result = runner.score_session("sess-1", judge_call=_spy)
+
+    assert result is not None
+    assert result.skipped is True
+    assert "no judge API key" in (result.skip_reason or "")
+    assert called["judge"] is False, "judge must NOT be called without a key"
+
+
+def test_score_session_proceeds_with_key(monkeypatch):
+    # With a key, the no-key guard must NOT short-circuit (it should get far
+    # enough to attempt transcript collection / judging). We assert it does
+    # NOT return the no-key skip reason.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setattr(er, "_NO_KEY_LOGGED", False, raising=False)
+    # Empty store -> no transcript -> a DIFFERENT skip, never the no-key one.
+    runner = er.EvalRunner(store=_EmptyStore())
+    result = runner.score_session("sess-2", judge_call=lambda *a, **k: "Score: 5")
+    assert result is None or "no judge API key" not in (result.skip_reason or "")
+
+
+class _EmptyStore:
+    """Minimal store stub: returns no events so transcript collection yields
+    nothing (a non-key skip path)."""
+
+    def query_events(self, *a, **k):
+        return []
+
+    def execute(self, *a, **k):
+        return []


### PR DESCRIPTION
## Why

Follow-up to #2715 (which fixed the `No module named 'httpx'` crash). Evals are **default-on**, and the judge calls a real LLM (Anthropic/OpenAI) needing an API key. With no key the scheduler attempted every session and logged a WARNING **each tick**:

```
evals: judge call failed for claude_code:… : ANTHROPIC_API_KEY not set
```

That spams `sync.log` and reads as "broken" — and on a box that *does* have a key in the daemon env, evals would **spend silently** without the user opting in.

## Fix

`score_session` now checks `_judge_key_present(judge_model)` up front (mirrors the provider routing: `gpt`/`o*` -> `OPENAI_API_KEY`, else `ANTHROPIC_API_KEY`). With no key it returns a **quiet SKIP** (`skipped=True`, `skip_reason="no judge API key configured"`), never invokes the judge, and logs the notice **once per process**.

Net: evals become **implicit opt-in** — they run (and spend) only when the user has set an LLM key. No key = no spam, no spend.

## Tests
`tests/test_eval_skip_without_key.py`: no key -> skip + judge not called; with key -> does not take the no-key skip path.