### PR TITLE
feat(entitlement): add Entitlement.allows_node_count() — third corner of the gating triad

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -269,6 +269,46 @@ class Entitlement:
             return False
         return feature in self.features
 
+    def allows_node_count(self, current: int) -> bool:
+        """Whether ``current`` registered nodes still fit under this
+        entitlement's node cap. Completes the gating triad alongside
+        :meth:`allows_runtime` and :meth:`allows_feature` so fleet code can
+        check node-limit overflow with the same never-crash contract.
+
+        Semantics — chosen to match the existing helpers:
+
+        * Grace mode (default) — always ``True``. Wiring this into a fleet
+          path therefore changes no behaviour before the enforce phase.
+        * ``current <= 0`` — always ``True``. A node count that hasn't been
+          measured yet (zero/negative) should never be the thing that blocks
+          a request.
+        * Expired entitlement — collapses to a single node (the OSS-free
+          default), mirroring how :meth:`allows_runtime` falls back to free
+          runtimes on expiry.
+        * ``node_limit <= 0`` — treated as unlimited. The license payload
+          uses ``0`` (or omits ``nodes``) for Enterprise/unlimited grants;
+          honoring that keeps the wire format unchanged.
+        * Otherwise — ``current <= node_limit``.
+
+        Non-int ``current`` (e.g. a stray ``None`` from a fleet table read)
+        is swallowed and returns ``True`` so a flaky read never blocks a
+        request — same posture as :func:`_gate.gate` on a flaky entitlement
+        resolution.
+        """
+        if self.grace:
+            return True
+        try:
+            n = int(current)
+        except (TypeError, ValueError):
+            return True
+        if n <= 0:
+            return True
+        if self.expired:
+            return n <= 1
+        if self.node_limit is None or int(self.node_limit) <= 0:
+            return True
+        return n <= int(self.node_limit)
+
     def event_retention_days(self) -> int | None:
         """Days of event history this tier may keep. ``None`` means unlimited
         / custom (Enterprise). The daemon's prune loop in ``clawmetry/sync.py``

--- a/tests/test_entitlement_node_count.py
+++ b/tests/test_entitlement_node_count.py
@@ -1,0 +1,163 @@
+"""Tests for :meth:`Entitlement.allows_node_count` — the third corner of the
+open-core gating triad (alongside :meth:`allows_runtime` /
+:meth:`allows_feature`).
+
+Pins the grace/enforce posture, the expiry collapse, the unlimited sentinel
+for Enterprise grants, and the defensive never-crash behaviour on bad input.
+Companion to ``tests/test_entitlements.py`` (general grace mechanics) and
+``tests/test_entitlements_catalogue.py`` (per-tier buckets).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ``~/.clawmetry/license.key`` or ``cloud_plan.json`` leaks in.
+    Enforcement off by default — matches the project rollout posture."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── grace mode: pure pass-through ────────────────────────────────────────────
+
+
+def test_grace_allows_any_node_count(ent):
+    """Grace mode (default) mirrors ``allows_runtime`` / ``allows_feature``:
+    nothing is ever blocked, regardless of node_limit. This is the headline
+    invariant the rollout depends on — wiring this helper into fleet routes
+    must not change current behaviour before the enforce phase."""
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    for count in (0, 1, 2, 5, 100, 10_000):
+        assert en.allows_node_count(count) is True, count
+
+
+def test_grace_allows_count_above_explicit_node_limit(ent):
+    """Even when an Entitlement is constructed with a low node_limit, grace
+    mode short-circuits and allows the request."""
+    en = ent._build(ent.TIER_OSS, "oss", node_limit=1)
+    assert en.grace is True
+    assert en.allows_node_count(50) is True
+
+
+# ── enforce mode: limits actually apply ──────────────────────────────────────
+
+
+def test_enforce_oss_caps_at_one_node(ent, monkeypatch):
+    """OSS free in enforce mode is a single-node grant — extra registered
+    nodes fail the check."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.grace is False
+    assert en.node_limit == 1
+    assert en.allows_node_count(1) is True
+    assert en.allows_node_count(2) is False
+    assert en.allows_node_count(99) is False
+
+
+def test_enforce_cloud_pro_respects_payload_node_limit(ent, monkeypatch, tmp_path):
+    """A cloud_pro plan with ``node_limit=10`` allows up to 10 and blocks 11."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro", "node_limit": 10}))
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_CLOUD_PRO
+    assert en.node_limit == 10
+    assert en.allows_node_count(1) is True
+    assert en.allows_node_count(10) is True
+    assert en.allows_node_count(11) is False
+
+
+def test_enforce_enterprise_unlimited_when_node_limit_is_zero(ent, monkeypatch):
+    """An Enterprise grant with ``node_limit=0`` is the unlimited sentinel —
+    keeps the wire format unchanged (license payloads use ``nodes=0`` /
+    omit ``nodes`` for unlimited). Negative values are treated the same way
+    as a defensive measure."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent._build(ent.TIER_ENTERPRISE, "license", node_limit=0)
+    assert en.grace is False
+    assert en.allows_node_count(1) is True
+    assert en.allows_node_count(10_000) is True
+    en_neg = ent._build(ent.TIER_ENTERPRISE, "license", node_limit=-1)
+    assert en_neg.allows_node_count(99) is True
+
+
+# ── expiry: collapse to single node ──────────────────────────────────────────
+
+
+def test_enforce_expired_paid_plan_collapses_to_single_node(ent, monkeypatch, tmp_path):
+    """An expired paid plan should behave like OSS-free for node-count checks
+    too — same posture as :meth:`allows_runtime`, which drops back to
+    free-runtimes-only on expiry."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({
+        "plan": "cloud_pro",
+        "node_limit": 25,
+        "expiry": time.time() - 60,
+    }))
+    en = ent.get_entitlement(force=True)
+    assert en.expired is True
+    assert en.allows_node_count(1) is True
+    assert en.allows_node_count(2) is False
+
+
+# ── edge cases ───────────────────────────────────────────────────────────────
+
+
+def test_enforce_zero_and_negative_current_always_allowed(ent, monkeypatch):
+    """``current=0`` (no nodes registered yet) and stray negative values
+    should never be the thing that blocks a request — this matches the
+    never-crash posture of the rest of the entitlements module."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_node_count(0) is True
+    assert en.allows_node_count(-1) is True
+    assert en.allows_node_count(-100) is True
+
+
+def test_enforce_non_int_current_is_swallowed(ent, monkeypatch):
+    """A non-int ``current`` (e.g. a stray ``None`` / string from a fleet
+    table read) must not crash the check — falls through to allowed so a
+    flaky read never blocks a request path."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_node_count(None) is True
+    assert en.allows_node_count("not-a-number") is True
+    assert en.allows_node_count(object()) is True
+
+
+def test_enforce_string_int_current_is_accepted(ent, monkeypatch):
+    """A numeric string (``"3"``) coerces cleanly. Defensive convenience —
+    a fleet count read from a query string parameter is already a str."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_node_count("1") is True
+    assert en.allows_node_count("2") is False  # OSS caps at 1
+
+
+# ── triad consistency: matches allows_runtime / allows_feature posture ──────
+
+
+def test_grace_triad_is_symmetric(ent):
+    """In grace mode every gate corner returns True for any input — the
+    rollout invariant the dashboard / fleet / runtime ingest all depend on."""
+    en = ent.get_entitlement(force=True)
+    assert en.allows_runtime("claude_code") is True
+    assert en.allows_feature("self_evolve") is True
+    assert en.allows_node_count(999) is True


### PR DESCRIPTION
## Summary

Completes the open-core gating triad. `clawmetry/entitlements.py` already exposes:

- `Entitlement.allows_runtime(runtime)` — runtime axis
- `Entitlement.allows_feature(feature)` — feature axis

…but the **node-count axis** has been a dead field: `node_limit` lands on every `Entitlement` (license payload's `nodes`, `cloud_plan.json`'s `node_limit`), serializes through `to_dict()` / `/api/entitlement`, and is plumbed by the daemon's plan-cache writer/loader — but nothing ever *checks* it.

This PR adds `Entitlement.allows_node_count(current: int) -> bool` so fleet code can call the same never-crash helper pattern, and adds 10 tests that pin every branch. **No call sites are migrated** in this PR — pure helper addition; a future fleet PR can wire it in (e.g. into `routes/fleet_history.py::api_nodes_register`) without touching the helper's contract again.

## Semantics

Chosen to mirror the existing helpers — the rollout invariant ("grace = no behavior change") is the load-bearing one:

| Condition | Result |
|-----------|--------|
| Grace mode (`CLAWMETRY_ENFORCE` unset / != 1) | `True` |
| `current <= 0` | `True` (a not-yet-measured count should never be the blocker) |
| Expired entitlement | collapses to ≤ 1 node (matches `allows_runtime`'s OSS-free fallback on expiry) |
| `node_limit <= 0` | `True` — unlimited sentinel for Enterprise grants. License payloads use `0` / omit `nodes` for unlimited; honoring keeps the wire format unchanged. |
| Otherwise | `current <= node_limit` |

Non-`int` `current` (stray `None` / object from a fleet table read) is swallowed and returns `True` — same defensive posture as `_gate.gate` on a flaky entitlement resolution.

## Changes

- `clawmetry/entitlements.py` — `Entitlement.allows_node_count()` method (40 lines incl. docstring).
- `tests/test_entitlement_node_count.py` — 10 tests pinning grace pass-through, enforce OSS cap=1, cloud_pro respects payload, Enterprise unlimited via 0 / negative sentinel, expired collapse, zero/negative `current` allowed, non-`int` swallowed, numeric-string coercion, and triad symmetry with `allows_runtime` / `allows_feature`.

## Why this isn't in #2426 / #2692 / #2697

- #2426 (`feature_catalog` + `/api/features`) and #2692 (`tier_catalog` + `/api/tiers`) extend the **catalog** surface — they read the same `Entitlement` but don't add new gate methods.
- #2697 (`gate_runtime()` decorator) extends the **decorator** surface around `allows_runtime`. The runtime axis already had a `allows_runtime()` method; this PR adds the *missing* method on the node axis. They compose without conflict.
- #2674 (`required_tier` in 402 body) is decorator-internal; no overlap with the data-model helpers here.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py tests/test_entitlement_node_count.py` clean.
- [x] `python3 -m pytest tests/test_entitlement_node_count.py -v` → 10 passed.
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_entitlement_node_count.py -q` → 51 passed (no regressions in the upstream catalogue / API tests).
- [x] `ruff check clawmetry/entitlements.py tests/test_entitlement_node_count.py` → All checks passed.
- [ ] No call site migration in this PR (the helper is unused on the wire) — fleet wiring is a follow-up.

## Local operator verification checklist

This agent has no access to your machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please:

- [ ] `git fetch origin feat/entitlement-allows-node-count && git checkout feat/entitlement-allows-node-count`.
- [ ] Copy `clawmetry/entitlements.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/entitlements.py` (and the new test under `tests/`).
- [ ] Clear `__pycache__` under the install path: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon.
- [ ] Hit `/api/entitlement` and confirm the existing shape is unchanged (this PR adds a method, not a JSON field).
- [ ] Decrypt the live cloud snapshot and confirm no behavioural drift in grace mode.
- [ ] Browser-check the dashboard — no UI surface consumes `allows_node_count` yet (fleet wiring is a follow-up); every paid-runtime UI surface should render exactly as before.
- [ ] Optionally `CLAWMETRY_ENFORCE=1 python3 -c "from clawmetry.entitlements import get_entitlement; e=get_entitlement(force=True); print(e.allows_node_count(1), e.allows_node_count(2))"` → expect `True False` (OSS caps at 1).

This PR is **DRAFT** — leave it for the operator to mark ready / merge / cut the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ad4wz32BfJve37pM9WwgX1)_