### PR TITLE
fix: implement OSS asset registry routes (replaces 402 stub)

### DIFF
--- a/routes/assets.py
+++ b/routes/assets.py
@@ -1,52 +1,150 @@
-"""routes/assets.py: OSS stub after the impl moved to clawmetry-pro.
+"""routes/assets.py — OSS asset registry API.
 
-The real asset-registry impl (list, get, upsert, review) ships in the
-closed-source ``clawmetry-pro`` package as
-``clawmetry_pro/routes/assets.py``. When that package is installed its
-blueprint registers via the ``clawmetry.extensions`` entry point at app
-startup and wins the URL routes. When clawmetry-pro is NOT installed
-this stub returns HTTP 402 ``upgrade_required`` at every URL the impl
-used to serve.
-
-dashboard.py decides which blueprint to register by inspecting
-``clawmetry_pro.is_loaded()`` so the two never coexist on the URL map.
+Basic CRUD + review workflow over the ``assets`` DuckDB table.
+All storage-layer plumbing (table, LocalStore methods, daemon-proxy
+allowlist) lives in the OSS ``local_store.py`` / ``local_query.py``.
+These routes expose that plumbing to dashboard users when
+``clawmetry-pro`` is NOT installed; when Pro is installed its own
+blueprint registers via the ``clawmetry.extensions`` entry point and
+``dashboard.py`` skips registering this one.
 """
 from __future__ import annotations
 
 import logging
+import uuid
 
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 logger = logging.getLogger("clawmetry.routes.assets")
 
 bp_assets = Blueprint("assets", __name__)
 
+_ASSET_TYPES = frozenset({
+    "skill", "prompt", "workflow", "playbook",
+    "memory_snippet", "tool_config", "evaluation_case",
+})
 
-_UPGRADE = {
-    "error": "upgrade_required",
-    "feature": "asset_registry",
-    "hint": (
-        "Asset registry is a Pro feature. Install ``clawmetry-pro`` with a "
-        "valid license key, or use Cloud Pro at clawmetry.com/pricing."
-    ),
-}
+# Maps the user-facing review action to the DuckDB status string.
+_REVIEW_ACTION_TO_STATUS = {"approve": "approved", "reject": "rejected"}
+
+# Methods that must open the store read-only in the direct fallback path.
+_READ_METHODS = frozenset({"query_assets", "get_asset"})
+
+
+def _try_store_call(method_name: str, **kwargs):
+    """Route a LocalStore call through the daemon proxy first.
+
+    Falls back to a direct DuckDB open for single-process boots (dev
+    mode, tests). Matches the pattern in routes/hitl.py._try_store_call.
+    Returns the method's return value, or None when both paths fail.
+    """
+    try:
+        from routes.local_query import local_store_via_daemon
+        result = local_store_via_daemon(method_name, **kwargs)
+        if result is not None:
+            return result
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=method_name in _READ_METHODS)
+        return getattr(store, method_name)(**kwargs)
+    except Exception:
+        return None
 
 
 @bp_assets.route("/api/assets", methods=["GET"])
-def _list_stub():
-    return jsonify(_UPGRADE), 402
+def list_assets():
+    """List assets newest-first.
+
+    Query params: status, asset_type, source_session_id, limit (1–500).
+    """
+    status = (request.args.get("status") or "").strip() or None
+    asset_type = (request.args.get("asset_type") or "").strip() or None
+    source_session_id = (
+        request.args.get("source_session_id") or ""
+    ).strip() or None
+    try:
+        limit = max(1, min(500, int(request.args.get("limit", 100))))
+    except (ValueError, TypeError):
+        limit = 100
+
+    assets = _try_store_call(
+        "query_assets",
+        status=status,
+        asset_type=asset_type,
+        source_session_id=source_session_id,
+        limit=limit,
+    )
+    assets = assets or []
+    return jsonify({"assets": assets, "count": len(assets)})
 
 
 @bp_assets.route("/api/assets/<asset_id>", methods=["GET"])
-def _get_stub(asset_id: str):
-    return jsonify(_UPGRADE), 402
+def get_asset(asset_id: str):
+    """Return one asset by id, or 404."""
+    asset = _try_store_call("get_asset", asset_id=asset_id)
+    if asset is None:
+        return jsonify({"error": "not_found"}), 404
+    return jsonify(asset)
 
 
 @bp_assets.route("/api/assets", methods=["POST"])
-def _create_stub():
-    return jsonify(_UPGRADE), 402
+def create_asset():
+    """Create or upsert an asset.
+
+    Required body fields: ``asset_type`` (one of the canonical types),
+    ``name`` (non-empty string). All other fields are optional.
+    """
+    body = request.get_json(silent=True) or {}
+    asset_type = (body.get("asset_type") or "").strip()
+    if asset_type not in _ASSET_TYPES:
+        return jsonify(
+            {"error": f"asset_type must be one of {sorted(_ASSET_TYPES)}"}
+        ), 400
+    name = (body.get("name") or "").strip()
+    if not name:
+        return jsonify({"error": "name is required"}), 400
+
+    asset = {
+        "id": (body.get("id") or "").strip() or str(uuid.uuid4()),
+        "asset_type": asset_type,
+        "name": name,
+        "description": body.get("description") or "",
+        "source_session_id": body.get("source_session_id") or "",
+        "source_run_id": body.get("source_run_id") or "",
+        "author": body.get("author") or "",
+        "tags": body.get("tags"),
+        "content": body.get("content"),
+        "status": body.get("status") or "pending",
+    }
+    _try_store_call("ingest_asset", asset=asset)
+    return jsonify({"ok": True, "id": asset["id"], "status": asset["status"]}), 201
 
 
 @bp_assets.route("/api/assets/<asset_id>/review", methods=["POST"])
-def _review_stub(asset_id: str):
-    return jsonify(_UPGRADE), 402
+def review_asset(asset_id: str):
+    """Approve or reject an asset.
+
+    Body: ``{"action": "approve"|"reject", "reviewer"?: str, "reason"?: str}``.
+    Returns 404 when the asset does not exist.
+    """
+    body = request.get_json(silent=True) or {}
+    action = (body.get("action") or "").strip().lower()
+    if action not in _REVIEW_ACTION_TO_STATUS:
+        return jsonify(
+            {"error": "action must be 'approve' or 'reject'"}
+        ), 400
+
+    new_status = _REVIEW_ACTION_TO_STATUS[action]
+    updated = _try_store_call(
+        "update_asset_status",
+        asset_id=asset_id,
+        status=new_status,
+        reviewer=body.get("reviewer") or "",
+        reason=body.get("reason") or "",
+    )
+    # update_asset_status returns False when the asset_id does not exist.
+    if updated is False:
+        return jsonify({"error": "not_found"}), 404
+    return jsonify({"ok": True, "asset_id": asset_id, "status": new_status})


### PR DESCRIPTION
Closes #2201

## Summary

- All storage-layer plumbing for the asset registry was already OSS: the `assets` DuckDB table (in `local_store.py`), four LocalStore methods (`query_assets`, `get_asset`, `ingest_asset`, `update_asset_status`), their daemon-proxy allowlist entries, and the `dashboard.py` blueprint registration.
- The only missing piece was `routes/assets.py` — a 53-line Pro upgrade stub returning HTTP 402 for every request.
- This PR replaces that stub with ~110 lines of real route handlers using the established `_try_store_call` daemon-proxy pattern from `routes/hitl.py`.

**Endpoints now live in OSS:**
- `GET /api/assets?status=&asset_type=&source_session_id=&limit=` — list assets newest-first
- `GET /api/assets/<id>` — get one asset (404 if not found)
- `POST /api/assets` — create/upsert (requires `asset_type` + `name`)
- `POST /api/assets/<id>/review` — approve or reject (`{"action": "approve"|"reject", "reviewer"?, "reason"?}`)

No other files changed. No schema migration needed (table already exists).

## Test plan

- `POST /api/assets` with `{"asset_type": "skill", "name": "test-skill"}` → 201 with `status: "pending"`
- `GET /api/assets` → returns the created asset
- `GET /api/assets/<id>` → returns asset detail; unknown id → 404
- `POST /api/assets/<id>/review` with `{"action": "approve"}` → `status: "approved"`
- `POST /api/assets/<id>/review` with `{"action": "reject", "reason": "not ready"}` → `status: "rejected"`
- `GET /api/assets?status=approved` → only approved assets returned
- `POST /api/assets` with invalid `asset_type` → 400 with error message

https://claude.ai/code/session_01KJG2mHxMvqEPFERLFDg2zM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJG2mHxMvqEPFERLFDg2zM)_