### PR TITLE
feat(evals): redact secrets + PII from the transcript before the judge LLM

### DIFF
--- a/clawmetry/eval_runner.py
+++ b/clawmetry/eval_runner.py
@@ -432,6 +432,13 @@ class EvalRunner:
     def _build_prompt(self, rubric: dict[str, Any], transcript: str) -> str:
         """Compose the final judge prompt: rubric instructions + transcript."""
         instructions = str(rubric.get("prompt") or DEFAULT_RUBRIC["prompt"])
+        # PRIVACY: the transcript is about to leave the machine for a THIRD-PARTY
+        # judge LLM (Anthropic/OpenAI). Everything else in ClawMetry is E2E
+        # encrypted so even our own cloud cannot read it; the judge is the one
+        # place raw session text goes out. Redact secrets + PII first. Done
+        # BEFORE the length cap so a secret near the truncation boundary is still
+        # scrubbed.
+        transcript = _redact_for_judge(transcript)
         # Cap transcript length so a 100K-token session doesn't run the
         # judge bill into the ground. The first/last ~4K chars carry the
         # signal we need (intent + outcome) without the toolchain noise.
@@ -635,6 +642,35 @@ class EvalRunner:
 # Logged once per process when evals are on but no judge key is configured, so
 # we don't repeat the notice on every scheduler tick.
 _NO_KEY_LOGGED = False
+
+# Email PII pattern, redacted before the transcript goes to the third-party
+# judge LLM (the secret redactor in clawmetry/redaction.py handles keys/tokens).
+_JUDGE_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
+
+
+def _redact_for_judge(text: str) -> str:
+    """Scrub secrets + PII from a transcript before it leaves the machine for
+    the third-party judge LLM. Reuses the ingest secret redactor (API keys,
+    tokens, Bearer, private keys) and adds email PII. Respects the global
+    CLAWMETRY_REDACT opt-out (so a user who explicitly disables redaction owns
+    that). Never raises; never returns None."""
+    if not text:
+        return text
+    try:
+        from clawmetry import redaction as _redaction
+        if _redaction._disabled():
+            return text
+        text = _redaction.redact_text(text)
+        text = _JUDGE_EMAIL_RE.sub("[REDACTED:email]", text)
+    except Exception:
+        # Never lose the transcript on a redaction bug, but also never send raw
+        # if we cannot confirm redaction ran: on import/other failure, drop a
+        # conservative best-effort email scrub at minimum.
+        try:
+            text = _JUDGE_EMAIL_RE.sub("[REDACTED:email]", text)
+        except Exception:
+            pass
+    return text
 
 
 def _judge_key_present(model: str) -> bool:

--- a/tests/test_eval_redact_before_judge.py
+++ b/tests/test_eval_redact_before_judge.py
@@ -1,0 +1,46 @@
+"""The eval transcript must be redacted before it goes to the judge LLM.
+
+The judge is the ONE place raw session text leaves the machine (everything else
+is E2E encrypted). Secrets (API keys/tokens) and PII (emails) must be scrubbed
+first, reusing the ingest secret redactor + an email pass.
+"""
+import clawmetry.eval_runner as er
+
+
+SECRET_BLOB = (
+    "User alice@example.com asked to deploy.\n"
+    "export ANTHROPIC_API_KEY=sk-ant-api03-ABCDEF1234567890abcdefXYZ\n"
+    "Authorization: Bearer ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\n"
+    "second contact bob.smith@corp.io\n"
+)
+
+
+def test_redact_for_judge_scrubs_secrets_and_emails(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_REDACT", raising=False)
+    out = er._redact_for_judge(SECRET_BLOB)
+    assert "alice@example.com" not in out
+    assert "bob.smith@corp.io" not in out
+    assert "sk-ant-api03-ABCDEF1234567890abcdefXYZ" not in out
+    assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" not in out
+    assert "[REDACTED:email]" in out
+
+
+def test_build_prompt_redacts_transcript(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_REDACT", raising=False)
+    runner = er.EvalRunner()
+    prompt = runner._build_prompt({"prompt": "Rate this."}, SECRET_BLOB)
+    # The composed judge prompt (what actually gets sent) carries no raw secrets.
+    assert "alice@example.com" not in prompt
+    assert "sk-ant-api03-ABCDEF1234567890abcdefXYZ" not in prompt
+    assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" not in prompt
+    assert "TRANSCRIPT:" in prompt  # structure preserved
+
+
+def test_opt_out_keeps_raw(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_REDACT", "0")
+    assert er._redact_for_judge("contact me at a@b.com") == "contact me at a@b.com"
+
+
+def test_empty_is_safe():
+    assert er._redact_for_judge("") == ""
+    assert er._redact_for_judge(None) is None


### PR DESCRIPTION
## Why (founder)

> "we should do pii redact before eval? as it goes to llm??"

Correct, and it was a real gap. The eval judge is the **one place raw session text leaves the machine** for a third party (Anthropic/OpenAI) — everything else in ClawMetry is E2E encrypted so even our own cloud can't read it. The transcript was sent **unredacted**, so a session containing API keys, tokens, or emails leaked them to the judge provider.

## Fix

`_build_prompt` now scrubs the transcript via `_redact_for_judge` **before** it is sent (and before the length cap, so a secret near the truncation boundary is still caught):
- reuses the existing ingest secret redactor (`clawmetry/redaction.py` — API keys, tokens, `Bearer`, private keys, our own `cm_` keys), and
- adds an **email PII** pass (`[REDACTED:email]`).

Respects the global `CLAWMETRY_REDACT` opt-out. Never raises (on any failure it still applies at least the email scrub, never sends raw on a redaction bug).

## Tests
`tests/test_eval_redact_before_judge.py`: secrets + emails scrubbed; the composed `_build_prompt` output carries no raw secrets; opt-out keeps raw; empty/None safe.

## Note
This covers the eval path specifically (the third-party egress). The ingest/storage path already runs `redact_text` for secrets; extending *ingest* to also redact emails is a separate, larger call (emails are used for channel attribution) and not included here.