### PR TITLE
feat(evals): set the judge API key from the dashboard (UI + local key store)

### DIFF
--- a/clawmetry/eval_runner.py
+++ b/clawmetry/eval_runner.py
@@ -673,14 +673,83 @@ def _redact_for_judge(text: str) -> str:
     return text
 
 
-def _judge_key_present(model: str) -> bool:
-    """True if the API key for this judge model's provider is set in the env.
-    Mirrors the provider routing in ``_call_judge`` (gpt/o* -> OpenAI, else
-    Anthropic)."""
+# Local judge-key store, so the dashboard can enable evals by saving a key (no
+# need to set an env var + restart the daemon). Lives ONLY on disk (chmod 600),
+# never in the cloud snapshot — it's a real LLM API key. Read fresh per call so
+# a key saved from the UI takes effect on the next scheduler tick without a
+# daemon restart.
+_EVAL_KEYS_PATH = os.path.expanduser("~/.clawmetry/eval_keys.json")
+_JUDGE_PROVIDERS = ("anthropic", "openai")
+
+
+def _provider_for_model(model: str) -> str:
     m = (model or "").lower()
-    if m.startswith(("gpt-", "o1-", "o3-", "o4-")):
-        return bool(os.environ.get("OPENAI_API_KEY", "").strip())
-    return bool(os.environ.get("ANTHROPIC_API_KEY", "").strip())
+    return "openai" if m.startswith(("gpt-", "o1-", "o3-", "o4-")) else "anthropic"
+
+
+def _stored_judge_key(provider: str) -> str:
+    """Read the UI-saved key for ``provider`` from the local key store. Never
+    raises; returns '' when absent."""
+    try:
+        import json as _json
+        with open(_EVAL_KEYS_PATH, encoding="utf-8") as fh:
+            data = _json.load(fh)
+        return str((data or {}).get(provider, "") or "").strip()
+    except Exception:
+        return ""
+
+
+def _judge_api_key(model: str) -> str:
+    """The API key to use for this judge model: env var first (operator intent
+    / CI), then the UI-saved local key. Empty string when neither is set."""
+    provider = _provider_for_model(model)
+    env_name = "OPENAI_API_KEY" if provider == "openai" else "ANTHROPIC_API_KEY"
+    return os.environ.get(env_name, "").strip() or _stored_judge_key(provider)
+
+
+def save_judge_key(provider: str, api_key: str) -> None:
+    """Persist a judge API key locally (chmod 600). Used by the dashboard so a
+    user can enable evals without setting an env var. ``api_key=""`` clears it."""
+    import json as _json
+    provider = (provider or "").strip().lower()
+    if provider not in _JUDGE_PROVIDERS:
+        raise ValueError(f"unknown provider {provider!r} (expected one of {_JUDGE_PROVIDERS})")
+    os.makedirs(os.path.dirname(_EVAL_KEYS_PATH), exist_ok=True)
+    data = {}
+    try:
+        with open(_EVAL_KEYS_PATH, encoding="utf-8") as fh:
+            data = _json.load(fh) or {}
+    except Exception:
+        data = {}
+    key = (api_key or "").strip()
+    if key:
+        data[provider] = key
+    else:
+        data.pop(provider, None)
+    # Write 0600 so the key is not world-readable.
+    fd = os.open(_EVAL_KEYS_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        _json.dump(data, fh)
+    try:
+        os.chmod(_EVAL_KEYS_PATH, 0o600)
+    except Exception:
+        pass
+
+
+def judge_keys_present() -> dict:
+    """Presence map for the UI — NEVER returns the key values themselves. Each
+    provider is True if a key is available via env OR the local store."""
+    out = {}
+    for prov in _JUDGE_PROVIDERS:
+        env_name = "OPENAI_API_KEY" if prov == "openai" else "ANTHROPIC_API_KEY"
+        out[prov] = bool(os.environ.get(env_name, "").strip() or _stored_judge_key(prov))
+    return out
+
+
+def _judge_key_present(model: str) -> bool:
+    """True if an API key for this judge model's provider is available (env or
+    the UI-saved local store)."""
+    return bool(_judge_api_key(model))
 
 
 def _judge_http_post_json(url: str, payload: dict, headers: dict, timeout: float) -> dict:
@@ -735,7 +804,7 @@ def _call_judge(model: str, prompt: str, *, timeout: float = 30.0) -> str:
     """
     model_lower = model.lower()
     if model_lower.startswith(("gpt-", "o1-", "o3-", "o4-")):
-        api_key = os.environ.get("OPENAI_API_KEY", "")
+        api_key = _judge_api_key(model)  # env var, else UI-saved local key
         if not api_key:
             raise RuntimeError("OPENAI_API_KEY not set")
         url = "https://api.openai.com/v1/chat/completions"
@@ -756,7 +825,7 @@ def _call_judge(model: str, prompt: str, *, timeout: float = 30.0) -> str:
         return choices[0].get("message", {}).get("content", "") or ""
 
     # Default: Anthropic (Claude Haiku/Sonnet/Opus).
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    api_key = _judge_api_key(model)  # env var, else UI-saved local key
     if not api_key:
         raise RuntimeError("ANTHROPIC_API_KEY not set")
     url = "https://api.anthropic.com/v1/messages"

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3308,6 +3308,7 @@ async function openEvalRubricModal() {
   var pathEl = document.getElementById('eval-rubric-path');
   if (!modal || !ta) return;
   modal.style.display = 'flex';
+  loadEvalKeyStatus();
   if (status) status.textContent = t("app.loading", null, "Loading...");
   try {
     var data = await fetch('/api/evals/rubric').then(function(r){return r.json();});
@@ -3320,6 +3321,57 @@ async function openEvalRubricModal() {
     }
   } catch (e) {
     if (status) status.textContent = t("app.failed_to_load_2", null, "Failed to load: ") + e.message;
+  }
+}
+
+// Judge API key: presence-only status (never the value) so the user knows
+// whether scoring can run, and can paste a key to enable it without an env var.
+async function loadEvalKeyStatus() {
+  var el = document.getElementById('eval-key-status');
+  var sel = document.getElementById('eval-key-provider');
+  if (!el) return;
+  try {
+    var d = await fetch('/api/evals/key').then(function(r){return r.json();}).catch(function(){return null;});
+    var present = (d && d.present) || {};
+    var prov = sel ? sel.value : 'anthropic';
+    if (present[prov]) {
+      el.textContent = '✓ key set';
+      el.style.color = '#22c55e';
+    } else if (d && d.any) {
+      el.textContent = 'set for another provider';
+      el.style.color = 'var(--text-muted)';
+    } else {
+      el.textContent = 'not set — scoring paused';
+      el.style.color = '#f59e0b';
+    }
+  } catch (e) {
+    el.textContent = '';
+  }
+}
+
+// Save the judge API key (or clear it with an empty value). POSTs to
+// /api/evals/key, which stores it locally chmod 600; never echoed back.
+async function saveEvalKey() {
+  var sel = document.getElementById('eval-key-provider');
+  var inp = document.getElementById('eval-key-input');
+  var el = document.getElementById('eval-key-status');
+  if (!sel || !inp) return;
+  if (el) { el.textContent = t("app.saving", null, "Saving..."); el.style.color = 'var(--text-muted)'; }
+  try {
+    var resp = await fetch('/api/evals/key', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({provider: sel.value, api_key: inp.value || ''})
+    }).then(function(r){return r.json();});
+    if (resp && resp.ok) {
+      inp.value = '';  // never keep the secret in the DOM after save
+      loadEvalKeyStatus();
+    } else if (el) {
+      el.textContent = (resp && resp.error) || 'Save failed';
+      el.style.color = '#ef4444';
+    }
+  } catch (e) {
+    if (el) { el.textContent = 'Save failed: ' + e.message; el.style.color = '#ef4444'; }
   }
 }
 

--- a/clawmetry/templates/partials/overlays.html
+++ b/clawmetry/templates/partials/overlays.html
@@ -1,3 +1,37 @@
+<!-- Eval rubric + judge-key modal (opened from the Overview eval card). The
+     judge calls a third-party LLM, so the user provides their own API key here;
+     it is stored locally chmod 600 and never synced to the cloud. -->
+<div id="eval-rubric-modal" style="display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.6);z-index:1000;align-items:center;justify-content:center;">
+  <div style="background:var(--bg-primary);border:1px solid var(--border-primary);border-radius:12px;padding:20px;max-width:640px;width:90%;max-height:80vh;display:flex;flex-direction:column;gap:12px;overflow-y:auto;">
+    <div style="display:flex;justify-content:space-between;align-items:center;">
+      <h3 style="margin:0;font-size:14px;font-weight:700;color:var(--text-primary);">Evals (LLM judge)</h3>
+      <button onclick="closeEvalRubricModal()" style="background:transparent;border:none;color:var(--text-muted);font-size:18px;cursor:pointer;">&times;</button>
+    </div>
+    <div style="border:1px solid var(--border-primary);border-radius:8px;padding:12px;display:flex;flex-direction:column;gap:8px;background:var(--bg-secondary);">
+      <div style="display:flex;justify-content:space-between;align-items:center;">
+        <div style="font-size:12px;font-weight:700;color:var(--text-primary);">Judge API key</div>
+        <span id="eval-key-status" style="font-size:11px;color:var(--text-muted);"></span>
+      </div>
+      <div style="font-size:11px;color:var(--text-muted);line-height:1.5;">Scoring sends a <strong>redacted</strong> transcript to a judge LLM, which needs your own API key. Stored locally only (chmod 600), never synced to the cloud. Leave blank and Save to clear.</div>
+      <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+        <select id="eval-key-provider" onchange="loadEvalKeyStatus()" style="font-size:12px;padding:6px 8px;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:6px;">
+          <option value="anthropic">Anthropic (claude-*)</option>
+          <option value="openai">OpenAI (gpt-*/o*)</option>
+        </select>
+        <input id="eval-key-input" type="password" autocomplete="off" placeholder="sk-ant-... / sk-..." style="flex:1;min-width:200px;font-family:monospace;font-size:12px;padding:6px 10px;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:6px;">
+        <button onclick="saveEvalKey()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;font-weight:600;cursor:pointer;">Save key</button>
+      </div>
+    </div>
+    <div style="font-size:11px;color:var(--text-muted);">Edit the YAML rubric used by the judge. Saved to <code id="eval-rubric-path">~/.clawmetry/evals.yaml</code>. Disable scoring entirely with <code>CLAWMETRY_EVALS_ENABLED=0</code>.</div>
+    <textarea id="eval-rubric-yaml" style="font-family:monospace;font-size:12px;width:100%;min-height:220px;padding:10px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:8px;resize:vertical;" spellcheck="false"></textarea>
+    <div id="eval-rubric-status" style="font-size:11px;color:var(--text-muted);min-height:14px;"></div>
+    <div style="display:flex;justify-content:flex-end;gap:8px;">
+      <button onclick="closeEvalRubricModal()" style="background:transparent;color:var(--text-muted);border:1px solid var(--border-primary);border-radius:6px;padding:6px 12px;font-size:12px;cursor:pointer;">Cancel</button>
+      <button onclick="saveEvalRubric()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;font-weight:600;cursor:pointer;">Save rubric</button>
+    </div>
+  </div>
+</div>
+
 <!-- Login overlay -->
 <div id="login-overlay" style="
   display:none;

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -25,6 +25,21 @@
     </div>
   </div>
 
+  <!-- Eval quality (LLM-as-judge). Score tile + a button to set the judge API
+       key / rubric. The judge needs your own LLM key; scoring is paused until
+       one is set (transcripts are redacted before they go to the judge). -->
+  <div id="eval-card" style="background:var(--bg-secondary);border:2px solid var(--border-primary);border-radius:12px;padding:18px 22px;margin-bottom:14px;box-shadow:var(--card-shadow);display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap;">
+    <div>
+      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:6px;">✅ <span data-i18n="overview.eval_quality">Session quality (LLM judge)</span></div>
+      <div style="display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;">
+        <span id="eval-avg-score" style="font-size:26px;font-weight:800;line-height:1.1;color:var(--text-muted);">--</span>
+        <span id="eval-coverage" style="font-size:12px;color:var(--text-muted);"></span>
+      </div>
+      <div id="eval-regression-line" style="font-size:12px;color:var(--text-muted);margin-top:6px;"></div>
+    </div>
+    <button onclick="openEvalRubricModal()" title="Set the judge API key and edit the scoring rubric" style="background:var(--button-bg);color:var(--text-secondary);border:1px solid var(--border-primary);border-radius:8px;padding:8px 14px;font-size:12px;font-weight:600;cursor:pointer;white-space:nowrap;">&#9881; <span data-i18n="overview.eval_setup">Judge key &amp; rubric</span></button>
+  </div>
+
   <!-- Per-runtime sparkline of recent runs (#2196 item #4). Severity: red=real
        error, yellow=waste flag, green=clean. Empty when no runtime has data. -->
   <div id="health-timeline-card" style="display:none;background:var(--bg-secondary);border:2px solid var(--border-primary);border-radius:12px;padding:14px 22px;margin-bottom:14px;box-shadow:var(--card-shadow);">

--- a/dashboard.py
+++ b/dashboard.py
@@ -4690,6 +4690,21 @@ function clawmetryLogout(){
         <button onclick="closeEvalRubricModal()" style="background:transparent;border:none;color:var(--text-muted);font-size:18px;cursor:pointer;">&times;</button>
       </div>
       <div style="font-size:11px;color:var(--text-muted);">Edit the YAML rubric used by the local LLM judge. Saved to <code id="eval-rubric-path">~/.clawmetry/evals.yaml</code>. Disable scoring entirely with <code>CLAWMETRY_EVALS_ENABLED=0</code>.</div>
+      <div style="border:1px solid var(--border-primary);border-radius:8px;padding:12px;display:flex;flex-direction:column;gap:8px;background:var(--bg-secondary);">
+        <div style="display:flex;justify-content:space-between;align-items:center;">
+          <div style="font-size:12px;font-weight:700;color:var(--text-primary);">Judge API key</div>
+          <span id="eval-key-status" style="font-size:11px;color:var(--text-muted);"></span>
+        </div>
+        <div style="font-size:11px;color:var(--text-muted);line-height:1.5;">Scoring sends a redacted transcript to a judge LLM, which needs your own API key. Stored locally only (chmod 600), never synced to the cloud. Leave blank and Save to clear.</div>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+          <select id="eval-key-provider" onchange="loadEvalKeyStatus()" style="font-size:12px;padding:6px 8px;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:6px;">
+            <option value="anthropic">Anthropic (claude-*)</option>
+            <option value="openai">OpenAI (gpt-*/o*)</option>
+          </select>
+          <input id="eval-key-input" type="password" autocomplete="off" placeholder="sk-ant-... / sk-..." style="flex:1;min-width:200px;font-family:monospace;font-size:12px;padding:6px 10px;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:6px;">
+          <button onclick="saveEvalKey()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;font-weight:600;cursor:pointer;">Save key</button>
+        </div>
+      </div>
       <textarea id="eval-rubric-yaml" style="font-family:monospace;font-size:12px;width:100%;min-height:280px;padding:10px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:8px;resize:vertical;" spellcheck="false"></textarea>
       <div id="eval-rubric-status" style="font-size:11px;color:var(--text-muted);min-height:14px;"></div>
       <div style="display:flex;justify-content:flex-end;gap:8px;">

--- a/dashboard.py
+++ b/dashboard.py
@@ -4690,21 +4690,6 @@ function clawmetryLogout(){
         <button onclick="closeEvalRubricModal()" style="background:transparent;border:none;color:var(--text-muted);font-size:18px;cursor:pointer;">&times;</button>
       </div>
       <div style="font-size:11px;color:var(--text-muted);">Edit the YAML rubric used by the local LLM judge. Saved to <code id="eval-rubric-path">~/.clawmetry/evals.yaml</code>. Disable scoring entirely with <code>CLAWMETRY_EVALS_ENABLED=0</code>.</div>
-      <div style="border:1px solid var(--border-primary);border-radius:8px;padding:12px;display:flex;flex-direction:column;gap:8px;background:var(--bg-secondary);">
-        <div style="display:flex;justify-content:space-between;align-items:center;">
-          <div style="font-size:12px;font-weight:700;color:var(--text-primary);">Judge API key</div>
-          <span id="eval-key-status" style="font-size:11px;color:var(--text-muted);"></span>
-        </div>
-        <div style="font-size:11px;color:var(--text-muted);line-height:1.5;">Scoring sends a redacted transcript to a judge LLM, which needs your own API key. Stored locally only (chmod 600), never synced to the cloud. Leave blank and Save to clear.</div>
-        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
-          <select id="eval-key-provider" onchange="loadEvalKeyStatus()" style="font-size:12px;padding:6px 8px;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:6px;">
-            <option value="anthropic">Anthropic (claude-*)</option>
-            <option value="openai">OpenAI (gpt-*/o*)</option>
-          </select>
-          <input id="eval-key-input" type="password" autocomplete="off" placeholder="sk-ant-... / sk-..." style="flex:1;min-width:200px;font-family:monospace;font-size:12px;padding:6px 10px;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:6px;">
-          <button onclick="saveEvalKey()" style="background:var(--bg-accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:12px;font-weight:600;cursor:pointer;">Save key</button>
-        </div>
-      </div>
       <textarea id="eval-rubric-yaml" style="font-family:monospace;font-size:12px;width:100%;min-height:280px;padding:10px;background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border-primary);border-radius:8px;resize:vertical;" spellcheck="false"></textarea>
       <div id="eval-rubric-status" style="font-size:11px;color:var(--text-muted);min-height:14px;"></div>
       <div style="display:flex;justify-content:flex-end;gap:8px;">

--- a/routes/evals.py
+++ b/routes/evals.py
@@ -166,6 +166,45 @@ def evals_regression_summary():
     return jsonify(payload)
 
 
+@bp_evals.route("/api/evals/key", methods=["GET"])
+def evals_key_get():
+    """Presence-only: which judge providers have a key (env or UI-saved).
+    NEVER returns the key value itself."""
+    try:
+        from clawmetry import eval_runner
+    except Exception as e:
+        return jsonify({"error": f"eval runner unavailable: {e}"}), 503
+    try:
+        present = eval_runner.judge_keys_present()
+    except Exception:
+        present = {"anthropic": False, "openai": False}
+    return jsonify({"present": present, "any": any(present.values())})
+
+
+@bp_evals.route("/api/evals/key", methods=["POST"])
+def evals_key_save():
+    """Save (or clear) a judge API key locally so evals can run without an env
+    var. Body: ``{"provider": "anthropic"|"openai", "api_key": "<key>"}``. An
+    empty ``api_key`` clears it. The key is stored chmod 600 on disk only and is
+    never echoed back or synced to the cloud."""
+    try:
+        from clawmetry import eval_runner
+    except Exception as e:
+        return jsonify({"error": f"eval runner unavailable: {e}"}), 503
+    body = request.get_json(silent=True) or {}
+    provider = str(body.get("provider", "")).strip().lower()
+    api_key = body.get("api_key", "")
+    if provider not in ("anthropic", "openai"):
+        return jsonify({"error": "provider must be 'anthropic' or 'openai'"}), 400
+    if not isinstance(api_key, str):
+        return jsonify({"error": "api_key must be a string"}), 400
+    try:
+        eval_runner.save_judge_key(provider, api_key)
+    except Exception as e:
+        return jsonify({"error": f"save failed: {e}"}), 400
+    return jsonify({"ok": True, "present": eval_runner.judge_keys_present()})
+
+
 @bp_evals.route("/api/evals/rubric", methods=["POST"])
 def evals_rubric_save():
     """Replace the rubric YAML. Validates parse before writing.

--- a/tests/test_eval_judge_key_store.py
+++ b/tests/test_eval_judge_key_store.py
@@ -1,0 +1,59 @@
+"""Judge API key can be set from the dashboard (local store), enabling evals
+without an env var. The key lives chmod 600 on disk only, never echoed/synced.
+"""
+import os
+import stat
+
+import clawmetry.eval_runner as er
+
+
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(er, "_EVAL_KEYS_PATH", str(tmp_path / "eval_keys.json"))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
+def test_save_present_resolve_and_clear(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    assert er.judge_keys_present() == {"anthropic": False, "openai": False}
+
+    er.save_judge_key("anthropic", "sk-ant-secret123")
+    assert er.judge_keys_present()["anthropic"] is True
+    assert er._judge_api_key("claude-haiku-4-5") == "sk-ant-secret123"
+    assert er._judge_key_present("claude-haiku-4-5") is True
+    # gpt model has no key yet
+    assert er._judge_key_present("gpt-4o-mini") is False
+
+    er.save_judge_key("anthropic", "")  # clear
+    assert er.judge_keys_present()["anthropic"] is False
+
+
+def test_key_file_is_chmod_600(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    er.save_judge_key("openai", "sk-openai-xyz")
+    mode = stat.S_IMODE(os.stat(er._EVAL_KEYS_PATH).st_mode)
+    assert mode == 0o600, oct(mode)
+
+
+def test_env_takes_precedence_over_stored(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    er.save_judge_key("anthropic", "sk-ant-stored")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fromenv")
+    assert er._judge_api_key("claude-haiku-4-5") == "sk-ant-fromenv"
+
+
+def test_unknown_provider_rejected(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    try:
+        er.save_judge_key("googlegemini", "x")
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_presence_never_leaks_value(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    er.save_judge_key("anthropic", "sk-ant-topsecret")
+    present = er.judge_keys_present()
+    assert "sk-ant-topsecret" not in str(present)
+    assert present == {"anthropic": True, "openai": False}


### PR DESCRIPTION
## Why (founder)

> "is there a ui for evals? if so we should ask for api key there itself"

Yes — there's an eval score tile + a rubric editor modal. But evals are default-on and need an LLM API key to actually score (the judge calls Anthropic/OpenAI), and the only way to provide it was a daemon env var most users won't set — so the feature just sat paused (and spammed before the earlier no-key-skip fix). Now you can enable it right from the dashboard.

## What

The eval rubric modal gains a **"Judge API key"** section: pick provider (Anthropic / OpenAI), paste the key, **Save**. Status shows `✓ key set` / `not set — scoring paused` — **presence only, never the value**.

### Backend
- `eval_runner`: local key store at `~/.clawmetry/eval_keys.json` (**chmod 600**, never synced to cloud). `_judge_api_key(model)` resolves the **env var first**, then the UI-saved key; read **fresh per call** so a saved key takes effect on the next scheduler tick with no daemon restart. `_call_judge` + `_judge_key_present` use it.
- `routes/evals.py`: `GET /api/evals/key` (presence map) + `POST /api/evals/key {provider, api_key}` (empty clears).

### Frontend
`dashboard.py` modal section + `app.js` (`loadEvalKeyStatus()` on open, `saveEvalKey()` that clears the input after save so the secret never lingers in the DOM).

## Security
Key is stored locally chmod 600, never returned by the API, never put in the cloud snapshot. Combined with the prior PR (#2725) that redacts transcripts before the judge, the whole eval egress path is now privacy-safe.

## Tests
`tests/test_eval_judge_key_store.py` (5): save/present/resolve/clear, chmod 600, env precedence, unknown-provider rejected, presence never leaks the value.