### PR TITLE
feat(entitlement): add Entitlement.days_until_expiry() + expires_within()

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -247,6 +247,40 @@ class Entitlement:
     def expired(self) -> bool:
         return self.expiry is not None and time.time() > self.expiry
 
+    def days_until_expiry(self) -> int | None:
+        """Full days remaining until ``expiry`` (epoch seconds).
+
+        ``None`` means perpetual (OSS / Enterprise air-gapped / Free cloud) and
+        the UI should hide any countdown affordance. An already-expired
+        entitlement collapses to ``0`` rather than going negative so banner
+        copy ("expires in 0 days") stays sensible without extra clamping at the
+        callsite. A non-numeric or otherwise broken ``expiry`` value falls back
+        to ``None`` — never raises."""
+        try:
+            if self.expiry is None:
+                return None
+            remaining = float(self.expiry) - time.time()
+            if remaining <= 0:
+                return 0
+            return int(remaining // 86400)
+        except (TypeError, ValueError):
+            return None
+
+    def expires_within(self, days: int) -> bool:
+        """``True`` when the entitlement has a finite expiry that falls within
+        ``days`` days (inclusive). Perpetual entitlements (``expiry is None``)
+        always return ``False`` so a Free OSS install never trips trial-style
+        "renew soon" banners. ``days`` is clamped at ``0`` — negative thresholds
+        degrade to "already expired only" rather than raising."""
+        remaining = self.days_until_expiry()
+        if remaining is None:
+            return False
+        try:
+            threshold = max(0, int(days))
+        except (TypeError, ValueError):
+            return False
+        return remaining <= threshold
+
     def allows_runtime(self, runtime: str) -> bool:
         """Whether ``runtime`` may be observed. In grace mode everything is
         allowed; otherwise free runtimes plus whatever the tier grants."""
@@ -291,6 +325,7 @@ class Entitlement:
             "node_limit": self.node_limit,
             "expiry": self.expiry,
             "expired": self.expired,
+            "days_until_expiry": self.days_until_expiry(),
             "is_paid": self.is_paid,
             "grace": self.grace,
             "enforced": not self.grace,

--- a/tests/test_entitlement_expiry.py
+++ b/tests/test_entitlement_expiry.py
@@ -1,0 +1,224 @@
+"""Tests for ``Entitlement.days_until_expiry()`` / ``expires_within()``.
+
+These helpers are pure display/alerting helpers — they do not influence the
+gate decision (``allows_runtime`` / ``allows_feature``), so the headline
+invariant is "adding them changes no current behaviour" and the wire-shape
+addition (``to_dict()["days_until_expiry"]``) is a purely additive key.
+
+The tests pin:
+  * Perpetual entitlements (``expiry is None``) -> ``None`` / ``False``.
+  * Already-expired entitlements collapse to ``0`` (not negative).
+  * Future expiry returns the floor in days.
+  * Sub-day expiry (12 hours) returns ``0`` (floor).
+  * ``expires_within`` threshold semantics + clamping of negative thresholds.
+  * Defensive: non-numeric ``expiry`` returns ``None`` without raising.
+  * ``to_dict()`` carries the new key with the right type.
+"""
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import json
+import time
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement off
+    by default — these helpers are read-only and grace-mode-agnostic, but the
+    fixture mirrors the existing tests/test_entitlements.py pattern."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── days_until_expiry ────────────────────────────────────────────────────────
+
+
+def test_perpetual_entitlement_returns_none(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.expiry is None
+    assert en.days_until_expiry() is None
+
+
+def test_expired_entitlement_collapses_to_zero(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() - 3600})
+    )
+    en = ent.get_entitlement(force=True)
+    assert en.expired is True
+    assert en.days_until_expiry() == 0
+
+
+def test_five_days_in_future_returns_five(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    # 5 full days + 1 hour of slack so floor still yields 5 even if the test
+    # straddles a second boundary.
+    cache.write_text(
+        json.dumps(
+            {"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() + (5 * 86400) + 3600}
+        )
+    )
+    en = ent.get_entitlement(force=True)
+    assert en.days_until_expiry() == 5
+
+
+def test_sub_day_expiry_floors_to_zero(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() + (12 * 3600)})
+    )
+    en = ent.get_entitlement(force=True)
+    # 12 hours from now -> 0 full days (the UI should round its own display).
+    assert en.days_until_expiry() == 0
+    # And the entitlement is *not* yet expired.
+    assert en.expired is False
+
+
+def test_exactly_one_day_left(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps(
+            {"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() + 86400 + 60}
+        )
+    )
+    en = ent.get_entitlement(force=True)
+    assert en.days_until_expiry() == 1
+
+
+def test_non_numeric_expiry_defensive_fallback(ent):
+    # The dataclass is frozen but ``dataclasses.replace`` honours the type
+    # contract; we explicitly inject a broken value to confirm the helper
+    # swallows it rather than crashing a render path.
+    en = ent.get_entitlement(force=True)
+    broken = dataclasses.replace(en, expiry="not-a-number")  # type: ignore[arg-type]
+    assert broken.days_until_expiry() is None
+    assert broken.expires_within(30) is False
+
+
+# ── expires_within ───────────────────────────────────────────────────────────
+
+
+def test_expires_within_perpetual_is_false(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.expires_within(0) is False
+    assert en.expires_within(7) is False
+    assert en.expires_within(365) is False
+
+
+def test_expires_within_already_expired_is_true(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() - 60})
+    )
+    en = ent.get_entitlement(force=True)
+    assert en.expires_within(0) is True
+    assert en.expires_within(7) is True
+
+
+def test_expires_within_threshold_inclusive(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    # ~6 days out -> within 7-day banner threshold, outside 5-day.
+    cache.write_text(
+        json.dumps(
+            {"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() + (6 * 86400) + 3600}
+        )
+    )
+    en = ent.get_entitlement(force=True)
+    assert en.days_until_expiry() == 6
+    assert en.expires_within(7) is True
+    assert en.expires_within(6) is True
+    assert en.expires_within(5) is False
+
+
+def test_expires_within_negative_threshold_clamped(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    # 5 days out + slack: comfortably beyond the clamped-to-zero threshold.
+    cache.write_text(
+        json.dumps(
+            {"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() + (5 * 86400) + 3600}
+        )
+    )
+    en = ent.get_entitlement(force=True)
+    # Negative threshold clamps to 0 -> only "already expired" satisfies it,
+    # and this entitlement isn't expired, so False.
+    assert en.expires_within(-5) is False
+    assert en.expires_within(-1) is False
+
+
+def test_expires_within_nonnumeric_threshold_is_false(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.expires_within("seven") is False  # type: ignore[arg-type]
+
+
+# ── to_dict wire shape ────────────────────────────────────────────────────────
+
+
+def test_to_dict_perpetual_carries_null(ent):
+    d = ent.get_entitlement(force=True).to_dict()
+    assert "days_until_expiry" in d
+    assert d["days_until_expiry"] is None
+
+
+def test_to_dict_finite_carries_int(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps(
+            {"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() + (10 * 86400) + 3600}
+        )
+    )
+    d = ent.get_entitlement(force=True).to_dict()
+    assert isinstance(d["days_until_expiry"], int)
+    assert d["days_until_expiry"] == 10
+
+
+def test_to_dict_expired_carries_zero(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() - 1})
+    )
+    d = ent.get_entitlement(force=True).to_dict()
+    assert d["expired"] is True
+    assert d["days_until_expiry"] == 0
+
+
+# ── grace-mode contract: these helpers are display-only ──────────────────────
+
+
+def test_helpers_do_not_affect_gate_decisions(ent, monkeypatch, tmp_path):
+    """The new helpers are display-only; ``allows_runtime`` / ``allows_feature``
+    still resolve identically. Pins the "no current behaviour change"
+    contract that the rollout phase requires."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps(
+            {"plan": "cloud_pro", "node_limit": 1, "expiry": time.time() + (20 * 86400) + 3600}
+        )
+    )
+    en = ent.get_entitlement(force=True)
+    # Helpers report something useful…
+    assert en.days_until_expiry() == 20
+    assert en.expires_within(30) is True
+    # …but the underlying gate decisions are unchanged.
+    assert en.allows_runtime("claude_code") is True
+    assert en.allows_feature("self_evolve") is True


### PR DESCRIPTION
## Summary

Adds two display/alerting helpers to `clawmetry/entitlements.py::Entitlement` so the dashboard can render trial-countdown banners and "renew soon" copy off `/api/entitlement` without recomputing from the raw `expiry` epoch on the frontend.

| Helper | Returns |
|--------|---------|
| `Entitlement.days_until_expiry()` | `int` (full days remaining), `0` if already-expired, `None` if perpetual |
| `Entitlement.expires_within(days)` | `bool` — `True` iff finite expiry falls within `days` days (inclusive) |

`to_dict()` gains a `days_until_expiry` key (int / None) so `/api/entitlement` consumers can render the same banners without recomputing.

## Semantics

Chosen to mirror the existing `expired` property and keep banner copy sensible:

| Condition | `days_until_expiry()` | `expires_within(N)` |
|-----------|----------------------|---------------------|
| Perpetual (`expiry is None`) — OSS / Enterprise air-gapped / Free cloud | `None` | `False` for all `N` |
| Already-expired (`expiry < now`) | `0` (not negative) | `True` for all `N >= 0` |
| Sub-day remaining (e.g. 12 h) | `0` (floor) | `True` if `N >= 0` |
| 6 days + slack remaining | `6` | `True` for `N >= 6`, else `False` |
| Non-numeric `expiry` (defensive) | `None` | `False` |
| Non-numeric / negative `days` threshold | — | `False` / clamped to 0 |

The helpers are **read-only and gate-irrelevant**. They are not consulted by `allows_runtime` / `allows_feature` / `allows_node_count`, so the grace-vs-enforce decision surface is byte-for-byte identical. Wiring this in changes **no current behaviour**.

## Why this isn't in #2722 / #2426 / #2692 / #2697 / #2674

- **#2722 (`allows_node_count`)** — the node-axis gate; this PR is on the **time axis** (expiry) and never participates in any `allows_*` decision.
- **#2426 (`feature_catalog` + `/api/features`)** and **#2692 (`tier_catalog` + `/api/tiers`)** — catalogue surfaces; they don't address per-entitlement expiry.
- **#2697 (`gate_runtime`)** and **#2674 (`required_tier` in 402)** — decorator-internal `_gate.py` work; no overlap with the data-model helpers added here.

The wire-shape addition (`days_until_expiry` in `to_dict`) is purely additive — every existing key keeps its shape, so existing `/api/entitlement` consumers are unaffected.

## Changes

- `clawmetry/entitlements.py` — `Entitlement.days_until_expiry()` + `Entitlement.expires_within()` methods + `to_dict()["days_until_expiry"]` key (35 lines incl. docstrings).
- `tests/test_entitlement_expiry.py` — 15 tests pinning:
  - Perpetual → `None` / `False`.
  - Expired collapses to `0` (not negative).
  - Future expiry returns the floor in days (5 days + slack → 5; 12 h → 0).
  - Exactly-one-day-remaining returns 1.
  - Non-numeric expiry handled without raising.
  - `expires_within` threshold inclusivity + perpetual + already-expired branches.
  - Negative threshold clamped to 0.
  - Non-numeric threshold returns `False`.
  - `to_dict()` wire shape: perpetual → `null`, finite → `int`, expired → `0`.
  - Gate-irrelevance: with `CLAWMETRY_ENFORCE=1` + a cloud_pro cache, helpers report useful values but `allows_runtime` / `allows_feature` resolve identically.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py tests/test_entitlement_expiry.py` — clean.
- [x] `python3 -m ruff check clawmetry/entitlements.py tests/test_entitlement_expiry.py` — All checks passed.
- [x] `python3 -m pytest tests/test_entitlement_expiry.py -v` — **15 passed in 0.10s**.
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_entitlement_expiry.py tests/test_extensions.py tests/test_license.py tests/test_license_api.py` — **100 passed in 0.65s** (no regressions in adjacent surfaces).
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — clean.

The pre-existing repo-wide `make lint` failures (199 errors, all unrelated; e.g. `F841` for `p_status`/`p_connect`/`p_uninstall` in `dashboard.py`) reproduce on `origin/main` and are unaffected here — neither changed file contributes to them.

## Local operator verification checklist

This agent has no access to the user's local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please complete on a real install:

1. `git fetch origin feat/entitlement-days-until-expiry && git checkout feat/entitlement-days-until-expiry`
2. `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/entitlements.py`
3. `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
4. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. `curl -s http://localhost:8900/api/entitlement | python3 -m json.tool` — expect the existing shape plus a new `"days_until_expiry": null` field on an OSS / perpetual install
6. With a real Pro license installed: `clawmetry activate <KEY>` → re-curl `/api/entitlement` and confirm `days_until_expiry` is an `int` matching the license payload's days-remaining
7. Optionally `python3 -c "from clawmetry.entitlements import get_entitlement; e=get_entitlement(force=True); print(e.days_until_expiry(), e.expires_within(30))"` — perpetual → `None False`; finite → `<int> True/False`
8. Decrypt the live cloud snapshot and confirm no behavioural drift — the helpers are read-only and never participate in `allows_*` decisions, so grace mode is preserved end-to-end
9. Browser-check the dashboard — no UI surface consumes `days_until_expiry` yet (frontend countdown banner is a follow-up); every existing surface should render exactly as before

This PR is **DRAFT** — leave it for the operator to mark ready / merge / cut the release. No `__version__` bump, no `[RELEASE]` PR, no enforcement gate flipped.

---
_Generated by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS8yeKf1n4NtRDqBorF74X)_