### PR TITLE
feat(snapshot): add evals slice (scores) so the hosted dashboard can show them

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -12619,6 +12619,19 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     except Exception as _e_ce:
         log.debug("snapshot: context_economics slice failed: %s", _e_ce)
 
+    # Eval (LLM-judge) scores, so the hosted dashboard's Eval card populates from
+    # the encrypted snapshot (cloud stays blind; E2E preserved). Built on the
+    # daemon's own store handle. Best-effort; empty until evals run (needs a
+    # judge key), which the card then reads as "scoring paused".
+    evals_slice = {"summary": {}, "recent": []}
+    try:
+        from clawmetry import local_store as _ls_ev
+        _ev_store = _ls_ev.get_store()
+        evals_slice["summary"] = _ev_store.query_eval_summary(window_hours=24) or {}
+        evals_slice["recent"] = _ev_store.query_recent_evals(limit=10) or []
+    except Exception as _e_ev:
+        log.debug("snapshot: evals slice failed: %s", _e_ev)
+
     from clawmetry.providers_pricing import provider_for_model as _pfm
     payload = {
         "system": system,
@@ -12649,6 +12662,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "toolCatalog": tool_catalog_slice,
         "mcpServers": mcp_servers_slice,
         "contextEconomics": context_economics_slice,
+        "evals": evals_slice,
         "spending": spending,
         # Compact all-runtime slice a WiFi hardware companion decrypts + renders
         # (the device GETs the snapshot, decrypts with the user's key, reads


### PR DESCRIPTION
Step 1 of surfacing evals on the **hosted** dashboard (you approved the cloud surfacing).

The Eval card (#2726) fetches `/api/evals/summary`; on cloud that hits a server with no local DuckDB, so it shows `--`. This adds an **`evals`** slice to the E2E-encrypted snapshot (`query_eval_summary` 24h + `query_recent_evals` 10), built on the daemon's **own** store handle (per FLYWHEEL §1), so a `cm-cloud-evals` interceptor can serve the card client-side from the decrypted snapshot. Cloud stays blind; E2E preserved. Best-effort; empty until a judge key is set (card reads that as "scoring paused").

**Next (clawmetry-cloud):** bump the OSS pin (ships the Eval card frontend from #2726), add the `cm-cloud-evals` interceptor, and gate the key input to a "set this on your machine" note in `CLOUD_MODE`.

Verified: `py_compile`; slice mirrors the existing `contextEconomics`/`toolCatalog` pattern. Will live-verify by decrypting the snapshot for the `evals` key after release.