### PR TITLE
fix(ui): revive Outcome tile (Overview) + Loop-signals badge/panel (Brain)

### DIFF
--- a/clawmetry/templates/tabs/brain.html
+++ b/clawmetry/templates/tabs/brain.html
@@ -1,12 +1,22 @@
 <div class="page" id="page-brain">
   <div style="padding:12px 0 8px 0;">
     <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;">
-      <span style="font-size:14px;font-weight:700;color:var(--text-primary);">🧠 <span data-i18n="brain.title">Brain · Unified Activity Stream</span></span>
+      <span style="font-size:14px;font-weight:700;color:var(--text-primary);">🧠 <span data-i18n="brain.title">Brain · Unified Activity Stream</span>
+        <!-- Loop-signals badge (#1364): hidden until /api/loop-signals returns >0. JS: app.js loadLoopSignals() (called from loadBrainPage). Revived from the dead DASHBOARD_HTML block (UI-coverage audit 2026-06-06). -->
+        <button id="brain-loops-badge" type="button" onclick="toggleLoopSignalsList()" style="display:none;margin-left:8px;background:rgba(239,68,68,0.15);color:#ef4444;border:1px solid rgba(239,68,68,0.4);border-radius:10px;padding:2px 9px;font-size:11px;font-weight:700;cursor:pointer;font-family:inherit;" title="LoopDetector signals from the ClawMetry proxy"><span id="brain-loops-badge-count">0</span> loops</button></span>
       <div style="
         display:flex;
         align-items:center;
         gap:8px;
         "><span id="brain-live-indicator"></span><button id="brain-plumbing-btn" class="refresh-btn" onclick="toggleBrainPlumbing()" data-i18n-title="brain.plumbing_tooltip" title="Show internal queue/dequeue events (hidden by default, they're plumbing, not content)" style="font-weight:500;"><span id="brain-plumbing-state">○</span> <span data-i18n="brain.show_plumbing">Show plumbing</span> <span id="brain-plumbing-count" style="opacity:0.7;font-size:11px;"></span></button><button id="brain-focus-btn" class="refresh-btn" onclick="toggleBrainFocus()" data-i18n-title="brain.focus_tooltip" title="Focus mode: hide everything except the event stream">⛶ Focus</button><button class="refresh-btn" onclick="loadBrainPage()">↻ <span data-i18n="common.refresh">Refresh</span></button></div>
+    </div>
+    <!-- Loop-signals table (#1364): collapsed until the badge is clicked. JS: app.js loadLoopSignals() fills #brain-loops-table; toggleLoopSignalsList() shows it. Revived from the dead DASHBOARD_HTML block. -->
+    <div id="brain-loops-panel" style="display:none;background:var(--bg-secondary);border:1px solid rgba(239,68,68,0.4);border-radius:8px;padding:10px 14px;margin-bottom:12px;">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">
+        <span style="font-size:11px;font-weight:600;color:#ef4444;text-transform:uppercase;letter-spacing:1px;">Loops detected (proxy)</span>
+        <span style="font-size:10px;color:var(--text-muted);">From the ClawMetry proxy LoopDetector (last 60 min)</span>
+      </div>
+      <div id="brain-loops-table" style="font-size:11px;font-family:'JetBrains Mono','SF Mono',monospace;color:var(--text-secondary);"></div>
     </div>
     <style>
       /* Focus mode: hide chrome, expand event stream to viewport */

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -5,6 +5,22 @@
        triage) get relocated into a collapsed "Advanced" disclosure below. -->
   <div id="overview-hero" style="display:none;margin:0 0 16px;border-radius:18px;padding:26px 30px;background:radial-gradient(120% 140% at 0% 0%, rgba(59,130,246,0.10), transparent 55%), linear-gradient(180deg, var(--bg-secondary), var(--bg-primary));border:1px solid var(--border-primary);box-shadow:0 1px 0 rgba(255,255,255,0.03) inset, 0 8px 30px rgba(0,0,0,0.25);"></div>
 
+  <!-- Today's task outcomes (succeeded / failed / abandoned). JS: app.js
+       loadOutcomeTile() -> /api/outcomes, called from the overview load path.
+       Revived from the dead DASHBOARD_HTML block (UI-coverage audit 2026-06-06). -->
+  <div id="outcome-card" style="background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:10px;padding:14px 18px;margin-bottom:10px;box-shadow:var(--card-shadow);cursor:pointer;" onclick="toggleOutcomeDrilldown()" title="Click for details">
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;">
+      <div style="display:flex;align-items:baseline;gap:14px;flex-wrap:wrap;">
+        <span style="font-size:12px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.2px;">Today</span>
+        <span id="outcome-tile-summary" style="font-size:14px;color:var(--text-primary);">Loading task outcomes...</span>
+      </div>
+      <span id="outcome-tile-chevron" style="font-size:11px;color:var(--text-muted);">show details</span>
+    </div>
+    <div id="outcome-drilldown" style="display:none;margin-top:12px;padding-top:12px;border-top:1px solid var(--border-secondary);font-size:12px;">
+      <div id="outcome-drilldown-body" style="color:var(--text-muted);">Loading...</div>
+    </div>
+  </div>
+
   <!-- How independently your agent runs -->
   <div id="autonomy-card" data-i18n-title="overview.autonomy_tooltip" style="background:var(--bg-secondary);border:2px solid var(--border-primary);border-radius:12px;padding:18px 22px;margin-bottom:14px;box-shadow:var(--card-shadow);display:grid;grid-template-columns:1fr 1fr;gap:16px;align-items:start;" title="How often you need to step in. Higher means more independent.">
     <div>


### PR DESCRIPTION
Batch 2 of the **"UI for everything we capture"** pass (verified UI-coverage audit). Two more dead-UI revivals (HTML was only in the dead `DASHBOARD_HTML` block; JS already wired):

- **Outcome tile** (today's task succeeded / failed / abandoned) → `overview.html`. `loadOutcomeTile()` fills it (called from the overview load path); `toggleOutcomeDrilldown()` expands details.
- **Loop-signals badge + table** (proxy LoopDetector hits) → `brain.html` header + panel. `loadLoopSignals()` (called from `loadBrainPage`) reveals the badge when `/api/loop-signals` returns >0 and fills the table. This surfaces enforcement loop-detections that were captured but invisible.

Verified: Jinja renders both templates with all new ids; JS call sites confirmed; `py_compile` clean.

(Spans panel deferred — it overlaps the Tracing tab's richer per-trace span views + needs a separate trigger; revisiting in a later batch.)