### PR TITLE
feat(ui): surface today's activity counters (computed but never shown)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1330,6 +1330,24 @@ function _friendlyBytes(n) {
 // escalated, Z failed). Drill-down is lazy-loaded on click. Per memory
 // `feedback_no_em_dashes_in_user_facing_copy.md`, copy uses commas not
 // em-dashes.
+// UI-coverage audit: today's activity counters strip. Reads /api/activity-today
+// (local: cached DuckDB rollup; cloud: cm-cloud-activity serves it from the
+// snapshot's activityToday slice). Hidden until there is any activity today.
+async function loadActivityToday() {
+  var strip = document.getElementById('activity-today-strip');
+  if (!strip) return;
+  var d = {};
+  try { d = await fetchJsonWithTimeout('/api/activity-today', 4000) || {}; } catch (e) { return; }
+  var tool = d.tool_calls_today || 0, exec = d.exec_calls_today || 0,
+      brow = d.browser_actions_today || 0, msgs = d.messages_today || 0,
+      uniq = d.unique_tools_today || 0;
+  if (!(tool || exec || brow || msgs || uniq)) { strip.style.display = 'none'; return; }
+  var set = function(id, v){ var el = document.getElementById(id); if (el) el.textContent = v; };
+  set('at-tool-calls', tool); set('at-exec-calls', exec); set('at-browser-actions', brow);
+  set('at-messages', msgs); set('at-unique-tools', uniq);
+  strip.style.display = '';
+}
+
 async function loadOutcomeTile() {
   var summaryEl = document.getElementById('outcome-tile-summary');
   if (!summaryEl) return;
@@ -3009,6 +3027,8 @@ async function loadAll() {
     if (typeof loadActivityHeatmap === 'function') setTimeout(function(){ loadActivityHeatmap().catch(function(e){console.warn('activity heatmap failed',e)}); }, 4500);
     // Issue #1614 — outcome tile (Today: N tasks, X% success).
     if (typeof loadOutcomeTile === 'function') setTimeout(function(){ loadOutcomeTile().catch(function(e){console.warn('outcome tile failed',e)}); }, 800);
+    // UI-coverage audit — today's activity counters strip.
+    if (typeof loadActivityToday === 'function') setTimeout(function(){ loadActivityToday().catch(function(e){console.warn('activity today failed',e)}); }, 900);
     document.getElementById('refresh-time').textContent = t("app.updated", null, "Updated ") + new Date().toLocaleTimeString();
 
     if (overview.infra) {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -12663,6 +12663,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "mcpServers": mcp_servers_slice,
         "contextEconomics": context_economics_slice,
         "evals": evals_slice,
+        "activityToday": _collect_activity_counters_today() or {},
         "spending": spending,
         # Compact all-runtime slice a WiFi hardware companion decrypts + renders
         # (the device GETs the snapshot, decrypts with the user's key, reads

--- a/clawmetry/templates/tabs/overview.html
+++ b/clawmetry/templates/tabs/overview.html
@@ -21,6 +21,20 @@
     </div>
   </div>
 
+  <!-- Today's activity counters. JS: app.js loadActivityToday() -> /api/activity-today
+       (cloud: cm-cloud-activity serves it from the snapshot's activityToday slice).
+       Surfaces signals that were captured but never shown (UI-coverage audit 2026-06-06). -->
+  <div id="activity-today-strip" style="display:none;background:var(--bg-secondary);border:1px solid var(--border-primary);border-radius:10px;padding:10px 16px;margin-bottom:10px;box-shadow:var(--card-shadow);">
+    <div style="display:flex;gap:18px;flex-wrap:wrap;align-items:center;">
+      <span style="font-size:11px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:1.2px;">Today</span>
+      <span style="font-size:13px;color:var(--text-secondary);">&#128296; <b id="at-tool-calls" style="color:var(--text-primary);">0</b> tool calls</span>
+      <span style="font-size:13px;color:var(--text-secondary);">&#9889; <b id="at-exec-calls" style="color:var(--text-primary);">0</b> exec</span>
+      <span style="font-size:13px;color:var(--text-secondary);">&#127760; <b id="at-browser-actions" style="color:var(--text-primary);">0</b> browser</span>
+      <span style="font-size:13px;color:var(--text-secondary);">&#128172; <b id="at-messages" style="color:var(--text-primary);">0</b> messages</span>
+      <span style="font-size:13px;color:var(--text-secondary);">&#128295; <b id="at-unique-tools" style="color:var(--text-primary);">0</b> unique tools</span>
+    </div>
+  </div>
+
   <!-- How independently your agent runs -->
   <div id="autonomy-card" data-i18n-title="overview.autonomy_tooltip" style="background:var(--bg-secondary);border:2px solid var(--border-primary);border-radius:12px;padding:18px 22px;margin-bottom:14px;box-shadow:var(--card-shadow);display:grid;grid-template-columns:1fr 1fr;gap:16px;align-items:start;" title="How often you need to step in. Higher means more independent.">
     <div>

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -2818,6 +2818,32 @@ def api_usage_export():
         return jsonify({'error': str(e)}), 500
 
 
+_ACTIVITY_TODAY_CACHE = {"ts": 0.0, "data": None}
+_ACTIVITY_TODAY_TTL = 30.0
+
+
+@bp_usage.route('/api/activity-today')
+def api_activity_today():
+    """Today's activity counters (tool calls / exec / browser / messages /
+    unique tools) for the Overview activity strip. Mirrors the daemon
+    ``activityToday`` snapshot slice (cloud serves that via an interceptor).
+    DuckDB-backed via ``clawmetry.sync._collect_activity_counters_today``;
+    cached 30s; never 500s (empty dict on any error)."""
+    now = time.time()
+    c = _ACTIVITY_TODAY_CACHE
+    if c["data"] is not None and (now - c["ts"]) < _ACTIVITY_TODAY_TTL:
+        return jsonify(c["data"])
+    out = {}
+    try:
+        from clawmetry.sync import _collect_activity_counters_today
+        out = _collect_activity_counters_today() or {}
+    except Exception:
+        out = {}
+    c["data"] = out
+    c["ts"] = now
+    return jsonify(out)
+
+
 @bp_usage.route('/api/runtime-summary')
 def api_runtime_summary():
     """Per-runtime rollup (tokens / cost / turns / sessions / primary model),


### PR DESCRIPTION
UI-coverage audit, first captured-but-no-UI item. `_collect_activity_counters_today()` (tool calls / exec / browser / messages / unique tools today) was **defined but never called** — computed-and-dropped, no UI.

- **sync.py**: `activityToday` slice added to the E2E snapshot (cloud parity).
- **routes/usage.py**: cached (30s) `/api/activity-today`, DuckDB-backed, never 500s.
- **overview.html**: compact "Today" activity strip (hidden until >0).
- **app.js**: `loadActivityToday()` fetches it on overview load + reveals the strip.

Verified: `py_compile` (sync + usage), `node --check` app.js, Jinja renders all strip ids. The cloud `cm-cloud-activity` interceptor (serves the strip from `snapshot.activityToday`) follows in clawmetry-cloud.