### PR TITLE
perf(daemon): cap DuckDB threads + memory so it can't peg the machine

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1110,6 +1110,28 @@ def _to_blob(value: Any) -> bytes | None:
         return str(value).encode("utf-8", errors="replace")
 
 
+# DuckDB defaults to threads == CPU core count, so a single aggregate query
+# fans out across every core (observed: a 12-core box pegged at ~200% CPU just
+# re-running query_aggregates). ClawMetry is an observability sidecar, not a
+# warehouse: it must stay light (CPU budget, see FLYWHEEL.md). We cap threads to
+# a small number and bound the buffer pool so no query can take over the
+# machine. Both are env-overridable for power users with big stores.
+#   CLAWMETRY_DUCKDB_THREADS       (default 2; 0/blank = DuckDB default = all cores)
+#   CLAWMETRY_DUCKDB_MEMORY_LIMIT  (default "2GB"; blank = DuckDB default)
+def _duckdb_runtime_config() -> dict:
+    cfg: dict = {}
+    try:
+        threads = int(os.environ.get("CLAWMETRY_DUCKDB_THREADS", "2") or "0")
+    except ValueError:
+        threads = 2
+    if threads > 0:
+        cfg["threads"] = threads
+    mem = os.environ.get("CLAWMETRY_DUCKDB_MEMORY_LIMIT", "2GB")
+    if mem:
+        cfg["memory_limit"] = mem
+    return cfg
+
+
 def _open_connection(*, read_only: bool = False) -> duckdb.DuckDBPyConnection:
     """Open a DuckDB connection at DB_PATH, creating the directory if needed.
 
@@ -1126,9 +1148,10 @@ def _open_connection(*, read_only: bool = False) -> duckdb.DuckDBPyConnection:
     # if the conflicting holder is genuinely stuck we surface the real
     # DuckDB error instead of silently sleeping past it.
     last_exc: Exception | None = None
+    _cfg = _duckdb_runtime_config()
     for attempt in range(5):
         try:
-            return duckdb.connect(str(DB_PATH), read_only=read_only)
+            return duckdb.connect(str(DB_PATH), read_only=read_only, config=_cfg)
         except duckdb.IOException as exc:
             msg = str(exc)
             if "Conflicting lock" not in msg and "could not set lock" not in msg:
@@ -1138,7 +1161,7 @@ def _open_connection(*, read_only: bool = False) -> duckdb.DuckDBPyConnection:
     # Out of retries — re-raise the last lock error so the caller sees it.
     if last_exc is not None:
         raise last_exc
-    return duckdb.connect(str(DB_PATH), read_only=read_only)  # unreachable
+    return duckdb.connect(str(DB_PATH), read_only=read_only, config=_cfg)  # unreachable
 
 
 # ── Singleton store ─────────────────────────────────────────────────────────

--- a/tests/test_duckdb_cpu_cap.py
+++ b/tests/test_duckdb_cpu_cap.py
@@ -1,0 +1,42 @@
+"""DuckDB must not fan out across every core — ClawMetry is a light sidecar.
+
+Regression guard for the CPU-budget principle (FLYWHEEL.md): _open_connection
+caps DuckDB threads + memory_limit so a single aggregate query can't peg the
+whole machine (observed: a 12-core box at ~200% CPU re-running query_aggregates).
+"""
+import os
+import importlib
+
+
+def _reload_store():
+    import clawmetry.local_store as ls
+    return importlib.reload(ls)
+
+
+def test_default_caps_threads_and_memory(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_DUCKDB_THREADS", raising=False)
+    monkeypatch.delenv("CLAWMETRY_DUCKDB_MEMORY_LIMIT", raising=False)
+    ls = _reload_store()
+    cfg = ls._duckdb_runtime_config()
+    assert cfg["threads"] == 2, cfg
+    assert cfg["memory_limit"] == "2GB", cfg
+
+
+def test_env_override_threads(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_DUCKDB_THREADS", "1")
+    ls = _reload_store()
+    assert ls._duckdb_runtime_config()["threads"] == 1
+
+
+def test_zero_threads_means_duckdb_default(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_DUCKDB_THREADS", "0")
+    ls = _reload_store()
+    assert "threads" not in ls._duckdb_runtime_config()
+
+
+def test_applied_to_real_connection(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_DUCKDB_THREADS", raising=False)
+    import duckdb
+    ls = _reload_store()
+    con = duckdb.connect(str(tmp_path / "t.duckdb"), config=ls._duckdb_runtime_config())
+    assert con.execute("SELECT current_setting('threads')").fetchone()[0] == 2


### PR DESCRIPTION
**Problem (found on the founder's box):** the sync daemon sat at ~200% CPU. Profiling showed ~100% of the time inside DuckDB's allocator + `BufferPool::EvictBlocks` (buffer thrash). Root cause: `duckdb.connect()` was opened with **no config**, so DuckDB used `threads = 12` (all cores) and a `25.5 GiB` memory_limit — a single `query_aggregates` fanned out across the whole machine, re-run ~1×/sec.

**Fix (layer 1):** `_open_connection` now passes `config={threads, memory_limit}` — default **threads=2**, **memory_limit=2GB**, both env-overridable (`CLAWMETRY_DUCKDB_THREADS` / `CLAWMETRY_DUCKDB_MEMORY_LIMIT`; `0` = DuckDB default). No single query can take over the box.

This is the first of the CPU-budget work the founder asked to make a FLYWHEEL principle (daemon must stay light, target ≤5–10% CPU). **Layer 2** (result-caching the hot aggregates so they run ~once/minute instead of ~1/sec — the average-CPU fix) follows next.

Verified: `tests/test_duckdb_cpu_cap.py` (4 cases); live-confirmed the config reports `threads=2` on a real connection.