### PR TITLE
perf(daemon): TTL-cache query_aggregates (layer 2 of the CPU budget)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1132,6 +1132,27 @@ def _duckdb_runtime_config() -> dict:
     return cfg
 
 
+# Layer 2 of the CPU budget (FLYWHEEL.md): the hot rollup ``query_aggregates`` is
+# a full-table dedupe scan, and the dashboard re-requests it many times a minute.
+# It only changes when the daemon ingests new events (~every sync cycle), so a
+# short TTL cache collapses those repeats into ~one real compute per window. This
+# is what actually pulls AVERAGE daemon CPU down (the thread cap only bounds the
+# peak). TTL is env-overridable (CLAWMETRY_AGG_CACHE_TTL seconds); 0 disables it.
+_AGG_CACHE: dict = {}
+_AGG_CACHE_LOCK = threading.Lock()
+try:
+    _AGG_CACHE_TTL = float(os.environ.get("CLAWMETRY_AGG_CACHE_TTL", "20") or "0")
+except ValueError:
+    _AGG_CACHE_TTL = 20.0
+
+
+def invalidate_aggregate_cache() -> None:
+    """Drop the query_aggregates TTL cache. Reads tolerate <=TTL staleness, so
+    this is only needed when a caller wants sub-TTL freshness after an ingest."""
+    with _AGG_CACHE_LOCK:
+        _AGG_CACHE.clear()
+
+
 def _open_connection(*, read_only: bool = False) -> duckdb.DuckDBPyConnection:
     """Open a DuckDB connection at DB_PATH, creating the directory if needed.
 
@@ -7895,6 +7916,12 @@ class LocalStore:
         BEFORE the dedupe CTE so all downstream cost/token math reuses the
         same code path. Sum across runtime values == unfiltered total, by
         construction (RULE #1: filtered totals reconcile)."""
+        _ck = (agent_id, since, until, runtime)
+        if _AGG_CACHE_TTL > 0:
+            with _AGG_CACHE_LOCK:
+                _hit = _AGG_CACHE.get(_ck)
+                if _hit is not None and (time.monotonic() - _hit[0]) < _AGG_CACHE_TTL:
+                    return _hit[1]
         clauses: list[str] = []
         params: list[Any] = []
         if agent_id:
@@ -7967,8 +7994,12 @@ class LocalStore:
             GROUP BY r.day, r.agent_id, ds.cost_usd_d, ds.token_count_d
             ORDER BY r.day DESC
         """
-        return [_row_to_dict(r, ["day","agent_id","event_count","cost_usd","token_count"])
-                for r in self._fetch(sql, params)]
+        _rows = [_row_to_dict(r, ["day","agent_id","event_count","cost_usd","token_count"])
+                 for r in self._fetch(sql, params)]
+        if _AGG_CACHE_TTL > 0:
+            with _AGG_CACHE_LOCK:
+                _AGG_CACHE[_ck] = (time.monotonic(), _rows)
+        return _rows
 
     # ── ops / maintenance ──────────────────────────────────────────────
 

--- a/tests/test_aggregate_cache.py
+++ b/tests/test_aggregate_cache.py
@@ -1,0 +1,42 @@
+"""query_aggregates must be TTL-cached so the daemon doesn't re-run the heavy
+full-table dedupe on every dashboard poll (CPU-budget, FLYWHEEL.md)."""
+import importlib
+
+
+def _store(tmp_path, monkeypatch, ttl):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.02")
+    monkeypatch.setenv("CLAWMETRY_AGG_CACHE_TTL", ttl)
+    import clawmetry.local_store as ls
+    ls = importlib.reload(ls)
+    ls.invalidate_aggregate_cache()
+    return ls, ls.LocalStore(read_only=False)
+
+
+def _counting_fetch(st, monkeypatch, calls):
+    real = st._fetch
+    def counting(sql, params):
+        if "deduped" in sql:
+            calls["n"] += 1
+        return real(sql, params)
+    monkeypatch.setattr(st, "_fetch", counting)
+
+
+def test_second_call_is_cached(tmp_path, monkeypatch):
+    ls, st = _store(tmp_path, monkeypatch, "60")
+    calls = {"n": 0}
+    _counting_fetch(st, monkeypatch, calls)
+    st.query_aggregates(since="2026-01-01")
+    st.query_aggregates(since="2026-01-01")
+    assert calls["n"] == 1, f"expected 1 SQL run (2nd cached), got {calls['n']}"
+    st.query_aggregates(since="2026-02-01")   # different params -> recompute
+    assert calls["n"] == 2
+
+
+def test_ttl_zero_disables_cache(tmp_path, monkeypatch):
+    ls, st = _store(tmp_path, monkeypatch, "0")
+    calls = {"n": 0}
+    _counting_fetch(st, monkeypatch, calls)
+    st.query_aggregates(since="2026-01-01")
+    st.query_aggregates(since="2026-01-01")
+    assert calls["n"] == 2


### PR DESCRIPTION
Follow-up to #2750. The thread cap bounds **peak** CPU; this cuts **total** work — the real ≤5-10%-average fix.

`query_aggregates` is a full-table dedupe scan re-run ~10-20×/min by the dashboard, but it only changes when the daemon ingests new events. A process-global TTL cache (default **20s**, `CLAWMETRY_AGG_CACHE_TTL`, `0`=off) collapses those repeats into ~one real compute per window. The daemon's snapshot loop and its localhost query server share the store, so every HTTP-proxied dashboard call hits the cache.

Verified: `tests/test_aggregate_cache.py` — 2 calls → 1 SQL run; different params recompute; TTL=0 disables. Part of the CPU-budget work the founder asked to encode in every FLYWHEEL (next PR).