### PR TITLE
feat(openclaw): stamp openclawToolCatalogKind for native tool-search builds (#2732)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -126,6 +126,61 @@ def _model_router_fingerprint() -> dict:
 # starts exporting the catalog to the host (e.g. ~/.nemoclaw/skills/).
 
 
+def _scan_openclaw_selection_runtime() -> tuple[bool, bool]:
+    """Scan the pinned OpenClaw ``selection-*.js`` once and report whether
+    (a) the NemoClaw compact-catalog patch marker is present, and
+    (b) all three native tool-search symbols are present.
+
+    Returns ``(nemoclaw_patched, native_tool_search)``. Never raises.
+    """
+    nemoclaw_marker = b"/* nemoclaw compact tool catalog (#2600) */"
+    # Mirror scripts/patch-openclaw-tool-catalog.js NATIVE_TOOL_SEARCH_PATTERNS:
+    # all three symbols must be present before the patch script considers the
+    # dist to already have a native tool-search build (#2732).
+    native_markers = (
+        b"applyToolSearchCatalog",
+        b"buildToolSearchRunPlan",
+        b"uncompactedEffectiveTools",
+    )
+    patched = False
+    native = False
+    try:
+        home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
+        dist_dirs = [
+            os.path.join(home, "node_modules", "openclaw", "dist"),
+            "/usr/local/lib/node_modules/openclaw/dist",
+        ]
+        for dist in dist_dirs:
+            if not os.path.isdir(dist):
+                continue
+            try:
+                names = os.listdir(dist)
+            except OSError:
+                continue
+            for n in names:
+                if not (n.startswith("selection-") and n.endswith(".js")):
+                    continue
+                fp = os.path.join(dist, n)
+                try:
+                    with open(fp, "rb") as fh:
+                        # Patch marker + native symbols sit early in the
+                        # rewritten module; cap the read.
+                        blob = fh.read(2_000_000)
+                except OSError:
+                    continue
+                if not patched and nemoclaw_marker in blob:
+                    patched = True
+                if not native and all(m in blob for m in native_markers):
+                    native = True
+                if patched and native:
+                    break
+            if patched and native:
+                break
+    except Exception:
+        return patched, native
+    return patched, native
+
+
 def _nemoclaw_tool_catalog_state() -> Optional[bool]:
     """Whether the NemoClaw compact tool-catalog wrapper is active for this
     runtime (#2683).
@@ -143,44 +198,36 @@ def _nemoclaw_tool_catalog_state() -> Optional[bool]:
     catalog state that doesn't exist. Never raises.
     """
     env = os.environ.get("NEMOCLAW_TOOL_CATALOG")
-    # Look for the applied patch marker in the openclaw dist selection runtime.
-    patched = False
-    try:
-        home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
-        dist_dirs = [
-            os.path.join(home, "node_modules", "openclaw", "dist"),
-            "/usr/local/lib/node_modules/openclaw/dist",
-        ]
-        marker = b"/* nemoclaw compact tool catalog (#2600) */"
-        for dist in dist_dirs:
-            if not os.path.isdir(dist):
-                continue
-            try:
-                names = os.listdir(dist)
-            except OSError:
-                continue
-            for n in names:
-                if not (n.startswith("selection-") and n.endswith(".js")):
-                    continue
-                fp = os.path.join(dist, n)
-                try:
-                    with open(fp, "rb") as fh:
-                        # Marker sits early in the rewritten module; cap the read.
-                        if marker in fh.read(2_000_000):
-                            patched = True
-                            break
-                except OSError:
-                    continue
-            if patched:
-                break
-    except Exception:
-        patched = False
-
+    patched, _native = _scan_openclaw_selection_runtime()
     if not patched and env is None:
-        # No NemoClaw signal at all → don't claim a catalog state.
+        # No NemoClaw signal at all -> don't claim a catalog state.
         return None
     # Mirror the harness gate exactly: enabled unless explicitly "0".
     return env != "0"
+
+
+def _openclaw_tool_catalog_kind() -> Optional[str]:
+    """Provenance of the active OpenClaw tool-catalog mechanism, if any (#2732).
+
+    Returns:
+        ``"nemoclaw"`` when the NemoClaw compact-catalog patch is applied
+        (matches ``_nemoclaw_tool_catalog_state() is True``).
+        ``"native"`` when the dist ships native ``applyToolSearchCatalog`` /
+        ``buildToolSearchRunPlan`` / ``uncompactedEffectiveTools`` symbols and
+        the NemoClaw patch was skipped — previously indistinguishable from
+        "no catalog at all".
+        ``None`` when neither signal is present.
+
+    The NemoClaw patch wins over native detection: when both fire (e.g. a
+    forward-port window) the patched wrapper is what's actually intercepting
+    catalog calls. Never raises.
+    """
+    patched, native = _scan_openclaw_selection_runtime()
+    if patched:
+        return "nemoclaw"
+    if native:
+        return "native"
+    return None
 
 
 class OpenClawAdapter(AgentAdapter):
@@ -217,6 +264,12 @@ class OpenClawAdapter(AgentAdapter):
             _tc_enabled = _nemoclaw_tool_catalog_state()
             if _tc_enabled is not None:
                 meta["nemoclawToolCatalogEnabled"] = _tc_enabled
+            # Provenance — distinguish NemoClaw patch from native OpenClaw
+            # tool-search builds where the patch is a no-op (#2732). Stamped
+            # in addition to the back-compat boolean above.
+            _tc_kind = _openclaw_tool_catalog_kind()
+            if _tc_kind is not None:
+                meta["openclawToolCatalogKind"] = _tc_kind
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,
@@ -246,6 +299,10 @@ class OpenClawAdapter(AgentAdapter):
         # compact tool-catalog wrapper is active for this install. None on
         # plain OpenClaw (no NemoClaw signal) — we don't stamp a state then.
         _tc_enabled = _nemoclaw_tool_catalog_state()
+        # Catalog provenance (#2732): "nemoclaw" or "native" when either
+        # signal is present, so native-tool-search OpenClaw builds are no
+        # longer indistinguishable from "no catalog at all".
+        _tc_kind = _openclaw_tool_catalog_kind()
         out: List[Session] = []
         for s in raw[:limit]:
             updated_ms = s.get("updatedAt") or 0
@@ -257,6 +314,8 @@ class OpenClawAdapter(AgentAdapter):
             }
             if _tc_enabled is not None:
                 extra["nemoclawToolCatalogEnabled"] = _tc_enabled
+            if _tc_kind is not None:
+                extra["openclawToolCatalogKind"] = _tc_kind
             out.append(
                 Session(
                     agent=self.name,

--- a/tests/test_openclaw_tool_catalog_kind.py
+++ b/tests/test_openclaw_tool_catalog_kind.py
@@ -1,0 +1,104 @@
+"""Regression: distinguish native OpenClaw tool-search builds from plain
+OpenClaw (#2732), without losing the existing NemoClaw-patch detection (#2683).
+
+Before the fix, ``_nemoclaw_tool_catalog_state()`` was the only signal: it
+scanned ``selection-*.js`` only for the NemoClaw patch marker and returned
+``None`` for native-tool-search builds, leaving ``nemoclawToolCatalogEnabled``
+unset and indistinguishable from "no catalog at all". The new
+``_openclaw_tool_catalog_kind()`` helper closes the obs-gap by also returning
+``"native"`` when the dist ships the three tool-search symbols.
+"""
+from __future__ import annotations
+
+import pytest
+
+import clawmetry.adapters.openclaw as oc
+
+
+PATCH_MARKER = b"/* nemoclaw compact tool catalog (#2600) */\nexport const x = 1;\n"
+NATIVE_BLOB = (
+    b"export function applyToolSearchCatalog(){}\n"
+    b"export function buildToolSearchRunPlan(){}\n"
+    b"export const uncompactedEffectiveTools = [];\n"
+)
+PARTIAL_NATIVE_BLOB = (
+    # Only two of three symbols -> NOT a native build per the patch script's
+    # NATIVE_TOOL_SEARCH_PATTERNS contract.
+    b"export function applyToolSearchCatalog(){}\n"
+    b"export function buildToolSearchRunPlan(){}\n"
+)
+
+
+def _make_dist(tmp_path, blob: bytes, filename: str = "selection-abc.js"):
+    home = tmp_path / ".openclaw"
+    dist = home / "node_modules" / "openclaw" / "dist"
+    dist.mkdir(parents=True)
+    (dist / filename).write_bytes(blob)
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    # Strip env-var signals so the on-disk scan is the only input.
+    monkeypatch.delenv("NEMOCLAW_TOOL_CATALOG", raising=False)
+    # Default OPENCLAW_HOME to a non-existent dir; each test overrides.
+    monkeypatch.setenv("OPENCLAW_HOME", "/nonexistent-openclaw-home-for-tests")
+
+
+def test_plain_openclaw_returns_none(monkeypatch, tmp_path):
+    home = tmp_path / ".openclaw"
+    home.mkdir()
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert oc._nemoclaw_tool_catalog_state() is None
+    assert oc._openclaw_tool_catalog_kind() is None
+
+
+def test_native_tool_search_build_detected(monkeypatch, tmp_path):
+    home = _make_dist(tmp_path, NATIVE_BLOB)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    # Existing nemoclaw signal stays None (patch is not applied).
+    assert oc._nemoclaw_tool_catalog_state() is None
+    # NEW: native build is no longer indistinguishable from no catalog.
+    assert oc._openclaw_tool_catalog_kind() == "native"
+
+
+def test_nemoclaw_patch_wins_over_native(monkeypatch, tmp_path):
+    home = _make_dist(tmp_path, PATCH_MARKER + NATIVE_BLOB)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert oc._nemoclaw_tool_catalog_state() is True
+    assert oc._openclaw_tool_catalog_kind() == "nemoclaw"
+
+
+def test_partial_native_symbols_not_treated_as_native(monkeypatch, tmp_path):
+    home = _make_dist(tmp_path, PARTIAL_NATIVE_BLOB)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert oc._openclaw_tool_catalog_kind() is None
+
+
+def test_nemoclaw_patch_only(monkeypatch, tmp_path):
+    home = _make_dist(tmp_path, PATCH_MARKER)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert oc._nemoclaw_tool_catalog_state() is True
+    assert oc._openclaw_tool_catalog_kind() == "nemoclaw"
+
+
+def test_env_var_disables_nemoclaw_but_kind_still_reports_provenance(monkeypatch, tmp_path):
+    home = _make_dist(tmp_path, PATCH_MARKER)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    monkeypatch.setenv("NEMOCLAW_TOOL_CATALOG", "0")
+    # State reports False (disabled) per the harness gate.
+    assert oc._nemoclaw_tool_catalog_state() is False
+    # Kind still surfaces "nemoclaw" — the patched wrapper is on disk
+    # regardless of the runtime gate.
+    assert oc._openclaw_tool_catalog_kind() == "nemoclaw"
+
+
+def test_env_var_without_dist_marker_keeps_state_but_no_kind(monkeypatch, tmp_path):
+    home = tmp_path / ".openclaw"
+    home.mkdir()
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    monkeypatch.setenv("NEMOCLAW_TOOL_CATALOG", "1")
+    # Env-only signal: existing API still returns True (#2683 contract).
+    assert oc._nemoclaw_tool_catalog_state() is True
+    # But there's no on-disk wrapper, so no provenance to stamp.
+    assert oc._openclaw_tool_catalog_kind() is None


### PR DESCRIPTION
## Why

#2732 reports an obs-gap: when an OpenClaw dist already ships native tool-search symbols (`applyToolSearchCatalog`, `buildToolSearchRunPlan`, `uncompactedEffectiveTools`), `scripts/patch-openclaw-tool-catalog.js` skips itself. The NemoClaw patch marker (`/* nemoclaw compact tool catalog (#2600) */`) is therefore absent, `NEMOCLAW_TOOL_CATALOG` is unset, and `_nemoclaw_tool_catalog_state()` returns `None`. Result: `nemoclawToolCatalogEnabled` is never stamped, and the dashboard cannot tell a native-tool-search install apart from a plain dist that has no catalog at all.

## Data flow

`clawmetry/adapters/openclaw.py` :
1. `_scan_openclaw_selection_runtime()` (new) reads each `selection-*.js` once and returns `(nemoclaw_patched, native_tool_search)`. The native pattern requires ALL THREE of the symbols listed above to match the patch script's `NATIVE_TOOL_SEARCH_PATTERNS` contract.
2. `_nemoclaw_tool_catalog_state()` (refactored) consumes `(patched, _)` from the new helper. Semantics are unchanged for back-compat: returns `True` / `False` only when the NemoClaw patch marker is present or the env var is explicitly set, `None` otherwise.
3. `_openclaw_tool_catalog_kind()` (new) returns `"nemoclaw"` when the patch marker is present, `"native"` when only the native symbols are present, `None` otherwise. NemoClaw patch wins over native when both are present, mirroring the runtime precedence (the patched wrapper is what actually intercepts catalog calls).
4. Both `OpenClawAdapter.detect()` (DetectResult.meta) and `OpenClawAdapter.list_sessions()` (Session.extra) now stamp `openclawToolCatalogKind` alongside the existing `nemoclawToolCatalogEnabled` boolean.

## Verification

- New test `tests/test_openclaw_tool_catalog_kind.py` covers 7 states: plain dist (None / None), native-only (None / "native"), NemoClaw-only (True / "nemoclaw"), NemoClaw + native (True / "nemoclaw" -- patch wins), partial native (2/3 symbols, None / None), env-var disable with patch on disk (False / "nemoclaw"), env-var enable without dist marker (True / None).
- `python3 -m py_compile clawmetry/adapters/openclaw.py tests/test_openclaw_tool_catalog_kind.py` -- clean.
- `pytest tests/test_openclaw_tool_catalog_kind.py` -- 7/7 green.
- Five pre-existing failures in `tests/test_openclaw_detection_real.py` and `tests/test_openclaw_sessions_followup.py` reproduce on clean `origin/main` (host pollution + fixture drift, not caused by this PR).

## Backwards compatibility

- `nemoclawToolCatalogEnabled` semantics + presence rules are byte-identical to before: returns `True` / `False` only when the NemoClaw signal exists, `None` (and unstamped) otherwise. No consumer of that key needs to change.
- `openclawToolCatalogKind` is a strictly additive new key. Dashboards that don't read it ignore it. Dashboards that do can now disambiguate "nemoclaw" / "native" / absent.
- No new dependencies, no schema migration.

closes #2732

---

🦞 Generated with [Claude Code](https://claude.com/claude-code)