### PR TITLE
fix(ui): scope Overview outcome tile + activity strip per runtime

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1850,6 +1850,7 @@ class LocalStore:
         agent_type: str = "openclaw",
         since: str | None = None,
         until: str | None = None,
+        runtime: str | None = None,
         limit: int = 2000,
     ) -> list[dict[str, Any]]:
         """Read per-session outcome rows for the dashboard tile / drill-down.
@@ -1870,6 +1871,12 @@ class LocalStore:
         if until:
             clauses.append("COALESCE(last_active_at, started_at, '') <= ?")
             params.append(until)
+        # Runtime scope (session_id prefix), same canonical clause as
+        # query_aggregates so per-runtime outcomes reconcile with the total.
+        _rt_clause, _rt_params = _runtime_session_id_clause(runtime)
+        if _rt_clause:
+            clauses.append(_rt_clause)
+            params.extend(_rt_params)
         where = "WHERE " + " AND ".join(clauses)
         sql = f"""
             SELECT session_id, title, last_active_at, ended_at, status,
@@ -3887,6 +3894,7 @@ class LocalStore:
         self,
         *,
         since: str | None = None,
+        runtime: str | None = None,
         limit: int = 50_000,
     ) -> list[dict[str, Any]]:
         """Tier-1 MOAT: /api/plugins fast-path.
@@ -3935,6 +3943,10 @@ class LocalStore:
         if since:
             clauses.append("ts >= ?")
             params.append(since)
+        _rt_clause, _rt_params = _runtime_session_id_clause(runtime)
+        if _rt_clause:
+            clauses.append(_rt_clause)
+            params.extend(_rt_params)
         where = "WHERE " + " AND ".join(clauses)
         sql = f"""
             SELECT ts, event_type, data
@@ -4211,6 +4223,7 @@ class LocalStore:
         event_type: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        runtime: str | None = None,
         limit: int = 500,
     ) -> list[dict[str, Any]]:
         """Read events. Defaults to most recent first."""
@@ -4219,6 +4232,10 @@ class LocalStore:
         if session_id:
             clauses.append("session_id = ?")
             params.append(session_id)
+        _rt_clause, _rt_params = _runtime_session_id_clause(runtime)
+        if _rt_clause:
+            clauses.append(_rt_clause)
+            params.extend(_rt_params)
         if agent_id:
             clauses.append("agent_id = ?")
             params.append(agent_id)

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -1336,8 +1336,10 @@ function _friendlyBytes(n) {
 async function loadActivityToday() {
   var strip = document.getElementById('activity-today-strip');
   if (!strip) return;
+  var _rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  var _q = (_rt && _rt !== 'all') ? ('?runtime=' + encodeURIComponent(_rt)) : '';
   var d = {};
-  try { d = await fetchJsonWithTimeout('/api/activity-today', 4000) || {}; } catch (e) { return; }
+  try { d = await fetchJsonWithTimeout('/api/activity-today' + _q, 4000) || {}; } catch (e) { return; }
   var tool = d.tool_calls_today || 0, exec = d.exec_calls_today || 0,
       brow = d.browser_actions_today || 0, msgs = d.messages_today || 0,
       uniq = d.unique_tools_today || 0;
@@ -1351,8 +1353,10 @@ async function loadActivityToday() {
 async function loadOutcomeTile() {
   var summaryEl = document.getElementById('outcome-tile-summary');
   if (!summaryEl) return;
+  var _ocRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  var _ocQ = (_ocRt && _ocRt !== 'all') ? ('&runtime=' + encodeURIComponent(_ocRt)) : '';
   try {
-    var d = await fetchJsonWithTimeout('/api/outcomes?window=1d', 3000);
+    var d = await fetchJsonWithTimeout('/api/outcomes?window=1d' + _ocQ, 3000);
     if (!d || d.total === 0) {
       summaryEl.textContent = t("app.no_completed_tasks_yet_today_outcomes_will_appear_", null, "No completed tasks yet today. Outcomes will appear once sessions finish.");
       return;

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -5468,13 +5468,14 @@ def _today_start_iso_utc() -> str:
     return start.isoformat()
 
 
-def _outcomes_slice_for_snapshot() -> dict:
+def _outcomes_slice_for_snapshot(runtime: str | None = None) -> dict:
     """Outcome roll-up (1d) for the Overview tile on the hosted dashboard.
 
     Mirrors ``routes/sessions.api_outcomes`` (``query_outcomes`` then
     ``aggregate_outcomes``) so the cloud can render the tile from the snapshot
-    instead of an empty /api/outcomes. Best-effort; ``{}`` on any error so the
-    snapshot never fails.
+    instead of an empty /api/outcomes. ``runtime`` scopes to one runtime
+    (session_id prefix) for the per-runtime breakdown. Best-effort; ``{}`` on
+    any error so the snapshot never fails.
     """
     try:
         from clawmetry import local_store as _ls_oc
@@ -5482,7 +5483,7 @@ def _outcomes_slice_for_snapshot() -> dict:
         from datetime import datetime as _dt, timedelta as _td, timezone as _tz
         since = (_dt.now(_tz.utc) - _td(days=1)).isoformat().replace("+00:00", "Z")
         rows = _ls_oc.get_store().query_outcomes(
-            agent_type="openclaw", since=since, limit=1000) or []
+            agent_type="openclaw", since=since, runtime=runtime, limit=1000) or []
         agg = aggregate_outcomes(rows)
         agg["window"] = "1d"
         return agg
@@ -5491,8 +5492,12 @@ def _outcomes_slice_for_snapshot() -> dict:
         return {}
 
 
-def _collect_activity_counters_today() -> dict | None:
+def _collect_activity_counters_today(runtime: str | None = None) -> dict | None:
     """Plaintext activity counters for the heartbeat envelope (issue #1652).
+
+    ``runtime`` (optional): scope the counts to one runtime (session_id prefix,
+    e.g. "openclaw", "codex"). None / "all" = node-wide. Used to build the
+    per-runtime breakdown so the Overview cards re-scope with the runtime switcher.
 
     Cloud has no plaintext source for real exec/tool-call activity counts —
     sessions + nodes.metadata carry version/health bits but no per-day
@@ -5529,7 +5534,8 @@ def _collect_activity_counters_today() -> dict | None:
         # per ACTUAL tool call, not once per row (an assistant message
         # carrying 3 toolMetas yields 3 invocations, not 1).
         try:
-            invs = store.query_tool_call_invocations(since=since, limit=200_000)
+            invs = store.query_tool_call_invocations(
+                since=since, runtime=runtime, limit=200_000)
         except Exception:
             invs = []
         tool_calls = 0
@@ -5557,7 +5563,7 @@ def _collect_activity_counters_today() -> dict | None:
         for et in _MESSAGE_EVENT_TYPES_TODAY:
             try:
                 rows = store.query_events(
-                    event_type=et, since=since, limit=100_000,
+                    event_type=et, since=since, runtime=runtime, limit=100_000,
                 )
             except Exception:
                 continue
@@ -12692,6 +12698,29 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
     except Exception as _e_ev:
         log.debug("snapshot: evals slice failed: %s", _e_ev)
 
+    # Per-runtime breakdowns so the Overview cards (outcome tile + activity
+    # strip) re-scope with the runtime switcher on the hosted dashboard. Keyed
+    # by the runtimes that actually have data (runtimeSummary keys), so cost is
+    # bounded. The cloud cm-cloud-outcomes / cm-cloud-activity interceptors read
+    # ?runtime= and serve byRuntime[rt], falling back to the node-wide slice.
+    _runtime_summary = _build_runtime_summary()
+    _outcomes_by_rt: dict = {}
+    _activity_by_rt: dict = {}
+    try:
+        _rt_keys = list(_runtime_summary.keys()) if isinstance(_runtime_summary, dict) else []
+        for _rtk in _rt_keys:
+            try:
+                _o = _outcomes_slice_for_snapshot(runtime=_rtk)
+                if _o:
+                    _outcomes_by_rt[_rtk] = _o
+                _a = _collect_activity_counters_today(runtime=_rtk)
+                if _a:
+                    _activity_by_rt[_rtk] = _a
+            except Exception:
+                continue
+    except Exception as _e_rtb:
+        log.debug("snapshot: per-runtime breakdown failed: %s", _e_rtb)
+
     from clawmetry.providers_pricing import provider_for_model as _pfm
     payload = {
         "system": system,
@@ -12724,7 +12753,9 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "contextEconomics": context_economics_slice,
         "evals": evals_slice,
         "activityToday": _collect_activity_counters_today() or {},
+        "activityTodayByRuntime": _activity_by_rt,
         "outcomes": _outcomes_slice_for_snapshot(),
+        "outcomesByRuntime": _outcomes_by_rt,
         "spending": spending,
         # Compact all-runtime slice a WiFi hardware companion decrypts + renders
         # (the device GETs the snapshot, decrypts with the user's key, reads
@@ -12747,7 +12778,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "firstRun": _build_first_run(),
         "diagnostics": _build_diagnostics(paths.get("workspace")),
         "modelAttribution": _build_model_attribution(),
-        "runtimeSummary": _build_runtime_summary(),
+        "runtimeSummary": _runtime_summary,
         "transcripts": _build_transcripts(
             extra_sids=[
                 s["sessionId"]

--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -6354,6 +6354,7 @@ def api_outcomes():
         "query_outcomes",
         agent_type=agent_type,
         since=since,
+        runtime=(request.args.get("runtime") or None),
         limit=int(request.args.get("limit") or 1000),
     )
     if rows is None:

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -2818,29 +2818,31 @@ def api_usage_export():
         return jsonify({'error': str(e)}), 500
 
 
-_ACTIVITY_TODAY_CACHE = {"ts": 0.0, "data": None}
+_ACTIVITY_TODAY_CACHE: dict = {}   # runtime-key -> {"ts": float, "data": dict}
 _ACTIVITY_TODAY_TTL = 30.0
 
 
 @bp_usage.route('/api/activity-today')
 def api_activity_today():
     """Today's activity counters (tool calls / exec / browser / messages /
-    unique tools) for the Overview activity strip. Mirrors the daemon
-    ``activityToday`` snapshot slice (cloud serves that via an interceptor).
+    unique tools) for the Overview activity strip. ``?runtime=`` scopes to one
+    runtime (session_id prefix); omitted/"all" = node-wide. Mirrors the daemon
+    ``activityToday`` snapshot slice (cloud serves it via cm-cloud-activity).
     DuckDB-backed via ``clawmetry.sync._collect_activity_counters_today``;
-    cached 30s; never 500s (empty dict on any error)."""
+    cached 30s per runtime; never 500s (empty dict on any error)."""
+    runtime = (request.args.get("runtime") or "all").lower()
+    rt_arg = None if runtime in ("", "all") else runtime
     now = time.time()
-    c = _ACTIVITY_TODAY_CACHE
-    if c["data"] is not None and (now - c["ts"]) < _ACTIVITY_TODAY_TTL:
+    c = _ACTIVITY_TODAY_CACHE.get(runtime)
+    if c is not None and c["data"] is not None and (now - c["ts"]) < _ACTIVITY_TODAY_TTL:
         return jsonify(c["data"])
     out = {}
     try:
         from clawmetry.sync import _collect_activity_counters_today
-        out = _collect_activity_counters_today() or {}
+        out = _collect_activity_counters_today(runtime=rt_arg) or {}
     except Exception:
         out = {}
-    c["data"] = out
-    c["ts"] = now
+    _ACTIVITY_TODAY_CACHE[runtime] = {"data": out, "ts": now}
     return jsonify(out)
 
 

--- a/tests/test_per_runtime_filter.py
+++ b/tests/test_per_runtime_filter.py
@@ -1,0 +1,48 @@
+"""Per-runtime scoping for the Overview cards (outcome tile + activity strip).
+
+Regression guard: query_events / query_tool_call_invocations / query_outcomes
+accept a ``runtime`` filter (session_id prefix, the canonical
+_runtime_session_id_clause) so the cards re-scope with the runtime switcher
+instead of showing identical node-wide numbers for every runtime.
+Bug: the founder saw "3 tasks / 31 tool calls" identical across all/openclaw/codex.
+"""
+import os, uuid, importlib, tempfile
+
+
+def _store(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", tempfile.mktemp(suffix=".duckdb"))
+    monkeypatch.setenv("CLAWMETRY_DUCKDB_THREADS", "2")
+    import clawmetry.local_store as ls
+    ls = importlib.reload(ls)
+    return ls.LocalStore(read_only=False)
+
+
+def _ev(store, session_id, etype="message"):
+    store.ingest({
+        "id": str(uuid.uuid4()), "node_id": "agent+test", "agent_id": "a",
+        "agent_type": "openclaw", "session_id": session_id, "event_type": etype,
+        "ts": "2099-01-01T00:00:00Z", "token_count": 1, "cost_usd": 0.0, "data": {},
+    })
+    store.flush()
+
+
+def test_query_events_filters_by_runtime(monkeypatch):
+    st = _store(monkeypatch)
+    oc = str(uuid.uuid4())                 # bare UUID => openclaw
+    cx = "codex:" + str(uuid.uuid4())      # codex prefix
+    _ev(st, oc); _ev(st, oc); _ev(st, cx)
+    alln = len(st.query_events(event_type="message", limit=100))
+    ocn  = len(st.query_events(event_type="message", runtime="openclaw", limit=100))
+    cxn  = len(st.query_events(event_type="message", runtime="codex", limit=100))
+    assert alln == 3, alln
+    assert ocn == 2, ocn
+    assert cxn == 1, cxn
+    # the bug was: every runtime returned the node-wide number
+    assert ocn != alln and cxn != alln
+
+
+def test_unknown_runtime_returns_nothing(monkeypatch):
+    st = _store(monkeypatch)
+    _ev(st, str(uuid.uuid4()))
+    # an unknown runtime label must not leak the unfiltered total
+    assert st.query_events(event_type="message", runtime="not_a_runtime", limit=100) == []


### PR DESCRIPTION
**Bug (founder-reported):** with the runtime switcher on openclaw / codex / all, the **Outcome tile** ("3 tasks / 67%") and the **activity strip** ("31 tool calls / 31 exec / 1 unique") showed identical node-wide numbers for every runtime. Header session count + spend re-scoped; these two cards didn't.

**Root cause:** `/api/outcomes` + `/api/activity-today` and their snapshot slices were node-wide and ignored the runtime switcher.

**Fix, end to end:**
- `local_store`: `query_outcomes` / `query_events` / `query_tool_call_invocations` accept `runtime=`, applying the canonical `_runtime_session_id_clause` (same primitive as `query_aggregates`, so per-runtime reconciles with the total).
- `sync.py`: per-runtime activity + outcomes; snapshot adds `activityTodayByRuntime` + `outcomesByRuntime`.
- routes: `?runtime=` on both endpoints (runtime-keyed cache for activity).
- `app.js`: both loaders pass `_cmRuntimeFilter()`.

Cloud `cm-cloud-outcomes` / `cm-cloud-activity` interceptors read `?runtime=` → `byRuntime` in a follow-up cloud PR. Verified: `tests/test_per_runtime_filter.py` (per-runtime filtering + no leak on unknown runtime); py_compile + node --check.