### PR TITLE
fix(ui): honest per-runtime scope banner on Overview (don't confuse users)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3008,6 +3008,8 @@ async function loadAll() {
   if (Date.now() - _loadAllLastFinishedMs < _LOADALL_COALESCE_MS) return;
   _loadAllInFlight = (async function () {
   try {
+    // Runtime scope banner on first paint (showTab only fires on tab switch).
+    try { _cmApplyRuntimeScopeNote('overview'); } catch (e) {}
     // Render overview quickly; do not block on heavy usage aggregation.
     var overview = await fetchJsonWithTimeout('/api/overview', 3000);
     window._cmOverview = overview;
@@ -7858,6 +7860,22 @@ function _cmApplyRuntimeScopeNote(name) {
   var noteId = 'cm-rt-scope-note';
   var existing = page.querySelector('#' + noteId);
   var rt = _cmRuntimeFilter();
+  // Overview is a MIX: some cards re-scope with the runtime switcher (today's
+  // tasks/outcome, the activity strip, the hero token/cost stats) and some stay
+  // node-wide (autonomy score, reliability, activity heatmap). A single
+  // nodewide/aggregate note would be wrong, so spell out exactly what is scoped
+  // so the same number never looks runtime-specific when it isn't. (Founder:
+  // "don't confuse users" after the outcome/activity cards read identically
+  // across runtimes.)
+  if (name === 'overview') {
+    if (rt === 'all') { if (existing) existing.parentNode.removeChild(existing); return; }
+    var _ovl = _cmRuntimeLabel(rt);
+    var _ovmsg = 'Showing <strong>' + escHtml(_ovl) + '</strong>: today\'s tasks, activity, tokens and cost below are scoped to it. The autonomy score, reliability and activity heatmap stay <strong>node-wide</strong> (all runtimes).';
+    var _ovhtml = '<div id="' + noteId + '" style="display:flex;align-items:center;gap:8px;margin:0 0 14px;padding:9px 13px;border-radius:8px;background:rgba(59,130,246,0.10);border:1px solid rgba(59,130,246,0.35);font-size:12px;color:var(--text-secondary);line-height:1.4;"><span style="color:#3b82f6;font-size:13px;flex-shrink:0;">&#127760;</span><span>' + _ovmsg + '</span></div>';
+    if (existing) existing.outerHTML = _ovhtml;
+    else page.insertAdjacentHTML('afterbegin', _ovhtml);
+    return;
+  }
   var scope = _CM_RT_NODEWIDE[name] ? 'nodewide' : (_CM_RT_AGGREGATE[name] ? 'aggregate' : null);
   if (rt === 'all' || !scope) { if (existing) existing.parentNode.removeChild(existing); return; }
   // For AGGREGATE tabs: if only one runtime actually has data, the cross-runtime


### PR DESCRIPTION
Companion to #2761. Overview is a mix of runtime-scoped cards (today's tasks/outcome, activity strip, hero token/cost) and node-wide cards (autonomy, reliability, activity heatmap). Silently showing the node-wide ones under a runtime filter is what confused users. When a specific runtime is selected, Overview now shows one precise banner spelling out exactly what is scoped vs node-wide (removed on 'all'). No more guessing whether a number is runtime-specific. Verified: node --check.