### PR TITLE
fix(ui): Clusters tab fetched a non-existent endpoint (always empty)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -14624,7 +14624,7 @@ async function loadClusters() {
   if (!el) return;
   el.innerHTML = '<div style="color:var(--text-muted);font-size:13px;padding:16px;">' + t("app.analyzing_session_patterns", null, "Analyzing session patterns...") + '</div>';
   try {
-    var data = await fetch('/api/clusters').then(r => r.json());
+    var data = await fetch('/api/sessions/clusters').then(r => r.json());
     if (!data.clusters || data.clusters.length === 0) {
       el.innerHTML = '<div class="card" style="padding:20px;text-align:center;"><div style="font-size:13px;color:var(--text-muted);">' + t("app.no_sessions_found_to_cluster", null, "No sessions found to cluster.") + '</div></div>';
       return;


### PR DESCRIPTION
Trial-bug hunt finding (verified). `loadClusters()` fetched `/api/clusters` which has no route -> the Clusters tab always showed 'No sessions found' on local AND cloud. Fixed to the real `/api/sessions/clusters` (returns `{clusters}`, already used by the other cluster render). First of a verified remediation batch from the 38-bug hosted-dashboard hunt.