### PR TITLE
[RELEASE] trial-bug daemon slice: cron health summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## [Unreleased]
 
-### Trial-bug daemon slices: Flow runs + Flow lanes (2026-06-06)
-- **flowRuns**: ship the historical flow-runs list (mirrors /api/flow/runs via query_flow_runs) so the Flow tab "Runs" subtab renders on the hosted dashboard instead of "No historical flow runs yet".
-- **flowLanes**: ship the active-session lanes (sessions touched in the last 30 min) so "Active Session Lanes" renders. Cloud interceptors that read these follow.
+### Trial-bug daemon slice: cron health summary (2026-06-06)
+- **cronHealthSummary**: ship the cron health summary (reuse routes.crons._try_local_store_cron_health_summary) so the "Cron Health Monitor" card renders on the hosted dashboard instead of blank. Cloud interceptor follows.
 
 
 ### Trial-bug daemon slices: autonomy, context util, transcript runtime (2026-06-06)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10123,6 +10123,17 @@ def _build_autonomy_snapshot():
         return {}
 
 
+def _build_cron_health_summary_snapshot():
+    """Cron health summary slice (mirrors /api/cron/health-summary). Trial-bug
+    fix: the "Cron Health Monitor" card was blank on the hosted dashboard."""
+    try:
+        from routes.crons import _try_local_store_cron_health_summary
+        r = _try_local_store_cron_health_summary()
+        return r if r is not None else {}
+    except Exception:
+        return {}
+
+
 def _build_flow_runs_snapshot(limit=60):
     """Flow runs slice (mirrors /api/flow/runs). Trial-bug fix: the Flow "Runs"
     subtab was blank on the hosted dashboard (no interceptor + no slice)."""
@@ -12883,6 +12894,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         # this). Cloud stays blind; E2E preserved.
         "deviceSummary": _build_device_summary(spending, _du),
         "cronJobs": _build_cron_jobs(paths),
+        "cronHealthSummary": _build_cron_health_summary_snapshot(),
         "channels": _build_channel_data(config),
         "toolStats": _build_tool_stats(),
         "externalCalls": _build_external_calls(),


### PR DESCRIPTION
Adds cronHealthSummary snapshot slice (reuses the store-backed cron health builder) so the Cron Health Monitor card renders on the hosted dashboard. Cloud interceptor follows. py_compile + import verified.