### PR TITLE
[RELEASE] trial-bug daemon slice: Harness tab (templates + per-runtime data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Trial-bug daemon slice: Harness tab (templates + per-runtime data) (2026-06-06)
+- **harness**: ship the Harness slice (templates + per-runtime data blobs) so the Harness tab renders on the hosted dashboard instead of "Loading harness view..." forever. Refactored routes/harness.py http_harness_data into a reusable _harness_data_for(runtime) shared by the route + the snapshot. Cloud interceptor follows.
+
+
 ### Trial-bug daemon slice: cron health summary (2026-06-06)
 - **cronHealthSummary**: ship the cron health summary (reuse routes.crons._try_local_store_cron_health_summary) so the "Cron Health Monitor" card renders on the hosted dashboard instead of blank. Cloud interceptor follows.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10123,6 +10123,27 @@ def _build_autonomy_snapshot():
         return {}
 
 
+def _build_harness_snapshot():
+    """Harness tab slice: templates + per-runtime data blobs. Trial-bug #10:
+    the Harness tab was blank ("Loading harness view...") on the hosted
+    dashboard (no slice + no interceptor)."""
+    out = {"templates": {}, "runtimes": [], "dataByRuntime": {}}
+    try:
+        from clawmetry import harness_templates as _ht
+        tmpls = _ht.all_templates()
+        out["templates"] = tmpls
+        out["runtimes"] = sorted(tmpls.keys())
+        from routes.harness import _harness_data_for
+        for _rt in out["runtimes"]:
+            try:
+                out["dataByRuntime"][_rt] = _harness_data_for(_rt)
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return out
+
+
 def _build_cron_health_summary_snapshot():
     """Cron health summary slice (mirrors /api/cron/health-summary). Trial-bug
     fix: the "Cron Health Monitor" card was blank on the hosted dashboard."""
@@ -12895,6 +12916,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "deviceSummary": _build_device_summary(spending, _du),
         "cronJobs": _build_cron_jobs(paths),
         "cronHealthSummary": _build_cron_health_summary_snapshot(),
+        "harness": _build_harness_snapshot(),
         "channels": _build_channel_data(config),
         "toolStats": _build_tool_stats(),
         "externalCalls": _build_external_calls(),

--- a/routes/harness.py
+++ b/routes/harness.py
@@ -79,6 +79,14 @@ def http_harness_data():
         }
     """
     runtime = (request.args.get("runtime") or "openclaw").strip().lower()
+    return jsonify(_harness_data_for(runtime))
+
+
+def _harness_data_for(runtime):
+    """Compute the per-runtime harness data blob, shared by the HTTP route and
+    the cloud snapshot builder (trial-bug #10: the Harness tab was blank on the
+    hosted dashboard). Never raises; returns the dict."""
+    runtime = (runtime or "openclaw").strip().lower()
     blob = {"runtime": runtime, "summary": {"sessions": 0, "cost_usd": 0.0, "tokens": 0},
             "sessions": [], "extra": {}}
     try:
@@ -87,7 +95,7 @@ def http_harness_data():
         rows = body.get("rows") or body.get("sessions") or []
     except Exception as exc:
         logger.warning("harness data dispatch failed: %s", exc)
-        return jsonify(blob)
+        return blob
 
     mine = [r for r in rows if _runtime_match(r.get("session_id", ""), runtime)]
     total_cost = sum(_num(r.get("cost_usd")) for r in mine)
@@ -123,7 +131,7 @@ def http_harness_data():
     blob["sessions"] = sessions
     if models:
         blob["extra"]["models"] = models
-    return jsonify(blob)
+    return blob
 
 
 def _harvest_event_extra(runtime: str):


### PR DESCRIPTION
Refactored http_harness_data into reusable _harness_data_for; added the harness snapshot slice {templates, runtimes, dataByRuntime} so the Harness tab renders on the hosted dashboard instead of loading forever. Cloud interceptor follows. py_compile verified.