### PR TITLE
[RELEASE] trial-bug daemon slice: Usage tab cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Trial-bug daemon slice: Usage tab cards (2026-06-06)
+- **usage**: ship the Usage slices (anomalies, cost-comparison, cache-trends, cost-breakdown, spend-optimization, forecast) reusing the store-backed fast-paths so the Usage tab cards render on the hosted dashboard instead of "No data" / "Loading...". Cloud interceptors follow.
+
+
 ### Trial-bug daemon slice: Harness tab (templates + per-runtime data) (2026-06-06)
 - **harness**: ship the Harness slice (templates + per-runtime data blobs) so the Harness tab renders on the hosted dashboard instead of "Loading harness view..." forever. Refactored routes/harness.py http_harness_data into a reusable _harness_data_for(runtime) shared by the route + the snapshot. Cloud interceptor follows.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10123,6 +10123,40 @@ def _build_autonomy_snapshot():
         return {}
 
 
+def _build_usage_snapshot():
+    """Usage tab slices (anomalies, cost-comparison, cache-trends, cost-breakdown,
+    spend-optimization, forecast). Trial-bug #12: these Usage cards were blank on
+    the hosted dashboard (the /api/usage/* + /api/sessions/cost-breakdown routes
+    return empty without DuckDB and had no interceptor). Reuses the store-backed
+    fast-paths; each returns {} when the builder defers."""
+    out = {}
+    def _safe(fn):
+        try:
+            r = fn()
+            return r if r is not None else {}
+        except Exception:
+            return {}
+    try:
+        from routes.usage import (
+            _try_local_store_anomalies, _try_local_store_cost_comparison,
+            _try_local_store_cache_trends, _try_local_store_spend_optimization,
+            _try_local_store_usage_forecast,
+        )
+        out["anomalies"] = _safe(_try_local_store_anomalies)
+        out["costComparison"] = _safe(_try_local_store_cost_comparison)
+        out["cacheTrends"] = _safe(lambda: _try_local_store_cache_trends(30))
+        out["spendOptimization"] = _safe(_try_local_store_spend_optimization)
+        out["forecast"] = _safe(_try_local_store_usage_forecast)
+    except Exception:
+        pass
+    try:
+        from routes.sessions import _try_local_store_cost_breakdown
+        out["costBreakdown"] = _safe(_try_local_store_cost_breakdown)
+    except Exception:
+        out["costBreakdown"] = {}
+    return out
+
+
 def _build_harness_snapshot():
     """Harness tab slice: templates + per-runtime data blobs. Trial-bug #10:
     the Harness tab was blank ("Loading harness view...") on the hosted
@@ -12917,6 +12951,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "cronJobs": _build_cron_jobs(paths),
         "cronHealthSummary": _build_cron_health_summary_snapshot(),
         "harness": _build_harness_snapshot(),
+        "usage": _build_usage_snapshot(),
         "channels": _build_channel_data(config),
         "toolStats": _build_tool_stats(),
         "externalCalls": _build_external_calls(),


### PR DESCRIPTION
Adds the usage snapshot slice (anomalies, cost-comparison, cache-trends, cost-breakdown, spend-optimization, forecast) reusing the store-backed fast-paths so the Usage tab cards render on the hosted dashboard. Cloud interceptors follow. py_compile + import verified. Solo release to avoid the concurrent-release version race.