### PR TITLE
[RELEASE] trial-bug daemon slice: approvals audit (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
-### Trial-bug daemon slice: Usage tab cards (2026-06-06)
-- **usage**: ship the Usage slices (anomalies, cost-comparison, cache-trends, cost-breakdown, spend-optimization, forecast) reusing the store-backed fast-paths so the Usage tab cards render on the hosted dashboard instead of "No data" / "Loading...". Cloud interceptors follow.
+### Trial-bug daemon slice: approvals audit (2026-06-06)
+- **approvalsAudit**: ship the exec-approval decision audit (refactored routes/policy.py into a reusable _approvals_audit_payload) so the Policy tab audit renders on the hosted dashboard. The cloud interceptor already reads sp.approvalsAudit.
 
 
 ### Trial-bug daemon slice: Harness tab (templates + per-runtime data) (2026-06-06)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10157,6 +10157,16 @@ def _build_usage_snapshot():
     return out
 
 
+def _build_approvals_audit_snapshot():
+    """Approvals audit slice (mirrors /api/approvals-audit). Trial-bug #22: the
+    Policy tab's exec-approval audit was blank on the hosted dashboard."""
+    try:
+        from routes.policy import _approvals_audit_payload
+        return _approvals_audit_payload(limit=100)
+    except Exception:
+        return {}
+
+
 def _build_harness_snapshot():
     """Harness tab slice: templates + per-runtime data blobs. Trial-bug #10:
     the Harness tab was blank ("Loading harness view...") on the hosted
@@ -12952,6 +12962,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         "cronHealthSummary": _build_cron_health_summary_snapshot(),
         "harness": _build_harness_snapshot(),
         "usage": _build_usage_snapshot(),
+        "approvalsAudit": _build_approvals_audit_snapshot(),
         "channels": _build_channel_data(config),
         "toolStats": _build_tool_stats(),
         "externalCalls": _build_external_calls(),

--- a/routes/policy.py
+++ b/routes/policy.py
@@ -120,6 +120,13 @@ def api_approvals_audit():
         limit = 100
     status = (request.args.get("status") or "").strip() or None
 
+    return jsonify(_approvals_audit_payload(status=status, limit=limit))
+
+
+def _approvals_audit_payload(status=None, limit=100):
+    """Exec-approval decision audit payload, shared by the HTTP route and the
+    cloud snapshot builder (trial-bug #22: the Policy tab audit was blank on the
+    hosted dashboard). Returns {decisions, summary, _source}."""
     rows = _coerce_rows(_ls_call("query_approvals", status=status, limit=limit))
 
     def _arg_preview(args) -> str:
@@ -171,4 +178,4 @@ def api_approvals_audit():
         "approved": approved,
         "denied": denied,
     }
-    return jsonify({"decisions": decisions, "summary": summary, "_source": "local_store"})
+    return {"decisions": decisions, "summary": summary, "_source": "local_store"}


### PR DESCRIPTION
Refactored api_approvals_audit into reusable _approvals_audit_payload + added the approvalsAudit snapshot slice so the Policy tab audit renders (cloud interceptor already reads it). py_compile + import verified. Will merge SOLO after usage #2779 publishes to avoid the concurrent-release version race.