### PR TITLE
fix(openclaw): fold nemoclaw tool_result details into tool spans (#2733)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -458,10 +458,13 @@ class OpenClawAdapter(AgentAdapter):
         """Map raw JSONL objects to OTel-shaped span dicts.
 
         Mapping per issue #1010:
-        - ``session`` (version set)   → root span (INTERNAL)
+        - ``session`` (version set)    → root span (INTERNAL)
         - ``message`` (role=assistant) → llm.call span (CLIENT, child of root)
-          - each tool_use block       → tool.<name> span (CLIENT, child of llm)
-        - ``subagent_spawn``          → agent.spawn span (INTERNAL, link to child trace)
+          - each tool_use block        → tool.<name> span (CLIENT, child of llm)
+        - ``message`` (role=user)      → matched tool_result blocks fold their
+          structured ``details`` payload + ``is_error`` flag + text content back
+          onto the tool span identified by ``tool_use_id`` (#2733).
+        - ``subagent_spawn``           → agent.spawn span (INTERNAL, link to child trace)
 
         Span IDs are deterministic SHA-256 prefixes so re-ingesting is idempotent.
         """
@@ -470,6 +473,10 @@ class OpenClawAdapter(AgentAdapter):
         session_span_id = _sid("session", session_id)
         now = _time.time()
         spans: list = []
+        # tool_use_id → tool span dict, populated as assistant tool_use blocks
+        # are emitted; consumed when a later user tool_result block references
+        # the same id (#2733).
+        tool_span_by_id: dict = {}
 
         for obj in events:
             if not isinstance(obj, dict):
@@ -495,7 +502,59 @@ class OpenClawAdapter(AgentAdapter):
 
             elif t == "message" and isinstance(obj.get("message"), dict):
                 msg = obj["message"]
-                if msg.get("role") != "assistant":
+                role = msg.get("role")
+                content = msg.get("content") or []
+                if role == "user":
+                    # Tool results live in user-role messages. Fold the
+                    # structured details payload + is_error flag + text content
+                    # back onto the originating tool span (#2733). Orphan
+                    # tool_results (no matching tool_use_id) are skipped.
+                    if not isinstance(content, list):
+                        continue
+                    for block in content:
+                        if not isinstance(block, dict) or block.get("type") != "tool_result":
+                            continue
+                        tu_id = block.get("tool_use_id") or block.get("toolUseId") or ""
+                        target = tool_span_by_id.get(tu_id)
+                        if target is None:
+                            continue
+                        attrs = target.get("attributes") or {}
+                        attrs["tool.result_present"] = True
+                        if "is_error" in block:
+                            attrs["tool.result_is_error"] = bool(block.get("is_error"))
+                        # NemoClaw nemoClawBuildToolResult helper attaches a
+                        # top-level structured ``details`` dict on the result
+                        # (catalog hits, schemas, dispatch output). Surface it
+                        # so downstream Tracing/Event.extra can render the real
+                        # payload instead of just the stringified text wrapper.
+                        details = block.get("details")
+                        if details is not None:
+                            attrs["tool.result_details"] = details
+                            if isinstance(details, dict):
+                                attrs["tool.result_details_keys"] = sorted(details.keys())
+                        # Text content blocks (the JSON-stringified wrapper that
+                        # NemoClaw co-emits, or plain text from native tools)
+                        # collapsed into a single string for quick read.
+                        result_content = block.get("content")
+                        text_parts: list = []
+                        if isinstance(result_content, str):
+                            text_parts.append(result_content)
+                        elif isinstance(result_content, list):
+                            for inner in result_content:
+                                if isinstance(inner, dict) and inner.get("type") == "text":
+                                    val = inner.get("text")
+                                    if isinstance(val, str):
+                                        text_parts.append(val)
+                        if text_parts:
+                            attrs["tool.result_text"] = "".join(text_parts)
+                        target["attributes"] = attrs
+                        # End-time the tool span to whatever the result arrived
+                        # at. start_ts ≤ end_ts isn't enforced (assistant emits
+                        # tool_use and user tool_result share clock); but the
+                        # signal is still useful for duration heuristics.
+                        target["end_ts"] = ts
+                    continue
+                if role != "assistant":
                     continue
                 model = msg.get("model") or ""
                 usage = msg.get("usage") or {}
@@ -516,7 +575,6 @@ class OpenClawAdapter(AgentAdapter):
                     "tokens_output": tok_out or None,
                     "token_count": (tok_in + tok_out) or None,
                 })
-                content = msg.get("content") or []
                 if isinstance(content, list):
                     for block in content:
                         if not isinstance(block, dict) or block.get("type") != "tool_use":
@@ -564,6 +622,8 @@ class OpenClawAdapter(AgentAdapter):
                         }
 
                         spans.append(tool_span)
+                        if tool_id:
+                            tool_span_by_id[tool_id] = tool_span
 
             elif t in ("subagent_spawn", "agent_spawn"):
                 sub_id = (

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -149,3 +149,108 @@ def test_catalog_dispatch_span_unwraps_real_tool():
     assert by["Bash"]["attributes"] is None
     # other catalog meta-tools -> guardrail tag only (not a dispatcher)
     assert by["tool_search"]["attributes"] == {"nemoclaw.catalog_guardrail": True}
+
+
+# -- #2733 tool_result details fold-back -------------------------------------
+
+def test_tool_result_details_attach_to_originating_tool_span():
+    """NemoClaw nemoClawBuildToolResult emits structured `details` on the
+    result block in the user-role message. The span builder must look the
+    matching tool_use_id up and fold details + is_error + text onto the
+    pre-existing tool span via Event.extra-shaped attributes.
+    """
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    catalog_payload = {
+        "tools": [{"name": "Read", "schema": {"path": "str"}}],
+        "matched": 1,
+    }
+    events = [
+        {"type": "session", "version": "v1", "timestamp": "1700000000"},
+        {"type": "message", "timestamp": "1700000001",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu-1", "name": "tool_search",
+              "input": {"q": "read"}},
+         ]}},
+        {"type": "message", "timestamp": "1700000002",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu-1",
+              "is_error": False,
+              "content": [{"type": "text", "text": '{"matched":1}'}],
+              "details": catalog_payload},
+         ]}},
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    tool_spans = [s for s in spans if s.get("tool_name") == "tool_search"]
+    assert len(tool_spans) == 1, "exactly one tool_search span expected"
+    ts_span = tool_spans[0]
+    attrs = ts_span["attributes"]
+    assert attrs["tool.result_present"] is True
+    assert attrs["tool.result_is_error"] is False
+    assert attrs["tool.result_details"] == catalog_payload
+    assert attrs["tool.result_details_keys"] == ["matched", "tools"]
+    assert attrs["tool.result_text"] == '{"matched":1}'
+    # End-timestamp is stamped to the result's clock.
+    assert ts_span["end_ts"] == 1700000002.0
+
+
+def test_orphan_tool_result_is_silently_skipped():
+    """A tool_result whose tool_use_id never appeared upstream must not crash
+    the span builder, and must not produce a phantom span."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {"type": "message", "timestamp": "1700000002",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "ghost",
+              "details": {"x": 1}, "content": "ignored"},
+         ]}},
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    assert spans == []
+
+
+def test_tool_result_without_details_still_marks_result_present():
+    """Native (non-NemoClaw) tools omit `details`. We still want to flag that
+    the result arrived so consumers can distinguish in-flight from completed
+    tool calls."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {"type": "message", "timestamp": "1700000001",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu-9", "name": "Bash",
+              "input": {"command": "ls"}},
+         ]}},
+        {"type": "message", "timestamp": "1700000002",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu-9",
+              "content": "file1\nfile2\n"},
+         ]}},
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    bash = next(s for s in spans if s.get("tool_name") == "Bash")
+    attrs = bash["attributes"]
+    assert attrs["tool.result_present"] is True
+    assert "tool.result_details" not in attrs
+    assert "tool.result_details_keys" not in attrs
+    assert "tool.result_is_error" not in attrs
+    assert attrs["tool.result_text"] == "file1\nfile2\n"
+
+
+def test_tool_result_camelcase_tool_use_id_alias_supported():
+    """JS-side emitters sometimes carry the camelCase variant (toolUseId).
+    Accept both so we don't lose results from harness JSON shape drift."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {"type": "message", "timestamp": "1700000001",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu-77", "name": "Edit",
+              "input": {"file_path": "/x"}},
+         ]}},
+        {"type": "message", "timestamp": "1700000002",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "toolUseId": "tu-77",
+              "details": {"applied": True}},
+         ]}},
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    edit = next(s for s in spans if s.get("tool_name") == "Edit")
+    assert edit["attributes"]["tool.result_details"] == {"applied": True}


### PR DESCRIPTION
## Why

NemoClaw's injected `nemoClawBuildToolResult` helper (lives in the harness's `scripts/patch-openclaw-tool-catalog.js`, patched into openclaw's `dist/selection-*.js`) attaches a structured `details` payload on every `tool_search` / `tool_describe` / `tool_call` result block — the actual matched-tool list, schema, or dispatch output. That payload is the high-signal piece of the catalog: it's what surfaces what the agent really pulled.

But `_build_spans_from_events()` only walked `role=assistant` messages and only handled `tool_use` blocks inside them. `tool_result` blocks live in the *next* user-role message per Anthropic's content-block format, so we walked right past them. End result: spans + `Event.extra` never carried `details`, and the Tracing tab could only show the JSON-stringified text wrapper.

## Data flow now

1. Assistant message arrives → for each `tool_use` block we build the tool span as before AND register it in `tool_span_by_id[block.id]`.
2. User message arrives → if its content carries `tool_result` blocks, we look each one up by `tool_use_id` (snake_case) or `toolUseId` (camelCase, for the JS-shape variant some emitters use) and fold result info onto the originating span:
   - `tool.result_present = True` (always, so consumers can distinguish in-flight from completed)
   - `tool.result_is_error` (only when the block carries the flag)
   - `tool.result_details` (raw structured payload — catalog response, schema, dispatch output)
   - `tool.result_details_keys` (sorted dict keys, cheap to filter on without unpacking the full payload)
   - `tool.result_text` (collapsed string content, native-tool fallback or the NemoClaw JSON-stringified wrapper)
   - `end_ts` stamped from the tool_result event's clock
3. Orphan `tool_result` blocks (no matching `tool_use_id`) are silently skipped — never crash the builder.

## Verification

- New unit tests in `tests/test_obs_gap_talk_sandbox.py`:
  - `test_tool_result_details_attach_to_originating_tool_span` — full happy path with a NemoClaw-shaped catalog payload, asserts `details` + keys + text + `end_ts`.
  - `test_orphan_tool_result_is_silently_skipped` — defensive: spurious result doesn't crash and produces no phantom span.
  - `test_tool_result_without_details_still_marks_result_present` — native (non-NemoClaw) tools that omit `details` still get `tool.result_present` so consumers can flag completion.
  - `test_tool_result_camelcase_tool_use_id_alias_supported` — accept `toolUseId` as well as `tool_use_id` for JS-shape drift.
- `python3 -m pytest tests/test_obs_gap_talk_sandbox.py -x -q` → 14 passed.
- 3 pre-existing failures in `test_openclaw_claude_session_ingest.py` (`flusher did not drain in time`) reproduce on clean `origin/main` after `git stash` — unrelated to this change.
- `python3 -m py_compile` clean on both touched files.

## Backwards-compat story

Strictly additive. Existing assertions on the `tool_use` → tool-span mapping are byte-identical (the assistant branch was reorganized but its emit logic is untouched). New attribute keys are namespaced under `tool.result_*` so they can't collide with the existing `nemoclaw.*` catalog attrs. Spans missing a matching `tool_use_id` simply don't get the new attrs — the no-result-arrived case is indistinguishable from pre-fix behavior at the span level.

Closes #2733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)