### PR TITLE
fix(openclaw): surface MCP tool_result non-text block types + coercion metadata (#2731)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -532,21 +532,53 @@ class OpenClawAdapter(AgentAdapter):
                             attrs["tool.result_details"] = details
                             if isinstance(details, dict):
                                 attrs["tool.result_details_keys"] = sorted(details.keys())
-                        # Text content blocks (the JSON-stringified wrapper that
-                        # NemoClaw co-emits, or plain text from native tools)
-                        # collapsed into a single string for quick read.
+                        # Walk the tool_result content array. Text blocks
+                        # collapse into a single string for quick read
+                        # (NemoClaw JSON-stringified wrapper, or plain text
+                        # from native tools). Non-text block types
+                        # (resource_link, resource, audio, image) are
+                        # surfaced by sorted type-list so downstream UI can
+                        # see that MCP returned a non-text payload (#2731).
+                        # Coercion metadata (the harness preserves the
+                        # original block type when it materializes a
+                        # resource_link / resource / audio / malformed-image
+                        # into a text-safe shape) is recorded as
+                        # {from, to} pairs. Accepts the common field-name
+                        # variants seen in the wild.
                         result_content = block.get("content")
                         text_parts: list = []
+                        types_seen: set = set()
+                        coercions: list = []
                         if isinstance(result_content, str):
                             text_parts.append(result_content)
                         elif isinstance(result_content, list):
                             for inner in result_content:
-                                if isinstance(inner, dict) and inner.get("type") == "text":
+                                if not isinstance(inner, dict):
+                                    continue
+                                inner_type = inner.get("type")
+                                if isinstance(inner_type, str) and inner_type:
+                                    types_seen.add(inner_type)
+                                if inner_type == "text":
                                     val = inner.get("text")
                                     if isinstance(val, str):
                                         text_parts.append(val)
+                                coerced_from = (
+                                    inner.get("coerced_from")
+                                    or inner.get("coercedFrom")
+                                    or inner.get("original_type")
+                                    or inner.get("originalType")
+                                )
+                                if isinstance(coerced_from, str) and coerced_from:
+                                    coercions.append({
+                                        "from": coerced_from,
+                                        "to": inner_type if isinstance(inner_type, str) and inner_type else "unknown",
+                                    })
                         if text_parts:
                             attrs["tool.result_text"] = "".join(text_parts)
+                        if types_seen:
+                            attrs["tool.result_content_types"] = sorted(types_seen)
+                        if coercions:
+                            attrs["tool.result_coercions"] = coercions
                         target["attributes"] = attrs
                         # End-time the tool span to whatever the result arrived
                         # at. start_ts ≤ end_ts isn't enforced (assistant emits

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -254,3 +254,122 @@ def test_tool_result_camelcase_tool_use_id_alias_supported():
     spans = OpenClawAdapter._build_spans_from_events(events, "s1")
     edit = next(s for s in spans if s.get("tool_name") == "Edit")
     assert edit["attributes"]["tool.result_details"] == {"applied": True}
+
+
+# -- #2731 MCP tool_result non-text content blocks ---------------------------
+
+def test_tool_result_content_types_capture_non_text_blocks():
+    """OpenClaw's MCP path materializes tool_result content arrays that may
+    include resource_link, resource, audio, or malformed-image blocks
+    alongside text. The span builder must record every block type that
+    appears so downstream Tracing/Event.extra can tell a text-only result
+    from one that carried a resource or audio payload."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {"type": "message", "timestamp": "1700000001",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu-1", "name": "mcp__docs__fetch",
+              "input": {"id": "rfc-7807"}},
+         ]}},
+        {"type": "message", "timestamp": "1700000002",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu-1",
+              "content": [
+                  {"type": "text", "text": "fetched 1 doc"},
+                  {"type": "resource_link", "uri": "https://example/rfc7807",
+                   "title": "Problem Details"},
+              ]},
+         ]}},
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    tool_span = next(s for s in spans if s.get("tool_name") == "mcp__docs__fetch")
+    attrs = tool_span["attributes"]
+    assert attrs["tool.result_content_types"] == ["resource_link", "text"]
+    assert attrs["tool.result_text"] == "fetched 1 doc"
+
+
+def test_tool_result_coercion_metadata_surfaces_original_type():
+    """When the harness materializes a non-text MCP block at the boundary
+    (e.g. an audio block coerced into a text-safe wrapper), it preserves
+    the original block type on the coerced block. Capture {from, to} pairs
+    so consumers can tell raw text apart from a coerced payload."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {"type": "message", "timestamp": "1700000001",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu-2", "name": "mcp__media__play",
+              "input": {"track": "x"}},
+         ]}},
+        {"type": "message", "timestamp": "1700000002",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu-2",
+              "content": [
+                  {"type": "text",
+                   "text": "[audio omitted]",
+                   "coerced_from": "audio"},
+                  {"type": "text",
+                   "text": "[image omitted]",
+                   "originalType": "image"},
+              ]},
+         ]}},
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    tool_span = next(s for s in spans if s.get("tool_name") == "mcp__media__play")
+    attrs = tool_span["attributes"]
+    assert attrs["tool.result_coercions"] == [
+        {"from": "audio", "to": "text"},
+        {"from": "image", "to": "text"},
+    ]
+    assert attrs["tool.result_content_types"] == ["text"]
+    assert attrs["tool.result_text"] == "[audio omitted][image omitted]"
+
+
+def test_tool_result_resource_and_audio_only_blocks_visible():
+    """A tool_result with no text blocks (purely resource + audio) still
+    surfaces a content-types list; the text accumulator stays absent."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {"type": "message", "timestamp": "1700000001",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu-3", "name": "mcp__bundle__pull",
+              "input": {}},
+         ]}},
+        {"type": "message", "timestamp": "1700000002",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu-3",
+              "content": [
+                  {"type": "resource", "uri": "file:///x.bin"},
+                  {"type": "audio", "source": {"mime_type": "audio/wav"}},
+              ]},
+         ]}},
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    tool_span = next(s for s in spans if s.get("tool_name") == "mcp__bundle__pull")
+    attrs = tool_span["attributes"]
+    assert attrs["tool.result_content_types"] == ["audio", "resource"]
+    assert "tool.result_text" not in attrs
+
+
+def test_tool_result_string_content_does_not_emit_content_types():
+    """Pre-existing native-tool shape (content is a plain string, not a
+    block list) must not pick up a content_types attribute — that field
+    only describes block-array results."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {"type": "message", "timestamp": "1700000001",
+         "message": {"role": "assistant", "content": [
+             {"type": "tool_use", "id": "tu-4", "name": "Bash",
+              "input": {"command": "ls"}},
+         ]}},
+        {"type": "message", "timestamp": "1700000002",
+         "message": {"role": "user", "content": [
+             {"type": "tool_result", "tool_use_id": "tu-4",
+              "content": "file1\nfile2\n"},
+         ]}},
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    bash = next(s for s in spans if s.get("tool_name") == "Bash")
+    attrs = bash["attributes"]
+    assert "tool.result_content_types" not in attrs
+    assert "tool.result_coercions" not in attrs
+    assert attrs["tool.result_text"] == "file1\nfile2\n"


### PR DESCRIPTION
## Why

Closes #2731 (filed by `scripts/harness/audit.py`, fingerprint `hgap-28ed9240b0`).

OpenClaw's MCP path materializes `tool_result` content arrays that may carry
`resource_link`, `resource`, `audio`, or malformed-image blocks. The harness keeps some blocks as-is and coerces others into a text-safe wrapper at the materialize boundary, preserving the original block type on the coerced block. `_build_spans_from_events()` in `clawmetry/adapters/openclaw.py` previously only collected blocks whose `type == "text"` (see the post-#2733 walk) and silently dropped every other block type. Coerced `resource_link` / `resource` / `audio` payloads and any coercion metadata were therefore invisible to span reconstruction and never reached `Event.extra` via `list_events()`.

## What changed

In the existing `role == "user"` → `tool_result` fold-back branch in `clawmetry/adapters/openclaw.py`:

1. While walking the content list we now collect the **sorted unique set of block `type` values observed** under `tool.result_content_types` (e.g. `["resource_link", "text"]`).
2. We surface **per-block coercion metadata** under `tool.result_coercions` as a list of `{"from": <original_type>, "to": <coerced_type>}` pairs. The harness has shipped four field-name variants over time, so we accept all of `coerced_from`, `coercedFrom`, `original_type`, `originalType`.
3. Text accumulation, the `details` fold, `is_error`, `tool.result_text`, and `end_ts` stamping from #2733 are byte-identical — this is purely additive.

## Data flow

`OpenClaw JSONL` → `reconstruct_spans()` → `_build_spans_from_events()` → on user-role `tool_result` blocks, look up the originating tool span by `tool_use_id` (#2733), then walk `block.get("content")`:

- string → goes into `tool.result_text` only (no `content_types`, consistent with native-tool shape).
- list of dicts → each dict's `type` is recorded in `types_seen`; text blocks feed `text_parts`; any block carrying a coercion field appends `{from, to}` to `coercions`.

`types_seen` and `coercions` are stamped on `target["attributes"]` only when non-empty.

## Verification

- `python3 -m py_compile clawmetry/adapters/openclaw.py tests/test_obs_gap_talk_sandbox.py` → clean.
- `python3 -m pytest tests/test_obs_gap_talk_sandbox.py -x -q` → 18 passed (the existing 14 plus 4 new).
- Four new tests cover: `text + resource_link` mixed content (types list + text both surfaced), `text-from-audio + text-from-image` coerced blocks (both alias spellings exercised), `resource + audio only` with no text block (content_types present, `tool.result_text` absent), and the native-tool string-content negative case (no `content_types` / `coercions` emitted).

## Backwards-compat

Purely additive. Every attribute set by the post-#2733 walk is still set, with the same values. The new attributes (`tool.result_content_types`, `tool.result_coercions`) are stamped only when there is something to stamp, so spans from text-only or string-content tool_results stay shape-identical to before. Consumers that read the existing `tool.result_text` / `tool.result_details` / `tool.result_is_error` keys are untouched.

Closes #2731.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
