### PR TITLE
feat(entitlement): add `Entitlement.allows_retention_window()` — fourth `allows_*` axis

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -284,6 +284,39 @@ class Entitlement:
         """
         return _TIER_RETENTION_DAYS.get(self.tier, 7)
 
+    def allows_retention_window(self, days: int | None) -> bool:
+        """Whether the install may query / keep a retention window of ``days``
+        days of history.
+
+        Sibling to :meth:`allows_runtime`, :meth:`allows_feature`, and the
+        ``allows_node_count`` axis — gives the frontend (history-range toggles
+        like "7 / 30 / 90 / all") and the daemon's prune loop a single
+        canonical check, so neither has to re-derive tier→cap math.
+
+        Semantics:
+
+        * Grace mode: always ``True`` (no current behaviour changes pre-enforce).
+        * ``days <= 0``: ``True`` — asking for zero history is trivially fine
+          regardless of tier.
+        * Expired entitlement: ``False`` for any positive window.
+        * Enterprise (``event_retention_days() is None``): ``True`` for any
+          finite or ``None`` (unlimited) request.
+        * ``days is None`` (request unlimited) on a finite-cap tier: ``False``.
+        * Otherwise: ``days <= cap``.
+        """
+        if self.grace:
+            return True
+        if days is not None and days <= 0:
+            return True
+        if self.expired:
+            return False
+        cap = self.event_retention_days()
+        if cap is None:  # Enterprise: unlimited
+            return True
+        if days is None:  # caller asked for unlimited; only Enterprise grants it
+            return False
+        return days <= cap
+
     def to_dict(self) -> dict:
         return {
             "tier": self.tier,

--- a/tests/test_entitlements_retention_window.py
+++ b/tests/test_entitlements_retention_window.py
@@ -1,0 +1,176 @@
+"""Tests for ``Entitlement.allows_retention_window`` — per-tier history-window
+gate that mirrors the existing ``allows_runtime`` / ``allows_feature``
+``allows_node_count`` family.
+
+Companion to ``tests/test_entitlements_catalogue.py`` (which already pins the
+per-tier ``event_retention_days`` cap) — this file pins the *check method*
+that the frontend history-range toggles and the daemon's prune loop call.
+
+The headline invariants:
+
+* Grace mode (default OSS-free without ``CLAWMETRY_ENFORCE``) always returns
+  ``True`` — wiring the gate in changes no current behaviour.
+* Once enforce is on, every paid tier's window cap (Starter=30, Pro=90,
+  Enterprise=unlimited) is respected.
+* ``days <= 0`` is trivially allowed (asking for zero history is free).
+* ``days is None`` (request unlimited) only passes on Enterprise.
+* An expired entitlement denies any positive window.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _write_plan(tmp_path, plan, **extra):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    body = {"plan": plan}
+    body.update(extra)
+    cache.write_text(json.dumps(body))
+
+
+# ── grace mode ───────────────────────────────────────────────────────────────
+
+
+def test_grace_allows_any_window(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.allows_retention_window(7) is True
+    assert en.allows_retention_window(30) is True
+    assert en.allows_retention_window(365) is True
+    assert en.allows_retention_window(None) is True
+    assert en.allows_retention_window(0) is True
+    assert en.allows_retention_window(-1) is True
+
+
+# ── enforce mode: per-tier caps ──────────────────────────────────────────────
+
+
+def test_enforce_oss_caps_at_seven(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.grace is False
+    assert en.allows_retention_window(1) is True
+    assert en.allows_retention_window(7) is True       # at the cap
+    assert en.allows_retention_window(8) is False      # one day over
+    assert en.allows_retention_window(30) is False
+    assert en.allows_retention_window(None) is False   # unlimited denied
+
+
+def test_enforce_starter_caps_at_thirty(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    _write_plan(tmp_path, "cloud_starter")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_retention_window(7) is True
+    assert en.allows_retention_window(30) is True      # at the cap
+    assert en.allows_retention_window(31) is False
+    assert en.allows_retention_window(90) is False
+    assert en.allows_retention_window(None) is False
+
+
+def test_enforce_pro_caps_at_ninety(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    _write_plan(tmp_path, "cloud_pro")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_retention_window(30) is True
+    assert en.allows_retention_window(90) is True      # at the cap
+    assert en.allows_retention_window(91) is False
+    assert en.allows_retention_window(365) is False
+    assert en.allows_retention_window(None) is False
+
+
+def test_enforce_enterprise_is_unlimited(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    _write_plan(tmp_path, "enterprise")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_retention_window(7) is True
+    assert en.allows_retention_window(90) is True
+    assert en.allows_retention_window(10_000) is True
+    assert en.allows_retention_window(None) is True    # unlimited explicitly granted
+
+
+def test_enforce_trial_matches_starter_window(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    _write_plan(tmp_path, "trial")
+    en = ent.get_entitlement(force=True)
+    # Trial uses the Starter retention cap (30) per _TIER_RETENTION_DAYS.
+    assert en.allows_retention_window(30) is True
+    assert en.allows_retention_window(31) is False
+
+
+# ── edge cases ───────────────────────────────────────────────────────────────
+
+
+def test_zero_or_negative_days_is_allowed_on_oss(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_retention_window(0) is True
+    assert en.allows_retention_window(-5) is True
+
+
+def test_zero_days_is_allowed_even_when_expired(ent, monkeypatch, tmp_path):
+    """An expired tier still allows the trivial zero-day window — denying that
+    would force any consumer to special-case `0` before calling, defeating the
+    point of a single canonical check."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    _write_plan(tmp_path, "cloud_pro", expiry=time.time() - 3600)
+    en = ent.get_entitlement(force=True)
+    assert en.expired is True
+    assert en.allows_retention_window(0) is True
+
+
+def test_expired_paid_tier_denies_positive_window(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    _write_plan(tmp_path, "cloud_pro", expiry=time.time() - 3600)
+    en = ent.get_entitlement(force=True)
+    assert en.expired is True
+    assert en.allows_retention_window(1) is False
+    assert en.allows_retention_window(90) is False
+    assert en.allows_retention_window(None) is False
+
+
+def test_expired_enterprise_also_denies_positive_window(ent, monkeypatch, tmp_path):
+    """Even Enterprise (unlimited cap) denies positive windows once expired —
+    `expired` checks land before the cap lookup."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    _write_plan(tmp_path, "enterprise", expiry=time.time() - 3600)
+    en = ent.get_entitlement(force=True)
+    assert en.expired is True
+    assert en.allows_retention_window(7) is False
+    assert en.allows_retention_window(None) is False
+    # Zero-day window still trivially fine.
+    assert en.allows_retention_window(0) is True
+
+
+# ── consistency with event_retention_days() ──────────────────────────────────
+
+
+def test_window_check_at_cap_matches_event_retention_days(ent, monkeypatch, tmp_path):
+    """For every paid tier with a finite cap, `allows_retention_window(cap)` is
+    True and `allows_retention_window(cap + 1)` is False — pins the gate
+    against the catalogue table."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    for plan in ("cloud_starter", "cloud_pro", "trial"):
+        _write_plan(tmp_path, plan)
+        en = ent.get_entitlement(force=True)
+        cap = en.event_retention_days()
+        assert cap is not None, plan
+        assert en.allows_retention_window(cap) is True, plan
+        assert en.allows_retention_window(cap + 1) is False, plan
+        ent.invalidate()


### PR DESCRIPTION
## Summary

Adds a fourth `allows_*` method on `clawmetry.entitlements.Entitlement`, mirroring the existing `allows_runtime` / `allows_feature` / `allows_node_count` (the latter currently sitting in #2722) family. Gives the frontend history-range toggles ("7 / 30 / 90 / all") and the daemon's prune loop a single canonical check, so neither has to re-derive tier→cap math against `_TIER_RETENTION_DAYS`.

## What changes

- `clawmetry/entitlements.py` — new `Entitlement.allows_retention_window(days: int | None) -> bool` method (33 lines of code + docstring). No new constants, no catalogue changes; thin wrapper over the existing `event_retention_days()` lookup so the gate stays in lockstep with the per-tier cap.
- `tests/test_entitlements_retention_window.py` — 11 new tests pinning grace mode, every paid-tier cap, the edge cases, and a parametric `cap` / `cap+1` pin against the catalogue so any drift between `event_retention_days()` and the gate is caught in CI.

## Semantics

| Caller passes | Grace mode | Enforce + OSS | Enforce + Starter / Trial | Enforce + Pro | Enforce + Enterprise | Expired |
|---|---|---|---|---|---|---|
| `7`        | ✅ | ✅ (= cap) | ✅ | ✅ | ✅ | ❌ |
| `30`       | ✅ | ❌ | ✅ (= cap) | ✅ | ✅ | ❌ |
| `90`       | ✅ | ❌ | ❌ | ✅ (= cap) | ✅ | ❌ |
| `10000`    | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
| `None` (unlimited request) | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
| `0` / negative | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

Key invariants:

- **Grace mode always True** — wiring this in changes no current behaviour (open-core rollout is grace-first).
- **`days <= 0` is always True** — asking for zero history is trivially fine on any tier; otherwise every consumer would have to special-case `0` before calling, defeating the point of a single canonical check.
- **Expired beats everything except `0`** — a finite-cap tier that has expired denies any positive window, even on Enterprise (`expired` checks land before the cap lookup, matching `allows_runtime` / `allows_feature`).

## Why this is its own PR

- Tiny surface area (one method, no constants, no new wire format).
- Independent of the other open `allows_*` PRs (#2722 `allows_node_count`, #2727 `days_until_expiry`/`expires_within`, #2697 `gate_runtime`, #2674 `required_tier` in 402 body) — no shared lines, can land in any order.
- Doesn't touch any blueprint / route. A follow-up can wire `gate_retention_window` onto the daemon prune loop and the history-range API once this lands.

## Verification

- `python -m pytest tests/test_entitlements_retention_window.py` → 11 passed
- `python -m pytest tests/test_entitlements.py tests/test_entitlements_catalogue.py tests/test_entitlement_api.py` → 41 passed (no regression)
- `python -m ruff check clawmetry/entitlements.py tests/test_entitlements_retention_window.py` → clean
- `python -m py_compile` on both files → clean

The 5 failures in the broader `entitle|license|gate|retention` test sweep are all pre-existing on `origin/main` (`ModuleNotFoundError: duckdb` collection errors + one unrelated `/api/assets` gate test) — verified by stashing the diff and re-running; same failures appear.

## Local operator verification checklist

You're the only one who can finish this off — the agent can't reach your machine. Roughly:

- [ ] `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/entitlements.py`
- [ ] `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +` to clear stale bytecode
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or your platform's equivalent — `systemctl restart clawmetry-sync` on Linux) to restart the daemon
- [ ] Sanity-check the method is callable: `python -c "from clawmetry.entitlements import get_entitlement; e = get_entitlement(); print(e.allows_retention_window(30), e.allows_retention_window(0), e.allows_retention_window(None))"` → should print `True True True` in grace mode.
- [ ] Hit `curl -s http://localhost:8900/api/entitlement | jq .` — JSON shape unchanged (no new fields, since I deliberately didn't bolt this onto `to_dict()`; can be a follow-up).
- [ ] Decrypt the live cloud snapshot and confirm no shape change.
- [ ] Browser-check the dashboard loads with no new console errors — no UI surface here so nothing visible should change.

PR stays **draft** per house rules — operator drives the local-daemon + cloud verification + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013Gn2wvwHVid5fAv6i8aTdw)_