### PR TITLE
feat(entitlement): add Entitlement.channel_limit() + allows_channel_count() — channels corner of the per-tier quota family

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -208,6 +208,23 @@ _TIER_RETENTION_DAYS = {
     TIER_ENTERPRISE: None,
 }
 
+# Per-tier maximum number of distinct channel adapters the install may surface
+# in the dashboard (Telegram, Signal, Slack, …). ``None`` = unlimited. This is
+# the wire side of the ``all_channels`` Starter feature: Free taps cap at 3 so
+# the unlock has teeth, and every paid tier gets the full set of 21 adapters.
+# The channels route consults :meth:`Entitlement.allows_channel_count` (still
+# grace-gated) to enforce this without scattering tier checks into ``routes/``.
+_FREE_CHANNEL_LIMIT = 3
+_TIER_CHANNEL_LIMIT = {
+    TIER_OSS: _FREE_CHANNEL_LIMIT,
+    TIER_CLOUD_FREE: _FREE_CHANNEL_LIMIT,
+    TIER_TRIAL: None,
+    TIER_CLOUD_STARTER: None,
+    TIER_CLOUD_PRO: None,
+    TIER_PRO: None,
+    TIER_ENTERPRISE: None,
+}
+
 # Tiers that unlock the paid runtimes.
 _TIER_PAID_RUNTIMES = _PAID_TIERS
 
@@ -283,6 +300,60 @@ class Entitlement:
             Enterprise:      None  (custom)
         """
         return _TIER_RETENTION_DAYS.get(self.tier, 7)
+
+    def channel_limit(self) -> int | None:
+        """Maximum distinct channel adapters this tier may surface in the UI.
+        ``None`` means unlimited (every paid tier). Free / OSS caps at 3 so
+        the ``all_channels`` Starter unlock has teeth.
+
+        Grace mode (default) returns ``None`` so wiring this into the
+        channels route changes no current behaviour before the enforce
+        phase — same posture as :meth:`event_retention_days` etc.
+
+        Per-tier values (see ``_TIER_CHANNEL_LIMIT``):
+            Free / OSS:                3
+            Starter / Trial / Pro:  None  (all 21 adapters)
+            Enterprise:             None
+        """
+        if self.grace:
+            return None
+        return _TIER_CHANNEL_LIMIT.get(self.tier, _FREE_CHANNEL_LIMIT)
+
+    def allows_channel_count(self, current: int) -> bool:
+        """Whether ``current`` configured channel adapters still fit under
+        this entitlement's channel cap. Symmetric with
+        :meth:`allows_runtime` / :meth:`allows_feature` /
+        :meth:`allows_node_count` / :meth:`allows_retention_window` —
+        same never-crash contract so channels code can wire it in without
+        scattering tier checks.
+
+        Semantics (mirrors :meth:`allows_node_count`):
+
+        * Grace mode — always ``True`` (the rollout invariant).
+        * ``current <= 0`` — always ``True``. A zero/negative count is
+          either "not measured yet" or a fleet-table miss; either way it
+          should never be the thing that blocks a request.
+        * Expired entitlement — collapses to :data:`_FREE_CHANNEL_LIMIT`,
+          matching how :meth:`allows_runtime` falls back to free runtimes
+          on expiry.
+        * ``channel_limit() is None`` — unlimited tier, always ``True``.
+        * Otherwise — ``current <= channel_limit()``.
+
+        Non-int ``current`` is swallowed and returns ``True`` so a flaky
+        config read never blocks a request path.
+        """
+        if self.grace:
+            return True
+        try:
+            n = int(current)
+        except (TypeError, ValueError):
+            return True
+        if n <= 0:
+            return True
+        if self.expired:
+            return n <= _FREE_CHANNEL_LIMIT
+        lim = self.channel_limit()
+        return lim is None or n <= lim
 
     def to_dict(self) -> dict:
         return {

--- a/tests/test_entitlement_channel_limit.py
+++ b/tests/test_entitlement_channel_limit.py
@@ -1,0 +1,168 @@
+"""Tests for :meth:`Entitlement.channel_limit` /
+:meth:`Entitlement.allows_channel_count` — the channel-adapter cap that backs
+the ``all_channels`` Starter feature ("Free is limited to 3").
+
+Same grace/enforce posture as :meth:`allows_node_count` and
+:meth:`allows_retention_window`: wiring this into the channels route must not
+change behaviour before the enforce phase, and a flaky read must never block
+a request.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ``~/.clawmetry/license.key`` or ``cloud_plan.json`` leaks in.
+    Enforcement off by default — matches the project rollout posture."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── grace mode: pure pass-through ────────────────────────────────────────────
+
+
+def test_grace_channel_limit_is_none(ent):
+    """In grace mode every tier reports ``None`` (unlimited) so wiring this
+    into the channels route changes nothing before the enforce flip."""
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.channel_limit() is None
+
+
+def test_grace_allows_any_channel_count(ent):
+    """Headline rollout invariant: grace mode allows any count."""
+    en = ent.get_entitlement(force=True)
+    for count in (0, 1, 3, 4, 21, 100):
+        assert en.allows_channel_count(count) is True, count
+
+
+# ── enforce mode: free tier capped at 3, paid tiers unlimited ─────────────────
+
+
+def test_enforce_oss_caps_channels_at_three(ent, monkeypatch):
+    """OSS free in enforce mode caps at 3 channel adapters — the wire side
+    of the ``all_channels`` Starter unlock."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.grace is False
+    assert en.channel_limit() == 3
+    assert en.allows_channel_count(1) is True
+    assert en.allows_channel_count(3) is True
+    assert en.allows_channel_count(4) is False
+    assert en.allows_channel_count(21) is False
+
+
+def test_enforce_cloud_starter_is_unlimited(ent, monkeypatch, tmp_path):
+    """A Starter plan unlocks all 21 adapters — ``channel_limit()`` is
+    ``None`` and any reasonable count passes."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_starter"}))
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_CLOUD_STARTER
+    assert en.channel_limit() is None
+    assert en.allows_channel_count(4) is True
+    assert en.allows_channel_count(21) is True
+    assert en.allows_channel_count(100) is True
+
+
+def test_enforce_cloud_pro_and_enterprise_are_unlimited(ent, monkeypatch):
+    """Pro and Enterprise inherit the unlimited cap from Starter — the cap
+    is monotonic up the ladder, not bucketed by Pro-only / Enterprise-only."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    pro = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    ent_ent = ent._build(ent.TIER_ENTERPRISE, "license")
+    assert pro.channel_limit() is None
+    assert ent_ent.channel_limit() is None
+    assert pro.allows_channel_count(21) is True
+    assert ent_ent.allows_channel_count(21) is True
+
+
+def test_enforce_cloud_free_caps_at_three(ent, monkeypatch):
+    """Cloud Free (the signed-in-but-not-paying tier) matches OSS-free —
+    both sit on the same cap and the same unlock CTA."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent._build(ent.TIER_CLOUD_FREE, "cloud")
+    assert en.channel_limit() == 3
+    assert en.allows_channel_count(3) is True
+    assert en.allows_channel_count(4) is False
+
+
+# ── expiry: collapse to free cap ─────────────────────────────────────────────
+
+
+def test_enforce_expired_paid_plan_collapses_to_free_cap(ent, monkeypatch, tmp_path):
+    """Expired paid plans drop back to the free cap — mirrors how
+    :meth:`allows_runtime` falls back to free runtimes on expiry."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({
+        "plan": "cloud_pro",
+        "expiry": time.time() - 60,
+    }))
+    en = ent.get_entitlement(force=True)
+    assert en.expired is True
+    assert en.allows_channel_count(3) is True
+    assert en.allows_channel_count(4) is False
+
+
+# ── edge cases ───────────────────────────────────────────────────────────────
+
+
+def test_enforce_zero_and_negative_current_always_allowed(ent, monkeypatch):
+    """``current=0`` (no channels configured yet) and stray negatives never
+    block — same never-crash posture as the rest of the entitlements module."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_channel_count(0) is True
+    assert en.allows_channel_count(-1) is True
+    assert en.allows_channel_count(-99) is True
+
+
+def test_enforce_non_int_current_is_swallowed(ent, monkeypatch):
+    """A non-int ``current`` (e.g. ``None`` from a config-table miss) must
+    not crash — falls through to allowed so a flaky read never blocks the
+    channels route."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_channel_count(None) is True
+    assert en.allows_channel_count("not-a-number") is True
+    assert en.allows_channel_count(object()) is True
+
+
+def test_enforce_string_int_current_is_accepted(ent, monkeypatch):
+    """Numeric strings (``"4"``) coerce cleanly — defensive convenience for
+    a count read from a query string parameter."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_channel_count("3") is True
+    assert en.allows_channel_count("4") is False  # OSS caps at 3
+
+
+# ── consistency with the rest of the allows_* family ─────────────────────────
+
+
+def test_grace_allows_family_is_symmetric(ent):
+    """In grace mode every gate corner returns True — the rollout invariant
+    the channels route now joins. Same property test as
+    ``test_grace_triad_is_symmetric`` (in ``tests/test_entitlements.py``),
+    extended to the new channel-count corner."""
+    en = ent.get_entitlement(force=True)
+    assert en.allows_runtime("claude_code") is True
+    assert en.allows_feature("self_evolve") is True
+    assert en.allows_channel_count(21) is True


### PR DESCRIPTION
## What

Adds the channel-adapter side of the open-core quota family to `clawmetry/entitlements.py`. The `all_channels` Starter feature documents "Free is limited to 3 adapters" — until now there was no helper that actually expressed that cap. This adds two:

```python
Entitlement.channel_limit() -> int | None
Entitlement.allows_channel_count(current: int) -> bool
```

…plus a `_TIER_CHANNEL_LIMIT` map next to the existing `_TIER_RETENTION_DAYS` map. Free / OSS / Cloud-Free cap at 3, every paid tier is unlimited (`None`).

## Where this fits

Sits alongside the other `allows_*` corners that have been landing recently:

| Helper                       | PR     | Status |
|------------------------------|--------|--------|
| `allows_runtime`             | (in main) | merged |
| `allows_feature`             | (in main) | merged |
| `allows_node_count`          | #2722  | open   |
| `allows_retention_window`    | #2790  | open   |
| `allows_channel_count`       | **this PR** | draft |

This PR is fully independent of #2722 / #2790 — no method-name overlap, no shared dict, no test cross-import.

## Semantics (mirrors `allows_node_count`)

* **Grace mode (default)** — always `True`, `channel_limit()` returns `None`. Wiring this into `routes/channels.py` therefore changes no current behaviour before the enforce phase. Headline rollout invariant.
* **`current <= 0`** — always `True`. Zero/negative is "not measured yet" or a config-table miss; never the thing that blocks a request.
* **Expired entitlement** — collapses to `_FREE_CHANNEL_LIMIT` (3), matching how `allows_runtime` falls back to free runtimes on expiry.
* **`channel_limit() is None`** — unlimited tier, always `True`.
* **Otherwise** — `current <= channel_limit()`.
* **Non-int `current`** (`None`, stray string, object) — swallowed to `True` so a flaky config read never blocks the channels route.

## Tests

`tests/test_entitlement_channel_limit.py` covers:

* grace pass-through (channel_limit is None, any count allowed)
* enforce-mode caps for OSS, Cloud-Free, Cloud-Starter, Cloud-Pro, Enterprise
* the expiry collapse back to the Free cap
* edge cases (zero / negative / non-int / numeric strings)
* the symmetry invariant: grace mode keeps every `allows_*` corner returning `True`

```
$ python3 -m pytest tests/test_entitlement_channel_limit.py tests/test_entitlements.py tests/test_entitlements_catalogue.py tests/test_entitlement_api.py
52 passed in 0.39s
```

Ruff clean on the two changed files (`make lint` failures on `dashboard.py` are pre-existing and unrelated).

## Rollout posture

* Stays in **GRACE** end to end — no route change, no behaviour change.
* No `__version__` bump, no tag, no `[RELEASE]` PR. Local operator owns the release loop per `FLYWHEEL.md`.

## Local operator verification checklist

(Cannot be performed remotely from this PR — listed so the operator can run them when picking this up.)

- [ ] Copy `clawmetry/entitlements.py` + `tests/test_entitlement_channel_limit.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and clear `__pycache__`
- [ ] `python3 -m pytest tests/test_entitlement_channel_limit.py -q` locally
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to reload the daemon
- [ ] Hit `/api/entitlement` — confirm the JSON shape is unchanged (this PR does not add fields to the API yet; the helper is library-only)
- [ ] Spot-check via `python3 -c "from clawmetry import entitlements as e; ent = e.get_entitlement(); print(ent.channel_limit(), ent.allows_channel_count(21))"` — should print `None True` in grace mode
- [ ] Decrypt the live cloud snapshot, confirm no regression in the channels tab
- [ ] Browser check `/dashboard` — channels list still renders all configured adapters

## Out of scope

* Wiring `allows_channel_count` into `routes/channels.py` (separate PR — keeps this one purely additive on the entitlements layer).
* Surfacing `channel_limit` on the `/api/entitlement` response body (the existing `to_dict()` already serialises features/runtimes; quota fields can land together once the family stabilises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uttp4tHcswGu8igyKCwJpj)_