### PR TITLE
[RELEASE] fix(brain): stamp sessionId on brain-cache events for per-session feeds

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6788,13 +6788,26 @@ def _rows_to_brain_events(rows: list) -> list:
                 # dashboard.py) can show "CHANNEL.IN" / "CHANNEL.OUT"
                 # rather than guessing from a missing role.
                 data.setdefault("type", r.get("event_type"))
+            # Stamp the session id so per-session feeds (the desk device's live
+            # feed + cloud Brain filtering) can attribute each event. Family
+            # runtime payloads (claude_code/codex/…) carry NO sessionId inside
+            # ``data`` -- only the row's top-level session_id column has it, so
+            # the device's per-session filter matched nothing and every session
+            # showed the same node-wide feed. Use the BARE uuid (drop the
+            # ``runtime:`` namespace) so it matches the device-agent session ids
+            # (#1465). Never overwrite a sessionId the payload already carries.
+            _sid = r.get("session_id")
+            if _sid and not data.get("sessionId") and not data.get("session_id"):
+                data = {**data, "sessionId": _sid.rsplit(":", 1)[-1]}
             out.append(data)
         elif isinstance(data, str):
+            _sid = r.get("session_id")
             out.append({
                 **enrich,
                 "type":      r.get("event_type") or "raw",
                 "timestamp": r.get("ts", ""),
                 "detail":    data[:2000],
+                **({"sessionId": _sid.rsplit(":", 1)[-1]} if _sid else {}),
             })
     return out
 


### PR DESCRIPTION
## The bug
`_rows_to_brain_events` forwards each row's inner JSONL `data` payload to the brain cache. Family-runtime payloads (claude_code, codex, …) carry **no sessionId inside `data`** — only the DuckDB row's top-level `session_id` column has it. So every brain event reached the cloud + desk device with **no session attribution**, and the device's per-session live feed matched nothing → every session showed the same node-wide feed (or "No activity for this session yet").

This is the second half of the live-feed fix (the first, #2807, unfroze the *freshness* — events were 70h stale; this one restores *per-session attribution*).

## The fix
Stamp the **bare uuid** (drop the `runtime:` namespace) onto each event from the row's `session_id`, matching the device-agent session ids (#1465). Never overwrites a sessionId the payload already carries. Covers both the dict-data and string-data branches.

## Verification
On live DuckDB rows: **500/500** brain events now carry `sessionId` (e.g. `e149acae-8789-…`), bare-uuid form matching the device filter. Decrypted the live cloud blob — before: 0/200 events had sessionId; after this lands they will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)