### PR TITLE
feat(entitlement): surface retention_days in to_dict() + /api/entitlement

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -299,6 +299,11 @@ class Entitlement:
             "free_runtimes": sorted(FREE_RUNTIMES),
             "paid_runtimes": sorted(PAID_RUNTIMES),
             "all_runtimes": sorted(ALL_RUNTIMES),
+            # Derived per-tier quota — the dashboard's data-retention badge and
+            # history-range picker read this off /api/entitlement so the UI can
+            # render "data retained for N days" without a second round trip.
+            # None = unlimited / custom (Enterprise).
+            "retention_days": self.event_retention_days(),
         }
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -49,6 +49,7 @@ def api_entitlement():
                 "enforced": False,
                 "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
+                "retention_days": 7,
             }
         )
 

--- a/tests/test_entitlement_retention_in_todict.py
+++ b/tests/test_entitlement_retention_in_todict.py
@@ -1,0 +1,213 @@
+"""Pin ``retention_days`` in :meth:`Entitlement.to_dict` and on
+``/api/entitlement``.
+
+``Entitlement.event_retention_days()`` has been the canonical per-tier quota for
+months, but the wire format the dashboard reads on every page load
+(``/api/entitlement``) did not include it — every consumer had to call a second
+endpoint or hardcode the per-tier number to render "data retained for N days".
+
+The :meth:`to_dict` serializer now surfaces the same value under
+``retention_days`` so:
+
+* the dashboard's data-retention badge and history-range picker can read it off
+  ``/api/entitlement`` directly,
+* the API fallback returns the OSS-free default (``7``) instead of dropping the
+  key entirely, and
+* a future drift between :meth:`Entitlement.event_retention_days` and the
+  catalogue cap is caught in CI.
+
+This file is the parametric pin across every published tier, plus the API
+shape + safe-fallback paths in ``routes/entitlement.py::api_entitlement``.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so
+    real ``~/.clawmetry/license.key`` / ``cloud_plan.json`` never leak in.
+    Enforcement off by default."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client wired with bp_entitlement and a clean HOME."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client(), tmp_path
+
+
+def _write_cloud_plan(tmp_path, plan: str, **extra):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    body = {"plan": plan}
+    body.update(extra)
+    cache.write_text(json.dumps(body))
+
+
+# ── to_dict() pins ────────────────────────────────────────────────────────────
+
+
+def test_to_dict_includes_retention_days_in_grace(ent):
+    d = ent.get_entitlement(force=True).to_dict()
+    assert "retention_days" in d
+    # OSS / grace defaults to the published 7-day cap.
+    assert d["retention_days"] == 7
+
+
+def test_to_dict_retention_matches_event_retention_days(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.to_dict()["retention_days"] == en.event_retention_days()
+
+
+@pytest.mark.parametrize(
+    "plan, expected",
+    [
+        ("cloud_free", 7),
+        ("cloud_starter", 30),
+        ("trial", 30),
+        ("cloud_pro", 90),
+        ("pro", 90),
+        ("enterprise", None),
+    ],
+)
+def test_to_dict_retention_per_tier(ent, tmp_path, monkeypatch, plan, expected):
+    """Every cloud-plan tier surfaces its catalogue retention through
+    ``to_dict`` — no drift between the dict and ``event_retention_days``."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    _write_cloud_plan(tmp_path, plan)
+    ent.invalidate()
+    d = ent.get_entitlement(force=True).to_dict()
+    assert d["retention_days"] == expected
+    # The whole point of the field is the dashboard can render it without
+    # calling event_retention_days() separately — pin the symmetry.
+    assert d["retention_days"] == ent.get_entitlement().event_retention_days()
+
+
+def test_to_dict_retention_unaffected_by_grace_flip(ent, monkeypatch):
+    """Toggling enforcement does not change the per-tier cap — only the gate
+    bypass — so ``retention_days`` should be identical in grace vs enforce
+    on the same tier."""
+    grace_val = ent.get_entitlement(force=True).to_dict()["retention_days"]
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforce_val = ent.get_entitlement(force=True).to_dict()["retention_days"]
+    assert grace_val == enforce_val == 7
+
+
+def test_to_dict_existing_keys_preserved(ent):
+    """Adding ``retention_days`` must not drop any pre-existing field — the
+    dashboard reads ``tier``, ``runtimes``, ``features`` etc. on every load."""
+    d = ent.get_entitlement(force=True).to_dict()
+    for key in (
+        "tier",
+        "source",
+        "node_limit",
+        "expiry",
+        "expired",
+        "is_paid",
+        "grace",
+        "enforced",
+        "runtimes",
+        "features",
+        "free_runtimes",
+        "paid_runtimes",
+        "all_runtimes",
+        "retention_days",
+    ):
+        assert key in d, key
+
+
+# ── /api/entitlement shape ────────────────────────────────────────────────────
+
+
+def test_api_entitlement_includes_retention_days_in_grace(client):
+    c, _ = client
+    d = c.get("/api/entitlement").get_json()
+    assert "retention_days" in d
+    assert d["retention_days"] == 7
+
+
+def test_api_entitlement_retention_for_paid_tier(monkeypatch, tmp_path):
+    """A cached cloud-pro plan should bubble its 90-day cap through the API."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    _write_cloud_plan(tmp_path, "cloud_pro")
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement").get_json()
+    assert d["tier"] == "cloud_pro"
+    assert d["retention_days"] == 90
+
+
+def test_api_entitlement_retention_for_enterprise_is_null(monkeypatch, tmp_path):
+    """Enterprise is unlimited — the API must serialise that as JSON ``null``,
+    not a sentinel int, so the UI never renders ``-1 days``."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    _write_cloud_plan(tmp_path, "enterprise")
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement").get_json()
+    assert d["tier"] == "enterprise"
+    assert d["retention_days"] is None
+
+
+def test_api_entitlement_safe_fallback_includes_retention(monkeypatch):
+    """When ``get_entitlement`` itself blows up, the dashboard still gets a
+    safe OSS-free shape — including ``retention_days`` so the data-retention
+    badge degrades gracefully rather than disappearing."""
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+
+    import clawmetry.entitlements as e
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(e, "get_entitlement", _boom)
+    d = app.test_client().get("/api/entitlement").get_json()
+    assert d["tier"] == "oss"
+    assert d["retention_days"] == 7


### PR DESCRIPTION
## Summary

Plumb `Entitlement.event_retention_days()` through the wire format so the dashboard can render "data retained for N days" off `/api/entitlement` directly, without a second round-trip or a hardcoded per-tier ladder in JavaScript.

This is the explicit follow-up #2790 flagged: *"I deliberately didn't bolt this onto `to_dict()`; can be a follow-up."*

## Where this fits

The five quota axes are converging on a uniform shape — `to_dict()` already serialises `node_limit`; this PR adds the retention sibling:

| Axis            | Helper                          | In `to_dict()` |
|-----------------|---------------------------------|----------------|
| Runtime         | `allows_runtime()`              | yes (`runtimes`) |
| Feature         | `allows_feature()`              | yes (`features`) |
| Node count      | `node_limit` field              | yes (`node_limit`) |
| **Retention**   | `event_retention_days()`        | **this PR** (`retention_days`) |
| Retention gate  | `allows_retention_window()` (#2790) | not yet (PR-2790 follow-up) |

Independent of the other in-flight `allows_*` PRs (#2722 `allows_node_count`, #2790 `allows_retention_window`, #2792 `allows_channel_count`) — no method overlap, no shared constants, no test cross-import. Touches the serialiser only; the gate semantics those PRs add are untouched.

## Changes

- **`clawmetry/entitlements.py`** — `Entitlement.to_dict()` emits `retention_days = self.event_retention_days()`. Enterprise (unlimited) round-trips as JSON `null` so the UI never renders "-1 days".
- **`routes/entitlement.py`** — the never-raise safe fallback in `api_entitlement` also emits `retention_days: 7` so a flaky resolver doesn't drop the field. The data-retention badge degrades gracefully instead of disappearing.
- **`tests/test_entitlement_retention_in_todict.py`** *(new, 14 tests)* — pins the field in `to_dict()` across grace and every published tier, the symmetry with `event_retention_days()` so any future drift is caught in CI, enterprise serialising as `null` on the wire, and the safe-fallback path including the field.

## Semantics

| Tier            | `retention_days` | JSON wire |
|-----------------|------------------|-----------|
| OSS / Cloud-Free | 7               | `7`       |
| Cloud-Starter / Trial | 30          | `30`      |
| Cloud-Pro / Self-host Pro | 90      | `90`      |
| Enterprise      | None             | `null`    |

The value is independent of the grace flag — only the gate behaviour changes with enforcement, not the catalogue cap.

## Rollout posture

- Stays in **GRACE** end-to-end. No route change, no behaviour change.
- No `__version__` bump, no tag, no `[RELEASE]` PR. Local operator owns the release loop per `FLYWHEEL.md`.
- Purely additive on the wire — existing consumers that don't read `retention_days` are unaffected.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_retention_in_todict.py -v` — **14/14 pass in 0.21s**
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_license.py tests/test_license_api.py tests/test_extensions.py` — **85/85 pass** (no regression in adjacent surfaces)
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_retention_in_todict.py` — syntax clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_retention_in_todict.py` — clean

## Local operator verification checklist

I cannot reach the user's local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please complete on a real install:

1. `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/entitlements.py`
2. `cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/entitlement.py`
3. `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
4. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. `curl -s http://localhost:8900/api/entitlement | jq .retention_days` → should print `7` on OSS / grace.
6. With a Pro key installed (`clawmetry license activate <KEY>`), re-curl `/api/entitlement` and confirm `retention_days` is `90`.
7. Confirm every other existing field on `/api/entitlement` (`tier`, `runtimes`, `features`, `grace`, `enforced`, …) is unchanged — this PR only *adds* a key, never removes one.
8. Decrypt the live cloud snapshot and confirm no daemon-side regression — this PR is dashboard-only; the snapshot shape is unchanged.
9. Browser-check the dashboard — no UI surface consumes `retention_days` yet (frontend wiring is a follow-up); every existing tab should render exactly as before.

This PR is **draft-only**: not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Grace mode stays on. Once you've run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01REycoWwjzbcXWkfh77V4BD)_