### PR TITLE
fix(openclaw): surface per-sandbox inference config on DetectResult.meta (#2796)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -116,6 +116,73 @@ def _model_router_fingerprint() -> dict:
         return {}
 
 
+def _sandbox_inference_configs() -> list:
+    """Read per-sandbox inference config from ~/.nemoclaw/sandboxes.json.
+
+    Mirrors getSandboxInferenceConfig() (nemoclaw/src/lib/inference/config.ts)
+    to surface providerKey / primaryModelRef / inferenceBaseUrl / inferenceApi /
+    inferenceCompat on DetectResult.meta (gap #2796). The identical derivation
+    lives in sync._read_nemoclaw_sandbox_routing (#2684); this helper makes it
+    available in the adapter layer without importing the heavy sync module.
+    Never raises — returns [] on plain OpenClaw (no sandboxes.json).
+    """
+    home = os.environ.get("HOME") or os.path.expanduser("~")
+    reg = os.path.join(home, ".nemoclaw", "sandboxes.json")
+    out: list = []
+    try:
+        with open(reg, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception:
+        return out
+    if not isinstance(data, dict):
+        return out
+    default_sb = data.get("defaultSandbox")
+    sandboxes = data.get("sandboxes")
+    if not isinstance(sandboxes, dict):
+        return out
+    _MANAGED = "inference"
+    _MANAGED_URL = "https://inference.local/v1"
+    for name, entry in sandboxes.items():
+        try:
+            if not isinstance(entry, dict):
+                continue
+            provider = entry.get("provider") or ""
+            model = entry.get("model") or ""
+            api = entry.get("preferredInferenceApi") or "openai-completions"
+            base_url = _MANAGED_URL
+            if provider == "openai-api":
+                provider_key = "openai"
+                primary = f"openai/{model}" if model else ""
+                compat = "openai"
+            elif provider == "anthropic-prod" or (
+                provider == "compatible-anthropic-endpoint"
+                and api != "openai-completions"
+            ):
+                provider_key = "anthropic"
+                primary = f"anthropic/{model}" if model else ""
+                base_url = "https://inference.local"
+                api = "anthropic-messages"
+                compat = "anthropic"
+            else:
+                provider_key = _MANAGED
+                primary = f"{_MANAGED}/{model}" if model else ""
+                compat = "openai"
+            out.append({
+                "sandbox": name,
+                "isDefault": bool(default_sb and name == default_sb),
+                "provider": provider,
+                "model": model,
+                "providerKey": provider_key,
+                "primaryModelRef": primary,
+                "inferenceBaseUrl": base_url,
+                "inferenceApi": api,
+                "inferenceCompat": compat,
+            })
+        except Exception:
+            continue
+    return out
+
+
 # NOTE (#2610, deferred): NemoClaw's skill-catalog version/provenance lives in
 # ``skills/catalog-metadata.json`` (min/tested NemoClaw version, content shas),
 # but that file is a SOURCE-repo build artifact — it is not shipped in the npm
@@ -270,6 +337,11 @@ class OpenClawAdapter(AgentAdapter):
             _tc_kind = _openclaw_tool_catalog_kind()
             if _tc_kind is not None:
                 meta["openclawToolCatalogKind"] = _tc_kind
+            # Per-sandbox inference config (#2796): providerKey/primaryModelRef/
+            # inferenceBaseUrl/inferenceApi/inferenceCompat from sandboxes.json.
+            _sb_configs = _sandbox_inference_configs()
+            if _sb_configs:
+                meta["sandboxInferenceConfigs"] = _sb_configs
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -9,6 +9,9 @@ Covers:
   the harness getSandboxInferenceConfig switch (compatible-anthropic-endpoint
   with the default api routes to the MANAGED 'inference' provider).
 - #2608 _model_router_fingerprint — parse git:<sha> from the fingerprint file.
+- #2796 _sandbox_inference_configs — providerKey/primaryModelRef/inferenceBaseUrl/
+  inferenceApi/inferenceCompat surfaced on DetectResult.meta for all NemoClaw
+  sandboxes (mirrors getSandboxInferenceConfig from nemoclaw/src/lib/inference/config.ts).
 """
 import json
 import os
@@ -16,7 +19,7 @@ import os
 import pytest
 
 from clawmetry.sync import parse_talk_lifecycle_line, _read_nemoclaw_sandbox_routing
-from clawmetry.adapters.openclaw import _model_router_fingerprint
+from clawmetry.adapters.openclaw import _model_router_fingerprint, _sandbox_inference_configs
 
 
 # -- #2604 talk parser -------------------------------------------------------
@@ -373,3 +376,70 @@ def test_tool_result_string_content_does_not_emit_content_types():
     assert "tool.result_content_types" not in attrs
     assert "tool.result_coercions" not in attrs
     assert attrs["tool.result_text"] == "file1\nfile2\n"
+
+
+# -- #2796 _sandbox_inference_configs ----------------------------------------
+
+def test_sandbox_inference_configs_empty_when_no_file(tmp_path, monkeypatch):
+    """No sandboxes.json -> empty list, no effect on plain OpenClaw installs."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert _sandbox_inference_configs() == []
+
+
+def test_sandbox_inference_configs_anthropic_prod(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": "main",
+        "sandboxes": {
+            "main": {"provider": "anthropic-prod", "model": "claude-opus-4-5"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    r = result[0]
+    assert r["providerKey"] == "anthropic"
+    assert r["primaryModelRef"] == "anthropic/claude-opus-4-5"
+    assert r["inferenceApi"] == "anthropic-messages"
+    assert r["inferenceCompat"] == "anthropic"
+    assert r["isDefault"] is True
+
+
+def test_sandbox_inference_configs_openai_api(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": None,
+        "sandboxes": {
+            "coding": {"provider": "openai-api", "model": "gpt-4o"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    r = result[0]
+    assert r["providerKey"] == "openai"
+    assert r["primaryModelRef"] == "openai/gpt-4o"
+    assert r["inferenceCompat"] == "openai"
+    assert r["isDefault"] is False
+
+
+def test_sandbox_inference_configs_managed_default(tmp_path, monkeypatch):
+    """compatible-anthropic-endpoint + default api -> MANAGED inference provider."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": "dev",
+        "sandboxes": {
+            "dev": {"provider": "compatible-anthropic-endpoint", "model": "llama3"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    r = result[0]
+    assert r["providerKey"] == "inference"
+    assert r["inferenceApi"] == "openai-completions"
+    assert r["inferenceCompat"] == "openai"
+    assert r["isDefault"] is True


### PR DESCRIPTION
## Summary

Gap #2796: `OpenClawAdapter.detect()` never read `~/.nemoclaw/sandboxes.json`, so multi-provider NemoClaw deployments had no way to see which inference provider, model ref, or endpoint URL each sandbox was using. This adds a `_sandbox_inference_configs()` helper that mirrors `getSandboxInferenceConfig()` from the harness and stamps the result onto `DetectResult.meta["sandboxInferenceConfigs"]`.

## Changes

- `clawmetry/adapters/openclaw.py` — adds `_sandbox_inference_configs()` helper (~58 lines) after `_model_router_fingerprint()`, following the same pattern; wires it into `OpenClawAdapter.detect()` (3 lines). Returns `[]` and is a no-op on plain OpenClaw (file absent), so there is zero behaviour change for non-NemoClaw installs.
- `tests/test_obs_gap_talk_sandbox.py` — adds 4 new tests covering `anthropic-prod` provider key derivation, `openai-api` provider key, managed `compatible-anthropic-endpoint` default, and missing-file no-op. All 22 tests in the file pass.

## Implementation note

The identical derivation logic (`getSandboxInferenceConfig` switch) already lives in `sync.py::_read_nemoclaw_sandbox_routing` (#2684). This PR ports it to the adapter layer rather than importing the heavy 10 k-line sync module, keeping the adapter self-contained.

## Test plan

- [x] `python3 -m pytest tests/test_obs_gap_talk_sandbox.py -v` — 22/22 pass (4 new + 18 existing), no regressions
- [x] `python3 -m py_compile clawmetry/adapters/openclaw.py` — syntax clean
- [ ] On a machine without `~/.nemoclaw/sandboxes.json`: verify `detect().meta` has no `sandboxInferenceConfigs` key
- [ ] On a NemoClaw install: verify `detect().meta["sandboxInferenceConfigs"]` lists each sandbox with correct `providerKey` / `primaryModelRef` / `inferenceApi`

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #2796. Marked draft for human review — mark Ready for Review once happy.

Closes #2796

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzEKqkf8oRDWkNY1H7CC4a)_