### PR TITLE
feat(otel): accept OpenLLMetry traffic end to end (OTLP/JSON+gzip, indexed prompts, service.name runtime, gen_ai metrics + live tiles)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -164,6 +164,76 @@ except ImportError:
     trace_service_pb2 = None
     logs_service_pb2 = None
 
+
+def _otlp_decode(pb_data, proto_msg, content_encoding=None, content_type=None):
+    """Decode an OTLP/HTTP request body into ``proto_msg`` and return it.
+
+    OpenLLMetry / traceloop-sdk and the OTel SDKs can export over three
+    on-the-wire encodings that all map onto the same proto message:
+
+      * ``application/x-protobuf``                 → ``ParseFromString`` (binary);
+      * ``application/json``                       → ``json_format.Parse`` (OTLP/JSON);
+      * any of the above wrapped in ``Content-Encoding: gzip``.
+
+    We normalise here so the downstream ``_process_otlp_*`` mappers stay
+    encoding-agnostic. Raises on malformed input (the caller turns that into a
+    400, never a 500 stacktrace leak)."""
+    ce = (content_encoding or "").lower()
+    if "gzip" in ce:
+        import gzip as _gzip
+        pb_data = _gzip.decompress(pb_data)
+    ct = (content_type or "").lower()
+    if "application/json" in ct or "application/x-ndjson" in ct:
+        from google.protobuf import json_format as _json_format
+        # ignore_unknown_fields: OTLP/JSON producers occasionally add
+        # forward-compat keys; tolerate them rather than 400 the whole batch.
+        _json_format.Parse(
+            pb_data.decode("utf-8") if isinstance(pb_data, (bytes, bytearray)) else pb_data,
+            proto_msg,
+            ignore_unknown_fields=True,
+        )
+    else:
+        proto_msg.ParseFromString(pb_data)
+    return proto_msg
+
+
+def _otlp_service_name_to_agent_type(service_name):
+    """Map an OTLP resource ``service.name`` onto a ClawMetry ``agent_type``.
+
+    OpenLLMetry-instrumented apps ("bring your own agent") set
+    ``service.name`` to their app name (the traceloop-sdk default is
+    ``"unknown_service"`` but most apps override it, e.g.
+    ``"my-langchain-app"``). Without this every foreign span defaulted to
+    ``agent_type="openclaw"`` and mis-bucketed under the OpenClaw runtime
+    filter. We instead:
+
+      * keep ``"openclaw"`` for OpenClaw / ClawMetry-known emitters (so existing
+        OpenClaw OTLP flows are unchanged);
+      * slugify any other name to ``[a-z0-9_]`` (``"my-langchain-app"`` →
+        ``"my_langchain_app"``) so the app shows up as its OWN runtime/agent in
+        the spans + ``/api/v1/*?runtime=`` (agent_type) views;
+      * fall back to ``"custom"`` when ``service.name`` is absent or empty.
+
+    Returns ``None`` to signal "no opinion" (caller keeps its own default) only
+    when the input is not a string."""
+    if service_name is None:
+        return "custom"
+    if not isinstance(service_name, str):
+        return None
+    raw = service_name.strip()
+    if not raw:
+        return "custom"
+    low = raw.lower()
+    # OpenClaw / ClawMetry-known emitters stay 'openclaw' so we don't break the
+    # existing OpenClaw OTLP path or leak it out of the OpenClaw runtime view.
+    if low in ("openclaw", "clawmetry", "clawmetry-sync", "clawmetry_sync",
+               "openclaw-gateway", "openclaw_gateway", "unknown_service"):
+        return "openclaw"
+    import re as _re
+    slug = _re.sub(r"[^a-z0-9_]+", "_", low).strip("_")
+    return slug or "custom"
+
+
 __version__ = "0.12.467"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
@@ -2050,10 +2120,14 @@ def _get_dp_attrs(dp):
     return attrs
 
 
-def _process_otlp_metrics(pb_data):
-    """Decode OTLP metrics protobuf and store relevant data."""
-    req = metrics_service_pb2.ExportMetricsServiceRequest()
-    req.ParseFromString(pb_data)
+def _process_otlp_metrics(pb_data, content_encoding=None, content_type=None):
+    """Decode OTLP metrics protobuf/JSON and store relevant data."""
+    req = _otlp_decode(
+        pb_data,
+        metrics_service_pb2.ExportMetricsServiceRequest(),
+        content_encoding,
+        content_type,
+    )
 
     for resource_metrics in req.resource_metrics:
         resource_attrs = {}
@@ -2188,6 +2262,63 @@ def _process_otlp_metrics(pb_data):
                                     "channel", resource_attrs.get("channel", "")
                                 ),
                                 "type": wtype,
+                            },
+                        )
+                # OTel GenAI metric semconv (OpenLLMetry / OTel SDK auto-instrument
+                # emit these instead of the openclaw.* names). gen_ai.client.
+                # token.usage is a histogram/sum keyed by gen_ai.token.type
+                # (input|output); gen_ai.client.operation.duration is the
+                # request latency. Map them onto the same tiles as the
+                # openclaw.* path so a "bring your own agent" install lights the
+                # token / runs tiles. Unknown metrics stay silently dropped.
+                elif name == "gen_ai.client.token.usage":
+                    for dp in _get_data_points(metric):
+                        attrs = _get_dp_attrs(dp)
+                        ttype = str(attrs.get("gen_ai.token.type", "")).lower()
+                        try:
+                            val = int(_get_dp_value(dp))
+                        except (TypeError, ValueError):
+                            continue
+                        model = attrs.get("gen_ai.request.model") or attrs.get(
+                            "model", resource_attrs.get("model", "")
+                        )
+                        provider = attrs.get("gen_ai.system") or attrs.get(
+                            "gen_ai.provider.name"
+                        ) or attrs.get("provider", resource_attrs.get("provider", ""))
+                        _add_metric(
+                            "tokens",
+                            {
+                                "timestamp": ts,
+                                "input": val if ttype == "input" else 0,
+                                "output": val if ttype == "output" else 0,
+                                "total": val,
+                                "model": model,
+                                "channel": attrs.get(
+                                    "channel", resource_attrs.get("channel", "")
+                                ),
+                                "provider": provider,
+                            },
+                        )
+                elif name == "gen_ai.client.operation.duration":
+                    for dp in _get_data_points(metric):
+                        attrs = _get_dp_attrs(dp)
+                        try:
+                            # semconv unit is seconds; the runs tile stores ms.
+                            dur_ms = float(_get_dp_value(dp)) * 1000.0
+                        except (TypeError, ValueError):
+                            continue
+                        model = attrs.get("gen_ai.request.model") or attrs.get(
+                            "model", resource_attrs.get("model", "")
+                        )
+                        _add_metric(
+                            "runs",
+                            {
+                                "timestamp": ts,
+                                "duration_ms": dur_ms,
+                                "model": model,
+                                "channel": attrs.get(
+                                    "channel", resource_attrs.get("channel", "")
+                                ),
                             },
                         )
 
@@ -2354,8 +2485,17 @@ def _otel_to_row(span, resource_attrs):
     # session/conversation: semconv uses gen_ai.conversation.id.
     session_id = _pick("gen_ai.conversation.id", "session.id", "openclaw.session_id", "session_id")
     agent_id = _pick("gen_ai.agent.id", "agent.id", "openclaw.agent_id", "agent_id") or "main"
-    agent_type = _pick("agent.type", "openclaw.agent_type", "agent_type") or "openclaw"
     service_name = resource_attrs.get("service.name") or attrs.get("service.name")
+    # Runtime identity. An explicit agent.type wins (OpenClaw / clawmetry-pro
+    # adapters set it); otherwise derive it from the OTLP resource service.name
+    # so OpenLLMetry-instrumented foreign apps appear as their OWN agent_type
+    # ("my-langchain-app" -> "my_langchain_app") instead of mis-bucketing under
+    # "openclaw". Absent service.name -> "custom". OpenClaw/clawmetry-known
+    # service names stay "openclaw" so existing OpenClaw OTLP flows are intact.
+    agent_type = _pick("agent.type", "openclaw.agent_type", "agent_type")
+    if not agent_type:
+        derived = _otlp_service_name_to_agent_type(service_name)
+        agent_type = derived or "openclaw"
     node_id = _pick("node.id", "openclaw.node_id", "host.name")
 
     # Span events: array of {time_unix_nano, name, attributes}.
@@ -2382,6 +2522,77 @@ def _otel_to_row(span, resource_attrs):
             "attributes": ln_attrs,
         })
 
+    # input / output messages. The current semconv ships a single
+    # ``gen_ai.input.messages`` / ``gen_ai.output.messages`` value, but
+    # OpenLLMetry / traceloop-sdk emit INDEXED attributes instead:
+    #   gen_ai.prompt.0.role, gen_ai.prompt.0.content, gen_ai.prompt.1.role, ...
+    #   gen_ai.completion.0.role, gen_ai.completion.0.content, plus tool-call
+    #   variants (gen_ai.completion.0.tool_calls.0.name / .arguments).
+    # When the flat keys are absent we assemble an ordered messages list from
+    # the indexed attrs so the same downstream column gets a structured value
+    # (JSON-serialized by _to_blob, the same shape the flat path stores).
+    _MSG_CAP = 200_000  # defensive total-size cap (matches the brain-blob house style)
+
+    def _assemble_indexed(prefix):
+        """Collect gen_ai.<prefix>.<i>.<field> into an ordered [{role, content,
+        ...}] list. Returns None when no indexed attrs exist (caller falls back
+        to the flat keys). Bounded by _MSG_CAP total chars so a pathological
+        span can't blow the row up."""
+        by_index = {}
+        plen = len(prefix) + 1  # "gen_ai.prompt."
+        for k, v in attrs.items():
+            if not k.startswith(prefix + "."):
+                continue
+            rest = k[plen:]
+            dot = rest.find(".")
+            if dot <= 0:
+                continue
+            idx_str, field = rest[:dot], rest[dot + 1:]
+            try:
+                idx = int(idx_str)
+            except ValueError:
+                continue
+            by_index.setdefault(idx, {})[field] = v
+        if not by_index:
+            return None
+        out_msgs = []
+        total = 0
+        for idx in sorted(by_index.keys()):
+            fields = by_index[idx]
+            msg = {}
+            role = fields.get("role")
+            if role is not None:
+                msg["role"] = role
+            content = fields.get("content")
+            if content is not None:
+                msg["content"] = content
+            # Tool-call variants (gen_ai.completion.0.tool_calls.0.name etc.)
+            # and any other indexed sub-fields ride along verbatim so nothing
+            # is silently dropped.
+            for fk, fv in fields.items():
+                if fk in ("role", "content"):
+                    continue
+                msg[fk] = fv
+            if not msg:
+                continue
+            out_msgs.append(msg)
+            try:
+                total += len(str(content or "")) + len(str(role or ""))
+            except Exception:
+                pass
+            if total >= _MSG_CAP:
+                break
+        return out_msgs or None
+
+    input_val = (attrs.get("gen_ai.input.messages") or attrs.get("gen_ai.prompt")
+                 or attrs.get("llm.prompts") or attrs.get("input"))
+    if input_val is None:
+        input_val = _assemble_indexed("gen_ai.prompt")
+    output_val = (attrs.get("gen_ai.output.messages") or attrs.get("gen_ai.completion")
+                  or attrs.get("llm.completions") or attrs.get("output"))
+    if output_val is None:
+        output_val = _assemble_indexed("gen_ai.completion")
+
     return {
         "span_id": _hex(span.span_id),
         "trace_id": _hex(span.trace_id),
@@ -2406,17 +2617,15 @@ def _otel_to_row(span, resource_attrs):
         "token_count": token_count,
         "tokens_input": tokens_input,
         "tokens_output": tokens_output,
-        "input": (attrs.get("gen_ai.input.messages") or attrs.get("gen_ai.prompt")
-                  or attrs.get("llm.prompts") or attrs.get("input")),
-        "output": (attrs.get("gen_ai.output.messages") or attrs.get("gen_ai.completion")
-                   or attrs.get("llm.completions") or attrs.get("output")),
+        "input": input_val,
+        "output": output_val,
         "attributes": attrs,
         "events": events,
         "links": links,
     }
 
 
-def _process_otlp_traces(pb_data):
+def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
     """Decode OTLP traces protobuf and extract relevant span data.
 
     Two-path design (issue #1007): we still feed the in-memory metrics
@@ -2426,8 +2635,12 @@ def _process_otlp_traces(pb_data):
     query historical traces. The DuckDB write is best-effort wrapped in
     try/except — a write failure must NOT break the metrics cache path.
     """
-    req = trace_service_pb2.ExportTraceServiceRequest()
-    req.ParseFromString(pb_data)
+    req = _otlp_decode(
+        pb_data,
+        trace_service_pb2.ExportTraceServiceRequest(),
+        content_encoding,
+        content_type,
+    )
 
     # Resolve the local store lazily so unit tests that monkeypatch the
     # singleton in advance (or run without DuckDB) don't pay the import
@@ -2456,7 +2669,20 @@ def _process_otlp_traces(pb_data):
                 duration_ms = duration_ns / 1_000_000
 
                 span_name = span.name.lower()
-                if "run" in span_name or "completion" in span_name:
+                # Count a "run" for OpenClaw-shaped span names AND for GenAI LLM
+                # spans: OpenLLMetry / traceloop-sdk name them ``openai.chat`` /
+                # ``anthropic.chat`` / ``<vendor>.completion`` and tag the
+                # operation on ``gen_ai.operation.name`` (chat / text_completion
+                # / generate_content). Without this a "bring your own agent"
+                # install records spans but the live Runs tile stays at zero.
+                _genai_op = (attrs.get("gen_ai.operation.name") or "").lower()
+                _is_genai_run = (
+                    _genai_op in ("chat", "text_completion", "generate_content")
+                    or span_name.endswith(".chat")
+                    or span_name.endswith(".completion")
+                    or span_name in ("openai.chat", "anthropic.chat")
+                )
+                if "run" in span_name or "completion" in span_name or _is_genai_run:
                     _add_metric(
                         "runs",
                         {
@@ -2490,7 +2716,8 @@ def _process_otlp_traces(pb_data):
                 # arrives via the /v1/metrics path (openclaw.cost.usd), not span
                 # attrs, so this doesn't double-count. Same shape as /v1/logs
                 # (#2591).
-                _sc = attrs.get("cost_usd") or attrs.get("cost.usd") or attrs.get("cost")
+                _sc = (attrs.get("cost_usd") or attrs.get("cost.usd")
+                       or attrs.get("cost") or attrs.get("gen_ai.usage.cost_usd"))
                 if _sc is not None:
                     try:
                         _add_metric("cost", {
@@ -2501,9 +2728,11 @@ def _process_otlp_traces(pb_data):
                         })
                     except (TypeError, ValueError):
                         pass
-                _si = (attrs.get("input_tokens") or attrs.get("tokens.input")
+                _si = (attrs.get("gen_ai.usage.input_tokens")
+                       or attrs.get("input_tokens") or attrs.get("tokens.input")
                        or attrs.get("prompt_tokens"))
-                _so = (attrs.get("output_tokens") or attrs.get("tokens.output")
+                _so = (attrs.get("gen_ai.usage.output_tokens")
+                       or attrs.get("output_tokens") or attrs.get("tokens.output")
                        or attrs.get("completion_tokens"))
                 if _si is not None or _so is not None:
                     try:
@@ -2534,7 +2763,7 @@ def _process_otlp_traces(pb_data):
                             pass
 
 
-def _process_otlp_logs(pb_data):
+def _process_otlp_logs(pb_data, content_encoding=None, content_type=None):
     """Decode OTLP logs protobuf and ingest agent EVENT records (#2596).
 
     Claude Code (and other runtimes) export their per-turn event stream as OTel
@@ -2545,8 +2774,12 @@ def _process_otlp_logs(pb_data):
     /v1/metrics (cost / tokens / runs), so the cost + usage tiles light up.
     Best-effort: a bad record never breaks the batch.
     """
-    req = logs_service_pb2.ExportLogsServiceRequest()
-    req.ParseFromString(pb_data)
+    req = _otlp_decode(
+        pb_data,
+        logs_service_pb2.ExportLogsServiceRequest(),
+        content_encoding,
+        content_type,
+    )
 
     def _f(attrs, *keys):
         for k in keys:
@@ -10127,10 +10360,14 @@ def _get_dp_attrs(dp):
     return attrs
 
 
-def _process_otlp_metrics(pb_data):
-    """Decode OTLP metrics protobuf and store relevant data."""
-    req = metrics_service_pb2.ExportMetricsServiceRequest()
-    req.ParseFromString(pb_data)
+def _process_otlp_metrics(pb_data, content_encoding=None, content_type=None):
+    """Decode OTLP metrics protobuf/JSON and store relevant data."""
+    req = _otlp_decode(
+        pb_data,
+        metrics_service_pb2.ExportMetricsServiceRequest(),
+        content_encoding,
+        content_type,
+    )
 
     for resource_metrics in req.resource_metrics:
         resource_attrs = {}
@@ -10265,6 +10502,63 @@ def _process_otlp_metrics(pb_data):
                                     "channel", resource_attrs.get("channel", "")
                                 ),
                                 "type": wtype,
+                            },
+                        )
+                # OTel GenAI metric semconv (OpenLLMetry / OTel SDK auto-instrument
+                # emit these instead of the openclaw.* names). gen_ai.client.
+                # token.usage is a histogram/sum keyed by gen_ai.token.type
+                # (input|output); gen_ai.client.operation.duration is the
+                # request latency. Map them onto the same tiles as the
+                # openclaw.* path so a "bring your own agent" install lights the
+                # token / runs tiles. Unknown metrics stay silently dropped.
+                elif name == "gen_ai.client.token.usage":
+                    for dp in _get_data_points(metric):
+                        attrs = _get_dp_attrs(dp)
+                        ttype = str(attrs.get("gen_ai.token.type", "")).lower()
+                        try:
+                            val = int(_get_dp_value(dp))
+                        except (TypeError, ValueError):
+                            continue
+                        model = attrs.get("gen_ai.request.model") or attrs.get(
+                            "model", resource_attrs.get("model", "")
+                        )
+                        provider = attrs.get("gen_ai.system") or attrs.get(
+                            "gen_ai.provider.name"
+                        ) or attrs.get("provider", resource_attrs.get("provider", ""))
+                        _add_metric(
+                            "tokens",
+                            {
+                                "timestamp": ts,
+                                "input": val if ttype == "input" else 0,
+                                "output": val if ttype == "output" else 0,
+                                "total": val,
+                                "model": model,
+                                "channel": attrs.get(
+                                    "channel", resource_attrs.get("channel", "")
+                                ),
+                                "provider": provider,
+                            },
+                        )
+                elif name == "gen_ai.client.operation.duration":
+                    for dp in _get_data_points(metric):
+                        attrs = _get_dp_attrs(dp)
+                        try:
+                            # semconv unit is seconds; the runs tile stores ms.
+                            dur_ms = float(_get_dp_value(dp)) * 1000.0
+                        except (TypeError, ValueError):
+                            continue
+                        model = attrs.get("gen_ai.request.model") or attrs.get(
+                            "model", resource_attrs.get("model", "")
+                        )
+                        _add_metric(
+                            "runs",
+                            {
+                                "timestamp": ts,
+                                "duration_ms": dur_ms,
+                                "model": model,
+                                "channel": attrs.get(
+                                    "channel", resource_attrs.get("channel", "")
+                                ),
                             },
                         )
 
@@ -10431,8 +10725,17 @@ def _otel_to_row(span, resource_attrs):
     # session/conversation: semconv uses gen_ai.conversation.id.
     session_id = _pick("gen_ai.conversation.id", "session.id", "openclaw.session_id", "session_id")
     agent_id = _pick("gen_ai.agent.id", "agent.id", "openclaw.agent_id", "agent_id") or "main"
-    agent_type = _pick("agent.type", "openclaw.agent_type", "agent_type") or "openclaw"
     service_name = resource_attrs.get("service.name") or attrs.get("service.name")
+    # Runtime identity. An explicit agent.type wins (OpenClaw / clawmetry-pro
+    # adapters set it); otherwise derive it from the OTLP resource service.name
+    # so OpenLLMetry-instrumented foreign apps appear as their OWN agent_type
+    # ("my-langchain-app" -> "my_langchain_app") instead of mis-bucketing under
+    # "openclaw". Absent service.name -> "custom". OpenClaw/clawmetry-known
+    # service names stay "openclaw" so existing OpenClaw OTLP flows are intact.
+    agent_type = _pick("agent.type", "openclaw.agent_type", "agent_type")
+    if not agent_type:
+        derived = _otlp_service_name_to_agent_type(service_name)
+        agent_type = derived or "openclaw"
     node_id = _pick("node.id", "openclaw.node_id", "host.name")
 
     # Span events: array of {time_unix_nano, name, attributes}.
@@ -10459,6 +10762,77 @@ def _otel_to_row(span, resource_attrs):
             "attributes": ln_attrs,
         })
 
+    # input / output messages. The current semconv ships a single
+    # ``gen_ai.input.messages`` / ``gen_ai.output.messages`` value, but
+    # OpenLLMetry / traceloop-sdk emit INDEXED attributes instead:
+    #   gen_ai.prompt.0.role, gen_ai.prompt.0.content, gen_ai.prompt.1.role, ...
+    #   gen_ai.completion.0.role, gen_ai.completion.0.content, plus tool-call
+    #   variants (gen_ai.completion.0.tool_calls.0.name / .arguments).
+    # When the flat keys are absent we assemble an ordered messages list from
+    # the indexed attrs so the same downstream column gets a structured value
+    # (JSON-serialized by _to_blob, the same shape the flat path stores).
+    _MSG_CAP = 200_000  # defensive total-size cap (matches the brain-blob house style)
+
+    def _assemble_indexed(prefix):
+        """Collect gen_ai.<prefix>.<i>.<field> into an ordered [{role, content,
+        ...}] list. Returns None when no indexed attrs exist (caller falls back
+        to the flat keys). Bounded by _MSG_CAP total chars so a pathological
+        span can't blow the row up."""
+        by_index = {}
+        plen = len(prefix) + 1  # "gen_ai.prompt."
+        for k, v in attrs.items():
+            if not k.startswith(prefix + "."):
+                continue
+            rest = k[plen:]
+            dot = rest.find(".")
+            if dot <= 0:
+                continue
+            idx_str, field = rest[:dot], rest[dot + 1:]
+            try:
+                idx = int(idx_str)
+            except ValueError:
+                continue
+            by_index.setdefault(idx, {})[field] = v
+        if not by_index:
+            return None
+        out_msgs = []
+        total = 0
+        for idx in sorted(by_index.keys()):
+            fields = by_index[idx]
+            msg = {}
+            role = fields.get("role")
+            if role is not None:
+                msg["role"] = role
+            content = fields.get("content")
+            if content is not None:
+                msg["content"] = content
+            # Tool-call variants (gen_ai.completion.0.tool_calls.0.name etc.)
+            # and any other indexed sub-fields ride along verbatim so nothing
+            # is silently dropped.
+            for fk, fv in fields.items():
+                if fk in ("role", "content"):
+                    continue
+                msg[fk] = fv
+            if not msg:
+                continue
+            out_msgs.append(msg)
+            try:
+                total += len(str(content or "")) + len(str(role or ""))
+            except Exception:
+                pass
+            if total >= _MSG_CAP:
+                break
+        return out_msgs or None
+
+    input_val = (attrs.get("gen_ai.input.messages") or attrs.get("gen_ai.prompt")
+                 or attrs.get("llm.prompts") or attrs.get("input"))
+    if input_val is None:
+        input_val = _assemble_indexed("gen_ai.prompt")
+    output_val = (attrs.get("gen_ai.output.messages") or attrs.get("gen_ai.completion")
+                  or attrs.get("llm.completions") or attrs.get("output"))
+    if output_val is None:
+        output_val = _assemble_indexed("gen_ai.completion")
+
     return {
         "span_id": _hex(span.span_id),
         "trace_id": _hex(span.trace_id),
@@ -10483,17 +10857,15 @@ def _otel_to_row(span, resource_attrs):
         "token_count": token_count,
         "tokens_input": tokens_input,
         "tokens_output": tokens_output,
-        "input": (attrs.get("gen_ai.input.messages") or attrs.get("gen_ai.prompt")
-                  or attrs.get("llm.prompts") or attrs.get("input")),
-        "output": (attrs.get("gen_ai.output.messages") or attrs.get("gen_ai.completion")
-                   or attrs.get("llm.completions") or attrs.get("output")),
+        "input": input_val,
+        "output": output_val,
         "attributes": attrs,
         "events": events,
         "links": links,
     }
 
 
-def _process_otlp_traces(pb_data):
+def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
     """Decode OTLP traces protobuf and extract relevant span data.
 
     Two-path design (issue #1007): we still feed the in-memory metrics
@@ -10503,8 +10875,12 @@ def _process_otlp_traces(pb_data):
     query historical traces. The DuckDB write is best-effort wrapped in
     try/except — a write failure must NOT break the metrics cache path.
     """
-    req = trace_service_pb2.ExportTraceServiceRequest()
-    req.ParseFromString(pb_data)
+    req = _otlp_decode(
+        pb_data,
+        trace_service_pb2.ExportTraceServiceRequest(),
+        content_encoding,
+        content_type,
+    )
 
     # Resolve the local store lazily so unit tests that monkeypatch the
     # singleton in advance (or run without DuckDB) don't pay the import
@@ -10533,7 +10909,20 @@ def _process_otlp_traces(pb_data):
                 duration_ms = duration_ns / 1_000_000
 
                 span_name = span.name.lower()
-                if "run" in span_name or "completion" in span_name:
+                # Count a "run" for OpenClaw-shaped span names AND for GenAI LLM
+                # spans: OpenLLMetry / traceloop-sdk name them ``openai.chat`` /
+                # ``anthropic.chat`` / ``<vendor>.completion`` and tag the
+                # operation on ``gen_ai.operation.name`` (chat / text_completion
+                # / generate_content). Without this a "bring your own agent"
+                # install records spans but the live Runs tile stays at zero.
+                _genai_op = (attrs.get("gen_ai.operation.name") or "").lower()
+                _is_genai_run = (
+                    _genai_op in ("chat", "text_completion", "generate_content")
+                    or span_name.endswith(".chat")
+                    or span_name.endswith(".completion")
+                    or span_name in ("openai.chat", "anthropic.chat")
+                )
+                if "run" in span_name or "completion" in span_name or _is_genai_run:
                     _add_metric(
                         "runs",
                         {
@@ -10567,7 +10956,8 @@ def _process_otlp_traces(pb_data):
                 # arrives via the /v1/metrics path (openclaw.cost.usd), not span
                 # attrs, so this doesn't double-count. Same shape as /v1/logs
                 # (#2591).
-                _sc = attrs.get("cost_usd") or attrs.get("cost.usd") or attrs.get("cost")
+                _sc = (attrs.get("cost_usd") or attrs.get("cost.usd")
+                       or attrs.get("cost") or attrs.get("gen_ai.usage.cost_usd"))
                 if _sc is not None:
                     try:
                         _add_metric("cost", {
@@ -10578,9 +10968,11 @@ def _process_otlp_traces(pb_data):
                         })
                     except (TypeError, ValueError):
                         pass
-                _si = (attrs.get("input_tokens") or attrs.get("tokens.input")
+                _si = (attrs.get("gen_ai.usage.input_tokens")
+                       or attrs.get("input_tokens") or attrs.get("tokens.input")
                        or attrs.get("prompt_tokens"))
-                _so = (attrs.get("output_tokens") or attrs.get("tokens.output")
+                _so = (attrs.get("gen_ai.usage.output_tokens")
+                       or attrs.get("output_tokens") or attrs.get("tokens.output")
                        or attrs.get("completion_tokens"))
                 if _si is not None or _so is not None:
                     try:
@@ -10611,7 +11003,7 @@ def _process_otlp_traces(pb_data):
                             pass
 
 
-def _process_otlp_logs(pb_data):
+def _process_otlp_logs(pb_data, content_encoding=None, content_type=None):
     """Decode OTLP logs protobuf and ingest agent EVENT records (#2596).
 
     Claude Code (and other runtimes) export their per-turn event stream as OTel
@@ -10622,8 +11014,12 @@ def _process_otlp_logs(pb_data):
     /v1/metrics (cost / tokens / runs), so the cost + usage tiles light up.
     Best-effort: a bad record never breaks the batch.
     """
-    req = logs_service_pb2.ExportLogsServiceRequest()
-    req.ParseFromString(pb_data)
+    req = _otlp_decode(
+        pb_data,
+        logs_service_pb2.ExportLogsServiceRequest(),
+        content_encoding,
+        content_type,
+    )
 
     def _f(attrs, *keys):
         for k in keys:

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -1031,9 +1031,20 @@ def otlp_metrics():
 
     try:
         pb_data = request.get_data()
-        _d._process_otlp_metrics(pb_data)
+        _d._process_otlp_metrics(
+            pb_data,
+            content_encoding=request.headers.get("Content-Encoding"),
+            content_type=request.headers.get("Content-Type"),
+        )
         return "{}", 200, {"Content-Type": "application/json"}
     except Exception as e:
+        try:
+            import logging as _lg
+            _lg.getLogger("clawmetry.dashboard").warning(
+                "OTLP /v1/metrics rejected malformed payload: %s", e
+            )
+        except Exception:
+            pass
         return jsonify({"error": str(e)}), 400
 
 
@@ -1056,9 +1067,20 @@ def otlp_traces():
 
     try:
         pb_data = request.get_data()
-        _d._process_otlp_traces(pb_data)
+        _d._process_otlp_traces(
+            pb_data,
+            content_encoding=request.headers.get("Content-Encoding"),
+            content_type=request.headers.get("Content-Type"),
+        )
         return "{}", 200, {"Content-Type": "application/json"}
     except Exception as e:
+        try:
+            import logging as _lg
+            _lg.getLogger("clawmetry.dashboard").warning(
+                "OTLP /v1/traces rejected malformed payload: %s", e
+            )
+        except Exception:
+            pass
         return jsonify({"error": str(e)}), 400
 
 
@@ -1083,9 +1105,20 @@ def otlp_logs():
 
     try:
         pb_data = request.get_data()
-        _d._process_otlp_logs(pb_data)
+        _d._process_otlp_logs(
+            pb_data,
+            content_encoding=request.headers.get("Content-Encoding"),
+            content_type=request.headers.get("Content-Type"),
+        )
         return "{}", 200, {"Content-Type": "application/json"}
     except Exception as e:
+        try:
+            import logging as _lg
+            _lg.getLogger("clawmetry.dashboard").warning(
+                "OTLP /v1/logs rejected malformed payload: %s", e
+            )
+        except Exception:
+            pass
         return jsonify({"error": str(e)}), 400
 
 

--- a/tests/test_spans_otlp_edge_cases.py
+++ b/tests/test_spans_otlp_edge_cases.py
@@ -21,11 +21,14 @@ Gated on ``opentelemetry-proto`` (the receiver 501s without it).
 
 from __future__ import annotations
 
+import gzip as _gzip
 import importlib
+import json as _json
 import time
 
 import pytest
 from flask import Flask
+from google.protobuf import json_format as _json_format
 
 try:
     from opentelemetry.proto.collector.trace.v1 import trace_service_pb2 as _ts_pb2
@@ -33,6 +36,13 @@ try:
     _HAS_OTEL_PROTO = True
 except Exception:  # pragma: no cover
     _HAS_OTEL_PROTO = False
+
+try:
+    from opentelemetry.proto.collector.metrics.v1 import (
+        metrics_service_pb2 as _ms_pb2,
+    )
+except Exception:  # pragma: no cover
+    _ms_pb2 = None
 
 pytestmark = pytest.mark.skipif(
     not _HAS_OTEL_PROTO,
@@ -75,9 +85,10 @@ def _hx(n: int) -> str:
     return f"{n:016x}"
 
 
-def _build_pb(specs, *, n_resource_spans=1):
-    """Build a serialized OTLP request. ``specs`` is a list of span dicts;
-    set n_resource_spans>1 to split them across multiple resource_spans."""
+def _build_req(specs, *, n_resource_spans=1, service_name="openclaw"):
+    """Build the OTLP request PROTO object (not yet serialized) so callers can
+    pick the wire encoding (binary / JSON / gzip). ``specs`` is a list of span
+    dicts; set n_resource_spans>1 to split them across multiple resource_spans."""
     req = _ts_pb2.ExportTraceServiceRequest()
     groups = [[] for _ in range(n_resource_spans)]
     for i, spec in enumerate(specs):
@@ -86,7 +97,7 @@ def _build_pb(specs, *, n_resource_spans=1):
         rs = req.resource_spans.add()
         ra = rs.resource.attributes.add()
         ra.key = "service.name"
-        ra.value.string_value = "openclaw"
+        ra.value.string_value = service_name
         ss = rs.scope_spans.add()
         for spec in grp:
             sp = ss.spans.add()
@@ -106,7 +117,14 @@ def _build_pb(specs, *, n_resource_spans=1):
                 a = sp.attributes.add()
                 a.key = k
                 a.value.int_value = iv
-    return req.SerializeToString()
+    return req
+
+
+def _build_pb(specs, *, n_resource_spans=1, service_name="openclaw"):
+    """Serialized (binary protobuf) OTLP request — the common case."""
+    return _build_req(
+        specs, n_resource_spans=n_resource_spans, service_name=service_name
+    ).SerializeToString()
 
 
 def _post(client, pb_bytes):
@@ -265,3 +283,394 @@ def test_malformed_protobuf_is_400_not_500(app):
         f"{r.get_data(as_text=True)[:200]}"
     )
     assert r.status_code != 500
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# OpenLLMetry ("bring your own agent") ingest — OTLP/JSON + gzip, indexed
+# prompts, service.name runtime identity, gen_ai.* live tiles + metrics.
+# OpenLLMetry / traceloop-sdk is the neutral standard most third-party apps use;
+# these pin that ClawMetry is a first-class OTLP backend for them.
+# ════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def clear_metrics():
+    """The in-memory metrics tiles are module-global; clear them so a test can
+    assert exactly what its own POST produced."""
+    import dashboard as _d
+    with _d._metrics_lock:
+        for k in _d.metrics_store:
+            _d.metrics_store[k].clear()
+    yield _d
+
+
+# ── OTLP/JSON + gzip wire encodings ─────────────────────────────────────────
+
+
+def test_gzip_protobuf_accepted(app):
+    """OTLP exporters can gzip the body (Content-Encoding: gzip). The receiver
+    must gunzip before parsing, not 400 on the compressed bytes."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 30
+    raw = _build_pb([{"span_id_hex": _hx(0x51), "start_ts": base,
+                      "str_attrs": {"session.id": "s-gz"}}])
+    r = c.post("/v1/traces", data=_gzip.compress(raw),
+               content_type="application/x-protobuf",
+               headers={"Content-Encoding": "gzip"})
+    assert r.status_code == 200, r.get_data(as_text=True)[:200]
+    _drain(ls)
+    assert _spans(c, "?session_id=s-gz&limit=10")["count"] == 1
+
+
+def test_otlp_json_accepted_and_parsed_identically(app):
+    """OTLP/JSON (Content-Type: application/json) must parse into the same proto
+    and persist the span identically to the binary path."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 30
+    req = _build_req([{"span_id_hex": _hx(0x52), "start_ts": base,
+                       "str_attrs": {"session.id": "s-json",
+                                     "gen_ai.request.model": "claude-3-5-haiku-20241022"},
+                       "int_attrs": {"gen_ai.usage.input_tokens": 10,
+                                     "gen_ai.usage.output_tokens": 5}}])
+    body = _json_format.MessageToJson(req)
+    r = c.post("/v1/traces", data=body, content_type="application/json")
+    assert r.status_code == 200, r.get_data(as_text=True)[:200]
+    _drain(ls)
+    sp = _spans(c, "?session_id=s-json&limit=10")
+    assert sp["count"] == 1
+    assert sp["spans"][0]["span_id"] == _hx(0x52)
+    assert sp["spans"][0].get("model") == "claude-3-5-haiku-20241022"
+
+
+def test_gzip_json_accepted(app):
+    """The two can combine: gzip-wrapped OTLP/JSON."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 30
+    req = _build_req([{"span_id_hex": _hx(0x53), "start_ts": base,
+                       "str_attrs": {"session.id": "s-gzjson"}}])
+    body = _json_format.MessageToJson(req).encode("utf-8")
+    r = c.post("/v1/traces", data=_gzip.compress(body),
+               content_type="application/json",
+               headers={"Content-Encoding": "gzip"})
+    assert r.status_code == 200, r.get_data(as_text=True)[:200]
+    _drain(ls)
+    assert _spans(c, "?session_id=s-gzjson&limit=10")["count"] == 1
+
+
+def test_malformed_json_is_400_not_500(app):
+    """Garbage JSON to /v1/traces must be a clean 4xx, never a 500."""
+    a, _ls = app
+    c = a.test_client()
+    r = c.post("/v1/traces", data=b'{"not":"a valid OTLP doc"',
+               content_type="application/json")
+    assert r.status_code in (400, 422), r.get_data(as_text=True)[:200]
+    assert r.status_code != 500
+
+
+# ── indexed prompt / completion attributes (OpenLLMetry shape) ──────────────
+
+
+def test_indexed_prompts_assemble_into_input_output(app):
+    """OpenLLMetry emits gen_ai.prompt.<i>.role/content and
+    gen_ai.completion.<i>.role/content rather than the flat semconv keys. They
+    must be assembled, in order, into the span input/output columns."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 30
+    _post(c, _build_pb([{
+        "span_id_hex": _hx(0x60), "start_ts": base, "name": "openai.chat",
+        "str_attrs": {
+            "session.id": "s-idx",
+            "gen_ai.prompt.0.role": "system",
+            "gen_ai.prompt.0.content": "You are helpful.",
+            "gen_ai.prompt.1.role": "user",
+            "gen_ai.prompt.1.content": "Hello there",
+            "gen_ai.completion.0.role": "assistant",
+            "gen_ai.completion.0.content": "Hi! How can I help?",
+        },
+    }]))
+    _drain(ls)
+    store = ls.get_store()
+    rows = store._fetch(
+        "SELECT input, output FROM spans WHERE session_id='s-idx'", [])
+    assert rows, "indexed-prompt span was not ingested"
+    raw_in, raw_out = rows[0]
+    inp = raw_in.decode() if isinstance(raw_in, (bytes, bytearray)) else raw_in
+    out = raw_out.decode() if isinstance(raw_out, (bytes, bytearray)) else raw_out
+    msgs_in = _json.loads(inp)
+    msgs_out = _json.loads(out)
+    assert [m.get("role") for m in msgs_in] == ["system", "user"], msgs_in
+    assert msgs_in[1]["content"] == "Hello there"
+    assert msgs_out[0]["role"] == "assistant"
+    assert msgs_out[0]["content"] == "Hi! How can I help?"
+
+
+def test_flat_keys_win_over_indexed(app):
+    """When the flat gen_ai.prompt key is present it must be used as-is (the
+    indexed assembly only kicks in as a fallback)."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 30
+    _post(c, _build_pb([{
+        "span_id_hex": _hx(0x61), "start_ts": base,
+        "str_attrs": {
+            "session.id": "s-flat",
+            "gen_ai.prompt": "FLAT-PROMPT-WINS",
+            "gen_ai.prompt.0.content": "indexed-should-be-ignored",
+        },
+    }]))
+    _drain(ls)
+    store = ls.get_store()
+    rows = store._fetch("SELECT input FROM spans WHERE session_id='s-flat'", [])
+    raw = rows[0][0]
+    inp = raw.decode() if isinstance(raw, (bytes, bytearray)) else raw
+    assert "FLAT-PROMPT-WINS" in inp
+
+
+# ── service.name → agent_type runtime identity ──────────────────────────────
+
+
+def test_service_name_becomes_agent_type_slug(app):
+    """A foreign OpenLLMetry app's service.name becomes its agent_type slug so
+    it shows up as its OWN runtime, not mis-bucketed under openclaw."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 30
+    _post(c, _build_pb([{"span_id_hex": _hx(0x70), "start_ts": base,
+                         "str_attrs": {"session.id": "s-svc"}}],
+                       service_name="my-langchain-app"))
+    _drain(ls)
+    store = ls.get_store()
+    rows = store._fetch(
+        "SELECT agent_type FROM spans WHERE session_id='s-svc'", [])
+    assert rows and rows[0][0] == "my_langchain_app", rows
+
+
+def test_service_name_absent_falls_back_to_custom(app):
+    """No service.name on the resource → agent_type 'custom' (NOT openclaw)."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 30
+    # Build a request with NO service.name resource attribute.
+    req = _ts_pb2.ExportTraceServiceRequest()
+    rs = req.resource_spans.add()
+    ss = rs.scope_spans.add()
+    sp = ss.spans.add()
+    sp.trace_id = bytes.fromhex("0123456789abcdef0123456789abcdef")
+    sp.span_id = bytes.fromhex(_hx(0x71))
+    sp.name = "openai.chat"
+    sp.start_time_unix_nano = int((base) * 1e9)
+    sp.end_time_unix_nano = int((base + 0.1) * 1e9)
+    aa = sp.attributes.add()
+    aa.key = "session.id"
+    aa.value.string_value = "s-nosvc"
+    _post(c, req.SerializeToString())
+    _drain(ls)
+    store = ls.get_store()
+    rows = store._fetch(
+        "SELECT agent_type FROM spans WHERE session_id='s-nosvc'", [])
+    assert rows and rows[0][0] == "custom", rows
+
+
+def test_openclaw_service_name_preserved(app):
+    """The default fixture service.name 'openclaw' must keep agent_type
+    'openclaw' so existing OpenClaw OTLP flows are unchanged."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 30
+    _post(c, _build_pb([{"span_id_hex": _hx(0x72), "start_ts": base,
+                         "str_attrs": {"session.id": "s-oc"}}]))
+    _drain(ls)
+    store = ls.get_store()
+    rows = store._fetch(
+        "SELECT agent_type FROM spans WHERE session_id='s-oc'", [])
+    assert rows and rows[0][0] == "openclaw", rows
+
+
+def test_explicit_agent_type_wins_over_service_name(app):
+    """An explicit agent.type span attr (clawmetry-pro adapters set it) wins
+    over the service.name derivation."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 30
+    _post(c, _build_pb([{"span_id_hex": _hx(0x73), "start_ts": base,
+                         "str_attrs": {"session.id": "s-at",
+                                       "agent.type": "claude_code"}}],
+                       service_name="my-app"))
+    _drain(ls)
+    store = ls.get_store()
+    rows = store._fetch(
+        "SELECT agent_type FROM spans WHERE session_id='s-at'", [])
+    assert rows and rows[0][0] == "claude_code", rows
+
+
+# ── gen_ai.* live tiles ─────────────────────────────────────────────────────
+
+
+def test_genai_usage_lights_live_tiles(app, clear_metrics):
+    """gen_ai.usage.* span attrs + a GenAI operation must light the in-memory
+    tokens + runs tiles (not just persist to the spans table)."""
+    a, ls = app
+    _d = clear_metrics
+    c = a.test_client()
+    base = time.time() - 5
+    _post(c, _build_pb([{
+        "span_id_hex": _hx(0x80), "start_ts": base, "name": "anthropic.chat",
+        "str_attrs": {"session.id": "s-tile",
+                      "gen_ai.operation.name": "chat",
+                      "gen_ai.request.model": "claude-3-5-haiku-20241022"},
+        "int_attrs": {"gen_ai.usage.input_tokens": 120,
+                      "gen_ai.usage.output_tokens": 34},
+    }]))
+    with _d._metrics_lock:
+        toks = list(_d.metrics_store["tokens"])
+        runs = list(_d.metrics_store["runs"])
+    assert any(t.get("input") == 120 and t.get("output") == 34 for t in toks), toks
+    assert len(runs) >= 1, "a GenAI chat span must count as a run"
+
+
+def test_genai_cost_usd_lights_cost_tile(app, clear_metrics):
+    """gen_ai.usage.cost_usd on a span must light the live cost tile."""
+    a, ls = app
+    _d = clear_metrics
+    c = a.test_client()
+    base = time.time() - 5
+    # cost_usd is a float; the proto builder above only does str/int attrs, so
+    # add the double attr directly.
+    req = _build_req([{"span_id_hex": _hx(0x81), "start_ts": base,
+                       "name": "openai.chat",
+                       "str_attrs": {"session.id": "s-costtile"}}])
+    sp = req.resource_spans[0].scope_spans[0].spans[0]
+    da = sp.attributes.add()
+    da.key = "gen_ai.usage.cost_usd"
+    da.value.double_value = 0.0123
+    _post(c, req.SerializeToString())
+    with _d._metrics_lock:
+        costs = list(_d.metrics_store["cost"])
+    assert any(abs(x.get("usd", 0) - 0.0123) < 1e-9 for x in costs), costs
+
+
+# ── gen_ai.client.token.usage metric ────────────────────────────────────────
+
+
+@pytest.mark.skipif(_ms_pb2 is None, reason="metrics proto unavailable")
+def test_genai_token_usage_metric_ingested(app, clear_metrics):
+    """OTel GenAI metric semconv: gen_ai.client.token.usage split by
+    gen_ai.token.type (input|output) must route into the tokens tile."""
+    a, ls = app
+    _d = clear_metrics
+    c = a.test_client()
+
+    req = _ms_pb2.ExportMetricsServiceRequest()
+    rm = req.resource_metrics.add()
+    ra = rm.resource.attributes.add()
+    ra.key = "service.name"
+    ra.value.string_value = "my-app"
+    sm = rm.scope_metrics.add()
+
+    def _add_token_metric(ttype, val):
+        m = sm.metrics.add()
+        m.name = "gen_ai.client.token.usage"
+        dp = m.sum.data_points.add()
+        dp.as_int = val
+        at = dp.attributes.add()
+        at.key = "gen_ai.token.type"
+        at.value.string_value = ttype
+        mt = dp.attributes.add()
+        mt.key = "gen_ai.request.model"
+        mt.value.string_value = "gpt-4o-mini"
+
+    _add_token_metric("input", 200)
+    _add_token_metric("output", 50)
+
+    r = c.post("/v1/metrics", data=req.SerializeToString(),
+               content_type="application/x-protobuf")
+    assert r.status_code == 200, r.get_data(as_text=True)[:200]
+    with _d._metrics_lock:
+        toks = list(_d.metrics_store["tokens"])
+    assert any(t.get("input") == 200 for t in toks), toks
+    assert any(t.get("output") == 50 for t in toks), toks
+
+
+# ── end-to-end: a real traceloop-sdk openai.chat shape ──────────────────────
+
+
+def test_openllmetry_openai_chat_shape_end_to_end(app):
+    """A realistic OTLP/JSON trace matching what traceloop-sdk emits for an
+    openai.chat span: resource service.name, gen_ai.system, llm.usage.* aliases,
+    indexed prompts, gen_ai.conversation.id. Assert end to end that the span is
+    persisted with model, tokens, DERIVED cost, the conversation id as
+    session_id, and the service.name-derived agent_type."""
+    a, ls = app
+    c = a.test_client()
+    base = time.time() - 20
+    req = _ts_pb2.ExportTraceServiceRequest()
+    rs = req.resource_spans.add()
+    for k, v in (("service.name", "rag-chatbot"),
+                 ("telemetry.sdk.name", "opentelemetry")):
+        ra = rs.resource.attributes.add()
+        ra.key = k
+        ra.value.string_value = v
+    ss = rs.scope_spans.add()
+    ss.scope.name = "opentelemetry.instrumentation.openai"
+    sp = ss.spans.add()
+    sp.trace_id = bytes.fromhex("aaaabbbbccccddddeeeeffff00001111")
+    sp.span_id = bytes.fromhex(_hx(0x90))
+    sp.name = "openai.chat"
+    sp.kind = _trace_pb2.Span.SPAN_KIND_CLIENT
+    sp.start_time_unix_nano = int(base * 1e9)
+    sp.end_time_unix_nano = int((base + 1.2) * 1e9)
+    sp.status.code = _trace_pb2.Status.STATUS_CODE_OK
+
+    def _sattr(k, v):
+        a_ = sp.attributes.add()
+        a_.key = k
+        a_.value.string_value = v
+
+    def _iattr(k, v):
+        a_ = sp.attributes.add()
+        a_.key = k
+        a_.value.int_value = v
+
+    _sattr("gen_ai.system", "openai")
+    _sattr("gen_ai.request.model", "gpt-4o")
+    _sattr("gen_ai.response.model", "gpt-4o-2024-08-06")
+    _sattr("gen_ai.operation.name", "chat")
+    _sattr("gen_ai.conversation.id", "conv-xyz-789")
+    _sattr("gen_ai.prompt.0.role", "user")
+    _sattr("gen_ai.prompt.0.content", "Summarize the quarterly report.")
+    _sattr("gen_ai.completion.0.role", "assistant")
+    _sattr("gen_ai.completion.0.content", "Revenue grew 12% QoQ.")
+    # traceloop also ships the llm.usage.* aliases the mapper understands.
+    _iattr("llm.usage.prompt_tokens", 850)
+    _iattr("llm.usage.completion_tokens", 120)
+
+    body = _json_format.MessageToJson(req)
+    r = c.post("/v1/traces", data=body, content_type="application/json")
+    assert r.status_code == 200, r.get_data(as_text=True)[:200]
+    _drain(ls)
+
+    store = ls.get_store()
+    rows = store._fetch(
+        "SELECT model, tokens_input, tokens_output, cost_usd, agent_type, "
+        "session_id, input, output FROM spans WHERE span_id=?", [_hx(0x90)])
+    assert rows, "openllmetry openai.chat span was not persisted"
+    model, ti, to, cost, atype, sid, raw_in, raw_out = rows[0]
+    assert model == "gpt-4o"
+    assert ti == 850 and to == 120
+    assert cost is not None and cost > 0, (
+        f"cost must be DERIVED from tokens × gpt-4o pricing; got {cost!r}")
+    assert sid == "conv-xyz-789", "gen_ai.conversation.id must map to session_id"
+    assert atype == "rag_chatbot", f"service.name slug agent_type; got {atype!r}"
+    inp = raw_in.decode() if isinstance(raw_in, (bytes, bytearray)) else raw_in
+    out = raw_out.decode() if isinstance(raw_out, (bytes, bytearray)) else raw_out
+    assert "Summarize the quarterly report." in inp
+    assert "Revenue grew 12% QoQ." in out
+
+    # session-attach: the span is queryable scoped to its conversation id.
+    sp_body = _spans(c, "?session_id=conv-xyz-789&limit=10")
+    assert sp_body["count"] == 1
+    assert sp_body["spans"][0]["span_id"] == _hx(0x90)


### PR DESCRIPTION
## Why

OpenLLMetry (traceloop-sdk) is the neutral, vendor-agnostic standard for LLM-app telemetry, and post the ServiceNow acquisition it is the default people reach for when they instrument a non-OpenClaw app. Making ClawMetry a working OTLP backend for it turns any instrumented app into a first-class runtime: open the dashboard, point your app's OTLP exporter at `/v1/traces` (and `/v1/metrics`, `/v1/logs`), and the spans, tokens, derived cost, and live tiles light up under the app's own runtime identity.

An audit found five concrete breaks that stopped OpenLLMetry traffic end to end. This PR fixes all five.

## What

1. **OTLP/JSON + gzip on the receivers.** `/v1/{metrics,traces,logs}` parsed binary protobuf only. A shared `_otlp_decode` now gunzips a `Content-Encoding: gzip` body and parses `application/json` via `json_format.Parse` into the same proto, so the downstream mappers are unchanged. Bad input stays a logged 400, never a 500 stacktrace leak.
2. **Indexed prompt/completion attributes.** OpenLLMetry emits `gen_ai.prompt.0.role` / `gen_ai.prompt.0.content` / ... and `gen_ai.completion.0.*` (plus tool-call variants) instead of the flat semconv keys. `_otel_to_row` now assembles an ordered messages list from the indexed attrs when the flat keys are absent (flat still wins), size-capped defensively.
3. **Runtime identity from `service.name`.** Every OTLP span used to default `agent_type` to `openclaw`, mis-bucketing foreign apps under the OpenClaw filter. We now derive `agent_type` from the resource `service.name` (slugified: `my-langchain-app` becomes `my_langchain_app`), fall back to `custom` when absent, and keep `openclaw` only for openclaw/clawmetry-known names. An explicit `agent.type` span attr still wins. The closed session-prefix runtime switcher is untouched, so the no-leak contract still holds.
4. **Live tiles read `gen_ai.*`.** The in-memory hot-path tile mapper now reads `gen_ai.usage.input_tokens` / `output_tokens` / `cost_usd` and counts a run for GenAI spans (`gen_ai.operation.name` in chat/text_completion/generate_content, or names like `openai.chat` / `anthropic.chat` / `*.completion`).
5. **gen_ai metrics on `/v1/metrics`.** Added the OTel GenAI metric semconv: `gen_ai.client.token.usage` (routed by `gen_ai.token.type` into the token tiles) and `gen_ai.client.operation.duration`. Unknown metric names stay silently dropped as before.

## Verification

- Extended `tests/test_spans_otlp_edge_cases.py` (22 tests pass locally): gzip-encoded protobuf accepted, OTLP/JSON accepted and parsed identically, gzip+JSON combined, malformed JSON is a 400, indexed `gen_ai.prompt.0.content` / `gen_ai.completion.0.content` land in input/output (and flat keys win over indexed), `service.name` to agent_type slug plus `custom` fallback plus `openclaw` preserved plus explicit `agent.type` wins, `gen_ai.usage.*` lights the live token/run/cost tiles, and `gen_ai.client.token.usage` metric ingestion.
- One realistic end-to-end test posts an OTLP/JSON trace matching what traceloop-sdk emits for an `openai.chat` span (resource `service.name`, `gen_ai.system`, `llm.usage.*` aliases, indexed prompts, `gen_ai.conversation.id`) and asserts the span is persisted with model, tokens, DERIVED cost, conversation-id session attach, and the `service.name`-derived agent_type.
- Unit-checked `_otel_to_row` mapping directly (indexed assembly, slug, fallbacks, flat precedence) independent of the store.
- Existing OTLP suites pass: `test_otlp_logs.py`, `test_otlp_metrics_edge_cases.py`, `test_otlp_traces_cost.py`, `test_spans_e2e.py`, plus the three runtime no-leak bucketing tests. (Two pre-existing store-flush flakes on this dev box, `test_spans_ingest.py` round-trips and one `test_otel_export` entitlement test, fail identically on clean `origin/main` and are unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
