### PR TITLE
[RELEASE] fix(brain): derive recent sessions from the sessions table, not the event stream

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7009,14 +7009,31 @@ def _build_brain_cache_pushes(config: dict) -> list:
         per_session[sid] = per_session.get(sid, 0) + 1
         picked.append(r)
 
-    # Most-recently-active sessions, in recency order (from the newest events).
+    # Most-recently-active sessions, from the typed sessions table (one row per
+    # session, ordered by last activity) -- NOT from the event stream, which a
+    # flooding session dominates: a session the user messaged 15 min ago has long
+    # scrolled off the newest-200 events, so deriving recency from events hid it
+    # and its per-session feed came back empty. The sessions table is the same
+    # source the device-agent session list uses, so every session the user can
+    # TAP on the device is covered here.
     recent_sids: list = []
+    try:
+        for s in store.query_sessions_table(limit=BRAIN_SESSION_FANOUT * 3):
+            sid = s.get("session_id")
+            if sid and sid not in recent_sids:
+                recent_sids.append(sid)
+            if len(recent_sids) >= BRAIN_SESSION_FANOUT:
+                break
+    except Exception:
+        recent_sids = []
+    # Supplement with any session present in the newest events but not yet in the
+    # sessions table (a brand-new session that hasn't been upserted yet).
     for r in nw_rows:
+        if len(recent_sids) >= BRAIN_SESSION_FANOUT:
+            break
         sid = r.get("session_id")
         if sid and sid not in recent_sids:
             recent_sids.append(sid)
-        if len(recent_sids) >= BRAIN_SESSION_FANOUT:
-            break
     # (a) each recent session's newest renderable events (capped per session).
     for sid in recent_sids:
         try:


### PR DESCRIPTION
Follow-up to #2819. That fix derived the recent-session list from the newest 200 events node-wide — which a flooding session still dominates. A session messaged ~15 min ago scrolls off the newest events, so it never made the recency list and its per-session feed came back **empty again** (verified live: the OpenClaw session dropped to 0 blob events once a busier session out-produced it).

**Fix:** derive `recent_sids` from `query_sessions_table` (one row per session, ordered by last activity) — the **same source the device-agent session list uses** — so every session the user can tap is covered regardless of event volume. The event-stream scan is kept only to supplement brand-new sessions not yet in the table.

**Verified live:** the quiet OpenClaw session is now **#1** in `recent_sids` with 392 renderable events available → it gets its guaranteed per-session slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)