### PR TITLE
test(paywall): pin /api/paywall/event 204 + truncation + never-raise contract

### DIFF
--- a/tests/test_paywall_event_api.py
+++ b/tests/test_paywall_event_api.py
@@ -1,0 +1,265 @@
+"""Tests for the ``POST /api/paywall/event`` telemetry endpoint
+(``routes/entitlement.py::api_paywall_event``).
+
+The route accepts a fire-and-forget client-side paywall ping
+(``paywall_view`` / ``paywall_cta_click``) and is documented to:
+
+* Always return **204** so callers never read the response.
+* Never raise — a malformed payload, missing body, wrong content-type,
+  or non-string fields must all fall through to 204.
+* Truncate the ``event`` / ``harness`` / ``source`` fields to 64 chars
+  and ``feature`` to 128 chars before logging, so an oversized field
+  cannot blow up the log line or smuggle log content past the cap.
+* Reject non-POST methods with 405 (Flask routing default).
+
+None of these invariants are pinned today. This file is **tests-only**
+— no production change — so the contract is locked in before any future
+refactor of the endpoint (e.g. wiring the events into an analytics
+sink) can silently regress it.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client():
+    """Minimal Flask app with ``bp_entitlement`` registered. The endpoint is
+    pure logging + no I/O so no HOME / license / entitlements fixture is needed.
+    """
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+# ── happy path ───────────────────────────────────────────────────────────────
+
+
+def test_valid_event_returns_204(client):
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps(
+            {
+                "event": "paywall_view",
+                "feature": "self_evolve",
+                "harness": "claude_code",
+                "source": "runtime_switcher",
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+    # 204 contract: no body.
+    assert resp.data == b""
+
+
+def test_cta_click_event_returns_204(client):
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps({"event": "paywall_cta_click", "feature": "fleet"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+
+# ── never-raise contract ─────────────────────────────────────────────────────
+
+
+def test_empty_body_returns_204(client):
+    """No body at all must still return 204 — the route uses
+    ``request.get_json(silent=True)`` precisely so a beacon ping with no payload
+    doesn't 500."""
+    resp = client.post("/api/paywall/event")
+    assert resp.status_code == 204
+
+
+def test_empty_json_object_returns_204(client):
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+
+def test_malformed_json_body_returns_204(client):
+    """A garbage body must not 400/500 — ``silent=True`` swallows the parse
+    error and the route logs an empty event."""
+    resp = client.post(
+        "/api/paywall/event",
+        data="{not valid json",
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+
+def test_missing_content_type_returns_204(client):
+    """Beacons (``navigator.sendBeacon``) often omit the JSON content-type;
+    silent=True still returns None and the handler must not raise."""
+    resp = client.post("/api/paywall/event", data=json.dumps({"event": "paywall_view"}))
+    assert resp.status_code == 204
+
+
+def test_non_string_fields_do_not_raise(client):
+    """The route does ``str(body.get(...))`` so ints / lists / dicts in the
+    payload must coerce without raising."""
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps(
+            {
+                "event": 42,
+                "feature": ["self_evolve"],
+                "harness": {"name": "claude_code"},
+                "source": None,
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+
+def test_array_body_does_not_raise(client):
+    """``get_json(silent=True)`` returns the parsed JSON which may be a list;
+    the route guards with ``or {}`` so list bodies must still 204."""
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps(["not", "an", "object"]),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+
+
+# ── truncation invariants ────────────────────────────────────────────────────
+
+
+def _capture_log(caplog: pytest.LogCaptureFixture):
+    caplog.set_level(logging.INFO, logger="clawmetry.routes.entitlement")
+    return caplog
+
+
+def test_event_field_truncated_to_64_chars(client, caplog):
+    _capture_log(caplog)
+    long_event = "a" * 200
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps({"event": long_event}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+    line = " ".join(r.getMessage() for r in caplog.records)
+    assert "a" * 64 in line
+    # The 65th `a` must not appear — caps the budget for log size.
+    assert "a" * 65 not in line
+
+
+def test_feature_field_truncated_to_128_chars(client, caplog):
+    _capture_log(caplog)
+    long_feature = "f" * 300
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps({"event": "paywall_view", "feature": long_feature}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+    line = " ".join(r.getMessage() for r in caplog.records)
+    assert "f" * 128 in line
+    assert "f" * 129 not in line
+
+
+def test_harness_field_truncated_to_64_chars(client, caplog):
+    _capture_log(caplog)
+    long_harness = "h" * 200
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps({"event": "paywall_view", "harness": long_harness}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+    line = " ".join(r.getMessage() for r in caplog.records)
+    assert "h" * 64 in line
+    assert "h" * 65 not in line
+
+
+def test_source_field_truncated_to_64_chars(client, caplog):
+    _capture_log(caplog)
+    long_source = "s" * 200
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps({"event": "paywall_view", "source": long_source}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+    line = " ".join(r.getMessage() for r in caplog.records)
+    assert "s" * 64 in line
+    assert "s" * 65 not in line
+
+
+# ── method enforcement ───────────────────────────────────────────────────────
+
+
+def test_get_method_not_allowed(client):
+    """The route is registered POST-only; a GET must 405 so callers don't
+    accidentally surface the telemetry endpoint as a readable resource."""
+    resp = client.get("/api/paywall/event")
+    assert resp.status_code == 405
+
+
+def test_put_method_not_allowed(client):
+    resp = client.put("/api/paywall/event", data=b"{}")
+    assert resp.status_code == 405
+
+
+# ── grace-mode invariant ─────────────────────────────────────────────────────
+
+
+def test_endpoint_does_not_consult_entitlement(client):
+    """The paywall telemetry endpoint must not gate on the resolved
+    entitlement — it is a fire-and-forget client beacon that fires *exactly*
+    when the user is locked out, so a paid/Pro/Enterprise install gating it
+    would silently drop the event. Verify by monkey-patching
+    ``clawmetry.entitlements.get_entitlement`` to raise and confirming the
+    route still 204s."""
+    import clawmetry.entitlements as e
+
+    original = e.get_entitlement
+    e.get_entitlement = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("nope"))
+    try:
+        resp = client.post(
+            "/api/paywall/event",
+            data=json.dumps({"event": "paywall_view"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 204
+    finally:
+        e.get_entitlement = original
+
+
+# ── logger pipeline ──────────────────────────────────────────────────────────
+
+
+def test_event_is_logged_at_info_level(client, caplog):
+    _capture_log(caplog)
+    resp = client.post(
+        "/api/paywall/event",
+        data=json.dumps(
+            {"event": "paywall_view", "feature": "self_evolve", "harness": "claude_code"}
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 204
+    info_records = [
+        r for r in caplog.records
+        if r.levelno == logging.INFO and r.name == "clawmetry.routes.entitlement"
+    ]
+    assert info_records, "expected an INFO log line on the entitlement route logger"
+    joined = " ".join(r.getMessage() for r in info_records)
+    assert "paywall_view" in joined
+    assert "self_evolve" in joined
+    assert "claude_code" in joined


### PR DESCRIPTION
## Summary

The `POST /api/paywall/event` endpoint in `routes/entitlement.py::api_paywall_event` accepts a fire-and-forget client paywall telemetry beacon (`paywall_view` / `paywall_cta_click`, plus a `feature` / `harness` / `source` tag) and is documented to:

* always return **204** so callers never read the response,
* never raise — a malformed payload, missing body, wrong content-type, or non-string fields must all fall through to 204,
* truncate `event` / `harness` / `source` to **64** chars and `feature` to **128** chars before logging,
* reject non-`POST` methods with **405**.

None of those invariants are pinned today. This file is **tests-only** — no production change — so the contract is locked in before any future refactor of the endpoint (e.g. wiring the events into an analytics sink, switching the logger, or adding a body schema) can silently regress it.

This complements the existing `tests/test_entitlement_api.py` (`/api/entitlement`) and `tests/test_license_api.py` (`/api/license/*`) — `bp_entitlement`'s six routes were five-out-of-six covered; the telemetry beacon was the only one without a backend test.

## What changes

- `tests/test_paywall_event_api.py` — new, **16** tests, ~265 LOC, runs in ~0.05 s. Uses a minimal `Flask` app with `bp_entitlement` registered; no HOME / license / entitlements fixture is needed because the endpoint is pure logging with no I/O.

## Tests

| # | Test | What it pins |
|---|------|--------------|
| 1 | `test_valid_event_returns_204` | happy path returns 204 + empty body |
| 2 | `test_cta_click_event_returns_204` | `paywall_cta_click` is also accepted |
| 3 | `test_empty_body_returns_204` | beacon with no body → 204 (silent=True) |
| 4 | `test_empty_json_object_returns_204` | `{}` body → 204 |
| 5 | `test_malformed_json_body_returns_204` | garbage body → 204 (silent swallows) |
| 6 | `test_missing_content_type_returns_204` | `navigator.sendBeacon`-style ping → 204 |
| 7 | `test_non_string_fields_do_not_raise` | int / list / dict / None coerce → 204 |
| 8 | `test_array_body_does_not_raise` | top-level JSON array → 204 |
| 9 | `test_event_field_truncated_to_64_chars` | event capped at 64 in the log line |
| 10 | `test_feature_field_truncated_to_128_chars` | feature capped at 128 |
| 11 | `test_harness_field_truncated_to_64_chars` | harness capped at 64 |
| 12 | `test_source_field_truncated_to_64_chars` | source capped at 64 |
| 13 | `test_get_method_not_allowed` | GET → 405 (route is POST-only) |
| 14 | `test_put_method_not_allowed` | PUT → 405 |
| 15 | `test_endpoint_does_not_consult_entitlement` | grace-mode invariant: handler must not gate on the resolved entitlement (beacons fire *exactly* when the user is locked out — a paid/Pro install gating it would silently drop the events) |
| 16 | `test_event_is_logged_at_info_level` | event/feature/harness reach the route logger at INFO |

## No behaviour change

Pure additive test coverage. No `__version__` bump. No `[RELEASE]` PR. No enforcement gate flipped. Grace mode stays on. The behaviour these tests pin is what `api_paywall_event()` already does today — the tests just lock it in.

## Why this isn't in any of the in-flight open-core drafts

Scanning the open-core PR landscape, every active draft touches the gate/catalog surfaces (`allows_*` helpers, `feature_catalog` / `tier_catalog`, `gate_runtime`, `required_tier`, `clawmetry entitlement` CLI, license CLI subcommands, the OSS-leak CI guard) — none of them touch `api_paywall_event`. A `git log --all --since="14 days ago" -- routes/entitlement.py` shows the route untouched since the original landing, and a PR search for `paywall` returns zero open PRs. So this is a genuine gap that no in-flight work covers.

## Test plan

- [x] `python3 -m pytest tests/test_paywall_event_api.py -v` — **16/16 pass in 0.25 s**
- [x] `python3 -m pytest tests/test_entitlement_api.py tests/test_license_api.py tests/test_entitlements.py tests/test_paywall_event_api.py -q` — **50/50 pass** (no regression in adjacent `bp_entitlement` surfaces)
- [x] `python3 -m py_compile tests/test_paywall_event_api.py` — syntax clean
- [x] `python3 -m ruff check tests/test_paywall_event_api.py` — **All checks passed**

## Local operator verification checklist

I cannot reach the user's local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. This PR is tests-only so the runtime verification surface is small — please confirm on a real install:

1. `git fetch origin test/paywall-event-api && git checkout test/paywall-event-api`
2. From the repo root: `python3 -m pytest tests/test_paywall_event_api.py -v` — expect 16/16 pass in ~0.05 s
3. From the repo root: `python3 -m pytest tests/test_entitlement_api.py tests/test_license_api.py tests/test_entitlements.py tests/test_paywall_event_api.py -q` — expect 50/50 pass
4. `python3 -m ruff check tests/test_paywall_event_api.py` — expect clean
5. No daemon kickstart needed — this PR ships zero runtime code; `~/.clawmetry/lib/.../site-packages/` and `__pycache__` do not need a refresh
6. No `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` required
7. No live cloud snapshot decryption needed — daemon snapshot shape is unchanged
8. No browser check needed — there is no UI surface in this PR
9. Optional: hit the endpoint against your running dashboard to sanity-check the 204 contract holds end-to-end:
   ```bash
   curl -i -X POST http://localhost:8900/api/paywall/event \
     -H 'Content-Type: application/json' \
     -d '{"event":"paywall_view","feature":"self_evolve","harness":"claude_code","source":"runtime_switcher"}'
   ```
   Expect `HTTP/1.1 204 No Content` with an empty body.

This PR is **draft-only**: I am not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Grace mode stays on. Once you have run steps 2-4 above, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
Generated by Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcHXBmLsBrLrSnHhCCaCX2)_