### PR TITLE
[RELEASE] fix(brain): stamp the CANONICAL row session_id, not the inner wrapped one

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6852,16 +6852,19 @@ def _rows_to_brain_events(rows: list) -> list:
             # Bound the per-event size so a burst of big tool outputs can't push
             # the blob past the device's 128 KB buffer (the "feed locked" cause).
             data = _truncate_brain_payload(data)
-            # Stamp the session id so per-session feeds (the desk device's live
-            # feed + cloud Brain filtering) can attribute each event. Family
-            # runtime payloads (claude_code/codex/…) carry NO sessionId inside
-            # ``data`` -- only the row's top-level session_id column has it, so
-            # the device's per-session filter matched nothing and every session
-            # showed the same node-wide feed. Use the BARE uuid (drop the
-            # ``runtime:`` namespace) so it matches the device-agent session ids
-            # (#1465). Never overwrite a sessionId the payload already carries.
+            # Stamp the CANONICAL session id from the row's top-level session_id
+            # column (the BARE uuid, dropping the ``runtime:`` namespace) so
+            # per-session feeds (desk device + cloud Brain filtering) attribute
+            # each event to the session the device shows. We OVERWRITE any
+            # ``sessionId`` already inside ``data``: an OpenClaw session that runs
+            # Claude Code under the hood embeds the INNER Claude-CLI sessionId in
+            # its event payload (e.g. data.sessionId=<claude uuid> while the row
+            # belongs to the OpenClaw session) -- trusting that inner id filed the
+            # events under the wrong session, so tapping the OpenClaw session on
+            # the device showed "no activity". The row's session_id is the same
+            # id the device-agent + sessions table use, so it's authoritative.
             _sid = r.get("session_id")
-            if _sid and not data.get("sessionId") and not data.get("session_id"):
+            if _sid:
                 data = {**data, "sessionId": _sid.rsplit(":", 1)[-1]}
             out.append(_cap_brain_event_size(data))
         elif isinstance(data, str):


### PR DESCRIPTION
## THE root cause of "No activity for this session" on the device
An OpenClaw session that runs Claude Code under the hood embeds the **inner Claude-CLI sessionId** in each event payload (`data.sessionId=<claude uuid>`) while the event **row** belongs to the OpenClaw session (`row.session_id=<openclaw uuid>`). The brain translator only stamped `sessionId` *when absent*, so it kept the inner id → the OpenClaw session's events were filed in the blob under the inner Claude session, and tapping the OpenClaw session on the device (which filters by the OpenClaw id from device-agent) matched nothing.

### Confirmed live
Session `682c73e4`'s events carried `data.sessionId=6e6a42fc`. The daemon **picked its 5 events** (fanout debug log) but they surfaced under `6e6a42fc`, not `682c73e4` — so the per-session feed was empty.

### Fix
**Always** overwrite `sessionId` with the row's top-level `session_id` (the same id device-agent + the sessions table use). Authoritative attribution.

This is the final piece of the device live-feed chain (freshness → blob size → attribution → per-session fairness → **canonical session id**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)