### PR TITLE
[RELEASE] feat(storage): CCR reversible event compression (opt-in) + safety eval (#2843, #2844)

### DIFF
--- a/clawmetry/ccr.py
+++ b/clawmetry/ccr.py
@@ -1,0 +1,69 @@
+"""CCR — reversible event-payload compression for the DuckDB store (#2843).
+
+Headroom-inspired (chopratejas/headroom): tool outputs (search results, logs,
+diffs, big JSON) dominate transcript size. We optionally gzip the event ``data``
+BLOB at ingest and transparently inflate it on read, cutting local DuckDB +
+the E2E cloud snapshot by a large margin with ZERO loss.
+
+Design for safety:
+- The decoder is AUTO-DETECTING: a compressed blob carries a 5-byte magic
+  prefix; ``maybe_decompress`` inflates only when it sees the magic and returns
+  everything else untouched. So old (uncompressed) rows and new (compressed)
+  rows both read correctly regardless of the write flag, and turning the flag
+  off later never strands already-compressed rows.
+- Compression on WRITE is OFF by default (``CLAWMETRY_CCR=1`` to enable), so the
+  default path is byte-for-byte unchanged. Self-hosters opt in.
+- zlib only (stdlib) — no new dependency, per the minimal-deps rule.
+"""
+from __future__ import annotations
+
+import os
+import zlib
+
+# 5-byte magic. \x1f is never the first byte of our UTF-8 JSON payloads
+# ({, [, ", digit, whitespace), so detection is unambiguous.
+_MAGIC = b"\x1fCCR1"
+# Only compress payloads above this size; tiny blobs do not benefit and the
+# magic prefix would be pure overhead.
+_MIN_BYTES = 2048
+
+
+def enabled() -> bool:
+    """True when CCR compression-on-write is opted in via env. Read path is
+    always on (auto-detecting), so this only gates whether we compress."""
+    return str(os.environ.get("CLAWMETRY_CCR", "")).strip().lower() in ("1", "true", "yes", "on")
+
+
+def compress(raw: bytes, *, force: bool = False) -> bytes:
+    """Compress ``raw`` (utf-8 JSON bytes) to ``_MAGIC + zlib`` IF it is large
+    enough; otherwise return it unchanged. Never raises — on any error the
+    original bytes pass through so ingest can never break."""
+    if not isinstance(raw, (bytes, bytearray)):
+        return raw
+    raw = bytes(raw)
+    if not force and len(raw) < _MIN_BYTES:
+        return raw
+    if raw.startswith(_MAGIC):  # already compressed — idempotent
+        return raw
+    try:
+        packed = _MAGIC + zlib.compress(raw, 6)
+        # Never let the "compressed" form be bigger than the original.
+        return packed if len(packed) < len(raw) else raw
+    except Exception:
+        return raw
+
+
+def maybe_decompress(raw):
+    """Inflate a CCR blob; pass anything else through untouched. Accepts bytes
+    or str (str is returned as-is — it cannot carry the binary magic). Never
+    raises; on a corrupt blob returns the raw bytes so the caller's own decode
+    path decides what to do."""
+    if not isinstance(raw, (bytes, bytearray)):
+        return raw
+    raw = bytes(raw)
+    if not raw.startswith(_MAGIC):
+        return raw
+    try:
+        return zlib.decompress(raw[len(_MAGIC):])
+    except Exception:
+        return raw

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -41,6 +41,7 @@ import json
 import logging
 import math
 import os
+from clawmetry import ccr as _ccr  # reversible event-payload compression (#2843)
 import threading
 import time
 from collections import deque
@@ -2621,6 +2622,7 @@ class LocalStore:
             raw = d.get("details")
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     try:
                         d["details"] = json.loads(text)
@@ -3358,6 +3360,7 @@ class LocalStore:
                 if raw is None:
                     continue
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     try:
                         d[k] = json.loads(text)
@@ -3672,6 +3675,7 @@ class LocalStore:
                 if raw is None:
                     continue
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     try:
                         d[c] = json.loads(text)
@@ -3875,6 +3879,7 @@ class LocalStore:
             data: dict[str, Any] = {}
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     parsed = json.loads(text) if text else {}
                     if isinstance(parsed, dict):
@@ -3962,6 +3967,7 @@ class LocalStore:
             data: dict[str, Any] = {}
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     parsed = json.loads(text) if text else {}
                     if isinstance(parsed, dict):
@@ -4026,6 +4032,7 @@ class LocalStore:
             data: dict[str, Any] = {}
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     parsed = json.loads(text) if text else {}
                     if isinstance(parsed, dict):
@@ -4445,6 +4452,7 @@ class LocalStore:
         for (eid, data, model) in rows:
             try:
                 if isinstance(data, (bytes, bytearray)):
+                    data = _ccr.maybe_decompress(data)
                     data = bytes(data).decode("utf-8", "replace")
                 obj = json.loads(data) if isinstance(data, str) else data
             except Exception:
@@ -4524,6 +4532,7 @@ class LocalStore:
                 max_id = eid
             try:
                 if isinstance(data, (bytes, bytearray)):
+                    data = _ccr.maybe_decompress(data)
                     data = bytes(data).decode("utf-8", "replace")
                 obj = json.loads(data) if isinstance(data, str) else data
             except Exception:
@@ -5010,6 +5019,7 @@ class LocalStore:
             raw = d.get("raw_blob")
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     try:
                         d["raw_blob"] = json.loads(text)
@@ -5901,6 +5911,7 @@ class LocalStore:
             raw = d.get("condition_json")
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     try:
                         d["condition_json"] = json.loads(text)
@@ -6760,6 +6771,7 @@ class LocalStore:
             meta: dict[str, Any] = {}
             if raw:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     meta = json.loads(text) if text else {}
                     if not isinstance(meta, dict):
@@ -6807,6 +6819,7 @@ class LocalStore:
             data: dict[str, Any] = {}
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     parsed = json.loads(text) if text else {}
                     if isinstance(parsed, dict):
@@ -6860,6 +6873,7 @@ class LocalStore:
             data: dict[str, Any] = {}
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     parsed = json.loads(text) if text else {}
                     if isinstance(parsed, dict):
@@ -7092,6 +7106,7 @@ class LocalStore:
                 data: dict[str, Any] = {}
                 if raw is not None:
                     try:
+                        raw = _ccr.maybe_decompress(raw)
                         text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                         parsed = json.loads(text) if text else {}
                         if isinstance(parsed, dict):
@@ -7235,6 +7250,7 @@ class LocalStore:
             if raw is None:
                 return {}
             try:
+                raw = _ccr.maybe_decompress(raw)
                 text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                 parsed = json.loads(text) if text else {}
                 return parsed if isinstance(parsed, dict) else {}
@@ -7466,6 +7482,7 @@ class LocalStore:
             data: dict[str, Any] = {}
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     parsed = json.loads(text) if text else {}
                     if isinstance(parsed, dict):
@@ -7591,6 +7608,7 @@ class LocalStore:
             data: dict[str, Any] = {}
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     parsed = json.loads(text) if text else {}
                     if isinstance(parsed, dict):
@@ -7798,6 +7816,7 @@ class LocalStore:
             data: dict[str, Any] = {}
             if raw is not None:
                 try:
+                    raw = _ccr.maybe_decompress(raw)
                     text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                     parsed = json.loads(text) if text else {}
                     if isinstance(parsed, dict):
@@ -8949,6 +8968,8 @@ def _event_to_row(e: dict[str, Any]) -> tuple:
             data = data.encode("utf-8")
         else:
             data = json.dumps(data, separators=(",", ":")).encode("utf-8")
+            if _ccr.enabled():
+                data = _ccr.compress(data)
     cost, tokens, model = _extract_event_metrics(e)
     return (
         str(e["id"]),
@@ -8974,6 +8995,7 @@ def _row_to_event(row: tuple, cols: list[str]) -> dict[str, Any]:
     raw = out.get("data")
     if raw is not None:
         try:
+            raw = _ccr.maybe_decompress(raw)
             text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
             try:
                 out["data"] = json.loads(text)
@@ -9699,6 +9721,7 @@ def _decode_data_blob_rows(rows: Iterable[tuple], cols: list[str]) -> list[dict[
         raw = d.get("data")
         if raw is not None:
             try:
+                raw = _ccr.maybe_decompress(raw)
                 text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
                 try:
                     d["data"] = json.loads(text)

--- a/tests/test_ccr.py
+++ b/tests/test_ccr.py
@@ -1,0 +1,75 @@
+"""CCR codec + safety eval (#2843, #2844): reversible, auto-detecting, lossless,
+never larger, and a no-op on uncompressed/foreign blobs so every reader is safe."""
+import json
+import os
+import importlib
+
+import clawmetry.ccr as ccr
+
+
+def test_roundtrip_lossless():
+    payload = json.dumps([{"path": "/x/%d" % i, "ok": True} for i in range(500)]).encode()
+    packed = ccr.compress(payload, force=True)
+    assert packed.startswith(b"\x1fCCR1")
+    assert ccr.maybe_decompress(packed) == payload     # byte-identical
+    # large repetitive content actually shrinks
+    assert len(packed) < len(payload)
+
+
+def test_decoder_is_a_noop_on_plain_blobs():
+    plain = b'{"hello":"world"}'
+    assert ccr.maybe_decompress(plain) == plain         # plain JSON untouched
+    assert ccr.maybe_decompress("a string") == "a string"
+    assert ccr.maybe_decompress(None) is None
+    # decoding random non-magic bytes returns them unchanged (reader then decides)
+    assert ccr.maybe_decompress(b"\x00\x01\x02") == b"\x00\x01\x02"
+
+
+def test_small_payloads_not_compressed():
+    tiny = b'{"a":1}'
+    assert ccr.compress(tiny) == tiny                   # below threshold, unchanged
+    assert not ccr.compress(tiny).startswith(b"\x1fCCR1")
+
+
+def test_compress_is_idempotent_and_never_grows():
+    p = ("x" * 5000).encode()
+    once = ccr.compress(p, force=True)
+    assert ccr.compress(once, force=True) == once       # idempotent
+    # incompressible-but-small magic guard: never returns something bigger
+    assert len(ccr.compress(p, force=True)) <= len(p) + len(b"\x1fCCR1")
+
+
+def test_enabled_reads_env(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_CCR", raising=False)
+    assert ccr.enabled() is False
+    monkeypatch.setenv("CLAWMETRY_CCR", "1")
+    assert ccr.enabled() is True
+
+
+def test_event_row_seam_roundtrip_byte_identical(monkeypatch):
+    """The real write->read seam: with CCR ON a large event compresses on write
+    (_event_to_row) and inflates byte-identical on read (_row_to_event)."""
+    monkeypatch.setenv("CLAWMETRY_CCR", "1")
+    import clawmetry.local_store as ls
+    big = {"tool": "Grep", "results": [{"path": "/p/%d" % i, "line": "x" * 40} for i in range(300)]}
+    ev = {"id": "ev1", "agent_type": "openclaw", "node_id": "n", "agent_id": "main",
+          "session_id": "s1", "event_type": "tool_result", "ts": "2026-06-08T00:00:00Z",
+          "data": big}
+    row = ls._event_to_row(ev)
+    # the stored data BLOB is actually compressed (carries the CCR magic)
+    data_idx = ls._EVENT_COLS.index("data")
+    assert row[data_idx].startswith(b"\x1fCCR1"), "large event was not compressed with CCR on"
+    back = ls._row_to_event(row, ls._EVENT_COLS)
+    assert back["data"] == big, "CCR seam changed the payload"
+
+
+def test_event_row_seam_default_off_is_unchanged(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_CCR", raising=False)
+    import clawmetry.local_store as ls
+    big = {"results": [{"k": "v" * 50} for i in range(300)]}
+    row = ls._event_to_row({"id": "e", "agent_type": "openclaw", "node_id": "n",
+                            "agent_id": "main", "session_id": "s", "event_type": "t",
+                            "ts": "x", "data": big})
+    data_idx = ls._EVENT_COLS.index("data")
+    assert not row[data_idx].startswith(b"\x1fCCR1"), "default path must NOT compress"
+    assert ls._row_to_event(row, ls._EVENT_COLS)["data"] == big


### PR DESCRIPTION
[RELEASE] feat(storage): CCR reversible event compression (opt-in) + safety eval (#2843, #2844)

Headroom-inspired (chopratejas/headroom): tool outputs (search results, logs,
diffs, big JSON) dominate transcript size. CCR optionally gzips the event `data`
BLOB at ingest and transparently inflates it on read, cutting local DuckDB + the
E2E cloud snapshot with ZERO loss.

Safety-first design:
- clawmetry/ccr.py: tiny stdlib-only (zlib) codec. compress() adds a 5-byte magic
  prefix + zlib (only above 2KB, never larger than the original, idempotent);
  maybe_decompress() inflates ONLY blobs carrying the magic and passes everything
  else through untouched.
- Because the decoder auto-detects, it is a no-op on uncompressed/foreign blobs,
  so it is prepended to ALL 18 event-data decoders + the 2 ad-hoc cost/benign
  readers in local_store.py — every read path stays correct whether the write
  flag is on or off, and old uncompressed rows always read fine.
- WRITE compression is OFF by default; CLAWMETRY_CCR=1 opts in (self-host). The
  default path is byte-for-byte unchanged.
- tests/test_ccr.py (#2844): lossless round-trip, decoder no-op on plain blobs,
  threshold + idempotency + never-grows, env gate, and the REAL _event_to_row ->
  _row_to_event seam proving a large event compresses on write and inflates
  byte-identical on read (and default-off stays uncompressed).

Refs epic #2837. Closes #2843, #2844.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
