### PR TITLE
[RELEASE] feat(cloud): carry compression-potential metrics in the snapshot (cloud #1478)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10424,6 +10424,11 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                     "cache_expiry_count": _idle.get("cacheExpiryCount"),
                     "tool_error_pct": _thealth.get("toolErrorPct"),
                     "compaction_count": _compactions or None,
+                    # Compression-potential meter (#2838) carried to the cloud so
+                    # the recoverable-spend roll-up renders from the snapshot too.
+                    "compression_potential_pct": _compress.get("compressionPotentialPct"),
+                    "compressible_tool_tokens": _compress.get("compressibleToolTokens"),
+                    "compression_recoverable_usd": _compress.get("compressionRecoverableUsd"),
                 })
                 # Events → transcript (rides the existing _build_transcripts path).
                 # Re-ingest the full event set for sessions that advanced (the


### PR DESCRIPTION
[RELEASE] feat(cloud): carry compression-potential metrics in the snapshot (closes cloud #1478)

The compression-potential meter (#2838) stored compressionPotentialPct /
compressibleToolTokens / compressionRecoverableUsd on session metadata, but the
cloud snapshot session slice whitelists fields, so they did not reach the cloud
recoverable-spend roll-up. Add them (snake_case) alongside the existing
reasoning_cost_usd / cache_expiry_count so `_derive_waste_summary` + the
`_renderWasteSummary` cards (already shipped) render the "compressible tool
output" + "cache expiries" rows on app.clawmetry.com too once the wheel is pinned.

Refs epic #2837. Closes vivekchand/clawmetry-cloud#1478.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
