### PR TITLE
[RELEASE] feat(stuck-detect): daemon-side stuck-agent detection from the event stream (#15)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -12990,6 +12990,356 @@ def _seconds_since(ts) -> int:
         return 0
 
 
+# ── Daemon-side STUCK-agent detection (issue clawmetry-hardware#15) ──────────
+# The desk device promises a "<runtime> stuck: N tool calls, no progress"
+# banner. Until now the ONLY stuck/loop signal came from the enforcement PROXY
+# (clawmetry.proxy.LoopDetector.ingest_loop_signal), so anyone NOT running the
+# proxy never saw it. This detector reconstructs the same signal from the event
+# stream the daemon already ingests into DuckDB, so it works for EVERYONE,
+# proxy-independent. It is strictly read-only (it only READS events and WRITES a
+# loop_signals row — it never touches the agent), so it can default ON.
+#
+# Definition of "stuck": a recently-active, non-ended session whose newest
+# events are a long CONSECUTIVE run of tool activity with NO progress marker
+# since the streak began. A progress marker is what a healthy agent emits
+# between tool batches: an assistant message carrying TEXT content (a reply /
+# reasoning, not just tool_use), a user message, or a session end. A normal
+# agent doing real work breaks its tool streak with text replies and hits
+# results, so only a true no-progress streak that is BOTH long (>= threshold
+# tool calls) AND slow (spanning >= min-seconds wall-clock) trips it. Both
+# bounds must hold so a fast burst of tool calls (legitimate parallel work)
+# and a small streak are both excused.
+STUCK_TOOL_THRESHOLD = int(os.environ.get("CLAWMETRY_STUCK_TOOLS", "25"))
+STUCK_MIN_SECONDS = int(os.environ.get("CLAWMETRY_STUCK_SECONDS", "180"))
+# How recently a session must have been active to be a candidate. A truly idle
+# session (last active hours ago) is not "stuck right now" — it just stopped.
+STUCK_RECENT_MINUTES = int(os.environ.get("CLAWMETRY_STUCK_RECENT_MINUTES", "15"))
+# How many newest events to inspect per candidate session. 120 comfortably
+# covers a streak well past the threshold plus the preceding progress marker.
+_STUCK_EVENT_WINDOW = 120
+
+# Event types that count as a TOOL action in the streak. Covers every ingest
+# variant (Anthropic-style, OpenClaw v3 dotted, camelCase, hyphenated) so the
+# streak counts the same tool turns the transcript renders. Mirrors
+# local_store._TOOL_CALL_TOPLEVEL_EVENT_TYPES + the result/dotted forms.
+# Top-level tool-CALL events (family adapters emit these directly). Tool RESULT
+# events are deliberately EXCLUDED — a result is not a new invocation, and
+# counting it double-counts each round-trip (~2x inflation).
+_STUCK_TOPLEVEL_TOOL_CALL_TYPES = frozenset({
+    "tool_call", "tool_use", "toolcall", "tool.call", "tool.invoked",
+})
+# Assistant/model turn envelopes that may HOST tool calls inside the message
+# (OpenClaw v3 ``model.completed`` + ``data.toolMetas``; Claude Code ``assistant``
+# + ``message.content`` tool_use blocks). Counted via the canonical
+# ``_iter_tool_invocation_names`` so the streak counts the same tool turns the
+# rest of the app counts — top-level ``tool_call`` is rare on the real runtimes.
+_STUCK_ASSISTANT_EVENT_TYPES = frozenset({
+    "assistant", "message", "model.completed", "subagent:assistant",
+})
+# Event types that are unambiguously a PROGRESS marker on their own (no need to
+# inspect content). A user prompt or a session end breaks any streak.
+_STUCK_PROGRESS_EVENT_TYPES = frozenset({
+    "user", "prompt.submitted",
+    "session.ended", "session.end", "session.completed", "session.stopped",
+})
+
+
+def _stuck_tool_call_count(et: str, data: Any) -> int:
+    """Number of tool CALLS an event represents (0 if none). Handles all three
+    real shapes: a top-level ``tool_call``/``tool_use`` event (1), OpenClaw v3
+    ``model.completed`` with ``data.toolMetas`` (N), and Claude Code ``assistant``
+    with ``message.content`` tool_use blocks (N). Mirrors the app-wide
+    ``_iter_tool_invocation_names`` so the streak counts what everything else
+    counts — and counts CALLS only, never tool_result. Never raises."""
+    if et in _STUCK_TOPLEVEL_TOOL_CALL_TYPES:
+        return 1
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except Exception:
+            return 0
+    if not isinstance(data, dict):
+        return 0
+    try:
+        from clawmetry.local_store import _iter_tool_invocation_names
+        return sum(1 for _ in _iter_tool_invocation_names(et, data))
+    except Exception:
+        return 0
+
+
+def _stuck_event_role(data: Any) -> str:
+    """Best-effort role for an event payload. ``data`` may be a dict, a JSON
+    string, or junk — mirror _row_to_event/_brain_row_renderable defensiveness
+    and never raise. Returns a lowercase role ('assistant'/'user'/'system'/…)
+    or '' when none is discernible."""
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except Exception:
+            return ""
+    if not isinstance(data, dict):
+        return ""
+    role = data.get("role")
+    if not role and isinstance(data.get("message"), dict):
+        role = data["message"].get("role")
+    return str(role or "").strip().lower()
+
+
+def _stuck_assistant_has_text(data: Any) -> bool:
+    """True if an assistant event carries real TEXT content (a reply / visible
+    reasoning), as opposed to a tool-call-only turn. Walks the common content
+    shapes: a plain string, or a list of blocks where a ``text`` block has
+    non-empty text. ``tool_use``/``toolCall`` blocks do NOT count as text —
+    those ARE the streak. Never raises."""
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except Exception:
+            # A non-JSON string body is itself text content.
+            return bool(data.strip())
+    if not isinstance(data, dict):
+        return False
+    msg = data.get("message") if isinstance(data.get("message"), dict) else data
+    content = msg.get("content")
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        for blk in content:
+            if not isinstance(blk, dict):
+                # A bare string block counts as text.
+                if isinstance(blk, str) and blk.strip():
+                    return True
+                continue
+            btype = str(blk.get("type") or "").lower()
+            if btype in ("text", "output_text") and str(blk.get("text") or "").strip():
+                return True
+            # Some shapes omit ``type`` but carry ``text`` directly.
+            if not btype and str(blk.get("text") or "").strip():
+                return True
+    # Anthropic SDK also surfaces a top-level ``text`` on some assistant rows.
+    if isinstance(msg.get("text"), str) and msg["text"].strip():
+        return True
+    # OpenClaw v3 ``model.completed`` turns carry the reply under different keys
+    # (a string ``completionText``/``completion`` or a list ``assistantTexts``);
+    # a real text reply there is progress too, so a v3 narration breaks the streak.
+    for k in ("completionText", "completion"):
+        if isinstance(data.get(k), str) and data[k].strip():
+            return True
+    at = data.get("assistantTexts")
+    if isinstance(at, list) and any(isinstance(t, str) and t.strip() for t in at):
+        return True
+    return False
+
+
+def _detect_stuck_sessions(store) -> list[dict]:
+    """Reconstruct the proxy's stuck/loop signal from the DuckDB event stream.
+
+    For each recently-active, NON-ended session, walk its newest events
+    newest->older counting the CONSECUTIVE tool streak since the last progress
+    marker. A streak that is BOTH long (>= STUCK_TOOL_THRESHOLD tool calls) AND
+    slow (>= STUCK_MIN_SECONDS wall-clock span) marks the session STUCK.
+
+    Returns a list of ``{session_id, runtime, tool_calls, since_seconds}``,
+    most-stuck (longest streak) first. Read-only and never raises — any store
+    error logs a warning and yields ``[]`` so the daemon loop is never taken
+    down by detection.
+    """
+    try:
+        from clawmetry import waste_flags as _wf
+    except Exception:
+        _wf = None
+
+    try:
+        sessions = store.query_sessions_table(limit=300) or []
+    except Exception as e:  # noqa: BLE001
+        log.warning("stuck-detect: query_sessions_table failed: %s", e)
+        return []
+
+    out: list[dict] = []
+    for s in sessions:
+        if not isinstance(s, dict):
+            continue
+        # Skip ended sessions outright — a finished agent is not "stuck".
+        if s.get("ended_at"):
+            continue
+        status = str(s.get("status") or "").lower()
+        if status in ("ended", "completed", "stopped", "failed"):
+            continue
+        sid = s.get("session_id") or ""
+        if not sid:
+            continue
+        # Recency gate: only sessions active in the last STUCK_RECENT_MINUTES
+        # are candidates. query_sessions_table is ordered most-recent-active
+        # first, so the first stale row lets us stop scanning the tail.
+        last_active = s.get("last_active_at") or s.get("started_at")
+        idle_s = _seconds_since(last_active)
+        if last_active and idle_s > STUCK_RECENT_MINUTES * 60:
+            break
+
+        try:
+            events = store.query_events(
+                session_id=sid, limit=_STUCK_EVENT_WINDOW,
+            ) or []
+        except Exception as e:  # noqa: BLE001
+            log.warning("stuck-detect: query_events failed for %s: %s", sid, e)
+            continue
+        # query_events returns newest-first (ORDER BY ts DESC). Walk it in that
+        # order, counting the consecutive tool streak until the first progress
+        # marker. ``newest_ts``/``oldest_ts`` bound the streak's wall-clock span.
+        tool_calls = 0
+        newest_ts = None
+        oldest_ts = None
+        for ev in events:
+            if not isinstance(ev, dict):
+                continue
+            et = str(ev.get("event_type") or "").strip().lower()
+            data = ev.get("data")
+            ts = ev.get("ts")
+
+            if et in _STUCK_PROGRESS_EVENT_TYPES:
+                break  # user prompt / session end → progress, streak ends.
+            # An assistant / model.completed turn carrying TEXT is a reply →
+            # progress. A user message is progress regardless of et. A tool-only
+            # assistant/model turn is NOT progress — its hosted tools are counted.
+            role = _stuck_event_role(data)
+            if role == "user":
+                break
+            if et in _STUCK_ASSISTANT_EVENT_TYPES or role == "assistant":
+                if _stuck_assistant_has_text(data):
+                    break  # text reply → progress.
+
+            # Count tool CALLS for this event — top-level tool_call OR tool calls
+            # hosted inside an assistant/model envelope (toolMetas / content
+            # blocks). Counts calls only (never tool_result), so the threshold +
+            # the reported number mean real invocations.
+            n = _stuck_tool_call_count(et, data)
+            if n:
+                tool_calls += n
+                if newest_ts is None:
+                    newest_ts = ts
+                oldest_ts = ts
+            # Any other event (tool_result, heartbeat, model.changed, system, …)
+            # is neither a new tool call nor progress — skip without breaking.
+            continue
+
+        if tool_calls < STUCK_TOOL_THRESHOLD:
+            continue
+        # Wall-clock span of the streak (oldest..newest tool call). _seconds_since
+        # on the OLDEST streak event is the streak duration only if the newest
+        # is ~now; compute the explicit span instead to be precise.
+        span = _stuck_streak_span_seconds(oldest_ts, newest_ts)
+        if span < STUCK_MIN_SECONDS:
+            continue
+        runtime = "openclaw"
+        if _wf is not None:
+            try:
+                runtime = _wf.runtime_from_session_id(sid) or "openclaw"
+            except Exception:
+                runtime = "openclaw"
+        out.append({
+            "session_id": sid,
+            "runtime": runtime,
+            "tool_calls": tool_calls,
+            "since_seconds": span,
+        })
+
+    out.sort(key=lambda r: r.get("tool_calls", 0), reverse=True)
+    return out
+
+
+def _stuck_streak_span_seconds(oldest_ts, newest_ts) -> int:
+    """Wall-clock seconds between the oldest and newest tool-call in a streak.
+    Both are ISO-ish naive local strings (the store's convention). Falls back to
+    'seconds since oldest' when newest is unparseable, and 0 on total failure."""
+    try:
+        from datetime import datetime as _dt
+
+        def _parse(x):
+            s = str(x).strip().replace("Z", "")
+            try:
+                return _dt.fromisoformat(s)
+            except ValueError:
+                return _dt.fromisoformat(s.split(".")[0].split("+")[0])
+
+        if oldest_ts and newest_ts:
+            o, n = _parse(oldest_ts), _parse(newest_ts)
+            return max(0, int((n - o).total_seconds()))
+    except Exception:
+        pass
+    # Fallback: treat the streak as running until now.
+    return _seconds_since(oldest_ts)
+
+
+def _emit_stuck_signals(store, state: dict) -> int:
+    """Run stuck detection and emit each as a loop_signals row so the EXISTING
+    device-alert path (``_build_device_summary`` → ``query_recent_loop_signals``)
+    fires the "<runtime> stuck" banner WITHOUT a new alert source. Dedupes per
+    session within STUCK_REEMIT_SECONDS so we don't re-write every tick; the
+    30-minute ``last_seen`` window in the snapshot auto-clears the banner once a
+    session stops being stuck (we simply stop re-emitting). Returns the count of
+    sessions detected as stuck this tick. Never raises into the daemon loop."""
+    try:
+        stuck = _detect_stuck_sessions(store)
+    except Exception as e:  # noqa: BLE001
+        log.warning("stuck-detect: detector errored: %s", e)
+        return 0
+    if not stuck:
+        return 0
+
+    memo = state.setdefault("stuck_emit_memo", {})
+    if not isinstance(memo, dict):
+        memo = {}
+        state["stuck_emit_memo"] = memo
+    now = time.time()
+    # Don't re-write a session's signal more than once per re-emit window, but
+    # DO re-emit periodically so ``last_seen`` stays fresh inside the snapshot's
+    # 30-min window while the session remains stuck.
+    reemit = max(30, STUCK_MIN_SECONDS // 2)
+
+    emitted = 0
+    for st in stuck:
+        sid = st["session_id"]
+        last = memo.get(sid)
+        if isinstance(last, (int, float)) and (now - last) < reemit:
+            continue
+        n = int(st["tool_calls"])
+        mins = max(1, st["since_seconds"] // 60)
+        rt = st["runtime"]
+        msg = f"{rt} stuck: {n} tool calls, no progress for {mins}m"
+        try:
+            store.ingest_loop_signal(
+                session_id=sid,
+                # Stable signature per session so a re-emit UPSERTs the same row
+                # (GREATEST bumps repeat_count, refreshes last_seen) instead of
+                # piling up rows — matches the proxy's (session_id, signature) PK.
+                signature="daemon_stuck",
+                repeat_count=n,
+                severity="warning",
+                agent_type=rt,
+                details={
+                    "source": "daemon_stuck_detector",
+                    "message": msg,
+                    "tool_calls": n,
+                    "since_seconds": st["since_seconds"],
+                },
+            )
+            memo[sid] = now
+            emitted += 1
+            log.info("stuck-detect: %s", msg)
+        except Exception as e:  # noqa: BLE001
+            log.warning("stuck-detect: ingest_loop_signal failed for %s: %s",
+                        sid, e)
+            continue
+    # Bound memo growth: drop entries we haven't touched in an hour.
+    try:
+        for k in [k for k, v in memo.items()
+                  if not (isinstance(v, (int, float)) and (now - v) < 3600)]:
+            memo.pop(k, None)
+    except Exception:
+        pass
+    return emitted
+
+
 def _build_device_summary(spending, daily_usage):
     """Compact, all-runtime payload for a WiFi hardware companion.
 
@@ -13106,17 +13456,32 @@ def _build_device_summary(spending, daily_usage):
         pass
     # Surface a "something is stuck" alert from the daemon's loop-detection
     # signals so the device alert card can fire. It was always null while the
-    # alert source lived only in the dashboard process (#contract-drift).
+    # alert source lived only in the dashboard process (#contract-drift). The
+    # signals come from BOTH the enforcement proxy's LoopDetector AND (issue
+    # clawmetry-hardware#15) the daemon's proxy-independent _emit_stuck_signals,
+    # so the banner now fires for everyone, not just proxy users.
     try:
         from clawmetry import waste_flags as _wf
         sigs = store.query_recent_loop_signals(limit=5, since_minutes=30) or []
         hot = next((s for s in sigs if isinstance(s, dict)
                     and int(s.get("repeat_count") or 0) >= 5), None)
         if hot:
-            rt = (_wf.runtime_from_session_id(hot.get("session_id") or "")
-                  or hot.get("agent_type") or "an agent")
-            n = int(hot.get("repeat_count") or 0)
-            summary["alert"] = {"message": f"{rt} looping, {n} repeats, no progress"}
+            # Prefer the precise message the daemon stuck-detector stashed in
+            # ``details`` ("<rt> stuck: N tool calls, no progress for Mm");
+            # fall back to the generic looping wording for proxy-only signals.
+            det = hot.get("details")
+            if isinstance(det, str):
+                try:
+                    det = json.loads(det)
+                except Exception:
+                    det = None
+            msg = det.get("message") if isinstance(det, dict) else None
+            if not msg:
+                rt = (_wf.runtime_from_session_id(hot.get("session_id") or "")
+                      or hot.get("agent_type") or "an agent")
+                n = int(hot.get("repeat_count") or 0)
+                msg = f"{rt} looping, {n} repeats, no progress"
+            summary["alert"] = {"message": str(msg)[:200]}
     except Exception:
         pass
     # A waiting approval or a stuck/looping agent is what needs a human.
@@ -14742,6 +15107,11 @@ def run_daemon() -> None:
     # ENABLED=0 disables cleanly. 0 = fire on first cycle so a daemon
     # restart scores the backlog without waiting 5 min.
     last_evals_run = 0.0
+    # Stuck-agent detector (issue clawmetry-hardware#15). Proxy-independent;
+    # reads the event stream and emits a loop_signals row that the device-alert
+    # path already reads. 0 = run on first cycle so a stuck agent at daemon
+    # start surfaces immediately.
+    last_stuck_eval = 0.0
 
     while True:
         try:
@@ -14967,6 +15337,34 @@ def run_daemon() -> None:
                     save_state(state)
                 except Exception:
                     pass
+
+            # ── Stuck-agent detector (issue clawmetry-hardware#15) ──
+            # Proxy-independent: reads the event stream from DuckDB, finds
+            # sessions in a long no-progress tool streak, and emits a
+            # loop_signals row so the device's "<runtime> stuck" banner fires
+            # for EVERYONE (not just users running the enforcement proxy).
+            # Strictly read-only w.r.t. the agent, throttled, and best-effort —
+            # a failure logs but never raises into the sync cycle.
+            if os.environ.get("CLAWMETRY_STUCK_DETECT", "1") != "0":
+                now_stuck = time.time()
+                if (now_stuck - last_stuck_eval) >= STUCK_EVAL_INTERVAL_SEC:
+                    try:
+                        from clawmetry import local_store as _ls_stuck
+                        store_for_stuck = _ls_stuck.get_store()
+                        n_stuck = _emit_stuck_signals(store_for_stuck, state)
+                        if n_stuck:
+                            log.info(
+                                f"stuck-detect: {n_stuck} stuck session(s)"
+                            )
+                    except Exception as _se:
+                        log.warning(
+                            f"stuck-detect: tick errored: {_se}"
+                        )
+                    last_stuck_eval = now_stuck
+                    try:
+                        save_state(state)
+                    except Exception:
+                        pass
 
             # ── Eval scheduler (issue #1619 Phase 1) ──
             # Sister of the alerts evaluator. Picks unscored completed
@@ -16032,6 +16430,11 @@ def sync_autonomy(config, state, paths):
 
 
 ALERTS_EVAL_INTERVAL_SEC = 60  # Re-evaluate alerts every 60s (PRD #779)
+
+# Stuck-agent detector cadence (issue clawmetry-hardware#15). 60s keeps the
+# device banner fresh without re-scanning every tight sync tick; env override
+# for tests / tuning.
+STUCK_EVAL_INTERVAL_SEC = int(os.environ.get("CLAWMETRY_STUCK_INTERVAL_SEC", "60"))
 
 # Issue #1619 Phase 1 — LLM-as-judge eval scheduler cadence. 300s (5 min)
 # matches the PRD: every 5 min, pick up to EVAL_BATCH unscored completed

--- a/tests/test_stuck_detection.py
+++ b/tests/test_stuck_detection.py
@@ -1,0 +1,485 @@
+"""Tests for the daemon-side STUCK-agent detector (issue clawmetry-hardware#15).
+
+The desk device promises a "<runtime> stuck: N tool calls, no progress" banner.
+Until now the only stuck/loop signal came from the enforcement PROXY's
+LoopDetector, so anyone not running the proxy never saw it. ``sync._detect_stuck_sessions``
+reconstructs the same signal from the DuckDB event stream so it works for
+EVERYONE, proxy-independent.
+
+These tests pin the detector's LOGIC with a synthetic event stream (a fake
+store) — synthetic input is appropriate for a deterministic unit test (the
+no-synthetic-seeds rule targets e2e tests) — plus one real-DuckDB integration
+test of the full emit -> query_recent_loop_signals -> device-alert path.
+
+Covered:
+  * A long no-progress tool streak trips the detector.
+  * A stream WITH interleaved assistant text replies does NOT trip it.
+  * Threshold boundary: streak of exactly (threshold-1) is excused, threshold trips.
+  * The wall-clock min-seconds bound: a long but FAST streak is excused.
+  * An ended / idle session is ignored.
+  * A user message inside the streak resets it (progress marker).
+  * Bad / malformed event data doesn't crash the detector.
+  * Integration: _emit_stuck_signals -> ingest_loop_signal -> the
+    _build_device_summary alert path produces the "<rt> stuck" banner, and the
+    banner self-clears (no re-emit) once the session is no longer stuck.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import clawmetry.sync as sync  # noqa: E402
+
+
+# ── Synthetic event-stream helpers ───────────────────────────────────────────
+#
+# query_events() returns NEWEST-first (ORDER BY ts DESC). The detector walks in
+# that order, so build helpers that produce a chronological list and reverse it
+# to mimic the store's ordering.
+
+_BASE = 1_700_000_000  # arbitrary epoch base for synthetic ts (seconds)
+
+
+def _ts(offset_s: int) -> str:
+    """Naive-local ISO string `offset_s` seconds after the base — matches the
+    store's wall-clock convention."""
+    from datetime import datetime
+
+    return datetime.fromtimestamp(_BASE + offset_s).isoformat()
+
+
+def _tool_ev(offset_s: int, et: str = "tool_call") -> dict:
+    return {"event_type": et, "ts": _ts(offset_s), "data": {"name": "Bash"}}
+
+
+def _assistant_text_ev(offset_s: int, text: str = "Here is the result.") -> dict:
+    return {
+        "event_type": "assistant",
+        "ts": _ts(offset_s),
+        "data": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _user_ev(offset_s: int) -> dict:
+    return {"event_type": "user", "ts": _ts(offset_s),
+            "data": {"role": "user", "content": "do the thing"}}
+
+
+class _FakeStore:
+    """Minimal store satisfying the detector's surface: query_sessions_table,
+    query_events, ingest_loop_signal."""
+
+    def __init__(self, sessions, events_by_sid):
+        self._sessions = sessions
+        # events_by_sid maps session_id -> chronological event list; store
+        # returns newest-first, so reverse on read.
+        self._events = events_by_sid
+        self.ingested: list[dict] = []
+
+    def query_sessions_table(self, *, agent_type=None, limit=200):
+        return list(self._sessions)[:limit]
+
+    def query_events(self, *, session_id=None, limit=500, **kw):
+        evs = list(self._events.get(session_id, []))
+        evs = list(reversed(evs))  # newest-first, like DuckDB ORDER BY ts DESC
+        return evs[:limit]
+
+    def ingest_loop_signal(self, **kw):
+        self.ingested.append(kw)
+
+
+def _active_session(sid="claude_code:abc", **extra):
+    """A recently-active, non-ended session row. last_active_at defaults to
+    'now' so the recency gate passes regardless of test clock."""
+    from datetime import datetime
+
+    row = {
+        "session_id": sid,
+        "status": "active",
+        "ended_at": None,
+        "started_at": datetime.now().isoformat(),
+        "last_active_at": datetime.now().isoformat(),
+    }
+    row.update(extra)
+    return row
+
+
+@pytest.fixture(autouse=True)
+def _conservative_thresholds(monkeypatch):
+    """Pin module thresholds to the documented defaults regardless of the
+    runner's env (a CI box might export CLAWMETRY_STUCK_* )."""
+    monkeypatch.setattr(sync, "STUCK_TOOL_THRESHOLD", 25, raising=False)
+    monkeypatch.setattr(sync, "STUCK_MIN_SECONDS", 180, raising=False)
+    monkeypatch.setattr(sync, "STUCK_RECENT_MINUTES", 15, raising=False)
+
+
+# ── Core logic ───────────────────────────────────────────────────────────────
+
+
+def test_long_no_progress_streak_trips():
+    sid = "claude_code:stuck1"
+    # 40 tool calls, one every 10s -> 390s span, well over both bounds.
+    evs = [_tool_ev(i * 10) for i in range(40)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+
+    stuck = sync._detect_stuck_sessions(store)
+
+    assert len(stuck) == 1
+    s = stuck[0]
+    assert s["session_id"] == sid
+    assert s["runtime"] == "claude_code"
+    assert s["tool_calls"] == 40
+    assert s["since_seconds"] >= 180
+
+
+def test_interleaved_text_replies_do_not_trip():
+    sid = "openclaw:healthy"
+    # 40 tool calls but an assistant TEXT reply every 5 calls -> the streak
+    # since the last reply is only ~4, far below threshold.
+    evs = []
+    t = 0
+    for batch in range(8):
+        for _ in range(5):
+            evs.append(_tool_ev(t))
+            t += 10
+        evs.append(_assistant_text_ev(t))  # progress marker
+        t += 10
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+
+    assert sync._detect_stuck_sessions(store) == []
+
+
+def test_threshold_boundary():
+    sid = "codex:edge"
+    span_each = 10  # 10s between calls
+
+    # threshold-1 (24) tool calls -> NOT stuck.
+    evs24 = [_tool_ev(i * span_each) for i in range(sync.STUCK_TOOL_THRESHOLD - 1)]
+    store24 = _FakeStore([_active_session(sid)], {sid: evs24})
+    assert sync._detect_stuck_sessions(store24) == []
+
+    # exactly threshold (25) tool calls AND span >= 180s -> stuck.
+    evs25 = [_tool_ev(i * span_each) for i in range(sync.STUCK_TOOL_THRESHOLD)]
+    store25 = _FakeStore([_active_session(sid)], {sid: evs25})
+    stuck = sync._detect_stuck_sessions(store25)
+    assert len(stuck) == 1
+    assert stuck[0]["tool_calls"] == sync.STUCK_TOOL_THRESHOLD
+
+
+def test_long_but_fast_streak_is_excused():
+    sid = "aider:fast"
+    # 60 tool calls but only 1s apart -> 59s span, below STUCK_MIN_SECONDS.
+    evs = [_tool_ev(i) for i in range(60)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    assert sync._detect_stuck_sessions(store) == []
+
+
+def test_user_message_resets_streak():
+    sid = "openclaw:reset"
+    # 30 tool calls, then a USER message, then 5 more tool calls (newest).
+    # Walking newest->older, the user message breaks the streak at 5 tools.
+    evs = [_tool_ev(i * 10) for i in range(30)]
+    evs.append(_user_ev(300))
+    evs += [_tool_ev(310 + i * 10) for i in range(5)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    assert sync._detect_stuck_sessions(store) == []
+
+
+def test_ended_session_ignored():
+    sid = "claude_code:done"
+    evs = [_tool_ev(i * 10) for i in range(40)]
+    ended = _active_session(sid, status="ended", ended_at=_ts(400))
+    store = _FakeStore([ended], {sid: evs})
+    assert sync._detect_stuck_sessions(store) == []
+
+
+def test_idle_session_ignored():
+    sid = "claude_code:idle"
+    from datetime import datetime, timedelta
+
+    long_ago = (datetime.now() - timedelta(minutes=90)).isoformat()
+    evs = [_tool_ev(i * 10) for i in range(40)]
+    idle = _active_session(sid, last_active_at=long_ago, started_at=long_ago)
+    store = _FakeStore([idle], {sid: evs})
+    assert sync._detect_stuck_sessions(store) == []
+
+
+def test_bad_data_does_not_crash():
+    sid = "openclaw:junk"
+    # Mix valid tool calls with malformed rows: data is a junk string, a list,
+    # None, an int; rows that aren't dicts; a tool row whose data is a bad
+    # JSON string. None of this should raise.
+    evs = []
+    for i in range(40):
+        evs.append(_tool_ev(i * 10))
+    evs.append({"event_type": "tool_call", "ts": _ts(500), "data": "{not json"})
+    evs.append({"event_type": "assistant", "ts": _ts(510), "data": "plain string body"})
+    evs.append({"event_type": "weird", "ts": _ts(520), "data": [1, 2, 3]})
+    evs.append({"event_type": "tool_call", "ts": _ts(530), "data": None})
+    evs.append("not-a-dict-event")  # not a dict at all
+    evs.append({"event_type": "tool_call", "ts": None, "data": {"x": 1}})
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+
+    # Must not raise; the valid streak is still detected.
+    stuck = sync._detect_stuck_sessions(store)
+    assert isinstance(stuck, list)
+
+
+def test_assistant_text_string_content_is_progress():
+    sid = "openclaw:strcontent"
+    # assistant reply whose content is a plain STRING (not a block list) counts
+    # as text -> progress. 30 tools, then a string-content assistant reply,
+    # then 5 tools -> streak resets to 5.
+    evs = [_tool_ev(i * 10) for i in range(30)]
+    evs.append({"event_type": "assistant", "ts": _ts(300),
+                "data": {"role": "assistant", "content": "done with that step"}})
+    evs += [_tool_ev(310 + i * 10) for i in range(5)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    assert sync._detect_stuck_sessions(store) == []
+
+
+def test_tool_use_only_assistant_does_not_count_as_progress():
+    sid = "claude_code:tooluseonly"
+    # Anthropic shape: an assistant turn whose content is ONLY a tool_use block
+    # is NOT a text reply, so it must NOT break the streak. 40 such turns ->
+    # stuck. (The assistant envelope itself isn't a tool event type here, but
+    # the explicit tool_call rows around it are; model it as tool_use events.)
+    evs = [_tool_ev(i * 10, et="tool_use") for i in range(40)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    stuck = sync._detect_stuck_sessions(store)
+    assert len(stuck) == 1
+    assert stuck[0]["tool_calls"] == 40
+
+
+def test_tool_result_not_counted_only_calls():
+    """A round-trip is one tool_call + one tool_result; only the CALL counts
+    (results would ~2x-inflate the streak)."""
+    sid = "openclaw:dotted"
+    evs = []
+    t = 0
+    for _ in range(30):
+        evs.append(_tool_ev(t, et="tool.call"))
+        t += 10
+        evs.append(_tool_ev(t, et="tool.result"))  # result must NOT count
+        t += 10
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    stuck = sync._detect_stuck_sessions(store)
+    assert len(stuck) == 1
+    assert stuck[0]["tool_calls"] == 30  # 30 calls, not 60
+
+
+# ── Emit wiring + dedupe ─────────────────────────────────────────────────────
+
+
+def test_emit_writes_signal_and_message():
+    sid = "claude_code:emit"
+    evs = [_tool_ev(i * 10) for i in range(40)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    state: dict = {}
+
+    n = sync._emit_stuck_signals(store, state)
+
+    assert n == 1
+    assert len(store.ingested) == 1
+    sig = store.ingested[0]
+    assert sig["session_id"] == sid
+    assert sig["signature"] == "daemon_stuck"
+    assert sig["repeat_count"] == 40
+    assert "stuck" in sig["details"]["message"]
+    assert sig["details"]["message"].startswith("claude_code stuck:")
+    assert "no progress" in sig["details"]["message"]
+
+
+def test_emit_dedupes_within_window():
+    sid = "claude_code:dedupe"
+    evs = [_tool_ev(i * 10) for i in range(40)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    state: dict = {}
+
+    assert sync._emit_stuck_signals(store, state) == 1
+    # Immediate re-run: within the re-emit window -> no new write.
+    assert sync._emit_stuck_signals(store, state) == 0
+    assert len(store.ingested) == 1
+
+
+def test_emit_no_stuck_is_noop():
+    sid = "openclaw:fine"
+    evs = [_tool_ev(i) for i in range(10)]  # short + fast
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    state: dict = {}
+    assert sync._emit_stuck_signals(store, state) == 0
+    assert store.ingested == []
+
+
+# ── Real-DuckDB integration: emit -> read -> device alert -> self-clear ───────
+
+
+@pytest.fixture
+def real_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "stuck.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "1")
+    sys.modules.pop("clawmetry.local_store", None)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    # Own the writer so get_store() opens the real DuckDB writer against our tmp
+    # file instead of returning a _ProxyStore that forwards to any daemon that
+    # happens to be running on this dev box.
+    ls.mark_writer_owner()
+    store = ls.get_store()
+    yield store
+    try:
+        store.close()
+    except Exception:
+        pass
+
+
+def test_emit_to_device_alert_path(real_store):
+    """Full path: a detected stuck session -> ingest_loop_signal ->
+    query_recent_loop_signals -> _build_device_summary surfaces the precise
+    "<rt> stuck: ..." banner with NO cloud change."""
+    sid = "claude_code:integ"
+    evs = [_tool_ev(i * 10) for i in range(40)]
+
+    # Drive the detector against a fake-events store but write the signal into
+    # the REAL store, then read it back exactly as the snapshot does.
+    fake = _FakeStore([_active_session(sid)], {sid: evs})
+    stuck = sync._detect_stuck_sessions(fake)
+    assert len(stuck) == 1
+    st = stuck[0]
+    msg = f"{st['runtime']} stuck: {st['tool_calls']} tool calls, no progress"
+    real_store.ingest_loop_signal(
+        session_id=sid,
+        signature="daemon_stuck",
+        repeat_count=st["tool_calls"],
+        severity="warning",
+        agent_type=st["runtime"],
+        details={"source": "daemon_stuck_detector", "message": msg,
+                 "tool_calls": st["tool_calls"]},
+    )
+
+    sigs = real_store.query_recent_loop_signals(limit=5, since_minutes=30)
+    assert sigs, "signal must be readable within the 30-min window"
+    hot = next((s for s in sigs if int(s.get("repeat_count") or 0) >= 5), None)
+    assert hot is not None
+
+    # Mirror _build_device_summary's alert composition (details.message wins).
+    det = hot.get("details")
+    if isinstance(det, str):
+        import json as _j
+        det = _j.loads(det)
+    alert_msg = det.get("message") if isinstance(det, dict) else None
+    assert alert_msg and alert_msg.startswith("claude_code stuck:")
+
+
+def test_device_alert_self_clears_when_not_stuck(real_store):
+    """A signal whose last_seen is older than the snapshot's 30-min window is
+    NOT surfaced — so once the daemon stops re-emitting (session no longer
+    stuck) the banner clears on its own. No permanently-red banner.
+
+    Drive it with an explicit BACK-DATED last_seen (45 min ago) so the
+    snapshot's since_minutes=30 window excludes it, proving the auto-clear."""
+    from datetime import datetime, timedelta
+
+    sid = "claude_code:expire"
+    stale = (datetime.now() - timedelta(minutes=45)).isoformat(timespec="seconds")
+    real_store.ingest_loop_signal(
+        session_id=sid, signature="daemon_stuck", repeat_count=40,
+        first_seen=stale, last_seen=stale,
+        severity="warning", agent_type="claude_code",
+        details={"message": "claude_code stuck: 40 tool calls, no progress"},
+    )
+    # The snapshot reads with since_minutes=30 -> a 45-min-old row is excluded,
+    # so summary['alert'] stays None (banner clears).
+    assert real_store.query_recent_loop_signals(limit=5, since_minutes=30) == []
+    # And a wider window still finds it (proves it's the window, not a lost row).
+    assert real_store.query_recent_loop_signals(limit=5, since_minutes=60)
+
+
+# ── Regression: real runtime shapes (blocker fix) ────────────────────────────
+# The two dominant runtimes host tool calls INSIDE a message envelope, not as
+# top-level tool_call events. Counting only top-level types made the detector
+# inert for them. These lock in the content-aware counting.
+
+def _v3_model_completed_tools_ev(offset_s, n_tools=1):
+    """OpenClaw v3 turn: event_type=model.completed, tools in data.toolMetas."""
+    return {
+        "event_type": "model.completed",
+        "ts": _ts(offset_s),
+        "data": {"toolMetas": [{"name": "Bash"} for _ in range(n_tools)]},
+    }
+
+
+def _v3_model_completed_text_ev(offset_s, text="Done — here is the answer."):
+    return {
+        "event_type": "model.completed",
+        "ts": _ts(offset_s),
+        "data": {"completionText": text},
+    }
+
+
+def _cc_assistant_tooluse_ev(offset_s, n_tools=1):
+    """Claude Code turn: event_type=assistant, tool_use in message.content."""
+    return {
+        "event_type": "assistant",
+        "ts": _ts(offset_s),
+        "data": {"message": {"role": "assistant", "content": [
+            {"type": "tool_use", "name": "Bash", "input": {}} for _ in range(n_tools)
+        ]}},
+    }
+
+
+def test_openclaw_v3_model_completed_toolmetas_trips():
+    """BLOCKER fix: OpenClaw v3 (model.completed + toolMetas) must be counted."""
+    sid = "openclaw:v3stuck"
+    evs = [_v3_model_completed_tools_ev(i * 10) for i in range(30)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    stuck = sync._detect_stuck_sessions(store)
+    assert len(stuck) == 1
+    assert stuck[0]["tool_calls"] == 30
+
+
+def test_claude_code_assistant_content_tooluse_trips():
+    """BLOCKER fix: Claude Code (assistant + message.content tool_use) counted."""
+    sid = "claude_code:ccstuck"
+    evs = [_cc_assistant_tooluse_ev(i * 10) for i in range(30)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    stuck = sync._detect_stuck_sessions(store)
+    assert len(stuck) == 1
+    assert stuck[0]["tool_calls"] == 30
+
+
+def test_v3_model_completed_text_is_progress():
+    """A v3 text reply (completionText) breaks the streak — not a false positive."""
+    sid = "openclaw:v3narrating"
+    evs = []
+    # 30 tool turns, but a real text reply every 5 turns -> never a long streak.
+    for i in range(30):
+        evs.append(_v3_model_completed_tools_ev(i * 20))
+        if i % 5 == 4:
+            evs.append(_v3_model_completed_text_ev(i * 20 + 5))
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    assert sync._detect_stuck_sessions(store) == []
+
+
+def test_cc_assistant_text_block_is_progress():
+    """A Claude Code assistant turn with a text block breaks the streak."""
+    sid = "claude_code:narrating"
+    evs = []
+    for i in range(30):
+        evs.append(_cc_assistant_tooluse_ev(i * 20))
+        if i % 5 == 4:
+            evs.append({
+                "event_type": "assistant", "ts": _ts(i * 20 + 5),
+                "data": {"message": {"role": "assistant", "content": [
+                    {"type": "text", "text": "Making progress."}]}},
+            })
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+    assert sync._detect_stuck_sessions(store) == []


### PR DESCRIPTION
Reconstructs the proxy's stuck/loop signal from the DuckDB event stream so it works for users **not** running the enforcement proxy — matching the clawmetry.com/device promise ("38 tool calls, no progress").

For each recently-active non-ended session, walks newest events counting the **consecutive tool-call streak since the last progress marker** (user turn / session end / assistant TEXT reply); trips when the streak is BOTH long (`CLAWMETRY_STUCK_TOOLS`, default 25) AND slow (`CLAWMETRY_STUCK_SECONDS`, default 180 s). Read-only, conservative, env-tunable, default ON. Self-clears via the 30-min last-seen window.

Implemented + adversarially reviewed via a workflow; this PR **fixes the review's blocker + major:**
| sev | fix |
|---|---|
| **blocker** | counted only top-level tool events → **inert** for the 2 main runtimes (OpenClaw v3 `model.completed`+`toolMetas`, Claude Code `assistant`+`message.content` tool_use). Now counts via the app-wide `_iter_tool_invocation_names` + top-level `tool_call`. |
| **major** | counted tool_result alongside tool_call (~2× inflation). Now **calls only**. |
| minor | a v3 `model.completed` text reply (`completionText`/`assistantTexts`) now counts as progress. |

**Tests:** `test_stuck_detection.py` **20 passed**, incl. real-shape regressions (v3 toolMetas trips; CC content tool_use trips; tool_result not counted; v3/CC text = progress).

**Follow-on:** the default WiFi device reads the cloud `device_summary` (Postgres), which this OSS signal doesn't yet reach — a coordinated heartbeat→cloud change will surface a daemon-fed, last-seen-bounded stuck source. This PR lands the now-correct detector + the local-dashboard reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)