### PR TITLE
[RELEASE] feat(stuck): carry the stuck signal on the heartbeat so the WiFi device sees it (#15)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6405,6 +6405,39 @@ def _detect_runtimes_for_heartbeat() -> list:
     return out
 
 
+def _heartbeat_stuck_payload(now: float | None = None) -> list:
+    """The stuck list to ride the next heartbeat, or ``[]``.
+
+    Reads the module-level ``_LATEST_STUCK`` cache (refreshed by
+    ``_emit_stuck_signals`` each detector tick) and returns its items ONLY when
+    the cache is FRESH (refreshed within ``_STUCK_HEARTBEAT_FRESH_SECONDS``).
+    A stale cache → ``[]`` so a wedged/stopped detector can never pin a banner
+    on the device; the cloud's device_summary also has its own recency gate, so
+    this is belt-and-suspenders. Empty-but-fresh → ``[]`` (self-clear). Each
+    item is kept tiny (capped count, ``message`` truncated). Never raises."""
+    try:
+        ts = float(_LATEST_STUCK.get("ts") or 0.0)
+        if ts <= 0:
+            return []
+        ref = time.time() if now is None else now
+        if (ref - ts) > _STUCK_HEARTBEAT_FRESH_SECONDS:
+            return []
+        items = _LATEST_STUCK.get("items") or []
+        out = []
+        for it in items[:_STUCK_HEARTBEAT_MAX_ITEMS]:
+            if not isinstance(it, dict):
+                continue
+            out.append({
+                "runtime": str(it.get("runtime") or "openclaw"),
+                "tool_calls": int(it.get("tool_calls") or 0),
+                "since_seconds": int(it.get("since_seconds") or 0),
+                "message": str(it.get("message") or "")[:_STUCK_HEARTBEAT_MAX_MSG],
+            })
+        return out
+    except Exception:
+        return []
+
+
 def send_heartbeat(config: dict) -> bool:
     """Send heartbeat to cloud. Returns True on success, False on failure.
 
@@ -6437,6 +6470,19 @@ def send_heartbeat(config: dict) -> bool:
         # accounts without the clawmetry-pro adapters too.
         "detected_runtimes": _detect_runtimes_for_heartbeat(),
     }
+    # Stuck-agent signal (clawmetry-hardware#15). The WiFi desk device fetches
+    # the CLOUD device_summary (built from Postgres), NOT the local dashboard or
+    # the legacy E2E snapshot, so the daemon's loop_signals never reached it.
+    # Ride the cached stuck list on the plaintext, regularly-sent, self-clearing
+    # heartbeat instead. ONLY attach when fresh+non-empty (helper enforces the
+    # 5-min freshness gate) so a stale cache can't pin a banner. Best-effort —
+    # heartbeat MUST still send if this fails.
+    try:
+        _stuck = _heartbeat_stuck_payload()
+        if _stuck:
+            payload["stuck"] = _stuck
+    except Exception as _st_e:
+        log.debug("stuck heartbeat payload build failed (continuing): %s", _st_e)
     # Agent-install self-report (cloud bug fix 2026-05-18). Cloud Run pods
     # can't stat the user's home directory, so the daemon tells cloud what
     # agents exist locally and cloud aggregates across the user's fleet.
@@ -13312,6 +13358,22 @@ STUCK_MIN_SECONDS = int(os.environ.get("CLAWMETRY_STUCK_SECONDS", "180"))
 # How recently a session must have been active to be a candidate. A truly idle
 # session (last active hours ago) is not "stuck right now" — it just stopped.
 STUCK_RECENT_MINUTES = int(os.environ.get("CLAWMETRY_STUCK_RECENT_MINUTES", "15"))
+
+# Latest stuck-detection result, cached so the (plaintext, self-clearing)
+# HEARTBEAT can carry it to the cloud's device_summary — the WiFi desk device
+# fetches the CLOUD summary (built from Postgres), NOT the local dashboard or
+# the legacy E2E snapshot, so loop_signals alone never reached it. ``ts`` is the
+# wall-clock the result was last refreshed; ``items`` is the (possibly empty)
+# top-few stuck list, each already carrying the built banner ``message``. An
+# EMPTY items with a fresh ts means "checked, none stuck" → the device self-
+# clears. The heartbeat treats a STALE ts (>5 min) as "no signal" so a wedged
+# detector can't pin a banner forever.
+_LATEST_STUCK: dict = {"ts": 0.0, "items": []}
+# Heartbeat only trusts a stuck cache refreshed within this window (seconds).
+_STUCK_HEARTBEAT_FRESH_SECONDS = 300
+# Cap how much stuck rides each heartbeat (keep the plaintext payload tiny).
+_STUCK_HEARTBEAT_MAX_ITEMS = 5
+_STUCK_HEARTBEAT_MAX_MSG = 200
 # How many newest events to inspect per candidate session. 120 comfortably
 # covers a streak well past the threshold plus the preceding progress marker.
 _STUCK_EVENT_WINDOW = 120
@@ -13580,7 +13642,35 @@ def _emit_stuck_signals(store, state: dict) -> int:
         stuck = _detect_stuck_sessions(store)
     except Exception as e:  # noqa: BLE001
         log.warning("stuck-detect: detector errored: %s", e)
+        # Detector errored — do NOT touch _LATEST_STUCK here: leaving the old
+        # value is harmless because the heartbeat staleness gate (5 min) will
+        # drop it; clearing it on a transient error would suppress a real,
+        # still-stuck banner mid-incident. (When detection SUCCEEDS with no
+        # stuck below, we DO refresh ts with items=[] to self-clear.)
         return 0
+
+    # Refresh the heartbeat cache every tick the detector RAN — including the
+    # no-stuck case (items=[], fresh ts) so the cloud/device self-clears. Build
+    # the same banner messages the loop_signals path emits, capped tiny for the
+    # plaintext heartbeat. Never let cache bookkeeping take down the loop.
+    try:
+        items = []
+        for st in stuck[:_STUCK_HEARTBEAT_MAX_ITEMS]:
+            n = int(st.get("tool_calls") or 0)
+            mins = max(1, int(st.get("since_seconds") or 0) // 60)
+            rt = str(st.get("runtime") or "openclaw")
+            msg = f"{rt} stuck: {n} tool calls, no progress for {mins}m"
+            items.append({
+                "runtime": rt,
+                "tool_calls": n,
+                "since_seconds": int(st.get("since_seconds") or 0),
+                "message": msg[:_STUCK_HEARTBEAT_MAX_MSG],
+            })
+        _LATEST_STUCK["items"] = items
+        _LATEST_STUCK["ts"] = time.time()
+    except Exception as _ce:  # noqa: BLE001
+        log.debug("stuck-detect: cache refresh failed (continuing): %s", _ce)
+
     if not stuck:
         return 0
 

--- a/tests/test_stuck_heartbeat_payload.py
+++ b/tests/test_stuck_heartbeat_payload.py
@@ -1,0 +1,190 @@
+"""Stuck-agent signal → HEARTBEAT wiring (clawmetry-hardware#15).
+
+The WiFi desk device fetches the CLOUD's device_summary (built from Postgres),
+NOT the local dashboard or the legacy E2E snapshot — so the daemon's loop_signals
+never reached it. The fix rides the cached stuck list on the plaintext, regularly-
+sent, self-clearing HEARTBEAT.
+
+These tests cover the OSS half of that wiring:
+
+  * `_emit_stuck_signals` populates the module-level `_LATEST_STUCK` cache
+    (items + fresh ts) when sessions are stuck, and clears it to `items=[]`
+    (still fresh ts → self-clear) when a detector tick finds none.
+  * `_heartbeat_stuck_payload()` returns the cached items when FRESH and `[]`
+    when STALE (so a wedged/stopped detector can never pin a banner).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import clawmetry.sync as sync  # noqa: E402
+
+
+_BASE = 1_700_000_000
+
+
+def _ts(offset_s: int) -> str:
+    from datetime import datetime
+    return datetime.fromtimestamp(_BASE + offset_s).isoformat()
+
+
+def _tool_ev(offset_s: int, et: str = "tool_call") -> dict:
+    return {"event_type": et, "ts": _ts(offset_s), "data": {"name": "Bash"}}
+
+
+class _FakeStore:
+    def __init__(self, sessions, events_by_sid):
+        self._sessions = sessions
+        self._events = events_by_sid
+        self.ingested: list[dict] = []
+
+    def query_sessions_table(self, *, agent_type=None, limit=200):
+        return list(self._sessions)[:limit]
+
+    def query_events(self, *, session_id=None, limit=500, **kw):
+        evs = list(reversed(self._events.get(session_id, [])))
+        return evs[:limit]
+
+    def ingest_loop_signal(self, **kw):
+        self.ingested.append(kw)
+
+
+def _active_session(sid="claude_code:abc", **extra):
+    from datetime import datetime
+    row = {
+        "session_id": sid,
+        "status": "active",
+        "ended_at": None,
+        "started_at": datetime.now().isoformat(),
+        "last_active_at": datetime.now().isoformat(),
+    }
+    row.update(extra)
+    return row
+
+
+@pytest.fixture(autouse=True)
+def _conservative_thresholds(monkeypatch):
+    monkeypatch.setattr(sync, "STUCK_TOOL_THRESHOLD", 25, raising=False)
+    monkeypatch.setattr(sync, "STUCK_MIN_SECONDS", 180, raising=False)
+    monkeypatch.setattr(sync, "STUCK_RECENT_MINUTES", 15, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Each test starts from a clean cache so order can't leak state."""
+    sync._LATEST_STUCK = {"ts": 0.0, "items": []}
+    yield
+    sync._LATEST_STUCK = {"ts": 0.0, "items": []}
+
+
+# ── cache population ─────────────────────────────────────────────────────────
+
+def test_emit_populates_latest_stuck_cache():
+    sid = "claude_code:wedged"
+    # 40 tool calls, one every 10s -> 390s span -> stuck on both bounds.
+    evs = [_tool_ev(i * 10) for i in range(40)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+
+    n = sync._emit_stuck_signals(store, {})
+    assert n == 1
+
+    cache = sync._LATEST_STUCK
+    assert cache["ts"] > 0
+    assert len(cache["items"]) == 1
+    item = cache["items"][0]
+    # Runtime resolution (waste_flags.runtime_from_session_id) is exercised by
+    # the detector tests; here we only assert the cache carries SOME runtime and
+    # the pre-built banner is correctly shaped — that's the heartbeat wiring.
+    assert item["runtime"]
+    assert item["tool_calls"] == 40
+    assert "stuck:" in item["message"]
+    assert "40 tool calls" in item["message"]
+    assert len(item["message"]) <= sync._STUCK_HEARTBEAT_MAX_MSG
+
+
+def test_emit_no_stuck_clears_cache_items_but_keeps_fresh_ts():
+    """A detector tick that finds NONE must refresh ts with items=[] so the
+    device self-clears (the payload helper then returns [] because items=[])."""
+    # Pre-seed a stale "stuck" cache as if a prior tick had one.
+    sync._LATEST_STUCK = {"ts": 123.0, "items": [{"runtime": "openclaw",
+                          "tool_calls": 30, "since_seconds": 200,
+                          "message": "openclaw stuck: 30 tool calls, no progress for 3m"}]}
+
+    # Now feed a session with too few tool calls -> NOT stuck.
+    sid = "openclaw:fine"
+    evs = [_tool_ev(i * 10) for i in range(5)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+
+    n = sync._emit_stuck_signals(store, {})
+    assert n == 0
+    # Cleared the items (self-clear) and refreshed ts to ~now.
+    assert sync._LATEST_STUCK["items"] == []
+    assert sync._LATEST_STUCK["ts"] > 123.0
+
+
+# ── payload freshness gate ───────────────────────────────────────────────────
+
+def test_payload_includes_stuck_when_fresh():
+    import time
+    sync._LATEST_STUCK = {
+        "ts": time.time(),
+        "items": [{"runtime": "codex", "tool_calls": 31, "since_seconds": 240,
+                   "message": "codex stuck: 31 tool calls, no progress for 4m"}],
+    }
+    out = sync._heartbeat_stuck_payload()
+    assert len(out) == 1
+    assert out[0]["runtime"] == "codex"
+    assert out[0]["tool_calls"] == 31
+    assert out[0]["message"].startswith("codex stuck:")
+
+
+def test_payload_omits_stuck_when_stale():
+    import time
+    # ts is well outside the freshness window -> helper returns [].
+    sync._LATEST_STUCK = {
+        "ts": time.time() - (sync._STUCK_HEARTBEAT_FRESH_SECONDS + 60),
+        "items": [{"runtime": "codex", "tool_calls": 31, "since_seconds": 240,
+                   "message": "codex stuck: 31 tool calls, no progress for 4m"}],
+    }
+    assert sync._heartbeat_stuck_payload() == []
+
+
+def test_payload_empty_when_fresh_but_no_items():
+    import time
+    sync._LATEST_STUCK = {"ts": time.time(), "items": []}
+    assert sync._heartbeat_stuck_payload() == []
+
+
+def test_payload_caps_item_count_and_message_length():
+    import time
+    long_msg = "x" * 500
+    items = [{"runtime": "openclaw", "tool_calls": 30, "since_seconds": 200,
+              "message": long_msg} for _ in range(20)]
+    sync._LATEST_STUCK = {"ts": time.time(), "items": items}
+    out = sync._heartbeat_stuck_payload()
+    assert len(out) == sync._STUCK_HEARTBEAT_MAX_ITEMS
+    assert all(len(it["message"]) <= sync._STUCK_HEARTBEAT_MAX_MSG for it in out)
+
+
+def test_payload_never_raises_on_garbage_cache():
+    sync._LATEST_STUCK = {"ts": "not-a-float", "items": "nope"}
+    assert sync._heartbeat_stuck_payload() == []
+
+
+def test_emit_then_payload_end_to_end():
+    """Integration: detector tick -> cache -> a FRESH payload carries it."""
+    sid = "claude_code:wedged"
+    evs = [_tool_ev(i * 10) for i in range(40)]
+    store = _FakeStore([_active_session(sid)], {sid: evs})
+
+    assert sync._emit_stuck_signals(store, {}) == 1
+    out = sync._heartbeat_stuck_payload()
+    assert len(out) == 1
+    assert out[0]["runtime"]
+    assert "stuck:" in out[0]["message"]


### PR DESCRIPTION
Completes #15 for the WiFi device. The daemon stuck detector emits loop_signals (local dashboard + legacy snapshot), but the default device reads the cloud `device_summary` (Postgres) and never saw it. Carries the signal on the plaintext, regularly-sent, **self-clearing** heartbeat:
- `_LATEST_STUCK` cache refreshed every detector tick (`items=[]` when none → self-clears); transient detector error leaves the cache for the staleness gate to drop.
- `_heartbeat_stuck_payload()` returns cached items only when fresh (≤300 s), capped (5 / 200 chars); `send_heartbeat` attaches `payload['stuck']` only when non-empty, in its own try/except.

Paired with **clawmetry-cloud feat/device-stuck-surface** (stores `nodes.stuck/stuck_at`, surfaces a 3-min last-seen-bounded alert, no `alert_history`). Reviewed via workflow — 3 lenses **all pass**. Tests: 8 passed; py_compile clean. No firmware change needed (renders on the device's existing alert banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)