### PR TITLE
feat(runtime): surface OpenLLMetry/OTLP apps in the runtime switcher + inventory (bring your own agent, visible)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -3890,6 +3890,101 @@ class LocalStore:
             })
         return out
 
+    def query_otlp_app_rollup(
+        self,
+        *,
+        exclude_agent_types: "Iterable[str] | None" = None,
+        since: float | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """One row per DISTINCT ``agent_type`` in the spans table for foreign
+        OTLP / OpenLLMetry apps (#2822 stamps ``agent_type`` from the resource
+        ``service.name``), so the runtime switcher + Agent Inventory can surface
+        a LangChain / CrewAI / OpenAI-Agents app that only ever sent OTLP traces
+        (it has no session-id prefix, so it appears in NONE of the
+        session-prefix rollups).
+
+        This is a SINGLE ``GROUP BY agent_type`` aggregate (one index-backed
+        scan over ``spans``), meant to run on the daemon's snapshot timer inside
+        the cached rollup path, NEVER per HTTP request (FLYWHEEL 1e CPU budget).
+
+        ``exclude_agent_types`` removes the 12 known session-prefix runtimes
+        (plus ``openclaw``) so we only return the foreign apps. ``since`` bounds
+        to recent activity. Rows are ordered by recent activity desc and capped
+        at ``limit`` (the caller logs when truncated). Each row::
+
+            {agent_type, service_name, sessions, traces, spans, turns,
+             tokens, cost_usd, primary_model, last_ts}
+
+        ``turns`` counts model-bearing spans (a chat/LLM call), mirroring the
+        per-runtime ``turns`` semantics; ``sessions`` counts distinct non-null
+        session ids (often 0 for a pure-trace app, which is honest). Best-effort:
+        any failure (e.g. an old store without the spans table) yields ``[]``.
+        """
+        try:
+            excl = {str(x).lower() for x in (exclude_agent_types or [])}
+            clauses: list[str] = []
+            params: list[Any] = []
+            if since is not None:
+                clauses.append("start_ts >= ?")
+                params.append(float(since))
+            if excl:
+                placeholders = ", ".join(["?"] * len(excl))
+                clauses.append(f"LOWER(agent_type) NOT IN ({placeholders})")
+                params.extend(sorted(excl))
+            # Defensive: never return a NULL/blank bucket as a phantom runtime.
+            clauses.append("agent_type IS NOT NULL AND agent_type <> ''")
+            where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+            sql = f"""
+                SELECT
+                    agent_type,
+                    MAX(service_name)                                  AS service_name,
+                    COUNT(DISTINCT session_id)                         AS sessions,
+                    COUNT(DISTINCT trace_id)                           AS traces,
+                    COUNT(*)                                           AS spans,
+                    SUM(CASE WHEN model IS NOT NULL AND model <> ''
+                             THEN 1 ELSE 0 END)                        AS turns,
+                    SUM(COALESCE(token_count, 0))                      AS tokens,
+                    SUM(COALESCE(cost_usd, 0.0))                       AS cost_usd,
+                    MAX(start_ts)                                      AS last_ts
+                FROM spans
+                {where}
+                GROUP BY agent_type
+                ORDER BY MAX(start_ts) DESC
+                LIMIT ?
+            """
+            params.append(int(limit))
+            cols = [
+                "agent_type", "service_name", "sessions", "traces", "spans",
+                "turns", "tokens", "cost_usd", "last_ts",
+            ]
+            out: list[dict[str, Any]] = []
+            for r in self._fetch(sql, params):
+                d = dict(zip(cols, r))
+                # Per-app primary model (most frequent model on its spans). One
+                # tiny grouped read per app; the app set is already capped at
+                # ``limit`` so this stays bounded.
+                atype = d.get("agent_type")
+                primary = ""
+                try:
+                    mrows = self._fetch(
+                        """
+                        SELECT model, COUNT(*) AS n FROM spans
+                        WHERE agent_type = ? AND model IS NOT NULL AND model <> ''
+                        GROUP BY model ORDER BY n DESC LIMIT 1
+                        """,
+                        [atype],
+                    )
+                    if mrows:
+                        primary = mrows[0][0] or ""
+                except Exception:
+                    primary = ""
+                d["primary_model"] = primary
+                out.append(d)
+            return out
+        except Exception:
+            return []
+
     def query_recent_read_tool_calls(
         self,
         *,

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -3689,7 +3689,7 @@ async function loadActiveTasks() {
     var now = Date.now();
     var all = (saData.subagents || []);
     // Scope to the selected runtime (sub-agent sessionId prefix = runtime).
-    var _atRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+    var _atRt = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
     if (_atRt !== 'all') all = all.filter(function(a) { return _cmRuntimeOf(a) === _atRt; });
     var live = all.filter(function(a) { return a.status === 'active' || a.status === 'idle'; });
     var recentFailed = all.filter(function(a) {
@@ -4694,7 +4694,7 @@ function renderBrainStream(events) {
   // Global runtime switcher (header): scope the activity stream to one runtime
   // so Brain stops mixing OpenClaw with Claude Code / Codex / etc. Each event
   // carries `sessionId`, whose prefix is the runtime discriminator.
-  var _brainRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  var _brainRt = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
   if (_brainRt && _brainRt !== 'all') {
     filtered = filtered.filter(function(ev) { return _cmRuntimeOf(ev) === _brainRt; });
   }
@@ -5470,7 +5470,7 @@ function renderBrainChart(events) {
   if (typeof _brainChannelFilter !== 'undefined' && _brainChannelFilter !== 'all') {
     events = events.filter(function(ev) { return (ev.channel || '') === _brainChannelFilter; });
   }
-  var _bcRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  var _bcRt = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
   if (_bcRt && _bcRt !== 'all') {
     events = events.filter(function(ev) { return _cmRuntimeOf(ev) === _bcRt; });
   }
@@ -7968,16 +7968,44 @@ var _CM_RT_LABEL = {
   hermes: 'Hermes', claude_code: 'Claude Code', codex: 'Codex', cursor: 'Cursor',
   aider: 'Aider', goose: 'Goose', opencode: 'opencode', qwen_code: 'Qwen Code'
 };
+// The CLOSED session-prefix runtimes (the only keys that can ride a session_id
+// prefix). Foreign OTLP / OpenLLMetry apps are NOT in here — they have no
+// prefix and are filtered by agent_type server-side, so _cmRuntimeOf must never
+// derive them from a prefix (it can't) and never mis-bucket them into openclaw.
+var _CM_RT_PREFIXES = {
+  openclaw: 1, picoclaw: 1, nanoclaw: 1, hermes: 1, claude_code: 1, codex: 1,
+  cursor: 1, aider: 1, goose: 1, opencode: 1, qwen_code: 1
+};
+// Dynamic registry of foreign OTLP/OpenLLMetry apps surfaced by the daemon
+// (runtimeSummary/agentInventory carry `otlp:true` + a `displayName`). These are
+// keyed by agent_type (e.g. 'my_app' from service.name) and scoped SERVER-SIDE
+// via ?runtime=<agent_type>; there is no session-id prefix to match client-side.
+// agentKey -> {label}. Populated by _cmRegisterOtlpRuntime as data arrives.
+var _CM_OTLP_RT = {};
+function _cmRegisterOtlpRuntime(key, label) {
+  if (!key) return;
+  key = String(key);
+  if (_CM_RT_PREFIXES.hasOwnProperty(key.toLowerCase())) return; // never shadow a native runtime
+  _CM_OTLP_RT[key] = { label: label || key };
+  // Surface the label so _cmRuntimeLabel / chips read 'My App (OTel)'.
+  if (!_CM_RT_LABEL.hasOwnProperty(key)) _CM_RT_LABEL[key] = label || key;
+}
+// True iff `rt` is a foreign OTLP app (agent_type filter, not session prefix).
+function _cmIsOtlpRuntime(rt) { return !!(rt && _CM_OTLP_RT.hasOwnProperty(rt)); }
 function _cmRuntimeOf(o) {
   var id = (o && (o.id || o.sessionId || o.session_id || o.key)) || '';
   var i = id.indexOf(':');
   if (i > 0) {
     var p = id.slice(0, i).toLowerCase();
-    if (_CM_RT_LABEL.hasOwnProperty(p) && p !== 'openclaw') return p;
+    if (_CM_RT_PREFIXES.hasOwnProperty(p) && p !== 'openclaw') return p;
   }
-  if (o && o.runtime) {
-    var r = String(o.runtime).toLowerCase();
-    if (_CM_RT_LABEL.hasOwnProperty(r)) return r;
+  // Explicit agent_type / runtime field (OTLP apps + server-tagged rows). An
+  // OTLP app's spans carry agent_type=<its key>; honor it directly so a
+  // selected OTLP runtime matches its own data and nothing else.
+  var r = o && (o.runtime || o.agent_type || o.agentType);
+  if (r) {
+    r = String(r).toLowerCase();
+    if (_CM_RT_PREFIXES.hasOwnProperty(r) || _CM_OTLP_RT.hasOwnProperty(r)) return r;
   }
   return 'openclaw';
 }
@@ -8014,6 +8042,16 @@ function _cmSetRuntimeFilter(v, reload) {
   if (typeof reload === 'function') reload();
 }
 function _cmRuntimeLabel(rt) { return _CM_RT_LABEL[rt] || rt; }
+// Runtime to use for CLIENT-SIDE prefix filtering of a node-wide blob (Brain
+// list/chart, Tracing, model attribution, active tasks, transcripts). A foreign
+// OTLP app has no session-id prefix, so a prefix filter would empty the view —
+// which would contradict the honest "showing all runtimes" scope note we render
+// for it. Collapse OTLP selections to 'all' here so the blob shows unfiltered
+// (the note explains why); the server-side runtime= path (the no-leak contract)
+// is unaffected. Native runtimes pass through unchanged.
+function _cmClientFilterRt(rt) {
+  return _cmIsOtlpRuntime(rt) ? 'all' : rt;
+}
 // Tabs whose data is a cross-runtime AGGREGATE (merged server/snapshot-side):
 // the switcher can't scope them client-side yet, so picking a specific runtime
 // shows an honest "all runtimes" note rather than pretending the numbers are
@@ -8082,10 +8120,19 @@ var _CM_NODE_TABS = ['alerts','notifications','security'];
 var _CM_RT_ALL_TABS = ['flow','brain','models','context','tracing','turn-anatomy',
   'context-economics','approvals','alerts','cost','dives','crons','memory',
   'notifications','security','policy','skills','selfevolve','subagents','nemoclaw'];
+// Foreign OTLP apps only emit spans/traces (events + maybe cost). They get the
+// EVENTS + COST tabs (Brain/Tracing/Models/Context/Turn-anatomy/Cost), plus the
+// roster; OpenClaw-only concepts (Crons/Memory/Skills/Channels/Subagents) do not
+// apply and stay hidden. Honest scope notes still cover any aggregate tab.
+var _CM_OTLP_CAPS = ['EVENTS', 'COST'];
+function _cmCapsForRuntime(rt) {
+  if (_cmIsOtlpRuntime(rt)) return _CM_OTLP_CAPS;
+  return _CM_RT_CAPS[rt];
+}
 function _cmShownTabsForRuntime(rt) {
   var show = {};
   _CM_NODE_TABS.forEach(function (t) { show[t] = 1; });
-  (_CM_RT_CAPS[rt] || []).forEach(function (cap) {
+  (_cmCapsForRuntime(rt) || []).forEach(function (cap) {
     (_CM_CAP_TABS[cap] || []).forEach(function (t) { show[t] = 1; });
   });
   if (rt === 'nemoclaw') show['nemoclaw'] = 1;
@@ -8094,7 +8141,7 @@ function _cmShownTabsForRuntime(rt) {
 function _cmApplyRuntimeTabVisibility() {
   var rt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
   // 'all' or an unknown/unmapped runtime => show everything (never silently drop).
-  var showAll = !rt || rt === 'all' || !_CM_RT_CAPS[rt];
+  var showAll = !rt || rt === 'all' || !_cmCapsForRuntime(rt);
   var shown = showAll ? null : _cmShownTabsForRuntime(rt);
   _CM_RT_ALL_TABS.forEach(function (tab) {
     var show = showAll || !!shown[tab];
@@ -8116,6 +8163,25 @@ function _cmApplyRuntimeScopeNote(name) {
   var noteId = 'cm-rt-scope-note';
   var existing = page.querySelector('#' + noteId);
   var rt = _cmRuntimeFilter();
+  // Foreign OTLP / OpenLLMetry app selected. These have no session-id prefix, so
+  // the session/event tabs that filter client-side by prefix cannot scope to
+  // them honestly. Rather than silently empty (or worse, show node-wide and call
+  // it the app's data), state plainly that this app is observed via OTLP traces
+  // and its scoped views live where the data actually is (the Inventory roster
+  // row + cost/tokens). The Inventory tab keeps its own roster note below.
+  // 'inventory' has its own roster note; 'dives' (transcripts) has its own
+  // scoped empty-state ("no <app> sessions have a transcript yet"), so skip both
+  // to avoid a conflicting double-note.
+  if (_cmIsOtlpRuntime(rt) && name !== 'inventory' && name !== 'dives') {
+    var _otl = _cmRuntimeLabel(rt);
+    var _otmsg = '<strong>' + escHtml(_otl) + '</strong> is observed via OpenLLMetry / OTLP traces. '
+      + 'This view shows <strong>all runtimes</strong>; its scoped tokens, cost and sessions are on the '
+      + '<strong>Agent Inventory</strong> roster.';
+    var _othtml = '<div id="' + noteId + '" style="display:flex;align-items:center;gap:8px;margin:0 0 14px;padding:9px 13px;border-radius:8px;background:rgba(245,158,11,0.10);border:1px solid rgba(245,158,11,0.35);font-size:12px;color:var(--text-secondary);line-height:1.4;"><span style="color:#d97706;font-size:13px;flex-shrink:0;">&#9888;</span><span>' + _otmsg + '</span></div>';
+    if (existing) existing.outerHTML = _othtml;
+    else page.insertAdjacentHTML('afterbegin', _othtml);
+    return;
+  }
   // Overview is a MIX: some cards re-scope with the runtime switcher (today's
   // tasks/outcome, the activity strip, the hero token/cost stats) and some stay
   // node-wide (autonomy score, reliability, activity heatmap). A single
@@ -8260,11 +8326,16 @@ function _cmPopulateGlobalRuntime(counts) {
   // Observed runtimes (have local sessions) ∪ locked-but-visible runtimes.
   // _cmLockedRuntimes is empty in grace mode, so this collapses to the
   // previous behaviour (observed-only) by default.
-  var observed = Object.keys(_CM_RT_LABEL).filter(function(k) { return counts[k]; });
+  var observedAll = Object.keys(_CM_RT_LABEL).filter(function(k) { return counts[k]; });
+  // Split native session-prefix runtimes from foreign OTLP apps: the OTLP apps
+  // get their own optgroup and their count is traces, not sessions, so they
+  // must not inflate the "All runtimes · N sessions" total.
+  var observed = observedAll.filter(function(k) { return !_cmIsOtlpRuntime(k); });
+  var otlpApps = observedAll.filter(function(k) { return _cmIsOtlpRuntime(k); });
   var seen = {};
-  observed.forEach(function(k) { seen[k] = 1; });
+  observedAll.forEach(function(k) { seen[k] = 1; });
   var locked = Object.keys(_cmLockedRuntimes).filter(function(k) { return !seen[k]; });
-  var order = observed.concat(locked);
+  var order = observed.concat(otlpApps).concat(locked);
   if (order.length < 2) { wrap.style.display = 'none'; return; }
   var active = _cmRuntimeFilter();
   if (active !== 'all' && !counts[active] && !_cmLockedRuntimes[active]) active = 'all';
@@ -8275,6 +8346,13 @@ function _cmPopulateGlobalRuntime(counts) {
   function _sessLabel(n) { return n + (n === 1 ? ' session' : ' sessions'); }
   function _opt(k) {
     var lbl = _CM_RT_LABEL[k] || k;
+    if (_cmIsOtlpRuntime(k)) {
+      // Foreign OTLP/OpenLLMetry app: count is sessions or traces; keep the
+      // wording neutral ("activity") since a pure-trace app has no sessions.
+      var on = counts[k] || 0;
+      var act = on ? (' · ' + on + (on === 1 ? ' trace' : ' traces')) : '';
+      return '<option value="' + k + '">' + escHtml(lbl) + act + '</option>';
+    }
     if (_cmLockedRuntimes[k]) {
       // A locked (Pro) runtime that is ACTUALLY DETECTED on this machine is the
       // strongest upgrade signal — "you're using it here, upgrade to observe
@@ -8294,6 +8372,14 @@ function _cmPopulateGlobalRuntime(counts) {
   var lockedOther = locked.filter(function(k) { return !_cmRunningRuntimes[k]; });
   var html = '<option value="all">All runtimes · ' + _sessLabel(total) + '</option>';
   observed.forEach(function(k) { html += _opt(k); });
+  // Foreign OpenLLMetry / OTLP apps (bring your own agent): grouped on their own
+  // so a LangChain / CrewAI / OpenAI-Agents app reads as distinct from a native
+  // runtime. Selecting one scopes server-side by agent_type.
+  if (otlpApps.length) {
+    html += '<optgroup label="OpenLLMetry / OTLP apps">';
+    otlpApps.forEach(function(k) { html += _opt(k); });
+    html += '</optgroup>';
+  }
   // Group the detected-but-locked runtimes under their own header so the
   // "running here, needs Pro" distinction is unmistakable in the dropdown.
   if (lockedRunning.length) {
@@ -8362,6 +8448,10 @@ function _invFmtAgo(iso) {
 // Does this runtime declare COST? Cursor / PicoClaw / NanoClaw don't — show an
 // honest "--" with a tooltip, never a misleading $0.
 function _invHasCost(rt) {
+  // Foreign OTLP apps report cost from their spans (when the instrumentation
+  // emits it); treat them as cost-capable so the roster shows their $ instead
+  // of "--".
+  if (_cmIsOtlpRuntime(rt)) return true;
   var caps = _CM_RT_CAPS[rt] || [];
   return caps.indexOf('COST') !== -1;
 }
@@ -8545,6 +8635,13 @@ async function renderInventory() {
   var inv = await _invFetchData();
   var agents = (inv && inv.agents) || [];
 
+  // Register any foreign OTLP/OpenLLMetry app in the roster so _cmIsOtlpRuntime /
+  // _invHasCost / the header dropdown recognise it (the roster is the canonical
+  // source for the app set; the dropdown is fed from the same data on init).
+  agents.forEach(function (a) {
+    if (a && a.otlp && a.agentKey) _cmRegisterOtlpRuntime(a.agentKey, a.displayName || a.agentKey);
+  });
+
   var statsEl = document.getElementById('inv-stats');
   var rosterEl = document.getElementById('inv-roster');
   var emptyEl = document.getElementById('inv-empty');
@@ -8705,6 +8802,39 @@ async function _cmInitGlobalRuntimeSwitcher() {
     });
     _cmPopulateGlobalRuntime(counts);
   } catch (e) { /* non-fatal — the switcher just stays hidden */ }
+  // Surface foreign OTLP / OpenLLMetry apps (no session prefix, so absent from
+  // /api/sessions). The Agent Inventory roster carries them with otlp:true; one
+  // read registers each so the dropdown lists 'My App (OTel)'.
+  try { await _cmLoadOtlpRuntimes(); } catch (e) { /* non-fatal */ }
+}
+
+// Pull the OTLP/custom apps the daemon folded into the inventory roster and
+// register each so the switcher dropdown + labels include it. Local: GET
+// /api/inventory; cloud: the agentInventory snapshot slice (already loaded via
+// __cmSnap by other consumers, so this is cheap / deduped). Each app contributes
+// a session count to the dropdown (or its trace count when it has no sessions).
+async function _cmLoadOtlpRuntimes() {
+  var inv = null;
+  try {
+    if (window.CLOUD_MODE && typeof window.__cmSnap === 'function') {
+      var sp = await window.__cmSnap();
+      inv = sp && sp.agentInventory;
+    } else {
+      inv = await fetch('/api/inventory', { credentials: 'same-origin' })
+        .then(function(r) { return r.json(); }).catch(function() { return null; });
+    }
+  } catch (e) { return; }
+  var agents = (inv && inv.agents) || [];
+  var counts = {};
+  agents.forEach(function(a) {
+    if (!a || !a.otlp || !a.agentKey) return;
+    _cmRegisterOtlpRuntime(a.agentKey, a.displayName || a.agentKey);
+    // Dropdown count: prefer sessions, fall back to traces/spans so a pure-trace
+    // app (sessions=0) still shows a non-zero presence and stays listed.
+    var n = a.sessions || a.traces || a.spans || 1;
+    counts[a.agentKey] = Math.max(counts[a.agentKey] || 0, n);
+  });
+  if (Object.keys(counts).length) _cmPopulateGlobalRuntime(counts);
 }
 
 async function loadSessions() {
@@ -10582,7 +10712,7 @@ async function loadTurnAnatomy() {
   // Runtime scoping — a trace's id IS the session id, whose prefix is the
   // runtime (same derivation the Tracing tab uses). Don't silently merge when
   // a specific runtime is picked; show a scoped empty state instead.
-  var _taRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  var _taRt = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
   if (_taRt !== 'all') {
     traces = traces.filter(function(t) { return _cmRuntimeOf({ id: t.trace_id }) === _taRt; });
   }
@@ -10779,7 +10909,7 @@ function _renderTraceRows() {
   // Global runtime switcher (header): scope traces to one runtime. Each
   // event-derived trace's `trace_id` IS its session_id, whose prefix is the
   // runtime discriminator (OTLP traces with hex ids fall through to OpenClaw).
-  var _trRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+  var _trRt = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
   if (_trRt && _trRt !== 'all') {
     traces = traces.filter(function(t) { return _cmRuntimeOf({ id: t.trace_id }) === _trRt; });
   }
@@ -15227,7 +15357,7 @@ async function loadMainActivity() {
     // tab (event sessionId prefix = runtime). Previously this Overview panel
     // showed every runtime's events regardless of the switcher, so picking
     // "Qwen Code" still surfaced Claude Code / OpenClaw cron chatter.
-    var _maRt = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
+    var _maRt = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
     if (_maRt !== 'all') events = events.filter(function(ev) { return _cmRuntimeOf(ev) === _maRt; });
 
     if (!events.length) {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10775,9 +10775,10 @@ def _build_runtime_summary(limit: int = 20000):
         store = _ls.get_store()
         if store is None:
             return {}
-        evs = store.query_events(limit=int(limit))
-        if not evs:
-            return {}
+        evs = store.query_events(limit=int(limit)) or []
+        # NOTE: we no longer early-return on empty events — a node that ONLY ever
+        # sent OTLP traces (a pure OpenLLMetry app, no OpenClaw sessions) has no
+        # events but DOES have foreign-app spans to surface below.
         agg: dict = {}
         sess_models = defaultdict(list)  # (rt, sid) -> ordered model list
         for ev in sorted(evs, key=lambda e: (e.get("session_id") or "", e.get("ts") or "")):
@@ -10828,10 +10829,106 @@ def _build_runtime_summary(limit: int = 20000):
                 "models": models_out,
                 "switch_count": rt_switches[rt],
             }
+        # Fold in foreign OTLP / OpenLLMetry apps (#2822/#2853 follow-up). These
+        # derive ``agent_type`` from the resource ``service.name`` and have NO
+        # session-id prefix, so they appear in NONE of the buckets above. One
+        # cheap GROUP BY agent_type over the spans table (daemon snapshot timer,
+        # NOT per request — FLYWHEEL 1e) surfaces them as first-class runtimes so
+        # the switcher dropdown + the inventory roster can scope to them.
+        try:
+            _merge_otlp_apps_into_summary(out, store)
+        except Exception as _eo:
+            log.debug("otlp app summary merge failed: %s", _eo)
         return out
     except Exception as _e:
         log.debug("runtime summary snapshot build failed: %s", _e)
         return {}
+
+
+# Defensive cap on how many distinct OTLP/custom apps we surface in the shared
+# snapshot (top-N by recent activity). A misconfigured fleet could otherwise emit
+# hundreds of service.names; we keep the snapshot tiny and log when we truncate
+# (no SILENT cap — FLYWHEEL). Override with CLAWMETRY_OTLP_APP_CAP.
+_OTLP_APP_CAP = int(os.environ.get("CLAWMETRY_OTLP_APP_CAP", "50") or "50")
+
+
+def _humanize_service_name(service_name: str, agent_type: str) -> str:
+    """Friendly display label for a foreign OTLP app row.
+
+    ``agent_type`` is the slugified service.name (#2822: lowercased, non-alnum
+    -> '_'); the original ``service.name`` is the better label when present.
+    'custom' (the #2822 fallback when service.name was absent) reads as
+    'Custom (OTel)' so it never looks like a real product name. Otherwise we
+    title-case the slug ('my_app' -> 'My App'). Always tagged '(OTel)' so a
+    bring-your-own-agent app is visibly distinct from a native runtime.
+    """
+    at = (agent_type or "").strip().lower()
+    if at == "custom":
+        return "Custom (OTel)"
+    base = (service_name or "").strip()
+    if not base:
+        base = (agent_type or "").replace("_", " ").replace("-", " ").strip()
+        base = " ".join(w.capitalize() for w in base.split()) or (agent_type or "app")
+    return f"{base} (OTel)"
+
+
+def _merge_otlp_apps_into_summary(out: dict, store) -> None:
+    """Add one ``runtimeSummary`` entry per foreign OTLP/custom app.
+
+    Mutates ``out`` in place. Each entry mirrors the session-prefix runtime
+    shape (so every existing consumer — Models interceptor, inventory builder,
+    Overview headline — reads it verbatim) PLUS:
+      - ``otlp = True`` so the frontend knows this runtime is filtered by
+        ``agent_type`` (no session-id prefix) rather than the prefix path.
+      - ``display_name`` (a humanized service name) so the dropdown/roster reads
+        'My App (OTel)', never the raw slug.
+    Excludes the 12 known session-prefix runtimes + ``openclaw`` so a native
+    runtime can NEVER be re-bucketed here (the pre-#2822 mis-bucket bug).
+    """
+    if store is None:
+        return
+    exclude = set(_RUNTIME_PREFIXES) | {"openclaw", "nemoclaw"}
+    rows = store.query_otlp_app_rollup(
+        exclude_agent_types=exclude, limit=_OTLP_APP_CAP + 1,
+    )
+    if not rows:
+        return
+    if len(rows) > _OTLP_APP_CAP:
+        log.warning(
+            "otlp app rollup truncated: %d apps observed, surfacing top %d by "
+            "recent activity (raise CLAWMETRY_OTLP_APP_CAP)",
+            len(rows), _OTLP_APP_CAP,
+        )
+        rows = rows[:_OTLP_APP_CAP]
+    for r in rows:
+        at = (r.get("agent_type") or "").strip()
+        if not at:
+            continue
+        # Never clobber a real session-prefix runtime that happens to share a key
+        # (belt-and-braces; the query already excludes them).
+        if at.lower() in exclude or at in out:
+            continue
+        primary = r.get("primary_model") or ""
+        out[at] = {
+            "sessions": int(r.get("sessions") or 0),
+            "turns": int(r.get("turns") or 0),
+            "tokens": int(r.get("tokens") or 0),
+            "cost_usd": round(float(r.get("cost_usd") or 0.0), 4),
+            "primary_model": primary,
+            "total_turns": int(r.get("turns") or 0),
+            "models": (
+                [{"model": primary, "turns": int(r.get("turns") or 0),
+                  "sessions": int(r.get("sessions") or 0), "share_pct": 100}]
+                if primary else []
+            ),
+            "switch_count": 0,
+            # Markers the inventory builder + frontend use to treat this as an
+            # OTLP app (agent_type filter, not session-prefix).
+            "otlp": True,
+            "display_name": _humanize_service_name(r.get("service_name") or "", at),
+            "traces": int(r.get("traces") or 0),
+            "spans": int(r.get("spans") or 0),
+        }
 
 
 # Friendly per-runtime label map for the Agent Inventory roster. Mirrors the
@@ -10871,12 +10968,13 @@ def _build_agent_inventory(
       with ONLY that runtime's row (the per-runtime no-leak contract). An absent
       runtime is simply not a key, so the interceptor returns ZERO for it.
 
-    NOTE (open question, deferred): foreign OTLP apps (post #2822) derive
-    ``agent_type`` from ``spans.service.name`` with no session-id prefix, so they
-    bucket into ``openclaw`` here and do NOT get their own row. Including them
-    would need a new GROUP-BY-agent_type scan over the spans table (a request /
-    snapshot-path full scan), which the CPU budget (FLYWHEEL 1e) rejects for v1.
-    OTLP-app rows are a follow-up. The 12 session-prefix runtimes are covered.
+    Foreign OTLP / OpenLLMetry apps (post #2822) derive ``agent_type`` from the
+    resource ``service.name`` with NO session-id prefix. ``_build_runtime_summary``
+    now folds them in (one cheap GROUP BY agent_type on the daemon snapshot timer,
+    NOT a request-path scan — FLYWHEEL 1e), tagged ``otlp=True`` + ``display_name``.
+    They flow through here automatically and get their own roster row, identified
+    by ``agent_type`` (the per-runtime no-leak slice scopes them by agent_type,
+    not session prefix). The 12 session-prefix runtimes are unaffected.
 
     Best-effort: never raises (any failure yields empty slices).
     """
@@ -10895,13 +10993,22 @@ def _build_agent_inventory(
             if not isinstance(summ, dict):
                 continue
             d = det_by_name.get(rt) or {}
+            is_otlp = bool(summ.get("otlp"))
             label = (
-                _INV_RT_LABELS.get(rt)
+                # OTLP apps carry their own humanized 'My App (OTel)' label;
+                # they have no _INV_RT_LABELS / detected-runtime entry.
+                (summ.get("display_name") if is_otlp else None)
+                or _INV_RT_LABELS.get(rt)
                 or d.get("displayName")
                 or rt
             )
             if rt == "openclaw":
                 detected = bool(oc_present)
+            elif is_otlp:
+                # An OTLP app is "detected" iff it has emitted spans (it has, or
+                # it wouldn't be in runtime_summary). It is not a local process
+                # we can heartbeat, so ``running`` stays False, labeled honestly.
+                detected = True
             else:
                 detected = rt in det_by_name
             mrow = meta.get(rt) or {}
@@ -10909,6 +11016,10 @@ def _build_agent_inventory(
                 "agentKey": rt,
                 "displayName": label,
                 "detected": detected,
+                # Foreign OpenLLMetry/OTLP app (no session-id prefix): the
+                # frontend scopes it by agent_type, not the prefix path, and the
+                # roster labels it as a bring-your-own-agent app.
+                "otlp": is_otlp,
                 # process-presence for family runtimes (only OpenClaw/NemoClaw
                 # emit a real heartbeat); labeled honestly in the UI tooltip.
                 "running": bool(d.get("running", False)),

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -563,6 +563,12 @@ _DAEMON_METHODS = frozenset({
     # Issue #1013: Trace 7 — one row per trace_id with aggregate stats.
     # Powers /api/local/traces + the cloud relay query.traces shape.
     "query_traces",
+    # Foreign OTLP / OpenLLMetry apps (#2822 stamps agent_type from
+    # service.name): a single GROUP BY agent_type rollup so the runtime
+    # switcher + Agent Inventory surface a bring-your-own-agent app that only
+    # ever sent OTLP traces. Daemon snapshot-path use; allowlisted so the
+    # local Inventory route can read it through the proxy too.
+    "query_otlp_app_rollup",
     # Issue #1364 (Tier-1 2026-05-15): /api/fallbacks model/provider
     # transition aggregator. Replaces a JSONL walker that opened up to 100
     # transcript files per request — multi-second on a busy workspace.

--- a/tests/test_appjs_units.js
+++ b/tests/test_appjs_units.js
@@ -1103,13 +1103,20 @@ console.log('tool alternatives toggle (issue #1616)');
 // ── Runtime filter: _cmRuntimeOf derivation (session-id prefix = runtime) ──
 console.log('_cmRuntimeOf (runtime from session-id prefix)');
 {
-  // Pull the runtime-label map + the deriver. _cmRuntimeOf references the
-  // module-level _CM_RT_LABEL, so eval both together.
+  // Pull the runtime-label map, the prefix set, the OTLP registry + helpers,
+  // and the deriver. _cmRuntimeOf references _CM_RT_PREFIXES + _CM_OTLP_RT, so
+  // eval them together.
   const labelSrc = src.match(/var _CM_RT_LABEL = \{[\s\S]*?\};/)[0];
+  const prefixSrc = src.match(/var _CM_RT_PREFIXES = \{[\s\S]*?\};/)[0];
+  const otlpSrc = src.match(/var _CM_OTLP_RT = \{\};/)[0];
+  const regFn = extractFunction('_cmRegisterOtlpRuntime');
+  const isOtlpFn = extractFunction('_cmIsOtlpRuntime');
   const fnSrc = extractFunction('_cmRuntimeOf');
   const sandbox = {};
   vm.createContext(sandbox);
-  vm.runInContext(labelSrc + '\n' + fnSrc + '\nthis._f = _cmRuntimeOf;', sandbox);
+  vm.runInContext(labelSrc + '\n' + prefixSrc + '\n' + otlpSrc + '\n'
+    + regFn + '\n' + isOtlpFn + '\n' + fnSrc
+    + '\nthis._f = _cmRuntimeOf; this._reg = _cmRegisterOtlpRuntime; this._isOtlp = _cmIsOtlpRuntime;', sandbox);
   const rt = sandbox._f;
   eq(rt({ id: 'qwen_code:f9f7f80f-c858' }), 'qwen_code', 'qwen_code: prefix → qwen_code');
   eq(rt({ id: 'claude_code:bfb6be7d' }), 'claude_code', 'claude_code: prefix → claude_code');
@@ -1119,6 +1126,27 @@ console.log('_cmRuntimeOf (runtime from session-id prefix)');
   eq(rt({ id: 'clawmetry-selfevolve' }), 'openclaw', 'internal session → openclaw');
   eq(rt({ trace_id: 'qwen_code:x' }), 'openclaw', 'trace_id is NOT read (only id/sessionId/session_id/key)');
   eq(rt({ sessionId: 'goose:20260525_3' }), 'goose', 'sessionId field honoured');
+
+  // ── Foreign OTLP apps (no session prefix; agent_type filter) ──────────────
+  // Before registration, an unknown agent_type does NOT bucket to a phantom
+  // runtime; it stays openclaw (the default) — never mis-bucketed.
+  eq(rt({ session_id: 's1', agent_type: 'my_app' }), 'openclaw',
+     'unregistered OTLP agent_type → openclaw (no phantom)');
+  // Register the OTLP app (as the daemon's inventory/runtimeSummary would), then
+  // the deriver honours its agent_type, and ONLY its own data matches.
+  sandbox._reg('my_app', 'My App (OTel)');
+  truthy(sandbox._isOtlp('my_app'), 'registered app is recognised as OTLP');
+  eq(rt({ agent_type: 'my_app' }), 'my_app', 'registered OTLP app → matches its agent_type');
+  eq(rt({ runtime: 'my_app' }), 'my_app', 'OTLP app via runtime field');
+  // No leak: a native session id never resolves to the OTLP app, and the OTLP
+  // app id never resolves to a native runtime.
+  eq(rt({ id: 'claude_code:abc', agent_type: 'my_app' }), 'claude_code',
+     'native prefix wins over agent_type (no OTLP leak into native)');
+  eq(rt({ id: '625c0ad9-71af', agent_type: 'openclaw' }), 'openclaw',
+     'openclaw stays openclaw');
+  // Registering must never shadow a native runtime key.
+  sandbox._reg('claude_code', 'should-not-apply');
+  truthy(!sandbox._isOtlp('claude_code'), 'register cannot turn a native runtime into OTLP');
 }
 
 // ── Runtime filter: _cmApplyRuntimeScopeNote picks the right scope ─────────
@@ -1144,13 +1172,21 @@ console.log('_cmApplyRuntimeScopeNote (honest note on aggregate / node-wide tabs
     escHtml: function(s) { return String(s); },
     _cmRuntimeFilter: function() { return filterVal; },
     _cmRuntimeLabel: function(rt) { return ({ qwen_code: 'Qwen Code' })[rt] || rt; },
+    // The scope note now short-circuits for OTLP runtimes; this suite tests the
+    // native-runtime branches, so report "not OTLP" for them.
+    _cmIsOtlpRuntime: function() { return false; },
+    // Multi-runtime node so the aggregate-note suppression (single-runtime
+    // installs hide the note) does not fire.
+    _cmGlobalRtCounts: { openclaw: 3, qwen_code: 2 },
   };
   vm.createContext(sandbox);
   vm.runInContext(maps + '\n' + fnSrc + '\nthis._note = _cmApplyRuntimeScopeNote;', sandbox);
 
-  // aggregate tab (usage/Cost) → "all runtimes" note mentioning the runtime
-  thePage = null; sandbox.document.getElementById = function(id) { return id === 'page-usage' ? (thePage = thePage || makePage()) : null; };
-  sandbox._note('usage');
+  // aggregate tab (LLM Context) → "all runtimes" note mentioning the runtime.
+  // (usage/Cost moved to real per-runtime filtering; LLM Context is the
+  // remaining aggregate tab in _CM_RT_AGGREGATE.)
+  thePage = null; sandbox.document.getElementById = function(id) { return id === 'page-context' ? (thePage = thePage || makePage()) : null; };
+  sandbox._note('context');
   truthy(thePage && thePage._html.indexOf('all runtimes') !== -1, 'aggregate tab → "all runtimes" note');
   truthy(thePage._html.indexOf('Qwen Code') !== -1, 'aggregate note names the selected runtime');
 

--- a/tests/test_otlp_rollup_cpu_budget.py
+++ b/tests/test_otlp_rollup_cpu_budget.py
@@ -1,0 +1,79 @@
+"""CPU-budget guard for the OTLP/OpenLLMetry app rollup (FLYWHEEL 1e).
+
+The distinct-agent_type spans scan that surfaces foreign OTLP apps in the
+runtime switcher + Agent Inventory MUST run on the daemon's snapshot/rollup
+timer (inside ``sync._build_runtime_summary`` -> ``_merge_otlp_apps_into_summary``)
+and NEVER inside an HTTP request handler. A per-request GROUP BY over the spans
+table would re-scan on every poll and blow the <=5-10% one-core budget.
+
+This is a STRUCTURAL guard (not a perf measurement): it asserts the only
+invocation of ``LocalStore.query_otlp_app_rollup`` in the package source lives
+in ``clawmetry/sync.py`` (the cached rollup builder), and that no module under
+``routes/`` invokes it. ``routes/local_query.py`` may name it in the
+``_DAEMON_METHODS`` allowlist (a string, not a call) so the local Inventory route
+can read the already-built rollup through the daemon proxy.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+import pytest
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _call_sites(path: str) -> list[int]:
+    """Return line numbers where ``query_otlp_app_rollup`` is CALLED (an
+    ``ast.Call`` whose func is an attribute access ``something.query_otlp_app_rollup``),
+    ignoring it appearing only as a bare string literal (the allowlist)."""
+    with open(path, "r", encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=path)
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            if isinstance(fn, ast.Attribute) and fn.attr == "query_otlp_app_rollup":
+                hits.append(node.lineno)
+    return hits
+
+
+def test_otlp_rollup_called_only_in_sync_not_in_handlers():
+    sync_path = os.path.join(_REPO, "clawmetry", "sync.py")
+    assert _call_sites(sync_path), (
+        "expected sync.py to invoke query_otlp_app_rollup in the rollup builder")
+
+    routes_dir = os.path.join(_REPO, "routes")
+    offenders = {}
+    for name in os.listdir(routes_dir):
+        if not name.endswith(".py"):
+            continue
+        path = os.path.join(routes_dir, name)
+        sites = _call_sites(path)
+        if sites:
+            offenders[name] = sites
+    assert not offenders, (
+        "query_otlp_app_rollup must NOT be CALLED from any HTTP handler "
+        f"(per-request full scan banned by FLYWHEEL 1e). Offenders: {offenders}")
+
+
+def test_otlp_rollup_lives_in_cached_rollup_builder():
+    """The call site is inside ``_merge_otlp_apps_into_summary``, which is only
+    reached from ``_build_runtime_summary`` (the daemon's cached rollup path),
+    not a request handler."""
+    sync_path = os.path.join(_REPO, "clawmetry", "sync.py")
+    with open(sync_path, "r", encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=sync_path)
+
+    enclosing = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for inner in ast.walk(node):
+                if (isinstance(inner, ast.Call)
+                        and isinstance(inner.func, ast.Attribute)
+                        and inner.func.attr == "query_otlp_app_rollup"):
+                    enclosing = node.name
+                    break
+    assert enclosing == "_merge_otlp_apps_into_summary", (
+        f"expected the call inside _merge_otlp_apps_into_summary, got {enclosing}")

--- a/tests/test_runtime_filter_no_leak.py
+++ b/tests/test_runtime_filter_no_leak.py
@@ -101,6 +101,25 @@ def _seed(store, sid: str, model: str, ts: float) -> None:
     })
 
 
+def _seed_span(store, *, agent_type: str, service_name: str, span_id: str,
+               ts: float, model: str = "", cost: float = 0.0, tokens: int = 0,
+               session_id: str | None = None) -> None:
+    """Seed one OTLP-shaped span (#2822: agent_type stamped from service.name)."""
+    store.ingest_span({
+        "span_id": span_id,
+        "trace_id": "trace-" + span_id,
+        "agent_type": agent_type,
+        "service_name": service_name,
+        "session_id": session_id,
+        "name": "chat" if model else "op",
+        "start_ts": ts,
+        "end_ts": ts + 0.1,
+        "model": model or None,
+        "cost_usd": cost,
+        "token_count": tokens,
+    })
+
+
 # ── 1. Pure bucketing function ──────────────────────────────────────────────
 
 
@@ -247,3 +266,182 @@ def test_usage_api_per_runtime_no_leak(app_and_store):
     body_all = cli.get("/api/usage").get_json() or {}
     assert (body_all.get("today") or 0) == sum(t for _, t in seeds.values()), (
         f"unfiltered today mismatch: {body_all.get('today')}")
+
+
+# ── 5. Foreign OTLP / OpenLLMetry apps: surfaced + no-leak (#2822/#2853) ─────
+#
+# A LangChain/CrewAI/OpenAI-Agents app sends OTLP traces; #2822 stamps
+# ``agent_type`` from the resource ``service.name`` onto the spans. The app has
+# NO session-id prefix, so it must be surfaced by agent_type (not prefix) and
+# must obey the same no-leak contract: selecting it returns ONLY its data, and
+# selecting a native runtime returns ZERO of its data (no leak either way).
+
+
+def test_otlp_app_rollup_excludes_native_runtimes(app_and_store):
+    """``query_otlp_app_rollup`` returns ONLY foreign apps, never a native
+    session-prefix runtime (the pre-#2822 mis-bucket bug, inverted)."""
+    import clawmetry.sync as sync
+    a, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    # Native runtimes write spans too (agent_type = prefix); they must NOT
+    # appear in the OTLP rollup.
+    _seed_span(store, agent_type="claude_code", service_name="claude-code",
+               span_id="native-cc", ts=now - 50, model="claude-opus-4-7")
+    _seed_span(store, agent_type="openclaw", service_name="openclaw",
+               span_id="native-oc", ts=now - 49, model="claude-opus-4-7")
+    # Foreign OTLP apps.
+    _seed_span(store, agent_type="my_app", service_name="my-app",
+               span_id="otlp-m1", ts=now - 40, model="gpt-4o", cost=0.05,
+               tokens=120, session_id="my_app-s1")
+    _seed_span(store, agent_type="my_app", service_name="my-app",
+               span_id="otlp-m2", ts=now - 39, model="gpt-4o", cost=0.02,
+               tokens=80, session_id="my_app-s1")
+    _seed_span(store, agent_type="crew", service_name="crew-bot",
+               span_id="otlp-c1", ts=now - 30, model="gpt-4o-mini", cost=0.01,
+               tokens=40)
+    _wait_flush(store)
+
+    exclude = set(sync._RUNTIME_PREFIXES) | {"openclaw", "nemoclaw"}
+    rows = store.query_otlp_app_rollup(exclude_agent_types=exclude, limit=50)
+    by_type = {r["agent_type"]: r for r in rows}
+    # Only the two foreign apps; no native runtime.
+    assert set(by_type) == {"my_app", "crew"}, f"unexpected rollup: {set(by_type)}"
+    assert "claude_code" not in by_type and "openclaw" not in by_type
+    # Aggregates are correct + scoped to the app.
+    assert by_type["my_app"]["turns"] == 2
+    assert by_type["my_app"]["tokens"] == 200
+    assert round(by_type["my_app"]["cost_usd"], 4) == 0.07
+    assert by_type["my_app"]["sessions"] == 1
+    assert by_type["my_app"]["primary_model"] == "gpt-4o"
+    assert by_type["crew"]["turns"] == 1
+
+
+def test_runtime_summary_folds_otlp_app_without_leak(app_and_store):
+    """``_build_runtime_summary`` surfaces a foreign OTLP app as its own entry
+    (otlp=True + display_name) and its cost/tokens never bleed into openclaw."""
+    import clawmetry.sync as sync
+    a, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    # A real openclaw EVENT (session-prefix path) + a foreign OTLP app SPAN.
+    _seed(store, "bareuuid-oc", "claude-opus-4-7", now - 60)   # → openclaw
+    _seed_span(store, agent_type="my_app", service_name="my-app",
+               span_id="otlp-a1", ts=now - 40, model="gpt-4o", cost=0.05,
+               tokens=120, session_id="my_app-s1")
+    _wait_flush(store)
+
+    summary = sync._build_runtime_summary()
+    assert "my_app" in summary, f"OTLP app missing from runtime_summary: {list(summary)}"
+    assert "openclaw" in summary
+    my = summary["my_app"]
+    assert my.get("otlp") is True
+    assert my.get("display_name") == "my-app (OTel)"
+    assert my["tokens"] == 120
+    assert round(my["cost_usd"], 4) == 0.05
+    # No leak: the OTLP app's cost/tokens did NOT land in the openclaw bucket.
+    oc = summary["openclaw"]
+    assert oc.get("otlp") is not True
+    assert oc["tokens"] == 100        # only the seeded openclaw event
+    assert round(oc["cost_usd"], 4) == 0.01
+    # And openclaw's tokens are not my_app's.
+    assert oc["tokens"] != my["tokens"]
+
+
+def test_agent_inventory_by_runtime_otlp_no_leak(app_and_store):
+    """``agentInventoryByRuntime['my_app']`` contains ONLY the my_app row, and
+    selecting 'openclaw' returns ZERO my_app rows (no leak either direction)."""
+    import clawmetry.sync as sync
+    a, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    _seed(store, "bareuuid-oc", "claude-opus-4-7", now - 60)   # → openclaw
+    _seed_span(store, agent_type="my_app", service_name="my-app",
+               span_id="otlp-i1", ts=now - 40, model="gpt-4o", cost=0.05,
+               tokens=120, session_id="my_app-s1")
+    _wait_flush(store)
+
+    summary = sync._build_runtime_summary()
+    node_wide, by_rt = sync._build_agent_inventory(
+        summary, {}, {}, {}, {}, [], {}, "node-test",
+    )
+    keys = {a["agentKey"] for a in node_wide["agents"]}
+    assert "my_app" in keys and "openclaw" in keys
+
+    # my_app slice: only the my_app row, tagged otlp, with its cost.
+    assert "my_app" in by_rt
+    my_slice = by_rt["my_app"]
+    assert my_slice["total"] == 1
+    assert len(my_slice["agents"]) == 1
+    my_row = my_slice["agents"][0]
+    assert my_row["agentKey"] == "my_app"
+    assert my_row["otlp"] is True
+    assert my_row["displayName"] == "my-app (OTel)"
+    assert round(my_row["costUsd"], 4) == 0.05
+    assert all(x["agentKey"] != "openclaw" for x in my_slice["agents"])
+
+    # openclaw slice: only openclaw, ZERO my_app rows.
+    assert "openclaw" in by_rt
+    oc_slice = by_rt["openclaw"]
+    assert all(x["agentKey"] != "my_app" for x in oc_slice["agents"])
+    assert oc_slice["agents"][0]["agentKey"] == "openclaw"
+
+    # An absent runtime is simply not a key (interceptor returns zero, not the
+    # node total).
+    assert "no_such_app" not in by_rt
+
+
+def test_otlp_custom_fallback_is_honest_single_bucket(app_and_store):
+    """#2822 sets agent_type='custom' when service.name was absent; those group
+    under ONE 'custom' entry labeled 'Custom (OTel)', never the openclaw bucket."""
+    import clawmetry.sync as sync
+    a, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    _seed_span(store, agent_type="custom", service_name="",
+               span_id="otlp-cu1", ts=now - 20, model="gpt-4o", cost=0.01,
+               tokens=10)
+    _seed_span(store, agent_type="custom", service_name="",
+               span_id="otlp-cu2", ts=now - 19, model="gpt-4o", cost=0.01,
+               tokens=10)
+    _wait_flush(store)
+    summary = sync._build_runtime_summary()
+    assert "custom" in summary
+    assert summary["custom"]["display_name"] == "Custom (OTel)"
+    assert summary["custom"]["otlp"] is True
+    # Two spans, one bucket (not two phantom runtimes, not openclaw).
+    assert summary["custom"]["turns"] == 2
+    assert "custom" != "openclaw"
+
+
+def test_otlp_app_cap_is_logged_not_silent(app_and_store, caplog):
+    """More OTLP apps than the cap truncates to top-N AND logs a warning (no
+    silent cap — FLYWHEEL)."""
+    import logging
+    import clawmetry.sync as sync
+    a, ls = app_and_store
+    store = ls.get_store()
+    now = time.time()
+    # Seed cap+5 distinct apps.
+    n = sync._OTLP_APP_CAP + 5
+    for i in range(n):
+        _seed_span(store, agent_type=f"app{i}", service_name=f"svc{i}",
+                   span_id=f"otlp-cap-{i}", ts=now - (n - i), model="gpt-4o",
+                   tokens=1)
+    _wait_flush(store)
+    # The "clawmetry-sync" logger may not propagate to caplog's root handler;
+    # attach caplog's handler to it directly so the warning is captured.
+    _slog = logging.getLogger("clawmetry-sync")
+    _prev_prop = _slog.propagate
+    _slog.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="clawmetry-sync"):
+            summary = sync._build_runtime_summary()
+    finally:
+        _slog.propagate = _prev_prop
+    otlp_keys = [k for k, v in summary.items()
+                 if isinstance(v, dict) and v.get("otlp")]
+    assert len(otlp_keys) == sync._OTLP_APP_CAP, (
+        f"expected exactly {sync._OTLP_APP_CAP} OTLP apps, got {len(otlp_keys)}")
+    assert "otlp app rollup truncated" in caplog.text.lower(), (
+        "cap truncation was not logged")


### PR DESCRIPTION
## Why

#2822 made the OTLP `/v1/traces` receiver derive `agent_type` from the resource `service.name` (slugified, fallback `custom`) and store it on the spans table. #2853 shipped the Agent Inventory roster. But both the global runtime switcher (`_cmRuntimeOf` / `_RUNTIME_PREFIXES`, a CLOSED registry keyed on the session-id prefix) and the inventory roster (keyed on `runtimeSummary` keys, also session-prefix) only know session-prefix runtimes. A LangChain / CrewAI / OpenAI-Agents app that sent OTLP traces got `agent_type='my_app'` on its spans but appeared NOWHERE in the switcher dropdown or the roster.

This completes #2822/#2853: foreign instrumented apps were observed but invisible. Bring your own agent, now visible.

## Design

Daemon-side, in the CACHED rollup path only (never a per-request scan, FLYWHEEL 1e):

- `local_store.query_otlp_app_rollup`: a single `GROUP BY agent_type` over the spans table, EXCLUDING the 12 known session-prefix runtimes (+ openclaw/nemoclaw), so it returns only the foreign OTLP/custom apps. Capped at top-50 by recent activity, with a logged warning on truncation (no silent cap).
- `sync._build_runtime_summary` folds each foreign app in as its own entry tagged `otlp=True` + a humanized `display_name` ("My App (OTel)", or "Custom (OTel)" for the #2822 service.name-absent fallback). Because every downstream consumer reads `runtimeSummary` keys, the apps automatically flow into:
  - `runtimeSummary` (Models interceptor, Overview headline)
  - `agentInventory` / `agentInventoryByRuntime` (a real roster row with cost/tokens/sessions, the OTLP-row follow-up deferred in #2853)
  - the switcher dropdown runtime list

Frontend:

- `_CM_OTLP_RT` is a dynamic registry populated from the inventory/runtimeSummary data (`otlp:true` rows). `_cmRegisterOtlpRuntime` adds the label so the dropdown lists the app under an "OpenLLMetry / OTLP apps" optgroup.
- An OTLP app has NO session-id prefix, so `_cmRuntimeOf` keys native runtimes off the closed prefix set and OTLP apps off their `agent_type`/`runtime` field. A native id can never resolve to an OTLP app, and an OTLP key can never shadow a native runtime.
- Selecting an OTLP app scopes SERVER-SIDE by `agent_type` (the inventory `?runtime=<agent_type>` path). For the aggregate/session-prefix tabs that filter client-side, the selection collapses to "all" plus an honest scope note ("observed via OpenLLMetry / OTLP traces; its scoped tokens, cost and sessions are on the Agent Inventory roster"), so a prefix view never silently empties or shows the wrong runtime's data.

## How the no-leak contract is preserved

The prefix-based no-leak contract is untouched: OTLP apps are filtered by `agent_type`, never by prefix, so the two paths never cross. `tests/test_runtime_filter_no_leak.py` is extended to seed openclaw + claude_code + a bare-UUID session + an OTLP app (spans with `agent_type='my_app'`, `service.name='my-app'`) and assert:

- selecting `my_app` returns ONLY my_app data, ZERO openclaw/claude_code rows;
- selecting `openclaw` returns ZERO my_app rows (no leak either direction);
- `agentInventoryByRuntime['my_app']` contains only the my_app row;
- an absent runtime returns zero, not the node total;
- the `custom` fallback groups under ONE honest "Custom (OTel)" entry, never the openclaw bucket (the pre-#2822 mis-bucket bug).

CPU budget: `tests/test_otlp_rollup_cpu_budget.py` is a structural guard asserting `query_otlp_app_rollup` is CALLED only inside `sync._merge_otlp_apps_into_summary` (the cached rollup builder) and NEVER from any `routes/` handler. The client-side mirror is guarded in `tests/test_appjs_units.js` (native vs OTLP derivation, no leak either way).

## Cloud parity (gate 0a.1)

Rides the EXISTING `runtimeSummary` + `agentInventory` / `agentInventoryByRuntime` snapshot slices, which the cm-cloud interceptors already consume. This PR only ENRICHES those slices with extra rows. No NEW snapshot key, so NO new cloud interceptor is required.

## Verification

In-process: seeded an openclaw event + an OTLP app span, rebuilt the rollup, and confirmed the app appears in `runtimeSummary` (otlp=True, correct tokens/cost/sessions), gets its own inventory row, `agentInventoryByRuntime['my_app']` holds only my_app, `['openclaw']` holds zero my_app, and the local `/api/inventory?runtime=my_app` route returns only the my_app row (total 1) while `?runtime=openclaw` returns zero my_app rows. Tests: 11 new pass; the existing runtime-filter / inventory / per-runtime / capability-parity / tool-catalog / context-econ suites pass (2 pre-existing failures on origin/main, unrelated: a stale device-summary schema assertion and a stale `_CM_RT_AGGREGATE` usage-tab assertion which this PR also corrects). `node --check` clean; ruff E/W clean in the changed regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)