### PR TITLE
[RELEASE] fix(web): turn-anatomy cost rollup + honest cost-basis caveat

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -10687,6 +10687,9 @@ var _TA_KIND_ICONS = {
 };
 function _taColor(kind) { return _TA_KIND_COLORS[kind] || '#94a3b8'; }
 function _taIcon(kind) { return _TA_KIND_ICONS[kind] || '•'; }
+// Top-level cost formatter for the turn-anatomy waterfall (the page-scoped
+// fmtCost helpers live inside other functions and aren't in scope here).
+function _taFmtCost(c) { c = Number(c) || 0; return c >= 0.01 ? '$' + c.toFixed(2) : c > 0 ? '<$0.01' : '$0.00'; }
 
 window._taSession = null;
 
@@ -10823,7 +10826,8 @@ function _taRenderTurn(t) {
   var head = '<div style="display:flex;align-items:center;gap:10px;margin-bottom:8px;">'
     + '<span style="font-size:13px;font-weight:700;color:var(--text-primary);">Turn ' + t.turn + '</span>'
     + (isErr ? '<span style="background:rgba(239,68,68,0.15);color:#f87171;border-radius:6px;padding:1px 7px;font-size:10px;font-weight:600;">error</span>' : '')
-    + '<span style="font-size:11px;color:var(--text-muted);">' + _traceFmtDur(t.duration_ms) + ' &middot; ' + (t.tool_count || 0) + ' tool' + (t.tool_count === 1 ? '' : 's') + ' &middot; ' + ((t.total_tokens || 0) / 1000).toFixed(1) + 'K tok</span>'
+    + '<span style="font-size:11px;color:var(--text-muted);">' + _traceFmtDur(t.duration_ms) + ' &middot; ' + (t.tool_count || 0) + ' tool' + (t.tool_count === 1 ? '' : 's') + ' &middot; ' + ((t.total_tokens || 0) / 1000).toFixed(1) + 'K tok'
+       + ((t.total_cost || 0) > 0 ? ' &middot; ' + _taFmtCost(t.total_cost) : '') + '</span>'
     + '</div>';
   var prompt = t.prompt ? '<div style="font-size:12px;color:var(--text-secondary);margin-bottom:10px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="' + escHtml(t.prompt) + '">&#128172; ' + escHtml(t.prompt) + '</div>' : '';
   var bars = '<div style="min-width:560px;">';
@@ -10837,7 +10841,8 @@ function _taRenderTurn(t) {
     var color = _taColor(s.kind);
     var spanErr = s.status === 'error';
     var label = (s.label || s.kind || '');
-    bars += '<div style="display:flex;align-items:center;gap:8px;padding:2px 0;" title="' + escHtml(label) + ' · ' + _traceFmtDur(s.duration_ms) + (spanErr ? ' · error' : '') + '">'
+    var spanCostTip = ((s.cost || 0) > 0 ? ' · ' + _taFmtCost(s.cost) : '') + ((s.tokens || 0) > 0 ? ' · ' + (s.tokens >= 1000 ? (s.tokens / 1000).toFixed(1) + 'K' : s.tokens) + ' tok' : '');
+    bars += '<div style="display:flex;align-items:center;gap:8px;padding:2px 0;" title="' + escHtml(label) + ' · ' + _traceFmtDur(s.duration_ms) + spanCostTip + (spanErr ? ' · error' : '') + '">'
       + '<span style="width:18px;flex-shrink:0;text-align:center;font-size:11px;">' + _taIcon(s.kind) + '</span>'
       + '<span style="width:170px;flex-shrink:0;font-size:11px;color:' + (spanErr ? '#f87171' : 'var(--text-secondary)') + ';white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + escHtml(label) + (spanErr ? ' &#9888;' : '') + '</span>'
       + '<span style="flex:1;position:relative;height:14px;background:var(--bg-primary);border-radius:3px;">'
@@ -12479,9 +12484,21 @@ async function loadUsage() {
     // Cost table
     var usageInfoIcon = document.getElementById('usage-cost-info-icon');
     if (usageInfoIcon) {
-      if (data.billingSummary === 'likely_oauth_or_included' || data.billingSummary === 'mixed') {
+      // Cost shown is API-EQUIVALENT (tokens x API rates, same method as
+      // ccusage). It's only an actual cash charge when the account bills
+      // per-token (an API key). For OAuth/subscription plans (e.g. Claude Max
+      // via the Claude CLI) the incremental cost is $0 — the plan covers it.
+      // Surface the caveat for EVERY mode except confidently-metered
+      // ('likely_api_key'), so an "unknown / billing unconfirmed" account no
+      // longer reads as if it owes the displayed dollars (#web-accuracy).
+      var bs = data.billingSummary;
+      if (bs && bs !== 'likely_api_key') {
         usageInfoIcon.style.display = '';
-        usageInfoIcon.title = 'Equivalent if billed from token usage. OAuth/included models may be billed $0 at provider level.';
+        if (bs === 'likely_oauth_or_included' || bs === 'mixed') {
+          usageInfoIcon.title = 'API-equivalent (tokens × API rates). OAuth/included models are typically billed $0 at the provider — your subscription covers them.';
+        } else {
+          usageInfoIcon.title = 'API-equivalent (tokens × API rates). Billing basis unconfirmed — if your account is on a subscription plan (e.g. Claude Max via the Claude CLI), the actual incremental cost is $0.';
+        }
       } else {
         usageInfoIcon.style.display = 'none';
         usageInfoIcon.title = '';

--- a/routes/turn_anatomy.py
+++ b/routes/turn_anatomy.py
@@ -231,6 +231,11 @@ def _build_turns(rows):
             # Default end = next event's start within the WHOLE session.
             nxt = start_ms[gi + 1] if gi + 1 < len(start_ms) else s_ms
             tokens = int(e.get("token_count") or 0)
+            # cost_usd is daemon-stamped on every event at ingest (same column
+            # the tracing waterfall + tool catalog read). Turn anatomy never
+            # carried it, so the user couldn't see which span was expensive
+            # (#web-accuracy). Read it directly here and roll it up per turn.
+            cost = float(e.get("cost_usd") or 0.0)
             model = e.get("model") or _data(e).get("model") or ""
 
             if kind == "tool_result":
@@ -258,6 +263,7 @@ def _build_turns(rows):
                     "started_ms": s_ms, "ended_ms": nxt,
                     "duration_ms": max(0, nxt - s_ms),
                     "tokens": tokens or None,
+                    "cost": cost or None,
                     "status": "error" if _is_error(e) else "ok",
                 }
                 spans.append(sp)
@@ -292,7 +298,8 @@ def _build_turns(rows):
                          + (" " + model if model else ""),
                 "started_ms": s_ms, "ended_ms": nxt,
                 "duration_ms": max(0, nxt - s_ms),
-                "tokens": tokens or None, "model": model or None,
+                "tokens": tokens or None, "cost": cost or None,
+                "model": model or None,
                 "status": "error" if _is_error(e) else "ok",
             })
 
@@ -307,6 +314,7 @@ def _build_turns(rows):
             (s["label"] for s in spans if s["kind"] == "prompt"), "")
         tool_count = sum(1 for s in spans if s["kind"] == "tool")
         total_tokens = sum(int(s.get("tokens") or 0) for s in spans)
+        total_cost = sum(float(s.get("cost") or 0.0) for s in spans)
         has_error = any(s.get("status") == "error" for s in spans)
         out.append({
             "turn": tn + 1,
@@ -316,6 +324,7 @@ def _build_turns(rows):
             "prompt": prompt_label,
             "tool_count": tool_count,
             "total_tokens": total_tokens,
+            "total_cost": round(total_cost, 6),
             "span_count": len(spans),
             "status": "error" if has_error else "ok",
             "spans": spans,

--- a/tests/test_turn_anatomy_cost.py
+++ b/tests/test_turn_anatomy_cost.py
@@ -1,0 +1,53 @@
+"""Guard: turn anatomy now carries per-span and per-turn cost.
+
+Before #web-accuracy (2026-06-08) ``routes/turn_anatomy._build_turns`` emitted
+only duration/tokens — there was NO cost field anywhere (span, turn, or
+response), so the Turn-anatomy waterfall could never show which span was
+expensive even though every event is daemon-stamped with ``cost_usd`` at
+ingest. These tests pin that cost is read off the events and rolled up.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import routes.turn_anatomy as ta
+
+
+def _ev(et, ts, *, cost=0.0, tokens=0, model="", role="", **data):
+    d = {"role": role} if role else {}
+    d.update(data)
+    return {
+        "event_type": et,
+        "ts": datetime.fromtimestamp(ts, tz=timezone.utc).isoformat(),
+        "cost_usd": cost,
+        "token_count": tokens,
+        "model": model,
+        "data": d,
+    }
+
+
+def test_turn_cost_rolls_up_from_events():
+    rows = [
+        _ev("prompt.submitted", 1000, role="user", text="hello"),
+        _ev("model.completed", 1002, cost=12.0, tokens=20000, model="claude-opus-4-8"),
+        _ev("model.completed", 1004, cost=7.86, tokens=12760, model="claude-opus-4-8"),
+    ]
+    turns = ta._build_turns(rows)
+    assert len(turns) == 1
+    t = turns[0]
+    # Turn-level cost = sum of span costs.
+    assert round(t["total_cost"], 2) == 19.86
+    assert t["total_tokens"] == 32760
+    # The expensive span carries its own cost so the UI can highlight it.
+    model_spans = [s for s in t["spans"] if s["kind"] in ("model", "reply")]
+    assert any(round(s.get("cost") or 0, 2) == 12.0 for s in model_spans)
+
+
+def test_zero_cost_turn_reports_zero_not_missing():
+    rows = [
+        _ev("prompt.submitted", 1000, role="user", text="hi"),
+        _ev("model.completed", 1001, cost=0.0, tokens=5, model="llama3.2"),
+    ]
+    turns = ta._build_turns(rows)
+    assert turns[0]["total_cost"] == 0.0  # present, not absent


### PR DESCRIPTION
Follow-up to #2880, closing two web number-honesty gaps from the #web-accuracy audit.

## Turn anatomy had no cost
`routes/turn_anatomy._build_turns` emitted only duration + tokens — **no cost field anywhere** (span, turn, or response) — so the waterfall could never show which span was expensive, even though every event is daemon-stamped with `cost_usd` at ingest. Now it reads `cost_usd` per event, attaches it to model/reply/tool spans, and rolls up `total_cost` per turn. The frontend renders it in the turn header and the per-span tooltip (new top-level `_taFmtCost` — the page-scoped `fmtCost` helpers aren't in scope at `_taRenderTurn`).

## Cost-basis caveat hidden for "billing unconfirmed"
The Usage cost table's caveat icon only showed for OAuth/mixed accounts. An **unknown / billing-unconfirmed** account — e.g. OpenClaw via the Claude CLI on a Claude Max plan (the founder's exact setup, "0 tokens — billing unconfirmed, shown at API rates") — saw `$X` with **no context**, implying real money owed. The caveat now surfaces for every mode except confidently-metered (`likely_api_key`), with mode-specific wording making clear the figure is API-equivalent (tokens × API rates) and a subscription plan covers it at \$0 incremental.

## Verification
- `tests/test_turn_anatomy_cost.py`: per-turn cost rollup (reconciles to \$19.86/32,760), zero-cost reported as `0.0` not absent.
- `node --check` on app.js; turn_anatomy.py parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)