### PR TITLE
[RELEASE] fix(snapshot): source per-runtime rollup totals from the bridged sessions table

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -4032,32 +4032,45 @@ class LocalStore:
                 f"THEN split_part(session_id, ':', 1) ELSE 'openclaw' END"
             )
             by_runtime: dict[str, dict[str, Any]] = {}
-            # Per-runtime TOTALS come from the SESSIONS table with the same
-            # GREATEST(stored, SUM(events)) bridge that query_sessions_table uses
-            # — NOT a raw events sum. Family adapters (claude_code, codex, goose,
-            # …) stash a session's token total on ``sessions.total_tokens`` while
-            # ``events.token_count`` stays 0, so an events-only sum under-reported
-            # tokens (goose/hermes/opencode/qwen_code showed ~0, claude_code 105M
-            # vs the real 134M). Sourcing totals from the bridged sessions table
-            # makes the snapshot reconcile EXACTLY with query_sessions_table (the
-            # source the OSS dashboard already trusts). cost_usd reconciles too
-            # (events DO carry cost, but GREATEST is harmless and keeps one path).
+            # Per-runtime TOTALS use the same GREATEST(stored, SUM(events)) bridge
+            # query_sessions_table uses — NOT a raw events sum. Family adapters
+            # (claude_code, codex, goose, …) stash a session's token total on
+            # ``sessions.total_tokens`` while ``events.token_count`` stays 0, so an
+            # events-only sum under-reported tokens (goose/hermes/opencode/
+            # qwen_code showed ~0, claude_code 105M vs the real 134M).
+            #
+            # FULL OUTER JOIN the sessions table against a per-session events
+            # rollup so EVERY session (in either table) is counted ONCE and gets
+            # GREATEST(row, events) per session, then summed by runtime:
+            #   * family sessions (tokens on the row, events.token_count = 0)
+            #     report the row total;
+            #   * an event-only session with no metadata row yet (transient, or a
+            #     pure-event ingest) still reports its events total — not dropped
+            #     (preserves the OTLP/openclaw no-leak contract).
+            # Joined on session_id (its effective key) so a row and its events
+            # never count as two sessions. Reconciles EXACTLY with
+            # query_sessions_table (the source the OSS dashboard already trusts).
             sql_rt = f"""
+                WITH ev AS (
+                    SELECT session_id,
+                           SUM(COALESCE(token_count, 0)) AS tok,
+                           SUM(COALESCE(cost_usd, 0.0))  AS cost
+                    FROM events GROUP BY session_id
+                ),
+                combined AS (
+                    SELECT COALESCE(s.session_id, ev.session_id) AS session_id,
+                           GREATEST(COALESCE(s.total_tokens, 0),
+                                    COALESCE(ev.tok, 0))         AS tokens,
+                           GREATEST(COALESCE(s.cost_usd, 0.0),
+                                    COALESCE(ev.cost, 0.0))      AS cost_usd
+                    FROM sessions s
+                    FULL OUTER JOIN ev ON s.session_id = ev.session_id
+                )
                 SELECT {rt_case} AS runtime,
-                       COUNT(*) AS sessions,
-                       SUM(GREATEST(
-                           COALESCE(s.total_tokens, 0),
-                           COALESCE((SELECT SUM(e.token_count) FROM events e
-                                      WHERE e.session_id = s.session_id
-                                        AND e.agent_type  = s.agent_type), 0)
-                       )) AS tokens,
-                       SUM(GREATEST(
-                           COALESCE(s.cost_usd, 0.0),
-                           COALESCE((SELECT SUM(e.cost_usd) FROM events e
-                                      WHERE e.session_id = s.session_id
-                                        AND e.agent_type  = s.agent_type), 0.0)
-                       )) AS cost_usd
-                FROM sessions s
+                       COUNT(*)      AS sessions,
+                       SUM(tokens)   AS tokens,
+                       SUM(cost_usd) AS cost_usd
+                FROM combined
                 GROUP BY 1
             """
             for r in self._fetch(sql_rt, list(prefixes)):

--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -4032,13 +4032,32 @@ class LocalStore:
                 f"THEN split_part(session_id, ':', 1) ELSE 'openclaw' END"
             )
             by_runtime: dict[str, dict[str, Any]] = {}
+            # Per-runtime TOTALS come from the SESSIONS table with the same
+            # GREATEST(stored, SUM(events)) bridge that query_sessions_table uses
+            # — NOT a raw events sum. Family adapters (claude_code, codex, goose,
+            # …) stash a session's token total on ``sessions.total_tokens`` while
+            # ``events.token_count`` stays 0, so an events-only sum under-reported
+            # tokens (goose/hermes/opencode/qwen_code showed ~0, claude_code 105M
+            # vs the real 134M). Sourcing totals from the bridged sessions table
+            # makes the snapshot reconcile EXACTLY with query_sessions_table (the
+            # source the OSS dashboard already trusts). cost_usd reconciles too
+            # (events DO carry cost, but GREATEST is harmless and keeps one path).
             sql_rt = f"""
                 SELECT {rt_case} AS runtime,
-                       COUNT(DISTINCT session_id) AS sessions,
-                       SUM(COALESCE(token_count, 0)) AS tokens,
-                       SUM(COALESCE(cost_usd, 0.0)) AS cost_usd,
-                       COUNT(*) AS events
-                FROM events
+                       COUNT(*) AS sessions,
+                       SUM(GREATEST(
+                           COALESCE(s.total_tokens, 0),
+                           COALESCE((SELECT SUM(e.token_count) FROM events e
+                                      WHERE e.session_id = s.session_id
+                                        AND e.agent_type  = s.agent_type), 0)
+                       )) AS tokens,
+                       SUM(GREATEST(
+                           COALESCE(s.cost_usd, 0.0),
+                           COALESCE((SELECT SUM(e.cost_usd) FROM events e
+                                      WHERE e.session_id = s.session_id
+                                        AND e.agent_type  = s.agent_type), 0.0)
+                       )) AS cost_usd
+                FROM sessions s
                 GROUP BY 1
             """
             for r in self._fetch(sql_rt, list(prefixes)):
@@ -4047,7 +4066,6 @@ class LocalStore:
                     "sessions": int(r[1] or 0),
                     "tokens": int(r[2] or 0),
                     "cost_usd": float(r[3] or 0.0),
-                    "events": int(r[4] or 0),
                 }
             by_runtime_model: list[dict[str, Any]] = []
             sql_rtm = f"""

--- a/tests/test_model_rollup_uncapped.py
+++ b/tests/test_model_rollup_uncapped.py
@@ -71,6 +71,20 @@ def _seed(store, sid, model, ts, *, tokens=100, cost=0.01, eid=None):
     })
 
 
+def _seed_session(store, sid, *, tokens=0, cost=0.0):
+    """Write the sessions-table row that the per-runtime TOTALS read from.
+
+    In production every session is written here (sync_session_metadata / family
+    adapters); family adapters stash the token total on the row while
+    events.token_count stays 0, which is exactly why the rollup totals must come
+    from this table, not the events sum."""
+    store.ingest_session({
+        "session_id": sid, "agent_type": "openclaw", "agent_id": "main",
+        "status": "completed", "total_tokens": tokens, "cost_usd": cost,
+        "last_active_at": _iso(1000.0),
+    })
+
+
 def test_rollup_includes_every_runtime_with_exact_totals(store):
     """No runtime starves; per-runtime token/cost/turn sums are exact."""
     now = time.time()
@@ -89,6 +103,16 @@ def test_rollup_includes_every_runtime_with_exact_totals(store):
     ]
     for j, (sid, m, ts, tok, cost) in enumerate(seeds):
         _seed(store, sid, m, ts, tokens=tok, cost=cost, eid=f"e{j}")
+    # Per-runtime totals come from the sessions table (family adapters keep
+    # the token total there, not on events). Mirror production by writing each
+    # session row with its bridged total. Family runtimes (goose/hermes/…) keep
+    # tokens ONLY on the session row — events.token_count is irrelevant for them.
+    _seed_session(store, "claude_code:c1", tokens=40000, cost=4.00)
+    _seed_session(store, "goose:g1", tokens=26487, cost=0.0)
+    _seed_session(store, "hermes:h1", tokens=8832, cost=0.0)
+    _seed_session(store, "opencode:o1", tokens=22505, cost=0.0)
+    _seed_session(store, "qwen_code:q1", tokens=50643, cost=0.0)
+    _seed_session(store, "682c73e4-aaa", tokens=32760, cost=19.86)
     _wait_flush(store)
 
     roll = store.query_model_rollup()
@@ -98,7 +122,8 @@ def test_rollup_includes_every_runtime_with_exact_totals(store):
     for rt in ("claude_code", "goose", "hermes", "opencode", "qwen_code", "openclaw"):
         assert rt in by_rt, f"runtime {rt} starved out of the rollup: {list(by_rt)}"
 
-    # Exact sums (no cap → no loss).
+    # Exact sums sourced from the bridged sessions table (no cap → no loss; and
+    # family token totals are NOT lost just because events.token_count is 0).
     assert by_rt["goose"]["tokens"] == 26487
     assert by_rt["hermes"]["tokens"] == 8832
     assert by_rt["opencode"]["tokens"] == 22505
@@ -107,7 +132,7 @@ def test_rollup_includes_every_runtime_with_exact_totals(store):
     assert by_rt["openclaw"]["tokens"] == 32760
     assert round(by_rt["openclaw"]["cost_usd"], 2) == 19.86
     assert by_rt["openclaw"]["sessions"] == 1
-    # claude_code: 40 events × 1000 tokens, all one session.
+    # claude_code: one session, totals from its bridged session row.
     assert by_rt["claude_code"]["tokens"] == 40000
     assert by_rt["claude_code"]["sessions"] == 1
     assert round(by_rt["claude_code"]["cost_usd"], 2) == 4.00
@@ -126,19 +151,22 @@ def test_rollup_detects_model_switches(store):
     assert ("claude-sonnet-4-6", "claude-opus-4-8") in pairs
 
 
-def test_model_less_events_count_tokens_not_turns(store):
+def test_model_less_events_do_not_count_as_turns(store):
     now = time.time()
     _seed(store, "goose:g1", "llama3.2", now - 30, tokens=100, eid="m1")
-    # A model-less event (e.g. a tool_result row) still has tokens.
+    # A model-less event (e.g. a tool_result row).
     store.ingest({
         "id": "m2", "node_id": "agent+test", "agent_id": "main",
         "session_id": "goose:g1", "event_type": "tool_result",
         "ts": _iso(now - 20), "data": {}, "cost_usd": 0.0,
         "token_count": 50, "model": None,
     })
+    # Session-level token total (the authoritative source for runtime totals).
+    _seed_session(store, "goose:g1", tokens=150, cost=0.0)
     _wait_flush(store)
     roll = store.query_model_rollup()
-    assert roll["by_runtime"]["goose"]["tokens"] == 150  # both events
+    # Runtime total comes from the bridged session row, not the events sum.
+    assert roll["by_runtime"]["goose"]["tokens"] == 150
     goose_models = [r for r in roll["by_runtime_model"] if r["runtime"] == "goose"]
     # Only the model-bearing event counts as a turn.
     assert sum(r["turns"] for r in goose_models) == 1


### PR DESCRIPTION
Follow-up to #2880, found by **live verification** against the decrypted cloud snapshot.

## What #2880 fixed
Runtime starvation (5 runtimes were missing) + OpenClaw cost ($15.97→exact $19.86).

## Residual gap this closes
Per-runtime **token** totals were still summed from `events.token_count`, which is **0 for family adapters** (claude_code, codex, goose, hermes, opencode, qwen_code) — they stash the session token total on `sessions.total_tokens`, not on events. Live snapshot showed goose/hermes/opencode/qwen_code tokens ≈0 and claude_code **105M vs the real 134M** (cost was already near-exact since events *do* carry `cost_usd`).

## Fix
`query_model_rollup.by_runtime` now aggregates the **sessions** table with the same `GREATEST(stored, SUM(events))` bridge `query_sessions_table` uses → the snapshot reconciles **exactly** with the source the OSS dashboard already trusts. Per-model turn attribution (`by_runtime_model`) stays events-sourced (that data only lives on events).

## Live verification (against `/api/cloud/system-snapshot`, decrypted)
| runtime | ground truth | before #2880 | after #2880 | after this PR (expected) |
|---|---|---|---|---|
| claude_code | 134 sess / 134M tok / \$103k | 12 / 22M / \$12.5k | 134 / 105M / \$103k | 134 / **134M** / \$103k |
| openclaw | 2 / 32,760 / \$19.86 | 1 / 20,330 / \$15.97 | **exact** | exact |
| goose/hermes/opencode/qwen_code | present, tokens>0 | **missing** | present, tok≈0 | present, **tok exact** |

Test seeds session rows (mirroring production) and pins exact reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)