### PR TITLE
[RELEASE] fix(sync): re-push recent sessions so events-bridged cost reaches cloud

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -9528,8 +9528,19 @@ def sync_session_metadata(config: dict, state: dict = None) -> int:
         batch: list = []
         total_uploaded = 0
         BATCH_SIZE = 50
-        for fpath, current_mtime in jsonl_files:
-            if last_mtimes.get(fpath.name) == current_mtime:
+        # jsonl_files is sorted mtime-desc. ALWAYS re-process the most-recent
+        # _ALWAYS_RESYNC_RECENT sessions, even when their JSONL mtime is unchanged
+        # — OpenClaw's Claude-CLI JSONL doesn't bump mtime on append AND carries
+        # no usage, so a session's REAL cost/tokens only land via the events
+        # bridge in _flush(). Without this, the bridge never re-reaches Postgres
+        # for an already-synced session and the cloud "Your agents" / device-
+        # summary cost stayed $0 forever (#web-accuracy / audit FIX 7). Bounded
+        # so steady-state cost stays tiny (re-parse a handful of small JSONLs).
+        _ALWAYS_RESYNC_RECENT = int(
+            os.environ.get("CLAWMETRY_RESYNC_RECENT_SESSIONS", "30") or "30")
+        for _idx, (fpath, current_mtime) in enumerate(jsonl_files):
+            if _idx >= _ALWAYS_RESYNC_RECENT and \
+                    last_mtimes.get(fpath.name) == current_mtime:
                 continue
             try:
                 # `<uuid>.jsonl` -> stem is `<uuid>`. For an archived


### PR DESCRIPTION
Final gap from the #web-accuracy sweep, found by **live verification of the device-summary** (Postgres path, separate from the snapshot/Models path fixed in #2880/#2884).

## Symptom
After #2880 the Models tab showed OpenClaw **$19.86** (correct), but the **"Your agents" / device-summary** still showed OpenClaw **$0**.

## Root cause
#2880 added an events-cost bridge to `sync_session_metadata._flush` (the gateway JSONL has no usage for Claude-CLI OpenClaw, so cost must come from the events table). But `_flush` only runs for sessions that pass the **mtime-skip** — and OpenClaw JSONL mtime doesn't bump on append. So an already-synced session is never re-flushed and its Postgres `cost_usd` stays the stale `0` forever. (The snapshot path is immune because it rebuilds from DuckDB every heartbeat.)

## Fix
Always re-process the most-recent `CLAWMETRY_RESYNC_RECENT_SESSIONS` (default **30**, sorted mtime-desc) regardless of the mtime cache, so the events bridge keeps their Postgres cost/tokens fresh. Bounded — re-parses a handful of small JSONLs per cycle.

## Verify-live plan
After this ships + the daemon upgrades: `GET /api/cloud/device-summary` → `agents[runtime=openclaw].cost_today_usd` should read **~19.86** (currently 0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)