### PR TITLE
[RELEASE] feat(agents): TODAY + LIFETIME cost columns + fold inactive agents

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -4079,7 +4079,32 @@ class LocalStore:
                     "sessions": int(r[1] or 0),
                     "tokens": int(r[2] or 0),
                     "cost_usd": float(r[3] or 0.0),
+                    "cost_today_usd": 0.0,
+                    "tokens_today": 0,
                 }
+            # TODAY's cost/tokens per runtime, from events with ts in the current
+            # UTC day. The cost_usd above is LIFETIME (all the runtime's sessions);
+            # the UI shows both. True per-day cost needs event-level cost+ts (which
+            # the cloud sessions table lacks) — so it's computed here on the daemon
+            # and rides the snapshot. Event cost is correct post-#web-accuracy
+            # re-ingest (deduped + current-gen rates).
+            from datetime import datetime as _dt, timezone as _tz
+            _today = _dt.now(_tz.utc).strftime("%Y-%m-%dT00:00:00")
+            sql_today = f"""
+                SELECT {rt_case} AS runtime,
+                       SUM(COALESCE(cost_usd, 0.0))    AS cost_today,
+                       SUM(COALESCE(token_count, 0))   AS tokens_today
+                FROM events
+                WHERE ts >= ?
+                GROUP BY 1
+            """
+            for r in self._fetch(sql_today, list(prefixes) + [_today]):
+                rt = r[0] or "openclaw"
+                b = by_runtime.setdefault(rt, {
+                    "sessions": 0, "tokens": 0, "cost_usd": 0.0,
+                    "cost_today_usd": 0.0, "tokens_today": 0})
+                b["cost_today_usd"] = float(r[1] or 0.0)
+                b["tokens_today"] = int(r[2] or 0)
             by_runtime_model: list[dict[str, Any]] = []
             sql_rtm = f"""
                 SELECT {rt_case} AS runtime,

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8493,43 +8493,75 @@ async function _invFetchData() {
   }
 }
 
+// An agent is "active/recent" (shown by default) when it's running, did work
+// today (cost or tokens), or is the currently-selected runtime. Everything else
+// folds under a "Show N inactive" expander so the roster reads like the device's
+// calm view instead of every runtime ever used on this machine (#web-accuracy).
+function _invIsRecentlyActive(a, rtFilter) {
+  return !!(a.running
+    || (Number(a.costTodayUsd || 0) > 0)
+    || (Number(a.tokensToday || 0) > 0)
+    || (rtFilter !== 'all' && a.agentKey === rtFilter));
+}
+
+function _invRosterRow(a, rtFilter) {
+  var rt = a.agentKey;
+  var label = a.displayName || rt;
+  var doing = _invDoingNow(a);
+  var dot = _invAliveDot(a);
+  var owner = _invOwnerLabel(a);
+  var hasCost = _invHasCost(rt);
+  // TODAY (event-windowed) vs LIFETIME (all the runtime's sessions). The column
+  // used to be labeled "Cost today" but rendered the lifetime total — fixed.
+  var naTip = '<span class="inv-na" data-i18n-title="inventory.cost_na_tip" title="This runtime does not report cost yet.">--</span>';
+  var todayCell = hasCost ? _invFmtUsd(a.costTodayUsd) : naTip;
+  var lifeCell = hasCost ? _invFmtUsd(a.costUsd) : naTip;
+  var work = (a.sessions || 0) + ((a.sessions === 1) ? ' conversation' : ' conversations');
+  var model = a.primaryModel || '--';
+  var highlight = (rtFilter !== 'all' && rt === rtFilter) ? ' inv-row-active' : '';
+  var pencil = window.CLOUD_MODE
+    ? ''
+    : '<span class="inv-owner-pencil" title="Rename owner" onclick="event.stopPropagation();_invStartOwnerEdit(this,\'' + escHtml(rt) + '\')">&#9998;</span>';
+  return ''
+    + '<tr class="inv-row' + highlight + '" data-rt="' + escHtml(rt) + '" onclick="_invToggleRow(this,\'' + escHtml(rt) + '\')">'
+    +   '<td class="inv-c-agent"><span class="inv-dot" style="background:' + dot.color + '"></span>' + escHtml(label) + '</td>'
+    +   '<td class="inv-c-owner"><span class="inv-owner-chip" data-rt="' + escHtml(rt) + '"><span class="inv-owner-name">' + escHtml(owner) + '</span>' + pencil + '</span></td>'
+    +   '<td class="inv-c-doing"><span class="inv-doing ' + doing.cls + '">' + doing.txt + '</span></td>'
+    +   '<td class="inv-c-alive"><span class="inv-dot" style="background:' + dot.color + '"></span>'
+    +     '<span class="inv-alive-lbl" title="For OpenClaw and NemoClaw this is a real heartbeat; for other runtimes it means a process is running.">' + dot.label + '</span></td>'
+    +   '<td class="inv-c-cost" title="Cost from today\'s activity (API-equivalent)">' + todayCell + '</td>'
+    +   '<td class="inv-c-cost inv-c-cost-life" title="All-time cost across this agent\'s tracked sessions (API-equivalent)">' + lifeCell + '</td>'
+    +   '<td class="inv-c-work">' + escHtml(work) + '</td>'
+    +   '<td class="inv-c-model">' + escHtml(model) + '</td>'
+    + '</tr>'
+    + '<tr class="inv-expand-row" id="inv-exp-' + escHtml(rt) + '" style="display:none;"><td colspan="8">'
+    +   _invExpandHtml(a)
+    + '</td></tr>';
+}
+
 function _invRenderRoster(inv) {
   var agents = (inv && inv.agents) || [];
   var rtFilter = (typeof _cmRuntimeFilter === 'function') ? _cmRuntimeFilter() : 'all';
-  var rows = agents.map(function (a) {
-    var rt = a.agentKey;
-    var label = a.displayName || rt;
-    var doing = _invDoingNow(a);
-    var dot = _invAliveDot(a);
-    var owner = _invOwnerLabel(a);
-    var costCell;
-    if (_invHasCost(rt)) {
-      costCell = _invFmtUsd(a.costUsd);
-    } else {
-      costCell = '<span class="inv-na" data-i18n-title="inventory.cost_na_tip" title="This runtime does not report cost yet.">--</span>';
-    }
-    var work = (a.sessions || 0) + ((a.sessions === 1) ? ' conversation' : ' conversations');
-    var model = a.primaryModel || '--';
-    var highlight = (rtFilter !== 'all' && rt === rtFilter) ? ' inv-row-active' : '';
-    var pencil = window.CLOUD_MODE
-      ? ''
-      : '<span class="inv-owner-pencil" title="Rename owner" onclick="event.stopPropagation();_invStartOwnerEdit(this,\'' + escHtml(rt) + '\')">&#9998;</span>';
-    var aliveAgo = a.ownerUpdatedAt ? '' : '';
-    return ''
-      + '<tr class="inv-row' + highlight + '" data-rt="' + escHtml(rt) + '" onclick="_invToggleRow(this,\'' + escHtml(rt) + '\')">'
-      +   '<td class="inv-c-agent"><span class="inv-dot" style="background:' + dot.color + '"></span>' + escHtml(label) + '</td>'
-      +   '<td class="inv-c-owner"><span class="inv-owner-chip" data-rt="' + escHtml(rt) + '"><span class="inv-owner-name">' + escHtml(owner) + '</span>' + pencil + '</span></td>'
-      +   '<td class="inv-c-doing"><span class="inv-doing ' + doing.cls + '">' + doing.txt + '</span></td>'
-      +   '<td class="inv-c-alive"><span class="inv-dot" style="background:' + dot.color + '"></span>'
-      +     '<span class="inv-alive-lbl" title="For OpenClaw and NemoClaw this is a real heartbeat; for other runtimes it means a process is running.">' + dot.label + '</span></td>'
-      +   '<td class="inv-c-cost">' + costCell + '</td>'
-      +   '<td class="inv-c-work">' + escHtml(work) + '</td>'
-      +   '<td class="inv-c-model">' + escHtml(model) + '</td>'
+  var active = [], inactive = [];
+  agents.forEach(function (a) {
+    (_invIsRecentlyActive(a, rtFilter) ? active : inactive).push(a);
+  });
+  // Never end up with an empty roster: if nothing is "active" right now, show
+  // everything rather than an empty table.
+  if (!active.length && inactive.length) { active = inactive; inactive = []; }
+  var rows = active.map(function (a) { return _invRosterRow(a, rtFilter); }).join('');
+  var foldRows = '';
+  if (inactive.length) {
+    foldRows = ''
+      + '<tr class="inv-fold-toggle" onclick="_invToggleInactive(this)">'
+      +   '<td colspan="8"><span class="inv-fold-caret">&#9656;</span> '
+      +     'Show ' + inactive.length + ' inactive agent' + (inactive.length === 1 ? '' : 's')
+      +     ' <span class="inv-fold-hint">(no activity today)</span></td>'
       + '</tr>'
-      + '<tr class="inv-expand-row" id="inv-exp-' + escHtml(rt) + '" style="display:none;"><td colspan="7">'
-      +   _invExpandHtml(a)
-      + '</td></tr>';
-  }).join('');
+      + '<tbody class="inv-fold-body" style="display:none;">'
+      +   inactive.map(function (a) { return _invRosterRow(a, rtFilter); }).join('')
+      + '</tbody>';
+  }
 
   return ''
     + '<table class="inv-table">'
@@ -8538,12 +8570,26 @@ function _invRenderRoster(inv) {
     +     '<th data-i18n="inventory.col_owner">Owner</th>'
     +     '<th data-i18n="inventory.col_doing">Doing now</th>'
     +     '<th data-i18n="inventory.col_alive">Alive</th>'
-    +     '<th data-i18n="inventory.col_cost">Cost today</th>'
+    +     '<th data-i18n="inventory.col_cost_today">Cost today</th>'
+    +     '<th data-i18n="inventory.col_cost_life">Cost (lifetime)</th>'
     +     '<th data-i18n="inventory.col_work">Work done</th>'
     +     '<th data-i18n="inventory.col_model">Main model</th>'
     +   '</tr></thead>'
     +   '<tbody>' + rows + '</tbody>'
+    +   foldRows
     + '</table>';
+}
+
+function _invToggleInactive(el) {
+  try {
+    var body = el.parentNode.querySelector('.inv-fold-body')
+      || (el.nextElementSibling && el.nextElementSibling.classList.contains('inv-fold-body') ? el.nextElementSibling : null);
+    if (!body) return;
+    var open = body.style.display !== 'none';
+    body.style.display = open ? 'none' : '';
+    var caret = el.querySelector('.inv-fold-caret');
+    if (caret) caret.innerHTML = open ? '&#9656;' : '&#9662;';
+  } catch (e) {}
 }
 
 function _invExpandHtml(a) {

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10956,6 +10956,9 @@ def _build_runtime_summary(limit: int = 20000):
                 "turns": total,
                 "tokens": int(totals.get("tokens") or 0),
                 "cost_usd": round(float(totals.get("cost_usd") or 0.0), 4),
+                # LIFETIME cost_usd above; today's slice for the dual-column UI.
+                "cost_today_usd": round(float(totals.get("cost_today_usd") or 0.0), 4),
+                "tokens_today": int(totals.get("tokens_today") or 0),
                 "primary_model": sorted_models[0][0] if sorted_models else "",
                 "total_turns": total,
                 "models": models_out,
@@ -11160,6 +11163,9 @@ def _build_agent_inventory(
                 "turns": summ.get("turns", 0),
                 "tokens": summ.get("tokens", 0),
                 "costUsd": round(float(summ.get("cost_usd", 0.0) or 0.0), 4),
+                # LIFETIME (costUsd) vs TODAY split for the dual-column roster.
+                "costTodayUsd": round(float(summ.get("cost_today_usd", 0.0) or 0.0), 4),
+                "tokensToday": summ.get("tokens_today", 0),
                 "primaryModel": summ.get("primary_model", "") or "",
                 # already bounded to 15 in runtime_summary; trim to 5 for size.
                 "models": (summ.get("models") or [])[:5],

--- a/tests/test_model_rollup_uncapped.py
+++ b/tests/test_model_rollup_uncapped.py
@@ -138,6 +138,22 @@ def test_rollup_includes_every_runtime_with_exact_totals(store):
     assert round(by_rt["claude_code"]["cost_usd"], 2) == 4.00
 
 
+def test_rollup_carries_today_cost_split(store):
+    """by_runtime carries a TODAY slice (events in the current UTC day) distinct
+    from the LIFETIME cost_usd — the dual-column 'Your agents' view."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).timestamp()
+    old = now - 5 * 86400  # 5 days ago → counts toward lifetime, not today
+    _seed(store, "claude_code:c1", "claude-opus-4-8", now - 60, cost=2.0, eid="t1")
+    _seed(store, "claude_code:c1", "claude-opus-4-8", old, cost=8.0, eid="t2")
+    _seed_session(store, "claude_code:c1", tokens=100, cost=10.0)
+    _wait_flush(store)
+    roll = store.query_model_rollup()
+    cc = roll["by_runtime"]["claude_code"]
+    assert round(cc["cost_today_usd"], 2) == 2.0, "today = only today's events"
+    assert round(cc["cost_usd"], 2) == 10.0, "lifetime = the session total"
+
+
 def test_rollup_detects_model_switches(store):
     now = time.time()
     _seed(store, "682c73e4-aaa", "claude-opus-4-8", now - 30, eid="s1")


### PR DESCRIPTION
Addresses the founder's "Your agents" feedback: cost mislabeled + too many inactive agents shown.

## Cost column was lifetime mislabeled "today"
The single "Cost today" column actually rendered `costUsd` (the **lifetime** total), so the screenshot showed $103,439 under a "today" label. Now there are **two columns**:
- **Cost today** — `cost_today_usd`, summed from events in the current UTC day (the cloud sessions table can't compute true per-day cost — no event-level cost — so the daemon computes it from local DuckDB and it rides the snapshot).
- **Cost (lifetime)** — `cost_usd`, all of the runtime's tracked sessions.

## Fold inactive agents
8 runtimes were ever used on this machine; only 2 are recently active (the device shows just those). The roster now shows **recently-active** agents (running / spent today / tokens today / the selected runtime) and folds the rest under **"Show N inactive (no activity today)"**. Never renders an empty table.

## Live-verified
claude_code: **lifetime $4,713.04, today $199.67** (was a single mislabeled $103,439). Numbers are ccusage-accurate after clawmetry#2889 (current-gen rates) + clawmetry-pro#93 (transcript dedup).

Note: full cache-aware token *breakdown* (input/output/cache-read/cache-write) — the adapter now carries `cache_write_tokens`; surfacing the split in the roster expander is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)