### PR TITLE
chore: add GitHub Sponsors button (FUNDING.yml)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: vivekchand


### PR DESCRIPTION
Adds `.github/FUNDING.yml` pointing to GitHub Sponsors (`github: vivekchand`) so a **Sponsor** button appears on the repo and supports the open-source core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)