### PR TITLE
[RELEASE] fix(agents): rolling last-24h cost window instead of calendar today

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -4079,32 +4079,34 @@ class LocalStore:
                     "sessions": int(r[1] or 0),
                     "tokens": int(r[2] or 0),
                     "cost_usd": float(r[3] or 0.0),
-                    "cost_today_usd": 0.0,
-                    "tokens_today": 0,
+                    "cost_24h_usd": 0.0,
+                    "tokens_24h": 0,
                 }
-            # TODAY's cost/tokens per runtime, from events with ts in the current
-            # UTC day. The cost_usd above is LIFETIME (all the runtime's sessions);
-            # the UI shows both. True per-day cost needs event-level cost+ts (which
-            # the cloud sessions table lacks) — so it's computed here on the daemon
-            # and rides the snapshot. Event cost is correct post-#web-accuracy
-            # re-ingest (deduped + current-gen rates).
-            from datetime import datetime as _dt, timezone as _tz
-            _today = _dt.now(_tz.utc).strftime("%Y-%m-%dT00:00:00")
-            sql_today = f"""
+            # Rolling LAST-24h cost/tokens per runtime, from events in the trailing
+            # 24 hours. (A rolling window, not a calendar "today" — a calendar day
+            # starts at an arbitrary UTC midnight that's confusing across
+            # timezones.) cost_usd above is LIFETIME (all the runtime's sessions);
+            # the UI shows both. True windowed cost needs event-level cost+ts
+            # (which the cloud sessions table lacks) — so it's computed here on the
+            # daemon and rides the snapshot. Event cost is correct post-
+            # #web-accuracy re-ingest (deduped + current-gen rates).
+            from datetime import datetime as _dt, timezone as _tz, timedelta as _tdelta
+            _since_24h = (_dt.now(_tz.utc) - _tdelta(hours=24)).isoformat()
+            sql_24h = f"""
                 SELECT {rt_case} AS runtime,
-                       SUM(COALESCE(cost_usd, 0.0))    AS cost_today,
-                       SUM(COALESCE(token_count, 0))   AS tokens_today
+                       SUM(COALESCE(cost_usd, 0.0))    AS cost_24h,
+                       SUM(COALESCE(token_count, 0))   AS tokens_24h
                 FROM events
                 WHERE ts >= ?
                 GROUP BY 1
             """
-            for r in self._fetch(sql_today, list(prefixes) + [_today]):
+            for r in self._fetch(sql_24h, list(prefixes) + [_since_24h]):
                 rt = r[0] or "openclaw"
                 b = by_runtime.setdefault(rt, {
                     "sessions": 0, "tokens": 0, "cost_usd": 0.0,
-                    "cost_today_usd": 0.0, "tokens_today": 0})
-                b["cost_today_usd"] = float(r[1] or 0.0)
-                b["tokens_today"] = int(r[2] or 0)
+                    "cost_24h_usd": 0.0, "tokens_24h": 0})
+                b["cost_24h_usd"] = float(r[1] or 0.0)
+                b["tokens_24h"] = int(r[2] or 0)
             by_runtime_model: list[dict[str, Any]] = []
             sql_rtm = f"""
                 SELECT {rt_case} AS runtime,

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8493,14 +8493,14 @@ async function _invFetchData() {
   }
 }
 
-// An agent is "active/recent" (shown by default) when it's running, did work
-// today (cost or tokens), or is the currently-selected runtime. Everything else
-// folds under a "Show N inactive" expander so the roster reads like the device's
-// calm view instead of every runtime ever used on this machine (#web-accuracy).
+// An agent is "active/recent" (shown by default) when it's running, did work in
+// the last 24h (cost or tokens), or is the currently-selected runtime. Everything
+// else folds under a "Show N inactive" expander so the roster reads like the
+// device's calm view instead of every runtime ever used here (#web-accuracy).
 function _invIsRecentlyActive(a, rtFilter) {
   return !!(a.running
-    || (Number(a.costTodayUsd || 0) > 0)
-    || (Number(a.tokensToday || 0) > 0)
+    || (Number(a.cost24hUsd || 0) > 0)
+    || (Number(a.tokens24h || 0) > 0)
     || (rtFilter !== 'all' && a.agentKey === rtFilter));
 }
 
@@ -8511,10 +8511,10 @@ function _invRosterRow(a, rtFilter) {
   var dot = _invAliveDot(a);
   var owner = _invOwnerLabel(a);
   var hasCost = _invHasCost(rt);
-  // TODAY (event-windowed) vs LIFETIME (all the runtime's sessions). The column
-  // used to be labeled "Cost today" but rendered the lifetime total — fixed.
+  // LAST 24h (rolling, event-windowed) vs LIFETIME (all the runtime's sessions).
+  // The column used to be labeled "Cost today" but rendered the lifetime total.
   var naTip = '<span class="inv-na" data-i18n-title="inventory.cost_na_tip" title="This runtime does not report cost yet.">--</span>';
-  var todayCell = hasCost ? _invFmtUsd(a.costTodayUsd) : naTip;
+  var dayCell = hasCost ? _invFmtUsd(a.cost24hUsd) : naTip;
   var lifeCell = hasCost ? _invFmtUsd(a.costUsd) : naTip;
   var work = (a.sessions || 0) + ((a.sessions === 1) ? ' conversation' : ' conversations');
   var model = a.primaryModel || '--';
@@ -8529,7 +8529,7 @@ function _invRosterRow(a, rtFilter) {
     +   '<td class="inv-c-doing"><span class="inv-doing ' + doing.cls + '">' + doing.txt + '</span></td>'
     +   '<td class="inv-c-alive"><span class="inv-dot" style="background:' + dot.color + '"></span>'
     +     '<span class="inv-alive-lbl" title="For OpenClaw and NemoClaw this is a real heartbeat; for other runtimes it means a process is running.">' + dot.label + '</span></td>'
-    +   '<td class="inv-c-cost" title="Cost from today\'s activity (API-equivalent)">' + todayCell + '</td>'
+    +   '<td class="inv-c-cost" title="Cost from the last 24 hours of activity (API-equivalent)">' + dayCell + '</td>'
     +   '<td class="inv-c-cost inv-c-cost-life" title="All-time cost across this agent\'s tracked sessions (API-equivalent)">' + lifeCell + '</td>'
     +   '<td class="inv-c-work">' + escHtml(work) + '</td>'
     +   '<td class="inv-c-model">' + escHtml(model) + '</td>'
@@ -8556,7 +8556,7 @@ function _invRenderRoster(inv) {
       + '<tr class="inv-fold-toggle" onclick="_invToggleInactive(this)">'
       +   '<td colspan="8"><span class="inv-fold-caret">&#9656;</span> '
       +     'Show ' + inactive.length + ' inactive agent' + (inactive.length === 1 ? '' : 's')
-      +     ' <span class="inv-fold-hint">(no activity today)</span></td>'
+      +     ' <span class="inv-fold-hint">(no activity in 24h)</span></td>'
       + '</tr>'
       + '<tbody class="inv-fold-body" style="display:none;">'
       +   inactive.map(function (a) { return _invRosterRow(a, rtFilter); }).join('')
@@ -8570,7 +8570,7 @@ function _invRenderRoster(inv) {
     +     '<th data-i18n="inventory.col_owner">Owner</th>'
     +     '<th data-i18n="inventory.col_doing">Doing now</th>'
     +     '<th data-i18n="inventory.col_alive">Alive</th>'
-    +     '<th data-i18n="inventory.col_cost_today">Cost today</th>'
+    +     '<th data-i18n="inventory.col_cost_24h">Cost (24h)</th>'
     +     '<th data-i18n="inventory.col_cost_life">Cost (lifetime)</th>'
     +     '<th data-i18n="inventory.col_work">Work done</th>'
     +     '<th data-i18n="inventory.col_model">Main model</th>'

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10956,9 +10956,10 @@ def _build_runtime_summary(limit: int = 20000):
                 "turns": total,
                 "tokens": int(totals.get("tokens") or 0),
                 "cost_usd": round(float(totals.get("cost_usd") or 0.0), 4),
-                # LIFETIME cost_usd above; today's slice for the dual-column UI.
-                "cost_today_usd": round(float(totals.get("cost_today_usd") or 0.0), 4),
-                "tokens_today": int(totals.get("tokens_today") or 0),
+                # LIFETIME cost_usd above; rolling last-24h slice for the
+                # dual-column UI.
+                "cost_24h_usd": round(float(totals.get("cost_24h_usd") or 0.0), 4),
+                "tokens_24h": int(totals.get("tokens_24h") or 0),
                 "primary_model": sorted_models[0][0] if sorted_models else "",
                 "total_turns": total,
                 "models": models_out,
@@ -11163,9 +11164,9 @@ def _build_agent_inventory(
                 "turns": summ.get("turns", 0),
                 "tokens": summ.get("tokens", 0),
                 "costUsd": round(float(summ.get("cost_usd", 0.0) or 0.0), 4),
-                # LIFETIME (costUsd) vs TODAY split for the dual-column roster.
-                "costTodayUsd": round(float(summ.get("cost_today_usd", 0.0) or 0.0), 4),
-                "tokensToday": summ.get("tokens_today", 0),
+                # LIFETIME (costUsd) vs rolling-24h split for the dual-column roster.
+                "cost24hUsd": round(float(summ.get("cost_24h_usd", 0.0) or 0.0), 4),
+                "tokens24h": summ.get("tokens_24h", 0),
                 "primaryModel": summ.get("primary_model", "") or "",
                 # already bounded to 15 in runtime_summary; trim to 5 for size.
                 "models": (summ.get("models") or [])[:5],

--- a/tests/test_model_rollup_uncapped.py
+++ b/tests/test_model_rollup_uncapped.py
@@ -138,19 +138,19 @@ def test_rollup_includes_every_runtime_with_exact_totals(store):
     assert round(by_rt["claude_code"]["cost_usd"], 2) == 4.00
 
 
-def test_rollup_carries_today_cost_split(store):
-    """by_runtime carries a TODAY slice (events in the current UTC day) distinct
-    from the LIFETIME cost_usd — the dual-column 'Your agents' view."""
+def test_rollup_carries_24h_cost_split(store):
+    """by_runtime carries a rolling LAST-24h slice (events in the trailing 24h)
+    distinct from the LIFETIME cost_usd — the dual-column 'Your agents' view."""
     from datetime import datetime, timezone
     now = datetime.now(timezone.utc).timestamp()
-    old = now - 5 * 86400  # 5 days ago → counts toward lifetime, not today
+    old = now - 5 * 86400  # 5 days ago → counts toward lifetime, not the 24h window
     _seed(store, "claude_code:c1", "claude-opus-4-8", now - 60, cost=2.0, eid="t1")
     _seed(store, "claude_code:c1", "claude-opus-4-8", old, cost=8.0, eid="t2")
     _seed_session(store, "claude_code:c1", tokens=100, cost=10.0)
     _wait_flush(store)
     roll = store.query_model_rollup()
     cc = roll["by_runtime"]["claude_code"]
-    assert round(cc["cost_today_usd"], 2) == 2.0, "today = only today's events"
+    assert round(cc["cost_24h_usd"], 2) == 2.0, "24h = only the last 24h of events"
     assert round(cc["cost_usd"], 2) == 10.0, "lifetime = the session total"
 
 


### PR DESCRIPTION
Founder feedback: a calendar "today" starts at UTC midnight — an arbitrary, timezone-confusing boundary ("not sure when the start time of today is"). Switch the per-runtime windowed cost/tokens to a **rolling trailing 24h** (events with `ts >= now-24h`), recomputed each snapshot.

Renamed honestly: `cost_24h_usd` / `tokens_24h` / `cost24hUsd` / `tokens24h`; column **"Cost (24h)"**; fold hint "no activity in 24h". Lifetime (`cost_usd`) unchanged.

Verified live: claude_code **24h $443.17 / lifetime $4,734.00**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)