### PR TITLE
fix(otlp): persist OTLP spans through the daemon writer (bring-your-own-agent was silently dropped)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -2753,7 +2753,16 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
                 # retries land as INSERT OR REPLACE without duping.
                 if _store is not None:
                     try:
-                        _store.put_span(_otel_to_row(span, resource_attrs))
+                        # Keyword arg is REQUIRED: in the dashboard process
+                        # get_store() returns a _ProxyStore that forwards to the
+                        # daemon writer, and the proxy only forwards **kwargs
+                        # (positional args are dropped). With a positional span
+                        # the write silently no-ops and OTLP spans never persist
+                        # whenever the daemon owns the writer lock (i.e. every
+                        # real install). put_span is allowlisted in
+                        # routes/local_query._DAEMON_METHODS so the daemon
+                        # executes the real write.
+                        _store.put_span(span=_otel_to_row(span, resource_attrs))
                     except Exception as e:
                         try:
                             import logging as _lg
@@ -10993,7 +11002,16 @@ def _process_otlp_traces(pb_data, content_encoding=None, content_type=None):
                 # retries land as INSERT OR REPLACE without duping.
                 if _store is not None:
                     try:
-                        _store.put_span(_otel_to_row(span, resource_attrs))
+                        # Keyword arg is REQUIRED: in the dashboard process
+                        # get_store() returns a _ProxyStore that forwards to the
+                        # daemon writer, and the proxy only forwards **kwargs
+                        # (positional args are dropped). With a positional span
+                        # the write silently no-ops and OTLP spans never persist
+                        # whenever the daemon owns the writer lock (i.e. every
+                        # real install). put_span is allowlisted in
+                        # routes/local_query._DAEMON_METHODS so the daemon
+                        # executes the real write.
+                        _store.put_span(span=_otel_to_row(span, resource_attrs))
                     except Exception as e:
                         try:
                             import logging as _lg

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -569,6 +569,15 @@ _DAEMON_METHODS = frozenset({
     # ever sent OTLP traces. Daemon snapshot-path use; allowlisted so the
     # local Inventory route can read it through the proxy too.
     "query_otlp_app_rollup",
+    # OTLP span WRITE-through. The /v1/traces receiver runs in the dashboard
+    # process, which does not own the DuckDB writer; get_store() returns a
+    # _ProxyStore that forwards put_span here so the daemon (the writer) does
+    # the real INSERT. Without this allowlist entry the proxy 400s and the span
+    # silently vanishes, so a "bring your own agent" OTLP app never persists or
+    # appears in the switcher / Inventory. Same write-through-proxy pattern as
+    # set_agent_meta. The handler calls put_span(span=...) by keyword (the proxy
+    # only forwards kwargs).
+    "put_span",
     # Issue #1364 (Tier-1 2026-05-15): /api/fallbacks model/provider
     # transition aggregator. Replaces a JSONL walker that opened up to 100
     # transcript files per request — multi-second on a busy workspace.

--- a/tests/test_spans_otlp_edge_cases.py
+++ b/tests/test_spans_otlp_edge_cases.py
@@ -674,3 +674,67 @@ def test_openllmetry_openai_chat_shape_end_to_end(app):
     sp_body = _spans(c, "?session_id=conv-xyz-789&limit=10")
     assert sp_body["count"] == 1
     assert sp_body["spans"][0]["span_id"] == _hx(0x90)
+
+
+class _RecordingProxy:
+    """Stand-in for the dashboard-process _ProxyStore: records every method
+    call (args + kwargs) and no-ops, mirroring how the real proxy forwards to
+    the daemon. Crucially it lets us assert the OTLP receiver passes the span
+    by KEYWORD (the real proxy drops positional args)."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __getattr__(self, name):
+        def _f(*a, **k):
+            self.calls.append((name, a, k))
+            return None
+        return _f
+
+
+@pytest.mark.skipif(_ts_pb2 is None, reason="opentelemetry-proto not installed")
+def test_otlp_span_write_forwards_through_daemon_proxy(monkeypatch):
+    """Regression (caught live 2026-06-08): when the daemon owns the DuckDB
+    writer, the dashboard's get_store() returns a _ProxyStore that ONLY
+    forwards **kwargs (positional args are dropped). The OTLP /v1/traces
+    receiver therefore MUST call put_span(span=...) by keyword, and put_span
+    MUST be in routes.local_query._DAEMON_METHODS, or every OTLP span silently
+    no-ops and a bring-your-own-agent (OpenLLMetry) app never persists or shows
+    up in the runtime switcher / Agent Inventory. The other tests in this file
+    force single-process (`_daemon_registered` -> False), which is exactly why
+    they missed this; here we force the proxy path."""
+    import importlib
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    rec = _RecordingProxy()
+    monkeypatch.setattr(ls, "get_store", lambda *a, **k: rec)
+
+    import dashboard as _d
+    pb = _build_pb(
+        [{
+            "span_id_hex": "1111111111111111",
+            "name": "openai.chat",
+            "start_ts": time.time(),
+            "str_attrs": {"gen_ai.system": "openai", "gen_ai.request.model": "gpt-4o"},
+            "int_attrs": {
+                "gen_ai.usage.input_tokens": 1200,
+                "gen_ai.usage.output_tokens": 350,
+            },
+        }],
+        service_name="my-langchain-app",
+    )
+    _d._process_otlp_traces(pb)
+
+    put_calls = [c for c in rec.calls if c[0] == "put_span"]
+    assert put_calls, "put_span was never called by the OTLP receiver"
+    _name, args, kwargs = put_calls[0]
+    # The real proxy drops positional args; the span MUST ride as a keyword.
+    assert not args, f"positional put_span args are dropped by the proxy: {args!r}"
+    assert "span" in kwargs, "put_span must be called as put_span(span=...)"
+    row = kwargs["span"]
+    # service.name -> per-app agent_type (the bring-your-own-agent identity).
+    assert row.get("agent_type") == "my_langchain_app", row.get("agent_type")
+
+    # And the daemon must accept the write, or the proxy 400s -> silent drop.
+    import routes.local_query as lq
+    assert "put_span" in lq._DAEMON_METHODS


### PR DESCRIPTION
## The bug (caught by live verification, not CI)
`/v1/traces` runs in the dashboard process, which does not own the DuckDB writer lock. There `get_store()` returns a `_ProxyStore` that forwards to the daemon and **only passes `**kwargs`** (positional args dropped), and `put_span` was **not** daemon-allowlisted. So `_process_otlp_traces` calling `put_span(row)` **positionally** made every OTLP span silently no-op whenever a daemon runs (every real install): the POST returns 200 but nothing persists, so a bring-your-own-agent OpenLLMetry app never appeared in the switcher or Agent Inventory. The OTLP tests missed it because they force single-process (`_daemon_registered -> False`), where `get_store()` is the real writer.

## Fix (mirrors the working `set_agent_meta` write-through pattern)
- allowlist `put_span` in `routes/local_query._DAEMON_METHODS`;
- call `put_span(span=...)` by keyword in both `_process_otlp_traces` copies.

## Verified live (the proof it is not vaporware)
Sent a real OpenLLMetry-shaped OTLP trace to a running daemon+dashboard. **Before:** 0 spans persist. **After:** span lands in DuckDB, `query_otlp_app_rollup` returns it with derived cost, and it surfaces in `runtimeSummary` + `agentInventory` and on the **hosted dashboard** (switcher 'OpenLLMetry / OTLP apps' optgroup + inventory row 'byo-langchain-demo (OTel)', gpt-4o, real cost). New regression test forces the proxy path the suite skipped and asserts keyword forwarding + allowlist. 23/23 OTLP tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)