### PR TITLE
fix(tokens): seed output_tokens floor from message_start + streamed-thinking reconciliation tests (#2842)

### DIFF
--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -1007,6 +1007,12 @@ def parse_anthropic_sse_chunk(line: str, usage: StreamUsage) -> None:
         usage.cache_read_tokens = u.get("cache_read_input_tokens", 0)
         usage.cache_creation_tokens = u.get("cache_creation_input_tokens", 0)
         usage.model = msg.get("model", usage.model)
+        # message_start carries an output_tokens floor (the prefill/initial count).
+        # Seed it so a stream that gets truncated *before* the final message_delta
+        # (client disconnect, upstream error mid-thinking) still records a non-zero
+        # lower bound instead of 0. Use max() so the authoritative message_delta
+        # total below can only raise it, never lose ground (#2842).
+        usage.output_tokens = max(usage.output_tokens, int(u.get("output_tokens", 0) or 0))
 
     elif event_type == "message_delta":
         # message_delta carries the running/final usage. Take the MAX so multiple

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -209,6 +209,65 @@ class TestSSEParsing:
         assert usage.output_tokens == 150
         assert usage.stop_reason == "end_turn"
 
+    def test_anthropic_streamed_thinking_matches_nonstreamed(self):
+        # A full extended-thinking SSE sequence (thinking + signature deltas, then
+        # text) must accumulate the same output_tokens the equivalent non-streamed
+        # response reports in its final usage. Refs #2842.
+        from clawmetry.proxy import parse_anthropic_sse_chunk, StreamUsage
+
+        usage = StreamUsage()
+        stream = [
+            'data: {"type":"message_start","message":{"model":"claude-opus-4-20260313","usage":{"input_tokens":58,"cache_read_input_tokens":12,"output_tokens":2}}}',
+            'data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}',
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me reason about this"}}',
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"abc123"}}',
+            'data: {"type":"content_block_stop","index":0}',
+            'data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}',
+            'data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Answer."}}',
+            'data: {"type":"content_block_stop","index":1}',
+            # Final message_delta carries the authoritative total (thinking + text).
+            'data: {"type":"message_delta","usage":{"output_tokens":314},"delta":{"stop_reason":"end_turn"}}',
+        ]
+        for line in stream:
+            parse_anthropic_sse_chunk(line, usage)
+
+        # Equivalent non-streamed usage block reports output_tokens=314.
+        nonstreamed_output = 314
+        assert usage.input_tokens == 58
+        assert usage.cache_read_tokens == 12
+        assert usage.output_tokens == nonstreamed_output
+        assert usage.stop_reason == "end_turn"
+
+    def test_anthropic_truncated_stream_keeps_floor(self):
+        # If the stream is cut off before the final message_delta, the output_tokens
+        # floor seeded from message_start must survive (never reset to 0). Refs #2842.
+        from clawmetry.proxy import parse_anthropic_sse_chunk, StreamUsage
+
+        usage = StreamUsage()
+        parse_anthropic_sse_chunk(
+            'data: {"type":"message_start","message":{"model":"m","usage":{"input_tokens":40,"output_tokens":7}}}',
+            usage,
+        )
+        # ... thinking deltas stream, then the connection drops. No message_delta.
+        parse_anthropic_sse_chunk(
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"partial"}}',
+            usage,
+        )
+        assert usage.input_tokens == 40
+        assert usage.output_tokens == 7  # floor preserved, not 0
+
+    def test_anthropic_message_start_output_floor_never_lowers_delta(self):
+        # message_start's floor must not clobber a larger value already accumulated.
+        from clawmetry.proxy import parse_anthropic_sse_chunk, StreamUsage
+
+        usage = StreamUsage()
+        usage.output_tokens = 200
+        parse_anthropic_sse_chunk(
+            'data: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":3}}}',
+            usage,
+        )
+        assert usage.output_tokens == 200
+
     def test_anthropic_ignores_non_data(self):
         from clawmetry.proxy import parse_anthropic_sse_chunk, StreamUsage
 


### PR DESCRIPTION
Closes #2842

## What
Hardens the Anthropic SSE token state machine in `proxy.py:parse_anthropic_sse_chunk` so extended-thinking streamed responses are never undercounted, and adds the reconciliation test the issue asks for (streamed thinking usage == non-streamed usage).

## How
- **`message_start` now seeds an `output_tokens` floor.** Previously only `message_delta` ever set `output_tokens`. If a stream was truncated *before* the final `message_delta` (client disconnect, upstream error mid-thinking), the recorded output was **0** — silently undercounting cost. We now take `max(output_tokens, message_start.usage.output_tokens)`, a true lower bound. The authoritative final `message_delta` total (already `max()`-reconciled) can only raise it, never lose ground.
- **Tests added** in `tests/test_proxy.py::TestSSEParsing`:
  - `test_anthropic_streamed_thinking_matches_nonstreamed` — a full thinking sequence (thinking_delta + signature_delta + text_delta, then final `message_delta`) accumulates the exact `output_tokens` the equivalent non-streamed response reports.
  - `test_anthropic_truncated_stream_keeps_floor` — a stream cut off before `message_delta` preserves the `message_start` floor instead of dropping to 0.
  - `test_anthropic_message_start_output_floor_never_lowers_delta` — the floor never clobbers a larger accumulated value.

## Verification
`pytest tests/test_proxy.py tests/test_proxy_cache_risk.py` → 66 passed (10 SSE-parsing tests, 3 new).

Refs epic #2837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)