### PR TITLE
fix(integrity): tamper-evident hash chain ON by default + batched dedup

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -986,7 +986,13 @@ _MIGRATIONS_V2 = [
 # Off by default. Set CLAWMETRY_INTEGRITY=1 to enable stamping new events with
 # a per-node SHA-256 chain. Existing rows keep chain_prev_hash/chain_hash=NULL
 # and are skipped by verify-integrity (reported as "pre-chain" events).
-_INTEGRITY_ENABLED = os.environ.get("CLAWMETRY_INTEGRITY", "0").strip().lower() not in (
+# ON BY DEFAULT (the tamper-evident log is a Free, always-on feature, surfaced
+# in the Security tab + `clawmetry verify-integrity`). Was opt-in ("0") which
+# left the Security integrity card perpetually "empty" and the always-on claim
+# false. Stamping is batched on the flush path and the dedup check is a single
+# query per flush (see _stamp_integrity), so the CPU cost stays within budget;
+# set CLAWMETRY_INTEGRITY=0 to disable on an extreme-volume node.
+_INTEGRITY_ENABLED = os.environ.get("CLAWMETRY_INTEGRITY", "1").strip().lower() not in (
     "0", "false", "no", ""
 )
 
@@ -4727,18 +4733,32 @@ class LocalStore:
             # Sort by id so stamp order within a created_at bucket is deterministic
             # and matches the ORDER BY id ASC used in verify_integrity.
             events.sort(key=lambda e: str(e.get("id") or ""))
+            # Dedup check in ONE query for the whole batch (was a SELECT per
+            # event). INSERT OR IGNORE may have skipped a re-delivered event
+            # that is already stamped; re-stamping it would fork the chain, so
+            # we must skip those. With the flush batch up to 1000 rows, a
+            # per-event lookup is up to 1000 indexed PK queries per flush; this
+            # collapses it to one IN(...) lookup, keeping default-on stamping
+            # within the daemon CPU budget (FLYWHEEL 1e).
+            ids = [str(e.get("id")) for e in events if e.get("id")]
+            already_stamped: dict[str, str] = {}
+            if ids:
+                placeholders = ",".join("?" for _ in ids)
+                for r in conn.execute(
+                    "SELECT id, chain_hash FROM events "
+                    f"WHERE id IN ({placeholders}) AND chain_hash IS NOT NULL",
+                    ids,
+                ).fetchall():
+                    already_stamped[str(r[0])] = r[1]
             updates: list[tuple[str, str, str]] = []
             for e in events:
                 eid = str(e.get("id") or "")
                 if not eid:
                     continue
                 # Only stamp events that were actually inserted (not duplicates).
-                already = conn.execute(
-                    "SELECT chain_hash FROM events WHERE id = ? AND chain_hash IS NOT NULL",
-                    [eid],
-                ).fetchone()
-                if already:
-                    head = already[0]
+                prev = already_stamped.get(eid)
+                if prev is not None:
+                    head = prev
                     continue
                 new_hash = _integrity_hash(head, e)
                 updates.append((head, new_hash, eid))

--- a/tests/test_integrity_hash_chain.py
+++ b/tests/test_integrity_hash_chain.py
@@ -162,3 +162,54 @@ class TestIntegrityEnabled:
         _flush(s)
         result = s.verify_integrity()
         assert result["pre_chain"] >= 1
+
+
+def test_integrity_on_by_default(tmp_path, monkeypatch):
+    """The tamper-evident chain is a Free, always-on feature: with no
+    CLAWMETRY_INTEGRITY env var set it must default ON and stamp new events
+    (regression for the Security integrity card showing a perpetual 'empty'
+    state because the chain was opt-in / off by default)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.delenv("CLAWMETRY_INTEGRITY", raising=False)
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    assert ls._INTEGRITY_ENABLED is True, "integrity must be ON by default"
+    s = ls.LocalStore()
+    s.start()
+    try:
+        for _ in range(3):
+            s.ingest(_ev(node_id="node-a"))
+        _flush(s)
+        res = s.verify_integrity()
+        assert res["status"] == "valid", res
+        assert res["checked"] >= 3, res
+    finally:
+        s.stop(flush=True)
+
+
+def test_batched_dedup_redelivery_keeps_chain_valid(store_with_integrity):
+    """The batched dedup (one IN(...) lookup per flush instead of a SELECT per
+    event) must behave like the per-event version: a re-delivered, already
+    stamped event is NOT re-stamped, so the chain stays valid and length is
+    unchanged. Exercises a flush batch with both fresh and already-stamped ids."""
+    s = store_with_integrity
+    evs = [_ev(node_id="node-a") for _ in range(8)]
+    for e in evs:
+        s.ingest(e)
+    _flush(s)
+    first = s.verify_integrity()
+    assert first["status"] == "valid", first
+    n1 = first["checked"]
+    # Re-deliver the SAME events (idempotent INSERT OR IGNORE) plus a couple new
+    # ones in one batch: the already-stamped ids must be skipped, not re-stamped.
+    for e in evs:
+        s.ingest(dict(e))
+    for _ in range(2):
+        s.ingest(_ev(node_id="node-a"))
+    _flush(s)
+    second = s.verify_integrity()
+    assert second["status"] == "valid", second
+    # Only the 2 genuinely new events get stamped; re-deliveries are skipped.
+    assert second["checked"] == n1 + 2, (n1, second["checked"])


### PR DESCRIPTION
## Why
The tamper-evident hash chain (Security tab integrity card + `clawmetry verify-integrity`) is marketed as a Free, always-on feature, but `_INTEGRITY_ENABLED` defaulted to `CLAWMETRY_INTEGRITY=0` (OFF). On a standard install nothing ever stamped: the integrity card showed a perpetual 'empty' state (`chain_length=0`, surfaced live during the control-tower verification) and the always-on claim was false.

## What
- Default `CLAWMETRY_INTEGRITY` to `1`. `events.id` is a `VARCHAR PRIMARY KEY` (ART-indexed) so stamping is indexed point ops on the flush path, not a scan; set `=0` to disable on an extreme-volume node.
- Batch the duplicate check: one `IN(...)` lookup per flush instead of a `SELECT` per event (flush batch up to 1000 rows), keeping default-on within the daemon CPU budget (FLYWHEEL 1e). Equivalent semantics (re-delivered already-stamped events are skipped, not re-stamped).
- Tests: integrity ON by default stamps + verifies; batched dedup on a mixed fresh/re-delivered flush keeps the chain valid and stamps only the new events. 12/12 integrity tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)