### PR TITLE
feat(device): carry session titles in the encrypted deviceSummary

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -14074,6 +14074,33 @@ def _build_device_summary(spending, daily_usage):
             ]
         except Exception:
             pass
+        # schema 2: per-session titles for the device's runtime-detail recent
+        # -sessions rows. The title is the session's FIRST USER MESSAGE (real
+        # content, e.g. "read flywheel.md ..."), so it rides the ENCRYPTED
+        # deviceSummary (decrypted on-device) and NEVER the plaintext
+        # device-agent endpoint -- raw content never leaves the daemon in the
+        # clear (the cloud only ever stores an empty display_name for these).
+        # The firmware looks each recent-session row up here by its BARE session
+        # id (post-':' so it matches the device-agent rows) and falls back to a
+        # short id when absent. Keyed by bare id, capped + truncated to keep the
+        # ~8s-polled summary small. ``rows`` is already last_active DESC.
+        try:
+            titles: dict = {}
+            for s in rows:
+                if not isinstance(s, dict):
+                    continue
+                t = (s.get("title") or "").strip()
+                if not t:
+                    continue
+                bare = str(s.get("session_id") or "").rsplit(":", 1)[-1]
+                if bare and bare not in titles:
+                    titles[bare] = t[:56]
+                if len(titles) >= 40:
+                    break
+            if titles:
+                summary["sessionTitles"] = titles
+        except Exception:
+            pass
     except Exception:
         pass
     try:

--- a/tests/test_device_summary_snapshot.py
+++ b/tests/test_device_summary_snapshot.py
@@ -103,3 +103,48 @@ def test_active_sessions_and_oldest_approval(sync_with_store):
     assert s["approval"]["action"] == "bash"
     assert s["approval"]["runtime"] == "openclaw"
     assert s["health"] == "amber"  # a human is needed
+
+
+def test_session_titles_ride_encrypted_summary_not_uuid(sync_with_store):
+    """The device's runtime-detail recent-session rows must show the session's
+    first-message title (real content), not a raw UUID. That title is content,
+    so it rides the ENCRYPTED deviceSummary (sessionTitles), keyed by the BARE
+    session id, never the plaintext device-agent endpoint."""
+    import time
+    sync, ls = sync_with_store
+    store = ls.get_store()
+    store.ingest_session({
+        "session_id": "claude_code:e149acae-8789-4f61-b365-3b356bf07f88",
+        "agent_type": "claude_code",
+        "status": "ended",
+        "title": "read flywheel.md && ../clawmetry-cloud/flywheel.md",
+        "started_at": "2026-06-08T09:00:00+00:00",
+        "last_active_at": "2026-06-08T11:00:00+00:00",
+    })
+    store.ingest_session({
+        "session_id": "claude_code:e0dbf7e3-2301-4abc-9def-000000000000",
+        "agent_type": "claude_code",
+        "status": "ended",
+        "title": "what does github sponsoring mean??",
+        "started_at": "2026-06-08T08:00:00+00:00",
+        "last_active_at": "2026-06-08T10:00:00+00:00",
+    })
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and store.health()["ring_depth"] != 0:
+        time.sleep(0.02)
+
+    s = sync._build_device_summary({"today": 0}, {"today": 0})
+    titles = s.get("sessionTitles")
+    assert isinstance(titles, dict) and titles, s
+    # keyed by the BARE id (post-':'), value is the human title, never the uuid
+    assert titles.get("e149acae-8789-4f61-b365-3b356bf07f88") == \
+        "read flywheel.md && ../clawmetry-cloud/flywheel.md"
+    assert titles.get("e0dbf7e3-2301-4abc-9def-000000000000") == \
+        "what does github sponsoring mean??"
+    # the prefixed form is NOT a key (firmware looks up the bare device-agent id)
+    assert "claude_code:e149acae-8789-4f61-b365-3b356bf07f88" not in titles
+    # values are never a bare uuid (i.e. content, not an id)
+    import re
+    uuid = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-')
+    for v in titles.values():
+        assert not uuid.match(v), v


### PR DESCRIPTION
## Why
The device runtime-detail recent-session rows showed raw session UUIDs because the meaningful title is the session's **first user message** (content), which the E2E design deliberately keeps out of the cloud (the plaintext sessions table has an empty display_name for claude_code/codex/goose; OpenClaw only carries a label). Captured on the physical device.

## What
Carry the titles in the **encrypted** `deviceSummary.sessionTitles` (the device decrypts on-device; the cloud server never sees them), a compact map keyed by the **bare** session id, built from the rows `_build_device_summary` already queries (last_active DESC), capped 40 / truncated 56 chars. Consistent with 'raw content never leaves the daemon.'

## Verified
Decrypted the live snapshot: `sessionTitles` carries the real first-message titles (e.g. `e149acae-... -> 'read flywheel.md ...'`), content stays encrypted. New test asserts the map is keyed by bare id with the human title, never a UUID.

Pairs with: firmware PR (read + render the titles, the visible part, your OTA) + a cloud PR (revert the plaintext 'Session -' fallback to a short id). Note: `test_shape_and_cost_tokens_passthrough` is a pre-existing failure on origin/main (schema bump), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)