### PR TITLE
fix(connect): never silently run on a temporary placeholder account

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -808,6 +808,12 @@ def _cmd_connect(args) -> None:
     print(f"  https://app.clawmetry.com/cloud")
     print()
 
+    # If this was a zero-friction connect (no real key), the node landed on a
+    # temporary placeholder account and will NOT show under the user's real
+    # login. Warn loudly with the exact relink command instead of letting them
+    # discover a silent "0 nodes" later. No-op (+ skipped) for a keyed connect.
+    _warn_if_placeholder_account(api_key)
+
     try:
         import webbrowser
         webbrowser.open(_dashboard_url)
@@ -1575,6 +1581,37 @@ def _status_live() -> None:
         _sys.stdout.flush()
 
 
+def _is_placeholder_account(email) -> bool:
+    """True when the account is a zero-friction PLACEHOLDER (the daemon
+    auto-registered without a real login). Such an account is invisible from
+    the user's real dashboard, so the node silently never shows up under their
+    email -- the recurring 'I installed it but see 0 nodes' trap."""
+    e = (email or "").strip().lower()
+    return e.endswith("@clawmetry.auto") or e.endswith("@clawmetry.linked")
+
+
+def _warn_if_placeholder_account(api_key: str, email=None) -> bool:
+    """If this node is bound to a placeholder account, print a LOUD, actionable
+    warning (it will NOT appear in the user's dashboard until linked). Returns
+    True when it warned. Best-effort: resolves the email itself if not given,
+    never raises, no-ops offline."""
+    try:
+        if email is None:
+            email, _ = _resolve_account_email(api_key)
+        if not _is_placeholder_account(email):
+            return False
+        print()
+        print("  \033[33m⚠  This machine is on a TEMPORARY account, not your ClawMetry login.\033[0m")
+        print("     It will NOT show up at app.clawmetry.com/cloud under your email.")
+        print("     Link it to your account (copy the command from the '+ Add node'")
+        print("     box at app.clawmetry.com/cloud -- it carries YOUR key):")
+        print("        \033[36mclawmetry connect --key cm_xxxxxxxxxxxx\033[0m")
+        print()
+        return True
+    except Exception:
+        return False
+
+
 def _resolve_account_email(api_key: str):
     """Best-effort: ask the cloud which ACCOUNT this node's api_key is linked to,
     so `clawmetry status` can show the email (and plan). This is the fastest way
@@ -1625,7 +1662,8 @@ def _cmd_status(args) -> None:
             _acct_email, _acct_plan = _resolve_account_email(api_key)
             if _acct_email:
                 _plan_suffix = f"  ({_acct_plan})" if _acct_plan else ""
-                print(f"  Account:     {_acct_email}{_plan_suffix}")
+                _acct_note = "  ⚠ temporary, not linked" if _is_placeholder_account(_acct_email) else ""
+                print(f"  Account:     {_acct_email}{_plan_suffix}{_acct_note}")
             print(f"  Node ID:     {cfg.get('node_id', '?')}")
             print(f"  Connected:   {cfg.get('connected_at', '?')[:19]}")
             if enc_key:
@@ -1637,6 +1675,9 @@ def _cmd_status(args) -> None:
                 print("  E2E:         🔒 enabled")
             else:
                 print("  E2E:         ⚠️  disabled (no secret key in config)")
+            # Loud, actionable block when the node is on a placeholder account
+            # (the recurring 'connected but 0 nodes in my dashboard' trap).
+            _warn_if_placeholder_account(api_key, _acct_email)
         except Exception as e:
             print(f"  Config error: {e}")
     else:

--- a/tests/test_placeholder_account_warning.py
+++ b/tests/test_placeholder_account_warning.py
@@ -1,0 +1,34 @@
+"""The daemon must not silently run on a temporary placeholder account (the
+recurring 'connected but 0 nodes under my login' trap). _cmd_status + the connect
+flow detect a @clawmetry.auto/.linked account and warn with the relink command."""
+import io
+from contextlib import redirect_stdout
+from clawmetry.cli import _is_placeholder_account, _warn_if_placeholder_account
+
+
+def test_detects_placeholder_domains():
+    assert _is_placeholder_account("agent+90652efd@clawmetry.linked") is True
+    assert _is_placeholder_account("agent+abc12345@clawmetry.auto") is True
+    assert _is_placeholder_account("VIVEK@GMAIL.COM") is False
+    assert _is_placeholder_account("vivekchand19@gmail.com") is False
+    assert _is_placeholder_account("") is False
+    assert _is_placeholder_account(None) is False
+
+
+def test_warn_prints_actionable_relink_for_placeholder():
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        warned = _warn_if_placeholder_account("cm_x", email="agent+abc@clawmetry.linked")
+    out = buf.getvalue()
+    assert warned is True
+    assert "TEMPORARY" in out
+    assert "clawmetry connect --key" in out  # the exact fix
+    assert "app.clawmetry.com/cloud" in out
+
+
+def test_warn_silent_for_real_account():
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        warned = _warn_if_placeholder_account("cm_x", email="vivekchand19@gmail.com")
+    assert warned is False
+    assert buf.getvalue() == ""


### PR DESCRIPTION
## Why
The recurring 'installed it but 0 nodes in my dashboard' trap. A zero-friction install binds the daemon to a throwaway placeholder account (`agent+<hash>@clawmetry.auto`, renamed `.linked` after device pairing) that's invisible from the user's real login -- and `clawmetry status` printed `Account: agent+...@clawmetry.linked` with **no hint** anything was wrong, so the node silently never appears under their email.

## What
Detect the placeholder domains and warn loudly + actionably:
- `clawmetry status`: tags the account line (`temporary, not linked`) + a block with the exact relink command.
- zero-friction `clawmetry connect`: same warning at install time (skipped for a keyed connect).

## Verified live
Ran against a real placeholder node (`agent+90652efd@clawmetry.linked`): status now shows the warning + `clawmetry connect --key cm_...`. 3 tests.

Follow-up: deeper auto-claim of the placeholder onto the real account (so the user doesn't even need to re-run connect) -- a bigger cloud+daemon change with a rekey security dimension; this PR kills the silent-failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)