### PR TITLE
[RELEASE] fix(daemon): clean claim-watcher re-exec (release pid lock + stop store)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Release: clean claim-watcher re-exec (#2918) (2026-06-09)
+- The one-step onboarding claim-watcher (0.12.491) re-execs to adopt the real account. os.execv keeps the same PID, so _acquire_pid_lock saw its own live PID and the DuckDB writer lock stayed held — the re-exec'd daemon could fail to start (relying on the launchd KeepAlive crash-restart). Now it stops the store (flush + release the writer lock) and releases the pid lock before execv, so the restart is clean.
+
 ### Release: one-step first-node onboarding — daemon adopts the real account automatically (#2915) (2026-06-08)
 - A zero-friction install lands on a throwaway placeholder account (agent+<hash>@clawmetry.auto), invisible from the user's real login. The daemon now watches for that node being claimed onto the user's real account (by the cloud /cloud auto-claim when `clawmetry connect` opens the browser) and adopts it automatically — NO `clawmetry connect --key` step.
 - While on a placeholder, the daemon polls /api/cloud/claim-status every 5s; the moment the node is claimed it rewrites config with the real key and re-execs, so every thread (heartbeat, snapshot push, pro auto-provision) restarts on the real account and the node syncs there directly. Re-exec also runs the existing pro auto-provision, so adopting a Trial/Pro key installs the pro package and the other runtimes (Claude Code, Codex, …) start syncing automatically.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -15278,6 +15278,21 @@ def start_claim_watcher(config: dict):
                 save_config(cfg)
                 log.info("Node claimed onto %s — adopting the real account and "
                          "restarting (pro auto-provision runs on restart)", new_email)
+                # Clean re-exec: the new process image keeps this PID, so
+                # _acquire_pid_lock would see its OWN live PID and abort, and the
+                # DuckDB writer lock would still be held. Stop the store (flush +
+                # release the writer lock) and drop the pid lock first; then the
+                # re-exec'd run_daemon starts cleanly. (launchd KeepAlive is the
+                # backstop if execv ever fails.)
+                try:
+                    from clawmetry import local_store as _ls
+                    _ls.get_store().stop(flush=True)
+                except Exception:
+                    pass
+                try:
+                    _release_pid_lock()
+                except Exception:
+                    pass
                 time.sleep(0.5)
                 os.execv(sys.executable, [sys.executable] + sys.argv)
             except Exception as e:


### PR DESCRIPTION
Follow-up to #2915. The claim-watcher re-execs to adopt the real account; `os.execv` keeps the PID so `_acquire_pid_lock` saw its own live PID and aborted, and the DuckDB writer lock stayed held. Now stops the store + releases the pid lock before execv. launchd KeepAlive remains the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)