### PR TITLE
fix(proxy): tool-order churn detection per session (#2841)

### DIFF
--- a/clawmetry/proxy.py
+++ b/clawmetry/proxy.py
@@ -874,6 +874,11 @@ def compute_request_hash(body: dict) -> str:
 # in-process, bounded; the proxy is a single long-lived process per node.
 _SESSION_PREFIX: dict = {}
 
+# Per-session raw and normalised tool fingerprints, for tool-order churn
+# detection (#2841). Raw preserves list order; normalised does not.
+_SESSION_TOOLS_NORM: dict = {}
+_SESSION_TOOLS_RAW: dict = {}
+
 _VOLATILE_PATTERNS = {
     "iso_timestamp": re.compile(r"\d{4}-\d\d-\d\d[ T]\d\d:\d\d(?::\d\d)?"),
     "uuid": re.compile(
@@ -906,6 +911,20 @@ def normalize_tools(tools) -> str:
         norm = [_sort_json(t) for t in tools if isinstance(t, dict)]
         norm.sort(key=lambda t: str(t.get("name", "")))
         return json.dumps(norm, separators=(",", ":"), ensure_ascii=False)
+    except Exception:
+        return ""
+
+
+def raw_tools_fp(tools) -> str:
+    """Order-preserving fingerprint for the tools array (#2841). Pair with
+    normalize_tools to detect when a session sends the same tools in a
+    different order across turns. Never raises."""
+    try:
+        if not isinstance(tools, list):
+            return ""
+        return hashlib.sha256(
+            json.dumps(tools, separators=(",", ":"), ensure_ascii=False).encode()
+        ).hexdigest()[:16]
     except Exception:
         return ""
 
@@ -2192,6 +2211,33 @@ def create_proxy_app(config: ProxyConfig = None) -> "Flask":
                 )
         except Exception as _exc:  # noqa: BLE001 — never break the proxy
             logger.debug("cache-risk detection skipped: %s", _exc)
+
+        # ── Tool-order churn detection (#2841) ─────────────────────────
+        # Flag when a session's tools array is reordered between turns but the
+        # normalised set is unchanged — caller is sending tools non-deterministically.
+        # Detection only; never blocks. Diagnostic for the Cost-lens.
+        try:
+            if session_id and isinstance(body.get("tools"), list):
+                _tnorm = normalize_tools(body.get("tools"))
+                _traw = raw_tools_fp(body.get("tools"))
+                _prev_norm = _SESSION_TOOLS_NORM.get(session_id)
+                _prev_raw = _SESSION_TOOLS_RAW.get(session_id)
+                if len(_SESSION_TOOLS_NORM) > 2000:
+                    _SESSION_TOOLS_NORM.clear()
+                    _SESSION_TOOLS_RAW.clear()
+                _SESSION_TOOLS_NORM[session_id] = _tnorm
+                _SESSION_TOOLS_RAW[session_id] = _traw
+                if (_prev_norm and _prev_raw and _tnorm and _traw
+                        and _prev_raw != _traw and _prev_norm == _tnorm):
+                    db.record_event(
+                        "tool_order_churn",
+                        "tool array reordered across turns (same tools, different order)"
+                        " — normalising; caller may be building tools non-deterministically",
+                        severity="info",
+                        details={"session_id": session_id, "model": model},
+                    )
+        except Exception as _exc:  # noqa: BLE001 — never break the proxy
+            logger.debug("tool-order churn detection skipped: %s", _exc)
 
         # ── Velocity check ─────────────────────────────────────────────
         is_spike, spike_reason = velocity_breaker.check(session_id)

--- a/tests/test_proxy_cache_risk.py
+++ b/tests/test_proxy_cache_risk.py
@@ -1,6 +1,6 @@
 """Proxy cache-bust detection + SSE token-counting tests (#2839/#2840/#2841/#2842)."""
 from clawmetry.proxy import (
-    normalize_tools, scan_volatile_content, stable_prefix_hash,
+    normalize_tools, raw_tools_fp, scan_volatile_content, stable_prefix_hash,
     detect_cache_risk, parse_anthropic_sse_chunk, StreamUsage,
 )
 
@@ -42,6 +42,22 @@ def test_detect_cache_risk_scores_volatile():
     assert r["cache_risk_score"] >= 2
     assert r["prefix_hash"]
     assert "content" not in r  # no raw text
+
+
+def test_tool_order_churn_detection():
+    tools_ab = [{"name": "a", "input_schema": {"type": "object"}}, {"name": "b"}]
+    tools_ba = [{"name": "b"}, {"name": "a", "input_schema": {"type": "object"}}]
+    tools_diff = [{"name": "a"}, {"name": "c"}]
+    # raw fp differs on reorder; normalize_tools doesn't — this combination
+    # is the signal for order-only churn
+    assert raw_tools_fp(tools_ab) != raw_tools_fp(tools_ba)
+    assert normalize_tools(tools_ab) == normalize_tools(tools_ba)
+    # a genuine tool change shows up in both fingerprints
+    assert raw_tools_fp(tools_ab) != raw_tools_fp(tools_diff)
+    assert normalize_tools(tools_ab) != normalize_tools(tools_diff)
+    # edge cases never raise
+    assert isinstance(raw_tools_fp([]), str)  # empty list still hashes cleanly
+    assert raw_tools_fp("bad") == ""  # type: ignore[arg-type]  # non-list → empty
 
 
 def test_sse_message_delta_takes_max_output_tokens():


### PR DESCRIPTION
## Summary

- Adds `raw_tools_fp(tools) -> str` — order-preserving sha256 fingerprint of the tools array (public, used alongside `normalize_tools` to isolate order-only changes)
- Adds `_SESSION_TOOLS_NORM` / `_SESSION_TOOLS_RAW` in-process dicts (mirrors `_SESSION_PREFIX`) to track per-session tool fingerprints across turns
- Adds churn-detection block in the proxy request handler: if the raw fingerprint changes but the normalised fingerprint stays the same, emits a `tool_order_churn` event to DuckDB for the Cost-lens — signals that caller code is sending tools non-deterministically

Detection only — never blocks a request.

## Test plan

- [ ] `python -m pytest tests/test_proxy_cache_risk.py -v` — all 6 tests pass (new `test_tool_order_churn_detection` verifies raw fps differ on reorder while normalised fps agree, and genuine tool changes show up in both)
- [ ] No regressions in existing tests (`test_normalize_tools_is_order_and_key_stable`, `test_stable_prefix_hash_ignores_tool_order_but_catches_system_drift`)

Closes #2841

---
_Generated by [Claude Code](https://claude.ai/code/session_013zdvwjtazCoY5n2Zxr6oDk)_