### PR TITLE
feat(entitlement): add runtime_tier() + tier field on runtime_catalog() rows

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -816,6 +816,32 @@ def feature_catalog() -> list[dict]:
     return out
 
 
+
+def runtime_tier(runtime: str) -> str:
+    """Minimum tier-ladder identifier that unlocks observing ``runtime``.
+
+    Returns a short tier string (``"free"`` / ``"starter"``) — the same
+    vocabulary the in-flight ``feature_tier()`` uses — so the UI can render
+    Runtime + Feature rows against a single tier identifier.
+
+    * ``FREE_RUNTIMES`` (``openclaw``, ``nemoclaw``)  → ``"free"``.
+    * ``PAID_RUNTIMES`` (Claude Code, Codex, Cursor, …) → ``"starter"``. All
+      paid runtimes unlock together via the Starter ``multi_runtime`` grant
+      — there is no per-runtime split inside the paid tiers today.
+    * Unknown / empty / non-string ids → ``"starter"`` so an unknown runtime
+      errs on the locked side instead of silently granting access (matches
+      ``feature_tier()``'s unknown-id policy).
+
+    Pure catalogue lookup — does NOT call ``get_entitlement()`` and is the
+    same answer in grace and enforce. Never raises.
+    """
+    try:
+        rt = (runtime or "").strip().lower()
+    except (AttributeError, TypeError):
+        return "starter"
+    return "free" if rt in FREE_RUNTIMES else "starter"
+
+
 def runtime_catalog() -> list[dict]:
     """The full runtime catalog with the entitlement-derived availability for
     each entry. Single source of truth the UI uses to render *every* known
@@ -829,6 +855,9 @@ def runtime_catalog() -> list[dict]:
           "free":     True | False,        # FREE_RUNTIMES membership
           "allowed":  True | False,        # entitlement allows observing it
           "locked":   True | False,        # paid + not allowed (UI shows 🔒)
+          "tier":     "free" | "starter",  # min tier that unlocks this row;
+                                           # see runtime_tier() — symmetric to
+                                           # feature_catalog()'s "tier" field
         }
 
     Ordering: free runtimes first (alphabetical), then paid runtimes
@@ -853,6 +882,7 @@ def runtime_catalog() -> list[dict]:
                 "allowed": True,
                 "locked": False,
                 "entitled": True,
+                "tier": "free",
             }
         )
     for rt in sorted(PAID_RUNTIMES):
@@ -868,6 +898,7 @@ def runtime_catalog() -> list[dict]:
                 # teaser/upgrade affordance in grace mode without changing
                 # what `allowed`/`locked` mean for enforcement.
                 "entitled": ent.entitled_runtime(rt),
+                "tier": "starter",
             }
         )
     return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -104,12 +104,21 @@ def api_runtimes():
         {
           "runtimes": [
             {"id": "openclaw", "label": "OpenClaw",
-             "free": true, "allowed": true, "locked": false},
+             "free": true, "allowed": true, "locked": false,
+             "tier": "free"},
+            {"id": "claude_code", "label": "Claude Code",
+             "free": false, "allowed": true, "locked": false,
+             "tier": "starter"},
             ...
           ],
           "grace":    true | false,   # mirrors /api/entitlement.grace
           "enforced": true | false
         }
+
+    ``tier`` carries the minimum tier that unlocks each row — ``"free"`` for
+    ``FREE_RUNTIMES`` and ``"starter"`` for every paid runtime (since the
+    Starter ``multi_runtime`` grant unlocks them all). Mirrors
+    ``feature_catalog()``'s ``tier`` field so the UI uses one tier vocabulary.
 
     Side-effect-free and never-raise: any resolution error falls back to a
     grace OSS-free shape with the OpenClaw row, so the UI still has something
@@ -137,6 +146,7 @@ def api_runtimes():
                         "free": True,
                         "allowed": True,
                         "locked": False,
+                        "tier": "free",
                     },
                     {
                         "id": "openclaw",
@@ -144,6 +154,7 @@ def api_runtimes():
                         "free": True,
                         "allowed": True,
                         "locked": False,
+                        "tier": "free",
                     },
                 ],
                 "grace": True,

--- a/tests/test_runtime_tier.py
+++ b/tests/test_runtime_tier.py
@@ -1,0 +1,162 @@
+"""Tests for ``clawmetry.entitlements.runtime_tier`` and the ``tier`` field
+on ``runtime_catalog()`` rows.
+
+Runtime side of the catalogue's tier vocabulary — mirrors the in-flight
+``feature_tier()`` so the dashboard renders Runtime and Feature rows against
+a single tier identifier (``"free"`` / ``"starter"`` / ``"pro"`` / ``"enterprise"``).
+
+All paid runtimes unlock together via the Starter ``multi_runtime`` grant, so
+the runtime vocabulary is intentionally smaller than the feature one:
+``{"free", "starter"}``.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with a clean HOME — mirrors the fixture used
+    in tests/test_entitlements_catalogue.py and tests/test_routes_runtimes.py."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── runtime_tier() helper ──────────────────────────────────────────────────────
+
+
+def test_free_runtimes_tier_is_free(ent):
+    assert ent.runtime_tier("openclaw") == "free"
+    assert ent.runtime_tier("nemoclaw") == "free"
+
+
+def test_every_free_runtime_resolves_to_free(ent):
+    for rt in ent.FREE_RUNTIMES:
+        assert ent.runtime_tier(rt) == "free", rt
+
+
+def test_every_paid_runtime_resolves_to_starter(ent):
+    for rt in ent.PAID_RUNTIMES:
+        assert ent.runtime_tier(rt) == "starter", rt
+
+
+def test_unknown_runtime_defaults_to_starter(ent):
+    """Unknown ids err on the locked side rather than silently grant access —
+    same policy ``feature_tier()`` uses for unknown feature keys."""
+    assert ent.runtime_tier("totally_made_up_runtime") == "starter"
+    assert ent.runtime_tier("some.other.runtime") == "starter"
+
+
+def test_empty_and_none_safely_default(ent):
+    assert ent.runtime_tier("") == "starter"
+    assert ent.runtime_tier(None) == "starter"  # type: ignore[arg-type]
+
+
+def test_case_insensitive(ent):
+    assert ent.runtime_tier("OpenClaw") == "free"
+    assert ent.runtime_tier("CLAUDE_CODE") == "starter"
+
+
+def test_whitespace_is_stripped(ent):
+    assert ent.runtime_tier("  openclaw  ") == "free"
+    assert ent.runtime_tier("\tclaude_code\n") == "starter"
+
+
+def test_never_raises_on_non_string_input(ent):
+    """CLAUDE.md rule: never crash on bad input. Non-string ids fall back to
+    the safe-default ``"starter"`` so a buggy caller can't take the gate down."""
+    for weird in (123, 0, [], {}, object()):
+        try:
+            result = ent.runtime_tier(weird)  # type: ignore[arg-type]
+        except Exception as exc:
+            pytest.fail(f"runtime_tier({weird!r}) raised: {exc}")
+        assert result == "starter"
+
+
+# ── runtime_catalog() carries the tier field ───────────────────────────────────
+
+
+def test_catalog_rows_carry_tier_field(ent):
+    for row in ent.runtime_catalog():
+        assert "tier" in row, row
+        assert isinstance(row["tier"], str)
+
+
+def test_catalog_free_rows_are_tier_free(ent):
+    rows = {r["id"]: r for r in ent.runtime_catalog()}
+    for rt in ent.FREE_RUNTIMES:
+        assert rows[rt]["tier"] == "free", rt
+
+
+def test_catalog_paid_rows_are_tier_starter(ent):
+    rows = {r["id"]: r for r in ent.runtime_catalog()}
+    for rt in ent.PAID_RUNTIMES:
+        assert rows[rt]["tier"] == "starter", rt
+
+
+def test_catalog_tier_vocabulary_is_only_free_or_starter(ent):
+    """Runtime tier vocabulary is intentionally narrower than feature_tier():
+    all paid runtimes unlock together via the Starter ``multi_runtime`` grant,
+    so no row reports ``pro`` or ``enterprise`` tier."""
+    tiers = {r["tier"] for r in ent.runtime_catalog()}
+    assert tiers == {"free", "starter"}
+
+
+def test_catalog_tier_matches_free_bit(ent):
+    """Invariant: every ``free=True`` row is ``tier="free"`` and every
+    ``free=False`` row is ``tier="starter"``."""
+    for row in ent.runtime_catalog():
+        if row["free"]:
+            assert row["tier"] == "free", row
+        else:
+            assert row["tier"] == "starter", row
+
+
+def test_catalog_tier_matches_runtime_tier_helper(ent):
+    """``runtime_catalog()`` and ``runtime_tier()`` agree row-by-row — the
+    helper is the single source of truth that the catalog reads from."""
+    for row in ent.runtime_catalog():
+        assert row["tier"] == ent.runtime_tier(row["id"]), row
+
+
+def test_tier_is_static_across_grace_and_enforce(monkeypatch, tmp_path):
+    """``tier`` is a catalogue fact (which tier *could* unlock this row), not
+    an entitlement check (does THIS install have that tier). It must not
+    change between grace and enforce."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    grace_tiers = {r["id"]: r["tier"] for r in e.runtime_catalog()}
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce_tiers = {r["id"]: r["tier"] for r in e.runtime_catalog()}
+
+    assert grace_tiers == enforce_tiers
+
+
+def test_tier_unchanged_by_resolution_failure(ent, monkeypatch):
+    """Even when ``get_entitlement()`` blows up, the catalogue still reports
+    the same per-row tier (grace fallback path) — never silently drops the
+    field on the error branch."""
+    def _boom():
+        raise RuntimeError("simulated resolution failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    rows = ent.runtime_catalog()
+    assert rows, "fallback catalog should still be non-empty"
+    for row in rows:
+        assert "tier" in row, row
+        assert row["tier"] in ("free", "starter"), row


### PR DESCRIPTION
## Summary

Adds the **runtime side** of the catalogue's tier vocabulary so the dashboard can render Runtime and Feature rows against a single tier identifier. This is the runtime mirror of the in-flight `feature_tier()` + `feature_catalog()` work (PR #2426).

The three catalogue helpers now converge on a uniform `tier` field:

| Helper              | `tier` vocabulary                         | Source PR |
|---------------------|-------------------------------------------|-----------|
| `feature_catalog()` | `"free" \| "starter" \| "pro" \| "enterprise"` | #2426 (in flight) |
| `tier_catalog()`    | full tier ids (`oss`, `cloud_pro`, …)     | #2692 (in flight) |
| `runtime_catalog()` | `"free" \| "starter"` (**this PR**)        | this PR |

All paid runtimes unlock together via the Starter `multi_runtime` grant, so the runtime vocabulary is intentionally narrower than the feature one — no row reports `pro` or `enterprise`.

## Changes

### `clawmetry/entitlements.py`
- **`runtime_tier(runtime: str) -> str`** — module-level helper. Returns:
  - `"free"` for `FREE_RUNTIMES` (`openclaw`, `nemoclaw`)
  - `"starter"` for every `PAID_RUNTIMES` member
  - `"starter"` for unknown / empty / non-string ids (errs on the locked side, matches `feature_tier()`'s unknown-id policy)
  - Pure catalogue lookup — does not call `get_entitlement()`. Same answer in grace and enforce. Never raises.
- **`runtime_catalog()`** — each row now carries a `tier` field (`"free"` for free runtimes, `"starter"` for paid). Docstring updated.

### `routes/entitlement.py`
- `GET /api/runtimes` inherits the new field through `runtime_catalog()`. Docstring shape updated. The never-raise OSS-free fallback emits `tier: "free"` on its `openclaw`/`nemoclaw` rows so the UI always has the field.

### `tests/test_runtime_tier.py` (new, 16 tests)
- Mapping: free runtimes resolve to `"free"`; paid runtimes resolve to `"starter"`; unknown ids default to `"starter"`.
- Robustness: case-insensitive, whitespace stripped, empty/`None` safe, never-raise on non-string input.
- Catalog invariants: every row carries `tier`; tier matches the `free` bit; tier vocabulary is exactly `{"free", "starter"}`; row tier matches `runtime_tier(row["id"])`.
- Grace/enforce: tier is a catalogue fact, not an entitlement check — identical across both modes.
- Never-raise: a simulated `get_entitlement()` failure still produces rows with the `tier` field set.

## Response shape

```jsonc
{
  "runtimes": [
    {"id": "nemoclaw",    "label": "NemoClaw",    "free": true,  "allowed": true,  "locked": false, "tier": "free"},
    {"id": "openclaw",    "label": "OpenClaw",    "free": true,  "allowed": true,  "locked": false, "tier": "free"},
    {"id": "aider",       "label": "Aider",       "free": false, "allowed": true,  "locked": false, "tier": "starter"},
    {"id": "claude_code", "label": "Claude Code", "free": false, "allowed": true,  "locked": false, "tier": "starter"},
    ...
  ],
  "grace":    true,
  "enforced": false
}
```

## Grace / enforce

Pure addition. Grace mode behaviour is unchanged — `tier` is a static catalogue fact (which tier *could* unlock this row), not an entitlement check (does THIS install have that tier). The existing `allowed` / `locked` fields keep their semantics so any existing `/api/runtimes` consumer continues to work.

## Why this doesn't conflict with the in-flight PRs

- **#2426 (`feature_catalog` + `feature_tier`)** — independent dimension; that PR adds helpers in its own section of `entitlements.py` and a separate route. Edit windows are non-overlapping.
- **#2692 (`tier_catalog` + `tier_label`)** — independent dimension; adds a constants block + a new function below `runtime_catalog()`. No overlap with the rows I touch.
- **#2674 (`required_tier` in 402 body)** — touches `_gate.py` only.
- **#2722 / #2790 / #2792 (`allows_node_count` / `allows_retention_window` / `allows_channel_count`)** — add methods inside the `Entitlement` class; this PR touches the module-level helpers + `runtime_catalog()` tail.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_runtime_tier.py` — clean
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_runtime_tier.py` — clean
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — clean
- [x] `python3 -m pytest tests/test_runtime_tier.py -v` — **16/16 pass**
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_routes_runtimes.py tests/test_runtime_tier.py tests/test_extensions.py tests/test_license.py tests/test_license_api.py -q` — **104/104 pass** (no regression in adjacent surfaces)
- [ ] Frontend rendering of the new `tier` field (consumes `/api/runtimes`) — separate PR, out of scope.

## Local operator verification checklist

Since this agent runs in CI and has no access to the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser, the local operator should:

1. `git fetch origin feat/runtime-tier-helper && git checkout feat/runtime-tier-helper`
2. Copy the two changed files into the live install:
   ```bash
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/entitlements.py
   cp routes/entitlement.py    ~/.clawmetry/lib/python3.*/site-packages/routes/entitlement.py
   ```
3. Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
4. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. Hit `/api/runtimes`:
   ```bash
   curl -s http://localhost:8900/api/runtimes | python3 -m json.tool
   ```
   Expect every row to carry a `tier` field. `openclaw` and `nemoclaw` → `"free"`; every other runtime → `"starter"`.
6. ```bash
   curl -s http://localhost:8900/api/runtimes | python3 -c "import json,sys; d=json.load(sys.stdin); print({r['tier'] for r in d['runtimes']})"
   ```
   Should print exactly `{'free', 'starter'}`.
7. Confirm `/api/entitlement` still returns the same shape (this PR does not modify it).
8. Decrypt the live cloud snapshot — this PR is dashboard-only, no daemon code is touched, so snapshot shape is unchanged.
9. Browser-check the dashboard — no UI surface consumes the new `tier` field yet (frontend wiring is a follow-up).

This PR is **draft-only**: I am not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Grace mode stays on. Once you have run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MX8AbUMCh68GUew2tQuziF)_