### PR TITLE
fix(obs): detect full-native nemoclaw builds via enforcement symbols (#2877)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -126,24 +126,33 @@ def _model_router_fingerprint() -> dict:
 # starts exporting the catalog to the host (e.g. ~/.nemoclaw/skills/).
 
 
-def _scan_openclaw_selection_runtime() -> tuple[bool, bool]:
+def _scan_openclaw_selection_runtime() -> tuple[bool, bool, bool]:
     """Scan the pinned OpenClaw ``selection-*.js`` once and report whether
-    (a) the NemoClaw compact-catalog patch marker is present, and
-    (b) all three native tool-search symbols are present.
+    (a) the NemoClaw compact-catalog patch marker is present,
+    (b) the three base native tool-search symbols are present, and
+    (c) the two enforcement symbols (visibleAllowedToolNames /
+        replayAllowedToolNames) that distinguish a full-native build from a
+        basic-native one are present (#2877).
 
-    Returns ``(nemoclaw_patched, native_tool_search)``. Never raises.
+    Returns ``(nemoclaw_patched, native_base, native_enforcement)``. Never raises.
     """
     nemoclaw_marker = b"/* nemoclaw compact tool catalog (#2600) */"
-    # Mirror scripts/patch-openclaw-tool-catalog.js NATIVE_TOOL_SEARCH_PATTERNS:
-    # all three symbols must be present before the patch script considers the
-    # dist to already have a native tool-search build (#2732).
-    native_markers = (
+    # Mirror scripts/patch-openclaw-tool-catalog.js NATIVE_TOOL_SEARCH_PATTERNS
+    # entries 1-3: catalog infrastructure symbols (#2732).
+    native_base_markers = (
         b"applyToolSearchCatalog",
         b"buildToolSearchRunPlan",
         b"uncompactedEffectiveTools",
     )
+    # Entries 4-5: enforcement signals added by the harness (#2877). Both must
+    # be present to confirm the build actively enforces visible/replay allow-lists.
+    native_enforcement_markers = (
+        b"visibleAllowedToolNames",
+        b"replayAllowedToolNames",
+    )
     patched = False
-    native = False
+    native_base = False
+    native_enforcement = False
     try:
         home = os.environ.get("OPENCLAW_HOME") or os.path.expanduser("~/.openclaw")
         dist_dirs = [
@@ -170,15 +179,19 @@ def _scan_openclaw_selection_runtime() -> tuple[bool, bool]:
                     continue
                 if not patched and nemoclaw_marker in blob:
                     patched = True
-                if not native and all(m in blob for m in native_markers):
-                    native = True
-                if patched and native:
+                if not native_base and all(m in blob for m in native_base_markers):
+                    native_base = True
+                if native_base and not native_enforcement and all(
+                    m in blob for m in native_enforcement_markers
+                ):
+                    native_enforcement = True
+                if patched and native_base and native_enforcement:
                     break
-            if patched and native:
+            if patched and native_base and native_enforcement:
                 break
     except Exception:
-        return patched, native
-    return patched, native
+        return patched, native_base, native_enforcement
+    return patched, native_base, native_enforcement
 
 
 def _nemoclaw_tool_catalog_state() -> Optional[bool]:
@@ -198,7 +211,7 @@ def _nemoclaw_tool_catalog_state() -> Optional[bool]:
     catalog state that doesn't exist. Never raises.
     """
     env = os.environ.get("NEMOCLAW_TOOL_CATALOG")
-    patched, _native = _scan_openclaw_selection_runtime()
+    patched, _native, _native_enf = _scan_openclaw_selection_runtime()
     if not patched and env is None:
         # No NemoClaw signal at all -> don't claim a catalog state.
         return None
@@ -207,24 +220,27 @@ def _nemoclaw_tool_catalog_state() -> Optional[bool]:
 
 
 def _openclaw_tool_catalog_kind() -> Optional[str]:
-    """Provenance of the active OpenClaw tool-catalog mechanism, if any (#2732).
+    """Provenance of the active OpenClaw tool-catalog mechanism, if any (#2732, #2877).
 
     Returns:
         ``"nemoclaw"`` when the NemoClaw compact-catalog patch is applied
         (matches ``_nemoclaw_tool_catalog_state() is True``).
-        ``"native"`` when the dist ships native ``applyToolSearchCatalog`` /
-        ``buildToolSearchRunPlan`` / ``uncompactedEffectiveTools`` symbols and
-        the NemoClaw patch was skipped — previously indistinguishable from
-        "no catalog at all".
+        ``"native-full"`` when all five NATIVE_TOOL_SEARCH_PATTERNS are present:
+        the three base infrastructure symbols plus ``visibleAllowedToolNames`` /
+        ``replayAllowedToolNames`` (enforcement-active build).
+        ``"native"`` when only the three base infrastructure symbols are present
+        (catalog infrastructure present, enforcement inactive).
         ``None`` when neither signal is present.
 
     The NemoClaw patch wins over native detection: when both fire (e.g. a
     forward-port window) the patched wrapper is what's actually intercepting
     catalog calls. Never raises.
     """
-    patched, native = _scan_openclaw_selection_runtime()
+    patched, native, native_enforcement = _scan_openclaw_selection_runtime()
     if patched:
         return "nemoclaw"
+    if native_enforcement:
+        return "native-full"
     if native:
         return "native"
     return None

--- a/tests/test_openclaw_tool_catalog_kind.py
+++ b/tests/test_openclaw_tool_catalog_kind.py
@@ -1,12 +1,14 @@
 """Regression: distinguish native OpenClaw tool-search builds from plain
 OpenClaw (#2732), without losing the existing NemoClaw-patch detection (#2683).
+Also distinguishes basic-native (3 infrastructure symbols) from full-native
+(all 5 NATIVE_TOOL_SEARCH_PATTERNS including enforcement signals) (#2877).
 
-Before the fix, ``_nemoclaw_tool_catalog_state()`` was the only signal: it
-scanned ``selection-*.js`` only for the NemoClaw patch marker and returned
-``None`` for native-tool-search builds, leaving ``nemoclawToolCatalogEnabled``
-unset and indistinguishable from "no catalog at all". The new
-``_openclaw_tool_catalog_kind()`` helper closes the obs-gap by also returning
-``"native"`` when the dist ships the three tool-search symbols.
+Before the #2732 fix, ``_nemoclaw_tool_catalog_state()`` was the only signal;
+it returned ``None`` for native builds, leaving them indistinguishable from "no
+catalog at all". After #2877, ``_openclaw_tool_catalog_kind()`` returns
+``"native-full"`` for builds that also carry ``visibleAllowedToolNames`` /
+``replayAllowedToolNames`` (enforcement active), and ``"native"`` for builds
+with only the three base infrastructure symbols.
 """
 from __future__ import annotations
 
@@ -17,12 +19,21 @@ import clawmetry.adapters.openclaw as oc
 
 PATCH_MARKER = b"/* nemoclaw compact tool catalog (#2600) */\nexport const x = 1;\n"
 NATIVE_BLOB = (
+    # Three base infrastructure symbols -> basic-native build ("native").
     b"export function applyToolSearchCatalog(){}\n"
     b"export function buildToolSearchRunPlan(){}\n"
     b"export const uncompactedEffectiveTools = [];\n"
 )
+FULL_NATIVE_BLOB = (
+    # All five NATIVE_TOOL_SEARCH_PATTERNS: base + enforcement -> "native-full".
+    b"export function applyToolSearchCatalog(){}\n"
+    b"export function buildToolSearchRunPlan(){}\n"
+    b"export const uncompactedEffectiveTools = [];\n"
+    b"export const visibleAllowedToolNames = [];\n"
+    b"export const replayAllowedToolNames = [];\n"
+)
 PARTIAL_NATIVE_BLOB = (
-    # Only two of three symbols -> NOT a native build per the patch script's
+    # Only two of three base symbols -> NOT a native build per the patch script's
     # NATIVE_TOOL_SEARCH_PATTERNS contract.
     b"export function applyToolSearchCatalog(){}\n"
     b"export function buildToolSearchRunPlan(){}\n"
@@ -60,6 +71,13 @@ def test_native_tool_search_build_detected(monkeypatch, tmp_path):
     assert oc._nemoclaw_tool_catalog_state() is None
     # NEW: native build is no longer indistinguishable from no catalog.
     assert oc._openclaw_tool_catalog_kind() == "native"
+
+
+def test_full_native_enforcement_build_detected(monkeypatch, tmp_path):
+    home = _make_dist(tmp_path, FULL_NATIVE_BLOB)
+    monkeypatch.setenv("OPENCLAW_HOME", str(home))
+    assert oc._nemoclaw_tool_catalog_state() is None
+    assert oc._openclaw_tool_catalog_kind() == "native-full"
 
 
 def test_nemoclaw_patch_wins_over_native(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #2877

## Summary

- `_scan_openclaw_selection_runtime()` now returns a 3-tuple `(patched, native_base, native_enforcement)` — scanning all 5 `NATIVE_TOOL_SEARCH_PATTERNS` instead of 3
- `_openclaw_tool_catalog_kind()` returns `"native-full"` when both enforcement symbols (`visibleAllowedToolNames` + `replayAllowedToolNames`) are present, `"native"` for 3-symbol basic builds, preserving backward compat
- Callers `_nemoclaw_tool_catalog_state()` updated to unpack the 3-tuple (ignores new field)

## Test plan

- `pytest tests/test_openclaw_tool_catalog_kind.py` — 8 tests pass (7 existing + 1 new `test_full_native_enforcement_build_detected`)
- `FULL_NATIVE_BLOB` (all 5 symbols) → `"native-full"`; `NATIVE_BLOB` (3 symbols) → `"native"` unchanged; `PARTIAL_NATIVE_BLOB` → `None` unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_014guwLpKajX4tYCa7tU5Hx8)_