### PR TITLE
feat(search): add GET /api/local/search — session full-text search (#2860)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -7159,6 +7159,75 @@ class LocalStore:
             return []
         return [dict(zip(cols, r)) for r in rows]
 
+    def query_search(
+        self,
+        *,
+        q: str,
+        model: str | None = None,
+        status: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Search sessions by title and eval_reason text.
+
+        Matches rows where ``sessions.title`` or ``sessions.eval_reason``
+        contains the query string (case-insensitive). Optional ``model``
+        filter restricts to sessions that used a specific model name
+        (sub-selects session_ids from the events table). Returns session
+        summary rows sorted newest-first.
+        """
+        q = (q or "").strip()
+        if not q:
+            return []
+        q_like = f"%{q}%"
+        params: list[Any] = []
+
+        model_join = ""
+        if model:
+            model_join = (
+                "JOIN (SELECT DISTINCT session_id FROM events "
+                "WHERE model ILIKE ? AND session_id IS NOT NULL) em "
+                "ON s.session_id = em.session_id"
+            )
+            params.append(f"%{model}%")
+
+        clauses: list[str] = ["(s.title ILIKE ? OR s.eval_reason ILIKE ?)"]
+        params.extend([q_like, q_like])
+        if status:
+            clauses.append("s.status = ?")
+            params.append(str(status))
+        if since:
+            clauses.append("s.last_active_at >= ?")
+            params.append(since)
+        if until:
+            clauses.append("s.last_active_at <= ?")
+            params.append(until)
+        where = "WHERE " + " AND ".join(clauses)
+        sql = f"""
+            SELECT s.session_id, s.agent_type, s.title,
+                   s.started_at, s.last_active_at, s.status,
+                   s.cost_usd, s.total_tokens,
+                   s.outcome, s.eval_score, s.eval_reason
+            FROM sessions s
+            {model_join}
+            {where}
+            ORDER BY s.last_active_at DESC NULLS LAST
+            LIMIT ?
+        """
+        params.append(int(limit))
+        cols = [
+            "session_id", "agent_type", "title",
+            "started_at", "last_active_at", "status",
+            "cost_usd", "total_tokens",
+            "outcome", "eval_score", "eval_reason",
+        ]
+        try:
+            return [dict(zip(cols, r)) for r in self._fetch(sql, params)]
+        except Exception as e:
+            log.warning("local store: query_search failed: %s", e)
+            return []
+
     def query_sessions_table(
         self,
         *,

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -47,6 +47,7 @@ _SHAPES = {
     "spans":           "query_spans",             # Issue #1013: full-filter span list
     "traces":          "query_traces",            # Issue #1013: one row per trace_id
     "external_calls":  "query_external_calls",   # Issue #883: external API tracing
+    "search":          "query_search",            # Issue #2860: session full-text search
 }
 
 
@@ -218,6 +219,18 @@ def _coerce_args(shape: str, raw: dict) -> dict:
             "since":      raw.get("since"),
             "until":      raw.get("until"),
             "limit":      _safe_int(raw.get("limit"), default=200, lo=1, hi=2000),
+        }
+    if shape == "search":
+        q = (raw.get("q") or "").strip()
+        if not q:
+            raise ValueError("search shape requires non-empty 'q' parameter")
+        return {
+            "q":      q,
+            "model":  raw.get("model") or None,
+            "status": raw.get("status") or None,
+            "since":  raw.get("since"),
+            "until":  raw.get("until"),
+            "limit":  _safe_int(raw.get("limit"), default=50, lo=1, hi=500),
         }
     raise ValueError(f"unknown shape: {shape}")
 
@@ -405,6 +418,23 @@ def http_external_calls():
     try:
         args = _coerce_args("external_calls", request.args.to_dict())
         return jsonify(_dispatch("external_calls", args))
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
+@bp_local_query.route("/api/local/search", methods=["GET"])
+def http_search():
+    """Search sessions by title / eval-reason text.
+
+    Required: ``q`` (search string). Optional: ``model``, ``status``,
+    ``since`` (ISO), ``until`` (ISO), ``limit`` (int, default 50, max 500).
+    Returns session summary rows matching the query, sorted newest-first.
+    """
+    try:
+        args = _coerce_args("search", request.args.to_dict())
+        return jsonify(_dispatch("search", args))
+    except ValueError as e:
+        return jsonify({"error": str(e)[:300]}), 400
     except Exception as e:
         return jsonify({"error": str(e)[:300]}), 500
 
@@ -656,6 +686,9 @@ _DAEMON_METHODS = frozenset({
     # returns None and the proxy 400s (memory feedback_cli_methods_need_daemon_allowlist).
     "query_agent_meta",
     "set_agent_meta",
+    # Issue #2860: session full-text search. Read-only; routed through the
+    # daemon proxy so the dashboard process never opens DuckDB writable.
+    "query_search",
 })
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,150 @@
+"""Tests for LocalStore.query_search() — issue #2860.
+
+Covers: title match, eval_reason match, case-insensitive match, miss,
+model filter, status filter, and empty-query guard.
+"""
+from __future__ import annotations
+
+import importlib
+import time
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.LocalStore()
+    s.start()
+    yield s
+    s.stop(flush=True)
+
+
+def _session(*, title, status="ended", agent_type="openclaw", session_id=None,
+             last_active_at="2026-06-09T10:05:00Z"):
+    return {
+        "session_id":     session_id or str(uuid.uuid4()),
+        "agent_type":     agent_type,
+        "title":          title,
+        "status":         status,
+        "started_at":     "2026-06-09T10:00:00Z",
+        "last_active_at": last_active_at,
+    }
+
+
+def _event(session_id, model="claude-opus-4-8"):
+    return {
+        "id":          str(uuid.uuid4()),
+        "node_id":     "test-node",
+        "agent_id":    "main",
+        "session_id":  session_id,
+        "event_type":  "assistant",
+        "ts":          "2026-06-09T10:01:00Z",
+        "model":       model,
+        "cost_usd":    0.001,
+        "token_count": 10,
+    }
+
+
+def _wait_flush(s, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if s.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+
+
+def test_title_match(store):
+    sess = _session(title="debug file read loop issue")
+    store.ingest_session(sess)
+    rows = store.query_search(q="file read loop")
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == sess["session_id"]
+
+
+def test_eval_reason_match(store):
+    sess = _session(title="unrelated title")
+    store.ingest_session(sess)
+    store.persist_eval_score(
+        session_id=sess["session_id"],
+        score=0.4,
+        reason="agent stuck on permissions error",
+        judge_model="test",
+        scored_at=int(time.time() * 1000),
+    )
+    rows = store.query_search(q="permissions error")
+    assert len(rows) == 1
+    assert rows[0]["session_id"] == sess["session_id"]
+
+
+def test_case_insensitive(store):
+    sess = _session(title="Python Import Error")
+    store.ingest_session(sess)
+    assert store.query_search(q="python import") != []
+    assert store.query_search(q="PYTHON IMPORT") != []
+
+
+def test_no_match_returns_empty(store):
+    sess = _session(title="write unit test")
+    store.ingest_session(sess)
+    rows = store.query_search(q="xyzzy_nonexistent_token_42")
+    assert rows == []
+
+
+def test_empty_query_returns_empty(store):
+    store.ingest_session(_session(title="some session"))
+    assert store.query_search(q="") == []
+    assert store.query_search(q="   ") == []
+
+
+def test_model_filter(store):
+    sid_opus = str(uuid.uuid4())
+    sid_haiku = str(uuid.uuid4())
+    store.ingest_session(_session(title="deploy script", session_id=sid_opus))
+    store.ingest_session(_session(title="deploy again", session_id=sid_haiku))
+    store.ingest(_event(sid_opus, model="claude-opus-4-8"))
+    store.ingest(_event(sid_haiku, model="claude-haiku-4-5"))
+    _wait_flush(store)
+    rows = store.query_search(q="deploy", model="opus")
+    sids = {r["session_id"] for r in rows}
+    assert sid_opus in sids
+    assert sid_haiku not in sids
+
+
+def test_status_filter(store):
+    sid_ended = str(uuid.uuid4())
+    sid_active = str(uuid.uuid4())
+    store.ingest_session(_session(title="same title task", session_id=sid_ended,
+                                  status="ended"))
+    store.ingest_session(_session(title="same title task", session_id=sid_active,
+                                  status="active"))
+    rows = store.query_search(q="same title task", status="ended")
+    sids = {r["session_id"] for r in rows}
+    assert sid_ended in sids
+    assert sid_active not in sids
+
+
+def test_result_fields(store):
+    sess = _session(title="check result shape")
+    store.ingest_session(sess)
+    store.persist_eval_score(
+        session_id=sess["session_id"],
+        score=0.9,
+        reason="all good",
+        judge_model="test",
+        scored_at=int(time.time() * 1000),
+    )
+    rows = store.query_search(q="result shape")
+    assert len(rows) == 1
+    row = rows[0]
+    for key in ("session_id", "agent_type", "title", "started_at",
+                "last_active_at", "status", "cost_usd", "total_tokens",
+                "outcome", "eval_score", "eval_reason"):
+        assert key in row, f"missing key: {key}"
+    assert row["title"] == "check result shape"
+    assert row["eval_reason"] == "all good"


### PR DESCRIPTION
Closes #2860

## What

Adds `GET /api/local/search?q=<text>` to ClawMetry's local query API so users can find sessions by content instead of scrolling by time or guessing session IDs.

## How

- **`clawmetry/local_store.py`** — new `query_search()` method. Searches `sessions.title ILIKE '%q%' OR sessions.eval_reason ILIKE '%q%'`. Optional `model` filter subqueries `events.model`. Supports `status`, `since`, `until`, `limit`. Returns session-summary rows sorted newest-first. Errors are swallowed (returns `[]`) — consistent with every other query method.

- **`routes/local_query.py`** — four small additions:
  1. `"search": "query_search"` in `_SHAPES` (makes it available over the WS relay too)
  2. `search` branch in `_coerce_args()` — validates non-empty `q`, accepts `model`, `status`, `since`, `until`, `limit`; returns 400 on empty/missing `q`
  3. `GET /api/local/search` HTTP handler
  4. `"query_search"` in `_DAEMON_METHODS` — multi-process installs proxy through the daemon correctly

- **`tests/test_search.py`** — 8 tests: title hit, eval_reason hit, case-insensitive, no-match, empty-query guard, model filter, status filter, result field shape.

## Test plan

```
pytest tests/test_search.py -v   # 8 passed
python3 -m py_compile clawmetry/local_store.py routes/local_query.py
```

## Scope note

Searches `title` and `eval_reason` (both uncompressed VARCHAR columns). The `events.data` BLOB contains raw prompts/responses but is Python-compressed before hitting DuckDB — deep content indexing is the natural follow-up once a denormalized text column is added at ingest time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xe3a1qefkmTnzCdNqa54HD)_