### PR TITLE
[RELEASE] fix(license): daemon auto-provision UPGRADES pro + valid wheel filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Release: daemon auto-provision UPGRADES clawmetry-pro (+ valid wheel filename) (2026-06-09)
+- `auto_provision_pro` returned early whenever pro was importable, so an installed pro NEVER upgraded — rolling a newer wheel to the cloud reached no existing node (the claude_code ai-title fix in pro 0.3.4 sat unused because every daemon kept 0.3.3). Now it re-validates against the server each cycle: downloads the small wheel, reads its METADATA version, and installs (pip --upgrade) only when strictly newer; a download/check failure keeps the current version (never strands a working node).
+- `_download_wheel` saved to a random `mkstemp` name (`clawmetry_pro-ab12.whl`) that pip rejects as "not a valid wheel filename", silently breaking every re-download. Now it preserves the real PEP-427 filename from Content-Disposition in a temp dir.
+
 ### Release: clean claim-watcher re-exec (#2918) (2026-06-09)
 - The one-step onboarding claim-watcher (0.12.491) re-execs to adopt the real account. os.execv keeps the same PID, so _acquire_pid_lock saw its own live PID and the DuckDB writer lock stayed held — the re-exec'd daemon could fail to start (relying on the launchd KeepAlive crash-restart). Now it stops the store (flush + release the writer lock) and releases the pid lock before execv, so the restart is clean.
 

--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -207,6 +207,32 @@ def _write_pro_marker(extra: dict) -> None:
         logger.debug("license: pro marker write skipped: %s", exc)
 
 
+def _ver_tuple(v) -> tuple:
+    """Parse a version string into a comparable int tuple ('0.3.4' -> (0,3,4))."""
+    try:
+        return tuple(int(x) for x in str(v).split("+")[0].split(".")[:4])
+    except Exception:
+        return (0,)
+
+
+def _wheel_file_version(wheel_path: str) -> str | None:
+    """Read the version from a wheel's dist-info/METADATA (reliable regardless
+    of the on-disk filename). Used to decide whether the server's wheel is newer
+    than what's installed. Never raises."""
+    try:
+        import zipfile
+
+        with zipfile.ZipFile(wheel_path) as z:
+            for n in z.namelist():
+                if n.endswith(".dist-info/METADATA"):
+                    for line in z.read(n).decode("utf-8", "replace").splitlines():
+                        if line.startswith("Version:"):
+                            return line.split(":", 1)[1].strip()
+    except Exception:
+        return None
+    return None
+
+
 def _download_wheel(url: str, headers: dict | None = None) -> str | None:
     """Download the clawmetry-pro wheel from ``url`` (HTTPS only) to a temp file
     and return its path, or None on failure. Security: refuses any non-HTTPS URL
@@ -224,10 +250,22 @@ def _download_wheel(url: str, headers: dict | None = None) -> str | None:
         with urllib.request.urlopen(req, timeout=60) as resp:
             # 2xx only; redirects are followed by urlopen, 402/403/503 raise HTTPError.
             data = resp.read()
+            cdisp = resp.headers.get("Content-Disposition", "") or ""
         if not data:
             return None
-        fd, path = tempfile.mkstemp(prefix="clawmetry_pro-", suffix=".whl")
-        with os.fdopen(fd, "wb") as fh:
+        # Keep the REAL PEP-427 wheel filename (NAME-VER-PY-ABI-PLAT.whl) from
+        # Content-Disposition, in a temp DIR. A random mkstemp name like
+        # `clawmetry_pro-ab12.whl` is rejected by pip as "not a valid wheel
+        # filename" -- which silently broke EVERY wheel re-download/upgrade.
+        import re as _re
+
+        m = _re.search(r'filename\*?=(?:UTF-8\'\')?"?([^";]+\.whl)"?', cdisp)
+        fname = os.path.basename(m.group(1)) if m else "clawmetry_pro-0-py3-none-any.whl"
+        if not fname.endswith(".whl") or "/" in fname or "\\" in fname:
+            fname = "clawmetry_pro-0-py3-none-any.whl"
+        d = tempfile.mkdtemp(prefix="cmpro-")
+        path = os.path.join(d, fname)
+        with open(path, "wb") as fh:
             fh.write(data)
         return path
     except Exception as exc:
@@ -383,16 +421,29 @@ def _provision_pro_wheel(download_url: str, *, headers: dict | None = None,
     # Make a prior fallback-dir install importable before the idempotency check,
     # so we don't re-download when pro is already present in the HOME fallback.
     ensure_pro_on_path()
-    # Idempotent: if pro is already importable, don't re-download. A version
-    # bump still re-installs because the marker is rewritten on every success
-    # and the server serves the current wheel.
+    # Re-validate against the server EVERY time: download the (small ~140KB)
+    # wheel and install it ONLY when it is strictly newer than what's installed.
+    # The old code returned here whenever pro was importable, so an installed
+    # pro NEVER upgraded -- rolling a new wheel to the cloud reached nobody (the
+    # claude_code ai-title fix in 0.3.4 sat unused because every node kept the
+    # installed 0.3.3). Keeping the current version on a download/check failure
+    # means a transient outage never strands a working node.
     already = _pro_installed_version()
-    if already:
-        _write_pro_marker({"node_id": node_id, "source": "already_present"})
-        return f"clawmetry-pro {already} already installed"
     wheel = _download_wheel(download_url, headers=headers)
     if not wheel:
+        if already:
+            return f"clawmetry-pro {already} already installed (server check failed; kept)"
         return "clawmetry-pro wheel unavailable (will retry on next connect)"
+    if already:
+        avail = _wheel_file_version(wheel)
+        if avail and _ver_tuple(avail) <= _ver_tuple(already):
+            try:
+                os.unlink(wheel)
+            except Exception:
+                pass
+            _write_pro_marker({"node_id": node_id, "source": "already_current"})
+            return f"clawmetry-pro {already} already installed (latest is {avail})"
+        # else: a newer wheel is available -> fall through and install it.
     ok, detail = _pip_install_wheel(wheel)
     try:
         os.unlink(wheel)

--- a/tests/test_license_pro_upgrade.py
+++ b/tests/test_license_pro_upgrade.py
@@ -1,0 +1,38 @@
+"""auto_provision must UPGRADE an installed clawmetry-pro to a newer cloud wheel
+(it used to return early whenever pro was importable, so nodes never upgraded —
+the claude_code ai-title fix in 0.3.4 sat unused on 0.3.3), and the downloaded
+wheel must keep a valid PEP-427 filename or pip rejects it."""
+import io, zipfile
+from clawmetry import license as L
+
+
+def _wheel(version):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr(f"clawmetry_pro-{version}.dist-info/METADATA",
+                   f"Metadata-Version: 2.1\nName: clawmetry-pro\nVersion: {version}\n")
+    import tempfile, os
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, f"clawmetry_pro-{version}-py3-none-any.whl")
+    open(p, "wb").write(buf.getvalue())
+    return p
+
+
+def test_ver_tuple_orders_correctly():
+    assert L._ver_tuple("0.3.4") > L._ver_tuple("0.3.3")
+    assert L._ver_tuple("0.3.10") > L._ver_tuple("0.3.9")
+    assert L._ver_tuple("1.0.0") > L._ver_tuple("0.9.9")
+    assert L._ver_tuple("bad") == (0,)
+
+
+def test_wheel_file_version_reads_metadata():
+    assert L._wheel_file_version(_wheel("0.3.4")) == "0.3.4"
+    assert L._wheel_file_version("/nope/missing.whl") is None
+
+
+def test_upgrade_decision():
+    # the gate installs when the available wheel is strictly newer than installed
+    installed, avail = "0.3.3", L._wheel_file_version(_wheel("0.3.4"))
+    assert L._ver_tuple(avail) > L._ver_tuple(installed)   # -> upgrade
+    same = L._wheel_file_version(_wheel("0.3.3"))
+    assert L._ver_tuple(same) <= L._ver_tuple(installed)   # -> keep current


### PR DESCRIPTION
Two bugs that broke the 'roll the pro wheel to the cloud → daemons pick it up' flow (the FLYWHEEL step):
1. **No upgrade** — `auto_provision_pro` returned early whenever pro was importable, so an installed pro never upgraded (pro 0.3.4's ai-title fix sat unused on 0.3.3). Now re-validates each cycle: download → compare METADATA version → `pip --upgrade` only when strictly newer → keep current on failure.
2. **Bad wheel filename** — `_download_wheel` used a random `mkstemp` name pip rejects ('not a valid wheel filename'), silently breaking re-download. Now keeps the real PEP-427 name from Content-Disposition.

+3 tests. This makes the documented pro-wheel-roll step actually reach existing nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)