### PR TITLE
fix(tokens): prefer totalTokens in spans + surface in event.extra

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -458,6 +458,7 @@ class OpenClawAdapter(AgentAdapter):
                                     ("outputTokens", "output_tokens", "outputTokens"),
                                     ("cacheReadTokens", "cache_read_input_tokens", "cacheReadInputTokens", "cacheRead"),
                                     ("cacheWriteTokens", "cache_creation_input_tokens", "cacheCreationInputTokens", "cacheWrite"),
+                                    ("totalTokens", "totalTokens", "total_tokens"),
                                 ]:
                                     for k in keys:
                                         v = usage.get(k)
@@ -502,7 +503,7 @@ class OpenClawAdapter(AgentAdapter):
             Capability.CHANNELS,
         }
 
-    # ── Span reconstruction (issue #1010 / Trace 4) ────────────────────────
+    # ── Span reconstruction (issue #1010 / Trace 4) ───────────────────────────────────────
 
     @staticmethod
     def _span_id(*parts: str) -> str:
@@ -655,6 +656,9 @@ class OpenClawAdapter(AgentAdapter):
                 # input/output; fold them into token_count so LLM-span cost
                 # totals are not systematically under-reported.
                 tok_reasoning = _reasoning_tokens(usage)
+                # totalTokens includes reasoning tokens on extended-thinking models;
+                # prefer it when present so spans are not under-counted (#2794).
+                tok_total = int(usage.get("totalTokens") or usage.get("total_tokens") or 0)
                 llm_sid = _sid("llm", session_id, str(raw_ts))
                 spans.append({
                     "span_id": llm_sid,
@@ -669,7 +673,11 @@ class OpenClawAdapter(AgentAdapter):
                     "tokens_input": tok_in or None,
                     "tokens_output": tok_out or None,
                     "tokens_reasoning": tok_reasoning or None,
-                    "token_count": (tok_in + tok_out + tok_reasoning) or None,
+                    # max() is the only safe combination of #2876 and #2794:
+                    # totalTokens (when the SDK emits it) ALREADY includes the
+                    # reasoning share, so summing them would double-count, and
+                    # either alone under-counts when the other key is present.
+                    "token_count": max(tok_total, tok_in + tok_out + tok_reasoning) or None,
                 })
                 if isinstance(content, list):
                     for block in content:

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -334,3 +334,68 @@ def test_list_events_surfaces_cache_token_split_sdk_keys(isolated_store):
     assert ex.get("outputTokens") == 20
     assert ex.get("cacheReadTokens") == 80
     assert ex.get("cacheWriteTokens") == 10
+
+
+def test_list_events_surfaces_total_tokens_for_reasoning_model(isolated_store):
+    """totalTokens from usage lands in event.extra so callers can derive the
+    reasoning share (totalTokens - inputTokens - outputTokens). Fixes #2794."""
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-TOTAL",
+        "event_type": "model.completed",
+        "ts": _t.time(),
+        "model": "claude-opus-4-7",
+        "token_count": 162,
+        "data": {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-7",
+                "usage": {
+                    "input_tokens": 30,
+                    "output_tokens": 20,
+                    "totalTokens": 162,
+                },
+            },
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-TOTAL")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("inputTokens") == 30
+    assert ex.get("outputTokens") == 20
+    assert ex.get("totalTokens") == 162, "totalTokens must appear in extra for reasoning-model events"
+
+
+def test_build_spans_prefers_total_tokens_for_reasoning_model():
+    """_build_spans_from_events must use totalTokens as token_count when it
+    exceeds tok_in+tok_out — the extra comes from reasoning. Fixes #2794."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {
+            "type": "message",
+            "timestamp": "1700000001",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "usage": {
+                    "input_tokens": 30,
+                    "output_tokens": 20,
+                    "totalTokens": 162,  # 112 reasoning tokens on top
+                },
+                "content": [],
+            },
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "sess-span-r")
+    llm_spans = [s for s in spans if s.get("name", "").startswith("llm.call")]
+    assert len(llm_spans) == 1
+    assert llm_spans[0]["token_count"] == 162, (
+        "token_count must equal totalTokens (162), not tok_in+tok_out (50)"
+    )


### PR DESCRIPTION
Closes #2794

Replaces #2932 (rebased onto current main to resolve conflicts).

## Summary

- **`_build_spans_from_events`**: reads `usage.totalTokens`/`total_tokens` and prefers it over `tok_in + tok_out` when it's larger — fixes under-counted `token_count` in llm.call spans for reasoning models (the reasoning portion was silently dropped).
- **`list_events`**: adds `("totalTokens", "totalTokens", "total_tokens")` to the extraction tuple so `event.extra["totalTokens"]` is populated, allowing callers to derive reasoning tokens as `totalTokens − inputTokens − outputTokens`.

`Session.reasoning_tokens` field population in `list_sessions()` is left as a follow-up (needs a Session dataclass change — out of this tight scope, per original issue note).

## Test plan

- `test_build_spans_prefers_total_tokens_for_reasoning_model` — pure logic, no DuckDB dep: asserts span `token_count == 162` (totalTokens) not `50` (tok_in+tok_out) for a reasoning-model event.
- `test_list_events_surfaces_total_tokens_for_reasoning_model` — DuckDB-dependent: asserts `event.extra["totalTokens"] == 162` for a seeded event with `usage.totalTokens`.
- All existing tests in `test_openclaw_list_events.py` are unchanged and pass in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8SN52XmdhPm7JbvM3683q)_