### PR TITLE
test(e2e): expand C5 post-auth sweep from 19 to 32 dashboard tabs

### DIFF
--- a/tests/test_e2e_oss_all_tabs.py
+++ b/tests/test_e2e_oss_all_tabs.py
@@ -1,5 +1,4 @@
-"""
-OSS all-tabs post-auth gate (E2E criterion C5).
+"""OSS all-tabs post-auth gate (E2E criterion C5).
 
 Verifies that every canonical dashboard tab renders without an auth overlay
 when the gateway token is correctly passed. Acceptance gate for:
@@ -53,9 +52,17 @@ def _overlay_page(_shared_chromium):
     ctx.close()
 
 # Canonical tabs that must load without auth overlay post-login.
-# Matches PR_SCREENSHOT_TABS in .github/workflows/pr-screenshots.yml
-# so the Playwright gate covers the same surface as the visual-diff workflow.
+#
+# These are all tabs that have a template file in clawmetry/templates/tabs/
+# or are served by a dedicated route module (e.g. channels via routes/channels.py).
+# Kept in sync with the filesystem: if a new tab template is added, add the
+# switchTab() identifier here so the post-auth sweep covers it immediately.
+#
+# The test only checks that none of the four auth-blocking overlay IDs are
+# visible -- it does NOT require data to be present. Pro/enterprise gating
+# overlays use distinct IDs and will not cause false failures here.
 CANONICAL_TABS = [
+    # Core dashboard
     "overview",
     "flow",
     "brain",
@@ -65,6 +72,7 @@ CANONICAL_TABS = [
     "security",
     "subagents",
     "transcripts",
+    # Infrastructure / ops
     "logs",
     "skills",
     "models",
@@ -75,6 +83,21 @@ CANONICAL_TABS = [
     "limits",
     "clusters",
     "history",
+    # Tabs added after initial C5 coverage -- verified present in
+    # clawmetry/templates/tabs/ or routes/ as of 2026-06-09.
+    "channels",          # routes/channels.py: 21 chat-channel adapters
+    "dives",             # dives.html / dives.js: session deep-dive feature
+    "harness",           # harness.html: harness observability
+    "inventory",         # inventory.html: tool/resource inventory
+    "nemoclaw",          # nemoclaw.html: NeMo Guardrails governance
+    "policy",            # policy.html: policy management
+    "selfevolve",        # selfevolve.html: self-evolve feature
+    "swimlane",          # swimlane.html: swimlane visualization
+    "tool-catalog",      # tool-catalog.html: tool catalog
+    "tracing",           # tracing.html: OpenTelemetry tracing view
+    "turn-anatomy",      # turn-anatomy.html: turn anatomy analysis
+    "version-impact",    # version-impact.html: version impact view
+    "context-economics", # context-economics.html: context economics
 ]
 
 # Overlay element IDs that signal the auth overlay is blocking the UI.


### PR DESCRIPTION
## Gap closed

`CANONICAL_TABS` in `tests/test_e2e_oss_all_tabs.py` covered 19 tabs. A full audit of `clawmetry/templates/tabs/` reveals 13 more tab templates (plus the route-only `channels`) that were never added to the post-auth overlay sweep:

| Tab | Source |
|-----|--------|
| `channels` | `routes/channels.py` -- 21 chat-channel adapters |
| `dives` | `dives.html` / `dives.js` -- session deep-dive feature |
| `harness` | `harness.html` -- harness observability |
| `inventory` | `inventory.html` -- tool/resource inventory |
| `nemoclaw` | `nemoclaw.html` -- NeMo Guardrails governance |
| `policy` | `policy.html` -- policy management |
| `selfevolve` | `selfevolve.html` -- self-evolve feature |
| `swimlane` | `swimlane.html` -- swimlane visualization |
| `tool-catalog` | `tool-catalog.html` -- tool catalog |
| `tracing` | `tracing.html` -- OpenTelemetry tracing |
| `turn-anatomy` | `turn-anatomy.html` -- turn anatomy analysis |
| `version-impact` | `version-impact.html` -- version impact |
| `context-economics` | `context-economics.html` -- context economics |

Any auth-token-propagation regression on these tabs (the original user-reported symptom: "gateway token not passed for OSS so it never displays other screens", 2026-05-17) would silently pass the C5 gate today.

## What changed

`tests/test_e2e_oss_all_tabs.py`: CANONICAL_TABS extended from 19 to 32 entries. The test logic is unchanged -- each tab is parametrized and checked that none of `[login-overlay, gw-setup-overlay, auth-overlay, setup-overlay]` are visible after gateway token injection into localStorage. Pro/enterprise gating overlays use distinct element IDs and will not cause false failures.

## Before

C5 post-auth sweep: 19 tabs (13 shipped dashboard tabs never tested).

## After

C5 post-auth sweep: 32 tabs (full coverage of all templates in `clawmetry/templates/tabs/` + channels route).

## Acceptance test

```
CLAWMETRY_URL=http://localhost:8900 CLAWMETRY_TOKEN=ci-test-token \
pytest tests/test_e2e_oss_all_tabs.py -v
```

Expected: 1 auth-check test + 32 parametrized tab tests = 33 PASSED.

## Tracking

vivekchand/clawmetry#2146 -- E2E Robustness epic, C5 depth, fire 2026-06-09.

C6 (required-status-checks) is the only RED criterion; it requires a one-time admin action (see issue #2146 for close instructions).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDL6fc1yRhV57sAYLZAgzs)_