### PR TITLE
feat(update): auto-update default-ON for the supervised sync daemon + crash-loop rollback guard

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -15321,6 +15321,21 @@ def run_daemon() -> None:
     # done, instead of starting a second daemon mid-drain.
     _install_shutdown_handlers()
 
+    # Self-update crash-loop guard (firmware-OTA style, see
+    # clawmetry/update_guard.py). If a just-installed wheel boot-loops under
+    # launchd/systemd, the Nth rapid boot rolls back to the previous version
+    # and exits so the supervisor respawns on the known-good build. A healthy
+    # run self-confirms after a few minutes. Runs BEFORE heavy init so a
+    # crash later in startup still counts as a failed boot. Never raises.
+    try:
+        from clawmetry import __version__ as _cm_boot_ver
+        from clawmetry.update_guard import check_boot_and_maybe_rollback as _ug_check
+        _ug_status = _ug_check(_cm_boot_ver)
+        if _ug_status not in ("idle",):
+            log.info("update guard: boot status=%s (v%s)", _ug_status, _cm_boot_ver)
+    except Exception as _ug_e:
+        log.warning("update guard boot check failed: %s", _ug_e)
+
     # Open-core plugin discovery. dashboard.py runs this at import time so the
     # dashboard process picks up entry-point plugins (clawmetry-pro adapters,
     # event handlers, etc.). The sync daemon is a SEPARATE process — started
@@ -15795,18 +15810,19 @@ def run_daemon() -> None:
     except Exception as _e:
         log.warning(f"pro-entitlement watcher failed to start: {_e}")
 
-    # ── Opt-in auto-update worker ────────────────────────────────────────
-    # routes/update_check.py runs a background checker that self-updates ONLY
-    # when the `auto_update` config is on (default OFF → no behaviour change
-    # for anyone who hasn't opted in), via the same vetted pip+restart path as
-    # the manual "Update now". It was started only in the DASHBOARD process —
-    # but a headless / cloud-synced node runs only this daemon, so auto-update
-    # never fired where it's most needed. Start it here too (idempotent: the
-    # module guards against a double-started thread). Never blocks/raises.
+    # ── Auto-update worker (default ON in this daemon) ───────────────────
+    # routes/update_check.py runs a background checker that self-updates via
+    # the same vetted pip+restart path as the manual "Update now".
+    # ``role="daemon"`` marks this as the supervised always-on process: the
+    # ONLY role where the default-on policy acts (the dashboard stays opt-in).
+    # Rails: 48h PyPI staleness window, CLAWMETRY_AUTO_UPDATE=0 kill switch,
+    # boot-loop rollback guard (clawmetry/update_guard.py), and no self-exit
+    # when unsupervised. WHY: the 2026-06-09 fleet audit found 92% of active
+    # nodes months stale — fixes shipped but never arrived. Never blocks/raises.
     try:
         from routes.update_check import start_update_check_thread as _start_uc
-        _start_uc()
-        log.info("update-check thread started (auto-update honours the opt-in flag)")
+        _start_uc(role="daemon")
+        log.info("update-check thread started (auto-update default-on, daemon role)")
     except Exception as _e:
         log.warning(f"update-check thread failed to start: {_e}")
 

--- a/clawmetry/update_guard.py
+++ b/clawmetry/update_guard.py
@@ -1,0 +1,183 @@
+"""Crash-loop rollback guard for daemon self-update (firmware-OTA style).
+
+``perform_self_update()`` (routes/meta.py) ARMS the guard right after
+``pip install -U clawmetry`` succeeds, before the process restarts.
+``run_daemon()`` (clawmetry/sync.py) CHECKS the guard at boot:
+
+- Each daemon boot inside the guard window increments a boot counter.
+- ``MAX_BOOTS`` rapid boots in a row (a launchd/systemd respawn loop) means
+  the freshly installed wheel is crashing, so the guard pip-installs the
+  PREVIOUS version and exits; the supervisor respawns on the rolled-back
+  build. The rollback is recorded in ``update_rollback.json`` so the
+  dashboard / heartbeat can surface it.
+- A healthy run self-CONFIRMS (clears the guard) after ``CONFIRM_AFTER_S``
+  seconds of uptime, mirroring the firmware OTA ``PENDING_VERIFY`` →
+  ``mark_app_valid`` flow in clawmetry-hardware.
+
+An import-time crash of ``clawmetry.sync`` is outside what this guard can
+catch (the guard itself would never run); that band is covered by the PyPI
+staleness rail (``CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS``, default 48h), which
+keeps unattended installs off brand-new releases. Never raises: every entry
+point swallows and logs.
+"""
+import json
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_CLAWMETRY_HOME = Path(os.path.expanduser("~/.clawmetry"))
+STATE_PATH = _CLAWMETRY_HOME / "update_state.json"
+ROLLBACK_MARKER = _CLAWMETRY_HOME / "update_rollback.json"
+
+# A guard older than this is stale (the update clearly applied long ago).
+WINDOW_S = 3600
+# This many boots inside the window = crash loop -> roll back.
+MAX_BOOTS = 3
+# A run that stays up this long confirms the new version is healthy.
+CONFIRM_AFTER_S = 300
+
+
+def _read_state():
+    try:
+        with open(STATE_PATH, "r") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def _write_state(state):
+    try:
+        STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = STATE_PATH.with_suffix(".json.tmp")
+        with open(tmp, "w") as f:
+            json.dump(state, f)
+        os.replace(tmp, STATE_PATH)
+    except Exception as exc:
+        log.warning("update guard: could not write state: %s", exc)
+
+
+def _clear_state():
+    try:
+        STATE_PATH.unlink()
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        log.warning("update guard: could not clear state: %s", exc)
+
+
+def arm_rollback_guard(prev_version, target_version, reason="manual"):
+    """Record that an upgrade ``prev -> target`` is about to restart the
+    daemon. Called by ``perform_self_update`` AFTER pip succeeded. No-op when
+    the versions are equal (nothing actually changed)."""
+    try:
+        prev_version = str(prev_version or "").strip()
+        target_version = str(target_version or "").strip()
+        if not prev_version or not target_version or prev_version == target_version:
+            return
+        _write_state({
+            "prev": prev_version,
+            "target": target_version,
+            "reason": str(reason),
+            "ts": time.time(),
+            "boots": 0,
+        })
+        log.info("update guard armed: %s -> %s (%s)", prev_version, target_version, reason)
+    except Exception as exc:
+        log.warning("update guard: arm failed: %s", exc)
+
+
+def confirm_update_ok():
+    """Healthy-run confirmation: the new version survived; drop the guard."""
+    if _read_state() is not None:
+        log.info("update guard: new version confirmed healthy")
+    _clear_state()
+
+
+def _pip_install_version(version):
+    """Best-effort ``pip install clawmetry==<version>`` in this interpreter's
+    venv (ensurepip bootstrap first: the ~/.clawmetry venv may lack pip)."""
+    py = sys.executable
+    try:
+        subprocess.run(
+            [py, "-m", "ensurepip", "--upgrade", "--default-pip"],
+            timeout=60, capture_output=True,
+        )
+    except Exception:
+        pass
+    try:
+        proc = subprocess.run(
+            [py, "-m", "pip", "install", "--no-cache-dir", "clawmetry==%s" % version],
+            timeout=300, capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            tail = ((proc.stdout or "") + (proc.stderr or "")).strip()[-400:]
+            log.error("update guard: rollback pip failed (%s): %s", proc.returncode, tail)
+        return proc.returncode == 0
+    except Exception as exc:
+        log.error("update guard: rollback pip errored: %s", exc)
+        return False
+
+
+def check_boot_and_maybe_rollback(current_version, _install=None, _exit=None):
+    """Call once, early in ``run_daemon``. Returns a status string (for tests
+    and logs): ``idle`` / ``expired`` / ``mismatch`` / ``armed`` /
+    ``rolled_back`` / ``rollback_failed``. Never raises."""
+    try:
+        state = _read_state()
+        if not state:
+            return "idle"
+        if time.time() - float(state.get("ts", 0) or 0) > WINDOW_S:
+            _clear_state()
+            return "expired"
+        if str(state.get("target", "")) != str(current_version):
+            # We are not running the version the guard was armed for (the
+            # update never applied, or a manual fix already happened).
+            _clear_state()
+            return "mismatch"
+
+        boots = int(state.get("boots", 0) or 0) + 1
+        if boots >= MAX_BOOTS:
+            prev = str(state.get("prev", "") or "")
+            log.error(
+                "update guard: %d rapid boots on v%s — rolling back to v%s",
+                boots, current_version, prev,
+            )
+            ok = bool(prev) and (_install or _pip_install_version)(prev)
+            try:
+                ROLLBACK_MARKER.parent.mkdir(parents=True, exist_ok=True)
+                with open(ROLLBACK_MARKER, "w") as f:
+                    json.dump({
+                        "from": str(current_version),
+                        "to": prev,
+                        "ok": bool(ok),
+                        "ts": time.time(),
+                        "reason": state.get("reason", ""),
+                    }, f)
+            except Exception:
+                pass
+            _clear_state()
+            if ok:
+                # Exit so the supervisor (launchd KeepAlive / systemd
+                # Restart=always) respawns on the rolled-back wheel.
+                (_exit or os._exit)(0)
+                return "rolled_back"  # only reached when _exit is a test spy
+            return "rollback_failed"
+
+        state["boots"] = boots
+        _write_state(state)
+        # Healthy-run confirmation: if we stay up CONFIRM_AFTER_S, the new
+        # version is good and the guard clears itself.
+        t = threading.Timer(CONFIRM_AFTER_S, confirm_update_ok)
+        t.daemon = True
+        t.start()
+        return "armed"
+    except Exception as exc:
+        log.warning("update guard: boot check failed: %s", exc)
+        return "error"

--- a/routes/meta.py
+++ b/routes/meta.py
@@ -351,7 +351,7 @@ def api_version():
     return {"current": current, "latest": latest, "update_available": update_available}
 
 
-def perform_self_update(reason: str = "manual"):
+def perform_self_update(reason: str = "manual", restart: bool = True):
     """Core self-update: ``pip install -U clawmetry`` then schedule a process
     restart. Returns ``(payload_dict, http_status)``.
 
@@ -359,6 +359,10 @@ def perform_self_update(reason: str = "manual"):
     (``routes/update_check.py``) so both use one vetted upgrade+restart path.
     Safe to call from a worker thread — the restart is scheduled on a Timer
     that exits the process (launchd/systemd respawns it on the new wheel).
+
+    ``restart=False`` installs the new wheel but does NOT exit the process —
+    the auto-updater uses it for an unsupervised daemon (nothing would
+    respawn it); the new version applies on the next start.
     """
     import dashboard as _d
     import subprocess as _sp
@@ -416,6 +420,22 @@ def perform_self_update(reason: str = "manual"):
                 break
     except Exception:
         pass
+
+    # Arm the crash-loop rollback guard BEFORE any restart: if the new wheel
+    # boot-loops, the daemon's next boots detect it and pip-roll back to
+    # ``old_version`` (clawmetry/update_guard.py — firmware-OTA style).
+    try:
+        from clawmetry.update_guard import arm_rollback_guard
+        arm_rollback_guard(old_version, new_version, reason)
+    except Exception:
+        pass
+
+    if not restart:
+        _ulog.info("self-update (%s): upgraded v%s -> v%s; restart deferred "
+                   "(unsupervised process keeps running the old build until "
+                   "its next start)", reason, old_version, new_version)
+        return {"ok": True, "old_version": old_version,
+                "new_version": new_version, "restart_deferred": True}, 200
 
     # Schedule restart after response is sent.
     # CRITICAL: kick the sync daemon FIRST. Otherwise it keeps the OLD wheel in

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -12,6 +12,7 @@ Blueprint: bp_update_check
 import json
 import logging
 import os
+import sys
 import threading
 import time
 from datetime import datetime, timezone
@@ -26,7 +27,57 @@ bp_update_check = Blueprint("update_check", __name__)
 _update_check_thread = None
 _update_check_stop_event = threading.Event()
 
+# Which process this checker runs in: "dashboard" (default) or "daemon" (the
+# supervised sync daemon, set via start_update_check_thread(role="daemon")).
+# Default-on auto-update applies ONLY to the daemon role — the always-on,
+# launchd/systemd-supervised process where a restart is safe and invisible.
+# A dashboard process (often a foreground terminal) auto-installs only when
+# the user EXPLICITLY opted in via the settings toggle.
+_process_role = "dashboard"
+
 CHANGELOG_URL = "https://github.com/vivekchand/clawmetry/blob/main/CHANGELOG.md"
+
+
+def _env_auto_update_disabled():
+    """Kill switch: ``CLAWMETRY_AUTO_UPDATE=0`` disables unattended upgrades
+    regardless of the stored config (fleet operators / CI / debugging)."""
+    val = os.environ.get("CLAWMETRY_AUTO_UPDATE", "").strip().lower()
+    return val in ("0", "false", "no", "off")
+
+
+def _auto_update_explicitly_set():
+    """True when an ``auto_update`` row exists in the config table — i.e. a
+    user (or the entitled-plan sync) chose a value, as opposed to the
+    built-in default."""
+    try:
+        with _get_fleet_db_lock():
+            db = _get_fleet_db()
+            row = db.execute(
+                "SELECT value FROM update_check_config WHERE key='auto_update'"
+            ).fetchone()
+            db.close()
+        return row is not None
+    except Exception:
+        return False
+
+
+def _daemon_supervised():
+    """Best-effort: is the sync daemon under a supervisor that respawns it
+    (launchd KeepAlive / systemd Restart=always)? When it is not, exiting to
+    'restart' would just kill the daemon — so the auto-updater installs the
+    new wheel but defers the restart to the next manual start."""
+    try:
+        from pathlib import Path
+        if sys.platform == "darwin":
+            return (Path.home() / "Library" / "LaunchAgents"
+                    / "com.clawmetry.sync.plist").exists()
+        if sys.platform.startswith("linux"):
+            unit = (Path.home() / ".config" / "systemd" / "user"
+                    / "clawmetry-sync.service")
+            return unit.exists() or bool(os.environ.get("INVOCATION_ID"))
+    except Exception:
+        pass
+    return False
 
 
 def _live_current_version() -> str:
@@ -93,10 +144,17 @@ def _get_update_check_config():
         "enabled": True,
         "check_on_startup": True,
         "check_daily": True,
-        # Opt-in: when on, a detected newer release is installed automatically
-        # by the background worker (no click needed). Off by default — auto
-        # pip-install + restart is something the user explicitly turns on.
-        "auto_update": False,
+        # Default ON (since 0.12.494): a detected newer release is installed
+        # automatically by the background worker. Rails: only the supervised
+        # sync-daemon process acts on the default (see _maybe_auto_update),
+        # releases must age CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS (48h) on PyPI
+        # first, CLAWMETRY_AUTO_UPDATE=0 is a hard kill switch, and the boot
+        # guard (clawmetry/update_guard.py) rolls back a crash-looping wheel.
+        # WHY default-on: 92% of active nodes were found running months-stale
+        # daemons (2026-06-09 fleet audit) — every shipped fix reached almost
+        # nobody, and the hosted dashboard rendered blank cards against old
+        # snapshots. An observability sidecar must keep itself current.
+        "auto_update": True,
         "dismissed_version": "",
         "last_check_at": 0,
     }
@@ -245,9 +303,10 @@ def _check_for_update():
     except Exception:
         _age_h = None
 
-    # Auto-update: if the user opted in, install the newer release now (no
-    # click). Runs in the always-on dashboard server process, so it works
-    # with no browser open. Guarded so a pending restart isn't re-triggered.
+    # Auto-update: install the newer release unattended (default-on for the
+    # supervised sync daemon; opt-in for the dashboard process — see
+    # _maybe_auto_update for the full rail set). Guarded so a pending
+    # restart isn't re-triggered.
     if update_available:
         try:
             _maybe_auto_update(current, latest, _age_h)
@@ -280,8 +339,16 @@ def _maybe_auto_update(current, latest, age_hours=None):
     global _auto_update_in_progress
     if _auto_update_in_progress:
         return
+    if _env_auto_update_disabled():
+        log.info("auto-update: disabled via CLAWMETRY_AUTO_UPDATE env")
+        return
     cfg = _get_update_check_config()
     if not cfg.get("auto_update"):
+        return
+    # The default-on policy applies only to the supervised sync daemon. A
+    # dashboard process (frequently a foreground terminal session) must not
+    # pip-install + exit underneath the user unless they explicitly opted in.
+    if _process_role != "daemon" and not _auto_update_explicitly_set():
         return
     try:
         import os as _os
@@ -292,11 +359,19 @@ def _maybe_auto_update(current, latest, age_hours=None):
         log.info("auto-update: holding v%s (released %.1fh ago < %.0fh stability "
                  "window) — will install once it ages in", latest, age_hours, _min_age)
         return
+    # An UNSUPERVISED daemon (no launchd plist / systemd unit — e.g. a manual
+    # `python -m clawmetry.sync` or Windows) still installs the new wheel but
+    # keeps running: exiting would stop ingest with nothing to respawn it.
+    # The new version applies on its next start.
+    restart = True
+    if _process_role == "daemon" and not _daemon_supervised():
+        restart = False
     _auto_update_in_progress = True
-    log.info("auto-update: opted in — upgrading clawmetry v%s -> v%s", current, latest)
+    log.info("auto-update: upgrading clawmetry v%s -> v%s (restart=%s)",
+             current, latest, restart)
     try:
         from routes.meta import perform_self_update
-        payload, _status = perform_self_update(reason="auto")
+        payload, _status = perform_self_update(reason="auto", restart=restart)
         if not (isinstance(payload, dict) and payload.get("ok")):
             log.warning("auto-update: upgrade failed, will retry next check: %s", payload)
             _auto_update_in_progress = False  # allow retry; no restart was scheduled
@@ -332,9 +407,17 @@ def _update_check_worker(stop_event):
         stop_event.wait(3600)
 
 
-def start_update_check_thread():
-    """Start the background update check thread."""
-    global _update_check_thread, _update_check_stop_event
+def start_update_check_thread(role=None):
+    """Start the background update check thread.
+
+    ``role="daemon"`` marks this process as the supervised sync daemon, the
+    only role where default-on auto-update acts (see ``_maybe_auto_update``).
+    The dashboard calls this with no argument and keeps the opt-in behaviour.
+    """
+    global _update_check_thread, _update_check_stop_event, _process_role
+
+    if role:
+        _process_role = str(role)
 
     if _update_check_thread is not None and _update_check_thread.is_alive():
         return

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -1,6 +1,7 @@
-"""Opt-in auto-update: the background update-check worker installs a newer
-release automatically only when the `auto_update` config is on, and never
-re-triggers pip once a restart is already pending.
+"""Auto-update gating: default ON for the supervised sync-daemon role
+(0.12.494+), opt-in for the dashboard role; never re-triggers pip once a
+restart is pending; honours the CLAWMETRY_AUTO_UPDATE kill switch and the
+release-age stability rail.
 
 The upgrade itself goes through the same vetted path as the manual "Update
 now" button (routes.meta.perform_self_update), which is mocked here — these
@@ -16,11 +17,20 @@ def _uc():
     return importlib.reload(uc)
 
 
-def _mock_self_update(monkeypatch, calls, ok=True):
+def _as_daemon(uc, monkeypatch):
+    """Run the checker as the supervised sync daemon (the default-on role)."""
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    uc._process_role = "daemon"
+    monkeypatch.setattr(uc, "_daemon_supervised", lambda: True)
+
+
+def _mock_self_update(monkeypatch, calls, ok=True, restarts=None):
     import routes.meta as meta
 
-    def _fake(reason="manual"):
+    def _fake(reason="manual", restart=True):
         calls.append(reason)
+        if restarts is not None:
+            restarts.append(restart)
         return ({"ok": ok, "old_version": "0.12.1", "new_version": "0.12.2"},
                 200 if ok else 500)
 
@@ -29,6 +39,7 @@ def _mock_self_update(monkeypatch, calls, ok=True):
 
 def test_auto_update_off_does_not_upgrade(monkeypatch):
     uc = _uc()
+    _as_daemon(uc, monkeypatch)
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": False})
     calls = []
     _mock_self_update(monkeypatch, calls)
@@ -38,6 +49,7 @@ def test_auto_update_off_does_not_upgrade(monkeypatch):
 
 def test_auto_update_on_upgrades_once(monkeypatch):
     uc = _uc()
+    _as_daemon(uc, monkeypatch)
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     calls = []
     _mock_self_update(monkeypatch, calls)
@@ -50,6 +62,7 @@ def test_auto_update_on_upgrades_once(monkeypatch):
 
 def test_auto_update_failure_allows_retry(monkeypatch):
     uc = _uc()
+    _as_daemon(uc, monkeypatch)
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     calls = []
     _mock_self_update(monkeypatch, calls, ok=False)
@@ -74,6 +87,7 @@ def test_auto_update_in_allowed_config_keys(monkeypatch):
 
 def test_auto_update_holds_fresh_release(monkeypatch):
     uc = _uc()
+    _as_daemon(uc, monkeypatch)
     calls = []
     _mock_self_update(monkeypatch, calls)
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
@@ -88,11 +102,96 @@ def test_auto_update_holds_fresh_release(monkeypatch):
 
 def test_auto_update_unknown_age_does_not_block(monkeypatch):
     uc = _uc()
+    _as_daemon(uc, monkeypatch)
     calls = []
     _mock_self_update(monkeypatch, calls)
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=None)
     assert calls == ["auto"], "unknown age must not block (back-compat)"
+
+
+# ── Default-on policy + rails (0.12.494) ────────────────────────────────────
+
+
+def test_auto_update_default_is_on(monkeypatch):
+    """REGRESSION GUARD for the 2026-06-09 stale-fleet audit: with no stored
+    config at all, auto_update must default to True. (Fails on the old
+    opt-in default — that default left 92% of active nodes months stale.)"""
+    uc = _uc()
+    # Empty config store: every read falls through to the defaults dict.
+    monkeypatch.setattr(uc, "_get_fleet_db_lock", lambda: __import__("threading").Lock())
+
+    class _EmptyDb:
+        def execute(self, *a, **k):
+            class _R:
+                def fetchall(self):
+                    return []
+
+                def fetchone(self):
+                    return None
+            return _R()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(uc, "_get_fleet_db", lambda: _EmptyDb())
+    assert uc._get_update_check_config()["auto_update"] is True
+
+
+def test_env_kill_switch_blocks_auto_update(monkeypatch):
+    uc = _uc()
+    _as_daemon(uc, monkeypatch)
+    monkeypatch.setenv("CLAWMETRY_AUTO_UPDATE", "0")
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+    calls = []
+    _mock_self_update(monkeypatch, calls)
+    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    assert calls == [], "CLAWMETRY_AUTO_UPDATE=0 must hard-disable auto-update"
+
+
+def test_dashboard_role_requires_explicit_opt_in(monkeypatch):
+    """The default-on policy is daemon-only: a dashboard process (often a
+    foreground terminal) must not pip-install + exit on the DEFAULT."""
+    uc = _uc()
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    assert uc._process_role == "dashboard"  # reload resets the role
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+    calls = []
+    _mock_self_update(monkeypatch, calls)
+    # Default True but NOT explicitly stored → dashboard must not act.
+    monkeypatch.setattr(uc, "_auto_update_explicitly_set", lambda: False)
+    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    assert calls == [], "dashboard role must ignore the default-on policy"
+    # Explicit user opt-in → dashboard acts (pre-existing behaviour kept).
+    monkeypatch.setattr(uc, "_auto_update_explicitly_set", lambda: True)
+    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    assert calls == ["auto"], "explicit opt-in must still work in the dashboard"
+
+
+def test_unsupervised_daemon_defers_restart(monkeypatch):
+    """A daemon with no launchd/systemd supervisor installs the new wheel but
+    must NOT exit (nothing would respawn it → ingest stops)."""
+    uc = _uc()
+    monkeypatch.delenv("CLAWMETRY_AUTO_UPDATE", raising=False)
+    uc._process_role = "daemon"
+    monkeypatch.setattr(uc, "_daemon_supervised", lambda: False)
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+    calls, restarts = [], []
+    _mock_self_update(monkeypatch, calls, restarts=restarts)
+    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    assert calls == ["auto"]
+    assert restarts == [False], "unsupervised daemon must defer the restart"
+
+
+def test_supervised_daemon_restarts(monkeypatch):
+    uc = _uc()
+    _as_daemon(uc, monkeypatch)
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+    calls, restarts = [], []
+    _mock_self_update(monkeypatch, calls, restarts=restarts)
+    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    assert calls == ["auto"]
+    assert restarts == [True], "supervised daemon restarts to apply the wheel"
 
 
 def test_entitled_plan_enables_auto_update(monkeypatch):

--- a/tests/test_update_guard.py
+++ b/tests/test_update_guard.py
@@ -1,0 +1,123 @@
+"""Crash-loop rollback guard (clawmetry/update_guard.py).
+
+perform_self_update ARMS the guard; run_daemon CHECKS it each boot. Three
+rapid boots on a freshly-installed version = boot loop -> pip-roll back to
+the previous version and exit for the supervisor to respawn. A healthy run
+confirms (clears) the guard. These tests drive the pure state machine with
+the pip/exit side effects injected.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+
+
+def _ug(tmp_path, monkeypatch):
+    import clawmetry.update_guard as ug
+    ug = importlib.reload(ug)
+    monkeypatch.setattr(ug, "STATE_PATH", tmp_path / "update_state.json")
+    monkeypatch.setattr(ug, "ROLLBACK_MARKER", tmp_path / "update_rollback.json")
+    return ug
+
+
+def test_idle_without_armed_guard(tmp_path, monkeypatch):
+    ug = _ug(tmp_path, monkeypatch)
+    assert ug.check_boot_and_maybe_rollback("0.12.2") == "idle"
+
+
+def test_arm_noops_on_same_version(tmp_path, monkeypatch):
+    ug = _ug(tmp_path, monkeypatch)
+    ug.arm_rollback_guard("0.12.2", "0.12.2", "auto")
+    assert not ug.STATE_PATH.exists(), "same-version 'upgrade' must not arm"
+
+
+def test_third_rapid_boot_rolls_back(tmp_path, monkeypatch):
+    ug = _ug(tmp_path, monkeypatch)
+    ug.arm_rollback_guard("0.12.1", "0.12.2", "auto")
+
+    installed, exited = [], []
+    fake_install = lambda v: (installed.append(v), True)[1]
+    fake_exit = lambda code: exited.append(code)
+
+    # Boots 1 and 2: armed, counter increments, no rollback.
+    assert ug.check_boot_and_maybe_rollback("0.12.2", fake_install, fake_exit) == "armed"
+    assert ug.check_boot_and_maybe_rollback("0.12.2", fake_install, fake_exit) == "armed"
+    assert installed == [] and exited == []
+
+    # Boot 3: crash loop -> roll back to the previous version and exit.
+    status = ug.check_boot_and_maybe_rollback("0.12.2", fake_install, fake_exit)
+    assert status == "rolled_back"
+    assert installed == ["0.12.1"], "must pip-install the PREVIOUS version"
+    assert exited == [0], "must exit so the supervisor respawns on the old wheel"
+    assert not ug.STATE_PATH.exists(), "guard must clear after rollback"
+    marker = json.loads(ug.ROLLBACK_MARKER.read_text())
+    assert marker["from"] == "0.12.2" and marker["to"] == "0.12.1" and marker["ok"]
+
+
+def test_failed_rollback_does_not_exit(tmp_path, monkeypatch):
+    ug = _ug(tmp_path, monkeypatch)
+    ug.arm_rollback_guard("0.12.1", "0.12.2", "auto")
+    exited = []
+    for _ in range(2):
+        ug.check_boot_and_maybe_rollback("0.12.2", lambda v: False, exited.append)
+    status = ug.check_boot_and_maybe_rollback("0.12.2", lambda v: False, exited.append)
+    assert status == "rollback_failed"
+    assert exited == [], "a failed pip rollback must NOT exit (keep running)"
+
+
+def test_version_mismatch_clears_guard(tmp_path, monkeypatch):
+    """Booting a version other than the armed target (update never applied,
+    or someone already fixed it by hand) must clear the guard, not count."""
+    ug = _ug(tmp_path, monkeypatch)
+    ug.arm_rollback_guard("0.12.1", "0.12.2", "auto")
+    assert ug.check_boot_and_maybe_rollback("0.12.3") == "mismatch"
+    assert not ug.STATE_PATH.exists()
+
+
+def test_stale_guard_expires(tmp_path, monkeypatch):
+    ug = _ug(tmp_path, monkeypatch)
+    ug.arm_rollback_guard("0.12.1", "0.12.2", "auto")
+    state = json.loads(ug.STATE_PATH.read_text())
+    state["ts"] = time.time() - ug.WINDOW_S - 10
+    ug.STATE_PATH.write_text(json.dumps(state))
+    assert ug.check_boot_and_maybe_rollback("0.12.2") == "expired"
+    assert not ug.STATE_PATH.exists()
+
+
+def test_confirm_clears_guard(tmp_path, monkeypatch):
+    ug = _ug(tmp_path, monkeypatch)
+    ug.arm_rollback_guard("0.12.1", "0.12.2", "auto")
+    ug.check_boot_and_maybe_rollback("0.12.2", lambda v: True, lambda c: None)
+    ug.confirm_update_ok()
+    assert not ug.STATE_PATH.exists(), "healthy-run confirmation must clear"
+    # Next boot after confirmation is a clean slate.
+    assert ug.check_boot_and_maybe_rollback("0.12.2") == "idle"
+
+
+def test_perform_self_update_arms_guard(tmp_path, monkeypatch):
+    """The vetted upgrade path must arm the guard after pip succeeds
+    (integration seam: routes.meta.perform_self_update -> update_guard).
+    pip + restart are stubbed; restart=False keeps the process alive."""
+    ug = _ug(tmp_path, monkeypatch)
+
+    import subprocess
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Proc())
+    monkeypatch.setattr(
+        subprocess, "check_output",
+        lambda *a, **k: b"Name: clawmetry\nVersion: 9.9.9\n",
+    )
+
+    import routes.meta as meta
+    payload, status = meta.perform_self_update(reason="auto", restart=False)
+    assert status == 200 and payload.get("ok") is True
+    assert payload.get("restart_deferred") is True
+    state = json.loads(ug.STATE_PATH.read_text())
+    assert state["target"] == "9.9.9", "guard must be armed for the new version"
+    assert state["reason"] == "auto"


### PR DESCRIPTION
## Why

The 2026-06-09 fleet audit (prod DB, real nodes active in the last 7 days) found **92% of active nodes running stale daemons** (75% at 0.12.0-0.12.299 vs current 0.12.493). Auto-update existed but was opt-in, so effectively nobody had it; every shipped fix reached almost nobody, and the hosted dashboard (the trial) rendered blank cards against old snapshots. Tracking issue: vivekchand/clawmetry-cloud#1530.

## What

1. **Default ON** for `auto_update` (routes/update_check.py), with rails:
   - The default acts **only in the supervised sync-daemon process** (`start_update_check_thread(role="daemon")` from `run_daemon`). The dashboard process keeps the opt-in behaviour (explicit stored toggle), so a foreground terminal session is never pip-installed + exited underneath the user.
   - Hard kill switch: `CLAWMETRY_AUTO_UPDATE=0` (same env the entitled-plan sync already honours).
   - The 48h PyPI release-age stability window (`CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS`) is unchanged.
   - An **unsupervised** daemon (no launchd plist / systemd unit, e.g. manual `python -m clawmetry.sync` or Windows) installs the new wheel but **defers the restart**: it never self-kills ingest with nothing to respawn it.
2. **Crash-loop rollback guard** (`clawmetry/update_guard.py`, new; mirrors the firmware OTA PENDING_VERIFY flow): `perform_self_update` arms it after pip succeeds; `run_daemon` checks it at boot. 3 rapid boots on a fresh wheel = boot loop -> pip-rolls back to the previous version, records `update_rollback.json`, exits for the supervisor to respawn on the known-good build. A healthy run self-confirms after 5 minutes.
3. `perform_self_update(reason, restart=True)` gains the `restart=False` path and arms the guard on both paths.

## Verification

- 21 unit tests green: `tests/test_auto_update.py` (extended: default-on, kill switch, role gating, deferred restart) + `tests/test_update_guard.py` (new: 3-boot rollback, failed-rollback-no-exit, mismatch/expiry/confirm, integration seam through `perform_self_update` with stubbed pip).
- **Revert-proof** (ruthless-verify rule): `test_auto_update_default_is_on` FAILS against origin/main's opt-in default and passes with this change.
- `py_compile` clean on `clawmetry/sync.py`, `routes/meta.py`, `routes/update_check.py`, `clawmetry/update_guard.py`; `tests/test_update_banner_live_version.py` still green.

## Limits (stated, not hidden)

- An import-time crash of `clawmetry.sync` on a new wheel is outside the guard's reach (the guard never runs); the 48h staleness rail covers that band.
- This converts the fleet only from the first version that CONTAINS it onward; the existing stale fleet needs the cloud-side update-nag + honest "update your daemon" states (next part of #1530, cloud repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)