### PR TITLE
feat(teaser): locked-runtime upgrade affordance renders in grace mode

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -252,6 +252,16 @@ class Entitlement:
         allowed; otherwise free runtimes plus whatever the tier grants."""
         if self.grace:
             return True
+        return self.entitled_runtime(runtime)
+
+    def entitled_runtime(self, runtime: str) -> bool:
+        """Grace-INDEPENDENT: does the plan itself grant ``runtime``? This
+        drives the teaser UI (#1532): a paid runtime the plan does not
+        include renders a locked upgrade affordance even in grace mode,
+        because without the pro package its data cannot be observed anyway
+        (the adapter only auto-provisions for entitled accounts) — "allowed
+        by grace" was indistinguishable from "working" and the conversion
+        surface never rendered (12 paywall views in 30 days fleet-wide)."""
         rt = (runtime or "").lower()
         if rt in FREE_RUNTIMES:
             return True
@@ -453,6 +463,7 @@ def runtime_catalog() -> list[dict]:
                 "free": True,
                 "allowed": True,
                 "locked": False,
+                "entitled": True,
             }
         )
     for rt in sorted(PAID_RUNTIMES):
@@ -464,6 +475,10 @@ def runtime_catalog() -> list[dict]:
                 "free": False,
                 "allowed": allowed,
                 "locked": not allowed,
+                # Grace-independent plan fact (#1532): lets the UI render the
+                # teaser/upgrade affordance in grace mode without changing
+                # what `allowed`/`locked` mean for enforcement.
+                "entitled": ent.entitled_runtime(rt),
             }
         )
     return out

--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -8813,18 +8813,41 @@ function _cmDismissRtPaywall() {
 }
 
 async function _cmLoadRuntimeCatalog() {
-  // Read the entitlement-aware runtime catalog (Phase 5 open-core). In grace
-  // mode (the default) nothing is locked, so _cmLockedRuntimes stays {} and
-  // the switcher behaves exactly as it did before this endpoint existed.
-  // Once enforcement is on, the locked paid runtimes appear in the dropdown
-  // with a 🔒 affordance regardless of session count.
+  // Read the entitlement-aware runtime catalog (Phase 5 open-core).
+  // Two ways a runtime earns the lock affordance in the dropdown:
+  //   1. enforced && locked: the original paywall semantics.
+  //   2. !entitled (grace teaser, cloud#1532): the plan does not include the
+  //      runtime, so even though grace "allows" it, its data is never
+  //      ingested (the pro adapter only provisions for entitled accounts).
+  //      Showing it locked is both the honest state AND the conversion
+  //      surface; picking it opens the non-blocking two-path card.
+  // Cloud guard: the hosted server resolves entitlement as OSS-free, so in
+  // CLOUD_MODE trust the account plan/trial instead. A paying or trialing
+  // hosted user must never see the teaser. Re-checked once after 4s because
+  // window._account loads async.
   try {
     var cat = await fetch('/api/runtimes', { credentials: 'same-origin' }).then(function(r) { return r.json(); });
-    if (!cat || !cat.enforced || !Array.isArray(cat.runtimes)) return;
+    if (!cat || !Array.isArray(cat.runtimes)) return;
+    var teaserOk = true;
+    try {
+      if (window.CLOUD_MODE) {
+        var plan = String(window.CLOUD_PLAN || '').toLowerCase();
+        var acct = window._account || {};
+        teaserOk = !(/pro|starter|paid/.test(plan) || acct.trial_active);
+      }
+    } catch (e) { teaserOk = false; }
     var locked = {};
-    cat.runtimes.forEach(function(r) { if (r && r.locked && r.id) locked[r.id] = 1; });
+    cat.runtimes.forEach(function(r) {
+      if (!r || !r.id) return;
+      if ((cat.enforced && r.locked) ||
+          (teaserOk && r.free === false && r.entitled === false)) locked[r.id] = 1;
+    });
     _cmLockedRuntimes = locked;
-  } catch (e) { /* non-fatal — grace mode keeps the previous behaviour */ }
+    if (window.CLOUD_MODE && !window._cmRtCatalogRecheck) {
+      window._cmRtCatalogRecheck = 1;
+      setTimeout(_cmLoadRuntimeCatalog, 4000);
+    }
+  } catch (e) { /* non-fatal: keeps the previous behaviour */ }
 }
 
 async function _cmInitGlobalRuntimeSwitcher() {

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -249,3 +249,60 @@ def test_paid_runtimes_allowed_on_paid_tiers_enforced(ent, monkeypatch, tmp_path
             assert en.allows_runtime(rt) is True, f"{tier}/{rt}"
         for rt in ent.FREE_RUNTIMES:
             assert en.allows_runtime(rt) is True, f"{tier}/{rt}"
+
+
+# ── grace teaser (#1532: entitled is grace-INDEPENDENT) ─────────────────────
+
+
+def test_entitled_runtime_is_grace_independent(ent):
+    """REGRESSION GUARD for the dead conversion surface: in grace mode
+    allows_runtime says True for everything, which the UI read as 'working'
+    so the upgrade affordance never rendered (12 paywall views in 30 days
+    fleet-wide). `entitled_runtime` must report the PLAN fact regardless of
+    grace."""
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    # Grace allows...
+    assert en.allows_runtime("claude_code") is True
+    # ...but the OSS-free plan does NOT entitle paid runtimes.
+    for rt in ent.PAID_RUNTIMES:
+        assert en.entitled_runtime(rt) is False, rt
+    for rt in ent.FREE_RUNTIMES:
+        assert en.entitled_runtime(rt) is True, rt
+
+
+def test_runtime_catalog_carries_entitled_in_grace(ent):
+    cat = {r["id"]: r for r in ent.runtime_catalog()}
+    for rt in ent.PAID_RUNTIMES:
+        assert cat[rt]["entitled"] is False, rt
+        # Enforcement semantics unchanged: grace still does not LOCK.
+        assert cat[rt]["locked"] is False, rt
+        assert cat[rt]["allowed"] is True, rt
+    for rt in ent.FREE_RUNTIMES:
+        assert cat[rt]["entitled"] is True, rt
+
+
+def test_entitled_tier_entitles_its_runtimes(ent):
+    en = ent.Entitlement(tier="pro", runtimes=set(ent.ALL_RUNTIMES),
+                         features=set(), grace=True, source="test")
+    assert en.entitled_runtime("claude_code") is True
+    assert en.entitled_runtime("cursor") is True
+
+
+def test_appjs_teaser_wiring():
+    """The catalog loader must use `entitled` (grace teaser) and must NOT
+    early-return when enforcement is off, while guarding hosted paying/trial
+    accounts via CLOUD_PLAN/_account. Mirrors the two-renderer-mirror rule:
+    server flag + JS consumer must move together."""
+    import os
+    appjs = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                         "clawmetry", "static", "js", "app.js")
+    src = open(appjs).read()
+    i = src.find("async function _cmLoadRuntimeCatalog")
+    assert i != -1
+    block = src[i:i + 2500]
+    assert "entitled === false" in block, "loader must consume the entitled flag"
+    assert "!cat.enforced" not in block, "loader must not bail out in grace mode"
+    assert "CLOUD_PLAN" in block and "_account" in block, (
+        "hosted paying/trial guard missing"
+    )


### PR DESCRIPTION
Implements cloud#1532. The detection + paywall machinery already existed (stat-only `_detect_runtimes_lite`, `detectedRuntimes` snapshot key, the two-path paywall card, the 'running here · Upgrade' dropdown group); what was missing is that GRACE mode reported every paid runtime as allowed so the lock affordance never rendered, anywhere, for anyone (12 paywall views in 30 days).

## What
- `Entitlement.entitled_runtime()` (grace-independent plan fact) + `entitled` flag on every `runtime_catalog()` entry. `allowed`/`locked` enforcement semantics untouched.
- `_cmLoadRuntimeCatalog` marks paid+unentitled runtimes locked even in grace; the existing dropdown groups + non-blocking two-path card take over from there. Detected-on-this-machine runtimes get the existing 'running here' label via `_cmRunningRuntimes`.
- Hosted guard: in CLOUD_MODE the teaser is suppressed for pro/starter/paid plans and active trials (the cloud container itself always resolves OSS-free, so the catalog's `entitled` cannot be trusted there).

## Verification
- 40 tests green across test_entitlements / test_entitlement_api / test_routes_runtimes / test_advertised_runtimes_match_catalogue; `node --check` clean on app.js.
- Revert-proof: the two new entitlement tests FAIL against origin/main.
- Success metric (from the issue): pro_upsell_shown / paywall_view counts in analytics_events, target 10x within 30 days as the fleet converges on 0.12.494+.

After merge: [RELEASE] -> pin bump so the hosted trial serves the new app.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)