### PR TITLE
fix(tokens): extract openclaw reasoning/thinking tokens (#2876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fix: openclaw reasoning/thinking tokens now extracted (#2876) (2026-06-10)
+- Anthropic extended-thinking sessions emit a reasoning-token share inside the per-turn `usage` object that input+output alone never account for. The openclaw adapter's usage-extraction only read input/output/cacheRead/cacheWrite, so `Session.reasoning_tokens` was always 0 and per-turn `token_count` was systematically under-reported for reasoning-capable models.
+- New `_reasoning_tokens()` helper reads any known spelling (`reasoning_tokens`, `reasoningTokens`, `thinking_tokens`, `thinkingTokens`, `thinking_input_tokens`, …), coercing to a non-negative int. Wired into `list_events()` (surfaces `reasoningTokens` in `event.extra`), `_build_spans_from_events()` (adds `tokens_reasoning` and folds it into the LLM span's `token_count`), and `list_sessions()` (populates `Session.reasoning_tokens`).
+- Verified: new tests pin the reasoning-token extraction, the helper's key-variant/garbage-input handling, and existing input/output/cache splits stay unchanged.
+
 ### Release: runtime paywall shows the real plan ladder (#2945) (2026-06-09)
 - The "Two ways to observe X" card asked users to start a trial without ever saying what the plans are. The modal now mirrors the live clawmetry.com/pricing ladder: Free $0 forever (OpenClaw + NemoClaw), Starter $9/node/mo (every supported runtime, 7-day free trial, no card), Pro $29/node/mo (alerts, budgets, loop detection, fleet), with a footnote that annual plans include the desk device and that self-hosted uses the same plans with a license key (link to /pricing).
 - Prices live in one `_cmPlanPrices` object so a reprice is a one-line change. Trial CTA and paywall telemetry wiring unchanged; guard tests assert tiers, the self-hosted mention, the pricing link, and the no-em-dash copy rule.

--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -33,6 +33,41 @@ _NEMOCLAW_CATALOG_TOOLS: frozenset = frozenset({
     "tool_call",
 })
 
+# Reasoning / extended-thinking token key variants (#2876). Anthropic
+# extended-thinking sessions emit a reasoning-token share inside the per-turn
+# usage object under one of several spellings; older code only read
+# input/output/cache keys, so Session.reasoning_tokens was always 0 and per-turn
+# token counts were under-reported for reasoning-capable models.
+_REASONING_TOKEN_KEYS: tuple = (
+    "reasoning_tokens",
+    "reasoningTokens",
+    "thinking_tokens",
+    "thinkingTokens",
+    "thinking_input_tokens",
+    "thinkingInputTokens",
+    "reasoning_output_tokens",
+    "reasoningOutputTokens",
+)
+
+
+def _reasoning_tokens(usage: dict) -> int:
+    """Return the reasoning/thinking token count from a usage dict.
+
+    Accepts any of the known key spellings (snake/camel, thinking/reasoning)
+    and coerces to a non-negative int. Returns 0 when absent or unparsable.
+    """
+    if not isinstance(usage, dict):
+        return 0
+    for k in _REASONING_TOKEN_KEYS:
+        v = usage.get(k)
+        if v is None:
+            continue
+        try:
+            return max(0, int(v))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
 
 def _d():
     """Late import to avoid circular init with dashboard module."""
@@ -329,6 +364,7 @@ class OpenClawAdapter(AgentAdapter):
                     output_tokens=int(s.get("outputTokens") or 0),
                     cache_read_tokens=int(s.get("cacheReadTokens") or 0),
                     cache_write_tokens=int(s.get("cacheWriteTokens") or 0),
+                    reasoning_tokens=_reasoning_tokens(s),
                     cost_usd=float(s["costUsd"]) if s.get("costUsd") is not None else None,
                     extra=extra,
                 )
@@ -412,6 +448,13 @@ class OpenClawAdapter(AgentAdapter):
                                         if v is not None:
                                             extra[dst] = int(v)
                                             break
+                                # Extended-thinking / reasoning tokens (#2876):
+                                # Anthropic thinking sessions emit a reasoning
+                                # token share that input+output alone omit. Surface
+                                # it so per-turn cost is not under-reported.
+                                _rt = _reasoning_tokens(usage)
+                                if _rt:
+                                    extra["reasoningTokens"] = _rt
                     except Exception:
                         pass
                 events.append(Event(
@@ -592,6 +635,10 @@ class OpenClawAdapter(AgentAdapter):
                 usage = msg.get("usage") or {}
                 tok_in = int(usage.get("input_tokens") or usage.get("inputTokens") or 0)
                 tok_out = int(usage.get("output_tokens") or usage.get("outputTokens") or 0)
+                # Reasoning/thinking tokens (#2876) are billed but not part of
+                # input/output; fold them into token_count so LLM-span cost
+                # totals are not systematically under-reported.
+                tok_reasoning = _reasoning_tokens(usage)
                 llm_sid = _sid("llm", session_id, str(raw_ts))
                 spans.append({
                     "span_id": llm_sid,
@@ -605,7 +652,8 @@ class OpenClawAdapter(AgentAdapter):
                     "model": model or None,
                     "tokens_input": tok_in or None,
                     "tokens_output": tok_out or None,
-                    "token_count": (tok_in + tok_out) or None,
+                    "tokens_reasoning": tok_reasoning or None,
+                    "token_count": (tok_in + tok_out + tok_reasoning) or None,
                 })
                 if isinstance(content, list):
                     for block in content:

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -230,6 +230,66 @@ def test_list_events_dict_message_does_not_set_content(isolated_store):
     assert events[0].content == ""
 
 
+def test_list_events_surfaces_reasoning_tokens(isolated_store):
+    """Extended-thinking / reasoning tokens land in event.extra (#2876).
+
+    Anthropic extended-thinking sessions emit a reasoning-token share in
+    the per-turn usage object that input+output alone omit. list_events()
+    must surface it as ``reasoningTokens`` so per-turn cost is not
+    under-reported for reasoning-capable models.
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-THINK",
+        "event_type": "model.completed",
+        "ts": _t.time(),
+        "model": "claude-opus-4-7",
+        "token_count": 150,
+        "data": {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-7",
+                "usage": {
+                    "input_tokens": 30,
+                    "output_tokens": 20,
+                    "thinking_input_tokens": 64,
+                },
+            },
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-THINK")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("inputTokens") == 30
+    assert ex.get("outputTokens") == 20
+    assert ex.get("reasoningTokens") == 64
+
+
+def test_reasoning_tokens_helper_key_variants():
+    """_reasoning_tokens accepts the known key spellings and is robust to
+    missing/garbage values (#2876)."""
+    from clawmetry.adapters.openclaw import _reasoning_tokens
+    assert _reasoning_tokens({"reasoning_tokens": 12}) == 12
+    assert _reasoning_tokens({"reasoningTokens": 7}) == 7
+    assert _reasoning_tokens({"thinking_tokens": 5}) == 5
+    assert _reasoning_tokens({"thinking_input_tokens": 9}) == 9
+    assert _reasoning_tokens({"reasoning_output_tokens": 3}) == 3
+    # absent / non-dict / unparsable → 0
+    assert _reasoning_tokens({"input_tokens": 10}) == 0
+    assert _reasoning_tokens({}) == 0
+    assert _reasoning_tokens(None) == 0  # type: ignore[arg-type]
+    assert _reasoning_tokens({"reasoning_tokens": "nope"}) == 0
+    # negative coerced to non-negative floor
+    assert _reasoning_tokens({"reasoning_tokens": -4}) == 0
+
+
 def test_list_events_surfaces_cache_token_split_sdk_keys(isolated_store):
     """SDK-normalized cacheRead/cacheWrite usage keys are read by list_events.
 


### PR DESCRIPTION
Closes #2876

## What
Anthropic extended-thinking sessions emit a reasoning-token share inside the per-turn `usage` object that input+output alone never account for. The openclaw adapter's usage-extraction only read `input`/`output`/`cacheRead`/`cacheWrite`, so:
- `Session.reasoning_tokens` was always **0**, and
- per-turn `token_count` was systematically **under-reported** by the reasoning portion for reasoning-capable models.

## How
- New module-level `_reasoning_tokens(usage)` helper reads any known spelling (`reasoning_tokens`, `reasoningTokens`, `thinking_tokens`, `thinkingTokens`, `thinking_input_tokens`, `thinkingInputTokens`, `reasoning_output_tokens`, `reasoningOutputTokens`), coercing to a non-negative int (0 on absent/garbage).
- Wired into three sites in `clawmetry/adapters/openclaw.py`:
  - `list_events()` — surfaces `reasoningTokens` in `event.extra` alongside the existing input/output/cache split.
  - `_build_spans_from_events()` — adds `tokens_reasoning` to the LLM span and folds it into `token_count`.
  - `list_sessions()` — populates `Session.reasoning_tokens`.

## Tests
- New: reasoning-token extraction in `list_events`, plus a helper unit test covering all key variants, missing/non-dict/unparsable input, and negative-floor handling.
- Existing input/output/cache-split tests unchanged and green (11/11 in `test_openclaw_list_events.py`).
- Pre-existing failures in `test_transcript_openclaw_shapes.py` / `test_brain_llm_call_timeline.py` were verified to fail on clean `main` as well (unrelated `routes/sessions.py` path).

Fingerprint: hgap-9f80a87994