### PR TITLE
test(e2e): expand PR_SCREENSHOT_TABS from 19 to 32 to match CANONICAL_TABS (C5)

### DIFF
--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -38,7 +38,8 @@ env:
   # Tabs to screenshot. Every name MUST match an `id="page-<name>"` in
   # clawmetry/templates/tabs/*.html and be reachable via window.switchTab().
   # See routes/* for the API endpoints each tab calls.
-  PR_SCREENSHOT_TABS: "overview,flow,brain,usage,crons,memory,security,subagents,transcripts,logs,skills,models,approvals,alerts,notifications,context,limits,clusters,history"
+  # Must stay in sync with CANONICAL_TABS in tests/test_e2e_oss_all_tabs.py.
+  PR_SCREENSHOT_TABS: "overview,flow,brain,usage,crons,memory,security,subagents,transcripts,logs,skills,models,approvals,alerts,notifications,context,limits,clusters,history,channels,dives,harness,inventory,nemoclaw,policy,selfevolve,swimlane,tool-catalog,tracing,turn-anatomy,version-impact,context-economics"
   HEAD_PORT: "8082"
   BASE_PORT: "8081"
   # Local-store fast-paths must be on so the dashboard renders the seeded


### PR DESCRIPTION
## Problem

PR #2937 expands `CANONICAL_TABS` in `tests/test_e2e_oss_all_tabs.py` from 19 to 32 tabs.

The test file carries this comment:
> Matches PR_SCREENSHOT_TABS in .github/workflows/pr-screenshots.yml
> so the Playwright gate covers the same surface as the visual-diff workflow.

`pr-screenshots.yml` was not updated in #2937, so after that PR merges the two lists drift:
- Overlay test (C5 gate): 32 tabs
- Visual-diff screenshots: 19 tabs (13 tabs never screenshotted)

Any auth-token regression on those 13 tabs would silently pass the visual-diff check -- the exact failure mode the user originally reported (2026-05-17): "gateway token not passed for OSS so it never displays other screens."

## What changed

`PR_SCREENSHOT_TABS` in `.github/workflows/pr-screenshots.yml`: added 13 tabs to match PR #2937's CANONICAL_TABS expansion.

**13 tabs added:**
`channels`, `dives`, `harness`, `inventory`, `nemoclaw`, `policy`, `selfevolve`, `swimlane`, `tool-catalog`, `tracing`, `turn-anatomy`, `version-impact`, `context-economics`

**Total:** 19 + 13 = 32 tabs. Matches CANONICAL_TABS in `tests/test_e2e_oss_all_tabs.py` exactly.

## Acceptance

After this PR and #2937 both merge: `PR_SCREENSHOT_TABS` and `CANONICAL_TABS` are identical 32-entry lists. Any future auth regression on any of the 32 tabs will be caught by both the Playwright overlay test (hard gate) and the visual-diff screenshot bot.

## Merge order

Merge #2937 first (or together). This PR is safe to merge independently -- it only adds tabs to the screenshot list and the workflow has `continue-on-error: true`.

## Tracking

vivekchand/clawmetry#2146 -- E2E Robustness epic, C5 visual-diff full coverage, fire 2026-06-09.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GURSGZNKmsY56wyyJZTM4N)_