### PR TITLE
feat(entitlement): add Entitlement.locked_runtimes() + locked_features()

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -279,6 +279,44 @@ class Entitlement:
             return False
         return feature in self.features
 
+    def locked_runtimes(self) -> tuple[str, ...]:
+        """Sorted tuple of PAID runtime ids the install currently can NOT
+        observe — the inverse view of :meth:`allows_runtime` restricted to
+        ``PAID_RUNTIMES``. Mirrors the ``locked`` flag in
+        :func:`runtime_catalog` exactly: a runtime is "locked" iff
+        ``allows_runtime`` returns ``False``.
+
+        In grace mode the gate passes everything, so the result is ``()``;
+        once enforcement is on (``CLAWMETRY_ENFORCE=1``) it returns the paid
+        runtimes the current tier (and non-expired state) does not unlock,
+        giving the UI a one-call source for a "N runtimes locked — upgrade"
+        badge without iterating ``PAID_RUNTIMES`` or re-deriving the gate.
+        Free runtimes are never reported (they can never be locked).
+        Never raises.
+        """
+        try:
+            return tuple(sorted(rt for rt in PAID_RUNTIMES if not self.allows_runtime(rt)))
+        except Exception:  # belt-and-suspenders: a flaky gate read must never crash a render
+            return ()
+
+    def locked_features(self) -> tuple[str, ...]:
+        """Sorted tuple of PAID feature keys the install does NOT unlock —
+        the inverse view of :meth:`allows_feature` restricted to
+        ``PAID_FEATURES ∪ ENTERPRISE_FEATURES``.
+
+        In grace mode every gate passes, so the result is ``()``; once
+        enforcement is on it returns the paid keys the current tier (and
+        non-expired state) does not grant, giving the UI a single source
+        for a paywall summary off ``/api/entitlement`` without re-deriving
+        feature-set membership on the frontend. Free features are never
+        reported (they can never be locked). Never raises.
+        """
+        try:
+            paid_universe = PAID_FEATURES | ENTERPRISE_FEATURES
+            return tuple(sorted(f for f in paid_universe if not self.allows_feature(f)))
+        except Exception:
+            return ()
+
     def event_retention_days(self) -> int | None:
         """Days of event history this tier may keep. ``None`` means unlimited
         / custom (Enterprise). The daemon's prune loop in ``clawmetry/sync.py``
@@ -309,6 +347,8 @@ class Entitlement:
             "free_runtimes": sorted(FREE_RUNTIMES),
             "paid_runtimes": sorted(PAID_RUNTIMES),
             "all_runtimes": sorted(ALL_RUNTIMES),
+            "locked_runtimes": list(self.locked_runtimes()),
+            "locked_features": list(self.locked_features()),
         }
 
 

--- a/tests/test_entitlement_locked_helpers.py
+++ b/tests/test_entitlement_locked_helpers.py
@@ -1,0 +1,229 @@
+"""Tests for Entitlement.locked_runtimes() / locked_features() — the inverse
+view of allows_runtime / allows_feature restricted to the paid universe.
+
+These helpers exist so the UI can render a "N runtimes locked — upgrade"
+badge off /api/entitlement in one call, without iterating PAID_RUNTIMES or
+re-deriving feature-set membership on the frontend.
+
+Invariants pinned here:
+
+* Grace mode → both helpers return empty tuples (every gate passes).
+* Enforce + OSS → every paid runtime / paid+enterprise feature is locked.
+* Enforce + Pro tier → no paid runtimes locked, only ENTERPRISE_FEATURES
+  are locked.
+* Enforce + Enterprise tier → nothing is locked.
+* Expired paid licence → paid runtimes / features collapse back to locked
+  (mirrors the ``expired`` short-circuit in ``allows_*``).
+* ``to_dict()`` exposes the two lists with stable, alphabetical ordering.
+* Free runtimes / free features are NEVER reported as locked — they cannot
+  be (they're always allowed).
+* The helpers never raise: a flaky ``allows_*`` call falls back to ``()``.
+* Grace mode is byte-for-byte gate-irrelevant: with the helpers wired in,
+  ``allows_runtime`` / ``allows_feature`` decisions are unchanged.
+"""
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement
+    off by default."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── grace mode: nothing is ever locked ────────────────────────────────────────
+
+
+def test_grace_locked_runtimes_is_empty(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.locked_runtimes() == ()
+
+
+def test_grace_locked_features_is_empty(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.locked_features() == ()
+
+
+# ── enforce + OSS: the full paid universe is locked ───────────────────────────
+
+
+def test_enforce_oss_locks_every_paid_runtime(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.grace is False
+    assert set(en.locked_runtimes()) == set(ent.PAID_RUNTIMES)
+    # No free runtime ever appears.
+    assert not (set(en.locked_runtimes()) & set(ent.FREE_RUNTIMES))
+
+
+def test_enforce_oss_locks_paid_and_enterprise_features(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    expected = ent.PAID_FEATURES | ent.ENTERPRISE_FEATURES
+    assert set(en.locked_features()) == expected
+    # No free feature ever appears.
+    assert not (set(en.locked_features()) & set(ent.FREE_FEATURES))
+
+
+# ── enforce + Pro: paid runtimes open, enterprise features still locked ───────
+
+
+def test_enforce_pro_unlocks_paid_runtimes(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    pro = ent._build(ent.TIER_PRO, "license")
+    assert pro.locked_runtimes() == ()
+
+
+def test_enforce_pro_still_locks_enterprise_features(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    pro = ent._build(ent.TIER_PRO, "license")
+    locked = set(pro.locked_features())
+    # Pro covers PAID_FEATURES but not ENTERPRISE_FEATURES.
+    assert locked == ent.ENTERPRISE_FEATURES
+    # And no free feature leaks in.
+    assert not (locked & ent.FREE_FEATURES)
+
+
+# ── enforce + Enterprise: nothing is locked ───────────────────────────────────
+
+
+def test_enforce_enterprise_locks_nothing(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent_tier = ent._build(ent.TIER_ENTERPRISE, "license")
+    assert ent_tier.locked_runtimes() == ()
+    assert ent_tier.locked_features() == ()
+
+
+# ── expired licence: paid surface collapses back to locked ────────────────────
+
+
+def test_enforce_expired_pro_locks_paid_runtimes(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    pro = ent._build(ent.TIER_PRO, "license", expiry=time.time() - 60)
+    assert pro.expired is True
+    # Expired short-circuit in allows_runtime → paid runtimes locked again.
+    assert set(pro.locked_runtimes()) == set(ent.PAID_RUNTIMES)
+
+
+def test_enforce_expired_pro_locks_paid_features(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    pro = ent._build(ent.TIER_PRO, "license", expiry=time.time() - 60)
+    assert pro.expired is True
+    expected = ent.PAID_FEATURES | ent.ENTERPRISE_FEATURES
+    assert set(pro.locked_features()) == expected
+
+
+# ── ordering + shape ──────────────────────────────────────────────────────────
+
+
+def test_locked_runtimes_is_sorted_tuple(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    result = en.locked_runtimes()
+    assert isinstance(result, tuple)
+    assert list(result) == sorted(result)
+
+
+def test_locked_features_is_sorted_tuple(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    result = en.locked_features()
+    assert isinstance(result, tuple)
+    assert list(result) == sorted(result)
+
+
+# ── to_dict wire shape ────────────────────────────────────────────────────────
+
+
+def test_to_dict_carries_locked_lists(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    d = en.to_dict()
+    assert "locked_runtimes" in d
+    assert "locked_features" in d
+    assert isinstance(d["locked_runtimes"], list)
+    assert isinstance(d["locked_features"], list)
+    assert set(d["locked_runtimes"]) == set(ent.PAID_RUNTIMES)
+    assert set(d["locked_features"]) == ent.PAID_FEATURES | ent.ENTERPRISE_FEATURES
+
+
+def test_to_dict_in_grace_has_empty_locked_lists(ent):
+    en = ent.get_entitlement(force=True)
+    d = en.to_dict()
+    assert d["locked_runtimes"] == []
+    assert d["locked_features"] == []
+
+
+# ── gate-irrelevance: the helpers don't change the decision surface ──────────
+
+
+def test_helpers_never_change_allows_decisions(ent, monkeypatch):
+    """Adding the inverse helpers must not alter what ``allows_*`` decides
+    for the same input. This is the no-behaviour-change contract."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    pro = ent._build(ent.TIER_PRO, "license")
+    # Trigger the helpers first — must not mutate any state.
+    pro.locked_runtimes()
+    pro.locked_features()
+    assert pro.allows_runtime("openclaw") is True
+    assert pro.allows_runtime("claude_code") is True
+    assert pro.allows_feature("custom_alerts") is True
+    assert pro.allows_feature("sso") is False  # Enterprise-only
+
+
+# ── never-raise contract ──────────────────────────────────────────────────────
+
+
+def test_locked_runtimes_swallows_flaky_gate(ent, monkeypatch):
+    """A raising ``allows_runtime`` (e.g. a bad subclass) must collapse the
+    helper to ``()`` rather than break a UI render."""
+    en = ent.get_entitlement(force=True)
+
+    class _Boom(ent.Entitlement):
+        def allows_runtime(self, runtime: str) -> bool:  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    boom = _Boom(
+        tier=en.tier,
+        source=en.source,
+        node_limit=en.node_limit,
+        expiry=en.expiry,
+        features=en.features,
+        runtimes=en.runtimes,
+        grace=en.grace,
+    )
+    assert boom.locked_runtimes() == ()
+
+
+def test_locked_features_swallows_flaky_gate(ent, monkeypatch):
+    en = ent.get_entitlement(force=True)
+
+    class _Boom(ent.Entitlement):
+        def allows_feature(self, feature: str) -> bool:  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    boom = _Boom(
+        tier=en.tier,
+        source=en.source,
+        node_limit=en.node_limit,
+        expiry=en.expiry,
+        features=en.features,
+        runtimes=en.runtimes,
+        grace=en.grace,
+    )
+    assert boom.locked_features() == ()


### PR DESCRIPTION
## Summary

Adds two read-only **inverse-view** helpers to `clawmetry/entitlements.py::Entitlement` so the UI can render a "N runtimes locked — upgrade" badge off `/api/entitlement` in **one call**, without iterating `PAID_RUNTIMES` / `PAID_FEATURES` on the frontend or re-deriving the gate decision in each route.

| Helper | Returns |
|--------|---------|
| `Entitlement.locked_runtimes()` | `tuple[str, ...]` — sorted ids in `PAID_RUNTIMES` for which `allows_runtime()` is `False` |
| `Entitlement.locked_features()` | `tuple[str, ...]` — sorted keys in `PAID_FEATURES ∪ ENTERPRISE_FEATURES` for which `allows_feature()` is `False` |

`to_dict()` gains `locked_runtimes` and `locked_features` list keys so `/api/entitlement` consumers can render the badge without recomputing.

## Semantics

Chosen to mirror the existing `locked` flag in `runtime_catalog()` exactly — a runtime is "locked" iff `allows_runtime()` returns `False`. That makes the helpers **grace-mode-dependent** (gate parity), so:

| Condition | `locked_runtimes()` | `locked_features()` |
|-----------|---------------------|---------------------|
| Grace (default) | `()` | `()` |
| Enforce + OSS | full `PAID_RUNTIMES` | full `PAID_FEATURES ∪ ENTERPRISE_FEATURES` |
| Enforce + Pro tier | `()` | `ENTERPRISE_FEATURES` (Pro doesn't unlock those) |
| Enforce + Enterprise tier | `()` | `()` |
| Enforce + expired Pro | full `PAID_RUNTIMES` (expired short-circuit) | full `PAID_FEATURES ∪ ENTERPRISE_FEATURES` |
| Free runtime/feature | never reported (always allowed) | never reported (always allowed) |
| Flaky subclass raising in `allows_*` | `()` (never raises) | `()` (never raises) |

The helpers are **read-only and gate-irrelevant**: they are not consulted by `allows_runtime` / `allows_feature` / `entitled_runtime`, so the grace-vs-enforce decision surface is byte-for-byte identical. Wiring this in changes **no current behaviour**.

The wire-shape addition (`locked_runtimes` / `locked_features` in `to_dict`) is purely additive — every existing key keeps its shape and ordering, so existing `/api/entitlement` consumers are unaffected.

## Why this isn't in #2925 / #2810 / #2792 / #2790 / #2727 / #2722 / #2692 / #2426

Those PRs each add a **different** axis or surface:

- **#2925** (`runtime_tier()`) — per-runtime tier *label* on the catalog rows; not an inverse view.
- **#2810** (`retention_days`) — time-window axis; doesn't address the paid-universe membership.
- **#2792** (`channel_limit` / `allows_channel_count`) — channel-count axis.
- **#2790** (`allows_retention_window`) — retention-axis gate.
- **#2727** (`days_until_expiry` / `expires_within`) — time-axis display helpers.
- **#2722** (`allows_node_count`) — node-count gate.
- **#2692** (`tier_catalog` + `/api/tiers`) — tier catalogue surface.
- **#2426** (`feature_catalog` + `/api/features`) — feature catalogue surface.

The inverse view across both axes — "which paid runtimes/features are currently locked for this install" — is the gap none of the above fills, and it is the single call the UI needs to render a paywall summary badge.

## Changes

- `clawmetry/entitlements.py` (+44 lines) — `Entitlement.locked_runtimes()` + `Entitlement.locked_features()` + two `to_dict()` keys.
- `tests/test_entitlement_locked_helpers.py` (+225 lines) — 16 tests pinning:
  - Grace → both helpers return `()`.
  - Enforce + OSS → full paid universe locked.
  - Enforce + Pro tier → no paid runtimes locked, only ENTERPRISE_FEATURES locked.
  - Enforce + Enterprise tier → nothing locked.
  - Enforce + expired Pro → paid surface collapses back to locked.
  - Sorted tuple return shape.
  - `to_dict()` exposes the lists with stable alphabetical ordering.
  - Free runtimes/features never appear in either result.
  - Helpers swallow flaky `allows_*` subclasses (never raise).
  - Gate-irrelevance: calling the helpers does not change subsequent `allows_*` decisions.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py tests/test_entitlement_locked_helpers.py` — clean.
- [x] `python3 -m ruff check clawmetry/entitlements.py tests/test_entitlement_locked_helpers.py` — All checks passed.
- [x] `python3 -m pytest tests/test_entitlement_locked_helpers.py -v` — **16 passed in 0.12s**.
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_extensions.py tests/test_license.py tests/test_license_api.py` — **71 passed**, 3 pre-existing failures in `test_license.py` (unrelated `_Resp` stub-helper bug; reproduces on `origin/main` with the change reverted).
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — clean.

## Local operator verification checklist

This agent has no access to the user's local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please complete on a real install before flipping out of draft:

1. `git fetch origin feat/entitlement-locked-helpers && git checkout feat/entitlement-locked-helpers`
2. `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/entitlements.py`
3. `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
4. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. `curl -s http://localhost:8900/api/entitlement | jq '{locked_runtimes, locked_features, grace, tier}'` — expect `locked_runtimes: []`, `locked_features: []`, `grace: true`, `tier: "oss"` on a default OSS install.
6. `CLAWMETRY_ENFORCE=1 curl -s http://localhost:8900/api/entitlement | jq '{locked_runtimes, locked_features}'` — expect the full paid universe in both arrays (10 runtimes, ~25 features).
7. Decrypt the live cloud snapshot and confirm the `/api/entitlement` response shape now exposes the two new arrays — grace mode means existing consumers see `[]`/`[]` so no client-side change is required to ship this.
8. Open the dashboard in a browser; nothing in the live UI should look different because grace mode keeps the helpers reporting empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0166JDJrZnocSiAUr2iq9eWq)_