### PR TITLE
fix(security): authenticate OTLP receivers + bound gzip/request size

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -166,6 +166,28 @@ except ImportError:
     logs_service_pb2 = None
 
 
+# Hard ceiling on a gzip-decompressed OTLP body. A few-KB gzip bomb can expand
+# to many GB and OOM the daemon (never-crash / never-hang). Cap the output and
+# reject anything larger. Override via CLAWMETRY_OTLP_MAX_DECOMPRESSED_MB.
+try:
+    _OTLP_MAX_DECOMPRESSED = int(os.environ.get("CLAWMETRY_OTLP_MAX_DECOMPRESSED_MB", "64")) * 1024 * 1024
+except (TypeError, ValueError):
+    _OTLP_MAX_DECOMPRESSED = 64 * 1024 * 1024
+
+
+def _gunzip_bounded(pb_data, limit=None):
+    """gzip-decompress with a hard output cap. Reads at most ``limit``+1 bytes
+    so a gzip bomb can never inflate into memory. Raises ValueError past the cap."""
+    import gzip as _gzip
+    import io as _io
+    limit = _OTLP_MAX_DECOMPRESSED if limit is None else limit
+    with _gzip.GzipFile(fileobj=_io.BytesIO(pb_data)) as gf:
+        out = gf.read(limit + 1)
+    if len(out) > limit:
+        raise ValueError("gzip body exceeds decompressed size limit")
+    return out
+
+
 def _otlp_decode(pb_data, proto_msg, content_encoding=None, content_type=None):
     """Decode an OTLP/HTTP request body into ``proto_msg`` and return it.
 
@@ -181,8 +203,7 @@ def _otlp_decode(pb_data, proto_msg, content_encoding=None, content_type=None):
     400, never a 500 stacktrace leak)."""
     ce = (content_encoding or "").lower()
     if "gzip" in ce:
-        import gzip as _gzip
-        pb_data = _gzip.decompress(pb_data)
+        pb_data = _gunzip_bounded(pb_data)
     ct = (content_type or "").lower()
     if "application/json" in ct or "application/x-ndjson" in ct:
         from google.protobuf import json_format as _json_format
@@ -8485,6 +8506,16 @@ app = Flask(
     template_folder=os.path.join(os.path.dirname(__file__), 'clawmetry', 'templates'),
 )
 
+# Cap request body size (DoS guard). OTLP/JSON batches and config posts are
+# small; a 32 MB ceiling lets Flask reject oversized bodies (413) before they
+# are read into memory. Override with CLAWMETRY_MAX_REQUEST_MB for large OTLP
+# exporters.
+try:
+    _MAX_REQUEST_MB = int(os.environ.get("CLAWMETRY_MAX_REQUEST_MB", "32"))
+except (TypeError, ValueError):
+    _MAX_REQUEST_MB = 32
+app.config["MAX_CONTENT_LENGTH"] = max(1, _MAX_REQUEST_MB) * 1024 * 1024
+
 # ── Cross-platform helpers ──────────────────────────────────────────────
 import platform as _platform
 
@@ -12650,8 +12681,16 @@ def _check_auth():
         return  # Gateway setup must work before auth is configured
     if request.path.startswith("/api/nodes"):
         return  # Fleet API uses its own X-Fleet-Key authentication
-    if not request.path.startswith("/api/"):
+    # OTLP ingestion (/v1/metrics|traces|logs) accepts UNTRUSTED data that lands
+    # in cost/usage analytics, so it must not be open to the network. Gate it
+    # like /api/*: loopback is trusted (zero-config local exporters keep working),
+    # non-loopback requires the gateway token. Opt out for a trusted LAN with
+    # CLAWMETRY_OTLP_ALLOW_UNAUTH=1.
+    is_otlp = request.path.startswith("/v1/")
+    if not request.path.startswith("/api/") and not is_otlp:
         return  # HTML, static, etc. are fine
+    if is_otlp and str(os.environ.get("CLAWMETRY_OTLP_ALLOW_UNAUTH", "")).strip().lower() in ("1", "true", "yes"):
+        return
     # Trust localhost — the dashboard is a local tool; auth protects remote access only
     remote = request.remote_addr or ""
     if remote in ("127.0.0.1", "::1", "localhost"):

--- a/tests/test_otlp_dos_auth.py
+++ b/tests/test_otlp_dos_auth.py
@@ -1,0 +1,86 @@
+"""Regression guard for the unauthenticated-OTLP + gzip-bomb DoS (cloud #1567).
+
+Two bugs:
+ 1. `_check_auth` early-returned for any non-`/api/` path, so the OTLP receivers
+    at `/v1/metrics|traces|logs` skipped auth entirely -> anyone reachable could
+    poison cost/usage analytics.
+ 2. `_otlp_decode` did unbounded `gzip.decompress`, and the app set no
+    `MAX_CONTENT_LENGTH` -> a few-KB gzip bomb OOM'd the daemon.
+
+Fix: gate `/v1/*` like `/api/*` (loopback trusted, non-loopback needs the
+gateway token, opt out with CLAWMETRY_OTLP_ALLOW_UNAUTH=1); bound gzip output
+with `_gunzip_bounded`; set `MAX_CONTENT_LENGTH`.
+"""
+import gzip
+import importlib
+import io
+
+import pytest
+
+dashboard = importlib.import_module("dashboard")
+
+
+def _gz(b):
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb") as f:
+        f.write(b)
+    return buf.getvalue()
+
+
+# ── gzip-bomb bound ────────────────────────────────────────────────────────
+
+def test_gunzip_bounded_allows_normal_payload():
+    raw = b"hello world " * 100
+    assert dashboard._gunzip_bounded(_gz(raw)) == raw
+
+
+def test_gunzip_bounded_rejects_bomb():
+    bomb = _gz(b"\x00" * (4 * 1024 * 1024))  # 4 MB decompressed from a tiny blob
+    with pytest.raises(ValueError):
+        dashboard._gunzip_bounded(bomb, limit=64 * 1024)  # 64 KB cap
+
+
+def test_max_content_length_is_capped():
+    mcl = dashboard.app.config.get("MAX_CONTENT_LENGTH")
+    assert mcl and mcl > 0
+
+
+# ── OTLP auth gate ─────────────────────────────────────────────────────────
+
+def test_otlp_rejected_from_network_without_token(monkeypatch):
+    monkeypatch.setattr(dashboard, "GATEWAY_TOKEN", "secret-token", raising=False)
+    monkeypatch.delenv("CLAWMETRY_OTLP_ALLOW_UNAUTH", raising=False)
+    with dashboard.app.test_request_context(
+        "/v1/metrics", method="POST", environ_base={"REMOTE_ADDR": "203.0.113.9"}
+    ):
+        rv = dashboard._check_auth()
+        assert rv is not None, "OTLP from the network must not be allowed unauthenticated"
+        assert rv[1] == 401
+
+
+def test_otlp_allowed_from_loopback(monkeypatch):
+    monkeypatch.setattr(dashboard, "GATEWAY_TOKEN", "secret-token", raising=False)
+    with dashboard.app.test_request_context(
+        "/v1/metrics", method="POST", environ_base={"REMOTE_ADDR": "127.0.0.1"}
+    ):
+        assert dashboard._check_auth() is None  # zero-config local exporters keep working
+
+
+def test_otlp_allowed_with_explicit_optout(monkeypatch):
+    monkeypatch.setattr(dashboard, "GATEWAY_TOKEN", "secret-token", raising=False)
+    monkeypatch.setenv("CLAWMETRY_OTLP_ALLOW_UNAUTH", "1")
+    with dashboard.app.test_request_context(
+        "/v1/metrics", method="POST", environ_base={"REMOTE_ADDR": "203.0.113.9"}
+    ):
+        assert dashboard._check_auth() is None
+
+
+def test_otlp_allowed_from_network_with_valid_token(monkeypatch):
+    monkeypatch.setattr(dashboard, "GATEWAY_TOKEN", "secret-token", raising=False)
+    monkeypatch.delenv("CLAWMETRY_OTLP_ALLOW_UNAUTH", raising=False)
+    with dashboard.app.test_request_context(
+        "/v1/metrics", method="POST",
+        headers={"Authorization": "Bearer secret-token"},
+        environ_base={"REMOTE_ADDR": "203.0.113.9"},
+    ):
+        assert dashboard._check_auth() is None


### PR DESCRIPTION
Tracking: vivekchand/clawmetry-cloud#1567 (filed private to avoid public 0-day disclosure). HIGH.

## The bugs
1. **Unauthenticated OTLP.** `_check_auth` early-returned for any path not starting with `/api/`. The OTLP receivers are `/v1/metrics|traces|logs`, so they skipped auth for every caller. Anyone reachable could POST arbitrary OTLP and inject fake cost/token/model/trace data into analytics + budget auto-pause. Default loopback bind mitigates, but `clawmetry --host 0.0.0.0` is documented for LAN.
2. **gzip-bomb DoS.** `_otlp_decode` did unbounded `gzip.decompress`, and the app set no `MAX_CONTENT_LENGTH`. A few-KB gzip bomb with `Content-Encoding: gzip` decompressed to multiple GB and OOM'd the daemon (violates never-crash/never-hang).

## The fix
- Gate `/v1/*` in `_check_auth` exactly like `/api/*`: loopback trusted (zero-config local exporters unchanged), non-loopback requires the gateway token. Escape hatch `CLAWMETRY_OTLP_ALLOW_UNAUTH=1` for a trusted LAN.
- `_gunzip_bounded()` reads at most `limit+1` bytes (64 MB default) and raises past the cap, so a bomb can never inflate into memory.
- `app.config["MAX_CONTENT_LENGTH"]` = 32 MB (override `CLAWMETRY_MAX_REQUEST_MB`).

## Verification
`tests/test_otlp_dos_auth.py` (7 tests): network OTLP rejected without token; loopback / opt-out / valid-token allowed; gzip bomb rejected; request cap present. Proven red on the un-fixed early-return. `ast.parse(dashboard.py)` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)