### PR TITLE
fix(security): SSRF guard on alert webhooks + loopback-only gw/config

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1599,10 +1599,56 @@ def _send_telegram_alert(message):
         pass
 
 
+def _url_safe_for_external_request(url):
+    """Return (ok, reason) for an outbound webhook URL.
+
+    SSRF guard: a user-supplied webhook must reach an EXTERNAL service, never
+    the cloud metadata endpoint (169.254.169.254), the local gateway, or any
+    internal host. Rejects non-http(s) schemes and any host that resolves to a
+    loopback / link-local / private / reserved / multicast / unspecified IP.
+    """
+    import ipaddress as _ip
+    import socket as _socket
+    from urllib.parse import urlparse as _urlparse
+    try:
+        p = _urlparse(url)
+    except Exception:
+        return False, "unparseable url"
+    if p.scheme not in ("http", "https"):
+        return False, "scheme must be http or https"
+    host = p.hostname
+    if not host:
+        return False, "missing host"
+    try:
+        port = p.port or (443 if p.scheme == "https" else 80)
+        infos = _socket.getaddrinfo(host, port, proto=_socket.IPPROTO_TCP)
+    except Exception:
+        return False, "dns resolution failed"
+    for info in infos:
+        ip = info[4][0]
+        try:
+            addr = _ip.ip_address(ip)
+        except ValueError:
+            return False, "unparseable resolved ip"
+        if (addr.is_loopback or addr.is_link_local or addr.is_private
+                or addr.is_reserved or addr.is_multicast or addr.is_unspecified):
+            return False, f"blocked internal address {ip}"
+    return True, ""
+
+
 def _send_webhook_alert(url, alert_data, payload_type="generic"):
     """Send alert to a webhook URL (generic JSON, Slack, or Discord)."""
     try:
         import urllib.request as _ur
+
+        # SSRF guard: never POST a user-configured webhook at an internal target.
+        _ok, _reason = _url_safe_for_external_request(url)
+        if not _ok:
+            try:
+                app.logger.warning("webhook alert blocked (%s): %s", _reason, url)
+            except Exception:
+                pass
+            return
 
         if payload_type == "discord":
             content = (
@@ -12683,7 +12729,13 @@ def _check_auth():
     if request.path == "/api/auth/check":
         return  # Auth check endpoint is always accessible
     if request.path == "/api/gw/config":
-        return  # Gateway setup must work before auth is configured
+        # Gateway setup must work before auth is configured, but only from
+        # loopback: this route opens an outbound connection to a caller-supplied
+        # URL, so a non-loopback caller must be authenticated (SSRF guard).
+        _r = request.remote_addr or ""
+        if _r in ("127.0.0.1", "::1", "localhost"):
+            return
+        # else fall through to the standard token check below
     if request.path.startswith("/api/nodes"):
         return  # Fleet API uses its own X-Fleet-Key authentication
     # OTLP ingestion (/v1/metrics|traces|logs) accepts UNTRUSTED data that lands

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -1,0 +1,51 @@
+"""Regression guard for SSRF via alert webhooks + the gw/config exemption
+(cloud #1574).
+
+Webhook URLs were POSTed to with no validation (blind SSRF to 169.254.169.254,
+the local gateway, internal hosts). And /api/gw/config was auth-exempt for ALL
+callers while opening an outbound connection to a caller-supplied URL.
+"""
+import importlib
+import socket
+
+dashboard = importlib.import_module("dashboard")
+
+
+def test_url_safe_rejects_internal_and_bad_schemes():
+    bad = [
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+        "http://127.0.0.1:18789/",                    # local gateway
+        "http://localhost/x",
+        "http://10.0.0.5/x",                          # private
+        "http://192.168.1.1/x",                       # private
+        "https://[::1]/x",                            # loopback v6
+        "ftp://example.com/x",                        # non-http scheme
+        "file:///etc/passwd",
+        "http://0.0.0.0/x",                           # unspecified
+    ]
+    for u in bad:
+        ok, _ = dashboard._url_safe_for_external_request(u)
+        assert ok is False, u
+
+
+def test_url_safe_allows_external(monkeypatch):
+    # Force a public resolution so the test is offline-stable.
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **k: [(2, 1, 6, "", ("93.184.216.34", 443))])
+    ok, _ = dashboard._url_safe_for_external_request("https://hooks.slack.com/services/x")
+    assert ok is True
+
+
+def test_gw_config_remote_requires_token(monkeypatch):
+    monkeypatch.setattr(dashboard, "GATEWAY_TOKEN", "tok", raising=False)
+    # Non-loopback caller: must be rejected (was unconditionally exempt).
+    with dashboard.app.test_request_context(
+        "/api/gw/config", method="POST", environ_base={"REMOTE_ADDR": "203.0.113.5"}
+    ):
+        rv = dashboard._check_auth()
+        assert rv is not None and rv[1] == 401
+    # Loopback caller: still allowed without a token (local setup).
+    with dashboard.app.test_request_context(
+        "/api/gw/config", method="POST", environ_base={"REMOTE_ADDR": "127.0.0.1"}
+    ):
+        assert dashboard._check_auth() is None


### PR DESCRIPTION
Tracking: vivekchand/clawmetry-cloud#1574 (filed private). MEDIUM.

## The bug
- Alert webhook URLs (`webhook_url`/`slack_webhook_url`/`discord_webhook_url`) were POSTed to with no scheme/IP validation -> blind SSRF to `169.254.169.254` (cloud metadata), `127.0.0.1:18789` (the gateway), internal hosts.
- `/api/gw/config` was auth-exempt for every caller while opening an outbound WS+HTTP connection to a caller-supplied `url` -> unauthenticated SSRF when bound non-loopback.

## The fix
- `_url_safe_for_external_request()` rejects non-http(s) schemes and any host resolving to a loopback/link-local/private/reserved/multicast/unspecified address; `_send_webhook_alert` refuses blocked targets (logged).
- `/api/gw/config` exemption is now loopback-only; remote callers need the gateway token (local setup still works with zero config).

## Verification
`tests/test_ssrf_guard.py` (3): metadata/gateway/private/bad-scheme rejected, external allowed, remote gw/config 401 while loopback stays free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)