### PR TITLE
fix: interceptor streaming + ~/.clawmetry sidecar + atomic 0600 config

### DIFF
--- a/clawmetry/interceptor.py
+++ b/clawmetry/interceptor.py
@@ -57,12 +57,13 @@ _EXCLUDED_HOST_DEFAULTS = frozenset([
 ])
 
 
-# Output file — in OpenClaw dir so ClawMetry sync picks it up
+# Output file — in ClawMetry's OWN data dir (~/.clawmetry), never inside the
+# agent's ~/.openclaw workspace. ClawMetry is read-only w.r.t. the agent: it
+# must not create or modify files under the agent's dir. The sync daemon tails
+# this path (and the legacy ~/.openclaw location for older installs).
 def _get_output_file() -> Path:
-    openclaw_dir = os.environ.get(
-        "CLAWMETRY_OPENCLAW_DIR", str(Path.home() / ".openclaw")
-    )
-    return Path(openclaw_dir) / "clawmetry-intercepted.jsonl"
+    cm_home = os.environ.get("CLAWMETRY_HOME", str(Path.home() / ".clawmetry"))
+    return Path(cm_home) / "intercepted.jsonl"
 
 
 # Write lock for thread-safe JSONL appends
@@ -411,12 +412,14 @@ def _patch_httpx() -> bool:
             response = _original_send(self, request, **kwargs)
             latency_ms = (time.monotonic() - t0) * 1000
 
-            # Read response body (handle streaming responses properly)
+            # Only capture the body for NON-streaming calls. For a stream=True
+            # request, reading the body here would consume the caller's stream
+            # before it can iterate (turning token-by-token streaming into a
+            # blocking wait, or raising StreamConsumed). Never touch a stream.
             resp_body = b""
             try:
-                if hasattr(response, "stream") and response.stream:
-                    response.read()
-                resp_body = response.content
+                if not kwargs.get("stream", False):
+                    resp_body = response.content
             except Exception:
                 pass
 
@@ -474,11 +477,12 @@ def _patch_httpx() -> bool:
                 response = await _original_async_send(self, request, **kwargs)
                 latency_ms = (time.monotonic() - t0) * 1000
 
+                # Non-streaming only: never consume the caller's stream (see
+                # the sync path for the full rationale).
                 resp_body = b""
                 try:
-                    if hasattr(response, "stream") and response.stream:
-                        await response.read()
-                    resp_body = response.content
+                    if not kwargs.get("stream", False):
+                        resp_body = response.content
                 except Exception:
                     pass
 
@@ -563,9 +567,12 @@ def _patch_requests() -> bool:
             response = _original_session_send(self, request, **kwargs)
             latency_ms = (time.monotonic() - t0) * 1000
 
+            # requests' .content consumes a stream=True response, so only read
+            # it for non-streaming calls (never break the caller's stream).
             resp_body = b""
             try:
-                resp_body = response.content
+                if not kwargs.get("stream", False):
+                    resp_body = response.content
             except Exception:
                 pass
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -750,8 +750,26 @@ def load_config() -> dict:
 
 def save_config(data: dict) -> None:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    CONFIG_FILE.write_text(json.dumps(data, indent=2))
-    CONFIG_FILE.chmod(0o600)
+    # config.json holds the api_key + encryption_key. Create it 0600 ATOMICALLY
+    # (O_CREAT|O_EXCL via a temp file, then os.replace) so there is never a
+    # window where it exists world-readable (write_text + a later chmod left a
+    # brief 0644 gap that another local user could read on a shared host).
+    payload = json.dumps(data, indent=2)
+    tmp = CONFIG_FILE.with_name(CONFIG_FILE.name + f".tmp.{os.getpid()}")
+    try:
+        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(fd, payload.encode("utf-8"))
+        finally:
+            os.close(fd)
+        os.replace(str(tmp), str(CONFIG_FILE))
+        CONFIG_FILE.chmod(0o600)
+    finally:
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError:
+            pass
 
 
 def load_state() -> dict:
@@ -4982,49 +5000,60 @@ def sync_voice_log_events(config: dict, state: dict, paths: dict) -> int:
 
 
 def sync_intercepted_events(config: dict, state: dict, paths: dict) -> int:
-    """Tail ~/.openclaw/clawmetry-intercepted.jsonl and ingest external_api_call
-    rows into the local DuckDB store. Uses a byte-offset cursor in state so
+    """Tail the interceptor's JSONL and ingest external_api_call rows into the
+    local DuckDB store. Reads ClawMetry's own ~/.clawmetry/intercepted.jsonl
+    plus the legacy ~/.openclaw/clawmetry-intercepted.jsonl (older interceptors
+    wrote into the agent workspace). Per-file byte-offset cursor in state so
     only new lines are read each tick. Returns the number of rows ingested."""
-    openclaw_dir = paths.get("openclaw_dir", str(Path.home() / ".openclaw"))
-    fpath = Path(openclaw_dir) / "clawmetry-intercepted.jsonl"
-    if not fpath.exists():
-        return 0
     node_id = config.get("node_id", "")
-    offset_key = "last_intercepted_offset"
-    offset = state.get(offset_key, 0)
+    cm_home = os.environ.get("CLAWMETRY_HOME", str(Path.home() / ".clawmetry"))
+    openclaw_dir = paths.get("openclaw_dir", str(Path.home() / ".openclaw"))
+    # The legacy file keeps its existing offset key so we never re-ingest it.
+    targets = [
+        (Path(cm_home) / "intercepted.jsonl", "last_intercepted_offset_cm"),
+        (Path(openclaw_dir) / "clawmetry-intercepted.jsonl", "last_intercepted_offset"),
+    ]
     ingested = 0
     try:
         from clawmetry import local_store as _ls
         store = _ls.get_store()
-        with open(fpath, "r", errors="replace") as f:
-            f.seek(0, 2)
-            size = f.tell()
-            if offset > size:
-                offset = 0
-            f.seek(offset)
-            for raw in f:
-                raw = raw.strip()
-                if not raw:
-                    continue
-                try:
-                    ev = json.loads(raw)
-                except Exception:
-                    continue
-                _evt = ev.get("type")
-                if _evt in ("external_api_call", "llm_call"):
-                    # llm_call carries cost/tokens/model + provider; normalise
-                    # provider→host so both event types share external_api_calls
-                    # (the out-loop card then shows real per-source $ spend).
-                    if _evt == "llm_call" and not ev.get("host"):
-                        ev["host"] = ev.get("provider") or ""
-                    try:
-                        store.ingest_external_call(ev, node_id)
-                        ingested += 1
-                    except Exception as _ie:
-                        log.debug("ingest_external_call failed: %s", _ie)
-            state[offset_key] = f.tell()
     except Exception as e:
-        log.warning("sync_intercepted_events error: %s", e)
+        log.warning("sync_intercepted_events store error: %s", e)
+        return 0
+    for fpath, offset_key in targets:
+        if not fpath.exists():
+            continue
+        offset = state.get(offset_key, 0)
+        try:
+            with open(fpath, "r", errors="replace") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                if offset > size:
+                    offset = 0
+                f.seek(offset)
+                for raw in f:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        ev = json.loads(raw)
+                    except Exception:
+                        continue
+                    _evt = ev.get("type")
+                    if _evt in ("external_api_call", "llm_call"):
+                        # llm_call carries cost/tokens/model + provider; normalise
+                        # provider→host so both event types share external_api_calls
+                        # (the out-loop card then shows real per-source $ spend).
+                        if _evt == "llm_call" and not ev.get("host"):
+                            ev["host"] = ev.get("provider") or ""
+                        try:
+                            store.ingest_external_call(ev, node_id)
+                            ingested += 1
+                        except Exception as _ie:
+                            log.debug("ingest_external_call failed: %s", _ie)
+                state[offset_key] = f.tell()
+        except Exception as e:
+            log.warning("sync_intercepted_events error (%s): %s", fpath, e)
     return ingested
 
 

--- a/tests/test_oss_hardening.py
+++ b/tests/test_oss_hardening.py
@@ -1,0 +1,51 @@
+"""Guards for the OSS hardening batch.
+
+- #1572 interceptor: never force-read a streaming response (would consume the
+  caller's stream); write the sidecar into ~/.clawmetry, not the agent's
+  ~/.openclaw workspace (read-only contract).
+- #1577 config.json (api_key + encryption_key) is created 0600 atomically, with
+  no brief world-readable window.
+"""
+import importlib
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+interceptor = importlib.import_module("clawmetry.interceptor")
+sync = importlib.import_module("clawmetry.sync")
+
+
+# ── interceptor ────────────────────────────────────────────────────────────
+
+def test_output_file_is_in_clawmetry_dir_not_openclaw(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_HOME", raising=False)
+    p = str(interceptor._get_output_file())
+    assert ".clawmetry" in p
+    assert ".openclaw" not in p
+
+
+def test_no_forced_stream_read_in_body_capture():
+    src = Path(interceptor.__file__).read_text()
+    # The agent-breaking forced reads must be gone...
+    assert "response.read()" not in src
+    assert "await response.read()" not in src
+    # ...replaced by a stream-kwarg guard at all three capture sites.
+    assert src.count('if not kwargs.get("stream", False):') >= 3
+
+
+# ── config.json atomic 0600 ────────────────────────────────────────────────
+
+def test_save_config_is_0600(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.json"
+    monkeypatch.setattr(sync, "CONFIG_DIR", tmp_path, raising=False)
+    monkeypatch.setattr(sync, "CONFIG_FILE", cfg, raising=False)
+    sync.save_config({"api_key": "cm_secret", "encryption_key": "k"})
+    assert cfg.exists()
+    mode = stat.S_IMODE(cfg.stat().st_mode)
+    assert mode == 0o600, oct(mode)
+    import json
+    assert json.loads(cfg.read_text())["api_key"] == "cm_secret"
+    # no leftover temp files
+    assert not list(tmp_path.glob("config.json.tmp*"))


### PR DESCRIPTION
Tracking: vivekchand/clawmetry-cloud#1572, #1577 (filed private). MEDIUM/LOW.

## #1572 interceptor (opt-in `CLAWMETRY_INTERCEPT=1`)
- **Never break the host agent's stream.** Body-capture force-read every response (`response.read()` then `.content`); for a `stream=True` request that consumes the caller's stream before it can iterate (streaming becomes a blocking wait, or `StreamConsumed`). All three sites (httpx sync/async, requests) now capture the body only when `kwargs.get("stream")` is false.
- **Stop writing into `~/.openclaw`.** The sidecar moves to ClawMetry's own `~/.clawmetry/intercepted.jsonl` (read-only contract). The daemon tails the new path **and** the legacy file (keeping its existing offset key) so older installs keep ingesting with no re-ingest.

## #1577 config.json atomic 0600
`config.json` (holds `api_key` + `encryption_key`) was `write_text` (0644) then `chmod 0600` — a brief world-readable window on a shared host. Now created 0600 atomically (`O_EXCL` temp + `os.replace`).

## Note (verify-before-assert)
The audit flagged `ProxyConfig.enabled` as a dead no-op; on current code every breaker checks `self.config.enabled`, so it IS honored. No change made.

## Verification
`tests/test_oss_hardening.py` (3): sidecar path under `~/.clawmetry`, no forced stream read + 3 stream guards, config.json mode == 0600 with no temp leftover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)