### PR TITLE
fix(cost): dedupe sibling rows in query_model_rollup (Models tab / 24h / per-model)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -1473,6 +1473,37 @@ def heal_index_corruption() -> int:
         return -1
 
 
+# Shared envelope-dedup CTE. OpenClaw v3 emits BOTH an assistant/message row AND
+# a sibling model.completed row per turn ~100ms apart, both stamped with the same
+# token_count + cost_usd, so a naive SUM over `events` doubles every billable
+# turn. Prepend `WITH ` + this fragment and read FROM deduped: the slim
+# model.completed sibling is dropped only when a richer assistant/message row
+# shares its (session_id, ts-rounded-to-second) bucket. This mirrors the
+# canonical dedup in query_sessions/query_aggregates so all cost surfaces agree.
+_DEDUPED_EVENTS_CTE = """
+  _ranked AS (
+    SELECT session_id, ts, cost_usd, token_count, model, event_type,
+      CASE event_type
+        WHEN 'assistant'       THEN 2
+        WHEN 'message'         THEN 2
+        WHEN 'model.completed' THEN 1
+        ELSE 0
+      END AS _envelope_rank,
+      CAST(EXTRACT(EPOCH FROM CAST(ts AS TIMESTAMP)) AS BIGINT) AS _ts_sec
+    FROM events
+  ),
+  _bucket_max AS (
+    SELECT session_id, _ts_sec, MAX(_envelope_rank) AS _max_rank
+    FROM _ranked GROUP BY session_id, _ts_sec
+  ),
+  deduped AS (
+    SELECT r.* FROM _ranked r
+    JOIN _bucket_max bm USING (session_id, _ts_sec)
+    WHERE NOT (r._envelope_rank = 1 AND bm._max_rank = 2)
+  )
+"""
+
+
 class LocalStore:
     """Thread-safe local event store with a background batched flusher.
 
@@ -4057,11 +4088,12 @@ class LocalStore:
             # never count as two sessions. Reconciles EXACTLY with
             # query_sessions_table (the source the OSS dashboard already trusts).
             sql_rt = f"""
-                WITH ev AS (
+                WITH {_DEDUPED_EVENTS_CTE},
+                ev AS (
                     SELECT session_id,
                            SUM(COALESCE(token_count, 0)) AS tok,
                            SUM(COALESCE(cost_usd, 0.0))  AS cost
-                    FROM events GROUP BY session_id
+                    FROM deduped GROUP BY session_id
                 ),
                 combined AS (
                     SELECT COALESCE(s.session_id, ev.session_id) AS session_id,
@@ -4099,10 +4131,11 @@ class LocalStore:
             from datetime import datetime as _dt, timezone as _tz, timedelta as _tdelta
             _since_24h = (_dt.now(_tz.utc) - _tdelta(hours=24)).isoformat()
             sql_24h = f"""
+                WITH {_DEDUPED_EVENTS_CTE}
                 SELECT {rt_case} AS runtime,
                        SUM(COALESCE(cost_usd, 0.0))    AS cost_24h,
                        SUM(COALESCE(token_count, 0))   AS tokens_24h
-                FROM events
+                FROM deduped
                 WHERE ts >= ?
                 GROUP BY 1
             """
@@ -4115,13 +4148,14 @@ class LocalStore:
                 b["tokens_24h"] = int(r[2] or 0)
             by_runtime_model: list[dict[str, Any]] = []
             sql_rtm = f"""
+                WITH {_DEDUPED_EVENTS_CTE}
                 SELECT {rt_case} AS runtime,
                        model,
                        COUNT(*) AS turns,
                        SUM(COALESCE(token_count, 0)) AS tokens,
                        SUM(COALESCE(cost_usd, 0.0)) AS cost_usd,
                        COUNT(DISTINCT session_id) AS sessions
-                FROM events
+                FROM deduped
                 WHERE model IS NOT NULL AND model <> ''
                 GROUP BY 1, 2
             """

--- a/tests/test_cost_rollup_dedup.py
+++ b/tests/test_cost_rollup_dedup.py
@@ -1,0 +1,86 @@
+"""Regression guard for cost double-count in query_model_rollup (cloud #1570).
+
+OpenClaw v3 emits BOTH an `assistant` row AND a sibling `model.completed` row
+per billable turn, same second, same cost+tokens. The rollup's ev CTE, 24h
+slice, and per-(runtime,model) query summed raw `events`, doubling every turn on
+the cloud Models tab, the 24h spend columns, and the per-model rollup. They now
+read from the shared envelope-dedup CTE.
+
+Two turns ($1.00/100 tok and $2.00/200 tok), each as an assistant+model.completed
+pair, must total $3.00 / 300 tok / 2 turns, never $6.00 / 600 / 4.
+"""
+import datetime as _dt
+import importlib
+import time
+
+import pytest
+
+NODE_ID = "node-dedup-test"
+SESSION_ID = "sess-dedup-0001"
+MODEL = "claude-opus-4-8"
+
+
+def _ts(seconds_ago):
+    now = _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0)
+    return (now - _dt.timedelta(seconds=seconds_ago)).isoformat().replace("+00:00", "Z")
+
+
+def _ev(ev_id, et, cost, tokens, secs):
+    return {
+        "id": ev_id, "node_id": NODE_ID, "agent_type": "openclaw",
+        "agent_id": "main", "session_id": SESSION_ID,
+        "event_type": et, "ts": _ts(secs),
+        "model": MODEL, "provider": "anthropic",
+        "token_count": tokens, "cost_usd": cost, "data": {},
+    }
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.get_store()
+    # Two turns, each an assistant + sibling model.completed (same second).
+    s.ingest(_ev("a1", "assistant", 1.00, 100, 10))
+    s.ingest(_ev("m1", "model.completed", 1.00, 100, 10))
+    s.ingest(_ev("a2", "assistant", 2.00, 200, 5))
+    s.ingest(_ev("m2", "model.completed", 2.00, 200, 5))
+    s._flush_now()
+    deadline = time.monotonic() + 3.0
+    flushed = 0
+    while time.monotonic() < deadline:
+        row = s._fetch("SELECT COUNT(*) FROM events", [])
+        flushed = row[0][0] if row and row[0] else 0
+        if flushed >= 4:
+            break
+        time.sleep(0.02)
+    if flushed < 4:
+        pytest.skip("no local DuckDB writer (a daemon holds the lock); this runs "
+                    "in CI where get_store() opens a real writer")
+    yield s
+    try:
+        s.stop(flush=True)
+    except Exception:
+        pass
+    try:
+        ls._reset_singleton_for_tests()
+    except Exception:
+        pass
+
+
+def test_model_rollup_dedupes_sibling(store):
+    rb = store.query_model_rollup()
+    oc = (rb.get("by_runtime") or {}).get("openclaw") or {}
+    assert abs(oc.get("cost_usd", 0) - 3.0) < 1e-6, oc           # not 6.0
+    assert oc.get("tokens") == 300, oc                            # not 600
+    assert abs(oc.get("cost_24h_usd", 0) - 3.0) < 1e-6, oc        # 24h, not 6.0
+    assert oc.get("tokens_24h") == 300, oc
+
+    brm = [r for r in (rb.get("by_runtime_model") or []) if r.get("model") == MODEL]
+    assert brm, rb.get("by_runtime_model")
+    assert brm[0]["turns"] == 2, brm                              # not 4
+    assert abs(brm[0]["cost_usd"] - 3.0) < 1e-6, brm
+    assert brm[0]["tokens"] == 300, brm


### PR DESCRIPTION
Tracking: vivekchand/clawmetry-cloud#1570 (filed private). HIGH (cost accuracy).

## The bug
OpenClaw v3 emits BOTH an `assistant`/`message` row AND a sibling `model.completed` row per billable turn (same second, same cost+tokens). `query_model_rollup` summed raw `events` in three spots, **doubling** every turn on the cloud Models tab, the rolling 24h spend columns, and the per-(runtime,model) rollup — while the Cost tab (already deduped via `query_aggregates`) showed the correct number. Three cost surfaces, two answers.

## The fix
New shared `_DEDUPED_EVENTS_CTE` (mirrors the canonical dedup in `query_sessions`/`query_aggregates`): drops the slim `model.completed` sibling when a richer row shares its `(session_id, ts-second)` bucket. The `ev` CTE, the 24h slice, and the per-model query now read `FROM deduped`.

## Verification
- Direct DuckDB twin-row check: naive `6.0/600/4` → deduped `3.0/300/2`.
- `tests/test_cost_rollup_dedup.py`: two turns ($1/100 + $2/200, each as an assistant+model.completed pair) total $3.00 / 300 tok / 2 turns across `by_runtime`, the 24h fields, and `by_runtime_model`. Runs in CI; skips locally when a daemon holds the writer lock.

## Remaining (same issue)
`query_sessions_table` (sessions list / device summary) uses correlated event-sum subqueries with the same doubling — tracked as the follow-up part of #1570. This PR fixes the primary visible 2x surfaces (Models / 24h / per-model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)