### PR TITLE
fix(cost): per-runtime Top Sessions + sessions-table dedup + pricing $0/namespace

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -7322,20 +7322,39 @@ class LocalStore:
         # the list but "0 messages" / "2 messages" in the detail page.
         renderable_in = _sql_in_clause(_RENDERABLE_EVENT_TYPES)
         sql = f"""
+            WITH _ev_ranked AS (
+                SELECT session_id, agent_type, token_count, cost_usd,
+                    CASE event_type
+                        WHEN 'assistant'       THEN 2
+                        WHEN 'message'         THEN 2
+                        WHEN 'model.completed' THEN 1
+                        ELSE 0
+                    END AS _er,
+                    CAST(EXTRACT(EPOCH FROM CAST(ts AS TIMESTAMP)) AS BIGINT) AS _tsec
+                FROM events
+            ),
+            _ev_bmax AS (
+                SELECT session_id, _tsec, MAX(_er) AS _mr
+                FROM _ev_ranked GROUP BY session_id, _tsec
+            ),
+            _ev_agg AS (
+                -- Deduped per (session, agent_type): drop the slim
+                -- model.completed sibling when a richer assistant/message row
+                -- shares its (session, ts-second) bucket, so the events bridge
+                -- below does not double cost/tokens (the same envelope-dedup as
+                -- query_aggregates / query_model_rollup).
+                SELECT r.session_id, r.agent_type,
+                       SUM(r.token_count) AS tok,
+                       SUM(r.cost_usd)    AS cost
+                FROM _ev_ranked r
+                JOIN _ev_bmax bm USING (session_id, _tsec)
+                WHERE NOT (r._er = 1 AND bm._mr = 2)
+                GROUP BY r.session_id, r.agent_type
+            )
             SELECT s.agent_type, s.session_id, s.agent_id, s.title, s.started_at,
                    s.last_active_at, s.ended_at, s.status,
-                   GREATEST(
-                       COALESCE(s.total_tokens, 0),
-                       COALESCE((SELECT SUM(e.token_count) FROM events e
-                                  WHERE e.session_id = s.session_id
-                                    AND e.agent_type  = s.agent_type), 0)
-                   ) AS total_tokens,
-                   GREATEST(
-                       COALESCE(s.cost_usd, 0.0),
-                       COALESCE((SELECT SUM(e.cost_usd) FROM events e
-                                  WHERE e.session_id = s.session_id
-                                    AND e.agent_type  = s.agent_type), 0.0)
-                   ) AS cost_usd,
+                   GREATEST(COALESCE(s.total_tokens, 0), COALESCE(ea.tok, 0))    AS total_tokens,
+                   GREATEST(COALESCE(s.cost_usd, 0.0),   COALESCE(ea.cost, 0.0)) AS cost_usd,
                    GREATEST(
                        COALESCE(s.message_count, 0),
                        (SELECT COUNT(*) FROM events e
@@ -7345,6 +7364,8 @@ class LocalStore:
                    ) AS message_count,
                    s.metadata
             FROM sessions s
+            LEFT JOIN _ev_agg ea
+                   ON ea.session_id = s.session_id AND ea.agent_type = s.agent_type
             {where}
             ORDER BY COALESCE(s.last_active_at, s.started_at) DESC NULLS LAST
             LIMIT ?

--- a/clawmetry/providers_pricing.py
+++ b/clawmetry/providers_pricing.py
@@ -167,6 +167,19 @@ def _get_rates(provider: str, model: str) -> tuple[float, float]:
         prov_lower = "gemini"
 
     if model:
+        # Strip a leading provider namespace so OpenRouter ids
+        # ("anthropic/claude-opus-4-1") and Bedrock ids
+        # ("us.anthropic.claude-opus-4-1") match the bare-name overrides instead
+        # of falling to the provider baseline (a ~5x undercount on namespaced
+        # Claude/GPT, the bulk of real spend).
+        match_model = model_lower
+        if "/" in match_model:
+            match_model = match_model.split("/", 1)[1]
+        for _vendor in ("anthropic.", "amazon.", "meta.", "mistral.", "cohere.", "google."):
+            _idx = match_model.find(_vendor)
+            if _idx != -1:
+                match_model = match_model[_idx + len(_vendor):]
+                break
         # Longest matching prefix wins, so a specific current-gen key
         # ("claude-opus-4-8") beats the shorter family key ("claude-opus-4")
         # regardless of dict order. Plain first-match silently mispriced every
@@ -174,7 +187,7 @@ def _get_rates(provider: str, model: str) -> tuple[float, float]:
         best_rates = None
         best_len = -1
         for (prov, prefix), rates in MODEL_OVERRIDES.items():
-            if prov == prov_lower and model_lower.startswith(prefix.lower()):
+            if prov == prov_lower and match_model.startswith(prefix.lower()):
                 if len(prefix) > best_len:
                     best_len = len(prefix)
                     best_rates = rates
@@ -192,8 +205,14 @@ def _get_rates(provider: str, model: str) -> tuple[float, float]:
 # #2049: self-hosted / local model name hints. Routed to the "local" provider
 # so _get_rates returns 0 (the user pays for hardware, not per token) instead
 # of the conservative unknown-provider default.
+# Self-hosted model name hints -> "local" provider (zero per-token cost). Only
+# families that are overwhelmingly run locally (via ollama/lmstudio/etc.). NOT
+# mistral/mixtral/qwen/deepseek: those have hosted paid APIs, so a bare name is
+# routed to its provider (mistral) or the conservative non-zero default
+# (qwen/deepseek) rather than silently priced at $0. A genuinely local instance
+# should carry an explicit local prefix (e.g. "ollama/qwen2.5") to be free.
 _LOCAL_MODEL_HINTS = (
-    "llama", "qwen", "mistral", "mixtral", "deepseek", "phi", "gemma", "codellama",
+    "llama", "phi", "gemma", "codellama",
 )
 
 # Anthropic prompt-cache multipliers, relative to the input rate:
@@ -227,6 +246,11 @@ def provider_for_model(model: str) -> str:
         return "google"
     if "grok" in m:
         return "xai"
+    # Mistral's hosted family (mistral-large/small/medium, mixtral, codestral)
+    # has real per-token rates in the pricing table; route it instead of
+    # treating it as free/local.
+    if "mistral" in m or "mixtral" in m or "codestral" in m:
+        return "mistral"
     return ""
 
 

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -361,7 +361,7 @@ def _try_local_store_usage(runtime: Optional[str] = None):
         "modelBilling": [],
         "billingSummary": {},
         "sessionCosts": {},
-        "sessions": _ls_top_sessions_by_cost(limit=20),
+        "sessions": _ls_top_sessions_by_cost(limit=20, runtime=runtime),
         "anomalies": [],
         "anomalySessionIds": [],
         "trend": {},
@@ -369,17 +369,27 @@ def _try_local_store_usage(runtime: Optional[str] = None):
     }
 
 
-def _ls_top_sessions_by_cost(limit=20):
+def _ls_top_sessions_by_cost(limit=20, runtime=None):
     """Issue #68 — top-N sessions by total cost. Sources rows from the
     DuckDB ``events`` table aggregated per session, joined back to a
     sample event for the model column. Returns ``[]`` on any failure so
-    the caller can drop the key silently."""
+    the caller can drop the key silently.
+
+    When ``runtime`` is set, scope to that runtime (session-id prefix) so the
+    Cost tab's "Top Sessions" honours the runtime switcher instead of leaking
+    node-wide rows under a specific runtime (per-runtime honesty gate)."""
     try:
         sessions = _ls_call("query_sessions", limit=500)
     except Exception:
         sessions = None
     if not sessions:
         return []
+    if runtime:
+        _rt = str(runtime).lower()
+        sessions = [s for s in sessions
+                    if _runtime_of(s.get("session_id") or "") == _rt]
+        if not sessions:
+            return []
     # Sort by cost desc and take top-N before the model lookup so we
     # avoid scanning events for hundreds of cheap sessions.
     ranked = sorted(

--- a/tests/test_cost_cluster.py
+++ b/tests/test_cost_cluster.py
@@ -1,0 +1,91 @@
+"""Guards for the cost cluster:
+- #1571 per-runtime leak: Cost-tab "Top Sessions" must scope to the runtime.
+- #1570 tail: query_sessions_table must not double-count sibling rows.
+"""
+import datetime as _dt
+import importlib
+import time
+
+import pytest
+
+usage = importlib.import_module("routes.usage")
+
+
+# ── #1571 Top Sessions by Cost honours the runtime switcher ────────────────
+
+def test_top_sessions_runtime_filter(monkeypatch):
+    def fake_ls_call(method, **kw):
+        if method == "query_sessions":
+            return [
+                {"session_id": "claude_code:aaa", "cost_usd": 5.0},
+                {"session_id": "plain-openclaw-bbb", "cost_usd": 9.0},
+                {"session_id": "qwen_code:ccc", "cost_usd": 3.0},
+            ]
+        if method == "query_events":
+            return [{"model": "m"}]
+        return []
+    monkeypatch.setattr(usage, "_ls_call", fake_ls_call)
+
+    only_cc = usage._ls_top_sessions_by_cost(limit=20, runtime="claude_code")
+    assert [r["session_id"] for r in only_cc] == ["claude_code:aaa"]
+
+    only_oc = usage._ls_top_sessions_by_cost(limit=20, runtime="openclaw")
+    assert [r["session_id"] for r in only_oc] == ["plain-openclaw-bbb"]
+
+    node_wide = usage._ls_top_sessions_by_cost(limit=20)
+    assert len(node_wide) == 3
+
+
+# ── #1570 tail: query_sessions_table dedupes sibling rows ──────────────────
+
+def _ts(secs):
+    now = _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0)
+    return (now - _dt.timedelta(seconds=secs)).isoformat().replace("+00:00", "Z")
+
+
+def _ev(eid, et, cost, tok, secs, sid):
+    return {"id": eid, "node_id": "n", "agent_type": "openclaw", "agent_id": "main",
+            "session_id": sid, "event_type": et, "ts": _ts(secs),
+            "token_count": tok, "cost_usd": cost, "data": {}}
+
+
+def test_sessions_table_dedupes_siblings(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    s = ls.get_store()
+    sid = "sess-st-0001"
+    try:
+        s.upsert_session({"session_id": sid, "agent_type": "openclaw",
+                          "total_tokens": 0, "cost_usd": 0.0})
+        s.ingest(_ev("a1", "assistant", 1.0, 100, 10, sid))
+        s.ingest(_ev("m1", "model.completed", 1.0, 100, 10, sid))
+        s.ingest(_ev("a2", "assistant", 2.0, 200, 5, sid))
+        s.ingest(_ev("m2", "model.completed", 2.0, 200, 5, sid))
+        s._flush_now()
+        deadline = time.monotonic() + 3.0
+        n = 0
+        while time.monotonic() < deadline:
+            row = s._fetch("SELECT COUNT(*) FROM events", [])
+            n = row[0][0] if row and row[0] else 0
+            if n >= 4:
+                break
+            time.sleep(0.02)
+        if n < 4:
+            pytest.skip("no local DuckDB writer (daemon holds the lock); CI covers this")
+        rows = s.query_sessions_table(limit=50)
+        mine = [r for r in rows if r["session_id"] == sid]
+        assert mine, rows
+        assert abs(mine[0]["cost_usd"] - 3.0) < 1e-6, mine          # not 6.0
+        assert mine[0]["total_tokens"] == 300, mine                 # not 600
+    finally:
+        try:
+            s.stop(flush=True)
+        except Exception:
+            pass
+        try:
+            ls._reset_singleton_for_tests()
+        except Exception:
+            pass

--- a/tests/test_pricing_accuracy.py
+++ b/tests/test_pricing_accuracy.py
@@ -1,0 +1,43 @@
+"""Regression guard for pricing $0 / namespace drift (cloud #1576).
+
+- Bare family names mistral/qwen/deepseek were routed to the "local" provider
+  ($0) even for hosted API usage (qwen_code is a paid runtime that read $0).
+- MODEL_OVERRIDES matched startswith-only, so namespaced ids
+  (anthropic/claude-opus-4-1 via OpenRouter, us.anthropic.claude-... via Bedrock)
+  missed every override and fell to the $3/$15 baseline (a ~5x undercount).
+"""
+import importlib
+
+pp = importlib.import_module("clawmetry.providers_pricing")
+
+
+def _rates(prov, model):
+    return pp._get_rates(prov, model)
+
+
+def test_mistral_routes_to_provider_not_local():
+    assert pp.provider_for_model("mistral-large-latest") == "mistral"
+    assert _rates("mistral", "mistral-large-latest")[0] > 0
+
+
+def test_namespaced_claude_matches_bare_override():
+    bare = _rates("anthropic", "claude-opus-4-1")
+    openrouter = _rates("anthropic", "anthropic/claude-opus-4-1")
+    bedrock = _rates("anthropic", "us.anthropic.claude-opus-4-1-20250805-v1:0")
+    assert bare == openrouter == bedrock, (bare, openrouter, bedrock)
+    # and it is the real opus rate, not the $3/$15 anthropic baseline
+    assert bare[0] > 3.0, bare
+
+
+def test_hosted_qwen_deepseek_not_zero():
+    for name in ("qwen-max", "deepseek-chat"):
+        assert pp.provider_for_model(name) != "local", name
+        prov = pp.provider_for_model(name) or ""
+        inp, out = _rates(prov, name)
+        assert inp > 0 and out > 0, (name, inp, out)
+
+
+def test_genuine_local_still_free():
+    assert pp.provider_for_model("ollama/llama3.1") == "local"
+    assert pp.provider_for_model("llama3.1") == "local"
+    assert _rates("local", "llama3.1") == (0.0, 0.0)


### PR DESCRIPTION
Tracking: vivekchand/clawmetry-cloud#1571, #1570 (tail), #1576. HIGH/MED (cost accuracy).

## #1571 per-runtime honesty
Cost tab "Top Sessions by Cost" showed node-wide rows under a specific runtime. `_ls_top_sessions_by_cost` now takes `runtime` (already in scope) and scopes by session-id prefix.

## #1570 tail (query_sessions_table)
The sessions list + device summary doubled cost/tokens via two correlated raw-events `SUM` subqueries (the v3 assistant + model.completed sibling pair). Rewritten to LEFT JOIN a deduped per-(session, agent_type) aggregate. DuckDB-verified `600/6.0 -> 300/3.0`.

## #1576 pricing
- Bare `mistral`/`qwen`/`deepseek` were `$0` (routed to "local") even for hosted API usage (`qwen_code` is a paid runtime). Now `mistral` -> its provider (real $2/$6), `qwen`/`deepseek` -> conservative non-zero, `llama`/`gemma`/`phi` stay local-free.
- `MODEL_OVERRIDES` now strips a provider namespace so `anthropic/claude-opus-4-1` (OpenRouter) and `us.anthropic.claude-...` (Bedrock) match their override (real $15/$75) instead of the `$3/$15` baseline — a ~5x Claude undercount.

## Verification
`tests/test_cost_cluster.py` + `tests/test_pricing_accuracy.py` (5 pass, 1 CI-only skip locally). Direct-DuckDB checks for both dedup rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)