### PR TITLE
feat(cli): add `clawmetry tier` — scriptable entitlement read-out

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2847,6 +2847,81 @@ def _cmd_license(args) -> None:
         print("  E2E:         🔒 verified offline")
 
 
+def _cmd_tier(args) -> None:
+    """clawmetry tier — print the resolved open-core entitlement.
+
+    Read-only, side-effect free. Useful for scripting (``clawmetry tier --json
+    | jq -r .tier``) and for the "what tier am I on?" diagnostic that's
+    cheaper than the full ``clawmetry status`` block. Never raises — on any
+    resolution error it falls back to the OSS-free shape so a shell wrapper
+    always sees a valid response.
+
+    Output:
+      default — compact human-readable block matching the project style
+      --json  — :func:`Entitlement.to_dict` serialized (indent=2 for piping
+                to jq / direct viewing)
+    """
+    import json as _json
+
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        info = ent.to_dict()
+    except Exception as exc:
+        # The resolver itself never raises, but a broken install (missing dep,
+        # corrupt module) could. Match the never-crash contract — log the
+        # warning to stderr and emit the OSS-free fallback so scripts keep
+        # working.
+        print(f"⚠️  tier resolution failed: {exc}", file=sys.stderr)
+        info = {
+            "tier": "oss",
+            "source": "oss",
+            "node_limit": 1,
+            "expiry": None,
+            "expired": False,
+            "is_paid": False,
+            "grace": True,
+            "enforced": False,
+            "runtimes": ["nemoclaw", "openclaw"],
+            "features": [],
+            "free_runtimes": ["nemoclaw", "openclaw"],
+            "paid_runtimes": [],
+            "all_runtimes": ["nemoclaw", "openclaw"],
+        }
+
+    if getattr(args, "as_json", False):
+        print(_json.dumps(info, indent=2, sort_keys=True))
+        return
+
+    tier = str(info.get("tier", "oss")).lower()
+    source = str(info.get("source", "oss"))
+    grace = bool(info.get("grace", True))
+    runtimes = list(info.get("runtimes") or [])
+    all_runtimes = list(info.get("all_runtimes") or [])
+    locked = [r for r in all_runtimes if r not in set(runtimes)]
+    features = list(info.get("features") or [])
+
+    tier_label = "OSS (free)" if tier == "oss" else tier.replace("_", " ").title()
+    mode = "🟡 grace  (set CLAWMETRY_ENFORCE=1 to enforce)" if grace else "🔒 enforced"
+
+    print("ClawMetry Tier\n" + "─" * 40)
+    print(f"  Tier:        {tier_label}")
+    print(f"  Source:      {source}")
+    print(f"  Mode:        {mode}")
+    expiry = info.get("expiry")
+    if expiry:
+        expired = "expired" if info.get("expired") else "valid"
+        print(f"  Expiry:      {int(expiry)} ({expired})")
+    if info.get("node_limit") and info["node_limit"] != 1:
+        print(f"  Node limit:  {info['node_limit']}")
+    if runtimes:
+        print(f"  Runtimes:    {', '.join(runtimes)}")
+    if locked:
+        print(f"  Locked:      {', '.join(locked)}")
+    print(f"  Features:    {len(features)} unlocked")
+
+
 def _cmd_verify_integrity(args) -> None:
     """clawmetry verify-integrity — walk the hash chain and report validity."""
     from clawmetry.local_store import get_store
@@ -3254,6 +3329,18 @@ def main() -> None:
         help="License key (CLAW1.…) — required for 'activate'",
     )
 
+    # tier — print the resolved open-core entitlement (scriptable)
+    p_tier = sub.add_parser(
+        "tier",
+        help="Print the resolved open-core entitlement (tier, runtimes, features)",
+    )
+    p_tier.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit the full Entitlement.to_dict() as JSON (jq-friendly)",
+    )
+
     # verify-integrity — walk hash chain and report validity (Issue #2200)
     p_verify = sub.add_parser(
         "verify-integrity",
@@ -3282,6 +3369,7 @@ def main() -> None:
         "uninstall",
         "activate",
         "license",
+        "tier",
         "verify-integrity",
         "nemoclaw-daemons",
     )
@@ -3317,6 +3405,8 @@ def main() -> None:
             _cmd_activate(args)
         elif args.cmd == "license":
             _cmd_license(args)
+        elif args.cmd == "tier":
+            _cmd_tier(args)
         elif args.cmd == "verify-integrity":
             _cmd_verify_integrity(args)
         elif args.cmd == "nemoclaw-daemons":

--- a/tests/test_tier_cli.py
+++ b/tests/test_tier_cli.py
@@ -1,0 +1,133 @@
+"""Tests for ``clawmetry tier`` — the scriptable entitlement read-out.
+
+The CLI subcommand is a thin shell around :func:`clawmetry.entitlements.get_entitlement`,
+so these tests pin the *contract* surface:
+
+* a default (no-flag) invocation prints a human-readable block,
+* ``--json`` emits parseable JSON whose top-level keys mirror
+  ``Entitlement.to_dict()``,
+* the command never raises — a broken resolver still produces a usable
+  OSS-free fallback so shell wrappers see a valid response,
+* the subparser is wired and ``tier`` is in the dispatcher's allowlist.
+
+It does not assert specific tier *values* beyond OSS-free, because the
+resolver's tier set is the domain of ``tests/test_entitlements.py`` and
+other parallel PRs are extending it.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import clawmetry.cli as cli
+
+
+@pytest.fixture
+def grace_oss(monkeypatch, tmp_path):
+    """Force a clean OSS-free / grace-mode resolver across the test.
+
+    Mirrors the fixture in ``tests/test_entitlements.py``: blow away any
+    inherited license / cloud plan by repointing ``$HOME`` at an empty dir,
+    drop ``CLAWMETRY_ENFORCE`` and reload :mod:`clawmetry.entitlements` so its
+    expanded paths use the patched home. The cache is invalidated on entry
+    and exit so neighbouring tests can't poison this one.
+    """
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── plain-text mode ──────────────────────────────────────────────────────────
+
+
+def test_cmd_tier_plain_output(grace_oss, capsys):
+    """Default output is the human-readable block used by ``clawmetry tier``."""
+    cli._cmd_tier(SimpleNamespace(as_json=False))
+    out = capsys.readouterr().out
+    assert "ClawMetry Tier" in out
+    assert "Tier:" in out
+    assert "Mode:" in out
+    # OSS-free + grace is the headline default-install state.
+    assert "OSS" in out
+    assert "grace" in out
+
+
+def test_cmd_tier_plain_lists_free_runtimes(grace_oss, capsys):
+    """The Runtimes line surfaces every free runtime in the catalog."""
+    cli._cmd_tier(SimpleNamespace(as_json=False))
+    out = capsys.readouterr().out
+    for free_rt in grace_oss.FREE_RUNTIMES:
+        assert free_rt in out
+
+
+# ── --json mode ──────────────────────────────────────────────────────────────
+
+
+def test_cmd_tier_json_is_parseable(grace_oss, capsys):
+    """``clawmetry tier --json`` emits the full Entitlement.to_dict()."""
+    cli._cmd_tier(SimpleNamespace(as_json=True))
+    out = capsys.readouterr().out
+    doc = json.loads(out)
+    # Cover the keys the resolver's contract has *always* exposed; new keys
+    # added by parallel PRs (retention_days, locked_*, …) are not asserted
+    # here so this test does not fight them.
+    for key in ("tier", "source", "grace", "enforced", "runtimes", "features"):
+        assert key in doc, f"missing key in --json output: {key!r}"
+    assert doc["tier"] == grace_oss.TIER_OSS
+    assert doc["grace"] is True
+    assert doc["enforced"] is False
+    # Free runtimes show up unconditionally; paid runtimes show up too while
+    # grace is on (the grace contract: nothing disappears pre-enforce).
+    assert set(grace_oss.FREE_RUNTIMES).issubset(set(doc["runtimes"]))
+
+
+def test_cmd_tier_json_never_raises_on_resolver_error(monkeypatch, capsys):
+    """If the resolver explodes (broken install), the command still emits a
+    valid OSS-free JSON document so a piped shell wrapper keeps working."""
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("entitlement resolver exploded")
+
+    monkeypatch.setattr("clawmetry.entitlements.get_entitlement", _boom)
+    cli._cmd_tier(SimpleNamespace(as_json=True))
+    out = capsys.readouterr().out
+    doc = json.loads(out)
+    assert doc["tier"] == "oss"
+    assert doc["grace"] is True
+
+
+# ── subparser wiring ─────────────────────────────────────────────────────────
+
+
+def test_tier_subcommand_is_registered(monkeypatch):
+    """``parser.parse_args(['tier'])`` succeeds (subparser exists + the
+    handler is dispatchable). We exercise the parser-construction path that
+    ``main()`` uses without actually running the dashboard fallback."""
+    # Rebuild the same parser shape main() builds. The exact construction is
+    # internal to main(), so we just sanity-check that ``--help`` lists tier.
+    monkeypatch.setattr(sys, "argv", ["clawmetry", "tier", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert exc.value.code == 0
+
+
+def test_tier_json_flag_is_accepted(monkeypatch, capsys, grace_oss):
+    """``clawmetry tier --json`` reaches ``_cmd_tier`` and prints JSON.
+
+    We swap ``argv`` and let ``main()`` route to the dispatcher; an empty
+    capsys means routing dropped the command on the floor.
+    """
+    monkeypatch.setattr(sys, "argv", ["clawmetry", "tier", "--json"])
+    cli.main()
+    out = capsys.readouterr().out
+    doc = json.loads(out)
+    assert doc["tier"] == grace_oss.TIER_OSS


### PR DESCRIPTION
## Summary

A read-only CLI subcommand that prints the resolved open-core entitlement so operators and shell wrappers can answer **"what tier is this install on"** without parsing the heavier `clawmetry status` block or curling `/api/entitlement` against a running daemon.

```
$ clawmetry tier
ClawMetry Tier
────────────────────────────────────────
  Tier:        OSS (free)
  Source:      oss
  Mode:        🟡 grace  (set CLAWMETRY_ENFORCE=1 to enforce)
  Runtimes:    nemoclaw, openclaw
  Locked:      aider, claude_code, codex, cursor, goose, hermes, nanoclaw, opencode, picoclaw, qwen_code
  Features:    12 unlocked

$ clawmetry tier --json | jq -r .tier
oss
```

- `clawmetry tier` — human-readable block: tier, source, mode (grace vs enforced), unlocked + locked runtimes, feature count.
- `clawmetry tier --json` — full `Entitlement.to_dict()` as indent=2 JSON, jq-friendly.

The handler reads through `clawmetry.entitlements.get_entitlement()` — the single source of truth — and never re-derives tier logic locally, so it stays correct as the seven parallel entitlement-helper PRs land (`#2727`, `#2790`, `#2792`, `#2810`, `#2925`, `#2955`, `#2968`). Falls back to an OSS-free shape on any resolver error to honour the never-raise contract in `CLAUDE.md`.

Behaviour-neutral in grace mode: this is a diagnostic, not a gate. No existing route, no entitlement logic, and no daemon path is touched.

## Files touched

- `clawmetry/cli.py` — new `_cmd_tier()` handler, `tier` subparser registration, dispatcher entry. Sits between `license` and `verify-integrity`.
- `tests/test_tier_cli.py` (new, 6 tests) — pins plain-text + JSON output contracts, the never-raise fallback when the resolver explodes, and the subparser wiring.

## Why this and why now

The 7 parallel draft PRs are all extending `clawmetry/entitlements.py` and `routes/entitlement.py`. A CLI surface lives in `clawmetry/cli.py` and a brand-new test file, so this PR collides with none of them and gives operators something they can wire into shell scripts today.

## Conventions

- Snake_case handler (`_cmd_tier`), matches existing `_cmd_license` / `_cmd_status` style.
- No new dependencies; only stdlib + the existing `clawmetry.entitlements` module.
- Read-only, never-raise, graceful fallback on resolver error (logged warning, OSS-free shape).
- Subparser registered next to `license` so `clawmetry --help` groups them.

## Tests

```
$ python -m pytest tests/test_tier_cli.py -q
......                                                                   [100%]
6 passed in 0.24s
```

Existing entitlement + license + CLI suites all still pass (one pre-existing failure in `tests/test_license.py::test_auto_provision_entitled_account_downloads_and_installs` is unrelated — fails identically on clean `origin/main` due to a `_Resp` mock missing `headers`).

Ruff is clean on the touched lines.

## Local operator verification checklist

I cannot reach the user's machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The operator should:

- [ ] Copy the changed files into the install:
      ```sh
      cp clawmetry/cli.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/cli.py
      cp tests/test_tier_cli.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/  # for ad-hoc rerun if needed
      find ~/.clawmetry -name __pycache__ -exec rm -rf {} +
      ```
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Smoke-test the new CLI:
      ```sh
      clawmetry tier
      clawmetry tier --json | jq -r '.tier, .grace, .runtimes'
      CLAWMETRY_ENFORCE=1 clawmetry tier      # Mode should flip to 🔒 enforced
      ```
- [ ] Confirm `/api/entitlement` still returns the same shape (no route change here, but worth a once-over).
- [ ] Run `make lint` and the entitlement test slice locally.
- [ ] Decrypt the live cloud snapshot and browser-check the dashboard — purely as a regression sanity (nothing in the dashboard path changed).

Keep this PR **draft**. Do not `[RELEASE]` until the operator has done the local + cloud verification above; do not enforce any gate (this stays grace-mode).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuQ2i5Sj9uhzqXJPpHs8pP)_