### PR TITLE
fix(privacy): security_posture rides the encrypted snapshot, not plaintext

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6632,10 +6632,10 @@ def send_heartbeat(config: dict) -> bool:
             payload["billing"] = _billing
     except Exception as _bm_e:
         log.debug("billing-mode detection failed (continuing): %s", _bm_e)
-    # Daemon-collected snapshots (see _collect_security_posture docstring)
-    sec = _collect_security_posture()
-    if sec is not None:
-        payload["security_posture"] = sec
+    # security_posture is a SCAN OF THE USER'S MACHINE; it must not ride the
+    # plaintext heartbeat (the cloud stored it in cleartext). It now travels in
+    # the E2E-encrypted system snapshot as `securityPosture` and renders
+    # client-side from the decrypted blob. See sync_system_snapshot().
     # Local-store health (epic #964 phase 1 → rollout gate for phase 2).
     # We need ≥80% of active nodes reporting healthy local stores before
     # slimming cloud retention to 24h. Best-effort; never blocks heartbeat.
@@ -14859,6 +14859,10 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         # cloud can show a runtime chip without bloating the snapshot.
         "detectedRuntimes": _detected_runtimes,
         "machineInfo": _build_machine_info(),
+        # Security posture (a scan of the user's machine) rides the ENCRYPTED
+        # snapshot, never the plaintext heartbeat — the cloud stores only this
+        # opaque blob and the Security tab decrypts it client-side.
+        "securityPosture": _collect_security_posture(),
         "channelList": _build_channel_list(config),
         "ollamaInfo": _detect_ollama_for_heartbeat(),
         "firstRun": _build_first_run(),

--- a/tests/test_security_posture_encrypted.py
+++ b/tests/test_security_posture_encrypted.py
@@ -1,0 +1,22 @@
+"""Guard: security_posture rides the ENCRYPTED snapshot, not the plaintext
+heartbeat (cloud #1569 / encrypt-everything).
+
+The daemon must put the machine security scan into the E2E-encrypted system
+snapshot (key `securityPosture`) and must NOT attach it to the plaintext
+heartbeat payload (the cloud stored that in cleartext).
+"""
+import pathlib
+
+SYNC = (pathlib.Path(__file__).resolve().parents[1] / "clawmetry" / "sync.py").read_text()
+
+
+def test_security_posture_in_encrypted_snapshot():
+    # sync_system_snapshot builds the AES-GCM-encrypted payload; it must include
+    # the securityPosture key.
+    assert '"securityPosture": _collect_security_posture()' in SYNC
+
+
+def test_security_posture_not_on_plaintext_heartbeat():
+    # send_heartbeat must not stash the scan on the plaintext payload.
+    assert 'payload["security_posture"]' not in SYNC
+    assert "payload['security_posture']" not in SYNC


### PR DESCRIPTION
Tracking: vivekchand/clawmetry-cloud#1569 (encrypt-everything). First step.

## The bug
`_collect_security_posture()` (a scan of the user's machine: score + checks) was attached to the **plaintext** heartbeat, and the cloud stored it in cleartext (`nodes.security_posture`) — contradicting "all data is encrypted before it leaves the machine."

## The fix (daemon side)
- Add `securityPosture` to the **E2E-encrypted** system snapshot (`sync_system_snapshot`), decrypted client-side, never readable by the cloud.
- Remove `security_posture` from the plaintext heartbeat payload.

## Verification (live)
Restarted the local daemon with this change and decrypted the live cloud snapshot: it now contains `securityPosture` (score "A", 10 checks); the heartbeat no longer carries it. Guard `tests/test_security_posture_encrypted.py`.

## Paired cloud PR
`clawmetry-cloud`: stop persisting it plaintext, the `/api/security/posture` route returns an encrypted-pending placeholder, a `cm-cloud-security-posture` interceptor renders it from the decrypted snapshot, and the 500 existing plaintext rows were purged from prod.

This is step 1 of #1569; `local_ips` + the machine fingerprint (os/arch/ram/cpu) follow next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)