### PR TITLE
feat(approvals): policy replay eval + monitor dry-run mode

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -311,6 +311,86 @@ def match_policy(policies: list[dict], tool_name: str, args: dict):
     return None
 
 
+def replay_policy(policy: dict, rows: list[dict], max_samples: int = 20) -> dict:
+    """Replay a CANDIDATE policy over historical tool-call events and report
+    what it WOULD have paused — without creating approvals, blocking anything,
+    or touching the cloud (the "eval before you enable" loop, CrabTrap-style).
+
+    ``policy`` is a raw policy dict (same shape as ``policies.yml`` / the
+    cloud builder rows — ``_compile_policy`` handles both). ``rows`` are
+    events-table rows in ``query_events`` shape. Pure function: no store
+    access and no network, so callers fetch rows however they like (route
+    handlers go through the daemon proxy) and pass them in.
+
+    Returns ``{ok, policy, scanned_events, scanned_tool_calls, matches,
+    by_runtime, by_tool, samples}`` or ``{ok: False, error}`` on a bad policy.
+    """
+    compiled = _compile_policy(policy)
+    if compiled is None:
+        return {"ok": False, "error": "invalid policy (bad regex or shape)"}
+    try:
+        from clawmetry.sync import _runtime_of_session as _rt_of
+    except Exception:  # pure-OSS edge: attribution degrades, replay still works
+        def _rt_of(sid: str) -> str:
+            return "openclaw"
+    scanned_events = 0
+    scanned_tool_calls = 0
+    matches = 0
+    by_runtime: dict[str, int] = {}
+    by_tool: dict[str, int] = {}
+    samples: list[dict] = []
+    seen_rows: set = set()
+    for row in rows or []:
+        if not isinstance(row, dict):
+            continue
+        rid = row.get("id")
+        if rid is not None:
+            # The caller merges per-event_type queries; dedup row ids so an
+            # event present in both result sets counts once.
+            if rid in seen_rows:
+                continue
+            seen_rows.add(rid)
+        data = row.get("data")
+        if isinstance(data, str):
+            # Cross-process transports may serialise the data column.
+            try:
+                row = dict(row, data=json.loads(data))
+            except Exception:
+                pass
+        scanned_events += 1
+        sid = row.get("session_id") or ""
+        for _tcid, tool_name, args in _extract_tool_blocks(row):
+            if not tool_name:
+                continue
+            args = args if isinstance(args, dict) else {}
+            scanned_tool_calls += 1
+            if match_policy([compiled], tool_name, args) is None:
+                continue
+            matches += 1
+            rt = _rt_of(sid)
+            by_runtime[rt] = by_runtime.get(rt, 0) + 1
+            canon = _canonical_tool(tool_name)
+            by_tool[canon] = by_tool.get(canon, 0) + 1
+            if len(samples) < max_samples:
+                samples.append({
+                    "ts": row.get("ts"),
+                    "session_id": sid,
+                    "runtime": rt,
+                    "tool": tool_name,
+                    "command": _extract_command(tool_name, args)[:160],
+                })
+    return {
+        "ok": True,
+        "policy": compiled["name"],
+        "scanned_events": scanned_events,
+        "scanned_tool_calls": scanned_tool_calls,
+        "matches": matches,
+        "by_runtime": by_runtime,
+        "by_tool": by_tool,
+        "samples": samples,
+    }
+
+
 # ── Cloud round-trip ──────────────────────────────────────────────────────
 
 
@@ -422,7 +502,9 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
     a cloud-mediated approval.
 
     Blocks for up to policy.timeout seconds while waiting for the decision.
-    Returns: {decision: approved|denied|timeout|no_policy|error,
+    A policy with ``action: monitor`` never blocks: it records a
+    ``simulated`` approval row (dry-run) and returns immediately.
+    Returns: {decision: approved|denied|timeout|monitored|no_policy|error,
               policy: <name or None>, killed: bool}
     """
     if policies is None:
@@ -444,6 +526,52 @@ def process_tool_call(api_key: str, node_id: str, session_id: Optional[str],
              f"cmd={cmd_preview!r} session={session_id}")
 
     approval_id = uuid.uuid4().hex
+
+    if (policy.get("action") or "") == "monitor":
+        # Dry-run mode: record what WOULD have paused so the audit feed shows
+        # it, but never block the agent, never round-trip the cloud, never
+        # kill. Lets a user trial a rule live before flipping it to
+        # require_approval.
+        try:
+            import hashlib as _hl
+            from clawmetry import local_store as _lsm
+            _lsm.get_store().ingest_approval({
+                "id": approval_id,
+                "owner_hash": _hl.sha256((api_key or "").encode()).hexdigest(),
+                "requestor_session_id": session_id,
+                "action": f"{tool_name}: {cmd_preview}",
+                "args": args,
+                "status": "simulated",
+                "decision_reason": (f"monitor mode: policy '{policy['name']}' "
+                                    "would have paused this"),
+                "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            })
+        except Exception as _me:
+            log.debug("monitor-mode approval persist failed: %s", _me)
+        try:
+            from clawmetry import audit as _audit
+            _audit.audit_event(
+                "approval.simulated",
+                actor="policy",
+                target=tool_name,
+                result="monitored",
+                source="approvals",
+                metadata={
+                    "approval_id": approval_id,
+                    "policy": policy["name"],
+                    "session_id": session_id,
+                    "command": cmd_preview,
+                },
+            )
+        except Exception:
+            pass
+        result = {"decision": "monitored", "policy": policy["name"],
+                  "killed": False, "approval_id": approval_id}
+        log.info(f"[approval] {approval_id} → monitored (dry-run, not blocked)")
+        with _in_flight_lock:
+            _in_flight[key] = result
+        return result
+
     req = {
         "id": approval_id,
         "node_id": node_id,

--- a/routes/policy.py
+++ b/routes/policy.py
@@ -148,11 +148,14 @@ def _approvals_audit_payload(status=None, limit=100):
         return str(args)[:160]
 
     decisions = []
-    pending = approved = denied = 0
+    pending = approved = denied = simulated = 0
     for r in rows:
         st = (r.get("status") or "pending")
         dec = (r.get("decision") or "")
-        if st == "pending":
+        if st == "simulated":
+            # Monitor-mode (dry-run) policies record what WOULD have paused.
+            simulated += 1
+        elif st == "pending":
             pending += 1
         elif st in ("approved", "allow", "allowed") or dec in ("approve", "allow"):
             approved += 1
@@ -177,5 +180,58 @@ def _approvals_audit_payload(status=None, limit=100):
         "pending": pending,
         "approved": approved,
         "denied": denied,
+        "simulated": simulated,
     }
     return {"decisions": decisions, "summary": summary, "_source": "local_store"}
+
+
+@bp_policy.route("/api/policy/replay", methods=["POST"])
+def api_policy_replay():
+    """Replay a CANDIDATE approval policy over recent tool-call history.
+
+    The "eval before you enable" loop: before saving a rule, see what it
+    would have paused over the last N days, across every runtime. Nothing is
+    created, blocked, or sent to the cloud; this is a pure read.
+
+    Body: ``{policy: {...}, days: int (default 14, max 30),
+             limit: int (default 5000, max 10000)}``
+    ``policy`` uses the same shape as ``~/.clawmetry/policies.yml`` rows or
+    cloud-builder rows (``tool`` / ``match.command_regex`` / ...).
+
+    Returns the ``clawmetry.approvals.replay_policy`` payload plus
+    ``days`` + ``since``. Invalid input returns 400 with ``{ok: False}``;
+    an empty store returns an honest all-zeros payload, never a 500.
+    """
+    body = request.get_json(silent=True) or {}
+    policy = body.get("policy")
+    if not isinstance(policy, dict) or not policy:
+        return jsonify({"ok": False,
+                        "error": "body must include a 'policy' object"}), 400
+    try:
+        days = max(1, min(30, int(body.get("days", 14))))
+    except (TypeError, ValueError):
+        days = 14
+    try:
+        limit = max(100, min(10000, int(body.get("limit", 5000))))
+    except (TypeError, ValueError):
+        limit = 5000
+
+    import time as _time
+    since = _time.strftime("%Y-%m-%dT%H:%M:%SZ",
+                           _time.gmtime(_time.time() - days * 86400))
+    # Same merged-event_type read as the live watcher
+    # (clawmetry/approvals.py:_query_new_events): adapters ingest assistant
+    # turns under either event_type. replay_policy dedups by row id.
+    rows: list[dict] = []
+    for et in ("message", "assistant"):
+        rows.extend(_coerce_rows(
+            _ls_call("query_events", event_type=et, since=since, limit=limit)))
+
+    try:
+        from clawmetry.approvals import replay_policy
+        result = replay_policy(policy, rows)
+    except Exception as e:
+        result = {"ok": False, "error": f"replay failed: {e}"}
+    result["days"] = days
+    result["since"] = since
+    return jsonify(result), (200 if result.get("ok") else 400)

--- a/tests/test_policy_replay.py
+++ b/tests/test_policy_replay.py
@@ -1,0 +1,284 @@
+"""Tests for policy replay (eval-before-enable) + monitor (dry-run) mode.
+
+Two features adopted from the agent-guardrail tools' playbook (CrabTrap's
+"replay the audit log against a candidate policy" eval loop):
+
+  1. ``clawmetry.approvals.replay_policy`` — a PURE function that replays a
+     candidate policy over historical events-table rows and reports what it
+     WOULD have paused (counts, per-runtime / per-tool buckets, samples).
+     Exposed at ``POST /api/policy/replay`` (routes/policy.py).
+  2. ``action: monitor`` policies — ``process_tool_call`` records a
+     ``simulated`` approval row and returns immediately: no cloud
+     round-trip, no blocking, no session kill.
+
+Revert-proof: with the monitor branch removed, the monitor tests fail
+because ``process_tool_call`` reaches the cloud round-trip (the patched
+``_post_approval_request`` fails the test). With ``replay_policy`` removed,
+the replay tests fail on import and the route returns non-200.
+
+Synthetic rows are fine here — these are isolated unit tests of pure
+matching/replay logic, not a claim that the live pipeline works (that is
+the watcher + E2E suites' job).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from clawmetry import approvals
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _row(eid: str, sid: str, ts: str, tool_blocks, flavor: str = "openclaw") -> dict:
+    """Build an events-table row carrying assistant tool-invocation blocks.
+
+    ``flavor='openclaw'`` emits ``toolCall``+``arguments`` blocks;
+    ``flavor='claude'`` emits ``tool_use``+``input`` (Claude Code shape).
+    """
+    blocks = []
+    for i, (name, args) in enumerate(tool_blocks):
+        if flavor == "claude":
+            blocks.append({"type": "tool_use", "id": f"{eid}-{i}",
+                           "name": name, "input": args})
+        else:
+            blocks.append({"type": "toolCall", "id": f"{eid}-{i}",
+                           "name": name, "arguments": args})
+    return {
+        "id": eid,
+        "session_id": sid,
+        "ts": ts,
+        "event_type": "message",
+        "data": {"type": "message",
+                 "message": {"role": "assistant", "content": blocks}},
+    }
+
+
+_RM_POLICY = {
+    "name": "gate-rm-rf",
+    "match": {"tool": "exec", "command_regex": r"rm\s+-rf"},
+    "action": "require_approval",
+}
+
+
+# ── replay_policy (pure) ──────────────────────────────────────────────────
+
+
+def test_replay_matches_across_harness_aliases():
+    """A policy authored for ``exec`` must match OpenClaw ``exec`` AND Claude
+    Code ``Bash`` (tool_use) rows, with per-runtime attribution."""
+    rows = [
+        _row("e1", "0f0e-uuid-openclaw", "2026-06-01T00:00:00Z",
+             [("exec", {"command": "rm -rf /tmp/scratch"})]),
+        _row("e2", "claude_code:sess-1", "2026-06-01T00:00:01Z",
+             [("Bash", {"command": "rm -rf node_modules"})], flavor="claude"),
+        _row("e3", "claude_code:sess-1", "2026-06-01T00:00:02Z",
+             [("Bash", {"command": "ls -la"})], flavor="claude"),
+        _row("e4", "0f0e-uuid-openclaw", "2026-06-01T00:00:03Z",
+             [("read", {"path": "/etc/hosts"})]),
+    ]
+    out = approvals.replay_policy(_RM_POLICY, rows)
+    assert out["ok"] is True
+    assert out["policy"] == "gate-rm-rf"
+    assert out["scanned_events"] == 4
+    assert out["scanned_tool_calls"] == 4
+    assert out["matches"] == 2
+    assert out["by_runtime"] == {"openclaw": 1, "claude_code": 1}
+    assert out["by_tool"] == {"exec": 2}
+    assert len(out["samples"]) == 2
+    assert all("rm -rf" in s["command"] for s in out["samples"])
+
+
+def test_replay_command_not_regex_excludes():
+    policy = {
+        "name": "gate-push-except-fork",
+        "match": {"tool": "exec",
+                  "command_regex": r"git\s+push",
+                  "command_not_regex": r"my-fork"},
+    }
+    rows = [
+        _row("e1", "s", "2026-06-01T00:00:00Z",
+             [("exec", {"command": "git push origin main --force"})]),
+        _row("e2", "s", "2026-06-01T00:00:01Z",
+             [("exec", {"command": "git push my-fork feature"})]),
+    ]
+    out = approvals.replay_policy(policy, rows)
+    assert out["matches"] == 1
+    assert out["samples"][0]["command"] == "git push origin main --force"
+
+
+def test_replay_invalid_regex_returns_error_not_crash():
+    out = approvals.replay_policy(
+        {"name": "bad", "match": {"command_regex": "["}}, [])
+    assert out["ok"] is False
+    assert "invalid policy" in out["error"]
+
+
+def test_replay_dedups_row_ids_and_caps_samples():
+    """Merged event_type queries can return the same row twice — count once.
+    Samples cap at max_samples while ``matches`` keeps counting."""
+    rows = []
+    for i in range(30):
+        rows.append(_row(f"e{i}", "s", f"2026-06-01T00:00:{i:02d}Z",
+                         [("exec", {"command": "rm -rf /tmp/x"})]))
+    rows.append(dict(rows[0]))  # duplicate id e0 from the second query
+    out = approvals.replay_policy(_RM_POLICY, rows)
+    assert out["scanned_events"] == 30
+    assert out["matches"] == 30
+    assert len(out["samples"]) == 20  # default max_samples
+
+
+def test_replay_tolerates_data_as_json_string():
+    """Cross-process transports may serialise the ``data`` column."""
+    row = _row("e1", "s", "2026-06-01T00:00:00Z",
+               [("exec", {"command": "rm -rf /tmp/x"})])
+    row["data"] = json.dumps(row["data"])
+    out = approvals.replay_policy(_RM_POLICY, [row])
+    assert out["matches"] == 1
+
+
+def test_replay_garbage_rows_never_crash():
+    rows = [None, 42, "nope", {}, {"id": "x", "data": "{not json"},
+            {"id": "y", "data": {"type": "message", "message": {"content": None}}}]
+    out = approvals.replay_policy(_RM_POLICY, rows)
+    assert out["ok"] is True
+    assert out["matches"] == 0
+
+
+# ── monitor (dry-run) mode ────────────────────────────────────────────────
+
+
+class _StoreStub:
+    def __init__(self):
+        self.ingested: list[dict] = []
+
+    def ingest_approval(self, approval: dict):
+        self.ingested.append(approval)
+
+
+@pytest.fixture()
+def monitor_env(monkeypatch):
+    """Patch the cloud round-trip + kill path to FAIL the test if reached,
+    and capture local approval persists."""
+    store = _StoreStub()
+    monkeypatch.setattr(
+        approvals, "_post_approval_request",
+        lambda *a, **k: pytest.fail("monitor mode must not call the cloud"))
+    monkeypatch.setattr(
+        approvals, "_poll_decision",
+        lambda *a, **k: pytest.fail("monitor mode must not poll for a decision"))
+    monkeypatch.setattr(
+        approvals, "_kill_session",
+        lambda *a, **k: pytest.fail("monitor mode must never kill a session"))
+    import clawmetry.local_store as _ls
+    monkeypatch.setattr(_ls, "get_store", lambda *a, **k: store)
+    return store
+
+
+def test_monitor_mode_never_blocks_and_records_simulated(monitor_env):
+    policy = approvals._compile_policy({
+        "name": "mon-rm",
+        "match": {"tool": "exec", "command_regex": r"rm\s+-rf"},
+        "action": "monitor",
+    })
+    assert policy is not None
+    result = approvals.process_tool_call(
+        api_key="test-key", node_id="node-1", session_id="claude_code:s1",
+        tool_call_id=uuid.uuid4().hex, tool_name="Bash",
+        args={"command": "rm -rf /tmp/scratch"}, policies=[policy])
+    assert result["decision"] == "monitored"
+    assert result["killed"] is False
+    assert result["policy"] == "mon-rm"
+    assert len(monitor_env.ingested) == 1
+    row = monitor_env.ingested[0]
+    assert row["status"] == "simulated"
+    assert "rm -rf /tmp/scratch" in row["action"]
+    assert "mon-rm" in (row.get("decision_reason") or "")
+
+
+def test_monitor_mode_non_matching_tool_is_untouched(monitor_env):
+    policy = approvals._compile_policy({
+        "name": "mon-rm",
+        "match": {"tool": "exec", "command_regex": r"rm\s+-rf"},
+        "action": "monitor",
+    })
+    result = approvals.process_tool_call(
+        api_key="test-key", node_id="node-1", session_id="s",
+        tool_call_id=uuid.uuid4().hex, tool_name="Bash",
+        args={"command": "ls -la"}, policies=[policy])
+    assert result["decision"] == "no_policy"
+    assert monitor_env.ingested == []
+
+
+# ── POST /api/policy/replay route ─────────────────────────────────────────
+
+
+@pytest.fixture()
+def replay_client(monkeypatch):
+    from flask import Flask
+    import routes.policy as rp
+
+    rows = [
+        _row("e1", "claude_code:sess-1", "2026-06-01T00:00:00Z",
+             [("Bash", {"command": "rm -rf build/"})], flavor="claude"),
+        _row("e2", "s2", "2026-06-01T00:00:01Z",
+             [("exec", {"command": "echo hi"})]),
+    ]
+
+    def _fake_ls_call(method_name, **kwargs):
+        assert method_name == "query_events"
+        assert "since" in kwargs and "limit" in kwargs
+        return rows
+
+    monkeypatch.setattr(rp, "_ls_call", _fake_ls_call)
+    app = Flask(__name__)
+    app.register_blueprint(rp.bp_policy)
+    return app.test_client()
+
+
+def test_replay_route_happy_path(replay_client):
+    resp = replay_client.post("/api/policy/replay", json={
+        "policy": {"name": "gate-rm",
+                   "match": {"tool": "exec", "command_regex": r"rm\s+-rf"}},
+        "days": 7,
+    })
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["matches"] == 1
+    assert body["by_runtime"] == {"claude_code": 1}
+    assert body["days"] == 7
+    assert body["since"]
+
+
+def test_replay_route_rejects_missing_policy(replay_client):
+    resp = replay_client.post("/api/policy/replay", json={"days": 7})
+    assert resp.status_code == 400
+    assert resp.get_json()["ok"] is False
+
+
+def test_replay_route_rejects_bad_regex(replay_client):
+    resp = replay_client.post("/api/policy/replay", json={
+        "policy": {"name": "bad", "match": {"command_regex": "["}}})
+    assert resp.status_code == 400
+    assert resp.get_json()["ok"] is False
+
+
+def test_replay_route_clamps_days(replay_client):
+    resp = replay_client.post("/api/policy/replay", json={
+        "policy": {"name": "gate-rm",
+                   "match": {"tool": "exec", "command_regex": r"rm\s+-rf"}},
+        "days": 9999,
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()["days"] == 30


### PR DESCRIPTION
## Why

The agent-guardrail category is forming fast (Deno's clawpatrol, Brex's CrabTrap, both MIT, both ~600 stars within weeks). The strongest idea in CrabTrap for an average ClawMetry user is the eval loop: replay a candidate policy against observed history BEFORE enabling it, so policy authoring stops being scary. We are better positioned than they are to do this: every tool call across all 12 runtimes is already in DuckDB, so our replay evals semantic tool calls cross-runtime, not just HTTP.

This PR ships the OSS half (P1 of the plan): replay plus a monitor (dry-run) policy action. Cloud builder preview wiring is the follow-up in clawmetry-cloud.

## What

- `clawmetry.approvals.replay_policy(policy, rows)`: pure function, replays a candidate policy over events-table rows and returns `{matches, by_runtime, by_tool, samples[<=20], scanned_*}`. Reuses the existing `_compile_policy` / `_extract_tool_blocks` / `match_policy` chain, so harness tool aliasing (Bash/shell/exec) and both policy shapes (local YAML `match` dict, cloud builder rows) work unchanged. Dedups merged event_type rows by id; tolerates `data` arriving as a JSON string; never raises on garbage rows.
- `POST /api/policy/replay` in `routes/policy.py`: body `{policy, days<=30, limit<=10000}`. Reads events through the daemon proxy (`_ls_call`, same pattern as the rest of the module), runs the replay in-process. Pure read: creates nothing, blocks nothing, no cloud calls. 400 on bad policy, honest zeros on empty store, never a 500.
- `action: monitor` policies: `process_tool_call` now records a `simulated` approvals row (visible in the audit feed) and returns `decision=monitored` immediately. No cloud round-trip, no `_poll_decision`, no session kill. The cloud pending queue is untouched (it only surfaces `status=pending`).
- `/api/approvals-audit` summary gains a `simulated` count so the posture bar stays honest.

## Verification

- 12 new tests in `tests/test_policy_replay.py` green on py3.9: harness-alias matching with per-runtime attribution, `command_not_regex`, bad-regex 400, row-id dedup plus sample cap, JSON-string data, garbage rows, monitor-mode no-cloud/no-kill guards (patched `_post_approval_request` / `_poll_decision` / `_kill_session` fail the test if reached), route happy path, missing-policy 400, days clamp.
- Revert-proof per the ruthless-verify rule: checked out un-fixed `approvals.py`/`policy.py`, 11/12 tests went red; restored, 12/12 green.
- Pre-existing `test_approvals_*` failures in my local py3.9 env reproduce identically on clean origin/main (environment-only; CI is the arbiter).
- CPU budget: replay is on-demand only (no poller), bounded by days/limit caps; monitor mode is one DuckDB upsert per fired policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)