### PR TITLE
fix(approvals): policies now see family-runtime tool calls (event_type=tool_call)

### DIFF
--- a/clawmetry/approvals.py
+++ b/clawmetry/approvals.py
@@ -730,6 +730,17 @@ _STATE_KEY_SEEN = "approvals_seen_ids_at_boundary"
 # (it takes a parsed args dict).
 _TOOL_BLOCK_TYPES = ("toolCall", "tool_use")
 
+# Event types that can carry tool invocations. The watcher
+# (``_query_new_events``) and the replay route (``routes/policy.py``) MUST
+# query the same list or they drift: the family adapters (claude_code,
+# codex, cursor, …) ingest one row PER tool call under
+# ``event_type='tool_call'`` with an OpenAI-style ``data.tool_calls`` array
+# — a type the watcher historically never queried, so approval policies
+# silently never fired for those runtimes (found 2026-06-10 by replaying a
+# policy over the live store: 2,539 tool_call rows in 3 days, 0 visible to
+# the watcher).
+_TOOL_EVENT_TYPES = ("message", "assistant", "tool_call")
+
 
 def _read_persisted_watermark() -> tuple[Optional[str], set[str]]:
     """Read the persisted watermark + boundary-id set from sync-state.json.
@@ -838,6 +849,25 @@ def _extract_tool_blocks(row: dict) -> list[tuple[str, str, dict]]:
             str(data.get("name") or ""),
             data.get("arguments") or data.get("input") or {},
         ))
+    # Case D: family adapters (claude_code / codex / cursor / …) ingest one
+    # row per tool call under ``event_type='tool_call'`` with an OpenAI-style
+    # array: ``data = {_runtime, role: "assistant", tool_name,
+    # tool_calls: [{id, name, input}]}``. Args may be ``input`` /
+    # ``arguments`` / ``args`` depending on the adapter.
+    if not out and isinstance(data.get("tool_calls"), list):
+        if data.get("role") in (None, "assistant"):
+            for blk in data["tool_calls"]:
+                if not isinstance(blk, dict):
+                    continue
+                name = blk.get("name") or data.get("tool_name")
+                if not name:
+                    continue
+                args = blk.get("input") or blk.get("arguments") or blk.get("args") or {}
+                out.append((
+                    str(blk.get("id") or ""),
+                    str(name),
+                    args if isinstance(args, dict) else {},
+                ))
     return out
 
 
@@ -847,9 +877,10 @@ def _query_new_events(since: Optional[str], limit: int) -> list[dict]:
     ``query_events`` accepts only one ``event_type`` filter at a time, but
     different adapters ingest the same conceptual "assistant turn" event
     under different ``event_type`` strings (OpenClaw uses ``"message"``;
-    some Anthropic-shape adapters use ``"assistant"``). Issue both queries
-    and merge. Cost is negligible — both are indexed by
-    ``idx_events_type_ts``.
+    some Anthropic-shape adapters use ``"assistant"``; the family adapters
+    emit one ``"tool_call"`` row per invocation). Issue one query per type
+    in ``_TOOL_EVENT_TYPES`` and merge. Cost is negligible — all are
+    indexed by ``idx_events_type_ts``.
     """
     from clawmetry import local_store
     try:
@@ -861,7 +892,7 @@ def _query_new_events(since: Optional[str], limit: int) -> list[dict]:
         log.debug(f"approvals: local_store unavailable ({e})")
         return []
     rows: list[dict] = []
-    for et in ("message", "assistant"):
+    for et in _TOOL_EVENT_TYPES:
         try:
             rows.extend(store.query_events(event_type=et, since=since, limit=limit))
         except Exception as e:

--- a/routes/policy.py
+++ b/routes/policy.py
@@ -219,16 +219,20 @@ def api_policy_replay():
     import time as _time
     since = _time.strftime("%Y-%m-%dT%H:%M:%SZ",
                            _time.gmtime(_time.time() - days * 86400))
-    # Same merged-event_type read as the live watcher
-    # (clawmetry/approvals.py:_query_new_events): adapters ingest assistant
-    # turns under either event_type. replay_policy dedups by row id.
+    # Same merged-event_type read as the live watcher: import the SHARED
+    # list from approvals so replay and enforcement cannot drift (a replay
+    # that scans different event types than the watcher would "predict"
+    # pauses the watcher never fires, or miss ones it does).
+    try:
+        from clawmetry.approvals import replay_policy, _TOOL_EVENT_TYPES
+    except Exception as e:
+        return jsonify({"ok": False, "error": f"approvals engine unavailable: {e}"}), 500
     rows: list[dict] = []
-    for et in ("message", "assistant"):
+    for et in _TOOL_EVENT_TYPES:
         rows.extend(_coerce_rows(
             _ls_call("query_events", event_type=et, since=since, limit=limit)))
 
     try:
-        from clawmetry.approvals import replay_policy
         result = replay_policy(policy, rows)
     except Exception as e:
         result = {"ok": False, "error": f"replay failed: {e}"}

--- a/tests/test_policy_replay.py
+++ b/tests/test_policy_replay.py
@@ -155,6 +155,80 @@ def test_replay_garbage_rows_never_crash():
     assert out["matches"] == 0
 
 
+def _family_tool_call_row(eid: str, sid: str, ts: str, name: str, args: dict) -> dict:
+    """The REAL shape the family adapters (claude_code/codex/cursor/…) ingest:
+    one row per tool call, ``event_type='tool_call'``, OpenAI-style
+    ``tool_calls`` array. Copied from a live store row (2026-06-10)."""
+    return {
+        "id": eid,
+        "session_id": sid,
+        "ts": ts,
+        "event_type": "tool_call",
+        "data": {
+            "_runtime": sid.split(":", 1)[0],
+            "content": "",
+            "role": "assistant",
+            "tool_name": name,
+            "tool_calls": [{"id": f"toolu_{eid}", "name": name, "input": args}],
+        },
+    }
+
+
+def test_replay_matches_family_tool_call_rows():
+    """Family adapters emit event_type='tool_call' rows with a ``tool_calls``
+    array. The extractor + replay must see them — before 2026-06-10 the
+    watcher neither queried nor parsed this shape, so approval policies
+    silently never fired for Claude Code / Codex / Cursor / etc."""
+    rows = [
+        _family_tool_call_row("f1", "claude_code:sess-9", "2026-06-09T00:00:00Z",
+                              "Bash", {"command": "rm -rf /tmp/cache"}),
+        _family_tool_call_row("f2", "codex:sess-3", "2026-06-09T00:00:01Z",
+                              "shell", {"command": "rm -rf ./dist"}),
+        _family_tool_call_row("f3", "claude_code:sess-9", "2026-06-09T00:00:02Z",
+                              "Read", {"file_path": "/etc/hosts"}),
+    ]
+    out = approvals.replay_policy(_RM_POLICY, rows)
+    assert out["matches"] == 2
+    assert out["by_runtime"] == {"claude_code": 1, "codex": 1}
+    assert out["by_tool"] == {"exec": 2}
+
+
+def test_extract_tool_blocks_family_array_edge_cases():
+    base = _family_tool_call_row("f1", "claude_code:s", "2026-06-09T00:00:00Z",
+                                 "Bash", {"command": "ls"})
+    assert approvals._extract_tool_blocks(base) == [("toolu_f1", "Bash", {"command": "ls"})]
+    # name falls back to top-level tool_name
+    row = _family_tool_call_row("f2", "claude_code:s", "t", "Bash", {"command": "ls"})
+    del row["data"]["tool_calls"][0]["name"]
+    assert approvals._extract_tool_blocks(row)[0][1] == "Bash"
+    # non-assistant role is ignored (tool_result echoes must not fire policies)
+    row = _family_tool_call_row("f3", "claude_code:s", "t", "Bash", {"command": "ls"})
+    row["data"]["role"] = "tool"
+    assert approvals._extract_tool_blocks(row) == []
+    # garbage entries in the array are skipped
+    row = _family_tool_call_row("f4", "claude_code:s", "t", "Bash", {"command": "ls"})
+    row["data"]["tool_calls"] = [None, "x", {}, {"name": "Bash", "input": "notadict"}]
+    blocks = approvals._extract_tool_blocks(row)
+    assert blocks == [("", "Bash", {}), ("", "Bash", {})]
+
+
+def test_watcher_queries_tool_call_event_type(monkeypatch):
+    """The watcher's store read must include event_type='tool_call' — the
+    family adapters' rows live ONLY there. Revert-proof: fails on the old
+    ('message', 'assistant')-only query list."""
+    seen: list = []
+
+    class _QStub:
+        def query_events(self, *, event_type=None, since=None, limit=0):
+            seen.append(event_type)
+            return []
+
+    import clawmetry.local_store as _ls
+    monkeypatch.setattr(_ls, "get_store", lambda *a, **k: _QStub())
+    approvals._query_new_events(None, 10)
+    assert set(seen) == {"message", "assistant", "tool_call"}
+
+
 # ── monitor (dry-run) mode ────────────────────────────────────────────────
 
 
@@ -235,15 +309,20 @@ def replay_client(monkeypatch):
              [("exec", {"command": "echo hi"})]),
     ]
 
+    requested_event_types: list = []
+
     def _fake_ls_call(method_name, **kwargs):
         assert method_name == "query_events"
         assert "since" in kwargs and "limit" in kwargs
+        requested_event_types.append(kwargs.get("event_type"))
         return rows
 
     monkeypatch.setattr(rp, "_ls_call", _fake_ls_call)
     app = Flask(__name__)
     app.register_blueprint(rp.bp_policy)
-    return app.test_client()
+    client = app.test_client()
+    client._requested_event_types = requested_event_types
+    return client
 
 
 def test_replay_route_happy_path(replay_client):
@@ -259,6 +338,10 @@ def test_replay_route_happy_path(replay_client):
     assert body["by_runtime"] == {"claude_code": 1}
     assert body["days"] == 7
     assert body["since"]
+    # Replay must scan the SAME event types as the live watcher (shared
+    # _TOOL_EVENT_TYPES constant) — including the family adapters' tool_call.
+    assert set(replay_client._requested_event_types) == {
+        "message", "assistant", "tool_call"}
 
 
 def test_replay_route_rejects_missing_policy(replay_client):


### PR DESCRIPTION
## Why

Replaying a candidate policy over the live store (the eval shipped in #2980 doing its job) exposed a real enforcement gap: **approval policies silently never fired for the family runtimes** (Claude Code, Codex, Cursor, and friends). Those adapters ingest one row per tool call under `event_type='tool_call'` with an OpenAI-style `data.tool_calls` array. The watcher's `_query_new_events` only queried `('message','assistant')`, and `_extract_tool_blocks` had no branch for the array shape. Either one alone is fatal; both were missing.

Live evidence (founder node, via the daemon query proxy): 2,539 `tool_call` rows in the last 3 days, zero visible to the watcher. A 14-day replay of a risky-exec policy saw 15 tool calls before this fix and 5,015 after, with 310 real matches attributed to `claude_code`.

## What

- `_TOOL_EVENT_TYPES = ('message', 'assistant', 'tool_call')` shared constant in `clawmetry/approvals.py`. Both the live watcher and `POST /api/policy/replay` use it, so enforcement and eval scan the same event types and cannot drift (the two-renderers-must-mirror rule).
- `_extract_tool_blocks` Case D: parses the `data.tool_calls` array. Assistant-or-None role only (tool_result echoes must not fire policies), per-entry name falls back to top-level `tool_name`, args read from `input`/`arguments`/`args`, garbage entries skipped.

## Verification

- 3 new tests use the REAL row shape copied from the live store, plus edge cases; a watcher test asserts the query list includes `tool_call`; the route test asserts replay scans the shared list. Revert-proof: with the source reverted to 0.12.501 and the new tests kept, 4 go red; with the fix, all 15 pass.
- Live replay over the founder node's real DuckDB (through the daemon proxy, no writer-lock contact): matches went 0 to 310, all correctly attributed to `claude_code` / canonical tool `exec`, sample commands are real Bash invocations.
- Pre-existing `test_approvals_duckdb_watcher` local failures reproduce identically on clean origin/main (env-only; CI is the arbiter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)