### PR TITLE
feat(extensions): add loaded_plugins() + GET /api/extensions diagnostic

### DIFF
--- a/clawmetry/extensions.py
+++ b/clawmetry/extensions.py
@@ -29,6 +29,13 @@ logger = logging.getLogger("clawmetry.extensions")
 _registry: Dict[str, List[Callable]] = {}
 _lock = threading.Lock()
 _loaded = False
+# Names of plugin entry points that successfully loaded, in load order.
+# A diagnostic-only mirror used by :func:`loaded_plugins` and
+# ``GET /api/extensions`` so operators can confirm clawmetry-pro is actually
+# wired in without scraping ``pip list``. A plugin that raised during load
+# is intentionally NOT recorded here — matches the warning-and-continue
+# posture of ``load_plugins`` itself.
+_loaded_plugins: List[str] = []
 
 
 def register(event: str, handler: Callable[[Dict[str, Any]], None]) -> None:
@@ -109,6 +116,10 @@ def load_plugins(app=None) -> None:
     if _loaded:
         return
     _loaded = True
+    # Reset the diagnostic mirror so a test that flips ``_loaded`` back to
+    # False and re-runs the loader doesn't see stale names from the prior pass.
+    with _lock:
+        _loaded_plugins.clear()
 
     try:
         eps = _select_entry_points("clawmetry.extensions")
@@ -133,6 +144,12 @@ def load_plugins(app=None) -> None:
                 fn(app)
             else:
                 fn()
+            # Record AFTER a successful invocation so a plugin that raised
+            # is reported as not-loaded by ``loaded_plugins`` / /api/extensions.
+            name = getattr(ep, "name", "") or ""
+            if name:
+                with _lock:
+                    _loaded_plugins.append(name)
             logger.info(f"Loaded ClawMetry extension plugin: {ep.name!r}")
         except Exception as exc:
             logger.warning(f"Failed to load extension plugin {ep.name!r}: {exc}")
@@ -148,3 +165,18 @@ def handler_count(event: str) -> int:
     """Return number of handlers registered for an event."""
     with _lock:
         return len(_registry.get(event, []))
+
+
+def loaded_plugins() -> List[str]:
+    """Names of entry-point plugins that loaded successfully in this process.
+
+    The ``clawmetry-pro`` wheel ships as a ``clawmetry.extensions`` entry point;
+    this helper lets ``clawmetry status``, ``GET /api/extensions``, and the
+    dashboard's diagnostic surface answer "is the paid package actually wired
+    in?" without scraping ``pip list`` or importing the package. Returns a
+    SHALLOW COPY so callers can't mutate the registry. Names appear in load
+    order; entries that raised during load are excluded — matching the
+    warning-and-continue posture of :func:`load_plugins`. Never raises.
+    """
+    with _lock:
+        return list(_loaded_plugins)

--- a/dashboard.py
+++ b/dashboard.py
@@ -130,6 +130,7 @@ from routes.turn_anatomy import bp_turn_anatomy
 from routes.tool_catalog import bp_tool_catalog
 from routes.context_economics import bp_context_economics
 from routes.entitlement import bp_entitlement
+from routes.extensions import bp_extensions
 from routes.otel_export import bp_otel_export
 from routes.device import bp_device
 from routes.runtime_ingest import bp_runtime_ingest
@@ -11570,6 +11571,7 @@ def detect_config(args=None):
     app.register_blueprint(bp_tool_catalog)
     app.register_blueprint(bp_context_economics)
     app.register_blueprint(bp_entitlement)
+    app.register_blueprint(bp_extensions)
     app.register_blueprint(bp_audit)
     app.register_blueprint(bp_device)
 

--- a/routes/extensions.py
+++ b/routes/extensions.py
@@ -1,0 +1,65 @@
+"""
+routes/extensions.py — diagnostic introspection for the entry-point plugin loader.
+
+``clawmetry/extensions.py`` discovers external packages via the
+``clawmetry.extensions`` entry-point group. The closed-source ``clawmetry-pro``
+wheel ships its runtime adapters that way, so operators frequently need to
+answer "did the paid package actually load on this node?" — currently the only
+way is to scrape daemon logs or run ``pip list``.
+
+This module exposes a tiny, always-Free, never-raise endpoint that surfaces
+the in-memory state of the loader so the dashboard, ``clawmetry status``, and
+shell wrappers can read it directly. No entitlement check is required: knowing
+which plugins are loaded is diagnostic, not gated. Pure read.
+
+Blueprint: ``bp_extensions``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, jsonify
+
+logger = logging.getLogger("clawmetry.routes.extensions")
+
+bp_extensions = Blueprint("extensions", __name__)
+
+
+@bp_extensions.route("/api/extensions", methods=["GET"])
+def api_extensions():
+    """Return loaded entry-point plugins + registered event hooks.
+
+    Response shape::
+
+        {
+          "plugins":        ["clawmetry-pro", ...],
+          "plugin_count":   1,
+          "events":         ["session.snapshot", ...],
+          "handler_counts": {"session.snapshot": 2, ...}
+        }
+
+    Never raises and never returns 5xx — any introspection failure resolves to
+    an empty shape so the dashboard's diagnostic panel always has something
+    safe to render.
+    """
+    try:
+        from clawmetry import extensions as _ext
+
+        plugins = list(_ext.loaded_plugins())
+        events = list(_ext.registered_events())
+        handler_counts = {evt: _ext.handler_count(evt) for evt in events}
+        return jsonify({
+            "plugins": plugins,
+            "plugin_count": len(plugins),
+            "events": events,
+            "handler_counts": handler_counts,
+        })
+    except Exception as exc:
+        logger.warning("extensions: introspection failed: %s", exc)
+        return jsonify({
+            "plugins": [],
+            "plugin_count": 0,
+            "events": [],
+            "handler_counts": {},
+        })

--- a/tests/test_extensions_introspection.py
+++ b/tests/test_extensions_introspection.py
@@ -1,0 +1,186 @@
+"""Tests for the entry-point plugin loader's introspection surface.
+
+Pins the diagnostic API operators read to confirm ``clawmetry-pro`` (or any
+other ``clawmetry.extensions`` entry point) has actually loaded on a node:
+
+- ``clawmetry.extensions.loaded_plugins()`` — names of plugins that loaded
+  successfully in this process.
+- ``GET /api/extensions`` — wire shape carrying those names plus the
+  registered-event hooks, never-raising on any introspection failure.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from flask import Flask
+
+import clawmetry.extensions as ext
+
+
+class _FakeEntryPoint:
+    """Stub mimicking importlib.metadata.EntryPoint."""
+
+    def __init__(self, fn, name="fake"):
+        self._fn = fn
+        self.name = name
+
+    def load(self):
+        return self._fn
+
+
+def _fake_eps(*pairs):
+    return [_FakeEntryPoint(fn, name=n) for fn, n in pairs]
+
+
+@pytest.fixture(autouse=True)
+def _reset_loader():
+    """Drop the once-guard + the loaded-name mirror before every test so
+    monkeypatched entry points actually run. Also snapshot/restore the event
+    registry so handlers registered here can't leak into adjacent suites and
+    handlers from adjacent suites can't leak in here."""
+    ext._loaded = False
+    with ext._lock:
+        ext._loaded_plugins.clear()
+        prior_registry = {k: list(v) for k, v in ext._registry.items()}
+        ext._registry.clear()
+    yield
+    ext._loaded = False
+    with ext._lock:
+        ext._loaded_plugins.clear()
+        ext._registry.clear()
+        ext._registry.update(prior_registry)
+
+
+# ── loaded_plugins() ─────────────────────────────────────────────────────────
+
+
+def test_loaded_plugins_empty_before_load():
+    assert ext.loaded_plugins() == []
+
+
+def test_loaded_plugins_returns_a_copy():
+    """Caller mutation must not corrupt the registry."""
+    ext.loaded_plugins().append("ghost")
+    assert ext.loaded_plugins() == []
+
+
+def test_loaded_plugins_records_successful_loads(monkeypatch):
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((lambda: None, "alpha"), (lambda: None, "beta")),
+    )
+    ext.load_plugins()
+    assert ext.loaded_plugins() == ["alpha", "beta"]
+
+
+def test_loaded_plugins_excludes_failed_plugins(monkeypatch):
+    """A plugin that raised during load must NOT appear — operators rely on
+    this list to confirm successful wiring, not attempted wiring."""
+    def boom():
+        raise RuntimeError("boom")
+
+    def good():
+        return None
+
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((boom, "broken"), (good, "ok")),
+    )
+    ext.load_plugins()
+    assert ext.loaded_plugins() == ["ok"]
+
+
+def test_loaded_plugins_resets_on_reentry(monkeypatch):
+    """If a test flips ``_loaded`` back to False, the next load_plugins()
+    call must start the list fresh (no duplicates from the prior pass)."""
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((lambda: None, "alpha")),
+    )
+    ext.load_plugins()
+    assert ext.loaded_plugins() == ["alpha"]
+    # Simulate a process where ``_loaded`` was reset (test fixture, reload, …).
+    ext._loaded = False
+    ext.load_plugins()
+    assert ext.loaded_plugins() == ["alpha"]  # not ["alpha", "alpha"]
+
+
+def test_loaded_plugins_records_app_style_plugins(monkeypatch):
+    """A plugin with ``register_all(app)`` is also recorded once invoked."""
+    received = []
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((lambda app: received.append(app), "needs-app")),
+    )
+    sentinel = object()
+    ext.load_plugins(app=sentinel)
+    assert received == [sentinel]
+    assert ext.loaded_plugins() == ["needs-app"]
+
+
+# ── GET /api/extensions ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client():
+    from routes.extensions import bp_extensions
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_extensions)
+    return app.test_client()
+
+
+def test_api_extensions_shape_empty(client):
+    resp = client.get("/api/extensions")
+    assert resp.status_code == 200
+    body = json.loads(resp.data)
+    assert body == {
+        "plugins": [],
+        "plugin_count": 0,
+        "events": [],
+        "handler_counts": {},
+    }
+
+
+def test_api_extensions_reports_loaded_plugins(client, monkeypatch):
+    monkeypatch.setattr(
+        ext, "_select_entry_points",
+        lambda group: _fake_eps((lambda: None, "clawmetry-pro")),
+    )
+    ext.load_plugins()
+
+    body = json.loads(client.get("/api/extensions").data)
+    assert body["plugins"] == ["clawmetry-pro"]
+    assert body["plugin_count"] == 1
+
+
+def test_api_extensions_reports_registered_events(client):
+    ext.register("test.evt.api.a", lambda p: None)
+    ext.register("test.evt.api.a", lambda p: None)  # 2 handlers for one event
+    ext.register("test.evt.api.b", lambda p: None)
+
+    body = json.loads(client.get("/api/extensions").data)
+    assert "test.evt.api.a" in body["events"]
+    assert "test.evt.api.b" in body["events"]
+    assert body["handler_counts"]["test.evt.api.a"] >= 2
+    assert body["handler_counts"]["test.evt.api.b"] >= 1
+
+
+def test_api_extensions_never_raises(client, monkeypatch):
+    """If introspection itself blows up, the endpoint still returns 200 with
+    a safe empty shape — the dashboard always has something to render."""
+    def explode():
+        raise RuntimeError("introspection broken")
+
+    monkeypatch.setattr(ext, "loaded_plugins", explode)
+
+    resp = client.get("/api/extensions")
+    assert resp.status_code == 200
+    body = json.loads(resp.data)
+    assert body == {
+        "plugins": [],
+        "plugin_count": 0,
+        "events": [],
+        "handler_counts": {},
+    }


### PR DESCRIPTION
## Summary

The entry-point loader in `clawmetry/extensions.py` is how the closed-source `clawmetry-pro` wheel hooks its runtime adapters into the dashboard. Until now there was **no in-process way** to ask *"is the paid package actually wired in on this node?"* — operators had to scrape `pip list` or daemon logs.

This PR adds a diagnostic mirror of the existing `registered_events()` / `handler_count()` helpers. The new helper + endpoint are the obvious answer to the question every Pro install triage walks back to: *did the plugin actually load?*

- `clawmetry.extensions.loaded_plugins() -> list[str]` — names of plugin entry points that loaded successfully in this process.
- `GET /api/extensions` — wire shape carrying those names plus the registered-event hooks, never-raising on any introspection failure.

Always free, never raises, no entitlement check (knowing which plugins loaded is diagnostic, not gated). Pure addition — nothing on the existing loader path changes.

## Why this isn't in any of the in-flight entitlement drafts

The open entitlement PR stack (#2426 `feature_catalog`, #2692 `tier_catalog`, #2722 `allows_node_count`, #2790 `allows_retention_window`, #2792 `channel_limit`, #2810 retention in `to_dict`, #2925 `runtime_tier`, #2955 `locked_*`, #2968 `tier_rank`/`is_at_least`, #2978 `clawmetry tier` CLI) all extends the **entitlement** surface. This PR extends the **plugin loader** surface — orthogonal axis, distinct file (`clawmetry/extensions.py`), distinct route module, no edit-window overlap.

## Changes

### `clawmetry/extensions.py`
- New module-level `_loaded_plugins: list[str]`, populated only **after** the plugin's `register_all()` returns successfully (a plugin that raised stays out — matching the warning-and-continue posture of `load_plugins()`).
- `loaded_plugins()` returns a **shallow copy** of that list so callers can't mutate the registry.
- The list is cleared when `load_plugins()` re-runs (i.e. `_loaded` was flipped back to `False`) so a reloaded daemon doesn't see ghost duplicates.

### `routes/extensions.py` (new)
- `bp_extensions` / `GET /api/extensions` returning:
  ```jsonc
  {
    "plugins":        ["clawmetry-pro", ...],
    "plugin_count":   1,
    "events":         ["session.snapshot", ...],
    "handler_counts": {"session.snapshot": 2, ...}
  }
  ```
- Never-raise fallback emits an empty shape so the dashboard diagnostic panel always has something safe to render — never a 5xx.

### `dashboard.py`
- Import + register `bp_extensions` next to `bp_entitlement`.

### `tests/test_extensions_introspection.py` (new, 10 tests)
- Empty-state contract before any load.
- Copy semantics — caller mutation of `loaded_plugins()` doesn't corrupt the registry.
- Success-only recording (failed plugins excluded).
- Idempotent re-load — flipping `_loaded` back to `False` doesn't produce ghost duplicates.
- App-style `register_all(app)` plugins are recorded once invoked.
- API wire shape including the never-raise fallback via a monkeypatched explosion in `loaded_plugins()`.
- Autouse fixture snapshots/restores the event registry so handlers registered in this suite can't leak into adjacent ones and vice versa.

## Grace / enforce

Pure addition. No behavior change in grace mode or under enforcement: this PR adds a diagnostic read surface, nothing more. No `allows_*` check is invoked anywhere on the new path.

## Test plan

- [x] `python3 -m py_compile clawmetry/extensions.py routes/extensions.py tests/test_extensions_introspection.py` — clean
- [x] `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — clean
- [x] `python3 -m pytest tests/test_extensions_introspection.py -v` → **10/10 pass**
- [x] `python3 -m pytest tests/test_extensions.py tests/test_extensions_introspection.py tests/test_claudecode_loads_plugins.py tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py -q` → **65/65 pass** (no regression in adjacent surfaces)
- [x] The three `tests/test_license.py::test_auto_provision_*` failures are pre-existing on `origin/main` (`'_Resp' object has no attribute 'headers'` — mock fixture issue with the recent Content-Disposition handling in `_download_wheel`) and unrelated to this PR.
- [ ] Frontend rendering of `/api/extensions` (a diagnostic badge in the status footer) — separate PR, out of scope.

## Local operator verification checklist

Since this agent has no access to your machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser, please:

1. `git fetch origin feat/extensions-introspection && git checkout feat/extensions-introspection`
2. Copy the changed files into the live install:
   ```bash
   cp clawmetry/extensions.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/extensions.py
   cp routes/extensions.py    ~/.clawmetry/lib/python3.*/site-packages/routes/extensions.py
   ```
3. Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
4. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. Hit the new endpoint:
   ```bash
   curl -s http://localhost:8900/api/extensions | python3 -m json.tool
   ```
   Expect a 200 with `plugins`, `plugin_count`, `events`, `handler_counts`. On a Pro-entitled install `plugins` should contain `clawmetry-pro` (entry-point name from the wheel). On an OSS-only install it should be `[]`.
6. Confirm `/api/entitlement` still returns its existing shape (this PR does not modify it).
7. Decrypt the live cloud snapshot and confirm no behavioural drift in any existing surface.
8. Browser-check the dashboard — no UI surface consumes `/api/extensions` yet (a diagnostic badge in the status footer is a follow-up).

This PR is **DRAFT** — I am not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Grace mode stays on. Once you've run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzquCnEAsnrDUvKBzs9cP7)_