### PR TITLE
feat(rollups): materialized model/runtime/session rollup tables written at ingest + accuracy gates (#2988)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -47,6 +47,7 @@ import time
 from collections import deque
 from contextlib import contextmanager
 from datetime import datetime
+from datetime import date as _dt_date
 from pathlib import Path
 from typing import Any, Iterable, Iterator
 
@@ -115,6 +116,8 @@ def _migrate_legacy_db_path() -> None:
 FLUSH_INTERVAL_SECS = float(os.environ.get("CLAWMETRY_LOCAL_FLUSH_SECS", "2.0"))
 FLUSH_BATCH = int(os.environ.get("CLAWMETRY_LOCAL_FLUSH_BATCH", "1000"))
 RING_MAX = int(os.environ.get("CLAWMETRY_LOCAL_RING_MAX", "10000"))
+# #2988 — events scanned per pass during the one-time rollup backfill.
+ROLLUP_BACKFILL_CHUNK = int(os.environ.get("CLAWMETRY_ROLLUP_BACKFILL_CHUNK", "5000"))
 # Bounded-retry budget for transient DuckDB write failures (lock contention,
 # brief disk hiccups). Default 3 attempts × ≤1s backoff = ≤1.4s wall. After
 # the budget the flush re-raises and the batch stays queued in the ring for
@@ -285,6 +288,51 @@ _DDL = [
         event_count   INTEGER DEFAULT 0,
         error_count   INTEGER DEFAULT 0,
         PRIMARY KEY (agent_type, agent_id, workspace_id, day)
+    )
+    """,
+    # ── Query Spine P2 (#2988): materialized rollups, written incrementally
+    # at ingest by the daemon's own store handle (never a read-only re-open).
+    # Upserts are O(events ingested per flush); a one-time chunked backfill
+    # (backfill_rollups) rebuilds them on upgrade. Day keys are derived from
+    # the event/session timestamp's date part (ts[:10], no tz conversion).
+    # Rows survive event pruning on purpose: they are the durable summary.
+    """
+    CREATE TABLE IF NOT EXISTS rollup_model_daily (
+        day           DATE    NOT NULL,
+        model         VARCHAR NOT NULL,
+        runtime       VARCHAR NOT NULL,
+        tokens_in     BIGINT  DEFAULT 0,
+        tokens_out    BIGINT  DEFAULT 0,
+        cache_read    BIGINT  DEFAULT 0,
+        cache_write   BIGINT  DEFAULT 0,
+        cost_usd      DOUBLE  DEFAULT 0,
+        calls         BIGINT  DEFAULT 0,
+        PRIMARY KEY (day, model, runtime)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS rollup_runtime_daily (
+        day              DATE    NOT NULL,
+        runtime          VARCHAR NOT NULL,
+        tokens           BIGINT  DEFAULT 0,
+        cost_usd         DOUBLE  DEFAULT 0,
+        sessions         BIGINT  DEFAULT 0,
+        active_sessions  BIGINT  DEFAULT 0,
+        PRIMARY KEY (day, runtime)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS rollup_session (
+        session_id     VARCHAR PRIMARY KEY,
+        runtime        VARCHAR,
+        title          VARCHAR,
+        status         VARCHAR,
+        started_at     VARCHAR,
+        last_activity  VARCHAR,
+        tokens         BIGINT  DEFAULT 0,
+        cost_usd       DOUBLE  DEFAULT 0,
+        turns          BIGINT  DEFAULT 0,
+        stuck_flag     BOOLEAN DEFAULT FALSE
     )
     """,
     """
@@ -1575,6 +1623,15 @@ class LocalStore:
         if not read_only:
             try:
                 self._migrate()
+                # #2988 — one-time bounded backfill of the materialized
+                # rollup tables on upgrade (no-op once they hold rows).
+                try:
+                    self.backfill_rollups()
+                except Exception:
+                    log.exception(
+                        "local store: rollup backfill failed (continuing; "
+                        "rollups fill incrementally from here)"
+                    )
             except Exception:
                 # Release the file lock so the next boot can open the
                 # db cleanly and retry the migration (#1602). Without
@@ -1824,6 +1881,15 @@ class LocalStore:
             now_ms,
         ]
         with self._write_lock:
+            # #2988 — snapshot the pre-upsert day keys so the rollup session
+            # counts only recompute the (runtime, day) cells that actually
+            # change. Direct conn read (NOT _fetch — it takes _write_lock
+            # internally and would deadlock here).
+            prev = self._conn.execute(
+                "SELECT started_at, last_active_at FROM sessions"
+                " WHERE agent_type = ? AND session_id = ?",
+                [atype, sid],
+            ).fetchone()
             # Upsert: replace if (agent_type, session_id) exists.
             self._conn.execute("""
                 INSERT INTO sessions (
@@ -1846,6 +1912,12 @@ class LocalStore:
                     metadata       = COALESCE(excluded.metadata, sessions.metadata),
                     updated_at     = excluded.updated_at
             """, params)
+            try:
+                self._upsert_session_rollup_locked(session, atype, prev)
+            except Exception:
+                log.exception(
+                    "local store: session rollup upsert failed (non-fatal)"
+                )
 
     def reclassify_session_outcome(
         self,
@@ -4591,11 +4663,21 @@ class LocalStore:
             if not self._ring:
                 return 0
             batch = list(self._ring)
-        rows = [_event_to_row(e) for e in batch]
+        usages = [_extract_event_usage(e) for e in batch]
+        rows = [_event_to_row(e, u) for e, u in zip(batch, usages)]
         last_exc: Exception | None = None
         for attempt in range(FLUSH_MAX_ATTEMPTS):
             try:
                 with self._write_lock:
+                    # Rollups (#2988) must count each event exactly once:
+                    # INSERT OR IGNORE silently drops ids already in the
+                    # events table (and in-batch dupes), so only the rows
+                    # that will actually insert may increment the rollups.
+                    # Indexed id lookup — O(batch), never a table scan.
+                    new_idx = self._new_event_indices_locked(batch)
+                    model_d, runtime_d = _rollup_deltas(
+                        (batch[i], usages[i]) for i in new_idx
+                    )
                     with _txn(self._conn):
                         self._conn.executemany(
                             """
@@ -4607,6 +4689,10 @@ class LocalStore:
                             rows,
                         )
                         self._stamp_integrity(batch, self._conn)
+                        # Same transaction: a failed rollup write rolls the
+                        # event insert back too, and the ring (snapshot-then-
+                        # pop) retries the whole batch consistently.
+                        self._apply_rollup_deltas_locked(model_d, runtime_d)
                 last_exc = None
                 break
             except Exception as exc:  # noqa: BLE001 — surface any DuckDB error
@@ -4691,6 +4777,421 @@ class LocalStore:
         if self._read_only:
             return 0
         return self._flush_now()
+
+    # ── materialized rollups (#2988, Query Spine P2) ─────────────────────
+    #
+    # Written ONLY here, on the daemon's own writer handle, inside the same
+    # transaction as the event insert (events) / under the same _write_lock
+    # as the sessions upsert (sessions). Never opened read-only, never
+    # recomputed full-table on the hot path.
+
+    def _new_event_indices_locked(self, batch: list[dict[str, Any]]) -> list[int]:
+        """Indices of batch events that are NOT yet in the events table and
+        not duplicated earlier in the batch — i.e. the rows INSERT OR IGNORE
+        will actually insert. Caller holds ``_write_lock``."""
+        seen: set[str] = set()
+        uniq: list[int] = []
+        for i, e in enumerate(batch):
+            eid = str(e.get("id"))
+            if eid in seen:
+                continue
+            seen.add(eid)
+            uniq.append(i)
+        existing: set[str] = set()
+        ids = [str(batch[i]["id"]) for i in uniq]
+        for off in range(0, len(ids), 500):
+            chunk = ids[off:off + 500]
+            ph = ",".join("?" * len(chunk))
+            cur = self._conn.execute(
+                f"SELECT id FROM events WHERE id IN ({ph})", chunk
+            )
+            existing.update(r[0] for r in cur.fetchall())
+        return [i for i in uniq if str(batch[i]["id"]) not in existing]
+
+    def _apply_rollup_deltas_locked(
+        self,
+        model_deltas: dict[tuple, list],
+        runtime_deltas: dict[tuple, list],
+    ) -> None:
+        """Additive upserts for one ingest batch. O(distinct keys in the
+        batch); caller holds ``_write_lock`` (and usually an open _txn)."""
+        if model_deltas:
+            self._conn.executemany(
+                """
+                INSERT INTO rollup_model_daily
+                  (day, model, runtime, tokens_in, tokens_out,
+                   cache_read, cache_write, cost_usd, calls)
+                VALUES (CAST(? AS DATE),?,?,?,?,?,?,?,?)
+                ON CONFLICT (day, model, runtime) DO UPDATE SET
+                    tokens_in   = rollup_model_daily.tokens_in   + excluded.tokens_in,
+                    tokens_out  = rollup_model_daily.tokens_out  + excluded.tokens_out,
+                    cache_read  = rollup_model_daily.cache_read  + excluded.cache_read,
+                    cache_write = rollup_model_daily.cache_write + excluded.cache_write,
+                    cost_usd    = rollup_model_daily.cost_usd    + excluded.cost_usd,
+                    calls       = rollup_model_daily.calls       + excluded.calls
+                """,
+                [[day, model, runtime, *vals]
+                 for (day, model, runtime), vals in model_deltas.items()],
+            )
+        if runtime_deltas:
+            self._conn.executemany(
+                """
+                INSERT INTO rollup_runtime_daily
+                  (day, runtime, tokens, cost_usd, sessions, active_sessions)
+                VALUES (CAST(? AS DATE),?,?,?,0,0)
+                ON CONFLICT (day, runtime) DO UPDATE SET
+                    tokens   = rollup_runtime_daily.tokens   + excluded.tokens,
+                    cost_usd = rollup_runtime_daily.cost_usd + excluded.cost_usd
+                """,
+                [[day, runtime, *vals]
+                 for (day, runtime), vals in runtime_deltas.items()],
+            )
+
+    def _refresh_runtime_day_session_counts_locked(
+        self, runtime: str, days: Iterable[str],
+    ) -> None:
+        """Recompute the sessions/active_sessions cells of
+        ``rollup_runtime_daily`` for the given (runtime, day) pairs from the
+        sessions table. Bounded: an indexed single-runtime scan per touched
+        day (the sessions table is small — never the events table). Caller
+        holds ``_write_lock``.
+
+        Semantics: ``sessions`` = sessions of the runtime whose effective
+        start (COALESCE(started_at, last_active_at)) date is the day;
+        ``active_sessions`` = sessions whose last activity date is the day.
+        """
+        for day in days:
+            started = self._conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE agent_type = ? AND "
+                "substr(COALESCE(started_at, last_active_at), 1, 10) = ?",
+                [runtime, day],
+            ).fetchone()[0]
+            active = self._conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE agent_type = ? AND "
+                "substr(last_active_at, 1, 10) = ?",
+                [runtime, day],
+            ).fetchone()[0]
+            self._conn.execute(
+                """
+                INSERT INTO rollup_runtime_daily
+                  (day, runtime, tokens, cost_usd, sessions, active_sessions)
+                VALUES (CAST(? AS DATE),?,0,0,?,?)
+                ON CONFLICT (day, runtime) DO UPDATE SET
+                    sessions        = excluded.sessions,
+                    active_sessions = excluded.active_sessions
+                """,
+                [day, runtime, int(started), int(active)],
+            )
+
+    def _upsert_session_rollup_locked(
+        self,
+        session: dict[str, Any],
+        atype: str,
+        prev: tuple | None,
+    ) -> None:
+        """Mirror one ``ingest_session`` upsert into ``rollup_session`` and
+        refresh the touched (runtime, day) session counts. Caller holds
+        ``_write_lock``; ``prev`` is the pre-upsert (started_at,
+        last_active_at) row (None for a new session)."""
+        sid = str(session.get("session_id"))
+        started = session.get("started_at")
+        last_active = session.get("last_active_at")
+        stuck = bool(session.get("stuck") or session.get("stuck_flag") or False)
+        self._conn.execute(
+            """
+            INSERT INTO rollup_session
+              (session_id, runtime, title, status, started_at,
+               last_activity, tokens, cost_usd, turns, stuck_flag)
+            VALUES (?,?,?,?,?,?,?,?,?,?)
+            ON CONFLICT (session_id) DO UPDATE SET
+                runtime       = excluded.runtime,
+                title         = COALESCE(excluded.title, rollup_session.title),
+                status        = excluded.status,
+                started_at    = COALESCE(rollup_session.started_at, excluded.started_at),
+                last_activity = excluded.last_activity,
+                tokens        = excluded.tokens,
+                cost_usd      = excluded.cost_usd,
+                turns         = excluded.turns,
+                stuck_flag    = excluded.stuck_flag
+            """,
+            [
+                sid, atype, session.get("title"), session.get("status"),
+                started, last_active,
+                int(session.get("total_tokens") or 0),
+                float(session.get("cost_usd") or 0),
+                int(session.get("message_count") or 0),
+                stuck,
+            ],
+        )
+        # Touched-day session counts. ``started_at`` keeps the existing value
+        # on conflict (COALESCE(sessions.started_at, excluded.started_at)),
+        # so the effective start day comes from the pre-upsert row when set.
+        eff_started = (prev[0] if prev and prev[0] else started)
+        new_days = {
+            _event_day(eff_started or last_active),
+            _event_day(last_active),
+        } - {None}
+        if prev is not None:
+            old_days = {
+                _event_day(prev[0] or prev[1]),
+                _event_day(prev[1]),
+            } - {None}
+            days = new_days ^ old_days
+        else:
+            days = new_days
+        if days:
+            self._refresh_runtime_day_session_counts_locked(atype, sorted(days))
+
+    def backfill_rollups(self, *, force: bool = False) -> dict[str, Any]:
+        """One-time, bounded, chunked rebuild of the three rollup tables from
+        the events + sessions tables. Runs at writer start when the rollups
+        are empty but events exist (the upgrade path); ``force=True`` wipes
+        and rebuilds (used by tests / manual repair).
+
+        Chunked keyset scan over events by rowid (memory stays capped at
+        CLAWMETRY_ROLLUP_BACKFILL_CHUNK rows per pass, progress logged).
+        Never called from a request handler.
+        """
+        if self._read_only:
+            return {"skipped": True, "reason": "read_only"}
+        with self._write_lock:
+            have = self._conn.execute(
+                "SELECT (SELECT COUNT(*) FROM rollup_model_daily)"
+                " + (SELECT COUNT(*) FROM rollup_runtime_daily)"
+                " + (SELECT COUNT(*) FROM rollup_session)"
+            ).fetchone()[0]
+            n_events = self._conn.execute(
+                "SELECT COUNT(*) FROM events"
+            ).fetchone()[0]
+            n_sessions = self._conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            if have and not force:
+                return {"skipped": True, "reason": "rollups_populated"}
+            if not n_events and not n_sessions:
+                return {"skipped": True, "reason": "store_empty"}
+            log.info(
+                "local store: backfilling rollup tables from %d events / %d "
+                "sessions (one-time, chunk=%d)",
+                n_events, n_sessions, ROLLUP_BACKFILL_CHUNK,
+            )
+            t0 = time.monotonic()
+            with _txn(self._conn):
+                if force:
+                    self._conn.execute("DELETE FROM rollup_model_daily")
+                    self._conn.execute("DELETE FROM rollup_runtime_daily")
+                    self._conn.execute("DELETE FROM rollup_session")
+                # 1. events -> rollup_model_daily + runtime tokens/cost.
+                last_rowid = -1
+                done = 0
+                while True:
+                    cur = self._conn.execute(
+                        """
+                        SELECT rowid, agent_type, ts, data,
+                               cost_usd, token_count, model
+                        FROM events WHERE rowid > ?
+                        ORDER BY rowid LIMIT ?
+                        """,
+                        [last_rowid, ROLLUP_BACKFILL_CHUNK],
+                    )
+                    rows = cur.fetchall()
+                    if not rows:
+                        break
+                    last_rowid = rows[-1][0]
+                    pairs = []
+                    for (_rid, atype, ts, blob, cost, tokens, model) in rows:
+                        data = None
+                        if blob is not None:
+                            try:
+                                raw = _ccr.maybe_decompress(blob)
+                                text = (raw.decode("utf-8")
+                                        if isinstance(raw, (bytes, bytearray))
+                                        else raw)
+                                data = json.loads(text)
+                            except Exception:
+                                data = None
+                        # The STORED cost/token/model columns are the source
+                        # of truth (they were priced once at original ingest);
+                        # top-level keys win inside _extract_event_usage, so
+                        # only the in/out/cache splits are re-read from data.
+                        pseudo = {
+                            "agent_type": atype, "ts": ts,
+                            "cost_usd": cost, "token_count": tokens,
+                            "model": model,
+                            "data": data if isinstance(data, dict) else None,
+                        }
+                        pairs.append((pseudo, _extract_event_usage(pseudo)))
+                    model_d, runtime_d = _rollup_deltas(pairs)
+                    self._apply_rollup_deltas_locked(model_d, runtime_d)
+                    done += len(rows)
+                    log.info(
+                        "local store: rollup backfill %d/%d events",
+                        done, n_events,
+                    )
+                # 2. sessions -> rollup_session (newest row wins when a bare
+                # session_id exists under two agent_types).
+                self._conn.execute(
+                    """
+                    INSERT OR IGNORE INTO rollup_session
+                      (session_id, runtime, title, status, started_at,
+                       last_activity, tokens, cost_usd, turns, stuck_flag)
+                    SELECT session_id, agent_type, title, status, started_at,
+                           last_active_at, COALESCE(total_tokens, 0),
+                           COALESCE(cost_usd, 0), COALESCE(message_count, 0),
+                           FALSE
+                    FROM (
+                        SELECT *, ROW_NUMBER() OVER (
+                            PARTITION BY session_id
+                            ORDER BY updated_at DESC NULLS LAST
+                        ) AS _rn FROM sessions
+                    ) WHERE _rn = 1
+                    """
+                )
+                # 3. sessions -> per-(runtime, day) session counts.
+                day_counts: dict[tuple[str, str], list[int]] = {}
+                for atype, d, n in self._conn.execute(
+                    "SELECT agent_type,"
+                    " substr(COALESCE(started_at, last_active_at), 1, 10), COUNT(*)"
+                    " FROM sessions"
+                    " WHERE COALESCE(started_at, last_active_at) IS NOT NULL"
+                    " GROUP BY 1, 2"
+                ).fetchall():
+                    if _event_day(d):
+                        day_counts.setdefault((str(atype), d), [0, 0])[0] = int(n)
+                for atype, d, n in self._conn.execute(
+                    "SELECT agent_type, substr(last_active_at, 1, 10), COUNT(*)"
+                    " FROM sessions WHERE last_active_at IS NOT NULL"
+                    " GROUP BY 1, 2"
+                ).fetchall():
+                    if _event_day(d):
+                        day_counts.setdefault((str(atype), d), [0, 0])[1] = int(n)
+                if day_counts:
+                    self._conn.executemany(
+                        """
+                        INSERT INTO rollup_runtime_daily
+                          (day, runtime, tokens, cost_usd, sessions, active_sessions)
+                        VALUES (CAST(? AS DATE),?,0,0,?,?)
+                        ON CONFLICT (day, runtime) DO UPDATE SET
+                            sessions        = excluded.sessions,
+                            active_sessions = excluded.active_sessions
+                        """,
+                        [[d, rt, s, a]
+                         for (rt, d), (s, a) in day_counts.items()],
+                    )
+            elapsed = time.monotonic() - t0
+            log.info(
+                "local store: rollup backfill done — %d events, %d sessions "
+                "in %.1fs", n_events, n_sessions, elapsed,
+            )
+            return {
+                "skipped": False, "events": int(n_events),
+                "sessions": int(n_sessions), "elapsed_s": round(elapsed, 2),
+            }
+
+    def query_rollup_model_daily(
+        self,
+        *,
+        runtime: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Read the per-(day, model, runtime) materialized rollup. ``since``/
+        ``until`` accept ISO timestamps or bare dates (date part is compared;
+        unparseable bounds are ignored rather than raising)."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if runtime:
+            clauses.append("runtime = ?")
+            params.append(str(runtime))
+        if since:
+            clauses.append("(TRY_CAST(substr(?,1,10) AS DATE) IS NULL"
+                           " OR day >= TRY_CAST(substr(?,1,10) AS DATE))")
+            params.extend([str(since), str(since)])
+        if until:
+            clauses.append("(TRY_CAST(substr(?,1,10) AS DATE) IS NULL"
+                           " OR day <= TRY_CAST(substr(?,1,10) AS DATE))")
+            params.extend([str(until), str(until)])
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(int(limit))
+        rows = self._fetch(
+            f"""
+            SELECT CAST(day AS VARCHAR) AS day, model, runtime,
+                   tokens_in, tokens_out, cache_read, cache_write,
+                   ROUND(cost_usd, 8) AS cost_usd, calls
+            FROM rollup_model_daily {where}
+            ORDER BY day DESC, runtime, model
+            LIMIT ?
+            """,
+            params,
+        )
+        cols = ["day", "model", "runtime", "tokens_in", "tokens_out",
+                "cache_read", "cache_write", "cost_usd", "calls"]
+        return [dict(zip(cols, r)) for r in rows]
+
+    def query_rollup_runtime_daily(
+        self,
+        *,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Read the per-(day, runtime) materialized rollup."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if since:
+            clauses.append("(TRY_CAST(substr(?,1,10) AS DATE) IS NULL"
+                           " OR day >= TRY_CAST(substr(?,1,10) AS DATE))")
+            params.extend([str(since), str(since)])
+        if until:
+            clauses.append("(TRY_CAST(substr(?,1,10) AS DATE) IS NULL"
+                           " OR day <= TRY_CAST(substr(?,1,10) AS DATE))")
+            params.extend([str(until), str(until)])
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(int(limit))
+        rows = self._fetch(
+            f"""
+            SELECT CAST(day AS VARCHAR) AS day, runtime, tokens,
+                   ROUND(cost_usd, 8) AS cost_usd, sessions, active_sessions
+            FROM rollup_runtime_daily {where}
+            ORDER BY day DESC, runtime
+            LIMIT ?
+            """,
+            params,
+        )
+        cols = ["day", "runtime", "tokens", "cost_usd", "sessions",
+                "active_sessions"]
+        return [dict(zip(cols, r)) for r in rows]
+
+    def query_rollup_sessions(
+        self,
+        *,
+        runtime: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Read the per-session materialized rollup, most recently active
+        first."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if runtime:
+            clauses.append("runtime = ?")
+            params.append(str(runtime))
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(int(limit))
+        rows = self._fetch(
+            f"""
+            SELECT session_id, runtime, title, status, started_at,
+                   last_activity, tokens, ROUND(cost_usd, 8) AS cost_usd,
+                   turns, stuck_flag
+            FROM rollup_session {where}
+            ORDER BY COALESCE(last_activity, started_at) DESC NULLS LAST
+            LIMIT ?
+            """,
+            params,
+        )
+        cols = ["session_id", "runtime", "title", "status", "started_at",
+                "last_activity", "tokens", "cost_usd", "turns", "stuck_flag"]
+        return [dict(zip(cols, r)) for r in rows]
 
     # ── queries ─────────────────────────────────────────────────────────
 
@@ -9380,7 +9881,21 @@ _EVENT_COLS = [
 def _extract_event_metrics(
     e: dict[str, Any],
 ) -> tuple[float | None, int | None, str | None]:
-    """Pull (cost_usd, token_count, model) from an event with shape fallbacks.
+    """Back-compat wrapper around :func:`_extract_event_usage` returning the
+    historical ``(cost_usd, token_count, model)`` triple."""
+    u = _extract_event_usage(e)
+    return u["cost"], u["tokens"], u["model"]
+
+
+def _extract_event_usage(e: dict[str, Any]) -> dict[str, Any]:
+    """Pull the full usage breakdown from an event with shape fallbacks.
+
+    Returns ``{"cost", "tokens", "model", "tokens_in", "tokens_out",
+    "cache_read", "cache_write"}`` where ``cost``/``tokens``/``model`` keep
+    the exact semantics the events-table columns have always had (see below)
+    and the four split fields are the per-call input/output/cache token
+    counts (0 when the shape doesn't carry a split). The splits feed the
+    rollup_model_daily materialized table (#2988).
 
     Top-level ``cost_usd`` / ``token_count`` / ``model`` are honoured first —
     that's what the interceptor, claude-cli adapter, sync, and tests already
@@ -9407,9 +9922,17 @@ def _extract_event_metrics(
     model = e.get("model")
     provider = e.get("provider")
 
+    def _out(cr: int = 0, cw: int = 0,
+             ti: int | None = None, to: int | None = None) -> dict[str, Any]:
+        return {
+            "cost": cost, "tokens": tokens, "model": model,
+            "tokens_in": int(ti or 0), "tokens_out": int(to or 0),
+            "cache_read": int(cr or 0), "cache_write": int(cw or 0),
+        }
+
     d = e.get("data") if isinstance(e.get("data"), dict) else None
     if d is None:
-        return cost, tokens, model
+        return _out()
 
     if not model:
         model = d.get("modelId") or d.get("model") or d.get("model_id")
@@ -9565,10 +10088,83 @@ def _extract_event_metrics(
         except Exception:
             pass
 
-    return cost, tokens, model
+    return _out(cache_read, cache_write, tokens_in, tokens_out)
 
 
-def _event_to_row(e: dict[str, Any]) -> tuple:
+def _event_day(ts: Any) -> str | None:
+    """Day key ('YYYY-MM-DD') for a rollup row, derived from the timestamp
+    string's date part — no timezone conversion, matching how the rest of
+    the store buckets days (substr(ts,1,10)). Returns None (event skipped
+    from rollups) when the prefix is not a valid calendar date."""
+    s = str(ts or "")[:10]
+    if len(s) != 10:
+        return None
+    try:
+        _dt_date.fromisoformat(s)
+    except ValueError:
+        return None
+    return s
+
+
+def _rollup_deltas(
+    pairs: Iterable[tuple[dict[str, Any], dict[str, Any]]],
+) -> tuple[dict[tuple, list], dict[tuple, list]]:
+    """Aggregate ``(event, usage)`` pairs (usage from
+    :func:`_extract_event_usage`) into per-key rollup increments.
+
+    Returns ``(model_deltas, runtime_deltas)``:
+
+    * ``model_deltas[(day, model, runtime)]`` ->
+      ``[tokens_in, tokens_out, cache_read, cache_write, cost_usd, calls]``
+      — only events that resolved a model contribute (one "call" each).
+    * ``runtime_deltas[(day, runtime)]`` -> ``[tokens, cost_usd]`` — every
+      event with a valid day contributes its stored token_count/cost_usd
+      (NULL treated as 0), so the runtime series matches a
+      SUM(token_count)/SUM(cost_usd) GROUP BY substr(ts,1,10), agent_type
+      full scan of the events table exactly.
+
+    O(events in the batch); the caller applies the result as
+    INSERT .. ON CONFLICT additive upserts. Pricing is NOT re-derived here:
+    ``usage["cost"]`` is the same value the events row stores, so cost is
+    priced exactly once (at extraction, via the longest-prefix rates in
+    providers_pricing).
+    """
+    model_d: dict[tuple, list] = {}
+    runtime_d: dict[tuple, list] = {}
+    for e, u in pairs:
+        day = _event_day(e.get("ts"))
+        if day is None:
+            continue
+        runtime = str(e.get("agent_type") or "openclaw")
+        tokens = int(u["tokens"] or 0)
+        cost = float(u["cost"] or 0.0)
+        rk = (day, runtime)
+        racc = runtime_d.get(rk)
+        if racc is None:
+            runtime_d[rk] = [tokens, cost]
+        else:
+            racc[0] += tokens
+            racc[1] += cost
+        model = u["model"]
+        if not model:
+            continue
+        mk = (day, str(model), runtime)
+        macc = model_d.get(mk)
+        if macc is None:
+            model_d[mk] = [int(u["tokens_in"]), int(u["tokens_out"]),
+                           int(u["cache_read"]), int(u["cache_write"]),
+                           cost, 1]
+        else:
+            macc[0] += int(u["tokens_in"])
+            macc[1] += int(u["tokens_out"])
+            macc[2] += int(u["cache_read"])
+            macc[3] += int(u["cache_write"])
+            macc[4] += cost
+            macc[5] += 1
+    return model_d, runtime_d
+
+
+def _event_to_row(e: dict[str, Any], usage: dict[str, Any] | None = None) -> tuple:
     """Coerce an event dict into the column tuple for the events table.
     Unknown keys are tolerated and dropped — events come from many sources
     (jsonl parser, gateway, claude-cli adapter) with slightly different
@@ -9581,7 +10177,8 @@ def _event_to_row(e: dict[str, Any]) -> tuple:
             data = json.dumps(data, separators=(",", ":")).encode("utf-8")
             if _ccr.enabled():
                 data = _ccr.compress(data)
-    cost, tokens, model = _extract_event_metrics(e)
+    u = usage if usage is not None else _extract_event_usage(e)
+    cost, tokens, model = u["cost"], u["tokens"], u["model"]
     return (
         str(e["id"]),
         str(e.get("agent_type") or "openclaw"),

--- a/clawmetry/query_contract.py
+++ b/clawmetry/query_contract.py
@@ -180,25 +180,46 @@ QUERY_CONTRACT: dict = {
                 "Non-goal: no per-model data in glance."),
     },
     "runtimes": {
-        "status": STATUS_PLANNED,
+        # Live since #2988 (Query Spine P2): served from the materialized
+        # rollup_runtime_daily table, written incrementally at ingest.
+        "status": STATUS_LIVE,
         "args": {
             "since": _arg(),
             "until": _arg(),
+            "limit": _arg(default=1000, lo=1, hi=10000),
         },
         "trust": TRUST_PLAINTEXT,
-        "backing": "rollup_runtimes",
-        "doc": "Per-runtime activity/cost rollup (claude_code, openclaw, ...).",
+        "backing": "query_rollup_runtime_daily",
+        "doc": "Per-runtime daily activity/cost rollup (claude_code, openclaw, ...).",
     },
     "models": {
-        "status": STATUS_PLANNED,
+        # Live since #2988 (Query Spine P2): served from the materialized
+        # rollup_model_daily table, written incrementally at ingest.
+        "status": STATUS_LIVE,
         "args": {
             "runtime": _arg(),
             "since": _arg(),
             "until": _arg(),
+            "limit": _arg(default=1000, lo=1, hi=10000),
         },
         "trust": TRUST_PLAINTEXT,
-        "backing": "rollup_models",
-        "doc": "Per-model token/cost rollup across runtimes.",
+        "backing": "query_rollup_model_daily",
+        "doc": "Per-model daily token/cost rollup across runtimes.",
+    },
+    "rollup_sessions": {
+        # #2988: per-session materialized rollup (rollup_session table).
+        # Distinct from "sessions" (events-table GROUP BY) and "session"
+        # (planned single-session detail): this is the typed one-row-per-
+        # session summary the daemon maintains at ingest. Carries titles,
+        # so it is e2e-classed like every session/content method.
+        "status": STATUS_LIVE,
+        "args": {
+            "runtime": _arg(),
+            "limit": _arg(default=200, lo=1, hi=2000),
+        },
+        "trust": TRUST_E2E,
+        "backing": "query_rollup_sessions",
+        "doc": "Per-session materialized summary (title, status, totals, stuck flag).",
     },
     "usage": {
         "status": STATUS_PLANNED,

--- a/docs/QUERY_CONTRACT.md
+++ b/docs/QUERY_CONTRACT.md
@@ -39,6 +39,9 @@ test enforces both directions).
 | `events` | live | e2e | `query_events` | `session_id`, `agent_id`, `event_type`, `since`, `until`, `limit` (default 200, range 1..5000) | Raw event rows (tool calls, messages, errors), newest first. |
 | `external_calls` | live | e2e | `query_external_calls` | `session_id`, `since`, `until`, `limit` (default 200, range 1..2000) | External (non-LLM) API calls captured by the interceptor. |
 | `health` | live | plaintext | `health` | (none) | Store health snapshot (engine, size, ring depth, flush age). |
+| `models` | live | plaintext | `query_rollup_model_daily` | `runtime`, `since`, `until`, `limit` (default 1000, range 1..10000) | Per-model daily token/cost rollup across runtimes. |
+| `rollup_sessions` | live | e2e | `query_rollup_sessions` | `runtime`, `limit` (default 200, range 1..2000) | Per-session materialized summary (title, status, totals, stuck flag). |
+| `runtimes` | live | plaintext | `query_rollup_runtime_daily` | `since`, `until`, `limit` (default 1000, range 1..10000) | Per-runtime daily activity/cost rollup (claude_code, openclaw, ...). |
 | `search` | live | e2e | `query_search` | `q` (required), `model`, `status`, `since`, `until`, `limit` (default 50, range 1..500) | Full-text search over session titles and eval reasons. |
 | `sessions` | live | e2e | `query_sessions` | `agent_id`, `since`, `until`, `limit` (default 100, range 1..2000) | One row per session_id with start/end, event count, cost. |
 | `spans` | live | e2e | `query_spans` | `trace_id`, `session_id`, `agent_type`, `since`, `until`, `limit` (default 200, range 1..2000) | OTel span rows with full filters (trace/session/agent/time). |
@@ -47,9 +50,7 @@ test enforces both directions).
 | `approvals` | planned | plaintext | `query_approvals` | `status`, `limit` (default 100, range 1..1000) | Approval queue metadata (ids, states, timestamps; no content). |
 | `brain` | planned | e2e | `query_events` | `session_id`, `since`, `limit` (default 200, range 1..2000) | Reasoning/tool event slice powering the Brain feed. |
 | `glance` | planned | plaintext | `rollup_glance` | (none) | Device-facing top-line counters (sessions, cost, alerts). Non-goal: no per-model data in glance. |
-| `models` | planned | plaintext | `rollup_models` | `runtime`, `since`, `until` | Per-model token/cost rollup across runtimes. |
-| `runtimes` | planned | plaintext | `rollup_runtimes` | `since`, `until` | Per-runtime activity/cost rollup (claude_code, openclaw, ...). |
 | `session` | planned | e2e | `query_sessions_table` | `session_id` (required) | Single-session detail row (title, status, outcome, totals). |
 | `usage` | planned | plaintext | `rollup_usage_daily` | `runtime`, `since`, `until` | Daily token/cost usage series (input/output/cache splits). |
 
-Live methods: 9. Planned methods: 7.
+Live methods: 12. Planned methods: 5.

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -223,6 +223,24 @@ def _coerce_args(shape: str, raw: dict) -> dict:
             "until":      raw.get("until"),
             "limit":      _safe_int(raw.get("limit"), default=200, lo=1, hi=2000),
         }
+    if shape == "models":
+        return {
+            "runtime": raw.get("runtime"),
+            "since":   raw.get("since"),
+            "until":   raw.get("until"),
+            "limit":   _safe_int(raw.get("limit"), default=1000, lo=1, hi=10000),
+        }
+    if shape == "runtimes":
+        return {
+            "since": raw.get("since"),
+            "until": raw.get("until"),
+            "limit": _safe_int(raw.get("limit"), default=1000, lo=1, hi=10000),
+        }
+    if shape == "rollup_sessions":
+        return {
+            "runtime": raw.get("runtime"),
+            "limit":   _safe_int(raw.get("limit"), default=200, lo=1, hi=2000),
+        }
     if shape == "search":
         q = (raw.get("q") or "").strip()
         if not q:
@@ -692,6 +710,12 @@ _DAEMON_METHODS = frozenset({
     # Issue #2860: session full-text search. Read-only; routed through the
     # daemon proxy so the dashboard process never opens DuckDB writable.
     "query_search",
+    # #2988 (Query Spine P2): materialized rollup reads. The daemon writes
+    # the rollup tables at ingest; these are the read methods backing the
+    # q/1 "models" / "runtimes" / "rollup_sessions" contract shapes.
+    "query_rollup_model_daily",
+    "query_rollup_runtime_daily",
+    "query_rollup_sessions",
 })
 
 

--- a/tests/fixtures/query_contract/models.json
+++ b/tests/fixtures/query_contract/models.json
@@ -1,0 +1,30 @@
+{
+  "_elapsed_ms": "<volatile>",
+  "_shape": "models",
+  "_via": "<volatile>",
+  "count": 2,
+  "rows": [
+    {
+      "cache_read": 0,
+      "cache_write": 0,
+      "calls": 1,
+      "cost_usd": 0.004,
+      "day": "2026-01-02",
+      "model": "claude-haiku-4-5",
+      "runtime": "openclaw",
+      "tokens_in": 0,
+      "tokens_out": 0
+    },
+    {
+      "cache_read": 0,
+      "cache_write": 0,
+      "calls": 3,
+      "cost_usd": 0.006,
+      "day": "2026-01-02",
+      "model": "claude-opus-4-7",
+      "runtime": "openclaw",
+      "tokens_in": 0,
+      "tokens_out": 0
+    }
+  ]
+}

--- a/tests/fixtures/query_contract/rollup_sessions.json
+++ b/tests/fixtures/query_contract/rollup_sessions.json
@@ -1,0 +1,32 @@
+{
+  "_elapsed_ms": "<volatile>",
+  "_shape": "rollup_sessions",
+  "_via": "<volatile>",
+  "count": 2,
+  "rows": [
+    {
+      "cost_usd": 0.004,
+      "last_activity": "2026-01-02T10:00:03Z",
+      "runtime": "openclaw",
+      "session_id": "sess-b",
+      "started_at": "2026-01-02T10:00:03Z",
+      "status": "ended",
+      "stuck_flag": false,
+      "title": "beta cleanup",
+      "tokens": 40,
+      "turns": 1
+    },
+    {
+      "cost_usd": 0.006,
+      "last_activity": "2026-01-02T10:00:02Z",
+      "runtime": "openclaw",
+      "session_id": "sess-a",
+      "started_at": "2026-01-02T10:00:00Z",
+      "status": "active",
+      "stuck_flag": false,
+      "title": "golden alpha refactor",
+      "tokens": 60,
+      "turns": 3
+    }
+  ]
+}

--- a/tests/fixtures/query_contract/runtimes.json
+++ b/tests/fixtures/query_contract/runtimes.json
@@ -1,0 +1,16 @@
+{
+  "_elapsed_ms": "<volatile>",
+  "_shape": "runtimes",
+  "_via": "<volatile>",
+  "count": 1,
+  "rows": [
+    {
+      "active_sessions": 2,
+      "cost_usd": 0.01,
+      "day": "2026-01-02",
+      "runtime": "openclaw",
+      "sessions": 2,
+      "tokens": 100
+    }
+  ]
+}

--- a/tests/test_local_query_dispatch_edge_cases.py
+++ b/tests/test_local_query_dispatch_edge_cases.py
@@ -73,7 +73,11 @@ def test_known_shapes_are_exactly_the_allowlist(lq_app):
     lq, _c = lq_app
     assert set(lq._SHAPES) == {"events", "sessions", "aggregates", "health",
                                "transcript", "spans", "traces",
-                               "external_calls", "search"}, (
+                               "external_calls", "search",
+                               # #2988 Query Spine P2: materialized-rollup
+                               # backed shapes (models/runtimes plaintext
+                               # aggregates; rollup_sessions e2e-classed).
+                               "models", "runtimes", "rollup_sessions"}, (
         "the dispatch allowlist changed — review for new query surface before "
         "widening what the relay/cloud can ask the local store to run "
         f"(got {sorted(lq._SHAPES)})"

--- a/tests/test_query_contract_drift.py
+++ b/tests/test_query_contract_drift.py
@@ -162,6 +162,8 @@ EXPECTED_TRUST = {
     "approvals": "plaintext",
     "events": "e2e",
     "sessions": "e2e",
+    # #2988: rollup_session carries titles -> content class, never plaintext.
+    "rollup_sessions": "e2e",
     "session": "e2e",
     "transcript": "e2e",
     "brain": "e2e",

--- a/tests/test_query_contract_goldens.py
+++ b/tests/test_query_contract_goldens.py
@@ -42,6 +42,10 @@ DISPATCH_ARGS = {
     "traces": {},
     "external_calls": {},
     "search": {"q": "alpha"},
+    # #2988 (Query Spine P2): materialized-rollup backed methods.
+    "models": {},
+    "runtimes": {},
+    "rollup_sessions": {},
 }
 
 # health() fields that legitimately vary run-to-run / machine-to-machine.

--- a/tests/test_rollup_tables.py
+++ b/tests/test_rollup_tables.py
@@ -1,0 +1,350 @@
+"""Accuracy gates for the materialized rollup tables (issue #2988,
+Query Spine P2).
+
+Three gates, all on a varied fixture corpus (multiple models, runtimes,
+days, cache-token splits, derived-cost events, duplicate event ids):
+
+1. PARITY — rollup totals exactly equal an independent full-scan
+   aggregate over the events table (stored cost_usd / token_count /
+   model columns + splits re-read from the data payloads), and
+   rollup_session rows match query_sessions_table for the shared fields.
+2. INCREMENTAL == BATCH — ingesting the corpus in several flushed
+   batches produces byte-identical rollups to a single-batch ingest.
+3. BACKFILL == INCREMENTAL — wiping the rollups and running the chunked
+   backfill reproduces the incrementally-built tables exactly.
+
+Plus regression guards: duplicate-id re-ingest must not double-count
+(INSERT OR IGNORE drops the row, so the rollup must too), and the
+startup backfill must be a no-op when the rollups already hold rows
+(no full-table recompute on the steady-state hot path).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# Costs are stored per-event rounded to 8 decimals; sums are compared at
+# the same precision so float association order (batching) cannot flake
+# the exact-equality gates.
+_R = 8
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Isolated LocalStore factory on a tmp DuckDB path."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "3600")  # manual flush only
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "100000")
+
+    made = []
+
+    def _make(name: str):
+        monkeypatch.setenv(
+            "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / f"{name}.duckdb")
+        )
+        import clawmetry.local_store as ls
+        ls = importlib.reload(ls)
+        store = ls.LocalStore()
+        made.append(store)
+        return ls, store
+
+    yield _make
+    for s in made:
+        try:
+            s.stop(flush=False)
+        except Exception:
+            pass
+
+
+def _corpus() -> tuple[list[dict], list[dict]]:
+    """(events, sessions): multiple models / runtimes / days, cache splits,
+    a derived-cost event, a no-model event, and a duplicate event id."""
+    events = [
+        # day 1, openclaw, explicit cost + lumped tokens (no split)
+        {"id": "ev-001", "node_id": "n1", "agent_type": "openclaw",
+         "session_id": "s-oc-1", "event_type": "message",
+         "ts": "2026-01-01T08:00:00Z", "model": "claude-opus-4-7",
+         "cost_usd": 0.012, "token_count": 1200,
+         "data": {"text": "hello"}},
+        # day 1, openclaw, second model
+        {"id": "ev-002", "node_id": "n1", "agent_type": "openclaw",
+         "session_id": "s-oc-1", "event_type": "message",
+         "ts": "2026-01-01T09:00:00Z", "model": "gpt-4o",
+         "cost_usd": 0.005, "token_count": 800, "data": {"text": "hi"}},
+        # day 1, claude_code adapter shape: lumped token_count preset,
+        # in/out/cache splits stashed under data.extra, cost derived once
+        # at ingest via providers_pricing (longest-prefix rates).
+        {"id": "ev-003", "node_id": "n1", "agent_type": "claude_code",
+         "session_id": "s-cc-1", "event_type": "assistant",
+         "ts": "2026-01-01T10:00:00Z", "model": "claude-opus-4-7",
+         "token_count": 5000,
+         "data": {"extra": {"inputTokens": 1000, "outputTokens": 500,
+                            "cacheReadInputTokens": 3000,
+                            "cacheCreationInputTokens": 500}}},
+        # day 2, claude_code, same model (rolls into a new day row)
+        {"id": "ev-004", "node_id": "n1", "agent_type": "claude_code",
+         "session_id": "s-cc-1", "event_type": "assistant",
+         "ts": "2026-01-02T11:00:00Z", "model": "claude-opus-4-7",
+         "token_count": 2000,
+         "data": {"extra": {"inputTokens": 700, "outputTokens": 300,
+                            "cacheReadInputTokens": 1000}}},
+        # day 2, openclaw, usage-dict shape (data.usage splits)
+        {"id": "ev-005", "node_id": "n1", "agent_type": "openclaw",
+         "session_id": "s-oc-2", "event_type": "model.completed",
+         "ts": "2026-01-02T12:00:00Z",
+         "data": {"modelId": "claude-haiku-4-5",
+                  "usage": {"input_tokens": 400, "output_tokens": 100}}},
+        # day 2, no model / no tokens: counts toward runtime activity only
+        {"id": "ev-006", "node_id": "n1", "agent_type": "openclaw",
+         "session_id": "s-oc-2", "event_type": "tool_call",
+         "ts": "2026-01-02T12:01:00Z", "data": {"tool": "Bash"}},
+        # DUPLICATE id of ev-001 (different payload): INSERT OR IGNORE
+        # drops it from the events table, so the rollup must drop it too.
+        {"id": "ev-001", "node_id": "n1", "agent_type": "openclaw",
+         "session_id": "s-oc-1", "event_type": "message",
+         "ts": "2026-01-01T08:00:00Z", "model": "claude-opus-4-7",
+         "cost_usd": 99.0, "token_count": 999999, "data": {"text": "dupe"}},
+    ]
+    sessions = [
+        {"session_id": "s-oc-1", "agent_type": "openclaw", "node_id": "n1",
+         "title": "alpha", "started_at": "2026-01-01T08:00:00Z",
+         "last_active_at": "2026-01-01T09:30:00Z", "status": "ended",
+         "total_tokens": 2000, "cost_usd": 0.017, "message_count": 2},
+        {"session_id": "s-cc-1", "agent_type": "claude_code", "node_id": "n1",
+         "title": "code session", "started_at": "2026-01-01T10:00:00Z",
+         "last_active_at": "2026-01-02T11:00:00Z", "status": "active",
+         "total_tokens": 7000, "cost_usd": 0.04, "message_count": 2},
+        {"session_id": "s-oc-2", "agent_type": "openclaw", "node_id": "n1",
+         "title": "beta", "started_at": "2026-01-02T12:00:00Z",
+         "last_active_at": "2026-01-02T12:01:00Z", "status": "active",
+         "total_tokens": 500, "cost_usd": 0.001, "message_count": 1},
+    ]
+    return events, sessions
+
+
+def _seed(store, events, sessions, *, batches: int = 1):
+    n = max(1, len(events) // batches)
+    for off in range(0, len(events), n):
+        for e in events[off:off + n]:
+            store.ingest(dict(e))
+        assert store.flush() >= 0
+    for s in sessions:
+        store.ingest_session(dict(s))
+    store.flush()
+
+
+def _model_rollup_map(store):
+    return {
+        (r["day"], r["model"], r["runtime"]): (
+            r["tokens_in"], r["tokens_out"], r["cache_read"],
+            r["cache_write"], round(float(r["cost_usd"]), _R), r["calls"],
+        )
+        for r in store.query_rollup_model_daily(limit=10000)
+    }
+
+
+def _runtime_rollup_map(store):
+    return {
+        (r["day"], r["runtime"]): (
+            r["tokens"], round(float(r["cost_usd"]), _R),
+            r["sessions"], r["active_sessions"],
+        )
+        for r in store.query_rollup_runtime_daily(limit=10000)
+    }
+
+
+def _split_from_payload(data) -> tuple[int, int, int, int]:
+    """Independent (test-local) split reader: in/out/cache tokens from the
+    adapter/data payload shapes the corpus uses."""
+    ti = to = cr = cw = 0
+    if isinstance(data, dict):
+        for src in (data.get("extra"), data.get("usage")):
+            if not isinstance(src, dict):
+                continue
+            ti = ti or int(src.get("inputTokens") or src.get("input_tokens") or 0)
+            to = to or int(src.get("outputTokens") or src.get("output_tokens") or 0)
+            cr = cr or int(src.get("cacheReadInputTokens")
+                           or src.get("cache_read_input_tokens") or 0)
+            cw = cw or int(src.get("cacheCreationInputTokens")
+                           or src.get("cache_creation_input_tokens") or 0)
+    return ti, to, cr, cw
+
+
+def test_rollups_match_full_scan_aggregate(fresh_store):
+    """Gate 1 (parity): rollup totals == independent full-scan aggregate of
+    the events table; rollup_session == query_sessions_table shared fields."""
+    _, store = fresh_store("parity")
+    events, sessions = _corpus()
+    _seed(store, events, sessions)
+
+    rows = store.query_events(limit=10000)
+    assert len(rows) == 6, "duplicate id must be deduped in the events table"
+
+    # Full-scan aggregates (independent reimplementation).
+    want_model: dict = {}
+    want_runtime: dict = {}
+    for r in rows:
+        day = str(r["ts"])[:10]
+        runtime = r["agent_type"]
+        tokens = int(r["token_count"] or 0)
+        cost = float(r["cost_usd"] or 0.0)
+        wr = want_runtime.setdefault((day, runtime), [0, 0.0, None, None])
+        wr[0] += tokens
+        wr[1] += cost
+        if r["model"]:
+            ti, to, cr, cw = _split_from_payload(r.get("data"))
+            wm = want_model.setdefault((day, r["model"], runtime),
+                                       [0, 0, 0, 0, 0.0, 0])
+            wm[0] += ti
+            wm[1] += to
+            wm[2] += cr
+            wm[3] += cw
+            wm[4] += cost
+            wm[5] += 1
+
+    got_model = _model_rollup_map(store)
+    assert set(got_model) == set(want_model)
+    for k, w in want_model.items():
+        assert got_model[k] == (w[0], w[1], w[2], w[3], round(w[4], _R), w[5]), k
+
+    # Derived pricing sanity: the adapter-shape event (ev-003) has no
+    # explicit cost; the rollup cost must equal the events-table stored
+    # cost (priced once, longest-prefix rates), and be non-zero.
+    cc_key = ("2026-01-01", "claude-opus-4-7", "claude_code")
+    assert got_model[cc_key][4] > 0
+
+    # Session-count refreshes may create day/runtime cells with zero event
+    # tokens; the corpus aligns sessions with event days, so the key sets
+    # match exactly here.
+    got_runtime = _runtime_rollup_map(store)
+    assert set(got_runtime) == set(want_runtime)
+    for k, w in want_runtime.items():
+        assert got_runtime[k][0] == w[0], k
+        assert got_runtime[k][1] == round(w[1], _R), k
+
+    # Session counts vs a sessions-table scan.
+    sess_rows = store.query_sessions_table(limit=1000)
+    for (day, runtime), got in got_runtime.items():
+        started = sum(
+            1 for s in sess_rows
+            if s["agent_type"] == runtime
+            and str(s["started_at"] or s["last_active_at"])[:10] == day
+        )
+        active = sum(
+            1 for s in sess_rows
+            if s["agent_type"] == runtime
+            and str(s["last_active_at"] or "")[:10] == day
+        )
+        assert got[2] == started, (day, runtime)
+        assert got[3] == active, (day, runtime)
+
+    # rollup_session vs query_sessions_table shared fields. ``turns`` is
+    # compared against the seeded typed-session row: query_sessions_table
+    # GREATEST-bridges message_count with a renderable-events count, while
+    # rollup_session mirrors the typed sessions row (the ingest contract).
+    seeded = {s["session_id"]: s for s in sessions}
+    got_sessions = {r["session_id"]: r for r in store.query_rollup_sessions(limit=1000)}
+    assert set(got_sessions) == set(seeded)
+    for s in sess_rows:
+        g = got_sessions[s["session_id"]]
+        assert g["runtime"] == s["agent_type"]
+        assert g["title"] == s["title"]
+        assert g["status"] == s["status"]
+        assert g["started_at"] == s["started_at"]
+        assert g["last_activity"] == s["last_active_at"]
+        assert g["tokens"] == s["total_tokens"]
+        assert round(float(g["cost_usd"]), _R) == round(float(s["cost_usd"]), _R)
+        assert g["turns"] == seeded[s["session_id"]]["message_count"]
+        assert g["stuck_flag"] is False
+
+
+def test_duplicate_id_reingest_does_not_double_count(fresh_store):
+    """Re-flushing an already-stored id is a rollup no-op (mirrors the
+    events table's INSERT OR IGNORE)."""
+    _, store = fresh_store("dedup")
+    events, sessions = _corpus()
+    _seed(store, events, sessions)
+    before_m = _model_rollup_map(store)
+    before_r = _runtime_rollup_map(store)
+    for e in events:
+        store.ingest(dict(e))
+    store.flush()
+    assert _model_rollup_map(store) == before_m
+    assert _runtime_rollup_map(store) == before_r
+
+
+def test_incremental_equals_single_batch(fresh_store):
+    """Gate 2: N flushed batches == one batch, byte-identical rollups."""
+    events, sessions = _corpus()
+    _, inc = fresh_store("incremental")
+    _seed(inc, events, sessions, batches=3)
+    _, one = fresh_store("singlebatch")
+    _seed(one, events, sessions, batches=1)
+    assert _model_rollup_map(inc) == _model_rollup_map(one)
+    assert _runtime_rollup_map(inc) == _runtime_rollup_map(one)
+    assert inc.query_rollup_sessions(limit=100) == one.query_rollup_sessions(limit=100)
+
+
+def test_backfill_equals_incremental(fresh_store):
+    """Gate 3: wipe the rollups, run the chunked backfill, get identical
+    tables back."""
+    _, store = fresh_store("backfill")
+    events, sessions = _corpus()
+    _seed(store, events, sessions)
+    want_m = _model_rollup_map(store)
+    want_r = _runtime_rollup_map(store)
+    want_s = store.query_rollup_sessions(limit=1000)
+    res = store.backfill_rollups(force=True)
+    assert res["skipped"] is False
+    assert _model_rollup_map(store) == want_m
+    assert _runtime_rollup_map(store) == want_r
+    assert store.query_rollup_sessions(limit=1000) == want_s
+
+
+def test_backfill_is_chunked(fresh_store, monkeypatch):
+    """The backfill paginates by rowid: with a chunk smaller than the corpus
+    it still reproduces the exact totals (no chunk-boundary drift)."""
+    ls, store = fresh_store("chunked")
+    events, sessions = _corpus()
+    _seed(store, events, sessions)
+    want_m = _model_rollup_map(store)
+    monkeypatch.setattr(ls, "ROLLUP_BACKFILL_CHUNK", 2)
+    res = store.backfill_rollups(force=True)
+    assert res["skipped"] is False
+    assert _model_rollup_map(store) == want_m
+
+
+def test_backfill_skips_when_populated(fresh_store):
+    """Steady-state guard: a writer (re)open never re-runs the backfill once
+    the rollups hold rows — no full-table recompute on the hot path."""
+    _, store = fresh_store("skipguard")
+    events, sessions = _corpus()
+    _seed(store, events, sessions)
+    res = store.backfill_rollups()
+    assert res == {"skipped": True, "reason": "rollups_populated"}
+
+
+def test_backfill_runs_on_upgrade_open(fresh_store, tmp_path, monkeypatch):
+    """Upgrade path: a store whose events exist but whose rollups are empty
+    (simulating a pre-rollup wheel) backfills once at writer open."""
+    ls, store = fresh_store("upgrade")
+    events, sessions = _corpus()
+    _seed(store, events, sessions)
+    want_m = _model_rollup_map(store)
+    want_r = _runtime_rollup_map(store)
+    # Simulate the pre-upgrade store: drop the rollup contents, close.
+    with store._write_lock:
+        store._conn.execute("DELETE FROM rollup_model_daily")
+        store._conn.execute("DELETE FROM rollup_runtime_daily")
+        store._conn.execute("DELETE FROM rollup_session")
+    store.stop(flush=False)
+    # Re-open the SAME db path: __init__ must detect empty-rollups +
+    # populated events and rebuild.
+    reopened = ls.LocalStore()
+    try:
+        assert _model_rollup_map(reopened) == want_m
+        assert _runtime_rollup_map(reopened) == want_r
+        assert len(reopened.query_rollup_sessions(limit=100)) == len(sessions)
+    finally:
+        reopened.stop(flush=False)


### PR DESCRIPTION
Closes #2988 (Query Spine P2). Builds on the q/1 contract from #2993.

## What

Three materialized DuckDB rollup tables, written incrementally at ingest on the daemon's own writer handle (never a read-only re-open), shipped dark and readable through q/1 methods:

```sql
rollup_model_daily(day DATE, model, runtime, tokens_in BIGINT, tokens_out BIGINT,
                   cache_read BIGINT, cache_write BIGINT, cost_usd DOUBLE, calls BIGINT,
                   PRIMARY KEY(day, model, runtime))
rollup_runtime_daily(day DATE, runtime, tokens BIGINT, cost_usd DOUBLE,
                     sessions BIGINT, active_sessions BIGINT, PRIMARY KEY(day, runtime))
rollup_session(session_id PRIMARY KEY, runtime, title, status, started_at,
               last_activity, tokens BIGINT, cost_usd DOUBLE, turns BIGINT, stuck_flag BOOLEAN)
```

## How

- Event rollups upsert inside the existing flush transaction (`LocalStore._flush_now_locked`). The batch is pre-checked against existing event ids with an indexed IN lookup, so the INSERT OR IGNORE dedup and the rollup increments agree exactly (duplicate message/event ids never double-count). Deltas are aggregated in Python per key and applied as one `INSERT .. ON CONFLICT DO UPDATE` executemany per table: O(events ingested per flush), never a full-table recompute. A failed rollup write rolls the event insert back too, and the ring retries the whole batch.
- `rollup_session` mirrors every `ingest_session` upsert under the same `_write_lock` (direct conn statements, never `_fetch`, which takes `_write_lock` internally). Per-day session counts refresh only the touched (runtime, day) cells via an indexed single-runtime scan of the small sessions table; steady-state re-upserts with unchanged day keys do zero count queries.
- Pricing applied exactly once: rollup cost sums the same per-event value the events row stores, produced by the existing extraction path (longest-prefix `_get_rates` via `providers_pricing.estimate_event_cost_usd`). No second pricing table. `_extract_event_metrics` is now a thin wrapper over the new `_extract_event_usage` (which also exposes the in/out/cache splits); its 11 existing regression tests pass unchanged.
- One bounded backfill on upgrade: at writer open, if the rollups are empty but events/sessions exist, `backfill_rollups()` rebuilds them in rowid-keyset chunks (`CLAWMETRY_ROLLUP_BACKFILL_CHUNK`, default 5000) with progress logging, then never runs again (guarded by a test).
- q/1 contract: `models` and `runtimes` flipped planned to live, backed by `query_rollup_model_daily` / `query_rollup_runtime_daily` (plaintext aggregate counters). `rollup_sessions` added as a new live e2e-classed method (it carries titles). The existing `sessions` shape is untouched: `rollup_session` does not cover its full event-derived shape, so flipping it would have broken the contract. Registry, `_coerce_args`, `_DAEMON_METHODS`, the pinned shape-allowlist test, goldens, and `docs/QUERY_CONTRACT.md` all updated together; the #2993 drift suite stays green.
- No existing endpoint changes in this PR (handler migration is P3); the `query_aggregates` TTL cache stays as the fallback.

## Accuracy gates (CI, this PR)

`tests/test_rollup_tables.py` runs on a varied corpus: multiple models, runtimes and days, cache-token splits (adapter `data.extra` shape and `data.usage` shape), a derived-cost event, a no-model event, and duplicate event ids.

1. Parity: rollup totals exactly equal an independent full-scan aggregate over the events table, and `rollup_session` matches `query_sessions_table` on the shared fields.
2. Incremental equals batch: three flushed batches produce identical rollups to a single-batch ingest.
3. Backfill equals incremental: wiping the rollups and running the chunked backfill (including chunk=2, crossing chunk boundaries) reproduces the incrementally built tables exactly; a reopened store backfills once and skips when already populated.

## Revert proofs (guard red on injected drift, green after restore)

- Injected `new_idx = range(len(batch))` (rollup counts duplicate ids): dedup guard + parity test FAILED, restored green.
- Injected skip of `_apply_rollup_deltas_locked` in the flush txn: parity test FAILED, restored green.
- Injected `last_rowid = 10**18` (backfill never scans events): both backfill tests FAILED, restored green.
- The pinned shape allowlist (`test_known_shapes_are_exactly_the_allowlist`) went red the moment the new shapes were served before the pin was updated, as designed.

## Live verification (FLYWHEEL section 3, real daemon + real store)

Copied the changed files into the live daemon venv (0.12.494 install), cleared pycache, restarted via launchctl:

- Backfill ran once at writer open over the real store (56,462 events, 98 sessions, 1.1 GB DuckDB): rollups populated back to 2026-04-17 (21 runtime-day rows, 36 model-day rows, 104 session rows) within the startup window (writer warm-up 21:49:52.4, first heartbeat 21:49:53.6).
- CPU (budget 5 to 10 percent of one core): steady state 11.62s CPU over 180s wall = 6.5 percent while this machine was actively running agent sessions; 31.5s over 7m15s elapsed = 7.2 percent including the one-time backfill. Instantaneous %CPU 0.0 between flushes; `sample <pid> 4` top-of-stack is entirely `semaphore_wait_trap`/`__psynch_cvwait`/`poll` (idle waits), zero rollup or DuckDB hot frames.
- Spot check, same-moment reads via the daemon proxy: `rollup_runtime_daily` for 2026-06-10 = 1,255,893 tokens / $181.143376 vs the dashboard `/api/usage` for 2026-06-10 = 1,255,893 tokens / $181.143376. Exact to the token and the cent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
