### PR TITLE
feat(daemon): kill/pause/resume a runaway agent on the host

### DIFF
--- a/clawmetry/process_control.py
+++ b/clawmetry/process_control.py
@@ -1,0 +1,795 @@
+"""clawmetry/process_control.py — host-side process control for runaway agents.
+
+This module is the OSS daemon-side engine that lets a runaway agent be
+**killed**, **paused**, or **resumed** on the user's own machine, triggered by a
+command relayed from the cloud (the actual cloud endpoint / UI lives in the
+private cloud repo; the daemon wiring lives in ``sync.py``). Nothing here talks
+to the network or the cloud: it maps an observed session to a local OS process
+and sends bounded, guarded POSIX signals.
+
+Design constraints (read these before editing):
+
+* **Dependency-light & host-testable.** No Flask, no DuckDB, no cloud imports.
+  ``psutil`` is used *if available* (import-guarded) and we degrade to ``ps`` /
+  ``lsof`` shelling otherwise, so OSS keeps deps minimal.
+* **Cross-platform.** macOS and Linux are first-class. Windows / other POSIX
+  return an honest ``unsupported`` result rather than guessing (POSIX job-control
+  signals like SIGSTOP/SIGCONT do not exist on Windows).
+* **Never crashes.** A missing file, a dead pid, or a permission error returns
+  ``ok=False`` with a ``reason`` — it never raises into the caller. Respects the
+  never-hang contract: every wait is bounded, no unbounded loops.
+* **pid-reuse guard.** Before signaling we re-verify the target pid is alive
+  (``os.kill(pid, 0)``) AND its recorded start time still matches the live
+  process start time. If the OS recycled the pid onto a different process we
+  REFUSE to signal — we will not SIGKILL a stranger's process.
+
+The descendant walk handles a real gotcha found in recon: in-flight tool shells
+launched by a Node CLI are frequently *detached session leaders* with their OWN
+process-group id (``tty=??``). A single ``kill(-pgid, sig)`` against the parent's
+group misses them. So we enumerate the descendant tree by ``ppid`` (BFS) and
+signal each DISTINCT process group we find.
+
+cursor is explicitly UNSUPPORTED for per-session signals: one IDE process holds
+all sessions, so signaling it would freeze every session and the editor. We
+return a clear unsupported result and never touch the IDE.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+log = logging.getLogger("clawmetry.process_control")
+
+# psutil is optional — OSS keeps deps minimal. Everything degrades to ps/lsof.
+try:  # pragma: no cover - import guard exercised by both branches in CI matrices
+    import psutil as _psutil  # type: ignore
+except Exception:  # noqa: BLE001
+    _psutil = None
+
+_IS_MACOS = sys.platform == "darwin"
+_IS_LINUX = sys.platform.startswith("linux")
+_POSIX = os.name == "posix" and (_IS_MACOS or _IS_LINUX)
+
+# Default bound for graceful_kill's SIGTERM->SIGKILL escalation window.
+_DEFAULT_GRACE_SECS = 5.0
+
+# Runtimes whose per-session process we can locate + signal. cursor is omitted
+# on purpose (single shared IDE process). openclaw is handled by the CLI cancel
+# path in sync.py, not here.
+SUPPORTED_RUNTIMES = frozenset(
+    {"claude_code", "codex", "goose", "opencode", "aider"}
+)
+UNSUPPORTED_RUNTIMES = frozenset({"cursor"})
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Result helpers
+# ──────────────────────────────────────────────────────────────────────────
+def _result(
+    ok: bool,
+    action: str,
+    pid: Optional[int] = None,
+    runtime: str = "",
+    detail: str = "",
+    **extra: Any,
+) -> Dict[str, Any]:
+    """Build the structured result dict every public helper returns."""
+    r: Dict[str, Any] = {
+        "ok": bool(ok),
+        "action": action,
+        "pid": pid,
+        "runtime": runtime,
+        "detail": detail,
+    }
+    r.update(extra)
+    return r
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Process start-time (for the pid-reuse guard)
+# ──────────────────────────────────────────────────────────────────────────
+def _proc_start_epoch(pid: int) -> Optional[float]:
+    """Return the process start time as a unix epoch (float), or None if it
+    cannot be determined (dead pid / permission / unsupported platform).
+
+    * psutil (any OS): ``create_time()`` is already an epoch.
+    * Linux: field 22 of ``/proc/<pid>/stat`` is starttime in clock ticks since
+      boot; convert via ``btime`` (boot epoch) + ticks/Hz.
+    * macOS: ``ps -o lstart= -p <pid>`` prints a human start timestamp; we keep
+      the raw string comparison path for macOS in ``_proc_start_token`` because
+      lstart has 1s resolution and parsing locale-dependent dates is brittle.
+    """
+    if pid is None or pid <= 0:
+        return None
+    if _psutil is not None:
+        try:
+            return float(_psutil.Process(int(pid)).create_time())
+        except Exception:  # noqa: BLE001 - dead/zombie/perm
+            return None
+    if _IS_LINUX:
+        try:
+            with open(f"/proc/{int(pid)}/stat", "r") as fh:
+                data = fh.read()
+            # comm may contain spaces/parens; split after the last ')'.
+            rparen = data.rfind(")")
+            fields = data[rparen + 2:].split()
+            starttime_ticks = float(fields[19])  # field 22 overall, 0-based 19 here
+            hz = os.sysconf("SC_CLK_TCK")
+            btime = _linux_btime()
+            if btime is None or not hz:
+                return None
+            return btime + (starttime_ticks / hz)
+        except Exception:  # noqa: BLE001
+            return None
+    return None
+
+
+def _linux_btime() -> Optional[float]:
+    """Boot time (unix epoch) from /proc/stat's ``btime`` line."""
+    try:
+        with open("/proc/stat", "r") as fh:
+            for line in fh:
+                if line.startswith("btime "):
+                    return float(line.split()[1])
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _proc_start_token(pid: int) -> Optional[str]:
+    """A stable, comparable token for the process's start time.
+
+    The token is what we persist/compare for the pid-reuse guard. We prefer a
+    numeric epoch (psutil / Linux) but on macOS without psutil we fall back to
+    the raw ``ps -o lstart=`` string, which is stable for a given process but
+    not parseable into an epoch cheaply. Both forms compare equal-to-equal,
+    which is all the guard needs.
+    """
+    epoch = _proc_start_epoch(pid)
+    if epoch is not None:
+        # Round to the second: macOS lstart has 1s resolution, and procStart
+        # recorded by claude_code is an ISO/epoch with sub-second jitter we must
+        # not let trip the guard.
+        return f"epoch:{int(round(epoch))}"
+    if _IS_MACOS:
+        out = _run(["ps", "-o", "lstart=", "-p", str(int(pid))], timeout=5)
+        if out is not None:
+            tok = out.strip()
+            if tok:
+                return f"lstart:{tok}"
+    return None
+
+
+def _normalize_recorded_start(recorded: Any) -> Optional[str]:
+    """Normalize a recorded procStart (from a session map / fabricated record)
+    into the same token space ``_proc_start_token`` produces.
+
+    Accepts:
+      * an int/float epoch  -> ``epoch:<rounded>``
+      * a numeric string    -> ``epoch:<rounded>``
+      * an ISO-8601 string  -> ``epoch:<rounded>`` (best-effort parse)
+      * an already-tokenized ``epoch:...`` / ``lstart:...`` string -> as-is
+      * anything else        -> ``raw:<str>`` (compares only to itself)
+    """
+    if recorded is None:
+        return None
+    if isinstance(recorded, (int, float)):
+        return f"epoch:{int(round(float(recorded)))}"
+    s = str(recorded).strip()
+    if not s:
+        return None
+    if s.startswith("epoch:") or s.startswith("lstart:") or s.startswith("raw:"):
+        return s
+    # numeric string?
+    try:
+        return f"epoch:{int(round(float(s)))}"
+    except ValueError:
+        pass
+    # ISO-8601-ish?
+    try:
+        import datetime as _dt
+
+        iso = s.replace("Z", "+00:00")
+        dt = _dt.datetime.fromisoformat(iso)
+        return f"epoch:{int(round(dt.timestamp()))}"
+    except Exception:  # noqa: BLE001
+        return f"raw:{s}"
+
+
+def is_alive(pid: int) -> bool:
+    """True iff ``pid`` is a live process we can address. Never raises."""
+    if pid is None or pid <= 0:
+        return False
+    try:
+        os.kill(int(pid), 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — alive, just not ours to signal.
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def verify_pid(pid: int, recorded_start: Any = None) -> Tuple[bool, str]:
+    """The pid-reuse guard. Returns ``(ok, reason)``.
+
+    ``ok`` is True only when ``pid`` is alive AND (if ``recorded_start`` is
+    given) its live start-time token matches the recorded one. A mismatch means
+    the OS recycled the pid onto a different process; we refuse to signal.
+    """
+    if not is_alive(pid):
+        return False, "pid_not_alive"
+    if recorded_start is None:
+        return True, "alive_no_start_check"
+    want = _normalize_recorded_start(recorded_start)
+    have = _proc_start_token(pid)
+    if have is None:
+        # Could not read live start time (perm / platform). Fail safe: do NOT
+        # signal a process we cannot positively identify.
+        return False, "start_unverifiable"
+    if want is None:
+        return True, "recorded_start_unparseable_but_alive"
+    if want == have:
+        return True, "verified"
+    return False, f"start_mismatch(recorded={want},live={have})"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Shell fallbacks (used only when psutil is absent)
+# ──────────────────────────────────────────────────────────────────────────
+def _run(cmd: List[str], timeout: float = 10) -> Optional[str]:
+    """Run a short command, return stdout or None. Never raises, always bounded."""
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout
+        )
+        if proc.returncode != 0 and not proc.stdout:
+            return None
+        return proc.stdout
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _all_procs_ps() -> List[Tuple[int, int, int]]:
+    """Return ``[(pid, ppid, pgid), ...]`` for every process, via ps.
+
+    Used only when psutil is unavailable. ``pgid`` is best-effort (-1 if ps
+    can't report it on this platform).
+    """
+    out = _run(["ps", "-axo", "pid=,ppid=,pgid="], timeout=15)
+    rows: List[Tuple[int, int, int]] = []
+    if not out:
+        # Some BSD ps reject pgid; retry without it.
+        out2 = _run(["ps", "-axo", "pid=,ppid="], timeout=15)
+        if not out2:
+            return rows
+        for line in out2.splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                try:
+                    rows.append((int(parts[0]), int(parts[1]), -1))
+                except ValueError:
+                    continue
+        return rows
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) >= 3:
+            try:
+                rows.append((int(parts[0]), int(parts[1]), int(parts[2])))
+            except ValueError:
+                continue
+    return rows
+
+
+def _proc_cwd(pid: int) -> Optional[str]:
+    """Best-effort current working directory of ``pid``."""
+    if _psutil is not None:
+        try:
+            return _psutil.Process(int(pid)).cwd()
+        except Exception:  # noqa: BLE001
+            return None
+    if _IS_LINUX:
+        try:
+            return os.readlink(f"/proc/{int(pid)}/cwd")
+        except Exception:  # noqa: BLE001
+            return None
+    if _IS_MACOS:
+        # lsof is the portable way to read another process's cwd on macOS.
+        out = _run(["lsof", "-a", "-d", "cwd", "-p", str(int(pid)), "-Fn"], timeout=8)
+        if out:
+            for line in out.splitlines():
+                if line.startswith("n"):
+                    return line[1:]
+        return None
+    return None
+
+
+def _proc_cmdline(pid: int) -> List[str]:
+    """Best-effort argv of ``pid``."""
+    if _psutil is not None:
+        try:
+            return list(_psutil.Process(int(pid)).cmdline())
+        except Exception:  # noqa: BLE001
+            return []
+    if _IS_LINUX:
+        try:
+            with open(f"/proc/{int(pid)}/cmdline", "rb") as fh:
+                raw = fh.read()
+            return [p.decode("utf-8", "replace") for p in raw.split(b"\x00") if p]
+        except Exception:  # noqa: BLE001
+            return []
+    if _IS_MACOS:
+        out = _run(["ps", "-o", "command=", "-p", str(int(pid))], timeout=5)
+        if out:
+            return out.strip().split()
+    return []
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Descendant tree + process-group enumeration
+# ──────────────────────────────────────────────────────────────────────────
+def descendant_pids(pid: int) -> List[int]:
+    """All descendant pids of ``pid`` (children, grandchildren, …), NOT
+    including ``pid`` itself. BFS over the ppid tree. Bounded, never raises.
+
+    Handles the detached-session-leader gotcha: descendants are enumerated by
+    ppid, so a tool shell that re-parented its own process group is still found.
+    """
+    pid = int(pid)
+    if _psutil is not None:
+        try:
+            parent = _psutil.Process(pid)
+            return [c.pid for c in parent.children(recursive=True)]
+        except Exception:  # noqa: BLE001
+            return []
+    # ps fallback: build ppid -> [children] and BFS.
+    rows = _all_procs_ps()
+    kids: Dict[int, List[int]] = {}
+    for cpid, ppid, _pgid in rows:
+        kids.setdefault(ppid, []).append(cpid)
+    out: List[int] = []
+    seen: Set[int] = {pid}
+    frontier = list(kids.get(pid, []))
+    # Bound the walk so a pathological/looping ppid table can't hang us.
+    guard = 0
+    while frontier and guard < 100000:
+        guard += 1
+        cur = frontier.pop()
+        if cur in seen:
+            continue
+        seen.add(cur)
+        out.append(cur)
+        frontier.extend(kids.get(cur, []))
+    return out
+
+
+def _pgid_of(pid: int) -> Optional[int]:
+    """Process-group id of ``pid``. Uses os.getpgid (cheap) then ps fallback."""
+    try:
+        return os.getpgid(int(pid))
+    except Exception:  # noqa: BLE001
+        pass
+    for cpid, _ppid, pgid in _all_procs_ps():
+        if cpid == int(pid) and pgid > 0:
+            return pgid
+    return None
+
+
+def process_set(pid: int) -> List[int]:
+    """The full set of pids to act on for a session: the main pid plus every
+    descendant. Ordered children-first (descendants before parent) so a caller
+    that wants leaves-first can iterate as-is; reverse for parent-first."""
+    pid = int(pid)
+    descendants = descendant_pids(pid)
+    # children first, parent last
+    ordered = descendants + [pid]
+    # de-dup preserving order
+    seen: Set[int] = set()
+    out: List[int] = []
+    for p in ordered:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+def _distinct_pgids(pids: List[int]) -> List[int]:
+    """Distinct, positive process-group ids across ``pids`` (order preserved)."""
+    out: List[int] = []
+    seen: Set[int] = set()
+    for p in pids:
+        g = _pgid_of(p)
+        if g and g > 0 and g not in seen:
+            seen.add(g)
+            out.append(g)
+    return out
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Signal helpers
+# ──────────────────────────────────────────────────────────────────────────
+def _signal_pid(pid: int, sig: int) -> bool:
+    """Send ``sig`` to a single pid. Returns True on success, swallows the
+    'already dead' / permission cases into False without raising."""
+    try:
+        os.kill(int(pid), sig)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        log.warning("process_control: no permission to signal pid %s", pid)
+        return False
+    except Exception as exc:  # noqa: BLE001
+        log.debug("process_control: signal %s -> pid %s failed: %s", sig, pid, exc)
+        return False
+
+
+def stop_turn(pid: int, runtime: str = "") -> Dict[str, Any]:
+    """Cancel the CURRENT turn of a Node-CLI agent by sending SIGINT to the
+    MAIN pid only (the cleanest non-destructive stop — mirrors the user hitting
+    Ctrl-C in the CLI). We do NOT signal the group: a group SIGINT can tear down
+    in-flight tool shells and the TUI in ways the CLI doesn't expect.
+    """
+    if not _POSIX:
+        return _result(False, "stop_turn", pid, runtime, "unsupported_platform")
+    if not is_alive(pid):
+        return _result(False, "stop_turn", pid, runtime, "pid_not_alive")
+    ok = _signal_pid(pid, signal.SIGINT)
+    return _result(ok, "stop_turn", pid, runtime,
+                   "sigint_sent" if ok else "sigint_failed")
+
+
+def graceful_kill(pid: int, runtime: str = "",
+                  grace_secs: float = _DEFAULT_GRACE_SECS) -> Dict[str, Any]:
+    """SIGTERM the main pid, wait up to ``grace_secs`` for it to exit, then
+    escalate to SIGKILL of the FULL descendant set if it is still alive.
+
+    The escalation kills the whole tree (descendants first, then the parent) so
+    a detached tool shell can't outlive its agent. Bounded poll, never hangs.
+    """
+    if not _POSIX:
+        return _result(False, "graceful_kill", pid, runtime, "unsupported_platform")
+    if not is_alive(pid):
+        return _result(True, "graceful_kill", pid, runtime, "already_dead")
+
+    # Snapshot the tree up front: after the parent dies, ppid links to its
+    # descendants are lost (re-parented to init), so capture them now.
+    tree = process_set(pid)
+    _signal_pid(pid, signal.SIGTERM)
+
+    deadline = time.monotonic() + max(0.0, float(grace_secs))
+    while time.monotonic() < deadline:
+        if not is_alive(pid):
+            break
+        time.sleep(0.1)
+
+    if not is_alive(pid):
+        # Parent gone. Reap any descendant that lingered (best-effort SIGKILL).
+        for p in tree:
+            if p != pid and is_alive(p):
+                _signal_pid(p, signal.SIGKILL)
+        return _result(True, "graceful_kill", pid, runtime, "terminated")
+
+    # Still alive after grace — hard kill the whole tree, leaves first.
+    killed_any = False
+    for p in tree:  # process_set is children-first already
+        if is_alive(p):
+            killed_any = _signal_pid(p, signal.SIGKILL) or killed_any
+    # brief bounded confirm
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and is_alive(pid):
+        time.sleep(0.1)
+    detail = "killed" if not is_alive(pid) else "kill_signaled_still_present"
+    return _result(not is_alive(pid) or killed_any, "graceful_kill", pid,
+                   runtime, detail)
+
+
+def pause(pid: int, runtime: str = "") -> Dict[str, Any]:
+    """Pause the whole agent: SIGSTOP every distinct process group in the
+    descendant tree (children-group first, parent-group last). State is held
+    until ``resume``.
+
+    Why per-pgid: in-flight tool shells are often detached session leaders with
+    their own pgid (``tty=??``), so a single ``kill(-pgid)`` against the
+    parent's group misses them. We enumerate the tree by ppid, then signal each
+    DISTINCT pgid we find.
+
+    SIGSTOP vs SIGTSTP: we use SIGSTOP. SIGTSTP is the soft, catchable
+    "terminal stop" a TUI may trap (and ignore, or redraw); SIGSTOP is
+    uncatchable and guarantees the process is frozen, which is what an operator
+    clicking Pause expects. The trade-off (a TUI won't get a chance to
+    save/redraw) is acceptable for an emergency control.
+    """
+    if not _POSIX:
+        return _result(False, "pause", pid, runtime, "unsupported_platform")
+    if not is_alive(pid):
+        return _result(False, "pause", pid, runtime, "pid_not_alive")
+
+    pids = process_set(pid)  # children first, parent last
+    pgids = _distinct_pgids(pids)
+    stopped_pgids: List[int] = []
+    for g in pgids:
+        if _signal_pid(-g, signal.SIGSTOP):
+            stopped_pgids.append(g)
+    # Belt-and-braces: also SIGSTOP any individual pid whose pgid we couldn't
+    # resolve (e.g. ps lacked pgid), so nothing in the tree escapes the freeze.
+    covered = set()
+    for g in pgids:
+        for p in pids:
+            if _pgid_of(p) == g:
+                covered.add(p)
+    for p in pids:
+        if p not in covered and is_alive(p):
+            _signal_pid(p, signal.SIGSTOP)
+    ok = bool(stopped_pgids) or bool(pids)
+    return _result(ok, "pause", pid, runtime,
+                   "paused" if ok else "nothing_to_pause",
+                   pgids=stopped_pgids, pids=pids)
+
+
+def resume(pid: int, runtime: str = "") -> Dict[str, Any]:
+    """Resume a paused agent: SIGCONT the same set in REVERSE (parent-group
+    first, then children-groups) so the parent is runnable before its children
+    wake. Mirror of ``pause``."""
+    if not _POSIX:
+        return _result(False, "resume", pid, runtime, "unsupported_platform")
+    # Note: a SIGSTOP'd process IS still alive (os.kill(pid,0) succeeds), so the
+    # alive check here is meaningful.
+    pids = process_set(pid)
+    pgids = _distinct_pgids(pids)
+    resumed_pgids: List[int] = []
+    for g in reversed(pgids):  # parent group first
+        if _signal_pid(-g, signal.SIGCONT):
+            resumed_pgids.append(g)
+    for p in reversed(pids):
+        # Cover any pid whose pgid wasn't resolvable.
+        _signal_pid(p, signal.SIGCONT)
+    ok = bool(resumed_pgids) or bool(pids)
+    return _result(ok, "resume", pid, runtime,
+                   "resumed" if ok else "nothing_to_resume",
+                   pgids=resumed_pgids, pids=pids)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Session -> process discovery
+# ──────────────────────────────────────────────────────────────────────────
+def _claude_sessions_dir() -> str:
+    """The directory claude_code writes per-pid session json files into.
+
+    Honors ``CLAUDE_CONFIG_DIR`` (-> ``<dir>/sessions/``), else the default
+    ``~/.claude/sessions/``.
+    """
+    base = os.environ.get("CLAUDE_CONFIG_DIR")
+    if base:
+        return os.path.join(os.path.expanduser(base), "sessions")
+    return os.path.expanduser("~/.claude/sessions")
+
+
+def claude_code_session_map() -> Dict[str, Dict[str, Any]]:
+    """Build ``sessionId -> {pid, cwd, procStart, status, version}`` from the
+    per-pid json files claude_code writes (``<sessions_dir>/<pid>.json``).
+
+    This is the primary, richest mapping. Never raises; a missing dir / unreadable
+    or malformed file is skipped with a debug log.
+    """
+    import json
+
+    out: Dict[str, Dict[str, Any]] = {}
+    d = _claude_sessions_dir()
+    try:
+        names = os.listdir(d)
+    except Exception:  # noqa: BLE001 - dir absent
+        return out
+    for name in names:
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(d, name)
+        try:
+            with open(path, "r") as fh:
+                rec = json.load(fh)
+        except Exception:  # noqa: BLE001
+            log.debug("process_control: unreadable claude session file %s", path)
+            continue
+        if not isinstance(rec, dict):
+            continue
+        sid = rec.get("sessionId")
+        pid = rec.get("pid")
+        if not sid or not pid:
+            continue
+        try:
+            pid = int(pid)
+        except (TypeError, ValueError):
+            continue
+        out[str(sid)] = {
+            "pid": pid,
+            "cwd": rec.get("cwd"),
+            "procStart": rec.get("procStart"),
+            "status": rec.get("status"),
+            "version": rec.get("version"),
+        }
+    return out
+
+
+def resolve_claude_code(session_id: str) -> Dict[str, Any]:
+    """Resolve a claude_code session_id to its target process descriptor.
+
+    Returns ``{ok, pid, cwd, recorded_start, status, runtime}`` (ok=False with a
+    ``reason`` when not found).
+    """
+    m = claude_code_session_map()
+    rec = m.get(str(session_id))
+    if not rec:
+        return {"ok": False, "runtime": "claude_code",
+                "reason": "session_not_in_claude_map", "session_id": session_id}
+    return {
+        "ok": True,
+        "runtime": "claude_code",
+        "pid": rec["pid"],
+        "cwd": rec.get("cwd"),
+        "recorded_start": rec.get("procStart"),
+        "status": rec.get("status"),
+        "session_id": session_id,
+    }
+
+
+# argv basename hints for the generic-by-cwd fallback runtimes.
+_RUNTIME_ARGV_HINTS = {
+    "codex": ("codex",),
+    "goose": ("goose",),
+    "opencode": ("opencode", "opencode-tui"),
+    "aider": ("aider",),
+}
+
+
+def resolve_by_cwd(runtime: str, cwd: str) -> Dict[str, Any]:
+    """Generic fallback for codex/goose/opencode/aider: find a candidate process
+    whose argv basename matches the runtime AND whose cwd matches ``cwd``.
+
+    ``cwd`` is taken from the session's adapter extra (goose ``workingDir``,
+    opencode ``directory``; codex/aider derivable from on-disk paths). Uses
+    psutil if available, else ps/lsof. Returns the lowest-pid match (most likely
+    the top-level CLI rather than a child). Never raises.
+    """
+    runtime = (runtime or "").lower()
+    if not cwd:
+        return {"ok": False, "runtime": runtime, "reason": "no_cwd"}
+    hints = _RUNTIME_ARGV_HINTS.get(runtime)
+    if not hints:
+        return {"ok": False, "runtime": runtime, "reason": "runtime_not_cwd_resolvable"}
+    target_cwd = os.path.realpath(os.path.expanduser(cwd))
+
+    candidates: List[int] = []
+    if _psutil is not None:
+        try:
+            for proc in _psutil.process_iter(["pid", "name", "cmdline"]):
+                try:
+                    argv = proc.info.get("cmdline") or []
+                    name = (proc.info.get("name") or "")
+                    blob = " ".join([name] + list(argv)).lower()
+                    if not any(h in os.path.basename(name).lower() or h in blob
+                               for h in hints):
+                        continue
+                    pcwd = None
+                    try:
+                        pcwd = proc.cwd()
+                    except Exception:  # noqa: BLE001
+                        pcwd = None
+                    if pcwd and os.path.realpath(pcwd) == target_cwd:
+                        candidates.append(int(proc.info["pid"]))
+                except Exception:  # noqa: BLE001
+                    continue
+        except Exception:  # noqa: BLE001
+            candidates = []
+    else:
+        for cpid, _ppid, _pgid in _all_procs_ps():
+            argv = _proc_cmdline(cpid)
+            if not argv:
+                continue
+            blob = " ".join(argv).lower()
+            base = os.path.basename(argv[0]).lower() if argv else ""
+            if not any(h in base or h in blob for h in hints):
+                continue
+            pcwd = _proc_cwd(cpid)
+            if pcwd and os.path.realpath(pcwd) == target_cwd:
+                candidates.append(cpid)
+
+    if not candidates:
+        return {"ok": False, "runtime": runtime, "reason": "no_matching_process",
+                "cwd": target_cwd}
+    pid = min(candidates)
+    return {
+        "ok": True,
+        "runtime": runtime,
+        "pid": pid,
+        "cwd": target_cwd,
+        # No recorded start for cwd-resolved procs; the guard becomes a liveness
+        # check only (we just located this pid live by cwd+argv, so reuse risk is
+        # negligible for the immediate signal).
+        "recorded_start": None,
+        "candidates": candidates,
+    }
+
+
+def resolve_session(runtime: str, session_id: str = "",
+                    cwd: str = "") -> Dict[str, Any]:
+    """Resolve any supported runtime's session to a process descriptor.
+
+    * claude_code -> per-pid session-json map (primary).
+    * codex/goose/opencode/aider -> generic cwd+argv match.
+    * cursor -> explicit unsupported (single IDE process).
+    * anything else -> unsupported.
+    """
+    runtime = (runtime or "").lower()
+    if runtime in UNSUPPORTED_RUNTIMES:
+        return {"ok": False, "runtime": runtime, "unsupported": True,
+                "reason": "cursor_single_ide_process_no_per_session_signal"}
+    if runtime == "claude_code":
+        return resolve_claude_code(session_id)
+    if runtime in _RUNTIME_ARGV_HINTS:
+        return resolve_by_cwd(runtime, cwd)
+    return {"ok": False, "runtime": runtime, "unsupported": True,
+            "reason": "runtime_not_signal_supported"}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# High-level, guarded session control (what sync.py calls)
+# ──────────────────────────────────────────────────────────────────────────
+def _guarded(action_name: str, runtime: str, session_id: str, cwd: str,
+             fn) -> Dict[str, Any]:
+    """Resolve the session, run the pid-reuse guard, then call ``fn(pid)``.
+
+    Returns a structured result. Never raises. ``fn`` is one of the signal
+    helpers (stop_turn / graceful_kill / pause / resume).
+    """
+    if not _POSIX:
+        return _result(False, action_name, None, runtime, "unsupported_platform",
+                       session_id=session_id)
+    info = resolve_session(runtime, session_id, cwd)
+    if not info.get("ok"):
+        return _result(False, action_name, None, runtime,
+                       info.get("reason") or "unresolved",
+                       session_id=session_id, unsupported=info.get("unsupported"))
+    pid = info["pid"]
+    ok, reason = verify_pid(pid, info.get("recorded_start"))
+    if not ok:
+        return _result(False, action_name, pid, runtime,
+                       f"pid_guard_refused:{reason}", session_id=session_id)
+    res = fn(pid)
+    res.setdefault("session_id", session_id)
+    res["guard"] = reason
+    res["resolved_cwd"] = info.get("cwd")
+    return res
+
+
+def kill_session(runtime: str, session_id: str = "", cwd: str = "",
+                 mode: str = "kill") -> Dict[str, Any]:
+    """Kill (or softly stop) a family-runtime session.
+
+    ``mode == 'stop'`` sends the soft SIGINT (cancel current turn); any other
+    mode does a graceful_kill (SIGTERM -> escalate to SIGKILL of the tree).
+    """
+    if mode == "stop":
+        return _guarded("stop_turn", runtime, session_id, cwd,
+                        lambda pid: stop_turn(pid, runtime))
+    return _guarded("graceful_kill", runtime, session_id, cwd,
+                    lambda pid: graceful_kill(pid, runtime))
+
+
+def pause_session(runtime: str, session_id: str = "", cwd: str = "") -> Dict[str, Any]:
+    """Pause a family-runtime session (SIGSTOP the tree)."""
+    return _guarded("pause", runtime, session_id, cwd,
+                    lambda pid: pause(pid, runtime))
+
+
+def resume_session(runtime: str, session_id: str = "", cwd: str = "") -> Dict[str, Any]:
+    """Resume a paused family-runtime session (SIGCONT the tree)."""
+    return _guarded("resume", runtime, session_id, cwd,
+                    lambda pid: resume(pid, runtime))

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -7538,6 +7538,11 @@ _PENDING_ACTIONS = frozenset({
     "cron_fix",
     "dives_query",
     "runtime_backfill",
+    # Process-control (kill/pause/resume a runaway agent on the host). Inert
+    # until the cloud enqueues them; safe to merge daemon-only.
+    "kill_session",
+    "pause_session",
+    "resume_session",
 })
 
 
@@ -7747,6 +7752,237 @@ def _dispatch_pending_action(config: dict, action: dict) -> None:
     if atype == "dives_query":
         _action_dives_query(config, action)
         return
+    if atype in ("kill_session", "pause_session", "resume_session"):
+        _action_process_control(config, action)
+        return
+
+
+# ── Process control: kill / pause / resume a runaway agent on the host ──────
+# The cloud relays {type:"kill_session"|"pause_session"|"resume_session",
+# session_id, runtime, cache_key, mode?}. For family runtimes
+# (claude_code/codex/goose/opencode/aider) we map the session to a host process
+# via clawmetry.process_control and send guarded POSIX signals. For
+# openclaw/nemoclaw we cancel via the `openclaw tasks cancel` CLI (the gateway
+# token is read-only). Belt-and-suspenders: every kill/pause also writes the
+# proxy HITL pause file so any proxied runtime refuses further LLM calls even if
+# the signal missed; resume removes it. Every action records an audit event and
+# posts a structured result back under the action's cache_key.
+
+# A clean per-session pause primitive does not exist for OpenClaw's task
+# scheduler, so pause/resume of an openclaw session is honestly reported
+# unsupported rather than faked.
+_OPENCLAW_RUNTIMES = frozenset({"openclaw", "nemoclaw"})
+
+
+def _hitl_pause_path(session_id: str):
+    """Path to the proxy's legacy operator pause file for a session.
+
+    Mirrors clawmetry/proxy.py: ``~/.clawmetry/hitl/pause_<session_id>`` (no
+    extension) — an empty file that ``_is_session_hitl_paused`` honors with no
+    expiry, so the enforcement proxy refuses further LLM calls for that session
+    until the file is removed.
+    """
+    return Path.home() / ".clawmetry" / "hitl" / f"pause_{session_id}"
+
+
+def _write_hitl_pause(session_id: str) -> bool:
+    """Create the proxy HITL pause file for a session. Best-effort, never raises."""
+    if not session_id:
+        return False
+    try:
+        p = _hitl_pause_path(session_id)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.touch(exist_ok=True)
+        return True
+    except Exception as e:
+        log.debug("hitl pause write skipped for %s: %s", session_id, e)
+        return False
+
+
+def _remove_hitl_pause(session_id: str) -> bool:
+    """Remove the proxy HITL pause file for a session. Best-effort, never raises."""
+    if not session_id:
+        return False
+    try:
+        p = _hitl_pause_path(session_id)
+        if p.exists():
+            p.unlink()
+        # Also clear any auto-backoff json so resume is a clean unpause.
+        pj = p.with_name(p.name + ".json")
+        if pj.exists():
+            pj.unlink()
+        return True
+    except Exception as e:
+        log.debug("hitl pause remove skipped for %s: %s", session_id, e)
+        return False
+
+
+def _openclaw_cancel_task(lookup: str, timeout: int = 30) -> dict:
+    """Cancel an OpenClaw task/run/session via ``openclaw tasks cancel <lookup>``.
+
+    ``lookup`` may be a task id, a run id, OR a session key. Uses OpenClaw's own
+    full-scope creds (the gateway token is operator.read only). ``openclaw`` is a
+    Node script; under the daemon's launchd PATH ``node`` may not be found, so we
+    augment PATH the same way ``run_openclaw_cron`` does. Returns
+    ``{ok, scope_pending, error, raw}``. Never raises.
+    """
+    binp = _resolve_openclaw_bin()
+    if not binp:
+        return {"ok": False, "scope_pending": False,
+                "error": "openclaw CLI not found on this machine", "raw": ""}
+    env = dict(os.environ)
+    node_dirs = [
+        os.path.dirname(binp),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        os.path.expanduser("~/.local/bin"),
+    ]
+    env["PATH"] = os.pathsep.join(node_dirs + [env.get("PATH", "/usr/bin:/bin")])
+    cmd = [binp, "tasks", "cancel", str(lookup)]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "scope_pending": False,
+                "error": "openclaw tasks cancel timed out", "raw": ""}
+    except Exception as e:
+        return {"ok": False, "scope_pending": False, "error": str(e)[:400], "raw": ""}
+    blob = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    low = blob.lower()
+    scope_pending = (
+        "pairing required" in low
+        or "scope upgrade" in low
+        or "more scopes than currently approved" in low
+    )
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "exit %d" % proc.returncode).strip()
+        if scope_pending:
+            err = ("Cancel needs a one-time gateway approval. On the host run "
+                   "`openclaw devices list` then `openclaw devices approve <id>` "
+                   "(or approve the pairing prompt), then retry.")
+        return {"ok": False, "scope_pending": scope_pending,
+                "error": err[:500], "raw": blob[:1000]}
+    return {"ok": True, "scope_pending": False, "error": "", "raw": blob[:1000]}
+
+
+def _process_control_audit(atype: str, session_id: str, runtime: str,
+                           result: dict, actor: str) -> None:
+    """Record an Enterprise audit event for a kill/pause/resume. Never raises."""
+    try:
+        from clawmetry import audit as _audit
+        _audit.audit_event(
+            "process." + atype,
+            actor=actor or "cloud-relay",
+            target=session_id or "",
+            result=("ok" if result.get("ok") else "failed"),
+            source="cloud-relay",
+            metadata={
+                "runtime": runtime,
+                "detail": result.get("detail") or result.get("error") or "",
+                "pid": result.get("pid"),
+            },
+        )
+    except Exception:
+        pass
+
+
+def _action_process_control(config: dict, action: dict) -> None:
+    """Cloud-relayed kill / pause / resume of a runaway agent on the host.
+
+    Action shape::
+
+        {type:"kill_session"|"pause_session"|"resume_session",
+         session_id, runtime, cache_key, id?, mode?, actor?}
+
+    Runs in a daemon thread so a SIGTERM->SIGKILL grace window never blocks the
+    heartbeat. Writes/removes the proxy HITL pause file as belt-and-suspenders,
+    records an audit event, and POSTs the structured result under ``cache_key``
+    so the cloud can show the user success/failure."""
+    atype = action.get("type")
+    cache_key = action.get("cache_key")
+    enc_key = config.get("encryption_key")
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    aid = action.get("id")
+    session_id = str(action.get("session_id") or "").strip()
+    runtime = str(action.get("runtime") or "").strip().lower()
+    mode = str(action.get("mode") or "").strip().lower()
+    actor = str(action.get("actor") or "").strip()
+    if not (cache_key and enc_key and api_key and session_id):
+        return
+
+    def _run():
+        result: dict = {"ok": False, "action": atype, "runtime": runtime,
+                        "session_id": session_id}
+        try:
+            import clawmetry.process_control as _pc
+
+            if runtime in _OPENCLAW_RUNTIMES:
+                if atype == "kill_session":
+                    res = _openclaw_cancel_task(session_id)
+                    result.update({
+                        "ok": bool(res.get("ok")),
+                        "detail": "openclaw_task_cancelled" if res.get("ok")
+                        else (res.get("error") or "cancel_failed"),
+                        "scope_pending": bool(res.get("scope_pending")),
+                    })
+                    # Belt-and-suspenders pause file even on kill so a proxied
+                    # OpenClaw refuses further LLM calls if cancel missed.
+                    _write_hitl_pause(session_id)
+                else:
+                    # No clean per-session pause/resume primitive for OpenClaw's
+                    # task scheduler — be honest, don't fake it. We DO still
+                    # flip the proxy HITL pause file so the user's Pause click
+                    # has a real effect on any proxied LLM traffic.
+                    if atype == "pause_session":
+                        wrote = _write_hitl_pause(session_id)
+                        result.update({
+                            "ok": wrote, "unsupported": True,
+                            "detail": "openclaw_pause_unsupported_hitl_only"
+                            if wrote else "openclaw_pause_unsupported",
+                        })
+                    else:  # resume_session
+                        removed = _remove_hitl_pause(session_id)
+                        result.update({
+                            "ok": removed, "unsupported": True,
+                            "detail": "openclaw_resume_unsupported_hitl_only"
+                            if removed else "openclaw_resume_unsupported",
+                        })
+            else:
+                # Family runtimes: real process signals.
+                cwd = str(action.get("cwd") or "").strip()
+                if atype == "kill_session":
+                    res = _pc.kill_session(runtime, session_id, cwd, mode=mode)
+                    _write_hitl_pause(session_id)  # belt-and-suspenders
+                    result.update(res)
+                elif atype == "pause_session":
+                    res = _pc.pause_session(runtime, session_id, cwd)
+                    _write_hitl_pause(session_id)
+                    result.update(res)
+                else:  # resume_session
+                    res = _pc.resume_session(runtime, session_id, cwd)
+                    _remove_hitl_pause(session_id)
+                    result.update(res)
+        except Exception as e:
+            result.update({"ok": False, "detail": ("error: " + str(e))[:300]})
+
+        _process_control_audit(atype, session_id, runtime, result, actor)
+
+        try:
+            blob = encrypt_payload(
+                {**result, "_shape": "process_control"}, enc_key,
+            )
+            _post(
+                "/ingest/cache",
+                {"node_id": node_id, "id": aid, "cache_key": cache_key,
+                 "blob": blob, "shape": "process_control", "ttl": 3600},
+                api_key,
+            )
+        except Exception as e:
+            log.warning("process_control cache post failed: %s", e)
+
+    threading.Thread(target=_run, daemon=True).start()
 
 
 def _action_runtime_backfill(config: dict, action: dict) -> None:

--- a/tests/test_process_control.py
+++ b/tests/test_process_control.py
@@ -1,0 +1,341 @@
+"""Unit tests for clawmetry/process_control.py + the sync.py kill/pause/resume
+dispatch wiring.
+
+These tests spawn REAL throwaway child processes (``sleep`` subprocesses) and
+assert the actual OS state transitions:
+
+  * pause  -> the process enters the STOPPED state (T) and resume -> running (R)
+  * graceful_kill terminates it
+  * the pid-reuse GUARD refuses to signal when the recorded procStart mismatches
+  * a claude_code session-json map resolves a sessionId to a controlled pid and
+    signaling it works
+
+All spawned processes are cleaned up in teardown. Signal tests are skipped on
+platforms that don't support POSIX job-control signals (Windows).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import clawmetry.process_control as pc  # noqa: E402
+
+_POSIX = pc._POSIX
+posix_only = pytest.mark.skipif(not _POSIX, reason="POSIX signals required")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# spawn helper + cleanup
+# ──────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def spawned():
+    procs = []
+
+    def _spawn(cmd=None):
+        # A child that ignores SIGINT would defeat stop_turn tests; a plain
+        # sleep is fine for pause/resume/kill.
+        cmd = cmd or [sys.executable, "-c", "import time; time.sleep(120)"]
+        # start_new_session=True puts the child in its OWN session + process
+        # group. Critical for the pause tests: pause() signals the process
+        # GROUP, and if the child shared pytest's pgid we'd SIGSTOP the test
+        # runner itself. Real agent CLIs (claude/codex/goose) are launched as
+        # their own session leaders too, so this also mirrors production.
+        p = subprocess.Popen(cmd, start_new_session=True)
+        procs.append(p)
+        # give it a moment to actually be running
+        time.sleep(0.2)
+        return p
+
+    yield _spawn
+
+    for p in procs:
+        # A SIGSTOP'd process must be continued before SIGKILL can reap it
+        # cleanly; SIGCONT first so wait() never blocks on a stopped child.
+        try:
+            os.kill(p.pid, signal.SIGCONT)
+        except Exception:
+            pass
+        try:
+            p.kill()
+        except Exception:
+            pass
+        try:
+            p.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def _proc_state(pid: int) -> str:
+    """Single-char process state from ps (R/S/T/Z...). '' if gone."""
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "state=", "-p", str(pid)],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+        # macOS prints e.g. 'T+', 'R+', 'S' — first char is the state.
+        return out[:1] if out else ""
+    except Exception:
+        return ""
+
+
+def _reaped(p, timeout: float = 4.0) -> bool:
+    """True once the Popen child has actually exited (and is reaped).
+
+    NOTE: ``os.kill(pid, 0)`` succeeds on a ZOMBIE (exited-but-unreaped) child,
+    so ``pc.is_alive`` reports True until the parent (pytest) calls wait(). In
+    production the daemon kills a process whose REAL parent reaps it, so it
+    vanishes — there is no zombie. In-test, pytest is the parent, so we must
+    reap with wait() to observe the exit. This asymmetry is a test artifact,
+    not a module bug.
+    """
+    try:
+        p.wait(timeout=timeout)
+        return True
+    except Exception:
+        return False
+
+
+def _wait_state(pid: int, want: str, timeout: float = 3.0) -> str:
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        last = _proc_state(pid)
+        if last == want:
+            return last
+        time.sleep(0.05)
+    return last
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# pid-reuse guard
+# ──────────────────────────────────────────────────────────────────────────
+def test_is_alive_and_dead(spawned):
+    p = spawned()
+    assert pc.is_alive(p.pid) is True
+    p.kill()
+    p.wait(timeout=5)
+    assert pc.is_alive(p.pid) is False
+    assert pc.is_alive(-1) is False
+    assert pc.is_alive(0) is False
+
+
+def test_verify_pid_alive_no_start_check(spawned):
+    p = spawned()
+    ok, reason = pc.verify_pid(p.pid, recorded_start=None)
+    assert ok is True
+    assert reason == "alive_no_start_check"
+
+
+def test_verify_pid_matches_real_start(spawned):
+    p = spawned()
+    tok = pc._proc_start_token(p.pid)
+    if tok is None:
+        pytest.skip("could not read process start time on this platform")
+    # Feed the live token back as the recorded value -> must verify.
+    ok, reason = pc.verify_pid(p.pid, recorded_start=tok)
+    assert ok is True, reason
+    assert reason == "verified"
+
+
+def test_pid_reuse_guard_refuses_on_start_mismatch(spawned):
+    """The core safety guard: a fabricated/stale procStart must REFUSE."""
+    p = spawned()
+    assert pc.is_alive(p.pid)
+    # A clearly-wrong recorded start (epoch far in the past).
+    ok, reason = pc.verify_pid(p.pid, recorded_start="epoch:1")
+    assert ok is False
+    assert reason.startswith("start_mismatch"), reason
+
+
+def test_pid_reuse_guard_refuses_dead_pid(spawned):
+    p = spawned()
+    p.kill()
+    p.wait(timeout=5)
+    ok, reason = pc.verify_pid(p.pid, recorded_start="epoch:1")
+    assert ok is False
+    assert reason == "pid_not_alive"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# signal helpers: pause / resume / graceful_kill
+# ──────────────────────────────────────────────────────────────────────────
+@posix_only
+def test_pause_then_resume_real_state_transition(spawned):
+    p = spawned()
+    assert _proc_state(p.pid) in ("R", "S")  # running or sleeping
+
+    res = pc.pause(p.pid, runtime="claude_code")
+    assert res["ok"] is True, res
+    assert res["action"] == "pause"
+    state = _wait_state(p.pid, "T", timeout=3.0)
+    assert state == "T", f"expected stopped (T), got {state!r}"
+
+    res2 = pc.resume(p.pid, runtime="claude_code")
+    assert res2["ok"] is True, res2
+    # back to running/sleeping (not T)
+    deadline = time.monotonic() + 3.0
+    state2 = "T"
+    while time.monotonic() < deadline:
+        state2 = _proc_state(p.pid)
+        if state2 and state2 != "T":
+            break
+        time.sleep(0.05)
+    assert state2 in ("R", "S"), f"expected resumed, got {state2!r}"
+
+
+@posix_only
+def test_graceful_kill_terminates(spawned):
+    p = spawned()
+    assert pc.is_alive(p.pid)
+    res = pc.graceful_kill(p.pid, runtime="codex", grace_secs=2.0)
+    assert res["ok"] is True, res
+    # SIGTERM on a plain python sleep exits promptly. Reap to observe the exit.
+    assert _reaped(p), res
+    assert p.returncode is not None
+
+
+@posix_only
+def test_graceful_kill_escalates_to_sigkill(spawned):
+    # A child that ignores SIGTERM must still be killed via the SIGKILL escalation.
+    code = (
+        "import signal, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "time.sleep(120)\n"
+    )
+    p = spawned([sys.executable, "-c", code])
+    assert pc.is_alive(p.pid)
+    res = pc.graceful_kill(p.pid, runtime="goose", grace_secs=1.0)
+    # SIGTERM is ignored, so only the SIGKILL escalation can end it. Reap.
+    assert _reaped(p), res
+    assert p.returncode is not None
+
+
+@posix_only
+def test_descendant_set_includes_child():
+    # parent spawns a child; descendant_pids must find the child.
+    code = (
+        "import subprocess, sys, time\n"
+        "c = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])\n"
+        "time.sleep(120)\n"
+    )
+    parent = subprocess.Popen([sys.executable, "-c", code], start_new_session=True)
+    try:
+        time.sleep(0.6)
+        desc = pc.descendant_pids(parent.pid)
+        assert len(desc) >= 1, f"expected at least one descendant, got {desc}"
+        pset = pc.process_set(parent.pid)
+        assert parent.pid in pset
+        assert pset[-1] == parent.pid  # parent last (children first)
+    finally:
+        parent.kill()
+        try:
+            parent.wait(timeout=5)
+        except Exception:
+            pass
+        # reap any orphaned grandchild
+        for d in pc.descendant_pids(parent.pid):
+            try:
+                os.kill(d, signal.SIGKILL)
+            except Exception:
+                pass
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# claude_code session-json discovery
+# ──────────────────────────────────────────────────────────────────────────
+@posix_only
+def test_claude_code_session_map_and_signal(spawned, tmp_path, monkeypatch):
+    import json
+
+    p = spawned()
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    sid = "test-session-abc123"
+    start_tok = pc._proc_start_token(p.pid)
+    if start_tok is None:
+        pytest.skip("no start token on this platform")
+    # claude_code writes <pid>.json with {pid, sessionId, cwd, procStart, status}
+    (sessions_dir / f"{p.pid}.json").write_text(json.dumps({
+        "pid": p.pid,
+        "sessionId": sid,
+        "cwd": os.getcwd(),
+        "procStart": start_tok,   # use the live token so the guard verifies
+        "status": "running",
+        "version": "1.0.0",
+    }))
+    # CLAUDE_CONFIG_DIR override -> <dir>/sessions/
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+    m = pc.claude_code_session_map()
+    assert sid in m
+    assert m[sid]["pid"] == p.pid
+
+    info = pc.resolve_claude_code(sid)
+    assert info["ok"] is True
+    assert info["pid"] == p.pid
+
+    # End-to-end: pause via the high-level guarded path, assert it stops.
+    res = pc.pause_session("claude_code", sid)
+    assert res["ok"] is True, res
+    assert _wait_state(p.pid, "T", timeout=3.0) == "T"
+    pc.resume_session("claude_code", sid)
+
+
+def test_claude_code_unknown_session_returns_not_found(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    info = pc.resolve_claude_code("does-not-exist")
+    assert info["ok"] is False
+    assert info["reason"] == "session_not_in_claude_map"
+
+
+def test_cursor_is_unsupported():
+    info = pc.resolve_session("cursor", "sid")
+    assert info["ok"] is False
+    assert info["unsupported"] is True
+    res = pc.kill_session("cursor", "sid")
+    assert res["ok"] is False
+    assert res.get("unsupported") is True
+
+
+def test_kill_session_refuses_stale_claude_record(spawned, tmp_path, monkeypatch):
+    """The reuse guard, exercised through the high-level kill path: a stale
+    procStart must REFUSE to signal (the process must survive)."""
+    import json
+
+    p = spawned()
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    sid = "stale-session"
+    (sessions_dir / f"{p.pid}.json").write_text(json.dumps({
+        "pid": p.pid,
+        "sessionId": sid,
+        "cwd": os.getcwd(),
+        "procStart": "epoch:1",   # deliberately wrong
+        "status": "running",
+    }))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+
+    res = pc.kill_session("claude_code", sid)
+    assert res["ok"] is False
+    assert "pid_guard_refused" in res["detail"], res
+    # process must still be alive — we refused to signal a possibly-reused pid.
+    assert pc.is_alive(p.pid) is True
+
+
+@posix_only
+def test_stop_turn_sends_sigint(spawned):
+    # A python child that exits on SIGINT (default) — stop_turn should end it.
+    p = spawned([sys.executable, "-c", "import time; time.sleep(120)"])
+    res = pc.stop_turn(p.pid, runtime="claude_code")
+    assert res["ok"] is True, res
+    # Default SIGINT handler raises KeyboardInterrupt -> the child exits. Reap.
+    assert _reaped(p), res
+    assert p.returncode is not None

--- a/tests/test_sync_process_control_dispatch.py
+++ b/tests/test_sync_process_control_dispatch.py
@@ -1,0 +1,174 @@
+"""Tests for the sync.py kill/pause/resume dispatch wiring.
+
+Feeds fake kill_session / pause_session / resume_session actions through
+``_dispatch_pending_action`` and asserts:
+
+  * the right process_control path is called,
+  * a result blob is POSTed back to /ingest/cache under the action's cache_key,
+  * the proxy HITL pause file is written on kill/pause and removed on resume,
+  * UNKNOWN action types are still dropped silently (no POST).
+
+The cloud POST and the actual signal helpers are monkeypatched, so no real
+process is touched and no network call is made.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import clawmetry.sync as sync  # noqa: E402
+import clawmetry.process_control as pc  # noqa: E402
+
+
+def _wait(predicate, timeout=4.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
+
+
+@pytest.fixture
+def captured_posts(monkeypatch):
+    posts = []
+
+    def _fake_post(path, payload, api_key, timeout=45):
+        posts.append((path, payload))
+        return {"ok": True}
+
+    monkeypatch.setattr(sync, "_post", _fake_post)
+    # encrypt_payload must not need a real key; pass through a marker.
+    monkeypatch.setattr(sync, "encrypt_payload",
+                        lambda obj, key: b"ENC:" + repr(obj).encode()[:200])
+    return posts
+
+
+@pytest.fixture
+def hitl_dir(tmp_path, monkeypatch):
+    # Redirect the HITL pause-file path into tmp by monkeypatching Path.home.
+    import pathlib
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(sync.Path, "home", staticmethod(lambda: home))
+    return home / ".clawmetry" / "hitl"
+
+
+_CFG = {"encryption_key": "k" * 44, "api_key": "key123", "node_id": "node-1"}
+
+
+def test_unknown_action_type_still_dropped(captured_posts):
+    sync._dispatch_pending_action(_CFG, {"type": "definitely_not_a_real_action",
+                                         "cache_key": "ck", "session_id": "s"})
+    time.sleep(0.3)
+    assert captured_posts == []
+
+
+def test_kill_session_family_calls_process_control_and_posts(
+        captured_posts, hitl_dir, monkeypatch):
+    calls = {}
+
+    def _fake_kill(runtime, session_id, cwd="", mode="kill"):
+        calls["kill"] = (runtime, session_id, mode)
+        return {"ok": True, "action": "graceful_kill", "pid": 4242,
+                "runtime": runtime, "detail": "terminated"}
+
+    monkeypatch.setattr(pc, "kill_session", _fake_kill)
+
+    action = {"type": "kill_session", "session_id": "sess-xyz",
+              "runtime": "claude_code", "cache_key": "ck-1", "id": "a1"}
+    sync._dispatch_pending_action(_CFG, action)
+
+    assert _wait(lambda: len(captured_posts) == 1), "no result posted"
+    path, payload = captured_posts[0]
+    assert path == "/ingest/cache"
+    assert payload["cache_key"] == "ck-1"
+    assert payload["shape"] == "process_control"
+    assert payload["node_id"] == "node-1"
+    # No mode given -> empty string passed through; kill_session treats any
+    # non-"stop" mode as a graceful kill.
+    assert calls["kill"] == ("claude_code", "sess-xyz", "")
+    # belt-and-suspenders HITL pause file written on kill
+    assert (hitl_dir / "pause_sess-xyz").exists()
+
+
+def test_kill_session_stop_mode_passthrough(captured_posts, hitl_dir, monkeypatch):
+    seen = {}
+
+    def _fake_kill(runtime, session_id, cwd="", mode="kill"):
+        seen["mode"] = mode
+        return {"ok": True, "pid": 1, "detail": "sigint_sent"}
+
+    monkeypatch.setattr(pc, "kill_session", _fake_kill)
+    sync._dispatch_pending_action(_CFG, {
+        "type": "kill_session", "session_id": "s2", "runtime": "codex",
+        "cache_key": "ck-2", "mode": "stop",
+    })
+    assert _wait(lambda: len(captured_posts) == 1)
+    assert seen["mode"] == "stop"
+
+
+def test_pause_then_resume_flips_hitl_file(captured_posts, hitl_dir, monkeypatch):
+    monkeypatch.setattr(pc, "pause_session",
+                        lambda r, s, c="": {"ok": True, "detail": "paused", "pid": 9})
+    monkeypatch.setattr(pc, "resume_session",
+                        lambda r, s, c="": {"ok": True, "detail": "resumed", "pid": 9})
+
+    sync._dispatch_pending_action(_CFG, {
+        "type": "pause_session", "session_id": "p1", "runtime": "goose",
+        "cache_key": "ck-p"})
+    assert _wait(lambda: (hitl_dir / "pause_p1").exists())
+
+    sync._dispatch_pending_action(_CFG, {
+        "type": "resume_session", "session_id": "p1", "runtime": "goose",
+        "cache_key": "ck-r"})
+    assert _wait(lambda: not (hitl_dir / "pause_p1").exists())
+    assert _wait(lambda: len(captured_posts) == 2)
+
+
+def test_openclaw_kill_uses_cli_cancel(captured_posts, hitl_dir, monkeypatch):
+    seen = {}
+
+    def _fake_cancel(lookup, timeout=30):
+        seen["lookup"] = lookup
+        return {"ok": True, "scope_pending": False, "error": "", "raw": ""}
+
+    monkeypatch.setattr(sync, "_openclaw_cancel_task", _fake_cancel)
+    sync._dispatch_pending_action(_CFG, {
+        "type": "kill_session", "session_id": "ocsess", "runtime": "openclaw",
+        "cache_key": "ck-oc"})
+    assert _wait(lambda: len(captured_posts) == 1)
+    assert seen["lookup"] == "ocsess"
+    _, payload = captured_posts[0]
+    assert payload["shape"] == "process_control"
+
+
+def test_openclaw_pause_is_honest_unsupported(captured_posts, hitl_dir, monkeypatch):
+    # pause/resume have no clean OpenClaw primitive — must report unsupported,
+    # but still flip the HITL pause file so the user's click has a real effect.
+    sync._dispatch_pending_action(_CFG, {
+        "type": "pause_session", "session_id": "ocp", "runtime": "openclaw",
+        "cache_key": "ck-ocp"})
+    assert _wait(lambda: len(captured_posts) == 1)
+    assert (hitl_dir / "pause_ocp").exists()
+    _, payload = captured_posts[0]
+    # blob is our marker bytes; assert the repr embeds unsupported + the shape.
+    assert b"unsupported" in payload["blob"]
+
+
+def test_missing_cache_key_is_noop(captured_posts, hitl_dir):
+    sync._dispatch_pending_action(_CFG, {
+        "type": "kill_session", "session_id": "s", "runtime": "claude_code"})
+    time.sleep(0.3)
+    assert captured_posts == []
+
+
+def test_action_types_in_allowlist():
+    for t in ("kill_session", "pause_session", "resume_session"):
+        assert t in sync._PENDING_ACTIONS


### PR DESCRIPTION
## What

Adds the OSS daemon-side engine that lets a runaway agent be **killed**, **paused**, or **resumed** on the user's own machine, triggered by a command relayed from the cloud. This is the foundation for a non-technical person clicking Kill on the hosted dashboard and a runaway agent actually dying mid-task.

New module `clawmetry/process_control.py` (pure, dependency-light, host-testable) plus wiring into `clawmetry/sync.py`. **Daemon-only**: the new action types are inert until the cloud enqueues them, so this is safe to merge. No cloud endpoint or UI here (that is a separate cloud PR).

## How it works

`process_control.py` maps an observed session to a local OS process per runtime, then sends bounded, guarded POSIX signals:

- **Discovery.** `claude_code` is read from per-pid `~/.claude/sessions/<pid>.json` (honors `CLAUDE_CONFIG_DIR`), the primary rich mapping. Generic cwd+argv match for `codex`/`goose`/`opencode`/`aider`. `cursor` is explicitly unsupported (one IDE process holds all sessions, so we never signal the IDE). macOS and Linux first-class; `psutil` optional with `ps`/`lsof` fallbacks.
- **pid-reuse guard.** Before signaling we re-verify the pid is alive AND its live start time still matches the recorded `procStart`. On mismatch we refuse, so the OS recycling a pid can never make us SIGKILL a stranger's process.
- **Signals.** `stop_turn` SIGINT to the main pid (cancel current turn), `graceful_kill` SIGTERM then escalate to SIGKILL of the full descendant set, `pause`/`resume` SIGSTOP/SIGCONT every distinct process group in the ppid tree. The per-pgid walk catches detached tool shells that re-parented into their own process group (a single `kill(-pgid)` would miss them).
- **Never crashes, never hangs.** Missing file, dead pid, permission error all return `ok:false` with a reason; every wait is bounded.

### sync.py wiring

`kill_session` / `pause_session` / `resume_session` added to `_PENDING_ACTIONS` with a `_dispatch_pending_action` branch:

- `openclaw`/`nemoclaw` kill via `openclaw tasks cancel <session_id>` (augmented PATH so the launchd daemon finds `node`; `scope_pending` classified). openclaw pause/resume honestly report unsupported rather than faking a primitive that does not exist.
- Family runtimes use `process_control`.
- Every action also flips the proxy HITL pause file (`~/.clawmetry/hitl/pause_<session_id>`) as belt-and-suspenders so a proxied runtime refuses further LLM calls even if the signal missed, records an audit event (who/what/result), and posts the structured result back under the action `cache_key`.

## Verification

- 22 unit tests pass. They spawn real throwaway processes and assert R to T on pause, T to R on resume, graceful_kill terminates (including the SIGKILL escalation past an ignored SIGTERM), the reuse guard refuses on a stale `procStart`, claude_code discovery resolves a sessionId to a controlled pid, and cursor is unsupported.
- **Revert-proven:** broke the procStart guard, watched the two reuse-guard tests go red, restored, green again.
- The sync dispatch test feeds fake actions through `_dispatch_pending_action` and asserts the right path runs, the result posts, the HITL file flips on pause/resume, and unknown types stay dropped.
- **Live smoke on the deployed daemon** against a controlled `sleep` target with a synthetic claude pid-map (never touching real active work): pause flipped state `Ss` to `Ts`, resume `Ts` to `Ss`, the stale-record guard refused and the target survived, graceful_kill drove it to `Z`. The full `_dispatch_pending_action` path wrote real `process.pause_session` / `process.resume_session` audit rows and posted `_shape:"process_control"` blobs under the right cache keys. Daemon restored to merged code afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)