### PR TITLE
fix(sync): _post tolerates empty 204 body (kills spurious cache-post-failed warnings)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -993,7 +993,13 @@ def _post(path: str, payload: dict, api_key: str, timeout: int = 45) -> dict:
     for attempt in range(1, _HTTP_MAX_ATTEMPTS + 1):
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
-                resp_body = json.loads(resp.read())
+                raw = resp.read()
+                # Some endpoints answer 204 / an empty body on success
+                # (e.g. /ingest/cache returns ("", 204) after storing a
+                # process_control or cron result). json.loads("") raises,
+                # which surfaced as a spurious "cache post failed" warning
+                # on every successful post-back. Treat an empty body as {}.
+                resp_body = json.loads(raw) if raw.strip() else {}
             # Cloud heartbeat (and any other endpoint) may attach the user's
             # plan / sync_allowed / trial_days_left / upgrade_url. We mirror
             # those into _TRIAL_STATE so subsequent uploads can self-throttle

--- a/tests/test_sync_post_empty_body.py
+++ b/tests/test_sync_post_empty_body.py
@@ -1,0 +1,52 @@
+"""Regression: clawmetry.sync._post must tolerate an empty / 204 response body.
+
+The cloud /ingest/cache endpoint answers ("", 204) after storing a result
+(process_control kill/pause/resume, cron_killall, dives_query, ...). Before
+the fix, ``_post`` did ``json.loads(resp.read())`` unconditionally, so every
+successful post-back raised ``json.JSONDecodeError`` ("Expecting value: line 1
+column 1") which the action handlers logged as a spurious "cache post failed"
+warning. The write had actually succeeded.
+
+This test drives ``_post`` against a fake urlopen returning an empty body and
+asserts it returns ``{}`` instead of raising.
+"""
+import io
+import json
+import urllib.request
+
+import pytest
+
+from clawmetry import sync
+
+
+class _FakeResp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.mark.parametrize("body", [b"", b"   ", b"\n"])
+def test_post_tolerates_empty_body(monkeypatch, body):
+    monkeypatch.setattr(sync, "INGEST_URL", "https://ingest.example.com")
+    monkeypatch.setattr(urllib.request, "urlopen", lambda req, timeout=0: _FakeResp(body))
+    # Must not raise; an empty body means "stored, nothing to return" -> {}.
+    out = sync._post("/ingest/cache", {"node_id": "n1", "blob": "x"}, "cm_test")
+    assert out == {}
+
+
+def test_post_still_parses_json_body(monkeypatch):
+    monkeypatch.setattr(sync, "INGEST_URL", "https://ingest.example.com")
+    payload = {"ok": True, "sync_allowed": True}
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda req, timeout=0: _FakeResp(json.dumps(payload).encode())
+    )
+    out = sync._post("/ingest/heartbeat", {"node_id": "n1"}, "cm_test")
+    assert out["ok"] is True and out["sync_allowed"] is True


### PR DESCRIPTION
## Why
The cloud `/ingest/cache` endpoint answers `("", 204)` after storing a result, but the daemon's `_post` did `json.loads(resp.read())` unconditionally, raising `JSONDecodeError` on every successful post-back. Surfaced as a noisy `process_control cache post failed: Expecting value: line 1 column 1` (and the same for cron_killall / dives_query / selfevolve) even though the write succeeded. Found while live-verifying the kill switch (#2996).

## What
Treat an empty body as `{}`. One-line guard, plus a regression test (`tests/test_sync_post_empty_body.py`) covering empty / whitespace bodies and confirming real JSON still parses.

## Verification
Revert-proven: 4 pass with the fix, 3 fail on the restored buggy line, green again after restore. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)