### PR TITLE
fix(openclaw): surface Talk/voice lifecycle log fields from data blob

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -460,6 +460,21 @@ class OpenClawAdapter(AgentAdapter):
                                 _val = obj.get(_field)
                                 if _val:
                                     extra[_key] = _val
+                            # Talk / realtime-voice / managed-room lifecycle
+                            # fields (#2957). sync.py stores these top-level in
+                            # the data blob for voice events (sync.py ~L4960);
+                            # surface them so callers see voice/Talk metadata.
+                            # String fields skip empties; numeric fields use an
+                            # explicit None check so a legitimate 0 (e.g. a
+                            # zero-byte payload) is preserved rather than dropped.
+                            for _field in ("mode", "transport", "provider"):
+                                _val = obj.get(_field)
+                                if _val:
+                                    extra[_field] = _val
+                            for _field in ("duration_ms", "size_bytes"):
+                                _val = obj.get(_field)
+                                if _val is not None:
+                                    extra[_field] = _val
                             msg = obj.get("message")
                             if isinstance(msg, str):
                                 content_text = msg

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -239,6 +239,47 @@ def test_list_events_surfaces_log_level_and_subsystem(isolated_store):
     assert ex.get("hostname") == "Dhriti-1"
 
 
+def test_list_events_surfaces_voice_lifecycle_fields(isolated_store):
+    """Talk/realtime-voice/managed-room lifecycle fields come through extra (#2957).
+
+    sync.py stores ``mode``, ``transport``, ``provider``, ``duration_ms`` and
+    ``size_bytes`` top-level in the voice event's data blob (sync.py ~L4960).
+    Previously list_events unpacked only ``channel``/``hostname``, so these
+    five fields were present in DuckDB but never reached Event.extra. Pin the
+    new behavior, including that a zero ``size_bytes`` is preserved (numeric
+    fields use a None check, not truthiness).
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-VOICE",
+        "event_type": "voice.session",
+        "ts": _t.time(),
+        "data": {
+            "mode": "realtime",
+            "transport": "webrtc",
+            "provider": "openai",
+            "duration_ms": 1234,
+            "size_bytes": 0,
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-VOICE")
+    assert len(events) == 1
+    e = events[0]
+    assert e.extra.get("mode") == "realtime"
+    assert e.extra.get("transport") == "webrtc"
+    assert e.extra.get("provider") == "openai"
+    assert e.extra.get("duration_ms") == 1234
+    # A legitimate 0 (zero-byte payload) must survive, not be dropped.
+    assert e.extra.get("size_bytes") == 0
+
+
 def test_list_events_dict_message_does_not_set_content(isolated_store):
     """Sanity guard: when ``message`` is a dict (assistant turn shape),
     Event.content stays empty — only string ``message`` values are


### PR DESCRIPTION
Closes #2957

## What
`OpenClawAdapter.list_events()` unpacked only `channel` and `hostname` from the `events.data` blob. The Talk / realtime-voice / managed-room lifecycle fields `mode`, `transport`, `provider`, `duration_ms`, and `size_bytes` are written into the blob by `sync.py` (~L4960) but were never placed into `Event.extra` — present in DuckDB, invisible to callers.

## How
- Extend the blob-unpack loop in `clawmetry/adapters/openclaw.py` to surface the five voice lifecycle fields into `Event.extra`.
- String fields (`mode`/`transport`/`provider`) skip empties; numeric fields (`duration_ms`/`size_bytes`) use an explicit `is not None` check so a legitimate `0` (e.g. zero-byte payload) is preserved rather than dropped by truthiness.
- Add `test_list_events_surfaces_voice_lifecycle_fields` mirroring the existing channel/hostname test, including the zero-`size_bytes` edge case.

## Verify
`pytest tests/test_openclaw_list_events.py -q` → 14 passed.