### PR TITLE
feat(snapshot): per-runtime byRuntime slices for Cost + Context-econ + Flow Active Tools (#3004)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -16560,6 +16560,14 @@ function _backfillFlowFromBrain() {
   // never empty after a page reload, even if /api/flow-events has been quiet.
   fetch('/api/brain-history?limit=40').then(function(r){return r.json();}).then(function(d) {
     var events = (d && d.events) || [];
+    // Scope Active Tools to the selected runtime (#3004): brain-history is
+    // node-wide, so without this filter a single-runtime switcher still lit up
+    // from other runtimes' tool events. Same client-side prefix filter the
+    // Brain tab's native renderers use (_cmRuntimeOf on the session-id prefix).
+    var _r = (typeof _cmRuntimeFilter === 'function') ? _cmClientFilterRt(_cmRuntimeFilter()) : 'all';
+    if (_r !== 'all') {
+      events = events.filter(function(ev) { return _cmRuntimeOf(ev) === _r; });
+    }
     var now = Date.now();
     var seen = 0;
     // events are most-recent-first; scan up to 8 tool-typed events.

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11257,10 +11257,45 @@ def _build_runtime_summary(limit: int = 20000):
         rt_switches: dict = defaultdict(int)
         for s in (rollup.get("switches") or []):
             rt_switches[s.get("runtime") or "openclaw"] += 1
+        # Per-runtime rolling 7-day + 30-day token/cost windows (#3004) so the
+        # cloud Cost cards can show REAL week/month per-runtime numbers instead
+        # of standing in lifetime. Sourced from the materialized
+        # ``rollup_runtime_daily`` table (#2988): one cheap read, no event scan
+        # (FLYWHEEL 1e). Naming mirrors the existing ``tokens_24h`` /
+        # ``cost_24h_usd`` rolling fields. ``rt -> {tokens_7d, cost_7d,
+        # tokens_30d, cost_30d}``.
+        rt_windows: dict = {}
+        try:
+            from datetime import datetime as _dt, timedelta as _td
+            _now = _dt.now()
+            _d7 = (_now - _td(days=6)).strftime("%Y-%m-%d")
+            _d30 = (_now - _td(days=29)).strftime("%Y-%m-%d")
+            for r in (store.query_rollup_runtime_daily(
+                since=_d30, limit=10000,
+            ) or []):
+                d = str(r.get("day") or "")[:10]
+                if not d:
+                    continue
+                rt = (r.get("runtime") or "").strip() or "openclaw"
+                w = rt_windows.setdefault(rt, {
+                    "tokens_7d": 0, "cost_7d": 0.0,
+                    "tokens_30d": 0, "cost_30d": 0.0,
+                })
+                tk = int(r.get("tokens") or 0)
+                ct = float(r.get("cost_usd") or 0.0)
+                w["tokens_30d"] += tk
+                w["cost_30d"] += ct
+                if d >= _d7:
+                    w["tokens_7d"] += tk
+                    w["cost_7d"] += ct
+        except Exception as _e_w:
+            log.debug("runtime summary 7d/30d window build failed: %s", _e_w)
+            rt_windows = {}
         out: dict = {}
-        # Union of runtimes seen in the per-runtime totals and the per-model rows
-        # (a runtime with only model-less events still gets a card with 0 turns).
-        for rt in set(by_runtime) | set(rt_models):
+        # Union of runtimes seen in the per-runtime totals, the per-model rows,
+        # and the rolling-window rollup (a runtime with only model-less events,
+        # or one present only in rollup_runtime_daily, still gets a card).
+        for rt in set(by_runtime) | set(rt_models) | set(rt_windows):
             totals = by_runtime.get(rt) or {}
             models = rt_models.get(rt) or {}
             total = sum(mm["turns"] for mm in models.values())
@@ -11270,6 +11305,7 @@ def _build_runtime_summary(limit: int = 20000):
                 "sessions": mm["sessions"],
                 "share_pct": round(mm["turns"] / total * 100, 2) if total else 0,
             } for m, mm in sorted_models[:15]]
+            _w = rt_windows.get(rt) or {}
             out[rt] = {
                 "sessions": int(totals.get("sessions") or 0),
                 "turns": total,
@@ -11279,6 +11315,12 @@ def _build_runtime_summary(limit: int = 20000):
                 # dual-column UI.
                 "cost_24h_usd": round(float(totals.get("cost_24h_usd") or 0.0), 4),
                 "tokens_24h": int(totals.get("tokens_24h") or 0),
+                # Rolling 7-day + 30-day windows (#3004) for the cloud Cost
+                # week/month cards; sourced from rollup_runtime_daily.
+                "tokens_7d": int(_w.get("tokens_7d") or 0),
+                "cost_7d_usd": round(float(_w.get("cost_7d") or 0.0), 4),
+                "tokens_30d": int(_w.get("tokens_30d") or 0),
+                "cost_30d_usd": round(float(_w.get("cost_30d") or 0.0), 4),
                 "primary_model": sorted_models[0][0] if sorted_models else "",
                 "total_turns": total,
                 "models": models_out,
@@ -12701,6 +12743,50 @@ def _build_daily_usage(days=14):
         tstr = now.strftime("%Y-%m-%d")
         wk = (now - timedelta(days=now.weekday())).strftime("%Y-%m-%d")
         mo = now.strftime("%Y-%m-01")
+        # Per-runtime daily series (#3004) so the cloud Cost 14-day chart can
+        # render purely from the encrypted snapshot when scoped to a runtime,
+        # instead of falling back to the scoped server path. Sourced from the
+        # materialized ``rollup_runtime_daily`` table (#2988) -> cheap read, no
+        # full event scan (FLYWHEEL 1e). Additive: node-wide ``days``/``today``/
+        # ``week``/``month`` above are unchanged. Shape per runtime is a list of
+        # ``{day, tokens, cost_usd}`` over the same ``days``-day window, oldest
+        # first, with a zero-filled point for every day so the chart axis lines
+        # up across runtimes. Empty {} when the rollup is unavailable.
+        by_runtime: dict = {}
+        try:
+            window = [
+                (now - timedelta(days=i)).strftime("%Y-%m-%d")
+                for i in range(days - 1, -1, -1)
+            ]
+            window_set = set(window)
+            since = window[0]
+            # rt -> {day: {"tokens": int, "cost_usd": float}}
+            rt_days: dict = {}
+            for r in (store.query_rollup_runtime_daily(
+                since=since, limit=10000,
+            ) or []):
+                d = str(r.get("day") or "")[:10]
+                if not d or d not in window_set:
+                    continue
+                rt = (r.get("runtime") or "").strip() or "openclaw"
+                slot = rt_days.setdefault(rt, {})
+                cell = slot.setdefault(d, {"tokens": 0, "cost_usd": 0.0})
+                cell["tokens"] += int(r.get("tokens") or 0)
+                cell["cost_usd"] += float(r.get("cost_usd") or 0.0)
+            for rt, slot in rt_days.items():
+                by_runtime[rt] = [
+                    {
+                        "day": d,
+                        "tokens": int(slot.get(d, {}).get("tokens", 0)),
+                        "cost_usd": round(
+                            float(slot.get(d, {}).get("cost_usd", 0.0)), 6
+                        ),
+                    }
+                    for d in window
+                ]
+        except Exception as _e_rt:
+            log.debug("daily usage byRuntime build failed: %s", _e_rt)
+            by_runtime = {}
         return {
             "days": out_days,
             "today": int(daily_tok.get(tstr, 0)),
@@ -12709,6 +12795,7 @@ def _build_daily_usage(days=14):
             "todayCost": round(float(daily_cost.get(tstr, 0.0)), 6),
             "weekCost": round(sum(v for k, v in daily_cost.items() if k >= wk), 6),
             "monthCost": round(sum(v for k, v in daily_cost.items() if k >= mo), 6),
+            "byRuntime": by_runtime,
         }
     except Exception as _e:
         log.debug("daily usage snapshot build failed: %s", _e)
@@ -13386,35 +13473,77 @@ def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
     return out
 
 
-def _context_econ_by_runtime(compactions, overflow_sessions, base_summary):
+def _session_chips_from_utilization(utilization):
+    """Distinct-session chips from a utilization series, most-recent first, each
+    ``{session_id, peak_pct, ts}``. Mirrors the route builder in
+    ``routes/context_economics.py`` so the snapshot ships the same shape the
+    cloud Context-economics interceptor expects."""
+    chips: dict = {}
+    for u in (utilization or []):
+        sid = str((u or {}).get("session_id") or "")
+        if not sid:
+            continue
+        entry = chips.setdefault(sid, {"session_id": sid, "peak_pct": 0.0, "ts": ""})
+        try:
+            entry["peak_pct"] = max(entry["peak_pct"], float(u.get("pct") or 0))
+        except (TypeError, ValueError):
+            pass
+        ts = str(u.get("ts") or "")
+        if ts > entry["ts"]:
+            entry["ts"] = ts
+    return sorted(chips.values(), key=lambda c: c["ts"], reverse=True)
+
+
+def _context_econ_by_runtime(compactions, overflow_sessions, base_summary,
+                             utilization=None):
     """Group context-economics compactions + overflow sessions per runtime
     (session_id prefix) for the Context-economics runtime filter. Returns
-    ``{runtime: {compactions, overflow_sessions, summary}}``; a runtime that
-    never compacted is absent (the cloud interceptor then serves an empty
-    slice). ``peak_pct``/``utilization_points`` inherit the node-wide value —
-    utilization points are not per-session, so they aren't split."""
+    ``{runtime: {compactions, overflow_sessions, summary, utilization,
+    session_chips}}``; a runtime that never compacted AND has no utilization
+    readings is absent (the cloud interceptor then serves an empty slice).
+
+    The per-turn ``utilization`` series and the derived ``session_chips`` ARE
+    bucketed per runtime (#3004) by each point's ``session_id`` prefix, so the
+    cloud context-window gauge + session picker can scope to the selected
+    runtime instead of returning empty. ``peak_pct`` is recomputed from the
+    runtime's own utilization points (falling back to the node-wide value when
+    a runtime has compactions but no readings); the node-wide slice is
+    unchanged."""
+    # Bucket utilization points by runtime first so a runtime with readings but
+    # no compactions still gets a slice (its gauge + chips populate).
+    util_by_rt: dict = {}
+    for u in (utilization or []):
+        rt = _runtime_of_session((u or {}).get("session_id") or "")
+        util_by_rt.setdefault(rt, []).append(u)
     by: dict = {}
     for c in (compactions or []):
         rt = _runtime_of_session((c or {}).get("session_id") or "")
         by.setdefault(rt, []).append(c)
     base = base_summary or {}
     out: dict = {}
-    for rt, comps in by.items():
+    for rt in set(by) | set(util_by_rt):
+        comps = by.get(rt, [])
+        rt_util = util_by_rt.get(rt, [])
         ovn = sum(1 for c in comps if c.get("trigger") == "overflow")
         rt_ovf = [s for s in (overflow_sessions or [])
                   if _runtime_of_session(
                       (s.get("session_id") if isinstance(s, dict) else s) or "") == rt]
+        rt_chips = _session_chips_from_utilization(rt_util)
+        rt_peak = max((float(u.get("pct") or 0) for u in rt_util),
+                      default=base.get("peak_pct", 0))
         out[rt] = {
             "compactions": comps,
             "overflow_sessions": rt_ovf,
+            "utilization": rt_util,
+            "session_chips": rt_chips,
             "summary": {
                 "compaction_count": len(comps),
                 "overflow_count": ovn,
                 "proactive_count": len(comps) - ovn,
                 "total_reclaimed": sum(int(c.get("reclaimed") or 0) for c in comps),
-                "peak_pct": base.get("peak_pct", 0),
+                "peak_pct": round(float(rt_peak), 2),
                 "overflow_sessions": len(rt_ovf),
-                "utilization_points": base.get("utilization_points", 0),
+                "utilization_points": len(rt_util),
             },
         }
     return out
@@ -14958,6 +15087,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
                 context_economics_slice["compactions"],
                 context_economics_slice["overflow_sessions"],
                 context_economics_slice["summary"],
+                utilization=_ce_util,
             )
     except Exception as _e_ce:
         log.debug("snapshot: context_economics slice failed: %s", _e_ce)

--- a/tests/test_appjs_units.js
+++ b/tests/test_appjs_units.js
@@ -1237,6 +1237,91 @@ console.log('renderBrainChart + renderBrainStream apply the runtime filter');
          'renderBrainChart honours the channel pill (mirrors the list)');
 }
 
+// ── Issue #3004 — Flow "Active Tools" backfill honours the runtime filter ─
+//
+// _backfillFlowFromBrain consumes node-wide /api/brain-history events to seed
+// the Flow tab's Active Tools row. Under a single-runtime switcher it must NOT
+// light up from OTHER runtimes' brain events. This test both (a) statically
+// guards the filter is present, and (b) actually runs the function with a
+// stubbed fetch returning a mix of claude_code + openclaw events and asserts
+// only the selected runtime's tool lights up flowStats.activeTools.
+console.log('_backfillFlowFromBrain scopes Active Tools by runtime (#3004)');
+{
+  const backfill = extractFunction('_backfillFlowFromBrain');
+  // (a) Static leak guard: the same client filter the Brain tab uses.
+  truthy(/_cmRuntimeFilter\s*\(/.test(backfill),
+         '_backfillFlowFromBrain calls _cmRuntimeFilter()');
+  truthy(/_cmClientFilterRt\s*\(/.test(backfill),
+         '_backfillFlowFromBrain collapses OTLP via _cmClientFilterRt()');
+  truthy(/_cmRuntimeOf\(\s*ev\s*\)/.test(backfill),
+         '_backfillFlowFromBrain filters events by _cmRuntimeOf(ev)');
+
+  // (b) Behavioural: run the real function under a stubbed environment.
+  // Two recent tool events, one per runtime (session-id prefix). With the
+  // switcher pinned to claude_code, only its tool must be marked active.
+  const now = new Date();
+  const recentIso = new Date(now.getTime() - 60 * 1000).toISOString(); // 1 min ago
+  const events = [
+    { id: 'claude_code:s1', type: 'EXEC', time: recentIso, tool: 'bash' },
+    { id: 'openclaw:s2',    type: 'READ', time: recentIso, tool: 'read' },
+  ];
+
+  function runBackfill(selectedRuntime) {
+    const activeTools = {};
+    const sandbox = {
+      Date: Date,
+      setTimeout: function() {},   // never expire within the test
+      console: console,
+      // brain-type → flow-tool: map EXEC→exec, READ→read so both events count.
+      _brainTypeToFlowTool: function(t) {
+        if (t === 'EXEC') return 'exec';
+        if (t === 'READ') return 'read';
+        return null;
+      },
+      // The two client-filter helpers + the prefix resolver, mirroring app.js.
+      _cmRuntimeFilter: function() { return selectedRuntime; },
+      _cmClientFilterRt: function(rt) { return rt; }, // no OTLP in this test
+      _cmRuntimeOf: function(o) {
+        const id = (o && (o.id || o.sessionId || o.session_id || o.key)) || '';
+        const i = id.indexOf(':');
+        return i > 0 ? id.slice(0, i).toLowerCase() : 'openclaw';
+      },
+      flowStats: { activeTools: activeTools },
+      updateFlowStats: function() {},
+      fetch: function() {
+        return Promise.resolve({ json: function() {
+          return Promise.resolve({ events: events });
+        } });
+      },
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(backfill + '\n_backfillFlowFromBrain();', sandbox);
+    return new Promise(function(resolve) {
+      setImmediate(function() { setImmediate(function() {
+        resolve(activeTools);
+      }); });
+    });
+  }
+
+  (async function() {
+    const ccOnly = await runBackfill('claude_code');
+    truthy(ccOnly['exec'] === true,
+           'claude_code selected → its EXEC tool lights up');
+    truthy(ccOnly['read'] === undefined,
+           'claude_code selected → openclaw READ tool does NOT light up (#3004)');
+
+    const all = await runBackfill('all');
+    truthy(all['exec'] === true && all['read'] === true,
+           'all runtimes selected → both tools light up (no filter)');
+
+    const ocOnly = await runBackfill('openclaw');
+    truthy(ocOnly['read'] === true,
+           'openclaw selected → its READ tool lights up');
+    truthy(ocOnly['exec'] === undefined,
+           'openclaw selected → claude_code EXEC tool does NOT light up');
+  })();
+}
+
 // Auth-bootstrap scenarios above are async — wait for the microtask /
 // macrotask queue to drain before printing the summary. (The previous
 // synchronous test blocks all completed in-tick, so no wait was needed

--- a/tests/test_byruntime_slices.py
+++ b/tests/test_byruntime_slices.py
@@ -1,0 +1,227 @@
+"""Per-runtime snapshot slices for the cloud Cost + Context-economics tabs
+(issue #3004).
+
+The cloud runtime-scope sweep (clawmetry-cloud #1618) made every hosted tab
+honest, but three sub-panels fell back to empty / lifetime-stand-in because the
+daemon snapshot carried no per-runtime slice for them. This test pins the three
+new slices the daemon now emits, all sourced from the materialized
+``rollup_runtime_daily`` table (#2988) so they cost a cheap read, not a full
+event scan (FLYWHEEL 1e):
+
+1. ``dailyUsage.byRuntime[rt]`` — a 14-day per-runtime {day, tokens, cost_usd}
+   series for the Cost 14-day chart.
+2. ``runtimeSummary[rt].tokens_7d / cost_7d_usd / tokens_30d / cost_30d_usd`` —
+   real rolling week/month windows per runtime for the Cost cards.
+3. ``contextEconomics.byRuntime[rt].utilization / session_chips`` — the
+   per-turn utilization series + the session-picker chips, bucketed per
+   runtime for the Context-economics gauge.
+
+All three are additive: the node-wide ``dailyUsage`` / ``runtimeSummary`` /
+``contextEconomics`` keys are untouched.
+"""
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def fresh_store(tmp_path, monkeypatch):
+    """Isolated LocalStore on a tmp DuckDB path (manual flush)."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "3600")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "100000")
+    monkeypatch.setenv(
+        "CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "byruntime.duckdb")
+    )
+    import clawmetry.local_store as ls
+    ls = importlib.reload(ls)
+    store = ls.LocalStore()
+    try:
+        yield ls, store
+    finally:
+        try:
+            store.stop(flush=False)
+        except Exception:
+            pass
+
+
+def _day(offset_days: int) -> str:
+    return (datetime.now() - timedelta(days=offset_days)).strftime("%Y-%m-%d")
+
+
+def _seed_runtime_daily(store, rows):
+    """Insert (day, runtime, tokens, cost_usd, sessions, active_sessions)
+    directly into the materialized rollup, bypassing ingest so the test owns
+    the exact per-day/per-runtime corpus."""
+    with store._write_lock:
+        for day, rt, tok, cost, sess, act in rows:
+            store._conn.execute(
+                "INSERT INTO rollup_runtime_daily "
+                "(day, runtime, tokens, cost_usd, sessions, active_sessions) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                [day, rt, tok, cost, sess, act],
+            )
+
+
+def _corpus_rows():
+    """Two runtimes across several days inside the 14d/7d/30d windows.
+
+    claude_code: days 0,1,8,20  (so 7d window catches days 0+1 only;
+                 30d catches all four; 14d series catches days 0,1,8)
+    openclaw:    days 0,2,40    (day 40 is OUTSIDE every window)
+    """
+    return [
+        # claude_code
+        (_day(0),  "claude_code", 1000, 1.0, 2, 1),
+        (_day(1),  "claude_code", 2000, 2.0, 1, 0),
+        (_day(8),  "claude_code", 4000, 4.0, 3, 1),
+        (_day(20), "claude_code", 8000, 8.0, 1, 0),
+        # openclaw
+        (_day(0),  "openclaw",     500, 0.5, 1, 1),
+        (_day(2),  "openclaw",     700, 0.7, 2, 0),
+        (_day(40), "openclaw",    9999, 9.9, 1, 0),  # outside 30d window
+    ]
+
+
+# ── 1. dailyUsage.byRuntime ──────────────────────────────────────────────
+
+def test_daily_usage_by_runtime_14d_series(fresh_store, monkeypatch):
+    ls, store = fresh_store
+    _seed_runtime_daily(store, _corpus_rows())
+    import clawmetry.sync as sync
+    monkeypatch.setattr(sync, "_backfill_event_costs_once", lambda s: None)
+    monkeypatch.setattr(sync, "_backfill_benign_errors_once", lambda s: None)
+    monkeypatch.setattr(ls, "get_store", lambda *a, **k: store)
+
+    du = sync._build_daily_usage(days=14)
+
+    # Node-wide keys still present + unchanged in shape (additive).
+    assert "days" in du and "today" in du and "monthCost" in du
+    assert len(du["days"]) == 14
+
+    br = du.get("byRuntime") or {}
+    assert set(br.keys()) == {"claude_code", "openclaw"}
+
+    # Each runtime series is exactly 14 points, oldest first, zero-filled.
+    cc = br["claude_code"]
+    assert len(cc) == 14
+    assert [p["day"] for p in cc] == [_day(i) for i in range(13, -1, -1)]
+
+    by_day = {p["day"]: p for p in cc}
+    assert by_day[_day(0)]["tokens"] == 1000
+    assert by_day[_day(0)]["cost_usd"] == 1.0
+    assert by_day[_day(1)]["tokens"] == 2000
+    assert by_day[_day(8)]["tokens"] == 4000
+    # day 20 is outside the 14-day window -> not present as a point
+    assert _day(20) not in by_day
+    # a day with no rollup row is a zero-filled point, not missing
+    assert by_day[_day(5)]["tokens"] == 0
+    assert by_day[_day(5)]["cost_usd"] == 0.0
+
+    oc = {p["day"]: p for p in br["openclaw"]}
+    assert oc[_day(0)]["tokens"] == 500
+    assert oc[_day(2)]["tokens"] == 700
+    # the 14d sum per runtime reconciles with the seeded in-window rows
+    assert sum(p["tokens"] for p in cc) == 1000 + 2000 + 4000
+    assert sum(p["tokens"] for p in br["openclaw"]) == 500 + 700
+
+
+# ── 2. runtimeSummary[rt] 7d / 30d windows ───────────────────────────────
+
+def test_runtime_summary_7d_30d_windows(fresh_store, monkeypatch):
+    ls, store = fresh_store
+    _seed_runtime_daily(store, _corpus_rows())
+    import clawmetry.sync as sync
+    monkeypatch.setattr(ls, "get_store", lambda *a, **k: store)
+
+    rs = sync._build_runtime_summary()
+
+    assert "claude_code" in rs and "openclaw" in rs
+    cc = rs["claude_code"]
+    # existing fields are still present (additive change)
+    assert "cost_24h_usd" in cc and "tokens_24h" in cc and "tokens" in cc
+
+    # 7d window: days 0 + 1 only (day 8/20 are older than 6 days back)
+    assert cc["tokens_7d"] == 1000 + 2000
+    assert cc["cost_7d_usd"] == 3.0
+    # 30d window: days 0 + 1 + 8 + 20
+    assert cc["tokens_30d"] == 1000 + 2000 + 4000 + 8000
+    assert cc["cost_30d_usd"] == 15.0
+
+    oc = rs["openclaw"]
+    assert oc["tokens_7d"] == 500 + 700
+    assert oc["cost_7d_usd"] == 1.2
+    # day 40 is outside the 30d window -> excluded
+    assert oc["tokens_30d"] == 500 + 700
+    assert oc["cost_30d_usd"] == 1.2
+
+
+# ── 3. contextEconomics.byRuntime utilization + chips ────────────────────
+
+def _util(sid, ts, pct):
+    return {"session_id": sid, "ts": ts, "pct": pct, "tokens": 1, "window": 2}
+
+
+def test_context_econ_by_runtime_buckets_util_and_chips(monkeypatch):
+    import clawmetry.sync as sync
+    monkeypatch.setattr(sync, "_runtime_of_session", lambda s: (
+        s.split(":")[0] if ":" in s else "openclaw"))
+
+    comps = [
+        {"session_id": "claude_code:a", "trigger": "overflow", "reclaimed": 500},
+        {"session_id": "goose:c", "trigger": "proactive", "reclaimed": 50},
+    ]
+    ovf = [{"session_id": "claude_code:a"}]
+    base = {"peak_pct": 99.0, "utilization_points": 7}
+    util = [
+        _util("claude_code:a", "2026-06-10T10:00:00Z", 40.0),
+        _util("claude_code:a", "2026-06-10T11:00:00Z", 80.0),
+        _util("claude_code:b", "2026-06-10T12:00:00Z", 30.0),
+        _util("goose:c", "2026-06-10T09:00:00Z", 55.0),
+        # a runtime (codex) with readings but NO compactions still gets a slice
+        _util("codex:z", "2026-06-10T08:00:00Z", 12.0),
+    ]
+
+    out = sync._context_econ_by_runtime(comps, ovf, base, utilization=util)
+
+    # codex has utilization but no compaction -> still surfaces
+    assert set(out.keys()) == {"claude_code", "goose", "codex"}
+
+    cc = out["claude_code"]
+    # utilization bucketed to claude_code's two sessions (3 points)
+    assert len(cc["utilization"]) == 3
+    assert {u["session_id"] for u in cc["utilization"]} == {
+        "claude_code:a", "claude_code:b"}
+    # session chips: one per distinct session, peak = max pct, most-recent first
+    chips = {c["session_id"]: c for c in cc["session_chips"]}
+    assert set(chips) == {"claude_code:a", "claude_code:b"}
+    assert chips["claude_code:a"]["peak_pct"] == 80.0
+    assert chips["claude_code:b"]["peak_pct"] == 30.0
+    # peak recomputed from THIS runtime's points (80), not the node-wide 99
+    assert cc["summary"]["peak_pct"] == 80.0
+    assert cc["summary"]["utilization_points"] == 3
+    # compactions/overflow still bucketed correctly
+    assert cc["summary"]["compaction_count"] == 1
+    assert [s["session_id"] for s in cc["overflow_sessions"]] == ["claude_code:a"]
+
+    # codex: readings only, no compactions
+    codex = out["codex"]
+    assert codex["summary"]["compaction_count"] == 0
+    assert codex["summary"]["utilization_points"] == 1
+    assert codex["summary"]["peak_pct"] == 12.0
+    assert [c["session_id"] for c in codex["session_chips"]] == ["codex:z"]
+
+
+def test_context_econ_by_runtime_no_util_back_compat(monkeypatch):
+    """Old call shape (no utilization) still works: empty util/chips per
+    runtime, peak inherits the node-wide value."""
+    import clawmetry.sync as sync
+    monkeypatch.setattr(sync, "_runtime_of_session", lambda s: (
+        s.split(":")[0] if ":" in s else "openclaw"))
+    comps = [{"session_id": "goose:c", "trigger": "proactive", "reclaimed": 10}]
+    out = sync._context_econ_by_runtime(comps, [], {"peak_pct": 42.0})
+    assert out["goose"]["utilization"] == []
+    assert out["goose"]["session_chips"] == []
+    assert out["goose"]["summary"]["peak_pct"] == 42.0


### PR DESCRIPTION
Closes #3004.

Follow-up to the cloud per-runtime scope sweep (clawmetry-cloud #1618/#1619). That sweep made every hosted tab honest, but three sub-panels fell back to empty or lifetime-stand-in because the daemon snapshot carried no per-runtime slice for them. This PR adds those slices.

Leverage: all per-runtime daily/weekly/monthly numbers come from the materialized `rollup_runtime_daily` table (#2988), so they are cheap reads, not full event scans (FLYWHEEL 1e). Every addition is additive: the node-wide keys the cloud and device already read are untouched.

## What changed

1. **`dailyUsage.byRuntime`** (`_build_daily_usage`): a `{ runtime: [{day, tokens, cost_usd}, ... last 14 days, zero-filled] }` map so the cloud Cost 14-day chart can render per-runtime purely from the encrypted snapshot.
2. **`runtimeSummary[rt]` week/month windows** (`_build_runtime_summary`): real rolling `tokens_7d` / `cost_7d_usd` + `tokens_30d` / `cost_30d_usd` per runtime (naming mirrors the existing `tokens_24h` / `cost_24h_usd`) so the cloud Cost week/month cards show true per-runtime numbers instead of lifetime.
3. **`contextEconomics.byRuntime` utilization + chips** (`_context_econ_by_runtime`): the per-turn utilization series and the derived `session_chips` are now bucketed into each `byRuntime[rt]` by each point's session-id prefix, with `peak_pct` recomputed from the runtime's own readings, so the cloud context-window gauge and session picker can scope to the selected runtime.
4. **Flow Active Tools** (`app.js` `_backfillFlowFromBrain`): applies the same client-side runtime filter the Brain tab uses, so the Flow Active Tools row no longer lights up from other runtimes' brain events under a single-runtime switcher.

## Tests (ruthless-verify, revert-proven)

- `tests/test_byruntime_slices.py` seeds `rollup_runtime_daily` with 2 runtimes across several days and asserts the 14-day `byRuntime` series, the 7d/30d `runtimeSummary` windows, and per-runtime utilization/chips bucketing. Proven RED with `sync.py` reverted (test kept), GREEN after.
- `tests/test_appjs_units.js` adds a static leak guard plus a behavioural run of `_backfillFlowFromBrain` with mixed-runtime events. Proven RED with the app.js filter removed, GREEN after.

## Scope

Cloud is a separate follow-up: it will repin this published version and read the new slices via the `cm-cloud-*` interceptors. No interceptor changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)