### PR TITLE
chore: reconcile __version__ to 0.12.504 (published by #3009)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -256,7 +256,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.503"
+__version__ = "0.12.504"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
The `release-on-merge` run for #3009 published clawmetry **0.12.504** to PyPI (wheel verified to contain the new byRuntime slices), but the post-publish install-verification step hit the known PyPI propagation race and exited non-zero. Because that step failed, the workflow skipped both the `v0.12.504` tag and the automatic version-bump PR, so `dashboard.py` on main still reads `0.12.503` while PyPI is on `0.12.504`.

This bumps `__version__` to `0.12.504` to match what is live on PyPI, so the next `[RELEASE]` computes `0.12.505` rather than retrying `0.12.504` (which PyPI would reject as a duplicate).

No code change beyond the version string. `[skip ci]` since this is bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)