### PR TITLE
[RELEASE] fix(ci): add MOAT Keystone as required branch-protection check

### DIFF
--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -59,9 +59,10 @@ OWNER = "vivekchand"
 
 # Each tuple: (repo, exact job name as it appears in the workflow's `name:` field)
 #
-# Job names verified against workflow files 2026-06-01:
+# Job names verified against workflow files 2026-06-11:
 #   clawmetry/.github/workflows/oss-golden-path.yml      -> "OSS golden path (wheel + OpenClaw + 9 tabs)"
 #   clawmetry/.github/workflows/cross-repo-handoff.yml   -> "Cross-repo handoff (C4)"
+#   clawmetry/.github/workflows/ci.yml (moat-keystone)   -> "MOAT Keystone (13-endpoint bar)"
 #   clawmetry-cloud/.github/workflows/e2e.yml            -> "Cloud golden-path browser E2E"
 #   clawmetry-landing/.github/workflows/landing-golden-path.yml -> "Landing golden path (C3)"
 #
@@ -72,6 +73,9 @@ OWNER = "vivekchand"
 REQUIRED_CHECKS: list[tuple[str, str]] = [
     ("clawmetry",         "OSS golden path (wheel + OpenClaw + 9 tabs)"),
     ("clawmetry",         "Cross-repo handoff (C4)"),
+    # docs/MOAT_BAR.md Section 5, AC#1: keystone_e2e --no-drive blocks merge.
+    # ci.yml `moat-keystone` job runs on every PR; job name must match exactly.
+    ("clawmetry",         "MOAT Keystone (13-endpoint bar)"),
     ("clawmetry-cloud",   "Cloud golden-path browser E2E"),
     ("clawmetry-landing", "Landing golden path (C3)"),
 ]


### PR DESCRIPTION
## What

Adds `"MOAT Keystone (13-endpoint bar)"` to `REQUIRED_CHECKS` in
`scripts/apply_required_status_checks.py`.

This is **#1679 criterion 1**: wire `keystone_e2e.py --no-drive` into CI as a
required branch-protection check on `routes/*.py`, `clawmetry/sync.py`,
`clawmetry/local_store.py`, and `dashboard.py` diffs (per `docs/MOAT_BAR.md`
Section 5, AC#1).

## Why this wasn't wired before

The `moat-keystone` CI job has existed in `ci.yml` (line 213) since PR #1672 landed
and runs correctly on every PR (job guard detects `keystone_e2e.py` present →
`KEYSTONE_PRESENT=1`). The gap was that the job name was never added to
`REQUIRED_CHECKS` in this script, so `apply-required-checks.yml` never registered
it as a branch-protection rule.

## How this works

`apply-required-checks.yml` runs on every push to `main` (and on
`workflow_dispatch`). It calls `apply_required_status_checks.py`, which calls the
GitHub branch-protection API to register each entry in `REQUIRED_CHECKS`. With a
`GITHUB_TOKEN` (default on push) it runs in read-only mode and prints instructions;
with `E2E_ADMIN_PAT` set as a repo secret (or typed into the workflow dispatch
dialog) it writes the rule. No manual Settings → Rules click needed.

## Change

```
scripts/apply_required_status_checks.py  +3 lines  (2 comment + 1 entry)
```

No production code changed. No test changes needed (the CI job itself is the gate).

## Related

- Closes criterion 1 of #1679 — remaining criteria (2: nightly ✅, 3: cloud nightly, 4: weekly coverage, 5: lint guard) tracked in that issue.
- `moat-keystone-drive-nightly.yml` covers criterion 2 (nightly drive mode with P0 auto-filing).

https://claude.ai/code/session_01T37pMnF3rHSbnCBRh9nZN1

---
_Generated by [Claude Code](https://claude.ai/code/session_01T37pMnF3rHSbnCBRh9nZN1)_