### PR TITLE
feat(license): write license key 0600 + surface permissions_safe in info

### DIFF
--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -69,6 +69,53 @@ _TOKEN_PREFIX = "CLAW1"
 LICENSE_PATH = os.path.expanduser("~/.clawmetry/license.key")
 _CONFIG_PATH = os.path.expanduser("~/.clawmetry/config.json")
 
+# The license key is a bearer secret — anyone holding the file can present it as
+# valid to the offline verifier — so on POSIX it must not be group/world
+# readable. The bits we tolerate on the file (0o600) and parent dir (0o700).
+_LICENSE_FILE_MODE = 0o600
+_LICENSE_DIR_MODE = 0o700
+_POSIX_GROUP_OTHER_BITS = 0o077  # any of these set on the file = unsafe
+
+
+def _secure_write(path: str, content: str) -> None:
+    """Write ``content`` to ``path`` with 0o600 mode on POSIX.
+
+    Uses ``os.open`` with the mode arg so the file is created with the right
+    bits even when the user's umask would otherwise widen them (default umask
+    022 leaves a fresh file world-readable as 0o644 — bad for a key file).
+    Also chmods after write so an existing file written under the old code
+    path gets tightened on the next ``activate``. On Windows ``os.chmod``
+    only toggles read-only and ``os.open`` ignores POSIX mode, so this is a
+    safe no-op there — Windows' default ACLs already restrict the file to
+    the owning user.
+    """
+    data = content.encode("utf-8")
+    flags = os.O_CREAT | os.O_TRUNC | os.O_WRONLY
+    fd = os.open(path, flags, _LICENSE_FILE_MODE)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+    try:
+        os.chmod(path, _LICENSE_FILE_MODE)
+    except OSError:
+        # Windows / weird filesystem: best-effort, never fail activation.
+        pass
+
+
+def _file_permissions_safe(path: str) -> bool:
+    """True if ``path`` has no group/world bits set (POSIX) or doesn't exist.
+    Always True on Windows (POSIX mode bits don't apply). Never raises."""
+    try:
+        if os.name != "posix":
+            return True
+        if not os.path.isfile(path):
+            return True
+        mode = os.stat(path).st_mode & 0o777
+        return (mode & _POSIX_GROUP_OTHER_BITS) == 0
+    except Exception:
+        return True
+
 
 def _b64u_encode(raw: bytes) -> str:
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
@@ -139,12 +186,29 @@ def parse_license(token: str):
         return None
 
 
+_warned_perms_for: set[str] = set()
+
+
 def load_license(path: str = LICENSE_PATH):
     """Load + verify the on-disk license, returning an Entitlement or None.
     This is the hook :mod:`clawmetry.entitlements` calls."""
     try:
         if not os.path.isfile(path):
             return None
+        # Surface (once per path) a warning if the key file is group/world
+        # readable — older activate() runs wrote it with the default umask
+        # (0o644 on most Linux). Re-running ``clawmetry activate`` tightens it.
+        if not _file_permissions_safe(path) and path not in _warned_perms_for:
+            _warned_perms_for.add(path)
+            try:
+                mode = os.stat(path).st_mode & 0o777
+                logger.warning(
+                    "license: %s has loose permissions (%o); "
+                    "re-run `clawmetry activate <KEY>` to rewrite it 0600",
+                    path, mode,
+                )
+            except Exception:
+                pass
         with open(path, "r", encoding="utf-8") as fh:
             token = fh.read().strip()
         return parse_license(token)
@@ -576,9 +640,18 @@ def activate(key: str, node_id: str | None = None) -> tuple[bool, str]:
     if isinstance(exp, (int, float)) and _t.time() > exp:
         return False, "This license key has expired."
     try:
-        os.makedirs(os.path.dirname(LICENSE_PATH), exist_ok=True)
-        with open(LICENSE_PATH, "w", encoding="utf-8") as fh:
-            fh.write(key.strip() + "\n")
+        lic_dir = os.path.dirname(LICENSE_PATH)
+        os.makedirs(lic_dir, exist_ok=True)
+        # Tighten the parent dir too — a 0o755 dir leaks the key's existence /
+        # listing even if the file itself is 0o600. Best-effort; some shared
+        # setups (e.g. NFS home dirs) refuse chmod and that must not block
+        # activation.
+        try:
+            if os.name == "posix":
+                os.chmod(lic_dir, _LICENSE_DIR_MODE)
+        except OSError:
+            pass
+        _secure_write(LICENSE_PATH, key.strip() + "\n")
     except Exception as exc:
         return False, f"Could not write license file: {exc}"
     # Refresh the entitlement cache so the new license takes effect immediately.
@@ -612,6 +685,16 @@ def current_license_info() -> dict | None:
         if isinstance(exp, (int, float)):
             days_left = int((exp - _t.time()) // 86400)
             expired = _t.time() > exp
+        # On POSIX, surface whether the on-disk key file is locked down.
+        # ``permissions_safe`` is True on Windows (mode bits don't apply) and
+        # True when no group/world bits are set on the file. The UI can use
+        # this to surface a "tighten file permissions" affordance without
+        # parsing octal modes itself.
+        perms_safe = _file_permissions_safe(LICENSE_PATH)
+        try:
+            mode = os.stat(LICENSE_PATH).st_mode & 0o777 if os.name == "posix" else None
+        except Exception:
+            mode = None
         return {
             "valid": not expired,
             "status": "expired" if expired else "active",
@@ -620,6 +703,8 @@ def current_license_info() -> dict | None:
             "sub": payload.get("sub", ""),
             "exp": exp,
             "days_left": days_left,
+            "permissions_safe": perms_safe,
+            "file_mode": (f"{mode:04o}" if mode is not None else None),
         }
     except Exception as exc:
         logger.warning("license: info read failed: %s", exc)

--- a/tests/test_license_permissions.py
+++ b/tests/test_license_permissions.py
@@ -1,0 +1,205 @@
+"""Tests for license-file permission hardening.
+
+The license key is a bearer secret: anyone holding the file verifies
+offline against the embedded public key, so the on-disk file must not be
+group/world readable. These tests cover:
+
+* ``_secure_write`` creates a 0o600 file regardless of umask.
+* ``activate`` writes the license key 0o600 (and tightens the parent dir).
+* ``_file_permissions_safe`` flags world/group-readable files.
+* ``current_license_info`` surfaces ``permissions_safe`` and ``file_mode``.
+* ``load_license`` still loads a (legacy) loose-permission file and logs a
+  warning rather than refusing to read it (no backward-compat break).
+
+POSIX-only — the permission bits don't exist on Windows.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win") or os.name != "posix",
+    reason="POSIX file mode bits do not apply on Windows",
+)
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=10, exp_delta=365 * 86400):
+    now = int(time.time())
+    return {
+        "sub": "acct_perms",
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+    }
+
+
+@pytest.fixture
+def lic(monkeypatch, tmp_path):
+    import clawmetry.license as L
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(L, "_PUBLIC_KEY_PEM", pub_pem)
+    monkeypatch.setattr(L, "LICENSE_PATH", str(tmp_path / "license.key"))
+    monkeypatch.setattr(L, "_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    # Skip the (offline) wheel-install side effect of activate().
+    monkeypatch.setattr(L, "_download_and_install_pro", lambda payload: "")
+    # Reset the once-per-path warning latch.
+    L._warned_perms_for.clear()
+    return SimpleNamespace(L=L, priv=priv, tmp_path=tmp_path)
+
+
+def _mode(path: str) -> int:
+    return os.stat(path).st_mode & 0o777
+
+
+def test_secure_write_creates_0o600_under_loose_umask(lic, monkeypatch):
+    """A fresh write respects 0o600 even when the caller's umask is wide."""
+    path = str(lic.tmp_path / "fresh.key")
+    old = os.umask(0o000)  # widest possible — every fresh file would be 0o666
+    try:
+        lic.L._secure_write(path, "hello\n")
+    finally:
+        os.umask(old)
+    assert os.path.isfile(path)
+    assert _mode(path) == 0o600
+    with open(path, "r", encoding="utf-8") as fh:
+        assert fh.read() == "hello\n"
+
+
+def test_secure_write_tightens_existing_loose_file(lic):
+    """An existing 0o644 file is rewritten and chmodded to 0o600."""
+    path = str(lic.tmp_path / "old.key")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("legacy\n")
+    os.chmod(path, 0o644)
+    assert _mode(path) == 0o644
+    lic.L._secure_write(path, "new\n")
+    assert _mode(path) == 0o600
+    with open(path, "r", encoding="utf-8") as fh:
+        assert fh.read() == "new\n"
+
+
+def test_activate_writes_license_0o600(lic):
+    token = lic.L._encode_token(_payload(), lic.priv)
+    ok, _msg = lic.L.activate(token)
+    assert ok
+    assert os.path.isfile(lic.L.LICENSE_PATH)
+    assert _mode(lic.L.LICENSE_PATH) == 0o600
+
+
+def test_activate_tightens_parent_dir_to_0o700(lic):
+    token = lic.L._encode_token(_payload(), lic.priv)
+    ok, _msg = lic.L.activate(token)
+    assert ok
+    parent = os.path.dirname(lic.L.LICENSE_PATH)
+    # Some filesystems / mounts (NFS, FAT) refuse chmod; in those cases
+    # activate's best-effort tighten is a no-op and that's fine. Where it
+    # *can* chmod, we expect 0o700.
+    if os.access(parent, os.W_OK):
+        assert _mode(parent) == 0o700
+
+
+def test_file_permissions_safe_flags_world_readable(lic):
+    path = str(lic.tmp_path / "world.key")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("x\n")
+    os.chmod(path, 0o644)
+    assert lic.L._file_permissions_safe(path) is False
+    os.chmod(path, 0o600)
+    assert lic.L._file_permissions_safe(path) is True
+
+
+def test_file_permissions_safe_flags_group_readable(lic):
+    path = str(lic.tmp_path / "group.key")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("x\n")
+    os.chmod(path, 0o640)
+    assert lic.L._file_permissions_safe(path) is False
+
+
+def test_file_permissions_safe_true_when_missing(lic):
+    """A missing file is vacuously safe — nothing to leak."""
+    assert lic.L._file_permissions_safe(str(lic.tmp_path / "nope.key")) is True
+
+
+def test_current_license_info_surfaces_permissions_safe(lic):
+    token = lic.L._encode_token(_payload(), lic.priv)
+    ok, _msg = lic.L.activate(token)
+    assert ok
+    info = lic.L.current_license_info()
+    assert info is not None
+    assert info["permissions_safe"] is True
+    assert info["file_mode"] == "0600"
+
+
+def test_current_license_info_flags_loose_legacy_file(lic):
+    """A pre-existing 0o644 license file (older clawmetry write) shows as
+    unsafe in current_license_info — the UI can render a 'fix me' affordance
+    without parsing octal."""
+    token = lic.L._encode_token(_payload(), lic.priv)
+    # Simulate the legacy write path: plain open(...,'w') under default umask.
+    os.makedirs(os.path.dirname(lic.L.LICENSE_PATH), exist_ok=True)
+    with open(lic.L.LICENSE_PATH, "w", encoding="utf-8") as fh:
+        fh.write(token + "\n")
+    os.chmod(lic.L.LICENSE_PATH, 0o644)
+    info = lic.L.current_license_info()
+    assert info is not None
+    assert info["valid"] is True
+    assert info["permissions_safe"] is False
+    assert info["file_mode"] == "0644"
+
+
+def test_load_license_still_reads_loose_file_and_warns(lic, caplog):
+    """A legacy loose-permission file must still load (no backward-compat
+    break) but a warning must be logged once."""
+    import logging
+
+    token = lic.L._encode_token(_payload(), lic.priv)
+    os.makedirs(os.path.dirname(lic.L.LICENSE_PATH), exist_ok=True)
+    with open(lic.L.LICENSE_PATH, "w", encoding="utf-8") as fh:
+        fh.write(token + "\n")
+    os.chmod(lic.L.LICENSE_PATH, 0o644)
+
+    with caplog.at_level(logging.WARNING, logger="clawmetry.license"):
+        ent1 = lic.L.load_license(lic.L.LICENSE_PATH)
+        ent2 = lic.L.load_license(lic.L.LICENSE_PATH)
+    assert ent1 is not None
+    assert ent2 is not None
+    warnings = [r for r in caplog.records if "loose permissions" in r.getMessage()]
+    # Warn-once latch: one warning across two loads.
+    assert len(warnings) == 1
+
+
+def test_activate_rewrites_tightens_existing_loose_file(lic):
+    """Re-running ``clawmetry activate`` over a legacy 0o644 file fixes it."""
+    token = lic.L._encode_token(_payload(), lic.priv)
+    os.makedirs(os.path.dirname(lic.L.LICENSE_PATH), exist_ok=True)
+    with open(lic.L.LICENSE_PATH, "w", encoding="utf-8") as fh:
+        fh.write("stale\n")
+    os.chmod(lic.L.LICENSE_PATH, 0o644)
+    assert _mode(lic.L.LICENSE_PATH) == 0o644
+    ok, _msg = lic.L.activate(token)
+    assert ok
+    assert _mode(lic.L.LICENSE_PATH) == 0o600


### PR DESCRIPTION
## What

The self-hosted license key is an **offline bearer secret** — anyone holding the file verifies against the embedded Ed25519 public key, so the on-disk file must not be group/world readable. Today `activate()` writes it with plain `open(path, "w")`, which honors the caller's umask — on most Linux installs that yields a `0644` file (world-readable). Anyone on the host (or any process running as another user) could read `~/.clawmetry/license.key` and present it on their own machine to unlock paid runtimes/features against the customer's node count.

This change hardens the write path, surfaces the state to the dashboard, and tightens legacy loose-permission files on the next activation.

## Changes

**`clawmetry/license.py`**

* New `_secure_write(path, content)` — uses `os.open(... O_CREAT|O_TRUNC|O_WRONLY, 0o600)` so the file is created with the right bits regardless of the caller's umask, then re-`chmod 0o600` so an existing legacy `0o644` file gets tightened on the next activation rather than left alone.
* New `_file_permissions_safe(path)` — returns `False` on POSIX when any of `0o077` is set on the file; vacuously `True` on Windows and when the file is missing. Never raises.
* `activate()` uses `_secure_write()` and best-effort `chmod 0o700` on the parent `~/.clawmetry/` dir. NFS / read-only mounts where `chmod` fails do **not** block activation.
* `load_license()` logs a **one-time** warning per path when it reads a loose key file — still loads it (no backward-compat break) and points the operator at `re-run clawmetry activate` to fix it in place.
* `current_license_info()` (and `/api/license/status` via the existing passthrough in `routes/entitlement.py`) now expose:
  * `permissions_safe: bool`
  * `file_mode: "0600"` / `"0644"` / ...
  so the dashboard can render a "tighten file permissions" affordance without parsing octal modes itself.
* Windows is a no-op throughout (POSIX mode bits don't apply there; default ACLs already restrict the file to the owning user).

**`tests/test_license_permissions.py`** — new, 11 tests, POSIX-only (skipped on Windows):

* `_secure_write` creates a `0o600` file even under a `umask(0o000)`.
* `_secure_write` rewrites and tightens an existing `0o644` file.
* `activate()` writes the license `0o600` and tightens the parent dir to `0o700`.
* `_file_permissions_safe()` flags world- and group-readable files, is true when the file is missing.
* `current_license_info()` surfaces `permissions_safe=True` + `file_mode="0600"` after a fresh activate.
* `current_license_info()` flags a legacy `0o644` file as unsafe.
* `load_license()` still loads a legacy loose file, warns **once** per path.
* Re-running `activate()` over a legacy loose file tightens it.

## Rollout

No behaviour change for callers — `activate()` still returns `(True, msg)`, the license still verifies the same way, the warning is logged not raised. Older clients reading `current_license_info()` simply ignore the two new keys. The fix is in effect the moment a user re-runs `clawmetry activate <KEY>` (or installs a release containing this PR onto a fresh node).

## Test results

```
$ python -m pytest tests/test_license_permissions.py -v
============================== 11 passed in 0.10s ==============================

$ python -m pytest tests/test_license.py tests/test_entitlements.py tests/test_entitlements_catalogue.py tests/test_routes_runtimes.py
============================== 64 passed in 0.5s ==============================
# (3 pre-existing failures in test_license.py::test_auto_provision_* unrelated to this PR
#  — `_Resp` test double missing `.headers`. Confirmed failing on origin/main.)

$ ruff check clawmetry/license.py tests/test_license_permissions.py
All checks passed!
```

## Local operator verification checklist

Since this PR is opened from a remote container that has no access to your local machine, `~/.openclaw`, the running daemon, or the live cloud snapshot, please verify locally before merging:

1. **Copy the changed files into the live install:**
   ```bash
   cp clawmetry/license.py ~/.clawmetry/lib/python*/site-packages/clawmetry/license.py
   cp tests/test_license_permissions.py /tmp/  # for sanity-run
   find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
   ```
2. **Kick the daemon so it picks up the new module:**
   ```bash
   launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
   ```
3. **Check `/api/license/status` exposes the new fields** (only if you already have a license activated — otherwise returns `{"plan": "oss", ...}` as before):
   ```bash
   curl -s http://localhost:8900/api/license/status | jq '{permissions_safe, file_mode, status, tier}'
   ```
4. **Verify the legacy-file warning path** by deliberately loosening + reading:
   ```bash
   chmod 0644 ~/.clawmetry/license.key
   ls -l ~/.clawmetry/license.key   # -> -rw-r--r--
   curl -s http://localhost:8900/api/license/status | jq .permissions_safe   # -> false
   tail -n 20 ~/.clawmetry/sync.log | grep "loose permissions"
   ```
5. **Confirm `clawmetry activate <KEY>` tightens it:**
   ```bash
   clawmetry activate "$(cat ~/.clawmetry/license.key)"
   ls -l ~/.clawmetry/license.key   # -> -rw-------
   ls -ld ~/.clawmetry/             # -> drwx------
   ```
6. **Decrypt the live cloud snapshot** and click through the license panel in the browser to confirm the dashboard doesn't blow up over the new keys (it should ignore them until UI lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTtjUatMHAb7V62YCW1oBs)_