### PR TITLE
fix(adapters): extract voice/talk lifecycle fields from gateway log records (#3014)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -443,10 +443,14 @@ class OpenClawAdapter(AgentAdapter):
                             raw_data = bytes(raw_data).decode("utf-8", "replace")
                         obj = json.loads(raw_data) if isinstance(raw_data, str) else raw_data
                         if isinstance(obj, dict):
-                            for _field in ("channel", "hostname"):
+                            for _field in ("channel", "hostname", "mode", "transport", "provider"):
                                 _val = obj.get(_field)
                                 if _val:
                                     extra[_field] = _val
+                            for _num_field in ("duration_ms", "size_bytes"):
+                                _v = obj.get(_num_field)
+                                if _v is not None:
+                                    extra[_num_field] = _v
                             msg = obj.get("message")
                             if isinstance(msg, str):
                                 content_text = msg

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -373,6 +373,53 @@ def test_list_events_surfaces_total_tokens_for_reasoning_model(isolated_store):
     assert ex.get("totalTokens") == 162, "totalTokens must appear in extra for reasoning-model events"
 
 
+def test_list_events_voice_lifecycle_fields_in_extra(isolated_store):
+    """Voice/talk/managed-room lifecycle log records land all five structured
+    fields in Event.extra (#3014).
+
+    Gateway JSONL log records for Talk/voice/room activity carry mode,
+    transport, provider (strings) and duration_ms, size_bytes (numbers)
+    alongside channel/hostname. list_events() was previously extracting
+    only channel and hostname; the five voice-lifecycle fields were silently
+    dropped. Pin the corrected extraction.
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-VOICE",
+        "event_type": "log",
+        "ts": _t.time(),
+        "data": {
+            "channel": "voice",
+            "hostname": "host-1",
+            "mode": "realtime",
+            "transport": "webrtc",
+            "provider": "deepgram",
+            "duration_ms": 4200,
+            "size_bytes": 87040,
+            "message": "voice session ended",
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-VOICE")
+    assert len(events) == 1
+    ex = events[0].extra
+    # string fields
+    assert ex.get("channel") == "voice"
+    assert ex.get("hostname") == "host-1"
+    assert ex.get("mode") == "realtime"
+    assert ex.get("transport") == "webrtc"
+    assert ex.get("provider") == "deepgram"
+    # numeric fields — 0 would survive too, so use is not None check in prod
+    assert ex.get("duration_ms") == 4200
+    assert ex.get("size_bytes") == 87040
+
+
 def test_build_spans_prefers_total_tokens_for_reasoning_model():
     """_build_spans_from_events must use totalTokens as token_count when it
     exceeds tok_in+tok_out — the extra comes from reasoning. Fixes #2794."""


### PR DESCRIPTION
## Summary

`list_events()` in `clawmetry/adapters/openclaw.py` extracted `channel` and `hostname` from gateway log record data blobs but silently dropped the five structured fields emitted by Talk/voice/managed-room lifecycle events. Callers couldn't filter or display mode, transport, provider, duration, or size for these events. This adds them following the exact same extraction pattern already in place.

## Changes

- `clawmetry/adapters/openclaw.py` — extend the string-field extraction tuple from `("channel", "hostname")` to `("channel", "hostname", "mode", "transport", "provider")`. Add a separate numeric loop for `duration_ms` and `size_bytes` using `if _v is not None:` (not `if _v:`) so zero values survive.
- `tests/test_openclaw_list_events.py` — new test `test_list_events_voice_lifecycle_fields_in_extra` seeds a mock voice lifecycle log record with all five new fields and asserts each lands in `Event.extra`, following the same isolated-store fixture pattern as the sibling channel/hostname test.

## Test plan

- [ ] `python -m pytest tests/test_openclaw_list_events.py -v` — all tests pass (requires `duckdb` + full deps; DuckDB tests fail in this minimal container but pass in CI)
- [ ] CI lint + test matrix green

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3014. Marked draft for human review — mark Ready for Review once happy.

Closes #3014

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4vcwpCvPp9KSUS32rjr4E)_