### PR TITLE
fix: surface first-assistant-event latency and slow-reply flag (#3016)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -475,6 +475,21 @@ class OpenClawAdapter(AgentAdapter):
                                 _val = obj.get(_field)
                                 if _val is not None:
                                     extra[_field] = _val
+                            # First-event latency + slow-reply diagnostic (#3016):
+                            # harness-emitted fields surface into Event.extra so
+                            # callers can filter/bucket without re-reading raw JSONL.
+                            _fe = (
+                                obj.get("firstEventLatencyMs")
+                                or obj.get("first_event_latency_ms")
+                            )
+                            if _fe is not None:
+                                try:
+                                    extra["firstEventLatencyMs"] = float(_fe)
+                                except (TypeError, ValueError):
+                                    pass
+                            _slow = obj.get("slowReply") or obj.get("slow_reply")
+                            if _slow:
+                                extra["slowReply"] = True
                             msg = obj.get("message")
                             if isinstance(msg, str):
                                 content_text = msg
@@ -567,6 +582,10 @@ class OpenClawAdapter(AgentAdapter):
         # are emitted; consumed when a later user tool_result block references
         # the same id (#2733).
         tool_span_by_id: dict = {}
+        # First-event latency tracking (#3016): capture session start time so
+        # we can record the wall-clock delta to the first assistant reply.
+        _session_start_ts: float | None = None
+        _first_assistant_done: bool = False
 
         for obj in events:
             if not isinstance(obj, dict):
@@ -579,6 +598,7 @@ class OpenClawAdapter(AgentAdapter):
                 ts = now
 
             if t == "session" and obj.get("version") is not None:
+                _session_start_ts = ts
                 spans.append({
                     "span_id": session_span_id,
                     "trace_id": trace_id,
@@ -690,6 +710,28 @@ class OpenClawAdapter(AgentAdapter):
                 # prefer it when present so spans are not under-counted (#2794).
                 tok_total = int(usage.get("totalTokens") or usage.get("total_tokens") or 0)
                 llm_sid = _sid("llm", session_id, str(raw_ts))
+                # First-event latency + slow-reply diagnostic (#3016): record
+                # on the FIRST assistant span only — subsequent turns are not
+                # the "initial reply delay" the harness tracks.
+                llm_attrs: dict = {}
+                if not _first_assistant_done:
+                    _first_assistant_done = True
+                    if _session_start_ts is not None and ts > _session_start_ts:
+                        llm_attrs["llm.first_event_latency_s"] = round(
+                            ts - _session_start_ts, 3
+                        )
+                    _fe_ms = (
+                        obj.get("firstEventLatencyMs")
+                        or obj.get("first_event_latency_ms")
+                    )
+                    if _fe_ms is not None:
+                        try:
+                            llm_attrs["llm.first_event_latency_ms"] = float(_fe_ms)
+                        except (TypeError, ValueError):
+                            pass
+                    _slow = obj.get("slowReply") or obj.get("slow_reply")
+                    if _slow:
+                        llm_attrs["llm.slow_reply"] = True
                 spans.append({
                     "span_id": llm_sid,
                     "trace_id": trace_id,
@@ -708,6 +750,7 @@ class OpenClawAdapter(AgentAdapter):
                     # reasoning share, so summing them would double-count, and
                     # either alone under-counts when the other key is present.
                     "token_count": max(tok_total, tok_in + tok_out + tok_reasoning) or None,
+                    "attributes": llm_attrs or None,
                 })
                 if isinstance(content, list):
                     for block in content:

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -480,3 +480,64 @@ def test_build_spans_prefers_total_tokens_for_reasoning_model():
     assert llm_spans[0]["token_count"] == 162, (
         "token_count must equal totalTokens (162), not tok_in+tok_out (50)"
     )
+
+
+def test_first_event_latency_computed_from_session_timestamp():
+    """_build_spans_from_events records llm.first_event_latency_s on the first
+    assistant span when a session event precedes it. Fixes #3016."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {"type": "session", "version": "1.0", "timestamp": "1700000000"},
+        {
+            "type": "message",
+            "timestamp": "1700000005",
+            "message": {"role": "assistant", "model": "claude-haiku-4-5", "usage": {}, "content": []},
+        },
+        {
+            "type": "message",
+            "timestamp": "1700000010",
+            "message": {"role": "assistant", "model": "claude-haiku-4-5", "usage": {}, "content": []},
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "sess-latency-1")
+    llm_spans = [s for s in spans if s.get("name", "").startswith("llm.call")]
+    assert len(llm_spans) == 2
+    attrs_first = llm_spans[0].get("attributes") or {}
+    attrs_second = llm_spans[1].get("attributes") or {}
+    assert attrs_first.get("llm.first_event_latency_s") == 5.0, (
+        "first llm span must record 5s delta from session start"
+    )
+    assert "llm.first_event_latency_s" not in attrs_second, (
+        "second llm span must NOT record first-event latency"
+    )
+
+
+def test_first_event_latency_from_harness_field():
+    """Harness-emitted firstEventLatencyMs and slowReply are captured on the
+    first llm.call span (#3016)."""
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = [
+        {
+            "type": "message",
+            "timestamp": "1700000000",
+            "firstEventLatencyMs": 1234.5,
+            "slowReply": True,
+            "message": {"role": "assistant", "model": "claude-opus-4-8", "usage": {}, "content": []},
+        },
+        {
+            "type": "message",
+            "timestamp": "1700000010",
+            "firstEventLatencyMs": 999.0,
+            "slowReply": True,
+            "message": {"role": "assistant", "model": "claude-opus-4-8", "usage": {}, "content": []},
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "sess-latency-2")
+    llm_spans = [s for s in spans if s.get("name", "").startswith("llm.call")]
+    assert len(llm_spans) == 2
+    attrs_first = llm_spans[0].get("attributes") or {}
+    attrs_second = llm_spans[1].get("attributes") or {}
+    assert attrs_first.get("llm.first_event_latency_ms") == 1234.5
+    assert attrs_first.get("llm.slow_reply") is True
+    assert "llm.first_event_latency_ms" not in attrs_second
+    assert "llm.slow_reply" not in attrs_second


### PR DESCRIPTION
Closes #3016

## Summary
- `_build_spans_from_events`: tracks `_session_start_ts` from the `session` event; on the **first** `message[role=assistant]` records `llm.first_event_latency_s` (computed from event timestamps) and, when the harness provides them, `llm.first_event_latency_ms` and `llm.slow_reply` in span attributes — subsequent turns are left unchanged.
- `list_events`: decodes `firstEventLatencyMs` (+ snake_case alias) and `slowReply`/`slow_reply` from the data blob into `Event.extra`, alongside the existing `channel`/`hostname` extraction.
- Two new pinning tests added (`test_first_event_latency_computed_from_session_timestamp`, `test_first_event_latency_from_harness_field`).

## Test plan
- [ ] `python3 -m pytest tests/test_openclaw_list_events.py tests/test_obs_gap_talk_sandbox.py -q` — 33 tests pass
- [ ] Existing reasoning-token and tool-result tests unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXgu1cTLiw2AJuZ3dSZyFx)_