### PR TITLE
fix(snapshot): restore per-runtime Cost 7d/30d windows + ctx-econ session_chips clobbered by stale-rebase merge (#3004)

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10986,10 +10986,45 @@ def _build_runtime_summary(limit: int = 20000):
         rt_switches: dict = defaultdict(int)
         for s in (rollup.get("switches") or []):
             rt_switches[s.get("runtime") or "openclaw"] += 1
+        # Per-runtime rolling 7-day + 30-day token/cost windows (#3004) so the
+        # cloud Cost cards can show REAL week/month per-runtime numbers instead
+        # of standing in lifetime. Sourced from the materialized
+        # ``rollup_runtime_daily`` table (#2988): one cheap read, no event scan
+        # (FLYWHEEL 1e). Naming mirrors the existing ``tokens_24h`` /
+        # ``cost_24h_usd`` rolling fields. ``rt -> {tokens_7d, cost_7d,
+        # tokens_30d, cost_30d}``.
+        rt_windows: dict = {}
+        try:
+            from datetime import datetime as _dt, timedelta as _td
+            _now = _dt.now()
+            _d7 = (_now - _td(days=6)).strftime("%Y-%m-%d")
+            _d30 = (_now - _td(days=29)).strftime("%Y-%m-%d")
+            for r in (store.query_rollup_runtime_daily(
+                since=_d30, limit=10000,
+            ) or []):
+                d = str(r.get("day") or "")[:10]
+                if not d:
+                    continue
+                rt = (r.get("runtime") or "").strip() or "openclaw"
+                w = rt_windows.setdefault(rt, {
+                    "tokens_7d": 0, "cost_7d": 0.0,
+                    "tokens_30d": 0, "cost_30d": 0.0,
+                })
+                tk = int(r.get("tokens") or 0)
+                ct = float(r.get("cost_usd") or 0.0)
+                w["tokens_30d"] += tk
+                w["cost_30d"] += ct
+                if d >= _d7:
+                    w["tokens_7d"] += tk
+                    w["cost_7d"] += ct
+        except Exception as _e_w:
+            log.debug("runtime summary 7d/30d window build failed: %s", _e_w)
+            rt_windows = {}
         out: dict = {}
-        # Union of runtimes seen in the per-runtime totals and the per-model rows
-        # (a runtime with only model-less events still gets a card with 0 turns).
-        for rt in set(by_runtime) | set(rt_models):
+        # Union of runtimes seen in the per-runtime totals, the per-model rows,
+        # and the rolling-window rollup (a runtime with only model-less events,
+        # or one present only in rollup_runtime_daily, still gets a card).
+        for rt in set(by_runtime) | set(rt_models) | set(rt_windows):
             totals = by_runtime.get(rt) or {}
             models = rt_models.get(rt) or {}
             total = sum(mm["turns"] for mm in models.values())
@@ -10999,6 +11034,7 @@ def _build_runtime_summary(limit: int = 20000):
                 "sessions": mm["sessions"],
                 "share_pct": round(mm["turns"] / total * 100, 2) if total else 0,
             } for m, mm in sorted_models[:15]]
+            _w = rt_windows.get(rt) or {}
             out[rt] = {
                 "sessions": int(totals.get("sessions") or 0),
                 "turns": total,
@@ -11008,6 +11044,12 @@ def _build_runtime_summary(limit: int = 20000):
                 # dual-column UI.
                 "cost_24h_usd": round(float(totals.get("cost_24h_usd") or 0.0), 4),
                 "tokens_24h": int(totals.get("tokens_24h") or 0),
+                # Rolling 7-day + 30-day windows (#3004) for the cloud Cost
+                # week/month cards; sourced from rollup_runtime_daily.
+                "tokens_7d": int(_w.get("tokens_7d") or 0),
+                "cost_7d_usd": round(float(_w.get("cost_7d") or 0.0), 4),
+                "tokens_30d": int(_w.get("tokens_30d") or 0),
+                "cost_30d_usd": round(float(_w.get("cost_30d") or 0.0), 4),
                 "primary_model": sorted_models[0][0] if sorted_models else "",
                 "total_turns": total,
                 "models": models_out,
@@ -12430,6 +12472,50 @@ def _build_daily_usage(days=14):
         tstr = now.strftime("%Y-%m-%d")
         wk = (now - timedelta(days=now.weekday())).strftime("%Y-%m-%d")
         mo = now.strftime("%Y-%m-01")
+        # Per-runtime daily series (#3004) so the cloud Cost 14-day chart can
+        # render purely from the encrypted snapshot when scoped to a runtime,
+        # instead of falling back to the scoped server path. Sourced from the
+        # materialized ``rollup_runtime_daily`` table (#2988) -> cheap read, no
+        # full event scan (FLYWHEEL 1e). Additive: node-wide ``days``/``today``/
+        # ``week``/``month`` above are unchanged. Shape per runtime is a list of
+        # ``{day, tokens, cost_usd}`` over the same ``days``-day window, oldest
+        # first, with a zero-filled point for every day so the chart axis lines
+        # up across runtimes. Empty {} when the rollup is unavailable.
+        by_runtime: dict = {}
+        try:
+            window = [
+                (now - timedelta(days=i)).strftime("%Y-%m-%d")
+                for i in range(days - 1, -1, -1)
+            ]
+            window_set = set(window)
+            since = window[0]
+            # rt -> {day: {"tokens": int, "cost_usd": float}}
+            rt_days: dict = {}
+            for r in (store.query_rollup_runtime_daily(
+                since=since, limit=10000,
+            ) or []):
+                d = str(r.get("day") or "")[:10]
+                if not d or d not in window_set:
+                    continue
+                rt = (r.get("runtime") or "").strip() or "openclaw"
+                slot = rt_days.setdefault(rt, {})
+                cell = slot.setdefault(d, {"tokens": 0, "cost_usd": 0.0})
+                cell["tokens"] += int(r.get("tokens") or 0)
+                cell["cost_usd"] += float(r.get("cost_usd") or 0.0)
+            for rt, slot in rt_days.items():
+                by_runtime[rt] = [
+                    {
+                        "day": d,
+                        "tokens": int(slot.get(d, {}).get("tokens", 0)),
+                        "cost_usd": round(
+                            float(slot.get(d, {}).get("cost_usd", 0.0)), 6
+                        ),
+                    }
+                    for d in window
+                ]
+        except Exception as _e_rt:
+            log.debug("daily usage byRuntime build failed: %s", _e_rt)
+            by_runtime = {}
         return {
             "days": out_days,
             "today": int(daily_tok.get(tstr, 0)),
@@ -12438,6 +12524,7 @@ def _build_daily_usage(days=14):
             "todayCost": round(float(daily_cost.get(tstr, 0.0)), 6),
             "weekCost": round(sum(v for k, v in daily_cost.items() if k >= wk), 6),
             "monthCost": round(sum(v for k, v in daily_cost.items() if k >= mo), 6),
+            "byRuntime": by_runtime,
         }
     except Exception as _e:
         log.debug("daily usage snapshot build failed: %s", _e)
@@ -13115,35 +13202,77 @@ def _build_tool_catalog_slice(limit: int = 5000, top: int = 60) -> dict:
     return out
 
 
-def _context_econ_by_runtime(compactions, overflow_sessions, base_summary):
+def _session_chips_from_utilization(utilization):
+    """Distinct-session chips from a utilization series, most-recent first, each
+    ``{session_id, peak_pct, ts}``. Mirrors the route builder in
+    ``routes/context_economics.py`` so the snapshot ships the same shape the
+    cloud Context-economics interceptor expects."""
+    chips: dict = {}
+    for u in (utilization or []):
+        sid = str((u or {}).get("session_id") or "")
+        if not sid:
+            continue
+        entry = chips.setdefault(sid, {"session_id": sid, "peak_pct": 0.0, "ts": ""})
+        try:
+            entry["peak_pct"] = max(entry["peak_pct"], float(u.get("pct") or 0))
+        except (TypeError, ValueError):
+            pass
+        ts = str(u.get("ts") or "")
+        if ts > entry["ts"]:
+            entry["ts"] = ts
+    return sorted(chips.values(), key=lambda c: c["ts"], reverse=True)
+
+
+def _context_econ_by_runtime(compactions, overflow_sessions, base_summary,
+                             utilization=None):
     """Group context-economics compactions + overflow sessions per runtime
     (session_id prefix) for the Context-economics runtime filter. Returns
-    ``{runtime: {compactions, overflow_sessions, summary}}``; a runtime that
-    never compacted is absent (the cloud interceptor then serves an empty
-    slice). ``peak_pct``/``utilization_points`` inherit the node-wide value —
-    utilization points are not per-session, so they aren't split."""
+    ``{runtime: {compactions, overflow_sessions, summary, utilization,
+    session_chips}}``; a runtime that never compacted AND has no utilization
+    readings is absent (the cloud interceptor then serves an empty slice).
+
+    The per-turn ``utilization`` series and the derived ``session_chips`` ARE
+    bucketed per runtime (#3004) by each point's ``session_id`` prefix, so the
+    cloud context-window gauge + session picker can scope to the selected
+    runtime instead of returning empty. ``peak_pct`` is recomputed from the
+    runtime's own utilization points (falling back to the node-wide value when
+    a runtime has compactions but no readings); the node-wide slice is
+    unchanged."""
+    # Bucket utilization points by runtime first so a runtime with readings but
+    # no compactions still gets a slice (its gauge + chips populate).
+    util_by_rt: dict = {}
+    for u in (utilization or []):
+        rt = _runtime_of_session((u or {}).get("session_id") or "")
+        util_by_rt.setdefault(rt, []).append(u)
     by: dict = {}
     for c in (compactions or []):
         rt = _runtime_of_session((c or {}).get("session_id") or "")
         by.setdefault(rt, []).append(c)
     base = base_summary or {}
     out: dict = {}
-    for rt, comps in by.items():
+    for rt in set(by) | set(util_by_rt):
+        comps = by.get(rt, [])
+        rt_util = util_by_rt.get(rt, [])
         ovn = sum(1 for c in comps if c.get("trigger") == "overflow")
         rt_ovf = [s for s in (overflow_sessions or [])
                   if _runtime_of_session(
                       (s.get("session_id") if isinstance(s, dict) else s) or "") == rt]
+        rt_chips = _session_chips_from_utilization(rt_util)
+        rt_peak = max((float(u.get("pct") or 0) for u in rt_util),
+                      default=base.get("peak_pct", 0))
         out[rt] = {
             "compactions": comps,
             "overflow_sessions": rt_ovf,
+            "utilization": rt_util,
+            "session_chips": rt_chips,
             "summary": {
                 "compaction_count": len(comps),
                 "overflow_count": ovn,
                 "proactive_count": len(comps) - ovn,
                 "total_reclaimed": sum(int(c.get("reclaimed") or 0) for c in comps),
-                "peak_pct": base.get("peak_pct", 0),
+                "peak_pct": round(float(rt_peak), 2),
                 "overflow_sessions": len(rt_ovf),
-                "utilization_points": base.get("utilization_points", 0),
+                "utilization_points": len(rt_util),
             },
         }
     return out
@@ -14850,6 +14979,7 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
                 context_economics_slice["compactions"],
                 context_economics_slice["overflow_sessions"],
                 context_economics_slice["summary"],
+                utilization=_ce_util,
             )
     except Exception as _e_ce:
         log.debug("snapshot: context_economics slice failed: %s", _e_ce)


### PR DESCRIPTION
## What

PR #3020 (judge-free detectors, commit b31e67b3) was cut from a base predating #3008 (commit 3ea99e4d) and its squash-merge **silently dropped #3008's per-runtime byRuntime snapshot hunks in `clawmetry/sync.py`** while keeping the detector code. Classic stale-rebase clobber.

Evidence:
- `git show 3ea99e4d:clawmetry/sync.py | grep -c tokens_7d` = 4
- `git show origin/main:clawmetry/sync.py | grep -c tokens_7d` = 0
- the only sync.py commit since #3008 is the detector PR

This restores the dropped hunks WITHOUT touching the detector code.

## Restored hunks

1. `_build_runtime_summary`: `rt_windows` rolling 7d/30d token+cost windows from `rollup_runtime_daily`, emitted on `runtimeSummary[rt]` as `tokens_7d` / `cost_7d_usd` / `tokens_30d` / `cost_30d_usd`.
2. `_build_daily_usage`: `dailyUsage.byRuntime` 14-day per-runtime `{day, tokens, cost_usd}` series.
3. `_session_chips_from_utilization` + `_context_econ_by_runtime`: per-runtime `utilization` + `session_chips` under `contextEconomics.byRuntime[rt]`, `peak_pct` recomputed from the runtime's own readings.
4. `sync_system_snapshot` call site passes `utilization=_ce_util`.

The detector code (`_emit_detector_incidents`, `daemon_detector`, `DETECT_*`) is untouched (different region of sync.py). The app.js `_backfillFlowFromBrain` runtime filter from #3008 was on a separate file and survived the merge (verified present on origin/main).

The cloud Cost/ctx-econ interceptors (clawmetry-cloud #1622) read these exact field names.

## Guard (revert-proven, same PR)

`tests/test_byruntime_slices.py` (shipped with #3008, survived the merge) already pins all four field families. Proven:
- **RED** on clobbered main: 4 failed (`KeyError: 'utilization'`)
- **GREEN** after restore: 4 passed

So a future clobber fails CI.

## Verification

Grep counts on restored sync.py: `tokens_7d=4 cost_7d_usd=1 tokens_30d=4 cost_30d_usd=1 session_chips=5 byRuntime-daily=1`; detectors intact (`_emit_detector_incidents=2 daemon_detector=1 DETECT_=5`). No new ruff errors (26 == origin/main 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)