### PR TITLE
[RELEASE] fix(tools): count family-adapter tool_call events

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -10880,9 +10880,15 @@ def _iter_tool_invocation_names(event_type: str | None, data: dict) -> Iterable[
 
     et = (event_type or "").lower()
 
-    # Shape 1: top-level tool.call / toolCall / tool_use event.
-    if et in ("tool.call", "toolcall", "tool_use"):
-        name = data.get("name") or data.get("tool")
+    # Shape 1: top-level tool.call / toolCall / tool_use / tool_call event.
+    # Family adapters (claude_code et al via clawmetry_pro) emit
+    # ``tool_call`` with the name under ``tool_name`` -- without it every
+    # family tool invocation counted as zero (device runtime_tools empty,
+    # /api/plugins blind to family runtimes; found via the device camera
+    # loop, 2026-06-11).
+    if et in ("tool.call", "toolcall", "tool_use", "tool_call"):
+        name = (data.get("name") or data.get("tool")
+                or data.get("tool_name"))
         if isinstance(name, str) and name:
             yield name
         return

--- a/dashboard.py
+++ b/dashboard.py
@@ -256,7 +256,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.508"
+__version__ = "0.12.509"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
Family adapters emit `tool_call` + `tool_name`; the invocation iterator missed both → family runtimes invisible to `query_tool_call_invocations` (device `runtime_tools` empty, /api/plugins blind). One-shape fix, verified against live DuckDB (500 events now counted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)