### PR TITLE
feat(sync): record Claude Code sub-agent fan-out as Command River lanes

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -7795,6 +7795,21 @@ class LocalStore:
         if agent_type:
             clauses.append("s.agent_type = ?")
             params.append(str(agent_type))
+        # Exclude sub-agent child sessions from the top-level list. Family
+        # adapters (e.g. Claude Code) ingest each spawned sub-agent's
+        # transcript as its OWN session row so its events reconcile cost in
+        # the ``subagents`` rollup — but it is a CHILD of its parent session,
+        # not a top-level conversation, so it must not clutter the sessions
+        # list. A child is exactly a sessions row whose id is also a
+        # ``subagents.subagent_id`` carrying a ``parent_session_id``. (OpenClaw
+        # sub-agent rows have no matching sessions row, so this is a no-op for
+        # them.)
+        clauses.append(
+            "s.session_id NOT IN ("
+            "SELECT subagent_id FROM subagents "
+            "WHERE parent_session_id IS NOT NULL AND parent_session_id != ''"
+            ")"
+        )
         where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         # ``sessions.message_count`` is only populated by the typed-session
         # ingest path (sync.py + claude_code adapter). The OpenClaw events

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -10649,6 +10649,58 @@ def sync_family_runtimes(config: dict, state: dict, paths: dict) -> int:
                 except Exception as _se:
                     log.warning("family session upsert failed (%s): %s", ns_id, _se)
                     continue
+                # Agent fan-out: a family adapter may emit a session with
+                # ``parent_id`` set (e.g. the Claude Code adapter surfaces each
+                # spawned sub-agent transcript under its parent session). Record
+                # it in the ``subagents`` table so it lands in the snapshot
+                # ``subagents[]`` slice (read back via ``query_subagents``) and
+                # the Command River renders the real per-session fan-out instead
+                # of "1 agent". The child's transcript events were ALSO ingested
+                # above (under ``ns_id``) so its tokens/cost reconcile from the
+                # events table on read. parent_session_id carries the runtime
+                # prefix so it matches the parent's session row id; the cloud
+                # filter normalises both bare + prefixed forms.
+                if getattr(s, "parent_id", None):
+                    try:
+                        _sa_extra = s.extra if isinstance(s.extra, dict) else {}
+                        store.ingest_subagent({
+                            "subagent_id": ns_id,
+                            "agent_type": "openclaw",
+                            "parent_session_id": f"{runtime}:{s.parent_id}",
+                            "spawned_at": started,
+                            # Open (running) children leave ended_at None so the
+                            # river draws the stream to NOW; finished children
+                            # carry their last event ts.
+                            "ended_at": ended,
+                            "task": _ftitle,
+                            "status": (s.cost_status or
+                                       ("failed" if s.end_reason == "error"
+                                        else "completed")),
+                            "cost_usd": float(s.cost_usd or 0.0),
+                            "token_count": int(s.total_tokens or 0),
+                            # data-blob fields the /api/subagents shaper reads.
+                            "model": s.model or "",
+                            "label": _ftitle,
+                            "displayName": _ftitle,
+                            "depth": int(_sa_extra.get("depth") or 1),
+                            "error": (_sa_extra.get("description")
+                                      if s.end_reason == "error" else ""),
+                            "runtime": runtime,
+                        })
+                    except Exception as _sae:
+                        log.debug("family subagent ingest failed (%s): %s", ns_id, _sae)
+                # Sub-agent children stop here: they ride the snapshot
+                # ``subagents[]`` slice (river lanes), not the top-level
+                # Sessions list (local: excluded in ``query_sessions_table``;
+                # cloud: not pushed below). Their tokens/cost are carried on the
+                # subagent row itself (cache-aware, from the adapter), so we skip
+                # the per-event re-ingest + cloud session push entirely — a big
+                # CPU saving for a session that fanned out to hundreds of agents.
+                # Mark the watermark so we don't re-scan an unchanged child.
+                if getattr(s, "parent_id", None):
+                    if _activity:
+                        _evt_hw[ns_id] = _activity
+                    continue
                 # Carry the same row to cloud so the cloud Sessions list shows it.
                 cloud_session_rows.append({
                     "agent_type": "openclaw",

--- a/tests/test_family_subagent_fanout.py
+++ b/tests/test_family_subagent_fanout.py
@@ -1,0 +1,195 @@
+"""sync_family_runtimes records adapter-emitted sub-agent children into the
+``subagents`` table so they reach the snapshot ``subagents[]`` slice (the
+Command River lanes), and excludes them from the top-level sessions list.
+
+The Claude Code adapter (clawmetry-pro) surfaces each spawned sub-agent
+transcript as a CHILD ``Session`` with ``parent_id`` set. This test uses a
+FAKE family adapter (no pro dependency) that emits one parent + two children,
+and asserts the daemon:
+
+  * writes each child to ``subagents`` with ``parent_session_id`` = the
+    parent's namespaced session id (so ``query_subagents`` / the snapshot
+    surface them, and the cloud river filter — which normalises bare +
+    prefixed forms — binds them to the parent),
+  * carries the child's cache-aware cost + tokens + label + status onto the
+    subagent row,
+  * keeps children OUT of ``query_sessions_table`` (the top-level list) while
+    keeping the parent in.
+
+Revert-proof: dropping the ``if s.parent_id: store.ingest_subagent(...)`` block
+makes ``test_child_lands_in_subagents_table`` go RED.
+"""
+from __future__ import annotations
+
+import importlib
+import time
+from unittest.mock import patch
+
+import pytest
+
+from clawmetry.adapters.base import (
+    AgentAdapter,
+    Capability,
+    DetectResult,
+    Session,
+)
+
+
+_PARENT_UUID = "1aaf7ca1-ce93-4c96-9e5f-0ad496e36479"
+_RUNTIME = "claude_code"
+
+
+class _FakeFanoutAdapter(AgentAdapter):
+    """Emits one parent session + two sub-agent children (parent_id set)."""
+
+    name = _RUNTIME
+    display_name = "Claude Code (fake)"
+
+    def detect(self) -> DetectResult:
+        return DetectResult(name=self.name, display_name=self.display_name,
+                            detected=True, running=True)
+
+    def list_sessions(self, limit: int = 100):
+        parent = Session(
+            agent=self.name, id=_PARENT_UUID,
+            title="Review flywheel documentation across projects",
+            model="claude-fable-5",
+            started_at=1_780_000_000.0, ended_at=1_780_000_500.0,
+            message_count=4, total_tokens=1000, cost_usd=0.50,
+        )
+        child_running = Session(
+            agent=self.name, id=f"{_PARENT_UUID}::agent-a1111111",
+            parent_id=_PARENT_UUID,
+            title="Build Command River into Brain tab",
+            display_name="Build Command River into Brain tab",
+            model="claude-fable-5",
+            started_at=1_780_000_100.0, ended_at=None,
+            message_count=3, total_tokens=300, cost_usd=0.12,
+            cost_status="running",
+            extra={"depth": 1, "isSubagent": True,
+                   "description": "Build Command River into Brain tab",
+                   "agentFile": "agent-a1111111"},
+        )
+        child_failed = Session(
+            agent=self.name, id=f"{_PARENT_UUID}::agent-a3333333",
+            parent_id=_PARENT_UUID,
+            title="Risky step", display_name="Risky step",
+            model="claude-fable-5",
+            started_at=1_780_000_050.0, ended_at=1_780_000_200.0,
+            message_count=2, total_tokens=50, cost_usd=0.02,
+            end_reason="error",
+            extra={"depth": 1, "isSubagent": True,
+                   "description": "Risky step", "agentFile": "agent-a3333333"},
+        )
+        return [parent, child_running, child_failed]
+
+    def list_events(self, session_id: str, limit: int = 500):
+        # One renderable event per session so the daemon's per-session read +
+        # title-fallback paths run; children skip event ingest in the daemon.
+        from clawmetry.adapters.base import Event
+        return [Event(agent=self.name, session_id=session_id,
+                      id=f"{session_id}:1", type="message", ts=1_780_000_100.0,
+                      role="assistant", content="hi", tokens=10)]
+
+    def capabilities(self):
+        return {Capability.SESSIONS, Capability.EVENTS, Capability.COST,
+                Capability.SUBAGENTS}
+
+
+@pytest.fixture
+def sync_with_isolated_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    import clawmetry.local_store as ls
+    import clawmetry.sync as sync
+    importlib.reload(ls)
+    importlib.reload(sync)
+    monkeypatch.setattr(ls, "_daemon_registered", lambda: False)
+    monkeypatch.delenv("CLAWMETRY_ROLE", raising=False)
+    yield sync, ls
+    try:
+        ls.get_store().stop(flush=True)
+    except Exception:
+        pass
+
+
+def _wait_for_flush(store, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if store.health()["ring_depth"] == 0:
+            return
+        time.sleep(0.02)
+    raise AssertionError("flusher did not drain in time")
+
+
+def _run(sync, ls):
+    config = {"node_id": "test-node", "api_key": "test-key"}
+    with patch.object(sync, "_sync_allowed", return_value=True), \
+         patch.object(sync, "_post", return_value={}), \
+         patch.object(sync, "_family_adapter_classes",
+                      return_value=[_FakeFanoutAdapter]), \
+         patch.object(sync, "_openclaw_spawned_claude_ids", return_value=set()):
+        sync.sync_family_runtimes(config, {}, {})
+    store = ls.get_store()
+    _wait_for_flush(store)
+    return store
+
+
+def test_child_lands_in_subagents_table(sync_with_isolated_store):
+    sync, ls = sync_with_isolated_store
+    store = _run(sync, ls)
+
+    rows = store.query_subagents(parent_session_id=f"{_RUNTIME}:{_PARENT_UUID}",
+                                 limit=100)
+    ids = {r["subagent_id"] for r in rows}
+    assert f"{_RUNTIME}:{_PARENT_UUID}::agent-a1111111" in ids
+    assert f"{_RUNTIME}:{_PARENT_UUID}::agent-a3333333" in ids
+    assert len(rows) == 2
+
+    by_id = {r["subagent_id"]: r for r in rows}
+    running = by_id[f"{_RUNTIME}:{_PARENT_UUID}::agent-a1111111"]
+    assert running["parent_session_id"] == f"{_RUNTIME}:{_PARENT_UUID}"
+    assert running["status"] == "running"
+    assert running["task"] == "Build Command River into Brain tab"
+    # cache-aware cost + tokens carried from the adapter (>= stored).
+    assert running["cost_usd"] >= 0.12 - 1e-9
+    assert running["token_count"] >= 300
+
+    failed = by_id[f"{_RUNTIME}:{_PARENT_UUID}::agent-a3333333"]
+    assert failed["status"] == "failed"
+
+
+def test_subagents_snapshot_slice_contains_children(sync_with_isolated_store):
+    """The /api/subagents shaper (same source the snapshot subagents[] uses)
+    returns the children bound to the parent with the river fields."""
+    sync, ls = sync_with_isolated_store
+    store = _run(sync, ls)
+
+    import routes.sessions as sa_routes
+    rows = store.query_subagents(limit=500)
+    shaped = sa_routes._try_local_store_subagents(_rows=rows)
+    assert shaped is not None
+    subs = shaped["subagents"]
+    # The cloud river normalises ``parent`` via bareSid; assert the raw parent
+    # carries the parent uuid (prefixed form is fine).
+    river = [s for s in subs if str(s["parent"]).endswith(_PARENT_UUID)]
+    assert len(river) == 2
+    one = next(s for s in river if "a1111111" in s["sessionId"])
+    assert one["displayName"] == "Build Command River into Brain tab"
+    assert one["depth"] == 1
+    assert one["totalTokens"] >= 300
+    assert one["costUsd"] >= 0.12 - 1e-9
+
+
+def test_children_excluded_from_sessions_list(sync_with_isolated_store):
+    sync, ls = sync_with_isolated_store
+    store = _run(sync, ls)
+
+    rows = store.query_sessions_table(limit=200)
+    ids = {r["session_id"] for r in rows}
+    # Parent shows in the top-level list.
+    assert f"{_RUNTIME}:{_PARENT_UUID}" in ids
+    # Children do NOT.
+    assert f"{_RUNTIME}:{_PARENT_UUID}::agent-a1111111" not in ids
+    assert f"{_RUNTIME}:{_PARENT_UUID}::agent-a3333333" not in ids


### PR DESCRIPTION
## Why
A Claude Code session that spawned N sub-agents rendered as **"1 AGENT"** in the Command River — the payoff for the founder's session-flow-visualization goal was missing because the daemon never surfaced the on-disk sub-agent transcripts as children of their parent session.

## Trace (where the chain was broken)
- The clawmetry-pro `claude_code` adapter only read `<cwd>/<uuid>.jsonl`; it never descended into `<cwd>/<uuid>/subagents/agent-*.jsonl`.
- `sync_family_runtimes` ingested each Session into the `sessions` table but **never** called `ingest_subagent()` for family runtimes — the only thing populating the `subagents` table (which feeds `query_subagents` → snapshot `subagents[]` → the river) was the OpenClaw `sessions.json` path.

## This PR (OSS half)
- The pro adapter now emits each sub-agent as a CHILD `Session` (`parent_id` set) — see clawmetry-pro PR.
- `sync_family_runtimes` records any adapter-emitted child (`s.parent_id` set) into the `subagents` table with `parent_session_id` = the parent's namespaced session id, status, cache-aware cost + tokens, and label. They flow through the existing `query_subagents` read-back into the snapshot `subagents[]` slice the river filters by parent.
- Children are kept OUT of the top-level sessions list (`query_sessions_table` excludes ids that are `subagents.subagent_id` with a `parent_session_id`) and are not pushed to the cloud Sessions list. Their per-event re-ingest is skipped (cost rides the subagent row) so a session that fanned out to hundreds of agents stays within the CPU budget.

## Test
`tests/test_family_subagent_fanout.py` — a fake family adapter emitting a parent + running/failed children; asserts the `subagents` table, the `/api/subagents` snapshot shaper, and the sessions-list exclusion. Revert-proof (dropping the `ingest_subagent` block goes RED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)