### PR TITLE
feat(audit): emit license.activate/license.deactivate audit events

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2781,7 +2781,7 @@ def _cmd_activate(args) -> None:
     """clawmetry activate <KEY> — install a self-hosted Pro/Enterprise license."""
     from clawmetry import license as _lic
 
-    ok, msg = _lic.activate(args.key, node_id=_lic._node_id())
+    ok, msg = _lic.activate(args.key, node_id=_lic._node_id(), actor="cli")
     if ok:
         print(f"✅  {msg}")
         print("    Run `clawmetry license` to see status. Restart the daemon to load Pro features.")
@@ -2801,7 +2801,7 @@ def _cmd_license(args) -> None:
             print("❌  Usage: clawmetry license activate <KEY>")
             sys.exit(1)
         from clawmetry import license as _lic
-        ok, msg = _lic.activate(key.strip(), node_id=_lic._node_id())
+        ok, msg = _lic.activate(key.strip(), node_id=_lic._node_id(), actor="cli")
         if ok:
             print(f"✅  {msg}")
             print("    Run `clawmetry license status` to verify. Restart the daemon to load Pro features.")
@@ -2811,15 +2811,12 @@ def _cmd_license(args) -> None:
             sys.exit(1)
 
     elif action == "deactivate":
-        import os
         from clawmetry import license as _lic
-        try:
-            from clawmetry import entitlements as _ent
-            _ent.invalidate()
-        except Exception:
-            pass
-        if os.path.isfile(_lic.LICENSE_PATH):
-            os.remove(_lic.LICENSE_PATH)
+        ok, removed = _lic.deactivate(actor="cli")
+        if not ok:
+            print("❌  Could not remove the license file. Check filesystem permissions.")
+            sys.exit(1)
+        if removed:
             print("✅  License removed. ClawMetry will revert to OSS tier on next restart.")
         else:
             print("ℹ️  No license key installed — nothing to deactivate.")

--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -564,22 +564,75 @@ def auto_provision_pro(api_key: str, node_id: str | None = None) -> tuple[bool, 
         return False, ""
 
 
-def activate(key: str, node_id: str | None = None) -> tuple[bool, str]:
+def _audit_license_event(
+    action: str,
+    *,
+    result: str,
+    actor: str = "",
+    payload: dict | None = None,
+    detail: str = "",
+) -> None:
+    """Record a license state-change to the Enterprise audit log.
+
+    Never raises — a failed audit write must never block the activate /
+    deactivate path. The raw license key is NEVER recorded; only the
+    non-secret claims (tier, nodes, sub, exp) and the outcome are kept."""
+    try:
+        from clawmetry import audit as _audit
+
+        meta: dict = {}
+        if isinstance(payload, dict):
+            for k in ("tier", "nodes", "exp"):
+                if k in payload:
+                    meta[k] = payload[k]
+        if detail:
+            meta["detail"] = detail[:256]
+        target = ""
+        if isinstance(payload, dict):
+            target = str(payload.get("sub", "") or "")
+        _audit.audit_event(
+            action,
+            actor=actor or "",
+            target=target,
+            result=result,
+            source="license",
+            metadata=meta,
+        )
+    except Exception:
+        pass
+
+
+def activate(key: str, node_id: str | None = None, actor: str = "") -> tuple[bool, str]:
     """Verify ``key`` offline, persist it, and (best-effort) register the node
-    + install clawmetry-pro. Returns (ok, message). Never raises."""
+    + install clawmetry-pro. Returns (ok, message). Never raises.
+
+    ``actor`` is an optional human/system identifier folded into the audit
+    log entry; routes pass the X-Actor header (or remote address). Defaults
+    to empty (the CLI path)."""
     payload = verify_token(key)
     if payload is None:
+        _audit_license_event(
+            "license.activate", result="invalid_key", actor=actor,
+            detail="signature failed or key unparseable",
+        )
         return False, "Invalid or unrecognized license key."
     import time as _t
 
     exp = payload.get("exp")
     if isinstance(exp, (int, float)) and _t.time() > exp:
+        _audit_license_event(
+            "license.activate", result="expired_key", actor=actor, payload=payload,
+        )
         return False, "This license key has expired."
     try:
         os.makedirs(os.path.dirname(LICENSE_PATH), exist_ok=True)
         with open(LICENSE_PATH, "w", encoding="utf-8") as fh:
             fh.write(key.strip() + "\n")
     except Exception as exc:
+        _audit_license_event(
+            "license.activate", result="write_error", actor=actor, payload=payload,
+            detail=str(exc),
+        )
         return False, f"Could not write license file: {exc}"
     # Refresh the entitlement cache so the new license takes effect immediately.
     try:
@@ -591,7 +644,49 @@ def activate(key: str, node_id: str | None = None) -> tuple[bool, str]:
     install_status = _download_and_install_pro(payload)
     tier = str(payload.get("tier", "pro")).lower()
     nodes = payload.get("nodes", 1)
+    _audit_license_event(
+        "license.activate", result="activated", actor=actor, payload=payload,
+    )
     return True, f"Activated {tier} license for {nodes} node(s). {install_status}"
+
+
+def deactivate(actor: str = "") -> tuple[bool, bool]:
+    """Remove the on-disk license file and invalidate the entitlement cache.
+
+    Returns ``(ok, removed)`` — ``removed`` is False when no key was
+    installed (idempotent). Records a ``license.deactivate`` audit entry
+    with the prior tier/sub when the key parsed; never raises."""
+    prior_payload: dict | None = None
+    try:
+        if os.path.isfile(LICENSE_PATH):
+            with open(LICENSE_PATH, "r", encoding="utf-8") as fh:
+                prior_payload = verify_token(fh.read().strip())
+    except Exception:
+        prior_payload = None
+    removed = False
+    try:
+        if os.path.isfile(LICENSE_PATH):
+            os.remove(LICENSE_PATH)
+            removed = True
+    except Exception as exc:
+        _audit_license_event(
+            "license.deactivate", result="remove_error", actor=actor,
+            payload=prior_payload, detail=str(exc),
+        )
+        return False, False
+    try:
+        from clawmetry import entitlements as _ent
+
+        _ent.invalidate()
+    except Exception:
+        pass
+    _audit_license_event(
+        "license.deactivate",
+        result="removed" if removed else "noop",
+        actor=actor,
+        payload=prior_payload,
+    )
+    return True, removed
 
 
 def current_license_info() -> dict | None:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 import logging
 
-import os
-
 from flask import Blueprint, jsonify, request
 
 logger = logging.getLogger("clawmetry.routes.entitlement")
@@ -152,6 +150,23 @@ def api_paywall_event():
     return "", 204
 
 
+def _route_actor() -> str:
+    """Best-effort actor identity for the audit log. Routes don't have a
+    full auth surface yet; the dashboard sends an ``X-Actor`` header when
+    available, falling back to ``X-Forwarded-For`` then the remote address.
+    Empty string is fine — the audit reader UI shows ``system`` for
+    blank actors."""
+    try:
+        for h in ("X-Actor", "X-Forwarded-For"):
+            v = request.headers.get(h, "") or ""
+            v = v.split(",")[0].strip()
+            if v:
+                return v[:128]
+        return (request.remote_addr or "")[:128]
+    except Exception:
+        return ""
+
+
 @bp_entitlement.route("/api/license/activate", methods=["POST"])
 def api_license_activate():
     """Activate a self-hosted Pro/Enterprise license key.
@@ -166,7 +181,7 @@ def api_license_activate():
             return jsonify({"ok": False, "error": "key is required"}), 400
         from clawmetry import license as _lic
 
-        ok, msg = _lic.activate(key)
+        ok, msg = _lic.activate(key, actor=_route_actor())
         status_code = 200 if ok else 400
         return jsonify({"ok": ok, "message": msg}), status_code
     except Exception as exc:
@@ -184,16 +199,9 @@ def api_license_deactivate():
     try:
         from clawmetry import license as _lic
 
-        removed = False
-        if os.path.isfile(_lic.LICENSE_PATH):
-            os.remove(_lic.LICENSE_PATH)
-            removed = True
-        try:
-            from clawmetry import entitlements as _ent
-
-            _ent.invalidate()
-        except Exception:
-            pass
+        ok, removed = _lic.deactivate(actor=_route_actor())
+        if not ok:
+            return jsonify({"ok": False, "removed": False, "error": "remove_failed"}), 500
         return jsonify({"ok": True, "removed": removed})
     except Exception as exc:
         logger.warning("api_license_deactivate: error: %s", exc)

--- a/tests/test_license_api.py
+++ b/tests/test_license_api.py
@@ -168,3 +168,61 @@ def test_deactivate_idempotent_when_no_license(app):
     data = resp.get_json()
     assert data["ok"] is True
     assert data["removed"] is False
+
+
+# ── /api/license audit producers ──────────────────────────────────────────────
+
+
+def test_activate_route_records_audit(app, monkeypatch, tmp_path):
+    """A successful POST /api/license/activate records a license.activate
+    audit entry tagged with the requesting actor (X-Actor header)."""
+    import clawmetry.audit as A
+
+    monkeypatch.setenv("CLAWMETRY_AUDIT_DB", str(tmp_path / "audit.db"))
+    A._initialised.clear()
+
+    tok = app.lic._encode_token(_payload("pro", nodes=4), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/activate",
+            data=json.dumps({"key": tok}),
+            content_type="application/json",
+            headers={"X-Actor": "bob@example.com"},
+        )
+    assert resp.status_code == 200
+
+    rows = A.read_audit_log(limit=10, event_type="license.activate")
+    assert len(rows) == 1
+    assert rows[0]["actor"] == "bob@example.com"
+    assert rows[0]["details"]["result"] == "activated"
+    assert rows[0]["details"]["tier"] == "pro"
+    assert rows[0]["details"]["nodes"] == 4
+
+
+def test_deactivate_route_records_audit(app, monkeypatch, tmp_path):
+    """A successful POST /api/license/deactivate records a license.deactivate
+    audit entry. Pins behavior parity with the inline-removal path it
+    replaced — the route used to bypass audit entirely."""
+    import clawmetry.audit as A
+
+    monkeypatch.setenv("CLAWMETRY_AUDIT_DB", str(tmp_path / "audit.db"))
+    A._initialised.clear()
+
+    tok = app.lic._encode_token(_payload("pro", nodes=9), app.priv)
+    app.lic.activate(tok)
+
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/deactivate",
+            headers={"X-Actor": "carol@example.com"},
+        )
+    assert resp.status_code == 200
+    assert resp.get_json()["removed"] is True
+
+    rows = A.read_audit_log(limit=10, event_type="license.deactivate")
+    assert len(rows) == 1
+    assert rows[0]["actor"] == "carol@example.com"
+    assert rows[0]["details"]["result"] == "removed"
+    # Prior tier surfaces so the operator can see WHICH key was removed.
+    assert rows[0]["details"]["tier"] == "pro"
+    assert rows[0]["details"]["nodes"] == 9

--- a/tests/test_license_audit.py
+++ b/tests/test_license_audit.py
@@ -1,0 +1,253 @@
+"""Tests for the license.activate / license.deactivate audit producers.
+
+Pins the contract that every license state change records an entry in
+``clawmetry.audit``:
+
+* a successful activation records ``license.activate`` with ``result=activated``
+* an invalid / expired / write-failed activation records the failure
+* a deactivation records ``license.deactivate`` with prior tier/sub metadata
+* the raw license key is NEVER written to the audit log
+* an audit-write failure NEVER breaks the activate / deactivate path
+
+Hermetic: each test uses an ephemeral Ed25519 keypair (so the embedded
+production public key is never trusted) and points ``CLAWMETRY_AUDIT_DB``
+at a tmp_path file, so no real filesystem state is touched.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub_pem
+
+
+def _payload(tier="pro", nodes=4, exp_delta=365 * 86400, sub="acct_test"):
+    now = int(time.time())
+    return {
+        "sub": sub,
+        "tier": tier,
+        "nodes": nodes,
+        "iat": now,
+        "exp": now + exp_delta,
+        "features": ["runtimes"],
+    }
+
+
+@pytest.fixture
+def lic(monkeypatch, tmp_path):
+    """Hermetic license fixture: ephemeral keypair, tmp license path, tmp
+    audit DB. Mirrors the fixture in test_license.py / test_license_api.py
+    so behavioural pins stay symmetric."""
+    import clawmetry.license as L
+    import clawmetry.audit as A
+
+    priv, pub_pem = _keypair()
+    monkeypatch.setattr(L, "_PUBLIC_KEY_PEM", pub_pem)
+    monkeypatch.setattr(L, "LICENSE_PATH", str(tmp_path / "license.key"))
+    monkeypatch.setattr(L, "_CONFIG_PATH", str(tmp_path / "config.json"))
+    monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
+    monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    # Point the audit DB at a per-test file and reset the "initialised" guard
+    # so the schema is rebuilt against the fresh DB.
+    monkeypatch.setenv("CLAWMETRY_AUDIT_DB", str(tmp_path / "audit.db"))
+    A._initialised.clear()
+    return SimpleNamespace(L=L, A=A, priv=priv)
+
+
+def _audit_rows(A, event_type: str | None = None) -> list[dict]:
+    return A.read_audit_log(limit=50, event_type=event_type)
+
+
+# ── activate audit producer ────────────────────────────────────────────────────
+
+
+def test_activate_success_records_audit(lic):
+    tok = lic.L._encode_token(_payload("pro", nodes=11, sub="acct_42"), lic.priv)
+    ok, _msg = lic.L.activate(tok)
+    assert ok is True
+
+    rows = _audit_rows(lic.A, "license.activate")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["event_type"] == "license.activate"
+    assert r["target"] == "acct_42"
+    assert r["details"]["result"] == "activated"
+    assert r["details"]["source"] == "license"
+    assert r["details"]["tier"] == "pro"
+    assert r["details"]["nodes"] == 11
+    assert "exp" in r["details"]
+
+
+def test_activate_invalid_key_records_audit(lic):
+    ok, _msg = lic.L.activate("CLAW1.not.a.real.token")
+    assert ok is False
+
+    rows = _audit_rows(lic.A, "license.activate")
+    assert len(rows) == 1
+    assert rows[0]["details"]["result"] == "invalid_key"
+    # No payload claims surface for an unverifiable key — only the failure.
+    assert "tier" not in rows[0]["details"]
+
+
+def test_activate_expired_key_records_audit(lic):
+    tok = lic.L._encode_token(
+        _payload(exp_delta=-3600, sub="acct_expired"), lic.priv,
+    )
+    ok, _msg = lic.L.activate(tok)
+    assert ok is False
+
+    rows = _audit_rows(lic.A, "license.activate")
+    assert len(rows) == 1
+    assert rows[0]["details"]["result"] == "expired_key"
+    # Expired keys still verified — non-secret claims surface so the operator
+    # can see WHICH key expired (audit log doesn't depend on the file write).
+    assert rows[0]["target"] == "acct_expired"
+    assert rows[0]["details"]["tier"] == "pro"
+
+
+def test_activate_does_not_log_raw_key(lic):
+    """The CLAW1.…sig… token MUST NOT appear anywhere in the audit details."""
+    tok = lic.L._encode_token(_payload("pro", sub="acct_secret"), lic.priv)
+    ok, _msg = lic.L.activate(tok)
+    assert ok is True
+
+    rows = _audit_rows(lic.A, "license.activate")
+    assert len(rows) == 1
+    import json as _json
+    blob = _json.dumps(rows[0])
+    assert "CLAW1" not in blob
+    assert tok not in blob
+    # Best-effort: also assert the b64 signature segment isn't accidentally logged.
+    _prefix, _body, sig_seg = tok.split(".")
+    assert sig_seg not in blob
+
+
+def test_activate_records_actor_when_provided(lic):
+    tok = lic.L._encode_token(_payload(), lic.priv)
+    ok, _msg = lic.L.activate(tok, actor="alice@example.com")
+    assert ok is True
+
+    rows = _audit_rows(lic.A, "license.activate")
+    assert len(rows) == 1
+    assert rows[0]["actor"] == "alice@example.com"
+
+
+def test_activate_audit_failure_does_not_break_activation(lic, monkeypatch):
+    """If audit_event throws, activate() MUST still succeed — the audit
+    write is best-effort and never load-bearing for the entitlement flow."""
+    import clawmetry.audit as A
+
+    def _explode(*_a, **_kw):
+        raise RuntimeError("audit DB unreachable")
+
+    monkeypatch.setattr(A, "audit_event", _explode)
+
+    tok = lic.L._encode_token(_payload(), lic.priv)
+    ok, msg = lic.L.activate(tok)
+    assert ok is True
+    assert "pro" in msg.lower()
+
+
+# ── deactivate audit producer ──────────────────────────────────────────────────
+
+
+def test_deactivate_removes_and_records_audit(lic):
+    tok = lic.L._encode_token(_payload("pro", nodes=2, sub="acct_dx"), lic.priv)
+    lic.L.activate(tok)
+
+    # Reset the audit DB read so the deactivate event is the only row.
+    lic.A._initialised.clear()
+    import os
+    if os.path.isfile(os.environ["CLAWMETRY_AUDIT_DB"]):
+        os.remove(os.environ["CLAWMETRY_AUDIT_DB"])
+    lic.A._initialised.clear()
+
+    ok, removed = lic.L.deactivate()
+    assert ok is True
+    assert removed is True
+    assert not os.path.isfile(lic.L.LICENSE_PATH)
+
+    rows = _audit_rows(lic.A, "license.deactivate")
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["details"]["result"] == "removed"
+    assert r["details"]["source"] == "license"
+    # Prior tier/sub surface so the audit reader knows WHICH license was removed.
+    assert r["target"] == "acct_dx"
+    assert r["details"]["tier"] == "pro"
+    assert r["details"]["nodes"] == 2
+
+
+def test_deactivate_noop_when_no_license(lic):
+    ok, removed = lic.L.deactivate()
+    assert ok is True
+    assert removed is False
+
+    rows = _audit_rows(lic.A, "license.deactivate")
+    assert len(rows) == 1
+    assert rows[0]["details"]["result"] == "noop"
+    # No prior license, so no tier/sub surfaces.
+    assert rows[0]["target"] == ""
+    assert "tier" not in rows[0]["details"]
+
+
+def test_deactivate_records_actor(lic):
+    tok = lic.L._encode_token(_payload(), lic.priv)
+    lic.L.activate(tok)
+
+    ok, removed = lic.L.deactivate(actor="cli")
+    assert ok is True
+    assert removed is True
+
+    rows = _audit_rows(lic.A, "license.deactivate")
+    assert len(rows) == 1
+    assert rows[0]["actor"] == "cli"
+
+
+def test_deactivate_audit_failure_does_not_break_removal(lic, monkeypatch):
+    import clawmetry.audit as A
+    import os
+
+    tok = lic.L._encode_token(_payload(), lic.priv)
+    lic.L.activate(tok)
+
+    def _explode(*_a, **_kw):
+        raise RuntimeError("audit DB unreachable")
+
+    monkeypatch.setattr(A, "audit_event", _explode)
+
+    ok, removed = lic.L.deactivate()
+    assert ok is True
+    assert removed is True
+    assert not os.path.isfile(lic.L.LICENSE_PATH)
+
+
+def test_deactivate_clears_entitlement_cache(lic, monkeypatch):
+    """The deactivate path MUST invalidate() the entitlement cache so the
+    Free fallback takes effect on the next request — equivalent to the
+    behaviour the pre-refactor route had inline."""
+    import clawmetry.entitlements as e
+
+    monkeypatch.setattr(e, "_LICENSE_PATH", lic.L.LICENSE_PATH)
+    tok = lic.L._encode_token(_payload("pro"), lic.priv)
+    lic.L.activate(tok)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    e.invalidate()
+    assert e.get_entitlement(force=True).is_paid is True
+
+    lic.L.deactivate()
+    # Cache must have been busted — the next read resolves to OSS-free.
+    assert e.get_entitlement().is_paid is False


### PR DESCRIPTION
## Summary

The Enterprise audit log producer (`clawmetry/audit.py`) explicitly lists "license activation, config changes, approval decisions, admin overrides" as the canonical use cases, but the actual `license.activate()` / route deactivate paths never called `audit_event()` — license state changes were invisible to the audit chain even though every other governance-relevant write (HITL pause/resume/decide, approval decisions, budget config, alert rules) already records one.

This PR fills the gap. After this lands, the audit reader UI shows the same `who / when / what` audit trail for license changes that it already shows for HITL and approvals — without changing any runtime behaviour for end users.

## Changes

### `clawmetry/license.py`
- New helper `_audit_license_event` records the event with the **non-secret** payload claims (`tier`, `nodes`, `sub`, `exp`) — never the raw `CLAW1.…sig…` token, never the signature segment.
- `activate(key, ..., actor="")` now records `license.activate` on success and on every failure mode (`invalid_key`, `expired_key`, `write_error`).
- New `deactivate(actor="")` helper: reads the prior payload (for audit metadata) BEFORE removing the file, then unlinks, invalidates the entitlement cache, and records `license.deactivate` with `removed` | `noop` | `remove_error`. Replaces the inline `os.remove` that previously lived in both `routes/entitlement.py` and `clawmetry/cli.py` — DRY, and so a future caller can't bypass the audit producer.

### `routes/entitlement.py`
- `api_license_activate` / `api_license_deactivate` now pass an `actor` extracted from the `X-Actor` / `X-Forwarded-For` headers (fallback: `remote_addr`). Empty when unknown — the audit reader UI shows `system` for blank actors.
- `api_license_deactivate` calls into the new `license.deactivate()` helper instead of doing its own `os.remove` + invalidate.
- Dead `import os` removed.

### `clawmetry/cli.py`
- `_cmd_activate` / `_cmd_license activate` pass `actor="cli"`.
- `_cmd_license deactivate` calls `license.deactivate(actor="cli")` instead of its inline `os.remove`.

### `tests/test_license_audit.py` (new, 11 tests)
- Pins that activate (success + invalid + expired) records the right event with `result`, `target=sub`, `tier`, `nodes`, `exp`.
- Pins that the raw `CLAW1` token / signature segment is NEVER written to the audit log (regression guard for credential leakage).
- Pins the `actor` surface.
- Pins the never-raise contract: an `audit_event()` that throws must NOT break the activate / deactivate code path.
- Pins that deactivate clears the entitlement cache and records the prior tier/sub of the removed license.

### `tests/test_license_api.py` (+2 tests)
- `POST /api/license/activate` records audit with the `X-Actor` header surfaced.
- `POST /api/license/deactivate` records audit with the prior tier/sub of the removed license.

## Event shapes

```jsonc
// successful activation
{"event_type": "license.activate", "actor": "alice@example.com",
 "target": "acct_42",
 "details": {"result": "activated", "source": "license",
             "tier": "pro", "nodes": 11, "exp": 1812345678}}

// signature failed / malformed
{"event_type": "license.activate", "actor": "cli", "target": "",
 "details": {"result": "invalid_key", "source": "license",
             "detail": "signature failed or key unparseable"}}

// expired key — non-secret claims still surface so the operator can see
// WHICH key expired
{"event_type": "license.activate", "actor": "cli",
 "target": "acct_expired",
 "details": {"result": "expired_key", "source": "license",
             "tier": "pro", "nodes": 5, "exp": 1700000000}}

// deactivate of an installed Pro license
{"event_type": "license.deactivate", "actor": "carol@example.com",
 "target": "acct_42",
 "details": {"result": "removed", "source": "license",
             "tier": "pro", "nodes": 11, "exp": 1812345678}}

// idempotent deactivate when no key was installed
{"event_type": "license.deactivate", "actor": "cli", "target": "",
 "details": {"result": "noop", "source": "license"}}
```

## No behaviour change

- Return shapes / status codes for `activate()`, `deactivate()`, `/api/license/activate`, `/api/license/deactivate` are unchanged.
- No `__version__` bump. No `[RELEASE]` PR. No enforcement gate flipped — grace mode stays on.
- Audit producer is fully best-effort: every `audit_event()` call is wrapped in a try/except, and `tests/test_license_audit.py::test_*_audit_failure_does_not_break_*` pins the never-raise contract.

## Test plan

- [x] `python3 -m pytest tests/test_license_audit.py tests/test_license_api.py -v` — **21/21 pass in 0.61s**
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_extensions.py tests/test_audit.py tests/test_license_audit.py tests/test_license_api.py -q` — **83/83 pass** (no regression in adjacent surfaces)
- [x] `python3 -m py_compile clawmetry/license.py routes/entitlement.py clawmetry/cli.py tests/test_license_audit.py tests/test_license_api.py` — clean
- [x] `ruff check clawmetry/license.py routes/entitlement.py tests/test_license_audit.py tests/test_license_api.py` — clean (cli.py has pre-existing lint warnings on lines I did not touch)
- [x] Confirmed the 3 failures in `tests/test_license.py::test_auto_provision_*` pre-exist on `origin/main` and are unrelated to this PR (the test fixture's stub `_Resp` is missing `.headers`, surfaced by an environmental cryptography upgrade).
- [x] Verified the audit reader endpoint (`routes/audit.py`) already filters by `event_type` — the new `license.activate` / `license.deactivate` rows will appear in the existing audit panel with zero UI work.

## Local operator verification checklist

I cannot reach the user's local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please complete on a real install:

1. `cp clawmetry/license.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/license.py`
2. `cp clawmetry/cli.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/cli.py`
3. `cp routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/routes/entitlement.py`
4. `rm -f ~/.clawmetry/lib/python3.11/site-packages/clawmetry/__pycache__/license*.pyc ~/.clawmetry/lib/python3.11/site-packages/clawmetry/__pycache__/cli*.pyc ~/.clawmetry/lib/python3.11/site-packages/routes/__pycache__/entitlement*.pyc`
5. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` and restart the dashboard if it's running
6. `~/.clawmetry/bin/clawmetry license activate CLAW1.bogus.bogus` — should fail; `curl -s http://localhost:8900/api/audit/events?event_type=license.activate | jq '.[0]'` should show `{"actor":"cli","details":{"result":"invalid_key",...}}`
7. `~/.clawmetry/bin/clawmetry license activate $(cat ~/.clawmetry/license.key.bak)` — with a real key, audit row should show `result: activated`, `tier: pro|enterprise`, the right `nodes`, and `target` matching the `sub` claim
8. `~/.clawmetry/bin/clawmetry license deactivate` — audit row should show `result: removed` with the prior tier/sub surfacing
9. Re-run `~/.clawmetry/bin/clawmetry license deactivate` — second call should add a `result: noop` row (idempotent, still audited)
10. `curl -s -X POST http://localhost:8900/api/license/deactivate -H "X-Actor: vivek" | jq` — audit row should show `actor: vivek`
11. `curl -s http://localhost:8900/api/audit/events?event_type=license.activate | jq` — confirm the raw `CLAW1.…sig…` token does **not** appear in any row (search for `"CLAW1"` in the JSON — must return zero matches)
12. Decrypt the live cloud snapshot — no daemon-side change; snapshot shape is unchanged
13. Browser check: load the dashboard's audit panel and confirm `license.activate` / `license.deactivate` rows render with the new actor/tier/nodes columns

This PR is **draft-only**: I am not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Grace mode stays on. Once you have run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_019CEkwuD8b5ckJgtz7Qr3Mr)_