### PR TITLE
fix: surface gateway log level + subsystem in openclaw list_events

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -443,10 +443,21 @@ class OpenClawAdapter(AgentAdapter):
                             raw_data = bytes(raw_data).decode("utf-8", "replace")
                         obj = json.loads(raw_data) if isinstance(raw_data, str) else raw_data
                         if isinstance(obj, dict):
-                            for _field in ("channel", "hostname"):
+                            # Surface gateway log-record top-level structured
+                            # fields. channel/hostname keep their names; the
+                            # severity level is exposed as ``log_level`` and the
+                            # originating subsystem as ``subsystem`` so callers
+                            # can filter or alert on log severity and origin
+                            # (closes #3055 / #3013).
+                            for _field, _key in (
+                                ("channel", "channel"),
+                                ("hostname", "hostname"),
+                                ("level", "log_level"),
+                                ("subsystem", "subsystem"),
+                            ):
                                 _val = obj.get(_field)
                                 if _val:
-                                    extra[_field] = _val
+                                    extra[_key] = _val
                             msg = obj.get("message")
                             if isinstance(msg, str):
                                 content_text = msg

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -199,6 +199,46 @@ def test_list_events_populates_content_from_log_message_text(isolated_store):
     assert e.extra.get("hostname") == "Dhriti-1"
 
 
+def test_list_events_surfaces_log_level_and_subsystem(isolated_store):
+    """Gateway log severity + subsystem land in event.extra (#3055 / #3013).
+
+    OpenClaw gateway JSONL log records carry top-level ``level``
+    (info/warn/error/debug) and ``subsystem`` fields that the CLI and
+    Control UI parse to render structured log output. list_events already
+    surfaced channel/hostname but silently dropped level/subsystem, so
+    callers could not filter or alert on log severity or origin. Pin the
+    new behavior: ``level`` -> ``log_level`` and ``subsystem`` pass through.
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-LVL",
+        "event_type": "log",
+        "ts": _t.time(),
+        "data": {
+            "channel": "gateway",
+            "hostname": "Dhriti-1",
+            "level": "warn",
+            "subsystem": "scheduler",
+            "message": "cron job overran budget",
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-LVL")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("log_level") == "warn"
+    assert ex.get("subsystem") == "scheduler"
+    # existing channel/hostname extraction is unchanged.
+    assert ex.get("channel") == "gateway"
+    assert ex.get("hostname") == "Dhriti-1"
+
+
 def test_list_events_dict_message_does_not_set_content(isolated_store):
     """Sanity guard: when ``message`` is a dict (assistant turn shape),
     Event.content stays empty — only string ``message`` values are


### PR DESCRIPTION
Closes #3055
Closes #3013

## What
OpenClaw gateway JSONL log records carry top-level `level` (info/warn/error/debug) and `subsystem` structured fields that the CLI and Control UI Logs tab parse to render structured output. `OpenClawAdapter.list_events` already extracted `channel` and `hostname` from the log-record top level but silently dropped `level` and `subsystem`, so callers could not filter, bucket, or alert on log severity or originating subsystem.

## How
- Extended the top-level field extraction loop in `clawmetry/adapters/openclaw.py` to also read `level` (surfaced as `log_level`) and `subsystem` (verbatim) into `Event.extra`, guarded by the existing truthiness check so empty fields are skipped.
- Kept the existing `channel`/`hostname` behavior unchanged (same names).
- Added `test_list_events_surfaces_log_level_and_subsystem` pinning the new behavior and asserting channel/hostname extraction still works.

## Test
```
python3 -m pytest tests/test_openclaw_list_events.py -q
14 passed
```

Fingerprints: hgap-dd9dfb2549 (#3055), hgap-197fa6027b (#3013)