### PR TITLE
feat(sync): Query Spine P4 — per-method q/1 proactive cache push

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -6899,6 +6899,14 @@ def send_heartbeat(config: dict) -> bool:
             payload.setdefault("cache_pushes", []).extend(cron_pushes)
     except Exception as _cl_e:
         log.debug("crons cache_push build failed (continuing): %s", _cl_e)
+    # Query Spine P4 (#2990): per-method q/1 cache entries alongside the
+    # monolith snapshot. Gated by CLAWMETRY_QUERY_CACHE_PUSH (default off).
+    try:
+        q1_pushes = _build_q1_cache_pushes(config)
+        if q1_pushes:
+            payload.setdefault("cache_pushes", []).extend(q1_pushes)
+    except Exception as _q1_e:
+        log.debug("q1 cache_push build failed (continuing): %s", _q1_e)
     # Local-first: persist this heartbeat to local DuckDB so the dashboard
     # has a per-node liveness history even when offline. Best-effort.
     try:
@@ -6941,7 +6949,13 @@ def send_heartbeat(config: dict) -> bool:
 # Allowlist mirrors routes.local_query._SHAPES. Duplicated here so the
 # daemon stays safe when `routes/` isn't on sys.path (some installs run the
 # sync daemon without the dashboard module loaded).
-_PENDING_SHAPES = {"events", "sessions", "aggregates", "health", "transcript"}
+_PENDING_SHAPES = {
+    "events", "sessions", "aggregates", "health", "transcript",
+    # Added in P4 (#2990): new live shapes from P2 materialized rollups.
+    "runtimes", "models", "rollup_sessions",
+    # Added in P3 (#2989): rollup-backed span/trace shapes.
+    "spans", "traces", "external_calls", "search",
+}
 
 
 def _canonical_args_hash(args: dict) -> str:
@@ -8822,6 +8836,89 @@ def _build_cron_runs_cache_pushes(config: dict) -> list:
             "ttl_s": CRON_RUNS_CACHE_TTL_SEC,
             "blob":  blob,
         })
+    return pushes
+
+
+# ── Query Spine P4 (#2990): per-method q/1 proactive cache push ───────────────
+# Pushes each no-required-arg live q/1 shape as its own keyed cache entry
+# alongside the monolith snapshot. Plaintext-classed shapes are stored as
+# base64url-encoded JSON (no encryption needed); e2e-classed shapes use
+# AES-256-GCM (only when enc_key is present). Gated by
+# CLAWMETRY_QUERY_CACHE_PUSH env var — default off for the first release.
+Q1_PUSH_CACHE_TTL_SEC = 300   # 5 min — aggregate rollups update every ~60s
+_Q1_PUSH_DEBOUNCE_SEC = 60    # at most one push per shape per heartbeat window
+_Q1_LAST_PUSH: dict = {}      # {shape: float} last-push unix timestamp
+
+
+def _build_q1_cache_pushes(config: dict) -> list:
+    """Return cache_push entries for all no-required-arg live q/1 shapes.
+
+    Plaintext-classed methods (aggregates, health, runtimes, models) are stored
+    as base64url JSON — the cloud can read them without a decryption key.
+    E2e-classed methods (rollup_sessions) are AES-256-GCM encrypted and are
+    skipped when no encryption key is configured.
+
+    The CI guard in ``tests/test_sync_q1_cache_pushes.py`` asserts that no
+    e2e-classed method is ever pushed without an encryption key (enforcing the
+    trust-class contract declared in ``clawmetry/query_contract.py``).
+    """
+    if not os.environ.get("CLAWMETRY_QUERY_CACHE_PUSH", "").lower() in (
+        "1", "true", "yes"
+    ):
+        return []
+    api_key = config.get("api_key", "")
+    node_id = config.get("node_id", "")
+    if not (api_key and node_id):
+        return []
+    enc_key = config.get("encryption_key")
+
+    try:
+        from routes.local_query import _dispatch as _local_dispatch  # type: ignore
+    except Exception:
+        _local_dispatch = _local_dispatch_fallback  # type: ignore
+
+    try:
+        from clawmetry.query_contract import (  # type: ignore
+            QUERY_CONTRACT, TRUST_E2E, STATUS_LIVE,
+        )
+    except ImportError:
+        return []
+
+    owner_hash = _owner_hash_for_token(api_key)
+    pushes: list = []
+    now = time.time()
+
+    for shape, spec in QUERY_CONTRACT.items():
+        if spec["status"] != STATUS_LIVE:
+            continue
+        # Skip methods with any required arg — we can't pre-push those without
+        # iterating all entities (transcripts, spans, etc.). They are served
+        # on-demand via _dispatch_pending_queries.
+        if any(v.get("required") for v in spec.get("args", {}).values()):
+            continue
+        # Per-method debounce: skip if we pushed this shape recently.
+        if now - _Q1_LAST_PUSH.get(shape, 0) < _Q1_PUSH_DEBOUNCE_SEC:
+            continue
+        is_e2e = spec["trust"] == TRUST_E2E
+        if is_e2e and not enc_key:
+            continue  # hard guard: never push e2e content without encryption
+        try:
+            payload = _local_dispatch(shape, {})
+            if is_e2e:
+                blob = encrypt_payload(payload, enc_key)
+            else:
+                blob = base64.urlsafe_b64encode(
+                    json.dumps(payload, default=str).encode()
+                ).rstrip(b"=").decode()
+            pushes.append({
+                "key":   f"q1:{shape}:{owner_hash}:{node_id}",
+                "ttl_s": Q1_PUSH_CACHE_TTL_SEC,
+                "blob":  blob,
+            })
+            _Q1_LAST_PUSH[shape] = now
+        except Exception as _e:
+            log.debug("q1 cache push failed for shape=%s: %s", shape, _e)
+
     return pushes
 
 

--- a/tests/test_sync_q1_cache_pushes.py
+++ b/tests/test_sync_q1_cache_pushes.py
@@ -1,0 +1,197 @@
+"""Tests for Query Spine P4 — per-method q/1 proactive cache pushes.
+
+Covers:
+- CI guard: e2e-classed methods are NEVER pushed without an encryption key.
+- Plaintext methods produce base64url JSON blobs (no encryption key required).
+- E2e methods produce encrypted blobs when an encryption key is present.
+- Cache key follows ``q1:{shape}:{owner_hash}:{node_id}`` pattern.
+- Methods with required args are skipped (no pre-push without entity lookup).
+- Feature flag off (default): no pushes emitted.
+- Per-method debounce: second call within the window returns nothing.
+- _PENDING_SHAPES includes all live q/1 shapes (P4 expansion).
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import time
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from clawmetry.query_contract import QUERY_CONTRACT, TRUST_E2E, TRUST_PLAINTEXT, STATUS_LIVE
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_FAKE_CONFIG = {
+    "api_key": "cm_testtoken",
+    "node_id": "node_abc",
+    "encryption_key": None,
+}
+
+_FAKE_CONFIG_WITH_KEY = {
+    **_FAKE_CONFIG,
+    "encryption_key": "c2VjcmV0a2V5c2VjcmV0a2V5c2VjcmV0a2U=",  # 32-byte base64
+}
+
+
+def _fake_encrypt(data: dict, key: str) -> str:
+    """Stub for encrypt_payload — returns a deterministic fake encrypted blob."""
+    return "FAKEBLOB_" + base64.urlsafe_b64encode(
+        json.dumps(data, default=str).encode()
+    ).rstrip(b"=").decode()
+
+
+def _import_sync():
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as s
+    return s
+
+
+def _fake_dispatch(shape, args):
+    return {"rows": [], "count": 0, "_shape": shape, "_via": "test"}
+
+
+def _patch_dispatch(monkeypatch):
+    """Patch dispatch at both the fallback slot and the importable routes module."""
+    s = _import_sync()
+    monkeypatch.setattr(s, "_local_dispatch_fallback", _fake_dispatch)
+    try:
+        from routes import local_query as lq  # type: ignore
+        monkeypatch.setattr(lq, "_dispatch", _fake_dispatch, raising=False)
+    except Exception:
+        pass
+    return s
+
+
+# ── CI guard: no e2e push without enc_key ────────────────────────────────────
+
+def test_e2e_shapes_never_pushed_without_enc_key(monkeypatch):
+    """Hard guard: e2e-classed shapes must not appear in push list when no key."""
+    monkeypatch.setenv("CLAWMETRY_QUERY_CACHE_PUSH", "1")
+    s = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(s, "_Q1_LAST_PUSH", {})
+
+    e2e_shapes = {n for n, spec in QUERY_CONTRACT.items() if spec["trust"] == TRUST_E2E}
+    config_no_key = {**_FAKE_CONFIG, "encryption_key": None}
+    pushes = s._build_q1_cache_pushes(config_no_key)
+
+    pushed_shapes = {p["key"].split(":")[1] for p in pushes}
+    leaked = pushed_shapes & e2e_shapes
+    assert not leaked, (
+        f"e2e shapes {leaked} were pushed without an encryption key — "
+        "trust-class contract violation"
+    )
+
+
+# ── Feature flag off by default ──────────────────────────────────────────────
+
+def test_flag_off_returns_empty(monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_QUERY_CACHE_PUSH", raising=False)
+    s = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(s, "encrypt_payload", _fake_encrypt)
+    monkeypatch.setattr(s, "_Q1_LAST_PUSH", {})
+    assert s._build_q1_cache_pushes(_FAKE_CONFIG_WITH_KEY) == []
+
+
+# ── Cache key pattern ────────────────────────────────────────────────────────
+
+def test_cache_key_follows_q1_pattern(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_QUERY_CACHE_PUSH", "1")
+    s = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(s, "encrypt_payload", _fake_encrypt)
+    monkeypatch.setattr(s, "_Q1_LAST_PUSH", {})
+
+    pushes = s._build_q1_cache_pushes(_FAKE_CONFIG_WITH_KEY)
+    assert pushes, "expected at least one push with enc_key set"
+    for push in pushes:
+        parts = push["key"].split(":")
+        assert parts[0] == "q1", f"key prefix must be 'q1', got {parts[0]!r}"
+        assert len(parts) == 4, f"key must have 4 segments, got {push['key']!r}"
+        assert parts[2] and parts[3], "owner_hash and node_id must be non-empty"
+
+
+# ── Plaintext blobs are unencrypted base64url JSON ───────────────────────────
+
+def test_plaintext_shapes_produce_readable_blobs(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_QUERY_CACHE_PUSH", "1")
+    s = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(s, "_Q1_LAST_PUSH", {})
+
+    plaintext_shapes = {
+        n for n, spec in QUERY_CONTRACT.items()
+        if spec["status"] == STATUS_LIVE
+        and spec["trust"] == TRUST_PLAINTEXT
+        and not any(v.get("required") for v in spec.get("args", {}).values())
+    }
+    config_no_enc = {**_FAKE_CONFIG, "encryption_key": None}
+    pushes = s._build_q1_cache_pushes(config_no_enc)
+    pushed = {p["key"].split(":")[1]: p["blob"] for p in pushes}
+
+    for shape in plaintext_shapes:
+        if shape not in pushed:
+            continue
+        blob = pushed[shape]
+        # Must be valid base64url-decodable JSON (no encryption)
+        padded = blob + "=" * (4 - len(blob) % 4) if len(blob) % 4 else blob
+        decoded = json.loads(base64.urlsafe_b64decode(padded))
+        assert "_shape" in decoded
+
+
+# ── Required-arg methods are skipped ─────────────────────────────────────────
+
+def test_required_arg_methods_are_not_pushed(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_QUERY_CACHE_PUSH", "1")
+    s = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(s, "encrypt_payload", _fake_encrypt)
+    monkeypatch.setattr(s, "_Q1_LAST_PUSH", {})
+
+    required_arg_shapes = {
+        n for n, spec in QUERY_CONTRACT.items()
+        if spec["status"] == STATUS_LIVE
+        and any(v.get("required") for v in spec.get("args", {}).values())
+    }
+    pushes = s._build_q1_cache_pushes(_FAKE_CONFIG_WITH_KEY)
+    pushed_shapes = {p["key"].split(":")[1] for p in pushes}
+    assert not (pushed_shapes & required_arg_shapes), (
+        f"methods with required args should not be pre-pushed: "
+        f"{pushed_shapes & required_arg_shapes}"
+    )
+
+
+# ── Debounce: second call within window returns nothing ──────────────────────
+
+def test_debounce_suppresses_second_call(monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_QUERY_CACHE_PUSH", "1")
+    s = _patch_dispatch(monkeypatch)
+    monkeypatch.setattr(s, "encrypt_payload", _fake_encrypt)
+    monkeypatch.setattr(s, "_Q1_LAST_PUSH", {})
+
+    first = s._build_q1_cache_pushes(_FAKE_CONFIG_WITH_KEY)
+    assert first, "first call should produce pushes"
+    second = s._build_q1_cache_pushes(_FAKE_CONFIG_WITH_KEY)
+    assert second == [], "second call within debounce window must return nothing"
+
+
+# ── _PENDING_SHAPES includes new P4 shapes ───────────────────────────────────
+
+def test_pending_shapes_includes_p4_live_shapes():
+    """All live q/1 no-required-arg shapes must appear in _PENDING_SHAPES."""
+    sys.modules.pop("clawmetry.sync", None)
+    import clawmetry.sync as s
+    live_no_required = {
+        n for n, spec in QUERY_CONTRACT.items()
+        if spec["status"] == STATUS_LIVE
+        and not any(v.get("required") for v in spec.get("args", {}).values())
+    }
+    missing = live_no_required - s._PENDING_SHAPES
+    assert not missing, (
+        f"_PENDING_SHAPES is missing live no-required-arg shapes: {missing}. "
+        "Add them so cloud-requested on-demand queries can also fetch these shapes."
+    )


### PR DESCRIPTION
Closes #2990

## Summary

- **`_build_q1_cache_pushes(config)`** (new, ~70 LOC in `sync.py`): iterates all live no-required-arg q/1 shapes, dispatches each via `_local_dispatch`/fallback, returns `cache_pushes` entries keyed `q1:{shape}:{owner_hash}:{node_id}`. Plaintext shapes (aggregates, health, runtimes, models) get base64url JSON blobs; e2e shapes (rollup_sessions) use `encrypt_payload()` and are silently skipped when no enc_key is set.
- **Heartbeat assembly**: new best-effort try/except call block inserted after the crons push, same pattern as all other cache push phases.
- **`_PENDING_SHAPES` expansion**: adds `runtimes`, `models`, `rollup_sessions`, `spans`, `traces`, `external_calls`, `search` — all live P2/P3 shapes that were missing from the on-demand dispatch allowlist.
- **`tests/test_sync_q1_cache_pushes.py`** (7 tests): e2e-trust CI guard, flag-off, key format, plaintext blob decodeability, required-arg skip, debounce, `_PENDING_SHAPES` coverage.

Gated by `CLAWMETRY_QUERY_CACHE_PUSH=1` (default off for one release). The monolith snapshot is unchanged until P9.

## Test plan

- [ ] `python -m pytest tests/test_sync_q1_cache_pushes.py tests/test_query_contract_drift.py -v` — all 20 tests pass
- [ ] Set `CLAWMETRY_QUERY_CACHE_PUSH=1` on a live node and confirm `cache_pushes` in the next heartbeat payload include `q1:aggregates:*`, `q1:health:*`, `q1:runtimes:*`, `q1:models:*` entries
- [ ] Confirm e2e shapes (`rollup_sessions`) appear only when `encryption_key` is set in config

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjonATqWneKY6RkcSUCkd6)_