### PR TITLE
feat(device): efficiency grade + savings hint on deviceSummary

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -14523,7 +14523,7 @@ def _emit_detector_incidents(store, state: dict) -> int:
     return emitted
 
 
-def _build_device_summary(spending, daily_usage):
+def _build_device_summary(spending, daily_usage, efficiency=None):
     """Compact, all-runtime payload for a WiFi hardware companion.
 
     Mirrors ``routes/device.py``'s ``/api/device/snapshot`` but built on the
@@ -14701,6 +14701,27 @@ def _build_device_summary(spending, daily_usage):
                 n = int(hot.get("repeat_count") or 0)
                 msg = f"{rt} looping, {n} repeats, no progress"
             summary["alert"] = {"message": str(msg)[:200]}
+    except Exception:
+        pass
+    # Efficiency grade + monthly savings hint (schema 2, additive). One letter
+    # plus one dollar figure for the glance hero sub-line; the full ranked plan
+    # lives on the web Cost tab. `efficiency` is the slice sync_system_snapshot
+    # already computed this cycle (shared, never recomputed here — CPU budget).
+    # Omitted entirely (older firmware tolerates unknown/missing fields) rather
+    # than faked when the window is thin or the engine failed.
+    try:
+        if (isinstance(efficiency, dict) and efficiency.get("grade")
+                and not efficiency.get("insufficient_data")):
+            _save = 0.0
+            for _a in (efficiency.get("actions") or []):
+                try:
+                    _save += float(_a.get("savings_monthly_usd") or 0.0)
+                except (TypeError, ValueError):
+                    pass
+            summary["efficiency"] = {
+                "grade": str(efficiency["grade"])[:1],
+                "save_monthly_usd": round(_save, 2),
+            }
     except Exception:
         pass
     # A waiting approval or a stuck/looping agent is what needs a human.
@@ -15312,6 +15333,23 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         _inv_node_id,
     )
 
+    # Efficiency grade + measured savings, computed ONCE per cycle on the
+    # daemon's OWN store handle (never a read_only re-open — FLYWHEEL §1) and
+    # shared by BOTH the top-level `efficiency` snapshot slice (hosted Cost
+    # tab) and `deviceSummary.efficiency` (the desk-device glance sub-line).
+    # Best-effort: None on any failure, both consumers omit honestly.
+    _eff_slice = None
+    try:
+        from clawmetry import local_store as _ls_eff
+        from clawmetry.efficiency import build_efficiency_slice as _build_eff
+        _eff_store = _ls_eff.get_store()
+        if _eff_store is not None:
+            _eff_slice = _build_eff(
+                _eff_store.query_efficiency_rollup(days=30) or [], days=30
+            )
+    except Exception as _e_eff:
+        log.debug("snapshot: efficiency slice failed: %s", _e_eff)
+
     from clawmetry.providers_pricing import provider_for_model as _pfm
     payload = {
         "system": system,
@@ -15359,7 +15397,8 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
         # Compact all-runtime slice a WiFi hardware companion decrypts + renders
         # (the device GETs the snapshot, decrypts with the user's key, reads
         # this). Cloud stays blind; E2E preserved.
-        "deviceSummary": _build_device_summary(spending, _du),
+        "deviceSummary": _build_device_summary(spending, _du,
+                                               efficiency=_eff_slice),
         "cronJobs": _build_cron_jobs(paths),
         "cronHealthSummary": _build_cron_health_summary_snapshot(),
         "harness": _build_harness_snapshot(),
@@ -15424,20 +15463,12 @@ def sync_system_snapshot(config: dict, state: dict, paths: dict) -> int:
 
     # Efficiency grade + measured savings (node-wide + byRuntime), so the
     # hosted dashboard can serve /api/efficiency from the encrypted snapshot.
-    # Built on the daemon's OWN store handle (same pattern as the
-    # runtimeSummary builder — never a read_only re-open, which deadlocks the
-    # writer). Best-effort: on any failure log a debug warning and OMIT the
-    # key (cloud falls back to its honest empty state).
-    try:
-        from clawmetry import local_store as _ls_eff
-        from clawmetry.efficiency import build_efficiency_slice as _build_eff
-        _eff_store = _ls_eff.get_store()
-        if _eff_store is not None:
-            payload["efficiency"] = _build_eff(
-                _eff_store.query_efficiency_rollup(days=30) or [], days=30
-            )
-    except Exception as _e_eff:
-        log.debug("snapshot: efficiency slice failed: %s", _e_eff)
+    # Computed ONCE per cycle (above, before the payload dict) and shared with
+    # the deviceSummary builder — the CPU budget forbids running the rollup
+    # aggregate twice per push. Best-effort: omitted on failure (cloud falls
+    # back to its honest empty state).
+    if _eff_slice is not None:
+        payload["efficiency"] = _eff_slice
 
     # ── NemoClaw / sandbox enrichment ────────────────────────────────────────
     # Detect NemoClaw and add optional sandbox metadata to the snapshot.

--- a/tests/test_device_summary_snapshot.py
+++ b/tests/test_device_summary_snapshot.py
@@ -45,7 +45,9 @@ def test_shape_and_cost_tokens_passthrough(sync_with_store):
     s = sync._build_device_summary({"today": 4.2}, {"today": 1000})
     for k in _keys():
         assert k in s, f"missing key: {k}"
-    assert s["schema"] == 1
+    # schema 2 = the additive per-runtime `runtimes` array (sync.py docstring);
+    # every schema-1 field is preserved, asserted by _keys() above.
+    assert s["schema"] == 2
     assert s["cost_today_usd"] == 4.2
     assert s["tokens_today"] == 1000
     assert s["active_sessions"] == 0
@@ -148,3 +150,29 @@ def test_session_titles_ride_encrypted_summary_not_uuid(sync_with_store):
     uuid = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-')
     for v in titles.values():
         assert not uuid.match(v), v
+
+
+def test_efficiency_subslice_present_when_graded(sync_with_store):
+    """A valid efficiency slice yields a one-letter grade + summed monthly
+    savings on deviceSummary; the device renders it as the glance sub-line."""
+    sync, _ls = sync_with_store
+    eff = {
+        "grade": "B", "score": 78, "insufficient_data": False,
+        "actions": [
+            {"id": "model_downgrade", "savings_monthly_usd": 14.2},
+            {"id": "context_trim", "savings_monthly_usd": 9.1},
+            {"id": "cache_warm", "savings_monthly_usd": "garbage"},  # coerced to 0
+        ],
+    }
+    s = sync._build_device_summary({"today": 1.0}, {"today": 10}, efficiency=eff)
+    assert s["efficiency"] == {"grade": "B", "save_monthly_usd": 23.3}
+
+
+def test_efficiency_subslice_omitted_when_thin_or_absent(sync_with_store):
+    """insufficient_data / missing grade / no slice -> the key is OMITTED
+    (older firmware tolerates unknown fields; a fake grade is never sent)."""
+    sync, _ls = sync_with_store
+    thin = {"grade": None, "insufficient_data": True, "actions": []}
+    for eff in (None, thin, {"grade": "A", "insufficient_data": True}, "junk", 42):
+        s = sync._build_device_summary({"today": 1.0}, {"today": 10}, efficiency=eff)
+        assert "efficiency" not in s, f"leaked for {eff!r}"


### PR DESCRIPTION
OSS half of the device follow-up to #3066: `deviceSummary.efficiency = {grade, save_monthly_usd}` for the desk-device glance sub-line ("B, save about \$18/mo" next to the limits bar). Firmware rendering lands in clawmetry-hardware.

- Slice computed once per snapshot cycle and shared by the top-level `efficiency` key and the deviceSummary builder (CPU budget).
- Omitted when insufficient/failed; never a fake grade. Older firmware tolerates the missing field.
- Drive-by: fixed the stale `schema == 1` assertion in test_device_summary_snapshot (pre-existing failure on main; deviceSummary is schema 2).

Verification: 37 tests green including new present/omitted/garbage cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)