### PR TITLE
test(open-core): pin entitlement-table conformance invariants

### DIFF
--- a/tests/test_entitlements_table_conformance.py
+++ b/tests/test_entitlements_table_conformance.py
@@ -1,0 +1,156 @@
+"""Catalogue-table conformance tests for ``clawmetry/entitlements.py``.
+
+Pins invariants that the existing entitlements suites do not cover and that
+silently regress today:
+
+* ``_TIER_FEATURES`` and ``_TIER_RETENTION_DAYS`` register a row for *every*
+  public ``TIER_*`` constant. A future PR that adds ``TIER_FOO`` without
+  registering it falls through ``dict.get(..., frozenset())`` / ``dict.get(..., 7)``
+  and silently downgrades the new tier to free-tier feature grants and 7-day
+  retention — visible nowhere until a customer reports missing data.
+
+* ``Entitlement.to_dict()`` is ``json.dumps``-able for every tier. The dashboard
+  route ``/api/entitlement`` wraps the call in a never-raise fallback that
+  returns an OSS-free shape, so a non-serialisable type leaking into ``to_dict()``
+  (e.g. a stray ``frozenset``) silently masks the real entitlement.
+
+* ``allows_feature`` / ``allows_runtime`` for an unknown id are allowed in grace
+  (matches the documented "grace allows everything" contract) but blocked once
+  enforcement is on (matches the "deny-by-default for unknown keys" posture so a
+  typo in a route gate can't silently leak access).
+
+* ``event_retention_days()`` always returns ``None`` or a positive ``int`` —
+  never ``0`` (which would prune everything on the next sweep) and never a
+  negative value.
+
+Tests-only, never-raise, GRACE-safe — no production code is touched.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ``~/.clawmetry/license.key`` or ``cloud_plan.json`` leaks in.
+    Enforcement off by default (the tests opt in per-case)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _public_tier_constants(mod):
+    """Every ``TIER_*`` string constant the module exports."""
+    return [
+        getattr(mod, name)
+        for name in dir(mod)
+        if name.startswith("TIER_") and isinstance(getattr(mod, name), str)
+    ]
+
+
+# ── per-tier tables cover every public tier constant ────────────────────────
+
+
+def test_tier_features_table_covers_every_public_tier_constant(ent):
+    tiers = _public_tier_constants(ent)
+    assert tiers, "no TIER_* constants exported"
+    missing = [t for t in tiers if t not in ent._TIER_FEATURES]
+    assert not missing, (
+        f"_TIER_FEATURES has no row for: {missing}. "
+        "A tier without an explicit grant falls through to free-tier features "
+        "via dict.get(..., frozenset()) and silently under-grants."
+    )
+
+
+def test_tier_retention_table_covers_every_public_tier_constant(ent):
+    tiers = _public_tier_constants(ent)
+    missing = [t for t in tiers if t not in ent._TIER_RETENTION_DAYS]
+    assert not missing, (
+        f"_TIER_RETENTION_DAYS has no row for: {missing}. "
+        "A tier without an explicit retention falls through to "
+        "dict.get(..., 7) and silently caps the new tier at 7 days."
+    )
+
+
+# ── to_dict() JSON round-trip ───────────────────────────────────────────────
+
+
+def test_to_dict_is_json_serializable_for_every_tier(ent, monkeypatch, tmp_path):
+    """A non-serialisable value leaking into ``to_dict()`` (e.g. a frozenset)
+    breaks ``/api/entitlement`` — but the route's never-raise fallback hides
+    the failure, so the regression goes undetected until a Cloud feature
+    reads the entitlement directly. Pin every tier here."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    for tier in _public_tier_constants(ent):
+        cache.write_text(json.dumps({"plan": tier, "node_limit": 3, "expiry": None}))
+        en = ent.get_entitlement(force=True)
+        d = en.to_dict()
+        # Round-trip must produce identical primitive JSON (no set/frozenset slip).
+        roundtripped = json.loads(json.dumps(d))
+        assert roundtripped == d, f"{tier}: to_dict() did not round-trip cleanly"
+
+
+# ── unknown feature / runtime ids ───────────────────────────────────────────
+
+
+def test_unknown_feature_is_blocked_under_enforce(ent, monkeypatch):
+    """A typo in a route-level ``@gate("feeture_x")`` decorator must NOT
+    silently behave as allowed. Under enforce, an unknown id is blocked."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_feature("definitely_not_a_real_feature_id_xyzzy") is False
+
+
+def test_unknown_feature_is_allowed_in_grace(ent):
+    """Grace mode allows everything by contract — including unknown ids. The
+    inverse (under enforce) is pinned by the test above."""
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.allows_feature("definitely_not_a_real_feature_id_xyzzy") is True
+
+
+def test_unknown_runtime_is_blocked_under_enforce(ent, monkeypatch):
+    """A typo in a runtime adapter id must not silently observe a runtime the
+    plan does not grant. Under enforce + OSS, an unknown runtime is blocked."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    en = ent.get_entitlement(force=True)
+    assert en.allows_runtime("brand_new_unknown_runtime") is False
+
+
+def test_unknown_runtime_is_allowed_in_grace(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.allows_runtime("brand_new_unknown_runtime") is True
+
+
+# ── retention values are well-formed for every tier ─────────────────────────
+
+
+def test_event_retention_days_is_positive_int_or_none_for_every_tier(
+    ent, monkeypatch, tmp_path
+):
+    """A regression that set a tier's retention to 0 / -1 would silently prune
+    every event on the next sync sweep. Pin per-tier that the value is either
+    ``None`` (unlimited) or a positive integer."""
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    for tier in _public_tier_constants(ent):
+        cache.write_text(json.dumps({"plan": tier, "node_limit": 1, "expiry": None}))
+        en = ent.get_entitlement(force=True)
+        days = en.event_retention_days()
+        if days is None:
+            continue
+        assert isinstance(days, int) and days > 0, (
+            f"{tier}: event_retention_days() must be a positive int or None, got {days!r}"
+        )


### PR DESCRIPTION
## Summary

Adds `tests/test_entitlements_table_conformance.py` — 8 tests pinning catalogue-table invariants the existing entitlement suites do not cover and that silently regress today. Symmetric with #2532 (which pins packaging-side conformance for paid-runtime adapters); this PR pins the catalogue-side conformance for the entitlement tables themselves.

Tests-only, GRACE-safe, zero production code touched. Designed to land cleanly alongside the in-flight entitlement helper PRs (#2421, #2426, #2674, #2697, #2925, #2978, #3005) — none of them touch `tests/test_entitlements_table_conformance.py` (a new file) and none of them edit the catalogue tables this PR pins.

## What it pins

| # | Invariant | Regression class caught |
|---|-----------|-------------------------|
| 1 | Every public `TIER_*` constant has a row in `_TIER_FEATURES` | A new `TIER_FOO` lands without a feature grant → falls through `dict.get(..., frozenset())` → silently downgrades to no paid features |
| 2 | Every public `TIER_*` constant has a row in `_TIER_RETENTION_DAYS` | Same fall-through silently caps the new tier at the 7-day default |
| 3 | `Entitlement.to_dict()` round-trips through `json.dumps()` for every tier | A non-serialisable type (e.g. a stray `frozenset`) leaking in is masked by the never-raise fallback in `/api/entitlement` and only surfaces when a Cloud-side consumer reads the shape directly |
| 4 | `allows_feature("typo_id")` returns `False` under enforce | A typo in a `@gate("feeture_x")` decorator can't silently leak access |
| 5 | `allows_feature("unknown")` returns `True` in grace | The "grace allows everything" contract still holds for unknown ids |
| 6 | `allows_runtime("unknown")` returns `False` under enforce + OSS | A typo in a runtime adapter id can't silently observe a runtime the plan does not grant |
| 7 | `allows_runtime("unknown")` returns `True` in grace | Mirror of #5 for the runtime axis |
| 8 | `event_retention_days()` is always `None` or a positive int for every tier | A stray `0` / negative value would prune every event on the next sync sweep — caught at the catalogue level, not in production |

## Why this and why now

Open-core has crossed the threshold where the *entitlement tables themselves* are the contract — a quiet regression to the `_TIER_FEATURES` / `_TIER_RETENTION_DAYS` shape is visible nowhere until a customer reports missing data. The existing `tests/test_entitlements_catalogue.py` pins published-pricing keys and the existing `tests/test_entitlements.py` pins grace/enforce behavioural surfaces, but neither walks every `TIER_*` constant against the lookup tables to confirm coverage. This PR adds that walk + the four "unknown id" deny-by-default pins.

## Why this doesn't conflict with the in-flight queue

Every other entitlement-shaped PR in flight extends `clawmetry/entitlements.py`, `routes/entitlement.py`, `clawmetry/license.py`, `clawmetry/cli.py`, or `clawmetry/_gate.py`. This PR is a single new file under `tests/`. There is no overlap, no rebase tax, and the tests stay correct regardless of which order the helper PRs land.

## Test plan

- [x] `python3 -m pytest tests/test_entitlements_table_conformance.py -v` — **8/8 pass**
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlements_catalogue.py tests/test_entitlement_api.py tests/test_entitlements_table_conformance.py -q` — **53/53 pass** (no regression in adjacent suites)
- [x] `ruff check tests/test_entitlements_table_conformance.py` — clean
- [x] `python3 -m py_compile tests/test_entitlements_table_conformance.py` — clean

Pre-existing failures in `tests/test_license.py::test_auto_provision_*` (3) reproduce identically on `origin/main` (`_Resp` mock missing `.headers`) and are unrelated to this PR — see e.g. #2421 / #2978 / #3059, all of which note the same pre-existing failure.

## No behaviour change

Pure addition. No `__version__` bump. No `[RELEASE]` PR. No enforcement gate flipped — GRACE mode stays on. No frontend, no daemon, no route, no helper, no CLI is touched.

## Local operator verification checklist

I cannot reach the user's local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. This PR is tests-only — the runtime verification surface is small — please confirm on a real install:

1. `cp tests/test_entitlements_table_conformance.py ~/.clawmetry/lib/python3.11/site-packages/tests/test_entitlements_table_conformance.py` *(only if you mirror tests into the install path; otherwise no copy needed — CI is the only consumer)*
2. `rm -f ~/.clawmetry/lib/python3.11/site-packages/tests/__pycache__/test_entitlements_table_conformance*.pyc`
3. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` — no daemon code changed; restart only needed if you mirror tests into the runtime tree
4. `pytest tests/test_entitlements_table_conformance.py -v` from a fresh checkout — 8/8 should pass
5. `curl -s http://localhost:8900/api/entitlement | python3 -m json.tool` — confirm the shape is unchanged from before (this PR cannot affect the route; only a regression on `main` would)
6. Decrypt the live cloud snapshot to confirm no daemon-side regression — this PR is tests-only; snapshot shape is unchanged
7. Browser-check the dashboard — no UI is touched

This PR is **draft-only**. I am not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, and not enforcing any gate. Grace mode stays on. Once you have run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcTRpiWDWHMPe2MRtCgun6)_