### PR TITLE
feat(entitlement): add resolution_diagnostic() + GET /api/entitlement/diagnostic

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -410,6 +410,81 @@ def invalidate() -> None:
         _cache.update(ent=None, ts=0.0, enforce=None)
 
 
+def resolution_diagnostic() -> dict:
+    """Snapshot of the *inputs* that determine entitlement resolution.
+
+    Where :func:`get_entitlement` (and ``/api/entitlement``) report the
+    resolved *outputs* (tier, runtimes, features, expiry), this helper
+    reports the *inputs* the resolver consulted to produce them:
+
+    * presence (not contents) of ``~/.clawmetry/license.key``
+    * presence (not contents) of ``~/.clawmetry/cloud_plan.json``
+    * the raw ``CLAWMETRY_ENFORCE`` env value + the boolean it resolves to
+    * cache liveness (age vs TTL, hit/miss for the next call)
+
+    Existing operator-triage flow for "why does this install think it's on
+    tier X?" required reading dashboard logs, ``ls``-ing ``~/.clawmetry``,
+    and ``echo``-ing the env var by hand. This rolls those checks into one
+    blob the dashboard / CLI / a tail-only operator can read uniformly.
+
+    Side-effect-free; never reads file contents; never raises (a failed
+    ``os.stat`` becomes ``present=False`` with the error string). No secrets
+    are surfaced — only paths, sizes, and the resolver's view of them.
+    """
+    out: dict = {
+        "license_path": _LICENSE_PATH,
+        "license_present": False,
+        "license_size_bytes": 0,
+        "cloud_plan_path": _CLOUD_PLAN_CACHE,
+        "cloud_plan_present": False,
+        "cloud_plan_size_bytes": 0,
+        "enforce_env": os.environ.get("CLAWMETRY_ENFORCE"),
+        "is_enforced": False,
+        "cache_age_seconds": None,
+        "cache_ttl_seconds": _CACHE_TTL_SECS,
+        "cache_hit_next_call": False,
+        "cache_cached_tier": None,
+    }
+    try:
+        out["is_enforced"] = is_enforced()
+    except Exception as exc:  # pragma: no cover - is_enforced is a string check
+        logger.warning("resolution_diagnostic: is_enforced failed: %s", exc)
+    try:
+        st = os.stat(_LICENSE_PATH)
+        out["license_present"] = True
+        out["license_size_bytes"] = int(st.st_size)
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        out["license_error"] = str(exc)
+    try:
+        st = os.stat(_CLOUD_PLAN_CACHE)
+        out["cloud_plan_present"] = True
+        out["cloud_plan_size_bytes"] = int(st.st_size)
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        out["cloud_plan_error"] = str(exc)
+    try:
+        with _lock:
+            ts = float(_cache.get("ts") or 0.0)
+            cached_ent = _cache.get("ent")
+            cached_enforce = _cache.get("enforce")
+        if ts > 0.0:
+            age = max(0.0, time.time() - ts)
+            out["cache_age_seconds"] = round(age, 3)
+            out["cache_hit_next_call"] = (
+                cached_ent is not None
+                and cached_enforce == out["is_enforced"]
+                and age < _CACHE_TTL_SECS
+            )
+            if cached_ent is not None:
+                out["cache_cached_tier"] = getattr(cached_ent, "tier", None)
+    except Exception as exc:
+        out["cache_error"] = str(exc)
+    return out
+
+
 def available_runtimes() -> list[str]:
     """Runtimes the UI should expose. In grace mode that's every known
     runtime (so nothing disappears before enforcement); once enforced it's the

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6,8 +6,11 @@ runtimes/features to surface (and, once enforcement is live, which to render
 locked behind an upgrade CTA). Backed by :mod:`clawmetry.entitlements`, which
 is the single source of truth — handlers never re-derive tier logic here.
 
-  GET /api/entitlement — the current Entitlement as JSON.
-  GET /api/runtimes    — the full runtime catalog with locked/free flags.
+  GET /api/entitlement            — the current Entitlement as JSON.
+  GET /api/entitlement/diagnostic — the *inputs* the resolver consulted
+                                     (license/cloud-plan presence, enforce env,
+                                     cache liveness) for operator triage.
+  GET /api/runtimes               — the full runtime catalog with locked/free flags.
 
 Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
 on the cloud side: when no license/cloud plan is present it returns a graceful
@@ -49,6 +52,43 @@ def api_entitlement():
                 "enforced": False,
                 "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/diagnostic")
+def api_entitlement_diagnostic():
+    """Return the *inputs* the entitlement resolver consulted.
+
+    Where ``/api/entitlement`` reports the resolved outputs, this endpoint
+    reports the inputs — license/cloud-plan path presence (not contents), the
+    raw ``CLAWMETRY_ENFORCE`` env var and the boolean it resolves to, and the
+    cache liveness for the next call. Lets operators answer "why does this
+    install think it's on tier X?" without shelling into the host.
+
+    Side-effect-free, never reads file contents, never raises: on any
+    diagnostic-collection failure the route returns a minimal safe shape so a
+    dashboard panel can always render something.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        return jsonify(_ent.resolution_diagnostic())
+    except Exception as exc:  # never crash the dashboard over a diagnostic read
+        logger.warning("api_entitlement_diagnostic: falling back to minimal: %s", exc)
+        return jsonify(
+            {
+                "license_path": None,
+                "license_present": False,
+                "cloud_plan_path": None,
+                "cloud_plan_present": False,
+                "enforce_env": os.environ.get("CLAWMETRY_ENFORCE"),
+                "is_enforced": False,
+                "cache_age_seconds": None,
+                "cache_ttl_seconds": None,
+                "cache_hit_next_call": False,
+                "cache_cached_tier": None,
+                "error": str(exc),
             }
         )
 

--- a/tests/test_entitlement_resolution_diagnostic.py
+++ b/tests/test_entitlement_resolution_diagnostic.py
@@ -1,0 +1,308 @@
+"""Tests for ``clawmetry.entitlements.resolution_diagnostic()`` and the
+companion ``GET /api/entitlement/diagnostic`` endpoint.
+
+The diagnostic surfaces the *inputs* to entitlement resolution — license file
+presence, cloud-plan cache presence, the raw ``CLAWMETRY_ENFORCE`` env value
++ the bool it resolves to, and the in-process cache liveness. This is the
+operator triage surface for "why does this install think it's on tier X?".
+
+Pins:
+    * Default OSS shape (no files present, enforce off) reports the expected
+      paths and booleans.
+    * The ``license_path`` / ``cloud_plan_path`` reflect ``HOME`` — proving
+      no real ``$HOME/.clawmetry`` leaks in.
+    * ``license_present`` / ``cloud_plan_present`` + ``*_size_bytes`` flip on
+      when the files exist.
+    * File *contents* are never read or surfaced (only path + size + presence).
+    * ``CLAWMETRY_ENFORCE`` is reflected accurately (raw env + ``is_enforced``).
+    * Cache liveness flips with ``get_entitlement()`` calls + ``invalidate()``.
+    * The route returns a 200 + the helper's shape; falls back gracefully
+      when the helper raises (never 5xx).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import time
+
+import pytest
+from flask import Flask
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ``~/.clawmetry/license.key`` or ``cloud_plan.json`` leaks in."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e, tmp_path
+    e.invalidate()
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client with bp_entitlement wired and a clean HOME."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client(), tmp_path
+
+
+# ── resolution_diagnostic() shape ────────────────────────────────────────────
+
+
+def test_resolution_diagnostic_default_shape(ent):
+    """Empty HOME, no enforce env: known keys present, sensible defaults."""
+    e, tmp_path = ent
+    d = e.resolution_diagnostic()
+    for key in (
+        "license_path",
+        "license_present",
+        "license_size_bytes",
+        "cloud_plan_path",
+        "cloud_plan_present",
+        "cloud_plan_size_bytes",
+        "enforce_env",
+        "is_enforced",
+        "cache_age_seconds",
+        "cache_ttl_seconds",
+        "cache_hit_next_call",
+        "cache_cached_tier",
+    ):
+        assert key in d, key
+    assert d["license_present"] is False
+    assert d["license_size_bytes"] == 0
+    assert d["cloud_plan_present"] is False
+    assert d["cloud_plan_size_bytes"] == 0
+    assert d["enforce_env"] is None
+    assert d["is_enforced"] is False
+    # Empty cache before any get_entitlement() call.
+    assert d["cache_age_seconds"] is None
+    assert d["cache_hit_next_call"] is False
+    assert d["cache_cached_tier"] is None
+    assert isinstance(d["cache_ttl_seconds"], (int, float))
+    assert d["cache_ttl_seconds"] > 0
+
+
+def test_resolution_diagnostic_paths_reflect_home(ent):
+    """The paths must root under the test HOME — proves no real ~/.clawmetry
+    leaks into the test."""
+    e, tmp_path = ent
+    d = e.resolution_diagnostic()
+    # _LICENSE_PATH / _CLOUD_PLAN_CACHE are computed at module import via
+    # os.path.expanduser; reload above re-evaluates them under our HOME.
+    assert str(tmp_path) in d["license_path"]
+    assert str(tmp_path) in d["cloud_plan_path"]
+    assert d["license_path"].endswith("license.key")
+    assert d["cloud_plan_path"].endswith("cloud_plan.json")
+
+
+def test_resolution_diagnostic_is_json_serializable(ent):
+    """Dashboard / CLI consume this via JSON — pin a clean round-trip so a
+    stray frozenset/Path leak fails loudly here, not in /api/entitlement/diagnostic."""
+    e, _ = ent
+    d = e.resolution_diagnostic()
+    assert json.loads(json.dumps(d)) == d
+
+
+# ── license / cloud-plan presence ────────────────────────────────────────────
+
+
+def test_license_present_flips_when_file_exists(ent):
+    e, tmp_path = ent
+    lic = tmp_path / ".clawmetry" / "license.key"
+    lic.parent.mkdir(parents=True, exist_ok=True)
+    lic.write_text("CLAW1.fake.fake")
+    d = e.resolution_diagnostic()
+    assert d["license_present"] is True
+    assert d["license_size_bytes"] == len("CLAW1.fake.fake")
+
+
+def test_cloud_plan_present_flips_when_file_exists(ent):
+    e, tmp_path = ent
+    cp = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cp.parent.mkdir(parents=True, exist_ok=True)
+    cp.write_text(json.dumps({"plan": "cloud_starter"}))
+    d = e.resolution_diagnostic()
+    assert d["cloud_plan_present"] is True
+    assert d["cloud_plan_size_bytes"] > 0
+
+
+def test_resolution_diagnostic_never_surfaces_file_contents(ent):
+    """Critical: the diagnostic exposes paths + presence + size, never the
+    license body. A leaked license key in the diagnostic would defeat the
+    whole point of the file-permission hardening."""
+    e, tmp_path = ent
+    lic = tmp_path / ".clawmetry" / "license.key"
+    lic.parent.mkdir(parents=True, exist_ok=True)
+    secret = "CLAW1.SECRET_BODY_SHOULD_NEVER_LEAK"
+    lic.write_text(secret)
+    cp = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cloud_secret_marker = "CLOUD_SECRET_SHOULD_NEVER_LEAK"
+    cp.write_text(json.dumps({"plan": "cloud_pro", "note": cloud_secret_marker}))
+    blob = json.dumps(e.resolution_diagnostic())
+    assert "SECRET_BODY_SHOULD_NEVER_LEAK" not in blob
+    assert cloud_secret_marker not in blob
+
+
+# ── enforce env reflection ───────────────────────────────────────────────────
+
+
+def test_resolution_diagnostic_reflects_enforce_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    d = e.resolution_diagnostic()
+    assert d["enforce_env"] == "1"
+    assert d["is_enforced"] is True
+
+
+def test_resolution_diagnostic_reports_raw_env_even_when_invalid(monkeypatch, tmp_path):
+    """Raw env is reported verbatim so operators see typos like
+    'CLAWMETRY_ENFORCE=enabled' that *look* on but resolve to off."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "enabled")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    d = e.resolution_diagnostic()
+    assert d["enforce_env"] == "enabled"
+    assert d["is_enforced"] is False  # not in _ENFORCE_ENABLE_VALUES
+
+
+# ── cache liveness ───────────────────────────────────────────────────────────
+
+
+def test_cache_age_and_hit_after_get_entitlement(ent):
+    e, _ = ent
+    e.get_entitlement(force=True)
+    d = e.resolution_diagnostic()
+    assert d["cache_age_seconds"] is not None
+    assert d["cache_age_seconds"] >= 0.0
+    assert d["cache_hit_next_call"] is True
+    assert d["cache_cached_tier"] == "oss"
+
+
+def test_cache_invalidate_resets_diagnostic(ent):
+    e, _ = ent
+    e.get_entitlement(force=True)
+    e.invalidate()
+    d = e.resolution_diagnostic()
+    assert d["cache_age_seconds"] is None
+    assert d["cache_hit_next_call"] is False
+    assert d["cache_cached_tier"] is None
+
+
+def test_cache_age_grows_over_time(ent):
+    e, _ = ent
+    e.get_entitlement(force=True)
+    first = e.resolution_diagnostic()["cache_age_seconds"]
+    time.sleep(0.02)
+    second = e.resolution_diagnostic()["cache_age_seconds"]
+    assert second >= first
+
+
+# ── /api/entitlement/diagnostic endpoint ─────────────────────────────────────
+
+
+def test_api_entitlement_diagnostic_returns_helper_shape(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/diagnostic")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    for key in (
+        "license_path",
+        "license_present",
+        "cloud_plan_path",
+        "cloud_plan_present",
+        "enforce_env",
+        "is_enforced",
+        "cache_age_seconds",
+        "cache_ttl_seconds",
+        "cache_hit_next_call",
+        "cache_cached_tier",
+    ):
+        assert key in d, key
+
+
+def test_api_entitlement_diagnostic_reflects_enforce(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement/diagnostic").get_json()
+    assert d["enforce_env"] == "1"
+    assert d["is_enforced"] is True
+
+
+def test_api_entitlement_diagnostic_never_raises(monkeypatch, client):
+    """When the helper itself explodes the route must still return a 200 +
+    a minimal safe shape — the dashboard polls this endpoint."""
+    c, _ = client
+
+    def _boom():
+        raise RuntimeError("simulated diagnostic breakage")
+
+    import clawmetry.entitlements as e
+
+    monkeypatch.setattr(e, "resolution_diagnostic", _boom)
+    resp = c.get("/api/entitlement/diagnostic")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    # The fallback still carries the structural keys callers depend on.
+    for key in (
+        "license_path",
+        "license_present",
+        "cloud_plan_path",
+        "cloud_plan_present",
+        "enforce_env",
+        "is_enforced",
+    ):
+        assert key in d, key
+    assert d["license_present"] is False
+    assert d["cloud_plan_present"] is False
+    assert d.get("error")
+
+
+def test_api_entitlement_diagnostic_does_not_leak_file_contents(client, tmp_path):
+    """End-to-end mirror of the helper-level secrecy test — pin that the route
+    surface, not just the helper, refuses to surface license / cloud-plan body
+    bytes."""
+    c, _ = client
+    lic = tmp_path / ".clawmetry" / "license.key"
+    lic.parent.mkdir(parents=True, exist_ok=True)
+    secret = "CLAW1.ROUTE_SECRET_NO_LEAK"
+    lic.write_text(secret)
+    cp = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cloud_secret = "ROUTE_CLOUD_SECRET_NO_LEAK"
+    cp.write_text(json.dumps({"plan": "cloud_pro", "note": cloud_secret}))
+    blob = c.get("/api/entitlement/diagnostic").get_data(as_text=True)
+    assert "ROUTE_SECRET_NO_LEAK" not in blob
+    assert cloud_secret not in blob


### PR DESCRIPTION
## Summary

Adds an operator-triage surface that reports the **inputs** the entitlement resolver consulted — complementary to the existing `/api/entitlement`, which reports the resolved **outputs** (tier / runtimes / features / expiry).

Today, answering *"why does this install think it's on tier X?"* requires reading dashboard logs, `ls`-ing `~/.clawmetry`, and `echo $CLAWMETRY_ENFORCE` on the host. This rolls those checks into one structured blob the dashboard / CLI / a tail-only operator can read uniformly.

```
$ curl -s http://localhost:8900/api/entitlement/diagnostic | jq .
{
  "license_path":       "/Users/op/.clawmetry/license.key",
  "license_present":    false,
  "license_size_bytes": 0,
  "cloud_plan_path":    "/Users/op/.clawmetry/cloud_plan.json",
  "cloud_plan_present": false,
  "cloud_plan_size_bytes": 0,
  "enforce_env":        null,
  "is_enforced":        false,
  "cache_age_seconds":  3.412,
  "cache_ttl_seconds":  60.0,
  "cache_hit_next_call": true,
  "cache_cached_tier":  "oss"
}
```

## Why this and why now

The in-flight entitlement PR stack (#2426 `feature_catalog`, #2692 `tier_catalog`, #2722 `allows_node_count`, #2727 `days_until_expiry`, #2790 `allows_retention_window`, #2792 `channel_limit`, #2810 retention in `to_dict`, #2925 `runtime_tier`, #2955 `locked_*`, #2968 `tier_rank`/`is_at_least`, #3033 `lock_reason`) all extends the **resolved-Entitlement** surface — describing what the install *is* allowed to do.

This PR adds an orthogonal axis: **what did the resolver see** when it produced that verdict. Distinct functions, distinct route, distinct test file, non-overlapping edit windows inside `clawmetry/entitlements.py` (insert between `invalidate()` and `available_runtimes()`) and `routes/entitlement.py` (insert between `/api/entitlement` and `/api/runtimes`).

#2992 adds `/api/extensions` for the **plugin loader** — a different surface (which plugins loaded, not what the entitlement resolver saw). No edit-window overlap.

## Scope

### `clawmetry/entitlements.py`
- `resolution_diagnostic() -> dict` returns:
  - **License file:** `license_path`, `license_present`, `license_size_bytes` (no contents)
  - **Cloud-plan cache:** `cloud_plan_path`, `cloud_plan_present`, `cloud_plan_size_bytes` (no contents)
  - **Enforce env:** `enforce_env` (raw `CLAWMETRY_ENFORCE` value), `is_enforced` (resolved bool)
  - **Cache state:** `cache_age_seconds`, `cache_ttl_seconds`, `cache_hit_next_call`, `cache_cached_tier`
- Side-effect-free: only `os.stat` is consulted, **file contents are never read or surfaced** — pinned by a dedicated test asserting that license-body and cloud-plan-body bytes never appear in the diagnostic blob.
- Never raises: each section is independently `try`/`except`'d; a failed `os.stat` becomes `present=False` (FileNotFoundError) or surfaces just the error string for diagnostic value, never the contents.

### `routes/entitlement.py`
- `GET /api/entitlement/diagnostic` returns the helper output as JSON.
- Wraps the call in the same never-raise fallback the other `bp_entitlement` endpoints use — a flaky diagnostic read can never 5xx the dashboard panel.

### `tests/test_entitlement_resolution_diagnostic.py` (15 tests, ~0.24s)
- Default shape + complete key set
- HOME-rooted paths (proves no real `~/.clawmetry` leakage)
- `json.dumps` round-trip (defends against future frozenset/Path slips)
- `license_present` / `cloud_plan_present` + `*_size_bytes` flip when files materialise
- **File contents are never surfaced** — both helper-level and route-level
- `CLAWMETRY_ENFORCE` reflection: raw env reported verbatim (incl. typos like `"enabled"` that resolve to `False`), `is_enforced` is the resolver's verdict
- Cache liveness round-trip via `get_entitlement(force=True)` + `invalidate()`
- `cache_age_seconds` grows over time
- `/api/entitlement/diagnostic` 200 + shape contract
- `/api/entitlement/diagnostic` enforce reflection
- `/api/entitlement/diagnostic` never-raise fallback via monkeypatched `resolution_diagnostic()` boom

## No behaviour change

Pure additive read-only diagnostic. No `allows_*` is invoked on the new path. No catalog / `to_dict()` / cache resolver logic changes. No `__version__` bump. No enforcement flipped. Grace mode stays on.

## Test plan

- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_resolution_diagnostic.py` — clean
- [x] `python3 -m pytest tests/test_entitlement_resolution_diagnostic.py -v` → **15/15 pass in 0.24s**
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_routes_runtimes.py tests/test_entitlement_resolution_diagnostic.py -q` → **63/63 pass in 0.53s** — no regression in adjacent suites
- [ ] Frontend wiring of `/api/entitlement/diagnostic` (a "Why is my tier X?" status footer panel) — separate PR, out of scope.

## Local operator verification checklist

This agent has no access to the user's machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please run on a real install:

1. `git fetch origin feat/entitlement-resolution-diagnostic && git checkout feat/entitlement-resolution-diagnostic`
2. Copy the changed files into the live install:
   ```bash
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/entitlements.py
   cp routes/entitlement.py     ~/.clawmetry/lib/python3.*/site-packages/routes/entitlement.py
   ```
3. Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
4. Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. Hit the new endpoint and confirm the inputs view:
   ```bash
   curl -s http://localhost:8900/api/entitlement/diagnostic | python3 -m json.tool
   ```
   Expect a 200 + the documented keys. On an OSS-only install both `*_present` flags should be `false`. After `clawmetry activate <KEY>`, `license_present` should flip to `true` (and `license_size_bytes` > 0), without the body bytes appearing anywhere in the response.
6. Sanity check: confirm `/api/entitlement` still returns its existing shape (this PR does not modify it).
7. Decrypt the live cloud snapshot — daemon snapshot shape is unchanged.
8. Browser-check the dashboard — no UI consumes `/api/entitlement/diagnostic` yet (footer panel is a follow-up).

This PR is **DRAFT** — `__version__` is not bumped, no `[RELEASE]` PR is opened, no gate is enforced. Grace mode stays on. Once you have run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_019uHsEfNiquUQdJRaMPVBv6)_