### PR TITLE
feat(entitlement): add feature_catalog() + GET /api/features (feature parity with /api/runtimes)

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -163,6 +163,18 @@ FEATURE_LABELS = {
     "custom_data_residency": "Custom data residency",
 }
 
+# Backwards-compat alias keys living inside ``PRO_ONLY_FEATURES`` that older
+# callers may still import. They satisfy ``allows_feature(...)`` for the
+# canonical feature they alias, but the user-facing catalog (and so the
+# upgrade copy) should hide them — listing them alongside the canonical
+# keys advertises feature names that aren't on /pricing anymore. The catalog
+# row carries ``alias=True`` so the UI can filter them out without
+# hard-coding the four ids on the frontend (a duplicate that would drift the
+# next time we shuffle the PRO_ONLY set).
+_ALIAS_FEATURES = frozenset(
+    {"custom_alerts", "alert_webhooks", "anomaly_detection", "cost_optimizer"}
+)
+
 # ── Feature catalogue ───────────────────────────────────────────────────────
 # Core observability — always free. Keys are stable identifiers the route /
 # UI layer checks via Entitlement.allows_feature(...).
@@ -572,6 +584,7 @@ def feature_catalog() -> list[dict]:
                 "allowed": allowed,
                 "locked": (not is_free) and (not allowed),
                 "entitled": entitled,
+                "alias": fid in _ALIAS_FEATURES,
             }
         )
     return out

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -111,6 +111,58 @@ RUNTIME_LABELS = {
     "nanoclaw": "NanoClaw",
 }
 
+# Display labels for every known feature. Mirrors the runtime label map and is
+# the source of truth the dashboard reads via ``/api/features`` so the locked-
+# but-visible affordance on paid features renders human-readable copy. Adding a
+# feature to one of the ``*_FEATURES`` sets without a label here is safe — the
+# helper falls back to the id — but a missing label trips the catalogue
+# conformance test in ``tests/test_entitlements_feature_catalog.py``.
+FEATURE_LABELS = {
+    # Free / core observability
+    "sessions": "Sessions",
+    "transcripts": "Transcripts",
+    "usage": "Usage",
+    "brain": "Brain",
+    "flow": "Flow",
+    "tracing": "Tracing",
+    "health": "Health",
+    "logs": "Logs",
+    "crons": "Crons",
+    "channels": "Channels",
+    "nemo_governance": "NeMo Governance",
+    "overview": "Overview",
+    # Starter
+    "multi_runtime": "Multi-runtime",
+    "fleet": "Multi-node fleet",
+    "cloud_sync": "Cloud sync",
+    "all_channels": "All channels",
+    "approval_queue": "Approval queue",
+    "budget_limits": "Budget limits",
+    "per_runtime_health_timeline": "Per-runtime health timeline",
+    # Pro-only
+    "per_run_waste_flags": "Per-run waste flags",
+    "per_run_compare": "Per-run compare",
+    "error_triage": "Error triage",
+    "self_evolve": "Self-Evolve",
+    "asset_registry": "Asset registry",
+    "eval_suite": "Eval suite",
+    "tool_policy": "Tool policy",
+    "otel_export": "OTel export",
+    "custom_webhooks": "Custom webhooks",
+    "custom_runtime_ingest": "Custom runtime ingest",
+    "custom_alerts": "Custom alerts",
+    "alert_webhooks": "Alert webhooks",
+    "anomaly_detection": "Anomaly detection",
+    "cost_optimizer": "Cost optimizer",
+    # Enterprise
+    "siem_export": "SIEM export",
+    "sso": "SSO",
+    "audit_logs": "Audit logs",
+    "rbac": "RBAC",
+    "air_gapped_license": "Air-gapped license",
+    "custom_data_residency": "Custom data residency",
+}
+
 # ── Feature catalogue ───────────────────────────────────────────────────────
 # Core observability — always free. Keys are stable identifiers the route /
 # UI layer checks via Entitlement.allows_feature(...).
@@ -425,6 +477,104 @@ def runtime_label(runtime: str) -> str:
     so unknown plugin runtimes still render with *something*."""
     rt = (runtime or "").strip().lower()
     return RUNTIME_LABELS.get(rt, rt)
+
+
+def feature_label(feature: str) -> str:
+    """Human-readable label for ``feature``. Falls back to the id when unknown
+    so plugin/extension features still render with *something*."""
+    fid = (feature or "").strip().lower()
+    return FEATURE_LABELS.get(fid, fid)
+
+
+# Ordered tier ladder used to resolve "minimum tier that unlocks X" — the lower
+# the index the cheaper the tier. Free first, then Starter, Pro, Enterprise.
+_FEATURE_TIER_ORDER = (
+    (TIER_OSS, FREE_FEATURES),
+    (TIER_CLOUD_STARTER, STARTER_FEATURES),
+    (TIER_CLOUD_PRO, PRO_ONLY_FEATURES),
+    (TIER_ENTERPRISE, ENTERPRISE_FEATURES),
+)
+
+
+def feature_tier(feature: str) -> str:
+    """The lowest tier code that unlocks ``feature``. Returns ``TIER_OSS`` for
+    free features (and unknown ids — same fallback as the runtime helper, so an
+    extension feature never appears mysteriously locked). Used by the UI to
+    label the upgrade CTA ("Requires Starter", "Requires Pro", "Requires
+    Enterprise") without hard-coding the bucket on the frontend."""
+    fid = (feature or "").strip().lower()
+    for tier, bucket in _FEATURE_TIER_ORDER:
+        if fid in bucket:
+            return tier
+    return TIER_OSS
+
+
+# Stable ordering rank used to sort the catalogue: free first, then by tier.
+_FEATURE_TIER_RANK = {
+    TIER_OSS: 0,
+    TIER_CLOUD_STARTER: 1,
+    TIER_CLOUD_PRO: 2,
+    TIER_ENTERPRISE: 3,
+}
+
+
+def feature_catalog() -> list[dict]:
+    """The full feature catalog with the entitlement-derived availability for
+    each entry. Single source of truth the UI uses to render *every* known
+    feature — including paid ones the local install does not have — so the
+    locked-but-visible upgrade affordance has data to render against and the
+    upgrade CTA knows which tier to advertise.
+
+    Each entry::
+
+        {
+          "id":       "<feature>",         # canonical key
+          "label":    "<Display Name>",    # falls back to id
+          "tier":     "oss" | "cloud_starter" | "cloud_pro" | "enterprise",
+          "free":     True | False,        # FREE_FEATURES membership
+          "allowed":  True | False,        # entitlement allows using it
+          "locked":   True | False,        # paid + not allowed (UI shows the lock)
+          "entitled": True | False,        # grace-INDEPENDENT plan fact
+        }
+
+    Ordering: free first, then by tier rank (Starter -> Pro -> Enterprise), then
+    alphabetical inside each bucket — stable so the UI list is deterministic.
+
+    Never raises; on any resolution error every paid feature is reported as
+    ``locked=False`` (grace) to match the OSS-free fallback in
+    :func:`get_entitlement`.
+    """
+    try:
+        ent = get_entitlement()
+    except Exception as exc:  # never crash a catalog read
+        logger.warning("entitlements: feature_catalog falling back to grace: %s", exc)
+        ent = _oss_free()
+    out: list[dict] = []
+    for fid in sorted(ALL_FEATURES, key=lambda f: (_FEATURE_TIER_RANK.get(feature_tier(f), 9), f)):
+        tier = feature_tier(fid)
+        is_free = fid in FREE_FEATURES
+        allowed = ent.allows_feature(fid)
+        # Grace-independent plan fact — does the resolved tier itself grant
+        # this feature, ignoring grace bypass? Free features are always
+        # entitled; expired plans don't entitle paid features.
+        if is_free:
+            entitled = True
+        elif ent.expired:
+            entitled = False
+        else:
+            entitled = fid in ent.features
+        out.append(
+            {
+                "id": fid,
+                "label": feature_label(fid),
+                "tier": tier,
+                "free": is_free,
+                "allowed": allowed,
+                "locked": (not is_free) and (not allowed),
+                "entitled": entitled,
+            }
+        )
+    return out
 
 
 def runtime_catalog() -> list[dict]:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -113,6 +113,49 @@ def api_runtimes():
         )
 
 
+@bp_entitlement.route("/api/features")
+def api_features():
+    """Return the full feature catalog with per-feature ``free``/``allowed``/
+    ``locked`` flags + the minimum tier that unlocks each one, so the dashboard
+    can render *every* known feature in the upgrade surface — including paid
+    ones the local install does not have — and overlay a lock affordance + an
+    accurate "Requires <Tier>" CTA once enforcement is on.
+
+    Shape::
+
+        {
+          "features": [
+            {"id": "sessions",  "label": "Sessions",
+             "tier": "oss",          "free": true,  "allowed": true,
+             "locked": false, "entitled": true},
+            {"id": "self_evolve", "label": "Self-Evolve",
+             "tier": "cloud_pro",    "free": false, "allowed": true,
+             "locked": false, "entitled": false},
+            ...
+          ],
+          "grace":    true | false,   # mirrors /api/entitlement.grace
+          "enforced": true | false
+        }
+
+    Side-effect-free and never-raise: any resolution error falls back to a
+    grace OSS-free shape so the UI still has something safe to render.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "features": _ent.feature_catalog(),
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_features: falling back to OSS-free: %s", exc)
+        return jsonify({"features": [], "grace": True, "enforced": False})
+
+
 @bp_entitlement.route("/api/license/status")
 def api_license_status():
     """Return the current self-hosted license info as JSON.

--- a/tests/test_entitlements_feature_catalog.py
+++ b/tests/test_entitlements_feature_catalog.py
@@ -182,6 +182,37 @@ def test_enforce_cloud_pro_unlocks_paid_but_not_enterprise(ent, monkeypatch, tmp
         assert by_id[fid]["entitled"] is False, fid
 
 
+# ── alias flag (backwards-compat PRO_ONLY keys) ──────────────────────────────
+
+
+def test_catalog_alias_flag_marks_backcompat_pro_keys(ent):
+    """The four backwards-compat keys living inside PRO_ONLY_FEATURES carry
+    ``alias=True`` so the UI can hide them from the user-facing feature list
+    without hard-coding the ids on the frontend (where they'd drift the next
+    time the PRO_ONLY set shuffles)."""
+    by_id = {row["id"]: row for row in ent.feature_catalog()}
+    for fid in ("custom_alerts", "alert_webhooks", "anomaly_detection", "cost_optimizer"):
+        assert by_id[fid]["alias"] is True, fid
+
+
+def test_catalog_alias_flag_false_for_canonical_keys(ent):
+    """Canonical features — every tier bucket — must not be flagged as
+    aliases. Guards against an accidental membership change in
+    ``_ALIAS_FEATURES`` silently hiding a real feature from the catalog."""
+    by_id = {row["id"]: row for row in ent.feature_catalog()}
+    for fid in ent.FREE_FEATURES | ent.STARTER_FEATURES | ent.ENTERPRISE_FEATURES:
+        assert by_id[fid]["alias"] is False, fid
+    for fid in ("self_evolve", "otel_export", "custom_webhooks", "tool_policy"):
+        assert by_id[fid]["alias"] is False, fid
+
+
+def test_catalog_alias_keys_live_inside_pro_only(ent):
+    """Every alias key must exist in PRO_ONLY_FEATURES — otherwise the flag
+    advertises a row that ``allows_feature`` won't actually unlock."""
+    import clawmetry.entitlements as e
+    assert e._ALIAS_FEATURES.issubset(e.PRO_ONLY_FEATURES)
+
+
 def test_enforce_enterprise_unlocks_everything_paid(ent, monkeypatch, tmp_path):
     monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
     cache = tmp_path / ".clawmetry" / "cloud_plan.json"

--- a/tests/test_entitlements_feature_catalog.py
+++ b/tests/test_entitlements_feature_catalog.py
@@ -1,0 +1,194 @@
+"""Tests for ``feature_catalog()`` + ``feature_tier()`` + ``feature_label()``.
+
+The feature catalog is the source of truth the UI reads to render the locked-
+but-visible upgrade affordance on paid *features* — the parallel of
+``runtime_catalog()`` for the runtime switcher. These tests pin:
+
+* every feature in ``ALL_FEATURES`` has a non-empty label and a recognised tier
+* the catalog ordering is deterministic (free first, then by tier rank)
+* grace mode reports zero locked rows (zero behaviour change)
+* enforce mode locks paid rows for an OSS install and unlocks them for the
+  paid tier that grants the feature
+* unknown feature ids fall back to ``TIER_OSS`` (extension features never
+  appear mysteriously locked)
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── helper invariants ─────────────────────────────────────────────────────────
+
+
+def test_feature_label_falls_back_to_id(ent):
+    """Unknown feature -> id back (matches the runtime helper)."""
+    assert ent.feature_label("not_a_real_feature") == "not_a_real_feature"
+    assert ent.feature_label("") == ""
+
+
+def test_feature_label_strips_and_lowercases(ent):
+    assert ent.feature_label("  Sessions  ") == "Sessions"
+    assert ent.feature_label("SESSIONS") == "Sessions"
+
+
+def test_feature_tier_free(ent):
+    for fid in ent.FREE_FEATURES:
+        assert ent.feature_tier(fid) == ent.TIER_OSS, fid
+
+
+def test_feature_tier_starter(ent):
+    for fid in ent.STARTER_FEATURES:
+        assert ent.feature_tier(fid) == ent.TIER_CLOUD_STARTER, fid
+
+
+def test_feature_tier_pro(ent):
+    for fid in ent.PRO_ONLY_FEATURES:
+        assert ent.feature_tier(fid) == ent.TIER_CLOUD_PRO, fid
+
+
+def test_feature_tier_enterprise(ent):
+    for fid in ent.ENTERPRISE_FEATURES:
+        assert ent.feature_tier(fid) == ent.TIER_ENTERPRISE, fid
+
+
+def test_feature_tier_unknown_defaults_to_oss(ent):
+    """Extension features (not in any bucket) must not render as locked."""
+    assert ent.feature_tier("plugin_feature_xyz") == ent.TIER_OSS
+
+
+# ── label completeness ────────────────────────────────────────────────────────
+
+
+def test_every_known_feature_has_a_label(ent):
+    """A label gap silently regresses the upgrade copy to a raw id like
+    'per_run_waste_flags' in the UI — pin it in CI."""
+    missing = sorted(f for f in ent.ALL_FEATURES if f not in ent.FEATURE_LABELS)
+    assert not missing, f"missing FEATURE_LABELS for: {missing}"
+
+
+def test_every_label_is_non_blank(ent):
+    for fid, label in ent.FEATURE_LABELS.items():
+        assert isinstance(label, str) and label.strip(), fid
+
+
+# ── catalog shape ─────────────────────────────────────────────────────────────
+
+
+def test_catalog_covers_every_known_feature(ent):
+    catalog = ent.feature_catalog()
+    ids = {row["id"] for row in catalog}
+    assert ids == set(ent.ALL_FEATURES)
+
+
+def test_catalog_row_shape(ent):
+    """Every row carries the keys the frontend reads — defends against an
+    accidental rename breaking the upgrade surface."""
+    catalog = ent.feature_catalog()
+    assert catalog, "catalog must not be empty"
+    for row in catalog:
+        for key in ("id", "label", "tier", "free", "allowed", "locked", "entitled"):
+            assert key in row, row
+        assert isinstance(row["id"], str)
+        assert isinstance(row["label"], str) and row["label"]
+        assert row["tier"] in {
+            ent.TIER_OSS,
+            ent.TIER_CLOUD_STARTER,
+            ent.TIER_CLOUD_PRO,
+            ent.TIER_ENTERPRISE,
+        }
+        assert isinstance(row["free"], bool)
+        assert isinstance(row["allowed"], bool)
+        assert isinstance(row["locked"], bool)
+        assert isinstance(row["entitled"], bool)
+        # locked = paid-and-not-allowed; mutually exclusive with free=True.
+        if row["free"]:
+            assert row["locked"] is False, row
+            assert row["tier"] == ent.TIER_OSS, row
+
+
+def test_catalog_ordering_free_then_by_tier(ent):
+    """Free first, then Starter, then Pro, then Enterprise. Stable order so
+    the upgrade list does not reshuffle on refresh."""
+    catalog = ent.feature_catalog()
+    rank = {
+        ent.TIER_OSS: 0,
+        ent.TIER_CLOUD_STARTER: 1,
+        ent.TIER_CLOUD_PRO: 2,
+        ent.TIER_ENTERPRISE: 3,
+    }
+    ranks = [rank[row["tier"]] for row in catalog]
+    assert ranks == sorted(ranks), ranks
+
+
+# ── grace vs enforce behaviour ────────────────────────────────────────────────
+
+
+def test_grace_locks_nothing(ent):
+    """Headline invariant — grace mode keeps every row unlocked so wiring the
+    catalog into the UI changes no current behaviour."""
+    catalog = ent.feature_catalog()
+    for row in catalog:
+        assert row["allowed"] is True, row
+        assert row["locked"] is False, row
+
+
+def test_enforce_oss_locks_every_paid_feature(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    catalog = ent.feature_catalog()
+    by_id = {row["id"]: row for row in catalog}
+    for fid in ent.FREE_FEATURES:
+        assert by_id[fid]["locked"] is False, fid
+        assert by_id[fid]["allowed"] is True, fid
+    for fid in ent.STARTER_FEATURES | ent.PRO_ONLY_FEATURES | ent.ENTERPRISE_FEATURES:
+        assert by_id[fid]["locked"] is True, fid
+        assert by_id[fid]["allowed"] is False, fid
+        assert by_id[fid]["entitled"] is False, fid
+
+
+def test_enforce_cloud_pro_unlocks_paid_but_not_enterprise(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    catalog = ent.feature_catalog()
+    by_id = {row["id"]: row for row in catalog}
+    # Starter + Pro unlocked.
+    for fid in ent.STARTER_FEATURES | ent.PRO_ONLY_FEATURES:
+        assert by_id[fid]["allowed"] is True, fid
+        assert by_id[fid]["locked"] is False, fid
+        assert by_id[fid]["entitled"] is True, fid
+    # Enterprise still locked.
+    for fid in ent.ENTERPRISE_FEATURES:
+        assert by_id[fid]["allowed"] is False, fid
+        assert by_id[fid]["locked"] is True, fid
+        assert by_id[fid]["entitled"] is False, fid
+
+
+def test_enforce_enterprise_unlocks_everything_paid(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "enterprise"}))
+    ent.invalidate()
+    catalog = ent.feature_catalog()
+    for row in catalog:
+        assert row["allowed"] is True, row["id"]
+        assert row["locked"] is False, row["id"]

--- a/tests/test_routes_features.py
+++ b/tests/test_routes_features.py
@@ -1,0 +1,150 @@
+"""Tests for the ``/api/features`` endpoint (``routes/entitlement.py``).
+
+The endpoint feeds the locked-but-visible upgrade affordance on paid features
+in the dashboard — every paid feature appears in the catalog even when the
+local install does not exercise it, with ``locked`` set from the resolved
+entitlement and ``tier`` set to the minimum tier that unlocks it (so the CTA
+can read "Requires Starter" / "Requires Pro" / "Requires Enterprise"
+verbatim from the API).
+
+Headline invariant: in GRACE mode (the default) every catalog row reports
+``locked=False`` so the UI behaves exactly as it did before this endpoint
+existed. ``CLAWMETRY_ENFORCE=1`` flips the paid rows to ``locked=True`` for an
+OSS install.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client wired with bp_entitlement against a clean HOME."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_features_endpoint_returns_200(client):
+    resp = client.get("/api/features")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "features" in data
+    assert "grace" in data
+    assert "enforced" in data
+    assert isinstance(data["features"], list)
+    assert data["features"], "feature catalog should never be empty"
+
+
+def test_features_row_shape_is_stable(client):
+    data = client.get("/api/features").get_json()
+    for row in data["features"]:
+        for key in ("id", "label", "tier", "free", "allowed", "locked", "entitled"):
+            assert key in row, row
+        assert isinstance(row["id"], str)
+        assert isinstance(row["label"], str)
+        assert isinstance(row["free"], bool)
+        assert isinstance(row["allowed"], bool)
+        assert isinstance(row["locked"], bool)
+        assert isinstance(row["entitled"], bool)
+        assert row["tier"] in {"oss", "cloud_starter", "cloud_pro", "enterprise"}
+        if row["free"]:
+            assert row["locked"] is False, row
+            assert row["tier"] == "oss", row
+
+
+def test_features_grace_locks_nothing(client):
+    data = client.get("/api/features").get_json()
+    assert data["grace"] is True
+    assert data["enforced"] is False
+    for row in data["features"]:
+        assert row["locked"] is False, row
+
+
+def test_features_grace_enforced_are_inverse(client):
+    data = client.get("/api/features").get_json()
+    assert data["grace"] == (not data["enforced"])
+
+
+# ── enforce mode ─────────────────────────────────────────────────────────────
+
+
+def test_features_enforced_oss_locks_paid(monkeypatch, tmp_path):
+    """When CLAWMETRY_ENFORCE=1 and no license/cloud plan is present every
+    paid feature is reported locked — the UI uses this to render the 🔒
+    affordance on features the OSS install cannot exercise."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    data = app.test_client().get("/api/features").get_json()
+
+    assert data["enforced"] is True
+    assert data["grace"] is False
+    by_id = {row["id"]: row for row in data["features"]}
+    # Free stays free.
+    assert by_id["sessions"]["locked"] is False
+    assert by_id["sessions"]["tier"] == "oss"
+    # Starter locked at OSS.
+    assert by_id["multi_runtime"]["locked"] is True
+    assert by_id["multi_runtime"]["tier"] == "cloud_starter"
+    # Pro locked at OSS.
+    assert by_id["self_evolve"]["locked"] is True
+    assert by_id["self_evolve"]["tier"] == "cloud_pro"
+    # Enterprise locked at OSS.
+    assert by_id["sso"]["locked"] is True
+    assert by_id["sso"]["tier"] == "enterprise"
+
+
+def test_features_cloud_pro_unlocks_pro_keeps_enterprise_locked(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    data = app.test_client().get("/api/features").get_json()
+    by_id = {row["id"]: row for row in data["features"]}
+    assert by_id["multi_runtime"]["locked"] is False
+    assert by_id["self_evolve"]["locked"] is False
+    assert by_id["siem_export"]["locked"] is True
+
+
+def test_features_ordering_deterministic(client):
+    """Two consecutive reads return the same id ordering — the upgrade list
+    must not reshuffle on refresh."""
+    a = [row["id"] for row in client.get("/api/features").get_json()["features"]]
+    b = [row["id"] for row in client.get("/api/features").get_json()["features"]]
+    assert a == b


### PR DESCRIPTION
## Summary

Adds the **feature-side parallel** of `runtime_catalog()` / `/api/runtimes` so the dashboard can render the locked-but-visible upgrade affordance on paid *features* the same way it already does for paid runtimes, with an accurate "Requires &lt;Tier&gt;" CTA driven from the API.

Today the entitlement surface exposes a rich runtime catalogue (`runtime_catalog()`, `GET /api/runtimes`) and per-runtime helpers, but the feature side only ships sets (`FREE_FEATURES`, `STARTER_FEATURES`, `PRO_ONLY_FEATURES`, `ENTERPRISE_FEATURES`) and the `allows_feature()` check. The UI has no single place to read "every known feature + which tier unlocks it + is it locked here", so the upgrade copy has to hard-code the bucket on the frontend.

### What's in this PR

**`clawmetry/entitlements.py`**

- `FEATURE_LABELS` — display strings for every key in `ALL_FEATURES`, mirrors `RUNTIME_LABELS`.
- `feature_label(id)` — id → display string with a graceful id fallback (matches the runtime helper, so plugin/extension features still render with *something*).
- `feature_tier(id)` — id → minimum tier code that unlocks it (`oss` / `cloud_starter` / `cloud_pro` / `enterprise`). Unknown ids resolve to `TIER_OSS` so extension/plugin features never appear mysteriously locked.
- `feature_catalog()` — `[{id, label, tier, free, allowed, locked, entitled}, …]` for every known feature, ordered free-first then by tier rank then alphabetical (deterministic so the upgrade list does not reshuffle on refresh). Never raises; on resolution error every paid row is reported as `locked=False` (grace).

**`routes/entitlement.py`**

- `GET /api/features` on `bp_entitlement` — shape parallel to `/api/runtimes`:
  ```json
  {
    "features": [
      {"id": "sessions",    "label": "Sessions",    "tier": "oss",
       "free": true,  "allowed": true,  "locked": false, "entitled": true},
      {"id": "self_evolve", "label": "Self-Evolve", "tier": "cloud_pro",
       "free": false, "allowed": true,  "locked": false, "entitled": false}
    ],
    "grace": true,
    "enforced": false
  }
  ```
  Side-effect-free and never-raise; falls back to a grace OSS-free shape on any error.

**Tests**

- `tests/test_entitlements_feature_catalog.py` — helper invariants, label completeness (every `ALL_FEATURES` key has a non-empty label), tier pinning per bucket, catalog shape + ordering, grace mode locks nothing, enforce mode locks the right rows at OSS / `cloud_pro` / `enterprise`.
- `tests/test_routes_features.py` — endpoint shape, grace/enforced inverse, deterministic ordering, per-tier lock state at OSS and `cloud_pro`.

23 new tests; the related existing suites (`test_entitlements*.py`, `test_routes_runtimes.py`) all still pass.

### Why this is safe

Purely additive and grace-safe. In the default grace mode every row reports `locked=False`, so wiring this into the UI changes **no current behaviour**. Nothing in this PR touches `__version__`, the resolution path, or the existing `allows_*` semantics — the new helpers route through `get_entitlement()` and use the same `FREE_FEATURES`/`STARTER_FEATURES`/`PRO_ONLY_FEATURES`/`ENTERPRISE_FEATURES` constants the rest of the module reads from.

### Test plan

- [x] `python -m pytest tests/test_entitlements_feature_catalog.py tests/test_routes_features.py -q` — 23 passed
- [x] Regression: `python -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_routes_runtimes.py tests/test_entitlements_catalogue.py -q` — 48 passed
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlements_feature_catalog.py tests/test_routes_features.py` — clean
- [x] `python -m py_compile` on every changed file — clean

### Local operator verification checklist

Operator must verify on the live daemon + cloud snapshot since the remote runner has no access to `~/.openclaw`, the running daemon, or the browser:

- [ ] Copy the changed files into the live install:
  - `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/entitlements.py`
  - `cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/entitlement.py`
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Reload the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s http://localhost:8900/api/features | jq '.features | length, (.[] | select(.id=="self_evolve"))'` — non-zero count, `self_evolve` row has `tier=="cloud_pro"`, `free==false`.
- [ ] `curl -s http://localhost:8900/api/features | jq '.grace, .enforced'` — `true, false` (grace mode unchanged).
- [ ] `CLAWMETRY_ENFORCE=1` smoke: relaunch the daemon with the env var, hit `/api/features`, confirm every paid row reports `locked=true` for an OSS install, then revert.
- [ ] Browser sanity at `http://localhost:8900/` — no console errors, no behaviour delta (grace).
- [ ] Decrypt the live snapshot once the cloud relay has picked up the next heartbeat — confirm the dashboard's upgrade surface still reads correctly with the new payload available client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4JhA93NQLeNTsmQkHUte2)_