### PR TITLE
feat(frontend): extract animation tokens to motion.css + add missing utilities

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles.css";
+import "./styles/motion.css";
 
 // /v2/ is the SPA root (matches vite.config.ts `base` + Flask blueprint mount).
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -273,21 +273,6 @@
 .ab *::-webkit-scrollbar { display: none; }
 .ab * { scrollbar-width: none; }
 
-/* animation tokens */
-@keyframes cm-blink { 0%,80%,100%{opacity:1} 40%{opacity:.2} }
-@keyframes cm-sweep { 0%{transform:rotate(0)} 100%{transform:rotate(360deg)} }
-@keyframes cm-pulse { 0%,100%{opacity:.4;transform:scale(1)} 50%{opacity:1;transform:scale(1.05)} }
-@keyframes cm-trail { 0%{stroke-dashoffset:200} 100%{stroke-dashoffset:0} }
-
-.cm-blink { animation: cm-blink 1.4s infinite; }
-.cm-pulse { animation: cm-pulse 1.8s ease-in-out infinite; } 
-
-.cm-ecg path {
-  stroke-dasharray: 200;
-  stroke-dashoffset: 200;
-  animation: cm-trail 1.4s linear infinite;
-}
-
 /* metaphor frame variants — wraps the featured dashboard */
 .metaphor-hood {
   background:

--- a/frontend/src/styles/motion.css
+++ b/frontend/src/styles/motion.css
@@ -1,0 +1,27 @@
+/* animation tokens — extracted from styles.css so consumers can import
+   only what they need and the keyframes live in one canonical place. */
+
+/* ── keyframes ─────────────────────────────────────────────────────── */
+@keyframes cm-blink { 0%,80%,100%{opacity:1} 40%{opacity:.2} }
+@keyframes cm-sweep { 0%{transform:rotate(0)} 100%{transform:rotate(360deg)} }
+@keyframes cm-pulse { 0%,100%{opacity:.4;transform:scale(1)} 50%{opacity:1;transform:scale(1.05)} }
+@keyframes cm-trail { 0%{stroke-dashoffset:200} 100%{stroke-dashoffset:0} }
+@keyframes cm-bounce {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.18); }
+  70%  { transform: scale(0.94); }
+  88%  { transform: scale(1.04); }
+  100% { transform: scale(1); }
+}
+
+/* ── utility classes ───────────────────────────────────────────────── */
+.cm-blink { animation: cm-blink 1.4s infinite; }
+.cm-pulse { animation: cm-pulse 1.8s ease-in-out infinite; }
+.cm-sonar { animation: cm-sweep 4s linear infinite; }
+.cm-bounce { animation: cm-bounce 0.45s cubic-bezier(0.36, 0.07, 0.19, 0.97) both; }
+
+.cm-ecg path {
+  stroke-dasharray: 200;
+  stroke-dashoffset: 200;
+  animation: cm-trail 1.4s linear infinite;
+}


### PR DESCRIPTION
Partially addresses #1519 (animation token centralization sub-task only).

## What changed

- Extracted the four `@keyframes` (`cm-blink`, `cm-sweep`, `cm-pulse`, `cm-trail`) and their utility classes from `styles.css` into a new `frontend/src/styles/motion.css`
- Added two utilities that were in the design spec but missing from the codebase:
  - `.cm-sonar { animation: cm-sweep 4s linear infinite; }` — the sonar-sweep rotate used by live-signal elements
  - `@keyframes cm-bounce` + `.cm-bounce` — cubic-bezier overshoot spring for approval/action interaction feedback
- `main.tsx` imports the new file; `styles.css` no longer owns animation concerns

## What this does NOT touch

- Dark-theme audit (needs RFC-v2-003 sign-off)
- `--v2-default` flag flip (gated on i18n parity per maintainer comment)
- Empty/error/loading states (larger diff, needs copy sign-off)
- v1 legacy cleanup (blocked on traffic telemetry)

## Test plan

- [ ] `npm run dev` in `frontend/` → all existing animations (`cm-blink`, `cm-pulse`, `.cm-ecg`) still render correctly
- [ ] Add `class="cm-sonar"` to any rotating element → confirm 4s rotation
- [ ] Add `class="cm-bounce"` to any element and trigger → confirm overshoot spring plays once
- [ ] No visual regressions on any v2 tab (Layout, Sidebar, Topbar chrome unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CN6G1u3UfW96KTPn3oS4P7)_