### PR TITLE
fix(autoupdate): install the newest aged-in release, not the absolute latest

### DIFF
--- a/routes/meta.py
+++ b/routes/meta.py
@@ -351,7 +351,8 @@ def api_version():
     return {"current": current, "latest": latest, "update_available": update_available}
 
 
-def perform_self_update(reason: str = "manual", restart: bool = True):
+def perform_self_update(reason: str = "manual", restart: bool = True,
+                        target_version=None):
     """Core self-update: ``pip install -U clawmetry`` then schedule a process
     restart. Returns ``(payload_dict, http_status)``.
 
@@ -363,6 +364,11 @@ def perform_self_update(reason: str = "manual", restart: bool = True):
     ``restart=False`` installs the new wheel but does NOT exit the process —
     the auto-updater uses it for an unsupervised daemon (nothing would
     respawn it); the new version applies on the next start.
+
+    ``target_version`` pins the install to a specific version (e.g.
+    ``clawmetry==0.12.510``). The auto-updater passes the newest aged-in
+    release here so it never jumps to a too-fresh absolute latest; a manual
+    update leaves it None and takes the absolute latest.
     """
     import dashboard as _d
     import subprocess as _sp
@@ -371,7 +377,8 @@ def perform_self_update(reason: str = "manual", restart: bool = True):
 
     _ulog = _log.getLogger(__name__)
     old_version = _d.__version__
-    _ulog.info("self-update (%s): pip install -U clawmetry from v%s", reason, old_version)
+    _pip_spec = ("clawmetry==" + str(target_version)) if target_version else "clawmetry"
+    _ulog.info("self-update (%s): pip install -U %s from v%s", reason, _pip_spec, old_version)
     py = sys.executable
     # Bootstrap pip via the stdlib's ensurepip first. The daemon's venv at
     # ~/.clawmetry/bin/python3 is provisioned WITHOUT pip by uv-style
@@ -394,7 +401,7 @@ def perform_self_update(reason: str = "manual", restart: bool = True):
             # --no-cache-dir dodges the uv-cache-stale-after-[RELEASE] race
             # (see feedback_uv_cache_stale_after_release.md): a fresh PyPI
             # publish is sometimes shadowed by uv's "already at latest" cache.
-            [py, "-m", "pip", "install", "--upgrade", "--no-cache-dir", "clawmetry"],
+            [py, "-m", "pip", "install", "--upgrade", "--no-cache-dir", _pip_spec],
             timeout=180, capture_output=True, text=True,
         )
         if proc.returncode != 0:

--- a/routes/update_check.py
+++ b/routes/update_check.py
@@ -256,6 +256,56 @@ def _should_show_update_banner(config, latest_check):
     return True
 
 
+def _autoupdate_min_age_hours() -> float:
+    """Stability window (hours) a release must survive on PyPI before the
+    daemon will silently install it. Env override:
+    ``CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS`` (default 48)."""
+    try:
+        return float(os.environ.get("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", "48") or 48)
+    except Exception:
+        return 48.0
+
+
+def _newest_aged_in_version(releases, current, min_age_hours):
+    """Newest published version greater than ``current`` whose files have all
+    been on PyPI at least ``min_age_hours`` (the stability window). Returns the
+    version string, or None if nothing newer has aged in yet.
+
+    The unattended auto-updater installs THIS, not the absolute latest. During
+    an active release run (many publishes less than the window apart) the
+    absolute latest is always too fresh; gating on it alone meant a node never
+    saw an installable target and stayed stuck on an old build indefinitely.
+    Targeting the newest aged-in release keeps the fleet at
+    latest-minus-window instead of frozen. (Burned 2026-06-13: a 2-day release
+    spree left every version under 48h old, so daemons never auto-updated.)
+    """
+    from datetime import datetime as _dt, timezone as _tz
+    _now = _dt.now(_tz.utc)
+    best = None
+    for ver, files in (releases or {}).items():
+        if not _version_gt(ver, current):
+            continue
+        if best is not None and not _version_gt(ver, best):
+            continue  # already have a newer candidate; skip the age cost
+        times = [
+            f.get("upload_time_iso_8601") or f.get("upload_time")
+            for f in (files or [])
+            if f.get("upload_time_iso_8601") or f.get("upload_time")
+        ]
+        if not times:
+            continue
+        try:
+            t0 = min(_dt.fromisoformat(str(t).replace("Z", "+00:00")) for t in times)
+            if t0.tzinfo is None:
+                t0 = t0.replace(tzinfo=_tz.utc)
+        except Exception:
+            continue
+        if (_now - t0).total_seconds() / 3600.0 < min_age_hours:
+            continue
+        best = ver
+    return best
+
+
 def _check_for_update():
     """Check PyPI for the latest version and record the result."""
     import dashboard as _d
@@ -281,35 +331,20 @@ def _check_for_update():
 
     _record_update_check(current, latest, update_available, CHANGELOG_URL)
 
-    # Age (hours) of the latest release, for the auto-update staleness rail.
-    # NEVER blocks the banner — only the silent upgrade waits for the release
-    # to have survived a stability window before installing it unattended.
-    _age_h = None
-    try:
-        _files = (data.get("releases", {}) or {}).get(latest) or []
-        _times = [
-            f.get("upload_time_iso_8601") or f.get("upload_time")
-            for f in _files
-            if f.get("upload_time_iso_8601") or f.get("upload_time")
-        ]
-        if _times:
-            from datetime import datetime as _dt, timezone as _tz
-            _t0 = min(
-                _dt.fromisoformat(str(t).replace("Z", "+00:00")) for t in _times
-            )
-            if _t0.tzinfo is None:
-                _t0 = _t0.replace(tzinfo=_tz.utc)
-            _age_h = (_dt.now(_tz.utc) - _t0).total_seconds() / 3600.0
-    except Exception:
-        _age_h = None
-
-    # Auto-update: install the newer release unattended (default-on for the
-    # supervised sync daemon; opt-in for the dashboard process — see
-    # _maybe_auto_update for the full rail set). Guarded so a pending
-    # restart isn't re-triggered.
+    # Auto-update target: the NEWEST published version above `current` that has
+    # aged past the stability window (see _newest_aged_in_version). NOT the
+    # absolute `latest` — during an active release run the absolute latest is
+    # perpetually too fresh, so gating the silent install on it alone strands
+    # every node on an ancient build forever. The banner still advertises the
+    # absolute `latest` (above); only the unattended install targets the aged
+    # release, keeping the fleet at latest-minus-stability-window.
     if update_available:
         try:
-            _maybe_auto_update(current, latest, _age_h)
+            _target = _newest_aged_in_version(
+                data.get("releases", {}), current, _autoupdate_min_age_hours()
+            )
+            if _target and _version_gt(_target, current):
+                _maybe_auto_update(current, _target, latest)
         except Exception as exc:
             log.warning("auto-update trigger failed: %s", exc)
 
@@ -327,14 +362,16 @@ def _check_for_update():
 _auto_update_in_progress = False
 
 
-def _maybe_auto_update(current, latest, age_hours=None):
-    """Install a newer release automatically when ``auto_update`` is enabled.
+def _maybe_auto_update(current, target, latest=None):
+    """Install ``target`` (the newest aged-in release, chosen by
+    ``_newest_aged_in_version``) automatically when ``auto_update`` is enabled.
 
-    Staleness rail: unattended upgrades wait until the release has been on PyPI
-    for at least ``CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS`` (default 48h), so a node
-    never auto-installs a brand-new (possibly broken) release the instant it
-    publishes. The update banner is unaffected — only the silent upgrade waits.
-    ``age_hours=None`` (age unknown) does not block, preserving prior behaviour.
+    The stability-window rail is applied during target SELECTION, not here, so
+    by the time we are called ``target`` is already known to have survived the
+    window. ``target`` is a specific version (e.g. installing 0.12.510 even
+    when 0.12.518 is the absolute ``latest`` but still too fresh), so the fleet
+    keeps moving forward during active releases instead of freezing on an old
+    build.
     """
     global _auto_update_in_progress
     if _auto_update_in_progress:
@@ -350,14 +387,7 @@ def _maybe_auto_update(current, latest, age_hours=None):
     # pip-install + exit underneath the user unless they explicitly opted in.
     if _process_role != "daemon" and not _auto_update_explicitly_set():
         return
-    try:
-        import os as _os
-        _min_age = float(_os.environ.get("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", "48") or 48)
-    except Exception:
-        _min_age = 48.0
-    if age_hours is not None and age_hours < _min_age:
-        log.info("auto-update: holding v%s (released %.1fh ago < %.0fh stability "
-                 "window) — will install once it ages in", latest, age_hours, _min_age)
+    if not target or not _version_gt(target, current):
         return
     # An UNSUPERVISED daemon (no launchd plist / systemd unit — e.g. a manual
     # `python -m clawmetry.sync` or Windows) still installs the new wheel but
@@ -367,11 +397,12 @@ def _maybe_auto_update(current, latest, age_hours=None):
     if _process_role == "daemon" and not _daemon_supervised():
         restart = False
     _auto_update_in_progress = True
-    log.info("auto-update: upgrading clawmetry v%s -> v%s (restart=%s)",
-             current, latest, restart)
+    log.info("auto-update: upgrading clawmetry v%s -> v%s (latest available v%s, "
+             "restart=%s)", current, target, latest or target, restart)
     try:
         from routes.meta import perform_self_update
-        payload, _status = perform_self_update(reason="auto", restart=restart)
+        payload, _status = perform_self_update(
+            reason="auto", restart=restart, target_version=target)
         if not (isinstance(payload, dict) and payload.get("ok")):
             log.warning("auto-update: upgrade failed, will retry next check: %s", payload)
             _auto_update_in_progress = False  # allow retry; no restart was scheduled

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -27,7 +27,7 @@ def _as_daemon(uc, monkeypatch):
 def _mock_self_update(monkeypatch, calls, ok=True, restarts=None):
     import routes.meta as meta
 
-    def _fake(reason="manual", restart=True):
+    def _fake(reason="manual", restart=True, target_version=None):
         calls.append(reason)
         if restarts is not None:
             restarts.append(restart)
@@ -85,29 +85,37 @@ def test_auto_update_in_allowed_config_keys(monkeypatch):
     assert captured == {"auto_update": True}, "auto_update must pass the allow-list, bogus keys filtered"
 
 
-def test_auto_update_holds_fresh_release(monkeypatch):
+def test_auto_update_installs_given_target(monkeypatch):
+    """The stability-window rail now lives in target SELECTION
+    (_newest_aged_in_version, covered in test_autoupdate_newest_aged.py). Once a
+    concrete aged-in ``target`` reaches _maybe_auto_update, it installs it and
+    passes it through to perform_self_update as ``target_version``."""
+    uc = _uc()
+    _as_daemon(uc, monkeypatch)
+    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
+    import routes.meta as meta
+    seen = {}
+
+    def _fake(reason="manual", restart=True, target_version=None):
+        seen["reason"] = reason
+        seen["target"] = target_version
+        return ({"ok": True}, 200)
+
+    monkeypatch.setattr(meta, "perform_self_update", _fake)
+    uc._maybe_auto_update("0.12.1", "0.12.10", latest="0.12.18")
+    assert seen == {"reason": "auto", "target": "0.12.10"}, \
+        "must install the chosen aged-in target, pinned via target_version"
+
+
+def test_auto_update_ignores_target_not_newer(monkeypatch):
+    """A target equal to or older than current is a no-op (defensive)."""
     uc = _uc()
     _as_daemon(uc, monkeypatch)
     calls = []
     _mock_self_update(monkeypatch, calls)
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
-    monkeypatch.setenv("CLAWMETRY_AUTOUPDATE_MIN_AGE_HOURS", "48")
-    # 2h-old release → held (too fresh)
-    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=2.0)
-    assert calls == [], "must hold a release younger than the stability window"
-    # 72h-old release → installs
-    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=72.0)
-    assert calls == ["auto"], "must install once the release has aged in"
-
-
-def test_auto_update_unknown_age_does_not_block(monkeypatch):
-    uc = _uc()
-    _as_daemon(uc, monkeypatch)
-    calls = []
-    _mock_self_update(monkeypatch, calls)
-    monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
-    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=None)
-    assert calls == ["auto"], "unknown age must not block (back-compat)"
+    uc._maybe_auto_update("0.12.10", "0.12.10")
+    assert calls == [], "must not upgrade to the same (or an older) version"
 
 
 # ── Default-on policy + rails (0.12.494) ────────────────────────────────────
@@ -145,7 +153,7 @@ def test_env_kill_switch_blocks_auto_update(monkeypatch):
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     calls = []
     _mock_self_update(monkeypatch, calls)
-    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
     assert calls == [], "CLAWMETRY_AUTO_UPDATE=0 must hard-disable auto-update"
 
 
@@ -160,11 +168,11 @@ def test_dashboard_role_requires_explicit_opt_in(monkeypatch):
     _mock_self_update(monkeypatch, calls)
     # Default True but NOT explicitly stored → dashboard must not act.
     monkeypatch.setattr(uc, "_auto_update_explicitly_set", lambda: False)
-    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
     assert calls == [], "dashboard role must ignore the default-on policy"
     # Explicit user opt-in → dashboard acts (pre-existing behaviour kept).
     monkeypatch.setattr(uc, "_auto_update_explicitly_set", lambda: True)
-    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
     assert calls == ["auto"], "explicit opt-in must still work in the dashboard"
 
 
@@ -178,7 +186,7 @@ def test_unsupervised_daemon_defers_restart(monkeypatch):
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     calls, restarts = [], []
     _mock_self_update(monkeypatch, calls, restarts=restarts)
-    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
     assert calls == ["auto"]
     assert restarts == [False], "unsupervised daemon must defer the restart"
 
@@ -189,7 +197,7 @@ def test_supervised_daemon_restarts(monkeypatch):
     monkeypatch.setattr(uc, "_get_update_check_config", lambda: {"auto_update": True})
     calls, restarts = [], []
     _mock_self_update(monkeypatch, calls, restarts=restarts)
-    uc._maybe_auto_update("0.12.1", "0.12.2", age_hours=999)
+    uc._maybe_auto_update("0.12.1", "0.12.2")
     assert calls == ["auto"]
     assert restarts == [True], "supervised daemon restarts to apply the wheel"
 

--- a/tests/test_autoupdate_newest_aged.py
+++ b/tests/test_autoupdate_newest_aged.py
@@ -1,0 +1,59 @@
+"""Auto-update must target the newest AGED-IN release, not the absolute latest.
+
+Burned 2026-06-13: a dense release run left every published version younger
+than the 48h stability window, so the old rail (gate the install on the
+absolute latest's age) found no installable target and left daemons stuck on
+an ancient build indefinitely. The fix selects the newest version above the
+current build that has aged past the window, so the fleet keeps moving forward.
+"""
+from datetime import datetime, timezone, timedelta
+
+from routes.update_check import _newest_aged_in_version
+
+
+def _iso(hours_ago):
+    return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat().replace("+00:00", "Z")
+
+
+def _releases(spec):
+    """spec: {version: hours_ago}. None hours_ago => no upload time."""
+    out = {}
+    for ver, ago in spec.items():
+        out[ver] = [] if ago is None else [{"upload_time_iso_8601": _iso(ago)}]
+    return out
+
+
+def test_picks_newest_aged_in_not_absolute_latest():
+    # current 0.12.504. 509 (72h) and 510 (50h) have aged in; 517/518 are fresh.
+    rel = _releases({
+        "0.12.504": 200, "0.12.509": 72, "0.12.510": 50,
+        "0.12.517": 20, "0.12.518": 3,
+    })
+    # Absolute latest is 0.12.518 (3h) but it is too fresh; install 0.12.510.
+    assert _newest_aged_in_version(rel, "0.12.504", 48) == "0.12.510"
+
+
+def test_none_when_everything_too_fresh():
+    # The real 2026-06-13 shape: every version above current is < 48h old.
+    rel = _releases({
+        "0.12.504": 200, "0.12.509": 44, "0.12.514": 21, "0.12.518": 3,
+    })
+    assert _newest_aged_in_version(rel, "0.12.504", 48) is None
+
+
+def test_ignores_versions_at_or_below_current():
+    rel = _releases({"0.12.504": 200, "0.12.503": 300, "0.12.510": 60})
+    assert _newest_aged_in_version(rel, "0.12.504", 48) == "0.12.510"
+
+
+def test_skips_versions_without_upload_time():
+    rel = _releases({"0.12.504": 200, "0.12.510": None, "0.12.509": 60})
+    # 510 has no timestamp so it cannot be confirmed aged-in; fall back to 509.
+    assert _newest_aged_in_version(rel, "0.12.504", 48) == "0.12.509"
+
+
+def test_lower_window_makes_more_installable():
+    rel = _releases({"0.12.504": 200, "0.12.514": 21, "0.12.518": 3})
+    assert _newest_aged_in_version(rel, "0.12.504", 48) is None
+    # A 12h window lets the 21h-old 0.12.514 in (3h-old 518 still too fresh).
+    assert _newest_aged_in_version(rel, "0.12.504", 12) == "0.12.514"


### PR DESCRIPTION
## Why
The daemon auto-update has been silently broken during active development. `_maybe_auto_update` gated the unattended install on the ABSOLUTE latest version's age vs a 48h stability window. During a dense release run (we shipped 0.12.505 to 0.12.518 in ~2 days) the absolute latest is ALWAYS younger than 48h, so the daemon found no installable target and held every time, leaving nodes stuck on an ancient build. The founder's node sat on 0.12.504 while PyPI was at 0.12.518; this matches the known fleet audit (92% of active nodes months-stale, every shipped fix reaching almost nobody).

## What
Select the **newest version above current that has aged past the window** (`_newest_aged_in_version`) and install that specific version (`perform_self_update(target_version=...)` pins `clawmetry==<aged>`). The fleet now tracks latest-minus-stability-window and keeps moving forward during active releases, instead of freezing. The update banner still advertises the absolute latest; only the silent install targets the aged release. Window stays 48h, env-overridable.

## Verify
- New `tests/test_autoupdate_newest_aged.py`: picks newest aged-in (not fresh latest), None when all too fresh, ignores no-timestamp + at-or-below-current, lower window installs more. **Revert-proven** (breaking the age check makes the selection tests fail).
- `test_auto_update.py` updated to the new signature (age-gating moved to selection); the env-kill-switch / role / restart / retry gating tests all still pass. 26 green on Python 3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)