### PR TITLE
feat(entitlement): surface retention_days on to_dict() + /api/entitlement

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -295,6 +295,12 @@ class Entitlement:
         return _TIER_RETENTION_DAYS.get(self.tier, 7)
 
     def to_dict(self) -> dict:
+        # ``retention_days`` mirrors :meth:`event_retention_days` so the
+        # dashboard can render a tier-aware "we are keeping N days of history"
+        # banner (and an Enterprise "unlimited / custom" pill when ``None``)
+        # without re-deriving the per-tier table client-side. The daemon's
+        # prune loop in ``clawmetry/sync.py`` still reads the method directly;
+        # this is just the read-only API surface.
         return {
             "tier": self.tier,
             "source": self.source,
@@ -304,6 +310,7 @@ class Entitlement:
             "is_paid": self.is_paid,
             "grace": self.grace,
             "enforced": not self.grace,
+            "retention_days": self.event_retention_days(),
             "runtimes": sorted(self.runtimes),
             "features": sorted(self.features),
             "free_runtimes": sorted(FREE_RUNTIMES),

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -47,6 +47,7 @@ def api_entitlement():
                 "is_paid": False,
                 "grace": True,
                 "enforced": False,
+                "retention_days": 7,
                 "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
             }

--- a/tests/test_entitlement_api.py
+++ b/tests/test_entitlement_api.py
@@ -41,11 +41,53 @@ def test_api_entitlement_shape_grace(client):
     assert resp.status_code == 200
     d = resp.get_json()
     for key in ("tier", "source", "grace", "enforced", "is_paid",
-                "runtimes", "features", "all_runtimes"):
+                "retention_days", "runtimes", "features", "all_runtimes"):
         assert key in d, key
     assert isinstance(d["runtimes"], list)
     assert isinstance(d["features"], list)
     assert isinstance(d["all_runtimes"], list)
+
+
+@pytest.mark.parametrize(
+    "plan,expected",
+    [
+        ("cloud_starter", 30),
+        ("cloud_pro", 90),
+        ("enterprise", None),
+    ],
+)
+def test_api_entitlement_retention_days_matches_tier(monkeypatch, tmp_path, plan, expected):
+    """``/api/entitlement`` carries the per-tier retention cap so the
+    dashboard can render "we are keeping N days" without re-deriving the
+    table client-side. Enterprise comes back as JSON ``null`` (= unlimited /
+    custom). Pinned alongside the in-process ``to_dict`` test so an accidental
+    desync between the method, the dict, and the HTTP shape fails loudly."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": plan, "node_limit": 1, "expiry": None}))
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement").get_json()
+
+    assert d["tier"] == plan
+    assert d["retention_days"] == expected
+
+
+def test_api_entitlement_retention_days_oss_default(client):
+    """OSS-free surfaces ``retention_days == 7`` — the same value the
+    never-raise fallback hard-codes, so a resolver failure can't silently
+    flip the surfaced cap."""
+    c, _ = client
+    d = c.get("/api/entitlement").get_json()
+    assert d["retention_days"] == 7
 
 
 def test_api_entitlement_grace_defaults(client):

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -139,10 +139,46 @@ def test_corrupt_cloud_plan_falls_back_to_oss(ent, tmp_path):
 
 def test_to_dict_shape(ent):
     d = ent.get_entitlement(force=True).to_dict()
-    for key in ("tier", "source", "grace", "enforced", "runtimes", "features", "all_runtimes"):
+    for key in ("tier", "source", "grace", "enforced", "retention_days",
+                "runtimes", "features", "all_runtimes"):
         assert key in d
     assert d["enforced"] == (not d["grace"])
     assert isinstance(d["runtimes"], list)
+
+
+def test_to_dict_retention_days_oss_is_seven(ent):
+    """OSS-free surfaces the 7-day retention cap so the UI can render it."""
+    d = ent.get_entitlement(force=True).to_dict()
+    assert d["retention_days"] == 7
+
+
+@pytest.mark.parametrize(
+    "plan,expected",
+    [
+        ("cloud_free", 7),
+        ("cloud_starter", 30),
+        ("trial", 30),
+        ("cloud_pro", 90),
+        ("pro", 90),
+        ("enterprise", None),
+    ],
+)
+def test_to_dict_retention_days_matches_tier(ent, monkeypatch, tmp_path, plan, expected):
+    """Every tier surfaces its retention cap through ``to_dict()`` — and
+    Enterprise's "unlimited / custom" reads as ``None`` (JSON ``null``) so the
+    UI can render the special-case copy instead of a number.
+
+    Mirrors the per-tier values in ``_TIER_RETENTION_DAYS`` (see also
+    ``tests/test_entitlements_catalogue.py``). Pinning this here means a
+    silent retention-cap change in the table now breaks the API contract too,
+    not just the method.
+    """
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": plan, "node_limit": 1, "expiry": None}))
+    d = ent.get_entitlement(force=True).to_dict()
+    assert d["tier"] == plan
+    assert d["retention_days"] == expected
 
 
 # ── runtime_catalog (Phase 5: locked-but-visible foundation) ────────────────


### PR DESCRIPTION
## Summary

`Entitlement.event_retention_days()` already returns the per-tier event retention cap (OSS=7, Starter/Trial=30, Pro=90, Enterprise=`None`). The daemon's prune loop in `clawmetry/sync.py` and the proxy's `prune_old_data()` both read it. But the value is **not** exposed through `to_dict()`, so the dashboard cannot render a tier-aware "we are keeping N days of history" pill without duplicating the per-tier table client-side.

This PR surfaces it on the API.

## Changes

- **`clawmetry/entitlements.py`** — `Entitlement.to_dict()` now includes a `retention_days` field, sourced directly from `event_retention_days()`. `None` (Enterprise's "unlimited / custom") round-trips as JSON `null` so the UI can render the special-case copy instead of a number.
- **`routes/entitlement.py`** — the never-raise OSS-free fallback in `api_entitlement` hard-codes `retention_days: 7` to match the OSS tier value, so a resolver failure can't silently flip the surfaced cap.
- **`tests/test_entitlements.py`** — adds `retention_days` to the `to_dict_shape` check, plus a parametrised test pinning the cap for `cloud_free`, `cloud_starter`, `trial`, `cloud_pro`, `pro`, `enterprise`. Mirrors `tests/test_entitlements_catalogue.py` so a silent retention-cap change in `_TIER_RETENTION_DAYS` now breaks the API contract too.
- **`tests/test_entitlement_api.py`** — `retention_days` added to the shape check, plus a parametrised test confirming `/api/entitlement` carries the correct cap under `cloud_starter` (30), `cloud_pro` (90), `enterprise` (`null`), and an OSS test pinning the fallback to 7.

## Response shape (no breaking change — purely additive)

```jsonc
GET /api/entitlement
{
  "tier": "oss",
  "source": "oss",
  "node_limit": 1,
  "expiry": null,
  "expired": false,
  "is_paid": false,
  "grace": true,
  "enforced": false,
  "retention_days": 7,          // NEW — null on enterprise
  "runtimes": ["nemoclaw", "openclaw"],
  "features": [...]
}
```

## No behaviour change

Read-only API surface addition. Grace mode preserved end-to-end. No `__version__` bump, no `[RELEASE]` PR, no enforcement gate flip. The daemon prune loop still calls `event_retention_days()` directly — it does not read this field — so the operational pipeline is unchanged.

## Test plan

- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py -q` — **56/56 pass**
- [x] `python3 -m pytest tests/test_advertised_runtimes_match_catalogue.py tests/test_routes_runtimes.py tests/test_sync_cloud_plan_cache.py -q` — **adjacent surfaces all pass**
- [x] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlements.py tests/test_entitlement_api.py` — clean
- [x] Confirmed the one unrelated failure (`test_runtime_paywall_overlay_present` asserting `"Start free trial"` is in the runtime-switcher overlay HTML) is **pre-existing on `origin/main`** — verified by re-running the same test on `origin/main` HEAD before applying this diff.

## Local operator verification checklist

I cannot reach your local machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please complete on a real install:

1. `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/entitlements.py`
2. `cp routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/routes/entitlement.py`
3. `rm -f ~/.clawmetry/lib/python3.11/site-packages/clawmetry/__pycache__/entitlements*.pyc ~/.clawmetry/lib/python3.11/site-packages/routes/__pycache__/entitlement*.pyc`
4. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` and restart the dashboard if it's running
5. `curl -s http://localhost:8900/api/entitlement | jq '.retention_days'` — should print `7` on an OSS install
6. If a Pro license is installed locally: `curl -s http://localhost:8900/api/entitlement | jq '{tier, retention_days}'` — should show `{tier: "pro", retention_days: 90}`
7. Decrypt the live cloud snapshot — no daemon code is touched here, snapshot shape is unchanged
8. Browser check: open the dashboard, confirm `/api/entitlement` response in the network panel now carries `retention_days`; no UI is wired in this PR so nothing visual to verify yet

This PR is **draft-only**: not flipping to ready-for-review, not editing `__version__`, not opening a `[RELEASE]` PR, not enforcing any gate. Grace mode stays on. Once the operator checklist is green, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NubjmwWJf4iN7Q3L6rCpNf)_