### PR TITLE
feat(entitlement): add POST /api/entitlement/refresh for cache busting

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6,14 +6,21 @@ runtimes/features to surface (and, once enforcement is live, which to render
 locked behind an upgrade CTA). Backed by :mod:`clawmetry.entitlements`, which
 is the single source of truth — handlers never re-derive tier logic here.
 
-  GET /api/entitlement            — the current Entitlement as JSON.
-  GET /api/entitlement/diagnostic — the *inputs* the resolver consulted
+  GET  /api/entitlement          — the current Entitlement as JSON.
+  GET  /api/entitlement/diagnostic — the *inputs* the resolver consulted
                                      (license/cloud-plan presence, enforce env,
                                      cache liveness) for operator triage.
-  GET /api/runtimes               — the full runtime catalog with locked/free flags.
+  POST /api/entitlement/refresh  — drop the cache and return the freshly
+                                   re-resolved Entitlement (used after a
+                                   license is dropped in or the daemon
+                                   writes a new cloud_plan.json, so the UI
+                                   does not have to wait for the 60 s TTL).
+  GET  /api/runtimes             — the full runtime catalog with locked/free
+                                   flags.
 
-Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
-on the cloud side: when no license/cloud plan is present it returns a graceful
+Side-effect-free and never-raise (refresh's only side effect is busting the
+in-process cache), so it is safe to classify ``oss-passthrough`` on the cloud
+side: when no license/cloud plan is present every endpoint returns a graceful
 OSS-free shape, never a 4xx.
 """
 
@@ -88,6 +95,47 @@ def api_entitlement_diagnostic():
                 "cache_hit_next_call": False,
                 "cache_cached_tier": None,
                 "error": str(exc),
+            }
+        )
+
+
+
+@bp_entitlement.route("/api/entitlement/refresh", methods=["POST"])
+def api_entitlement_refresh():
+    """Force-drop the in-process entitlement cache and re-resolve.
+
+    The resolver caches for 60 s (see ``_CACHE_TTL_SECS`` in
+    ``clawmetry.entitlements``), which is the right default for per-request
+    reads but the wrong default right after the operator just dropped a
+    license file into ``~/.clawmetry/license.key`` or the daemon just wrote a
+    fresh ``cloud_plan.json``. ``/api/license/activate`` already busts the
+    cache internally; this endpoint covers the manual / out-of-band install
+    path the activate route doesn't see.
+
+    Returns the freshly resolved Entitlement (same shape as ``/api/entitlement``)
+    so the caller can render the new state in one round-trip. Falls back to the
+    grace OSS-free shape on any error — refresh is idempotent and must never
+    take the dashboard down.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        _ent.invalidate()
+        return jsonify(_ent.get_entitlement(force=True).to_dict())
+    except Exception as exc:  # never crash the dashboard over a cache bust
+        logger.warning("api_entitlement_refresh: falling back to OSS-free: %s", exc)
+        return jsonify(
+            {
+                "tier": "oss",
+                "source": "oss",
+                "node_limit": 1,
+                "expiry": None,
+                "expired": False,
+                "is_paid": False,
+                "grace": True,
+                "enforced": False,
+                "runtimes": ["nemoclaw", "openclaw"],
+                "features": [],
             }
         )
 

--- a/tests/test_entitlement_api.py
+++ b/tests/test_entitlement_api.py
@@ -136,6 +136,69 @@ def test_api_entitlement_enforced_oss_grace_false(monkeypatch, tmp_path):
     assert d["grace"] == (not d["enforced"])
 
 
+
+
+# ── refresh endpoint ──────────────────────────────────────────────────────────
+
+
+def test_api_entitlement_refresh_grace_shape(client):
+    """POST /api/entitlement/refresh returns the same shape as GET when no
+    license/cloud plan is present, and never raises on a clean HOME."""
+    c, _ = client
+    resp = c.post("/api/entitlement/refresh")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    for key in ("tier", "source", "grace", "enforced", "is_paid",
+                "runtimes", "features"):
+        assert key in d, key
+    assert d["tier"] == "oss"
+    assert d["grace"] is True
+    assert d["enforced"] is False
+    assert d["grace"] == (not d["enforced"])
+
+
+def test_api_entitlement_refresh_busts_cache(monkeypatch, tmp_path):
+    """Refresh must pick up a cloud_plan.json that was written *after* the
+    first GET populated the cache, without waiting for the 60 s TTL."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    client_ = app.test_client()
+
+    first = client_.get("/api/entitlement").get_json()
+    assert first["tier"] == "oss"
+    assert first["source"] == "oss"
+
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro", "node_limit": 5,
+                                 "expiry": None}))
+
+    # GET still returns the cached OSS result — TTL hasn't elapsed.
+    stale = client_.get("/api/entitlement").get_json()
+    assert stale["tier"] == "oss"
+
+    refreshed = client_.post("/api/entitlement/refresh").get_json()
+    assert refreshed["tier"] == "cloud_pro"
+    assert refreshed["source"] == "cloud"
+    assert refreshed["is_paid"] is True
+
+
+def test_api_entitlement_refresh_idempotent(client):
+    """Repeated refresh calls return identical shapes — refresh must be safe
+    to spam from a dashboard timer / connect-flow retry loop."""
+    c, _ = client
+    a = c.post("/api/entitlement/refresh").get_json()
+    b = c.post("/api/entitlement/refresh").get_json()
+    assert a == b
+
+
 # ── paid tiers ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Add `POST /api/entitlement/refresh` to `routes/entitlement.py`. The handler calls `clawmetry.entitlements.invalidate()` and returns `get_entitlement(force=True).to_dict()` — same JSON shape as `GET /api/entitlement`.

## Why

The resolver caches each `Entitlement` for 60 s (`_CACHE_TTL_SECS`). That's the right default for per-request reads but the wrong default when the operator has just dropped a license file into `~/.clawmetry/license.key` or the daemon has just written a fresh `~/.clawmetry/cloud_plan.json` out-of-band.

`/api/license/activate` already calls `invalidate()` internally, but it only covers the in-process activation path. A manual file drop (the `clawmetry activate` CLI lands the key on disk) and the daemon's heartbeat-driven cloud-plan write both bypass it. Without a way to bust the cache, the dashboard would render the stale OSS-free state for up to a full TTL after the new entitlement is on disk.

This endpoint covers that gap. The dashboard (or `clawmetry connect` flow) can POST `/api/entitlement/refresh` once after the install completes and immediately render the new tier in a single round-trip.

## Behaviour

- **GRACE-safe.** `invalidate()` does not change resolution rules, only re-runs them. With no license/plan present, the response is byte-for-byte identical to today's `GET /api/entitlement` OSS-free shape.
- **Never-raise.** Falls back to the same OSS-free shape every other endpoint in this module uses, so refresh is safe to spam from a dashboard timer / connect-flow retry loop without ever taking the dashboard down.
- **No side effect beyond the in-process cache.** Does not touch the license file, the cloud-plan cache, or the daemon.

## Tests

Three new tests in `tests/test_entitlement_api.py`:

1. `test_api_entitlement_refresh_grace_shape` — POST returns the same key set as GET on a clean HOME, `tier=oss`, `grace=True`.
2. `test_api_entitlement_refresh_busts_cache` — GET populates the cache with OSS-free, then `cloud_plan.json` is written with `plan=cloud_pro`, a second GET still returns the stale OSS row (TTL not elapsed), POST `/refresh` returns `tier=cloud_pro`, `source=cloud`, `is_paid=True`.
3. `test_api_entitlement_refresh_idempotent` — two consecutive POSTs return identical JSON, confirming the refresh path is safe to retry.

```
tests/test_entitlement_api.py ........... 10 passed in 0.22s
```

`ruff check routes/entitlement.py tests/test_entitlement_api.py` is clean.

## Out of scope

- No change to `__version__`, no enforce-flag flip, no UI work, no CLI subcommand. A `clawmetry entitlement refresh` CLI bound to this endpoint is a natural follow-up.
- The four pre-existing failures in `tests/test_license.py` (auto-provision install paths) and `tests/test_route_gates.py::…[/api/assets-GET]` reproduce on `origin/main` unchanged — not caused by this PR.

## Local operator verification checklist

Because this agent cannot reach your local daemon, ~/.openclaw, the live cloud snapshot, or a browser, the operator runs:

- [ ] `cp routes/entitlement.py ~/.clawmetry/lib/python3.X/site-packages/routes/entitlement.py` (replace `3.X` with the daemon's Python).
- [ ] `cp tests/test_entitlement_api.py ~/.clawmetry/lib/python3.X/site-packages/tests/test_entitlement_api.py`.
- [ ] `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] `curl -sS http://localhost:8900/api/entitlement | jq` — capture the OSS-free baseline.
- [ ] `curl -sS -X POST http://localhost:8900/api/entitlement/refresh | jq` — confirm identical shape and `grace=true`.
- [ ] Drop a real `~/.clawmetry/cloud_plan.json` or paste a license, then `curl -X POST /api/entitlement/refresh` and confirm `tier` flips immediately (no 60 s wait).
- [ ] Decrypt the live cloud snapshot and confirm `/api/entitlement` still classifies as `oss-passthrough` on the cloud side.
- [ ] Browser-check the dashboard for any unexpected UI flicker after refresh (there should be none — the shape is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PB324CK2o6zJXVbaedTsgX)_