### PR TITLE
feat(license): add OFFLINE dry-run verify (CLI + /api/license/verify)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2842,6 +2842,38 @@ def _cmd_license(args) -> None:
         print("  published at https://clawmetry.com/security to confirm your")
         print("  install carries the genuine license-verification key.")
 
+    elif action == "verify":
+        # Dry-run: verify a key OFFLINE and show what it would unlock,
+        # WITHOUT writing anything to disk. Useful for support and pre-flight.
+        key = getattr(args, "license_key", None) or ""
+        if not key:
+            print("❌  Usage: clawmetry license verify <KEY>")
+            sys.exit(1)
+        from clawmetry import license as _lic
+        info = _lic.inspect_key(key.strip())
+        print("ClawMetry License Verify (dry-run)\n" + "─" * 40)
+        if info is None:
+            print("  Result:      ❌  Invalid or unrecognized license key")
+            print("  Disk:        nothing written")
+            sys.exit(1)
+        status = info.get("status", "unknown")
+        tier = str(info.get("tier", "pro")).capitalize()
+        if not info.get("valid"):
+            # Expired-but-parseable: show what it WAS for so support can confirm.
+            print(f"  Result:      ⚠️  {status} (signature verified, but expired)")
+            print(f"  Was for:     {tier} · {info.get('nodes', 1)} node(s)")
+            if info.get("days_left") is not None:
+                print(f"  Expired:     {abs(info['days_left'])} day(s) ago")
+        else:
+            print("  Result:      ✅  valid (signature verified offline)")
+            print(f"  Would set:   {tier} (self-hosted)")
+            print(f"  Nodes:       {info.get('nodes', 1)}")
+            if info.get("days_left") is not None:
+                print(f"  Expires:     in {info['days_left']} day(s)")
+        if info.get("sub"):
+            print(f"  Account:     {info['sub']}")
+        print("  Disk:        nothing written (run `clawmetry license activate <KEY>` to install)")
+
     else:
         from clawmetry import license as _lic
         info = _lic.current_license_info()
@@ -3340,14 +3372,14 @@ def main() -> None:
         "license_action",
         nargs="?",
         default="status",
-        choices=["status", "activate", "deactivate", "fingerprint"],
-        help="status (default) | activate <KEY> | deactivate | fingerprint",
+        choices=["status", "activate", "deactivate", "fingerprint", "verify"],
+        help="status (default) | activate <KEY> | deactivate | fingerprint | verify <KEY>",
     )
     p_license.add_argument(
         "license_key",
         nargs="?",
         default=None,
-        help="License key (CLAW1.…) — required for 'activate'",
+        help="License key (CLAW1.…) — required for 'activate' / 'verify'",
     )
 
     # tier — print the resolved open-core entitlement (scriptable)

--- a/clawmetry/license.py
+++ b/clawmetry/license.py
@@ -813,6 +813,49 @@ def deactivate(actor: str = "") -> tuple[bool, bool]:
     return True, removed
 
 
+def inspect_key(key: str) -> dict | None:
+    """Verify ``key`` OFFLINE and return what it would unlock — without writing
+    anything to disk. The dry-run counterpart of :func:`activate`.
+
+    Use cases:
+      * Support: "paste your key, let's see what tier/exp it carries" without
+        having the customer mutate their install.
+      * Pre-flight from the CLI / dashboard before clicking *Activate*.
+      * Air-gap: validate a key on a staging box before transporting it.
+
+    Returns a dict with the same shape as :func:`current_license_info` (so the
+    UI can render the two the same way), or ``None`` if the signature is bogus
+    or the token is malformed. An EXPIRED but otherwise-valid token returns a
+    dict with ``valid=False`` + ``status="expired"`` so the caller can still
+    show what the (now-stale) key was for. Never raises, never touches disk."""
+    import time as _t
+
+    try:
+        payload = verify_token(key)
+        if payload is None:
+            return None
+        exp = payload.get("exp")
+        days_left = None
+        expired = False
+        if isinstance(exp, (int, float)):
+            days_left = int((exp - _t.time()) // 86400)
+            expired = _t.time() > exp
+        tier_in = str(payload.get("tier", "pro")).strip().lower()
+        tier = "enterprise" if tier_in == "enterprise" else "pro"
+        return {
+            "valid": not expired,
+            "status": "expired" if expired else "active",
+            "tier": tier,
+            "nodes": int(payload.get("nodes", 1) or 1),
+            "sub": str(payload.get("sub", "")),
+            "exp": exp,
+            "days_left": days_left,
+        }
+    except Exception as exc:  # never raise from a dry-run inspector
+        logger.warning("license: inspect_key failed: %s", exc)
+        return None
+
+
 def current_license_info() -> dict | None:
     """Human-readable summary of the installed license, or None if there is no
     valid one. Never raises."""

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -301,6 +301,38 @@ def api_license_activate():
         return jsonify({"ok": False, "error": str(exc)}), 500
 
 
+@bp_entitlement.route("/api/license/verify", methods=["POST"])
+def api_license_verify():
+    """Verify a license key OFFLINE without persisting it (dry-run).
+
+    Body: ``{"key": "CLAW1.…"}``. Returns the same shape as
+    ``/api/license/status`` plus a ``"dry_run": true`` marker, so the UI can
+    show "this is what activating this key would unlock" before the user
+    commits. Always 200 on a malformed/forged key (the body carries
+    ``valid=false``) — only a missing ``key`` field is a 400. The server never
+    writes the key to disk, never touches the entitlement cache, and never
+    raises.
+    """
+    try:
+        body = request.get_json(silent=True) or {}
+        key = str(body.get("key", "")).strip()
+        if not key:
+            return jsonify({"ok": False, "error": "key is required"}), 400
+        from clawmetry import license as _lic
+
+        info = _lic.inspect_key(key)
+        if info is None:
+            return jsonify(
+                {"valid": False, "status": "invalid", "dry_run": True}
+            )
+        info = dict(info)
+        info["dry_run"] = True
+        return jsonify(info)
+    except Exception as exc:
+        logger.warning("api_license_verify: error: %s", exc)
+        return jsonify({"valid": False, "status": "invalid", "dry_run": True})
+
+
 @bp_entitlement.route("/api/license/deactivate", methods=["POST"])
 def api_license_deactivate():
     """Remove the installed license key and revert to OSS tier.

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -152,6 +152,73 @@ def test_activate_expired_key(lic):
     assert "expired" in msg.lower()
 
 
+def test_inspect_key_valid_returns_summary(lic):
+    """inspect_key returns the unlock summary for a valid key WITHOUT writing."""
+    import os
+
+    tok = lic.L._encode_token(_payload("pro", nodes=11), lic.priv)
+    info = lic.L.inspect_key(tok)
+    assert info is not None
+    assert info["valid"] is True
+    assert info["status"] == "active"
+    assert info["tier"] == "pro"
+    assert info["nodes"] == 11
+    assert info["days_left"] is not None and info["days_left"] > 300
+    # critical contract: dry-run never touches disk
+    assert not os.path.isfile(lic.L.LICENSE_PATH)
+
+
+def test_inspect_key_enterprise_tier(lic):
+    tok = lic.L._encode_token(_payload("enterprise", nodes=99), lic.priv)
+    info = lic.L.inspect_key(tok)
+    assert info is not None and info["tier"] == "enterprise"
+    assert info["nodes"] == 99
+
+
+def test_inspect_key_invalid_returns_none(lic):
+    """Bogus / forged tokens return None — no partial info leaked."""
+    import os
+
+    other_priv, _ = _keypair()
+    forged = lic.L._encode_token(_payload(), other_priv)
+    assert lic.L.inspect_key(forged) is None
+    assert lic.L.inspect_key("CLAW1.garbage.garbage") is None
+    assert lic.L.inspect_key("") is None
+    assert not os.path.isfile(lic.L.LICENSE_PATH)
+
+
+def test_inspect_key_expired_marks_invalid_but_returns_payload(lic):
+    """Expired-but-parseable keys come back with valid=False + status='expired'
+    so support can still confirm what the (now-stale) key was for."""
+    tok = lic.L._encode_token(_payload("pro", nodes=4, exp_delta=-7200), lic.priv)
+    info = lic.L.inspect_key(tok)
+    assert info is not None
+    assert info["valid"] is False
+    assert info["status"] == "expired"
+    assert info["tier"] == "pro"
+    assert info["nodes"] == 4
+    assert info["days_left"] is not None and info["days_left"] <= 0
+
+
+def test_inspect_key_never_touches_disk_or_cache(lic, monkeypatch):
+    """Hardens the no-side-effects contract: a verify must NOT invalidate the
+    entitlement cache (activate does that; verify must not)."""
+    import os
+
+    import clawmetry.entitlements as e
+
+    monkeypatch.setattr(e, "_LICENSE_PATH", lic.L.LICENSE_PATH)
+    called = {"invalidate": 0}
+    real_invalidate = e.invalidate
+    monkeypatch.setattr(
+        e, "invalidate", lambda: called.__setitem__("invalidate", called["invalidate"] + 1) or real_invalidate()
+    )
+    tok = lic.L._encode_token(_payload(), lic.priv)
+    lic.L.inspect_key(tok)
+    assert not os.path.isfile(lic.L.LICENSE_PATH)
+    assert called["invalidate"] == 0
+
+
 def test_current_license_info(lic):
     tok = lic.L._encode_token(_payload("pro", nodes=3), lic.priv)
     lic.L.activate(tok)

--- a/tests/test_license_api.py
+++ b/tests/test_license_api.py
@@ -142,6 +142,71 @@ def test_activate_expired_key(app):
     assert resp.get_json()["ok"] is False
 
 
+# ── /api/license/verify (dry-run) ─────────────────────────────────────────────
+
+
+def test_verify_valid_key_returns_unlock_summary_without_writing(app):
+    import os
+
+    tok = app.lic._encode_token(_payload("pro", nodes=7), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/verify",
+            data=json.dumps({"key": tok}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is True
+    assert data["status"] == "active"
+    assert data["tier"] == "pro"
+    assert data["nodes"] == 7
+    assert data["dry_run"] is True
+    # critical contract: HTTP verify never persists the key
+    assert not os.path.isfile(app.license_path)
+
+
+def test_verify_invalid_key_returns_200_with_valid_false(app):
+    """A bogus key is a query result, not a 4xx — the body carries valid=false."""
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/verify",
+            data=json.dumps({"key": "CLAW1.not.real"}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["status"] == "invalid"
+    assert data["dry_run"] is True
+
+
+def test_verify_expired_key_marks_invalid(app):
+    tok = app.lic._encode_token(_payload(exp_delta=-3600), app.priv)
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/verify",
+            data=json.dumps({"key": tok}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["valid"] is False
+    assert data["status"] == "expired"
+    assert data["dry_run"] is True
+
+
+def test_verify_missing_key_body_returns_400(app):
+    with app.app.test_client() as c:
+        resp = c.post(
+            "/api/license/verify",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+    assert resp.status_code == 400
+    assert resp.get_json()["ok"] is False
+
+
 # ── /api/license/deactivate ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a no-side-effects path to inspect a self-hosted Pro/Enterprise license key — the offline dry-run counterpart of `clawmetry activate`. Verifies the Ed25519 signature, reports tier / nodes / expiry / days-left, and explicitly does NOT touch disk or the entitlement cache.

The licensing surface has activate (writes the key + provisions pro), status (reads the installed key), and deactivate (removes it) — but there was no way to verify a key the customer hasn't installed yet. That's the gap this fills.

## What it adds

- **`clawmetry.license.inspect_key(key) -> dict | None`** — verifies the token's Ed25519 signature against the embedded public key, returns the unlock summary in the same shape as `current_license_info()` (`valid`, `status`, `tier`, `nodes`, `sub`, `exp`, `days_left`). Returns `None` for a forged / malformed token. For an EXPIRED-but-parseable token returns `valid=False` + `status="expired"` so support can still confirm what the (now-stale) key was for. Never raises; never writes.
- **`clawmetry license verify <KEY>` CLI** — pretty-prints the dry-run summary ("would set: Pro · N nodes · M days") and explicitly notes that nothing was written to disk. Exits 1 on an invalid/forged key for scripting.
- **`POST /api/license/verify` HTTP endpoint** — same dry-run over HTTP with a `dry_run: true` marker on the response. Returns 200 even for a forged key (the body carries `valid=false`) because it is a query, not a mutation; only a missing `key` body is a 400.

## Use cases

1. **Support triage** — verify a key a customer pasted into a ticket without having them mutate their install.
2. **Pre-flight UI** — show "this is what activating this key would unlock" before the user clicks *Activate*.
3. **Air-gap** — validate a key on a staging box before transporting it.

## Contract

- Never raises (warning-logged on any unexpected error → returns None / `valid=false`).
- Never writes the key, the license file, the pro marker, the cache, or any other side-effect target.
- Never re-invalidates the `entitlements` cache (explicit test).
- HTTP `200` for both valid and invalid keys; `400` only when the body lacks a `key` field.
- Pure offline — no network call, no `CLAWMETRY_LICENSE_SERVER` lookup.

## Scope guard

No version bump, no `__version__` change, no behavior change to existing flows. Grace stays on; the resolver still returns the OSS-free entitlement when no key is installed.

## Tests

- `tests/test_license.py` — 5 new cases (valid summary, enterprise tier, invalid forged/empty, expired-still-payload, no-disk-no-cache).
- `tests/test_license_api.py` — 4 new cases (valid 200, invalid 200 with `valid=false`, expired 200, missing-key 400).

All 40 license-related tests pass (3 pre-existing unrelated auto-provision failures on origin/main — `_Resp` mock missing `.headers` — are out of scope and deselected). New code introduces **zero** new ruff warnings.

## Local operator verification checklist

You'll need to do this; the remote container has no daemon / `~/.openclaw` / cloud snapshot:

- [ ] `cp` the updated files into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and `routes/`, `tests/`).
- [ ] Clear `__pycache__/` under both dirs.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (or systemd equivalent).
- [ ] `clawmetry license verify CLAW1.<good-key>` — confirms green ✅ block with tier/nodes/expiry; verify `~/.clawmetry/license.key` is NOT created.
- [ ] `clawmetry license verify garbage` — confirms ❌ "Invalid or unrecognized license key" + exit code 1.
- [ ] `curl -s -X POST http://127.0.0.1:8900/api/license/verify -H 'Content-Type: application/json' -d '{"key":"<good-key>"}'` — confirms `{"valid":true,"dry_run":true,...}`.
- [ ] Same curl with `{"key":"bogus"}` — confirms 200 with `{"valid":false,"dry_run":true,...}`.
- [ ] Same curl with `{}` — confirms 400.
- [ ] `python -m pytest tests/test_license.py tests/test_license_api.py -q` — green on the cases this PR adds.
- [ ] Browser-check `/api/license/verify` is reachable through the dashboard (no console errors).
- [ ] Decrypt the live cloud snapshot and confirm it still ingests with the new wheel.

PR stays DRAFT until you've run the local verification.

---

https://claude.ai/code/session_012EWbGwZimNvMn5CQcWAVG6

---
_Generated by [Claude Code](https://claude.ai/code/session_012EWbGwZimNvMn5CQcWAVG6)_