### PR TITLE
feat(entitlement): upgrade_diff() + /api/entitlement/upgrade-diff

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -418,6 +418,43 @@ class Entitlement:
         """
         return _TIER_RETENTION_DAYS.get(self.tier, 7)
 
+    def upgrade_diff(self, target_tier: str) -> dict:
+        """Features + runtimes ``target_tier`` would unlock on top of this
+        entitlement. Drives the upgrade CTA on a locked row: hovering "Upgrade
+        to Pro" needs to know which feature/runtime keys would light up so the
+        UI can list them without round-tripping the whole feature catalog.
+
+        Returns ``{"target": "<tier>", "added_features": [...sorted...],
+        "added_runtimes": [...sorted...]}``. An unknown or empty target tier,
+        or a target that would not add anything (already on the same/higher
+        tier), returns empty lists. Free features/runtimes are always present
+        on every tier, so they never appear in ``added_*``. Never raises."""
+        try:
+            tt = (target_tier or "").strip().lower()
+            target_paid_feats = _TIER_FEATURES.get(tt)
+            if target_paid_feats is None:
+                return {"target": tt, "added_features": [], "added_runtimes": []}
+            target_feats = FREE_FEATURES | target_paid_feats
+            if tt == TIER_ENTERPRISE:
+                target_feats = target_feats | ENTERPRISE_FEATURES
+            target_runtimes = (
+                FREE_RUNTIMES | PAID_RUNTIMES
+                if tt in _TIER_PAID_RUNTIMES
+                else FREE_RUNTIMES
+            )
+            return {
+                "target": tt,
+                "added_features": sorted(target_feats - self.features),
+                "added_runtimes": sorted(target_runtimes - self.runtimes),
+            }
+        except Exception as exc:
+            logger.warning("entitlements: upgrade_diff failed: %s", exc)
+            return {
+                "target": target_tier or "",
+                "added_features": [],
+                "added_runtimes": [],
+            }
+
     def to_dict(self) -> dict:
         # ``retention_days`` mirrors :meth:`event_retention_days` so the
         # dashboard can render a tier-aware "we are keeping N days of history"
@@ -599,6 +636,21 @@ def invalidate() -> None:
     """Drop the cached entitlement (call after activating/removing a license)."""
     with _lock:
         _cache.update(ent=None, ts=0.0, enforce=None)
+
+
+def upgrade_diff(target_tier: str) -> dict:
+    """Module-level convenience: resolve the current entitlement and return
+    what ``target_tier`` would add. Equivalent to
+    ``get_entitlement().upgrade_diff(target_tier)``. Never raises."""
+    try:
+        return get_entitlement().upgrade_diff(target_tier)
+    except Exception as exc:
+        logger.warning("entitlements: upgrade_diff (module) failed: %s", exc)
+        return {
+            "target": target_tier or "",
+            "added_features": [],
+            "added_runtimes": [],
+        }
 
 
 def resolution_diagnostic() -> dict:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -195,6 +195,34 @@ def api_features():
         return jsonify({"features": [], "grace": True, "enforced": False})
 
 
+@bp_entitlement.route("/api/entitlement/upgrade-diff")
+def api_entitlement_upgrade_diff():
+    """Return the features + runtimes ``?target=<tier>`` would unlock on top of
+    the current entitlement. Drives the upgrade CTA shown on locked rows so the
+    UI can list exactly what the user would gain without re-deriving tier logic
+    client-side.
+
+    Shape::
+
+        {"target": "<tier>", "added_features": [...], "added_runtimes": [...]}
+
+    Unknown / missing ``target`` returns empty lists; never raises."""
+    try:
+        target = (request.args.get("target") or "").strip().lower()
+        from clawmetry import entitlements as _ent
+
+        return jsonify(_ent.upgrade_diff(target))
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_entitlement_upgrade_diff: error: %s", exc)
+        return jsonify(
+            {
+                "target": (request.args.get("target") or "").strip().lower(),
+                "added_features": [],
+                "added_runtimes": [],
+            }
+        )
+
+
 @bp_entitlement.route("/api/license/status")
 def api_license_status():
     """Return the current self-hosted license info as JSON.

--- a/tests/test_entitlement_api.py
+++ b/tests/test_entitlement_api.py
@@ -165,3 +165,80 @@ def test_api_entitlement_paid_tier_grants_all_runtimes(monkeypatch, tmp_path, ti
     # All paid runtimes must be present.
     for rt in e.PAID_RUNTIMES:
         assert rt in d["runtimes"], f"{tier}: {rt} missing from runtimes"
+
+
+# ── /api/entitlement/upgrade-diff ────────────────────────────────────────────
+
+
+def test_api_upgrade_diff_oss_to_cloud_pro(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/upgrade-diff?target=cloud_pro")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["target"] == "cloud_pro"
+    import clawmetry.entitlements as e
+    assert set(d["added_features"]) == set(e.PAID_FEATURES)
+    assert set(d["added_runtimes"]) == set(e.PAID_RUNTIMES)
+    # Sorted contract — the UI relies on stable order.
+    assert d["added_features"] == sorted(d["added_features"])
+    assert d["added_runtimes"] == sorted(d["added_runtimes"])
+
+
+def test_api_upgrade_diff_unknown_target_is_empty_not_500(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/upgrade-diff?target=nope")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["target"] == "nope"
+    assert d["added_features"] == []
+    assert d["added_runtimes"] == []
+
+
+def test_api_upgrade_diff_missing_target_is_empty(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/upgrade-diff")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["added_features"] == []
+    assert d["added_runtimes"] == []
+
+
+def test_api_upgrade_diff_case_insensitive(client):
+    c, _ = client
+    a = c.get("/api/entitlement/upgrade-diff?target=cloud_pro").get_json()
+    b = c.get("/api/entitlement/upgrade-diff?target=CLOUD_PRO").get_json()
+    assert a["added_features"] == b["added_features"]
+    assert a["added_runtimes"] == b["added_runtimes"]
+
+
+@pytest.mark.parametrize("tier,expected_runtime_diff", [
+    ("cloud_starter", "paid"),    # OSS → Starter unlocks paid runtimes
+    ("cloud_pro", "paid"),         # OSS → Pro unlocks paid runtimes
+    ("enterprise", "paid"),        # OSS → Enterprise unlocks paid runtimes
+])
+def test_api_upgrade_diff_paid_tiers_all_unlock_paid_runtimes(client, tier, expected_runtime_diff):
+    c, _ = client
+    d = c.get(f"/api/entitlement/upgrade-diff?target={tier}").get_json()
+    import clawmetry.entitlements as e
+    assert set(d["added_runtimes"]) == set(e.PAID_RUNTIMES)
+
+
+def test_api_upgrade_diff_starter_subscriber_to_pro(monkeypatch, tmp_path):
+    """A Starter subscriber asking for Pro should only see PRO_ONLY features."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_starter", "node_limit": 1, "expiry": None}))
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement/upgrade-diff?target=cloud_pro").get_json()
+
+    assert set(d["added_features"]) == set(e.PRO_ONLY_FEATURES)
+    assert d["added_runtimes"] == []  # already on Starter, paid runtimes unlocked

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -325,6 +325,121 @@ def test_entitled_tier_entitles_its_runtimes(ent):
     assert en.entitled_runtime("cursor") is True
 
 
+# ── upgrade_diff (upgrade CTA driver) ───────────────────────────────────────
+
+
+def test_upgrade_diff_oss_to_starter_adds_starter_features_and_paid_runtimes(ent):
+    """OSS → Starter unlocks exactly STARTER_FEATURES on top of FREE_FEATURES,
+    and the paid runtime catalogue."""
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_OSS
+    diff = en.upgrade_diff(ent.TIER_CLOUD_STARTER)
+    assert diff["target"] == ent.TIER_CLOUD_STARTER
+    # Free features are already on every tier — never in the diff.
+    assert set(diff["added_features"]) == set(ent.STARTER_FEATURES)
+    assert set(ent.FREE_FEATURES).isdisjoint(diff["added_features"])
+    assert set(diff["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+    # Sorted output is a stable contract for the UI.
+    assert diff["added_features"] == sorted(diff["added_features"])
+    assert diff["added_runtimes"] == sorted(diff["added_runtimes"])
+
+
+def test_upgrade_diff_oss_to_pro_adds_all_paid_features(ent):
+    en = ent.get_entitlement(force=True)
+    diff = en.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert set(diff["added_features"]) == set(ent.PAID_FEATURES)
+    assert set(diff["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_upgrade_diff_oss_to_enterprise_adds_enterprise_features(ent):
+    en = ent.get_entitlement(force=True)
+    diff = en.upgrade_diff(ent.TIER_ENTERPRISE)
+    expected = set(ent.PAID_FEATURES) | set(ent.ENTERPRISE_FEATURES)
+    assert set(diff["added_features"]) == expected
+    assert set(diff["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_upgrade_diff_starter_to_pro_adds_only_pro_only_features(ent, tmp_path):
+    """A Starter subscriber upgrading to Pro should see ONLY the PRO_ONLY
+    features in the diff — paid runtimes are already unlocked at Starter."""
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_STARTER, "node_limit": 1, "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_CLOUD_STARTER
+    diff = en.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert set(diff["added_features"]) == set(ent.PRO_ONLY_FEATURES)
+    assert diff["added_runtimes"] == []   # Starter already has all paid runtimes
+
+
+def test_upgrade_diff_pro_to_enterprise_adds_only_enterprise_features(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1, "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_CLOUD_PRO
+    diff = en.upgrade_diff(ent.TIER_ENTERPRISE)
+    assert set(diff["added_features"]) == set(ent.ENTERPRISE_FEATURES)
+    assert diff["added_runtimes"] == []
+
+
+def test_upgrade_diff_same_tier_is_empty(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1, "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    diff = en.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert diff["added_features"] == []
+    assert diff["added_runtimes"] == []
+
+
+def test_upgrade_diff_downgrade_target_is_empty(ent, tmp_path):
+    """A Pro subscriber 'upgrading' to OSS gains nothing — the diff direction
+    is target-MINUS-current, never the reverse, so this stays empty (and the UI
+    never renders a nonsensical 'downgrade to unlock' CTA)."""
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1, "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    diff = en.upgrade_diff(ent.TIER_OSS)
+    assert diff["added_features"] == []
+    assert diff["added_runtimes"] == []
+
+
+def test_upgrade_diff_unknown_target_returns_empty(ent):
+    en = ent.get_entitlement(force=True)
+    diff = en.upgrade_diff("totally-made-up-tier")
+    assert diff["added_features"] == []
+    assert diff["added_runtimes"] == []
+    # Target echoed back so the UI can render "Unknown tier" safely.
+    assert diff["target"] == "totally-made-up-tier"
+
+
+def test_upgrade_diff_empty_and_none_targets_are_safe(ent):
+    en = ent.get_entitlement(force=True)
+    for bad in ("", None, "   "):
+        diff = en.upgrade_diff(bad)
+        assert diff["added_features"] == []
+        assert diff["added_runtimes"] == []
+
+
+def test_upgrade_diff_module_helper_resolves_current(ent):
+    """The module-level ``upgrade_diff`` is a thin wrapper around
+    ``get_entitlement().upgrade_diff`` — same shape, no surprises."""
+    direct = ent.get_entitlement(force=True).upgrade_diff(ent.TIER_CLOUD_PRO)
+    via_module = ent.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert direct == via_module
+
+
+def test_upgrade_diff_case_insensitive_target(ent):
+    en = ent.get_entitlement(force=True)
+    a = en.upgrade_diff(ent.TIER_CLOUD_PRO)
+    b = en.upgrade_diff(ent.TIER_CLOUD_PRO.upper())
+    c = en.upgrade_diff("  " + ent.TIER_CLOUD_PRO + "  ")
+    assert a["added_features"] == b["added_features"] == c["added_features"]
+    assert a["added_runtimes"] == b["added_runtimes"] == c["added_runtimes"]
+
+
 # ── canonical_runtime + RUNTIME_ALIASES ─────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds `Entitlement.upgrade_diff(target_tier)` + `GET /api/entitlement/upgrade-diff?target=<tier>` — the features and runtimes a target tier would unlock on top of the current entitlement. Drives the upgrade CTA on locked rows so the UI can list exactly what the user would gain without re-deriving tier logic client-side or round-tripping the entire feature catalog.

Returns:

```json
{
  "target": "cloud_pro",
  "added_features": ["...sorted..."],
  "added_runtimes": ["...sorted..."]
}
```

- Free features/runtimes are always on every tier, so they never appear in `added_*`.
- Same-tier or downgrade target → empty lists (UI never renders a nonsensical "downgrade to unlock" CTA).
- Unknown / empty target → empty lists, target echoed back.
- Never raises; on any error, falls back to empty.
- Case-insensitive (`cloud_pro` == `CLOUD_PRO`).

Module-level `upgrade_diff(target_tier)` is a thin wrapper around `get_entitlement().upgrade_diff(target_tier)`.

Grace-mode safe: the resolver still always returns OSS-free in grace, so the endpoint reports the diff against the OSS-free baseline by default — **no behavior change** to existing callers. Stays in line with the rollout's grace-vs-enforce semantics.

## Files changed

- `clawmetry/entitlements.py` — `Entitlement.upgrade_diff()` method + module-level `upgrade_diff()` helper.
- `routes/entitlement.py` — `/api/entitlement/upgrade-diff` on `bp_entitlement`.
- `tests/test_entitlements.py` — 10 new tests covering OSS→Starter / Pro / Enterprise, Starter→Pro (only PRO_ONLY), Pro→Enterprise (only ENTERPRISE), same-tier, downgrade, unknown target, empty/None, module helper parity, case-insensitivity.
- `tests/test_entitlement_api.py` — 5 new API tests for the endpoint (OSS→Pro, unknown target, missing target, case-insensitive, Starter subscriber → Pro).

## Test plan

- [ ] `python -m pytest tests/test_entitlements.py tests/test_entitlement_api.py -v` — all 49 tests green locally.
- [ ] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlements.py tests/test_entitlement_api.py` — clean.
- [ ] No existing test regressions (the three pre-existing `test_license.py::test_auto_provision_*` failures are unrelated and reproduce on `origin/main`).

## Local operator verification checklist

I can't reach your local daemon, `~/.openclaw`, the live cloud snapshot, or a browser from this environment — please run:

1. Copy changed files into the installed package:
   ```
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/
   cp routes/entitlement.py     ~/.clawmetry/lib/python3.11/site-packages/routes/
   find ~/.clawmetry/lib/python3.11/site-packages/clawmetry/__pycache__ -delete 2>/dev/null
   find ~/.clawmetry/lib/python3.11/site-packages/routes/__pycache__   -delete 2>/dev/null
   ```
2. Restart the daemon:
   ```
   launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
   ```
3. Hit the new endpoint:
   ```
   curl -s http://localhost:8900/api/entitlement/upgrade-diff?target=cloud_pro | jq .
   curl -s http://localhost:8900/api/entitlement/upgrade-diff?target=enterprise | jq .
   curl -s http://localhost:8900/api/entitlement/upgrade-diff               | jq .   # empty
   curl -s http://localhost:8900/api/entitlement/upgrade-diff?target=bogus  | jq .   # empty, target echoed
   ```
4. Decrypt the live snapshot (cloud) and confirm `/api/entitlement` itself still returns the expected shape — `upgrade_diff` is additive, but worth a sanity check.
5. Browser-check the dashboard still boots — this PR adds one route on an existing Blueprint, no template/JS edits.

Stays in **GRACE** mode. No enforcement, no `__version__` bump, no tag, no release PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk8RvN6mtJkeNRE1kJwuKA)_