### PR TITLE
feat(entitlement): min_tier_for_feature/runtime + /api/entitlement/required-tier

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -297,6 +297,33 @@ _TIER_RETENTION_DAYS = {
 # Tiers that unlock the paid runtimes.
 _TIER_PAID_RUNTIMES = _PAID_TIERS
 
+# Canonical ordering of the *purchasable* plans, lowest -> highest. Used by
+# :func:`tier_rank` and the ``min_tier_for_*`` helpers so the UI can render
+# locked rows as "Available in Starter" / "Available in Pro" without each
+# caller re-deriving the order. Trial is excluded — it is a time-limited
+# promotional grant of Pro, not a plan a customer can pick from a price page.
+_PURCHASABLE_TIERS = (
+    TIER_OSS,
+    TIER_CLOUD_FREE,
+    TIER_CLOUD_STARTER,
+    TIER_CLOUD_PRO,
+    TIER_PRO,
+    TIER_ENTERPRISE,
+)
+
+# rank: oss/cloud_free = 0, starter = 1, pro/cloud_pro = 2, enterprise = 3.
+# Self-hosted Pro and cloud Pro share rank 2 because they unlock the same
+# feature set. Unknown tiers return -1 from :func:`tier_rank`.
+_TIER_RANK = {
+    TIER_OSS: 0,
+    TIER_CLOUD_FREE: 0,
+    TIER_CLOUD_STARTER: 1,
+    TIER_TRIAL: 2,        # trial unlocks the Pro feature set
+    TIER_CLOUD_PRO: 2,
+    TIER_PRO: 2,
+    TIER_ENTERPRISE: 3,
+}
+
 _LICENSE_PATH = os.path.expanduser("~/.clawmetry/license.key")
 _CLOUD_PLAN_CACHE = os.path.expanduser("~/.clawmetry/cloud_plan.json")
 _ENFORCE_ENABLE_VALUES = frozenset({"1", "true", "yes", "on"})
@@ -402,6 +429,25 @@ class Entitlement:
             return tuple(sorted(f for f in paid_universe if not self.allows_feature(f)))
         except Exception:
             return ()
+
+    def min_tier_for(self, key: str) -> str | None:
+        """Return the minimum *purchasable* tier id that would unlock ``key``.
+
+        ``key`` may be a feature id (e.g. ``"otel_export"``) or a runtime id
+        (e.g. ``"claude_code"``). For a free key returns :data:`TIER_OSS`; for
+        an unknown key returns ``None``. Convenience wrapper over the
+        module-level :func:`min_tier_for_feature` / :func:`min_tier_for_runtime`
+        so callers that already have an ``Entitlement`` don't need to import
+        both. Never raises.
+        """
+        k = (key or "").strip().lower()
+        if not k:
+            return None
+        if k in ALL_FEATURES:
+            return min_tier_for_feature(k)
+        if k in ALL_RUNTIMES:
+            return min_tier_for_runtime(k)
+        return None
 
     def event_retention_days(self) -> int | None:
         """Days of event history this tier may keep. ``None`` means unlimited
@@ -715,6 +761,59 @@ def runtime_label(runtime: str) -> str:
     when unknown so unknown plugin runtimes still render with *something*."""
     rt = canonical_runtime(runtime)
     return RUNTIME_LABELS.get(rt, rt)
+
+
+def tier_rank(tier: str) -> int:
+    """Comparable rank for ``tier`` (higher = unlocks more). Returns ``-1`` for
+    unknown tiers so callers can do ``tier_rank(a) > tier_rank(b)`` without a
+    KeyError. See :data:`_TIER_RANK` for the canonical numbering."""
+    return _TIER_RANK.get((tier or "").strip().lower(), -1)
+
+
+def min_tier_for_feature(feature: str) -> str | None:
+    """Return the cheapest *purchasable* tier id that grants ``feature``.
+
+    Resolution:
+      * ``feature in FREE_FEATURES`` -> :data:`TIER_OSS`
+      * else walks :data:`_PURCHASABLE_TIERS` in rank order and returns the
+        first tier whose grant includes ``feature``
+      * unknown ``feature`` -> ``None`` (caller decides whether to 404)
+
+    The result is intended for the UI's lock affordance — "Available in
+    Starter" / "Available in Pro" — so :data:`TIER_TRIAL` is intentionally
+    excluded: it is a time-limited promotional grant, not a plan a customer
+    picks from a price page. Never raises.
+    """
+    f = (feature or "").strip().lower()
+    if not f:
+        return None
+    if f in FREE_FEATURES:
+        return TIER_OSS
+    for tier in _PURCHASABLE_TIERS:
+        if tier == TIER_OSS or tier == TIER_CLOUD_FREE:
+            continue
+        if f in _TIER_FEATURES.get(tier, frozenset()):
+            return tier
+    return None
+
+
+def min_tier_for_runtime(runtime: str) -> str | None:
+    """Return the cheapest *purchasable* tier id that grants ``runtime``.
+
+    Free runtimes resolve to :data:`TIER_OSS`. Any runtime in
+    :data:`PAID_RUNTIMES` resolves to :data:`TIER_CLOUD_STARTER` — every paid
+    tier (Starter / Pro / Enterprise / self-hosted Pro) grants all paid
+    runtimes, so Starter is the cheapest one. Unknown runtimes return
+    ``None``. Never raises.
+    """
+    rt = (runtime or "").strip().lower()
+    if not rt:
+        return None
+    if rt in FREE_RUNTIMES:
+        return TIER_OSS
+    if rt in PAID_RUNTIMES:
+        return TIER_CLOUD_STARTER
+    return None
 
 
 def feature_label(feature: str) -> str:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -195,6 +195,70 @@ def api_features():
         return jsonify({"features": [], "grace": True, "enforced": False})
 
 
+@bp_entitlement.route("/api/entitlement/required-tier")
+def api_entitlement_required_tier():
+    """Resolve the minimum *purchasable* tier that unlocks a given feature or
+    runtime. Drives the lock affordance copy (``Available in Starter`` /
+    ``Available in Pro``) so each caller does not re-derive the order.
+    Query: exactly one of ``feature=<id>`` or ``runtime=<id>`` (case-insensitive).
+    Returns 200 with ``{"key": ..., "kind": "feature"|"runtime",
+    "required_tier": "<id>"|null, "required_tier_label": "<display>"|null,
+    "current_tier": "<id>", "current_tier_rank": <int>,
+    "required_tier_rank": <int>, "upgrade_required": true|false,
+    "allowed": true|false}`` on success. ``required_tier`` is ``null`` for an
+    unknown key (callers may choose to 404 client-side); when set it is the
+    cheapest plan a customer can pick that grants the key (Trial is excluded,
+    see :func:`clawmetry.entitlements.min_tier_for_feature`). 400 only when
+    neither ``feature`` nor ``runtime`` is supplied.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+        feature = (request.args.get("feature") or "").strip().lower()
+        runtime = (request.args.get("runtime") or "").strip().lower()
+        if not feature and not runtime:
+            return (
+                jsonify({"error": "supply either feature=<id> or runtime=<id>"}),
+                400,
+            )
+        if feature and runtime:
+            return (
+                jsonify({"error": "supply only one of feature= or runtime="}),
+                400,
+            )
+        if feature:
+            key, kind = feature, "feature"
+            required = _ent.min_tier_for_feature(feature)
+            allowed = _ent.get_entitlement().allows_feature(feature)
+        else:
+            key, kind = runtime, "runtime"
+            required = _ent.min_tier_for_runtime(runtime)
+            allowed = _ent.get_entitlement().allows_runtime(runtime)
+        ent = _ent.get_entitlement()
+        cur_rank = _ent.tier_rank(ent.tier)
+        req_rank = _ent.tier_rank(required) if required else -1
+        # tier_label() ships in the parallel tier-label PR; fall back to the
+        # tier id so this endpoint stays self-sufficient if labels aren't on
+        # main yet.
+        label_fn = getattr(_ent, "tier_label", None)
+        required_label = label_fn(required) if (required and callable(label_fn)) else required
+        return jsonify(
+            {
+                "key": key,
+                "kind": kind,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "current_tier": ent.tier,
+                "current_tier_rank": cur_rank,
+                "upgrade_required": bool(required) and req_rank > cur_rank,
+                "allowed": allowed,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_required_tier: error: %s", exc)
+        return jsonify({"error": str(exc)}), 500
+
+
 @bp_entitlement.route("/api/license/status")
 def api_license_status():
     """Return the current self-hosted license info as JSON.

--- a/tests/test_entitlements_min_tier.py
+++ b/tests/test_entitlements_min_tier.py
@@ -1,0 +1,201 @@
+"""Tests for the ``min_tier_for_*`` helpers and ``/api/entitlement/required-tier``.
+The lock affordance copy ("Available in Starter" / "Available in Pro") needs a
+single, canonical reverse lookup from a feature or runtime to the cheapest
+purchasable tier that grants it. The helpers under test are the source of
+truth; this file pins the table so a future tier shuffle (e.g. moving
+``otel_export`` between Pro and Enterprise) breaks loudly here instead of
+silently in the UI.
+"""
+from __future__ import annotations
+import importlib
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir, so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement off
+    by default."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    """Flask test client wired with bp_entitlement against the patched ent."""
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── tier_rank ────────────────────────────────────────────────────────────────
+
+
+def test_tier_rank_orders_purchasable_tiers(ent):
+    # OSS / cloud_free both at the floor.
+    assert ent.tier_rank(ent.TIER_OSS) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_FREE) == 0
+    # Starter strictly above the floor.
+    assert ent.tier_rank(ent.TIER_CLOUD_STARTER) > ent.tier_rank(ent.TIER_OSS)
+    # Self-hosted Pro and cloud Pro share a rank (they grant the same set).
+    assert ent.tier_rank(ent.TIER_PRO) == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    # Pro strictly above Starter.
+    assert ent.tier_rank(ent.TIER_CLOUD_PRO) > ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    # Enterprise is the cap.
+    assert ent.tier_rank(ent.TIER_ENTERPRISE) > ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+def test_tier_rank_unknown_returns_minus_one(ent):
+    assert ent.tier_rank("nope") == -1
+    assert ent.tier_rank("") == -1
+    assert ent.tier_rank(None) == -1
+
+
+def test_tier_rank_case_insensitive(ent):
+    assert ent.tier_rank("CLOUD_PRO") == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+# ── min_tier_for_feature ─────────────────────────────────────────────────────
+
+
+def test_free_feature_minimum_is_oss(ent):
+    for f in sorted(ent.FREE_FEATURES):
+        assert ent.min_tier_for_feature(f) == ent.TIER_OSS, f
+
+
+def test_starter_features_minimum_is_starter(ent):
+    # Each Starter feature should resolve to the Starter tier — the cheapest
+    # purchasable plan that grants it. If a feature is later promoted up the
+    # ladder, this assertion catches the move.
+    for f in sorted(ent.STARTER_FEATURES):
+        assert ent.min_tier_for_feature(f) == ent.TIER_CLOUD_STARTER, f
+
+
+def test_pro_only_features_minimum_is_cloud_pro(ent):
+    # Pro-only features are NOT in the Starter grant, so the cheapest
+    # purchasable tier is cloud Pro (self-hosted Pro shares the rank).
+    for f in sorted(ent.PRO_ONLY_FEATURES):
+        assert ent.min_tier_for_feature(f) == ent.TIER_CLOUD_PRO, f
+
+
+def test_enterprise_features_minimum_is_enterprise(ent):
+    for f in sorted(ent.ENTERPRISE_FEATURES):
+        assert ent.min_tier_for_feature(f) == ent.TIER_ENTERPRISE, f
+
+
+def test_min_tier_for_feature_unknown_returns_none(ent):
+    assert ent.min_tier_for_feature("not_a_real_feature") is None
+    assert ent.min_tier_for_feature("") is None
+    assert ent.min_tier_for_feature(None) is None
+
+
+def test_min_tier_for_feature_excludes_trial(ent):
+    # Trial unlocks the Pro feature set but is NOT a plan a customer can pick
+    # from a price page — the helper must never advertise it as the cheapest
+    # path to a paid feature.
+    for f in ent.PAID_FEATURES | ent.ENTERPRISE_FEATURES:
+        assert ent.min_tier_for_feature(f) != ent.TIER_TRIAL, f
+
+
+def test_min_tier_for_feature_is_case_insensitive(ent):
+    # The dashboard sometimes sends feature ids upper-cased — the lookup must
+    # not care.
+    assert ent.min_tier_for_feature("OTEL_EXPORT") == ent.TIER_CLOUD_PRO
+
+
+# ── min_tier_for_runtime ─────────────────────────────────────────────────────
+
+
+def test_free_runtime_minimum_is_oss(ent):
+    for rt in sorted(ent.FREE_RUNTIMES):
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_OSS, rt
+
+
+def test_paid_runtime_minimum_is_starter(ent):
+    # Every paid tier (Starter / Pro / Enterprise) grants every paid runtime,
+    # so Starter is always the cheapest plan that unlocks any one of them.
+    for rt in sorted(ent.PAID_RUNTIMES):
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_CLOUD_STARTER, rt
+
+
+def test_min_tier_for_runtime_unknown_returns_none(ent):
+    assert ent.min_tier_for_runtime("not_a_runtime") is None
+    assert ent.min_tier_for_runtime("") is None
+    assert ent.min_tier_for_runtime(None) is None
+
+
+# ── Entitlement.min_tier_for ─────────────────────────────────────────────────
+
+
+def test_entitlement_min_tier_for_dispatches_to_feature_and_runtime(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.min_tier_for("sessions") == ent.TIER_OSS         # free feature
+    assert en.min_tier_for("otel_export") == ent.TIER_CLOUD_PRO  # paid feature
+    assert en.min_tier_for("claude_code") == ent.TIER_CLOUD_STARTER  # paid runtime
+    assert en.min_tier_for("openclaw") == ent.TIER_OSS         # free runtime
+
+
+def test_entitlement_min_tier_for_unknown_returns_none(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.min_tier_for("not_a_key") is None
+    assert en.min_tier_for("") is None
+    assert en.min_tier_for(None) is None
+
+
+# ── /api/entitlement/required-tier ───────────────────────────────────────────
+
+
+def test_required_tier_for_feature(client, ent):
+    resp = client.get("/api/entitlement/required-tier?feature=otel_export")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["key"] == "otel_export"
+    assert d["kind"] == "feature"
+    assert d["required_tier"] == ent.TIER_CLOUD_PRO
+    assert d["current_tier"] == ent.TIER_OSS
+    # rank is grace-INDEPENDENT: an OSS-free install needs an upgrade to get
+    # otel_export even though grace mode permits it today.
+    assert d["upgrade_required"] is True
+    # current ent allows it because we are in grace mode.
+    assert d["allowed"] is True
+
+
+def test_required_tier_for_free_feature(client, ent):
+    d = client.get("/api/entitlement/required-tier?feature=sessions").get_json()
+    assert d["required_tier"] == ent.TIER_OSS
+    assert d["upgrade_required"] is False
+    assert d["allowed"] is True
+
+
+def test_required_tier_for_runtime(client, ent):
+    d = client.get("/api/entitlement/required-tier?runtime=claude_code").get_json()
+    assert d["key"] == "claude_code"
+    assert d["kind"] == "runtime"
+    assert d["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert d["upgrade_required"] is True
+
+
+def test_required_tier_unknown_key_is_null_not_error(client):
+    # Unknown keys must NOT 4xx — the UI may call this speculatively for
+    # plugin-provided keys. Returns ``required_tier: null`` instead.
+    resp = client.get("/api/entitlement/required-tier?feature=nope_does_not_exist")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["required_tier"] is None
+    assert d["upgrade_required"] is False
+
+
+def test_required_tier_requires_one_query_param(client):
+    # Neither feature= nor runtime= -> 400.
+    assert client.get("/api/entitlement/required-tier").status_code == 400
+    # Both supplied -> 400 as well; ambiguous which to resolve.
+    assert client.get(
+        "/api/entitlement/required-tier?feature=sessions&runtime=openclaw"
+    ).status_code == 400


### PR DESCRIPTION
## Summary

Adds the canonical **reverse lookup** the lock-affordance copy needs — given a feature or runtime id, what is the cheapest plan a customer can pick that unlocks it?

```python
ent.min_tier_for_feature("otel_export")    # -> "cloud_pro"
ent.min_tier_for_runtime("claude_code")    # -> "cloud_starter"
ent.tier_rank("cloud_pro")                 # -> 2

GET /api/entitlement/required-tier?feature=otel_export
{
  "key": "otel_export",
  "kind": "feature",
  "required_tier": "cloud_pro",
  "required_tier_rank": 2,
  "current_tier": "oss",
  "current_tier_rank": 0,
  "upgrade_required": true,
  "allowed": true        # grace mode still permits it today
}
```

Without this, each caller (sidebar lock badge, paywall modal, runtime switcher, pricing teaser) was re-deriving the answer from `_TIER_FEATURES` / `PAID_RUNTIMES` and drifting when a feature moved up the ladder (`otel_export` Enterprise → Pro was the most recent shuffle). One source of truth fixes that.

### What's added
* `clawmetry/entitlements.py`
  * `_TIER_RANK` table + public `tier_rank(tier)` — `-1` for unknown so callers can `>` without a `KeyError`.
  * `min_tier_for_feature(feature)` — `TIER_OSS` for free features, then walks `_PURCHASABLE_TIERS` in rank order. Returns `None` for unknown features (caller decides whether to 404).
  * `min_tier_for_runtime(runtime)` — `TIER_OSS` for free runtimes, `TIER_CLOUD_STARTER` for any paid runtime (every paid tier grants every paid runtime).
  * `Entitlement.min_tier_for(key)` — dispatches feature-vs-runtime by membership so callers with an Entitlement in hand don't need to import both module-level helpers.
* `routes/entitlement.py`
  * `GET /api/entitlement/required-tier?feature=<id>` / `?runtime=<id>` — wraps the helpers and reports `required_tier_rank > current_tier_rank` so the UI can render "Available in Pro" while **grace mode still lets the call through** (preserves the GRACE invariant — no behaviour change on this fire).
* `tests/test_entitlements_min_tier.py` — 20 tests pinning the table, including:
  * `STARTER_FEATURES` → `cloud_starter`, `PRO_ONLY_FEATURES` → `cloud_pro`, `ENTERPRISE_FEATURES` → `enterprise`
  * `TIER_TRIAL` is **never** advertised as the min tier (it's a promo grant, not a price-page plan)
  * Unknown key → `required_tier: null` + HTTP 200 (UI may probe speculatively)
  * Neither `feature=` nor `runtime=` → HTTP 400; both → HTTP 400 (ambiguous)

### Grace / enforce
Pure addition. No existing call site changes, no `_TIER_FEATURES` / `_PAID_TIERS` membership shifts. `Entitlement.allows_*` still returns `True` for everything in grace; `required-tier` reports the *plan fact* alongside `allowed=true` so the lock affordance can render today without the gate enforcing.

### CI
* `python3 -m py_compile` on changed files — clean
* `ruff check clawmetry/ routes/entitlement.py tests/test_entitlements_min_tier.py` — `All checks passed!`
* `pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_entitlements_min_tier.py` — **65 passed**
* `python3 -c "import ast; ast.parse(open('dashboard.py').read())"` — OK

### Local operator verification checklist
The remote agent cannot touch the daemon, `~/.clawmetry/`, the live cloud snapshot, or a browser — please drive these locally before flipping out of draft:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and `routes/entitlement.py` into the dashboard install path).
- [ ] `find ~/.clawmetry -name __pycache__ -type d -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s http://localhost:8900/api/entitlement/required-tier?feature=otel_export | jq` → `required_tier == "cloud_pro"`, `upgrade_required == true`, `allowed == true` (grace).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/required-tier?runtime=claude_code' | jq` → `required_tier == "cloud_starter"`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/required-tier?feature=sessions' | jq` → `required_tier == "oss"`, `upgrade_required == false`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/required-tier?feature=does_not_exist' | jq` → `required_tier == null`, status 200.
- [ ] `curl -i http://localhost:8900/api/entitlement/required-tier` → HTTP 400.
- [ ] Decrypt the live cloud snapshot, confirm no behaviour change (still GRACE).
- [ ] Browser-check the dashboard — no console errors, runtime switcher still renders all 12 runtimes.

### Roadmap note
P1 / P2 helpers are already on main. P3-P6 require the private `clawmetry-cloud` / `clawmetry-pro` repos the remote agent cannot reach — those stay with the local operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8xJ9d3FB42bH7yqRGk7SK)_