### PR TITLE
fix(cost): surface cache write/saved cost in breakdown + add /api/usage/cache-risk (#2839)

### DIFF
--- a/routes/sessions.py
+++ b/routes/sessions.py
@@ -3145,7 +3145,7 @@ def _try_local_store_cost_breakdown():
         intel = {}
         for mr in meta_rows:
             md = mr.get("metadata") or {}
-            if isinstance(md, dict) and any(md.get(k) is not None for k in ("reasoningCostUsd", "cacheHitPct", "toolErrorPct", "compactionCount", "cacheExpiryCount", "compressionPotentialPct", "compressionRecoverableUsd")):
+            if isinstance(md, dict) and any(md.get(k) is not None for k in ("reasoningCostUsd", "cacheHitPct", "toolErrorPct", "compactionCount", "cacheExpiryCount", "compressionPotentialPct", "compressionRecoverableUsd", "cacheWriteCostUsd", "cacheSavedUsd", "maxIdleGapSec")):
                 intel[mr.get("session_id") or ""] = md
         if intel:
             for row in result:
@@ -3168,6 +3168,12 @@ def _try_local_store_cost_breakdown():
                     row["compressible_tool_tokens"] = md["compressibleToolTokens"]
                 if md.get("compressionRecoverableUsd") is not None:
                     row["compression_recoverable_usd"] = md["compressionRecoverableUsd"]
+                if md.get("cacheWriteCostUsd") is not None:
+                    row["cache_write_cost_usd"] = md["cacheWriteCostUsd"]
+                if md.get("cacheSavedUsd") is not None:
+                    row["cache_saved_usd"] = md["cacheSavedUsd"]
+                if md.get("maxIdleGapSec") is not None:
+                    row["max_idle_gap_sec"] = md["maxIdleGapSec"]
     except Exception:
         pass
     # Cache-hit % (for the event-usage runtimes: OpenClaw / Claude Code) + the

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -3719,6 +3719,63 @@ def api_usage_cache_trends():
     })
 
 
+# ── Cache-bust risk summary (#2839) ─────────────────────────────────────
+
+
+@bp_usage.route("/api/usage/cache-risk")
+def api_usage_cache_risk():
+    """Cache-bust risk summary — idle-gap expiries and re-write tax (#2839).
+
+    Reads per-session metadata from the sessions table to surface how many
+    sessions' prompt caches expired between turns and the cost of rebuilding
+    them, vs. the savings from cache hits.
+
+    Returns:
+      {
+        sessions_with_expiry:     int,
+        total_expiry_count:       int,
+        rewrite_cost_usd:         float,
+        sessions_with_reread_tax: int,
+        reread_tax_usd:           float,
+        cache_saved_usd:          float,
+      }
+    Never 500s — any failure yields zeroed-out fields.
+    """
+    out = {
+        "sessions_with_expiry": 0,
+        "total_expiry_count": 0,
+        "rewrite_cost_usd": 0.0,
+        "sessions_with_reread_tax": 0,
+        "reread_tax_usd": 0.0,
+        "cache_saved_usd": 0.0,
+    }
+    try:
+        meta_rows = _ls_call("query_sessions_table", limit=2000) or []
+        for mr in meta_rows:
+            md = mr.get("metadata") or {}
+            if not isinstance(md, dict):
+                continue
+            exp = md.get("cacheExpiryCount")
+            if exp and int(exp) > 0:
+                out["sessions_with_expiry"] += 1
+                out["total_expiry_count"] += int(exp)
+            cwc = float(md.get("cacheWriteCostUsd") or 0.0)
+            csv_ = float(md.get("cacheSavedUsd") or 0.0)
+            if cwc > 0.0:
+                out["rewrite_cost_usd"] += cwc
+                if cwc > 0.005 and cwc > csv_:
+                    out["sessions_with_reread_tax"] += 1
+                    out["reread_tax_usd"] += cwc
+            if csv_ > 0.0:
+                out["cache_saved_usd"] += csv_
+    except Exception:
+        pass
+    out["rewrite_cost_usd"] = round(out["rewrite_cost_usd"], 4)
+    out["reread_tax_usd"] = round(out["reread_tax_usd"], 4)
+    out["cache_saved_usd"] = round(out["cache_saved_usd"], 4)
+    return jsonify(out)
+
+
 # ── Skills fidelity telemetry (GH #687) ─────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`_try_local_store_cost_breakdown` in `routes/sessions.py` was reading 8 cost-intel metadata keys from the sessions table blob but skipping `cacheWriteCostUsd`, `cacheSavedUsd`, and `maxIdleGapSec`. This meant `_derive_waste_summary`'s `reread_tax_usd` was always 0 even when sessions genuinely paid the prompt-cache re-write penalty (the data was there in DuckDB, just never read back). This PR fixes that omission and adds a dedicated fleet-level cache-risk summary endpoint.

## Changes

- **`routes/sessions.py`** (+8 LOC): Add `cacheWriteCostUsd`, `cacheSavedUsd`, and `maxIdleGapSec` to the `any()` gate check (line 3148) and the metadata readback block — so these three fields now flow into the session rows that `_derive_waste_summary` aggregates. `reread_tax_usd` and `reread_tax_sessions` in `/api/waste-summary` will now reflect real values.
- **`routes/usage.py`** (+56 LOC): New `/api/usage/cache-risk` endpoint that reads `query_sessions_table` metadata and rolls up `cacheExpiryCount`, `cacheWriteCostUsd`, and `cacheSavedUsd` into a fleet summary (`sessions_with_expiry`, `total_expiry_count`, `rewrite_cost_usd`, `sessions_with_reread_tax`, `reread_tax_usd`, `cache_saved_usd`). Follows the same guard/fallback pattern as `/api/usage/cache-trends`. Never 500s.

## Test plan

- [ ] `python3 -c 'import ast; ast.parse(open("routes/sessions.py").read())'` — passes (✓ validated locally)
- [ ] `python3 -c 'import ast; ast.parse(open("routes/usage.py").read())'` — passes (✓ validated locally)
- [ ] Start the server and run `curl -s http://localhost:8900/api/usage/cache-risk | python3 -m json.tool` — returns the expected JSON shape with all 6 keys
- [ ] `/api/waste-summary` `reread_tax_usd` is non-zero for any session where `cacheWriteCostUsd > cacheSavedUsd` exists in the sessions metadata

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #2839. Marked draft for human review — mark Ready for Review once happy.

Closes #2839

---
_Generated by [Claude Code](https://claude.ai/code/session_015kq4vbZQnR8zAxjx3CHQ9d)_