### PR TITLE
feat(entitlement): CLAWMETRY_ENFORCE_AT grace-countdown surface on /api/entitlement

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -301,6 +301,7 @@ _LICENSE_PATH = os.path.expanduser("~/.clawmetry/license.key")
 _CLOUD_PLAN_CACHE = os.path.expanduser("~/.clawmetry/cloud_plan.json")
 _ENFORCE_ENABLE_VALUES = frozenset({"1", "true", "yes", "on"})
 _CACHE_TTL_SECS = 60.0
+_ENFORCE_AT_ENV = "CLAWMETRY_ENFORCE_AT"
 
 
 def is_enforced() -> bool:
@@ -310,6 +311,40 @@ def is_enforced() -> bool:
         os.environ.get("CLAWMETRY_ENFORCE", "").strip().lower()
         in _ENFORCE_ENABLE_VALUES
     )
+
+
+def enforce_at_epoch() -> float | None:
+    """Resolve the announced enforce-at moment from ``CLAWMETRY_ENFORCE_AT``.
+
+    Accepts three formats — the first parse that wins is used::
+
+        CLAWMETRY_ENFORCE_AT=2026-07-01            # ISO date (UTC midnight)
+        CLAWMETRY_ENFORCE_AT=2026-07-01T12:00:00Z  # ISO datetime
+        CLAWMETRY_ENFORCE_AT=1782950400            # epoch seconds
+
+    Unset / empty / unparseable returns ``None`` (logged at warning). Used by
+    :meth:`Entitlement.grace_remaining_days` and :meth:`Entitlement.to_dict` so
+    the dashboard can render a countdown banner ("Enforcement begins in N
+    days") without re-implementing the parse rules on the frontend. Never
+    raises."""
+    raw = os.environ.get(_ENFORCE_AT_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    try:
+        from datetime import datetime, timezone
+
+        s = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except Exception as exc:
+        logger.warning("entitlements: bad CLAWMETRY_ENFORCE_AT %r: %s", raw, exc)
+        return None
 
 
 @dataclass(frozen=True)
@@ -403,6 +438,18 @@ class Entitlement:
         except Exception:
             return ()
 
+    def grace_remaining_days(self) -> int | None:
+        """Days remaining in the grace period, or ``None`` when no enforce-at
+        date is announced (``CLAWMETRY_ENFORCE_AT`` unset). Clamps to ``0``
+        once the announced moment has passed, so the UI never shows a
+        negative countdown. Drives the dashboard countdown banner without
+        re-parsing the env var on every render."""
+        at = enforce_at_epoch()
+        if at is None:
+            return None
+        remaining = (at - time.time()) / 86400.0
+        return int(remaining) if remaining > 0 else 0
+
     def event_retention_days(self) -> int | None:
         """Days of event history this tier may keep. ``None`` means unlimited
         / custom (Enterprise). The daemon's prune loop in ``clawmetry/sync.py``
@@ -425,6 +472,19 @@ class Entitlement:
         # without re-deriving the per-tier table client-side. The daemon's
         # prune loop in ``clawmetry/sync.py`` still reads the method directly;
         # this is just the read-only API surface.
+        enforce_at = enforce_at_epoch()
+        enforce_at_iso: str | None = None
+        if enforce_at is not None:
+            try:
+                from datetime import datetime, timezone
+
+                enforce_at_iso = (
+                    datetime.fromtimestamp(enforce_at, tz=timezone.utc)
+                    .isoformat()
+                    .replace("+00:00", "Z")
+                )
+            except Exception:
+                enforce_at_iso = None
         return {
             "tier": self.tier,
             "source": self.source,
@@ -434,6 +494,9 @@ class Entitlement:
             "is_paid": self.is_paid,
             "grace": self.grace,
             "enforced": not self.grace,
+            "enforce_at": enforce_at,
+            "enforce_at_iso": enforce_at_iso,
+            "days_until_enforce": self.grace_remaining_days(),
             "retention_days": self.event_retention_days(),
             "runtimes": sorted(self.runtimes),
             "features": sorted(self.features),

--- a/tests/test_entitlement_api.py
+++ b/tests/test_entitlement_api.py
@@ -136,6 +136,40 @@ def test_api_entitlement_enforced_oss_grace_false(monkeypatch, tmp_path):
     assert d["grace"] == (not d["enforced"])
 
 
+# -- grace countdown (CLAWMETRY_ENFORCE_AT) -------------------------
+
+
+def test_api_entitlement_enforce_at_keys_unset(client):
+    """Always present on /api/entitlement so frontend can read them without
+    a feature-detect; unset means all three are null."""
+    c, _ = client
+    d = c.get("/api/entitlement").get_json()
+    for key in ("enforce_at", "enforce_at_iso", "days_until_enforce"):
+        assert key in d, key
+        assert d[key] is None
+
+
+def test_api_entitlement_enforce_at_surfaced(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "2099-01-01T00:00:00Z")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement").get_json()
+    assert d["enforce_at"] is not None
+    assert d["enforce_at_iso"] == "2099-01-01T00:00:00Z"
+    assert isinstance(d["days_until_enforce"], int)
+    assert d["days_until_enforce"] > 0
+    # Setting the countdown does NOT turn enforcement on.
+    assert d["grace"] is True
+    assert d["enforced"] is False
+
+
 # ── paid tiers ────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -325,6 +325,84 @@ def test_entitled_tier_entitles_its_runtimes(ent):
     assert en.entitled_runtime("cursor") is True
 
 
+# -- CLAWMETRY_ENFORCE_AT (grace countdown) -------------------------
+
+
+def test_enforce_at_unset_is_none(ent, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE_AT", raising=False)
+    assert ent.enforce_at_epoch() is None
+    en = ent.get_entitlement(force=True)
+    assert en.grace_remaining_days() is None
+    d = en.to_dict()
+    assert d["enforce_at"] is None
+    assert d["enforce_at_iso"] is None
+    assert d["days_until_enforce"] is None
+
+
+def test_enforce_at_iso_date_future(ent, monkeypatch):
+    # ~30 days out
+    future = time.time() + 30 * 86400
+    from datetime import datetime, timezone
+    iso = datetime.fromtimestamp(future, tz=timezone.utc).date().isoformat()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", iso)
+    at = ent.enforce_at_epoch()
+    assert at is not None
+    en = ent.get_entitlement(force=True)
+    days = en.grace_remaining_days()
+    assert days is not None and 25 <= days <= 31  # tolerate UTC midnight rounding
+    d = en.to_dict()
+    assert d["enforce_at"] == pytest.approx(at)
+    assert d["enforce_at_iso"] is not None and d["enforce_at_iso"].endswith("Z")
+    assert d["days_until_enforce"] == days
+
+
+def test_enforce_at_epoch_seconds_accepted(ent, monkeypatch):
+    future = time.time() + 7 * 86400
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", str(int(future)))
+    en = ent.get_entitlement(force=True)
+    assert en.grace_remaining_days() in (6, 7)
+    assert en.to_dict()["enforce_at"] == pytest.approx(float(int(future)))
+
+
+def test_enforce_at_iso_datetime_z_suffix(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "2099-01-01T00:00:00Z")
+    en = ent.get_entitlement(force=True)
+    d = en.to_dict()
+    assert d["enforce_at"] is not None
+    assert d["enforce_at_iso"] == "2099-01-01T00:00:00Z"
+    assert d["days_until_enforce"] is not None and d["days_until_enforce"] > 0
+
+
+def test_enforce_at_past_clamps_to_zero(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "2000-01-01")
+    en = ent.get_entitlement(force=True)
+    # Past moment: countdown is 0, never negative.
+    assert en.grace_remaining_days() == 0
+    d = en.to_dict()
+    assert d["days_until_enforce"] == 0
+    assert d["enforce_at"] is not None
+
+
+def test_enforce_at_malformed_is_graceful(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "not-a-date")
+    assert ent.enforce_at_epoch() is None
+    en = ent.get_entitlement(force=True)
+    d = en.to_dict()
+    assert d["enforce_at"] is None
+    assert d["enforce_at_iso"] is None
+    assert d["days_until_enforce"] is None
+
+
+def test_enforce_at_independent_of_enforce_flag(ent, monkeypatch):
+    """Setting the countdown env var must NOT flip grace -> enforce. Only
+    CLAWMETRY_ENFORCE does that."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "2099-01-01")
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.allows_runtime("claude_code") is True
+
+
 # ── canonical_runtime + RUNTIME_ALIASES ─────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a passive grace-countdown surface so the dashboard can render an
"Enforcement begins in N days" banner straight off `/api/entitlement`
without re-parsing the env var on the frontend.

**Zero behavior change.** The resolver stays in GRACE; only
`CLAWMETRY_ENFORCE=1` turns the gate on (unchanged). Setting
`CLAWMETRY_ENFORCE_AT` is purely informational — it does NOT flip grace
to enforce.

### Changes

* `clawmetry/entitlements.py`
  * New env var `CLAWMETRY_ENFORCE_AT` — accepts ISO date
    (`2026-07-01`), ISO datetime (`2026-07-01T00:00:00Z`), or epoch
    seconds.
  * `enforce_at_epoch()` module helper — never-raise; logs a warning
    on unparseable input.
  * `Entitlement.grace_remaining_days()` — clamps to `0` once the
    announced moment has passed, so the UI never shows a negative
    countdown.
  * `Entitlement.to_dict()` adds three keys, always present (null when
    `CLAWMETRY_ENFORCE_AT` is unset):
    * `enforce_at` — epoch seconds (float)
    * `enforce_at_iso` — ISO 8601 with `Z` suffix
    * `days_until_enforce` — int

* `tests/test_entitlements.py` — 7 new tests covering: unset / ISO date
  / epoch seconds / ISO datetime with `Z` suffix / past clamps to 0 /
  malformed graceful / independent of the `CLAWMETRY_ENFORCE` flag.

* `tests/test_entitlement_api.py` — 2 new tests: keys always present on
  `/api/entitlement` (so the frontend can read them without
  feature-detecting), and surfaced value present when the env var is
  set.

### How it composes with existing PRs

This adds three new keys to `Entitlement.to_dict()` (alongside
`tier_label`, `retention_days`, etc. from prior fires). The keys are
disjoint, so this is mergeable independently of any of the other open
draft PRs that extend `to_dict()`.

## Test plan

- [x] `python -m pytest tests/test_entitlements.py tests/test_entitlement_api.py -q` — **39 passed**
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlements.py tests/test_entitlement_api.py` — clean
- [x] `python -m py_compile` on the changed files
- [x] No new failures vs `origin/main` on the broader entitlement suite
  (`tests/test_entitlements.py`, `tests/test_entitlement_api.py`,
  `tests/test_routes_runtimes.py`, `tests/test_advertised_runtimes_match_catalogue.py`,
  `tests/test_entitlements_catalogue.py`) — 86 pass; the lone
  pre-existing failure on main (`test_route_gates.py::…/api/assets-GET`)
  is unrelated and reproduces without this change. The 3 license-wheel
  test failures (`_Resp` mock missing `headers` attr) are likewise
  pre-existing on main.

## Local operator verification checklist

Since this fire has no access to the local daemon or live cloud
snapshot, the local operator should:

- [ ] Copy `clawmetry/entitlements.py` into
      `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/`
- [ ] Clear `__pycache__/` under that dir
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s http://localhost:8900/api/entitlement | jq '{enforce_at, enforce_at_iso, days_until_enforce, grace, enforced}'`
      — confirm all three new keys are present and null (env unset)
- [ ] `CLAWMETRY_ENFORCE_AT=2099-01-01 launchctl kickstart -k …` →
      re-curl → confirm `enforce_at_iso == "2099-01-01T00:00:00Z"`,
      `days_until_enforce` is a positive int, and `grace` is still
      `true` (countdown alone does NOT flip enforcement)
- [ ] Decrypt the live cloud snapshot → `/api/entitlement` returns the
      same shape via the relay
- [ ] Browser-check: open the dashboard and confirm no console errors
      from the new keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019mcLAuTbRZGpibhz9Cy5X6)_