### PR TITLE
chore: remove stale /api/local-store diagnostic routes (#3120)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -11726,40 +11726,6 @@ def detect_config(args=None):
             "env_optout": bool(os.environ.get("CLAWMETRY_NO_CLOUD", "").strip()),
         })
 
-    # Local SQLite event store (epic #964 / phase 1) — proves the daemon is
-    # writing through to ~/.clawmetry/events.db. The dashboard's main read
-    # paths are migrating to this store progressively; in the meantime this
-    # endpoint exposes the store's own metrics so we can verify the
-    # write-through is working in prod and start the cutover safely.
-    @app.route("/api/local-store/health", endpoint="local_store_health")
-    def _local_store_health():
-        from flask import jsonify as _jsonify
-        try:
-            from clawmetry import local_store
-            # read_only=True: this health endpoint runs in the dashboard
-            # process, which must NEVER open the DuckDB writer (it would steal
-            # the lock from the sync daemon during a restart window and blank
-            # every snapshot read). health() is a read; RO is sufficient.
-            return _jsonify(local_store.get_store(read_only=True).health())
-        except Exception as _e:
-            return _jsonify({"error": str(_e)[:300]}), 503
-
-    @app.route("/api/local-store/events", endpoint="local_store_events")
-    def _local_store_events():
-        from flask import jsonify as _jsonify, request as _req
-        try:
-            from clawmetry import local_store
-            store = local_store.get_store()
-            rows = store.query_events(
-                session_id=_req.args.get("session_id"),
-                event_type=_req.args.get("event_type"),
-                since=_req.args.get("since"),
-                until=_req.args.get("until"),
-                limit=int(_req.args.get("limit", "200")),
-            )
-            return _jsonify({"events": rows, "count": len(rows)})
-        except Exception as _e:
-            return _jsonify({"error": str(_e)[:300]}), 500
     # ────────────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Two cutover-verification endpoints (`GET /api/local-store/health` and `GET /api/local-store/events`) were added during the DuckDB migration (epic #964, ~v0.12.164) to prove the daemon was writing through correctly. That migration completed ~100 versions ago (current: v0.12.275). Grep confirms zero callers in frontend JS, `sync.py`, `cli.py`, and all tests.

The `/events` handler had an additional safety issue: it called `local_store.get_store()` **without** `read_only=True`, which would have stolen the DuckDB writer lock from the sync daemon if ever invoked.

## Changes
- Remove `_local_store_health()` and its section comment (`dashboard.py:11729–11745`)
- Remove `_local_store_events()` (`dashboard.py:11747–11762`) — eliminates the write-lock footgun

## Test plan
- [x] `python3 -c 'import ast; ast.parse(open("dashboard.py").read())'` — passes
- [ ] `make lint` — verify no regressions
- [ ] Confirm neither endpoint appears in any `curl`/fetch call in the repo

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3120. See the issue comment for the full analysis of which patrol findings are false positives vs. genuine. Marked draft for human review — mark Ready for Review once happy.

Closes #3120

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkysdD99CHwYrPp8Jw6pkA)_