### PR TITLE
fix(security): strong salted KDF (scrypt) for custom passphrases

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -708,28 +708,29 @@ def _cmd_connect(args) -> None:
             print(f"❌  {e}")
             sys.exit(1)
 
-    from clawmetry.sync import generate_encryption_key
+    from clawmetry.sync import generate_encryption_key, _derive_key_for_storage
 
-    # Always prompt for encryption key — be transparent
-    # Store the raw passphrase as-is; normalization happens at encrypt/decrypt time
-    # Use --enc-key if provided (non-interactive sandbox/automated use)
+    # Always prompt for encryption key — be transparent.
+    # A typed passphrase is run through a strong salted KDF (scrypt) and we store
+    # the DERIVED key, never the raw passphrase. A pasted real key is kept as-is.
+    # Use --enc-key if provided (non-interactive sandbox/automated use).
     _enc_key_arg = getattr(args, "enc_key", None) or ""
 
     print()
     print("🔐 Encryption key protects your data end-to-end.")
     if _enc_key_arg:
-        enc_key = _enc_key_arg
+        enc_key = _derive_key_for_storage(_enc_key_arg)
         print("  Using provided encryption key.")
     elif _saved_enc_key:
         masked = _saved_enc_key[:6] + "…" + _saved_enc_key[-4:]
         print(f"  Existing key: {masked}")
         custom_key = _input("  Press Enter to keep it, or type a new one: ").strip()
-        enc_key = custom_key if custom_key else _saved_enc_key
+        enc_key = _derive_key_for_storage(custom_key) if custom_key else _saved_enc_key
     else:
         custom_key = _input(
             "  Enter a custom secret key (or press Enter to auto-generate): "
         ).strip()
-        enc_key = custom_key if custom_key else generate_encryption_key()
+        enc_key = _derive_key_for_storage(custom_key) if custom_key else generate_encryption_key()
 
     config = {
         "api_key": api_key,

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -553,6 +553,38 @@ def _normalize_encryption_key(key_str: str) -> str:
     return base64.urlsafe_b64encode(derived).decode().rstrip("=")
 
 
+def _derive_key_for_storage(key_str: str) -> str:
+    """Turn a user-supplied custom secret into the 32-byte key we PERSIST.
+
+    A value that is already a valid 16/24/32-byte base64url key is kept as-is.
+    A human passphrase is run through scrypt with a random salt (NOT the old
+    unsalted single-pass SHA-256) so a weak passphrase can't be brute-forced
+    with a global rainbow table and the same passphrase on two machines yields
+    different keys. We store the DERIVED key (the user backs it up / pastes it
+    via ``--show-key``), so the salt is ephemeral and the passphrase never
+    persists.
+
+    Existing installs that stored a raw passphrase are unaffected: their config
+    is still read through ``_normalize_encryption_key`` (legacy SHA-256) on every
+    use, so their already-encrypted cloud data keeps decrypting.
+    """
+    import os as _os_d
+    try:
+        raw = base64.urlsafe_b64decode((key_str or "") + "==")
+        if len(raw) in (16, 24, 32):
+            return key_str  # already a real key — keep it
+    except Exception:
+        pass
+    # Passphrase -> strong salted KDF. Use cryptography's Scrypt (already a core
+    # dep) rather than hashlib.scrypt, which is missing on Pythons built against
+    # LibreSSL (some macOS builds). N=2**15 keeps offline brute-force of a weak
+    # passphrase expensive; the random salt kills rainbow tables.
+    from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
+    salt = _os_d.urandom(16)
+    dk = Scrypt(salt=salt, length=32, n=2 ** 15, r=8, p=1).derive(key_str.encode())
+    return base64.urlsafe_b64encode(dk).decode().rstrip("=")
+
+
 def _get_aesgcm(key_b64: str):
     """Return an AESGCM cipher from a base64url key (auto-derives if passphrase)."""
     try:

--- a/tests/test_kdf_scrypt.py
+++ b/tests/test_kdf_scrypt.py
@@ -1,0 +1,59 @@
+"""Guard for the weak passphrase KDF (cloud #1573).
+
+A typed custom passphrase used to be stored RAW and turned into the AES key via
+unsalted single-pass SHA-256 (instant offline brute-force + a global rainbow
+table works against everyone who picked the same passphrase). Now a passphrase
+is run through scrypt with a random salt at setup and we store the DERIVED key
+(never the passphrase). Existing installs that stored a raw passphrase keep
+working via the legacy SHA-256 path in _normalize_encryption_key.
+"""
+import base64
+import hashlib
+import pathlib
+import sys
+
+# Import the repo's clawmetry, not a separately-installed copy that may shadow it
+# on a dev box (the daemon installs clawmetry into its own venv). In CI the repo
+# is the only clawmetry, so this is a no-op there.
+_ROOT = str(pathlib.Path(__file__).resolve().parents[1])
+if sys.path[:1] != [_ROOT]:
+    sys.path.insert(0, _ROOT)
+for _m in [m for m in list(sys.modules) if m == "clawmetry" or m.startswith("clawmetry.")]:
+    del sys.modules[_m]
+import clawmetry.sync as sync  # noqa: E402
+
+
+def _is_32b_key(s):
+    return len(base64.urlsafe_b64decode(s + "==")) == 32
+
+
+def test_passphrase_is_scrypt_derived_not_stored_raw():
+    k = sync._derive_key_for_storage("hunter2")
+    assert k != "hunter2", "raw passphrase must never be persisted"
+    assert _is_32b_key(k), "must store a real 32-byte key"
+
+
+def test_passphrase_derivation_is_salted():
+    # The old unsalted SHA-256 made the same passphrase -> the same key on every
+    # machine (rainbow-table-able). Salting makes two derivations differ.
+    a = sync._derive_key_for_storage("hunter2")
+    b = sync._derive_key_for_storage("hunter2")
+    assert a != b
+
+
+def test_real_key_passed_through_unchanged():
+    key = sync.generate_encryption_key()
+    assert sync._derive_key_for_storage(key) == key
+
+
+def test_legacy_raw_passphrase_still_sha256():
+    # Existing configs stored a raw passphrase; _normalize_encryption_key must
+    # keep deriving it the old way so their already-encrypted data decrypts.
+    expect = base64.urlsafe_b64encode(hashlib.sha256(b"hunter2").digest()).decode().rstrip("=")
+    assert sync._normalize_encryption_key("hunter2") == expect
+
+
+def test_derived_key_roundtrips_through_encrypt():
+    k = sync._derive_key_for_storage("a weak passphrase")
+    blob = sync.encrypt_payload({"x": 1, "secret": "abc"}, k)
+    assert sync.decrypt_payload(blob, k) == {"x": 1, "secret": "abc"}


### PR DESCRIPTION
Tracking: vivekchand/clawmetry-cloud#1573. MEDIUM.

## The bug
A typed custom secret was stored **raw** and turned into the AES key via **unsalted single-pass SHA-256**. A weak passphrase was trivially brute-forced offline, and with no salt a single global rainbow table worked against everyone who picked the same passphrase.

## The fix
`_derive_key_for_storage` runs a passphrase through **scrypt** (cryptography's Scrypt, N=2^15, random salt) **at setup** and stores the **derived** 32-byte key; the passphrase never persists. A pasted real key is kept as-is. `cli.py` applies it on every custom-key path.

**Backward compatible:** existing raw-passphrase configs keep decrypting via the unchanged legacy SHA-256 path in `_normalize_encryption_key`. Recovery model unchanged (back up the KEY via `--show-key`, not the passphrase).

Uses cryptography's Scrypt (not `hashlib.scrypt`, absent on LibreSSL Pythons).

## Verification
`tests/test_kdf_scrypt.py` (5): derived-not-raw, salted, real-key passthrough, legacy SHA-256 intact, encrypt/decrypt round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)