### PR TITLE
[RELEASE] fix(sync): restore kill/pause/resume daemon dispatch (0.12.523)

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -256,7 +256,7 @@ def _otlp_service_name_to_agent_type(service_name):
     return slug or "custom"
 
 
-__version__ = "0.12.522"
+__version__ = "0.12.523"
 
 # Extensions (Phase 2): import the plugin host now, but defer the actual
 # load_plugins() call until after the Flask app is created below so we can


### PR DESCRIPTION
Cuts **0.12.523** to ship #3129.

The runaway-agent control **dispatch wiring** (`kill_session`/`pause_session`/`resume_session` → `process_control`) and the `_post` empty-body tolerance were dropped in a stale-rebase clobber, silently breaking the web **Stop/Pause/Resume** chain. The cloud endpoints (`/api/cloud/session/*`) and the web UI (`_KILL_SWITCH_JS`) were intact the whole time — only the daemon dispatch was missing, so enqueued actions were dropped on the floor.

Restored + revert-proven RED→GREEN (26 tests). This is the foundation for the **on-device Stop/Pause/Resume** Product Hunt launch claim (firmware buttons next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)