### PR TITLE
feat(usage): surface compression-potential card in Cost lens (#2837)

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -12956,6 +12956,8 @@ async function loadUsage() {
     loadHeatmap();
     // Load prompt cache analytics (GH #979)
     loadCacheAnalytics();
+    // Load compression potential card (EPIC #2837)
+    loadCompressionPotential();
     // Load cost forecast (issue #1413)
     loadCostForecast();
     // Load spend optimization recommendations (issue #1415)
@@ -13152,6 +13154,43 @@ async function loadCacheAnalytics() {
     document.getElementById('cache-perf-content').innerHTML = html;
   } catch(e) {
     // Cache panel is optional — skip silently on error
+  }
+}
+
+async function loadCompressionPotential() {
+  try {
+    var d = await fetch('/api/usage/compression').then(function(r) { return r.json(); });
+    var title = document.getElementById('compression-potential-title');
+    var card = document.getElementById('compression-potential-card');
+    if (!title || !card) return;
+    var compSessions = d.compressible_sessions || 0;
+    if (compSessions === 0) return;
+    title.style.display = '';
+    card.style.display = '';
+
+    function fmtToks(n) { return n >= 1e6 ? (n/1e6).toFixed(1)+'M' : n >= 1e3 ? (n/1e3).toFixed(0)+'K' : String(n||0); }
+    function fmtCost(c) { return c >= 0.01 ? '$'+c.toFixed(2) : c > 0 ? '<$0.01' : '$0.00'; }
+
+    var recoverUsd = d.total_recoverable_usd || 0;
+    var compTok = d.total_compressible_tokens || 0;
+    var totalSess = d.session_count || 0;
+    var pct = totalSess > 0 ? Math.round(compSessions / totalSess * 100) : 0;
+    var recColor = recoverUsd >= 0.10 ? '#f59e0b' : '#64748b';
+
+    var html = '<div style="display:flex;flex-wrap:wrap;gap:16px;align-items:flex-start;">'
+      + '<div style="min-width:120px;text-align:center;">'
+      + '<div style="font-size:32px;font-weight:700;color:'+recColor+';">'+fmtCost(recoverUsd)+'</div>'
+      + '<div style="font-size:11px;color:var(--text-muted);margin-top:2px;">recoverable spend</div>'
+      + '<div style="font-size:11px;color:var(--text-muted);margin-top:4px;">'+compSessions+' of '+totalSess+' sessions ('+pct+'%)</div>'
+      + '</div>'
+      + '<div style="flex:1;min-width:180px;">'
+      + '<div style="font-size:13px;margin-bottom:8px;">🗜️ '+fmtToks(compTok)+' compressible tokens across '+compSessions+' session'+(compSessions!==1?'s':'')+' (&ge;50% tool output)</div>'
+      + '<div style="font-size:12px;color:var(--text-muted);">JSON, diffs, and logs in tool results can be compressed without changing answers — recoverable without modifying prompts.</div>'
+      + '</div></div>';
+
+    document.getElementById('compression-potential-content').innerHTML = html;
+  } catch(e) {
+    // Compression panel is optional — skip silently on error
   }
 }
 

--- a/clawmetry/templates/tabs/usage.html
+++ b/clawmetry/templates/tabs/usage.html
@@ -56,6 +56,13 @@
   <div class="card" id="cache-perf-card" style="display:none;">
     <div id="cache-perf-content" style="min-height:48px;color:var(--text-muted);"></div>
   </div>
+  <!-- Compression Potential (EPIC #2837) — recoverable spend from compressible tool output.
+       JS: app.js loadCompressionPotential() -> /api/usage/compression.
+       Hidden until at least one session with high compression potential exists. -->
+  <div class="section-title" id="compression-potential-title" style="display:none;">🗜️ Compression Potential <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">recoverable spend · compressible tool output</span></div>
+  <div class="card" id="compression-potential-card" style="display:none;">
+    <div id="compression-potential-content" style="min-height:48px;color:var(--text-muted);"></div>
+  </div>
   <!-- Issue #68 — top sessions by cost (per-session breakdown) -->
   <div class="section-title">🏆 <span data-i18n="usage.top_sessions_by_cost">Top Sessions by Cost</span> <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;" data-i18n="usage.top_sessions_hint">which session burned the budget · top 20</span></div>
   <div class="card"><table class="usage-table" id="usage-top-sessions-table"><tbody><tr><td colspan="6" style="color:#666;" data-i18n="app.loading">Loading...</td></tr></tbody></table></div>

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -4269,3 +4269,53 @@ def api_efficiency():
         entry["runtime"] = runtime
         return jsonify(entry)
     return jsonify(out)
+
+
+def _agg_compression(rows: list) -> dict:
+    """Aggregate compression-potential metrics across session rows.
+
+    Rows are the dicts returned by ``query_sessions_table`` with ``metadata``
+    already decoded.  Only sessions with >=50% compression potential AND
+    >=2 000 compressible tokens count as high-potential (mirrors the threshold
+    used by ``_derive_waste_summary`` in routes/sessions.py).
+    """
+    total = 0
+    high = 0
+    total_tok = 0
+    total_usd = 0.0
+    for row in rows or []:
+        if not isinstance(row, dict):
+            continue
+        md = row.get("metadata") or {}
+        if not isinstance(md, dict):
+            continue
+        total += 1
+        cpp = md.get("compressionPotentialPct")
+        ctok = md.get("compressibleToolTokens") or 0
+        cru = md.get("compressionRecoverableUsd")
+        if cpp is not None and float(cpp) >= 50 and int(ctok) >= 2000:
+            high += 1
+            total_tok += int(ctok)
+            total_usd += float(cru or 0.0)
+    return {
+        "session_count": total,
+        "compressible_sessions": high,
+        "total_compressible_tokens": total_tok,
+        "total_recoverable_usd": round(total_usd, 4),
+    }
+
+
+@bp_usage.route("/api/usage/compression")
+def api_usage_compression():
+    """Aggregate compression-potential metrics across all sessions (EPIC #2837).
+
+    Returns:
+      {
+        session_count:             int   -- total sessions with metadata
+        compressible_sessions:     int   -- sessions with >=50% potential + >=2K tokens
+        total_compressible_tokens: int   -- sum of compressible tokens for those sessions
+        total_recoverable_usd:     float -- sum of recoverable spend for those sessions
+      }
+    """
+    rows = _ls_call("query_sessions_table", limit=2000) or []
+    return jsonify(_agg_compression(rows))

--- a/tests/test_compression_potential.py
+++ b/tests/test_compression_potential.py
@@ -53,6 +53,42 @@ def test_detector_never_raises_on_garbage():
     assert S._session_compression_potential([object()]) == {}
 
 
+def test_aggregate_compression():
+    from routes.usage import _agg_compression
+    rows = [
+        {"metadata": {"compressionPotentialPct": 85.0, "compressibleToolTokens": 5000,
+                      "compressionRecoverableUsd": 0.05}},
+        {"metadata": {"compressionPotentialPct": 10.0, "compressibleToolTokens": 100}},
+        {"metadata": {}},
+        {"metadata": None},
+        "not-a-dict",
+    ]
+    agg = _agg_compression(rows)
+    assert agg["session_count"] == 4  # None metadata coerces to {} and still counts
+    assert agg["compressible_sessions"] == 1
+    assert agg["total_compressible_tokens"] == 5000
+    assert round(agg["total_recoverable_usd"], 2) == 0.05
+
+
+def test_aggregate_compression_empty():
+    from routes.usage import _agg_compression
+    assert _agg_compression([]) == {
+        "session_count": 0, "compressible_sessions": 0,
+        "total_compressible_tokens": 0, "total_recoverable_usd": 0.0,
+    }
+
+
+def test_aggregate_compression_below_threshold():
+    from routes.usage import _agg_compression
+    rows = [
+        {"metadata": {"compressionPotentialPct": 85.0, "compressibleToolTokens": 100}},
+        {"metadata": {"compressionPotentialPct": 40.0, "compressibleToolTokens": 5000}},
+    ]
+    agg = _agg_compression(rows)
+    assert agg["compressible_sessions"] == 0
+    assert agg["total_recoverable_usd"] == 0.0
+
+
 def test_waste_summary_rolls_up_compression_and_cache_expiry():
     sessions = [
         {"session_id": "a", "cost_usd": 1.0,


### PR DESCRIPTION
## Summary

The sync daemon already computes `compressionPotentialPct`, `compressibleToolTokens`, and `compressionRecoverableUsd` per session and stores them in the DuckDB sessions metadata blob. The Sessions panel already reads and uses them — but the **Usage tab / Cost lens had no aggregate view** of total recoverable spend across all sessions. This wires up sub-task #1 of EPIC #2837 (Compression Potential card).

## Changes

- **`routes/usage.py`**: adds `_agg_compression(rows)` helper (aggregates camelCase metadata fields, mirrors threshold logic from `_derive_waste_summary` in `routes/sessions.py`) and a `/api/usage/compression` route that calls `_ls_call("query_sessions_table")` and returns the aggregate (~47 LOC)
- **`clawmetry/templates/tabs/usage.html`**: adds `#compression-potential-card` section after the cache-perf card — hidden by default, shown by JS when at least one high-compression session exists (~7 LOC)
- **`clawmetry/static/js/app.js`**: adds `loadCompressionPotential()` (mirrors `loadCacheAnalytics()`) and calls it from `loadUsage()` (~38 LOC)
- **`tests/test_compression_potential.py`**: adds 3 new tests for `_agg_compression` covering the success path, empty input, and below-threshold filtering (~30 LOC)

## Test plan

- [ ] `PYTHONPATH=/tmp/pylibs python3 -m pytest tests/test_compression_potential.py -v` — 8 tests pass (4 pre-existing + 3 new `test_aggregate_compression*`)
- [ ] `python3 -c 'import ast; ast.parse(open("routes/usage.py").read())'` — syntax clean
- [ ] `node --check clawmetry/static/js/app.js` — syntax clean
- [ ] Locally: Usage tab shows "Compression Potential" card only when DuckDB has sessions with ≥50% compression potential + ≥2K compressible tokens; otherwise the section stays hidden
- [ ] No changes to ingestion, write paths, or DuckDB schema

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #2837. Marked draft for human review — mark Ready for Review once happy.

Partially addresses #2837 (sub-task: Compression Potential card)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1aTXKRbp1oGbbtPg2QNf9)_