### PR TITLE
feat(entitlement): canonical_runtime() + RUNTIME_ALIASES alias map

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -111,6 +111,27 @@ RUNTIME_LABELS = {
     "nanoclaw": "NanoClaw",
 }
 
+# Common alternative spellings that callers (custom ingest, OTLP service.name,
+# CLI flags) sometimes use. Mapped to the canonical snake_case identifier so the
+# gate and the labels lookup don't reject a runtime over a stray hyphen. The
+# canonical id is always the value; only the keys differ.
+RUNTIME_ALIASES = {
+    "claude-code": "claude_code",
+    "claudecode": "claude_code",
+    "qwen-code": "qwen_code",
+    "qwencode": "qwen_code",
+    "open-code": "opencode",
+    "open_code": "opencode",
+    "open-claw": "openclaw",
+    "open_claw": "openclaw",
+    "nemo-claw": "nemoclaw",
+    "nemo_claw": "nemoclaw",
+    "pico-claw": "picoclaw",
+    "pico_claw": "picoclaw",
+    "nano-claw": "nanoclaw",
+    "nano_claw": "nanoclaw",
+}
+
 # Display labels for every known feature. Mirrors the runtime label map and is
 # the source of truth the dashboard reads via ``/api/features`` so the locked-
 # but-visible affordance on paid features renders human-readable copy. Adding a
@@ -174,6 +195,7 @@ FEATURE_LABELS = {
 _ALIAS_FEATURES = frozenset(
     {"custom_alerts", "alert_webhooks", "anomaly_detection", "cost_optimizer"}
 )
+
 
 # ── Feature catalogue ───────────────────────────────────────────────────────
 # Core observability — always free. Keys are stable identifiers the route /
@@ -664,10 +686,34 @@ def available_runtimes() -> list[str]:
     return sorted(ent.runtimes)
 
 
+def canonical_runtime(runtime: str) -> str:
+    """Normalize a runtime identifier to its canonical snake_case key.
+
+    Accepts the common alternative spellings (hyphenated, no-separator, mixed
+    case) callers sometimes pass — OTLP ``service.name``, custom ingest, CLI
+    flags — and resolves them to the id used in :data:`ALL_RUNTIMES`. Unknown
+    identifiers are returned lower-cased unchanged so plugin runtimes still
+    pass through. Empty / non-string inputs return an empty string.
+
+    Never raises.
+    """
+    try:
+        rt = (runtime or "").strip().lower()
+    except Exception:
+        return ""
+    if not rt:
+        return ""
+    if rt in ALL_RUNTIMES:
+        return rt
+    return RUNTIME_ALIASES.get(rt, rt)
+
+
 def runtime_label(runtime: str) -> str:
-    """Human-readable label for ``runtime``. Falls back to the id when unknown
-    so unknown plugin runtimes still render with *something*."""
-    rt = (runtime or "").strip().lower()
+    """Human-readable label for ``runtime``. Aliases (``claude-code``,
+    ``qwencode``, …) resolve to the canonical id first so they render with the
+    same label as the snake_case form. Falls back to the (canonicalised) id
+    when unknown so unknown plugin runtimes still render with *something*."""
+    rt = canonical_runtime(runtime)
     return RUNTIME_LABELS.get(rt, rt)
 
 

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -325,6 +325,71 @@ def test_entitled_tier_entitles_its_runtimes(ent):
     assert en.entitled_runtime("cursor") is True
 
 
+# ── canonical_runtime + RUNTIME_ALIASES ─────────────────────────────────────
+
+
+def test_canonical_runtime_passthrough_for_known_ids(ent):
+    for rt in ent.ALL_RUNTIMES:
+        assert ent.canonical_runtime(rt) == rt
+
+
+def test_canonical_runtime_resolves_aliases(ent):
+    cases = {
+        "claude-code": "claude_code",
+        "claudecode": "claude_code",
+        "qwen-code": "qwen_code",
+        "qwencode": "qwen_code",
+        "open-code": "opencode",
+        "open_code": "opencode",
+        "open-claw": "openclaw",
+        "open_claw": "openclaw",
+        "nemo-claw": "nemoclaw",
+        "nemo_claw": "nemoclaw",
+        "pico-claw": "picoclaw",
+        "pico_claw": "picoclaw",
+        "nano-claw": "nanoclaw",
+        "nano_claw": "nanoclaw",
+    }
+    for alias, canonical in cases.items():
+        assert ent.canonical_runtime(alias) == canonical, alias
+
+
+def test_canonical_runtime_is_case_insensitive(ent):
+    assert ent.canonical_runtime("CLAUDE-CODE") == "claude_code"
+    assert ent.canonical_runtime("  Claude-Code  ") == "claude_code"
+    assert ent.canonical_runtime("OpenClaw") == "openclaw"
+
+
+def test_canonical_runtime_unknown_passes_through_lowercased(ent):
+    assert ent.canonical_runtime("brand_new_plugin_runtime") == "brand_new_plugin_runtime"
+    assert ent.canonical_runtime("BRAND_NEW") == "brand_new"
+
+
+def test_canonical_runtime_empty_and_none_safe(ent):
+    assert ent.canonical_runtime("") == ""
+    assert ent.canonical_runtime(None) == ""
+    assert ent.canonical_runtime("   ") == ""
+
+
+def test_runtime_label_resolves_via_aliases(ent):
+    # Aliases now hit the same label as the canonical id, so UI strings stay
+    # consistent regardless of which form the caller passed in.
+    assert ent.runtime_label("claude-code") == "Claude Code"
+    assert ent.runtime_label("CLAUDECODE") == "Claude Code"
+    assert ent.runtime_label("qwen-code") == "Qwen Code"
+    assert ent.runtime_label("open-claw") == "OpenClaw"
+
+
+def test_runtime_aliases_all_resolve_to_known_runtimes(ent):
+    # Every alias value must be a canonical runtime — otherwise the alias is
+    # mapping to nothing the gate or label lookup understands.
+    for alias, canonical in ent.RUNTIME_ALIASES.items():
+        assert canonical in ent.ALL_RUNTIMES, alias
+        # The alias key itself must NOT already be a canonical id (an alias
+        # for itself is dead weight).
+        assert alias not in ent.ALL_RUNTIMES, alias
+
+
 def test_appjs_teaser_wiring():
     """The catalog loader must use `entitled` (grace teaser) and must NOT
     early-return when enforcement is off, while guarding hosted paying/trial


### PR DESCRIPTION
## What

Add `canonical_runtime()` + `RUNTIME_ALIASES` to `clawmetry/entitlements.py`,
and route `runtime_label()` through the normaliser so aliases render with the
same human label as the canonical id.

```py
canonical_runtime("CLAUDE-CODE")  # -> "claude_code"
canonical_runtime("claudecode")   # -> "claude_code"
canonical_runtime("openclaw")     # -> "openclaw"
canonical_runtime("custom_rt")    # -> "custom_rt"   (unknown id passes through)
canonical_runtime("")             # -> ""
canonical_runtime(None)           # -> ""
runtime_label("claude-code")      # -> "Claude Code"
runtime_label("open-claw")        # -> "OpenClaw"
```

Aliases covered: every paid runtime + the two free runtimes, in their
hyphenated and no-separator forms (`claude-code`, `claudecode`, `qwen-code`,
`qwencode`, `open-code`, `open_code`, `open-claw`, `nemo-claw`, …).

## Why

Custom ingest, OTLP `service.name`, and CLI flags routinely emit the
hyphenated or no-separator spelling. The gate (`allows_runtime`) and the
label lookup (`RUNTIME_LABELS`) both key on the canonical snake_case id, so
those callers silently fell through to the lowercased input. This makes the
normalisation an opt-in helper callers can use *before* gating, and quietly
upgrades `runtime_label()` so the UI shows "Claude Code" instead of
"claude-code" regardless of which form the upstream system passed.

Gate methods (`allows_runtime`, `entitled_runtime`) are deliberately
untouched — keeping the helper opt-in avoids any behaviour change in grace
mode and keeps the diff additive.

## Files touched

- `clawmetry/entitlements.py` — add `RUNTIME_ALIASES`, `canonical_runtime()`,
  route `runtime_label()` through the normaliser.
- `tests/test_entitlements.py` — 7 new tests covering passthrough,
  alias resolution, case/whitespace, unknown-id passthrough, None/empty,
  alias-aware `runtime_label`, and a structural invariant on the alias map.

## Tests

```
$ python3 -m pytest tests/test_entitlements.py -x -q
..............................                                           [100%]
30 passed in 0.26s
```

Adjacent suites stay green (3 pre-existing `_Resp.headers` failures in
`tests/test_license.py::test_auto_provision_*` reproduce on `origin/main`
and are unrelated to this change).

## Grace + enforce semantics

No change. `allows_runtime` / `entitled_runtime` / `allows_feature` are
untouched; `runtime_catalog()` keeps returning canonical ids; `to_dict()`
output is byte-identical. The only user-visible change is `runtime_label`
no longer returning the hyphenated form when an alias is passed in.

## Local operator verification checklist

This PR is **DRAFT** because remote CI is the only thing I can drive from
here. Local verification still needs:

- [ ] Copy changed files into the live install:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/`
      (adjust Python minor version as needed).
- [ ] Clear `__pycache__/` under that site-packages path.
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
      (or the equivalent systemd-user / Windows service restart).
- [ ] Sanity-hit `GET /api/entitlement` and `GET /api/runtimes` — both
      should return the same JSON shape as before; `runtimes[].label`
      stays canonical.
- [ ] (Optional) call `from clawmetry.entitlements import canonical_runtime;
      canonical_runtime("claude-code")` in a REPL and confirm
      `"claude_code"`.
- [ ] Decrypt the live cloud snapshot in the browser and confirm no
      regression in the runtime switcher.
- [ ] Merge when satisfied; this PR does **not** bump `__version__` and
      does **not** open a `[RELEASE]` PR — the release flywheel is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014DPX3Vp6BdrsEV8RuTSH34)_