### PR TITLE
feat(entitlement): emit `entitlement.changed` on tier transitions

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -368,12 +368,69 @@ def _read_cloud_plan() -> Entitlement | None:
 _lock = threading.Lock()
 _cache: dict = {"ent": None, "ts": 0.0, "enforce": None}
 
+# Memo of the tier we last announced on the extension bus. Drives
+# :func:`_maybe_emit_change` so ``entitlement.changed`` fires on a genuine
+# transition (OSS -> cloud_pro after the daemon writes a plan cache, pro ->
+# oss after ``clawmetry license deactivate``) and stays quiet on the every-
+# minute cache refresh that resolves to the same tier. Lock-guarded so two
+# concurrent fresh resolves never double-emit the initial tier.
+_last_emitted_tier: str | None = None
+
+
+def _maybe_emit_change(ent: Entitlement) -> None:
+    """Emit ``entitlement.changed`` to the extension bus on a tier transition.
+
+    The first successful resolution emits with ``previous_tier=None`` so a
+    listener registered before startup hears the initial tier exactly once.
+    Subsequent resolutions to the same tier are no-ops, so the every-minute
+    cache refresh does not spam the bus. Best-effort end-to-end: a missing
+    ``clawmetry.extensions`` import or a misbehaving listener is logged at
+    debug and swallowed — the resolver must never crash a request path.
+
+    Payload::
+
+        {"previous_tier": "<old>"|None, "tier": "<new>",
+         "source": "license"|"cloud"|"oss", "is_paid": bool, "grace": bool}
+    """
+    global _last_emitted_tier
+    try:
+        with _lock:
+            if _last_emitted_tier == ent.tier:
+                return
+            previous = _last_emitted_tier
+            _last_emitted_tier = ent.tier
+        try:
+            from clawmetry import extensions as _ext
+        except Exception:
+            return
+        try:
+            _ext.emit(
+                "entitlement.changed",
+                {
+                    "previous_tier": previous,
+                    "tier": ent.tier,
+                    "source": ent.source,
+                    "is_paid": ent.is_paid,
+                    "grace": ent.grace,
+                },
+            )
+        except Exception as exc:
+            logger.debug("entitlements: emit failed: %s", exc)
+    except Exception as exc:
+        logger.debug("entitlements: change-emit skipped: %s", exc)
+
 
 def get_entitlement(force: bool = False) -> Entitlement:
     """Resolve (and cache) the current entitlement. Cheap by design — the
     FLYWHEEL performance budget forbids a per-request network call, so the
     result is cached for ``_CACHE_TTL_SECS``. The cache also busts when the
-    enforce flag flips. Never raises: any failure returns OSS-free."""
+    enforce flag flips. Never raises: any failure returns OSS-free.
+
+    On every fresh resolution (cache miss) the resolved entitlement is fed
+    through :func:`_maybe_emit_change`, which fires ``entitlement.changed``
+    on the extension bus iff the tier changed since the previous emit. Cache
+    hits skip the emit so the bus stays quiet on steady-state reads.
+    """
     try:
         enforce = is_enforced()
         with _lock:
@@ -388,6 +445,7 @@ def get_entitlement(force: bool = False) -> Entitlement:
         ent = _read_local_license() or _read_cloud_plan() or _oss_free()
         with _lock:
             _cache.update(ent=ent, ts=time.time(), enforce=enforce)
+        _maybe_emit_change(ent)
         return ent
     except Exception as exc:
         logger.warning("entitlements: resolution failed, defaulting to OSS free: %s", exc)

--- a/tests/test_entitlement_change_emit.py
+++ b/tests/test_entitlement_change_emit.py
@@ -1,0 +1,251 @@
+"""Tests for the ``entitlement.changed`` extension-bus emit.
+
+``clawmetry/entitlements.py`` fires ``entitlement.changed`` through
+``clawmetry/extensions.py`` on every tier transition so the closed-source
+``clawmetry-pro`` plugin (and any other listener) can react when
+``clawmetry license activate`` / ``deactivate`` or the daemon's cloud-plan
+cache writes a new tier.
+
+Headline invariants pinned here:
+
+* First fresh resolution emits exactly once with ``previous_tier=None``.
+* Cache hits and resolutions that land on the same tier do NOT re-emit
+  (so the every-minute cache refresh never spams the bus).
+* A genuine tier transition (OSS -> cloud_pro via a cloud_plan cache write)
+  fires a second emit with the right ``previous_tier`` / ``tier`` pair.
+* Concurrent fresh resolves never double-emit the initial tier.
+* A listener raising never propagates out of ``get_entitlement``.
+* An ``ImportError`` on ``clawmetry.extensions`` (defensive) never crashes
+  resolution.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import threading
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module rooted at an empty HOME, enforcement off,
+    listener registry snapshotted/restored, and the emit memo reset."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.extensions as ext_mod
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)  # re-expand ~ against the patched HOME
+    e.invalidate()
+    e._last_emitted_tier = None
+
+    # Snapshot the event registry so listeners registered by a test can't
+    # leak into the next one.
+    saved_registry = {k: list(v) for k, v in ext_mod._registry.items()}
+    ext_mod._registry.clear()
+
+    try:
+        yield e
+    finally:
+        e.invalidate()
+        e._last_emitted_tier = None
+        ext_mod._registry.clear()
+        ext_mod._registry.update({k: list(v) for k, v in saved_registry.items()})
+
+
+def _listen(ext_mod):
+    """Register a list-collecting listener and return the list."""
+    received: list[dict] = []
+    ext_mod.register("entitlement.changed", lambda p: received.append(p))
+    return received
+
+
+def _write_cloud_plan(home, plan="cloud_pro", node_limit=5, expiry=None):
+    """Drop a cloud_plan.json with ``plan`` so the resolver picks it up."""
+    cm = home / ".clawmetry"
+    cm.mkdir(parents=True, exist_ok=True)
+    payload = {"plan": plan, "node_limit": node_limit}
+    if expiry is not None:
+        payload["expiry"] = expiry
+    (cm / "cloud_plan.json").write_text(json.dumps(payload))
+
+
+# ── first emit ───────────────────────────────────────────────────────────────
+
+
+def test_first_resolution_emits_once(ent):
+    import clawmetry.extensions as ext_mod
+    received = _listen(ext_mod)
+
+    ent.get_entitlement(force=True)
+    assert len(received) == 1
+    e0 = received[0]
+    assert e0["tier"] == ent.TIER_OSS
+    assert e0["previous_tier"] is None
+    assert e0["source"] == "oss"
+    assert e0["is_paid"] is False
+    assert e0["grace"] is True
+
+
+def test_listener_registered_after_resolution_misses_initial_emit(ent):
+    """The bus is fire-and-forget; a listener that registers AFTER the first
+    resolution does not retroactively hear the initial tier. Documenting the
+    contract so the operator knows to call ``get_entitlement`` themselves
+    when probing current state."""
+    import clawmetry.extensions as ext_mod
+    ent.get_entitlement(force=True)  # initial emit lands in the void
+    received = _listen(ext_mod)
+    ent.get_entitlement(force=True)
+    assert received == []  # same tier -> silent
+
+
+# ── steady-state silence ─────────────────────────────────────────────────────
+
+
+def test_same_tier_resolution_does_not_re_emit(ent):
+    import clawmetry.extensions as ext_mod
+    received = _listen(ext_mod)
+    ent.get_entitlement(force=True)
+    ent.get_entitlement(force=True)
+    ent.get_entitlement(force=True)
+    assert len(received) == 1  # only the initial transition None -> oss
+
+
+def test_cache_hit_does_not_emit(ent):
+    """Within the 60s cache TTL, get_entitlement() returns the memoised
+    Entitlement without re-running resolution or the emit hook."""
+    import clawmetry.extensions as ext_mod
+    ent.get_entitlement(force=True)  # primes cache + fires initial emit
+    received = _listen(ext_mod)
+    for _ in range(10):
+        ent.get_entitlement()  # no force=True -> cache-hit path
+    assert received == []
+
+
+def test_invalidate_then_same_tier_still_quiet(ent):
+    """``invalidate()`` busts the cache but NOT the emit memo, so a
+    re-resolve that lands on the same tier stays silent. (The "did we
+    actually transition?" question is independent of "is the cache hot?")."""
+    import clawmetry.extensions as ext_mod
+    ent.get_entitlement(force=True)
+    received = _listen(ext_mod)
+    ent.invalidate()
+    ent.get_entitlement(force=True)
+    assert received == []
+
+
+# ── real tier transitions ───────────────────────────────────────────────────
+
+
+def test_oss_to_cloud_pro_transition_emits(ent, tmp_path):
+    import clawmetry.extensions as ext_mod
+    received = _listen(ext_mod)
+
+    ent.get_entitlement(force=True)
+    assert received[-1]["tier"] == ent.TIER_OSS
+
+    _write_cloud_plan(tmp_path, plan="cloud_pro", node_limit=11)
+    ent.invalidate()
+    ent.get_entitlement(force=True)
+
+    assert len(received) == 2
+    e1 = received[1]
+    assert e1["previous_tier"] == ent.TIER_OSS
+    assert e1["tier"] == ent.TIER_CLOUD_PRO
+    assert e1["source"] == "cloud"
+    assert e1["is_paid"] is True
+
+
+def test_paid_to_oss_transition_emits(ent, tmp_path):
+    """Activating then deactivating a license fires both transitions."""
+    import clawmetry.extensions as ext_mod
+    received = _listen(ext_mod)
+
+    _write_cloud_plan(tmp_path, plan="cloud_starter", node_limit=3)
+    ent.get_entitlement(force=True)
+    # Remove the cache file so the next force-refresh resolves OSS.
+    (tmp_path / ".clawmetry" / "cloud_plan.json").unlink()
+    ent.invalidate()
+    ent.get_entitlement(force=True)
+
+    tiers = [(e["previous_tier"], e["tier"]) for e in received]
+    assert tiers == [
+        (None, ent.TIER_CLOUD_STARTER),
+        (ent.TIER_CLOUD_STARTER, ent.TIER_OSS),
+    ]
+
+
+# ── never-raise contract ────────────────────────────────────────────────────
+
+
+def test_misbehaving_listener_does_not_break_resolution(ent):
+    import clawmetry.extensions as ext_mod
+
+    def boom(_payload):
+        raise RuntimeError("listener exploded")
+
+    ext_mod.register("entitlement.changed", boom)
+    # The exception must be swallowed by ext.emit and never bubble up.
+    out = ent.get_entitlement(force=True)
+    assert out.tier == ent.TIER_OSS
+
+
+def test_missing_extensions_module_does_not_break_resolution(ent, monkeypatch):
+    """If ``clawmetry.extensions`` is somehow unimportable (vendoring shenanigans,
+    a broken install), resolution still returns the right tier."""
+    import sys
+    import clawmetry.extensions as ext_mod
+    saved = sys.modules.pop("clawmetry.extensions", None)
+    try:
+        # Force the late ``from clawmetry import extensions`` inside
+        # _maybe_emit_change to raise ImportError.
+        monkeypatch.setitem(sys.modules, "clawmetry.extensions", None)
+        out = ent.get_entitlement(force=True)
+        assert out.tier == ent.TIER_OSS
+    finally:
+        if saved is not None:
+            sys.modules["clawmetry.extensions"] = saved
+        else:
+            sys.modules.pop("clawmetry.extensions", None)
+        # Restore the real module for the next test.
+        importlib.reload(ext_mod)
+
+
+# ── concurrency: no double-emit on the initial tier ─────────────────────────
+
+
+def test_concurrent_first_resolves_emit_once(ent):
+    """Two threads racing the very first ``get_entitlement(force=True)`` must
+    produce exactly one emit (the lock-guarded memo prevents double-fire)."""
+    import clawmetry.extensions as ext_mod
+    received: list[dict] = []
+    received_lock = threading.Lock()
+
+    def listener(p):
+        with received_lock:
+            received.append(p)
+
+    ext_mod.register("entitlement.changed", listener)
+
+    barrier = threading.Barrier(8)
+    errors: list[BaseException] = []
+
+    def worker():
+        try:
+            barrier.wait(timeout=5)
+            ent.get_entitlement(force=True)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert not errors
+    assert len(received) == 1
+    assert received[0]["previous_tier"] is None
+    assert received[0]["tier"] == ent.TIER_OSS


### PR DESCRIPTION
## Summary

Wire `clawmetry.entitlements` into the existing `clawmetry.extensions` bus
so a listener can react when the resolved tier changes. Today there is no
in-process signal — a `clawmetry-pro` plugin that wants to (re-)register
blueprints on activation, a cloud-relay that wants to push tier
transitions, or an audit producer that wants to log "OSS → cloud_pro" has
to poll `/api/entitlement` or scrape logs. This closes that gap with a
single bus event.

```python
from clawmetry import extensions
def on_change(payload):
    if payload["tier"] == "cloud_pro" and payload["previous_tier"] == "oss":
        ...
extensions.register("entitlement.changed", on_change)
```

Payload:

```jsonc
{
  "previous_tier": "<old>" | null,   // null on the first emit
  "tier":          "<new>",
  "source":        "license" | "cloud" | "oss",
  "is_paid":       bool,
  "grace":         bool
}
```

## Behaviour

* **First fresh resolution** emits exactly once with `previous_tier=null`
  so an OSS-only install gets a single startup-time announcement of its
  tier.
* **Same-tier resolutions are silent.** The every-minute cache refresh
  resolves to the same tier and never re-emits — the bus is for
  transitions, not heartbeats.
* **Genuine transitions fire.** `clawmetry license activate` (OSS → Pro)
  and the daemon's cloud-plan cache write (OSS → cloud_pro) and
  `clawmetry license deactivate` (Pro → OSS) each produce one emit with
  the correct `previous_tier` / `tier` pair.
* **Lock-guarded memo** prevents two concurrent fresh resolves from
  double-emitting the initial tier.
* **Never-raise end-to-end.** A missing `clawmetry.extensions` import or
  a listener that raises is swallowed at debug; the resolver still
  returns the right `Entitlement` and never crashes a request path.

## Scope

### `clawmetry/entitlements.py`

* New module-level `_last_emitted_tier: str | None = None` next to the
  existing `_cache` / `_lock`.
* New `_maybe_emit_change(ent)` helper, ~30 lines, lock-guarded memo
  update + late `from clawmetry import extensions` import so this file
  stays import-cycle-free.
* `get_entitlement(force=…)` calls `_maybe_emit_change(ent)` after the
  fresh-resolve cache update. Cache-hit short-circuit unchanged, so
  steady-state reads never touch the bus.
* `invalidate()` is intentionally NOT changed — busting the cache must
  not re-fire a same-tier emit (the memo tracks what we announced to
  listeners, independent of cache liveness).

### `tests/test_entitlement_change_emit.py` (new, 10 tests, ~0.11s)

* First resolution emits once with the right payload.
* Listener that registers AFTER the first resolution misses the initial
  emit (documents the fire-and-forget contract).
* Same-tier force-refresh + cache-hit reads are silent.
* `invalidate()` followed by a same-tier resolve stays silent.
* OSS → cloud_pro transition (via dropping `~/.clawmetry/cloud_plan.json`)
  emits with `previous_tier=oss`.
* paid → OSS (delete the plan file then force-refresh) emits the reverse
  transition.
* A listener that raises does NOT propagate out of `get_entitlement`.
* A vanished `clawmetry.extensions` module (`sys.modules[…] = None`) does
  NOT crash resolution.
* 8 threads racing the very first force-refresh produce exactly one emit.

## Why this isn't in any of the in-flight entitlement drafts

The open entitlement PR stack (`feature_catalog` / `tier_catalog` /
`tier_label` / `lock_reason` / `gate_runtime` / `allows_node_count` /
`allows_retention_window` / `min_tier_for_feature` / `upgrade_diff` /
`canonical_runtime` / `resolution_diagnostic` / `/api/entitlement/refresh`
/ …) all extends the **resolved-Entitlement** surface or the **catalog**
surface. This PR adds an orthogonal axis: the **bus signal** when the
resolved tier transitions. Distinct symbol (`_maybe_emit_change`),
distinct memo (`_last_emitted_tier`), distinct test file. Inserts
between the existing `_cache` declaration and `get_entitlement`, no
edit-window overlap with the other drafts.

## No behaviour change

Pure additive bus signal. No `allows_*` semantics changed, no
`to_dict()` change, no catalog change, no `__version__` bump, no
enforcement flipped. Grace stays the default. On an OSS install with
zero listeners the only observable effect is one extra dict
construction + a `frozenset.contains` check per fresh resolution
(roughly one cache miss / minute).

## Test plan

* [x] `python3 -m py_compile clawmetry/entitlements.py tests/test_entitlement_change_emit.py` — clean
* [x] `python3 -m pytest tests/test_entitlement_change_emit.py -v` — **10/10 pass in 0.11s**
* [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py tests/test_extensions.py tests/test_entitlement_change_emit.py -q` — **61/61 pass in 0.62s** (no regression in adjacent surfaces)
* [x] `python3 -m pytest tests/test_license.py tests/test_license_api.py tests/test_sync_loads_plugins.py tests/test_proxy_loads_plugins.py tests/test_claudecode_loads_plugins.py -q` — **44/44 pass** (license + plugin-loader paths green)
* [x] `ruff check clawmetry/entitlements.py tests/test_entitlement_change_emit.py` — **All checks passed!**
* [ ] Frontend / cloud-relay listener wiring — separate PR (this PR only adds the producer).

## Local operator verification checklist

This agent has no access to the user's local machine, the running
daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please
complete on a real install:

1. `git fetch origin feat/entitlement-event-emit-on-tier-change && git checkout feat/entitlement-event-emit-on-tier-change`
2. Copy the changed file into the live install:
   ```bash
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/entitlements.py
   ```
3. Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
4. Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. Confirm the existing surface is unchanged: `curl -s http://localhost:8900/api/entitlement | python3 -m json.tool` — same shape as before (this PR does not touch `to_dict()`).
6. Smoke the new bus signal in a REPL:
   ```python
   python3 - <<'PY'
   from clawmetry import extensions, entitlements
   seen = []
   extensions.register("entitlement.changed", seen.append)
   entitlements.invalidate(); entitlements._last_emitted_tier = None
   entitlements.get_entitlement(force=True)
   entitlements.get_entitlement(force=True)
   print(seen)  # exactly one record with tier='oss', previous_tier=None
   PY
   ```
7. Decrypt the live cloud snapshot — daemon snapshot shape is unchanged.
8. Browser-check the dashboard — no UI consumes `entitlement.changed`
   yet; every existing surface should render exactly as before.

This PR is **DRAFT** — `__version__` is not bumped, no `[RELEASE]` PR
is opened, no gate is enforced. Grace mode stays on. Once you have run
the operator checklist, mark Ready for Review and proceed with the
normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01143nkxEcKL5Su1Bz61UYwE)_