### PR TITLE
fix(ci): C6 push path informational, stop reddening main on every merge

### DIFF
--- a/scripts/apply_required_status_checks.py
+++ b/scripts/apply_required_status_checks.py
@@ -19,8 +19,9 @@ GITHUB_TOKEN from Actions (prefix ghs_):
   Can read branch protection state but CANNOT write it. The script detects
   this automatically: it verifies current state (read-only, scoped to the
   current repo only) and exits 0 with actionable instructions. Push-triggered
-  runs are informational: exit 0 when C6 is correctly configured, exit 1
-  when checks are not yet configured (red job = forcing signal).
+  runs are always informational (exit 0): closing C6 is an explicit admin
+  action via scripts/close-c6.sh, never a red-main gate. A perpetually-red
+  main from an unconfigured-but-optional C6 hides real failures.
   Note: requesting administration:write in the workflow permissions block is
   invalid for GITHUB_TOKEN and causes 0-job workflow failures -- do not add it.
 
@@ -407,10 +408,14 @@ def main() -> None:
             print("=== (Set by manual Settings UI action or a prior admin run.) ===")
             return  # exit 0: C6 is done, self-heals to green after admin action
         print()
-        print("Action needed (takes ~30 seconds):")
+        print("Action needed (takes ~30 seconds) to make these checks required on main:")
         print("  bash scripts/close-c6.sh")
         print("  (Or: Actions > 'Apply required E2E status checks (C6 -- one-shot)' > Run workflow)")
-        sys.exit(1)  # red job on every main push until admin closes C6
+        # Push-triggered runs are informational only and must NEVER block main.
+        # Closing C6 (configuring branch protection) is an explicit admin action
+        # via the instructions above, not a gate that reds every merge. A
+        # perpetually-red main hides real failures, so exit 0 here.
+        return  # exit 0 on push; C6 stays actionable, just non-blocking
 
     # PAT / OAuth path: full apply + verify across all repos.
     checks = _checks_to_apply()

--- a/tests/test_c6_push_non_blocking.py
+++ b/tests/test_c6_push_non_blocking.py
@@ -1,0 +1,57 @@
+"""Guard: the C6 (apply-required-checks) push path must NEVER block main.
+
+Regression for the red-main-on-every-merge bug: when only GITHUB_TOKEN (ghs_)
+is available and branch protection is not yet configured, the script used to
+`sys.exit(1)` as a "forcing signal", which turned main red on every push and
+hid real failures. Push-triggered runs are informational only and must exit 0.
+
+This test fails on the old code (SystemExit code 1) and passes on the fix.
+"""
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "apply_required_status_checks.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("apply_required_status_checks", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_readonly_push_path_exits_zero_when_unconfigured(monkeypatch):
+    mod = _load_module()
+
+    # Simulate the Actions push context: GITHUB_TOKEN (ghs_ = read-only), this repo,
+    # and NOT a manual confirm=APPLY dispatch.
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_readonlytoken")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "vivekchand/clawmetry")
+    monkeypatch.delenv("CONFIRM_INPUT", raising=False)
+
+    # Branch protection is NOT configured (the exact state that reddened main).
+    # Stub the network read so the test is hermetic and deterministic.
+    monkeypatch.setattr(mod, "verify_required_checks_readonly", lambda *a, **k: False)
+
+    # main() must return normally (exit 0), never raise SystemExit with a code.
+    try:
+        result = mod.main()
+    except SystemExit as exc:  # pragma: no cover - this is the bug we guard against
+        pytest.fail(f"C6 push path raised SystemExit({exc.code!r}); it must be non-blocking (exit 0).")
+    assert result is None
+
+
+def test_confirm_apply_with_readonly_token_still_errors(monkeypatch):
+    """A manual confirm=APPLY with only GITHUB_TOKEN should still fail loudly:
+    that is a real misconfiguration, distinct from the informational push path."""
+    mod = _load_module()
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_readonlytoken")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "vivekchand/clawmetry")
+    monkeypatch.setenv("CONFIRM_INPUT", "APPLY")
+
+    with pytest.raises(SystemExit) as exc:
+        mod.main()
+    assert exc.value.code not in (0, None)


### PR DESCRIPTION
## Problem
clawmetry `main` shows RED after every merge. The failing job is **Apply required E2E status checks (C6)**, which runs on every push to main. With only the read-only `GITHUB_TOKEN` and branch protection not yet configured, the script `sys.exit(1)`'d on purpose as a "forcing signal". A perpetually red main hides real failures and reads as a broken pipeline.

## Fix
The read-only **push** path now always exits 0 (informational). Closing C6 (configuring branch-protection required checks) stays an explicit admin action via `scripts/close-c6.sh`, not a gate that reds every merge. A manual `confirm=APPLY` dispatch with only `GITHUB_TOKEN` still errors loudly (that is a real misconfiguration, not a routine push).

## Guard (revert-proved)
`tests/test_c6_push_non_blocking.py`: asserts the read-only push path returns (exit 0) when branch protection is unconfigured, and that confirm=APPLY without an admin token still errors. Verified it fails on the old `sys.exit(1)` and passes on the fix.

Note: branch-protection policy is unchanged here (intentionally, so it does not block the open-PR backlog). Founder has separate local WIP on this file moving the same direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)