### PR TITLE
fix(entitlement): import os so /api/entitlement/diagnostic fallback never 5xx's

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -20,6 +20,7 @@ OSS-free shape, never a 4xx.
 from __future__ import annotations
 
 import logging
+import os
 
 from flask import Blueprint, jsonify, request
 


### PR DESCRIPTION
## Summary

`routes/entitlement.py:84` references `os.environ.get("CLAWMETRY_ENFORCE")` inside the never-raise fallback of `api_entitlement_diagnostic` — but `os` was never imported in the route module.

That fallback only ever runs when `clawmetry.entitlements.resolution_diagnostic()` itself raises. The docstring promises a safe shape on that path so the operator-triage panel never goes dark. In reality, every entry into the fallback raises `NameError: name 'os' is not defined`, Flask returns **500**, and the panel goes dark **exactly when operators need it** — when something has already gone wrong with entitlement resolution.

## Repro on `origin/main`

```
$ python3 -m pytest tests/test_entitlement_resolution_diagnostic.py -q
...F...........
FAILED tests/test_entitlement_resolution_diagnostic.py::test_api_entitlement_diagnostic_never_raises
NameError: name 'os' is not defined
1 failed, 14 passed in 0.26s
```

That regression test (`test_api_entitlement_diagnostic_never_raises`) shipped with the feature in #3079 — it patches `resolution_diagnostic` to raise and asserts the route still returns **200** with the structural keys. The fallback's `NameError` turns it into a 500, so the contract test fails on `origin/main` today. The CI gate in `ci.yml` doesn't currently run this file (it runs an explicit allow-list, not the full `tests/`), which is why the regression slipped through review — orthogonal, out of scope here.

## Fix

One line:

```diff
 from __future__ import annotations

 import logging
+import os

 from flask import Blueprint, jsonify, request
```

## After

```
$ python3 -m pytest tests/test_entitlement_resolution_diagnostic.py -q
...............
15 passed in 0.25s
```

The other `bp_entitlement` endpoints (`/api/entitlement`, `/api/runtimes`, `/api/features`, `/api/license/*`) already had identical never-raise fallbacks that did not touch `os`, so they were unaffected.

## No behavior change

Only the previously-unreachable error path is now reachable in the way its docstring promised. The success path is untouched. No `__version__` bump. No `[RELEASE]` PR. No gate enforced — `CLAWMETRY_ENFORCE` default stays off, grace mode stays on.

## Adjacent suites still green

```
$ python3 -m pytest \
    tests/test_entitlement_resolution_diagnostic.py \
    tests/test_entitlement_api.py \
    tests/test_entitlements.py \
    tests/test_entitlements_catalogue.py \
    tests/test_entitlement_change_emit.py \
    tests/test_entitlement_locked_helpers.py \
    tests/test_entitlements_feature_catalog.py \
    tests/test_entitlements_table_conformance.py \
    tests/test_extensions.py \
    tests/test_extensions_introspection.py -q
... all pass
```

Three pre-existing `tests/test_license.py::test_auto_provision_*` failures on `origin/main` are unrelated to this change (confirmed by stashing the diff and re-running — they fail identically before and after). Tracked separately, out of scope for this PR.

## Local operator verification checklist

This agent has no access to your machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please run on a real install:

1. `git fetch origin feat/entitlement-diagnostic-fallback-import-os && git checkout feat/entitlement-diagnostic-fallback-import-os`
2. Copy the changed file into the live install:
   ```bash
   cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/entitlement.py
   ```
3. Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
4. Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. Confirm `/api/entitlement/diagnostic` still returns 200 with the expected shape on the happy path:
   ```bash
   curl -s http://localhost:8900/api/entitlement/diagnostic | python3 -m json.tool
   ```
6. (Optional but the point of the fix) Force the fallback by monkey-failing `resolution_diagnostic` in a Python REPL against the live install — should now return 200 + a minimal safe shape with `"error"` populated, not 500.
7. Decrypt the live cloud snapshot — daemon snapshot shape is unchanged.
8. Browser-check the dashboard — no UI consumes `/api/entitlement/diagnostic` yet, so this is purely an operator-curl path.

This PR is **DRAFT** — `__version__` is not bumped, no `[RELEASE]` PR is opened, no gate is enforced. Once you have run the operator checklist, mark Ready for Review and proceed with the normal `[RELEASE]` loop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMinVyzu3cTuvKRYNynL4W)_