### PR TITLE
fix(nemoclaw): surface Ollama inference host + local model roster (obs-gap #2959)

### DIFF
--- a/clawmetry/adapters/nemo.py
+++ b/clawmetry/adapters/nemo.py
@@ -698,6 +698,70 @@ def _read_nemoclaw_skill_catalog() -> dict:
     return {}
 
 
+_OLLAMA_HOST_DOCKER_INTERNAL = "http://host.docker.internal:11434"
+_OLLAMA_LOCALHOST = "http://127.0.0.1:11434"
+
+
+def _resolve_ollama_host() -> tuple:
+    """Resolve the Ollama base URL and how it was chosen.
+
+    Priority order:
+    1. ``OLLAMA_HOST`` env var (with http:// prefix added if missing)
+    2. Docker internal host when running inside a container
+    3. Loopback (127.0.0.1)
+
+    Returns (url, mode) where mode is "explicit", "docker-internal", or
+    "loopback".  Never raises.
+    """
+    import os
+
+    explicit = (os.environ.get("OLLAMA_HOST") or "").strip()
+    if explicit:
+        if "://" not in explicit:
+            explicit = "http://" + explicit
+        return explicit, "explicit"
+    in_docker = False
+    try:
+        in_docker = os.path.exists("/.dockerenv") or bool(
+            (os.environ.get("OLLAMA_IN_DOCKER") or "").strip()
+        )
+    except Exception:
+        in_docker = False
+    if in_docker:
+        return _OLLAMA_HOST_DOCKER_INTERNAL, "docker-internal"
+    return _OLLAMA_LOCALHOST, "loopback"
+
+
+def _read_nemoclaw_ollama_inference() -> dict:
+    """Surface the local Ollama inference host + available model roster.
+
+    Hits ``<host>/api/tags`` (Ollama's list-models endpoint) with a tight
+    0.6 s timeout so the adapter stays fast when Ollama is absent.  Returns a
+    dict with ``ollama_host``, ``ollama_host_mode``, and (when reachable)
+    ``ollama_local_models`` (sorted list of model-name strings).  Never raises.
+    """
+    import json
+    import urllib.request
+
+    host, mode = _resolve_ollama_host()
+    out: dict = {"ollama_host": host, "ollama_host_mode": mode}
+    try:
+        url = host.rstrip("/") + "/api/tags"
+        with urllib.request.urlopen(url, timeout=0.6) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        models = payload.get("models") if isinstance(payload, dict) else None
+        names: list = []
+        for m in models or []:
+            if isinstance(m, dict):
+                name = m.get("name") or m.get("model")
+                if name:
+                    names.append(str(name))
+        out["ollama_local_models"] = sorted(set(names))
+    except Exception as exc:
+        logger.debug("nemoclaw ollama model roster query failed (%s): %s", host, exc)
+    return out
+
+
 def _read_model_router_model_list() -> dict:
     """Read the proxy-config YAML written by ``model-router proxy-config --output <path>``.
 
@@ -873,6 +937,7 @@ class NemoClawAdapter(AgentAdapter):
         meta.update(_read_nemoclaw_skill_catalog())
         meta.update(_read_model_router_model_list())
         meta.update(_read_nemoclaw_sandbox_lifecycle())
+        meta["ollama_inference"] = _read_nemoclaw_ollama_inference()
         return DetectResult(
             name=self.name,
             display_name=self.display_name,

--- a/tests/test_nemoclaw_runtime_adapter.py
+++ b/tests/test_nemoclaw_runtime_adapter.py
@@ -277,3 +277,90 @@ def test_nemoclaw_ignores_non_nemo_events(isolated_store):
     _wait_flush(isolated_store)
     from clawmetry.adapters.nemo import NemoClawAdapter
     assert NemoClawAdapter().detect().detected is False
+
+
+# ── obs-gap #2959: Ollama inference host + local model roster ────────────────
+
+
+def test_resolve_ollama_host_loopback(monkeypatch):
+    """No OLLAMA_HOST and not in docker -> loopback host."""
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    monkeypatch.delenv("OLLAMA_IN_DOCKER", raising=False)
+    monkeypatch.setattr("os.path.exists", lambda p: False)
+    from clawmetry.adapters.nemo import _resolve_ollama_host, _OLLAMA_LOCALHOST
+    host, mode = _resolve_ollama_host()
+    assert host == _OLLAMA_LOCALHOST
+    assert mode == "loopback"
+
+
+def test_resolve_ollama_host_docker(monkeypatch):
+    """Inside a container (/.dockerenv present) -> docker-internal host."""
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    monkeypatch.setattr("os.path.exists", lambda p: p == "/.dockerenv")
+    from clawmetry.adapters.nemo import _resolve_ollama_host, _OLLAMA_HOST_DOCKER_INTERNAL
+    host, mode = _resolve_ollama_host()
+    assert host == _OLLAMA_HOST_DOCKER_INTERNAL
+    assert mode == "docker-internal"
+
+
+def test_resolve_ollama_host_explicit_normalises_scheme(monkeypatch):
+    """An explicit OLLAMA_HOST wins and a bare host:port gets an http:// scheme."""
+    monkeypatch.setenv("OLLAMA_HOST", "ollama.internal:11434")
+    from clawmetry.adapters.nemo import _resolve_ollama_host
+    host, mode = _resolve_ollama_host()
+    assert host == "http://ollama.internal:11434"
+    assert mode == "explicit"
+
+
+def test_ollama_inference_roster_parsed(monkeypatch):
+    """When /api/tags answers, the model roster is sorted + de-duplicated."""
+    import json as _json
+
+    class _FakeResp:
+        def __init__(self, body):
+            self._b = body.encode("utf-8")
+        def read(self):
+            return self._b
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    payload = {"models": [{"name": "llama3:8b"}, {"name": "qwen2:7b"}, {"name": "llama3:8b"}]}
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda url, timeout=0: _FakeResp(_json.dumps(payload)),
+    )
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    monkeypatch.setattr("os.path.exists", lambda p: False)
+    from clawmetry.adapters.nemo import _read_nemoclaw_ollama_inference
+    info = _read_nemoclaw_ollama_inference()
+    assert info["ollama_host_mode"] == "loopback"
+    assert info["ollama_local_models"] == ["llama3:8b", "qwen2:7b"]
+
+
+def test_ollama_inference_unreachable_still_returns_host(monkeypatch):
+    """When Ollama is unreachable, host/mode are still surfaced, no roster key."""
+    def _boom(url, timeout=0):
+        raise OSError("connection refused")
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    monkeypatch.setattr("os.path.exists", lambda p: False)
+    from clawmetry.adapters.nemo import _read_nemoclaw_ollama_inference
+    info = _read_nemoclaw_ollama_inference()
+    assert "ollama_host" in info and "ollama_host_mode" in info
+    assert "ollama_local_models" not in info
+
+
+def test_detect_meta_includes_ollama_inference(isolated_store, monkeypatch):
+    """detect().meta carries ollama_inference with host + mode (gap #2959)."""
+    def _boom(url, timeout=0):
+        raise OSError("connection refused")
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    _seed_nemoclaw_event(isolated_store)
+    _wait_flush(isolated_store)
+    from clawmetry.adapters.nemo import NemoClawAdapter
+    meta = NemoClawAdapter().detect().meta
+    assert "ollama_inference" in meta
+    assert "ollama_host" in meta["ollama_inference"]
+    assert "ollama_host_mode" in meta["ollama_inference"]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `_resolve_ollama_host()` mirroring the harness `dist/lib/inference/local.js` host-resolution logic: explicit `OLLAMA_HOST` env var > `host.docker.internal` when in a container > `127.0.0.1` loopback
- Adds `_read_nemoclaw_ollama_inference()` which queries `{host}/api/tags` with a 0.6 s timeout and surfaces `ollama_host`, `ollama_host_mode`, and (when reachable) `ollama_local_models` in `detect().meta`
- Six unit tests covering all three host-resolution modes, roster parsing/dedup, unreachable-host fallback, and the `detect()` integration

Closes #2959. Replaces #2965 (rebased cleanly onto current main).

## Test plan

- [ ] `pytest tests/test_nemoclaw_runtime_adapter.py -k ollama` -- all 6 new tests pass
- [ ] Full `pytest tests/test_nemoclaw_runtime_adapter.py` -- no regressions
- [ ] `python3 -m py_compile clawmetry/adapters/nemo.py` -- syntax clean

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_