### PR TITLE
feat(nemoclaw): add _parse_proxy_config_model_list + _model_router_proxy_config_models (#2960)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -243,6 +243,105 @@ def _model_router_live() -> dict:
     return {"modelRouterPort": port, "modelRouterRunning": _model_router_health_ok(port)}
 
 
+def _parse_proxy_config_model_list(content: str) -> Optional[List[str]]:
+    """Extract model names from a LiteLLM-style proxy-config YAML (#2960).
+
+    Tries ``yaml.safe_load`` first (PyYAML, optional dep); falls back to a
+    line-by-line scan for ``model_name:`` keys so no new hard dependency is
+    needed.  Returns ``None`` on parse failure so callers can omit the field.
+    Never raises.
+    """
+    try:
+        import yaml as _yaml  # type: ignore[import]
+        data = _yaml.safe_load(content)
+        items = data.get("model_list", []) if isinstance(data, dict) else []
+        return [
+            m["model_name"]
+            for m in items
+            if isinstance(m, dict) and "model_name" in m
+        ]
+    except ImportError:
+        pass
+    except Exception:
+        return None
+
+    # Fallback: line scan for ``model_name: <value>`` in a model_list block
+    in_list = False
+    names: List[str] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "model_list:":
+            in_list = True
+            continue
+        if in_list:
+            if stripped.startswith("- model_name:"):
+                _, _, name = stripped.partition(":")
+                names.append(name.strip().strip("\"'"))
+            elif stripped and not stripped.startswith("-") and not stripped.startswith(" "):
+                in_list = False
+    return names or None
+
+
+def _model_router_proxy_config_models() -> dict:
+    """Read the NeMoClaw model-router proxy-config model roster (#2960).
+
+    The harness writes a proxy-config YAML during onboarding
+    (test/onboard-model-router.test.ts). Checks ``<venv>/proxy-config.yaml``
+    first; falls back to running ``model-router proxy-config --output <tmp>``
+    if the binary is on PATH.
+
+    Returns ``{"modelRouterProxyModels": ["name", ...]}`` or ``{}`` on any
+    failure (file absent, binary missing, parse error).  Never raises.
+    """
+    import subprocess
+    import shutil
+    import tempfile
+
+    venv = os.environ.get("NEMOCLAW_MODEL_ROUTER_VENV") or os.path.expanduser(
+        os.path.join("~", ".nemoclaw", "model-router-venv"))
+
+    # Fast path: static file written by harness onboarding
+    static_path = os.path.join(venv, "proxy-config.yaml")
+    content: Optional[str] = None
+    if os.path.isfile(static_path):
+        try:
+            with open(static_path, encoding="utf-8") as fh:
+                content = fh.read()
+        except OSError:
+            pass
+
+    # Slow path: generate via model-router CLI
+    if content is None:
+        mr_bin_venv = os.path.join(venv, "bin", "model-router")
+        mr_bin: Optional[str] = (
+            mr_bin_venv if os.path.isfile(mr_bin_venv) else shutil.which("model-router")
+        )
+        if not mr_bin:
+            return {}
+        tmp_path: Optional[str] = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
+                tmp_path = tmp.name
+            subprocess.check_call(
+                [mr_bin, "proxy-config", "--output", tmp_path],
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+            )
+            with open(tmp_path, encoding="utf-8") as fh:
+                content = fh.read()
+        except Exception:
+            return {}
+        finally:
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+    models = _parse_proxy_config_model_list(content)
+    return {"modelRouterProxyModels": models} if models is not None else {}
+
+
 # NOTE (#2610, deferred): NemoClaw's skill-catalog version/provenance lives in
 # ``skills/catalog-metadata.json`` (min/tested NemoClaw version, content shas),
 # but that file is a SOURCE-repo build artifact — it is not shipped in the npm
@@ -404,6 +503,7 @@ class OpenClawAdapter(AgentAdapter):
             # OpenClaw, so meta is unchanged there. (#2610 skill-catalog deferred
             # — see note above: no host-readable on-disk location.)
             meta.update(_model_router_fingerprint())
+            meta.update(_model_router_proxy_config_models())
             # Runtime liveness (#2795). The fingerprint above only proves the
             # router was INSTALLED; probe /health so a crashed router is no
             # longer indistinguishable from a healthy one. Only meaningful when

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -215,6 +215,41 @@ def test_model_router_health_ok_false_when_nothing_listening():
     assert _model_router_health_ok(0) is False
 
 
+# -- #2960 model-router proxy-config model_list -----------------------------
+
+def test_model_router_proxy_config_models_reads_static_file(tmp_path, monkeypatch):
+    venv = tmp_path / "mrv"
+    venv.mkdir()
+    (venv / "proxy-config.yaml").write_text(
+        "model_list:\n  - model_name: claude-opus-4\n  - model_name: gpt-4o\n"
+    )
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(venv))
+    from clawmetry.adapters.openclaw import _model_router_proxy_config_models
+    out = _model_router_proxy_config_models()
+    assert out == {"modelRouterProxyModels": ["claude-opus-4", "gpt-4o"]}
+
+
+def test_model_router_proxy_config_models_absent_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(tmp_path / "nope"))
+    from clawmetry.adapters.openclaw import _model_router_proxy_config_models
+    assert _model_router_proxy_config_models() == {}
+
+
+def test_parse_proxy_config_model_list_litellm_format():
+    from clawmetry.adapters.openclaw import _parse_proxy_config_model_list
+    yaml_content = (
+        "model_list:\n"
+        "  - model_name: claude-opus-4\n"
+        "    litellm_params:\n"
+        "      model: anthropic/claude-opus-4\n"
+        "  - model_name: gpt-4o\n"
+        "    litellm_params:\n"
+        "      model: openai/gpt-4o\n"
+    )
+    result = _parse_proxy_config_model_list(yaml_content)
+    assert result == ["claude-opus-4", "gpt-4o"]
+
+
 # -- #2682 nemoclaw catalog dispatch span unwrap -----------------------------
 
 def test_catalog_dispatch_span_unwraps_real_tool():


### PR DESCRIPTION
## Summary

The NeMoClaw model-router proxy exposes a configurable roster of models via a `proxy-config.yaml` (LiteLLM format), but ClawMetry never read that file — so the dashboard had no way to show which models are actually routed through the model router.

## Changes

- **`clawmetry/adapters/openclaw.py`**: Add `_parse_proxy_config_model_list()` — minimal YAML parser (PyYAML-optional; falls back to line scan, no new hard dependency). Add `_model_router_proxy_config_models()` — checks `$NEMOCLAW_MODEL_ROUTER_VENV/proxy-config.yaml` first (static file written by harness onboarding), falls back to running `model-router proxy-config --output <tmp>` if the binary is on PATH. Returns `{}` on any failure; never raises.
- **`clawmetry/adapters/openclaw.py`**: Wire `meta.update(_model_router_proxy_config_models())` into `OpenClawAdapter.detect()` alongside the existing fingerprint call, so `modelRouterProxyModels` appears in `DetectResult.meta` when the config is present.
- **`tests/test_obs_gap_talk_sandbox.py`**: 3 new unit tests: reads a static proxy-config.yaml, absent file returns `{}`, and the LiteLLM multi-dict format is parsed correctly.

Closes #2960

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgHhsL14eJCXXvrUkJyrqV)_