### PR TITLE
fix(openclaw): surface NeMoClaw model-router proxy-config model roster (obs-gap #2960)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -151,6 +151,105 @@ def _model_router_fingerprint() -> dict:
         return {}
 
 
+def _parse_proxy_config_model_list(content: str) -> Optional[List[str]]:
+    """Extract model names from a LiteLLM-style proxy-config YAML (#2960).
+
+    Tries ``yaml.safe_load`` first (PyYAML, optional dep); falls back to a
+    line-by-line scan for ``model_name:`` keys so no new hard dependency is
+    needed.  Returns ``None`` on parse failure so callers can omit the field.
+    Never raises.
+    """
+    try:
+        import yaml as _yaml  # type: ignore[import]
+        data = _yaml.safe_load(content)
+        items = data.get("model_list", []) if isinstance(data, dict) else []
+        return [
+            m["model_name"]
+            for m in items
+            if isinstance(m, dict) and "model_name" in m
+        ]
+    except ImportError:
+        pass
+    except Exception:
+        return None
+
+    # Fallback: line scan for ``model_name: <value>`` in a model_list block
+    in_list = False
+    names: List[str] = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped == "model_list:":
+            in_list = True
+            continue
+        if in_list:
+            if stripped.startswith("- model_name:"):
+                _, _, name = stripped.partition(":")
+                names.append(name.strip().strip("\"'"))
+            elif stripped and not stripped.startswith("-") and not stripped.startswith(" "):
+                in_list = False
+    return names or None
+
+
+def _model_router_proxy_config_models() -> dict:
+    """Read the NeMoClaw model-router proxy-config model roster (#2960).
+
+    The harness writes a proxy-config YAML during onboarding
+    (test/onboard-model-router.test.ts). Checks ``<venv>/proxy-config.yaml``
+    first; falls back to running ``model-router proxy-config --output <tmp>``
+    if the binary is on PATH.
+
+    Returns ``{"modelRouterProxyModels": ["name", ...]}`` or ``{}`` on any
+    failure (file absent, binary missing, parse error).  Never raises.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+
+    venv = os.environ.get("NEMOCLAW_MODEL_ROUTER_VENV") or os.path.expanduser(
+        os.path.join("~", ".nemoclaw", "model-router-venv"))
+
+    # Fast path: static file written by harness onboarding
+    static_path = os.path.join(venv, "proxy-config.yaml")
+    content: Optional[str] = None
+    if os.path.isfile(static_path):
+        try:
+            with open(static_path, encoding="utf-8") as fh:
+                content = fh.read()
+        except OSError:
+            pass
+
+    # Slow path: generate via model-router CLI
+    if content is None:
+        mr_bin_venv = os.path.join(venv, "bin", "model-router")
+        mr_bin: Optional[str] = (
+            mr_bin_venv if os.path.isfile(mr_bin_venv) else shutil.which("model-router")
+        )
+        if not mr_bin:
+            return {}
+        tmp_path: Optional[str] = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
+                tmp_path = tmp.name
+            subprocess.check_call(
+                [mr_bin, "proxy-config", "--output", tmp_path],
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+            )
+            with open(tmp_path, encoding="utf-8") as fh:
+                content = fh.read()
+        except Exception:
+            return {}
+        finally:
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+    models = _parse_proxy_config_model_list(content)
+    return {"modelRouterProxyModels": models} if models is not None else {}
+
+
 def _discover_model_router_port() -> Optional[int]:
     """Find the ``--port`` of a running ``model-router proxy`` process.
 
@@ -404,6 +503,7 @@ class OpenClawAdapter(AgentAdapter):
             # OpenClaw, so meta is unchanged there. (#2610 skill-catalog deferred
             # — see note above: no host-readable on-disk location.)
             meta.update(_model_router_fingerprint())
+            meta.update(_model_router_proxy_config_models())
             # Runtime liveness (#2795). The fingerprint above only proves the
             # router was INSTALLED; probe /health so a crashed router is no
             # longer indistinguishable from a healthy one. Only meaningful when

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -127,6 +127,41 @@ def test_model_router_fingerprint_absent_returns_empty(tmp_path, monkeypatch):
     assert _model_router_fingerprint() == {}
 
 
+# -- #2960 model-router proxy-config model_list -----------------------------
+
+def test_model_router_proxy_config_models_reads_static_file(tmp_path, monkeypatch):
+    venv = tmp_path / "mrv"
+    venv.mkdir()
+    (venv / "proxy-config.yaml").write_text(
+        "model_list:\n  - model_name: claude-opus-4\n  - model_name: gpt-4o\n"
+    )
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(venv))
+    from clawmetry.adapters.openclaw import _model_router_proxy_config_models
+    out = _model_router_proxy_config_models()
+    assert out == {"modelRouterProxyModels": ["claude-opus-4", "gpt-4o"]}
+
+
+def test_model_router_proxy_config_models_absent_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("NEMOCLAW_MODEL_ROUTER_VENV", str(tmp_path / "nope"))
+    from clawmetry.adapters.openclaw import _model_router_proxy_config_models
+    assert _model_router_proxy_config_models() == {}
+
+
+def test_parse_proxy_config_model_list_litellm_format():
+    from clawmetry.adapters.openclaw import _parse_proxy_config_model_list
+    yaml_content = (
+        "model_list:\n"
+        "  - model_name: claude-opus-4\n"
+        "    litellm_params:\n"
+        "      model: anthropic/claude-opus-4\n"
+        "  - model_name: gpt-4o\n"
+        "    litellm_params:\n"
+        "      model: openai/gpt-4o\n"
+    )
+    result = _parse_proxy_config_model_list(yaml_content)
+    assert result == ["claude-opus-4", "gpt-4o"]
+
+
 # -- #2795 model-router proxy liveness ---------------------------------------
 
 def test_model_router_port_parsed_from_cmdline(monkeypatch):


### PR DESCRIPTION
## Summary

- Adds `_parse_proxy_config_model_list(content)`: tries `yaml.safe_load` (PyYAML optional) then falls back to a line scan for `model_name:` entries -- no new hard dependencies
- Adds `_model_router_proxy_config_models()`: checks `<venv>/proxy-config.yaml` (written by harness onboarding) first, then falls back to invoking `model-router proxy-config --output <tmp>` if the binary is on PATH
- Wires into `OpenClawAdapter.detect()` alongside the existing `_model_router_fingerprint()` call
- Three unit tests covering static-file read, absent-file fallback, and LiteLLM-format parsing

Closes #2960. Replaces #2973, #3144 (rebased cleanly onto current main).

## Test plan

- [ ] `pytest tests/test_obs_gap_talk_sandbox.py -k proxy_config` -- all 3 new tests pass
- [ ] `python3 -m py_compile clawmetry/adapters/openclaw.py` -- syntax clean

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_