### PR TITLE
feat(entitlements): tier_label, runtime_tier, tier_rank, min_tier_for, upgrade_diff, lock_reason, grace-countdown, refresh + required-tier endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -132,11 +132,27 @@ RUNTIME_ALIASES = {
     "nano_claw": "nanoclaw",
 }
 
+# Display labels for every known tier id. The dashboard, the CLI, and any
+# operator-facing surface should call :func:`tier_label` instead of hard-coding
+# these strings so the vocabulary stays consistent.
+# An unknown tier id is rendered title-cased with underscores swapped for
+# spaces, so a future tier added before this map is updated still renders
+# *something* sensible.
+TIER_LABELS = {
+    TIER_OSS: "OSS",
+    TIER_CLOUD_FREE: "Free",
+    TIER_TRIAL: "Trial",
+    TIER_CLOUD_STARTER: "Starter",
+    TIER_CLOUD_PRO: "Pro",
+    TIER_PRO: "Self-hosted Pro",
+    TIER_ENTERPRISE: "Enterprise",
+}
+
 # Display labels for every known feature. Mirrors the runtime label map and is
 # the source of truth the dashboard reads via ``/api/features`` so the locked-
 # but-visible affordance on paid features renders human-readable copy. Adding a
 # feature to one of the ``*_FEATURES`` sets without a label here is safe — the
-# helper falls back to the id — but a missing label trips the catalogue
+# helper falls back to the id -- but a missing label trips the catalogue
 # conformance test in ``tests/test_entitlements_feature_catalog.py``.
 FEATURE_LABELS = {
     # Free / core observability
@@ -297,10 +313,38 @@ _TIER_RETENTION_DAYS = {
 # Tiers that unlock the paid runtimes.
 _TIER_PAID_RUNTIMES = _PAID_TIERS
 
+# Canonical ordering of the *purchasable* plans, lowest -> highest. Used by
+# :func:`tier_rank` and the ``min_tier_for_*`` helpers so the UI can render
+# locked rows as "Available in Starter" / "Available in Pro" without each
+# caller re-deriving the order. Trial is excluded: it is a time-limited
+# promotional grant of Pro, not a plan a customer can pick from a price page.
+_PURCHASABLE_TIERS = (
+    TIER_OSS,
+    TIER_CLOUD_FREE,
+    TIER_CLOUD_STARTER,
+    TIER_CLOUD_PRO,
+    TIER_PRO,
+    TIER_ENTERPRISE,
+)
+
+# rank: oss/cloud_free = 0, starter = 1, pro/cloud_pro = 2, enterprise = 3.
+# Self-hosted Pro and cloud Pro share rank 2 because they unlock the same
+# feature set. Unknown tiers return -1 from :func:`tier_rank`.
+_TIER_RANK = {
+    TIER_OSS: 0,
+    TIER_CLOUD_FREE: 0,
+    TIER_CLOUD_STARTER: 1,
+    TIER_TRIAL: 2,
+    TIER_CLOUD_PRO: 2,
+    TIER_PRO: 2,
+    TIER_ENTERPRISE: 3,
+}
+
 _LICENSE_PATH = os.path.expanduser("~/.clawmetry/license.key")
 _CLOUD_PLAN_CACHE = os.path.expanduser("~/.clawmetry/cloud_plan.json")
 _ENFORCE_ENABLE_VALUES = frozenset({"1", "true", "yes", "on"})
 _CACHE_TTL_SECS = 60.0
+_ENFORCE_AT_ENV = "CLAWMETRY_ENFORCE_AT"
 
 
 def is_enforced() -> bool:
@@ -310,6 +354,39 @@ def is_enforced() -> bool:
         os.environ.get("CLAWMETRY_ENFORCE", "").strip().lower()
         in _ENFORCE_ENABLE_VALUES
     )
+
+
+def enforce_at_epoch() -> float | None:
+    """Resolve the announced enforce-at moment from ``CLAWMETRY_ENFORCE_AT``.
+
+    Accepts three formats -- the first parse that wins is used::
+
+        CLAWMETRY_ENFORCE_AT=2026-07-01            # ISO date (UTC midnight)
+        CLAWMETRY_ENFORCE_AT=2026-07-01T12:00:00Z  # ISO datetime
+        CLAWMETRY_ENFORCE_AT=1782950400            # epoch seconds
+
+    Unset / empty / unparseable returns ``None`` (logged at warning). Used by
+    :meth:`Entitlement.grace_remaining_days` and :meth:`Entitlement.to_dict` so
+    the dashboard can render a countdown banner without re-implementing the
+    parse rules on the frontend. Never raises."""
+    raw = os.environ.get(_ENFORCE_AT_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    try:
+        from datetime import datetime, timezone
+
+        s = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except Exception as exc:
+        logger.warning("entitlements: bad CLAWMETRY_ENFORCE_AT %r: %s", raw, exc)
+        return None
 
 
 @dataclass(frozen=True)
@@ -403,6 +480,106 @@ class Entitlement:
         except Exception:
             return ()
 
+    def min_tier_for(self, key: str) -> str | None:
+        """Return the minimum *purchasable* tier id that would unlock ``key``.
+
+        ``key`` may be a feature id (e.g. ``"otel_export"``) or a runtime id
+        (e.g. ``"claude_code"``). For a free key returns :data:`TIER_OSS`; for
+        an unknown key returns ``None``. Never raises.
+        """
+        k = (key or "").strip().lower()
+        if not k:
+            return None
+        if k in ALL_FEATURES:
+            return min_tier_for_feature(k)
+        if k in ALL_RUNTIMES:
+            return min_tier_for_runtime(k)
+        return None
+
+    def upgrade_diff(self, target_tier: str) -> dict:
+        """Features + runtimes ``target_tier`` would unlock on top of this
+        entitlement. Returns ``{"target": "<tier>", "added_features": [...sorted...],
+        "added_runtimes": [...sorted...]}``. Never raises."""
+        try:
+            tt = (target_tier or "").strip().lower()
+            target_paid_feats = _TIER_FEATURES.get(tt)
+            if target_paid_feats is None:
+                return {"target": tt, "added_features": [], "added_runtimes": []}
+            target_feats = FREE_FEATURES | target_paid_feats
+            if tt == TIER_ENTERPRISE:
+                target_feats = target_feats | ENTERPRISE_FEATURES
+            target_runtimes = (
+                FREE_RUNTIMES | PAID_RUNTIMES
+                if tt in _TIER_PAID_RUNTIMES
+                else FREE_RUNTIMES
+            )
+            return {
+                "target": tt,
+                "added_features": sorted(target_feats - self.features),
+                "added_runtimes": sorted(target_runtimes - self.runtimes),
+            }
+        except Exception as exc:
+            logger.warning("entitlements: upgrade_diff failed: %s", exc)
+            return {
+                "target": target_tier or "",
+                "added_features": [],
+                "added_runtimes": [],
+            }
+
+    def grace_remaining_days(self) -> int | None:
+        """Days remaining in the grace period, or ``None`` when no enforce-at
+        date is announced (``CLAWMETRY_ENFORCE_AT`` unset). Clamps to ``0``
+        once the announced moment has passed. Never raises."""
+        at = enforce_at_epoch()
+        if at is None:
+            return None
+        remaining = (at - time.time()) / 86400.0
+        return int(remaining) if remaining > 0 else 0
+
+    def lock_reason(self, item: str, *, kind: str | None = None) -> str | None:
+        """Return a human-readable explanation of why ``item`` is locked, or
+        ``None`` when it is allowed (including grace mode). Never raises.
+        """
+        try:
+            k = (item or "").strip().lower()
+            if not k or len(k) > 256:
+                return None
+            if self.grace:
+                return None
+            inferred_kind = kind
+            if inferred_kind is None:
+                if k in ALL_RUNTIMES:
+                    inferred_kind = "runtime"
+                elif k in ALL_FEATURES:
+                    inferred_kind = "feature"
+                else:
+                    return None
+            if inferred_kind == "runtime":
+                if k not in ALL_RUNTIMES:
+                    return None
+                if k in FREE_RUNTIMES:
+                    return None
+                if self.expired:
+                    return f"License expired; '{k}' runtime requires a valid subscription."
+                if self.allows_runtime(k):
+                    return None
+                return f"Paid runtime '{k}' requires Starter or above."
+            if inferred_kind == "feature":
+                if k not in ALL_FEATURES:
+                    return None
+                if k in FREE_FEATURES:
+                    return None
+                if self.expired:
+                    return f"License expired; '{k}' feature requires a valid subscription."
+                if self.allows_feature(k):
+                    return None
+                req = min_tier_for_feature(k)
+                lbl = tier_label(req) if req else "Paid"
+                return f"'{k}' feature requires {lbl} or above."
+            return None
+        except Exception:
+            return None
+
     def event_retention_days(self) -> int | None:
         """Days of event history this tier may keep. ``None`` means unlimited
         / custom (Enterprise). The daemon's prune loop in ``clawmetry/sync.py``
@@ -425,8 +602,22 @@ class Entitlement:
         # without re-deriving the per-tier table client-side. The daemon's
         # prune loop in ``clawmetry/sync.py`` still reads the method directly;
         # this is just the read-only API surface.
+        enforce_at = enforce_at_epoch()
+        enforce_at_iso: str | None = None
+        if enforce_at is not None:
+            try:
+                from datetime import datetime, timezone
+
+                enforce_at_iso = (
+                    datetime.fromtimestamp(enforce_at, tz=timezone.utc)
+                    .isoformat()
+                    .replace("+00:00", "Z")
+                )
+            except Exception:
+                enforce_at_iso = None
         return {
             "tier": self.tier,
+            "tier_label": tier_label(self.tier),
             "source": self.source,
             "node_limit": self.node_limit,
             "expiry": self.expiry,
@@ -434,6 +625,9 @@ class Entitlement:
             "is_paid": self.is_paid,
             "grace": self.grace,
             "enforced": not self.grace,
+            "enforce_at": enforce_at,
+            "enforce_at_iso": enforce_at_iso,
+            "days_until_enforce": self.grace_remaining_days(),
             "retention_days": self.event_retention_days(),
             "runtimes": sorted(self.runtimes),
             "features": sorted(self.features),
@@ -601,6 +795,20 @@ def invalidate() -> None:
         _cache.update(ent=None, ts=0.0, enforce=None)
 
 
+def upgrade_diff(target_tier: str) -> dict:
+    """Module-level convenience: resolve the current entitlement and return
+    what ``target_tier`` would add. Never raises."""
+    try:
+        return get_entitlement().upgrade_diff(target_tier)
+    except Exception as exc:
+        logger.warning("entitlements: upgrade_diff (module) failed: %s", exc)
+        return {
+            "target": target_tier or "",
+            "added_features": [],
+            "added_runtimes": [],
+        }
+
+
 def resolution_diagnostic() -> dict:
     """Snapshot of the *inputs* that determine entitlement resolution.
 
@@ -715,6 +923,90 @@ def runtime_label(runtime: str) -> str:
     when unknown so unknown plugin runtimes still render with *something*."""
     rt = canonical_runtime(runtime)
     return RUNTIME_LABELS.get(rt, rt)
+
+
+def runtime_tier(runtime: str) -> str:
+    """Minimum tier-ladder identifier that unlocks observing ``runtime``.
+
+    Returns ``"free"`` for :data:`FREE_RUNTIMES` and ``"starter"`` for every
+    paid runtime (all paid runtimes unlock together via the Starter
+    ``multi_runtime`` grant). Unknown / empty / non-string ids default to
+    ``"starter"`` (errs on the locked side). Never raises.
+    """
+    try:
+        rt = (runtime or "").strip().lower()
+    except (AttributeError, TypeError):
+        return "starter"
+    return "free" if rt in FREE_RUNTIMES else "starter"
+
+
+def tier_label(tier: str) -> str:
+    """Human-readable label for ``tier``. Mirrors :func:`runtime_label` so the
+    dashboard / CLI never hard-code tier strings.
+
+    An unknown tier id is rendered title-cased with underscores turned into
+    spaces so the UI still has *something* to render. The empty / falsy id
+    falls back to the OSS label.
+    """
+    t = (tier or "").strip().lower()
+    if not t:
+        return TIER_LABELS[TIER_OSS]
+    label = TIER_LABELS.get(t)
+    if label is not None:
+        return label
+    return t.replace("_", " ").title()
+
+
+def tier_rank(tier: str) -> int:
+    """Comparable rank for ``tier`` (higher = unlocks more). Returns ``-1`` for
+    unknown tiers. See :data:`_TIER_RANK` for the canonical numbering."""
+    return _TIER_RANK.get((tier or "").strip().lower(), -1)
+
+
+def min_tier_for_feature(feature: str) -> str | None:
+    """Return the cheapest *purchasable* tier id that grants ``feature``.
+
+    :data:`TIER_TRIAL` is intentionally excluded: it is a promotional grant,
+    not a plan a customer can select from a price page. Never raises.
+    """
+    f = (feature or "").strip().lower()
+    if not f:
+        return None
+    if f in FREE_FEATURES:
+        return TIER_OSS
+    for tier in _PURCHASABLE_TIERS:
+        if tier in (TIER_OSS, TIER_CLOUD_FREE):
+            continue
+        if f in _TIER_FEATURES.get(tier, frozenset()):
+            return tier
+    return None
+
+
+def min_tier_for_runtime(runtime: str) -> str | None:
+    """Return the cheapest *purchasable* tier id that grants ``runtime``.
+
+    Free runtimes resolve to :data:`TIER_OSS`. Any runtime in
+    :data:`PAID_RUNTIMES` resolves to :data:`TIER_CLOUD_STARTER`. Unknown
+    runtimes return ``None``. Never raises.
+    """
+    rt = (runtime or "").strip().lower()
+    if not rt:
+        return None
+    if rt in FREE_RUNTIMES:
+        return TIER_OSS
+    if rt in PAID_RUNTIMES:
+        return TIER_CLOUD_STARTER
+    return None
+
+
+def lock_reason(item: str, *, kind: str | None = None) -> str | None:
+    """Module-level convenience: resolve the current entitlement and return
+    why ``item`` is locked, or ``None`` when allowed (or on any error).
+    Never raises."""
+    try:
+        return get_entitlement().lock_reason(item, kind=kind)
+    except Exception:
+        return None
 
 
 def feature_label(feature: str) -> str:
@@ -850,6 +1142,7 @@ def runtime_catalog() -> list[dict]:
                 "id": rt,
                 "label": runtime_label(rt),
                 "free": True,
+                "tier": "free",
                 "allowed": True,
                 "locked": False,
                 "entitled": True,
@@ -862,6 +1155,7 @@ def runtime_catalog() -> list[dict]:
                 "id": rt,
                 "label": runtime_label(rt),
                 "free": False,
+                "tier": "starter",
                 "allowed": allowed,
                 "locked": not allowed,
                 # Grace-independent plan fact (#1532): lets the UI render the

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1,19 +1,32 @@
 """
-routes/entitlement.py — ``bp_entitlement``.
+routes/entitlement.py -- ``bp_entitlement``.
 
 Exposes the resolved open-core entitlement so the frontend knows which
 runtimes/features to surface (and, once enforcement is live, which to render
 locked behind an upgrade CTA). Backed by :mod:`clawmetry.entitlements`, which
-is the single source of truth — handlers never re-derive tier logic here.
+is the single source of truth -- handlers never re-derive tier logic here.
 
-  GET /api/entitlement            — the current Entitlement as JSON.
-  GET /api/entitlement/diagnostic — the *inputs* the resolver consulted
-                                     (license/cloud-plan presence, enforce env,
-                                     cache liveness) for operator triage.
-  GET /api/runtimes               — the full runtime catalog with locked/free flags.
+  GET  /api/entitlement              -- the current Entitlement as JSON.
+  GET  /api/entitlement/diagnostic   -- the *inputs* the resolver consulted
+                                        (license/cloud-plan presence, enforce
+                                        env, cache liveness) for operator
+                                        triage.
+  POST /api/entitlement/refresh      -- drop the cache and return the freshly
+                                        re-resolved Entitlement (used after a
+                                        license is dropped in or the daemon
+                                        writes a new cloud_plan.json, so the
+                                        UI does not have to wait for the 60 s
+                                        TTL).
+  GET  /api/entitlement/required-tier -- resolve the minimum purchasable tier
+                                         for a feature= or runtime= key.
+  GET  /api/entitlement/upgrade-diff  -- features + runtimes a target tier
+                                         would add on top of the current ent.
+  GET  /api/runtimes                  -- the full runtime catalog with
+                                         locked/free/tier flags.
 
-Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
-on the cloud side: when no license/cloud plan is present it returns a graceful
+Side-effect-free and never-raise (refresh's only side effect is busting the
+in-process cache), so it is safe to classify ``oss-passthrough`` on the cloud
+side: when no license/cloud plan is present every endpoint returns a graceful
 OSS-free shape, never a 4xx.
 """
 
@@ -41,6 +54,7 @@ def api_entitlement():
         return jsonify(
             {
                 "tier": "oss",
+                "tier_label": "OSS",
                 "source": "oss",
                 "node_limit": 1,
                 "expiry": None,
@@ -48,11 +62,125 @@ def api_entitlement():
                 "is_paid": False,
                 "grace": True,
                 "enforced": False,
+                "enforce_at": None,
+                "enforce_at_iso": None,
+                "days_until_enforce": None,
                 "retention_days": 7,
                 "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/refresh", methods=["POST"])
+def api_entitlement_refresh():
+    """Force-drop the in-process entitlement cache and re-resolve.
+
+    The resolver caches for 60 s; this endpoint covers the manual / out-of-band
+    install path where the operator just dropped a license file or the daemon
+    wrote a fresh cloud_plan.json and does not want to wait for the TTL.
+    Returns the freshly resolved Entitlement (same shape as ``/api/entitlement``).
+    Falls back to the grace OSS-free shape on any error.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        _ent.invalidate()
+        return jsonify(_ent.get_entitlement(force=True).to_dict())
+    except Exception as exc:
+        logger.warning("api_entitlement_refresh: falling back to OSS-free: %s", exc)
+        return jsonify(
+            {
+                "tier": "oss",
+                "tier_label": "OSS",
+                "source": "oss",
+                "node_limit": 1,
+                "expiry": None,
+                "expired": False,
+                "is_paid": False,
+                "grace": True,
+                "enforced": False,
+                "enforce_at": None,
+                "enforce_at_iso": None,
+                "days_until_enforce": None,
+                "runtimes": ["nemoclaw", "openclaw"],
+                "features": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/upgrade-diff")
+def api_entitlement_upgrade_diff():
+    """Return the features + runtimes ``?target=<tier>`` would unlock on top of
+    the current entitlement. Drives the upgrade CTA shown on locked rows.
+
+    Shape: ``{"target": "<tier>", "added_features": [...], "added_runtimes": [...]}``
+
+    Unknown / missing ``target`` returns empty lists; never raises."""
+    try:
+        target = (request.args.get("target") or "").strip().lower()
+        from clawmetry import entitlements as _ent
+
+        return jsonify(_ent.upgrade_diff(target))
+    except Exception as exc:
+        logger.warning("api_entitlement_upgrade_diff: error: %s", exc)
+        return jsonify(
+            {
+                "target": (request.args.get("target") or "").strip().lower(),
+                "added_features": [],
+                "added_runtimes": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/required-tier")
+def api_entitlement_required_tier():
+    """Resolve the minimum *purchasable* tier that unlocks a given feature or
+    runtime. Drives the lock affordance copy ("Available in Starter" / "Available
+    in Pro").
+
+    Query: exactly one of ``feature=<id>`` or ``runtime=<id>``.
+
+    Returns 200 with key, kind, required_tier, current_tier, upgrade_required,
+    allowed. Returns 400 when neither query param is supplied or both are given.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        feature = (request.args.get("feature") or "").strip().lower()
+        runtime = (request.args.get("runtime") or "").strip().lower()
+        if not feature and not runtime:
+            return jsonify({"error": "supply either feature=<id> or runtime=<id>"}), 400
+        if feature and runtime:
+            return jsonify({"error": "supply only one of feature= or runtime="}), 400
+        if feature:
+            key, kind = feature, "feature"
+            required = _ent.min_tier_for_feature(feature)
+            allowed = _ent.get_entitlement().allows_feature(feature)
+        else:
+            key, kind = runtime, "runtime"
+            required = _ent.min_tier_for_runtime(runtime)
+            allowed = _ent.get_entitlement().allows_runtime(runtime)
+        ent = _ent.get_entitlement()
+        cur_rank = _ent.tier_rank(ent.tier)
+        req_rank = _ent.tier_rank(required) if required else -1
+        required_label = _ent.tier_label(required) if required else None
+        return jsonify(
+            {
+                "key": key,
+                "kind": kind,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "current_tier": ent.tier,
+                "current_tier_rank": cur_rank,
+                "upgrade_required": bool(required) and req_rank > cur_rank,
+                "allowed": allowed,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_required_tier: error: %s", exc)
+        return jsonify({"error": str(exc)}), 500
 
 
 @bp_entitlement.route("/api/entitlement/diagnostic")
@@ -135,6 +263,7 @@ def api_runtimes():
                         "id": "nemoclaw",
                         "label": "NemoClaw",
                         "free": True,
+                        "tier": "free",
                         "allowed": True,
                         "locked": False,
                     },
@@ -142,6 +271,7 @@ def api_runtimes():
                         "id": "openclaw",
                         "label": "OpenClaw",
                         "free": True,
+                        "tier": "free",
                         "allowed": True,
                         "locked": False,
                     },

--- a/tests/test_entitlement_api.py
+++ b/tests/test_entitlement_api.py
@@ -165,3 +165,187 @@ def test_api_entitlement_paid_tier_grants_all_runtimes(monkeypatch, tmp_path, ti
     # All paid runtimes must be present.
     for rt in e.PAID_RUNTIMES:
         assert rt in d["runtimes"], f"{tier}: {rt} missing from runtimes"
+
+
+# ── tier_label on /api/entitlement ──────────────────────────────────────────
+
+
+def test_api_entitlement_carries_tier_label(client):
+    """The payload includes a human-readable label alongside the tier id so
+    the dashboard's tier badge can render without a duplicate JS map."""
+    c, _ = client
+    d = c.get("/api/entitlement").get_json()
+    assert d["tier"] == "oss"
+    assert d["tier_label"] == "OSS"
+
+
+# ── refresh endpoint ──────────────────────────────────────────────────────────
+
+
+def test_api_entitlement_refresh_grace_shape(client):
+    """POST /api/entitlement/refresh returns the same shape as GET when no
+    license/cloud plan is present, and never raises on a clean HOME."""
+    c, _ = client
+    resp = c.post("/api/entitlement/refresh")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    for key in ("tier", "source", "grace", "enforced", "is_paid",
+                "runtimes", "features"):
+        assert key in d, key
+    assert d["tier"] == "oss"
+    assert d["grace"] is True
+    assert d["enforced"] is False
+    assert d["grace"] == (not d["enforced"])
+
+
+def test_api_entitlement_refresh_busts_cache(monkeypatch, tmp_path):
+    """Refresh must pick up a cloud_plan.json that was written *after* the
+    first GET populated the cache, without waiting for the 60 s TTL."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    client_ = app.test_client()
+
+    first = client_.get("/api/entitlement").get_json()
+    assert first["tier"] == "oss"
+    assert first["source"] == "oss"
+
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro", "node_limit": 5,
+                                 "expiry": None}))
+
+    # GET still returns the cached OSS result -- TTL hasn't elapsed.
+    stale = client_.get("/api/entitlement").get_json()
+    assert stale["tier"] == "oss"
+
+    refreshed = client_.post("/api/entitlement/refresh").get_json()
+    assert refreshed["tier"] == "cloud_pro"
+    assert refreshed["source"] == "cloud"
+    assert refreshed["is_paid"] is True
+
+
+def test_api_entitlement_refresh_idempotent(client):
+    """Repeated refresh calls return identical shapes -- refresh must be safe
+    to spam from a dashboard timer / connect-flow retry loop."""
+    c, _ = client
+    a = c.post("/api/entitlement/refresh").get_json()
+    b = c.post("/api/entitlement/refresh").get_json()
+    assert a == b
+
+
+# ── upgrade-diff endpoint ────────────────────────────────────────────────────
+
+
+def test_api_upgrade_diff_oss_to_cloud_pro(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/upgrade-diff?target=cloud_pro")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["target"] == "cloud_pro"
+    import clawmetry.entitlements as e
+    assert set(d["added_features"]) == set(e.PAID_FEATURES)
+    assert set(d["added_runtimes"]) == set(e.PAID_RUNTIMES)
+    assert d["added_features"] == sorted(d["added_features"])
+    assert d["added_runtimes"] == sorted(d["added_runtimes"])
+
+
+def test_api_upgrade_diff_unknown_target_is_empty_not_500(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/upgrade-diff?target=nope")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["target"] == "nope"
+    assert d["added_features"] == []
+    assert d["added_runtimes"] == []
+
+
+def test_api_upgrade_diff_missing_target_is_empty(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/upgrade-diff")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["added_features"] == []
+    assert d["added_runtimes"] == []
+
+
+def test_api_upgrade_diff_case_insensitive(client):
+    c, _ = client
+    a = c.get("/api/entitlement/upgrade-diff?target=cloud_pro").get_json()
+    b = c.get("/api/entitlement/upgrade-diff?target=CLOUD_PRO").get_json()
+    assert a["added_features"] == b["added_features"]
+    assert a["added_runtimes"] == b["added_runtimes"]
+
+
+@pytest.mark.parametrize("tier,expected_runtime_diff", [
+    ("cloud_starter", "paid"),
+    ("cloud_pro", "paid"),
+    ("enterprise", "paid"),
+])
+def test_api_upgrade_diff_paid_tiers_all_unlock_paid_runtimes(client, tier,
+                                                               expected_runtime_diff):
+    c, _ = client
+    d = c.get(f"/api/entitlement/upgrade-diff?target={tier}").get_json()
+    import clawmetry.entitlements as e
+    assert set(d["added_runtimes"]) == set(e.PAID_RUNTIMES)
+
+
+def test_api_upgrade_diff_starter_subscriber_to_pro(monkeypatch, tmp_path):
+    """A Starter subscriber asking for Pro should only see PRO_ONLY features."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_starter", "node_limit": 1,
+                                 "expiry": None}))
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement/upgrade-diff?target=cloud_pro").get_json()
+
+    assert set(d["added_features"]) == set(e.PRO_ONLY_FEATURES)
+    assert d["added_runtimes"] == []
+
+
+# ── grace countdown ───────────────────────────────────────────────────────────
+
+
+def test_api_entitlement_enforce_at_keys_unset(client):
+    """Always present on /api/entitlement so frontend can read them without
+    a feature-detect; unset means all three are null."""
+    c, _ = client
+    d = c.get("/api/entitlement").get_json()
+    for key in ("enforce_at", "enforce_at_iso", "days_until_enforce"):
+        assert key in d, key
+        assert d[key] is None
+
+
+def test_api_entitlement_enforce_at_surfaced(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "2099-01-01T00:00:00Z")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/entitlement").get_json()
+    assert d["enforce_at"] is not None
+    assert d["enforce_at_iso"] == "2099-01-01T00:00:00Z"
+    assert isinstance(d["days_until_enforce"], int)
+    assert d["days_until_enforce"] > 0
+    assert d["grace"] is True
+    assert d["enforced"] is False

--- a/tests/test_entitlement_lock_reason.py
+++ b/tests/test_entitlement_lock_reason.py
@@ -1,0 +1,240 @@
+"""Tests for ``Entitlement.lock_reason()`` + the module-level convenience.
+
+The helper exists so every surface that needs to explain *why* a runtime or
+feature is locked composes the same string from the same place. The tests
+below pin that contract:
+
+* grace mode locks nothing (never returns a reason)
+* free runtimes / free features never have a reason
+* paid items on a free tier surface a reason that mentions the tier where
+  they unlock (Starter / Pro / Enterprise)
+* an expired license locks the paid items it used to grant
+* a higher tier (Pro) sees its grants as un-locked
+* a Starter tier still sees Pro-only items as locked
+* unknown / empty input is silently un-locked (never-raise, never-claim)
+* the module-level :func:`clawmetry.entitlements.lock_reason` mirrors the
+  instance method
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── grace mode ──────────────────────────────────────────────────────────────
+
+
+def test_grace_locks_nothing_runtime(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("claude_code") is None
+    assert en.lock_reason("openclaw") is None
+
+
+def test_grace_locks_nothing_feature(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("self_evolve") is None
+    assert en.lock_reason("sessions") is None
+
+
+# ── free items never lock ───────────────────────────────────────────────────
+
+
+def test_free_runtime_never_locked_when_enforced(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.grace is False
+    assert en.lock_reason("openclaw") is None
+    assert en.lock_reason("nemoclaw") is None
+
+
+def test_free_feature_never_locked_when_enforced(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("sessions") is None
+    assert en.lock_reason("transcripts") is None
+    assert en.lock_reason("nemo_governance") is None
+
+
+# ── paid items on OSS in enforce mode ───────────────────────────────────────
+
+
+def test_paid_runtime_locked_on_oss(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("claude_code")
+    assert reason is not None
+    assert "claude_code" in reason
+    assert "Paid runtime" in reason
+
+
+def test_paid_feature_reason_names_starter(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("fleet")
+    assert reason is not None
+    assert "Starter" in reason
+    assert "fleet" in reason
+
+
+def test_paid_feature_reason_names_pro(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("self_evolve")
+    assert reason is not None
+    assert "Pro" in reason
+    assert "self_evolve" in reason
+
+
+def test_paid_feature_reason_names_enterprise(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("sso")
+    assert reason is not None
+    assert "Enterprise" in reason
+    assert "sso" in reason
+
+
+# ── explicit kind selection ─────────────────────────────────────────────────
+
+
+def test_kind_runtime_explicit(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("claude_code", kind="runtime")
+    assert reason is not None
+    assert "runtime" in reason.lower()
+
+
+def test_kind_feature_explicit(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("fleet", kind="feature")
+    assert reason is not None
+    assert "feature" in reason.lower()
+
+
+# ── tier-dependent unlocks ──────────────────────────────────────────────────
+
+
+def test_pro_tier_unlocks_paid_runtimes(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    pro = ent._build(ent.TIER_PRO, "license", node_limit=1, expiry=None)
+    assert pro.lock_reason("claude_code") is None
+    assert pro.lock_reason("self_evolve") is None
+
+
+def test_starter_tier_still_locks_pro_only_feature(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    starter = ent._build(ent.TIER_CLOUD_STARTER, "cloud", node_limit=1, expiry=None)
+    assert starter.lock_reason("fleet") is None
+    reason = starter.lock_reason("self_evolve")
+    assert reason is not None
+    assert "Pro" in reason
+
+
+def test_starter_tier_still_locks_enterprise_feature(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    starter = ent._build(ent.TIER_CLOUD_STARTER, "cloud", node_limit=1, expiry=None)
+    reason = starter.lock_reason("sso")
+    assert reason is not None
+    assert "Enterprise" in reason
+
+
+# ── expiry ──────────────────────────────────────────────────────────────────
+
+
+def test_expired_paid_runtime_reason_says_expired(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    expired = ent._build(ent.TIER_PRO, "license", node_limit=1, expiry=1.0)
+    assert expired.expired is True
+    reason = expired.lock_reason("claude_code")
+    assert reason is not None
+    assert "expired" in reason.lower()
+
+
+def test_expired_paid_feature_reason_says_expired(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    expired = ent._build(ent.TIER_PRO, "license", node_limit=1, expiry=1.0)
+    reason = expired.lock_reason("self_evolve")
+    assert reason is not None
+    assert "expired" in reason.lower()
+
+
+# ── unknown / bad input ─────────────────────────────────────────────────────
+
+
+def test_unknown_item_returns_none(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("not_a_real_thing") is None
+    assert en.lock_reason("definitely_not_a_runtime", kind="runtime") is None
+    assert en.lock_reason("definitely_not_a_feature", kind="feature") is None
+
+
+def test_empty_and_none_input_is_safe(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("") is None
+    assert en.lock_reason(None) is None  # type: ignore[arg-type]
+    assert en.lock_reason("   ") is None
+    assert en.lock_reason("X" * 4096) is None
+
+
+def test_case_insensitive_input(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("Claude_Code")
+    assert reason is not None
+    assert "claude_code" in reason
+
+
+# ── module-level convenience ────────────────────────────────────────────────
+
+
+def test_module_level_lock_reason_mirrors_instance(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    assert ent.lock_reason("claude_code") is not None
+    assert ent.lock_reason("openclaw") is None
+    assert ent.lock_reason("self_evolve") is not None
+
+
+def test_module_level_lock_reason_grace_returns_none(ent):
+    assert ent.lock_reason("claude_code") is None
+    assert ent.lock_reason("self_evolve") is None
+
+
+def test_module_level_lock_reason_never_raises(ent, monkeypatch):
+    def boom(*a, **kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.lock_reason("claude_code") is None
+    assert ent.lock_reason("self_evolve") is None

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -390,6 +390,230 @@ def test_runtime_aliases_all_resolve_to_known_runtimes(ent):
         assert alias not in ent.ALL_RUNTIMES, alias
 
 
+# ── tier_label() ─────────────────────────────────────────────────────────────
+
+
+def test_tier_label_known_tiers(ent):
+    assert ent.tier_label(ent.TIER_OSS) == "OSS"
+    assert ent.tier_label(ent.TIER_CLOUD_FREE) == "Free"
+    assert ent.tier_label(ent.TIER_TRIAL) == "Trial"
+    assert ent.tier_label(ent.TIER_CLOUD_STARTER) == "Starter"
+    assert ent.tier_label(ent.TIER_CLOUD_PRO) == "Pro"
+    assert ent.tier_label(ent.TIER_PRO) == "Self-hosted Pro"
+    assert ent.tier_label(ent.TIER_ENTERPRISE) == "Enterprise"
+
+
+def test_tier_label_covers_every_known_tier_id(ent):
+    known = {
+        ent.TIER_OSS, ent.TIER_CLOUD_FREE, ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    missing = known - set(ent.TIER_LABELS.keys())
+    assert not missing, f"TIER_LABELS missing rows for: {sorted(missing)}"
+
+
+def test_tier_label_unknown_titlecased(ent):
+    assert ent.tier_label("cloud_team") == "Cloud Team"
+    assert ent.tier_label("FOO_BAR") == "Foo Bar"
+
+
+def test_tier_label_empty_and_none_safe(ent):
+    assert ent.tier_label("") == "OSS"
+    assert ent.tier_label("   ") == "OSS"
+    assert ent.tier_label(None) == "OSS"  # type: ignore[arg-type]
+
+
+def test_tier_label_normalises_case_and_whitespace(ent):
+    assert ent.tier_label("  CLOUD_PRO  ") == "Pro"
+    assert ent.tier_label("Enterprise") == "Enterprise"
+
+
+def test_to_dict_surfaces_tier_label(ent):
+    en = ent.get_entitlement(force=True)
+    payload = en.to_dict()
+    assert payload["tier"] == ent.TIER_OSS
+    assert payload["tier_label"] == "OSS"
+
+
+def test_to_dict_tier_label_for_paid_tier(ent):
+    pro = ent._build(ent.TIER_CLOUD_PRO, "cloud", node_limit=2, expiry=None)
+    payload = pro.to_dict()
+    assert payload["tier"] == ent.TIER_CLOUD_PRO
+    assert payload["tier_label"] == "Pro"
+
+
+# ── upgrade_diff ────────────────────────────────────────────────────────────
+
+
+def test_upgrade_diff_oss_to_starter_adds_starter_features_and_paid_runtimes(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_OSS
+    diff = en.upgrade_diff(ent.TIER_CLOUD_STARTER)
+    assert diff["target"] == ent.TIER_CLOUD_STARTER
+    assert set(diff["added_features"]) == set(ent.STARTER_FEATURES)
+    assert set(ent.FREE_FEATURES).isdisjoint(diff["added_features"])
+    assert set(diff["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+    assert diff["added_features"] == sorted(diff["added_features"])
+    assert diff["added_runtimes"] == sorted(diff["added_runtimes"])
+
+
+def test_upgrade_diff_oss_to_pro_adds_all_paid_features(ent):
+    en = ent.get_entitlement(force=True)
+    diff = en.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert set(diff["added_features"]) == set(ent.PAID_FEATURES)
+    assert set(diff["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_upgrade_diff_oss_to_enterprise_adds_enterprise_features(ent):
+    en = ent.get_entitlement(force=True)
+    diff = en.upgrade_diff(ent.TIER_ENTERPRISE)
+    expected = set(ent.PAID_FEATURES) | set(ent.ENTERPRISE_FEATURES)
+    assert set(diff["added_features"]) == expected
+    assert set(diff["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_upgrade_diff_starter_to_pro_adds_only_pro_only_features(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_STARTER, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_CLOUD_STARTER
+    diff = en.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert set(diff["added_features"]) == set(ent.PRO_ONLY_FEATURES)
+    assert diff["added_runtimes"] == []
+
+
+def test_upgrade_diff_pro_to_enterprise_adds_only_enterprise_features(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_CLOUD_PRO
+    diff = en.upgrade_diff(ent.TIER_ENTERPRISE)
+    assert set(diff["added_features"]) == set(ent.ENTERPRISE_FEATURES)
+    assert diff["added_runtimes"] == []
+
+
+def test_upgrade_diff_same_tier_is_empty(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    diff = en.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert diff["added_features"] == []
+    assert diff["added_runtimes"] == []
+
+
+def test_upgrade_diff_unknown_target_returns_empty(ent):
+    en = ent.get_entitlement(force=True)
+    diff = en.upgrade_diff("totally-made-up-tier")
+    assert diff["added_features"] == []
+    assert diff["added_runtimes"] == []
+    assert diff["target"] == "totally-made-up-tier"
+
+
+def test_upgrade_diff_empty_and_none_targets_are_safe(ent):
+    en = ent.get_entitlement(force=True)
+    for bad in ("", None, "   "):
+        diff = en.upgrade_diff(bad)
+        assert diff["added_features"] == []
+        assert diff["added_runtimes"] == []
+
+
+def test_upgrade_diff_module_helper_resolves_current(ent):
+    direct = ent.get_entitlement(force=True).upgrade_diff(ent.TIER_CLOUD_PRO)
+    via_module = ent.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert direct == via_module
+
+
+def test_upgrade_diff_case_insensitive_target(ent):
+    en = ent.get_entitlement(force=True)
+    a = en.upgrade_diff(ent.TIER_CLOUD_PRO)
+    b = en.upgrade_diff(ent.TIER_CLOUD_PRO.upper())
+    c = en.upgrade_diff("  " + ent.TIER_CLOUD_PRO + "  ")
+    assert a["added_features"] == b["added_features"] == c["added_features"]
+    assert a["added_runtimes"] == b["added_runtimes"] == c["added_runtimes"]
+
+
+# ── CLAWMETRY_ENFORCE_AT (grace countdown) ────────────────────────────────────
+
+
+def test_enforce_at_unset_is_none(ent, monkeypatch):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE_AT", raising=False)
+    assert ent.enforce_at_epoch() is None
+    en = ent.get_entitlement(force=True)
+    assert en.grace_remaining_days() is None
+    d = en.to_dict()
+    assert d["enforce_at"] is None
+    assert d["enforce_at_iso"] is None
+    assert d["days_until_enforce"] is None
+
+
+def test_enforce_at_iso_date_future(ent, monkeypatch):
+    future = time.time() + 30 * 86400
+    from datetime import datetime, timezone
+    iso = datetime.fromtimestamp(future, tz=timezone.utc).date().isoformat()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", iso)
+    at = ent.enforce_at_epoch()
+    assert at is not None
+    en = ent.get_entitlement(force=True)
+    days = en.grace_remaining_days()
+    assert days is not None and 25 <= days <= 31
+    d = en.to_dict()
+    assert d["enforce_at"] == pytest.approx(at)
+    assert d["enforce_at_iso"] is not None and d["enforce_at_iso"].endswith("Z")
+    assert d["days_until_enforce"] == days
+
+
+def test_enforce_at_epoch_seconds_accepted(ent, monkeypatch):
+    future = time.time() + 7 * 86400
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", str(int(future)))
+    en = ent.get_entitlement(force=True)
+    assert en.grace_remaining_days() in (6, 7)
+    assert en.to_dict()["enforce_at"] == pytest.approx(float(int(future)))
+
+
+def test_enforce_at_iso_datetime_z_suffix(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "2099-01-01T00:00:00Z")
+    en = ent.get_entitlement(force=True)
+    d = en.to_dict()
+    assert d["enforce_at"] is not None
+    assert d["enforce_at_iso"] == "2099-01-01T00:00:00Z"
+    assert d["days_until_enforce"] is not None and d["days_until_enforce"] > 0
+
+
+def test_enforce_at_past_clamps_to_zero(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "2000-01-01")
+    en = ent.get_entitlement(force=True)
+    assert en.grace_remaining_days() == 0
+    d = en.to_dict()
+    assert d["days_until_enforce"] == 0
+    assert d["enforce_at"] is not None
+
+
+def test_enforce_at_malformed_is_graceful(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "not-a-date")
+    assert ent.enforce_at_epoch() is None
+    en = ent.get_entitlement(force=True)
+    d = en.to_dict()
+    assert d["enforce_at"] is None
+    assert d["enforce_at_iso"] is None
+    assert d["days_until_enforce"] is None
+
+
+def test_enforce_at_independent_of_enforce_flag(ent, monkeypatch):
+    """Setting the countdown env var must NOT flip grace -> enforce."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE_AT", "2099-01-01")
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.allows_runtime("claude_code") is True
+
+
 def test_appjs_teaser_wiring():
     """The catalog loader must use `entitled` (grace teaser) and must NOT
     early-return when enforcement is off, while guarding hosted paying/trial

--- a/tests/test_entitlements_min_tier.py
+++ b/tests/test_entitlements_min_tier.py
@@ -1,0 +1,177 @@
+"""Tests for the ``min_tier_for_*`` helpers and ``/api/entitlement/required-tier``.
+
+The lock affordance copy ("Available in Starter" / "Available in Pro") needs a
+single, canonical reverse lookup from a feature or runtime to the cheapest
+purchasable tier that grants it. The helpers under test are the source of
+truth; this file pins the table so a future tier shuffle breaks loudly here
+instead of silently in the UI.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── tier_rank ────────────────────────────────────────────────────────────────
+
+
+def test_tier_rank_orders_purchasable_tiers(ent):
+    assert ent.tier_rank(ent.TIER_OSS) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_FREE) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_STARTER) > ent.tier_rank(ent.TIER_OSS)
+    assert ent.tier_rank(ent.TIER_PRO) == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert ent.tier_rank(ent.TIER_CLOUD_PRO) > ent.tier_rank(ent.TIER_CLOUD_STARTER)
+    assert ent.tier_rank(ent.TIER_ENTERPRISE) > ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+def test_tier_rank_unknown_returns_minus_one(ent):
+    assert ent.tier_rank("nope") == -1
+    assert ent.tier_rank("") == -1
+    assert ent.tier_rank(None) == -1
+
+
+def test_tier_rank_case_insensitive(ent):
+    assert ent.tier_rank("CLOUD_PRO") == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+# ── min_tier_for_feature ─────────────────────────────────────────────────────
+
+
+def test_free_feature_minimum_is_oss(ent):
+    for f in sorted(ent.FREE_FEATURES):
+        assert ent.min_tier_for_feature(f) == ent.TIER_OSS, f
+
+
+def test_starter_features_minimum_is_starter(ent):
+    for f in sorted(ent.STARTER_FEATURES):
+        assert ent.min_tier_for_feature(f) == ent.TIER_CLOUD_STARTER, f
+
+
+def test_pro_only_features_minimum_is_cloud_pro(ent):
+    for f in sorted(ent.PRO_ONLY_FEATURES):
+        assert ent.min_tier_for_feature(f) == ent.TIER_CLOUD_PRO, f
+
+
+def test_enterprise_features_minimum_is_enterprise(ent):
+    for f in sorted(ent.ENTERPRISE_FEATURES):
+        assert ent.min_tier_for_feature(f) == ent.TIER_ENTERPRISE, f
+
+
+def test_min_tier_for_feature_unknown_returns_none(ent):
+    assert ent.min_tier_for_feature("not_a_real_feature") is None
+    assert ent.min_tier_for_feature("") is None
+    assert ent.min_tier_for_feature(None) is None
+
+
+def test_min_tier_for_feature_excludes_trial(ent):
+    for f in ent.PAID_FEATURES | ent.ENTERPRISE_FEATURES:
+        assert ent.min_tier_for_feature(f) != ent.TIER_TRIAL, f
+
+
+def test_min_tier_for_feature_is_case_insensitive(ent):
+    assert ent.min_tier_for_feature("OTEL_EXPORT") == ent.TIER_CLOUD_PRO
+
+
+# ── min_tier_for_runtime ─────────────────────────────────────────────────────
+
+
+def test_free_runtime_minimum_is_oss(ent):
+    for rt in sorted(ent.FREE_RUNTIMES):
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_OSS, rt
+
+
+def test_paid_runtime_minimum_is_starter(ent):
+    for rt in sorted(ent.PAID_RUNTIMES):
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_CLOUD_STARTER, rt
+
+
+def test_min_tier_for_runtime_unknown_returns_none(ent):
+    assert ent.min_tier_for_runtime("not_a_runtime") is None
+    assert ent.min_tier_for_runtime("") is None
+    assert ent.min_tier_for_runtime(None) is None
+
+
+# ── Entitlement.min_tier_for ─────────────────────────────────────────────────
+
+
+def test_entitlement_min_tier_for_dispatches_to_feature_and_runtime(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.min_tier_for("sessions") == ent.TIER_OSS
+    assert en.min_tier_for("otel_export") == ent.TIER_CLOUD_PRO
+    assert en.min_tier_for("claude_code") == ent.TIER_CLOUD_STARTER
+    assert en.min_tier_for("openclaw") == ent.TIER_OSS
+
+
+def test_entitlement_min_tier_for_unknown_returns_none(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.min_tier_for("not_a_key") is None
+    assert en.min_tier_for("") is None
+    assert en.min_tier_for(None) is None
+
+
+# ── /api/entitlement/required-tier ───────────────────────────────────────────
+
+
+def test_required_tier_for_feature(client, ent):
+    resp = client.get("/api/entitlement/required-tier?feature=otel_export")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["key"] == "otel_export"
+    assert d["kind"] == "feature"
+    assert d["required_tier"] == ent.TIER_CLOUD_PRO
+    assert d["current_tier"] == ent.TIER_OSS
+    assert d["upgrade_required"] is True
+    assert d["allowed"] is True  # grace mode
+
+
+def test_required_tier_for_free_feature(client, ent):
+    d = client.get("/api/entitlement/required-tier?feature=sessions").get_json()
+    assert d["required_tier"] == ent.TIER_OSS
+    assert d["upgrade_required"] is False
+    assert d["allowed"] is True
+
+
+def test_required_tier_for_runtime(client, ent):
+    d = client.get("/api/entitlement/required-tier?runtime=claude_code").get_json()
+    assert d["key"] == "claude_code"
+    assert d["kind"] == "runtime"
+    assert d["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert d["upgrade_required"] is True
+
+
+def test_required_tier_unknown_key_is_null_not_error(client):
+    resp = client.get("/api/entitlement/required-tier?feature=nope_does_not_exist")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["required_tier"] is None
+    assert d["upgrade_required"] is False
+
+
+def test_required_tier_requires_one_query_param(client):
+    assert client.get("/api/entitlement/required-tier").status_code == 400
+    assert client.get(
+        "/api/entitlement/required-tier?feature=sessions&runtime=openclaw"
+    ).status_code == 400

--- a/tests/test_runtime_tier.py
+++ b/tests/test_runtime_tier.py
@@ -1,0 +1,140 @@
+"""Tests for ``clawmetry.entitlements.runtime_tier`` and the ``tier`` field
+on ``runtime_catalog()`` rows.
+
+All paid runtimes unlock together via the Starter ``multi_runtime`` grant, so
+the runtime vocabulary is intentionally smaller than the feature one:
+``{"free", "starter"}``.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── runtime_tier() helper ──────────────────────────────────────────────────────
+
+
+def test_free_runtimes_tier_is_free(ent):
+    assert ent.runtime_tier("openclaw") == "free"
+    assert ent.runtime_tier("nemoclaw") == "free"
+
+
+def test_every_free_runtime_resolves_to_free(ent):
+    for rt in ent.FREE_RUNTIMES:
+        assert ent.runtime_tier(rt) == "free", rt
+
+
+def test_every_paid_runtime_resolves_to_starter(ent):
+    for rt in ent.PAID_RUNTIMES:
+        assert ent.runtime_tier(rt) == "starter", rt
+
+
+def test_unknown_runtime_defaults_to_starter(ent):
+    """Unknown ids err on the locked side rather than silently grant access."""
+    assert ent.runtime_tier("totally_made_up_runtime") == "starter"
+    assert ent.runtime_tier("some.other.runtime") == "starter"
+
+
+def test_empty_and_none_safely_default(ent):
+    assert ent.runtime_tier("") == "starter"
+    assert ent.runtime_tier(None) == "starter"  # type: ignore[arg-type]
+
+
+def test_case_insensitive(ent):
+    assert ent.runtime_tier("OpenClaw") == "free"
+    assert ent.runtime_tier("CLAUDE_CODE") == "starter"
+
+
+def test_whitespace_is_stripped(ent):
+    assert ent.runtime_tier("  openclaw  ") == "free"
+    assert ent.runtime_tier("\tclaude_code\n") == "starter"
+
+
+def test_never_raises_on_non_string_input(ent):
+    for weird in (123, 0, [], {}, object()):
+        try:
+            result = ent.runtime_tier(weird)  # type: ignore[arg-type]
+        except Exception as exc:
+            pytest.fail(f"runtime_tier({weird!r}) raised: {exc}")
+        assert result == "starter"
+
+
+# ── runtime_catalog() carries the tier field ───────────────────────────────────
+
+
+def test_catalog_rows_carry_tier_field(ent):
+    for row in ent.runtime_catalog():
+        assert "tier" in row, row
+        assert isinstance(row["tier"], str)
+
+
+def test_catalog_free_rows_are_tier_free(ent):
+    rows = {r["id"]: r for r in ent.runtime_catalog()}
+    for rt in ent.FREE_RUNTIMES:
+        assert rows[rt]["tier"] == "free", rt
+
+
+def test_catalog_paid_rows_are_tier_starter(ent):
+    rows = {r["id"]: r for r in ent.runtime_catalog()}
+    for rt in ent.PAID_RUNTIMES:
+        assert rows[rt]["tier"] == "starter", rt
+
+
+def test_catalog_tier_vocabulary_is_only_free_or_starter(ent):
+    tiers = {r["tier"] for r in ent.runtime_catalog()}
+    assert tiers == {"free", "starter"}
+
+
+def test_catalog_tier_matches_free_bit(ent):
+    for row in ent.runtime_catalog():
+        if row["free"]:
+            assert row["tier"] == "free", row
+        else:
+            assert row["tier"] == "starter", row
+
+
+def test_catalog_tier_matches_runtime_tier_helper(ent):
+    for row in ent.runtime_catalog():
+        assert row["tier"] == ent.runtime_tier(row["id"]), row
+
+
+def test_tier_is_static_across_grace_and_enforce(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    grace_tiers = {r["id"]: r["tier"] for r in e.runtime_catalog()}
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(e)
+    e.invalidate()
+    enforce_tiers = {r["id"]: r["tier"] for r in e.runtime_catalog()}
+
+    assert grace_tiers == enforce_tiers
+
+
+def test_tier_unchanged_by_resolution_failure(ent, monkeypatch):
+    def _boom():
+        raise RuntimeError("simulated resolution failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", _boom)
+    rows = ent.runtime_catalog()
+    assert rows, "fallback catalog should still be non-empty"
+    for row in rows:
+        assert "tier" in row, row
+        assert row["tier"] in ("free", "starter"), row


### PR DESCRIPTION
## Summary

Consolidates 7 related open PRs (#2925, #3033, #3084, #3104, #3106, #3109, #3112) into one clean batch rebased onto current main (including feature_catalog, retention_days, canonical_runtime, resolution_diagnostic, and emit-changed commits). Replaces #3146.

### entitlements.py additions

- `TIER_LABELS` + `tier_label(tier)` -- human-readable tier strings for the dashboard tier badge (replaces hardcoded JS map)
- `_PURCHASABLE_TIERS`, `_TIER_RANK`, `tier_rank(tier)` -- canonical tier ordering for the "Available in..." lock affordance
- `min_tier_for_feature(feature)` + `min_tier_for_runtime(runtime)` + `Entitlement.min_tier_for(key)` -- cheapest purchasable tier reverse-lookup
- `Entitlement.upgrade_diff(target_tier)` + module-level `upgrade_diff()` -- what a target tier would add on top of the current entitlement (upgrade CTA driver)
- `Entitlement.lock_reason(item, *, kind)` + module-level `lock_reason()` -- single source of truth for "why is this locked" copy (grace-safe, never-raise)
- `runtime_tier(runtime)` -- "free" vs "starter" for runtime catalog rows
- `_ENFORCE_AT_ENV`, `enforce_at_epoch()`, `Entitlement.grace_remaining_days()` -- grace countdown banner driven by `CLAWMETRY_ENFORCE_AT` env var
- `Entitlement.to_dict()` gains `tier_label`, `enforce_at`, `enforce_at_iso`, `days_until_enforce`
- `runtime_catalog()` rows gain a `"tier"` field

### routes/entitlement.py additions

- `POST /api/entitlement/refresh` -- bust the 60s cache and re-resolve
- `GET /api/entitlement/upgrade-diff?target=` -- upgrade CTA diff
- `GET /api/entitlement/required-tier?feature=` / `?runtime=` -- lock affordance tier lookup
- Fallback shapes updated to include new fields

### Tests

- 3 new test files: `test_runtime_tier.py`, `test_entitlement_lock_reason.py`, `test_entitlements_min_tier.py`
- Extensions to `test_entitlements.py` (tier_label, upgrade_diff, grace-countdown sections)
- Extensions to `test_entitlement_api.py` (tier_label, refresh, upgrade-diff, grace countdown sections)

Closes #2925, #3033, #3084, #3104, #3106, #3109, #3112.

## Test plan

- [ ] `pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_runtime_tier.py tests/test_entitlement_lock_reason.py tests/test_entitlements_min_tier.py` -- all pass
- [ ] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py` -- syntax clean

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_