### PR TITLE
fix(entitlement): import os so /api/entitlement/diagnostic fallback never NameErrors

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -20,6 +20,7 @@ OSS-free shape, never a 4xx.
 from __future__ import annotations
 
 import logging
+import os
 
 from flask import Blueprint, jsonify, request
 


### PR DESCRIPTION
## Summary

One-line bug fix: adds `import os` to `routes/entitlement.py`.

The `/api/entitlement/diagnostic` fallback path (the `except` block in `api_entitlement_diagnostic`) references `os.environ.get("CLAWMETRY_ENFORCE")` but `os` was never imported in the module. Every time `resolution_diagnostic()` raises an exception, the fallback itself raises `NameError: name 'os' is not defined`, Flask returns **500**, and the operator-triage panel goes dark **exactly when it is needed** -- when something has already gone wrong with entitlement resolution.

## Diff

```diff
 from __future__ import annotations

 import logging
+import os

 from flask import Blueprint, jsonify, request
```

## After

The fallback returns its promised safe shape (with `enforce_env`, `is_enforced`, and `error` populated) instead of a 500.

## No behavior change

Only the previously-broken fallback path is now reachable as documented. The success path is untouched. No `__version__` bump. No `[RELEASE]` PR. No gate enforced.

Supersedes draft PR #3142 (same fix, rebased on current `origin/main`).

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_