### PR TITLE
fix: surface daemon_error_rate_per_min on /api/system-health

### DIFF
--- a/routes/health.py
+++ b/routes/health.py
@@ -1327,6 +1327,9 @@ def api_system_health():
             "security": _d._detect_security_metadata(),
             "service_status": service_status,
             "daemon": daemon_health,
+            "daemon_error_rate_per_min": round(
+                daemon_health.get("errors_last_5min", 0) / 5.0, 2
+            ),
             "gateway": gateway_health,
             # Issue #1310 follow-up — per-provider channel ingest summary
             # so operators see whether the gateway WS tap is actually

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -471,6 +471,22 @@ class TestHeartbeatStatus:
         assert "resources" in ss
         assert ss["resources"] in ("ok", "warn", "critical")
 
+    def test_system_health_includes_daemon_error_rate_per_min(self, api, base_url):
+        """system-health returns daemon_error_rate_per_min (PRD #1133 layer 4)."""
+        d = assert_ok(get(api, base_url, "/api/system-health"))
+        assert "daemon_error_rate_per_min" in d, (
+            "system-health must include daemon_error_rate_per_min"
+        )
+        rate = d["daemon_error_rate_per_min"]
+        assert isinstance(rate, (int, float)), "daemon_error_rate_per_min must be numeric"
+        assert rate >= 0, "daemon_error_rate_per_min must be non-negative"
+        # Must equal daemon.errors_last_5min / 5 (the source window)
+        daemon = d.get("daemon", {})
+        expected = round(daemon.get("errors_last_5min", 0) / 5.0, 2)
+        assert rate == expected, (
+            f"daemon_error_rate_per_min {rate} != daemon.errors_last_5min/5 {expected}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Heartbeat Liveness Panel (#686)


### PR DESCRIPTION
## Summary

- `routes/health.py`: adds `"daemon_error_rate_per_min"` field to the `/api/system-health` response, computed as `round(daemon_health.get("errors_last_5min", 0) / 5.0, 2)` between `"daemon"` and `"gateway"`.
- `tests/test_api.py`: adds `test_system_health_includes_daemon_error_rate_per_min` -- verifies presence, numeric type, non-negativity, and the exact `errors_last_5min / 5` derivation.

Operators can now graph the per-minute error rate directly without client-side arithmetic.

Replaces #2405.

## Test plan
- [ ] `pytest tests/test_api.py -k daemon_error_rate` passes
- [ ] `/api/system-health` response includes `daemon_error_rate_per_min`
- [ ] CI green across all 3 OS x 2 Python matrix

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_