### PR TITLE
feat: surface per-sandbox inference configs on DetectResult.meta (#2796)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -151,6 +151,73 @@ def _model_router_fingerprint() -> dict:
         return {}
 
 
+def _sandbox_inference_configs() -> list:
+    """Read per-sandbox inference config from ~/.nemoclaw/sandboxes.json.
+
+    Mirrors getSandboxInferenceConfig() (nemoclaw/src/lib/inference/config.ts)
+    to surface providerKey / primaryModelRef / inferenceBaseUrl / inferenceApi /
+    inferenceCompat on DetectResult.meta (gap #2796). The identical derivation
+    lives in sync._read_nemoclaw_sandbox_routing (#2684); this helper makes it
+    available in the adapter layer without importing the heavy sync module.
+    Never raises -- returns [] on plain OpenClaw (no sandboxes.json).
+    """
+    home = os.environ.get("HOME") or os.path.expanduser("~")
+    reg = os.path.join(home, ".nemoclaw", "sandboxes.json")
+    out: list = []
+    try:
+        with open(reg, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception:
+        return out
+    if not isinstance(data, dict):
+        return out
+    default_sb = data.get("defaultSandbox")
+    sandboxes = data.get("sandboxes")
+    if not isinstance(sandboxes, dict):
+        return out
+    _MANAGED = "inference"
+    _MANAGED_URL = "https://inference.local/v1"
+    for name, entry in sandboxes.items():
+        try:
+            if not isinstance(entry, dict):
+                continue
+            provider = entry.get("provider") or ""
+            model = entry.get("model") or ""
+            api = entry.get("preferredInferenceApi") or "openai-completions"
+            base_url = _MANAGED_URL
+            if provider == "openai-api":
+                provider_key = "openai"
+                primary = f"openai/{model}" if model else ""
+                compat = "openai"
+            elif provider == "anthropic-prod" or (
+                provider == "compatible-anthropic-endpoint"
+                and api != "openai-completions"
+            ):
+                provider_key = "anthropic"
+                primary = f"anthropic/{model}" if model else ""
+                base_url = "https://inference.local"
+                api = "anthropic-messages"
+                compat = "anthropic"
+            else:
+                provider_key = _MANAGED
+                primary = f"{_MANAGED}/{model}" if model else ""
+                compat = "openai"
+            out.append({
+                "sandbox": name,
+                "isDefault": bool(default_sb and name == default_sb),
+                "provider": provider,
+                "model": model,
+                "providerKey": provider_key,
+                "primaryModelRef": primary,
+                "inferenceBaseUrl": base_url,
+                "inferenceApi": api,
+                "inferenceCompat": compat,
+            })
+        except Exception:
+            continue
+    return out
+
+
 def _discover_model_router_port() -> Optional[int]:
     """Find the ``--port`` of a running ``model-router proxy`` process.
 
@@ -419,6 +486,11 @@ class OpenClawAdapter(AgentAdapter):
             _tc_kind = _openclaw_tool_catalog_kind()
             if _tc_kind is not None:
                 meta["openclawToolCatalogKind"] = _tc_kind
+            # Per-sandbox inference config (#2796): providerKey/primaryModelRef/
+            # inferenceBaseUrl/inferenceApi/inferenceCompat from sandboxes.json.
+            _sb_configs = _sandbox_inference_configs()
+            if _sb_configs:
+                meta["sandboxInferenceConfigs"] = _sb_configs
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,

--- a/tests/test_obs_gap_talk_sandbox.py
+++ b/tests/test_obs_gap_talk_sandbox.py
@@ -9,6 +9,9 @@ Covers:
   the harness getSandboxInferenceConfig switch (compatible-anthropic-endpoint
   with the default api routes to the MANAGED 'inference' provider).
 - #2608 _model_router_fingerprint — parse git:<sha> from the fingerprint file.
+- #2796 _sandbox_inference_configs -- providerKey/primaryModelRef/inferenceBaseUrl/
+  inferenceApi/inferenceCompat surfaced on DetectResult.meta for all NemoClaw
+  sandboxes (mirrors getSandboxInferenceConfig from nemoclaw/src/lib/inference/config.ts).
 """
 import json
 import os
@@ -18,7 +21,7 @@ import types
 import pytest
 
 from clawmetry.sync import parse_talk_lifecycle_line, _read_nemoclaw_sandbox_routing
-from clawmetry.adapters.openclaw import _model_router_fingerprint
+from clawmetry.adapters.openclaw import _model_router_fingerprint, _sandbox_inference_configs
 
 
 # -- #2604 talk parser -------------------------------------------------------
@@ -603,3 +606,70 @@ def test_list_events_talk_final_false_is_surfaced():
     assert len(events) == 1
     assert events[0].extra.get("final") is False
     assert events[0].extra.get("mode") == "voice"
+
+
+# -- #2796 _sandbox_inference_configs ----------------------------------------
+
+def test_sandbox_inference_configs_empty_when_no_file(tmp_path, monkeypatch):
+    """No sandboxes.json -> empty list, no effect on plain OpenClaw installs."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert _sandbox_inference_configs() == []
+
+
+def test_sandbox_inference_configs_anthropic_prod(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": "main",
+        "sandboxes": {
+            "main": {"provider": "anthropic-prod", "model": "claude-opus-4-5"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    r = result[0]
+    assert r["providerKey"] == "anthropic"
+    assert r["primaryModelRef"] == "anthropic/claude-opus-4-5"
+    assert r["inferenceApi"] == "anthropic-messages"
+    assert r["inferenceCompat"] == "anthropic"
+    assert r["isDefault"] is True
+
+
+def test_sandbox_inference_configs_openai_api(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": None,
+        "sandboxes": {
+            "coding": {"provider": "openai-api", "model": "gpt-4o"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    r = result[0]
+    assert r["providerKey"] == "openai"
+    assert r["primaryModelRef"] == "openai/gpt-4o"
+    assert r["inferenceCompat"] == "openai"
+    assert r["isDefault"] is False
+
+
+def test_sandbox_inference_configs_managed_default(tmp_path, monkeypatch):
+    """compatible-anthropic-endpoint + default api -> MANAGED inference provider."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": "dev",
+        "sandboxes": {
+            "dev": {"provider": "compatible-anthropic-endpoint", "model": "llama3"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    r = result[0]
+    assert r["providerKey"] == "inference"
+    assert r["inferenceApi"] == "openai-completions"
+    assert r["inferenceCompat"] == "openai"
+    assert r["isDefault"] is True


### PR DESCRIPTION
## Summary

Adds `_sandbox_inference_configs()` to `clawmetry/adapters/openclaw.py`, mirroring `getSandboxInferenceConfig()` (nemoclaw/src/lib/inference/config.ts). When `~/.nemoclaw/sandboxes.json` is present, `detect()` stamps `meta["sandboxInferenceConfigs"]` with per-sandbox `providerKey`/`primaryModelRef`/`inferenceBaseUrl`/`inferenceApi`/`inferenceCompat`.

Provider mapping:
- `openai-api` -> `providerKey: "openai"`
- `anthropic-prod` / `compatible-anthropic-endpoint` + non-default api -> `providerKey: "anthropic"`
- everything else (including `compatible-anthropic-endpoint` + default api) -> `providerKey: "inference"` (MANAGED)

Adds 4 tests in `tests/test_obs_gap_talk_sandbox.py`.

Replaces #2813.

## Test plan
- [ ] `pytest tests/test_obs_gap_talk_sandbox.py -k sandbox_inference_configs -v` passes (4 tests)
- [ ] `detect()` on an install with `~/.nemoclaw/sandboxes.json` includes `sandboxInferenceConfigs` in meta
- [ ] Plain OpenClaw with no `sandboxes.json` returns empty meta (no regression)
- [ ] CI green across all 3 OS x 2 Python matrix

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_