### PR TITLE
feat: add V1_TO_V2 / V2_TO_V1 route map for v2 URL migration

### DIFF
--- a/clawmetry/v2/__init__.py
+++ b/clawmetry/v2/__init__.py
@@ -1,0 +1,5 @@
+"""ClawMetry v2 package -- React SPA + parallel-rails Flask blueprint."""
+
+from clawmetry.v2.route_map import V1_TO_V2, V2_TO_V1
+
+__all__ = ["V1_TO_V2", "V2_TO_V1"]

--- a/clawmetry/v2/route_map.py
+++ b/clawmetry/v2/route_map.py
@@ -1,0 +1,27 @@
+"""Canonical tab-name mapping between v1 and v2 URL schemes.
+
+V1_TO_V2 maps the short tab identifiers used in v1 URL fragments /
+query params to the corresponding v2 React Router path segments.
+V2_TO_V1 is the reverse.
+
+Usage::
+
+    from clawmetry.v2.route_map import V1_TO_V2, V2_TO_V1
+    v2_tab = V1_TO_V2.get(v1_tab, v1_tab)  # graceful passthrough for unmapped tabs
+    v1_tab = V2_TO_V1.get(v2_tab, v2_tab)
+"""
+
+V1_TO_V2: dict[str, str] = {
+    "flow": "trace",
+    "sessions": "brain",
+    "memory": "context",
+    "usage": "cost",
+    "crons": "ops",
+    "logs": "ops",
+}
+
+# Reverse mapping. "crons" and "logs" both map to "ops" in V1_TO_V2,
+# so V2_TO_V1["ops"] resolves to "logs" (last writer wins in dict
+# comprehension). Callers that need to distinguish should consult
+# V1_TO_V2 directly rather than relying on V2_TO_V1["ops"].
+V2_TO_V1: dict[str, str] = {v: k for k, v in V1_TO_V2.items()}


### PR DESCRIPTION
## Summary

Adds `clawmetry/v2/route_map.py` with canonical tab-name mappings between the v1 URL scheme (fragments/query-params) and v2 React Router path segments, and wires them into `clawmetry/v2/__init__.py`.

| v1 | v2 |
|---|---|
| `flow` | `trace` |
| `sessions` | `brain` |
| `memory` | `context` |
| `usage` | `cost` |
| `crons` | `ops` |
| `logs` | `ops` |

`V2_TO_V1` is the reverse dict (last-writer-wins for the `ops` collision -- callers that need to distinguish `crons`/`logs` should consult `V1_TO_V2` directly).

Replaces #2409.

## Test plan
- [ ] `python -c "from clawmetry.v2 import V1_TO_V2, V2_TO_V1; print(V1_TO_V2)"` works
- [ ] `V1_TO_V2['flow'] == 'trace'`, `V2_TO_V1['brain'] == 'sessions'`
- [ ] CI green

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_