### PR TITLE
feat: /api/version-health -- per-version session metrics + regression flag

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5985,6 +5985,77 @@ class LocalStore:
                 "events_total", "data"]
         return _decode_data_blob_rows(self._fetch(sql, params), cols)
 
+    def query_version_health(
+        self,
+        *,
+        window_days: int = 90,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Per-OpenClaw-version session metric rollup for issue #2861.
+
+        Joins ``sessions`` with ``heartbeats`` by node_id + time to assign
+        each session the OpenClaw version active when it started, then groups
+        by version and computes avg cost/tokens/messages and an error_rate
+        (fraction of sessions with outcome in failed/error/stuck).
+
+        Returns a list ordered newest-version-first so callers can trivially
+        compare versions[0] (current) against versions[1] (previous).
+        """
+        from datetime import datetime, timedelta
+        cutoff = (datetime.utcnow() - timedelta(days=window_days)).isoformat()
+        sql = """
+            WITH session_versions AS (
+                SELECT
+                    s.session_id,
+                    COALESCE(s.cost_usd, 0.0)   AS cost_usd,
+                    COALESCE(s.total_tokens, 0)  AS total_tokens,
+                    COALESCE(s.message_count, 0) AS message_count,
+                    s.outcome,
+                    s.started_at,
+                    (
+                        SELECT h.version
+                        FROM heartbeats h
+                        WHERE h.node_id = s.node_id
+                          AND h.version IS NOT NULL
+                          AND h.version != ''
+                          AND h.ts <= s.started_at
+                        ORDER BY h.ts DESC
+                        LIMIT 1
+                    ) AS version
+                FROM sessions s
+                WHERE s.started_at >= ?
+                  AND s.node_id IS NOT NULL
+            )
+            SELECT
+                version,
+                COUNT(*)                                                  AS session_count,
+                AVG(cost_usd)                                             AS avg_cost_usd,
+                AVG(CAST(total_tokens AS DOUBLE))                         AS avg_tokens,
+                AVG(CAST(message_count AS DOUBLE))                        AS avg_messages,
+                AVG(CASE WHEN outcome IN ('failed', 'error', 'stuck')
+                         THEN 1.0 ELSE 0.0 END)                          AS error_rate,
+                MIN(started_at)                                           AS first_seen,
+                MAX(started_at)                                           AS last_seen
+            FROM session_versions
+            WHERE version IS NOT NULL
+            GROUP BY version
+            ORDER BY MAX(started_at) DESC
+            LIMIT ?
+        """
+        rows = self._fetch(sql, [cutoff, int(limit)])
+        cols = ["version", "session_count", "avg_cost_usd", "avg_tokens",
+                "avg_messages", "error_rate", "first_seen", "last_seen"]
+        result = []
+        for row in rows:
+            d = dict(zip(cols, row))
+            d["session_count"] = int(d["session_count"] or 0)
+            d["avg_cost_usd"] = round(float(d["avg_cost_usd"] or 0), 6)
+            d["avg_tokens"] = round(float(d["avg_tokens"] or 0), 1)
+            d["avg_messages"] = round(float(d["avg_messages"] or 0), 1)
+            d["error_rate"] = round(float(d["error_rate"] or 0), 4)
+            result.append(d)
+        return result
+
     def query_channels(
         self,
         *,

--- a/routes/health.py
+++ b/routes/health.py
@@ -34,6 +34,8 @@ Module-level helpers (``_history_db``, ``AgentReliabilityScorer``,
 ``import dashboard as _d``. Pure mechanical move — zero behaviour change.
 """
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os
@@ -3318,3 +3320,138 @@ def api_handler_latency():
     stats = latency_tracker.get_stats(top_n=top_n, slow_threshold_ms=slow_ms)
     stats["_source"] = "in_memory"
     return jsonify(stats)
+
+
+# ---------------------------------------------------------------------------
+# Issue #2861 -- version-aware health regression detection
+# ---------------------------------------------------------------------------
+
+_REGRESSION_THRESHOLD_PCT = 30.0
+_REGRESSION_MIN_SESSIONS = 3
+
+
+def _compute_version_regression(versions: list[dict]) -> dict:
+    """Flag degradation between the two most-recent OpenClaw versions.
+
+    Compares versions[0] (current) with versions[1] (previous) on cost,
+    error_rate, and avg_tokens.  Emits a banner string when any metric
+    worsens by more than _REGRESSION_THRESHOLD_PCT percent, provided both
+    versions have at least _REGRESSION_MIN_SESSIONS sessions so sparse
+    data doesn't trigger false positives.
+    """
+    regression: dict = {"detected": False}
+    if len(versions) >= 2:
+        current = versions[0]
+        baseline = versions[1]
+        if (current["session_count"] >= _REGRESSION_MIN_SESSIONS
+                and baseline["session_count"] >= _REGRESSION_MIN_SESSIONS):
+            for metric, label in [
+                ("avg_cost_usd", "Cost"),
+                ("error_rate", "Error rate"),
+                ("avg_tokens", "Token usage"),
+            ]:
+                base_val = float(baseline.get(metric) or 0)
+                curr_val = float(current.get(metric) or 0)
+                if base_val > 0:
+                    change_pct = (curr_val - base_val) / base_val * 100.0
+                    if change_pct > _REGRESSION_THRESHOLD_PCT:
+                        try:
+                            from datetime import datetime as _dt
+                            ago_days = (
+                                _dt.utcnow()
+                                - _dt.fromisoformat(
+                                    (current.get("first_seen") or "")[:10]
+                                )
+                            ).days
+                            ago_str = (
+                                f" -- {ago_days} day{'s' if ago_days != 1 else ''} ago"
+                            )
+                        except Exception:
+                            ago_str = ""
+                        regression = {
+                            "detected": True,
+                            "current_version": current["version"],
+                            "baseline_version": baseline["version"],
+                            "metric": label.lower(),
+                            "change_pct": round(change_pct, 1),
+                            "banner": (
+                                f"{label} +{round(change_pct)}% since upgrade to "
+                                f"{current['version']}{ago_str}"
+                            ),
+                        }
+                        break
+    return regression
+
+
+def _try_local_store_version_health(window_days: int) -> dict | None:
+    """Daemon-proxy first, then direct read-only store fallback."""
+    try:
+        from routes.local_query import local_store_via_daemon
+        rows = local_store_via_daemon("query_version_health", window_days=window_days)
+        if rows is not None:
+            return {
+                "versions": rows,
+                "regression": _compute_version_regression(rows),
+                "_source": "duckdb",
+            }
+    except Exception:
+        pass
+    try:
+        from clawmetry import local_store
+        store = local_store.get_store(read_only=True)
+        rows = store.query_version_health(window_days=window_days)
+        return {
+            "versions": rows,
+            "regression": _compute_version_regression(rows),
+            "_source": "duckdb",
+        }
+    except Exception:
+        return None
+
+
+@bp_health.route("/api/version-health")
+def api_version_health():
+    """Per-OpenClaw-version session metric rollup with regression flags.
+
+    Joins sessions with heartbeats to assign each session the OpenClaw
+    version active at session start, then groups by version and checks
+    whether the current version shows >30% degradation vs the previous on
+    cost / error-rate / token usage.
+
+    Query params (all optional):
+      window_days  -- lookback window in days (default 90, clamp 7..365)
+
+    Response shape:
+      {
+        "versions": [
+          { "version": str, "session_count": int,
+            "avg_cost_usd": float, "avg_tokens": float,
+            "avg_messages": float, "error_rate": float,
+            "first_seen": str, "last_seen": str }
+        ],
+        "regression": {
+          "detected": bool,
+          "current_version": str,   # only when detected=true
+          "baseline_version": str,
+          "metric": str,
+          "change_pct": float,
+          "banner": str
+        },
+        "_source": "duckdb" | "unavailable"
+      }
+    """
+    try:
+        window_days = max(7, min(365, int(request.args.get("window_days", 90))))
+    except (TypeError, ValueError):
+        window_days = 90
+
+    if is_local_store_read_enabled():
+        fast = _try_local_store_version_health(window_days)
+        if fast is not None:
+            return jsonify(fast)
+
+    return jsonify({
+        "versions": [],
+        "regression": {"detected": False},
+        "_source": "unavailable",
+    })

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -721,6 +721,10 @@ _DAEMON_METHODS = frozenset({
     # routes/usage.py:/api/efficiency through the daemon proxy (read-only;
     # the daemon owns the writer lock).
     "query_efficiency_rollup",
+    # Issue #2861 -- version-aware health regression. Read-only join of
+    # sessions + heartbeats; routed through the daemon proxy so the
+    # dashboard process never opens DuckDB writable.
+    "query_version_health",
 })
 
 

--- a/tests/test_version_health_local_store.py
+++ b/tests/test_version_health_local_store.py
@@ -1,0 +1,256 @@
+"""Tests for issue #2861 -- version-aware health regression detection.
+
+Verifies that:
+  1. query_version_health() groups sessions by the OpenClaw version active at
+     session start (correlated via heartbeats.ts <= sessions.started_at).
+  2. The /api/version-health endpoint returns the correct per-version averages.
+  3. _compute_version_regression() flags a regression when the current version
+     shows >30% degradation vs the previous on cost/error-rate/tokens.
+  4. No regression is flagged when either version has fewer than 3 sessions or
+     when metrics improve.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _iso(ts: str) -> str:
+    """Return an ISO-8601 timestamp string."""
+    return ts
+
+
+def _seed_store(store, *, node_id: str = "node-1"):
+    """Seed two OpenClaw versions with known sessions.
+
+    v_old (2026.1.1): 3 sessions, avg_cost=0.10, no failures.
+    v_new (2026.2.1): 3 sessions, avg_cost=0.25, 1 failure -> cost +150%, error_rate ~33%.
+
+    Note: ingest_session() does not write the ``outcome`` column (that's the
+    classifier's job). We set it via a direct SQL UPDATE after ingestion so
+    query_version_health() sees the expected error_rate.
+    """
+    # Heartbeats: v_old from 2026-01-01, v_new from 2026-02-01
+    store.ingest_heartbeat({
+        "node_id": node_id,
+        "ts": "2026-01-01T00:00:00",
+        "version": "2026.1.1",
+    })
+    store.ingest_heartbeat({
+        "node_id": node_id,
+        "ts": "2026-02-01T00:00:00",
+        "version": "2026.2.1",
+    })
+
+    # Sessions under v_old
+    for i in range(3):
+        store.ingest_session({
+            "session_id": f"old-{i}",
+            "node_id": node_id,
+            "started_at": f"2026-01-{10 + i:02d}T12:00:00",
+            "last_active_at": f"2026-01-{10 + i:02d}T12:30:00",
+            "cost_usd": 0.10,
+            "total_tokens": 1000,
+            "message_count": 5,
+            "status": "completed",
+        })
+
+    # Sessions under v_new (cost doubled; one failure)
+    for i in range(3):
+        store.ingest_session({
+            "session_id": f"new-{i}",
+            "node_id": node_id,
+            "started_at": f"2026-02-{10 + i:02d}T12:00:00",
+            "last_active_at": f"2026-02-{10 + i:02d}T12:30:00",
+            "cost_usd": 0.25,
+            "total_tokens": 2500,
+            "message_count": 8,
+            "status": "completed",
+        })
+
+    # Set outcomes directly -- ingest_session() delegates that to the classifier
+    with store._write_lock:
+        store._conn.execute(
+            "UPDATE sessions SET outcome='success' WHERE session_id LIKE 'old-%'"
+        )
+        store._conn.execute(
+            "UPDATE sessions SET outcome='success' WHERE session_id IN ('new-1','new-2')"
+        )
+        store._conn.execute(
+            "UPDATE sessions SET outcome='failed' WHERE session_id='new-0'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def store_and_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "events.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as rh
+    importlib.reload(rh)
+
+    store = ls.get_store()
+    _seed_store(store)
+
+    app = Flask(__name__)
+    app.register_blueprint(rh.bp_health)
+    yield store, app
+    try:
+        store.stop(flush=True)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Unit tests on query_version_health()
+# ---------------------------------------------------------------------------
+
+def test_query_version_health_returns_two_versions(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_version_health(window_days=365)
+    assert len(rows) == 2, f"expected 2 versions, got {len(rows)}: {rows}"
+
+
+def test_query_version_health_newest_first(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_version_health(window_days=365)
+    assert rows[0]["version"] == "2026.2.1"
+    assert rows[1]["version"] == "2026.1.1"
+
+
+def test_query_version_health_session_counts(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_version_health(window_days=365)
+    by_version = {r["version"]: r for r in rows}
+    assert by_version["2026.1.1"]["session_count"] == 3
+    assert by_version["2026.2.1"]["session_count"] == 3
+
+
+def test_query_version_health_avg_cost(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_version_health(window_days=365)
+    by_version = {r["version"]: r for r in rows}
+    assert abs(by_version["2026.1.1"]["avg_cost_usd"] - 0.10) < 0.001
+    assert abs(by_version["2026.2.1"]["avg_cost_usd"] - 0.25) < 0.001
+
+
+def test_query_version_health_error_rate(store_and_app):
+    store, _ = store_and_app
+    rows = store.query_version_health(window_days=365)
+    by_version = {r["version"]: r for r in rows}
+    assert by_version["2026.1.1"]["error_rate"] == 0.0
+    # 1 failure out of 3 sessions -> ~0.333
+    assert abs(by_version["2026.2.1"]["error_rate"] - 1 / 3) < 0.01
+
+
+def test_query_version_health_empty_when_no_heartbeats(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "e2.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    store = ls.get_store()
+    try:
+        # Sessions with no heartbeats -> no version assignment
+        store.ingest_session({
+            "session_id": "orphan-1",
+            "node_id": "node-x",
+            "started_at": "2026-03-01T10:00:00",
+        })
+        rows = store.query_version_health(window_days=365)
+        assert rows == []
+    finally:
+        try:
+            store.stop(flush=True)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Integration test: /api/version-health endpoint
+# ---------------------------------------------------------------------------
+
+def test_api_version_health_endpoint(store_and_app):
+    _, app = store_and_app
+    c = app.test_client()
+    r = c.get("/api/version-health?window_days=365")
+    assert r.status_code == 200, r.get_data(as_text=True)[:300]
+    body = r.get_json()
+
+    assert "_source" in body
+    assert "versions" in body
+    assert "regression" in body
+    assert isinstance(body["versions"], list)
+    assert len(body["versions"]) == 2
+
+
+def test_api_version_health_regression_detected(store_and_app):
+    """Cost increased 150% -> regression.detected should be True."""
+    _, app = store_and_app
+    c = app.test_client()
+    r = c.get("/api/version-health?window_days=365")
+    body = r.get_json()
+    reg = body["regression"]
+    assert reg["detected"] is True, f"expected regression, got: {reg}"
+    assert reg["current_version"] == "2026.2.1"
+    assert reg["baseline_version"] == "2026.1.1"
+    assert reg["change_pct"] > 30
+
+
+def test_api_version_health_no_regression_when_improved(tmp_path, monkeypatch):
+    """Sessions that cost less on the new version -> no regression."""
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_PATH", str(tmp_path / "e3.duckdb"))
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_SECS", "0.05")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_FLUSH_BATCH", "5")
+    monkeypatch.setenv("CLAWMETRY_LOCAL_STORE_READ", "1")
+
+    import clawmetry.local_store as ls
+    importlib.reload(ls)
+    import routes.health as rh
+    importlib.reload(rh)
+
+    store = ls.get_store()
+    try:
+        store.ingest_heartbeat({"node_id": "n1", "ts": "2026-01-01T00:00:00", "version": "2026.1.0"})
+        store.ingest_heartbeat({"node_id": "n1", "ts": "2026-02-01T00:00:00", "version": "2026.2.0"})
+        for i in range(3):
+            store.ingest_session({
+                "session_id": f"o{i}", "node_id": "n1",
+                "started_at": f"2026-01-{10+i:02d}T12:00:00", "cost_usd": 0.20,
+                "outcome": "success",
+            })
+        for i in range(3):
+            store.ingest_session({
+                "session_id": f"n{i}", "node_id": "n1",
+                "started_at": f"2026-02-{10+i:02d}T12:00:00", "cost_usd": 0.10,
+                "outcome": "success",
+            })
+
+        app = Flask(__name__)
+        app.register_blueprint(rh.bp_health)
+        c = app.test_client()
+        r = c.get("/api/version-health?window_days=365")
+        body = r.get_json()
+        assert body["regression"]["detected"] is False
+    finally:
+        try:
+            store.stop(flush=True)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

Adds version-aware health regression detection (issue #2861):

- `clawmetry/local_store.py`: `query_version_health()` -- correlated subquery joins sessions with heartbeats to assign each session the OpenClaw version active at `started_at`, then groups by version returning `session_count`, `avg_cost_usd`, `avg_tokens`, `avg_messages`, `error_rate`, `first_seen`, `last_seen` (newest-version-first).

- `routes/local_query.py`: adds `"query_version_health"` to the daemon proxy allowlist so the dashboard reads through the daemon without grabbing the DuckDB writer lock.

- `routes/health.py`: adds `_compute_version_regression()` (flags >30% degradation on cost/error_rate/tokens between current and previous version) and `GET /api/version-health`. Also adds `from __future__ import annotations` to support `dict | None` annotation on Python 3.9.

- `tests/test_version_health_local_store.py`: 9 tests covering version grouping, newest-first ordering, session counts, avg cost, error rate, empty-without-heartbeats, endpoint shape, regression detection, and no-regression-when-improved.

Replaces #2927.

## Test plan
- [ ] `pytest tests/test_version_health_local_store.py -v` passes (9 tests)
- [ ] `GET /api/version-health` returns `{versions: [...], regression: {...}, _source: "duckdb"}`
- [ ] Regression detected when cost increases >30% vs previous version
- [ ] CI green across all 3 OS x 2 Python matrix

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_