### PR TITLE
feat: add _required_tier() to _gate.py; include required_tier in 402 body

### DIFF
--- a/clawmetry/_gate.py
+++ b/clawmetry/_gate.py
@@ -21,12 +21,39 @@ Example::
 
 The error shape matches what ``routes/audit.py`` and ``routes/otel_export.py``
 have been returning by hand for months, so existing front-ends that already
-handle 402 continue to work.
+handle 402 continue to work. ``required_tier`` is included so the UI can
+route users to the *correct* upgrade CTA (Starter vs Pro vs Enterprise)
+instead of a generic one.
 """
 from __future__ import annotations
 
 from functools import wraps
 from typing import Callable
+
+
+def _required_tier(feature_key: str) -> str | None:
+    """Minimum tier identifier that unlocks ``feature_key``.
+
+    Returns a tier id from :mod:`clawmetry.entitlements` (e.g.
+    ``"cloud_starter"``, ``"cloud_pro"``, ``"enterprise"``) or ``None`` for
+    free features and unknown keys. Used to enrich the 402 body so the UI
+    can render the right upgrade CTA without re-deriving tier logic in JS.
+    Never raises: any lookup error returns ``None``.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        if feature_key in _ent.FREE_FEATURES:
+            return None
+        if feature_key in _ent.STARTER_FEATURES:
+            return _ent.TIER_CLOUD_STARTER
+        if feature_key in _ent.PRO_ONLY_FEATURES:
+            return _ent.TIER_CLOUD_PRO
+        if feature_key in _ent.ENTERPRISE_FEATURES:
+            return _ent.TIER_ENTERPRISE
+    except Exception:
+        return None
+    return None
 
 
 def gate(feature_key: str) -> Callable:
@@ -47,6 +74,7 @@ def gate(feature_key: str) -> Callable:
                         "error": "upgrade_required",
                         "feature": feature_key,
                         "tier": en.tier,
+                        "required_tier": _required_tier(feature_key),
                         "hint": (
                             "This is a paid feature on clawmetry.com/pricing. "
                             "Upgrade or set CLAWMETRY_ENFORCE=0 to disable enforcement."

--- a/tests/test_route_gates.py
+++ b/tests/test_route_gates.py
@@ -58,6 +58,76 @@ def test_gate_decorator_blocks_in_enforce_mode(enforce):
         assert body["feature"] == "self_evolve"
         assert "tier" in body
         assert "hint" in body
+        # required_tier lets the UI route to the right upgrade CTA.
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
+
+
+# ── required_tier mapping ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "feature_key,expected_tier_attr",
+    [
+        ("multi_runtime", "TIER_CLOUD_STARTER"),       # Starter feature
+        ("budget_limits", "TIER_CLOUD_STARTER"),       # Starter feature
+        ("self_evolve", "TIER_CLOUD_PRO"),             # Pro-only feature
+        ("otel_export", "TIER_CLOUD_PRO"),             # Pro-only (moved off Enterprise)
+        ("siem_export", "TIER_ENTERPRISE"),            # Enterprise-only feature
+        ("sso", "TIER_ENTERPRISE"),                    # Enterprise-only feature
+    ],
+)
+def test_gate_required_tier_routes_to_correct_upgrade(
+    enforce, feature_key, expected_tier_attr
+):
+    """The 402 response carries ``required_tier`` so the UI can render the
+    right upgrade CTA (Starter vs Pro vs Enterprise) without re-deriving
+    tier logic in JavaScript."""
+    from clawmetry._gate import gate
+
+    app = Flask(__name__)
+
+    @app.route("/test")
+    @gate(feature_key)
+    def view():
+        return {"ok": True}
+
+    with app.test_client() as c:
+        r = c.get("/test")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["required_tier"] == getattr(enforce, expected_tier_attr)
+
+
+def test_gate_required_tier_is_none_for_free_feature(enforce):
+    """Free features never produce a 402, but if a caller asks the helper
+    directly for one it returns None (no upgrade required)."""
+    from clawmetry._gate import _required_tier
+
+    assert _required_tier("sessions") is None
+    assert _required_tier("usage") is None
+
+
+def test_gate_required_tier_is_none_for_unknown_feature(enforce):
+    """Unknown / typo'd feature keys resolve to ``None`` rather than raising.
+    Keeps the 402 path graceful when a route uses a key not yet in the
+    catalogue (e.g. a clawmetry-pro plugin's private feature)."""
+    from clawmetry._gate import _required_tier
+
+    assert _required_tier("totally_unknown_feature_xyz") is None
+
+
+def test_gate_required_tier_swallows_entitlement_lookup_errors(monkeypatch):
+    """If a catalogue read itself raises the helper returns ``None`` rather
+    than propagating — the 402 body still serializes and the request path
+    stays defensive."""
+    from clawmetry import _gate
+
+    class _Boom:
+        def __contains__(self, _key):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.FREE_FEATURES", _Boom())
+    assert _gate._required_tier("self_evolve") is None
 
 
 def test_gate_decorator_passes_in_grace_mode(grace):


### PR DESCRIPTION
## Summary

Enriches the `upgrade_required` 402 response with the minimum tier that unlocks the gated feature, so the UI can route to the correct upgrade CTA without re-deriving tier logic in JavaScript.

**`clawmetry/_gate.py`:**
- Adds `_required_tier(feature_key)` helper -- looks up `FREE_FEATURES`, `STARTER_FEATURES`, `PRO_ONLY_FEATURES`, `ENTERPRISE_FEATURES` from `clawmetry.entitlements` and returns the tier id (`"cloud_starter"`, `"cloud_pro"`, `"enterprise"`) or `None` for free/unknown keys. Never raises.
- Adds `"required_tier": _required_tier(feature_key)` to the 402 JSON body in `gate()`.
- Updates module docstring: notes that `required_tier` is now included so the UI can route to the correct upgrade CTA.

**`tests/test_route_gates.py`:**
- New assertion in `test_gate_blocks_self_evolve_when_enforced`: verifies `body["required_tier"] == TIER_CLOUD_PRO`
- 4 new parametrized tests: `_required_tier` maps 6 feature keys to the correct tier, returns `None` for free/unknown features, swallows entitlement-catalogue read errors.

Replaces #2674.

**Sequencing:** merge this before or after `feat/gate-require-runtime` (runtime gating) -- they touch different parts of `_gate.py` and will need a one-line docstring reconciliation at merge time.

## Test plan
- [ ] `pytest tests/test_route_gates.py -v` passes (all tests including 4 new ones)
- [ ] Enforce mode 402 body includes `"required_tier"` field
- [ ] `_required_tier("sso") == "enterprise"`, `_required_tier("sessions") is None`
- [ ] CI green across all 3 OS x 2 Python matrix

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_