### PR TITLE
feat: log dive_run telemetry to DuckDB events table (DIVES-6)

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -9962,6 +9962,45 @@ class LocalStore:
                 ev.get("model") or "",
             ])
 
+    def ingest_dive_run(
+        self,
+        *,
+        question: str = "",
+        sql: str = "",
+        chart_type: str = "",
+        row_count: int = 0,
+        latency_ms: int = 0,
+        had_error: bool = False,
+    ) -> None:
+        """Log one Dives query execution for prompt improvement (issue #999, DIVES-6).
+
+        Writes to the events table with event_type='dive_run'. The run_id is
+        derived from the question + sql + current time, making re-delivery of
+        the same RPC call within a sub-second window a safe no-op.
+        """
+        import hashlib as _hashlib
+        import json as _json
+        import time as _time
+        ts = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        run_id = "dive_" + _hashlib.sha256(
+            f"{question[:100]}{sql[:100]}{_time.time()}".encode()
+        ).hexdigest()[:24]
+        data = _json.dumps({
+            "question":   question[:200],
+            "sql":        sql[:500],
+            "chart_type": chart_type,
+            "row_count":  row_count,
+            "latency_ms": latency_ms,
+            "had_error":  had_error,
+        }).encode()
+        with self._write_lock:
+            self._conn.execute("""
+                INSERT INTO events
+                    (id, agent_type, node_id, agent_id, event_type, ts, data, created_at)
+                VALUES (?, 'clawmetry', 'local', 'dives', 'dive_run', ?, ?, ?)
+                ON CONFLICT (id) DO NOTHING
+            """, [run_id, ts, data, int(_time.time())])
+
     def query_external_calls(
         self,
         *,

--- a/routes/dives.py
+++ b/routes/dives.py
@@ -268,6 +268,20 @@ def api_dives_query():
     rows, sql_error = _execute(sql, store)
     ms = int((time.monotonic() - t0) * 1000)
 
+    try:
+        from routes.local_query import local_store_via_daemon
+        local_store_via_daemon(
+            "ingest_dive_run",
+            question=question,
+            sql=sql,
+            chart_type=spec.get("chart_type", ""),
+            row_count=len(rows),
+            latency_ms=ms,
+            had_error=bool(sql_error),
+        )
+    except Exception:
+        pass
+
     chart_spec = {
         "chart_type":  spec.get("chart_type", "table"),
         "x":           spec.get("x"),

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -716,6 +716,10 @@ _DAEMON_METHODS = frozenset({
     "query_rollup_model_daily",
     "query_rollup_runtime_daily",
     "query_rollup_sessions",
+    # Issue #999 DIVES-6: log Dives query telemetry via the daemon's writer
+    # connection so the dashboard process can fire-and-forget without opening
+    # DuckDB writable itself.
+    "ingest_dive_run",
     # Efficiency grade + measured savings (feat/efficiency-grade): trailing-
     # window per-(runtime, model) aggregate over rollup_model_daily, read by
     # routes/usage.py:/api/efficiency through the daemon proxy (read-only;

--- a/tests/test_dives_telemetry.py
+++ b/tests/test_dives_telemetry.py
@@ -1,0 +1,125 @@
+"""Tests for DIVES-6: ingest_dive_run stores dive_run events in DuckDB (issue #999)."""
+import json
+import threading
+import tempfile
+import pathlib
+import unittest
+
+
+def _make_store():
+    """Create a minimal in-memory-ish LocalStore with only the events table."""
+    from clawmetry.local_store import LocalStore
+    import duckdb
+    tmp = pathlib.Path(tempfile.mkdtemp()) / "test_dives.duckdb"
+    store = LocalStore.__new__(LocalStore)
+    store._conn = duckdb.connect(str(tmp))
+    store._write_lock = threading.Lock()
+    store._path = tmp
+    store._conn.execute("""
+        CREATE TABLE IF NOT EXISTS events (
+            id              VARCHAR PRIMARY KEY,
+            agent_type      VARCHAR NOT NULL DEFAULT 'openclaw',
+            node_id         VARCHAR NOT NULL,
+            agent_id        VARCHAR NOT NULL DEFAULT 'main',
+            session_id      VARCHAR,
+            workspace_id    VARCHAR,
+            event_type      VARCHAR NOT NULL,
+            ts              VARCHAR NOT NULL,
+            data            BLOB,
+            cost_usd        DOUBLE,
+            token_count     INTEGER,
+            model           VARCHAR,
+            created_at      BIGINT NOT NULL,
+            chain_prev_hash VARCHAR,
+            chain_hash      VARCHAR
+        )
+    """)
+    return store
+
+
+def _fetch_dive_runs(store):
+    rows = store._conn.execute(
+        "SELECT event_type, agent_type, node_id, agent_id, data "
+        "FROM events WHERE event_type = 'dive_run'"
+    ).fetchall()
+    return [
+        {
+            "event_type": r[0],
+            "agent_type": r[1],
+            "node_id":    r[2],
+            "agent_id":   r[3],
+            "data":       json.loads(r[4]),
+        }
+        for r in rows
+    ]
+
+
+class TestIngestDiveRun(unittest.TestCase):
+    def test_basic_row_written(self):
+        store = _make_store()
+        store.ingest_dive_run(
+            question="How much did sessions cost today?",
+            sql="SELECT SUM(cost_usd) FROM sessions",
+            chart_type="bar",
+            row_count=3,
+            latency_ms=412,
+            had_error=False,
+        )
+        runs = _fetch_dive_runs(store)
+        self.assertEqual(len(runs), 1)
+        r = runs[0]
+        self.assertEqual(r["event_type"], "dive_run")
+        self.assertEqual(r["agent_type"], "clawmetry")
+        self.assertEqual(r["node_id"], "local")
+        self.assertEqual(r["agent_id"], "dives")
+        self.assertEqual(r["data"]["question"], "How much did sessions cost today?")
+        self.assertEqual(r["data"]["sql"], "SELECT SUM(cost_usd) FROM sessions")
+        self.assertEqual(r["data"]["chart_type"], "bar")
+        self.assertEqual(r["data"]["row_count"], 3)
+        self.assertEqual(r["data"]["latency_ms"], 412)
+        self.assertFalse(r["data"]["had_error"])
+
+    def test_error_run_flagged(self):
+        store = _make_store()
+        store.ingest_dive_run(
+            question="oops",
+            sql="not valid sql",
+            had_error=True,
+        )
+        runs = _fetch_dive_runs(store)
+        self.assertEqual(len(runs), 1)
+        self.assertTrue(runs[0]["data"]["had_error"])
+
+    def test_long_inputs_truncated(self):
+        store = _make_store()
+        store.ingest_dive_run(
+            question="q" * 300,
+            sql="s" * 600,
+        )
+        runs = _fetch_dive_runs(store)
+        self.assertEqual(len(runs), 1)
+        data = runs[0]["data"]
+        self.assertLessEqual(len(data["question"]), 200)
+        self.assertLessEqual(len(data["sql"]), 500)
+
+    def test_defaults_are_safe(self):
+        store = _make_store()
+        store.ingest_dive_run()
+        runs = _fetch_dive_runs(store)
+        self.assertEqual(len(runs), 1)
+        data = runs[0]["data"]
+        self.assertEqual(data["question"], "")
+        self.assertEqual(data["sql"], "")
+        self.assertEqual(data["row_count"], 0)
+        self.assertFalse(data["had_error"])
+
+    def test_multiple_runs_all_logged(self):
+        store = _make_store()
+        for i in range(3):
+            store.ingest_dive_run(question=f"q{i}", latency_ms=i * 10)
+        runs = _fetch_dive_runs(store)
+        self.assertEqual(len(runs), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Every Dives query execution now logs a `dive_run` event to the local DuckDB `events` table, closing DIVES-6. This gives operators the raw material to analyse which questions users ask, how often the LLM-generated SQL errors, and where latency is worst -- enabling prompt iteration.

## Changes

- **`clawmetry/local_store.py`** -- New `ingest_dive_run()` method. Writes to the `events` table with `event_type='dive_run'`; stores `{question, sql, chart_type, row_count, latency_ms, had_error}` in the `data` blob. Uses `ON CONFLICT DO NOTHING` so re-delivery is safe. Follows the `ingest_guardrail_event` pattern.
- **`routes/local_query.py`** -- `"ingest_dive_run"` added to `_DAEMON_METHODS` so the dashboard process calls it via the daemon proxy without contending for the DuckDB writer lock.
- **`routes/dives.py`** -- `api_dives_query()` fires `local_store_via_daemon("ingest_dive_run", ...)` after each query completes. Wrapped in `try/except` so telemetry never fails the user-facing response.
- **`tests/test_dives_telemetry.py`** -- 5 new tests covering the basic write, truncation of long inputs, error-run flagging, safe defaults, and multiple-run accumulation.

## Test plan

- [ ] `python3 -m pytest tests/test_dives_telemetry.py -v` -- 5/5 pass
- [ ] Syntax check: `python3 -m py_compile clawmetry/local_store.py routes/local_query.py routes/dives.py tests/test_dives_telemetry.py`
- [ ] `python3 scripts/lint_daemon_allowlist.py` -- `ingest_dive_run` registered

Supersedes #2423 (stale base, dirty).

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_