### PR TITLE
feat(entitlements): add TIER_LABELS, tier_label(), tier_catalog(), and GET /api/tiers

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -111,6 +111,34 @@ RUNTIME_LABELS = {
     "nanoclaw": "NanoClaw",
 }
 
+# Display labels for every tier identifier. Mirrors the runtime/feature label
+# pattern so the dashboard never has to hardcode a tier display name -- the
+# upgrade-ladder UI reads :func:`tier_catalog` and trusts these. Falls back to
+# the tier id when a label is missing so an unknown tier still renders with
+# *something*. Plain tier names only -- no pricing strings live in this file.
+TIER_LABELS = {
+    TIER_OSS: "OSS",
+    TIER_CLOUD_FREE: "Free",
+    TIER_TRIAL: "Trial",
+    TIER_CLOUD_STARTER: "Starter",
+    TIER_CLOUD_PRO: "Pro",
+    TIER_PRO: "Pro (Self-hosted)",
+    TIER_ENTERPRISE: "Enterprise",
+}
+
+# Stable display order for the upgrade ladder: cheapest to most capable. The
+# self-hosted Pro tier sits next to cloud Pro because it grants the same paid
+# feature set. The UI iterates :func:`tier_catalog` in this order.
+_TIER_ORDER = (
+    TIER_OSS,
+    TIER_CLOUD_FREE,
+    TIER_TRIAL,
+    TIER_CLOUD_STARTER,
+    TIER_CLOUD_PRO,
+    TIER_PRO,
+    TIER_ENTERPRISE,
+)
+
 # Common alternative spellings that callers (custom ingest, OTLP service.name,
 # CLI flags) sometimes use. Mapped to the canonical snake_case identifier so the
 # gate and the labels lookup don't reject a runtime over a stray hyphen. The
@@ -1162,6 +1190,67 @@ def runtime_catalog() -> list[dict]:
                 # teaser/upgrade affordance in grace mode without changing
                 # what `allowed`/`locked` mean for enforcement.
                 "entitled": ent.entitled_runtime(rt),
+            }
+        )
+    return out
+
+
+def tier_label(tier: str) -> str:
+    """Human-readable label for ``tier``. Falls back to the id when unknown so
+    an unrecognised tier (e.g. a future plan code) still renders with
+    *something*."""
+    t = (tier or "").strip().lower()
+    return TIER_LABELS.get(t, t)
+
+
+def tier_catalog() -> list[dict]:
+    """The full tier ladder with the per-tier feature/runtime/retention
+    metadata the dashboard needs to render an upgrade affordance.
+
+    Mirrors :func:`runtime_catalog` (and the in-flight ``feature_catalog``) so
+    every catalogue the UI consumes has the same shape and ordering contract.
+    Returned in :data:`_TIER_ORDER` (cheapest to most capable) so the upgrade
+    ladder is deterministic across reloads.
+
+    Each entry::
+
+        {
+          "id":               "<tier>",        # canonical key (TIER_*)
+          "label":            "<Display>",     # falls back to id
+          "is_paid":          True | False,    # is in _PAID_TIERS
+          "is_current":       True | False,    # matches the resolved tier
+          "rank":             0..n,            # position in the ladder
+          "unlocks_paid_runtimes": True|False, # tier grants paid runtimes
+          "retention_days":   int | None,      # event retention cap (None = unlimited)
+          "features":         [...],           # paid feature keys this tier grants
+                                               # (free features are always included
+                                               # on top -- they're not listed here so
+                                               # the upgrade copy stays scoped to the
+                                               # paid delta)
+        }
+
+    Never raises; on any resolution error the ``is_current`` flag falls back to
+    the OSS tier so the UI still has a safe row highlighted.
+    """
+    try:
+        ent = get_entitlement()
+        current = ent.tier
+    except Exception as exc:  # never crash a catalog read
+        logger.warning("entitlements: tier_catalog falling back to OSS-free: %s", exc)
+        current = TIER_OSS
+    out: list[dict] = []
+    for rank, tier in enumerate(_TIER_ORDER):
+        paid_feats = _TIER_FEATURES.get(tier, frozenset())
+        out.append(
+            {
+                "id": tier,
+                "label": tier_label(tier),
+                "is_paid": tier in _PAID_TIERS,
+                "is_current": tier == current,
+                "rank": rank,
+                "unlocks_paid_runtimes": tier in _TIER_PAID_RUNTIMES,
+                "retention_days": _TIER_RETENTION_DAYS.get(tier, 7),
+                "features": sorted(paid_feats),
             }
         )
     return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -23,6 +23,7 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          would add on top of the current ent.
   GET  /api/runtimes                  -- the full runtime catalog with
                                          locked/free/tier flags.
+  GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
 
 Side-effect-free and never-raise (refresh's only side effect is busting the
 in-process cache), so it is safe to classify ``oss-passthrough`` on the cloud
@@ -277,6 +278,54 @@ def api_runtimes():
                         "locked": False,
                     },
                 ],
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/tiers")
+def api_tiers():
+    """Return the full tier ladder with per-tier metadata so the dashboard can
+    render an upgrade affordance without re-deriving tier identifiers in
+    JavaScript.
+
+    Shape::
+
+        {
+          "tiers": [
+            {"id": "oss", "label": "OSS", "is_paid": false,
+             "is_current": true, "rank": 0,
+             "unlocks_paid_runtimes": false,
+             "retention_days": 7, "features": []},
+            ...
+          ],
+          "current":  "oss",
+          "grace":    true | false,   # mirrors /api/entitlement.grace
+          "enforced": true | false
+        }
+
+    Side-effect-free and never-raise: any resolution error falls back to a
+    grace OSS-free shape so the UI still has something safe to render.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": _ent.tier_catalog(),
+                "current": ent.tier,
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_tiers: falling back to OSS-free: %s", exc)
+        return jsonify(
+            {
+                "tiers": [],
+                "current": "oss",
                 "grace": True,
                 "enforced": False,
             }

--- a/tests/test_tier_catalog.py
+++ b/tests/test_tier_catalog.py
@@ -1,0 +1,222 @@
+"""Tests for the tier catalogue helpers in clawmetry/entitlements.py.
+
+Pins:
+
+* :data:`TIER_LABELS` covers every tier id ``Entitlement.tier`` can take.
+* :func:`tier_label` returns the label for known ids and the raw id for unknown
+  ones (never-crash contract).
+* :func:`tier_catalog` returns one row per tier in the published ladder order,
+  marks exactly one row ``is_current``, never raises, and is internally
+  consistent with the per-tier feature / runtime / retention maps.
+
+Plus an integration test for :func:`routes.entitlement.api_tiers` that confirms
+the wire shape and the never-raise fallback.
+
+Companion to ``tests/test_entitlements.py`` (grace/enforce mechanics) and
+``tests/test_entitlements_catalogue.py`` (feature / retention buckets).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ~/.clawmetry/license.key or cloud_plan.json leaks in. Enforcement off
+    by default (grace mode)."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# -- tier_label ----------------------------------------------------------------
+
+
+def test_tier_label_known_tier_ids_return_their_label(ent):
+    assert ent.tier_label(ent.TIER_OSS) == "OSS"
+    assert ent.tier_label(ent.TIER_CLOUD_FREE) == "Free"
+    assert ent.tier_label(ent.TIER_TRIAL) == "Trial"
+    assert ent.tier_label(ent.TIER_CLOUD_STARTER) == "Starter"
+    assert ent.tier_label(ent.TIER_CLOUD_PRO) == "Pro"
+    assert ent.tier_label(ent.TIER_PRO) == "Pro (Self-hosted)"
+    assert ent.tier_label(ent.TIER_ENTERPRISE) == "Enterprise"
+
+
+def test_tier_label_unknown_tier_falls_back_to_id(ent):
+    assert ent.tier_label("not_a_real_tier") == "not_a_real_tier"
+
+
+def test_tier_label_handles_empty_and_none(ent):
+    assert ent.tier_label("") == ""
+    assert ent.tier_label(None) == ""
+
+
+def test_tier_label_is_case_insensitive(ent):
+    assert ent.tier_label("CLOUD_PRO") == "Pro"
+    assert ent.tier_label(" Cloud_Starter ") == "Starter"
+
+
+def test_tier_labels_cover_every_known_tier(ent):
+    """Every TIER_* constant exported by entitlements.py must have a label so
+    the upgrade-ladder UI never has to fall back to a raw tier id for a tier
+    we already know about. New tiers MUST add a TIER_LABELS entry to keep this
+    test green."""
+    known = {
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    assert known.issubset(set(ent.TIER_LABELS.keys()))
+
+
+# -- tier_catalog --------------------------------------------------------------
+
+
+def test_tier_catalog_returns_one_row_per_known_tier(ent):
+    rows = ent.tier_catalog()
+    ids = [row["id"] for row in rows]
+    expected_known = {
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    assert expected_known.issubset(set(ids))
+    assert len(ids) == len(set(ids))
+
+
+def test_tier_catalog_order_is_oss_first_enterprise_last(ent):
+    rows = ent.tier_catalog()
+    assert rows[0]["id"] == ent.TIER_OSS
+    assert rows[-1]["id"] == ent.TIER_ENTERPRISE
+    ranks = [row["rank"] for row in rows]
+    assert ranks == list(range(len(rows)))
+
+
+def test_tier_catalog_marks_exactly_one_current_in_grace(ent):
+    rows = ent.tier_catalog()
+    current = [row for row in rows if row["is_current"]]
+    assert len(current) == 1
+    assert current[0]["id"] == ent.TIER_OSS
+
+
+def test_tier_catalog_is_paid_matches_paid_tiers(ent):
+    rows = ent.tier_catalog()
+    paid_ids = {row["id"] for row in rows if row["is_paid"]}
+    assert paid_ids == {
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+
+
+def test_tier_catalog_unlocks_paid_runtimes_matches_is_paid(ent):
+    """A paid tier always unlocks the paid runtime bundle (the open-core
+    invariant). A free tier never does."""
+    for row in ent.tier_catalog():
+        assert row["unlocks_paid_runtimes"] == row["is_paid"]
+
+
+def test_tier_catalog_retention_days_match_published_caps(ent):
+    rows_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    assert rows_by_id[ent.TIER_OSS]["retention_days"] == 7
+    assert rows_by_id[ent.TIER_CLOUD_FREE]["retention_days"] == 7
+    assert rows_by_id[ent.TIER_TRIAL]["retention_days"] == 30
+    assert rows_by_id[ent.TIER_CLOUD_STARTER]["retention_days"] == 30
+    assert rows_by_id[ent.TIER_CLOUD_PRO]["retention_days"] == 90
+    assert rows_by_id[ent.TIER_PRO]["retention_days"] == 90
+    assert rows_by_id[ent.TIER_ENTERPRISE]["retention_days"] is None
+
+
+def test_tier_catalog_features_are_paid_only_no_free_leakage(ent):
+    for row in ent.tier_catalog():
+        assert set(row["features"]).isdisjoint(ent.FREE_FEATURES)
+
+
+def test_tier_catalog_marks_active_paid_tier_when_license_resolves(ent, monkeypatch, tmp_path):
+    """A cloud-plan cache file lights up the matching tier as current."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro", "node_limit": 3}))
+    ent.invalidate()
+    rows = ent.tier_catalog()
+    current = [row for row in rows if row["is_current"]]
+    assert len(current) == 1
+    assert current[0]["id"] == ent.TIER_CLOUD_PRO
+
+
+def test_tier_catalog_never_raises_on_resolution_failure(ent, monkeypatch):
+    """If get_entitlement explodes, tier_catalog still returns the ladder with
+    OSS as the (default) current row -- never propagates an exception."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated entitlement failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rows = ent.tier_catalog()
+    assert any(row["id"] == ent.TIER_OSS for row in rows)
+    current = [row for row in rows if row["is_current"]]
+    assert len(current) == 1
+    assert current[0]["id"] == ent.TIER_OSS
+
+
+# -- /api/tiers endpoint -------------------------------------------------------
+
+
+@pytest.fixture
+def client(ent):
+    from flask import Flask
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def test_api_tiers_returns_ladder_shape(client, ent):
+    resp = client.get("/api/tiers")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "tiers" in body and isinstance(body["tiers"], list) and body["tiers"]
+    assert body["current"] == ent.TIER_OSS
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    assert body["tiers"][0]["id"] == ent.TIER_OSS
+    assert body["tiers"][-1]["id"] == ent.TIER_ENTERPRISE
+
+
+def test_api_tiers_falls_back_on_internal_error(client, ent, monkeypatch):
+    """If both ``get_entitlement`` AND ``tier_catalog`` explode the route still
+    returns 200 with the safe OSS-free fallback (never 5xx)."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated catalog failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    monkeypatch.setattr(ent, "tier_catalog", boom)
+    resp = client.get("/api/tiers")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["current"] == "oss"
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    assert body["tiers"] == []


### PR DESCRIPTION
## Summary

Introduces the tier catalogue -- the source of truth for the upgrade-ladder UI -- so the dashboard can render per-tier metadata (label, is_paid, rank, retention, features) without hardcoding anything in JavaScript.

## Changes

- **`clawmetry/entitlements.py`** -- `TIER_LABELS` map (7 entries), `_TIER_ORDER` tuple, `tier_label(tier)` (never-crash, falls back to the raw id for unknown tiers), and `tier_catalog()` which returns the full 7-tier ladder in `_TIER_ORDER` order. Each row: `{id, label, is_paid, is_current, rank, unlocks_paid_runtimes, retention_days, features}`.
- **`routes/entitlement.py`** -- `GET /api/tiers` returns `{tiers, current, grace, enforced}`; side-effect-free, never-raise, OSS-free fallback on any error.
- **`tests/test_tier_catalog.py`** -- 17 tests covering label coverage, catalog order, `is_current` marking, paid/free split, retention caps, feature-delta isolation, cloud-plan activation, never-raise contract, and the `/api/tiers` wire shape + fallback.

## Test plan

- [ ] `python3 -m pytest tests/test_tier_catalog.py -v` -- all pass
- [ ] `python3 -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_tier_catalog.py`

Supersedes #2692 (stale base, dirty).

https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz

---
_Generated by [Claude Code](https://claude.ai/code/session_012PFN9pfW3e1g2Ux4p4PnZz)_