### PR TITLE
feat(entitlements): surface channel_limit on to_dict() / /api/entitlement

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -826,6 +826,11 @@ class Entitlement:
             "tier_label": tier_label(self.tier),
             "source": self.source,
             "node_limit": self.node_limit,
+            # Channel-adapter cap. Goes through the method so grace mode reads
+            # ``None`` (unlimited) end-to-end -- the dashboard's "X of N adapters"
+            # badge then matches the gate the channels route will eventually use.
+            # Free / OSS = 3 once enforced; every paid tier is ``None``.
+            "channel_limit": self.channel_limit(),
             "expiry": self.expiry,
             "expired": self.expired,
             "days_until_expiry": self.days_until_expiry(),

--- a/tests/test_entitlement_channel_limit.py
+++ b/tests/test_entitlement_channel_limit.py
@@ -147,3 +147,46 @@ def test_grace_allows_family_is_symmetric(ent):
     assert en.allows_runtime("claude_code") is True
     assert en.allows_feature("self_evolve") is True
     assert en.allows_channel_count(21) is True
+
+
+# -- to_dict wire shape -------------------------------------------------------
+
+
+def test_to_dict_grace_channel_limit_is_none(ent):
+    """``/api/entitlement`` carries ``channel_limit`` so the dashboard can
+    render the "X of N adapters" badge without re-deriving the tier-to-cap
+    table client-side. Grace mode reads ``None`` (JSON ``null``) so the badge
+    falls back to "X adapters" until the enforce flip."""
+    d = ent.get_entitlement(force=True).to_dict()
+    assert "channel_limit" in d
+    assert d["channel_limit"] is None
+
+
+def test_to_dict_enforce_oss_channel_limit_is_three(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    d = ent.get_entitlement(force=True).to_dict()
+    assert d["channel_limit"] == 3
+
+
+def test_to_dict_enforce_paid_channel_limit_is_none(ent, monkeypatch, tmp_path):
+    """Every paid tier renders the badge as "X adapters" (no denominator), so
+    the wire shape carries ``None`` for Starter/Pro/Enterprise."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    for plan in ("cloud_starter", "cloud_pro", "enterprise", "trial"):
+        cache.write_text(json.dumps({"plan": plan}))
+        ent.invalidate()
+        d = ent.get_entitlement(force=True).to_dict()
+        assert d["tier"] == plan, plan
+        assert d["channel_limit"] is None, plan
+
+
+def test_to_dict_channel_limit_is_json_serialisable(ent, monkeypatch):
+    """Same round-trip invariant the table-conformance test pins for every
+    other ``to_dict`` key -- a non-serialisable type leaking in would 500 the
+    ``/api/entitlement`` handler."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    d = ent.get_entitlement(force=True).to_dict()
+    roundtripped = json.loads(json.dumps(d))
+    assert roundtripped["channel_limit"] == d["channel_limit"]


### PR DESCRIPTION
## Summary

PR #3169 added `Entitlement.channel_limit()` / `allows_channel_count()` but never exposed the cap on the wire. The dashboard's "X of N adapters" badge would have to re-derive the tier-to-cap table client-side to render the denominator -- exactly the duplication `to_dict()` exists to prevent. Mirrors how `retention_days`, `node_limit`, `days_until_expiry`, and `tier_label` are already surfaced for the same reason.

## Wire shape

| Tier (enforce) | `channel_limit` |
|---|---|
| Grace mode (any tier) | `None` |
| OSS / Free | `3` |
| Starter / Trial | `None` |
| Pro / Enterprise | `None` |
| Expired paid plan | (collapses via `channel_limit()` -> `_FREE_CHANNEL_LIMIT` semantics; `allows_channel_count` covers the gate path) |

Grace mode reads `None` (JSON `null`) end-to-end so the dashboard's badge falls back to "X adapters" until the enforce flip -- no behaviour change pre-enforce.

## Changes

- **`clawmetry/entitlements.py`** -- `to_dict()` gains `"channel_limit": self.channel_limit()` between `node_limit` and `expiry` (both quota fields). 5 lines, no helper churn, no new constants.
- **`tests/test_entitlement_channel_limit.py`** -- 4 new tests pin the wire shape: grace = `None`, OSS enforce = `3`, every paid tier enforce = `None`, and `json.dumps` round-trip (the same invariant `test_entitlements_table_conformance` pins for every other key).

No call sites migrated -- pure additive surface. Channels route wiring of `allows_channel_count()` is still a follow-up.

## Test plan

- [ ] `python3 -m pytest tests/test_entitlement_channel_limit.py -v` -- 15/15 pass (11 pre-existing + 4 new)
- [ ] `python3 -m pytest tests/test_entitlements_table_conformance.py tests/test_entitlement_expiry.py tests/test_entitlement_locked_helpers.py tests/test_entitlements_retention_window.py tests/test_entitlement_node_count.py` -- 75/75 pass; no `to_dict` neighbours regress
- [ ] `python3 -m py_compile clawmetry/entitlements.py tests/test_entitlement_channel_limit.py`

Pre-existing failures on `main` (3 in `test_entitlements.py` / `test_tier_catalog.py` around `tier_label("pro")` returning "Self-hosted Pro" vs "Pro (Self-hosted)") are unrelated -- caused by a duplicate `TIER_LABELS` / `tier_label()` definition at lines 119/169 and 1150/1377. Leaving that alone here; it deserves its own focused PR.

## Local operator verification checklist

Because the routine fires can't touch your machine, the daemon, or the live snapshot, here's the loop for you:

- [ ] `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/` (adjust to your interpreter)
- [ ] `find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or `systemctl --user restart clawmetry-sync` (Linux)
- [ ] `curl -s http://localhost:8900/api/entitlement | jq '.channel_limit'` -> `null` in grace mode (no behaviour change)
- [ ] `CLAWMETRY_ENFORCE=1` (or set in the launchd plist / unit) and bounce the daemon -> same curl returns `3` for OSS-free
- [ ] Drop a `~/.clawmetry/cloud_plan.json` with `{"plan": "cloud_starter"}`, bounce the daemon -> curl returns `null`
- [ ] Decrypt the live cloud snapshot and confirm `/api/entitlement` on the cloud side now carries `channel_limit` alongside `retention_days` / `node_limit`
- [ ] Browser smoke: channels page still loads (no new gate is wired so behaviour is unchanged); the `channel_limit` field is available for the eventual "X of N adapters" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0124b2bHbSCuqivu81Jh4aAW)_