### PR TITLE
feat(entitlements): surface runtimes + channel_limit on tier_catalog rows

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1406,11 +1406,17 @@ def tier_catalog() -> list[dict]:
           "rank":             0..n,            # position in the ladder
           "unlocks_paid_runtimes": True|False, # tier grants paid runtimes
           "retention_days":   int | None,      # event retention cap (None = unlimited)
+          "channel_limit":    int | None,      # channel-adapter cap (None = unlimited)
           "features":         [...],           # paid feature keys this tier grants
                                                # (free features are always included
                                                # on top -- they're not listed here so
                                                # the upgrade copy stays scoped to the
                                                # paid delta)
+          "runtimes":         [...],           # paid runtime keys this tier grants
+                                               # (free runtimes are always included on
+                                               # top -- same scoping rule as features:
+                                               # the upgrade copy lists only the paid
+                                               # delta. Empty for free tiers.)
         }
 
     Never raises; on any resolution error the ``is_current`` flag falls back to
@@ -1423,8 +1429,10 @@ def tier_catalog() -> list[dict]:
         logger.warning("entitlements: tier_catalog falling back to OSS-free: %s", exc)
         current = TIER_OSS
     out: list[dict] = []
+    paid_runtimes_sorted = sorted(PAID_RUNTIMES)
     for rank, tier in enumerate(_TIER_ORDER):
         paid_feats = _TIER_FEATURES.get(tier, frozenset())
+        unlocks_paid = tier in _TIER_PAID_RUNTIMES
         out.append(
             {
                 "id": tier,
@@ -1432,9 +1440,11 @@ def tier_catalog() -> list[dict]:
                 "is_paid": tier in _PAID_TIERS,
                 "is_current": tier == current,
                 "rank": rank,
-                "unlocks_paid_runtimes": tier in _TIER_PAID_RUNTIMES,
+                "unlocks_paid_runtimes": unlocks_paid,
                 "retention_days": _TIER_RETENTION_DAYS.get(tier, 7),
+                "channel_limit": _TIER_CHANNEL_LIMIT.get(tier, _FREE_CHANNEL_LIMIT),
                 "features": sorted(paid_feats),
+                "runtimes": list(paid_runtimes_sorted) if unlocks_paid else [],
             }
         )
     return out

--- a/tests/test_tier_catalog.py
+++ b/tests/test_tier_catalog.py
@@ -151,6 +151,50 @@ def test_tier_catalog_features_are_paid_only_no_free_leakage(ent):
         assert set(row["features"]).isdisjoint(ent.FREE_FEATURES)
 
 
+def test_tier_catalog_channel_limit_matches_published_caps(ent):
+    """Free / OSS caps at 3 (the ``all_channels`` Starter unlock has teeth);
+    every paid tier is unlimited (``None``). Mirrors
+    ``_TIER_CHANNEL_LIMIT`` so the UI gets the same value the route gate
+    will eventually enforce."""
+    rows_by_id = {row["id"]: row for row in ent.tier_catalog()}
+    assert rows_by_id[ent.TIER_OSS]["channel_limit"] == 3
+    assert rows_by_id[ent.TIER_CLOUD_FREE]["channel_limit"] == 3
+    assert rows_by_id[ent.TIER_TRIAL]["channel_limit"] is None
+    assert rows_by_id[ent.TIER_CLOUD_STARTER]["channel_limit"] is None
+    assert rows_by_id[ent.TIER_CLOUD_PRO]["channel_limit"] is None
+    assert rows_by_id[ent.TIER_PRO]["channel_limit"] is None
+    assert rows_by_id[ent.TIER_ENTERPRISE]["channel_limit"] is None
+
+
+def test_tier_catalog_runtimes_are_paid_only_no_free_leakage(ent):
+    """Symmetric with ``features``: each row lists only the paid runtimes the
+    tier grants -- free runtimes are implicit-everywhere and never repeated
+    on the upgrade-ladder rows."""
+    for row in ent.tier_catalog():
+        assert set(row["runtimes"]).isdisjoint(ent.FREE_RUNTIMES), row["id"]
+        assert set(row["runtimes"]).issubset(ent.PAID_RUNTIMES), row["id"]
+
+
+def test_tier_catalog_paid_tiers_unlock_all_paid_runtimes(ent):
+    """Open-core invariant: every paid tier unlocks the full paid-runtime
+    bundle (all paid runtimes ship together via the Starter ``multi_runtime``
+    grant). Pins this against the ``unlocks_paid_runtimes`` flag so the two
+    columns can never drift."""
+    expected = sorted(ent.PAID_RUNTIMES)
+    for row in ent.tier_catalog():
+        if row["unlocks_paid_runtimes"]:
+            assert row["runtimes"] == expected, row["id"]
+        else:
+            assert row["runtimes"] == [], row["id"]
+
+
+def test_tier_catalog_runtimes_are_sorted(ent):
+    """Stable display order: paid runtimes are returned sorted so the UI
+    list is deterministic across reloads (same contract as ``features``)."""
+    for row in ent.tier_catalog():
+        assert row["runtimes"] == sorted(row["runtimes"]), row["id"]
+
+
 def test_tier_catalog_marks_active_paid_tier_when_license_resolves(ent, monkeypatch, tmp_path):
     """A cloud-plan cache file lights up the matching tier as current."""
     monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")


### PR DESCRIPTION
## Summary

`tier_catalog()` is the upgrade-ladder source the UI reads via `/api/tiers` to render one row per tier with the per-tier delta it would unlock. Each row already advertises `retention_days` and the paid `features` bucket, but does not list:

- the paid **runtimes** the tier grants, even though `_TIER_PAID_RUNTIMES` is the authoritative table for "does this tier unlock the paid runtime bundle"; and
- the per-tier **channel_limit**, even though `_TIER_CHANNEL_LIMIT` is the authoritative table for the `all_channels` Starter unlock and `Entitlement.channel_limit()` already reads it for the resolved tier.

Today the dashboard reconstructs "Starter unlocks: 10 runtimes, unlimited channels, 30 days" by cross-joining `/api/runtimes` (per-runtime `free/locked` rows) and `/api/entitlement` (only the *resolved* tier's `channel_limit`). The source module already has the data to render the full ladder in one fetch.

This makes the row shape symmetric with the existing `features` column:

- **`runtimes`** — sorted list of paid runtime ids this tier grants. Free tiers get `[]`. Paid tiers list all of `PAID_RUNTIMES` (the open-core invariant: the full paid runtime bundle ships together via the Starter `multi_runtime` grant). Pinned against `unlocks_paid_runtimes` so the two columns can never drift.
- **`channel_limit`** — per-tier adapter cap from `_TIER_CHANNEL_LIMIT` (`3` on free / OSS, `None` on every paid tier). Identical to `Entitlement.channel_limit()` in enforce mode; surfacing the cap directly on the ladder row means the UI doesn't have to resolve a per-tier entitlement to render it.

Same scoping convention as `features`: free runtimes are implicit-everywhere and intentionally omitted, so upgrade copy stays scoped to the paid delta. Purely additive — no existing field changes shape, no `tier_catalog` consumer breaks.

**Stays in GRACE.** This is a read API; no gate behaviour changes, no rollout posture changes.

## Files touched

- `clawmetry/entitlements.py` — `tier_catalog()` rows gain `runtimes` + `channel_limit`; docstring example updated to the new shape.
- `tests/test_tier_catalog.py` — four new pins:
  - `channel_limit` per row matches `_TIER_CHANNEL_LIMIT`,
  - `runtimes` per row is paid-only / no free leakage,
  - paid tiers list all of `PAID_RUNTIMES` and free tiers list none (pinned against `unlocks_paid_runtimes`),
  - `runtimes` per row is sorted (same determinism contract as `features`).

## Tests

```
tests/test_tier_catalog.py                  19 of 20 pass *
tests/test_entitlements.py                  44 of 46 pass *
tests/test_entitlements_catalogue.py        15 pass
tests/test_entitlements_table_conformance.py 8 pass
tests/test_entitlement_api.py               25 pass
tests/test_entitlement_channel_limit.py      pass
tests/test_entitlements_min_tier.py          pass
tests/test_routes_runtimes.py                pass
tests/test_routes_features.py                pass
-------
171 pass, 3 fail
```

\* The three failures (`test_tier_label_known_tier_ids_return_their_label`, `test_tier_label_unknown_titlecased`, `test_tier_label_empty_and_none_safe`) fail on `origin/main` as well — they're caused by the pre-existing duplicate `TIER_LABELS` dict and duplicate `tier_label()` function definitions in `entitlements.py` (the second redefinition wins; the tests assert the first form's behaviour). Out of scope for this PR — leaving those alone so this branch stays focused on a single additive change.

## Local operator verification checklist

Because the routine fires can't touch your machine, the daemon, or the live snapshot, here's the loop for you:

- [ ] `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/` (adjust to your interpreter).
- [ ] `find ~/.clawmetry -name __pycache__ -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or `systemctl --user restart clawmetry-sync` (Linux).
- [ ] `curl -s http://localhost:8900/api/tiers | jq '.tiers[] | {id, channel_limit, runtimes}'`:
  - OSS / Cloud Free → `channel_limit: 3`, `runtimes: []`.
  - Starter / Cloud Pro / Pro / Trial / Enterprise → `channel_limit: null`, `runtimes: ["aider","claude_code","codex","cursor","goose","hermes","nanoclaw","opencode","picoclaw","qwen_code"]`.
- [ ] `curl -s http://localhost:8900/api/tiers | jq '.tiers | map(select(.unlocks_paid_runtimes != (.runtimes != [])))'` → empty (the two columns must stay in lockstep).
- [ ] Decrypt the live cloud snapshot — `/api/tiers` on the cloud side should now carry the same `runtimes` / `channel_limit` columns on each row.
- [ ] Browser smoke: the upgrade-ladder UI rows can now render the per-tier paid runtime count and the channel cap without a second fetch — confirm no regression on the existing `retention_days` / `features` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQR9ugxgRfzA9JCLDgnxCH)_