### PR TITLE
fix(cli): restore missing _cmd_runtimes implementation (#3005 follow-up)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2975,6 +2975,88 @@ def _cmd_tier(args) -> None:
     print(f"  Features:    {len(features)} unlocked")
 
 
+def _cmd_runtimes(args) -> None:
+    """clawmetry runtimes — list every observable runtime and which are unlocked.
+
+    Sibling of :func:`_cmd_tier`: that one answers "what tier am I on?", this
+    one answers "which runtimes is this install cleared to observe?". Reads
+    :func:`clawmetry.entitlements.runtime_catalog` -- the same source the
+    dashboard's ``GET /api/runtimes`` consumes -- so the CLI and the UI cannot
+    drift.
+
+    Never raises. A poisoned catalog read surfaces the error inline (a warning
+    row in the human table, or an ``error`` key on the JSON payload with
+    ``runtimes=[]``) so a wrapper script always sees a parseable response.
+    Matches the never-crash contract documented on :func:`get_entitlement`.
+
+    Output:
+      default -- compact table (id, label, tier, status)
+      --json  -- ``{tier, grace, enforced, runtimes: [...], error?: str}``
+    """
+    import json as _json
+
+    from clawmetry import entitlements as _ent
+
+    try:
+        ent = _ent.get_entitlement()
+        tier = ent.tier
+        grace = bool(ent.grace)
+        enforced = _ent.is_enforced()
+    except Exception as exc:
+        # Mirror _cmd_tier's never-crash fallback: a broken install still gets
+        # a parseable shape, with the failure surfaced to stderr so it isn't
+        # silently lost in a pipeline.
+        print(f"⚠️  entitlement resolution failed: {exc}", file=sys.stderr)
+        tier, grace, enforced = "oss", True, False
+
+    rows: list[dict] = []
+    catalog_error: str | None = None
+    try:
+        rows = list(_ent.runtime_catalog())
+    except Exception as exc:
+        catalog_error = str(exc)
+
+    if getattr(args, "as_json", False):
+        payload: dict = {
+            "tier": tier,
+            "grace": grace,
+            "enforced": enforced,
+            "runtimes": rows,
+        }
+        if catalog_error:
+            payload["error"] = catalog_error
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    mode_line = "off (grace)" if not enforced else "on"
+    print("ClawMetry Runtimes\n" + "─" * 40)
+    print(f"  Tier:        {tier}")
+    print(f"  Enforcement: {mode_line}")
+    if catalog_error:
+        print(f"  ⚠️  catalog error: {catalog_error}")
+        return
+
+    any_locked = False
+    print()
+    print(f"  {'ID':<14} {'Label':<14} {'Tier':<6} Status")
+    print("  " + "─" * 50)
+    for row in rows:
+        rid = str(row.get("id", ""))
+        label = str(row.get("label", rid))
+        is_free = bool(row.get("free", False))
+        locked = bool(row.get("locked", False))
+        if locked:
+            status = "🔒 locked"
+            any_locked = True
+        else:
+            status = "✅ available"
+        tier_tag = "free" if is_free else "paid"
+        print(f"  {rid:<14} {label:<14} {tier_tag:<6} {status}")
+    if any_locked:
+        print()
+        print("  Upgrade: clawmetry license activate <KEY>")
+
+
 def _cmd_verify_integrity(args) -> None:
     """clawmetry verify-integrity — walk the hash chain and report validity."""
     from clawmetry.local_store import get_store
@@ -3394,6 +3476,18 @@ def main() -> None:
         help="Emit the full Entitlement.to_dict() as JSON (jq-friendly)",
     )
 
+    # runtimes — list every observable runtime and which are unlocked (PR #3005)
+    p_runtimes = sub.add_parser(
+        "runtimes",
+        help="List every observable runtime and which this install can unlock",
+    )
+    p_runtimes.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit {tier, grace, enforced, runtimes:[...]} JSON (jq-friendly)",
+    )
+
     # verify-integrity — walk hash chain and report validity (Issue #2200)
     p_verify = sub.add_parser(
         "verify-integrity",
@@ -3423,6 +3517,7 @@ def main() -> None:
         "activate",
         "license",
         "tier",
+        "runtimes",
         "verify-integrity",
         "nemoclaw-daemons",
     )
@@ -3460,6 +3555,8 @@ def main() -> None:
             _cmd_license(args)
         elif args.cmd == "tier":
             _cmd_tier(args)
+        elif args.cmd == "runtimes":
+            _cmd_runtimes(args)
         elif args.cmd == "verify-integrity":
             _cmd_verify_integrity(args)
         elif args.cmd == "nemoclaw-daemons":


### PR DESCRIPTION
## Summary

PR #3005 (`feat(cli): clawmetry runtimes subcommand -- list runtime catalog`) **landed `tests/test_cli_runtimes_subcommand.py` (114 lines, 5 cases) but its actual implementation never made it into `clawmetry/cli.py`** -- the merged diff only added a `license fingerprint` action. Compare the commit message of `f4fbd41` ("Adds `clawmetry runtimes` subcommand that lists the 12 supported runtime catalog entries…") against `git show f4fbd41 -- clawmetry/cli.py` to see the mismatch.

All 5 tests in `tests/test_cli_runtimes_subcommand.py` have been silently failing on `origin/main` ever since because the file isn't in the CI MOAT verifier suite (`.github/workflows/ci.yml` `moat-tests` job is the gate). PR #3175 calls out the same class of slip-through for `test_entitlements.py` / `test_tier_catalog.py` (different bug, also silently failing on main).

```
$ python3 -m pytest tests/test_cli_runtimes_subcommand.py  # on origin/main
FAILED tests/test_cli_runtimes_subcommand.py::test_runtimes_table_lists_every_known_runtime
FAILED tests/test_cli_runtimes_subcommand.py::test_runtimes_json_is_machine_readable
FAILED tests/test_cli_runtimes_subcommand.py::test_runtimes_enforced_oss_shows_paid_runtimes_locked
FAILED tests/test_cli_runtimes_subcommand.py::test_runtimes_falls_back_when_catalog_errors
FAILED tests/test_cli_runtimes_subcommand.py::test_runtimes_subcommand_is_registered
==================== 5 failed in 0.14s ====================
E   AttributeError: module 'clawmetry.cli' has no attribute '_cmd_runtimes'
```

### What this PR lands

The missing piece exactly as the tests describe it:

* **`_cmd_runtimes(args)`** -- reads `entitlements.runtime_catalog()` (the same source `GET /api/runtimes` serves), prints either a compact ASCII table (id | label | tier | status) or `--json` payload `{tier, grace, enforced, runtimes:[...], error?: str}`. Sibling to `_cmd_tier`; uses the same import / fallback pattern so reviewers don't have to context-switch.
* **`runtimes` subparser** with the `--json` flag (`dest="as_json"` to match the test's namespace).
* **Dispatch wiring** -- `"runtimes"` added to `_subcmds` tuple + `args.cmd == "runtimes"` branch that calls `_cmd_runtimes(args)`.

Matches the never-crash contract: a poisoned `runtime_catalog()` surfaces the failure inline (a warning row in the human table, an `error` key on the JSON payload with `runtimes=[]`) so wrapper scripts always see a parseable response. A broken entitlement resolver falls back to OSS-grace defaults with the exception written to stderr.

**Pure grace.** No behavior change for any existing install -- the locked affordance only shows when `CLAWMETRY_ENFORCE=1` is already set.

### Smoke output

Default install (grace):

```
ClawMetry Runtimes
────────────────────────────────────────
  Tier:        oss
  Enforcement: off (grace)

  ID             Label          Tier   Status
  ──────────────────────────────────────────────────
  nemoclaw       NemoClaw       free   ✅ available
  openclaw       OpenClaw       free   ✅ available
  aider          Aider          paid   ✅ available
  …
```

With `CLAWMETRY_ENFORCE=1`:

```
ClawMetry Runtimes
────────────────────────────────────────
  Tier:        oss
  Enforcement: on

  ID             Label          Tier   Status
  ──────────────────────────────────────────────────
  nemoclaw       NemoClaw       free   ✅ available
  openclaw       OpenClaw       free   ✅ available
  aider          Aider          paid   🔒 locked
  …

  Upgrade: clawmetry license activate <KEY>
```

## Test plan

- [x] `python3 -m pytest tests/test_cli_runtimes_subcommand.py -v` -- 5/5 pass (was 0/5 on origin/main)
- [x] `python3 -m pytest tests/test_cli.py tests/test_cli_banner.py tests/test_cli_runtimes_subcommand.py -v` -- 16/16 pass (no CLI-suite regressions)
- [x] `python3 -m py_compile clawmetry/cli.py`
- [x] Smoke: `clawmetry runtimes`, `clawmetry runtimes --json | python3 -m json.tool`, `CLAWMETRY_ENFORCE=1 clawmetry runtimes` -- all three render correctly with the lock affordance appearing only when enforced

Out of scope for this PR (filed elsewhere):
- Adding `tests/test_cli_runtimes_subcommand.py` to the CI MOAT verifier so this class of slip-through can't repeat -- best handled as its own focused CI change so it isn't bundled with the code fix.
- Pre-existing `tests/test_entitlements.py` duplicate-defs failures -- already addressed by #3175.

## Local operator verification checklist

You can't see what I see, so:

- [ ] `cp clawmetry/cli.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/cli.py` (or whichever Python your daemon uses)
- [ ] `find ~/.clawmetry/lib -name '__pycache__' -prune -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `clawmetry runtimes` -- expect the grace-mode table with every runtime marked `available`
- [ ] `clawmetry runtimes --json | jq '.runtimes[].id' | sort` -- expect 12 ids matching `entitlements.ALL_RUNTIMES`
- [ ] `CLAWMETRY_ENFORCE=1 clawmetry runtimes` -- expect paid rows rendered with the 🔒 lock + `clawmetry license activate <KEY>` CTA at the bottom
- [ ] `curl -s http://localhost:8900/api/entitlement | jq .grace` -- expect `true` (still in grace; this PR didn't move enforcement)
- [ ] Decrypt today's live cloud snapshot in the browser -- no UI changes expected (CLI-only change)
- [ ] Land + release whenever you're ready; safe in GRACE, no enforcement change

---
_Generated by [Claude Code](https://claude.com/claude-code) -- `claude-opus-4-7`_

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZGoezadZ4a3y6qWWFn7kJ)_