### PR TITLE
feat(entitlement): add next_purchasable_tier() -- Upgrade-to-X CTA target

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -606,6 +606,44 @@ class Entitlement:
             return min_tier_for_runtime(k)
         return None
 
+    def next_purchasable_tier(self) -> str | None:
+        """The cheapest *purchasable* tier id with a strictly higher rank than
+        this entitlement's tier — the natural target for the dashboard's primary
+        "Upgrade to ___" CTA button.
+
+        Walks :data:`_PURCHASABLE_TIERS` (which intentionally excludes
+        :data:`TIER_TRIAL` — trial is a promotional grant, not pickable from a
+        price page) and returns the first tier whose :func:`tier_rank` is
+        strictly greater than the current rank, so:
+
+        * ``oss`` / ``cloud_free`` (rank 0) -> ``cloud_starter``
+        * ``cloud_starter`` (rank 1)        -> ``cloud_pro``
+        * ``cloud_pro`` (rank 2)            -> ``enterprise``
+        * ``pro`` (rank 2, self-hosted)     -> ``enterprise``
+        * ``trial`` (rank 2)                -> ``enterprise``
+        * ``enterprise`` (rank 3)           -> ``None`` (already at the top)
+
+        Unknown tiers are treated as rank ``0`` (the OSS bucket), so a
+        misconfigured plan still drives the operator at ``cloud_starter`` --
+        the upgrade ladder's bottom rung -- rather than returning ``None`` and
+        rendering no CTA at all. Never raises.
+
+        Companion to :meth:`upgrade_diff`: ``ent.upgrade_diff(ent.next_purchasable_tier())``
+        is the one-call "what would I get by clicking the CTA?" payload.
+        """
+        try:
+            # Unknown tiers (rank -1) clamp to 0 so the lookup still produces a
+            # useful CTA target (cloud_starter) instead of advertising "oss" as
+            # an "upgrade".
+            current_rank = max(0, tier_rank(self.tier))
+            for candidate in _PURCHASABLE_TIERS:
+                if tier_rank(candidate) > current_rank:
+                    return candidate
+            return None
+        except Exception as exc:
+            logger.warning("entitlements: next_purchasable_tier failed: %s", exc)
+            return None
+
     def upgrade_diff(self, target_tier: str) -> dict:
         """Features + runtimes ``target_tier`` would unlock on top of this
         entitlement. Returns ``{"target": "<tier>", "added_features": [...sorted...],
@@ -895,6 +933,16 @@ class Entitlement:
             "all_runtimes": sorted(ALL_RUNTIMES),
             "locked_runtimes": list(self.locked_runtimes()),
             "locked_features": list(self.locked_features()),
+            # Next purchasable tier above this entitlement -- the dashboard's
+            # primary "Upgrade to ___" CTA target. ``None`` once the install is
+            # already on Enterprise. ``next_tier_label`` mirrors the labelling
+            # the UI shows alongside the tier id.
+            "next_tier": self.next_purchasable_tier(),
+            "next_tier_label": (
+                tier_label(self.next_purchasable_tier())
+                if self.next_purchasable_tier() is not None
+                else None
+            ),
         }
 
 
@@ -1226,6 +1274,18 @@ def tier_rank(tier: str) -> int:
     """Comparable rank for ``tier`` (higher = unlocks more). Returns ``-1`` for
     unknown tiers. See :data:`_TIER_RANK` for the canonical numbering."""
     return _TIER_RANK.get((tier or "").strip().lower(), -1)
+
+
+def next_purchasable_tier() -> str | None:
+    """Module-level convenience: resolve the current entitlement and return the
+    next purchasable tier above it -- the dashboard's "Upgrade to ___" CTA
+    target. See :meth:`Entitlement.next_purchasable_tier` for semantics. Never
+    raises; any resolution error returns ``None``."""
+    try:
+        return get_entitlement().next_purchasable_tier()
+    except Exception as exc:
+        logger.warning("entitlements: next_purchasable_tier (module) failed: %s", exc)
+        return None
 
 
 def min_tier_for_feature(feature: str) -> str | None:

--- a/tests/test_entitlement_next_tier.py
+++ b/tests/test_entitlement_next_tier.py
@@ -1,0 +1,165 @@
+"""Tests for ``Entitlement.next_purchasable_tier()`` + the module-level helper.
+
+The dashboard's primary "Upgrade to ___" CTA button needs a single, canonical
+"what's the next tier above this install?" lookup so the JS doesn't re-derive
+the ladder. These tests pin the table per-tier so a future ladder shuffle
+breaks loudly here instead of silently in the UI.
+"""
+from __future__ import annotations
+
+import importlib
+from dataclasses import replace
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    # Grace mode by default -- next_purchasable_tier is grace-independent so
+    # this matches every other entitlement test in the suite.
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── per-tier table ──────────────────────────────────────────────────────────
+
+
+def test_oss_upgrades_to_cloud_starter(ent):
+    e = ent._build(ent.TIER_OSS, "oss")
+    assert e.next_purchasable_tier() == ent.TIER_CLOUD_STARTER
+
+
+def test_cloud_free_upgrades_to_cloud_starter(ent):
+    e = ent._build(ent.TIER_CLOUD_FREE, "cloud")
+    assert e.next_purchasable_tier() == ent.TIER_CLOUD_STARTER
+
+
+def test_cloud_starter_upgrades_to_cloud_pro(ent):
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    assert e.next_purchasable_tier() == ent.TIER_CLOUD_PRO
+
+
+def test_cloud_pro_upgrades_to_enterprise(ent):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    assert e.next_purchasable_tier() == ent.TIER_ENTERPRISE
+
+
+def test_self_hosted_pro_upgrades_to_enterprise(ent):
+    e = ent._build(ent.TIER_PRO, "license")
+    assert e.next_purchasable_tier() == ent.TIER_ENTERPRISE
+
+
+def test_trial_upgrades_to_enterprise(ent):
+    # Trial shares rank 2 with cloud_pro/self-hosted pro, so the next strictly
+    # higher purchasable tier is enterprise (rank 3).
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    assert e.next_purchasable_tier() == ent.TIER_ENTERPRISE
+
+
+def test_enterprise_has_no_next_tier(ent):
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    assert e.next_purchasable_tier() is None
+
+
+# ── safety / fallback ───────────────────────────────────────────────────────
+
+
+def test_unknown_tier_falls_through_to_cloud_starter(ent):
+    # A misconfigured plan with an unknown tier id should still drive the
+    # operator at the bottom rung of the upgrade ladder rather than render
+    # no CTA at all.
+    e = replace(ent._oss_free(), tier="nonsense_tier_xyz")
+    assert e.next_purchasable_tier() == ent.TIER_CLOUD_STARTER
+
+
+def test_returned_tier_is_always_purchasable(ent):
+    # Trial is intentionally excluded from the purchasable ladder; assert that
+    # no tier ever returns trial as its "next" target.
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        nxt = e.next_purchasable_tier()
+        assert nxt != ent.TIER_TRIAL, f"{tier} should not advertise trial as next"
+
+
+def test_next_tier_rank_is_strictly_higher(ent):
+    # For every non-enterprise tier the returned next-tier must out-rank the
+    # current one. Pins the strict-greater invariant against accidental
+    # off-by-one regressions in _PURCHASABLE_TIERS ordering.
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    ):
+        e = ent._build(tier, "test")
+        nxt = e.next_purchasable_tier()
+        assert nxt is not None
+        assert ent.tier_rank(nxt) > ent.tier_rank(tier)
+
+
+# ── module-level convenience function ───────────────────────────────────────
+
+
+def test_module_level_helper_matches_method(ent):
+    # The bare module-level helper resolves the current entitlement and
+    # delegates, so it must agree with the bound method.
+    assert ent.next_purchasable_tier() == ent.get_entitlement().next_purchasable_tier()
+
+
+def test_module_level_helper_never_raises(monkeypatch, ent):
+    # If get_entitlement somehow raises, the module-level helper must swallow
+    # and return None rather than crash the dashboard CTA render.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.next_purchasable_tier() is None
+
+
+# ── to_dict / API surface ───────────────────────────────────────────────────
+
+
+def test_to_dict_includes_next_tier_and_label(ent):
+    payload = ent._oss_free().to_dict()
+    assert payload["next_tier"] == ent.TIER_CLOUD_STARTER
+    assert payload["next_tier_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+
+
+def test_to_dict_omits_next_for_enterprise(ent):
+    payload = ent._build(ent.TIER_ENTERPRISE, "license").to_dict()
+    assert payload["next_tier"] is None
+    assert payload["next_tier_label"] is None
+
+
+def test_api_entitlement_surfaces_next_tier(client, ent):
+    rv = client.get("/api/entitlement")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    # An OSS-default install should advertise cloud_starter as the upgrade.
+    assert body["next_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["next_tier_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)


### PR DESCRIPTION
## Summary

The dashboard's primary "Upgrade to ___" CTA button needs a single, canonical "what's the next tier above this install?" lookup so the JS doesn't have to re-derive the ladder from `tier_rank()` + `_PURCHASABLE_TIERS` on every render. Adds the helper at the same altitude as the existing `min_tier_for` / `upgrade_diff` helpers, and surfaces it on `/api/entitlement` so frontends can render the CTA in a single read.

### What lands

* **`Entitlement.next_purchasable_tier()`** -- bound method. Walks `_PURCHASABLE_TIERS` (which intentionally excludes `TIER_TRIAL` -- trial is a promotional grant, not pickable from a price page) and returns the first tier whose `tier_rank()` is strictly greater than the current rank:

  | Current tier                  | Next                |
  |-------------------------------|---------------------|
  | `oss` / `cloud_free`          | `cloud_starter`     |
  | `cloud_starter`               | `cloud_pro`         |
  | `cloud_pro` / `pro` / `trial` | `enterprise`        |
  | `enterprise`                  | `None` (top of ladder) |
  | unknown tier (`rank == -1`)   | `cloud_starter` (clamps to rank 0) |

* **Module-level `next_purchasable_tier()`** -- convenience wrapper that resolves the current entitlement and delegates. Mirrors the `upgrade_diff` / `lock_reason` module-level shorthand pattern.

* **`to_dict()` surface** -- adds `next_tier` (id) and `next_tier_label` (human-readable) so `/api/entitlement` is the one source of truth for "which Upgrade CTA should the dashboard render?" -- no behaviour change for clients that ignore the new keys.

Companion to `upgrade_diff()`: `ent.upgrade_diff(ent.next_purchasable_tier())` is the one-call "what would I get by clicking the CTA?" payload.

### Posture

Pure grace. No behaviour change, additive only. The CTA target is the same upgrade page that's been advertised for months -- this just gives the dashboard a one-call source for *which* tier to highlight, instead of every renderer re-deriving the ladder client-side.

The new helpers follow the never-crash contract used by every other entitlement helper: any resolution error falls back to `None` (the module-level helper) or a logged warning + `None` (the bound method), so a flaky read can never break a render.

## Test plan

- [x] `python3 -m pytest tests/test_entitlement_next_tier.py -v` -- 15/15 pass (per-tier table, module-level wrapper, to_dict surface, `/api/entitlement` payload, unknown-tier fallback, never-raise contract, trial-never-advertised invariant)
- [x] `python3 -m pytest tests/test_entitlement*.py tests/test_entitlements*.py` -- 291/291 pass (no regressions in the entitlement suite)
- [x] `python3 -m py_compile clawmetry/entitlements.py`
- [x] No new lint findings on `clawmetry/entitlements.py` or `tests/test_entitlement_next_tier.py` (pre-existing repo-wide ruff warnings unrelated to this PR)

## Local operator verification checklist

You can't see what I see, so:

- [ ] `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/entitlements.py` (or whichever Python your daemon uses)
- [ ] `find ~/.clawmetry/lib -name '__pycache__' -prune -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] `curl -s http://localhost:8900/api/entitlement | jq '.next_tier, .next_tier_label'` -- expect `"cloud_starter"` + `"Starter"` on an OSS-default install
- [ ] `curl -s http://localhost:8900/api/entitlement | jq '.grace'` -- expect `true` (still in grace; this PR didn't move enforcement)
- [ ] Decrypt today's live cloud snapshot in the browser -- no UI changes expected (API-only addition; the frontend that consumes `next_tier` lands separately)
- [ ] Optional: with a self-hosted Pro license active, the same endpoint should return `"next_tier": "enterprise"`, `"next_tier_label": "Enterprise"`
- [ ] Land + release whenever you're ready; safe in GRACE, no enforcement change

---
_Generated by [Claude Code](https://claude.com/claude-code) -- `claude-opus-4-7`_

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8dbqCVP7D6UFDbYtozeTv)_