### PR TITLE
feat(entitlements): add upgrade_diff(target_tier) -- the upgrade-CTA primitive

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -279,6 +279,55 @@ class Entitlement:
             return False
         return feature in self.features
 
+    def upgrade_diff(self, target_tier: str) -> dict:
+        """Features + runtimes ``target_tier`` would unlock on top of this
+        entitlement.
+
+        Drives the upgrade CTA on every locked surface ("Upgrade to Pro -
+        unlocks N features + M runtimes") and the comparison table the pricing
+        page renders. Single source of truth so the dashboard never re-derives
+        per-tier feature membership in JavaScript.
+
+        Returns the same shape regardless of inputs::
+
+            {
+              "target":          "<tier>",       # canonical id (lower-cased)
+              "added_features":  [...sorted...], # paid features the tier adds
+              "added_runtimes":  [...sorted...], # paid runtimes the tier adds
+            }
+
+        An unknown / empty ``target_tier`` returns empty lists rather than
+        raising, so a stray query-string typo never crashes the dashboard.
+        Free features are intentionally not subtracted from ``added_features``
+        because they are already in :attr:`features` for every entitlement; the
+        diff is the *delta*, not the destination set.
+        """
+        try:
+            tt = (target_tier or "").strip().lower()
+            target_paid_feats = _TIER_FEATURES.get(tt)
+            if target_paid_feats is None:
+                return {"target": tt, "added_features": [], "added_runtimes": []}
+            target_feats = FREE_FEATURES | target_paid_feats
+            if tt == TIER_ENTERPRISE:
+                target_feats = target_feats | ENTERPRISE_FEATURES
+            target_runtimes = (
+                FREE_RUNTIMES | PAID_RUNTIMES
+                if tt in _TIER_PAID_RUNTIMES
+                else FREE_RUNTIMES
+            )
+            return {
+                "target": tt,
+                "added_features": sorted(target_feats - self.features),
+                "added_runtimes": sorted(target_runtimes - self.runtimes),
+            }
+        except Exception as exc:
+            logger.warning("entitlements: upgrade_diff failed: %s", exc)
+            return {
+                "target": target_tier or "",
+                "added_features": [],
+                "added_runtimes": [],
+            }
+
     def event_retention_days(self) -> int | None:
         """Days of event history this tier may keep. ``None`` means unlimited
         / custom (Enterprise). The daemon's prune loop in ``clawmetry/sync.py``
@@ -418,6 +467,22 @@ def available_runtimes() -> list[str]:
     if ent.grace:
         return sorted(ALL_RUNTIMES)
     return sorted(ent.runtimes)
+
+
+def upgrade_diff(target_tier: str) -> dict:
+    """Module-level convenience: resolve the current entitlement and return
+    what ``target_tier`` would unlock on top of it. Same shape as
+    :meth:`Entitlement.upgrade_diff`. Never raises -- any resolution error
+    returns the empty-list shape so the dashboard CTA can always render."""
+    try:
+        return get_entitlement().upgrade_diff(target_tier)
+    except Exception as exc:
+        logger.warning("entitlements: upgrade_diff (module) failed: %s", exc)
+        return {
+            "target": (target_tier or ""),
+            "added_features": [],
+            "added_runtimes": [],
+        }
 
 
 def runtime_label(runtime: str) -> str:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6,8 +6,11 @@ runtimes/features to surface (and, once enforcement is live, which to render
 locked behind an upgrade CTA). Backed by :mod:`clawmetry.entitlements`, which
 is the single source of truth — handlers never re-derive tier logic here.
 
-  GET /api/entitlement — the current Entitlement as JSON.
-  GET /api/runtimes    — the full runtime catalog with locked/free flags.
+  GET /api/entitlement              — the current Entitlement as JSON.
+  GET /api/entitlement/upgrade-diff — features + runtimes a target tier would
+                                      add on top of the current ent.
+  GET /api/runtimes                 — the full runtime catalog with
+                                      locked/free flags.
 
 Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
 on the cloud side: when no license/cloud plan is present it returns a graceful
@@ -49,6 +52,36 @@ def api_entitlement():
                 "enforced": False,
                 "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/upgrade-diff")
+def api_entitlement_upgrade_diff():
+    """Return the features + runtimes ``?target=<tier>`` would unlock on top of
+    the current entitlement. Drives the upgrade CTA shown on locked rows
+    ("Upgrade to Pro - unlocks N features + M runtimes") so the dashboard
+    never re-derives per-tier feature membership in JavaScript.
+
+    Shape::
+
+        {"target": "<tier>", "added_features": [...], "added_runtimes": [...]}
+
+    Unknown / missing ``target`` returns empty lists rather than 4xx -- a stray
+    typo in the query string must never crash the dashboard CTA render.
+    Side-effect-free and never-raise."""
+    try:
+        target = (request.args.get("target") or "").strip().lower()
+        from clawmetry import entitlements as _ent
+
+        return jsonify(_ent.upgrade_diff(target))
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_entitlement_upgrade_diff: error: %s", exc)
+        return jsonify(
+            {
+                "target": (request.args.get("target") or "").strip().lower(),
+                "added_features": [],
+                "added_runtimes": [],
             }
         )
 

--- a/tests/test_entitlement_upgrade_diff.py
+++ b/tests/test_entitlement_upgrade_diff.py
@@ -1,0 +1,200 @@
+"""Tests for ``Entitlement.upgrade_diff`` + the module-level helper +
+``GET /api/entitlement/upgrade-diff``.
+
+The dashboard's upgrade CTA ("Upgrade to Pro - unlocks N features + M
+runtimes") reads this single primitive instead of re-deriving per-tier feature
+membership in JavaScript. These tests pin the per-tier delta so a future
+reshuffle of the tier -> feature/runtime tables breaks loudly here instead of
+silently in the UI.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    # Grace mode by default -- upgrade_diff is a pure-data primitive that does
+    # not depend on grace; matching every other entitlement test fixture in the
+    # suite keeps the test env identical.
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── per-tier delta from OSS ────────────────────────────────────────────────
+
+
+def test_oss_to_cloud_starter_adds_starter_features(ent):
+    e = ent._oss_free()
+    diff = e.upgrade_diff(ent.TIER_CLOUD_STARTER)
+    assert diff["target"] == ent.TIER_CLOUD_STARTER
+    assert set(diff["added_features"]) == set(ent.STARTER_FEATURES)
+    # Cloud Starter is a paid tier -> unlocks every paid runtime in one shot.
+    assert set(diff["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_oss_to_cloud_pro_adds_all_paid_features(ent):
+    e = ent._oss_free()
+    diff = e.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert diff["target"] == ent.TIER_CLOUD_PRO
+    assert set(diff["added_features"]) == set(ent.PAID_FEATURES)
+    assert set(diff["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_oss_to_enterprise_adds_paid_and_enterprise_features(ent):
+    e = ent._oss_free()
+    diff = e.upgrade_diff(ent.TIER_ENTERPRISE)
+    assert diff["target"] == ent.TIER_ENTERPRISE
+    assert set(diff["added_features"]) == set(ent.PAID_FEATURES) | set(
+        ent.ENTERPRISE_FEATURES
+    )
+    assert set(diff["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+# ── per-tier delta from a non-OSS starting tier ────────────────────────────
+
+
+def test_starter_to_cloud_pro_adds_only_pro_only_features(ent):
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    diff = e.upgrade_diff(ent.TIER_CLOUD_PRO)
+    # Starter already grants STARTER_FEATURES -- only the pro-only delta
+    # should appear as "added".
+    assert set(diff["added_features"]) == set(ent.PRO_ONLY_FEATURES)
+    # Starter is paid -> already has every paid runtime; nothing to add.
+    assert diff["added_runtimes"] == []
+
+
+def test_cloud_pro_to_enterprise_adds_only_enterprise_features(ent):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    diff = e.upgrade_diff(ent.TIER_ENTERPRISE)
+    assert set(diff["added_features"]) == set(ent.ENTERPRISE_FEATURES)
+    assert diff["added_runtimes"] == []
+
+
+def test_enterprise_to_enterprise_is_empty(ent):
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    diff = e.upgrade_diff(ent.TIER_ENTERPRISE)
+    assert diff["target"] == ent.TIER_ENTERPRISE
+    assert diff["added_features"] == []
+    assert diff["added_runtimes"] == []
+
+
+def test_diff_to_same_or_lower_tier_is_empty(ent):
+    # "Upgrading" from Pro back down to Starter is a no-op for the CTA: the
+    # delta surface is a strict ADD list, so nothing should appear.
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    diff = e.upgrade_diff(ent.TIER_CLOUD_STARTER)
+    assert diff["added_features"] == []
+    assert diff["added_runtimes"] == []
+
+
+# ── safety / fallback ──────────────────────────────────────────────────────
+
+
+def test_unknown_target_returns_empty_lists(ent):
+    diff = ent._oss_free().upgrade_diff("nonsense_tier_xyz")
+    assert diff["target"] == "nonsense_tier_xyz"
+    assert diff["added_features"] == []
+    assert diff["added_runtimes"] == []
+
+
+def test_empty_target_returns_empty_lists(ent):
+    diff = ent._oss_free().upgrade_diff("")
+    assert diff["added_features"] == []
+    assert diff["added_runtimes"] == []
+
+
+def test_target_is_lowercased(ent):
+    # The dashboard renders tier ids verbatim from /api/tiers eventually; an
+    # accidental upper-case query parameter must not produce a phantom miss.
+    diff = ent._oss_free().upgrade_diff("CLOUD_STARTER")
+    assert diff["target"] == ent.TIER_CLOUD_STARTER
+    assert set(diff["added_features"]) == set(ent.STARTER_FEATURES)
+
+
+def test_added_features_are_sorted(ent):
+    diff = ent._oss_free().upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert diff["added_features"] == sorted(diff["added_features"])
+
+
+def test_added_runtimes_are_sorted(ent):
+    diff = ent._oss_free().upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert diff["added_runtimes"] == sorted(diff["added_runtimes"])
+
+
+def test_added_features_never_includes_free(ent):
+    # The delta is a strict ADD list; every entitlement already carries
+    # FREE_FEATURES so they must never appear as "would unlock" copy.
+    diff = ent._oss_free().upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert set(diff["added_features"]).isdisjoint(ent.FREE_FEATURES)
+
+
+# ── module-level convenience function ──────────────────────────────────────
+
+
+def test_module_level_helper_matches_method(ent):
+    # The bare module-level helper resolves the current entitlement and
+    # delegates, so it must agree with the bound method on the same target.
+    target = ent.TIER_CLOUD_PRO
+    assert ent.upgrade_diff(target) == ent.get_entitlement().upgrade_diff(target)
+
+
+def test_module_level_helper_never_raises(monkeypatch, ent):
+    # If get_entitlement somehow raises, the helper must swallow and return
+    # the empty-list shape rather than crash a dashboard render.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    out = ent.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert out["target"] == ent.TIER_CLOUD_PRO
+    assert out["added_features"] == []
+    assert out["added_runtimes"] == []
+
+
+# ── API surface ────────────────────────────────────────────────────────────
+
+
+def test_api_returns_diff_for_starter(client, ent):
+    rv = client.get(f"/api/entitlement/upgrade-diff?target={ent.TIER_CLOUD_STARTER}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == ent.TIER_CLOUD_STARTER
+    assert set(body["added_features"]) == set(ent.STARTER_FEATURES)
+    assert set(body["added_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_api_empty_target_returns_empty_lists_200(client):
+    rv = client.get("/api/entitlement/upgrade-diff")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == ""
+    assert body["added_features"] == []
+    assert body["added_runtimes"] == []
+
+
+def test_api_unknown_target_returns_empty_lists_200(client):
+    rv = client.get("/api/entitlement/upgrade-diff?target=nonsense_tier_xyz")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["target"] == "nonsense_tier_xyz"
+    assert body["added_features"] == []
+    assert body["added_runtimes"] == []


### PR DESCRIPTION
## Summary

Adds the single primitive every paywall / locked-row surface needs: **"what would I get by going to plan X?"**

The dashboard renders an upgrade CTA on every locked runtime row and locked-feature affordance. Today the JS would have to re-derive per-tier feature/runtime membership client-side; this change lets it read the delta off the canonical entitlement layer in one call.

### What landed

- **`Entitlement.upgrade_diff(target_tier) -> dict`** returning `{"target", "added_features", "added_runtimes"}` — the strict ADD list on top of the current entitlement. Free features are intentionally excluded (every entitlement already carries them; the diff is the delta, not the destination set).
- **Module-level `upgrade_diff(target_tier)`** convenience that resolves the current entitlement and delegates. Never raises — any resolution error returns the empty-list shape so a CTA can always render.
- **`GET /api/entitlement/upgrade-diff?target=<tier>`** exposing the same shape. Unknown / empty target returns 200 with empty lists rather than 4xx so a stray query-string typo never crashes the dashboard.
- **`tests/test_entitlement_upgrade_diff.py`** (18 tests) pins:
  - the per-tier delta table (OSS→Starter, OSS→Pro, OSS→Enterprise, Starter→Pro, Pro→Enterprise, same-tier no-op, lower-tier no-op)
  - the lower-cased / sorted / free-excluded invariants
  - the module-level fallback contract
  - the API shape

### Rollout

Pure-data plumbing — **no behaviour change**. Nothing downstream gates on the result yet; this is the read-only primitive the CTA UI will pull from `/api/entitlement` adjunct endpoints. Sits alongside the existing entitlement layer in **GRACE** mode like every other open-core primitive.

### Verification done in this environment

- `python3 -m py_compile` clean on every changed file
- `ruff check` clean on changed files (matches `make lint-py`)
- `pytest tests/test_entitlement_upgrade_diff.py` — 18/18 pass
- `pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py` — 41/41 pass (no sibling regression)

### Local operator verification checklist

The autonomous run cannot reach the running daemon, the live cloud snapshot, or a browser. After CI is green, please run locally before flipping out of draft:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (or pip install -e from this branch)
- [ ] Clear `__pycache__` under the install path so the import picks up the new module-level helper
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon
- [ ] `curl http://localhost:8900/api/entitlement/upgrade-diff?target=cloud_pro` — should return the OSS→Pro delta (every paid feature + every paid runtime)
- [ ] `curl http://localhost:8900/api/entitlement/upgrade-diff` — should return `{"target": "", "added_features": [], "added_runtimes": []}` and **not** 4xx
- [ ] Decrypt the live cloud snapshot and confirm the same shape is reachable through the relay
- [ ] Browser-check the dashboard renders without console errors

### Out of scope

- Frontend wiring of the CTA (waits on the entitlement UI tab refactor)
- Any enforce-mode flip (this is GRACE only, like every entitlement primitive)
- No `__version__` bump, no tag, no `[RELEASE]` — the local operator owns the release flywheel

https://claude.ai/code/session_01VyeYoUGxUGVKrwkJyYNB7X

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyeYoUGxUGVKrwkJyYNB7X)_