### PR TITLE
feat(entitlements): add downgrade_diff(target_tier) -- cancellation / enforce-flip preview

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -674,6 +674,56 @@ class Entitlement:
                 "added_runtimes": [],
             }
 
+    def downgrade_diff(self, target_tier: str) -> dict:
+        """Features + runtimes ``target_tier`` would REMOVE from this
+        entitlement. The symmetric counterpart of :meth:`upgrade_diff`.
+
+        Drives the cancellation / downgrade-warning surface ("Switching to
+        Starter will lock 4 features your team uses + 8 runtimes you've ever
+        ingested") and the enforce-flip preview ("When grace ends you will
+        lose ..."), with ``target_tier=oss`` standing in for the OSS-free
+        floor every install falls back to.
+
+        Returns the same shape regardless of inputs::
+
+            {
+              "target":         "<tier>",        # canonical id (lower-cased)
+              "lost_features":  [...sorted...],  # features the move removes
+              "lost_runtimes":  [...sorted...],  # runtimes the move removes
+            }
+
+        An unknown / empty ``target_tier`` returns empty lists rather than
+        raising, so a stray query-string typo never crashes the dashboard. A
+        same-tier or higher-tier ``target_tier`` returns empty lists because
+        the diff is the strict REMOVE list -- no items move from current to
+        target.
+        """
+        try:
+            tt = (target_tier or "").strip().lower()
+            target_paid_feats = _TIER_FEATURES.get(tt)
+            if target_paid_feats is None:
+                return {"target": tt, "lost_features": [], "lost_runtimes": []}
+            target_feats = FREE_FEATURES | target_paid_feats
+            if tt == TIER_ENTERPRISE:
+                target_feats = target_feats | ENTERPRISE_FEATURES
+            target_runtimes = (
+                FREE_RUNTIMES | PAID_RUNTIMES
+                if tt in _TIER_PAID_RUNTIMES
+                else FREE_RUNTIMES
+            )
+            return {
+                "target": tt,
+                "lost_features": sorted(self.features - target_feats),
+                "lost_runtimes": sorted(self.runtimes - target_runtimes),
+            }
+        except Exception as exc:
+            logger.warning("entitlements: downgrade_diff failed: %s", exc)
+            return {
+                "target": target_tier or "",
+                "lost_features": [],
+                "lost_runtimes": [],
+            }
+
     def grace_remaining_days(self) -> int | None:
         """Days remaining in the grace period, or ``None`` when no enforce-at
         date is announced (``CLAWMETRY_ENFORCE_AT`` unset). Clamps to ``0``
@@ -1113,6 +1163,23 @@ def upgrade_diff(target_tier: str) -> dict:
             "target": target_tier or "",
             "added_features": [],
             "added_runtimes": [],
+        }
+
+
+def downgrade_diff(target_tier: str) -> dict:
+    """Module-level convenience: resolve the current entitlement and return
+    what ``target_tier`` would REMOVE. Same shape as
+    :meth:`Entitlement.downgrade_diff`. Never raises -- any resolution error
+    returns the empty-list shape so the downgrade-warning UI can always
+    render."""
+    try:
+        return get_entitlement().downgrade_diff(target_tier)
+    except Exception as exc:
+        logger.warning("entitlements: downgrade_diff (module) failed: %s", exc)
+        return {
+            "target": target_tier or "",
+            "lost_features": [],
+            "lost_runtimes": [],
         }
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -21,6 +21,10 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          for a feature= or runtime= key.
   GET  /api/entitlement/upgrade-diff  -- features + runtimes a target tier
                                          would add on top of the current ent.
+  GET  /api/entitlement/downgrade-diff -- features + runtimes a target tier
+                                          would REMOVE from the current ent
+                                          (cancellation / downgrade preview;
+                                          target=oss == enforce-flip preview).
   GET  /api/runtimes                  -- the full runtime catalog with
                                          locked/free/tier flags.
   GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
@@ -131,6 +135,37 @@ def api_entitlement_upgrade_diff():
                 "target": (request.args.get("target") or "").strip().lower(),
                 "added_features": [],
                 "added_runtimes": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/downgrade-diff")
+def api_entitlement_downgrade_diff():
+    """Return the features + runtimes ``?target=<tier>`` would REMOVE from the
+    current entitlement. Symmetric counterpart of ``/api/entitlement/upgrade-diff``,
+    drives the cancellation / downgrade preview ("Switching to Starter will
+    lock N features + M runtimes you currently use") and the enforce-flip
+    preview when ``target=oss`` (the floor every install falls back to once
+    grace ends).
+
+    Shape: ``{"target": "<tier>", "lost_features": [...], "lost_runtimes": [...]}``
+
+    Unknown / missing ``target`` returns empty lists rather than 4xx so a
+    stray query-string typo never crashes the dashboard. Same-tier or
+    higher-tier ``target`` also returns empty lists because the diff is the
+    strict REMOVE list. Side-effect-free and never-raise."""
+    try:
+        target = (request.args.get("target") or "").strip().lower()
+        from clawmetry import entitlements as _ent
+
+        return jsonify(_ent.downgrade_diff(target))
+    except Exception as exc:
+        logger.warning("api_entitlement_downgrade_diff: error: %s", exc)
+        return jsonify(
+            {
+                "target": (request.args.get("target") or "").strip().lower(),
+                "lost_features": [],
+                "lost_runtimes": [],
             }
         )
 

--- a/tests/test_entitlement_api.py
+++ b/tests/test_entitlement_api.py
@@ -339,6 +339,84 @@ def test_api_upgrade_diff_starter_subscriber_to_pro(monkeypatch, tmp_path):
     assert d["added_runtimes"] == []
 
 
+# ── downgrade-diff endpoint ──────────────────────────────────────────────────
+
+
+def _client_for_plan(monkeypatch, tmp_path, plan):
+    """Helper -- build a Flask test client for an install on ``plan``."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": plan, "node_limit": 1, "expiry": None}))
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client(), e
+
+
+def test_api_downgrade_diff_pro_to_starter(monkeypatch, tmp_path):
+    c, e = _client_for_plan(monkeypatch, tmp_path, "cloud_pro")
+    resp = c.get("/api/entitlement/downgrade-diff?target=cloud_starter")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["target"] == "cloud_starter"
+    assert set(d["lost_features"]) == set(e.PRO_ONLY_FEATURES)
+    assert d["lost_runtimes"] == []
+    assert d["lost_features"] == sorted(d["lost_features"])
+    assert d["lost_runtimes"] == sorted(d["lost_runtimes"])
+
+
+def test_api_downgrade_diff_pro_to_oss_loses_all_paid(monkeypatch, tmp_path):
+    """Enforce-flip preview: Pro -> OSS removes every paid feature and every
+    paid runtime in one shot. The dashboard renders this as the "you'll lose
+    these when grace ends" panel."""
+    c, e = _client_for_plan(monkeypatch, tmp_path, "cloud_pro")
+    d = c.get("/api/entitlement/downgrade-diff?target=oss").get_json()
+    assert set(d["lost_features"]) == set(e.PAID_FEATURES)
+    assert set(d["lost_runtimes"]) == set(e.PAID_RUNTIMES)
+
+
+def test_api_downgrade_diff_unknown_target_is_empty_not_500(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/downgrade-diff?target=nope")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["target"] == "nope"
+    assert d["lost_features"] == []
+    assert d["lost_runtimes"] == []
+
+
+def test_api_downgrade_diff_missing_target_is_empty(client):
+    c, _ = client
+    resp = c.get("/api/entitlement/downgrade-diff")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["lost_features"] == []
+    assert d["lost_runtimes"] == []
+
+
+def test_api_downgrade_diff_case_insensitive(monkeypatch, tmp_path):
+    c, _ = _client_for_plan(monkeypatch, tmp_path, "cloud_pro")
+    a = c.get("/api/entitlement/downgrade-diff?target=cloud_starter").get_json()
+    b = c.get("/api/entitlement/downgrade-diff?target=CLOUD_STARTER").get_json()
+    assert a["lost_features"] == b["lost_features"]
+    assert a["lost_runtimes"] == b["lost_runtimes"]
+
+
+def test_api_downgrade_diff_from_oss_is_empty(client):
+    """An OSS-free install has nothing paid to lose; every target tier returns
+    empty lists."""
+    c, _ = client
+    for target in ("oss", "cloud_free", "cloud_starter", "cloud_pro", "enterprise"):
+        d = c.get(f"/api/entitlement/downgrade-diff?target={target}").get_json()
+        assert d["lost_features"] == [], target
+        assert d["lost_runtimes"] == [], target
+
+
 # ── grace countdown ───────────────────────────────────────────────────────────
 
 

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -539,6 +539,193 @@ def test_upgrade_diff_case_insensitive_target(ent):
     assert a["added_runtimes"] == b["added_runtimes"] == c["added_runtimes"]
 
 
+# ── downgrade_diff ──────────────────────────────────────────────────────────
+
+
+def test_downgrade_diff_pro_to_starter_loses_only_pro_only_features(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_CLOUD_PRO
+    diff = en.downgrade_diff(ent.TIER_CLOUD_STARTER)
+    assert diff["target"] == ent.TIER_CLOUD_STARTER
+    assert set(diff["lost_features"]) == set(ent.PRO_ONLY_FEATURES)
+    # Both Pro and Starter are paid tiers -> same paid-runtime set -> no
+    # runtimes lost on this hop.
+    assert diff["lost_runtimes"] == []
+    assert diff["lost_features"] == sorted(diff["lost_features"])
+    assert diff["lost_runtimes"] == sorted(diff["lost_runtimes"])
+
+
+def test_downgrade_diff_enterprise_to_pro_loses_only_enterprise_features(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_ENTERPRISE, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_ENTERPRISE
+    diff = en.downgrade_diff(ent.TIER_CLOUD_PRO)
+    assert set(diff["lost_features"]) == set(ent.ENTERPRISE_FEATURES)
+    assert diff["lost_runtimes"] == []
+
+
+def test_downgrade_diff_pro_to_oss_loses_all_paid(ent, tmp_path):
+    """The enforce-flip preview: when grace ends, a Pro install dropping to
+    OSS-free loses every paid feature and every paid runtime in one shot."""
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    diff = en.downgrade_diff(ent.TIER_OSS)
+    assert set(diff["lost_features"]) == set(ent.PAID_FEATURES)
+    assert set(diff["lost_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_downgrade_diff_starter_to_oss_loses_starter_features_and_paid_runtimes(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_STARTER, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    diff = en.downgrade_diff(ent.TIER_OSS)
+    assert set(diff["lost_features"]) == set(ent.STARTER_FEATURES)
+    # PRO_ONLY features were never granted at Starter, so they must not appear
+    # as "lost" -- the diff is the strict REMOVE list from current, not the
+    # gap between target and the top tier.
+    assert set(diff["lost_features"]).isdisjoint(ent.PRO_ONLY_FEATURES)
+    assert set(diff["lost_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_downgrade_diff_oss_to_anywhere_is_empty(ent):
+    """An OSS-free install has nothing paid to lose; every target tier is a
+    no-op for the downgrade preview."""
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_OSS
+    for target in (ent.TIER_OSS, ent.TIER_CLOUD_FREE, ent.TIER_CLOUD_STARTER,
+                   ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE):
+        diff = en.downgrade_diff(target)
+        assert diff["lost_features"] == [], target
+        assert diff["lost_runtimes"] == [], target
+
+
+def test_downgrade_diff_same_tier_is_empty(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    diff = en.downgrade_diff(ent.TIER_CLOUD_PRO)
+    assert diff["lost_features"] == []
+    assert diff["lost_runtimes"] == []
+
+
+def test_downgrade_diff_higher_tier_target_is_empty(ent, tmp_path):
+    """Asking what a *higher* tier would 'remove' is a no-op: the diff is the
+    strict REMOVE list, so nothing should appear."""
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_STARTER, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    diff = en.downgrade_diff(ent.TIER_CLOUD_PRO)
+    assert diff["lost_features"] == []
+    assert diff["lost_runtimes"] == []
+
+
+def test_downgrade_diff_lost_features_never_includes_free(ent, tmp_path):
+    """Free features survive every downgrade (they are in every tier's grant);
+    the REMOVE list must never claim a free feature is lost."""
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    diff = en.downgrade_diff(ent.TIER_OSS)
+    assert set(diff["lost_features"]).isdisjoint(ent.FREE_FEATURES)
+
+
+def test_downgrade_diff_lost_runtimes_never_includes_free(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    diff = en.downgrade_diff(ent.TIER_OSS)
+    assert set(diff["lost_runtimes"]).isdisjoint(ent.FREE_RUNTIMES)
+
+
+def test_downgrade_diff_unknown_target_returns_empty(ent):
+    en = ent.get_entitlement(force=True)
+    diff = en.downgrade_diff("totally-made-up-tier")
+    assert diff["target"] == "totally-made-up-tier"
+    assert diff["lost_features"] == []
+    assert diff["lost_runtimes"] == []
+
+
+def test_downgrade_diff_empty_and_none_targets_are_safe(ent):
+    en = ent.get_entitlement(force=True)
+    for bad in ("", None, "   "):
+        diff = en.downgrade_diff(bad)
+        assert diff["lost_features"] == []
+        assert diff["lost_runtimes"] == []
+
+
+def test_downgrade_diff_case_insensitive_target(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    en = ent.get_entitlement(force=True)
+    a = en.downgrade_diff(ent.TIER_CLOUD_STARTER)
+    b = en.downgrade_diff(ent.TIER_CLOUD_STARTER.upper())
+    c = en.downgrade_diff("  " + ent.TIER_CLOUD_STARTER + "  ")
+    assert a["lost_features"] == b["lost_features"] == c["lost_features"]
+    assert a["lost_runtimes"] == b["lost_runtimes"] == c["lost_runtimes"]
+
+
+def test_downgrade_diff_module_helper_resolves_current(ent, tmp_path):
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    ent.invalidate()
+    direct = ent.get_entitlement(force=True).downgrade_diff(ent.TIER_OSS)
+    via_module = ent.downgrade_diff(ent.TIER_OSS)
+    assert direct == via_module
+
+
+def test_downgrade_diff_module_helper_swallows_resolver_errors(monkeypatch, ent):
+    """If get_entitlement raises, the helper must return the empty-list shape
+    rather than crash a downgrade-warning render."""
+    def boom(*_a, **_kw):
+        raise RuntimeError("synthetic resolver failure")
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    out = ent.downgrade_diff(ent.TIER_OSS)
+    assert out["target"] == ent.TIER_OSS
+    assert out["lost_features"] == []
+    assert out["lost_runtimes"] == []
+
+
+def test_downgrade_diff_is_inverse_of_upgrade_diff_oss_pro(ent, tmp_path):
+    """Round-trip invariant: the features added on the way up from OSS->Pro
+    must equal the features removed on the way back down Pro->OSS (and same
+    for runtimes). Pins the symmetry so a future shuffle of one half cannot
+    silently diverge from the other."""
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": ent.TIER_CLOUD_PRO, "node_limit": 1,
+                                 "expiry": None}))
+    pro = ent.get_entitlement(force=True)
+    down = pro.downgrade_diff(ent.TIER_OSS)
+    oss = ent._oss_free()
+    up = oss.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert set(down["lost_features"]) == set(up["added_features"])
+    assert set(down["lost_runtimes"]) == set(up["added_runtimes"])
+
+
 # ── CLAWMETRY_ENFORCE_AT (grace countdown) ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Symmetric counterpart of the existing `upgrade_diff(target_tier)`: returns the strict **REMOVE** list a user would face moving to a lower tier. Single source of truth so the dashboard never re-derives per-tier feature/runtime membership in JavaScript.

Two surfaces consume it:

1. **Cancellation / downgrade flow** — "Switching to Starter will lock 4 features your team uses + 8 runtimes you've ingested."
2. **Enforce-flip preview** — with `target=oss` it answers "when grace ends, here's what locks" so an OSS install on a `CLAWMETRY_ENFORCE_AT` countdown can show the user exactly what they're about to lose.

### What landed

- **`Entitlement.downgrade_diff(target_tier) -> dict`** returning `{"target", "lost_features", "lost_runtimes"}` mirroring the `upgrade_diff` shape. Free features and free runtimes are intentionally never in the `lost_*` lists because they survive every downgrade.
- **Module-level `downgrade_diff(target_tier)`** convenience that resolves the current entitlement and delegates. Never raises — any resolver error returns the empty-list shape so a downgrade-warning render can always run.
- **`GET /api/entitlement/downgrade-diff?target=<tier>`** exposing the same shape. Unknown / empty `target` returns 200 with empty lists rather than 4xx so a stray query-string typo never crashes the dashboard.
- **Tests** under `tests/test_entitlements.py` (the `downgrade_diff` section, parallel to `upgrade_diff`):
  - the per-tier delta table (pro→starter, enterprise→pro, pro→oss enforce-flip, starter→oss)
  - the lower-cased / sorted / free-excluded invariants
  - the empty-on-unknown / empty-on-same-or-higher contracts
  - the module-helper resolver-fallback contract
  - a **round-trip invariant** pinning `downgrade ↔ upgrade` symmetry: `Pro→OSS lost_*` must equal `OSS→Pro added_*`, so a future reshuffle of one half breaks loudly here instead of silently diverging from the other.
- **Tests** under `tests/test_entitlement_api.py` (the `downgrade-diff endpoint` section): pro→starter, pro→oss enforce-flip, unknown / missing target → 200 with empty lists, case-insensitivity, and oss→* is a full no-op.

### Rollout

Pure-data plumbing — **no behaviour change**. Nothing downstream gates on the result yet; this is the read-only primitive the cancellation / enforce-flip-preview UI will pull from `/api/entitlement` adjunct endpoints. Sits alongside the existing entitlement layer in **GRACE** mode like every other open-core primitive.

### Verification done in this environment

- `python3 -m py_compile` clean on every changed file
- `ruff check` clean on changed files (matches `make lint-py`)
- `pytest tests/test_entitlements.py tests/test_entitlement_api.py` — 108/108 pass (16 new + every prior test, no sibling regression)
- The two pre-existing failures in `tests/test_tier_pro_paywall_no_flash.py` are present on `origin/main` without this branch — confirmed by stashing and re-running — so they are out of scope for this PR.

### Local operator verification checklist

The autonomous run cannot reach the running daemon, the live cloud snapshot, or a browser. After CI is green, please run locally before flipping out of draft:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` (or `pip install -e` from this branch)
- [ ] Clear `__pycache__` under the install path so the import picks up the new `downgrade_diff`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon
- [ ] `curl 'http://localhost:8900/api/entitlement/downgrade-diff?target=oss'` — should return the enforce-flip preview shape (every paid feature + every paid runtime your install carries today)
- [ ] `curl 'http://localhost:8900/api/entitlement/downgrade-diff?target=cloud_starter'` — should return only the PRO_ONLY features (no runtimes) for a Pro install
- [ ] `curl 'http://localhost:8900/api/entitlement/downgrade-diff'` — should return `{"target": "", "lost_features": [], "lost_runtimes": []}` and **not** 4xx
- [ ] Decrypt the live cloud snapshot and confirm the same shape is reachable through the relay
- [ ] Browser-check the dashboard renders without console errors

### Out of scope

- Frontend wiring of the downgrade-warning / enforce-flip-preview panel (waits on the entitlement UI tab refactor)
- Any enforce-mode flip (this is GRACE only, like every entitlement primitive)
- No `__version__` bump, no tag, no `[RELEASE]` — the local operator owns the release flywheel


---
_Generated by [Claude Code](https://claude.ai/code/session_014scgxQpZtCkZM8kpTorWZ1)_