### PR TITLE
feat(entitlements): add previous_purchasable_tier() -- Downgrade-to-X CTA target

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -644,6 +644,69 @@ class Entitlement:
             logger.warning("entitlements: next_purchasable_tier failed: %s", exc)
             return None
 
+    def previous_purchasable_tier(self) -> str | None:
+        """The highest *purchasable* tier id with a strictly lower rank than
+        this entitlement's tier -- the natural target for the cancellation /
+        "Downgrade to ___" CTA, and the input the downgrade-warning surface
+        passes back into :meth:`downgrade_diff` to render "what would I lose?".
+
+        Mirror of :meth:`next_purchasable_tier`: skips :data:`TIER_TRIAL`
+        (promotional grant, not a pickable downgrade target) and returns the
+        member of the next-lower rank cluster that matches this install's
+        source, so:
+
+        * ``enterprise`` (rank 3)         -> ``cloud_pro`` (cloud install)
+                                              or ``pro``     (license install)
+        * ``cloud_pro`` (rank 2)          -> ``cloud_starter``
+        * ``pro`` (rank 2, self-hosted)   -> ``cloud_starter``
+        * ``trial`` (rank 2)              -> ``cloud_starter``
+        * ``cloud_starter`` (rank 1)      -> ``cloud_free`` (cloud install)
+                                              or ``oss``    (license/self-hosted)
+        * ``oss`` / ``cloud_free`` (rank 0) -> ``None`` (already at the floor)
+
+        Source-aware cluster resolution: where multiple purchasable tiers
+        share a rank (``oss``/``cloud_free`` at rank 0, ``pro``/``cloud_pro``
+        at rank 2) a cloud-sourced entitlement picks the ``cloud_``-prefixed
+        sibling (account preserved, paid features removed) while a license /
+        OSS-sourced entitlement picks the self-hosted sibling. Ranks without
+        a cluster just return the only member.
+
+        Unknown tiers are treated as rank ``0`` (the OSS bucket), matching
+        :meth:`next_purchasable_tier` -- a misconfigured plan reports
+        "already at the floor" instead of returning a misleading downgrade
+        target. Never raises.
+
+        Companion to :meth:`downgrade_diff`:
+        ``ent.downgrade_diff(ent.previous_purchasable_tier())`` is the one-call
+        "what would I lose by cancelling one step?" payload.
+        """
+        try:
+            current_rank = max(0, tier_rank(self.tier))
+            lower_ranks = sorted(
+                {tier_rank(t) for t in _PURCHASABLE_TIERS if 0 <= tier_rank(t) < current_rank},
+                reverse=True,
+            )
+            if not lower_ranks:
+                return None
+            target_rank = lower_ranks[0]
+            cluster = [t for t in _PURCHASABLE_TIERS if tier_rank(t) == target_rank]
+            if not cluster:
+                return None
+            if self.source == "cloud":
+                cloud_pick = next((t for t in cluster if t.startswith("cloud_")), None)
+                if cloud_pick is not None:
+                    return cloud_pick
+            else:
+                self_hosted_pick = next(
+                    (t for t in cluster if not t.startswith("cloud_")), None,
+                )
+                if self_hosted_pick is not None:
+                    return self_hosted_pick
+            return cluster[0]
+        except Exception as exc:
+            logger.warning("entitlements: previous_purchasable_tier failed: %s", exc)
+            return None
+
     def upgrade_diff(self, target_tier: str) -> dict:
         """Features + runtimes ``target_tier`` would unlock on top of this
         entitlement. Returns ``{"target": "<tier>", "added_features": [...sorted...],
@@ -991,6 +1054,17 @@ class Entitlement:
             "next_tier_label": (
                 tier_label(self.next_purchasable_tier())
                 if self.next_purchasable_tier() is not None
+                else None
+            ),
+            # Symmetric downgrade target -- the cancellation / "Downgrade to
+            # ___" CTA target. ``None`` once the install is already on the
+            # OSS-free floor. Paired with /api/entitlement/downgrade-diff the
+            # dashboard can render "Cancelling drops you to <prev_tier_label>;
+            # you would lose ..." in one render pass.
+            "prev_tier": self.previous_purchasable_tier(),
+            "prev_tier_label": (
+                tier_label(self.previous_purchasable_tier())
+                if self.previous_purchasable_tier() is not None
                 else None
             ),
         }
@@ -1352,6 +1426,18 @@ def next_purchasable_tier() -> str | None:
         return get_entitlement().next_purchasable_tier()
     except Exception as exc:
         logger.warning("entitlements: next_purchasable_tier (module) failed: %s", exc)
+        return None
+
+
+def previous_purchasable_tier() -> str | None:
+    """Module-level convenience: resolve the current entitlement and return the
+    previous purchasable tier below it -- the dashboard's "Downgrade to ___" /
+    cancellation CTA target. See :meth:`Entitlement.previous_purchasable_tier`
+    for semantics. Never raises; any resolution error returns ``None``."""
+    try:
+        return get_entitlement().previous_purchasable_tier()
+    except Exception as exc:
+        logger.warning("entitlements: previous_purchasable_tier (module) failed: %s", exc)
         return None
 
 

--- a/tests/test_entitlement_prev_tier.py
+++ b/tests/test_entitlement_prev_tier.py
@@ -1,0 +1,216 @@
+"""Tests for ``Entitlement.previous_purchasable_tier()`` + the module-level
+helper.
+
+The dashboard's cancellation / "Downgrade to ___" CTA needs a single,
+canonical "what's the next tier *below* this install?" lookup so the JS
+doesn't re-derive the ladder. This is the symmetric counterpart of
+``next_purchasable_tier`` and these tests pin the table per-tier so a future
+ladder shuffle breaks loudly here instead of silently in the UI.
+"""
+from __future__ import annotations
+
+import importlib
+from dataclasses import replace
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    # Grace mode by default -- previous_purchasable_tier is grace-independent
+    # so this matches every other entitlement test in the suite.
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── per-tier table ──────────────────────────────────────────────────────────
+
+
+def test_oss_has_no_previous_tier(ent):
+    e = ent._build(ent.TIER_OSS, "oss")
+    assert e.previous_purchasable_tier() is None
+
+
+def test_cloud_free_has_no_previous_tier(ent):
+    e = ent._build(ent.TIER_CLOUD_FREE, "cloud")
+    assert e.previous_purchasable_tier() is None
+
+
+def test_cloud_starter_downgrades_to_cloud_free(ent):
+    # Cloud-sourced Starter cancels into cloud_free -- the account is
+    # preserved, only the paid features are removed.
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    assert e.previous_purchasable_tier() == ent.TIER_CLOUD_FREE
+
+
+def test_license_starter_downgrades_to_oss(ent):
+    # A license/self-hosted entitlement at rank 1 collapses to the OSS floor,
+    # not cloud_free -- there is no cloud account to preserve.
+    e = ent._build(ent.TIER_CLOUD_STARTER, "license")
+    assert e.previous_purchasable_tier() == ent.TIER_OSS
+
+
+def test_cloud_pro_downgrades_to_cloud_starter(ent):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    assert e.previous_purchasable_tier() == ent.TIER_CLOUD_STARTER
+
+
+def test_self_hosted_pro_downgrades_to_cloud_starter(ent):
+    e = ent._build(ent.TIER_PRO, "license")
+    assert e.previous_purchasable_tier() == ent.TIER_CLOUD_STARTER
+
+
+def test_trial_downgrades_to_cloud_starter(ent):
+    # Trial shares rank 2 with cloud_pro/self-hosted pro; the next strictly
+    # lower purchasable tier is cloud_starter (rank 1).
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    assert e.previous_purchasable_tier() == ent.TIER_CLOUD_STARTER
+
+
+def test_cloud_enterprise_downgrades_to_cloud_pro(ent):
+    # Cloud-sourced Enterprise steps into cloud_pro -- the cloud-sibling at
+    # rank 2.
+    e = ent._build(ent.TIER_ENTERPRISE, "cloud")
+    assert e.previous_purchasable_tier() == ent.TIER_CLOUD_PRO
+
+
+def test_license_enterprise_downgrades_to_self_hosted_pro(ent):
+    # License-sourced Enterprise (self-hosted) steps into self-hosted pro,
+    # not cloud_pro -- the customer is not in the cloud world.
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    assert e.previous_purchasable_tier() == ent.TIER_PRO
+
+
+# ── safety / fallback ───────────────────────────────────────────────────────
+
+
+def test_unknown_tier_clamps_to_floor(ent):
+    # A misconfigured plan with an unknown tier id should report "already at
+    # the floor" (None) -- unknown tier clamps to rank 0, so there is no lower
+    # purchasable rung to advertise.
+    e = replace(ent._oss_free(), tier="nonsense_tier_xyz")
+    assert e.previous_purchasable_tier() is None
+
+
+def test_returned_tier_is_always_purchasable(ent):
+    # Trial is intentionally excluded from the purchasable ladder; assert that
+    # no tier ever returns trial as its "previous" target.
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        prev = e.previous_purchasable_tier()
+        assert prev != ent.TIER_TRIAL, f"{tier} should not advertise trial as previous"
+
+
+def test_prev_tier_rank_is_strictly_lower(ent):
+    # For every non-floor tier the returned prev-tier must be strictly lower
+    # than the current one. Pins the strict-less invariant against accidental
+    # off-by-one regressions in _PURCHASABLE_TIERS ordering.
+    for tier in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        prev = e.previous_purchasable_tier()
+        assert prev is not None
+        assert ent.tier_rank(prev) < ent.tier_rank(tier)
+
+
+def test_prev_is_inverse_of_next_in_round_trip(ent):
+    # Symmetry sanity: stepping up via next_purchasable_tier and then back
+    # down via previous_purchasable_tier should never advance the rank --
+    # i.e. the down-step must reach the original rank or a rank below it,
+    # never above it. (Strict equality would over-pin since starter/pro have
+    # the cluster of rank-2 tiers sharing one slot in the diff matrix.)
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ):
+        e = ent._build(tier, "test")
+        nxt = e.next_purchasable_tier()
+        if nxt is None:
+            continue
+        stepped_up = ent._build(nxt, "test")
+        back = stepped_up.previous_purchasable_tier()
+        assert back is not None
+        assert ent.tier_rank(back) <= ent.tier_rank(tier)
+
+
+# ── module-level convenience function ───────────────────────────────────────
+
+
+def test_module_level_helper_matches_method(ent):
+    assert (
+        ent.previous_purchasable_tier()
+        == ent.get_entitlement().previous_purchasable_tier()
+    )
+
+
+def test_module_level_helper_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.previous_purchasable_tier() is None
+
+
+# ── to_dict / API surface ───────────────────────────────────────────────────
+
+
+def test_to_dict_omits_prev_for_oss_floor(ent):
+    payload = ent._oss_free().to_dict()
+    assert payload["prev_tier"] is None
+    assert payload["prev_tier_label"] is None
+
+
+def test_to_dict_includes_prev_for_cloud_starter(ent):
+    # Cloud-sourced Starter advertises cloud_free as its cancellation floor.
+    payload = ent._build(ent.TIER_CLOUD_STARTER, "cloud").to_dict()
+    assert payload["prev_tier"] == ent.TIER_CLOUD_FREE
+    assert payload["prev_tier_label"] == ent.tier_label(ent.TIER_CLOUD_FREE)
+
+
+def test_to_dict_includes_prev_for_license_enterprise(ent):
+    # License-sourced Enterprise advertises self-hosted pro as its
+    # cancellation step-down.
+    payload = ent._build(ent.TIER_ENTERPRISE, "license").to_dict()
+    assert payload["prev_tier"] == ent.TIER_PRO
+    assert payload["prev_tier_label"] == ent.tier_label(ent.TIER_PRO)
+
+
+def test_api_entitlement_surfaces_prev_tier(client, ent):
+    # An OSS-default install is already at the floor, so prev_tier is None.
+    rv = client.get("/api/entitlement")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert "prev_tier" in body
+    assert "prev_tier_label" in body
+    assert body["prev_tier"] is None
+    assert body["prev_tier_label"] is None


### PR DESCRIPTION
## Summary

Symmetric counterpart of `next_purchasable_tier()` ([#3179](https://github.com/vivekchand/clawmetry/pull/3179)). Drives the cancellation / "Downgrade to ___" CTA so the dashboard can render the downgrade-warning surface without re-deriving the tier ladder in JS. Pairing the new helper with `downgrade_diff()` ([#3182](https://github.com/vivekchand/clawmetry/pull/3182)) yields the one-call "what would I lose by cancelling one step?" payload.

Grace-independent — wiring this in changes no current behaviour before the enforce phase, same posture as every other helper in `clawmetry/entitlements.py`.

## Details

Adds:

- `Entitlement.previous_purchasable_tier()` method.
- Module-level `previous_purchasable_tier()` convenience (same pattern as `next_purchasable_tier()`).
- `prev_tier` / `prev_tier_label` in `Entitlement.to_dict()`, so `GET /api/entitlement` surfaces the downgrade CTA target alongside the existing `next_tier` upgrade CTA target.

### Source-aware cluster resolution

Where multiple purchasable tiers share a rank (`oss`/`cloud_free` at rank 0, `pro`/`cloud_pro` at rank 2) the helper picks the sibling that matches `Entitlement.source`:

- `source == "cloud"` → picks the `cloud_`-prefixed sibling (account preserved, paid features removed).
- `source == "license"` / `"oss"` → picks the self-hosted sibling (no cloud account to advertise).

`TIER_TRIAL` stays excluded from the purchasable ladder (matches `next_purchasable_tier`'s contract — trial is a promotional grant, not a pickable downgrade target).

Per-tier table:

| Current tier | `previous_purchasable_tier()` |
|---|---|
| `enterprise` (cloud source) | `cloud_pro` |
| `enterprise` (license source) | `pro` |
| `cloud_pro` | `cloud_starter` |
| `pro` (self-hosted) | `cloud_starter` |
| `trial` | `cloud_starter` |
| `cloud_starter` (cloud source) | `cloud_free` |
| `cloud_starter` (license source) | `oss` |
| `oss` / `cloud_free` | `None` (already at the floor) |

## Tests

`tests/test_entitlement_prev_tier.py` (19 tests) — mirror of `tests/test_entitlement_next_tier.py`:

- Per-tier table pinned (both cloud and license source variants for the rank-0 and rank-2 clusters).
- Trial never surfaces as a previous target.
- `prev_tier_rank < current_rank` strict-less invariant.
- Round-trip with `next_purchasable_tier()` never advances rank.
- Module-level helper matches the bound method.
- Module-level helper never raises (synthetic boom in `get_entitlement`).
- `to_dict()` surfaces `prev_tier` + `prev_tier_label`.
- `/api/entitlement` exposes both fields on an OSS-default install.

```
364 passed in 2.79s   (all entitlement test files)
 19 passed            (the new file)
```

Existing `tests/test_entitlement_next_tier.py` continues to pass unchanged.

## Lint

`ruff check` passes on every changed file. The `make lint` failures already on `main` (207 errors in `dashboard.py`) are unrelated to this PR.

## Local operator verification checklist

The bot cannot reach the local daemon, `~/.openclaw`, the live cloud snapshot, or a browser. Please run these locally before flipping the PR out of draft:

- [ ] Copy `clawmetry/entitlements.py` into `~/.clawmetry/lib/python3.*/site-packages/clawmetry/` and the test file into the corresponding `tests/` location.
- [ ] Clear `__pycache__` under the daemon's site-packages copy.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] `curl -s http://localhost:8900/api/entitlement | jq '{prev_tier, prev_tier_label, next_tier, next_tier_label, tier, source}'` — expect `prev_tier` / `prev_tier_label` present (`null` on an OSS-default install).
- [ ] Decrypt the live cloud snapshot, browser-check the dashboard for nothing-visibly-different in the upgrade affordance (this PR only adds API surface; UI wiring is a follow-up).

## What is intentionally **not** in this PR

- No UI wiring — the dashboard does not yet read `prev_tier`. Surface-only landing first so the JS can light it up later without an entitlement-layer dependency.
- No enforce-flip behaviour — grace stays the default; this is a pure additive helper (FLYWHEEL grace invariant).
- No CLI subcommand — `clawmetry tier` already prints the full `to_dict()` so the new fields surface there for free.
- No closed-source / cloud changes (those live in private repos this bot cannot see).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcVuLhdwh5ZyUasnUKai9K)_