### PR TITLE
feat(entitlement): add Entitlement.locked_runtimes() + locked_features() — inverse view of allows_*

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -269,6 +269,44 @@ class Entitlement:
             return False
         return feature in self.features
 
+    def locked_runtimes(self) -> tuple[str, ...]:
+        """Sorted tuple of PAID runtime ids the install currently can NOT
+        observe — the inverse view of :meth:`allows_runtime` restricted to
+        :data:`PAID_RUNTIMES`. Mirrors the ``locked`` flag in
+        :func:`runtime_catalog` exactly: a runtime is "locked" iff
+        ``allows_runtime`` returns ``False``.
+
+        In grace mode the gate passes everything, so the result is ``()``;
+        once enforcement is on (``CLAWMETRY_ENFORCE=1``) it returns the paid
+        runtimes the current tier (and non-expired state) does not unlock,
+        giving the UI a one-call source for a "N runtimes locked — upgrade"
+        badge without iterating :data:`PAID_RUNTIMES` or re-deriving the
+        gate. Free runtimes are never reported (they can never be locked).
+        Never raises.
+        """
+        try:
+            return tuple(sorted(rt for rt in PAID_RUNTIMES if not self.allows_runtime(rt)))
+        except Exception:  # a flaky gate read must never crash a render
+            return ()
+
+    def locked_features(self) -> tuple[str, ...]:
+        """Sorted tuple of PAID feature keys the install does NOT unlock —
+        the inverse view of :meth:`allows_feature` restricted to
+        ``PAID_FEATURES | ENTERPRISE_FEATURES``.
+
+        In grace mode every gate passes, so the result is ``()``; once
+        enforcement is on it returns the paid keys the current tier (and
+        non-expired state) does not grant, giving the UI a single source
+        for a paywall summary off ``/api/entitlement`` without re-deriving
+        feature-set membership on the frontend. Free features are never
+        reported (they can never be locked). Never raises.
+        """
+        try:
+            paid_universe = PAID_FEATURES | ENTERPRISE_FEATURES
+            return tuple(sorted(f for f in paid_universe if not self.allows_feature(f)))
+        except Exception:
+            return ()
+
     def event_retention_days(self) -> int | None:
         """Days of event history this tier may keep. ``None`` means unlimited
         / custom (Enterprise). The daemon's prune loop in ``clawmetry/sync.py``
@@ -299,6 +337,11 @@ class Entitlement:
             "free_runtimes": sorted(FREE_RUNTIMES),
             "paid_runtimes": sorted(PAID_RUNTIMES),
             "all_runtimes": sorted(ALL_RUNTIMES),
+            # Inverse views the UI consumes for paywall summaries — empty in
+            # grace mode (every gate passes), populated once enforcement is
+            # on. See :meth:`locked_runtimes` / :meth:`locked_features`.
+            "locked_runtimes": list(self.locked_runtimes()),
+            "locked_features": list(self.locked_features()),
         }
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -49,6 +49,8 @@ def api_entitlement():
                 "enforced": False,
                 "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
+                "locked_runtimes": [],
+                "locked_features": [],
             }
         )
 

--- a/tests/test_entitlement_locked_helpers.py
+++ b/tests/test_entitlement_locked_helpers.py
@@ -1,0 +1,217 @@
+"""Tests for ``Entitlement.locked_runtimes()`` / ``locked_features()``.
+
+The dashboard wants a single, never-raises source for "what is the paywall
+covering on this install?" so the paywall summary / "N runtimes locked"
+badge does not have to iterate :data:`PAID_RUNTIMES` and re-derive the
+gate. These tests pin the inverse-of-``allows_*`` contract across grace,
+each paid tier, and the expired-license case so a future tier shuffle or
+a misbehaving gate breaks loudly here instead of silently in the UI.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from dataclasses import replace
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── grace mode (the default) ────────────────────────────────────────────────
+
+
+def test_grace_locks_nothing(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.locked_runtimes() == ()
+    assert en.locked_features() == ()
+
+
+# ── enforced: each tier reports the right paid-gap ──────────────────────────
+
+
+def test_oss_enforced_locks_every_paid_runtime_and_feature(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_OSS
+    assert en.grace is False
+    assert set(en.locked_runtimes()) == set(ent.PAID_RUNTIMES)
+    assert set(en.locked_features()) == set(ent.PAID_FEATURES) | set(
+        ent.ENTERPRISE_FEATURES
+    )
+    # Free items must never appear in either list.
+    assert set(en.locked_runtimes()).isdisjoint(ent.FREE_RUNTIMES)
+    assert set(en.locked_features()).isdisjoint(ent.FREE_FEATURES)
+
+
+def test_starter_enforced_locks_pro_only_plus_enterprise(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"plan": "cloud_starter", "node_limit": 1, "expiry": None})
+    )
+    importlib.reload(ent)
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_CLOUD_STARTER
+    # Starter unlocks every paid runtime, so the locked list is empty.
+    assert en.locked_runtimes() == ()
+    # Starter does NOT unlock pro-only or enterprise features.
+    expected = (set(ent.PAID_FEATURES) - set(ent.STARTER_FEATURES)) | set(
+        ent.ENTERPRISE_FEATURES
+    )
+    assert set(en.locked_features()) == expected
+
+
+def test_pro_enforced_locks_only_enterprise_features(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"plan": "cloud_pro", "node_limit": 1, "expiry": None})
+    )
+    importlib.reload(ent)
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_CLOUD_PRO
+    assert en.locked_runtimes() == ()
+    assert set(en.locked_features()) == set(ent.ENTERPRISE_FEATURES)
+
+
+def test_enterprise_enforced_locks_nothing(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"plan": "enterprise", "node_limit": 0, "expiry": None})
+    )
+    importlib.reload(ent)
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.tier == ent.TIER_ENTERPRISE
+    assert en.locked_runtimes() == ()
+    assert en.locked_features() == ()
+
+
+# ── expired entitlement collapses back to the OSS-paywall ───────────────────
+
+
+def test_expired_pro_enforced_locks_every_paid_again(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    expired = ent._build(
+        ent.TIER_CLOUD_PRO,
+        "cloud",
+        node_limit=1,
+        expiry=time.time() - 3600,  # one hour ago
+    )
+    assert expired.expired is True
+    assert set(expired.locked_runtimes()) == set(ent.PAID_RUNTIMES)
+    assert set(expired.locked_features()) == set(ent.PAID_FEATURES) | set(
+        ent.ENTERPRISE_FEATURES
+    )
+
+
+# ── shape invariants ────────────────────────────────────────────────────────
+
+
+def test_locked_runtimes_returns_sorted_tuple(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    locked = en.locked_runtimes()
+    assert isinstance(locked, tuple)
+    assert list(locked) == sorted(locked)
+
+
+def test_locked_features_returns_sorted_tuple(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    locked = en.locked_features()
+    assert isinstance(locked, tuple)
+    assert list(locked) == sorted(locked)
+
+
+def test_locked_helpers_match_allows_inverse(ent, monkeypatch):
+    """Per-item invariant: `locked_*` lists exactly the paid items
+    `allows_*` rejects. Drift between the two would mean the paywall
+    summary and the per-gate decision disagree."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    for rt in ent.PAID_RUNTIMES:
+        assert (rt in en.locked_runtimes()) is (not en.allows_runtime(rt)), rt
+    for f in set(ent.PAID_FEATURES) | set(ent.ENTERPRISE_FEATURES):
+        assert (f in en.locked_features()) is (not en.allows_feature(f)), f
+
+
+def test_locked_helpers_never_raise_on_corrupt_state(ent):
+    """A locked-list call on a deeply broken Entitlement (e.g. ``features``
+    swapped for a non-iterable) must collapse to ``()`` rather than crash a
+    request path."""
+    broken = replace(ent._oss_free(), grace=False, features=None, runtimes=None)
+    assert broken.locked_runtimes() == ()
+    assert broken.locked_features() == ()
+
+
+# ── to_dict / API surface ───────────────────────────────────────────────────
+
+
+def test_to_dict_includes_locked_keys_in_grace(ent):
+    payload = ent._oss_free().to_dict()
+    assert "locked_runtimes" in payload
+    assert "locked_features" in payload
+    assert payload["locked_runtimes"] == []
+    assert payload["locked_features"] == []
+
+
+def test_to_dict_includes_locked_keys_when_enforced(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    payload = ent.get_entitlement(force=True).to_dict()
+    assert set(payload["locked_runtimes"]) == set(ent.PAID_RUNTIMES)
+    assert set(payload["locked_features"]) == set(ent.PAID_FEATURES) | set(
+        ent.ENTERPRISE_FEATURES
+    )
+
+
+def test_api_entitlement_surfaces_locked_keys(client):
+    rv = client.get("/api/entitlement")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert "locked_runtimes" in body
+    assert "locked_features" in body
+    # Default install is OSS in grace -> both empty.
+    assert body["locked_runtimes"] == []
+    assert body["locked_features"] == []


### PR DESCRIPTION
## Summary

Adds two small primitives on `Entitlement` that expose the inverse view of `allows_*` so the dashboard has a single, never-raises source for "what is the paywall covering on this install?":

- `Entitlement.locked_runtimes() -> tuple[str, ...]` — sorted tuple of PAID runtime ids the install currently cannot observe. Mirrors the `locked` flag in `runtime_catalog()` exactly.
- `Entitlement.locked_features() -> tuple[str, ...]` — sorted tuple of PAID feature keys the install does not unlock.

Both methods iterate the paid universe (`PAID_RUNTIMES` / `PAID_FEATURES | ENTERPRISE_FEATURES`) and filter by `not allows_*(...)`. Free items are never reported (they can never be locked). Wrapped in a `try/except` that collapses to `()` so a flaky gate read or a deeply corrupted Entitlement (e.g. a `None` features set) cannot crash a render path — same posture as every other resolver helper.

Surfaced on `to_dict()` as `locked_runtimes` / `locked_features` (lists) so `/api/entitlement` carries them directly. The dashboard can render a "N runtimes / features locked — upgrade to Starter" badge off the existing endpoint without iterating `PAID_RUNTIMES` and re-deriving the gate in JavaScript.

Grace mode (the default) returns empty tuples because every `allows_*` passes — so wiring this in changes no current behaviour. Once enforcement is on (`CLAWMETRY_ENFORCE=1`), the lists populate to the paid items the current tier (and non-expired state) does not grant.

The `/api/entitlement` route fallback (the OSS-free shape returned when the resolver itself blows up) also carries the new keys as empty lists so the API shape stays stable across happy-path and graceful-degradation reads.

## Files

- `clawmetry/entitlements.py` — `Entitlement.locked_runtimes()`, `Entitlement.locked_features()`, surfaced in `to_dict()`.
- `routes/entitlement.py` — fallback shape carries `locked_runtimes` / `locked_features` keys (empty lists).
- `tests/test_entitlement_locked_helpers.py` — 13 tests covering grace mode, each paid tier under enforcement, expired-license collapse, shape invariants, inverse-of-`allows_*` per-item check, and corrupted-state fallback.

## Test plan

- [x] `python3 -m py_compile` clean on `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_locked_helpers.py`.
- [x] `ruff check` clean on changed files.
- [x] `python3 -m pytest tests/test_entitlement_locked_helpers.py` — 13 passed.
- [x] `python3 -m pytest tests/test_entitlements.py tests/test_entitlement_api.py tests/test_entitlements_catalogue.py` — 41 passed (no regression on existing entitlement coverage).

## Local operator verification checklist

The remote agent cannot touch the live daemon, `~/.openclaw`, or the live cloud snapshot. After merge, on the operator's machine:

- [ ] Copy the changed files into the install: `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/` and `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`.
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`.
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
- [ ] `curl -s http://localhost:8900/api/entitlement | jq '{locked_runtimes, locked_features, grace, tier}'` — confirm both keys present, grace=true (default), both empty.
- [ ] Flip enforce on a scratch shell: `CLAWMETRY_ENFORCE=1 python3 -c "from clawmetry import entitlements as e; print(e.get_entitlement(force=True).to_dict()['locked_runtimes'][:3], e.get_entitlement().to_dict()['locked_features'][:3])"` — confirm paid runtimes/features appear sorted.
- [ ] Decrypt the live cloud snapshot in the browser and confirm the existing UI still loads (this PR adds keys, never removes; no JS change required for compatibility).

This PR stays in **GRACE** mode by default — no enforcement flag is flipped, no existing behaviour changes. Pure additive primitive + API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VB7mZ8x3QNDbxNzPp7Zjaw)_