### PR TITLE
fix(entitlement): add locked_runtimes/locked_features to /api/entitlement fallback shape

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -74,6 +74,8 @@ def api_entitlement():
                 "retention_days": 7,
                 "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
+                "locked_runtimes": [],
+                "locked_features": [],
             }
         )
 
@@ -111,6 +113,8 @@ def api_entitlement_refresh():
                 "days_until_enforce": None,
                 "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
+                "locked_runtimes": [],
+                "locked_features": [],
             }
         )
 


### PR DESCRIPTION
## Summary

- `Entitlement.to_dict()` already includes `locked_runtimes` and `locked_features` keys (added when the helpers were merged). The two error-path fallback shapes in `api_entitlement()` and `api_entitlement_refresh()` were missing them.
- A UI client that destructures the response shape unconditionally would throw on the rare resolver-error path.
- Adds the empty-list defaults to make the fallback and happy-path response shapes consistent.

## Files changed

- `routes/entitlement.py`: 4 lines added (2 keys in each of the 2 fallback shapes).

## This supersedes #3184

PR #3184 (`feat(entitlement): add Entitlement.locked_runtimes() + locked_features()`) became unmergeable: the branch was 200+ commits behind main, and main had independently absorbed all of its substantive changes (`locked_runtimes()`/`locked_features()` methods, `to_dict()` keys, test coverage). The only gap that remained was this 4-line fallback fix, extracted here as a fresh PR from main.

## Test plan

- [x] `python3 -m py_compile routes/entitlement.py` clean.
- [x] `git diff` shows exactly 4 lines added, no deletions.
- [x] Happy path: `GET /api/entitlement` goes through `to_dict()` which already returns both keys. No change to happy path.
- [x] Fallback path: `"locked_runtimes": []` and `"locked_features": []` now present in both fallback dicts.

Existing CI covers the full entitlement test suite (13 tests in `tests/test_entitlement_locked_helpers.py`, 41 tests in `tests/test_entitlements.py` + `test_entitlement_api.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017a8HzGt3pH6RreV8g9JgVv)_