### PR TITLE
feat(_gate): include required_tier + canonicalise aliases in require_runtime 402 body

### DIFF
--- a/clawmetry/_gate.py
+++ b/clawmetry/_gate.py
@@ -100,6 +100,22 @@ def gate(feature_key: str) -> Callable:
     return deco
 
 
+def _required_tier_for_runtime(runtime: str) -> str | None:
+    """Cheapest *purchasable* tier id that unlocks ``runtime``.
+
+    Mirrors :func:`_required_tier` (the feature variant): the 402 body
+    needs a target tier so the dashboard can render the correct upgrade
+    CTA instead of a generic one. Defensive: any lookup error returns
+    ``None`` so a flaky entitlement read still produces a valid 402 body.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        return _ent.min_tier_for_runtime(runtime)
+    except Exception:
+        return None
+
+
 def require_runtime(runtime: str):
     """Inline gate for runtime-scoped routes that pick the runtime out of a
     path or body parameter at request time.
@@ -110,6 +126,14 @@ def require_runtime(runtime: str):
     ``runtime``. Defensive: any error inside the entitlement read swallows
     to ``None`` so a flaky lookup never blocks a request that would otherwise
     succeed.
+
+    Alias-tolerant: ``"claude-code"`` / ``"open-claw"`` / etc. are
+    canonicalised via :func:`entitlements.canonical_runtime` before the
+    entitlement check so an alias for a free runtime still passes through.
+
+    The 402 body includes ``required_tier`` (the cheapest purchasable tier
+    that unlocks the runtime) so the dashboard can render the correct
+    upgrade CTA without re-deriving tier logic in JS.
 
     Typical usage::
 
@@ -126,7 +150,11 @@ def require_runtime(runtime: str):
         from flask import jsonify
         from clawmetry import entitlements as _ent
 
-        rt = (runtime or "").strip().lower()
+        raw = (runtime or "").strip().lower()
+        try:
+            rt = _ent.canonical_runtime(raw)
+        except Exception:
+            rt = raw
         en = _ent.get_entitlement()
         if en.allows_runtime(rt):
             return None
@@ -134,6 +162,7 @@ def require_runtime(runtime: str):
             "error": "upgrade_required",
             "runtime": rt,
             "tier": en.tier,
+            "required_tier": _required_tier_for_runtime(rt),
             "hint": (
                 "This runtime ships in the closed-source clawmetry-pro "
                 "package. Install it with a license key or use Cloud Pro at "

--- a/tests/test_gate_runtime.py
+++ b/tests/test_gate_runtime.py
@@ -210,3 +210,90 @@ def test_require_runtime_unknown_runtime_returns_402_when_enforced(enforce):
         result = require_runtime("totally_unknown_xyz")
         assert result is not None
         assert result[1] == 402
+
+
+# -- required_tier + alias canonicalisation -----------------------------------
+
+
+def test_require_runtime_402_body_includes_required_tier(enforce):
+    """The 402 body carries the cheapest purchasable tier that unlocks the
+    runtime so the dashboard can render the correct upgrade CTA without
+    re-deriving tier logic in JS. Mirrors the ``@gate`` feature contract."""
+    from clawmetry._gate import require_runtime
+    from clawmetry import entitlements as _ent
+
+    app = Flask(__name__)
+    with app.test_request_context("/test"):
+        resp, status = require_runtime("claude_code")
+        assert status == 402
+        body = resp.get_json()
+        assert body["required_tier"] == _ent.TIER_CLOUD_STARTER
+
+
+def test_gate_runtime_402_body_includes_required_tier(enforce):
+    """``@gate_runtime`` shares the same 402 body shape as the inline form,
+    so it surfaces ``required_tier`` too."""
+    from clawmetry._gate import gate_runtime
+    from clawmetry import entitlements as _ent
+
+    app = Flask(__name__)
+
+    @app.route("/test")
+    @gate_runtime("codex")
+    def view():
+        return {"ok": True}
+
+    with app.test_client() as c:
+        r = c.get("/test")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["required_tier"] == _ent.TIER_CLOUD_STARTER
+
+
+def test_require_runtime_402_body_required_tier_none_for_unknown(enforce):
+    """Unknown runtimes have no known purchasable tier, so ``required_tier``
+    is ``None`` rather than absent -- the field is part of the contract."""
+    from clawmetry._gate import require_runtime
+
+    app = Flask(__name__)
+    with app.test_request_context("/test"):
+        resp, status = require_runtime("totally_unknown_xyz")
+        assert status == 402
+        body = resp.get_json()
+        assert "required_tier" in body
+        assert body["required_tier"] is None
+
+
+@pytest.mark.parametrize(
+    "alias",
+    ["open-claw", "open_claw", "nemo-claw", "nemo_claw"],
+)
+def test_require_runtime_canonicalises_free_runtime_aliases(enforce, alias):
+    """Aliases for the FREE runtimes (``open-claw`` → ``openclaw``) must
+    pass through even in enforce mode -- they map onto a free runtime."""
+    from clawmetry._gate import require_runtime
+
+    app = Flask(__name__)
+    with app.test_request_context("/test"):
+        assert require_runtime(alias) is None
+
+
+@pytest.mark.parametrize(
+    "alias",
+    ["claude-code", "claudecode", "qwen-code", "qwencode"],
+)
+def test_require_runtime_canonicalises_paid_runtime_aliases(enforce, alias):
+    """Aliases for paid runtimes still get gated, and the 402 body reports
+    the *canonical* runtime id so the UI can render its proper label."""
+    from clawmetry._gate import require_runtime
+    from clawmetry import entitlements as _ent
+
+    app = Flask(__name__)
+    with app.test_request_context("/test"):
+        result = require_runtime(alias)
+        assert result is not None
+        resp, status = result
+        assert status == 402
+        body = resp.get_json()
+        assert body["runtime"] == _ent.canonical_runtime(alias)
+        assert body["required_tier"] == _ent.TIER_CLOUD_STARTER


### PR DESCRIPTION
## What

Bring the runtime gate's 402 body to parity with the feature gate's, and make the runtime check alias-tolerant.

`@gate("feature_key")` already enriches its 402 body with `required_tier` — the cheapest *purchasable* tier id that unlocks the feature — so the dashboard can render the right upgrade CTA (Starter vs Pro vs Enterprise) without re-deriving tier logic in JS. `require_runtime()` / `@gate_runtime()` were missing the equivalent field, so a paid-runtime 402 forced the UI into a generic upgrade prompt.

This change adds two things to `clawmetry/_gate.py`:

1. **`required_tier` on the runtime 402 body.** New `_required_tier_for_runtime()` helper defers to `entitlements.min_tier_for_runtime()`. Defensive: any lookup error returns `None`, so a flaky entitlement read still produces a valid 402 body. The field is *always* present (never absent) — it's part of the contract — and pinned in tests.
2. **Runtime-alias canonicalisation.** Input goes through `entitlements.canonical_runtime()` before the entitlement check so `"claude-code"` → `"claude_code"`, `"open-claw"` → `"openclaw"`, etc. An alias for a FREE runtime now passes through instead of being mis-gated, and the 402 body reports the canonical id so the UI renders the proper label.

## What does NOT change

- **Grace mode is unchanged.** Default behaviour (no `CLAWMETRY_ENFORCE=1`) still passes every runtime through. Nobody on a current install sees a single behavioural shift.
- **No new gates wired anywhere.** This only enriches the body of 402s the runtime gate was *already* returning in enforce mode.
- Existing 402 fields (`error`, `runtime`, `tier`, `hint`) are preserved, casing/whitespace normalisation still works, and the swallow-on-error contract is intact.

## Tests

`tests/test_gate_runtime.py` grows by 8 cases (26 total, all pass):

- `required_tier` for paid runtimes (inline `require_runtime` *and* `@gate_runtime` decorator)
- `required_tier` is `None`, but present, for unknown runtimes
- Free-runtime aliases (`open-claw`, `open_claw`, `nemo-claw`, `nemo_claw`) pass through
- Paid-runtime aliases (`claude-code`, `claudecode`, `qwen-code`, `qwencode`) still 402 and report the canonical id

`ruff check clawmetry/_gate.py tests/test_gate_runtime.py` is clean.

The one failing test in `tests/test_route_gates.py` (`/api/assets` returning 200) pre-exists on `origin/main` and is unrelated to this change — confirmed by re-running with the diff stashed.

## Local operator verification checklist

I can't reach the live daemon / cloud snapshot / browser from CI, so before flipping this out of draft:

- [ ] `cp clawmetry/_gate.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/_gate.py`
- [ ] `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit `/api/entitlement` — should still return the resolved entitlement (no shape regression)
- [ ] With `CLAWMETRY_ENFORCE=1`, hit a runtime-gated paid-runtime endpoint and confirm the 402 body now includes `"required_tier": "cloud_starter"` and the canonical runtime id
- [ ] Confirm `/api/entitlement` / decrypted cloud snapshot / browser dashboard still load normally
- [ ] When happy, mark ready-for-review and merge — the local operator owns release / `[RELEASE]` PR / cloud verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J31bMEzg4h6Yjsmb1oM4sg)_