### PR TITLE
feat(v2): /v2/skills tab — tree, source viewer, fidelity stats

### DIFF
--- a/clawmetry/v2/routes.py
+++ b/clawmetry/v2/routes.py
@@ -703,6 +703,75 @@ def get_fleet():
     return jsonify({"nodes": nodes, "is_single_node": len(nodes) <= 1})
 
 
+# ── Skills API ───────────────────────────────────────────────────────────────
+
+@bp_v2.route("/api/v2/skills", methods=["GET"])
+def get_skills():
+    """Stage A: adapts routes.skills.compute_skills_payload() to the v2 wire shape.
+
+    Wire shape: {tree: [{name, active, dead, header_tokens,
+                          body_fetch_count_7d, linked_file_read_count_7d,
+                          last_used_ts}],
+                 summary: {total_installed, dead_count, wasted_header_tokens}}
+    """
+    try:
+        from routes.skills import compute_skills_payload
+        payload = compute_skills_payload()
+    except Exception:
+        payload = {}
+
+    skills = payload.get("skills") or []
+    summary = payload.get("summary") or {}
+
+    tree = [
+        {
+            "name": s.get("name", ""),
+            "active": s.get("status") not in ("dead", "stuck"),
+            "dead": s.get("status") == "dead",
+            "header_tokens": s.get("header_tokens", 0),
+            "body_fetch_count_7d": s.get("body_fetch_count_7d", 0),
+            "linked_file_read_count_7d": s.get("linked_file_read_count_7d", 0),
+            "last_used_ts": s.get("last_used_ts"),
+        }
+        for s in skills
+    ]
+
+    return jsonify({
+        "tree": tree,
+        "summary": {
+            "total_installed": summary.get("total_installed", 0),
+            "dead_count": summary.get("dead_count", 0),
+            "wasted_header_tokens": summary.get("wasted_header_tokens", 0),
+        },
+    })
+
+
+@bp_v2.route("/api/v2/skills/<name>/source", methods=["GET"])
+def get_skill_source(name: str):
+    """Return SKILL.md contents for a single skill.
+
+    Wire shape: {name, content, language: "markdown"}
+    Returns 400 on invalid name, 404 if not found.
+    """
+    if not name or "/" in name or ".." in name or "\\" in name:
+        return jsonify({"error": "invalid skill name"}), 400
+
+    try:
+        from routes.skills import _find_skill_dir
+        import os as _os
+        skill_dir = _find_skill_dir(name)
+        if not skill_dir:
+            return jsonify({"error": "skill not found"}), 404
+        skill_md = _os.path.join(skill_dir, "SKILL.md")
+        if not _os.path.isfile(skill_md):
+            return jsonify({"error": "SKILL.md not found"}), 404
+        with open(skill_md, "r", errors="replace") as fh:
+            content = fh.read(65_536)  # cap at 64 KB
+        return jsonify({"name": name, "content": content, "language": "markdown"})
+    except Exception:
+        return jsonify({"error": "failed to read skill"}), 500
+
+
 # ── SPA serving ───────────────────────────────────────────────────────────
 # Registered after the API routes. Flask matches by rule specificity, so the
 # explicit /api/v2/* rules still win over the catch-all even in default mode.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { ToolCatalogPage } from "./pages/ToolCatalogPage";
 import { CostPage } from "./pages/CostPage";
 import { ApprovalsPage } from "./pages/ApprovalsPage";
 import { FleetSonarPage } from "./pages/FleetSonarPage";
+import { SkillsPage } from "./pages/SkillsPage";
 
 // Nav slugs that now have a real React page (so the stub fallback skips them).
 const REAL_PAGES = new Set([
@@ -30,6 +31,7 @@ const REAL_PAGES = new Set([
   "cost",
   "approvals",
   "fleet",
+  "skills",
 ]);
 
 // All v2 routes live inside <Layout>, which renders the sidebar + topbar
@@ -57,6 +59,7 @@ export default function App() {
         <Route path="cost" element={<CostPage />} />
         <Route path="approvals" element={<ApprovalsPage />} />
         <Route path="fleet" element={<FleetSonarPage />} />
+        <Route path="skills" element={<SkillsPage />} />
         {NAV_ITEMS.filter((it) => !REAL_PAGES.has(it.id)).map((it) => (
           <Route key={it.id} path={it.id} element={<StubPage slug={it.id} />} />
         ))}

--- a/frontend/src/pages/SkillsPage.tsx
+++ b/frontend/src/pages/SkillsPage.tsx
@@ -1,0 +1,352 @@
+import { useState, useEffect } from "react";
+import { Clawbert } from "../mascot";
+
+interface Skill {
+  name: string;
+  active: boolean;
+  dead: boolean;
+  header_tokens: number;
+  body_fetch_count_7d: number;
+  linked_file_read_count_7d: number;
+  last_used_ts: number | null;
+}
+
+interface SkillsData {
+  tree: Skill[];
+  summary: {
+    total_installed: number;
+    dead_count: number;
+    wasted_header_tokens: number;
+  };
+}
+
+interface SkillSource {
+  name: string;
+  content: string;
+}
+
+function fmtLastUsed(ts: number | null): string {
+  if (!ts) return "never";
+  const secs = Date.now() / 1000 - ts;
+  if (secs < 3600) return `${Math.round(secs / 60)}m ago`;
+  if (secs < 86400) return `${Math.round(secs / 3600)}h ago`;
+  return `${Math.round(secs / 86400)}d ago`;
+}
+
+function SkillRow({
+  skill,
+  selected,
+  onSelect,
+}: {
+  skill: Skill;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <div
+      onClick={onSelect}
+      style={{
+        padding: "7px 12px",
+        cursor: "pointer",
+        borderLeft: selected ? "3px solid var(--claw-red)" : "3px solid transparent",
+        background: selected ? "var(--panel-2)" : "transparent",
+        transition: "background 80ms",
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 11,
+          color: skill.dead ? "var(--ink-4)" : "var(--ink-2)",
+          flex: 1,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          fontFamily: "var(--f-mono)",
+        }}
+      >
+        {skill.name}
+      </span>
+      {skill.body_fetch_count_7d > 0 && (
+        <span
+          className="mono"
+          style={{ fontSize: 9, color: "var(--moss)", flexShrink: 0 }}
+        >
+          {skill.body_fetch_count_7d}×
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function SkillsPage() {
+  const [data, setData] = useState<SkillsData | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [source, setSource] = useState<SkillSource | null>(null);
+  const [sourceLoading, setSourceLoading] = useState(false);
+  const [deadOpen, setDeadOpen] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/v2/skills")
+      .then((r) => r.json())
+      .then((d: SkillsData) => {
+        setData(d);
+        const first = (d.tree ?? []).find((s) => !s.dead);
+        if (first) setSelected(first.name);
+      })
+      .catch(console.error);
+  }, []);
+
+  useEffect(() => {
+    if (!selected) return;
+    setSourceLoading(true);
+    setSource(null);
+    fetch(`/api/v2/skills/${encodeURIComponent(selected)}/source`)
+      .then((r) => r.json())
+      .then((d: SkillSource) => {
+        setSource(d);
+        setSourceLoading(false);
+      })
+      .catch(() => setSourceLoading(false));
+  }, [selected]);
+
+  if (!data) {
+    return (
+      <div style={{ padding: 40, color: "var(--ink-4)" }} className="mono">
+        Loading skills…
+      </div>
+    );
+  }
+
+  if (data.tree.length === 0) {
+    return (
+      <div style={{ padding: "80px 40px", textAlign: "center" }}>
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: 16 }}>
+          <Clawbert size={80} mood="calm" tool="clipboard" />
+        </div>
+        <div style={{ fontSize: 15, color: "var(--ink-3)" }}>
+          No skills here yet. Drop a SKILL.md anywhere in the workspace.
+        </div>
+      </div>
+    );
+  }
+
+  const activeSkills = data.tree.filter((s) => !s.dead);
+  const deadSkills = data.tree.filter((s) => s.dead);
+  const sel = selected ? data.tree.find((s) => s.name === selected) ?? null : null;
+
+  return (
+    <div style={{ flex: 1, display: "flex", minHeight: 0, overflow: "hidden" }}>
+      {/* Left: skill tree */}
+      <div
+        style={{
+          width: 220,
+          flexShrink: 0,
+          borderRight: "1px solid var(--line)",
+          overflow: "auto",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <div
+          className="caps"
+          style={{ color: "var(--ink-4)", padding: "10px 12px 6px", fontSize: 9 }}
+        >
+          Skills · {data.summary.total_installed}
+        </div>
+        {activeSkills.map((s) => (
+          <SkillRow
+            key={s.name}
+            skill={s}
+            selected={selected === s.name}
+            onSelect={() => setSelected(s.name)}
+          />
+        ))}
+        {deadSkills.length > 0 && (
+          <div>
+            <div
+              onClick={() => setDeadOpen((o) => !o)}
+              style={{
+                padding: "7px 12px",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+              }}
+            >
+              <span style={{ fontSize: 9, color: "var(--ink-4)" }}>
+                {deadOpen ? "▾" : "▸"}
+              </span>
+              <span
+                className="mono"
+                style={{ fontSize: 10, color: "var(--ink-4)" }}
+              >
+                _dead/ · {deadSkills.length}
+              </span>
+            </div>
+            {deadOpen &&
+              deadSkills.map((s) => (
+                <SkillRow
+                  key={s.name}
+                  skill={s}
+                  selected={selected === s.name}
+                  onSelect={() => setSelected(s.name)}
+                />
+              ))}
+          </div>
+        )}
+      </div>
+
+      {/* Centre: SKILL.md source viewer */}
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          overflow: "auto",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {selected ? (
+          <>
+            <div
+              style={{
+                padding: "8px 14px",
+                borderBottom: "1px solid var(--line)",
+                fontSize: 11,
+                color: "var(--ink-3)",
+                background: "var(--panel-2)",
+                fontFamily: "var(--f-mono)",
+                flexShrink: 0,
+              }}
+            >
+              {selected}/SKILL.md
+            </div>
+            {sourceLoading ? (
+              <div
+                style={{ padding: 20, color: "var(--ink-4)" }}
+                className="mono"
+              >
+                Loading…
+              </div>
+            ) : (
+              <pre
+                style={{
+                  margin: 0,
+                  padding: "14px 18px",
+                  fontFamily: "var(--f-mono)",
+                  fontSize: 12,
+                  color: "var(--abs-paper)",
+                  lineHeight: 1.7,
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  background: "var(--abs-ink)",
+                  flex: 1,
+                  overflow: "auto",
+                }}
+              >
+                {source?.content ?? "(no content)"}
+              </pre>
+            )}
+          </>
+        ) : (
+          <div
+            style={{ padding: 40, color: "var(--ink-4)" }}
+            className="mono"
+          >
+            Select a skill from the tree.
+          </div>
+        )}
+      </div>
+
+      {/* Right: fidelity stats */}
+      <div
+        style={{
+          width: 192,
+          flexShrink: 0,
+          borderLeft: "1px solid var(--line)",
+          overflow: "auto",
+          padding: "12px 14px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+        }}
+      >
+        <div className="caps" style={{ color: "var(--ink-4)", fontSize: 9 }}>
+          Fidelity
+        </div>
+        {sel ? (
+          <>
+            {(
+              [
+                ["header tok", sel.header_tokens, "var(--ink-2)"],
+                ["body 7d", sel.body_fetch_count_7d, "var(--moss)"],
+                ["linked 7d", sel.linked_file_read_count_7d, "var(--sea, #3b82f6)"],
+                ["last used", fmtLastUsed(sel.last_used_ts), "var(--ink-3)"],
+              ] as [string, string | number, string][]
+            ).map(([label, val, color]) => (
+              <div key={label}>
+                <div
+                  className="caps"
+                  style={{ color: "var(--ink-4)", fontSize: 9 }}
+                >
+                  {label}
+                </div>
+                <div
+                  className="mono"
+                  style={{ fontSize: 16, color, marginTop: 2 }}
+                >
+                  {val}
+                </div>
+              </div>
+            ))}
+            <div
+              style={{
+                borderTop: "1px dashed var(--line)",
+                paddingTop: 10,
+                display: "flex",
+                flexDirection: "column",
+                gap: 5,
+              }}
+            >
+              <div className="caps" style={{ color: "var(--ink-4)", fontSize: 9 }}>
+                workspace
+              </div>
+              {(
+                [
+                  ["installed", data.summary.total_installed, "var(--ink-2)"],
+                  ["dead", data.summary.dead_count, "var(--claw-red)"],
+                  ["wasted tok", data.summary.wasted_header_tokens, "var(--amber)"],
+                ] as [string, number, string][]
+              ).map(([k, v, c]) => (
+                <div
+                  key={k}
+                  style={{ display: "flex", justifyContent: "space-between" }}
+                >
+                  <span
+                    className="mono"
+                    style={{ fontSize: 10, color: "var(--ink-4)" }}
+                  >
+                    {k}
+                  </span>
+                  <span className="mono" style={{ fontSize: 10, color: c }}>
+                    {v}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div
+            className="mono"
+            style={{ fontSize: 10, color: "var(--ink-4)" }}
+          >
+            Select a skill to see stats.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1514

## Summary

- **`clawmetry/v2/routes.py`** — two new endpoints:
  - `GET /api/v2/skills` adapts the existing `routes.skills.compute_skills_payload()` (used by v1 and the cloud snapshot) to the v2 `{tree, summary}` wire shape. No new sync work.
  - `GET /api/v2/skills/<name>/source` reads `SKILL.md` for a given skill (64 KB cap; sanitises path separators).
- **`frontend/src/pages/SkillsPage.tsx`** (new) — three-column layout: skill tree on the left (active skills + collapsible `_dead/` group with count), `SKILL.md` source viewer in the centre (dark `<pre>` background, Stage A — see tradeoff note), fidelity stats on the right (header tokens, 7d body/linked reads, last-used, plus a workspace summary tile).
- **`frontend/src/App.tsx`** — imports `SkillsPage`, adds `"skills"` to `REAL_PAGES`, registers `<Route path="skills" element={<SkillsPage />} />`.

## Tradeoff

Stage A uses `<pre>` instead of `@monaco-editor/react` — full functional spec covered immediately with no new npm deps (~3 MB). Monaco syntax highlighting is a clean follow-up once the bundle-size impact is reviewed.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('clawmetry/v2/routes.py').read())"` — Python syntax clean
- [ ] `GET /api/v2/skills` returns `{tree: [...], summary: {...}}` when `~/.openclaw/skills/` is populated; returns `{tree: [], summary: {total_installed:0, ...}}` when empty
- [ ] `GET /api/v2/skills/<name>/source` returns `{name, content, language:"markdown"}` for a known skill; returns 404 for an unknown skill; returns 400 for a path-traversal attempt (`name` containing `/` or `..`)
- [ ] `/v2/skills` renders the three-column layout (not the "Coming soon" stub) when the v2 flag is on
- [ ] Empty state (no skills installed) shows the Clawbert mascot + the "No skills here yet" message
- [ ] `_dead/` group is collapsed by default; clicking the header expands it

---
_Generated by [Claude Code](https://claude.ai/code/session_011wheeYfXtsxteRRnKtDk81)_