### PR TITLE
feat(_gate): add required_tier to 402 upgrade_required body

### DIFF
--- a/clawmetry/_gate.py
+++ b/clawmetry/_gate.py
@@ -21,7 +21,9 @@ Example::
 
 The error shape matches what ``routes/audit.py`` and ``routes/otel_export.py``
 have been returning by hand for months, so existing front-ends that already
-handle 402 continue to work.
+handle 402 continue to work. ``required_tier`` is included so the dashboard
+can route the user to the *correct* upgrade CTA (Starter vs Pro vs
+Enterprise) without re-deriving tier logic in JavaScript.
 """
 from __future__ import annotations
 
@@ -29,10 +31,29 @@ from functools import wraps
 from typing import Callable
 
 
+def _required_tier(feature_key: str) -> str | None:
+    """Cheapest tier identifier that unlocks ``feature_key``.
+
+    Thin pass-through to :func:`entitlements.min_tier_for_feature` so the
+    402 body has the right "Upgrade to ___" target without the caller
+    needing to know the catalogue. Returns ``None`` for free features,
+    unknown keys, or any lookup error — never raises.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        return _ent.min_tier_for_feature(feature_key)
+    except Exception:
+        return None
+
+
 def gate(feature_key: str) -> Callable:
     """Decorator factory: gate a Flask view on an entitlement feature key.
 
     Returns 402 ``upgrade_required`` JSON when the install lacks the key.
+    The body always carries ``required_tier`` (the cheapest purchasable
+    tier id that unlocks the feature, or ``None`` for free/unknown keys)
+    so the dashboard can render the correct upgrade CTA directly.
     """
     def deco(fn):
         @wraps(fn)
@@ -47,6 +68,7 @@ def gate(feature_key: str) -> Callable:
                         "error": "upgrade_required",
                         "feature": feature_key,
                         "tier": en.tier,
+                        "required_tier": _required_tier(feature_key),
                         "hint": (
                             "This is a paid feature on clawmetry.com/pricing. "
                             "Upgrade or set CLAWMETRY_ENFORCE=0 to disable enforcement."

--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -417,6 +417,34 @@ def runtime_label(runtime: str) -> str:
     return RUNTIME_LABELS.get(rt, rt)
 
 
+def min_tier_for_feature(feature_key: str) -> str | None:
+    """Cheapest tier identifier that unlocks ``feature_key``.
+
+    Returns one of the ``TIER_*`` constants (``cloud_starter``, ``cloud_pro``,
+    ``enterprise``) when the feature is paid, or ``None`` for free / unknown
+    keys. The 402 ``upgrade_required`` body and the dashboard's per-feature
+    paywall both call this so the upgrade CTA renders the right tier card
+    (Starter vs Pro vs Enterprise) without re-deriving the mapping in JS.
+
+    Never raises: any catalogue lookup error returns ``None`` so a flaky
+    read still produces a valid 402 body.
+    """
+    try:
+        key = (feature_key or "").strip()
+        if not key or key in FREE_FEATURES:
+            return None
+        if key in STARTER_FEATURES:
+            return TIER_CLOUD_STARTER
+        if key in PRO_ONLY_FEATURES:
+            return TIER_CLOUD_PRO
+        if key in ENTERPRISE_FEATURES:
+            return TIER_ENTERPRISE
+    except Exception as exc:
+        logger.warning("entitlements: min_tier_for_feature(%r) failed: %s", feature_key, exc)
+        return None
+    return None
+
+
 def runtime_catalog() -> list[dict]:
     """The full runtime catalog with the entitlement-derived availability for
     each entry. Single source of truth the UI uses to render *every* known

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -249,3 +249,54 @@ def test_paid_runtimes_allowed_on_paid_tiers_enforced(ent, monkeypatch, tmp_path
             assert en.allows_runtime(rt) is True, f"{tier}/{rt}"
         for rt in ent.FREE_RUNTIMES:
             assert en.allows_runtime(rt) is True, f"{tier}/{rt}"
+
+
+# ── min_tier_for_feature ─────────────────────────────────────────────────────
+
+
+def test_min_tier_for_feature_starter(ent):
+    """Starter-card features resolve to ``cloud_starter`` so the upgrade CTA
+    routes the user to the cheapest purchasable tier that unlocks them."""
+    for key in ("multi_runtime", "fleet", "all_channels", "budget_limits"):
+        assert ent.min_tier_for_feature(key) == ent.TIER_CLOUD_STARTER, key
+
+
+def test_min_tier_for_feature_pro(ent):
+    """Pro-only features resolve to ``cloud_pro``."""
+    for key in ("self_evolve", "asset_registry", "otel_export", "custom_alerts"):
+        assert ent.min_tier_for_feature(key) == ent.TIER_CLOUD_PRO, key
+
+
+def test_min_tier_for_feature_enterprise(ent):
+    """Enterprise-only features resolve to ``enterprise``."""
+    for key in ("siem_export", "sso", "rbac", "audit_logs"):
+        assert ent.min_tier_for_feature(key) == ent.TIER_ENTERPRISE, key
+
+
+def test_min_tier_for_feature_free_is_none(ent):
+    """Free features never gate-fail; the helper returns ``None`` so a
+    caller can short-circuit instead of rendering an upgrade CTA."""
+    for key in ent.FREE_FEATURES:
+        assert ent.min_tier_for_feature(key) is None, key
+
+
+def test_min_tier_for_feature_unknown_is_none(ent):
+    """Unknown / typo'd keys resolve to ``None`` rather than raising. Keeps
+    the 402 body well-formed when a route uses a feature key that isn't yet
+    in the catalogue (e.g. a clawmetry-pro plugin's private key)."""
+    assert ent.min_tier_for_feature("totally_unknown_feature_xyz") is None
+    assert ent.min_tier_for_feature("") is None
+    assert ent.min_tier_for_feature(None) is None  # type: ignore[arg-type]
+
+
+def test_min_tier_for_feature_swallows_catalogue_errors(ent, monkeypatch):
+    """If a catalogue read itself raises the helper returns ``None`` rather
+    than propagating — the 402 body still serialises and the request path
+    stays defensive."""
+
+    class _Boom:
+        def __contains__(self, _key):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "STARTER_FEATURES", _Boom())
+    assert ent.min_tier_for_feature("self_evolve") is None

--- a/tests/test_route_gates.py
+++ b/tests/test_route_gates.py
@@ -58,6 +58,76 @@ def test_gate_decorator_blocks_in_enforce_mode(enforce):
         assert body["feature"] == "self_evolve"
         assert "tier" in body
         assert "hint" in body
+        # required_tier lets the dashboard render the right "Upgrade to ___"
+        # CTA directly off the 402 body.
+        assert body["required_tier"] == enforce.TIER_CLOUD_PRO
+
+
+# ── required_tier mapping ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "feature_key,expected_tier_attr",
+    [
+        ("multi_runtime", "TIER_CLOUD_STARTER"),
+        ("budget_limits", "TIER_CLOUD_STARTER"),
+        ("self_evolve", "TIER_CLOUD_PRO"),
+        ("otel_export", "TIER_CLOUD_PRO"),
+        ("siem_export", "TIER_ENTERPRISE"),
+        ("sso", "TIER_ENTERPRISE"),
+    ],
+)
+def test_gate_required_tier_routes_to_correct_upgrade(
+    enforce, feature_key, expected_tier_attr
+):
+    """The 402 body carries ``required_tier`` so the UI can render the right
+    upgrade CTA (Starter vs Pro vs Enterprise) without re-deriving tier
+    logic in JavaScript."""
+    from clawmetry._gate import gate
+
+    app = Flask(__name__)
+
+    @app.route("/test")
+    @gate(feature_key)
+    def view():
+        return {"ok": True}
+
+    with app.test_client() as c:
+        r = c.get("/test")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["required_tier"] == getattr(enforce, expected_tier_attr)
+
+
+def test_gate_required_tier_helper_is_none_for_free_feature(enforce):
+    """Free features never produce a 402, but if a caller asks the helper
+    directly it returns ``None`` (no upgrade required)."""
+    from clawmetry._gate import _required_tier
+
+    assert _required_tier("sessions") is None
+    assert _required_tier("usage") is None
+
+
+def test_gate_required_tier_helper_is_none_for_unknown_feature(enforce):
+    """Unknown / typo'd feature keys resolve to ``None`` rather than raising.
+    Keeps the 402 body well-formed when a route uses a key that isn't yet in
+    the catalogue (e.g. a clawmetry-pro plugin's private feature)."""
+    from clawmetry._gate import _required_tier
+
+    assert _required_tier("totally_unknown_feature_xyz") is None
+
+
+def test_gate_required_tier_helper_swallows_entitlement_errors(monkeypatch):
+    """If the catalogue lookup itself raises the helper returns ``None``
+    rather than propagating — the 402 path stays defensive even if a flaky
+    entitlements module is loaded."""
+    from clawmetry import _gate
+
+    def explode(_key):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("clawmetry.entitlements.min_tier_for_feature", explode)
+    assert _gate._required_tier("self_evolve") is None
 
 
 def test_gate_decorator_passes_in_grace_mode(grace):


### PR DESCRIPTION
## What

The `@gate` decorator's 402 `upgrade_required` JSON tells the dashboard the install's *current* tier (`"tier": "free"`) but not which tier to upgrade to. Frontends today either hard-code the feature → tier mapping in JS, or make a follow-up call to `/api/entitlement/required-tier` just to render the right "Upgrade to ___" card.

This PR adds `required_tier` to the 402 body so the dashboard can render the correct upgrade CTA (Starter vs Pro vs Enterprise) **directly off the 402** — no extra request, no parallel mapping in JS.

```diff
 {
   "error": "upgrade_required",
   "feature": "self_evolve",
   "tier": "free",
+  "required_tier": "cloud_pro",
   "hint": "..."
 }
```

## Changes

- **`clawmetry/entitlements.py`** — new `min_tier_for_feature(feature_key)` returning the cheapest `TIER_*` constant that unlocks `feature_key`, or `None` for free / unknown keys. Defensive: any catalogue lookup error swallows to `None` so a flaky read still produces a well-formed 402 body.
- **`clawmetry/_gate.py`** — new `_required_tier(feature_key)` thin pass-through, plus `required_tier` included in the 402 body. Docstring updated.
- **`tests/test_entitlements.py`** — 6 new cases pinning Starter/Pro/Enterprise routing, free + unknown + empty + `None` inputs, and the catalogue-explodes defensive path.
- **`tests/test_route_gates.py`** — 9 new cases (6 parametrised) pinning the `required_tier` field on the live 402 body across the three paid tiers, plus the free/unknown/explode helper paths.

## What does NOT change

- **Grace mode is unchanged.** With `CLAWMETRY_ENFORCE` unset (the default install) no 402 is ever produced — the OSS-free fallback still passes every `allows_*` check, so this is purely additive.
- **Existing 402 fields are preserved** (`error`, `feature`, `tier`, `hint`). Any client that already handles 402 keeps working; `required_tier` is a new key it can adopt incrementally.
- **No new gates wired anywhere.** This only enriches the body of 402s the gate decorator is *already* returning in enforce mode.
- **No new endpoints, dependencies, or migrations.**

## Tests

```
$ python3 -m pytest tests/test_route_gates.py tests/test_entitlements.py \
    tests/test_entitlement_api.py tests/test_entitlements_catalogue.py \
    --deselect tests/test_route_gates.py::test_gated_route_passes_in_grace_mode
64 passed, 1 deselected
```

The one deselected case (`test_gated_route_passes_in_grace_mode`) fails identically on clean `origin/main` (the `/api/assets` blueprint registers a 402-returning gate at import time before the grace fixture can re-read env). Unrelated to this change — confirmed by re-running with the diff stashed.

`ruff check clawmetry/_gate.py clawmetry/entitlements.py` clean.

## Local operator verification checklist

I can't reach the live daemon, cloud snapshot, or browser from CI, so before flipping this out of draft:

- [ ] `cp clawmetry/_gate.py clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/`
- [ ] `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit `/api/entitlement` — should still return the resolved entitlement (no shape regression, this PR doesn't touch routes).
- [ ] With `CLAWMETRY_ENFORCE=1`, hit a paid-feature route (e.g. `/api/selfevolve/status`, `/api/assets`) and confirm the 402 body now includes `"required_tier": "cloud_pro"` for Pro-only features and `"cloud_starter"` for Starter features.
- [ ] Confirm `/api/entitlement` / decrypted cloud snapshot / browser dashboard still load normally.
- [ ] When happy, mark ready-for-review and merge — the local operator owns release / `[RELEASE]` PR / cloud verification.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NXoYdr3ZpJtYjxMEpLqo4x)_