### PR TITLE
feat(_paywall): standardize OSS-stub 402 body with tier + required_tier

### DIFF
--- a/clawmetry/_paywall.py
+++ b/clawmetry/_paywall.py
@@ -1,0 +1,138 @@
+"""Shared 402 ``upgrade_required`` body builder for OSS stub blueprints.
+
+The ``@gate`` decorator in :mod:`clawmetry._gate` covers routes whose
+implementation lives in this OSS repo — it short-circuits paid features
+with a structured 402 when ``CLAWMETRY_ENFORCE=1``. But several blueprints
+in ``routes/`` are pure *OSS stubs* whose real implementation ships in the
+closed-source ``clawmetry-pro`` package and registers via the
+``clawmetry.extensions`` entry point when installed. When ``clawmetry-pro``
+is NOT installed the stub blueprint registers in its place and returns 402
+unconditionally — there is nothing on this install to call.
+
+Those stubs each used to hand-roll their own dict literal. Three of them
+(``routes/selfevolve.py``, ``routes/runtime_ingest.py``,
+``routes/nemoclaw.py``) were missing ``tier``, and none of them carried
+``required_tier`` — so the dashboard could not render the right
+"Upgrade to ___" CTA off the 402 body, the way it already does for
+``@gate`` 402s.
+
+This module centralises the body so a stub blueprint just does::
+
+    from clawmetry._paywall import upgrade_required_body
+
+    @bp.route("/api/foo")
+    def foo_stub():
+        return jsonify(upgrade_required_body("self_evolve")), 402
+
+and the wire shape stays in lockstep with what ``@gate`` returns. The
+helper resolves the install's *current* tier and the feature's *minimum
+unlock tier* at request time, with both lookups defensive — any
+entitlements-module failure degrades to ``tier="oss"`` /
+``required_tier=None`` so the body still serialises.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("clawmetry.paywall")
+
+
+_DEFAULT_HINT = (
+    "This feature ships in the closed-source ``clawmetry-pro`` package. "
+    "Install it with a valid license key, or use ClawMetry Cloud at "
+    "clawmetry.com/pricing."
+)
+
+
+def upgrade_required_body(
+    feature_key: str,
+    *,
+    hint: str | None = None,
+) -> dict:
+    """Build a 402 ``upgrade_required`` JSON body for an OSS stub route.
+
+    Returns a dict whose shape matches ``@gate``'s 402 body so frontends can
+    handle stub-blueprint 402s and gate-decorator 402s with the same code::
+
+        {
+            "error": "upgrade_required",
+            "feature": "<feature_key>",
+            "tier": "<current install tier>",
+            "required_tier": "<min purchasable tier or None>",
+            "hint": "<human-readable copy>",
+        }
+
+    ``feature_key`` is the entitlement feature id the stub stands in for
+    (``self_evolve``, ``custom_runtime_ingest``, ...). It is echoed in the
+    body verbatim so the UI can branch on it without re-deriving the route
+    -> feature mapping.
+
+    ``hint`` overrides the default copy. Pass a feature-specific message
+    when the default ("install clawmetry-pro or use Cloud") is too generic
+    -- e.g. the audit-log stub wants to mention Enterprise specifically.
+
+    The current tier is read via :func:`entitlements.get_entitlement`; the
+    minimum unlock tier via :func:`entitlements.min_tier_for_feature`. Both
+    are wrapped in try/except so a flaky entitlements read collapses to
+    ``tier="oss"`` / ``required_tier=None`` instead of crashing the request.
+
+    Never raises.
+    """
+    tier = "oss"
+    required_tier: str | None = None
+    try:
+        from clawmetry import entitlements as _ent
+
+        try:
+            tier = _ent.get_entitlement().tier
+        except Exception as exc:
+            logger.warning(
+                "_paywall: tier read failed for feature %r: %s",
+                feature_key,
+                exc,
+            )
+        try:
+            required_tier = _min_tier_for_feature(_ent, feature_key)
+        except Exception as exc:
+            logger.warning(
+                "_paywall: min-tier lookup for feature %r failed: %s",
+                feature_key,
+                exc,
+            )
+    except Exception as exc:  # entitlements module itself unimportable
+        logger.warning("_paywall: entitlements import failed: %s", exc)
+
+    return {
+        "error": "upgrade_required",
+        "feature": feature_key,
+        "tier": tier,
+        "required_tier": required_tier,
+        "hint": hint or _DEFAULT_HINT,
+    }
+
+
+def _min_tier_for_feature(ent_module, feature_key: str) -> str | None:
+    """Map ``feature_key`` to the cheapest purchasable tier id that unlocks it.
+
+    Uses the catalogue sets that ``clawmetry/entitlements.py`` already
+    exports (``STARTER_FEATURES``, ``PRO_ONLY_FEATURES``,
+    ``ENTERPRISE_FEATURES``). A free or unknown key returns ``None``: free
+    features don't have an upgrade target, and an unknown key may be a
+    clawmetry-pro plugin's private id we don't have in the OSS catalogue.
+
+    Kept private to this module so it doesn't compete with a future
+    catalogue-level helper in ``entitlements`` (and so the body builder
+    stays self-contained for OSS stubs).
+    """
+    key = (feature_key or "").strip()
+    if not key:
+        return None
+    if key in getattr(ent_module, "FREE_FEATURES", frozenset()):
+        return None
+    if key in getattr(ent_module, "STARTER_FEATURES", frozenset()):
+        return getattr(ent_module, "TIER_CLOUD_STARTER", None)
+    if key in getattr(ent_module, "PRO_ONLY_FEATURES", frozenset()):
+        return getattr(ent_module, "TIER_CLOUD_PRO", None)
+    if key in getattr(ent_module, "ENTERPRISE_FEATURES", frozenset()):
+        return getattr(ent_module, "TIER_ENTERPRISE", None)
+    return None

--- a/routes/audit.py
+++ b/routes/audit.py
@@ -15,6 +15,8 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
+from clawmetry._paywall import upgrade_required_body
+
 logger = logging.getLogger("clawmetry.routes.audit")
 
 bp_audit = Blueprint("audit", __name__)
@@ -33,14 +35,12 @@ def _allowed() -> tuple[bool, dict]:
 
 @bp_audit.route("/api/audit-log", methods=["GET"])
 def api_audit_log():
-    ok, ent = _allowed()
+    ok, _ent = _allowed()
     if not ok:
-        return jsonify({
-            "error": "upgrade_required",
-            "feature": "audit_logs",
-            "tier": ent.get("tier"),
-            "hint": "Audit logs are an Enterprise feature. https://clawmetry.com/pricing",
-        }), 402
+        return jsonify(upgrade_required_body(
+            "audit_logs",
+            hint="Audit logs are an Enterprise feature. https://clawmetry.com/pricing",
+        )), 402
     try:
         from clawmetry import audit as _audit
 

--- a/routes/otel_export.py
+++ b/routes/otel_export.py
@@ -23,6 +23,8 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
+from clawmetry._paywall import upgrade_required_body
+
 logger = logging.getLogger("clawmetry.routes.otel_export")
 
 bp_otel_export = Blueprint("otel_export", __name__)
@@ -123,14 +125,12 @@ def _fetch_events(limit: int) -> list[dict]:
 def api_otel_export():
     """OTLP/JSON export of recent events. Pro+ entitlement-gated; permissive
     during the open-core grace period. Never raises."""
-    allowed, ent = _entitlement_allows()
+    allowed, _ent = _entitlement_allows()
     if not allowed:
-        return jsonify({
-            "error": "upgrade_required",
-            "feature": "otel_export",
-            "tier": ent.get("tier"),
-            "hint": "OTel export is a Pro feature on clawmetry.com/pricing",
-        }), 402
+        return jsonify(upgrade_required_body(
+            "otel_export",
+            hint="OTel export is a Pro feature on clawmetry.com/pricing",
+        )), 402
 
     try:
         limit = max(1, min(int(request.args.get("limit", 200) or 200), 5000))

--- a/routes/runtime_ingest.py
+++ b/routes/runtime_ingest.py
@@ -20,20 +20,24 @@ import logging
 
 from flask import Blueprint, jsonify
 
+from clawmetry._paywall import upgrade_required_body
+
 logger = logging.getLogger("clawmetry.routes.runtime_ingest")
 
 bp_runtime_ingest = Blueprint("runtime_ingest", __name__)
 
 
-# Shared 402 body so the wire format is identical to ``@gate`` enforce-mode.
-_UPGRADE = {
-    "error": "upgrade_required",
-    "feature": "custom_runtime_ingest",
-    "hint": (
-        "Custom runtime ingest is a Pro feature. Install ``clawmetry-pro`` "
-        "with a valid license key, or use Cloud Pro at clawmetry.com/pricing."
-    ),
-}
+# Shared 402 body so the wire format is identical to ``@gate`` enforce-mode
+# (tier + required_tier included so the dashboard can route the right
+# upgrade CTA off the 402 directly).
+_HINT = (
+    "Custom runtime ingest is a Pro feature. Install ``clawmetry-pro`` "
+    "with a valid license key, or use Cloud Pro at clawmetry.com/pricing."
+)
+
+
+def _upgrade():
+    return jsonify(upgrade_required_body("custom_runtime_ingest", hint=_HINT)), 402
 
 
 @bp_runtime_ingest.route("/api/v1/runtimes", methods=["GET"])
@@ -52,27 +56,27 @@ def list_runtimes():
 
 @bp_runtime_ingest.route("/api/v1/runs", methods=["POST"])
 def start_run_stub():
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_runtime_ingest.route("/api/v1/runs/<run_id>/events", methods=["POST"])
 def append_events_stub(run_id: str):
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_runtime_ingest.route("/api/v1/runs/<run_id>/end", methods=["POST"])
 def end_run_stub(run_id: str):
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_runtime_ingest.route("/api/v1/runs/<run_id>", methods=["GET"])
 def get_run_stub(run_id: str):
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_runtime_ingest.route("/api/v1/engines", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
 def engines_stub():
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_runtime_ingest.route(
@@ -80,4 +84,4 @@ def engines_stub():
     methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
 )
 def engines_subpath_stub(subpath: str):
-    return jsonify(_UPGRADE), 402
+    return _upgrade()

--- a/routes/selfevolve.py
+++ b/routes/selfevolve.py
@@ -17,44 +17,46 @@ import logging
 
 from flask import Blueprint, jsonify
 
+from clawmetry._paywall import upgrade_required_body
+
 logger = logging.getLogger("clawmetry.routes.selfevolve")
 
 bp_selfevolve = Blueprint("selfevolve", __name__)
 
 
-_UPGRADE = {
-    "error": "upgrade_required",
-    "feature": "self_evolve",
-    "hint": (
-        "Self-Evolve is a Pro feature. Install ``clawmetry-pro`` with a "
-        "valid license key, or use Cloud Pro at clawmetry.com/pricing."
-    ),
-}
+_HINT = (
+    "Self-Evolve is a Pro feature. Install ``clawmetry-pro`` with a "
+    "valid license key, or use Cloud Pro at clawmetry.com/pricing."
+)
+
+
+def _upgrade():
+    return jsonify(upgrade_required_body("self_evolve", hint=_HINT)), 402
 
 
 @bp_selfevolve.route("/api/selfevolve/status")
 def _status_stub():
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_selfevolve.route("/api/selfevolve/latest")
 def _latest_stub():
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_selfevolve.route("/api/selfevolve/analyze", methods=["POST"])
 def _analyze_stub():
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_selfevolve.route("/api/selfevolve/fix", methods=["POST"])
 def _fix_stub():
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_selfevolve.route("/api/selfevolve/fix/status")
 def _fix_status_stub():
-    return jsonify(_UPGRADE), 402
+    return _upgrade()
 
 
 @bp_selfevolve.route(
@@ -62,4 +64,4 @@ def _fix_status_stub():
     methods=["POST"],
 )
 def _save_as_asset_stub(finding_id: str):
-    return jsonify(_UPGRADE), 402
+    return _upgrade()

--- a/tests/test_paywall_body.py
+++ b/tests/test_paywall_body.py
@@ -1,0 +1,260 @@
+"""Tests for the shared OSS-stub 402 ``upgrade_required`` body builder.
+
+Pins the wire shape :func:`clawmetry._paywall.upgrade_required_body`
+returns and the live 402 bodies emitted by the four stub blueprints that
+adopt it. The shape must stay in lockstep with what ``@gate`` returns so
+the dashboard can branch on the same fields regardless of which path
+produced the 402.
+
+Companion to :mod:`tests.test_route_gates`.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent_grace(monkeypatch, tmp_path):
+    """Reload entitlements with HOME pointed at an empty tmp_path so the
+    resolver collapses to the OSS-free entitlement deterministically."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── upgrade_required_body shape ──────────────────────────────────────────────
+
+
+def test_body_shape_matches_gate_decorator(ent_grace):
+    """The 402 body must carry the same five keys ``@gate`` produces so
+    frontends can branch on either path with one handler."""
+    from clawmetry._paywall import upgrade_required_body
+
+    body = upgrade_required_body("self_evolve")
+    assert set(body.keys()) == {
+        "error",
+        "feature",
+        "tier",
+        "required_tier",
+        "hint",
+    }
+    assert body["error"] == "upgrade_required"
+    assert body["feature"] == "self_evolve"
+
+
+def test_body_required_tier_starter_feature(ent_grace):
+    """A Starter-card feature resolves ``required_tier`` to
+    ``cloud_starter`` -- the cheapest purchasable tier that unlocks it."""
+    from clawmetry._paywall import upgrade_required_body
+
+    for key in ("multi_runtime", "fleet", "all_channels", "budget_limits"):
+        body = upgrade_required_body(key)
+        assert body["required_tier"] == ent_grace.TIER_CLOUD_STARTER, key
+
+
+def test_body_required_tier_pro_feature(ent_grace):
+    """A Pro-only feature resolves ``required_tier`` to ``cloud_pro``."""
+    from clawmetry._paywall import upgrade_required_body
+
+    for key in ("self_evolve", "custom_runtime_ingest", "otel_export"):
+        body = upgrade_required_body(key)
+        assert body["required_tier"] == ent_grace.TIER_CLOUD_PRO, key
+
+
+def test_body_required_tier_enterprise_feature(ent_grace):
+    """An Enterprise-only feature resolves ``required_tier`` to
+    ``enterprise`` so the UI renders the Enterprise CTA, not the Pro one."""
+    from clawmetry._paywall import upgrade_required_body
+
+    for key in ("audit_logs", "sso", "siem_export"):
+        body = upgrade_required_body(key)
+        assert body["required_tier"] == ent_grace.TIER_ENTERPRISE, key
+
+
+def test_body_required_tier_free_feature_is_none(ent_grace):
+    """Free features don't have an upgrade target -- ``required_tier`` is
+    ``None`` so the UI can short-circuit instead of rendering a CTA."""
+    from clawmetry._paywall import upgrade_required_body
+
+    for key in ent_grace.FREE_FEATURES:
+        body = upgrade_required_body(key)
+        assert body["required_tier"] is None, key
+
+
+def test_body_required_tier_unknown_feature_is_none(ent_grace):
+    """An unknown / typo'd feature key collapses to ``None`` rather than
+    raising so a stub for a clawmetry-pro plugin's private key still
+    returns a well-formed 402 body."""
+    from clawmetry._paywall import upgrade_required_body
+
+    body = upgrade_required_body("totally_unknown_feature_xyz")
+    assert body["required_tier"] is None
+    assert body["feature"] == "totally_unknown_feature_xyz"
+    assert body["error"] == "upgrade_required"
+
+
+def test_body_default_hint_used_when_omitted(ent_grace):
+    """Omitting ``hint`` falls back to the default ('install clawmetry-pro
+    or use Cloud') copy so stubs that don't care about the wording don't
+    have to inline a string."""
+    from clawmetry._paywall import upgrade_required_body
+
+    body = upgrade_required_body("self_evolve")
+    assert "clawmetry-pro" in body["hint"]
+    assert body["hint"]  # non-empty
+
+
+def test_body_custom_hint_overrides_default(ent_grace):
+    """A feature-specific hint overrides the default so the audit-log stub
+    can mention Enterprise explicitly, etc."""
+    from clawmetry._paywall import upgrade_required_body
+
+    body = upgrade_required_body("audit_logs", hint="Audit logs are Enterprise.")
+    assert body["hint"] == "Audit logs are Enterprise."
+
+
+def test_body_tier_reflects_current_install(ent_grace):
+    """Free / OSS installs report ``tier="oss"`` in the 402 body so the
+    UI knows where the user is starting from when rendering the upgrade
+    delta."""
+    from clawmetry._paywall import upgrade_required_body
+
+    body = upgrade_required_body("self_evolve")
+    assert body["tier"] == ent_grace.TIER_OSS
+
+
+def test_body_swallows_feature_set_errors(monkeypatch):
+    """If a catalogue set itself raises on membership lookup, the helper
+    still produces a well-formed body with ``required_tier=None`` rather
+    than 500-ing the request."""
+    import clawmetry.entitlements as ent
+    from clawmetry._paywall import upgrade_required_body
+
+    class _Boom:
+        def __contains__(self, _key):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "PRO_ONLY_FEATURES", _Boom())
+    body = upgrade_required_body("self_evolve")
+    assert body["error"] == "upgrade_required"
+    assert body["feature"] == "self_evolve"
+    assert body["required_tier"] is None
+
+
+def test_body_swallows_get_entitlement_errors(monkeypatch):
+    """If ``get_entitlement`` itself raises, ``tier`` falls back to ``oss``
+    rather than crashing the request path."""
+    import clawmetry.entitlements as ent
+    from clawmetry._paywall import upgrade_required_body
+
+    def explode(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "get_entitlement", explode)
+    body = upgrade_required_body("self_evolve")
+    assert body["tier"] == "oss"
+    assert body["error"] == "upgrade_required"
+
+
+# ── live stub-blueprint smoke checks ─────────────────────────────────────────
+
+
+def _make_app_with(blueprint):
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    return app
+
+
+@pytest.mark.parametrize(
+    "path,method,bp_import,expected_feature,expected_required_attr",
+    [
+        # selfevolve stub: 6 endpoints, all return the same body
+        (
+            "/api/selfevolve/status",
+            "GET",
+            "routes.selfevolve:bp_selfevolve",
+            "self_evolve",
+            "TIER_CLOUD_PRO",
+        ),
+        (
+            "/api/selfevolve/latest",
+            "GET",
+            "routes.selfevolve:bp_selfevolve",
+            "self_evolve",
+            "TIER_CLOUD_PRO",
+        ),
+        # runtime_ingest stub: every write endpoint returns 402
+        (
+            "/api/v1/runs",
+            "POST",
+            "routes.runtime_ingest:bp_runtime_ingest",
+            "custom_runtime_ingest",
+            "TIER_CLOUD_PRO",
+        ),
+        (
+            "/api/v1/runs/abc/events",
+            "POST",
+            "routes.runtime_ingest:bp_runtime_ingest",
+            "custom_runtime_ingest",
+            "TIER_CLOUD_PRO",
+        ),
+    ],
+)
+def test_stub_blueprint_402_carries_required_tier(
+    ent_grace,
+    path,
+    method,
+    bp_import,
+    expected_feature,
+    expected_required_attr,
+):
+    """The 402 body emitted by the live stub blueprints carries the full
+    ``{error, feature, tier, required_tier, hint}`` shape so the dashboard
+    can render the right upgrade CTA off the stub 402 the same way it
+    already does off the ``@gate`` 402."""
+    mod_name, attr = bp_import.split(":")
+    bp = getattr(importlib.import_module(mod_name), attr)
+    app = _make_app_with(bp)
+    with app.test_client() as c:
+        r = c.open(path, method=method)
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["error"] == "upgrade_required"
+        assert body["feature"] == expected_feature
+        assert body["tier"] == ent_grace.TIER_OSS
+        assert body["required_tier"] == getattr(ent_grace, expected_required_attr)
+        assert "hint" in body and body["hint"]
+
+
+def test_audit_stub_402_uses_paywall_shape(ent_grace, monkeypatch):
+    """``routes/audit.py`` gates on the Enterprise-only ``audit_logs``
+    feature; forcing the entitlement check to deny exercises the 402 path
+    and the shared body builder. ``required_tier`` must be
+    ``enterprise`` (not ``cloud_pro``) so the UI offers the right plan."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    # Reload so is_enforced() picks up the env change.
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.audit import bp_audit
+
+    app = _make_app_with(bp_audit)
+    with app.test_client() as c:
+        r = c.get("/api/audit-log")
+        assert r.status_code == 402
+        body = r.get_json()
+        assert body["feature"] == "audit_logs"
+        assert body["required_tier"] == e.TIER_ENTERPRISE
+        assert body["tier"] in (e.TIER_OSS, e.TIER_CLOUD_FREE)
+
+    e.invalidate()


### PR DESCRIPTION
## What

The four hand-rolled 402 `upgrade_required` bodies in OSS-stub blueprints each shipped a slightly different shape:

| route | `error` | `feature` | `tier` | `required_tier` | `hint` |
|---|---|---|---|---|---|
| `routes/selfevolve.py` | ✓ | ✓ | ✗ | ✗ | ✓ |
| `routes/runtime_ingest.py` | ✓ | ✓ | ✗ | ✗ | ✓ |
| `routes/audit.py` | ✓ | ✓ | ✓ | ✗ | ✓ |
| `routes/otel_export.py` | ✓ | ✓ | ✓ | ✗ | ✓ |
| `@gate` decorator | ✓ | ✓ | ✓ | ✗ (today) | ✓ |

So the dashboard can't render the right "Upgrade to ___" CTA off a stub 402 — it has no way to know whether the gated feature wants Starter, Pro, or Enterprise.

This PR factors a shared `clawmetry._paywall.upgrade_required_body(feature_key, hint=...)` helper and refactors the four stubs to use it. The wire shape becomes a stable `{error, feature, tier, required_tier, hint}` for every OSS stub, with the per-feature minimum unlock tier resolved at request time:

```diff
 {
   "error": "upgrade_required",
   "feature": "self_evolve",
+  "tier": "oss",
+  "required_tier": "cloud_pro",
   "hint": "..."
 }
```

## Changes

- **`clawmetry/_paywall.py`** *(new, 116 lines)* — `upgrade_required_body(feature_key, *, hint=None)` returning the standardised body. Inline feature→tier mapping against the existing `FREE_FEATURES` / `STARTER_FEATURES` / `PRO_ONLY_FEATURES` / `ENTERPRISE_FEATURES` sets so the PR is self-contained. Every entitlements read is defensive: a flaky catalogue lookup collapses to `tier="oss"` / `required_tier=None` rather than 500-ing the request.
- **`routes/selfevolve.py`** — every stub endpoint now returns the shared body via a `_upgrade()` helper; gains `tier` + `required_tier`.
- **`routes/runtime_ingest.py`** — same refactor; the always-free `GET /api/v1/runtimes` catalogue endpoint is untouched.
- **`routes/audit.py`** — drops its hand-rolled dict literal for the shared helper. The Enterprise-specific hint copy is preserved.
- **`routes/otel_export.py`** — same.
- **`tests/test_paywall_body.py`** *(new)* — 16 cases pinning:
  - the five-key body shape (`error`, `feature`, `tier`, `required_tier`, `hint`)
  - the per-feature `required_tier` mapping (Starter / Pro / Enterprise / free / unknown)
  - default and custom `hint` paths
  - defensive swallowing of catalogue set + `get_entitlement()` failures
  - the live 402 emitted by `selfevolve`, `runtime_ingest`, and `audit` blueprints

## What does NOT change

- **Grace mode is unchanged.** Stub blueprints already returned 402 unconditionally (the impl simply isn't installed) — this PR enriches the *body*, not the status code or the condition under which it fires.
- **`@gate` decorator is not modified.** Its 402 body already carries `tier`; if a future PR adds `required_tier` to `@gate` directly, the helper here can be unified with that path.
- **`routes/nemoclaw.py`** is intentionally left alone — its 402 body uses `feature: "nemo_governance"` which is in `FREE_FEATURES`, so the right fix is a separate design discussion about whether the governance endpoints should be 402-stubbed at all.
- **`routes/insights.py`** is also left alone — it uses a different `{ok: false, error: "pro_required", ...}` envelope.
- **No new endpoints, dependencies, or migrations.**

## Tests

```
$ python3 -m pytest tests/test_paywall_body.py tests/test_oss_stubs_after_pro_move.py \
    tests/test_phase2_stubs.py tests/test_audit.py tests/test_otel_export.py \
    tests/test_route_gates.py tests/test_entitlements.py tests/test_entitlement_api.py \
    tests/test_entitlements_catalogue.py \
    --deselect tests/test_route_gates.py::test_gated_route_passes_in_grace_mode
102 passed, 1 deselected
```

The one deselected case (`test_gated_route_passes_in_grace_mode`) fails identically on clean `origin/main` — confirmed by re-running with the diff stashed. Unrelated to this change; same caveat as the in-flight PR #3190.

`ruff check clawmetry/_paywall.py routes/{selfevolve,runtime_ingest,audit,otel_export}.py tests/test_paywall_body.py` clean.

## Local operator verification checklist

I can't reach the live daemon, cloud snapshot, or browser from CI, so before flipping this out of draft:

- [ ] `cp clawmetry/_paywall.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/`
- [ ] `cp routes/{selfevolve,runtime_ingest,audit,otel_export}.py ~/.clawmetry/lib/python3.*/site-packages/routes/`
- [ ] `find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +`
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit `/api/selfevolve/status` and confirm the 402 body now includes `"tier": "oss"` and `"required_tier": "cloud_pro"`.
- [ ] Hit `/api/v1/runs` with `POST` and confirm the same enrichment.
- [ ] With `CLAWMETRY_ENFORCE=1`, hit `/api/otel/export` and `/api/audit-log` and confirm the bodies carry `required_tier` (`cloud_pro` and `enterprise` respectively).
- [ ] Decrypt the live cloud snapshot and confirm the browser dashboard still loads normally.
- [ ] When happy, mark ready-for-review and merge — release / `[RELEASE]` PR / cloud verification stays with the local operator.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016s1VKUtxtGUumUitHxNmsg)_