### PR TITLE
feat(usage): surface compression-potential card in Usage tab

### DIFF
--- a/clawmetry/static/js/app.js
+++ b/clawmetry/static/js/app.js
@@ -13002,6 +13002,8 @@ async function loadUsage() {
     loadCacheAnalytics();
     // Load cache re-read tax card (issue #2839)
     loadCacheRisk();
+    // Load compression-potential card (issue #2837)
+    loadCompressionPotential();
     // Load cost forecast (issue #1413)
     loadCostForecast();
     // Load per-agent / per-team cost attribution (issue #3000)
@@ -13176,6 +13178,53 @@ async function loadCacheRisk() {
       + '</div></div>';
     document.getElementById('cache-risk-content').innerHTML = html;
   } catch(e) {}
+}
+
+async function loadCompressionPotential() {
+  // Issue #2837 sub-task #1 — surface compression-potential fleet roll-up on the Usage tab.
+  try {
+    var d = await fetch('/api/usage/compression').then(function(r) { return r.json(); });
+    var title = document.getElementById('compression-potential-title');
+    var card = document.getElementById('compression-potential-card');
+    if (!title || !card) return;
+    var sessions = Number(d.compressible_sessions) || 0;
+    if (!sessions) return;
+    title.style.display = '';
+    card.style.display = '';
+    var toks = Number(d.compressible_tokens) || 0;
+    var usd = Number(d.recoverable_usd) || 0;
+    var total = Number(d.total_sessions) || 0;
+    var pct = total > 0 ? Math.round(sessions / total * 100) : 0;
+    var byType = d.by_type || {};
+
+    function fmtToks(n) { return n >= 1e6 ? (n/1e6).toFixed(1)+'M' : n >= 1e3 ? (n/1e3).toFixed(0)+'K' : String(n||0); }
+    function fmtCost(c) { return c >= 0.01 ? '$'+c.toFixed(2) : c > 0 ? '<$0.01' : '$0.00'; }
+
+    var html = '<div style="display:flex;gap:24px;flex-wrap:wrap;align-items:flex-start;">'
+      + '<div style="min-width:140px;text-align:center;">'
+      + '<div style="font-size:28px;font-weight:700;color:#f59e0b;">'+fmtToks(toks)+'</div>'
+      + '<div style="font-size:11px;color:var(--text-muted);margin-top:2px;">compressible tokens</div>'
+      + (usd > 0 ? '<div style="font-size:12px;color:#22c55e;margin-top:4px;font-weight:600;">'+fmtCost(usd)+' recoverable</div>' : '')
+      + '</div>'
+      + '<div style="flex:1;min-width:200px;font-size:13px;color:var(--text-secondary);">'
+      + '<div style="margin-bottom:6px;"><strong>'+sessions+'</strong> of '+total+' sessions ('+pct+'%) have compressible tool output.'
+      + ' Summarising repeated JSON, diffs, or log blobs before context re-injection could recover these tokens.</div>';
+
+    var typeKeys = Object.keys(byType);
+    if (typeKeys.length > 0) {
+      html += '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:4px;">';
+      typeKeys.sort(function(a, b) { return (byType[b]||0) - (byType[a]||0); }).forEach(function(k) {
+        html += '<span style="font-size:11px;padding:2px 8px;border-radius:10px;background:var(--bg-secondary);color:var(--text-muted);">'
+          + escHtml(k)+' '+fmtToks(byType[k])+'</span>';
+      });
+      html += '</div>';
+    }
+
+    html += '</div></div>';
+    document.getElementById('compression-potential-content').innerHTML = html;
+  } catch(e) {
+    // Compression panel is optional — skip silently on error
+  }
 }
 
 async function loadCacheAnalytics() {

--- a/clawmetry/templates/tabs/usage.html
+++ b/clawmetry/templates/tabs/usage.html
@@ -61,6 +61,11 @@
   <div class="card" id="cache-risk-card" style="display:none;">
     <div id="cache-risk-content" style="min-height:48px;color:var(--text-muted);"></div>
   </div>
+  <!-- Compression Potential card (issue #2837) — recoverable tokens from compressible tool output -->
+  <div class="section-title" id="compression-potential-title" style="display:none;">🗜 Compression Potential <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;">compressible tool output · recoverable tokens</span></div>
+  <div class="card" id="compression-potential-card" style="display:none;">
+    <div id="compression-potential-content" style="min-height:48px;color:var(--text-muted);"></div>
+  </div>
   <!-- Issue #68 — top sessions by cost (per-session breakdown) -->
   <div class="section-title">🏆 <span data-i18n="usage.top_sessions_by_cost">Top Sessions by Cost</span> <span style="font-size:11px;font-weight:400;color:var(--text-muted);margin-left:8px;" data-i18n="usage.top_sessions_hint">which session burned the budget · top 20</span></div>
   <div class="card"><table class="usage-table" id="usage-top-sessions-table"><tbody><tr><td colspan="6" style="color:#666;" data-i18n="app.loading">Loading...</td></tr></tbody></table></div>

--- a/routes/usage.py
+++ b/routes/usage.py
@@ -4481,3 +4481,64 @@ def api_efficiency():
         entry["runtime"] = runtime
         return jsonify(entry)
     return jsonify(out)
+
+
+# ---------------------------------------------------------------------------
+# Issue #2837 sub-task #1 — Compression Potential card
+# ---------------------------------------------------------------------------
+
+def _agg_compression(rows):
+    """Aggregate per-session compression-potential fields into fleet totals.
+
+    Thresholds mirror _derive_waste_summary: a session qualifies when
+    compression_potential_pct >= 50 AND compressible_tool_tokens >= 2000.
+    Returns {} when no sessions clear the thresholds (so callers can skip
+    rendering the card entirely).
+    """
+    if not rows:
+        return {}
+    compressible_sessions = 0
+    compressible_tokens = 0
+    recoverable_usd = 0.0
+    by_type = {}
+    for s in rows:
+        try:
+            pct = float(s.get("compression_potential_pct") or 0)
+            toks = int(s.get("compressible_tool_tokens") or 0)
+        except (TypeError, ValueError):
+            continue
+        if pct < 50 or toks < 2000:
+            continue
+        compressible_sessions += 1
+        compressible_tokens += toks
+        try:
+            recoverable_usd += float(s.get("compression_recoverable_usd") or 0)
+        except (TypeError, ValueError):
+            pass
+        ctype = s.get("dominant_compression_type") or "mixed"
+        by_type[ctype] = by_type.get(ctype, 0) + toks
+    if compressible_sessions == 0:
+        return {}
+    return {
+        "compressible_sessions": compressible_sessions,
+        "total_sessions": len(rows),
+        "compressible_tokens": compressible_tokens,
+        "recoverable_usd": round(recoverable_usd, 4),
+        "by_type": by_type,
+    }
+
+
+@bp_usage.route("/api/usage/compression")
+def api_usage_compression():
+    """Compression-potential roll-up for the Usage tab card (issue #2837).
+
+    Reads per-session compression fields written by the sync daemon and
+    returns fleet-level aggregates. Returns {} when no sessions clear the
+    thresholds so the JS can hide the card without any special-casing.
+    Never 500s.
+    """
+    try:
+        rows = _ls_call("query_sessions_table", limit=2000) or []
+        return jsonify(_agg_compression(rows))
+    except Exception:
+        return jsonify({})

--- a/tests/test_compression_potential.py
+++ b/tests/test_compression_potential.py
@@ -4,9 +4,13 @@ aggregation that surfaces it (#2839 cache-risk roll-up).
 Measurement only: we assert the heuristics classify content correctly, the
 detector estimates recoverable token share, persists ONLY aggregates (never raw
 content), and the waste summary rolls per-session metrics into fleet figures.
+
+Also covers _agg_compression (issue #2837 sub-task #1) — the Usage-tab
+endpoint helper that rolls per-session fields into fleet totals.
 """
 import clawmetry.sync as S
 from routes.sessions import _derive_waste_summary
+from routes.usage import _agg_compression
 
 
 class _Ev:
@@ -67,3 +71,42 @@ def test_waste_summary_rolls_up_compression_and_cache_expiry():
     assert round(w["compressible_usd"], 2) == 0.02
     assert w["cache_expiry_sessions"] == 1
     assert w["cache_expiry_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# _agg_compression (issue #2837 sub-task #1)
+# ---------------------------------------------------------------------------
+
+def test_agg_compression_rolls_up_qualifying_sessions():
+    rows = [
+        {"compression_potential_pct": 85.0, "compressible_tool_tokens": 5000,
+         "compression_recoverable_usd": 0.03, "dominant_compression_type": "json"},
+        {"compression_potential_pct": 60.0, "compressible_tool_tokens": 3000,
+         "compression_recoverable_usd": 0.01, "dominant_compression_type": "diff"},
+        # below threshold: pct < 50
+        {"compression_potential_pct": 30.0, "compressible_tool_tokens": 5000,
+         "compression_recoverable_usd": 0.01},
+        # below threshold: tokens < 2000
+        {"compression_potential_pct": 80.0, "compressible_tool_tokens": 500,
+         "compression_recoverable_usd": 0.01},
+    ]
+    out = _agg_compression(rows)
+    assert out["compressible_sessions"] == 2
+    assert out["total_sessions"] == 4
+    assert out["compressible_tokens"] == 8000
+    assert round(out["recoverable_usd"], 2) == 0.04
+    assert out["by_type"]["json"] == 5000
+    assert out["by_type"]["diff"] == 3000
+
+
+def test_agg_compression_empty_input():
+    assert _agg_compression([]) == {}
+    assert _agg_compression(None) == {}
+
+
+def test_agg_compression_all_below_threshold():
+    rows = [
+        {"compression_potential_pct": 40.0, "compressible_tool_tokens": 10000},
+        {"compression_potential_pct": 90.0, "compressible_tool_tokens": 100},
+    ]
+    assert _agg_compression(rows) == {}


### PR DESCRIPTION
## Summary

Closes #2837 (sub-task #1 — Compression Potential card).

`compressionPotentialPct` / `compressibleToolTokens` / `compressionRecoverableUsd` are already computed by the sync daemon and stored in DuckDB session metadata, but were never rolled up or shown in the Usage tab. This PR surfaces them.

- **`routes/usage.py`** — `_agg_compression(rows)` helper aggregates per-session fields (thresholds: `pct ≥ 50` AND `tokens ≥ 2000`, matching `_derive_waste_summary`) + `GET /api/usage/compression` endpoint backed by `_ls_call("query_sessions_table", limit=2000)`
- **`clawmetry/templates/tabs/usage.html`** — `#compression-potential-card` section (hidden until JS reveals it), placed after the existing cache-risk card
- **`clawmetry/static/js/app.js`** — `loadCompressionPotential()` async function mirrors `loadCacheRisk()`; called from `loadUsage()`. Card only appears when `compressible_sessions > 0`.
- **`tests/test_compression_potential.py`** — 3 new unit tests for `_agg_compression`: success path, empty input, and all-below-threshold → `{}`

## Test plan

- [ ] `python -m pytest tests/test_compression_potential.py -v` — 8 passed (5 pre-existing + 3 new)
- [ ] `GET /api/usage/compression` returns `{}` when no sessions clear thresholds; card stays hidden
- [ ] With qualifying sessions in DuckDB the card renders token count, recoverable USD, and per-type breakdown badges
- [ ] No regressions in cache-perf, cache-risk, or other Usage tab cards

---
_Generated by [Claude Code](https://claude.ai/code/session_012AiS2sqTNykSvH8YVkEaJH)_