### PR TITLE
fix(ci): cache Playwright browsers + raise OSS Golden Path timeout to 8 min

### DIFF
--- a/.github/workflows/oss-golden-path.yml
+++ b/.github/workflows/oss-golden-path.yml
@@ -2,7 +2,8 @@ name: OSS Golden Path (C1)
 
 # C1 gate: wheel install + real OpenClaw + synthetic session + 9 tabs render
 # without auth errors. Hard gate on every PR, no continue-on-error.
-# Budget: 5 minutes wall-clock.
+# Budget: 8 minutes wall-clock (raised from 5; Playwright chromium download
+# ~100 MB takes up to 4.5 min on a cold runner -- cache hit drops it to ~30 s).
 # Tracking: vivekchand/clawmetry#1646 (C1)
 
 on:
@@ -18,7 +19,7 @@ jobs:
   oss-golden-path:
     name: OSS golden path (wheel + OpenClaw + 9 tabs)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
 
     steps:
       - uses: actions/checkout@v6
@@ -26,6 +27,16 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+
+      # Cache the ~100 MB Playwright chromium binary so the download step
+      # takes seconds rather than minutes on warm runners.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('setup.py', 'requirements.txt') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
 
       # Step 1 -- build the wheel from source and install into an isolated venv.
       # This proves the wheel ships all runtime assets (same surface as the


### PR DESCRIPTION
## Problem

OSS Golden Path (C1) run #2087 (2026-06-18T18:06:32Z, commit `1b348ff`) timed out and was cancelled. The job's 5-minute `timeout-minutes` budget was almost entirely consumed by "Install Playwright browsers" (4 min 33 s), leaving no time for the actual golden-path test to run.

Step breakdown that shows the squeeze:
- Steps 1-11 (checkout through session sync): ~38 s
- Step 12 (Install Playwright browsers): ~4 min 33 s (100 MB chromium + system deps)
- Step 13 (Run OSS golden path test): never reached

This is intermittent: when a GitHub-hosted runner has the Playwright binary warm from a prior run, install takes ~30 s and the job passes easily (see run #2085, same workflow file, earlier commit, succeeded in under 5 min). On a cold runner the 100 MB download kills the budget.

## Fix

1. **Cache `~/.cache/ms-playwright`** keyed on OS + `setup.py`/`requirements.txt`. Cache hit drops the browser-download portion from ~4 min to ~5 s; only `apt-get --with-deps` (system libs, ~30 s) still runs every time.

2. **Raise `timeout-minutes` from 5 to 8** so even a cold-cache run (worst case ~5-6 min total) has headroom rather than racing the clock.

## Evidence

| Run | Conclusion | Playwright step |
|-----|------------|-----------------|
| #2087 (cold runner, no cache) | cancelled | 4 min 33 s, timed out |
| #2085 (prior commit, warm runner) | success | under budget |

Cache + timeout bump together make the cold-runner case safe while keeping the gate strict.

## Checklist

- [x] No em-dashes in user-facing copy
- [x] No direct push to main
- [x] Fix is in CI config only, no code logic change
- [x] Evidence of failure documented above

Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Ac2NEvUxCghNsj1eampTGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ac2NEvUxCghNsj1eampTGR)_