### PR TITLE
feat(cli): `clawmetry features` — list every feature + lock state (sibling of `runtimes`)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -3057,6 +3057,95 @@ def _cmd_runtimes(args) -> None:
         print("  Upgrade: clawmetry license activate <KEY>")
 
 
+def _cmd_features(args) -> None:
+    """clawmetry features — list every observable feature and which are unlocked.
+
+    Sibling of :func:`_cmd_runtimes`: that one answers "which runtimes is
+    this install cleared to observe?", this one answers the same question
+    for features. Reads :func:`clawmetry.entitlements.feature_catalog` --
+    the same source the dashboard's ``GET /api/features`` consumes -- so the
+    CLI and the UI cannot drift on the locked-but-visible upgrade affordance.
+
+    Never raises. A poisoned catalog read surfaces the error inline (a
+    warning row in the human table, or an ``error`` key on the JSON payload
+    with ``features=[]``) so a wrapper script always sees a parseable
+    response. Matches the never-crash contract documented on
+    :func:`get_entitlement`.
+
+    Output:
+      default -- compact table (id, label, tier, status)
+      --json  -- ``{tier, grace, enforced, features: [...], error?: str}``
+    """
+    import json as _json
+
+    from clawmetry import entitlements as _ent
+
+    try:
+        ent = _ent.get_entitlement()
+        tier = ent.tier
+        grace = bool(ent.grace)
+        enforced = _ent.is_enforced()
+    except Exception as exc:
+        # Mirror _cmd_runtimes' never-crash fallback: a broken install still
+        # gets a parseable shape, with the failure surfaced to stderr so it
+        # isn't silently lost in a pipeline.
+        print(f"⚠️  entitlement resolution failed: {exc}", file=sys.stderr)
+        tier, grace, enforced = "oss", True, False
+
+    rows: list[dict] = []
+    catalog_error: str | None = None
+    try:
+        rows = list(_ent.feature_catalog())
+    except Exception as exc:
+        catalog_error = str(exc)
+
+    if getattr(args, "as_json", False):
+        payload: dict = {
+            "tier": tier,
+            "grace": grace,
+            "enforced": enforced,
+            "features": rows,
+        }
+        if catalog_error:
+            payload["error"] = catalog_error
+        print(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    mode_line = "off (grace)" if not enforced else "on"
+    print("ClawMetry Features\n" + "─" * 40)
+    print(f"  Tier:        {tier}")
+    print(f"  Enforcement: {mode_line}")
+    if catalog_error:
+        print(f"  ⚠️  catalog error: {catalog_error}")
+        return
+
+    any_locked = False
+    print()
+    print(f"  {'ID':<28} {'Label':<28} {'Tier':<14} Status")
+    print("  " + "─" * 80)
+    for row in rows:
+        # Alias rows duplicate a canonical feature -- hide them so the table
+        # mirrors the upgrade affordance shown in /pricing rather than
+        # advertising deprecated names.
+        if row.get("alias"):
+            continue
+        fid = str(row.get("id", ""))
+        label = str(row.get("label", fid))
+        feat_tier = str(row.get("tier", "oss"))
+        is_free = bool(row.get("free", False))
+        locked = bool(row.get("locked", False))
+        if locked:
+            status = "🔒 locked"
+            any_locked = True
+        else:
+            status = "✅ available"
+        tier_tag = "free" if is_free else feat_tier
+        print(f"  {fid:<28} {label:<28} {tier_tag:<14} {status}")
+    if any_locked:
+        print()
+        print("  Upgrade: clawmetry license activate <KEY>")
+
+
 def _cmd_verify_integrity(args) -> None:
     """clawmetry verify-integrity — walk the hash chain and report validity."""
     from clawmetry.local_store import get_store
@@ -3488,6 +3577,21 @@ def main() -> None:
         help="Emit {tier, grace, enforced, runtimes:[...]} JSON (jq-friendly)",
     )
 
+    # features — list every observable feature and which are unlocked.
+    # CLI sibling of `clawmetry runtimes` and of the dashboard's GET
+    # /api/features so the operator can answer "what does this tier unlock?"
+    # from the shell without parsing `tier --json`.
+    p_features = sub.add_parser(
+        "features",
+        help="List every observable feature and which this install can unlock",
+    )
+    p_features.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit {tier, grace, enforced, features:[...]} JSON (jq-friendly)",
+    )
+
     # verify-integrity — walk hash chain and report validity (Issue #2200)
     p_verify = sub.add_parser(
         "verify-integrity",
@@ -3518,6 +3622,7 @@ def main() -> None:
         "license",
         "tier",
         "runtimes",
+        "features",
         "verify-integrity",
         "nemoclaw-daemons",
     )
@@ -3557,6 +3662,8 @@ def main() -> None:
             _cmd_tier(args)
         elif args.cmd == "runtimes":
             _cmd_runtimes(args)
+        elif args.cmd == "features":
+            _cmd_features(args)
         elif args.cmd == "verify-integrity":
             _cmd_verify_integrity(args)
         elif args.cmd == "nemoclaw-daemons":

--- a/tests/test_cli_features_subcommand.py
+++ b/tests/test_cli_features_subcommand.py
@@ -1,0 +1,125 @@
+"""Tests for the ``clawmetry features`` CLI subcommand.
+
+Sibling of ``tests/test_cli_runtimes_subcommand.py``: the subcommand is a thin
+read of :func:`clawmetry.entitlements.feature_catalog` and must never crash --
+even when the entitlement read itself fails. These tests cover the human
+table, ``--json``, the locked-row CTA, the alias-row filter, and the OSS-free
+fallback.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+
+@pytest.fixture
+def cli_mod(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so the
+    table is rendered against the OSS-free default and never against a license
+    that happens to live on the host."""
+    import importlib
+
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    import clawmetry.entitlements as ent
+
+    importlib.reload(ent)
+    ent.invalidate()
+
+    import clawmetry.cli as cli  # imported after entitlements is rebuilt
+
+    yield cli
+    ent.invalidate()
+
+
+def _ns(**kw) -> argparse.Namespace:
+    return argparse.Namespace(**kw)
+
+
+def test_features_table_lists_every_known_canonical_feature(cli_mod, capsys):
+    import clawmetry.entitlements as ent
+
+    cli_mod._cmd_features(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "ClawMetry Features" in out
+    # Every non-alias feature in the catalogue surfaces -- no silent drops.
+    for f in ent.ALL_FEATURES:
+        if f in ent._ALIAS_FEATURES:
+            continue
+        assert f in out, f
+    # Alias rows are hidden from the human table so the upgrade copy stays
+    # scoped to the canonical names shown on /pricing.
+    for alias in ent._ALIAS_FEATURES:
+        assert alias not in out, alias
+    # Default install is in grace mode → no lock affordance is shown yet.
+    assert "Enforcement: off (grace)" in out
+    assert "🔒 locked" not in out
+
+
+def test_features_json_is_machine_readable(cli_mod, capsys):
+    import clawmetry.entitlements as ent
+
+    cli_mod._cmd_features(_ns(as_json=True))
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["tier"] == ent.TIER_OSS
+    assert payload["grace"] is True
+    assert payload["enforced"] is False
+    ids = {row["id"] for row in payload["features"]}
+    # JSON path keeps the full catalogue (including aliases) so scripts
+    # consuming the API shape don't see the rows disappear.
+    assert ids == set(ent.ALL_FEATURES)
+    for row in payload["features"]:
+        assert {"id", "label", "tier", "free", "allowed", "locked"} <= set(row)
+
+
+def test_features_enforced_oss_shows_paid_features_locked(
+    cli_mod, capsys, monkeypatch
+):
+    import clawmetry.entitlements as ent
+
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cli_mod._cmd_features(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "Enforcement: on" in out
+    # The CTA fires only when at least one row is locked.
+    assert "clawmetry license activate <KEY>" in out
+    # Free features never lock.
+    for f in ent.FREE_FEATURES:
+        line = next(ln for ln in out.splitlines() if ln.strip().startswith(f))
+        assert "available" in line, f
+
+
+def test_features_falls_back_when_catalog_errors(cli_mod, capsys, monkeypatch):
+    """A poisoned feature_catalog() must not crash the CLI."""
+    import clawmetry.entitlements as ent
+
+    def _boom():
+        raise RuntimeError("synthetic catalog failure")
+
+    monkeypatch.setattr(ent, "feature_catalog", _boom)
+    cli_mod._cmd_features(_ns(as_json=False))
+    out = capsys.readouterr().out
+    assert "synthetic catalog failure" in out
+    # JSON path also stays graceful.
+    cli_mod._cmd_features(_ns(as_json=True))
+    out_json = capsys.readouterr().out.strip()
+    payload = json.loads(out_json)
+    assert payload["features"] == []
+    assert "synthetic catalog failure" in payload["error"]
+
+
+def test_features_subcommand_is_registered():
+    """The subparser + dispatch table must list `features` so it is reachable
+    from the CLI entry point."""
+    import inspect
+
+    import clawmetry.cli as cli
+
+    src = inspect.getsource(cli.main)
+    assert '"features"' in src
+    assert "_cmd_features" in src


### PR DESCRIPTION
## Summary

Adds `clawmetry features`, the CLI sibling of the existing `clawmetry runtimes` subcommand and of the dashboard's `GET /api/features` endpoint. Lets the operator answer "what does this tier unlock?" from the shell without parsing `tier --json | jq`.

- Reads `clawmetry.entitlements.feature_catalog()` — the same source the dashboard consumes — so the CLI and the UI cannot drift on the locked-but-visible upgrade affordance.
- Default output: compact table `(id, label, tier, status)`. Alias rows (the backwards-compat `_ALIAS_FEATURES` set) are hidden so the upgrade copy stays scoped to the canonical feature names shown on `/pricing`.
- `--json` keeps the **full** catalogue (aliases included) so scripts see a stable shape and `jq` queries don't suddenly miss rows.
- Stays in **GRACE** mode: in the default install nothing is locked yet, so the subcommand prints `Enforcement: off (grace)` and emits no lock affordance until `CLAWMETRY_ENFORCE=1` flips. No current behaviour changes.
- Never crashes: a poisoned `feature_catalog()` read surfaces inline (warning row in the table, `error` key on the JSON payload) — same never-raise contract as the runtimes sibling.

### Why now
The entitlement surface already exposes `tier`, `runtimes`, `features` over HTTP and the first two are mirrored in the CLI; this closes the parity gap. No frontend change, no version bump, no new dependency — Flask/waitress/cryptography only.

### Files
- `clawmetry/cli.py` — adds `_cmd_features(args)` (mirrors `_cmd_runtimes`), the `features` subparser + dispatch entry, and the alias-row filter on the human table.
- `tests/test_cli_features_subcommand.py` — 5 tests mirroring `tests/test_cli_runtimes_subcommand.py`: table lists every canonical feature + hides aliases, JSON keeps the full catalogue, enforced mode flags every paid feature as 🔒 with the CTA, a poisoned catalog read degrades to the inline error path, and the subparser/dispatch entries are registered.

### Test plan
- [x] `python3 -m pytest tests/test_cli_features_subcommand.py -v` → 5 passed
- [x] `python3 -m pytest tests/test_cli_runtimes_subcommand.py tests/test_entitlements.py tests/test_entitlement_api.py -q` → 118 passed (no sibling regression)
- [x] `python3 -m py_compile clawmetry/cli.py tests/test_cli_features_subcommand.py` — syntax OK
- [x] `ruff check clawmetry/cli.py` — zero new violations (15 errors pre-existing on main, none in the added function)

### Local operator verification checklist
The remote agent cannot reach the live daemon / browser / `~/.openclaw` — these steps are for the local operator on their machine:

1. Copy the changed files into the daemon's site-packages:
   ```
   cp clawmetry/cli.py ~/.clawmetry/lib/python*/site-packages/clawmetry/cli.py
   cp tests/test_cli_features_subcommand.py /tmp/  # optional, for re-running tests
   find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} + 2>/dev/null
   ```
2. Restart the daemon so the new CLI is picked up:
   ```
   launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
   ```
3. Smoke-test the subcommand against the live install:
   ```
   clawmetry features
   clawmetry features --json | jq '.features | length'
   CLAWMETRY_ENFORCE=1 clawmetry features        # should show 🔒 on paid rows + CTA
   ```
4. Confirm the dashboard's `/api/features` payload still matches the CLI table:
   ```
   curl -s http://127.0.0.1:8900/api/features | jq '.features[].id' | sort > /tmp/api.txt
   clawmetry features --json | jq '.features[].id' | sort > /tmp/cli.txt
   diff /tmp/api.txt /tmp/cli.txt   # should be empty
   ```
5. Browser-check: open the dashboard, confirm the existing feature panel / upgrade CTAs render unchanged.

### Rollout
GRACE-only — no behaviour change in the default install. The subcommand is read-only, side-effect-free, and never raises. Safe to merge whenever the operator has time to verify.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0116z5NZr4YESGhZhHcG9DC9)_