### PR TITLE
fix: surface compaction-event usage in spans and DB token_count (#3199)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1305,6 +1305,45 @@ class OpenClawAdapter(AgentAdapter):
                     "attributes": fa_attrs or None,
                 })
 
+            elif t == "compaction":
+                # Harness fix #93084 preserves fresh usage data on compaction
+                # records. Emit an INTERNAL span so the Tracing tab shows the
+                # compaction boundary; surface tokens_before + any usage so
+                # callers can see what was reclaimed and what was re-billed
+                # (#3199).
+                comp_attrs: dict = {"event.kind": "compaction"}
+                summary = obj.get("summary")
+                if isinstance(summary, str) and summary.strip():
+                    comp_attrs["compaction.summary"] = summary[:500]
+                tb = obj.get("tokensBefore") or obj.get("tokens_before")
+                if tb is not None:
+                    try:
+                        comp_attrs["compaction.tokens_before"] = int(tb)
+                    except (TypeError, ValueError):
+                        pass
+                from_hook = obj.get("fromHook") if obj.get("fromHook") is not None else obj.get("from_hook")
+                if from_hook is not None:
+                    comp_attrs["compaction.from_hook"] = bool(from_hook)
+                comp_usage = obj.get("usage")
+                if isinstance(comp_usage, dict):
+                    tok_total = int(comp_usage.get("totalTokens") or comp_usage.get("total_tokens") or 0)
+                    tok_in = int(comp_usage.get("input_tokens") or comp_usage.get("inputTokens") or 0)
+                    tok_out = int(comp_usage.get("output_tokens") or comp_usage.get("outputTokens") or 0)
+                    effective = tok_total or (tok_in + tok_out)
+                    if effective:
+                        comp_attrs["compaction.usage.total_tokens"] = effective
+                spans.append({
+                    "span_id": _sid("compaction", session_id, str(raw_ts)),
+                    "trace_id": trace_id,
+                    "parent_span_id": session_span_id,
+                    "name": "compaction",
+                    "kind": "INTERNAL",
+                    "start_ts": ts,
+                    "session_id": session_id,
+                    "agent_type": "openclaw",
+                    "attributes": comp_attrs,
+                })
+
         return spans
 
     def reconstruct_spans(self, jsonl_path: str) -> list:

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2528,6 +2528,29 @@ def _extract_cost_tokens_model(obj: dict) -> tuple:
                         cost_usd = float(cv)
                     except (TypeError, ValueError):
                         cost_usd = None
+    else:
+        # Compaction events (harness fix #93084) and other non-message events
+        # carry usage at the top level, not nested under message.usage (#3199).
+        top_usage = obj.get("usage")
+        if isinstance(top_usage, dict):
+            if token_count is None:
+                tt = top_usage.get("totalTokens") or top_usage.get("total_tokens")
+                if tt is not None:
+                    try:
+                        token_count = int(tt)
+                    except (TypeError, ValueError):
+                        pass
+            if cost_usd is None:
+                cost = top_usage.get("cost")
+                if isinstance(cost, dict):
+                    cv = cost.get("total") or cost.get("total_usd")
+                else:
+                    cv = cost if isinstance(cost, (int, float)) else None
+                if cv is not None:
+                    try:
+                        cost_usd = float(cv)
+                    except (TypeError, ValueError):
+                        pass
 
     # #2049: derive cost when the provider didn't report it. OpenClaw / OAuth
     # events carry tokens + model but no cost_usd, so the Cost tab showed ~$0

--- a/tests/test_obs_gap_compaction_usage.py
+++ b/tests/test_obs_gap_compaction_usage.py
@@ -1,0 +1,125 @@
+"""Tests for #3199 — openclaw:compaction-event usage fields.
+
+Compaction events preserve fresh token-usage data after harness fix #93084.
+Two gaps:
+1. _build_spans_from_events now emits a span for compaction events so the
+   Tracing tab shows the compaction boundary (previously silently dropped).
+2. _extract_cost_tokens_model now reads token_count/cost from top-level usage
+   on non-message events so the DB column is populated correctly.
+"""
+from __future__ import annotations
+
+from clawmetry.adapters.openclaw import OpenClawAdapter
+from clawmetry.sync import _extract_cost_tokens_model
+
+
+def test_compaction_event_produces_span():
+    events = [
+        {"type": "session", "version": 3, "timestamp": "2026-06-19T10:00:00Z"},
+        {
+            "type": "compaction",
+            "timestamp": "2026-06-19T10:05:00Z",
+            "summary": "Summarised 47 turns to free context.",
+            "tokensBefore": 180000,
+            "fromHook": False,
+            "usage": {"totalTokens": 8200, "input_tokens": 6800, "output_tokens": 1400},
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "sess1")
+    by_name = {s["name"]: s for s in spans}
+    assert "compaction" in by_name, "compaction event must produce a span"
+    sp = by_name["compaction"]
+    assert sp["kind"] == "INTERNAL"
+    assert sp["parent_span_id"] == by_name["session"]["span_id"]
+    attrs = sp["attributes"]
+    assert attrs["event.kind"] == "compaction"
+    assert attrs["compaction.tokens_before"] == 180000
+    assert attrs["compaction.usage.total_tokens"] == 8200
+    assert attrs["compaction.from_hook"] is False
+    assert attrs["compaction.summary"] == "Summarised 47 turns to free context."
+
+
+def test_compaction_span_without_usage():
+    events = [
+        {"type": "compaction", "timestamp": "2026-06-19T10:06:00Z",
+         "summary": "Proactive compaction.", "tokensBefore": 90000},
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "sess1")
+    assert len(spans) == 1
+    sp = spans[0]
+    assert sp["name"] == "compaction"
+    attrs = sp["attributes"]
+    assert attrs["event.kind"] == "compaction"
+    assert attrs["compaction.tokens_before"] == 90000
+    assert "compaction.usage.total_tokens" not in attrs
+
+
+def test_compaction_span_id_is_deterministic():
+    events = [
+        {"type": "compaction", "timestamp": "2026-06-19T10:07:00Z"},
+    ]
+    a = OpenClawAdapter._build_spans_from_events(events, "s2")
+    b = OpenClawAdapter._build_spans_from_events(events, "s2")
+    assert a[0]["span_id"] == b[0]["span_id"]
+
+
+def test_compaction_usage_inout_fallback():
+    """When totalTokens is absent, input+output sum is used."""
+    events = [
+        {
+            "type": "compaction",
+            "timestamp": "2026-06-19T10:08:00Z",
+            "usage": {"input_tokens": 5000, "output_tokens": 1200},
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "sess1")
+    assert spans[0]["attributes"]["compaction.usage.total_tokens"] == 6200
+
+
+def test_extract_cost_tokens_compaction_top_level_usage():
+    """_extract_cost_tokens_model reads totalTokens + cost from compaction's top-level usage."""
+    obj = {
+        "type": "compaction",
+        "timestamp": "2026-06-19T10:05:00Z",
+        "summary": "Context summarised.",
+        "tokensBefore": 200000,
+        "usage": {
+            "totalTokens": 9500,
+            "input_tokens": 8000,
+            "output_tokens": 1500,
+            "cost": {"total": 0.025},
+        },
+    }
+    cost_usd, token_count, model = _extract_cost_tokens_model(obj)
+    assert token_count == 9500, f"expected 9500 got {token_count}"
+    assert cost_usd == 0.025
+
+
+def test_extract_cost_tokens_no_regression_for_message_events():
+    """Existing message events continue to read usage from message.usage."""
+    obj = {
+        "type": "message",
+        "message": {
+            "role": "assistant",
+            "model": "claude-opus-4-7",
+            "usage": {
+                "totalTokens": 500,
+                "cost": {"total": 0.01},
+            },
+        },
+    }
+    cost_usd, token_count, model = _extract_cost_tokens_model(obj)
+    assert token_count == 500
+    assert cost_usd == 0.01
+    assert model == "claude-opus-4-7"
+
+
+def test_extract_cost_tokens_compaction_cost_only():
+    """cost_usd extracted even when totalTokens absent."""
+    obj = {
+        "type": "compaction",
+        "usage": {"cost": {"total": 0.005}},
+    }
+    cost_usd, token_count, _model = _extract_cost_tokens_model(obj)
+    assert cost_usd == 0.005
+    assert token_count is None


### PR DESCRIPTION
Closes #3199

## Summary

- **Span gap fixed**: `_build_spans_from_events` now has an `elif t == "compaction":` branch that emits an INTERNAL span under the session root, surfacing `tokens_before`, `from_hook`, a truncated `summary`, and `compaction.usage.total_tokens` when the harness fix #93084 includes fresh usage data. The Tracing tab previously dropped compaction events silently.

- **Cost/token DB gap fixed**: `_extract_cost_tokens_model` now reads `totalTokens` and `cost` from top-level `obj["usage"]` when `message` is absent (the `else` branch). Compaction events carry usage at the top level; previously the DB stored `token_count = NULL` and `cost_usd = NULL` for every compaction turn. No change for normal `message` events.

- **7 new unit tests** in `tests/test_obs_gap_compaction_usage.py` covering both fixes and edge cases (missing usage, totalTokens absent, no regression for message events).

## Test plan

- [ ] `python -m pytest tests/test_obs_gap_compaction_usage.py -v` — all 7 pass
- [ ] `python -m pytest tests/test_obs_gap_commentary_progress.py -v` — no regressions in adjacent span-builder tests
- [ ] `python -m py_compile clawmetry/adapters/openclaw.py clawmetry/sync.py` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfQP44WJb1LoXSJgpKDrJB)_