### PR TITLE
fix(spans): emit retry span for openclaw retry events

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1344,6 +1344,41 @@ class OpenClawAdapter(AgentAdapter):
                     "attributes": comp_attrs,
                 })
 
+            elif t == "retry":
+                # Harness fix #92191/#93073 emits a retry event when the agent
+                # retries a thinking-only or empty post-tool turn, carrying
+                # retry reason and turn-kind metadata. Without this branch the
+                # span builder drops retried turns silently, so the Tracing tab
+                # shows a gap wherever a retry occurred (#3198).
+                retry_reason = (
+                    obj.get("reason") or obj.get("retry_reason") or obj.get("retryReason") or ""
+                )
+                turn_kind = (
+                    obj.get("turn_kind") or obj.get("turnKind") or ""
+                )
+                retry_count = obj.get("count") or obj.get("retry_count") or obj.get("retryCount")
+                retry_attrs: dict = {"event.kind": "retry"}
+                if isinstance(retry_reason, str) and retry_reason.strip():
+                    retry_attrs["retry.reason"] = retry_reason.strip()
+                if isinstance(turn_kind, str) and turn_kind.strip():
+                    retry_attrs["retry.turn_kind"] = turn_kind.strip()
+                if retry_count is not None:
+                    try:
+                        retry_attrs["retry.count"] = int(retry_count)
+                    except (TypeError, ValueError):
+                        pass
+                spans.append({
+                    "span_id": _sid("retry", session_id, str(raw_ts)),
+                    "trace_id": trace_id,
+                    "parent_span_id": session_span_id,
+                    "name": "retry",
+                    "kind": "INTERNAL",
+                    "start_ts": ts,
+                    "session_id": session_id,
+                    "agent_type": "openclaw",
+                    "attributes": retry_attrs,
+                })
+
         return spans
 
     def reconstruct_spans(self, jsonl_path: str) -> list:

--- a/tests/test_obs_gap_openclaw_retry_event_3198.py
+++ b/tests/test_obs_gap_openclaw_retry_event_3198.py
@@ -1,0 +1,84 @@
+"""Tests for #3198 — openclaw retry events produce spans in the Tracing tab.
+
+The harness emits a ``"retry"`` JSONL event (openclaw 2026.6.9, #92191/#93073)
+when the agent retries a thinking-only or empty post-tool turn. Before this fix
+``_build_spans_from_events`` had no branch for the ``retry`` type, so every
+retry event fell through the loop and produced no span — leaving a silent gap
+in the trace wherever a retry occurred.
+"""
+from __future__ import annotations
+
+from clawmetry.adapters.openclaw import OpenClawAdapter
+
+
+def test_retry_event_produces_span_with_reason_and_turn_kind():
+    events = [
+        {"type": "session", "version": "1.0", "timestamp": "2026-06-19T00:00:00Z"},
+        {
+            "type": "retry",
+            "timestamp": "2026-06-19T00:00:01Z",
+            "reason": "thinking_only",
+            "turn_kind": "post_tool",
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s1")
+    by_name = {s["name"]: s for s in spans}
+    assert "retry" in by_name, "retry event must produce a span"
+    span = by_name["retry"]
+    assert span["kind"] == "INTERNAL"
+    assert span["parent_span_id"] == by_name["session"]["span_id"]
+    attrs = span["attributes"]
+    assert attrs["event.kind"] == "retry"
+    assert attrs["retry.reason"] == "thinking_only"
+    assert attrs["retry.turn_kind"] == "post_tool"
+
+
+def test_retry_event_with_count():
+    events = [
+        {
+            "type": "retry",
+            "timestamp": "2026-06-19T00:00:02Z",
+            "reason": "empty_post_tool",
+            "turn_kind": "thinking_only",
+            "count": 2,
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s2")
+    assert len(spans) == 1
+    attrs = spans[0]["attributes"]
+    assert attrs["retry.reason"] == "empty_post_tool"
+    assert attrs["retry.turn_kind"] == "thinking_only"
+    assert attrs["retry.count"] == 2
+
+
+def test_retry_event_accepts_camelcase_fields():
+    events = [
+        {
+            "type": "retry",
+            "timestamp": "2026-06-19T00:00:03Z",
+            "retryReason": "thinking_only",
+            "turnKind": "post_tool",
+            "retryCount": 3,
+        },
+    ]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s3")
+    assert len(spans) == 1
+    attrs = spans[0]["attributes"]
+    assert attrs["retry.reason"] == "thinking_only"
+    assert attrs["retry.turn_kind"] == "post_tool"
+    assert attrs["retry.count"] == 3
+
+
+def test_retry_event_minimal_payload_still_emits_span():
+    events = [{"type": "retry", "timestamp": "2026-06-19T00:00:04Z"}]
+    spans = OpenClawAdapter._build_spans_from_events(events, "s4")
+    assert len(spans) == 1
+    assert spans[0]["name"] == "retry"
+    assert spans[0]["attributes"] == {"event.kind": "retry"}
+
+
+def test_retry_span_ids_are_deterministic():
+    events = [{"type": "retry", "timestamp": "2026-06-19T00:00:05Z", "reason": "thinking_only"}]
+    a = OpenClawAdapter._build_spans_from_events(events, "s5")
+    b = OpenClawAdapter._build_spans_from_events(events, "s5")
+    assert a[0]["span_id"] == b[0]["span_id"]


### PR DESCRIPTION
Closes #3198

## Summary

- The openclaw harness (2026.6.9, #92191/#93073) emits a `"retry"` JSONL event when the agent retries a thinking-only or empty post-tool turn, carrying `reason` and `turn_kind` metadata.
- Without this fix `_build_spans_from_events` fell through every branch and silently dropped retry events — the Tracing tab showed a gap wherever a retry occurred.
- Adds `elif t == "retry":` in `clawmetry/adapters/openclaw.py` that emits an `INTERNAL` span under the session root, recording `retry.reason`, `retry.turn_kind`, and optional `retry.count`. Accepts both snake_case and camelCase field variants.

## Test plan

- `tests/test_obs_gap_openclaw_retry_event_3198.py` — 5 new tests:
  - Retry span with reason + turn_kind, parented to session root
  - Retry span with count field
  - camelCase field aliases (`retryReason`, `turnKind`, `retryCount`)
  - Minimal payload (no metadata) still emits a span
  - Span IDs are deterministic (idempotent re-ingest)
- All 5 pass; existing `_build_spans_from_events` tests unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSaaM1M73tbJtYtEyn4ny4)_