### PR TITLE
refactor(open-core): consolidate required_tier resolvers on min_tier_for_feature

### DIFF
--- a/clawmetry/_gate.py
+++ b/clawmetry/_gate.py
@@ -49,21 +49,25 @@ def _required_tier(feature_key: str) -> str | None:
     free features and unknown keys. Used to enrich the 402 body so the UI
     can render the right upgrade CTA without re-deriving tier logic in JS.
     Never raises: any lookup error returns ``None``.
+
+    Thin wrapper over :func:`entitlements.min_tier_for_feature` (the
+    canonical purchasable-tier resolver, also used by ``min_tier_for`` and
+    ``/api/entitlement/required-tier``) so the feature->tier mapping lives
+    in exactly one place. The companion :func:`_required_tier_for_runtime`
+    already delegates to :func:`entitlements.min_tier_for_runtime`; this
+    closes the matching gap on the feature side. ``TIER_OSS`` collapses to
+    ``None`` because free features have no upgrade target -- the UI uses
+    ``None`` to short-circuit the CTA render.
     """
     try:
         from clawmetry import entitlements as _ent
 
-        if feature_key in _ent.FREE_FEATURES:
+        tier = _ent.min_tier_for_feature(feature_key)
+        if tier is None or tier == _ent.TIER_OSS:
             return None
-        if feature_key in _ent.STARTER_FEATURES:
-            return _ent.TIER_CLOUD_STARTER
-        if feature_key in _ent.PRO_ONLY_FEATURES:
-            return _ent.TIER_CLOUD_PRO
-        if feature_key in _ent.ENTERPRISE_FEATURES:
-            return _ent.TIER_ENTERPRISE
+        return tier
     except Exception:
         return None
-    return None
 
 
 def gate(feature_key: str) -> Callable:

--- a/clawmetry/_paywall.py
+++ b/clawmetry/_paywall.py
@@ -114,25 +114,30 @@ def upgrade_required_body(
 def _min_tier_for_feature(ent_module, feature_key: str) -> str | None:
     """Map ``feature_key`` to the cheapest purchasable tier id that unlocks it.
 
-    Uses the catalogue sets that ``clawmetry/entitlements.py`` already
-    exports (``STARTER_FEATURES``, ``PRO_ONLY_FEATURES``,
-    ``ENTERPRISE_FEATURES``). A free or unknown key returns ``None``: free
-    features don't have an upgrade target, and an unknown key may be a
-    clawmetry-pro plugin's private id we don't have in the OSS catalogue.
+    Thin wrapper over :func:`entitlements.min_tier_for_feature` -- the
+    canonical purchasable-tier resolver also used by ``Entitlement.min_tier_for``,
+    ``/api/entitlement/required-tier`` and :func:`clawmetry._gate._required_tier`
+    -- so the feature->tier mapping lives in exactly one place and the OSS-stub
+    402 body can never drift from the ``@gate`` 402 body. ``TIER_OSS`` (returned
+    for free features) collapses to ``None`` so the body's ``required_tier`` is
+    ``None`` for a free key and the UI short-circuits the upgrade CTA, matching
+    the prior in-module if-tree exactly.
 
-    Kept private to this module so it doesn't compete with a future
-    catalogue-level helper in ``entitlements`` (and so the body builder
-    stays self-contained for OSS stubs).
+    Catalogue-set membership is read via ``getattr`` defaults on
+    :func:`min_tier_for_feature` indirectly: a stubbed-out ``ent_module``
+    without the canonical helper falls back to ``None`` via the swallowed
+    ``AttributeError`` -- the body builder's outer try/except still degrades
+    cleanly to ``required_tier=None``.
     """
     key = (feature_key or "").strip()
     if not key:
         return None
-    if key in getattr(ent_module, "FREE_FEATURES", frozenset()):
+    resolver = getattr(ent_module, "min_tier_for_feature", None)
+    if resolver is None:
         return None
-    if key in getattr(ent_module, "STARTER_FEATURES", frozenset()):
-        return getattr(ent_module, "TIER_CLOUD_STARTER", None)
-    if key in getattr(ent_module, "PRO_ONLY_FEATURES", frozenset()):
-        return getattr(ent_module, "TIER_CLOUD_PRO", None)
-    if key in getattr(ent_module, "ENTERPRISE_FEATURES", frozenset()):
-        return getattr(ent_module, "TIER_ENTERPRISE", None)
-    return None
+    tier = resolver(key)
+    if tier is None:
+        return None
+    if tier == getattr(ent_module, "TIER_OSS", "oss"):
+        return None
+    return tier

--- a/tests/test_paywall_body.py
+++ b/tests/test_paywall_body.py
@@ -131,18 +131,18 @@ def test_body_tier_reflects_current_install(ent_grace):
     assert body["tier"] == ent_grace.TIER_OSS
 
 
-def test_body_swallows_feature_set_errors(monkeypatch):
-    """If a catalogue set itself raises on membership lookup, the helper
-    still produces a well-formed body with ``required_tier=None`` rather
-    than 500-ing the request."""
+def test_body_swallows_min_tier_resolver_errors(monkeypatch):
+    """If the canonical tier resolver raises, the helper still produces a
+    well-formed body with ``required_tier=None`` rather than 500-ing the
+    request -- the body builder owns the never-raise contract regardless of
+    what the entitlements catalogue does."""
     import clawmetry.entitlements as ent
     from clawmetry._paywall import upgrade_required_body
 
-    class _Boom:
-        def __contains__(self, _key):
-            raise RuntimeError("boom")
+    def explode(_key):
+        raise RuntimeError("boom")
 
-    monkeypatch.setattr(ent, "PRO_ONLY_FEATURES", _Boom())
+    monkeypatch.setattr(ent, "min_tier_for_feature", explode)
     body = upgrade_required_body("self_evolve")
     assert body["error"] == "upgrade_required"
     assert body["feature"] == "self_evolve"

--- a/tests/test_required_tier_canonical.py
+++ b/tests/test_required_tier_canonical.py
@@ -1,0 +1,190 @@
+"""Pin :func:`clawmetry._gate._required_tier` and
+:func:`clawmetry._paywall._min_tier_for_feature` to the canonical
+:func:`clawmetry.entitlements.min_tier_for_feature` resolver.
+
+Before this consolidation both helpers carried their own hand-rolled
+if-tree against ``FREE_FEATURES`` / ``STARTER_FEATURES`` / ``PRO_ONLY_FEATURES``
+/ ``ENTERPRISE_FEATURES``. The runtime side already pointed at the
+canonical :func:`min_tier_for_runtime` (see :func:`_required_tier_for_runtime`
+in ``_gate.py``); the feature side did not. Adding a new tier bucket or
+renaming a constant would silently drift the 402 ``required_tier`` between
+the ``@gate`` decorator's body and the OSS-stub body for the same key.
+
+These tests assert that for every key in the catalogue both helpers track
+:func:`min_tier_for_feature` exactly, with the single documented translation
+:data:`TIER_OSS` -> ``None`` (free keys don't have an upgrade target -- the
+UI uses ``None`` to short-circuit the CTA render). They also verify the
+never-raise contract still holds when the canonical resolver itself blows
+up.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ent_grace(monkeypatch, tmp_path):
+    """Reload entitlements pointed at an empty HOME so the resolver collapses
+    to OSS-free deterministically. Mirrors the fixture in
+    ``tests/test_paywall_body.py``."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+def _expected_required_tier(ent_module, key: str):
+    """The wire shape both helpers must produce: canonical resolver answer
+    with :data:`TIER_OSS` collapsed to ``None``."""
+    tier = ent_module.min_tier_for_feature(key)
+    if tier is None or tier == ent_module.TIER_OSS:
+        return None
+    return tier
+
+
+def test_gate_required_tier_matches_canonical_for_full_catalogue(ent_grace):
+    """``_gate._required_tier`` must agree with the canonical resolver for
+    every key in ``ALL_FEATURES`` -- the universe both the ``@gate``
+    decorator and the OSS-stub body builder branch on."""
+    from clawmetry._gate import _required_tier
+
+    for key in ent_grace.ALL_FEATURES:
+        assert _required_tier(key) == _expected_required_tier(ent_grace, key), key
+
+
+def test_paywall_min_tier_matches_canonical_for_full_catalogue(ent_grace):
+    """``_paywall._min_tier_for_feature`` must agree with the canonical
+    resolver for every key in ``ALL_FEATURES`` -- the OSS-stub blueprints
+    that adopt :func:`upgrade_required_body` rely on this."""
+    from clawmetry._paywall import _min_tier_for_feature
+
+    for key in ent_grace.ALL_FEATURES:
+        assert (
+            _min_tier_for_feature(ent_grace, key)
+            == _expected_required_tier(ent_grace, key)
+        ), key
+
+
+def test_gate_and_paywall_helpers_agree_for_full_catalogue(ent_grace):
+    """The two helpers must produce identical output for every catalogue
+    key, so the 402 body emitted by ``@gate`` and by the OSS-stub builder
+    carry the same ``required_tier`` for the same feature."""
+    from clawmetry._gate import _required_tier
+    from clawmetry._paywall import _min_tier_for_feature
+
+    for key in ent_grace.ALL_FEATURES:
+        assert _required_tier(key) == _min_tier_for_feature(ent_grace, key), key
+
+
+def test_gate_required_tier_free_collapses_to_none(ent_grace):
+    """Free features have no upgrade target -- ``required_tier`` is ``None``
+    so the UI short-circuits the CTA render."""
+    from clawmetry._gate import _required_tier
+
+    for key in ent_grace.FREE_FEATURES:
+        assert _required_tier(key) is None, key
+
+
+def test_gate_required_tier_unknown_collapses_to_none(ent_grace):
+    """An unknown / typo'd key resolves to ``None`` -- a clawmetry-pro
+    plugin's private feature id we don't have in the OSS catalogue still
+    produces a well-formed 402 body."""
+    from clawmetry._gate import _required_tier
+
+    assert _required_tier("totally_unknown_feature_xyz") is None
+    assert _required_tier("") is None
+
+
+def test_gate_required_tier_starter_feature_resolves_to_starter(ent_grace):
+    """Starter-card features resolve to ``cloud_starter`` -- the cheapest
+    purchasable tier that unlocks them. Mirrors
+    :func:`min_tier_for_feature`."""
+    from clawmetry._gate import _required_tier
+
+    for key in ("multi_runtime", "fleet", "all_channels", "budget_limits"):
+        assert _required_tier(key) == ent_grace.TIER_CLOUD_STARTER, key
+
+
+def test_gate_required_tier_pro_feature_resolves_to_pro(ent_grace):
+    """Pro-only features resolve to ``cloud_pro``."""
+    from clawmetry._gate import _required_tier
+
+    for key in ("self_evolve", "custom_runtime_ingest", "otel_export"):
+        assert _required_tier(key) == ent_grace.TIER_CLOUD_PRO, key
+
+
+def test_gate_required_tier_enterprise_feature_resolves_to_enterprise(ent_grace):
+    """Enterprise-only features resolve to ``enterprise`` so the 402 body
+    drives the right CTA (not the Pro one)."""
+    from clawmetry._gate import _required_tier
+
+    for key in ("audit_logs", "sso", "siem_export"):
+        assert _required_tier(key) == ent_grace.TIER_ENTERPRISE, key
+
+
+def test_gate_required_tier_swallows_resolver_errors(monkeypatch):
+    """A flaky :func:`min_tier_for_feature` falls back to ``None`` -- the
+    402 body must stay well-formed even when the catalogue lookup blows
+    up. Same posture as ``upgrade_required_body``'s never-raise contract."""
+    import clawmetry.entitlements as ent
+    from clawmetry._gate import _required_tier
+
+    def explode(_key):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_feature", explode)
+    assert _required_tier("self_evolve") is None
+
+
+def test_paywall_min_tier_swallows_resolver_errors(monkeypatch):
+    """Same never-raise contract for the OSS-stub helper -- the body
+    builder's outer try/except still degrades cleanly to
+    ``required_tier=None`` when the canonical resolver blows up."""
+    import clawmetry.entitlements as ent
+    from clawmetry._paywall import _min_tier_for_feature
+
+    def explode(_key):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ent, "min_tier_for_feature", explode)
+    with pytest.raises(RuntimeError):
+        # The helper itself propagates -- the outer try/except in
+        # ``upgrade_required_body`` is what swallows it. Pin both layers
+        # explicitly so the contract is unambiguous.
+        _min_tier_for_feature(ent, "self_evolve")
+
+    from clawmetry._paywall import upgrade_required_body
+
+    body = upgrade_required_body("self_evolve")
+    assert body["error"] == "upgrade_required"
+    assert body["required_tier"] is None
+
+
+def test_paywall_min_tier_handles_missing_resolver(ent_grace):
+    """A stripped ``entitlements`` module without ``min_tier_for_feature``
+    collapses cleanly to ``None`` -- the OSS-stub builder still emits a
+    well-formed body."""
+    from clawmetry._paywall import _min_tier_for_feature
+
+    class _Stub:
+        TIER_OSS = "oss"
+        # deliberately no ``min_tier_for_feature`` attr
+
+    assert _min_tier_for_feature(_Stub, "self_evolve") is None
+
+
+def test_paywall_min_tier_handles_blank_key(ent_grace):
+    """Blank / whitespace-only keys short-circuit to ``None`` without
+    calling the canonical resolver."""
+    from clawmetry._paywall import _min_tier_for_feature
+
+    assert _min_tier_for_feature(ent_grace, "") is None
+    assert _min_tier_for_feature(ent_grace, "   ") is None
+    assert _min_tier_for_feature(ent_grace, None) is None  # type: ignore[arg-type]


### PR DESCRIPTION
## What

Collapses two hand-rolled feature->tier if-trees onto the canonical
`entitlements.min_tier_for_feature` resolver, closing a long-standing
drift risk on the open-core 402 body.

The 402 `required_tier` field is built in two places today:
* `clawmetry/_gate.py::_required_tier` — used by the `@gate` decorator's
  upgrade_required body
* `clawmetry/_paywall.py::_min_tier_for_feature` — used by
  `upgrade_required_body` for the OSS-stub blueprints
  (`routes/selfevolve.py`, `routes/runtime_ingest.py`, `routes/audit.py`, …)

Both carried their own if-tree against `FREE_FEATURES` / `STARTER_FEATURES`
/ `PRO_ONLY_FEATURES` / `ENTERPRISE_FEATURES` even though
`entitlements.min_tier_for_feature` is the canonical purchasable-tier
resolver (already used by `Entitlement.min_tier_for`,
`/api/entitlement/required-tier`, the lock-reason copy, etc.). Adding a
new tier bucket or shuffling a feature between sets would have silently
drifted the 402 body between the `@gate` and OSS-stub paths for the same
key.

The companion `_required_tier_for_runtime` already delegates to
`entitlements.min_tier_for_runtime`. This PR closes the matching gap on
the feature side so the catalogue split lives in exactly one place.

## Wire shape

Preserved exactly — no observable change.

`TIER_OSS` (returned by `min_tier_for_feature` for free features)
collapses to `None` at both callsites, so the body's `required_tier` is
`None` for a free key and the UI keeps short-circuiting the CTA render.
Every existing 402 emitter (`@gate`, OSS-stub blueprints, audit stub)
returns the same field for the same key as before.

## Tests

* New `tests/test_required_tier_canonical.py` (12 tests) pins both
  helpers to `min_tier_for_feature` across the full `ALL_FEATURES`
  catalogue, plus the equivalence of the two helpers, free/unknown/blank
  key short-circuits, the Starter/Pro/Enterprise bucket invariants, and
  the never-raise contract under a flaky / missing canonical resolver.
* `tests/test_paywall_body.py::test_body_swallows_feature_set_errors`
  → renamed `test_body_swallows_min_tier_resolver_errors`. Same intent
  (broken catalogue → body still serialises with `required_tier=None`)
  but monkey-patches the new entry point (`min_tier_for_feature`)
  instead of the catalogue set that the helper no longer reads
  directly.

## Grace / enforce

Pure refactor. Grace-mode behaviour unchanged — `required_tier` is a
catalogue fact (which tier *could* unlock this key), not an entitlement
check, so the resolved value is identical in grace and enforce. The
existing 402 emission paths keep the same shape.

## Verification

* `python3 -m py_compile clawmetry/_gate.py clawmetry/_paywall.py tests/test_required_tier_canonical.py tests/test_paywall_body.py` — clean.
* `ruff check clawmetry/_gate.py clawmetry/_paywall.py tests/test_required_tier_canonical.py tests/test_paywall_body.py` — clean.
* `pytest tests/test_required_tier_canonical.py -v` — 12/12 pass.
* `pytest tests/test_paywall_body.py tests/test_entitlements_min_tier.py tests/test_required_tier_canonical.py tests/test_entitlements.py tests/test_entitlements_catalogue.py tests/test_entitlement_api.py tests/test_entitlement_api_lock_reason.py tests/test_runtime_tier.py tests/test_entitlement_lock_reason.py tests/test_entitlement_locked_helpers.py tests/test_entitlement_upgrade_diff.py tests/test_route_gates.py -q` — 271 passed, 1 failed.
* The single failure (`tests/test_route_gates.py::test_gated_route_returns_402_when_enforced[/api/assets-GET]`) reproduces on origin/main without this branch's diff applied (confirmed via `git stash` round-trip), so it is pre-existing and unrelated.

## Local operator verification checklist

Since this agent runs without access to the local daemon, `~/.openclaw`,
the live cloud snapshot, or a browser, the local operator should:

1. `git fetch origin feat/required-tier-via-canonical-resolver && git checkout feat/required-tier-via-canonical-resolver`
2. Copy the changed files into the live install:
   ```bash
   cp clawmetry/_gate.py     ~/.clawmetry/lib/python3.*/site-packages/clawmetry/_gate.py
   cp clawmetry/_paywall.py  ~/.clawmetry/lib/python3.*/site-packages/clawmetry/_paywall.py
   ```
3. Clear caches: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
4. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
5. Hit `/api/entitlement` and confirm the resolved shape is identical to
   the pre-PR baseline (this PR doesn't touch the route).
6. With `CLAWMETRY_ENFORCE=1`, hit one `@gate("self_evolve")` endpoint
   (e.g. `/api/assets`) and one OSS-stub endpoint
   (e.g. `/api/selfevolve/status`) and confirm both 402 bodies carry the
   same `required_tier == "cloud_pro"`.
7. Decrypt the live cloud snapshot — unchanged, no daemon code touched.
8. Browser-check the upgrade CTA — same copy as before, since the wire
   shape is preserved.

This PR is **draft-only**: not flipping to ready-for-review, not editing
`__version__`, not opening a `[RELEASE]` PR, not enforcing any gate.
Grace mode stays on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJPCqskquNMFDWNUtHEMow

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJPCqskquNMFDWNUtHEMow)_