### PR TITLE
feat(adapters): surface gateway plugin health in OpenClaw detect() (#3200)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -613,6 +613,53 @@ def _openclaw_tool_catalog_kind() -> Optional[str]:
     return None
 
 
+def _gateway_plugin_health() -> dict:
+    """Per-plugin health state from the OpenClaw gateway status RPC (#3200).
+
+    As of harness 2026.6.9 (PR #93395) the gateway ``gateway.status`` response
+    includes a ``plugins`` list where each entry carries the plugin ``name``,
+    its ``state`` (``"loaded"`` / ``"errored"`` / ``"disabled"``), and an
+    optional ``type`` field (``"channel"`` / ``"provider"``).
+
+    Returns a dict with two keys when any plugin data is present:
+    - ``"gatewayPluginHealth"`` — the raw list of plugin entries
+      (``[{"name": str, "state": str, "type": str|None}, ...]``).
+    - ``"gatewayPluginHealthSummary"`` — a ``{state: count}`` tally for quick
+      health assessment (e.g. ``{"loaded": 3, "errored": 1}``).
+
+    Returns ``{}`` when the gateway RPC returns nothing, the response contains
+    no ``plugins`` key, or the list is empty. Never raises.
+    """
+    try:
+        d = _d()
+        rpc = getattr(d, "_gw_ws_rpc", None)
+        if rpc is None:
+            return {}
+        payload = rpc("gateway.status")
+        if not isinstance(payload, dict):
+            return {}
+        raw_plugins = payload.get("plugins")
+        if not isinstance(raw_plugins, list) or not raw_plugins:
+            return {}
+        plugins = []
+        summary: dict = {}
+        for entry in raw_plugins:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name") or entry.get("id") or ""
+            state = str(entry.get("state") or "").lower()
+            ptype = entry.get("type") or entry.get("kind") or None
+            if not name or not state:
+                continue
+            plugins.append({"name": name, "state": state, **({"type": ptype} if ptype else {})})
+            summary[state] = summary.get(state, 0) + 1
+        if not plugins:
+            return {}
+        return {"gatewayPluginHealth": plugins, "gatewayPluginHealthSummary": summary}
+    except Exception:
+        return {}
+
+
 class OpenClawAdapter(AgentAdapter):
     name = "openclaw"
     display_name = "OpenClaw"
@@ -669,6 +716,11 @@ class OpenClawAdapter(AgentAdapter):
             # from ~/.nemoclaw/agents.yaml (written by harness onboarding,
             # commit 01e5525).
             meta.update(_nemoclaw_agents_manifest())
+            # Gateway plugin health (#3200): per-plugin state (loaded/errored/
+            # disabled) added to gateway.status in harness 2026.6.9 (#93395).
+            # Only meaningful — and safe to query — when the gateway is live.
+            if running:
+                meta.update(_gateway_plugin_health())
             return DetectResult(
                 name=self.name,
                 display_name=self.display_name,

--- a/tests/test_obs_gap_openclaw_gateway_plugin_health_3200.py
+++ b/tests/test_obs_gap_openclaw_gateway_plugin_health_3200.py
@@ -1,0 +1,93 @@
+"""Tests for issue #3200 — openclaw: gateway plugin health.
+
+Verifies that _gateway_plugin_health() extracts per-plugin state from the
+gateway.status RPC response and surfaces it on DetectResult.meta.
+
+Fingerprint: hgap-267c342338 (used to dedupe — keep it in the body).
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _make_mock_dashboard(rpc_return):
+    """Return a minimal mock dashboard module with _gw_ws_rpc wired up."""
+    mod = types.ModuleType("dashboard")
+    mod._gw_ws_rpc = lambda method, params=None: rpc_return
+    sys.modules["dashboard"] = mod
+    return mod
+
+
+def _reload_adapter():
+    import clawmetry.adapters.openclaw as oc_mod
+    importlib.reload(oc_mod)
+    return oc_mod
+
+
+def test_loaded_errored_disabled_summary():
+    """Helper builds summary counts per state."""
+    _make_mock_dashboard({
+        "plugins": [
+            {"name": "telegram", "state": "loaded", "type": "channel"},
+            {"name": "slack", "state": "errored", "type": "channel"},
+            {"name": "openai", "state": "loaded", "type": "provider"},
+            {"name": "legacy-sms", "state": "disabled", "type": "channel"},
+        ]
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    assert "gatewayPluginHealth" in result
+    assert "gatewayPluginHealthSummary" in result
+    summary = result["gatewayPluginHealthSummary"]
+    assert summary.get("loaded") == 2
+    assert summary.get("errored") == 1
+    assert summary.get("disabled") == 1
+
+
+def test_rpc_returns_none_gives_empty_dict():
+    """When the gateway RPC returns None (gateway down), return {}."""
+    _make_mock_dashboard(None)
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    assert result == {}
+
+
+def test_empty_plugins_list_gives_empty_dict():
+    """An empty plugins list means no data to surface."""
+    _make_mock_dashboard({"plugins": []})
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    assert result == {}
+
+
+def test_plugins_without_type_field_accepted():
+    """Entries without a type field are included; type key omitted."""
+    _make_mock_dashboard({
+        "plugins": [
+            {"name": "whatsapp", "state": "loaded"},
+        ]
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    assert result["gatewayPluginHealthSummary"] == {"loaded": 1}
+    entry = result["gatewayPluginHealth"][0]
+    assert entry["name"] == "whatsapp"
+    assert "type" not in entry
+
+
+def test_entries_with_missing_name_or_state_skipped():
+    """Malformed entries (no name or no state) are silently dropped."""
+    _make_mock_dashboard({
+        "plugins": [
+            {"name": "good-plugin", "state": "loaded"},
+            {"state": "errored"},          # missing name
+            {"name": "no-state-plugin"},   # missing state
+            {},                            # empty
+        ]
+    })
+    oc = _reload_adapter()
+    result = oc._gateway_plugin_health()
+    assert len(result["gatewayPluginHealth"]) == 1
+    assert result["gatewayPluginHealth"][0]["name"] == "good-plugin"


### PR DESCRIPTION
## Summary

The OpenClaw gateway (harness 2026.6.9, #93395) now exposes per-plugin health state (`loaded` / `errored` / `disabled`) in its `gateway.status` RPC response. Without this fix the Flow panel's gateway card has no visibility into which channel/provider plugins are broken — the data existed at the gateway but was never fetched.

## Changes

- **`clawmetry/adapters/openclaw.py`** — new `_gateway_plugin_health()` helper: calls `_gw_ws_rpc("gateway.status")`, extracts the `plugins` list, returns `{"gatewayPluginHealth": [...], "gatewayPluginHealthSummary": {state: count}}` or `{}` on any failure. Wired into `detect()` after `_nemoclaw_agents_manifest()`, gated on `running` to avoid a pointless timeout when the gateway is down.
- **`tests/test_obs_gap_openclaw_gateway_plugin_health_3200.py`** — 5 new tests: loaded/errored/disabled summary counts, graceful `{}` on `None` RPC response, empty plugins list, entries without `type` field, malformed entries silently dropped.

## Test plan

- [x] 5/5 new tests pass
- [x] `python3 -c 'import ast; ast.parse(open("clawmetry/adapters/openclaw.py").read())'` — clean

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3200. Marked draft for human review — mark Ready for Review once happy.

Closes #3200

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nh9D43BNAzaSu7PP6uPvLQ)_