### PR TITLE
fix: surface nemoclaw sandbox Phase/Policy in sandboxInferenceConfigs

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -190,6 +190,34 @@ def _list_ollama_models(host: str) -> list:
         return []
 
 
+def _openshell_sandbox_phase_policy(name: str) -> dict:
+    """Call 'openshell sandbox get <name>' and parse Phase / Policy fields.
+
+    Returns a dict with 'sandboxPhase' and/or 'sandboxPolicy' keys from the
+    CLI output.  Never raises; returns {} when the openshell binary is absent
+    (plain OpenClaw installs) or the subprocess call fails, so existing entries
+    are left unchanged.
+    """
+    try:
+        import shutil as _sh
+        if not _sh.which("openshell"):
+            return {}
+        import subprocess as _sp
+        res = _sp.run(
+            ["openshell", "sandbox", "get", name],
+            capture_output=True, text=True, timeout=5,
+        )
+        out: dict = {}
+        for line in (res.stdout or "").splitlines():
+            if line.startswith("Phase:"):
+                out["sandboxPhase"] = line.split(":", 1)[1].strip()
+            elif line.startswith("Policy:"):
+                out["sandboxPolicy"] = line.split(":", 1)[1].strip()
+        return out
+    except Exception:
+        return {}
+
+
 def _sandbox_inference_configs() -> list:
     """Read per-sandbox inference config from ~/.nemoclaw/sandboxes.json.
 
@@ -199,6 +227,8 @@ def _sandbox_inference_configs() -> list:
     also receive ollamaHost + ollamaModels (gap #3201). The identical derivation
     lives in sync._read_nemoclaw_sandbox_routing (#2684); this helper makes it
     available in the adapter layer without importing the heavy sync module.
+    Also calls _openshell_sandbox_phase_policy() per sandbox to surface live
+    Phase / Policy fields (gap #3202).
     Never raises -- returns [] on plain OpenClaw (no sandboxes.json).
     """
     home = os.environ.get("HOME") or os.path.expanduser("~")
@@ -258,7 +288,7 @@ def _sandbox_inference_configs() -> list:
                 provider_key = _MANAGED
                 primary = f"{_MANAGED}/{model}" if model else ""
                 compat = "openai"
-            out.append({
+            entry = {
                 "sandbox": name,
                 "isDefault": bool(default_sb and name == default_sb),
                 "provider": provider,
@@ -268,7 +298,9 @@ def _sandbox_inference_configs() -> list:
                 "inferenceBaseUrl": base_url,
                 "inferenceApi": api,
                 "inferenceCompat": compat,
-            })
+            }
+            entry.update(_openshell_sandbox_phase_policy(name))
+            out.append(entry)
         except Exception:
             continue
     return out

--- a/tests/test_obs_gap_nemoclaw_sandbox_phase_3202.py
+++ b/tests/test_obs_gap_nemoclaw_sandbox_phase_3202.py
@@ -1,0 +1,148 @@
+"""Tests for #3202 — _openshell_sandbox_phase_policy surfaces live Phase /
+Policy per NemoClaw sandbox in DetectResult.meta.sandboxInferenceConfigs.
+"""
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from clawmetry.adapters.openclaw import (
+    _openshell_sandbox_phase_policy,
+    _sandbox_inference_configs,
+)
+
+
+# -- _openshell_sandbox_phase_policy ------------------------------------------
+
+def test_phase_policy_returns_empty_when_openshell_absent(monkeypatch):
+    """No openshell binary → {} with no exception."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+    assert _openshell_sandbox_phase_policy("alpha") == {}
+
+
+def test_phase_policy_parses_phase_and_policy(monkeypatch):
+    """Both Phase and Policy lines are parsed from openshell output."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "Name: alpha\nPhase: Ready\nPolicy: strict\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    result = _openshell_sandbox_phase_policy("alpha")
+    assert result == {"sandboxPhase": "Ready", "sandboxPolicy": "strict"}
+
+
+def test_phase_policy_empty_policy_value(monkeypatch):
+    """Policy field present but empty → sandboxPolicy = '' (default policy)."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "Name: alpha\nPhase: Ready\nPolicy:\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    result = _openshell_sandbox_phase_policy("alpha")
+    assert result.get("sandboxPhase") == "Ready"
+    assert result.get("sandboxPolicy") == ""
+
+
+def test_phase_policy_only_phase_when_no_policy_line(monkeypatch):
+    """If Policy line is absent only sandboxPhase is set."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "Name: alpha\nPhase: Pending\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    result = _openshell_sandbox_phase_policy("alpha")
+    assert result == {"sandboxPhase": "Pending"}
+
+
+def test_phase_policy_subprocess_error_returns_empty(monkeypatch):
+    """Subprocess failure → {} never raises."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    def boom(*a, **kw):
+        raise OSError("binary broken")
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert _openshell_sandbox_phase_policy("alpha") == {}
+
+
+def test_phase_policy_empty_stdout(monkeypatch):
+    """Empty stdout → {} with no exception (openshell returned nothing)."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": ""})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    assert _openshell_sandbox_phase_policy("beta") == {}
+
+
+# -- integration: _sandbox_inference_configs merges phase fields --------------
+
+def test_sandbox_inference_configs_includes_phase_and_policy(tmp_path, monkeypatch):
+    """sandboxInferenceConfigs entries gain sandboxPhase / sandboxPolicy
+    when openshell is available and returns status for the sandbox."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": "alpha",
+        "sandboxes": {
+            "alpha": {"provider": "anthropic-prod", "model": "claude-opus-4-5"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "Name: alpha\nPhase: Ready\nPolicy:\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    r = result[0]
+    assert r["sandboxPhase"] == "Ready"
+    assert r.get("sandboxPolicy") == ""
+    # existing fields must still be intact
+    assert r["providerKey"] == "anthropic"
+    assert r["isDefault"] is True
+
+
+def test_sandbox_inference_configs_no_phase_when_openshell_absent(tmp_path, monkeypatch):
+    """When openshell is absent, inference config entries are returned without
+    sandboxPhase / sandboxPolicy (backwards-compatible)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": None,
+        "sandboxes": {
+            "dev": {"provider": "openai-api", "model": "gpt-4o"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    r = result[0]
+    assert "sandboxPhase" not in r
+    assert "sandboxPolicy" not in r
+    assert r["providerKey"] == "openai"
+
+
+def test_sandbox_inference_configs_multiple_sandboxes_each_queried(tmp_path, monkeypatch):
+    """Each sandbox is queried independently; phases can differ."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": "prod",
+        "sandboxes": {
+            "prod": {"provider": "anthropic-prod", "model": "claude-opus-4-5"},
+            "dev": {"provider": "openai-api", "model": "gpt-4o"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+
+    phases = {"prod": "Ready", "dev": "Pending"}
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+
+    def fake_run(cmd, **kw):
+        sandbox_name = cmd[-1]
+        stdout = f"Name: {sandbox_name}\nPhase: {phases[sandbox_name]}\nPolicy:\n"
+        return type("R", (), {"stdout": stdout})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 2
+    by_name = {r["sandbox"]: r for r in result}
+    assert by_name["prod"]["sandboxPhase"] == "Ready"
+    assert by_name["dev"]["sandboxPhase"] == "Pending"


### PR DESCRIPTION
Closes #3202

## Summary

- Adds `_openshell_sandbox_phase_policy(name)` helper in `clawmetry/adapters/openclaw.py` that calls `openshell sandbox get <name>` and parses `Phase:` / `Policy:` from stdout
- `_sandbox_inference_configs()` now calls it per sandbox and merges `sandboxPhase` / `sandboxPolicy` into each entry — a crashed or Pending sandbox is now distinguishable from a Ready one
- Returns `{}` gracefully when `openshell` is absent so plain OpenClaw installs are completely unaffected

## Test plan

- `python3 -m pytest tests/test_obs_gap_nemoclaw_sandbox_phase_3202.py -v` — 9 new tests: binary absent, Phase+Policy parsed, empty Policy, Phase-only, subprocess error, empty stdout, integration (phase appears in entry), backwards-compat (no phase when openshell absent), multiple sandboxes queried independently
- `python3 -m pytest tests/test_obs_gap_talk_sandbox.py -k sandbox_inference -v` — 4 existing `_sandbox_inference_configs` tests still pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xu6AuJ2zrpHCKKEGPB2XoS)_