### PR TITLE
feat(entitlements): tier_label + tier_rank + min_tier_for_* + /api/entitlement/required-tier

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -65,6 +65,49 @@ _PAID_TIERS = frozenset(
     {TIER_TRIAL, TIER_CLOUD_STARTER, TIER_CLOUD_PRO, TIER_PRO, TIER_ENTERPRISE}
 )
 
+# Human-readable labels for every known tier id. The dashboard, the CLI, and any
+# operator-facing surface should call :func:`tier_label` instead of hard-coding
+# these strings so the vocabulary stays consistent. Unknown ids are rendered
+# title-cased with underscores swapped for spaces, so a future tier added before
+# this map is updated still renders *something* sensible.
+TIER_LABELS = {
+    TIER_OSS: "OSS",
+    TIER_CLOUD_FREE: "Free",
+    TIER_TRIAL: "Trial",
+    TIER_CLOUD_STARTER: "Starter",
+    TIER_CLOUD_PRO: "Pro",
+    TIER_PRO: "Self-hosted Pro",
+    TIER_ENTERPRISE: "Enterprise",
+}
+
+# Comparable rank per tier (higher = unlocks more). Self-hosted Pro and cloud
+# Pro share rank 2 because they unlock the same feature set; trial sits at the
+# same rank because it grants the full Pro feature set for the trial window.
+# Unknown tiers resolve to -1 from :func:`tier_rank`.
+_TIER_RANK = {
+    TIER_OSS: 0,
+    TIER_CLOUD_FREE: 0,
+    TIER_CLOUD_STARTER: 1,
+    TIER_TRIAL: 2,
+    TIER_CLOUD_PRO: 2,
+    TIER_PRO: 2,
+    TIER_ENTERPRISE: 3,
+}
+
+# Canonical ordering of the *purchasable* plans, lowest -> highest. Used by the
+# ``min_tier_for_*`` helpers so the UI can render locked rows as "Available in
+# Starter" / "Available in Pro" without each caller re-deriving the order.
+# Trial is excluded: it is a time-limited promotional grant of Pro, not a plan a
+# customer can pick from a price page.
+_PURCHASABLE_TIERS = (
+    TIER_OSS,
+    TIER_CLOUD_FREE,
+    TIER_CLOUD_STARTER,
+    TIER_CLOUD_PRO,
+    TIER_PRO,
+    TIER_ENTERPRISE,
+)
+
 # ── Runtime catalogue ───────────────────────────────────────────────────────
 # FREE: the OpenClaw and NVIDIA NemoClaw runtimes. NeMo *governance* (policy
 # enforcement) is a separate free feature; ``nemoclaw`` here is the agent
@@ -287,6 +330,8 @@ class Entitlement:
     def to_dict(self) -> dict:
         return {
             "tier": self.tier,
+            "tier_label": tier_label(self.tier),
+            "tier_rank": tier_rank(self.tier),
             "source": self.source,
             "node_limit": self.node_limit,
             "expiry": self.expiry,
@@ -415,6 +460,69 @@ def runtime_label(runtime: str) -> str:
     so unknown plugin runtimes still render with *something*."""
     rt = (runtime or "").strip().lower()
     return RUNTIME_LABELS.get(rt, rt)
+
+
+def tier_label(tier: str) -> str:
+    """Human-readable label for ``tier``. Mirrors :func:`runtime_label` so the
+    dashboard / CLI never hard-code tier strings.
+
+    An unknown tier id is rendered title-cased with underscores turned into
+    spaces so the UI still has *something* to render. The empty / falsy id
+    falls back to the OSS label.
+    """
+    t = (tier or "").strip().lower()
+    if not t:
+        return TIER_LABELS[TIER_OSS]
+    label = TIER_LABELS.get(t)
+    if label is not None:
+        return label
+    return t.replace("_", " ").title()
+
+
+def tier_rank(tier: str) -> int:
+    """Comparable rank for ``tier`` (higher = unlocks more). Returns ``-1`` for
+    unknown tiers. See :data:`_TIER_RANK` for the canonical numbering."""
+    return _TIER_RANK.get((tier or "").strip().lower(), -1)
+
+
+def min_tier_for_feature(feature: str) -> str | None:
+    """Return the cheapest *purchasable* tier id that grants ``feature``.
+
+    Free features resolve to :data:`TIER_OSS`. Unknown / empty ids return
+    ``None`` so a caller can distinguish "free" from "unknown" without a
+    separate membership check. :data:`TIER_TRIAL` is intentionally excluded:
+    it is a promotional grant, not a plan a customer can select from a price
+    page. Never raises.
+    """
+    f = (feature or "").strip().lower()
+    if not f:
+        return None
+    if f in FREE_FEATURES:
+        return TIER_OSS
+    for tier in _PURCHASABLE_TIERS:
+        if tier in (TIER_OSS, TIER_CLOUD_FREE):
+            continue
+        if f in _TIER_FEATURES.get(tier, frozenset()):
+            return tier
+    return None
+
+
+def min_tier_for_runtime(runtime: str) -> str | None:
+    """Return the cheapest *purchasable* tier id that grants ``runtime``.
+
+    Free runtimes resolve to :data:`TIER_OSS`. Any runtime in
+    :data:`PAID_RUNTIMES` resolves to :data:`TIER_CLOUD_STARTER` (all paid
+    runtimes unlock together via the Starter ``multi_runtime`` grant).
+    Unknown / empty ids return ``None``. Never raises.
+    """
+    rt = (runtime or "").strip().lower()
+    if not rt:
+        return None
+    if rt in FREE_RUNTIMES:
+        return TIER_OSS
+    if rt in PAID_RUNTIMES:
+        return TIER_CLOUD_STARTER
+    return None
 
 
 def runtime_catalog() -> list[dict]:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6,8 +6,11 @@ runtimes/features to surface (and, once enforcement is live, which to render
 locked behind an upgrade CTA). Backed by :mod:`clawmetry.entitlements`, which
 is the single source of truth — handlers never re-derive tier logic here.
 
-  GET /api/entitlement — the current Entitlement as JSON.
-  GET /api/runtimes    — the full runtime catalog with locked/free flags.
+  GET /api/entitlement                — the current Entitlement as JSON.
+  GET /api/entitlement/required-tier  — minimum purchasable tier that unlocks a
+                                        ``feature=<id>`` or ``runtime=<id>``.
+  GET /api/runtimes                   — the full runtime catalog with
+                                        locked/free flags.
 
 Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
 on the cloud side: when no license/cloud plan is present it returns a graceful
@@ -40,6 +43,8 @@ def api_entitlement():
         return jsonify(
             {
                 "tier": "oss",
+                "tier_label": "OSS",
+                "tier_rank": 0,
                 "source": "oss",
                 "node_limit": 1,
                 "expiry": None,
@@ -49,6 +54,88 @@ def api_entitlement():
                 "enforced": False,
                 "runtimes": ["nemoclaw", "openclaw"],
                 "features": [],
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/required-tier")
+def api_entitlement_required_tier():
+    """Resolve the minimum *purchasable* tier that unlocks a given feature or
+    runtime. Drives the lock-affordance copy ("Available in Starter" / "Available
+    in Pro") so the dashboard never re-derives the per-feature tier bucket in
+    JavaScript.
+
+    Query: exactly one of ``feature=<id>`` or ``runtime=<id>``.
+
+    Returns 200 with::
+
+        {
+          "key":                 "<id>",
+          "kind":                "feature" | "runtime",
+          "required_tier":       "<tier>" | null,
+          "required_tier_label": "<Display>" | null,
+          "required_tier_rank":  int,                 # -1 when unknown
+          "current_tier":        "<tier>",
+          "current_tier_rank":   int,
+          "upgrade_required":    bool,                # required rank > current rank
+          "allowed":             bool                 # resolved allows_* answer
+        }
+
+    Returns 400 when neither query param is supplied or both are given. Never
+    5xx — any internal failure returns the never-raise grace shape so a flaky
+    entitlement read can never break a paywall tooltip render.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        feature = (request.args.get("feature") or "").strip().lower()
+        runtime = (request.args.get("runtime") or "").strip().lower()
+        if not feature and not runtime:
+            return jsonify({"error": "supply either feature=<id> or runtime=<id>"}), 400
+        if feature and runtime:
+            return jsonify({"error": "supply only one of feature= or runtime="}), 400
+        ent = _ent.get_entitlement()
+        if feature:
+            key, kind = feature, "feature"
+            required = _ent.min_tier_for_feature(feature)
+            allowed = ent.allows_feature(feature)
+        else:
+            key, kind = runtime, "runtime"
+            required = _ent.min_tier_for_runtime(runtime)
+            allowed = ent.allows_runtime(runtime)
+        cur_rank = _ent.tier_rank(ent.tier)
+        req_rank = _ent.tier_rank(required) if required else -1
+        required_label = _ent.tier_label(required) if required else None
+        return jsonify(
+            {
+                "key": key,
+                "kind": kind,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "current_tier": ent.tier,
+                "current_tier_rank": cur_rank,
+                "upgrade_required": bool(required) and req_rank > cur_rank,
+                "allowed": allowed,
+            }
+        )
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_entitlement_required_tier: error: %s", exc)
+        feature = (request.args.get("feature") or "").strip().lower()
+        runtime = (request.args.get("runtime") or "").strip().lower()
+        key = feature or runtime
+        kind = "feature" if feature else ("runtime" if runtime else "")
+        return jsonify(
+            {
+                "key": key,
+                "kind": kind,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "upgrade_required": False,
+                "allowed": True,
             }
         )
 

--- a/tests/test_entitlements_min_tier.py
+++ b/tests/test_entitlements_min_tier.py
@@ -1,0 +1,295 @@
+"""Tests for the tier-ordering primitives on :mod:`clawmetry.entitlements`.
+
+Pins the contracts for:
+
+* :func:`tier_label` -- human-readable label, with a graceful fallback for
+  unknown ids so the UI never shows a blank pill.
+* :func:`tier_rank` -- comparable rank used by the paywall to decide whether a
+  click on a locked feature must route the operator through an upgrade.
+* :func:`min_tier_for_feature` / :func:`min_tier_for_runtime` -- the "Available
+  in ___" copy backing the lock affordance: free items resolve to ``oss``,
+  paid items to their cheapest *purchasable* tier (Trial is excluded -- it is
+  a promotional grant, not a price-page row).
+* ``GET /api/entitlement/required-tier`` -- the matching HTTP surface, plus
+  the never-raise contract on top of a flaky resolver.
+* ``tier_label`` / ``tier_rank`` carried on ``/api/entitlement`` itself, so the
+  dashboard's existing entitlement read keeps a single source of truth for
+  copy + ordering.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module rooted at an empty tmp HOME, enforcement off."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── tier_label ───────────────────────────────────────────────────────────────
+
+
+def test_tier_label_known_ids(ent):
+    assert ent.tier_label(ent.TIER_OSS) == "OSS"
+    assert ent.tier_label(ent.TIER_CLOUD_FREE) == "Free"
+    assert ent.tier_label(ent.TIER_CLOUD_STARTER) == "Starter"
+    assert ent.tier_label(ent.TIER_CLOUD_PRO) == "Pro"
+    assert ent.tier_label(ent.TIER_PRO) == "Self-hosted Pro"
+    assert ent.tier_label(ent.TIER_TRIAL) == "Trial"
+    assert ent.tier_label(ent.TIER_ENTERPRISE) == "Enterprise"
+
+
+def test_tier_label_is_case_insensitive(ent):
+    assert ent.tier_label("OSS") == "OSS"
+    assert ent.tier_label("Cloud_Pro") == "Pro"
+
+
+def test_tier_label_unknown_falls_back_to_title_case(ent):
+    # Unknown ids still render *something* sensible so the UI never shows a
+    # blank pill if a future tier slips in before the label map is updated.
+    assert ent.tier_label("custom_plan") == "Custom Plan"
+
+
+def test_tier_label_empty_falls_back_to_oss(ent):
+    # A blank tier reads like "no info" and should match the OSS-free fallback
+    # everywhere else in the resolver.
+    assert ent.tier_label("") == "OSS"
+    assert ent.tier_label(None) == "OSS"  # type: ignore[arg-type]
+
+
+def test_every_known_tier_has_a_label(ent):
+    """The label catalog must cover every TIER_* constant -- the catalogue
+    conformance check the UI relies on so adding a tier without a label trips
+    here, not in production."""
+    canonical = {
+        ent.TIER_OSS, ent.TIER_CLOUD_FREE, ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO, ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    assert canonical <= set(ent.TIER_LABELS)
+
+
+# ── tier_rank ────────────────────────────────────────────────────────────────
+
+
+def test_tier_rank_orders_ladder(ent):
+    assert ent.tier_rank(ent.TIER_OSS) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_FREE) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_STARTER) == 1
+    # cloud_pro and self-hosted pro share rank 2 -- they unlock the same set.
+    assert ent.tier_rank(ent.TIER_CLOUD_PRO) == 2
+    assert ent.tier_rank(ent.TIER_PRO) == 2
+    assert ent.tier_rank(ent.TIER_TRIAL) == 2
+    assert ent.tier_rank(ent.TIER_ENTERPRISE) == 3
+
+
+def test_tier_rank_unknown_is_negative(ent):
+    assert ent.tier_rank("unknown_plan") == -1
+    assert ent.tier_rank("") == -1
+
+
+def test_tier_rank_is_strictly_increasing_along_purchasable_ladder(ent):
+    # The "Upgrade required" boolean on /api/entitlement/required-tier compares
+    # ranks; if the ladder regressed (e.g. starter > pro) the upgrade CTA
+    # would point operators at the *wrong* tier.
+    ranks = [
+        ent.tier_rank(ent.TIER_OSS),
+        ent.tier_rank(ent.TIER_CLOUD_STARTER),
+        ent.tier_rank(ent.TIER_CLOUD_PRO),
+        ent.tier_rank(ent.TIER_ENTERPRISE),
+    ]
+    assert ranks == sorted(ranks)
+    assert len(set(ranks)) == len(ranks)  # strictly increasing
+
+
+# ── min_tier_for_feature ─────────────────────────────────────────────────────
+
+
+def test_min_tier_for_feature_free(ent):
+    for f in ("sessions", "overview", "nemo_governance"):
+        assert ent.min_tier_for_feature(f) == ent.TIER_OSS
+
+
+def test_min_tier_for_feature_starter(ent):
+    # STARTER_FEATURES all resolve to cloud_starter -- the cheapest tier that
+    # grants the multi_runtime/fleet/all_channels bucket.
+    for f in ent.STARTER_FEATURES:
+        assert ent.min_tier_for_feature(f) == ent.TIER_CLOUD_STARTER
+
+
+def test_min_tier_for_feature_pro_only(ent):
+    # PRO_ONLY_FEATURES require cloud_pro -- starter does not grant them.
+    for f in ent.PRO_ONLY_FEATURES:
+        assert ent.min_tier_for_feature(f) == ent.TIER_CLOUD_PRO
+
+
+def test_min_tier_for_feature_enterprise(ent):
+    for f in ent.ENTERPRISE_FEATURES:
+        assert ent.min_tier_for_feature(f) == ent.TIER_ENTERPRISE
+
+
+def test_min_tier_for_feature_unknown_returns_none(ent):
+    # Unknown id is distinguishable from "free"; the route renders no CTA
+    # rather than misleading the operator about a non-existent tier.
+    assert ent.min_tier_for_feature("not_a_real_feature") is None
+
+
+def test_min_tier_for_feature_empty_returns_none(ent):
+    assert ent.min_tier_for_feature("") is None
+    assert ent.min_tier_for_feature(None) is None  # type: ignore[arg-type]
+
+
+def test_min_tier_for_feature_does_not_return_trial(ent):
+    """Trial unlocks the full Pro set but is a promotional grant, not a price-
+    page row. The required-tier CTA should never advertise it as the upgrade
+    target."""
+    for f in ent.PAID_FEATURES | ent.ENTERPRISE_FEATURES:
+        assert ent.min_tier_for_feature(f) != ent.TIER_TRIAL
+
+
+# ── min_tier_for_runtime ─────────────────────────────────────────────────────
+
+
+def test_min_tier_for_runtime_free(ent):
+    for rt in ent.FREE_RUNTIMES:
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_OSS
+
+
+def test_min_tier_for_runtime_paid_is_starter(ent):
+    # All paid runtimes unlock together via Starter's multi_runtime grant.
+    for rt in ent.PAID_RUNTIMES:
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_CLOUD_STARTER
+
+
+def test_min_tier_for_runtime_unknown_returns_none(ent):
+    assert ent.min_tier_for_runtime("not_a_runtime") is None
+    assert ent.min_tier_for_runtime("") is None
+
+
+# ── /api/entitlement surfacing ───────────────────────────────────────────────
+
+
+def test_api_entitlement_surfaces_tier_label_and_rank(client, ent):
+    rv = client.get("/api/entitlement")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["tier_label"] == "OSS"
+    assert body["tier_rank"] == 0
+
+
+# ── /api/entitlement/required-tier ───────────────────────────────────────────
+
+
+def test_required_tier_feature_starter(client, ent):
+    rv = client.get("/api/entitlement/required-tier?feature=multi_runtime")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "feature"
+    assert body["key"] == "multi_runtime"
+    assert body["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["required_tier_label"] == "Starter"
+    assert body["required_tier_rank"] == 1
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_rank"] == 0
+    assert body["upgrade_required"] is True
+    # Grace mode still flips allowed=True regardless of upgrade_required --
+    # both flags carry independent information for the UI.
+    assert body["allowed"] is True
+
+
+def test_required_tier_feature_pro(client, ent):
+    rv = client.get("/api/entitlement/required-tier?feature=self_evolve")
+    body = rv.get_json()
+    assert body["required_tier"] == ent.TIER_CLOUD_PRO
+    assert body["required_tier_rank"] == 2
+    assert body["upgrade_required"] is True
+
+
+def test_required_tier_feature_enterprise(client, ent):
+    rv = client.get("/api/entitlement/required-tier?feature=sso")
+    body = rv.get_json()
+    assert body["required_tier"] == ent.TIER_ENTERPRISE
+    assert body["upgrade_required"] is True
+
+
+def test_required_tier_feature_free(client, ent):
+    rv = client.get("/api/entitlement/required-tier?feature=sessions")
+    body = rv.get_json()
+    assert body["required_tier"] == ent.TIER_OSS
+    assert body["upgrade_required"] is False
+    assert body["allowed"] is True
+
+
+def test_required_tier_runtime_paid(client, ent):
+    rv = client.get("/api/entitlement/required-tier?runtime=claude_code")
+    body = rv.get_json()
+    assert body["kind"] == "runtime"
+    assert body["key"] == "claude_code"
+    assert body["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["upgrade_required"] is True
+
+
+def test_required_tier_runtime_free(client, ent):
+    rv = client.get("/api/entitlement/required-tier?runtime=openclaw")
+    body = rv.get_json()
+    assert body["required_tier"] == ent.TIER_OSS
+    assert body["upgrade_required"] is False
+
+
+def test_required_tier_unknown_feature_returns_null(client, ent):
+    rv = client.get("/api/entitlement/required-tier?feature=not_real")
+    body = rv.get_json()
+    # Unknown ids carry through as null so the UI shows no CTA at all rather
+    # than advertising a tier that doesn't actually grant the missing key.
+    assert body["required_tier"] is None
+    assert body["required_tier_label"] is None
+    assert body["upgrade_required"] is False
+
+
+def test_required_tier_no_query_400(client):
+    rv = client.get("/api/entitlement/required-tier")
+    assert rv.status_code == 400
+
+
+def test_required_tier_both_query_400(client):
+    rv = client.get("/api/entitlement/required-tier?feature=sessions&runtime=openclaw")
+    assert rv.status_code == 400
+
+
+# ── never-raise on resolver failure ──────────────────────────────────────────
+
+
+def test_required_tier_swallows_resolver_failure(monkeypatch, client, ent):
+    """A flaky entitlement read must never break the paywall tooltip render --
+    the route falls back to the OSS-free shape instead of 5xx."""
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/required-tier?feature=multi_runtime")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["allowed"] is True
+    assert body["current_tier"] == "oss"
+    assert body["upgrade_required"] is False


### PR DESCRIPTION
## Summary

Open-core foundation: the tier-ordering primitives the paywall surface needs to render a locked-but-visible affordance with accurate "Available in <Tier>" copy, without the dashboard re-deriving per-feature tier buckets in JavaScript.

Purely additive. No behavior change. Grace mode (the default) still flips every `allows_*` check `True`, so wiring this in changes nothing on a current install.

## Changes

**`clawmetry/entitlements.py`** -- new module-level helpers:

- `TIER_LABELS` + `tier_label(tier)` -- single source of truth for tier copy, with a title-cased fallback so an unknown id never blanks the UI.
- `_TIER_RANK` + `tier_rank(tier)` -- comparable rank; `cloud_pro` / `pro` (self-hosted) / `trial` share rank 2 because they unlock the same feature set. Unknown tiers resolve to `-1`.
- `min_tier_for_feature(feature)` -- cheapest *purchasable* tier that grants `feature`. Free features resolve to `oss`; unknown ids return `None` so a caller can tell "free" from "missing" without a separate membership check. `TIER_TRIAL` is intentionally excluded (promotional grant, not a price-page row).
- `min_tier_for_runtime(runtime)` -- the runtime sibling. All `PAID_RUNTIMES` unlock together via Starter's `multi_runtime` grant.

`Entitlement.to_dict()` now carries `tier_label` + `tier_rank` so an existing `/api/entitlement` consumer reads both without a second round trip.

**`routes/entitlement.py`** -- new endpoint:

`GET /api/entitlement/required-tier?feature=<id>` _OR_ `?runtime=<id>` returns:

```json
{
  "key": "self_evolve",
  "kind": "feature",
  "required_tier": "cloud_pro",
  "required_tier_label": "Pro",
  "required_tier_rank": 2,
  "current_tier": "oss",
  "current_tier_rank": 0,
  "upgrade_required": true,
  "allowed": true
}
```

- `400` when neither query param is supplied or both are given.
- Never `5xx` -- a flaky resolver falls back to the OSS-free grace shape so a paywall tooltip never breaks the page.

**`tests/test_entitlements_min_tier.py`** -- 29 new assertions covering:

- Label / rank catalog conformance (every `TIER_*` constant has a label; the ladder is strictly increasing across the purchasable tiers).
- Free / Starter / Pro / Enterprise bucket mapping for `min_tier_for_feature`.
- The `min_tier_for_*` never-returns-trial invariant.
- The 400 (missing/both query) and 200 shapes on the new endpoint.
- Never-raise contract under a synthetic `get_entitlement` failure.

## Open-core rollout status

Grace mode still on. Trial still excluded from `min_tier_for_*` (intentional; promotional grant). No enforcement flips, no `__version__` bump, no `[RELEASE]` tag.

## Local operator verification checklist

The remote container cannot reach `~/.clawmetry/`, the live daemon, or the cloud snapshot, so these steps belong to the local operator:

1. Copy the changed files into the editable install:
   ```bash
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/
   cp routes/entitlement.py     ~/.clawmetry/lib/python*/site-packages/routes/
   find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
   ```
2. Kick the sync daemon so the new code path loads:
   ```bash
   launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
   ```
3. Smoke the new endpoint against the live dashboard:
   ```bash
   curl -s http://localhost:8900/api/entitlement | jq '.tier_label,.tier_rank'
   curl -s 'http://localhost:8900/api/entitlement/required-tier?feature=self_evolve' | jq
   curl -s 'http://localhost:8900/api/entitlement/required-tier?runtime=claude_code' | jq
   curl -s 'http://localhost:8900/api/entitlement/required-tier' -w '\n%{http_code}\n'   # expect 400
   ```
4. Decrypt the live cloud snapshot in the browser and confirm `/api/entitlement` still renders (grace shape, no UI change).
5. Browser-check the Overview / paywall surface: no new lock affordances should appear (grace mode still on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rmmaymGqeQWpyWnZpVEHd

---
_Generated by [Claude Code](https://claude.ai/code/session_018rmmaymGqeQWpyWnZpVEHd)_