### PR TITLE
feat(entitlements): min_tier_for_channel_count + min_tier_for_retention_window

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1561,6 +1561,86 @@ def min_tier_for_runtime(runtime: str) -> str | None:
     return None
 
 
+def min_tier_for_channel_count(count: int) -> str | None:
+    """Return the cheapest *purchasable* tier id whose channel-adapter cap fits
+    ``count`` configured channels. Closes the symmetry gap with
+    :func:`min_tier_for_feature` / :func:`min_tier_for_runtime` so the lock
+    affordance on the channels surface ("you have 5 channels -- Available in
+    Starter") reads from the same single source of truth.
+
+    Walks :data:`_PURCHASABLE_TIERS` (cheapest -> most capable, trial excluded
+    -- it is a promotional grant, not a plan a customer can pick from a price
+    page) and returns the first tier whose ``_TIER_CHANNEL_LIMIT`` value is
+    either ``None`` (unlimited) or ``>= count``.
+
+    Semantics:
+
+    * ``count <= 0`` -- collapses to :data:`TIER_OSS`. A zero/negative count is
+      either "not measured yet" or trivially satisfied; either way the free
+      floor covers it (matches :meth:`Entitlement.allows_channel_count`'s
+      grace-on-zero contract).
+    * Non-int ``count`` -- returns ``None`` so a caller can distinguish "free"
+      from "couldn't parse". Never raises.
+    * Otherwise -- the first tier whose cap admits ``count``, falling back to
+      :data:`TIER_ENTERPRISE` if every finite cap is exceeded (Enterprise is
+      unlimited, so this is always a safe ceiling).
+    """
+    try:
+        n = int(count)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return TIER_OSS
+    for tier in _PURCHASABLE_TIERS:
+        cap = _TIER_CHANNEL_LIMIT.get(tier, _FREE_CHANNEL_LIMIT)
+        if cap is None or n <= cap:
+            return tier
+    return TIER_ENTERPRISE
+
+
+def min_tier_for_retention_window(days: int | None) -> str | None:
+    """Return the cheapest *purchasable* tier id whose event-retention cap fits
+    a ``days`` history window. Companion to :func:`min_tier_for_channel_count`
+    so the history-range toggle ("7 / 30 / 90 / all") can render "Available in
+    <tier>" copy off the same canonical reverse lookup the other gates use.
+
+    Walks :data:`_PURCHASABLE_TIERS` (cheapest -> most capable, trial excluded)
+    and returns the first tier whose ``_TIER_RETENTION_DAYS`` value either
+    matches the unlimited request (``days is None``) or admits the finite
+    window.
+
+    Semantics:
+
+    * ``days is None`` (caller asked for unlimited history) -- returns the
+      first tier whose cap is ``None``, i.e. :data:`TIER_ENTERPRISE`. Mirrors
+      :meth:`Entitlement.allows_retention_window` which only grants ``None``
+      to Enterprise.
+    * ``days <= 0`` -- collapses to :data:`TIER_OSS`. Asking for zero history
+      is trivially satisfied by the free floor (same posture as
+      :meth:`Entitlement.allows_retention_window`).
+    * Non-int ``days`` (other than the explicit ``None``) -- returns ``None``
+      so a caller can distinguish "free" from "couldn't parse". Never raises.
+    * Otherwise -- the first tier whose cap admits ``days``, falling back to
+      :data:`TIER_ENTERPRISE` if every finite cap is exceeded.
+    """
+    if days is None:
+        for tier in _PURCHASABLE_TIERS:
+            if _TIER_RETENTION_DAYS.get(tier, 7) is None:
+                return tier
+        return TIER_ENTERPRISE
+    try:
+        n = int(days)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return TIER_OSS
+    for tier in _PURCHASABLE_TIERS:
+        cap = _TIER_RETENTION_DAYS.get(tier, 7)
+        if cap is None or n <= cap:
+            return tier
+    return TIER_ENTERPRISE
+
+
 def lock_reason(item: str, *, kind: str | None = None) -> str | None:
     """Module-level convenience: resolve the current entitlement and return
     why ``item`` is locked, or ``None`` when allowed (or on any error).

--- a/tests/test_entitlements_min_tier_capacity.py
+++ b/tests/test_entitlements_min_tier_capacity.py
@@ -1,0 +1,189 @@
+"""Tests for the capacity-axis ``min_tier_for_*`` helpers.
+
+``min_tier_for_channel_count(n)`` and ``min_tier_for_retention_window(days)``
+close the symmetry gap with ``min_tier_for_feature`` / ``min_tier_for_runtime``
+so the lock affordance on the channel-overflow and history-range surfaces can
+render "Available in <tier>" copy off a single canonical reverse lookup
+instead of re-deriving the per-tier cap tables in JavaScript.
+
+This file pins the bucket boundaries so a future tier-cap shuffle (e.g.
+raising Starter retention from 30d to 45d, or dropping the free channel
+limit) breaks loudly here instead of silently in the UI.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── min_tier_for_channel_count ───────────────────────────────────────────────
+
+
+def test_channel_count_zero_or_negative_collapses_to_oss(ent):
+    # zero/negative means "not measured yet" or trivially satisfied -- the free
+    # floor covers it (mirrors allows_channel_count's grace-on-zero contract).
+    assert ent.min_tier_for_channel_count(0) == ent.TIER_OSS
+    assert ent.min_tier_for_channel_count(-5) == ent.TIER_OSS
+
+
+def test_channel_count_within_free_cap_is_oss(ent):
+    # Free cap is 3 (see _FREE_CHANNEL_LIMIT). 1/2/3 all fit on OSS.
+    assert ent.min_tier_for_channel_count(1) == ent.TIER_OSS
+    assert ent.min_tier_for_channel_count(2) == ent.TIER_OSS
+    assert ent.min_tier_for_channel_count(3) == ent.TIER_OSS
+
+
+def test_channel_count_over_free_cap_requires_starter(ent):
+    # Every paid tier has channel_limit=None (unlimited), so the first tier
+    # above the free cap is Starter -- the "Available in Starter" surface.
+    assert ent.min_tier_for_channel_count(4) == ent.TIER_CLOUD_STARTER
+    assert ent.min_tier_for_channel_count(21) == ent.TIER_CLOUD_STARTER
+    assert ent.min_tier_for_channel_count(1_000_000) == ent.TIER_CLOUD_STARTER
+
+
+def test_channel_count_non_int_returns_none(ent):
+    # None / unparseable -- caller can distinguish "free" from "broken input".
+    assert ent.min_tier_for_channel_count(None) is None
+    assert ent.min_tier_for_channel_count("not a number") is None
+    assert ent.min_tier_for_channel_count(object()) is None
+
+
+def test_channel_count_string_digit_is_accepted(ent):
+    # int() accepts numeric strings; documenting the wire-side contract.
+    assert ent.min_tier_for_channel_count("3") == ent.TIER_OSS
+    assert ent.min_tier_for_channel_count("4") == ent.TIER_CLOUD_STARTER
+
+
+def test_channel_count_never_returns_trial(ent):
+    # Trial is a promotional grant, not a price-page row -- the lock copy
+    # should never advertise it. Sweep a representative range.
+    for n in (0, 1, 3, 4, 5, 10, 21, 100):
+        assert ent.min_tier_for_channel_count(n) != ent.TIER_TRIAL
+
+
+def test_channel_count_returns_purchasable_tiers_only(ent):
+    # Every answer must be selectable from /pricing (trial excluded by design).
+    purchasable = {
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    for n in (0, 1, 3, 4, 21, 100):
+        assert ent.min_tier_for_channel_count(n) in purchasable
+
+
+# ── min_tier_for_retention_window ────────────────────────────────────────────
+
+
+def test_retention_zero_or_negative_collapses_to_oss(ent):
+    # Same posture as channel_count: zero history is trivially satisfied.
+    assert ent.min_tier_for_retention_window(0) == ent.TIER_OSS
+    assert ent.min_tier_for_retention_window(-30) == ent.TIER_OSS
+
+
+def test_retention_within_free_cap_is_oss(ent):
+    # Free cap is 7 days.
+    assert ent.min_tier_for_retention_window(1) == ent.TIER_OSS
+    assert ent.min_tier_for_retention_window(7) == ent.TIER_OSS
+
+
+def test_retention_within_starter_cap_is_starter(ent):
+    # Starter cap is 30 days. 8..30 fall in this bucket.
+    assert ent.min_tier_for_retention_window(8) == ent.TIER_CLOUD_STARTER
+    assert ent.min_tier_for_retention_window(14) == ent.TIER_CLOUD_STARTER
+    assert ent.min_tier_for_retention_window(30) == ent.TIER_CLOUD_STARTER
+
+
+def test_retention_within_pro_cap_is_cloud_pro(ent):
+    # Pro cap is 90 days. 31..90 fall here.
+    assert ent.min_tier_for_retention_window(31) == ent.TIER_CLOUD_PRO
+    assert ent.min_tier_for_retention_window(60) == ent.TIER_CLOUD_PRO
+    assert ent.min_tier_for_retention_window(90) == ent.TIER_CLOUD_PRO
+
+
+def test_retention_above_pro_cap_requires_enterprise(ent):
+    # Anything over 90 days only fits Enterprise (cap=None / unlimited).
+    assert ent.min_tier_for_retention_window(91) == ent.TIER_ENTERPRISE
+    assert ent.min_tier_for_retention_window(180) == ent.TIER_ENTERPRISE
+    assert ent.min_tier_for_retention_window(3650) == ent.TIER_ENTERPRISE
+
+
+def test_retention_unlimited_request_is_enterprise(ent):
+    # ``days is None`` means "unlimited history", which only Enterprise grants
+    # -- mirrors allows_retention_window's `days is None -> Enterprise only`.
+    assert ent.min_tier_for_retention_window(None) == ent.TIER_ENTERPRISE
+
+
+def test_retention_non_int_returns_none(ent):
+    # Distinguishes "no answer" from "free floor". ``None`` is the explicit
+    # unlimited request and is handled above.
+    assert ent.min_tier_for_retention_window("not a number") is None
+    assert ent.min_tier_for_retention_window(object()) is None
+
+
+def test_retention_string_digit_is_accepted(ent):
+    assert ent.min_tier_for_retention_window("7") == ent.TIER_OSS
+    assert ent.min_tier_for_retention_window("30") == ent.TIER_CLOUD_STARTER
+    assert ent.min_tier_for_retention_window("90") == ent.TIER_CLOUD_PRO
+
+
+def test_retention_never_returns_trial(ent):
+    # Trial is excluded by design even though _TIER_RETENTION_DAYS lists it.
+    for d in (0, 1, 7, 8, 30, 31, 90, 91, 365, None):
+        assert ent.min_tier_for_retention_window(d) != ent.TIER_TRIAL
+
+
+def test_retention_returns_purchasable_tiers_only(ent):
+    purchasable = {
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    for d in (0, 1, 7, 8, 30, 31, 90, 91, 365, None):
+        assert ent.min_tier_for_retention_window(d) in purchasable
+
+
+def test_retention_buckets_are_monotonic_in_tier_rank(ent):
+    # As days grow the answer should never get cheaper.
+    samples = [1, 7, 8, 30, 31, 90, 91, 365]
+    ranks = [ent.tier_rank(ent.min_tier_for_retention_window(d)) for d in samples]
+    assert ranks == sorted(ranks), ranks
+
+
+def test_channel_count_buckets_are_monotonic_in_tier_rank(ent):
+    samples = [0, 1, 3, 4, 5, 21, 100]
+    ranks = [ent.tier_rank(ent.min_tier_for_channel_count(n)) for n in samples]
+    assert ranks == sorted(ranks), ranks
+
+
+# ── never-raise contract ─────────────────────────────────────────────────────
+
+
+def test_helpers_never_raise_on_garbage(ent):
+    # The dashboard renders these inline; a stray non-numeric query string
+    # must never crash the page.
+    for bad in (None, "", "abc", [], {}, object()):
+        try:
+            ent.min_tier_for_channel_count(bad)
+            ent.min_tier_for_retention_window(bad)
+        except Exception as exc:  # pragma: no cover - regression guard
+            pytest.fail(f"helper raised on {bad!r}: {exc}")


### PR DESCRIPTION
## Summary

Closes the symmetry gap on the two capacity-axis gates. `min_tier_for_feature` and `min_tier_for_runtime` already exist so the lock affordance ("Available in Starter" / "Available in Pro") can render off a single canonical reverse lookup; the **channel-overflow** and **history-range** surfaces had no matching helper, leaving them to re-derive the per-tier cap tables in JavaScript (or skip the copy entirely).

Purely additive. No behaviour change. Grace mode (the default) still flips every `allows_*` check `True`, so wiring this into a route changes nothing on a current install.

## Changes

**`clawmetry/entitlements.py`** -- two new module-level helpers:

- `min_tier_for_channel_count(count)` -- walks `_PURCHASABLE_TIERS` (trial excluded -- promotional grant, not a price-page row) and returns the cheapest tier whose `_TIER_CHANNEL_LIMIT` value is either `None` (unlimited) or `>= count`. Free floor (`_FREE_CHANNEL_LIMIT == 3`) covers `count <= 3`; anything above bumps straight to Starter (every paid tier is unlimited).
- `min_tier_for_retention_window(days)` -- mirror of the above against `_TIER_RETENTION_DAYS`. Buckets: 0..7 -> OSS, 8..30 -> Starter, 31..90 -> Pro, 91+ -> Enterprise. `days is None` (caller asked for unlimited history) resolves to Enterprise -- matches `allows_retention_window`'s "`None` only granted to Enterprise" contract.

Both honour the existing never-raise posture:
- non-int input returns `None` so a caller can distinguish "free floor" from "couldn't parse"
- `n <= 0` collapses to OSS so a not-yet-measured count never appears mysteriously locked

No endpoints wired and no callers updated -- this is just the canonical lookup the channels surface + the history-range toggle will read once they pick it up. Mirrors the rollout shape of the existing `min_tier_for_feature` / `min_tier_for_runtime` helpers.

**`tests/test_entitlements_min_tier_capacity.py`** -- 20 new assertions pinning the bucket boundaries so a future tier-cap shuffle (Starter retention 30->45d, free channel cap 3->5) breaks loudly here instead of silently in the UI:

- zero / negative collapse to OSS
- within-free-cap stays on OSS
- over-free-cap bumps to Starter (channels) / Starter / Pro / Enterprise (retention by bucket)
- `days is None` -> Enterprise
- non-int input returns `None`
- trial never appears in the answer set
- answer ranks are monotonic in the input size

## Open-core rollout status

Grace mode still on. No `allows_*` semantics change. No `__version__` bump. No `[RELEASE]` tag.

## Local operator verification checklist

The remote container cannot reach `~/.clawmetry/`, the live daemon, the live cloud snapshot, or a browser, so these belong to the local operator:

1. Copy the changed files into the editable install:
   ```bash
   cp clawmetry/entitlements.py                       ~/.clawmetry/lib/python*/site-packages/clawmetry/
   cp tests/test_entitlements_min_tier_capacity.py    ~/.clawmetry/lib/python*/site-packages/../tests/  # if you mirror tests locally
   find ~/.clawmetry/lib -name __pycache__ -type d -exec rm -rf {} +
   ```
2. Kick the sync daemon so the new code path loads:
   ```bash
   launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
   ```
3. Smoke the helpers from the REPL (no endpoint yet -- this PR is intentionally helper-only):
   ```bash
   python3 -c "
   from clawmetry import entitlements as e
   print(e.min_tier_for_channel_count(3),  '== oss')
   print(e.min_tier_for_channel_count(4),  '== cloud_starter')
   print(e.min_tier_for_retention_window(7),    '== oss')
   print(e.min_tier_for_retention_window(30),   '== cloud_starter')
   print(e.min_tier_for_retention_window(90),   '== cloud_pro')
   print(e.min_tier_for_retention_window(180),  '== enterprise')
   print(e.min_tier_for_retention_window(None), '== enterprise')
   "
   ```
4. Confirm `/api/entitlement` still renders unchanged (no shape diff -- this PR adds no fields).
5. Decrypt the live cloud snapshot in the browser and confirm the dashboard renders normally (grace mode invariant: zero UI delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrRX17D3bdXMdcUre6UqNw)_