### PR TITLE
feat(entitlement): carry required_tier on /api/entitlement/lock-reason

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -16,7 +16,12 @@ is the single source of truth -- handlers never re-derive tier logic here.
   GET  /api/entitlement/required-tier -- resolve the minimum purchasable tier
                                          for a feature= or runtime= key.
   GET  /api/entitlement/lock-reason   -- human-readable explanation of why a
-                                         feature= or runtime= key is locked.
+                                         feature= or runtime= key is locked,
+                                         carrying the structured
+                                         ``required_tier`` payload alongside
+                                         the message so a paywall tooltip can
+                                         render "Locked: <reason>. [Upgrade to
+                                         <X>]" in one round-trip.
   GET  /api/entitlement/upgrade-diff  -- features + runtimes a target tier
                                          would add on top of the current ent.
   GET  /api/entitlement/downgrade-diff -- features + runtimes a target tier
@@ -213,10 +218,15 @@ def api_entitlement_lock_reason():
         if feature:
             key, kind = feature, "feature"
             allowed = ent.allows_feature(feature)
+            required = _ent.min_tier_for_feature(feature)
         else:
             key, kind = runtime, "runtime"
             allowed = ent.allows_runtime(runtime)
+            required = _ent.min_tier_for_runtime(runtime)
         reason = ent.lock_reason(key, kind=kind)
+        cur_rank = _ent.tier_rank(ent.tier)
+        req_rank = _ent.tier_rank(required) if required else -1
+        required_label = _ent.tier_label(required) if required else None
         return jsonify(
             {
                 "key": key,
@@ -224,6 +234,12 @@ def api_entitlement_lock_reason():
                 "reason": reason,
                 "locked": reason is not None,
                 "allowed": allowed,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "current_tier": ent.tier,
+                "current_tier_rank": cur_rank,
+                "upgrade_required": bool(required) and req_rank > cur_rank,
             }
         )
     except Exception as exc:
@@ -243,6 +259,12 @@ def api_entitlement_lock_reason():
                 "reason": None,
                 "locked": False,
                 "allowed": True,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "upgrade_required": False,
             }
         )
 

--- a/tests/test_entitlement_api_lock_reason.py
+++ b/tests/test_entitlement_api_lock_reason.py
@@ -11,6 +11,11 @@ wire contract:
 * paid items on enforced OSS return a non-empty reason naming the unlock
   tier (Starter / Pro / Enterprise) + ``locked: true``
 * explicit ``feature=`` / ``runtime=`` carry the correct ``kind``
+* the ``required_tier`` payload (id + label + rank, plus the current tier
+  and an ``upgrade_required`` flag) rides alongside the message so a
+  paywall tooltip can render "Locked: <reason>. [Upgrade to <X>]" in a
+  single round-trip instead of pairing this call with
+  ``/api/entitlement/required-tier``
 * the never-raise grace fallback still returns the documented shape
 """
 from __future__ import annotations
@@ -64,13 +69,19 @@ def test_grace_feature_is_unlocked(client):
     resp = c.get("/api/entitlement/lock-reason?feature=self_evolve")
     assert resp.status_code == 200
     d = resp.get_json()
-    assert d == {
-        "key": "self_evolve",
-        "kind": "feature",
-        "reason": None,
-        "locked": False,
-        "allowed": True,
-    }
+    # Grace cancels the lock but still names the upgrade target so the UI can
+    # render a "you're on grace -- Pro at enforce" badge off the same call.
+    assert d["key"] == "self_evolve"
+    assert d["kind"] == "feature"
+    assert d["reason"] is None
+    assert d["locked"] is False
+    assert d["allowed"] is True
+    assert d["required_tier"] == "cloud_pro"
+    assert d["required_tier_label"] == "Pro"
+    assert d["required_tier_rank"] >= 2
+    assert d["current_tier"] == "oss"
+    assert d["current_tier_rank"] == 0
+    assert d["upgrade_required"] is True
 
 
 def test_grace_runtime_is_unlocked(client):
@@ -284,10 +295,157 @@ def test_never_raises_on_resolution_failure(monkeypatch, tmp_path):
     )
     assert resp.status_code == 200
     d = resp.get_json()
+    # The fallback shape is fully populated -- including the required_tier
+    # payload -- so a frontend never sees a half-shape regardless of which
+    # branch served the response.
     assert d == {
         "key": "self_evolve",
         "kind": "feature",
         "reason": None,
         "locked": False,
         "allowed": True,
+        "required_tier": None,
+        "required_tier_label": None,
+        "required_tier_rank": -1,
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "upgrade_required": False,
     }
+
+
+# ── required_tier payload rides alongside the message ──────────────────────
+
+
+def test_paid_feature_carries_required_tier_payload(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = (
+        app.test_client()
+        .get("/api/entitlement/lock-reason?feature=fleet")
+        .get_json()
+    )
+    assert d["locked"] is True
+    assert d["allowed"] is False
+    assert d["required_tier"] == "cloud_starter"
+    assert d["required_tier_label"] == "Starter"
+    assert d["required_tier_rank"] >= 1
+    assert d["current_tier"] == "oss"
+    assert d["current_tier_rank"] == 0
+    assert d["upgrade_required"] is True
+
+
+def test_paid_runtime_carries_required_tier_payload(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = (
+        app.test_client()
+        .get("/api/entitlement/lock-reason?runtime=claude_code")
+        .get_json()
+    )
+    assert d["locked"] is True
+    assert d["allowed"] is False
+    # PAID_RUNTIMES all unlock starting at cloud_starter -- mirrors
+    # ``min_tier_for_runtime``.
+    assert d["required_tier"] == "cloud_starter"
+    assert d["required_tier_label"] == "Starter"
+    assert d["required_tier_rank"] >= 1
+    assert d["upgrade_required"] is True
+
+
+def test_free_feature_required_tier_is_oss(monkeypatch, tmp_path):
+    """Free items still surface their required_tier so a frontend can render
+    a uniform "Available in <tier>" badge across the catalogue without a
+    special case for the free row."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = (
+        app.test_client()
+        .get("/api/entitlement/lock-reason?feature=sessions")
+        .get_json()
+    )
+    assert d["locked"] is False
+    assert d["allowed"] is True
+    assert d["required_tier"] == "oss"
+    assert d["required_tier_label"] == "OSS"
+    assert d["required_tier_rank"] == 0
+    # OSS == current tier => no upgrade needed.
+    assert d["upgrade_required"] is False
+
+
+def test_starter_install_paid_pro_feature_payload(monkeypatch, tmp_path):
+    """When a Starter install hits a Pro-only feature the required_tier still
+    reads Pro and ``upgrade_required`` reflects the rank delta from Starter,
+    not from OSS."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps({"plan": "cloud_starter", "node_limit": 1, "expiry": None})
+    )
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = (
+        app.test_client()
+        .get("/api/entitlement/lock-reason?feature=self_evolve")
+        .get_json()
+    )
+    assert d["locked"] is True
+    assert d["allowed"] is False
+    assert d["required_tier"] == "cloud_pro"
+    assert d["required_tier_label"] == "Pro"
+    assert d["current_tier"] == "cloud_starter"
+    assert d["current_tier_rank"] == 1
+    assert d["required_tier_rank"] >= 2
+    assert d["upgrade_required"] is True
+
+
+def test_unknown_feature_required_tier_is_none(monkeypatch, tmp_path):
+    """Mirrors the ``required-tier`` endpoint's posture: an unknown id maps
+    to ``required_tier: null`` with rank ``-1`` and ``upgrade_required: false``
+    so a UI can quietly skip the row without rendering a broken badge."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = (
+        app.test_client()
+        .get("/api/entitlement/lock-reason?feature=not_a_real_feature_id")
+        .get_json()
+    )
+    assert d["required_tier"] is None
+    assert d["required_tier_label"] is None
+    assert d["required_tier_rank"] == -1
+    assert d["upgrade_required"] is False


### PR DESCRIPTION
## Summary

Adds the structured `required_tier` payload (`required_tier`, `required_tier_label`, `required_tier_rank`, `current_tier`, `current_tier_rank`, `upgrade_required`) to `GET /api/entitlement/lock-reason` so a paywall tooltip can render

> Locked: &lt;reason&gt;. **[Upgrade to &lt;X&gt;]**

in a single round-trip instead of pairing this route with `/api/entitlement/required-tier`.

This is the same one-call consolidation pattern as #3210 (`next_tier_diff`/`prev_tier_diff` on `to_dict`) and #3216 (`tier_rank` on `to_dict`). The reverse lookup reuses `min_tier_for_feature` / `min_tier_for_runtime` exactly as `/api/entitlement/required-tier` already does, so no new resolver logic — purely a response-shape extension that closes the symmetry gap between the two endpoints.

## Shape change

```diff
 GET /api/entitlement/lock-reason?feature=fleet
 {
   "key": "fleet",
   "kind": "feature",
   "reason": "'fleet' feature requires Starter or above.",
   "locked": true,
   "allowed": false,
+  "required_tier": "cloud_starter",
+  "required_tier_label": "Starter",
+  "required_tier_rank": 1,
+  "current_tier": "oss",
+  "current_tier_rank": 0,
+  "upgrade_required": true
 }
```

The never-raise fallback branch is widened to the same shape so a frontend never sees a half-populated response regardless of which path served the request.

Grace mode keeps `locked: false` and `reason: null` (no behavior change) but now also surfaces the unlock target so the UI can render a "you're on grace — Pro at enforce" badge off the same call. Free items return `required_tier: "oss"` with `upgrade_required: false`, matching the `min_tier_for_feature` posture.

## Test plan

- [x] `python -m pytest tests/test_entitlement_api_lock_reason.py` — 17/17 (12 existing + 5 new)
- [x] `ruff check routes/entitlement.py tests/test_entitlement_api_lock_reason.py`
- [x] Verified the 2 pre-existing failures in `tests/test_tier_pro_paywall_no_flash.py` are present on `main` too — not introduced here
- [x] Broader entitlement suite (`test_entitlement_*.py`, `test_paywall_body.py`) — 218 passing
- [ ] **Local operator verification checklist** (I cannot run any of these — please run on the host):
  - [ ] Copy the two changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (or your active site-packages) — `routes/entitlement.py` and `tests/test_entitlement_api_lock_reason.py`
  - [ ] Clear `__pycache__/`
  - [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
  - [ ] `curl -s http://localhost:8900/api/entitlement/lock-reason?feature=fleet | jq` — confirm the new fields are present
  - [ ] `curl -s http://localhost:8900/api/entitlement/lock-reason?runtime=claude_code | jq` — confirm `required_tier: "cloud_starter"`
  - [ ] Decrypt the live cloud snapshot and confirm the dashboard's paywall tooltips render the new fields without an additional `/api/entitlement/required-tier` call
  - [ ] Browser-check `/` on a free node — confirm Pro/Starter affordances pick up the structured target

## Notes for the operator

- Draft only. No version bump, no `[RELEASE]` PR, no enforce flip — the gate stays in grace until you ship the enforce-phase release.
- Pricing/strategy not touched (response shape is a pure code symmetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gk1TExxE4hsqRK4esLZCjZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk1TExxE4hsqRK4esLZCjZ)_