### PR TITLE
feat(entitlement): /api/entitlement/required-tier accepts channels= + retention_days=

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -14,7 +14,13 @@ is the single source of truth -- handlers never re-derive tier logic here.
   POST /api/entitlement/refresh      -- drop the cache and return the freshly
                                         re-resolved Entitlement.
   GET  /api/entitlement/required-tier -- resolve the minimum purchasable tier
-                                         for a feature= or runtime= key.
+                                         for a feature=, runtime=, channels=,
+                                         or retention_days= key. The capacity
+                                         axes (channels / retention_days) wrap
+                                         the matching ``min_tier_for_*`` Python
+                                         helpers so the same endpoint answers
+                                         all four "what tier do I need" axes
+                                         off one URL.
   GET  /api/entitlement/lock-reason   -- human-readable explanation of why a
                                          feature= or runtime= key is locked,
                                          carrying the structured
@@ -146,6 +152,32 @@ def api_entitlement_downgrade_diff():
         )
 
 
+_CAPACITY_PARAMS = ("channels", "retention_days")
+
+
+def _parse_capacity_arg(name: str) -> tuple[bool, bool, int | None, str]:
+    """Parse a capacity query param.
+
+    Returns ``(present, parsed_ok, value, raw)``. ``present`` is True iff the
+    caller supplied the param at all (even with an empty value, so blank input
+    doesn't silently fall through to a feature/runtime branch). ``parsed_ok``
+    is False when the supplied value couldn't be coerced to ``int`` -- the
+    HTTP wrapper then short-circuits to ``required_tier=None`` instead of
+    handing ``None`` to the underlying helper (where, for retention, ``None``
+    is the *unlimited* sentinel and would mis-route to Enterprise).
+    """
+    raw = request.args.get(name)
+    if raw is None:
+        return False, False, None, ""
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return True, False, None, raw_stripped
+    try:
+        return True, True, int(raw_stripped), raw_stripped
+    except (TypeError, ValueError):
+        return True, False, None, raw_stripped
+
+
 @bp_entitlement.route("/api/entitlement/required-tier")
 def api_entitlement_required_tier():
     try:
@@ -153,19 +185,84 @@ def api_entitlement_required_tier():
 
         feature = (request.args.get("feature") or "").strip().lower()
         runtime = (request.args.get("runtime") or "").strip().lower()
-        if not feature and not runtime:
-            return jsonify({"error": "supply either feature=<id> or runtime=<id>"}), 400
-        if feature and runtime:
-            return jsonify({"error": "supply only one of feature= or runtime="}), 400
+        (
+            channels_present,
+            channels_ok,
+            channels_n,
+            channels_raw,
+        ) = _parse_capacity_arg("channels")
+        (
+            retention_present,
+            retention_ok,
+            retention_n,
+            retention_raw,
+        ) = _parse_capacity_arg("retention_days")
+
+        supplied = [
+            bool(feature),
+            bool(runtime),
+            channels_present,
+            retention_present,
+        ]
+        n_supplied = sum(1 for s in supplied if s)
+        if n_supplied == 0:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply exactly one of feature=<id>, runtime=<id>, "
+                            "channels=<int>, or retention_days=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+        if n_supplied > 1:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply only one of feature=, runtime=, channels=, "
+                            "or retention_days="
+                        )
+                    }
+                ),
+                400,
+            )
+
+        ent = _ent.get_entitlement()
         if feature:
             key, kind = feature, "feature"
             required = _ent.min_tier_for_feature(feature)
-            allowed = _ent.get_entitlement().allows_feature(feature)
-        else:
+            allowed = ent.allows_feature(feature)
+        elif runtime:
             key, kind = runtime, "runtime"
             required = _ent.min_tier_for_runtime(runtime)
-            allowed = _ent.get_entitlement().allows_runtime(runtime)
-        ent = _ent.get_entitlement()
+            allowed = ent.allows_runtime(runtime)
+        elif channels_present:
+            key, kind = channels_raw, "channels"
+            if channels_ok:
+                required = _ent.min_tier_for_channel_count(channels_n)
+                allowed = ent.allows_channel_count(channels_n)
+            else:
+                # Blank / non-int: never-crash short-circuit. ``required_tier``
+                # is None so the UI knows there's no upgrade target to render,
+                # and ``allowed`` defaults to True (same posture as
+                # ``allows_channel_count`` swallowing a non-int to True).
+                required = None
+                allowed = True
+        else:
+            key, kind = retention_raw, "retention_days"
+            if retention_ok:
+                required = _ent.min_tier_for_retention_window(retention_n)
+                allowed = ent.allows_retention_window(retention_n)
+            else:
+                # Blank / non-int: same posture as the channels branch.
+                # Important: don't forward ``None`` to
+                # :func:`min_tier_for_retention_window` -- there ``None`` is
+                # the *unlimited* sentinel and would mis-route to Enterprise.
+                required = None
+                allowed = True
         cur_rank = _ent.tier_rank(ent.tier)
         req_rank = _ent.tier_rank(required) if required else -1
         required_label = _ent.tier_label(required) if required else None
@@ -186,8 +283,18 @@ def api_entitlement_required_tier():
         logger.warning("api_entitlement_required_tier: error: %s", exc)
         feature = (request.args.get("feature") or "").strip().lower()
         runtime = (request.args.get("runtime") or "").strip().lower()
-        key = feature or runtime
-        kind = "feature" if feature else ("runtime" if runtime else "")
+        channels_raw = (request.args.get("channels") or "").strip()
+        retention_raw = (request.args.get("retention_days") or "").strip()
+        if feature:
+            key, kind = feature, "feature"
+        elif runtime:
+            key, kind = runtime, "runtime"
+        elif channels_raw:
+            key, kind = channels_raw, "channels"
+        elif retention_raw:
+            key, kind = retention_raw, "retention_days"
+        else:
+            key, kind = "", ""
         return jsonify(
             {
                 "key": key,

--- a/tests/test_entitlement_required_tier_capacity.py
+++ b/tests/test_entitlement_required_tier_capacity.py
@@ -1,0 +1,221 @@
+"""Tests for the capacity-axis branches of ``GET /api/entitlement/required-tier``.
+
+The Python helpers :func:`clawmetry.entitlements.min_tier_for_channel_count` and
+:func:`clawmetry.entitlements.min_tier_for_retention_window` already close the
+symmetry with :func:`min_tier_for_feature` / :func:`min_tier_for_runtime`
+(see ``tests/test_entitlements_min_tier_capacity.py``). This file pins the
+HTTP wrapper so the same endpoint answers all four "what tier do I need" axes
+off one URL, and a future param rename / shape drift fails loudly here.
+
+Companion to ``tests/test_entitlement_api.py`` (feature / runtime branches).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client wired with bp_entitlement and a clean HOME so the
+    resolver collapses to OSS-free deterministically. Mirrors the fixture in
+    ``tests/test_entitlement_api.py``."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── channels= branch ─────────────────────────────────────────────────────────
+
+
+def test_channels_within_free_cap_resolves_to_oss(client):
+    """1/2/3 channels fit on OSS (free cap = 3). Grace pass-through keeps
+    ``allowed`` True."""
+    resp = client.get("/api/entitlement/required-tier?channels=3")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["kind"] == "channels"
+    assert d["key"] == "3"
+    assert d["required_tier"] == "oss"
+    assert d["required_tier_label"] == "OSS"
+    assert d["required_tier_rank"] == 0
+    assert d["allowed"] is True
+    assert d["upgrade_required"] is False
+
+
+def test_channels_over_free_cap_resolves_to_starter(client):
+    """4+ channels require Starter -- the cheapest tier with channel_limit
+    set to None (unlimited)."""
+    d = client.get("/api/entitlement/required-tier?channels=21").get_json()
+    assert d["kind"] == "channels"
+    assert d["required_tier"] == "cloud_starter"
+    assert d["required_tier_label"] == "Starter"
+    assert d["required_tier_rank"] == 1
+
+
+def test_channels_grace_keeps_allowed_true_even_over_cap(client):
+    """The headline grace invariant -- wiring this endpoint must not change
+    current behaviour. ``allowed`` is True for any count in grace mode."""
+    d = client.get("/api/entitlement/required-tier?channels=999").get_json()
+    assert d["allowed"] is True
+
+
+def test_channels_non_int_swallows_to_required_none(client):
+    """A non-int ``channels`` is swallowed by ``min_tier_for_channel_count``
+    (which returns None). The HTTP wrapper inherits the never-crash posture --
+    ``required_tier`` is None and the body still well-formed."""
+    d = client.get("/api/entitlement/required-tier?channels=abc").get_json()
+    assert d["kind"] == "channels"
+    assert d["key"] == "abc"
+    assert d["required_tier"] is None
+    assert d["required_tier_label"] is None
+    assert d["upgrade_required"] is False
+
+
+def test_channels_blank_value_is_swallowed(client):
+    """``?channels=`` (present but empty) parses to None, not to "fell
+    through to a feature/runtime branch". The body returns required_tier
+    None, kind="channels"."""
+    d = client.get("/api/entitlement/required-tier?channels=").get_json()
+    assert d["kind"] == "channels"
+    assert d["required_tier"] is None
+
+
+# ── retention_days= branch ───────────────────────────────────────────────────
+
+
+def test_retention_seven_days_fits_oss(client):
+    """7d fits the OSS cap (7d). Available on the free floor."""
+    d = client.get("/api/entitlement/required-tier?retention_days=7").get_json()
+    assert d["kind"] == "retention_days"
+    assert d["key"] == "7"
+    assert d["required_tier"] == "oss"
+
+
+def test_retention_thirty_days_requires_starter(client):
+    """30d needs Starter -- the cheapest tier whose retention cap admits it."""
+    d = client.get("/api/entitlement/required-tier?retention_days=30").get_json()
+    assert d["required_tier"] == "cloud_starter"
+    assert d["required_tier_label"] == "Starter"
+
+
+def test_retention_ninety_days_requires_pro(client):
+    """90d needs Pro -- the next tier up after Starter (30d cap)."""
+    d = client.get("/api/entitlement/required-tier?retention_days=90").get_json()
+    assert d["required_tier"] == "cloud_pro"
+    assert d["required_tier_label"] == "Pro"
+
+
+def test_retention_over_pro_cap_requires_enterprise(client):
+    """365d exceeds every finite cap -- only Enterprise admits it (unlimited
+    sentinel)."""
+    d = client.get("/api/entitlement/required-tier?retention_days=365").get_json()
+    assert d["required_tier"] == "enterprise"
+    assert d["required_tier_label"] == "Enterprise"
+
+
+def test_retention_zero_collapses_to_oss(client):
+    """retention_days=0 means "no history" -- trivially satisfied by the free
+    floor. Mirrors :func:`min_tier_for_retention_window`."""
+    d = client.get("/api/entitlement/required-tier?retention_days=0").get_json()
+    assert d["required_tier"] == "oss"
+
+
+def test_retention_non_int_returns_none(client):
+    """A non-int ``retention_days`` swallows to required_tier=None -- the
+    never-crash posture inherited from the underlying helper."""
+    d = client.get("/api/entitlement/required-tier?retention_days=notanumber").get_json()
+    assert d["kind"] == "retention_days"
+    assert d["required_tier"] is None
+
+
+# ── validation: exactly-one-param ────────────────────────────────────────────
+
+
+def test_400_when_no_params_supplied(client):
+    """Same posture as the existing feature/runtime branches -- empty query
+    is a 400, not a silent 200."""
+    resp = client.get("/api/entitlement/required-tier")
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "error" in body
+    assert "channels" in body["error"]
+    assert "retention_days" in body["error"]
+
+
+@pytest.mark.parametrize(
+    "qs",
+    [
+        "feature=self_evolve&channels=5",
+        "runtime=claude_code&retention_days=30",
+        "channels=5&retention_days=30",
+        "feature=self_evolve&runtime=claude_code&channels=5",
+    ],
+)
+def test_400_when_multiple_params_supplied(client, qs):
+    """Mixing axes is a 400 -- the same exactly-one-axis contract the
+    original feature/runtime check enforced, extended to the capacity axes."""
+    resp = client.get(f"/api/entitlement/required-tier?{qs}")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+# ── feature / runtime branches still work after the refactor ────────────────
+
+
+def test_feature_branch_unchanged(client):
+    """Regression guard -- adding the capacity branches must not break the
+    existing feature= response shape."""
+    d = client.get("/api/entitlement/required-tier?feature=self_evolve").get_json()
+    assert d["kind"] == "feature"
+    assert d["key"] == "self_evolve"
+    assert d["required_tier"] == "cloud_pro"
+    assert d["required_tier_label"] == "Pro"
+
+
+def test_runtime_branch_unchanged(client):
+    """Regression guard for runtime= -- same shape as before the refactor."""
+    d = client.get("/api/entitlement/required-tier?runtime=claude_code").get_json()
+    assert d["kind"] == "runtime"
+    assert d["key"] == "claude_code"
+    assert d["required_tier"] == "cloud_starter"
+
+
+# ── enforce mode: allowed reflects current entitlement ──────────────────────
+
+
+def test_enforce_channels_over_cap_marks_not_allowed(client, monkeypatch):
+    """Under enforce, an OSS install at 5 channels (over the free cap) sees
+    ``allowed=False`` -- the gate axis is wired through, just inert in grace."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e
+
+    e.invalidate()
+    d = client.get("/api/entitlement/required-tier?channels=5").get_json()
+    assert d["required_tier"] == "cloud_starter"
+    assert d["allowed"] is False
+    assert d["upgrade_required"] is True
+
+
+def test_enforce_retention_over_cap_marks_not_allowed(client, monkeypatch):
+    """Under enforce, an OSS install asking for 30d retention sees
+    ``allowed=False`` -- matches the cap surfaced on /api/entitlement."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e
+
+    e.invalidate()
+    d = client.get("/api/entitlement/required-tier?retention_days=30").get_json()
+    assert d["required_tier"] == "cloud_starter"
+    assert d["allowed"] is False
+    assert d["upgrade_required"] is True


### PR DESCRIPTION
## Summary

Closes the HTTP-layer symmetry gap with the existing `feature=` / `runtime=` branches on `GET /api/entitlement/required-tier`. The Python helpers `min_tier_for_channel_count(n)` and `min_tier_for_retention_window(days)` already land the capacity-axis reverse lookup (see `tests/test_entitlements_min_tier_capacity.py`) — this PR wires them into the same endpoint so all four "what tier do I need" axes answer off one URL, and the channel-overflow and history-range surfaces can render "Available in &lt;tier&gt;" copy off the same canonical resolver the feature/runtime locks already read from.

Before:
```
GET /api/entitlement/required-tier?feature=self_evolve   → required_tier=cloud_pro
GET /api/entitlement/required-tier?runtime=claude_code   → required_tier=cloud_starter
GET /api/entitlement/required-tier?channels=5            → 400
GET /api/entitlement/required-tier?retention_days=30     → 400
```

After:
```
GET /api/entitlement/required-tier?channels=5            → required_tier=cloud_starter, allowed=<grace>, …
GET /api/entitlement/required-tier?retention_days=30     → required_tier=cloud_starter, allowed=<grace>, …
GET /api/entitlement/required-tier?retention_days=365    → required_tier=enterprise, …
```

The response shape (`key`, `kind`, `required_tier`, `required_tier_label`, `required_tier_rank`, `current_tier`, `current_tier_rank`, `upgrade_required`, `allowed`) is identical to the existing branches; `kind` is `"channels"` or `"retention_days"` accordingly.

## Contract notes

- **Exactly-one-axis** contract extended: any combination of two+ of `feature` / `runtime` / `channels` / `retention_days` is `400` (same posture as the existing `feature`+`runtime` mutual-exclusion check). Empty query is still `400`.
- **Never-crash**: blank / non-int capacity values short-circuit to `required_tier=null`, `allowed=true`. The important nuance for `retention_days` is that the underlying `min_tier_for_retention_window` helper treats `None` as the **unlimited sentinel** and would otherwise mis-route a typo'd value to Enterprise — the wrapper does the parse so the helper only sees a real int.
- **Grace preserved**: with the default (no `CLAWMETRY_ENFORCE`), `allowed` remains `True` for every count — the new gate axes are wired but inert. Existing `feature=` / `runtime=` responses are unchanged (regression-guarded in the test suite).
- **Allowed reflects the resolved Entitlement** via `allows_channel_count` / `allows_retention_window`, so a paywall tooltip can render the lock state plus the upgrade target in one round-trip — matching the `feature=` / `runtime=` branches.

## Test plan

- [x] `tests/test_entitlement_required_tier_capacity.py` (20 new tests):
  - channels= within / over free cap → OSS / Starter
  - retention_days= = 7 / 30 / 90 / 365 → OSS / Starter / Pro / Enterprise
  - retention_days=0 → OSS (matches `min_tier_for_retention_window`)
  - non-int / blank capacity values → `required_tier=None` (no Enterprise mis-route)
  - validation: empty / multi-param queries → 400
  - regression: `feature=` and `runtime=` branches unchanged
  - enforce: `allowed=False` + `upgrade_required=True` on overflow
- [x] No regressions in surrounding entitlement suites: `test_entitlement_api*`, `test_entitlements*`, `test_required_tier_canonical` (456 tests passing locally)
- [x] `python -m py_compile routes/entitlement.py tests/test_entitlement_required_tier_capacity.py`
- [x] No new `make lint` errors in the changed files

## Local operator verification checklist

(Remote agent can't reach the local daemon or live cloud snapshot — please verify before flipping out of draft.)

- [ ] Copy `routes/entitlement.py` and `tests/test_entitlement_required_tier_capacity.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (or the editable install path you use).
- [ ] Clear `__pycache__/` under the install dir so the new helpers load.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon.
- [ ] Hit each axis once on the running daemon:
  - `curl -s 'http://localhost:8900/api/entitlement/required-tier?channels=5' | jq`
  - `curl -s 'http://localhost:8900/api/entitlement/required-tier?retention_days=30' | jq`
  - `curl -s 'http://localhost:8900/api/entitlement/required-tier?retention_days=365' | jq`
  - `curl -s 'http://localhost:8900/api/entitlement/required-tier?retention_days=notanumber' | jq` — confirm `required_tier=null` (no Enterprise mis-route).
- [ ] Confirm grace posture is preserved: every response carries `allowed: true` until `CLAWMETRY_ENFORCE=1` is set.
- [ ] Decrypt the live cloud snapshot in the browser; confirm no behaviour change on existing dashboard surfaces (the endpoint is purely additive — no consumer is wired up yet).
- [ ] Confirm CI green before flipping out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BqFrHnRyNzmPjfdF5TUL7u)_