### PR TITLE
feat(entitlement): /api/entitlement/lock-reason accepts channels= + retention_days=

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -598,6 +598,50 @@ class Entitlement:
                 req = min_tier_for_feature(k)
                 lbl = tier_label(req) if req else "Paid"
                 return f"'{k}' feature requires {lbl} or above."
+            if inferred_kind == "channels":
+                try:
+                    n = int(k)
+                except (TypeError, ValueError):
+                    return None
+                if n <= 0:
+                    return None
+                if self.allows_channel_count(n):
+                    return None
+                if self.expired:
+                    return (
+                        f"License expired; {n} channels requires a valid "
+                        f"subscription."
+                    )
+                cap = self.channel_limit()
+                cap_str = str(cap) if cap is not None else "unlimited"
+                req = min_tier_for_channel_count(n)
+                lbl = tier_label(req) if req else "Paid"
+                return (
+                    f"{n} channels exceeds the {tier_label(self.tier)} cap of "
+                    f"{cap_str}; requires {lbl} or above."
+                )
+            if inferred_kind == "retention_days":
+                try:
+                    n = int(k)
+                except (TypeError, ValueError):
+                    return None
+                if n <= 0:
+                    return None
+                if self.allows_retention_window(n):
+                    return None
+                if self.expired:
+                    return (
+                        f"License expired; {n}-day retention requires a valid "
+                        f"subscription."
+                    )
+                cap = self.event_retention_days()
+                cap_str = f"{cap} days" if cap is not None else "unlimited"
+                req = min_tier_for_retention_window(n)
+                lbl = tier_label(req) if req else "Paid"
+                return (
+                    f"{n}-day retention exceeds the {tier_label(self.tier)} "
+                    f"cap of {cap_str}; requires {lbl} or above."
+                )
             return None
         except Exception:
             return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -22,12 +22,15 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          all four "what tier do I need" axes
                                          off one URL.
   GET  /api/entitlement/lock-reason   -- human-readable explanation of why a
-                                         feature= or runtime= key is locked,
+                                         feature=, runtime=, channels= or
+                                         retention_days= key is locked,
                                          carrying the structured
                                          ``required_tier`` payload alongside
                                          the message so a paywall tooltip can
                                          render "Locked: <reason>. [Upgrade to
-                                         <X>]" in one round-trip.
+                                         <X>]" in one round-trip. The four
+                                         axes match the ones on
+                                         ``/api/entitlement/required-tier``.
   GET  /api/entitlement/upgrade-diff  -- features + runtimes a target tier
                                          would add on top of the current ent.
   GET  /api/entitlement/downgrade-diff -- features + runtimes a target tier
@@ -317,20 +320,91 @@ def api_entitlement_lock_reason():
 
         feature = (request.args.get("feature") or "").strip().lower()
         runtime = (request.args.get("runtime") or "").strip().lower()
-        if not feature and not runtime:
-            return jsonify({"error": "supply either feature=<id> or runtime=<id>"}), 400
-        if feature and runtime:
-            return jsonify({"error": "supply only one of feature= or runtime="}), 400
+        (
+            channels_present,
+            channels_ok,
+            channels_n,
+            channels_raw,
+        ) = _parse_capacity_arg("channels")
+        (
+            retention_present,
+            retention_ok,
+            retention_n,
+            retention_raw,
+        ) = _parse_capacity_arg("retention_days")
+
+        supplied = [
+            bool(feature),
+            bool(runtime),
+            channels_present,
+            retention_present,
+        ]
+        n_supplied = sum(1 for s in supplied if s)
+        if n_supplied == 0:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply exactly one of feature=<id>, runtime=<id>, "
+                            "channels=<int>, or retention_days=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+        if n_supplied > 1:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply only one of feature=, runtime=, channels=, "
+                            "or retention_days="
+                        )
+                    }
+                ),
+                400,
+            )
+
         ent = _ent.get_entitlement()
         if feature:
             key, kind = feature, "feature"
             allowed = ent.allows_feature(feature)
             required = _ent.min_tier_for_feature(feature)
-        else:
+            reason = ent.lock_reason(key, kind=kind)
+        elif runtime:
             key, kind = runtime, "runtime"
             allowed = ent.allows_runtime(runtime)
             required = _ent.min_tier_for_runtime(runtime)
-        reason = ent.lock_reason(key, kind=kind)
+            reason = ent.lock_reason(key, kind=kind)
+        elif channels_present:
+            key, kind = channels_raw, "channels"
+            if channels_ok:
+                required = _ent.min_tier_for_channel_count(channels_n)
+                allowed = ent.allows_channel_count(channels_n)
+                reason = ent.lock_reason(str(channels_n), kind=kind)
+            else:
+                # Blank / non-int: mirror the required-tier wrapper's
+                # never-crash posture -- ``reason`` is None so the UI has
+                # nothing to render, ``required_tier`` is None, and
+                # ``allowed`` defaults to True (same as
+                # ``allows_channel_count`` swallowing a non-int to True).
+                required = None
+                allowed = True
+                reason = None
+        else:
+            key, kind = retention_raw, "retention_days"
+            if retention_ok:
+                required = _ent.min_tier_for_retention_window(retention_n)
+                allowed = ent.allows_retention_window(retention_n)
+                reason = ent.lock_reason(str(retention_n), kind=kind)
+            else:
+                # Same never-crash posture as the channels branch. Important:
+                # don't forward ``None`` to
+                # :func:`min_tier_for_retention_window` -- there ``None`` is
+                # the *unlimited* sentinel and would mis-route to Enterprise.
+                required = None
+                allowed = True
+                reason = None
         cur_rank = _ent.tier_rank(ent.tier)
         req_rank = _ent.tier_rank(required) if required else -1
         required_label = _ent.tier_label(required) if required else None
@@ -353,10 +427,16 @@ def api_entitlement_lock_reason():
         logger.warning("api_entitlement_lock_reason: error: %s", exc)
         feature = (request.args.get("feature") or "").strip().lower()
         runtime = (request.args.get("runtime") or "").strip().lower()
+        channels_raw = (request.args.get("channels") or "").strip()
+        retention_raw = (request.args.get("retention_days") or "").strip()
         if feature:
             key, kind = feature, "feature"
         elif runtime:
             key, kind = runtime, "runtime"
+        elif channels_raw:
+            key, kind = channels_raw, "channels"
+        elif retention_raw:
+            key, kind = retention_raw, "retention_days"
         else:
             key, kind = "", ""
         return jsonify(

--- a/tests/test_entitlement_api_lock_reason_capacity.py
+++ b/tests/test_entitlement_api_lock_reason_capacity.py
@@ -1,0 +1,253 @@
+"""Tests for the capacity-axis branches of ``GET /api/entitlement/lock-reason``.
+
+Sibling of ``tests/test_entitlement_required_tier_capacity.py``: the
+``required-tier`` route already answers all four "which tier do I need" axes
+(feature / runtime / channels / retention_days) off one URL. This pins the
+matching ``lock-reason`` axes so the paywall tooltip on the channels and
+history-range surfaces can render
+
+    Locked: <reason>. [Upgrade to <X>]
+
+in a single round-trip -- same wire contract as the feature= and runtime=
+branches in ``tests/test_entitlement_api_lock_reason.py``.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _enforced_client(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── grace: nothing locks, but the required_tier payload still rides along ──
+
+
+def test_channels_grace_is_unlocked_but_carries_required_tier(client):
+    d = client.get("/api/entitlement/lock-reason?channels=21").get_json()
+    assert d["kind"] == "channels"
+    assert d["key"] == "21"
+    assert d["reason"] is None
+    assert d["locked"] is False
+    assert d["allowed"] is True
+    # Even in grace the upgrade target is named so a "you're on grace --
+    # Starter at enforce" badge can render off the same call.
+    assert d["required_tier"] == "cloud_starter"
+    assert d["required_tier_label"] == "Starter"
+    assert d["required_tier_rank"] == 1
+    assert d["upgrade_required"] is True
+
+
+def test_retention_grace_is_unlocked_but_carries_required_tier(client):
+    d = client.get("/api/entitlement/lock-reason?retention_days=30").get_json()
+    assert d["kind"] == "retention_days"
+    assert d["reason"] is None
+    assert d["locked"] is False
+    assert d["allowed"] is True
+    assert d["required_tier"] == "cloud_starter"
+    assert d["upgrade_required"] is True
+
+
+# ── enforced OSS: capacity overflow surfaces a tier-naming reason ──────────
+
+
+def test_channels_overflow_on_enforced_oss_is_locked(monkeypatch, tmp_path):
+    c = _enforced_client(monkeypatch, tmp_path)
+    d = c.get("/api/entitlement/lock-reason?channels=5").get_json()
+    assert d["kind"] == "channels"
+    assert d["key"] == "5"
+    assert d["locked"] is True
+    assert d["allowed"] is False
+    assert d["reason"] is not None
+    assert "5 channels" in d["reason"]
+    assert "Starter" in d["reason"]
+    assert d["required_tier"] == "cloud_starter"
+    assert d["required_tier_label"] == "Starter"
+    assert d["upgrade_required"] is True
+
+
+def test_channels_within_free_cap_on_enforced_oss_is_unlocked(monkeypatch, tmp_path):
+    c = _enforced_client(monkeypatch, tmp_path)
+    d = c.get("/api/entitlement/lock-reason?channels=3").get_json()
+    assert d["kind"] == "channels"
+    assert d["reason"] is None
+    assert d["locked"] is False
+    assert d["allowed"] is True
+
+
+def test_retention_thirty_days_on_enforced_oss_is_locked(monkeypatch, tmp_path):
+    c = _enforced_client(monkeypatch, tmp_path)
+    d = c.get("/api/entitlement/lock-reason?retention_days=30").get_json()
+    assert d["kind"] == "retention_days"
+    assert d["locked"] is True
+    assert d["allowed"] is False
+    assert "30-day retention" in d["reason"]
+    assert "Starter" in d["reason"]
+    assert d["required_tier"] == "cloud_starter"
+
+
+def test_retention_ninety_days_on_enforced_oss_names_pro(monkeypatch, tmp_path):
+    c = _enforced_client(monkeypatch, tmp_path)
+    d = c.get("/api/entitlement/lock-reason?retention_days=90").get_json()
+    assert d["locked"] is True
+    assert "Pro" in d["reason"]
+    assert d["required_tier"] == "cloud_pro"
+
+
+def test_retention_year_on_enforced_oss_names_enterprise(monkeypatch, tmp_path):
+    c = _enforced_client(monkeypatch, tmp_path)
+    d = c.get("/api/entitlement/lock-reason?retention_days=365").get_json()
+    assert d["locked"] is True
+    assert "Enterprise" in d["reason"]
+    assert d["required_tier"] == "enterprise"
+
+
+# ── never-crash posture mirrors the required-tier wrapper ──────────────────
+
+
+def test_non_int_channels_returns_unlocked(client):
+    d = client.get("/api/entitlement/lock-reason?channels=abc").get_json()
+    assert d["kind"] == "channels"
+    assert d["key"] == "abc"
+    assert d["reason"] is None
+    assert d["locked"] is False
+    assert d["allowed"] is True
+    assert d["required_tier"] is None
+    assert d["required_tier_rank"] == -1
+
+
+def test_non_int_retention_returns_unlocked(client):
+    d = client.get(
+        "/api/entitlement/lock-reason?retention_days=notanumber"
+    ).get_json()
+    assert d["kind"] == "retention_days"
+    assert d["reason"] is None
+    assert d["locked"] is False
+    assert d["allowed"] is True
+    assert d["required_tier"] is None
+
+
+def test_blank_channels_swallows_to_required_none(client):
+    """``?channels=`` (present but empty) parses to None, not "fell through
+    to a feature/runtime branch"."""
+    d = client.get("/api/entitlement/lock-reason?channels=").get_json()
+    assert d["kind"] == "channels"
+    assert d["required_tier"] is None
+    assert d["reason"] is None
+
+
+# ── validation: exactly-one-of {feature, runtime, channels, retention_days} ─
+
+
+def test_400_when_no_params_supplied(client):
+    resp = client.get("/api/entitlement/lock-reason")
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "error" in body
+    assert "channels" in body["error"]
+    assert "retention_days" in body["error"]
+
+
+@pytest.mark.parametrize(
+    "qs",
+    [
+        "feature=self_evolve&channels=5",
+        "runtime=claude_code&retention_days=30",
+        "channels=5&retention_days=30",
+        "feature=self_evolve&runtime=claude_code&channels=5",
+    ],
+)
+def test_400_when_multiple_params_supplied(client, qs):
+    resp = client.get(f"/api/entitlement/lock-reason?{qs}")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+# ── feature / runtime branches still work after the refactor ────────────────
+
+
+def test_feature_branch_unchanged(monkeypatch, tmp_path):
+    """Regression guard -- the existing feature= response shape is preserved
+    after the capacity branches landed."""
+    c = _enforced_client(monkeypatch, tmp_path)
+    d = c.get("/api/entitlement/lock-reason?feature=fleet").get_json()
+    assert d["kind"] == "feature"
+    assert d["locked"] is True
+    assert "Starter" in d["reason"]
+    assert d["required_tier"] == "cloud_starter"
+
+
+def test_runtime_branch_unchanged(monkeypatch, tmp_path):
+    """Regression guard for runtime= -- same shape as before the refactor."""
+    c = _enforced_client(monkeypatch, tmp_path)
+    d = c.get("/api/entitlement/lock-reason?runtime=claude_code").get_json()
+    assert d["kind"] == "runtime"
+    assert d["locked"] is True
+    assert d["required_tier"] == "cloud_starter"
+
+
+# ── never-raise on resolution failure (matches feature/runtime fallback) ───
+
+
+def test_never_raises_on_resolution_failure_capacity(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("entitlement read sad")
+
+    monkeypatch.setattr(e, "get_entitlement", boom)
+
+    from routes.entitlement import bp_entitlement
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    resp = app.test_client().get(
+        "/api/entitlement/lock-reason?channels=21"
+    )
+    assert resp.status_code == 200
+    d = resp.get_json()
+    # The fallback fully populates the shape on the capacity axis too --
+    # ``kind`` reflects which axis the caller asked about so a frontend
+    # branch on ``kind`` keeps working through the failure mode.
+    assert d["kind"] == "channels"
+    assert d["key"] == "21"
+    assert d["reason"] is None
+    assert d["locked"] is False
+    assert d["allowed"] is True
+    assert d["required_tier"] is None
+    assert d["required_tier_rank"] == -1
+    assert d["upgrade_required"] is False

--- a/tests/test_entitlement_lock_reason_capacity.py
+++ b/tests/test_entitlement_lock_reason_capacity.py
@@ -1,0 +1,205 @@
+"""Tests for the capacity-axis branches of
+:meth:`clawmetry.entitlements.Entitlement.lock_reason`.
+
+Closes the symmetry with
+:func:`clawmetry.entitlements.min_tier_for_channel_count` and
+:func:`clawmetry.entitlements.min_tier_for_retention_window` so the dashboard
+can render "you have 5 channels -- Available in Starter" / "30-day window
+exceeds your free cap -- Available in Starter" copy off the same helper that
+already answers the feature= and runtime= axes.
+
+Companion to ``tests/test_entitlement_lock_reason.py``
+(feature / runtime helper contract) and
+``tests/test_entitlements_min_tier_capacity.py`` (the reverse-lookup helpers
+this branch consumes).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── grace mode locks nothing ────────────────────────────────────────────────
+
+
+def test_grace_channels_overflow_is_unlocked(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.lock_reason("21", kind="channels") is None
+
+
+def test_grace_retention_overflow_is_unlocked(ent):
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("365", kind="retention_days") is None
+
+
+# ── enforced OSS: channels overflow surfaces a tier-naming reason ──────────
+
+
+def test_channels_within_free_cap_is_unlocked_on_oss(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("3", kind="channels") is None
+
+
+def test_channels_over_free_cap_on_oss_names_starter(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("5", kind="channels")
+    assert reason is not None
+    # Mentions the overflow count, the cap, and the unlock tier.
+    assert "5 channels" in reason
+    assert "Starter" in reason
+    assert "3" in reason  # the OSS cap
+
+
+# ── enforced OSS: retention overflow surfaces a tier-naming reason ─────────
+
+
+def test_retention_within_free_cap_is_unlocked_on_oss(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("7", kind="retention_days") is None
+
+
+def test_retention_thirty_days_on_oss_names_starter(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("30", kind="retention_days")
+    assert reason is not None
+    assert "30-day retention" in reason
+    assert "Starter" in reason
+
+
+def test_retention_ninety_days_on_oss_names_pro(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("90", kind="retention_days")
+    assert reason is not None
+    assert "Pro" in reason
+
+
+def test_retention_year_on_oss_names_enterprise(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("365", kind="retention_days")
+    assert reason is not None
+    assert "Enterprise" in reason
+
+
+# ── tier-dependent unlocks ──────────────────────────────────────────────────
+
+
+def test_starter_unlocks_unlimited_channels(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    starter = ent._build(ent.TIER_CLOUD_STARTER, "cloud", node_limit=1, expiry=None)
+    assert starter.lock_reason("21", kind="channels") is None
+
+
+def test_starter_unlocks_thirty_day_retention(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    starter = ent._build(ent.TIER_CLOUD_STARTER, "cloud", node_limit=1, expiry=None)
+    assert starter.lock_reason("30", kind="retention_days") is None
+
+
+def test_starter_still_locks_ninety_day_retention_with_pro_message(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    starter = ent._build(ent.TIER_CLOUD_STARTER, "cloud", node_limit=1, expiry=None)
+    reason = starter.lock_reason("90", kind="retention_days")
+    assert reason is not None
+    assert "Pro" in reason
+
+
+# ── expiry ──────────────────────────────────────────────────────────────────
+
+
+def test_expired_channels_overflow_says_expired(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    expired = ent._build(ent.TIER_PRO, "license", node_limit=1, expiry=1.0)
+    assert expired.expired is True
+    reason = expired.lock_reason("21", kind="channels")
+    assert reason is not None
+    assert "expired" in reason.lower()
+
+
+def test_expired_retention_overflow_says_expired(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    expired = ent._build(ent.TIER_PRO, "license", node_limit=1, expiry=1.0)
+    reason = expired.lock_reason("30", kind="retention_days")
+    assert reason is not None
+    assert "expired" in reason.lower()
+
+
+# ── bad input is silently un-locked (never-crash, never-claim) ─────────────
+
+
+def test_non_int_channels_returns_none(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("abc", kind="channels") is None
+    assert en.lock_reason("", kind="channels") is None
+
+
+def test_non_int_retention_returns_none(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("abc", kind="retention_days") is None
+
+
+def test_zero_channels_returns_none(ent, monkeypatch):
+    """Zero / negative counts are trivially satisfied; no lock to explain."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("0", kind="channels") is None
+    assert en.lock_reason("-3", kind="channels") is None
+
+
+def test_zero_retention_returns_none(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("0", kind="retention_days") is None
+    assert en.lock_reason("-30", kind="retention_days") is None
+
+
+# ── auto-infer never picks up a numeric key ────────────────────────────────
+
+
+def test_numeric_input_requires_explicit_kind(ent, monkeypatch):
+    """``lock_reason`` auto-infers ``kind`` from a known feature/runtime id.
+    A bare digit string is neither, so without an explicit ``kind`` the helper
+    silently returns None -- matching the pre-existing "unknown ids err on the
+    un-locked side" contract."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("21") is None
+    # ...but with kind=, the capacity branch fires.
+    assert en.lock_reason("21", kind="channels") is not None


### PR DESCRIPTION
## Summary

Closes the symmetry gap between the two paywall-helper endpoints. `/api/entitlement/required-tier` already answers all four "which tier do I need" axes (`feature` / `runtime` / `channels` / `retention_days`) off one URL — landed in #3219 on top of the reverse-lookup helpers from #3215. Its sibling `/api/entitlement/lock-reason` (#3218) still only spoke `feature=` and `runtime=`, so the channels surface and the history-range toggle had to either pair two calls to render `Locked: <reason>. [Upgrade to <X>]` or special-case the human-readable message in the frontend.

After this change, both endpoints answer the same four axes off one URL pattern, with matching exactly-one-of validation and matching never-crash posture.

## What it does

`Entitlement.lock_reason` now dispatches on `kind="channels"` and `kind="retention_days"` — the count rides in `item` as a digit string, matching the `key` shape the route already returns for the existing branches. Behaviour:

- **Grace** → `None` (matches the headline grace invariant for the existing branches).
- **Count within current tier's cap** → `None` (free cap is 3 channels / 7 days on OSS).
- **Overflow** → message naming the overflow count, the current tier's cap, and the unlock tier, e.g.
  - `"5 channels exceeds the OSS cap of 3; requires Starter or above."`
  - `"30-day retention exceeds the OSS cap of 7 days; requires Starter or above."`
- **Expired license** → `"License expired; <N> channels requires a valid subscription."` (same shape the existing feature/runtime branches use).
- **Non-int / zero / negative** → `None` (mirrors `allows_channel_count` / `allows_retention_window` swallow-to-True).

The route uses the existing module-level `_parse_capacity_arg` helper (shared with `/required-tier`), enforces the same exactly-one-of validation across all four axes, and inherits the never-crash posture: blank / non-int values short-circuit to `reason=None`, `required_tier=None`, `allowed=True` instead of mis-routing the unlimited sentinel (`None`) through `min_tier_for_retention_window`.

Strictly additive on the wire — existing `feature=` / `runtime=` callers see the same shape, the `required_tier` payload still rides alongside the message, and grace mode is preserved so no current behaviour changes.

## Files

- `clawmetry/entitlements.py` — `Entitlement.lock_reason` gains the two capacity branches (+58 lines).
- `routes/entitlement.py` — `api_entitlement_lock_reason` refactored to the same exactly-one-of dispatch as `api_entitlement_required_tier`, reusing `_parse_capacity_arg`. Doc header updated.
- `tests/test_entitlement_lock_reason_capacity.py` (new) — 18 cases for the helper (grace, overflow, expiry, bad input, tier-dependent unlocks, auto-infer never picks up a digit).
- `tests/test_entitlement_api_lock_reason_capacity.py` (new) — 18 cases for the wire contract (grace carries required_tier, overflow surfaces tier-naming reason, validation, never-raise fallback).

## Test plan

- [x] `ruff check` on the four changed files — `All checks passed!` (the 207 pre-existing errors on main are untouched by this change).
- [x] `pytest tests/test_entitlement_lock_reason.py tests/test_entitlement_lock_reason_capacity.py tests/test_entitlement_api_lock_reason.py tests/test_entitlement_api_lock_reason_capacity.py tests/test_entitlement_required_tier_capacity.py tests/test_entitlement_api.py tests/test_entitlements.py tests/test_entitlements_catalogue.py` — **217 passed**.
- [x] Pre-existing failures on adjacent files (`tier_pro_paywall_no_flash`, `license` Rust-binding panics, missing `duckdb`/`protobuf` modules) reproduce on `origin/main` without this change — not introduced here.
- [ ] CI green on the PR.

## Local operator verification checklist

Since this runs in the public OSS repo with no access to the local daemon, `~/.openclaw`, or `app.clawmetry.com`, please verify locally:

1. **Copy changed files into the live install**
   ```
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/
   cp routes/entitlement.py     ~/.clawmetry/lib/python3.11/site-packages/routes/
   find ~/.clawmetry/lib/python3.11/site-packages/clawmetry -name __pycache__ -exec rm -rf {} +
   find ~/.clawmetry/lib/python3.11/site-packages/routes    -name __pycache__ -exec rm -rf {} +
   ```
2. **Restart the daemon** so the new code loads:
   ```
   launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
   ```
3. **Hit the endpoint** locally:
   ```
   # grace (default): reason=null, allowed=true, required_tier=cloud_starter
   curl -s 'http://localhost:8900/api/entitlement/lock-reason?channels=21' | jq

   # under enforce: reason names the overflow + the unlock tier
   CLAWMETRY_ENFORCE=1 launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync
   curl -s 'http://localhost:8900/api/entitlement/lock-reason?channels=5' | jq
   curl -s 'http://localhost:8900/api/entitlement/lock-reason?retention_days=30' | jq
   curl -s 'http://localhost:8900/api/entitlement/lock-reason?retention_days=365' | jq

   # validation: 400 with the new exactly-one-of error message
   curl -si 'http://localhost:8900/api/entitlement/lock-reason' | head -1
   curl -si 'http://localhost:8900/api/entitlement/lock-reason?channels=5&feature=fleet' | head -1
   ```
4. **Decrypt the live cloud snapshot** (browser DevTools) and confirm no frontend regression — the existing `feature=` / `runtime=` callers see the same response shape, and any new code can switch to the capacity axes whenever.
5. **Browser-check** the dashboard at `http://localhost:8900` — verify the channels + history-range surfaces still render normally (grace mode = no visible change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113ACzvbXPWusSkYoj27vza

---
_Generated by [Claude Code](https://claude.ai/code/session_0113ACzvbXPWusSkYoj27vza)_