### PR TITLE
feat(entitlement): preview(tier) + GET /api/entitlement/preview

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -919,6 +919,46 @@ def previous_tier_diff() -> dict | None:
         return None
 
 
+def preview(target_tier: str) -> dict | None:
+    """Render the :meth:`Entitlement.to_dict` shape for a hypothetical tier.
+
+    Companion to :func:`upgrade_diff` / :func:`downgrade_diff`: where those
+    answer "what would change", ``preview`` answers "what would the resulting
+    Entitlement *look like*" -- the full denormalised shape the upgrade-CTA
+    card renders ("Cloud Pro: 365-day retention, unlimited channels, claude_code
+    + codex + ... unlocked"). Returns ``None`` for an unknown tier id and never
+    raises.
+
+    The previewed Entitlement is always rendered with ``grace=False`` so the
+    concrete per-tier limits (``channel_limit``, ``retention_days``) surface --
+    a grace-mode preview would zero those out and defeat the purpose. Source
+    is tagged ``"preview"`` so the UI never mistakes it for a live entitlement.
+    """
+    try:
+        tt = (target_tier or "").strip().lower()
+        if tt not in _PURCHASABLE_TIERS:
+            return None
+        paid_feats = _TIER_FEATURES.get(tt, frozenset())
+        runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if tt in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        ent = Entitlement(
+            tier=tt,
+            source="preview",
+            node_limit=1,
+            expiry=None,
+            features=FREE_FEATURES | paid_feats,
+            runtimes=runtimes,
+            grace=False,
+        )
+        return ent.to_dict()
+    except Exception as exc:
+        logger.warning("entitlements: preview failed: %s", exc)
+        return None
+
+
 def resolution_diagnostic() -> dict:
     out: dict = {
         "license_path": _LICENSE_PATH,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -35,6 +35,11 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          would add on top of the current ent.
   GET  /api/entitlement/downgrade-diff -- features + runtimes a target tier
                                           would REMOVE from the current ent.
+  GET  /api/entitlement/preview        -- the full Entitlement.to_dict() shape
+                                          rendered for an arbitrary tier so the
+                                          upgrade-CTA card can show concrete
+                                          numbers without per-tier derivation
+                                          in JS.
   GET  /api/runtimes                  -- the full runtime catalog.
   GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
 """
@@ -153,6 +158,28 @@ def api_entitlement_downgrade_diff():
                 "lost_runtimes": [],
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/preview")
+def api_entitlement_preview():
+    """``GET /api/entitlement/preview?tier=<id>`` -- the full
+    :meth:`Entitlement.to_dict` shape rendered for a hypothetical tier so an
+    upgrade-CTA card can show concrete numbers ("365-day retention, unlimited
+    channels, claude_code unlocked") without the client re-deriving per-tier
+    capacity. ``404`` when the tier id is unknown."""
+    target = (request.args.get("tier") or "").strip().lower()
+    if not target:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.preview(target)
+        if body is None:
+            return jsonify({"error": "unknown tier", "tier": target}), 404
+        return jsonify(body)
+    except Exception as exc:
+        logger.warning("api_entitlement_preview: error: %s", exc)
+        return jsonify({"error": "preview failed", "tier": target}), 500
 
 
 _CAPACITY_PARAMS = ("channels", "retention_days")

--- a/tests/test_entitlement_preview.py
+++ b/tests/test_entitlement_preview.py
@@ -1,0 +1,197 @@
+"""Tests for ``clawmetry.entitlements.preview`` +
+``GET /api/entitlement/preview``.
+
+Where :func:`upgrade_diff` answers "what changes", :func:`preview` answers
+"what does the resulting Entitlement look like" -- the full denormalised
+``to_dict()`` shape so the upgrade-CTA card can render concrete numbers
+("Cloud Pro: 90-day retention, unlimited channels, claude_code unlocked")
+without re-deriving per-tier capacity tables in JS. These tests pin the
+shape and per-tier limits so a future reshuffle of those tables breaks
+loudly here instead of silently in the UI.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    # preview() is grace-independent -- it always renders enforced limits --
+    # but match every other entitlement fixture in the suite so the test env
+    # stays identical.
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────
+
+
+def test_preview_returns_full_to_dict_shape(ent):
+    body = ent.preview(ent.TIER_CLOUD_PRO)
+    # The whole point is that the upgrade-CTA card reads the same shape as
+    # /api/entitlement -- pin the contract.
+    expected_keys = set(ent._build(ent.TIER_CLOUD_PRO, "preview").to_dict().keys())
+    assert set(body.keys()) == expected_keys
+
+
+def test_preview_tier_matches_target(ent):
+    body = ent.preview(ent.TIER_CLOUD_PRO)
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+def test_preview_source_is_preview(ent):
+    # The UI must be able to tell a preview from a live entitlement -- if a
+    # preview ever leaked into the live state surface it would silently
+    # over-grant. The "preview" source is the trip-wire.
+    body = ent.preview(ent.TIER_CLOUD_PRO)
+    assert body["source"] == "preview"
+
+
+def test_preview_is_never_grace(ent, monkeypatch):
+    # Grace zeroes out channel_limit / retention_days, which defeats the
+    # purpose of a preview ("show concrete numbers"). Force grace ON in the
+    # environment and verify preview still renders enforced limits.
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    body = ent.preview(ent.TIER_CLOUD_PRO)
+    assert body["grace"] is False
+    assert body["enforced"] is True
+
+
+# ── per-tier limits ───────────────────────────────────────────────────────
+
+
+def test_preview_oss_has_free_caps(ent):
+    body = ent.preview(ent.TIER_OSS)
+    assert body["retention_days"] == 7
+    assert body["channel_limit"] == ent._FREE_CHANNEL_LIMIT
+    # OSS doesn't unlock any paid runtimes.
+    assert set(body["runtimes"]) == set(ent.FREE_RUNTIMES)
+
+
+def test_preview_starter_unlocks_paid_runtimes(ent):
+    body = ent.preview(ent.TIER_CLOUD_STARTER)
+    assert body["retention_days"] == 30
+    assert body["channel_limit"] is None  # unlimited
+    assert set(body["runtimes"]) == set(ent.ALL_RUNTIMES)
+
+
+def test_preview_cloud_pro_caps(ent):
+    body = ent.preview(ent.TIER_CLOUD_PRO)
+    assert body["retention_days"] == 90
+    assert body["channel_limit"] is None
+    assert set(body["features"]) == set(ent.FREE_FEATURES) | set(ent.PAID_FEATURES)
+
+
+def test_preview_enterprise_includes_enterprise_features(ent):
+    body = ent.preview(ent.TIER_ENTERPRISE)
+    assert body["retention_days"] is None  # unlimited
+    expected = (
+        set(ent.FREE_FEATURES) | set(ent.PAID_FEATURES) | set(ent.ENTERPRISE_FEATURES)
+    )
+    assert set(body["features"]) == expected
+
+
+# ── locked_* shows nothing in preview ─────────────────────────────────────
+
+
+def test_preview_pro_has_no_locked_runtimes(ent):
+    # In a Pro preview every paid runtime is unlocked -- locked_runtimes is
+    # the inverse view and must therefore be empty so the CTA card doesn't
+    # show ghost "still locked" rows.
+    body = ent.preview(ent.TIER_CLOUD_PRO)
+    assert body["locked_runtimes"] == []
+
+
+def test_preview_enterprise_has_no_locked_features(ent):
+    body = ent.preview(ent.TIER_ENTERPRISE)
+    assert body["locked_features"] == []
+
+
+# ── safety / fallback ─────────────────────────────────────────────────────
+
+
+def test_preview_unknown_tier_returns_none(ent):
+    assert ent.preview("nonsense_tier_xyz") is None
+
+
+def test_preview_empty_returns_none(ent):
+    assert ent.preview("") is None
+    assert ent.preview(None) is None  # type: ignore[arg-type]
+
+
+def test_preview_lowercases_input(ent):
+    # Tier ids are case-insensitive everywhere else in the API; preview
+    # mustn't be the one corner that breaks the symmetry.
+    body = ent.preview("CLOUD_PRO")
+    assert body is not None
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_preview_never_raises(monkeypatch, ent):
+    # Force the inner build to blow up and confirm the helper swallows.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "Entitlement", boom)
+    assert ent.preview(ent.TIER_CLOUD_PRO) is None
+
+
+def test_preview_does_not_mutate_live_entitlement(ent):
+    # The whole module-level cache must be untouched by a preview call --
+    # the rendered Entitlement is a throwaway, not a state change.
+    live_before = ent.get_entitlement().to_dict()
+    ent.preview(ent.TIER_ENTERPRISE)
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# ── API surface ───────────────────────────────────────────────────────────
+
+
+def test_api_preview_returns_shape_for_pro(client, ent):
+    rv = client.get(f"/api/entitlement/preview?tier={ent.TIER_CLOUD_PRO}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["source"] == "preview"
+    assert body["grace"] is False
+    assert body["retention_days"] == 90
+
+
+def test_api_preview_missing_tier_is_400(client):
+    rv = client.get("/api/entitlement/preview")
+    assert rv.status_code == 400
+    assert "error" in rv.get_json()
+
+
+def test_api_preview_unknown_tier_is_404(client):
+    rv = client.get("/api/entitlement/preview?tier=nonsense_tier_xyz")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["tier"] == "nonsense_tier_xyz"
+
+
+def test_api_preview_lowercases_query(client, ent):
+    rv = client.get("/api/entitlement/preview?tier=CLOUD_STARTER")
+    assert rv.status_code == 200
+    assert rv.get_json()["tier"] == ent.TIER_CLOUD_STARTER


### PR DESCRIPTION
## Summary

`upgrade_diff()` answers "what changes"; `preview()` answers **"what does the resulting Entitlement look like"** — the full denormalised `to_dict()` shape rendered for an arbitrary purchasable tier so the upgrade-CTA card can render concrete numbers ("Cloud Pro: 90-day retention, unlimited channels, claude_code + codex + … unlocked") without re-deriving per-tier capacity tables in JS.

- The previewed `Entitlement` is built with `grace=False` so per-tier limits (`channel_limit`, `retention_days`) actually surface — a grace-mode preview zeroes those out and defeats the purpose.
- `source="preview"` tags the synthetic shape so the UI can never mistake it for a live entitlement.
- `GET /api/entitlement/preview?tier=cloud_pro` → the `to_dict()` body. `400` on missing tier, `404` on unknown tier.
- `preview()` itself returns `None` for unknown / empty / non-string input and never raises.

## Behaviour change

**None.** This is a pure-read primitive; nothing in the existing gates calls it. It composes with `upgrade_diff` / `downgrade_diff` (delta surface) and `tier_catalog` (per-tier static metadata) — `preview` is the third leg: "the *resolved* shape at tier X".

## Files

- `clawmetry/entitlements.py` — `preview(target_tier)` module-level helper (~40 lines, follows the `_build()` pattern).
- `routes/entitlement.py` — `GET /api/entitlement/preview` on `bp_entitlement` + docstring update.
- `tests/test_entitlement_preview.py` — 19 tests covering shape, per-tier limits (OSS / Starter / Pro / Enterprise), case-insensitivity, `source="preview"` invariant, grace-independence, mutation-free, and the four HTTP status paths.

## Tests

```
$ python -m pytest tests/test_entitlement_preview.py -q
19 passed in 0.29s
$ python -m pytest tests/test_entitlements.py tests/test_entitlement_upgrade_diff.py tests/test_entitlement_tier_diff.py tests/test_entitlement_api.py tests/test_entitlements_table_conformance.py -q
154 passed in 1.33s
$ ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_preview.py
All checks passed!
```

## Local operator verification checklist

Since this PR is opened from a remote container, the local-daemon + live-cloud verification has to happen on your box:

- [ ] Copy changed files into `~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (and `routes/`):
      - `clawmetry/entitlements.py`
      - `routes/entitlement.py`
- [ ] Clear `__pycache__` under the installed `clawmetry/` + `routes/` trees.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon.
- [ ] `curl -s http://localhost:8900/api/entitlement/preview?tier=cloud_pro | jq .tier,.source,.retention_days,.channel_limit` — expect `"cloud_pro"`, `"preview"`, `90`, `null`.
- [ ] `curl -i http://localhost:8900/api/entitlement/preview` — expect `400`.
- [ ] `curl -i http://localhost:8900/api/entitlement/preview?tier=nope` — expect `404`.
- [ ] Decrypt the live cloud snapshot, confirm the dashboard tab still loads with no new console errors.
- [ ] Browser-check `/api/entitlement` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BJvYk6GSmzBBe5wnbP3LNy)_