### PR TITLE
feat(entitlement): nodes capacity axis on lock-reason / required-tier

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -286,6 +286,23 @@ _TIER_CHANNEL_LIMIT = {
     TIER_ENTERPRISE: None,
 }
 
+# Node-count cap per tier. OSS / Cloud Free are a single-node grant; every paid
+# tier is license-bound (the actual node_limit comes off the license payload or
+# cached cloud plan), so the static per-tier ceiling here is the *unlimited*
+# sentinel ``None``. ``min_tier_for_node_count`` walks this map the same way
+# ``min_tier_for_channel_count`` walks ``_TIER_CHANNEL_LIMIT`` so all four
+# capacity axes resolve off a single shape.
+_FREE_NODE_LIMIT = 1
+_TIER_NODE_LIMIT = {
+    TIER_OSS: _FREE_NODE_LIMIT,
+    TIER_CLOUD_FREE: _FREE_NODE_LIMIT,
+    TIER_TRIAL: None,
+    TIER_CLOUD_STARTER: None,
+    TIER_CLOUD_PRO: None,
+    TIER_PRO: None,
+    TIER_ENTERPRISE: None,
+}
+
 _TIER_PAID_RUNTIMES = _PAID_TIERS
 
 _PURCHASABLE_TIERS = (
@@ -641,6 +658,33 @@ class Entitlement:
                 return (
                     f"{n}-day retention exceeds the {tier_label(self.tier)} "
                     f"cap of {cap_str}; requires {lbl} or above."
+                )
+            if inferred_kind == "nodes":
+                try:
+                    n = int(k)
+                except (TypeError, ValueError):
+                    return None
+                if n <= 0:
+                    return None
+                if self.allows_node_count(n):
+                    return None
+                if self.expired:
+                    return (
+                        f"License expired; {n} nodes requires a valid "
+                        f"subscription."
+                    )
+                # node_limit comes off the license payload (per-grant), not the
+                # static per-tier map. <=0 is the unlimited sentinel licenses
+                # use for Enterprise.
+                lim = self.node_limit
+                cap_str = (
+                    str(lim) if isinstance(lim, int) and lim > 0 else "unlimited"
+                )
+                req = min_tier_for_node_count(n)
+                lbl = tier_label(req) if req else "Paid"
+                return (
+                    f"{n} nodes exceeds the {tier_label(self.tier)} cap of "
+                    f"{cap_str}; requires {lbl} or above."
                 )
             return None
         except Exception:
@@ -1185,6 +1229,45 @@ def min_tier_for_retention_window(days: int | None) -> str | None:
     return TIER_ENTERPRISE
 
 
+def min_tier_for_node_count(count: int) -> str | None:
+    """Return the cheapest *purchasable* tier id whose node-count cap admits
+    ``count`` registered nodes. Closes the fourth axis (alongside
+    :func:`min_tier_for_feature` / :func:`min_tier_for_runtime` /
+    :func:`min_tier_for_channel_count` / :func:`min_tier_for_retention_window`)
+    so the fleet-page upgrade affordance ("you have 4 nodes -- Available in
+    Starter") reads from the same single source of truth.
+
+    Walks :data:`_PURCHASABLE_TIERS` (cheapest -> most capable, trial excluded
+    -- it is a promotional grant, not a plan a customer can pick from a price
+    page) and returns the first tier whose ``_TIER_NODE_LIMIT`` value is either
+    ``None`` (unlimited) or ``>= count``.
+
+    Semantics mirror :func:`min_tier_for_channel_count` exactly so the four
+    capacity axes are interchangeable from the caller's perspective:
+
+    * ``count <= 0`` -- collapses to :data:`TIER_OSS`. A zero/negative count is
+      either "no nodes registered yet" or trivially satisfied; either way the
+      free floor covers it (matches :meth:`Entitlement.allows_node_count`'s
+      grace-on-zero contract).
+    * Non-int ``count`` -- returns ``None`` so a caller can distinguish "free"
+      from "couldn't parse". Never raises.
+    * Otherwise -- the first tier whose cap admits ``count``, falling back to
+      :data:`TIER_ENTERPRISE` if every finite cap is exceeded (Enterprise is
+      unlimited, so this is always a safe ceiling).
+    """
+    try:
+        n = int(count)
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return TIER_OSS
+    for tier in _PURCHASABLE_TIERS:
+        cap = _TIER_NODE_LIMIT.get(tier, _FREE_NODE_LIMIT)
+        if cap is None or n <= cap:
+            return tier
+    return TIER_ENTERPRISE
+
+
 def lock_reason(item: str, *, kind: str | None = None) -> str | None:
     try:
         return get_entitlement().lock_reason(item, kind=kind)
@@ -1310,6 +1393,7 @@ def tier_catalog() -> list[dict]:
                 "unlocks_paid_runtimes": unlocks_paid,
                 "retention_days": _TIER_RETENTION_DAYS.get(tier, 7),
                 "channel_limit": _TIER_CHANNEL_LIMIT.get(tier, _FREE_CHANNEL_LIMIT),
+                "node_limit": _TIER_NODE_LIMIT.get(tier, _FREE_NODE_LIMIT),
                 "features": sorted(paid_feats),
                 "runtimes": list(paid_runtimes_sorted) if unlocks_paid else [],
             }

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -182,7 +182,7 @@ def api_entitlement_preview():
         return jsonify({"error": "preview failed", "tier": target}), 500
 
 
-_CAPACITY_PARAMS = ("channels", "retention_days")
+_CAPACITY_PARAMS = ("channels", "retention_days", "nodes")
 
 
 def _parse_capacity_arg(name: str) -> tuple[bool, bool, int | None, str]:
@@ -227,12 +227,19 @@ def api_entitlement_required_tier():
             retention_n,
             retention_raw,
         ) = _parse_capacity_arg("retention_days")
+        (
+            nodes_present,
+            nodes_ok,
+            nodes_n,
+            nodes_raw,
+        ) = _parse_capacity_arg("nodes")
 
         supplied = [
             bool(feature),
             bool(runtime),
             channels_present,
             retention_present,
+            nodes_present,
         ]
         n_supplied = sum(1 for s in supplied if s)
         if n_supplied == 0:
@@ -241,7 +248,8 @@ def api_entitlement_required_tier():
                     {
                         "error": (
                             "supply exactly one of feature=<id>, runtime=<id>, "
-                            "channels=<int>, or retention_days=<int>"
+                            "channels=<int>, retention_days=<int>, or "
+                            "nodes=<int>"
                         )
                     }
                 ),
@@ -253,7 +261,7 @@ def api_entitlement_required_tier():
                     {
                         "error": (
                             "supply only one of feature=, runtime=, channels=, "
-                            "or retention_days="
+                            "retention_days=, or nodes="
                         )
                     }
                 ),
@@ -281,7 +289,7 @@ def api_entitlement_required_tier():
                 # ``allows_channel_count`` swallowing a non-int to True).
                 required = None
                 allowed = True
-        else:
+        elif retention_present:
             key, kind = retention_raw, "retention_days"
             if retention_ok:
                 required = _ent.min_tier_for_retention_window(retention_n)
@@ -291,6 +299,17 @@ def api_entitlement_required_tier():
                 # Important: don't forward ``None`` to
                 # :func:`min_tier_for_retention_window` -- there ``None`` is
                 # the *unlimited* sentinel and would mis-route to Enterprise.
+                required = None
+                allowed = True
+        else:
+            key, kind = nodes_raw, "nodes"
+            if nodes_ok:
+                required = _ent.min_tier_for_node_count(nodes_n)
+                allowed = ent.allows_node_count(nodes_n)
+            else:
+                # Same never-crash posture as the channels / retention_days
+                # branches -- a blank or non-int ``nodes`` swallows to
+                # ``required_tier=None`` rather than 500ing.
                 required = None
                 allowed = True
         cur_rank = _ent.tier_rank(ent.tier)
@@ -315,6 +334,7 @@ def api_entitlement_required_tier():
         runtime = (request.args.get("runtime") or "").strip().lower()
         channels_raw = (request.args.get("channels") or "").strip()
         retention_raw = (request.args.get("retention_days") or "").strip()
+        nodes_raw = (request.args.get("nodes") or "").strip()
         if feature:
             key, kind = feature, "feature"
         elif runtime:
@@ -323,6 +343,8 @@ def api_entitlement_required_tier():
             key, kind = channels_raw, "channels"
         elif retention_raw:
             key, kind = retention_raw, "retention_days"
+        elif nodes_raw:
+            key, kind = nodes_raw, "nodes"
         else:
             key, kind = "", ""
         return jsonify(
@@ -359,12 +381,19 @@ def api_entitlement_lock_reason():
             retention_n,
             retention_raw,
         ) = _parse_capacity_arg("retention_days")
+        (
+            nodes_present,
+            nodes_ok,
+            nodes_n,
+            nodes_raw,
+        ) = _parse_capacity_arg("nodes")
 
         supplied = [
             bool(feature),
             bool(runtime),
             channels_present,
             retention_present,
+            nodes_present,
         ]
         n_supplied = sum(1 for s in supplied if s)
         if n_supplied == 0:
@@ -373,7 +402,8 @@ def api_entitlement_lock_reason():
                     {
                         "error": (
                             "supply exactly one of feature=<id>, runtime=<id>, "
-                            "channels=<int>, or retention_days=<int>"
+                            "channels=<int>, retention_days=<int>, or "
+                            "nodes=<int>"
                         )
                     }
                 ),
@@ -385,7 +415,7 @@ def api_entitlement_lock_reason():
                     {
                         "error": (
                             "supply only one of feature=, runtime=, channels=, "
-                            "or retention_days="
+                            "retention_days=, or nodes="
                         )
                     }
                 ),
@@ -418,7 +448,7 @@ def api_entitlement_lock_reason():
                 required = None
                 allowed = True
                 reason = None
-        else:
+        elif retention_present:
             key, kind = retention_raw, "retention_days"
             if retention_ok:
                 required = _ent.min_tier_for_retention_window(retention_n)
@@ -429,6 +459,18 @@ def api_entitlement_lock_reason():
                 # don't forward ``None`` to
                 # :func:`min_tier_for_retention_window` -- there ``None`` is
                 # the *unlimited* sentinel and would mis-route to Enterprise.
+                required = None
+                allowed = True
+                reason = None
+        else:
+            key, kind = nodes_raw, "nodes"
+            if nodes_ok:
+                required = _ent.min_tier_for_node_count(nodes_n)
+                allowed = ent.allows_node_count(nodes_n)
+                reason = ent.lock_reason(str(nodes_n), kind=kind)
+            else:
+                # Same never-crash posture as the other capacity branches --
+                # a blank or non-int ``nodes`` swallows to ``reason=None``.
                 required = None
                 allowed = True
                 reason = None
@@ -456,6 +498,7 @@ def api_entitlement_lock_reason():
         runtime = (request.args.get("runtime") or "").strip().lower()
         channels_raw = (request.args.get("channels") or "").strip()
         retention_raw = (request.args.get("retention_days") or "").strip()
+        nodes_raw = (request.args.get("nodes") or "").strip()
         if feature:
             key, kind = feature, "feature"
         elif runtime:
@@ -464,6 +507,8 @@ def api_entitlement_lock_reason():
             key, kind = channels_raw, "channels"
         elif retention_raw:
             key, kind = retention_raw, "retention_days"
+        elif nodes_raw:
+            key, kind = nodes_raw, "nodes"
         else:
             key, kind = "", ""
         return jsonify(

--- a/tests/test_entitlement_api_nodes.py
+++ b/tests/test_entitlement_api_nodes.py
@@ -1,0 +1,239 @@
+"""Tests for the ``nodes=`` branch of
+``GET /api/entitlement/required-tier`` and
+``GET /api/entitlement/lock-reason``.
+
+The Python helpers :func:`clawmetry.entitlements.min_tier_for_node_count` and
+:meth:`Entitlement.lock_reason(kind="nodes")` are pinned in
+``tests/test_entitlements_min_tier_nodes.py`` and
+``tests/test_entitlement_lock_reason_nodes.py``. This file pins the HTTP
+wrappers so the same two endpoints answer all four capacity axes off the
+same URL shape, and a future param rename / shape drift fails loudly here.
+
+Companion to ``tests/test_entitlement_required_tier_capacity.py`` (the
+channels / retention HTTP branches this file mirrors).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """Flask test client wired with bp_entitlement and a clean HOME so the
+    resolver collapses to OSS-free deterministically. Mirrors the fixture in
+    ``tests/test_entitlement_required_tier_capacity.py``."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── /api/entitlement/required-tier?nodes= ─────────────────────────────────
+
+
+def test_required_tier_one_node_fits_oss(client):
+    """1 node fits the OSS single-node grant. Grace pass-through keeps
+    ``allowed`` True."""
+    resp = client.get("/api/entitlement/required-tier?nodes=1")
+    assert resp.status_code == 200
+    d = resp.get_json()
+    assert d["kind"] == "nodes"
+    assert d["key"] == "1"
+    assert d["required_tier"] == "oss"
+    assert d["required_tier_label"] == "OSS"
+    assert d["required_tier_rank"] == 0
+    assert d["allowed"] is True
+    assert d["upgrade_required"] is False
+
+
+def test_required_tier_two_nodes_resolves_to_starter(client):
+    """2+ nodes require Starter -- the cheapest tier with node_limit set
+    to None (unlimited)."""
+    d = client.get("/api/entitlement/required-tier?nodes=4").get_json()
+    assert d["kind"] == "nodes"
+    assert d["required_tier"] == "cloud_starter"
+    assert d["required_tier_label"] == "Starter"
+    assert d["required_tier_rank"] == 1
+
+
+def test_required_tier_grace_keeps_allowed_true_over_cap(client):
+    """The headline grace invariant -- wiring this branch must not change
+    current behaviour. ``allowed`` is True for any count in grace mode."""
+    d = client.get("/api/entitlement/required-tier?nodes=999").get_json()
+    assert d["allowed"] is True
+
+
+def test_required_tier_zero_nodes_collapses_to_oss(client):
+    """``nodes=0`` means "no nodes registered yet" -- trivially satisfied
+    by the free floor. Mirrors :func:`min_tier_for_node_count`."""
+    d = client.get("/api/entitlement/required-tier?nodes=0").get_json()
+    assert d["required_tier"] == "oss"
+
+
+def test_required_tier_non_int_swallows_to_required_none(client):
+    """A non-int ``nodes`` is swallowed by ``min_tier_for_node_count``
+    (which returns None). The HTTP wrapper inherits the never-crash
+    posture -- ``required_tier`` is None and the body still well-formed."""
+    d = client.get("/api/entitlement/required-tier?nodes=abc").get_json()
+    assert d["kind"] == "nodes"
+    assert d["key"] == "abc"
+    assert d["required_tier"] is None
+    assert d["required_tier_label"] is None
+    assert d["upgrade_required"] is False
+
+
+def test_required_tier_blank_value_is_swallowed(client):
+    """``?nodes=`` (present but empty) parses to None, not "fell through
+    to a feature/runtime branch". The body returns required_tier None,
+    kind="nodes"."""
+    d = client.get("/api/entitlement/required-tier?nodes=").get_json()
+    assert d["kind"] == "nodes"
+    assert d["required_tier"] is None
+
+
+# ── /api/entitlement/lock-reason?nodes= ───────────────────────────────────
+
+
+def test_lock_reason_one_node_is_unlocked(client):
+    """1 node fits OSS -- no reason to render."""
+    d = client.get("/api/entitlement/lock-reason?nodes=1").get_json()
+    assert d["kind"] == "nodes"
+    assert d["reason"] is None
+    assert d["locked"] is False
+    assert d["allowed"] is True
+    assert d["required_tier"] == "oss"
+
+
+def test_lock_reason_grace_keeps_locked_false_over_cap(client):
+    """Grace mode locks nothing -- the rollout invariant. The endpoint still
+    reports the required_tier so the UI can render the upgrade affordance
+    once enforce flips on, but ``locked`` stays False today."""
+    d = client.get("/api/entitlement/lock-reason?nodes=21").get_json()
+    assert d["kind"] == "nodes"
+    assert d["locked"] is False
+    assert d["allowed"] is True
+    assert d["required_tier"] == "cloud_starter"
+
+
+def test_lock_reason_non_int_swallows_to_none(client):
+    """A non-int ``nodes`` lands the never-crash branch -- reason / locked /
+    required_tier all neutral, no 500."""
+    d = client.get("/api/entitlement/lock-reason?nodes=abc").get_json()
+    assert d["kind"] == "nodes"
+    assert d["key"] == "abc"
+    assert d["reason"] is None
+    assert d["locked"] is False
+    assert d["required_tier"] is None
+
+
+# ── validation: exactly-one-param ────────────────────────────────────────
+
+
+def test_required_tier_400_when_no_params(client):
+    """No params is still a 400 -- the error message now mentions ``nodes``
+    alongside the other three axes."""
+    resp = client.get("/api/entitlement/required-tier")
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "error" in body
+    assert "nodes" in body["error"]
+
+
+def test_lock_reason_400_when_no_params(client):
+    resp = client.get("/api/entitlement/lock-reason")
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert "error" in body
+    assert "nodes" in body["error"]
+
+
+@pytest.mark.parametrize(
+    "qs",
+    [
+        "feature=self_evolve&nodes=5",
+        "runtime=claude_code&nodes=5",
+        "channels=5&nodes=5",
+        "retention_days=30&nodes=5",
+    ],
+)
+def test_required_tier_400_when_nodes_paired_with_other_axis(client, qs):
+    """Mixing the new nodes= axis with any other axis is a 400 -- same
+    exactly-one-axis contract the other three branches already enforce."""
+    resp = client.get(f"/api/entitlement/required-tier?{qs}")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+@pytest.mark.parametrize(
+    "qs",
+    [
+        "feature=self_evolve&nodes=5",
+        "runtime=claude_code&nodes=5",
+        "channels=5&nodes=5",
+        "retention_days=30&nodes=5",
+    ],
+)
+def test_lock_reason_400_when_nodes_paired_with_other_axis(client, qs):
+    resp = client.get(f"/api/entitlement/lock-reason?{qs}")
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+# ── existing branches still work after the refactor ──────────────────────
+
+
+def test_required_tier_feature_branch_unchanged(client):
+    """Regression guard -- adding the nodes branch must not break the
+    existing feature= response shape."""
+    d = client.get("/api/entitlement/required-tier?feature=self_evolve").get_json()
+    assert d["kind"] == "feature"
+    assert d["required_tier"] == "cloud_pro"
+
+
+def test_required_tier_retention_branch_unchanged(client):
+    """Regression guard -- retention_days= still resolves the same way."""
+    d = client.get("/api/entitlement/required-tier?retention_days=30").get_json()
+    assert d["kind"] == "retention_days"
+    assert d["required_tier"] == "cloud_starter"
+
+
+# ── enforce mode: allowed reflects current entitlement ──────────────────
+
+
+def test_enforce_two_nodes_marks_not_allowed(client, monkeypatch):
+    """Under enforce, an OSS install at 2 nodes (over the single-node grant)
+    sees ``allowed=False`` -- the gate axis is wired through, just inert in
+    grace."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e
+
+    e.invalidate()
+    d = client.get("/api/entitlement/required-tier?nodes=2").get_json()
+    assert d["required_tier"] == "cloud_starter"
+    assert d["allowed"] is False
+    assert d["upgrade_required"] is True
+
+
+def test_enforce_lock_reason_two_nodes_returns_reason(client, monkeypatch):
+    """Under enforce, lock-reason on 2 nodes returns the rendered string
+    naming the overflow count, the cap, and the unlock tier."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    import clawmetry.entitlements as e
+
+    e.invalidate()
+    d = client.get("/api/entitlement/lock-reason?nodes=2").get_json()
+    assert d["locked"] is True
+    assert d["reason"] is not None
+    assert "2 nodes" in d["reason"]
+    assert "Starter" in d["reason"]

--- a/tests/test_entitlement_lock_reason_nodes.py
+++ b/tests/test_entitlement_lock_reason_nodes.py
@@ -1,0 +1,144 @@
+"""Tests for the ``nodes`` capacity-axis branch of
+:meth:`clawmetry.entitlements.Entitlement.lock_reason`.
+
+Closes the symmetry with :func:`min_tier_for_node_count` so the dashboard /
+fleet route can render "you have 5 nodes -- Available in Starter" copy off
+the same helper that already answers the feature / runtime / channels /
+retention_days axes.
+
+Companion to ``tests/test_entitlement_lock_reason.py`` (feature / runtime
+contract) and ``tests/test_entitlement_lock_reason_capacity.py`` (the
+channels= / retention_days= branches this mirrors).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── grace mode locks nothing ────────────────────────────────────────────────
+
+
+def test_grace_nodes_overflow_is_unlocked(ent):
+    """Headline rollout invariant -- wiring this branch must not change
+    current behaviour. Grace returns None for any node count."""
+    en = ent.get_entitlement(force=True)
+    assert en.grace is True
+    assert en.lock_reason("99", kind="nodes") is None
+
+
+# ── enforced OSS: node overflow surfaces a tier-naming reason ──────────────
+
+
+def test_single_node_within_free_cap_is_unlocked_on_oss(ent, monkeypatch):
+    """1 node fits the OSS single-node grant -- no lock to explain."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("1", kind="nodes") is None
+
+
+def test_two_nodes_on_oss_names_starter(ent, monkeypatch):
+    """2 nodes over the OSS single-node grant names Starter, the cap, and
+    the overflow count -- mirrors the channels branch's reason shape."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    reason = en.lock_reason("2", kind="nodes")
+    assert reason is not None
+    # Mentions the overflow count, the cap, and the unlock tier.
+    assert "2 nodes" in reason
+    assert "Starter" in reason
+    assert "1" in reason  # the OSS cap surfaced from Entitlement.node_limit
+
+
+# ── tier-dependent unlocks ─────────────────────────────────────────────────
+
+
+def test_starter_unlocks_higher_node_counts(ent, monkeypatch):
+    """A Starter grant with node_limit=10 admits 1..10 and locks 11+. Lock
+    reason on 11 cites Starter's per-license cap (10), not the static
+    per-tier ceiling (None / unlimited)."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    starter = ent._build(
+        ent.TIER_CLOUD_STARTER, "cloud", node_limit=10, expiry=None,
+    )
+    assert starter.lock_reason("10", kind="nodes") is None
+    reason = starter.lock_reason("11", kind="nodes")
+    assert reason is not None
+    assert "11 nodes" in reason
+    assert "10" in reason  # the license-bound cap surfaces, not "unlimited"
+
+
+def test_enterprise_unlimited_grant_unlocks_everything(ent, monkeypatch):
+    """An Enterprise grant with ``node_limit=0`` (the unlimited sentinel)
+    locks nothing -- matches :meth:`Entitlement.allows_node_count`'s
+    contract."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent._build(ent.TIER_ENTERPRISE, "license", node_limit=0, expiry=None)
+    assert en.lock_reason("1000", kind="nodes") is None
+
+
+# ── expiry ─────────────────────────────────────────────────────────────────
+
+
+def test_expired_paid_grant_says_expired(ent, monkeypatch):
+    """An expired paid plan should behave like OSS for node-count checks
+    too -- same posture as the channels / retention branches."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    expired = ent._build(ent.TIER_PRO, "license", node_limit=25, expiry=1.0)
+    assert expired.expired is True
+    reason = expired.lock_reason("2", kind="nodes")
+    assert reason is not None
+    assert "expired" in reason.lower()
+
+
+# ── bad input is silently un-locked (never-crash, never-claim) ────────────
+
+
+def test_non_int_nodes_returns_none(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("abc", kind="nodes") is None
+    assert en.lock_reason("", kind="nodes") is None
+
+
+def test_zero_nodes_returns_none(ent, monkeypatch):
+    """Zero / negative counts are trivially satisfied; no lock to explain."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("0", kind="nodes") is None
+    assert en.lock_reason("-3", kind="nodes") is None
+
+
+# ── auto-infer never picks up a numeric key ────────────────────────────────
+
+
+def test_numeric_input_requires_explicit_nodes_kind(ent, monkeypatch):
+    """``lock_reason`` auto-infers ``kind`` only from a known feature/runtime
+    id. A bare digit string is neither, so without an explicit ``kind`` the
+    helper returns None -- matches the channels / retention_days branches."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    en = ent.get_entitlement(force=True)
+    assert en.lock_reason("5") is None
+    # ...but with kind=, the nodes branch fires.
+    assert en.lock_reason("5", kind="nodes") is not None

--- a/tests/test_entitlements_min_tier_nodes.py
+++ b/tests/test_entitlements_min_tier_nodes.py
@@ -1,0 +1,136 @@
+"""Tests for :func:`clawmetry.entitlements.min_tier_for_node_count` -- the
+fourth capacity-axis reverse-lookup helper, alongside
+:func:`min_tier_for_channel_count` / :func:`min_tier_for_retention_window`.
+
+The OSS free tier is a single-node grant; every paid tier carries an
+unlimited per-tier ceiling (the actual cap is license-bound, surfaced through
+``Entitlement.node_limit``). The helper therefore answers "what is the
+cheapest *purchasable* tier whose static cap admits N registered nodes" so
+the fleet page can render "you have 4 nodes -- Available in Starter" copy off
+the same single source of truth the other three axes already use.
+
+Companion to ``tests/test_entitlements_min_tier_capacity.py`` (the
+channels= / retention= helper contract this file mirrors).
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir so no
+    real ``~/.clawmetry/license.key`` or ``cloud_plan.json`` leaks in.
+    Enforcement off by default -- matches the project rollout posture."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+# ── happy path: within / over the free cap ─────────────────────────────────
+
+
+def test_single_node_collapses_to_oss(ent):
+    """1 node fits on OSS (free cap = 1). The free floor covers it."""
+    assert ent.min_tier_for_node_count(1) == ent.TIER_OSS
+
+
+def test_two_nodes_resolves_to_starter(ent):
+    """2+ nodes need the cheapest paid tier (Starter) -- the first tier
+    whose ``_TIER_NODE_LIMIT`` value is ``None`` (unlimited)."""
+    assert ent.min_tier_for_node_count(2) == ent.TIER_CLOUD_STARTER
+
+
+def test_large_count_still_resolves_to_starter(ent):
+    """Every paid tier carries the unlimited sentinel, so even very high
+    counts still resolve to the cheapest paid tier -- mirrors the channels
+    axis where any count over the free cap also lands on Starter."""
+    for n in (3, 10, 100, 10_000):
+        assert ent.min_tier_for_node_count(n) == ent.TIER_CLOUD_STARTER, n
+
+
+# ── zero / negative are trivially satisfied ────────────────────────────────
+
+
+def test_zero_collapses_to_oss(ent):
+    """``count == 0`` means "no nodes registered yet" -- trivially satisfied
+    by the free floor. Mirrors :meth:`Entitlement.allows_node_count`'s
+    zero-on-grace contract and the same posture on the channels axis."""
+    assert ent.min_tier_for_node_count(0) == ent.TIER_OSS
+
+
+def test_negative_collapses_to_oss(ent):
+    """Stray negative values land on the free floor too -- defensive parity
+    with :func:`min_tier_for_channel_count`."""
+    assert ent.min_tier_for_node_count(-1) == ent.TIER_OSS
+    assert ent.min_tier_for_node_count(-9999) == ent.TIER_OSS
+
+
+# ── non-int / bad input ────────────────────────────────────────────────────
+
+
+def test_non_int_returns_none(ent):
+    """A non-int ``count`` returns ``None`` so a caller can distinguish
+    "free covers it" from "couldn't parse" -- same contract the channels
+    helper uses. Must never raise."""
+    assert ent.min_tier_for_node_count("not-a-number") is None
+    assert ent.min_tier_for_node_count(None) is None
+    assert ent.min_tier_for_node_count(object()) is None
+
+
+def test_numeric_string_is_accepted(ent):
+    """A numeric string (``"3"``) coerces cleanly -- a fleet count read off
+    a query string is already a str."""
+    assert ent.min_tier_for_node_count("1") == ent.TIER_OSS
+    assert ent.min_tier_for_node_count("4") == ent.TIER_CLOUD_STARTER
+
+
+# ── never raises (defensive contract) ──────────────────────────────────────
+
+
+def test_never_raises_on_weird_input(ent):
+    """The helper is on a hot path (fleet route rendering); anything that
+    would normally raise is swallowed to ``None``."""
+    for bad in (object(), [], {}, b"bytes", float("nan")):
+        try:
+            ent.min_tier_for_node_count(bad)
+        except Exception as exc:
+            pytest.fail(f"min_tier_for_node_count raised on {bad!r}: {exc}")
+
+
+# ── tier_catalog surface ───────────────────────────────────────────────────
+
+
+def test_tier_catalog_surfaces_node_limit(ent):
+    """``tier_catalog`` rows carry the static per-tier ``node_limit`` so the
+    UI's plan-comparison table can render the same map the gate consumes
+    (mirrors the ``channel_limit`` / ``retention_days`` columns already
+    there)."""
+    rows = {row["id"]: row for row in ent.tier_catalog()}
+    assert rows[ent.TIER_OSS]["node_limit"] == 1
+    assert rows[ent.TIER_CLOUD_FREE]["node_limit"] == 1
+    for paid in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        assert rows[paid]["node_limit"] is None, paid
+
+
+# ── triad consistency with the other capacity helpers ──────────────────────
+
+
+def test_axis_helpers_agree_on_free_floor(ent):
+    """All four capacity axes collapse to OSS on zero / minimum counts --
+    the canonical "free floor" invariant the dashboard relies on."""
+    assert ent.min_tier_for_channel_count(0) == ent.TIER_OSS
+    assert ent.min_tier_for_retention_window(0) == ent.TIER_OSS
+    assert ent.min_tier_for_node_count(0) == ent.TIER_OSS


### PR DESCRIPTION
## Summary

Closes the fourth capacity-axis symmetry gap. `Entitlement.allows_node_count` already exists as the third gate corner (alongside `allows_runtime` / `allows_feature`), but it lacked the same reverse-lookup + HTTP wrappers the other three capacity axes (channels / retention_days / features / runtimes) have, so the fleet-page upgrade affordance had to hand-roll its own copy.

### What's added

- `_TIER_NODE_LIMIT` map — OSS / Cloud Free at the single-node grant, every paid tier at `None` (the per-license cap is what matters in paid tiers; the static per-tier ceiling here is the unlimited sentinel).
- `min_tier_for_node_count(count)` — cheapest purchasable tier whose static cap admits `count` registered nodes. Walks `_PURCHASABLE_TIERS` exactly like `min_tier_for_channel_count` (zero/negative → `oss`, non-int → `None`, never raises).
- `Entitlement.lock_reason(item, kind="nodes")` — renders the lock copy with the overflow count, the per-license cap, and the unlock tier label. Cites `self.node_limit` (the license-bound cap), not the static per-tier ceiling, so a `Starter@node_limit=10` grant says *"11 nodes exceeds the Starter cap of 10"* rather than *"…of unlimited"*.
- `GET /api/entitlement/required-tier?nodes=N` and `GET /api/entitlement/lock-reason?nodes=N` — same exactly-one-axis contract as the existing branches, same never-crash posture on blank / non-int input, same fallback shape.
- `node_limit` surfaced on every `tier_catalog()` row so the plan-comparison table can render the new column off the same map the gate consumes.

### Rollout posture is unchanged

Grace mode short-circuits every branch to `allowed=True` / `reason=None` / `locked=False`, so wiring this in **changes no current behaviour**. Enforce mode is what the existing `test_entitlement_node_count.py` already pinned for `allows_node_count`.

### Tests

- `tests/test_entitlements_min_tier_nodes.py` — helper contract (zero/negative → OSS, single-node → OSS, 2+ → Starter, non-int → None, `tier_catalog` rows carry the column, triad symmetry with the other capacity axes).
- `tests/test_entitlement_lock_reason_nodes.py` — `Entitlement` branch (grace unlocked, OSS overflow names Starter + the cap, Starter grant `@ node_limit=10` cites the license cap on 11, Enterprise unlimited unlocks everything, expired grants say expired, bad input swallows).
- `tests/test_entitlement_api_nodes.py` — HTTP wrappers (happy path on both endpoints, grace `allowed=True`, non-int/blank swallow, 400 on missing or mixed axis, regression guards on feature / retention branches, enforce-mode `allowed=False`).

**42 new tests, 522 entitlement tests passing total.** `min_tier_for_*` and `lock_reason` continue to never raise on bad input.

## Local operator verification checklist

Cannot perform any of these remotely — the agent has no access to the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The operator runs:

- [ ] Copy `clawmetry/entitlements.py` and `routes/entitlement.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `…/routes/`.
- [ ] Clear `__pycache__` under both dirs.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) / `systemctl --user restart clawmetry-sync` (Linux).
- [ ] `curl -sS http://localhost:8900/api/entitlement | jq '.node_limit, .tier'` — should be unchanged (grace mode).
- [ ] `curl -sS 'http://localhost:8900/api/entitlement/required-tier?nodes=1' | jq` — `required_tier: "oss"`, `allowed: true`.
- [ ] `curl -sS 'http://localhost:8900/api/entitlement/required-tier?nodes=4' | jq` — `required_tier: "cloud_starter"`, `allowed: true` (grace).
- [ ] `curl -sS 'http://localhost:8900/api/entitlement/lock-reason?nodes=4' | jq` — `locked: false`, `reason: null` (grace).
- [ ] `CLAWMETRY_ENFORCE=1 …` smoke: `required_tier=cloud_starter`, `allowed=false`, `reason` strings render with the overflow count + cap + tier label.
- [ ] `curl -sS http://localhost:8900/api/tiers | jq '.tiers[] | {id, node_limit}'` — every row carries the new column.
- [ ] Decrypt the live cloud snapshot and browser-check `/api/entitlement` doesn't 5xx; `/fleet` page still renders.
- [ ] Mark ready-for-review (or merge) once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G47UWFK6BHMUEHwR387qAr

---
_Generated by [Claude Code](https://claude.ai/code/session_01G47UWFK6BHMUEHwR387qAr)_