### PR TITLE
feat(v2): respect prefers-color-scheme on first visit (#1495)

### DIFF
--- a/clawmetry/v2/routes.py
+++ b/clawmetry/v2/routes.py
@@ -44,7 +44,7 @@ _PREFS_FILE = _PREFS_DIR / "preferences.json"
 
 _VALID_THEMES = {"light", "mid", "dark"}
 _VALID_DENSITIES = {"compact", "regular", "comfy"}
-_DEFAULT_PREFS = {"theme": "light", "density": "regular"}
+_DEFAULT_PREFS = {"theme": None, "density": "regular"}
 
 bp_v2 = Blueprint(
     "v2",
@@ -60,7 +60,7 @@ def _read_prefs() -> dict:
             with open(_PREFS_FILE) as f:
                 stored = json.load(f)
             return {
-                "theme": stored.get("theme", "light") if stored.get("theme") in _VALID_THEMES else "light",
+                "theme": stored.get("theme") if stored.get("theme") in _VALID_THEMES else None,
                 "density": stored.get("density", "regular") if stored.get("density") in _VALID_DENSITIES else "regular",
             }
     except (json.JSONDecodeError, OSError):

--- a/frontend/src/stores/themeStore.ts
+++ b/frontend/src/stores/themeStore.ts
@@ -41,17 +41,20 @@ export const useThemeStore = create<ThemeState>((set, get) => ({
   },
 
   hydrate: async () => {
+    let storedTheme: Theme | null = null;
+    let storedDensity: Density = "regular";
     try {
       const res = await fetch("/api/v2/preferences");
       if (res.ok) {
         const prefs = await res.json();
-        const theme = prefs.theme ?? "light";
-        const density = prefs.density ?? "regular";
-        set({ theme, density });
-        applyToDOM(theme, density);
+        storedTheme = (prefs.theme as Theme) ?? null;
+        storedDensity = (prefs.density as Density) ?? "regular";
       }
-    } catch {
-      applyToDOM(get().theme, get().density);
-    }
+    } catch {}
+    // null theme means no stored preference — respect prefers-color-scheme
+    const theme: Theme =
+      storedTheme ?? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+    set({ theme, density: storedDensity });
+    applyToDOM(theme, storedDensity);
   },
 }));


### PR DESCRIPTION
## Summary

The v2 SPA always started in light mode on first visit, even for users whose OS was set to dark mode. This lands the last open design question from the RFC: "Respect `prefers-color-scheme`? Yes, on first visit only."

## Changes

- **`clawmetry/v2/routes.py`**: `_DEFAULT_PREFS["theme"]` changed from `"light"` to `None`; `_read_prefs()` now returns `None` (not `"light"`) when no preference file exists or the stored value isn't a valid theme. `None` is the signal for "user hasn't picked yet."
- **`frontend/src/stores/themeStore.ts`**: `hydrate()` simplified — treats `null` theme from the server as "fall back to `prefers-color-scheme`" and applies without persisting, so the OS preference stays effective until the user explicitly picks a theme via the 3-button switcher.

## Test plan

- [ ] No `~/.clawmetry/preferences.json` + OS in dark mode → v2 opens in dark theme
- [ ] No preferences file + OS in light mode → opens in light theme
- [ ] Existing prefs with `"theme": "light"` + OS in dark mode → stays light (stored preference wins)
- [ ] Set theme via switcher → persists across page reloads
- [ ] Delete prefs file → follows OS again on next load

## Bot meta
<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #1495. Marked draft for human review — mark Ready for Review once happy.

Closes #1495

---
_Generated by [Claude Code](https://claude.ai/code/session_01We51g6ErBL4q2dLVDhoZxr)_