### PR TITLE
feat(entitlements): min_tier_for_features + min_tier_for_runtimes (plural) -- batched upgrade-CTA resolver

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1407,6 +1407,81 @@ def min_tier_for_node_count(count: int) -> str | None:
     return TIER_ENTERPRISE
 
 
+def min_tier_for_features(features) -> str | None:
+    """Cheapest *purchasable* tier admitting **all** ``features`` at once.
+
+    Plural sibling of :func:`min_tier_for_feature`. A dashboard wiring "you
+    are using fleet + otel_export + sso -- Available in Enterprise" has to
+    resolve the most-constraining feature in the set; this helper folds the
+    per-item lookups + max-by-rank in one place so callers don't reinvent
+    the walk (and so all five capacity axes look symmetric from the caller's
+    side: feature/runtime singular + features/runtimes plural).
+
+    Semantics:
+
+    * Empty / ``None`` iterable -- returns ``None``. "I asked for nothing"
+      has no upgrade target, distinct from "I asked for free features"
+      (which returns :data:`TIER_OSS`). Same posture as the singular helper
+      returning ``None`` for empty input.
+    * Unknown items contribute nothing -- they are skipped, not treated as
+      a constraint, so a typo doesn't silently mis-route to Enterprise. If
+      **every** item is unknown / empty, the helper returns ``None``.
+    * All-known-free items -- returns :data:`TIER_OSS` (same as the singular
+      free-feature path).
+    * Mixed -- returns the highest-rank ``min_tier_for_feature`` across the
+      set (the most-constraining feature wins).
+    * Non-iterable input -- returns ``None``. Never raises.
+    """
+    try:
+        if features is None:
+            return None
+        items = list(features)
+    except TypeError:
+        return None
+    tiers: list[str] = []
+    for f in items:
+        t = min_tier_for_feature(f)
+        if t is not None:
+            tiers.append(t)
+    if not tiers:
+        return None
+    return max(tiers, key=tier_rank)
+
+
+def min_tier_for_runtimes(runtimes) -> str | None:
+    """Cheapest *purchasable* tier admitting **all** ``runtimes`` at once.
+
+    Plural sibling of :func:`min_tier_for_runtime`. Today every paid runtime
+    unlocks at :data:`TIER_CLOUD_STARTER`, so for a set containing any paid
+    runtime the answer is always Starter -- but the helper is provided for
+    API symmetry with :func:`min_tier_for_features` (so a caller batching
+    feature+runtime asks reads off one shape) and to stay correct if the
+    paid-runtime tier mapping ever becomes per-runtime.
+
+    Semantics mirror :func:`min_tier_for_features` exactly:
+
+    * Empty / ``None`` iterable -- returns ``None``.
+    * Unknown items contribute nothing (skipped); all-unknown -- ``None``.
+    * All-free items -- :data:`TIER_OSS`.
+    * Mixed -- the highest-rank ``min_tier_for_runtime`` across the set.
+    * Non-iterable input -- ``None``. Never raises.
+    """
+    try:
+        if runtimes is None:
+            return None
+        items = list(runtimes)
+    except TypeError:
+        return None
+    tiers: list[str] = []
+    for rt in items:
+        t = min_tier_for_runtime(rt)
+        if t is not None:
+            tiers.append(t)
+    if not tiers:
+        return None
+    return max(tiers, key=tier_rank)
+
+
 def lock_reason(item: str, *, kind: str | None = None) -> str | None:
     try:
         return get_entitlement().lock_reason(item, kind=kind)

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -40,6 +40,16 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                           upgrade-CTA card can show concrete
                                           numbers without per-tier derivation
                                           in JS.
+  GET  /api/entitlement/required-tier-batch -- plural sibling of
+                                          ``/required-tier``: takes
+                                          ``features=a,b,c`` and/or
+                                          ``runtimes=x,y,z`` (comma-separated)
+                                          and returns the cheapest tier
+                                          admitting *all* of them at once.
+                                          Lets a dashboard answer "I'm using
+                                          fleet + otel_export + sso -- what
+                                          tier covers everything?" in a single
+                                          round-trip.
   GET  /api/runtimes                  -- the full runtime catalog.
   GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
 """
@@ -550,6 +560,108 @@ def api_entitlement_lock_reason():
                 "current_tier": "oss",
                 "current_tier_rank": 0,
                 "upgrade_required": False,
+            }
+        )
+
+
+def _parse_csv_arg(name: str) -> list[str]:
+    """Parse a comma-separated query arg into a normalised id list.
+
+    Empty / whitespace tokens are dropped; remaining tokens are lowercased and
+    deduplicated while preserving first-seen order so the response payload is
+    stable. ``features=otel_export,,sso,otel_export`` -> ``["otel_export", "sso"]``.
+    Never raises (a missing arg returns ``[]``).
+    """
+    raw = request.args.get(name, "") or ""
+    out: list[str] = []
+    seen: set[str] = set()
+    for token in raw.split(","):
+        t = token.strip().lower()
+        if not t or t in seen:
+            continue
+        seen.add(t)
+        out.append(t)
+    return out
+
+
+@bp_entitlement.route("/api/entitlement/required-tier-batch")
+def api_entitlement_required_tier_batch():
+    """``GET /api/entitlement/required-tier-batch?features=a,b,c&runtimes=x,y``
+    -- plural sibling of ``/api/entitlement/required-tier``.
+
+    Returns the cheapest *purchasable* tier admitting **all** supplied
+    features and runtimes at once: the most-constraining item across the
+    two sets wins. Wraps :func:`min_tier_for_features` /
+    :func:`min_tier_for_runtimes` so a dashboard surface that mixes axes
+    ("you are using fleet + otel_export + sso + claude_code -- Available
+    in Enterprise") gets the answer in one round-trip instead of N calls
+    + max-by-rank on the client.
+
+    At least one of ``features=`` / ``runtimes=`` must be supplied
+    (non-empty after CSV parsing). Comma-separated tokens; whitespace and
+    duplicates are normalised away; unknown ids contribute nothing (so a
+    typo does not silently mis-route to Enterprise, matching the singular
+    helpers' posture). Never 5xxs: the OSS-free shape is returned on any
+    resolver failure.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        if not features and not runtimes:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv> or "
+                            "runtimes=<csv>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        ent = _ent.get_entitlement()
+        feat_tier = _ent.min_tier_for_features(features) if features else None
+        runtime_tier = _ent.min_tier_for_runtimes(runtimes) if runtimes else None
+        candidates = [t for t in (feat_tier, runtime_tier) if t is not None]
+        required = max(candidates, key=_ent.tier_rank) if candidates else None
+
+        cur_rank = _ent.tier_rank(ent.tier)
+        req_rank = _ent.tier_rank(required) if required else -1
+        required_label = _ent.tier_label(required) if required else None
+
+        feat_allowed = all(ent.allows_feature(f) for f in features)
+        runtime_allowed = all(ent.allows_runtime(r) for r in runtimes)
+        allowed = feat_allowed and runtime_allowed
+
+        return jsonify(
+            {
+                "features": features,
+                "runtimes": runtimes,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "current_tier": ent.tier,
+                "current_tier_rank": cur_rank,
+                "upgrade_required": bool(required) and req_rank > cur_rank,
+                "allowed": allowed,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_required_tier_batch: error: %s", exc)
+        return jsonify(
+            {
+                "features": _parse_csv_arg("features"),
+                "runtimes": _parse_csv_arg("runtimes"),
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "upgrade_required": False,
+                "allowed": True,
             }
         )
 

--- a/tests/test_entitlements_min_tier_batch.py
+++ b/tests/test_entitlements_min_tier_batch.py
@@ -1,0 +1,249 @@
+"""Tests for ``min_tier_for_features`` / ``min_tier_for_runtimes`` plural
+helpers and the ``/api/entitlement/required-tier-batch`` endpoint.
+
+The dashboard's upgrade-CTA copy ("you're using fleet + otel_export + sso --
+Available in Enterprise") needs a single canonical reverse lookup that folds
+the per-item lookup + max-by-rank into one place. The plural helpers under
+test are that canonical lookup; this file pins their semantics so a future
+tier shuffle breaks loudly here instead of silently in the UI.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── min_tier_for_features ──────────────────────────────────────────────────
+
+
+def test_features_empty_iterable_returns_none(ent):
+    assert ent.min_tier_for_features([]) is None
+    assert ent.min_tier_for_features(()) is None
+
+
+def test_features_none_returns_none(ent):
+    assert ent.min_tier_for_features(None) is None
+
+
+def test_features_all_free_returns_oss(ent):
+    assert ent.min_tier_for_features(["sessions", "usage", "brain"]) == ent.TIER_OSS
+
+
+def test_features_single_paid_returns_its_min(ent):
+    assert ent.min_tier_for_features(["fleet"]) == ent.TIER_CLOUD_STARTER
+    assert ent.min_tier_for_features(["otel_export"]) == ent.TIER_CLOUD_PRO
+    assert ent.min_tier_for_features(["sso"]) == ent.TIER_ENTERPRISE
+
+
+def test_features_picks_highest_rank_min(ent):
+    """Most-constraining feature wins -- the answer must be the highest-rank
+    ``min_tier_for_feature`` across the set, never the cheapest one."""
+    assert (
+        ent.min_tier_for_features(["fleet", "otel_export"]) == ent.TIER_CLOUD_PRO
+    )
+    assert (
+        ent.min_tier_for_features(["fleet", "otel_export", "sso"])
+        == ent.TIER_ENTERPRISE
+    )
+    assert (
+        ent.min_tier_for_features(["sessions", "fleet"]) == ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_features_unknown_items_are_skipped(ent):
+    """A typo in one item must not silently mis-route to Enterprise. The
+    helper skips unknowns and resolves off the known subset."""
+    assert (
+        ent.min_tier_for_features(["fleet", "not_a_real_feature"])
+        == ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_features_all_unknown_returns_none(ent):
+    """If *every* item is unknown, the helper has no constraint to resolve
+    against and returns ``None`` (matches the singular helper's posture)."""
+    assert ent.min_tier_for_features(["nope", "also_nope", ""]) is None
+
+
+def test_features_case_insensitive(ent):
+    assert ent.min_tier_for_features(["OTEL_EXPORT", "SSO"]) == ent.TIER_ENTERPRISE
+
+
+def test_features_non_iterable_returns_none(ent):
+    """Never raises -- non-iterable input collapses to ``None``."""
+    assert ent.min_tier_for_features(42) is None
+
+
+def test_features_excludes_trial(ent):
+    """Trial is a promotional grant, not a plan a customer can pick from a
+    price page. The plural helper inherits that exclusion from the singular."""
+    for f in ent.PAID_FEATURES | ent.ENTERPRISE_FEATURES:
+        assert ent.min_tier_for_features([f]) != ent.TIER_TRIAL, f
+
+
+# ── min_tier_for_runtimes ──────────────────────────────────────────────────
+
+
+def test_runtimes_empty_returns_none(ent):
+    assert ent.min_tier_for_runtimes([]) is None
+    assert ent.min_tier_for_runtimes(None) is None
+
+
+def test_runtimes_all_free_returns_oss(ent):
+    assert ent.min_tier_for_runtimes(["openclaw", "nemoclaw"]) == ent.TIER_OSS
+
+
+def test_runtimes_any_paid_returns_starter(ent):
+    """Today every paid runtime unlocks at Starter, so any set containing one
+    paid runtime resolves to Starter regardless of the rest."""
+    assert ent.min_tier_for_runtimes(["claude_code"]) == ent.TIER_CLOUD_STARTER
+    assert (
+        ent.min_tier_for_runtimes(["claude_code", "codex"])
+        == ent.TIER_CLOUD_STARTER
+    )
+    assert (
+        ent.min_tier_for_runtimes(["openclaw", "claude_code"])
+        == ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_runtimes_unknown_skipped(ent):
+    assert (
+        ent.min_tier_for_runtimes(["claude_code", "not_a_runtime"])
+        == ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_runtimes_all_unknown_returns_none(ent):
+    assert ent.min_tier_for_runtimes(["nope", ""]) is None
+
+
+def test_runtimes_non_iterable_returns_none(ent):
+    assert ent.min_tier_for_runtimes(42) is None
+
+
+# ── /api/entitlement/required-tier-batch ───────────────────────────────────
+
+
+def test_batch_features_only(client, ent):
+    rv = client.get(
+        "/api/entitlement/required-tier-batch?features=fleet,otel_export"
+    )
+    assert rv.status_code == 200
+    d = rv.get_json()
+    assert d["features"] == ["fleet", "otel_export"]
+    assert d["runtimes"] == []
+    assert d["required_tier"] == ent.TIER_CLOUD_PRO
+    assert d["required_tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert d["current_tier"] == ent.TIER_OSS
+    assert d["current_tier_rank"] == 0
+    assert d["upgrade_required"] is True
+    assert d["allowed"] is True  # grace mode
+
+
+def test_batch_runtimes_only(client, ent):
+    d = client.get(
+        "/api/entitlement/required-tier-batch?runtimes=claude_code,codex"
+    ).get_json()
+    assert d["runtimes"] == ["claude_code", "codex"]
+    assert d["features"] == []
+    assert d["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert d["upgrade_required"] is True
+
+
+def test_batch_features_and_runtimes_mix(client, ent):
+    """The endpoint must take the max across both axes, not just one."""
+    d = client.get(
+        "/api/entitlement/required-tier-batch?features=sso&runtimes=claude_code"
+    ).get_json()
+    assert d["required_tier"] == ent.TIER_ENTERPRISE
+    assert d["required_tier_rank"] == ent.tier_rank(ent.TIER_ENTERPRISE)
+
+
+def test_batch_all_free_returns_oss(client, ent):
+    d = client.get(
+        "/api/entitlement/required-tier-batch?features=sessions,usage&runtimes=openclaw"
+    ).get_json()
+    assert d["required_tier"] == ent.TIER_OSS
+    assert d["upgrade_required"] is False
+
+
+def test_batch_normalises_csv(client, ent):
+    """Whitespace, blank tokens, and duplicates must be normalised away so
+    the response payload is stable across messy input."""
+    d = client.get(
+        "/api/entitlement/required-tier-batch?features=otel_export,,otel_export,%20fleet%20"
+    ).get_json()
+    assert d["features"] == ["otel_export", "fleet"]
+    assert d["required_tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_batch_unknown_items_skipped(client, ent):
+    d = client.get(
+        "/api/entitlement/required-tier-batch?features=fleet,not_a_real_feature"
+    ).get_json()
+    assert d["required_tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_batch_all_unknown_returns_null_tier(client, ent):
+    """All-unknown collapses to ``required_tier=None`` (no upgrade target),
+    not a 500. Matches the singular endpoint's unknown-key posture."""
+    rv = client.get(
+        "/api/entitlement/required-tier-batch?features=nope,also_nope"
+    )
+    assert rv.status_code == 200
+    d = rv.get_json()
+    assert d["required_tier"] is None
+    assert d["upgrade_required"] is False
+
+
+def test_batch_requires_at_least_one_axis(client):
+    assert client.get("/api/entitlement/required-tier-batch").status_code == 400
+    assert (
+        client.get("/api/entitlement/required-tier-batch?features=").status_code == 400
+    )
+    assert (
+        client.get(
+            "/api/entitlement/required-tier-batch?features=&runtimes="
+        ).status_code
+        == 400
+    )
+
+
+def test_batch_swallows_resolver_failure(monkeypatch, client, ent):
+    """A flaky entitlement resolver must never 5xx the batch paywall endpoint."""
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get(
+        "/api/entitlement/required-tier-batch?features=otel_export"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["allowed"] is True
+    assert body["current_tier"] == "oss"
+    assert body["upgrade_required"] is False


### PR DESCRIPTION
## What

Adds the plural sibling of `min_tier_for_feature` / `min_tier_for_runtime` so a dashboard surface that mixes axes ("you are using fleet + otel_export + sso + claude_code -- Available in Enterprise") can resolve the most-constraining upgrade target in one helper call instead of N per-item lookups + max-by-rank on the client.

### Python helpers (`clawmetry/entitlements.py`)
- `min_tier_for_features(iterable) -> str | None` -- cheapest *purchasable* tier admitting **all** features. Empty/None → `None`. All-unknown → `None`. All-free → `TIER_OSS`. Mixed → highest-rank `min_tier_for_feature` across the set. Unknown items are *skipped* (a typo never silently mis-routes to Enterprise). Non-iterable input → `None`. Never raises.
- `min_tier_for_runtimes(iterable) -> str | None` -- identical contract for runtimes. Today every paid runtime unlocks at Starter so batching is degenerate, but the helper exists for API symmetry with `min_tier_for_features` and to stay correct if the paid-runtime tier mapping ever becomes per-runtime.

### HTTP endpoint (`routes/entitlement.py`)
`GET /api/entitlement/required-tier-batch?features=a,b,c&runtimes=x,y` -- sibling of `/api/entitlement/required-tier`. At least one of the two axes must be supplied. CSV tokens are normalised (whitespace stripped, blanks dropped, duplicates collapsed, lowercased). Returns the union answer:

```json
{
  "features": ["fleet", "otel_export"],
  "runtimes": ["claude_code"],
  "required_tier": "cloud_pro",
  "required_tier_label": "Pro",
  "required_tier_rank": 2,
  "current_tier": "oss",
  "current_tier_rank": 0,
  "upgrade_required": true,
  "allowed": true
}
```

`allowed` folds `ent.allows_feature(f)` over the features and `ent.allows_runtime(r)` over the runtimes -- batch grace-mode answer in one call.

## Why

The capacity-axis story already has singular `min_tier_for_feature` / `min_tier_for_runtime` / `min_tier_for_channel_count` / `min_tier_for_retention_window` / `min_tier_for_node_count` helpers, but a dashboard surface that needs to resolve "what tier covers everything on this page?" currently has to issue N calls and `max(... key=tier_rank)` on the client. The plural helpers close that gap. Same pattern as `capacity_diff(target)` (#3225) and `preview(tier)` (#3221) -- one helper that consolidates a multi-step reverse lookup into the canonical resolver layer.

## Not changing

- Singular `/api/entitlement/required-tier` is untouched (existing tests still green).
- Every other entitlement endpoint is untouched.
- No `__version__` bump, no `[RELEASE]` PR, no enforce-flip -- stays in GRACE.

## Tests

`tests/test_entitlements_min_tier_batch.py` (25 tests, all green): 16 Python-helper cases (empty / None / unknown / all-free / mixed / case-insensitive / trial-excluded / non-iterable) + 9 endpoint cases (features-only / runtimes-only / mix / all-free / CSV normalisation / unknown-skipped / all-unknown → `null` tier / missing-axes → 400 / resolver-failure → graceful fallback).

Full entitlement-related test pack (595 tests across 30 files including `test_entitlements_min_tier.py`, `test_entitlement_api.py`, `test_entitlement_capacity_diff.py`, `test_entitlement_preview.py`, `test_entitlement_required_tier_capacity.py`, `test_entitlement_lock_reason_capacity.py`, …) -- all green. `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlements_min_tier_batch.py` clean.

## Local operator verification checklist

Since the autonomous fire has no access to the local daemon, the live cloud snapshot, or a browser, the local operator needs to verify these steps before flipping to ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlements_min_tier_batch.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and matching paths for routes/ and tests/), clear `__pycache__/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/required-tier-batch?features=fleet,otel_export,sso&runtimes=claude_code' | jq` -- expect `required_tier: "enterprise"`, `required_tier_rank: 3`, `upgrade_required: true`, `allowed: true` (grace mode).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/required-tier-batch?features=sessions,usage' | jq` -- expect `required_tier: "oss"`, `upgrade_required: false`.
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/api/entitlement/required-tier-batch` -- expect `400` (at least one axis required).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/required-tier-batch?features=otel_export,,otel_export,%20fleet%20' | jq .features` -- expect `["otel_export", "fleet"]` (CSV normalisation).
- [ ] Decrypt the live cloud snapshot and confirm the dashboard still loads (the batch endpoint is additive; the existing entitlement payload is unchanged).
- [ ] Browser-check: no regression on the upgrade-CTA card -- it still reads off `next_tier_diff` from `/api/entitlement`; the new endpoint is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgzUGuCrxPxjN6GaGxQwai

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgzUGuCrxPxjN6GaGxQwai)_