### PR TITLE
feat(entitlements): tier_unlocks(tier) — per-tier marginal unlocks ("what's new at X vs the tier below")

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1142,6 +1142,71 @@ def preview(target_tier: str) -> dict | None:
         return None
 
 
+def tier_unlocks(target_tier: str) -> dict | None:
+    """Per-tier marginal unlocks: features + runtimes that first become
+    available *at* ``target_tier`` -- the set difference between this
+    tier's grant and the next-lower purchasable tier's grant.
+
+    Companion to :func:`preview` (cumulative state at a tier): where
+    ``preview`` answers "what would the resulting Entitlement *look like*",
+    ``tier_unlocks`` answers "what does this tier *first* unlock vs the
+    tier below it" -- the "what's new in Pro vs Starter" view a
+    pricing-page row or upgrade-CTA card uses.
+
+    The "tier below" is the highest-rank entry in :data:`_PURCHASABLE_TIERS`
+    whose rank is strictly less than ``target_tier``'s rank (trial is
+    excluded from purchasables, so a promotional grant never shows up as
+    the upgrade source). When ``target_tier`` sits at the floor (rank 0 --
+    :data:`TIER_OSS` / :data:`TIER_CLOUD_FREE`) ``previous_tier`` is
+    ``None`` and the marginal collapses to the full free grant
+    (``FREE_FEATURES`` / ``FREE_RUNTIMES``).
+
+    Returns ``None`` for an unknown tier id (including :data:`TIER_TRIAL`,
+    which is not purchasable) and never raises.
+    """
+    try:
+        tid = (target_tier or "").strip().lower()
+        if tid not in _PURCHASABLE_TIERS:
+            return None
+        target_rank = _TIER_RANK.get(tid, -1)
+        prev_id: str | None = None
+        prev_rank = -1
+        for cand in _PURCHASABLE_TIERS:
+            cand_rank = _TIER_RANK.get(cand, -1)
+            if 0 <= cand_rank < target_rank and cand_rank > prev_rank:
+                prev_id = cand
+                prev_rank = cand_rank
+        this_feats = FREE_FEATURES | _TIER_FEATURES.get(tid, frozenset())
+        this_runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if tid in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        if prev_id is None:
+            prev_feats: frozenset = frozenset()
+            prev_runtimes: frozenset = frozenset()
+        else:
+            prev_feats = FREE_FEATURES | _TIER_FEATURES.get(prev_id, frozenset())
+            prev_runtimes = (
+                FREE_RUNTIMES | PAID_RUNTIMES
+                if prev_id in _TIER_PAID_RUNTIMES
+                else FREE_RUNTIMES
+            )
+        return {
+            "tier": tid,
+            "tier_label": tier_label(tid),
+            "tier_rank": tier_rank(tid),
+            "previous_tier": prev_id,
+            "previous_tier_label": tier_label(prev_id) if prev_id else None,
+            "previous_tier_rank": tier_rank(prev_id) if prev_id else None,
+            "features": sorted(this_feats - prev_feats),
+            "runtimes": sorted(this_runtimes - prev_runtimes),
+        }
+    except Exception as exc:
+        logger.warning("entitlements: tier_unlocks failed: %s", exc)
+        return None
+
+
 def resolution_diagnostic() -> dict:
     out: dict = {
         "license_path": _LICENSE_PATH,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -208,6 +208,28 @@ def api_entitlement_preview():
         return jsonify({"error": "preview failed", "tier": target}), 500
 
 
+@bp_entitlement.route("/api/entitlement/tier-unlocks")
+def api_entitlement_tier_unlocks():
+    """``GET /api/entitlement/tier-unlocks?tier=<id>`` -- marginal unlocks
+    for ``tier`` (features + runtimes that first become available at that
+    tier vs the next-lower purchasable tier). Sibling of ``/preview``
+    (cumulative shape). ``404`` when the tier id is unknown (including
+    ``trial`` -- not purchasable)."""
+    target = (request.args.get("tier") or "").strip().lower()
+    if not target:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tier_unlocks(target)
+        if body is None:
+            return jsonify({"error": "unknown tier", "tier": target}), 404
+        return jsonify(body)
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_unlocks: error: %s", exc)
+        return jsonify({"error": "tier-unlocks failed", "tier": target}), 500
+
+
 _CAPACITY_PARAMS = ("channels", "retention_days", "nodes")
 
 

--- a/tests/test_entitlement_tier_unlocks.py
+++ b/tests/test_entitlement_tier_unlocks.py
@@ -1,0 +1,255 @@
+"""Tests for ``clawmetry.entitlements.tier_unlocks`` +
+``GET /api/entitlement/tier-unlocks``.
+
+Where :func:`preview` answers "what would the resulting Entitlement *look
+like*" at a target tier (cumulative grant), :func:`tier_unlocks` answers
+"what does this tier *first* unlock vs the tier below it" (marginal
+grant) -- the "what's new in Pro vs Starter" view a pricing-page row or
+upgrade-CTA card uses. These tests pin the marginal sets per tier so a
+future reshuffle of ``_TIER_FEATURES`` / ``_TIER_PAID_RUNTIMES`` /
+``_PURCHASABLE_TIERS`` / ``_TIER_RANK`` breaks loudly here instead of
+silently in the upgrade-CTA copy.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────
+
+
+def test_returns_full_shape(ent):
+    body = ent.tier_unlocks(ent.TIER_CLOUD_PRO)
+    assert set(body.keys()) == {
+        "tier",
+        "tier_label",
+        "tier_rank",
+        "previous_tier",
+        "previous_tier_label",
+        "previous_tier_rank",
+        "features",
+        "runtimes",
+    }
+
+
+def test_tier_metadata_matches_target(ent):
+    body = ent.tier_unlocks(ent.TIER_CLOUD_PRO)
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+
+
+def test_lists_are_sorted(ent):
+    body = ent.tier_unlocks(ent.TIER_CLOUD_STARTER)
+    assert body["features"] == sorted(body["features"])
+    assert body["runtimes"] == sorted(body["runtimes"])
+
+
+# ── per-tier marginals ────────────────────────────────────────────────────
+
+
+def test_oss_has_no_previous_tier(ent):
+    # OSS sits at rank 0 -- no purchasable tier is "below" it, so the
+    # marginal collapses to the full free grant.
+    body = ent.tier_unlocks(ent.TIER_OSS)
+    assert body["previous_tier"] is None
+    assert body["previous_tier_label"] is None
+    assert body["previous_tier_rank"] is None
+    assert set(body["features"]) == set(ent.FREE_FEATURES)
+    assert set(body["runtimes"]) == set(ent.FREE_RUNTIMES)
+
+
+def test_cloud_free_floor_collapses_to_free_grant(ent):
+    # Cloud Free is also rank 0 -- same floor as OSS, so previous=None and
+    # the marginal is the full free grant. This is the trip-wire if the
+    # rank table ever drifts.
+    body = ent.tier_unlocks(ent.TIER_CLOUD_FREE)
+    assert body["previous_tier"] is None
+    assert set(body["features"]) == set(ent.FREE_FEATURES)
+    assert set(body["runtimes"]) == set(ent.FREE_RUNTIMES)
+
+
+def test_starter_unlocks_paid_runtimes_and_starter_features(ent):
+    body = ent.tier_unlocks(ent.TIER_CLOUD_STARTER)
+    # Previous purchasable below Starter (rank 1) is OSS (rank 0).
+    assert body["previous_tier"] == ent.TIER_OSS
+    assert set(body["features"]) == set(ent.STARTER_FEATURES)
+    # Every paid runtime first becomes available at Starter.
+    assert set(body["runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_pro_unlocks_pro_only_features_no_new_runtimes(ent):
+    body = ent.tier_unlocks(ent.TIER_CLOUD_PRO)
+    # Previous purchasable below Pro (rank 2) is Starter (rank 1).
+    assert body["previous_tier"] == ent.TIER_CLOUD_STARTER
+    assert set(body["features"]) == set(ent.PRO_ONLY_FEATURES)
+    # All paid runtimes already unlocked at Starter -- no marginal here.
+    assert body["runtimes"] == []
+
+
+def test_self_hosted_pro_mirrors_cloud_pro(ent):
+    # TIER_PRO and TIER_CLOUD_PRO share rank 2 and grant set -- same
+    # marginal vs the tier below.
+    body = ent.tier_unlocks(ent.TIER_PRO)
+    assert body["previous_tier"] == ent.TIER_CLOUD_STARTER
+    assert set(body["features"]) == set(ent.PRO_ONLY_FEATURES)
+    assert body["runtimes"] == []
+
+
+def test_enterprise_unlocks_enterprise_features(ent):
+    body = ent.tier_unlocks(ent.TIER_ENTERPRISE)
+    # Previous purchasable below Enterprise (rank 3) is Cloud Pro (rank 2)
+    # -- the first rank-2 entry in _PURCHASABLE_TIERS.
+    assert body["previous_tier"] == ent.TIER_CLOUD_PRO
+    assert set(body["features"]) == set(ent.ENTERPRISE_FEATURES)
+    assert body["runtimes"] == []
+
+
+# ── trial / unknown / safety ──────────────────────────────────────────────
+
+
+def test_trial_returns_none(ent):
+    # Trial is a promotional grant, not a purchasable plan -- callers must
+    # not route an upgrade-CTA to it. Mirrors preview()'s posture (which
+    # also rejects non-purchasable tiers).
+    assert ent.tier_unlocks(ent.TIER_TRIAL) is None
+
+
+def test_unknown_tier_returns_none(ent):
+    assert ent.tier_unlocks("nonsense_tier_xyz") is None
+
+
+def test_empty_returns_none(ent):
+    assert ent.tier_unlocks("") is None
+    assert ent.tier_unlocks(None) is None  # type: ignore[arg-type]
+
+
+def test_lowercases_input(ent):
+    body = ent.tier_unlocks("CLOUD_PRO")
+    assert body is not None
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_label", boom)
+    assert ent.tier_unlocks(ent.TIER_CLOUD_PRO) is None
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    live_before = ent.get_entitlement().to_dict()
+    ent.tier_unlocks(ent.TIER_ENTERPRISE)
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# ── round-trip vs catalogue ───────────────────────────────────────────────
+
+
+def test_marginals_union_covers_paid_features(ent):
+    # Every paid + enterprise feature must first-unlock at exactly one
+    # purchasable tier so the pricing page can list them with no gaps.
+    seen: set = set()
+    for tier_id in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        seen |= set(ent.tier_unlocks(tier_id)["features"])
+    assert seen == set(ent.PAID_FEATURES) | set(ent.ENTERPRISE_FEATURES)
+
+
+def test_marginals_union_covers_paid_runtimes(ent):
+    # Every paid runtime must first-unlock at exactly one purchasable
+    # tier (Starter, today) -- same no-gap invariant.
+    seen: set = set()
+    for tier_id in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        seen |= set(ent.tier_unlocks(tier_id)["runtimes"])
+    assert seen == set(ent.PAID_RUNTIMES)
+
+
+def test_marginal_features_disjoint_across_tiers(ent):
+    # A feature must first-unlock at exactly *one* tier -- if it shows up
+    # in two marginal sets the pricing page double-lists it.
+    starter = set(ent.tier_unlocks(ent.TIER_CLOUD_STARTER)["features"])
+    pro = set(ent.tier_unlocks(ent.TIER_CLOUD_PRO)["features"])
+    enterprise = set(ent.tier_unlocks(ent.TIER_ENTERPRISE)["features"])
+    assert starter.isdisjoint(pro)
+    assert starter.isdisjoint(enterprise)
+    assert pro.isdisjoint(enterprise)
+
+
+# ── API surface ───────────────────────────────────────────────────────────
+
+
+def test_api_returns_marginal_for_pro(client, ent):
+    rv = client.get(f"/api/entitlement/tier-unlocks?tier={ent.TIER_CLOUD_PRO}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["previous_tier"] == ent.TIER_CLOUD_STARTER
+    assert set(body["features"]) == set(ent.PRO_ONLY_FEATURES)
+    assert body["runtimes"] == []
+
+
+def test_api_returns_marginal_for_starter(client, ent):
+    rv = client.get(f"/api/entitlement/tier-unlocks?tier={ent.TIER_CLOUD_STARTER}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["previous_tier"] == ent.TIER_OSS
+    assert set(body["runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_api_missing_tier_is_400(client):
+    rv = client.get("/api/entitlement/tier-unlocks")
+    assert rv.status_code == 400
+    assert "error" in rv.get_json()
+
+
+def test_api_unknown_tier_is_404(client):
+    rv = client.get("/api/entitlement/tier-unlocks?tier=nonsense_tier_xyz")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["tier"] == "nonsense_tier_xyz"
+
+
+def test_api_trial_is_404(client, ent):
+    # Trial is not purchasable -- the upgrade-CTA must never route to it.
+    rv = client.get(f"/api/entitlement/tier-unlocks?tier={ent.TIER_TRIAL}")
+    assert rv.status_code == 404
+
+
+def test_api_lowercases_query(client, ent):
+    rv = client.get("/api/entitlement/tier-unlocks?tier=CLOUD_STARTER")
+    assert rv.status_code == 200
+    assert rv.get_json()["tier"] == ent.TIER_CLOUD_STARTER


### PR DESCRIPTION
## What

Adds the marginal sibling of `preview(tier)`: where `preview()` answers _"what would the resulting Entitlement **look like** at tier X"_ (cumulative grant), `tier_unlocks()` answers _"what does tier X **first** unlock vs the tier below it"_ (marginal grant) — the **"what's new in Pro vs Starter"** view a pricing-page row or upgrade-CTA card uses.

### Python helper (`clawmetry/entitlements.py`)
- `tier_unlocks(target_tier) -> dict | None`. Returns:
  ```json
  {
    "tier": "cloud_pro",
    "tier_label": "Pro",
    "tier_rank": 2,
    "previous_tier": "cloud_starter",
    "previous_tier_label": "Starter",
    "previous_tier_rank": 1,
    "features": ["alert_webhooks", "anomaly_detection", "asset_registry", "cost_optimizer", "custom_alerts", "custom_runtime_ingest", "custom_webhooks", "error_triage", "eval_suite", "otel_export", "per_run_compare", "per_run_waste_flags", "self_evolve", "tool_policy"],
    "runtimes": []
  }
  ```
- `features` / `runtimes` are the **set difference** between this tier's grant and the next-lower *purchasable* tier's grant. Trial is excluded from purchasables — a promotional grant never shows up as the upgrade source. Floor tiers (OSS / Cloud Free at rank 0) collapse to `previous_tier = null` and the marginal reports the **full free grant**.
- Unknown / non-purchasable / empty / None → `None`. Never raises.

### HTTP endpoint (`routes/entitlement.py`)
`GET /api/entitlement/tier-unlocks?tier=<id>` — sibling of `/api/entitlement/preview`. `400` on missing tier, `404` on unknown tier (including `trial` — not purchasable), `500` on resolver failure with a logged warning.

## Why

`preview(target)` already renders the **cumulative** denormalised shape at a tier ("at Pro you'd have 90-day retention, unlimited channels, all paid features, …"). The CTA card uses that to show concrete numbers. But the pricing-page / "What's new at this tier" copy wants the **marginal** view — "Upgrade to Pro to unlock: per_run_waste_flags, otel_export, custom_alerts, …" — and that's been left for the client to derive by diffing `_TIER_FEATURES` itself. `tier_unlocks` closes that gap as a single canonical resolver call, same pattern as the other reverse-lookup helpers in the module.

Today's marginal sets, pinned by tests:

| Tier (`previous_tier`) | `features` (new at this tier) | `runtimes` (new at this tier) |
|---|---|---|
| `oss` / `cloud_free` (`null`) | `FREE_FEATURES` | `FREE_RUNTIMES` |
| `cloud_starter` (← `oss`) | `STARTER_FEATURES` | every `PAID_RUNTIMES` |
| `cloud_pro` / `pro` (← `cloud_starter`) | `PRO_ONLY_FEATURES` | `[]` (already unlocked at Starter) |
| `enterprise` (← `cloud_pro`) | `ENTERPRISE_FEATURES` | `[]` |

## Not changing

- `preview(tier)` and `/api/entitlement/preview` are untouched (existing tests still green).
- `tier_catalog()` is untouched — adding a marginal `unlocks` field per row is intentionally deferred to a follow-up PR; this PR is just the helper + endpoint.
- Every other entitlement endpoint is untouched.
- No `__version__` bump, no `[RELEASE]` PR, no enforce-flip — stays in GRACE.

## Tests

`tests/test_entitlement_tier_unlocks.py` (24 tests, all green):
- shape pins (full keyset, sorted lists, tier metadata matches target)
- per-tier marginals (oss / cloud_free floor collapses; starter → paid runtimes + `STARTER_FEATURES`; cloud_pro / pro → `PRO_ONLY_FEATURES`, no new runtimes; enterprise → `ENTERPRISE_FEATURES`)
- safety (trial → None, unknown → None, empty/None → None, lowercases input, never raises, doesn't mutate live entitlement)
- catalogue round-trip (union of marginals across purchasable tiers equals `PAID_FEATURES | ENTERPRISE_FEATURES` and `PAID_RUNTIMES` respectively; marginal feature sets are disjoint across tiers — no double-listing on the pricing page)
- API surface (200 for pro/starter, 400 missing, 404 unknown, 404 trial, case-insensitive query)

Broader regression: 273 tests across `test_entitlement_preview.py`, `test_entitlements_catalogue.py`, `test_entitlements.py`, `test_entitlement_api.py`, `test_entitlement_upgrade_diff.py`, `test_entitlement_capacity_diff.py`, `test_entitlement_next_tier.py`, `test_entitlement_prev_tier.py`, `test_entitlement_tier_diff.py`, `test_entitlement_tier_unlocks.py` — all green.

`ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_unlocks.py` clean.

## Local operator verification checklist

Since the autonomous fire has no access to the local daemon, the live cloud snapshot, or a browser, the local operator needs to verify these steps before flipping to ready-for-review:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_tier_unlocks.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and matching paths for `routes/` and `tests/`), clear `__pycache__/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tier-unlocks?tier=cloud_pro' | jq` — expect `previous_tier: "cloud_starter"`, `features` listing the 14 PRO_ONLY features, `runtimes: []`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tier-unlocks?tier=cloud_starter' | jq` — expect `previous_tier: "oss"`, every paid runtime in `runtimes`, `features` listing the 7 STARTER_FEATURES.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tier-unlocks?tier=enterprise' | jq` — expect `previous_tier: "cloud_pro"`, `features` listing the 6 ENTERPRISE_FEATURES, `runtimes: []`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/tier-unlocks?tier=oss' | jq .previous_tier` — expect `null` and `features` listing the free baseline.
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8900/api/entitlement/tier-unlocks` — expect `400`.
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tier-unlocks?tier=trial'` — expect `404` (trial is not purchasable).
- [ ] `curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:8900/api/entitlement/tier-unlocks?tier=nonsense_xyz'` — expect `404`.
- [ ] Decrypt the live cloud snapshot and confirm the dashboard still loads (the new endpoint is additive; the existing entitlement payload is unchanged).
- [ ] Browser-check: no regression on the upgrade-CTA card — it still reads off `next_tier_diff` from `/api/entitlement`; the new endpoint is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BdYJJPLYeF2BTvkevENh18)_