### PR TITLE
feat(entitlements): min_tier_for_all + extend /required-tier-batch to capacity axes

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1547,6 +1547,73 @@ def min_tier_for_runtimes(runtimes) -> str | None:
     return max(tiers, key=tier_rank)
 
 
+def min_tier_for_all(
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> str | None:
+    """Cheapest *purchasable* tier admitting **all** supplied constraints at
+    once across every capacity axis.
+
+    Aggregate sibling of :func:`min_tier_for_features` /
+    :func:`min_tier_for_runtimes` / :func:`min_tier_for_channel_count` /
+    :func:`min_tier_for_retention_window` / :func:`min_tier_for_node_count`.
+    A dashboard surface that mixes axes ("fleet + claude_code + 5 channels +
+    30-day retention + 2 nodes -- what tier covers everything?") gets a
+    single tier id back instead of N round-trips + max-by-rank on the client.
+
+    The capacity axes use ``None`` as the "axis not supplied" sentinel so a
+    caller can omit any subset and the helper just skips them. Critically,
+    ``retention_days=None`` here means *unset*, NOT *unlimited* -- asking
+    for the unlimited-retention tier is the singular
+    :func:`min_tier_for_retention_window` (``days=None``) call's job and
+    would mis-route the aggregate to Enterprise.
+
+    Semantics mirror the plural helpers exactly:
+
+    * No constraints supplied -- returns ``None`` (matches the "nothing
+      asked" posture of the plural helpers).
+    * Any axis collapses to ``None`` (empty iterable / non-int / all-
+      unknown items) -- that axis contributes nothing, the result is
+      resolved off the remaining axes.
+    * All axes collapse to ``None`` -- returns ``None``.
+    * Otherwise -- the highest-rank tier across the per-axis answers (the
+      most-constraining axis wins).
+    * Never raises.
+    """
+    try:
+        tiers: list[str] = []
+        if features is not None:
+            t = min_tier_for_features(features)
+            if t is not None:
+                tiers.append(t)
+        if runtimes is not None:
+            t = min_tier_for_runtimes(runtimes)
+            if t is not None:
+                tiers.append(t)
+        if channels is not None:
+            t = min_tier_for_channel_count(channels)
+            if t is not None:
+                tiers.append(t)
+        if retention_days is not None:
+            t = min_tier_for_retention_window(retention_days)
+            if t is not None:
+                tiers.append(t)
+        if nodes is not None:
+            t = min_tier_for_node_count(nodes)
+            if t is not None:
+                tiers.append(t)
+        if not tiers:
+            return None
+        return max(tiers, key=tier_rank)
+    except Exception as exc:
+        logger.warning("entitlements: min_tier_for_all failed: %s", exc)
+        return None
+
+
 def lock_reason(item: str, *, kind: str | None = None) -> str | None:
     try:
         return get_entitlement().lock_reason(item, kind=kind)

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -608,22 +608,26 @@ def _parse_csv_arg(name: str) -> list[str]:
 
 @bp_entitlement.route("/api/entitlement/required-tier-batch")
 def api_entitlement_required_tier_batch():
-    """``GET /api/entitlement/required-tier-batch?features=a,b,c&runtimes=x,y``
-    -- plural sibling of ``/api/entitlement/required-tier``.
+    """``GET /api/entitlement/required-tier-batch?features=a,b,c&runtimes=x,y
+    &channels=N&retention_days=K&nodes=M`` -- aggregate sibling of
+    ``/api/entitlement/required-tier``.
 
     Returns the cheapest *purchasable* tier admitting **all** supplied
-    features and runtimes at once: the most-constraining item across the
-    two sets wins. Wraps :func:`min_tier_for_features` /
-    :func:`min_tier_for_runtimes` so a dashboard surface that mixes axes
-    ("you are using fleet + otel_export + sso + claude_code -- Available
-    in Enterprise") gets the answer in one round-trip instead of N calls
-    + max-by-rank on the client.
+    constraints across every capacity axis at once: the most-constraining
+    item across all five wins. Wraps :func:`min_tier_for_all` so a
+    dashboard surface that mixes axes ("you are using fleet + claude_code
+    + 5 channels + 30-day retention + 2 nodes -- Available in Pro") gets
+    the answer in one round-trip instead of five calls + max-by-rank on
+    the client.
 
-    At least one of ``features=`` / ``runtimes=`` must be supplied
-    (non-empty after CSV parsing). Comma-separated tokens; whitespace and
-    duplicates are normalised away; unknown ids contribute nothing (so a
-    typo does not silently mis-route to Enterprise, matching the singular
-    helpers' posture). Never 5xxs: the OSS-free shape is returned on any
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied (non-empty / parseable
+    after normalisation). ``features=`` / ``runtimes=`` take comma-separated
+    tokens (whitespace and duplicates are normalised away; unknown ids
+    contribute nothing). The three capacity axes take a single int each;
+    a blank or non-int value is treated as "not supplied" (matches the
+    singular endpoint's never-crash posture rather than mis-routing a typo
+    to Enterprise). Never 5xxs: the OSS-free shape is returned on any
     resolver failure.
     """
     try:
@@ -631,13 +635,26 @@ def api_entitlement_required_tier_batch():
 
         features = _parse_csv_arg("features")
         runtimes = _parse_csv_arg("runtimes")
-        if not features and not runtimes:
+        (_, channels_ok, channels_n, channels_raw) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, retention_raw) = _parse_capacity_arg(
+            "retention_days",
+        )
+        (_, nodes_ok, nodes_n, nodes_raw) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
             return (
                 jsonify(
                     {
                         "error": (
-                            "supply at least one of features=<csv> or "
-                            "runtimes=<csv>"
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
                         )
                     }
                 ),
@@ -645,10 +662,13 @@ def api_entitlement_required_tier_batch():
             )
 
         ent = _ent.get_entitlement()
-        feat_tier = _ent.min_tier_for_features(features) if features else None
-        runtime_tier = _ent.min_tier_for_runtimes(runtimes) if runtimes else None
-        candidates = [t for t in (feat_tier, runtime_tier) if t is not None]
-        required = max(candidates, key=_ent.tier_rank) if candidates else None
+        required = _ent.min_tier_for_all(
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
 
         cur_rank = _ent.tier_rank(ent.tier)
         req_rank = _ent.tier_rank(required) if required else -1
@@ -656,12 +676,28 @@ def api_entitlement_required_tier_batch():
 
         feat_allowed = all(ent.allows_feature(f) for f in features)
         runtime_allowed = all(ent.allows_runtime(r) for r in runtimes)
-        allowed = feat_allowed and runtime_allowed
+        channels_allowed = (
+            ent.allows_channel_count(channels_n) if channels_ok else True
+        )
+        retention_allowed = (
+            ent.allows_retention_window(retention_n) if retention_ok else True
+        )
+        nodes_allowed = ent.allows_node_count(nodes_n) if nodes_ok else True
+        allowed = (
+            feat_allowed
+            and runtime_allowed
+            and channels_allowed
+            and retention_allowed
+            and nodes_allowed
+        )
 
         return jsonify(
             {
                 "features": features,
                 "runtimes": runtimes,
+                "channels": channels_n if channels_ok else None,
+                "retention_days": retention_n if retention_ok else None,
+                "nodes": nodes_n if nodes_ok else None,
                 "required_tier": required,
                 "required_tier_label": required_label,
                 "required_tier_rank": req_rank,
@@ -673,10 +709,16 @@ def api_entitlement_required_tier_batch():
         )
     except Exception as exc:
         logger.warning("api_entitlement_required_tier_batch: error: %s", exc)
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
         return jsonify(
             {
                 "features": _parse_csv_arg("features"),
                 "runtimes": _parse_csv_arg("runtimes"),
+                "channels": channels_n if channels_ok else None,
+                "retention_days": retention_n if retention_ok else None,
+                "nodes": nodes_n if nodes_ok else None,
                 "required_tier": None,
                 "required_tier_label": None,
                 "required_tier_rank": -1,

--- a/tests/test_entitlements_min_tier_batch.py
+++ b/tests/test_entitlements_min_tier_batch.py
@@ -247,3 +247,171 @@ def test_batch_swallows_resolver_failure(monkeypatch, client, ent):
     assert body["allowed"] is True
     assert body["current_tier"] == "oss"
     assert body["upgrade_required"] is False
+
+
+# ── min_tier_for_all (aggregate across all 5 axes) ────────────────────────
+
+
+def test_all_no_constraints_returns_none(ent):
+    assert ent.min_tier_for_all() is None
+
+
+def test_all_features_only_matches_plural(ent):
+    """Single-axis use of the aggregate must agree with the plural helper."""
+    assert ent.min_tier_for_all(features=["fleet", "otel_export"]) == (
+        ent.min_tier_for_features(["fleet", "otel_export"])
+    )
+    assert ent.min_tier_for_all(features=["sso"]) == ent.TIER_ENTERPRISE
+
+
+def test_all_runtimes_only_matches_plural(ent):
+    assert ent.min_tier_for_all(runtimes=["claude_code"]) == (
+        ent.min_tier_for_runtimes(["claude_code"])
+    )
+
+
+def test_all_capacity_axes_singularly(ent):
+    """Each capacity axis must resolve identically when passed via the
+    aggregate vs the underlying singular helper."""
+    assert ent.min_tier_for_all(channels=5) == ent.min_tier_for_channel_count(5)
+    assert ent.min_tier_for_all(retention_days=30) == (
+        ent.min_tier_for_retention_window(30)
+    )
+    assert ent.min_tier_for_all(nodes=2) == ent.min_tier_for_node_count(2)
+
+
+def test_all_mixes_features_and_capacity(ent):
+    """The aggregate must take the max across feature *and* capacity axes,
+    not just one. ``fleet`` is Starter; 30-day retention is also Starter;
+    the answer is Starter, not Pro."""
+    assert ent.min_tier_for_all(features=["fleet"], retention_days=30) == (
+        ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_all_most_constraining_axis_wins(ent):
+    """``otel_export`` is Pro; 5 channels is Starter; ``sso`` is Enterprise.
+    The aggregate must pick Enterprise (the highest-rank constraint)."""
+    assert (
+        ent.min_tier_for_all(
+            features=["otel_export", "sso"],
+            runtimes=["claude_code"],
+            channels=5,
+        )
+        == ent.TIER_ENTERPRISE
+    )
+
+
+def test_all_skips_axes_set_to_none(ent):
+    """A capacity axis left at the default ``None`` must contribute
+    nothing (NOT be interpreted as "unlimited retention" -> Enterprise).
+    Same posture as the per-axis singular helpers being un-called."""
+    assert ent.min_tier_for_all(features=["fleet"], retention_days=None) == (
+        ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_all_unknown_features_dont_misroute(ent):
+    """A typo in features must not silently push the aggregate to a higher
+    tier -- unknown ids contribute nothing."""
+    assert ent.min_tier_for_all(features=["fleet", "not_a_real_feature"]) == (
+        ent.TIER_CLOUD_STARTER
+    )
+
+
+def test_all_all_axes_collapse_to_none(ent):
+    """Every axis going None (empty / unknown / non-int) collapses the
+    aggregate to ``None`` -- never a 500."""
+    assert ent.min_tier_for_all(
+        features=[],
+        runtimes=[],
+        channels="not-a-number",  # type: ignore[arg-type]
+    ) is None
+
+
+# ── /api/entitlement/required-tier-batch -- capacity axes ─────────────────
+
+
+def test_batch_channels_only(client, ent):
+    """Channels axis alone must resolve like the singular endpoint."""
+    d = client.get(
+        "/api/entitlement/required-tier-batch?channels=5"
+    ).get_json()
+    assert d["channels"] == 5
+    assert d["features"] == []
+    assert d["runtimes"] == []
+    assert d["required_tier"] == ent.min_tier_for_channel_count(5)
+    assert d["upgrade_required"] is True
+    assert d["allowed"] is True  # grace mode
+
+
+def test_batch_retention_only(client, ent):
+    d = client.get(
+        "/api/entitlement/required-tier-batch?retention_days=30"
+    ).get_json()
+    assert d["retention_days"] == 30
+    assert d["required_tier"] == ent.min_tier_for_retention_window(30)
+
+
+def test_batch_nodes_only(client, ent):
+    d = client.get(
+        "/api/entitlement/required-tier-batch?nodes=3"
+    ).get_json()
+    assert d["nodes"] == 3
+    assert d["required_tier"] == ent.min_tier_for_node_count(3)
+
+
+def test_batch_mixes_all_five_axes(client, ent):
+    """The whole point: a dashboard call mixing features + runtimes +
+    capacity must resolve to the most-constraining tier in one round-trip."""
+    d = client.get(
+        "/api/entitlement/required-tier-batch"
+        "?features=fleet&runtimes=claude_code&channels=5&retention_days=30&nodes=2"
+    ).get_json()
+    assert d["features"] == ["fleet"]
+    assert d["runtimes"] == ["claude_code"]
+    assert d["channels"] == 5
+    assert d["retention_days"] == 30
+    assert d["nodes"] == 2
+    assert d["required_tier"] == ent.min_tier_for_all(
+        features=["fleet"],
+        runtimes=["claude_code"],
+        channels=5,
+        retention_days=30,
+        nodes=2,
+    )
+
+
+def test_batch_capacity_alone_satisfies_at_least_one_axis(client):
+    """Supplying only a capacity axis (no features/runtimes) must NOT 400
+    -- the "at least one axis" rule now covers all five."""
+    assert client.get(
+        "/api/entitlement/required-tier-batch?channels=5"
+    ).status_code == 200
+    assert client.get(
+        "/api/entitlement/required-tier-batch?retention_days=30"
+    ).status_code == 200
+    assert client.get(
+        "/api/entitlement/required-tier-batch?nodes=3"
+    ).status_code == 200
+
+
+def test_batch_blank_capacity_treated_as_unsupplied(client):
+    """A blank or non-int capacity value must be treated as "not supplied"
+    (NOT mis-routed to Enterprise via the retention-None=unlimited
+    sentinel). With ALL inputs blank, the endpoint must 400."""
+    rv = client.get(
+        "/api/entitlement/required-tier-batch?channels=&retention_days=&nodes="
+    )
+    assert rv.status_code == 400
+
+
+def test_batch_non_int_capacity_silently_skipped(client, ent):
+    """A non-int capacity is the never-crash path: that axis contributes
+    nothing, the resolution uses the remaining axes."""
+    d = client.get(
+        "/api/entitlement/required-tier-batch?features=fleet&channels=abc"
+    ).get_json()
+    assert d["features"] == ["fleet"]
+    assert d["channels"] is None
+    assert d["required_tier"] == ent.TIER_CLOUD_STARTER


### PR DESCRIPTION
## Summary

Closes a gap in `/api/entitlement/required-tier-batch`: it only accepted `features=<csv>` and `runtimes=<csv>`, even though the singular `/api/entitlement/required-tier` supports all five axes (feature, runtime, channels, retention_days, nodes). A dashboard mixing axes ("you're using fleet + claude_code + 5 channels + 30-day retention + 2 nodes — what tier covers this?") needed N round-trips and a max-by-rank on the client.

### Changes
- **`clawmetry/entitlements.py`** — new module-level helper `min_tier_for_all(*, features, runtimes, channels, retention_days, nodes)`. Folds the five per-axis `min_tier_for_*` helpers + max-by-rank into one canonical reverse lookup. `retention_days=None` means *axis not supplied* (NOT *unlimited* → Enterprise, which would mis-route every call that omits retention). Never raises.
- **`routes/entitlement.py`** — `/api/entitlement/required-tier-batch` now also accepts `channels=<int>`, `retention_days=<int>`, `nodes=<int>`. Blank / non-int values are silently treated as "not supplied" (matches the singular endpoint's never-crash posture rather than mis-routing a typo to Enterprise). The 400 "supply at least one axis" guard now covers all five axes. Existing `features=` / `runtimes=` contract unchanged.
- **`tests/test_entitlements_min_tier_batch.py`** — 17 new tests pinning `min_tier_for_all` semantics (no-args → None, single-axis matches singular helper, most-constraining axis wins, capacity `None` ≠ unlimited, unknown items skipped) + the extended endpoint contract (capacity-only calls satisfy "at least one axis", blank/non-int capacity is silently skipped, mixed five-axis calls resolve in one round-trip).

### Posture
- **Grace by default.** No `Entitlement` defaults change; resolved entitlement is still `grace=True`, all `allows_*` checks still return `True`. This PR only adds *introspection* surface; no enforcement gate flips. Safe to ship.
- **Backward-compatible response shape.** The existing keys (`features`, `runtimes`, `required_tier`, `required_tier_rank`, `current_tier`, `current_tier_rank`, `upgrade_required`, `allowed`) keep their meaning; three new keys (`channels`, `retention_days`, `nodes`) are added alongside.

### Test plan

- [x] `python -m py_compile` clean on changed files
- [x] `pytest tests/test_entitlements_min_tier_batch.py` — 41 passed (24 pre-existing + 17 new)
- [x] `pytest tests/test_entitlement*.py tests/test_entitlements*.py` — 641 passed
- [ ] CI green on this PR
- [ ] Local operator verification (see below)

### Local operator verification checklist
This runs in a remote sandbox with no access to the user's machine, the live daemon, `~/.openclaw`, or the cloud snapshot. Verifying *live* requires the local box:

1. Pull the branch locally: `git fetch origin feat/entitlement-min-tier-for-all && git checkout feat/entitlement-min-tier-for-all`.
2. Copy changed files into the installed package:
   ```
   cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/
   cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/
   ```
3. Clear `__pycache__` under both `clawmetry/` and `routes/`.
4. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`.
5. Hit the extended endpoint:
   ```
   curl -s 'http://localhost:8900/api/entitlement/required-tier-batch?features=fleet&runtimes=claude_code&channels=5&retention_days=30&nodes=2' | jq
   ```
   Expect `required_tier: "cloud_starter"` (most-constraining axis), `allowed: true` (grace mode), and the new `channels` / `retention_days` / `nodes` keys echoed back as ints.
6. Confirm the existing two-axis call still works unchanged:
   ```
   curl -s 'http://localhost:8900/api/entitlement/required-tier-batch?features=sso&runtimes=claude_code' | jq
   ```
   Expect `required_tier: "enterprise"` (no behaviour change vs main).
7. Decrypt the live cloud snapshot in the browser and confirm the dashboard renders normally (no regression in grace-mode behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019YZ8CucgyXFfrutrSSWD8Y)_