### PR TITLE
feat(entitlements): feature_catalog() + GET /api/features

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -111,6 +111,57 @@ RUNTIME_LABELS = {
     "nanoclaw": "NanoClaw",
 }
 
+# Display labels for every known feature. Used by :func:`feature_catalog` so
+# the dashboard's Settings / pricing-parity surfaces render human copy off the
+# same source of truth as the gate. Falls back to the id when a key is
+# missing, so adding a feature key without a label here is safe (but please
+# add one — the id reads as snake_case in the UI otherwise).
+FEATURE_LABELS = {
+    # free
+    "sessions": "Sessions",
+    "transcripts": "Transcripts",
+    "usage": "Usage",
+    "brain": "Brain",
+    "flow": "Flow",
+    "tracing": "Tracing",
+    "health": "Health",
+    "logs": "Logs",
+    "crons": "Crons",
+    "channels": "Channels",
+    "nemo_governance": "NeMo governance",
+    "overview": "Overview",
+    # starter
+    "multi_runtime": "Multi-runtime support",
+    "fleet": "Multi-node fleet",
+    "cloud_sync": "Cloud sync",
+    "all_channels": "All channel adapters",
+    "approval_queue": "Approval queue",
+    "budget_limits": "Budget limits",
+    "per_runtime_health_timeline": "Per-runtime health timeline",
+    # pro-only
+    "per_run_waste_flags": "Per-run waste flags",
+    "per_run_compare": "Per-run compare",
+    "error_triage": "Error triage",
+    "self_evolve": "Self-Evolve",
+    "asset_registry": "Asset registry",
+    "eval_suite": "Eval suite",
+    "tool_policy": "Tool policy",
+    "otel_export": "OTel export",
+    "custom_webhooks": "Custom webhooks",
+    "custom_runtime_ingest": "Custom runtime ingest",
+    "custom_alerts": "Custom alerts",
+    "alert_webhooks": "Alert webhooks",
+    "anomaly_detection": "Anomaly detection",
+    "cost_optimizer": "Cost optimizer",
+    # enterprise
+    "siem_export": "SIEM export",
+    "sso": "SSO",
+    "audit_logs": "Audit logs",
+    "rbac": "RBAC",
+    "air_gapped_license": "Air-gapped license",
+    "custom_data_residency": "Custom data residency",
+}
+
 # ── Feature catalogue ───────────────────────────────────────────────────────
 # Core observability — always free. Keys are stable identifiers the route /
 # UI layer checks via Entitlement.allows_feature(...).
@@ -466,4 +517,89 @@ def runtime_catalog() -> list[dict]:
                 "locked": not allowed,
             }
         )
+    return out
+
+
+def feature_label(feature: str) -> str:
+    """Human-readable label for ``feature``. Falls back to the id when unknown
+    so a not-yet-labelled key still renders with *something*."""
+    fid = (feature or "").strip().lower()
+    return FEATURE_LABELS.get(fid, fid)
+
+
+# Per-feature unlock tier — the cheapest tier id where this feature is granted.
+# Walked once in :func:`feature_tier` so the catalog's ``tier`` column reads off
+# the same source of truth as :data:`_TIER_FEATURES`. FREE features collapse to
+# :data:`TIER_OSS`. An unknown id is treated as OSS to stay grace-safe (an
+# unknown feature is never spuriously rendered as a locked Enterprise row).
+_FEATURE_TIER_ORDER = (
+    (TIER_OSS, FREE_FEATURES),
+    (TIER_CLOUD_STARTER, STARTER_FEATURES),
+    (TIER_CLOUD_PRO, PRO_ONLY_FEATURES),
+    (TIER_ENTERPRISE, ENTERPRISE_FEATURES),
+)
+
+
+def feature_tier(feature: str) -> str:
+    """Return the cheapest tier id that grants ``feature``.
+
+    The mapping is:
+        FREE_FEATURES        -> ``TIER_OSS``
+        STARTER_FEATURES     -> ``TIER_CLOUD_STARTER``
+        PRO_ONLY_FEATURES    -> ``TIER_CLOUD_PRO``
+        ENTERPRISE_FEATURES  -> ``TIER_ENTERPRISE``
+        unknown id           -> ``TIER_OSS`` (grace-safe fallback)
+    """
+    fid = (feature or "").strip().lower()
+    for tier, bucket in _FEATURE_TIER_ORDER:
+        if fid in bucket:
+            return tier
+    return TIER_OSS
+
+
+def feature_catalog() -> list[dict]:
+    """The full feature catalog with the entitlement-derived availability for
+    each entry. Mirrors :func:`runtime_catalog` for paid *features*: single
+    source of truth the UI reads to render every known feature row (Settings
+    matrix, pricing-parity grid, upgrade CTA copy) without re-deriving tier
+    buckets in JS.
+
+    Each entry:
+        {
+          "id":      "<feature>",                # canonical key
+          "label":   "<Display Name>",           # falls back to id
+          "tier":    "oss" | "cloud_starter" |   # unlock tier id (see
+                     "cloud_pro" | "enterprise", #  feature_tier())
+          "free":    True | False,               # FREE_FEATURES membership
+          "allowed": True | False,               # entitlement allows it
+          "locked":  True | False,               # paid + not allowed (UI 🔒)
+        }
+
+    Ordering: free first, then starter, then pro-only, then enterprise —
+    alphabetical within each group, so the UI grid is deterministic.
+
+    Never raises; on any resolution error the catalog is built against the
+    OSS-free grace shape so every paid row reports ``locked=False`` and the
+    UI stays renderable.
+    """
+    try:
+        ent = get_entitlement()
+    except Exception as exc:  # never crash a catalog read
+        logger.warning("entitlements: feature_catalog falling back to grace: %s", exc)
+        ent = _oss_free()
+    out: list[dict] = []
+    for tier, bucket in _FEATURE_TIER_ORDER:
+        is_free = tier == TIER_OSS
+        for fid in sorted(bucket):
+            allowed = ent.allows_feature(fid)
+            out.append(
+                {
+                    "id": fid,
+                    "label": feature_label(fid),
+                    "tier": tier,
+                    "free": is_free,
+                    "allowed": allowed,
+                    "locked": (not is_free) and (not allowed),
+                }
+            )
     return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -8,6 +8,7 @@ is the single source of truth — handlers never re-derive tier logic here.
 
   GET /api/entitlement — the current Entitlement as JSON.
   GET /api/runtimes    — the full runtime catalog with locked/free flags.
+  GET /api/features    — the full feature catalog with locked/free/tier flags.
 
 Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
 on the cloud side: when no license/cloud plan is present it returns a graceful
@@ -107,6 +108,71 @@ def api_runtimes():
                         "locked": False,
                     },
                 ],
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/features")
+def api_features():
+    """Return the full feature catalog with per-feature ``free``/``tier``/
+    ``allowed``/``locked`` flags so the dashboard's Settings matrix, the
+    pricing-parity grid, and the upgrade-CTA copy all read off one canonical
+    list instead of re-deriving tier buckets in JS.
+
+    Shape::
+
+        {
+          "features": [
+            {"id": "sessions", "label": "Sessions", "tier": "oss",
+             "free": true, "allowed": true, "locked": false},
+            {"id": "fleet", "label": "Multi-node fleet",
+             "tier": "cloud_starter", "free": false,
+             "allowed": true, "locked": false},
+            ...
+          ],
+          "grace":    true | false,   # mirrors /api/entitlement.grace
+          "enforced": true | false
+        }
+
+    Side-effect-free and never-raise: any resolution error falls back to a
+    grace-mode shape (every feature ``allowed=True``, ``locked=False``) so
+    the UI still has something safe to render.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "features": _ent.feature_catalog(),
+                "grace": ent.grace,
+                "enforced": not ent.grace,
+            }
+        )
+    except Exception as exc:  # never crash the dashboard over a gate read
+        logger.warning("api_features: falling back to grace shape: %s", exc)
+        try:
+            from clawmetry import entitlements as _ent
+
+            fallback = [
+                {
+                    "id": fid,
+                    "label": _ent.feature_label(fid),
+                    "tier": _ent.feature_tier(fid),
+                    "free": fid in _ent.FREE_FEATURES,
+                    "allowed": True,
+                    "locked": False,
+                }
+                for tier, bucket in _ent._FEATURE_TIER_ORDER
+                for fid in sorted(bucket)
+            ]
+        except Exception:
+            fallback = []
+        return jsonify(
+            {
+                "features": fallback,
                 "grace": True,
                 "enforced": False,
             }

--- a/tests/test_entitlements_feature_catalog.py
+++ b/tests/test_entitlements_feature_catalog.py
@@ -1,0 +1,340 @@
+"""Tests for the feature catalog: ``feature_label`` / ``feature_tier`` /
+``feature_catalog`` in ``clawmetry/entitlements.py`` and the
+``GET /api/features`` endpoint in ``routes/entitlement.py``.
+
+The catalog is the single source of truth the dashboard reads to render the
+Settings feature matrix, the pricing-parity grid, and the upgrade-CTA copy
+without re-deriving tier buckets in JS. These tests pin the per-tier bucket
+membership, the catalog's locked/allowed/free flags under each representative
+tier, the never-raise posture, and the route shape.
+
+Companion to ``tests/test_entitlements_catalogue.py`` (which pins the bucket
+*set* membership against /pricing) and ``tests/test_entitlement_api.py``
+(which covers /api/entitlement + /api/runtimes).
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── feature_label ─────────────────────────────────────────────────────────────
+
+
+def test_feature_label_known_keys(ent):
+    assert ent.feature_label("sessions") == "Sessions"
+    assert ent.feature_label("fleet") == "Multi-node fleet"
+    assert ent.feature_label("self_evolve") == "Self-Evolve"
+    assert ent.feature_label("sso") == "SSO"
+
+
+def test_feature_label_unknown_falls_back_to_id(ent):
+    assert ent.feature_label("not_a_real_feature") == "not_a_real_feature"
+
+
+def test_feature_label_empty_and_none_are_safe(ent):
+    assert ent.feature_label("") == ""
+    assert ent.feature_label(None) == ""  # type: ignore[arg-type]
+
+
+def test_feature_label_case_insensitive(ent):
+    assert ent.feature_label("SESSIONS") == "Sessions"
+    assert ent.feature_label("  fleet  ") == "Multi-node fleet"
+
+
+def test_every_known_feature_has_a_label(ent):
+    """Every key in ALL_FEATURES should ship with a human-readable label —
+    a missing label silently degrades to the snake_case id in the UI."""
+    missing = sorted(ent.ALL_FEATURES - set(ent.FEATURE_LABELS))
+    assert not missing, f"missing FEATURE_LABELS entries: {missing}"
+
+
+# ── feature_tier ──────────────────────────────────────────────────────────────
+
+
+def test_feature_tier_buckets(ent):
+    assert ent.feature_tier("sessions") == ent.TIER_OSS
+    assert ent.feature_tier("transcripts") == ent.TIER_OSS
+    assert ent.feature_tier("fleet") == ent.TIER_CLOUD_STARTER
+    assert ent.feature_tier("multi_runtime") == ent.TIER_CLOUD_STARTER
+    assert ent.feature_tier("self_evolve") == ent.TIER_CLOUD_PRO
+    assert ent.feature_tier("otel_export") == ent.TIER_CLOUD_PRO
+    assert ent.feature_tier("sso") == ent.TIER_ENTERPRISE
+    assert ent.feature_tier("siem_export") == ent.TIER_ENTERPRISE
+
+
+def test_feature_tier_unknown_collapses_to_oss(ent):
+    """Unknown ids must NOT spuriously render as a locked Enterprise row —
+    they collapse to OSS (free) so the catalog stays grace-safe."""
+    assert ent.feature_tier("not_a_real_feature") == ent.TIER_OSS
+
+
+def test_feature_tier_empty_and_none_are_safe(ent):
+    assert ent.feature_tier("") == ent.TIER_OSS
+    assert ent.feature_tier(None) == ent.TIER_OSS  # type: ignore[arg-type]
+
+
+def test_feature_tier_case_insensitive(ent):
+    assert ent.feature_tier("FLEET") == ent.TIER_CLOUD_STARTER
+    assert ent.feature_tier("  SSO  ") == ent.TIER_ENTERPRISE
+
+
+# ── feature_catalog: grace mode ───────────────────────────────────────────────
+
+
+def test_catalog_covers_every_known_feature(ent):
+    cat = ent.feature_catalog()
+    ids = {row["id"] for row in cat}
+    assert ids == ent.ALL_FEATURES
+
+
+def test_catalog_grace_all_allowed_none_locked(ent):
+    cat = ent.feature_catalog()
+    assert all(row["allowed"] is True for row in cat)
+    assert all(row["locked"] is False for row in cat)
+
+
+def test_catalog_shape_keys(ent):
+    cat = ent.feature_catalog()
+    assert cat, "catalog must not be empty"
+    for row in cat:
+        for k in ("id", "label", "tier", "free", "allowed", "locked"):
+            assert k in row, f"row missing {k}: {row}"
+
+
+def test_catalog_free_flag_matches_FREE_FEATURES(ent):
+    cat = ent.feature_catalog()
+    for row in cat:
+        assert row["free"] == (row["id"] in ent.FREE_FEATURES)
+
+
+def test_catalog_tier_column_matches_feature_tier(ent):
+    """Every row's ``tier`` column must equal ``feature_tier(id)`` — the
+    catalog should NEVER drift from the per-feature lookup."""
+    cat = ent.feature_catalog()
+    for row in cat:
+        assert row["tier"] == ent.feature_tier(row["id"]), row
+
+
+# ── feature_catalog: ordering invariant ───────────────────────────────────────
+
+
+def test_catalog_ordering_free_then_starter_then_pro_then_enterprise(ent):
+    """Stable ordering: free -> starter -> pro -> enterprise; alphabetical
+    within each group. The UI relies on this for its deterministic grid."""
+    tier_order = [
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+    cat = ent.feature_catalog()
+    seen_groups: list[str] = []
+    prev_id_in_group: str | None = None
+    for row in cat:
+        t = row["tier"]
+        if not seen_groups or seen_groups[-1] != t:
+            seen_groups.append(t)
+            prev_id_in_group = None
+        if prev_id_in_group is not None:
+            assert row["id"] > prev_id_in_group, (
+                f"ids must be alphabetical within tier {t}: "
+                f"{prev_id_in_group} >= {row['id']}"
+            )
+        prev_id_in_group = row["id"]
+    assert seen_groups == tier_order
+
+
+# ── feature_catalog: enforce mode ─────────────────────────────────────────────
+
+
+def test_catalog_enforce_oss_free_allowed_paid_locked(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    cat = ent.feature_catalog()
+    for row in cat:
+        if row["free"]:
+            assert row["allowed"] is True, row
+            assert row["locked"] is False, row
+        else:
+            assert row["allowed"] is False, row
+            assert row["locked"] is True, row
+
+
+def test_catalog_enforce_starter_grants_starter_only(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_starter"}))
+    ent.invalidate()
+    by_id = {row["id"]: row for row in ent.feature_catalog()}
+    # Starter rows pass.
+    assert by_id["fleet"]["allowed"] is True
+    assert by_id["multi_runtime"]["allowed"] is True
+    # Pro-only rows are still locked.
+    assert by_id["self_evolve"]["allowed"] is False
+    assert by_id["self_evolve"]["locked"] is True
+    assert by_id["otel_export"]["allowed"] is False
+    # Enterprise rows are still locked.
+    assert by_id["sso"]["allowed"] is False
+    assert by_id["sso"]["locked"] is True
+
+
+def test_catalog_enforce_pro_grants_starter_plus_pro(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    by_id = {row["id"]: row for row in ent.feature_catalog()}
+    assert by_id["multi_runtime"]["allowed"] is True  # starter
+    assert by_id["self_evolve"]["allowed"] is True  # pro
+    assert by_id["otel_export"]["allowed"] is True  # pro
+    assert by_id["siem_export"]["allowed"] is False  # enterprise
+    assert by_id["sso"]["locked"] is True
+
+
+def test_catalog_enforce_enterprise_grants_everything(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "enterprise"}))
+    ent.invalidate()
+    cat = ent.feature_catalog()
+    for row in cat:
+        assert row["allowed"] is True, row
+        assert row["locked"] is False, row
+
+
+def test_catalog_swallows_resolver_failure(ent, monkeypatch):
+    """A flaky entitlement resolver must NOT 500 the catalog — it falls back
+    to the OSS-free grace shape so the UI can still render."""
+    def boom(*_, **__):
+        raise RuntimeError("synthetic resolver crash")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    cat = ent.feature_catalog()
+    # Grace fallback: every row reports allowed=True, locked=False.
+    assert cat, "fallback catalog must not be empty"
+    assert all(row["allowed"] is True for row in cat)
+    assert all(row["locked"] is False for row in cat)
+
+
+# ── /api/features endpoint ────────────────────────────────────────────────────
+
+
+def test_api_features_shape_grace(client, ent):
+    rv = client.get("/api/features")
+    assert rv.status_code == 200
+    d = rv.get_json()
+    assert "features" in d and isinstance(d["features"], list)
+    assert d["grace"] is True
+    assert d["enforced"] is False
+    assert d["grace"] == (not d["enforced"])
+    ids = {row["id"] for row in d["features"]}
+    assert ids == ent.ALL_FEATURES
+
+
+def test_api_features_grace_all_allowed(client):
+    d = client.get("/api/features").get_json()
+    assert all(row["allowed"] is True for row in d["features"])
+    assert all(row["locked"] is False for row in d["features"])
+
+
+def test_api_features_enforce_oss_locks_paid(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/features").get_json()
+    assert d["grace"] is False
+    assert d["enforced"] is True
+    by_id = {row["id"]: row for row in d["features"]}
+    assert by_id["sessions"]["allowed"] is True
+    assert by_id["sessions"]["locked"] is False
+    assert by_id["fleet"]["allowed"] is False
+    assert by_id["fleet"]["locked"] is True
+    assert by_id["sso"]["allowed"] is False
+    assert by_id["sso"]["locked"] is True
+
+
+def test_api_features_enforce_pro_unlocks_starter_and_pro(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    d = app.test_client().get("/api/features").get_json()
+    by_id = {row["id"]: row for row in d["features"]}
+    assert by_id["fleet"]["allowed"] is True
+    assert by_id["self_evolve"]["allowed"] is True
+    assert by_id["sso"]["allowed"] is False
+    assert by_id["sso"]["locked"] is True
+
+
+def test_api_features_never_500s_on_resolver_failure(monkeypatch, tmp_path):
+    """An exploded entitlement resolver must not 5xx the catalog endpoint —
+    the route falls back to a grace-mode shape so the UI keeps rendering."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(e, "get_entitlement", boom)
+
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    rv = app.test_client().get("/api/features")
+    assert rv.status_code == 200
+    d = rv.get_json()
+    assert d["grace"] is True
+    assert d["enforced"] is False
+    assert all(row["allowed"] is True for row in d["features"])
+    assert all(row["locked"] is False for row in d["features"])


### PR DESCRIPTION
## Summary

`runtime_catalog()` / `GET /api/runtimes` lets the dashboard render every known runtime row + its lock state off one canonical list. The feature side did not — every surface that wanted to render the Settings feature matrix, the pricing-parity grid, or the upgrade-CTA copy had to re-derive tier buckets from `FREE_FEATURES` / `STARTER_FEATURES` / `PRO_ONLY_FEATURES` / `ENTERPRISE_FEATURES` on its own. This adds the symmetric helper + endpoint so features read off the same shape.

## Files

### `clawmetry/entitlements.py`

- `FEATURE_LABELS` dict — a human-readable label for every key in `ALL_FEATURES`.
- `feature_label(feature)` — falls back to the id when unknown.
- `feature_tier(feature)` — the cheapest tier id that grants the feature:
  - `FREE_FEATURES` → `TIER_OSS`
  - `STARTER_FEATURES` → `TIER_CLOUD_STARTER`
  - `PRO_ONLY_FEATURES` → `TIER_CLOUD_PRO`
  - `ENTERPRISE_FEATURES` → `TIER_ENTERPRISE`
  - Unknown / empty / non-string → `TIER_OSS` (grace-safe — an unknown id is never rendered as a locked Enterprise row).
- `feature_catalog()` — list of `{id, label, tier, free, allowed, locked}` rows for every feature, ordered free → starter → pro → enterprise, alphabetical within each group. Mirrors `runtime_catalog()`'s shape. Never raises: on resolver failure it falls back to the OSS-free grace shape so the UI keeps rendering.

### `routes/entitlement.py`

- `GET /api/features` — `{ features: [...], grace, enforced }`. Same never-raise posture as `/api/runtimes`: a resolver crash returns a grace-mode shape, not a 500.

### `tests/test_entitlements_feature_catalog.py`

25 tests covering label fallback, tier-bucket membership for every named representative feature, grace mode, enforce + OSS, enforce + Starter, enforce + Pro, enforce + Enterprise, the free-then-starter-then-pro-then-enterprise ordering invariant, the never-raise fallback for both the helper and the route, and the `/api/features` shape (including the `grace == not enforced` contract).

## Behaviour change

**None.** This is a pure-read primitive — no current gate consults it, and GRACE mode is preserved everywhere. Every row reports `allowed=True` / `locked=False` until `CLAWMETRY_ENFORCE=1`.

## Test plan

```
$ python -m pytest tests/test_entitlements_feature_catalog.py -q
25 passed in 0.23s

$ python -m pytest tests/test_entitlement_api.py tests/test_entitlements.py tests/test_entitlements_catalogue.py -q
41 passed in 0.29s

$ python -m py_compile clawmetry/entitlements.py routes/entitlement.py tests/test_entitlements_feature_catalog.py
# clean
```

## Local operator verification checklist

I (the autonomous fire) cannot exercise the local daemon, the live cloud snapshot, or a browser. The local operator should verify:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `~/.clawmetry/lib/pythonX.Y/site-packages/routes/`, then clear `__pycache__`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or restart the daemon (Linux).
- [ ] `curl -s http://localhost:8900/api/features | jq` — every key from `ALL_FEATURES` present, `grace=true`, `enforced=false`, `allowed=true` everywhere by default.
- [ ] `CLAWMETRY_ENFORCE=1` restart → `/api/features` shows `fleet`, `self_evolve`, `sso` etc. with `locked=true`; `sessions`, `transcripts`, `nemo_governance` etc. still `locked=false`.
- [ ] Decrypt the live cloud snapshot and confirm nothing changed (the daemon does not consult `feature_catalog()` yet — this is a pure-read API).
- [ ] Browser-check `http://localhost:8900` — no regression in the runtime switcher or the existing entitlement-driven affordances (the new endpoint isn't wired into the UI yet; that lands in a follow-up).

This PR is intentionally **draft**: it is the autonomous-fire deliverable. The local operator owns the daemon-side / live-snapshot verification, the `__version__` bump, the `[RELEASE]` PR, and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01A967fLF7BRJATTCnezowqm)_