### PR TITLE
feat(entitlements): lock_reasons_batch + /api/entitlement/lock-reason-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1621,6 +1621,179 @@ def lock_reason(item: str, *, kind: str | None = None) -> str | None:
         return None
 
 
+def _normalise_csv(items) -> list[str]:
+    if items is None:
+        return []
+    if isinstance(items, str):
+        raw = items.split(",")
+    else:
+        try:
+            raw = list(items)
+        except TypeError:
+            return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for tok in raw:
+        try:
+            s = str(tok).strip().lower()
+        except Exception:
+            continue
+        if not s or s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+def _lock_row(ent, key: str, kind: str) -> dict:
+    try:
+        if kind == "feature":
+            allowed = ent.allows_feature(key)
+            required = min_tier_for_feature(key)
+        elif kind == "runtime":
+            allowed = ent.allows_runtime(key)
+            required = min_tier_for_runtime(key)
+        elif kind == "channels":
+            try:
+                n = int(key)
+            except (TypeError, ValueError):
+                return {
+                    "key": str(key),
+                    "kind": kind,
+                    "reason": None,
+                    "locked": False,
+                    "allowed": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                }
+            allowed = ent.allows_channel_count(n)
+            required = min_tier_for_channel_count(n)
+            key = str(n)
+        elif kind == "retention_days":
+            try:
+                n = int(key)
+            except (TypeError, ValueError):
+                return {
+                    "key": str(key),
+                    "kind": kind,
+                    "reason": None,
+                    "locked": False,
+                    "allowed": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                }
+            allowed = ent.allows_retention_window(n)
+            required = min_tier_for_retention_window(n)
+            key = str(n)
+        elif kind == "nodes":
+            try:
+                n = int(key)
+            except (TypeError, ValueError):
+                return {
+                    "key": str(key),
+                    "kind": kind,
+                    "reason": None,
+                    "locked": False,
+                    "allowed": True,
+                    "required_tier": None,
+                    "required_tier_label": None,
+                    "required_tier_rank": -1,
+                }
+            allowed = ent.allows_node_count(n)
+            required = min_tier_for_node_count(n)
+            key = str(n)
+        else:
+            allowed = True
+            required = None
+        reason = ent.lock_reason(key, kind=kind)
+        return {
+            "key": key,
+            "kind": kind,
+            "reason": reason,
+            "locked": reason is not None,
+            "allowed": allowed,
+            "required_tier": required,
+            "required_tier_label": tier_label(required) if required else None,
+            "required_tier_rank": tier_rank(required) if required else -1,
+        }
+    except Exception:
+        return {
+            "key": str(key),
+            "kind": kind,
+            "reason": None,
+            "locked": False,
+            "allowed": True,
+            "required_tier": None,
+            "required_tier_label": None,
+            "required_tier_rank": -1,
+        }
+
+
+def lock_reasons_batch(
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict:
+    """Per-item lock reasons for every supplied item across all 5 axes in one
+    pass.
+
+    Plural sibling of :func:`lock_reason`. While
+    :func:`min_tier_for_all` / ``/required-tier-batch`` collapse the answer to
+    the single most-constraining tier, this helper preserves the per-item
+    detail so a Settings or paywall matrix UI can render N rows with their
+    individual reasons + per-row required tier off **one** call instead of N
+    round-trips to ``/lock-reason``.
+
+    Shape::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``reason`` (``None`` when not
+    locked / unknown id / grace mode), ``locked``, ``allowed``,
+    ``required_tier``, ``required_tier_label``, ``required_tier_rank``.
+
+    The capacity axes (``channels`` / ``retention_days`` / ``nodes``) use
+    ``None`` as the "axis not supplied" sentinel and the corresponding key
+    in the returned dict is ``None``. Mirrors ``min_tier_for_all`` exactly:
+    ``retention_days=None`` here means *unset*, NOT *unlimited*.
+
+    Grace mode (the default until enforcement flips on): every row has
+    ``reason=None`` / ``locked=False`` / ``allowed=True`` -- the helper does
+    not invent locks. Never raises: a resolver failure short-circuits to the
+    grace-shape rows so the UI keeps rendering.
+    """
+    feats = _normalise_csv(features)
+    rts = _normalise_csv(runtimes)
+    try:
+        ent = get_entitlement()
+    except Exception as exc:
+        logger.warning("entitlements: lock_reasons_batch falling back to grace: %s", exc)
+        ent = _oss_free()
+    out: dict = {
+        "features": [_lock_row(ent, f, "feature") for f in feats],
+        "runtimes": [_lock_row(ent, r, "runtime") for r in rts],
+        "channels": _lock_row(ent, channels, "channels") if channels is not None else None,
+        "retention_days": (
+            _lock_row(ent, retention_days, "retention_days")
+            if retention_days is not None
+            else None
+        ),
+        "nodes": _lock_row(ent, nodes, "nodes") if nodes is not None else None,
+    }
+    return out
+
+
 def feature_label(feature: str) -> str:
     fid = (feature or "").strip().lower()
     return FEATURE_LABELS.get(fid, fid)

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -50,6 +50,15 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                           fleet + otel_export + sso -- what
                                           tier covers everything?" in a single
                                           round-trip.
+  GET  /api/entitlement/lock-reason-batch -- per-item plural sibling of
+                                          ``/lock-reason``: same CSV +
+                                          capacity inputs as
+                                          ``/required-tier-batch``, but
+                                          preserves per-item ``reason`` /
+                                          ``locked`` / ``required_tier`` rows
+                                          so a Settings or paywall matrix UI
+                                          renders N rows off one round-trip
+                                          instead of N calls.
   GET  /api/runtimes                  -- the full runtime catalog.
   GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
 """
@@ -726,6 +735,105 @@ def api_entitlement_required_tier_batch():
                 "current_tier_rank": 0,
                 "upgrade_required": False,
                 "allowed": True,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/lock-reason-batch")
+def api_entitlement_lock_reason_batch():
+    """``GET /api/entitlement/lock-reason-batch?features=a,b,c&runtimes=x,y
+    &channels=N&retention_days=K&nodes=M`` -- per-item plural sibling of
+    ``/api/entitlement/lock-reason``.
+
+    Where ``/required-tier-batch`` aggregates the most-constraining axis into
+    one tier answer, this preserves the per-item detail so a Settings or
+    paywall matrix UI ("show me each runtime + feature row with its
+    individual lock + required tier") renders off **one** round-trip instead
+    of N calls to ``/lock-reason``.
+
+    At least one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied. ``features=`` /
+    ``runtimes=`` take comma-separated tokens (whitespace + duplicates are
+    normalised away; unknown ids contribute a grace-shape row -- they don't
+    error). The three capacity axes take a single int each; a blank or
+    non-int value is treated as "not supplied" (matches the singular
+    endpoint's never-crash posture rather than mis-routing a typo to
+    Enterprise). Never 5xxs: the per-axis grace shape is returned on any
+    resolver failure.
+
+    Response shape::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+          "current_tier":   "...",
+          "current_tier_rank": <int>,
+          "grace":          <bool>,
+          "enforced":       <bool>,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``reason``, ``locked``,
+    ``allowed``, ``required_tier``, ``required_tier_label``,
+    ``required_tier_rank``.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg("retention_days")
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        batch = _ent.lock_reasons_batch(
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        ent = _ent.get_entitlement()
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning("api_entitlement_lock_reason_batch: error: %s", exc)
+        return jsonify(
+            {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
             }
         )
 

--- a/tests/test_entitlement_lock_reason_batch.py
+++ b/tests/test_entitlement_lock_reason_batch.py
@@ -1,0 +1,319 @@
+"""Tests for ``lock_reasons_batch`` helper and the
+``/api/entitlement/lock-reason-batch`` endpoint.
+
+Plural per-item sibling of ``lock_reason`` / ``/lock-reason``. Where
+``min_tier_for_all`` / ``/required-tier-batch`` collapse the answer to the
+single most-constraining tier, this surface preserves the per-item detail so
+a Settings or paywall matrix UI ("show me each runtime + feature row with
+its own lock + required tier") renders off ONE round-trip instead of N
+calls. These tests pin that the shape, the grace-mode posture, the
+unknown-id fallback, and the never-raise contract all match the singular
+endpoint's behaviour, item-for-item.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── lock_reasons_batch -- grace mode (default) ─────────────────────────────
+
+
+def test_helper_grace_mode_returns_no_reasons(ent):
+    """In grace mode (default) every row must report reason=None,
+    locked=False, allowed=True -- the helper must not invent locks
+    pre-enforcement."""
+    out = ent.lock_reasons_batch(
+        features=["fleet", "sso"],
+        runtimes=["claude_code"],
+        channels=5,
+        retention_days=30,
+        nodes=3,
+    )
+    for row in out["features"] + out["runtimes"]:
+        assert row["reason"] is None
+        assert row["locked"] is False
+        assert row["allowed"] is True
+    for axis in ("channels", "retention_days", "nodes"):
+        assert out[axis] is not None
+        assert out[axis]["reason"] is None
+        assert out[axis]["locked"] is False
+        assert out[axis]["allowed"] is True
+
+
+def test_helper_no_inputs_returns_empty_shape(ent):
+    out = ent.lock_reasons_batch()
+    assert out["features"] == []
+    assert out["runtimes"] == []
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+def test_helper_none_axis_means_unsupplied_not_unlimited(ent):
+    """``retention_days=None`` here means "axis not supplied", NOT the
+    unlimited sentinel that would mis-route to Enterprise."""
+    out = ent.lock_reasons_batch(retention_days=None)
+    assert out["retention_days"] is None
+
+
+# ── helper -- enforce mode + OSS ──────────────────────────────────────────
+
+
+def test_helper_enforce_oss_locks_paid_features(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    out = ent.lock_reasons_batch(features=["fleet", "otel_export", "sso"])
+    rows = {r["key"]: r for r in out["features"]}
+    assert rows["fleet"]["locked"] is True
+    assert rows["fleet"]["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert rows["otel_export"]["locked"] is True
+    assert rows["otel_export"]["required_tier"] == ent.TIER_CLOUD_PRO
+    assert rows["sso"]["locked"] is True
+    assert rows["sso"]["required_tier"] == ent.TIER_ENTERPRISE
+
+
+def test_helper_enforce_oss_free_features_never_locked(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    out = ent.lock_reasons_batch(
+        features=["sessions", "transcripts", "nemo_governance"],
+    )
+    for row in out["features"]:
+        assert row["reason"] is None
+        assert row["locked"] is False
+
+
+def test_helper_enforce_oss_locks_paid_runtimes(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    out = ent.lock_reasons_batch(runtimes=["claude_code", "openclaw"])
+    rows = {r["key"]: r for r in out["runtimes"]}
+    assert rows["claude_code"]["locked"] is True
+    assert "Paid runtime" in rows["claude_code"]["reason"]
+    assert rows["claude_code"]["required_tier"] == ent.TIER_CLOUD_STARTER
+    assert rows["openclaw"]["locked"] is False
+    assert rows["openclaw"]["reason"] is None
+
+
+def test_helper_enforce_oss_locks_capacity(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    out = ent.lock_reasons_batch(channels=5, retention_days=30, nodes=3)
+    assert out["channels"]["locked"] is True
+    assert out["channels"]["required_tier"] == (
+        ent.min_tier_for_channel_count(5)
+    )
+    assert out["retention_days"]["locked"] is True
+    assert out["retention_days"]["required_tier"] == (
+        ent.min_tier_for_retention_window(30)
+    )
+    assert out["nodes"]["locked"] is True
+    assert out["nodes"]["required_tier"] == ent.min_tier_for_node_count(3)
+
+
+# ── helper -- unknown / malformed inputs ──────────────────────────────────
+
+
+def test_helper_unknown_ids_get_grace_shape(ent, monkeypatch):
+    """A typo must not 500 and must not invent a tier -- the row reports
+    reason=None / required_tier=None."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    out = ent.lock_reasons_batch(
+        features=["not_a_real_feature"],
+        runtimes=["not_a_real_runtime"],
+    )
+    assert out["features"][0]["reason"] is None
+    assert out["features"][0]["required_tier"] is None
+    assert out["features"][0]["locked"] is False
+    assert out["runtimes"][0]["reason"] is None
+    assert out["runtimes"][0]["required_tier"] is None
+    assert out["runtimes"][0]["locked"] is False
+
+
+def test_helper_csv_string_accepted(ent):
+    """The helper accepts a comma-separated string in addition to an
+    iterable -- mirrors how the HTTP wrapper would forward a raw param."""
+    out = ent.lock_reasons_batch(features="fleet, sso , fleet")
+    assert [r["key"] for r in out["features"]] == ["fleet", "sso"]
+
+
+def test_helper_duplicates_collapsed(ent):
+    out = ent.lock_reasons_batch(features=["fleet", "FLEET", "fleet"])
+    assert [r["key"] for r in out["features"]] == ["fleet"]
+
+
+def test_helper_never_raises_on_resolver_failure(ent, monkeypatch):
+    """Resolver crash must short-circuit to the OSS-free grace shape, not
+    raise."""
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    out = ent.lock_reasons_batch(features=["fleet"])
+    assert out["features"][0]["reason"] is None
+    assert out["features"][0]["locked"] is False
+
+
+# ── /api/entitlement/lock-reason-batch ────────────────────────────────────
+
+
+def test_endpoint_no_input_400s(client):
+    rv = client.get("/api/entitlement/lock-reason-batch")
+    assert rv.status_code == 400
+    assert "supply at least one" in rv.get_json()["error"]
+
+
+def test_endpoint_blank_capacities_treated_as_unsupplied(client):
+    """A blank capacity value must be treated as "not supplied" (NOT
+    mis-routed to Enterprise via retention-None=unlimited). With ALL inputs
+    blank the endpoint must 400, matching ``/required-tier-batch``."""
+    rv = client.get(
+        "/api/entitlement/lock-reason-batch"
+        "?channels=&retention_days=&nodes="
+    )
+    assert rv.status_code == 400
+
+
+def test_endpoint_features_only(client, ent):
+    d = client.get(
+        "/api/entitlement/lock-reason-batch?features=fleet,sso"
+    ).get_json()
+    keys = [r["key"] for r in d["features"]]
+    assert keys == ["fleet", "sso"]
+    # grace -- every reason None
+    for row in d["features"]:
+        assert row["reason"] is None
+        assert row["locked"] is False
+    assert d["grace"] is True
+    assert d["enforced"] is False
+    assert d["current_tier"] == ent.TIER_OSS
+    assert d["current_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+
+
+def test_endpoint_runtimes_only(client):
+    d = client.get(
+        "/api/entitlement/lock-reason-batch?runtimes=claude_code,openclaw"
+    ).get_json()
+    keys = [r["key"] for r in d["runtimes"]]
+    assert keys == ["claude_code", "openclaw"]
+
+
+def test_endpoint_all_five_axes_one_call(client, ent, monkeypatch):
+    """The whole point: one round-trip yields per-item rows for every axis
+    a paywall matrix needs to render."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    d = client.get(
+        "/api/entitlement/lock-reason-batch"
+        "?features=fleet,sso"
+        "&runtimes=claude_code"
+        "&channels=5"
+        "&retention_days=30"
+        "&nodes=3"
+    ).get_json()
+    feat_rows = {r["key"]: r for r in d["features"]}
+    assert feat_rows["fleet"]["locked"] is True
+    assert feat_rows["sso"]["required_tier"] == ent.TIER_ENTERPRISE
+    rt_rows = {r["key"]: r for r in d["runtimes"]}
+    assert rt_rows["claude_code"]["locked"] is True
+    assert d["channels"]["locked"] is True
+    assert d["retention_days"]["locked"] is True
+    assert d["nodes"]["locked"] is True
+    assert d["grace"] is False
+    assert d["enforced"] is True
+
+
+def test_endpoint_non_int_capacity_silently_skipped(client):
+    """A non-int capacity is the never-crash path: that axis goes None, the
+    remaining axes still resolve -- same posture as the singular endpoint."""
+    d = client.get(
+        "/api/entitlement/lock-reason-batch?features=fleet&channels=abc"
+    ).get_json()
+    assert d["channels"] is None
+    assert len(d["features"]) == 1
+
+
+def test_endpoint_unknown_ids_dont_500(client, ent, monkeypatch):
+    """A typo in features must not error and must report a grace-shape row
+    rather than mis-routing to a tier."""
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    rv = client.get(
+        "/api/entitlement/lock-reason-batch"
+        "?features=fleet,not_a_real_feature"
+    )
+    assert rv.status_code == 200
+    rows = {r["key"]: r for r in rv.get_json()["features"]}
+    assert rows["fleet"]["locked"] is True
+    assert rows["not_a_real_feature"]["locked"] is False
+    assert rows["not_a_real_feature"]["required_tier"] is None
+
+
+def test_endpoint_capacity_alone_is_enough_input(client):
+    """Supplying only a capacity axis (no features/runtimes) must NOT 400
+    -- the "at least one axis" rule covers all five."""
+    assert client.get(
+        "/api/entitlement/lock-reason-batch?channels=5"
+    ).status_code == 200
+    assert client.get(
+        "/api/entitlement/lock-reason-batch?retention_days=30"
+    ).status_code == 200
+    assert client.get(
+        "/api/entitlement/lock-reason-batch?nodes=3"
+    ).status_code == 200
+
+
+def test_endpoint_resolver_failure_returns_grace_shape(client, monkeypatch):
+    """A resolver crash must fall back to the grace shape -- never a 500."""
+    import clawmetry.entitlements as _ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(_ent, "lock_reasons_batch", boom)
+    rv = client.get("/api/entitlement/lock-reason-batch?features=fleet")
+    assert rv.status_code == 200
+    d = rv.get_json()
+    assert d["features"] == []
+    assert d["current_tier"] == "oss"
+    assert d["grace"] is True
+    assert d["enforced"] is False
+
+
+def test_endpoint_carries_current_tier_metadata(client, ent):
+    """Every response must carry current_tier / current_tier_rank / grace /
+    enforced so a single round-trip can render the upgrade-CTA badge
+    alongside the per-row locks without a second /api/entitlement call."""
+    d = client.get(
+        "/api/entitlement/lock-reason-batch?features=fleet"
+    ).get_json()
+    assert "current_tier" in d
+    assert "current_tier_rank" in d
+    assert "grace" in d
+    assert "enforced" in d


### PR DESCRIPTION
## Summary

Plural per-item sibling of `lock_reason()` / `/api/entitlement/lock-reason`. Where `min_tier_for_all` / `/required-tier-batch` collapse the answer to a single most-constraining tier, this surface preserves the per-item detail so a Settings or paywall matrix UI ("show me each runtime + feature row with its own lock + required tier") renders off **one** round-trip instead of N calls to `/lock-reason`.

## Files

### `clawmetry/entitlements.py`

- `_normalise_csv(items)` — accepts a CSV string or any iterable, lower-cases + strips + dedupes (mirrors the route's `_parse_csv_arg`).
- `_lock_row(ent, key, kind)` — single-row resolver shared across all five axes; folds the per-axis singular-endpoint logic (parse → `allows_*` → `min_tier_for_*` → `lock_reason`) into a uniform row shape and never raises.
- `lock_reasons_batch(*, features=, runtimes=, channels=, retention_days=, nodes=)` — one-call per-item answer for every supplied item across all five axes.

Returned shape:

```json
{
  "features":       [{ "key": "...", "kind": "feature",
                       "reason": "..." | null, "locked": bool, "allowed": bool,
                       "required_tier": "..." | null,
                       "required_tier_label": "..." | null,
                       "required_tier_rank": <int> }, ...],
  "runtimes":       [<row>, ...],
  "channels":       <row> | null,
  "retention_days": <row> | null,
  "nodes":          <row> | null
}
```

### `routes/entitlement.py`

- `GET /api/entitlement/lock-reason-batch` — HTTP wrapper. Same five inputs as `/required-tier-batch` (CSV for features/runtimes, single int for the capacity axes). Returns the helper shape plus `current_tier`, `current_tier_rank`, `grace`, `enforced` so a single round-trip drives both the per-row lock affordances and the upgrade-CTA badge.

### `tests/test_entitlement_lock_reason_batch.py`

21 tests covering helper + endpoint:

- grace-mode posture (default) — every row `reason=None`, `locked=False`, `allowed=True`
- `no inputs` returns the empty shape from the helper, 400 from the endpoint
- `retention_days=None` is "axis not supplied" (never the unlimited sentinel)
- enforce + OSS — paid features / paid runtimes / over-cap capacity all locked with correct `required_tier`
- free features / free runtimes still un-locked under enforce
- unknown ids → grace-shape row (typo never mis-routes to a tier or 500s)
- CSV string parsing + duplicate collapsing on the helper
- resolver-failure → grace-shape fallback (helper) / 200 with OSS-free shape (endpoint), never 5xx
- non-int capacity is silently skipped (the never-crash contract)
- capacity alone satisfies the "at least one axis" rule
- envelope carries `current_tier` / `current_tier_rank` / `grace` / `enforced`

## Behaviour change

**None.** Pure-read primitive — no current gate consults it, and GRACE mode is preserved everywhere. Every row reports `reason=None` / `locked=False` / `allowed=True` until `CLAWMETRY_ENFORCE=1`.

## Test plan

```
$ python -m pytest tests/test_entitlement_lock_reason_batch.py -q
21 passed in 0.35s

$ python -m pytest \
    tests/test_entitlement_lock_reason.py \
    tests/test_entitlement_lock_reason_capacity.py \
    tests/test_entitlement_lock_reason_nodes.py \
    tests/test_entitlement_api_lock_reason.py \
    tests/test_entitlement_api_lock_reason_capacity.py \
    tests/test_entitlements_min_tier_batch.py \
    tests/test_entitlements.py \
    tests/test_entitlement_api.py \
    tests/test_entitlements_feature_catalog.py -q
251 passed in 1.99s

$ ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_lock_reason_batch.py
All checks passed!
```

## Local operator verification checklist

I (the autonomous fire) cannot exercise the local daemon, the live cloud snapshot, or a browser. The local operator should verify:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` and `~/.clawmetry/lib/pythonX.Y/site-packages/routes/`, then clear `__pycache__`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` (macOS) or restart the daemon (Linux).
- [ ] `curl -s 'http://localhost:8900/api/entitlement/lock-reason-batch?features=fleet,sso&runtimes=claude_code&channels=5&retention_days=30&nodes=3' | jq` — five-axis shape, grace mode, every row `reason=null` / `locked=false`.
- [ ] `CLAWMETRY_ENFORCE=1` restart → same URL now shows per-row locks for paid features / paid runtimes / over-cap capacity with the matching `required_tier`; free features (`sessions`, `nemo_governance`) and free runtimes (`openclaw`, `nemoclaw`) stay un-locked.
- [ ] `curl 'http://localhost:8900/api/entitlement/lock-reason-batch'` → 400 with the "supply at least one" error.
- [ ] `curl 'http://localhost:8900/api/entitlement/lock-reason-batch?features=fleet&channels=abc'` → 200, `channels=null`, `features[0]` row still present (the never-crash contract).
- [ ] Decrypt the live cloud snapshot and confirm nothing changed (the daemon does not consult `lock_reasons_batch()` yet — this is a pure-read API).
- [ ] Browser-check `http://localhost:8900` — no regression in the runtime switcher or the existing entitlement-driven affordances (the new endpoint isn't wired into the UI yet; that lands in a follow-up).

This PR is intentionally **draft**: it is the autonomous-fire deliverable. The local operator owns the daemon-side / live-snapshot verification, the `__version__` bump, the `[RELEASE]` PR, and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015seRwbQk1YrpH8gDrQUnQw)_