### PR TITLE
fix(nemoclaw): tag sandbox sessions as agent_type='nemoclaw' in DuckDB

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2325,7 +2325,8 @@ def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
                     if isinstance(obj, dict):
                         batch.append(obj)
                 if batch:
-                    _flush_session_batch(batch, fname, api_key, enc_key, node_id, None)
+                    _flush_session_batch(batch, fname, api_key, enc_key, node_id, None,
+                                         agent_type="nemoclaw")
                     total += len(batch)
                 cursors[cursor_key] = len(all_lines)
             except Exception as _ce:
@@ -2344,6 +2345,7 @@ def _flush_session_batch(
     enc_key: str | None,
     node_id: str,
     subagent_id: str | None = None,
+    agent_type: str = "openclaw",
 ) -> None:
     # Write-through to local DuckDB FIRST (epic #964 / phase 1 / issue #958),
     # then synchronously flush so the rows are durable BEFORE the caller
@@ -2372,7 +2374,7 @@ def _flush_session_batch(
     # or partial installs without DuckDB. The next flusher tick (or daemon
     # restart) will retry the local write; INSERT OR IGNORE makes it safe.
     try:
-        _local_ingest_session_batch(batch, fname, node_id, subagent_id)
+        _local_ingest_session_batch(batch, fname, node_id, subagent_id, agent_type)
         from clawmetry import local_store as _ls
         _ls.get_store().flush()
     except Exception as _e:
@@ -3073,6 +3075,7 @@ def _local_ingest_session_batch(
     session_file: str,
     node_id: str,
     subagent_id: str | None,
+    agent_type: str = "openclaw",
 ) -> None:
     """Translate a batch of raw OpenClaw transcript events into the local
     store's normalised shape and queue them for write. Idempotent at the
@@ -3156,6 +3159,7 @@ def _local_ingest_session_batch(
             data_payload = obj
         rows.append({
             "id": str(eid),
+            "agent_type": agent_type,
             "node_id": node_id,
             "agent_id": obj.get("agent_id") or "main",
             "session_id": session_id,

--- a/tests/test_sandbox_session_sync.py
+++ b/tests/test_sandbox_session_sync.py
@@ -1,4 +1,4 @@
-"""Tests for sync_sandbox_sessions_openshell (issue #3116).
+"""Tests for sync_sandbox_sessions_openshell (issues #3116, #3234).
 
 No DuckDB or network required — all openshell and flush calls are mocked.
 """
@@ -70,6 +70,31 @@ def test_sidecar_files_excluded():
         sync_sandbox_sessions_openshell(CONFIG, {})
 
     assert len(flushed) == 1
+
+
+def test_sandbox_sessions_tagged_as_nemoclaw():
+    """Sandbox sessions must land with agent_type='nemoclaw' so NemoClawAdapter
+    list_sessions() (which filters WHERE agent_type='nemoclaw') can see them.
+    Regression test for #3234."""
+    events = [json.dumps({"type": "message", "id": "e1", "content": "hi"})]
+    sandbox_list = json.dumps([{"name": "sb", "status": "running"}])
+    ls_output = "sess.jsonl\n"
+    cat_output = "\n".join(events) + "\n"
+
+    side_effects = [_run(0, sandbox_list), _run(0, ls_output), _run(0, cat_output)]
+
+    flush_kwargs = []
+    with patch("clawmetry.sync._find_openshell_bin", return_value="/usr/bin/openshell"), \
+         patch("subprocess.run", side_effect=side_effects), \
+         patch("clawmetry.sync._flush_session_batch",
+               side_effect=lambda b, *a, **k: flush_kwargs.append(k)):
+        sync_sandbox_sessions_openshell(CONFIG, {})
+
+    assert flush_kwargs, "flush was never called"
+    assert flush_kwargs[0].get("agent_type") == "nemoclaw", (
+        "sandbox sessions must be tagged agent_type='nemoclaw' so the "
+        "NemoClawAdapter session query can find them"
+    )
 
 
 def test_cursor_skips_already_seen_lines_on_second_call():


### PR DESCRIPTION
Closes #3234

## Summary
- `sync_sandbox_sessions_openshell` was calling `_flush_session_batch` → `_local_ingest_session_batch` without an `agent_type`, so the DB default `'openclaw'` was stamped on every sandbox event row
- `NemoClawAdapter.list_sessions()` queries `WHERE agent_type = 'nemoclaw'`, so all sandbox sessions were invisible in the NeMoClaw Sessions tab despite the daemon successfully reading them
- Add optional `agent_type: str = "openclaw"` to `_flush_session_batch` and `_local_ingest_session_batch` (backwards-compatible default); `sync_sandbox_sessions_openshell` now passes `agent_type="nemoclaw"`

## Test plan
- [ ] `python3 -m pytest tests/test_sandbox_session_sync.py -v` — all 5 tests pass, including new `test_sandbox_sessions_tagged_as_nemoclaw` that asserts the kwarg reaches `_flush_session_batch`
- [ ] No regressions in other session paths (default `'openclaw'` unchanged for all other callers)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbVEoJFqReJDnaakXaPNri)_