### PR TITLE
feat: upgrade_path() + GET /api/entitlement/upgrade-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1248,6 +1248,56 @@ def tier_unlocks_batch() -> list[dict]:
         return []
 
 
+def upgrade_path() -> list[dict]:
+    """Ordered marginal-unlock ladder from the resolved tier upward.
+
+    Where :func:`tier_unlocks` answers "what does tier X unlock vs the
+    tier below it" for one named tier, ``upgrade_path`` answers "which
+    tiers are still available to me, and what does each one unlock as I
+    climb" -- the sequenced view an upgrade flow renders ("Starter adds
+    these runtimes, then Pro adds these features, then Enterprise adds
+    SSO + audit").
+
+    Walks :data:`_PURCHASABLE_TIERS` sorted by ``(tier_rank, tier_id)``,
+    filters to entries whose rank is strictly *greater* than the resolved
+    entitlement's rank, and folds :func:`tier_unlocks` over each. Same-rank
+    siblings (e.g. ``TIER_CLOUD_PRO`` and ``TIER_PRO`` both at rank 2) both
+    appear so a caller keyed off the tier id keeps working; rank-deduped
+    consumers can collapse by ``tier_rank`` client-side.
+
+    The marginal stored on each row is :func:`tier_unlocks`'s answer (vs
+    the absolute next-lower purchasable tier in the catalogue) -- *not*
+    "vs the previous step in the path". So the union of the rows is
+    direction-agnostic and matches the corresponding rows from a
+    full-ladder ``tier_unlocks_batch``-style call, while the *selection*
+    of rows is current-tier-relative.
+
+    Returns an empty list when the resolved tier already sits at the top
+    of the purchasable ladder (Enterprise), and never raises -- a resolver
+    failure short-circuits to ``[]`` so an upgrade-CTA surface keeps
+    rendering instead of breaking.
+    """
+    try:
+        ent = get_entitlement()
+        current_rank = _TIER_RANK.get(ent.tier, -1)
+        ordered = sorted(
+            _PURCHASABLE_TIERS,
+            key=lambda t: (_TIER_RANK.get(t, -1), t),
+        )
+        path: list[dict] = []
+        for tid in ordered:
+            cand_rank = _TIER_RANK.get(tid, -1)
+            if cand_rank <= current_rank:
+                continue
+            row = tier_unlocks(tid)
+            if row is not None:
+                path.append(row)
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: upgrade_path failed: %s", exc)
+        return []
+
+
 def resolution_diagnostic() -> dict:
     out: dict = {
         "license_path": _LICENSE_PATH,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -59,6 +59,14 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                           so a Settings or paywall matrix UI
                                           renders N rows off one round-trip
                                           instead of N calls.
+  GET  /api/entitlement/tier-unlocks-batch -- plural sibling of
+                                          ``/tier-unlocks``: returns the full
+                                          pricing-page marginal-unlock ladder
+                                          in one pass.
+  GET  /api/entitlement/upgrade-path  -- ordered marginal-unlock ladder from
+                                         the resolved tier upward (current-
+                                         user-relative sibling of
+                                         ``/tier-unlocks-batch``).
   GET  /api/runtimes                  -- the full runtime catalog.
   GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
 """
@@ -296,6 +304,60 @@ def api_entitlement_tier_unlocks_batch():
         return jsonify(
             {
                 "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/upgrade-path")
+def api_entitlement_upgrade_path():
+    """``GET /api/entitlement/upgrade-path`` -- ordered marginal-unlock
+    ladder from the resolved tier upward.
+
+    Current-user-relative sibling of ``/api/entitlement/tier-unlocks-batch``:
+    where the batch returns the full purchasable ladder, this returns only
+    tiers whose rank is *strictly above* the caller's resolved entitlement
+    rank, so an upgrade-CTA wizard renders its step sequence without
+    client-side filtering.
+
+    Response shape::
+
+        {
+          "path":              [<row>, ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` matches ``/api/entitlement/tier-unlocks`` exactly
+    (``tier``, ``tier_label``, ``tier_rank``, ``previous_tier``,
+    ``previous_tier_label``, ``previous_tier_rank``, ``features``,
+    ``runtimes``). Enterprise callers get an empty ``path`` (already at
+    the top). Never 5xxs: a resolver failure yields ``path: []`` with the
+    grace-shape envelope so the upgrade CTA keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "path": _ent.upgrade_path(),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_upgrade_path: error: %s", exc)
+        return jsonify(
+            {
+                "path": [],
                 "current_tier": "oss",
                 "current_tier_rank": 0,
                 "grace": True,

--- a/tests/test_entitlement_upgrade_path.py
+++ b/tests/test_entitlement_upgrade_path.py
@@ -1,0 +1,258 @@
+"""Tests for ``clawmetry.entitlements.upgrade_path`` +
+``GET /api/entitlement/upgrade-path``.
+
+Where :func:`tier_unlocks` answers "what does tier X unlock vs the tier
+below it" for one named tier, ``upgrade_path`` answers the
+current-user-relative question: "which purchasable tiers are still
+*above* me, in order, and what does each one first unlock as I climb".
+These tests pin the per-current-tier ladder + per-row marginal shape so
+a future reshuffle of ``_PURCHASABLE_TIERS`` / ``_TIER_RANK`` /
+``_TIER_FEATURES`` breaks loudly here instead of silently in an
+upgrade-CTA wizard.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _force_tier(monkeypatch, ent, tier: str):
+    """Pin :func:`get_entitlement` to a synthetic entitlement at ``tier``.
+
+    Each test asserts the ladder *above* a specific current tier, so we
+    bypass the live resolver and hand back a deterministic Entitlement.
+    """
+    synthetic = ent._build(tier, source="test")
+
+    def _stub(force: bool = False):  # noqa: ARG001
+        return synthetic
+
+    monkeypatch.setattr(ent, "get_entitlement", _stub)
+
+
+# -- shape -----------------------------------------------------------------
+
+
+def test_returns_list(ent):
+    path = ent.upgrade_path()
+    assert isinstance(path, list)
+
+
+def test_each_row_matches_tier_unlocks_shape(ent):
+    path = ent.upgrade_path()
+    expected_keys = {
+        "tier",
+        "tier_label",
+        "tier_rank",
+        "previous_tier",
+        "previous_tier_label",
+        "previous_tier_rank",
+        "features",
+        "runtimes",
+    }
+    for row in path:
+        assert set(row.keys()) == expected_keys
+
+
+def test_rows_byte_equal_to_singular_tier_unlocks(ent):
+    # Row equality with the singular endpoint -- the batch is a pure
+    # plural sibling, not a divergent path. If a future patch tries to
+    # compute "marginal vs previous step in the path" this trips.
+    path = ent.upgrade_path()
+    for row in path:
+        assert row == ent.tier_unlocks(row["tier"])
+
+
+# -- per-current-tier ladder -----------------------------------------------
+
+
+def test_oss_default_path_is_full_upper_ladder(ent):
+    # Fresh fixture resolves to OSS (rank 0) -- path covers everything above.
+    path = ent.upgrade_path()
+    tiers = [row["tier"] for row in path]
+    assert tiers == [
+        ent.TIER_CLOUD_STARTER,  # rank 1
+        ent.TIER_CLOUD_PRO,       # rank 2 (sorted by id, cloud_pro < pro)
+        ent.TIER_PRO,             # rank 2
+        ent.TIER_ENTERPRISE,      # rank 3
+    ]
+
+
+def test_floor_includes_both_rank0_siblings_excluded(ent):
+    # OSS and CLOUD_FREE are both rank 0 -- neither should appear in the
+    # path when current is OSS (or CLOUD_FREE), since rank must be
+    # *strictly greater* than current_rank.
+    path = ent.upgrade_path()
+    ids = {row["tier"] for row in path}
+    assert ent.TIER_OSS not in ids
+    assert ent.TIER_CLOUD_FREE not in ids
+
+
+def test_starter_path_drops_starter_and_below(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_CLOUD_STARTER)
+    path = ent.upgrade_path()
+    tiers = [row["tier"] for row in path]
+    assert tiers == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_cloud_pro_path_is_enterprise_only(monkeypatch, ent):
+    # Cloud Pro is rank 2 -- only Enterprise (rank 3) sits above.
+    # Self-hosted Pro (rank 2) is the same rank, so it's excluded.
+    _force_tier(monkeypatch, ent, ent.TIER_CLOUD_PRO)
+    path = ent.upgrade_path()
+    assert [row["tier"] for row in path] == [ent.TIER_ENTERPRISE]
+
+
+def test_self_hosted_pro_path_mirrors_cloud_pro(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_PRO)
+    path = ent.upgrade_path()
+    assert [row["tier"] for row in path] == [ent.TIER_ENTERPRISE]
+
+
+def test_enterprise_path_is_empty(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    assert ent.upgrade_path() == []
+
+
+def test_cloud_free_path_matches_oss_path(monkeypatch, ent):
+    # CLOUD_FREE shares rank 0 with OSS -- same ladder above.
+    _force_tier(monkeypatch, ent, ent.TIER_CLOUD_FREE)
+    cloud_free_tiers = [row["tier"] for row in ent.upgrade_path()]
+    # Reset and check OSS default.
+    ent.invalidate()
+    oss_tiers = [row["tier"] for row in ent.upgrade_path()]
+    assert cloud_free_tiers == oss_tiers
+
+
+# -- ordering / stability --------------------------------------------------
+
+
+def test_ordered_by_rank_then_tier_id(ent):
+    path = ent.upgrade_path()
+    ranks = [row["tier_rank"] for row in path]
+    assert ranks == sorted(ranks)
+    # Same-rank cluster (rank 2): cloud_pro < pro lexicographically.
+    rank2 = [row["tier"] for row in path if row["tier_rank"] == 2]
+    assert rank2 == sorted(rank2)
+
+
+def test_stable_across_calls(ent):
+    a = ent.upgrade_path()
+    b = ent.upgrade_path()
+    c = ent.upgrade_path()
+    assert a == b == c
+
+
+def test_trial_never_in_path(monkeypatch, ent):
+    # Trial is a promotional grant, not purchasable. The upgrade-CTA must
+    # never route to it -- mirrors tier_unlocks()'s posture.
+    _force_tier(monkeypatch, ent, ent.TIER_OSS)
+    ids = {row["tier"] for row in ent.upgrade_path()}
+    assert ent.TIER_TRIAL not in ids
+
+
+# -- safety ----------------------------------------------------------------
+
+
+def test_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.upgrade_path() == []
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    live_before = ent.get_entitlement().to_dict()
+    ent.upgrade_path()
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# -- API surface -----------------------------------------------------------
+
+
+def test_api_envelope_shape(client):
+    rv = client.get("/api/entitlement/upgrade-path")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == {
+        "path",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+
+
+def test_api_oss_default_path(client, ent):
+    rv = client.get("/api/entitlement/upgrade-path")
+    body = rv.get_json()
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_rank"] == 0
+    tiers = [row["tier"] for row in body["path"]]
+    assert tiers == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ]
+
+
+def test_api_row_parity_with_singular_endpoint(client, ent):
+    rv = client.get("/api/entitlement/upgrade-path")
+    body = rv.get_json()
+    for row in body["path"]:
+        single = client.get(
+            f"/api/entitlement/tier-unlocks?tier={row['tier']}",
+        ).get_json()
+        assert row == single
+
+
+def test_api_enterprise_path_is_empty(client, ent, monkeypatch):
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    rv = client.get("/api/entitlement/upgrade-path")
+    body = rv.get_json()
+    assert body["current_tier"] == ent.TIER_ENTERPRISE
+    assert body["path"] == []
+
+
+def test_api_never_5xxs_on_resolver_failure(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/upgrade-path")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["path"] == []
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

- Adds `upgrade_path()` to `clawmetry/entitlements.py`: returns the ordered marginal-unlock ladder of purchasable tiers strictly above the caller's current tier (sorted by rank then tier ID), with safe fallback to `[]` on resolver failure.
- Adds `GET /api/entitlement/upgrade-path` to `routes/entitlement.py`: returns `{path, current_tier, current_tier_rank, grace, enforced}` envelope; never 5xx.
- Adds 20 tests in `tests/test_entitlement_upgrade_path.py` covering shape, per-current-tier ladder, ordering/stability, trial exclusion, safety invariants, and API surface.

## Key behavior

- OSS (rank 0) path: `[cloud_starter, cloud_pro, pro, enterprise]`
- Enterprise (rank 3) path: `[]`
- `TIER_TRIAL` is never in the path (promotional grant, not purchasable)
- Each row in `path` is byte-equal to the corresponding `tier_unlocks()` result
- Both the function and the route fall back gracefully on resolver errors

## Test plan

- [ ] All 20 tests in `tests/test_entitlement_upgrade_path.py` pass
- [ ] `test_rows_byte_equal_to_singular_tier_unlocks` confirms no divergence from the singular endpoint
- [ ] `test_never_raises` and `test_api_never_5xxs_on_resolver_failure` confirm safe fallback
- [ ] `test_api_row_parity_with_singular_endpoint` confirms API-level parity

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvFGu28AmSAaUiwxrwcNXD)_