### PR TITLE
fix(security): constant-time token comparison + atomic config.json write

### DIFF
--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -11,6 +11,7 @@ import json
 import os
 import random
 import sys
+import tempfile
 import time
 import glob
 import base64
@@ -782,8 +783,17 @@ def load_config() -> dict:
 
 def save_config(data: dict) -> None:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    CONFIG_FILE.write_text(json.dumps(data, indent=2))
-    CONFIG_FILE.chmod(0o600)
+    content = json.dumps(data, indent=2).encode()
+    # Write to a temp file with 0o600 mode first, then atomically replace to
+    # avoid a window where the file exists but is world-readable (the race
+    # between write_text() and chmod()).
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=CONFIG_DIR, prefix=".config.tmp.")
+    try:
+        os.write(tmp_fd, content)
+        os.fchmod(tmp_fd, 0o600)
+    finally:
+        os.close(tmp_fd)
+    os.replace(tmp_path, CONFIG_FILE)
 
 
 def load_state() -> dict:

--- a/dashboard.py
+++ b/dashboard.py
@@ -14,6 +14,7 @@ https://github.com/vivekchand/clawmetry
 MIT License
 """
 
+import hmac
 import os
 import sys
 
@@ -554,7 +555,7 @@ def _fleet_check_key(req):
     if not FLEET_API_KEY:
         return True  # No key configured = open (for dev/testing)
     key = req.headers.get("X-Fleet-Key", "")
-    return key == FLEET_API_KEY
+    return hmac.compare_digest(key, FLEET_API_KEY)
 
 
 def _fleet_update_statuses():
@@ -9151,7 +9152,7 @@ def _fleet_check_key(req):
     if not FLEET_API_KEY:
         return True  # No key configured = open (for dev/testing)
     key = req.headers.get("X-Fleet-Key", "")
-    return key == FLEET_API_KEY
+    return hmac.compare_digest(key, FLEET_API_KEY)
 
 
 def _fleet_update_statuses():
@@ -12746,7 +12747,7 @@ def _check_auth():
     token = request.headers.get("Authorization", "").replace("Bearer ", "").strip()
     if not token:
         token = request.args.get("token", "").strip()
-    if token == GATEWAY_TOKEN:
+    if hmac.compare_digest(token, GATEWAY_TOKEN):
         return
     return jsonify({"error": "Unauthorized", "authRequired": True}), 401
 


### PR DESCRIPTION
## Summary

Two targeted security hardening fixes from the open security audit backlog (issues #1574, #1577):

- **Constant-time secret comparison** (`dashboard.py`): `_check_auth` and both copies of `_fleet_check_key` compared tokens with `==`, which leaks timing information enabling remote timing attacks against the gateway token and fleet key. Switched to `hmac.compare_digest` (stdlib, no new dep).

- **Atomic `config.json` write** (`clawmetry/sync.py`): `save_config` called `write_text()` then `chmod(0o600)`, leaving a window on multi-user hosts where `~/.clawmetry/config.json` (containing `api_key` + `encryption_key`) was world-readable. Now writes to a temp file via `mkstemp` (mode 0o600 via `fchmod` before close), then `os.replace()` atomically into the final path.

## Files changed

| File | Change |
|---|---|
| `dashboard.py` | `import hmac` added; 3 `==` comparisons -> `hmac.compare_digest` |
| `clawmetry/sync.py` | `import tempfile` added; `save_config` uses atomic write |

## Test plan

- [ ] `python3 -c "import py_compile; py_compile.compile('dashboard.py', doraise=True)"` passes (syntax OK)
- [ ] CI lint + test matrix green
- [ ] Manual: start dashboard with `GATEWAY_TOKEN=test123`, curl with wrong token gets 401, right token gets 200 -- same behaviour, now timing-safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcLmXWQDE4y8WUZd6cAdax

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcLmXWQDE4y8WUZd6cAdax)_