### PR TITLE
feat(entitlement): downgrade_path() + GET /api/entitlement/downgrade-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1298,6 +1298,80 @@ def upgrade_path() -> list[dict]:
         return []
 
 
+def downgrade_path() -> list[dict]:
+    """Ordered cumulative-loss ladder from the resolved tier downward.
+
+    Direction-flipped sibling of :func:`upgrade_path`: where the upgrade
+    ladder walks purchasable tiers strictly *above* the caller and folds
+    :func:`tier_unlocks` over each, this walks purchasable tiers strictly
+    *below* the caller and folds :meth:`Entitlement.downgrade_diff` over
+    each. The destination view a downgrade-warning CTA renders ("dropping
+    to Starter loses claude_code + custom_alerts; dropping to Free also
+    loses retention beyond 7 days and every paid runtime").
+
+    Rows are sorted by ``(-tier_rank, tier_id)`` so the closest-to-current
+    rung sits first and same-rank siblings (e.g. ``TIER_CLOUD_FREE`` and
+    ``TIER_OSS`` both at rank 0) appear in stable lexicographic order. Each
+    row is the ``downgrade_diff`` shape augmented with destination tier
+    metadata + the caller's current-tier context::
+
+        {
+          "target":             "<tier id>",
+          "target_label":       "<display>",
+          "target_rank":        <int>,
+          "current_tier":       "<resolved tier id>",
+          "current_tier_label": "<display>",
+          "current_tier_rank":  <int>,
+          "lost_features":      [...],
+          "lost_runtimes":      [...],
+        }
+
+    Cumulative not marginal: ``lost_features`` / ``lost_runtimes`` on each
+    row reflect the *full* delta between the caller's resolved entitlement
+    and that row's destination -- so the lists strictly grow as the path
+    descends and consumers can render "if you drop to X, here's everything
+    you'd lose" without summing rows client-side. The marginal-per-rung
+    view (analogue of :func:`tier_unlocks`) is a separate future helper;
+    this one mirrors :func:`upgrade_path`'s *selection* (current-tier-relative
+    catalogue walk) rather than its *row shape*.
+
+    Returns an empty list when the resolved tier already sits at the floor
+    of the purchasable ladder (no rung below to descend to) and never raises
+    -- a resolver failure short-circuits to ``[]`` so a downgrade-warning
+    surface keeps rendering instead of breaking.
+    """
+    try:
+        ent = get_entitlement()
+        current_rank = _TIER_RANK.get(ent.tier, -1)
+        current_label = tier_label(ent.tier)
+        ordered = sorted(
+            _PURCHASABLE_TIERS,
+            key=lambda t: (-_TIER_RANK.get(t, -1), t),
+        )
+        path: list[dict] = []
+        for tid in ordered:
+            cand_rank = _TIER_RANK.get(tid, -1)
+            if cand_rank < 0 or cand_rank >= current_rank:
+                continue
+            diff = ent.downgrade_diff(tid)
+            path.append(
+                {
+                    "target": tid,
+                    "target_label": tier_label(tid),
+                    "target_rank": cand_rank,
+                    "current_tier": ent.tier,
+                    "current_tier_label": current_label,
+                    "current_tier_rank": current_rank,
+                    "lost_features": list(diff.get("lost_features") or []),
+                    "lost_runtimes": list(diff.get("lost_runtimes") or []),
+                }
+            )
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: downgrade_path failed: %s", exc)
+        return []
+
+
 def resolution_diagnostic() -> dict:
     out: dict = {
         "license_path": _LICENSE_PATH,

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -67,6 +67,9 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          the resolved tier upward (current-
                                          user-relative sibling of
                                          ``/tier-unlocks-batch``).
+  GET  /api/entitlement/downgrade-path -- ordered cumulative-loss ladder from
+                                         the resolved tier downward (direction-
+                                         flipped sibling of ``/upgrade-path``).
   GET  /api/runtimes                  -- the full runtime catalog.
   GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
 """
@@ -355,6 +358,59 @@ def api_entitlement_upgrade_path():
         )
     except Exception as exc:
         logger.warning("api_entitlement_upgrade_path: error: %s", exc)
+        return jsonify(
+            {
+                "path": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/downgrade-path")
+def api_entitlement_downgrade_path():
+    """``GET /api/entitlement/downgrade-path`` -- ordered cumulative-loss
+    ladder from the resolved tier downward.
+
+    Direction-flipped sibling of ``/api/entitlement/upgrade-path``: rows
+    cover the purchasable tiers whose rank is strictly *below* the caller's
+    resolved entitlement rank, closest rung first. Lets a downgrade-warning
+    surface render every rung's full loss list without per-tier round-trips.
+
+    Response shape::
+
+        {
+          "path":              [<row>, ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` carries the destination tier metadata + the caller's
+    current-tier context + ``lost_features`` / ``lost_runtimes`` cumulative
+    over the gap (see :func:`clawmetry.entitlements.downgrade_path`). Floor
+    callers (OSS / Cloud Free) get an empty ``path`` -- no rung below to
+    descend to. Never 5xxs: a resolver failure yields ``path: []`` with the
+    grace-shape envelope so the downgrade CTA keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "path": _ent.downgrade_path(),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_downgrade_path: error: %s", exc)
         return jsonify(
             {
                 "path": [],

--- a/tests/test_entitlement_downgrade_path.py
+++ b/tests/test_entitlement_downgrade_path.py
@@ -1,0 +1,309 @@
+"""Tests for ``clawmetry.entitlements.downgrade_path`` +
+``GET /api/entitlement/downgrade-path``.
+
+Direction-flipped sibling of :mod:`test_entitlement_upgrade_path`: pins
+the per-current-tier *descending* ladder + the cumulative-loss row shape
+(rather than upgrade's marginal-unlock rows) so a downgrade-warning CTA
+keeps rendering when ``_PURCHASABLE_TIERS`` / ``_TIER_RANK`` /
+``_TIER_FEATURES`` shift underneath it.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+def _force_tier(monkeypatch, ent, tier: str):
+    """Pin :func:`get_entitlement` to a synthetic entitlement at ``tier``.
+
+    Each test asserts the ladder *below* a specific current tier, so we
+    bypass the live resolver and hand back a deterministic Entitlement.
+    """
+    synthetic = ent._build(tier, source="test")
+
+    def _stub(force: bool = False):  # noqa: ARG001
+        return synthetic
+
+    monkeypatch.setattr(ent, "get_entitlement", _stub)
+
+
+# -- shape -----------------------------------------------------------------
+
+
+def test_returns_list(ent):
+    path = ent.downgrade_path()
+    assert isinstance(path, list)
+
+
+def test_each_row_has_expected_keys(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    path = ent.downgrade_path()
+    assert path, "Enterprise should have rungs to descend to"
+    expected_keys = {
+        "target",
+        "target_label",
+        "target_rank",
+        "current_tier",
+        "current_tier_label",
+        "current_tier_rank",
+        "lost_features",
+        "lost_runtimes",
+    }
+    for row in path:
+        assert set(row.keys()) == expected_keys
+
+
+def test_row_lost_lists_match_downgrade_diff(monkeypatch, ent):
+    # Cumulative-loss rows: each row's lost_* must match the same
+    # downgrade_diff(target) the caller could compute directly. If a
+    # future patch quietly switches to "marginal vs previous step" this
+    # trips.
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    pinned = ent.get_entitlement()
+    path = ent.downgrade_path()
+    for row in path:
+        diff = pinned.downgrade_diff(row["target"])
+        assert row["lost_features"] == diff["lost_features"]
+        assert row["lost_runtimes"] == diff["lost_runtimes"]
+
+
+def test_current_tier_context_pinned_on_every_row(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_CLOUD_PRO)
+    path = ent.downgrade_path()
+    for row in path:
+        assert row["current_tier"] == ent.TIER_CLOUD_PRO
+        assert row["current_tier_rank"] == 2
+        assert row["current_tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+
+
+# -- per-current-tier ladder -----------------------------------------------
+
+
+def test_oss_default_path_is_empty(ent):
+    # Fresh fixture resolves to OSS (rank 0) -- nothing below to descend to.
+    assert ent.downgrade_path() == []
+
+
+def test_cloud_free_path_is_empty(monkeypatch, ent):
+    # Cloud Free shares rank 0 with OSS -- also has no rung below.
+    _force_tier(monkeypatch, ent, ent.TIER_CLOUD_FREE)
+    assert ent.downgrade_path() == []
+
+
+def test_starter_path_is_rank0_floor(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_CLOUD_STARTER)
+    tiers = [row["target"] for row in ent.downgrade_path()]
+    assert tiers == [ent.TIER_CLOUD_FREE, ent.TIER_OSS]
+
+
+def test_cloud_pro_path_drops_starter_then_floor(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_CLOUD_PRO)
+    tiers = [row["target"] for row in ent.downgrade_path()]
+    assert tiers == [
+        ent.TIER_CLOUD_STARTER,  # rank 1
+        ent.TIER_CLOUD_FREE,      # rank 0 (sorted by id, cloud_free < oss)
+        ent.TIER_OSS,             # rank 0
+    ]
+
+
+def test_self_hosted_pro_path_mirrors_cloud_pro(monkeypatch, ent):
+    # Pro is rank 2, same as Cloud Pro -- same descending ladder. Cloud Pro
+    # (the sibling at rank 2) is *not* included since rank must be
+    # strictly less than current_rank.
+    _force_tier(monkeypatch, ent, ent.TIER_PRO)
+    tiers = [row["target"] for row in ent.downgrade_path()]
+    assert tiers == [
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_OSS,
+    ]
+
+
+def test_enterprise_path_is_full_lower_ladder(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    tiers = [row["target"] for row in ent.downgrade_path()]
+    assert tiers == [
+        ent.TIER_CLOUD_PRO,       # rank 2 (sorted by id, cloud_pro < pro)
+        ent.TIER_PRO,             # rank 2
+        ent.TIER_CLOUD_STARTER,   # rank 1
+        ent.TIER_CLOUD_FREE,      # rank 0
+        ent.TIER_OSS,             # rank 0
+    ]
+
+
+# -- cumulative-loss semantics ---------------------------------------------
+
+
+def test_lost_lists_grow_as_path_descends(monkeypatch, ent):
+    # Cumulative loss strictly grows (or stays equal across same-rank
+    # siblings) as the destination drops further from current.
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    path = ent.downgrade_path()
+    prev_feats: set = set()
+    prev_runtimes: set = set()
+    for row in path:
+        this_feats = set(row["lost_features"])
+        this_runtimes = set(row["lost_runtimes"])
+        assert prev_feats.issubset(this_feats)
+        assert prev_runtimes.issubset(this_runtimes)
+        prev_feats = this_feats
+        prev_runtimes = this_runtimes
+
+
+def test_floor_row_loses_every_paid_runtime(monkeypatch, ent):
+    # The bottom rung (rank 0) sees every paid runtime in lost_runtimes
+    # when current sits at a paid-runtime-bearing tier.
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    path = ent.downgrade_path()
+    floor = path[-1]
+    assert floor["target_rank"] == 0
+    assert set(floor["lost_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_same_rank_siblings_have_identical_loss(monkeypatch, ent):
+    # cloud_pro and pro both at rank 2 -- dropping from Enterprise to
+    # either should lose the same cumulative set.
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    path = ent.downgrade_path()
+    by_target = {row["target"]: row for row in path}
+    cp = by_target[ent.TIER_CLOUD_PRO]
+    pro = by_target[ent.TIER_PRO]
+    assert cp["lost_features"] == pro["lost_features"]
+    assert cp["lost_runtimes"] == pro["lost_runtimes"]
+
+
+# -- ordering / stability --------------------------------------------------
+
+
+def test_ordered_by_rank_desc_then_tier_id(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    path = ent.downgrade_path()
+    ranks = [row["target_rank"] for row in path]
+    assert ranks == sorted(ranks, reverse=True)
+    # Same-rank cluster (rank 2): cloud_pro < pro lexicographically.
+    rank2 = [row["target"] for row in path if row["target_rank"] == 2]
+    assert rank2 == sorted(rank2)
+    # Same-rank cluster (rank 0): cloud_free < oss lexicographically.
+    rank0 = [row["target"] for row in path if row["target_rank"] == 0]
+    assert rank0 == sorted(rank0)
+
+
+def test_stable_across_calls(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    a = ent.downgrade_path()
+    b = ent.downgrade_path()
+    c = ent.downgrade_path()
+    assert a == b == c
+
+
+def test_trial_never_in_path(monkeypatch, ent):
+    # Trial is a promotional grant, not purchasable -- must never appear
+    # as a downgrade destination. Mirrors upgrade_path's posture.
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    ids = {row["target"] for row in ent.downgrade_path()}
+    assert ent.TIER_TRIAL not in ids
+
+
+# -- safety ----------------------------------------------------------------
+
+
+def test_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.downgrade_path() == []
+
+
+def test_does_not_mutate_live_entitlement(monkeypatch, ent):
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    live_before = ent.get_entitlement().to_dict()
+    ent.downgrade_path()
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# -- API surface -----------------------------------------------------------
+
+
+def test_api_envelope_shape(client):
+    rv = client.get("/api/entitlement/downgrade-path")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == {
+        "path",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+
+
+def test_api_oss_default_path_is_empty(client, ent):
+    rv = client.get("/api/entitlement/downgrade-path")
+    body = rv.get_json()
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_rank"] == 0
+    assert body["path"] == []
+
+
+def test_api_enterprise_path_is_full_lower_ladder(client, ent, monkeypatch):
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    rv = client.get("/api/entitlement/downgrade-path")
+    body = rv.get_json()
+    assert body["current_tier"] == ent.TIER_ENTERPRISE
+    targets = [row["target"] for row in body["path"]]
+    assert targets == [
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_OSS,
+    ]
+
+
+def test_api_row_lost_lists_match_module_path(client, ent, monkeypatch):
+    # API row equality with the module helper -- the route is a pure pass-
+    # through, not a re-derivation. A future divergence (extra fields, sort
+    # change) trips here before reaching the UI.
+    _force_tier(monkeypatch, ent, ent.TIER_ENTERPRISE)
+    rv = client.get("/api/entitlement/downgrade-path")
+    body = rv.get_json()
+    assert body["path"] == ent.downgrade_path()
+
+
+def test_api_never_5xxs_on_resolver_failure(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/downgrade-path")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["path"] == []
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["grace"] is True
+    assert body["enforced"] is False


### PR DESCRIPTION
## Summary

Direction-flipped sibling of the recently-added `upgrade_path()`: walks
purchasable tiers strictly *below* the resolved tier, closest rung first,
and folds `downgrade_diff` over each so a downgrade-warning CTA can
render every rung's full loss list without per-tier round-trips.

### Selection
Same current-tier-relative walk as `upgrade_path()`, mirrored: filter
`_PURCHASABLE_TIERS` to entries whose rank is strictly *less than* the
resolved entitlement rank, sort by `(-tier_rank, tier_id)`.

Same-rank siblings (cloud_free/oss at rank 0, cloud_pro/pro at rank 2)
both appear in stable lexicographic order so callers keyed off `target`
keep working; rank-deduped consumers can collapse client-side.

### Row shape
Each row carries destination tier metadata + the caller's current-tier
context + the cumulative `downgrade_diff(target)` payload:

```json
{
  "target":             "starter",
  "target_label":       "Starter",
  "target_rank":        1,
  "current_tier":       "enterprise",
  "current_tier_label": "Enterprise",
  "current_tier_rank":  3,
  "lost_features":      ["custom_alerts", ...],
  "lost_runtimes":      ["claude_code", ...]
}
```

**Cumulative not marginal:** `lost_*` reflects the *full* delta between
current and that destination — lists strictly grow as the path descends,
so consumers can render "if you drop to X, here's everything you'd
lose" without summing rows client-side. The marginal-per-rung view
(`tier_locks` analogue of `tier_unlocks`) is left for a follow-up; this
PR mirrors `upgrade_path`'s *selection* rather than its *row shape*.

### Envelope
```json
{
  "path":              [<row>, ...],
  "current_tier":      "...",
  "current_tier_rank": <int>,
  "grace":             <bool>,
  "enforced":          <bool>
}
```

Floor callers (OSS / Cloud Free) get `path: []` — no rung below to
descend to. Never 5xxs: a resolver failure yields `path: []` with the
grace-shape envelope so the downgrade-warning surface keeps rendering.

## Files changed
- `clawmetry/entitlements.py` — `+74` new `downgrade_path()` helper after `upgrade_path()`
- `routes/entitlement.py` — `+56` new `/api/entitlement/downgrade-path` endpoint after `/upgrade-path`, module docstring updated
- `tests/test_entitlement_downgrade_path.py` — `+309` new test file mirroring `test_entitlement_upgrade_path.py` (28 tests: shape, per-current-tier ladder, cumulative-loss semantics, ordering/stability, safety, API surface)

## Behaviour invariants
- Stays in **GRACE**. Every existing `allows_*` check still returns `True`. The new helper is read-only metadata and changes no current behaviour.
- Module-level helper short-circuits to `[]` on resolver failure; route returns the grace-shape envelope with `path: []`.
- Trial tier is excluded (mirrors `upgrade_path` / `tier_unlocks` posture — trial is a promotional grant, not purchasable).
- Same-rank siblings yield identical cumulative-loss rows (pinned by `test_same_rank_siblings_have_identical_loss`).
- Cumulative growth invariant pinned by `test_lost_lists_grow_as_path_descends`.

## Test plan
- [x] `pytest tests/test_entitlement_downgrade_path.py` — 28 new tests, all green locally
- [x] `pytest tests/ -k entitlement` — 737 entitlement tests pass on the sandbox (one preexisting collection error in `test_retention_prune.py` from missing `duckdb` in the sandbox env, unrelated)
- [x] `python -m py_compile` on all three changed files

## Local operator verification checklist
Since this remote agent can't touch the live daemon or browser:

1. `cp clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (or wherever the installed package lives — adjust Python version)
2. `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
3. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
4. `curl -s http://localhost:8900/api/entitlement/downgrade-path | jq` — expect `{"path": [], "current_tier": "oss", "current_tier_rank": 0, "grace": true, "enforced": false}` on a default OSS install
5. To exercise the populated ladder, temporarily `CLAWMETRY_LICENSE=...` or stub the resolver, then re-hit; expect rows in descending rank order with cumulative-growing `lost_*` lists
6. Decrypt the live cloud snapshot (operator-only) and confirm the new endpoint responds; spot-check a browser session to make sure no existing CTA card 500s now that the new route is registered
7. Make sure `pytest tests/test_entitlement_downgrade_path.py` is green against the operator's local checkout too (the sandbox is missing duckdb, the operator's env shouldn't be)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XGdTsg86yRTbCe9wcvJtno)_