### PR TITLE
feat(entitlement): tier_locks() + GET /api/entitlement/tier-locks

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1248,6 +1248,86 @@ def tier_unlocks_batch() -> list[dict]:
         return []
 
 
+def tier_locks(target_tier: str) -> dict | None:
+    """Per-tier marginal locks: features + runtimes that disappear when
+    you *descend to* ``target_tier`` from the next-higher purchasable
+    tier -- the marginal-loss companion to :func:`tier_unlocks`.
+
+    Where ``tier_unlocks(X)`` answers "what does X *first* unlock vs the
+    tier below it" (the upgrade-step marginal grant), ``tier_locks(X)``
+    answers "what does X *first* lose vs the tier above it" (the
+    downgrade-step marginal loss) -- the "what you'd be giving up by
+    stepping down to Starter from Pro" view a per-rung downgrade-warning
+    row uses, paired with :func:`downgrade_path` (cumulative state at a
+    rung) the way :func:`tier_unlocks` is paired with :func:`upgrade_path`.
+
+    The "tier above" is the *lowest*-rank entry in :data:`_PURCHASABLE_TIERS`
+    whose rank is strictly *greater* than ``target_tier``'s rank (trial is
+    excluded from purchasables, so a promotional grant never shows up as
+    the downgrade source). When ``target_tier`` sits at the ceiling
+    (:data:`TIER_ENTERPRISE`) ``next_tier`` is ``None`` and the marginal
+    collapses to empty loss lists -- there is no rung above to step down
+    from.
+
+    Set-identity: by construction the marginal loss at ``X`` equals the
+    marginal unlock at the next-higher purchasable tier above ``X``,
+    just attributed to the destination (the rung you land on) rather
+    than the source (the rung you stepped off). So
+    ``tier_locks(X)['lost_features']`` byte-equals
+    ``tier_unlocks(next_tier(X))['features']``, and likewise for runtimes
+    -- pinned in the test suite so a future reshuffle of the tier grant
+    sets can't silently desync the two views.
+
+    Returns ``None`` for an unknown tier id (including :data:`TIER_TRIAL`,
+    which is not purchasable) and never raises -- a resolver failure
+    short-circuits to ``None`` so a downgrade-warning surface keeps
+    rendering instead of 500-ing.
+    """
+    try:
+        tid = (target_tier or "").strip().lower()
+        if tid not in _PURCHASABLE_TIERS:
+            return None
+        target_rank = _TIER_RANK.get(tid, -1)
+        next_candidates = sorted(
+            (
+                c
+                for c in _PURCHASABLE_TIERS
+                if _TIER_RANK.get(c, -1) > target_rank
+            ),
+            key=lambda c: (_TIER_RANK.get(c, -1), c),
+        )
+        next_id: str | None = next_candidates[0] if next_candidates else None
+        this_feats = FREE_FEATURES | _TIER_FEATURES.get(tid, frozenset())
+        this_runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if tid in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        if next_id is None:
+            next_feats: frozenset = frozenset()
+            next_runtimes: frozenset = frozenset()
+        else:
+            next_feats = FREE_FEATURES | _TIER_FEATURES.get(next_id, frozenset())
+            next_runtimes = (
+                FREE_RUNTIMES | PAID_RUNTIMES
+                if next_id in _TIER_PAID_RUNTIMES
+                else FREE_RUNTIMES
+            )
+        return {
+            "tier": tid,
+            "tier_label": tier_label(tid),
+            "tier_rank": tier_rank(tid),
+            "next_tier": next_id,
+            "next_tier_label": tier_label(next_id) if next_id else None,
+            "next_tier_rank": tier_rank(next_id) if next_id else None,
+            "lost_features": sorted(next_feats - this_feats),
+            "lost_runtimes": sorted(next_runtimes - this_runtimes),
+        }
+    except Exception as exc:
+        logger.warning("entitlements: tier_locks failed: %s", exc)
+        return None
+
+
 def upgrade_path() -> list[dict]:
     """Ordered marginal-unlock ladder from the resolved tier upward.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -63,6 +63,11 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                           ``/tier-unlocks``: returns the full
                                           pricing-page marginal-unlock ladder
                                           in one pass.
+  GET  /api/entitlement/tier-locks    -- marginal-loss companion of
+                                         ``/tier-unlocks``: features + runtimes
+                                         that disappear when you step down to
+                                         the named tier from the next-higher
+                                         purchasable tier.
   GET  /api/entitlement/upgrade-path  -- ordered marginal-unlock ladder from
                                          the resolved tier upward (current-
                                          user-relative sibling of
@@ -313,6 +318,39 @@ def api_entitlement_tier_unlocks_batch():
                 "enforced": False,
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/tier-locks")
+def api_entitlement_tier_locks():
+    """``GET /api/entitlement/tier-locks?tier=<id>`` -- marginal locks for
+    ``tier`` (features + runtimes that disappear when descending from
+    the next-higher purchasable tier into ``tier``). Marginal-loss
+    companion to ``/tier-unlocks``: where the unlocks endpoint answers
+    "what does X first unlock vs the tier below it", this answers "what
+    does X first lose vs the tier above it" -- the per-rung
+    downgrade-warning row a step-down CTA renders, paired with
+    ``/downgrade-path`` the way ``/tier-unlocks`` is paired with
+    ``/upgrade-path``.
+
+    Returns ``404`` when the tier id is unknown (including ``trial`` --
+    not purchasable). Enterprise callers get a populated envelope with
+    ``next_tier=null`` and empty loss lists (nothing above to step down
+    from), not a 404 -- the tier is valid, the marginal just collapses
+    to nothing.
+    """
+    target = (request.args.get("tier") or "").strip().lower()
+    if not target:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tier_locks(target)
+        if body is None:
+            return jsonify({"error": "unknown tier", "tier": target}), 404
+        return jsonify(body)
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_locks: error: %s", exc)
+        return jsonify({"error": "tier-locks failed", "tier": target}), 500
 
 
 @bp_entitlement.route("/api/entitlement/upgrade-path")

--- a/tests/test_entitlement_tier_locks.py
+++ b/tests/test_entitlement_tier_locks.py
@@ -1,0 +1,356 @@
+"""Tests for ``clawmetry.entitlements.tier_locks`` +
+``GET /api/entitlement/tier-locks``.
+
+Where :func:`tier_unlocks` answers "what does tier X *first* unlock vs
+the tier below it" (the upgrade-step marginal grant), ``tier_locks``
+answers "what does tier X *first* lose vs the tier above it" (the
+downgrade-step marginal loss) -- the per-rung downgrade-warning row a
+step-down CTA renders. These tests pin the marginal-loss sets per tier
++ the set-identity invariant with ``tier_unlocks`` so a future reshuffle
+of ``_TIER_FEATURES`` / ``_TIER_PAID_RUNTIMES`` / ``_PURCHASABLE_TIERS``
+/ ``_TIER_RANK`` breaks loudly here instead of silently in the
+downgrade-warning copy.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- shape -----------------------------------------------------------------
+
+
+def test_returns_full_shape(ent):
+    body = ent.tier_locks(ent.TIER_CLOUD_STARTER)
+    assert set(body.keys()) == {
+        "tier",
+        "tier_label",
+        "tier_rank",
+        "next_tier",
+        "next_tier_label",
+        "next_tier_rank",
+        "lost_features",
+        "lost_runtimes",
+    }
+
+
+def test_tier_metadata_matches_target(ent):
+    body = ent.tier_locks(ent.TIER_CLOUD_STARTER)
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_STARTER)
+
+
+def test_lists_are_sorted(ent):
+    body = ent.tier_locks(ent.TIER_OSS)
+    assert body["lost_features"] == sorted(body["lost_features"])
+    assert body["lost_runtimes"] == sorted(body["lost_runtimes"])
+
+
+# -- per-tier marginals ----------------------------------------------------
+
+
+def test_enterprise_has_no_next_tier(ent):
+    # Enterprise sits at the ceiling (rank 3) -- no purchasable tier
+    # sits above, so the marginal-loss view collapses to empty lists.
+    body = ent.tier_locks(ent.TIER_ENTERPRISE)
+    assert body["next_tier"] is None
+    assert body["next_tier_label"] is None
+    assert body["next_tier_rank"] is None
+    assert body["lost_features"] == []
+    assert body["lost_runtimes"] == []
+
+
+def test_cloud_pro_loses_enterprise_features(ent):
+    # Stepping down to Cloud Pro (rank 2) from Enterprise (rank 3) drops
+    # every enterprise-only feature; paid runtimes stay (Cloud Pro is
+    # also a paid-runtime tier).
+    body = ent.tier_locks(ent.TIER_CLOUD_PRO)
+    assert body["next_tier"] == ent.TIER_ENTERPRISE
+    assert set(body["lost_features"]) == set(ent.ENTERPRISE_FEATURES)
+    assert body["lost_runtimes"] == []
+
+
+def test_self_hosted_pro_mirrors_cloud_pro(ent):
+    # TIER_PRO and TIER_CLOUD_PRO share rank 2 and grant set -- same
+    # marginal-loss vs the tier above (Enterprise).
+    body = ent.tier_locks(ent.TIER_PRO)
+    assert body["next_tier"] == ent.TIER_ENTERPRISE
+    assert set(body["lost_features"]) == set(ent.ENTERPRISE_FEATURES)
+    assert body["lost_runtimes"] == []
+
+
+def test_starter_loses_pro_only_features_no_paid_runtimes(ent):
+    # Stepping down to Starter (rank 1) from Cloud Pro (the next rank-2
+    # entry above by ``(rank, id)`` order) drops pro-only features; paid
+    # runtimes stay since Starter is also a paid-runtime tier.
+    body = ent.tier_locks(ent.TIER_CLOUD_STARTER)
+    assert body["next_tier"] == ent.TIER_CLOUD_PRO
+    assert set(body["lost_features"]) == set(ent.PRO_ONLY_FEATURES)
+    assert body["lost_runtimes"] == []
+
+
+def test_oss_floor_loses_starter_grant(ent):
+    # Stepping down to OSS (rank 0) from Cloud Starter (rank 1) drops
+    # every Starter-tier feature *and* every paid runtime.
+    body = ent.tier_locks(ent.TIER_OSS)
+    assert body["next_tier"] == ent.TIER_CLOUD_STARTER
+    assert set(body["lost_features"]) == set(ent.STARTER_FEATURES)
+    assert set(body["lost_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_cloud_free_floor_mirrors_oss(ent):
+    # CLOUD_FREE shares rank 0 with OSS -- same marginal-loss view vs
+    # the tier above (Cloud Starter). Trip-wire for rank-table drift.
+    body = ent.tier_locks(ent.TIER_CLOUD_FREE)
+    assert body["next_tier"] == ent.TIER_CLOUD_STARTER
+    assert set(body["lost_features"]) == set(ent.STARTER_FEATURES)
+    assert set(body["lost_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+# -- set-identity vs tier_unlocks -----------------------------------------
+
+
+def test_loss_at_X_equals_unlock_at_next_features(ent):
+    # The marginal loss at X must byte-equal the marginal unlock at the
+    # next-higher purchasable tier above X -- the two views attribute the
+    # same set difference to opposite endpoints of the rung. If this
+    # desyncs the downgrade-warning row will quietly disagree with the
+    # upgrade-CTA row above it.
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    ):
+        locks = ent.tier_locks(tid)
+        unlocks = ent.tier_unlocks(locks["next_tier"])
+        assert locks["lost_features"] == unlocks["features"]
+        assert locks["lost_runtimes"] == unlocks["runtimes"]
+
+
+def test_enterprise_has_no_set_identity_pair(ent):
+    # Enterprise has no rung above -- the set-identity invariant is
+    # vacuously empty, captured by both sides being [] / None.
+    body = ent.tier_locks(ent.TIER_ENTERPRISE)
+    assert body["next_tier"] is None
+    assert body["lost_features"] == []
+    assert body["lost_runtimes"] == []
+
+
+# -- next-tier selection (same-rank siblings) -----------------------------
+
+
+def test_starter_next_picks_cloud_pro_over_self_hosted_pro(ent):
+    # cloud_pro and pro share rank 2. Among strictly-higher candidates,
+    # selection sorts by ``(rank, id)`` and takes the first -- "cloud_pro"
+    # sorts before "pro" lexicographically.
+    body = ent.tier_locks(ent.TIER_CLOUD_STARTER)
+    assert body["next_tier"] == ent.TIER_CLOUD_PRO
+
+
+def test_trial_never_appears_as_next_tier(ent):
+    # Trial is excluded from _PURCHASABLE_TIERS; it must never be picked
+    # as the marginal-loss source even though its rank (2) ties with the
+    # paid Pro tiers.
+    seen = {ent.tier_locks(t)["next_tier"] for t in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    )}
+    assert ent.TIER_TRIAL not in seen
+
+
+# -- trial / unknown / safety ---------------------------------------------
+
+
+def test_trial_returns_none(ent):
+    # Trial is a promotional grant, not a purchasable plan -- callers must
+    # not route a downgrade-warning row to it. Mirrors ``tier_unlocks``'s
+    # posture (which also rejects non-purchasable tiers).
+    assert ent.tier_locks(ent.TIER_TRIAL) is None
+
+
+def test_unknown_tier_returns_none(ent):
+    assert ent.tier_locks("nonsense_tier_xyz") is None
+
+
+def test_empty_returns_none(ent):
+    assert ent.tier_locks("") is None
+    assert ent.tier_locks(None) is None  # type: ignore[arg-type]
+
+
+def test_lowercases_input(ent):
+    body = ent.tier_locks("CLOUD_STARTER")
+    assert body is not None
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_label", boom)
+    assert ent.tier_locks(ent.TIER_CLOUD_STARTER) is None
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    live_before = ent.get_entitlement().to_dict()
+    ent.tier_locks(ent.TIER_OSS)
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# -- round-trip vs catalogue ----------------------------------------------
+
+
+def test_marginal_losses_union_covers_paid_features(ent):
+    # Every paid + enterprise feature must first-lock at exactly one
+    # purchasable tier so the downgrade-warning roll-up has no gaps.
+    seen: set = set()
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ):
+        seen |= set(ent.tier_locks(tid)["lost_features"])
+    assert seen == set(ent.PAID_FEATURES) | set(ent.ENTERPRISE_FEATURES)
+
+
+def test_marginal_losses_union_covers_paid_runtimes(ent):
+    # Every paid runtime must first-lock at exactly one purchasable tier
+    # (OSS, today) -- same no-gap invariant on the downgrade direction.
+    seen: set = set()
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+    ):
+        seen |= set(ent.tier_locks(tid)["lost_runtimes"])
+    assert seen == set(ent.PAID_RUNTIMES)
+
+
+def test_marginal_losses_disjoint_across_distinct_ranks(ent):
+    # A feature must first-lock at exactly *one* rung so the
+    # downgrade-warning roll-up doesn't double-list it. Same-rank
+    # siblings legitimately share the same loss set (oss & cloud_free
+    # at rank 0; cloud_pro & pro at rank 2), so the disjointness check
+    # is across distinct ranks.
+    oss = set(ent.tier_locks(ent.TIER_OSS)["lost_features"])
+    starter = set(ent.tier_locks(ent.TIER_CLOUD_STARTER)["lost_features"])
+    cloud_pro = set(ent.tier_locks(ent.TIER_CLOUD_PRO)["lost_features"])
+    assert oss.isdisjoint(starter)
+    assert oss.isdisjoint(cloud_pro)
+    assert starter.isdisjoint(cloud_pro)
+
+
+def test_same_rank_siblings_have_identical_loss(ent):
+    # cloud_free / oss (rank 0) and cloud_pro / pro (rank 2) both produce
+    # identical loss rows -- same next_tier, same lost_* lists.
+    a = ent.tier_locks(ent.TIER_OSS)
+    b = ent.tier_locks(ent.TIER_CLOUD_FREE)
+    assert a["next_tier"] == b["next_tier"]
+    assert a["lost_features"] == b["lost_features"]
+    assert a["lost_runtimes"] == b["lost_runtimes"]
+    c = ent.tier_locks(ent.TIER_CLOUD_PRO)
+    d = ent.tier_locks(ent.TIER_PRO)
+    assert c["next_tier"] == d["next_tier"]
+    assert c["lost_features"] == d["lost_features"]
+    assert c["lost_runtimes"] == d["lost_runtimes"]
+
+
+# -- API surface ----------------------------------------------------------
+
+
+def test_api_returns_marginal_for_starter(client, ent):
+    rv = client.get(f"/api/entitlement/tier-locks?tier={ent.TIER_CLOUD_STARTER}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["next_tier"] == ent.TIER_CLOUD_PRO
+    assert set(body["lost_features"]) == set(ent.PRO_ONLY_FEATURES)
+    assert body["lost_runtimes"] == []
+
+
+def test_api_returns_marginal_for_oss(client, ent):
+    rv = client.get(f"/api/entitlement/tier-locks?tier={ent.TIER_OSS}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["next_tier"] == ent.TIER_CLOUD_STARTER
+    assert set(body["lost_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_api_enterprise_is_200_with_empty_loss(client, ent):
+    # Enterprise is a valid purchasable tier -- the marginal collapses
+    # to empty lists, not a 404.
+    rv = client.get(f"/api/entitlement/tier-locks?tier={ent.TIER_ENTERPRISE}")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["next_tier"] is None
+    assert body["lost_features"] == []
+    assert body["lost_runtimes"] == []
+
+
+def test_api_missing_tier_is_400(client):
+    rv = client.get("/api/entitlement/tier-locks")
+    assert rv.status_code == 400
+    assert "error" in rv.get_json()
+
+
+def test_api_unknown_tier_is_404(client):
+    rv = client.get("/api/entitlement/tier-locks?tier=nonsense_tier_xyz")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["tier"] == "nonsense_tier_xyz"
+
+
+def test_api_trial_is_404(client, ent):
+    # Trial is not purchasable -- the downgrade-CTA must never route to it.
+    rv = client.get(f"/api/entitlement/tier-locks?tier={ent.TIER_TRIAL}")
+    assert rv.status_code == 404
+
+
+def test_api_lowercases_query(client, ent):
+    rv = client.get("/api/entitlement/tier-locks?tier=CLOUD_STARTER")
+    assert rv.status_code == 200
+    assert rv.get_json()["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_api_row_parity_with_tier_unlocks_at_next(client, ent):
+    # The HTTP-level set-identity check: the locks payload at X carries
+    # the same loss lists as the unlocks payload at next_tier(X) carries
+    # for features/runtimes. Routes shouldn't diverge from the helper.
+    rv = client.get(f"/api/entitlement/tier-locks?tier={ent.TIER_CLOUD_STARTER}")
+    locks = rv.get_json()
+    rv2 = client.get(
+        f"/api/entitlement/tier-unlocks?tier={locks['next_tier']}",
+    )
+    unlocks = rv2.get_json()
+    assert locks["lost_features"] == unlocks["features"]
+    assert locks["lost_runtimes"] == unlocks["runtimes"]


### PR DESCRIPTION
## Summary

Marginal-loss companion to `tier_unlocks()`: where `tier_unlocks(X)`
answers "what does X *first* unlock vs the tier below it" (the
upgrade-step marginal grant), `tier_locks(X)` answers "what does X
*first* lose vs the tier above it" (the downgrade-step marginal
loss) — the per-rung downgrade-warning row a step-down CTA renders,
paired with `downgrade_path` the way `tier_unlocks` is paired with
`upgrade_path`.

Closes the marginal-per-rung gap explicitly called out in the recent
`downgrade_path` PR (#3247): *"the marginal-per-rung view (`tier_locks`
analogue of `tier_unlocks`) is left for a follow-up."*

### Selection
The "tier above" is the *lowest*-rank entry in `_PURCHASABLE_TIERS`
whose rank is strictly *greater* than `target_tier`'s rank.
Same-rank siblings (e.g. `cloud_pro` / `pro` both at rank 2) are
disambiguated by lexicographic id, so `cloud_starter`'s
marginal-loss source is `cloud_pro` (since `"cloud_pro" < "pro"`).
Enterprise sits at the ceiling, so `next_tier=None` and the loss
lists collapse to empty. Trial is excluded from selection (mirrors
`tier_unlocks`'s posture — a promotional grant must not surface as a
downgrade source).

### Row shape (parallel to `tier_unlocks`)
```json
{
  "tier":            "<id>",
  "tier_label":      "<display>",
  "tier_rank":        <int>,
  "next_tier":       "<id of tier above>" | null,
  "next_tier_label": "<display>" | null,
  "next_tier_rank":   <int> | null,
  "lost_features":   [...],
  "lost_runtimes":   [...]
}
```

### Set-identity invariant
By construction `tier_locks(X)['lost_features']` byte-equals
`tier_unlocks(next_tier(X))['features']` (and likewise for runtimes)
— the two views attribute the same set difference to opposite
endpoints of the rung. Pinned in the test suite so a future
reshuffle of the tier grant sets can't silently desync the
downgrade-warning copy from the upgrade-CTA copy.

## Files changed
- `clawmetry/entitlements.py` — `+81` new `tier_locks()` helper after `tier_unlocks_batch()`.
- `routes/entitlement.py` — `+37` new `/api/entitlement/tier-locks` endpoint after `/tier-unlocks-batch`, module docstring updated.
- `tests/test_entitlement_tier_locks.py` — `+298` new test file mirroring `test_entitlement_tier_unlocks.py` (31 tests: shape, per-tier marginals, set-identity vs `tier_unlocks`, same-rank-sibling selection, trial / unknown / safety, catalogue round-trip, API surface).

## Behaviour invariants
- Stays in **GRACE**. `tier_locks` is read-only metadata; no `allows_*` check flips, no current behaviour changes.
- Helper short-circuits to `None` on resolver failure; HTTP wrapper short-circuits to `500` with an error payload only on hard exception (mirrors `/tier-unlocks`).
- Enterprise is a valid purchasable tier, so `GET /api/entitlement/tier-locks?tier=enterprise` returns **`200`** with empty loss lists (not `404`) — the marginal collapses to nothing but the tier is real.
- Unknown / blank / trial tiers return `404` (singular) / `None` (helper).

## Test plan
- [x] `pytest tests/test_entitlement_tier_locks.py` — 31 new tests, all green locally.
- [x] `pytest tests/ -k entitlement` — 768 entitlement tests pass on the sandbox (one preexisting collection error in `test_retention_prune.py` from missing `duckdb` in the sandbox env, unrelated).
- [x] `python -m py_compile` on all three changed files.

## Local operator verification checklist
Since this remote agent can't touch the live daemon or browser:

1. `cp clawmetry/entitlements.py routes/entitlement.py ~/.clawmetry/lib/python3.11/site-packages/clawmetry/` (adjust Python version to match the installed package layout)
2. `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
3. `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
4. `curl -s 'http://localhost:8900/api/entitlement/tier-locks?tier=cloud_starter' | jq` — expect `next_tier: "cloud_pro"`, `lost_features: [<pro-only features>]`, `lost_runtimes: []`.
5. `curl -s 'http://localhost:8900/api/entitlement/tier-locks?tier=oss' | jq` — expect `next_tier: "cloud_starter"`, `lost_runtimes` covers every paid runtime.
6. `curl -s 'http://localhost:8900/api/entitlement/tier-locks?tier=enterprise' | jq` — expect `next_tier: null`, empty loss lists, **`200`** (not `404`).
7. `curl -s 'http://localhost:8900/api/entitlement/tier-locks?tier=trial' -w '\n%{http_code}\n'` — expect `404` (trial is not purchasable, mirrors `/tier-unlocks` posture).
8. Decrypt the live cloud snapshot (operator-only) and confirm the new endpoint responds; spot-check a browser session to make sure no existing CTA card 500s now that the new route is registered.
9. `pytest tests/test_entitlement_tier_locks.py` against the operator's local checkout (the sandbox is missing `duckdb`, the operator's env shouldn't be).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NtZ5tUue5apyuFrZ31WESU)_