### PR TITLE
fix: preserve openapi key order in /openapi.json (Flask ≤2.1 compat)

### DIFF
--- a/helpers/openapi.py
+++ b/helpers/openapi.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import json
 import re
-from flask import Blueprint, jsonify, current_app
+from flask import Blueprint, Response, current_app
 
 bp_openapi = Blueprint("openapi", __name__)
 
@@ -414,7 +414,12 @@ def openapi_json():
     v1 = (request.args.get("v1_only") == "1"
           or getattr(current_app, '_cloud_mode', False)
           or bool(current_app.config.get("CLOUD_MODE")))
-    return jsonify(build_spec(current_app, v1_only=v1))
+    # Use json.dumps (not jsonify) so insertion order is preserved regardless
+    # of Flask version — jsonify sorts keys alphabetically on Flask ≤2.1,
+    # which buries the required "openapi" field after the large "components"
+    # block and breaks any validator reading only the first N bytes.
+    return Response(json.dumps(build_spec(current_app, v1_only=v1)),
+                    mimetype="application/json")
 
 
 @bp_openapi.route("/api/docs")


### PR DESCRIPTION
## Summary

- Flask ≤2.1 has `JSON_SORT_KEYS=True` by default, causing `jsonify()` to sort OpenAPI spec keys alphabetically — putting `"components"` before `"openapi"` (c < o), which buries the required `"openapi"` field thousands of bytes into the response.
- Switches `helpers/openapi.py` to `Response(json.dumps(spec), mimetype="application/json")` so Python's insertion-order-preserving dict serialization is used regardless of Flask version.
- Zero behavior change for Flask ≥2.2 users (already no-sort by default); fixes broken validators and watchdog checks for anyone on Flask 2.0–2.1.

Closes #3196

## Test plan

- `python3 -c "import ast; ast.parse(open('helpers/openapi.py').read()); print('OK')"` — syntax clean ✅
- Verify `json.dumps({'openapi': '3.1.0', 'components': {...}, ...})` outputs `openapi` as the first key ✅
- Manual: `curl -s http://localhost:8900/openapi.json | python3 -c "import json,sys; d=json.load(sys.stdin); assert list(d)[0]=='openapi', list(d)[:3]; print('OK')"` should pass on any Flask version.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuUwzDt9omagX7kFBGg2xS)_