### PR TITLE
fix: append :11434 to Ollama host when no port is specified

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -157,10 +157,16 @@ def _resolve_ollama_host() -> str:
     Mirrors getOllamaModelOptions() priority in nemoclaw/dist/lib/inference/local.js:
     OLLAMA_HOST_DOCKER_INTERNAL → OLLAMA_LOCALHOST → http://localhost:11434.
     """
+    from urllib.parse import urlparse
     for var in ("OLLAMA_HOST_DOCKER_INTERNAL", "OLLAMA_LOCALHOST"):
         val = os.environ.get(var, "").strip()
-        if val:
-            return val if val.startswith("http") else f"http://{val}"
+        if not val:
+            continue
+        if not val.startswith("http"):
+            val = f"http://{val}"
+        if not urlparse(val).port:
+            val = f"{val}:11434"
+        return val
     return "http://localhost:11434"
 
 

--- a/tests/test_obs_gap_nemoclaw_ollama_3201.py
+++ b/tests/test_obs_gap_nemoclaw_ollama_3201.py
@@ -47,6 +47,13 @@ def test_resolve_ollama_host_prepends_http_scheme(monkeypatch):
     assert _resolve_ollama_host() == "http://172.17.0.1:11434"
 
 
+def test_resolve_ollama_host_bare_ip_gets_default_port(monkeypatch):
+    """Bare IP/hostname without port must get :11434, not :80 (regression #3253)."""
+    monkeypatch.setenv("OLLAMA_HOST_DOCKER_INTERNAL", "172.17.0.1")
+    monkeypatch.delenv("OLLAMA_LOCALHOST", raising=False)
+    assert _resolve_ollama_host() == "http://172.17.0.1:11434"
+
+
 # ---------------------------------------------------------------------------
 # _list_ollama_models — HTTP path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3253

## Summary

- `_resolve_ollama_host()` in `clawmetry/adapters/openclaw.py` returned `http://bare-hostname` (no port) when `OLLAMA_HOST_DOCKER_INTERNAL` or `OLLAMA_LOCALHOST` was set to a bare IP or hostname, causing `_list_ollama_models()` to probe port 80 and silently return `[]`.
- Fix uses `urllib.parse.urlparse` to detect a missing port and appends `:11434`, mirroring the nemoclaw harness behaviour (`getOllamaModelOptions` always appends `:11434`).
- Adds one regression test (`test_resolve_ollama_host_bare_ip_gets_default_port`) covering the bare-IP-without-port case. All 15 tests in the suite pass.

## Test plan

- [ ] `python -m pytest tests/test_obs_gap_nemoclaw_ollama_3201.py -v` — all 15 pass (confirmed locally)
- [ ] Values already containing an explicit port (`172.17.0.1:11434`, `http://myhost:11434`) are unchanged (covered by existing tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFAKNgJW6Ut6qbJnGFDJtc)_