### PR TITLE
fix: tag NeMo catalog guardrail dispatches in list_events() extra (#3254)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1029,6 +1029,28 @@ class OpenClawAdapter(AgentAdapter):
                             _sr = obj.get("slow_reply") or obj.get("slowReply") or obj.get("is_slow")
                             if _sr:
                                 extra["slow_reply"] = True
+                            # NeMo Guardrails catalog dispatch tag (#3254):
+                            # toolMetas carries tool_use blocks from the assistant
+                            # turn; names in _NEMOCLAW_CATALOG_TOOLS are guardrail
+                            # control-plane calls, not real agent actions.
+                            _tool_metas = (
+                                obj.get("toolMetas")
+                                or (obj.get("data") or {}).get("toolMetas")
+                                or []
+                            )
+                            if isinstance(_tool_metas, list):
+                                _catalog = [
+                                    m["name"] for m in _tool_metas
+                                    if isinstance(m, dict)
+                                    and m.get("name") in _NEMOCLAW_CATALOG_TOOLS
+                                ]
+                                if _catalog:
+                                    extra["hasCatalogTools"] = True
+                                    extra["catalogToolNames"] = _catalog
+                            # Top-level tool.call events store the name at obj["name"].
+                            _tname = obj.get("name") or (obj.get("data") or {}).get("name")
+                            if isinstance(_tname, str) and _tname in _NEMOCLAW_CATALOG_TOOLS:
+                                extra["isCatalogTool"] = True
                             msg = obj.get("message")
                             if isinstance(msg, str):
                                 content_text = msg

--- a/tests/test_openclaw_list_events.py
+++ b/tests/test_openclaw_list_events.py
@@ -541,3 +541,102 @@ def test_first_event_latency_from_harness_field():
     assert attrs_first.get("llm.slow_reply") is True
     assert "llm.first_event_latency_ms" not in attrs_second
     assert "llm.slow_reply" not in attrs_second
+
+
+# ── NeMo Guardrails catalog dispatch tagging (issue #3254) ───────────────────
+
+
+def test_list_events_tags_catalog_tools_in_tool_metas(isolated_store):
+    """model.completed events whose toolMetas include a catalog guardrail name
+    get hasCatalogTools=True and catalogToolNames populated in extra (#3254).
+
+    The NeMo Guardrails tool catalog injects tool_search, tool_describe, and
+    tool_call as control-plane meta-tools. When an assistant turn contains one
+    or more of these as tool_use blocks, sync.py stores them in toolMetas.
+    list_events() must flag these so callers can filter/style them separately
+    from real agent tool calls.
+    """
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-CATALOG",
+        "event_type": "model.completed",
+        "ts": _t.time(),
+        "model": "nv/llama3-70b",
+        "token_count": 10,
+        "data": {
+            "type": "model.completed",
+            "toolMetas": [
+                {"id": "tu_1", "name": "tool_search", "input": {"query": "bash"}},
+                {"id": "tu_2", "name": "bash", "input": {"command": "ls"}},
+            ],
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-CATALOG")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("hasCatalogTools") is True
+    assert ex.get("catalogToolNames") == ["tool_search"]
+
+
+def test_list_events_no_catalog_flag_for_real_tools(isolated_store):
+    """model.completed events whose toolMetas contain only real tool names
+    must NOT get the catalog flag — only catalog guardrail names trigger it (#3254)."""
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-REAL",
+        "event_type": "model.completed",
+        "ts": _t.time(),
+        "data": {
+            "type": "model.completed",
+            "toolMetas": [
+                {"id": "tu_1", "name": "bash", "input": {"command": "ls"}},
+                {"id": "tu_2", "name": "read_file", "input": {"path": "/etc/hosts"}},
+            ],
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-REAL")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert "hasCatalogTools" not in ex
+    assert "catalogToolNames" not in ex
+
+
+def test_list_events_tags_top_level_catalog_tool_call(isolated_store):
+    """Top-level tool.call events (rare; name at obj['name']) also get
+    isCatalogTool=True when the tool is a catalog guardrail dispatch (#3254)."""
+    import uuid, time as _t
+    isolated_store.ingest({
+        "id": str(uuid.uuid4()),
+        "node_id": "agent+test-node",
+        "agent_id": "main",
+        "agent_type": "openclaw",
+        "session_id": "sess-TOP",
+        "event_type": "tool.call",
+        "ts": _t.time(),
+        "data": {
+            "type": "tool.call",
+            "name": "tool_describe",
+            "input": {"tool": "bash"},
+        },
+    })
+    _wait_flush(isolated_store)
+
+    from clawmetry.adapters.openclaw import OpenClawAdapter
+    events = OpenClawAdapter().list_events("sess-TOP")
+    assert len(events) == 1
+    ex = events[0].extra
+    assert ex.get("isCatalogTool") is True


### PR DESCRIPTION
## Summary

`_NEMOCLAW_CATALOG_TOOLS` (`frozenset{"tool_search", "tool_describe", "tool_call"}`) was defined in `clawmetry/adapters/openclaw.py` at module level but never consulted inside `list_events()`. NeMo Guardrails catalog control-plane tool dispatches reached every dashboard route indistinguishable from real agent tool calls — the tagging already done in `_build_spans_from_events()` / `routes/tracing.py` had no equivalent in the live event stream.

## Changes

- `clawmetry/adapters/openclaw.py` — inside the data-blob parsing block of `list_events()`, check each event's `toolMetas` list against `_NEMOCLAW_CATALOG_TOOLS`; when matches are found set `extra["hasCatalogTools"] = True` and `extra["catalogToolNames"] = [<matched names>]`. Also handle rare top-level `tool.call` events via `obj["name"]` → `extra["isCatalogTool"] = True`.
- `tests/test_openclaw_list_events.py` — three new tests: mixed toolMetas (catalog + real) get `hasCatalogTools`, pure-real toolMetas don't, top-level `tool.call` catalog events get `isCatalogTool`.

## Test plan

- [ ] `python -m pytest tests/test_openclaw_list_events.py -v` — all tests pass (including 3 new ones)
- [ ] Events with `tool_search`/`tool_describe`/`tool_call` in `toolMetas` get `hasCatalogTools=True` and the correct `catalogToolNames`
- [ ] Events with only real tool names (e.g. `bash`) get neither flag

## Bot meta

<!-- bot-autofix -->
Draft PR opened autonomously based on the plan in #3254. Marked draft for human review — mark Ready for Review once happy.

Closes #3254

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwUProaoHSkBnCbFjnUfh3)_