### PR TITLE
fix: surface tool_result.details in list_events() Event.extra (#3255)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -1066,6 +1066,29 @@ class OpenClawAdapter(AgentAdapter):
                                         _res = max(0, int(_tt) - _split)
                                         if _res:
                                             extra["reasoningTokens"] = _res
+                            # Walk message.content blocks for tool_result.details (#3255).
+                            # nemoClawBuildToolResult attaches a `details` dict on every
+                            # tool_result block; _build_spans_from_events() already reads
+                            # it for OTel spans but list_events() was not propagating it
+                            # to Event.extra, so the live event stream lacked this data.
+                            if isinstance(msg, dict):
+                                _content = msg.get("content")
+                                if isinstance(_content, list):
+                                    _tr_details = [
+                                        {
+                                            "tool_use_id": (
+                                                blk.get("tool_use_id")
+                                                or blk.get("toolUseId")
+                                            ),
+                                            "details": blk["details"],
+                                        }
+                                        for blk in _content
+                                        if isinstance(blk, dict)
+                                        and blk.get("type") == "tool_result"
+                                        and blk.get("details") is not None
+                                    ]
+                                    if _tr_details:
+                                        extra["tool_result_details"] = _tr_details
                     except Exception:
                         pass
                 # #2794: DB token_count derives from input+output and under-counts


### PR DESCRIPTION
Closes #3255

## What

`nemoClawBuildToolResult` attaches a structured `details` dict to every `tool_result` content block. `_build_spans_from_events()` already extracts it for OTel spans, but `list_events()` only read the top-level `message` string and `usage` sub-dict — the `details` payload was silently dropped from `Event.extra`, so the live event stream (brain-stream, dashboard routes) never saw it.

## Change

In `clawmetry/adapters/openclaw.py` → `list_events()`, after the existing `if usage:` token-extraction block, walk `msg["content"]` blocks. For each block where `type == "tool_result"` and `details is not None`, collect `{tool_use_id, details}` into `extra["tool_result_details"]`. (+23 lines, no new dependencies.)

## Why it's safe

- Events without `nemoClawBuildToolResult` (standard openclaw) produce no `tool_result_details` key — callers already guard for missing keys.
- Mirrors the existing logic in `_build_spans_from_events()` (L1197–1201 same file), so behaviour is consistent across both paths.
- Wrapped in the existing `try/except` so a malformed blob never breaks the event stream.

## Test plan

- [ ] Run a NemoClaw session that uses catalog tools (`tool_search`/`tool_describe`/`tool_call`); confirm `Event.extra["tool_result_details"]` is populated in the brain-stream SSE payload.
- [ ] Run a standard OpenClaw session; confirm no `tool_result_details` key appears and no errors are raised.
- [ ] `make lint` on `clawmetry/adapters/openclaw.py` → clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgZvUBPGhtAkjcHX5C1ewc)_