### PR TITLE
feat(entitlement): tiers_for_feature/runtime + /api/entitlement/tiers-for

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1646,6 +1646,110 @@ def min_tier_for_runtime(runtime: str) -> str | None:
     return None
 
 
+def _tier_row(tier: str) -> dict:
+    return {
+        "id": tier,
+        "label": tier_label(tier),
+        "rank": tier_rank(tier),
+        "purchasable": tier in _PURCHASABLE_TIERS,
+    }
+
+
+def tiers_for_feature(feature: str) -> dict | None:
+    """Inverse of :func:`min_tier_for_feature`: list **every** tier that
+    grants ``feature`` (not just the cheapest one).
+
+    Where ``min_tier_for_feature`` answers "what's the cheapest tier
+    that unlocks X" -- a single id used by the upgrade-CTA -- this
+    helper returns the full "Available in: Pro, Self-hosted Pro,
+    Trial, Enterprise" availability list a pricing-page row or
+    feature tooltip renders. Walks :data:`_TIER_ORDER` so the
+    promotional ``trial`` tier appears alongside the purchasable
+    plans (each row carries ``purchasable`` so the UI can dim or
+    badge it).
+
+    Rows are sorted by ``(tier_rank, tier_id)`` for stable output.
+    ``min_tier`` matches :func:`min_tier_for_feature` (trial
+    excluded -- not a plan a customer picks).
+
+    Returns ``None`` for empty / unknown feature ids and never raises.
+    """
+    try:
+        f = (feature or "").strip().lower()
+        if not f or f not in ALL_FEATURES:
+            return None
+        carriers: list[str] = []
+        for tier in _TIER_ORDER:
+            paid_feats = _TIER_FEATURES.get(tier, frozenset())
+            if f in FREE_FEATURES or f in paid_feats:
+                carriers.append(tier)
+        rows = [
+            _tier_row(t)
+            for t in sorted(carriers, key=lambda t: (tier_rank(t), t))
+        ]
+        min_t = min_tier_for_feature(f)
+        return {
+            "item": f,
+            "kind": "feature",
+            "label": feature_label(f),
+            "free": f in FREE_FEATURES,
+            "min_tier": min_t,
+            "min_tier_label": tier_label(min_t) if min_t else None,
+            "min_tier_rank": tier_rank(min_t) if min_t else None,
+            "tiers": rows,
+        }
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_feature failed: %s", exc)
+        return None
+
+
+def tiers_for_runtime(runtime: str) -> dict | None:
+    """Inverse of :func:`min_tier_for_runtime`: list every tier that
+    grants ``runtime``.
+
+    FREE_RUNTIMES are granted at every tier in :data:`_TIER_ORDER`;
+    PAID_RUNTIMES are granted at every tier in
+    :data:`_TIER_PAID_RUNTIMES` (trial, starter, cloud_pro, self-hosted
+    pro, enterprise). Rows sorted ``(rank, id)``; trial appears
+    alongside purchasable plans with ``purchasable=False`` so the UI
+    can render it as a separate promotional badge.
+
+    Returns ``None`` for empty / unknown runtime ids and never raises.
+    Accepts the canonical id (``claude_code``) or any registered alias
+    (``claude-code``).
+    """
+    try:
+        rt = canonical_runtime(runtime)
+        if not rt or rt not in ALL_RUNTIMES:
+            return None
+        carriers: list[str] = []
+        is_free = rt in FREE_RUNTIMES
+        is_paid = rt in PAID_RUNTIMES
+        for tier in _TIER_ORDER:
+            if is_free:
+                carriers.append(tier)
+            elif is_paid and tier in _TIER_PAID_RUNTIMES:
+                carriers.append(tier)
+        rows = [
+            _tier_row(t)
+            for t in sorted(carriers, key=lambda t: (tier_rank(t), t))
+        ]
+        min_t = min_tier_for_runtime(rt)
+        return {
+            "item": rt,
+            "kind": "runtime",
+            "label": runtime_label(rt),
+            "free": is_free,
+            "min_tier": min_t,
+            "min_tier_label": tier_label(min_t) if min_t else None,
+            "min_tier_rank": tier_rank(min_t) if min_t else None,
+            "tiers": rows,
+        }
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_runtime failed: %s", exc)
+        return None
+
+
 def min_tier_for_channel_count(count: int) -> str | None:
     """Return the cheapest *purchasable* tier id whose channel-adapter cap fits
     ``count`` configured channels. Closes the symmetry gap with
@@ -2116,6 +2220,25 @@ _FEATURE_TIER_RANK = {
 }
 
 
+def _feature_tier_ids(feature: str) -> list[str]:
+    """Compact id-only sibling of :func:`tiers_for_feature` (just the
+    ladder of tier ids that grant ``feature``). Used to enrich the
+    feature catalog row so a matrix UI doesn't need a per-row roundtrip
+    to ``/api/entitlement/tiers-for`` to know which columns to tick."""
+    body = tiers_for_feature(feature)
+    if body is None:
+        return []
+    return [row["id"] for row in body.get("tiers", [])]
+
+
+def _runtime_tier_ids(runtime: str) -> list[str]:
+    """Compact id-only sibling of :func:`tiers_for_runtime`."""
+    body = tiers_for_runtime(runtime)
+    if body is None:
+        return []
+    return [row["id"] for row in body.get("tiers", [])]
+
+
 def feature_catalog() -> list[dict]:
     try:
         ent = get_entitlement()
@@ -2138,6 +2261,7 @@ def feature_catalog() -> list[dict]:
                 "id": fid,
                 "label": feature_label(fid),
                 "tier": tier,
+                "tiers": _feature_tier_ids(fid),
                 "free": is_free,
                 "allowed": allowed,
                 "locked": (not is_free) and (not allowed),
@@ -2162,6 +2286,7 @@ def runtime_catalog() -> list[dict]:
                 "label": runtime_label(rt),
                 "free": True,
                 "tier": "free",
+                "tiers": _runtime_tier_ids(rt),
                 "allowed": True,
                 "locked": False,
                 "entitled": True,
@@ -2175,6 +2300,7 @@ def runtime_catalog() -> list[dict]:
                 "label": runtime_label(rt),
                 "free": False,
                 "tier": "starter",
+                "tiers": _runtime_tier_ids(rt),
                 "allowed": allowed,
                 "locked": not allowed,
                 "entitled": ent.entitled_runtime(rt),

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -75,6 +75,13 @@ is the single source of truth -- handlers never re-derive tier logic here.
   GET  /api/entitlement/downgrade-path -- ordered cumulative-loss ladder from
                                          the resolved tier downward (direction-
                                          flipped sibling of ``/upgrade-path``).
+  GET  /api/entitlement/tiers-for     -- inverse of ``/required-tier``: the
+                                         full ladder of tiers that grant a
+                                         ``feature=`` or ``runtime=`` key
+                                         (the "Available in: Pro,
+                                         Self-hosted Pro, Trial, Enterprise"
+                                         availability list a pricing-page
+                                         row or feature tooltip needs).
   GET  /api/runtimes                  -- the full runtime catalog.
   GET  /api/tiers                     -- the full tier ladder with per-tier metadata.
 """
@@ -1131,6 +1138,48 @@ def api_entitlement_diagnostic():
                 "error": str(exc),
             }
         )
+
+
+@bp_entitlement.route("/api/entitlement/tiers-for")
+def api_entitlement_tiers_for():
+    """``GET /api/entitlement/tiers-for?feature=<id>`` (or
+    ``?runtime=<id>``) -- inverse of ``/required-tier``: returns the
+    full ladder of tiers that grant the named feature or runtime, not
+    just the cheapest one. The "Available in: Pro, Self-hosted Pro,
+    Trial, Enterprise" availability list a pricing-page row or feature
+    tooltip needs.
+
+    Exactly one of ``feature=`` or ``runtime=`` must be supplied -- a
+    missing key is ``400``, both keys at once is ``400`` (no implicit
+    precedence so callers cannot accidentally query the wrong axis).
+    An unknown id (not in ``ALL_FEATURES`` / ``ALL_RUNTIMES``) is
+    ``404``. Never 5xxs.
+    """
+    feat = (request.args.get("feature") or "").strip().lower()
+    rt = (request.args.get("runtime") or "").strip().lower()
+    if not feat and not rt:
+        return jsonify({"error": "missing feature or runtime"}), 400
+    if feat and rt:
+        return jsonify(
+            {"error": "pass feature OR runtime, not both"}
+        ), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if feat:
+            body = _ent.tiers_for_feature(feat)
+            kind = "feature"
+            item = feat
+        else:
+            body = _ent.tiers_for_runtime(rt)
+            kind = "runtime"
+            item = rt
+        if body is None:
+            return jsonify({"error": f"unknown {kind}", kind: item}), 404
+        return jsonify(body)
+    except Exception as exc:
+        logger.warning("api_entitlement_tiers_for: error: %s", exc)
+        return jsonify({"error": "tiers-for failed"}), 500
 
 
 @bp_entitlement.route("/api/runtimes")

--- a/tests/test_entitlement_tiers_for.py
+++ b/tests/test_entitlement_tiers_for.py
@@ -1,0 +1,398 @@
+"""Tests for ``clawmetry.entitlements.tiers_for_feature`` /
+``tiers_for_runtime`` + ``GET /api/entitlement/tiers-for``.
+
+Inverse of :func:`min_tier_for_feature` / :func:`min_tier_for_runtime`:
+where the ``min_tier_for_*`` helpers return the *cheapest* tier that
+grants an item (one id used by the upgrade-CTA), the ``tiers_for_*``
+helpers return the **full** ladder of tiers that grant it. The
+"Available in: Pro, Self-hosted Pro, Trial, Enterprise" availability
+list a pricing-page row or feature tooltip needs.
+
+These tests pin:
+
+* every paid feature / runtime resolves to a non-empty tier list
+* free features / runtimes appear in every tier (no holes)
+* paid features only appear in tiers that grant them (no leakage
+  into Starter for Pro-only features, etc.)
+* min_tier matches the existing :func:`min_tier_for_feature` /
+  :func:`min_tier_for_runtime` helpers (consistency invariant)
+* the catalog rows surface the same ladder so a matrix UI does not
+  need an N+1 round-trip
+* the API endpoint round-trips both axes and rejects bad input cleanly
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────
+
+
+def test_feature_returns_full_shape(ent):
+    body = ent.tiers_for_feature("self_evolve")
+    assert body is not None
+    assert set(body.keys()) == {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert body["kind"] == "feature"
+    assert body["item"] == "self_evolve"
+
+
+def test_runtime_returns_full_shape(ent):
+    body = ent.tiers_for_runtime("claude_code")
+    assert body is not None
+    assert set(body.keys()) == {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    assert body["kind"] == "runtime"
+    assert body["item"] == "claude_code"
+
+
+def test_tier_rows_have_expected_keys(ent):
+    body = ent.tiers_for_feature("self_evolve")
+    assert body["tiers"], "paid feature must list at least one tier"
+    for row in body["tiers"]:
+        assert set(row.keys()) == {"id", "label", "rank", "purchasable"}
+        assert isinstance(row["id"], str) and row["id"]
+        assert isinstance(row["label"], str) and row["label"]
+        assert isinstance(row["rank"], int)
+        assert isinstance(row["purchasable"], bool)
+
+
+def test_tier_rows_sorted_by_rank_then_id(ent):
+    body = ent.tiers_for_feature("self_evolve")
+    ranks = [(r["rank"], r["id"]) for r in body["tiers"]]
+    assert ranks == sorted(ranks)
+
+
+# ── min_tier consistency ──────────────────────────────────────────────────
+
+
+def test_min_tier_matches_min_tier_for_feature(ent):
+    for fid in ent.ALL_FEATURES:
+        body = ent.tiers_for_feature(fid)
+        assert body is not None, fid
+        assert body["min_tier"] == ent.min_tier_for_feature(fid), fid
+
+
+def test_min_tier_matches_min_tier_for_runtime(ent):
+    for rt in ent.ALL_RUNTIMES:
+        body = ent.tiers_for_runtime(rt)
+        assert body is not None, rt
+        assert body["min_tier"] == ent.min_tier_for_runtime(rt), rt
+
+
+# ── free features / runtimes available everywhere ─────────────────────────
+
+
+def test_free_feature_appears_in_every_tier(ent):
+    body = ent.tiers_for_feature("sessions")
+    assert body["free"] is True
+    ids = {row["id"] for row in body["tiers"]}
+    # Every known tier grants the free observability surface.
+    assert ids == set(ent._TIER_ORDER)
+
+
+def test_free_runtime_appears_in_every_tier(ent):
+    body = ent.tiers_for_runtime("openclaw")
+    assert body["free"] is True
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == set(ent._TIER_ORDER)
+
+
+def test_nemoclaw_free_runtime_appears_in_every_tier(ent):
+    body = ent.tiers_for_runtime("nemoclaw")
+    assert body["free"] is True
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == set(ent._TIER_ORDER)
+
+
+# ── paid feature/runtime carriage ─────────────────────────────────────────
+
+
+def test_starter_feature_carried_by_all_paid_tiers(ent):
+    # ``fleet`` is in STARTER_FEATURES -> trial + starter + pro + self-hosted
+    # pro + enterprise all carry it; OSS / cloud_free do not.
+    body = ent.tiers_for_feature("fleet")
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_OSS not in ids
+    assert ent.TIER_CLOUD_FREE not in ids
+    assert ent.TIER_TRIAL in ids
+    assert ent.TIER_CLOUD_STARTER in ids
+    assert ent.TIER_CLOUD_PRO in ids
+    assert ent.TIER_PRO in ids
+    assert ent.TIER_ENTERPRISE in ids
+
+
+def test_pro_only_feature_skips_starter(ent):
+    # ``self_evolve`` is PRO_ONLY -> NOT in starter, but in trial (full paid
+    # grant) + pro tiers + enterprise.
+    body = ent.tiers_for_feature("self_evolve")
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_CLOUD_STARTER not in ids
+    assert ent.TIER_TRIAL in ids
+    assert ent.TIER_CLOUD_PRO in ids
+    assert ent.TIER_PRO in ids
+    assert ent.TIER_ENTERPRISE in ids
+
+
+def test_enterprise_feature_only_in_enterprise(ent):
+    body = ent.tiers_for_feature("sso")
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == {ent.TIER_ENTERPRISE}
+
+
+def test_paid_runtime_carriage(ent):
+    # Every paid runtime is granted at every paid tier (trial, starter,
+    # cloud pro, self-hosted pro, enterprise).
+    expected = {
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+    for rt in ent.PAID_RUNTIMES:
+        body = ent.tiers_for_runtime(rt)
+        ids = {row["id"] for row in body["tiers"]}
+        assert ids == expected, rt
+
+
+# ── purchasable flag ──────────────────────────────────────────────────────
+
+
+def test_trial_row_marked_non_purchasable(ent):
+    body = ent.tiers_for_feature("fleet")
+    by_id = {row["id"]: row for row in body["tiers"]}
+    assert by_id[ent.TIER_TRIAL]["purchasable"] is False
+    assert by_id[ent.TIER_CLOUD_STARTER]["purchasable"] is True
+    assert by_id[ent.TIER_ENTERPRISE]["purchasable"] is True
+
+
+def test_min_tier_is_purchasable_for_paid_feature(ent):
+    body = ent.tiers_for_feature("fleet")
+    # min_tier is cheapest purchasable -- trial is excluded (promo grant).
+    assert body["min_tier"] == ent.TIER_CLOUD_STARTER
+    by_id = {row["id"]: row for row in body["tiers"]}
+    assert by_id[body["min_tier"]]["purchasable"] is True
+
+
+# ── input handling / safety ───────────────────────────────────────────────
+
+
+def test_unknown_feature_returns_none(ent):
+    assert ent.tiers_for_feature("not_a_real_feature_xyz") is None
+
+
+def test_unknown_runtime_returns_none(ent):
+    assert ent.tiers_for_runtime("not_a_real_runtime_xyz") is None
+
+
+def test_empty_returns_none(ent):
+    assert ent.tiers_for_feature("") is None
+    assert ent.tiers_for_feature(None) is None  # type: ignore[arg-type]
+    assert ent.tiers_for_runtime("") is None
+    assert ent.tiers_for_runtime(None) is None  # type: ignore[arg-type]
+
+
+def test_runtime_alias_resolves(ent):
+    # ``claude-code`` aliases ``claude_code`` -- the inverse helper must
+    # canonicalise the same way the rest of the resolver does.
+    body = ent.tiers_for_runtime("claude-code")
+    assert body is not None
+    assert body["item"] == "claude_code"
+
+
+def test_lowercases_input(ent):
+    body = ent.tiers_for_feature("FLEET")
+    assert body is not None
+    assert body["item"] == "fleet"
+
+
+def test_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "tier_label", boom)
+    assert ent.tiers_for_feature("fleet") is None
+    assert ent.tiers_for_runtime("claude_code") is None
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    live_before = ent.get_entitlement().to_dict()
+    ent.tiers_for_feature("self_evolve")
+    ent.tiers_for_runtime("claude_code")
+    live_after = ent.get_entitlement().to_dict()
+    assert live_before == live_after
+
+
+# ── catalog row enrichment ────────────────────────────────────────────────
+
+
+def test_feature_catalog_carries_tiers_ladder(ent):
+    by_id = {row["id"]: row for row in ent.feature_catalog()}
+    # Free features: every tier in the ladder.
+    assert set(by_id["sessions"]["tiers"]) == set(ent._TIER_ORDER)
+    # Pro-only features: starter is missing.
+    assert ent.TIER_CLOUD_STARTER not in by_id["self_evolve"]["tiers"]
+    assert ent.TIER_CLOUD_PRO in by_id["self_evolve"]["tiers"]
+    # Enterprise-only features.
+    assert by_id["sso"]["tiers"] == [ent.TIER_ENTERPRISE]
+
+
+def test_runtime_catalog_carries_tiers_ladder(ent):
+    by_id = {row["id"]: row for row in ent.runtime_catalog()}
+    # Free runtimes -> every tier.
+    assert set(by_id["openclaw"]["tiers"]) == set(ent._TIER_ORDER)
+    assert set(by_id["nemoclaw"]["tiers"]) == set(ent._TIER_ORDER)
+    # Paid runtime -> every paid tier, no oss / cloud_free.
+    paid_tier_ids = set(by_id["claude_code"]["tiers"])
+    assert ent.TIER_OSS not in paid_tier_ids
+    assert ent.TIER_CLOUD_FREE not in paid_tier_ids
+    assert ent.TIER_CLOUD_STARTER in paid_tier_ids
+    assert ent.TIER_TRIAL in paid_tier_ids
+    assert ent.TIER_ENTERPRISE in paid_tier_ids
+
+
+def test_catalog_tiers_are_id_only_strings(ent):
+    """The catalog inline-list uses ids only (compact). The full row-shape
+    -- id / label / rank / purchasable -- lives on
+    ``/api/entitlement/tiers-for``."""
+    for row in ent.feature_catalog():
+        assert isinstance(row["tiers"], list)
+        for t in row["tiers"]:
+            assert isinstance(t, str)
+    for row in ent.runtime_catalog():
+        assert isinstance(row["tiers"], list)
+        for t in row["tiers"]:
+            assert isinstance(t, str)
+
+
+# ── API surface ───────────────────────────────────────────────────────────
+
+
+def test_api_returns_feature_ladder(client, ent):
+    rv = client.get("/api/entitlement/tiers-for?feature=fleet")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "feature"
+    assert body["item"] == "fleet"
+    ids = {row["id"] for row in body["tiers"]}
+    assert ent.TIER_CLOUD_STARTER in ids
+    assert ent.TIER_ENTERPRISE in ids
+    assert ent.TIER_OSS not in ids
+
+
+def test_api_returns_runtime_ladder(client, ent):
+    rv = client.get("/api/entitlement/tiers-for?runtime=claude_code")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["kind"] == "runtime"
+    assert body["item"] == "claude_code"
+    ids = {row["id"] for row in body["tiers"]}
+    assert ids == {
+        ent.TIER_TRIAL,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    }
+
+
+def test_api_missing_args_is_400(client):
+    rv = client.get("/api/entitlement/tiers-for")
+    assert rv.status_code == 400
+    body = rv.get_json()
+    assert "error" in body
+
+
+def test_api_both_args_is_400(client):
+    rv = client.get(
+        "/api/entitlement/tiers-for?feature=fleet&runtime=claude_code"
+    )
+    assert rv.status_code == 400
+    body = rv.get_json()
+    assert "error" in body
+
+
+def test_api_unknown_feature_is_404(client):
+    rv = client.get("/api/entitlement/tiers-for?feature=nonsense_xyz")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["feature"] == "nonsense_xyz"
+
+
+def test_api_unknown_runtime_is_404(client):
+    rv = client.get("/api/entitlement/tiers-for?runtime=nonsense_xyz")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["runtime"] == "nonsense_xyz"
+
+
+def test_api_runtime_alias_resolves(client, ent):
+    rv = client.get("/api/entitlement/tiers-for?runtime=claude-code")
+    assert rv.status_code == 200
+    assert rv.get_json()["item"] == "claude_code"
+
+
+def test_api_lowercases_query(client, ent):
+    rv = client.get("/api/entitlement/tiers-for?feature=FLEET")
+    assert rv.status_code == 200
+    assert rv.get_json()["item"] == "fleet"
+
+
+# ── invariant vs tier_catalog ─────────────────────────────────────────────
+
+
+def test_feature_ladder_matches_tier_catalog_grants(ent):
+    """Every (feature, tier) pair where tier carries feature in
+    ``tiers_for_feature`` must also list that feature in
+    ``tier_catalog``'s ``features`` set -- catches a desync between
+    the inverse helper and the forward catalog."""
+    tier_feats = {
+        t["id"]: set(t["features"]) | set(ent.FREE_FEATURES)
+        for t in ent.tier_catalog()
+    }
+    for fid in ent.ALL_FEATURES:
+        body = ent.tiers_for_feature(fid)
+        for row in body["tiers"]:
+            tid = row["id"]
+            assert fid in tier_feats[tid], (fid, tid)


### PR DESCRIPTION
## Summary

Inverse of `min_tier_for_feature` / `min_tier_for_runtime`: where the `min_tier_for_*` helpers return the *cheapest* tier that grants an item (the upgrade-CTA case), the new `tiers_for_*` helpers return the **full** ladder of tiers that grant it — the "Available in: Pro, Self-hosted Pro, Trial, Enterprise" availability list a pricing-page row or feature tooltip renders.

- `clawmetry/entitlements.py`
  - `tiers_for_feature(feature) -> dict | None` — `{item, kind, label, free, min_tier, min_tier_label, min_tier_rank, tiers: [{id, label, rank, purchasable}, ...]}` sorted `(rank, id)`.
  - `tiers_for_runtime(runtime)` — same shape; canonicalises runtime aliases (`claude-code` → `claude_code`).
  - `feature_catalog()` / `runtime_catalog()` rows gain a compact id-only `tiers: list[str]` ladder so a matrix UI doesn't need an N+1 round-trip — purely additive, existing keys unchanged.
- `routes/entitlement.py`
  - `GET /api/entitlement/tiers-for?feature=<id>` (or `?runtime=<id>`) — returns the dict above. `400` on missing args / both at once; `404` on unknown id; never 5xxs.
- `tests/test_entitlement_tiers_for.py`
  - 34 tests: shape, free-everywhere, paid-tier carriage, `min_tier` consistency vs the existing `min_tier_for_*`, trial-row `purchasable=False`, alias resolution, never-raises, catalog enrichment, API surface (400 / 404 / 200), and a cross-helper invariant pinning the inverse ladder against `tier_catalog()`'s forward grants.

## Posture

GRACE-safe: the helpers are read-only views over the existing tier data — no `allows_*` change, no behaviour change for any current install. Module remains in grace by default.

## Local operator verification checklist

(I cannot do these remotely — they require the running daemon / live cloud snapshot / browser.)

- [ ] Copy changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and `routes/`).
- [ ] Clear `__pycache__` under `clawmetry/` and `routes/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to reload the daemon.
- [ ] `curl -s http://127.0.0.1:8900/api/entitlement/tiers-for?feature=fleet | jq` — expect 5-tier ladder (`trial`, `cloud_starter`, `cloud_pro`, `pro`, `enterprise`) and `min_tier=cloud_starter`.
- [ ] `curl -s http://127.0.0.1:8900/api/entitlement/tiers-for?runtime=claude_code | jq` — same 5-tier ladder for a paid runtime.
- [ ] `curl -s http://127.0.0.1:8900/api/entitlement/tiers-for?feature=sessions | jq '.tiers | length'` — expect 7 (free feature in every tier).
- [ ] `curl -s http://127.0.0.1:8900/api/entitlement/tiers-for | jq` — expect `400 missing feature or runtime`.
- [ ] `curl -s http://127.0.0.1:8900/api/features | jq '.features[] | select(.id=="self_evolve") | .tiers'` — expect `["trial","cloud_pro","pro","enterprise"]`.
- [ ] Decrypt the live cloud snapshot, confirm no schema regression in `/api/features` / `/api/runtimes`.
- [ ] Browser check: dashboard still loads; the snapshot relay still serves the catalog rows with the new `tiers` field present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpfKwPmXTGuHZ9ejs39XMK)_