### PR TITLE
feat(entitlement): tier_diff(from, to) + /api/entitlement/tier-diff

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1057,6 +1057,122 @@ def downgrade_diff(target_tier: str) -> dict:
         return {"target": target_tier or "", "lost_features": [], "lost_runtimes": []}
 
 
+def tier_diff(from_tier: str, to_tier: str) -> dict | None:
+    """Arbitrary-endpoint diff between two tiers.
+
+    Generalises :func:`upgrade_diff` / :func:`downgrade_diff` (which pin one
+    endpoint to the resolved entitlement) to ANY pair of known tiers, so a
+    "Compare A vs B" pricing-page widget can render the transition between
+    any two rungs without first switching the resolver. The payload carries
+    both directions on every call so the same shape covers an upgrade, a
+    downgrade, a lateral (same-rank, different id) and an identity (same
+    tier) -- the consumer reads the ``direction`` tag instead of inferring
+    it from the deltas.
+
+    Both endpoints accept any id in :data:`_TIER_FEATURES` (including
+    :data:`TIER_TRIAL`, which is unreachable via the purchasable-only
+    helpers but is a valid hypothetical destination for "what would a
+    14-day trial unlock right now" copy). Unknown ids on either side
+    short-circuit to ``None`` -- the same posture as :func:`preview` /
+    :func:`tier_unlocks` -- so a paywall surface keeps rendering instead
+    of 500-ing.
+
+    Response shape::
+
+        {
+          "from":             "<tier id>",
+          "from_label":       "...",
+          "from_rank":        <int>,
+          "to":               "<tier id>",
+          "to_label":         "...",
+          "to_rank":          <int>,
+          "direction":        "upgrade" | "downgrade" | "lateral" | "identity",
+          "added_features":   [...],   # in `to` but not in `from`
+          "lost_features":    [...],   # in `from` but not in `to`
+          "added_runtimes":   [...],
+          "lost_runtimes":    [...],
+          "capacity_changes": {
+              "channel_limit":   {before, after, delta, unlocked, locked},
+              "retention_days":  {before, after, delta, unlocked, locked},
+              "node_limit":      {before, after, delta, unlocked, locked},
+          },
+        }
+
+    The ``added_*`` / ``lost_*`` lists are sorted for byte-stable output,
+    so a snapshot diff against a fixture stays deterministic. Set-identity:
+    by construction ``tier_diff(X, Y)['added_features']`` byte-equals
+    ``tier_diff(Y, X)['lost_features']`` (and likewise for runtimes) -- the
+    same swap-the-endpoints invariant the upgrade/downgrade pair holds
+    against the current entitlement, lifted to arbitrary endpoints.
+    Pinned in the test suite so a future reshuffle of the tier grant sets
+    can't silently desync the two views.
+
+    Never raises: a resolver failure logs a warning and returns ``None``
+    so the surface keeps rendering.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        from_feats = FREE_FEATURES | _TIER_FEATURES.get(f, frozenset())
+        if f == TIER_ENTERPRISE:
+            from_feats = from_feats | ENTERPRISE_FEATURES
+        to_feats = FREE_FEATURES | _TIER_FEATURES.get(t, frozenset())
+        if t == TIER_ENTERPRISE:
+            to_feats = to_feats | ENTERPRISE_FEATURES
+        from_runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if f in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        to_runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if t in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return {
+            "from": f,
+            "from_label": tier_label(f),
+            "from_rank": from_rank,
+            "to": t,
+            "to_label": tier_label(t),
+            "to_rank": to_rank,
+            "direction": direction,
+            "added_features": sorted(to_feats - from_feats),
+            "lost_features": sorted(from_feats - to_feats),
+            "added_runtimes": sorted(to_runtimes - from_runtimes),
+            "lost_runtimes": sorted(from_runtimes - to_runtimes),
+            "capacity_changes": {
+                "channel_limit": _capacity_transition(
+                    _TIER_CHANNEL_LIMIT.get(f, _FREE_CHANNEL_LIMIT),
+                    _TIER_CHANNEL_LIMIT.get(t, _FREE_CHANNEL_LIMIT),
+                ),
+                "retention_days": _capacity_transition(
+                    _TIER_RETENTION_DAYS.get(f, 7),
+                    _TIER_RETENTION_DAYS.get(t, 7),
+                ),
+                "node_limit": _capacity_transition(
+                    _TIER_NODE_LIMIT.get(f, _FREE_NODE_LIMIT),
+                    _TIER_NODE_LIMIT.get(t, _FREE_NODE_LIMIT),
+                ),
+            },
+        }
+    except Exception as exc:
+        logger.warning("entitlements: tier_diff failed: %s", exc)
+        return None
+
+
 def next_tier_diff() -> dict | None:
     try:
         return get_entitlement().next_tier_diff()

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -35,6 +35,14 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          would add on top of the current ent.
   GET  /api/entitlement/downgrade-diff -- features + runtimes a target tier
                                           would REMOVE from the current ent.
+  GET  /api/entitlement/tier-diff     -- arbitrary-endpoint diff between any
+                                         two tiers (``?from=&to=``);
+                                         generalises ``/upgrade-diff`` /
+                                         ``/downgrade-diff`` from "current vs
+                                         target" to "any tier vs any tier" so
+                                         a "Compare A vs B" pricing-page
+                                         widget can render any pair without
+                                         first switching the resolver.
   GET  /api/entitlement/preview        -- the full Entitlement.to_dict() shape
                                           rendered for an arbitrary tier so the
                                           upgrade-CTA card can show concrete
@@ -199,6 +207,49 @@ def api_entitlement_downgrade_diff():
                 "lost_features": [],
                 "lost_runtimes": [],
             }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-diff")
+def api_entitlement_tier_diff():
+    """``GET /api/entitlement/tier-diff?from=<id>&to=<id>`` -- arbitrary-
+    endpoint diff between any two tiers, generalising ``/upgrade-diff`` /
+    ``/downgrade-diff`` (which pin one endpoint to the resolved entitlement)
+    to ANY pair so a "Compare A vs B" pricing-page widget can render the
+    transition between any two rungs without first switching the resolver.
+
+    The payload carries both ``added_*`` and ``lost_*`` lists on every call,
+    plus a ``direction`` tag (``upgrade`` | ``downgrade`` | ``lateral`` |
+    ``identity``) and a ``capacity_changes`` dict for the three capacity
+    axes (channels / retention / nodes), so the same shape covers all four
+    transition kinds and the consumer reads the tag instead of inferring
+    direction from the deltas.
+
+    ``400`` when ``from=`` or ``to=`` is missing; ``404`` when either id
+    is unknown. ``trial`` IS accepted -- it is unreachable via the
+    purchasable-only helpers but is a valid hypothetical endpoint.
+    Never 5xxs: a resolver failure short-circuits to ``404`` instead of
+    raising so a paywall surface keeps rendering.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tier_diff(f, t)
+        if body is None:
+            return (
+                jsonify({"error": "unknown tier", "from": f, "to": t}),
+                404,
+            )
+        return jsonify(body)
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_diff: error: %s", exc)
+        return (
+            jsonify({"error": "unknown tier", "from": f, "to": t}),
+            404,
         )
 
 

--- a/tests/test_entitlement_tier_diff_pair.py
+++ b/tests/test_entitlement_tier_diff_pair.py
@@ -1,0 +1,394 @@
+"""Tests for ``clawmetry.entitlements.tier_diff(from, to)`` + the
+``GET /api/entitlement/tier-diff`` endpoint.
+
+Generalises :func:`upgrade_diff` / :func:`downgrade_diff` (which pin one
+endpoint to the resolved entitlement) to ANY pair of known tiers so a
+"Compare A vs B" pricing-page widget can render any transition without
+first switching the resolver.
+
+Pins:
+
+* full payload shape (from/to, direction tag, added/lost lists,
+  capacity_changes dict for all three axes)
+* direction tag covers upgrade / downgrade / lateral / identity
+* swap-the-endpoints invariant -- ``added_features`` mirrors the swapped
+  ``lost_features`` byte-for-byte (and same for runtimes)
+* trial accepted as a hypothetical endpoint even though it is not
+  purchasable
+* identity-tier diff returns empty deltas
+* enterprise vs free unlocks the enterprise-only feature set
+* unknown tier id returns ``None`` (and ``404`` on the endpoint)
+* never raises
+* API surface: 400 on missing args, 404 on unknown ids, 200 on a happy
+  path with the expected shape
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_EXPECTED_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "added_features",
+    "lost_features",
+    "added_runtimes",
+    "lost_runtimes",
+    "capacity_changes",
+}
+
+
+# ── shape ────────────────────────────────────────────────────────────────────
+
+
+def test_tier_diff_shape(ent):
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert body is not None
+    assert set(body.keys()) == _EXPECTED_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_CLOUD_PRO
+    assert body["from_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["to_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert body["from_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["to_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    for axis in ("channel_limit", "retention_days", "node_limit"):
+        cap = body["capacity_changes"][axis]
+        assert set(cap.keys()) == {"before", "after", "delta", "unlocked", "locked"}
+
+
+def test_added_and_lost_lists_are_sorted(ent):
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert body["added_features"] == sorted(body["added_features"])
+    assert body["added_runtimes"] == sorted(body["added_runtimes"])
+    # downgrade direction also sorts.
+    body = ent.tier_diff(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    assert body["lost_features"] == sorted(body["lost_features"])
+    assert body["lost_runtimes"] == sorted(body["lost_runtimes"])
+
+
+# ── direction tag ────────────────────────────────────────────────────────────
+
+
+def test_direction_upgrade(ent):
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    assert body["direction"] == "upgrade"
+
+
+def test_direction_downgrade(ent):
+    body = ent.tier_diff(ent.TIER_ENTERPRISE, ent.TIER_CLOUD_STARTER)
+    assert body["direction"] == "downgrade"
+
+
+def test_direction_identity(ent):
+    body = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_PRO)
+    assert body["direction"] == "identity"
+    # identity collapses to empty deltas on every axis.
+    assert body["added_features"] == []
+    assert body["lost_features"] == []
+    assert body["added_runtimes"] == []
+    assert body["lost_runtimes"] == []
+
+
+def test_direction_lateral_same_rank(ent):
+    # cloud_pro and pro both sit at rank 2; the diff is a lateral move.
+    body = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_PRO)
+    assert body["direction"] == "lateral"
+    # the feature/runtime grants happen to match across the rank-2 cluster,
+    # so a lateral leaves the deltas empty.
+    assert body["added_features"] == []
+    assert body["lost_features"] == []
+
+
+def test_direction_lateral_oss_to_cloud_free(ent):
+    # OSS and cloud_free are both rank 0 -- lateral with empty deltas.
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_FREE)
+    assert body["direction"] == "lateral"
+    assert body["added_features"] == []
+    assert body["lost_features"] == []
+    assert body["added_runtimes"] == []
+    assert body["lost_runtimes"] == []
+
+
+# ── content sanity ───────────────────────────────────────────────────────────
+
+
+def test_oss_to_starter_unlocks_starter_features(ent):
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    added = set(body["added_features"])
+    assert ent.STARTER_FEATURES <= added
+    # Starter does not grant Pro-only features.
+    assert ent.PRO_ONLY_FEATURES.isdisjoint(added)
+
+
+def test_cloud_pro_to_starter_loses_pro_only_features(ent):
+    body = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER)
+    assert body["direction"] == "downgrade"
+    lost = set(body["lost_features"])
+    assert ent.PRO_ONLY_FEATURES <= lost
+
+
+def test_oss_to_enterprise_unlocks_enterprise_features(ent):
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    added = set(body["added_features"])
+    # Enterprise grants everything Pro grants AND the enterprise-only set.
+    assert ent.PAID_FEATURES <= added
+    assert ent.ENTERPRISE_FEATURES <= added
+
+
+def test_cloud_pro_to_enterprise_unlocks_only_enterprise_extras(ent):
+    body = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_ENTERPRISE)
+    added = set(body["added_features"])
+    # Cloud Pro already has every paid feature; only the enterprise set is new.
+    assert added == set(ent.ENTERPRISE_FEATURES)
+    assert body["lost_features"] == []
+
+
+def test_oss_to_starter_does_not_unlock_paid_runtimes(ent):
+    # Starter is a paid tier but the runtime grant is on/off across all paid
+    # tiers, not graded -- so any move from rank-0 to a paid tier flips on the
+    # full paid-runtime catalog.
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    added = set(body["added_runtimes"])
+    assert ent.PAID_RUNTIMES <= added
+    # Free runtimes are already on at both endpoints, so they are NOT added.
+    assert ent.FREE_RUNTIMES.isdisjoint(added)
+
+
+def test_capacity_changes_channel_unlocked_oss_to_pro(ent):
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    cap = body["capacity_changes"]["channel_limit"]
+    assert cap["before"] == 3
+    assert cap["after"] is None
+    assert cap["unlocked"] is True
+    assert cap["locked"] is False
+
+
+def test_capacity_changes_retention_finite_delta(ent):
+    body = ent.tier_diff(ent.TIER_CLOUD_STARTER, ent.TIER_CLOUD_PRO)
+    cap = body["capacity_changes"]["retention_days"]
+    assert cap["before"] == 30
+    assert cap["after"] == 90
+    assert cap["delta"] == 60
+    assert cap["unlocked"] is False
+    assert cap["locked"] is False
+
+
+def test_capacity_changes_retention_locked_pro_to_starter(ent):
+    body = ent.tier_diff(ent.TIER_ENTERPRISE, ent.TIER_CLOUD_STARTER)
+    cap = body["capacity_changes"]["retention_days"]
+    # Enterprise has unlimited retention -> Starter has 30d. Locked flips.
+    assert cap["before"] is None
+    assert cap["after"] == 30
+    assert cap["locked"] is True
+    assert cap["unlocked"] is False
+
+
+# ── trial as endpoint ────────────────────────────────────────────────────────
+
+
+def test_trial_accepted_as_destination(ent):
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_TRIAL)
+    assert body is not None
+    # trial carries the full paid feature set, same as Pro.
+    added = set(body["added_features"])
+    assert ent.PAID_FEATURES <= added
+
+
+def test_trial_accepted_as_source(ent):
+    body = ent.tier_diff(ent.TIER_TRIAL, ent.TIER_OSS)
+    assert body is not None
+    lost = set(body["lost_features"])
+    assert ent.PAID_FEATURES <= lost
+
+
+# ── swap-the-endpoints invariant ────────────────────────────────────────────
+
+
+def test_swap_endpoints_added_mirrors_lost_features(ent):
+    forward = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    reverse = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_OSS)
+    assert forward["added_features"] == reverse["lost_features"]
+    assert forward["lost_features"] == reverse["added_features"]
+
+
+def test_swap_endpoints_added_mirrors_lost_runtimes(ent):
+    forward = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    reverse = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_OSS)
+    assert forward["added_runtimes"] == reverse["lost_runtimes"]
+    assert forward["lost_runtimes"] == reverse["added_runtimes"]
+
+
+def test_swap_endpoints_flips_capacity_axes(ent):
+    forward = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    reverse = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_OSS)
+    for axis in ("channel_limit", "retention_days", "node_limit"):
+        f = forward["capacity_changes"][axis]
+        r = reverse["capacity_changes"][axis]
+        assert f["before"] == r["after"]
+        assert f["after"] == r["before"]
+        assert f["unlocked"] == r["locked"]
+        assert f["locked"] == r["unlocked"]
+
+
+def test_swap_endpoints_flips_direction(ent):
+    forward = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    reverse = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_OSS)
+    assert forward["direction"] == "upgrade"
+    assert reverse["direction"] == "downgrade"
+
+
+# ── consistency vs current-relative helpers ──────────────────────────────────
+
+
+def test_oss_upgrade_diff_matches_tier_diff_from_oss(ent):
+    # When `from` == the resolved entitlement, tier_diff's added_* equals
+    # the current-relative upgrade_diff's added_*.
+    e = ent._build(ent.TIER_OSS, "oss")
+    body = ent.tier_diff(ent.TIER_OSS, ent.TIER_CLOUD_PRO)
+    legacy = e.upgrade_diff(ent.TIER_CLOUD_PRO)
+    assert body["added_features"] == legacy["added_features"]
+    assert body["added_runtimes"] == legacy["added_runtimes"]
+
+
+def test_pro_downgrade_diff_matches_tier_diff_from_pro(ent):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    body = ent.tier_diff(ent.TIER_CLOUD_PRO, ent.TIER_CLOUD_STARTER)
+    legacy = e.downgrade_diff(ent.TIER_CLOUD_STARTER)
+    assert body["lost_features"] == legacy["lost_features"]
+    assert body["lost_runtimes"] == legacy["lost_runtimes"]
+
+
+# ── unknown ids ──────────────────────────────────────────────────────────────
+
+
+def test_unknown_from_returns_none(ent):
+    assert ent.tier_diff("not_a_tier", ent.TIER_CLOUD_PRO) is None
+
+
+def test_unknown_to_returns_none(ent):
+    assert ent.tier_diff(ent.TIER_OSS, "not_a_tier") is None
+
+
+def test_both_unknown_returns_none(ent):
+    assert ent.tier_diff("a", "b") is None
+
+
+def test_empty_args_return_none(ent):
+    assert ent.tier_diff("", ent.TIER_OSS) is None
+    assert ent.tier_diff(ent.TIER_OSS, "") is None
+    assert ent.tier_diff("", "") is None
+    assert ent.tier_diff(None, None) is None  # type: ignore[arg-type]
+
+
+def test_whitespace_and_case_normalised(ent):
+    # mixed-case + surrounding whitespace must still resolve.
+    body = ent.tier_diff("  OSS  ", "Cloud_Pro")
+    assert body is not None
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_CLOUD_PRO
+
+
+# ── never-raise ──────────────────────────────────────────────────────────────
+
+
+def test_never_raises_on_garbage(ent):
+    # The helper must never raise on garbage input -- a paywall surface
+    # short-circuits to None instead of 500-ing.
+    assert ent.tier_diff(object(), object()) is None  # type: ignore[arg-type]
+    assert ent.tier_diff(123, 456) is None  # type: ignore[arg-type]
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_api_tier_diff_ok(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tier-diff?from={ent.TIER_OSS}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _EXPECTED_KEYS
+    assert body["direction"] == "upgrade"
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_CLOUD_PRO
+
+
+def test_api_tier_diff_missing_from(client):
+    rv = client.get("/api/entitlement/tier-diff?to=cloud_pro")
+    assert rv.status_code == 400
+    body = rv.get_json()
+    assert body.get("error") == "missing from or to"
+
+
+def test_api_tier_diff_missing_to(client):
+    rv = client.get("/api/entitlement/tier-diff?from=oss")
+    assert rv.status_code == 400
+
+
+def test_api_tier_diff_missing_both(client):
+    rv = client.get("/api/entitlement/tier-diff")
+    assert rv.status_code == 400
+
+
+def test_api_tier_diff_unknown_from(client):
+    rv = client.get("/api/entitlement/tier-diff?from=not_a_tier&to=oss")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body.get("error") == "unknown tier"
+    assert body.get("from") == "not_a_tier"
+    assert body.get("to") == "oss"
+
+
+def test_api_tier_diff_unknown_to(client):
+    rv = client.get("/api/entitlement/tier-diff?from=oss&to=not_a_tier")
+    assert rv.status_code == 404
+
+
+def test_api_tier_diff_identity_returns_empty_deltas(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tier-diff?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["direction"] == "identity"
+    assert body["added_features"] == []
+    assert body["lost_features"] == []
+
+
+def test_api_tier_diff_trial_destination_ok(client, ent):
+    rv = client.get(
+        f"/api/entitlement/tier-diff?from={ent.TIER_OSS}&to={ent.TIER_TRIAL}"
+    )
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["to"] == ent.TIER_TRIAL
+    assert body["direction"] == "upgrade"


### PR DESCRIPTION
## Summary

Generalises `upgrade_diff` / `downgrade_diff` (which pin one endpoint to the resolved entitlement) to ANY pair of known tiers so a "Compare A vs B" pricing-page widget can render the transition between any two rungs without first switching the resolver.

- `clawmetry/entitlements.py`
  - `tier_diff(from_tier, to_tier) -> dict | None` returning:

    ```
    from / from_label / from_rank / to / to_label / to_rank,
    direction ("upgrade" | "downgrade" | "lateral" | "identity"),
    added_features / lost_features (sorted),
    added_runtimes / lost_runtimes (sorted),
    capacity_changes {
      channel_limit, retention_days, node_limit
    }  # each carrying {before, after, delta, unlocked, locked}
    ```

  - Accepts any id in `_TIER_FEATURES` (including `TIER_TRIAL` as a hypothetical endpoint -- unreachable via the purchasable-only helpers but a valid "what would a trial unlock right now" destination).
  - Unknown / empty ids short-circuit to `None`. Whitespace + case are normalised. Never raises.
- `routes/entitlement.py`
  - `GET /api/entitlement/tier-diff?from=&to=` returning the dict above. `400` on missing args, `404` on unknown ids, never 5xxs.
- `tests/test_entitlement_tier_diff_pair.py`
  - 37 tests: shape, direction tag (upgrade / downgrade / lateral / identity), content sanity (added/lost feature + runtime sets, capacity-axis unlock vs lock, enterprise vs free), trial-as-endpoint, swap-the-endpoints invariant (`added` ↔ `lost`, capacity `before` ↔ `after`, direction flip), consistency with the existing current-relative `upgrade_diff` / `downgrade_diff`, unknown-id / empty / garbage-input never-raise, and the API surface (200 / 400 / 404 / identity / trial-destination).

## Posture

GRACE-safe: a read-only view over the existing tier data -- no `allows_*` change, no behaviour change for any current install. Module remains in grace by default.

## Local operator verification checklist

(I cannot do these remotely -- they require the running daemon / live cloud snapshot / browser.)

- [ ] Copy changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and `routes/`).
- [ ] Clear `__pycache__` under `clawmetry/` and `routes/`.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to reload the daemon.
- [ ] `curl -s 'http://127.0.0.1:8900/api/entitlement/tier-diff?from=oss&to=cloud_pro' | jq` -- expect `direction=upgrade`, non-empty `added_features` and `added_runtimes`, `capacity_changes.channel_limit.unlocked=true`.
- [ ] `curl -s 'http://127.0.0.1:8900/api/entitlement/tier-diff?from=cloud_pro&to=oss' | jq` -- expect `direction=downgrade`, mirrored `lost_*` lists, `capacity_changes.channel_limit.locked=true`.
- [ ] `curl -s 'http://127.0.0.1:8900/api/entitlement/tier-diff?from=cloud_pro&to=pro' | jq` -- expect `direction=lateral` and empty deltas.
- [ ] `curl -s 'http://127.0.0.1:8900/api/entitlement/tier-diff?from=cloud_pro&to=cloud_pro' | jq` -- expect `direction=identity` and empty deltas.
- [ ] `curl -s 'http://127.0.0.1:8900/api/entitlement/tier-diff' -w '%{http_code}\n'` -- expect `400 missing from or to`.
- [ ] `curl -s 'http://127.0.0.1:8900/api/entitlement/tier-diff?from=oss&to=not_a_tier' -w '%{http_code}\n'` -- expect `404 unknown tier`.
- [ ] `curl -s 'http://127.0.0.1:8900/api/entitlement/tier-diff?from=oss&to=enterprise' | jq '.added_features | length'` -- expect the full paid + enterprise feature count.
- [ ] Decrypt the live cloud snapshot, confirm no schema regression on the existing `/api/entitlement` / `/api/entitlement/upgrade-diff` / `/downgrade-diff` payloads.
- [ ] Browser check: dashboard still loads; the new endpoint serves valid JSON; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lp8DMFvNx26mZEnjtYStrd)_