### PR TITLE
feat(entitlement): tiers_for_batch + /api/entitlement/tiers-for-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1999,6 +1999,70 @@ def tiers_for_runtime(runtime: str) -> dict | None:
         return None
 
 
+def tiers_for_batch() -> dict:
+    """Full availability ladder for every known feature *and* runtime in
+    one pass. Plural sibling of :func:`tiers_for_feature` /
+    :func:`tiers_for_runtime` and the inverse of the existing
+    ``min_tier_for_*`` resolvers: where the singular helpers answer
+    "which tiers grant *this* item" one id at a time -- the shape a
+    pricing-page row uses -- the batch returns the same row shape for
+    every entry in :data:`ALL_FEATURES` and :data:`ALL_RUNTIMES` so a
+    pricing-table or feature-comparison matrix UI can render the full
+    "Available in X" grid off **one** round-trip instead of an N+1
+    fan-out across ``/api/entitlement/tiers-for``.
+
+    Response shape::
+
+        {
+          "features": [<tiers_for_feature row>, ...],
+          "runtimes": [<tiers_for_runtime row>, ...],
+        }
+
+    Feature rows are sorted by ``(feature_tier_rank, id)`` so the free
+    surface appears first, then Starter, Pro, Enterprise -- the same
+    order :func:`feature_catalog` uses, so a UI that joins the two
+    surfaces (catalog row + availability ladder) sees a consistent
+    ordering. Runtime rows put :data:`FREE_RUNTIMES` first (alpha
+    within), then :data:`PAID_RUNTIMES` (alpha within), mirroring
+    :func:`runtime_catalog`.
+
+    Each row matches its singular helper exactly (``item``, ``kind``,
+    ``label``, ``free``, ``min_tier``, ``min_tier_label``,
+    ``min_tier_rank``, ``tiers``) so callers can pass a row to existing
+    components without reshaping. Aliases (``custom_alerts``,
+    ``alert_webhooks``, ``anomaly_detection``, ``cost_optimizer``) are
+    surfaced alongside their canonical features -- they each carry a
+    distinct id used by the dashboard, and the catalog already lists
+    them.
+
+    Never raises: if the resolver blows up the helper returns
+    ``{"features": [], "runtimes": []}`` so the pricing UI keeps
+    rendering instead of 500-ing.
+    """
+    try:
+        features: list[dict] = []
+        for fid in sorted(
+            ALL_FEATURES,
+            key=lambda f: (_FEATURE_TIER_RANK.get(feature_tier(f), 9), f),
+        ):
+            row = tiers_for_feature(fid)
+            if row is not None:
+                features.append(row)
+        runtimes: list[dict] = []
+        for rt in sorted(FREE_RUNTIMES):
+            row = tiers_for_runtime(rt)
+            if row is not None:
+                runtimes.append(row)
+        for rt in sorted(PAID_RUNTIMES):
+            row = tiers_for_runtime(rt)
+            if row is not None:
+                runtimes.append(row)
+        return {"features": features, "runtimes": runtimes}
+    except Exception as exc:
+        logger.warning("entitlements: tiers_for_batch failed: %s", exc)
+        return {"features": [], "runtimes": []}
+
+
 def min_tier_for_channel_count(count: int) -> str | None:
     """Return the cheapest *purchasable* tier id whose channel-adapter cap fits
     ``count`` configured channels. Closes the symmetry gap with

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1390,6 +1390,63 @@ def api_entitlement_tiers_for():
         return jsonify({"error": "tiers-for failed"}), 500
 
 
+@bp_entitlement.route("/api/entitlement/tiers-for-batch")
+def api_entitlement_tiers_for_batch():
+    """``GET /api/entitlement/tiers-for-batch`` -- full availability
+    ladder for every feature *and* runtime in one pass. Plural sibling
+    of ``/api/entitlement/tiers-for``: where the singular endpoint
+    returns one feature-or-runtime row (and 400s on a missing axis,
+    404s on an unknown id), the batch returns both surfaces in tier-rank
+    order so a pricing-table / feature-comparison matrix UI can render
+    the full "Available in X" grid off **one** round-trip instead of an
+    N+1 fan-out.
+
+    Response shape::
+
+        {
+          "features":          [<row>, ...],
+          "runtimes":          [<row>, ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` matches ``/api/entitlement/tiers-for`` exactly
+    (``item``, ``kind``, ``label``, ``free``, ``min_tier``,
+    ``min_tier_label``, ``min_tier_rank``, ``tiers``). Never 5xxs: a
+    resolver failure yields empty ``features`` / ``runtimes`` lists and
+    the grace-shape envelope so the pricing UI keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        body = _ent.tiers_for_batch()
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "features": body.get("features", []),
+                "runtimes": body.get("runtimes", []),
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_tiers_for_batch: error: %s", exc)
+        return jsonify(
+            {
+                "features": [],
+                "runtimes": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/runtimes")
 def api_runtimes():
     try:

--- a/tests/test_entitlement_tiers_for_batch.py
+++ b/tests/test_entitlement_tiers_for_batch.py
@@ -1,0 +1,281 @@
+"""Tests for ``clawmetry.entitlements.tiers_for_batch`` +
+``GET /api/entitlement/tiers-for-batch``.
+
+Plural sibling of :func:`tiers_for_feature` / :func:`tiers_for_runtime`.
+Where the singular helpers answer "which tiers grant *this* feature or
+runtime" one id at a time, the batch returns the same row shape for
+every entry in ``ALL_FEATURES`` and ``ALL_RUNTIMES`` so a pricing-table
+/ feature-comparison matrix UI can render the full "Available in X"
+grid off **one** round-trip. These tests pin the contract:
+
+  - returns one row per known feature and one row per known runtime
+  - each row matches the singular helper output byte-for-byte
+  - free items appear in every tier (no holes), paid items only in
+    their granting tiers (no leakage)
+  - never raises -- a resolver failure short-circuits to empty lists
+  - the wrapper endpoint always returns a 200 with the grace envelope
+    so the pricing page keeps rendering even when the resolver is sick
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────
+
+
+def test_returns_two_buckets(ent):
+    body = ent.tiers_for_batch()
+    assert isinstance(body, dict)
+    assert set(body.keys()) == {"features", "runtimes"}
+    assert isinstance(body["features"], list)
+    assert isinstance(body["runtimes"], list)
+    assert body["features"], "feature ladder must be non-empty"
+    assert body["runtimes"], "runtime ladder must be non-empty"
+
+
+def test_each_feature_row_has_singular_shape(ent):
+    expected = {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    for row in ent.tiers_for_batch()["features"]:
+        assert set(row.keys()) == expected
+        assert row["kind"] == "feature"
+
+
+def test_each_runtime_row_has_singular_shape(ent):
+    expected = {
+        "item",
+        "kind",
+        "label",
+        "free",
+        "min_tier",
+        "min_tier_label",
+        "min_tier_rank",
+        "tiers",
+    }
+    for row in ent.tiers_for_batch()["runtimes"]:
+        assert set(row.keys()) == expected
+        assert row["kind"] == "runtime"
+
+
+def test_tier_rows_have_expected_keys(ent):
+    body = ent.tiers_for_batch()
+    for row in body["features"] + body["runtimes"]:
+        for tier_row in row["tiers"]:
+            assert set(tier_row.keys()) == {
+                "id",
+                "label",
+                "rank",
+                "purchasable",
+            }
+
+
+# ── coverage ──────────────────────────────────────────────────────────────
+
+
+def test_covers_every_known_feature(ent):
+    items = {row["item"] for row in ent.tiers_for_batch()["features"]}
+    assert items == set(ent.ALL_FEATURES)
+
+
+def test_covers_every_known_runtime(ent):
+    items = {row["item"] for row in ent.tiers_for_batch()["runtimes"]}
+    assert items == set(ent.ALL_RUNTIMES)
+
+
+# ── ordering ──────────────────────────────────────────────────────────────
+
+
+def test_features_sorted_by_feature_tier_rank_then_id(ent):
+    rows = ent.tiers_for_batch()["features"]
+    keys = [
+        (ent._FEATURE_TIER_RANK.get(ent.feature_tier(r["item"]), 9), r["item"])
+        for r in rows
+    ]
+    assert keys == sorted(keys)
+
+
+def test_runtimes_free_first_then_paid_alpha(ent):
+    rows = ent.tiers_for_batch()["runtimes"]
+    items = [r["item"] for r in rows]
+    expected = sorted(ent.FREE_RUNTIMES) + sorted(ent.PAID_RUNTIMES)
+    assert items == expected
+
+
+def test_stable_across_calls(ent):
+    assert ent.tiers_for_batch() == ent.tiers_for_batch()
+
+
+# ── parity with singular helpers ──────────────────────────────────────────
+
+
+def test_feature_rows_equal_singular_calls(ent):
+    for row in ent.tiers_for_batch()["features"]:
+        assert row == ent.tiers_for_feature(row["item"])
+
+
+def test_runtime_rows_equal_singular_calls(ent):
+    for row in ent.tiers_for_batch()["runtimes"]:
+        assert row == ent.tiers_for_runtime(row["item"])
+
+
+# ── free vs paid invariants ───────────────────────────────────────────────
+
+
+def test_free_features_appear_in_every_tier(ent):
+    rows = {r["item"]: r for r in ent.tiers_for_batch()["features"]}
+    for fid in ent.FREE_FEATURES:
+        ids = {t["id"] for t in rows[fid]["tiers"]}
+        assert ids == set(ent._TIER_ORDER), fid
+        assert rows[fid]["free"] is True
+
+
+def test_free_runtimes_appear_in_every_tier(ent):
+    rows = {r["item"]: r for r in ent.tiers_for_batch()["runtimes"]}
+    for rt in ent.FREE_RUNTIMES:
+        ids = {t["id"] for t in rows[rt]["tiers"]}
+        assert ids == set(ent._TIER_ORDER), rt
+        assert rows[rt]["free"] is True
+
+
+def test_paid_runtimes_skip_floor_tiers(ent):
+    rows = {r["item"]: r for r in ent.tiers_for_batch()["runtimes"]}
+    for rt in ent.PAID_RUNTIMES:
+        ids = {t["id"] for t in rows[rt]["tiers"]}
+        assert ent.TIER_OSS not in ids
+        assert ent.TIER_CLOUD_FREE not in ids
+        assert rows[rt]["free"] is False
+
+
+def test_enterprise_feature_only_in_enterprise(ent):
+    rows = {r["item"]: r for r in ent.tiers_for_batch()["features"]}
+    ids = {t["id"] for t in rows["sso"]["tiers"]}
+    assert ids == {ent.TIER_ENTERPRISE}
+
+
+# ── safety ────────────────────────────────────────────────────────────────
+
+
+def test_does_not_mutate_live_entitlement(ent):
+    before = ent.get_entitlement().to_dict()
+    ent.tiers_for_batch()
+    after = ent.get_entitlement().to_dict()
+    assert before == after
+
+
+def test_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(ent, "tiers_for_feature", boom)
+    monkeypatch.setattr(ent, "tiers_for_runtime", boom)
+    # Helper swallows per-row failures and returns empty lists -- never
+    # propagates. The outer try/except guards against catastrophic
+    # failure in the iteration setup itself.
+    body = ent.tiers_for_batch()
+    assert body == {"features": [], "runtimes": []}
+
+
+# ── API surface ───────────────────────────────────────────────────────────
+
+
+def test_api_returns_envelope_shape(client):
+    rv = client.get("/api/entitlement/tiers-for-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == {
+        "features",
+        "runtimes",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+
+
+def test_api_covers_every_feature_and_runtime(client, ent):
+    rv = client.get("/api/entitlement/tiers-for-batch")
+    body = rv.get_json()
+    feat_ids = {row["item"] for row in body["features"]}
+    rt_ids = {row["item"] for row in body["runtimes"]}
+    assert feat_ids == set(ent.ALL_FEATURES)
+    assert rt_ids == set(ent.ALL_RUNTIMES)
+
+
+def test_api_rows_match_singular_endpoint(client, ent):
+    rv = client.get("/api/entitlement/tiers-for-batch")
+    body = rv.get_json()
+    for row in body["features"]:
+        single = client.get(
+            f"/api/entitlement/tiers-for?feature={row['item']}"
+        )
+        assert single.status_code == 200
+        assert single.get_json() == row
+    for row in body["runtimes"]:
+        single = client.get(
+            f"/api/entitlement/tiers-for?runtime={row['item']}"
+        )
+        assert single.status_code == 200
+        assert single.get_json() == row
+
+
+def test_api_envelope_reports_grace_in_oss_default(client):
+    body = client.get("/api/entitlement/tiers-for-batch").get_json()
+    # OSS-free default is grace=True, enforced=False, tier="oss" -- the
+    # envelope mirrors tier-unlocks-batch / tier-locks-batch.
+    assert body["grace"] is True
+    assert body["enforced"] is False
+    assert body["current_tier"] == "oss"
+    assert body["current_tier_rank"] == 0
+
+
+def test_api_resolver_failure_returns_grace_envelope(monkeypatch, client):
+    import clawmetry.entitlements as e
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic resolver failure")
+
+    monkeypatch.setattr(e, "tiers_for_batch", boom)
+    rv = client.get("/api/entitlement/tiers-for-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body == {
+        "features": [],
+        "runtimes": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }


### PR DESCRIPTION
## Summary

Plural sibling of `tiers_for_feature` / `tiers_for_runtime` and the inverse-batch companion to `tier_unlocks_batch` / `tier_locks_batch`. Where the singular helpers answer "which tiers grant *this* item" one id at a time, the batch returns the same row shape for every entry in `ALL_FEATURES` and `ALL_RUNTIMES` so a pricing-table / feature-comparison matrix UI can render the full "Available in X" grid off **one** round-trip instead of an N+1 fan-out across `/api/entitlement/tiers-for`.

## Changes

- `clawmetry/entitlements.py`: new `tiers_for_batch()` helper. Feature rows sorted by `(feature_tier_rank, id)` to match `feature_catalog`; runtime rows put `FREE_RUNTIMES` first then `PAID_RUNTIMES` (alpha within each), mirroring `runtime_catalog`. Each row is byte-identical to its singular helper output so callers can hand a row to existing components without reshaping. Trial appears alongside the purchasable tiers with `purchasable=False`, same posture as the singular helpers.
- `routes/entitlement.py`: `GET /api/entitlement/tiers-for-batch` wraps the helper in the established batch envelope (`current_tier`, `current_tier_rank`, `grace`, `enforced`) so a pricing UI keys off the same state shape as `tier-unlocks-batch` / `tier-locks-batch`. Never 5xxs: a resolver failure short-circuits to empty `features` / `runtimes` lists with the grace-shape envelope so the pricing UI keeps rendering.
- `tests/test_entitlement_tiers_for_batch.py`: 22 tests covering shape, coverage of every known feature/runtime, ordering, parity with the singular helpers (row-equality), free-vs-paid invariants, never-raises, and the API surface (envelope, resolver-failure grace fallback, byte-equality with `/api/entitlement/tiers-for`).

## Test Plan

- `python -m pytest tests/test_entitlement_tiers_for_batch.py -q` -> 22 passed
- `python -m pytest tests/test_entitlement_tiers_for.py tests/test_entitlement_tier_unlocks_batch.py tests/test_entitlement_tier_locks_batch.py tests/test_entitlements_catalogue.py tests/test_entitlements_feature_catalog.py -q` -> 114 passed (sibling helpers untouched)
- `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tiers_for_batch.py` -> clean
- `python -m py_compile` on changed files -> OK

Read-only helper, grace default unchanged. No behavior change for any currently-shipped surface; new endpoint is additive.

## Local operator verification checklist

Cannot be exercised remotely -- needs the live daemon + cloud snapshot the agent has no access to:

- [ ] Copy `clawmetry/entitlements.py`, `routes/entitlement.py`, `tests/test_entitlement_tiers_for_batch.py` into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (and `routes/`, `tests/` mirrors).
- [ ] Clear `__pycache__` under the install dir.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon.
- [ ] `curl -s localhost:8900/api/entitlement/tiers-for-batch | jq '.features|length, .runtimes|length, .current_tier, .grace, .enforced'` -- expect non-zero counts, `oss` / `true` / `false` on the OSS-free default.
- [ ] Decrypt the live cloud snapshot and confirm the new endpoint is reachable via the relay (shape/dispatcher contract).
- [ ] Browser-check the pricing / feature-availability surface (matrix renders without an N+1 round-trip; trial row marked non-purchasable; free rows tick every column).

---

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTqtZqHitPJKm9ZCQfd3J3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTqtZqHitPJKm9ZCQfd3J3)_