### PR TITLE
feat(entitlement): capacity_diff_batch + /api/entitlement/capacity-diff-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1295,6 +1295,57 @@ def previous_tier_capacity_diff() -> dict | None:
         return None
 
 
+def capacity_diff_batch() -> list[dict]:
+    """Per-tier capacity transition for every purchasable tier in one pass.
+
+    Plural sibling of :func:`capacity_diff`. Where the singular helper
+    answers "what would the channel cap / retention / node cap look like
+    at tier X" one tier at a time, the batch returns the same payload
+    shape for every entry in :data:`_PURCHASABLE_TIERS` so a pricing-page
+    table can render the capacity column off **one** round-trip instead
+    of N calls to ``/capacity-diff``.
+
+    Direction-agnostic capacity companion to the existing pricing-page
+    batches: pair with :func:`tier_unlocks_batch` (marginal feature/
+    runtime grant per rung), :func:`tier_locks_batch` (marginal feature/
+    runtime loss per rung) and :func:`preview_batch` (cumulative shape
+    per rung) to render the full "what's at X / what's new at X / what
+    you'd give up at X / capacity at X" pricing-table view without
+    client-side composition.
+
+    Rows are sorted by tier rank ascending (cheapest -> most capable)
+    and, within the same rank, by tier id so the ordering is stable
+    across calls and byte-stable against :func:`tier_unlocks_batch` /
+    :func:`tier_locks_batch` / :func:`preview_batch` (the four batches
+    walk :data:`_PURCHASABLE_TIERS` in the same ``(rank, id)`` order so
+    a pricing table lines up rung-for-rung without client-side re-sort).
+    The trial tier is excluded (mirrors :func:`preview_batch` / the
+    other batches -- it is not purchasable).
+
+    Each row carries the singular :func:`capacity_diff` payload exactly
+    (``target``, ``channel_limit``, ``retention_days``, ``node_limit``)
+    so per-axis ``{before, after, delta, unlocked, locked}`` triples
+    render identically off the batch and the singular endpoint. The
+    ``before`` side comes off the resolved entitlement, so under grace
+    the per-axis caps collapse to the unlimited (``None``) sentinel --
+    same posture as the singular helper.
+
+    Never raises: if the resolver blows up the helper returns ``[]``
+    so the UI keeps rendering instead of 500-ing.
+    """
+    try:
+        out: list[dict] = []
+        ordered = sorted(
+            _PURCHASABLE_TIERS, key=lambda t: (_TIER_RANK.get(t, -1), t)
+        )
+        for tid in ordered:
+            out.append(capacity_diff(tid))
+        return out
+    except Exception as exc:
+        logger.warning("entitlements: capacity_diff_batch failed: %s", exc)
+        return []
+
+
 def preview(target_tier: str) -> dict | None:
     """Render the :meth:`Entitlement.to_dict` shape for a hypothetical tier.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -71,6 +71,14 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                           ``/tier-unlocks``: returns the full
                                           pricing-page marginal-unlock ladder
                                           in one pass.
+  GET  /api/entitlement/capacity-diff-batch -- plural sibling of
+                                          ``/capacity-diff``: per-axis
+                                          capacity transitions (channels /
+                                          retention / nodes) for every
+                                          purchasable tier in one pass so
+                                          a pricing-page table can render
+                                          the capacity column off one
+                                          round-trip.
   GET  /api/entitlement/preview-batch  -- plural sibling of ``/preview``:
                                          the full ``Entitlement.to_dict``
                                          shape rendered for every purchasable
@@ -370,6 +378,70 @@ def api_entitlement_capacity_diff():
                 "channel_limit": None,
                 "retention_days": None,
                 "node_limit": None,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/capacity-diff-batch")
+def api_entitlement_capacity_diff_batch():
+    """``GET /api/entitlement/capacity-diff-batch`` -- per-axis capacity
+    transition for every purchasable tier in one pass. Plural sibling of
+    ``/api/entitlement/capacity-diff``: where the singular endpoint
+    returns one tier's per-axis triple, the batch returns the full
+    pricing-page ladder in tier-rank order so a pricing-table UI can
+    render the capacity column ("channels: 3 -> unlimited, retention:
+    7d -> 30d, nodes: 1 -> unlimited") off **one** round-trip instead
+    of N calls.
+
+    Direction-agnostic capacity companion to ``/tier-unlocks-batch``
+    (marginal feature / runtime grant per rung), ``/tier-locks-batch``
+    (marginal feature / runtime loss per rung) and ``/preview-batch``
+    (cumulative ``Entitlement.to_dict`` shape per rung): pair them to
+    render the full "what's at X / what's new at X / what you'd give
+    up at X / capacity at X" view of a pricing table without
+    client-side composition.
+
+    Response shape::
+
+        {
+          "tiers":             [<row>, ...],
+          "current_tier":      "...",
+          "current_tier_rank": <int>,
+          "grace":             <bool>,
+          "enforced":          <bool>,
+        }
+
+    Each ``<row>`` matches ``/api/entitlement/capacity-diff`` exactly
+    (``target``, ``channel_limit``, ``retention_days``, ``node_limit``
+    where each axis is the same ``{before, after, delta, unlocked,
+    locked}`` triple). The trial tier is excluded -- not purchasable,
+    same posture as the other ``*-batch`` siblings. Never 5xxs: a
+    resolver failure yields an empty ``tiers`` list and the grace-shape
+    envelope so the pricing page keeps rendering.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        rows = _ent.capacity_diff_batch()
+        ent = _ent.get_entitlement()
+        return jsonify(
+            {
+                "tiers": rows,
+                "current_tier": ent.tier,
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_capacity_diff_batch: error: %s", exc)
+        return jsonify(
+            {
+                "tiers": [],
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
             }
         )
 

--- a/tests/test_entitlement_capacity_diff_batch.py
+++ b/tests/test_entitlement_capacity_diff_batch.py
@@ -1,0 +1,247 @@
+"""Tests for ``clawmetry.entitlements.capacity_diff_batch`` +
+``GET /api/entitlement/capacity-diff-batch``.
+
+Plural sibling of :func:`capacity_diff`. Where the singular helper
+answers "what would the channel cap / retention / node cap look like at
+tier X" one tier at a time, the batch returns the same payload shape for
+every entry in ``_PURCHASABLE_TIERS`` so a pricing-page table can render
+the capacity column off **one** round-trip. These tests pin the
+contract:
+
+  - returns one row per purchasable tier in (rank, id) order
+  - each row matches the singular ``capacity_diff(tier)`` output exactly
+  - trial is excluded (mirrors the other ``*-batch`` siblings)
+  - rung order is byte-stable against ``tier_unlocks_batch`` /
+    ``tier_locks_batch`` / ``preview_batch`` so a pricing table lines up
+    rung-for-rung
+  - never raises -- a resolver failure short-circuits to ``[]``
+  - the wrapper endpoint always returns a 200 with the grace envelope so
+    the pricing page keeps rendering even when the resolver is sick
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+@pytest.fixture
+def enforced_client(enforced):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── shape ─────────────────────────────────────────────────────────────────
+
+
+def test_returns_list(ent):
+    rows = ent.capacity_diff_batch()
+    assert isinstance(rows, list)
+    assert len(rows) > 0
+
+
+def test_each_row_has_singular_shape(ent):
+    rows = ent.capacity_diff_batch()
+    expected = {"target", "channel_limit", "retention_days", "node_limit"}
+    for row in rows:
+        assert set(row.keys()) == expected
+
+
+def test_each_axis_carries_full_triple(enforced):
+    rows = enforced.capacity_diff_batch()
+    for row in rows:
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            triple = row[axis]
+            # Under enforce every purchasable tier resolves to a real
+            # transition payload -- the singular helper's full triple.
+            assert isinstance(triple, dict)
+            assert set(triple) == {"before", "after", "delta", "unlocked", "locked"}
+
+
+def test_excludes_trial(ent):
+    rows = ent.capacity_diff_batch()
+    ids = {row["target"] for row in rows}
+    assert ent.TIER_TRIAL not in ids
+
+
+def test_includes_every_purchasable_tier(ent):
+    rows = ent.capacity_diff_batch()
+    ids = {row["target"] for row in rows}
+    assert ids == set(ent._PURCHASABLE_TIERS)
+
+
+# ── ordering ──────────────────────────────────────────────────────────────
+
+
+def test_rows_sorted_by_rank_then_id(ent):
+    rows = ent.capacity_diff_batch()
+    keys = [(ent._TIER_RANK.get(r["target"], -1), r["target"]) for r in rows]
+    assert keys == sorted(keys)
+
+
+def test_ordering_byte_stable_against_other_batches(ent):
+    cap_ids = [r["target"] for r in ent.capacity_diff_batch()]
+    unlock_ids = [r["tier"] for r in ent.tier_unlocks_batch()]
+    lock_ids = [r["tier"] for r in ent.tier_locks_batch()]
+    preview_ids = [r["tier"] for r in ent.preview_batch()]
+    # All four batches walk _PURCHASABLE_TIERS in the same (rank, id)
+    # order so a pricing-page table lines up rung-for-rung without
+    # client-side re-sort.
+    assert cap_ids == unlock_ids == lock_ids == preview_ids
+
+
+# ── per-row identity with the singular helper ────────────────────────────
+
+
+def test_each_row_matches_singular_capacity_diff_under_enforce(enforced):
+    rows = enforced.capacity_diff_batch()
+    for row in rows:
+        # The batch is a thin walker over :func:`capacity_diff` so the
+        # singular endpoint and the batch must agree byte-for-byte per
+        # row.
+        assert row == enforced.capacity_diff(row["target"])
+
+
+def test_each_row_matches_singular_capacity_diff_under_grace(ent):
+    rows = ent.capacity_diff_batch()
+    for row in rows:
+        assert row == ent.capacity_diff(row["target"])
+
+
+# ── grace posture ─────────────────────────────────────────────────────────
+
+
+def test_grace_mode_collapses_channel_before_to_unlimited(ent):
+    # Under grace the resolved entitlement reports
+    # ``channel_limit() is None`` because there's no live cap. Each
+    # row's channel ``before`` therefore comes off the grace-resolved
+    # entitlement as ``None`` (the per-tier ``after`` is the target's
+    # static cap, so ``unlocked`` / ``locked`` still varies by direction
+    # -- that's the singular helper's job to settle).
+    rows = ent.capacity_diff_batch()
+    assert rows  # sanity: not short-circuiting under grace
+    for row in rows:
+        assert row["channel_limit"]["before"] is None
+
+
+# ── never-raise contract ─────────────────────────────────────────────────
+
+
+def test_batch_swallows_resolver_failure(monkeypatch, enforced):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(enforced, "capacity_diff", boom)
+    # The batch wraps :func:`capacity_diff` in a try/except envelope, so
+    # a synthetic blow-up inside the inner helper short-circuits to ``[]``
+    # rather than 500-ing the pricing page.
+    assert enforced.capacity_diff_batch() == []
+
+
+# ── API surface ──────────────────────────────────────────────────────────
+
+
+def test_api_returns_envelope_shape(client):
+    rv = client.get("/api/entitlement/capacity-diff-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body) == {
+        "tiers",
+        "current_tier",
+        "current_tier_rank",
+        "grace",
+        "enforced",
+    }
+    assert isinstance(body["tiers"], list)
+
+
+def test_api_rows_match_module_helper(client, ent):
+    rv = client.get("/api/entitlement/capacity-diff-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["tiers"] == ent.capacity_diff_batch()
+
+
+def test_api_carries_current_tier_under_enforce(enforced_client, enforced):
+    rv = enforced_client.get("/api/entitlement/capacity-diff-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    cur = enforced.get_entitlement()
+    assert body["current_tier"] == cur.tier
+    assert body["current_tier_rank"] == enforced.tier_rank(cur.tier)
+    assert body["enforced"] is True
+
+
+def test_api_carries_grace_envelope(client, ent):
+    rv = client.get("/api/entitlement/capacity-diff-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    cur = ent.get_entitlement()
+    assert body["grace"] is bool(cur.grace)
+    assert body["enforced"] is False
+
+
+def test_api_excludes_trial(client, ent):
+    rv = client.get("/api/entitlement/capacity-diff-batch")
+    body = rv.get_json()
+    ids = {row["target"] for row in body["tiers"]}
+    assert ent.TIER_TRIAL not in ids
+
+
+def test_api_returns_200_envelope_on_resolver_failure(monkeypatch, client):
+    # Force the resolver path used by the route to blow up; the route
+    # must still return a 200 with the grace-shape envelope so the
+    # pricing page keeps rendering instead of erroring out.
+    import clawmetry.entitlements as _ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(_ent, "capacity_diff_batch", boom)
+    rv = client.get("/api/entitlement/capacity-diff-batch")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body == {
+        "tiers": [],
+        "current_tier": "oss",
+        "current_tier_rank": 0,
+        "grace": True,
+        "enforced": False,
+    }


### PR DESCRIPTION
## Summary

Direction-agnostic capacity companion to the existing pricing-page batches (`tier_unlocks_batch`, `tier_locks_batch`, `preview_batch`).

- `clawmetry.entitlements.capacity_diff_batch()` -- per-tier `capacity_diff` payload for every entry in `_PURCHASABLE_TIERS` in `(rank, id)` order.
- `GET /api/entitlement/capacity-diff-batch` -- plural sibling of `/api/entitlement/capacity-diff`. Same `{tiers, current_tier, current_tier_rank, grace, enforced}` envelope shape as `/tier-unlocks-batch` and `/tier-locks-batch`.

Each row carries the singular `capacity_diff(tier)` payload exactly (`target`, `channel_limit`, `retention_days`, `node_limit`, where each axis is the `{before, after, delta, unlocked, locked}` triple), so a pricing-table UI can drop the round-trip-per-tier pattern and render the capacity column off one call.

Rung order is byte-stable against `tier_unlocks_batch` / `tier_locks_batch` / `preview_batch` -- all four batches walk `_PURCHASABLE_TIERS` in the same sort key so a pricing table lines up rung-for-rung without client-side re-sort. Trial is excluded (same posture as the other `*-batch` siblings -- not purchasable). Never raises: a resolver failure short-circuits to `[]`; the endpoint always returns 200 with the grace envelope so the pricing page keeps rendering.

Zero behavior change for existing surfaces -- this is purely additive. No new dependencies (uses the existing `clawmetry.entitlements` primitives).

## Tests

`tests/test_entitlement_capacity_diff_batch.py` -- 17 new tests covering:

- shape / triple-shape / per-row identity with the singular helper
- ordering pins (rank-then-id; byte-stable against the other three batches)
- trial exclusion + full purchasable coverage
- grace posture (channel `before` collapses to `None`)
- never-raise contract (resolver blow-up short-circuits to `[]` and to the grace envelope on the wrapper)
- API envelope shape, 200 on resolver failure, current-tier surfacing under both grace and enforce

```
$ python -m pytest tests/test_entitlement_capacity_diff_batch.py -q
17 passed in 0.24s

$ python -m pytest tests/ -k 'entitlement or entitlements' ...
956 passed, 4 skipped
```

`ruff check` clean on the three changed files; pre-existing dashboard.py errors are unrelated to this PR.

## Local operator verification checklist

I cannot run the live daemon, decrypt the cloud snapshot, or browser-check from this sandbox. Once CI is green, the local operator should:

- [ ] Copy the changed files into `~/.clawmetry/lib/pythonX.Y/site-packages/clawmetry/` (`entitlements.py`) and `~/.clawmetry/lib/pythonX.Y/site-packages/routes/` (`entitlement.py`).
- [ ] Clear `__pycache__` so the new helper / route are reloaded.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to bounce the daemon.
- [ ] `curl http://localhost:8900/api/entitlement/capacity-diff-batch | jq` -- verify the envelope shape and that the `tiers` array carries one row per purchasable tier with the per-axis triple.
- [ ] Cross-check rung order against `curl http://localhost:8900/api/entitlement/tier-unlocks-batch | jq '.tiers[].tier'` -- the two ordered ID lists must match byte-for-byte.
- [ ] Decrypt the live cloud snapshot and browser-check the pricing-page table (no regression on the existing columns).
- [ ] If everything looks right, mark this PR ready-for-review and handle the release / merge.

PR stays draft; no `__version__` bump and no `[RELEASE]` PR per the FLYWHEEL contract.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011UEZDU8tKTYDVM2F5heGSq)_