### PR TITLE
feat(entitlement): capacity_diff_path + /api/entitlement/capacity-diff-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1295,6 +1295,118 @@ def previous_tier_capacity_diff() -> dict | None:
         return None
 
 
+def _capacity_row(from_tier: str, to_tier: str) -> dict:
+    """Build one ``capacity_diff``-shape row for an arbitrary ``from -> to`` pair.
+
+    Singular-helper-shape row (``target``, ``channel_limit``, ``retention_days``,
+    ``node_limit``) computed off the static per-tier caps, NOT off the resolved
+    entitlement -- so a path / pair caller can compose marginal capacity steps
+    without pinning either side to the resolver.
+    """
+    return {
+        "target": to_tier,
+        "channel_limit": _capacity_transition(
+            _TIER_CHANNEL_LIMIT.get(from_tier, _FREE_CHANNEL_LIMIT),
+            _TIER_CHANNEL_LIMIT.get(to_tier, _FREE_CHANNEL_LIMIT),
+        ),
+        "retention_days": _capacity_transition(
+            _TIER_RETENTION_DAYS.get(from_tier, 7),
+            _TIER_RETENTION_DAYS.get(to_tier, 7),
+        ),
+        "node_limit": _capacity_transition(
+            _TIER_NODE_LIMIT.get(from_tier, _FREE_NODE_LIMIT),
+            _TIER_NODE_LIMIT.get(to_tier, _FREE_NODE_LIMIT),
+        ),
+    }
+
+
+def capacity_diff_path(from_tier: str, to_tier: str) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise capacity-transition path between two tiers.
+
+    Capacity-only path companion to :func:`tier_path` -- where the parent
+    helper returns the full :func:`tier_diff` payload per rung (added /
+    lost features + runtimes + ``capacity_changes``), this helper returns
+    just the singular :func:`capacity_diff` shape per rung
+    (``target``, ``channel_limit``, ``retention_days``, ``node_limit``)
+    so a capacity-only pricing widget can render the per-rung channel /
+    retention / node transitions off **one** round-trip without paying
+    for the feature / runtime set diff on every row.
+
+    Pairs with the ``*-batch`` family: :func:`capacity_diff_batch` walks
+    every purchasable tier as a cumulative "what does capacity look like
+    at each rung off the resolver" ladder; this helper walks an
+    arbitrary ``from -> to`` segment as a marginal "what happens to
+    capacity at each step between two endpoints" ladder. Same rung
+    semantics as :func:`tier_path`: visit every purchasable tier strictly
+    between ``from_tier`` and ``to_tier`` plus the destination
+    ``to_tier`` itself, in tier-rank order (ascending for an upgrade,
+    descending for a downgrade); same-rank siblings between the
+    endpoints are both included, same-rank siblings of the destination
+    are excluded so the path terminates exactly at ``to_tier``.
+
+    Each row's ``before`` side comes off the previous step's static
+    caps (or ``from_tier`` for the first row), so a consumer can fold
+    the rows to reconstruct the cumulative
+    ``tier_diff(from_tier, to_tier)['capacity_changes']`` shape. This is
+    deliberately decoupled from the resolved entitlement -- the path is
+    a hypothetical "if I walked from X to Y, what would each rung cost
+    me in capacity" view, not a "what would it cost from where I am
+    now" view (that's what :func:`capacity_diff_batch` is for).
+
+    Endpoint semantics match :func:`tier_diff` / :func:`tier_path`: both
+    ids accept any entry in :data:`_TIER_FEATURES` (including
+    :data:`TIER_TRIAL`, which is not purchasable -- excluded from the
+    walked rungs but is a valid endpoint for the marginal-step
+    computation). Identity (``from == to``) returns ``[]`` -- no rungs
+    to walk. Lateral (same rank, different id) returns a single-row
+    path: ``[_capacity_row(from, to)]``. Unknown ids on either side
+    short-circuit to ``None``.
+
+    Never raises: a resolver failure logs a warning and returns ``None``
+    so a pricing-page surface keeps rendering.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+        if from_rank == to_rank:
+            return [_capacity_row(f, t)]
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        prev_step = f
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            path.append(_capacity_row(prev_step, tid))
+            prev_step = tid
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: capacity_diff_path failed: %s", exc)
+        return None
+
+
 def capacity_diff_batch() -> list[dict]:
     """Per-tier capacity transition for every purchasable tier in one pass.
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -79,6 +79,16 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                           a pricing-page table can render
                                           the capacity column off one
                                           round-trip.
+  GET  /api/entitlement/capacity-diff-path -- path analogue of
+                                          ``/capacity-diff-batch``: per-rung
+                                          capacity transition along an
+                                          arbitrary ``?from=&to=`` segment,
+                                          capacity-only mirror of
+                                          ``/tier-path`` so a capacity-only
+                                          pricing widget can render
+                                          channel / retention / node
+                                          marginal steps between two tiers
+                                          off one round-trip.
   GET  /api/entitlement/preview-batch  -- plural sibling of ``/preview``:
                                          the full ``Entitlement.to_dict``
                                          shape rendered for every purchasable
@@ -443,6 +453,93 @@ def api_entitlement_capacity_diff_batch():
                 "grace": True,
                 "enforced": False,
             }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/capacity-diff-path")
+def api_entitlement_capacity_diff_path():
+    """``GET /api/entitlement/capacity-diff-path?from=<id>&to=<id>`` --
+    per-rung capacity transition along an arbitrary ``from -> to`` segment.
+    Path analogue of ``/capacity-diff-batch`` (which walks every purchasable
+    tier off the resolved entitlement); capacity-only mirror of
+    ``/tier-path`` (which carries the full ``tier_diff`` per rung). Lets a
+    capacity-only pricing widget render the channels / retention / nodes
+    marginal steps between any two tiers off ONE round-trip without paying
+    for the feature / runtime set diff on every row.
+
+    Rung walk matches ``/tier-path``: visit every purchasable tier strictly
+    between ``from`` and ``to`` plus the destination ``to`` itself, in
+    tier-rank order. Same-rank siblings between the endpoints are both
+    included; same-rank siblings of the destination are excluded so the
+    path terminates exactly at ``to``. Each row's ``before`` side comes
+    off the previous step's static caps (or ``from`` for the first row),
+    so a consumer can fold the rows to reconstruct the cumulative
+    ``tier_diff(from, to)['capacity_changes']`` shape.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<capacity_diff row>, ...],
+        }
+
+    Each ``<capacity_diff row>`` matches ``/capacity-diff`` exactly
+    (``target``, ``channel_limit``, ``retention_days``, ``node_limit``
+    where each axis is the same ``{before, after, delta, unlocked,
+    locked}`` triple). Identity (``from == to``) returns an empty path.
+    Lateral (same rank, different id) returns a single-row path. ``400``
+    when ``from=`` or ``to=`` is missing; ``404`` when either id is
+    unknown. ``trial`` IS accepted as an endpoint -- it is excluded from
+    the walked rungs (not purchasable) but the endpoint computation
+    still resolves. Never 5xxs: a resolver failure short-circuits to
+    ``404`` so a pricing-page surface keeps rendering instead of breaking.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        path = _ent.capacity_diff_path(f, t)
+        if path is None:
+            return (
+                jsonify({"error": "unknown tier", "from": f, "to": t}),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_capacity_diff_path: error: %s", exc)
+        return (
+            jsonify({"error": "unknown tier", "from": f, "to": t}),
+            404,
         )
 
 

--- a/tests/test_entitlement_capacity_diff_path.py
+++ b/tests/test_entitlement_capacity_diff_path.py
@@ -1,0 +1,469 @@
+"""Tests for ``clawmetry.entitlements.capacity_diff_path(from, to)`` + the
+``GET /api/entitlement/capacity-diff-path`` endpoint.
+
+Capacity-only path companion to :func:`tier_path`. Where the parent helper
+returns the full :func:`tier_diff` payload per rung (added / lost features +
+runtimes + ``capacity_changes``), this helper returns just the singular
+:func:`capacity_diff` shape per rung (``target``, ``channel_limit``,
+``retention_days``, ``node_limit``) so a capacity-only pricing widget can
+render the per-rung channel / retention / node transitions off **one**
+round-trip without paying for the feature / runtime set diff on every row.
+
+Pins:
+
+* same rung walk as :func:`tier_path` -- every purchasable tier strictly
+  between ``from`` and ``to`` plus the destination itself, in tier-rank
+  order; same-rank siblings of the destination excluded
+* each row matches the singular :func:`capacity_diff` row shape exactly
+  (``target``, ``channel_limit``, ``retention_days``, ``node_limit``)
+  with the full ``{before, after, delta, unlocked, locked}`` triple per
+  axis -- byte-stable against an arbitrary-endpoint call
+* row chain is continuous on every axis: row[i].axis.after ==
+  row[i+1].axis.before so a consumer can fold to reconstruct the
+  cumulative ``tier_diff(from, to)['capacity_changes']`` shape
+* identity (``from == to``) -> ``[]``; lateral (same rank, different id)
+  -> single row carrying the from->to transition
+* trial accepted as an endpoint -- excluded from the walked rungs (not
+  purchasable) but the endpoint computation still resolves
+* unknown / empty / garbage ids return ``None`` and never raise
+* path is decoupled from the resolved entitlement -- grace vs enforce
+  must NOT change the rows (same posture under both)
+* API surface: 400 on missing args, 404 on unknown ids, 200 with the
+  envelope shape on the happy path (incl. direction tag)
+* API 404s instead of 5xxing when the inner helper blows up
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def enforced(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ROW_KEYS = {"target", "channel_limit", "retention_days", "node_limit"}
+_AXIS_KEYS = {"before", "after", "delta", "unlocked", "locked"}
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+}
+
+
+# ── helper-level: shape + per-row contract ────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_has_singular_capacity_diff_shape(ent):
+    path = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == _ROW_KEYS
+        for axis in ("channel_limit", "retention_days", "node_limit"):
+            assert set(row[axis].keys()) == _AXIS_KEYS
+
+
+def test_target_is_the_destination_rung(ent):
+    """Each row's ``target`` is the rung that step lands on (matches the
+    singular ``capacity_diff(target)`` contract)."""
+    path = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert path[-1]["target"] == ent.TIER_ENTERPRISE
+    for row in path:
+        assert row["target"] in ent._PURCHASABLE_TIERS
+
+
+# ── rung walk: same shape as tier_path ────────────────────────────────────
+
+
+def test_chain_is_continuous_per_axis(ent):
+    """row[i].axis.after == row[i+1].axis.before for every axis -- the
+    marginal-step chain a consumer folds to reproduce the cumulative
+    ``tier_diff(from, to)['capacity_changes']`` shape."""
+    path = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for axis in ("channel_limit", "retention_days", "node_limit"):
+        for i in range(len(path) - 1):
+            assert path[i][axis]["after"] == path[i + 1][axis]["before"]
+
+
+def test_first_row_before_matches_from_tier_caps(ent):
+    """First rung's ``before`` is the ``from`` tier's static caps (NOT the
+    resolved entitlement's), so the path is hypothetical and decoupled
+    from the resolver."""
+    path = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    first = path[0]
+    assert first["channel_limit"]["before"] == ent._TIER_CHANNEL_LIMIT[ent.TIER_OSS]
+    assert first["retention_days"]["before"] == ent._TIER_RETENTION_DAYS[ent.TIER_OSS]
+    assert first["node_limit"]["before"] == ent._TIER_NODE_LIMIT[ent.TIER_OSS]
+
+
+def test_last_row_after_matches_to_tier_caps(ent):
+    """Terminal rung's ``after`` is the ``to`` tier's static caps."""
+    path = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    last = path[-1]
+    assert last["channel_limit"]["after"] == ent._TIER_CHANNEL_LIMIT[ent.TIER_ENTERPRISE]
+    assert (
+        last["retention_days"]["after"] == ent._TIER_RETENTION_DAYS[ent.TIER_ENTERPRISE]
+    )
+    assert last["node_limit"]["after"] == ent._TIER_NODE_LIMIT[ent.TIER_ENTERPRISE]
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    """``pro`` and ``cloud_pro`` share rank 2; asking for ``pro`` must end
+    exactly at ``pro`` and EXCLUDE the same-rank sibling ``cloud_pro``
+    from the final rung -- same rule as ``tier_path``."""
+    targets = [r["target"] for r in ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_PRO)]
+    assert targets[-1] == ent.TIER_PRO
+    assert targets.count(ent.TIER_PRO) == 1
+    assert ent.TIER_CLOUD_PRO not in targets
+
+
+def test_same_rank_siblings_between_endpoints_both_included(ent):
+    """Walking oss -> enterprise: rank-2 siblings cloud_pro AND pro both
+    appear because they sit strictly *between* the rank-0 start and the
+    rank-3 destination."""
+    targets = [
+        r["target"]
+        for r in ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    ]
+    assert ent.TIER_CLOUD_PRO in targets
+    assert ent.TIER_PRO in targets
+    assert targets[-1] == ent.TIER_ENTERPRISE
+
+
+def test_rung_walk_byte_equal_to_tier_path(ent):
+    """``capacity_diff_path`` and ``tier_path`` must agree on which rungs
+    to visit and in which order -- the capacity helper is just a narrower
+    projection of the full-diff walk, so the pair stays in lock-step."""
+    cap = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    full = ent.tier_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert [r["target"] for r in cap] == [r["to"] for r in full]
+
+
+# ── identity / lateral / adjacent ────────────────────────────────────────
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        assert ent.capacity_diff_path(tid, tid) == []
+
+
+def test_lateral_is_single_row(ent):
+    """Same rank, different id -- one row carrying the from->to transition.
+    Note: lateral capacity transitions on the current ladder are no-ops
+    (all paid tiers share unlimited channel/node caps), so this primarily
+    pins the row count + endpoint identity, not the delta shape."""
+    path = ent.capacity_diff_path(ent.TIER_CLOUD_PRO, ent.TIER_PRO)
+    assert len(path) == 1
+    assert path[0]["target"] == ent.TIER_PRO
+    # before-side reads off the from tier, after-side off the to tier
+    for axis in ("channel_limit", "retention_days", "node_limit"):
+        assert path[0][axis]["before"] == getattr(ent, f"_TIER_{axis.upper()}").get(
+            ent.TIER_CLOUD_PRO,
+            None,
+        )
+        assert path[0][axis]["after"] == getattr(ent, f"_TIER_{axis.upper()}").get(
+            ent.TIER_PRO,
+            None,
+        )
+
+
+def test_oss_to_cloud_free_lateral(ent):
+    """Both rank 0 -- lateral single-row path."""
+    path = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_CLOUD_FREE)
+    assert len(path) == 1
+    assert path[0]["target"] == ent.TIER_CLOUD_FREE
+
+
+def test_adjacent_step_is_one_row(ent):
+    """oss (rank 0) -> cloud_starter (rank 1) is a single rank-up step."""
+    path = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert len(path) == 1
+    assert path[0]["target"] == ent.TIER_CLOUD_STARTER
+    # channels go from finite (3) to unlimited -- unlocked flag flips True
+    assert path[0]["channel_limit"]["unlocked"] is True
+    assert path[0]["channel_limit"]["before"] == ent._FREE_CHANNEL_LIMIT
+    assert path[0]["channel_limit"]["after"] is None
+
+
+# ── descending mirror ───────────────────────────────────────────────────
+
+
+def test_descending_path_terminates_at_to(ent):
+    path = ent.capacity_diff_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    assert path[-1]["target"] == ent.TIER_OSS
+    # closest-to-from rung first
+    assert ent._TIER_RANK[path[0]["target"]] < ent._TIER_RANK[ent.TIER_ENTERPRISE]
+
+
+def test_descending_terminates_at_explicit_floor(ent):
+    """Asking for ``oss`` must NOT also include ``cloud_free`` (the other
+    rank-0 sibling) as a terminal rung."""
+    targets = [
+        r["target"]
+        for r in ent.capacity_diff_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    ]
+    assert targets[-1] == ent.TIER_OSS
+    assert targets.count(ent.TIER_OSS) == 1
+
+
+def test_descending_chain_is_continuous(ent):
+    path = ent.capacity_diff_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    for axis in ("channel_limit", "retention_days", "node_limit"):
+        for i in range(len(path) - 1):
+            assert path[i][axis]["after"] == path[i + 1][axis]["before"]
+
+
+def test_descending_loses_channel_cap_at_floor(ent):
+    """Walking enterprise -> oss the channel cap goes unlimited -> 3 by the
+    floor rung; the ``locked`` flag flips True there (unlimited becoming
+    finite)."""
+    path = ent.capacity_diff_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    final = path[-1]
+    assert final["target"] == ent.TIER_OSS
+    assert final["channel_limit"]["locked"] is True
+    assert final["channel_limit"]["before"] is None
+    assert final["channel_limit"]["after"] == ent._FREE_CHANNEL_LIMIT
+
+
+# ── trial endpoint ───────────────────────────────────────────────────────
+
+
+def test_trial_excluded_from_walked_rungs_but_valid_endpoint(ent):
+    """``trial`` is not purchasable -- it must never appear as a stop on a
+    path between purchasable tiers, but resolves as an endpoint."""
+    path = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["target"] != ent.TIER_TRIAL
+    upward = ent.capacity_diff_path(ent.TIER_TRIAL, ent.TIER_ENTERPRISE)
+    assert upward is not None
+    assert upward[-1]["target"] == ent.TIER_ENTERPRISE
+    downward = ent.capacity_diff_path(ent.TIER_TRIAL, ent.TIER_OSS)
+    assert downward is not None
+    assert downward[-1]["target"] == ent.TIER_OSS
+
+
+# ── decoupled from the resolver ──────────────────────────────────────────
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, enforced):
+    """The path is built off the static per-tier maps, not the resolved
+    entitlement -- flipping enforce on must NOT change the rows."""
+    grace_rows = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    enforced_rows = enforced.capacity_diff_path(
+        enforced.TIER_OSS, enforced.TIER_ENTERPRISE
+    )
+    assert grace_rows == enforced_rows
+
+
+# ── fold reproduces cumulative tier_diff capacity ────────────────────────
+
+
+def test_fold_matches_cumulative_tier_diff_capacity(ent):
+    """Folding the per-step marginal capacity rows reproduces the cumulative
+    ``tier_diff(from, to)['capacity_changes']`` after/before pair."""
+    f, t = ent.TIER_OSS, ent.TIER_ENTERPRISE
+    path = ent.capacity_diff_path(f, t)
+    direct = ent.tier_diff(f, t)["capacity_changes"]
+    for axis in ("channel_limit", "retention_days", "node_limit"):
+        assert path[0][axis]["before"] == direct[axis]["before"]
+        assert path[-1][axis]["after"] == direct[axis]["after"]
+
+
+# ── unknown / garbage inputs never raise ─────────────────────────────────
+
+
+def test_unknown_tiers_return_none(ent):
+    assert ent.capacity_diff_path("not_a_tier", ent.TIER_ENTERPRISE) is None
+    assert ent.capacity_diff_path(ent.TIER_OSS, "still_not_a_tier") is None
+    assert ent.capacity_diff_path("a", "b") is None
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.capacity_diff_path("", "") is None
+    assert ent.capacity_diff_path(None, None) is None  # type: ignore[arg-type]
+    assert ent.capacity_diff_path("  ", "  ") is None
+    assert ent.capacity_diff_path(123, 456) is None  # type: ignore[arg-type]
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    b = ent.capacity_diff_path("  OSS ", " ENTERPRISE  ")
+    assert a == b
+
+
+def test_helper_swallows_resolver_failure(monkeypatch, ent):
+    """A blow-up in the inner row builder must short-circuit the helper to
+    ``None`` (logged-warning + graceful fallback contract)."""
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "_capacity_row", boom)
+    assert ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE) is None
+
+
+# ── API surface ──────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_args(client):
+    assert (
+        client.get("/api/entitlement/capacity-diff-path").status_code == 400
+    )
+    assert (
+        client.get("/api/entitlement/capacity-diff-path?from=oss").status_code == 400
+    )
+    assert (
+        client.get("/api/entitlement/capacity-diff-path?to=cloud_pro").status_code
+        == 400
+    )
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get(
+        "/api/entitlement/capacity-diff-path?from=oss&to=not_a_tier"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["to"] == "not_a_tier"
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-diff-path"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["target"] == ent.TIER_ENTERPRISE
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-diff-path"
+        f"?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    assert body["path"][-1]["target"] == ent.TIER_OSS
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-diff-path"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-diff-path"
+        f"?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["target"] == ent.TIER_PRO
+
+
+def test_api_trial_endpoint_accepted(client, ent):
+    r = client.get(
+        "/api/entitlement/capacity-diff-path"
+        f"?from={ent.TIER_TRIAL}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["path"][-1]["target"] == ent.TIER_ENTERPRISE
+
+
+def test_api_path_byte_equals_helper(client, ent):
+    """The wrapper endpoint must echo the module helper's rows verbatim --
+    no client-side re-derivation in the route, otherwise the singular
+    capacity_diff posture and the path rows can drift."""
+    r = client.get(
+        "/api/entitlement/capacity-diff-path"
+        f"?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["path"] == ent.capacity_diff_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+
+
+def test_api_404_on_resolver_failure(monkeypatch, client):
+    """Force the resolver path used by the route to blow up; the route
+    must short-circuit to a 404 envelope instead of leaking a 500 to
+    the pricing page."""
+    import clawmetry.entitlements as _ent
+
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(_ent, "capacity_diff_path", boom)
+    r = client.get(
+        "/api/entitlement/capacity-diff-path?from=oss&to=enterprise"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"


### PR DESCRIPTION
## Summary

Adds `capacity_diff_path(from, to)` to `clawmetry.entitlements` and the companion `GET /api/entitlement/capacity-diff-path` endpoint — a **capacity-only path analogue** of `/tier-path`, so a capacity-only pricing widget can render per-rung channel / retention / node marginal steps between any two tiers off ONE round-trip.

| Helper                  | Walk                                | Per-rung row shape                                                                |
| ----------------------- | ----------------------------------- | --------------------------------------------------------------------------------- |
| `tier_path`             | arbitrary `from → to`               | full `tier_diff` (added/lost features+runtimes + `capacity_changes`)              |
| `capacity_diff_batch`   | every purchasable tier off resolver | singular `capacity_diff` (target + 3 axes)                                        |
| **`capacity_diff_path`**| **arbitrary `from → to`**           | **singular `capacity_diff` (target + 3 axes), `before` chained from previous rung** |

Rung walk is byte-stable against `tier_path`: every purchasable tier strictly between `from` and `to` plus the destination itself, in tier-rank order; same-rank siblings of the destination excluded so the path terminates exactly at `to`.

## Design notes

- **Purely additive; zero behavior change to existing surfaces.** No edits to existing helpers; the new `_capacity_row` private builder is only used by `capacity_diff_path` (the batch still calls `capacity_diff()` so its resolver-pinned semantics stay intact).
- **Row chain is continuous on every axis**: `row[i].axis.after == row[i+1].axis.before` so a consumer can fold to reconstruct the cumulative `tier_diff(from, to)['capacity_changes']` shape.
- **Decoupled from the resolved entitlement** (built off the static per-tier maps), so grace vs enforce yields identical rows — the path is the hypothetical "if I walked X to Y" view, complementing `capacity_diff_batch`'s resolver-pinned "from where I am now" view.
- **Never raises** in the helper; endpoint returns `400` on missing args, `404` on unknown ids / resolver failure, `200` with the envelope on the happy path.

## API envelope

```
GET /api/entitlement/capacity-diff-path?from=<id>&to=<id>

{
  "from":       "<tier id>",
  "from_label": "...",
  "from_rank":  <int>,
  "to":         "<tier id>",
  "to_label":   "...",
  "to_rank":    <int>,
  "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
  "path":       [<capacity_diff row>, ...]
}
```

Each `<capacity_diff row>` matches `/capacity-diff` exactly (`target`, `channel_limit`, `retention_days`, `node_limit` — each axis is the same `{before, after, delta, unlocked, locked}` triple).

## Tests

33 new tests covering: row shape, per-axis chain continuity, rung-walk byte-equality with `tier_path`, identity / lateral / adjacent edge cases, trial endpoint, grace/enforce row identity (resolver-independence), fold-matches-cumulative-`tier_diff` invariant, garbage-input never-raise contract, and the full API surface (400 / 404 / 200 / lateral / identity / trial / route-helper byte-equality / 404-on-resolver-failure).

```
$ python3 -m pytest tests/test_entitlement_capacity_diff_path.py -v
33 passed in 0.36s

$ python3 -m pytest tests/test_entitlement_*.py
978 passed in 7.38s

$ ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_capacity_diff_path.py
All checks passed!
```

The `lint-daemon-allowlist` Makefile target reports `query_cache_metrics` / `query_channel_delivery_health` failures, but those are **pre-existing on `origin/main`** (verified via `git stash`) and unrelated to this change.

## Local operator verification checklist

I can't reach the local daemon, `~/.openclaw`, or the live cloud snapshot — please do these on your box before flipping the PR to ready / releasing:

- [ ] Copy changed files into the daemon's site-packages:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/`
- [ ] Clear `__pycache__`:
      `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the sync daemon:
      `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint locally:
      `curl -s 'http://localhost:8900/api/entitlement/capacity-diff-path?from=oss&to=enterprise' | jq`
      → expect envelope with `direction: "upgrade"`, `path[-1].target == "enterprise"`, axes carrying full `{before, after, delta, unlocked, locked}` triples
- [ ] Spot-check the existing surfaces still work:
      `curl -s 'http://localhost:8900/api/entitlement/capacity-diff-batch' | jq '.tiers | length'` (unchanged)
      `curl -s 'http://localhost:8900/api/entitlement/tier-path?from=oss&to=enterprise' | jq '.path | length'` (unchanged)
- [ ] Decrypt the live cloud snapshot and confirm the entitlement panel still renders.
- [ ] Browser-check `localhost:8900` for any pricing-page regressions.

Cloud (`clawmetry-cloud`) and `clawmetry-pro` work in P3/P4/P6 is **out of scope for this PR** — those require the private repos this agent does not have access to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011YMZDQk5t99U9A1iqswYbv)_