### PR TITLE
fix(nemoclaw): surface sandbox runtime.kind (terminal vs docker)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -198,12 +198,12 @@ def _list_ollama_models(host: str) -> list:
 
 
 def _openshell_sandbox_phase_policy(name: str) -> dict:
-    """Call 'openshell sandbox get <name>' and parse Phase / Policy fields.
+    """Call 'openshell sandbox get <name>' and parse Phase / Policy / Runtime fields.
 
-    Returns a dict with 'sandboxPhase' and/or 'sandboxPolicy' keys from the
-    CLI output.  Never raises; returns {} when the openshell binary is absent
-    (plain OpenClaw installs) or the subprocess call fails, so existing entries
-    are left unchanged.
+    Returns a dict with 'sandboxPhase', 'sandboxPolicy', and/or
+    'sandboxRuntimeKind' keys from the CLI output.  Never raises; returns {}
+    when the openshell binary is absent (plain OpenClaw installs) or the
+    subprocess call fails, so existing entries are left unchanged.
     """
     try:
         import shutil as _sh
@@ -220,6 +220,8 @@ def _openshell_sandbox_phase_policy(name: str) -> dict:
                 out["sandboxPhase"] = line.split(":", 1)[1].strip()
             elif line.startswith("Policy:"):
                 out["sandboxPolicy"] = line.split(":", 1)[1].strip()
+            elif line.startswith("Runtime:"):
+                out["sandboxRuntimeKind"] = line.split(":", 1)[1].strip()
         return out
     except Exception:
         return {}
@@ -261,6 +263,13 @@ def _sandbox_inference_configs() -> list:
             provider = entry.get("provider") or ""
             model = entry.get("model") or ""
             api = entry.get("preferredInferenceApi") or "openai-completions"
+            # Read runtimeKind from JSON before the loop variable is shadowed
+            # below. openshell output takes precedence; this is the fallback.
+            json_runtime_kind = (
+                entry.get("runtimeKind")
+                or (entry.get("runtime") or {}).get("kind")
+                or ""
+            )
             base_url = _MANAGED_URL
             if provider == "openai-api":
                 provider_key = "openai"
@@ -291,6 +300,8 @@ def _sandbox_inference_configs() -> list:
                     "ollamaModels": _list_ollama_models(ollama_host),
                 }
                 entry.update(_openshell_sandbox_phase_policy(name))
+                if json_runtime_kind and "sandboxRuntimeKind" not in entry:
+                    entry["sandboxRuntimeKind"] = json_runtime_kind
                 out.append(entry)
                 continue
             else:
@@ -309,6 +320,8 @@ def _sandbox_inference_configs() -> list:
                 "inferenceCompat": compat,
             }
             entry.update(_openshell_sandbox_phase_policy(name))
+            if json_runtime_kind and "sandboxRuntimeKind" not in entry:
+                entry["sandboxRuntimeKind"] = json_runtime_kind
             out.append(entry)
         except Exception:
             continue

--- a/tests/test_obs_gap_nemoclaw_runtime_kind_3273.py
+++ b/tests/test_obs_gap_nemoclaw_runtime_kind_3273.py
@@ -1,0 +1,171 @@
+"""Tests for #3273 -- _openshell_sandbox_phase_policy and
+_sandbox_inference_configs surface sandbox runtime.kind (terminal vs docker).
+"""
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from clawmetry.adapters.openclaw import (
+    _openshell_sandbox_phase_policy,
+    _sandbox_inference_configs,
+)
+
+
+# -- _openshell_sandbox_phase_policy ------------------------------------------
+
+def test_phase_policy_parses_runtime_line(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "Name: alpha\nPhase: Ready\nRuntime: terminal\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    result = _openshell_sandbox_phase_policy("alpha")
+    assert result["sandboxRuntimeKind"] == "terminal"
+    assert result["sandboxPhase"] == "Ready"
+
+
+def test_phase_policy_runtime_docker(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "Name: b\nPhase: Ready\nRuntime: docker\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    result = _openshell_sandbox_phase_policy("b")
+    assert result["sandboxRuntimeKind"] == "docker"
+
+
+def test_phase_policy_absent_runtime_line_returns_no_key(monkeypatch):
+    """Backwards-compatible: when Runtime: is absent the key is not set."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "Name: alpha\nPhase: Ready\nPolicy: strict\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    result = _openshell_sandbox_phase_policy("alpha")
+    assert "sandboxRuntimeKind" not in result
+
+
+def test_phase_policy_no_openshell_no_runtime(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+    assert _openshell_sandbox_phase_policy("alpha") == {}
+
+
+# -- _sandbox_inference_configs: openshell runtime surfacing ------------------
+
+def test_sandbox_configs_surfaces_runtime_kind_from_openshell(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": "alpha",
+        "sandboxes": {"alpha": {"provider": "anthropic-prod", "model": "claude-opus-4-5"}},
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "Name: alpha\nPhase: Ready\nRuntime: terminal\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    assert result[0]["sandboxRuntimeKind"] == "terminal"
+    assert result[0]["sandboxPhase"] == "Ready"
+
+
+def test_sandbox_configs_surfaces_runtime_kind_from_json_field(tmp_path, monkeypatch):
+    """runtimeKind in sandboxes.json is used when openshell is absent."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "sandboxes": {
+            "dev": {
+                "provider": "openai-api",
+                "model": "gpt-4o",
+                "runtimeKind": "docker",
+            }
+        }
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    assert result[0]["sandboxRuntimeKind"] == "docker"
+
+
+def test_sandbox_configs_surfaces_runtime_kind_from_nested_json(tmp_path, monkeypatch):
+    """Nested runtime.kind in JSON entry is also read as a fallback."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "sandboxes": {
+            "dev": {
+                "provider": "openai-api",
+                "model": "gpt-4o",
+                "runtime": {"kind": "terminal"},
+            }
+        }
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    assert result[0]["sandboxRuntimeKind"] == "terminal"
+
+
+def test_openshell_runtime_takes_precedence_over_json(tmp_path, monkeypatch):
+    """Live openshell value wins over stale JSON field."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "sandboxes": {
+            "alpha": {
+                "provider": "anthropic-prod",
+                "model": "claude-haiku-4-5",
+                "runtimeKind": "docker",  # stale value in JSON
+            }
+        }
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "Name: alpha\nRuntime: terminal\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+
+    result = _sandbox_inference_configs()
+    assert result[0]["sandboxRuntimeKind"] == "terminal"
+
+
+def test_sandbox_configs_no_runtime_field_when_absent(tmp_path, monkeypatch):
+    """When neither openshell nor JSON provides runtimeKind, the key is absent."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "sandboxes": {"dev": {"provider": "openai-api", "model": "gpt-4o"}}
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    assert "sandboxRuntimeKind" not in result[0]
+
+
+def test_sandbox_configs_ollama_surfaces_runtime_from_openshell(tmp_path, monkeypatch):
+    """Ollama sandboxes also get sandboxRuntimeKind from openshell."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OLLAMA_HOST_DOCKER_INTERNAL", raising=False)
+    monkeypatch.delenv("OLLAMA_LOCALHOST", raising=False)
+    cfg = {
+        "sandboxes": {"local": {"provider": "ollama", "model": "llama3"}}
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    import urllib.request
+    monkeypatch.setattr(urllib.request, "urlopen",
+                        lambda *a, **kw: (_ for _ in ()).throw(OSError()))
+    fake = type("R", (), {"stdout": "Name: local\nRuntime: terminal\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    assert result[0]["providerKey"] == "ollama"
+    assert result[0]["sandboxRuntimeKind"] == "terminal"


### PR DESCRIPTION
Closes #3273

## Summary
- `_openshell_sandbox_phase_policy()`: adds parsing of a `Runtime:` line from `openshell sandbox get <name>` output → `sandboxRuntimeKind`, exactly mirroring the existing `Phase:` / `Policy:` handling
- `_sandbox_inference_configs()`: also reads `runtimeKind` (or nested `runtime.kind`) from the raw sandboxes.json entry before the loop variable is shadowed; merged as a fallback when openshell doesn't provide the field
- New test file `tests/test_obs_gap_nemoclaw_runtime_kind_3273.py` (10 tests, all pass) covering both openshell and JSON paths, precedence, and all provider types (anthropic, openai, managed, ollama)

## Test plan
- [ ] `python3 -m pytest tests/test_obs_gap_nemoclaw_runtime_kind_3273.py -v` — 10/10 pass
- [ ] `python3 -m pytest tests/test_obs_gap_nemoclaw_sandbox_phase_3202.py tests/test_obs_gap_nemoclaw_ollama_3201.py -v` — all pass, no regression

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMG4nCtsWyyHwkm9yCamf1)_