### PR TITLE
fix(nemoclaw): surface per-sandbox ocsf_json_enabled flag (#3274)

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -227,6 +227,32 @@ def _openshell_sandbox_phase_policy(name: str) -> dict:
         return {}
 
 
+def _openshell_sandbox_ocsf_enabled(name: str) -> dict:
+    """Call 'openshell settings get <name>' and surface sandboxOcsfJsonEnabled.
+
+    Returns {"sandboxOcsfJsonEnabled": bool} when the ocsf_json_enabled key
+    is present in the settings output, {} otherwise.  Never raises; returns {}
+    when openshell is absent (plain OpenClaw installs) or the call fails.
+    """
+    try:
+        import shutil as _sh
+        if not _sh.which("openshell"):
+            return {}
+        import subprocess as _sp
+        res = _sp.run(
+            ["openshell", "settings", "get", name],
+            capture_output=True, text=True, timeout=5,
+        )
+        for line in (res.stdout or "").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("ocsf_json_enabled:"):
+                val = stripped.split(":", 1)[1].strip().lower()
+                return {"sandboxOcsfJsonEnabled": val == "true"}
+        return {}
+    except Exception:
+        return {}
+
+
 def _sandbox_inference_configs() -> list:
     """Read per-sandbox inference config from ~/.nemoclaw/sandboxes.json.
 
@@ -300,6 +326,7 @@ def _sandbox_inference_configs() -> list:
                     "ollamaModels": _list_ollama_models(ollama_host),
                 }
                 entry.update(_openshell_sandbox_phase_policy(name))
+                entry.update(_openshell_sandbox_ocsf_enabled(name))
                 if json_runtime_kind and "sandboxRuntimeKind" not in entry:
                     entry["sandboxRuntimeKind"] = json_runtime_kind
                 out.append(entry)
@@ -320,6 +347,7 @@ def _sandbox_inference_configs() -> list:
                 "inferenceCompat": compat,
             }
             entry.update(_openshell_sandbox_phase_policy(name))
+            entry.update(_openshell_sandbox_ocsf_enabled(name))
             if json_runtime_kind and "sandboxRuntimeKind" not in entry:
                 entry["sandboxRuntimeKind"] = json_runtime_kind
             out.append(entry)

--- a/tests/test_obs_gap_nemoclaw_ocsf_3274.py
+++ b/tests/test_obs_gap_nemoclaw_ocsf_3274.py
@@ -1,0 +1,162 @@
+"""Tests for #3274 -- _openshell_sandbox_ocsf_enabled surfaces the
+ocsf_json_enabled setting per NemoClaw sandbox in DetectResult.meta.sandboxInferenceConfigs.
+"""
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from clawmetry.adapters.openclaw import (
+    _openshell_sandbox_ocsf_enabled,
+    _sandbox_inference_configs,
+)
+
+
+# -- _openshell_sandbox_ocsf_enabled ------------------------------------------
+
+def test_ocsf_returns_empty_when_openshell_absent(monkeypatch):
+    """No openshell binary -> {} with no exception."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+    assert _openshell_sandbox_ocsf_enabled("alpha") == {}
+
+
+def test_ocsf_enabled_true(monkeypatch):
+    """ocsf_json_enabled: true -> {"sandboxOcsfJsonEnabled": True}."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "some_key: value\nocsf_json_enabled: true\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    result = _openshell_sandbox_ocsf_enabled("alpha")
+    assert result == {"sandboxOcsfJsonEnabled": True}
+
+
+def test_ocsf_enabled_false(monkeypatch):
+    """ocsf_json_enabled: false -> {"sandboxOcsfJsonEnabled": False}."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "ocsf_json_enabled: false\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    result = _openshell_sandbox_ocsf_enabled("beta")
+    assert result == {"sandboxOcsfJsonEnabled": False}
+
+
+def test_ocsf_key_absent_returns_empty(monkeypatch):
+    """Output without ocsf_json_enabled -> {}."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "some_key: value\nother_key: 123\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    assert _openshell_sandbox_ocsf_enabled("gamma") == {}
+
+
+def test_ocsf_subprocess_error_returns_empty(monkeypatch):
+    """Subprocess failure -> {} never raises."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    def boom(*a, **kw):
+        raise OSError("binary broken")
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert _openshell_sandbox_ocsf_enabled("alpha") == {}
+
+
+def test_ocsf_empty_stdout_returns_empty(monkeypatch):
+    """Empty stdout -> {} with no exception."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": ""})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    assert _openshell_sandbox_ocsf_enabled("beta") == {}
+
+
+def test_ocsf_case_insensitive_value(monkeypatch):
+    """Value matching is case-insensitive (TRUE / True / true all work)."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    fake = type("R", (), {"stdout": "ocsf_json_enabled: TRUE\n"})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake)
+    result = _openshell_sandbox_ocsf_enabled("alpha")
+    assert result == {"sandboxOcsfJsonEnabled": True}
+
+
+# -- integration: _sandbox_inference_configs merges OCSF flag ----------------
+
+def test_sandbox_inference_configs_includes_ocsf_flag(tmp_path, monkeypatch):
+    """sandboxInferenceConfigs entries gain sandboxOcsfJsonEnabled when
+    openshell settings reports the flag."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": "alpha",
+        "sandboxes": {
+            "alpha": {"provider": "anthropic-prod", "model": "claude-opus-4-5"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+
+    def fake_run(cmd, **kw):
+        # cmd form: ["openshell", "settings", "get", <name>] or sandbox variant
+        if cmd[1] == "settings":
+            return type("R", (), {"stdout": "ocsf_json_enabled: true\n"})()
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    r = result[0]
+    assert r["sandboxOcsfJsonEnabled"] is True
+    assert r["providerKey"] == "anthropic"
+    assert r["isDefault"] is True
+
+
+def test_sandbox_inference_configs_no_ocsf_when_openshell_absent(tmp_path, monkeypatch):
+    """When openshell is absent, entries are returned without sandboxOcsfJsonEnabled
+    (backwards-compatible)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": None,
+        "sandboxes": {
+            "dev": {"provider": "openai-api", "model": "gpt-4o"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 1
+    assert "sandboxOcsfJsonEnabled" not in result[0]
+    assert result[0]["providerKey"] == "openai"
+
+
+def test_sandbox_inference_configs_ocsf_per_sandbox(tmp_path, monkeypatch):
+    """Each sandbox is queried independently; OCSF flag can differ per sandbox."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = {
+        "defaultSandbox": "prod",
+        "sandboxes": {
+            "prod": {"provider": "anthropic-prod", "model": "claude-opus-4-5"},
+            "dev": {"provider": "openai-api", "model": "gpt-4o"},
+        },
+    }
+    (tmp_path / ".nemoclaw").mkdir()
+    (tmp_path / ".nemoclaw" / "sandboxes.json").write_text(json.dumps(cfg))
+
+    ocsf_states = {"prod": "true", "dev": "false"}
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+
+    def fake_run(cmd, **kw):
+        # cmd form: ["openshell", "settings", "get", <sandbox_name>]
+        #       or: ["openshell", "sandbox",  "get", <sandbox_name>]
+        if cmd[1] == "settings":
+            sandbox_name = cmd[3]
+            return type("R", (), {
+                "stdout": f"ocsf_json_enabled: {ocsf_states[sandbox_name]}\n"
+            })()
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = _sandbox_inference_configs()
+    assert len(result) == 2
+    by_name = {r["sandbox"]: r for r in result}
+    assert by_name["prod"]["sandboxOcsfJsonEnabled"] is True
+    assert by_name["dev"]["sandboxOcsfJsonEnabled"] is False


### PR DESCRIPTION
Closes #3274

## What

- Adds `_openshell_sandbox_ocsf_enabled(name)` helper in `clawmetry/adapters/openclaw.py` that calls `openshell settings get <sandbox>` and parses the `ocsf_json_enabled:` line.
- Wires it into `_sandbox_inference_configs()` (both the ollama branch and the main branch) so every sandbox entry gains `sandboxOcsfJsonEnabled: bool` when the flag is set.
- Backwards-compatible: field is simply absent when openshell is unavailable or the key isn't in the settings output.

## Test plan

- `python -m pytest tests/test_obs_gap_nemoclaw_ocsf_3274.py -v` — 10 tests, all green (helper + integration through `_sandbox_inference_configs`)
- Existing sandbox-phase tests (`test_obs_gap_nemoclaw_sandbox_phase_3202.py`) unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_0139z5WgvuC56VX4bpUm1e9V)_