### PR TITLE
feat(entitlement): tier_unlocks_path + /api/entitlement/tier-unlocks-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1548,6 +1548,160 @@ def tier_unlocks_batch() -> list[dict]:
         return []
 
 
+def _unlocks_row(from_tier: str, to_tier: str) -> dict | None:
+    """Single marginal-unlocks row between two arbitrary tiers, with the
+    source carried as ``previous_tier`` (path-chained, **not** the global
+    next-lower-purchasable-tier anchor used by :func:`tier_unlocks`).
+
+    Private builder for :func:`tier_unlocks_path`: each row is "what the
+    `to` rung first unlocks vs the previous step in the walked path" so a
+    consumer can fold the per-rung rows to reconstruct the cumulative
+    ``tier_diff(from, to)['added_*']`` shape -- the same chain-property
+    :func:`tier_path` and :func:`capacity_diff_path` enforce on their rows.
+
+    Returns ``None`` on unknown ids and never raises -- the path walker
+    drops ``None`` rows on the floor so a pricing surface keeps rendering.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        from_feats = FREE_FEATURES | _TIER_FEATURES.get(f, frozenset())
+        if f == TIER_ENTERPRISE:
+            from_feats = from_feats | ENTERPRISE_FEATURES
+        to_feats = FREE_FEATURES | _TIER_FEATURES.get(t, frozenset())
+        if t == TIER_ENTERPRISE:
+            to_feats = to_feats | ENTERPRISE_FEATURES
+        from_runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if f in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        to_runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if t in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        return {
+            "tier": t,
+            "tier_label": tier_label(t),
+            "tier_rank": tier_rank(t),
+            "previous_tier": f,
+            "previous_tier_label": tier_label(f),
+            "previous_tier_rank": tier_rank(f),
+            "features": sorted(to_feats - from_feats),
+            "runtimes": sorted(to_runtimes - from_runtimes),
+        }
+    except Exception as exc:
+        logger.warning("entitlements: _unlocks_row failed: %s", exc)
+        return None
+
+
+def tier_unlocks_path(from_tier: str, to_tier: str) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise unlock path between two tiers.
+
+    Unlocks-focused analogue of :func:`tier_path` and unlocks-focused
+    path analogue of :func:`tier_unlocks` -- the third member of the
+    ``_path`` family alongside :func:`tier_path` (full ``tier_diff`` per
+    rung) and :func:`capacity_diff_path` (capacity-only per rung). Lets
+    an "upgrade-walkthrough" surface render only the *newly-unlocked*
+    features + runtimes at each rung between any two tiers off ONE
+    round-trip, without the noise of the capacity axes or the symmetric
+    ``lost_*`` lists that :func:`tier_path` carries.
+
+    Per-rung row shape matches :func:`tier_unlocks` exactly --
+    ``tier``, ``tier_label``, ``tier_rank``, ``previous_tier``,
+    ``previous_tier_label``, ``previous_tier_rank``, ``features``,
+    ``runtimes`` -- with one critical difference: ``previous_tier`` is
+    the **previous step in the walked path** (or ``from_tier`` for the
+    first row), NOT the global "next-lower purchasable tier" anchor
+    :func:`tier_unlocks` uses. The path-chained source guarantees
+    ``row[i]['tier'] == row[i+1]['previous_tier']`` so a consumer can
+    fold ``features`` / ``runtimes`` across rows to reconstruct the
+    cumulative ``tier_diff(from_tier, to_tier)['added_*']`` shape -- the
+    same chain-property :func:`tier_path` and :func:`capacity_diff_path`
+    enforce on their rows.
+
+    The walk visits every purchasable tier strictly between ``from_tier``
+    and ``to_tier`` plus the destination ``to_tier`` itself, in tier-rank
+    order (ascending or descending depending on direction). Same-rank
+    siblings *between* the endpoints are both included (matching
+    :func:`tier_path`'s ladder shape); same-rank siblings of the
+    destination are excluded so the path terminates exactly at
+    ``to_tier``. Rung walk is byte-stable against :func:`tier_path` and
+    :func:`capacity_diff_path` (same ``_PURCHASABLE_TIERS`` filter +
+    same sort key + same destination-sibling exclusion).
+
+    Direction semantics:
+
+    * ``upgrade`` (ascending) -- each row's ``features`` / ``runtimes``
+      are the marginal grant at that rung. The natural "what do I get if
+      I climb this far" walkthrough.
+    * ``downgrade`` (descending) -- each row's ``features`` /
+      ``runtimes`` are typically empty (you're losing things, not
+      unlocking them); use :func:`tier_path` (or the future
+      ``tier_locks_path``) for the marginal-loss view of a downgrade.
+      The path still walks rungs so a UI keyed off rung shape keeps
+      working; the empty lists are the correct "unlocks" answer.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the set difference between the two same-rank tier grants.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Endpoint semantics match :func:`tier_path` / :func:`tier_diff`: both
+    ids accept any entry in :data:`_TIER_FEATURES` (including
+    :data:`TIER_TRIAL`, which is not purchasable -- it is excluded from
+    the walked rungs but is a valid endpoint for the marginal-step
+    computation). Unknown ids on either side short-circuit to ``None``.
+
+    Never raises: a resolver failure logs a warning and returns ``None``
+    so an upgrade-walkthrough surface keeps rendering.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+        if from_rank == to_rank:
+            row = _unlocks_row(f, t)
+            return [row] if row is not None else []
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        prev_step = f
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            row = _unlocks_row(prev_step, tid)
+            if row is not None:
+                path.append(row)
+                prev_step = tid
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: tier_unlocks_path failed: %s", exc)
+        return None
+
+
 def tier_locks(target_tier: str) -> dict | None:
     """Per-tier marginal locks: features + runtimes that disappear when
     you *descend to* ``target_tier`` from the next-higher purchasable

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -71,6 +71,16 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                           ``/tier-unlocks``: returns the full
                                           pricing-page marginal-unlock ladder
                                           in one pass.
+  GET  /api/entitlement/tier-unlocks-path -- arbitrary-endpoint stepwise
+                                          unlock path between any two tiers
+                                          (``?from=&to=``); unlocks-focused
+                                          analogue of ``/tier-path`` (full
+                                          ``tier_diff`` per rung) and
+                                          ``/capacity-diff-path`` (capacity-
+                                          only per rung). Each row is a
+                                          ``tier_unlocks`` payload between
+                                          the previous step in the path and
+                                          the current rung.
   GET  /api/entitlement/capacity-diff-batch -- plural sibling of
                                           ``/capacity-diff``: per-axis
                                           capacity transitions (channels /
@@ -604,6 +614,112 @@ def api_entitlement_tier_unlocks_batch():
                 "grace": True,
                 "enforced": False,
             }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/tier-unlocks-path")
+def api_entitlement_tier_unlocks_path():
+    """``GET /api/entitlement/tier-unlocks-path?from=<id>&to=<id>`` --
+    arbitrary-endpoint stepwise unlock path between any two tiers; the
+    unlocks-focused analogue of ``/tier-path`` (full ``tier_diff`` per
+    rung) and ``/capacity-diff-path`` (capacity-only per rung). Lets an
+    upgrade-walkthrough surface render only the *newly-unlocked* features
+    + runtimes at each rung between any two tiers off ONE round-trip,
+    without the noise of the capacity axes or the symmetric ``lost_*``
+    lists ``/tier-path`` carries.
+
+    Each row in ``path`` is a :func:`clawmetry.entitlements.tier_unlocks`
+    payload between the previous step in the path (or ``from`` for the
+    first row) and the current rung -- so each row is a marginal-step
+    unlock and a consumer can fold ``features`` / ``runtimes`` across
+    rows to reconstruct the cumulative
+    ``tier_diff(from, to)['added_*']`` shape (the same chain-property
+    ``/tier-path`` and ``/capacity-diff-path`` enforce on their rows).
+    Same-rank siblings strictly between the endpoints are both included;
+    same-rank siblings of the destination are excluded so the path
+    terminates exactly at ``to``. Rung walk is byte-stable against
+    ``/tier-path`` and ``/capacity-diff-path``.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_unlocks row>, ...],
+        }
+
+    Each ``<row>`` matches the singular ``/tier-unlocks`` row shape
+    exactly (``tier``, ``tier_label``, ``tier_rank``, ``previous_tier``,
+    ``previous_tier_label``, ``previous_tier_rank``, ``features``,
+    ``runtimes``) -- with ``previous_tier`` chained from the path (the
+    previous step), NOT the global next-lower-purchasable-tier anchor
+    the singular helper uses.
+
+    Direction semantics:
+
+    * ``upgrade`` (ascending) -- each row's ``features`` / ``runtimes``
+      are the marginal grant at that rung.
+    * ``downgrade`` (descending) -- each row's ``features`` /
+      ``runtimes`` are typically empty (use ``/tier-path`` for the
+      marginal-loss view of a downgrade). The path still walks rungs so
+      a UI keyed off rung shape keeps working.
+    * ``lateral`` (same rank, different id) -- single-row path; carries
+      the set difference between the two same-rank tier grants.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Identity (``from == to``) returns an empty path. Lateral (same rank,
+    different id) returns a single-row path. ``400`` when ``from=`` or
+    ``to=`` is missing; ``404`` when either id is unknown. ``trial`` IS
+    accepted as an endpoint -- it is excluded from the walked rungs (not
+    purchasable) but the endpoint computation still resolves. Never
+    5xxs: a resolver failure short-circuits to ``404`` so an upgrade-
+    walkthrough surface keeps rendering instead of breaking.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        path = _ent.tier_unlocks_path(f, t)
+        if path is None:
+            return (
+                jsonify({"error": "unknown tier", "from": f, "to": t}),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_unlocks_path: error: %s", exc)
+        return (
+            jsonify({"error": "unknown tier", "from": f, "to": t}),
+            404,
         )
 
 

--- a/tests/test_entitlement_tier_unlocks_path.py
+++ b/tests/test_entitlement_tier_unlocks_path.py
@@ -1,0 +1,439 @@
+"""Tests for ``clawmetry.entitlements.tier_unlocks_path(from, to)`` + the
+``GET /api/entitlement/tier-unlocks-path`` endpoint.
+
+Unlocks-focused analogue of :func:`tier_path` (full ``tier_diff`` per
+rung) and :func:`capacity_diff_path` (capacity-only per rung) -- the
+third member of the ``_path`` family. Lets an upgrade-walkthrough
+surface render only the *newly-unlocked* features + runtimes at each
+rung between any two tiers off ONE round-trip, without the noise of the
+capacity axes or the symmetric ``lost_*`` lists :func:`tier_path`
+carries.
+
+Each row matches :func:`tier_unlocks`'s row shape exactly --
+``tier``, ``tier_label``, ``tier_rank``, ``previous_tier``,
+``previous_tier_label``, ``previous_tier_rank``, ``features``,
+``runtimes`` -- with ``previous_tier`` chained from the path (the
+previous step), NOT the global next-lower-purchasable-tier anchor
+:func:`tier_unlocks` uses. The path-chained source guarantees
+``row[i]['tier'] == row[i+1]['previous_tier']`` so a consumer can fold
+``features`` / ``runtimes`` across rows to reconstruct the cumulative
+``tier_diff(from, to)['added_*']`` shape.
+
+Pins:
+
+* row shape matches singular ``tier_unlocks`` schema (down to the key set)
+* ``previous_tier`` is path-chained, not the global anchor (the *one*
+  semantic difference vs :func:`tier_unlocks`); ``previous_tier_*``
+  fields are NEVER ``None`` (the path always has a concrete source)
+* per-rung chain is continuous on the tier axis
+  (``row[i]['tier'] == row[i+1]['previous_tier']``)
+* rung walk is byte-stable against :func:`tier_path` (same
+  ``_PURCHASABLE_TIERS`` filter + same sort + same destination-sibling
+  exclusion); confirmed by extracting the rung ``to`` ids
+* ascending path features + runtimes fold to the cumulative
+  ``tier_diff(from, to)['added_*']`` sets
+* descending path rows carry empty unlock lists (you lose things, you
+  don't unlock them) but still walk the rungs so a UI keyed off rung
+  shape keeps working
+* identity (``from == to``) returns an empty path
+* lateral (same rank, different id) returns a single-row path
+* trial accepted as an endpoint -- excluded from walked rungs but the
+  endpoint computation still resolves
+* unknown / empty / garbage ids return ``None`` and never raise
+* grace vs enforce yields identical rows (helper is decoupled from the
+  resolved entitlement; it walks the static per-tier maps)
+* API surface: 400 on missing args, 404 on unknown ids, 200 with the
+  envelope shape on the happy path (incl. direction tag)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ROW_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "previous_tier",
+    "previous_tier_label",
+    "previous_tier_rank",
+    "features",
+    "runtimes",
+}
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+}
+
+
+# ── helper-level: shape + invariants ─────────────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_matches_tier_unlocks_schema(ent):
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == _ROW_KEYS
+        assert isinstance(row["features"], list)
+        assert isinstance(row["runtimes"], list)
+
+
+def test_previous_tier_fields_never_none_on_path(ent):
+    """Singular :func:`tier_unlocks` returns ``previous_tier=None`` at the
+    floor rungs (oss / cloud_free have no purchasable tier below them).
+    The path variant ALWAYS has a concrete previous step (``from_tier``
+    on the first row, the prior rung on later rows), so the
+    ``previous_tier_*`` fields are never ``None`` -- pin this so a UI
+    that strictly relies on the chained source can render confidently."""
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["previous_tier"] is not None
+        assert row["previous_tier_label"] is not None
+        assert row["previous_tier_rank"] is not None
+
+
+def test_first_row_previous_is_from_tier(ent):
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert path[0]["previous_tier"] == ent.TIER_OSS
+    assert path[0]["previous_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+
+
+def test_chain_is_continuous_on_tier_axis(ent):
+    """Each row's ``tier`` is the next row's ``previous_tier`` -- the
+    same chain-property :func:`tier_path` and :func:`capacity_diff_path`
+    enforce on their rows."""
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for i in range(len(path) - 1):
+        assert path[i]["tier"] == path[i + 1]["previous_tier"]
+        assert path[i]["tier_rank"] == path[i + 1]["previous_tier_rank"]
+    assert path[-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    """``pro`` and ``cloud_pro`` share rank 2; asking for ``pro`` must end
+    exactly at ``pro`` and EXCLUDE the same-rank sibling ``cloud_pro``
+    from the final rung -- same rule as :func:`tier_path`."""
+    rungs = [r["tier"] for r in ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_PRO)]
+    assert rungs[-1] == ent.TIER_PRO
+    assert rungs.count(ent.TIER_PRO) == 1
+    assert ent.TIER_CLOUD_PRO not in rungs
+
+
+def test_same_rank_siblings_between_endpoints_both_included(ent):
+    """Walking oss -> enterprise: rank-2 siblings ``cloud_pro`` AND
+    ``pro`` both appear because they sit strictly *between* rank-0 start
+    and rank-3 destination -- same rule as :func:`tier_path`."""
+    rungs = [r["tier"] for r in ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)]
+    assert ent.TIER_CLOUD_PRO in rungs
+    assert ent.TIER_PRO in rungs
+    assert rungs[-1] == ent.TIER_ENTERPRISE
+
+
+def test_rung_walk_byte_stable_against_tier_path(ent):
+    """The set of rung ``tier`` ids must match :func:`tier_path`'s set
+    of rung ``to`` ids byte-for-byte -- same ``_PURCHASABLE_TIERS``
+    filter + same sort + same destination-sibling exclusion."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_OSS, ent.TIER_CLOUD_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_PRO, ent.TIER_CLOUD_FREE),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        unlocks_rungs = [r["tier"] for r in ent.tier_unlocks_path(f, t)]
+        diff_rungs = [r["to"] for r in ent.tier_path(f, t)]
+        assert unlocks_rungs == diff_rungs
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        assert ent.tier_unlocks_path(tid, tid) == []
+
+
+def test_lateral_single_row(ent):
+    """Same rank, different id -- single-row path; row carries the set
+    difference between the two same-rank tier grants."""
+    path = ent.tier_unlocks_path(ent.TIER_CLOUD_PRO, ent.TIER_PRO)
+    assert len(path) == 1
+    row = path[0]
+    assert row["tier"] == ent.TIER_PRO
+    assert row["previous_tier"] == ent.TIER_CLOUD_PRO
+    # cloud_pro and pro share their grant set, so the set-diff is empty
+    assert row["features"] == []
+    assert row["runtimes"] == []
+
+
+def test_oss_to_cloud_free_lateral_empty_diff(ent):
+    """Both rank 0 -- lateral single-row path with no unlock diff."""
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_CLOUD_FREE)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_CLOUD_FREE
+    assert path[0]["previous_tier"] == ent.TIER_OSS
+    assert path[0]["features"] == []
+    assert path[0]["runtimes"] == []
+
+
+def test_adjacent_step_is_one_row(ent):
+    """oss (rank 0) -> cloud_starter (rank 1) is a single rank-up step."""
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_CLOUD_STARTER
+    assert path[0]["previous_tier"] == ent.TIER_OSS
+    # every paid runtime first unlocks at Starter
+    assert set(path[0]["runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_ascending_path_unlocks_enterprise_at_top(ent):
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    final = path[-1]
+    assert final["tier"] == ent.TIER_ENTERPRISE
+    # enterprise-only features land at the terminal rung
+    assert "sso" in final["features"]
+    assert "audit_logs" in final["features"]
+
+
+def test_descending_path_terminates_at_to_but_unlocks_are_empty(ent):
+    """Descending walk still visits the rungs (so a UI keyed off rung
+    shape keeps working), but each row's ``features`` / ``runtimes``
+    collapse to empty lists -- you lose things, you don't unlock them."""
+    path = ent.tier_unlocks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    assert path[0]["previous_tier"] == ent.TIER_ENTERPRISE
+    assert path[-1]["tier"] == ent.TIER_OSS
+    for row in path:
+        assert row["features"] == []
+        assert row["runtimes"] == []
+
+
+def test_descending_terminates_at_explicit_floor(ent):
+    """Asking for ``oss`` must NOT also include ``cloud_free`` (the other
+    rank-0 sibling) as a terminal rung -- same rule as :func:`tier_path`."""
+    rungs = [r["tier"] for r in ent.tier_unlocks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)]
+    assert rungs[-1] == ent.TIER_OSS
+    assert rungs.count(ent.TIER_OSS) == 1
+
+
+def test_fold_reproduces_cumulative_added_features(ent):
+    """Folding the per-step marginal unlock sets across the path must
+    reproduce the cumulative ``tier_diff(from, to)['added_features']``
+    set (and likewise for runtimes) -- the byte-level invariant that
+    makes the path a true marginal decomposition."""
+    f, t = ent.TIER_OSS, ent.TIER_ENTERPRISE
+    path = ent.tier_unlocks_path(f, t)
+    folded_features: set[str] = set()
+    folded_runtimes: set[str] = set()
+    for row in path:
+        folded_features |= set(row["features"])
+        folded_runtimes |= set(row["runtimes"])
+    direct = ent.tier_diff(f, t)
+    assert folded_features == set(direct["added_features"])
+    assert folded_runtimes == set(direct["added_runtimes"])
+
+
+def test_fold_handles_cloud_free_floor(ent):
+    """cloud_free (rank 0) -> enterprise (rank 3) folds the same way as
+    oss -> enterprise -- both floors share the same free grant so the
+    cumulative ``added_*`` set is identical."""
+    f, t = ent.TIER_CLOUD_FREE, ent.TIER_ENTERPRISE
+    path = ent.tier_unlocks_path(f, t)
+    folded_features: set[str] = set()
+    for row in path:
+        folded_features |= set(row["features"])
+    direct = ent.tier_diff(f, t)
+    assert folded_features == set(direct["added_features"])
+
+
+def test_lists_are_sorted_per_row(ent):
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["features"] == sorted(row["features"])
+        assert row["runtimes"] == sorted(row["runtimes"])
+
+
+def test_trial_excluded_from_walked_rungs_but_valid_endpoint(ent):
+    """``trial`` is not purchasable -- it must never appear as a stop on
+    a path between purchasable tiers, but it IS a valid endpoint."""
+    path = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["tier"] != ent.TIER_TRIAL
+        assert row["previous_tier"] != ent.TIER_TRIAL
+    # trial as an endpoint still resolves
+    upward = ent.tier_unlocks_path(ent.TIER_TRIAL, ent.TIER_ENTERPRISE)
+    assert upward is not None
+    assert upward[-1]["tier"] == ent.TIER_ENTERPRISE
+    downward = ent.tier_unlocks_path(ent.TIER_TRIAL, ent.TIER_OSS)
+    assert downward is not None
+    assert downward[-1]["tier"] == ent.TIER_OSS
+
+
+def test_unknown_tiers_return_none(ent):
+    assert ent.tier_unlocks_path("not_a_tier", ent.TIER_ENTERPRISE) is None
+    assert ent.tier_unlocks_path(ent.TIER_OSS, "still_not_a_tier") is None
+    assert ent.tier_unlocks_path("a", "b") is None
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.tier_unlocks_path("", "") is None
+    assert ent.tier_unlocks_path(None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_unlocks_path("  ", "  ") is None
+    assert ent.tier_unlocks_path(123, 456) is None  # type: ignore[arg-type]
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    b = ent.tier_unlocks_path("  OSS ", " ENTERPRISE  ")
+    assert a == b
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, monkeypatch):
+    """The helper is decoupled from the resolved entitlement -- it walks
+    the static per-tier maps so flipping enforce on must NOT change any
+    row. Pins the resolver-independence property the whole ``_path``
+    family shares."""
+    grace_rows = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_rows = ent.tier_unlocks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert grace_rows == enforced_rows
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_args(client):
+    assert client.get("/api/entitlement/tier-unlocks-path").status_code == 400
+    assert (
+        client.get("/api/entitlement/tier-unlocks-path?from=oss").status_code == 400
+    )
+    assert (
+        client.get("/api/entitlement/tier-unlocks-path?to=cloud_pro").status_code
+        == 400
+    )
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get("/api/entitlement/tier-unlocks-path?from=oss&to=not_a_tier")
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["to"] == "not_a_tier"
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-unlocks-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+    # row schema matches the singular endpoint
+    for row in body["path"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-unlocks-path?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    assert body["path"][-1]["tier"] == ent.TIER_OSS
+    # descending: each row's unlock lists collapse to empty
+    for row in body["path"]:
+        assert row["features"] == []
+        assert row["runtimes"] == []
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-unlocks-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-unlocks-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["previous_tier"] == ent.TIER_CLOUD_PRO
+    assert body["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_api_trial_endpoint_accepted(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-unlocks-path?from={ent.TIER_TRIAL}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_api_rungs_match_tier_path_route(client, ent):
+    """API-level byte-equality: rung ``tier`` ids from
+    ``/tier-unlocks-path`` match rung ``to`` ids from ``/tier-path``."""
+    a = client.get(
+        f"/api/entitlement/tier-unlocks-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/tier-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert [r["tier"] for r in a["path"]] == [r["to"] for r in b["path"]]


### PR DESCRIPTION
## Summary

Adds `tier_unlocks_path(from, to)` to `clawmetry.entitlements` and the companion `GET /api/entitlement/tier-unlocks-path` endpoint — the **unlocks-focused path analogue** of `tier_unlocks`, third member of the `_path` family alongside `tier_path` (full `tier_diff` per rung) and `capacity_diff_path` (capacity-only per rung). Lets an upgrade-walkthrough surface render only the *newly-unlocked* features + runtimes at each rung between any two tiers off ONE round-trip, without the noise of the capacity axes or the symmetric `lost_*` lists `tier_path` carries.

| Helper                  | Walk                                | Per-rung row shape                                                                |
| ----------------------- | ----------------------------------- | --------------------------------------------------------------------------------- |
| `tier_path`             | arbitrary `from → to`               | full `tier_diff` (added/lost features+runtimes + `capacity_changes`)              |
| `capacity_diff_path`    | arbitrary `from → to`               | singular `capacity_diff` (target + 3 axes), `before` chained from previous rung   |
| **`tier_unlocks_path`** | **arbitrary `from → to`**           | **singular `tier_unlocks` (features + runtimes only), `previous_tier` chained**   |

Rung walk is byte-stable against `tier_path` / `capacity_diff_path`: every purchasable tier strictly between `from` and `to` plus the destination itself, in tier-rank order; same-rank siblings of the destination excluded so the path terminates exactly at `to`.

## Design notes

- **Purely additive; zero behavior change to existing surfaces.** No edits to existing helpers; the new `_unlocks_row` private builder is only used by `tier_unlocks_path` (the singular `tier_unlocks` and batch `tier_unlocks_batch` still use the original global-anchor code so their semantics stay intact).
- **Row schema matches `tier_unlocks` exactly** down to the key set (`tier`, `tier_label`, `tier_rank`, `previous_tier`, `previous_tier_label`, `previous_tier_rank`, `features`, `runtimes`) with one critical difference: `previous_tier` is the **previous step in the walked path** (chained), NOT the global "next-lower purchasable tier" anchor `tier_unlocks` uses. Consumers that strictly rely on the chained source benefit from `previous_tier_*` fields NEVER being `None` (the path always has a concrete source).
- **Chain-continuity invariant**: `row[i]["tier"] == row[i+1]["previous_tier"]` so a consumer can fold `features` / `runtimes` across rows to reconstruct the cumulative `tier_diff(from, to)["added_*"]` shape — the same chain-property `tier_path` and `capacity_diff_path` enforce on their rows. Pinned in the test suite.
- **Decoupled from the resolved entitlement** (built off the static per-tier maps), so grace vs enforce yields identical rows — the path is the hypothetical "if I walked X to Y" view, complementing the resolver-pinned per-rung batches.
- **Direction semantics**: `upgrade` rows carry real marginal grants; `downgrade` rows still walk the rungs (so a UI keyed off rung shape keeps working) but the `features` / `runtimes` lists collapse to empty (use `tier_path` for the loss view of a downgrade); `lateral` is a single-row path; `identity` is `[]`.
- **Never raises** in the helper; endpoint returns `400` on missing args, `404` on unknown ids / resolver failure, `200` with the envelope on the happy path.

## API envelope

```
GET /api/entitlement/tier-unlocks-path?from=&to=

{
  "from":       "",
  "from_label": "...",
  "from_rank":  ,
  "to":         "",
  "to_label":   "...",
  "to_rank":    ,
  "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
  "path":       [, ...]
}
```

Each `` matches `/tier-unlocks` exactly — `tier`, `tier_label`, `tier_rank`, `previous_tier`, `previous_tier_label`, `previous_tier_rank`, `features`, `runtimes` — with `previous_tier` chained from the path (the previous step), NOT the global next-lower-purchasable-tier anchor the singular helper uses.

## Tests

31 new tests covering: row schema vs `tier_unlocks`, `previous_tier_*` non-null on the path, per-axis chain continuity, rung-walk byte-equality with `tier_path` across six endpoint pairs, identity / lateral / adjacent edge cases, ascending unlock semantics (enterprise-only features at the terminal rung), descending semantics (empty unlock lists, rungs still walked), fold-matches-cumulative-`added_*` invariant, trial endpoint accepted, garbage-input never-raise contract, grace/enforce row identity (resolver-independence), and the full API surface (400 / 404 / 200 / lateral / identity / trial / route-helper byte-equality with `/tier-path`).

```
$ python3 -m pytest tests/test_entitlement_tier_unlocks_path.py -v
31 passed in 0.43s

$ python3 -m pytest tests/test_entitlement_*.py tests/test_entitlements*.py
976 passed in 9.93s

$ ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_tier_unlocks_path.py
All checks passed!
```

The `lint-py` make target reports 207 pre-existing ruff errors on `dashboard.py` and the `clawmetry/` tree; verified identical count with this change stashed, so unrelated to this PR.

## Local operator verification checklist

I can't reach the local daemon, `~/.openclaw`, or the live cloud snapshot — please do these on your box before flipping the PR to ready / releasing:

- [ ] Copy changed files into the daemon's site-packages:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/`
- [ ] Clear `__pycache__`:
      `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the sync daemon:
      `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint locally:
      `curl -s 'http://localhost:8900/api/entitlement/tier-unlocks-path?from=oss&to=enterprise' | jq`
      → expect envelope with `direction: "upgrade"`, `path[-1].tier == "enterprise"`, each row carrying `features` / `runtimes` lists and a chained `previous_tier`
- [ ] Confirm rung byte-equality with `/tier-path`:
      `diff <(curl -s 'http://localhost:8900/api/entitlement/tier-unlocks-path?from=oss&to=enterprise' | jq '[.path[].tier]') <(curl -s 'http://localhost:8900/api/entitlement/tier-path?from=oss&to=enterprise' | jq '[.path[].to]')`
      → expect no diff
- [ ] Spot-check the existing surfaces still work:
      `curl -s 'http://localhost:8900/api/entitlement/tier-unlocks-batch' | jq '.tiers | length'` (unchanged)
      `curl -s 'http://localhost:8900/api/entitlement/tier-path?from=oss&to=enterprise' | jq '.path | length'` (unchanged)
- [ ] Decrypt the live cloud snapshot and confirm the entitlement panel still renders.
- [ ] Browser-check `localhost:8900` for any pricing-page regressions.

Cloud (`clawmetry-cloud`) and `clawmetry-pro` work in P3/P4/P6 is **out of scope for this PR** — those require the private repos this agent does not have access to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqgSBecf7pa36UfE38JTY4)_