### PR TITLE
feat(install): ask before creating a cloud account (local-only default + license path)

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2074,30 +2074,122 @@ def _cmd_onboard(args) -> None:
 
     print(f"\n  {BOLD(f'ClawMetry{_ver_str} installed!')}")
     print()
-    print(f"  Monitor your AI agents from anywhere with ClawMetry Cloud.")
+    print(f"  {BOLD('How do you want to run ClawMetry?')}")
+    print()
+    print(f"    {BOLD('[1] Local only')}    {DIM('Free. No account, nothing leaves this machine.')}")
+    print(f"                     {DIM('Watch OpenClaw and NeMo at http://localhost:8900.')}")
+    print(f"    {BOLD('[2] Cloud')}         {DIM('Free trial. A dashboard you can open from anywhere.')}")
+    print(f"                     {DIM('Creates an account for this machine. No card needed.')}")
+    print(f"    {BOLD('[3] License key')}   {DIM('Self-Hosted Pro: all 12 runtimes, offline. Paste a key.')}")
     print()
 
-    try:
-        choice = _input("  Do you have a ClawMetry account? [y/N]: ").strip().lower() or "n"
-    except (EOFError, KeyboardInterrupt):
-        choice = "n"
+    def _write_nocloud_marker():
+        """Persist the local-only opt-out so updates can't silently re-enable
+        cloud sync (clawmetry/config.py is_cloud_disabled / GitHub #1937)."""
+        try:
+            from clawmetry.config import NOCLOUD_MARKER_PATH
+            from pathlib import Path as _P
+            _P(NOCLOUD_MARKER_PATH).parent.mkdir(parents=True, exist_ok=True)
+            _P(NOCLOUD_MARKER_PATH).touch()
+        except Exception:
+            pass
+
+    def _finish_local():
+        """Save an account-free config and start the daemon. The nocloud
+        marker makes every cloud call a no-op while local DuckDB ingestion
+        still feeds http://localhost:8900."""
+        import platform as _plat
+        import socket as _sock
+        # The daemon reads config['node_id'] by subscript on start, so a
+        # local-only config still needs one. Hostname matches the daemon's own
+        # _node_id() fallback. No api_key/encryption_key -> the nocloud marker
+        # short-circuits every cloud call regardless.
+        _local_node_id = getattr(args, "custom_node_id", None) or _sock.gethostname() or "local"
+        try:
+            from clawmetry.sync import save_config as _save_config
+            _save_config({
+                "node_id": _local_node_id,
+                "platform": _plat.system(),
+                "connected_at": __import__("datetime").datetime.now().isoformat(),
+                "local_only": True,
+            })
+        except Exception:
+            pass
+        print(f"  Starting local dashboard...")
+        _stop_existing_daemon()
+        _start_daemon({"local_only": True}, args)
+        print()
+        print(f"  {GREEN(BOLD('Watching your agents locally.'))}")
+        print(f"     {BOLD('http://localhost:8900')}")
+        print(f"     {DIM('Nothing leaves this machine. Enable cloud anytime: clawmetry connect')}")
         print()
 
+    # Scriptable / non-interactive overrides. A headless install (curl | bash
+    # with no /dev/tty) must NEVER silently create a cloud account, so the
+    # default AND the EOF fallback are both LOCAL.
+    _env_local = _os.environ.get("CLAWMETRY_LOCAL_ONLY", "").strip().lower() in ("1", "true", "yes", "on")
+    if getattr(args, "local", False) or _env_local:
+        choice = "1"
+    elif getattr(args, "cloud", False):
+        choice = "2"
+    else:
+        try:
+            choice = _input("  Choose [1]: ").strip() or "1"
+        except (EOFError, KeyboardInterrupt):
+            choice = "1"
+            print()
+
     print()
 
-    if choice in ("y", "yes"):
-        # Existing user: email -> OTP -> connect
-        import argparse as _ap
-
-        _fake_args = _ap.Namespace(
-            key=None, foreground=False, custom_node_id=None,
-            enc_key=None, key_only=False, no_daemon=False,
-        )
-        _cmd_connect(_fake_args)
-
+    if choice == "3":
+        # ── Self-Hosted Pro license (local, offline, all 12 runtimes) ──────
+        _write_nocloud_marker()
+        try:
+            _lic_key = _input("  Paste your license key (CLAW1...), or press Enter to do it later: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            _lic_key = ""
+            print()
+        print()
+        if _lic_key:
+            try:
+                from clawmetry import license as _lic
+                ok, msg = _lic.activate(_lic_key, node_id=_lic._node_id())
+                print(f"  {GREEN('Activated.') if ok else '⚠️  '}{msg}")
+                if not ok:
+                    print(f"     {DIM('Try again later:')} {CYAN('clawmetry activate <key>')}")
+            except Exception as _e:
+                print(f"  ⚠️  Activation failed: {_e}")
+                print(f"     {DIM('Try again later:')} {CYAN('clawmetry activate <key>')}")
+        else:
+            print(f"  {DIM('No problem. Buy a key at')} {CYAN('https://clawmetry.com/pricing')}")
+            print(f"  {DIM('then run')} {CYAN('clawmetry activate <key>')}")
         print()
         _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
-    else:
+        _finish_local()
+        return
+
+    if choice == "2":
+        # ── Cloud (free trial) ────────────────────────────────────────────
+        try:
+            has_acct = (_input("  Already have a ClawMetry account? [y/N]: ").strip().lower() or "n")
+        except (EOFError, KeyboardInterrupt):
+            has_acct = "n"
+            print()
+        print()
+        if has_acct in ("y", "yes"):
+            # Existing user: email -> OTP -> connect
+            import argparse as _ap
+
+            _fake_args = _ap.Namespace(
+                key=None, foreground=False, custom_node_id=None,
+                enc_key=None, key_only=False, no_daemon=False,
+            )
+            _cmd_connect(_fake_args)
+
+            print()
+            _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
+            return
+
         # New user: instant registration (no OTP)
         print(f"  Setting up your cloud dashboard...")
         print()
@@ -2175,6 +2267,15 @@ def _cmd_onboard(args) -> None:
         _start_daemon(config, args)
         print(f"  {GREEN(BOLD('Your agent is now being monitored!'))}")
         print()
+        return
+
+    # ── [1] Local only (default) ──────────────────────────────────────────
+    print(f"  {GREEN(BOLD('Local only.'))} {DIM('No account, no cloud.')}")
+    print()
+    _write_nocloud_marker()
+    _maybe_apply_nemoclaw_preset(_input, BOLD, CYAN, DIM)
+    _finish_local()
+    return
 
 
 def _cmd_account(args) -> None:
@@ -3087,6 +3188,14 @@ def main() -> None:
         dest="custom_node_id",
         help="Custom node name (default: hostname)",
     )
+    p_onboard.add_argument(
+        "--local", "--no-cloud", action="store_true", dest="local",
+        help="Local only: no cloud account, nothing leaves this machine",
+    )
+    p_onboard.add_argument(
+        "--cloud", action="store_true", dest="cloud",
+        help="Create a cloud account non-interactively (skip the prompt)",
+    )
 
     # connect
     p_connect = sub.add_parser("connect", help="Activate cloud sync")
@@ -3147,6 +3256,14 @@ def main() -> None:
         metavar="NAME",
         dest="custom_node_id",
         help="Custom node name (default: hostname)",
+    )
+    p_setup.add_argument(
+        "--local", "--no-cloud", action="store_true", dest="local",
+        help="Local only: no cloud account, nothing leaves this machine",
+    )
+    p_setup.add_argument(
+        "--cloud", action="store_true", dest="cloud",
+        help="Create a cloud account non-interactively (skip the prompt)",
     )
 
     # account — link email or show account info

--- a/install.sh
+++ b/install.sh
@@ -764,6 +764,17 @@ fi
 # ── Onboarding ───────────────────────────────────────────────────────────────
 # Runs: clawmetry onboard (skipped when NemoClaw is detected — onboard happens inside sandbox)
 
+# Local-only opt-out: CLAWMETRY_LOCAL_ONLY=1 means "never create a cloud
+# account, nothing leaves this machine." Write the persistent marker now so it
+# holds even when onboard is skipped; onboard itself also defaults to local.
+case "${CLAWMETRY_LOCAL_ONLY:-}" in
+  1|true|yes|on|TRUE|YES|ON)
+    mkdir -p "$HOME/.clawmetry" 2>/dev/null || true
+    touch "$HOME/.clawmetry/nocloud" 2>/dev/null || true
+    echo -e "  ${DIM}Local-only mode (CLAWMETRY_LOCAL_ONLY set): no cloud account will be created.${NC}"
+    ;;
+esac
+
 if [ "${CLAWMETRY_SKIP_ONBOARD:-}" = "1" ] || [ "$NEMOCLAW_DETECTED" = "1" ]; then
   [ "$NEMOCLAW_DETECTED" = "1" ] || echo -e "  ${DIM}Skipping onboard (CLAWMETRY_SKIP_ONBOARD=1)${NC}"
 elif (exec </dev/tty) 2>/dev/null; then

--- a/tests/test_onboard_local_default.py
+++ b/tests/test_onboard_local_default.py
@@ -1,0 +1,107 @@
+"""Install-fork: onboard must NEVER silently mint a cloud account.
+
+The pre-fork onboard defaulted a no-account / EOF answer to _instant_register,
+so a headless `curl | bash` (no /dev/tty) silently created a cloud account.
+That is exactly the surprise-account complaint that triggered a GDPR deletion.
+
+These tests pin the new 3-way fork (default = local):
+  * no-TTY / EOF  -> local only, marker written, _instant_register NOT called
+  * --local flag  -> local only (no prompt read)
+  * CLAWMETRY_LOCAL_ONLY=1 env -> local only
+  * choosing [2]  -> cloud registration IS reached
+"""
+import argparse
+import os
+
+import pytest
+
+import clawmetry.cli as cli
+
+
+@pytest.fixture
+def onboard_env(monkeypatch, tmp_path):
+    """Isolate HOME + the nocloud marker, stub all side-effecting calls, and
+    record whether cloud registration was attempted."""
+    home = tmp_path / "home"
+    (home / ".clawmetry").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("CLAWMETRY_API_KEY", raising=False)
+    monkeypatch.delenv("CLAWMETRY_NODE_ID", raising=False)
+    monkeypatch.delenv("CLAWMETRY_LOCAL_ONLY", raising=False)
+
+    marker = home / ".clawmetry" / "nocloud"
+    monkeypatch.setattr("clawmetry.config.NOCLOUD_MARKER_PATH", str(marker))
+
+    state = {"instant_register": 0, "start_daemon": 0}
+
+    def _fake_instant_register(*a, **k):
+        state["instant_register"] += 1
+        return None  # registration "fails" -> harmless local fallback
+
+    monkeypatch.setattr(cli, "_instant_register", _fake_instant_register)
+    monkeypatch.setattr(cli, "_start_daemon", lambda *a, **k: state.__setitem__("start_daemon", state["start_daemon"] + 1))
+    monkeypatch.setattr(cli, "_stop_existing_daemon", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "_maybe_apply_nemoclaw_preset", lambda *a, **k: None)
+    monkeypatch.setattr("clawmetry.sync.save_config", lambda *a, **k: None)
+    # Make stdin look like a TTY so onboard uses input() (which we control)
+    # instead of opening /dev/tty.
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    return state, marker
+
+
+def _args(**kw):
+    base = dict(local=False, cloud=False, foreground=False, custom_node_id=None)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_eof_defaults_to_local_never_mints(onboard_env, monkeypatch):
+    state, marker = onboard_env
+
+    def _eof(_prompt=""):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof)
+    cli._cmd_onboard(_args())
+
+    assert state["instant_register"] == 0, "headless onboard must NOT create a cloud account"
+    assert marker.exists(), "local-only marker must be written"
+    assert state["start_daemon"] == 1, "local daemon should still start"
+
+
+def test_local_flag_forces_local(onboard_env, monkeypatch):
+    state, marker = onboard_env
+    # Should never read input when --local is set.
+    monkeypatch.setattr("builtins.input", lambda _p="": pytest.fail("should not prompt"))
+    cli._cmd_onboard(_args(local=True))
+    assert state["instant_register"] == 0
+    assert marker.exists()
+
+
+def test_env_local_only_forces_local(onboard_env, monkeypatch):
+    state, marker = onboard_env
+    monkeypatch.setenv("CLAWMETRY_LOCAL_ONLY", "1")
+    monkeypatch.setattr("builtins.input", lambda _p="": pytest.fail("should not prompt"))
+    cli._cmd_onboard(_args())
+    assert state["instant_register"] == 0
+    assert marker.exists()
+
+
+def test_choice_2_reaches_cloud_registration(onboard_env, monkeypatch):
+    state, _marker = onboard_env
+    answers = iter(["2", "n"])  # [2] Cloud, then "no existing account" -> instant register
+
+    def _ans(_prompt=""):
+        return next(answers)
+
+    monkeypatch.setattr("builtins.input", _ans)
+    cli._cmd_onboard(_args())
+    assert state["instant_register"] == 1, "[2] Cloud must reach instant registration"
+
+
+def test_empty_enter_defaults_to_local(onboard_env, monkeypatch):
+    state, marker = onboard_env
+    monkeypatch.setattr("builtins.input", lambda _p="": "")  # just press Enter
+    cli._cmd_onboard(_args())
+    assert state["instant_register"] == 0
+    assert marker.exists()


### PR DESCRIPTION
## What
Reworks the `clawmetry onboard` wizard (run by `curl -fsSL https://clawmetry.com/install.sh | bash`) from a binary account prompt into an explicit 3-way fork, mirroring the **Cloud vs Self-Hosted** choice already on `/pricing`:

```
How do you want to run ClawMetry?
  [1] Local only     Free. No account, nothing leaves this machine.   (DEFAULT)
  [2] Cloud          Free trial. A dashboard you can open from anywhere.
  [3] License key    Self-Hosted Pro: all 12 runtimes, offline. Paste a key.
```

## Why
The old prompt (`Do you have a ClawMetry account? [y/N]`) defaulted a **no-account / EOF** answer straight into `_instant_register`, so a headless `curl | bash` (no `/dev/tty`) **silently created a cloud account**. That is the exact surprise that led a self-hosted-only user (Zenva CEO) to file a GDPR deletion. The installer now asks first and defaults to the privacy-safe path.

## Behavior
- **No-TTY / EOF / empty Enter -> Local only.** Never mints a cloud account headlessly (the load-bearing change).
- **Local only** writes the `~/.clawmetry/nocloud` marker (`config.is_cloud_disabled`, #1937) so the daemon ingests into local DuckDB for `http://localhost:8900` while every cloud call is a no-op (the `_post` choke point already gates on `is_cloud_disabled()`).
- **[2] Cloud** keeps the existing instant-register + existing-account-connect flows, now behind explicit consent.
- **[3] License** reuses the existing `activate -> entitlements -> pro-wheel` chain (no cloud account needed).
- **Scriptable:** `--local`/`--no-cloud`, `--cloud`, and `CLAWMETRY_LOCAL_ONLY=1` (honored in `install.sh`, which also writes the marker pre-onboard so it holds even when onboard is skipped).
- Local-only config carries a hostname `node_id` so the daemon start banner (which subscripts `config['node_id']`) doesn't KeyError.

## Tests
`tests/test_onboard_local_default.py` (5): EOF / empty / `--local` / `CLAWMETRY_LOCAL_ONLY` all default to local and never call `_instant_register`; `[2]` does reach cloud registration. Existing `test_cli.py` / `test_cli_banner.py` / `test_tier_cli.py` still green. `bash -n install.sh` clean.

## Follow-ups (separate PRs, per plan)
- Landing copy: surface the local-only one-liner + qualify any air-gap claim to "activate once to download the Pro package, then runs offline."
- Confirm the two self-host launch gates (license signing key set in Cloud Run; a `clawmetry_pro` wheel published) before promoting the `[3]` path for sales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)