### PR TITLE
[RELEASE] installer asks before creating a cloud account (carries #3281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Install: the installer now asks before creating a cloud account (2026-06-23)
+- **`curl -fsSL https://clawmetry.com/install.sh | bash` no longer creates a cloud account by default (#3281).** The setup wizard used to default a no-account answer (and a headless install with no terminal) straight into creating a cloud account, so some people ended up with an account they never asked for. It now presents a clear choice: **[1] Local only** (free, no account, nothing leaves your machine, the default), **[2] Cloud** (free trial dashboard you can open anywhere), or **[3] License key** (activate Self-Hosted Pro for all 12 runtimes, offline). A non-interactive install defaults to local and never creates an account. You can script it with `--local` / `--cloud` or `CLAWMETRY_LOCAL_ONLY=1`. Local-only writes the `~/.clawmetry/nocloud` marker so updates can't silently re-enable cloud sync; the local dashboard at http://localhost:8900 works exactly as before.
+
 ### Security: stronger protection for custom encryption passphrases (2026-06-14)
 - **A typed custom secret is now run through a strong, salted key derivation (#3127).** Previously a custom passphrase was stored as-is and turned into the encryption key with a single, unsalted hash, so a weak passphrase could be brute-forced offline and the same passphrase produced the same key for everyone. ClawMetry now derives the key with scrypt and a random salt at setup and stores only the derived key (you back it up and paste it as before, via `clawmetry status --show-key`); the passphrase itself is never saved. Existing installs are unaffected and keep decrypting their data. If you auto-generate your key (the default), nothing changes.
 


### PR DESCRIPTION
Publishes the install-flow fork from #3281 to PyPI so `pip install clawmetry` ships the new 3-way onboard (local-only default, cloud, or license key) and stops silently creating a cloud account on headless installs.

- Carries: #3281 (cli.py onboard fork + install.sh `CLAWMETRY_LOCAL_ONLY` + tests)
- CHANGELOG `[Unreleased]` entry added (user-facing, em-dash-free; the only `--` are the backtick'd `--local`/`--cloud` flag names).
- `release-on-merge.yml` will bump the patch version and upload to PyPI on merge.

The install.sh half is already live (clawmetry.com/install.sh proxies OSS main with no-cache); this release gets the matching cli.py prompt to installed users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)