### PR TITLE
feat(entitlement): tier_locks_path + /api/entitlement/tier-locks-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1752,10 +1752,11 @@ def tier_unlocks_path(from_tier: str, to_tier: str) -> list[dict] | None:
       I climb this far" walkthrough.
     * ``downgrade`` (descending) -- each row's ``features`` /
       ``runtimes`` are typically empty (you're losing things, not
-      unlocking them); use :func:`tier_path` (or the future
-      ``tier_locks_path``) for the marginal-loss view of a downgrade.
-      The path still walks rungs so a UI keyed off rung shape keeps
-      working; the empty lists are the correct "unlocks" answer.
+      unlocking them); use :func:`tier_path` or
+      :func:`tier_locks_path` for the marginal-loss view of a
+      downgrade. The path still walks rungs so a UI keyed off rung
+      shape keeps working; the empty lists are the correct "unlocks"
+      answer.
     * ``lateral`` (same rank, different id) -- single-row path; row
       carries the set difference between the two same-rank tier grants.
     * ``identity`` (``from == to``) -- empty path; no rungs to walk.
@@ -1940,6 +1941,164 @@ def tier_locks_batch() -> list[dict]:
     except Exception as exc:
         logger.warning("entitlements: tier_locks_batch failed: %s", exc)
         return []
+
+
+def _locks_row(from_tier: str, to_tier: str) -> dict | None:
+    """Single marginal-locks row between two arbitrary tiers, with the
+    source carried as ``next_tier`` (path-chained, **not** the global
+    next-higher-purchasable-tier anchor used by :func:`tier_locks`).
+
+    Private builder for :func:`tier_locks_path`: each row is "what the
+    ``to`` rung first *loses* vs the previous step in the walked path"
+    so a consumer can fold the per-rung rows to reconstruct the
+    cumulative ``tier_diff(from, to)['lost_*']`` shape -- the marginal-
+    loss mirror of :func:`_unlocks_row` (which folds to
+    ``tier_diff(...)['added_*']``).
+
+    Returns ``None`` on unknown ids and never raises -- the path walker
+    drops ``None`` rows on the floor so a downgrade-warning surface
+    keeps rendering.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        from_feats = FREE_FEATURES | _TIER_FEATURES.get(f, frozenset())
+        if f == TIER_ENTERPRISE:
+            from_feats = from_feats | ENTERPRISE_FEATURES
+        to_feats = FREE_FEATURES | _TIER_FEATURES.get(t, frozenset())
+        if t == TIER_ENTERPRISE:
+            to_feats = to_feats | ENTERPRISE_FEATURES
+        from_runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if f in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        to_runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if t in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        return {
+            "tier": t,
+            "tier_label": tier_label(t),
+            "tier_rank": tier_rank(t),
+            "next_tier": f,
+            "next_tier_label": tier_label(f),
+            "next_tier_rank": tier_rank(f),
+            "lost_features": sorted(from_feats - to_feats),
+            "lost_runtimes": sorted(from_runtimes - to_runtimes),
+        }
+    except Exception as exc:
+        logger.warning("entitlements: _locks_row failed: %s", exc)
+        return None
+
+
+def tier_locks_path(from_tier: str, to_tier: str) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise marginal-loss path between two tiers.
+
+    Marginal-loss mirror of :func:`tier_unlocks_path` and the fourth
+    member of the ``_path`` family alongside :func:`tier_path` (full
+    ``tier_diff`` per rung), :func:`capacity_diff_path` (capacity-only
+    per rung), and :func:`tier_unlocks_path` (marginal grant per rung).
+    Lets a "downgrade-walkthrough" surface render only the *newly-lost*
+    features + runtimes at each rung between any two tiers off ONE
+    round-trip, without the noise of the capacity axes or the symmetric
+    ``added_*`` lists :func:`tier_path` carries.
+
+    Per-rung row shape matches :func:`tier_locks` exactly -- ``tier``,
+    ``tier_label``, ``tier_rank``, ``next_tier``, ``next_tier_label``,
+    ``next_tier_rank``, ``lost_features``, ``lost_runtimes`` -- with
+    one critical difference: ``next_tier`` is the **previous step in
+    the walked path** (or ``from_tier`` for the first row), NOT the
+    global "next-higher purchasable tier" anchor :func:`tier_locks`
+    uses. The path-chained source guarantees
+    ``row[i]['tier'] == row[i+1]['next_tier']`` so a consumer can fold
+    ``lost_features`` / ``lost_runtimes`` across rows to reconstruct the
+    cumulative ``tier_diff(from_tier, to_tier)['lost_*']`` shape -- the
+    same chain-property :func:`tier_path`, :func:`capacity_diff_path`,
+    and :func:`tier_unlocks_path` enforce on their rows.
+
+    The walk visits every purchasable tier strictly between ``from_tier``
+    and ``to_tier`` plus the destination ``to_tier`` itself, in tier-rank
+    order (ascending or descending depending on direction). Same-rank
+    siblings *between* the endpoints are both included (matching
+    :func:`tier_path`'s ladder shape); same-rank siblings of the
+    destination are excluded so the path terminates exactly at
+    ``to_tier``. Rung walk is byte-stable against :func:`tier_path`,
+    :func:`capacity_diff_path`, and :func:`tier_unlocks_path` (same
+    ``_PURCHASABLE_TIERS`` filter + same sort key + same destination-
+    sibling exclusion).
+
+    Direction semantics:
+
+    * ``downgrade`` (descending) -- each row's ``lost_features`` /
+      ``lost_runtimes`` are the marginal loss at that rung. The natural
+      "what do I give up if I drop this far" walkthrough.
+    * ``upgrade`` (ascending) -- each row's ``lost_features`` /
+      ``lost_runtimes`` are typically empty (you're gaining things, not
+      losing them); use :func:`tier_unlocks_path` for the marginal-grant
+      view of an upgrade. The path still walks rungs so a UI keyed off
+      rung shape keeps working; the empty lists are the correct "locks"
+      answer.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the set difference (``from`` minus ``to``) between the
+      two same-rank tier grants.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Endpoint semantics match :func:`tier_path` / :func:`tier_unlocks_path`:
+    both ids accept any entry in :data:`_TIER_FEATURES` (including
+    :data:`TIER_TRIAL`, which is not purchasable -- it is excluded from
+    the walked rungs but is a valid endpoint for the marginal-step
+    computation). Unknown ids on either side short-circuit to ``None``.
+
+    Never raises: a resolver failure logs a warning and returns ``None``
+    so a downgrade-walkthrough surface keeps rendering.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+        if from_rank == to_rank:
+            row = _locks_row(f, t)
+            return [row] if row is not None else []
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        prev_step = f
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            row = _locks_row(prev_step, tid)
+            if row is not None:
+                path.append(row)
+                prev_step = tid
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: tier_locks_path failed: %s", exc)
+        return None
 
 
 def upgrade_path() -> list[dict]:

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -912,6 +912,115 @@ def api_entitlement_tier_locks_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/tier-locks-path")
+def api_entitlement_tier_locks_path():
+    """``GET /api/entitlement/tier-locks-path?from=<id>&to=<id>`` --
+    arbitrary-endpoint stepwise marginal-loss path between any two
+    tiers; the locks-focused mirror of ``/tier-unlocks-path`` and the
+    fourth member of the ``_path`` family alongside ``/tier-path`` (full
+    ``tier_diff`` per rung) and ``/capacity-diff-path`` (capacity-only
+    per rung). Lets a downgrade-walkthrough surface render only the
+    *newly-lost* features + runtimes at each rung between any two tiers
+    off ONE round-trip, without the noise of the capacity axes or the
+    symmetric ``added_*`` lists ``/tier-path`` carries.
+
+    Each row in ``path`` is a :func:`clawmetry.entitlements.tier_locks`
+    payload between the previous step in the path (or ``from`` for the
+    first row) and the current rung -- so each row is a marginal-step
+    loss and a consumer can fold ``lost_features`` / ``lost_runtimes``
+    across rows to reconstruct the cumulative
+    ``tier_diff(from, to)['lost_*']`` shape (the same chain-property
+    ``/tier-path``, ``/capacity-diff-path``, and ``/tier-unlocks-path``
+    enforce on their rows). Same-rank siblings strictly between the
+    endpoints are both included; same-rank siblings of the destination
+    are excluded so the path terminates exactly at ``to``. Rung walk is
+    byte-stable against ``/tier-path``, ``/capacity-diff-path``, and
+    ``/tier-unlocks-path``.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<tier_locks row>, ...],
+        }
+
+    Each ``<row>`` matches the singular ``/tier-locks`` row shape
+    exactly (``tier``, ``tier_label``, ``tier_rank``, ``next_tier``,
+    ``next_tier_label``, ``next_tier_rank``, ``lost_features``,
+    ``lost_runtimes``) -- with ``next_tier`` chained from the path (the
+    previous step), NOT the global next-higher-purchasable-tier anchor
+    the singular helper uses.
+
+    Direction semantics:
+
+    * ``downgrade`` (descending) -- each row's ``lost_features`` /
+      ``lost_runtimes`` are the marginal loss at that rung.
+    * ``upgrade`` (ascending) -- each row's ``lost_features`` /
+      ``lost_runtimes`` are typically empty (use ``/tier-unlocks-path``
+      for the marginal-grant view of an upgrade). The path still walks
+      rungs so a UI keyed off rung shape keeps working.
+    * ``lateral`` (same rank, different id) -- single-row path; carries
+      the set difference (``from`` minus ``to``) between the two
+      same-rank tier grants.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Identity (``from == to``) returns an empty path. Lateral (same rank,
+    different id) returns a single-row path. ``400`` when ``from=`` or
+    ``to=`` is missing; ``404`` when either id is unknown. ``trial`` IS
+    accepted as an endpoint -- it is excluded from the walked rungs (not
+    purchasable) but the endpoint computation still resolves. Never
+    5xxs: a resolver failure short-circuits to ``404`` so a downgrade-
+    walkthrough surface keeps rendering instead of breaking.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        path = _ent.tier_locks_path(f, t)
+        if path is None:
+            return (
+                jsonify({"error": "unknown tier", "from": f, "to": t}),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_tier_locks_path: error: %s", exc)
+        return (
+            jsonify({"error": "unknown tier", "from": f, "to": t}),
+            404,
+        )
+
+
 @bp_entitlement.route("/api/entitlement/upgrade-path")
 def api_entitlement_upgrade_path():
     """``GET /api/entitlement/upgrade-path`` -- ordered marginal-unlock

--- a/tests/test_entitlement_tier_locks_path.py
+++ b/tests/test_entitlement_tier_locks_path.py
@@ -1,0 +1,519 @@
+"""Tests for ``clawmetry.entitlements.tier_locks_path(from, to)`` + the
+``GET /api/entitlement/tier-locks-path`` endpoint.
+
+Marginal-loss mirror of :func:`tier_unlocks_path` and the fourth member
+of the ``_path`` family alongside :func:`tier_path` (full ``tier_diff``
+per rung), :func:`capacity_diff_path` (capacity-only per rung), and
+:func:`tier_unlocks_path` (marginal grant per rung). Lets a downgrade-
+walkthrough surface render only the *newly-lost* features + runtimes at
+each rung between any two tiers off ONE round-trip, without the noise of
+the capacity axes or the symmetric ``added_*`` lists :func:`tier_path`
+carries.
+
+Each row matches :func:`tier_locks`'s row shape exactly -- ``tier``,
+``tier_label``, ``tier_rank``, ``next_tier``, ``next_tier_label``,
+``next_tier_rank``, ``lost_features``, ``lost_runtimes`` -- with
+``next_tier`` chained from the path (the previous step), NOT the global
+next-higher-purchasable-tier anchor :func:`tier_locks` uses. The path-
+chained source guarantees ``row[i]['tier'] == row[i+1]['next_tier']`` so
+a consumer can fold ``lost_features`` / ``lost_runtimes`` across rows to
+reconstruct the cumulative ``tier_diff(from, to)['lost_*']`` shape.
+
+Pins:
+
+* row shape matches singular ``tier_locks`` schema (down to the key set)
+* ``next_tier`` is path-chained, not the global anchor (the *one*
+  semantic difference vs :func:`tier_locks`); ``next_tier_*`` fields are
+  NEVER ``None`` (the path always has a concrete source step)
+* per-rung chain is continuous on the tier axis
+  (``row[i]['tier'] == row[i+1]['next_tier']``)
+* rung walk is byte-stable against :func:`tier_path` and
+  :func:`tier_unlocks_path` (same ``_PURCHASABLE_TIERS`` filter + same
+  sort + same destination-sibling exclusion); confirmed by extracting
+  the rung ``to`` ids
+* descending path lost_features + lost_runtimes fold to the cumulative
+  ``tier_diff(from, to)['lost_*']`` sets
+* ascending path rows carry empty loss lists (you gain things, you
+  don't lose them) but still walk the rungs so a UI keyed off rung
+  shape keeps working
+* identity (``from == to``) returns an empty path
+* lateral (same rank, different id) returns a single-row path
+* trial accepted as an endpoint -- excluded from walked rungs but the
+  endpoint computation still resolves
+* unknown / empty / garbage ids return ``None`` and never raise
+* grace vs enforce yields identical rows (helper is decoupled from the
+  resolved entitlement; it walks the static per-tier maps)
+* API surface: 400 on missing args, 404 on unknown ids, 200 with the
+  envelope shape on the happy path (incl. direction tag)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ROW_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "next_tier",
+    "next_tier_label",
+    "next_tier_rank",
+    "lost_features",
+    "lost_runtimes",
+}
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+}
+
+
+# ── helper-level: shape + invariants ─────────────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_matches_tier_locks_schema(ent):
+    path = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == _ROW_KEYS
+        assert isinstance(row["lost_features"], list)
+        assert isinstance(row["lost_runtimes"], list)
+
+
+def test_next_tier_fields_never_none_on_path(ent):
+    """Singular :func:`tier_locks` returns ``next_tier=None`` at the
+    ceiling rung (Enterprise has no purchasable tier above it). The
+    path variant ALWAYS has a concrete previous step (``from_tier`` on
+    the first row, the prior rung on later rows), so the ``next_tier_*``
+    fields are never ``None`` -- pin this so a UI that strictly relies
+    on the chained source can render confidently."""
+    path = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    for row in path:
+        assert row["next_tier"] is not None
+        assert row["next_tier_label"] is not None
+        assert row["next_tier_rank"] is not None
+
+
+def test_first_row_next_is_from_tier(ent):
+    path = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    assert path[0]["next_tier"] == ent.TIER_ENTERPRISE
+    assert path[0]["next_tier_rank"] == ent.tier_rank(ent.TIER_ENTERPRISE)
+
+
+def test_chain_is_continuous_on_tier_axis(ent):
+    """Each row's ``tier`` is the next row's ``next_tier`` -- the same
+    chain-property :func:`tier_path`, :func:`capacity_diff_path`, and
+    :func:`tier_unlocks_path` enforce on their rows."""
+    path = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    for i in range(len(path) - 1):
+        assert path[i]["tier"] == path[i + 1]["next_tier"]
+        assert path[i]["tier_rank"] == path[i + 1]["next_tier_rank"]
+    assert path[-1]["tier"] == ent.TIER_OSS
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    """``oss`` and ``cloud_free`` share rank 0; asking for ``oss`` must
+    end exactly at ``oss`` and EXCLUDE the same-rank sibling
+    ``cloud_free`` from the final rung -- same rule as
+    :func:`tier_path`."""
+    rungs = [r["tier"] for r in ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)]
+    assert rungs[-1] == ent.TIER_OSS
+    assert rungs.count(ent.TIER_OSS) == 1
+    assert ent.TIER_CLOUD_FREE not in rungs
+
+
+def test_same_rank_siblings_between_endpoints_both_included(ent):
+    """Walking enterprise -> oss: rank-2 siblings ``pro`` AND
+    ``cloud_pro`` both appear because they sit strictly *between* rank-3
+    start and rank-0 destination -- same rule as :func:`tier_path`."""
+    rungs = [r["tier"] for r in ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)]
+    assert ent.TIER_CLOUD_PRO in rungs
+    assert ent.TIER_PRO in rungs
+    assert rungs[-1] == ent.TIER_OSS
+
+
+def test_rung_walk_byte_stable_against_tier_path(ent):
+    """The set of rung ``tier`` ids must match :func:`tier_path`'s set
+    of rung ``to`` ids byte-for-byte -- same ``_PURCHASABLE_TIERS``
+    filter + same sort + same destination-sibling exclusion."""
+    for f, t in (
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_PRO, ent.TIER_CLOUD_FREE),
+        (ent.TIER_CLOUD_PRO, ent.TIER_OSS),
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_TRIAL, ent.TIER_OSS),
+    ):
+        locks_rungs = [r["tier"] for r in ent.tier_locks_path(f, t)]
+        diff_rungs = [r["to"] for r in ent.tier_path(f, t)]
+        assert locks_rungs == diff_rungs
+
+
+def test_rung_walk_byte_stable_against_tier_unlocks_path(ent):
+    """The set of rung ``tier`` ids must also match
+    :func:`tier_unlocks_path`'s set of rung ``tier`` ids byte-for-byte
+    -- pins the rung walk against the other ``_path`` family members so
+    the four endpoints stay in lockstep."""
+    for f, t in (
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_PRO, ent.TIER_CLOUD_FREE),
+        (ent.TIER_CLOUD_PRO, ent.TIER_OSS),
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_TRIAL, ent.TIER_OSS),
+    ):
+        locks_rungs = [r["tier"] for r in ent.tier_locks_path(f, t)]
+        unlocks_rungs = [r["tier"] for r in ent.tier_unlocks_path(f, t)]
+        assert locks_rungs == unlocks_rungs
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        assert ent.tier_locks_path(tid, tid) == []
+
+
+def test_lateral_single_row(ent):
+    """Same rank, different id -- single-row path; row carries the set
+    difference (``from`` minus ``to``) between the two same-rank tier
+    grants."""
+    path = ent.tier_locks_path(ent.TIER_CLOUD_PRO, ent.TIER_PRO)
+    assert len(path) == 1
+    row = path[0]
+    assert row["tier"] == ent.TIER_PRO
+    assert row["next_tier"] == ent.TIER_CLOUD_PRO
+    # cloud_pro and pro share their grant set, so the set-diff is empty
+    assert row["lost_features"] == []
+    assert row["lost_runtimes"] == []
+
+
+def test_cloud_free_to_oss_lateral_empty_diff(ent):
+    """Both rank 0 -- lateral single-row path with no loss diff."""
+    path = ent.tier_locks_path(ent.TIER_CLOUD_FREE, ent.TIER_OSS)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_OSS
+    assert path[0]["next_tier"] == ent.TIER_CLOUD_FREE
+    assert path[0]["lost_features"] == []
+    assert path[0]["lost_runtimes"] == []
+
+
+def test_adjacent_step_is_one_row(ent):
+    """cloud_starter (rank 1) -> oss (rank 0) is a single rank-down
+    step. Every paid runtime first appears at Starter, so the drop to
+    the floor loses every paid runtime in one rung."""
+    path = ent.tier_locks_path(ent.TIER_CLOUD_STARTER, ent.TIER_OSS)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_OSS
+    assert path[0]["next_tier"] == ent.TIER_CLOUD_STARTER
+    assert set(path[0]["lost_runtimes"]) == set(ent.PAID_RUNTIMES)
+
+
+def test_descending_path_loses_enterprise_at_top_step(ent):
+    """The first rung of an enterprise -> oss descent is the one that
+    sheds the enterprise-only features (``sso`` + ``audit_logs``)."""
+    path = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    first = path[0]
+    assert first["next_tier"] == ent.TIER_ENTERPRISE
+    assert "sso" in first["lost_features"]
+    assert "audit_logs" in first["lost_features"]
+
+
+def test_ascending_path_terminates_at_to_but_losses_are_empty(ent):
+    """Ascending walk still visits the rungs (so a UI keyed off rung
+    shape keeps working), but each row's ``lost_features`` /
+    ``lost_runtimes`` collapse to empty lists -- you gain things, you
+    don't lose them."""
+    path = ent.tier_locks_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert path[0]["next_tier"] == ent.TIER_OSS
+    assert path[-1]["tier"] == ent.TIER_ENTERPRISE
+    for row in path:
+        assert row["lost_features"] == []
+        assert row["lost_runtimes"] == []
+
+
+def test_ascending_terminates_at_explicit_ceiling(ent):
+    """Asking for ``pro`` must NOT also include ``cloud_pro`` (the other
+    rank-2 sibling) as a terminal rung -- same rule as
+    :func:`tier_path`."""
+    rungs = [r["tier"] for r in ent.tier_locks_path(ent.TIER_OSS, ent.TIER_PRO)]
+    assert rungs[-1] == ent.TIER_PRO
+    assert rungs.count(ent.TIER_PRO) == 1
+
+
+def test_fold_reproduces_cumulative_lost_features(ent):
+    """Folding the per-step marginal loss sets across the path must
+    reproduce the cumulative ``tier_diff(from, to)['lost_features']``
+    set (and likewise for runtimes) -- the byte-level invariant that
+    makes the path a true marginal decomposition. Mirror of
+    :func:`tier_unlocks_path`'s ``added_*`` fold."""
+    f, t = ent.TIER_ENTERPRISE, ent.TIER_OSS
+    path = ent.tier_locks_path(f, t)
+    folded_features: set[str] = set()
+    folded_runtimes: set[str] = set()
+    for row in path:
+        folded_features |= set(row["lost_features"])
+        folded_runtimes |= set(row["lost_runtimes"])
+    direct = ent.tier_diff(f, t)
+    assert folded_features == set(direct["lost_features"])
+    assert folded_runtimes == set(direct["lost_runtimes"])
+
+
+def test_fold_handles_cloud_free_floor(ent):
+    """enterprise (rank 3) -> cloud_free (rank 0) folds the same way as
+    enterprise -> oss -- both floors share the same free grant so the
+    cumulative ``lost_*`` set is identical."""
+    f, t = ent.TIER_ENTERPRISE, ent.TIER_CLOUD_FREE
+    path = ent.tier_locks_path(f, t)
+    folded_features: set[str] = set()
+    for row in path:
+        folded_features |= set(row["lost_features"])
+    direct = ent.tier_diff(f, t)
+    assert folded_features == set(direct["lost_features"])
+
+
+def test_set_identity_with_unlocks_path_swap(ent):
+    """Set-identity mirror of :func:`tier_diff`'s swap invariant: the
+    cumulative ``lost_*`` fold of ``tier_locks_path(X, Y)`` byte-equals
+    the cumulative ``added_*`` fold of ``tier_unlocks_path(Y, X)``. The
+    two ``_path`` family members carry the same information from
+    opposite ends -- pin this so a future reshuffle of the tier grant
+    sets cannot silently desync them."""
+    f, t = ent.TIER_ENTERPRISE, ent.TIER_OSS
+    locks = ent.tier_locks_path(f, t)
+    unlocks = ent.tier_unlocks_path(t, f)
+    locks_feats: set[str] = set()
+    locks_runtimes: set[str] = set()
+    for row in locks:
+        locks_feats |= set(row["lost_features"])
+        locks_runtimes |= set(row["lost_runtimes"])
+    unlocks_feats: set[str] = set()
+    unlocks_runtimes: set[str] = set()
+    for row in unlocks:
+        unlocks_feats |= set(row["features"])
+        unlocks_runtimes |= set(row["runtimes"])
+    assert locks_feats == unlocks_feats
+    assert locks_runtimes == unlocks_runtimes
+
+
+def test_lists_are_sorted_per_row(ent):
+    path = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    for row in path:
+        assert row["lost_features"] == sorted(row["lost_features"])
+        assert row["lost_runtimes"] == sorted(row["lost_runtimes"])
+
+
+def test_trial_excluded_from_walked_rungs_but_valid_endpoint(ent):
+    """``trial`` is not purchasable -- it must never appear as a stop on
+    a path between purchasable tiers, but it IS a valid endpoint."""
+    path = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    for row in path:
+        assert row["tier"] != ent.TIER_TRIAL
+        assert row["next_tier"] != ent.TIER_TRIAL
+    # trial as an endpoint still resolves
+    downward = ent.tier_locks_path(ent.TIER_TRIAL, ent.TIER_OSS)
+    assert downward is not None
+    assert downward[-1]["tier"] == ent.TIER_OSS
+    upward = ent.tier_locks_path(ent.TIER_TRIAL, ent.TIER_ENTERPRISE)
+    assert upward is not None
+    assert upward[-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_unknown_tiers_return_none(ent):
+    assert ent.tier_locks_path("not_a_tier", ent.TIER_OSS) is None
+    assert ent.tier_locks_path(ent.TIER_ENTERPRISE, "still_not_a_tier") is None
+    assert ent.tier_locks_path("a", "b") is None
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.tier_locks_path("", "") is None
+    assert ent.tier_locks_path(None, None) is None  # type: ignore[arg-type]
+    assert ent.tier_locks_path("  ", "  ") is None
+    assert ent.tier_locks_path(123, 456) is None  # type: ignore[arg-type]
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    b = ent.tier_locks_path(" ENTERPRISE  ", "  OSS ")
+    assert a == b
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, monkeypatch):
+    """The helper is decoupled from the resolved entitlement -- it walks
+    the static per-tier maps so flipping enforce on must NOT change any
+    row. Pins the resolver-independence property the whole ``_path``
+    family shares."""
+    grace_rows = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_rows = ent.tier_locks_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    assert grace_rows == enforced_rows
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_args(client):
+    assert client.get("/api/entitlement/tier-locks-path").status_code == 400
+    assert (
+        client.get("/api/entitlement/tier-locks-path?from=enterprise").status_code
+        == 400
+    )
+    assert (
+        client.get("/api/entitlement/tier-locks-path?to=oss").status_code == 400
+    )
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get("/api/entitlement/tier-locks-path?from=enterprise&to=not_a_tier")
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["to"] == "not_a_tier"
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_ENTERPRISE
+    assert body["to"] == ent.TIER_OSS
+    assert body["direction"] == "downgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["tier"] == ent.TIER_OSS
+    # row schema matches the singular endpoint
+    for row in body["path"]:
+        assert set(row.keys()) == _ROW_KEYS
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "upgrade"
+    assert body["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+    # ascending: each row's loss lists collapse to empty
+    for row in body["path"]:
+        assert row["lost_features"] == []
+        assert row["lost_runtimes"] == []
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["next_tier"] == ent.TIER_CLOUD_PRO
+    assert body["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_api_trial_endpoint_accepted(client, ent):
+    r = client.get(
+        f"/api/entitlement/tier-locks-path?from={ent.TIER_TRIAL}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["path"][-1]["tier"] == ent.TIER_OSS
+
+
+def test_api_rungs_match_tier_path_route(client, ent):
+    """API-level byte-equality: rung ``tier`` ids from
+    ``/tier-locks-path`` match rung ``to`` ids from ``/tier-path``."""
+    a = client.get(
+        f"/api/entitlement/tier-locks-path?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/tier-path?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    ).get_json()
+    assert [r["tier"] for r in a["path"]] == [r["to"] for r in b["path"]]
+
+
+def test_api_rungs_match_tier_unlocks_path_route(client, ent):
+    """API-level byte-equality: rung ``tier`` ids from
+    ``/tier-locks-path`` match rung ``tier`` ids from
+    ``/tier-unlocks-path`` -- the two locks/unlocks ``_path`` siblings
+    walk identical rungs (they only differ on the per-row payload)."""
+    a = client.get(
+        f"/api/entitlement/tier-locks-path?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/tier-unlocks-path?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    ).get_json()
+    assert [r["tier"] for r in a["path"]] == [r["tier"] for r in b["path"]]
+
+
+def test_api_garbage_query_never_5xx(client):
+    """A garbage-query sweep must never 5xx -- a downgrade-warning surface
+    must keep rendering instead of breaking."""
+    for f, t in (
+        ("", ""),
+        ("nope", "nope"),
+        ("oss", "still_not"),
+        ("not_a_tier", "oss"),
+        ("%%%", "***"),
+    ):
+        r = client.get(
+            f"/api/entitlement/tier-locks-path?from={f}&to={t}"
+        )
+        assert r.status_code < 500


### PR DESCRIPTION
## Summary

Adds `tier_locks_path(from_tier, to_tier)` to `clawmetry.entitlements` and the companion `GET /api/entitlement/tier-locks-path` endpoint — the **marginal-loss mirror of `tier_unlocks_path`** and the fourth member of the `_path` family alongside `tier_path` (full `tier_diff` per rung) and `capacity_diff_path` (capacity-only per rung).

`tier_unlocks_path(from, to)` answers "what does each rung *first unlock* as I climb between two tiers?" with a marginal-grant row per rung. `tier_locks_path(from, to)` answers the symmetric "what does each rung *first lose* as I drop between two tiers?" with a marginal-loss row per rung — the per-step downgrade-warning view a step-down walkthrough renders, paired with `tier_unlocks_path` the way `tier_locks` is paired with `tier_unlocks`.

| Helper                | Per-rung payload                              |
| --------------------- | --------------------------------------------- |
| `tier_path`           | full `tier_diff` (added + lost + capacity)    |
| `capacity_diff_path`  | capacity axes only                            |
| `tier_unlocks_path`   | marginal **grant** (`features`, `runtimes`)   |
| **`tier_locks_path`** | marginal **loss** (`lost_features`, `lost_runtimes`) |

## Design notes

- **Purely additive; zero behavior change to existing surfaces.** No edits to existing helpers other than clearing the `"future ``tier_locks_path``"` forward-reference in `tier_unlocks_path`'s docstring now that this PR lands the function.
- **Per-rung row shape matches singular `tier_locks` byte-for-byte** — `tier`, `tier_label`, `tier_rank`, `next_tier`, `next_tier_label`, `next_tier_rank`, `lost_features`, `lost_runtimes` — with one semantic difference: `next_tier` is the **previous step in the walked path** (chained), NOT the global "next-higher purchasable tier" anchor the singular helper uses. The chain guarantees `row[i]['tier'] == row[i+1]['next_tier']` so a consumer can fold `lost_features` / `lost_runtimes` across rows to reconstruct the cumulative `tier_diff(from, to)['lost_*']` shape — the same chain-property `tier_path`, `capacity_diff_path`, and `tier_unlocks_path` enforce on their rows.
- **Rung walk is byte-stable against `tier_path`, `capacity_diff_path`, and `tier_unlocks_path`** (same `_PURCHASABLE_TIERS` filter + same sort key + same destination-sibling exclusion). Pinned at both the helper and the API level in the test suite, so the four `_path` siblings can never silently drift apart.
- **Set-identity swap with `tier_unlocks_path` pinned**: the cumulative `lost_*` fold of `tier_locks_path(X, Y)` byte-equals the cumulative `added_*` fold of `tier_unlocks_path(Y, X)`. The two siblings carry the same information from opposite ends — pinning this prevents a future reshuffle of the tier grant sets from silently desyncing the views.
- **Direction semantics** mirror `tier_unlocks_path` (response carries a `direction` tag, consumer reads instead of inferring):
  - `downgrade` (descending) — each row's `lost_*` are the marginal loss at that rung.
  - `upgrade` (ascending) — each row's `lost_*` collapse to empty (use `tier_unlocks_path` for the marginal-grant view). The path still walks rungs so a UI keyed off rung shape keeps working.
  - `lateral` (same rank, different id) — single-row path; carries the set difference (`from` minus `to`) between the two same-rank grants.
  - `identity` (`from == to`) — empty path; no rungs to walk.
- **Decoupled from the resolved entitlement** (walks the static per-tier maps), so grace vs enforce yields identical rows — pinned in the test suite via a grace/enforce reload roundtrip.
- **`TIER_TRIAL` accepted as an endpoint** but excluded from walked rungs (matches `tier_unlocks_path` / `tier_path`).
- **Never raises**; endpoint returns `400` when an arg is missing, `404` on unknown id, `200` with the envelope shape on the happy path.

## API envelope

```
GET /api/entitlement/tier-locks-path?from=<id>&to=<id>

{
  "from":       "<tier id>",
  "from_label": "...",
  "from_rank":  <int>,
  "to":         "<tier id>",
  "to_label":   "...",
  "to_rank":    <int>,
  "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
  "path": [
    {
      "tier":             "<tier id>",
      "tier_label":       "...",
      "tier_rank":        <int>,
      "next_tier":        "<previous step in path>",
      "next_tier_label":  "...",
      "next_tier_rank":   <int>,
      "lost_features":    [...],
      "lost_runtimes":    [...]
    },
    ...
  ]
}
```

Rung walk is byte-equal to `/tier-path` and `/tier-unlocks-path` for the same args — pinned in the test suite.

## Tests

35 new tests covering: helper row schema, `next_tier_*` never `None` on the path (singular returns `None` at the ceiling rung; the path always has a concrete source), chain continuity, rung walk byte-stability against both `tier_path` **and** `tier_unlocks_path`, identity / lateral / adjacent / floor / top rung shapes, ascending-collapses-to-empty, descending fold to `tier_diff(from, to)['lost_*']`, set-identity swap with `tier_unlocks_path` (lost fold of A→B == added fold of B→A), trial accepted as endpoint but excluded from walked rungs, never-raise on garbage input, grace/enforce row identity, plus the full API surface (400 / 404 / 200 happy ascending + descending / identity / lateral / trial / rungs match `/tier-path` + `/tier-unlocks-path` byte-for-byte / garbage-query 5xx-never sweep).

```
$ python3 -m pytest tests/test_entitlement_tier_locks_path.py -v
35 passed in 0.39s

$ python3 -m pytest tests/test_entitlement_*.py tests/test_entitlements*.py
1044 passed in 9.21s

$ python3 -m ruff check clawmetry/entitlements.py routes/entitlement.py \
                        tests/test_entitlement_tier_locks_path.py
All checks passed!
```

## Local operator verification checklist

I can't reach the local daemon, `~/.openclaw`, or the live cloud snapshot — please do these on your box before flipping the PR to ready / releasing:

- [ ] Copy changed files into the daemon's site-packages:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/`
- [ ] Clear `__pycache__`:
      `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the sync daemon:
      `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint locally:
      `curl -s 'http://localhost:8900/api/entitlement/tier-locks-path?from=enterprise&to=oss' | jq`
      → expect envelope with `direction: "downgrade"`, terminal row `path[-1].tier == "oss"`, first row `path[0].next_tier == "enterprise"` carrying `sso` + `audit_logs` in `lost_features`
- [ ] Confirm rung byte-equality with `/tier-path` and `/tier-unlocks-path`:
      `diff <(curl -s 'http://localhost:8900/api/entitlement/tier-locks-path?from=enterprise&to=oss' | jq '[.path[].tier]') <(curl -s 'http://localhost:8900/api/entitlement/tier-path?from=enterprise&to=oss' | jq '[.path[].to]')`
      `diff <(curl -s 'http://localhost:8900/api/entitlement/tier-locks-path?from=enterprise&to=oss' | jq '[.path[].tier]') <(curl -s 'http://localhost:8900/api/entitlement/tier-unlocks-path?from=enterprise&to=oss' | jq '[.path[].tier]')`
      → expect no diff on either
- [ ] Spot-check existing endpoints still work:
      `curl -s 'http://localhost:8900/api/entitlement/tier-unlocks-path?from=oss&to=enterprise' | jq '.path | length'` (unchanged)
      `curl -s 'http://localhost:8900/api/entitlement/tier-locks-batch' | jq '.tiers | length'` (unchanged)
      `curl -s 'http://localhost:8900/api/entitlement' | jq '.tier'` (unchanged)
- [ ] Decrypt the live cloud snapshot and confirm the entitlement panel still renders.
- [ ] Browser-check `localhost:8900` for any pricing-page regressions.

Cloud (`clawmetry-cloud`) and `clawmetry-pro` work in P3/P4/P6 is **out of scope for this PR** — those require the private repos this agent does not have access to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jkzmyvp61ZcKtBqvbkfb8M)_