### PR TITLE
fix(daemon): local-only config (no api_key) crash-looped the daemon

### DIFF
--- a/clawmetry/cli.py
+++ b/clawmetry/cli.py
@@ -2108,6 +2108,10 @@ def _cmd_onboard(args) -> None:
         try:
             from clawmetry.sync import save_config as _save_config
             _save_config({
+                # Empty api_key keeps the local-only config shape complete: the
+                # daemon startup path subscripts config["api_key"], and an empty
+                # string is safe because is_cloud_disabled() gates all egress.
+                "api_key": "",
                 "node_id": _local_node_id,
                 "platform": _plat.system(),
                 "connected_at": __import__("datetime").datetime.now().isoformat(),

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -778,7 +778,21 @@ def _dlq_replay(api_key: str, enc_key: str | None) -> int:
 def load_config() -> dict:
     if not CONFIG_FILE.exists():
         raise FileNotFoundError(f"No config at {CONFIG_FILE}. Run: clawmetry connect")
-    return json.loads(CONFIG_FILE.read_text())
+    data = json.loads(CONFIG_FILE.read_text())
+    # Local-only installs (clawmetry onboard -> [1] Local only, #3281) write a
+    # config with no api_key, but the daemon startup path subscripts
+    # config["api_key"] (start_log_streamer + ~12 other call sites). Normalize
+    # so a missing key degrades to "" instead of KeyError-crashing the daemon
+    # on every boot (which leaves the local store empty). Cloud egress is
+    # independently gated by is_cloud_disabled(), so an empty api_key is never
+    # used for a real cloud call. node_id is likewise required by the start
+    # banner; default it to the hostname to match the daemon's own fallback.
+    if isinstance(data, dict):
+        data.setdefault("api_key", "")
+        if not data.get("node_id"):
+            import socket as _sock
+            data["node_id"] = _sock.gethostname() or "local"
+    return data
 
 
 def save_config(data: dict) -> None:

--- a/tests/test_local_only_config_normalize.py
+++ b/tests/test_local_only_config_normalize.py
@@ -1,0 +1,52 @@
+"""Regression: a local-only config (no api_key) must not crash the daemon.
+
+The install fork (#3281) added a [1] Local only onboard path that writes a
+config WITHOUT an api_key. The daemon startup path subscripts
+config["api_key"] (start_log_streamer + ~12 sites), so loading such a config
+KeyError-crashed run_daemon on every boot in 0.12.526, leaving the local store
+empty (no OpenClaw sessions ingested). load_config() now normalizes the shape.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def test_load_config_fills_missing_api_key(tmp_path, monkeypatch):
+    import clawmetry.sync as sync
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"node_id": "box-1", "local_only": True}))
+    monkeypatch.setattr(sync, "CONFIG_FILE", cfg)
+
+    data = sync.load_config()
+    assert data["api_key"] == "", "missing api_key must normalize to '' not KeyError"
+    assert data["node_id"] == "box-1"
+    # The subscript that crashed the daemon must now succeed.
+    assert data["api_key"] == ""  # config["api_key"] style access is safe
+
+
+def test_load_config_defaults_node_id_when_absent(tmp_path, monkeypatch):
+    import clawmetry.sync as sync
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"local_only": True}))  # neither api_key nor node_id
+    monkeypatch.setattr(sync, "CONFIG_FILE", cfg)
+
+    data = sync.load_config()
+    assert data["api_key"] == ""
+    assert data["node_id"], "node_id must default to a non-empty hostname"
+
+
+def test_load_config_preserves_existing_values(tmp_path, monkeypatch):
+    import clawmetry.sync as sync
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"api_key": "cm_real", "node_id": "n9", "encryption_key": "k"}))
+    monkeypatch.setattr(sync, "CONFIG_FILE", cfg)
+
+    data = sync.load_config()
+    assert data["api_key"] == "cm_real"  # do not clobber a real key
+    assert data["node_id"] == "n9"
+    assert data["encryption_key"] == "k"


### PR DESCRIPTION
## Critical regression in 0.12.526 (the install fork I just shipped)

The new `[1] Local only` onboard path (#3281) writes a config **without `api_key`**. But `run_daemon`'s startup path subscripts `config['api_key']` (`start_log_streamer` + ~12 other call sites), so `load_config()` of a local-only config raised `KeyError: 'api_key'` **on every boot**. The daemon crash-looped before ingesting any OpenClaw sessions, so the local store stayed empty and the dashboard (Brain / Tracing) showed no conversation.

Found from a real user report: local-only install, Brain tab empty, daemon log full of `KeyError: 'api_key'` in `start_log_streamer`.

## Fix
- **`load_config()` normalizes** a missing `api_key` to `''` and a missing `node_id` to the hostname, so the daemon boots regardless of config shape. This **self-heals existing broken 0.12.526 local-only installs** on update (no re-onboard needed). An empty `api_key` is safe because `is_cloud_disabled()` independently gates all cloud egress.
- **`cli.py`** local-only config now writes `api_key: ''` for a complete shape going forward.

## Verification
Reproduced + fixed on a live local-only install:
- **Before:** `KeyError: 'api_key'` crash-loop, `sessions` table empty (0 rows), Brain showed only daemon-error events.
- **After (patched + daemon restart):** `Event streamer started — watching ~/.openclaw/agents/main/sessions`, `Synced 403 events ... 2 session rows`. The user's OpenClaw sessions ingest.

`tests/test_local_only_config_normalize.py` guards it (missing `api_key` -> `''`, missing `node_id` -> hostname, real values preserved). 14 tests green incl. the onboard-fork suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)