### PR TITLE
fix(brain): show all local Brain history + hide our own daemon noise from the feed

### DIFF
--- a/routes/brain.py
+++ b/routes/brain.py
@@ -327,6 +327,17 @@ def _try_local_store_brain(limit, include_artifacts, since=None):
         # -mem-probe …) so our plumbing doesn't show up in the Brain feed.
         if hide_clawmetry_session(r.get("session_id")):
             continue
+        # Hide ClawMetry's OWN daemon diagnostics (the daemon-error -> DuckDB
+        # tee, PRD #1133) from the Brain conversation feed. These carry
+        # agent_id="clawmetry-daemon" / event_type="daemon.*" and an empty
+        # session_id, so the helper-session filter above misses them; left in,
+        # a noisy daemon (or a crash loop) buries the user's actual agent
+        # conversation under our own error spam. They still feed the health /
+        # diagnostics views.
+        _agent = (r.get("agent_id") or "")
+        _etype = (r.get("event_type") or "").lower()
+        if _agent == "clawmetry-daemon" or _etype.startswith("daemon."):
+            continue
         # P0 regression fix (#1143): the v3 sync mapper nests content under
         # ``data.data`` and the legacy trajectory parser nests it under
         # ``data.message.content`` — neither exposes the flat ``input/summary/
@@ -457,19 +468,14 @@ def api_brain_history():
     include_artifacts = _brain_history_bool_arg(
         request.args.get("include_artifacts") or request.args.get("artifacts")
     )
-    # OSS / Cloud-Free 24h retention cap (issue #1448 surface 3). Pro
-    # users bypass entirely; everyone else gets clamped to the last 24h
-    # of ts. ``capped_at_24h`` is mirrored back so the UI can render the
-    # Cloud-Pro upgrade CTA above the brain stream.
-    try:
-        is_pro = bool(_d._is_pro_user())
-    except Exception:
-        is_pro = False
+    # Local dashboards show ALL Brain history for free (founder call,
+    # 2026-06-23). The data lives in the user's own DuckDB and OpenClaw / NeMo
+    # observability is free on every plan, so we never cap it or upsell here.
+    # This OSS route only serves real data on the LOCAL dashboard; on the cloud
+    # server it returns empty (no DuckDB) and a cm-cloud interceptor renders
+    # Brain from the encrypted snapshot, where retention is enforced separately.
+    # (Was issue #1448's 24h cap, which only ever gated a user's own local data.)
     cap_since = None
-    if not is_pro:
-        cap_since = (
-            datetime.now(timezone.utc) - timedelta(hours=24)
-        ).strftime("%Y-%m-%dT%H:%M:%SZ")
     # Epic #964 phase 1b: opt-in local-store fast path. Skip the JSONL
     # parser entirely when CLAWMETRY_LOCAL_STORE_READ=1 AND the store
     # has data. Falls through to the full parser otherwise (so a fresh
@@ -1840,25 +1846,21 @@ def api_brain_clusters():
         days = max(1, min(90, int(request.args.get("days", 30))))
     except (TypeError, ValueError):
         days = 30
-    try:
-        is_pro = bool(_d._is_pro_user())
-    except Exception:
-        is_pro = False
-    if not is_pro:
-        days = 1  # mirror the 24h cap applied by /api/brain-history
+    # No local cap (founder call, 2026-06-23): local dashboards show the full
+    # requested window for free. Mirrors the uncapped /api/brain-history above.
     if is_local_store_read_enabled():
         # Late import to avoid circular dependency at module load time.
         from routes.usage import _try_local_store_sessions_clusters
         payload = _try_local_store_sessions_clusters(days)
         if payload is not None:
             payload["_shape"] = "brain_clusters"
-            payload["capped_at_24h"] = not is_pro
+            payload["capped_at_24h"] = False
             return jsonify(payload)
     return jsonify({
         "clusters": [],
         "total_sessions": 0,
         "days": days,
-        "capped_at_24h": not is_pro,
+        "capped_at_24h": False,
         "_source": "unavailable",
         "_shape": "brain_clusters",
     })

--- a/tests/test_brain_local_fastpath.py
+++ b/tests/test_brain_local_fastpath.py
@@ -130,12 +130,14 @@ def test_brain_fast_path_disabled_without_env_flag(tmp_path, monkeypatch):
         pass
 
 
-# ── Retention cap (issue #1448 surface 3) ───────────────────────────────────
+# ── No local retention cap (founder call, 2026-06-23) ───────────────────────
 #
-# OSS / Cloud-Free users get capped to the last 24h of events on
-# /api/brain-history. Cloud-Pro users (gated by ``dashboard._is_pro_user``)
-# bypass the cap. The response always carries ``capped_at_24h`` so the UI
-# can render the upgrade CTA above the brain stream.
+# Local dashboards show ALL Brain history for free: the data is in the user's
+# own DuckDB and OpenClaw / NeMo observability is free on every plan, so
+# /api/brain-history never caps to 24h and never sets capped_at_24h. (The
+# former issue #1448 cap only ever gated a user's own local data, since the
+# cloud serves Brain from the snapshot via a cm-cloud interceptor, not this
+# route.) The response always carries ``capped_at_24h`` (now always False).
 
 
 def _seed_old_and_recent_events(store):
@@ -159,7 +161,7 @@ def _seed_old_and_recent_events(store):
     _wait_flush(store)
 
 
-def test_api_brain_history_caps_24h_for_free(app, monkeypatch):
+def test_api_brain_history_no_cap_for_free(app, monkeypatch):
     a, ls = app
     _seed_old_and_recent_events(ls.get_store())
     import dashboard as _d
@@ -168,10 +170,10 @@ def test_api_brain_history_caps_24h_for_free(app, monkeypatch):
     r = a.test_client().get("/api/brain-history?limit=10")
     assert r.status_code == 200, r.get_data(as_text=True)[:300]
     body = r.get_json()
-    assert body.get("capped_at_24h") is True
+    # Local/free is NOT capped: the 8-day-old event must be visible, no upsell.
+    assert body.get("capped_at_24h") is False
     sids = {ev["sessionId"] for ev in body["events"]}
-    # 8-day-old event must be excluded; only the fresh one survives.
-    assert sids == {"sess-new"}
+    assert sids == {"sess-old", "sess-new"}
 
 
 def test_api_brain_history_no_cap_for_pro(app, monkeypatch):
@@ -186,3 +188,32 @@ def test_api_brain_history_no_cap_for_pro(app, monkeypatch):
     sids = {ev["sessionId"] for ev in body["events"]}
     # Pro users see the full history including the 8-day-old event.
     assert sids == {"sess-old", "sess-new"}
+
+
+def test_api_brain_history_hides_daemon_diagnostics(app, monkeypatch):
+    """ClawMetry's own daemon-error tee (agent_id=clawmetry-daemon /
+    event_type=daemon.*) must not appear in the Brain conversation feed, or a
+    noisy daemon (or a crash loop) buries the user's real agent activity."""
+    a, ls = app
+    store = ls.get_store()
+    import datetime as _dt
+    now = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    store.ingest({
+        "id": "ev-daemon", "node_id": "n1", "agent_id": "clawmetry-daemon",
+        "session_id": "", "event_type": "daemon.error", "ts": now,
+        "data": {"message": "Traceback ..."}, "cost_usd": 0.0, "token_count": 0,
+    })
+    store.ingest({
+        "id": "ev-agent", "node_id": "n1", "agent_id": "main",
+        "session_id": "sess-real", "event_type": "tool_call", "ts": now,
+        "data": {"tool": "Bash", "input": "echo hi"}, "cost_usd": 0.0, "token_count": 0,
+    })
+    _wait_flush(store)
+    import dashboard as _d
+    monkeypatch.setattr(_d, "_is_pro_user", lambda: False)
+
+    body = a.test_client().get("/api/brain-history?limit=20").get_json()
+    sids = {ev["sessionId"] for ev in body["events"]}
+    assert "sess-real" in sids, "real agent activity must show"
+    assert all(ev.get("agentId") != "clawmetry-daemon" for ev in body["events"])
+    assert all(not (ev.get("type") or "").upper().startswith("DAEMON.") for ev in body["events"])


### PR DESCRIPTION
Two local-dashboard Brain fixes, from a user report that their OpenClaw conversation wasn't showing in the Brain tab.

## 1. No 24h retention cap on the local dashboard (founder call)
`/api/brain-history` and the brain-clusters endpoint no longer clamp non-Pro users to the last 24h or set `capped_at_24h`, and the "Upgrade to Cloud-Pro for full conversation context" CTA no longer shows locally. Rationale: the data is in the user's own DuckDB and OpenClaw / NeMo observability is **free on every plan**, so capping a user's own local history to upsell cloud is wrong. This OSS route only serves real data **locally** (the cloud renders Brain from the encrypted snapshot via a `cm-cloud` interceptor, where retention is enforced separately), so removing the cap has **no cloud effect**. Was issue #1448's cap.

## 2. Hide ClawMetry's own daemon diagnostics from the Brain feed
The daemon-error -> DuckDB tee (PRD #1133) ingests events with `agent_id=clawmetry-daemon` / `event_type=daemon.*` and an empty `session_id`, which the existing helper-session filter missed. A noisy daemon (or the local-only crash loop fixed in the sibling PR) otherwise buries the user's real agent conversation under our own error spam. These still feed the health / diagnostics views.

## Verified live
On the reporter's dashboard (after applying both this and the crash fix): `capped_at_24h` is now `False`, and the 200 `daemon.error` rows are gone from the Brain feed.

## Tests
- Updated `test_api_brain_history_*` (the free path is now uncapped: both the 8-day-old and fresh sessions are visible, no upsell).
- New `test_api_brain_history_hides_daemon_diagnostics` (daemon-tee events filtered, real agent activity shown).

Note: pairs with #3285 (the local-only daemon crash fix). Both should ride one `[RELEASE]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)