### PR TITLE
feat: WizardFrame component + components/index.ts named exports (#1526)

### DIFF
--- a/frontend/src/components/WizardFrame.tsx
+++ b/frontend/src/components/WizardFrame.tsx
@@ -1,0 +1,99 @@
+// WizardFrame — wraps any onboarding wizard step with a progress strip,
+// optional "Skip for now" link, and a title block.
+//
+// All color/spacing values come from styles.css tokens — no inline magic.
+
+import React from "react";
+
+interface WizardFrameProps {
+  title: string;
+  current: number;
+  total: number;
+  onSkip?: () => void;
+  children: React.ReactNode;
+}
+
+export function WizardFrame({ title, current, total, onSkip, children }: WizardFrameProps) {
+  const progressPct = total > 0 ? Math.min(1, current / total) * 100 : 0;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--gap-3)",
+        padding: "var(--pad-4)",
+        borderRadius: "var(--r-3)",
+        background: "var(--panel)",
+        border: "1px solid var(--paper-line)",
+      }}
+    >
+      {/* progress strip */}
+      <div
+        style={{
+          height: 3,
+          borderRadius: "var(--r-1)",
+          background: "var(--paper-line)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            height: "100%",
+            width: `${progressPct}%`,
+            background: "var(--claw-red)",
+            borderRadius: "var(--r-1)",
+            transition: "width 0.3s ease",
+          }}
+        />
+      </div>
+
+      {/* header row */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--ink-4)",
+            fontFamily: "var(--f-mono)",
+            letterSpacing: "0.04em",
+          }}
+        >
+          {current} / {total}
+        </span>
+        {onSkip && (
+          <button
+            onClick={onSkip}
+            style={{
+              background: "none",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              fontSize: 12,
+              color: "var(--ink-4)",
+              textDecoration: "underline",
+            }}
+          >
+            Skip for now
+          </button>
+        )}
+      </div>
+
+      {/* title */}
+      <h2
+        style={{
+          margin: 0,
+          fontSize: 18,
+          fontFamily: "var(--f-sans)",
+          fontWeight: 600,
+          color: "var(--ink)",
+          lineHeight: 1.3,
+        }}
+      >
+        {title}
+      </h2>
+
+      {/* step content */}
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,0 +1,5 @@
+export { EncryptedBadge } from "./EncryptedBadge";
+export { WizardFrame } from "./WizardFrame";
+// RecoveryScroll (12-word scroll + fingerprint footer) is blocked on
+// vivekchand/clawmetry-cloud#893 — RFC-v5-001 crypto-alignment audit.
+// Add here once that audit confirms the word-list + fingerprint format.


### PR DESCRIPTION
Closes #1526

## Summary

- **`frontend/src/components/WizardFrame.tsx`** (new, ~85 LOC) — onboarding wizard wrapper with a progress strip (`--claw-red` fill on `--paper-line` track), step counter, title block, and an optional "Skip for now" link. All spacing/radius from `--pad-*` / `--r-*` design tokens.
- **`frontend/src/components/index.ts`** (new, 5 LOC) — named exports for `EncryptedBadge` (already shipped) and `WizardFrame`; stub comment for the deferred `RecoveryScroll` (blocked on cloud#893).

`RecoveryScroll` is intentionally excluded — it depends on the RFC-v5-001 word-list + fingerprint format confirmed in `vivekchand/clawmetry-cloud#893`.

## Test plan

- [ ] `cd frontend && npx tsc --noEmit` — no new errors beyond the pre-existing missing-node_modules baseline (same profile as `EncryptedBadge.tsx`)
- [ ] Import `{ WizardFrame }` from `@/components` in a page file — should resolve without TS error
- [ ] Render `<WizardFrame title="Step 1" current={1} total={3} onSkip={...}>...</WizardFrame>` — progress strip fills ~33%, "Skip for now" visible; remove `onSkip` — link disappears
- [ ] `make lint` passes (Python + JS layers unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_011x7SKPwY6QvtHLVxby9Cwe)_