### PR TITLE
feat(entitlement): preview_path + /api/entitlement/preview-path

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -1629,6 +1629,153 @@ def preview_batch() -> list[dict]:
         return []
 
 
+def _preview_row(tier: str) -> dict | None:
+    """Cumulative preview row for an arbitrary known tier.
+
+    Private builder for :func:`preview_path`: mirrors :func:`preview` but
+    accepts any id in :data:`_TIER_FEATURES` (including :data:`TIER_TRIAL`,
+    which the singular :func:`preview` rejects because it is not
+    purchasable), so a path that anchors a lateral or trial endpoint
+    still resolves the cumulative-state row. Same posture as
+    :func:`_unlocks_row` for :func:`tier_unlocks_path` -- the path
+    walker only emits these via rungs that are themselves in
+    :data:`_PURCHASABLE_TIERS`, so trial only surfaces here when the
+    destination itself is trial (the lateral branch).
+
+    Source is tagged ``"preview"`` and ``grace=False`` so concrete
+    per-tier capacity (``channel_limit``, ``retention_days``,
+    ``node_limit``) surfaces in the row -- a grace-mode preview would
+    zero those out and defeat the purpose. Returns ``None`` on unknown
+    ids and never raises.
+    """
+    try:
+        tt = (tier or "").strip().lower()
+        if tt not in _TIER_FEATURES:
+            return None
+        paid_feats = _TIER_FEATURES.get(tt, frozenset())
+        runtimes = (
+            FREE_RUNTIMES | PAID_RUNTIMES
+            if tt in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        ent = Entitlement(
+            tier=tt,
+            source="preview",
+            node_limit=1,
+            expiry=None,
+            features=FREE_FEATURES | paid_feats,
+            runtimes=runtimes,
+            grace=False,
+        )
+        return ent.to_dict()
+    except Exception as exc:
+        logger.warning("entitlements: _preview_row failed: %s", exc)
+        return None
+
+
+def preview_path(from_tier: str, to_tier: str) -> list[dict] | None:
+    """Arbitrary-endpoint stepwise cumulative-state path between two tiers.
+
+    Cumulative-state analogue of :func:`tier_path` (full ``tier_diff``
+    per rung), :func:`capacity_diff_path` (capacity-only per rung),
+    :func:`tier_unlocks_path` (marginal grants per rung) and
+    :func:`tier_locks_path` (marginal losses per rung) -- the fifth and
+    final member of the ``_path`` family, the path-shaped sibling of
+    :func:`preview_batch`. Where the four marginal/diff paths answer
+    "what *changes* at each rung", this one answers "what does the
+    resulting Entitlement *look like* at each rung" -- the cumulative
+    ``Entitlement.to_dict`` snapshot at every step between ``from_tier``
+    and ``to_tier``, so an upgrade-walkthrough surface can render the
+    "Cloud Pro: 90-day retention, unlimited channels, claude_code
+    unlocked" card at each rung off ONE round-trip without re-deriving
+    capacity in JS.
+
+    Per-rung row shape matches :func:`preview` exactly -- the full
+    ``Entitlement.to_dict`` shape with ``source="preview"`` and
+    ``grace=False`` -- so a UI that already renders a ``/preview`` row
+    needs zero new shape code to render a row off this path.
+
+    Walk semantics mirror :func:`tier_path` /
+    :func:`capacity_diff_path` / :func:`tier_unlocks_path` /
+    :func:`tier_locks_path` byte-for-byte (same ``_PURCHASABLE_TIERS``
+    filter + same sort key + same destination-sibling exclusion), so the
+    rung ``tier`` ids from this helper match the rung ``to`` ids from
+    those four helpers identically -- the five paths line up
+    rung-for-rung. Same-rank siblings strictly between the endpoints are
+    both included (matching :func:`tier_path`'s ladder shape); same-rank
+    siblings of the destination are excluded so the path terminates
+    exactly at ``to_tier``.
+
+    Direction semantics (all rows share the same cumulative-snapshot
+    shape; only the sequence changes):
+
+    * ``upgrade`` (ascending) -- rows climb cumulatively from the rung
+      above ``from_tier`` toward ``to_tier``; the natural "what does my
+      surface look like at each step up" walkthrough.
+    * ``downgrade`` (descending) -- rows shrink cumulatively rung by
+      rung; the cancellation-walkthrough counterpart.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the cumulative preview at ``to_tier``.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Endpoint semantics match :func:`tier_path` / :func:`tier_diff`: both
+    ids accept any entry in :data:`_TIER_FEATURES` (including
+    :data:`TIER_TRIAL`, which is not purchasable -- it is excluded from
+    the walked intermediate rungs but is a valid endpoint via the
+    lateral branch). Unknown ids on either side short-circuit to
+    ``None``.
+
+    Resolver-independent: walks the static per-tier maps, so flipping
+    enforce on yields byte-identical rows -- same property the rest of
+    the ``_path`` family guarantees.
+
+    Never raises: a resolver failure logs a warning and returns ``None``
+    so an upgrade-walkthrough surface keeps rendering instead of
+    breaking.
+    """
+    try:
+        f = (from_tier or "").strip().lower()
+        t = (to_tier or "").strip().lower()
+        if f not in _TIER_FEATURES or t not in _TIER_FEATURES:
+            return None
+        if f == t:
+            return []
+        from_rank = _TIER_RANK.get(f, -1)
+        to_rank = _TIER_RANK.get(t, -1)
+        if from_rank == to_rank:
+            row = _preview_row(t)
+            return [row] if row is not None else []
+        ascending = to_rank > from_rank
+        if ascending:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (_TIER_RANK.get(x, -1), x),
+            )
+        else:
+            ordered = sorted(
+                _PURCHASABLE_TIERS,
+                key=lambda x: (-_TIER_RANK.get(x, -1), x),
+            )
+        path: list[dict] = []
+        for tid in ordered:
+            r = _TIER_RANK.get(tid, -1)
+            if ascending:
+                if r <= from_rank or r > to_rank:
+                    continue
+            else:
+                if r >= from_rank or r < to_rank:
+                    continue
+            if r == to_rank and tid != t:
+                continue
+            row = _preview_row(tid)
+            if row is not None:
+                path.append(row)
+        return path
+    except Exception as exc:
+        logger.warning("entitlements: preview_path failed: %s", exc)
+        return None
+
+
 def tier_unlocks(target_tier: str) -> dict | None:
     """Per-tier marginal unlocks: features + runtimes that first become
     available *at* ``target_tier`` -- the set difference between this

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -105,6 +105,19 @@ is the single source of truth -- handlers never re-derive tier logic here.
                                          tier in one pass so a pricing-page
                                          table can render the cumulative-state
                                          column off one round-trip.
+  GET  /api/entitlement/preview-path   -- arbitrary-endpoint stepwise
+                                         cumulative-state path between any two
+                                         tiers (``?from=&to=``); path analogue
+                                         of ``/preview-batch`` and the
+                                         cumulative-state sibling of
+                                         ``/tier-path`` / ``/tier-unlocks-path``
+                                         / ``/tier-locks-path`` /
+                                         ``/capacity-diff-path``. Each row is
+                                         the full ``/preview`` payload for that
+                                         rung so an upgrade-walkthrough surface
+                                         can render the "Cloud Pro: 90-day
+                                         retention, ..." card at every step
+                                         off one round-trip.
   GET  /api/entitlement/tier-locks    -- marginal-loss companion of
                                          ``/tier-unlocks``: features + runtimes
                                          that disappear when you step down to
@@ -712,6 +725,103 @@ def api_entitlement_preview_batch():
                 "grace": True,
                 "enforced": False,
             }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/preview-path")
+def api_entitlement_preview_path():
+    """``GET /api/entitlement/preview-path?from=<id>&to=<id>`` --
+    arbitrary-endpoint stepwise cumulative-state path between any two
+    tiers; the cumulative-state analogue of ``/tier-path`` (full
+    ``tier_diff`` per rung), ``/capacity-diff-path`` (capacity-only per
+    rung), ``/tier-unlocks-path`` (marginal grants per rung) and
+    ``/tier-locks-path`` (marginal losses per rung) -- the fifth and
+    final member of the ``_path`` family, the path-shaped sibling of
+    ``/preview-batch``. Lets an upgrade-walkthrough surface render the
+    "Cloud Pro: 90-day retention, unlimited channels, claude_code
+    unlocked" card at every rung between any two tiers off ONE
+    round-trip, without re-deriving capacity in JS.
+
+    Each row in ``path`` is the full
+    :meth:`Entitlement.to_dict` payload at that rung -- identical shape
+    to a single ``/preview`` row, with ``source="preview"`` and
+    ``grace=False`` so concrete per-tier capacity surfaces. Rung walk
+    is byte-stable against ``/tier-path``, ``/capacity-diff-path``,
+    ``/tier-unlocks-path`` and ``/tier-locks-path`` (same
+    ``_PURCHASABLE_TIERS`` filter + same sort + same destination-sibling
+    exclusion), so the five paths line up rung-for-rung.
+
+    Response shape::
+
+        {
+          "from":       "<tier id>",
+          "from_label": "...",
+          "from_rank":  <int>,
+          "to":         "<tier id>",
+          "to_label":   "...",
+          "to_rank":    <int>,
+          "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
+          "path":       [<preview row>, ...],
+        }
+
+    Direction semantics:
+
+    * ``upgrade`` (ascending) -- rows climb cumulatively rung by rung.
+    * ``downgrade`` (descending) -- rows shrink cumulatively rung by
+      rung; the cancellation-walkthrough counterpart.
+    * ``lateral`` (same rank, different id) -- single-row path; row
+      carries the cumulative preview at ``to``.
+    * ``identity`` (``from == to``) -- empty path; no rungs to walk.
+
+    Same-rank siblings strictly between the endpoints are both
+    included; same-rank siblings of the destination are excluded so the
+    path terminates exactly at ``to``. ``400`` when ``from=`` or ``to=``
+    is missing; ``404`` when either id is unknown. ``trial`` IS accepted
+    as an endpoint -- it is excluded from the walked intermediate rungs
+    (not purchasable) but is a valid endpoint via the lateral branch.
+    Never 5xxs: a resolver failure short-circuits to ``404`` so an
+    upgrade-walkthrough surface keeps rendering instead of breaking.
+    """
+    f = (request.args.get("from") or "").strip().lower()
+    t = (request.args.get("to") or "").strip().lower()
+    if not f or not t:
+        return jsonify({"error": "missing from or to"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        path = _ent.preview_path(f, t)
+        if path is None:
+            return (
+                jsonify({"error": "unknown tier", "from": f, "to": t}),
+                404,
+            )
+        from_rank = _ent.tier_rank(f)
+        to_rank = _ent.tier_rank(t)
+        if f == t:
+            direction = "identity"
+        elif from_rank == to_rank:
+            direction = "lateral"
+        elif to_rank > from_rank:
+            direction = "upgrade"
+        else:
+            direction = "downgrade"
+        return jsonify(
+            {
+                "from": f,
+                "from_label": _ent.tier_label(f),
+                "from_rank": from_rank,
+                "to": t,
+                "to_label": _ent.tier_label(t),
+                "to_rank": to_rank,
+                "direction": direction,
+                "path": path,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_preview_path: error: %s", exc)
+        return (
+            jsonify({"error": "unknown tier", "from": f, "to": t}),
+            404,
         )
 
 

--- a/tests/test_entitlement_preview_path.py
+++ b/tests/test_entitlement_preview_path.py
@@ -1,0 +1,502 @@
+"""Tests for ``clawmetry.entitlements.preview_path(from, to)`` + the
+``GET /api/entitlement/preview-path`` endpoint.
+
+Cumulative-state analogue of :func:`tier_path` (full ``tier_diff`` per
+rung), :func:`capacity_diff_path` (capacity-only per rung),
+:func:`tier_unlocks_path` (marginal grants per rung) and
+:func:`tier_locks_path` (marginal losses per rung) -- the fifth and
+final member of the ``_path`` family, the path-shaped sibling of
+:func:`preview_batch`. Lets an upgrade-walkthrough surface render the
+"Cloud Pro: 90-day retention, unlimited channels, claude_code unlocked"
+card at every rung between any two tiers off ONE round-trip, without
+re-deriving capacity in JS.
+
+Per-rung row shape matches :func:`preview` exactly -- the full
+``Entitlement.to_dict`` shape with ``source="preview"`` and
+``grace=False`` so concrete per-tier capacity surfaces -- so a UI that
+already renders ``/preview`` rendering the per-rung row off this path
+needs zero new shape code.
+
+Pins:
+
+* row shape matches singular :func:`preview` schema down to the key set
+* every row carries ``source="preview"`` and ``grace=False``
+* rung walk is byte-stable against :func:`tier_path`,
+  :func:`capacity_diff_path`, :func:`tier_unlocks_path` and
+  :func:`tier_locks_path` (same ``_PURCHASABLE_TIERS`` filter + same
+  sort + same destination-sibling exclusion); confirmed by extracting
+  the rung ``tier`` ids
+* ascending walk reaches ``to_tier`` at the final rung; the rung
+  ``tier`` ids walk strictly upward in rank
+* descending walk reaches ``to_tier`` at the final rung; rung ``tier``
+  ids walk strictly downward in rank
+* per-rung byte-equality with the singular :func:`preview` endpoint for
+  every purchasable rung in the walk
+* the path's terminal row byte-equals :func:`preview` of ``to_tier``
+  whenever the destination is purchasable; for ``to=trial`` the lateral
+  branch produces a single-row path with the trial preview shape
+* identity (``from == to``) returns an empty path
+* lateral (same rank, different id) returns a single-row path
+* trial accepted as an endpoint -- excluded from walked intermediate
+  rungs (lateral endpoint pinned for ``to=trial``; intermediate-walk
+  paths with ``from=trial`` cross into the rung above)
+* unknown / empty / garbage ids return ``None`` and never raise
+* grace vs enforce yields identical rows (helper is decoupled from the
+  resolved entitlement; it walks the static per-tier maps)
+* API surface: 400 on missing args, 404 on unknown ids, 200 with the
+  envelope shape on the happy path (incl. direction tag)
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_ENVELOPE_KEYS = {
+    "from",
+    "from_label",
+    "from_rank",
+    "to",
+    "to_label",
+    "to_rank",
+    "direction",
+    "path",
+}
+
+
+# ── helper-level: shape + invariants ─────────────────────────────────────────
+
+
+def test_returns_list(ent):
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert isinstance(path, list)
+    assert len(path) >= 1
+
+
+def test_each_row_matches_preview_schema(ent):
+    """Per-rung row shape must byte-match the singular ``preview``
+    endpoint's row schema -- so a UI that already renders ``/preview``
+    needs zero new shape code to render a per-rung row off this path."""
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    reference_keys = set(ent.preview(ent.TIER_CLOUD_PRO).keys())
+    assert reference_keys  # sanity
+    for row in path:
+        assert isinstance(row, dict)
+        assert set(row.keys()) == reference_keys
+
+
+def test_every_row_tagged_preview_grace_false(ent):
+    """Each row is rendered with ``source="preview"`` and ``grace=False``
+    so concrete per-tier capacity (``channel_limit``, ``retention_days``,
+    ``node_limit``) surfaces -- a grace-mode preview would zero those out
+    and defeat the purpose. Same posture as the singular helper."""
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["source"] == "preview"
+        assert row["grace"] is False
+        assert row["enforced"] is True
+
+
+def test_first_row_is_first_step_above_from(ent):
+    """Ascending walk from oss (rank 0) toward enterprise: the first
+    row's ``tier`` must be the first purchasable rung strictly above
+    rank 0 -- cloud_starter at rank 1."""
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert path[0]["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_last_row_is_destination(ent):
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert path[-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_rung_walk_byte_stable_against_tier_path(ent):
+    """The set of rung ``tier`` ids must match :func:`tier_path`'s rung
+    ``to`` ids byte-for-byte -- same ``_PURCHASABLE_TIERS`` filter +
+    same sort + same destination-sibling exclusion."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_OSS, ent.TIER_CLOUD_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_PRO, ent.TIER_CLOUD_FREE),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        preview_rungs = [r["tier"] for r in ent.preview_path(f, t)]
+        diff_rungs = [r["to"] for r in ent.tier_path(f, t)]
+        assert preview_rungs == diff_rungs
+
+
+def test_rung_walk_byte_stable_against_capacity_diff_path(ent):
+    """And byte-stable against :func:`capacity_diff_path` -- the four
+    other path helpers must line up rung-for-rung against this one.
+    (``capacity_diff_path`` keys its rung id at ``target`` rather than
+    ``tier``; pin the same walk regardless.)"""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        preview_rungs = [r["tier"] for r in ent.preview_path(f, t)]
+        cap_rungs = [r["target"] for r in ent.capacity_diff_path(f, t)]
+        assert preview_rungs == cap_rungs
+
+
+def test_rung_walk_byte_stable_against_tier_unlocks_path(ent):
+    """And byte-stable against :func:`tier_unlocks_path`."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        preview_rungs = [r["tier"] for r in ent.preview_path(f, t)]
+        unlocks_rungs = [r["tier"] for r in ent.tier_unlocks_path(f, t)]
+        assert preview_rungs == unlocks_rungs
+
+
+def test_rung_walk_byte_stable_against_tier_locks_path(ent):
+    """And byte-stable against :func:`tier_locks_path` -- all five
+    paths line up rung-for-rung."""
+    for f, t in (
+        (ent.TIER_OSS, ent.TIER_ENTERPRISE),
+        (ent.TIER_CLOUD_FREE, ent.TIER_PRO),
+        (ent.TIER_ENTERPRISE, ent.TIER_OSS),
+        (ent.TIER_TRIAL, ent.TIER_ENTERPRISE),
+    ):
+        preview_rungs = [r["tier"] for r in ent.preview_path(f, t)]
+        locks_rungs = [r["tier"] for r in ent.tier_locks_path(f, t)]
+        assert preview_rungs == locks_rungs
+
+
+def test_ascending_walk_is_strictly_increasing_in_rank(ent):
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    ranks = [r["tier_rank"] for r in path]
+    # rungs may share a rank only at the destination's rank (cloud_pro
+    # and pro both at rank 2 in a oss->enterprise walk); strictly
+    # non-decreasing, with at most one repeat
+    assert ranks == sorted(ranks)
+
+
+def test_descending_walk_is_strictly_decreasing_in_rank(ent):
+    path = ent.preview_path(ent.TIER_ENTERPRISE, ent.TIER_OSS)
+    ranks = [r["tier_rank"] for r in path]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_path_terminates_at_to_not_a_sibling(ent):
+    """``pro`` and ``cloud_pro`` share rank 2; asking for ``pro`` must
+    end exactly at ``pro`` and EXCLUDE the same-rank sibling
+    ``cloud_pro`` from the final rung -- same rule as :func:`tier_path`."""
+    rungs = [r["tier"] for r in ent.preview_path(ent.TIER_OSS, ent.TIER_PRO)]
+    assert rungs[-1] == ent.TIER_PRO
+    assert rungs.count(ent.TIER_PRO) == 1
+    assert ent.TIER_CLOUD_PRO not in rungs
+
+
+def test_same_rank_siblings_between_endpoints_both_included(ent):
+    """Walking oss -> enterprise: rank-2 siblings ``cloud_pro`` AND
+    ``pro`` both appear because they sit strictly *between* rank-0 start
+    and rank-3 destination."""
+    rungs = [r["tier"] for r in ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)]
+    assert ent.TIER_CLOUD_PRO in rungs
+    assert ent.TIER_PRO in rungs
+    assert rungs[-1] == ent.TIER_ENTERPRISE
+
+
+def test_per_rung_byte_equality_with_singular_preview(ent):
+    """Each rung's row must byte-equal :func:`preview` of that rung --
+    the path is a sequence of singular previews, not a re-derivation."""
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        direct = ent.preview(row["tier"])
+        assert row == direct
+
+
+def test_terminal_row_byte_equals_preview_of_to_for_purchasable(ent):
+    """When the destination is purchasable the final rung must
+    byte-equal :func:`preview(to)`."""
+    for to in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        path = ent.preview_path(ent.TIER_OSS, to)
+        assert path[-1] == ent.preview(to)
+
+
+def test_terminal_row_for_trial_endpoint_via_lateral(ent):
+    """The singular :func:`preview` returns ``None`` for trial, but the
+    path's lateral branch can pin trial as a destination -- the row
+    surfaces via :func:`_preview_row` directly and carries the trial
+    cumulative shape."""
+    path = ent.preview_path(ent.TIER_CLOUD_PRO, ent.TIER_TRIAL)
+    assert len(path) == 1
+    row = path[0]
+    assert row["tier"] == ent.TIER_TRIAL
+    assert row["source"] == "preview"
+    assert row["grace"] is False
+    # trial carries the full paid feature/runtime grant
+    assert "claude_code" in row["runtimes"]
+
+
+def test_identity_returns_empty(ent):
+    for tid in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+        ent.TIER_TRIAL,
+    ):
+        assert ent.preview_path(tid, tid) == []
+
+
+def test_lateral_single_row(ent):
+    path = ent.preview_path(ent.TIER_CLOUD_PRO, ent.TIER_PRO)
+    assert len(path) == 1
+    row = path[0]
+    assert row["tier"] == ent.TIER_PRO
+
+
+def test_oss_to_cloud_free_lateral_single_row(ent):
+    """Both rank 0 -- lateral single-row path landing on cloud_free."""
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_CLOUD_FREE)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_CLOUD_FREE
+
+
+def test_adjacent_step_is_one_row(ent):
+    """oss (rank 0) -> cloud_starter (rank 1) is a single rank-up step."""
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_CLOUD_STARTER)
+    assert len(path) == 1
+    assert path[0]["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_trial_excluded_from_walked_intermediate_rungs(ent):
+    """``trial`` is not purchasable -- it must never appear as an
+    *intermediate* rung on a walk between purchasable endpoints."""
+    path = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    for row in path:
+        assert row["tier"] != ent.TIER_TRIAL
+
+
+def test_trial_endpoint_still_resolves(ent):
+    """``trial`` IS a valid endpoint -- as the source (via the
+    cross-rank branch landing at enterprise) or as the destination (via
+    the lateral branch)."""
+    upward = ent.preview_path(ent.TIER_TRIAL, ent.TIER_ENTERPRISE)
+    assert upward is not None
+    assert upward[-1]["tier"] == ent.TIER_ENTERPRISE
+    downward = ent.preview_path(ent.TIER_CLOUD_PRO, ent.TIER_TRIAL)
+    assert downward is not None
+    assert downward[-1]["tier"] == ent.TIER_TRIAL
+
+
+def test_unknown_tiers_return_none(ent):
+    assert ent.preview_path("not_a_tier", ent.TIER_ENTERPRISE) is None
+    assert ent.preview_path(ent.TIER_OSS, "still_not_a_tier") is None
+    assert ent.preview_path("a", "b") is None
+
+
+def test_empty_and_garbage_inputs_never_raise(ent):
+    assert ent.preview_path("", "") is None
+    assert ent.preview_path(None, None) is None  # type: ignore[arg-type]
+    assert ent.preview_path("  ", "  ") is None
+    assert ent.preview_path(123, 456) is None  # type: ignore[arg-type]
+
+
+def test_case_and_whitespace_normalised(ent):
+    a = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    b = ent.preview_path("  OSS ", " ENTERPRISE  ")
+    assert a == b
+
+
+def test_grace_and_enforce_yield_identical_rows(ent, monkeypatch):
+    """The helper is decoupled from the resolved entitlement -- it
+    walks the static per-tier maps so flipping enforce on must NOT
+    change any row. Pins the resolver-independence property the whole
+    ``_path`` family shares."""
+    grace_rows = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    enforced_rows = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert grace_rows == enforced_rows
+
+
+def test_resolver_failure_returns_none(ent, monkeypatch):
+    """A blown resolver must not 5xx -- the helper walks the static
+    per-tier maps so it never asks the resolver, but pin the
+    swallow-and-return-None posture anyway against future refactors
+    that might wire one in."""
+    # The function is intentionally decoupled from the resolver, so the
+    # most we can do is confirm it does not raise on unknown ids and
+    # short-circuits to None instead -- already covered above. As an
+    # extra belt-and-suspenders pin we monkeypatch the private row
+    # builder to blow up and confirm the wrapper swallows it.
+    monkeypatch.setattr(
+        ent,
+        "_preview_row",
+        lambda _tier: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    # The cross-rank walk never reaches a rung row because the iterator
+    # raises on the first call; the helper's outer try/except catches it.
+    result = ent.preview_path(ent.TIER_OSS, ent.TIER_ENTERPRISE)
+    assert result is None
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+def test_api_400_on_missing_args(client):
+    assert client.get("/api/entitlement/preview-path").status_code == 400
+    assert client.get("/api/entitlement/preview-path?from=oss").status_code == 400
+    assert (
+        client.get("/api/entitlement/preview-path?to=cloud_pro").status_code == 400
+    )
+
+
+def test_api_404_on_unknown_tier(client):
+    r = client.get("/api/entitlement/preview-path?from=oss&to=not_a_tier")
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body["error"] == "unknown tier"
+    assert body["to"] == "not_a_tier"
+
+
+def test_api_happy_path_ascending(client, ent):
+    r = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["from"] == ent.TIER_OSS
+    assert body["to"] == ent.TIER_ENTERPRISE
+    assert body["direction"] == "upgrade"
+    assert isinstance(body["path"], list) and body["path"]
+    assert body["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+    # row schema matches the singular endpoint
+    reference_keys = set(ent.preview(ent.TIER_CLOUD_PRO).keys())
+    for row in body["path"]:
+        assert set(row.keys()) == reference_keys
+
+
+def test_api_happy_path_descending(client, ent):
+    r = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_ENTERPRISE}&to={ent.TIER_OSS}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "downgrade"
+    assert body["path"][-1]["tier"] == ent.TIER_OSS
+    # rungs walk downward in rank
+    ranks = [r["tier_rank"] for r in body["path"]]
+    assert ranks == sorted(ranks, reverse=True)
+
+
+def test_api_identity_empty_path(client, ent):
+    r = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "identity"
+    assert body["path"] == []
+
+
+def test_api_lateral_single_row(client, ent):
+    r = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_PRO}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["tier"] == ent.TIER_PRO
+
+
+def test_api_trial_endpoint_accepted(client, ent):
+    r = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_TRIAL}&to={ent.TIER_ENTERPRISE}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["from"] == ent.TIER_TRIAL
+    assert body["path"][-1]["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_api_trial_destination_via_lateral(client, ent):
+    """``to=trial`` resolves via the lateral branch (cloud_pro and
+    trial share rank 2)."""
+    r = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_CLOUD_PRO}&to={ent.TIER_TRIAL}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["direction"] == "lateral"
+    assert len(body["path"]) == 1
+    assert body["path"][0]["tier"] == ent.TIER_TRIAL
+
+
+def test_api_rungs_match_tier_path_route(client, ent):
+    """API-level byte-equality: rung ``tier`` ids from
+    ``/preview-path`` match rung ``to`` ids from ``/tier-path``."""
+    a = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/tier-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert [r["tier"] for r in a["path"]] == [r["to"] for r in b["path"]]
+
+
+def test_api_rungs_match_tier_unlocks_path_route(client, ent):
+    """And against ``/tier-unlocks-path`` rung-for-rung."""
+    a = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    b = client.get(
+        f"/api/entitlement/tier-unlocks-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    assert [r["tier"] for r in a["path"]] == [r["tier"] for r in b["path"]]
+
+
+def test_api_per_rung_byte_equality_with_preview_endpoint(client, ent):
+    """Each rung's row must byte-equal the singular ``/preview``
+    endpoint for that rung -- the route returns a sequence of singular
+    previews, not a re-derivation."""
+    body = client.get(
+        f"/api/entitlement/preview-path?from={ent.TIER_OSS}&to={ent.TIER_ENTERPRISE}"
+    ).get_json()
+    for row in body["path"]:
+        ref = client.get(
+            f"/api/entitlement/preview?tier={row['tier']}"
+        ).get_json()
+        assert row == ref


### PR DESCRIPTION
## Summary

Adds `preview_path(from, to)` to `clawmetry.entitlements` and the companion `GET /api/entitlement/preview-path` endpoint — the **fifth and final member of the `_path` family**, the path-shaped sibling of `preview_batch` and the **cumulative-state analogue** of `tier_path` (full `tier_diff` per rung), `capacity_diff_path` (capacity-only per rung), `tier_unlocks_path` (marginal grants per rung) and `tier_locks_path` (marginal losses per rung).

Where the four other paths answer "what *changes* at each rung", this one answers "what does the resulting Entitlement *look like* at each rung" — the cumulative `Entitlement.to_dict` snapshot at every step between `from_tier` and `to_tier`, so an upgrade-walkthrough surface can render the "Cloud Pro: 90-day retention, unlimited channels, claude_code unlocked" card at each rung off **one** round-trip without re-deriving capacity in JS.

| `_path` helper          | Per-rung payload                                            |
| ----------------------- | ----------------------------------------------------------- |
| `tier_path`             | full `tier_diff` (all slices, marginal)                     |
| `capacity_diff_path`    | capacity axes only, marginal                                |
| `tier_unlocks_path`     | marginal grant (`features`, `runtimes`)                     |
| `tier_locks_path`       | marginal loss (`lost_features`, `lost_runtimes`)            |
| **`preview_path`**      | **cumulative `Entitlement.to_dict`** (absolute, no diff)    |

## Design notes

- **Purely additive; zero behavior change to existing surfaces.** No edits to existing helpers; the new function delegates to a private `_preview_row(tier)` that mirrors `preview` but accepts any id in `_TIER_FEATURES` (including `TIER_TRIAL`) so a lateral endpoint pinned at trial still resolves the cumulative-state row. Same posture as `_unlocks_row` for `tier_unlocks_path`.
- **Per-rung row shape matches the singular `/preview` endpoint byte-for-byte** (the full `Entitlement.to_dict` shape with `source="preview"` and `grace=False`), so a UI that already renders `/preview` needs zero new shape code to render a per-rung row off this path.
- **Walk semantics mirror the four sibling paths byte-for-byte** — same `_PURCHASABLE_TIERS` filter + same sort key + same destination-sibling exclusion — so all five paths line up rung-for-rung. Pinned in the test suite.
- **Per-rung byte-equality with the singular `preview()`** for every purchasable rung in the walk — the path is a sequence of singular previews, not a re-derivation. Pinned.
- **Identity** (`from == to`) returns `[]`. **Lateral** (same rank, different id) returns a single-row path. **Unknown ids** on either side return `None`.
- **Trial accepted as an endpoint**: excluded from walked intermediate rungs (not purchasable) but valid via the lateral branch (`to=trial`) or as a source paired with a higher-rank destination (`from=trial`, `to=enterprise`).
- **Resolver-independent**: walks the static per-tier maps so grace vs enforce yields byte-identical rows. Pinned.
- **Never raises**; endpoint always 400s on missing args, 404s on unknown ids, never 5xxs.

## API envelope

```
GET /api/entitlement/preview-path?from=<id>&to=<id>

{
  "from":       "<tier id>",
  "from_label": "...",
  "from_rank":  <int>,
  "to":         "<tier id>",
  "to_label":   "...",
  "to_rank":    <int>,
  "direction":  "upgrade" | "downgrade" | "lateral" | "identity",
  "path":       [<preview row>, ...]
}
```

Rung walk byte-equal to `/tier-path`, `/capacity-diff-path`, `/tier-unlocks-path` and `/tier-locks-path` for the same args — pinned in the test suite.

## Tests

38 new tests cover: row schema matches singular `/preview` exactly, every row tagged `source="preview"` + `grace=False`, ascending walk strictly non-decreasing in rank, descending walk strictly non-increasing, first row is the first step above `from`, terminal row is the destination, path terminates exactly at `to` (not a same-rank sibling), same-rank siblings strictly *between* endpoints both included, rung-walk byte-equality against the four sibling paths (`tier_path`, `capacity_diff_path`, `tier_unlocks_path`, `tier_locks_path`), per-rung byte-equality with the singular `preview()`, terminal-row byte-equality with `preview(to)` for purchasable destinations, terminal row for `to=trial` via lateral, identity / lateral / oss→cloud_free lateral / adjacent-step / unknown / empty / garbage / case+whitespace normalisation sweeps, trial excluded from intermediate rungs, trial valid as either endpoint, grace-vs-enforce row identity, resolver-failure swallow (returns `None`), plus the full API surface (envelope shape, 400 on missing args, 404 on unknown ids, ascending / descending / identity / lateral happy paths, trial endpoint accepted both ways, route-level rung byte-equality against `/tier-path` and `/tier-unlocks-path`, per-rung byte-equality against `/preview`).

```
$ python3 -m pytest tests/test_entitlement_preview_path.py -v
38 passed in 0.48s

$ python3 -m pytest tests/test_entitlement_*.py tests/test_entitlements*.py
1151 passed in 12.72s

$ python3 -m ruff check clawmetry/entitlements.py routes/entitlement.py \
        tests/test_entitlement_preview_path.py
All checks passed!
```

The `lint-py` make target reports 207 pre-existing ruff errors on `dashboard.py`; verified identical count with this change stashed, so unrelated to this PR.

## Local operator verification checklist

I can't reach the local daemon, `~/.openclaw`, or the live cloud snapshot — please do these on your box before flipping the PR to ready / releasing:

- [ ] Copy changed files into the daemon's site-packages:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python3.*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python3.*/site-packages/routes/`
- [ ] Clear `__pycache__`:
      `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Restart the sync daemon:
      `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint locally:
      `curl -s 'http://localhost:8900/api/entitlement/preview-path?from=oss&to=enterprise' | jq`
      → expect envelope with `direction="upgrade"`, `path` walked in `(rank, id)` order ending at `enterprise`, every row carrying `source="preview"` and `grace=false`
- [ ] Confirm rung walk byte-equality against the four sibling paths:
      `diff <(curl -s 'http://localhost:8900/api/entitlement/preview-path?from=oss&to=enterprise' | jq '[.path[].tier]') <(curl -s 'http://localhost:8900/api/entitlement/tier-unlocks-path?from=oss&to=enterprise' | jq '[.path[].tier]')`
      `diff <(curl -s 'http://localhost:8900/api/entitlement/preview-path?from=oss&to=enterprise' | jq '[.path[].tier]') <(curl -s 'http://localhost:8900/api/entitlement/tier-locks-path?from=oss&to=enterprise' | jq '[.path[].tier]')`
      `diff <(curl -s 'http://localhost:8900/api/entitlement/preview-path?from=oss&to=enterprise' | jq '[.path[].tier]') <(curl -s 'http://localhost:8900/api/entitlement/tier-path?from=oss&to=enterprise' | jq '[.path[].to]')`
      `diff <(curl -s 'http://localhost:8900/api/entitlement/preview-path?from=oss&to=enterprise' | jq '[.path[].tier]') <(curl -s 'http://localhost:8900/api/entitlement/capacity-diff-path?from=oss&to=enterprise' | jq '[.path[].target]')`
      → expect no diff on any of the four
- [ ] Spot-check per-rung byte-equality vs the singular `/preview`:
      `diff <(curl -s 'http://localhost:8900/api/entitlement/preview-path?from=oss&to=enterprise' | jq '.path[] | select(.tier=="cloud_pro")') <(curl -s 'http://localhost:8900/api/entitlement/preview?tier=cloud_pro')`
      → expect no diff
- [ ] Confirm trial endpoints resolve:
      `curl -s 'http://localhost:8900/api/entitlement/preview-path?from=cloud_pro&to=trial' | jq '.direction, (.path | length)'`
      → expect `"lateral"` and `1`
- [ ] Spot-check existing endpoints still work:
      `curl -s 'http://localhost:8900/api/entitlement/preview-batch' | jq '.tiers | length'` (unchanged)
      `curl -s 'http://localhost:8900/api/entitlement/preview?tier=cloud_pro' | jq '.tier'` (unchanged)
      `curl -s 'http://localhost:8900/api/entitlement' | jq '.tier'` (unchanged)
- [ ] Decrypt the live cloud snapshot and confirm the entitlement panel still renders.
- [ ] Browser-check `localhost:8900` for any pricing-page regressions.

Cloud (`clawmetry-cloud`) and `clawmetry-pro` work (P3/P4/P6) is **out of scope for this PR** — those require the private repos this agent does not have access to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ai1bPGn4k3UyBd6uC6ofHh)_