### PR TITLE
feat(entitlement): next_tier_unlocks + previous_tier_unlocks + endpoints

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -679,6 +679,46 @@ class Entitlement:
             logger.warning("entitlements: previous_tier_diff failed: %s", exc)
             return None
 
+    def next_tier_unlocks(self) -> dict | None:
+        """One-rung-up unlocks row in :func:`tier_unlocks` shape.
+
+        Convenience for ``tier_unlocks(self.next_purchasable_tier())`` so an
+        upgrade-CTA card can render the marginal "what's new at the next
+        rung" payload (with full ``tier`` / ``previous_tier`` metadata)
+        without first looking up the next purchasable tier. Returns ``None``
+        at the ceiling (no rung above to upgrade to) and never raises --
+        a resolver failure short-circuits to ``None`` so a CTA surface
+        keeps rendering instead of 500-ing.
+        """
+        try:
+            target = self.next_purchasable_tier()
+            if target is None:
+                return None
+            return tier_unlocks(target)
+        except Exception as exc:
+            logger.warning("entitlements: next_tier_unlocks failed: %s", exc)
+            return None
+
+    def previous_tier_unlocks(self) -> dict | None:
+        """One-rung-down unlocks row in :func:`tier_unlocks` shape.
+
+        Convenience for ``tier_unlocks(self.previous_purchasable_tier())`` --
+        the marginal-unlocks row of the rung immediately below current.
+        Useful for "you'd still keep X / you've already unlocked Y at your
+        current tier" copy on a downgrade confirmation card, paired with
+        :meth:`previous_tier_diff` (which carries the same marginal in
+        ``downgrade_diff`` shape). Returns ``None`` at the floor (no rung
+        below) and never raises.
+        """
+        try:
+            target = self.previous_purchasable_tier()
+            if target is None:
+                return None
+            return tier_unlocks(target)
+        except Exception as exc:
+            logger.warning("entitlements: previous_tier_unlocks failed: %s", exc)
+            return None
+
     def grace_remaining_days(self) -> int | None:
         at = enforce_at_epoch()
         if at is None:
@@ -925,6 +965,8 @@ class Entitlement:
             "prev_tier_diff": self.previous_tier_diff(),
             "next_tier_capacity_diff": self.next_tier_capacity_diff(),
             "prev_tier_capacity_diff": self.previous_tier_capacity_diff(),
+            "next_tier_unlocks": self.next_tier_unlocks(),
+            "prev_tier_unlocks": self.previous_tier_unlocks(),
         }
 
 
@@ -1338,6 +1380,26 @@ def previous_tier_diff() -> dict | None:
         return get_entitlement().previous_tier_diff()
     except Exception as exc:
         logger.warning("entitlements: previous_tier_diff (module) failed: %s", exc)
+        return None
+
+
+def next_tier_unlocks() -> dict | None:
+    """Module-level :meth:`Entitlement.next_tier_unlocks` against the resolved
+    entitlement. Never raises."""
+    try:
+        return get_entitlement().next_tier_unlocks()
+    except Exception as exc:
+        logger.warning("entitlements: next_tier_unlocks (module) failed: %s", exc)
+        return None
+
+
+def previous_tier_unlocks() -> dict | None:
+    """Module-level :meth:`Entitlement.previous_tier_unlocks` against the
+    resolved entitlement. Never raises."""
+    try:
+        return get_entitlement().previous_tier_unlocks()
+    except Exception as exc:
+        logger.warning("entitlements: previous_tier_unlocks (module) failed: %s", exc)
         return None
 
 

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -199,6 +199,8 @@ def api_entitlement():
                 "locked_features": [],
                 "next_tier_diff": None,
                 "prev_tier_diff": None,
+                "next_tier_unlocks": None,
+                "prev_tier_unlocks": None,
             }
         )
 
@@ -233,6 +235,8 @@ def api_entitlement_refresh():
                 "locked_features": [],
                 "next_tier_diff": None,
                 "prev_tier_diff": None,
+                "next_tier_unlocks": None,
+                "prev_tier_unlocks": None,
             }
         )
 
@@ -1005,6 +1009,94 @@ def api_entitlement_tier_unlocks_path():
         return (
             jsonify({"error": "unknown tier", "from": f, "to": t}),
             404,
+        )
+
+
+@bp_entitlement.route("/api/entitlement/next-tier-unlocks")
+def api_entitlement_next_tier_unlocks():
+    """``GET /api/entitlement/next-tier-unlocks`` -- marginal unlocks row
+    for the rung immediately above the resolved entitlement, in
+    :func:`clawmetry.entitlements.tier_unlocks` shape (``tier``,
+    ``tier_label``, ``tier_rank``, ``previous_tier``, ``previous_tier_label``,
+    ``previous_tier_rank``, ``features``, ``runtimes``).
+
+    Current-relative convenience for ``/api/entitlement/tier-unlocks
+    ?tier=<next_purchasable_tier>``; the upgrade-CTA companion to
+    ``/api/entitlement/next-tier-diff`` (same marginal, ``upgrade_diff``
+    shape). Returns ``{"unlocks": null, ...}`` at the ceiling
+    (no rung above to upgrade to). Never 5xxs: a resolver failure
+    short-circuits to the grace-shape envelope so the dashboard CTA
+    keeps rendering instead of disappearing.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        body = ent.next_tier_unlocks()
+        return jsonify(
+            {
+                "current_tier": ent.tier,
+                "current_tier_label": _ent.tier_label(ent.tier),
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "unlocks": body,
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_next_tier_unlocks: error: %s", exc)
+        return jsonify(
+            {
+                "current_tier": "oss",
+                "current_tier_label": "OSS",
+                "current_tier_rank": 0,
+                "unlocks": None,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/previous-tier-unlocks")
+def api_entitlement_previous_tier_unlocks():
+    """``GET /api/entitlement/previous-tier-unlocks`` -- marginal unlocks row
+    for the rung immediately below the resolved entitlement, in
+    :func:`clawmetry.entitlements.tier_unlocks` shape.
+
+    Current-relative convenience for ``/api/entitlement/tier-unlocks
+    ?tier=<previous_purchasable_tier>``. Useful as a downgrade-confirmation
+    detail row alongside :func:`previous_tier_diff` -- ``features`` /
+    ``runtimes`` here are what the rung below *first* unlocked vs the rung
+    below it (a tier-property), so a "you'd still keep X" copy can
+    reference the same set the rung-below was originally sold on. Returns
+    ``{"unlocks": null, ...}`` at the floor (no rung below). Never 5xxs.
+    """
+    try:
+        from clawmetry import entitlements as _ent
+
+        ent = _ent.get_entitlement()
+        body = ent.previous_tier_unlocks()
+        return jsonify(
+            {
+                "current_tier": ent.tier,
+                "current_tier_label": _ent.tier_label(ent.tier),
+                "current_tier_rank": _ent.tier_rank(ent.tier),
+                "unlocks": body,
+                "grace": bool(ent.grace),
+                "enforced": _ent.is_enforced(),
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_previous_tier_unlocks: error: %s", exc)
+        return jsonify(
+            {
+                "current_tier": "oss",
+                "current_tier_label": "OSS",
+                "current_tier_rank": 0,
+                "unlocks": None,
+                "grace": True,
+                "enforced": False,
+            }
         )
 
 

--- a/tests/test_entitlement_next_prev_tier_unlocks.py
+++ b/tests/test_entitlement_next_prev_tier_unlocks.py
@@ -1,0 +1,339 @@
+"""Tests for ``Entitlement.next_tier_unlocks`` / ``previous_tier_unlocks``,
+the module-level convenience helpers, the ``to_dict`` surface, and the
+companion ``/api/entitlement/{next,previous}-tier-unlocks`` endpoints.
+
+The dashboard's upgrade CTA currently composes the marginal-unlocks payload
+client-side by hitting ``/api/entitlement/tier-unlocks?tier=<next>`` after a
+``/api/entitlement`` round-trip; these helpers expose the same row in one call
+so the CTA can render off a single fetch. Pairs with the existing
+``next_tier_diff`` / ``previous_tier_diff`` family (upgrade_diff /
+downgrade_diff shape) -- this is the same marginal step in
+:func:`tier_unlocks` shape (tier-property row with ``previous_tier`` and
+labels).
+
+Pins covered here:
+
+* method-vs-tier_unlocks identity for next/previous
+* method-vs-module-level helper identity
+* tier_unlocks shape (8 stable keys, sorted lists, label/rank metadata)
+* ceiling / floor behaviour (Enterprise has no next, OSS/cloud_free has no
+  previous)
+* grace vs enforce yields the same body (these helpers are catalogue-derived,
+  not gated)
+* trial source resolves to enterprise as next (rank 2 -> rank 3) and to the
+  same-rank-cluster sibling for previous
+* to_dict carries the two new fields with the expected null/body shape per
+  tier
+* API surface: 200 always (no 5xx), unlocks=null at the floor/ceiling,
+  current_* tier metadata included, never-raise envelope on a synthetic
+  resolver failure
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+_UNLOCKS_KEYS = {
+    "tier",
+    "tier_label",
+    "tier_rank",
+    "previous_tier",
+    "previous_tier_label",
+    "previous_tier_rank",
+    "features",
+    "runtimes",
+}
+
+
+# ── Entitlement.next_tier_unlocks ────────────────────────────────────────────
+
+
+def test_next_tier_unlocks_matches_tier_unlocks_of_next(ent):
+    # next_tier_unlocks() is a convenience for tier_unlocks(next_purchasable_tier())
+    # -- they must be byte-equal across every purchasable tier so a caller
+    # can use the singular helper interchangeably.
+    for tier in (
+        ent.TIER_OSS,
+        ent.TIER_CLOUD_FREE,
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+    ):
+        e = ent._build(tier, "test")
+        nxt = e.next_purchasable_tier()
+        assert nxt is not None
+        assert e.next_tier_unlocks() == ent.tier_unlocks(nxt)
+
+
+def test_next_tier_unlocks_returns_none_at_ceiling(ent):
+    # Enterprise sits at the top of the purchasable ladder -- no rung above
+    # to upgrade to, so the convenience returns None just like
+    # next_purchasable_tier().
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    assert e.next_purchasable_tier() is None
+    assert e.next_tier_unlocks() is None
+
+
+def test_next_tier_unlocks_shape(ent):
+    # The row must carry the full tier_unlocks shape so the CTA can render
+    # labels + rank without a second round-trip.
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    body = e.next_tier_unlocks()
+    assert body is not None
+    assert set(body.keys()) == _UNLOCKS_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_PRO
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_PRO)
+    assert body["tier_rank"] == ent.tier_rank(ent.TIER_CLOUD_PRO)
+    assert body["features"] == sorted(body["features"])
+    assert body["runtimes"] == sorted(body["runtimes"])
+
+
+def test_next_tier_unlocks_never_raises_on_resolver_failure(ent, monkeypatch):
+    # If next_purchasable_tier blows up, the helper must swallow and return
+    # None so the dashboard CTA keeps rendering rather than 500-ing.
+    e = ent._oss_free()
+    monkeypatch.setattr(
+        type(e),
+        "next_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert e.next_tier_unlocks() is None
+
+
+# ── Entitlement.previous_tier_unlocks ────────────────────────────────────────
+
+
+def test_previous_tier_unlocks_matches_tier_unlocks_of_previous(ent):
+    # Symmetric to next_tier_unlocks: previous_tier_unlocks() must be
+    # byte-equal to tier_unlocks(previous_purchasable_tier()).
+    for tier in (
+        ent.TIER_CLOUD_STARTER,
+        ent.TIER_CLOUD_PRO,
+        ent.TIER_PRO,
+        ent.TIER_ENTERPRISE,
+    ):
+        e = ent._build(tier, "test")
+        prev = e.previous_purchasable_tier()
+        assert prev is not None
+        assert e.previous_tier_unlocks() == ent.tier_unlocks(prev)
+
+
+def test_previous_tier_unlocks_returns_none_at_floor(ent):
+    # OSS and cloud_free both sit at rank 0 -- no rung below to step down to,
+    # so the helper returns None mirroring previous_purchasable_tier().
+    for tier in (ent.TIER_OSS, ent.TIER_CLOUD_FREE):
+        e = ent._build(tier, "test")
+        assert e.previous_purchasable_tier() is None
+        assert e.previous_tier_unlocks() is None
+
+
+def test_previous_tier_unlocks_shape(ent):
+    e = ent._build(ent.TIER_CLOUD_PRO, "cloud")
+    body = e.previous_tier_unlocks()
+    assert body is not None
+    assert set(body.keys()) == _UNLOCKS_KEYS
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == ent.tier_label(ent.TIER_CLOUD_STARTER)
+
+
+def test_previous_tier_unlocks_never_raises_on_resolver_failure(ent, monkeypatch):
+    e = ent._build(ent.TIER_ENTERPRISE, "license")
+    monkeypatch.setattr(
+        type(e),
+        "previous_purchasable_tier",
+        lambda self: (_ for _ in ()).throw(RuntimeError("synthetic")),
+    )
+    assert e.previous_tier_unlocks() is None
+
+
+# ── trial source resolution ──────────────────────────────────────────────────
+
+
+def test_trial_next_unlocks_resolves_to_enterprise(ent):
+    # Trial sits at rank 2 alongside cloud_pro / self-hosted pro, so the next
+    # strictly-higher purchasable rung is enterprise (rank 3).
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    body = e.next_tier_unlocks()
+    assert body is not None
+    assert body["tier"] == ent.TIER_ENTERPRISE
+
+
+def test_trial_previous_unlocks_resolves_to_starter(ent):
+    # Trial steps down to rank 1 (starter) -- the highest rank strictly below
+    # trial's rank 2.
+    e = ent._build(ent.TIER_TRIAL, "cloud")
+    body = e.previous_tier_unlocks()
+    assert body is not None
+    assert body["tier"] == ent.TIER_CLOUD_STARTER
+
+
+# ── grace vs enforce ─────────────────────────────────────────────────────────
+
+
+def test_grace_and_enforce_yield_same_unlocks(ent, monkeypatch):
+    # These helpers are catalogue-derived (off the static per-tier grants),
+    # not gated -- so flipping enforce on must not change the body.
+    e = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    grace_body = e.next_tier_unlocks()
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    e2 = ent._build(ent.TIER_CLOUD_STARTER, "cloud")
+    enforce_body = e2.next_tier_unlocks()
+    assert enforce_body == grace_body
+
+
+# ── module-level helpers ─────────────────────────────────────────────────────
+
+
+def test_module_level_next_helper_matches_method(ent):
+    # The bare module-level helper resolves the current entitlement and
+    # delegates, so it must agree with the bound method.
+    assert ent.next_tier_unlocks() == ent.get_entitlement().next_tier_unlocks()
+
+
+def test_module_level_previous_helper_matches_method(ent):
+    assert (
+        ent.previous_tier_unlocks() == ent.get_entitlement().previous_tier_unlocks()
+    )
+
+
+def test_module_level_next_helper_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.next_tier_unlocks() is None
+
+
+def test_module_level_previous_helper_never_raises(monkeypatch, ent):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    assert ent.previous_tier_unlocks() is None
+
+
+# ── to_dict carries the new fields ───────────────────────────────────────────
+
+
+def test_to_dict_carries_next_tier_unlocks(ent):
+    body = ent._oss_free().to_dict()
+    assert "next_tier_unlocks" in body
+    # OSS has a next rung -> the field is a non-null row.
+    assert body["next_tier_unlocks"] is not None
+    assert body["next_tier_unlocks"]["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_to_dict_carries_prev_tier_unlocks(ent):
+    body = ent._build(ent.TIER_CLOUD_PRO, "cloud").to_dict()
+    assert "prev_tier_unlocks" in body
+    assert body["prev_tier_unlocks"] is not None
+    assert body["prev_tier_unlocks"]["tier"] == ent.TIER_CLOUD_STARTER
+
+
+def test_to_dict_next_unlocks_null_at_ceiling(ent):
+    body = ent._build(ent.TIER_ENTERPRISE, "license").to_dict()
+    assert body["next_tier_unlocks"] is None
+
+
+def test_to_dict_prev_unlocks_null_at_floor(ent):
+    body = ent._oss_free().to_dict()
+    assert body["prev_tier_unlocks"] is None
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+
+_ENVELOPE_KEYS = {
+    "current_tier",
+    "current_tier_label",
+    "current_tier_rank",
+    "unlocks",
+    "grace",
+    "enforced",
+}
+
+
+def test_next_tier_unlocks_endpoint_oss_default(client, ent):
+    rv = client.get("/api/entitlement/next-tier-unlocks")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["current_tier_label"] == ent.tier_label(ent.TIER_OSS)
+    assert body["current_tier_rank"] == ent.tier_rank(ent.TIER_OSS)
+    assert body["unlocks"] is not None
+    assert body["unlocks"]["tier"] == ent.TIER_CLOUD_STARTER
+    assert body["grace"] is True
+    assert body["enforced"] is False
+
+
+def test_previous_tier_unlocks_endpoint_oss_default_floor(client, ent):
+    rv = client.get("/api/entitlement/previous-tier-unlocks")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert set(body.keys()) == _ENVELOPE_KEYS
+    assert body["current_tier"] == ent.TIER_OSS
+    # OSS is the floor; nothing below to step down to.
+    assert body["unlocks"] is None
+
+
+def test_next_tier_unlocks_endpoint_never_raises(client, ent, monkeypatch):
+    # Synthesise a resolver failure and assert the envelope still returns 200
+    # with the grace-shape body so the dashboard doesn't break on a flaky
+    # entitlement read.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/next-tier-unlocks")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["unlocks"] is None
+    assert body["current_tier"] == "oss"
+
+
+def test_previous_tier_unlocks_endpoint_never_raises(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    rv = client.get("/api/entitlement/previous-tier-unlocks")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["unlocks"] is None
+    assert body["current_tier"] == "oss"
+
+
+def test_endpoint_unlocks_row_matches_tier_unlocks(client, ent):
+    # The body's unlocks row must byte-equal what /tier-unlocks?tier=<next>
+    # returns directly -- pin the equivalence so callers can swap between the
+    # two endpoints without copy drift.
+    rv = client.get("/api/entitlement/next-tier-unlocks")
+    body = rv.get_json()
+    assert body["unlocks"] == ent.tier_unlocks(ent.TIER_CLOUD_STARTER)


### PR DESCRIPTION
## What this changes

Adds two current-relative convenience helpers to `clawmetry.entitlements` plus the matching API surface:

- `Entitlement.next_tier_unlocks()` -> `tier_unlocks(self.next_purchasable_tier())`
- `Entitlement.previous_tier_unlocks()` -> `tier_unlocks(self.previous_purchasable_tier())`
- Module-level `next_tier_unlocks()` / `previous_tier_unlocks()` thunks
- `to_dict()` carries the new fields as `next_tier_unlocks` / `prev_tier_unlocks`
- `GET /api/entitlement/next-tier-unlocks`
- `GET /api/entitlement/previous-tier-unlocks`

## Why

The dashboard's upgrade-CTA card currently composes the marginal-unlocks payload client-side by hitting `/api/entitlement/tier-unlocks?tier=<next>` after a `/api/entitlement` round-trip. These helpers carry the same row in one call so the CTA renders off a single fetch.

Pairs with the existing `next_tier_diff` / `previous_tier_diff` family (`upgrade_diff` / `downgrade_diff` shape) -- this is the same marginal step in `tier_unlocks` row shape (richer row metadata: `previous_tier`, `previous_tier_label`, `previous_tier_rank`).

## Tests

`tests/test_entitlement_next_prev_tier_unlocks.py` -- 24 new tests covering:

- Method identity: body byte-equals `tier_unlocks(next_purchasable_tier())` / `tier_unlocks(previous_purchasable_tier())` across every purchasable tier.
- Module-level vs bound identity.
- `tier_unlocks` shape (8 stable keys, sorted lists, label/rank metadata).
- Ceiling / floor behaviour (`Enterprise` -> no next, `OSS` / `cloud_free` -> no previous).
- Trial-source resolution (rank 2 -> rank 3 next, rank 1 previous).
- Grace vs enforce body identity (helpers are catalogue-derived, not gated).
- `to_dict` carries the new keys with the expected null/body shape per tier.
- API envelope (`current_tier`, `current_tier_label`, `current_tier_rank`, `unlocks`, `grace`, `enforced`).
- Never-raise contract (synthetic resolver failure returns 200 with the grace envelope and `unlocks=null`).

## Posture

Purely additive; zero behaviour change to existing surfaces. Defaults to grace (no enforcement flip). License key / cloud heartbeat stubs unchanged. No version bump in this PR.

## Local operator verification checklist

Since this PR was authored remotely on the public repo, the operator should run these against the live local daemon + cloud snapshot before flipping to ready-for-review / merging:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_next_prev_tier_unlocks.py` into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and the route into `~/.clawmetry/lib/python3.X/site-packages/routes/`).
- [ ] Clear `__pycache__` under that site-packages tree.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon (or the equivalent systemd / supervisor unit on Linux).
- [ ] `curl -s http://localhost:8900/api/entitlement | jq '.next_tier_unlocks, .prev_tier_unlocks'` -- confirm both new keys appear on the existing payload.
- [ ] `curl -s http://localhost:8900/api/entitlement/next-tier-unlocks | jq` -- expect the envelope with the `cloud_starter` row at OSS defaults.
- [ ] `curl -s http://localhost:8900/api/entitlement/previous-tier-unlocks | jq` -- expect `unlocks: null` at OSS (floor).
- [ ] Decrypt the live cloud snapshot in the browser and confirm `/api/entitlement` still renders and existing entitlement-driven panels are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NybPvELzCo26nYAiC81aGE)_