### PR TITLE
feat(entitlement): min_tier_for_feature/runtime + tier_label/tier_rank

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -65,6 +65,42 @@ _PAID_TIERS = frozenset(
     {TIER_TRIAL, TIER_CLOUD_STARTER, TIER_CLOUD_PRO, TIER_PRO, TIER_ENTERPRISE}
 )
 
+# Purchasable tiers — the rungs an upgrade CTA may point at. Trial is paid but
+# promotional (granted, not sold), so it is *excluded* from the purchasable
+# ladder. ``min_tier_for_*`` returns picks from this set so a CTA never
+# tells the operator to "upgrade to Trial".
+_PURCHASABLE_TIERS = frozenset(
+    {TIER_CLOUD_STARTER, TIER_CLOUD_PRO, TIER_PRO, TIER_ENTERPRISE}
+)
+
+# Tier rank for ordering — cheapest (0) to most capable (3). The OSS and
+# Cloud Free tiers share rank 0 (both are floor); the self-hosted Pro and
+# Cloud Pro tiers share rank 2 with Trial (functionally equivalent grants);
+# Enterprise sits alone at rank 3. Used by ``tier_rank`` and the
+# ``min_tier_for_*`` helpers so the upgrade ladder is single-sourced.
+_TIER_RANK = {
+    TIER_OSS: 0,
+    TIER_CLOUD_FREE: 0,
+    TIER_CLOUD_STARTER: 1,
+    TIER_TRIAL: 2,
+    TIER_CLOUD_PRO: 2,
+    TIER_PRO: 2,
+    TIER_ENTERPRISE: 3,
+}
+
+# Display labels for tier ids — used by upgrade-CTA copy. Mirrors the
+# ``_CM_TIER_LABEL`` map in ``clawmetry/static/js/app.js`` so the dashboard
+# and the API agree on tier wording (e.g. "Pro (Self-hosted)" vs "Pro").
+TIER_LABELS = {
+    TIER_OSS: "OSS",
+    TIER_CLOUD_FREE: "Free",
+    TIER_CLOUD_STARTER: "Starter",
+    TIER_TRIAL: "Trial",
+    TIER_CLOUD_PRO: "Pro",
+    TIER_PRO: "Pro (Self-hosted)",
+    TIER_ENTERPRISE: "Enterprise",
+}
+
 # ── Runtime catalogue ───────────────────────────────────────────────────────
 # FREE: the OpenClaw and NVIDIA NemoClaw runtimes. NeMo *governance* (policy
 # enforcement) is a separate free feature; ``nemoclaw`` here is the agent
@@ -287,6 +323,8 @@ class Entitlement:
     def to_dict(self) -> dict:
         return {
             "tier": self.tier,
+            "tier_label": tier_label(self.tier),
+            "tier_rank": tier_rank(self.tier),
             "source": self.source,
             "node_limit": self.node_limit,
             "expiry": self.expiry,
@@ -467,3 +505,90 @@ def runtime_catalog() -> list[dict]:
             }
         )
     return out
+
+
+def tier_label(tier: str) -> str:
+    """Human-readable label for ``tier``. Falls back to the id when unknown so
+    a misconfigured plan still renders with *something* rather than blowing up
+    the upgrade-CTA copy."""
+    tid = (tier or "").strip().lower()
+    return TIER_LABELS.get(tid, tid or "Unknown")
+
+
+def tier_rank(tier: str) -> int:
+    """Numeric rank for ``tier`` (0=floor, 3=ceiling). Unknown tier ids map to
+    0 so an unrecognised plan is treated as floor for ladder comparisons —
+    matches the OSS-free fallback in :func:`get_entitlement` which returns the
+    floor rather than crashing."""
+    tid = (tier or "").strip().lower()
+    return _TIER_RANK.get(tid, 0)
+
+
+def min_tier_for_feature(feature: str) -> str | None:
+    """Cheapest purchasable tier that unlocks ``feature``.
+
+    Single source of truth for "Unlock <feature> starting at <tier>" upgrade-CTA
+    copy: returns the lowest-ranked tier in :data:`_PURCHASABLE_TIERS` whose
+    feature grant first includes ``feature``. Trial is intentionally excluded
+    (it's granted, not sold), so a CTA never tells the operator to "upgrade to
+    Trial". Same-rank ties break alphabetically so the cloud path
+    (``cloud_pro``) wins over the self-hosted path (``pro``) for Pro-only
+    features — matches how /pricing positions the standard upsell.
+
+    Returns:
+        - :data:`TIER_OSS` for any feature in :data:`FREE_FEATURES`.
+        - The cheapest tier id whose grant contains ``feature``, for
+          paid/enterprise features.
+        - ``None`` for unknown or empty feature ids so the caller can render a
+          neutral "not available" hint instead of pointing at a nonsense tier.
+
+    Never raises: an empty input or an unknown id returns ``None`` rather than
+    propagating an error so a misconfigured paywall ping can't crash the
+    dashboard. Catalogue-derived, so the answer is identical in grace and
+    enforce mode (this helper answers "where would this be unlocked", not
+    "is it unlocked right now").
+    """
+    f = (feature or "").strip()
+    if not f:
+        return None
+    if f in FREE_FEATURES:
+        return TIER_OSS
+    if f not in ALL_FEATURES:
+        return None
+    purchasable = sorted(
+        _PURCHASABLE_TIERS,
+        key=lambda t: (_TIER_RANK.get(t, 99), t),
+    )
+    for tier in purchasable:
+        if f in _TIER_FEATURES.get(tier, frozenset()):
+            return tier
+    return None
+
+
+def min_tier_for_runtime(runtime: str) -> str | None:
+    """Cheapest purchasable tier that unlocks ``runtime``.
+
+    Companion to :func:`min_tier_for_feature` — the runtime-side resolver an
+    upgrade CTA on a locked runtime row reads to render "Unlock {runtime}
+    starting at {tier}" copy. Every paid runtime is granted by every paid
+    tier (there is no per-runtime tier carve-out), so for any
+    ``runtime in PAID_RUNTIMES`` the answer is the cheapest purchasable paid
+    tier (:data:`TIER_CLOUD_STARTER`). Free runtimes return :data:`TIER_OSS`;
+    unknown runtimes return ``None``.
+
+    Same never-raise / catalogue-derived posture as
+    :func:`min_tier_for_feature` so the resolver is grace/enforce-invariant
+    and safe to call from a 402 handler.
+    """
+    rt = (runtime or "").strip().lower()
+    if not rt:
+        return None
+    if rt in FREE_RUNTIMES:
+        return TIER_OSS
+    if rt not in ALL_RUNTIMES:
+        return None
+    purchasable = sorted(
+        (t for t in _TIER_PAID_RUNTIMES if t in _PURCHASABLE_TIERS),
+        key=lambda t: (_TIER_RANK.get(t, 99), t),
+    )
+    return purchasable[0] if purchasable else None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -6,8 +6,9 @@ runtimes/features to surface (and, once enforcement is live, which to render
 locked behind an upgrade CTA). Backed by :mod:`clawmetry.entitlements`, which
 is the single source of truth — handlers never re-derive tier logic here.
 
-  GET /api/entitlement — the current Entitlement as JSON.
-  GET /api/runtimes    — the full runtime catalog with locked/free flags.
+  GET /api/entitlement          — the current Entitlement as JSON.
+  GET /api/runtimes             — the full runtime catalog with locked/free flags.
+  GET /api/entitlement/min-tier — cheapest tier that unlocks a feature/runtime.
 
 Side-effect-free and never-raise, so it is safe to classify ``oss-passthrough``
 on the cloud side: when no license/cloud plan is present it returns a graceful
@@ -109,6 +110,96 @@ def api_runtimes():
                 ],
                 "grace": True,
                 "enforced": False,
+            }
+        )
+
+
+@bp_entitlement.route("/api/entitlement/min-tier")
+def api_entitlement_min_tier():
+    """``GET /api/entitlement/min-tier?feature=<f>`` or ``?runtime=<r>`` —
+    cheapest purchasable tier that unlocks the named feature or runtime.
+
+    The dashboard's locked-row CTA (paid runtime / paid feature) reads this to
+    render "Unlock <X> starting at <Tier>" copy off a single fetch, instead of
+    walking the catalogue client-side. Backed by
+    :func:`clawmetry.entitlements.min_tier_for_feature` /
+    :func:`min_tier_for_runtime` — catalogue-derived, so the answer is
+    identical in grace and enforce mode.
+
+    Response shape::
+
+        {
+          "key":        "feature" | "runtime",
+          "value":      "<input>",
+          "free":       <bool>,           # true when min_tier == OSS
+          "min_tier":   "<tier id>" | null,
+          "tier_label": "<Display Label>" | null,
+          "tier_rank":  <int> | null,
+        }
+
+    400 when neither ``feature`` nor ``runtime`` is supplied (or both are).
+    404 when the input id is unknown — the caller can show a neutral "not
+    available" hint rather than pointing at a nonsense tier. Never 5xxs: a
+    resolver failure short-circuits to a grace-shape ``null`` envelope so the
+    dashboard CTA keeps rendering.
+    """
+    feature = (request.args.get("feature") or "").strip()
+    runtime = (request.args.get("runtime") or "").strip().lower()
+    if bool(feature) == bool(runtime):
+        return (
+            jsonify(
+                {
+                    "error": "exactly one of feature= or runtime= is required",
+                }
+            ),
+            400,
+        )
+    try:
+        from clawmetry import entitlements as _ent
+
+        if feature:
+            min_t = _ent.min_tier_for_feature(feature)
+            key, value = "feature", feature
+            known = feature in _ent.ALL_FEATURES
+        else:
+            min_t = _ent.min_tier_for_runtime(runtime)
+            key, value = "runtime", runtime
+            known = runtime in _ent.ALL_RUNTIMES
+        if not known:
+            return (
+                jsonify(
+                    {
+                        "key": key,
+                        "value": value,
+                        "free": False,
+                        "min_tier": None,
+                        "tier_label": None,
+                        "tier_rank": None,
+                        "error": "unknown",
+                    }
+                ),
+                404,
+            )
+        return jsonify(
+            {
+                "key": key,
+                "value": value,
+                "free": min_t == _ent.TIER_OSS,
+                "min_tier": min_t,
+                "tier_label": _ent.tier_label(min_t) if min_t else None,
+                "tier_rank": _ent.tier_rank(min_t) if min_t else None,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_min_tier: error: %s", exc)
+        return jsonify(
+            {
+                "key": "feature" if feature else "runtime",
+                "value": feature or runtime,
+                "free": False,
+                "min_tier": None,
+                "tier_label": None,
+                "tier_rank": None,
             }
         )
 

--- a/tests/test_entitlement_min_tier.py
+++ b/tests/test_entitlement_min_tier.py
@@ -1,0 +1,345 @@
+"""Tests for the ``min_tier_for_feature`` / ``min_tier_for_runtime`` helpers,
+the ``tier_label`` / ``tier_rank`` metadata accessors, the ``to_dict`` surface,
+and the companion ``/api/entitlement/min-tier`` endpoint.
+
+The dashboard's locked-row CTA (paid runtime / paid feature) needs a single,
+canonical "cheapest tier that unlocks X" lookup so the JS doesn't re-derive
+the ladder. These tests pin the per-feature / per-runtime answer so a future
+catalogue shuffle (a feature moves from Starter to Pro, a runtime is renamed)
+breaks loudly here rather than silently downgrading the CTA copy.
+
+The headline invariants:
+
+* Free features / free runtimes resolve to ``TIER_OSS`` so the CTA can short
+  to "Already included" rather than a paid tier.
+* Starter features resolve to ``TIER_CLOUD_STARTER`` and Pro-only features
+  resolve to ``TIER_CLOUD_PRO`` (cloud upsell wins the same-rank tie against
+  the self-hosted ``pro`` license).
+* Enterprise-only features resolve to ``TIER_ENTERPRISE``.
+* Trial is never the answer (it's promotional, not purchasable).
+* Unknown inputs return ``None`` / a 404 envelope — no nonsense tier.
+* Catalogue-derived: identical answer in grace and enforce mode.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── tier_label / tier_rank ──────────────────────────────────────────────────
+
+
+def test_tier_label_known_tiers(ent):
+    assert ent.tier_label(ent.TIER_OSS) == "OSS"
+    assert ent.tier_label(ent.TIER_CLOUD_FREE) == "Free"
+    assert ent.tier_label(ent.TIER_CLOUD_STARTER) == "Starter"
+    assert ent.tier_label(ent.TIER_TRIAL) == "Trial"
+    assert ent.tier_label(ent.TIER_CLOUD_PRO) == "Pro"
+    assert ent.tier_label(ent.TIER_PRO) == "Pro (Self-hosted)"
+    assert ent.tier_label(ent.TIER_ENTERPRISE) == "Enterprise"
+
+
+def test_tier_label_unknown_falls_back_to_id(ent):
+    # A misconfigured plan with an unknown tier id should still render with
+    # *something* — the id itself — rather than crash the CTA copy.
+    assert ent.tier_label("nonsense_tier_xyz") == "nonsense_tier_xyz"
+
+
+def test_tier_label_empty_falls_back_to_unknown(ent):
+    assert ent.tier_label("") == "Unknown"
+    assert ent.tier_label(None) == "Unknown"
+
+
+def test_tier_rank_orders_ladder(ent):
+    # The ladder must be strictly monotonic in the canonical upgrade order:
+    # OSS/Free (0) < Starter (1) < Pro (2) < Enterprise (3).
+    assert ent.tier_rank(ent.TIER_OSS) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_FREE) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_STARTER) == 1
+    assert ent.tier_rank(ent.TIER_TRIAL) == 2
+    assert ent.tier_rank(ent.TIER_CLOUD_PRO) == 2
+    assert ent.tier_rank(ent.TIER_PRO) == 2
+    assert ent.tier_rank(ent.TIER_ENTERPRISE) == 3
+
+
+def test_tier_rank_unknown_is_floor(ent):
+    # An unknown tier id maps to floor rank, matching the OSS-free fallback
+    # in get_entitlement (the resolver returns floor rather than crashing).
+    assert ent.tier_rank("nonsense_tier_xyz") == 0
+    assert ent.tier_rank("") == 0
+
+
+def test_tier_rank_case_insensitive(ent):
+    # Tier ids are normalised lowercase everywhere; the rank lookup must too.
+    assert ent.tier_rank("CLOUD_STARTER") == 1
+    assert ent.tier_rank("Enterprise") == 3
+
+
+# ── min_tier_for_feature ────────────────────────────────────────────────────
+
+
+def test_min_tier_free_feature_is_oss(ent):
+    # Free features are always available; the CTA short-circuits to
+    # "Already included" rather than recommending an upsell.
+    for feat in ("sessions", "transcripts", "usage", "brain", "nemo_governance"):
+        assert ent.min_tier_for_feature(feat) == ent.TIER_OSS
+
+
+def test_min_tier_starter_feature_is_cloud_starter(ent):
+    # Multi-runtime, fleet, cloud sync etc. unlock at Starter.
+    for feat in (
+        "multi_runtime",
+        "fleet",
+        "cloud_sync",
+        "all_channels",
+        "approval_queue",
+        "budget_limits",
+        "per_runtime_health_timeline",
+    ):
+        assert ent.min_tier_for_feature(feat) == ent.TIER_CLOUD_STARTER, feat
+
+
+def test_min_tier_pro_only_feature_is_cloud_pro(ent):
+    # Pro-only features tie at rank 2 between cloud_pro / pro / trial. Trial
+    # is excluded (not purchasable); cloud_pro beats pro on the lexical
+    # tiebreak so the standard cloud upsell wins.
+    for feat in (
+        "per_run_waste_flags",
+        "self_evolve",
+        "eval_suite",
+        "tool_policy",
+        "otel_export",
+        "custom_alerts",
+        "custom_webhooks",
+        "custom_runtime_ingest",
+        "anomaly_detection",
+        "cost_optimizer",
+    ):
+        assert ent.min_tier_for_feature(feat) == ent.TIER_CLOUD_PRO, feat
+
+
+def test_min_tier_enterprise_only_feature_is_enterprise(ent):
+    for feat in (
+        "siem_export",
+        "sso",
+        "audit_logs",
+        "rbac",
+        "air_gapped_license",
+        "custom_data_residency",
+    ):
+        assert ent.min_tier_for_feature(feat) == ent.TIER_ENTERPRISE, feat
+
+
+def test_min_tier_unknown_feature_is_none(ent):
+    # A misconfigured paywall ping with an unknown feature id must not point
+    # the operator at a nonsense tier — return None so the caller can render
+    # a neutral "not available" hint.
+    assert ent.min_tier_for_feature("nonsense_feature_xyz") is None
+    assert ent.min_tier_for_feature("") is None
+    assert ent.min_tier_for_feature(None) is None
+
+
+def test_min_tier_never_returns_trial(ent):
+    # Trial is granted, not sold; no feature should ever advertise it as the
+    # cheapest unlock. Pins the _PURCHASABLE_TIERS exclusion against an
+    # accidental future include.
+    for feat in ent.ALL_FEATURES:
+        assert ent.min_tier_for_feature(feat) != ent.TIER_TRIAL
+
+
+def test_min_tier_grace_and_enforce_match(ent, monkeypatch):
+    # The helper is catalogue-derived (it answers "where would this be
+    # unlocked", not "is it unlocked right now") so flipping enforce must not
+    # change the answer.
+    grace = ent.min_tier_for_feature("custom_alerts")
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    assert ent.min_tier_for_feature("custom_alerts") == grace
+
+
+# ── min_tier_for_runtime ────────────────────────────────────────────────────
+
+
+def test_min_tier_free_runtime_is_oss(ent):
+    for rt in ("openclaw", "nemoclaw"):
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_OSS
+
+
+def test_min_tier_paid_runtime_is_cloud_starter(ent):
+    # Every paid runtime unlocks at the cheapest paid tier (Starter) — there
+    # is no per-runtime tier carve-out.
+    for rt in (
+        "claude_code",
+        "codex",
+        "cursor",
+        "aider",
+        "goose",
+        "opencode",
+        "qwen_code",
+        "hermes",
+        "picoclaw",
+        "nanoclaw",
+    ):
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_CLOUD_STARTER, rt
+
+
+def test_min_tier_unknown_runtime_is_none(ent):
+    assert ent.min_tier_for_runtime("nonsense_runtime") is None
+    assert ent.min_tier_for_runtime("") is None
+    assert ent.min_tier_for_runtime(None) is None
+
+
+def test_min_tier_runtime_case_insensitive(ent):
+    # Runtime ids are normalised lowercase; uppercase input should still
+    # resolve.
+    assert ent.min_tier_for_runtime("CLAUDE_CODE") == ent.TIER_CLOUD_STARTER
+    assert ent.min_tier_for_runtime("OpenClaw") == ent.TIER_OSS
+
+
+# ── to_dict surface ─────────────────────────────────────────────────────────
+
+
+def test_to_dict_carries_tier_label_and_rank(ent):
+    body = ent._oss_free().to_dict()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["tier_label"] == "OSS"
+    assert body["tier_rank"] == 0
+
+
+def test_to_dict_paid_tier_label_and_rank(ent):
+    body = ent._build(ent.TIER_CLOUD_PRO, "cloud").to_dict()
+    assert body["tier_label"] == "Pro"
+    assert body["tier_rank"] == 2
+
+
+# ── /api/entitlement/min-tier ───────────────────────────────────────────────
+
+
+def test_endpoint_feature_free_returns_oss(client, ent):
+    rv = client.get("/api/entitlement/min-tier?feature=sessions")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["key"] == "feature"
+    assert body["value"] == "sessions"
+    assert body["free"] is True
+    assert body["min_tier"] == ent.TIER_OSS
+    assert body["tier_label"] == "OSS"
+    assert body["tier_rank"] == 0
+
+
+def test_endpoint_feature_starter(client, ent):
+    rv = client.get("/api/entitlement/min-tier?feature=multi_runtime")
+    body = rv.get_json()
+    assert rv.status_code == 200
+    assert body["free"] is False
+    assert body["min_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == "Starter"
+    assert body["tier_rank"] == 1
+
+
+def test_endpoint_feature_pro(client, ent):
+    rv = client.get("/api/entitlement/min-tier?feature=custom_alerts")
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_CLOUD_PRO
+    assert body["tier_rank"] == 2
+
+
+def test_endpoint_feature_enterprise(client, ent):
+    rv = client.get("/api/entitlement/min-tier?feature=siem_export")
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_ENTERPRISE
+    assert body["tier_rank"] == 3
+
+
+def test_endpoint_runtime_free(client, ent):
+    rv = client.get("/api/entitlement/min-tier?runtime=openclaw")
+    body = rv.get_json()
+    assert rv.status_code == 200
+    assert body["key"] == "runtime"
+    assert body["value"] == "openclaw"
+    assert body["free"] is True
+    assert body["min_tier"] == ent.TIER_OSS
+
+
+def test_endpoint_runtime_paid(client, ent):
+    rv = client.get("/api/entitlement/min-tier?runtime=claude_code")
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == "Starter"
+
+
+def test_endpoint_unknown_feature_404(client):
+    rv = client.get("/api/entitlement/min-tier?feature=nonsense")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["min_tier"] is None
+    assert body["tier_label"] is None
+    assert body["error"] == "unknown"
+
+
+def test_endpoint_unknown_runtime_404(client):
+    rv = client.get("/api/entitlement/min-tier?runtime=nonsense")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["min_tier"] is None
+
+
+def test_endpoint_requires_exactly_one_arg(client):
+    # No args → 400.
+    rv = client.get("/api/entitlement/min-tier")
+    assert rv.status_code == 400
+    # Both args → 400 (ambiguous: which one is being asked about?).
+    rv = client.get(
+        "/api/entitlement/min-tier?feature=sessions&runtime=openclaw"
+    )
+    assert rv.status_code == 400
+
+
+def test_endpoint_never_5xx_on_resolver_failure(client, ent, monkeypatch):
+    # Synthesise a resolver failure; the envelope must stay 200 with a
+    # null-shaped body so the dashboard CTA keeps rendering instead of
+    # disappearing.
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "min_tier_for_feature", boom)
+    rv = client.get("/api/entitlement/min-tier?feature=multi_runtime")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["min_tier"] is None
+    assert body["tier_label"] is None
+    assert body["key"] == "feature"
+    assert body["value"] == "multi_runtime"
+
+
+def test_endpoint_envelope_keys(client):
+    # Pin the envelope shape so a downstream consumer can rely on every key
+    # being present regardless of free/paid/unknown branch.
+    rv = client.get("/api/entitlement/min-tier?feature=sessions")
+    body = rv.get_json()
+    for key in ("key", "value", "free", "min_tier", "tier_label", "tier_rank"):
+        assert key in body, key


### PR DESCRIPTION
## What this changes

Adds a single-source "cheapest tier that unlocks X" lookup so the locked-row upgrade CTA can render off **one** fetch instead of walking the catalogue client-side. Foundational tier-metadata accessors (`tier_label`, `tier_rank`) land alongside since `to_dict()` surfaces them on the existing `/api/entitlement` payload.

### `clawmetry/entitlements.py`

- New module constants:
  - `_PURCHASABLE_TIERS` — `{Starter, Cloud Pro, Pro, Enterprise}`; trial is intentionally excluded so a CTA never recommends "upgrade to Trial" (trial is granted, not sold).
  - `_TIER_RANK` — `OSS/Free=0 < Starter=1 < (Trial, Cloud Pro, Pro)=2 < Enterprise=3`.
  - `TIER_LABELS` — display strings (`"Starter"`, `"Pro"`, `"Pro (Self-hosted)"`, `"Enterprise"`, …).
- New module-level helpers:
  - `tier_label(tier_id) -> str` — falls back to the id, then `"Unknown"` for empty input.
  - `tier_rank(tier_id) -> int` — unknown ids map to floor (0), matching the OSS-free fallback in `get_entitlement`.
  - `min_tier_for_feature(feature) -> str | None` — cheapest purchasable tier whose grant first includes `feature`. Free features return `TIER_OSS`; unknown features return `None`; Pro-only features resolve to `TIER_CLOUD_PRO` (cloud upsell wins the same-rank tiebreak against the self-hosted `pro` license).
  - `min_tier_for_runtime(runtime) -> str | None` — paid runtimes resolve to `TIER_CLOUD_STARTER` (every paid tier grants every paid runtime; no per-runtime carve-out).
- `Entitlement.to_dict()` adds `tier_label` + `tier_rank` keys.

### `routes/entitlement.py`

- `GET /api/entitlement/min-tier?feature=<f>` or `?runtime=<r>` — returns `{key, value, free, min_tier, tier_label, tier_rank}`.
  - **400** when neither (or both) args are supplied.
  - **404** with a neutral null envelope on an unknown id — the caller can render a "not available" hint instead of pointing at a nonsense tier.
  - **200** grace-shape envelope on a resolver failure (never 5xxs).

### `tests/test_entitlement_min_tier.py` — 30 new tests

- `tier_label` / `tier_rank` table per known tier, case-insensitive lookup, unknown-id fallback.
- `min_tier_for_feature` per-tier table (free / Starter / Pro-only / Enterprise-only), no-trial invariant, grace-vs-enforce identity.
- `min_tier_for_runtime` per-runtime table, case-insensitive, unknown returns `None`.
- `to_dict` carries the new keys.
- Endpoint: free feature, Starter feature, Pro feature, Enterprise feature, free runtime, paid runtime, unknown id (404), missing/both args (400), synthetic resolver failure (200 null envelope), envelope-keys pin.

## Posture

Purely additive; zero behaviour change to existing surfaces. Defaults to grace (no enforcement flip). License-key / cloud-heartbeat stubs unchanged. No version bump. The helpers are catalogue-derived (they answer "where would this be unlocked", not "is it unlocked right now"), so the answer is identical in grace and enforce mode.

## Local operator verification checklist

Since this PR was authored remotely on the public repo, the operator should run these against the live local daemon + cloud snapshot before flipping to ready-for-review / merging:

- [ ] `cp clawmetry/entitlements.py routes/entitlement.py` into `~/.clawmetry/lib/python3.X/site-packages/clawmetry/` (and the route into `~/.clawmetry/lib/python3.X/site-packages/routes/`). Copy the new test file under `tests/`.
- [ ] Clear `__pycache__` under that site-packages tree.
- [ ] `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync` to restart the daemon (or the equivalent systemd / supervisor unit on Linux).
- [ ] `curl -s http://localhost:8900/api/entitlement | jq '.tier_label, .tier_rank'` — confirm both new fields appear on the existing payload.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier?feature=multi_runtime' | jq` — expect `{..., "min_tier": "cloud_starter", "tier_label": "Starter", "tier_rank": 1, ...}`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier?feature=custom_alerts' | jq` — expect `"min_tier": "cloud_pro"`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier?feature=siem_export' | jq` — expect `"min_tier": "enterprise"`.
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier?runtime=claude_code' | jq` — expect `"min_tier": "cloud_starter"`.
- [ ] `curl -sw '%{http_code}\n' -o /dev/null 'http://localhost:8900/api/entitlement/min-tier?feature=nonsense'` — expect `404`.
- [ ] `curl -sw '%{http_code}\n' -o /dev/null 'http://localhost:8900/api/entitlement/min-tier'` — expect `400`.
- [ ] Decrypt the live cloud snapshot in the browser and confirm `/api/entitlement` still renders and existing entitlement-driven panels are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvdbWrm5vJVEuy7LiXcptS)_