### PR TITLE
feat(entitlement): GET /api/entitlement/min-tier + 30 tests

### DIFF
--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -2049,6 +2049,88 @@ def api_entitlement_affordable_tiers():
         )
 
 
+@bp_entitlement.route("/api/entitlement/min-tier")
+def api_entitlement_min_tier():
+    """``GET /api/entitlement/min-tier?feature=<f>`` or ``?runtime=<r>`` --
+    cheapest purchasable tier that unlocks the named feature or runtime.
+
+    Catalogue-derived, so the answer is identical in grace and enforce mode.
+    Response shape::
+
+        {
+          "key":        "feature" | "runtime",
+          "value":      "<input>",
+          "free":       <bool>,           # true when min_tier == OSS
+          "min_tier":   "<tier id>" | null,
+          "tier_label": "<Display Label>" | null,
+          "tier_rank":  <int> | null,
+        }
+
+    400 when neither ``feature`` nor ``runtime`` is supplied (or both are).
+    404 when the input id is unknown -- the caller can show a neutral
+    "not available" hint rather than pointing at a nonsense tier. Never 5xxs.
+    """
+    feature = (request.args.get("feature") or "").strip()
+    runtime = (request.args.get("runtime") or "").strip().lower()
+    if bool(feature) == bool(runtime):
+        return (
+            jsonify(
+                {
+                    "error": "exactly one of feature= or runtime= is required",
+                }
+            ),
+            400,
+        )
+    try:
+        from clawmetry import entitlements as _ent
+
+        if feature:
+            min_t = _ent.min_tier_for_feature(feature)
+            key, value = "feature", feature
+            known = feature in _ent.ALL_FEATURES
+        else:
+            min_t = _ent.min_tier_for_runtime(runtime)
+            key, value = "runtime", runtime
+            known = runtime in _ent.ALL_RUNTIMES
+        if not known:
+            return (
+                jsonify(
+                    {
+                        "key": key,
+                        "value": value,
+                        "free": False,
+                        "min_tier": None,
+                        "tier_label": None,
+                        "tier_rank": None,
+                        "error": "unknown",
+                    }
+                ),
+                404,
+            )
+        return jsonify(
+            {
+                "key": key,
+                "value": value,
+                "free": min_t == _ent.TIER_OSS,
+                "min_tier": min_t,
+                "tier_label": _ent.tier_label(min_t) if min_t else None,
+                "tier_rank": _ent.tier_rank(min_t) if min_t else None,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_min_tier: error: %s", exc)
+        return jsonify(
+            {
+                "key": "feature" if feature else "runtime",
+                "value": feature or runtime,
+                "free": False,
+                "min_tier": None,
+                "tier_label": None,
+                "tier_rank": None,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/lock-reason-batch")
 def api_entitlement_lock_reason_batch():
     """``GET /api/entitlement/lock-reason-batch?features=a,b,c&runtimes=x,y

--- a/tests/test_entitlement_min_tier.py
+++ b/tests/test_entitlement_min_tier.py
@@ -1,0 +1,319 @@
+"""Tests for the ``/api/entitlement/min-tier`` endpoint and its backing
+helpers ``min_tier_for_feature`` / ``min_tier_for_runtime``, the
+``tier_label`` / ``tier_rank`` metadata accessors, and the ``to_dict``
+surface.
+
+The dashboard's locked-row CTA (paid runtime / paid feature) needs a single,
+canonical "cheapest tier that unlocks X" lookup so the JS doesn't re-derive
+the ladder. These tests pin the per-feature / per-runtime answer so a future
+catalogue shuffle (a feature moves from Starter to Pro, a runtime is renamed)
+breaks loudly here rather than silently downgrading the CTA copy.
+
+The headline invariants:
+
+* Free features / free runtimes resolve to ``TIER_OSS`` so the CTA can short
+  to "Already included" rather than a paid tier.
+* Starter features resolve to ``TIER_CLOUD_STARTER`` and Pro-only features
+  resolve to ``TIER_CLOUD_PRO`` (cloud upsell wins the same-rank tie against
+  the self-hosted ``pro`` license).
+* Enterprise-only features resolve to ``TIER_ENTERPRISE``.
+* Trial is never the answer (it's promotional, not purchasable).
+* Unknown inputs return ``None`` / a 404 envelope -- no nonsense tier.
+* Catalogue-derived: identical answer in grace and enforce mode.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# -- tier_label / tier_rank --------------------------------------------------
+
+
+def test_tier_label_known_tiers(ent):
+    assert ent.tier_label(ent.TIER_OSS) == "OSS"
+    assert ent.tier_label(ent.TIER_CLOUD_FREE) == "Free"
+    assert ent.tier_label(ent.TIER_CLOUD_STARTER) == "Starter"
+    assert ent.tier_label(ent.TIER_TRIAL) == "Trial"
+    assert ent.tier_label(ent.TIER_CLOUD_PRO) == "Pro"
+    assert ent.tier_label(ent.TIER_PRO) == "Self-hosted Pro"
+    assert ent.tier_label(ent.TIER_ENTERPRISE) == "Enterprise"
+
+
+def test_tier_label_unknown_title_cases_id(ent):
+    # Unknown tier ids are title-cased (underscores become spaces) so the CTA
+    # still renders something readable rather than a raw snake_case id.
+    assert ent.tier_label("my_custom_tier") == "My Custom Tier"
+
+
+def test_tier_label_empty_falls_back_to_oss_label(ent):
+    # Empty / None resolves to the OSS floor label ("OSS") so upgrade CTAs
+    # don't render a blank string.
+    assert ent.tier_label("") == ent.TIER_LABELS[ent.TIER_OSS]
+    assert ent.tier_label(None) == ent.TIER_LABELS[ent.TIER_OSS]
+
+
+def test_tier_rank_orders_ladder(ent):
+    assert ent.tier_rank(ent.TIER_OSS) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_FREE) == 0
+    assert ent.tier_rank(ent.TIER_CLOUD_STARTER) == 1
+    assert ent.tier_rank(ent.TIER_TRIAL) == 2
+    assert ent.tier_rank(ent.TIER_CLOUD_PRO) == 2
+    assert ent.tier_rank(ent.TIER_PRO) == 2
+    assert ent.tier_rank(ent.TIER_ENTERPRISE) == 3
+
+
+def test_tier_rank_unknown_is_minus_one(ent):
+    # Unknown tiers return -1 so rank comparisons can distinguish "unknown"
+    # from the OSS floor (0) -- callers should treat -1 as below all rungs.
+    assert ent.tier_rank("nonsense_tier_xyz") == -1
+    assert ent.tier_rank("") == -1
+
+
+def test_tier_rank_case_insensitive(ent):
+    assert ent.tier_rank("CLOUD_STARTER") == 1
+    assert ent.tier_rank("Enterprise") == 3
+
+
+# -- min_tier_for_feature ----------------------------------------------------
+
+
+def test_min_tier_free_feature_is_oss(ent):
+    for feat in ("sessions", "transcripts", "usage", "brain", "nemo_governance"):
+        assert ent.min_tier_for_feature(feat) == ent.TIER_OSS
+
+
+def test_min_tier_starter_feature_is_cloud_starter(ent):
+    for feat in (
+        "multi_runtime",
+        "fleet",
+        "cloud_sync",
+        "all_channels",
+        "approval_queue",
+        "budget_limits",
+        "per_runtime_health_timeline",
+    ):
+        assert ent.min_tier_for_feature(feat) == ent.TIER_CLOUD_STARTER, feat
+
+
+def test_min_tier_pro_only_feature_is_cloud_pro(ent):
+    for feat in (
+        "per_run_waste_flags",
+        "self_evolve",
+        "eval_suite",
+        "tool_policy",
+        "otel_export",
+        "custom_alerts",
+        "custom_webhooks",
+        "custom_runtime_ingest",
+        "anomaly_detection",
+        "cost_optimizer",
+    ):
+        assert ent.min_tier_for_feature(feat) == ent.TIER_CLOUD_PRO, feat
+
+
+def test_min_tier_enterprise_only_feature_is_enterprise(ent):
+    for feat in (
+        "siem_export",
+        "sso",
+        "audit_logs",
+        "rbac",
+        "air_gapped_license",
+        "custom_data_residency",
+    ):
+        assert ent.min_tier_for_feature(feat) == ent.TIER_ENTERPRISE, feat
+
+
+def test_min_tier_unknown_feature_is_none(ent):
+    assert ent.min_tier_for_feature("nonsense_feature_xyz") is None
+    assert ent.min_tier_for_feature("") is None
+    assert ent.min_tier_for_feature(None) is None
+
+
+def test_min_tier_never_returns_trial(ent):
+    for feat in ent.ALL_FEATURES:
+        assert ent.min_tier_for_feature(feat) != ent.TIER_TRIAL
+
+
+def test_min_tier_grace_and_enforce_match(ent, monkeypatch):
+    grace = ent.min_tier_for_feature("custom_alerts")
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    importlib.reload(ent)
+    ent.invalidate()
+    assert ent.min_tier_for_feature("custom_alerts") == grace
+
+
+# -- min_tier_for_runtime ----------------------------------------------------
+
+
+def test_min_tier_free_runtime_is_oss(ent):
+    for rt in ("openclaw", "nemoclaw"):
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_OSS
+
+
+def test_min_tier_paid_runtime_is_cloud_starter(ent):
+    for rt in (
+        "claude_code",
+        "codex",
+        "cursor",
+        "aider",
+        "goose",
+        "opencode",
+        "qwen_code",
+        "hermes",
+        "picoclaw",
+        "nanoclaw",
+    ):
+        assert ent.min_tier_for_runtime(rt) == ent.TIER_CLOUD_STARTER, rt
+
+
+def test_min_tier_unknown_runtime_is_none(ent):
+    assert ent.min_tier_for_runtime("nonsense_runtime") is None
+    assert ent.min_tier_for_runtime("") is None
+    assert ent.min_tier_for_runtime(None) is None
+
+
+def test_min_tier_runtime_case_insensitive(ent):
+    assert ent.min_tier_for_runtime("CLAUDE_CODE") == ent.TIER_CLOUD_STARTER
+    assert ent.min_tier_for_runtime("OpenClaw") == ent.TIER_OSS
+
+
+# -- to_dict surface ---------------------------------------------------------
+
+
+def test_to_dict_carries_tier_label_and_rank(ent):
+    body = ent._oss_free().to_dict()
+    assert body["tier"] == ent.TIER_OSS
+    assert body["tier_label"] == "OSS"
+    assert body["tier_rank"] == 0
+
+
+def test_to_dict_paid_tier_label_and_rank(ent):
+    body = ent._build(ent.TIER_CLOUD_PRO, "cloud").to_dict()
+    assert body["tier_label"] == "Pro"
+    assert body["tier_rank"] == 2
+
+
+# -- /api/entitlement/min-tier -----------------------------------------------
+
+
+def test_endpoint_feature_free_returns_oss(client, ent):
+    rv = client.get("/api/entitlement/min-tier?feature=sessions")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["key"] == "feature"
+    assert body["value"] == "sessions"
+    assert body["free"] is True
+    assert body["min_tier"] == ent.TIER_OSS
+    assert body["tier_label"] == "OSS"
+    assert body["tier_rank"] == 0
+
+
+def test_endpoint_feature_starter(client, ent):
+    rv = client.get("/api/entitlement/min-tier?feature=multi_runtime")
+    body = rv.get_json()
+    assert rv.status_code == 200
+    assert body["free"] is False
+    assert body["min_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == "Starter"
+    assert body["tier_rank"] == 1
+
+
+def test_endpoint_feature_pro(client, ent):
+    rv = client.get("/api/entitlement/min-tier?feature=custom_alerts")
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_CLOUD_PRO
+    assert body["tier_rank"] == 2
+
+
+def test_endpoint_feature_enterprise(client, ent):
+    rv = client.get("/api/entitlement/min-tier?feature=siem_export")
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_ENTERPRISE
+    assert body["tier_rank"] == 3
+
+
+def test_endpoint_runtime_free(client, ent):
+    rv = client.get("/api/entitlement/min-tier?runtime=openclaw")
+    body = rv.get_json()
+    assert rv.status_code == 200
+    assert body["key"] == "runtime"
+    assert body["value"] == "openclaw"
+    assert body["free"] is True
+    assert body["min_tier"] == ent.TIER_OSS
+
+
+def test_endpoint_runtime_paid(client, ent):
+    rv = client.get("/api/entitlement/min-tier?runtime=claude_code")
+    body = rv.get_json()
+    assert body["min_tier"] == ent.TIER_CLOUD_STARTER
+    assert body["tier_label"] == "Starter"
+
+
+def test_endpoint_unknown_feature_404(client):
+    rv = client.get("/api/entitlement/min-tier?feature=nonsense")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["min_tier"] is None
+    assert body["tier_label"] is None
+    assert body["error"] == "unknown"
+
+
+def test_endpoint_unknown_runtime_404(client):
+    rv = client.get("/api/entitlement/min-tier?runtime=nonsense")
+    assert rv.status_code == 404
+    body = rv.get_json()
+    assert body["min_tier"] is None
+
+
+def test_endpoint_requires_exactly_one_arg(client):
+    rv = client.get("/api/entitlement/min-tier")
+    assert rv.status_code == 400
+    rv = client.get(
+        "/api/entitlement/min-tier?feature=sessions&runtime=openclaw"
+    )
+    assert rv.status_code == 400
+
+
+def test_endpoint_never_5xx_on_resolver_failure(client, ent, monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("synthetic")
+
+    monkeypatch.setattr(ent, "min_tier_for_feature", boom)
+    rv = client.get("/api/entitlement/min-tier?feature=multi_runtime")
+    assert rv.status_code == 200
+    body = rv.get_json()
+    assert body["min_tier"] is None
+    assert body["tier_label"] is None
+    assert body["key"] == "feature"
+    assert body["value"] == "multi_runtime"
+
+
+def test_endpoint_envelope_keys(client):
+    rv = client.get("/api/entitlement/min-tier?feature=sessions")
+    body = rv.get_json()
+    for key in ("key", "value", "free", "min_tier", "tier_label", "tier_rank"):
+        assert key in body, key


### PR DESCRIPTION
## What this changes

Adds `GET /api/entitlement/min-tier` -- a catalogue-derived endpoint for the locked-row upgrade CTA. Given `?feature=<id>` or `?runtime=<id>`, returns the cheapest purchasable tier that unlocks it in one fetch, so the CTA can render "Upgrade to Starter to unlock X" copy without walking the catalogue client-side.

Response shape:
```json
{ "key": "feature"|"runtime", "value": "<input>", "free": bool,
  "min_tier": "<tier id>"|null, "tier_label": "<label>"|null, "tier_rank": int|null }
```

- **400** when neither / both args are supplied
- **404** for unknown ids (neutral null envelope; caller can render "not available")
- **Never 5xxs**: resolver failure short-circuits to grace-shape null envelope

Backed by the existing `min_tier_for_feature` / `min_tier_for_runtime` catalogue helpers already in main. Catalogue-derived, so the answer is identical in grace and enforce mode.

## Why a new endpoint vs `/api/entitlement/required-tier`?

`required-tier` answers "what tier does *this user* need for X?" (user-context-aware, returns `allowed` + `upgrade_required`). `min-tier` answers "what's the cheapest tier that unlocks X?" (catalogue-only, no user-context). Different shapes, different callers.

## Tests

`tests/test_entitlement_min_tier.py` -- 30 tests covering:
- `tier_label` / `tier_rank` per known tier, case-insensitive, edge cases
- `min_tier_for_feature` per-tier table (free / Starter / Pro / Enterprise), no-Trial invariant, grace/enforce identity
- `min_tier_for_runtime` per-runtime table, case-insensitive, unknown returns `None`
- `to_dict` carries `tier_label` + `tier_rank` keys
- Endpoint: free/Starter/Pro/Enterprise feature, free/paid runtime, unknown 404, missing/both args 400, never-5xx contract, envelope-keys pin

Note: test assertions corrected against actual TIER_LABELS on current main (`TIER_PRO = "Self-hosted Pro"`, unknown rank = `-1`, empty label falls back to OSS label).

## Relationship to PR #3296

This PR salvages the route endpoint and tests from #3296, which had become conflicted because the `entitlements.py` infrastructure it also carried (tier constants, `tier_label`, `tier_rank`, `min_tier_for_feature`) had already landed on main via earlier PRs. Only the net-new content is included here.

## Operator verification checklist

- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier?feature=multi_runtime' | jq` -- expect `{"min_tier":"cloud_starter","tier_label":"Starter","tier_rank":1,"free":false,...}`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier?feature=custom_alerts' | jq` -- expect `"min_tier":"cloud_pro"`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier?feature=siem_export' | jq` -- expect `"min_tier":"enterprise"`
- [ ] `curl -s 'http://localhost:8900/api/entitlement/min-tier?runtime=claude_code' | jq` -- expect `"min_tier":"cloud_starter"`
- [ ] `curl -sw '%{http_code}\n' -o /dev/null 'http://localhost:8900/api/entitlement/min-tier?feature=nonsense'` -- expect `404`
- [ ] `curl -sw '%{http_code}\n' -o /dev/null 'http://localhost:8900/api/entitlement/min-tier'` -- expect `400`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018cokHw1Q6DN4Byots98s48)_