### PR TITLE
fix: identify Minimax provider in sandbox inference configs

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -170,6 +170,16 @@ def _resolve_ollama_host() -> str:
     return "http://localhost:11434"
 
 
+def _resolve_minimax_base_url() -> str:
+    """Return the active Minimax base URL from env var or the default.
+
+    Mirrors the MINIMAX_BASE_URL env var consumed by completeSimple()
+    in openclaw/plugin-sdk/llm. Falls back to the standard Minimax API.
+    """
+    val = os.environ.get("MINIMAX_BASE_URL", "").strip()
+    return val or "https://api.minimax.chat/v1"
+
+
 def _list_ollama_models(host: str) -> list:
     """Return available Ollama model names. Never raises; returns [] on failure.
 
@@ -331,6 +341,11 @@ def _sandbox_inference_configs() -> list:
                     entry["sandboxRuntimeKind"] = json_runtime_kind
                 out.append(entry)
                 continue
+            elif provider in ("minimax", "minimax-api"):
+                provider_key = "minimax"
+                primary = f"minimax/{model}" if model else ""
+                base_url = _resolve_minimax_base_url()
+                compat = "openai"
             else:
                 provider_key = _MANAGED
                 primary = f"{_MANAGED}/{model}" if model else ""

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -1488,6 +1488,10 @@ def _read_nemoclaw_sandbox_routing() -> list:
                 primary = f"anthropic/{model}" if model else ""
                 base_url = "https://inference.local"
                 api = "anthropic-messages"
+            elif provider in ("minimax", "minimax-api"):
+                provider_key = "minimax"
+                primary = f"minimax/{model}" if model else ""
+                base_url = os.environ.get("MINIMAX_BASE_URL", "").strip() or "https://api.minimax.chat/v1"
             else:
                 # Includes compatible-anthropic-endpoint + openai-completions
                 # (the common default) → managed "inference" provider.


### PR DESCRIPTION
Closes #3298

## What

Minimax-backed OpenClaw sandboxes were silently falling through to the default `"inference"` provider bucket in both `_sandbox_inference_configs()` (adapter layer) and `_read_nemoclaw_sandbox_routing()` (sync daemon). This meant `providerKey` was always `"inference"` and `inferenceBaseUrl` was always `https://inference.local/v1` for any Minimax sandbox — losing provider identity entirely.

## Changes

- **`clawmetry/adapters/openclaw.py`** — adds `_resolve_minimax_base_url()` helper (reads `MINIMAX_BASE_URL` env var, falls back to `https://api.minimax.chat/v1`) and an `elif provider in ("minimax", "minimax-api"):` branch in `_sandbox_inference_configs()` before the fallback `else`
- **`clawmetry/sync.py`** — mirrors the same `elif` branch in `_read_nemoclaw_sandbox_routing()` so the daemon's routing table is consistent with the adapter

Minimax uses an OpenAI-compatible API so `inferenceCompat` stays `"openai"`. Handling both `"minimax"` and `"minimax-api"` as provider strings covers potential harness variants.

## Test plan

- Confirm a `sandboxes.json` entry with `"provider": "minimax"` now produces `providerKey: "minimax"` and `inferenceBaseUrl: "https://api.minimax.chat/v1"` (or `MINIMAX_BASE_URL` if set) in the detection result
- Confirm all other provider branches (openai-api, anthropic-prod, ollama, default) are unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpVyA7AEF4pXZpjKsqRJ6L)_