### PR TITLE
feat(nemoclaw): ingest OpenShell OCSF sandbox audit logs into DuckDB

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -263,6 +263,42 @@ def _openshell_sandbox_ocsf_enabled(name: str) -> dict:
         return {}
 
 
+def _openshell_sandbox_logs(name: str, count: int = 20) -> list:
+    """Retrieve OCSF JSON audit log lines for a NemoClaw sandbox.
+
+    Arms OCSF output first (idempotent settings set), then calls
+    ``openshell logs <name> -n <count> --source all``.  Returns a list of
+    parsed OCSF event dicts; silently drops non-JSON lines.  Never raises;
+    returns ``[]`` when openshell is absent or any call fails.
+    """
+    try:
+        import shutil as _sh
+        if not _sh.which("openshell"):
+            return []
+        import subprocess as _sp
+        _sp.run(
+            ["openshell", "settings", "set", name,
+             "--key", "ocsf_json_enabled", "--value", "true"],
+            capture_output=True, text=True, timeout=5,
+        )
+        res = _sp.run(
+            ["openshell", "logs", name, "-n", str(count), "--source", "all"],
+            capture_output=True, text=True, timeout=10,
+        )
+        events = []
+        for line in (res.stdout or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except Exception:
+                pass
+        return events
+    except Exception:
+        return []
+
+
 def _sandbox_inference_configs() -> list:
     """Read per-sandbox inference config from ~/.nemoclaw/sandboxes.json.
 

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -2363,6 +2363,41 @@ def sync_sandbox_sessions_openshell(config: dict, state: dict) -> int:
                     sb_name, fname, _ce,
                 )
 
+        # OCSF audit log ingest — gap #3299.
+        # Only attempt when the sandbox has OCSF JSON output armed.
+        try:
+            from clawmetry.adapters.openclaw import (
+                _openshell_sandbox_ocsf_enabled,
+                _openshell_sandbox_logs,
+            )
+            if _openshell_sandbox_ocsf_enabled(sb_name).get("sandboxOcsfJsonEnabled"):
+                ocsf_events = _openshell_sandbox_logs(sb_name)
+                if ocsf_events:
+                    from clawmetry import local_store as _ls
+                    _store_obj = _ls.get_store()
+                    for idx, ev in enumerate(ocsf_events):
+                        uid = ev.get("uid") or ev.get("activity_id") or str(idx)
+                        ts_val = ev.get("time")
+                        ts_iso = (
+                            datetime.fromtimestamp(ts_val, tz=timezone.utc).isoformat()
+                            if isinstance(ts_val, (int, float))
+                            else datetime.now(timezone.utc).isoformat()
+                        )
+                        _store_obj.ingest({
+                            "id": f"nemoclaw-ocsf:{sb_name}:{uid}",
+                            "node_id": node_id,
+                            "agent_type": "nemoclaw",
+                            "agent_id": sb_name,
+                            "session_id": sb_name,
+                            "event_type": "sandbox.audit_log",
+                            "ts": ts_iso,
+                            "data": ev,
+                        })
+                    _store_obj.flush()
+                    log.debug("nemoclaw OCSF: ingested %d events for %s", len(ocsf_events), sb_name)
+        except Exception as _oe:
+            log.debug("nemoclaw OCSF ingest failed (non-fatal): %s", _oe)
+
     return total
 
 

--- a/routes/local_query.py
+++ b/routes/local_query.py
@@ -460,6 +460,33 @@ def http_search():
         return jsonify({"error": str(e)[:300]}), 500
 
 
+@bp_local_query.route("/api/local/sandbox-logs/<sandbox_name>", methods=["GET"])
+def http_sandbox_logs(sandbox_name: str):
+    """Return OCSF sandbox audit log events for a NemoClaw sandbox.
+
+    Queries ``events WHERE event_type='sandbox.audit_log' AND
+    agent_id=<sandbox_name>``. Optional query param: ``limit`` (int,
+    default 50, max 200).  Gap #3299.
+    """
+    try:
+        limit = min(int(request.args.get("limit", 50)), 200)
+        rows = local_store_via_daemon(
+            "query_events",
+            event_type="sandbox.audit_log",
+            agent_id=sandbox_name,
+            limit=limit,
+        )
+        if rows is None:
+            rows = _store().query_events(
+                event_type="sandbox.audit_log",
+                agent_id=sandbox_name,
+                limit=limit,
+            )
+        return jsonify({"events": rows or [], "sandbox": sandbox_name})
+    except Exception as e:
+        return jsonify({"error": str(e)[:300]}), 500
+
+
 @bp_local_query.route("/api/local/query", methods=["POST"])
 def http_query():
     """Generic shape-dispatched endpoint. Mirrors the WS relay frame format,

--- a/tests/test_obs_gap_nemoclaw_ocsf_3299.py
+++ b/tests/test_obs_gap_nemoclaw_ocsf_3299.py
@@ -1,0 +1,106 @@
+"""Tests for #3299 — _openshell_sandbox_logs retrieves OCSF JSON audit log
+lines for a NemoClaw sandbox and the sync hook ingests them into DuckDB.
+"""
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from clawmetry.adapters.openclaw import _openshell_sandbox_logs
+
+
+# -- _openshell_sandbox_logs --------------------------------------------------
+
+def test_logs_returns_empty_when_openshell_absent(monkeypatch):
+    """No openshell binary -> [] with no exception."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+    assert _openshell_sandbox_logs("alpha") == []
+
+
+def test_logs_calls_settings_set_and_logs(monkeypatch):
+    """Both 'settings set' and 'logs' commands are invoked for the sandbox."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(" ".join(str(c) for c in cmd[1:]))
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    _openshell_sandbox_logs("deepagents-code")
+
+    assert "settings set deepagents-code --key ocsf_json_enabled --value true" in calls
+    assert "logs deepagents-code -n 20 --source all" in calls
+
+
+def test_logs_parses_json_lines(monkeypatch):
+    """Valid JSON lines are returned as parsed dicts."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    ev1 = {"uid": "abc", "time": 1700000001, "activity": "exec"}
+    ev2 = {"uid": "def", "time": 1700000002, "activity": "net"}
+    output = "\n".join([json.dumps(ev1), json.dumps(ev2)]) + "\n"
+
+    def fake_run(cmd, **kw):
+        if cmd[1] == "logs":
+            return type("R", (), {"stdout": output})()
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = _openshell_sandbox_logs("alpha")
+    assert result == [ev1, ev2]
+
+
+def test_logs_drops_non_json_lines(monkeypatch):
+    """Non-JSON lines are silently skipped; valid JSON lines still returned."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    ev = {"uid": "xyz", "time": 1700000001}
+    output = "not-json\n" + json.dumps(ev) + "\nalso not json\n"
+
+    def fake_run(cmd, **kw):
+        if cmd[1] == "logs":
+            return type("R", (), {"stdout": output})()
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = _openshell_sandbox_logs("beta")
+    assert result == [ev]
+
+
+def test_logs_empty_output_returns_empty(monkeypatch):
+    """Empty openshell logs output -> []."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+
+    def fake_run(cmd, **kw):
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert _openshell_sandbox_logs("gamma") == []
+
+
+def test_logs_subprocess_error_returns_empty(monkeypatch):
+    """subprocess.run failure -> [] never raises."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+
+    def boom(*a, **kw):
+        raise OSError("binary broken")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert _openshell_sandbox_logs("alpha") == []
+
+
+def test_logs_respects_count_param(monkeypatch):
+    """count parameter is forwarded to the -n flag."""
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/openshell")
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(list(cmd))
+        return type("R", (), {"stdout": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    _openshell_sandbox_logs("alpha", count=42)
+
+    logs_call = next(c for c in calls if "logs" in c)
+    n_idx = logs_call.index("-n")
+    assert logs_call[n_idx + 1] == "42"


### PR DESCRIPTION
Closes #3299

## Summary

- **`clawmetry/adapters/openclaw.py`** — adds `_openshell_sandbox_logs(name, count=20)`: arms OCSF output (`openshell settings set <name> --key ocsf_json_enabled --value true`), fetches `openshell logs <name> -n <count> --source all`, JSON-parses each line. Never raises; `[]` when openshell absent.
- **`clawmetry/sync.py`** — hooks into `sync_sandbox_sessions_openshell`: after the JSONL session scan per sandbox, checks `sandboxOcsfJsonEnabled` and ingests OCSF events into the existing `events` table as `{agent_type='nemoclaw', event_type='sandbox.audit_log'}`. Non-fatal — OCSF failures are logged at DEBUG only.
- **`routes/local_query.py`** — adds `GET /api/local/sandbox-logs/<sandbox_name>` querying `events WHERE event_type='sandbox.audit_log' AND agent_id=<sandbox_name>` via daemon proxy with direct-open fallback. Consistent with all other `/api/local/*` endpoints.

## Test plan

- [ ] `python -m pytest tests/test_obs_gap_nemoclaw_ocsf_3299.py -v` — 7 tests: absent binary returns `[]`, both `settings set` and `logs` commands called, JSON parsed, non-JSON lines dropped, subprocess error safe, `count` param forwarded.
- [ ] `python -m pytest tests/test_obs_gap_nemoclaw_ocsf_3274.py -v` — 10 prior tests still pass (no regression in `_openshell_sandbox_ocsf_enabled`).
- [ ] Syntax: `python -m py_compile clawmetry/adapters/openclaw.py clawmetry/sync.py routes/local_query.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvYkpjSJ2iWQsFqky3xBmu)_