### PR TITLE
fix(tests): green the 4 license tests left failing after #3314

### DIFF
--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -273,6 +273,10 @@ def _fake_entitlement(monkeypatch, L, *, entitled, pro_available=True):
     calls = {"download": 0, "entitlement": 0}
 
     class _Resp(io.BytesIO):
+        # urllib's real HTTPResponse always exposes .headers; the wheel
+        # downloader reads Content-Disposition to keep the PEP-427 filename.
+        headers: dict = {}
+
         def __enter__(self):
             return self
 
@@ -341,12 +345,22 @@ def test_auto_provision_never_raises_on_install_failure(prov, monkeypatch):
 
 
 def test_auto_provision_idempotent_when_pro_present(prov, monkeypatch):
+    """When the installed pro version is >= the wheel the server is serving,
+    no re-install happens. The wheel itself is still downloaded every time --
+    that re-validate-on-every-connect policy is intentional (see the comment
+    on ``_provision_pro_wheel``: an installed pro never used to upgrade, so a
+    fix in 0.3.4 sat unused on nodes still pinned to 0.3.3)."""
     L = prov.L
     calls = _fake_entitlement(monkeypatch, L, entitled=True)
     monkeypatch.setattr(L, "_pro_installed_version", lambda: "0.2.0")
+    # Pin the wheel's advertised version <= the installed version so
+    # _provision_pro_wheel short-circuits before re-installing. We have to
+    # stub the parser because the fake `PK\x03\x04fake-wheel-bytes` body
+    # isn't a real PEP-427 wheel and would otherwise parse to None.
+    monkeypatch.setattr(L, "_wheel_file_version", lambda _path: "0.2.0")
     installed, msg = L.auto_provision_pro("cm_prouser", node_id="n1")
     assert installed is True
-    assert calls["download"] == 0  # already current -> no re-download
+    assert calls["download"] == 1  # re-validates with the server every call
     assert "already installed" in msg
 
 

--- a/tests/test_license_audit.py
+++ b/tests/test_license_audit.py
@@ -49,9 +49,21 @@ def _payload(tier="pro", nodes=4, exp_delta=365 * 86400, sub="acct_test"):
 def lic(monkeypatch, tmp_path):
     """Hermetic license fixture: ephemeral keypair, tmp license path, tmp
     audit DB. Mirrors the fixture in test_license.py / test_license_api.py
-    so behavioural pins stay symmetric."""
+    so behavioural pins stay symmetric.
+
+    Also isolates the entitlements module's resolver state -- some other
+    tests in the suite ``importlib.reload(clawmetry.entitlements)`` after
+    pointing ``HOME`` at a tmp_path and write a ``cloud_plan.json`` into
+    it. pytest keeps the last few tmp_path roots, so the module-level
+    ``_CLOUD_PLAN_CACHE`` constant can still resolve to a real file with
+    a paid ``plan`` value when this fixture runs later in the session.
+    Anchoring it (and ``_LICENSE_PATH``) at the per-test tmp_path makes
+    deactivate-then-resolve correctly fall back to OSS regardless of
+    cross-test leakage, and the in-process resolver cache is busted both
+    on entry and exit."""
     import clawmetry.license as L
     import clawmetry.audit as A
+    import clawmetry.entitlements as e
 
     priv, pub_pem = _keypair()
     monkeypatch.setattr(L, "_PUBLIC_KEY_PEM", pub_pem)
@@ -60,11 +72,17 @@ def lic(monkeypatch, tmp_path):
     monkeypatch.delenv("CLAWMETRY_LICENSE_SERVER", raising=False)
     monkeypatch.delenv("CLAWMETRY_INGEST_URL", raising=False)
     monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    # Point the entitlements resolver at the same tmp paths so a leaked
+    # cloud_plan.json from another test can't override the deactivate path.
+    monkeypatch.setattr(e, "_LICENSE_PATH", str(tmp_path / "license.key"))
+    monkeypatch.setattr(e, "_CLOUD_PLAN_CACHE", str(tmp_path / "cloud_plan.json"))
+    e.invalidate()
     # Point the audit DB at a per-test file and reset the "initialised" guard
     # so the schema is rebuilt against the fresh DB.
     monkeypatch.setenv("CLAWMETRY_AUDIT_DB", str(tmp_path / "audit.db"))
     A._initialised.clear()
-    return SimpleNamespace(L=L, A=A, priv=priv)
+    yield SimpleNamespace(L=L, A=A, priv=priv)
+    e.invalidate()
 
 
 def _audit_rows(A, event_type: str | None = None) -> list[dict]:


### PR DESCRIPTION
## Summary

PR #3314 ("restore 18 route handlers") noted 4 license tests still failing
after merge. All 4 root-cause to test-harness bugs, not production code,
so this PR is tests-only.

  tests/test_entitlement*.py + tests/test_entitlements*.py + tests/test_license*.py
  before: **1442 passed / 4 failed**
  after:  **1446 passed / 0 failed**

## Root causes

### 1. `_Resp` mock missing `.headers`  (2 of 4 failures)

`tests/test_license.py::_fake_entitlement` defines a `_Resp(io.BytesIO)` to
stand in for an HTTP response, but doesn't expose a `.headers` attribute.
The very first thing `clawmetry.license._download_wheel` does after
`urlopen()` is `resp.headers.get("Content-Disposition", "")` to preserve
the PEP-427 filename — that raised `AttributeError`, was swallowed by the
function's never-raise guard, and silently returned `None`. The
`entitled_account_downloads_and_installs` and
`never_raises_on_install_failure` tests both treated that as a "wheel
download didn't happen" outcome and failed. Real
`http.client.HTTPResponse` always has `.headers`, so the fix is to add
the empty dict on the mock.

### 2. `idempotent_when_pro_present` predates the re-validate policy (1 of 4)

`clawmetry/license.py::_provision_pro_wheel` carries an explicit comment
explaining a deliberate policy change: it now **always** downloads the
wheel from the server every connect, then short-circuits the `pip install`
only if the *wheel's parsed version* is `<= _pro_installed_version()`.
The comment is worth quoting because it's the reason the old behaviour
was abandoned:

> Re-validate against the server EVERY time: download the (small ~140KB)
> wheel and install it ONLY when it is strictly newer than what's
> installed. The old code returned here whenever pro was importable, so
> an installed pro NEVER upgraded -- rolling a new wheel to the cloud
> reached nobody (the claude_code ai-title fix in 0.3.4 sat unused
> because every node kept the installed 0.3.3).

The test still asserted the **old** policy (`calls["download"] == 0`).
Updated the test to:

- assert `calls["download"] == 1` (re-validate happens unconditionally)
- stub `_wheel_file_version` to return `"0.2.0"` so the fake wheel body
  (literally `b"PK\x03\x04fake-wheel-bytes"`, not a real PEP-427 wheel)
  takes the "wheel <= installed → skip pip install" branch deterministically
- keep the existing "already installed" message assertion

### 3. `test_deactivate_clears_entitlement_cache` test-isolation flake (1 of 4)

Passes alone, fails inside the broader `test_entitlement*/test_license*`
run. The bisect chases a real bug in the test fixture, not in
`license.deactivate`:

- `tests/test_entitlement_api.py::test_api_entitlement_paid_tier_grants_all_runtimes`
  is parametrised over `trial / pro / cloud_pro`. Each parameter does:
  `monkeypatch.setenv("HOME", str(tmp_path))` then
  `importlib.reload(clawmetry.entitlements)` so the module-level
  `_CLOUD_PLAN_CACHE = os.path.expanduser("~/.clawmetry/cloud_plan.json")`
  rebinds to `tmp_path/.clawmetry/cloud_plan.json`, then writes the
  paid-plan file at that path.
- When the test ends, monkeypatch reverts `HOME` — but it does **not**
  reload `entitlements`. The module-level `_CLOUD_PLAN_CACHE` constant
  stays bound to the tmp_path.
- pytest keeps the last few `tmp_path` roots on disk by default. So
  when `test_deactivate_clears_entitlement_cache` later calls
  `e.get_entitlement()`, the resolver's `_read_cloud_plan()` opens that
  still-existing tmp file, reads `plan: trial` (or pro / cloud_pro,
  whichever was the last parametrise round), and returns `is_paid=True`
  instead of the OSS-free fallback the assertion expects.

Fixed by hardening the `lic` fixture in `tests/test_license_audit.py`:

- monkeypatch `entitlements._LICENSE_PATH` and `entitlements._CLOUD_PLAN_CACHE`
  at this test's own `tmp_path` so neither can be hijacked by a stale
  module-level binding written by a different test
- `e.invalidate()` on entry and on teardown so the in-process resolver
  cache can't carry over either

This makes the audit suite robust against any future module-level
leakage from elsewhere in the suite without papering over the
`test_entitlement_api.py` reload pattern.

## Diff scope

Tests only. No `clawmetry/`, `routes/`, `dashboard.py`, `static/`,
`templates/` changes. **Stays in GRACE** — no entitlement gate flipped,
no behaviour change visible to a running install.

|File|+/-|What|
|---|---|---|
|`tests/test_license.py`|+15 / -1|add `_Resp.headers`, update idempotent test for the re-validate policy|
|`tests/test_license_audit.py`|+19 / -2|harden `lic` fixture against `_CLOUD_PLAN_CACHE` / `_LICENSE_PATH` module-state leakage|

## Local operator verification checklist

I can't run the live daemon, hit the cloud snapshot, or open a browser
from this sandbox — the steps below are for you. (Tests-only change, so
the verification is mostly "did the targeted test universe go green";
no `~/.clawmetry/lib/...` site-packages copy is needed unless you want
to dry-run before merging.)

- [ ] `git fetch origin fix/license-test-isolation && git checkout fix/license-test-isolation`
- [ ] `python3 -m pytest tests/test_license.py -q` → **31 passed** (was 28 / 3 failed)
- [ ] `python3 -m pytest tests/test_entitlement*.py tests/test_entitlements*.py tests/test_license*.py -q` → **1446 passed** (was 1442 / 4 failed)
- [ ] CI green on this branch
- [ ] (optional) Reproduce the deactivate flake on `main` first to confirm:
      `python3 -m pytest tests/test_entitlement_api.py::test_api_entitlement_paid_tier_grants_all_runtimes tests/test_license_audit.py::test_deactivate_clears_entitlement_cache` → 1 failed on main, all-pass on this branch.
- [ ] Once verified, flip out of draft and merge — this fire is leaving
      it draft per the routine's rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rBDMt1sPPih1wQPSYcC9F

---
_Generated by [Claude Code](https://claude.ai/code/session_018rBDMt1sPPih1wQPSYcC9F)_