### PR TITLE
fix(daemon): local-only heartbeat spam floods the events table and buries agent activity

### DIFF
--- a/clawmetry/local_store.py
+++ b/clawmetry/local_store.py
@@ -5348,11 +5348,22 @@ class LocalStore:
         since: str | None = None,
         until: str | None = None,
         runtime: str | None = None,
+        exclude_daemon: bool = False,
         limit: int = 500,
     ) -> list[dict[str, Any]]:
-        """Read events. Defaults to most recent first."""
+        """Read events. Defaults to most recent first.
+
+        ``exclude_daemon=True`` drops ClawMetry's own diagnostics (the
+        daemon-error -> DuckDB tee, PRD #1133: agent_id='clawmetry-daemon' /
+        event_type LIKE 'daemon.%') at the SQL level, so a noisy daemon can't
+        bury the user's real agent events inside the fetch ``limit`` window
+        (the Brain feed passes this).
+        """
         clauses: list[str] = []
         params: list[Any] = []
+        if exclude_daemon:
+            clauses.append("(agent_id IS DISTINCT FROM 'clawmetry-daemon')")
+            clauses.append("(event_type IS NULL OR event_type NOT LIKE 'daemon.%')")
         if session_id:
             clauses.append("session_id = ?")
             params.append(session_id)

--- a/clawmetry/sync.py
+++ b/clawmetry/sync.py
@@ -17629,7 +17629,19 @@ def run_daemon() -> None:
 
             now = time.time()
             if now - last_heartbeat > heartbeat_interval:
-                if send_heartbeat(config):
+                from clawmetry.config import is_cloud_disabled as _hb_cloud_off
+                if _hb_cloud_off():
+                    # Local-only mode (#3281): there is no cloud to heart-beat.
+                    # Skip the attempt entirely. Otherwise send_heartbeat returns
+                    # falsy every cycle, consecutive_hb_failures climbs without
+                    # bound, and we log CRITICAL "node appears offline in cloud"
+                    # every ~15s -- which the daemon-error tee (PRD #1133) writes
+                    # into the capped events table, EVICTING the user's real
+                    # agent events from the Brain feed. Local-only must be silent.
+                    consecutive_hb_failures = 0
+                    last_heartbeat = now
+                    heartbeat_interval = HEARTBEAT_INTERVAL_SLOW
+                elif send_heartbeat(config):
                     if consecutive_hb_failures > 0:
                         log.info(
                             f"Heartbeat recovered after {consecutive_hb_failures} consecutive failures"

--- a/routes/brain.py
+++ b/routes/brain.py
@@ -279,7 +279,10 @@ def _try_local_store_brain(limit, include_artifacts, since=None):
     cap (issue #1448) is enforced at the SQL layer.
     """
     rows = None
-    qkwargs = {"limit": limit}
+    # exclude_daemon: drop ClawMetry's own daemon diagnostics at the SQL level
+    # so a noisy/erroring daemon can't bury the user's real agent events inside
+    # the fetch limit window (the post-loop filter below is belt-and-braces).
+    qkwargs = {"limit": limit, "exclude_daemon": True}
     if since:
         qkwargs["since"] = since
     # Issue #1088: cross-process fast-path. The standard install runs daemon

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -815,3 +815,29 @@ def test_query_session_errors_edge(store):
     e1 = next(e for e in errs if e["span_id"] == "e1")
     assert e1["parent_span_id"] == "p1" and e1["tool_name"] == "browser"
     assert store.query_session_errors("") == []
+
+
+# ── exclude_daemon: keep ClawMetry's own diagnostics out of the agent feed ──
+
+def test_query_events_exclude_daemon(store):
+    """exclude_daemon drops agent_id='clawmetry-daemon' / event_type='daemon.*'
+    at the SQL level so a noisy/erroring daemon can't bury real agent events
+    inside the fetch limit window (the Brain feed depends on this)."""
+    store.ingest(_ev(id="real-1", agent_id="main", event_type="tool_call",
+                     session_id="sess-real"))
+    store.ingest(_ev(id="daemon-err", agent_id="clawmetry-daemon",
+                     event_type="daemon.error", session_id=""))
+    store.ingest(_ev(id="daemon-metric", agent_id="clawmetry-daemon",
+                     event_type="daemon.metric", session_id=""))
+    _wait_for_flush(store)
+
+    # Without the flag, daemon diagnostics are included.
+    all_ids = {e["id"] for e in store.query_events(limit=50)}
+    assert {"real-1", "daemon-err", "daemon-metric"} <= all_ids
+
+    # With exclude_daemon, only the real agent event survives.
+    kept = store.query_events(limit=50, exclude_daemon=True)
+    kept_ids = {e["id"] for e in kept}
+    assert "real-1" in kept_ids
+    assert "daemon-err" not in kept_ids
+    assert "daemon-metric" not in kept_ids


### PR DESCRIPTION
From a real local-only install: the Brain tab showed "No recent OpenClaw activity" with a "data feed stopped" banner, even though a real OpenClaw session existed. Two coupled local-only bugs:

## 1. Local-only mode still ran the cloud heartbeat loop
Every ~15s `send_heartbeat()` returned falsy (cloud disabled by the `nocloud` marker), `consecutive_hb_failures` climbed without bound, and the daemon logged `CRITICAL: N consecutive heartbeat failures — node appears offline in cloud` (caught at **1763** consecutive on the reporter's box). There is no cloud in local-only mode, so it must be silent. `run_daemon` now **skips the heartbeat entirely when `is_cloud_disabled()`**.

## 2. Those CRITICAL logs flooded the events table and buried real activity
The daemon-error tee (PRD #1133) writes ERROR logs into the events table. On the capped events table the every-15s heartbeat errors crowded out (by recency) the user's real agent events, so the Brain feed — which fetches the newest N rows — saw only daemon noise. `query_events` now accepts **`exclude_daemon=True`** (drops `agent_id='clawmetry-daemon'` / `event_type LIKE 'daemon.%'` in SQL), and the Brain feed passes it, so real agent events surface regardless of daemon noise. (Belt-and-braces with the post-fetch filter from #3286.)

## Verified live
On the reporter's local-only install (patched + restarted): heartbeat CRITICAL spam gone, and the Brain feed now shows the real conversation:
```
USER       hello, how are you?
ASSISTANT  Hey Vivek. Doing well, thanks. ...
```
instead of an empty feed.

## Test
`tests/test_local_store.py::test_query_events_exclude_daemon`.

Note: third in the local-only fix series after #3285 (daemon crash) and #3286 (Brain uncap + daemon-noise display filter). All three stem from local-only mode being newly the default (#3281).

🤖 Generated with [Claude Code](https://claude.com/claude-code)