### PR TITLE
fix(openclaw): surface /think reasoning-level tier in Session and Event extra

### DIFF
--- a/clawmetry/adapters/openclaw.py
+++ b/clawmetry/adapters/openclaw.py
@@ -960,6 +960,11 @@ class OpenClawAdapter(AgentAdapter):
             _fm = s.get("fastMode") if s.get("fastMode") is not None else s.get("isFastMode")
             if _fm is not None:
                 extra["fastMode"] = bool(_fm)
+            # /think reasoning-level tier (#3324): PR #94067 stores the active
+            # level (light/medium/deep) on session records; surface when present.
+            _think_level = s.get("thinkLevel") or s.get("reasoningLevel")
+            if _think_level is not None:
+                extra["thinkLevel"] = _think_level
             tok_total = int(s.get("totalTokens") or 0)
             tok_in = int(s.get("inputTokens") or 0)
             tok_out = int(s.get("outputTokens") or 0)
@@ -1124,6 +1129,12 @@ class OpenClawAdapter(AgentAdapter):
                                 if _fmval is not None:
                                     extra["fastMode"] = bool(_fmval)
                                     break
+                            # /think reasoning-level tier (#3324): PR #94067 stores
+                            # the active level (light/medium/deep) on model-turn
+                            # records; try camelCase then snake_case.
+                            _tl = obj.get("thinkLevel") or obj.get("reasoningLevel")
+                            if _tl is not None:
+                                extra["thinkLevel"] = _tl
                             # Normalized TTFR keys (#3054): also write ttfr_ms /
                             # slow_reply so callers that read the normalized form
                             # don't need to know the original key spellings.


### PR DESCRIPTION
Closes #3324

## Summary
- Reads `thinkLevel`/`reasoningLevel` from session records in `list_sessions()` and exposes as `extra["thinkLevel"]` when present
- Reads the same field from model-turn data blobs in `list_events()`, trying camelCase then snake_case
- Purely additive — same conditional guard pattern as `fastMode` (#3322), no schema changes

## Test plan
- [ ] Confirm no lint errors introduced in `clawmetry/adapters/openclaw.py` (`make lint` shows 0 new errors)
- [ ] In a session that used `/think medium` or `/think deep`, verify `extra.thinkLevel` appears in the `/api/sessions` and event stream responses
- [ ] In a plain session (no `/think`), verify `thinkLevel` is absent from `extra` (field is guarded by `if _think_level is not None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xwt6JaC3pEV19QF9F7sguj)_