### PR TITLE
feat(entitlement): lock_reason_at + /api/entitlement/lock-reason-at

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -3970,3 +3970,74 @@ def runtime_spec_at(tier: str, runtime: str) -> dict | None:
     except Exception as exc:
         logger.warning("entitlements: runtime_spec_at row build failed: %s", exc)
         return None
+
+
+def lock_reason_at(
+    perspective_tier: str, item: str, *, kind: str | None = None
+) -> str | None:
+    """What-if sibling of :func:`lock_reason`: the lock-reason string for
+    ``item`` (interpreted as ``kind``) computed as if the install were on
+    ``perspective_tier``, NOT against the live resolved entitlement.
+
+    Pairs with :func:`feature_spec_at` / :func:`runtime_spec_at` /
+    :func:`tier_spec_at` -- where those return the catalog row at a
+    hypothetical tier, this returns the human-readable lock sentence the
+    paywall surface renders ("``'sso' feature requires Cloud Pro or
+    above.``"). Lets a pricing-comparison tooltip preview the lock copy
+    a downgrade would surface BEFORE the user commits, without
+    consulting the live resolver.
+
+    Synthesises a fresh :class:`Entitlement` for ``perspective_tier``
+    with ``grace=False`` and the per-tier capacity caps
+    (``_TIER_NODE_LIMIT`` / ``_TIER_CHANNEL_LIMIT`` /
+    ``_TIER_RETENTION_DAYS`` flow off ``self.tier`` already), so the
+    capacity axes (``channels`` / ``retention_days`` / ``nodes``)
+    resolve correctly at the hypothetical tier rather than against the
+    OSS single-node default the unparameterised ``_hypothetical_entitlement``
+    uses for feature/runtime-only callers.
+
+    ``kind`` follows :meth:`Entitlement.lock_reason`: ``"feature"`` /
+    ``"runtime"`` / ``"channels"`` / ``"retention_days"`` / ``"nodes"``
+    explicitly; ``None`` lets the inner method infer ``feature`` vs
+    ``runtime`` from the id (capacity axes can't be inferred, so pass
+    ``kind=`` for those).
+
+    Returns ``None`` for empty / unknown perspective tier (caller renders
+    "unknown tier" / 404), for ids the inner method considers
+    unlockable (free features / runtimes, empty keys, malformed
+    capacity counts), or when the perspective is unenforceable. Never
+    raises: a synthesis failure short-circuits to ``None`` so the
+    tooltip silently hides instead of crashing the UI.
+    """
+    try:
+        t = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not t or t not in _TIER_ORDER:
+        return None
+    try:
+        paid_feats = _TIER_FEATURES.get(t, frozenset())
+        rts = (
+            (FREE_RUNTIMES | PAID_RUNTIMES)
+            if t in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        ent = Entitlement(
+            tier=t,
+            source="hypothetical",
+            node_limit=_TIER_NODE_LIMIT.get(t, _FREE_NODE_LIMIT),
+            expiry=None,
+            features=FREE_FEATURES | paid_feats,
+            runtimes=rts,
+            grace=False,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: lock_reason_at synthesis failed: %s", exc
+        )
+        return None
+    try:
+        return ent.lock_reason(item, kind=kind)
+    except Exception as exc:
+        logger.warning("entitlements: lock_reason_at lookup failed: %s", exc)
+        return None

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -1765,6 +1765,207 @@ def api_entitlement_lock_reason():
         )
 
 
+@bp_entitlement.route("/api/entitlement/lock-reason-at")
+def api_entitlement_lock_reason_at():
+    """``GET /api/entitlement/lock-reason-at?tier=<perspective>&<axis>=<id>``
+    -- what-if sibling of ``/api/entitlement/lock-reason``: the lock-row
+    for one item computed as if the install were on ``perspective_tier``,
+    NOT against the live resolved entitlement.
+
+    Same row shape as ``/api/entitlement/lock-reason`` -- ``key``,
+    ``kind``, ``reason``, ``locked``, ``allowed``, ``required_tier``,
+    ``required_tier_label``, ``required_tier_rank``, ``current_tier``
+    (the perspective), ``current_tier_rank``, ``upgrade_required``.
+    Lets a pricing-comparison tooltip preview the exact lock sentence a
+    downgrade-to-target would surface in one round-trip, before the
+    user commits.
+
+    Pairs with :func:`api_entitlement_feature_spec_at` /
+    :func:`api_entitlement_runtime_spec_at`: those return the catalog
+    row at a hypothetical tier; this returns the lock copy and
+    ``upgrade_required`` cue the paywall renders against that tier.
+
+    Exactly one of ``feature=`` / ``runtime=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` must be supplied.
+
+    - **400** when ``tier=`` is missing / blank, when no axis is
+      supplied, or when more than one axis is supplied
+    - **404** when ``tier`` is unknown (not in
+      :data:`entitlements._TIER_ORDER`). The body carries ``which`` so a
+      caller can render the right "unknown ..." message.
+    - **Never 5xxs**: a synthesis failure short-circuits to the
+      grace-shape row (``reason=null`` / ``locked=false`` /
+      ``allowed=true``) so the UI keeps rendering.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+        feature = (request.args.get("feature") or "").strip().lower()
+        runtime_in = (request.args.get("runtime") or "").strip().lower()
+        (
+            channels_present,
+            channels_ok,
+            channels_n,
+            channels_raw,
+        ) = _parse_capacity_arg("channels")
+        (
+            retention_present,
+            retention_ok,
+            retention_n,
+            retention_raw,
+        ) = _parse_capacity_arg("retention_days")
+        (
+            nodes_present,
+            nodes_ok,
+            nodes_n,
+            nodes_raw,
+        ) = _parse_capacity_arg("nodes")
+
+        supplied = [
+            bool(feature),
+            bool(runtime_in),
+            channels_present,
+            retention_present,
+            nodes_present,
+        ]
+        n_supplied = sum(1 for s in supplied if s)
+        if n_supplied == 0:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply exactly one of feature=<id>, runtime=<id>, "
+                            "channels=<int>, retention_days=<int>, or "
+                            "nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+        if n_supplied > 1:
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply only one of feature=, runtime=, channels=, "
+                            "retention_days=, or nodes="
+                        )
+                    }
+                ),
+                400,
+            )
+
+        if feature:
+            key, kind = feature, "feature"
+            required = _ent.min_tier_for_feature(feature)
+            reason = _ent.lock_reason_at(tier_in, feature, kind=kind)
+            allowed = reason is None
+        elif runtime_in:
+            rt = _ent.canonical_runtime(runtime_in)
+            key, kind = rt or runtime_in, "runtime"
+            required = _ent.min_tier_for_runtime(rt) if rt else None
+            reason = _ent.lock_reason_at(tier_in, rt or runtime_in, kind=kind)
+            allowed = reason is None
+        elif channels_present:
+            key, kind = channels_raw, "channels"
+            if channels_ok:
+                required = _ent.min_tier_for_channel_count(channels_n)
+                reason = _ent.lock_reason_at(
+                    tier_in, str(channels_n), kind=kind
+                )
+                allowed = reason is None
+            else:
+                required = None
+                reason = None
+                allowed = True
+        elif retention_present:
+            key, kind = retention_raw, "retention_days"
+            if retention_ok:
+                required = _ent.min_tier_for_retention_window(retention_n)
+                reason = _ent.lock_reason_at(
+                    tier_in, str(retention_n), kind=kind
+                )
+                allowed = reason is None
+            else:
+                required = None
+                reason = None
+                allowed = True
+        else:
+            key, kind = nodes_raw, "nodes"
+            if nodes_ok:
+                required = _ent.min_tier_for_node_count(nodes_n)
+                reason = _ent.lock_reason_at(tier_in, str(nodes_n), kind=kind)
+                allowed = reason is None
+            else:
+                required = None
+                reason = None
+                allowed = True
+
+        cur_rank = _ent.tier_rank(tier_in)
+        req_rank = _ent.tier_rank(required) if required else -1
+        required_label = _ent.tier_label(required) if required else None
+        return jsonify(
+            {
+                "key": key,
+                "kind": kind,
+                "reason": reason,
+                "locked": reason is not None,
+                "allowed": allowed,
+                "required_tier": required,
+                "required_tier_label": required_label,
+                "required_tier_rank": req_rank,
+                "current_tier": tier_in,
+                "current_tier_rank": cur_rank,
+                "upgrade_required": bool(required) and req_rank > cur_rank,
+            }
+        )
+    except Exception as exc:
+        logger.warning("api_entitlement_lock_reason_at: error: %s", exc)
+        feature = (request.args.get("feature") or "").strip().lower()
+        runtime_in = (request.args.get("runtime") or "").strip().lower()
+        channels_raw = (request.args.get("channels") or "").strip()
+        retention_raw = (request.args.get("retention_days") or "").strip()
+        nodes_raw = (request.args.get("nodes") or "").strip()
+        if feature:
+            key, kind = feature, "feature"
+        elif runtime_in:
+            key, kind = runtime_in, "runtime"
+        elif channels_raw:
+            key, kind = channels_raw, "channels"
+        elif retention_raw:
+            key, kind = retention_raw, "retention_days"
+        elif nodes_raw:
+            key, kind = nodes_raw, "nodes"
+        else:
+            key, kind = "", ""
+        return jsonify(
+            {
+                "key": key,
+                "kind": kind,
+                "reason": None,
+                "locked": False,
+                "allowed": True,
+                "required_tier": None,
+                "required_tier_label": None,
+                "required_tier_rank": -1,
+                "current_tier": tier_in,
+                "current_tier_rank": 0,
+                "upgrade_required": False,
+            }
+        )
+
+
 def _parse_csv_arg(name: str) -> list[str]:
     """Parse a comma-separated query arg into a normalised id list.
 

--- a/tests/test_entitlement_lock_reason_at.py
+++ b/tests/test_entitlement_lock_reason_at.py
@@ -1,0 +1,605 @@
+"""Tests for ``lock_reason_at(perspective_tier, item, kind=...)`` +
+``GET /api/entitlement/lock-reason-at``.
+
+What-if sibling of :func:`lock_reason` -- the lock-reason string for an
+item computed as if the install were on ``perspective_tier``, not
+against the live resolved entitlement. Lets a pricing-comparison
+tooltip preview the exact lock sentence a downgrade-to-target would
+surface in one round-trip, before the user commits.
+
+Pins:
+
+* the helper is independent of the live resolver -- grace mode,
+  enforcement, license cache, and cloud_plan.json all have no effect
+* every tier in ``_TIER_ORDER`` resolves; unknown / empty / ``None`` /
+  non-string perspective ids return ``None``
+* free features / free runtimes are always unlocked at every tier
+* paid features / paid runtimes are locked on OSS / Cloud Free and
+  unlocked at the tier ``min_tier_for_*`` reports (so the helper agrees
+  with the affordability surface)
+* capacity axes (``channels`` / ``retention_days`` / ``nodes``) use the
+  per-tier caps (``_TIER_CHANNEL_LIMIT`` / ``_TIER_RETENTION_DAYS`` /
+  ``_TIER_NODE_LIMIT``) rather than the single-node OSS default that
+  ``_hypothetical_entitlement`` hands to ``feature_spec_at`` /
+  ``runtime_spec_at`` -- so e.g. asking about 100 nodes from Enterprise
+  is unlocked, not locked
+* the helper never raises; a synthesis failure returns ``None``
+* the endpoint 400s on missing ``tier=`` / no-axis / multi-axis input,
+  404s on unknown tier (with ``which`` so the caller can render the
+  right "unknown ..." message), and never 5xxs
+* the endpoint response shape matches ``/api/entitlement/lock-reason``
+  exactly (same keys, same ordering of semantics) so a paywall surface
+  can swap the live endpoint for the what-if one with no reshape
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "upgrade_required",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- ``lock_reason_at`` is
+    independent of either knob, so the fixture only needs to make sure
+    the live resolver does not surprise the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: round-trip & shape ────────────────────────────────────────────────
+
+
+def test_helper_returns_string_or_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    out = ent.lock_reason_at(ent.TIER_CLOUD_PRO, fid, kind="feature")
+    assert out is None or isinstance(out, str)
+
+
+def test_every_tier_resolves(ent):
+    """Every tier in ``_TIER_ORDER`` returns a string-or-None for some
+    feature -- pins the per-tier round-trip contract."""
+    paid_universe = (
+        ent.STARTER_FEATURES | ent.PRO_ONLY_FEATURES | ent.ENTERPRISE_FEATURES
+    )
+    fid = next(iter(paid_universe))
+    for tier in ent._TIER_ORDER:
+        out = ent.lock_reason_at(tier, fid, kind="feature")
+        assert out is None or isinstance(out, str), (tier, fid)
+
+
+# ── invalid perspective tier ─────────────────────────────────────────────────
+
+
+def test_unknown_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.lock_reason_at("not_a_real_tier", fid, kind="feature") is None
+
+
+def test_empty_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.lock_reason_at("", fid, kind="feature") is None
+
+
+def test_none_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.lock_reason_at(None, fid, kind="feature") is None
+
+
+def test_non_string_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.lock_reason_at(123, fid, kind="feature") is None
+    assert ent.lock_reason_at(object(), fid, kind="feature") is None
+
+
+# ── normalisation ─────────────────────────────────────────────────────────────
+
+
+def test_tier_is_lowercased_and_trimmed(ent):
+    paid = next(iter(ent.STARTER_FEATURES))
+    a = ent.lock_reason_at(ent.TIER_OSS, paid, kind="feature")
+    b = ent.lock_reason_at(ent.TIER_OSS.upper(), paid, kind="feature")
+    c = ent.lock_reason_at(f"  {ent.TIER_OSS}  ", paid, kind="feature")
+    assert a == b == c
+    assert a is not None  # paid feature is locked on OSS
+
+
+# ── feature axis: free / paid / per-tier ──────────────────────────────────────
+
+
+def test_free_feature_unlocked_at_every_tier(ent):
+    """Free features are part of the OSS grant; the helper must return
+    ``None`` at every tier in the ladder. Mirrors the same invariant on
+    :func:`feature_spec_at`."""
+    fid = next(iter(ent.FREE_FEATURES))
+    for tier in ent._TIER_ORDER:
+        assert ent.lock_reason_at(tier, fid, kind="feature") is None, (tier, fid)
+
+
+def test_paid_feature_locked_at_oss(ent):
+    paid_universe = (
+        ent.STARTER_FEATURES | ent.PRO_ONLY_FEATURES | ent.ENTERPRISE_FEATURES
+    )
+    fid = next(iter(paid_universe))
+    out = ent.lock_reason_at(ent.TIER_OSS, fid, kind="feature")
+    assert isinstance(out, str) and out  # non-empty sentence
+
+
+def test_paid_feature_unlocked_at_enterprise(ent):
+    paid_universe = (
+        ent.STARTER_FEATURES | ent.PRO_ONLY_FEATURES | ent.ENTERPRISE_FEATURES
+    )
+    for fid in paid_universe:
+        out = ent.lock_reason_at(ent.TIER_ENTERPRISE, fid, kind="feature")
+        assert out is None, fid
+
+
+def test_starter_feature_unlocked_at_starter_locked_at_oss(ent):
+    """A Starter feature is unlocked at Starter but locked at OSS.
+    Cross-checks the per-tier resolution end-to-end -- if the
+    perspective tier is wired in correctly, the lock state flips
+    EXACTLY at the boundary :func:`min_tier_for_feature` reports."""
+    for fid in ent.STARTER_FEATURES:
+        unlocked = ent.lock_reason_at(
+            ent.TIER_CLOUD_STARTER, fid, kind="feature"
+        )
+        assert unlocked is None, fid
+        locked = ent.lock_reason_at(ent.TIER_OSS, fid, kind="feature")
+        assert isinstance(locked, str), fid
+
+
+def test_pro_only_feature_locked_at_starter(ent):
+    for fid in ent.PRO_ONLY_FEATURES:
+        locked = ent.lock_reason_at(
+            ent.TIER_CLOUD_STARTER, fid, kind="feature"
+        )
+        assert isinstance(locked, str), fid
+        unlocked = ent.lock_reason_at(ent.TIER_CLOUD_PRO, fid, kind="feature")
+        assert unlocked is None, fid
+
+
+def test_enterprise_feature_only_unlocked_at_enterprise(ent):
+    for fid in ent.ENTERPRISE_FEATURES:
+        for tier in ent._TIER_ORDER:
+            out = ent.lock_reason_at(tier, fid, kind="feature")
+            if tier == ent.TIER_ENTERPRISE:
+                assert out is None, (tier, fid)
+            else:
+                assert isinstance(out, str), (tier, fid)
+
+
+def test_kind_can_be_inferred_for_feature(ent):
+    """``kind=None`` lets the inner method infer ``feature`` vs
+    ``runtime`` from the id."""
+    paid = next(iter(ent.STARTER_FEATURES))
+    inferred = ent.lock_reason_at(ent.TIER_OSS, paid)
+    explicit = ent.lock_reason_at(ent.TIER_OSS, paid, kind="feature")
+    assert inferred == explicit
+    assert isinstance(inferred, str)
+
+
+# ── runtime axis ──────────────────────────────────────────────────────────────
+
+
+def test_free_runtime_unlocked_at_every_tier(ent):
+    for rt in ent.FREE_RUNTIMES:
+        for tier in ent._TIER_ORDER:
+            out = ent.lock_reason_at(tier, rt, kind="runtime")
+            assert out is None, (tier, rt)
+
+
+def test_paid_runtime_locked_on_oss_unlocked_on_starter(ent):
+    for rt in ent.PAID_RUNTIMES:
+        locked = ent.lock_reason_at(ent.TIER_OSS, rt, kind="runtime")
+        assert isinstance(locked, str), rt
+        unlocked = ent.lock_reason_at(
+            ent.TIER_CLOUD_STARTER, rt, kind="runtime"
+        )
+        assert unlocked is None, rt
+
+
+def test_kind_can_be_inferred_for_runtime(ent):
+    rt = next(iter(ent.PAID_RUNTIMES))
+    inferred = ent.lock_reason_at(ent.TIER_OSS, rt)
+    explicit = ent.lock_reason_at(ent.TIER_OSS, rt, kind="runtime")
+    assert inferred == explicit
+    assert isinstance(inferred, str)
+
+
+# ── capacity axes: channels / retention_days / nodes ─────────────────────────
+
+
+def test_channels_within_oss_cap_unlocked(ent):
+    """OSS gives :data:`_FREE_CHANNEL_LIMIT` channels; asking for one
+    within the cap is unlocked."""
+    assert ent.lock_reason_at(ent.TIER_OSS, "1", kind="channels") is None
+
+
+def test_channels_over_oss_cap_locked(ent):
+    """Asking for many more channels than OSS allows is locked, and the
+    sentence names a paid tier."""
+    over = ent._FREE_CHANNEL_LIMIT + 100
+    out = ent.lock_reason_at(ent.TIER_OSS, str(over), kind="channels")
+    assert isinstance(out, str), out
+
+
+def test_channels_unlimited_at_starter(ent):
+    """Starter and above are channel-unlimited (``_TIER_CHANNEL_LIMIT``
+    maps them to ``None``) -- asking about any positive count is
+    unlocked."""
+    assert (
+        ent.lock_reason_at(ent.TIER_CLOUD_STARTER, "10000", kind="channels")
+        is None
+    )
+
+
+def test_retention_within_oss_window_unlocked(ent):
+    """7-day retention is the OSS default cap."""
+    assert ent.lock_reason_at(ent.TIER_OSS, "7", kind="retention_days") is None
+
+
+def test_retention_over_oss_window_locked(ent):
+    out = ent.lock_reason_at(ent.TIER_OSS, "365", kind="retention_days")
+    assert isinstance(out, str), out
+
+
+def test_nodes_within_oss_cap_unlocked(ent):
+    """OSS / Cloud Free are a single-node grant; one node is allowed."""
+    assert ent.lock_reason_at(ent.TIER_OSS, "1", kind="nodes") is None
+
+
+def test_nodes_over_oss_cap_locked(ent):
+    out = ent.lock_reason_at(ent.TIER_OSS, "5", kind="nodes")
+    assert isinstance(out, str), out
+
+
+def test_nodes_unlimited_at_enterprise(ent):
+    """Enterprise (and every other paid tier) has ``node_limit=None``
+    (unlimited) in :data:`_TIER_NODE_LIMIT`. The naive
+    ``_hypothetical_entitlement`` builder hardcodes ``node_limit=1`` --
+    ``lock_reason_at`` must use the per-tier cap instead. This pins
+    that branch."""
+    for n in (5, 50, 5000):
+        out = ent.lock_reason_at(ent.TIER_ENTERPRISE, str(n), kind="nodes")
+        assert out is None, (n, out)
+
+
+def test_nodes_unlimited_at_cloud_pro(ent):
+    for n in (5, 50, 5000):
+        out = ent.lock_reason_at(ent.TIER_CLOUD_PRO, str(n), kind="nodes")
+        assert out is None, (n, out)
+
+
+# ── independent of live resolver ──────────────────────────────────────────────
+
+
+def test_helper_ignores_grace_mode(ent, monkeypatch):
+    """Grace short-circuits the live ``lock_reason`` to ``None`` for
+    everything. ``lock_reason_at`` builds its own hypothetical
+    Entitlement with ``grace=False``, so a paid feature at OSS still
+    surfaces a lock string regardless of grace state."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    ent.invalidate()
+    paid = next(iter(ent.STARTER_FEATURES))
+    out = ent.lock_reason_at(ent.TIER_OSS, paid, kind="feature")
+    assert isinstance(out, str), out
+
+
+def test_helper_ignores_enforce_flag(ent, monkeypatch):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    ent.invalidate()
+    fid = next(iter(ent.FREE_FEATURES))
+    # Free feature still unlocked at every tier regardless of enforce.
+    for tier in ent._TIER_ORDER:
+        assert ent.lock_reason_at(tier, fid, kind="feature") is None, tier
+
+
+def test_helper_ignores_cloud_plan_cache(ent, monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    cache = tmp_path / ".clawmetry" / "cloud_plan.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps({"plan": "cloud_pro"}))
+    ent.invalidate()
+    # Even with a Pro cache in HOME, asking from the OSS perspective
+    # still locks a Pro-only feature.
+    pro_only_fid = next(iter(ent.PRO_ONLY_FEATURES))
+    out = ent.lock_reason_at(ent.TIER_OSS, pro_only_fid, kind="feature")
+    assert isinstance(out, str), out
+
+
+# ── never-raise ───────────────────────────────────────────────────────────────
+
+
+def test_never_raises_when_get_entitlement_crashes(ent, monkeypatch):
+    """The helper synthesises its own Entitlement and never calls
+    :func:`get_entitlement`, so a blown live resolver must not affect
+    the result."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated resolver failure")
+
+    monkeypatch.setattr(ent, "get_entitlement", boom)
+    paid = next(iter(ent.STARTER_FEATURES))
+    out = ent.lock_reason_at(ent.TIER_OSS, paid, kind="feature")
+    assert isinstance(out, str), out
+
+
+def test_unknown_feature_returns_none(ent):
+    assert (
+        ent.lock_reason_at(ent.TIER_OSS, "not_a_real_feature", kind="feature")
+        is None
+    )
+
+
+def test_empty_item_returns_none(ent):
+    assert ent.lock_reason_at(ent.TIER_OSS, "", kind="feature") is None
+
+
+def test_unparseable_capacity_returns_none(ent):
+    assert ent.lock_reason_at(ent.TIER_OSS, "abc", kind="channels") is None
+    assert (
+        ent.lock_reason_at(ent.TIER_OSS, "abc", kind="retention_days") is None
+    )
+    assert ent.lock_reason_at(ent.TIER_OSS, "abc", kind="nodes") is None
+
+
+# ── HTTP endpoint: positive paths ─────────────────────────────────────────────
+
+
+def test_endpoint_returns_shape_matching_live_lock_reason(client, ent):
+    """The ``-at`` endpoint's row shape matches ``/api/entitlement/lock-reason``
+    exactly so a paywall surface can swap one for the other without
+    reshaping."""
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}&feature={fid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert set(body.keys()) == _ROW_KEYS
+
+
+def test_endpoint_feature_locked_at_oss(client, ent):
+    paid = next(iter(ent.STARTER_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}&feature={paid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["key"] == paid
+    assert body["kind"] == "feature"
+    assert body["locked"] is True
+    assert body["allowed"] is False
+    assert isinstance(body["reason"], str) and body["reason"]
+    assert body["current_tier"] == ent.TIER_OSS
+    assert body["required_tier"] is not None
+    assert body["upgrade_required"] is True
+
+
+def test_endpoint_feature_unlocked_at_enterprise(client, ent):
+    paid = next(iter(ent.STARTER_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_ENTERPRISE}"
+        f"&feature={paid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["locked"] is False
+    assert body["allowed"] is True
+    assert body["reason"] is None
+    assert body["current_tier"] == ent.TIER_ENTERPRISE
+    assert body["upgrade_required"] is False
+
+
+def test_endpoint_runtime_axis(client, ent):
+    rt = next(iter(ent.PAID_RUNTIMES))
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}&runtime={rt}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["kind"] == "runtime"
+    assert body["locked"] is True
+    assert body["current_tier"] == ent.TIER_OSS
+
+
+def test_endpoint_channels_axis(client, ent):
+    """100 channels at OSS is locked; at Cloud Starter (channel-unlimited)
+    it is not."""
+    over = ent._FREE_CHANNEL_LIMIT + 100
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}&channels={over}"
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["locked"] is True
+
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_CLOUD_STARTER}"
+        f"&channels={over}"
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["locked"] is False
+
+
+def test_endpoint_retention_axis(client, ent):
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}"
+        "&retention_days=365"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["kind"] == "retention_days"
+    assert body["locked"] is True
+
+
+def test_endpoint_nodes_axis(client, ent):
+    """Many nodes at OSS is locked; at Enterprise it is unlocked.
+    Pins that the endpoint flows the per-tier ``_TIER_NODE_LIMIT``
+    cap through correctly rather than the single-node default."""
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}&nodes=10"
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["locked"] is True
+
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_ENTERPRISE}"
+        "&nodes=10"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["locked"] is False
+    assert body["current_tier"] == ent.TIER_ENTERPRISE
+
+
+def test_endpoint_runtime_alias_canonicalises(client, ent):
+    """The endpoint canonicalises runtime aliases the same way
+    :func:`canonical_runtime` does, so callers can pass the dashed
+    form."""
+    # Pick a paid runtime that has a dashed alias.
+    rt = None
+    for cand in ent.PAID_RUNTIMES:
+        if "_" in cand:
+            rt = cand
+            break
+    if rt is None:
+        pytest.skip("no PAID_RUNTIMES with underscore for alias check")
+    aliased = rt.replace("_", "-")
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}"
+        f"&runtime={aliased}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["key"] == rt
+    assert body["kind"] == "runtime"
+    assert body["locked"] is True
+
+
+# ── HTTP endpoint: input validation ───────────────────────────────────────────
+
+
+def test_endpoint_missing_tier_returns_400(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(f"/api/entitlement/lock-reason-at?feature={fid}")
+    assert resp.status_code == 400
+
+
+def test_endpoint_blank_tier_returns_400(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier=%20%20&feature={fid}"
+    )
+    assert resp.status_code == 400
+
+
+def test_endpoint_unknown_tier_returns_404(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier=nonsense_xyz&feature={fid}"
+    )
+    assert resp.status_code == 404
+    body = resp.get_json()
+    assert body["which"] == "tier"
+    assert body["tier"] == "nonsense_xyz"
+
+
+def test_endpoint_no_axis_returns_400(client, ent):
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}"
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_multi_axis_returns_400(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    rt = next(iter(ent.FREE_RUNTIMES))
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}"
+        f"&feature={fid}&runtime={rt}"
+    )
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_endpoint_lowercases_and_trims_tier(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier=%20%20{ent.TIER_OSS.upper()}%20"
+        f"&feature={fid}"
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["current_tier"] == ent.TIER_OSS
+
+
+# ── HTTP endpoint: never-5xx contract ─────────────────────────────────────────
+
+
+def test_endpoint_never_5xxs_when_helper_crashes(client, ent, monkeypatch):
+    """Even if :func:`lock_reason_at` blows up, the route returns the
+    grace-shape row, not a 500. Pins the UI-safe contract."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated helper crash")
+
+    monkeypatch.setattr(ent, "lock_reason_at", boom)
+    fid = next(iter(ent.FREE_FEATURES))
+    resp = client.get(
+        f"/api/entitlement/lock-reason-at?tier={ent.TIER_OSS}&feature={fid}"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["reason"] is None
+    assert body["locked"] is False
+    assert body["allowed"] is True
+    assert body["current_tier"] == ent.TIER_OSS
+
+
+def test_endpoint_every_tier_round_trips_with_free_feature(client, ent):
+    """Round-trip every tier perspective with a free feature -- should
+    return 200 + unlocked at every tier."""
+    fid = next(iter(ent.FREE_FEATURES))
+    for tier in ent._TIER_ORDER:
+        resp = client.get(
+            f"/api/entitlement/lock-reason-at?tier={tier}&feature={fid}"
+        )
+        assert resp.status_code == 200, tier
+        body = resp.get_json()
+        assert body["current_tier"] == tier, tier
+        assert body["locked"] is False, tier
+        assert body["reason"] is None, tier


### PR DESCRIPTION
## Summary

Adds `lock_reason_at(perspective_tier, item, *, kind=None)` -- the what-if sibling of the live `lock_reason` helper: the lock-reason string for an item computed as if the install were on `perspective_tier`, not against the live resolved entitlement. Pairs with the `feature_spec_at` / `runtime_spec_at` / `tier_spec_at` trio landed in #3312 / #3320 / #3321: where those return the catalog row at a hypothetical tier, this returns the human-readable lock sentence the paywall surface renders.

Lets a pricing-comparison tooltip preview the exact lock copy a downgrade-to-target would surface in one round-trip, before the user commits, rather than fetching the full at-tier catalog and rebuilding the sentence client-side.

## Why a fresh `Entitlement` instead of `_hypothetical_entitlement`

`_hypothetical_entitlement` hardcodes `node_limit=1` because its catalog-row callers (`feature_spec_at`, `runtime_spec_at`, `feature_catalog_at`, `runtime_catalog_at`) don't expose node counts. The new helper has to support the `nodes` axis correctly -- asking about 100 nodes from `enterprise` must resolve to unlocked, not locked -- so it synthesises its own `Entitlement` with `node_limit = _TIER_NODE_LIMIT.get(tier, _FREE_NODE_LIMIT)` (paid tiers all map to the `None` unlimited sentinel). Channel and retention caps already flow off `self.tier` inside the `Entitlement` methods, so they don't need the same treatment. Tests pin the per-tier node-limit branch explicitly.

## API

`GET /api/entitlement/lock-reason-at?tier=<perspective>&<axis>=<id>`

Exactly one of `feature=` / `runtime=` / `channels=` / `retention_days=` / `nodes=` must be supplied.

Response shape is **byte-identical** to `/api/entitlement/lock-reason` (same 11 keys: `key`, `kind`, `reason`, `locked`, `allowed`, `required_tier`, `required_tier_label`, `required_tier_rank`, `current_tier`, `current_tier_rank`, `upgrade_required`), so a paywall surface can swap the live endpoint for the what-if one without reshape. `current_tier` reflects the perspective tier (the live tier is irrelevant to the calculation).

- **400** when `tier=` is missing / blank, when no axis is supplied, or when more than one axis is supplied
- **404** when `tier` is unknown (body carries `which: "tier"`)
- **Never 5xxs**: a synthesis failure short-circuits to the grace-shape row (`reason=null` / `locked=false` / `allowed=true`) so the UI keeps rendering

## Files

| File | Lines | Change |
|---|---|---|
| `clawmetry/entitlements.py` | +71 | `lock_reason_at(perspective_tier, item, kind=...)` helper |
| `routes/entitlement.py` | +201 | `bp_entitlement` route + grace-shape fallback |
| `tests/test_entitlement_lock_reason_at.py` | +605 | 49 tests pinning helper, endpoint, never-raise, never-5xx |

Read-only catalog-like accessor on top of the static tier maps -- no behaviour gate flips and no live entitlement is consulted, so the helper is safe to wire into pricing-page tooltips even during grace mode. No `__version__` bump, no UI wired.

## Test plan

- [x] `python -m pytest tests/test_entitlement_lock_reason_at.py -x -q` → **49 passed**
- [x] Adjacent suites: `test_entitlement_lock_reason.py`, `test_entitlement_lock_reason_capacity.py`, `test_entitlement_lock_reason_nodes.py`, `test_entitlement_lock_reason_batch.py`, `test_entitlement_feature_spec_at.py`, `test_entitlement_runtime_spec_at.py`, `test_entitlement_tier_spec.py`, `test_entitlement_tier_catalog_at.py`, `test_entitlement_feature_catalog_at.py`, `test_entitlement_runtime_catalog_at.py` → **236 passed**
- [x] Full `-k "entitlement or license"` sweep → **1517 passed** (errors limited to `test_license_pubkey.py` / `test_retention_prune.py` which need the optional `cryptography`/`duckdb` extras the autonomous CI image does not install -- unrelated to this change)
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_lock_reason_at.py` → **All checks passed!**
- [x] `python -m py_compile` on all three changed files

## Local operator verification checklist

The autonomous fire cannot touch the user's machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The following must be done by the local operator before flipping to ready-for-review:

- [ ] Copy changed files into the installed package:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint across all axes:
      `curl -s 'http://localhost:8900/api/entitlement/lock-reason-at?tier=oss&feature=sso' | jq`
      `curl -s 'http://localhost:8900/api/entitlement/lock-reason-at?tier=enterprise&nodes=100' | jq`
      `curl -s 'http://localhost:8900/api/entitlement/lock-reason-at?tier=cloud_starter&channels=50' | jq`
- [ ] Confirm `current_tier` matches the perspective tier in the response, and that `enterprise+nodes=100` returns `locked=false` (the per-tier `_TIER_NODE_LIMIT` branch the naive hypothetical otherwise gets wrong)
- [ ] Verify error contract: `curl -i '.../lock-reason-at?feature=sso'` → 400; `?tier=nonsense&feature=sso` → 404 with `which: "tier"`
- [ ] Decrypt the live cloud snapshot and browser-check that no existing tooltip / paywall surface regressed (this endpoint is unconsumed, so the check is purely defensive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6UJVVJ8PWBduvuBgFL8YF

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6UJVVJ8PWBduvuBgFL8YF)_