### PR TITLE
feat(entitlement): lock_reasons_at_batch + /api/entitlement/lock-reasons-at-batch

### DIFF
--- a/clawmetry/entitlements.py
+++ b/clawmetry/entitlements.py
@@ -4041,3 +4041,97 @@ def lock_reason_at(
     except Exception as exc:
         logger.warning("entitlements: lock_reason_at lookup failed: %s", exc)
         return None
+
+
+def lock_reasons_at_batch(
+    perspective_tier: str,
+    *,
+    features=None,
+    runtimes=None,
+    channels: int | None = None,
+    retention_days: int | None = None,
+    nodes: int | None = None,
+) -> dict | None:
+    """What-if sibling of :func:`lock_reasons_batch`: per-item lock-reason
+    rows for every supplied item across all 5 axes, computed as if the
+    install were on ``perspective_tier``.
+
+    Pairs with :func:`lock_reason_at` the same way :func:`lock_reasons_batch`
+    pairs with :func:`lock_reason` -- where the scalar what-if returns one
+    sentence for one item, this returns the full N-row matrix in one pass
+    so a pricing-comparison matrix UI can preview the lock copy a
+    downgrade-to-target would surface for many items BEFORE the user
+    commits, without N round-trips to ``/lock-reason-at``.
+
+    Synthesises a fresh :class:`Entitlement` for ``perspective_tier`` (with
+    grace=False and the per-tier capacity caps off ``_TIER_NODE_LIMIT``)
+    rather than calling :func:`_hypothetical_entitlement`, for the same
+    reason :func:`lock_reason_at` does: the unparameterised helper
+    hard-codes ``node_limit=1`` because its catalog-row callers don't
+    expose node counts, but the capacity axes here (``nodes`` etc.) must
+    resolve against the perspective tier's true cap.
+
+    Shape (byte-identical to :func:`lock_reasons_batch`)::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``reason``, ``locked``,
+    ``allowed``, ``required_tier``, ``required_tier_label``,
+    ``required_tier_rank`` -- the same 8 keys :func:`_lock_row` emits.
+
+    Returns ``None`` for empty / unknown perspective tier (caller renders
+    404). Never raises: a synthesis failure short-circuits to the
+    grace-shape rows so the matrix keeps rendering. Capacity axes use
+    ``None`` as the "axis not supplied" sentinel: ``retention_days=None``
+    here means *unset*, NOT *unlimited* -- matches
+    :func:`lock_reasons_batch` exactly.
+    """
+    try:
+        t = (perspective_tier or "").strip().lower()
+    except (AttributeError, TypeError):
+        return None
+    if not t or t not in _TIER_ORDER:
+        return None
+    feats = _normalise_csv(features)
+    rts = _normalise_csv(runtimes)
+    try:
+        paid_feats = _TIER_FEATURES.get(t, frozenset())
+        rt_set = (
+            (FREE_RUNTIMES | PAID_RUNTIMES)
+            if t in _TIER_PAID_RUNTIMES
+            else FREE_RUNTIMES
+        )
+        ent = Entitlement(
+            tier=t,
+            source="hypothetical",
+            node_limit=_TIER_NODE_LIMIT.get(t, _FREE_NODE_LIMIT),
+            expiry=None,
+            features=FREE_FEATURES | paid_feats,
+            runtimes=rt_set,
+            grace=False,
+        )
+    except Exception as exc:
+        logger.warning(
+            "entitlements: lock_reasons_at_batch synthesis failed: %s", exc
+        )
+        ent = _oss_free()
+    out: dict = {
+        "features": [_lock_row(ent, f, "feature") for f in feats],
+        "runtimes": [_lock_row(ent, r, "runtime") for r in rts],
+        "channels": (
+            _lock_row(ent, channels, "channels") if channels is not None else None
+        ),
+        "retention_days": (
+            _lock_row(ent, retention_days, "retention_days")
+            if retention_days is not None
+            else None
+        ),
+        "nodes": _lock_row(ent, nodes, "nodes") if nodes is not None else None,
+    }
+    return out

--- a/routes/entitlement.py
+++ b/routes/entitlement.py
@@ -2786,6 +2786,151 @@ def api_entitlement_lock_reason_batch():
         )
 
 
+@bp_entitlement.route("/api/entitlement/lock-reasons-at-batch")
+def api_entitlement_lock_reasons_at_batch():
+    """``GET /api/entitlement/lock-reasons-at-batch?tier=<perspective>
+    &features=a,b,c&runtimes=x,y&channels=N&retention_days=K&nodes=M`` --
+    what-if sibling of ``/api/entitlement/lock-reason-batch``.
+
+    Where ``/lock-reason-batch`` returns per-item lock rows against the
+    LIVE resolved entitlement, this returns them against a HYPOTHETICAL
+    ``perspective_tier``. Pairs with ``/lock-reason-at`` the same way
+    ``/lock-reason-batch`` pairs with ``/lock-reason``: scalar -> matrix
+    in one round-trip.
+
+    Use case: a pricing-comparison matrix UI ("would my Settings page
+    look like this on Cloud Pro vs Enterprise?") fetches all N rows for
+    each hypothetical tier in one call instead of N calls to
+    ``/lock-reason-at`` per tier.
+
+    Exactly one of ``features=`` / ``runtimes=`` / ``channels=`` /
+    ``retention_days=`` / ``nodes=`` is NOT required -- at least one
+    must be supplied (matches ``/lock-reason-batch``); supply as many
+    as you like. ``features=`` / ``runtimes=`` take comma-separated
+    tokens (whitespace + duplicates are normalised away; unknown ids
+    contribute a grace-shape row). The three capacity axes take a
+    single int each; blank / non-int values are treated as "not
+    supplied" (matches ``/lock-reason-batch``).
+
+    - **400** when ``tier=`` is missing / blank or no axis is supplied
+    - **404** when ``tier`` is unknown (body carries ``which: "tier"``
+      so the caller can render the right "unknown ..." message)
+    - **Never 5xxs**: a synthesis failure short-circuits to the
+      grace-shape payload (empty / None rows) with the perspective
+      tier echoed so the UI keeps rendering.
+
+    Response shape (byte-identical to ``/lock-reason-batch`` plus a
+    ``perspective_tier`` echo for caller round-trip safety)::
+
+        {
+          "features":       [<row>, ...],
+          "runtimes":       [<row>, ...],
+          "channels":       <row> | None,
+          "retention_days": <row> | None,
+          "nodes":          <row> | None,
+          "perspective_tier":      "...",
+          "perspective_tier_rank": <int>,
+          "current_tier":          "...",
+          "current_tier_rank":     <int>,
+          "grace":                 <bool>,
+          "enforced":              <bool>,
+        }
+
+    Each ``<row>`` carries ``key``, ``kind``, ``reason``, ``locked``,
+    ``allowed``, ``required_tier``, ``required_tier_label``,
+    ``required_tier_rank`` -- the same 8 keys ``/lock-reason-batch``
+    returns. ``current_tier`` reflects the LIVE resolved tier (so the
+    matrix UI can also show "you are here" badges); ``perspective_tier``
+    reflects the requested hypothetical.
+    """
+    raw_tier = request.args.get("tier")
+    tier_in = (raw_tier or "").strip().lower()
+    if not tier_in:
+        return jsonify({"error": "missing tier"}), 400
+    try:
+        from clawmetry import entitlements as _ent
+
+        if tier_in not in _ent._TIER_ORDER:
+            return (
+                jsonify(
+                    {"error": "unknown tier", "which": "tier", "tier": tier_in}
+                ),
+                404,
+            )
+
+        features = _parse_csv_arg("features")
+        runtimes = _parse_csv_arg("runtimes")
+        (_, channels_ok, channels_n, _) = _parse_capacity_arg("channels")
+        (_, retention_ok, retention_n, _) = _parse_capacity_arg(
+            "retention_days"
+        )
+        (_, nodes_ok, nodes_n, _) = _parse_capacity_arg("nodes")
+
+        if (
+            not features
+            and not runtimes
+            and not channels_ok
+            and not retention_ok
+            and not nodes_ok
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "supply at least one of features=<csv>, "
+                            "runtimes=<csv>, channels=<int>, "
+                            "retention_days=<int>, or nodes=<int>"
+                        )
+                    }
+                ),
+                400,
+            )
+
+        batch = _ent.lock_reasons_at_batch(
+            tier_in,
+            features=features or None,
+            runtimes=runtimes or None,
+            channels=channels_n if channels_ok else None,
+            retention_days=retention_n if retention_ok else None,
+            nodes=nodes_n if nodes_ok else None,
+        )
+        if batch is None:
+            batch = {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+            }
+        ent = _ent.get_entitlement()
+        batch["perspective_tier"] = tier_in
+        batch["perspective_tier_rank"] = _ent.tier_rank(tier_in)
+        batch["current_tier"] = ent.tier
+        batch["current_tier_rank"] = _ent.tier_rank(ent.tier)
+        batch["grace"] = bool(ent.grace)
+        batch["enforced"] = _ent.is_enforced()
+        return jsonify(batch)
+    except Exception as exc:
+        logger.warning(
+            "api_entitlement_lock_reasons_at_batch: error: %s", exc
+        )
+        return jsonify(
+            {
+                "features": [],
+                "runtimes": [],
+                "channels": None,
+                "retention_days": None,
+                "nodes": None,
+                "perspective_tier": tier_in,
+                "perspective_tier_rank": 0,
+                "current_tier": "oss",
+                "current_tier_rank": 0,
+                "grace": True,
+                "enforced": False,
+            }
+        )
+
+
 @bp_entitlement.route("/api/entitlement/diagnostic")
 def api_entitlement_diagnostic():
     try:

--- a/tests/test_entitlement_lock_reasons_at_batch.py
+++ b/tests/test_entitlement_lock_reasons_at_batch.py
@@ -1,0 +1,473 @@
+"""Tests for ``lock_reasons_at_batch(perspective_tier, ...)`` +
+``GET /api/entitlement/lock-reasons-at-batch``.
+
+What-if sibling of ``lock_reasons_batch`` -- per-item lock-reason rows
+for many items at once, computed as if the install were on
+``perspective_tier`` rather than against the live resolved entitlement.
+
+Pins:
+
+* the helper is independent of the live resolver (grace mode,
+  enforcement, license cache, and cloud_plan.json all have no effect)
+* every tier in ``_TIER_ORDER`` returns a dict with the 5 axis keys
+* unknown / empty / ``None`` / non-string perspective ids return ``None``
+* free features / free runtimes are unlocked at every tier (matches
+  the scalar ``lock_reason_at``)
+* paid features / paid runtimes are unlocked at the tier their
+  ``min_tier_for_*`` answer reports (so the matrix agrees with the
+  affordability surface)
+* capacity axes use the per-tier caps (``_TIER_CHANNEL_LIMIT`` /
+  ``_TIER_RETENTION_DAYS`` / ``_TIER_NODE_LIMIT``) rather than the
+  single-node OSS default ``_hypothetical_entitlement`` uses for
+  feature/runtime-only callers -- so asking about 100 nodes from
+  Enterprise is unlocked, not locked
+* the helper never raises -- a synthesis failure short-circuits to
+  grace-shape rows
+* the endpoint 400s on missing ``tier=`` / no-axis input, 404s on
+  unknown tier (with ``which`` carrier), and never 5xxs
+* the row shape is byte-identical to ``lock_reasons_batch`` (same 8
+  keys per row); the dict adds a ``perspective_tier`` echo for caller
+  round-trip safety
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from flask import Flask
+
+
+_ROW_KEYS = {
+    "key",
+    "kind",
+    "reason",
+    "locked",
+    "allowed",
+    "required_tier",
+    "required_tier_label",
+    "required_tier_rank",
+}
+
+_BATCH_KEYS = {"features", "runtimes", "channels", "retention_days", "nodes"}
+
+_API_EXTRA_KEYS = {
+    "perspective_tier",
+    "perspective_tier_rank",
+    "current_tier",
+    "current_tier_rank",
+    "grace",
+    "enforced",
+}
+
+
+@pytest.fixture
+def ent(monkeypatch, tmp_path):
+    """Fresh entitlements module with HOME pointed at an empty tmp dir
+    so no real ~/.clawmetry/license.key or cloud_plan.json leaks in.
+    Enforcement off by default (grace mode) -- the helper is
+    independent of either knob, so the fixture only needs to make sure
+    the live resolver does not surprise the test."""
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import clawmetry.entitlements as e
+
+    importlib.reload(e)
+    e.invalidate()
+    yield e
+    e.invalidate()
+
+
+@pytest.fixture
+def client(ent):
+    from routes.entitlement import bp_entitlement
+
+    app = Flask(__name__)
+    app.register_blueprint(bp_entitlement)
+    return app.test_client()
+
+
+# ── helper: shape + round-trip ───────────────────────────────────────────────
+
+
+def test_helper_returns_dict_with_axis_keys(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    out = ent.lock_reasons_at_batch(ent.TIER_CLOUD_PRO, features=[fid])
+    assert isinstance(out, dict)
+    assert set(out.keys()) == _BATCH_KEYS
+
+
+def test_helper_features_row_shape(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    out = ent.lock_reasons_at_batch(ent.TIER_CLOUD_PRO, features=[fid])
+    assert isinstance(out["features"], list)
+    assert len(out["features"]) == 1
+    assert set(out["features"][0].keys()) == _ROW_KEYS
+
+
+def test_helper_every_tier_returns_dict(ent):
+    """Every tier in ``_TIER_ORDER`` resolves to a dict, no crashes."""
+    paid_universe = (
+        ent.STARTER_FEATURES | ent.PRO_ONLY_FEATURES | ent.ENTERPRISE_FEATURES
+    )
+    fid = next(iter(paid_universe))
+    for tier in ent._TIER_ORDER:
+        out = ent.lock_reasons_at_batch(tier, features=[fid])
+        assert isinstance(out, dict), tier
+        assert set(out.keys()) == _BATCH_KEYS
+
+
+# ── invalid perspective tier ─────────────────────────────────────────────────
+
+
+def test_unknown_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.lock_reasons_at_batch("not_a_real_tier", features=[fid]) is None
+
+
+def test_empty_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.lock_reasons_at_batch("", features=[fid]) is None
+
+
+def test_none_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.lock_reasons_at_batch(None, features=[fid]) is None
+
+
+def test_non_string_tier_returns_none(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    assert ent.lock_reasons_at_batch(123, features=[fid]) is None
+
+
+# ── feature rows: free + paid ────────────────────────────────────────────────
+
+
+def test_free_feature_unlocked_at_every_tier(ent):
+    """A free feature should never be locked, regardless of perspective."""
+    fid = next(iter(ent.FREE_FEATURES))
+    for tier in ent._TIER_ORDER:
+        out = ent.lock_reasons_at_batch(tier, features=[fid])
+        row = out["features"][0]
+        assert row["locked"] is False, (tier, fid, row)
+        assert row["allowed"] is True, (tier, fid, row)
+        assert row["reason"] is None, (tier, fid, row)
+
+
+def test_paid_feature_locked_on_oss(ent):
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    out = ent.lock_reasons_at_batch(ent.TIER_OSS, features=[fid])
+    row = out["features"][0]
+    assert row["locked"] is True
+    assert row["allowed"] is False
+    assert isinstance(row["reason"], str) and row["reason"]
+
+
+def test_paid_feature_unlocked_at_pro(ent):
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    out = ent.lock_reasons_at_batch(ent.TIER_CLOUD_PRO, features=[fid])
+    row = out["features"][0]
+    assert row["locked"] is False
+    assert row["allowed"] is True
+    assert row["reason"] is None
+
+
+def test_enterprise_feature_locked_below_enterprise(ent):
+    fid = next(iter(ent.ENTERPRISE_FEATURES))
+    out = ent.lock_reasons_at_batch(ent.TIER_CLOUD_PRO, features=[fid])
+    row = out["features"][0]
+    assert row["locked"] is True
+    assert row["allowed"] is False
+
+
+def test_enterprise_feature_unlocked_at_enterprise(ent):
+    fid = next(iter(ent.ENTERPRISE_FEATURES))
+    out = ent.lock_reasons_at_batch(ent.TIER_ENTERPRISE, features=[fid])
+    row = out["features"][0]
+    assert row["locked"] is False
+    assert row["allowed"] is True
+
+
+def test_unknown_feature_does_not_error(ent):
+    """Unknown ids must not raise -- they contribute a row with ``reason
+    is None`` (the inner ``lock_reason`` short-circuits on ids it
+    doesn't recognise) rather than crashing the matrix."""
+    out = ent.lock_reasons_at_batch(
+        ent.TIER_OSS, features=["definitely_not_a_real_feature"]
+    )
+    row = out["features"][0]
+    assert row["reason"] is None
+    assert row["locked"] is False
+
+
+# ── runtime rows ─────────────────────────────────────────────────────────────
+
+
+def test_free_runtime_unlocked_everywhere(ent):
+    rt = next(iter(ent.FREE_RUNTIMES))
+    for tier in ent._TIER_ORDER:
+        out = ent.lock_reasons_at_batch(tier, runtimes=[rt])
+        row = out["runtimes"][0]
+        assert row["locked"] is False, (tier, rt)
+        assert row["allowed"] is True, (tier, rt)
+
+
+def test_paid_runtime_locked_on_oss(ent):
+    rt = next(iter(ent.PAID_RUNTIMES))
+    out = ent.lock_reasons_at_batch(ent.TIER_OSS, runtimes=[rt])
+    row = out["runtimes"][0]
+    assert row["locked"] is True
+    assert row["allowed"] is False
+
+
+def test_paid_runtime_unlocked_at_paid_tier(ent):
+    rt = next(iter(ent.PAID_RUNTIMES))
+    out = ent.lock_reasons_at_batch(ent.TIER_CLOUD_STARTER, runtimes=[rt])
+    row = out["runtimes"][0]
+    assert row["locked"] is False
+    assert row["allowed"] is True
+
+
+# ── capacity rows ────────────────────────────────────────────────────────────
+
+
+def test_capacity_axes_default_to_none_when_unset(ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    out = ent.lock_reasons_at_batch(ent.TIER_OSS, features=[fid])
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+def test_nodes_unlocked_at_enterprise_for_large_count(ent):
+    """100 nodes at Enterprise must be unlocked. This is the pin
+    that ``_hypothetical_entitlement``'s hardcoded ``node_limit=1``
+    would get wrong; the helper synthesises its own Entitlement with
+    ``_TIER_NODE_LIMIT.get(tier)`` so the per-tier cap flows."""
+    out = ent.lock_reasons_at_batch(ent.TIER_ENTERPRISE, nodes=100)
+    row = out["nodes"]
+    assert row is not None
+    assert row["locked"] is False, row
+    assert row["allowed"] is True, row
+
+
+def test_nodes_locked_at_oss_for_large_count(ent):
+    out = ent.lock_reasons_at_batch(ent.TIER_OSS, nodes=100)
+    row = out["nodes"]
+    assert row is not None
+    assert row["locked"] is True
+    assert row["allowed"] is False
+
+
+def test_channels_axis_resolves(ent):
+    out = ent.lock_reasons_at_batch(ent.TIER_OSS, channels=50)
+    row = out["channels"]
+    assert row is not None
+    assert row["kind"] == "channels"
+
+
+def test_retention_days_axis_resolves(ent):
+    out = ent.lock_reasons_at_batch(ent.TIER_OSS, retention_days=365)
+    row = out["retention_days"]
+    assert row is not None
+    assert row["kind"] == "retention_days"
+
+
+# ── independence from the live resolver ──────────────────────────────────────
+
+
+def test_helper_independent_of_grace_mode(ent, monkeypatch):
+    """The helper synthesises its own Entitlement so toggling enforcement
+    on or off should NOT change the answer at a given perspective."""
+    fid = next(iter(ent.PRO_ONLY_FEATURES))
+    monkeypatch.delenv("CLAWMETRY_ENFORCE", raising=False)
+    grace = ent.lock_reasons_at_batch(ent.TIER_OSS, features=[fid])
+    monkeypatch.setenv("CLAWMETRY_ENFORCE", "1")
+    enforced = ent.lock_reasons_at_batch(ent.TIER_OSS, features=[fid])
+    assert grace["features"][0]["locked"] == enforced["features"][0]["locked"]
+    assert grace["features"][0]["reason"] == enforced["features"][0]["reason"]
+
+
+# ── never-raise + grace-shape fallback ───────────────────────────────────────
+
+
+def test_helper_never_raises_on_garbage_features(ent):
+    """Garbage tokens must not raise -- they contribute grace-shape rows."""
+    out = ent.lock_reasons_at_batch(
+        ent.TIER_OSS, features=["", None, "valid_id"]  # type: ignore[list-item]
+    )
+    assert isinstance(out, dict)
+    assert isinstance(out["features"], list)
+
+
+def test_helper_empty_inputs_returns_empty_lists(ent):
+    out = ent.lock_reasons_at_batch(ent.TIER_OSS)
+    assert out["features"] == []
+    assert out["runtimes"] == []
+    assert out["channels"] is None
+    assert out["retention_days"] is None
+    assert out["nodes"] is None
+
+
+# ── endpoint: error contract ─────────────────────────────────────────────────
+
+
+def test_endpoint_missing_tier_400(client):
+    fid = "any"
+    r = client.get(f"/api/entitlement/lock-reasons-at-batch?features={fid}")
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "error" in body
+
+
+def test_endpoint_blank_tier_400(client):
+    r = client.get("/api/entitlement/lock-reasons-at-batch?tier=&features=any")
+    assert r.status_code == 400
+
+
+def test_endpoint_unknown_tier_404(client):
+    r = client.get(
+        "/api/entitlement/lock-reasons-at-batch?tier=nonsense&features=any"
+    )
+    assert r.status_code == 404
+    body = r.get_json()
+    assert body.get("which") == "tier"
+    assert body.get("tier") == "nonsense"
+
+
+def test_endpoint_no_axis_400(client, ent):
+    r = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_CLOUD_PRO}"
+    )
+    assert r.status_code == 400
+    body = r.get_json()
+    assert "error" in body
+
+
+# ── endpoint: happy path + shape ─────────────────────────────────────────────
+
+
+def test_endpoint_returns_full_envelope(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    r = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&features={fid}"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert _BATCH_KEYS.issubset(body.keys())
+    assert _API_EXTRA_KEYS.issubset(body.keys())
+
+
+def test_endpoint_perspective_tier_echoed(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    r = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_ENTERPRISE}"
+        f"&features={fid}"
+    )
+    body = r.get_json()
+    assert body["perspective_tier"] == ent.TIER_ENTERPRISE
+    assert body["perspective_tier_rank"] == ent.tier_rank(
+        ent.TIER_ENTERPRISE
+    )
+
+
+def test_endpoint_current_tier_reflects_live_not_perspective(client, ent):
+    """``current_tier`` echoes the live entitlement (OSS/grace by default
+    in the fixture), distinct from ``perspective_tier`` -- so a matrix UI
+    can render both a 'you are here' badge and a hypothetical column."""
+    fid = next(iter(ent.FREE_FEATURES))
+    r = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_ENTERPRISE}"
+        f"&features={fid}"
+    )
+    body = r.get_json()
+    assert body["current_tier"] != ent.TIER_ENTERPRISE
+    assert body["current_tier"] in ent._TIER_ORDER
+
+
+def test_endpoint_multi_axis_one_shot(client, ent):
+    """The endpoint accepts all 5 axes in one call -- distinguishes it
+    from the scalar ``/lock-reason-at`` which is exactly one axis."""
+    fid = next(iter(ent.FREE_FEATURES))
+    rt = next(iter(ent.FREE_RUNTIMES))
+    r = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&features={fid}&runtimes={rt}&channels=5&retention_days=30"
+        f"&nodes=2"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert len(body["features"]) == 1
+    assert len(body["runtimes"]) == 1
+    assert body["channels"] is not None
+    assert body["retention_days"] is not None
+    assert body["nodes"] is not None
+
+
+def test_endpoint_csv_dedupe(client, ent):
+    fid = next(iter(ent.FREE_FEATURES))
+    r = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&features={fid},,{fid}"
+    )
+    body = r.get_json()
+    assert len(body["features"]) == 1
+
+
+def test_endpoint_blank_capacity_is_not_supplied(client, ent):
+    """Blank capacity args don't count as supplied -- matches the
+    singular endpoint's never-crash-on-typo posture."""
+    fid = next(iter(ent.FREE_FEATURES))
+    r = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&features={fid}&channels=&nodes="
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["channels"] is None
+    assert body["nodes"] is None
+
+
+def test_endpoint_non_int_capacity_is_not_supplied(client, ent):
+    """Garbage capacity args don't error -- treated as not supplied."""
+    fid = next(iter(ent.FREE_FEATURES))
+    r = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&features={fid}&channels=abc&nodes=xyz"
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["channels"] is None
+    assert body["nodes"] is None
+
+
+# ── endpoint: row shape parity with /lock-reason-batch ───────────────────────
+
+
+def test_endpoint_row_shape_matches_lock_reason_batch(client, ent):
+    """The per-row shape is byte-identical to ``/lock-reason-batch`` so
+    a matrix UI can swap endpoints without reshape logic."""
+    fid = next(iter(ent.FREE_FEATURES))
+    r_at = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_CLOUD_PRO}"
+        f"&features={fid}"
+    )
+    r_live = client.get(
+        f"/api/entitlement/lock-reason-batch?features={fid}"
+    )
+    row_at = r_at.get_json()["features"][0]
+    row_live = r_live.get_json()["features"][0]
+    assert set(row_at.keys()) == set(row_live.keys())
+
+
+def test_endpoint_nodes_at_enterprise_unlocked(client, ent):
+    """End-to-end pin of the per-tier node cap correctness."""
+    r = client.get(
+        f"/api/entitlement/lock-reasons-at-batch?tier={ent.TIER_ENTERPRISE}"
+        f"&nodes=100"
+    )
+    body = r.get_json()
+    row = body["nodes"]
+    assert row is not None
+    assert row["locked"] is False
+    assert row["allowed"] is True


### PR DESCRIPTION
## Summary

Plural sibling of the just-landed `lock_reason_at` helper (#3328). Where the scalar what-if returns one lock sentence for one item at a hypothetical tier, this returns the full N-row matrix in one pass so a pricing-comparison matrix UI can preview the lock copy a downgrade-to-target would surface for many items **without** N round-trips to `/lock-reason-at`.

Composition is the natural one given the existing helper grid:

| helper                | live | batch | `_at` | `_at_batch` |
|-----------------------|:----:|:-----:|:-----:|:-----------:|
| `lock_reason`         |  ✅  |  ✅   |  ✅   |   **NEW**   |
| `lock_reasons_batch`  |  -   |  ✅   |   -   |      -      |

## Why a fresh `Entitlement` instead of `_hypothetical_entitlement`

Matches the rationale from #3328: `_hypothetical_entitlement` hard-codes `node_limit=1` because its catalog-row callers (`feature_spec_at`, `runtime_spec_at`, `feature_catalog_at`, `runtime_catalog_at`) don't expose node counts. This helper has to support the `nodes` axis correctly — asking about 100 nodes from `enterprise` must resolve to **unlocked**, not locked — so it synthesises its own `Entitlement` with `node_limit = _TIER_NODE_LIMIT.get(tier, _FREE_NODE_LIMIT)`. Channel and retention caps already flow off `self.tier` inside the `Entitlement` methods, so they don't need the same treatment. Tests pin the per-tier node-limit branch explicitly.

## API

`GET /api/entitlement/lock-reasons-at-batch?tier=<perspective>&features=a,b,c&runtimes=x,y&channels=N&retention_days=K&nodes=M`

At least one of `features=` / `runtimes=` / `channels=` / `retention_days=` / `nodes=` must be supplied; supply as many as you like (matches `/lock-reason-batch`'s contract, distinguishes from the scalar `/lock-reason-at` which takes exactly one axis).

Per-row shape is **byte-identical** to `/lock-reason-batch` so a matrix UI can swap endpoints without reshape logic. Envelope adds `perspective_tier` + `perspective_tier_rank` echoes for round-trip safety; `current_tier` echoes the LIVE resolved tier (distinct from `perspective_tier`) so the UI can also show a "you are here" badge alongside the hypothetical column.

- **400** when `tier=` is missing / blank, or when no axis is supplied
- **404** when `tier` is unknown (body carries `which: "tier"`)
- **Never 5xxs**: a synthesis failure short-circuits to the grace-shape payload (empty / `None` rows) with the perspective tier echoed

## Files

| File | Lines | Change |
|---|---|---|
| `clawmetry/entitlements.py` | +94 | `lock_reasons_at_batch(perspective_tier, *, features, runtimes, channels, retention_days, nodes)` helper |
| `routes/entitlement.py` | +145 | `/api/entitlement/lock-reasons-at-batch` route + grace-shape fallback |
| `tests/test_entitlement_lock_reasons_at_batch.py` | +473 | 37 tests pinning helper shape, per-tier resolution, capacity-axis correctness (incl. the `_TIER_NODE_LIMIT` branch), error contract, row-shape parity with `/lock-reason-batch` |

Read-only catalog-like accessor on top of the static tier maps — no behaviour gate flips. The live entitlement is only consulted for the `current_tier`/`grace`/`enforced` envelope echo (the helper itself doesn't touch the resolver), so this is safe to wire into pricing-page surfaces even during grace mode. No `__version__` bump, no UI wired.

## Test plan

- [x] `python -m pytest tests/test_entitlement_lock_reasons_at_batch.py -x -q` → **37 passed** in 0.47s
- [x] Adjacent regression sweep: `test_entitlement_lock_reason.py`, `test_entitlement_lock_reason_batch.py`, `test_entitlement_lock_reason_at.py`, `test_entitlement_lock_reason_capacity.py`, `test_entitlement_lock_reason_nodes.py` → **118 passed** in 1.17s
- [x] `ruff check clawmetry/entitlements.py routes/entitlement.py tests/test_entitlement_lock_reasons_at_batch.py` → **All checks passed!**
- [x] `python -m py_compile` on all three changed files

## Local operator verification checklist

The autonomous fire cannot touch the user's machine, the running daemon, `~/.openclaw`, the live cloud snapshot, or a browser. The following must be done by the local operator before flipping to ready-for-review:

- [ ] Copy changed files into the installed package:
      `cp clawmetry/entitlements.py ~/.clawmetry/lib/python*/site-packages/clawmetry/`
      `cp routes/entitlement.py ~/.clawmetry/lib/python*/site-packages/routes/`
- [ ] Clear bytecode: `find ~/.clawmetry/lib -name __pycache__ -exec rm -rf {} +`
- [ ] Kick the daemon: `launchctl kickstart -k gui/$(id -u)/com.clawmetry.sync`
- [ ] Hit the new endpoint across multiple axes:
      `curl -s '``http://localhost:8900/api/entitlement/lock-reasons-at-batch?tier=cloud_pro&features=sso,otel_export&runtimes=claude_code&channels=50&retention_days=365&nodes=5'`` | jq`
      `curl -s 'http://localhost:8900/api/entitlement/lock-reasons-at-batch?tier=enterprise&nodes=100' | jq '.nodes.locked'` (must be `false` — pins the per-tier `_TIER_NODE_LIMIT` branch the naive hypothetical otherwise gets wrong)
      `curl -s 'http://localhost:8900/api/entitlement/lock-reasons-at-batch?tier=oss&runtimes=claude_code' | jq '.runtimes[0].locked'` (must be `true`)
- [ ] Confirm `current_tier` reflects the live install (distinct from `perspective_tier` in the response), so a matrix UI can render both
- [ ] Verify error contract: `curl -i '.../lock-reasons-at-batch?features=sso'` → 400; `?tier=cloud_pro` (no axis) → 400; `?tier=nonsense&features=sso` → 404 with `which: "tier"`
- [ ] Decrypt the live cloud snapshot and browser-check that no existing tooltip / paywall surface regressed (this endpoint is unconsumed, so the check is purely defensive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PakrSv3zQsjXKZc9AJWwj9)_